### PR TITLE
fix(beads): gate the ready projection on the BACKEND, not the bd version

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -196,15 +196,74 @@ func classifyBDExecResult(parent, ctx context.Context, name string, timeout time
 		return "timeout", timeoutErr, timeoutErr
 	}
 	if runErr != nil {
-		detail := strings.TrimSpace(stderr)
-		if detail == "" && name == "bd" {
-			detail = bdStdoutErrorDetail(out)
-		}
-		if detail != "" {
+		if detail := bdFailureDetail(name, out, stderr); detail != "" {
 			return "error", runErr, fmt.Errorf("%w: %s", runErr, detail)
 		}
 	}
 	return "done", runErr, runErr
+}
+
+// bdFailureDetail composes the operator-facing detail for a failed invocation
+// out of the two streams bd splits its output across.
+//
+// bd writes unrelated startup notices to stderr BEFORE the command runs — the
+// BD_OTEL_* deprecation warning is the live example — so on a bd that both nags
+// and fails, stderr's FIRST line is the nag and the line saying what actually
+// broke sits below it. Every single-line render of the wrapped error (the cache
+// problem tile, `gc status`, a journal grep) then shows the nag. That is how a
+// permanently failing `bd sql ready projection` on maintainer-city read as a
+// telemetry warning for a night while the controller starved.
+//
+// So the detail leads with bd's own Error:/Hint: lines (cmd/bd/errors.go) and
+// keeps everything else verbatim, in order, after them. NOTHING is dropped, and
+// every other shape — a single line, stderr that already leads with the error,
+// stderr with no bd error line, empty stderr, a non-bd command — composes
+// byte-for-byte what it composed before.
+func bdFailureDetail(name string, out []byte, stderr string) string {
+	detail := strings.TrimSpace(stderr)
+	if name != "bd" {
+		return detail
+	}
+	if detail == "" {
+		// bd writes structured errors to stdout under --json while stderr is
+		// often empty.
+		return bdStdoutErrorDetail(out)
+	}
+	return hoistBdErrorLines(detail)
+}
+
+// bdErrorLinePrefixes are the prefixes bd stamps on the lines that say what
+// failed (cmd/bd/errors.go: HandleError, HandleErrorWithHint).
+var bdErrorLinePrefixes = []string{"Error:", "Fatal:", "Hint:"}
+
+func hoistBdErrorLines(detail string) string {
+	lines := strings.Split(detail, "\n")
+	if len(lines) < 2 || isBdErrorLine(lines[0]) {
+		return detail
+	}
+	leading := make([]string, 0, len(lines))
+	trailing := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if isBdErrorLine(line) {
+			leading = append(leading, line)
+			continue
+		}
+		trailing = append(trailing, line)
+	}
+	if len(leading) == 0 {
+		return detail
+	}
+	return strings.Join(append(leading, trailing...), "\n")
+}
+
+func isBdErrorLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	for _, prefix := range bdErrorLinePrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // bdExecTimeoutError formats the deadline error after the per-command context

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -373,6 +373,12 @@ type BdStore struct {
 	readyProjectionMu      sync.Mutex
 	readyProjectionChecked bool
 	readyProjectionEnabled bool
+	// readyProjectionScope memoizes, per SCOPE PATH, the verdict that this
+	// ledger cannot serve the ready projection at all. Shared with every other
+	// store rooted at the same directory, because cmd/gc rebuilds a store per
+	// request and the control dispatcher rebuilds one every few seconds. See
+	// bdstore_ready_projection.go.
+	readyProjectionScope *readyProjectionScopeGuard
 
 	// condReleaseLatchedUnsupported records that this bd rejected the
 	// conditional-release flags, pinning ReleaseIfCurrent to the raw-SQL
@@ -472,11 +478,12 @@ func NewBdStore(dir string, runner CommandRunner, opts ...BdStoreOption) *BdStor
 // NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
 func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string, opts ...BdStoreOption) *BdStore {
 	s := &BdStore{
-		dir:          dir,
-		runner:       runner,
-		idPrefix:     normalizeIDPrefix(idPrefix),
-		unreadStore:  guardForScope(dir),
-		localStrings: newLocalSidecar(bdLocalSidecarPath(dir)),
+		dir:                  dir,
+		runner:               runner,
+		idPrefix:             normalizeIDPrefix(idPrefix),
+		unreadStore:          guardForScope(dir),
+		readyProjectionScope: readyProjectionGuardForScope(dir),
+		localStrings:         newLocalSidecar(bdLocalSidecarPath(dir)),
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/internal/beads/bdstore_failure_detail_internal_test.go
+++ b/internal/beads/bdstore_failure_detail_internal_test.go
@@ -1,0 +1,95 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const bdOtelDeprecationWarning = "warning: BD_OTEL_* environment variables are deprecated. Replace with BD_OTEL_ENABLED=true plus the standard OpenTelemetry SDK variables. Translated for this run: BD_OTEL_METRICS_URL"
+
+func classifyForTest(t *testing.T, name string, out []byte, stderr string) error {
+	t.Helper()
+	ctx := context.Background()
+	_, _, resultErr := classifyBDExecResult(ctx, ctx, name, time.Minute, time.Now(), out, stderr, errors.New("exit status 1"))
+	return resultErr
+}
+
+// TestBdFailureDetailLeadsWithBdsErrorLine is the diagnosis half of the
+// maintainer-city outage: bd prints its BD_OTEL_* deprecation warning during
+// startup, BEFORE the command runs, so the actionable line is the SECOND line of
+// stderr. Every single-line render of the wrapped error — the cache problem
+// tile, a journal grep — then showed a telemetry nag where it used to show the
+// reason the read failed, and the real cause went unfound for a night.
+//
+// The detail keeps every byte bd wrote and only reorders it, so the actionable
+// line leads.
+func TestBdFailureDetailLeadsWithBdsErrorLine(t *testing.T) {
+	stderr := bdOtelDeprecationWarning + "\nError: 'bd sql' is not yet supported in embedded mode\n"
+
+	err := classifyForTest(t, "bd", nil, stderr)
+
+	first, _, _ := strings.Cut(err.Error(), "\n")
+	if !strings.Contains(first, "not yet supported in embedded mode") {
+		t.Fatalf("first line of the wrapped error = %q, want bd's actionable Error: line", first)
+	}
+	if !strings.Contains(err.Error(), "BD_OTEL_*") {
+		t.Errorf("reordering dropped the warning; the detail must keep every byte bd wrote: %v", err)
+	}
+	if !isBdSQLUnsupportedInEmbeddedMode(err) {
+		t.Errorf("the embedded-mode classifier no longer recognizes the wrapped error: %v", err)
+	}
+}
+
+// TestBdFailureDetailIsUnchangedWithoutNoise is the byte-identity guard: every
+// shape that is not "a warning printed before bd's own error line" composes
+// exactly the detail it composed before.
+func TestBdFailureDetailIsUnchangedWithoutNoise(t *testing.T) {
+	cases := []struct {
+		name   string
+		cmd    string
+		out    []byte
+		stderr string
+		want   string
+	}{
+		{
+			name:   "single stderr line",
+			cmd:    "bd",
+			stderr: "Error: 'bd sql' is not yet supported in embedded mode\n",
+			want:   "exit status 1: Error: 'bd sql' is not yet supported in embedded mode",
+		},
+		{
+			name:   "error line already leads",
+			cmd:    "bd",
+			stderr: "Error: no issue found matching \"tst-1\"\nHint: run bd list\n",
+			want:   "exit status 1: Error: no issue found matching \"tst-1\"\nHint: run bd list",
+		},
+		{
+			name:   "no bd error line at all",
+			cmd:    "bd",
+			stderr: "first\nsecond\n",
+			want:   "exit status 1: first\nsecond",
+		},
+		{
+			name: "empty stderr falls back to the stdout envelope",
+			cmd:  "bd",
+			out:  []byte(`{"error":"database is locked","schema_version":1}`),
+			want: "exit status 1: database is locked",
+		},
+		{
+			name:   "non-bd command is passed through",
+			cmd:    "dolt",
+			stderr: "warning: something\nError: real cause\n",
+			want:   "exit status 1: warning: something\nError: real cause",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyForTest(t, tc.cmd, tc.out, tc.stderr).Error(); got != tc.want {
+				t.Fatalf("wrapped error =\n%q\nwant\n%q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -2,12 +2,31 @@ package beads
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"path/filepath"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/deps"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 const bdReadyProjectionMinVersion = "1.0.5"
+
+// ErrReadyProjectionUnsupported is the named degraded state a cache enters when
+// its backing store cannot serve the ready projection AT ALL, as opposed to
+// having failed to serve it this cycle.
+//
+// It is a degrade rather than a partial result because the enrichment is an
+// optimization: IsBlocked==nil is the documented fallback and cachedBeadReady
+// derives readiness from dependencies instead, so the snapshot is whole. The
+// distinction is load-bearing — a cache that folds this into primePartialErr
+// declines every cache-only read for the life of the process.
+//
+// It is reported exactly once per store: the verdict is latched, so the first
+// prime or reconcile after the discovery carries the cause onto the problem log
+// and an operator notice, and every later cycle degrades quietly.
+var ErrReadyProjectionUnsupported = errors.New("ready projection unsupported by this bead store")
 
 type bdReadyProjectionRow struct {
 	ID        string       `json:"id"`
@@ -77,11 +96,21 @@ func skipBDReadyProjectionEnrichment(item Bead) bool {
 func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 	s.readyProjectionMu.Lock()
 	defer s.readyProjectionMu.Unlock()
-	// Probe the bd version once per process. Operators must restart gc after
-	// changing bd versions to re-evaluate ready-projection support.
+	// Probe the capability once per process. Operators must restart gc after
+	// changing bd versions or re-pointing a scope at another backend to
+	// re-evaluate ready-projection support.
 	if s.readyProjectionChecked {
 		return s.readyProjectionEnabled, nil
 	}
+	if reason := s.readyProjectionBackendRefusal(); reason != nil {
+		s.disableReadyProjectionLocked(reason)
+		return false, fmt.Errorf("bd ready projection backend gate: %w: %w", ErrReadyProjectionUnsupported, reason)
+	}
+	// A bd that predates the projection is not a degraded state to announce:
+	// the feature never existed for it, the pinned toolchain version is
+	// something operators already manage through deps.env, and the absence
+	// costs only the enrichment. The verdicts below this comment are about the
+	// LEDGER, and those do announce themselves.
 	out, err := s.runner(s.dir, "bd", "version")
 	if err != nil {
 		return false, fmt.Errorf("bd ready projection version gate: %w", err)
@@ -93,6 +122,63 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 	s.readyProjectionEnabled = deps.CompareVersions(version, bdReadyProjectionMinVersion) >= 0
 	s.readyProjectionChecked = true
 	return s.readyProjectionEnabled, nil
+}
+
+// readyProjectionBackendRefusal reports why this scope's backend cannot answer
+// `bd sql`, or nil when nothing on disk says it cannot.
+//
+// The version gate above asks the wrong question. `bd sql` is a raw-database
+// escape hatch, and whether bd implements it is a property of the BACKEND it
+// opened, not of the bd release: bd refuses it outright unless it holds a SQL
+// session ("'bd sql' is not yet supported in embedded mode", cmd/bd/sql.go).
+// gc's own composition root already names which backends this build implements
+// — reads their metadata shape, projects their environment, manages their
+// runtime (contract.RegisteredBackends). A scope served through the linked
+// beads library under any other name is one gc knows nothing about, so
+// assuming its `bd sql` works, and that its schema carries gc's issues/wisps
+// projection, is a guess. Withholding the call is the honest default and costs
+// that scope one optimization whose absence is already the documented benign
+// state (IsBlocked==nil falls back to dependency-derived readiness).
+//
+// A scope naming a registered backend — including metadata that names none, and
+// including metadata gc cannot read — reaches nil here and takes exactly the
+// path it took before, so the Dolt cities are untouched. Nothing on disk proves
+// a Dolt SQL server is REACHABLE, only that gc implements the backend; a bd
+// that then refuses anyway is caught by the runtime latch in
+// fetchReadyProjection.
+func (s *BdStore) readyProjectionBackendRefusal() error {
+	_, _, err := contract.LoadMetadataState(fsys.OSFS{}, filepath.Join(s.dir, ".beads", "metadata.json"))
+	if err == nil || !errors.Is(err, contract.ErrUnknownBackend) {
+		return nil
+	}
+	return err
+}
+
+// disableReadyProjectionLocked latches the projection off for the life of this
+// store and states the reason once. Callers hold readyProjectionMu.
+//
+// The latch is one-way for the same reason the conditional-release one is: the
+// ledger in front of the process cannot grow a capability mid-run, and
+// re-probing per cycle costs a guaranteed-failing subprocess on every cache
+// prime and every reconcile — which is exactly the defect this closes.
+func (s *BdStore) disableReadyProjectionLocked(reason error) {
+	s.readyProjectionEnabled = false
+	s.readyProjectionChecked = true
+	_, _ = fmt.Fprintf(s.noticeWriter(),
+		"gc: ready-projection enrichment disabled for %s: %v\n"+
+			"gc: cached ready falls back to dependency-derived readiness; no work is lost and no further bd sql is spent.\n",
+		s.dir, reason)
+}
+
+// latchReadyProjectionUnsupported records bd's own refusal of `bd sql`, so no
+// later cycle spends the call again.
+func (s *BdStore) latchReadyProjectionUnsupported(cause error) {
+	s.readyProjectionMu.Lock()
+	defer s.readyProjectionMu.Unlock()
+	if s.readyProjectionChecked && !s.readyProjectionEnabled {
+		return
+	}
+	s.disableReadyProjectionLocked(cause)
 }
 
 func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
@@ -138,6 +224,17 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 	// does not flap a spurious bead.updated.
 	out, err := s.runner(s.dir, "bd", "sql", readyProjectionSQL(), "--json")
 	if err != nil {
+		if isBdSQLUnsupportedInEmbeddedMode(err) {
+			// Belt-and-braces to the backend gate: a scope whose metadata does
+			// not name its backend, or names one gc implements while bd opened
+			// it some other way, only learns this from bd's own answer. It is a
+			// permanent property of the ledger, so it is latched rather than
+			// re-discovered — the unlatched version of this call cost
+			// maintainer-city a failing 6-16s subprocess on every prime and
+			// every reconcile, indefinitely.
+			s.latchReadyProjectionUnsupported(err)
+			return nil, fmt.Errorf("bd sql ready projection: %w: %w", ErrReadyProjectionUnsupported, err)
+		}
 		return nil, fmt.Errorf("bd sql ready projection: %w", err)
 	}
 	var rows []bdReadyProjectionRow

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/deps"
@@ -17,16 +19,90 @@ const bdReadyProjectionMinVersion = "1.0.5"
 // its backing store cannot serve the ready projection AT ALL, as opposed to
 // having failed to serve it this cycle.
 //
-// It is a degrade rather than a partial result because the enrichment is an
-// optimization: IsBlocked==nil is the documented fallback and cachedBeadReady
-// derives readiness from dependencies instead, so the snapshot is whole. The
-// distinction is load-bearing — a cache that folds this into primePartialErr
-// declines every cache-only read for the life of the process.
+// It is a degrade rather than a partial result because it costs the snapshot
+// exactly one column: the ROWS are whole, so List/Get/DepList keep serving from
+// cache. That distinction is load-bearing — a cache that folds this into
+// primePartialErr declines every cache-only read for the life of the process
+// and sends each one to a live bd subprocess.
 //
-// It is reported exactly once per store: the verdict is latched, so the first
-// prime or reconcile after the discovery carries the cause onto the problem log
-// and an operator notice, and every later cycle degrades quietly.
+// It does NOT mean readiness is unaffected. Without the column every bead's
+// IsBlocked is nil, and cachedBeadReady then derives readiness from the bead's
+// OWN direct blocks/waits-for/conditional-blocks deps. That predicate is weaker
+// than bd's is_blocked, which propagates blocked-ness transitively down
+// parent-child edges: a child of a blocked parent reads blocked to bd and ready
+// to the cache. The error direction is permissive — the cache would OFFER work
+// whose gate has not opened — which for the control dispatcher is worse than
+// hiding it (#3218). So readiness reads decline the cache and take their live
+// backing.Ready fallback (CachingStore.readyReadsMustGoLive) while every other
+// cached read keeps being served.
+//
+// It is reported exactly once per SCOPE: the verdict is latched in a registry
+// keyed by scope path, not on the store object, because cmd/gc rebuilds a store
+// per request and the control dispatcher rebuilds one every few seconds. Each
+// cache over the scope still learns the verdict — it must, to decline its ready
+// reads — but the operator notice and the failing subprocess are spent once.
 var ErrReadyProjectionUnsupported = errors.New("ready projection unsupported by this bead store")
+
+// readyProjectionDegrade is the latched verdict for one scope: the reason its
+// ledger cannot answer the ready projection.
+type readyProjectionDegrade struct {
+	cause error
+}
+
+// readyProjectionScopeGuard bounds the degrade verdict, its operator notice,
+// and the subprocess that discovers it to one per SCOPE.
+//
+// Per-scope rather than per-store object is the same correction unreadStoreGuard
+// already carries (scopeGuards, unread_store_notice.go). A verdict memoized on
+// the store object is memoized on nothing: cmd/gc's scoped stores are built per
+// request, and cmd/gc's control-ready path rebuilds a store per
+// controlReadyCacheTTL (3s) per scope for the life of the dispatcher. Bounding
+// there turns "once per store" into "once per rebuild" — an unbounded operator
+// notice, and a latch that never actually saves the failing 6-16s `bd sql` it
+// exists to save.
+type readyProjectionScopeGuard struct {
+	// degrade latches the reason this scope cannot serve the projection. It is
+	// never cleared: a ledger in front of a running process does not grow the
+	// capability, and re-probing costs a guaranteed-failing subprocess per
+	// cache prime and per reconcile.
+	degrade atomic.Pointer[readyProjectionDegrade]
+	// announced bounds the operator notice to one per scope. Compare-and-swap
+	// rather than sync.Once for the reason verdictClaimed is: the winner writes
+	// to a sink an operator owns, and no other caller should wait behind it.
+	announced atomic.Bool
+}
+
+// readyProjectionGuards memoizes one guard per resolved scope path. It grows by
+// one small entry per distinct bead scope a process reads — a city and its
+// rigs — and entries live for the process because the verdict does.
+var readyProjectionGuards sync.Map // map[string]*readyProjectionScopeGuard
+
+// readyProjectionGuardForScope returns the shared guard for dir, creating it on
+// first use. LoadOrStore, not a mutex: the losing racer discards a two-field
+// struct and takes the winner's. A store with no directory gets the empty key,
+// which is the right bucket rather than a leak: those stores run bd in the
+// process's working directory, so they all address one scope.
+func readyProjectionGuardForScope(dir string) *readyProjectionScopeGuard {
+	key := scopeGuardKey(dir)
+	if g, ok := readyProjectionGuards.Load(key); ok {
+		return g.(*readyProjectionScopeGuard)
+	}
+	g, _ := readyProjectionGuards.LoadOrStore(key, &readyProjectionScopeGuard{})
+	return g.(*readyProjectionScopeGuard)
+}
+
+// readyProjectionGuard returns this store's scope guard. Stores built by
+// NewBdStore resolve it once at construction; the lookup here is the fallback
+// for a zero-value BdStore.
+func (s *BdStore) readyProjectionGuard() *readyProjectionScopeGuard {
+	if s == nil {
+		return nil
+	}
+	if s.readyProjectionScope != nil {
+		return s.readyProjectionScope
+	}
+	return readyProjectionGuardForScope(s.dir)
+}
 
 type bdReadyProjectionRow struct {
 	ID        string       `json:"id"`
@@ -94,6 +170,14 @@ func skipBDReadyProjectionEnrichment(item Bead) bool {
 }
 
 func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
+	// The scope verdict outranks anything this store object knows: a store
+	// built after some other store over the same scope reached it must neither
+	// re-spend the discovery nor re-announce it. It still REPORTS the degrade,
+	// on every call, because that error is how each cache over the scope learns
+	// to decline its readiness reads.
+	if cause := s.latchedReadyProjectionDegrade(); cause != nil {
+		return false, fmt.Errorf("bd ready projection scope verdict: %w: %w", ErrReadyProjectionUnsupported, cause)
+	}
 	s.readyProjectionMu.Lock()
 	defer s.readyProjectionMu.Unlock()
 	// Probe the capability once per process. Operators must restart gc after
@@ -136,9 +220,10 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 // runtime (contract.RegisteredBackends). A scope served through the linked
 // beads library under any other name is one gc knows nothing about, so
 // assuming its `bd sql` works, and that its schema carries gc's issues/wisps
-// projection, is a guess. Withholding the call is the honest default and costs
-// that scope one optimization whose absence is already the documented benign
-// state (IsBlocked==nil falls back to dependency-derived readiness).
+// projection, is a guess. Withholding the call is the honest default, and it
+// costs that scope the enrichment rather than its correctness: readiness reads
+// there decline the cache and take bd's own verdict live (see
+// ErrReadyProjectionUnsupported), while every other cached read keeps serving.
 //
 // A scope naming a registered backend — including metadata that names none, and
 // including metadata gc cannot read — reaches nil here and takes exactly the
@@ -154,8 +239,8 @@ func (s *BdStore) readyProjectionBackendRefusal() error {
 	return err
 }
 
-// disableReadyProjectionLocked latches the projection off for the life of this
-// store and states the reason once. Callers hold readyProjectionMu.
+// disableReadyProjectionLocked latches the projection off for this scope and
+// states the reason once. Callers hold readyProjectionMu.
 //
 // The latch is one-way for the same reason the conditional-release one is: the
 // ledger in front of the process cannot grow a capability mid-run, and
@@ -164,20 +249,52 @@ func (s *BdStore) readyProjectionBackendRefusal() error {
 func (s *BdStore) disableReadyProjectionLocked(reason error) {
 	s.readyProjectionEnabled = false
 	s.readyProjectionChecked = true
+	s.latchReadyProjectionDegrade(reason)
+}
+
+// latchReadyProjectionDegrade records the scope verdict and announces it once.
+//
+// The notice states what actually changes for the operator: readiness reads on
+// this scope stop being served from cache and take a live `bd ready` instead,
+// every other cached read keeps serving, and the failing `bd sql` is not spent
+// again. It deliberately does not claim the cache is unaffected — the
+// dependency-derived predicate the cache would otherwise use is not equivalent
+// to bd's is_blocked (see ErrReadyProjectionUnsupported).
+func (s *BdStore) latchReadyProjectionDegrade(cause error) {
+	g := s.readyProjectionGuard()
+	if g == nil {
+		return
+	}
+	g.degrade.CompareAndSwap(nil, &readyProjectionDegrade{cause: cause})
+	if !g.announced.CompareAndSwap(false, true) {
+		return
+	}
 	_, _ = fmt.Fprintf(s.noticeWriter(),
 		"gc: ready-projection enrichment disabled for %s: %v\n"+
-			"gc: cached ready falls back to dependency-derived readiness; no work is lost and no further bd sql is spent.\n",
-		s.dir, reason)
+			"gc: ready reads on this scope answer from a live `bd ready` instead of the cache; other cached reads keep serving and no further bd sql is spent.\n",
+		s.dir, cause)
+}
+
+// latchedReadyProjectionDegrade returns the reason this SCOPE cannot serve the
+// ready projection, or nil when no store over it has reached that verdict.
+func (s *BdStore) latchedReadyProjectionDegrade() error {
+	g := s.readyProjectionGuard()
+	if g == nil {
+		return nil
+	}
+	verdict := g.degrade.Load()
+	if verdict == nil {
+		return nil
+	}
+	return verdict.cause
 }
 
 // latchReadyProjectionUnsupported records bd's own refusal of `bd sql`, so no
-// later cycle spends the call again.
+// later cycle — and no store built later over the same scope — spends the call
+// again.
 func (s *BdStore) latchReadyProjectionUnsupported(cause error) {
 	s.readyProjectionMu.Lock()
 	defer s.readyProjectionMu.Unlock()
-	if s.readyProjectionChecked && !s.readyProjectionEnabled {
-		return
-	}
 	s.disableReadyProjectionLocked(cause)
 }
 

--- a/internal/beads/bdstore_ready_projection_capability_internal_test.go
+++ b/internal/beads/bdstore_ready_projection_capability_internal_test.go
@@ -1,0 +1,228 @@
+package beads
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// bdEmbeddedSQLRefusal is the verbatim failure a bd serving a non-Dolt backend
+// returns for `bd sql`, as gc's runner composes it: bd writes
+// `Error: 'bd sql' is not yet supported in embedded mode` to stderr
+// (cmd/bd/sql.go HandleError) and classifyBDExecResult wraps it onto the exit
+// status.
+const bdEmbeddedSQLRefusal = "exit status 1: Error: 'bd sql' is not yet supported in embedded mode"
+
+// embeddedSQLRunner answers `bd version` like bd 1.1.0 and refuses `bd sql` the
+// way a bd serving a backend it cannot open a SQL session against does.
+func embeddedSQLRunner() *recordingRunner {
+	r := &recordingRunner{}
+	r.reply = func(args []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case joined == "version":
+			return []byte("bd version 1.1.0\n"), nil
+		case len(args) > 0 && args[0] == "sql":
+			return nil, errors.New(bdEmbeddedSQLRefusal)
+		}
+		return nil, fmt.Errorf("unexpected command: %s", joined)
+	}
+	return r
+}
+
+func writeScopeMetadata(t *testing.T, scope string, meta map[string]any) {
+	t.Helper()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", beadsDir, err)
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+}
+
+func activeWorkBeads() []Bead {
+	return []Bead{
+		{ID: "mc-1", Type: "task", Status: "open"},
+		{ID: "mc-2", Type: "task", Status: "open"},
+	}
+}
+
+// TestReadyProjectionLatchesOnTheEmbeddedModeRefusal is the live maintainer-city
+// defect: bd serves that city's work class from hosted Postgres, `bd sql` is not
+// implemented there, and the capability gate only ever asked bd its VERSION — so
+// every cache prime and every reconcile spent a guaranteed-failing 6-16s
+// subprocess, forever.
+//
+// The refusal is a permanent property of the ledger in front of the process, so
+// it is latched: bd is asked exactly once.
+func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
+	runner := embeddedSQLRunner()
+	notices := &bytes.Buffer{}
+	s := NewBdStore(t.TempDir(), runner.run, WithBdStoreNoticeSink(notices))
+
+	first, err := s.enrichReadyProjectionForCache(activeWorkBeads())
+	if !errors.Is(err, ErrReadyProjectionUnsupported) {
+		t.Fatalf("first enrich error = %v, want ErrReadyProjectionUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "not yet supported in embedded mode") {
+		t.Errorf("degrade does not carry bd's cause: %v", err)
+	}
+	for _, b := range first {
+		if b.IsBlocked != nil {
+			t.Errorf("bead %s was enriched from a failed projection: %v", b.ID, *b.IsBlocked)
+		}
+	}
+
+	var laterErrs []error
+	for i := 2; i <= 5; i++ {
+		if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); err != nil {
+			laterErrs = append(laterErrs, fmt.Errorf("enrich #%d: %w", i, err))
+		}
+	}
+
+	sqlCalls := 0
+	for _, call := range runner.calls {
+		if len(call) > 1 && call[1] == "sql" {
+			sqlCalls++
+		}
+	}
+	if sqlCalls != 1 {
+		t.Fatalf("bd sql ran %d times across 5 enrichments (calls=%v); the latch must spend exactly one", sqlCalls, runner.calls)
+	}
+	if len(laterErrs) != 0 {
+		t.Fatalf("the latched projection kept reporting failures instead of degrading quietly: %v", laterErrs)
+	}
+	if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
+		t.Fatalf("operator notice printed %d times, want exactly 1:\n%s", got, notices.String())
+	}
+	if !strings.Contains(notices.String(), "not yet supported in embedded mode") {
+		t.Errorf("operator notice does not name the cause:\n%s", notices.String())
+	}
+}
+
+// TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd is the
+// capability gate proper. `bd sql` support is a property of the BACKEND, not of
+// the bd release, so a scope whose metadata names a backend this build does not
+// implement never gets asked — not even for its version.
+func TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd(t *testing.T) {
+	scope := t.TempDir()
+	writeScopeMetadata(t, scope, map[string]any{
+		"database":   "dolt",
+		"backend":    "postgres",
+		"dolt_mode":  "server",
+		"project_id": "d2e95604-e869-478c-ad1a-ddee6e8bc3fc",
+	})
+	runner := embeddedSQLRunner()
+	notices := &bytes.Buffer{}
+	s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
+
+	for i := 1; i <= 3; i++ {
+		out, err := s.enrichReadyProjectionForCache(activeWorkBeads())
+		if i == 1 {
+			if !errors.Is(err, ErrReadyProjectionUnsupported) {
+				t.Fatalf("first enrich error = %v, want ErrReadyProjectionUnsupported", err)
+			}
+			if !strings.Contains(err.Error(), `unsupported backend "postgres"`) {
+				t.Errorf("degrade does not name the backend: %v", err)
+			}
+		} else if err != nil {
+			t.Fatalf("enrich #%d after the gate latched: %v", i, err)
+		}
+		for _, b := range out {
+			if b.IsBlocked != nil {
+				t.Errorf("bead %s was enriched by an unsupported backend", b.ID)
+			}
+		}
+	}
+
+	if len(runner.calls) != 0 {
+		t.Fatalf("an unimplemented backend was asked %v; the gate must spend no subprocess", runner.calls)
+	}
+	if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
+		t.Fatalf("operator notice printed %d times, want exactly 1:\n%s", got, notices.String())
+	}
+}
+
+// TestReadyProjectionOnAnImplementedBackendIsUnchanged is the byte-identity
+// guard for the five Dolt cities. Their metadata names a backend this build
+// implements, so the gate is inert: the exact same two commands run, in the same
+// order, and the rows come back enriched.
+//
+// Mutation proof: flipping "dolt" to any backend this build does not register
+// empties runner.calls (the sibling test above), and deleting the latch in
+// fetchReadyProjection re-runs `bd sql` on every call
+// (TestReadyProjectionLatchesOnTheEmbeddedModeRefusal).
+func TestReadyProjectionOnAnImplementedBackendIsUnchanged(t *testing.T) {
+	for _, backend := range []string{"dolt", "doltlite", ""} {
+		t.Run("backend="+backend, func(t *testing.T) {
+			scope := t.TempDir()
+			meta := map[string]any{"database": "dolt", "dolt_mode": "server", "dolt_database": "hq"}
+			if backend != "" {
+				meta["backend"] = backend
+			}
+			writeScopeMetadata(t, scope, meta)
+			runner := readyProjectionRunner(`[{"id":"mc-1","is_blocked":false},{"id":"mc-2","is_blocked":true}]`)
+			notices := &bytes.Buffer{}
+			s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
+
+			out, err := s.enrichReadyProjectionForCache(activeWorkBeads())
+			if err != nil {
+				t.Fatalf("enrichReadyProjectionForCache: %v", err)
+			}
+			want := [][]string{
+				{"bd", "version"},
+				{"bd", "sql", readyProjectionSQL(), "--json"},
+			}
+			if !reflect.DeepEqual(runner.calls, want) {
+				t.Fatalf("bd invocations = %v, want %v", runner.calls, want)
+			}
+			byID := make(map[string]Bead, len(out))
+			for _, b := range out {
+				byID[b.ID] = b
+			}
+			for id, wantBlocked := range map[string]bool{"mc-1": false, "mc-2": true} {
+				got := byID[id].IsBlocked
+				if got == nil || *got != wantBlocked {
+					t.Errorf("bead %s is_blocked = %v, want &%v", id, got, wantBlocked)
+				}
+			}
+			if notices.Len() != 0 {
+				t.Errorf("an implemented backend printed a degrade notice:\n%s", notices.String())
+			}
+		})
+	}
+}
+
+// TestReadyProjectionUnreadableMetadataFallsThroughToTheLatch keeps the gate
+// fail-open: metadata gc cannot read is not evidence about the backend, so the
+// version probe still runs and the runtime latch is what catches the refusal.
+func TestReadyProjectionUnreadableMetadataFallsThroughToTheLatch(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	runner := embeddedSQLRunner()
+	s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(&bytes.Buffer{}))
+
+	if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
+		t.Fatalf("enrich error = %v, want the runtime latch verdict", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %v, want the version probe and one refused sql", runner.calls)
+	}
+}

--- a/internal/beads/bdstore_ready_projection_capability_internal_test.go
+++ b/internal/beads/bdstore_ready_projection_capability_internal_test.go
@@ -65,7 +65,11 @@ func activeWorkBeads() []Bead {
 // subprocess, forever.
 //
 // The refusal is a permanent property of the ledger in front of the process, so
-// it is latched: bd is asked exactly once.
+// it is latched: bd is asked exactly once and the operator is told once. The
+// latch silences the SUBPROCESS and the NOTICE, not the verdict — every later
+// enrichment still reports the degrade, because that error is how each cache
+// over this scope learns to send its readiness reads to the live backing
+// (CachingStore.readyReadsMustGoLive).
 func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
 	runner := embeddedSQLRunner()
 	notices := &bytes.Buffer{}
@@ -84,10 +88,10 @@ func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
 		}
 	}
 
-	var laterErrs []error
+	var silentCycles []int
 	for i := 2; i <= 5; i++ {
-		if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); err != nil {
-			laterErrs = append(laterErrs, fmt.Errorf("enrich #%d: %w", i, err))
+		if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
+			silentCycles = append(silentCycles, i)
 		}
 	}
 
@@ -100,8 +104,8 @@ func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
 	if sqlCalls != 1 {
 		t.Fatalf("bd sql ran %d times across 5 enrichments (calls=%v); the latch must spend exactly one", sqlCalls, runner.calls)
 	}
-	if len(laterErrs) != 0 {
-		t.Fatalf("the latched projection kept reporting failures instead of degrading quietly: %v", laterErrs)
+	if len(silentCycles) != 0 {
+		t.Fatalf("enrich cycles %v stopped naming the degrade; a cache that primes on one of them would serve readiness from a projection it does not have", silentCycles)
 	}
 	if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
 		t.Fatalf("operator notice printed %d times, want exactly 1:\n%s", got, notices.String())
@@ -129,15 +133,11 @@ func TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd(t *testin
 
 	for i := 1; i <= 3; i++ {
 		out, err := s.enrichReadyProjectionForCache(activeWorkBeads())
-		if i == 1 {
-			if !errors.Is(err, ErrReadyProjectionUnsupported) {
-				t.Fatalf("first enrich error = %v, want ErrReadyProjectionUnsupported", err)
-			}
-			if !strings.Contains(err.Error(), `unsupported backend "postgres"`) {
-				t.Errorf("degrade does not name the backend: %v", err)
-			}
-		} else if err != nil {
-			t.Fatalf("enrich #%d after the gate latched: %v", i, err)
+		if !errors.Is(err, ErrReadyProjectionUnsupported) {
+			t.Fatalf("enrich #%d error = %v, want ErrReadyProjectionUnsupported on every cycle", i, err)
+		}
+		if !strings.Contains(err.Error(), `unsupported backend "postgres"`) {
+			t.Errorf("degrade #%d does not name the backend: %v", i, err)
 		}
 		for _, b := range out {
 			if b.IsBlocked != nil {
@@ -151,6 +151,95 @@ func TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd(t *testin
 	}
 	if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
 		t.Fatalf("operator notice printed %d times, want exactly 1:\n%s", got, notices.String())
+	}
+}
+
+// TestReadyProjectionVerdictIsPerScopeAcrossStoreRebuilds is the bound that
+// makes "once" mean anything.
+//
+// Nothing in gc holds one BdStore per scope for the life of the process:
+// cmd/gc's scoped stores are built per request, and the control-dispatcher
+// readiness scan rebuilds a store per scope every controlReadyCacheTTL (3s) and
+// primes it immediately, so a verdict memoized on the store object is
+// re-derived — and re-announced — a few times a minute, forever. That is the
+// same defect the sibling unread-store notice already had to fix, so this
+// reuses its registry pattern.
+//
+// The verdict is still REPORTED to every rebuilt store, because each one backs a
+// fresh cache that must learn to send readiness reads live; what the scope bound
+// removes is the repeated notice and the repeated failing subprocess.
+func TestReadyProjectionVerdictIsPerScopeAcrossStoreRebuilds(t *testing.T) {
+	rebuild := func(t *testing.T, scope string, notices *bytes.Buffer) [][]string {
+		t.Helper()
+		var calls [][]string
+		for i := 1; i <= 5; i++ {
+			runner := embeddedSQLRunner()
+			s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
+			if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
+				t.Fatalf("rebuild #%d enrich error = %v, want ErrReadyProjectionUnsupported", i, err)
+			}
+			calls = append(calls, runner.calls...)
+		}
+		return calls
+	}
+
+	t.Run("backend gate", func(t *testing.T) {
+		scope := t.TempDir()
+		writeScopeMetadata(t, scope, map[string]any{"database": "dolt", "backend": "postgres"})
+		notices := &bytes.Buffer{}
+		calls := rebuild(t, scope, notices)
+		if len(calls) != 0 {
+			t.Fatalf("rebuilt stores spent %v; the gate must spend no subprocess", calls)
+		}
+		if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
+			t.Fatalf("operator notice printed %d times across 5 stores over one scope, want exactly 1:\n%s", got, notices.String())
+		}
+	})
+
+	t.Run("runtime latch", func(t *testing.T) {
+		scope := t.TempDir()
+		writeScopeMetadata(t, scope, map[string]any{"database": "dolt", "backend": "dolt", "dolt_mode": "server"})
+		notices := &bytes.Buffer{}
+		calls := rebuild(t, scope, notices)
+		sqlCalls := 0
+		for _, call := range calls {
+			if len(call) > 1 && call[1] == "sql" {
+				sqlCalls++
+			}
+		}
+		if sqlCalls != 1 {
+			t.Fatalf("bd sql ran %d times across 5 stores over one scope (calls=%v); the latch must survive the rebuild", sqlCalls, calls)
+		}
+		if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
+			t.Fatalf("operator notice printed %d times across 5 stores over one scope, want exactly 1:\n%s", got, notices.String())
+		}
+	})
+}
+
+// TestReadyProjectionNoticeDoesNotClaimReadinessIsUnaffected pins the operator
+// line to what actually happens. An earlier draft said "no work is lost", which
+// named the wrong risk: the degraded predicate is permissive, not lossy, so the
+// cache would OFFER work whose gate has not opened. The notice must say where
+// readiness comes from instead.
+func TestReadyProjectionNoticeDoesNotClaimReadinessIsUnaffected(t *testing.T) {
+	scope := t.TempDir()
+	writeScopeMetadata(t, scope, map[string]any{"database": "dolt", "backend": "postgres"})
+	notices := &bytes.Buffer{}
+	s := NewBdStore(scope, embeddedSQLRunner().run, WithBdStoreNoticeSink(notices))
+	if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
+		t.Fatalf("enrich error = %v, want ErrReadyProjectionUnsupported", err)
+	}
+
+	notice := notices.String()
+	for _, banned := range []string{"no work is lost", "dependency-derived readiness"} {
+		if strings.Contains(notice, banned) {
+			t.Errorf("notice claims %q, which is not what the degrade does:\n%s", banned, notice)
+		}
+	}
+	for _, want := range []string{"live `bd ready`", "other cached reads keep serving", "no further bd sql is spent"} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("notice does not say %q:\n%s", want, notice)
+		}
 	}
 }
 

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -727,11 +727,10 @@ func (c *CachingStore) PrimeActive() error {
 		}
 		all = append(all, beads...)
 	}
-	if enriched, err := c.enrichReadyProjectionForCache(all); err != nil {
-		partialErr = errors.Join(partialErr, err)
-		c.recordProblem("prime active ready projection", err)
-	} else {
-		all = enriched
+	enriched, enrichErr := c.applyReadyProjection("prime active ready projection", all)
+	all = enriched
+	if enrichErr != nil {
+		partialErr = errors.Join(partialErr, enrichErr)
 	}
 
 	beadMap := make(map[string]Bead, len(all))
@@ -843,11 +842,10 @@ func (c *CachingStore) prime(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("prime list: %w", err)
 	}
-	if enriched, enrichErr := c.enrichReadyProjectionForCache(all); enrichErr != nil {
-		c.recordProblem("prime ready projection", enrichErr)
+	enriched, enrichErr := c.applyReadyProjection("prime ready projection", all)
+	all = enriched
+	if enrichErr != nil {
 		partialErr = errors.Join(partialErr, enrichErr)
-	} else {
-		all = enriched
 	}
 	if err := c.cacheContextErr(ctx); err != nil {
 		return err
@@ -1242,6 +1240,29 @@ func (c *CachingStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, erro
 		return backing.enrichReadyProjectionForCache(items)
 	}
 	return items, nil
+}
+
+// applyReadyProjection enriches items with the backing store's ready projection
+// and returns the failure that leaves the snapshot INCOMPLETE, having already
+// recorded every failure on the problem log.
+//
+// A projection the backing store cannot serve at all is not an incomplete
+// snapshot: IsBlocked==nil is the documented fallback and cachedBeadReady
+// derives readiness from dependencies instead, so the rows are whole and the
+// cache degrades to a named state rather than a partial one. Folding it into
+// primePartialErr — which nothing but a clean prime clears — declined every
+// cache-only read for the life of the process and sent each one to a live 5-6s
+// bd subprocess, which is the shape maintainer-city was stuck in.
+func (c *CachingStore) applyReadyProjection(op string, items []Bead) ([]Bead, error) {
+	enriched, err := c.enrichReadyProjectionForCache(items)
+	if err == nil {
+		return enriched, nil
+	}
+	c.recordProblem(op, err)
+	if errors.Is(err, ErrReadyProjectionUnsupported) {
+		return items, nil
+	}
+	return items, err
 }
 
 func (c *CachingStore) fetchDepsForBeads(beadMap map[string]Bead) (map[string][]Dep, bool, error) {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -42,6 +42,13 @@ type CachingStore struct {
 	mutationSeq     uint64
 	primePartialErr error
 
+	// readyProjectionDegraded latches when the backing store reported it cannot
+	// serve the ready projection at all. It is deliberately NOT primePartialErr:
+	// see readyReadsMustGoLive for what each flag costs which reads. Atomic
+	// rather than mu-guarded because it is set from the prime/reconcile paths
+	// and read under mu by the readiness readers.
+	readyProjectionDegraded atomic.Bool
+
 	reconciling    atomic.Bool
 	syncFailures   int
 	circuitTripped bool
@@ -1246,13 +1253,16 @@ func (c *CachingStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, erro
 // and returns the failure that leaves the snapshot INCOMPLETE, having already
 // recorded every failure on the problem log.
 //
-// A projection the backing store cannot serve at all is not an incomplete
-// snapshot: IsBlocked==nil is the documented fallback and cachedBeadReady
-// derives readiness from dependencies instead, so the rows are whole and the
-// cache degrades to a named state rather than a partial one. Folding it into
-// primePartialErr — which nothing but a clean prime clears — declined every
-// cache-only read for the life of the process and sent each one to a live 5-6s
-// bd subprocess, which is the shape maintainer-city was stuck in.
+// A projection the backing store cannot serve AT ALL costs the snapshot one
+// column, not rows: the cache latches readyProjectionDegraded, its readiness
+// reads decline to the live backing, and every other cached read keeps serving.
+// Folding that into primePartialErr — which nothing but a clean prime clears —
+// declined every cache-only read for the life of the process and sent each one
+// to a live 5-6s bd subprocess, which is the shape maintainer-city was stuck in.
+//
+// A projection that merely failed THIS cycle is a different verdict: the store
+// can answer, so the rows really are missing an answer they should have, and the
+// snapshot stays partial.
 func (c *CachingStore) applyReadyProjection(op string, items []Bead) ([]Bead, error) {
 	enriched, err := c.enrichReadyProjectionForCache(items)
 	if err == nil {
@@ -1260,9 +1270,33 @@ func (c *CachingStore) applyReadyProjection(op string, items []Bead) ([]Bead, er
 	}
 	c.recordProblem(op, err)
 	if errors.Is(err, ErrReadyProjectionUnsupported) {
+		c.readyProjectionDegraded.Store(true)
 		return items, nil
 	}
 	return items, err
+}
+
+// readyReadsMustGoLive reports whether readiness reads must decline the cache
+// and take their live-backing fallback.
+//
+// It latches when the backing store reported ErrReadyProjectionUnsupported,
+// which leaves every bead's IsBlocked nil. cachedBeadReady then derives
+// readiness from each bead's OWN direct blocks/waits-for/conditional-blocks
+// deps, and that predicate is WEAKER than bd's is_blocked: bd propagates
+// blocked-ness transitively down parent-child edges, so a child of a blocked
+// parent is blocked to bd and ready to the cache. Serving it would offer work
+// whose molecule gate has not opened to the control dispatcher — the exact
+// regression #3218 closed by mirroring bd's projection in the first place.
+//
+// Only readiness declines. List/Get/DepList keep serving from cache, because
+// the rows themselves are whole; that separation is the whole point of not
+// folding this verdict into primePartialErr.
+//
+// The latch is one-way to match the backing store's own: once a scope's ledger
+// is known not to serve the projection, later primes are told so without
+// spending a subprocess, so a cleared flag could never be re-derived.
+func (c *CachingStore) readyReadsMustGoLive() bool {
+	return c.readyProjectionDegraded.Load()
 }
 
 func (c *CachingStore) fetchDepsForBeads(beadMap map[string]Bead) (map[string][]Dep, bool, error) {

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -247,7 +247,8 @@ func (c *CachingStore) cachedReadyCompleteOnly(ctx context.Context, query ReadyQ
 	if !c.mu.TryRLock() {
 		return nil, fmt.Errorf("reading complete ready projection from busy cache: %w", ErrCacheUnavailable)
 	}
-	if c.state != cacheLive || !c.depsComplete || c.primePartialErr != nil || len(c.dirty) > 0 {
+	if c.state != cacheLive || !c.depsComplete || c.primePartialErr != nil || len(c.dirty) > 0 ||
+		c.readyReadsMustGoLive() {
 		c.mu.RUnlock()
 		return nil, fmt.Errorf("reading complete ready projection from cache: %w", ErrCacheUnavailable)
 	}
@@ -285,7 +286,8 @@ func (c *CachingStore) cachedReadyCompleteOnly(ctx context.Context, query ReadyQ
 }
 
 func (c *CachingStore) cachedReadyLocked(query ReadyQuery) ([]Bead, error) {
-	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil || len(c.dirty) > 0 {
+	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil ||
+		len(c.dirty) > 0 || c.readyReadsMustGoLive() {
 		return nil, fmt.Errorf("reading ready beads from cache: %w", ErrCacheUnavailable)
 	}
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -470,11 +470,15 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		depsByID   map[string][]Dep
 		openBeads  []Bead
 	)
-	// Ready requires a fully live cache with complete dependency coverage; the
-	// overlay refreshes any dirty rows first, then computes readiness from the
-	// cache. On overlay error the read takes the old full backing.Ready scan.
+	// Ready requires a fully live cache with complete dependency coverage and a
+	// ready projection the backing store can actually serve; the overlay
+	// refreshes any dirty rows first, then computes readiness from the cache.
+	// On overlay error the read takes the old full backing.Ready scan.
 	if err := c.readCacheWithOverlay(
-		func() bool { return c.state == cacheLive && c.depsComplete && c.primePartialErr == nil },
+		func() bool {
+			return c.state == cacheLive && c.depsComplete && c.primePartialErr == nil &&
+				!c.readyReadsMustGoLive()
+		},
 		func(suppressed map[string]struct{}) {
 			statusByID = make(map[string]string, len(c.beads))
 			openBeads = make([]Bead, 0, len(c.beads))
@@ -542,7 +546,7 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 	if c.state != cacheLive && c.state != cachePartial {
 		return nil, false
 	}
-	if c.primePartialErr != nil || len(c.dirty) > 0 {
+	if c.primePartialErr != nil || len(c.dirty) > 0 || c.readyReadsMustGoLive() {
 		return nil, false
 	}
 

--- a/internal/beads/caching_store_ready_projection_internal_test.go
+++ b/internal/beads/caching_store_ready_projection_internal_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -20,6 +22,10 @@ type projectionStore struct {
 func (p *projectionStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	p.calls++
 	return items, p.err
+}
+
+func unsupportedProjectionCause() error {
+	return fmt.Errorf("bd sql ready projection: %w: exit status 1: Error: 'bd sql' is not yet supported in embedded mode", ErrReadyProjectionUnsupported)
 }
 
 func primedProjectionCache(t *testing.T, err error) (*CachingStore, string) {
@@ -42,13 +48,12 @@ func primedProjectionCache(t *testing.T, err error) (*CachingStore, string) {
 // so every cache-only read declined with "bead cache unavailable" for the life
 // of the process and fell back to a live 5-6s bd subprocess.
 //
-// A projection the backing store CANNOT serve is not an incomplete snapshot:
-// IsBlocked==nil is the documented fallback and cachedBeadReady derives
-// readiness from dependencies. So the cache degrades to a named state — the
-// cause lands on the problem log — and keeps serving.
+// A projection the backing store CANNOT serve costs the snapshot one column,
+// not rows, so the rows keep being served and the cache degrades to a named
+// state rather than a partial one. What the missing column costs READINESS is a
+// separate verdict, pinned by TestDegradedProjectionSendsReadyToTheLiveBdVerdict.
 func TestPrimeDegradesRatherThanGoingPartialOnAnUnsupportedProjection(t *testing.T) {
-	cause := fmt.Errorf("bd sql ready projection: %w: exit status 1: Error: 'bd sql' is not yet supported in embedded mode", ErrReadyProjectionUnsupported)
-	cache, readyID := primedProjectionCache(t, cause)
+	cache, readyID := primedProjectionCache(t, unsupportedProjectionCause())
 
 	cache.mu.RLock()
 	partial := cache.primePartialErr
@@ -57,12 +62,15 @@ func TestPrimeDegradesRatherThanGoingPartialOnAnUnsupportedProjection(t *testing
 		t.Fatalf("primePartialErr = %v, want nil: an unsupported projection must not make the cache permanently unavailable", partial)
 	}
 
-	rows, err := cache.ReadyContext(context.Background())
-	if err != nil {
-		t.Fatalf("ReadyContext after the degrade: %v", err)
+	rows, ok := cache.CachedList(ListQuery{AllowScan: true})
+	if !ok {
+		t.Fatal("CachedList declined after the degrade: the rows are whole, so non-readiness reads must keep being served from cache")
 	}
 	if len(rows) != 1 || rows[0].ID != readyID {
-		t.Fatalf("ReadyContext rows = %+v, want the cached ready bead %s", rows, readyID)
+		t.Fatalf("CachedList rows = %+v, want the cached bead %s", rows, readyID)
+	}
+	if _, err := cache.Get(readyID); err != nil {
+		t.Fatalf("Get after the degrade: %v", err)
 	}
 
 	stats := cache.Stats()
@@ -87,4 +95,207 @@ func TestPrimeStaysPartialOnATransientProjectionFailure(t *testing.T) {
 	if partial == nil {
 		t.Fatal("primePartialErr = nil, want a transient projection failure to keep marking the snapshot partial")
 	}
+}
+
+// bdVerdictStore is a backing store whose ready projection is structurally
+// unavailable and whose Ready answers the way `bd ready` does.
+//
+// bd's is_blocked is not the cache's dependency-derived predicate: migration
+// 0046_add_is_blocked.up.sql propagates blocked-ness transitively DOWN
+// parent-child edges (its `reachable` CTE joins d.type='parent-child', pinned
+// upstream by TestIsBlocked_ParentChildTransitivePropagation) and `bd ready`
+// filters is_blocked = 0. blocked names the ids bd's column marks, so Ready
+// here is bd's verdict rather than the MemStore's direct-deps-only one.
+type bdVerdictStore struct {
+	Store
+	projectionErr error
+	blocked       map[string]bool
+
+	mu         sync.Mutex
+	readyCalls int
+	listCalls  int
+}
+
+func (b *bdVerdictStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	return items, b.projectionErr
+}
+
+func (b *bdVerdictStore) Ready(query ...ReadyQuery) ([]Bead, error) {
+	b.mu.Lock()
+	b.readyCalls++
+	b.mu.Unlock()
+	rows, err := b.Store.Ready(query...)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]Bead, 0, len(rows))
+	for _, row := range rows {
+		if b.blocked[row.ID] {
+			continue
+		}
+		kept = append(kept, row)
+	}
+	return kept, nil
+}
+
+func (b *bdVerdictStore) List(query ListQuery) ([]Bead, error) {
+	b.mu.Lock()
+	b.listCalls++
+	b.mu.Unlock()
+	return b.Store.List(query)
+}
+
+func (b *bdVerdictStore) counts() (ready, list int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.readyCalls, b.listCalls
+}
+
+// transitivelyBlockedFixture builds the shape the two readiness models disagree
+// about: a parent held by an open `blocks` dep, and a child attached to it by
+// parent-child only.
+//
+//	blocker (open) <-- blocks -- parent <-- parent-child -- child
+//
+// The child carries no blocking dep of its own, so the cache's predicate calls
+// it ready; bd marks it is_blocked=1 through the parent-child edge and hides it.
+// unrelated is the control both models call ready.
+func transitivelyBlockedFixture(t *testing.T, projectionErr error) (*CachingStore, *bdVerdictStore, map[string]string) {
+	t.Helper()
+	mem := NewMemStore()
+	ids := map[string]string{}
+	for _, title := range []string{"blocker", "parent", "child", "unrelated"} {
+		b, err := mem.Create(Bead{Type: "task", Status: "open", Title: title})
+		if err != nil {
+			t.Fatalf("Create %s: %v", title, err)
+		}
+		ids[title] = b.ID
+	}
+	if err := mem.DepAdd(ids["parent"], ids["blocker"], "blocks"); err != nil {
+		t.Fatalf("DepAdd blocks: %v", err)
+	}
+	if err := mem.DepAdd(ids["child"], ids["parent"], "parent-child"); err != nil {
+		t.Fatalf("DepAdd parent-child: %v", err)
+	}
+
+	backing := &bdVerdictStore{
+		Store:         mem,
+		projectionErr: projectionErr,
+		blocked:       map[string]bool{ids["parent"]: true, ids["child"]: true},
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	return cache, backing, ids
+}
+
+// TestDegradedProjectionSendsReadyToTheLiveBdVerdict is the correctness half of
+// the degrade, and the reason the flag is not primePartialErr.
+//
+// Without the projection every bead's IsBlocked is nil, and cachedBeadReady then
+// consults only the bead's OWN blocks/waits-for/conditional-blocks deps. That is
+// strictly weaker than bd's is_blocked, which is transitive down parent-child:
+// serving from cache would OFFER the control dispatcher a step whose molecule
+// gate has not opened, the regression #3218 closed by mirroring bd's projection
+// in the first place. So readiness — and only readiness — declines the cache and
+// takes bd's verdict live.
+func TestDegradedProjectionSendsReadyToTheLiveBdVerdict(t *testing.T) {
+	cache, backing, ids := transitivelyBlockedFixture(t, unsupportedProjectionCause())
+
+	if !cache.readyReadsMustGoLive() {
+		t.Fatal("cache did not latch the ready-projection degrade")
+	}
+
+	readyBefore, _ := backing.counts()
+	rows, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	got := sortedIDs(rows)
+	if want := wantReadyIDs(ids["blocker"], ids["unrelated"]); !equalIDs(got, want) {
+		t.Fatalf("Ready = %v, want %v: the transitively blocked child %s must not be offered as ready",
+			got, want, ids["child"])
+	}
+	readyAfter, listAfter := backing.counts()
+	if readyAfter != readyBefore+1 {
+		t.Fatalf("backing Ready calls = %d, want %d: the readiness read must reach bd's verdict", readyAfter, readyBefore+1)
+	}
+
+	if _, ok := cache.CachedReady(); ok {
+		t.Fatal("CachedReady answered from a cache with no ready projection; the control dispatcher reads this handle")
+	}
+	if _, err := cache.ReadyContext(context.Background()); !errors.Is(err, ErrCacheUnavailable) {
+		t.Fatalf("ReadyContext error = %v, want ErrCacheUnavailable", err)
+	}
+	if _, err := cache.Handles().Cached.Ready(); !errors.Is(err, ErrCacheUnavailable) {
+		t.Fatalf("cached reader Ready error = %v, want ErrCacheUnavailable", err)
+	}
+
+	// The outage this PR fixes must stay fixed: everything that does not depend
+	// on is_blocked keeps being served from the cache, with no backing traffic.
+	cached, ok := cache.CachedList(ListQuery{AllowScan: true})
+	if !ok {
+		t.Fatal("CachedList declined: the degrade must not make non-readiness reads unavailable")
+	}
+	if len(cached) != len(ids) {
+		t.Fatalf("CachedList returned %d rows, want %d", len(cached), len(ids))
+	}
+	if _, listNow := backing.counts(); listNow != listAfter {
+		t.Fatalf("backing List calls = %d, want %d: cached reads must not reach the backing store", listNow, listAfter)
+	}
+}
+
+// TestHealthyProjectionStillAnswersReadyFromCache is the control for the test
+// above: with a projection the backing store CAN serve, readiness is answered
+// from the cache off bd's is_blocked column, so the blocked child is hidden
+// without a live query.
+func TestHealthyProjectionStillAnswersReadyFromCache(t *testing.T) {
+	cache, backing, ids := transitivelyBlockedFixture(t, nil)
+	// A backing store that serves the projection stamps is_blocked itself; the
+	// fixture's enrichment is a no-op, so stamp the verdict the column carries.
+	cache.mu.Lock()
+	for id, blocked := range backing.blocked {
+		b := cache.beads[id]
+		b.IsBlocked = cloneBoolPtr(&blocked)
+		cache.beads[id] = b
+	}
+	cache.mu.Unlock()
+
+	if cache.readyReadsMustGoLive() {
+		t.Fatal("a servable projection must not latch the degrade")
+	}
+	readyBefore, _ := backing.counts()
+	rows, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if got, want := sortedIDs(rows), wantReadyIDs(ids["blocker"], ids["unrelated"]); !equalIDs(got, want) {
+		t.Fatalf("Ready = %v, want %v", got, want)
+	}
+	if readyAfter, _ := backing.counts(); readyAfter != readyBefore {
+		t.Fatalf("backing Ready calls = %d, want %d: a healthy cache answers readiness itself", readyAfter, readyBefore)
+	}
+}
+
+// wantReadyIDs is the expected readiness ANSWER, compared against sortedIDs so
+// the assertion does not depend on the order two different readers impose on
+// it: the cache path sorts with sortBeadsReadyOrder and the live path returns
+// the backing store's order.
+func wantReadyIDs(ids ...string) []string {
+	want := append([]string(nil), ids...)
+	sort.Strings(want)
+	return want
+}
+
+func equalIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/beads/caching_store_ready_projection_internal_test.go
+++ b/internal/beads/caching_store_ready_projection_internal_test.go
@@ -1,0 +1,90 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// projectionStore is a backing store whose ready-projection enrichment fails a
+// chosen way, so the cache's reaction to each verdict can be tested without a bd
+// subprocess.
+type projectionStore struct {
+	Store
+	err   error
+	calls int
+}
+
+func (p *projectionStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	p.calls++
+	return items, p.err
+}
+
+func primedProjectionCache(t *testing.T, err error) (*CachingStore, string) {
+	t.Helper()
+	backing := NewMemStore()
+	ready, createErr := backing.Create(Bead{Type: "task", Status: "open", Title: "ready work"})
+	if createErr != nil {
+		t.Fatalf("Create: %v", createErr)
+	}
+	cache := NewCachingStoreForTest(&projectionStore{Store: backing, err: err}, nil)
+	if primeErr := cache.Prime(context.Background()); primeErr != nil {
+		t.Fatalf("Prime: %v", primeErr)
+	}
+	return cache, ready.ID
+}
+
+// TestPrimeDegradesRatherThanGoingPartialOnAnUnsupportedProjection is the
+// operator-visible half of the maintainer-city defect. The enrichment failure
+// folded into primePartialErr, which is never cleared except by a clean prime,
+// so every cache-only read declined with "bead cache unavailable" for the life
+// of the process and fell back to a live 5-6s bd subprocess.
+//
+// A projection the backing store CANNOT serve is not an incomplete snapshot:
+// IsBlocked==nil is the documented fallback and cachedBeadReady derives
+// readiness from dependencies. So the cache degrades to a named state — the
+// cause lands on the problem log — and keeps serving.
+func TestPrimeDegradesRatherThanGoingPartialOnAnUnsupportedProjection(t *testing.T) {
+	cause := fmt.Errorf("bd sql ready projection: %w: exit status 1: Error: 'bd sql' is not yet supported in embedded mode", ErrReadyProjectionUnsupported)
+	cache, readyID := primedProjectionCache(t, cause)
+
+	cache.mu.RLock()
+	partial := cache.primePartialErr
+	cache.mu.RUnlock()
+	if partial != nil {
+		t.Fatalf("primePartialErr = %v, want nil: an unsupported projection must not make the cache permanently unavailable", partial)
+	}
+
+	rows, err := cache.ReadyContext(context.Background())
+	if err != nil {
+		t.Fatalf("ReadyContext after the degrade: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != readyID {
+		t.Fatalf("ReadyContext rows = %+v, want the cached ready bead %s", rows, readyID)
+	}
+
+	stats := cache.Stats()
+	if !strings.Contains(stats.LastProblem, "not yet supported in embedded mode") {
+		t.Errorf("LastProblem = %q, want the degrade to name its cause", stats.LastProblem)
+	}
+	if !strings.Contains(stats.LastProblem, "ready projection") {
+		t.Errorf("LastProblem = %q, want the degrade to name the projection", stats.LastProblem)
+	}
+}
+
+// TestPrimeStaysPartialOnATransientProjectionFailure is the control: only the
+// structural verdict degrades. A projection that merely failed this cycle still
+// marks the snapshot partial, because the rows really are missing an answer the
+// store can give.
+func TestPrimeStaysPartialOnATransientProjectionFailure(t *testing.T) {
+	cache, _ := primedProjectionCache(t, errors.New("bd sql ready projection: exit status 1: dial tcp: connection refused"))
+
+	cache.mu.RLock()
+	partial := cache.primePartialErr
+	cache.mu.RUnlock()
+	if partial == nil {
+		t.Fatal("primePartialErr = nil, want a transient projection failure to keep marking the snapshot partial")
+	}
+}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -318,13 +318,12 @@ func (c *CachingStore) runReconciliation() {
 		recordCacheScanLarge(context.Background(), c.idPrefix, len(fresh),
 			cacheReconcileScanWarnThreshold, time.Since(bdStart))
 	}
-	enriched, enrichErr := c.enrichReadyProjectionForCache(fresh)
+	// The reconcile pass never marked the snapshot partial on an enrichment
+	// failure — the rows it just listed are whole either way — so it discards
+	// the completeness verdict applyReadyProjection returns and keeps only the
+	// problem-log entry it already recorded.
+	fresh, _ = c.applyReadyProjection("reconcile ready projection", fresh)
 	bdLatency := time.Since(bdStart)
-	if enrichErr != nil {
-		c.recordProblem("reconcile ready projection", enrichErr)
-	} else {
-		fresh = enriched
-	}
 
 	freshByID := make(map[string]Bead, len(fresh))
 	for _, b := range fresh {

--- a/internal/beads/caching_store_reconcile_census_test.go
+++ b/internal/beads/caching_store_reconcile_census_test.go
@@ -98,6 +98,13 @@ func TestMergeOracleFieldCoverage(t *testing.T) {
 		"lifecycleMu": true, "lifecycleWG": true, "cancelFn": true, "stopCh": true,
 		"stopped": true, "latencyWindow": true, "latencyDriverActive": true,
 		"applyEventBeforeCommitForTest": true,
+		// readyProjectionDegraded is a one-way capability latch about the
+		// BACKING STORE, set by applyReadyProjection before the seam runs and
+		// never touched by mergeSnapshotLocked. It routes readiness reads to the
+		// live backing (readyReadsMustGoLive); the merge end state does not
+		// depend on it. Its own behavior is pinned by
+		// TestDegradedProjectionSendsReadyToTheLiveBdVerdict.
+		"readyProjectionDegraded": true,
 	}
 	assertFieldsClassified(t, reflect.TypeOf(CachingStore{}), comparedStore, excludedStore)
 

--- a/internal/beads/unread_store_notice.go
+++ b/internal/beads/unread_store_notice.go
@@ -338,13 +338,14 @@ func (s *BdStore) noticeIfStoreCannotSeeItsLedger(op string) {
 	if !ok {
 		return
 	}
-	_, _ = io.WriteString(s.unreadStoreNoticeSink(), UnreadStoreNotice(op, s.dir, unread, activeStore))
+	_, _ = io.WriteString(s.noticeWriter(), UnreadStoreNotice(op, s.dir, unread, activeStore))
 }
 
-// unreadStoreNoticeSink returns where this store's notice is written. os.Stderr
-// by default, so an operator running `gc ready` sees it and the controller's
-// log captures it, without touching the stdout a caller may be parsing.
-func (s *BdStore) unreadStoreNoticeSink() io.Writer {
+// noticeWriter returns where this store's operator notices are written.
+// os.Stderr by default, so an operator running `gc ready` sees them and the
+// controller's log captures them, without touching the stdout a caller may be
+// parsing.
+func (s *BdStore) noticeWriter() io.Writer {
 	if s.noticeSink != nil {
 		return s.noticeSink
 	}

--- a/internal/beads/unread_store_notice.go
+++ b/internal/beads/unread_store_notice.go
@@ -255,6 +255,16 @@ type unreadStoreGuard struct {
 // handful — and entries live for the process because the verdict does.
 var scopeGuards sync.Map // map[string]*unreadStoreGuard
 
+// scopeGuardKey is the registry key every per-scope verdict shares: the
+// resolved scope path, or "" for a store with no directory. Sharing it keeps
+// two guards over the same scope on the same key.
+func scopeGuardKey(dir string) string {
+	if strings.TrimSpace(dir) == "" {
+		return ""
+	}
+	return filepath.Clean(dir)
+}
+
 // guardForScope returns the shared guard for dir, creating it on first use.
 //
 // LoadOrStore, not a mutex: the losing racer discards a two-field struct and
@@ -262,10 +272,7 @@ var scopeGuards sync.Map // map[string]*unreadStoreGuard
 // has. A store with no directory gets the empty key, which is harmless —
 // UnreadBeadDatabase declines that shape before any evidence is gathered.
 func guardForScope(dir string) *unreadStoreGuard {
-	key := ""
-	if strings.TrimSpace(dir) != "" {
-		key = filepath.Clean(dir)
-	}
+	key := scopeGuardKey(dir)
 	if g, ok := scopeGuards.Load(key); ok {
 		return g.(*unreadStoreGuard)
 	}


### PR DESCRIPTION
## The defect (live on maintainer-city)

`CachingStore` prime and reconcile enrich every active bead's `is_blocked`
through `BdStore.fetchReadyProjection`, which shells `bd sql`
(`internal/beads/bdstore_ready_projection.go:139`). The capability gate
`bdReadyProjectionEnabled()` only ever asked bd its **version**
(`bdReadyProjectionMinVersion = "1.0.5"`).

maintainer-city is the one city whose work class lives on hosted Postgres. bd
serves Postgres embedded, where `bd sql` is not implemented:

```
Error: 'bd sql' is not yet supported in embedded mode      (exit 1, after 6-16s)
```

bd is 1.1.0, so the version gate passed, the failure was never latched, and it
retried on every cycle forever. The enrichment error folded into
`primePartialErr`, which nothing but a clean prime clears, so
`cachedReadyCompleteOnly`'s gate (`caching_store_handles.go:252`) declined every
cache-only read for the life of the process. Measured: reconcile at **24s**
(other rigs 8-50ms), every read falling back to a live 5-6s `bd` subprocess, the
controller tick starved, the order loop dead (`dolt-health` fired twice in 6h
against a 30s interval), 6h of events = 3 beads created / 2 closed against
25,271 `bead.updated` reconcile churn, 108 ready city beads with 0 routed, and
`partial: true` + `bead cache unavailable` on the city and all five rigs. It
survived a supervisor restart.

`isBdSQLUnsupportedInEmbeddedMode` already existed (`bdstore.go:1443`) wired to
exactly one call site — the claim-release path (#5126). The projection, the last
surviving `bd sql` read call site on `main`, referenced it zero times.

## Shape chosen: **both (b) then (a)**

**(b) Backend capability gate — the design fix.** `bd sql` is a raw-database
escape hatch and bd refuses it unless it holds a SQL session; that is a property
of the BACKEND, not the release. gc already has a composition root naming the
backends this build *implements* — reads their metadata shape, projects their
environment, manages their runtime: `contract.RegisteredBackends()` = `dolt`,
`doltlite`, unset. A scope served through the linked beads library under any
other name (maintainer-city's `"backend": "postgres"`) is one gc knows nothing
about, so assuming its `bd sql` works — and that its schema carries gc's
`issues`/`wisps` projection — is the guess. Withholding is the honest default.
This is determinable without guessing, so (b) is preferred, and it costs the
city store **zero** subprocesses.

**(a) Runtime latch — belt and braces, and load-bearing here.**
maintainer-city's rig scopes still declare `backend: dolt` in their own
`metadata.json` while bd opens them elsewhere, so the gate is inert for them.
bd's own refusal now disables the projection for the SCOPE (not the store
object — see MAJOR 2 below), bounding those scopes to exactly one failed call
each per process instead of one per cycle forever.
Metadata gc cannot read falls through to the latch too, so the gate never
fails closed on a parse error.

## The degrade is named, and it costs readiness — stated honestly

`ErrReadyProjectionUnsupported` is a **degrade**, not a partial result, because
it costs the snapshot exactly **one column**, not rows. What it costs
**readiness** is a separate question, and the first revision of this PR got that
answer wrong (see "Review fixes" below).

- `applyReadyProjection` records the cause on the problem log (so `LastProblem`
  reads `... 'bd sql' is not yet supported in embedded mode`) and returns the
  rows, instead of poisoning `primePartialErr`. A *transient* projection failure
  still marks the snapshot partial — only the structural verdict degrades.
- `List` / `Get` / `DepList` keep being served from cache. That is the outage
  fix: `primePartialErr` is what sent every cache-only read to a live 5-6s `bd`
  subprocess for the life of the process.
- **Readiness reads decline the cache and take bd's own verdict live.** The
  cache latches `readyProjectionDegraded`, consulted by `Ready`, `CachedReady`,
  `cachedReadyCompleteOnly` and `cachedReadyLocked`.
- One operator notice per **scope**, naming the reason and the real consequence,
  through the existing `WithBdStoreNoticeSink` seam.

Operators stop seeing `partial: true` / `bead cache unavailable` on the *list*
paths of this city, because the snapshot is no longer partial — the cause
travels on the problem log instead of being inferred from a bare
`ErrCacheUnavailable`.

## Review fixes (two confirmed MAJORs)

**MAJOR 1 — the degrade must not make the cache authoritative for readiness.**
Swallowing the error kept `primePartialErr` nil, and that flag is exactly what
used to route ready reads to the live store (`CachingStore.Ready` →
`c.backing.Ready(...)`, a live `bd ready` carrying bd's verdict). With it nil,
the cache served instead, using `cachedBeadReady` with `IsBlocked == nil` — a
predicate that consults only `readyBlockingDependencyTypes`
(blocks / waits-for / conditional-blocks). bd's `is_blocked` is strictly
stronger: migration `0046_add_is_blocked.up.sql` propagates blocked-ness
**transitively down parent-child edges** (its `reachable` CTE joins
`d.type='parent-child'`), and `bd ready` filters `is_blocked = 0`. bd's Issue
JSON carries no `is_blocked` field, so `bd sql` is gc's only source — with the
projection off, every bead on that store fell to the weaker predicate, and
`cmd/gc/dispatch_control_ready.go`'s per-tick scan reads exactly that handle.
That re-opened #3218 (`d414f7f1ac`), permanently and latched.

Shape chosen: **(c) a distinct cache flag**. `readyProjectionDegraded` is set by
`applyReadyProjection` and consulted only by the four readiness readers, so the
reads that actually depend on `is_blocked` decline to the live backing while
`List`/`Get`/`DepList` keep serving from cache. It keeps the outage fixed (no
per-cycle 6-16s `bd sql`, no poisoned `primePartialErr` for non-ready reads)
without making the cache authoritative for readiness.

Not (a) — teaching `cachedBeadReady` parent-child transitivity: the
direct-deps-only model is gc's standing behaviour for its NATIVE stores too
(`sqliteReadySQL`, `doltliteReadyIssueWhere`, Mem/File), so changing it there is
a larger semantic change and out of scope here. Not (b) — keeping *all* ready
readers on live `backing.Ready()`: acceptable but strictly slower than (c) for
the readers that do not depend on the column.

**MAJOR 2 — the notice was bounded per BdStore OBJECT, not per scope.** The
control-ready path rebuilds the store every `controlReadyCacheTTL` (3s) per
scope, so "once" degraded to "once per rebuild" — the exact defect #5180 fixed
for the unread-store notice. Fixed the same way and with the same pattern: a
package-level `sync.Map` keyed by `filepath.Clean(dir)` holding the latched
verdict plus an atomic `announced` flag, consulted by
`bdReadyProjectionEnabled`. Both guards now share `scopeGuardKey`. The verdict
is still *reported* to every rebuilt store — each one backs a fresh cache that
must learn to send readiness live — but the notice and the failing `bd sql` are
spent once per scope.

**And the claim.** The operator line no longer says "no work is lost" or "cached
ready falls back to dependency-derived readiness". It now reads:

```
gc: ready-projection enrichment disabled for <dir>: <cause>
gc: ready reads on this scope answer from a live `bd ready` instead of the
cache; other cached reads keep serving and no further bd sql is spent.
```

The old wording was literally true and named the wrong risk: the degraded
predicate errs **permissive** — it would OFFER work whose gate has not opened —
which for a dispatcher is worse than hiding work.

## Also fixed: the masked error

bd prints its `BD_OTEL_*` deprecation warning during startup, **before** the
command runs, so on a bd that both nags and fails, stderr line 1 is the nag and
the line saying what broke is line 2. gc's wrapping does not truncate — it
composed `strings.TrimSpace(stderr)` verbatim — but every single-line render of
the wrapped error (the cache problem tile, `gc status`, a journal grep) then
showed the telemetry warning where it used to show the real cause. That is gc's
composition, so it is fixed here: `bdFailureDetail` leads with bd's own
`Error:`/`Hint:` lines (`cmd/bd/errors.go`) and keeps everything else verbatim,
in order, after them. Nothing is dropped, and it also keeps
`isBdSQLUnsupportedInEmbeddedMode` able to classify the wrapped error.


## Tests

Red before the fix (both revisions):

```
bdstore_ready_projection_capability_internal_test.go:76: first enrich error =
  bd sql ready projection: exit status 1: Error: 'bd sql' is not yet supported
  in embedded mode, want ErrReadyProjectionUnsupported

caching_store_ready_projection_internal_test.go:57: primePartialErr = bd sql
  ready projection: ... want nil: an unsupported projection must not make the
  cache permanently unavailable

bdstore_failure_detail_internal_test.go:36: first line of the wrapped error =
  "exit status 1: warning: BD_OTEL_* environment variables are deprecated. ...",
  want bd's actionable Error: line
```

Red before the review fixes:

```
# MAJOR 1 (read sites no longer consult the degrade latch):
caching_store_ready_projection_internal_test.go:217: Ready = [gc-1 gc-3 gc-4],
  want [gc-1 gc-4]: the transitively blocked child gc-3 must not be offered as
  ready

# MAJOR 2 (verdict memoized per store object instead of per scope):
bdstore_ready_projection_capability_internal_test.go:195: operator notice
  printed 5 times across 5 stores over one scope, want exactly 1
bdstore_ready_projection_capability_internal_test.go:211: bd sql ran 5 times
  across 5 stores over one scope; the latch must survive the rebuild
```

`TestDegradedProjectionSendsReadyToTheLiveBdVerdict` is the council's
transitive-block experiment, defeated: `blocker <- blocks - parent <-
parent-child - child`, over a backing store that answers `Ready` the way `bd
ready` does. On the degraded cache, `Ready()` returns `[blocker unrelated]`
(one live backing call), `CachedReady()` is `ok=false`, `ReadyContext` and the
cached-reader `Ready` return `ErrCacheUnavailable` — while `CachedList` still
serves all four rows with zero backing traffic.
`TestHealthyProjectionStillAnswersReadyFromCache` is the control: with the
column present, the same fixture is answered from cache with no live call.

`TestReadyProjectionVerdictIsPerScopeAcrossStoreRebuilds` builds five fresh
`BdStore`s over one scope dir, on both the gate path and the runtime-latch
path: one notice, and — on the latch path — one `bd sql`, total.
`TestReadyProjectionNoticeDoesNotClaimReadinessIsUnaffected` pins the corrected
wording.

Once-only proof (`TestReadyProjectionLatchesOnTheEmbeddedModeRefusal`): five
enrichments, `bd sql` runs exactly once, one notice; every later enrichment
still *names* the degrade, because that error is how each cache over the scope
learns to send readiness live.

Byte-identity for the five Dolt cities
(`TestReadyProjectionOnAnImplementedBackendIsUnchanged`, over
`backend=dolt|doltlite|""`): the exact same two invocations, in the same order,
and the rows come back enriched. Mutation proof: making the gate fire for every
backend turns all three subtests red. `NativeDoltStore` does not implement the
enrichment interface at all, so `applyReadyProjection` returns on its first
branch, unchanged. Two further mutations pin the degrade branch: removing
`errors.Is(err, ErrReadyProjectionUnsupported)` reds the degrade test; making
everything degrade reds the transient-failure control.

`internal/beads/splittest` does not fit here — its leaves model write-time
*store semantics* (bd/Dolt vs SQLite residence rules) over a `beads.Store`, and
this defect lives in `BdStore`'s **subprocess** result. A Postgres-backed
`BdStore` has no splittest leaf and would need one that models a `CommandRunner`
verdict, which is a different kit. The `recordingRunner` already in
`internal/beads` is the right fixture and is what these tests use.

## Gates

`go build ./...`, `go vet ./...`, `gofmt -l` clean, `golangci-lint run ./...`
**0 issues**, `go test ./internal/beads/...`, `go test ./cmd/gc -timeout 25m`
serial (`ok 709.084s`), `go test ./internal/...` (144 packages ok, exit 0),
`scripts/check-core-boundary.sh` OK, `make check-split-topology-rows` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)