### PR TITLE
fix(cli,api): state the storage tier on every federated ready/list leg (ga-8lyxc)

### DIFF
--- a/cmd/gc/cmd_ready.go
+++ b/cmd/gc/cmd_ready.go
@@ -129,16 +129,19 @@ func toReadyBeadDeps(deps []beads.Dep) []readyBeadDep {
 }
 
 // readyOpts carries the parsed `gc ready` flags.
+//
+// --include-ephemeral is deliberately absent: the reader spans both storage
+// tiers on every leg unconditionally (beads.FederatedReadTier), so the flag
+// selects nothing. See newReadyCmd.
 type readyOpts struct {
-	assignee         string
-	unassigned       bool
-	metadataFields   []string
-	excludeTypes     []string
-	excludeLabels    []string
-	sortOrder        string
-	limit            int
-	includeEphemeral bool
-	status           string
+	assignee       string
+	unassigned     bool
+	metadataFields []string
+	excludeTypes   []string
+	excludeLabels  []string
+	sortOrder      string
+	limit          int
+	status         string
 }
 
 // newReadyCmd builds `gc ready`: the in-process, city-wide claimable-work reader
@@ -154,6 +157,7 @@ type readyOpts struct {
 func newReadyCmd(stdout, stderr io.Writer) *cobra.Command {
 	var opts readyOpts
 	var jsonOut bool
+	var includeEphemeral bool
 	cmd := &cobra.Command{
 		Use:   "ready",
 		Short: "List ready (claimable) work across every store in the city",
@@ -174,7 +178,11 @@ The flags mirror the "bd ready" contract the default work_query builds:
 Rows are emitted in canonical ready order (priority, created_at, id) unless
 --sort selects a created_at order, and --limit is applied last, so a bounded
 read is the true top-N of the merged set rather than the top-N of whichever
-store answered first.`,
+store answered first.
+
+Every leg is read across both storage tiers, so the wisp/ephemeral rows an
+orchestration step runs as are claimable work here whether or not
+--include-ephemeral is passed.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if cmdReady(opts, stdout, stderr) != 0 {
@@ -190,7 +198,14 @@ store answered first.`,
 	cmd.Flags().StringArrayVar(&opts.excludeLabels, "exclude-label", nil, "drop beads carrying this label (repeatable)")
 	cmd.Flags().StringVar(&opts.sortOrder, "sort", "", "sort order: oldest|newest (default: canonical ready order)")
 	cmd.Flags().IntVar(&opts.limit, "limit", 0, "max beads to return (0 = unlimited)")
-	cmd.Flags().BoolVar(&opts.includeEphemeral, "include-ephemeral", false, "include the wisp/ephemeral tier")
+	// --include-ephemeral is accepted for parity with `bd ready`, which the
+	// generated work_query carries verbatim on a bd-1.0.5 city. It selects
+	// nothing, and that is the honest spelling rather than a silent one: every
+	// leg is read at beads.FederatedReadTier, which already spans the wisp tier.
+	// Binding it to a discarded variable is deliberate — a readyOpts field
+	// nothing consults is how a flag ends up looking honored while one leg
+	// quietly narrows (ga-8lyxc).
+	cmd.Flags().BoolVar(&includeEphemeral, "include-ephemeral", false, "accept --include-ephemeral for bd-ready parity (every leg already spans the wisp tier)")
 	cmd.Flags().StringVar(&opts.status, "status", "", "list beads in this status instead of ready work: open|in_progress|blocked|closed")
 	// --json is accepted for parity with `bd ready --json`, which the generated
 	// work_query carries verbatim. The payload is a JSON array either way; the
@@ -262,7 +277,7 @@ func readyBeadsForOpts(legs []readyLeg, opts readyOpts) ([]readyBead, error) {
 	if err != nil {
 		return nil, err
 	}
-	items, err := readReadyCandidates(legs, opts, status)
+	items, err := readReadyCandidates(legs, status)
 	if err != nil {
 		return nil, err
 	}
@@ -280,17 +295,20 @@ func readyBeadsForOpts(legs []readyLeg, opts readyOpts) ([]readyBead, error) {
 // lists beads in exactly that status — the flag is a real selector, not a single
 // special case with an "everything else means ready" fallthrough, which answers
 // `--status closed` with open work.
-func readReadyCandidates(legs []readyLeg, opts readyOpts, status string) ([]beads.Bead, error) {
-	tier := beads.TierIssues
-	if opts.includeEphemeral {
-		tier = beads.TierBoth
-	}
+//
+// Both arms state beads.FederatedReadTier explicitly, and neither has a branch
+// that could state anything else. A tier left at the zero value is not a neutral
+// default across these legs: the work legs' bead-policy layer rewrites it to
+// TierBoth and the relocated class leg has no such layer, so the merged answer
+// would be one question asked of the work stores and a narrower one asked of the
+// store that holds the execution DAG. See beads.FederatedReadTier.
+func readReadyCandidates(legs []readyLeg, status string) ([]beads.Bead, error) {
 	if status == "" {
-		return federateReadyBeads(legs, beads.ReadyQuery{TierMode: tier})
+		return federateReadyBeads(legs, beads.ReadyQuery{TierMode: beads.FederatedReadTier})
 	}
 	return federateListBeads(legs, beads.ListQuery{
 		Status:   status,
-		TierMode: tier,
+		TierMode: beads.FederatedReadTier,
 		// Only the crash-recovery tier pays for a live read: a claim that
 		// happened seconds ago must be visible, and a cached projection of it is
 		// exactly the stale answer that re-dispatches work already in flight.

--- a/cmd/gc/cmd_ready_test.go
+++ b/cmd/gc/cmd_ready_test.go
@@ -1065,3 +1065,85 @@ func TestGcReadySteerDescribesTheFlagsItActuallyAccepts(t *testing.T) {
 		t.Errorf("the steer names --sort without its accepted values: %q", msg)
 	}
 }
+
+// readyTierRecordingStore records the storage tier every read it serves was
+// asked for, so a test can assert what the federation ASKED rather than only
+// what it got back.
+//
+// The distinction is the whole of ga-8lyxc. Every leg could serve every tier;
+// none of them failed, and none of them had a tier to refuse — the federation
+// never stated one. The work legs' bead-policy layer then rewrote the zero value
+// to TierBoth and the unwrapped class leg took it literally, so the merged answer
+// was two different questions and nothing on any path could say so.
+type readyTierRecordingStore struct {
+	beads.Store
+	readyTiers *[]beads.TierMode
+	listTiers  *[]beads.TierMode
+}
+
+func (s readyTierRecordingStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	var q beads.ReadyQuery
+	if len(query) > 0 {
+		q = query[0]
+	}
+	*s.readyTiers = append(*s.readyTiers, q.TierMode)
+	return s.Store.Ready(query...)
+}
+
+func (s readyTierRecordingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	*s.listTiers = append(*s.listTiers, query.TierMode)
+	return s.Store.List(query)
+}
+
+// TestReadyStatesTheSameTierOnEveryLeg is the structural guard behind ga-8lyxc,
+// and it is deliberately about the QUESTION rather than the rows.
+//
+// A row-level assertion only catches the tier hole on a fixture whose legs are
+// wrapped differently, and the wrapping is exactly what a refactor is free to
+// change. This asserts the invariant directly: every leg of the federation is
+// read at one explicit tier, and never at the zero value — which is not a
+// neutral default here but a narrower question the policy-wrapped legs silently
+// rewrite. Both arms are covered, because they build different query types.
+func TestReadyStatesTheSameTierOnEveryLeg(t *testing.T) {
+	var readyTiers, listTiers []beads.TierMode
+	legs := []readyLeg{
+		readyTestLeg("city", readyTierRecordingStore{
+			Store: splittest.NewWorkStore(t, "gc"), readyTiers: &readyTiers, listTiers: &listTiers,
+		}),
+		readyTestLeg("rig frontend", readyTierRecordingStore{
+			Store: splittest.NewWorkStore(t, "ra"), readyTiers: &readyTiers, listTiers: &listTiers,
+		}),
+		readyTestLeg("graph", readyTierRecordingStore{
+			Store: splittest.NewClassStore(t, config.BeadClassGraph), readyTiers: &readyTiers, listTiers: &listTiers,
+		}),
+	}
+
+	if _, err := readyBeadsForOpts(legs, readyOpts{}); err != nil {
+		t.Fatalf("gc ready: %v", err)
+	}
+	assertEveryLegAskedForTheFederatedTier(t, "gc ready", len(legs), readyTiers)
+
+	readyTiers, listTiers = nil, nil
+	if _, err := readyBeadsForOpts(legs, readyOpts{status: readyStatusInProgress}); err != nil {
+		t.Fatalf("gc ready --status in_progress: %v", err)
+	}
+	assertEveryLegAskedForTheFederatedTier(t, "gc ready --status in_progress", len(legs), listTiers)
+}
+
+// assertEveryLegAskedForTheFederatedTier asserts one read per leg, each at
+// beads.FederatedReadTier, and none at the zero value.
+func assertEveryLegAskedForTheFederatedTier(t *testing.T, surface string, legs int, got []beads.TierMode) {
+	t.Helper()
+	if len(got) != legs {
+		t.Fatalf("%s issued %d leg reads over %d legs; the recorder is not seeing the federation", surface, len(got), legs)
+	}
+	for i, tier := range got {
+		if tier == beads.TierIssues {
+			t.Errorf("%s read leg %d at the ZERO-VALUE tier. That is not a neutral default across these legs: a policy-wrapped work store rewrites it to TierBoth and an unwrapped relocated class store does not, so the merged answer is two different questions and the class store's whole ephemeral tier drops out with no error (ga-8lyxc)", surface, i)
+			continue
+		}
+		if tier != beads.FederatedReadTier {
+			t.Errorf("%s read leg %d at tier %v, want beads.FederatedReadTier (%v); legs that answer at different tiers cannot be merged into one answer", surface, i, tier, beads.FederatedReadTier)
+		}
+	}
+}

--- a/cmd/gc/ready_federation.go
+++ b/cmd/gc/ready_federation.go
@@ -59,6 +59,21 @@ package main
 // API. Promoting it to an error is a defensible product decision, but it is a
 // behavior change that has to land on BOTH surfaces at once.
 //
+// # Every leg answers the SAME question
+//
+// The legs are not wrapped alike. A work store sits behind cmd/gc's bead-policy
+// layer, which rewrites a TierIssues read to TierBoth before it reaches the
+// backend; a relocated class store has no such layer, because openStorageRoutes
+// keys the class map straight to the engine value the provider returned. So a
+// query that leaves TierMode at its zero value asks the work legs one question
+// and the class leg a narrower one, and the merge presents the two as one
+// answer. The class store's ephemeral tier — the wisps an orchestration step
+// runs as — drops out with no error and no short-array signal (ga-8lyxc).
+//
+// Every read below therefore states beads.FederatedReadTier explicitly on every
+// leg. That is the tier the policy-wrapped legs have always answered at, so it
+// changes nothing for a city that relocates no class.
+//
 // # Single-store cities take none of this
 //
 // relocatedGraphLegStore gates on STORE IDENTITY, the same rule the API's
@@ -189,7 +204,8 @@ func federateReadyBeads(legs []readyLeg, q beads.ReadyQuery) ([]beads.Bead, erro
 // The read is a direct store.List rather than the live handle's, because that
 // handle overrides TierMode to TierBoth and would silently discard the caller's
 // tier selection. The API's list arm reads the store directly for the same
-// reason.
+// reason. The caller states the tier it wants (readReadyCandidates), so nothing
+// here has to guess it.
 func federateListBeads(legs []readyLeg, q beads.ListQuery) ([]beads.Bead, error) {
 	return federateBeadLegs(legs, func(store beads.Store) ([]beads.Bead, error) {
 		return store.List(q)

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -95,6 +95,7 @@ func TestSplitTopologyConformance(t *testing.T) {
 	t.Run("I13-cli-ready-federation", func(t *testing.T) { forEachTopologyWithRig(t, conformanceCLIReadyFederation) })
 	t.Run("I14-projection-coherence", func(t *testing.T) { forEachTopology(t, conformanceProjectionCoherence) })
 	t.Run("I15-work-query-federation", func(t *testing.T) { forEachTopologyWithRig(t, conformanceWorkQueryFederation) })
+	t.Run("I16-federated-read-tier", func(t *testing.T) { forEachTopology(t, conformanceFederatedReadTier) })
 }
 
 // conformanceReadyFederation (I1) guards the "no work" fail-open: a worker
@@ -1227,9 +1228,13 @@ func conformanceReadPathConsistency(t *testing.T, e splitEnv) {
 
 	leaf, _, wrapped := unwrapBeadPolicyStore(front)
 	if !wrapped {
-		// Relocated class store: no policy layer, so no tier expansion and no
-		// ephemeral tier to be blind to. Everything the store holds is on the
-		// main tier and every read path sees it.
+		// Relocated class store: no policy layer, so no tier EXPANSION and no
+		// tier for these two beads to hide behind — mintWisp's create lands a
+		// plain row here. That is a statement about what this front door
+		// CREATES, not about what the store can hold: a create that names the
+		// tier itself still lands an ephemeral row in this store (see
+		// mintEphemeralGraphBead), and reading it back is exactly what the
+		// federated readers were failing to do. I16 owns that half.
 		//
 		// Which branch runs is decided by the fixture's model of the class
 		// store, so it cannot police that model. The pin that does is
@@ -1555,6 +1560,16 @@ func beadIDsOf(list []beads.Bead) []string {
 // The single-store row is not a formality: it is the byte-identity claim. There
 // the graph class is not relocated, both surfaces federate the same two work
 // legs, and the answer must be exactly the one a legacy city already got.
+//
+// # What an equality oracle cannot see, and what covers it
+//
+// CLI == API is blind by construction to a defect BOTH surfaces have. ga-8lyxc
+// was exactly that: the CLI defaulted its ready read to the zero-value tier and
+// the API passed no ready query at all, so both dropped the relocated store's
+// ephemeral rows and this row stayed green while both surfaces were short. I16
+// is the complement — its oracle is the LEG, not the other surface — and the two
+// rows have to be read together: this one pins that the surfaces agree, that one
+// pins that what they agree on is everything the stores hold.
 func conformanceCLIReadyFederation(t *testing.T, e splitEnv) {
 	cityWork, err := e.work.Create(beads.Bead{Title: "city work bead", Type: "task"})
 	if err != nil {
@@ -1718,6 +1733,18 @@ type apiReadyListBody struct {
 // rows.
 func apiReadyBody(t *testing.T, e splitEnv) apiReadyListBody {
 	t.Helper()
+	return apiGetBeadListBody(t, e, "/beads/ready")
+}
+
+// apiGetBeadListBody serves one of the city-scoped bead read endpoints through
+// the REAL handler stack over the fixture's stores and decodes the list body.
+//
+// The state is a controllerState — the production api.State — so BeadStores(),
+// CityBeadStore() and GraphBeadStore() resolve through exactly the dispatch the
+// running controller uses. suffix is the city-scoped path with its query string,
+// e.g. "/beads/ready" or "/beads?status=in_progress".
+func apiGetBeadListBody(t *testing.T, e splitEnv, suffix string) apiReadyListBody {
+	t.Helper()
 	cityName := loadedCityName(e.cfg, e.cityPath)
 	state := &controllerState{
 		cfg:           e.cfg,
@@ -1728,17 +1755,159 @@ func apiReadyBody(t *testing.T, e splitEnv) apiReadyListBody {
 		storageRoutes: e.routes,
 	}
 	mux := api.NewSupervisorMux(&singleCityStateResolver{state: state}, nil, false, "test", "", time.Now()).WithAnyHostAllowed()
-	req := httptest.NewRequest(http.MethodGet, "/v0/city/"+cityName+"/beads/ready", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/city/"+cityName+suffix, nil)
 	rec := httptest.NewRecorder()
 	mux.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("GET /beads/ready = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+		t.Fatalf("GET %s = %d, want 200 (body=%q)", suffix, rec.Code, rec.Body.String())
 	}
 	var body apiReadyListBody
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode /beads/ready: %v (body=%q)", err, rec.Body.String())
+		t.Fatalf("decode %s: %v (body=%q)", suffix, err, rec.Body.String())
 	}
+	// The partial tier is deliberately NOT asserted here: the dead-rig row
+	// (conformanceCLIReadyDeadRigLeg) reads this endpoint expecting Partial
+	// exactly, and a helper that failed on it would make that row unwritable.
+	// Callers over healthy stores assert it themselves.
 	return body
+}
+
+// conformanceFederatedReadTier (I16) pins that a city-wide federated read asks
+// EVERY leg the same question about storage tiers.
+//
+// # The defect, measured on a live split city
+//
+// The legs are not wrapped alike. A work store sits behind cmd/gc's bead-policy
+// layer, whose expandPolicyReadTier / expandPolicyReadyQuery rewrite a
+// TierIssues read to TierBoth before it reaches the backend. A relocated class
+// store has no such layer — openStorageRoutes keys the class map straight to the
+// engine value the provider returned. So a query that left TierMode at its zero
+// value asked the work legs one question and the class leg a narrower one, and
+// merged the two answers as if they were the same question.
+//
+// win-mc-forge measured it, and the arithmetic is exact: against the relocated
+// graph database `bd ready --include-ephemeral --limit 0` returned 17 claimable
+// beads, three of them wisps; the federated reader over the same store returned
+// exactly the other 14, while still serving the work stores' own ephemeral rows.
+// No leg errored. No flag was rejected. The wisps were simply not there — and
+// ephemeral wisps are how orchestration steps run, so a molecule mid-execution
+// reads as having no runnable frontier and is diagnosed as stalled when it is
+// fine.
+//
+// # Why the CLI == API row (I13) could not catch it
+//
+// I13's oracle is the OTHER surface, and both surfaces had the same hole: the
+// CLI defaulted to TierIssues and the API passed no ready query at all. Two
+// surfaces agreeing about a short answer is what an equality oracle is blind to
+// by construction. So this row's oracle is the LEG ITSELF — everything the store
+// holds must reach the merged answer — which is the same arithmetic
+// win-mc-forge ran by hand and cannot be satisfied by two wrong surfaces
+// agreeing.
+//
+// # Both topologies, and the single-store row is the byte-identity claim
+//
+// The single-store row is not a formality. Its owning leg is the policy-wrapped
+// work store, which has ALWAYS answered at TierBoth, so this row passes before
+// and after the fix and fails the moment the fix narrows a legacy city's answer.
+func conformanceFederatedReadTier(t *testing.T, e splitEnv) {
+	durable := mintDurableGraphBead(t, e, "federated-tier durable graph bead", "")
+	wisp := mintEphemeralGraphBead(t, e, "federated-tier graph wisp")
+
+	owner, ownerName := e.owner()
+	legIDs := legReadyIDsAcrossTiers(t, owner)
+	if !containsString(legIDs, wisp.ID) || !containsString(legIDs, durable.ID) {
+		t.Fatalf("the %s store's own ready read = %v, missing durable=%s or wisp=%s; the fixture is not staging the two tiers this row is about", ownerName, legIDs, durable.ID, wisp.ID)
+	}
+
+	assertFederationServesWholeLeg(t, "gc ready", ownerName, legIDs, cliReadyIDs(t, e))
+	assertFederationServesWholeLeg(t, "GET /v0/beads/ready", ownerName, legIDs, apiReadyIDs(t, e))
+
+	conformanceFederatedInFlightTier(t, e, ownerName)
+}
+
+// conformanceFederatedInFlightTier is the in-flight arm of I16, and it is the
+// symptom the incident was reported as: an adopt-pr step running as an ephemeral
+// wisp is invisible in the mid-flight listing, so a molecule that is executing
+// normally reads as having nothing in progress.
+//
+// It covers the other two federated readers — `gc ready --status in_progress`
+// (federateListBeads) and GET /v0/beads?status=in_progress (the API's list
+// fan-out) — which take a ListQuery rather than a ReadyQuery and had the same
+// unstated tier.
+func conformanceFederatedInFlightTier(t *testing.T, e splitEnv, ownerName string) {
+	t.Helper()
+	const holder = "executor-1"
+	claimed := mintEphemeralGraphBead(t, e, "federated-tier in-flight graph wisp")
+	inProgress := "in_progress"
+	if err := e.graphStore().Update(claimed.ID, beads.UpdateOpts{Status: &inProgress, Assignee: stringPtr(holder)}); err != nil {
+		t.Fatalf("claiming the in-flight graph wisp %s: %v", claimed.ID, err)
+	}
+
+	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	rows, err := readyBeadsForOpts(legs, readyOpts{status: readyStatusInProgress})
+	if err != nil {
+		t.Fatalf("gc ready --status in_progress over the fixture stores: %v", err)
+	}
+	cli := make([]string, 0, len(rows))
+	for _, row := range rows {
+		cli = append(cli, row.ID)
+	}
+	if !containsString(cli, claimed.ID) {
+		t.Errorf("`gc ready --status in_progress` = %v, missing the claimed ephemeral %s-store wisp %s. This is the reported symptom verbatim: a step running as a wisp is invisible mid-flight, so the molecule reads as having no runnable frontier and is diagnosed as stalled while it is executing", cli, ownerName, claimed.ID)
+	}
+
+	body := apiGetBeadListBody(t, e, "/beads?status=in_progress")
+	if body.Partial {
+		t.Fatalf("GET /v0/beads?status=in_progress reported a partial read over healthy stores: %v", body.PartialErrors)
+	}
+	apiIDs := make([]string, 0, len(body.Items))
+	for _, b := range body.Items {
+		apiIDs = append(apiIDs, b.ID)
+	}
+	if !containsString(apiIDs, claimed.ID) {
+		t.Errorf("GET /v0/beads?status=in_progress = %v, missing the claimed ephemeral %s-store wisp %s; the CLI and the API fan out over the same legs and must not disagree about which tiers those legs span", apiIDs, ownerName, claimed.ID)
+	}
+}
+
+// legReadyIDsAcrossTiers is the ORACLE for I16: everything one leg holds as
+// claimable work across both storage tiers, read from that store directly.
+//
+// The tier is spelled beads.TierBoth literally rather than through
+// beads.FederatedReadTier, which is the constant under test. Taking the oracle
+// from the same constant would make this row pass by construction the day
+// somebody narrows it.
+func legReadyIDsAcrossTiers(t *testing.T, store beads.Store) []string {
+	t.Helper()
+	rows, err := beads.HandlesFor(store).Live.Ready(beads.ReadyQuery{TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("reading the leg's own ready set across both tiers: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, b := range rows {
+		ids = append(ids, b.ID)
+	}
+	return ids
+}
+
+// assertFederationServesWholeLeg asserts that every id a leg holds reached the
+// merged answer, and reports the miss in the arithmetic shape the live report
+// used: leg total, merged∩leg total, and the difference by id.
+func assertFederationServesWholeLeg(t *testing.T, surface, legName string, legIDs, merged []string) {
+	t.Helper()
+	var missing []string
+	served := 0
+	for _, id := range legIDs {
+		if containsString(merged, id) {
+			served++
+			continue
+		}
+		missing = append(missing, id)
+	}
+	if len(missing) == 0 {
+		return
+	}
+	t.Errorf("%s dropped %d of the %s store's %d claimable beads: the leg holds %d, the merged answer carries %d of them, %d - %d = %d missing %v. Nothing failed and nothing was rejected — the rows are simply not there, which is indistinguishable from work that does not exist",
+		surface, len(missing), legName, len(legIDs), len(legIDs), served, len(legIDs), len(missing), served, missing)
 }
 
 // conformanceProjectionCoherence (I14) pins that the two `gc bd` PROJECTIONS

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -496,6 +496,57 @@ func (e splitEnv) mintWispWith(t *testing.T, opts wispOpts) beads.Bead {
 	return staged
 }
 
+// mintEphemeralGraphBead creates a graph-class bead that lands on the EPHEMERAL
+// tier of whichever store owns the class on this topology, and fails the test if
+// it did not.
+//
+// It exists because mintWisp lands a DURABLE row on the split leg: the relocated
+// class store carries no bead-policy layer, so the same create that maps onto
+// the ephemeral tier through a work front door lands a plain row there. Every
+// tier invariant built on mintWisp is therefore vacuous on the leg that matters,
+// which is how a whole ephemeral tier went missing from the federated readers
+// unnoticed (ga-8lyxc).
+//
+// The tier is reached the way production reaches it on each leg, not by patching
+// the bead afterwards:
+//
+//   - policy-wrapped front door (the single-store topology's work store): a
+//     gc.kind=wisp create, which defaultBeadStorage maps to "ephemeral" under
+//     bd-1.0.5 — plain mintWisp.
+//   - unwrapped relocated class store (the split topology): the store's own
+//     StorageCreateStore capability, which is the exact call
+//     createWithStoragePolicy makes once a storage class is decided. It is a
+//     real production shape on this leg: internal/mail/beadmail creates its
+//     message beads Ephemeral on whatever store owns the messaging class, and
+//     that class is relocated to this same binding.
+func mintEphemeralGraphBead(t *testing.T, e splitEnv, title string) beads.Bead {
+	t.Helper()
+	front := e.graphStore()
+	if e.policyWrapped(front) {
+		return e.mintWispWith(t, wispOpts{title: title})
+	}
+	store, ok := front.(beads.StorageCreateStore)
+	if !ok {
+		t.Fatalf("the relocated class store (%T) implements no StorageCreateStore, so this fixture cannot reach its ephemeral tier the way createWithStoragePolicy does", front)
+	}
+	created, err := store.CreateWithStorage(beads.Bead{
+		ID:       splitWispID(),
+		Title:    title,
+		Type:     "task", // graph.v2 wisps materialize as issue_type "task"
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWisp},
+	}, beads.StorageEphemeral)
+	if err != nil {
+		t.Fatalf("minting ephemeral graph bead %q on the relocated class store: %v", title, err)
+	}
+	if !created.Ephemeral {
+		t.Fatalf("minted graph bead %s has Ephemeral=false; the fixture is not exercising the relocated store's wisp tier and every tier assertion on it is vacuous", created.ID)
+	}
+	if !coordclass.Classify(created).IsInfrastructure() {
+		t.Fatalf("minted ephemeral graph bead %s classifies as work, want infrastructure (type=%q metadata=%v)", created.ID, created.Type, created.Metadata)
+	}
+	return created
+}
+
 // mintDurableGraphBead creates a DURABLE graph-class bead through the graph
 // front door: the routed control/workflow shape (gc.kind=workflow), which the
 // storage policy keeps off the ephemeral tier on either leg. routedTo, if

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3274,6 +3274,10 @@ Rows are emitted in canonical ready order (priority, created_at, id) unless
 read is the true top-N of the merged set rather than the top-N of whichever
 store answered first.
 
+Every leg is read across both storage tiers, so the wisp/ephemeral rows an
+orchestration step runs as are claimable work here whether or not
+--include-ephemeral is passed.
+
 ```
 gc ready [flags]
 ```
@@ -3283,7 +3287,7 @@ gc ready [flags]
 | `--assignee` | string |  | only work assigned to this identity |
 | `--exclude-label` | stringArray |  | drop beads carrying this label (repeatable) |
 | `--exclude-type` | stringArray |  | drop beads of this issue type (repeatable) |
-| `--include-ephemeral` | bool |  | include the wisp/ephemeral tier |
+| `--include-ephemeral` | bool |  | accept --include-ephemeral for bd-ready parity (every leg already spans the wisp tier) |
 | `--json` | bool | `true` | accept --json for bd-ready parity (output is always a JSON array) |
 | `--limit` | int |  | max beads to return (0 = unlimited) |
 | `--metadata-field` | stringArray |  | require metadata "key=value", or bare "key" for any non-empty value (repeatable) |

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -129,6 +129,13 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 				// map-iteration order, so a bounded read truncated an
 				// arbitrary, per-call-different subset (#3208).
 				Sort: beads.SortCreatedDesc,
+				// Explicit tier, for the same reason as the sort and with the
+				// same failure shape: the zero value is not neutral across these
+				// legs. The work legs' bead-policy layer rewrites it to TierBoth
+				// and the unwrapped graph leg does not, so the relocated store's
+				// ephemeral rows dropped out of an authoritative-looking 200
+				// (ga-8lyxc). See beads.FederatedReadTier.
+				TierMode: beads.FederatedReadTier,
 			}
 			if !query.HasFilter() {
 				query.AllowScan = true
@@ -447,7 +454,9 @@ func beadListLegCount(ctx context.Context, store beads.Store, assignee string, i
 
 // beadListCountQuery builds the count query for the all=true list path. It
 // carries the same filters as the list query so the count matches exactly;
-// Sort and Limit are omitted because they do not affect a count.
+// Sort and Limit are omitted because they do not affect a count. The tier is
+// NOT omitted for the same reason: a count taken over a narrower tier than the
+// list it bounds advertises a Total the walk can never reach.
 func beadListCountQuery(assignee string, input *BeadListInput) beads.ListQuery {
 	q := beads.ListQuery{
 		Status:        input.Status,
@@ -456,11 +465,21 @@ func beadListCountQuery(assignee string, input *BeadListInput) beads.ListQuery {
 		Assignee:      assignee,
 		IncludeClosed: input.All,
 		Live:          input.Status == "in_progress",
+		TierMode:      beads.FederatedReadTier,
 	}
 	if !q.HasFilter() {
 		q.AllowScan = true
 	}
 	return q
+}
+
+// readyFederationQuery is the ready query every leg of the ready federation is
+// read with. It exists so the work legs and the graph leg cannot be given
+// different ones: they are read from two places in the handler below, and the
+// defect this closes was exactly the two places disagreeing about the tier
+// without either of them naming it. See beads.FederatedReadTier.
+func readyFederationQuery() beads.ReadyQuery {
+	return beads.ReadyQuery{TierMode: beads.FederatedReadTier}
 }
 
 // humaHandleBeadReady is the Huma-typed handler for GET /v0/beads/ready.
@@ -493,6 +512,11 @@ func beadListCountQuery(assignee string, input *BeadListInput) beads.ListQuery {
 //   - Failure: a rig degrades (Partial 200 + partial_errors); the graph leg
 //     does not (503, carrying any work-leg errors recorded before it). See
 //     graphPlaneUnavailable.
+//   - Tier: every leg is read at beads.FederatedReadTier, stated explicitly.
+//     A no-argument Ready() left TierMode at its zero value, which the work
+//     legs' bead-policy layer rewrote to TierBoth while the unwrapped graph leg
+//     took literally — so the relocated store's whole ephemeral tier fell out of
+//     a 200 that named no failure (ga-8lyxc).
 func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput) (*ListOutput[beads.Bead], error) {
 	bp := input.toBlockingParams()
 	if bp.isBlocking() {
@@ -509,7 +533,7 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 			return
 		}
 		pa.attempt()
-		ready, err := beads.HandlesFor(store).Live.Ready()
+		ready, err := beads.HandlesFor(store).Live.Ready(readyFederationQuery())
 		if err != nil {
 			if beads.IsPartialResult(err) && len(ready) > 0 {
 				pa.record(label, err)
@@ -554,7 +578,7 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 	// does NOT go through federate(): the graph leg has no partial tier.
 	if graph := relocatedGraphStore(s.state); graph != nil {
 		pa.attempt()
-		ready, err := beads.HandlesFor(graph).Live.Ready()
+		ready, err := beads.HandlesFor(graph).Live.Ready(readyFederationQuery())
 		if err != nil {
 			return nil, graphPlaneUnavailable("ready", err, pa.messages()...)
 		}

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -47,6 +47,34 @@ const (
 	TierBoth
 )
 
+// FederatedReadTier is the tier every leg of a CITY-WIDE FEDERATED read must be
+// asked for explicitly, and it exists because the zero value cannot be trusted
+// across a federation whose legs are wrapped differently.
+//
+// A city's work stores are wrapped in a bead-policy layer that rewrites a
+// TierIssues read to TierBoth before it reaches the backend, so a work leg has
+// always answered across both tiers no matter what the caller asked for. A
+// relocated coordination-class store carries no such layer — the storage routes
+// key the class map straight to the value the provider's engine opener returned
+// — so it answers at exactly the tier in the query. A federation that leaves
+// TierMode at its zero value therefore asks the work legs one question and the
+// class leg a narrower one, and merges the two answers as if they were the same
+// question. The class store's whole ephemeral tier drops out, silently: no leg
+// errored, no flag was rejected, the rows are simply not there.
+//
+// That is not hypothetical. On a live split city `bd ready --include-ephemeral`
+// against the relocated graph database returned 17 claimable beads, three of
+// them wisps; the federated reader over the same store returned exactly the
+// other 14, while still serving the work stores' own ephemeral rows. Ephemeral
+// wisps are how orchestration steps run, so a molecule mid-execution reads as
+// having no runnable frontier and is diagnosed as stalled when it is fine.
+//
+// Every federated reader therefore states this tier on every leg. It is TierBoth
+// because that is the question the policy-wrapped legs have always answered, so
+// stating it changes nothing for a city that relocates no class and makes the
+// relocated leg answer the same question as its peers.
+const FederatedReadTier = TierBoth
+
 // TierModeFromOpts returns the tier mode implied by a slice of QueryOpts.
 // WithBothTiers takes precedence over WithEphemeral.
 func TierModeFromOpts(opts []QueryOpt) TierMode {


### PR DESCRIPTION
Closes the CLI+API half of **ga-8lyxc**, reported by win-mc-forge from live
maintainer-city. It is a hole in code shipped by #5158 / #5148, and it is the
exact silent class this program exists to kill: **the flag is accepted, no
error is raised, the wisps simply are not there.**

## The bug, measured

win-mc-forge, on a live split city, same moment:

| read | beads | of which |
| --- | --- | --- |
| `bd ready --db <relocated graph db> --include-ephemeral --limit 0` | **17** | 3 wisps (`gcg-wisp-c4j`, …) |
| `gc ready --include-ephemeral --limit 0` | **19** | **14** `gcg-` |

17 − 3 = 14. The federated reader picked up the graph store's **non-wisp**
ready beads and dropped its **ephemeral tier**, while still serving the work
stores' own ephemeral rows.

Reproduced before fixing, end to end, on a real converged split city
(`migratedOneShotCLICity` + the real `cmdReady`), seeded 2 durable + 3
ephemeral graph rows against 1 + 1 work rows:

```
graph leg:  TierIssues=2   TierBoth=5     no-arg Ready()=2
gc ready (default):  total=4  gcg=2  ephemeral=1   ← the work leg's wisp IS served
```

Same shape: the leg holds 5, the merged answer carries 2, the work store's own
ephemeral row is present throughout.

## Root cause — and yes, it is the zero-value tier trap

Exactly the #5149 shape, one layer up. **The legs are not wrapped alike:**

* a **work** store sits behind cmd/gc's bead-policy layer, whose
  `expandPolicyReadyQuery` / `expandPolicyReadTier` rewrite a `TierIssues`
  read to `TierBoth` **before it reaches the backend**;
* a **relocated class** store has no such layer — `openStorageRoutes` keys the
  class map straight to the engine value the provider returned
  (`TestSplitEnvClassStoreWrappingMatchesOpenStorageRoutes` pins that).

So a read that left `TierMode` at its zero value asked the work legs one
question and the class leg a narrower one, and merged the two as if they were
the same question. Four readers did that:

| reader | what it stated |
| --- | --- |
| `gc ready` | `--include-ephemeral` → `TierBoth`, its **absence** → `TierIssues` |
| `gc ready --status <s>` | same, on the `ListQuery` arm |
| `humaHandleBeadReady` | `Live.Ready()` — **no query at all** |
| `humaHandleBeadList` + `beadListCountQuery` | `ListQuery` with **no `TierMode`** |

The leg stores are innocent: `beads.SQLiteStore.Ready` and
`NativeDoltStore.Ready` both honour `TierBoth` correctly (verified directly
against a real workspace, which is also where the production `gcg-wisp-*` id
shape comes from). Nothing failed. Nothing was refused.

**Impact** is the motivating failure: adopt-pr steps that run as ephemeral
wisps are invisible mid-flight, so a molecule that is executing normally reads
as having no runnable frontier and gets diagnosed as **stalled**.

## The fix

`beads.FederatedReadTier` — the tier every leg of a city-wide federated read
**states explicitly**. It is `TierBoth` because that is the question the
policy-wrapped legs have always answered, so a city that relocates no class is
byte-identical and the relocated leg now answers the same question as its
peers.

`--include-ephemeral` keeps parsing (the generated work_query carries it
verbatim) and is now documented as **always satisfied** rather than left
looking like a selector. It binds to a discarded variable, not to a
`readyOpts` field nothing consults — a field nothing consults is how a flag
ends up looking honored while one leg quietly narrows.

## Why no error surfaced, and what stops the next one

**Nothing was ever asked, so there was nothing to refuse.** Every leg can
serve every tier; an unsupported-tier error path here would be dead code. What
closes the class is removing the ability to leave the tier **unstated** at a
federation boundary:

* `readReadyCandidates` has no branch that could state anything else;
* the API's two ready legs share one `readyFederationQuery()`, so they cannot
  be given different ones;
* `TestReadyStatesTheSameTierOnEveryLeg` records the tier **each leg is asked
  for** and fails on the zero value — an assertion about the *question*, not
  the rows, so it survives a refactor of how the legs are wrapped.

A leg that genuinely cannot answer still fails loud: `federateBeadLegs` aborts
the whole federation and names the leg (pinned by `TestReadyFailsLoudWhenALegErrors`).

## Was I13 (CLI == API) blind to this? Yes — and that is now pinned

`CLI == API` is blind **by construction** to a defect both surfaces have, and
both had this one. I13 stayed green while both sides were short.

`I16-federated-read-tier` takes its oracle from the **LEG**, not from the other
surface: everything the owning store holds across both tiers must reach the
merged answer, reported in win-mc-forge's own arithmetic shape. The two rows
now name each other in their doc comments.

`mintEphemeralGraphBead` is the fixture machinery that was missing, and it is
why the suite could not see this: `mintWisp` lands a **durable** row on the
split leg (no policy layer), so every tier assertion in the suite was vacuous
on the one leg that matters. It reaches the tier the way production does on
each leg — the wisp policy through a wrapped front door, the store's own
`StorageCreateStore` through the unwrapped class store, which is the exact call
`createWithStoragePolicy` makes. The class leaf is the real `beads.SQLiteStore`
(suite-wide since #5165), so the row is filtered by the store's own tier
column and its ready SQL, not by a Go-side predicate — which matters, because
this is a tier bug.

**Red-before**, mutating the fix out, split row:

```
gc ready dropped 1 of the class store's 2 claimable beads: the leg holds 2,
  the merged answer carries 1 of them, 2 - 1 = 1 missing [gcg-wisp-0001]
GET /v0/beads/ready dropped 1 of the class store's 2 claimable beads: the leg
  holds 2, the merged answer carries 1 of them, 2 - 1 = 1 missing [gcg-wisp-0001]
`gc ready --status in_progress` = [], missing the claimed ephemeral
  class-store wisp gcg-wisp-0002
GET /v0/beads?status=in_progress = [], missing the claimed ephemeral
  class-store wisp gcg-wisp-0002
gc ready read leg 0 at the ZERO-VALUE tier
```

**Byte identity, proved by mutation:** the single-store row passes under that
same mutation. The fix does not move a legacy city's answer in either
direction, because its work legs already answered at `TierBoth`.

## Sibling surfaces

* `gc bd ready` / `gc bd list` — **no defect**: they already REFUSE on a split
  city (`RelocatedClassFrontierRefusal`) instead of returning a short array.
* `readyForControllerDemandQuery` — **already correct**: it sets `TierBoth`
  explicitly.
* `GET /v0/beads` list federation — **same defect, fixed here** (it is the
  surface the dashboard reads, and leaving it would have re-broken I13 the
  other way).
* **Filed, not fixed:** `ga-gcby6` — the API workflow-snapshot store scan
  (`handler_convoy_dispatch.go`, two sites) has the identical unstated-tier
  fan-out over the graph leg. `ga-50lco` — the now-vestigial bd-1.0.4 gate on
  the generated `--include-ephemeral` (zero behavior change, wide golden churn).

No conformance KNOWN GAP became closable; none was added. I11's class-store
branch comment claimed the relocated store had "no ephemeral tier to be blind
to" — corrected in place to say what is true (it is a statement about what that
front door *creates*, not about what the store can *hold*), since that false
comment is part of why this hid.

## Gates

`go build ./...` · `go vet ./...` · `gofmt` clean ·
`golangci-lint run ./...` (2.10.1) **0 issues** ·
`go test ./cmd/gc -timeout 25m -p 1 -parallel 1` **ok 759.3s** ·
`go test ./internal/... -p 1 -parallel 1` **ok (144 packages)** ·
`scripts/check-core-boundary.sh` OK · `make check-split-topology-rows` OK ·
`make check-routed-test-rows` OK · `gen-command-census -check` OK ·
`docs/reference/cli.md` regenerated (`go run ./cmd/gc gen-doc`).

Nothing on the HTTP wire moved — `internal/api/openapi.json` and the generated
dashboard types are untouched — so no OpenAPI or dashboard regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
