### PR TITLE
fix(pidutil): preserve Darwin argv boundaries

### DIFF
--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -3557,7 +3557,7 @@ func TestExistingPollerPIDRejectsUnrelatedLivePID(t *testing.T) {
 }
 
 func TestExistingPollerPIDAcceptsMatchingCitySession(t *testing.T) {
-	cityPath := t.TempDir()
+	cityPath := filepath.Join(t.TempDir(), "city with spaces")
 	sessionName := "sess-worker"
 	pidPath := nudgePollerPIDPath(cityPath, sessionName, "session-id")
 	cmd := startPollerLikeProcess(t, cityPath, "session-id")

--- a/internal/pidutil/cmdline_darwin.go
+++ b/internal/pidutil/cmdline_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package pidutil
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func platformCmdline(pid int) ([]string, error) {
+	data, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, fmt.Errorf("pidutil: reading argv for PID %d via kern.procargs2: %w", pid, err)
+	}
+	argv, err := parseProcArgs2(data)
+	if err != nil {
+		return nil, fmt.Errorf("pidutil: parsing argv for PID %d: %w", pid, err)
+	}
+	return NormalizeArgv(argv), nil
+}

--- a/internal/pidutil/cmdline_other.go
+++ b/internal/pidutil/cmdline_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package pidutil
+
+func platformCmdline(pid int) ([]string, error) {
+	return psCmdline(pid)
+}

--- a/internal/pidutil/pidutil.go
+++ b/internal/pidutil/pidutil.go
@@ -179,14 +179,13 @@ func ArgvHasFlagValue(argv []string, flag, value string) bool {
 }
 
 // Cmdline returns a PID's command line, normalized through NormalizeArgv.
-// It reads /proc/<pid>/cmdline where available and otherwise falls back to ps,
-// which is how the rest of this repo already reads another process's argv
-// (see the ps -o args= call sites in cmd/gc and internal/runtime/tmux).
-// It returns an error when no mechanism can read the process record.
+// It reads /proc/<pid>/cmdline where available, kern.procargs2 on Darwin, and
+// otherwise falls back to ps. It returns an error when no mechanism can read
+// the process record.
 func Cmdline(pid int) ([]string, error) {
 	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err != nil {
-		return psCmdline(pid)
+		return platformCmdline(pid)
 	}
 	trimmed := strings.TrimRight(string(data), "\x00")
 	if trimmed == "" {
@@ -289,15 +288,9 @@ func psStartTime(pid int) (string, error) {
 	return identity, nil
 }
 
-// psCmdline reads a PID's argv with ps, for hosts without /proc.
-//
-// One accepted limitation: ps renders argv as a single space-joined string, so
-// an argument containing a space is split into two. The matchers in this package
-// compare flags and their values (ArgvContainsSequence, ArgvHasFlagValue), and
-// the identifiers they match on — session names, targets — do not contain
-// spaces. Reading argv exactly on darwin needs KERN_PROCARGS2 via cgo, which is
-// not worth it for that gap. A mis-split argv fails the match, and failing the
-// match is the safe direction for every caller.
+// psCmdline reads a PID's argv with ps on non-Darwin hosts without /proc.
+// ps renders argv as a single space-joined string, so it cannot preserve an
+// argument containing spaces. Darwin uses kern.procargs2 instead.
 //
 // -ww asks ps for full width, since a truncated argv fails the match on BSD ps.
 func psCmdline(pid int) ([]string, error) {

--- a/internal/pidutil/procargs2.go
+++ b/internal/pidutil/procargs2.go
@@ -1,0 +1,44 @@
+package pidutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// parseProcArgs2 extracts argv from Darwin's kern.procargs2 buffer. The first
+// four bytes contain argc, followed by the executable path, NUL padding, argv,
+// and environment entries. Counting exactly argc entries keeps environment
+// values out of the result.
+func parseProcArgs2(data []byte) ([]string, error) {
+	const argcSize = 4
+	if len(data) < argcSize {
+		return nil, fmt.Errorf("pidutil: procargs2 buffer has %d bytes, want at least %d", len(data), argcSize)
+	}
+	argcValue := binary.LittleEndian.Uint32(data[:argcSize])
+	if uint64(argcValue) > uint64(len(data)) {
+		return nil, fmt.Errorf("pidutil: procargs2 argc %d exceeds buffer size %d", argcValue, len(data))
+	}
+	argc := int(argcValue)
+
+	rest := data[argcSize:]
+	execEnd := bytes.IndexByte(rest, 0)
+	if execEnd < 0 {
+		return nil, fmt.Errorf("pidutil: procargs2 buffer has no terminated executable path")
+	}
+	rest = rest[execEnd+1:]
+	for len(rest) > 0 && rest[0] == 0 {
+		rest = rest[1:]
+	}
+
+	argv := make([]string, 0, argc)
+	for len(argv) < argc {
+		argEnd := bytes.IndexByte(rest, 0)
+		if argEnd < 0 {
+			return nil, fmt.Errorf("pidutil: procargs2 buffer ended after %d of %d arguments", len(argv), argc)
+		}
+		argv = append(argv, string(rest[:argEnd]))
+		rest = rest[argEnd+1:]
+	}
+	return argv, nil
+}

--- a/internal/pidutil/procargs2_test.go
+++ b/internal/pidutil/procargs2_test.go
@@ -1,0 +1,37 @@
+package pidutil
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseProcArgs2PreservesArgumentBoundaries(t *testing.T) {
+	data := make([]byte, 4)
+	binary.LittleEndian.PutUint32(data, 4)
+	data = append(data, []byte("/usr/local/bin/gc\x00\x00\x00")...)
+	data = append(data, []byte("gc\x00nudge\x00--city\x00/tmp/city with spaces\x00TOKEN=secret\x00")...)
+
+	got, err := parseProcArgs2(data)
+	if err != nil {
+		t.Fatalf("parseProcArgs2: %v", err)
+	}
+	want := []string{"gc", "nudge", "--city", "/tmp/city with spaces"}
+	if len(got) != len(want) {
+		t.Fatalf("parseProcArgs2 = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseProcArgs2 = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestParseProcArgs2RejectsTruncatedArgv(t *testing.T) {
+	data := make([]byte, 4)
+	binary.LittleEndian.PutUint32(data, 2)
+	data = append(data, []byte("/usr/bin/gc\x00gc\x00")...)
+
+	if _, err := parseProcArgs2(data); err == nil {
+		t.Fatal("parseProcArgs2 accepted fewer arguments than argc")
+	}
+}

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -523,7 +523,7 @@ func TestExistingSessionSubmitPollerPIDRejectsUnrelatedLivePID(t *testing.T) {
 }
 
 func TestExistingSessionSubmitPollerPIDAcceptsMatchingCitySession(t *testing.T) {
-	cityPath := t.TempDir()
+	cityPath := filepath.Join(t.TempDir(), "city with spaces")
 	sessionName := "s-test"
 	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName, "session-id")
 	cmd := startSubmitPollerLikeProcess(t, cityPath, sessionName, "session-id")


### PR DESCRIPTION
## Summary

- read Darwin process argv through `kern.procargs2` so arguments containing spaces retain their boundaries
- keep the existing `ps` fallback on other non-`/proc` platforms
- cover both poller identity callers with space-containing city paths

## Verification

- `go test -count=1 -race ./cmd/gc -run ^TestExistingPollerPID`
- `go test -count=1 -race ./internal/session -run ^TestExistingSessionSubmitPollerPID`
- `go test -count=1 -race ./internal/pidutil -run ^(TestParseProcArgs2|TestCmdline|TestAliveWithCmdline)`
- `go vet ./...`
- pre-commit hook passed
- fast baseline: unit-core and cmd/gc shards 1-5 passed; shard 6 test bodies passed, then the existing global Dolt leak guard reported a leaked test server under `cmd/gc/.gc`

Recovery publication for gc-8fx8z.2.1 under batch gc-0q2w3.