### PR TITLE
test(gc): regression coverage for the close-gate publication oracles (stacked on #5103)

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -56,7 +56,11 @@ type hookClaimOps struct {
 	// ResolveWorkBranch returns the git branch of the worker's worktree (dir),
 	// stamped onto the bead as gc.work_branch at claim time. Empty result (no
 	// repo / detached HEAD) omits the branch key — the session back-reference is
-	// still stamped.
+	// still stamped. The stamp is PROVISIONAL (the work does not exist yet, so
+	// this is the best-known value, useful for salvage if the worker dies): the
+	// close gate resolves the truth at close time and emits a stale-stamp
+	// advisory when the work landed on a different branch (ADR-0009 Defect C,
+	// work_record_gate.go).
 	ResolveWorkBranch hookResolveWorkBranchFunc
 	// StampWorkMeta writes the claim-time execution-identity metadata patch
 	// (gc.work_branch and/or the durable session back-reference gc.session_id /

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -16,9 +17,19 @@ import (
 // Work-record close gate (ADR-0009). Closing a work bead through the SDK close
 // seam (`gc bd close`) is validated against the typed work-record contract: the
 // bead must carry a typed gc.work_outcome, and a "shipped" outcome must point at
-// a commit that is reachable on the stamped gc.work_branch. This turns the
+// a commit that has been DELIVERED — present on a remote-tracking ref — and
+// reachable on the recorded gc.work_branch, with branch names resolved
+// remote-first (refs/remotes/origin/<branch> when it exists, because local refs
+// go stale in push-based topologies; gastownhall/gascity#5037). This turns the
 // recurring "drain-without-commit" close (a close that leaves no artifact at
 // all) into a machine-checkable violation.
+//
+// gc.work_branch is stamped at claim time (cmd_hook_claim.go) — before the work
+// exists — so it is a PROVISIONAL handle, not a promise. A shipped commit that
+// landed on a different branch than the stamp yields a non-blocking stale-stamp
+// advisory naming the actual landing branch (Defect C); only undelivered work
+// (no remote ref contains the commit) is a violation. Delivery is the guarantee;
+// the branch is the pointer.
 //
 // The gate ships warn-only by default — violations are logged but the close
 // proceeds — so existing open beads migrate without breakage. Set
@@ -68,37 +79,85 @@ func isWorkRecordGatedBead(bead beads.Bead) bool {
 	return true
 }
 
-// validateWorkRecordOnClose checks bead against the typed work-record contract
-// and returns a human-readable message for each violation (empty slice ⇒ the
-// bead satisfies the contract). commitReachable reports whether a commit SHA is
-// an ancestor of a branch; it is injected so the rule is unit-testable without
-// a real repo. The caller is responsible for scoping (isWorkRecordGatedBead).
-func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, branch string) bool) []string {
+// validateWorkRecordOnClose checks bead against the typed work-record contract.
+// It returns a human-readable message for each violation (blocking under
+// enforcement) and each advisory (never blocking). Empty violations ⇒ the bead
+// satisfies the contract. commitReachable reports whether a commit SHA is an
+// ancestor of a branch; commitOnRemote reports whether it is contained in any
+// remote-tracking ref; remoteBranchesContaining reports which remote-tracking
+// branches contain it. All three are injected so the rule is unit-testable
+// without a real repo. The caller is responsible for scoping
+// (isWorkRecordGatedBead).
+//
+// The oracles answer different questions and a shipped close needs them all.
+// Reachability is a LOCAL property: a commit on a branch that was never pushed is
+// still reachable from it, so reachability alone cannot distinguish delivered
+// work from work that exists only in a worktree. az-6n75 is that gap — nine beads
+// closed as delivered whose commits had no remote ref, one of them the only copy
+// in existence.
+//
+// The containment resolver exists for the converse gap (ADR-0009 Defect C):
+// gc.work_branch is stamped at claim time, before the work exists, with whatever
+// branch the claiming worktree was on. When the work lands elsewhere the stamp is
+// stale, and treating the resulting unreachability as a violation blocks honest
+// delivered closes — under GC_WORK_RECORD_ENFORCE, citywide. Delivery is the
+// guarantee this gate protects; the branch handle is the record's pointer to the
+// work. So: a commit unreachable on its stamped branch but present on a
+// remote-tracking ref yields a precise stale-stamp ADVISORY naming the branch the
+// work actually landed on (so the record can be corrected), not a violation —
+// while a commit on no remote ref remains a blocking violation regardless of the
+// stamp.
+func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, branch string) bool, commitOnRemote func(commit string) bool, remoteBranchesContaining func(commit string) []string) (violations, advisories []string) {
 	outcome := strings.TrimSpace(bead.Metadata[beadmeta.WorkOutcomeMetadataKey])
 	if outcome == "" {
-		return []string{fmt.Sprintf("missing %s (want one of shipped|no-op|blocked|abandoned)", beadmeta.WorkOutcomeMetadataKey)}
+		return []string{fmt.Sprintf("missing %s (want one of shipped|no-op|blocked|abandoned)", beadmeta.WorkOutcomeMetadataKey)}, nil
 	}
 	if !validWorkOutcome(outcome) {
-		return []string{fmt.Sprintf("invalid %s=%q (want one of shipped|no-op|blocked|abandoned)", beadmeta.WorkOutcomeMetadataKey, outcome)}
+		return []string{fmt.Sprintf("invalid %s=%q (want one of shipped|no-op|blocked|abandoned)", beadmeta.WorkOutcomeMetadataKey, outcome)}, nil
 	}
 	if outcome != beadmeta.WorkOutcomeShipped {
 		// no-op / blocked / abandoned carry their reason in the close-reason; no
 		// commit artifact is required.
-		return nil
+		return nil, nil
 	}
 	commit := strings.TrimSpace(bead.Metadata[beadmeta.WorkCommitMetadataKey])
 	branch := strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey])
-	var violations []string
 	if commit == "" {
 		violations = append(violations, fmt.Sprintf("%s=shipped requires %s (the commit that satisfied the bead)", beadmeta.WorkOutcomeMetadataKey, beadmeta.WorkCommitMetadataKey))
 	}
-	if branch == "" {
+	if branch == "" && commit != "" {
+		// The claim never stamped a branch (detached HEAD / non-repo claim dir).
+		// When the containment evidence can name where the work landed, the
+		// record is correctable — advise instead of blocking the delivered
+		// close; the durability rule below still decides delivery.
+		if containing := remoteBranchesContaining(commit); len(containing) > 0 {
+			advisories = append(advisories, fmt.Sprintf(
+				"%s is missing (claim stamped no branch): commit %s is contained in %s — correct the record with --set-metadata %s=%s",
+				beadmeta.WorkBranchMetadataKey, commit, strings.Join(containing, ", "), beadmeta.WorkBranchMetadataKey, containing[0]))
+		} else {
+			violations = append(violations, fmt.Sprintf("%s=shipped requires %s (the branch the commit lives on)", beadmeta.WorkOutcomeMetadataKey, beadmeta.WorkBranchMetadataKey))
+		}
+	} else if branch == "" {
 		violations = append(violations, fmt.Sprintf("%s=shipped requires %s (the branch the commit lives on)", beadmeta.WorkOutcomeMetadataKey, beadmeta.WorkBranchMetadataKey))
 	}
 	if commit != "" && branch != "" && !commitReachable(commit, branch) {
-		violations = append(violations, fmt.Sprintf("%s %s is not reachable on %s %s", beadmeta.WorkCommitMetadataKey, commit, beadmeta.WorkBranchMetadataKey, branch))
+		if containing := remoteBranchesContaining(commit); len(containing) > 0 {
+			// Delivered (or, in a repo with no publication remotes, present on a
+			// local branch), but the claim-time stamp went stale (Defect C):
+			// name where the work actually landed and how to correct the
+			// record. The resolver returns suggestible branch names —
+			// normalized, default-branch first, bounded.
+			advisories = append(advisories, fmt.Sprintf(
+				"%s %q is stale (stamped at claim time): commit %s is contained in %s — correct the record with --set-metadata %s=%s",
+				beadmeta.WorkBranchMetadataKey, branch, commit, strings.Join(containing, ", "), beadmeta.WorkBranchMetadataKey, containing[0]))
+		} else {
+			violations = append(violations, fmt.Sprintf("%s %s is not reachable on %s %s", beadmeta.WorkCommitMetadataKey, commit, beadmeta.WorkBranchMetadataKey, branch))
+		}
 	}
-	return violations
+	if commit != "" && !commitOnRemote(commit) {
+		violations = append(violations, fmt.Sprintf("%s %s is not present on any remote — the work exists only locally and any worktree prune or branch GC destroys it (push before closing)", beadmeta.WorkCommitMetadataKey, commit))
+	}
+	return violations, advisories
 }
 
 // gitCommitReachableOnBranch reports whether commit is an ancestor of branch in
@@ -107,6 +166,28 @@ func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, bra
 // repo, unknown ref, unknown commit — reads as "not reachable". A commit/branch
 // that looks like a flag (leading "-") is rejected outright so a malformed
 // metadata value can never be parsed as a git option.
+//
+// The branch name resolves against BOTH the remote-tracking refs of every
+// publication remote AND the local ref, and the commit is reachable when ANY of
+// them contains it (gastownhall/gascity#5037):
+//
+//   - The remote refs matter because in any topology where merges reach the
+//     target branch over the network, nothing ever advances the local ref —
+//     the refinery merges in a detached worktree and pushes, and no one may
+//     move a branch checked out in another worktree — so refs/heads/<branch>
+//     goes permanently stale while refs/remotes/<r>/<branch> is the truth. A
+//     bare name resolves to the stale local ref by gitrevisions precedence,
+//     reporting genuinely-merged commits unreachable. Every publication remote
+//     is consulted, not a hardcoded "origin" — a rig cloned with -o upstream is
+//     equally entitled to the fix.
+//   - The local ref matters because a commit sitting exactly on the stamped
+//     branch's local head, just not yet pushed, has a factually-correct branch
+//     record — its only defect is the missing push, which is the durability
+//     rule's job to report, precisely and alone.
+//
+// Each existence probe is a separate rev-parse call, deliberately NOT a
+// fallback on the merge-base exit code. A genuinely-unreachable commit is
+// contained by none of the refs and stays unreachable — fail closed.
 func gitCommitReachableOnBranch(repoDir, commit, branch string) bool {
 	if strings.TrimSpace(repoDir) == "" || commit == "" || branch == "" {
 		return false
@@ -114,7 +195,288 @@ func gitCommitReachableOnBranch(repoDir, commit, branch string) bool {
 	if strings.HasPrefix(commit, "-") || strings.HasPrefix(branch, "-") {
 		return false
 	}
-	return exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", commit, branch).Run() == nil
+	refs := []string{}
+	for _, remote := range gitPublicationRemotes(repoDir) {
+		remoteRef := "refs/remotes/" + remote + "/" + branch
+		if exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "--quiet", remoteRef).Run() == nil {
+			refs = append(refs, remoteRef)
+		}
+	}
+	if exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil {
+		refs = append(refs, "refs/heads/"+branch)
+	}
+	for _, ref := range refs {
+		if exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", commit, ref).Run() == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// gitCommitOnRemote reports whether commit is contained in a remote-tracking
+// ref of a PUBLICATION remote in the repository at repoDir — i.e. whether the
+// work has been published and would survive the worktree being pruned.
+//
+// It lists commits reachable from commit but from no publication remote: empty
+// output means the commit is already on one. Any git error reads as "not on a
+// remote" so the gate fails closed — a false "at risk" costs one push, a false
+// "durable" costs the work.
+//
+// Self-referential path remotes are excluded (gas-6tc; witness-side twin
+// gas-6wq): a remote whose URL resolves back into this same repository — the
+// gascity repo carries herdr-src = its own path — snapshots local branches into
+// refs/remotes/*, so a blanket --remotes reads any previously-fetched local
+// commit as "published" while it exists nowhere off this repo. That is the
+// az-6n75 hole reopened by configuration.
+//
+// This deliberately consults remote-tracking refs rather than running ls-remote:
+// the close path must not depend on network reachability. The tradeoff is that a
+// commit pushed by another clone since the last fetch reads as not-durable.
+func gitCommitOnRemote(repoDir, commit string) bool {
+	if strings.TrimSpace(repoDir) == "" || commit == "" {
+		return false
+	}
+	if strings.HasPrefix(commit, "-") {
+		return false
+	}
+	// A repo with no publication remotes has nowhere to publish, so durability
+	// is not applicable and the rule is skipped. Without this, every close in a
+	// local-only repo would be flagged for a push that cannot exist. A repo
+	// whose only remotes are self-referential is local-only in the same sense.
+	//
+	// Known tradeoff: a rig whose origin is removed or renamed silently stops
+	// being protected by this rule. Detecting that is the config layer's job —
+	// the close gate cannot tell "deliberately local" from "misconfigured".
+	publication := gitPublicationRemotes(repoDir)
+	if publication == nil {
+		return false
+	}
+	if len(publication) == 0 {
+		return true
+	}
+	args := []string{"-C", repoDir, "rev-list", "--max-count=1", commit, "--not"}
+	for _, name := range publication {
+		args = append(args, "--glob=refs/remotes/"+name+"/*")
+	}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) == 0
+}
+
+// gitPublicationRemotes returns the names of repoDir's remotes that can confer
+// durability: every configured remote except those whose URL resolves back into
+// this same repository (gas-6tc). nil means the remote list could not be read
+// (callers fail closed); an empty slice means there are remotes but none that
+// publish, or none at all.
+func gitPublicationRemotes(repoDir string) []string {
+	out, err := exec.Command("git", "-C", repoDir, "remote").Output()
+	if err != nil {
+		return nil
+	}
+	selfCommon := gitCommonDir(repoDir)
+	publication := []string{}
+	for _, name := range strings.Fields(string(out)) {
+		if strings.HasPrefix(name, "-") {
+			continue
+		}
+		urlOut, err := exec.Command("git", "-C", repoDir, "remote", "get-url", name).Output()
+		if err != nil {
+			// Unreadable URL: treat as a publication remote so the durability
+			// rule stays armed rather than silently skipped.
+			publication = append(publication, name)
+			continue
+		}
+		url := strings.TrimSpace(string(urlOut))
+		if isSelfRemoteURL(url, selfCommon) {
+			continue
+		}
+		publication = append(publication, name)
+	}
+	return publication
+}
+
+// isSelfRemoteURL reports whether a remote URL is a filesystem path that
+// resolves to the repository whose git common dir is selfCommon. Network URLs
+// (scheme://host/..., scp-style user@host:path) are never self-referential.
+func isSelfRemoteURL(url, selfCommon string) bool {
+	if url == "" || selfCommon == "" {
+		return false
+	}
+	if strings.Contains(url, "://") {
+		if !strings.HasPrefix(url, "file://") {
+			return false
+		}
+		url = strings.TrimPrefix(url, "file://")
+	} else if strings.Contains(url, "@") || looksLikeSCPRemote(url) {
+		return false
+	}
+	common := gitCommonDir(url)
+	return common != "" && common == selfCommon
+}
+
+// looksLikeSCPRemote reports whether url is scp-style (host:path) rather than a
+// local path: a colon before the first slash.
+func looksLikeSCPRemote(url string) bool {
+	colon := strings.Index(url, ":")
+	if colon < 0 {
+		return false
+	}
+	slash := strings.Index(url, "/")
+	return slash < 0 || colon < slash
+}
+
+// gitCommonDir resolves dir's git common directory (shared across worktrees) to
+// an absolute, symlink-resolved path, or "" when dir is not a git repository.
+// Two paths into the same repository — the root and any of its worktrees —
+// resolve to the same common dir, which is what makes it the right identity for
+// self-remote detection.
+func gitCommonDir(dir string) string {
+	if strings.TrimSpace(dir) == "" || strings.HasPrefix(dir, "-") {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir").Output()
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return p
+}
+
+// gitRemoteBranchesContaining reports which branches contain commit in the
+// repository at repoDir, as SUGGESTIBLE branch names: normalized (the
+// "<remote>/" qualifier stripped), deduplicated, remote default branches
+// first, bounded. It powers the stale claim-stamp advisory (Defect C): when
+// the stamped branch does not contain a shipped commit, the branches that DO
+// name where the work actually landed, and the first entry is the value the
+// advisory tells the closer to stamp.
+//
+// Sourcing rules:
+//   - Only publication remotes are consulted (gas-6tc): a self-referential
+//     path remote's snapshot of local branches is not delivery evidence and
+//     must never appear as a landing branch.
+//   - Bare-remote entries are dropped: %(refname:short) renders the symbolic
+//     refs/remotes/<r>/HEAD as the bare remote name, which is not a branch and
+//     must never become the suggested correction.
+//   - A remote's default branch (its HEAD symref target) sorts first when it
+//     contains the commit — for an older commit contained in many branches the
+//     alphabetically-first branch is an arbitrary and often transient choice,
+//     while the default branch is the durable pointer.
+//   - In a repo with no publication remotes — the local-only topology the
+//     durability rule deliberately accommodates — local branches are the only
+//     landing evidence there is, so refs/heads/* are consulted instead.
+//
+// Any git error reads as "no containing branches", which downgrades the caller
+// to the blocking not-reachable violation — fail closed, never open.
+//
+// Known shared window with the durability oracle: a remote-tracking ref whose
+// branch was deleted on the server still contains the commit locally until
+// `fetch --prune`, so recently-unpublished work can read as delivered. The
+// close path deliberately never touches the network (same tradeoff as
+// gitCommitOnRemote, documented there); closing this window for real is the
+// land-time SHA stamp + fetch-then-check design tracked for the universal bd
+// gate (az-5vwo / beads#4960).
+func gitRemoteBranchesContaining(repoDir, commit string) []string {
+	if strings.TrimSpace(repoDir) == "" || commit == "" || strings.HasPrefix(commit, "-") {
+		return nil
+	}
+	publication := gitPublicationRemotes(repoDir)
+	if publication == nil {
+		return nil
+	}
+	if len(publication) == 0 {
+		return gitLocalBranchesContaining(repoDir, commit)
+	}
+	publishes := make(map[string]bool, len(publication))
+	for _, name := range publication {
+		publishes[name] = true
+	}
+	out, err := exec.Command("git", "-C", repoDir, "branch", "-r", "--contains", commit, "--format=%(refname:short)").Output()
+	if err != nil {
+		return nil
+	}
+	defaults := gitRemoteDefaultBranches(repoDir, publication)
+	var preferred, rest []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasSuffix(line, "/HEAD") {
+			continue
+		}
+		remote, branch, ok := strings.Cut(line, "/")
+		if !ok || branch == "" || !publishes[remote] {
+			continue
+		}
+		if seen[branch] {
+			continue
+		}
+		seen[branch] = true
+		if defaults[branch] {
+			preferred = append(preferred, branch)
+		} else {
+			rest = append(rest, branch)
+		}
+	}
+	return boundLandingBranches(append(preferred, rest...))
+}
+
+// gitLocalBranchesContaining lists local branches containing commit, in
+// suggestible form, bounded. Used only when the repo has no publication
+// remotes (see gitRemoteBranchesContaining).
+func gitLocalBranchesContaining(repoDir, commit string) []string {
+	out, err := exec.Command("git", "-C", repoDir, "branch", "--contains", commit, "--format=%(refname:short)").Output()
+	if err != nil {
+		return nil
+	}
+	var branches []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		branches = append(branches, line)
+	}
+	return boundLandingBranches(branches)
+}
+
+// gitRemoteDefaultBranches resolves each publication remote's HEAD symref to
+// its default branch name. Missing symrefs (a remote never fetched, or set-head
+// never run) are simply absent.
+func gitRemoteDefaultBranches(repoDir string, publication []string) map[string]bool {
+	defaults := map[string]bool{}
+	for _, remote := range publication {
+		out, err := exec.Command("git", "-C", repoDir, "symbolic-ref", "--quiet", "refs/remotes/"+remote+"/HEAD").Output()
+		if err != nil {
+			continue
+		}
+		ref := strings.TrimSpace(string(out))
+		if branch, ok := strings.CutPrefix(ref, "refs/remotes/"+remote+"/"); ok && branch != "" {
+			defaults[branch] = true
+		}
+	}
+	return defaults
+}
+
+// maxLandingBranches bounds the advisory's branch list: enough to orient a
+// human, small enough to stay one readable line. The suggested correction is
+// always the first entry, so truncation costs context, never correctness.
+const maxLandingBranches = 5
+
+// boundLandingBranches caps branches at maxLandingBranches, appending a
+// "+N more" marker when truncating.
+func boundLandingBranches(branches []string) []string {
+	if len(branches) <= maxLandingBranches {
+		return branches
+	}
+	over := len(branches) - maxLandingBranches
+	return append(branches[:maxLandingBranches], fmt.Sprintf("(+%d more)", over))
 }
 
 // workRecordCloseTargets returns the bead IDs a bd invocation closes, and
@@ -238,16 +600,23 @@ func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched 
 		if repoDir == "" {
 			repoDir = scopeRoot
 		}
-		var violations []string
+		var violations, advisories []string
 		if projectionErr != nil {
 			violations = []string{projectionErr.Error()}
 		} else {
-			violations = validateWorkRecordOnClose(bead, func(commit, branch string) bool {
+			violations, advisories = validateWorkRecordOnClose(bead, func(commit, branch string) bool {
 				return gitCommitReachableOnBranch(repoDir, commit, branch)
+			}, func(commit string) bool {
+				return gitCommitOnRemote(repoDir, commit)
+			}, func(commit string) []string {
+				return gitRemoteBranchesContaining(repoDir, commit)
 			})
 		}
 		for _, v := range violations {
 			fmt.Fprintf(stderr, "gc bd: work-record gate (%s): close of %s: %s\n", mode, id, v) //nolint:errcheck // best-effort stderr
+		}
+		for _, a := range advisories {
+			fmt.Fprintf(stderr, "gc bd: work-record gate (advisory): close of %s: %s\n", id, a) //nolint:errcheck // best-effort stderr
 		}
 		if enforce && len(violations) > 0 {
 			block = true

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -275,7 +275,7 @@ func gitPublicationRemotes(repoDir string) []string {
 	if err != nil {
 		return nil
 	}
-	selfCommon := gitCommonDir(repoDir)
+	selfCommon := gitCommonDir("", repoDir)
 	publication := []string{}
 	for _, name := range strings.Fields(string(out)) {
 		if strings.HasPrefix(name, "-") {
@@ -289,7 +289,7 @@ func gitPublicationRemotes(repoDir string) []string {
 			continue
 		}
 		url := strings.TrimSpace(string(urlOut))
-		if isSelfRemoteURL(url, selfCommon) {
+		if isSelfRemoteURL(repoDir, url, selfCommon) {
 			continue
 		}
 		publication = append(publication, name)
@@ -300,7 +300,12 @@ func gitPublicationRemotes(repoDir string) []string {
 // isSelfRemoteURL reports whether a remote URL is a filesystem path that
 // resolves to the repository whose git common dir is selfCommon. Network URLs
 // (scheme://host/..., scp-style user@host:path) are never self-referential.
-func isSelfRemoteURL(url, selfCommon string) bool {
+//
+// repoDir anchors the resolution. Git resolves a relative remote URL against
+// the repository, so resolving it against the gc process's own working
+// directory instead would classify a self-referential remote as a publication
+// remote and let its snapshot refs stand in as delivery evidence.
+func isSelfRemoteURL(repoDir, url, selfCommon string) bool {
 	if url == "" || selfCommon == "" {
 		return false
 	}
@@ -312,7 +317,7 @@ func isSelfRemoteURL(url, selfCommon string) bool {
 	} else if strings.Contains(url, "@") || looksLikeSCPRemote(url) {
 		return false
 	}
-	common := gitCommonDir(url)
+	common := gitCommonDir(repoDir, url)
 	return common != "" && common == selfCommon
 }
 
@@ -332,11 +337,21 @@ func looksLikeSCPRemote(url string) bool {
 // Two paths into the same repository — the root and any of its worktrees —
 // resolve to the same common dir, which is what makes it the right identity for
 // self-remote detection.
-func gitCommonDir(dir string) string {
+//
+// baseDir, when non-empty, is the directory a relative dir resolves against.
+// Git applies -C flags left to right and resolves each against the previous, so
+// passing both reproduces git's own resolution of a relative remote URL —
+// against the repository, not against this process's working directory.
+func gitCommonDir(baseDir, dir string) string {
 	if strings.TrimSpace(dir) == "" || strings.HasPrefix(dir, "-") {
 		return ""
 	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir").Output()
+	args := []string{}
+	if strings.TrimSpace(baseDir) != "" && !strings.HasPrefix(baseDir, "-") {
+		args = append(args, "-C", baseDir)
+	}
+	args = append(args, "-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	out, err := exec.Command("git", args...).Output()
 	if err != nil {
 		return ""
 	}

--- a/cmd/gc/work_record_gate_oracle_test.go
+++ b/cmd/gc/work_record_gate_oracle_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// Regression coverage for the close gate's publication-oracle helpers (gas-amf).
+//
+// The gate's scenario tests inject fake oracles (alwaysOnRemote, neverOnRemote,
+// remoteContains) so they can exercise the decision logic without a git repo.
+// That is the right shape for those tests, but it means the real helper
+// implementations are never reached: measured at PR #5103's head, isSelfRemoteURL
+// sat at 50% having never once been observed returning true, boundLandingBranches
+// at 50% with its truncation arm unexercised, and looksLikeSCPRemote at 60%.
+// Six of the eight fixes in the gas-6tc/gas-dr5 review landed in this layer with
+// no regression test. These are those tests.
+//
+// They live in their own file on purpose: work_record_gate_test.go is the
+// conflict surface for the in-flight port of this layer onto main (PR #5103,
+// then gas-cj7 and gas-avv), and none of the behavior pinned here is touched by
+// those commits.
+
+// TestLooksLikeSCPRemote pins the scp-shorthand discriminator. It exists so
+// isSelfRemoteURL can reject `git@host:org/repo` without mistaking a local path
+// that merely contains a colon for a remote.
+func TestLooksLikeSCPRemote(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"scp shorthand with user", "git@github.com:org/repo.git", true},
+		{"scp shorthand without user", "github.com:org/repo", true},
+		{"colon with no slash anywhere", "host:", true},
+		{"absolute path", "/srv/git/repo", false},
+		{"relative path", "../sibling/repo", false},
+		{"bare name", "origin", false},
+		{"empty", "", false},
+		// The colon sits after the first slash, so this is a path that happens
+		// to contain a colon — not scp shorthand. This is the discrimination
+		// the function exists for.
+		{"colon after a slash is a path", "/srv/git/weird:name", false},
+		// A scheme URL also satisfies colon-before-slash. isSelfRemoteURL never
+		// asks this function about one — it routes "://" down the scheme branch
+		// first — so this is a documented shape of the helper in isolation, not
+		// a live defect. Pinned so a future caller knows to pre-filter schemes.
+		{"scheme url reads as scp in isolation", "https://example.com/org/repo", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeSCPRemote(tc.url); got != tc.want {
+				t.Errorf("looksLikeSCPRemote(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsSelfRemoteURL is probe B from gas-amf: the table the injected-fake suite
+// could not reach. isSelfRemoteURL resolves both sides through
+// `git rev-parse --git-common-dir`, so only a real repo can drive it to true —
+// and true is the answer that matters. It is the arm that filters a
+// self-referential path remote (the gascity rig's own `herdr-src`) out of the
+// publication set, so a commit pushed only back into the same repo is not
+// mistaken for durably published (gas-6tc).
+func TestIsSelfRemoteURL(t *testing.T) {
+	selfDir := t.TempDir()
+	runGit(t, selfDir, "init", "--initial-branch=main")
+	selfCommon := gitCommonDir("", selfDir)
+	if selfCommon == "" {
+		t.Fatalf("gitCommonDir(%q) = %q, want the repo's git dir — precondition failed", selfDir, selfCommon)
+	}
+
+	otherDir := t.TempDir()
+	runGit(t, otherDir, "init", "--initial-branch=main")
+
+	nonRepo := t.TempDir()
+
+	// A repo whose path contains "@". isSelfRemoteURL rejects any at-sign URL
+	// as ssh shorthand before it ever resolves the path, so this genuinely
+	// self-referential remote reads as "not self". See the dedicated test below.
+	atDir := filepath.Join(t.TempDir(), "worktree@2")
+	if err := os.MkdirAll(atDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", atDir, err)
+	}
+	runGit(t, atDir, "init", "--initial-branch=main")
+	atCommon := gitCommonDir("", atDir)
+	if atCommon == "" {
+		t.Fatalf("gitCommonDir(%q) = %q, want the repo's git dir — precondition failed", atDir, atCommon)
+	}
+
+	tests := []struct {
+		name       string
+		url        string
+		selfCommon string
+		want       bool
+	}{
+		// The two arms that were never observed returning true.
+		{"plain path to self", selfDir, selfCommon, true},
+		{"file:// url to self", "file://" + selfDir, selfCommon, true},
+
+		{"plain path to a different repo", otherDir, selfCommon, false},
+		{"file:// url to a different repo", "file://" + otherDir, selfCommon, false},
+		{"path that is not a repo", nonRepo, selfCommon, false},
+
+		// Non-file schemes are remote by definition, even when the path half
+		// points at this very repo.
+		{"ssh://localhost to self path", "ssh://localhost" + selfDir, selfCommon, false},
+		{"https url", "https://github.com/org/repo.git", selfCommon, false},
+		{"git protocol url", "git://example.com/org/repo.git", selfCommon, false},
+
+		{"scp shorthand", "git@github.com:org/repo.git", selfCommon, false},
+
+		{"empty url", "", selfCommon, false},
+		{"empty selfCommon", selfDir, "", false},
+		{"both empty", "", "", false},
+
+		// gitCommonDir refuses a leading dash rather than handing git something
+		// it would read as a flag.
+		{"dash-prefixed path", "-" + selfDir, selfCommon, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSelfRemoteURL(selfDir, tc.url, tc.selfCommon); got != tc.want {
+				t.Errorf("isSelfRemoteURL(%q, %q, %q) = %v, want %v", selfDir, tc.url, tc.selfCommon, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsSelfRemoteURLMissesSelfPathContainingAtSign pins a known limitation
+// rather than an intended behavior: the at-sign test that rejects ssh shorthand
+// runs before any path resolution, so a repo living under a directory with "@"
+// in its name is not recognized as self-referential.
+//
+// The failure is in the unsafe direction — such a remote stays in the
+// publication set, so a commit pushed only into the repo itself would read as
+// durably published. It needs a real path to reproduce, so it is pinned here and
+// filed rather than silently carried.
+func TestIsSelfRemoteURLMissesSelfPathContainingAtSign(t *testing.T) {
+	atDir := filepath.Join(t.TempDir(), "user@corp")
+	if err := os.MkdirAll(atDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", atDir, err)
+	}
+	runGit(t, atDir, "init", "--initial-branch=main")
+	atCommon := gitCommonDir("", atDir)
+	if atCommon == "" {
+		t.Fatalf("gitCommonDir(%q) = %q, want the repo's git dir — precondition failed", atDir, atCommon)
+	}
+
+	// The path IS this repo: resolution would say so if it were reached.
+	if got := isSelfRemoteURL(atDir, atDir, atCommon); got {
+		t.Fatalf("isSelfRemoteURL(%q, %q, %q) = true — the at-sign limitation is fixed; "+
+			"delete this test and drop the at-sign case from TestIsSelfRemoteURL", atDir, atDir, atCommon)
+	}
+}
+
+// TestBoundLandingBranches covers the truncation arm the advisory path never
+// exercised: the branch list is capped so the gate's suggestion stays one
+// readable line, and the suggested correction is always first, so truncation
+// costs context and never correctness.
+func TestBoundLandingBranches(t *testing.T) {
+	if maxLandingBranches != 5 {
+		t.Fatalf("maxLandingBranches = %d; this table is written against 5 — update the cases", maxLandingBranches)
+	}
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty", []string{}, []string{}},
+		{"under the cap", []string{"main", "release"}, []string{"main", "release"}},
+		{"exactly the cap", []string{"a", "b", "c", "d", "e"}, []string{"a", "b", "c", "d", "e"}},
+		{"one over the cap", []string{"a", "b", "c", "d", "e", "f"}, []string{"a", "b", "c", "d", "e", "(+1 more)"}},
+		{"several over the cap", []string{"a", "b", "c", "d", "e", "f", "g", "h"}, []string{"a", "b", "c", "d", "e", "(+3 more)"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := boundLandingBranches(slices.Clone(tc.in))
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("boundLandingBranches(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			if len(got) > maxLandingBranches+1 {
+				t.Errorf("boundLandingBranches(%v) returned %d entries, want at most %d", tc.in, len(got), maxLandingBranches+1)
+			}
+		})
+	}
+}
+
+// TestBoundLandingBranchesAliasesCallerSlice pins that the truncation appends
+// into the caller's backing array, overwriting the first dropped element.
+//
+// Both current callers hand over a freshly built slice they discard, so this is
+// latent rather than live — which is exactly why it needs a test. If a future
+// caller reuses its slice after the call, this documents the trap; if someone
+// makes the function copy instead, this test fails and is simply deleted.
+func TestBoundLandingBranchesAliasesCallerSlice(t *testing.T) {
+	in := []string{"a", "b", "c", "d", "e", "f", "g"}
+	_ = boundLandingBranches(in)
+	if in[maxLandingBranches] != "(+2 more)" {
+		t.Fatalf("in[%d] = %q, want %q — boundLandingBranches no longer aliases its "+
+			"argument; that is an improvement, so delete this test",
+			maxLandingBranches, in[maxLandingBranches], "(+2 more)")
+	}
+}
+
+// TestRunWorkRecordCloseGateIgnoresNonCloseArgs pins that only a real close
+// reaches the gate, asserted at the runWorkRecordCloseGate seam rather than
+// against workRecordCloseTargets in isolation.
+//
+// The panicOnGetStore double is what gives it teeth: a bd invocation wrongly
+// classified as a close walks on to the bead lookup, and with no preFetched
+// entry that panics instead of quietly returning false. Verified by mutation —
+// making bdUpdateClosesStatus return true unconditionally fails this test.
+//
+// The two `update` cases carry that weight. The `show` and `list` cases are
+// cheap breadth: a downstream write-ID guard independently rejects them, so
+// they would survive a regression in the verb switch alone.
+func TestRunWorkRecordCloseGateIgnoresNonCloseArgs(t *testing.T) {
+	t.Setenv(workRecordEnforceEnvVar, "1")
+	for _, args := range [][]string{
+		{"show", "wr-1"},
+		{"list"},
+		{"update", "wr-1", "--notes", "x"},
+		{"update", "wr-1", "--status=open"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stderr strings.Builder
+			if block := runWorkRecordCloseGate(args, t.TempDir(), "/nonexistent/does-not-exist", nil, panicOnGetStore{}, nil, &stderr); block {
+				t.Errorf("runWorkRecordCloseGate(%v) = true, want false — non-close args must never be gated", args)
+			}
+			if stderr.String() != "" {
+				t.Errorf("runWorkRecordCloseGate(%v) wrote %q to stderr, want nothing", args, stderr.String())
+			}
+		})
+	}
+}
+
+// runWorkRecordCloseGate's remaining two arms are deliberately left uncovered
+// here, and the reasons are worth recording so the next reader does not spend
+// the same afternoon on them:
+//
+//   - The store-opening arm (preOpened == nil) is not unit-testable. Handing the
+//     gate a real scope path makes openStoreAtForCityWithConfig start a managed
+//     `dolt sql-server`, which the package's own leak guard then fails the run
+//     over. That is why every gate test in this package injects preOpened.
+//
+//   - The fail-open arm ("cannot verify — never block a close on our own read
+//     failure") is unreachable by any input. openStoreAtForCityWithConfig
+//     returned a usable store for every hostile path tried — nonexistent, a
+//     regular file, a chmod-000 directory, a malformed .beads config — because
+//     it defers failure to query time.
+//
+// Both need an injectable store-opener seam to cover, which is a production
+// change and not this bead's scope. Left uncovered and filed rather than faked:
+// a test that cannot fail is worse than an honest gap.

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -1007,6 +1007,63 @@ func TestEvaluateWorkRecordCloseGateSelfRemote(t *testing.T) {
 	}
 }
 
+// TestEvaluateWorkRecordCloseGateRelativeSelfRemote covers a self-referential
+// remote written as a *relative* path. Git resolves such a URL against the
+// repository, so it is an ordinary configuration; resolving it against the gc
+// process's own working directory instead classifies it as a real publication
+// remote and its snapshot refs become delivery evidence for work that never
+// left the host. TestEvaluateWorkRecordCloseGateSelfRemote cannot cover this:
+// it adds its remote as an absolute t.TempDir() path.
+func TestEvaluateWorkRecordCloseGateRelativeSelfRemote(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	// Relative spelling of the same self-reference: from repoDir, "../<base>"
+	// is repoDir. The test process's cwd is the cmd/gc package directory, so a
+	// resolution anchored there lands somewhere else entirely.
+	relURL := "../" + filepath.Base(repoDir)
+	runGit(t, repoDir, "remote", "add", "self-rel", relURL)
+
+	// Precondition: the URL must stay relative. If git or a future helper ever
+	// records it absolute, this test silently becomes a duplicate of the
+	// absolute-path case and stops covering the branch it exists for.
+	if got := strings.TrimSpace(runGit(t, repoDir, "remote", "get-url", "self-rel")); got != relURL {
+		t.Fatalf("precondition: remote URL must stay relative, got %q want %q", got, relURL)
+	}
+
+	const workBranch = "gc-gastown.slit-4f3e2d1c0b9a"
+	runGit(t, repoDir, "checkout", "-b", workBranch)
+	commit := gateCommit(t, repoDir, "feature.txt", "only local\n", "feat: never pushed off-machine")
+	runGit(t, repoDir, "fetch", "self-rel")
+
+	// Precondition: git itself resolved the relative URL against the repository,
+	// so the snapshot genuinely contains the unpushed commit.
+	if !gateRefContains(t, repoDir, "refs/remotes/self-rel/"+workBranch, commit) {
+		t.Fatalf("precondition: relative self-remote ref must contain the unpushed commit")
+	}
+
+	newStore := func() beads.Store { return gateStoreWith("wr-rel-self-remote", repoDir) }
+	closeArgs := gateShippedCloseArgs("wr-rel-self-remote", commit, workBranch)
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(closeArgs, newStore(), nil, repoDir, true, &stderr); !block {
+		t.Fatalf("close of relative-self-remote-only work was allowed; the snapshot counted as delivery")
+	}
+	if got := stderr.String(); !strings.Contains(got, "not present on any remote") {
+		t.Fatalf("expected a durability violation, got %q", got)
+	}
+
+	// Paired positive: a real push must still be allowed, so the fix cannot be
+	// satisfied by a filter that discards every remote.
+	runGit(t, repoDir, "push", "origin", workBranch)
+	var pushedStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(closeArgs, newStore(), nil, repoDir, true, &pushedStderr); block {
+		t.Fatalf("close blocked after real push; stderr=%s", pushedStderr.String())
+	}
+	if got := pushedStderr.String(); got != "" {
+		t.Fatalf("pushed close warned: %q", got)
+	}
+}
+
 func TestWorkRecordEnforceEnabled(t *testing.T) {
 	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
 		t.Setenv(workRecordEnforceEnvVar, v)

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -15,12 +15,32 @@ import (
 func alwaysReachable(string, string) bool { return true }
 func neverReachable(string, string) bool  { return false }
 
+// alwaysOnRemote / neverOnRemote are injected durability oracles: they report
+// whether a commit is contained in any remote-tracking ref. Reachability on a
+// branch and presence on a remote are independent — a commit on a local-only
+// branch is reachable but not durable — so they are separate oracles.
+func alwaysOnRemote(string) bool { return true }
+func neverOnRemote(string) bool  { return false }
+
+// noRemoteContains / remoteContains are injected containment resolvers: they
+// report which remote-tracking branches contain a commit. The stale claim-stamp
+// rule (ADR-0009 Defect C) uses them to distinguish a delivered commit whose
+// stamped gc.work_branch is merely stale from genuinely undelivered work.
+func noRemoteContains(string) []string { return nil }
+
+func remoteContains(branches ...string) func(string) []string {
+	return func(string) []string { return branches }
+}
+
 func TestValidateWorkRecordOnClose(t *testing.T) {
 	tests := []struct {
-		name      string
-		meta      map[string]string
-		reachable func(string, string) bool
-		wantViol  string // substring expected in the (single) violation; "" ⇒ no violations
+		name       string
+		meta       map[string]string
+		reachable  func(string, string) bool
+		onRemote   func(string) bool
+		containing func(string) []string
+		wantViol   string // substring expected in the (single) violation; "" ⇒ no violations
+		wantAdv    string // substring expected in the (single) advisory; "" ⇒ no advisories
 	}{
 		{
 			name:     "no-op close passes",
@@ -43,6 +63,21 @@ func TestValidateWorkRecordOnClose(t *testing.T) {
 			wantViol:  "",
 		},
 		{
+			// az-6n75: the data-loss case. The polecat committed and the commit is
+			// reachable on the branch it recorded, but the branch was never pushed,
+			// so the work exists only in a worktree that any prune can destroy.
+			// Reachability alone cannot see this — the branch resolves locally.
+			name: "shipped with commit reachable locally but NOT on any remote is rejected",
+			meta: map[string]string{
+				beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped,
+				beadmeta.WorkCommitMetadataKey:  "abc123",
+				beadmeta.WorkBranchMetadataKey:  "gc-gastown.rictus-5bca5afe897d",
+			},
+			reachable: alwaysReachable,
+			onRemote:  neverOnRemote,
+			wantViol:  "not present on any remote",
+		},
+		{
 			name: "shipped with commit NOT reachable on branch is rejected",
 			meta: map[string]string{
 				beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped,
@@ -51,6 +86,39 @@ func TestValidateWorkRecordOnClose(t *testing.T) {
 			},
 			reachable: neverReachable,
 			wantViol:  "not reachable",
+		},
+		{
+			// ADR-0009 Defect C: gc.work_branch is stamped at claim time, before
+			// the work exists, so an honest delivered close can carry a stale
+			// branch. Delivered work (on a remote-tracking ref) must not be
+			// blocked for a stale stamp — it gets a precise advisory naming the
+			// branch the work actually landed on, so the record can be corrected.
+			name: "shipped delivered on another remote branch passes with a stale-stamp advisory",
+			meta: map[string]string{
+				beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped,
+				beadmeta.WorkCommitMetadataKey:  "abc123",
+				beadmeta.WorkBranchMetadataKey:  "gc-gastown.nux-1a2b3c4d5e6f",
+			},
+			reachable:  neverReachable,
+			onRemote:   alwaysOnRemote,
+			containing: remoteContains("fix/wr-defect-c"),
+			wantViol:   "",
+			wantAdv:    "fix/wr-defect-c",
+		},
+		{
+			// The advisory path must not open the az-6n75 hole: an unreachable
+			// commit that is on NO remote ref is undelivered work and still
+			// violates, stale stamp or not.
+			name: "shipped unreachable and on no remote ref stays rejected",
+			meta: map[string]string{
+				beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped,
+				beadmeta.WorkCommitMetadataKey:  "abc123",
+				beadmeta.WorkBranchMetadataKey:  "gc-gastown.nux-1a2b3c4d5e6f",
+			},
+			reachable:  neverReachable,
+			onRemote:   neverOnRemote,
+			containing: noRemoteContains,
+			wantViol:   "not reachable",
 		},
 		{
 			name: "shipped without commit is rejected",
@@ -87,8 +155,32 @@ func TestValidateWorkRecordOnClose(t *testing.T) {
 			if reachable == nil {
 				reachable = neverReachable
 			}
+			onRemote := tc.onRemote
+			if onRemote == nil {
+				// Default to durable so pre-existing cases exercise only the rule
+				// they were written for.
+				onRemote = alwaysOnRemote
+			}
+			containing := tc.containing
+			if containing == nil {
+				// Default to no containing branches so pre-existing cases keep
+				// their original violation semantics.
+				containing = noRemoteContains
+			}
 			bead := beads.Bead{ID: "wr-1", Type: "task", Metadata: tc.meta}
-			got := validateWorkRecordOnClose(bead, reachable)
+			got, advisories := validateWorkRecordOnClose(bead, reachable, onRemote, containing)
+			if tc.wantAdv == "" {
+				if len(advisories) != 0 {
+					t.Fatalf("expected no advisories, got %v", advisories)
+				}
+			} else {
+				if len(advisories) == 0 {
+					t.Fatalf("expected an advisory containing %q, got none", tc.wantAdv)
+				}
+				if joined := strings.Join(advisories, " | "); !strings.Contains(joined, tc.wantAdv) {
+					t.Fatalf("advisory %q does not contain %q", joined, tc.wantAdv)
+				}
+			}
 			if tc.wantViol == "" {
 				if len(got) != 0 {
 					t.Fatalf("expected no violations, got %v", got)
@@ -339,6 +431,269 @@ func TestEvaluateWorkRecordCloseGate(t *testing.T) {
 	}
 }
 
+// newGateRepo creates a repo with one configured remote (remoteName) backed by
+// a bare origin directory, a base commit on main pushed to that remote, and the
+// remote's HEAD symref set (as a real clone would have it). It is the shared
+// setup for every real-repo gate test; keeping it in one place keeps the gate
+// regression scenarios from silently diverging.
+func newGateRepo(t *testing.T, remoteName string) (repoDir string) {
+	t.Helper()
+	bareDir := t.TempDir()
+	runGit(t, bareDir, "init", "--bare", "--initial-branch=main")
+
+	repoDir = t.TempDir()
+	runGit(t, repoDir, "init", "--initial-branch=main")
+	runGit(t, repoDir, "config", "user.name", "Gas City Test")
+	runGit(t, repoDir, "config", "user.email", "gc-test@test.local")
+	runGit(t, repoDir, "remote", "add", remoteName, bareDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	runGit(t, repoDir, "add", "base.txt")
+	runGit(t, repoDir, "commit", "-m", "test: base")
+	runGit(t, repoDir, "push", remoteName, "main")
+	// A real clone carries refs/remotes/<name>/HEAD; tests must too, because
+	// %(refname:short) renders it as the bare remote name — a shape the
+	// containment filter has to reject (review finding: it sorts first and
+	// would otherwise become the advisory's suggested correction).
+	runGit(t, repoDir, "fetch", remoteName)
+	runGit(t, repoDir, "remote", "set-head", remoteName, "main")
+	return repoDir
+}
+
+// gateCommit writes path with content and commits it in repoDir, returning the
+// commit SHA.
+func gateCommit(t *testing.T, repoDir, path, content, message string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repoDir, path), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	runGit(t, repoDir, "add", path)
+	runGit(t, repoDir, "commit", "-m", message)
+	return strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+// gateRefContains reports whether ref contains commit, asking git the same
+// question the production oracles ask: `rev-list --max-count=1 <commit> --not
+// <ref>` prints nothing when ref already contains commit.
+//
+// It routes through runGit so a git error — a mistyped ref, a bad repo — fails
+// the test instead of reading as "not contained". These call sites are
+// preconditions, and a precondition that a typo can satisfy vacuously is worse
+// than no precondition at all.
+func gateRefContains(t *testing.T, repoDir, ref, commit string) bool {
+	t.Helper()
+	return strings.TrimSpace(runGit(t, repoDir, "rev-list", "--max-count=1", commit, "--not", ref)) == ""
+}
+
+// gateStoreWith returns a fresh in-memory store holding one gated task bead
+// whose work dir is repoDir.
+func gateStoreWith(id, repoDir string) beads.Store {
+	return beads.NewMemStoreFrom(1, []beads.Bead{{
+		ID:     id,
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey: repoDir,
+		},
+	}}, nil)
+}
+
+// gateShippedCloseArgs is the documented atomic shipped-close invocation for
+// bead id: stamp the typed work record and close in one update.
+func gateShippedCloseArgs(id, commit, branch string) []string {
+	return []string{
+		"update", id,
+		"--set-metadata", beadmeta.WorkOutcomeMetadataKey + "=" + beadmeta.WorkOutcomeShipped,
+		"--set-metadata", beadmeta.WorkCommitMetadataKey + "=" + commit,
+		"--set-metadata", beadmeta.WorkBranchMetadataKey + "=" + branch,
+		"--status=closed",
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateNonOriginRemote covers the review finding that
+// the remote-first resolution must not hardcode the remote name "origin": in a
+// rig whose only remote is named upstream (git clone -o upstream), the #5037
+// stale-local-ref fix must still work, and a stale-stamp advisory must suggest
+// the bare branch name, never a remote-qualified one.
+func TestEvaluateWorkRecordCloseGateNonOriginRemote(t *testing.T) {
+	repoDir := newGateRepo(t, "upstream")
+
+	// Land the work on upstream/main without moving local main (the refinery
+	// topology), as in TestEvaluateWorkRecordCloseGateStaleLocalRef.
+	runGit(t, repoDir, "checkout", "-b", "tmp-land")
+	commit := gateCommit(t, repoDir, "landed.txt", "merged over the network\n", "feat: the work")
+	runGit(t, repoDir, "push", "upstream", "tmp-land:main")
+	runGit(t, repoDir, "fetch", "upstream")
+	runGit(t, repoDir, "checkout", "main")
+	runGit(t, repoDir, "branch", "-D", "tmp-land")
+
+	if gateRefContains(t, repoDir, "refs/heads/main", commit) {
+		t.Fatalf("precondition: commit must NOT be reachable on the stale local main")
+	}
+	if !gitCommitReachableOnBranch(repoDir, commit, "main") {
+		t.Fatalf("remote-first resolution is inert for a remote not named origin")
+	}
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(gateShippedCloseArgs("wr-upstream", commit, "main"), gateStoreWith("wr-upstream", repoDir), nil, repoDir, true, &stderr); block {
+		t.Fatalf("delivered close blocked in a non-origin repo; stderr=%s", stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("clean delivered close produced gate output: %q", got)
+	}
+
+	// Stale stamp in the same repo: the advisory must suggest the unqualified
+	// branch name — never "upstream/main", and never the bare remote name.
+	var staleStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(gateShippedCloseArgs("wr-upstream", commit, "gc-gastown.nux-1a2b3c4d5e6f"), gateStoreWith("wr-upstream", repoDir), nil, repoDir, true, &staleStderr); block {
+		t.Fatalf("delivered stale-stamp close blocked; stderr=%s", staleStderr.String())
+	}
+	out := staleStderr.String()
+	if !strings.Contains(out, beadmeta.WorkBranchMetadataKey+"=main") {
+		t.Fatalf("advisory must suggest the unqualified branch: %q", out)
+	}
+	if strings.Contains(out, beadmeta.WorkBranchMetadataKey+"=upstream") {
+		t.Fatalf("advisory suggested a remote-qualified or bare-remote value: %q", out)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateUnpushedOnBranchSingleViolation covers the
+// review finding that a commit sitting exactly on its stamped branch's local
+// head — just not yet pushed — must produce only the actionable durability
+// violation, not an additional false "not reachable" one: the stamped branch is
+// factually correct, the only defect is the missing push.
+func TestEvaluateWorkRecordCloseGateUnpushedOnBranchSingleViolation(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	const workBranch = "gc-gastown.rictus-5bca5afe897d"
+	runGit(t, repoDir, "checkout", "-b", workBranch)
+	gateCommit(t, repoDir, "feature.txt", "v1\n", "feat: v1")
+	runGit(t, repoDir, "push", "origin", workBranch)
+	runGit(t, repoDir, "fetch", "origin")
+	// A second commit on the same branch, not yet pushed: origin/<workBranch>
+	// exists but is one behind.
+	commit := gateCommit(t, repoDir, "feature.txt", "v2\n", "feat: v2")
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(gateShippedCloseArgs("wr-onbranch", commit, workBranch), gateStoreWith("wr-onbranch", repoDir), nil, repoDir, true, &stderr); !block {
+		t.Fatalf("close of unpushed work was allowed")
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "not present on any remote") {
+		t.Fatalf("expected the durability violation, got %q", out)
+	}
+	if strings.Contains(out, "not reachable") {
+		t.Fatalf("factually-wrong reachability violation for a commit on its stamped branch: %q", out)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateRemotelessStaleStamp covers the review finding
+// that Defect C persisted in the local-only topology the durability oracle
+// deliberately supports: with no remotes at all, a stale claim stamp must
+// downgrade to an advisory naming the local branch the work landed on, not
+// block the close.
+func TestEvaluateWorkRecordCloseGateRemotelessStaleStamp(t *testing.T) {
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "--initial-branch=main")
+	runGit(t, repoDir, "config", "user.name", "Gas City Test")
+	runGit(t, repoDir, "config", "user.email", "gc-test@test.local")
+	if err := os.WriteFile(filepath.Join(repoDir, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	runGit(t, repoDir, "add", "base.txt")
+	runGit(t, repoDir, "commit", "-m", "test: base")
+
+	runGit(t, repoDir, "checkout", "-b", "fix/local-work")
+	commit := gateCommit(t, repoDir, "feature.txt", "local-only rig\n", "feat: local work")
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(gateShippedCloseArgs("wr-remoteless", commit, "gc-gastown.nux-1a2b3c4d5e6f"), gateStoreWith("wr-remoteless", repoDir), nil, repoDir, true, &stderr); block {
+		t.Fatalf("stale-stamp close blocked in a remoteless repo; stderr=%s", stderr.String())
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "advisory") || !strings.Contains(out, "fix/local-work") {
+		t.Fatalf("expected a stale-stamp advisory naming the local branch, got %q", out)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateMissingStampDelivered covers the review
+// finding that a delivered shipped close with no gc.work_branch at all (a
+// detached-HEAD or non-repo claim omits the stamp) was still hard-blocked:
+// when the containment evidence can name the landing branch, the missing stamp
+// downgrades to an advisory carrying the correction.
+func TestEvaluateWorkRecordCloseGateMissingStampDelivered(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	const landedBranch = "fix/wr-detached-claim"
+	runGit(t, repoDir, "checkout", "-b", landedBranch)
+	commit := gateCommit(t, repoDir, "feature.txt", "delivered\n", "feat: the work")
+	runGit(t, repoDir, "push", "origin", landedBranch)
+	runGit(t, repoDir, "fetch", "origin")
+
+	args := []string{
+		"update", "wr-nostamp",
+		"--set-metadata", beadmeta.WorkOutcomeMetadataKey + "=" + beadmeta.WorkOutcomeShipped,
+		"--set-metadata", beadmeta.WorkCommitMetadataKey + "=" + commit,
+		"--status=closed",
+	}
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(args, gateStoreWith("wr-nostamp", repoDir), nil, repoDir, true, &stderr); block {
+		t.Fatalf("delivered close with a missing stamp blocked; stderr=%s", stderr.String())
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "advisory") || !strings.Contains(out, landedBranch) {
+		t.Fatalf("expected a missing-stamp advisory naming the landed branch, got %q", out)
+	}
+
+	// The paired negative: missing stamp AND undelivered commit must still
+	// violate — the downgrade rides on delivery evidence, not on leniency.
+	unpushed := gateCommit(t, repoDir, "feature.txt", "delivered v2\n", "feat: never pushed")
+	undeliveredArgs := []string{
+		"update", "wr-nostamp",
+		"--set-metadata", beadmeta.WorkOutcomeMetadataKey + "=" + beadmeta.WorkOutcomeShipped,
+		"--set-metadata", beadmeta.WorkCommitMetadataKey + "=" + unpushed,
+		"--status=closed",
+	}
+	var undeliveredStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(undeliveredArgs, gateStoreWith("wr-nostamp", repoDir), nil, repoDir, true, &undeliveredStderr); !block {
+		t.Fatalf("undelivered close with a missing stamp was allowed")
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateAdvisoryPrefersDefaultBranch covers the review
+// finding that the suggested correction was containing[0] — the alphabetically
+// first remote branch, an arbitrary choice for an older commit contained in
+// many branches. The remote's default branch must win when it contains the
+// commit, and the bare remote name (origin/HEAD's short form) must never be
+// suggested.
+func TestEvaluateWorkRecordCloseGateAdvisoryPrefersDefaultBranch(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	// Land the work on main, then cut branches that also contain it and sort
+	// ahead of "main" alphabetically.
+	runGit(t, repoDir, "checkout", "main")
+	commit := gateCommit(t, repoDir, "feature.txt", "landed\n", "feat: the work")
+	runGit(t, repoDir, "push", "origin", "main")
+	for _, b := range []string{"aa-derived", "ab-derived"} {
+		runGit(t, repoDir, "branch", b)
+		runGit(t, repoDir, "push", "origin", b)
+	}
+	runGit(t, repoDir, "fetch", "origin")
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(gateShippedCloseArgs("wr-prefer", commit, "gc-gastown.nux-1a2b3c4d5e6f"), gateStoreWith("wr-prefer", repoDir), nil, repoDir, true, &stderr); block {
+		t.Fatalf("delivered stale-stamp close blocked; stderr=%s", stderr.String())
+	}
+	out := stderr.String()
+	if !strings.Contains(out, beadmeta.WorkBranchMetadataKey+"=main") {
+		t.Fatalf("advisory must suggest the remote default branch, got %q", out)
+	}
+	if strings.Contains(out, beadmeta.WorkBranchMetadataKey+"=aa-derived") {
+		t.Fatalf("advisory suggested the alphabetically-first branch instead of the default: %q", out)
+	}
+}
+
 func TestEvaluateWorkRecordCloseGateAtomicShippedUpdate(t *testing.T) {
 	repoDir := t.TempDir()
 	runGit(t, repoDir, "init", "--initial-branch=main")
@@ -422,6 +777,233 @@ func TestRunWorkRecordCloseGateReusesPreOpenedStore(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "work-record gate (enforced)") {
 		t.Fatalf("expected enforced gate output, got %q", stderr.String())
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateUnpushedBranch is the az-6n75 regression test.
+// It reproduces the kit-ccf incident end to end against a real repo: a polecat
+// commits on its own branch, records a correct and internally-consistent work
+// record, and closes — but never pushes. Every pre-existing rule passes. The
+// commit IS reachable on the branch it names; the branch simply exists nowhere
+// but this worktree, so a prune destroys the only copy.
+//
+// The paired assertion matters as much as the block: after the identical commit
+// is pushed, the same close must be allowed. A rule that blocks unpushed work by
+// blocking everything would pass a one-sided test.
+func TestEvaluateWorkRecordCloseGateUnpushedBranch(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	// The polecat's own branch, mirroring gc-gastown.<name>-<hash>.
+	const workBranch = "gc-gastown.rictus-5bca5afe897d"
+	runGit(t, repoDir, "checkout", "-b", workBranch)
+	commit := gateCommit(t, repoDir, "feature.txt", "quote stripper\n", "feat: quote stripper stage 1")
+
+	newStore := func() beads.Store { return gateStoreWith("wr-unpushed", repoDir) }
+	args := gateShippedCloseArgs("wr-unpushed", commit, workBranch)
+
+	// Sanity: the pre-existing reachability rule cannot see this failure. If this
+	// ever stops holding, the durability rule is no longer the thing under test.
+	if !gitCommitReachableOnBranch(repoDir, commit, workBranch) {
+		t.Fatalf("precondition: commit should be reachable on its own branch")
+	}
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(args, newStore(), nil, repoDir, true, &stderr); !block {
+		t.Fatalf("close of unpushed work was allowed; the branch exists on no remote")
+	}
+	if got := stderr.String(); !strings.Contains(got, "not present on any remote") {
+		t.Fatalf("expected a durability violation, got %q", got)
+	}
+
+	// Same commit, same close, after publishing: must now be allowed.
+	runGit(t, repoDir, "push", "origin", workBranch)
+	var pushedStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(args, newStore(), nil, repoDir, true, &pushedStderr); block {
+		t.Fatalf("close blocked after push; stderr=%s", pushedStderr.String())
+	}
+	if got := pushedStderr.String(); got != "" {
+		t.Fatalf("pushed close warned: %q", got)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateStaleClaimStamp is the ADR-0009 Defect C
+// regression test. gc.work_branch is stamped at claim time — before the work
+// exists — with the branch the claiming worktree happened to be on (the
+// polecat's persistent gc-<agent>-<hash> branch, cut from the default branch).
+// When the work then lands on a different branch, the stamp is stale, and the
+// pre-fix gate reported the delivered commit "not reachable" — under
+// GC_WORK_RECORD_ENFORCE that blocks every such honest close citywide, which is
+// exactly why az-fuag/az-z4p1 blocked enforcement on this defect.
+//
+// Contract under test: a shipped commit that IS on a remote-tracking ref must
+// close (delivery is the guarantee), with a precise advisory naming the branch
+// the work actually landed on so the record can be corrected — while the same
+// close with an unpushed commit must still block (the az-6n75 protection).
+func TestEvaluateWorkRecordCloseGateStaleClaimStamp(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	// The claim-time stamp: the polecat worktree branch, cut at base and never
+	// advanced. This is what gc.work_branch carries when the close arrives.
+	const claimBranch = "gc-gastown.nux-1a2b3c4d5e6f"
+	runGit(t, repoDir, "branch", claimBranch)
+
+	// The work lands on a different branch and is pushed — delivered.
+	const landedBranch = "fix/wr-defect-c"
+	runGit(t, repoDir, "checkout", "-b", landedBranch)
+	commit := gateCommit(t, repoDir, "feature.txt", "stale stamp fix\n", "feat: the work that satisfied the bead")
+	runGit(t, repoDir, "push", "origin", landedBranch)
+	runGit(t, repoDir, "fetch", "origin")
+
+	newStore := func() beads.Store { return gateStoreWith("wr-stale-stamp", repoDir) }
+	args := gateShippedCloseArgs("wr-stale-stamp", commit, claimBranch)
+
+	// Precondition: the stale stamp genuinely does not contain the commit, so
+	// this test exercises the stale-stamp rule and not reachability.
+	if gitCommitReachableOnBranch(repoDir, commit, claimBranch) {
+		t.Fatalf("precondition: commit must not be reachable on the claim-time branch")
+	}
+
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(args, newStore(), nil, repoDir, true, &stderr); block {
+		t.Fatalf("delivered close blocked on a stale claim-time stamp; stderr=%s", stderr.String())
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "advisory") {
+		t.Fatalf("expected a stale-stamp advisory, got %q", out)
+	}
+	if !strings.Contains(out, landedBranch) {
+		t.Fatalf("advisory %q does not name the landed branch %q", out, landedBranch)
+	}
+	if strings.Contains(out, "not reachable") {
+		t.Fatalf("delivered close still reported unreachable: %q", out)
+	}
+
+	// Paired negative: the same stale-stamp close with an UNPUSHED commit is the
+	// az-6n75 data-loss case and must still block under enforcement.
+	unpushed := gateCommit(t, repoDir, "unpushed.txt", "only copy\n", "feat: never pushed")
+	unpushedArgs := gateShippedCloseArgs("wr-stale-stamp", unpushed, claimBranch)
+	var unpushedStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(unpushedArgs, newStore(), nil, repoDir, true, &unpushedStderr); !block {
+		t.Fatalf("close of unpushed work was allowed through the stale-stamp path")
+	}
+	if got := unpushedStderr.String(); !strings.Contains(got, "not present on any remote") {
+		t.Fatalf("expected a durability violation, got %q", got)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateStaleLocalRef is the gastownhall/gascity#5037
+// finding-1 regression test. In any topology where merges reach the target
+// branch over the network (the refinery pushes from a detached worktree),
+// nothing ever advances the local ref: refs/heads/main goes permanently stale
+// while refs/remotes/origin/main is the truth. The pre-fix gate resolved the
+// bare branch name by gitrevisions precedence — the stale local ref — and
+// reported genuinely-merged commits unreachable.
+//
+// Per the issue's own verification guidance: do not verify by the warning
+// stopping — assert the check resolves against refs/remotes/origin/<branch> and
+// passes for a commit that is on origin/main but NOT on a deliberately-stale
+// local main.
+func TestEvaluateWorkRecordCloseGateStaleLocalRef(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	// Land the work on origin/main without moving local main, the way the
+	// refinery does: commit on a temporary branch, push it to origin's main,
+	// return to the stale local main, and drop the temporary branch so the
+	// commit exists locally only via the remote-tracking ref.
+	runGit(t, repoDir, "checkout", "-b", "tmp-land")
+	commit := gateCommit(t, repoDir, "landed.txt", "merged over the network\n", "feat: the work that satisfied the bead")
+	runGit(t, repoDir, "push", "origin", "tmp-land:main")
+	runGit(t, repoDir, "fetch", "origin")
+	runGit(t, repoDir, "checkout", "main")
+	runGit(t, repoDir, "branch", "-D", "tmp-land")
+
+	// Preconditions from the issue's repro: the local ref is genuinely stale
+	// and the remote-tracking ref genuinely contains the commit.
+	if gateRefContains(t, repoDir, "refs/heads/main", commit) {
+		t.Fatalf("precondition: commit must NOT be reachable on the stale local main")
+	}
+	if !gateRefContains(t, repoDir, "refs/remotes/origin/main", commit) {
+		t.Fatalf("precondition: commit must be reachable on origin/main")
+	}
+
+	// The fixed resolver must answer via the remote-tracking ref.
+	if !gitCommitReachableOnBranch(repoDir, commit, "main") {
+		t.Fatalf("gitCommitReachableOnBranch resolved the stale local ref; want refs/remotes/origin/main")
+	}
+
+	store := gateStoreWith("wr-stale-local", repoDir)
+	args := gateShippedCloseArgs("wr-stale-local", commit, "main")
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(args, store, nil, repoDir, true, &stderr); block {
+		t.Fatalf("close of work merged to origin/main blocked on a stale local ref; stderr=%s", stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("clean delivered close produced gate output: %q", got)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateSelfRemote is the gas-6tc regression test.
+// The gascity repo carries a remote whose URL is the repo's own path
+// (herdr-src), with fetched remote-tracking refs snapshotting local branches.
+// A blanket `rev-list <sha> --not --remotes` then reads any previously-fetched
+// local commit as "published" — the az-6n75 hole reopened by configuration, on
+// exactly the rig where the gate guards the gc tool itself. The witness-side
+// twin was fixed as gas-6wq ("exclude self-referential path remotes from the
+// publication oracle"); this covers the Go side: neither the durability oracle
+// nor the stale-stamp containment resolver may count a self-remote.
+func TestEvaluateWorkRecordCloseGateSelfRemote(t *testing.T) {
+	repoDir := newGateRepo(t, "origin")
+
+	// The self-referential path remote, as herdr-src is configured in the wild.
+	runGit(t, repoDir, "remote", "add", "self-src", repoDir)
+
+	// Unpushed work on its own branch; then fetch the self-remote so
+	// refs/remotes/self-src/* snapshot the local branches including the commit.
+	const workBranch = "gc-gastown.slit-9d8c7b6a5f4e"
+	runGit(t, repoDir, "checkout", "-b", workBranch)
+	commit := gateCommit(t, repoDir, "feature.txt", "only local\n", "feat: never pushed off-machine")
+	runGit(t, repoDir, "fetch", "self-src")
+
+	// Precondition: the self-remote genuinely snapshots the unpushed commit —
+	// the blanket --remotes query is genuinely defeated without the exclusion.
+	if !gateRefContains(t, repoDir, "refs/remotes/self-src/"+workBranch, commit) {
+		t.Fatalf("precondition: self-remote ref must contain the unpushed commit")
+	}
+
+	newStore := func() beads.Store { return gateStoreWith("wr-self-remote", repoDir) }
+	closeArgs := func(branch string) []string {
+		return gateShippedCloseArgs("wr-self-remote", commit, branch)
+	}
+
+	// With a correct branch stamp: the commit is reachable locally, its only
+	// "remote" presence is the self-remote snapshot — undelivered. Must block.
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(closeArgs(workBranch), newStore(), nil, repoDir, true, &stderr); !block {
+		t.Fatalf("close of self-remote-only work was allowed; --remotes counted the repo itself")
+	}
+	if got := stderr.String(); !strings.Contains(got, "not present on any remote") {
+		t.Fatalf("expected a durability violation, got %q", got)
+	}
+
+	// With a stale branch stamp: the containment resolver must not surface the
+	// self-remote snapshot as a landing branch — no advisory, still blocked.
+	var staleStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(closeArgs("gc-gastown.nux-1a2b3c4d5e6f"), newStore(), nil, repoDir, true, &staleStderr); !block {
+		t.Fatalf("stale-stamp close of self-remote-only work was allowed")
+	}
+	if got := staleStderr.String(); strings.Contains(got, "self-src/") {
+		t.Fatalf("advisory named a self-remote branch: %q", got)
+	}
+
+	// Paired positive: after a real push, the same close must be allowed — the
+	// exclusion must not block genuinely delivered work.
+	runGit(t, repoDir, "push", "origin", workBranch)
+	var pushedStderr strings.Builder
+	if block := evaluateWorkRecordCloseGate(closeArgs(workBranch), newStore(), nil, repoDir, true, &pushedStderr); block {
+		t.Fatalf("close blocked after real push; stderr=%s", pushedStderr.String())
+	}
+	if got := pushedStderr.String(); got != "" {
+		t.Fatalf("pushed close warned: %q", got)
 	}
 }
 

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -210,8 +210,11 @@ const (
 // whom, with what artifact, to what end":
 //
 //   - WorkBranchMetadataKey ("gc.work_branch") — the git branch the claiming
-//     worker is on; the durable handle from the bead to its work. Stamped at
-//     claim time alongside WorkDirMetadataKey and read by the close gate.
+//     worker is on; the handle from the bead to its work. Stamped at claim time
+//     alongside WorkDirMetadataKey, which makes it PROVISIONAL — the work does
+//     not exist yet when it is written. The close gate resolves the truth at
+//     close (remote-first) and advises when the work landed on a different
+//     branch (ADR-0009 Defect C, cmd/gc/work_record_gate.go).
 //   - WorkOutcomeMetadataKey ("gc.work_outcome") — the typed close disposition,
 //     one of "shipped" | "no-op" | "blocked" | "abandoned". Deliberately NOT
 //     OutcomeMetadataKey ("gc.outcome"): that key is the control-plane step


### PR DESCRIPTION
**Stacked on #5103 — draft until it merges.** This branch is #5103's head (46239876d) plus exactly one tests-only commit, 78fdb725e. Until #5103 lands, the diff below shows its commits too; only 78fdb725e is new here. No production code is touched, so it cannot conflict with the port. I'll mark this ready once #5103 merges and the base collapses to tests-only.

## What this adds

Regression coverage for the close-gate publication-oracle helpers (`cmd/gc/work_record_gate_oracle_test.go`, new file). The gate's scenario tests inject fake oracles (`alwaysOnRemote`, `neverOnRemote`, `remoteContains`) — the right shape for decision-logic tests, but it means the real git-backed implementations were never reached. Six of the eight fixes from the gas-6tc/gas-dr5 review live in that layer and none carried a regression test.

Coverage delta measured with `-coverpkg=./cmd/gc/`:

| function | before | after |
|---|---|---|
| `isSelfRemoteURL` | 50.0% (never once observed returning true) | 100% |
| `looksLikeSCPRemote` | 60.0% | 100% |
| `boundLandingBranches` | 50.0% (truncation arm unexercised) | 100% |
| `gitCommonDir` | 63.6% | 81.8% |
| `runWorkRecordCloseGate` | 44.4% | 55.6% (bounded — see the in-file note) |

The `isSelfRemoteURL` table drives the arm that matters — a genuinely self-referential path remote (plain path and `file://`) resolving to **true** — which is the behavior #5103 exists to ship and which no existing test observed directly.

## Known limitations pinned, not papered over

- **At-sign self-remote miss**: `isSelfRemoteURL` rejects any URL containing `@` as ssh shorthand before resolving the path, so a repo under a directory containing `@` stays in the publication set — the unsafe direction. Same family as the scp-style/drive-letter limitation already scoped out in #5103's description; pinned by a dedicated test that fails (with delete instructions) once fixed.
- **`boundLandingBranches` aliases its caller's slice**: truncation appends into the caller's backing array. Latent (both callers pass throwaway slices); pinned so it stays visible.
- `runWorkRecordCloseGate`'s two remaining arms are documented in-file as untestable without an injectable store-opener seam (the store-opening arm starts a managed `dolt sql-server` the package's leak guard rejects; the fail-open arm is unreachable because `openStoreAtForCityWithConfig` defers failure to query time). Left honestly uncovered rather than faked.

## Verification

- All 39 subtests pass on this exact base (`46239876d` + this commit).
- Guards are mutation-verified: forcing `isSelfRemoteURL` always-false fails exactly the two self arms; removing the truncation, inverting the scp slash test, and making every `update` read as a close each fail their matching test. One originally-drafted test was discarded during that process for being vacuous.
- `gofmt` clean, `go vet ./...` clean via the repo pre-commit hook.
- Originally written against #5103's prior head `347a098e8` (as `ef175938c`) and restacked after 46239876d threaded the anchoring `repoDir` through the oracles; the five call sites were adapted to the new signatures with no pinned behavior changed.

Tracked in the gas city as gas-amf (from the gas-dr5 arms-length review, finding F4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
