### PR TITLE
fix(beads): stop version_compat failing a comparison it cannot make (ga-40qh1)

### DIFF
--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -7,6 +7,9 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
@@ -41,6 +44,11 @@ type PreflightChecker struct {
 	// BeadsLibraryVersion is the linked github.com/steveyegge/beads module
 	// version. Empty means infer it from build info.
 	BeadsLibraryVersion string
+	// BeadsLibraryReplaced reports whether a go.mod replace directive supplied
+	// the linked beads library, in which case its version identifies the
+	// replacement rather than a beads release. Set together with
+	// BeadsLibraryVersion; leaving both zero infers them from build info.
+	BeadsLibraryReplaced bool
 }
 
 // Check runs the beads backend preflight for scope and returns typed diagnostics.
@@ -234,10 +242,8 @@ func (c PreflightChecker) checkIdentityMatch(scope string, metadata preflightMet
 }
 
 func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) PreflightCheckResult {
-	libraryVersion := strings.TrimPrefix(strings.TrimSpace(c.BeadsLibraryVersion), "v")
-	if libraryVersion == "" {
-		libraryVersion = strings.TrimPrefix(beadsModuleVersion(), "v")
-	}
+	library := c.linkedBeadsLibrary()
+	libraryVersion := strings.TrimPrefix(library.Version, "v")
 	details := PreflightDetails{
 		BDVersion:           ctx.BDVersion,
 		BeadsLibraryVersion: libraryVersion,
@@ -255,14 +261,16 @@ func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) 
 	if ctx.BDVersion == "" {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckWarn, "bd/beads version compatibility could not be confirmed", details)
 	}
-	if libraryVersion == "" || libraryVersion == "(devel)" {
-		// A local-path/replace (source) build of the linked beads library
-		// reports no module version ("(devel)") even though gc and bd are
-		// built from the same source. The schema version is validated above
-		// and is the real compatibility signal, so an unconfirmable library
-		// version must not take the native store offline — only a *confirmed*
-		// mismatch (below) should.
-		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckPass, "bd/beads schema compatible; linked library version unconfirmed (source build)", details)
+	if reason := library.unconfirmableReason(); reason != "" {
+		// The compare below only means something when both sides name the same
+		// released beads artifact. When the linked library does not — a source
+		// build, a replaced module, or a pseudo-version naming an untagged
+		// commit — the two strings can never be equal, and answering "mismatch"
+		// reports a verdict the check never had the evidence to reach. The
+		// schema version is validated above and is the real compatibility
+		// signal, so an unconfirmable library version must not take the native
+		// store offline; only a *confirmed* mismatch (below) should.
+		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckPass, "bd/beads schema compatible; linked library version unconfirmed ("+reason+")", details)
 	}
 	if strings.TrimPrefix(ctx.BDVersion, "v") != libraryVersion {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd version differs from linked beads library version", details)
@@ -296,20 +304,77 @@ func preflightFallbackReason(checks []PreflightCheckResult) string {
 	return ""
 }
 
-func beadsModuleVersion() string {
+// beadsModulePath is the module path of the beads library gc links.
+const beadsModulePath = "github.com/steveyegge/beads"
+
+// linkedBeadsLibrary resolves the beads library this binary links, preferring
+// the configured override so tests need not depend on their own build info.
+func (c PreflightChecker) linkedBeadsLibrary() beadsLibrary {
+	if version := strings.TrimSpace(c.BeadsLibraryVersion); version != "" || c.BeadsLibraryReplaced {
+		return beadsLibrary{Version: version, Replaced: c.BeadsLibraryReplaced}
+	}
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
+		return beadsLibrary{}
+	}
+	return linkedBeadsLibraryFrom(info)
+}
+
+// beadsLibrary describes the beads library a binary actually links.
+type beadsLibrary struct {
+	// Version is the module version recorded in build info, empty when unknown.
+	Version string
+	// Replaced reports whether a go.mod replace directive supplied the code.
+	// A replacement's version numbers belong to the replacement, not to beads,
+	// so they say nothing about which bd release the library agrees with.
+	Replaced bool
+}
+
+// unconfirmableReason names why the library version cannot be compared to a bd
+// release version, or returns "" when the comparison is meaningful.
+func (b beadsLibrary) unconfirmableReason() string {
+	version := strings.TrimPrefix(strings.TrimSpace(b.Version), "v")
+	switch {
+	case version == "" || version == "(devel)":
+		// A source build reports "(devel)" (or nothing) even though gc and bd
+		// are built from the same tree.
+		return "source build"
+	case b.Replaced:
+		return "replaced module"
+	case !comparableReleaseVersion(version):
+		// A pseudo-version names an untagged commit, not a release. gc pins
+		// beads at one whenever it tracks beads ahead of its last tag.
+		return "pseudo-version"
+	default:
 		return ""
 	}
-	for _, dep := range info.Deps {
-		if dep.Path == "github.com/steveyegge/beads" {
-			if dep.Replace != nil && dep.Replace.Version != "" {
-				return dep.Replace.Version
-			}
-			return dep.Version
-		}
+}
+
+// comparableReleaseVersion reports whether version names a released beads
+// artifact, and can therefore be compared with the version bd reports for
+// itself. Pseudo-versions and non-semver strings cannot.
+func comparableReleaseVersion(version string) bool {
+	canonical := "v" + strings.TrimPrefix(strings.TrimSpace(version), "v")
+	return semver.IsValid(canonical) && !module.IsPseudoVersion(canonical)
+}
+
+// linkedBeadsLibraryFrom extracts the linked beads library from build info.
+func linkedBeadsLibraryFrom(info *debug.BuildInfo) beadsLibrary {
+	if info == nil {
+		return beadsLibrary{}
 	}
-	return ""
+	for _, dep := range info.Deps {
+		if dep == nil || dep.Path != beadsModulePath {
+			continue
+		}
+		if dep.Replace != nil {
+			// Report the replacement's own version — including the empty one a
+			// local-path replace records — never the require line it displaced.
+			return beadsLibrary{Version: dep.Replace.Version, Replaced: true}
+		}
+		return beadsLibrary{Version: dep.Version}
+	}
+	return beadsLibrary{}
 }
 
 type preflightMetadata struct {

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -486,23 +487,227 @@ func TestCheckVersionCompatSourceBuild(t *testing.T) {
 	tests := []struct {
 		name       string
 		libVersion string
+		replaced   bool
 		ctx        PreflightBDContext
 		want       PreflightCheckState
 	}{
-		{"source build reports (devel) — schema is the signal, pass", "(devel)", validCtx("1.0.5"), PreflightCheckPass},
-		{"confirmed version mismatch still fails", "1.0.5", validCtx("1.0.4"), PreflightCheckFail},
-		{"matching versions pass", "1.0.5", validCtx("1.0.5"), PreflightCheckPass},
-		{"missing bd version is unconfirmable — warn", "1.0.5", validCtx(""), PreflightCheckWarn},
+		{"source build reports (devel) — schema is the signal, pass", "(devel)", false, validCtx("1.0.5"), PreflightCheckPass},
+		{"confirmed version mismatch still fails", "1.0.5", false, validCtx("1.0.4"), PreflightCheckFail},
+		{"matching versions pass", "1.0.5", false, validCtx("1.0.5"), PreflightCheckPass},
+		{"missing bd version is unconfirmable — warn", "1.0.5", false, validCtx(""), PreflightCheckWarn},
+
+		// The live defect (ga-40qh1). This fork replaces the beads module with
+		// the enterprise build, so the linked module reports the replacement's
+		// pseudo-version while bd reports its release. Those two strings can
+		// never be equal, so the compare answered "mismatch" for a question it
+		// was never able to ask.
+		{"enterprise replacement pseudo-version vs bd release — unknown, pass", "0.0.0-20260810084121-1aa7bf160786", true, validCtx("1.1.0"), PreflightCheckPass},
+		// Same shape without a replace: origin/main pins beads at an untagged
+		// commit, so even the unreplaced OSS build reports a pseudo-version.
+		{"pseudo-version without a replace — unknown, pass", "1.1.1-0.20260805093327-bf97b73749ac", false, validCtx("1.1.0"), PreflightCheckPass},
+		// A replacement module may carry a real tag. Its numbering belongs to a
+		// different module, so it is still not comparable to bd's release.
+		{"tagged replacement module — unknown, pass", "2.4.0", true, validCtx("1.1.0"), PreflightCheckPass},
+		// A local-path replace records no version at all.
+		{"replaced with no recorded version — unknown, pass", "", true, validCtx("1.1.0"), PreflightCheckPass},
+
+		// The other direction: an unreplaced release pair that genuinely
+		// disagrees must still fail, including against the live bd version.
+		{"unreplaced release skew still fails", "1.1.1", false, validCtx("1.1.0"), PreflightCheckFail},
+		{"unreplaced exact match still passes", "1.1.0", false, validCtx("1.1.0"), PreflightCheckPass},
+		{"v-prefixed unreplaced release skew still fails", "v1.2.0", false, validCtx("v1.1.0"), PreflightCheckFail},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := PreflightChecker{BeadsLibraryVersion: tt.libVersion}
+			c := PreflightChecker{BeadsLibraryVersion: tt.libVersion, BeadsLibraryReplaced: tt.replaced}
 			got := c.checkVersionCompat(tt.ctx, nil)
 			if got.ID != PreflightCheckVersionCompat {
 				t.Fatalf("ID = %q, want %q", got.ID, PreflightCheckVersionCompat)
 			}
 			if got.State != tt.want {
 				t.Fatalf("state = %q, want %q (summary: %q)", got.State, tt.want, got.Summary)
+			}
+		})
+	}
+}
+
+// TestCheckVersionCompatSummariesAreStableWhereItAlreadyPassed pins the exact
+// wording of every outcome that existed before ga-40qh1. Widening the "unknown"
+// set must be invisible to the scopes the check already answered — a summary
+// drift here would change `gc doctor` output and the recorded fallback reason
+// for scopes that were never broken.
+func TestCheckVersionCompatSummariesAreStableWhereItAlreadyPassed(t *testing.T) {
+	validCtx := func(bdVersion string) PreflightBDContext {
+		return PreflightBDContext{Backend: "dolt", DoltMode: "server", BDVersion: bdVersion, SchemaVersion: 50}
+	}
+	tests := []struct {
+		name       string
+		libVersion string
+		ctx        PreflightBDContext
+		err        error
+		want       string
+	}{
+		{"unreachable bd context", "1.0.5", PreflightBDContext{}, errors.New("not a git repository"), "bd context is unreachable; cannot confirm bd/beads version compatibility"},
+		{"no schema version", "1.0.5", PreflightBDContext{BDVersion: "1.0.5"}, nil, "bd context did not report a schema version"},
+		{"missing bd version", "1.0.5", validCtx(""), nil, "bd/beads version compatibility could not be confirmed"},
+		{"source build", "(devel)", validCtx("1.0.5"), nil, "bd/beads schema compatible; linked library version unconfirmed (source build)"},
+		{"matching releases", "1.0.5", validCtx("1.0.5"), nil, "bd and linked beads library versions match"},
+		{"confirmed mismatch", "1.0.5", validCtx("1.0.4"), nil, "bd version differs from linked beads library version"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := PreflightChecker{BeadsLibraryVersion: tt.libVersion}
+			if got := c.checkVersionCompat(tt.ctx, tt.err); got.Summary != tt.want {
+				t.Fatalf("summary = %q, want %q", got.Summary, tt.want)
+			}
+		})
+	}
+}
+
+// TestPreflightEligibleOnReplacedBeadsModuleWithReadableBDContext is the live
+// shape from ga-40qh1: a rig scope IS a git repo, so `bd context` succeeds and
+// every check can actually run. Before the fix the version compare was the only
+// FAIL, and it fired for a question it could not ask — dropping a healthy scope
+// to BdStore, where listIncludesCompleteDependencies() is hardcoded false and
+// complete-ready cache reads are permanently declined.
+func TestPreflightEligibleOnReplacedBeadsModuleWithReadableBDContext(t *testing.T) {
+	scope := "/city/rigs/gascity"
+	fs := fsys.NewFake()
+	fs.Dirs[filepath.Join(scope, ".beads")] = true
+	fs.Files[filepath.Join(scope, ".beads", "metadata.json")] = []byte(`{
+		"backend": "dolt",
+		"dolt_mode": "server",
+		"dolt_database": "gascity",
+		"project_id": "gc-local"
+	}`)
+	checker := PreflightChecker{
+		FS:                   fs,
+		Provider:             "bd",
+		BeadsLibraryVersion:  "0.0.0-20260810084121-1aa7bf160786",
+		BeadsLibraryReplaced: true,
+		BDContext: func(string) (PreflightBDContext, error) {
+			return PreflightBDContext{Backend: "dolt", DoltMode: "server", BDVersion: "1.1.0", SchemaVersion: 1}, nil
+		},
+		DatabaseProjectID: func(string) (string, bool, error) {
+			return "gc-local", true, nil
+		},
+	}
+
+	result, err := checker.Check(scope)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	assertPreflightVerdict(t, result, PreflightVerdictEligible, true)
+	assertCheckState(t, result, PreflightCheckVersionCompat, PreflightCheckPass)
+	// Eligibility here is earned by every check passing, not by the
+	// unreachable-bd-context upgrade — bd context was readable.
+	if result.NativeEligibleViaIdentityFallback {
+		t.Errorf("NativeEligibleViaIdentityFallback = true, want false when bd context is readable")
+	}
+	if result.Fallback != "" {
+		t.Errorf("Fallback = %q, want empty for an eligible scope", result.Fallback)
+	}
+}
+
+// TestPreflightBlocksOnRealVersionSkew is the other direction: with no replace
+// and two comparable releases that disagree, the check must still block the
+// native store. Widening "unknown" must not widen "compatible".
+func TestPreflightBlocksOnRealVersionSkew(t *testing.T) {
+	scope := "/city/rigs/gascity"
+	fs := fsys.NewFake()
+	fs.Dirs[filepath.Join(scope, ".beads")] = true
+	fs.Files[filepath.Join(scope, ".beads", "metadata.json")] = []byte(`{
+		"backend": "dolt",
+		"dolt_mode": "server",
+		"dolt_database": "gascity",
+		"project_id": "gc-local"
+	}`)
+	checker := PreflightChecker{
+		FS:                  fs,
+		Provider:            "bd",
+		BeadsLibraryVersion: "1.2.0",
+		BDContext: func(string) (PreflightBDContext, error) {
+			return PreflightBDContext{Backend: "dolt", DoltMode: "server", BDVersion: "1.1.0", SchemaVersion: 1}, nil
+		},
+		DatabaseProjectID: func(string) (string, bool, error) {
+			return "gc-local", true, nil
+		},
+	}
+
+	result, err := checker.Check(scope)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	assertPreflightVerdict(t, result, PreflightVerdictBlocked, false)
+	assertCheckState(t, result, PreflightCheckVersionCompat, PreflightCheckFail)
+	if result.Fallback != PreflightFallbackBdStore {
+		t.Errorf("Fallback = %q, want %q", result.Fallback, PreflightFallbackBdStore)
+	}
+}
+
+// TestLinkedBeadsLibraryFromBuildInfo covers the build-info reader that feeds
+// checkVersionCompat in production. A replace directive — of either form — means
+// the recorded version does not describe the code that is actually linked.
+func TestLinkedBeadsLibraryFromBuildInfo(t *testing.T) {
+	dep := func(version string, replace *debug.Module) *debug.BuildInfo {
+		return &debug.BuildInfo{Deps: []*debug.Module{
+			{Path: "github.com/spf13/cobra", Version: "v1.10.2"},
+			{Path: beadsModulePath, Version: version, Replace: replace},
+		}}
+	}
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		want beadsLibrary
+	}{
+		{"nil build info", nil, beadsLibrary{}},
+		{"beads is not linked", &debug.BuildInfo{Deps: []*debug.Module{{Path: "github.com/spf13/cobra", Version: "v1.10.2"}}}, beadsLibrary{}},
+		{"plain require", dep("v1.1.0", nil), beadsLibrary{Version: "v1.1.0"}},
+		{
+			"module replace records the replacement's version",
+			dep("v1.1.1-0.20260805093327-bf97b73749ac", &debug.Module{Path: "github.com/gascity/bd-enterprise", Version: "v0.0.0-20260810084121-1aa7bf160786"}),
+			beadsLibrary{Version: "v0.0.0-20260810084121-1aa7bf160786", Replaced: true},
+		},
+		{
+			"local-path replace records no version",
+			dep("v1.1.0", &debug.Module{Path: "../beads"}),
+			beadsLibrary{Replaced: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := linkedBeadsLibraryFrom(tt.info); got != tt.want {
+				t.Fatalf("linkedBeadsLibraryFrom() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComparableReleaseVersion pins the classifier that decides whether the two
+// reported versions name the same kind of thing. Only a released semver tag can
+// be compared to bd's self-reported release.
+func TestComparableReleaseVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"", false},
+		{"(devel)", false},
+		{"devel", false},
+		{"unknown", false},
+		{"1.1.0", true},
+		{"v1.1.0", true},
+		{"1.1.0-rc.1", true},
+		{"0.0.0-20260810084121-1aa7bf160786", false},
+		{"1.1.1-0.20260805093327-bf97b73749ac", false},
+		{"1.2.0-pre.0.20260805093327-bf97b73749ac", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := comparableReleaseVersion(tt.version); got != tt.want {
+				t.Fatalf("comparableReleaseVersion(%q) = %v, want %v", tt.version, got, tt.want)
 			}
 		})
 	}

--- a/internal/beads/native_dolt_store_ready_projection.go
+++ b/internal/beads/native_dolt_store_ready_projection.go
@@ -1,0 +1,113 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// NativeDoltStore hands readiness to the cache — listIncludesCompleteDependencies
+// reports true, which latches depsComplete — so it must also supply the column
+// that makes the cache's answer equal its own. Losing this method silently
+// reverts readiness to the weaker dependency-derived predicate, so pin it.
+var _ readyProjectionEnrichmentStore = (*NativeDoltStore)(nil)
+
+// enrichReadyProjectionForCache fills bd's denormalized is_blocked column onto
+// items so a cache over this store answers readiness with the same predicate
+// the store's own Ready() uses.
+//
+// It is not an optimization; it is what makes the cache's answer EQUAL the
+// backing's. NativeDoltStore.listIncludesCompleteDependencies reports true, so
+// a CachingStore over it latches depsComplete and serves readiness itself. With
+// the column absent every Bead.IsBlocked is nil — beadFromNativeIssue cannot
+// set it, because beadslib's types.Issue carries no is_blocked field — and
+// cachedBeadReady then derives readiness from the bead's OWN direct
+// blocks/waits-for/conditional-blocks deps. That fallback is weaker than the
+// column in two ways that matter to gascity, which creates parent-child edges
+// pervasively:
+//
+//   - is_blocked propagates transitively DOWN parent-child edges
+//     (issueops.markBlockedTemplateForIssues joins `d.type = 'parent-child' AND
+//     p.is_blocked = 1`), so a child of a blocked parent carries no blocking
+//     edge of its own and reads ready to the fallback.
+//   - cachedBeadReady treats a dep as blocking only when the target's status is
+//     resident in the same cache, so an edge onto another store's row — a
+//     relocated `gcg-` graph bead — is invisible to it.
+//
+// GetReadyWork filters `is_blocked = 0` (sqlbuild.ReadyWhere), so either gap
+// offers the control dispatcher a step whose gate has not opened, the
+// regression #3218 closed.
+//
+// The read is one batched IsBlockedBatch over the active set — the same
+// SELECT id, is_blocked FROM {issues,wisps} WHERE id IN (...) that BdStore
+// spends a `bd sql` subprocess on — issued in-process on the store's existing
+// connection and inside withReadRetry, so it recovers from a managed-Dolt
+// rebind like every other native read.
+//
+// A storage that cannot answer the column at all reports
+// ErrReadyProjectionUnsupported rather than a silently weaker cache: the
+// CachingStore then latches its degrade, declines every readiness handle, and
+// takes the backing's own Ready. Slower, and correct. The core beadslib.Storage
+// interface does not declare IsBlockedBatch (only DoltStorage composes
+// DependencyQueryStore), so this is a real branch, not a defensive one.
+func (s *NativeDoltStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
+	if len(items) == 0 {
+		return items, nil
+	}
+	ids := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		// Same exclusions as the bd path: message and nudge rows are
+		// notifications rather than dependency-blocked work, and stamping them
+		// makes the CachingStore reconciler re-emit bead.updated every cycle.
+		// Leaving their IsBlocked nil keeps the reconcile diff convergent.
+		if skipBDReadyProjectionEnrichment(item) {
+			continue
+		}
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+		ids = append(ids, item.ID)
+	}
+	if len(ids) == 0 {
+		return items, nil
+	}
+
+	var projection map[string]bool
+	err := s.withReadRetry(func(ctx context.Context, storage beadslib.Storage) error {
+		querier, ok := beadslib.AsBlockedQuerier(storage)
+		if !ok {
+			return fmt.Errorf("native ready projection: %w: storage %T does not expose beads.BlockedQuerier",
+				ErrReadyProjectionUnsupported, storage)
+		}
+		blocked, err := querier.IsBlockedBatch(ctx, ids)
+		if err != nil {
+			return fmt.Errorf("native ready projection: %w", err)
+		}
+		projection = blocked
+		return nil
+	})
+	if err != nil {
+		return items, err
+	}
+
+	enriched := make([]Bead, len(items))
+	copy(enriched, items)
+	for i := range enriched {
+		if skipBDReadyProjectionEnrichment(enriched[i]) {
+			continue
+		}
+		blocked, ok := projection[enriched[i].ID]
+		if !ok {
+			// ids present in neither the issues nor the wisps table are absent
+			// from the map. A row this store listed and then could not find is
+			// one that raced out of the ledger; leave its last value rather
+			// than inventing a verdict, matching the bd path exactly.
+			continue
+		}
+		enriched[i].IsBlocked = cloneBoolPtr(&blocked)
+	}
+	return enriched, nil
+}

--- a/internal/beads/native_dolt_store_ready_projection_internal_test.go
+++ b/internal/beads/native_dolt_store_ready_projection_internal_test.go
@@ -1,0 +1,360 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// nativeBlockedColumnStorage is a native beadslib backing that carries the one
+// thing a MemStore cannot: bd's denormalized, TRANSITIVE is_blocked column.
+//
+// The real Dolt storage maintains that column down parent-child edges
+// (issueops.markBlockedTemplateForIssues joins `d.type = 'parent-child' AND
+// p.is_blocked = 1`), GetReadyWork filters on it (sqlbuild.ReadyWhere emits
+// `is_blocked = 0`), and BlockedQuerier.IsBlockedBatch reads it back. blocked
+// stands in for the stored column, so both reads here answer from the same
+// place the live ledger does and cannot drift apart inside the fixture.
+type nativeBlockedColumnStorage struct {
+	*nativeDoltMemStorage
+	blocked map[string]bool
+
+	mu         sync.Mutex
+	batchCalls int
+	batchedIDs int
+}
+
+// IsBlocked mirrors the stored column for one id.
+func (s *nativeBlockedColumnStorage) IsBlocked(_ context.Context, id string) (bool, []string, error) {
+	return s.blocked[id], nil, nil
+}
+
+// IsBlockedBatch mirrors issueops.IsBlockedBatchInTx: one read over the stored
+// column, with ids absent from both tables absent from the map.
+func (s *nativeBlockedColumnStorage) IsBlockedBatch(_ context.Context, ids []string) (map[string]bool, error) {
+	s.mu.Lock()
+	s.batchCalls++
+	s.batchedIDs += len(ids)
+	s.mu.Unlock()
+	rows := s.rows()
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if _, resident := rows[id]; !resident {
+			continue
+		}
+		out[id] = s.blocked[id]
+	}
+	return out, nil
+}
+
+// rows is the fixture's stand-in for "the id exists in issues or wisps". The
+// MemStore scan behind it cannot fail; a nil map would simply enrich nothing
+// and fail the assertions loudly.
+func (s *nativeBlockedColumnStorage) rows() map[string]Bead {
+	beads, err := s.store.List(ListQuery{AllowScan: true, IncludeClosed: true, TierMode: TierBoth})
+	if err != nil {
+		return nil
+	}
+	rows := make(map[string]Bead, len(beads))
+	for _, b := range beads {
+		rows[b.ID] = b
+	}
+	return rows
+}
+
+// GetReadyWork answers the way bd's does: open rows whose stored is_blocked is
+// 0. It deliberately does NOT re-derive blocked-ness from the edges, because
+// the whole point of the column is that it already carries the transitive
+// answer the edge walk cannot reach.
+func (s *nativeBlockedColumnStorage) GetReadyWork(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+	beads, err := s.store.List(ListQuery{AllowScan: true, Status: string(beadslib.StatusOpen), TierMode: TierBoth})
+	if err != nil {
+		return nil, err
+	}
+	ready := make([]Bead, 0, len(beads))
+	for _, bead := range beads {
+		if !filter.IncludeEphemeral && bead.Ephemeral {
+			continue
+		}
+		if filter.Assignee != nil && bead.Assignee != *filter.Assignee {
+			continue
+		}
+		if s.blocked[bead.ID] {
+			continue
+		}
+		ready = append(ready, bead)
+	}
+	return nativeIssuesFromBeads(ready)
+}
+
+func (s *nativeBlockedColumnStorage) counts() (calls, ids int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.batchCalls, s.batchedIDs
+}
+
+// nativeReadyDisagreementFixture builds the two shapes where a cache's own
+// dependency-derived readiness predicate and a native backing's is_blocked
+// column disagree, primes a cache over the native store, and returns both.
+//
+//	blocker (open) <-- blocks -- parent <-- parent-child -- child
+//	gcg-offscope (not in this scope) <-- blocks -- xstore
+//
+// child carries no blocking dep of its own, so cachedBeadReady calls it ready
+// while bd marks it is_blocked=1 through the parent-child edge. xstore carries
+// one, but its target is not resident in this scope's cache, and cachedBeadReady
+// treats a dep as blocking only when statusByID holds the target — so that edge
+// is invisible to it too. unrelated is the control both models call ready.
+func nativeReadyDisagreementFixture(t *testing.T) (*CachingStore, *NativeDoltStore, *nativeBlockedColumnStorage, map[string]string) {
+	t.Helper()
+	storage := &nativeBlockedColumnStorage{nativeDoltMemStorage: newNativeDoltMemStorage(), blocked: map[string]bool{}}
+	native := newNativeDoltStoreForTest(storage)
+
+	ids := map[string]string{}
+	for _, title := range []string{"blocker", "parent", "child", "xstore", "unrelated"} {
+		b, err := native.Create(Bead{Type: "task", Status: "open", Title: title})
+		if err != nil {
+			t.Fatalf("Create %s: %v", title, err)
+		}
+		ids[title] = b.ID
+	}
+	if err := storage.store.DepAdd(ids["parent"], ids["blocker"], "blocks"); err != nil {
+		t.Fatalf("DepAdd blocks: %v", err)
+	}
+	if err := storage.store.DepAdd(ids["child"], ids["parent"], "parent-child"); err != nil {
+		t.Fatalf("DepAdd parent-child: %v", err)
+	}
+	// The relocated graph class lives in another store, so its row is never
+	// primed into this scope's cache even though the edge is.
+	if err := storage.store.DepAdd(ids["xstore"], "gcg-offscope", "blocks"); err != nil {
+		t.Fatalf("DepAdd cross-store blocks: %v", err)
+	}
+	storage.blocked[ids["parent"]] = true
+	storage.blocked[ids["child"]] = true
+	storage.blocked[ids["xstore"]] = true
+
+	cache := NewCachingStoreForTest(native, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	return cache, native, storage, ids
+}
+
+// TestCachedReadyOverNativeBackingNeverOffersWorkTheBackingHides is the
+// invariant a cache over a native store must satisfy, and the one the rig
+// scopes newly depend on now that preflight lets them reach NativeDoltStore.
+//
+// NativeDoltStore.listIncludesCompleteDependencies reports true, which latches
+// depsComplete on the cache and hands readiness to the cache's own predicate.
+// That predicate reads bd's is_blocked when it is present and falls back to the
+// bead's OWN direct blocks/waits-for/conditional-blocks deps when it is not.
+// The fallback is strictly weaker than the column in two ways this fixture
+// pins: it does not propagate down parent-child, and it ignores an edge whose
+// target is not resident in the same scope. Either gap offers the control
+// dispatcher a step whose gate has not opened — regression #3218.
+func TestCachedReadyOverNativeBackingNeverOffersWorkTheBackingHides(t *testing.T) {
+	cache, native, _, ids := nativeReadyDisagreementFixture(t)
+
+	live, err := native.Ready()
+	if err != nil {
+		t.Fatalf("native Ready: %v", err)
+	}
+	want := sortedIDs(live)
+	if got := wantReadyIDs(ids["blocker"], ids["unrelated"]); !equalIDs(want, got) {
+		t.Fatalf("native Ready = %v, want %v: the fixture must model bd's is_blocked filter", want, got)
+	}
+
+	readers := []struct {
+		name string
+		read func() ([]Bead, error)
+	}{
+		{"Ready", func() ([]Bead, error) { return cache.Ready() }},
+		{"ReadyContext", func() ([]Bead, error) { return cache.ReadyContext(context.Background()) }},
+		{"CachedReady", func() ([]Bead, error) {
+			rows, ok := cache.CachedReady()
+			if !ok {
+				return nil, ErrCacheUnavailable
+			}
+			return rows, nil
+		}},
+		{"Handles().Cached.Ready", func() ([]Bead, error) { return cache.Handles().Cached.Ready() }},
+	}
+	for _, reader := range readers {
+		rows, err := reader.read()
+		if err != nil {
+			// Declining is a correct answer: the caller then takes the live
+			// backing verdict. Answering with MORE than the backing is not.
+			if errors.Is(err, ErrCacheUnavailable) {
+				continue
+			}
+			t.Fatalf("%s: %v", reader.name, err)
+		}
+		got := sortedIDs(rows)
+		if containsID(got, ids["child"]) {
+			t.Errorf("%s offered %s, a child of a blocked parent that the backing's own Ready hides: "+
+				"blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it (backing = %v, cache = %v)",
+				reader.name, ids["child"], want, got)
+		}
+		if containsID(got, ids["xstore"]) {
+			t.Errorf("%s offered %s, whose blocker gcg-offscope is not resident in this scope's cache: "+
+				"cachedBeadReady treats a dep as blocking only when statusByID holds the target (backing = %v, cache = %v)",
+				reader.name, ids["xstore"], want, got)
+		}
+		if extra := idsBeyond(got, want); len(extra) > 0 {
+			t.Errorf("%s returned %v beyond the backing's own Ready (backing = %v)", reader.name, extra, want)
+		}
+	}
+
+	// Declining is the fail-safe, not the fix. The point of filling the column
+	// is that the cache keeps ANSWERING readiness — and answers it exactly the
+	// way the backing does. A store that only ever declined would satisfy the
+	// subset checks above while costing every rig a live read per tick.
+	cached, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady declined: a native backing that can answer is_blocked must keep serving readiness from cache")
+	}
+	if got := sortedIDs(cached); !equalIDs(got, want) {
+		t.Fatalf("CachedReady = %v, want %v (the backing's own verdict)", got, want)
+	}
+}
+
+// TestNativeReadyProjectionIsOneBatchedReadPerCycle pins the cost of filling the
+// column. The enrichment runs on every cache prime and every reconcile of every
+// native scope, so it must stay a single batched read over the active set — the
+// shape IsBlockedBatch exists for — rather than a per-bead fan-out.
+func TestNativeReadyProjectionIsOneBatchedReadPerCycle(t *testing.T) {
+	_, _, storage, ids := nativeReadyDisagreementFixture(t)
+
+	calls, batched := storage.counts()
+	if calls != 1 {
+		t.Fatalf("IsBlockedBatch calls during prime = %d, want 1: the projection must be one batched read, not a fan-out", calls)
+	}
+	if batched != len(ids) {
+		t.Fatalf("IsBlockedBatch received %d ids, want %d: the batch must cover the whole active set", batched, len(ids))
+	}
+}
+
+// nativeProjectionlessStorage is a native backing whose beadslib Storage does
+// not expose BlockedQuerier, so the is_blocked column is unreachable. The core
+// beads.Storage interface does not declare IsBlockedBatch (only DoltStorage
+// composes DependencyQueryStore), so this is a real shape, not a contrivance.
+type nativeProjectionlessStorage struct {
+	*nativeDoltMemStorage
+	blocked map[string]bool
+}
+
+func (s *nativeProjectionlessStorage) GetReadyWork(_ context.Context, filter beadslib.WorkFilter) ([]*beadslib.Issue, error) {
+	beads, err := s.store.List(ListQuery{AllowScan: true, Status: string(beadslib.StatusOpen), TierMode: TierBoth})
+	if err != nil {
+		return nil, err
+	}
+	ready := make([]Bead, 0, len(beads))
+	for _, bead := range beads {
+		if !filter.IncludeEphemeral && bead.Ephemeral {
+			continue
+		}
+		if s.blocked[bead.ID] {
+			continue
+		}
+		ready = append(ready, bead)
+	}
+	return nativeIssuesFromBeads(ready)
+}
+
+// TestNativeBackingWithoutTheBlockedColumnSendsReadyToTheLiveVerdict extends
+// #5183's invariant to the native path.
+//
+// TestDegradedProjectionSendsReadyToTheLiveBdVerdict pins that a cache with no
+// is_blocked column must decline every readiness handle and take the backing's
+// own verdict. It guards only the BdStore shape. A native store whose storage
+// cannot answer IsBlockedBatch is the same state — every IsBlocked nil, the
+// cache's predicate weaker than the backing's — and owes the same fail-safe.
+func TestNativeBackingWithoutTheBlockedColumnSendsReadyToTheLiveVerdict(t *testing.T) {
+	storage := &nativeProjectionlessStorage{nativeDoltMemStorage: newNativeDoltMemStorage(), blocked: map[string]bool{}}
+	if _, ok := beadslib.AsBlockedQuerier(storage); ok {
+		t.Fatal("fixture storage exposes BlockedQuerier; it must model a backing that cannot answer the column")
+	}
+	native := newNativeDoltStoreForTest(storage)
+
+	ids := map[string]string{}
+	for _, title := range []string{"blocker", "parent", "child", "unrelated"} {
+		b, err := native.Create(Bead{Type: "task", Status: "open", Title: title})
+		if err != nil {
+			t.Fatalf("Create %s: %v", title, err)
+		}
+		ids[title] = b.ID
+	}
+	if err := storage.store.DepAdd(ids["parent"], ids["blocker"], "blocks"); err != nil {
+		t.Fatalf("DepAdd blocks: %v", err)
+	}
+	if err := storage.store.DepAdd(ids["child"], ids["parent"], "parent-child"); err != nil {
+		t.Fatalf("DepAdd parent-child: %v", err)
+	}
+	storage.blocked[ids["parent"]] = true
+	storage.blocked[ids["child"]] = true
+
+	cache := NewCachingStoreForTest(native, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if !cache.readyReadsMustGoLive() {
+		t.Fatal("a native backing that cannot answer the is_blocked column must latch the ready-projection degrade")
+	}
+	rows, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if got, want := sortedIDs(rows), wantReadyIDs(ids["blocker"], ids["unrelated"]); !equalIDs(got, want) {
+		t.Fatalf("Ready = %v, want %v: the transitively blocked child %s must not be offered", got, want, ids["child"])
+	}
+	if _, ok := cache.CachedReady(); ok {
+		t.Error("CachedReady answered from a cache with no is_blocked column; the control dispatcher reads this handle")
+	}
+	if _, err := cache.ReadyContext(context.Background()); !errors.Is(err, ErrCacheUnavailable) {
+		t.Errorf("ReadyContext error = %v, want ErrCacheUnavailable", err)
+	}
+	if _, err := cache.Handles().Cached.Ready(); !errors.Is(err, ErrCacheUnavailable) {
+		t.Errorf("cached reader Ready error = %v, want ErrCacheUnavailable", err)
+	}
+
+	// The rows are whole, so everything that does not need the column keeps
+	// serving from cache — the separation #5183 established.
+	cached, ok := cache.CachedList(ListQuery{AllowScan: true})
+	if !ok {
+		t.Fatal("CachedList declined: the degrade must not make non-readiness reads unavailable")
+	}
+	if len(cached) != len(ids) {
+		t.Fatalf("CachedList returned %d rows, want %d", len(cached), len(ids))
+	}
+}
+
+// containsID reports whether ids holds want.
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// idsBeyond returns the members of got that want does not contain.
+func idsBeyond(got, want []string) []string {
+	allowed := make(map[string]struct{}, len(want))
+	for _, id := range want {
+		allowed[id] = struct{}{}
+	}
+	var extra []string
+	for _, id := range got {
+		if _, ok := allowed[id]; !ok {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(extra)
+	return extra
+}


### PR DESCRIPTION
Fixes ga-40qh1 (P0).

## The defect

`checkVersionCompat` string-compares the linked beads module version to the version bd reports for itself. That comparison only means something when both strings name the same released beads artifact. Two shapes in daily use do not:

- this fork replaces the module — `replace github.com/steveyegge/beads => github.com/gascity/bd-enterprise v0.0.0-20260810084121-1aa7bf160786` — so `debug.ReadBuildInfo()` reports the *replacement's* pseudo-version;
- `origin/main` itself pins beads at an untagged commit (`v1.1.1-0.20260805093327-bf97b73749ac`), which is a pseudo-version even with no replace at all.

bd reports `1.1.0`. Neither string can ever equal it, so the check returned `FAIL` — a **confirmed mismatch** — for a question it never had the evidence to ask. The existing `""` / `(devel)` bypass was written for precisely this situation ("the schema version is validated above and is the real compatibility signal"), but its set of unknowns was incomplete.

## Why it only bit some scopes, and why that is the real bug

The compare is reached only when `bd context` is readable.

| scope | `bd context` | version_compat | store |
|---|---|---|---|
| city root (not a git repo) | errors | WARN | `NativeDoltStore` — healthy |
| every rig (is a git repo) | succeeds | **FAIL** | `BdStore` — degraded |

On `BdStore`, `listIncludesCompleteDependencies()` is hardcoded false (ga-tgpfm), so `depsComplete` is permanently false and `cachedReadyCompleteOnly` declines every read. Those scopes report `partial: true` / `bead cache unavailable` forever and serve every complete-ready read from a live bd subprocess (~640 avoidable forks per three minutes, fleet-wide). Verified 1:1 on the live box: every scope logging `gate=version_compat` reports the partial error, and no other scope does.

**The fleet was healthy only where a capability probe happened to fail.** One probe failing gave you the healthy path; the other succeeding gave you the degraded one.

## The fix

Classify the linked library, then compare only when the comparison is answerable. A library version is unconfirmable when it is empty, `(devel)`, supplied by a `replace` directive (either form — a module replace records the replacement's own numbering; a local-path replace records none), or a pseudo-version naming an untagged commit. Unconfirmable **PASSes**, with the reason named in the summary; `schema_version` above remains the real compatibility signal. A **confirmed** mismatch between two comparable releases still **FAILs**.

`PASS` rather than `WARN` is load-bearing. `WARN` degrades the verdict, and the `degradedOnlyByUnreachableBDContext` upgrade requires `bdCtxErr != nil` — so a `WARN` here would leave every rig on `BdStore` exactly as before. Only `PASS` actually answers the bead.

`beadsModuleVersion` also reported the displaced `require` version for a local-path replace, describing code that is not linked. It now reports the replacement's own version, empty included.

## Fail-open vs fail-closed — the argument

Fail-open on an *unanswerable* question, fail-closed on a *confirmed* one.

Every other `FAIL` in this checker is a confirmed incompatibility: backend disagreement, `dolt_mode=embedded`, `project_id` mismatch. "I could not cross-verify" already means WARN-and-proceed on the `bd context` path. "I could not compare two strings" is the same epistemic state and was the only place answering it with a confirmed verdict.

Fail-closed bought no safety here. The question is unanswerable **by construction** for every fork build, every source build, and (today) for `origin/main` itself — so the gate was never selective, it was always on. What it cost was large: a silent downgrade to `BdStore` that permanently disables complete-ready cache reads. That asymmetry — a huge behavioural consequence attached to a comparison failure — is the actual defect.

The guards that matter are untouched: `schema_version` must still be reported (FAIL if not), the preflight `project_id` probe must still match, and beadslib's native-open still verifies `_project_id` over the authenticated connection and refuses to connect on mismatch, dropping the scope to `BdStore`.

## What changes on the live fleet at deploy

Rig scopes currently logging `native_store_unavailable gate=version_compat` move `BdStore` → `NativeDoltStore`. That is the **correct** state, and it is a real behaviour change on six live cities:

- `/status` partial errors (`reading complete ready projection from cache: bead cache unavailable`) clear on those scopes;
- complete-ready reads start being served from the cache instead of a live bd subprocess;
- the bd fork rate drops sharply (~640 forks/3min recovered).

Risks worth watching:

- **More native Dolt connections.** Each promoted rig opens pooled connections to the Dolt server instead of forking bd. Watch Dolt connection counts on promotion.
- **Native-store bugs previously masked.** These scopes have been on `BdStore` since 09:15 Aug 11; any `NativeDoltStore`-specific behaviour they were shielded from now applies to them.
- **Cache goes authoritative.** `depsComplete` becomes true, so ready reads come from cache. A stale cache now shows up as wrong readiness rather than as a slow-but-correct subprocess read.

Mitigations already in the code path: a scope with executable `.beads/hooks/on_{create,update,close}` still falls back (`gate=bd_hooks`); a failed native open falls back (`gate=native_open`); and `GC_BEADS_FORCE_FALLBACK=1` reverts a scope wholesale. **No deploy or restart is performed by this PR.**

## Tests

Red before, on unmodified production code, for both live pseudo-versions against bd `1.1.0`:

```
state = "FAIL", want "PASS" (summary: "bd version differs from linked beads library version")
```

Both directions proven:

- **still fails** — `1.1.1` vs bd `1.1.0`, `v1.2.0` vs bd `v1.1.0`, `1.0.5` vs `1.0.4`, plus end-to-end `TestPreflightBlocksOnRealVersionSkew` (BLOCKED, `Fallback=bd_store`);
- **now passes** — enterprise `0.0.0-20260810084121-1aa7bf160786`, `origin/main`'s `1.1.1-0.20260805093327-bf97b73749ac`, a tagged replacement, a path replacement with no version, plus end-to-end `TestPreflightEligibleOnReplacedBeadsModuleWithReadableBDContext` (ELIGIBLE with `bd context` readable, *not* via the identity fallback).

Also covered: `(devel)`, empty, missing dep, and the build-info reader for plain-require / module-replace / local-path-replace.

**Byte-identity where the check already passed** is pinned by `TestCheckVersionCompatSummariesAreStableWhereItAlreadyPassed`, which asserts the exact summary string of all six pre-existing outcomes. Proven by mutation — all seven mutants killed, including the two that would change the live cities' path:

| mutation | killed by |
|---|---|
| unreachable-bd-context `WARN`→`PASS` (the cities' path) | `TestPreflightEligibleOnUnreachableBDContextWhenIdentityVerified`, `TestPreflightDegradesOnUnreachableBDContextWithoutIdentityProof` |
| unreachable-bd-context summary reworded | summary-stability test |
| `(devel)` "source build" reason reworded | summary-stability test |
| classifier declares every version unknown | `TestCheckVersionCompatSourceBuild`, summary-stability, `TestPreflightBlocksOnRealVersionSkew` |
| matching-release PASS summary reworded | summary-stability test |
| replaced-module signal ignored | `TestCheckVersionCompatSourceBuild` |
| build-info reader ignores the replace directive | `TestLinkedBeadsLibraryFromBuildInfo` |

## Second commit: the native store's cache had no `is_blocked` column (MAJOR, fixed here)

Promoting rig scopes to `NativeDoltStore` hands their readiness to the `CachingStore` **and simultaneously removes the column that made the cache's answer equal bd's**. Left as it was, this PR would have re-created **#3218** on six live cities.

`NativeDoltStore.listIncludesCompleteDependencies()` returns `true` (vs `BdStore`'s `false`), so `fetchDepsForBeads` latches `depsComplete = true` — exactly what unblocks `CachingStore.Ready` and `cachedReadyCompleteOnly`. But `NativeDoltStore` implemented **neither** `enrichReadyProjectionForCache` nor `dependencySnapshotForCache`, and `beadFromNativeIssue` cannot set `Bead.IsBlocked` — beadslib's `types.Issue` has no `is_blocked` field; the flag is reachable only through `beads.AsBlockedQuerier`. So `applyReadyProjection` returned items unchanged with a **nil** error, `readyProjectionDegraded` never latched, `readyReadsMustGoLive()` stayed false, every cached row carried `IsBlocked == nil`, and `cachedBeadReady` fell through to the **direct-dependency** predicate.

That predicate is weaker than the column two ways, both of which gascity hits constantly:

- `is_blocked` propagates transitively **down parent-child** edges (`issueops.markBlockedTemplateForIssues`: `d.type = 'parent-child' AND p.is_blocked = 1`), so a child of a blocked parent carries no blocking edge of its own and reads ready to the cache;
- `cachedBeadReady` treats a dep as blocking only when `statusByID[dep.DependsOnID]` is present, so an edge onto **another store's row** — a relocated `gcg-` graph bead — is invisible to it.

`NativeDoltStore.Ready` goes through `GetReadyWork`, which filters `is_blocked = 0` (`sqlbuild.ReadyWhere`). Measured on `174bfc6ff8`: `backing.Ready = [blocker unrelated]` while `Ready` / `ReadyContext` / `CachedReady` / `Handles().Cached.Ready` all returned `[blocker child xstore unrelated]`, nil error, `ok=true`. `CachedReady()` is what `cmd/gc/dispatch_control_ready.go` reads on every dispatcher tick.

It also violated the invariant `TestDegradedProjectionSendsReadyToTheLiveBdVerdict` (#5183, merged hours earlier) established on the identical fixture — that test just guarded only the `BdStore` path.

### The fix: fill the column, don't decline it

`NativeDoltStore.enrichReadyProjectionForCache` batch-fills `IsBlocked` through `beads.BlockedQuerier.IsBlockedBatch`, mirroring `BdStore.fetchReadyProjection` **including the `skipBDReadyProjectionEnrichment` exclusions**, so message/nudge rows keep their nil and the reconcile diff still converges. The read runs in-process on the store's existing connection and inside `withReadRetry`, so it recovers from a managed-Dolt rebind like every other native read.

The fail-safe is kept as the fallback, not the design: a storage that cannot answer the column reports `ErrReadyProjectionUnsupported`, `readyReadsMustGoLive()` becomes true, and readiness declines the cache for the backing's own `Ready`. That branch is real, not defensive — the core `beads.Storage` interface does not declare `IsBlockedBatch`; only `DoltStorage` composes `DependencyQueryStore`. Both production storages (`DoltStore`, `EmbeddedDoltStore`) satisfy it, pinned upstream by compile-time assertions.

### Why fill rather than decline

The declining variant is correct but costs what this PR exists to buy back. Filling costs `ceil(N/200) × 2` primary-key `SELECT id, is_blocked FROM {issues,wisps} WHERE id IN (...)` statements, once per cache prime and once per reconcile (30–120 s by corpus size). Declining costs a full live `NativeDoltStore.Ready()` — two `GetReadyWork` calls with complete row hydration — on **every** readiness read, at up to one per `controlReadyCacheTTL` (3 s) per scope. That is 10–40× the frequency at many times the per-call cost. Measured on the in-memory harness at n=3000, the enrichment was ~0.36× the cost of a single live `Ready()`, and it replaces one per tick with one per reconcile. It also replaces `BdStore`'s equivalent, which spent a 6–16 s `bd sql` subprocess on maintainer-city.

### Tests

Red before, on `174bfc6ff8`, for both shapes and all four readiness handles:

```
Ready offered gc-3, a child of a blocked parent that the backing's own Ready hides:
blocked-ness propagates down parent-child and the cache's direct-dep predicate
cannot see it (backing = [gc-1 gc-5], cache = [gc-1 gc-3 gc-4 gc-5])

Ready offered gc-4, whose blocker gcg-offscope is not resident in this scope's cache:
cachedBeadReady treats a dep as blocking only when statusByID holds the target
(backing = [gc-1 gc-5], cache = [gc-1 gc-3 gc-4 gc-5])
```

and for the extended #5183 invariant:

```
a native backing that cannot answer the is_blocked column must latch the
ready-projection degrade
```

- `TestCachedReadyOverNativeBackingNeverOffersWorkTheBackingHides` asserts the invariant directly — a cached ready read over a native backing never returns a bead the backing's own `Ready()` excludes — across `Ready`, `ReadyContext`, `CachedReady` and `Handles().Cached.Ready`, on the council's fixture (`blocker <-blocks- parent <-parent-child- child`) plus a cross-store bead blocked by a non-resident `gcg-` row. It also asserts the cache still **answers** and answers equal to the backing, so a trivially-declining implementation cannot pass it.
- `TestNativeBackingWithoutTheBlockedColumnSendsReadyToTheLiveVerdict` extends #5183's invariant to the native path: all four handles decline, `Ready` takes the live verdict, and non-readiness cached reads keep serving.
- `TestNativeReadyProjectionIsOneBatchedReadPerCycle` pins the cost shape — one batched read over the whole active set per cycle, never a per-bead fan-out.
- `var _ readyProjectionEnrichmentStore = (*NativeDoltStore)(nil)` pins the coupling, so deleting the method breaks the build rather than silently reverting readiness.

The version_compat fix above is untouched: the fail-open decision, the PASS-not-WARN reasoning, and all six pinned byte-identity outcomes stand exactly as committed.

### What this adds to the deploy story

The promotion described above still happens, and now it is **transitively correct**. On a promoted rig, cached readiness equals `bd ready`'s verdict — a child of a blocked parent and a bead gated by a non-resident cross-store row stay hidden, exactly as they do today under `BdStore` — but without the `bd sql` subprocess. Without this commit, both would have been offered to the control dispatcher on every tick. Scopes on `BdStore`, DoltLite, exec or mem are unaffected.

## Follow-up

`BdStore.listIncludesCompleteDependencies() == false` — the second hardcoded pessimism that amplified this bug's blast radius — is **already filed as ga-tgpfm (P0) and linked to ga-40qh1**. Not fixed here: it is not trivial (BdStore would need a real `dependencySnapshotForCache` over `DepListBatch`, and flipping the flag without actually supplying deps would make blocked beads read as ready — a correctness bug, not a perf one).

## Gates

`go build ./...` · `go vet ./...` · `gofmt` clean · `golangci-lint run ./...` **0 issues** · `go test ./internal/beads/...` · `go test ./cmd/gc -timeout 25m -p 1 -parallel 1` **ok 687.324s** · `go test ./internal/...` · `scripts/check-core-boundary.sh` OK · `make check-split-topology-rows` OK.

No `go.mod` / `go.sum` change: `golang.org/x/mod` was already a direct dependency. No wire-type or OpenAPI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

