### PR TITLE
fix(cli): refuse `formula cook --attach` onto a work-resident bead on a split city (ga-99xhy)

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -629,14 +629,30 @@ per-source workflow lock and is idempotent: a repeat cook for the same
 source bead reuses the live workflow instead of duplicating it, and a
 conflicting live workflow from the same source is an error.
 
-On a city that serves a coordination class from its own [storage] binding,
---attach follows the ATTACH BEAD: the sub-DAG and the blocking dependency
-are written to the store that holds it, so the two ends of the edge stay in
-one store. A v2 (graph.v2) formula is the exception and is refused for an
-attach bead the binding owns: it normalizes its target into a synthetic
-input convoy, which is a work bead that can live neither in the binding nor
-in the work ledger, whose membership edge to the target would be
-cross-class. Attach a v1 formula to that bead instead.`,
+On a city that serves the graph class from its own [storage] binding, most
+of --attach is NOT SUPPORTED YET and refuses rather than serving. A graft is
+graph class whatever the formula's version — every bead it creates carries
+gc.root_bead_id — so the sub-DAG belongs in the binding while the blocking
+dependency belongs beside the attach bead, and a split city cannot have
+both:
+
+  * attach bead in the WORK ledger — refused. Writing the sub-DAG beside it
+    strands graph-class beads in the work store, which gc storage status
+    reports and exits non-zero on; writing it into the binding leaves the
+    work store holding a blocks row naming an id it cannot resolve, which
+    never clears. Representing that block across the store boundary needs a
+    cross-class membership edge: ga-2orlf.
+  * attach bead in the BINDING, v2 (graph.v2) formula — refused. It
+    normalizes its target into a synthetic input convoy, which is a work
+    bead that can live in neither store; its membership edge to the target
+    would be cross-class. Same remedy: ga-2orlf.
+  * attach bead in the BINDING, v1 formula — served. The sub-DAG and its
+    blocking dependency are both written to the binding.
+
+Single-store cities are unaffected: --attach behaves exactly as it always
+has. If an earlier cook already stranded beads in a split city's work
+store, copy them into the binding with
+` + storageRecoveryInstruction() + `.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cityPath, err := resolveCity()
@@ -669,7 +685,10 @@ cross-class. Attach a v1 formula to that bead instead.`,
 			//
 			// The --attach arms do not use this: a graft follows its PARENT,
 			// not its class, so they route by the attach bead's id instead —
-			// see attachStore below.
+			// see attachStore below. Following the parent is only sound when
+			// the parent's store may hold graph-class beads, which on a split
+			// city means the binding; attachGraftClassRefusal is the gate that
+			// keeps the two rules from contradicting each other.
 			graphStore := resolveGraphStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 
 			cookVars := parseFormulaVars(vars)
@@ -695,20 +714,21 @@ cross-class. Attach a v1 formula to that bead instead.`,
 				// The arm that can serve it is the V1 one. The graph.v2 arm
 				// cannot, and refuses — see the block on isGraphFormula below.
 				//
-				// STILL DEFERRED, and it is the other half of the v1 arm: on a
-				// split city whose attach bead lives in the WORK ledger, the
-				// sub-DAG is graph class and stays in the work ledger with it.
-				// Relocating it needs the block REPRESENTED across the store
-				// boundary — a mechanism that does not exist, in beads or here,
-				// and whose absence is why the edge must stay co-resident
-				// rather than be split. See the ga-k8pzw notes.
-				//
 				// Every city that relocates nothing, and every split city whose
 				// attach bead is work resident, gets back the exact store value
 				// resolveFormulaScope opened, so attachStore != store is
 				// precisely "the class binding holds this bead".
 				attachStore, err := classRoutedStoreForID(cityPath, attach, store)
 				if err != nil {
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
+				}
+				// The other half of co-residence, and it applies to BOTH arms:
+				// keeping the graft beside a WORK-resident attach bead keeps the
+				// edge resolvable and mints graph-class beads in the work
+				// ledger, which is a stranded write. Neither placement is
+				// expressible on a split city, so the graft is refused before
+				// either arm runs — see formula_cook_attach_class.go, ga-99xhy.
+				if err := attachGraftClassRefusal(cityPath, attach, store, attachStore); err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
 				if isGraphFormula {
@@ -755,10 +775,12 @@ cross-class. Attach a v1 formula to that bead instead.`,
 							"--attach %s: %s is owned by the relocated class binding, and a graph.v2 formula's synthetic input convoy is a work bead — it can live neither there (a work-class bead in the infra ledger) nor in the work ledger (its `tracks` edge to %s would be cross-class, which convoy.TrackItemIn refuses); grafting a graph.v2 formula onto a class-owned bead needs a cross-class membership edge: ga-2orlf. A v1 formula attaches to %s today",
 							attach, attach, attach, attach))
 					}
-					// Past the refusal attachStore IS store, so this arm runs
-					// on the one store it always did and its execution-fact
-					// legs are the same value: the root, its steps and the
-					// input convoy are all minted here.
+					// Past both refusals — this one, and the class gate above
+					// that rejects a work-resident attach bead on a split city —
+					// only a single-store city reaches here. attachStore IS
+					// store, this arm runs on the one store it always did, and
+					// its execution-fact legs are the same value: the root, its
+					// steps and the input convoy are all minted here.
 					storeRef := workflowStoreRefForDir(scope.storeRoot, cityPath, loadedCityName(cfg, cityPath), cfg)
 					var result *molecule.Result
 					var syntheticInputConvoyID string

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -630,24 +630,27 @@ source bead reuses the live workflow instead of duplicating it, and a
 conflicting live workflow from the same source is an error.
 
 On a city that serves the graph class from its own [storage] binding, most
-of --attach is NOT SUPPORTED YET and refuses rather than serving. A graft is
-graph class whatever the formula's version — every bead it creates carries
-gc.root_bead_id — so the sub-DAG belongs in the binding while the blocking
-dependency belongs beside the attach bead, and a split city cannot have
-both:
+of --attach in CITY scope is NOT SUPPORTED YET and refuses rather than
+serving. A graft is graph class whatever the formula's version — every bead
+it creates carries gc.root_bead_id — so the sub-DAG belongs in the binding
+while the blocking dependency belongs beside the attach bead, and a split
+city cannot have both:
 
-  * attach bead in the WORK ledger — refused. Writing the sub-DAG beside it
-    strands graph-class beads in the work store, which gc storage status
-    reports and exits non-zero on; writing it into the binding leaves the
-    work store holding a blocks row naming an id it cannot resolve, which
-    never clears. Representing that block across the store boundary needs a
-    cross-class membership edge: ga-2orlf.
+  * attach bead in the city's WORK ledger — refused. Writing the sub-DAG
+    beside it strands graph-class beads in the work store, which gc storage
+    status reports and exits non-zero on; writing it into the binding leaves
+    the work store holding a blocks row naming an id it cannot resolve,
+    which never clears. Representing that block across the store boundary
+    needs a cross-class membership edge: ga-2orlf.
   * attach bead in the BINDING, v2 (graph.v2) formula — refused. It
     normalizes its target into a synthetic input convoy, which is a work
     bead that can live in neither store; its membership edge to the target
     would be cross-class. Same remedy: ga-2orlf.
   * attach bead in the BINDING, v1 formula — served. The sub-DAG and its
     blocking dependency are both written to the binding.
+  * RIG scope (--rig, GC_RIG, or a cwd inside a rig) — served, unchanged.
+    A relocation moves city-level stores only, so a rig's ledger holds both
+    ends of the graft and nothing it writes can be stranded.
 
 Single-store cities are unaffected: --attach behaves exactly as it always
 has. If an earlier cook already stranded beads in a split city's work
@@ -686,9 +689,11 @@ store, copy them into the binding with
 			// The --attach arms do not use this: a graft follows its PARENT,
 			// not its class, so they route by the attach bead's id instead —
 			// see attachStore below. Following the parent is only sound when
-			// the parent's store may hold graph-class beads, which on a split
-			// city means the binding; attachGraftClassRefusal is the gate that
-			// keeps the two rules from contradicting each other.
+			// the parent's store may hold graph-class beads, which in a split
+			// city's CITY scope means the binding; attachGraftClassRefusal is
+			// the gate that keeps the two rules from contradicting each other,
+			// and it asks the scope question first because a rig store holds
+			// its own graph-class beads and the relocation never moves it.
 			graphStore := resolveGraphStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 
 			cookVars := parseFormulaVars(vars)
@@ -728,7 +733,10 @@ store, copy them into the binding with
 				// ledger, which is a stranded write. Neither placement is
 				// expressible on a split city, so the graft is refused before
 				// either arm runs — see formula_cook_attach_class.go, ga-99xhy.
-				if err := attachGraftClassRefusal(cityPath, attach, store, attachStore); err != nil {
+				// The scope root travels with the store because relocation is a
+				// CITY-scope property: a rig store is never relocated, so a
+				// rig-scoped graft is co-resident and stays served.
+				if err := attachGraftClassRefusal(cityPath, scope.storeRoot, attach, store, attachStore); err != nil {
 					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
 				if isGraphFormula {

--- a/cmd/gc/cmd_storage.go
+++ b/cmd/gc/cmd_storage.go
@@ -119,6 +119,22 @@ func storageRecoveryInstruction() string {
 	return storageRecoveryCommand + " --" + storageFleetStoppedFlag
 }
 
+// storageStatusInstruction renders the read-only report the way an operator
+// types it. The read verb has no operator-command spelling of its own — it
+// takes no source flag — so its namespace is derived from the one the migrate
+// spelling names, for the reason the file header gives: a message pointing at a
+// command this binary does not carry is an instruction that fails at the shell.
+// An unparseable spelling is already reported by newUnbuildableStorageCmd, so
+// here it degrades to the default namespace rather than swallowing the message
+// that carries it.
+func storageStatusInstruction() string {
+	surface, err := parseOperatorCommandSpelling(storageMigrationCommand)
+	if err != nil {
+		return "gc storage " + storageStatusVerb
+	}
+	return "gc " + surface.Namespace + " " + storageStatusVerb
+}
+
 // newStorageCmd constructs the `gc storage` tree named by the operator
 // spellings.
 func newStorageCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/formula_cook_attach_class.go
+++ b/cmd/gc/formula_cook_attach_class.go
@@ -16,6 +16,11 @@ package main
 // stranded write the city's own containment check counts, `gc storage status`
 // exits 1 on, and every later command carries as a permanent alarm.
 //
+// "The work ledger" here means the CITY's. A relocation moves one city-level
+// store per class and leaves every rig store exactly where it was, so a
+// rig-scoped graft is co-resident in the rig's own ledger and is not a stranded
+// write at all — see the scope gate in attachGraftClassRefusal.
+//
 // The other placement is worse and is not re-shipped: #5150 moved the sub-DAG
 // to the binding and left the work store holding a `blocks` row naming an id it
 // could not resolve, which no backend rejects and every Ready implementation
@@ -40,22 +45,38 @@ import (
 // attachGraftClassRefusal returns the reason a graft onto attachBeadID cannot
 // be expressed on this city, or nil when it can.
 //
-// scope is the store the command resolved for its own formula scope — the work
-// ledger — and attachStore is the store classRoutedStoreForID found the attach
-// bead in. Three gates, in the order that keeps a single-store city untouched:
+// scopeRoot is the directory resolveFormulaScope selected, scope is the store
+// opened for it, and attachStore is the store classRoutedStoreForID found the
+// attach bead in. Four gates, in the order that keeps a single-store city
+// untouched:
 //
 //   - the city relocates nothing, so there is no second store and no class to
 //     be on the wrong side of. Returns before reading anything, which is what
 //     makes an unsplit `--attach` byte-identical to what it always did.
+//   - the scope is a RIG, whose store the relocation never touched.
+//     controlScopeTakesGraphClass is the dispatcher's own predicate for this and
+//     the reason is the same one stated there: `gc storage migrate` copies only
+//     the CITY work store (openInfraMigrationSource), resolveClassStore holds a
+//     single city-level store per class with no per-scope binding to route a rig
+//     to, and controlGraphStore hands a rig scope back the store it was given.
+//     A rig graft is therefore co-resident in the rig's own ledger and cannot be
+//     stranded — the city-level containment check never reads that store, and
+//     the remedy this refusal names, which reads the city work store, would
+//     repair nothing there. Asking the city question and applying it to a rig
+//     store refused a shape that has always worked, and GC_RIG is ambient on
+//     every controller-spawned agent, so the answer had to be scoped.
 //   - the binding holds the attach bead, so the graft lands in the binding with
 //     it: graph-class beads in the graph store, co-resident with the edge. That
 //     is the shape the v1 arm serves today and it stays served.
 //   - the work ledger does not hold it either, so this is a bad id rather than
 //     a bad topology. The arms' own "attach bead <id>: bead not found" is a
 //     better answer than a topology lecture, so it is left to them.
-func attachGraftClassRefusal(cityPath, attachBeadID string, scope, attachStore beads.Store) error {
+func attachGraftClassRefusal(cityPath, scopeRoot, attachBeadID string, scope, attachStore beads.Store) error {
 	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
 	if !relocated || class == nil || class == scope {
+		return nil
+	}
+	if !controlScopeTakesGraphClass(cityPath, scopeRoot) {
 		return nil
 	}
 	if attachStore != scope {

--- a/cmd/gc/formula_cook_attach_class.go
+++ b/cmd/gc/formula_cook_attach_class.go
@@ -1,0 +1,83 @@
+package main
+
+// The class gate on `gc formula cook --attach`.
+//
+// by_id_store_route.go answers WHERE a graft is written: the store that holds
+// the attach bead, so the two ends of the blocking edge stay co-resident. This
+// file answers whether that store is allowed to hold it.
+//
+// A graft is always GRAPH class. Not "usually", and not "when the formula is
+// v2": molecule.Attach stamps gc.root_bead_id on every step it materializes
+// (resolved through the run chain, falling back to the attach bead's own id, so
+// it is never empty) and a non-empty gc.root_bead_id is coordclass.Classify's
+// workflow arm. A graph.v2 pour is graph class end to end for its own reasons.
+// So on a city that serves the graph class from its own binding, a graft onto a
+// WORK-resident bead writes graph-class rows into the work ledger — the
+// stranded write the city's own containment check counts, `gc storage status`
+// exits 1 on, and every later command carries as a permanent alarm.
+//
+// The other placement is worse and is not re-shipped: #5150 moved the sub-DAG
+// to the binding and left the work store holding a `blocks` row naming an id it
+// could not resolve, which no backend rejects and every Ready implementation
+// reads as a blocker that never clears.
+//
+// Neither end being expressible is what makes this a REFUSAL rather than a
+// route. Nothing automated calls `cook --attach` — it has no caller anywhere in
+// the tree, in any pack, formula, prompt or script — so the whole cost is borne
+// by a human or an agent invoking it directly, and being told "not yet
+// supported on a split city" is strictly better than holding a permanently
+// alarming ledger. The mechanism that lifts it is a cross-class membership
+// edge: ga-2orlf.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+// attachGraftClassRefusal returns the reason a graft onto attachBeadID cannot
+// be expressed on this city, or nil when it can.
+//
+// scope is the store the command resolved for its own formula scope — the work
+// ledger — and attachStore is the store classRoutedStoreForID found the attach
+// bead in. Three gates, in the order that keeps a single-store city untouched:
+//
+//   - the city relocates nothing, so there is no second store and no class to
+//     be on the wrong side of. Returns before reading anything, which is what
+//     makes an unsplit `--attach` byte-identical to what it always did.
+//   - the binding holds the attach bead, so the graft lands in the binding with
+//     it: graph-class beads in the graph store, co-resident with the edge. That
+//     is the shape the v1 arm serves today and it stays served.
+//   - the work ledger does not hold it either, so this is a bad id rather than
+//     a bad topology. The arms' own "attach bead <id>: bead not found" is a
+//     better answer than a topology lecture, so it is left to them.
+func attachGraftClassRefusal(cityPath, attachBeadID string, scope, attachStore beads.Store) error {
+	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	if !relocated || class == nil || class == scope {
+		return nil
+	}
+	if attachStore != scope {
+		return nil
+	}
+	source, err := scope.Get(attachBeadID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("reading attach bead %q from the work ledger: %w", attachBeadID, err)
+	}
+	return fmt.Errorf(
+		"--attach %s: %s is %s class and lives in a WORK store rather than in the %s binding, and the sub-DAG a graft materializes is %s class whatever the formula's version — molecule.Attach stamps gc.root_bead_id on every step it creates, and a graph.v2 pour is graph class end to end. This city serves the %s class from its own binding, so neither end of the graft is expressible: written beside %s the sub-DAG is a graph-class bead born in the work ledger, which is the stranded write `%s` counts and every later command refuses on; written into the binding the work store keeps a `blocks` row naming an id it cannot resolve, which no backend rejects and every Ready implementation reads as a blocker that never clears (#5150). Carrying that block across the store boundary needs a cross-class membership edge: ga-2orlf. Until it lands, --attach onto a work-resident bead is not supported on a split city; attach to a bead the binding owns instead. If an earlier cook already stranded beads here, stop every writer and copy them into the binding with `%s`",
+		attachBeadID,
+		attachBeadID,
+		coordclass.Classify(source),
+		coordclass.ClassGraph,
+		coordclass.ClassGraph,
+		coordclass.ClassGraph,
+		attachBeadID,
+		storageStatusInstruction(),
+		storageRecoveryInstruction(),
+	)
+}

--- a/cmd/gc/formula_cook_attach_class_test.go
+++ b/cmd/gc/formula_cook_attach_class_test.go
@@ -9,16 +9,23 @@ package main
 // in the work store — the stranded write a converged city's own containment
 // check counts and every later command refuses on (ga-99xhy, live-proven on a
 // throwaway split city as `stranded: 4` with `gc storage status` exiting 1).
+//
+// "The work ledger" is the CITY's. The relocation never moves a rig store, so a
+// rig-scoped graft is co-resident in the rig's own ledger and stays served —
+// TestFormulaCookAttachInRigScopeStaysServedOnASplitCity is that row.
 
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -183,6 +190,159 @@ func TestFormulaCookLegacyAttachOnAWorkResidentBeadIsRefusedOnSplitCity(t *testi
 	}
 	assertAttachRefusalNamesItsReason(t, out, source.ID)
 	assertRefusedGraftWroteNothing(t, work, graph, source.ID, before)
+}
+
+// rigScopedSplitCookCity is the fixture for the OTHER scope: the same split
+// city, plus a bound rig with its own file-backed ledger, entered the way every
+// controller-spawned agent enters one — the ambient GC_RIG the controller sets,
+// which resolveFormulaScope honors even when cwd is elsewhere.
+//
+// It returns the rig's store, the city work store and the binding, so a test
+// can tell all three apart. The rig gets its own control-dispatcher agent
+// because a graph.v2 cook in rig scope decorates its recipe against one; that
+// requirement predates this bead and is not what is under test.
+func rigScopedSplitCookCity(t *testing.T) (rig, cityWork, graph beads.Store) {
+	t.Helper()
+	cityDir := oneShotCookCity(t)
+	rigDir := filepath.Join(cityDir, "wf")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	cityTOML := filepath.Join(cityDir, "city.toml")
+	declared, err := os.ReadFile(cityTOML)
+	if err != nil {
+		t.Fatalf("read city.toml: %v", err)
+	}
+	declared = append(declared, []byte(testControlDispatcherAgentTOML("wf"))...)
+	declared = append(declared, []byte("\n[[rigs]]\nname = \"wf\"\n")...)
+	if err := os.WriteFile(cityTOML, declared, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", fmt.Sprintf("[[rig]]\nname = \"wf\"\npath = %q\n", rigDir))
+
+	// Scoped file-store roots, so the rig has a ledger of its own rather than
+	// aliasing the city's — without the marker every scope shares one file and
+	// the fixture would prove nothing.
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, root := range []string{cityDir, rigDir} {
+		if err := ensurePersistedScopeLocalFileStore(root); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", root, err)
+		}
+	}
+
+	graph = splittest.NewClassStore(t, config.BeadClassGraph)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+
+	// GC_RIG with no --rig is the shape under test: the persistent flag is the
+	// higher-priority tier, so a value another test left on the package global
+	// would resolve a different scope and the ambient path would go unexercised.
+	prevRigFlag := rigFlag
+	t.Cleanup(func() { rigFlag = prevRigFlag })
+	rigFlag = ""
+	t.Setenv("GC_RIG", "wf")
+
+	if rig, err = openStoreAtForCity(rigDir, cityDir); err != nil {
+		t.Fatalf("open rig store: %v", err)
+	}
+	if cityWork, err = openStoreAtForCity(cityDir, cityDir); err != nil {
+		t.Fatalf("open city work store: %v", err)
+	}
+	if got := beadIDs(allBeads(t, cityWork)); len(got) != 0 {
+		t.Fatalf("the city work store already holds %v; the fixture's premise is that only the rig ledger does", got)
+	}
+	return rig, cityWork, graph
+}
+
+// TestFormulaCookAttachInRigScopeStaysServedOnASplitCity is the scope half of
+// the class gate, and the reason the gate asks controlScopeTakesGraphClass
+// before it asks anything else.
+//
+// A relocation is a CITY-scope event. `gc storage migrate` copies only the city
+// work store (openInfraMigrationSource -> openStoreAtForCity(cityPath,
+// cityPath)), resolveClassStore holds one city-level store per class with no
+// per-rig binding to route to, and controlGraphStore hands a rig scope back the
+// very store it was given — the three facts controlScopeTakesGraphClass's own
+// doc comment states. So a rig's ledger holds BOTH ends of a graft, the city's
+// containment check never reads it, and nothing a rig-scoped cook writes can be
+// stranded. Refusing it would also hand the operator an inoperative remedy:
+// `gc storage recover-stranded --from-work` reads the city work store.
+//
+// GC_RIG is ambient on every controller-spawned agent, so a gate that asked the
+// city question and applied it to the rig store took `--attach` away from
+// essentially every agent on a split city with rigs.
+//
+// Red-before, with the scope gate removed — both rows:
+//
+//	gc formula cook legacy-work --attach gc-1 was refused in RIG scope on a
+//	split city: exit
+//	gc formula cook: --attach gc-1: gc-1 is work class and lives in a WORK
+//	store rather than in the graph binding, and the sub-DAG a graft
+//	materializes is graph class whatever the formula's version ...
+//	a rig store is never relocated, so both ends of the graft are co-resident
+//	in it and nothing it writes can be stranded
+func TestFormulaCookAttachInRigScopeStaysServedOnASplitCity(t *testing.T) {
+	for _, formulaName := range []string{"legacy-work", "graph-work"} {
+		t.Run(formulaName, func(t *testing.T) {
+			rig, cityWork, graph := rigScopedSplitCookCity(t)
+
+			source, err := rig.Create(beads.Bead{Title: "attach target", Type: "task"})
+			if err != nil {
+				t.Fatalf("create attach bead: %v", err)
+			}
+
+			out, err := cookFormulaErr(t, formulaName, "--attach", source.ID)
+			if err != nil {
+				t.Fatalf("gc formula cook %s --attach %s was refused in RIG scope on a split city: %v\n%s\na rig store is never relocated, so both ends of the graft are co-resident in it and nothing it writes can be stranded", formulaName, source.ID, err, out)
+			}
+			assertGraftIsCoResidentIn(t, rig, source.ID)
+			if got := beadIDs(allBeads(t, cityWork)); len(got) != 0 {
+				t.Errorf("the city work store holds %v after a rig-scoped graft; a rig scope writes to its own ledger", got)
+			}
+			if got := allBeads(t, graph); len(got) != 0 {
+				t.Errorf("the binding holds %d bead(s) after a rig-scoped graft: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+// assertGraftIsCoResidentIn requires the graft to be a real graft in ONE store:
+// the attach bead gained a blocking dep, the store resolves its target, and the
+// store holds GRAPH-class beads the graft minted. The last part is what makes
+// this the same shape the city-scope gate refuses — a rig graft is served
+// because of WHERE it lands, not because its beads are somehow work class.
+//
+// Not every grafted bead is graph class: a graph.v2 invocation also mints a
+// synthetic input convoy, which coordclass classifies as WORK by design. In a
+// rig scope both classes land in the one ledger, which is exactly why nothing
+// here is cross-store.
+func assertGraftIsCoResidentIn(t *testing.T, store beads.Store, attachBeadID string) {
+	t.Helper()
+	deps, err := store.DepList(attachBeadID, "down")
+	if err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatalf("attach bead %s has no blocking dep; the graft was never wired", attachBeadID)
+	}
+	for _, dep := range deps {
+		if _, err := store.Get(dep.DependsOnID); err != nil {
+			t.Errorf("the rig store holds dep %s -> %s (%s) whose target it cannot resolve: %v", dep.IssueID, dep.DependsOnID, dep.Type, err)
+		}
+	}
+	graphClass := 0
+	for _, b := range allBeads(t, store) {
+		if b.ID == attachBeadID {
+			continue
+		}
+		if coordclass.Classify(b) == coordclass.ClassGraph {
+			graphClass++
+		}
+	}
+	if graphClass == 0 {
+		t.Fatalf("the rig store holds no %v-class bead from the graft (%v); the premise is that a rig graft mints the same class the city-scope gate refuses", coordclass.ClassGraph, beadIDs(allBeads(t, store)))
+	}
 }
 
 // assertAttachRefusalNamesItsReason requires the refusal to carry everything an

--- a/cmd/gc/formula_cook_attach_class_test.go
+++ b/cmd/gc/formula_cook_attach_class_test.go
@@ -1,0 +1,272 @@
+package main
+
+// The class half of `gc formula cook --attach` on a split city.
+//
+// oneshot_by_id_routes_test.go answers WHERE the graft is written (the store
+// that holds the attach bead). This file answers whether it may be written at
+// all: a graft materializes GRAPH-class beads whatever the formula's compiler
+// version, so grafting onto a bead the WORK ledger holds mints graph-class rows
+// in the work store — the stranded write a converged city's own containment
+// check counts and every later command refuses on (ga-99xhy, live-proven on a
+// throwaway split city as `stranded: 4` with `gc storage status` exiting 1).
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
+)
+
+// convergedSplitCookCity builds the one city that can answer both halves of
+// this bead: it cooks formulas AND reports its own storage layout.
+//
+// It is the one-shot cook fixture cut over by the PRODUCTION migration onto a
+// real SQLite binding, so `gc storage status` has a marker, a non-empty
+// proven-copy manifest and a real destination to re-check containment against —
+// the state in which a stranded write is detectable at all. The CLI's own
+// routes are pointed at that same binding, so the cook command and the
+// containment check are talking about one topology rather than two fixtures
+// that happen to agree.
+func convergedSplitCookCity(t *testing.T) (cityDir string, cfg *config.City, work beads.Store, target infraBindingTarget) {
+	t.Helper()
+	cityDir = oneShotCookCity(t)
+	work, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
+	prev := openInfraMigrationSource
+	openInfraMigrationSource = func(string) (beads.Store, error) { return work, nil }
+	t.Cleanup(func() { openInfraMigrationSource = prev })
+
+	// One infrastructure bead so the proven-copy manifest is non-empty: an
+	// empty manifest turns stranded-write detection off and the assertion below
+	// would prove nothing.
+	mustCreateInfraBead(t, work, beads.Bead{Title: "live session", Type: "session", Labels: []string{"gc:session"}})
+
+	cfg = infraSplitConfig(filepath.Join(cityDir, ".gc", "store"))
+	var log bytes.Buffer
+	if got := migrateInfraClasses(t, cityDir, cfg, &log); got.Outcome != infraMigrationConverged {
+		t.Fatalf("cutover outcome = %v, want converged; log: %s", got.Outcome, log.String())
+	}
+	target = mustResolveInfraTarget(t, cityDir, cfg)
+	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(openMigratedDestination(t, target)))
+	return cityDir, cfg, work, target
+}
+
+// storageStatusExit runs the read-only `gc storage status` body and returns its
+// exit code with everything it said.
+func storageStatusExit(t *testing.T, cityPath string, cfg *config.City) (int, string) {
+	t.Helper()
+	stubInfraControllerPing(t, 0)
+	var stdout, stderr bytes.Buffer
+	code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr)
+	return code, stdout.String() + stderr.String()
+}
+
+// TestFormulaCookAttachOnAWorkResidentBeadStrandsNothingOnAConvergedSplitCity
+// is the live proof, reproduced in-process.
+//
+// Red-before, on main, it fails once per arm with the city's own containment
+// check. graph-work:
+//
+//	gc formula cook --attach gc-2 left the city stranded: `gc storage status`
+//	exited 1 and reports:
+//	  ...
+//	  converged: yes
+//	    proven copy: 1 bead(s)
+//	    stranded:    3
+//	  stranded ids: gc-4, gc-5, gc-6
+//	(the cook itself said err=<nil>: Attached: gc-2 -> gc-4 (root: gc-4))
+//
+// legacy-work:
+//
+//	    stranded:    2
+//	  stranded ids: gc-3, gc-4
+//	(the cook itself said err=<nil>: Attached: gc-2 -> gc-3 (root: gc-2))
+//
+// Same shape as the `stranded: 4` measured on the live throwaway city, and the
+// same shape as the ~42/hr accrual that made maintainer-city boot-fatal —
+// reached through a path `gc formula cook --help` documented as correct. The
+// count is the fixture's step count, not a constant.
+func TestFormulaCookAttachOnAWorkResidentBeadStrandsNothingOnAConvergedSplitCity(t *testing.T) {
+	for _, formulaName := range []string{"graph-work", "legacy-work"} {
+		t.Run(formulaName, func(t *testing.T) {
+			cityDir, cfg, work, _ := convergedSplitCookCity(t)
+			if code, said := storageStatusExit(t, cityDir, cfg); code != 0 {
+				t.Fatalf("the fixture is not clean before the cook: `gc storage status` exited %d: %s", code, said)
+			}
+			source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+			if err != nil {
+				t.Fatalf("create attach bead: %v", err)
+			}
+
+			out, cookErr := cookFormulaErr(t, formulaName, "--attach", source.ID)
+
+			code, said := storageStatusExit(t, cityDir, cfg)
+			if code != 0 {
+				t.Fatalf("gc formula cook --attach %s left the city stranded: `gc storage status` exited %d and reports:\n%s\n(the cook itself said err=%v: %s)", source.ID, code, said, cookErr, out)
+			}
+			if !strings.Contains(said, "stranded:    0") {
+				t.Errorf("`gc storage status` does not report a clean ledger after the cook: %s", said)
+			}
+		})
+	}
+}
+
+// TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity is the refusal
+// itself, for the graph.v2 arm.
+//
+// It replaces TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged, which pinned
+// this shape as SERVED and is the behavior ga-99xhy found minting strands. The
+// deferral that test described has not been closed — the block still cannot be
+// represented across the store boundary (ga-2orlf) — so the graft is refused
+// rather than mis-homed in either direction.
+//
+// Red-before, on main:
+//
+//	gc formula cook graph-work --attach gc-2 exited 0 on a split city; a graft
+//	that mints graph-class beads in the work ledger must refuse, not serve
+func TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
+	}
+	before := beadIDs(allBeads(t, work))
+
+	out, err := cookFormulaErr(t, "graph-work", "--attach", source.ID)
+	if err == nil {
+		t.Fatalf("gc formula cook graph-work --attach %s exited 0 on a split city; a graft that mints graph-class beads in the work ledger must refuse, not serve\n%s", source.ID, out)
+	}
+	assertAttachRefusalNamesItsReason(t, out, source.ID)
+	assertRefusedGraftWroteNothing(t, work, graph, source.ID, before)
+}
+
+// TestFormulaCookLegacyAttachOnAWorkResidentBeadIsRefusedOnSplitCity is the v1
+// arm, and it is the half #5163's reasoning did NOT already cover.
+//
+// #5163 kept the v1 arm's capability because a v1 formula returns from
+// PrepareInvocation before NormalizeInputConvoy and therefore mints no
+// work-class input convoy. That is still true, and it is about the CONVOY, not
+// about the sub-DAG: molecule.Attach stamps gc.root_bead_id on every step it
+// materializes, which is coordclass.Classify's workflow arm, so a v1 graft's
+// beads are graph class exactly like a v2 graft's. Grafted onto a work-resident
+// bead they are stranded writes just the same, and the arm is refused for the
+// same reason.
+//
+// Red-before, on main:
+//
+//	gc formula cook legacy-work --attach gc-2 exited 0 on a split city; a v1
+//	graft stamps gc.root_bead_id on every step, so its sub-DAG is graph class
+//	and mints strands in the work ledger
+func TestFormulaCookLegacyAttachOnAWorkResidentBeadIsRefusedOnSplitCity(t *testing.T) {
+	work, graph := cookCityWithSplitGraph(t)
+
+	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create attach bead: %v", err)
+	}
+	before := beadIDs(allBeads(t, work))
+
+	out, err := cookFormulaErr(t, "legacy-work", "--attach", source.ID)
+	if err == nil {
+		t.Fatalf("gc formula cook legacy-work --attach %s exited 0 on a split city; a v1 graft stamps gc.root_bead_id on every step, so its sub-DAG is graph class and mints strands in the work ledger\n%s", source.ID, out)
+	}
+	assertAttachRefusalNamesItsReason(t, out, source.ID)
+	assertRefusedGraftWroteNothing(t, work, graph, source.ID, before)
+}
+
+// assertAttachRefusalNamesItsReason requires the refusal to carry everything an
+// operator needs: which bead, which class each end is, why the graft is not
+// expressible, the bead that will make it expressible, and — for the operator
+// who already HAS strands from this path — the verb that repairs them.
+func assertAttachRefusalNamesItsReason(t *testing.T, out, attachBeadID string) {
+	t.Helper()
+	for _, want := range []string{
+		attachBeadID,
+		"work",
+		"graph",
+		"ga-2orlf",
+		storageRecoveryInstruction(),
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("refusal %q does not mention %q; the reason and the remedy have to travel with the refusal", out, want)
+		}
+	}
+}
+
+// assertRefusedGraftWroteNothing requires a refusal to be a refusal: no bead in
+// either ledger, and no dep on the attach bead. A half-graft is the state this
+// change exists to prevent, so a refusal that wrote one would be worse than the
+// bug.
+func assertRefusedGraftWroteNothing(t *testing.T, work, graph beads.Store, attachBeadID string, before []string) {
+	t.Helper()
+	if got := beadIDs(allBeads(t, work)); len(got) != len(before) {
+		t.Errorf("the work ledger holds %v after a refused graft, want the %v it held before; a refusal writes nothing", got, before)
+	}
+	if got := allBeads(t, graph); len(got) != 0 {
+		t.Errorf("the binding holds %d bead(s) after a refused graft: %+v", len(got), got)
+	}
+	if deps, err := work.DepList(attachBeadID, "down"); err != nil {
+		t.Fatalf("listing attach deps: %v", err)
+	} else if len(deps) > 0 {
+		t.Errorf("attach bead %s gained %d dep(s) from a refused graft: %+v", attachBeadID, len(deps), deps)
+	}
+}
+
+// TestAttachedSubDAGIsGraphClassWhateverTheFormulaVersion pins the premise the
+// refusal rests on, so it is measured rather than asserted in prose.
+//
+// The class of a graft is not the class of its recipe. molecule.Attach stamps
+// gc.root_bead_id on EVERY step before instantiating — resolved through the run
+// chain and falling back to the attach bead's own id, so it is never empty —
+// and a non-empty gc.root_bead_id is coordclass.Classify's workflow arm. So a
+// v1 POURED formula, which cooks standalone into the work ledger as ClassWork
+// (TestFormulaCookLegacyMoleculeStaysOnTheWorkStore), materializes a GRAPH-class
+// sub-DAG the moment it is grafted.
+func TestAttachedSubDAGIsGraphClassWhateverTheFormulaVersion(t *testing.T) {
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "existing work", Type: "task"})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	recipe := &formula.Recipe{
+		Name: "poured",
+		Steps: []formula.RecipeStep{
+			{ID: "poured", Title: "Poured", Type: "molecule", IsRoot: true},
+			{ID: "poured.sweep", Title: "Sweep", Type: "task", Assignee: "worker"},
+		},
+	}
+	if got := recipeCoordClass(recipe); got != coordclass.ClassWork {
+		t.Fatalf("the fixture recipe is %v, not %v; it has to be the shape a standalone cook leaves in the work ledger", got, coordclass.ClassWork)
+	}
+
+	result, err := molecule.Attach(context.Background(), store, recipe, parent.ID, molecule.AttachOptions{})
+	if err != nil {
+		t.Fatalf("molecule.Attach: %v", err)
+	}
+
+	graftedGraphBeads := 0
+	for _, b := range allBeads(t, store) {
+		if b.ID == parent.ID {
+			continue
+		}
+		if coordclass.Classify(b) != coordclass.ClassGraph {
+			t.Errorf("grafted bead %s (%q) classifies as %v, not %v (gc.root_bead_id=%q)", b.ID, b.Title, coordclass.Classify(b), coordclass.ClassGraph, b.Metadata[beadmeta.RootBeadIDMetadataKey])
+			continue
+		}
+		graftedGraphBeads++
+	}
+	if graftedGraphBeads != result.Created {
+		t.Fatalf("the graft created %d bead(s) and %d classify as graph; the refusal's premise is that ALL of them do", result.Created, graftedGraphBeads)
+	}
+}

--- a/cmd/gc/oneshot_by_id_routes_test.go
+++ b/cmd/gc/oneshot_by_id_routes_test.go
@@ -24,6 +24,15 @@ import (
 // target, so that arm refuses. The two outcomes sit next to each other below on
 // purpose — the resolver is the same, the expressibility is not.
 //
+// The OTHER residence — an attach bead in the work ledger — is refused by both
+// arms, and its tests live in formula_cook_attach_class_test.go
+// (TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity and its v1
+// twin). That refusal replaced this file's
+// TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged, which pinned the shape
+// as served: a graft is graph class whatever the formula's version, so serving
+// it beside a work-resident attach bead minted graph-class rows in the work
+// ledger, which is a stranded write (ga-99xhy).
+//
 // Its siblings live in oneshot_class_routes_test.go, which covers the BIRTH
 // half — where a newly minted bead lands. The distinction matters: a birth is
 // routed by the CLASS of what is being created, a by-id operation by where the
@@ -198,8 +207,8 @@ func TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused(t *testing.T) {
 	}
 }
 
-// TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity is the COMMAND-level
-// statement that the cook's execution-fact legs are not merely equal but right.
+// TestFormulaCookAttachEmitsTheWorkAssociation is the COMMAND-level statement
+// that the cook's execution-fact legs are not merely equal but right.
 //
 // executionevent.ProjectCurrent reads the root and its steps from the graph leg
 // and the input convoy's `tracks` edges from the work leg, and a work leg that
@@ -207,10 +216,27 @@ func TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused(t *testing.T) {
 // mis-assigned leg loses the run's link to the work it was grafted onto with no
 // error, no warning and exit 0. That failure is invisible to a residence
 // assertion, so it is asserted here on the fact the projection exists to
-// produce, through the real cobra command, on the split topology where the two
-// legs could diverge.
-func TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity(t *testing.T) {
-	work, _, cityPath := cookCityWithSplitGraphAt(t)
+// produce, through the real cobra command.
+//
+// It used to run on the SPLIT topology, where the two legs can actually
+// diverge. That row is gone because the shape is: the only cook that mints an
+// input convoy is a graph.v2 --attach, and on a split city BOTH of its
+// residences now refuse — a binding-owned attach bead because the convoy has
+// nowhere to live (#5163,
+// TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused) and a work-resident
+// one because the sub-DAG would be a stranded write (ga-99xhy,
+// TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity). So the
+// divergence is unreachable through this command rather than unasserted, and
+// the leg ASSIGNMENT keeps its own guard at
+// TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg. When ga-2orlf
+// lifts either refusal, this test moves back onto the split fixture with it.
+func TestFormulaCookAttachEmitsTheWorkAssociation(t *testing.T) {
+	cityPath := oneShotCookCity(t)
+	seedCLIStorageRoutes(t, cityPath, nil)
+	work, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		t.Fatalf("open work store: %v", err)
+	}
 
 	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
 	if err != nil {
@@ -275,54 +301,18 @@ func TestFormulaCookLegacyAttachGraftsOntoAClassResidentBeadInOneStore(t *testin
 	}
 }
 
-// TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged pins the DEFERRED half,
-// so it cannot close or widen without a test moving.
-//
-// When the attach bead lives in the work ledger, the graft stays there with it —
-// including the sub-DAG, whose beads are graph class. Relocating them would put
-// the two ends of the `blocks` edge in different stores, which no backend
-// rejects and every Ready implementation reads as a blocker that never clears
-// (#5150 reproduced it as "attach bead gc-1 is not Ready after the whole
-// workflow closed"). Closing this gap needs the block REPRESENTED across the
-// store boundary, which no mechanism provides today.
-//
-// If a cross-boundary representation ever lands, this test flips: the root moves
-// to the binding, the work store keeps only a resolvable edge, and the deferral
-// paragraph on attachStore in cmd_formula.go goes with it.
-func TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged(t *testing.T) {
-	work, graph := cookCityWithSplitGraph(t)
-
-	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
-	if err != nil {
-		t.Fatalf("create attach bead: %v", err)
-	}
-
-	res := cookFormula(t, "graph-work", "--attach", source.ID)
-
-	if _, err := work.Get(res.RootID); err != nil {
-		t.Fatalf("sub-DAG root %s left the work ledger its attach bead lives in: %v — that is the split edge, not the fix", res.RootID, err)
-	}
-	if _, err := graph.Get(res.RootID); err == nil {
-		t.Errorf("sub-DAG root %s landed in the binding while its attach bead stayed in the work ledger; the `blocks` row then names an id the work store cannot resolve", res.RootID)
-	}
-	deps, err := work.DepList(source.ID, "down")
-	if err != nil {
-		t.Fatalf("listing attach deps: %v", err)
-	}
-	if len(deps) == 0 {
-		t.Fatalf("attach bead %s has no blocking dep after cook", source.ID)
-	}
-	for _, dep := range deps {
-		if _, err := work.Get(dep.DependsOnID); err != nil {
-			t.Errorf("work store holds dep %s -> %s (%s) whose target it cannot resolve: %v", dep.IssueID, dep.DependsOnID, dep.Type, err)
-		}
-	}
-}
-
 // TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity is the single-store
 // compatibility row for the whole attach change: a city that relocates nothing
 // gets the exact store its scope resolved, so both arms behave as they always
-// did.
+// did — and, since ga-99xhy, are not refused by the split-city class gate.
+//
+// Green before and after by design. Its teeth were proven by mutation: dropping
+// attachGraftClassRefusal's unrelocated early return fails this test, and
+// TestFormulaCookAttachEmitsTheWorkAssociation and
+// TestFormulaCookAttachIsIdempotent/single-store with it, on
+//
+//	gc formula cook graph-work: --attach gc-1: gc-1 is work class and lives in
+//	a WORK store rather than in the graph binding ...
 func TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity(t *testing.T) {
 	cityDir := oneShotCookCity(t)
 	resetCLIStorageRoutes(t)

--- a/cmd/gc/oneshot_class_routes_test.go
+++ b/cmd/gc/oneshot_class_routes_test.go
@@ -497,6 +497,12 @@ func closeEveryBeadExcept(t *testing.T, store beads.Store, keep string) {
 // leaves Ready permanently. Neither production backend rejects that write
 // (internal/beads/splittest/strict_store.go's backend table), so the only thing
 // that can catch it is this test.
+//
+// It is asserted on the one graft a split city still serves: a v1 formula onto
+// a bead the BINDING owns. The work-resident residence it used to use refuses
+// now, because the sub-DAG it would mint beside the attach bead is graph class
+// and therefore a stranded write (ga-99xhy,
+// TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity).
 func TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity(t *testing.T) {
 	cityDir := oneShotCookCity(t)
 	graph := splittest.NewClassStore(t, config.BeadClassGraph)
@@ -506,14 +512,14 @@ func TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity(t *testing.T
 	if err != nil {
 		t.Fatalf("open work store: %v", err)
 	}
-	source, err := work.Create(beads.Bead{Title: "attach target", Type: "task"})
+	source, err := graph.Create(beads.Bead{Title: "a running workflow step", Type: "task"})
 	if err != nil {
-		t.Fatalf("create attach bead: %v", err)
+		t.Fatalf("create the class-resident attach bead: %v", err)
 	}
 
-	res := cookFormula(t, "graph-work", "--attach", source.ID)
+	res := cookFormula(t, "legacy-work", "--attach", source.ID)
 
-	deps, err := work.DepList(source.ID, "down")
+	deps, err := graph.DepList(source.ID, "down")
 	if err != nil {
 		t.Fatalf("listing attach deps: %v", err)
 	}
@@ -521,17 +527,17 @@ func TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity(t *testing.T
 		t.Fatalf("attach bead %s has no blocking dep after cook; the graft was never wired", source.ID)
 	}
 	for _, dep := range deps {
-		if _, err := work.Get(dep.DependsOnID); err != nil {
-			t.Errorf("work store holds dep %s -> %s (%s) whose target it cannot resolve: %v — a dangling cross-store blocking edge no backend rejects and no finalize path removes", dep.IssueID, dep.DependsOnID, dep.Type, err)
+		if _, err := graph.Get(dep.DependsOnID); err != nil {
+			t.Errorf("the binding holds dep %s -> %s (%s) whose target it cannot resolve: %v — a dangling cross-store blocking edge no backend rejects and no finalize path removes", dep.IssueID, dep.DependsOnID, dep.Type, err)
 		}
 	}
 
 	closeEveryBeadExcept(t, graph, source.ID)
 	closeEveryBeadExcept(t, work, source.ID)
 
-	ready, err := work.Ready()
+	ready, err := graph.Ready()
 	if err != nil {
-		t.Fatalf("work Ready(): %v", err)
+		t.Fatalf("binding Ready(): %v", err)
 	}
 	if !slices.Contains(beadIDs(ready), source.ID) {
 		t.Fatalf("attach bead %s is not Ready after the whole workflow closed (ready=%v, root=%s); the --attach contract says the graft unblocks it, so it is wedged out of Ready forever", source.ID, beadIDs(ready), res.RootID)
@@ -609,36 +615,78 @@ func TestFormulaCookMetaStampLandsOnTheGraphResidentRoot(t *testing.T) {
 	}
 }
 
-// TestFormulaCookAttachIsIdempotentOnSplitCity drives the `existing != nil`
-// early return, the one attach path that returns without instantiating. A
-// convoy target gives the invocation a stable input-convoy id and therefore a
-// stable graph root key, so a repeat cook must adopt the live workflow instead
-// of minting a second one — and must not add a second blocking edge. The lookup
-// that decides this reads the store, so it is a residence assertion: point it at
-// a ledger the root is not in and every re-cook duplicates the workflow.
-func TestFormulaCookAttachIsIdempotentOnSplitCity(t *testing.T) {
-	cityDir := oneShotCookCity(t)
-	graph := splittest.NewClassStore(t, config.BeadClassGraph)
-	seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+// TestFormulaCookAttachIsIdempotent drives the `existing != nil` early return,
+// the one attach path that returns without instantiating. A convoy target gives
+// the invocation a stable input-convoy id and therefore a stable graph root key,
+// so a repeat cook must adopt the live workflow instead of minting a second one
+// — and must not add a second blocking edge.
+//
+// Two rows, because a split city answers this differently now. The graph.v2
+// --attach arm is refused on BOTH residences there (the binding's, for the
+// convoy that has nowhere to live — #5163; the work ledger's, for the sub-DAG
+// that would be a stranded write — ga-99xhy), so the property a split city has
+// to hold is that a repeated refusal accumulates nothing. The idempotent adopt
+// itself is asserted where it still runs.
+func TestFormulaCookAttachIsIdempotent(t *testing.T) {
+	t.Run("single-store adopts the live workflow", func(t *testing.T) {
+		cityDir := oneShotCookCity(t)
+		seedCLIStorageRoutes(t, cityDir, nil)
+		work, err := openStoreAtForCity(cityDir, cityDir)
+		if err != nil {
+			t.Fatalf("open work store: %v", err)
+		}
+		source, err := work.Create(beads.Bead{Title: "attach target", Type: "convoy"})
+		if err != nil {
+			t.Fatalf("create attach bead: %v", err)
+		}
 
-	work, err := openStoreAtForCity(cityDir, cityDir)
-	if err != nil {
-		t.Fatalf("open work store: %v", err)
-	}
-	source, err := work.Create(beads.Bead{Title: "attach target", Type: "convoy"})
-	if err != nil {
-		t.Fatalf("create attach bead: %v", err)
-	}
+		first := cookFormula(t, "graph-work", "--attach", source.ID)
+		second := cookFormula(t, "graph-work", "--attach", source.ID)
 
-	first := cookFormula(t, "graph-work", "--attach", source.ID)
-	second := cookFormula(t, "graph-work", "--attach", source.ID)
+		if first.RootID != second.RootID {
+			t.Fatalf("re-cook minted a second workflow root (%s then %s); the idempotent lookup read a store that does not hold the root", first.RootID, second.RootID)
+		}
+		if got := blockingDepCount(t, work, source.ID); got != 1 {
+			t.Errorf("attach bead %s carries %d blocking deps after two cooks, want 1", source.ID, got)
+		}
+	})
 
-	if first.RootID != second.RootID {
-		t.Fatalf("re-cook minted a second workflow root (%s then %s); the idempotent lookup read a store that does not hold the root", first.RootID, second.RootID)
-	}
-	deps, err := work.DepList(source.ID, "down")
+	t.Run("split refuses repeatedly and accumulates nothing", func(t *testing.T) {
+		cityDir := oneShotCookCity(t)
+		graph := splittest.NewClassStore(t, config.BeadClassGraph)
+		seedCLIStorageRoutes(t, cityDir, messagingSplitRoutes(graph))
+		work, err := openStoreAtForCity(cityDir, cityDir)
+		if err != nil {
+			t.Fatalf("open work store: %v", err)
+		}
+		source, err := work.Create(beads.Bead{Title: "attach target", Type: "convoy"})
+		if err != nil {
+			t.Fatalf("create attach bead: %v", err)
+		}
+
+		for attempt := 1; attempt <= 2; attempt++ {
+			if out, err := cookFormulaErr(t, "graph-work", "--attach", source.ID); err == nil {
+				t.Fatalf("attempt %d served a graft onto a work-resident bead on a split city: %s", attempt, out)
+			}
+		}
+		if got := beadIDs(allBeads(t, work)); len(got) != 1 || got[0] != source.ID {
+			t.Errorf("the work ledger holds %v after two refused grafts, want only %s", got, source.ID)
+		}
+		if got := allBeads(t, graph); len(got) != 0 {
+			t.Errorf("the binding holds %d bead(s) after two refused grafts: %+v", len(got), got)
+		}
+		if got := blockingDepCount(t, work, source.ID); got != 0 {
+			t.Errorf("attach bead %s carries %d blocking deps after two refused grafts, want 0", source.ID, got)
+		}
+	})
+}
+
+// blockingDepCount returns how many `blocks` edges hang off a bead.
+func blockingDepCount(t *testing.T, store beads.Store, beadID string) int {
+	t.Helper()
+	deps, err := store.DepList(beadID, "down")
 	if err != nil {
-		t.Fatalf("listing attach deps: %v", err)
+		t.Fatalf("listing deps of %s: %v", beadID, err)
 	}
 	blocking := 0
 	for _, dep := range deps {
@@ -646,9 +694,7 @@ func TestFormulaCookAttachIsIdempotentOnSplitCity(t *testing.T) {
 			blocking++
 		}
 	}
-	if blocking != 1 {
-		t.Errorf("attach bead %s carries %d blocking deps after two cooks, want 1: %+v", source.ID, blocking, deps)
-	}
+	return blocking
 }
 
 // TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity is the mirror of
@@ -718,20 +764,22 @@ func TestOrderRunPouredV1MoleculeStaysOnTheWorkStoreOnSplitCity(t *testing.T) {
 // move.
 //
 // So the command is asserted too, on the FACT rather than on the arguments:
-// TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity drives the real
-// cobra `gc formula cook --attach` on a split city and requires an
-// execution.work_associated naming the attach bead. It fails when the convoy
-// leg names a store that does not hold the convoy, which the residence
-// assertions around it cannot see — DepList on a convoy a store never held
-// answers EMPTY, not an error.
+// TestFormulaCookAttachEmitsTheWorkAssociation drives the real cobra
+// `gc formula cook --attach` and requires an execution.work_associated naming
+// the attach bead. It fails when the convoy leg names a store that does not
+// hold the convoy, which the residence assertions around it cannot see —
+// DepList on a convoy a store never held answers EMPTY, not an error.
 //
-// What keeps the two legs equal in production is a REFUSAL, not an accident:
-// the one shape that would split them, a graph.v2 graft onto a bead the class
-// binding owns, cannot mint its work-class input convoy in either ledger and is
-// refused by name (ga-2orlf,
-// TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused). If that refusal
-// is ever lifted, the two legs diverge again and BOTH tests are the ones that
-// have to answer for it.
+// What keeps the two legs equal in production is a pair of REFUSALS, not an
+// accident. The only cook that mints an input convoy is a graph.v2 --attach,
+// and on a split city both of its residences refuse: a binding-owned attach
+// bead, whose work-class convoy can live in neither ledger (ga-2orlf,
+// TestFormulaCookGraphV2AttachOnAClassResidentBeadIsRefused), and a
+// work-resident one, whose graph-class sub-DAG would be a stranded write
+// (ga-99xhy, TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity). So
+// this unit test is the ONLY place the two legs can be handed different stores
+// today. If either refusal is lifted, the command-level test moves back onto
+// the split fixture and both are the ones that have to answer for it.
 func TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg(t *testing.T) {
 	cityPath := t.TempDir()
 	graph := splittest.NewClassStore(t, config.BeadClassGraph)

--- a/docs/guides/understanding-formulas.md
+++ b/docs/guides/understanding-formulas.md
@@ -104,6 +104,9 @@ Three verbs create formula instances:
   formula, writes its beads into the current scope's store, and stops.
   Nothing wakes up. Cook to inspect the beads first, route the work
   yourself, or graft a sub-DAG onto existing work with `--attach <bead-id>`.
+  `--attach` is limited on a **split city** — one that serves the graph
+  class from its own `[storage]` binding. See
+  [Grafting on a split city](#grafting-on-a-split-city).
 - **Sling creates and routes.** `gc sling <target> <name> --formula` cooks
   and routes in one motion: a v2 formula starts a workflow, a v1 formula
   starts a single-bead run (a *wisp*), both routed to the target. The
@@ -780,13 +783,42 @@ The two frameworks above compose. Find your situation, read across:
 | Ordered steps worked by one agent | v1 or v2 | `gc sling --formula` | v1 run (a *molecule*) or v2 workflow |
 | Steps spread across agents or pools | v2 | `gc sling --formula` | workflow |
 | Inspect or route the beads yourself | either | `gc formula cook` | unrouted run (v1) or workflow (v2) |
-| A sub-DAG grafted onto existing work | either | `gc formula cook --attach` | steps blocking the given bead |
+| A sub-DAG grafted onto existing work | either | `gc formula cook --attach` | steps blocking the given bead (see [Grafting on a split city](#grafting-on-a-split-city)) |
 | One run per convoy member | v2 | `gc sling --on` (targeted) | workflow with drain units |
 | Verified or hardened steps | v2 | any | workflow with check or retry controls |
 | Recurring work on a trigger | either; v2 for pools | order | one instance per firing |
 | Bounded iterative refinement | v2 | `[steps.check]` loop (or v1 `gc converge create`) | orchestrator re-runs until the check passes |
 | Reuse a base, change one detail | either | `extends` + same-id override | child graph with the overridden step spliced in |
 | Iterating multi-lane review | v2 | expansion with `[template.check]` | lanes → synthesize → fix subtree, re-run until the verdict passes |
+
+### Grafting On A Split City
+
+A **split city** serves the graph coordination class from its own `[storage]`
+binding: workflow roots, step beads and control beads live in a second
+database, and ordinary work stays in the work ledger. Most of
+`gc formula cook --attach` is **not supported yet** there and refuses rather
+than serving.
+
+The reason is that a graft is graph class whatever the formula's version.
+Every bead an attach materializes carries `gc.root_bead_id`, which is what
+classifies a bead as graph — so the sub-DAG belongs in the binding while the
+blocking dependency belongs beside the attach bead, and a split city cannot
+have both ends in one store.
+
+| Attach bead lives in | Formula | Outcome |
+|---|---|---|
+| the work ledger | v1 or v2 | **refused** — writing the sub-DAG beside the attach bead strands graph-class beads in the work store; writing it into the binding leaves an unresolvable `blocks` row that never clears |
+| the binding | v2 (graph.v2) | **refused** — a v2 invocation mints a work-class input convoy, which can live in neither store |
+| the binding | v1 | served — the sub-DAG and its blocking dependency are both written to the binding |
+
+Single-store cities — every city that authors no `[storage]` section — are
+unaffected: `--attach` behaves exactly as it always has, on both contracts.
+
+Lifting the refusals needs a cross-class membership edge, tracked as
+`ga-2orlf`. If an earlier cook already stranded beads in a split city's work
+store, `gc storage status` names them and
+`gc storage recover-stranded --from-work --fleet-stopped` copies them into
+the binding.
 
 ### Convergence Loops
 

--- a/docs/guides/understanding-formulas.md
+++ b/docs/guides/understanding-formulas.md
@@ -796,8 +796,8 @@ The two frameworks above compose. Find your situation, read across:
 A **split city** serves the graph coordination class from its own `[storage]`
 binding: workflow roots, step beads and control beads live in a second
 database, and ordinary work stays in the work ledger. Most of
-`gc formula cook --attach` is **not supported yet** there and refuses rather
-than serving.
+`gc formula cook --attach` **in city scope** is **not supported yet** there
+and refuses rather than serving.
 
 The reason is that a graft is graph class whatever the formula's version.
 Every bead an attach materializes carries `gc.root_bead_id`, which is what
@@ -805,11 +805,19 @@ classifies a bead as graph — so the sub-DAG belongs in the binding while the
 blocking dependency belongs beside the attach bead, and a split city cannot
 have both ends in one store.
 
-| Attach bead lives in | Formula | Outcome |
-|---|---|---|
-| the work ledger | v1 or v2 | **refused** — writing the sub-DAG beside the attach bead strands graph-class beads in the work store; writing it into the binding leaves an unresolvable `blocks` row that never clears |
-| the binding | v2 (graph.v2) | **refused** — a v2 invocation mints a work-class input convoy, which can live in neither store |
-| the binding | v1 | served — the sub-DAG and its blocking dependency are both written to the binding |
+| Scope | Attach bead lives in | Formula | Outcome |
+|---|---|---|---|
+| city | the city's work ledger | v1 or v2 | **refused** — writing the sub-DAG beside the attach bead strands graph-class beads in the work store; writing it into the binding leaves an unresolvable `blocks` row that never clears |
+| city | the binding | v2 (graph.v2) | **refused** — a v2 invocation mints a work-class input convoy, which can live in neither store |
+| city | the binding | v1 | served — the sub-DAG and its blocking dependency are both written to the binding |
+| rig | that rig's own store | v1 or v2 | served, unaffected — a rig scope is never relocated |
+
+A **rig scope** — `--rig`, the `GC_RIG` the controller sets on every rig
+agent, or a cwd inside a rig — is unaffected. `gc storage migrate` copies
+only the city work store, and the class routes hold one city-level store per
+class with no per-rig binding to route to, so a rig's ledger keeps both ends
+of the graft. Nothing it writes can be stranded, and the recovery verb below
+would not read that store anyway.
 
 Single-store cities — every city that authors no `[storage]` section — are
 unaffected: `--attach` behaves exactly as it always has, on both contracts.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1652,24 +1652,27 @@ source bead reuses the live workflow instead of duplicating it, and a
 conflicting live workflow from the same source is an error.
 
 On a city that serves the graph class from its own [storage] binding, most
-of --attach is NOT SUPPORTED YET and refuses rather than serving. A graft is
-graph class whatever the formula's version — every bead it creates carries
-gc.root_bead_id — so the sub-DAG belongs in the binding while the blocking
-dependency belongs beside the attach bead, and a split city cannot have
-both:
+of --attach in CITY scope is NOT SUPPORTED YET and refuses rather than
+serving. A graft is graph class whatever the formula's version — every bead
+it creates carries gc.root_bead_id — so the sub-DAG belongs in the binding
+while the blocking dependency belongs beside the attach bead, and a split
+city cannot have both:
 
-  * attach bead in the WORK ledger — refused. Writing the sub-DAG beside it
-    strands graph-class beads in the work store, which gc storage status
-    reports and exits non-zero on; writing it into the binding leaves the
-    work store holding a blocks row naming an id it cannot resolve, which
-    never clears. Representing that block across the store boundary needs a
-    cross-class membership edge: ga-2orlf.
+  * attach bead in the city's WORK ledger — refused. Writing the sub-DAG
+    beside it strands graph-class beads in the work store, which gc storage
+    status reports and exits non-zero on; writing it into the binding leaves
+    the work store holding a blocks row naming an id it cannot resolve,
+    which never clears. Representing that block across the store boundary
+    needs a cross-class membership edge: ga-2orlf.
   * attach bead in the BINDING, v2 (graph.v2) formula — refused. It
     normalizes its target into a synthetic input convoy, which is a work
     bead that can live in neither store; its membership edge to the target
     would be cross-class. Same remedy: ga-2orlf.
   * attach bead in the BINDING, v1 formula — served. The sub-DAG and its
     blocking dependency are both written to the binding.
+  * RIG scope (--rig, GC_RIG, or a cwd inside a rig) — served, unchanged.
+    A relocation moves city-level stores only, so a rig's ledger holds both
+    ends of the graft and nothing it writes can be stranded.
 
 Single-store cities are unaffected: --attach behaves exactly as it always
 has. If an earlier cook already stranded beads in a split city's work

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1651,14 +1651,30 @@ per-source workflow lock and is idempotent: a repeat cook for the same
 source bead reuses the live workflow instead of duplicating it, and a
 conflicting live workflow from the same source is an error.
 
-On a city that serves a coordination class from its own [storage] binding,
---attach follows the ATTACH BEAD: the sub-DAG and the blocking dependency
-are written to the store that holds it, so the two ends of the edge stay in
-one store. A v2 (graph.v2) formula is the exception and is refused for an
-attach bead the binding owns: it normalizes its target into a synthetic
-input convoy, which is a work bead that can live neither in the binding nor
-in the work ledger, whose membership edge to the target would be
-cross-class. Attach a v1 formula to that bead instead.
+On a city that serves the graph class from its own [storage] binding, most
+of --attach is NOT SUPPORTED YET and refuses rather than serving. A graft is
+graph class whatever the formula's version — every bead it creates carries
+gc.root_bead_id — so the sub-DAG belongs in the binding while the blocking
+dependency belongs beside the attach bead, and a split city cannot have
+both:
+
+  * attach bead in the WORK ledger — refused. Writing the sub-DAG beside it
+    strands graph-class beads in the work store, which gc storage status
+    reports and exits non-zero on; writing it into the binding leaves the
+    work store holding a blocks row naming an id it cannot resolve, which
+    never clears. Representing that block across the store boundary needs a
+    cross-class membership edge: ga-2orlf.
+  * attach bead in the BINDING, v2 (graph.v2) formula — refused. It
+    normalizes its target into a synthetic input convoy, which is a work
+    bead that can live in neither store; its membership edge to the target
+    would be cross-class. Same remedy: ga-2orlf.
+  * attach bead in the BINDING, v1 formula — served. The sub-DAG and its
+    blocking dependency are both written to the binding.
+
+Single-store cities are unaffected: --attach behaves exactly as it always
+has. If an earlier cook already stranded beads in a split city's work
+store, copy them into the binding with
+gc storage recover-stranded --from-work --fleet-stopped.
 
 ```
 gc formula cook <formula-name> [flags]

--- a/docs/reference/specs/formula-spec-v1.md
+++ b/docs/reference/specs/formula-spec-v1.md
@@ -611,6 +611,18 @@ under an existing bead as a sub-DAG; the attach target gains a blocking
 dependency on the sub-DAG root, so it cannot close until the sub-DAG
 completes.
 
+A graft is GRAPH class even for a v1 formula: the attach path stamps
+`gc.root_bead_id` on every bead it materializes, which is what makes a bead
+graph class, so the sub-DAG is graph class regardless of what the same recipe
+would compile to standalone. On a city that serves the graph class from its
+own `[storage]` binding, `--attach` is therefore only served for an attach
+bead the BINDING owns; grafting onto a work-resident bead is refused, because
+the sub-DAG would either be stranded in the work ledger or leave a `blocks`
+row naming an id the work store cannot resolve. Single-store cities are
+unaffected. See formula-spec-v2 §3 and `gc formula cook --help` for the full
+residence table; the cross-class membership edge that lifts the refusal is
+tracked as `ga-2orlf`.
+
 `gc sling <target> <formula> --formula` instantiates the formula as an
 ephemeral wisp and routes the root bead to the target:
 

--- a/docs/reference/specs/formula-spec-v1.md
+++ b/docs/reference/specs/formula-spec-v1.md
@@ -615,13 +615,16 @@ A graft is GRAPH class even for a v1 formula: the attach path stamps
 `gc.root_bead_id` on every bead it materializes, which is what makes a bead
 graph class, so the sub-DAG is graph class regardless of what the same recipe
 would compile to standalone. On a city that serves the graph class from its
-own `[storage]` binding, `--attach` is therefore only served for an attach
-bead the BINDING owns; grafting onto a work-resident bead is refused, because
-the sub-DAG would either be stranded in the work ledger or leave a `blocks`
-row naming an id the work store cannot resolve. Single-store cities are
-unaffected. See formula-spec-v2 §3 and `gc formula cook --help` for the full
-residence table; the cross-class membership edge that lifts the refusal is
-tracked as `ga-2orlf`.
+own `[storage]` binding, `--attach` in CITY scope is therefore only served
+for an attach bead the BINDING owns; grafting onto a city-work-resident bead
+is refused, because the sub-DAG would either be stranded in the work ledger
+or leave a `blocks` row naming an id the work store cannot resolve. A RIG
+scope — `--rig`, `GC_RIG`, or a cwd inside a rig — is unaffected: relocation
+copies the city work store only, so a rig's ledger holds both ends of the
+graft and `--attach` stays served there. Single-store cities are unaffected.
+See formula-spec-v2 §3 and `gc formula cook --help` for the full residence
+table; the cross-class membership edge that lifts the refusal is tracked as
+`ga-2orlf`.
 
 `gc sling <target> <formula> --formula` instantiates the formula as an
 ephemeral wisp and routes the root bead to the target:

--- a/docs/reference/specs/formula-spec-v2.md
+++ b/docs/reference/specs/formula-spec-v2.md
@@ -641,6 +641,23 @@ inject `convoy_id`, resolve the deprecated `issue` alias to the single
 tracked convoy member, and stamp the root as specified in section 2. The
 reserved-variable rules of section 1.4 are enforced at this point.
 
+**Attach on a split city.** A city that serves the graph coordination class
+from its own `[storage]` binding refuses most of `gc formula cook --attach`
+rather than serving it. A graft is graph class whatever the formula's
+version — every bead it materializes carries `gc.root_bead_id` — so the
+sub-DAG belongs in the binding while the blocking dependency belongs beside
+the attach bead, and one store cannot hold both:
+
+| Attach bead lives in | Formula | Outcome |
+|---|---|---|
+| the work ledger | v1 or v2 | refused: the sub-DAG would be stranded in the work ledger, or the work store would keep a `blocks` row naming an id it cannot resolve |
+| the binding | v2 | refused: the invocation mints a work-class input convoy, whose `tracks` edge to a binding-owned target is cross-class |
+| the binding | v1 | served: the sub-DAG and its blocking dependency are both written to the binding |
+
+Both refusals are lifted by the same missing mechanism, a cross-class
+membership edge (`ga-2orlf`). Cities that author no `[storage]` section are
+unaffected and `--attach` behaves exactly as it always has.
+
 **Control dispatch.** The orchestrator's control dispatcher processes every
 open control bead by `gc.kind`: `retry`, `ralph`, `check`, `retry-eval`,
 `fanout`, `drain`, `scope-check`, and `workflow-finalize`. An

--- a/docs/reference/specs/formula-spec-v2.md
+++ b/docs/reference/specs/formula-spec-v2.md
@@ -648,11 +648,17 @@ version — every bead it materializes carries `gc.root_bead_id` — so the
 sub-DAG belongs in the binding while the blocking dependency belongs beside
 the attach bead, and one store cannot hold both:
 
-| Attach bead lives in | Formula | Outcome |
-|---|---|---|
-| the work ledger | v1 or v2 | refused: the sub-DAG would be stranded in the work ledger, or the work store would keep a `blocks` row naming an id it cannot resolve |
-| the binding | v2 | refused: the invocation mints a work-class input convoy, whose `tracks` edge to a binding-owned target is cross-class |
-| the binding | v1 | served: the sub-DAG and its blocking dependency are both written to the binding |
+| Scope | Attach bead lives in | Formula | Outcome |
+|---|---|---|---|
+| city | the city's work ledger | v1 or v2 | refused: the sub-DAG would be stranded in the work ledger, or the work store would keep a `blocks` row naming an id it cannot resolve |
+| city | the binding | v2 | refused: the invocation mints a work-class input convoy, whose `tracks` edge to a binding-owned target is cross-class |
+| city | the binding | v1 | served: the sub-DAG and its blocking dependency are both written to the binding |
+| rig | that rig's own store | v1 or v2 | served, unaffected: relocation is a city-scope property, so a rig's ledger holds both ends of the graft |
+
+Relocation applies to the CITY scope only: the migration copies the city work
+store alone and the class routes hold one city-level store per class, so a
+rig scope — `--rig`, `GC_RIG`, or a cwd inside a rig — keeps serving
+`--attach` exactly as it always has, and nothing it writes is stranded.
 
 Both refusals are lifted by the same missing mechanism, a cross-class
 membership edge (`ga-2orlf`). Cities that author no `[storage]` section are


### PR DESCRIPTION
## The problem, live-proven

On a converged split city, `gc formula cook --attach <work-store bead>` wrote the graph-class sub-DAG into the **work** store — which `gc formula cook --help` documented as correct — and gc's own containment check then flagged exactly those beads: `gc storage status` reported `stranded: N` and exited 1, a permanent alarm on every later command. Same shape as the ~42/hr accrual that made maintainer-city boot-fatal, reached through a path the program declared correct.

## The class question, settled

The strand check is right; the documentation was wrong. The doc was written for a single-store world where the question could not arise.

A graft is **GRAPH class whatever the formula's version**. `molecule.Attach` stamps `gc.root_bead_id` on every step it materializes — resolved through the run chain with the attach bead's own id as the fallback, so it is never empty — and a non-empty `gc.root_bead_id` is `coordclass.Classify`'s workflow arm. A graph.v2 pour is graph class end to end for its own reasons. `TestAttachedSubDAGIsGraphClassWhateverTheFormulaVersion` pins this rather than asserting it in prose: it grafts a recipe `recipeCoordClass` calls `ClassWork` and requires every bead the graft creates to classify `ClassGraph`.

**So the v1 arm IS affected by this bead.** The capability #5163 kept for v1 was about the INPUT CONVOY (a v1 formula returns from `PrepareInvocation` before `NormalizeInputConvoy` and mints none) — not about the sub-DAG. That reasoning still stands for a binding-owned attach bead, and that shape stays served.

## What this ships

**A refusal, before either arm runs.** `attachGraftClassRefusal` (new `cmd/gc/formula_cook_attach_class.go`), called from the `--attach` block in `cmd/gc/cmd_formula.go` immediately after `classRoutedStoreForID`. It fires only when the city relocates the graph class **and** the attach bead lives in the work store. Neither placement is expressible there: beside the attach bead the sub-DAG is a stranded write; in the binding the work store keeps a `blocks` row naming an id it cannot resolve — the dangling edge #5150 reverted, reproduced as *"attach bead gc-1 is not Ready after the whole workflow closed"*. Neither previously-reverted shape is re-shipped.

The refusal names the attach bead, its class, the store it lives in, the sub-DAG's class, why it is not expressible, `ga-2orlf` (the cross-class membership edge that lifts it — #5163 measured that `TrackItemIn` refuses even when `MemberClasses.Graph` is named explicitly), and the repair verb that landed today for operators who already hold strands from this path, `gc storage recover-stranded --from-work --fleet-stopped` (c89a0fa580, #5178). Both operator instructions are rendered from the same constants the cobra tree is built from, so a refusal cannot name a command this binary does not carry.

Nothing automated calls `cook --attach` — zero callers anywhere in the tree, in any pack, formula, prompt or script — so an operator told "not yet supported on a split city" is strictly better off than one holding a permanently alarming ledger.

The full split-city residence table is now:

| Scope | Attach bead lives in | Formula | Outcome |
|---|---|---|---|
| city | the city's work ledger | v1 or v2 | **refused** (this PR, ga-99xhy) |
| city | the binding | v2 (graph.v2) | **refused** (#5163) |
| city | the binding | v1 | served |
| rig | that rig's own store | v1 or v2 | served, unaffected — a rig scope is never relocated |

**Documentation corrected.** `gc formula cook --help`/`Long` and the regenerated `docs/reference/cli.md`; the Cook bullet and the "A sub-DAG grafted onto existing work" recap row in `docs/guides/understanding-formulas.md`, plus a new "Grafting On A Split City" section; the `--attach` paragraphs of `docs/reference/specs/formula-spec-v1.md` and `-v2.md`.

## Tests, red-before

`TestFormulaCookAttachOnAWorkResidentBeadStrandsNothingOnAConvergedSplitCity` reproduces the live proof in-process: the one-shot cook fixture cut over by the **production** migration onto a real SQLite binding, so there is a marker, a non-empty proven-copy manifest and a real destination to re-check containment against. Red-before, per arm:

```
--- FAIL: .../graph-work
    gc formula cook --attach gc-2 left the city stranded: `gc storage status` exited 1 and reports:
      converged: yes
        proven copy: 1 bead(s)
        stranded:    3
        removed since cutover: 0
      stranded ids: gc-4, gc-5, gc-6
    blocking invariant: the binding cannot read these beads. Stop every writer and copy them in with
      `gc storage recover-stranded --from-work --fleet-stopped`
    (the cook itself said err=<nil>: Attached: gc-2 -> gc-4 (root: gc-4) / Created: 3)

--- FAIL: .../legacy-work
        stranded:    2
      stranded ids: gc-3, gc-4
    (the cook itself said err=<nil>: Attached: gc-2 -> gc-3 (root: gc-2) / Created: 2)
```

```
--- FAIL: TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity
    gc formula cook graph-work --attach gc-1 exited 0 on a split city; a graft that mints
    graph-class beads in the work ledger must refuse, not serve

--- FAIL: TestFormulaCookLegacyAttachOnAWorkResidentBeadIsRefusedOnSplitCity
    gc formula cook legacy-work --attach gc-1 exited 0 on a split city; a v1 graft stamps
    gc.root_bead_id on every step, so its sub-DAG is graph class and mints strands in the
    work ledger
```

All use `internal/beads/splittest` (the real `beads.SQLiteStore` class leaf) through the existing `cookCityWithSplitGraph` fixture.

## Single-store cities are byte-identical

The guard returns on the unrelocated branch before reading anything. Proven by mutation: dropping that early return fails `TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity`, `TestFormulaCookAttachEmitsTheWorkAssociation` and `TestFormulaCookAttachIsIdempotent/single-store` with

```
gc formula cook graph-work: --attach gc-1: gc-1 is work class and lives in a WORK store
rather than in the graph binding ...
```

## Tests that moved, and why

No coverage was deleted; four split-city rows changed shape because the shape they pinned is now refused.

- `TestFormulaCookAttachOnAWorkResidentBeadIsUnchanged` **flipped** into `TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity` (its own doc comment said it would flip). The by-id file header names the replacement.
- `TestFormulaCookAttachLeavesTheSourceBeadUnblockableOnSplitCity` re-targeted to the one graft a split city still serves — a v1 formula onto a binding-owned bead — keeping the Ready-after-close assertion.
- `TestFormulaCookAttachIsIdempotentOnSplitCity` → `TestFormulaCookAttachIsIdempotent`, two rows: single-store adopts the live workflow; split refuses twice and accumulates nothing.
- `TestFormulaCookAttachEmitsTheWorkAssociationOnASplitCity` → `TestFormulaCookAttachEmitsTheWorkAssociation`, on the single-store fixture. The split row is gone **by construction**: the only cook that mints an input convoy is a graph.v2 `--attach`, and both of its residences now refuse. `TestEmitFormulaCookExecutionFactsReadsTheConvoyFromTheWorkLeg` remains the leg-assignment guard, and its doc comment now says it is the only place the two legs can diverge. When ga-2orlf lifts either refusal, the command-level test moves back onto the split fixture.

No conformance KNOWN GAP became closable, and none was added.

## Gates

`go build ./...` · `go vet ./...` · `gofmt` clean · `golangci-lint run ./cmd/gc/...` **0 issues** · `go test ./cmd/gc -p 1 -parallel 1 -timeout 25m` **ok (758s)** · `go test ./internal/...` **ok** · `scripts/check-core-boundary.sh` **OK** · `make check-split-topology-rows` **OK** · `make check-routed-test-rows` **OK** · `go test ./test/docsync` **ok** · `go run ./cmd/genschema` re-run, generated docs in sync.

Closes nothing; ga-99xhy stays open pending review.

## Review fix (dd135a5719): the gate is scoped to the CITY work store

Review caught a MAJOR in the first cut. `attachGraftClassRefusal` resolved the binding with the **city-level** `graphClassBinding(cliStorageRoutes(cityPath))` and then decided residence against `scope` — but `scope` is whatever `resolveFormulaScope` opened, which is the **RIG work store** whenever `--rig`, `GC_RIG` or a rig cwd is active. `GC_RIG` is ambient on every controller-spawned agent, so on a split city with rigs this killed `--attach` for essentially every agent.

**A rig store is never relocated**, and the tree says so three ways: `controlScopeTakesGraphClass` (*"Only the CITY scope does… `gc storage migrate` copies only the city work store… A rig scope therefore stays entirely on its own store"*), `controlGraphStore` returns a rig scope's store unchanged, and `classifyInfraContainmentGap` → `openInfraMigrationSource` → `openStoreAtForCity(cityPath, cityPath)` reads only the city work store. So a rig-scoped graft can never be counted stranded — and the remedy the refusal names, `gc storage recover-stranded --from-work`, reads that same city store and would have repaired nothing for it.

**The predicate**, reusing the one the dispatcher already has rather than inventing a second answer:

```go
func attachGraftClassRefusal(cityPath, scopeRoot, attachBeadID string, scope, attachStore beads.Store) error {
	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
	if !relocated || class == nil || class == scope {
		return nil
	}
	if !controlScopeTakesGraphClass(cityPath, scopeRoot) { // samePath(resolveStoreScopeRoot(cityPath, scopeRoot), cityPath)
		return nil
	}
	...
```

`scope.storeRoot` is threaded in from the call site. **Nothing else moves.** `resolveGraphStore` → `resolveClassStore` stays scope-blind and `classRoutedStoreForID` on the line above the gate still asks the identical city-level question — that is the command's existing convention, so a binding-owned attach bead in rig scope is still served by the v1 arm, and changing either would be a production routing change out of scope for this bead.

### Measured, split city, rig `wf` bound, `GC_RIG=wf`, attach bead in the RIG store

| | v1 (`legacy-work`) | rig store after | binding | city work store |
|---|---|---|---|---|
| base `c89a0fa580` | `err=<nil>` · `Attached: gc-1 -> gc-2 (root: gc-1)` · `Created: 2` | `[gc-1 gc-2 gc-3]`, dep `gc-1 blocks gc-2` resolvable **in the rig store** | `[]` | `[]` |
| head `16e816e412` | **exit 1**, the refusal | `[gc-1]` | `[]` | `[]` |
| fixed `dd135a5719` | `err=<nil>` · `Attached: gc-1 -> gc-2 (root: gc-1)` · `Created: 2` | `[gc-1 gc-2 gc-3]`, dep resolvable **in the rig store** | `[]` | `[]` |

Identical to base. The v2 arm is the same story (`Attached: gc-1 -> gc-3 (root: gc-3)`, `Created: 3`, rig store `[gc-1 … gc-5]`). City scope is unchanged from head: a work-resident attach bead in city scope still refuses, on both arms.

### Tests, red-before, per direction

`TestFormulaCookAttachInRigScopeStaysServedOnASplitCity` (both arms) drives the real command on a rig with its **own** file-backed ledger — scoped file-store roots, so the rig is not aliasing the city's — entered through the ambient `GC_RIG` with `--rig` explicitly cleared. It asserts the graft is served, both ends are co-resident in the rig store, the graft mints the same GRAPH class the city gate refuses, and neither the city work store nor the binding gains a bead.

**Rig served** — dropping the scope gate:

```
gc formula cook legacy-work --attach gc-1 was refused in RIG scope on a split city: exit
gc formula cook: --attach gc-1: gc-1 is work class and lives in a WORK store rather than
in the graph binding, and the sub-DAG a graft materializes is graph class whatever the
formula's version ...
a rig store is never relocated, so both ends of the graft are co-resident in it and
nothing it writes can be stranded
```

(same for `graph-work`)

**City refused** — over-correcting the gate to return nil unconditionally:

```
--- FAIL: TestFormulaCookAttachOnAWorkResidentBeadIsRefusedOnSplitCity
    gc formula cook graph-work --attach gc-1 exited 0 on a split city; a graft that mints
    graph-class beads in the work ledger must refuse, not serve

--- FAIL: TestFormulaCookLegacyAttachOnAWorkResidentBeadIsRefusedOnSplitCity
    gc formula cook legacy-work --attach gc-1 exited 0 on a split city; a v1 graft stamps
    gc.root_bead_id on every step, so its sub-DAG is graph class and mints strands in the
    work ledger

--- FAIL: TestFormulaCookAttachIsIdempotent/split_refuses_repeatedly_and_accumulates_nothing
    attempt 1 served a graft onto a work-resident bead on a split city

--- FAIL: TestFormulaCookAttachOnAWorkResidentBeadStrandsNothingOnAConvergedSplitCity
    gc formula cook --attach gc-2 left the city stranded: `gc storage status` exited 1
```

**Single-store cities stay byte-identical**, re-proven by mutation on the new shape: dropping the unrelocated early return still fails `TestFormulaCookAttachStaysOnTheOneStoreOnASingleStoreCity`, `TestFormulaCookAttachEmitsTheWorkAssociation` and `TestFormulaCookAttachIsIdempotent/single-store`.

### Docs

A rig row was added to every residence table this PR touched: `gc formula cook --help`/`Long` (and the regenerated `docs/reference/cli.md`), the split-city table in `docs/guides/understanding-formulas.md` (now `Scope | Attach bead lives in | Formula | Outcome`), the same table in `docs/reference/specs/formula-spec-v2.md` §3, and the `--attach` paragraph of `docs/reference/specs/formula-spec-v1.md`.

Everything the council did not fault is kept: the v1-is-affected finding, one gate serving both arms at the same call site, and the refusal's `ga-2orlf` / `recover-stranded` references for the city case.

### Gates (re-run on the fixed tree)

`go build ./...` · `go vet ./...` · `gofmt` clean · `golangci-lint run ./cmd/gc/...` **0 issues** · `go test ./cmd/gc -p 1 -parallel 1 -timeout 25m` **ok (779.6s)** · `go test ./internal/...` **ok** · `scripts/check-core-boundary.sh` **OK** · `make check-split-topology-rows` **OK** · `make check-routed-test-rows` **OK** · `go test ./test/docsync` **ok** · `go run ./cmd/genschema` re-run, generated docs in sync.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

