### PR TITLE
feat(cli): route by-id reads and grafts to the store that holds the bead (ga-k8pzw)

### DIFF
--- a/cmd/gc/by_id_store_route.go
+++ b/cmd/gc/by_id_store_route.go
@@ -1,0 +1,126 @@
+package main
+
+// By-id store routing for the one-shot commands that hold a bead id and a work
+// store, and have to read or mutate THAT bead.
+//
+// `gc bd` answers the same question through its own closed front door
+// (cmd_bd_by_id.go), because its fall-through leg is a `bd` subprocess rather
+// than a beads.Store. Every other one-shot by-id call site holds two ordinary
+// stores and needs the ordering, the identity gate and the failure
+// classification to come from one place — answering "which store owns this
+// bead?" a second time is how this repo's split-store bug class reproduces
+// (#5125, #5127).
+//
+// # Candidate list and probe, never an unconditional route
+//
+// The list comes from storeref.ClassCandidates, the shared resolver: the class
+// store leads because it is the sole MINTER of the reserved namespace, but
+// minting is not holding. A reserved prefix is only an ADVISORY on work stores
+// (config.ReservedPrefixWarnings warns; config.ValidateRigs does not reject), so
+// a work store can legitimately hold an id inside the class namespace and a
+// resolver that routed unconditionally on the prefix would report those beads as
+// absent.
+//
+// # Why the residence fallback exists
+//
+// storeref.ClassCandidates gates on the class NAMESPACE (IDInNamespace) BEFORE
+// it builds a list, and `gc storage migrate` preserves ids
+// (infra_class_migrate.go). A bead the migration relocated therefore keeps its
+// HQ/rig-era prefix, sits outside the class namespace, and gets nil candidates
+// back — for exactly the ids that moved. The shared resolver's own doc says so.
+//
+// So a nil answer from the resolver is not "the work store owns this". It is
+// "the namespace rule cannot decide", and what decides is a RESIDENCE probe:
+// ask the class store about the id itself. That is the same probe
+// bdByIDClassDoor.resolve performs, for the same reason, and the fallback list
+// is the same [class, work] head the resolver would have returned — so the two
+// paths differ in what makes them fire, never in what they answer.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// classRoutedStoreForID returns the store that actually holds id: the relocated
+// class binding when it answers for the bead, and work otherwise.
+//
+// work is the caller's own resolved scope store and is BOTH the residual answer
+// and the last candidate, so a city that relocates nothing — and an id no
+// relocated class holds — gets back the exact store value the caller passed in.
+// A single-store city therefore never changes behavior, and never pays for the
+// funnel: the identity gate returns before any probe.
+//
+// An error is a read that FAILED, never absence. Reading "the binding could not
+// answer" as "the bead is not there" is the root-loss shape this whole lane
+// exists to prevent. The one error that is not a fault is the one-shot funnel's
+// standing refusal (isStandingStorageRefusal): it says this city's storage
+// configuration cannot be served, which is a fact about the city and none about
+// a particular bead — and a refused city still serves WORK from its work
+// ledger. So for a work-shaped id the refusal establishes nothing and the work
+// store still answers; for an id only the class binding could own it is the
+// answer, and surfaces.
+//
+// NOT consulted: the rig work stores. They are a different SCOPE, not a
+// different class — a caller that never read them cannot start reading them
+// here without changing which beads its command is about. storeref.ClassRouting
+// carries them as Shadows for the call sites that already hold them open
+// (internal/api's by-id resolver); this one does not, and passing an empty
+// Shadows list is what keeps the candidate order identical to the pre-seam
+// [class, work].
+func classRoutedStoreForID(cityPath, id string, work beads.Store) (beads.Store, error) {
+	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	if !relocated || class == nil || class == work {
+		return work, nil
+	}
+	for _, candidate := range classRouteCandidates(id, class, work) {
+		if candidate == nil || candidate == work {
+			// The work leg is the caller's own store and the residual answer.
+			// Stop here rather than probing it, so the caller's own read
+			// produces its own error message byte-identically.
+			return work, nil
+		}
+		_, err := candidate.Get(id)
+		switch {
+		case err == nil:
+			return candidate, nil
+		case errors.Is(err, beads.ErrNotFound):
+		case isStandingStorageRefusal(err) && !bdIDIsClassReserved(id):
+		default:
+			return nil, fmt.Errorf("reading %q from the relocated class binding: %w", id, err)
+		}
+	}
+	return work, nil
+}
+
+// classRouteCandidates is the by-id probe list: the shared resolver's answer,
+// or the residence-probe list when the resolver declines because id sits
+// outside the class namespace.
+//
+// Both lists lead with the class store and fall back to work, which is the
+// order the pre-seam resolver used and the order storeref.ClassCandidates
+// documents. The fallback is not a second opinion about ownership — it is the
+// same list, reached for the ids the namespace gate cannot speak about.
+//
+// One binding answers for every reserved prefix, which is sound only because
+// the served split shape is storageSplitWhole (storageSplitShapeOf admits a
+// split only when all five infrastructure classes name the same binding). The
+// graph prefix is therefore representative rather than special: a sessions- or
+// orders-prefixed id takes the fallback list and is probed against the same
+// store the resolver would have named. If per-class fan-out is ever served,
+// this has to resolve per class.
+func classRouteCandidates(id string, class, work beads.Store) []beads.Store {
+	if prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph); ok {
+		if candidates := storeref.ClassCandidates(id, storeref.ClassRouting{
+			Prefix: prefix,
+			Class:  class,
+			Work:   work,
+		}); candidates != nil {
+			return candidates
+		}
+	}
+	return []beads.Store{class, work}
+}

--- a/cmd/gc/by_id_store_route_test.go
+++ b/cmd/gc/by_id_store_route_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// byIDRouteCity seeds the one-shot funnel for a city whose graph class is served
+// from its own binding, and returns the city path plus the two stores.
+//
+// The work leaf mints outside the reserved class namespace and the class leaf
+// mints inside it, exactly as a real split city does — which is what makes the
+// namespace gate and the residence probe distinguishable here at all.
+func byIDRouteCity(t *testing.T) (cityPath string, work, class beads.Store) {
+	t.Helper()
+	cityPath = t.TempDir()
+	work, class = splittest.NewSplitStores(t)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(class))
+	return cityPath, work, class
+}
+
+// TestClassRoutedStoreForIDIsIdentityOnACityThatRelocatesNothing is the
+// single-store compatibility claim, and it is asserted by STORE IDENTITY rather
+// than by behavior: the resolver must hand back the exact value it was given,
+// so every optional-capability type assertion the caller already made keeps
+// holding. Mutate the identity branch to return any other store and this fails.
+func TestClassRoutedStoreForIDIsIdentityOnACityThatRelocatesNothing(t *testing.T) {
+	cityPath := t.TempDir()
+	resetCLIStorageRoutes(t)
+	seedCLIStorageRoutes(t, cityPath, nil)
+	work := splittest.NewWorkStore(t, "hq")
+	bead, err := work.Create(beads.Bead{Title: "work bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	classPrefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("no reserved graph prefix; there is no namespace for by-id routing to run on")
+	}
+	// Both id shapes, because they take different branches: a work id misses the
+	// namespace gate and a class-shaped id clears it, so only the class-shaped
+	// row can prove the IDENTITY gate fires first.
+	ids := []string{bead.ID, classPrefix + "-1", "hq-does-not-exist"}
+	for _, id := range ids {
+		got, err := classRoutedStoreForID(cityPath, id, work)
+		if err != nil {
+			t.Fatalf("classRoutedStoreForID(%q): %v", id, err)
+		}
+		if got != work {
+			t.Errorf("classRoutedStoreForID(%q) returned %p, want the caller's own store %p — a city that relocates nothing must get its exact store value back", id, got, work)
+		}
+	}
+
+	// The second identity shape: routes that DO name a binding for the graph
+	// class, whose store is the work store. storeref.ClassCandidates gates on
+	// exactly this (Class != Work) and returns nil, and so must this resolver —
+	// otherwise a city with nowhere to route to is routed anyway, and the class
+	// leg and the work leg are probed as if they were two ledgers.
+	selfRouted := t.TempDir()
+	resetCLIStorageRoutes(t)
+	seedCLIStorageRoutes(t, selfRouted, messagingSplitRoutes(work))
+	for _, id := range ids {
+		got, err := classRoutedStoreForID(selfRouted, id, work)
+		if err != nil {
+			t.Fatalf("classRoutedStoreForID(%q) on a self-routed city: %v", id, err)
+		}
+		if got != work {
+			t.Errorf("classRoutedStoreForID(%q) returned %p on a city whose class binding IS its work store, want %p", id, got, work)
+		}
+	}
+}
+
+// TestClassRoutedStoreForIDCoversTheLegacyIDTheSharedResolverDeclines is the
+// correction #5139's council landed, asserted rather than described.
+//
+// storeref.ClassCandidates gates on the class NAMESPACE, and `gc storage
+// migrate` preserves ids — so a bead the migration relocated keeps its HQ/rig-era
+// prefix and the shared resolver returns NIL candidates for it, for exactly the
+// ids that moved. Both halves are asserted here: that the resolver declines, and
+// that the residence probe answers anyway. Delete the fallback and the second
+// half fails.
+func TestClassRoutedStoreForIDCoversTheLegacyIDTheSharedResolverDeclines(t *testing.T) {
+	cityPath, work, class := byIDRouteCity(t)
+	// The migration copies the work store's infrastructure slice with ids
+	// PRESERVED, so the relocated row carries a work-shaped id.
+	migrated, err := class.Create(beads.Bead{ID: "hq-4177", Title: "relocated with its id preserved", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the migrated row: %v", err)
+	}
+	splittest.TakeResidenceViolations(class)
+
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("no reserved graph prefix")
+	}
+	if got := storeref.ClassCandidates(migrated.ID, storeref.ClassRouting{Prefix: prefix, Class: class, Work: work}); got != nil {
+		t.Fatalf("storeref.ClassCandidates(%q) returned %d candidates; this test's premise is that the namespace gate declines a migrated legacy id — if the resolver now covers it, the residence fallback can be reconsidered", migrated.ID, len(got))
+	}
+
+	got, err := classRoutedStoreForID(cityPath, migrated.ID, work)
+	if err != nil {
+		t.Fatalf("classRoutedStoreForID(%q): %v", migrated.ID, err)
+	}
+	if got != class {
+		t.Errorf("classRoutedStoreForID(%q) resolved %p, want the class binding %p — the shared resolver declines this id, so only a residence probe can reach it and the read would otherwise be answered by the work store's retained pre-migration copy", migrated.ID, got, class)
+	}
+}
+
+// TestClassRoutedStoreForIDProbesRatherThanRoutesOnThePrefix is the
+// candidate-list-and-probe property. A reserved class prefix is only an ADVISORY
+// on work stores (config.ReservedPrefixWarnings warns; config.ValidateRigs does
+// not reject), so a work store can legitimately hold an id inside the class
+// namespace — and a resolver that routed unconditionally on the prefix would
+// report that bead as absent.
+func TestClassRoutedStoreForIDProbesRatherThanRoutesOnThePrefix(t *testing.T) {
+	cityPath, work, class := byIDRouteCity(t)
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("no reserved graph prefix")
+	}
+	shadowed := prefix + "-9001"
+	// The forced path, which is the only way a work store comes to hold an id
+	// inside the class namespace: a reserved prefix is warned-and-allowed on a
+	// work store, and bd's own --force keeps such an id verbatim.
+	forcer, ok := work.(beads.ForeignIDCreator)
+	if !ok {
+		t.Fatalf("the work leaf %T cannot model a forced foreign-prefix create; this invariant is about an id the work store legitimately holds", work)
+	}
+	if _, err := forcer.CreateWithForeignID(beads.Bead{ID: shadowed, Title: "class-shaped id held by the work store", Type: "task"}); err != nil {
+		t.Fatalf("seeding the shadowed row: %v", err)
+	}
+	if _, err := class.Get(shadowed); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("the class binding claims %s (%v); the premise is that only the work store holds it", shadowed, err)
+	}
+
+	got, err := classRoutedStoreForID(cityPath, shadowed, work)
+	if err != nil {
+		t.Fatalf("classRoutedStoreForID(%q): %v", shadowed, err)
+	}
+	if got != work {
+		t.Errorf("classRoutedStoreForID(%q) resolved %p, want the work store %p — the class store MINTS the reserved namespace but minting is not holding, so the list must be probed and not routed", shadowed, got, work)
+	}
+}
+
+// TestClassRoutedStoreForIDResolvesAClassResidentID is the ordinary case: an id
+// the binding holds resolves to the binding, and never to the work store the
+// caller opened.
+func TestClassRoutedStoreForIDResolvesAClassResidentID(t *testing.T) {
+	cityPath, work, class := byIDRouteCity(t)
+	resident, err := class.Create(beads.Bead{Title: "graph root", Type: "task"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := classRoutedStoreForID(cityPath, resident.ID, work)
+	if err != nil {
+		t.Fatalf("classRoutedStoreForID(%q): %v", resident.ID, err)
+	}
+	if got != class {
+		t.Errorf("classRoutedStoreForID(%q) resolved %p, want the class binding %p", resident.ID, got, class)
+	}
+}
+
+// TestClassRoutedStoreForIDTakesTheSharedResolversCandidateOrder pins that the
+// probe list for an in-namespace id is literally storeref.ClassCandidates'
+// answer, so the ORDER and the identity gate have exactly one owner. A local
+// list that happened to agree today would drift the moment the resolver grows a
+// leg.
+func TestClassRoutedStoreForIDTakesTheSharedResolversCandidateOrder(t *testing.T) {
+	_, work, class := byIDRouteCity(t)
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("no reserved graph prefix")
+	}
+	id := prefix + "-1"
+	want := storeref.ClassCandidates(id, storeref.ClassRouting{Prefix: prefix, Class: class, Work: work})
+	if len(want) == 0 {
+		t.Fatal("the shared resolver produced no candidates for an in-namespace id on a relocated city")
+	}
+	got := classRouteCandidates(id, class, work)
+	if len(got) != len(want) {
+		t.Fatalf("classRouteCandidates produced %d candidates, want the shared resolver's %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("candidate %d = %p, want %p — the class store leads because it is the sole minter of the namespace, and work follows as the fallback leg", i, got[i], want[i])
+		}
+	}
+}
+
+// TestClassRoutedStoreForIDSurfacesAReadFailureRatherThanAbsence is the
+// classification the whole by-id lane exists for. Reading "the binding could not
+// answer" as "the bead is not there" is the root-loss shape, and it is the one
+// misclassification a caller cannot recover from once it has been flattened.
+func TestClassRoutedStoreForIDSurfacesAReadFailureRatherThanAbsence(t *testing.T) {
+	cityPath := t.TempDir()
+	work := splittest.NewWorkStore(t, "hq")
+	boom := errors.New("binding unreachable")
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(errStore{err: boom}))
+
+	if _, err := classRoutedStoreForID(cityPath, "hq-1", work); err == nil || !errors.Is(err, boom) {
+		t.Fatalf("classRoutedStoreForID on an unreadable binding returned err=%v, want the read failure — absence here would answer from the work ledger about a bead the binding may hold", err)
+	}
+}
+
+// TestClassRoutedStoreForIDKeepsWorkOnARefusedCity pins the one error that is
+// not a fault. The one-shot funnel's standing refusal is this build's verdict
+// about a CITY's storage configuration, not about a bead — and a refused city
+// still serves WORK from its work ledger. So a work-shaped id keeps its existing
+// path, while an id only the binding could own gets the refusal.
+func TestClassRoutedStoreForIDKeepsWorkOnARefusedCity(t *testing.T) {
+	cityPath := t.TempDir()
+	work := splittest.NewWorkStore(t, "hq")
+	refusal := errors.New("this city's storage cannot be served; run `gc storage migrate`")
+	resetCLIStorageRoutes(t)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = refusingStorageRoutes("infra", refusal) })
+
+	got, err := classRoutedStoreForID(cityPath, "hq-1", work)
+	if err != nil {
+		t.Fatalf("a work id on a refused city returned %v, want the work store: the refusal is a fact about the city and says nothing about a bead the work ledger still serves", err)
+	}
+	if got != work {
+		t.Errorf("a work id on a refused city resolved %p, want the work store %p", got, work)
+	}
+
+	classPrefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("no reserved graph prefix")
+	}
+	if _, err := classRoutedStoreForID(cityPath, classPrefix+"-1", work); err == nil {
+		t.Errorf("a reserved-prefix id on a refused city resolved without error; that id can only live in the binding, so the refusal IS the answer and must not be flattened into a work-store read")
+	}
+}
+
+// errStore is a beads.Store whose every read fails, for the failure-vs-absence
+// classification above. Only Get is exercised.
+type errStore struct {
+	beads.Store
+	err error
+}
+
+func (s errStore) Get(string) (beads.Bead, error) { return beads.Bead{}, s.err }

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -85,6 +85,15 @@ city (HQ) store. An explicit --city is a true scope override: it forces the
 city store and disables rig auto-detection (GC_RIG, cwd, bead prefix), so a
 deliberate city-scoped query is never silently downgraded to a rig store.
 
+On a city that serves a coordination class from its own [storage] binding,
+a by-id read or write of a bead that binding owns is answered in process
+from the binding, not by bd against a work store that does not hold it.
+--rig is refused for those beads rather than ignored or honored: it names a
+work scope, and a relocated class is not partitioned by rig, so there is
+nothing to narrow within. Drop --rig for a class-owned id. Auto-detected
+scope (GC_RIG, -C, cwd) is unaffected, and --city still selects which city's
+binding answers.
+
 All arguments after "gc bd" are forwarded to bd unchanged, except the
 gc-only "heartbeat <issue-id>" subcommand, which rewrites to
 "update <issue-id> --set-metadata gc.last_heartbeat_at=<RFC3339 UTC now>"
@@ -257,7 +266,14 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// It runs BEFORE the release-if-current arm below because that arm resolves
 	// only the work scope: on a split city it would release against the ledger
 	// the bead was moved off. See cmd_bd_by_id.go.
-	if code, handled := maybeRouteBdByID(cityPath, bdArgs, stdout, stderr); handled {
+	//
+	// rigName is the explicit --rig, and it travels because the WORK scope this
+	// function just resolved and the class binding are two different ledgers: a
+	// class-owned subject under an explicit --rig is refused rather than served
+	// from a store the operator did not name. Auto-detected scope (GC_RIG, -C,
+	// cwd) is resolved inside resolveBdScopeTarget and deliberately does not
+	// travel — see refuseRigScopedClassOwnedTarget.
+	if code, handled := maybeRouteBdByID(cityPath, rigName, bdArgs, stdout, stderr); handled {
 		return code
 	}
 	if id, expectedAssignee, ok, err := parseBdReleaseIfCurrentArgs(bdArgs); ok || err != nil {

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -33,6 +33,27 @@ package main
 // migrate this", it is "where is this class served from", and the funnel
 // answers that for every provider because the answer comes from the provider.
 //
+// # This IS the shared candidate list, with the work leg served by bd
+//
+// storeref.ClassCandidates is the tree's by-id resolver, and its answer for a
+// relocated city is [class, work] — the class store first, because it is the
+// sole MINTER of the reserved namespace, then the work store, because minting
+// is not holding. This surface probes exactly that list in exactly that order.
+// What differs is only how the work leg is READ: here it is the `bd`
+// subprocess, which is why the leg appears as a fall-through rather than as a
+// beads.Store. The in-process form of the same list, for the one-shot commands
+// that hold two ordinary stores, is by_id_store_route.go.
+//
+// The class leg is probed for EVERY id, not only for ids inside the class
+// namespace, and that is the one place this surface is deliberately STRONGER
+// than the shared resolver rather than merely equal to it. ClassCandidates
+// gates on the namespace before it builds a list (IDInNamespace), and `gc
+// storage migrate` preserves ids — so a bead the migration relocated keeps its
+// HQ/rig-era prefix and the resolver returns nil for exactly the ids that
+// moved. Only a residence probe reaches those, and without it their reads are
+// answered from the work store's retained pre-migration copy, frozen at
+// migration time. See resolve.
+//
 // # Three deliberate properties
 //
 //   - The routed operations take ONLY the closed contract
@@ -554,7 +575,15 @@ func bdIDIsClassReserved(id string) bool {
 // door. handled=false means the caller proceeds on its existing path unchanged
 // — the city relocates no class, the invocation is not one of the routed by-ID
 // forms, or the id is a work-store id the class store does not answer for.
-func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer) (int, bool) {
+//
+// rigName is the EXPLICIT --rig the operator wrote (or `gc --rig X bd …`, which
+// extractBdScopeFlags folds into the same value). It is never the auto-detected
+// scope: GC_RIG, -C and cwd resolve inside resolveBdScopeTarget and never reach
+// here, which is deliberate — a rig agent runs with GC_RIG set on every
+// invocation, so treating that as a deliberate scope would refuse the
+// step-completion write the core pack renders on every worked bead. See
+// refuseRigScopedClassOwnedTarget.
+func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr io.Writer) (int, bool) {
 	op, served := parseBdByIDOp(bdArgs)
 	named, namesClassBead := bdArgsNameClassOwnedBead(bdArgs)
 	if !served && !namesClassBead {
@@ -595,6 +624,14 @@ func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer
 		// truth, and the passthrough answers it byte-identically.
 		return 0, false
 	}
+	if rig := strings.TrimSpace(rigName); rig != "" {
+		// The invocation pins a WORK rig scope and names a bead the class
+		// binding owns. Both answers available here are wrong: serving it
+		// ignores a flag the operator reached for to be MORE specific, and
+		// honoring it sends the read to a ledger that does not hold the bead.
+		// So neither is taken. See refuseRigScopedClassOwnedTarget.
+		return refuseRigScopedClassOwnedTarget(door, op.ID, rig, stderr)
+	}
 	if !resolution.Found {
 		// Reserved-prefix id with no row: it has nowhere else to live.
 		printBdByIDNotFound(stderr, op.ID)
@@ -618,6 +655,50 @@ func maybeRouteBdByID(cityPath string, bdArgs []string, stdout, stderr io.Writer
 	// so the passthrough would run a verb this build recognized against the one
 	// ledger that cannot hold the bead.
 	return refuseClassOwnedTarget(door, string(op.Verb), op.ID, "", stderr)
+}
+
+// refuseRigScopedClassOwnedTarget refuses a by-ID invocation that pins a rig
+// work scope with an explicit --rig while naming a bead the relocated class
+// binding owns.
+//
+// # The rule, and why it is a refusal rather than a narrowing
+//
+// --rig names a WORK scope: a rig's own bd workspace, one leg of the city's
+// work ledger. A relocated coordination class is not partitioned by rig — the
+// served split shape is storageSplitWhole, one binding for all five
+// infrastructure classes and every scope in the city — so there is nothing for
+// --rig to narrow WITHIN. The flag and the subject describe two different
+// ledgers, and the command has to say so.
+//
+// Both silent answers are worse:
+//
+//   - Serving it anyway ignores the flag, which is what this surface did before
+//     the rule: `gc bd show <class-id> --rig <rig>` and the same command with no
+//     --rig produced identical output. An operator who wrote --rig to be more
+//     specific got an answer from a store they did not name, with no
+//     diagnostic — and a script pinning --rig to keep two rigs apart was reading
+//     whichever ledger the class routing chose.
+//   - Honoring it routes the read at the rig's work store, which does not hold
+//     the bead. That is the pre-#5132 behavior and the wrong-answer lane this
+//     whole surface exists to close: an empty result indistinguishable from a
+//     real one.
+//
+// # What it does NOT cover
+//
+// Only the EXPLICIT flag. GC_RIG, -C/--directory and cwd detection are
+// auto-detected scope, not a deliberate one, and the controller sets GC_RIG on
+// every rig agent — refusing those would break the step-completion write the
+// core pack renders on every worked bead (`gc bd update <id> --set-metadata
+// gc.outcome=pass --status closed`, run from a rig worktree against a
+// class-owned step). resolveBdScopeTarget already keeps them in a lower
+// priority band than the flag for the same reason.
+//
+// --city is also untouched, and for the opposite reason: it selects WHICH CITY
+// answers, and the class binding this door opened is that city's. A --city
+// scope and class routing agree; a --rig scope and class routing cannot.
+func refuseRigScopedClassOwnedTarget(door bdByIDClassDoor, id, rigName string, stderr io.Writer) (int, bool) {
+	fmt.Fprintf(stderr, "gc bd: %s is owned by %s, but --rig %s pins that rig's work store, which does not hold it; a relocated class is not partitioned by rig, so drop --rig (auto-detected scope — GC_RIG, -C, cwd — is not affected)\n", id, door.bindingName(), rigName) //nolint:errcheck // best-effort stderr
+	return 1, true
 }
 
 // refuseClassOwnedTarget is the single refusal message, so every unsupported

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -624,6 +624,18 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		// truth, and the passthrough answers it byte-identically.
 		return 0, false
 	}
+	if !resolution.Found {
+		// Reserved-prefix id with no row: it has nowhere else to live.
+		//
+		// This runs BEFORE the --rig refusal below, and the order is the
+		// diagnosis. The refusal's whole claim is that the binding owns this
+		// bead and the named rig's work store does not hold it — a sentence
+		// that is false when nothing holds it. A mistyped reserved-prefix id
+		// under --rig is an id error, not a scope error, and blaming the flag
+		// sends the operator to fix the one thing that was not wrong.
+		printBdByIDNotFound(stderr, op.ID)
+		return 1, true
+	}
 	if rig := strings.TrimSpace(rigName); rig != "" {
 		// The invocation pins a WORK rig scope and names a bead the class
 		// binding owns. Both answers available here are wrong: serving it
@@ -631,11 +643,6 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		// honoring it sends the read to a ledger that does not hold the bead.
 		// So neither is taken. See refuseRigScopedClassOwnedTarget.
 		return refuseRigScopedClassOwnedTarget(door, op.ID, rig, stderr)
-	}
-	if !resolution.Found {
-		// Reserved-prefix id with no row: it has nowhere else to live.
-		printBdByIDNotFound(stderr, op.ID)
-		return 1, true
 	}
 	switch op.Verb {
 	case bdByIDShow:

--- a/cmd/gc/cmd_bd_by_id_rig_test.go
+++ b/cmd/gc/cmd_bd_by_id_rig_test.go
@@ -128,6 +128,45 @@ func TestBdByIDRefusesAnExplicitRigScopeOnAClassOwnedBead(t *testing.T) {
 	}
 }
 
+// TestBdByIDRigRuleDoesNotBlameTheFlagForAnIDThatDoesNotExist pins the ORDER of
+// the two refusals, which is the difference between a correct diagnosis and a
+// wrong one.
+//
+// The --rig refusal asserts a fact: the binding owns this bead and the named
+// rig's work store does not hold it. For a mistyped reserved-prefix id that
+// sentence is false — nothing holds it — and the operator is sent to fix the
+// flag, which was the one thing that was not wrong. The not-found answer has to
+// come first.
+func TestBdByIDRigRuleDoesNotBlameTheFlagForAnIDThatDoesNotExist(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	missing := reservedClassID(t, "9999")
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, byIDRigName, []string{"show", missing}, &stdout, &stderr)
+	if !handled || code != 1 {
+		t.Fatalf("show %s under --rig exited %d (handled=%v), want a handled failure: %s", missing, code, handled, stderr.String())
+	}
+	msg := stderr.String()
+	if !strings.Contains(msg, "no issue found") {
+		t.Errorf("show %s under --rig reported %q, want the not-found answer — the id is what is wrong here, not the scope", missing, msg)
+	}
+	if strings.Contains(msg, "drop --rig") {
+		t.Errorf("show %s under --rig blamed the flag: %q. The refusal claims the binding owns the bead and the rig store does not hold it; nothing holds it, so that claim is false", missing, msg)
+	}
+
+	// The control: the same city, the same flag, an id the binding DOES own
+	// still refuses. Without this row the fix could be "stop refusing".
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "owned by the binding", Type: "task"})
+	stdout.Reset()
+	stderr.Reset()
+	if code, handled := maybeRouteBdByID(cityPath, byIDRigName, []string{"show", bead.ID}, &stdout, &stderr); !handled || code != 1 {
+		t.Fatalf("show %s under --rig exited %d (handled=%v), want the refusal", bead.ID, code, handled)
+	}
+	if !strings.Contains(stderr.String(), "drop --rig") {
+		t.Errorf("show %s under --rig lost the refusal: %q", bead.ID, stderr.String())
+	}
+}
+
 // TestBdByIDRigScopeLeavesWorkStoreIDsToThePassthrough is the carve-out that
 // keeps the rule from becoming "any --rig is refused on a split city". A rig id
 // under --rig is exactly what the flag is for, the class store never held it,

--- a/cmd/gc/cmd_bd_by_id_rig_test.go
+++ b/cmd/gc/cmd_bd_by_id_rig_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// This file pins the --rig RULE for `gc bd`'s by-id surface.
+//
+// The rule: an EXPLICIT --rig naming a work rig scope, combined with a bead the
+// relocated class binding owns, is refused. Neither of the silent answers is
+// taken — serving it ignores a flag the operator reached for to be MORE
+// specific, and honoring it routes the read at a ledger that does not hold the
+// bead and answers an empty result indistinguishable from a real one.
+//
+// Everything else is untouched, and each carve-out has a row below: a work id
+// under --rig still passes through, a class id with no --rig is still served,
+// auto-detected scope (GC_RIG) is not a deliberate scope and does not refuse,
+// and a city that relocates nothing never reaches the rule at all.
+
+const byIDRigName = "workflows"
+
+// writeRiggedForeignProviderCityTOML is writeForeignProviderCityTOML plus one
+// bound rig, so the --rig flag has a real target to resolve to. Without a
+// resolvable rig, resolveBdScopeTarget fails first with "rig not found" and the
+// class-routing rule is never reached — which is a different, already-loud
+// failure.
+func writeRiggedForeignProviderCityTOML(t *testing.T, cityPath, rigPath string) {
+	t.Helper()
+	body := fmt.Sprintf(`[workspace]
+name = "by-id-rig-city"
+
+[[rigs]]
+name = %q
+path = %q
+prefix = "wf"
+
+[storage.classes]
+work = %q
+graph = "infra"
+sessions = "infra"
+messaging = "infra"
+orders = "infra"
+nudges = "infra"
+
+[storage.bindings.infra]
+provider = %q
+config_ref = "infra"
+`, byIDRigName, rigPath, config.StorageWorkBinding, string(configRefEngineProviderID))
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing city.toml: %v", err)
+	}
+}
+
+// riggedForeignProviderCity is foreignProviderCity with a bound rig, for the
+// end-to-end doBd rows.
+func riggedForeignProviderCity(t *testing.T) (cityPath string, classStore beads.Store) {
+	t.Helper()
+	clearGCEnv(t)
+	cityPath = t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", byIDRigName)
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("creating the rig dir: %v", err)
+	}
+	writeRiggedForeignProviderCityTOML(t, cityPath, rigPath)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityPath)
+	registerConfigRefEngineProvider(t)
+	stubInfraMigrationSource(t)
+	resetCLIStorageRoutes(t)
+	captureCLIStorageStderr(t)
+
+	store, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	if !relocated {
+		t.Fatal("a city serving its classes from a foreign provider resolved no class binding")
+	}
+	return cityPath, store
+}
+
+// TestBdByIDRefusesAnExplicitRigScopeOnAClassOwnedBead is the rule.
+func TestBdByIDRefusesAnExplicitRigScopeOnAClassOwnedBead(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "owned by the binding", Type: "task"})
+
+	for _, args := range [][]string{
+		{"show", bead.ID},
+		{"show", bead.ID, "--json"},
+		{"update", bead.ID, "--claim"},
+		{"update", bead.ID, "--set-metadata", "gc.outcome=pass", "--status", "closed"},
+		{"dep", "list", bead.ID},
+		{"release-if-current", bead.ID, "someone"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code, handled := maybeRouteBdByID(cityPath, byIDRigName, args, &stdout, &stderr)
+		if !handled {
+			t.Fatalf("%v under --rig fell through to the bd subprocess, which would run it against the rig's work store", args)
+		}
+		if code != 1 {
+			t.Errorf("%v under --rig exited %d, want 1", args, code)
+		}
+		if stdout.Len() != 0 {
+			t.Errorf("%v under --rig wrote %q to stdout; a refused command must serve nothing", args, stdout.String())
+		}
+		msg := stderr.String()
+		for _, want := range []string{bead.ID, "--rig " + byIDRigName, "not partitioned by rig", "drop --rig"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("%v under --rig: refusal %q does not name %q", args, msg, want)
+			}
+		}
+	}
+
+	// The mutation guard: with no --rig the same invocations are SERVED. If this
+	// row ever fails alongside the rows above, the rule has become a blanket
+	// refusal rather than a scope-coherence rule.
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"show", bead.ID, "--json"}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("show without --rig exited %d (handled=%v): %s", code, handled, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), bead.ID) {
+		t.Errorf("show without --rig printed %q, want the bead", stdout.String())
+	}
+}
+
+// TestBdByIDRigScopeLeavesWorkStoreIDsToThePassthrough is the carve-out that
+// keeps the rule from becoming "any --rig is refused on a split city". A rig id
+// under --rig is exactly what the flag is for, the class store never held it,
+// and it must reach bd unchanged.
+func TestBdByIDRigScopeLeavesWorkStoreIDsToThePassthrough(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, byIDRigName, []string{"show", "wf-abc123"}, &stdout, &stderr); handled {
+		t.Fatalf("a work-store id under --rig was handled in process (code %d): %s", code, stderr.String())
+	}
+}
+
+// TestBdByIDRigScopeIsInertOnACityThatRelocatesNothing is the single-store
+// compatibility claim for the rule: a legacy city mints no class-owned ids and
+// opens no binding, so --rig cannot refuse anything.
+func TestBdByIDRigScopeIsInertOnACityThatRelocatesNothing(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"legacy\"\n"), 0o644); err != nil {
+		t.Fatalf("writing city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityPath)
+	resetCLIStorageRoutes(t)
+	captureCLIStorageStderr(t)
+
+	for _, id := range []string{"gc-abc123", reservedClassID(t, "anything")} {
+		var stdout, stderr bytes.Buffer
+		if code, handled := maybeRouteBdByID(cityPath, byIDRigName, []string{"show", id}, &stdout, &stderr); handled {
+			t.Fatalf("show %s under --rig was handled on an unrelocated city (code %d): %s", id, code, stderr.String())
+		}
+	}
+}
+
+// TestBdByIDRigRuleAppliesToTheFlagAndNotToAutoDetectedScope is the carve-out
+// that matters most in production. The controller sets GC_RIG on every rig
+// agent, so a rule that read auto-detected scope as a deliberate one would
+// refuse the step-completion write the core pack renders on every worked bead.
+//
+// It drives the whole of doBd, because GC_RIG is resolved inside
+// resolveBdScopeTarget and never reaches the by-id surface — a unit call could
+// not tell the two apart.
+func TestBdByIDRigRuleAppliesToTheFlagAndNotToAutoDetectedScope(t *testing.T) {
+	_, classStore := riggedForeignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "a worked step", Type: "task"})
+
+	t.Setenv("GC_RIG", byIDRigName)
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"show", bead.ID, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("GC_RIG=%s show exited %d: %s", byIDRigName, code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), bead.ID) {
+		t.Errorf("GC_RIG=%s show printed %q, want the bead served from the binding", byIDRigName, stdout.String())
+	}
+
+	// The same city, the same bead, the same rig — written as the flag.
+	stdout.Reset()
+	stderr.Reset()
+	if code := doBd([]string{"--rig", byIDRigName, "show", bead.ID, "--json"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("--rig %s show exited %d, want 1: stdout=%q stderr=%q", byIDRigName, code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "drop --rig") {
+		t.Errorf("--rig %s show: stderr %q does not carry the refusal", byIDRigName, stderr.String())
+	}
+
+	// `gc --rig X bd ...` is the same explicit flag by another spelling, and
+	// extractBdScopeFlags folds it into the same value.
+	stdout.Reset()
+	stderr.Reset()
+	prev := rigFlag
+	rigFlag = byIDRigName
+	t.Cleanup(func() { rigFlag = prev })
+	if code := doBd([]string{"show", bead.ID, "--json"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("gc --rig %s bd show exited %d, want 1: stdout=%q stderr=%q", byIDRigName, code, stdout.String(), stderr.String())
+	}
+}

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -179,7 +179,7 @@ func TestBdByIDServesAClassBeadFromANonBuiltInProviderBinding(t *testing.T) {
 	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "lives in the binding", Type: "task"})
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"show", bead.ID, "--json"}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"show", bead.ID, "--json"}, &stdout, &stderr)
 	if !handled {
 		t.Fatalf("a class-owned id fell through to the bd subprocess: stderr %q", stderr.String())
 	}
@@ -212,7 +212,7 @@ func TestBdByIDServesClaimReleaseAndDepListFromTheClassBinding(t *testing.T) {
 
 	t.Setenv("BEADS_ACTOR", "by-id-tester")
 	var stdout, stderr bytes.Buffer
-	if code, handled := maybeRouteBdByID(cityPath, []string{"update", subject.ID, "--claim"}, &stdout, &stderr); !handled || code != 0 {
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"update", subject.ID, "--claim"}, &stdout, &stderr); !handled || code != 0 {
 		t.Fatalf("claiming %s = (%d, %t): %s", subject.ID, code, handled, stderr.String())
 	}
 	claimed, err := classStore.Get(subject.ID)
@@ -225,7 +225,7 @@ func TestBdByIDServesClaimReleaseAndDepListFromTheClassBinding(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	if code, handled := maybeRouteBdByID(cityPath, []string{"release-if-current", subject.ID, "by-id-tester"}, &stdout, &stderr); !handled || code != 0 {
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"release-if-current", subject.ID, "by-id-tester"}, &stdout, &stderr); !handled || code != 0 {
 		t.Fatalf("releasing %s = (%d, %t): %s", subject.ID, code, handled, stderr.String())
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "released" {
@@ -234,7 +234,7 @@ func TestBdByIDServesClaimReleaseAndDepListFromTheClassBinding(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code, handled := maybeRouteBdByID(cityPath, []string{"dep", "list", subject.ID, "--json"}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"dep", "list", subject.ID, "--json"}, &stdout, &stderr)
 	if !handled || code != 0 {
 		t.Fatalf("listing %s dependencies = (%d, %t): %s", subject.ID, code, handled, stderr.String())
 	}
@@ -259,7 +259,7 @@ func TestBdByIDReservedPrefixAbsenceIsNotAFallThrough(t *testing.T) {
 	missing := reservedClassID(t, "notthere")
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"show", missing}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"show", missing}, &stdout, &stderr)
 	if !handled {
 		t.Fatal("an absent reserved-prefix id fell through to the bd subprocess")
 	}
@@ -291,7 +291,7 @@ func TestBdByIDRoutesAWorkShapedIDResidentInTheClassBinding(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"show", created.ID, "--json"}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"show", created.ID, "--json"}, &stdout, &stderr)
 	if !handled {
 		t.Fatalf("a class-resident work-shaped id fell through to the bd subprocess: %q", stderr.String())
 	}
@@ -318,7 +318,7 @@ func TestBdByIDServesTheStepCompletionWrite(t *testing.T) {
 	step := mustCreateClassBead(t, classStore, beads.Bead{Title: "the step", Type: "task"})
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"update", step.ID, "--set-metadata", "gc.outcome=pass", "--status", "closed"}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"update", step.ID, "--set-metadata", "gc.outcome=pass", "--status", "closed"}, &stdout, &stderr)
 	if !handled {
 		t.Fatalf("the step-completion write fell through to the bd subprocess: %q", stderr.String())
 	}
@@ -340,7 +340,7 @@ func TestBdByIDServesTheStepCompletionWrite(t *testing.T) {
 	other := mustCreateClassBead(t, classStore, beads.Bead{Title: "the other step", Type: "task"})
 	stdout.Reset()
 	stderr.Reset()
-	if code, handled := maybeRouteBdByID(cityPath, []string{"update", other.ID, "--set-metadata", "gc.outcome=fail", "--set-metadata", "gc.failure_class=transient", "--status=closed"}, &stdout, &stderr); !handled || code != 0 {
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"update", other.ID, "--set-metadata", "gc.outcome=fail", "--set-metadata", "gc.failure_class=transient", "--status=closed"}, &stdout, &stderr); !handled || code != 0 {
 		t.Fatalf("the inline-equals spelling = (%d, %t): %s", code, handled, stderr.String())
 	}
 	afterOther, err := classStore.Get(other.ID)
@@ -373,7 +373,7 @@ func TestBdByIDShowRendersTheWholeRecord(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	if code, handled := maybeRouteBdByID(cityPath, []string{"show", bead.ID}, &stdout, &stderr); !handled || code != 0 {
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"show", bead.ID}, &stdout, &stderr); !handled || code != 0 {
 		t.Fatalf("showing %s = (%d, %t): %s", bead.ID, code, handled, stderr.String())
 	}
 	out := stdout.String()
@@ -403,7 +403,7 @@ func TestBdByIDLeavesWorkStoreIDsToThePassthrough(t *testing.T) {
 	cityPath, _ := foreignProviderCity(t)
 
 	var stdout, stderr bytes.Buffer
-	if code, handled := maybeRouteBdByID(cityPath, []string{"show", "gc-abc123"}, &stdout, &stderr); handled {
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"show", "gc-abc123"}, &stdout, &stderr); handled {
 		t.Fatalf("a work-store id was answered here (exit %d): %s%s", code, stdout.String(), stderr.String())
 	}
 }
@@ -420,7 +420,7 @@ func TestBdByIDDoesNotRouteAnIDInAValuePosition(t *testing.T) {
 		{"list", "--label", quoted},
 	} {
 		var stdout, stderr bytes.Buffer
-		if code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr); handled {
+		if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
 			t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
 		}
 	}
@@ -435,7 +435,7 @@ func TestBdByIDRefusesAnUnservedVerbOnAClassOwnedBead(t *testing.T) {
 	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "not yours to close", Type: "task"})
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"close", bead.ID}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", bead.ID}, &stdout, &stderr)
 	if !handled {
 		t.Fatal("an unserved mutation of a class-owned bead was handed to the bd subprocess")
 	}
@@ -477,7 +477,7 @@ func TestBdByIDRefusesRatherThanFallsThroughWhenTheWorkspaceIsNotThere(t *testin
 
 	missing := reservedClassID(t, "unreachable")
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"show", missing}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"show", missing}, &stdout, &stderr)
 	if !handled {
 		t.Fatal("a city whose infrastructure workspace is missing fell through to the bd subprocess")
 	}
@@ -521,7 +521,7 @@ func TestBdByIDReadFailureIsAnErrorNotAbsence(t *testing.T) {
 	failClassBindingReads(t, cityPath, failure)
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"show", present}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"show", present}, &stdout, &stderr)
 	if !handled {
 		t.Fatal("a failing class-store read fell through to the bd subprocess")
 	}
@@ -567,7 +567,7 @@ func TestBdByIDLeavesAnUnrelocatedCityAlone(t *testing.T) {
 	captureCLIStorageStderr(t)
 
 	var stdout, stderr bytes.Buffer
-	if code, handled := maybeRouteBdByID(cityPath, []string{"show", reservedClassID(t, "anything")}, &stdout, &stderr); handled {
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"show", reservedClassID(t, "anything")}, &stdout, &stderr); handled {
 		t.Fatalf("an unrelocated city routed a by-id read here (exit %d): %s%s", code, stdout.String(), stderr.String())
 	}
 }
@@ -698,7 +698,7 @@ func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *te
 			resetCLIStorageRoutes(t)
 			registries := countStorageRegistryConstructions(t)
 			var stdout, stderr bytes.Buffer
-			maybeRouteBdByID(cityPath, tc.args, &stdout, &stderr)
+			maybeRouteBdByID(cityPath, "", tc.args, &stdout, &stderr)
 			entered := *registries > 0
 			if entered != tc.enter {
 				t.Errorf("%v entered the storage funnel = %t, want %t", tc.args, entered, tc.enter)
@@ -794,7 +794,7 @@ func TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead(t *testing.T) {
 	for _, args := range refused {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr)
+			code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr)
 			if !handled {
 				t.Fatalf("%v fell through to the bd subprocess", args)
 			}
@@ -817,7 +817,7 @@ func TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead(t *testing.T) {
 	} {
 		t.Run("served "+strings.Join(args, " "), func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr)
+			code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr)
 			if !handled {
 				t.Fatalf("%v fell through to the bd subprocess", args)
 			}
@@ -834,7 +834,7 @@ func TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead(t *testing.T) {
 	} {
 		t.Run("passthrough "+strings.Join(args, " "), func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			if code, handled := maybeRouteBdByID(cityPath, args, &stdout, &stderr); handled {
+			if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
 				t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
 			}
 		})
@@ -852,7 +852,7 @@ func TestBdByIDRefusalNamesTheUnrepresentableFlag(t *testing.T) {
 	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "step", Type: "task"})
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, []string{"update", bead.ID, "--set-metadata", "gc.outcome=pass", "--status=closed", "--notes", "done"}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"update", bead.ID, "--set-metadata", "gc.outcome=pass", "--status=closed", "--notes", "done"}, &stdout, &stderr)
 	if !handled || code == 0 {
 		t.Fatalf("the unrepresentable update was not refused: (%d, %t) %s", code, handled, stderr.String())
 	}

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -627,7 +627,16 @@ With --attach on a v2 formula — one declaring
 [requires] formula_compiler = ">=2.0.0" — the invocation runs under a
 per-source workflow lock and is idempotent: a repeat cook for the same
 source bead reuses the live workflow instead of duplicating it, and a
-conflicting live workflow from the same source is an error.`,
+conflicting live workflow from the same source is an error.
+
+On a city that serves a coordination class from its own [storage] binding,
+--attach follows the ATTACH BEAD: the sub-DAG and the blocking dependency
+are written to the store that holds it, so the two ends of the edge stay in
+one store. A v2 (graph.v2) formula is the exception and is refused for an
+attach bead the binding owns: it normalizes its target into a synthetic
+input convoy, which is a work bead that can live neither in the binding nor
+in the work ledger, whose membership edge to the target would be
+cross-class. Attach a v1 formula to that bead instead.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cityPath, err := resolveCity()
@@ -658,7 +667,9 @@ conflicting live workflow from the same source is an error.`,
 			// was handed on every city that relocates nothing, so a single-store
 			// cook runs against the one store it always did.
 			//
-			// The --attach arms route BY ID instead — see attachStore below.
+			// The --attach arms do not use this: a graft follows its PARENT,
+			// not its class, so they route by the attach bead's id instead —
+			// see attachStore below.
 			graphStore := resolveGraphStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 
 			cookVars := parseFormulaVars(vars)
@@ -668,51 +679,91 @@ conflicting live workflow from the same source is an error.`,
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("load formula %q: %w", args[0], err))
 				}
-				// A graft is a TWO-ENDED edge, so both arms below run whole
-				// against the store that holds the ATTACH BEAD, resolved by id
-				// — parent read, sub-DAG materialization and the blocking dep
-				// alike. That is the half of the two-store attach this routing
-				// can answer, and it is what keeps the edge co-resident: move
-				// only the sub-DAG root and the other store records a `blocks`
-				// row naming an id it cannot resolve, which no backend rejects
-				// (bd passes a cross-prefix target through as an external ref;
+				// A graft is a TWO-ENDED edge, so the arm that can serve it runs
+				// WHOLE against the store that holds the ATTACH BEAD, resolved
+				// by id — parent read, sub-DAG materialization and the blocking
+				// dep alike. That is what keeps the edge co-resident: move only
+				// the sub-DAG root and the other store records a `blocks` row
+				// naming an id it cannot resolve, which no backend rejects (bd
+				// passes a cross-prefix target through as an external ref;
 				// SQLite's deps table has no foreign key) and which every Ready
 				// implementation reads as a blocker that never clears. That is
 				// the dangling edge #5150 reproduced as "attach bead gc-1 is
 				// not Ready after the whole workflow closed", and it is not
 				// re-shipped here.
 				//
-				// STILL DEFERRED, and it is the other half: on a split city
-				// whose attach bead lives in the WORK ledger, the sub-DAG is
-				// graph class and stays in the work ledger with it. Relocating
-				// it needs the block REPRESENTED across the store boundary —
-				// a mechanism that does not exist, in beads or here, and whose
-				// absence is why the edge must stay co-resident rather than be
-				// split. See the ga-k8pzw notes.
+				// The arm that can serve it is the V1 one. The graph.v2 arm
+				// cannot, and refuses — see the block on isGraphFormula below.
 				//
-				// Behavior change is confined to one case: an attach bead the
-				// class binding owns, which today fails outright because the
-				// scope store cannot read it. Every city that relocates
-				// nothing, and every split city whose attach bead is work
-				// resident, gets back the exact store value resolveFormulaScope
-				// opened.
+				// STILL DEFERRED, and it is the other half of the v1 arm: on a
+				// split city whose attach bead lives in the WORK ledger, the
+				// sub-DAG is graph class and stays in the work ledger with it.
+				// Relocating it needs the block REPRESENTED across the store
+				// boundary — a mechanism that does not exist, in beads or here,
+				// and whose absence is why the edge must stay co-resident
+				// rather than be split. See the ga-k8pzw notes.
+				//
+				// Every city that relocates nothing, and every split city whose
+				// attach bead is work resident, gets back the exact store value
+				// resolveFormulaScope opened, so attachStore != store is
+				// precisely "the class binding holds this bead".
 				attachStore, err := classRoutedStoreForID(cityPath, attach, store)
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
 				if isGraphFormula {
-					// Every read, create and dep in this arm runs against
-					// attachStore, so the graft and the bead it hangs off stay
-					// in ONE store. The store-ref stamp keeps naming the SCOPE
-					// root, which is what the standalone graph.v2 arm below
-					// stamps on a graph-resident root too — the ref identifies
-					// the work scope a run belongs to, not the database its
-					// rows sit in.
+					if attachStore != store {
+						// REFUSED, not routed, and not silently redirected: a
+						// graph.v2 invocation normalizes its target into an
+						// input convoy (PrepareInvocation ->
+						// NormalizeInputConvoy -> CreateSingleItemInputConvoy),
+						// and a synthetic input convoy is a WORK bead by
+						// explicit classification (coordclass.Classify). For an
+						// attach bead the class binding owns there is nowhere to
+						// put it:
+						//
+						//   - in the binding: a work-class bead born in the
+						//     infra ledger, which the migration's own equality
+						//     invariant says never happens — the rule
+						//     drainUnitConvoyStore states for the drain's unit
+						//     convoy, and graphv2's own
+						//     TestSyntheticInputConvoyIsWorkClassAndCoResidentWithItsTarget
+						//     asserts for this one;
+						//   - in the work ledger: NormalizeInputConvoy cannot
+						//     read the target there at all, and the convoy's one
+						//     `tracks` edge to it is cross-class, which
+						//     convoy.TrackItemIn refuses with
+						//     ErrMemberNotCoResident even when the graph class
+						//     handle is named.
+						//
+						// So the missing piece is a cross-class MEMBERSHIP edge,
+						// which is a production mechanism rather than routing:
+						// ga-2orlf. Refusing costs nobody a capability — on a
+						// city without this routing the same invocation dies
+						// with "formulas v2 target <id> not found" — and the two
+						// alternatives are both silent: mis-homing the convoy,
+						// or emitting a run whose execution.work_associated is
+						// dropped because the projection's work leg reads a
+						// convoy the work ledger never held (DepList answers
+						// EMPTY there, not an error).
+						//
+						// The v1 arm below is unaffected and DOES serve this
+						// bead: PrepareInvocation returns before
+						// NormalizeInputConvoy for a non-graph formula, so it
+						// mints no convoy and the whole graft is co-resident.
+						return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf(
+							"--attach %s: %s is owned by the relocated class binding, and a graph.v2 formula's synthetic input convoy is a work bead — it can live neither there (a work-class bead in the infra ledger) nor in the work ledger (its `tracks` edge to %s would be cross-class, which convoy.TrackItemIn refuses); grafting a graph.v2 formula onto a class-owned bead needs a cross-class membership edge: ga-2orlf. A v1 formula attaches to %s today",
+							attach, attach, attach, attach))
+					}
+					// Past the refusal attachStore IS store, so this arm runs
+					// on the one store it always did and its execution-fact
+					// legs are the same value: the root, its steps and the
+					// input convoy are all minted here.
 					storeRef := workflowStoreRefForDir(scope.storeRoot, cityPath, loadedCityName(cfg, cityPath), cfg)
 					var result *molecule.Result
 					var syntheticInputConvoyID string
 					err := sourceworkflow.WithLock(cmd.Context(), cityPath, sourceWorkflowLockScopeForStoreRef(cityPath, cfg, scope.storeRoot, storeRef), attach, func() error {
-						inv, err := graphv2.PrepareInvocation(cmd.Context(), attachStore, args[0], scope.searchPaths, attach, cookVars)
+						inv, err := graphv2.PrepareInvocation(cmd.Context(), store, args[0], scope.searchPaths, attach, cookVars)
 						if err != nil {
 							return fmt.Errorf("prepare formulas v2 invocation: %w", err)
 						}
@@ -730,25 +781,25 @@ conflicting live workflow from the same source is an error.`,
 							return fmt.Errorf("validate runtime vars: %w", err)
 						}
 						graphRootKey := stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
-						if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, scope.rig, attachStore, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
+						if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, scope.rig, store, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
 							return fmt.Errorf("decorate formulas v2 recipe: %w", err)
 						}
 						if graphRootKey != "" {
 							unlock := graphv2.LockKey(graphRootKey)
 							defer unlock()
 						}
-						if err := closeFormulaCookFailedGraphV2Roots(attachStore, recipe); err != nil {
+						if err := closeFormulaCookFailedGraphV2Roots(store, recipe); err != nil {
 							return err
 						}
-						existing, err := existingFormulaCookGraphV2Root(attachStore, recipe)
+						existing, err := existingFormulaCookGraphV2Root(store, recipe)
 						if err != nil {
 							return err
 						}
 						if existing != nil {
 							result = existing
-							return ensureFormulaCookAttachDep(attachStore, attach, result.RootID)
+							return ensureFormulaCookAttachDep(store, attach, result.RootID)
 						}
-						if roots, err := formulaCookLiveInputConvoyGraphRoots(attachStore, inv.InputConvoy, graphRootKey); err != nil {
+						if roots, err := formulaCookLiveInputConvoyGraphRoots(store, inv.InputConvoy, graphRootKey); err != nil {
 							return err
 						} else if len(roots) > 0 {
 							return &sourceworkflow.ConflictError{
@@ -756,7 +807,7 @@ conflicting live workflow from the same source is an error.`,
 								WorkflowIDs:  sourceworkflow.BlockingWorkflowIDs(roots),
 							}
 						}
-						if roots, err := sourceworkflow.ListLiveRoots(attachStore, attach, storeRef, storeRef); err != nil {
+						if roots, err := sourceworkflow.ListLiveRoots(store, attach, storeRef, storeRef); err != nil {
 							return fmt.Errorf("checking live workflows for %s: %w", attach, err)
 						} else if len(roots) > 0 {
 							return &sourceworkflow.ConflictError{
@@ -764,30 +815,30 @@ conflicting live workflow from the same source is an error.`,
 								WorkflowIDs:  sourceworkflow.BlockingWorkflowIDs(roots),
 							}
 						}
-						source, err := attachStore.Get(attach)
+						source, err := store.Get(attach)
 						if err != nil {
 							return fmt.Errorf("attach bead %s: %w", attach, err)
 						}
-						result, err = molecule.Instantiate(cmd.Context(), attachStore, recipe, molecule.Options{
+						result, err = molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
 							Title:            title,
 							Vars:             cookVars,
 							IdempotencyKey:   graphRootKey,
 							PriorityOverride: cloneFormulaCookPriority(source.Priority),
 						})
 						if err != nil {
-							if cleanupErr := closeFormulaCookFailedGraphV2Roots(attachStore, recipe); cleanupErr != nil {
+							if cleanupErr := closeFormulaCookFailedGraphV2Roots(store, recipe); cleanupErr != nil {
 								return errors.Join(err, cleanupErr)
 							}
 							return err
 						}
-						emitFormulaCookExecutionFacts(attachStore, store, cityPath, result, stderr)
-						return ensureFormulaCookAttachDep(attachStore, attach, result.RootID)
+						emitFormulaCookExecutionFacts(store, store, cityPath, result, stderr)
+						return ensureFormulaCookAttachDep(store, attach, result.RootID)
 					})
 					if err != nil {
 						// A post-prepare failure discards the invocation; close the
 						// synthetic input convoy it minted (the success path threads the
 						// convoy into the started workflow, so err == nil never reaches here).
-						graphv2.CloseSyntheticInputConvoy(attachStore, syntheticInputConvoyID, attach)
+						graphv2.CloseSyntheticInputConvoy(store, syntheticInputConvoyID, attach)
 						return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 					}
 					if jsonOutput {
@@ -814,6 +865,11 @@ conflicting live workflow from the same source is an error.`,
 					return nil
 				}
 
+				// Non-graph formula: PrepareInvocation returns before
+				// NormalizeInputConvoy, so this call mints no input convoy and
+				// the store it is handed only has to be able to LOAD the
+				// formula. That is exactly why this arm can serve a class-owned
+				// attach bead when the graph.v2 arm above cannot.
 				inv, err := graphv2.PrepareInvocation(cmd.Context(), attachStore, args[0], scope.searchPaths, attach, cookVars)
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("prepare formulas v2 invocation: %w", err))
@@ -836,6 +892,11 @@ conflicting live workflow from the same source is an error.`,
 				// stays co-resident, and the sub-DAG follows its parent rather
 				// than its class. See the attachStore comment above for the
 				// half that is still deferred.
+				//
+				// The execution-fact emit below stays on `store`: it resolves
+				// its own graph leg through resolveGraphStore, which already
+				// names the binding, and its work leg is only read for an input
+				// convoy this arm never mints.
 				result, err := molecule.Attach(cmd.Context(), attachStore, recipe, attach, molecule.AttachOptions{
 					Title:          title,
 					Vars:           cookVars,

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -658,7 +658,7 @@ conflicting live workflow from the same source is an error.`,
 			// was handed on every city that relocates nothing, so a single-store
 			// cook runs against the one store it always did.
 			//
-			// The --attach arms are excluded — see the deferral comment on each.
+			// The --attach arms route BY ID instead — see attachStore below.
 			graphStore := resolveGraphStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 
 			cookVars := parseFormulaVars(vars)
@@ -668,30 +668,51 @@ conflicting live workflow from the same source is an error.`,
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("load formula %q: %w", args[0], err))
 				}
+				// A graft is a TWO-ENDED edge, so both arms below run whole
+				// against the store that holds the ATTACH BEAD, resolved by id
+				// — parent read, sub-DAG materialization and the blocking dep
+				// alike. That is the half of the two-store attach this routing
+				// can answer, and it is what keeps the edge co-resident: move
+				// only the sub-DAG root and the other store records a `blocks`
+				// row naming an id it cannot resolve, which no backend rejects
+				// (bd passes a cross-prefix target through as an external ref;
+				// SQLite's deps table has no foreign key) and which every Ready
+				// implementation reads as a blocker that never clears. That is
+				// the dangling edge #5150 reproduced as "attach bead gc-1 is
+				// not Ready after the whole workflow closed", and it is not
+				// re-shipped here.
+				//
+				// STILL DEFERRED, and it is the other half: on a split city
+				// whose attach bead lives in the WORK ledger, the sub-DAG is
+				// graph class and stays in the work ledger with it. Relocating
+				// it needs the block REPRESENTED across the store boundary —
+				// a mechanism that does not exist, in beads or here, and whose
+				// absence is why the edge must stay co-resident rather than be
+				// split. See the ga-k8pzw notes.
+				//
+				// Behavior change is confined to one case: an attach bead the
+				// class binding owns, which today fails outright because the
+				// scope store cannot read it. Every city that relocates
+				// nothing, and every split city whose attach bead is work
+				// resident, gets back the exact store value resolveFormulaScope
+				// opened.
+				attachStore, err := classRoutedStoreForID(cityPath, attach, store)
+				if err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
 				if isGraphFormula {
-					// NOT routed at the graph class, deliberately — the same
-					// deferral the legacy molecule.Attach arm below carries, for
-					// the same reason. A graft is a two-ended edge: the sub-DAG
-					// root is graph class, the attach bead is whatever class owns
-					// it, and ensureFormulaCookAttachDep writes a `blocks` row
-					// binding them. Move only the root and the work store records
-					// an edge naming an id it cannot resolve. No backend rejects
-					// that write (internal/beads/splittest documents both: bd
-					// passes a cross-prefix target through as an external ref,
-					// SQLite's deps table has no foreign key), and every Ready
-					// implementation treats an unresolvable blocker as open — so
-					// the caller's own work bead silently leaves Ready forever
-					// and the documented graft gate is void. Splitting it needs
-					// the attach bead's owning store resolved by id — the shared
-					// by-id class resolver, ga-k8pzw — plus a cross-boundary
-					// representation of the block, which is a production behavior
-					// change rather than wiring. Whole arm stays on the scope
-					// store until then, root and dep co-resident.
+					// Every read, create and dep in this arm runs against
+					// attachStore, so the graft and the bead it hangs off stay
+					// in ONE store. The store-ref stamp keeps naming the SCOPE
+					// root, which is what the standalone graph.v2 arm below
+					// stamps on a graph-resident root too — the ref identifies
+					// the work scope a run belongs to, not the database its
+					// rows sit in.
 					storeRef := workflowStoreRefForDir(scope.storeRoot, cityPath, loadedCityName(cfg, cityPath), cfg)
 					var result *molecule.Result
 					var syntheticInputConvoyID string
 					err := sourceworkflow.WithLock(cmd.Context(), cityPath, sourceWorkflowLockScopeForStoreRef(cityPath, cfg, scope.storeRoot, storeRef), attach, func() error {
-						inv, err := graphv2.PrepareInvocation(cmd.Context(), store, args[0], scope.searchPaths, attach, cookVars)
+						inv, err := graphv2.PrepareInvocation(cmd.Context(), attachStore, args[0], scope.searchPaths, attach, cookVars)
 						if err != nil {
 							return fmt.Errorf("prepare formulas v2 invocation: %w", err)
 						}
@@ -709,25 +730,25 @@ conflicting live workflow from the same source is an error.`,
 							return fmt.Errorf("validate runtime vars: %w", err)
 						}
 						graphRootKey := stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
-						if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, scope.rig, store, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
+						if err := decorateFormulaCookGraphV2Recipe(recipe, cookVars, storeRef, scope.rig, attachStore, loadedCityName(cfg, cityPath), cityPath, cfg); err != nil {
 							return fmt.Errorf("decorate formulas v2 recipe: %w", err)
 						}
 						if graphRootKey != "" {
 							unlock := graphv2.LockKey(graphRootKey)
 							defer unlock()
 						}
-						if err := closeFormulaCookFailedGraphV2Roots(store, recipe); err != nil {
+						if err := closeFormulaCookFailedGraphV2Roots(attachStore, recipe); err != nil {
 							return err
 						}
-						existing, err := existingFormulaCookGraphV2Root(store, recipe)
+						existing, err := existingFormulaCookGraphV2Root(attachStore, recipe)
 						if err != nil {
 							return err
 						}
 						if existing != nil {
 							result = existing
-							return ensureFormulaCookAttachDep(store, attach, result.RootID)
+							return ensureFormulaCookAttachDep(attachStore, attach, result.RootID)
 						}
-						if roots, err := formulaCookLiveInputConvoyGraphRoots(store, inv.InputConvoy, graphRootKey); err != nil {
+						if roots, err := formulaCookLiveInputConvoyGraphRoots(attachStore, inv.InputConvoy, graphRootKey); err != nil {
 							return err
 						} else if len(roots) > 0 {
 							return &sourceworkflow.ConflictError{
@@ -735,7 +756,7 @@ conflicting live workflow from the same source is an error.`,
 								WorkflowIDs:  sourceworkflow.BlockingWorkflowIDs(roots),
 							}
 						}
-						if roots, err := sourceworkflow.ListLiveRoots(store, attach, storeRef, storeRef); err != nil {
+						if roots, err := sourceworkflow.ListLiveRoots(attachStore, attach, storeRef, storeRef); err != nil {
 							return fmt.Errorf("checking live workflows for %s: %w", attach, err)
 						} else if len(roots) > 0 {
 							return &sourceworkflow.ConflictError{
@@ -743,30 +764,30 @@ conflicting live workflow from the same source is an error.`,
 								WorkflowIDs:  sourceworkflow.BlockingWorkflowIDs(roots),
 							}
 						}
-						source, err := store.Get(attach)
+						source, err := attachStore.Get(attach)
 						if err != nil {
 							return fmt.Errorf("attach bead %s: %w", attach, err)
 						}
-						result, err = molecule.Instantiate(cmd.Context(), store, recipe, molecule.Options{
+						result, err = molecule.Instantiate(cmd.Context(), attachStore, recipe, molecule.Options{
 							Title:            title,
 							Vars:             cookVars,
 							IdempotencyKey:   graphRootKey,
 							PriorityOverride: cloneFormulaCookPriority(source.Priority),
 						})
 						if err != nil {
-							if cleanupErr := closeFormulaCookFailedGraphV2Roots(store, recipe); cleanupErr != nil {
+							if cleanupErr := closeFormulaCookFailedGraphV2Roots(attachStore, recipe); cleanupErr != nil {
 								return errors.Join(err, cleanupErr)
 							}
 							return err
 						}
-						emitFormulaCookExecutionFacts(store, store, cityPath, result, stderr)
-						return ensureFormulaCookAttachDep(store, attach, result.RootID)
+						emitFormulaCookExecutionFacts(attachStore, store, cityPath, result, stderr)
+						return ensureFormulaCookAttachDep(attachStore, attach, result.RootID)
 					})
 					if err != nil {
 						// A post-prepare failure discards the invocation; close the
 						// synthetic input convoy it minted (the success path threads the
 						// convoy into the started workflow, so err == nil never reaches here).
-						graphv2.CloseSyntheticInputConvoy(store, syntheticInputConvoyID, attach)
+						graphv2.CloseSyntheticInputConvoy(attachStore, syntheticInputConvoyID, attach)
 						return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 					}
 					if jsonOutput {
@@ -793,7 +814,7 @@ conflicting live workflow from the same source is an error.`,
 					return nil
 				}
 
-				inv, err := graphv2.PrepareInvocation(cmd.Context(), store, args[0], scope.searchPaths, attach, cookVars)
+				inv, err := graphv2.PrepareInvocation(cmd.Context(), attachStore, args[0], scope.searchPaths, attach, cookVars)
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, fmt.Errorf("prepare formulas v2 invocation: %w", err))
 				}
@@ -808,17 +829,14 @@ conflicting live workflow from the same source is an error.`,
 					graphRootKey = stampFormulaCookGraphV2Root(recipe, args[0], inv.InputConvoy, cookVars)
 				}
 
-				// NOT routed at the graph class, deliberately. molecule.Attach is a
-				// one-store operation that reads the attach bead, materializes the
-				// sub-DAG and writes the blocking dep through the SAME store, and
-				// on a split city those are two classes: the attach bead is
-				// whatever class owns it, while every sub-DAG bead is graph (Attach
-				// stamps the parent's gc.root_bead_id onto each step). Answering
-				// that needs the attach bead's owning store resolved by id — the
-				// shared by-id class resolver, ga-k8pzw — and a two-store Attach,
-				// which is a production behavior change rather than wiring. Left on
-				// the scope store until then.
-				result, err := molecule.Attach(cmd.Context(), store, recipe, attach, molecule.AttachOptions{
+				// molecule.Attach reads the attach bead, materializes the
+				// sub-DAG and writes the blocking dep through ONE store, so it
+				// is handed the one that HOLDS the attach bead. That is the
+				// whole of the two-store attach this arm can express: the edge
+				// stays co-resident, and the sub-DAG follows its parent rather
+				// than its class. See the attachStore comment above for the
+				// half that is still deferred.
+				result, err := molecule.Attach(cmd.Context(), attachStore, recipe, attach, molecule.AttachOptions{
 					Title:          title,
 					Vars:           cookVars,
 					IdempotencyKey: graphRootKey,
@@ -1342,6 +1360,18 @@ since it was spawned.`,
 			}
 
 			store, err := openStoreAtForCity(scope.storeRoot, cityPath)
+			if err != nil {
+				return err
+			}
+			// version-check's subject is a molecule/workflow bead, which is the
+			// graph class: on a city that relocates graph, every root this
+			// command is about is minted in the binding and the scope store has
+			// never held it. Reading it there reported "not found" for a live
+			// root — a by-id read answering about the wrong ledger, which is
+			// the same defect the `gc bd` by-id surface exists to close.
+			// classRoutedStoreForID returns the exact store value passed in on
+			// every city that relocates nothing.
+			store, err = classRoutedStoreForID(cityPath, beadID, store)
 			if err != nil {
 				return err
 			}

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -392,30 +392,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 	queryEnv := mergeRuntimeEnv(os.Environ(), overrides)
 	failureTemplate, emitFailureEvent := hookWorkQueryFailureTemplate(len(args) > 0, sessionTemplateContext, a.QualifiedName())
 
-	// A cross-store-eligible (city-scoped) agent federates its work query across
-	// all stores — its own first, then every rig store — matched on its own
-	// identity (vp-kvp stage iii). A rig-scoped agent ("<rig>/<name>") instead
-	// queries its own <rig> store FIRST: its routed work lives there, but its
-	// city-scoped work-query env does not reach it, so without this the hook
-	// returns empty and the spawned session exits with nothing to do. The rig
-	// store goes first (as the primary entry, not a best-effort federated
-	// extra) so a rig-store work-query timeout still surfaces to the reconciler
-	// via bestStoreWithWork's emit-on-timeout contract — the agent's
-	// (work-less) city-scoped env stays as a best-effort secondary. This
-	// extends the #2877 city-scoped cross-store delivery to rig-scoped agents.
-	stores := []hookStore{{dir: workDir, env: queryEnv}}
-	if agentIsCrossStoreEligible(&a) {
-		stores = appendRigHookStores(stores, cityPath, cfg, &a, overrides)
-	} else if rig := rigScopedHookRig(cfg, agentForQuery); rig != "" {
-		if rigStores := appendOneRigHookStore(nil, cityPath, cfg, &a, rig, overrides); len(rigStores) > 0 {
-			stores = append(rigStores, stores...)
-		}
-		// A rig-backed agent's own env above is ALSO rig-scoped, so without
-		// this no entry reaches the CITY store and root-only beads assigned
-		// to the agent stay invisible. Best-effort tertiary; see
-		// appendCityHookStore.
-		stores = appendCityHookStore(stores, cityPath, cfg, &a, overrides)
-	}
+	stores := hookWorkQueryStores(cityPath, cfg, &a, agentForQuery, workDir, queryEnv, overrides)
 
 	// emitQueryFailure surfaces a killed/timed-out work query on the event bus
 	// so the reconciler can escalate instead of silently treating the strand as

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -21,6 +21,43 @@ type hookStore struct {
 // a real bd subprocess.
 type hookStoreRunner func(command, dir string, env []string) (string, error)
 
+// hookWorkQueryStores is the whole fan-out `gc hook` queries, in probe order.
+//
+// A cross-store-eligible (city-scoped) agent federates its work query across all
+// stores — its own first, then every rig store — matched on its own identity
+// (vp-kvp stage iii). A rig-scoped agent ("<rig>/<name>") instead queries its own
+// <rig> store FIRST: its routed work lives there, but its city-scoped
+// work-query env does not reach it, so without this the hook returns empty and
+// the spawned session exits with nothing to do. The rig store goes first (as the
+// primary entry, not a best-effort federated extra) so a rig-store work-query
+// timeout still surfaces to the reconciler via bestStoreWithWork's
+// emit-on-timeout contract — the agent's (work-less) city-scoped env stays as a
+// best-effort secondary. This extends the #2877 city-scoped cross-store delivery
+// to rig-scoped agents.
+//
+// Every leg is a bd WORKSPACE: a directory plus the env that points bd at it.
+// That is the shape of the I5 known gap — a relocated coordination class is not
+// a bd workspace, so no leg of this list can answer for a bead the binding owns,
+// and `gc hook --claim` never sees a class id to route. This function is the
+// seam that pins it (conformanceClaimRouting); closing the gap adds a leg here.
+func hookWorkQueryStores(cityPath string, cfg *config.City, a *config.Agent, agentForQuery, workDir string, queryEnv []string, identityOverrides map[string]string) []hookStore {
+	stores := []hookStore{{dir: workDir, env: queryEnv}}
+	if agentIsCrossStoreEligible(a) {
+		return appendRigHookStores(stores, cityPath, cfg, a, identityOverrides)
+	}
+	rig := rigScopedHookRig(cfg, agentForQuery)
+	if rig == "" {
+		return stores
+	}
+	if rigStores := appendOneRigHookStore(nil, cityPath, cfg, a, rig, identityOverrides); len(rigStores) > 0 {
+		stores = append(rigStores, stores...)
+	}
+	// A rig-backed agent's own env above is ALSO rig-scoped, so without this no
+	// entry reaches the CITY store and root-only beads assigned to the agent
+	// stay invisible. Best-effort tertiary; see appendCityHookStore.
+	return appendCityHookStore(stores, cityPath, cfg, a, identityOverrides)
+}
+
 // hookIdentityEnvKeys are the identity overrides that must stay constant across
 // every federated store attempt — the query always matches the agent's OWN
 // identity (gc.routed_to / assignee == this identity) regardless of which store

--- a/cmd/gc/oneshot_by_id_routes_test.go
+++ b/cmd/gc/oneshot_by_id_routes_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// This file covers the one-shot commands that hold a BEAD ID and read or mutate
+// that bead: `gc formula version-check` and the two `gc formula cook --attach`
+// arms. They resolve their store through classRoutedStoreForID
+// (by_id_store_route.go), which is the shared candidate-list-and-probe.
+//
+// Its siblings live in oneshot_class_routes_test.go, which covers the BIRTH
+// half — where a newly minted bead lands. The distinction matters: a birth is
+// routed by the CLASS of what is being created, a by-id operation by where the
+// subject already IS.
+
+// cookCityWithSplitGraph is the shared fixture: a cook city whose graph class is
+// served from its own binding, plus its work store.
+func cookCityWithSplitGraph(t *testing.T) (work, graph beads.Store) {
+	t.Helper()
+	cityDir := oneShotCookCity(t)
+	graph = splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	return work, graph
+}
+
+// runVersionCheck drives the real `gc formula version-check <id>` command and
+// returns its error, so a routing failure is read from the command rather than
+// from a helper.
+func runVersionCheck(t *testing.T, beadID string) (string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaVersionCheckCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{beadID})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	return stdout.String() + stderr.String(), err
+}
+
+// TestFormulaVersionCheckReadsTheGraphResidentRoot is one of the two readers
+// #5150's council named for this slice.
+//
+// version-check's subject is always a molecule/workflow bead — it needs
+// gc.formula_hash, which only instantiation writes — and on a split city every
+// such root is minted in the binding. Reading it through the scope store
+// reported "not found" for a live root: an existence answer from a ledger that
+// has never held the bead, which is the by-id defect this slice closes.
+func TestFormulaVersionCheckReadsTheGraphResidentRoot(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	res := cookFormula(t, "graph-work")
+	root, err := graph.Get(res.RootID)
+	if err != nil {
+		t.Fatalf("cooked root %s is not resident in the graph binding: %v", res.RootID, err)
+	}
+	if root.Metadata[beadmeta.FormulaHashMetadataKey] == "" {
+		t.Fatalf("cooked root %s carries no %s; version-check has nothing to compare and this fixture proves nothing", res.RootID, beadmeta.FormulaHashMetadataKey)
+	}
+	if _, err := work.Get(res.RootID); err == nil {
+		t.Fatalf("the work store also holds %s; the premise is that only the binding does", res.RootID)
+	}
+
+	out, err := runVersionCheck(t, res.RootID)
+	if err != nil {
+		t.Fatalf("gc formula version-check %s failed: %v\n%s", res.RootID, err, out)
+	}
+	if !strings.Contains(out, res.RootID) {
+		t.Errorf("version-check output %q does not name %s", out, res.RootID)
+	}
+}
+
+// TestFormulaVersionCheckLeavesWorkResidentRootsOnTheScopeStore is the other
+// half: a root the work ledger holds is still read from the work ledger, so the
+// probe cannot have become an unconditional route to the binding.
+func TestFormulaVersionCheckLeavesWorkResidentRootsOnTheScopeStore(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	res := cookFormula(t, "legacy-work")
+	if _, err := work.Get(res.RootID); err != nil {
+		t.Fatalf("a v1 molecule root must stay in the work ledger: %v", err)
+	}
+	if _, err := graph.Get(res.RootID); err == nil {
+		t.Fatalf("the binding holds the v1 root %s; the premise is that only the work store does", res.RootID)
+	}
+
+	if out, err := runVersionCheck(t, res.RootID); err != nil {
+		t.Fatalf("gc formula version-check %s failed: %v\n%s", res.RootID, err, out)
+	}
+}
+
+// TestFormulaCookAttachGraftsOntoAClassResidentBeadInOneStore is the by-id half
+// of the two-store attach, and the case main cannot serve at all.
+//
+// A graft onto a bead the binding owns — a workflow step expanding itself
+// mid-run, which is what late-bound DAG expansion IS — used to run `store.Get`
+// against the scope store, which has never held that bead, and failed outright.
+// Routing the whole arm by the attach bead's id both makes it work and keeps the
+// edge CO-RESIDENT: the sub-DAG root, the steps and the `blocks` row all land in
+// the store that holds the parent, so no dep has an endpoint the store cannot
+// resolve.
+func TestFormulaCookAttachGraftsOntoAClassResidentBeadInOneStore(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	source, err := graph.Create(beads.Bead{Title: "a running workflow step", Type: "task"})
+	if err != nil {
+		t.Fatalf("create the class-resident attach bead: %v", err)
+	}
+	if !bdIDIsClassReserved(source.ID) {
+		t.Fatalf("the binding minted %q, which carries no reserved class prefix", source.ID)
+	}
+
+	res := cookFormula(t, "graph-work", "--attach", source.ID)
+
+	if _, err := graph.Get(res.RootID); err != nil {
+		t.Fatalf("sub-DAG root %s is not resident in the store that holds its attach bead: %v", res.RootID, err)
+	}
+	if _, err := work.Get(res.RootID); err == nil {
+		t.Errorf("the work ledger holds sub-DAG root %s, which was grafted onto a bead it does not hold", res.RootID)
+	}
+
+	deps, err := graph.DepList(source.ID, "down")
+	if err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatalf("attach bead %s has no blocking dep after cook; the graft was never wired", source.ID)
+	}
+	for _, dep := range deps {
+		if _, err := graph.Get(dep.DependsOnID); err != nil {
+			t.Errorf("store holds dep %s -> %s (%s) whose target it cannot resolve: %v — a dangling cross-store blocking edge no backend rejects and no finalize path removes", dep.IssueID, dep.DependsOnID, dep.Type, err)
+		}
+	}
+	if workDeps, err := work.DepList(source.ID, "down"); err == nil && len(workDeps) > 0 {
+		t.Errorf("the work ledger recorded %d deps for a bead it does not hold: %+v", len(workDeps), workDeps)
+	}
+
+	// The graft gate itself: with the whole sub-DAG closed, the attach bead
+	// comes back to Ready. A split edge leaves it wedged out of Ready forever.
+	closeEveryBeadExcept(t, graph, source.ID)
+	ready, err := graph.Ready()
+	if err != nil {
+		t.Fatalf("graph Ready(): %v", err)
+	}
+	if !slices.Contains(beadIDs(ready), source.ID) {
+		t.Fatalf("attach bead %s is not Ready after the whole workflow closed (ready=%v, root=%s)", source.ID, beadIDs(ready), res.RootID)
+	}
+}
+
+// TestFormulaCookLegacyAttachGraftsOntoAClassResidentBeadInOneStore is the same
+// claim for the v1 arm, which runs molecule.Attach rather than the graph.v2
+// pipeline. Attach reads the parent, materializes the sub-DAG and writes the
+// blocking dep through ONE store, so the store it is handed has to be the one
+// that holds the parent.
+func TestFormulaCookLegacyAttachGraftsOntoAClassResidentBeadInOneStore(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	source, err := graph.Create(beads.Bead{Title: "a running workflow step", Type: "task"})
+	if err != nil {
+		t.Fatalf("create the class-resident attach bead: %v", err)
+	}
+
+	res := cookFormula(t, "legacy-work", "--attach", source.ID)
+
+	if _, err := graph.Get(res.RootID); err != nil {
+		t.Fatalf("v1 sub-DAG root %s is not resident in the store that holds its attach bead: %v", res.RootID, err)
+	}
+	if _, err := work.Get(res.RootID); err == nil {
+		t.Errorf("the work ledger holds v1 sub-DAG root %s, grafted onto a bead it does not hold", res.RootID)
+	}
+	deps, err := graph.DepList(source.ID, "down")
+	if err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatalf("attach bead %s has no blocking dep after a v1 cook; the graft was never wired", source.ID)
+	}
+	for _, dep := range deps {
+		if _, err := graph.Get(dep.DependsOnID); err != nil {
+			t.Errorf("store holds dep %s -> %s (%s) whose target it cannot resolve: %v", dep.IssueID, dep.DependsOnID, dep.Type, err)
+		}
+	}
+}
+
+// TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged pins the DEFERRED half,
+// so it cannot close or widen without a test moving.
+//
+// When the attach bead lives in the work ledger, the graft stays there with it —
+// including the sub-DAG, whose beads are graph class. Relocating them would put
+// the two ends of the `blocks` edge in different stores, which no backend
+// rejects and every Ready implementation reads as a blocker that never clears
+// (#5150 reproduced it as "attach bead gc-1 is not Ready after the whole
+// workflow closed"). Closing this gap needs the block REPRESENTED across the
+// store boundary, which no mechanism provides today.
+//
+// If a cross-boundary representation ever lands, this test flips: the root moves
+// to the binding, the work store keeps only a resolvable edge, and the deferral
+// paragraph on attachStore in cmd_formula.go goes with it.
+func TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
+	}
+
+	res := cookFormula(t, "graph-work", "--attach", source.ID)
+
+	if _, err := work.Get(res.RootID); err != nil {
+		t.Fatalf("sub-DAG root %s left the work ledger its attach bead lives in: %v — that is the split edge, not the fix", res.RootID, err)
+	}
+	if _, err := graph.Get(res.RootID); err == nil {
+		t.Errorf("sub-DAG root %s landed in the binding while its attach bead stayed in the work ledger; the `blocks` row then names an id the work store cannot resolve", res.RootID)
+	}
+	deps, err := work.DepList(source.ID, "down")
+	if err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatalf("attach bead %s has no blocking dep after cook", source.ID)
+	}
+	for _, dep := range deps {
+		if _, err := work.Get(dep.DependsOnID); err != nil {
+			t.Errorf("work store holds dep %s -> %s (%s) whose target it cannot resolve: %v", dep.IssueID, dep.DependsOnID, dep.Type, err)
+		}
+	}
+}
+
+// TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity is the single-store
+// compatibility row for the whole attach change: a city that relocates nothing
+// gets the exact store its scope resolved, so both arms behave as they always
+// did.
+func TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity(t *testing.T) {
+	cityDir := oneShotCookCity(t)
+	resetCLIStorageRoutes(t)
+	seedCLIStorageRoutes(t, cityDir, nil)
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
+	}
+
+	for _, formulaName := range []string{"graph-work", "legacy-work"} {
+		res := cookFormula(t, formulaName, "--attach", source.ID)
+		if _, err := work.Get(res.RootID); err != nil {
+			t.Fatalf("%s: sub-DAG root %s is not in the one store: %v", formulaName, res.RootID, err)
+		}
+		deps, err := work.DepList(source.ID, "down")
+		if err != nil {
+			t.Fatalf("%s: listing attach deps: %v", formulaName, err)
+		}
+		for _, dep := range deps {
+			if _, err := work.Get(dep.DependsOnID); err != nil {
+				t.Errorf("%s: dep %s -> %s has an unresolvable target on a single-store city: %v", formulaName, dep.IssueID, dep.DependsOnID, err)
+			}
+		}
+	}
+}

--- a/cmd/gc/oneshot_by_id_routes_test.go
+++ b/cmd/gc/oneshot_by_id_routes_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"slices"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,12 +10,19 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/splittest"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 )
 
 // This file covers the one-shot commands that hold a BEAD ID and read or mutate
 // that bead: `gc formula version-check` and the two `gc formula cook --attach`
 // arms. They resolve their store through classRoutedStoreForID
 // (by_id_store_route.go), which is the shared candidate-list-and-probe.
+//
+// Routing by id answers WHERE, and only where. What the v1 attach arm can then
+// do with a class-owned bead the graph.v2 arm cannot: a graph.v2 invocation
+// also has to MINT a work-class input convoy, which has no residence for such a
+// target, so that arm refuses. The two outcomes sit next to each other below on
+// purpose — the resolver is the same, the expressibility is not.
 //
 // Its siblings live in oneshot_class_routes_test.go, which covers the BIRTH
 // half — where a newly minted bead lands. The distinction matters: a birth is
@@ -26,14 +33,36 @@ import (
 // served from its own binding, plus its work store.
 func cookCityWithSplitGraph(t *testing.T) (work, graph beads.Store) {
 	t.Helper()
-	cityDir := oneShotCookCity(t)
+	work, graph, _ = cookCityWithSplitGraphAt(t)
+	return work, graph
+}
+
+// cookCityWithSplitGraphAt is cookCityWithSplitGraph for the callers that also
+// need the city path — the event stream a cook writes lives under it.
+func cookCityWithSplitGraphAt(t *testing.T) (work, graph beads.Store, cityDir string) {
+	t.Helper()
+	cityDir = oneShotCookCity(t)
 	graph = splittest.NewClassStore(t, config.BeadClassGraph)
 	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
 	work, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
 		t.Fatalf("open work store: %v", err)
 	}
-	return work, graph
+	return work, graph, cityDir
+}
+
+// cookFormulaErr drives the real `gc formula cook` command and returns its
+// combined output and its error, for the arms whose contract is a REFUSAL.
+// cookFormula is the success-path form.
+func cookFormulaErr(t *testing.T, name string, extraArgs ...string) (string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs(append([]string{name}, extraArgs...))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	return stdout.String() + stderr.String(), err
 }
 
 // runVersionCheck drives the real `gc formula version-check <id>` command and
@@ -101,17 +130,33 @@ func TestFormulaVersionCheckLeavesWorkResidentRootsOnTheScopeStore(t *testing.T)
 	}
 }
 
-// TestFormulaCookAttachGraftsOntoAClassResidentBeadInOneStore is the by-id half
-// of the two-store attach, and the case main cannot serve at all.
+// TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused pins the DEFERRED
+// arm, and the residence rule that forces the deferral.
 //
-// A graft onto a bead the binding owns — a workflow step expanding itself
-// mid-run, which is what late-bound DAG expansion IS — used to run `store.Get`
-// against the scope store, which has never held that bead, and failed outright.
-// Routing the whole arm by the attach bead's id both makes it work and keeps the
-// edge CO-RESIDENT: the sub-DAG root, the steps and the `blocks` row all land in
-// the store that holds the parent, so no dep has an endpoint the store cannot
-// resolve.
-func TestFormulaCookAttachGraftsOntoAClassResidentBeadInOneStore(t *testing.T) {
+// A graph.v2 invocation normalizes its target into an input convoy, and a
+// synthetic input convoy is a WORK bead (coordclass.Classify routes it to
+// ClassWork explicitly). For an attach bead the class binding owns, neither
+// placement exists:
+//
+//   - in the binding: a work-class bead in the infra ledger, which the
+//     migration's own equality invariant says never happens
+//     (internal/dispatch/drain.go drainUnitConvoyStore,
+//     internal/graphv2/invocation_test.go
+//     TestSyntheticInputConvoyIsWorkClassAndCoResidentWithItsTarget);
+//   - in the work ledger: NormalizeInputConvoy cannot read the target there at
+//     all, and the convoy's one `tracks` edge to it is cross-class, which
+//     convoy.TrackItemIn refuses with ErrMemberNotCoResident — measured even
+//     when the Graph class handle is named explicitly.
+//
+// So the graft is not expressible and the command refuses, loudly and by name,
+// rather than mis-homing the convoy or emitting a run whose work association is
+// silently dropped. Nobody loses a capability: on main the same invocation dies
+// with "formulas v2 target <id> not found".
+//
+// When the cross-class membership edge lands (ga-2orlf) this test flips: the
+// refusal goes, the convoy is minted work class, and the assertions below become
+// the residence assertions for a served graft.
+func TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused(t *testing.T) {
 	work, graph := cookCityWithSplitGraph(t)
 
 	source, err := graph.Create(beads.Bead{Title: "a running workflow step", Type: "task"})
@@ -122,40 +167,76 @@ func TestFormulaCookAttachGraftsOntoAClassResidentBeadInOneStore(t *testing.T) {
 		t.Fatalf("the binding minted %q, which carries no reserved class prefix", source.ID)
 	}
 
-	res := cookFormula(t, "graph-work", "--attach", source.ID)
-
-	if _, err := graph.Get(res.RootID); err != nil {
-		t.Fatalf("sub-DAG root %s is not resident in the store that holds its attach bead: %v", res.RootID, err)
+	out, err := cookFormulaErr(t, "graph-work", "--attach", source.ID)
+	if err == nil {
+		t.Fatalf("gc formula cook graph-work --attach %s exited 0; a graft whose input convoy has nowhere to live must refuse, not serve\n%s", source.ID, out)
 	}
-	if _, err := work.Get(res.RootID); err == nil {
-		t.Errorf("the work ledger holds sub-DAG root %s, which was grafted onto a bead it does not hold", res.RootID)
-	}
-
-	deps, err := graph.DepList(source.ID, "down")
-	if err != nil {
-		t.Fatalf("listing attach deps: %v", err)
-	}
-	if len(deps) == 0 {
-		t.Fatalf("attach bead %s has no blocking dep after cook; the graft was never wired", source.ID)
-	}
-	for _, dep := range deps {
-		if _, err := graph.Get(dep.DependsOnID); err != nil {
-			t.Errorf("store holds dep %s -> %s (%s) whose target it cannot resolve: %v — a dangling cross-store blocking edge no backend rejects and no finalize path removes", dep.IssueID, dep.DependsOnID, dep.Type, err)
+	for _, want := range []string{source.ID, "graph.v2", "work bead", "convoy.TrackItemIn", "ga-2orlf"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("refusal %q does not mention %q; the reason has to travel with the refusal", out, want)
 		}
 	}
-	if workDeps, err := work.DepList(source.ID, "down"); err == nil && len(workDeps) > 0 {
-		t.Errorf("the work ledger recorded %d deps for a bead it does not hold: %+v", len(workDeps), workDeps)
+
+	// The owner ruling, asserted: no work-class bead is born in the infra
+	// ledger. A synthetic input convoy minted here is exactly that, and it is
+	// what the by-id route did before this refusal.
+	for _, b := range allBeads(t, graph) {
+		if b.ID == source.ID {
+			continue
+		}
+		t.Errorf("the graph binding holds %s (%q, type=%s, metadata=%v) after a refused graft; a refusal writes nothing, and a synthetic convoy is a WORK bead that must never be born in the infra ledger", b.ID, b.Title, b.Type, b.Metadata)
+	}
+	if deps, err := graph.DepList(source.ID, "down"); err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	} else if len(deps) > 0 {
+		t.Errorf("attach bead %s gained %d dep(s) from a refused graft: %+v", source.ID, len(deps), deps)
+	}
+	for _, b := range allBeads(t, work) {
+		if b.Type == "convoy" {
+			t.Errorf("the work ledger holds convoy %s (%q) after a refused graft; the refusal must not mint a half-graft either", b.ID, b.Title)
+		}
+	}
+}
+
+// TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity is the COMMAND-level
+// statement that the cook's execution-fact legs are not merely equal but right.
+//
+// executionevent.ProjectCurrent reads the root and its steps from the graph leg
+// and the input convoy's `tracks` edges from the work leg, and a work leg that
+// does not hold the convoy returns an EMPTY dep list rather than an error — so a
+// mis-assigned leg loses the run's link to the work it was grafted onto with no
+// error, no warning and exit 0. That failure is invisible to a residence
+// assertion, so it is asserted here on the fact the projection exists to
+// produce, through the real cobra command, on the split topology where the two
+// legs could diverge.
+func TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity(t *testing.T) {
+	work, _, cityPath := cookCityWithSplitGraphAt(t)
+
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
 	}
 
-	// The graft gate itself: with the whole sub-DAG closed, the attach bead
-	// comes back to Ready. A split edge leaves it wedged out of Ready forever.
-	closeEveryBeadExcept(t, graph, source.ID)
-	ready, err := graph.Ready()
+	res := cookFormula(t, "graph-work", "--attach", source.ID)
+
+	recorded, err := events.ReadAll(filepath.Join(cityPath, ".gc", "events.jsonl"))
 	if err != nil {
-		t.Fatalf("graph Ready(): %v", err)
+		t.Fatalf("read execution events: %v", err)
 	}
-	if !slices.Contains(beadIDs(ready), source.ID) {
-		t.Fatalf("attach bead %s is not Ready after the whole workflow closed (ready=%v, root=%s)", source.ID, beadIDs(ready), res.RootID)
+	associated, steps := 0, 0
+	for _, e := range recorded {
+		switch {
+		case e.Type == events.ExecutionWorkAssociated && e.RunID == res.RootID && e.Subject == source.ID:
+			associated++
+		case e.Type == events.ExecutionStepDefined && e.RunID == res.RootID:
+			steps++
+		}
+	}
+	if steps == 0 {
+		t.Fatalf("run %s emitted no execution.step_defined at all (events=%+v); the graph leg is wrong and this fixture proves nothing about the work leg", res.RootID, recorded)
+	}
+	if associated != 1 {
+		t.Fatalf("run %s emitted %d execution.work_associated for attach bead %s, want 1 (events=%+v); the convoy leg read a ledger the input convoy does not live in, and a DepList on a convoy a store never held comes back empty rather than failing", res.RootID, associated, source.ID, recorded)
 	}
 }
 

--- a/cmd/gc/oneshot_class_routes_test.go
+++ b/cmd/gc/oneshot_class_routes_test.go
@@ -707,12 +707,31 @@ func TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity(t *testing.T) {
 // it does not live in, and the run's work associations vanish from the event
 // stream while the step facts still look right.
 //
-// It is asserted on the helper rather than through the cobra command because no
-// one-shot cook can reach the two-leg state today: PrepareInvocation only mints
-// an input convoy for a targeted invocation, and the --attach arms — the only
-// targeted ones — run wholly on the scope store (see the deferral comment in
-// cmd_formula.go). The helper is where the leg assignment lives, so it is where
-// a collapse is catchable.
+// It is asserted on the helper because the helper is where the leg ASSIGNMENT
+// lives, and a collapse of the two legs into one store value is only visible
+// there. It is not a substitute for driving the command, and the earlier
+// version of this paragraph — "no one-shot cook can reach the two-leg state
+// today … the --attach arms … run wholly on the scope store" — was a claim
+// about production standing in for coverage of it, which is exactly how a leg
+// mismatch ships green: by-id routing moved PrepareInvocation off the scope
+// store, the convoy went with it, the work leg did not, and this file did not
+// move.
+//
+// So the command is asserted too, on the FACT rather than on the arguments:
+// TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity drives the real
+// cobra `gc formula cook --attach` on a split city and requires an
+// execution.work_associated naming the attach bead. It fails when the convoy
+// leg names a store that does not hold the convoy, which the residence
+// assertions around it cannot see — DepList on a convoy a store never held
+// answers EMPTY, not an error.
+//
+// What keeps the two legs equal in production is a REFUSAL, not an accident:
+// the one shape that would split them, a graph.v2 graft onto a bead the class
+// binding owns, cannot mint its work-class input convoy in either ledger and is
+// refused by name (ga-2orlf,
+// TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused). If that refusal
+// is ever lifted, the two legs diverge again and BOTH tests are the ones that
+// have to answer for it.
 func TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg(t *testing.T) {
 	cityPath := t.TempDir()
 	graph := splittest.NewClassStore(t, config.BeadClassGraph)

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -56,8 +56,8 @@ import (
 // paragraph naming the divergence, the assertions that move when it closes, and
 // the slice that closes it — I1 and I2 (the HQ work store is in neither arm of
 // the controller's cross-store scan on a split city), I5 (`gc hook --claim`
-// does not consume the shared resolver yet) and I10 (the wake filter has no
-// coordination-class reachability arm). Leaving such a leg UNSEEDED is the
+// fans out over work scopes with no coordination-class arm) and I10 (the wake
+// filter has no coordination-class reachability arm). Leaving such a leg UNSEEDED is the
 // failure mode this convention exists to prevent: the invariant then reads as
 // coverage of a path it never touches.
 //
@@ -413,16 +413,26 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 // no other leg.
 //
 // KNOWN GAP, pinned rather than asserted as desirable — `gc hook --claim` does
-// not consume the resolver yet. It resolves its stores as hookStore{dir, env}
-// pairs (hook_cross_store.go) and execs bd in a work directory; the fan-out is
-// city + rigs, all WORK scopes, so a claim it issues for a relocated class id
-// still runs against a ledger that cannot see the bead. claimByID's own
-// fallback IS that fan-out, so the rows below state both answers side by side:
-// a class id routes, a work id keeps the legacy path byte-for-byte. Rewiring
-// the command is ga-k8pzw (by-id routing through the shared resolver); when it
-// lands, this paragraph goes and the assertions move from claimByID to the
-// command. ga-xo8ch — class-routed WRITES from one-shot commands — landed
-// without touching it: it routes where a coordination-class bead is BORN
+// not consume the resolver. It resolves its stores as hookStore{dir, env} pairs
+// (hook_cross_store.go) and execs bd in a work directory; the fan-out is city +
+// rigs, all WORK scopes, so a claim it issues for a relocated class id still
+// runs against a ledger that cannot see the bead. claimByID's own fallback IS
+// that fan-out, so the rows below state both answers side by side: a class id
+// routes, a work id keeps the legacy path byte-for-byte.
+//
+// ga-k8pzw — by-id routing through the shared resolver — landed WITHOUT closing
+// this, and the reason is worth stating because the earlier version of this
+// paragraph named it as the slice that would. The gap is a QUERY-federation
+// gap, not a by-id one: the hook only ever claims ids its OWN work query
+// returned, and that query never reaches the binding, so a by-id-routed claim
+// mutation would never be handed a class id to route. The two halves it needs
+// are a coordination-class arm in the work-query fan-out — the shape `gc ready`
+// got in ga-oxsyu (#5158) — and an in-process claim for the ids that arm
+// returns, because a relocated binding is not a bd workspace and cannot be
+// expressed as a hookStore{dir, env} at all. That is ga-x0oyt; when it lands,
+// this paragraph goes and the assertions move from claimByID to the command.
+// ga-xo8ch — class-routed WRITES from one-shot commands — landed without
+// touching it either: it routes where a coordination-class bead is BORN
 // (`gc order run`'s wisp, `gc formula cook`'s graph pour), and a claim is a
 // by-id mutation of a bead that already exists somewhere.
 //
@@ -457,7 +467,7 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		t.Fatalf("build the hook's work-query env: %v", err)
 	}
 	if got := hookEnv["GC_STORE_SCOPE"]; got != "city" {
-		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — if it now names a coordination class, the ga-k8pzw rewire has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", got)
+		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — if it now names a coordination class, the ga-x0oyt fan-out arm has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", got)
 	}
 	if got := hookEnv["GC_STORE_ROOT"]; got != e.cityPath {
 		t.Errorf("`gc hook --claim` resolves store root %q, want the city work root %q — a claim it issues for a relocated class id runs against the work ledger, and that is the gap this row pins", got, e.cityPath)

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -437,11 +437,20 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 // by-id mutation of a bead that already exists somewhere.
 //
 // The gap is ASSERTED and not merely described, the way I1, I2 and I10 assert
-// theirs: hookQueryEnv is the production seam that decides which store the
-// hook's claim runs against, and the row below pins that it answers a WORK scope
-// rooted at the city path on BOTH topologies — identically on a city whose graph
-// class lives in a binding of its own. A gap stated in prose and nowhere else
-// can close, or widen, without a single test moving.
+// theirs — and it is asserted on the seam the CLOSURE has to change, not on one
+// that survives it. hookWorkQueryStores is the whole fan-out the hook queries,
+// and the rows below pin that every leg of it is a bd WORKSPACE naming a WORK
+// scope, on BOTH topologies: relocating graph adds no leg, so no leg can answer
+// for a bead the binding owns. Half (a) of ga-x0oyt is a coordination-class arm
+// IN THIS LIST, so it cannot land without reddening them.
+//
+// The earlier version of this pin asserted only hookQueryEnv's GC_STORE_SCOPE
+// for the primary leg. That row is kept — the primary leg staying a work scope
+// is part of the claim — but on its own it was not a tripwire at all: the
+// closure ADDS an arm and changes nothing about the city leg, so it would have
+// stayed green through the very change it claimed to watch. A gap stated in
+// prose and nowhere else can close, or widen, without a single test moving; a
+// gap pinned on the wrong seam does the same thing while looking watched.
 //
 // `gc bd update --claim` is already routed (#5132, cmd_bd_by_id.go) and probes
 // the same way, so the resolver is not the only class-aware claim path — it is
@@ -471,6 +480,28 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 	}
 	if got := hookEnv["GC_STORE_ROOT"]; got != e.cityPath {
 		t.Errorf("`gc hook --claim` resolves store root %q, want the city work root %q — a claim it issues for a relocated class id runs against the work ledger, and that is the gap this row pins", got, e.cityPath)
+	}
+
+	// The tripwire: the WHOLE fan-out, which is what ga-x0oyt has to change.
+	// Every leg is a (dir, env) pair pointing a bd subprocess at a work
+	// workspace, and there are exactly as many as the city has work scopes —
+	// relocating graph adds none.
+	hookAgent := &config.Agent{Name: splitEnvPoolAgent}
+	fanout := hookWorkQueryStores(e.cityPath, e.cfg, hookAgent,
+		hookAgent.QualifiedName(),
+		agentCommandDir(e.cityPath, hookAgent, e.cfg.Rigs),
+		mergeRuntimeEnv(nil, hookEnv), hookEnv)
+	if want := 1 + len(e.cfg.Rigs); len(fanout) != want {
+		t.Errorf("`gc hook --claim` fans out over %d store(s), want %d (city + %d rig) — a leg appeared or vanished; if it is the coordination-class arm, ga-x0oyt has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", len(fanout), want, len(e.cfg.Rigs))
+	}
+	for i, leg := range fanout {
+		scope := hookStoreEnvValue(leg, "GC_STORE_SCOPE")
+		if scope != "city" && scope != "rig" {
+			t.Errorf("`gc hook --claim` fan-out leg %d names store scope %q, want a WORK scope (\"city\" or \"rig\") — a leg that names a coordination class is the ga-x0oyt arm landing, and the claim mutation has to stop being a bd subprocess call with it", i, scope)
+		}
+		if root := hookStoreEnvValue(leg, "GC_STORE_ROOT"); root == "" {
+			t.Errorf("`gc hook --claim` fan-out leg %d names no GC_STORE_ROOT; every leg here is a bd workspace, and a relocated binding cannot be expressed as one", i)
+		}
 	}
 
 	if !e.split {
@@ -592,6 +623,18 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		}
 		e.assertClaimedIn(t, tt.id, assignee, want)
 	}
+}
+
+// hookStoreEnvValue reads one variable out of a hook fan-out leg's subprocess
+// environment. Last assignment wins, matching exec's own resolution.
+func hookStoreEnvValue(leg hookStore, key string) string {
+	value := ""
+	for _, entry := range leg.env {
+		if name, v, ok := strings.Cut(entry, "="); ok && name == key {
+			value = v
+		}
+	}
+	return value
 }
 
 // conformanceStrictCrossStoreDeps (I6) guards the cross-store dependency class:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -272,6 +272,15 @@ city (HQ) store. An explicit --city is a true scope override: it forces the
 city store and disables rig auto-detection (GC_RIG, cwd, bead prefix), so a
 deliberate city-scoped query is never silently downgraded to a rig store.
 
+On a city that serves a coordination class from its own [storage] binding,
+a by-id read or write of a bead that binding owns is answered in process
+from the binding, not by bd against a work store that does not hold it.
+--rig is refused for those beads rather than ignored or honored: it names a
+work scope, and a relocated class is not partitioned by rig, so there is
+nothing to narrow within. Drop --rig for a class-owned id. Auto-detected
+scope (GC_RIG, -C, cwd) is unaffected, and --city still selects which city's
+binding answers.
+
 All arguments after "gc bd" are forwarded to bd unchanged, except the
 gc-only "heartbeat &lt;issue-id&gt;" subcommand, which rewrites to
 "update &lt;issue-id&gt; --set-metadata gc.last_heartbeat_at=&lt;RFC3339 UTC now&gt;"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1641,6 +1641,15 @@ per-source workflow lock and is idempotent: a repeat cook for the same
 source bead reuses the live workflow instead of duplicating it, and a
 conflicting live workflow from the same source is an error.
 
+On a city that serves a coordination class from its own [storage] binding,
+--attach follows the ATTACH BEAD: the sub-DAG and the blocking dependency
+are written to the store that holds it, so the two ends of the edge stay in
+one store. A v2 (graph.v2) formula is the exception and is refused for an
+attach bead the binding owns: it normalizes its target into a synthetic
+input convoy, which is a work bead that can live neither in the binding nor
+in the work ledger, whose membership edge to the target would be
+cross-class. Attach a v1 formula to that bead instead.
+
 ```
 gc formula cook <formula-name> [flags]
 ```

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -511,7 +511,15 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			if err := checkLegacySourceWorkflowConflict(deps, beadID); err != nil {
 				return result, fmt.Errorf("%w", err)
 			}
-			replacedSnapshot, err := snapshotGraphV2ReplacementRoot(deps.Store, formulaName, formulaVars, opts.ScopeKind, opts.ScopeRef, opts.Force)
+			// The replaced root is a graph.v2 workflow root, and every root
+			// this sling can find here was BORN through deps.graphStore()
+			// (InstantiateSlingFormula). Looking it up through deps.Store on a
+			// city that relocates graph asks the work ledger about a bead it
+			// never held: --force then finds nothing to replace and launches a
+			// second live root beside the first, and the rollback below has no
+			// snapshot to restore. Identity to deps.Store wherever graph is not
+			// relocated, so a single-store sling is byte-identical.
+			replacedSnapshot, err := snapshotGraphV2ReplacementRoot(deps.graphStore(), formulaName, formulaVars, opts.ScopeKind, opts.ScopeRef, opts.Force)
 			if err != nil {
 				return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 			}
@@ -526,7 +534,11 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, "", a, method, deps)
 			wfResult.FormulaName = formulaName
 			if wfErr != nil {
-				if rollbackErr := rollbackGraphV2ReplacementLaunch(deps.Store, mResult.RootID, replacedSnapshot); rollbackErr != nil {
+				// Same store the snapshot was taken from and the replacement
+				// root was created in: a rollback that closed the replacement
+				// through a store that does not hold it would leave the failed
+				// launch live and restore nothing.
+				if rollbackErr := rollbackGraphV2ReplacementLaunch(deps.graphStore(), mResult.RootID, replacedSnapshot); rollbackErr != nil {
 					return wfResult, errors.Join(wfErr, rollbackErr)
 				}
 				return wfResult, wfErr
@@ -1011,7 +1023,12 @@ func pendingGraphWorkflowLaunch(rootID, sourceBeadID string, a config.Agent, met
 			return result, err
 		},
 		rollback: func() error {
-			_, err := sourceworkflow.CloseWorkflowSubtree(deps.Store, rootID)
+			// rootID is the workflow root this launch just materialized
+			// through deps.graphStore(); the subtree it closes is that root's
+			// own members. Closing it through deps.Store on a city that
+			// relocates graph reads an empty subtree and silently leaves the
+			// abandoned launch open and claim-attracting.
+			_, err := sourceworkflow.CloseWorkflowSubtree(deps.graphStore(), rootID)
 			return err
 		},
 	}
@@ -1258,7 +1275,15 @@ func sourceWorkflowRootByID(deps SlingDeps, sourceBeadID, workflowID, sourceStor
 	}
 	sourceStoreRef = strings.TrimSpace(sourceStoreRef)
 	if deps.SourceWorkflowStores == nil {
-		return sourceWorkflowRootByIDInStore(deps.Store, sourceBeadID, workflowID, sourceStoreRef, sourceStoreRef)
+		// The single-store fallback, for callers that wire no federation. The
+		// subject is a workflow ROOT, which lives in the graph store; deps.Store
+		// holds the SOURCE bead. Identity wherever graph is not relocated.
+		//
+		// NOT fixed here: the federated arm below enumerates work scopes only
+		// (cmd/gc's openSourceWorkflowStores walks the city and rig dirs), so a
+		// city that relocates graph AND wires the federation still misses the
+		// binding. That is a query-federation gap, not a by-id one.
+		return sourceWorkflowRootByIDInStore(deps.graphStore(), sourceBeadID, workflowID, sourceStoreRef, sourceStoreRef)
 	}
 	stores, err := deps.SourceWorkflowStores()
 	if err != nil {

--- a/internal/sling/sling_graph_root_store_test.go
+++ b/internal/sling/sling_graph_root_store_test.go
@@ -1,0 +1,327 @@
+package sling
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
+)
+
+// This file pins the store the source-workflow REPLACEMENT machinery reads and
+// mutates graph.v2 roots through.
+//
+// A workflow root is GRAPH class and is BORN through deps.graphStore()
+// (InstantiateSlingFormula, doStartGraphWorkflow). Every read of that same root
+// has to use the same store: on a city that relocates graph, reading it through
+// deps.Store asks the WORK ledger about a bead it has never held, and every one
+// of these paths then fails silently rather than loudly — a replacement finds
+// nothing to replace and launches a second live root beside the first, a
+// rollback closes an empty subtree and leaves the abandoned launch open and
+// claim-attracting, and a workflow-id lookup reports a live root as missing.
+//
+// deps.graphStore() collapses to deps.Store whenever GraphStore is unset, so
+// every single-store caller is byte-identical.
+
+// splitSlingDeps returns deps whose graph class is served by a separate,
+// prefix-disjoint store — the shape a split city has. The work leaf mints
+// "gc-<n>" and the class leaf "gcg-<n>", so a root read from the wrong leg is
+// not merely a different row, it is an id the leg cannot mint.
+func splitSlingDeps(t *testing.T, cfg *config.City) (SlingDeps, beads.Store, beads.Store) {
+	t.Helper()
+	work, graph := splittest.NewSplitStores(t)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Store = work
+	deps.GraphStore = graph
+	return deps, work, graph
+}
+
+// newGraphResidentWorkflowRoot writes a workflow root and one member into the
+// GRAPH store, the way InstantiateSlingFormula does on a split city.
+func newGraphResidentWorkflowRoot(t *testing.T, graph beads.Store, sourceBeadID, sourceStoreRef string) (root, member beads.Bead) {
+	t.Helper()
+	root, err := graph.Create(beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:                 "workflow",
+			beadmeta.FormulaContractMetadataKey:      "graph.v2",
+			beadmeta.SourceBeadIDMetadataKey:         sourceBeadID,
+			sourceworkflow.SourceStoreRefMetadataKey: sourceStoreRef,
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating the graph-resident root: %v", err)
+	}
+	if !sourceworkflow.IsWorkflowRoot(root) {
+		t.Fatalf("fixture root %s is not recognized as a workflow root; the invariant would pass vacuously", root.ID)
+	}
+	member, err = graph.Create(beads.Bead{
+		Title: "workflow step",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating the graph-resident member: %v", err)
+	}
+	return root, member
+}
+
+// TestSourceWorkflowRootByIDReadsTheGraphStore covers the single-store fallback
+// in sourceWorkflowRootByID, taken by every caller that wires no
+// SourceWorkflowStores enumerator (the embedded dispatch paths).
+//
+// The subject is a workflow ROOT. deps.Store holds the SOURCE bead; the root
+// lives in the graph store, and a lookup that reads the source store reports a
+// live workflow as absent — which the replacement machinery reads as "there is
+// nothing to replace".
+func TestSourceWorkflowRootByIDReadsTheGraphStore(t *testing.T) {
+	deps, work, graph := splitSlingDeps(t, &config.City{Workspace: config.Workspace{Name: "test"}})
+	source, err := work.Create(beads.Bead{Title: "source bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("creating the source bead: %v", err)
+	}
+	root, _ := newGraphResidentWorkflowRoot(t, graph, source.ID, deps.StoreRef)
+	if deps.SourceWorkflowStores != nil {
+		t.Fatal("this invariant is about the single-store fallback; testDeps must not wire an enumerator")
+	}
+
+	got, ok, reason, err := sourceWorkflowRootByID(deps, source.ID, root.ID, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("sourceWorkflowRootByID: %v", err)
+	}
+	if !ok {
+		t.Fatalf("sourceWorkflowRootByID(%s) reported the live graph-resident root as absent (reason %q); the fallback read the work ledger, which never held it", root.ID, reason)
+	}
+	if got.root.ID != root.ID {
+		t.Errorf("resolved root %q, want %q", got.root.ID, root.ID)
+	}
+}
+
+// TestPendingGraphWorkflowLaunchRollbackClosesTheGraphSubtree covers the
+// rollback of a pending source-workflow launch. The subtree it closes is the
+// root this launch just materialized through the graph store; closing it through
+// deps.Store finds nothing, reports success, and leaves the abandoned workflow
+// open — a live root with no source, which the dispatcher keeps trying to run.
+func TestPendingGraphWorkflowLaunchRollbackClosesTheGraphSubtree(t *testing.T) {
+	deps, _, graph := splitSlingDeps(t, &config.City{Workspace: config.Workspace{Name: "test"}})
+	root, member := newGraphResidentWorkflowRoot(t, graph, "gc-source", "city:test-city")
+
+	launch := pendingGraphWorkflowLaunch(root.ID, "", config.Agent{Name: "mayor"}, "formula", "graph-work", deps)
+	if err := launch.rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	closedRoot, err := graph.Get(root.ID)
+	if err != nil {
+		t.Fatalf("reading the root back: %v", err)
+	}
+	if closedRoot.Status != "closed" {
+		t.Errorf("root %s status = %q after rollback, want closed — the rollback closed a subtree in a store that does not hold it", root.ID, closedRoot.Status)
+	}
+	closedMember, err := graph.Get(member.ID)
+	if err != nil {
+		t.Fatalf("reading the member back: %v", err)
+	}
+	if closedMember.Status != "closed" {
+		t.Errorf("member %s status = %q after rollback, want closed", member.ID, closedMember.Status)
+	}
+}
+
+// TestGraphV2ReplacementSnapshotAndRollbackUseTheGraphStore covers the --force
+// replacement pair: the snapshot that captures the root being replaced, and the
+// rollback that restores it when the replacement's launch fails.
+//
+// Both are called with one store expression inside attachFormulaToBead, and both
+// have the same subject — a graph.v2 root keyed by gc.graphv2_root_key, which
+// only ever exists in the graph store. A snapshot taken from the work ledger is
+// empty, so --force silently replaces nothing and the rollback has nothing to
+// restore.
+func TestGraphV2ReplacementSnapshotAndRollbackUseTheGraphStore(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps, work, graph := splitSlingDeps(t, cfg)
+	deps.CityPath = t.TempDir()
+
+	convoy, err := work.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("creating the input convoy: %v", err)
+	}
+	vars := map[string]string{"convoy_id": convoy.ID}
+
+	replaced, err := InstantiateSlingFormula(t.Context(), "graph-work", []string{formulaDir}, molecule.Options{Vars: vars}, "", "default", "", config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, deps)
+	if err != nil {
+		t.Fatalf("materializing the root to be replaced: %v", err)
+	}
+	if _, err := graph.Get(replaced.RootID); err != nil {
+		t.Fatalf("the first root is not graph resident (%v); the fixture cannot distinguish the two stores", err)
+	}
+
+	snapshot, err := snapshotGraphV2ReplacementRoot(deps.graphStore(), "graph-work", vars, "default", "", true)
+	if err != nil {
+		t.Fatalf("snapshotGraphV2ReplacementRoot: %v", err)
+	}
+	if snapshot.rootID != replaced.RootID {
+		t.Fatalf("snapshot captured root %q, want the live graph-resident root %q — a snapshot taken from the work ledger is empty, and --force then replaces nothing", snapshot.rootID, replaced.RootID)
+	}
+
+	// The rollback half: closing the live root and restoring it from the
+	// snapshot has to happen in the same store the snapshot came from.
+	closed := "closed"
+	if err := graph.Update(replaced.RootID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("closing the replaced root: %v", err)
+	}
+	if err := rollbackGraphV2ReplacementLaunch(deps.graphStore(), "", snapshot); err != nil {
+		t.Fatalf("rollbackGraphV2ReplacementLaunch: %v", err)
+	}
+	restored, err := graph.Get(replaced.RootID)
+	if err != nil {
+		t.Fatalf("reading the restored root: %v", err)
+	}
+	if restored.Status == "closed" {
+		t.Errorf("root %s is still closed after rollback; the restore ran against a store that does not hold it", replaced.RootID)
+	}
+}
+
+// TestGraphRootStoreCollapsesWhenGraphIsNotRelocated is the single-store
+// compatibility row for all four sites: with GraphStore unset, deps.graphStore()
+// returns the EXACT store value deps.Store carries, so every one of these paths
+// reads the store it always did — and the optional-capability assertions the
+// molecule create relies on keep holding on the same value.
+func TestGraphRootStoreCollapsesWhenGraphIsNotRelocated(t *testing.T) {
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), newFakeRunner().run)
+	if deps.GraphStore != nil {
+		t.Fatal("testDeps wired a GraphStore; this row is about the collapse")
+	}
+	if deps.graphStore() != deps.Store {
+		t.Errorf("graphStore() returned %p, want the identical work store %p", deps.graphStore(), deps.Store)
+	}
+}
+
+// rootKeyQuerySpy counts the gc.graphv2_root_key lookups a store answers. That
+// query is the replacement machinery's own fingerprint — closeFailedGraphV2RootsByKey
+// and snapshotGraphV2ReplacementRoot both run it — so counting it names WHICH
+// STORE the call site reached for, which a test that calls the helper directly
+// cannot do.
+type rootKeyQuerySpy struct {
+	beads.Store
+	rootKeyQueries int
+}
+
+func (s *rootKeyQuerySpy) ListByMetadata(match map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	if _, ok := match[beadmeta.Graphv2RootKeyMetadataKey]; ok {
+		s.rootKeyQueries++
+	}
+	return s.Store.ListByMetadata(match, limit, opts...)
+}
+
+// TestForcedGraphV2ReplacementQueriesTheGraphStoreNotTheWorkLedger is the
+// CALL-SITE assertion for the snapshot/rollback pair in attachFormulaToBead.
+//
+// A forced launch looks up the root it is replacing by gc.graphv2_root_key.
+// Only the graph store ever holds such a root, so the work ledger must never be
+// asked: a lookup there returns empty, --force replaces nothing, and a second
+// live root is launched beside the first.
+func TestForcedGraphV2ReplacementQueriesTheGraphStoreNotTheWorkLedger(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps, work, graph := splitSlingDeps(t, cfg)
+	deps.CityPath = t.TempDir()
+	workSpy := &rootKeyQuerySpy{Store: work}
+	graphSpy := &rootKeyQuerySpy{Store: graph}
+	deps.Store = workSpy
+	deps.GraphStore = graphSpy
+
+	source, err := work.Create(beads.Bead{Title: "source bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("creating the source bead: %v", err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	if _, err := DoSling(SlingOpts{Target: a, BeadOrFormula: source.ID, OnFormula: "graph-work", Force: true}, deps, deps.Store); err != nil {
+		t.Fatalf("forced sling: %v", err)
+	}
+
+	if graphSpy.rootKeyQueries == 0 {
+		t.Errorf("the forced launch never asked the graph store for a gc.graphv2_root_key root; the replacement lookup ran somewhere else")
+	}
+	if workSpy.rootKeyQueries != 0 {
+		t.Errorf("the forced launch asked the WORK ledger for a gc.graphv2_root_key root %d time(s); only the graph store holds one, so that lookup is always empty and --force silently replaces nothing", workSpy.rootKeyQueries)
+	}
+}
+
+// promoteFailingStore fails the in_progress promotion for every root except the
+// one named, so a SECOND forced launch fails at doStartGraphWorkflow — the only
+// path that reaches rollbackGraphV2ReplacementLaunch.
+type promoteFailingStore struct {
+	beads.Store
+	spare string
+	armed bool
+}
+
+func (s *promoteFailingStore) Update(id string, opts beads.UpdateOpts) error {
+	if s.armed && id != s.spare && opts.Status != nil && *opts.Status == "in_progress" {
+		return errRefusedPromotion
+	}
+	return s.Store.Update(id, opts)
+}
+
+var errRefusedPromotion = errorString("refusing the workflow promotion")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+// TestForcedGraphV2ReplacementRollbackRestoresInTheGraphStore is the CALL-SITE
+// assertion for the rollback half of the --force replacement pair.
+//
+// A forced launch closes the root it replaces and materializes a new one. When
+// the new one fails to start, the rollback has to close the replacement AND
+// restore the root it displaced — in the store both of them live in. Running the
+// restore against the work ledger silently succeeds against nothing, and the
+// city is left with the previous workflow closed and the replacement never
+// started: a run that vanished.
+func TestForcedGraphV2ReplacementRollbackRestoresInTheGraphStore(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps, work, graph := splitSlingDeps(t, cfg)
+	deps.CityPath = t.TempDir()
+	promoteGuard := &promoteFailingStore{Store: graph}
+	deps.GraphStore = promoteGuard
+
+	convoy, err := work.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("creating the input convoy: %v", err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	first, err := DoSling(SlingOpts{Target: a, BeadOrFormula: convoy.ID, OnFormula: "graph-work", Force: true}, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("first forced sling: %v", err)
+	}
+	if first.WorkflowID == "" {
+		t.Fatal("the first forced sling started no workflow; there is nothing for a replacement to displace")
+	}
+	promoteGuard.spare = first.WorkflowID
+	promoteGuard.armed = true
+
+	if _, err := DoSling(SlingOpts{Target: a, BeadOrFormula: convoy.ID, OnFormula: "graph-work", Force: true}, deps, deps.Store); err == nil {
+		t.Fatal("the second forced sling succeeded; the fixture must fail its start to reach the rollback")
+	}
+
+	restored, err := graph.Get(first.WorkflowID)
+	if err != nil {
+		t.Fatalf("reading the displaced root back: %v", err)
+	}
+	if restored.Status == "closed" {
+		t.Errorf("displaced root %s is still closed after the failed replacement rolled back; the restore ran against a store that does not hold it, so the city lost both workflows", first.WorkflowID)
+	}
+}


### PR DESCRIPTION
## What

Four by-id call sites resolved their store from a scope, not from the bead.
This routes them through the shared candidate-list-and-probe, and pins a
`--rig` rule for `gc bd`.

`gc bd`'s by-id surface already probed the relocated class binding for every
id (#5132). The other three did not, and `--rig` silently changed nothing on
the one that did.

## 1. The `--rig` rule: LOUD ERROR, never silent redirection

Measured on main, with a bound rig and a converged split city:

```
gc bd show <gcg-id>                    -> served from the binding
gc bd show <gcg-id> --rig <rig>        -> served from the binding, IDENTICALLY
```

A flag reached for to be *more* specific is silently dropped. A script that
pins `--rig` to keep two rigs apart is reading whichever ledger class routing
chose.

**The rule:** an explicit `--rig` naming a work rig scope, combined with a
bead the relocated class binding owns, is **refused**.

`--rig` names a WORK scope — a rig's own bd workspace. A relocated
coordination class is not partitioned by rig (the served shape is
`storageSplitWhole`: one binding for all five infrastructure classes and
every scope in the city), so there is nothing for `--rig` to narrow WITHIN.
The alternative — honoring it — routes the read at a store that does not hold
the bead, which is the pre-#5132 wrong-answer lane this whole surface exists
to close.

```
gc bd: gcg-1 is owned by the infra class binding, but --rig workflows pins
that rig's work store, which does not hold it; a relocated class is not
partitioned by rig, so drop --rig (auto-detected scope — GC_RIG, -C, cwd —
is not affected)
```

**Only the EXPLICIT flag refuses.** `GC_RIG`, `-C/--directory` and cwd are
auto-detected scope. The controller sets `GC_RIG` on every rig agent, so
refusing those would break the step-completion write the core pack renders on
every worked bead (`gc bd update <id> --set-metadata gc.outcome=pass --status
closed`, run from a rig worktree against a class-owned step).
`resolveBdScopeTarget` already keeps them in a lower priority band than the
flag for the same reason. `--city` is untouched, and for the opposite reason:
it selects WHICH CITY answers, and the binding this door opened is that
city's.

## 2. The shared resolver, and the correction it needs

`cmd/gc/by_id_store_route.go` is the in-process form of the same candidate
list, for the one-shot commands that hold two ordinary stores. It takes
`storeref.ClassCandidates`' answer — class first (sole MINTER of the reserved
namespace), work behind it (minting is not holding) — and PROBES it.
`TestClassRoutedStoreForIDTakesTheSharedResolversCandidateOrder` pins that the
list is literally the resolver's, so order and identity gate have one owner.

**Verified, as the bead asks:** `storeref.ClassCandidates` gates on the class
NAMESPACE (`IDInNamespace`) *before* it builds a list, and `gc storage
migrate` preserves ids — so it returns **nil** for exactly the ids that moved.
`TestClassRoutedStoreForIDCoversTheLegacyIDTheSharedResolverDeclines` asserts
both halves: that the resolver declines `hq-4177`, and that the residence
probe answers anyway. The fallback is not a second opinion about ownership —
it is the same `[class, work]` list, reached for the ids the namespace gate
cannot speak about. `cmd_bd_by_id.go`'s header now states the same mapping for
`gc bd`, where the work leg is served by the `bd` subprocess.

## 3. Cross-store `--attach`: the v1 half lands, the graph.v2 half REFUSES

**A dep is a two-ended edge, and both ends resolve.** The v1 (`molecule.Attach`)
arm now runs WHOLE against the store that holds the attach bead, resolved by id:
parent read, sub-DAG materialization, and the `blocks` row alike.

The graph.v2 arm cannot, and says so. It is unchanged from `main` byte for byte,
plus one refusal.

| city | attach bead resident in | formula | before | after |
| --- | --- | --- | --- | --- |
| single-store | the one store | either | works | identical (exact store value returned) |
| split | work ledger | either | works | identical |
| split | class binding | **v1** | hard error — `attach bead gcg-1: not found` | works, co-resident, no cross-store dep |
| split | class binding | **graph.v2** | hard error — `formulas v2 target gcg-1 not found` | **refused, by name** |

### Why graph.v2 refuses: the graft is not expressible today

A graph.v2 invocation normalizes its target into an input convoy
(`PrepareInvocation` → `NormalizeInputConvoy` → `CreateSingleItemInputConvoy`).
A synthetic input convoy is a **WORK bead** by explicit classification
(`coordclass.Classify`), and the owner ruling on this program is that it lives in
the work db, not the infra one. For an attach bead the binding owns, **neither
placement exists** — measured, not assumed:

```
TrackItem(work, mc-1, gcg-1)
  -> getting tracked item gcg-1: resolving gcg-1 across convoy: bead not found
TrackItemIn(MemberClasses{Convoy: work, Graph: graph}, mc-1, gcg-1)
  -> tracking gcg-1 in convoy mc-1: member is owned by the graph class store:
     convoy member is not co-resident with the convoy
NormalizeInputConvoy(work,  gcg-1) -> "" err = formulas v2 target gcg-1 not found
NormalizeInputConvoy(graph, gcg-1) -> "gcg-2" err = <nil>
  minted convoy gcg-2 in GRAPH binding: type=convoy meta=[gc.synthetic:true]
  and it is NOT in the work ledger: getting bead "gcg-2": bead not found
```

- **In the binding:** a work-class bead born in the infra ledger — the residence
  violation `drainUnitConvoyStore` states and
  `TestSyntheticInputConvoyIsWorkClassAndCoResidentWithItsTarget` asserts. This is
  what the previous revision of this PR shipped.
- **In the work ledger:** `NormalizeInputConvoy` cannot read the target there at
  all, and the convoy's one `tracks` edge is refused cross-class by
  `convoy.TrackItemIn` — **even when the `Graph` class handle is named
  explicitly**. `MemberClasses.Graph` participates in `MembersIn` (reads); it does
  not make `TrackItemIn` (writes) cross-class.

So the missing mechanism is a **cross-class membership edge**, which is production
behavior, not routing. Filed as **ga-2orlf**; the refusal names it. Refusing costs
nobody a capability — on `main` the same invocation dies with `formulas v2 target
gcg-1 not found` — and both alternatives are silent.

```
gc formula cook: --attach gcg-1: gcg-1 is owned by the relocated class binding,
and a graph.v2 formula's synthetic input convoy is a work bead — it can live
neither there (a work-class bead in the infra ledger) nor in the work ledger
(its `tracks` edge to gcg-1 would be cross-class, which convoy.TrackItemIn
refuses); grafting a graph.v2 formula onto a class-owned bead needs a
cross-class membership edge: ga-2orlf. A v1 formula attaches to gcg-1 today
```

### The consequence that dissolves with it

With the mint back on the scope store, `emitFormulaCookExecutionFacts(store,
store, …)` passes the same value for both legs, exactly as `main` does. The
previous revision passed `(attachStore, store)`: the convoy lived in the binding,
the projection's work leg read the city work store, and `DepList` on a convoy a
store never held answers **EMPTY rather than erroring** — so
`execution.work_associated` was dropped for the run with no error, no warning and
exit 0, and unrecoverably (every re-emitter, `gc events reemit-execution`
included, passes the same work leg). That is not patched here; it is **gone by
construction**, and pinned command-level:

```
run gc-3 emitted 0 execution.work_associated for attach bead gc-1, want 1
```

### The v1 arm is unaffected, and that is why it can serve

`PrepareInvocation` returns before `NormalizeInputConvoy` for a non-graph formula
(`IsGraphV2Formula` is literally `formula.UsesGraphCompiler`), so the v1 arm mints
no convoy. Its sub-DAG is graph class, lands in the binding with its parent, and
its `blocks` row is co-resident. Pinned by
`TestFormulaCookLegacyAttachGraftsOntoAClassResidentBeadInOneStore`.

**The dangling-edge version #5150 reverted is not re-shipped.** Mutating
`molecule.Instantiate` to the graph store while leaving the dep on the attach
bead's store still reddens both guards:

```
work store holds dep gc-1 -> gcg-1 (blocks) whose target it cannot resolve
attach bead gc-1 is not Ready after the whole workflow closed (ready=[], root=gcg-1)
```

**RE-DEFERRED, precisely:** a split city whose attach bead is WORK resident
keeps its graph-class sub-DAG in the work ledger. Relocating it needs the
block **represented across the store boundary**, and no such mechanism exists
— in beads or here. bd/Dolt writes a cross-prefix dep row unresolved
(`cmd/bd/dep.go:367-376`) and `is_blocked`'s INNER JOIN then leaves the bead
READY, silently voiding the graft gate; SQLite's deps table has no foreign key
and drops the bead from Ready forever. Both are wrong and neither is loud, so
the edge must stay co-resident rather than be split. That is a production
mechanism, not routing, so it is reported rather than smuggled in. Pinned by
`TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged`, which flips when a
cross-boundary representation lands.

## 4. The two readers #5150 named for this bead

- **`gc formula version-check <bead-id>`** read a molecule/workflow bead
  through the unrouted scope store. Its subject always carries
  `gc.formula_hash`, which only instantiation writes, so on a split city every
  such root is in the binding — and the command reported live roots as
  missing.
- **`internal/sling`'s source-workflow replacement machinery** read and mutated
  graph.v2 roots through `deps.Store` while births go to `deps.graphStore()`:
  `snapshotGraphV2ReplacementRoot` (514), `rollbackGraphV2ReplacementLaunch`
  (529), `pendingGraphWorkflowLaunch`'s `CloseWorkflowSubtree` (1014), and
  `sourceWorkflowRootByID`'s single-store fallback (1261). All four now use
  `deps.graphStore()`, which collapses to `deps.Store` when graph is not
  relocated.

  NOT fixed, and named at the call site: the *federated* arm of
  `sourceWorkflowRootByID` enumerates work scopes only
  (`openSourceWorkflowStores` walks city + rig dirs), so a split city that
  wires the enumerator still misses the binding. That is a query-federation
  gap, not a by-id one.

## 5. Conformance I5: gap does NOT close, re-pinned with a corrected reason

I5's KNOWN GAP named this bead as the slice that would close it. It does not,
and cannot. `gc hook --claim` only ever claims ids its OWN work query
returned, and that query fans out over `hookStore{dir, env}` pairs — bd
subprocesses in work directories. A relocated binding is not a bd workspace
and cannot be expressed as a `hookStore` at all, so the query never surfaces a
class id for by-id routing to route. Closing it needs a coordination-class arm
in the work-query fan-out (the shape `gc ready` got in ga-oxsyu / #5158) plus
an in-process claim for the ids that arm returns. Filed as **ga-x0oyt**; the
invariant's paragraph and its error string now name it.

## 6. The guard that should have caught it, and two ordering fixes

**`TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg` justified
asserting on the helper with a claim about production:** *"no one-shot cook can
reach the two-leg state today … the `--attach` arms — the only targeted ones —
run wholly on the scope store."* The first revision of this PR falsified that
sentence, reached the two-leg state through the cobra command, got the legs
wrong, and left `git diff` on that file EMPTY. The paragraph is rewritten to say
what is actually true — the legs are equal because the one shape that would split
them is REFUSED — and the claim no longer stands in for coverage:
`TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity` drives the real cobra
command on a split city and asserts the fact the projection exists to produce.
Mutation-proved: pointing the work leg at a store that does not hold the convoy
reddens it.

**`--rig` refusal ordering.** The refusal was evaluated before the not-found
branch, so a mistyped reserved-prefix id under `--rig` was blamed on the flag —
a claim (`the binding owns this bead and the rig store does not hold it`) that is
false when nothing holds it. Not-found now answers first, with the ownership
refusal kept behind it as a control row.

**I5's re-owned gap was pinned by an assertion that cannot fire.** The row asserted
`hookQueryEnv`'s `GC_STORE_SCOPE` for the primary leg — but ga-x0oyt ADDS a
coordination-class arm and changes nothing about the city leg, so the pin would
have stayed green through the very change it claimed to watch. The hook's fan-out
is now a named seam (`hookWorkQueryStores`, a pure extraction from `doHook`), and
the invariant asserts over the whole list: every leg is a bd workspace naming a
WORK scope, and relocating graph adds no leg.

## Red-before (proven by mutation, one production change at a time)

| reverted | test | red-before |
| --- | --- | --- |
| the `--rig` gate | `TestBdByIDRefusesAnExplicitRigScopeOnAClassOwnedBead` | ``[show gcg-1] under --rig exited 0, want 1`` / ``wrote "id:          gcg-1\ntitle:       owned by the binding\n…" to stdout; a refused command must serve nothing`` |
| version-check routing | `TestFormulaVersionCheckReadsTheGraphResidentRoot` | ``gc formula version-check gcg-1 failed: reading bead gcg-1: getting bead "gcg-1": bead not found`` |
| the graph.v2 class-resident refusal | `TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused` | ``gc formula cook graph-work --attach gcg-1 exited 0; a graft whose input convoy has nowhere to live must refuse, not serve`` |
| the cook's convoy leg (mutation `store` → `graphStore`) | `TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity` | ``run gc-3 emitted 0 execution.work_associated for attach bead gc-1, want 1`` |
| the `--rig` not-found ordering | `TestBdByIDRigRuleDoesNotBlameTheFlagForAnIDThatDoesNotExist` | ``show gcg-9999 under --rig blamed the flag: "gc bd: gcg-9999 is owned by the infra class binding, but --rig workflows pins that rig's work store, which does not hold it…"`` |
| the I5 fan-out tripwire (mutation: class arm added) | `conformanceClaimRouting` | ``` `gc hook --claim` fans out over 2 store(s), want 1 (city + 0 rig)``` / ``` `gc hook --claim` fan-out leg 1 names store scope "graph", want a WORK scope``` |
| attach by-id routing (v1) | `TestFormulaCookLegacyAttachGraftsOntoAClassResidentBeadInOneStore` | ``gc formula cook legacy-work: attach bead gcg-1: getting bead "gcg-1": bead not found`` |
| half-split attach (the #5150 shape) | `TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged` + `…LeavesTheSourceBeadUnblockableOnSplitCity` | ``sub-DAG root gcg-1 left the work ledger its attach bead lives in`` / ``work store holds dep gc-1 -> gcg-1 (blocks) whose target it cannot resolve`` / ``attach bead gc-1 is not Ready after the whole workflow closed (ready=[], root=gcg-1)`` |
| residence fallback | `TestClassRoutedStoreForIDCoversTheLegacyIDTheSharedResolverDeclines` | ``classRoutedStoreForID("hq-4177") resolved 0x…780, want the class binding 0x…810`` |
| shared-resolver order | `TestClassRoutedStoreForIDTakesTheSharedResolversCandidateOrder` | ``candidate 0 = 0x…540, want 0x…5a0 — the class store leads because it is the sole minter of the namespace`` |
| sling 514 + 529 | `TestForcedGraphV2ReplacementQueriesTheGraphStoreNotTheWorkLedger` | ``the forced launch asked the WORK ledger for a gc.graphv2_root_key root 2 time(s); only the graph store holds one, so that lookup is always empty and --force silently replaces nothing`` |
| sling 529 alone | `TestForcedGraphV2ReplacementRollbackRestoresInTheGraphStore` | ``displaced root gcg-1 is still closed after the failed replacement rolled back; the restore ran against a store that does not hold it, so the city lost both workflows`` |
| sling 1014 | `TestPendingGraphWorkflowLaunchRollbackClosesTheGraphSubtree` | ``rollback: getting bead "gcg-1": bead not found`` |
| sling 1261 | `TestSourceWorkflowRootByIDReadsTheGraphStore` | ``sourceWorkflowRootByID(gcg-1) reported the live graph-resident root as absent (reason "not_found")`` |

## Single-store byte-identity, proven by mutation

`TestClassRoutedStoreForIDIsIdentityOnACityThatRelocatesNothing` asserts STORE
IDENTITY (`got != work`), not behavior, over three id shapes and two identity
shapes (no routes, and routes whose class binding IS the work store) — so
every optional-capability type assertion the caller already made keeps
holding. `TestBdByIDRigScopeIsInertOnACityThatRelocatesNothing`,
`TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity` and
`TestGraphRootStoreCollapsesWhenGraphIsNotRelocated` cover the same claim per
surface.

The graph.v2 refusal is confined by the same identity gate, proven by widening
it: `if attachStore != store` → `if attachStore != nil` reddens
`…StaysOnTheOneStoreOnASingleStoreCity`, `…OnAWorkResidentBeadIsUnchanged`,
`…IsIdempotentOnSplitCity` and `…EmitsTheWorkAssociationOnASplitCity`, and
nothing else reaches it.

Tests use `internal/beads/splittest` with production-faithful leaves: the work
leaf rejects a foreign-prefix create the way bd does (the shadowed-id row uses
`CreateWithForeignID`, bd's own `--force` path), and the class leaf accepts it
and records a residence violation the way SQLite does.

## Gates

- `go build ./...` — ok
- `go vet ./...` — ok
- `gofmt -l cmd internal` — clean
- `golangci-lint 2.10.1 ./cmd/gc/... ./internal/sling/... ./internal/convoy/... ./internal/graphv2/...` — 0 issues
- `go test ./cmd/gc -timeout 25m` (serial) — ok, 733.070s
- `go test ./internal/...` — ok
- `scripts/check-core-boundary.sh` — OK
- `scripts/check-split-topology-rows.sh` — OK
- `scripts/check-routed-test-rows.sh` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

