### PR TITLE
test(cmd/gc): reap checkout-rooted dolt servers inherited across test runs

### DIFF
--- a/cmd/gc/dolt_leak_startup_sweep_test.go
+++ b/cmd/gc/dolt_leak_startup_sweep_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// doltProcRootedAt builds a dolt sql-server process whose --config lies under
+// root, matching the layout a managed dolt provider produces.
+func doltProcRootedAt(pid int, root string) DoltProcInfo {
+	configPath := filepath.Join(root, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	return DoltProcInfo{PID: pid, Argv: []string{"dolt", "sql-server", "--config=" + configPath}}
+}
+
+// sweepStaleForTest runs the startup sweep against a scripted process list and
+// returns what it decided to reap, without signalling anything real.
+func sweepStaleForTest(g *doltLeakGuardedTestingM, procs []DoltProcInfo) (swept bool, reaped []DoltProcInfo) {
+	swept = g.sweepStaleCmdGCTestDoltProcessesWith(
+		"startup",
+		func() ([]DoltProcInfo, error) { return procs, nil },
+		func(leaked []DoltProcInfo) { reaped = leaked },
+	)
+	return swept, reaped
+}
+
+// TestStartupSweepReapsSourceRootRootedServer is the across-invocation leak
+// this whole guard exists for. A managed dolt handed a city root of "" or "."
+// resolves it to the package directory, so its config lands in the checkout at
+// cmd/gc/.gc rather than under tempRoot. Such a server outlives the test binary
+// that spawned it, and the in-run snapshot diff can never report it: it is
+// already present in the INITIAL snapshot, so diffDoltProcessSnapshots
+// correctly excludes it as "not leaked by this run". The startup sweep is the
+// only path that can reap it, and before this change it could not classify it —
+// staleness was derived solely from an owner PID encoded in a temp-root
+// directory name, which a checkout-rooted path does not have.
+func TestStartupSweepReapsSourceRootRootedServer(t *testing.T) {
+	sourceRoot := t.TempDir()
+	g := &doltLeakGuardedTestingM{tempRoot: t.TempDir(), sourceRoot: sourceRoot}
+
+	proc := doltProcRootedAt(4242, sourceRoot)
+	swept, reaped := sweepStaleForTest(g, []DoltProcInfo{proc})
+
+	if !swept {
+		t.Fatalf("startup sweep reported nothing to do for a server rooted in the checkout at %q", sourceRoot)
+	}
+	if len(reaped) != 1 || reaped[0].PID != 4242 {
+		t.Fatalf("startup sweep reaped %v, want exactly pid 4242", reaped)
+	}
+}
+
+// TestStartupSweepIgnoresForeignCheckoutServer is the blast-radius guard. Many
+// agents run cmd/gc tests concurrently from separate worktrees on one box, so
+// the sweep must key on THIS checkout's source root only. Reaping a peer
+// checkout's live server would be a worse bug than the leak being fixed.
+func TestStartupSweepIgnoresForeignCheckoutServer(t *testing.T) {
+	g := &doltLeakGuardedTestingM{tempRoot: t.TempDir(), sourceRoot: t.TempDir()}
+
+	foreignCheckout := t.TempDir()
+	swept, reaped := sweepStaleForTest(g, []DoltProcInfo{doltProcRootedAt(4243, foreignCheckout)})
+
+	if swept || len(reaped) != 0 {
+		t.Fatalf("startup sweep reaped %v from a foreign checkout %q; must touch this checkout only", reaped, foreignCheckout)
+	}
+}
+
+// TestStartupSweepWithUnresolvedSourceRootReapsNothing pins that an empty
+// source root is ignored rather than treated as match-everything. os.Getwd can
+// fail, and newDoltLeakGuardedTestingM deliberately degrades to an empty root
+// instead of aborting the run; a bare prefix test against "" would match every
+// dolt process on the machine and turn this sweep into a box-wide reaper.
+func TestStartupSweepWithUnresolvedSourceRootReapsNothing(t *testing.T) {
+	g := &doltLeakGuardedTestingM{tempRoot: t.TempDir(), sourceRoot: ""}
+
+	swept, reaped := sweepStaleForTest(g, []DoltProcInfo{doltProcRootedAt(4244, t.TempDir())})
+
+	if swept || len(reaped) != 0 {
+		t.Fatalf("startup sweep with an unresolved source root reaped %v; want nothing", reaped)
+	}
+}
+
+// TestStartupSweepStillReapsDeadOwnerTempRootServer pins that widening the
+// sweep to the source root leaves the pre-existing owner-PID path intact: a
+// temp-root server whose owning test binary is gone is still stale.
+func TestStartupSweepStillReapsDeadOwnerTempRootServer(t *testing.T) {
+	tempParent := os.TempDir()
+	g := &doltLeakGuardedTestingM{
+		tempRoot:   filepath.Join(tempParent, fmt.Sprintf("%s%d-current", testCmdGCTempRootPrefix, os.Getpid())),
+		sourceRoot: t.TempDir(),
+	}
+
+	deadOwnerRoot := filepath.Join(tempParent, fmt.Sprintf("%s%d-stale", testCmdGCTempRootPrefix, nonLivePID(t)))
+	swept, reaped := sweepStaleForTest(g, []DoltProcInfo{doltProcRootedAt(4245, deadOwnerRoot)})
+
+	if !swept || len(reaped) != 1 || reaped[0].PID != 4245 {
+		t.Fatalf("startup sweep reaped %v for a dead-owner temp root; want exactly pid 4245", reaped)
+	}
+}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -258,7 +258,19 @@ func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool 
 }
 
 func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string) bool {
-	procs, err := discoverDoltProcesses()
+	return g.sweepStaleCmdGCTestDoltProcessesWith(label, discoverDoltProcesses, reapDoltLeakProcesses)
+}
+
+// sweepStaleCmdGCTestDoltProcessesWith is sweepStaleCmdGCTestDoltProcesses with
+// the process enumerator and reaper injected, mirroring runWith above. The sweep
+// KILLS processes, so its classification has to be assertable without spawning
+// or signalling anything real.
+func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcessesWith(
+	label string,
+	enumerate func() ([]DoltProcInfo, error),
+	reap func([]DoltProcInfo),
+) bool {
+	procs, err := enumerate()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s stale scan failed: %v\n", label, err) //nolint:errcheck
 		return true
@@ -267,7 +279,8 @@ func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string)
 	tempParent := filepath.Dir(filepath.Clean(g.tempRoot))
 	var leaked []DoltProcInfo
 	for _, proc := range procs {
-		if !isStaleCmdGCTestConfigPath(extractConfigPath(proc.Argv), activeRoots, tempParent) {
+		configPath := extractConfigPath(proc.Argv)
+		if !isStaleCmdGCTestConfigPath(configPath, activeRoots, tempParent) && !g.isStaleSourceRootConfigPath(configPath) {
 			continue
 		}
 		leaked = append(leaked, proc)
@@ -280,8 +293,39 @@ func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string)
 	})
 	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d stale cmd/gc test dolt sql-server process(es)\n", label, len(leaked)) //nolint:errcheck
 	writeDoltLeakReport(os.Stderr, leaked)
-	reapDoltLeakProcesses(leaked)
+	reap(leaked)
 	return true
+}
+
+// isStaleSourceRootConfigPath reports whether configPath belongs to a dolt
+// sql-server rooted in this checkout's package directory, which at startup can
+// only be a leftover from an earlier test binary.
+//
+// The owner-PID rules above cannot classify these. They derive staleness from a
+// PID encoded in a temp-root directory name, and a server that resolved its city
+// root to "." has no such directory — its config sits at cmd/gc/.gc inside the
+// checkout. So it fails every staleness test and survives.
+//
+// Nor can the in-run guard catch it: a server inherited from a previous
+// invocation is already in the INITIAL snapshot, so diffDoltProcessSnapshots
+// rightly excludes it as not leaked by this run. Widening the snapshot roots
+// (#5057) fixed detection for servers this run spawns, but left the inherited
+// ones with no path that reaps them. They accumulate across invocations,
+// holding ports, memory and the data-dir lock that blocks the next run in the
+// same checkout.
+//
+// Reaping is safe here for the same reason detection is: no real city lives
+// inside the checkout, so a dolt sql-server rooted here is a test leak by
+// construction. Scoping to THIS source root is what keeps it safe — peer
+// worktrees running their own cmd/gc tests concurrently root under their own
+// directories and are never matched. An unresolved (empty) source root is
+// ignored rather than treated as a match-everything prefix, which would turn
+// this sweep into a box-wide reaper of other checkouts' servers.
+func (g *doltLeakGuardedTestingM) isStaleSourceRootConfigPath(configPath string) bool {
+	if g.sourceRoot == "" || configPath == "" {
+		return false
+	}
+	return pathutil.PathWithin(g.sourceRoot, configPath)
 }
 
 // sweepOrphanDoltStoreDirs runs the symptom-based fallback sweep


### PR DESCRIPTION
Follow-up to #5118, taking up the item @sjarmak named there:

> neither PR touches `sweepStaleCmdGCTestDoltProcesses`, the startup sweep for dolt servers that outlive a test binary across separate invocations. That is the shape of the long-lived leak the original issue describes, so the in-process guard being fixed does not close it.

## The gap

A managed dolt provider handed a city root of `""` or `"."` resolves it to the package directory, so the server's config lands at `cmd/gc/.gc` inside the checkout. **No path currently reaps one of those once it outlives the test binary that spawned it.**

- `sweepStaleCmdGCTestDoltProcesses` derives staleness from an owner PID encoded in a temp-root directory name (`cmdGCTestConfigOwnerPID`). A checkout-rooted config has no such directory, so it returns `!ok` and `isStaleCmdGCTestConfigPathWithPIDCheck` classifies the process **not stale**.
- The in-run guard cannot see it either, and this is the part worth being precise about: a server inherited from an *earlier* invocation is already present in the **initial** snapshot, so `diffDoltProcessSnapshots` correctly excludes it — it was not leaked by this run. #5057 widened the snapshot roots and the SIGINT/SIGTERM reap, which fixes servers *this* run spawns, but inherited ones still have no path that reaps them.

So the two halves compose to a hole: the run that creates the leak may exit without ever reporting it, and no later run will clean it up.

Observed in the wild: one such server at 4h+ uptime survived four agent handoffs across sessions, holding a port, memory, and the `cmd/gc/.beads/dolt` lock that blocks the next run in the same checkout (`TestStartManagedDoltFailsClosedWhenDataDirLockHeld`).

## The change

Treat a config under the guard's own `sourceRoot` as stale during the startup sweep. At startup this run has not started a server yet, so such a process can only be a leftover — and per the `sourceRoot` rationale already in the guard, no real city lives inside the checkout, so a dolt server rooted there is a test leak by construction.

## Blast radius

This sweep **kills processes**, so the scoping is the load-bearing part:

- **Scoped to THIS source root.** Peer worktrees running `cmd/gc` tests concurrently root under their own directories and are never matched. Covered by `TestStartupSweepIgnoresForeignCheckoutServer`.
- **An empty `sourceRoot` is ignored, not treated as match-everything.** `newDoltLeakGuardedTestingM` deliberately degrades to `""` when `os.Getwd` fails; a bare prefix test against `""` would turn this into a box-wide reaper of other checkouts' servers. Covered by `TestStartupSweepWithUnresolvedSourceRootReapsNothing`.
- **The existing owner-PID path is unchanged.** Covered by `TestStartupSweepStillReapsDeadOwnerTempRootServer`.

`sweepStaleCmdGCTestDoltProcessesWith` injects the enumerator and reaper, mirroring the existing `runWith`, so classification is assertable without spawning or signalling anything real.

## Verification

Unit tests are red-first, but a green unit test proves behavior, not that the real path works — so this was also checked end-to-end against the **real `ps` enumerator and a real kill**:

- A dolt sql-server rooted in this checkout: **reaped**.
- One rooted in a peer checkout, running concurrently: **survived**.
- Mutation check — with only the new classification reverted, the same process **stays alive**, confirming this change is what reaps it rather than something else in the guard.

Also: `gofmt` clean, `go vet ./cmd/gc/` clean, `make lint-changed` 0 issues, and the leak-guard test set green (`GC_FAST_UNIT=1 go test ./cmd/gc/ -run 'TestStartupSweep|TestIsStaleCmdGCTestConfigPath|TestSnapshotDoltProcesses|TestRequireNoLeakedDolt|TestIsTestConfigPath|TestDoltLeakGuard'`).

Branched from current `main` with #5057 already in it, so there is no overlap with the conflict that closed #5118.

Refs #5057, #5118