### PR TITLE
feat(hook): route claim-time writes by coordination class (ga-601v2)

### DIFF
--- a/cmd/gc/claim_class_route.go
+++ b/cmd/gc/claim_class_route.go
@@ -16,7 +16,7 @@ package main
 // hookClaimOps seam, alongside the rig axis in claim_cross_store.go, rather than
 // a parallel claim path.
 //
-// # The order is WORK first, and that is not the by-id order
+// # The order is EVERY work leg first, and that is not the by-id order
 //
 // A claim is a WRITE, so the store is found by PROBE — ask which store holds the
 // bead — never by routing unconditionally on an id prefix. `gc storage migrate`
@@ -39,25 +39,77 @@ package main
 // The claim must agree with the reader that served it, and the failure if it
 // does not is not cosmetic: claiming the class copy while the reader keeps
 // answering from the still-open work copy re-serves the same bead every tick,
-// which is the treadmill this slice exists to end. So the work store is probed
-// FIRST — by running the existing work-scope write and letting it answer — and
-// the binding is reached only where that write proves the bead is not there.
-// Co-residence therefore keeps the WORK copy, byte-identically to today.
+// which is the treadmill this slice exists to end.
+//
+// "The work store" is a PLURAL, and reading it as a singular is how the order
+// above stops being true. The claim runs against one leg of a fan-out
+// (hookWorkQueryStores), and for the rig-scoped agents that are the shipped
+// shape of every worker that claims, the city work store is the leg that runs
+// LAST: the rig store is prepended as the primary and appendCityHookStore
+// appends the city store at the end. So the not-found the FIRST-selected leg
+// returns proves only that THAT leg does not hold the bead — the city work leg
+// behind it may.
+//
+// The escalation is therefore a property of the whole fan-out, not of one leg.
+// Before a not-found opens it, every OTHER leg is READ for the same id
+// (anotherWorkLegHolds), and a leg that holds the bead closes it: the work
+// store's answer stands, the federated loop drops the leg that could not resolve
+// it, and the leg that holds it claims it on the next turn of the same
+// invocation — at its own rank, not behind whatever else the fan-out is
+// carrying. Co-residence therefore keeps the WORK copy on any leg that holds it,
+// byte-identically to today.
+//
+// A read rather than a second pass, because a second pass would let unrelated
+// lower-tier work in another leg be claimed first, which is the starvation this
+// slice closes wearing a different hat. The reads are bounded — one per
+// remaining leg, once per id, only for a bead the leg that answered could not
+// resolve — and claimHookWorkWithRunner is what hands the route the leg set
+// (hookClaimOps.ClassRoute).
 //
 // # The escalation signal is the existing one, unwidened
 //
 // beads.ErrNotFound is the ONLY error that proves the bead is not in the store
-// the write ran against (hookClaimBeadIsElsewhere). A write timeout, store
-// contention or a controller-socket flap leaves ownership unresolved on a bead
-// the session may already own, and must keep failing closed — so those are
-// returned unchanged and never retried against a second store. This file
-// consumes that predicate; it does not widen it.
+// the write ran against (hookClaimBeadIsElsewhere), and it opens the escalation
+// only together with ok=false. A write timeout, store contention or a
+// controller-socket flap leaves ownership unresolved on a bead the session may
+// already own, and must keep failing closed — so those are returned unchanged
+// and never retried against a second store. This file consumes that predicate;
+// it does not widen it.
+//
+// ok=true is the same refusal for the same reason. hookClaimThroughStore returns
+// (claimed, true, err) for exactly one shape — the CAS COMMITTED and the
+// canonical readback then failed — and BdStore.Get produces an
+// ErrNotFound-wrapping error for a plain miss, an empty result AND
+// beads.ErrIDCollision, so that readback failure routinely satisfies the
+// predicate on a claim that landed. Escalating it would claim one logical bead
+// in two ledgers and swallow the signal both call sites stop on, so the
+// committed claim is returned exactly as the work store reported it.
 //
 // A read failure from the binding is likewise an error and never absence:
 // reading "the binding could not answer" as "the bead is not there" is the
 // root-loss shape this whole lane exists to prevent. The one error that is not a
 // fault is the one-shot funnel's standing refusal, handled exactly as
 // classRoutedStoreForID handles it.
+//
+// # A binding that cannot claim is a city fact, not a bead fault
+//
+// The CAS the routed claim acquires through is a capability: *beads.SQLiteStore
+// has the two-argument Claim and the other compiled-in binding provider's engine
+// (beadsworkspace over *beads.NativeDoltStore) does not, so the closed contract
+// answers ErrBeadsAdapterCapability rather than emulating it. That is a standing
+// property of the city's storage configuration, so it is refused at the DOOR —
+// newHookClaimClassRoute verifies it once, the way storebinding's
+// NewBeadsNudgeQueue verifies the same capability at construction — and
+// claimHookWork then runs unrouted with one loud line rather than failing every
+// claim of every bead in every store.
+//
+// If a refusal reaches a claim anyway, it is a per-BEAD skip and not a terminal
+// tick: the escalation only ran because a work store returned not-found, which
+// proves this session owns nothing there and that no mutation is outstanding
+// anywhere (the capability refusal is returned before any write). That is the
+// same proof the work-side not-found carries, so it earns the same skip —
+// hookClaimBindingRefusedTheClaim, kept separate so the work-side predicate
+// stays exactly as narrow as it was.
 //
 // # A single-store city takes none of this
 //
@@ -80,6 +132,12 @@ import (
 	"github.com/gastownhall/gascity/internal/storebinding"
 )
 
+// errClaimRouteBindingCannotClaim reports that the relocated coordination-class
+// binding has no compare-and-swap claim, so no claim-time write can be routed to
+// it. It is a property of the city's storage configuration rather than of any
+// bead, which is why the caller degrades to unrouted claiming instead of failing.
+var errClaimRouteBindingCannotClaim = errors.New("the relocated coordination-class binding cannot claim")
+
 // hookClaimClassRoute is the opened coordination-class front door a claim-time
 // write falls back to, plus the per-invocation record of which bead ids the
 // binding was PROVED to hold.
@@ -93,6 +151,11 @@ import (
 // stores, tryHookClaim walks candidates), and the map dies with the invocation.
 // Its job is to spare the follow-on writes for a bead the claim already resolved
 // a doomed bd subprocess each.
+//
+// workLegs and readLeg carry the fan-out ordering rule: before a not-found from
+// ONE leg is allowed to open the escalation, every other leg is read for the
+// same id. workHeld memoizes that answer for the same reason resident memoizes
+// the binding's.
 type hookClaimClassRoute struct {
 	// class is the raw binding store, needed by the lifecycle projector, which
 	// takes a beads.Store rather than the closed contract.
@@ -100,18 +163,90 @@ type hookClaimClassRoute struct {
 	graph storebinding.GraphStore
 
 	resident map[string]bool
+
+	// workLegs is the whole work fan-out this invocation claims across, and
+	// readLeg reads one bead through one leg's bd context. Both are empty on a
+	// caller that drives the seams directly rather than through the federated
+	// loop, which then has no other leg to preempt.
+	workLegs []hookStore
+	readLeg  func(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, error)
+	workHeld map[string]bool
 }
 
 // newHookClaimClassRoute opens the claim-time class front door over an already
 // resolved binding store. Split from hookClaimClassRouteForCity so the routing
 // is testable against a store a test controls rather than only against a city on
 // disk.
+//
+// A binding without the two-argument claim CAS is refused here rather than
+// discovered per-bead mid-tick: the capability is a property of the opened
+// engine, the closed contract will not emulate it with a read-then-write, and a
+// route that cannot perform the one write it exists for is worse than no route.
+// Same check, same place and same reason as storebinding.NewBeadsNudgeQueue.
 func newHookClaimClassRoute(class beads.Store) (*hookClaimClassRoute, error) {
 	graph, err := storebinding.NewBeadsGraphStore(class)
 	if err != nil {
 		return nil, fmt.Errorf("projecting the claim-time class front door: %w", err)
 	}
-	return &hookClaimClassRoute{class: class, graph: graph, resident: map[string]bool{}}, nil
+	if _, ok := class.(interface {
+		Claim(id, assignee string) (beads.Bead, bool, error)
+	}); !ok {
+		return nil, fmt.Errorf("%w: %T has no compare-and-swap assignment claim", errClaimRouteBindingCannotClaim, class)
+	}
+	return newClaimClassRouteOver(class, graph), nil
+}
+
+// newClaimClassRouteOver builds the route value over an already-projected front
+// door, with both per-invocation memos live. It is the one place they are
+// created, so a route can never reach the escalation with a nil map.
+func newClaimClassRouteOver(class beads.Store, graph storebinding.GraphStore) *hookClaimClassRoute {
+	return &hookClaimClassRoute{
+		class:    class,
+		graph:    graph,
+		resident: map[string]bool{},
+		workHeld: map[string]bool{},
+	}
+}
+
+// hookClaimRouteVerdict turns one class-route resolution into the claim ops the
+// invocation runs with, and reports whether `gc hook --claim` may proceed.
+//
+// A binding that cannot claim is the degrade case: binding-resident beads stay
+// unclaimable exactly as they were before this routing existed, every work store
+// the agent CAN reach keeps being claimed from, and the operator is told once
+// per invocation. Failing the tick instead would take a city whose graph claims
+// were already impossible and stop it claiming anything at all.
+//
+// Every other resolution failure still fails closed. Claiming through the work
+// store on a city that relocates a class writes ownership into a ledger that
+// does not hold the bead, which is the wrong-answer lane this routing closes.
+func hookClaimRouteVerdict(route *hookClaimClassRoute, err error, stderr io.Writer) (*hookClaimClassRoute, bool) {
+	switch {
+	case err == nil:
+		return route, true
+	case errors.Is(err, errClaimRouteBindingCannotClaim):
+		fmt.Fprintf(stderr, "gc hook --claim: %v; claim-time class routing is off, so a bead resident in the binding stays unclaimable — every work store this agent reaches is unaffected\n", err) //nolint:errcheck // best-effort stderr
+		return nil, true
+	default:
+		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+		return nil, false
+	}
+}
+
+// hookClaimBindingRefusedTheClaim reports whether a claim failed because the
+// relocated binding refused the CAS capability itself, rather than because the
+// write was attempted and failed.
+//
+// It is deliberately NOT folded into hookClaimBeadIsElsewhere. That predicate
+// answers a question about the WORK store, where only beads.ErrNotFound proves
+// the bead is absent and everything else may be an outstanding mutation; this
+// one answers a question about the BINDING, reached only after a work store
+// already proved this session owns nothing there. The refusal is returned before
+// any write (the adapter's type assertion fails first), so nothing is
+// outstanding anywhere and the bead can be skipped exactly as the work-side
+// not-found is.
+func hookClaimBindingRefusedTheClaim(err error) bool {
+	return errors.Is(err, storebinding.ErrBeadsAdapterCapability)
 }
 
 // hookClaimClassRouteForCity resolves the claim-time class front door for a
@@ -176,11 +311,67 @@ func (r *hookClaimClassRoute) holds(id string) (bool, error) {
 // workErr is the ONLY thing that can open the escalation: nil, or anything other
 // than the not-found that proves the bead is not in the store that answered,
 // means the work store's answer is the answer.
-func (r *hookClaimClassRoute) routes(id string, workErr error) (bool, error) {
+//
+// The not-found must come from the whole WORK fan-out, not from the one leg that
+// answered. from is the leg the write ran against; every OTHER leg is read for
+// the same id first, and a leg that holds it closes the escalation — the work
+// store's own answer stands, the federated loop drops this leg, and the leg that
+// holds the bead claims it on the next turn of the same invocation.
+func (r *hookClaimClassRoute) routes(ctx context.Context, from hookStore, id, assignee string, workErr error) (bool, error) {
 	if r == nil || !hookClaimBeadIsElsewhere(workErr) {
 		return false, nil
 	}
+	if r.anotherWorkLegHolds(ctx, from, id, assignee) {
+		return false, nil
+	}
 	return r.holds(id)
+}
+
+// anotherWorkLegHolds reports whether some work leg OTHER than the one that
+// answered can resolve id.
+//
+// Only the primary leg runs the city-wide reader (scopeFederatedHookStores), so
+// it is the only leg whose query can serve a bead it does not hold — and for a
+// rig-scoped agent, the shipped shape of every worker that claims, the primary
+// leg is the RIG store while the city work store is appended last. Without this,
+// the rig leg's not-found would send a claim to the binding for a co-resident
+// bead the city work leg holds, which is the ledger the federated reader
+// resolved it to and the copy it keeps re-serving.
+//
+// A read that FAILS counts as "may hold it". The consequence of guessing wrong
+// in that direction is one skipped bead, reclaimed next tick; the consequence of
+// guessing wrong in the other is an ownership write in a ledger that is not
+// where the reader is looking.
+func (r *hookClaimClassRoute) anotherWorkLegHolds(ctx context.Context, from hookStore, id, assignee string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" || r.readLeg == nil || len(r.workLegs) == 0 {
+		return false
+	}
+	if held, ok := r.workHeld[id]; ok {
+		return held
+	}
+	held := false
+	for _, leg := range r.workLegs {
+		if sameHookStore(leg, from) {
+			continue
+		}
+		if _, err := r.readLeg(ctx, leg.dir, leg.env, id, assignee); err == nil || !errors.Is(err, beads.ErrNotFound) {
+			held = true
+			break
+		}
+	}
+	r.workHeld[id] = held
+	return held
+}
+
+// observeWorkLegs records the fan-out the federated claim loop is about to run,
+// so a not-found from one leg can be checked against the others before it opens
+// the escalation. It is the loop's one input to the route.
+func (r *hookClaimClassRoute) observeWorkLegs(stores []hookStore) {
+	if r == nil {
+		return
+	}
+	r.workLegs = stores
 }
 
 // claim acquires a binding-resident bead through the closed graph contract,
@@ -251,13 +442,29 @@ func classRoutedHookClaimOps(ops hookClaimOps, route *hookClaimClassRoute) hookC
 	}
 	ops.applyDefaults()
 	base := ops
+	// The route reads OTHER work legs through the caller's own read seam before
+	// it escalates, so the residence question is asked with the same bd context
+	// the claim would have used. Carrying the route on the ops is how
+	// claimHookWorkWithRunner hands it the leg set.
+	route.readLeg = base.ReadWorkMeta
+	ops.ClassRoute = route
 
 	ops.Claim = func(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
 		if route.knownResident(beadID) {
 			return route.claim(beadID, assignee)
 		}
 		claimed, ok, err := base.Claim(ctx, dir, env, beadID, assignee)
-		routed, probeErr := route.routes(beadID, err)
+		leg := hookStore{dir: dir, env: env}
+		if ok {
+			// The work store's CAS COMMITTED. Its error, if any, is the
+			// canonical readback failing on a bead this session now owns HERE —
+			// the one signal claimFirstReadyHookAssignment and
+			// claimFirstEligibleHookCandidate both stop on. Escalating it would
+			// claim one logical bead in two ledgers and erase that signal, so
+			// the work store's answer is returned exactly as it came back.
+			return claimed, ok, err
+		}
+		routed, probeErr := route.routes(ctx, leg, beadID, assignee, err)
 		switch {
 		case probeErr != nil:
 			return beads.Bead{}, false, probeErr
@@ -274,7 +481,7 @@ func classRoutedHookClaimOps(ops hookClaimOps, route *hookClaimClassRoute) hookC
 			return write()
 		}
 		err := base.StampWorkMeta(ctx, dir, env, beadID, assignee, patch)
-		routed, probeErr := route.routes(beadID, err)
+		routed, probeErr := route.routes(ctx, hookStore{dir: dir, env: env}, beadID, assignee, err)
 		switch {
 		case probeErr != nil:
 			return probeErr
@@ -290,7 +497,7 @@ func classRoutedHookClaimOps(ops hookClaimOps, route *hookClaimClassRoute) hookC
 			return route.graph.Get(beadID)
 		}
 		bead, err := base.ReadWorkMeta(ctx, dir, env, beadID, assignee)
-		routed, probeErr := route.routes(beadID, err)
+		routed, probeErr := route.routes(ctx, hookStore{dir: dir, env: env}, beadID, assignee, err)
 		switch {
 		case probeErr != nil:
 			return beads.Bead{}, probeErr
@@ -309,6 +516,13 @@ func classRoutedHookClaimOps(ops hookClaimOps, route *hookClaimClassRoute) hookC
 	// proved to hold the group's root. A list error still fails loud: returning
 	// an empty list from the wrong store because a read failed is precisely the
 	// silent-empty this seam must not reproduce.
+	//
+	// It is also the one seam the fan-out arming does not gate, because its
+	// proof is already stronger than a single leg's not-found: an EMPTY group
+	// says this store holds no member at all, so no work leg's copy can be
+	// preempted by filling it, and the preassignment that follows writes to the
+	// store the list came from. It runs on the terminal path, after a claim has
+	// already resolved which ledger owns the work.
 	ops.ListContinuation = func(ctx context.Context, dir string, env []string, rootID, group string) ([]beads.Bead, error) {
 		if route.knownResident(rootID) {
 			return route.listContinuation(rootID, group)
@@ -334,7 +548,7 @@ func classRoutedHookClaimOps(ops hookClaimOps, route *hookClaimClassRoute) hookC
 			return write()
 		}
 		err := base.AssignContinuation(ctx, dir, env, beadID, assignee)
-		routed, probeErr := route.routes(beadID, err)
+		routed, probeErr := route.routes(ctx, hookStore{dir: dir, env: env}, beadID, assignee, err)
 		switch {
 		case probeErr != nil:
 			return probeErr

--- a/cmd/gc/claim_class_route.go
+++ b/cmd/gc/claim_class_route.go
@@ -1,0 +1,362 @@
+package main
+
+// Claim-time write routing by coordination class.
+//
+// `gc hook --claim` issues every claim-time write through
+// beads.NewBdStore(dir, ...) — a bd subprocess rooted in the agent's WORK
+// directory (hookClaimBdStoreContext). A relocated coordination class is not a
+// bd workspace and cannot be expressed as a hookStore{dir, env} at all, so on a
+// split city those writes run against a ledger that cannot see the bead.
+//
+// The read half closed first: the generated work query now reads through the
+// federated `gc ready`, which covers the binding in process (ga-bvdha). That
+// made relocated graph work VISIBLE to the worker without making it claimable —
+// an assigned graph step was re-served and re-skipped every tick and no worker
+// ever ran it. This file is the write half. It adds a CLASS axis to the existing
+// hookClaimOps seam, alongside the rig axis in claim_cross_store.go, rather than
+// a parallel claim path.
+//
+// # The order is WORK first, and that is not the by-id order
+//
+// A claim is a WRITE, so the store is found by PROBE — ask which store holds the
+// bead — never by routing unconditionally on an id prefix. `gc storage migrate`
+// preserves ids (infra_class_migrate.go), so a relocated bead keeps its
+// HQ/rig-era prefix and a prefix route would miss exactly the beads that moved;
+// the same reason bdByIDClassDoor.resolve probes residence.
+//
+// What differs from the by-id door is the ORDER of the probe, and the difference
+// is load-bearing on the one id a probe order can disagree about: a CO-RESIDENT
+// bead, which is the documented steady state of a migrated city because the
+// migration copies and never deletes back.
+//
+//   - storeref.ClassCandidates and bdByIDClassDoor lead with the class store.
+//     Their caller holds only an id.
+//   - `gc ready` — the federated reader that produced this claim's candidate —
+//     leads with the CITY work store and runs the graph leg LAST, so a
+//     co-resident id resolves to the work store's row (#5148/#5158/#5161,
+//     ready_federation.go).
+//
+// The claim must agree with the reader that served it, and the failure if it
+// does not is not cosmetic: claiming the class copy while the reader keeps
+// answering from the still-open work copy re-serves the same bead every tick,
+// which is the treadmill this slice exists to end. So the work store is probed
+// FIRST — by running the existing work-scope write and letting it answer — and
+// the binding is reached only where that write proves the bead is not there.
+// Co-residence therefore keeps the WORK copy, byte-identically to today.
+//
+// # The escalation signal is the existing one, unwidened
+//
+// beads.ErrNotFound is the ONLY error that proves the bead is not in the store
+// the write ran against (hookClaimBeadIsElsewhere). A write timeout, store
+// contention or a controller-socket flap leaves ownership unresolved on a bead
+// the session may already own, and must keep failing closed — so those are
+// returned unchanged and never retried against a second store. This file
+// consumes that predicate; it does not widen it.
+//
+// A read failure from the binding is likewise an error and never absence:
+// reading "the binding could not answer" as "the bead is not there" is the
+// root-loss shape this whole lane exists to prevent. The one error that is not a
+// fault is the one-shot funnel's standing refusal, handled exactly as
+// classRoutedStoreForID handles it.
+//
+// # A single-store city takes none of this
+//
+// hookClaimClassRouteForCity gates on graphClassBinding — store identity, the
+// same question resolveClassStore asks — and returns nil for a city that
+// relocates nothing. classRoutedHookClaimOps then returns the ops value it was
+// handed, unwrapped, so every claim-time write is the exact call it is today.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/executionevent"
+	"github.com/gastownhall/gascity/internal/storebinding"
+)
+
+// hookClaimClassRoute is the opened coordination-class front door a claim-time
+// write falls back to, plus the per-invocation record of which bead ids the
+// binding was PROVED to hold.
+//
+// The CAS stays the store's. Claims go through the closed contract's Claim —
+// the same acquire half `gc bd update --claim` routes through (#5132) — rather
+// than a read-then-write here, which would lose the single-winner guarantee.
+//
+// resident is a memo, not a cache with a lifetime: one `gc hook --claim` is one
+// process, the claim path is strictly sequential (claimHookWorkWithRunner loops
+// stores, tryHookClaim walks candidates), and the map dies with the invocation.
+// Its job is to spare the follow-on writes for a bead the claim already resolved
+// a doomed bd subprocess each.
+type hookClaimClassRoute struct {
+	// class is the raw binding store, needed by the lifecycle projector, which
+	// takes a beads.Store rather than the closed contract.
+	class beads.Store
+	graph storebinding.GraphStore
+
+	resident map[string]bool
+}
+
+// newHookClaimClassRoute opens the claim-time class front door over an already
+// resolved binding store. Split from hookClaimClassRouteForCity so the routing
+// is testable against a store a test controls rather than only against a city on
+// disk.
+func newHookClaimClassRoute(class beads.Store) (*hookClaimClassRoute, error) {
+	graph, err := storebinding.NewBeadsGraphStore(class)
+	if err != nil {
+		return nil, fmt.Errorf("projecting the claim-time class front door: %w", err)
+	}
+	return &hookClaimClassRoute{class: class, graph: graph, resident: map[string]bool{}}, nil
+}
+
+// hookClaimClassRouteForCity resolves the claim-time class front door for a
+// city, or (nil, nil) when the city relocates no coordination class.
+//
+// The funnel is the same one cityQueryTopology already entered to decide whether
+// this invocation's work query federates at all, and it is memoized per city
+// (cli_storage_routes.go), so a hook that reaches here opens no second binding.
+func hookClaimClassRouteForCity(cityPath string) (*hookClaimClassRoute, error) {
+	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	if !relocated {
+		return nil, nil
+	}
+	return newHookClaimClassRoute(class)
+}
+
+// knownResident reports whether an earlier probe in THIS invocation already
+// proved the binding holds id. It never probes: a false answer means "not proved
+// yet", and every caller that gets one still runs its work-scope write first.
+func (r *hookClaimClassRoute) knownResident(id string) bool {
+	if r == nil {
+		return false
+	}
+	return r.resident[strings.TrimSpace(id)]
+}
+
+// holds probes the binding for id and memoizes the answer.
+//
+// An error is a read that FAILED, never absence. The single exception is the
+// one-shot funnel's standing refusal on a WORK-shaped id: it says this city's
+// storage configuration cannot be served, which is a fact about the city and
+// none about a particular bead, and a refused city still serves work from its
+// work ledger — so the caller's own work-store answer stands. An id only the
+// binding could own (a reserved class prefix) has nowhere else to live, so for
+// that one the refusal is the answer and surfaces.
+func (r *hookClaimClassRoute) holds(id string) (bool, error) {
+	id = strings.TrimSpace(id)
+	if r == nil || id == "" {
+		return false, nil
+	}
+	if known, ok := r.resident[id]; ok {
+		return known, nil
+	}
+	_, err := r.graph.Get(id)
+	switch {
+	case err == nil:
+		r.resident[id] = true
+		return true, nil
+	case errors.Is(err, beads.ErrNotFound):
+		r.resident[id] = false
+		return false, nil
+	case isStandingStorageRefusal(err) && !bdIDIsClassReserved(id):
+		return false, nil
+	default:
+		return false, fmt.Errorf("reading %q from the relocated class binding: %w", id, err)
+	}
+}
+
+// routes reports whether a claim-time write for id must run against the binding
+// instead of the work store, given the error the work-scope write returned.
+//
+// workErr is the ONLY thing that can open the escalation: nil, or anything other
+// than the not-found that proves the bead is not in the store that answered,
+// means the work store's answer is the answer.
+func (r *hookClaimClassRoute) routes(id string, workErr error) (bool, error) {
+	if r == nil || !hookClaimBeadIsElsewhere(workErr) {
+		return false, nil
+	}
+	return r.holds(id)
+}
+
+// claim acquires a binding-resident bead through the closed graph contract,
+// applying the same post-mutation classification hookClaimWithBdStore applies to
+// the work store so the two claim paths report a lost race, a stale projection
+// and a canonical-readback failure identically.
+func (r *hookClaimClassRoute) claim(beadID, assignee string) (beads.Bead, bool, error) {
+	return hookClaimThroughStore(beadID, assignee,
+		func() (beads.Bead, bool, error) { return r.graph.Claim(beadID, assignee) },
+		r.graph.Get)
+}
+
+// listContinuation reads a continuation group out of the binding and records
+// every member as resident, so the per-sibling assignment that follows does not
+// re-probe (or re-fail) one bd subprocess at a time.
+func (r *hookClaimClassRoute) listContinuation(rootID, group string) ([]beads.Bead, error) {
+	siblings, err := r.graph.List(beads.ListQuery{
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey:        rootID,
+			beadmeta.ContinuationGroupMetadataKey: group,
+		},
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing continuation group %q of %q in the relocated class binding: %w", group, rootID, err)
+	}
+	for _, sibling := range siblings {
+		if id := strings.TrimSpace(sibling.ID); id != "" {
+			r.resident[id] = true
+		}
+	}
+	return siblings, nil
+}
+
+// emitExecutionStepStarted records the durable lifecycle-start fact against the
+// binding that owns the step.
+//
+// It mirrors hookEmitExecutionStepStarted, whose own comment asserts that "the
+// hook's bd context owns both the claimed graph step and its workflow root" —
+// true on a single-store city and false on a split one, where both live in the
+// binding and the work-directory bd context can read neither. Routing it is what
+// makes that sentence true again; EmitLifecycle still performs the authoritative
+// graph.v2 root validation before recording anything.
+func (r *hookClaimClassRoute) emitExecutionStepStarted(step beads.Bead) {
+	rec := openCityRecorder(io.Discard)
+	if closer, ok := rec.(io.Closer); ok {
+		defer closer.Close() //nolint:errcheck // lifecycle events are best-effort
+	}
+	_ = executionevent.EmitLifecycle(rec, r.class, events.ExecutionStepStarted, step, eventActor())
+}
+
+// classRoutedHookClaimOps returns ops whose claim-time writes fall back to the
+// relocated coordination-class binding for a bead the agent's work store does
+// not hold.
+//
+// A nil route returns ops UNCHANGED — not a wrapper that always delegates — so a
+// single-store city runs the identical function values it runs today and pays
+// nothing for a seam it cannot use.
+//
+// Every wrapped seam applies the same rule: run the work-scope write; escalate
+// only on the not-found that proves the bead is not there; take the binding only
+// when it is proved to hold the id. The one exception is ListContinuation, which
+// is a QUERY and has no not-found to escalate on — see below.
+func classRoutedHookClaimOps(ops hookClaimOps, route *hookClaimClassRoute) hookClaimOps {
+	if route == nil {
+		return ops
+	}
+	ops.applyDefaults()
+	base := ops
+
+	ops.Claim = func(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
+		if route.knownResident(beadID) {
+			return route.claim(beadID, assignee)
+		}
+		claimed, ok, err := base.Claim(ctx, dir, env, beadID, assignee)
+		routed, probeErr := route.routes(beadID, err)
+		switch {
+		case probeErr != nil:
+			return beads.Bead{}, false, probeErr
+		case routed:
+			return route.claim(beadID, assignee)
+		default:
+			return claimed, ok, err
+		}
+	}
+
+	ops.StampWorkMeta = func(ctx context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error {
+		write := func() error { return route.graph.Update(beadID, beads.UpdateOpts{Metadata: patch}) }
+		if route.knownResident(beadID) {
+			return write()
+		}
+		err := base.StampWorkMeta(ctx, dir, env, beadID, assignee, patch)
+		routed, probeErr := route.routes(beadID, err)
+		switch {
+		case probeErr != nil:
+			return probeErr
+		case routed:
+			return write()
+		default:
+			return err
+		}
+	}
+
+	ops.ReadWorkMeta = func(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, error) {
+		if route.knownResident(beadID) {
+			return route.graph.Get(beadID)
+		}
+		bead, err := base.ReadWorkMeta(ctx, dir, env, beadID, assignee)
+		routed, probeErr := route.routes(beadID, err)
+		switch {
+		case probeErr != nil:
+			return beads.Bead{}, probeErr
+		case routed:
+			return route.graph.Get(beadID)
+		default:
+			return bead, err
+		}
+	}
+
+	// A continuation LIST is the one claim-time call with no not-found to
+	// escalate on: a query against a store that holds no member of the group
+	// returns an empty list, not an error. Escalating on EMPTY is what keeps
+	// this honest — the work store's answer is never replaced, only an answer
+	// it had nothing to say about is filled, and only when the binding is
+	// proved to hold the group's root. A list error still fails loud: returning
+	// an empty list from the wrong store because a read failed is precisely the
+	// silent-empty this seam must not reproduce.
+	ops.ListContinuation = func(ctx context.Context, dir string, env []string, rootID, group string) ([]beads.Bead, error) {
+		if route.knownResident(rootID) {
+			return route.listContinuation(rootID, group)
+		}
+		siblings, err := base.ListContinuation(ctx, dir, env, rootID, group)
+		if err != nil || len(siblings) > 0 {
+			return siblings, err
+		}
+		held, probeErr := route.holds(rootID)
+		switch {
+		case probeErr != nil:
+			return nil, probeErr
+		case held:
+			return route.listContinuation(rootID, group)
+		default:
+			return siblings, nil
+		}
+	}
+
+	ops.AssignContinuation = func(ctx context.Context, dir string, env []string, beadID, assignee string) error {
+		write := func() error { return route.graph.Update(beadID, beads.UpdateOpts{Assignee: &assignee}) }
+		if route.knownResident(beadID) {
+			return write()
+		}
+		err := base.AssignContinuation(ctx, dir, env, beadID, assignee)
+		routed, probeErr := route.routes(beadID, err)
+		switch {
+		case probeErr != nil:
+			return probeErr
+		case routed:
+			return write()
+		default:
+			return err
+		}
+	}
+
+	// The lifecycle-start emission reads the step's workflow root, so it belongs
+	// in the store the claim landed in. It routes on the MEMO alone and never
+	// probes: a step this invocation did not route is one the work store
+	// answered for, and emitting it anywhere else would be a second opinion
+	// about ownership rather than a consequence of the claim.
+	ops.EmitExecutionStepStarted = func(step beads.Bead, dir string, env []string, assignee string) {
+		if !route.knownResident(step.ID) {
+			base.EmitExecutionStepStarted(step, dir, env, assignee)
+			return
+		}
+		route.emitExecutionStepStarted(step)
+	}
+
+	return ops
+}

--- a/cmd/gc/claim_class_route_test.go
+++ b/cmd/gc/claim_class_route_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -68,13 +70,24 @@ type claimRouteFailingStore struct {
 
 func (s claimRouteFailingStore) Get(string) (beads.Bead, error) { return beads.Bead{}, s.err }
 
+// Claim delegates to the wrapped store. Embedding the beads.Store INTERFACE
+// hides the optional two-argument claim, and a binding without it is refused at
+// the door (errClaimRouteBindingCannotClaim) — which would make these rows state
+// the capability check instead of the read-failure rule they are about.
+func (s claimRouteFailingStore) Claim(id, assignee string) (beads.Bead, bool, error) {
+	claimer, ok := s.Store.(interface {
+		Claim(id, assignee string) (beads.Bead, bool, error)
+	})
+	if !ok {
+		return beads.Bead{}, false, errors.New("wrapped store has no claim CAS")
+	}
+	return claimer.Claim(id, assignee)
+}
+
 func TestClassRoutedClaimEscalatesOnlyOnNotFound(t *testing.T) {
 	class := newClaimRouteClassStore(t)
 	mintClaimRouteBead(t, class, "gcg-100", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 
 	// The escalation: the work store proves it does not hold the bead, the
 	// binding does, and the claim lands there.
@@ -102,10 +115,7 @@ func TestClassRoutedClaimFailsClosedOnEveryOtherError(t *testing.T) {
 	// The binding DOES hold the bead, so the only thing keeping the claim off it
 	// is the classification of the work store's error.
 	mintClaimRouteBead(t, class, "gcg-200", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 
 	for _, tt := range []struct {
 		name string
@@ -142,10 +152,7 @@ func TestClassRoutedClaimFailsClosedOnEveryOtherError(t *testing.T) {
 func TestClassRoutedClaimKeepsTheWorkCopyOnCoResidence(t *testing.T) {
 	class := newClaimRouteClassStore(t)
 	mintClaimRouteBead(t, class, "gcg-300", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 	workClaimed := false
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
@@ -170,10 +177,7 @@ func TestClassRoutedClaimKeepsTheWorkCopyOnCoResidence(t *testing.T) {
 // holds it — the root-loss shape.
 func TestClassRoutedClaimSurfacesABindingReadFailure(t *testing.T) {
 	readErr := errors.New("binding unreachable: i/o timeout")
-	route, err := newHookClaimClassRoute(claimRouteFailingStore{Store: newClaimRouteClassStore(t), err: readErr})
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, claimRouteFailingStore{Store: newClaimRouteClassStore(t), err: readErr})
 	ops := classRoutedHookClaimOps(hookClaimOps{Claim: notFoundClaim(t, "gcg-400")}, route)
 	_, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-400", "worker-1")
 	if ok || !errors.Is(err, readErr) {
@@ -190,10 +194,7 @@ func TestClassRoutedClaimSurfacesABindingReadFailure(t *testing.T) {
 // refusal is the answer and surfaces.
 func TestClassRoutedClaimTreatsAStandingRefusalAsACityFact(t *testing.T) {
 	refusal := standingStorageRefusal{err: errors.New("this city's storage configuration cannot be served; run `gc storage migrate`")}
-	route, err := newHookClaimClassRoute(claimRouteFailingStore{Store: newClaimRouteClassStore(t), err: refusal})
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, claimRouteFailingStore{Store: newClaimRouteClassStore(t), err: refusal})
 	for _, tt := range []struct {
 		name, id  string
 		wantErrIs error
@@ -218,10 +219,7 @@ func TestClassRoutedClaimTreatsAStandingRefusalAsACityFact(t *testing.T) {
 func TestClassRoutedStampAndReadFollowTheClaim(t *testing.T) {
 	class := newClaimRouteClassStore(t)
 	mintClaimRouteBead(t, class, "gcg-600", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		Claim: notFoundClaim(t, "gcg-600"),
 		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
@@ -266,10 +264,7 @@ func TestClassRoutedContinuationEscalatesOnEmpty(t *testing.T) {
 		beadmeta.ContinuationGroupMetadataKey: "batch-1",
 	}
 	sibling := mintClaimRouteBead(t, class, "gcg-701", group)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
 			return nil, nil
@@ -304,10 +299,7 @@ func TestClassRoutedContinuationKeepsANonEmptyWorkAnswer(t *testing.T) {
 	// A binding that also holds the root, so only the ordering can keep the
 	// work answer.
 	mintClaimRouteBead(t, class, "gcg-800", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 	work := []beads.Bead{{ID: "gc-1", Status: "open"}}
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
@@ -330,10 +322,7 @@ func TestClassRoutedContinuationKeepsANonEmptyWorkAnswer(t *testing.T) {
 func TestClassRoutedContinuationListStillFailsLoud(t *testing.T) {
 	class := newClaimRouteClassStore(t)
 	mintClaimRouteBead(t, class, "gcg-900", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 	listErr := errors.New("bd list: context deadline exceeded")
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
@@ -354,10 +343,7 @@ func TestClassRoutedContinuationListStillFailsLoud(t *testing.T) {
 func TestClassRoutedLifecycleEmissionFollowsTheClaimOnly(t *testing.T) {
 	class := newClaimRouteClassStore(t)
 	mintClaimRouteBead(t, class, "gcg-a00", nil)
-	route, err := newHookClaimClassRoute(class)
-	if err != nil {
-		t.Fatalf("newHookClaimClassRoute: %v", err)
-	}
+	route := newClaimRouteFor(t, class)
 	workEmissions := 0
 	base := hookClaimOps{
 		Claim: notFoundClaim(t, "gcg-a00"),
@@ -396,4 +382,141 @@ func TestClassRoutedHookClaimOpsIsInertWithoutABinding(t *testing.T) {
 	if route != nil {
 		t.Fatal("hookClaimClassRouteForCity opened a class route for a city that relocates nothing")
 	}
+}
+
+// TestClassRoutedClaimNeverEscalatesACommittedWorkClaim is the ok=true half of
+// the elsewhere guard, which both production call sites already apply
+// (`if !ok && hookClaimBeadIsElsewhere(err)` on the ready tier, `if ok` as a
+// terminal stop on the routed tier).
+//
+// hookClaimThroughStore returns (claimed, true, err) for exactly one shape: the
+// CAS committed and the canonical readback then failed. BdStore.Get produces an
+// ErrNotFound-wrapping error for a plain miss, for an empty result AND for
+// beads.ErrIDCollision, so that readback error routinely satisfies
+// hookClaimBeadIsElsewhere — on a claim that landed. Escalating it claims the
+// same logical bead a second time in the binding and swallows the readback
+// failure the caller must stop on.
+func TestClassRoutedClaimNeverEscalatesACommittedWorkClaim(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	// Co-residence: the binding holds the id too, which is the migrated city's
+	// documented steady state and the only reason an escalation could land.
+	mintClaimRouteBead(t, class, "gcg-b00", nil)
+	route := newClaimRouteFor(t, class)
+
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{"plain readback miss", fmt.Errorf("reloading claimed bead %q: %w", "gcg-b00", fmt.Errorf("getting bead %q: %w", "gcg-b00", beads.ErrNotFound))},
+		{"substring id collision", fmt.Errorf("reloading claimed bead %q: %w", "gcg-b00", beads.ErrIDCollision)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			readbackErr := tt.err
+			committed := beads.Bead{ID: "gcg-b00", Status: "in_progress", Assignee: "worker-1"}
+			ops := classRoutedHookClaimOps(hookClaimOps{
+				Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+					return committed, true, readbackErr
+				},
+			}, route)
+			claimed, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-b00", "worker-1")
+			if !ok {
+				t.Fatalf("routed claim returned ok=%v, want true: the work store's CAS committed, so the caller must be told it owns the bead", ok)
+			}
+			if !errors.Is(err, readbackErr) {
+				t.Fatalf("routed claim returned err=%v, want the canonical-readback failure %v returned unchanged; swallowing it lets the caller stamp and emit against state it never confirmed", err, readbackErr)
+			}
+			if claimed.ID != committed.ID {
+				t.Fatalf("routed claim returned bead %+v, want the work store's committed bead %+v", claimed, committed)
+			}
+			if held, getErr := class.Get("gcg-b00"); getErr != nil || strings.TrimSpace(held.Assignee) != "" {
+				t.Fatalf("the binding's copy of gcg-b00 is claimed for %q; a claim that COMMITTED in the work store must never be re-claimed in a second ledger", held.Assignee)
+			}
+		})
+	}
+}
+
+// TestHookClaimClassRouteRefusesABindingThatCannotClaim pins the capability
+// check at the door, the shape storebinding.NewBeadsNudgeQueue already uses: a
+// leaf without the two-argument CAS claim cannot serve a claim-time route, and
+// discovering that per-bead in the middle of a tick is what made a whole
+// `gc hook --claim` invocation terminal.
+//
+// *beads.SQLiteStore is the only production store with it; the other compiled-in
+// binding provider (beadsworkspace) opens a *beads.NativeDoltStore, which has
+// ReleaseIfCurrent and no Claim.
+func TestHookClaimClassRouteRefusesABindingThatCannotClaim(t *testing.T) {
+	route, err := newHookClaimClassRoute(claimRouteNoCASStore{Store: beads.NewMemStore()})
+	if !errors.Is(err, errClaimRouteBindingCannotClaim) {
+		t.Fatalf("newHookClaimClassRoute over a binding without the claim CAS = (route=%v err=%v), want errClaimRouteBindingCannotClaim", route, err)
+	}
+	if route != nil {
+		t.Fatal("a refused binding still produced a route; a claim-time route that cannot claim is worse than none")
+	}
+}
+
+// TestHookClaimRouteVerdictDegradesRatherThanWedgingTheTick states what
+// claimHookWork does with each resolution outcome. A binding that cannot claim
+// is a standing property of the city's storage configuration, not a fault on
+// this bead: the worker must keep claiming the work it CAN reach and say once,
+// loudly, that binding-resident work is unclaimable. Every other resolution
+// failure still fails closed.
+func TestHookClaimRouteVerdictDegradesRatherThanWedgingTheTick(t *testing.T) {
+	opened, err := newHookClaimClassRoute(newClaimRouteClassStore(t))
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	for _, tt := range []struct {
+		name      string
+		route     *hookClaimClassRoute
+		err       error
+		wantRoute *hookClaimClassRoute
+		wantOK    bool
+		wantLog   string
+	}{
+		{name: "opened", route: opened, wantRoute: opened, wantOK: true},
+		{
+			name:    "binding cannot claim",
+			err:     fmt.Errorf("%w: assignment claim", errClaimRouteBindingCannotClaim),
+			wantOK:  true,
+			wantLog: "assignment claim",
+		},
+		{
+			name:   "any other resolution failure",
+			err:    errors.New("opening the binding: permission denied"),
+			wantOK: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			got, ok := hookClaimRouteVerdict(tt.route, tt.err, &stderr)
+			if ok != tt.wantOK {
+				t.Fatalf("hookClaimRouteVerdict ok = %v, want %v (stderr=%q)", ok, tt.wantOK, stderr.String())
+			}
+			if got != tt.wantRoute {
+				t.Fatalf("hookClaimRouteVerdict route = %v, want %v", got, tt.wantRoute)
+			}
+			if tt.err != nil && !strings.Contains(stderr.String(), tt.wantLog) {
+				t.Fatalf("stderr = %q, want it to name %q", stderr.String(), tt.wantLog)
+			}
+		})
+	}
+}
+
+// claimRouteNoCASStore models the production binding leaf that has no
+// two-argument claim: beads.NativeDoltStore, which beadsworkspace's OpenEngine
+// returns. beads.MemStore implements Claim, so the capability has to be hidden
+// behind a wrapper that does not.
+type claimRouteNoCASStore struct{ beads.Store }
+
+// newClaimRouteFor opens a claim-time class route over a store the row controls.
+// It observes no work legs, so nothing can preempt the escalation and the rows
+// state the escalation RULE alone; the fan-out ordering the loop imposes on it
+// belongs to hook_claim_class_fanout_test.go.
+func newClaimRouteFor(t *testing.T, class beads.Store) *hookClaimClassRoute {
+	t.Helper()
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	return route
 }

--- a/cmd/gc/claim_class_route_test.go
+++ b/cmd/gc/claim_class_route_test.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// The claim-time class routing unit rows. The split-topology conformance suite
+// (I5, I15) owns the end-to-end statement over both store arrangements; these
+// rows own the escalation RULE itself — which errors open it, which never do,
+// and what each wrapped seam does on either side of it — because that rule is
+// where a claim write can corrupt ownership rather than merely fail.
+
+// newClaimRouteClassStore opens the store a split city serves its coordination
+// classes from: a real beads.SQLiteStore under the graph class's reserved
+// prefix, which is what internal/storebinding/sqlite's OpenEngine opens. It is
+// not a MemStore, because the CAS a routed claim acquires through is a
+// capability only the real store has.
+func newClaimRouteClassStore(t *testing.T) beads.Store {
+	t.Helper()
+	store, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("gcg"))
+	if err != nil {
+		t.Fatalf("opening the class binding store: %v", err)
+	}
+	t.Cleanup(func() {
+		if closer, ok := store.(interface{ CloseStore() error }); ok {
+			_ = closer.CloseStore()
+		}
+	})
+	return store
+}
+
+// mintClaimRouteBead creates a bead in the binding with a pinned id, the way a
+// relocated graph step exists there.
+func mintClaimRouteBead(t *testing.T, store beads.Store, id string, metadata map[string]string) beads.Bead {
+	t.Helper()
+	created, err := store.Create(beads.Bead{ID: id, Title: "graph step " + id, Type: "task", Metadata: metadata})
+	if err != nil {
+		t.Fatalf("minting %s in the class binding: %v", id, err)
+	}
+	return created
+}
+
+// notFoundClaim is the work-scope claim of a bead the work store does not hold:
+// the not-found that is the ONLY signal permitted to open the class escalation.
+func notFoundClaim(t *testing.T, wantID string) hookClaimFunc {
+	t.Helper()
+	return func(_ context.Context, _ string, _ []string, beadID, _ string) (beads.Bead, bool, error) {
+		if beadID != wantID {
+			t.Errorf("work-scope claim called for %q, want %q", beadID, wantID)
+		}
+		return beads.Bead{}, false, beads.ErrNotFound
+	}
+}
+
+// claimRouteFailingStore is a binding whose reads fail with a supplied error, so
+// a row can state what the routing does with a read that FAILED as distinct from
+// one that answered "absent".
+type claimRouteFailingStore struct {
+	beads.Store
+	err error
+}
+
+func (s claimRouteFailingStore) Get(string) (beads.Bead, error) { return beads.Bead{}, s.err }
+
+func TestClassRoutedClaimEscalatesOnlyOnNotFound(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-100", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+
+	// The escalation: the work store proves it does not hold the bead, the
+	// binding does, and the claim lands there.
+	ops := classRoutedHookClaimOps(hookClaimOps{Claim: notFoundClaim(t, "gcg-100")}, route)
+	claimed, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-100", "worker-1")
+	if err != nil || !ok {
+		t.Fatalf("routed claim of gcg-100 = (ok=%v err=%v), want a successful claim", ok, err)
+	}
+	if strings.TrimSpace(claimed.Assignee) != "worker-1" {
+		t.Fatalf("routed claim returned assignee %q, want %q", claimed.Assignee, "worker-1")
+	}
+	held, err := class.Get("gcg-100")
+	if err != nil || strings.TrimSpace(held.Assignee) != "worker-1" || !strings.EqualFold(held.Status, "in_progress") {
+		t.Fatalf("binding holds gcg-100 as status=%q assignee=%q (err=%v), want in_progress owned by worker-1", held.Status, held.Assignee, err)
+	}
+}
+
+// TestClassRoutedClaimFailsClosedOnEveryOtherError is the narrowness pin. An
+// error that does not PROVE the bead is elsewhere leaves ownership unresolved on
+// a bead this session may already own, so it must be returned as-is and never
+// retried against a second store — retrying it is how one bead gets claimed
+// twice.
+func TestClassRoutedClaimFailsClosedOnEveryOtherError(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	// The binding DOES hold the bead, so the only thing keeping the claim off it
+	// is the classification of the work store's error.
+	mintClaimRouteBead(t, class, "gcg-200", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{"write timeout", context.DeadlineExceeded},
+		{"store contention", errors.New("bd update --claim: database is locked")},
+		{"controller socket flap", errors.New("dial unix .gc/controller.sock: connect: connection refused")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			workErr := tt.err
+			ops := classRoutedHookClaimOps(hookClaimOps{
+				Claim: func(context.Context, string, []string, string, string) (beads.Bead, bool, error) {
+					return beads.Bead{}, false, workErr
+				},
+			}, route)
+			_, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-200", "worker-1")
+			if ok || !errors.Is(err, workErr) {
+				t.Fatalf("claim = (ok=%v err=%v), want the work store's own error returned unchanged; only beads.ErrNotFound may send a claim to a second store", ok, err)
+			}
+			if held, getErr := class.Get("gcg-200"); getErr != nil || strings.TrimSpace(held.Assignee) != "" {
+				t.Fatalf("the binding's copy of gcg-200 was claimed for %q after a %s; an unresolved work-store mutation must not be retried elsewhere", held.Assignee, tt.name)
+			}
+		})
+	}
+}
+
+// TestClassRoutedClaimKeepsTheWorkCopyOnCoResidence states the tie-break. A
+// migrated city holds the same id in both stores (`gc storage migrate` copies
+// with ids preserved and never deletes back), and the federated `gc ready` that
+// served this claim its candidate dedupes such an id to the WORK row. The claim
+// must agree, or it takes the class copy while the reader keeps re-serving the
+// still-open work copy every tick.
+func TestClassRoutedClaimKeepsTheWorkCopyOnCoResidence(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-300", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	workClaimed := false
+	ops := classRoutedHookClaimOps(hookClaimOps{
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			workClaimed = true
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee}, true, nil
+		},
+	}, route)
+	if _, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-300", "worker-1"); !ok || err != nil {
+		t.Fatalf("co-resident claim = (ok=%v err=%v), want the work store's successful claim", ok, err)
+	}
+	if !workClaimed {
+		t.Fatal("the work-scope claim never ran; the work store is probed FIRST so co-residence resolves to its copy")
+	}
+	if held, err := class.Get("gcg-300"); err != nil || strings.TrimSpace(held.Assignee) != "" {
+		t.Fatalf("the binding's copy of gcg-300 was claimed for %q; a co-resident id must keep the WORK copy, which is what the reader that served it answers", held.Assignee)
+	}
+}
+
+// TestClassRoutedClaimSurfacesABindingReadFailure pins that a read that FAILED
+// is never read as absence. Flattening it would let a claim fall back to the
+// work store's not-found and report the bead as gone while the binding still
+// holds it — the root-loss shape.
+func TestClassRoutedClaimSurfacesABindingReadFailure(t *testing.T) {
+	readErr := errors.New("binding unreachable: i/o timeout")
+	route, err := newHookClaimClassRoute(claimRouteFailingStore{Store: newClaimRouteClassStore(t), err: readErr})
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	ops := classRoutedHookClaimOps(hookClaimOps{Claim: notFoundClaim(t, "gcg-400")}, route)
+	_, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-400", "worker-1")
+	if ok || !errors.Is(err, readErr) {
+		t.Fatalf("claim over an unreachable binding = (ok=%v err=%v), want the read failure surfaced; absence and unreachability are not the same answer", ok, err)
+	}
+}
+
+// TestClassRoutedClaimTreatsAStandingRefusalAsACityFact mirrors
+// classRoutedStoreForID and bdByIDClassDoor.resolve: the one-shot funnel's
+// standing refusal says this CITY's storage configuration cannot be served,
+// which is a statement about the city and none about a particular bead. A
+// refused city still serves work from its work ledger, so a work-shaped id keeps
+// its own store's answer; a reserved-prefix id has nowhere else to live, so the
+// refusal is the answer and surfaces.
+func TestClassRoutedClaimTreatsAStandingRefusalAsACityFact(t *testing.T) {
+	refusal := standingStorageRefusal{err: errors.New("this city's storage configuration cannot be served; run `gc storage migrate`")}
+	route, err := newHookClaimClassRoute(claimRouteFailingStore{Store: newClaimRouteClassStore(t), err: refusal})
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	for _, tt := range []struct {
+		name, id  string
+		wantErrIs error
+	}{
+		{"work-shaped id — the work store's answer stands", "gc-500", beads.ErrNotFound},
+		{"reserved-prefix id — only the binding could own it", "gcg-500", refusal},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := classRoutedHookClaimOps(hookClaimOps{Claim: notFoundClaim(t, tt.id)}, route)
+			_, ok, err := ops.Claim(context.Background(), "/work", nil, tt.id, "worker-1")
+			if ok || !errors.Is(err, tt.wantErrIs) {
+				t.Fatalf("claim of %s on a refused city = (ok=%v err=%v), want %v", tt.id, ok, err, tt.wantErrIs)
+			}
+		})
+	}
+}
+
+// TestClassRoutedStampAndReadFollowTheClaim covers the writes that hang off the
+// claim. A stamp that ran against the work store would drop gc.work_branch and
+// the durable session back-reference on the floor for exactly the beads the
+// routing exists for, and the dashboard's run detail reads those.
+func TestClassRoutedStampAndReadFollowTheClaim(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-600", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	ops := classRoutedHookClaimOps(hookClaimOps{
+		Claim: notFoundClaim(t, "gcg-600"),
+		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
+			return beads.ErrNotFound
+		},
+		ReadWorkMeta: func(context.Context, string, []string, string, string) (beads.Bead, error) {
+			return beads.Bead{}, beads.ErrNotFound
+		},
+	}, route)
+
+	patch := map[string]string{
+		beadmeta.WorkBranchMetadataKey: "feat/split",
+		beadmeta.SessionIDMetadataKey:  "gcg-sess-1",
+	}
+	if err := ops.StampWorkMeta(context.Background(), "/work", nil, "gcg-600", "worker-1", patch); err != nil {
+		t.Fatalf("routed stamp: %v", err)
+	}
+	stamped, err := ops.ReadWorkMeta(context.Background(), "/work", nil, "gcg-600", "worker-1")
+	if err != nil {
+		t.Fatalf("routed readback: %v", err)
+	}
+	for key, want := range patch {
+		if got := strings.TrimSpace(stamped.Metadata[key]); got != want {
+			t.Errorf("routed readback of gcg-600 has %s=%q, want %q", key, got, want)
+		}
+	}
+}
+
+// TestClassRoutedContinuationEscalatesOnEmpty covers the one claim-time call
+// with no not-found to escalate on: a LIST against a store holding no member of
+// the group returns an empty slice, not an error.
+//
+// The rule is monotone — the work store's answer is never replaced, only an
+// answer it had nothing to say about is filled — which is also the fix for the
+// branch bug this seam was warned about, where the continuation list returned an
+// empty slice from the wrong store while claiming to fail loud.
+func TestClassRoutedContinuationEscalatesOnEmpty(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	root := mintClaimRouteBead(t, class, "gcg-700", nil)
+	group := map[string]string{
+		beadmeta.RootBeadIDMetadataKey:        root.ID,
+		beadmeta.ContinuationGroupMetadataKey: "batch-1",
+	}
+	sibling := mintClaimRouteBead(t, class, "gcg-701", group)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	ops := classRoutedHookClaimOps(hookClaimOps{
+		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
+			return nil, nil
+		},
+		AssignContinuation: func(context.Context, string, []string, string, string) error {
+			t.Error("the work-scope assign ran for a binding-resident sibling; listing it through the binding must record its residence")
+			return nil
+		},
+	}, route)
+
+	siblings, err := ops.ListContinuation(context.Background(), "/work", nil, root.ID, "batch-1")
+	if err != nil {
+		t.Fatalf("routed continuation list: %v", err)
+	}
+	if len(siblings) != 1 || siblings[0].ID != sibling.ID {
+		t.Fatalf("routed continuation list = %+v, want exactly %s", siblings, sibling.ID)
+	}
+	if err := ops.AssignContinuation(context.Background(), "/work", nil, sibling.ID, "worker-1"); err != nil {
+		t.Fatalf("routed continuation assign: %v", err)
+	}
+	assigned, err := class.Get(sibling.ID)
+	if err != nil || strings.TrimSpace(assigned.Assignee) != "worker-1" {
+		t.Fatalf("binding holds %s assigned to %q (err=%v), want worker-1", sibling.ID, assigned.Assignee, err)
+	}
+}
+
+// TestClassRoutedContinuationKeepsANonEmptyWorkAnswer is the other half of the
+// monotone rule: a group the work store DOES answer for is never re-asked, so a
+// work-resident continuation group keeps the exact list it has today.
+func TestClassRoutedContinuationKeepsANonEmptyWorkAnswer(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	// A binding that also holds the root, so only the ordering can keep the
+	// work answer.
+	mintClaimRouteBead(t, class, "gcg-800", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	work := []beads.Bead{{ID: "gc-1", Status: "open"}}
+	ops := classRoutedHookClaimOps(hookClaimOps{
+		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
+			return work, nil
+		},
+	}, route)
+	siblings, err := ops.ListContinuation(context.Background(), "/work", nil, "gcg-800", "batch-1")
+	if err != nil {
+		t.Fatalf("continuation list: %v", err)
+	}
+	if len(siblings) != 1 || siblings[0].ID != "gc-1" {
+		t.Fatalf("continuation list = %+v, want the work store's own answer %+v", siblings, work)
+	}
+}
+
+// TestClassRoutedContinuationListStillFailsLoud pins the branch bug this seam
+// must not reproduce: a list ERROR is an error. Answering it with an empty slice
+// from another store would report a continuation group as absent because a read
+// failed, which is the silent-empty the file comment used to deny.
+func TestClassRoutedContinuationListStillFailsLoud(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-900", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	listErr := errors.New("bd list: context deadline exceeded")
+	ops := classRoutedHookClaimOps(hookClaimOps{
+		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
+			return nil, listErr
+		},
+	}, route)
+	if _, err := ops.ListContinuation(context.Background(), "/work", nil, "gcg-900", "batch-1"); !errors.Is(err, listErr) {
+		t.Fatalf("continuation list over a failing work store = %v, want the error surfaced", err)
+	}
+}
+
+// TestClassRoutedLifecycleEmissionFollowsTheClaimOnly pins the narrowest of the
+// wrapped seams. The lifecycle-start emission reads the step's workflow root, so
+// it belongs in the store the claim landed in — and NOWHERE else. It routes on
+// the memo alone: a step this invocation never routed is one the work store
+// answered for, and emitting it against the binding would be a second opinion
+// about ownership rather than a consequence of the claim.
+func TestClassRoutedLifecycleEmissionFollowsTheClaimOnly(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-a00", nil)
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	workEmissions := 0
+	base := hookClaimOps{
+		Claim: notFoundClaim(t, "gcg-a00"),
+		EmitExecutionStepStarted: func(beads.Bead, string, []string, string) {
+			workEmissions++
+		},
+	}
+
+	// Before any routed write, the emission stays on the work store.
+	ops := classRoutedHookClaimOps(base, route)
+	ops.EmitExecutionStepStarted(beads.Bead{ID: "gcg-a00"}, "/work", nil, "worker-1")
+	if workEmissions != 1 {
+		t.Fatalf("work-scope emissions = %d, want 1 before the claim routes; the memo, not a probe, is what moves this seam", workEmissions)
+	}
+
+	// After the claim routes the same id, it follows.
+	if _, ok, err := ops.Claim(context.Background(), "/work", nil, "gcg-a00", "worker-1"); !ok || err != nil {
+		t.Fatalf("routed claim = (ok=%v err=%v)", ok, err)
+	}
+	ops.EmitExecutionStepStarted(beads.Bead{ID: "gcg-a00"}, "/work", nil, "worker-1")
+	if workEmissions != 1 {
+		t.Fatalf("work-scope emissions = %d, want 1 — after the claim landed in the binding the emission must not run against the ledger that cannot read the step's root", workEmissions)
+	}
+}
+
+// TestClassRoutedHookClaimOpsIsInertWithoutABinding is the single-store
+// byte-identity statement at the unit level: no route means the caller's own ops
+// value comes straight back, not a wrapper that delegates.
+func TestClassRoutedHookClaimOpsIsInertWithoutABinding(t *testing.T) {
+	assertHookClaimOpsUnwrapped(t, classRoutedHookClaimOps(defaultedHookClaimOps(), nil), defaultedHookClaimOps())
+
+	route, err := hookClaimClassRouteForCity(t.TempDir())
+	if err != nil {
+		t.Fatalf("hookClaimClassRouteForCity on a city with no [storage]: %v", err)
+	}
+	if route != nil {
+		t.Fatal("hookClaimClassRouteForCity opened a class route for a city that relocates nothing")
+	}
+}

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -454,7 +454,7 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 			DrainAck:     opts.DrainAck,
 			JSON:         opts.JSON,
 		}
-		return claimHookWork(workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
+		return claimHookWork(cityPath, workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}
 	return doHook(workQuery, workDir, false, runner, stdout, stderr)
 }
@@ -584,8 +584,24 @@ func hookClaimSessionEligibility(info session.Info, instanceToken string) (hookC
 // claimHookWork claims routed work for gc hook --claim from the federated store
 // set, binding the production shell work-query runner and real claim ops. See
 // claimHookWorkWithRunner for the federation and lost-claim-race semantics.
-func claimHookWork(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
-	return claimHookWorkWithRunner(workQuery, workDir, queryEnv, stores, claimOpts, hookClaimOps{}, shellWorkQueryWithEnv, emitFailure, stdout, stderr)
+//
+// The claim ops carry the CLASS axis (claim_class_route.go): every store in the
+// federated set is a bd WORKSPACE, and a relocated coordination class is not
+// one, so the binding is reached through the ops rather than through a leg. On a
+// city that relocates nothing the route is nil and the ops value is the one this
+// function has always passed.
+func claimHookWork(cityPath, workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
+	route, err := hookClaimClassRouteForCity(cityPath)
+	if err != nil {
+		// The city relocates a class and its front door could not be projected.
+		// Claiming through the work store anyway would write ownership into a
+		// ledger that does not hold the bead, which is the wrong-answer lane
+		// this routing exists to close.
+		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	ops := classRoutedHookClaimOps(hookClaimOps{}, route)
+	return claimHookWorkWithRunner(workQuery, workDir, queryEnv, stores, claimOpts, ops, shellWorkQueryWithEnv, emitFailure, stdout, stderr)
 }
 
 // claimHookWorkWithRunner is claimHookWork with the work-query runner and claim

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -591,13 +591,15 @@ func hookClaimSessionEligibility(info session.Info, instanceToken string) (hookC
 // city that relocates nothing the route is nil and the ops value is the one this
 // function has always passed.
 func claimHookWork(cityPath, workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
-	route, err := hookClaimClassRouteForCity(cityPath)
-	if err != nil {
-		// The city relocates a class and its front door could not be projected.
-		// Claiming through the work store anyway would write ownership into a
-		// ledger that does not hold the bead, which is the wrong-answer lane
-		// this routing exists to close.
-		fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
+	// The city relocates a class and its front door could not be projected.
+	// Claiming through the work store anyway would write ownership into a
+	// ledger that does not hold the bead, which is the wrong-answer lane this
+	// routing exists to close — so every failure but one is fatal here. The
+	// exception, a binding with no claim CAS, degrades to unrouted claiming;
+	// see hookClaimRouteVerdict.
+	opened, err := hookClaimClassRouteForCity(cityPath)
+	route, proceed := hookClaimRouteVerdict(opened, err, stderr)
+	if !proceed {
 		return 1
 	}
 	ops := classRoutedHookClaimOps(hookClaimOps{}, route)
@@ -619,8 +621,17 @@ func claimHookWork(cityPath, workQuery, workDir string, queryEnv []string, store
 // has been exhausted; the drain reason is claims_errored when any exhausted
 // store's eligible claims errored rather than merely lost the race, else no_work.
 // emitFailure surfaces a work-query timeout on the event bus when eligible.
+//
+// The store set is also what the claim-time class escalation is measured
+// against: only the PRIMARY leg runs the city-wide reader, so it is the only leg
+// whose query can serve a bead it does not itself hold, and a not-found there
+// says nothing about the work legs behind it. observeWorkLegs hands the route
+// the whole fan-out so it can prove "no WORK store holds this bead" before it
+// writes ownership into the binding (claim_class_route.go). Nil on a city that
+// relocates nothing.
 func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, stores []hookStore, claimOpts hookClaimOptions, ops hookClaimOps, run hookStoreRunner, emitFailure func(command string, err error), stdout, stderr io.Writer) int {
 	ops.applyDefaults()
+	ops.ClassRoute.observeWorkLegs(stores)
 	// primary is the agent's own store (the first entry). It is captured once
 	// here, before the loop shrinks remaining: only the primary may surface a
 	// work-query error as a fatal claim failure. Once the primary loses its

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -70,6 +70,13 @@ type hookClaimOps struct {
 	// mutating the session bead after a successful work claim.
 	PublishRunMap hookPublishRunMapFunc
 	Now           func() time.Time
+	// ClassRoute is the relocated coordination-class binding these seams
+	// escalate to, or nil on a city that relocates nothing. It is not a seam:
+	// it is here so claimHookWorkWithRunner — the only caller that knows the
+	// whole work fan-out — can hand the route its leg set, which is what lets a
+	// not-found from ONE leg be checked against the others before it opens the
+	// escalation. See claim_class_route.go.
+	ClassRoute *hookClaimClassRoute
 }
 
 type (
@@ -263,13 +270,20 @@ func claimFirstReadyHookAssignment(candidates []beads.Bead, opts hookClaimOption
 		claimActor := strings.TrimSpace(candidate.Assignee)
 		claimed, ok, err := ops.Claim(ctx, dir, opts.Env, candidate.ID, claimActor)
 		if err != nil {
-			if !ok && hookClaimBeadIsElsewhere(err) {
+			if !ok && (hookClaimBeadIsElsewhere(err) || hookClaimBindingRefusedTheClaim(err)) {
 				// The read federated and the write did not: the assigned tier
 				// reads city-wide, so a graph step in a relocated class store
 				// arrives here while the claim runs against this store's bd
 				// context, which cannot resolve it. That is not an unresolved
 				// mutation on a bead we own here — this store holds no such bead —
 				// so skip it and let the federated caller try the store that does.
+				//
+				// A binding that refuses the claim CAS outright carries the same
+				// proof and is skipped for the same reason: the escalation only
+				// ran because a work store returned not-found, and the refusal
+				// lands before any write (hookClaimBindingRefusedTheClaim). One
+				// bead no store can claim must not stop this session claiming
+				// the work that other stores can.
 				fmt.Fprintf(stderr, "gc hook --claim: skipping ready assignment %s: %v\n", candidate.ID, err) //nolint:errcheck
 				claimsErrored = true
 				continue

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -594,7 +594,28 @@ func preassignHookContinuationGroup(bead beads.Bead, opts hookClaimOptions, ops 
 
 func hookClaimWithBdStore(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {
 	store := hookClaimBdStoreContext(ctx, dir, env, assignee)
-	claimed, ok, err := store.Claim(beadID)
+	return hookClaimThroughStore(beadID, assignee,
+		func() (beads.Bead, bool, error) { return store.Claim(beadID) },
+		store.Get)
+}
+
+// hookClaimThroughStore is the post-mutation classification shared by every
+// store a claim can run against: the work-directory bd context here, and the
+// relocated class binding in claim_class_route.go.
+//
+// It is factored out rather than duplicated because the classification IS the
+// contract the caller reads — a lost race must be reported as a rejection and
+// not as an error, a stale projection must not be treated as ours, and a failed
+// canonical readback must be surfaced with ok=true so the caller stops instead
+// of draining. Two copies of that would be two chances to disagree, and the
+// paths that disagree about ownership are this program's recurring bug class.
+//
+// claim and get are the store's own operations: the bd context's Claim takes the
+// assignee implicitly (BEADS_ACTOR in the subprocess env) while the class
+// binding's takes it explicitly, so the caller binds them and this function
+// never has to know which shape it is holding.
+func hookClaimThroughStore(beadID, assignee string, claim func() (beads.Bead, bool, error), get func(string) (beads.Bead, error)) (beads.Bead, bool, error) {
+	claimed, ok, err := claim()
 	if err != nil {
 		return beads.Bead{}, false, err
 	}
@@ -602,19 +623,20 @@ func hookClaimWithBdStore(ctx context.Context, dir string, env []string, beadID,
 		// Claim conflict: re-read the bead so the caller can surface who won
 		// the race in the bead.claim_rejected event (ADR-0009). Best-effort —
 		// a read error degrades to a silent no-op (empty bead, no event).
-		current, getErr := store.Get(beadID)
+		current, getErr := get(beadID)
 		if getErr != nil {
 			return beads.Bead{}, false, nil
 		}
 		return current, false, nil
 	}
 	if !hookClaimHasIdentity(claimed.Assignee, []string{assignee}) {
-		// bd reported a successful mutation but the bead is owned by another
-		// claimant (stale projection / lost race). Return it as a non-claim so
-		// the caller can report the rejection rather than treat it as ours.
+		// The store reported a successful mutation but the bead is owned by
+		// another claimant (stale projection / lost race). Return it as a
+		// non-claim so the caller can report the rejection rather than treat it
+		// as ours.
 		return claimed, false, nil
 	}
-	canonical, err := store.Get(beadID)
+	canonical, err := get(beadID)
 	if err != nil {
 		return claimed, true, fmt.Errorf("reloading claimed bead %q: %w", beadID, err)
 	}

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1845,11 +1845,26 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer, jsonOutput ...bool
 	// Each Update fires the bd on_update hook, which emits a bead.updated
 	// event the supervisor's CachingStore absorbs — the cache-update event
 	// the close path was previously missing (gastownhall/gascity#2625).
+	//
+	// The scan leads with the WORK store here, unlike the reconciler's, which
+	// leads with the sessions-class store. On a split city that difference is
+	// the whole release tier for relocated work: claim-time class routing
+	// (claim_class_route.go) can leave an in_progress assignee in the graph
+	// binding, and a work-led scan cannot see it. So the binding is handed in as
+	// a class leg — the same graphClassBinding identity the claim routes on, from
+	// the same one-shot funnel — and dropped again on a city that relocates
+	// nothing.
 	var rigStores map[string]beads.Store
+	var classStores []beads.Store
 	if cityErr == nil && cfg != nil {
 		rigStores = buildStandaloneRigStores(cfg, cityPath, stderr)
 	}
-	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, closedSessionBead, "", stderr)
+	if cityErr == nil {
+		if binding, relocated := graphClassBinding(cliStorageRoutes(cityPath)); relocated {
+			classStores = append(classStores, binding)
+		}
+	}
+	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, closedSessionBead, "", stderr, classStores...)
 
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{

--- a/cmd/gc/hook_claim_class_fanout_test.go
+++ b/cmd/gc/hook_claim_class_fanout_test.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/storebinding"
+)
+
+// The claim-time class escalation as the FEDERATED loop sees it. The unit rows
+// in claim_class_route_test.go own the per-call escalation rule; these rows own
+// the two properties only the loop can state:
+//
+//   - "work first" means every WORK leg, not the first leg the ranking picked.
+//     A rig-scoped agent — the shipped shape for every worker that claims — runs
+//     its rig store FIRST and the city work store LAST, so an escalation that
+//     fires on the leg that answered preempts an untried work leg that holds the
+//     bead.
+//   - a binding-side refusal is a fact about ONE bead, never about the tick. The
+//     escalation only runs after a work store returned not-found, which proves
+//     the session owns nothing there, so the claim can be skipped exactly as the
+//     work-side not-found is.
+
+// hookFanoutRigFirstStores is the fan-out hookWorkQueryStores builds for a
+// rig-scoped agent: the rig store as the PRIMARY entry, the agent's own
+// (rig-scoped) store, then the city work store appended LAST.
+func hookFanoutRigFirstStores() []hookStore {
+	return []hookStore{
+		{dir: "rig-a", env: []string{"GC_STORE_SCOPE=rig"}},
+		{dir: "city", env: []string{"GC_STORE_SCOPE=city"}},
+	}
+}
+
+// hookFanoutClaimOpts is the worker identity every row below claims as.
+func hookFanoutClaimOpts() hookClaimOptions {
+	return hookClaimOptions{
+		Assignee:           "worker-1",
+		IdentityCandidates: []string{"worker-1"},
+		RouteTargets:       []string{"worker"},
+		DrainAck:           true,
+		JSON:               true,
+	}
+}
+
+func hookFanoutBaseOps(claim hookClaimFunc) hookClaimOps {
+	return hookClaimOps{
+		Claim:             claim,
+		EmitClaimRejected: func(string, string, string) {},
+		ResolveWorkBranch: func(string) string { return "" },
+		DrainAck:          func(io.Writer) error { return nil },
+		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
+			return nil
+		},
+		ReadWorkMeta: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, error) {
+			return beads.Bead{ID: beadID, Assignee: assignee}, nil
+		},
+		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
+			return nil, nil
+		},
+		EmitExecutionStepStarted: func(beads.Bead, string, []string, string) {},
+		PublishRunMap:            func(string, string, ...string) error { return nil },
+	}
+}
+
+// newFanoutClassRoute opens a claim-time class route over a store a row
+// controls, bypassing hookClaimClassRouteForCity (which needs a city on disk).
+func newFanoutClassRoute(t *testing.T, class beads.Store) *hookClaimClassRoute {
+	t.Helper()
+	route, err := newHookClaimClassRoute(class)
+	if err != nil {
+		t.Fatalf("newHookClaimClassRoute: %v", err)
+	}
+	return route
+}
+
+// TestClassEscalationWaitsForEveryWorkLeg is the "work first" statement at the
+// level the phrase is about.
+//
+// A co-resident id — the documented steady state of a migrated city, because
+// `gc storage migrate` copies and never deletes back — is served by the
+// federated reader from the CITY work row (readyFederationLegs runs city, then
+// rigs, then graph, first-leg-wins). The claim must agree. On a rig-scoped agent
+// the ranking selects the RIG leg first, its work-scope claim answers not-found,
+// and an escalation that fires there takes the binding copy while the reader
+// keeps re-serving the still-open city work row — the treadmill this slice
+// exists to end, reintroduced by the slice itself.
+func TestClassEscalationWaitsForEveryWorkLeg(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-77", nil)
+	route := newFanoutClassRoute(t, class)
+
+	// Both work legs are served the same co-resident row; only the CITY leg's
+	// bd context can resolve it, exactly as appendCityHookStore documents.
+	row := `[{"id":"gcg-77","status":"open","assignee":"worker-1","metadata":{"gc.kind":"wisp"}}]`
+	run := func(_, _ string, _ []string) (string, error) { return row, nil }
+
+	var claimDirs []string
+	base := hookFanoutBaseOps(func(_ context.Context, dir string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		claimDirs = append(claimDirs, dir)
+		if dir != "city" {
+			return beads.Bead{}, false, fmt.Errorf("claiming bead %q: %w", beadID, beads.ErrNotFound)
+		}
+		return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee}, true, nil
+	})
+	// Residence, read through each leg's own bd context: the CITY work store
+	// holds the migration copy and the rig store does not.
+	base.ReadWorkMeta = func(_ context.Context, dir string, _ []string, beadID, assignee string) (beads.Bead, error) {
+		if dir != "city" {
+			return beads.Bead{}, fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+		}
+		return beads.Bead{ID: beadID, Assignee: assignee}, nil
+	}
+
+	stores := hookFanoutRigFirstStores()
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("gc ready --json", "city", stores[0].env, stores, hookFanoutClaimOpts(),
+		classRoutedHookClaimOps(base, route), run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if got := strings.Join(claimDirs, ","); got != "rig-a,city" {
+		t.Fatalf("work-scope claim ran against dirs %q, want rig-a,city: every WORK leg must answer before the class escalation opens", got)
+	}
+	if held, err := class.Get("gcg-77"); err != nil || strings.TrimSpace(held.Assignee) != "" {
+		t.Fatalf("the binding's copy of gcg-77 is claimed for %q (err=%v); a co-resident id belongs to the WORK copy the reader that served it answers from", held.Assignee, err)
+	}
+}
+
+// TestClassEscalationStillReachesABindingOnlyBead is the other side of the same
+// rule and the slice's headline capability: once EVERY work leg has answered
+// not-found, no work store holds the bead, and the binding is where it lives.
+func TestClassEscalationStillReachesABindingOnlyBead(t *testing.T) {
+	class := newClaimRouteClassStore(t)
+	mintClaimRouteBead(t, class, "gcg-88", nil)
+	route := newFanoutClassRoute(t, class)
+
+	row := `[{"id":"gcg-88","status":"open","assignee":"worker-1","metadata":{"gc.kind":"wisp"}}]`
+	run := func(_, _ string, _ []string) (string, error) { return row, nil }
+	var claimDirs []string
+	base := hookFanoutBaseOps(func(_ context.Context, dir string, _ []string, beadID, _ string) (beads.Bead, bool, error) {
+		claimDirs = append(claimDirs, dir)
+		return beads.Bead{}, false, fmt.Errorf("claiming bead %q: %w", beadID, beads.ErrNotFound)
+	})
+	base.ReadWorkMeta = func(_ context.Context, _ string, _ []string, beadID, _ string) (beads.Bead, error) {
+		return beads.Bead{}, fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+	}
+
+	stores := hookFanoutRigFirstStores()
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("gc ready --json", "city", stores[0].env, stores, hookFanoutClaimOpts(),
+		classRoutedHookClaimOps(base, route), run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %q", err, stdout.String())
+	}
+	if result.BeadID != "gcg-88" || !result.OK {
+		t.Fatalf("claim result = %+v, want gcg-88 claimed: a bead NO work leg holds is exactly what the class escalation is for", result)
+	}
+	// And on the FIRST leg it was selected on. Deferring the escalation until
+	// the fan-out drained would let unrelated lower-tier work in a later leg be
+	// claimed ahead of an ASSIGNED graph step, which is the starvation this
+	// slice closes.
+	if got := strings.Join(claimDirs, ","); got != "rig-a" {
+		t.Fatalf("work-scope claim ran against dirs %q, want rig-a alone: once no work leg holds the bead the escalation is immediate, at the candidate's own rank", got)
+	}
+	held, err := class.Get("gcg-88")
+	if err != nil || !strings.EqualFold(strings.TrimSpace(held.Status), "in_progress") || strings.TrimSpace(held.Assignee) != "worker-1" {
+		t.Fatalf("binding holds gcg-88 as status=%q assignee=%q (err=%v), want in_progress owned by worker-1", held.Status, held.Assignee, err)
+	}
+}
+
+// noCASBindingLeaf is the production binding leaf that cannot CAS-claim:
+// beadsworkspace's OpenEngine returns a *beads.NativeDoltStore, which carries
+// ReleaseIfCurrent and no two-argument Claim. beads.MemStore HAS the capability,
+// so it is hidden behind an embedding that does not re-export it.
+type noCASBindingLeaf struct{ beads.Store }
+
+// newCapabilityRefusingRoute builds a route whose binding answers reads but
+// refuses the claim CAS, bypassing the constructor's capability check so the row
+// states what happens if a refusal reaches the claim anyway.
+func newCapabilityRefusingRoute(t *testing.T, ids ...string) *hookClaimClassRoute {
+	t.Helper()
+	leaf := newClaimRouteClassStore(t)
+	for _, id := range ids {
+		mintClaimRouteBead(t, leaf, id, nil)
+	}
+	hidden := noCASBindingLeaf{Store: leaf}
+	graph, err := storebinding.NewBeadsGraphStore(hidden)
+	if err != nil {
+		t.Fatalf("projecting the graph front door over a claim-incapable leaf: %v", err)
+	}
+	return newClaimClassRouteOver(hidden, graph)
+}
+
+// TestBindingClaimRefusalIsPerBeadNotPerTick is the control-vs-refusal pair.
+//
+// The escalation runs only after a work store returned not-found, which PROVES
+// this session owns nothing there and that nothing was mutated anywhere. A
+// binding-side refusal on that bead is therefore a per-bead fact, exactly like
+// the work-side not-found it followed — and must be skipped the same way, or one
+// unclaimable id takes the whole tick down and the worker claims nothing at all,
+// including healthy work in stores that answer perfectly.
+func TestBindingClaimRefusalIsPerBeadNotPerTick(t *testing.T) {
+	// The graph step ranks AHEAD of the routed work (assigned beats routed), so
+	// the refusal is reached before the healthy bead either way.
+	row := `[{"id":"gcg-6","status":"open","assignee":"worker-1","metadata":{"gc.kind":"wisp"}},` +
+		`{"id":"gc-77","status":"open","metadata":{"gc.routed_to":"worker"}}]`
+	run := func(_, _ string, _ []string) (string, error) { return row, nil } //nolint:unparam // the runner seam returns an error the healthy rows never produce
+	newBase := func() hookClaimOps {
+		return hookFanoutBaseOps(func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			if strings.HasPrefix(beadID, "gcg-") {
+				return beads.Bead{}, false, fmt.Errorf("claiming bead %q: %w", beadID, beads.ErrNotFound)
+			}
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
+		})
+	}
+
+	for _, tt := range []struct {
+		name  string
+		ops   func(*testing.T) hookClaimOps
+		stdin string
+	}{
+		{
+			name: "control: no class route (main's behavior)",
+			ops:  func(*testing.T) hookClaimOps { return newBase() },
+		},
+		{
+			name: "class route whose binding refuses the claim CAS",
+			ops: func(t *testing.T) hookClaimOps {
+				return classRoutedHookClaimOps(newBase(), newCapabilityRefusingRoute(t, "gcg-6"))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stores := []hookStore{{dir: "city", env: []string{"GC_STORE_SCOPE=city"}}}
+			var stdout, stderr bytes.Buffer
+			code := claimHookWorkWithRunner("gc ready --json", "city", stores[0].env, stores, hookFanoutClaimOpts(),
+				tt.ops(t), run, func(string, error) {}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("claimHookWorkWithRunner = %d, want 0: a bead this session provably does not own in the work store cannot make the tick terminal; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			var result hookClaimJSONResult
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				t.Fatalf("stdout is not JSON: %v\nraw: %q", err, stdout.String())
+			}
+			if result.BeadID != "gc-77" {
+				t.Fatalf("claim result = %+v, want the healthy routed bead gc-77 claimed", result)
+			}
+		})
+	}
+}
+
+// TestBindingClaimRefusalAloneStillDrains pins the drain contract for the same
+// refusal with no other work behind it: a structured claims_errored drain a
+// --json caller can read, not a bare exit 1 with empty stdout.
+func TestBindingClaimRefusalAloneStillDrains(t *testing.T) {
+	row := `[{"id":"gcg-6","status":"open","assignee":"worker-1","metadata":{"gc.kind":"wisp"}}]`
+	run := func(_, _ string, _ []string) (string, error) { return row, nil }
+	base := hookFanoutBaseOps(func(_ context.Context, _ string, _ []string, beadID, _ string) (beads.Bead, bool, error) {
+		return beads.Bead{}, false, fmt.Errorf("claiming bead %q: %w", beadID, beads.ErrNotFound)
+	})
+	drained := false
+	base.DrainAck = func(io.Writer) error {
+		drained = true
+		return nil
+	}
+
+	stores := []hookStore{{dir: "city", env: []string{"GC_STORE_SCOPE=city"}}}
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("gc ready --json", "city", stores[0].env, stores, hookFanoutClaimOpts(),
+		classRoutedHookClaimOps(base, newCapabilityRefusingRoute(t, "gcg-6")), run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("claimHookWorkWithRunner = %d, want 0 (structured drain); stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !drained {
+		t.Fatal("drain ack was not called; the tick exited without completing the drain contract")
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %q", err, stdout.String())
+	}
+	if result.Reason != "claims_errored" {
+		t.Fatalf("drain reason = %q, want claims_errored: a refused claim must not be laundered into a healthy no_work", result.Reason)
+	}
+}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -943,14 +943,19 @@ func coordClassStoreCandidates(cfg *config.City, cityStore beads.Store, rigStore
 // without touching the call sites. Unlike coordClassStoreCandidates it has no
 // cfg/suspended context (the retirement scans run per session bead without a
 // suspension frame), so it fans out across all live rig stores by name.
-func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store) []beads.Store {
+//
+// extra appends the stores a caller knows can ALSO hold work this session owns
+// but that are not work stores — today the relocated coordination-class binding,
+// which claim-time routing (claim_class_route.go) can write an in_progress
+// assignee into on a split city. A caller whose leading store already IS that
+// binding passes nothing: duplicates are dropped, so the leg cannot be scanned
+// twice. It goes LAST because it is the ledger of last resort, the same order
+// the claim reaches it in.
+func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store, extra ...beads.Store) []beads.Store {
 	if store == nil {
 		return nil
 	}
 	stores := []beads.Store{store}
-	if len(rigStores) == 0 {
-		return stores
-	}
 	names := make([]string, 0, len(rigStores))
 	for name, rs := range rigStores {
 		if rs == nil {
@@ -962,7 +967,31 @@ func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store) [
 	for _, name := range names {
 		stores = append(stores, rigStores[name])
 	}
+	for _, candidate := range extra {
+		if candidate == nil || workAssignmentStoresHave(stores, candidate) {
+			continue
+		}
+		stores = append(stores, candidate)
+	}
 	return stores
+}
+
+// workAssignmentStoresHave reports whether candidate is already a leg. The
+// sessions and graph classes are served from ONE binding on a converged split
+// (openStorageRoutes keys every assigned class to the engine it opened), so a
+// reconciler scan led by the sessions-class store is already reading the store a
+// caller would add here.
+func workAssignmentStoresHave(stores []beads.Store, candidate beads.Store) bool {
+	key, ok := storePointerKey(candidate)
+	if !ok {
+		return false
+	}
+	for _, existing := range stores {
+		if existingKey, ok := storePointerKey(existing); ok && existingKey == key {
+			return true
+		}
+	}
+	return false
 }
 
 // unclaimResult reports the outcome of one unassign sweep over a retired
@@ -982,12 +1011,21 @@ type unclaimResult struct {
 	Failed   int
 }
 
+// unclaimWorkAssignedToRetiredSessionBead detaches every work bead a retired
+// session still owns, across the reachability scan workAssignmentStores builds.
+//
+// classStores are the non-work ledgers this caller knows can also hold work the
+// session owns. The reconciler leads with the sessions-class store, which on a
+// converged split IS the binding, so it passes none; a caller that leads with
+// the WORK store — `gc session close` — passes the relocated graph binding, or a
+// claim that claim_class_route.go routed there would be released by nothing.
 func unclaimWorkAssignedToRetiredSessionBead(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sessionBead beads.Bead,
 	fallbackRoute string,
 	stderr io.Writer,
+	classStores ...beads.Store,
 ) {
 	if store == nil || strings.TrimSpace(sessionBead.ID) == "" {
 		return
@@ -997,7 +1035,7 @@ func unclaimWorkAssignedToRetiredSessionBead(
 	}
 	identifiers := sessionAssignmentIdentifiers(sessionBead)
 	seen := make(map[string]struct{})
-	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores) {
+	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores, classStores...) {
 		wa := workAssignmentForStore(beads.WorkStore{Store: ownerStore})
 		for _, status := range []string{"open", "in_progress"} {
 			for _, assignee := range identifiers {

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -58,9 +58,10 @@ import (
 // Others pin behavior main HAS but should not keep. Those carry a KNOWN GAP
 // paragraph naming the divergence, the assertions that move when it closes, and
 // the slice that closes it — I1 and I2 (the HQ work store is in neither arm of
-// the controller's cross-store scan on a split city), I5 (`gc hook --claim`
-// fans out over work scopes with no coordination-class arm) and I10 (the wake
-// filter has no coordination-class reachability arm). Leaving such a leg UNSEEDED is the
+// the controller's cross-store scan on a split city), I5 (the RELEASE tier does
+// not follow the now class-routed claim: crash recovery, on_death/on_boot and
+// the retired-session sweep are all still work-only) and I10 (the wake filter
+// has no coordination-class reachability arm). Leaving such a leg UNSEEDED is the
 // failure mode this convention exists to prevent: the invariant then reads as
 // coverage of a path it never touches.
 //
@@ -417,57 +418,53 @@ func conformanceMaterializationResidence(t *testing.T, e splitEnv) {
 // the assertion is residence — the claim is visible in the owning store and in
 // no other leg.
 //
-// KNOWN GAP, pinned rather than asserted as desirable — `gc hook --claim` does
-// not consume the resolver. It resolves its stores as hookStore{dir, env} pairs
+// GAP CLOSED in ga-601v2 — `gc hook --claim` is class-routed, and NOT by the
+// shape the pin predicted. The prediction is kept here because the shape it got
+// wrong is the interesting part.
+//
+// What was pinned: the hook resolves its stores as hookStore{dir, env} pairs
 // (hook_cross_store.go) and execs bd in a work directory; the fan-out is city +
-// rigs, all WORK scopes, so a claim it issues for a relocated class id still
-// runs against a ledger that cannot see the bead. claimByID's own fallback IS
-// that fan-out, so the rows below state both answers side by side: a class id
-// routes, a work id keeps the legacy path byte-for-byte.
+// rigs, all WORK scopes, so a claim it issued for a relocated class id ran
+// against a ledger that could not see the bead. The rows below asserted that
+// fan-out on both topologies and were expected to REDDEN when the closure added
+// a coordination-class leg to it.
 //
-// ga-k8pzw — by-id routing through the shared resolver — landed WITHOUT closing
-// this, and the reason is worth stating because the earlier version of this
-// paragraph named it as the slice that would. The gap is a QUERY-federation
-// gap, not a by-id one: the hook only ever claims ids its OWN work query
-// returned, so while that query could not reach the binding a by-id-routed claim
-// mutation would never be handed a class id to route. The two halves it needs
-// are a coordination-class arm in the work query — the shape `gc ready` got in
-// ga-oxsyu (#5158) — and an in-process claim for the ids that arm returns,
-// because a relocated binding is not a bd workspace and cannot be expressed as a
-// hookStore{dir, env} at all. That is ga-x0oyt; when the second half lands, this
-// paragraph goes and the assertions move from claimByID to the command.
-// ga-xo8ch — class-routed WRITES from one-shot commands — landed without
-// touching it either: it routes where a coordination-class bead is BORN
-// (`gc order run`'s wisp, `gc formula cook`'s graph pour), and a claim is a
-// by-id mutation of a bead that already exists somewhere.
+// They did not, and could not: a relocated binding is not a bd workspace and
+// cannot be expressed as a hookStore{dir, env} at all — the same sentence the
+// pin used to explain why the gap existed also rules out the closure it
+// predicted. Both halves landed beside the fan-out instead of inside it:
 //
-// Half (a) HAS since landed, in ga-bvdha, and not in the shape this paragraph
-// predicted: the fan-out gained no leg, the primary leg's COMMAND was swapped to
-// the federated `gc ready` reader, which covers the binding in-process. So the
-// hook now SEES relocated graph work it still cannot claim — I15 pins that
-// asymmetry from the query side and names the drain it produces. The rows below
-// keep their meaning under that swap: they are about the store a CLAIM is issued
-// against, which is still a bd subprocess in a work workspace.
+//   - The READ half (ga-bvdha): no leg was added. The primary leg's COMMAND was
+//     swapped to the federated `gc ready`, which covers the binding in process.
+//   - The WRITE half (ga-601v2, claim_class_route.go): no leg was added. The
+//     CLASS axis went on the hookClaimOps seam, beside the rig axis already in
+//     claim_cross_store.go, so the claim-time writes escalate off the work store
+//     to the binding for a bead the work store proves it does not hold.
 //
-// The gap is ASSERTED and not merely described, the way I1, I2 and I10 assert
-// theirs — and it is asserted on the seam the CLOSURE has to change, not on one
-// that survives it. hookWorkQueryStores is the whole fan-out the hook queries,
-// and the rows below pin that every leg of it is a bd WORKSPACE naming a WORK
-// scope, on BOTH topologies: relocating graph adds no leg, so no leg can be
-// HANDED a bead the binding owns to claim. Half (b) of ga-x0oyt has to stop
-// being a bd subprocess call, so it cannot land without reddening them.
+// So the fan-out rows below are no longer a gap statement. They are the
+// invariant that keeps the two halves apart: every leg the hook QUERIES stays a
+// bd workspace naming a work scope, and a coordination-class leg appearing there
+// now means someone has tried to express a binding as a workspace. The rows that
+// state the closure are the routed-claim ones after them, and they are asserted
+// against the production seams (hookClaimClassRouteForCity, the resolver, and
+// classRoutedHookClaimOps, the ops wrapper) rather than against claimByID.
 //
-// The earlier version of this pin asserted only hookQueryEnv's GC_STORE_SCOPE
-// for the primary leg. That row is kept — the primary leg staying a work scope
-// is part of the claim — but on its own it was not a tripwire at all: the
-// closure ADDS an arm and changes nothing about the city leg, so it would have
-// stayed green through the very change it claimed to watch. A gap stated in
-// prose and nowhere else can close, or widen, without a single test moving; a
-// gap pinned on the wrong seam does the same thing while looking watched.
+// PROBE, NOT PREFIX, AND WORK FIRST. The claim is a WRITE, so it finds its store
+// by asking which one holds the bead — `gc storage migrate` preserves ids, so a
+// prefix route would miss exactly the beads that moved. The probe ORDER is the
+// part that differs from the by-id door, and it is deliberate: the by-id
+// resolvers lead with the class store, while the federated `gc ready` that
+// SERVED this claim its candidate leads with the work store and runs the graph
+// leg last (#5148/#5158/#5161). A claim must resolve co-residence the way the
+// reader that produced it does, or it claims the class copy while the reader
+// keeps answering from the still-open work copy — the treadmill this closure
+// exists to end. The rows below assert that: a class-resident id routes to the
+// binding, a co-resident id keeps the WORK copy.
 //
-// `gc bd update --claim` is already routed (#5132, cmd_bd_by_id.go) and probes
-// the same way, so the resolver is not the only class-aware claim path — it is
-// the one a caller holding just an id and a set of stores can use.
+// `gc bd update --claim` is also routed (#5132, cmd_bd_by_id.go) and probes the
+// same way but in the opposite ORDER, because its caller holds only an id and no
+// reader to agree with. That divergence is real and is asserted below rather
+// than left to be discovered.
 func conformanceClaimRouting(t *testing.T, e splitEnv) {
 	workBead, err := e.work.Create(beads.Bead{Title: "claim-routing work bead", Type: "task"})
 	if err != nil {
@@ -481,40 +478,52 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 		t.Fatal("config.ReservedClassPrefix(graph) = ok:false; there is no reserved namespace for by-id class routing to run on")
 	}
 
-	// The KNOWN GAP above, pinned on both topologies: the store `gc hook
-	// --claim` runs its claim against is a WORK scope, resolved from cfg with no
-	// class arm anywhere in it. Relocating graph does not move it.
+	// The QUERY fan-out, on both topologies: the store `gc hook --claim` runs its
+	// work query against is a WORK scope, resolved from cfg with no class arm
+	// anywhere in it. Relocating graph does not move it, and after ga-601v2 it
+	// still must not: the class axis is on the ops, not on a leg.
 	hookEnv, err := hookQueryEnv(e.cityPath, e.cfg, &config.Agent{Name: splitEnvPoolAgent})
 	if err != nil {
 		t.Fatalf("build the hook's work-query env: %v", err)
 	}
 	if got := hookEnv["GC_STORE_SCOPE"]; got != "city" {
-		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — if it now names a coordination class, the ga-x0oyt fan-out arm has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", got)
+		t.Errorf("`gc hook --claim` resolves store scope %q, want \"city\" — a coordination class named here would mean a relocated binding is being expressed as a bd workspace, which it is not; the class axis belongs on hookClaimOps (claim_class_route.go)", got)
 	}
 	if got := hookEnv["GC_STORE_ROOT"]; got != e.cityPath {
-		t.Errorf("`gc hook --claim` resolves store root %q, want the city work root %q — a claim it issues for a relocated class id runs against the work ledger, and that is the gap this row pins", got, e.cityPath)
+		t.Errorf("`gc hook --claim` resolves store root %q, want the city work root %q", got, e.cityPath)
 	}
 
-	// The tripwire: the WHOLE fan-out, which is what ga-x0oyt has to change.
 	// Every leg is a (dir, env) pair pointing a bd subprocess at a work
 	// workspace, and there are exactly as many as the city has work scopes —
-	// relocating graph adds none.
+	// relocating graph adds none, in either direction.
 	hookAgent := &config.Agent{Name: splitEnvPoolAgent}
 	fanout := hookWorkQueryStores(e.cityPath, e.cfg, hookAgent,
 		hookAgent.QualifiedName(),
 		agentCommandDir(e.cityPath, hookAgent, e.cfg.Rigs),
 		mergeRuntimeEnv(nil, hookEnv), hookEnv)
 	if want := 1 + len(e.cfg.Rigs); len(fanout) != want {
-		t.Errorf("`gc hook --claim` fans out over %d store(s), want %d (city + %d rig) — a leg appeared or vanished; if it is the coordination-class arm, ga-x0oyt has landed: drop this invariant's KNOWN GAP paragraph and move the claim assertions from claimByID onto the command", len(fanout), want, len(e.cfg.Rigs))
+		t.Errorf("`gc hook --claim` fans out over %d store(s), want %d (city + %d rig) — a leg appeared or vanished; the class binding is reached through hookClaimOps, never as a leg, because it is not a bd workspace", len(fanout), want, len(e.cfg.Rigs))
 	}
 	for i, leg := range fanout {
 		scope := hookStoreEnvValue(leg, "GC_STORE_SCOPE")
 		if scope != "city" && scope != "rig" {
-			t.Errorf("`gc hook --claim` fan-out leg %d names store scope %q, want a WORK scope (\"city\" or \"rig\") — a leg that names a coordination class is the ga-x0oyt arm landing, and the claim mutation has to stop being a bd subprocess call with it", i, scope)
+			t.Errorf("`gc hook --claim` fan-out leg %d names store scope %q, want a WORK scope (\"city\" or \"rig\")", i, scope)
 		}
 		if root := hookStoreEnvValue(leg, "GC_STORE_ROOT"); root == "" {
 			t.Errorf("`gc hook --claim` fan-out leg %d names no GC_STORE_ROOT; every leg here is a bd workspace, and a relocated binding cannot be expressed as one", i)
 		}
+	}
+
+	// The CLOSURE, asserted on the production resolver: the claim-time class
+	// route exists exactly when the city relocates a class, decided by store
+	// identity through graphClassBinding and read off the city on disk — the
+	// same authority cityQueryTopology asks for the read half.
+	cityRoute, err := hookClaimClassRouteForCity(e.cityPath)
+	if err != nil {
+		t.Fatalf("resolving the claim-time class route for this city: %v", err)
+	}
+	if (cityRoute != nil) != e.split {
+		t.Fatalf("hookClaimClassRouteForCity returned route!=nil = %v on a split=%v city; a claim routed on a city that relocates nothing writes through a binding it has no business opening, and one NOT routed on a split city writes ownership into a ledger that does not hold the bead", cityRoute != nil, e.split)
 	}
 
 	if !e.split {
@@ -564,6 +573,12 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 			}
 			e.assertClaimedIn(t, id, "single-store-claimant", e.work)
 		}
+		// BYTE-IDENTICAL claim-time writes, proved by function identity rather
+		// than by behavior. classRoutedHookClaimOps must return the ops value it
+		// was handed — not a wrapper that delegates — so a legacy city runs the
+		// exact same function values it runs today and pays nothing for a seam it
+		// cannot use. Mutating the wrapper to wrap unconditionally reddens this.
+		assertHookClaimOpsUnwrapped(t, classRoutedHookClaimOps(defaultedHookClaimOps(), nil), defaultedHookClaimOps())
 		return
 	}
 
@@ -635,6 +650,165 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 			continue
 		}
 		e.assertClaimedIn(t, tt.id, assignee, want)
+	}
+
+	conformanceHookClaimClassRouting(t, e, workBead.ID)
+}
+
+// conformanceHookClaimClassRouting is I5's closure row: the claim `gc hook
+// --claim` ISSUES, through the production ops seam, for the three id shapes a
+// split city can hand it.
+//
+// The class leg is re-opened capability-faithfully (withClaimCapableClassLeg):
+// a routed claim acquires through the binding's own CAS, which the production
+// SQLite binding has and the kit's MemStore leaf does not. The route is then
+// opened over that binding — what graphClassBinding(ce.routes) resolves to — so
+// the write lands where the row minted the bead. The base Claim is bound to the
+// fixture's real WORK store, so the not-found that opens the escalation is the
+// store's own answer rather than a restatement of one.
+//
+// The CO-RESIDENT row is the one that states the tie-break, and it is the
+// migrated-city steady state: `gc storage migrate` copies with ids preserved and
+// never deletes back, so the same id is live in both stores. The claim must keep
+// the WORK copy, because the federated `gc ready` that served it dedupes to the
+// work row (#5148 leg order, ready_federation.go). A class-first claim here would
+// leave the reader's work row open and re-serve the bead every tick — the exact
+// treadmill ga-601v2 closes.
+func conformanceHookClaimClassRouting(t *testing.T, base splitEnv, workBeadID string) {
+	t.Helper()
+	e := base.withClaimCapableClassLeg(t)
+	route, err := newHookClaimClassRoute(e.class)
+	if err != nil {
+		t.Fatalf("opening the claim-time class front door over the fixture's class store: %v", err)
+	}
+	classResident := e.mintWispWith(t, wispOpts{title: "hook-claim routed graph step"})
+
+	// The migration copy: a WORK-shaped id live in both stores. The class leaf
+	// models SQLite, which accepts a foreign-prefix pinned id and records the
+	// residence violation instead of refusing, so the fixture claims the record.
+	if _, err := e.class.Create(beads.Bead{ID: workBeadID, Title: "migrated copy of a work bead", Type: "task"}); err != nil {
+		t.Fatalf("staging the co-resident migration copy of %s in the class store: %v", workBeadID, err)
+	}
+	if violations := splittest.TakeResidenceViolations(e.class); len(violations) == 0 {
+		t.Fatal("class store recorded no residence violation for the co-resident work id; the SQLite-semantics leaf is not modeling the migrated steady state")
+	}
+
+	for _, tt := range []struct {
+		name, id  string
+		wantClass bool
+	}{
+		{"class-resident graph step — the bead the work query now serves", classResident.ID, true},
+		{"work bead — the legacy path, unchanged", workBeadID, false},
+		{"co-resident id — first-leg-wins, WORK copy", workBeadID, false},
+	} {
+		ops := classRoutedHookClaimOps(hookClaimOps{Claim: splitEnvStoreClaim(e.work)}, route)
+		assignee := "hook-claimant-" + tt.name
+		claimed, ok, err := ops.Claim(context.Background(), e.cityPath, nil, tt.id, assignee)
+		if err != nil || !ok {
+			t.Errorf("%s: `gc hook --claim` claim of %s = (ok=%v err=%v), want a successful claim; a class-resident bead the work query serves must be claimable by the command that served it", tt.name, tt.id, ok, err)
+			continue
+		}
+		if claimed.ID != tt.id {
+			t.Errorf("%s: claim returned bead %q, want %q", tt.name, claimed.ID, tt.id)
+		}
+		want, other := e.work, e.class
+		if tt.wantClass {
+			want, other = e.class, e.work
+		}
+		if got, err := want.Get(tt.id); err != nil || strings.TrimSpace(got.Assignee) != assignee {
+			t.Errorf("%s: the store that owns %s holds assignee %q (err=%v), want %q — the claim ran against a store that does not own the bead", tt.name, tt.id, got.Assignee, err, assignee)
+		}
+		if got, err := other.Get(tt.id); err == nil && strings.TrimSpace(got.Assignee) == assignee {
+			t.Errorf("%s: %s is claimed for %q in the store that does NOT own it; ownership was written into the wrong ledger", tt.name, tt.id, assignee)
+		}
+	}
+
+	assertClassRoutedClaimHasNoReleaseTier(t, e)
+}
+
+// assertClassRoutedClaimHasNoReleaseTier is the KNOWN GAP the routed claim
+// CREATES, pinned rather than described — the release tier does not follow the
+// claim.
+//
+// Everything that takes a claim back is still work-only:
+//
+//   - the crash-recovery work-query tier (`bd list --status in_progress` in the
+//     agent's work directory, plus its `bd show` enrichment),
+//   - on_death and on_boot (`bd list` + `bd update`, likewise),
+//   - the post-close sweep unclaimWorkAssignedToRetiredSessionBead, whose store
+//     set is workAssignmentStores(city, rigs) and whose call site in
+//     cmd_session.go says in as many words that it "is WORK-class and stays on
+//     the generic store".
+//
+// internal/config's TestQueryKindsWithoutAReadyReadAreTopologyBlind pins the
+// first two from the query side. This row pins the third and states the
+// consequence, which the claim routing changes in KIND: before it, a relocated
+// graph step never reached in_progress at all (the claim failed and the tier
+// re-served it, loudly, every tick); after it, the step goes in_progress in the
+// binding, and if the worker dies there nothing that could release it can see
+// it. The loud treadmill is gone and a quiet strand is possible in its place.
+//
+// It is NOT closed here, deliberately. A federated release is a status LIST and
+// a WRITE across stores on the session-retirement path — a different seam from
+// claim-time write routing, with its own failure modes — and this program has a
+// standing rule against widening a slice past what it was scoped to. It is
+// ga-zp3uj; when that lands, this row flips to found-and-released and this
+// paragraph goes with it.
+func assertClassRoutedClaimHasNoReleaseTier(t *testing.T, e splitEnv) {
+	t.Helper()
+	for i, store := range workAssignmentStores(e.work, e.rigStores) {
+		if sameStorePtr(store, e.class) {
+			t.Fatalf("workAssignmentStores leg %d is the class binding; the release tier now follows the claim, so this KNOWN GAP row and its paragraph should be replaced by a found-and-released assertion", i)
+		}
+	}
+
+	sessionBead := beads.Bead{ID: "gcg-retired-session", Metadata: map[string]string{"session_name": "worker-1"}}
+	step := e.mintWispWith(t, wispOpts{
+		title:    "graph step claimed by a session that then died",
+		status:   "in_progress",
+		assignee: sessionBead.ID,
+	})
+	unclaimWorkAssignedToRetiredSessionBead(e.work, e.rigStores, sessionBead, "", io.Discard)
+	stranded, err := e.class.Get(step.ID)
+	if err != nil {
+		t.Fatalf("reading the claimed graph step back from the binding: %v", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(stranded.Status), "in_progress") ||
+		strings.TrimSpace(stranded.Assignee) != sessionBead.ID {
+		t.Fatalf("the retired-session sweep released the binding-resident step %s (status=%q assignee=%q); the release tier reaches the binding now, so this KNOWN GAP has closed: replace this row with a found-and-released assertion and drop its paragraph", step.ID, stranded.Status, stranded.Assignee)
+	}
+}
+
+// defaultedHookClaimOps is the production claim-op set with every seam filled —
+// the value classRoutedHookClaimOps is handed on a real invocation.
+func defaultedHookClaimOps() hookClaimOps {
+	ops := hookClaimOps{}
+	ops.applyDefaults()
+	return ops
+}
+
+// assertHookClaimOpsUnwrapped asserts every claim-time seam in got is the SAME
+// function value as in want, which is how a single-store city's byte-identity is
+// stated: not "it behaves the same" but "it is the same call". A wrapper that
+// delegated unconditionally would behave identically and still be a different
+// function, another allocation and another branch on the hottest control-plane
+// operation.
+func assertHookClaimOpsUnwrapped(t *testing.T, got, want hookClaimOps) {
+	t.Helper()
+	for _, seam := range []struct {
+		name      string
+		got, want any
+	}{
+		{"Claim", got.Claim, want.Claim},
+		{"StampWorkMeta", got.StampWorkMeta, want.StampWorkMeta},
+		{"ReadWorkMeta", got.ReadWorkMeta, want.ReadWorkMeta},
+		{"ListContinuation", got.ListContinuation, want.ListContinuation},
+		{"AssignContinuation", got.AssignContinuation, want.AssignContinuation},
+		{"EmitExecutionStepStarted", got.EmitExecutionStepStarted, want.EmitExecutionStepStarted},
+	} {
+		if reflect.ValueOf(seam.got).Pointer() != reflect.ValueOf(seam.want).Pointer() {
+			t.Errorf("classRoutedHookClaimOps replaced the %s seam on a city with no relocated class; a legacy city must run the identical function value", seam.name)
+		}
 	}
 }
 
@@ -1742,29 +1916,44 @@ func fixtureGraphLeg(e splitEnv) beads.Store {
 //  3. The reader the command names actually answers with the routed graph work,
 //     read through the production leg assembly rather than a restatement of it.
 //
-// KNOWN GAP, pinned rather than asserted as desirable — SEE BUT CANNOT CLAIM.
-// This invariant makes graph-class work VISIBLE to the worker's query. `gc hook
-// --claim` then runs its claim against a bd store rooted in the agent's work
-// directory (hookClaimBdStoreContext over hookQueryEnv, the WORK scope I5 pins),
-// which cannot reach the relocated class at all. So on a split city the bead
-// this query now surfaces is one the same command cannot claim.
+// GAP CLOSED in ga-601v2 — SEE AND CLAIM. This invariant makes graph-class work
+// VISIBLE to the worker's query. What it used to pin, one paragraph down, was
+// that the same command could not then CLAIM it: `gc hook --claim` ran its claim
+// against a bd store rooted in the agent's work directory
+// (hookClaimBdStoreContext over hookQueryEnv, the WORK scope I5 pins), which
+// cannot reach the relocated class at all.
 //
-// What that costs is bounded, and the bound is asserted below rather than
-// asserted in prose. On BOTH federated tiers — routed
-// (claimFirstEligibleHookCandidate) and assigned (claimFirstReadyHookAssignment,
-// the tier a graph step assigned to this worker arrives on) — a claim that fails
-// because this store does not hold the id is SKIPPED, not fatal: claimsErrored
-// carries it to the shared drain, the worker reports action=drain
-// reason=claims_errored (distinguishable from the healthy no_work drain), and
-// the federated loop still reaches claimable work in another store. The cost is
-// that ONE bead, not the tick. Only an error that leaves ownership unresolved —
-// a write timeout, store contention — still fails closed.
+// The claim-time writes are now class-routed (claim_class_route.go). The work
+// store is still the store the claim RUNS AGAINST first — that is the tie-break,
+// and it has to be, because this query's own reader dedupes a co-resident id to
+// the work row — and the binding is reached only where that work-scope write
+// returns the not-found that PROVES the bead is not there
+// (hookClaimBeadIsElsewhere, unwidened). So the two halves of the split-city
+// worker now agree: the bead this query surfaces is one the same command claims.
 //
-// That is why this is shippable ahead of the claim-time write routing
-// (ga-601v2), though the two remain a coherent pair: until the claim is
-// class-routed, an assigned graph step is re-served and re-skipped every tick
-// and no worker ever runs it. The rows below assert today's answer; when the
-// claim routes, they flip and this paragraph goes with them.
+// The rows below assert both halves, because both still have to hold:
+//
+//  1. The WORK store still cannot resolve a relocated bead, and still fails with
+//     the not-found the claim path classifies as "it lives elsewhere". That is
+//     the fixture's residence fact AND the escalation signal — if it stopped
+//     being ErrNotFound, the routing would never fire and the claim would fail
+//     closed instead.
+//  2. The claim escalates past it and lands in the binding.
+//  3. The fail-soft behavior SURVIVES. An id NEITHER store holds is still
+//     skipped, not fatal: claimsErrored carries it to the shared drain, the
+//     worker reports action=drain reason=claims_errored (distinguishable from a
+//     healthy no_work), and the federated loop still reaches claimable work in
+//     another store. That property is what kept ga-bvdha shippable alone, and
+//     closing the gap must not spend it — a routed claim removes the common
+//     cause of the skip, not the skip.
+//
+// What the closure does NOT reach is the RELEASE tier: crash recovery
+// (`bd list --status in_progress`), on_death/on_boot, and the retired-session
+// sweep are all still work-only, so a routed claim can now strand a
+// binding-resident step in_progress where nothing that could release it can see
+// it. That gap is ga-zp3uj, pinned on I5
+// (assertClassRoutedClaimHasNoReleaseTier) and, from the query side, by
+// internal/config's TestQueryKindsWithoutAReadyReadAreTopologyBlind.
 func conformanceWorkQueryFederation(t *testing.T, e splitEnv) {
 	agentCfg := e.cfg.Agents[0]
 	topo := cityQueryTopology(e.cityPath, e.cfg)
@@ -1848,88 +2037,142 @@ func conformanceWorkQueryFederation(t *testing.T, e splitEnv) {
 		t.Fatalf("the reader the split work_query names answered %v and not the routed graph step %s; the command was swapped but the answer is still work-ledger-only, which is the blindness with extra steps", ids, routed.ID)
 	}
 
-	conformanceWorkQuerySeesButCannotClaim(t, e, routed.ID)
+	conformanceWorkQueryClaimsWhatItSees(t, e)
 }
 
-// conformanceWorkQuerySeesButCannotClaim pins the KNOWN GAP above as an
-// assertion: the bead the federated work query now serves is one the store
-// `gc hook --claim` issues its claim against cannot even resolve.
+// conformanceWorkQueryClaimsWhatItSees asserts the closed gap: the bead the
+// federated work query serves is one `gc hook --claim` claims, even though the
+// store it issues its claim against first cannot resolve it.
 //
-// The store asserted here is the fixture's WORK leg, because that is what
-// hookQueryEnv's scope resolves to on both topologies (I5 pins that env
-// directly). A gap stated only in prose can close, or widen, without a test
-// moving.
+// The store the claim runs against FIRST is the fixture's WORK leg, because that
+// is what hookQueryEnv's scope resolves to on both topologies (I5 pins that env
+// directly). What changed is what happens next, and it is asserted, not
+// described: the work store's not-found escalates the write to the binding.
 //
-// It covers BOTH federated tiers, because they are different claim paths and
-// the reviewer's tautology was that only the routed one was ever exercised. The
-// routed tier reaches claimFirstEligibleHookCandidate; the assigned tier — the
-// one a graph step assigned to this worker arrives on — reaches
-// claimFirstReadyHookAssignment, whose unresolvable-id branch is separate code.
-func conformanceWorkQuerySeesButCannotClaim(t *testing.T, e splitEnv, routedGraphBeadID string) {
+// It covers BOTH federated tiers, because they are different claim paths and the
+// reviewer's tautology on the previous version was that only the routed one was
+// ever exercised. The routed tier reaches claimFirstEligibleHookCandidate; the
+// assigned tier — the one a graph step assigned to this worker arrives on —
+// reaches claimFirstReadyHookAssignment, whose unresolvable-id branch is
+// separate code.
+//
+// The class leg is re-opened capability-faithfully (withClaimCapableClassLeg)
+// and BOTH halves — the reader assertion and the claim — run against it, so the
+// chain stays unbroken: the leg that serves the bead is the leg the claim writes
+// to. The caller's earlier rows already proved the same reader over the suite's
+// default class leg, so nothing is skipped by the swap.
+func conformanceWorkQueryClaimsWhatItSees(t *testing.T, base splitEnv) {
 	t.Helper()
-	assertClaimStoreCannotResolve(t, e, routedGraphBeadID, "routed")
+	e := base.withClaimCapableClassLeg(t)
+
+	routed := e.mintWispWith(t, wispOpts{title: "routed graph step", routedTo: e.qualified})
+	assertFederatedReaderServes(t, e, routed.ID, "routed", readyOpts{
+		unassigned:     true,
+		metadataFields: []string{beadmeta.RoutedToMetadataKey + "=" + e.qualified},
+		excludeTypes:   []string{"epic"},
+		sortOrder:      readySortOldest,
+		limit:          20,
+	})
+	assertClaimEscalatesOffTheWorkStore(t, e, routed.ID, "routed")
 
 	// The ASSIGNED shape, minted the way graphroute produces it: an OPEN graph
 	// step carrying this worker's identity as its assignee
 	// (graphroute.ApplyGraphRouteBinding sets step.Assignee for a non-pool,
 	// non-direct binding, and molecule materialization writes it through).
 	assigned := e.mintWispWith(t, wispOpts{title: "assigned graph step", assignee: e.qualified})
-	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
-	rows, err := readyBeadsForOpts(legs, readyOpts{
+	assertFederatedReaderServes(t, e, assigned.ID, "assigned", readyOpts{
 		assignee:  e.qualified,
 		sortOrder: readySortOldest,
 		limit:     20,
 	})
+	assertClaimEscalatesOffTheWorkStore(t, e, assigned.ID, "assigned")
+
+	conformanceAssignedTierClaimsTheGraphStep(t, e, assigned.ID)
+	conformanceUnresolvableCandidateStillDoesNotStrandWork(t, e)
+}
+
+// assertFederatedReaderServes asserts the reader the split work_query NAMES
+// answers with graphBeadID, read through the production leg assembly rather than
+// a restatement of it. It is the "sees" half of every see-and-claim row: a claim
+// assertion on a bead the query never served would prove nothing about the
+// command.
+func assertFederatedReaderServes(t *testing.T, e splitEnv, graphBeadID, tier string, opts readyOpts) {
+	t.Helper()
+	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	rows, err := readyBeadsForOpts(legs, opts)
 	if err != nil {
-		t.Fatalf("the reader the split work_query's assigned tier names failed over healthy stores: %v", err)
+		t.Fatalf("the reader the split work_query's %s tier names failed over healthy stores: %v", tier, err)
 	}
-	found := false
 	ids := make([]string, 0, len(rows))
 	for _, row := range rows {
 		ids = append(ids, row.ID)
-		if row.ID == assigned.ID {
-			found = true
+		if row.ID == graphBeadID {
+			return
 		}
 	}
-	if !found {
-		t.Fatalf("the assigned tier's reader answered %v and not the assigned graph step %s; the tier this slice federates is the one a graph step assigned to this worker arrives on, so a pin that never sees it pins nothing", ids, assigned.ID)
-	}
-	assertClaimStoreCannotResolve(t, e, assigned.ID, "assigned")
-
-	conformanceAssignedTierDoesNotStrandClaimableWork(t, e, assigned.ID)
+	t.Fatalf("the %s tier's reader answered %v and not the graph step %s; a see-and-claim row whose reader never sees the bead pins nothing", tier, ids, graphBeadID)
 }
 
-// assertClaimStoreCannotResolve pins today's answer for one federated tier's
-// bead: the store `gc hook --claim` roots its BdStore in cannot resolve it, and
-// it fails with the not-found the claim path classifies as "the bead lives in
-// another store" (hookClaimBeadIsElsewhere). Both halves matter — the first is
-// the gap, the second is what keeps the gap a skipped candidate instead of a
-// bare exit 1 that strands every other store's work.
-func assertClaimStoreCannotResolve(t *testing.T, e splitEnv, graphBeadID, tier string) {
+// assertClaimEscalatesOffTheWorkStore pins one federated tier's bead end to end:
+// the store `gc hook --claim` roots its BdStore in cannot resolve it, it fails
+// with the not-found the claim path classifies as "the bead lives in another
+// store" (hookClaimBeadIsElsewhere), and the class-routed ops therefore escalate
+// the write to the binding and take the bead.
+//
+// All three halves matter and the middle one is load-bearing in the new
+// direction: ErrNotFound is the ONLY error that opens the escalation, so if the
+// work store ever started failing differently the claim would fail CLOSED rather
+// than route, and the first two rows are what would say so.
+func assertClaimEscalatesOffTheWorkStore(t *testing.T, e splitEnv, graphBeadID, tier string) {
 	t.Helper()
 	_, err := e.work.Get(graphBeadID)
 	if err == nil {
-		t.Fatalf("the WORK store resolved the relocated %s-tier graph bead %s. Either `gc hook --claim` is now class-routed — in which case ga-601v2 has landed: drop I15's KNOWN GAP paragraph and assert the claim instead — or the fixture stopped relocating the graph class, which would make this whole invariant vacuous", tier, graphBeadID)
+		t.Fatalf("the WORK store resolved the relocated %s-tier graph bead %s; the fixture stopped relocating the graph class, which would make this whole invariant vacuous", tier, graphBeadID)
 	}
 	if !hookClaimBeadIsElsewhere(err) {
-		t.Fatalf("the WORK store failed on the relocated %s-tier graph bead %s with %v, which the claim path does not classify as \"this store does not hold it\"; the assigned tier would then fail closed and strand every other store's claimable work", tier, graphBeadID, err)
+		t.Fatalf("the WORK store failed on the relocated %s-tier graph bead %s with %v, which the claim path does not classify as \"this store does not hold it\"; the class route would never fire and the claim would fail closed instead", tier, graphBeadID, err)
+	}
+
+	route, err := newHookClaimClassRoute(e.class)
+	if err != nil {
+		t.Fatalf("opening the claim-time class front door: %v", err)
+	}
+	ops := classRoutedHookClaimOps(hookClaimOps{Claim: splitEnvStoreClaim(e.work)}, route)
+	// The claim actor is the worker's own identity, which is what the assigned
+	// tier requires: claimFirstReadyHookAssignment passes the bead's CURRENT
+	// assignee as the actor, because the store's idempotent claim treats a
+	// different actor on an already-assigned bead as a conflict, not a claim.
+	assignee := e.qualified
+	claimed, ok, claimErr := ops.Claim(context.Background(), e.cityPath, nil, graphBeadID, assignee)
+	if claimErr != nil || !ok {
+		t.Fatalf("`gc hook --claim` claim of the relocated %s-tier graph bead %s = (ok=%v err=%v), want a successful claim escalated to the binding; the query serves this bead, so a command that cannot claim it re-serves and re-skips it every tick", tier, graphBeadID, ok, claimErr)
+	}
+	if strings.TrimSpace(claimed.Assignee) != assignee {
+		t.Fatalf("the routed claim of %s returned assignee %q, want %q", graphBeadID, claimed.Assignee, assignee)
+	}
+	if held, err := e.class.Get(graphBeadID); err != nil || strings.TrimSpace(held.Assignee) != assignee {
+		t.Fatalf("the binding holds %s with assignee %q (err=%v), want %q — the claim reported success without landing in the store that owns the bead", graphBeadID, held.Assignee, err, assignee)
 	}
 }
 
-// conformanceAssignedTierDoesNotStrandClaimableWork is the behavioral half of
-// the KNOWN GAP: the visible-but-unclaimable assigned graph step must cost the
-// worker that ONE bead, not its whole tick.
+// conformanceAssignedTierClaimsTheGraphStep drives the whole federated claim
+// command over the shape ga-601v2 exists for: a relocated graph step ASSIGNED to
+// this worker, ranked ahead of everything else by bestStoreWithWork, arriving on
+// the tier claimFirstReadyHookAssignment serves.
 //
-// bestStoreWithWork ranks an assigned candidate ahead of a routed one, so the
-// store holding the unclaimable graph step is selected FIRST. If the assigned
-// tier answered its unresolvable claim with a terminal exit, the federated
-// drop-and-retry loop would never run and the claimable work-ledger bead below
-// would go unclaimed every tick.
+// Before the routing this produced the treadmill — the step was re-served and
+// re-skipped every tick while the worker claimed something else — so the
+// assertion is that the command now returns THE GRAPH STEP, not the consolation
+// work-ledger bead beside it.
 //
-// The claim is driven through the fixture's real WORK store, so the not-found is
-// the store's own answer rather than a restatement of it.
-func conformanceAssignedTierDoesNotStrandClaimableWork(t *testing.T, e splitEnv, assignedGraphBeadID string) {
+// The base claim is bound to the fixture's real WORK store, so the not-found the
+// escalation keys on is the store's own answer rather than a restatement of it.
+func conformanceAssignedTierClaimsTheGraphStep(t *testing.T, e splitEnv, assignedGraphBeadID string) {
 	t.Helper()
+	route, err := newHookClaimClassRoute(e.class)
+	if err != nil {
+		t.Fatalf("opening the claim-time class front door: %v", err)
+	}
 	claimable, err := e.work.Create(beads.Bead{
 		Title:    "claimable work-ledger bead",
 		Type:     "task",
@@ -1948,7 +2191,7 @@ func conformanceAssignedTierDoesNotStrandClaimableWork(t *testing.T, e splitEnv,
 		}
 		return `[{"id":"` + claimable.ID + `","status":"open","metadata":{"` + beadmeta.RoutedToMetadataKey + `":"` + e.qualified + `"}}]`, nil
 	}
-	ops := hookClaimOps{
+	ops := classRoutedHookClaimOps(hookClaimOps{
 		Claim:             splitEnvStoreClaim(e.work),
 		EmitClaimRejected: func(string, string, string) {},
 		ResolveWorkBranch: func(string) string { return "" },
@@ -1956,7 +2199,7 @@ func conformanceAssignedTierDoesNotStrandClaimableWork(t *testing.T, e splitEnv,
 			return nil
 		},
 		DrainAck: func(io.Writer) error { return nil },
-	}
+	}, route)
 	opts := hookClaimOptions{
 		Assignee:           e.qualified,
 		IdentityCandidates: []string{e.qualified},
@@ -1967,14 +2210,95 @@ func conformanceAssignedTierDoesNotStrandClaimableWork(t *testing.T, e splitEnv,
 	var stdout, stderr bytes.Buffer
 	code := claimHookWorkWithRunner("gc ready --json", e.cityPath, stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("gc hook --claim exited %d with the relocated assigned step %s ranked first; one unclaimable graph step must not strand the worker's other claimable work (stdout=%q stderr=%q)", code, assignedGraphBeadID, stdout.String(), stderr.String())
+		t.Fatalf("gc hook --claim exited %d with the relocated assigned step %s ranked first (stdout=%q stderr=%q)", code, assignedGraphBeadID, stdout.String(), stderr.String())
+	}
+	var result hookClaimJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("gc hook --claim stdout is not JSON: %v\nraw: %q", err, stdout.String())
+	}
+	if result.BeadID != assignedGraphBeadID {
+		t.Fatalf("gc hook --claim result = %+v, want the relocated assigned graph step %s — the worker claimed something else, which is the re-serve/re-skip treadmill ga-601v2 closes", result, assignedGraphBeadID)
+	}
+	if held, err := e.class.Get(assignedGraphBeadID); err != nil || !strings.EqualFold(strings.TrimSpace(held.Status), "in_progress") {
+		t.Fatalf("the binding holds %s with status %q (err=%v), want in_progress — the command reported a claim it did not write", assignedGraphBeadID, held.Status, err)
+	}
+}
+
+// conformanceUnresolvableCandidateStillDoesNotStrandWork keeps the property that
+// made ga-bvdha shippable on its own: a candidate NO store can resolve costs the
+// worker that ONE bead, not its whole tick.
+//
+// Class routing removes the common cause of that skip, not the skip — a routed
+// id whose bead was deleted, a stale row in a work query's captured output, an
+// id in neither ledger — and the assigned tier is where it matters, because
+// bestStoreWithWork ranks an assigned candidate ahead of a routed one and
+// therefore selects the store holding the unclaimable one FIRST. If that tier
+// answered with a terminal exit, the federated drop-and-retry loop would never
+// run and the claimable bead below would go unclaimed every tick.
+//
+// The claim is driven through the fixture's real WORK store with the class route
+// installed, so the not-found is a store's own answer at BOTH legs.
+func conformanceUnresolvableCandidateStillDoesNotStrandWork(t *testing.T, e splitEnv) {
+	t.Helper()
+	classPrefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("config.ReservedClassPrefix(graph) = ok:false")
+	}
+	// A reserved-prefix id neither store holds: the class binding is the only
+	// place it could live, and it does not live there either.
+	assignedGraphBeadID := classPrefix + "-deleted-under-us"
+	if _, err := e.class.Get(assignedGraphBeadID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("the binding resolved %s (err=%v); this row needs an id NO store holds", assignedGraphBeadID, err)
+	}
+	route, err := newHookClaimClassRoute(e.class)
+	if err != nil {
+		t.Fatalf("opening the claim-time class front door: %v", err)
+	}
+	claimable, err := e.work.Create(beads.Bead{
+		Title:    "claimable work-ledger bead behind an unresolvable candidate",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: e.qualified},
+	})
+	if err != nil {
+		t.Fatalf("minting claimable work-ledger bead: %v", err)
+	}
+	stores := []hookStore{
+		{dir: e.cityPath, env: []string{"GC_HOOK_LEG=assigned"}},
+		{dir: e.cityPath, env: []string{"GC_HOOK_LEG=routed"}},
+	}
+	run := func(_, _ string, env []string) (string, error) {
+		if len(env) > 0 && env[0] == "GC_HOOK_LEG=assigned" {
+			return `[{"id":"` + assignedGraphBeadID + `","status":"open","assignee":"` + e.qualified + `"}]`, nil
+		}
+		return `[{"id":"` + claimable.ID + `","status":"open","metadata":{"` + beadmeta.RoutedToMetadataKey + `":"` + e.qualified + `"}}]`, nil
+	}
+	ops := classRoutedHookClaimOps(hookClaimOps{
+		Claim:             splitEnvStoreClaim(e.work),
+		EmitClaimRejected: func(string, string, string) {},
+		ResolveWorkBranch: func(string) string { return "" },
+		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
+			return nil
+		},
+		DrainAck: func(io.Writer) error { return nil },
+	}, route)
+	opts := hookClaimOptions{
+		Assignee:           e.qualified,
+		IdentityCandidates: []string{e.qualified},
+		RouteTargets:       []string{e.qualified},
+		JSON:               true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claimHookWorkWithRunner("gc ready --json", e.cityPath, stores[0].env, stores, opts, ops, run, func(string, error) {}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc hook --claim exited %d with an unresolvable assigned candidate ranked first; one candidate no store holds must not strand the worker's other claimable work (stdout=%q stderr=%q)", code, stdout.String(), stderr.String())
 	}
 	var result hookClaimJSONResult
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("gc hook --claim stdout is not JSON: %v\nraw: %q", err, stdout.String())
 	}
 	if result.BeadID != claimable.ID {
-		t.Fatalf("gc hook --claim result = %+v, want the claimable work-ledger bead %s reached past the unclaimable assigned step", result, claimable.ID)
+		t.Fatalf("gc hook --claim result = %+v, want the claimable work-ledger bead %s reached past the unresolvable assigned candidate", result, claimable.ID)
 	}
 }
 

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -659,13 +659,12 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 // --claim` ISSUES, through the production ops seam, for the three id shapes a
 // split city can hand it.
 //
-// The class leg is re-opened capability-faithfully (withClaimCapableClassLeg):
-// a routed claim acquires through the binding's own CAS, which the production
-// SQLite binding has and the kit's MemStore leaf does not. The route is then
-// opened over that binding — what graphClassBinding(ce.routes) resolves to — so
-// the write lands where the row minted the bead. The base Claim is bound to the
-// fixture's real WORK store, so the not-found that opens the escalation is the
-// store's own answer rather than a restatement of one.
+// The route is opened over the fixture's class leg — a real beads.SQLiteStore,
+// what graphClassBinding(e.routes) resolves to — so the routed claim acquires
+// through the binding's own compare-and-swap and the write lands where the row
+// minted the bead. The base Claim is bound to the fixture's real WORK store, so
+// the not-found that opens the escalation is the store's own answer rather than
+// a restatement of one.
 //
 // The CO-RESIDENT row is the one that states the tie-break, and it is the
 // migrated-city steady state: `gc storage migrate` copies with ids preserved and
@@ -674,9 +673,8 @@ func conformanceClaimRouting(t *testing.T, e splitEnv) {
 // work row (#5148 leg order, ready_federation.go). A class-first claim here would
 // leave the reader's work row open and re-serve the bead every tick — the exact
 // treadmill ga-601v2 closes.
-func conformanceHookClaimClassRouting(t *testing.T, base splitEnv, workBeadID string) {
+func conformanceHookClaimClassRouting(t *testing.T, e splitEnv, workBeadID string) {
 	t.Helper()
-	e := base.withClaimCapableClassLeg(t)
 	route, err := newHookClaimClassRoute(e.class)
 	if err != nil {
 		t.Fatalf("opening the claim-time class front door over the fixture's class store: %v", err)
@@ -723,60 +721,79 @@ func conformanceHookClaimClassRouting(t *testing.T, base splitEnv, workBeadID st
 		}
 	}
 
-	assertClassRoutedClaimHasNoReleaseTier(t, e)
+	assertClassRoutedClaimIsReleasable(t, e)
 }
 
-// assertClassRoutedClaimHasNoReleaseTier is the KNOWN GAP the routed claim
-// CREATES, pinned rather than described — the release tier does not follow the
-// claim.
+// assertClassRoutedClaimIsReleasable is the other half of the routed claim: the
+// release tier reaches what the claim can now write.
 //
-// Everything that takes a claim back is still work-only:
+// The claim can leave an in_progress assignee in the BINDING, so a crashed
+// worker would strand a graph step forever if nothing that takes a claim back
+// could see it. Two scans have to be checked, and they lead with different
+// stores:
 //
-//   - the crash-recovery work-query tier (`bd list --status in_progress` in the
-//     agent's work directory, plus its `bd show` enrichment),
-//   - on_death and on_boot (`bd list` + `bd update`, likewise),
-//   - the post-close sweep unclaimWorkAssignedToRetiredSessionBead, whose store
-//     set is workAssignmentStores(city, rigs) and whose call site in
-//     cmd_session.go says in as many words that it "is WORK-class and stays on
-//     the generic store".
+//   - the reconciler's (stranded-repair, named retirement, the closeBead
+//     cascade) leads with the SESSIONS-class store, which on a converged split
+//     is the same engine the graph class is served from — openStorageRoutes keys
+//     every assigned class to the one store it opened — so it already reads the
+//     binding. That is a property of the topology rather than of any call site,
+//     which is exactly why it is asserted rather than assumed.
+//   - `gc session close` leads with the WORK store (openCityStore), so it cannot
+//     see the binding on its own and is handed the graph binding as a class leg.
 //
-// internal/config's TestQueryKindsWithoutAReadyReadAreTopologyBlind pins the
-// first two from the query side. This row pins the third and states the
-// consequence, which the claim routing changes in KIND: before it, a relocated
-// graph step never reached in_progress at all (the claim failed and the tier
-// re-served it, loudly, every tick); after it, the step goes in_progress in the
-// binding, and if the worker dies there nothing that could release it can see
-// it. The loud treadmill is gone and a quiet strand is possible in its place.
-//
-// It is NOT closed here, deliberately. A federated release is a status LIST and
-// a WRITE across stores on the session-retirement path — a different seam from
-// claim-time write routing, with its own failure modes — and this program has a
-// standing rule against widening a slice past what it was scoped to. It is
-// ga-zp3uj; when that lands, this row flips to found-and-released and this
-// paragraph goes with it.
-func assertClassRoutedClaimHasNoReleaseTier(t *testing.T, e splitEnv) {
+// What is NOT closed here, and is ga-zp3uj: the agent-side recovery tiers
+// (`bd list --status in_progress`, on_death, on_boot) are raw bd commands in the
+// agent's work directory, so they stay topology-blind — internal/config's
+// TestQueryKindsWithoutAReadyReadAreTopologyBlind pins that from the query side.
+// Those re-serve a strand rather than losing it, because the reconciler scan
+// above is what releases it.
+func assertClassRoutedClaimIsReleasable(t *testing.T, e splitEnv) {
 	t.Helper()
-	for i, store := range workAssignmentStores(e.work, e.rigStores) {
-		if sameStorePtr(store, e.class) {
-			t.Fatalf("workAssignmentStores leg %d is the class binding; the release tier now follows the claim, so this KNOWN GAP row and its paragraph should be replaced by a found-and-released assertion", i)
+	for _, tt := range []struct {
+		name    string
+		leading beads.Store
+		class   []beads.Store
+	}{
+		{
+			name:    "reconciler scan — leads with the sessions-class store, which IS the binding",
+			leading: e.sessionsStore(),
+		},
+		{
+			name:    "gc session close — leads with the work store and is handed the binding",
+			leading: e.work,
+			class:   []beads.Store{e.class},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if !workAssignmentStoresReach(workAssignmentStores(tt.leading, e.rigStores, tt.class...), e.class) {
+				t.Fatalf("no leg of the release scan is the class binding; a claim routed there is released by nothing")
+			}
+			sessionBead := beads.Bead{ID: "gcg-retired-session", Metadata: map[string]string{"session_name": "worker-1"}}
+			step := e.mintWispWith(t, wispOpts{
+				title:    "graph step claimed by a session that then died",
+				status:   "in_progress",
+				assignee: sessionBead.ID,
+			})
+			unclaimWorkAssignedToRetiredSessionBead(tt.leading, e.rigStores, sessionBead, "", io.Discard, tt.class...)
+			released, err := e.class.Get(step.ID)
+			if err != nil {
+				t.Fatalf("reading the claimed graph step back from the binding: %v", err)
+			}
+			if !strings.EqualFold(strings.TrimSpace(released.Status), "open") || strings.TrimSpace(released.Assignee) != "" {
+				t.Fatalf("the retired-session sweep left the binding-resident step %s as status=%q assignee=%q; a routed claim whose session died must be released, not stranded", step.ID, released.Status, released.Assignee)
+			}
+		})
+	}
+}
+
+// workAssignmentStoresReach reports whether want is one of the scanned legs.
+func workAssignmentStoresReach(stores []beads.Store, want beads.Store) bool {
+	for _, store := range stores {
+		if sameStorePtr(store, want) {
+			return true
 		}
 	}
-
-	sessionBead := beads.Bead{ID: "gcg-retired-session", Metadata: map[string]string{"session_name": "worker-1"}}
-	step := e.mintWispWith(t, wispOpts{
-		title:    "graph step claimed by a session that then died",
-		status:   "in_progress",
-		assignee: sessionBead.ID,
-	})
-	unclaimWorkAssignedToRetiredSessionBead(e.work, e.rigStores, sessionBead, "", io.Discard)
-	stranded, err := e.class.Get(step.ID)
-	if err != nil {
-		t.Fatalf("reading the claimed graph step back from the binding: %v", err)
-	}
-	if !strings.EqualFold(strings.TrimSpace(stranded.Status), "in_progress") ||
-		strings.TrimSpace(stranded.Assignee) != sessionBead.ID {
-		t.Fatalf("the retired-session sweep released the binding-resident step %s (status=%q assignee=%q); the release tier reaches the binding now, so this KNOWN GAP has closed: replace this row with a found-and-released assertion and drop its paragraph", step.ID, stranded.Status, stranded.Assignee)
-	}
+	return false
 }
 
 // defaultedHookClaimOps is the production claim-op set with every seam filled —
@@ -1280,9 +1297,20 @@ func conformanceReadPathConsistency(t *testing.T, e splitEnv) {
 	}
 }
 
-// conformanceGraphRecipe is the durable graph.v2 workflow shape: a root plus one
-// finalize step, wired parent-child and blocks the way a compiled v2 formula
-// wires them.
+// conformanceGraphRecipe is the durable graph.v2 workflow shape a compiled v2
+// formula actually produces: a root plus one finalize step, wired with the ONE
+// root -> finalize `blocks` edge and no parent-child edge at all.
+//
+// The missing parent-child edge is the point. internal/formula/compile.go gates
+// both of its parent-child emitters on `!graphWorkflow`, and addWorkflowRootDeps
+// emits only the blocks edge, so a graph.v2 recipe carries zero parent-child
+// deps — measured over the core pack's v2 formulas. This recipe used to add one
+// by hand, which is the only reason materializing it on the real SQLite backend
+// tripped sqlite_store_graph_apply.go's reverse-of-a-parent-child guard: that
+// guard reads sqliteGraphApplyParentDepPairs, which is built from ParentID,
+// which on a recipe plan is set only by a `parent-child` dep. A fixture that
+// carries an edge the compiler cannot emit turns a production-shaped invariant
+// into a statement about the fixture.
 func conformanceGraphRecipe() *formula.Recipe {
 	return &formula.Recipe{
 		Name: "conformance-graph",
@@ -1305,7 +1333,6 @@ func conformanceGraphRecipe() *formula.Recipe {
 			},
 		},
 		Deps: []formula.RecipeDep{
-			{StepID: "conformance-graph.workflow-finalize", DependsOnID: "conformance-graph", Type: "parent-child"},
 			{StepID: "conformance-graph", DependsOnID: "conformance-graph.workflow-finalize", Type: "blocks"},
 		},
 	}
@@ -1947,13 +1974,14 @@ func fixtureGraphLeg(e splitEnv) beads.Store {
 //     closing the gap must not spend it — a routed claim removes the common
 //     cause of the skip, not the skip.
 //
-// What the closure does NOT reach is the RELEASE tier: crash recovery
-// (`bd list --status in_progress`), on_death/on_boot, and the retired-session
-// sweep are all still work-only, so a routed claim can now strand a
-// binding-resident step in_progress where nothing that could release it can see
-// it. That gap is ga-zp3uj, pinned on I5
-// (assertClassRoutedClaimHasNoReleaseTier) and, from the query side, by
-// internal/config's TestQueryKindsWithoutAReadyReadAreTopologyBlind.
+// The RELEASE tier follows the claim, and is asserted on I5 rather than assumed
+// (assertClassRoutedClaimIsReleasable): the reconciler's retired-session scan
+// leads with the sessions-class store, which on a converged split is the engine
+// the graph class is served from, and `gc session close` — which leads with the
+// work store — is handed the binding as a class leg. What stays topology-blind
+// is the AGENT-side recovery (`bd list --status in_progress`, on_death,
+// on_boot), which is raw bd in the agent's work directory: that is ga-zp3uj, and
+// it re-serves rather than loses, because the reconciler scan releases.
 func conformanceWorkQueryFederation(t *testing.T, e splitEnv) {
 	agentCfg := e.cfg.Agents[0]
 	topo := cityQueryTopology(e.cityPath, e.cfg)
@@ -2056,14 +2084,11 @@ func conformanceWorkQueryFederation(t *testing.T, e splitEnv) {
 // reaches claimFirstReadyHookAssignment, whose unresolvable-id branch is
 // separate code.
 //
-// The class leg is re-opened capability-faithfully (withClaimCapableClassLeg)
-// and BOTH halves — the reader assertion and the claim — run against it, so the
-// chain stays unbroken: the leg that serves the bead is the leg the claim writes
-// to. The caller's earlier rows already proved the same reader over the suite's
-// default class leg, so nothing is skipped by the swap.
-func conformanceWorkQueryClaimsWhatItSees(t *testing.T, base splitEnv) {
+// BOTH halves — the reader assertion and the claim — run against the same class
+// leg, so the chain stays unbroken: the leg that serves the bead is the leg the
+// claim writes to.
+func conformanceWorkQueryClaimsWhatItSees(t *testing.T, e splitEnv) {
 	t.Helper()
-	e := base.withClaimCapableClassLeg(t)
 
 	routed := e.mintWispWith(t, wispOpts{title: "routed graph step", routedTo: e.qualified})
 	assertFederatedReaderServes(t, e, routed.ID, "routed", readyOpts{

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -47,11 +47,15 @@ import (
 //
 //   - work: BdSemantics, minting "gc-" — bd/Dolt, which hard-fails a mismatched
 //     --id and an unresolvable dep endpoint.
-//   - class: SQLiteSemantics, minting the graph class's reserved "gcg-" — the
-//     store internal/storebinding/sqlite's OpenEngine opens for the whole split
-//     (ONE engine serving all five infrastructure classes, opened with
+//   - class: a REAL beads.SQLiteStore behind SQLiteSemantics, minting the graph
+//     class's reserved "gcg-" — the store internal/storebinding/sqlite's
+//     OpenEngine opens for the whole split (ONE engine serving all five
+//     infrastructure classes, opened with
 //     config.ReservedClassPrefix(BeadClassGraph)). It ACCEPTS a residence
-//     violation and records it, because SQLite does.
+//     violation and records it, because SQLite does — and it carries the two
+//     capabilities the binding really has and a MemStore leaf does not: the
+//     compare-and-swap assignment claim a routed claim acquires through, and
+//     the graph applier. See newSplitEnvClassLeaf.
 //
 // The wrapping is asymmetric on purpose, and the asymmetry is production's, not
 // the fixture's: main.go and api_state.go put every WORK store (city and rig)
@@ -68,8 +72,8 @@ import (
 // production no longer serves, because nothing else in cmd/gc asserts the
 // wrapping of the store that function returns.
 //
-// Accepted fidelity gap, the same one every cmd/gc split fixture takes: the
-// leaves are in-memory, not real Dolt/SQLite behind CachingStore. The real
+// Accepted fidelity gap: the WORK leaf is in-memory rather than real bd/Dolt
+// behind CachingStore (the class leaf is a real SQLite store on disk). The real
 // openers are covered by the managed-Dolt and storage-boot integration tests.
 
 // splitEnv is the two-topology store fixture. Every field carries the production
@@ -163,8 +167,7 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 			BDCompatibility: config.BeadsBDCompatibility105,
 		},
 	}
-	workLeaf, classLeaf := splittest.NewSplitStores(t)
-	work := wrapStoreWithBeadPolicies(workLeaf, cfg)
+	work := wrapStoreWithBeadPolicies(splittest.NewWorkStore(t, config.EffectiveHQPrefix(cfg)), cfg)
 	e := splitEnv{cityPath: cityPath, cfg: cfg, work: work, store: work, split: split}
 	if split {
 		// Config and routes state the same relocation. The config half is what
@@ -175,8 +178,8 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 		cfg.Storage = splitEnvStorageConfig()
 		// The class store is NOT policy-wrapped: openStorageRoutes keys the class
 		// map straight to the value OpenEngine returned. See the file header.
-		e.class = classLeaf
-		e.routes = splitEnvRoutes(classLeaf)
+		e.class = newSplitEnvClassLeaf(t)
+		e.routes = splitEnvRoutes(e.class)
 	}
 	writeSplitTopologyCityConfig(t, cityPath, rigPath, split)
 	if opts.rig {
@@ -185,36 +188,25 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 	return e
 }
 
-// withClaimCapableClassLeg returns a copy of e whose class leg is re-opened on a
-// REAL beads.SQLiteStore — the store internal/storebinding/sqlite's OpenEngine
-// actually hands a split city, opened with the same reserved graph prefix.
+// newSplitEnvClassLeaf opens the class leg on the store a split city is really
+// served from: a real beads.SQLiteStore under the graph class's reserved prefix,
+// which is what internal/storebinding/sqlite's OpenEngine opens, behind the
+// kit's SQLiteSemantics strictness so a residence violation is still recorded.
 //
-// It exists because of a CAPABILITY, not a preference, and the direction of the
-// fidelity gap is the opposite of the one the kit warns about on
-// StrictStore.Count. A relocated-class claim acquires through the closed
-// contract's Claim (storebinding.NewBeadsGraphStore over the binding), which
-// *beads.SQLiteStore implements and beads.MemStore does not — so the kit's
-// default class leaf answers "assignment claim unsupported" and every
-// routed-claim assertion built on it would pin the fixture's limitation instead
-// of the program's behavior.
+// It is the real backend rather than the kit's MemStore leaf because the two
+// differ in exactly the ways this suite exists to catch: the SQLite store has
+// the compare-and-swap assignment claim a routed claim acquires through, and it
+// has the graph applier whose reverse-of-a-parent-child guard is the one thing
+// the binding enforces that a MemStore does not. A suite whose class leaf has
+// neither cannot see a divergence in either.
 //
-// It is scoped to the rows that need it rather than made the suite-wide class
-// leg, and that scoping is itself a finding rather than timidity: the SQLite
-// leaf has a graph applier and the MemStore leaf has none, so swapping it
-// wholesale makes conformanceResidenceSweep's molecule materialization fail with
-// "sqlite graph apply: edge N gcg-x->gcg-y creates a blocking reverse of a
-// parent-child relationship" — the root -> workflow-finalize `blocks` edge
-// internal/formula/compile.go emits, refused by the real backend. That is a
-// production question about graph.v2 on a split city and belongs to its own
-// slice, not to claim routing.
-//
-// Everything else — cfg, city path, work store, rig leg — is shared, so the row
-// still runs the same city on the same two topologies.
-func (e splitEnv) withClaimCapableClassLeg(t *testing.T) splitEnv {
+// (The claim rows were briefly scoped to a per-row helper because materializing
+// conformanceGraphRecipe on this leaf failed the graph-apply guard. That was the
+// fixture recipe carrying a hand-written parent-child dep no graph.v2 compiler
+// emits — see conformanceGraphRecipe — not a property of graph.v2 on a split
+// city.)
+func newSplitEnvClassLeaf(t *testing.T) beads.Store {
 	t.Helper()
-	if !e.split {
-		t.Fatal("withClaimCapableClassLeg is a split-topology helper; a single-store city has no binding to re-open")
-	}
 	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
 	if !ok {
 		t.Fatal("config.ReservedClassPrefix(graph) = ok:false; the fixture has no reserved namespace to open a class store under")
@@ -228,11 +220,7 @@ func (e splitEnv) withClaimCapableClassLeg(t *testing.T) splitEnv {
 			_ = closer.CloseStore()
 		}
 	})
-	binding := splittest.Strict(t, leaf, splittest.SQLiteSemantics)
-	out := e
-	out.class = binding
-	out.routes = splitEnvRoutes(binding)
-	return out
+	return splittest.Strict(t, leaf, splittest.SQLiteSemantics)
 }
 
 // splitEnvStorageConfig is the [storage] section of a converged split city: work

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -185,6 +185,56 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 	return e
 }
 
+// withClaimCapableClassLeg returns a copy of e whose class leg is re-opened on a
+// REAL beads.SQLiteStore — the store internal/storebinding/sqlite's OpenEngine
+// actually hands a split city, opened with the same reserved graph prefix.
+//
+// It exists because of a CAPABILITY, not a preference, and the direction of the
+// fidelity gap is the opposite of the one the kit warns about on
+// StrictStore.Count. A relocated-class claim acquires through the closed
+// contract's Claim (storebinding.NewBeadsGraphStore over the binding), which
+// *beads.SQLiteStore implements and beads.MemStore does not — so the kit's
+// default class leaf answers "assignment claim unsupported" and every
+// routed-claim assertion built on it would pin the fixture's limitation instead
+// of the program's behavior.
+//
+// It is scoped to the rows that need it rather than made the suite-wide class
+// leg, and that scoping is itself a finding rather than timidity: the SQLite
+// leaf has a graph applier and the MemStore leaf has none, so swapping it
+// wholesale makes conformanceResidenceSweep's molecule materialization fail with
+// "sqlite graph apply: edge N gcg-x->gcg-y creates a blocking reverse of a
+// parent-child relationship" — the root -> workflow-finalize `blocks` edge
+// internal/formula/compile.go emits, refused by the real backend. That is a
+// production question about graph.v2 on a split city and belongs to its own
+// slice, not to claim routing.
+//
+// Everything else — cfg, city path, work store, rig leg — is shared, so the row
+// still runs the same city on the same two topologies.
+func (e splitEnv) withClaimCapableClassLeg(t *testing.T) splitEnv {
+	t.Helper()
+	if !e.split {
+		t.Fatal("withClaimCapableClassLeg is a split-topology helper; a single-store city has no binding to re-open")
+	}
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("config.ReservedClassPrefix(graph) = ok:false; the fixture has no reserved namespace to open a class store under")
+	}
+	leaf, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix(prefix))
+	if err != nil {
+		t.Fatalf("opening the SQLite class store the split binding serves from: %v", err)
+	}
+	t.Cleanup(func() {
+		if closer, ok := leaf.(interface{ CloseStore() error }); ok {
+			_ = closer.CloseStore()
+		}
+	})
+	binding := splittest.Strict(t, leaf, splittest.SQLiteSemantics)
+	out := e
+	out.class = binding
+	out.routes = splitEnvRoutes(binding)
+	return out
+}
+
 // splitEnvStorageConfig is the [storage] section of a converged split city: work
 // on the reserved binding, all five infrastructure classes on one shared
 // binding. It is the only arrangement this build serves (storageSplitWhole).

--- a/internal/beads/splittest/strict_store.go
+++ b/internal/beads/splittest/strict_store.go
@@ -140,6 +140,7 @@ var (
 	_ beads.BatchDeleter                     = (*StrictStore)(nil)
 	_ beads.ForeignIDCreator                 = (*StrictStore)(nil)
 	_ beads.Counter                          = (*StrictStore)(nil)
+	_ assignmentClaimer                      = (*StrictStore)(nil)
 	_ beads.GraphApplyHandleProvider         = (*StrictStore)(nil)
 	_ beads.AtomicTxStore                    = (*StrictStore)(nil)
 	_ beads.ParentProjectionWaiter           = (*StrictStore)(nil)
@@ -471,6 +472,39 @@ func (s *StrictStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error
 		return false, beads.ErrConditionalReleaseUnsupported
 	}
 	return releaser.ReleaseIfCurrent(id, expectedAssignee)
+}
+
+// assignmentClaimer is the acquire half of the claim pair, discovered on the
+// leaf the same way beads.ConditionalAssignmentReleaser is. It is declared here
+// rather than in internal/beads because the canonical Store surface deliberately
+// has no claim method — internal/storebinding declares the identical shape for
+// the identical reason (beadsAssignmentClaimer), and only the relocated
+// coordination-class front door reaches it.
+type assignmentClaimer interface {
+	Claim(id, assignee string) (beads.Bead, bool, error)
+}
+
+// Claim forwards the leaf's two-argument assignment claim — the acquire dual of
+// ReleaseIfCurrent, and the CAS the class front door
+// (storebinding.NewBeadsGraphStore) routes a claim through. A leaf without one
+// errors rather than emulating the compare-and-swap with a read-then-write,
+// which would lose the single-winner guarantee the contract promises.
+//
+// FIDELITY GAP, the mirror of Count's. Declaring this method makes every kit
+// store satisfy the claimer assertion, and only the CLASS side of a split
+// matches production there: the relocated binding is a *beads.SQLiteStore, which
+// claims, while the work side is bd, whose BdStore.Claim takes the assignee
+// implicitly (one argument) and does not satisfy this shape at all. So a leaf
+// backed by beads.MemStore satisfies the assertion and then fails the call. A
+// fixture whose subject is a routed CLAIM must therefore use a real SQLite leaf
+// for the class store, not a MemStore one, or it pins the kit's limitation
+// instead of the program's behavior.
+func (s *StrictStore) Claim(id, assignee string) (beads.Bead, bool, error) {
+	claimer, ok := s.Store.(assignmentClaimer)
+	if !ok {
+		return beads.Bead{}, false, fmt.Errorf("strict store: leaf store %T does not support assignment claim", s.Store)
+	}
+	return claimer.Claim(id, assignee)
 }
 
 // DeleteBatch forwards the leaf's orphan-preserving batch delete. A leaf without


### PR DESCRIPTION
> **RETRACTION (2026-08-10).** An earlier revision of this PR and of `withClaimCapableClassLeg`'s doc comment claimed that materializing a graph.v2 molecule on the real SQLite binding fails on "the root → `workflow-finalize` `blocks` edge `internal/formula/compile.go` emits, refused by the real backend", and called that "a production question about graph.v2 on a split city". **That was wrong, and it is withdrawn.** No production graph.v2 recipe can trip that guard: `internal/formula/compile.go` gates both parent-child emitters on `!graphWorkflow`, and the SQLite guard fires only on `sqliteGraphApplyParentDepPairs`, which is built from a `parent-child` dep. The refusal came from `conformanceGraphRecipe()` carrying a hand-written `parent-child` dep no v2 compiler emits. That fixture dep is deleted here, the real SQLite leaf is now the **suite-wide** class leg, and `withClaimCapableClassLeg` is gone. There is no graph.v2-on-a-split-city hazard to investigate.

Closes the last implementation bead of the split-store program: **ga-601v2 — claim-time write routing by class**. The live-city proof (`ga-iaj7k`) was blocked only on this.

## The problem, and it was user-visible

`gc hook --claim` issued every claim-time write through `beads.NewBdStore(dir, …)` — a bd subprocess rooted in the agent's WORK directory. A relocated coordination class is not a bd workspace and cannot be expressed as a `hookStore{dir, env}` at all, so on a split city those writes ran against a ledger that could not see the bead.

ga-bvdha (#5161) made that visible: the generated work query now reads through the federated `gc ready`, so a relocated graph step assigned to a worker **is served** — and was then skipped every tick with `action=drain reason=claims_errored`. No worker ever ran it.

The red-before string, from `TestSplitTopologyConformance/I15-work-query-federation/split` with the routing disabled, is exactly that bug:

```
gc hook --claim result = {… BeadID:gc-1 Assignee:rig-A/executor …}, want the
relocated assigned graph step gcg-wisp-0003 — the worker claimed something else,
which is the re-serve/re-skip treadmill ga-601v2 closes
```

## Where the claim resolves its store, and why that shape

New file `cmd/gc/claim_class_route.go` adds a **CLASS axis to the existing `hookClaimOps` seam**, beside the rig axis already in `claim_cross_store.go` — not a parallel claim path, and **not a new leg in the query fan-out**: a binding is not a workspace, which is the same sentence the I5 pin used to explain why the gap existed.

Wrapped seams: `Claim`, `StampWorkMeta`, `ReadWorkMeta`, `ListContinuation`, `AssignContinuation`, `EmitExecutionStepStarted`.

**Probe, not prefix.** `gc storage migrate` preserves ids, so a relocated bead keeps its HQ/rig-era prefix and a prefix route would miss exactly the beads that moved. The store is found by asking which one holds the bead — the same reason `bdByIDClassDoor.resolve` probes residence.

**WORK first, and that is deliberately NOT the by-id order.**

| resolver | order | why |
| --- | --- | --- |
| `storeref.ClassCandidates`, `bdByIDClassDoor` | class first | caller holds only an id |
| `gc ready` (#5148/#5158/#5161) | city work first, graph leg **last** | co-resident id dedupes to the work row |
| **this claim** | **work first** | must agree with the reader that served its candidate |

The claim runs the existing work-scope write and escalates only where it answers. A class-first claim would take the class copy while the federated reader keeps answering from the still-open work copy — re-serving the bead every tick, which is the treadmill this PR closes, reintroduced one layer down. `TestClassRoutedClaimKeepsTheWorkCopyOnCoResidence` and I5's co-resident row assert it; mutating the order to class-first reddens both.

**The escalation signal is the existing one, unwidened.** `beads.ErrNotFound` is the only error that proves the bead is not in the store the write ran against (`hookClaimBeadIsElsewhere`). A write timeout, store contention or a controller-socket flap leaves ownership unresolved and is returned unchanged, never retried against a second store (`TestClassRoutedClaimFailsClosedOnEveryOtherError`). A read failure from the binding surfaces rather than being read as absence; the one-shot funnel's standing refusal is handled exactly as `classRoutedStoreForID` handles it.

`ListContinuation` is the one claim-time call with no not-found to escalate on, so it escalates on **empty** and only when the binding holds the group's root — monotone, so a work answer is never replaced, only an absence filled. A list error still fails loud, which is the branch bug this seam was warned about.

The CAS stays the store's: claims go through `storebinding.GraphStore.Claim`, the same acquire half `gc bd update --claim` routes through (#5132), never a read-then-write here. `hookClaimWithBdStore`'s post-mutation classification is factored into `hookClaimThroughStore` and shared, so the two claim paths report a lost race, a stale projection and a failed canonical readback identically.

## Review fixes on this revision

Six majors from the review council, each with a red-before row.

**1. A committed work claim is never escalated (findings 2 + 5).** `ops.Claim` passed only the error to `route.routes`, never `ok`. `hookClaimThroughStore` returns `(claimed, true, err)` for exactly one shape — the CAS COMMITTED and the canonical readback then failed — and `BdStore.Get` wraps `ErrNotFound` for a plain miss, an empty result AND `beads.ErrIDCollision`, so that readback failure routinely satisfied the predicate on a claim that had landed. The wrapper then claimed the same logical bead a second time in the binding and returned `err=nil`, erasing the signal both call sites stop on. Now `if ok { return claimed, ok, err }` before the escalation, matching `claimFirstReadyHookAssignment`'s own `!ok && hookClaimBeadIsElsewhere(err)`.

```
claim_class_route_test.go:444: routed claim returned err=<nil>, want the canonical-readback failure
  reloading claimed bead "gcg-b00": getting bead "gcg-b00": bead not found  returned unchanged
claim_class_route_test.go:444: … reloading claimed bead "gcg-b00": bd resolved a different bead ID
  (substring collision): bead not found  returned unchanged
```

**2. A binding-side claim refusal is per-bead, not per-tick (finding 1).** `*beads.SQLiteStore` is the only production store with the two-argument CAS; the other compiled-in binding provider (`beadsworkspace`, over `*beads.NativeDoltStore`) has none, so `storebinding.ErrBeadsAdapterCapability` came back — not `ErrNotFound`, so the WHOLE tick exited 1 and the worker claimed nothing, including healthy work in other stores. Both halves of the fix landed:

- **at the door**: `newHookClaimClassRoute` verifies the CAS once, the way `storebinding.NewBeadsNudgeQueue` verifies the same capability at construction, and `hookClaimRouteVerdict` degrades that ONE error to unrouted claiming with a loud line. A boot-time refusal in `openStorageRoutes` was considered and rejected: it would take a configuration that boots and serves reads today (`TestStorageGateServesACityFromItsBeadsWorkspace`) and make the whole city unusable — strictly larger than the availability bug being fixed, and a storage-plan question rather than a claim-routing one.
- **per bead**: `hookClaimBindingRefusedTheClaim` earns the same skip the work-side not-found gets. It is a SEPARATE predicate — `hookClaimBeadIsElsewhere` stays exactly as narrow as it was, `beads.ErrNotFound` only — because the two answer questions about different stores: the refusal is reached only after a work store proved this session owns nothing there, and it lands before any write.

```
control (route=nil, main's behavior) → exit 0, gc-77 claimed
claim-incapable leg                  → exit 1, stdout "", stderr
  "gc hook --claim: promoting ready assignment gcg-6: beads adapter capability unavailable: assignment claim"
```

**3. "WORK first" now means every work leg (finding 4).** Chose *make the rule true*, not rename it. The escalation fired on whatever leg `bestStoreWithWork` selected, and for a rig-scoped agent — the shipped shape of every worker that claims — the CITY work store is the leg that runs LAST. Only the primary leg runs the city-wide reader, so it is the only leg whose query can serve a bead it does not hold. Before a not-found opens the escalation, every OTHER leg is now READ for the same id (`anotherWorkLegHolds`, memoized, through the caller's own `ReadWorkMeta` seam); a leg that holds it closes the escalation, the federated loop drops the leg that could not resolve it, and the leg that holds it claims it on the next turn of the same invocation.

A read rather than a deferred second pass, deliberately: a second pass over the fan-out was implemented first and it let unrelated **lower-tier** work in a later leg be claimed ahead of an ASSIGNED graph step — the starvation this slice closes, wearing a different hat (`conformanceAssignedTierClaimsTheGraphStep` caught it). A failed leg read counts as "may hold it": one skipped bead reclaimed next tick beats an ownership write in a ledger the reader is not looking at.

```
hook_claim_class_fanout_test.go:128: work-scope claim ran against dirs "rig-a", want rig-a,city:
  every WORK leg must answer before the class escalation opens
```

`TestClassEscalationStillReachesABindingOnlyBead` pins the other side — once no work leg holds the bead the escalation is immediate, on the FIRST leg, at the candidate's own rank.

## Single-store cities are byte-identical

`hookClaimClassRouteForCity` gates on `graphClassBinding` (store identity, the same question `resolveClassStore` asks) and returns nil; `classRoutedHookClaimOps` then returns the ops **value** it was handed, not a delegating wrapper. Proved by function identity (`reflect.Value.Pointer`) rather than by behaviour, so an unconditional wrap reddens all six seams.

## The two pinned gaps

**I5 — flipped, and the prediction it got wrong is kept.** The KNOWN GAP predicted the closure would add a coordination-class **leg** to `hookWorkQueryStores` and redden the fan-out rows. It could not: a binding is not a bd workspace. Both halves landed beside the fan-out — ga-bvdha swapped the primary leg's *command*, ga-601v2 put the class axis on the *ops*. So the fan-out rows keep their assertions and become the invariant that keeps query and claim apart, and the closure is asserted on the production seams (`hookClaimClassRouteForCity`, `classRoutedHookClaimOps`) with a new `conformanceHookClaimClassRouting` row covering class-resident, work and co-resident ids.

**I15 — flipped.** `conformanceWorkQuerySeesButCannotClaim` → `conformanceWorkQueryClaimsWhatItSees`; `assertClaimStoreCannotResolve` → `assertClaimEscalatesOffTheWorkStore`, which keeps both original halves (the work store still cannot resolve the bead, and still fails with the not-found the claim path classifies) because they are now the *escalation signal*, and adds the landing. `conformanceAssignedTierDoesNotStrandClaimableWork` → `conformanceAssignedTierClaimsTheGraphStep` (the whole federated command over the ranked assigned tier now returns the graph step) plus `conformanceUnresolvableCandidateStillDoesNotStrandWork`, which keeps the fail-soft property for an id NO store holds. Prose rewritten, no row deleted.

Red-before with the routing disabled:

```
claim_class_route_test.go:84:  routed claim of gcg-100 = (ok=false err=bead not found), want a successful claim
claim_class_route_test.go:180: claim over an unreachable binding = (ok=false err=bead not found), want the read failure surfaced
claim_class_route_test.go:288: routed continuation list = [], want exactly gcg-701
split_topology_conformance_test.go:654:  class-resident graph step …: (ok=false err=claiming bead "gcg-wisp-0002": … bead not found), want a successful claim
split_topology_conformance_test.go:1976: `gc hook --claim` claim of the relocated assigned-tier graph bead gcg-wisp-0003 = (ok=false …), want a successful claim escalated to the binding
```

Widening the escalation predicate to any error:

```
claim_class_route_test.go:127: claim = (ok=true err=<nil>), want the work store's own error returned unchanged;
                               only beads.ErrNotFound may send a claim to a second store   (×3)
```

Class-first probe order:

```
claim_class_route_test.go:160: the work-scope claim never ran; the work store is probed FIRST so co-residence resolves to its copy
split_topology_conformance_test.go:654: co-resident id — first-leg-wins, WORK copy: … gc-1 is claimed for … in the store that does NOT own it
```

Wrapping unconditionally:

```
claim_class_route_test.go:390: classRoutedHookClaimOps replaced the Claim seam on a city with no relocated class   (×6 seams)
```

## The release tier, and what is actually still open (ga-zp3uj rescoped)

An earlier revision shipped the claim with the release half unclosed, on the premise that "nothing automated can release a routed claim". **Measured, that premise was wrong in one direction and right in another**, and the difference is which store the scan LEADS with:

| scan | leading store | reaches the binding? |
| --- | --- | --- |
| reconciler — stranded-repair, named retirement, the `closeBead` cascade | `sessStore.Store` = the SESSIONS-class store | **yes**: one binding serves every relocated class (`openStorageRoutes` keys them all to the engine it opened), so the sessions-class store IS the graph binding on a converged split |
| `gc session close` | `openCityStore` = the CITY WORK store | **no** — fixed here |

So the automated crash-recovery path — the one a dead worker actually goes through — already released a binding-resident claim, and the pinned "known gap" row was driving `unclaimWorkAssignedToRetiredSessionBead(e.work, …)`, which is not what production passes on that path. `gc session close` was genuinely blind, and now takes the graph binding as a class leg (`workAssignmentStores` gained an `extra` argument, de-duplicated by store identity so the reconciler's leg is never scanned twice).

`assertClassRoutedClaimHasNoReleaseTier` is therefore replaced by `assertClassRoutedClaimIsReleasable`, which asserts BOTH scans find and release the step. Red-before, with the class leg removed from `workAssignmentStores`:

```
split_topology_conformance_test.go:770: no leg of the release scan is the class binding;
                                        a claim routed there is released by nothing
--- FAIL: …/I5-claim-routing/split/gc_session_close_—_leads_with_the_work_store_and_is_handed_the_binding
--- PASS: …/I5-claim-routing/split/reconciler_scan_—_leads_with_the_sessions-class_store,_which_IS_the_binding
```

**ga-zp3uj is rescoped, not closed**: what remains topology-blind is the AGENT-side recovery — `bd list --status in_progress`, `on_death`, `on_boot` — which are raw `bd` commands in the agent's work directory. Those RE-SERVE a strand rather than lose it, because the reconciler scan above is what releases it. `internal/config`'s `TestQueryKindsWithoutAReadyReadAreTopologyBlind` is unchanged and still pins that query side.

## Two findings worth a reviewer's eye

1. **`EmitExecutionStepStarted` is routed**, and it is the one seam beyond the bead's literal op list (claim, stamp-branch, continuation list/assign, session-pointer record). It routes on the **memo only** — the store the claim landed in — never on a probe. Rationale: its own doc comment asserts "the hook's bd context owns both the claimed graph step and its workflow root", which is false on a split city, and leaving it unrouted would have the now-succeeding stamp hand it a doomed bd subprocess. Easy to drop if a reviewer disagrees; `TestClassRoutedLifecycleEmissionFollowsTheClaimOnly` pins the narrowness either way.
2. **The "session-pointer record" bug the bead warned about is structurally absent from main.** `publishHookClaimRunMap` publishes a run-map *file* and deliberately does not mutate the session bead, so there is no prefix-routed `RecordSessionPointers` to fix.

## Fixture fidelity — the real backend, suite-wide

The split fixture's class leg is now a real `beads.SQLiteStore` under the graph class's reserved prefix (`newSplitEnvClassLeaf`), behind the kit's `SQLiteSemantics` strictness — the store `internal/storebinding/sqlite`'s `OpenEngine` actually opens. `splittest.StrictStore` forwards `Claim` with the mirror of its own `Count` FIDELITY GAP note.

That leaf differs from the kit's MemStore leaf in exactly the two ways this suite exists to catch: it has the compare-and-swap assignment claim a routed claim acquires through, and it has the graph applier whose reverse-of-a-parent-child guard is the one thing the binding enforces that a MemStore does not. `withClaimCapableClassLeg` and its per-row scoping are deleted; see the retraction at the top for why the scoping existed and why it was not a real constraint.

`conformanceGraphRecipe()` loses its hand-written `parent-child` dep and now carries only the single root → `workflow-finalize` `blocks` edge, which is what a compiled graph.v2 formula emits.

## Gates

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l cmd internal` — empty
- `golangci-lint 2.10.1 ./cmd/gc/... ./internal/beads/...` — 0 issues
- `go test ./cmd/gc -timeout 25m` (SERIAL) — ok
- `go test ./internal/...` — ok
- `go test ./internal/testpolicy/... -count=1` — ok (resource census unchanged)
- `scripts/check-core-boundary.sh` — OK
- `make check-split-topology-rows` / `make check-routed-test-rows` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
