### PR TITLE
feat(api): add pi readiness probe recognizing ~/.pi/agent/auth.json

### DIFF
--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -432,6 +432,15 @@ func providerStatusFixHint(probeName, status string) string {
 		case api.ProbeStatusProbeError:
 			return "check ~/.gemini/settings.json and oauth_creds.json"
 		}
+	case "pi":
+		switch status {
+		case api.ProbeStatusNeedsAuth:
+			return "authenticate pi so it writes ~/.pi/agent/auth.json"
+		case api.ProbeStatusNotInstalled:
+			return "install the pi coding agent"
+		case api.ProbeStatusProbeError:
+			return "check ~/.pi/agent/auth.json and the local pi installation"
+		}
 	}
 	return ""
 }

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -804,38 +804,54 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 
 // TestCmdInitSkipProviderReadinessAllowsBuiltinWithoutProbe verifies that
 // --skip-provider-readiness lets --default-provider select any builtin
-// provider, not just the subset with a readiness probe. "pi" is a real
-// builtin (internal/worker/builtin/profiles.go) with no readiness probe
-// registered, so normalizeInitProvider's readiness-only allowlist rejects
-// it even when the caller explicitly asked to skip readiness checks (#4392).
+// provider, not just the subset with a readiness probe. "omp" (Oh My Pi) is
+// a real builtin (internal/worker/builtin/profiles.go) with no readiness
+// probe registered, so normalizeInitProvider's readiness-only allowlist
+// rejects it even when the caller explicitly asked to skip readiness checks
+// (#4392). ("pi" was the original exemplar but now has a probe of its own;
+// swap in another probe-less builtin if omp ever gains one too.)
 func TestCmdInitSkipProviderReadinessAllowsBuiltinWithoutProbe(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	configureIsolatedRuntimeEnv(t)
 	disableBootstrapForTests(t)
 
-	if api.SupportsProviderReadiness("pi") {
-		t.Fatal("test assumption broken: \"pi\" now has a readiness probe, pick a different probe-less builtin")
+	if api.SupportsProviderReadiness("omp") {
+		t.Fatal("test assumption broken: \"omp\" now has a readiness probe, pick a different probe-less builtin")
 	}
 	found := false
 	for _, name := range config.BuiltinProviderOrder() {
-		if name == "pi" {
+		if name == "omp" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatal("test assumption broken: \"pi\" is no longer a builtin provider")
+		t.Fatal("test assumption broken: \"omp\" is no longer a builtin provider")
 	}
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"init", "--default-provider", "pi", "--skip-provider-readiness", "--no-start", cityPath}, &stdout, &stderr)
+	code := run([]string{"init", "--default-provider", "omp", "--skip-provider-readiness", "--no-start", cityPath}, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("gc init --default-provider pi --skip-provider-readiness = %d, want 0; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		t.Fatalf("gc init --default-provider omp --skip-provider-readiness = %d, want 0; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
 	if strings.Contains(stderr.String(), "unknown provider") {
 		t.Fatalf("stderr = %q, want no unknown-provider rejection for a skipped-readiness builtin", stderr.String())
+	}
+}
+
+// TestNormalizeInitProviderAcceptsPiWithoutSkip locks in the payoff of
+// probePi: now that pi has a readiness probe, --default-provider pi is
+// accepted by the readiness-aware allowlist on its own, so `gc init
+// --default-provider pi` stops needing --skip-provider-readiness.
+func TestNormalizeInitProviderAcceptsPiWithoutSkip(t *testing.T) {
+	got, err := normalizeInitProvider("pi", false)
+	if err != nil {
+		t.Fatalf("normalizeInitProvider(pi, false) = %q, %v; want %q, nil", got, err, "pi")
+	}
+	if got != "pi" {
+		t.Fatalf("normalizeInitProvider(pi, false) = %q, want %q", got, "pi")
 	}
 }
 

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -57,6 +57,7 @@ var (
 		"codex":       {},
 		"gemini":      {},
 		"mimocode":    {},
+		"pi":          {},
 	}
 	supportedReadiness = readinessItemSet{
 		"antigravity": {},
@@ -65,6 +66,7 @@ var (
 		"gemini":      {},
 		"github_cli":  {},
 		"mimocode":    {},
+		"pi":          {},
 	}
 	readinessProbeSpecs = map[string]readinessProbeSpec{
 		"claude": {
@@ -98,6 +100,13 @@ var (
 			kind:        probeKindProvider,
 			probe: func(_ context.Context, homeDir string) providerProbeResult {
 				return probeMimoCode(homeDir)
+			},
+		},
+		"pi": {
+			displayName: "Pi Coding Agent",
+			kind:        probeKindProvider,
+			probe: func(_ context.Context, homeDir string) providerProbeResult {
+				return probePi(homeDir)
 			},
 		},
 		"github_cli": {
@@ -520,6 +529,26 @@ func probeMimoCode(homeDir string) providerProbeResult {
 	}
 	if len(credentials) == 0 {
 		return providerProbeResult{status: probeStatusNeedsAuth, detail: fmt.Sprintf("no credentials in %s; set XIAOMI_API_KEY or run `mimo providers login`", authPath)}
+	}
+	return providerProbeResult{status: probeStatusConfigured}
+}
+
+// probePi recognizes the pi coding agent by the presence of its auth
+// credential store at ~/.pi/agent/auth.json. pi writes that file on a
+// successful login, so its existence is the single configured/not-ready
+// signal — the probe deliberately does not parse the contents, to avoid
+// coupling to pi's evolving auth.json schema.
+func probePi(homeDir string) providerProbeResult {
+	if _, ok := findProbeBinary("pi", homeDir); !ok {
+		return providerProbeResult{status: probeStatusNotInstalled, detail: "pi executable not found in probe PATH"}
+	}
+
+	authPath := filepath.Join(homeDir, ".pi", "agent", "auth.json")
+	if _, err := os.Stat(authPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return providerProbeResult{status: probeStatusNeedsAuth, detail: "missing ~/.pi/agent/auth.json"}
+		}
+		return providerProbeResult{status: probeStatusProbeError, detail: fmt.Sprintf("failed to stat %s", authPath)}
 	}
 	return providerProbeResult{status: probeStatusConfigured}
 }

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -46,11 +46,11 @@ func TestReadinessRegistrySync(t *testing.T) {
 		}
 	}
 
-	wantProviderKeys := []string{"antigravity", "claude", "codex", "gemini", "mimocode"}
+	wantProviderKeys := []string{"antigravity", "claude", "codex", "gemini", "mimocode", "pi"}
 	if got := slices.Sorted(maps.Keys(supportedProviderReadiness)); !slices.Equal(got, wantProviderKeys) {
 		t.Fatalf("supportedProviderReadiness keys = %v, want %v", got, wantProviderKeys)
 	}
-	wantProviderOrder := []string{"claude", "codex", "gemini", "mimocode", "antigravity"}
+	wantProviderOrder := []string{"claude", "codex", "gemini", "mimocode", "pi", "antigravity"}
 	if got := ProviderReadinessNames(); !slices.Equal(got, wantProviderOrder) {
 		t.Fatalf("ProviderReadinessNames() = %v, want %v", got, wantProviderOrder)
 	}
@@ -79,6 +79,17 @@ func stageMimoProbeBinary(t *testing.T, homeDir string) {
 		t.Fatalf("mkdir user bin: %v", err)
 	}
 	writeExecutable(t, userBin, "mimo", "#!/bin/sh\nexit 0\n")
+}
+
+// stagePiProbeBinary installs a stub pi executable into homeDir's
+// ~/.local/bin so findProbeBinary resolves it.
+func stagePiProbeBinary(t *testing.T, homeDir string) {
+	t.Helper()
+	userBin := filepath.Join(homeDir, ".local", "bin")
+	if err := os.MkdirAll(userBin, 0o755); err != nil {
+		t.Fatalf("mkdir user bin: %v", err)
+	}
+	writeExecutable(t, userBin, "pi", "#!/bin/sh\nexit 0\n")
 }
 
 func TestProbeMimoCodeNotInstalled(t *testing.T) {
@@ -222,6 +233,46 @@ func TestProbeMimoCodeRelativeXDGDataHomeFallsBackToHome(t *testing.T) {
 	result := probeMimoCode(homeDir)
 	if result.status != probeStatusConfigured {
 		t.Fatalf("probeMimoCode status = %q, want %q (%s)", result.status, probeStatusConfigured, result.detail)
+	}
+}
+
+func TestProbePiNotInstalled(t *testing.T) {
+	homeDir := t.TempDir()
+	pinProbeSearchPath(t, homeDir)
+
+	result := probePi(homeDir)
+	if result.status != probeStatusNotInstalled {
+		t.Fatalf("probePi status = %q, want %q (%s)", result.status, probeStatusNotInstalled, result.detail)
+	}
+}
+
+func TestProbePiNeedsAuthWithoutAuthJson(t *testing.T) {
+	homeDir := t.TempDir()
+	pinProbeSearchPath(t, homeDir)
+	stagePiProbeBinary(t, homeDir)
+
+	result := probePi(homeDir)
+	if result.status != probeStatusNeedsAuth {
+		t.Fatalf("probePi status = %q, want %q (%s)", result.status, probeStatusNeedsAuth, result.detail)
+	}
+}
+
+func TestProbePiConfiguredByAuthJson(t *testing.T) {
+	homeDir := t.TempDir()
+	pinProbeSearchPath(t, homeDir)
+	stagePiProbeBinary(t, homeDir)
+
+	authDir := filepath.Join(homeDir, ".pi", "agent")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := probePi(homeDir)
+	if result.status != probeStatusConfigured {
+		t.Fatalf("probePi status = %q, want %q (%s)", result.status, probeStatusConfigured, result.detail)
 	}
 }
 


### PR DESCRIPTION
## Summary

Register "pi" in the provider readiness registry with a probe that treats the existence of ~/.pi/agent/auth.json as the configured signal (pi writes that file on login). The probe deliberately does not parse the contents, to avoid coupling to pi's evolving auth.json schema. This lets `gc init` detect pi without --skip-provider-readiness, so `gc init --default-provider pi` is no longer rejected with "unknown provider".

Mechanics: adds "pi" to supportedProviderReadiness, supportedReadiness, and readinessProbeSpecs (kind=provider), and wires a "pi" case into providerStatusFixHint for preflight remediation hints.

Tests:
- TestReadinessRegistrySync: "pi" joins the pinned readiness keys/order.
- TestCmdInitSkipProviderReadinessAllowsBuiltinWithoutProbe: "pi" was the probe-less exemplar guarding #4392; now that pi has a probe, swap to "omp" (Oh My Pi), another real builtin still without a probe. The test's own comment anticipated this swap.
- Add probePi unit tests (not_installed / needs_auth / configured) and TestNormalizeInitProviderAcceptsPiWithoutSkip, locking in that --default-provider pi no longer requires --skip-provider-readiness.

Default readiness items (defaultProviderReadinessItems / defaultReadinessItems) are unchanged, so /provider-readiness and /readiness default-query semantics and the OpenAPI/generated-client doc strings are unaffected (genspec is a no-op).

Issue: #5169 

## Testing

- [X] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
 - [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [X] Linked an issue, or explained why one is not needed
- [X] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
