### PR TITLE
fix(session): roll back wedged start-pending sessions, not just creating (gcf-ru0)

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -920,7 +920,15 @@ func healStatePatchWithRollbackInfo(info sessionpkg.Info, alive bool, clk clock.
 		target = string(sessionpkg.StateAsleep)
 		clearPendingCreateLeaseInfo(info.PendingCreateClaim, batch)
 	}
-	if rollbackAvailable && !alive && strings.TrimSpace(info.MetadataState) == "creating" {
+	// gcf-ru0: this gate originally checked MetadataState == "creating" only,
+	// from before #2583 split "start-pending" out as its own state ahead of
+	// "creating". projectRuntimeProjection's BaseStateStartPending branch has
+	// no staleness check of its own (unlike its BaseStateCreating sibling), so
+	// a bead stuck in start-pending with no rollback gate here just keeps
+	// re-projecting start-pending forever — pendingCreateLeaseExpiredForRollbackInfo
+	// already understands start-pending via pendingCreateRollbackState, so widen
+	// the gate to match instead of restricting it to "creating".
+	if rollbackAvailable && !alive && pendingCreateQueuedOrCreatingState(info.MetadataState) {
 		if pendingCreateLeaseExpiredForRollbackInfo(info, clk, startupTimeout) {
 			target = string(sessionpkg.StateAsleep)
 			stalePendingCreateRollback = true

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1829,6 +1829,40 @@ func TestHealState_NeverStartedPendingCreateMigratesToStartPendingUntilRollbackL
 	}
 }
 
+// gcf-ru0 regression: once a bead has migrated to state=start-pending (see
+// TestHealState_NeverStartedPendingCreateMigratesToStartPendingUntilRollbackLeaseExpires),
+// the rollback gate in healStatePatchWithRollbackInfo only fired for
+// info.MetadataState == "creating" — never for "start-pending", even though
+// pendingCreateLeaseExpiredForRollbackInfo itself already understands
+// start-pending via pendingCreateRollbackState. A never-started pending-create
+// lease that aged past pendingCreateNeverStartedTimeout (10m) while sitting in
+// start-pending was therefore never rolled back: projectRuntimeProjection's
+// BaseStateStartPending branch has no staleness check of its own and just
+// keeps re-projecting start-pending forever, so the bead wedged indefinitely
+// with no self-heal.
+func TestHealState_StartPendingNeverStartedRollsBackToAsleep(t *testing.T) {
+	store := newTestStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 18, 20, 0, 0, 0, time.UTC)}
+
+	// Past pendingCreateNeverStartedTimeout (10m) with no last_woke_at ever
+	// recorded — this create attempt never even reached a provider Start call.
+	startedAt := clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Minute))
+	session := makeBead("b1", map[string]string{
+		"state":                     string(sessionpkg.StateStartPending),
+		"pending_create_claim":      "true",
+		"pending_create_started_at": pendingCreateStartedAtNow(startedAt),
+	})
+	session.CreatedAt = startedAt
+
+	healStateInfo(&session, false, sessionFrontDoor(store), clk)
+	if got := session.Metadata["state"]; got != "asleep" {
+		t.Fatalf("state = %q, want asleep (expired start-pending lease must roll back)", got)
+	}
+	if got := session.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want empty after rollback", got)
+	}
+}
+
 func TestHealState_PreservesFreshCreatingWithoutPendingClaim(t *testing.T) {
 	store := newTestStore()
 	clk := &clock.Fake{Time: time.Date(2026, 3, 29, 4, 0, 0, 0, time.UTC)}


### PR DESCRIPTION
## Summary
- `healStatePatchWithRollbackInfo`'s expired-pending-create rollback gate only fired for `MetadataState == "creating"` — a leftover from before #2583 split `start-pending` out as its own precursor state.
- `projectRuntimeProjection`'s `BaseStateStartPending` branch has no staleness check of its own (unlike its `BaseStateCreating` sibling), so once a bead migrated to `start-pending` it kept re-projecting `start-pending` forever with no self-heal: newly-created sessions (morning resume, cold `gc session nudge` spawns) that failed to reach a provider `Start` call wedged indefinitely, silently consuming a pool slot.
- `pendingCreateLeaseExpiredForRollbackInfo` already understands `start-pending` via `pendingCreateRollbackState`, so this widens the gate to `pendingCreateQueuedOrCreatingState` instead of a bare `"creating"` string check.

Fixes gcf-ru0.

## Test plan
- [x] Added `TestHealState_StartPendingNeverStartedRollsBackToAsleep` (red before the fix, green after).
- [x] `go test ./cmd/gc/ -run 'TestHealState|TestReconcileSessionBeads|TestPendingCreate|TestStaleCreating'` — 269 pass, 0 fail.
- [x] `go test ./internal/session/...` — pass.
- [x] `go build ./...` and `go vet ./cmd/gc/... ./internal/session/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)