### PR TITLE
fix(reaper): exclude gc-injected scaffolding from the worktree disposal gate (gas-wr8)

### DIFF
--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/pathutil"
+	"github.com/gastownhall/gascity/internal/scaffold"
 	"github.com/gastownhall/gascity/internal/sling"
 )
 
@@ -287,10 +288,12 @@ func reapClosedBeadWorktrees(
 			// it as a clean answer would fail open.
 			if reason == "" {
 				wg := git.New(worktreePath)
-				hasUncommitted := wg.HasUncommittedWork()
+				hasUncommitted, uncommittedErr := worktreeHasUnsalvagedWork(wg, worktreePath)
 				hasUnreachable, unreachableErr := wg.HasUnreachableCommitsResult()
 				hasStashes, stashErr := wg.HasStashesResult()
 				switch {
+				case uncommittedErr != nil:
+					reason = fmt.Sprintf("git probe failed (failing closed): %v", uncommittedErr)
 				case unreachableErr != nil:
 					reason = fmt.Sprintf("git probe failed (failing closed): %v", unreachableErr)
 				case stashErr != nil:
@@ -465,6 +468,26 @@ func computeWorktreeAge(worktreePath string) (age time.Duration, ok bool) {
 // returns, for each candidate's worktree path, the IDs of any non-terminal
 // beads — in any molecule — whose gc.work_dir or legacy work_dir metadata
 // still points at that path (FR-1/FR-2/FR-3). Terminal status is decided by
+// worktreeHasUnsalvagedWork reports whether the worktree holds uncommitted
+// changes that are not gc's own injected scaffolding.
+//
+// A bare "git status --porcelain is non-empty" check cannot answer this: gc
+// writes provider-native MCP config, materialized skill symlinks, and a
+// ".gitignore" block into every worktree it creates, so the porcelain output
+// is never empty and the gate refuses forever (gas-wr8). Subtracting the
+// paths gc can prove it owns restores the signal the gate was written to
+// carry — real uncommitted work is about to be destroyed.
+//
+// A probe error returns true: an errored probe proves nothing, and treating
+// it as a clean answer would fail open.
+func worktreeHasUnsalvagedWork(wg *git.Git, worktreePath string) (bool, error) {
+	porcelain, err := wg.StatusPorcelainUntrimmed()
+	if err != nil {
+		return true, err
+	}
+	return scaffold.HasRealWork(worktreePath, porcelain, wg.ShowAtHead), nil
+}
+
 // convoycore.IsTerminalStatus, not a bare "!= closed" check, so a tombstoned
 // reference does not veto. Path matching is symlink/alias-normalized on both
 // sides via pathutil.NormalizePathForCompare, matching the liveness gate, so a

--- a/cmd/gc/bead_worktree_reaper_scaffold_test.go
+++ b/cmd/gc/bead_worktree_reaper_scaffold_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/git"
+)
+
+// scaffoldRepo builds a real git repo shaped like a live gc worktree: the
+// tracked files gc rewrites in place are committed first, then gc's injections
+// are applied on top.
+//
+// ".claude/skills" gets a committed file on purpose. That is what makes git
+// descend into the directory and report gc's materialized skill entries
+// individually instead of collapsing them into a single "?? .claude/", which
+// is exactly the shape the gascity rig produces (its .gitignore un-ignores
+// .claude/skills/ so the docs skill can be tracked).
+func scaffoldRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	mustGit(t, repo, "init")
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "Gas City Test")
+
+	// ".gc/" is committed as ignored, matching what gc init writes into a rig
+	// repo: gc's runtime state directory never reaches porcelain in the field.
+	writeRepoFile(t, repo, ".gitignore", "node_modules/\n.gc/\n")
+	writeRepoFile(t, repo, ".mcp.json", `{"mcpServers":{"excalidraw":{"type":"http"}}}`+"\n")
+	writeRepoFile(t, repo, filepath.Join(".claude", "skills", "docs-skill", "SKILL.md"), "docs\n")
+	mustGit(t, repo, "add", ".")
+	mustGit(t, repo, "commit", "-m", "init")
+
+	// --- everything below is gc scaffolding, not agent work ---
+
+	writeRepoFile(t, repo, ".gitignore", "node_modules/\n.gc/\n\n# Gas City\n.mcp.json\nopencode.json\n")
+
+	mcpContent := `{"mcpServers":{"bartertown":{"command":"/x/bartertown_mcp.py"}}}` + "\n"
+	writeRepoFile(t, repo, ".mcp.json", mcpContent)
+	sum := sha256.Sum256([]byte(mcpContent))
+	marker, err := json.Marshal(map[string]string{
+		"managed_by":     "gc",
+		"provider":       "claude",
+		"content_sha256": hex.EncodeToString(sum[:]),
+	})
+	if err != nil {
+		t.Fatalf("marshaling marker: %v", err)
+	}
+	writeRepoFile(t, repo, filepath.Join(".gc", "mcp-managed", "claude.json"), string(marker))
+
+	manifest, err := json.Marshal(map[string]any{
+		"targets": map[string]string{"core.gc-work": "/cache/skills/gc-work"},
+	})
+	if err != nil {
+		t.Fatalf("marshaling manifest: %v", err)
+	}
+	writeRepoFile(t, repo, filepath.Join(".claude", "skills", ".gc-skill-ownership.json"), string(manifest))
+	writeRepoFile(t, repo, filepath.Join(".claude", "skills", "core.gc-work"), "symlink-stand-in")
+
+	return repo
+}
+
+func writeRepoFile(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	path := filepath.Join(repo, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", rel, err)
+	}
+}
+
+// The regression this whole change exists for: a worktree holding nothing but
+// gc's injections is dirty to git and must still be disposable (gas-wr8).
+func TestWorktreeHasUnsalvagedWorkIgnoresGCScaffolding(t *testing.T) {
+	repo := scaffoldRepo(t)
+	wg := git.New(repo)
+
+	// Guard: the setup must actually reproduce the dirty tree, or the test
+	// would pass for the wrong reason.
+	porcelain, err := wg.StatusPorcelain()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if porcelain == "" {
+		t.Fatal("setup did not produce a dirty worktree; nothing is being tested")
+	}
+	if !wg.HasUncommittedWork() {
+		t.Fatal("setup did not trip the old bare-porcelain gate; nothing is being tested")
+	}
+
+	hasWork, err := worktreeHasUnsalvagedWork(wg, repo)
+	if err != nil {
+		t.Fatalf("probing: %v", err)
+	}
+	if hasWork {
+		t.Fatalf("pure gc scaffolding reported as unsalvaged work:\n%s", porcelain)
+	}
+}
+
+func TestWorktreeHasUnsalvagedWorkProtectsRealEdits(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func(t *testing.T, repo string)
+	}{
+		{"tracked file modified", func(t *testing.T, repo string) {
+			writeRepoFile(t, repo, filepath.Join(".claude", "skills", "docs-skill", "SKILL.md"), "edited\n")
+		}},
+		{"new untracked file", func(t *testing.T, repo string) {
+			writeRepoFile(t, repo, "notes.md", "in progress\n")
+		}},
+		{"hand-placed skill beside gc's", func(t *testing.T, repo string) {
+			writeRepoFile(t, repo, filepath.Join(".claude", "skills", "my-skill"), "mine\n")
+		}},
+		{"real edit alongside the Gas City block", func(t *testing.T, repo string) {
+			writeRepoFile(t, repo, ".gitignore", "node_modules/\n.gc/\ncoverage.out\n\n# Gas City\n.mcp.json\nopencode.json\n")
+		}},
+		{"gc-managed MCP config edited by hand", func(t *testing.T, repo string) {
+			writeRepoFile(t, repo, ".mcp.json", `{"mcpServers":{"mine":{}}}`+"\n")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := scaffoldRepo(t)
+			tc.apply(t, repo)
+
+			hasWork, err := worktreeHasUnsalvagedWork(git.New(repo), repo)
+			if err != nil {
+				t.Fatalf("probing: %v", err)
+			}
+			if !hasWork {
+				t.Fatal("real work was subtracted as scaffolding; a reap here would destroy it")
+			}
+		})
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -147,6 +147,17 @@ func (g *Git) HasUncommittedWork() bool {
 	return strings.TrimSpace(out) != ""
 }
 
+// ShowAtHead returns the committed bytes of a repo-relative path at HEAD.
+// A path absent from HEAD yields an error, which lets callers tell "modified
+// since the commit" apart from "never committed".
+func (g *Git) ShowAtHead(rel string) ([]byte, error) {
+	out, err := g.run("show", "HEAD:"+rel)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s at HEAD: %w", rel, err)
+	}
+	return []byte(out), nil
+}
+
 // HasUnpushedCommits reports whether HEAD has commits not reachable from
 // any remote tracking branch. Used as a safety check before removing a
 // worktree — unpushed commits represent completed work that would be lost.
@@ -281,6 +292,21 @@ func (g *Git) PullRebase(remote, branch string) error {
 // Each non-empty line represents one changed/untracked file.
 func (g *Git) StatusPorcelain() (string, error) {
 	return g.StatusPorcelainCtx(context.Background())
+}
+
+// StatusPorcelainUntrimmed returns porcelain status output verbatim.
+//
+// Porcelain v1 is a fixed-width format: two status characters, a space, then
+// the path. StatusPorcelain trims the whole output, which strips the leading
+// space of an unstaged first record (" M f" becomes "M f") and shifts that
+// one line out of alignment. Callers that parse the status column must use
+// this instead; callers that only test for emptiness can use either.
+func (g *Git) StatusPorcelainUntrimmed() (string, error) {
+	out, err := g.run("status", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("getting status: %w", err)
+	}
+	return out, nil
 }
 
 // StatusPorcelainCtx is like StatusPorcelain but accepts a context.

--- a/internal/materialize/mcp_managed.go
+++ b/internal/materialize/mcp_managed.go
@@ -1,0 +1,90 @@
+package materialize
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// mcpRelTarget is the slash-relative path, under a workdir, of the
+// provider-native MCP config file gc projects for providerKind. It returns ""
+// for an unsupported provider. This is the single source of the
+// provider-to-file mapping: BuildMCPProjection turns it into an absolute
+// target, and ManagedMCPTargets reverses a marker back into the path gc wrote.
+func mcpRelTarget(providerKind string) string {
+	switch providerKind {
+	case MCPProviderClaude:
+		return ".mcp.json"
+	case MCPProviderCodex:
+		return ".codex/config.toml"
+	case MCPProviderGemini:
+		return ".gemini/settings.json"
+	case MCPProviderOpenCode:
+		return "opencode.json"
+	case MCPProviderMimoCode:
+		return "mimocode.json"
+	case MCPProviderCursor:
+		return ".cursor/mcp.json"
+	default:
+		return ""
+	}
+}
+
+// ManagedMCPTarget is one provider-native MCP file gc has adopted in a
+// worktree, as recorded by the managed marker gc writes beside it.
+type ManagedMCPTarget struct {
+	// Provider is the MCP provider kind the marker was written for.
+	Provider string
+	// RelPath is the target file's slash-relative path within the worktree.
+	RelPath string
+	// SHA256 is the hex content hash gc recorded when it last wrote the
+	// target. It is empty for markers written before gc recorded hashes, and
+	// for a marker whose target could not be read back; callers must treat an
+	// empty hash as "ownership unproven".
+	SHA256 string
+}
+
+// ManagedMCPTargets reports the MCP config files gc manages under root, read
+// from the ".gc/mcp-managed" markers gc wrote when it adopted each file.
+//
+// It is best-effort and read-only: a missing directory, an unreadable entry,
+// a corrupt marker, or an unrecognized provider each yield no target rather
+// than an error, so a caller's worst case is treating gc's own file as
+// somebody else's.
+func ManagedMCPTargets(root string) []ManagedMCPTarget {
+	dir := filepath.Join(root, ".gc", "mcp-managed")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var out []ManagedMCPTarget
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var marker struct {
+			ManagedBy     string `json:"managed_by"`
+			Provider      string `json:"provider"`
+			ContentSHA256 string `json:"content_sha256"`
+		}
+		if err := json.Unmarshal(data, &marker); err != nil || marker.ManagedBy != "gc" {
+			continue
+		}
+		rel := mcpRelTarget(marker.Provider)
+		if rel == "" {
+			continue
+		}
+		out = append(out, ManagedMCPTarget{
+			Provider: marker.Provider,
+			RelPath:  rel,
+			SHA256:   marker.ContentSHA256,
+		})
+	}
+	return out
+}

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -48,38 +48,18 @@ type MCPProjection struct {
 // projection so callers can reconcile stale managed config away.
 func BuildMCPProjection(providerKind, workdir string, servers []MCPServer) (MCPProjection, error) {
 	workdir = filepath.Clean(workdir)
-	switch providerKind {
-	case MCPProviderClaude:
-	case MCPProviderCodex:
-	case MCPProviderGemini:
-	case MCPProviderOpenCode:
-	case MCPProviderMimoCode:
-	case MCPProviderCursor:
-	default:
+	rel := mcpRelTarget(providerKind)
+	if rel == "" {
 		return MCPProjection{}, fmt.Errorf("unsupported MCP provider %q", providerKind)
 	}
 
 	out := MCPProjection{
 		Provider: providerKind,
 		Root:     workdir,
+		Target:   filepath.Join(workdir, filepath.FromSlash(rel)),
 		Servers:  append([]MCPServer(nil), servers...),
 	}
 	sort.Slice(out.Servers, func(i, j int) bool { return out.Servers[i].Name < out.Servers[j].Name })
-
-	switch providerKind {
-	case MCPProviderClaude:
-		out.Target = filepath.Join(workdir, ".mcp.json")
-	case MCPProviderCodex:
-		out.Target = filepath.Join(workdir, ".codex", "config.toml")
-	case MCPProviderGemini:
-		out.Target = filepath.Join(workdir, ".gemini", "settings.json")
-	case MCPProviderOpenCode:
-		out.Target = filepath.Join(workdir, "opencode.json")
-	case MCPProviderMimoCode:
-		out.Target = filepath.Join(workdir, "mimocode.json")
-	case MCPProviderCursor:
-		out.Target = filepath.Join(workdir, ".cursor", "mcp.json")
-	}
 	return out, nil
 }
 
@@ -566,10 +546,21 @@ func (p MCPProjection) writeManagedMarker(fs fsys.FS) error {
 	if err := fs.MkdirAll(filepath.Dir(p.markerPath()), 0o755); err != nil {
 		return fmt.Errorf("creating %s: %w", filepath.Dir(p.markerPath()), err)
 	}
-	data, err := json.Marshal(map[string]string{
+	marker := map[string]string{
 		"managed_by": "gc",
 		"provider":   p.Provider,
-	})
+	}
+	// Record what gc actually left on disk. A disposal gate can then tell
+	// gc's own untouched config apart from one an agent edited afterwards,
+	// instead of treating every managed worktree as permanently dirty
+	// (gas-wr8). Read back rather than hashing the intended payload so the
+	// marker describes the bytes on disk under every write path, including
+	// the merge-into-existing-document ones.
+	if written, readErr := fs.ReadFile(p.Target); readErr == nil {
+		sum := sha256.Sum256(written)
+		marker["content_sha256"] = hex.EncodeToString(sum[:])
+	}
+	data, err := json.Marshal(marker)
 	if err != nil {
 		return fmt.Errorf("marshaling %s: %w", p.markerPath(), err)
 	}

--- a/internal/scaffold/residue.go
+++ b/internal/scaffold/residue.go
@@ -1,0 +1,243 @@
+// Package scaffold answers one question about a gc-managed worktree: of the
+// files git reports as dirty, which ones represent actual agent work?
+//
+// gc injects its own files into every worktree it creates — provider-native
+// MCP config, materialized skill symlinks, and an appended ".gitignore"
+// block. All three land on tracked-or-visible paths, so a plain
+// "git status --porcelain" in a healthy, untouched gc worktree is never
+// empty. Any disposal gate written as `[ -z "$DIRTY" ]` therefore refuses
+// forever, and the one signal that should mean "real uncommitted work is
+// about to be destroyed" fires on 100% of worktrees (gas-wr8).
+//
+// Residue subtracts only scaffolding gc can PROVE it owns, from records gc
+// itself wrote at injection time:
+//
+//   - skill symlinks — named in the sink's ".gc-skill-ownership.json"
+//   - MCP config — marked in ".gc/mcp-managed/<provider>.json", and only
+//     when the file still hashes to what gc last wrote
+//   - ".gitignore" — only when removing gc's own "# Gas City" blocks
+//     restores the committed content exactly
+//
+// Everything else is residue. The subtraction is deliberately one-directional:
+// an unprovable case stays residue, so the failure mode is a worktree that
+// lives too long, never one that is deleted with work in it.
+package scaffold
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/materialize"
+	"github.com/gastownhall/gascity/internal/reviewquorum"
+)
+
+// gasCityIgnoreMarker is the header ensureGitignoreEntries writes above each
+// block of gc-managed ignore entries. The block's CONTENTS vary per worktree
+// (the city block lists MCP targets, a rig block lists ".beads/*"), so the
+// marker is matched and the block parsed — never compared against fixed
+// expected content, which would silently stop matching and quietly restore
+// the gas-wr8 bug.
+const gasCityIgnoreMarker = "# Gas City"
+
+// ownershipManifestFile mirrors the materializer's per-sink bookkeeping file.
+const ownershipManifestFile = ".gc-skill-ownership.json"
+
+// HeadFileFunc returns the committed bytes of a repo-relative path at HEAD.
+// It returns an error when the path is absent from HEAD; callers treat any
+// error as "cannot prove", which keeps the entry in the residue.
+type HeadFileFunc func(rel string) ([]byte, error)
+
+// Residue returns the subset of entries that is not provably gc-injected
+// scaffolding. An empty result means the worktree holds nothing but gc's own
+// files and is safe to discard.
+//
+// worktree is the absolute path to the working tree the entries came from.
+// headFile reads committed content for the ".gitignore" comparison; a nil
+// headFile disables that one subtraction rather than failing the whole pass.
+func Residue(worktree string, entries []reviewquorum.StatusEntry, headFile HeadFileFunc) []reviewquorum.StatusEntry {
+	managed := managedMCPHashes(worktree)
+	manifests := newManifestCache(worktree)
+
+	var residue []reviewquorum.StatusEntry
+	for _, entry := range entries {
+		if isScaffolding(worktree, entry, managed, manifests, headFile) {
+			continue
+		}
+		residue = append(residue, entry)
+	}
+	return residue
+}
+
+// HasRealWork reports whether porcelain output from worktree contains any
+// change that is not gc scaffolding. It is the drop-in replacement for a bare
+// `strings.TrimSpace(porcelain) != ""` disposal gate.
+func HasRealWork(worktree, porcelain string, headFile HeadFileFunc) bool {
+	return len(Residue(worktree, reviewquorum.ParseStatusPorcelain(porcelain), headFile)) > 0
+}
+
+func isScaffolding(
+	worktree string,
+	entry reviewquorum.StatusEntry,
+	managed map[string]string,
+	manifests *manifestCache,
+	headFile HeadFileFunc,
+) bool {
+	// git reports untracked directories with a trailing slash; the skill sink
+	// holds symlinks, but normalize so either shape matches its manifest key.
+	rel := strings.TrimSuffix(entry.Path, "/")
+	if rel == "" {
+		return false
+	}
+
+	// A deletion is never scaffolding: gc only ever writes these paths, so a
+	// missing one is a change gc did not make.
+	if strings.Contains(entry.Status, "D") {
+		return false
+	}
+
+	if manifests.owns(rel) {
+		return true
+	}
+	if want, ok := managed[rel]; ok {
+		return mcpTargetUnmodified(filepath.Join(worktree, filepath.FromSlash(rel)), want)
+	}
+	if rel == ".gitignore" {
+		return gitignoreHoldsOnlyGasCityBlocks(worktree, headFile)
+	}
+	return false
+}
+
+// mcpTargetUnmodified reports whether the on-disk MCP config still hashes to
+// the content gc recorded when it wrote the file. A mismatch means something
+// edited it after gc, so the file is real work. An empty want (a marker
+// written before gc recorded hashes) proves nothing and fails closed.
+func mcpTargetUnmodified(absPath, want string) bool {
+	if want == "" {
+		return false
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return false
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]) == want
+}
+
+// managedMCPHashes maps each slash-relative MCP target gc has adopted in this
+// worktree to the content hash gc last wrote there.
+func managedMCPHashes(worktree string) map[string]string {
+	targets := materialize.ManagedMCPTargets(worktree)
+	if len(targets) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(targets))
+	for _, t := range targets {
+		out[t.RelPath] = t.SHA256
+	}
+	return out
+}
+
+// manifestCache resolves skill-sink ownership lazily: a path is gc's if the
+// sink directory holding it carries an ownership manifest that names it. No
+// sink location is hardcoded, so a pack materializing into ".codex/skills"
+// (or anywhere else) is recognized on the same evidence as ".claude/skills".
+type manifestCache struct {
+	worktree string
+	byDir    map[string]map[string]string
+}
+
+func newManifestCache(worktree string) *manifestCache {
+	return &manifestCache{worktree: worktree, byDir: map[string]map[string]string{}}
+}
+
+func (c *manifestCache) owns(rel string) bool {
+	dir := path.Dir(rel)
+	if dir == "." {
+		return false
+	}
+	targets, ok := c.byDir[dir]
+	if !ok {
+		targets = loadOwnershipTargets(filepath.Join(c.worktree, filepath.FromSlash(dir), ownershipManifestFile))
+		c.byDir[dir] = targets
+	}
+	if targets == nil {
+		return false
+	}
+	base := path.Base(rel)
+	// The manifest is gc's own bookkeeping file and never agent work, but it
+	// only counts as scaffolding inside a directory that actually is a sink.
+	if base == ownershipManifestFile {
+		return true
+	}
+	_, owned := targets[base]
+	return owned
+}
+
+// loadOwnershipTargets returns the manifest's entry names, or nil when the
+// directory is not a gc skill sink. A corrupt manifest yields nil so the
+// entries under it stay in the residue.
+func loadOwnershipTargets(manifestPath string) map[string]string {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil
+	}
+	var m struct {
+		Targets map[string]string `json:"targets"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil
+	}
+	return m.Targets
+}
+
+// gitignoreHoldsOnlyGasCityBlocks reports whether the working copy of
+// ".gitignore" differs from HEAD by nothing except gc's own appended blocks.
+//
+// The block is subtracted by PARSING it — from the "# Gas City" marker to the
+// next blank line — rather than by ignoring the ".gitignore" path outright.
+// Path-ignoring would drop an agent's legitimate edit to a shared, tracked
+// file and classify a worktree holding only that edit as disposable, which is
+// the destructive direction this whole gate exists to prevent.
+func gitignoreHoldsOnlyGasCityBlocks(worktree string, headFile HeadFileFunc) bool {
+	if headFile == nil {
+		return false
+	}
+	current, err := os.ReadFile(filepath.Join(worktree, ".gitignore"))
+	if err != nil {
+		return false
+	}
+	head, err := headFile(".gitignore")
+	if err != nil {
+		return false
+	}
+	stripped := stripGasCityBlocks(string(current))
+	// Trailing newlines are normalized: the injector inserts a blank
+	// separator line before its block, and restoring that exactly would mean
+	// guessing how many newlines HEAD ended with.
+	return strings.TrimRight(stripped, "\n") == strings.TrimRight(string(head), "\n")
+}
+
+// stripGasCityBlocks removes every "# Gas City" section from a .gitignore.
+// A section runs from its marker line to the next blank line or EOF, matching
+// how ensureGitignoreEntries appends one (and it may append more than one, as
+// later calls add newly-managed paths).
+func stripGasCityBlocks(content string) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != gasCityIgnoreMarker {
+			out = append(out, lines[i])
+			continue
+		}
+		// Skip the marker and its contiguous entries.
+		for i+1 < len(lines) && strings.TrimSpace(lines[i+1]) != "" {
+			i++
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/scaffold/residue_test.go
+++ b/internal/scaffold/residue_test.go
@@ -1,0 +1,247 @@
+package scaffold
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/reviewquorum"
+)
+
+// headGitignore is the committed .gitignore used across these tests.
+const headGitignore = "node_modules/\n.beads/proxieddb/\n"
+
+// gasCityBlock is what gc appends to a worktree .gitignore. Its contents
+// differ per worktree in the field, which is why the implementation parses
+// the marker instead of matching fixed text.
+const gasCityBlock = "\n# Gas City\n.mcp.json\n.gemini/settings.json\nopencode.json\n"
+
+func parse(porcelain string) []reviewquorum.StatusEntry {
+	return reviewquorum.ParseStatusPorcelain(porcelain)
+}
+
+func paths(entries []reviewquorum.StatusEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Path)
+	}
+	return out
+}
+
+func assertContains(t *testing.T, entries []reviewquorum.StatusEntry, want string) {
+	t.Helper()
+	for _, e := range entries {
+		if e.Path == want {
+			return
+		}
+	}
+	t.Fatalf("residue %v is missing %q", paths(entries), want)
+}
+
+func trimTrailing(s string) string { return strings.TrimRight(s, "\n") }
+
+func headFileFor(files map[string]string) HeadFileFunc {
+	return func(rel string) ([]byte, error) {
+		content, ok := files[rel]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return []byte(content), nil
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// newScaffoldedWorktree builds a worktree in the exact shape gc leaves one:
+// an appended .gitignore block, an adopted .mcp.json with its managed marker,
+// and materialized skill symlinks named by an ownership manifest.
+func newScaffoldedWorktree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mcpContent := `{"mcpServers":{"bartertown":{"command":"/x/bartertown_mcp.py"}}}` + "\n"
+
+	writeFile(t, filepath.Join(dir, ".gitignore"), headGitignore+gasCityBlock)
+	writeFile(t, filepath.Join(dir, ".mcp.json"), mcpContent)
+
+	marker, err := json.Marshal(map[string]string{
+		"managed_by":     "gc",
+		"provider":       "claude",
+		"content_sha256": sha256Hex(mcpContent),
+	})
+	if err != nil {
+		t.Fatalf("marshal marker: %v", err)
+	}
+	writeFile(t, filepath.Join(dir, ".gc", "mcp-managed", "claude.json"), string(marker))
+
+	manifest, err := json.Marshal(map[string]any{
+		"targets": map[string]string{
+			"core.gc-mail": "/cache/packs/core/skills/gc-mail",
+			"core.gc-work": "/cache/packs/core/skills/gc-work",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	writeFile(t, filepath.Join(dir, ".claude", "skills", ownershipManifestFile), string(manifest))
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "core.gc-mail"), "symlink-stand-in")
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "core.gc-work"), "symlink-stand-in")
+
+	return dir
+}
+
+// fullScaffoldPorcelain is the status a healthy, untouched gc worktree
+// reports — the 100%-of-worktrees case from gas-wr8.
+const fullScaffoldPorcelain = ` M .gitignore
+ M .mcp.json
+?? .claude/skills/.gc-skill-ownership.json
+?? .claude/skills/core.gc-mail
+?? .claude/skills/core.gc-work
+`
+
+func TestResidueEmptyForPureScaffolding(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+
+	if got := HasRealWork(dir, fullScaffoldPorcelain, head); got {
+		residue := Residue(dir, parse(fullScaffoldPorcelain), head)
+		t.Fatalf("pure gc scaffolding classified as real work; residue = %v", paths(residue))
+	}
+}
+
+func TestResidueKeepsRealWork(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+	porcelain := fullScaffoldPorcelain + " M internal/git/git.go\n?? notes.md\n"
+
+	residue := Residue(dir, parse(porcelain), head)
+	if got := paths(residue); len(got) != 2 {
+		t.Fatalf("residue = %v, want exactly the two non-gc paths", got)
+	}
+	assertContains(t, residue, "internal/git/git.go")
+	assertContains(t, residue, "notes.md")
+}
+
+// A skill the agent placed by hand shares the sink directory with gc's own,
+// but is absent from the manifest — it is work, and must survive.
+func TestResidueKeepsUnmanifestedSinkEntry(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "my-own-skill"), "mine")
+	porcelain := fullScaffoldPorcelain + "?? .claude/skills/my-own-skill\n"
+
+	residue := Residue(dir, parse(porcelain), head)
+	assertContains(t, residue, ".claude/skills/my-own-skill")
+	if len(residue) != 1 {
+		t.Fatalf("residue = %v, want only the hand-placed skill", paths(residue))
+	}
+}
+
+// The destructive direction the gate exists to prevent: a real edit to the
+// shared, tracked .gitignore must not be swallowed by the block subtraction.
+func TestResidueKeepsGitignoreEditBesideGasCityBlock(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	writeFile(t, filepath.Join(dir, ".gitignore"), headGitignore+"coverage.out\n"+gasCityBlock)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+
+	residue := Residue(dir, parse(fullScaffoldPorcelain), head)
+	assertContains(t, residue, ".gitignore")
+}
+
+func TestResidueKeepsEditedMCPConfig(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	writeFile(t, filepath.Join(dir, ".mcp.json"), `{"mcpServers":{"hand-edited":{}}}`+"\n")
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+
+	residue := Residue(dir, parse(fullScaffoldPorcelain), head)
+	assertContains(t, residue, ".mcp.json")
+}
+
+// A marker predating content hashing proves gc adopted the file but not that
+// the bytes are still gc's, so it must fail closed.
+func TestResidueKeepsMCPConfigWhenMarkerHasNoHash(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	writeFile(t, filepath.Join(dir, ".gc", "mcp-managed", "claude.json"),
+		`{"managed_by":"gc","provider":"claude"}`)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+
+	residue := Residue(dir, parse(fullScaffoldPorcelain), head)
+	assertContains(t, residue, ".mcp.json")
+}
+
+// gc only ever writes these paths, so a deleted one is a change gc did not
+// make and must not be subtracted.
+func TestResidueKeepsDeletedScaffolding(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+
+	residue := Residue(dir, parse(" D .mcp.json\n"), head)
+	assertContains(t, residue, ".mcp.json")
+}
+
+// Ownership records are what make a path provable. Without the manifest and
+// the managed marker, the skill entries and the MCP config are indistinguishable
+// from agent work and must all survive — only .gitignore, whose proof is the
+// parsed block rather than an on-disk record, is still subtracted.
+func TestResidueWithoutOwnershipRecordsKeepsEverythingProvableOnlyByRecord(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".gitignore"), headGitignore+gasCityBlock)
+	head := headFileFor(map[string]string{".gitignore": headGitignore})
+
+	residue := Residue(dir, parse(fullScaffoldPorcelain), head)
+	want := []string{
+		".claude/skills/.gc-skill-ownership.json",
+		".claude/skills/core.gc-mail",
+		".claude/skills/core.gc-work",
+		".mcp.json",
+	}
+	if got := paths(residue); len(got) != len(want) {
+		t.Fatalf("residue = %v, want %v", got, want)
+	}
+	for _, w := range want {
+		assertContains(t, residue, w)
+	}
+}
+
+// A nil headFile disables only the .gitignore subtraction; the rest still work.
+func TestResidueWithNilHeadFileKeepsGitignore(t *testing.T) {
+	dir := newScaffoldedWorktree(t)
+
+	residue := Residue(dir, parse(fullScaffoldPorcelain), nil)
+	if got := paths(residue); len(got) != 1 || got[0] != ".gitignore" {
+		t.Fatalf("residue = %v, want only .gitignore", got)
+	}
+}
+
+func TestStripGasCityBlocksRemovesEveryBlock(t *testing.T) {
+	content := headGitignore + gasCityBlock + "\n# Gas City\n.beads/*\n!.beads/identity.toml\n"
+	if got := stripGasCityBlocks(content); trimTrailing(got) != trimTrailing(headGitignore) {
+		t.Fatalf("stripGasCityBlocks = %q, want %q", got, headGitignore)
+	}
+}
+
+// A user comment that merely starts with the marker text must not swallow the
+// user's own following entries.
+func TestStripGasCityBlocksStopsAtBlankLine(t *testing.T) {
+	content := "# Gas City\n.mcp.json\n\nkeep-me/\n"
+	want := "\nkeep-me/\n"
+	if got := stripGasCityBlocks(content); got != want {
+		t.Fatalf("stripGasCityBlocks = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

gc writes its own files into every worktree it creates: provider-native MCP config, materialized skill symlinks, and an appended "# Gas City" `.gitignore` block. All three land on tracked-or-visible paths, so `git status --porcelain` in a healthy, untouched gc worktree is never empty.

Every disposal gate written as "porcelain is non-empty => keep" therefore refuses forever. The reaper's git-safety gate (`HasUncommittedWork()` in `cmd/gc/bead_worktree_reaper.go`) protected 100% of managed worktrees: recovered worktrees accumulate on disk indefinitely, and the one signal that should mean "real uncommitted work is about to be destroyed" becomes indistinguishable from background noise. Measured on a live rig: 11 porcelain entries in an untouched polecat worktree — an identical set to the rig root, all gc scaffolding.

## Fix

New `internal/scaffold` package computes **residue**: porcelain entries minus what gc can *prove* it owns, from records gc itself wrote at injection time:

- **skill symlinks** — named in the sink's `.gc-skill-ownership.json` (sink location discovered, not hardcoded)
- **MCP config** — marked in `.gc/mcp-managed/<provider>.json`, and only while the file still hashes to what gc last wrote (`content_sha256`, newly recorded by materialize)
- **`.gitignore`** — only when removing gc's own parsed "# Gas City" blocks restores the committed content exactly

Subtraction is one-directional: anything unprovable stays residue, so the failure mode is a worktree that lives too long — never one deleted with real work in it. `.gitignore` and `.mcp.json` are shared tracked files an agent may legitimately edit, so neither is excluded by path — the block is parsed and the config is hashed. Markers predating the hash prove adoption but not content, and fail closed until gc next rewrites them. Deletions are never subtracted.

Wired into the reaper's git-safety gate in `cmd/gc/bead_worktree_reaper.go`. `internal/git` stays generic — it gains `StatusPorcelainUntrimmed` (porcelain v1 is fixed-width; the trimmed variant strips the leading space of an unstaged first record and shifts it out of column alignment) and `ShowAtHead`, but no knowledge of gc scaffolding. The composition lives in `cmd/gc` beside the gate that needs it.

## Not in this PR (tracked separately)

- Three sibling gates with the same bare-porcelain shape: `cmd/gc/session_worktree_prune.go` (2 sites), `cmd/gc/agent_home_worktree_cleanup.go`, `internal/doctor/checks_semantic.go` (gas-o01)
- The mol-witness-patrol formula's DIRTY gate, which lives in gascity-packs (gas-o11)

## Validation

- `internal/scaffold`, `internal/materialize`, `internal/git`: full package tests green at this branch tip on macOS
- `go test ./cmd/gc -run 'TestWorktreeHasUnsalvagedWork'`: both new tests green against a real git-repo fixture shaped like a live worktree, including a guard that the fixture trips the old gate
- `go vet` clean on all touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
