### PR TITLE
fix(api): read the /status session snapshot from the sessions class, not the work ledger (ga-ioyvj)

### DIFF
--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -73,6 +73,13 @@ type StatusInput struct {
 // snapshot instead of rendering partial/empty data. CacheAgeS surfaces the
 // age of the latest fresh observation so `gc status` can append a staleness
 // banner when the supervisor is lagging.
+//
+// The gate and the age both read the WORK store, which is the class the body's
+// expensive legs come from (work counts, store health). It deliberately does
+// not gate the session-class store: a CachingStore that cannot serve a read
+// from cache falls through to its backing store rather than answering empty,
+// so a priming sessions binding surfaces as a "sessions:" partial error from
+// statusSessionSnapshot, never as a silent zero-session fleet.
 func (s *Server) humaHandleStatus(ctx context.Context, input *StatusInput) (*IndexOutput[StatusBody], error) {
 	store := s.state.CityBeadStore()
 	if err := cacheLiveOr503(store); err != nil {
@@ -290,7 +297,7 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 		})
 	}
 
-	// Session counts: walk the city bead store for session beads. Omitted in
+	// Session counts: derived from the session-class snapshot. Omitted in
 	// lite mode (detail block, not needed for the high-frequency overview).
 	var sessionCounts *StatusSessionCountsDetail
 	if !lite && len(sessionSnapshot.bySessionName) > 0 {
@@ -479,13 +486,35 @@ type statusSessionInfo struct {
 	state       session.State
 }
 
+// statusSessionSnapshot reads the session-class beads every session-derived
+// field of the status body is built from: per-agent running/suspended state,
+// named-session status, the unlimited-pool expansion, and the session counts.
+//
+// It reads SessionsBeadStore(), not CityBeadStore(). Those are the same store
+// on a city that relocates nothing, so this is byte-identical there; on a city
+// with [beads.classes.sessions] relocated the session beads live in the class
+// binding, and reading them off the work ledger returned an empty fleet at
+// whatever the work ledger costs — on a cross-region hosted work store that is
+// seconds, so the read blew statusStoreReadTimeout and /status reported
+// "sessions: loading session snapshot timed out after 1s" for data sitting in a
+// local store.
 func (s *Server) statusSessionSnapshot(ctx context.Context) statusSessionSnapshot {
 	snapshot := statusSessionSnapshot{
 		bySessionName: make(map[string]statusSessionInfo),
 		byTemplate:    make(map[string][]statusSessionInfo),
 	}
-	store := s.state.CityBeadStore()
+	sessions := s.state.SessionsBeadStore()
+	store := sessions.Store
 	if store == nil {
+		// A nil session-class store is benign only when the city has no bead
+		// store at all. When the work store IS present, the sessions binding
+		// failed to resolve and this projection cannot see the class: say so
+		// rather than reporting an empty fleet, and do NOT fall back to the
+		// work store. Reading session beads off the work ledger is precisely
+		// what kept this mis-routing invisible.
+		if s.state.CityBeadStore() != nil {
+			snapshot.partialErrors = []string{"sessions: session-class bead store unavailable"}
+		}
 		return snapshot
 	}
 
@@ -512,14 +541,14 @@ func (s *Server) statusSessionSnapshot(ctx context.Context) statusSessionSnapsho
 		// it hung the whole handler past its read budget, dragging the
 		// supervisor loop (gc-08qgn). Under the goroutine the same time.After
 		// as the read bounds it.
-		readStore := store
+		readSessions := sessions
 		if scoped, err := s.state.ScopedStoreLike(reqCtx, store); err != nil {
 			done <- snapshotResult{err: fmt.Errorf("resolving scoped store: %w", err)}
 			return
 		} else if scoped != nil {
-			readStore = scoped
+			readSessions = beads.SessionStore{Store: scoped}
 		}
-		infos, partialErrors, err := sessionReadModelInfos(session.NewStore(beads.SessionStore{Store: readStore}))
+		infos, partialErrors, err := sessionReadModelInfos(session.NewStore(readSessions))
 		done <- snapshotResult{infos: infos, partialErrors: partialErrors, err: err}
 	}()
 

--- a/internal/api/handler_status_session_class_test.go
+++ b/internal/api/handler_status_session_class_test.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// workLedgerStore stands in for a cross-region hosted work ledger: it counts
+// the List calls the status path sends it, and can be told to stall so a read
+// routed here cannot answer inside the caller's budget. The measured cost of a
+// single work-store read on maintainer-city is 4.386s (54ms RTT over ~83
+// serialized round trips, 87% network) against a 1s statusStoreReadTimeout, so
+// "does not return in time" is the honest model — a latch pins that
+// deterministically where a wall-clock sleep only approximates it.
+type workLedgerStore struct {
+	*beads.MemStore
+	listCalls atomic.Int64
+	stall     chan struct{} // nil answers immediately; non-nil parks until closed
+}
+
+func (s *workLedgerStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls.Add(1)
+	if s.stall != nil {
+		<-s.stall
+	}
+	return s.MemStore.List(query)
+}
+
+// stallWorkLedger makes every work-ledger read outlive the status read budget,
+// releasing parked readers at cleanup so no goroutine outlives the test.
+func stallWorkLedger(t *testing.T, work *workLedgerStore) {
+	t.Helper()
+	work.stall = make(chan struct{})
+	t.Cleanup(func() { close(work.stall) })
+}
+
+// sessionClassUnavailableState reports a work store but no session-class store,
+// the shape a city gets when [beads.classes.sessions] is relocated to a binding
+// that failed to open.
+type sessionClassUnavailableState struct{ *fakeState }
+
+func (sessionClassUnavailableState) SessionsBeadStore() beads.SessionStore {
+	return beads.SessionStore{}
+}
+
+// splitClassState builds a city with sessions relocated off the work ledger:
+// distinct work and session-class stores, the way a converged split city binds
+// them. The work ledger answers immediately unless a test stalls it, so the
+// tests that assert routing can still observe what a work-ledger read WOULD
+// have returned.
+func splitClassState(t *testing.T) (*fakeState, *workLedgerStore, *beads.MemStore) {
+	t.Helper()
+	work := &workLedgerStore{MemStore: beads.NewMemStore()}
+	sessions := beads.NewMemStore()
+	st := newFakeState(t)
+	st.cityBeadStore = work
+	st.sessionsBeadStore = sessions
+	// Drop the rig store so no unrelated leg reads while these tests run.
+	st.stores = map[string]beads.Store{}
+	st.cfg.Rigs = nil
+	return st, work, sessions
+}
+
+// TestStatusSessionSnapshotReadsSessionClassStore is the routing test: on a
+// split city the snapshot must see the beads in the session-class store and
+// must not see the work ledger's, because session beads are not work beads.
+func TestStatusSessionSnapshotReadsSessionClassStore(t *testing.T) {
+	st, work, sessions := splitClassState(t)
+	if _, err := work.Create(newSessionBead("work-ledger-session")); err != nil {
+		t.Fatalf("Create work-ledger session bead: %v", err)
+	}
+	if _, err := sessions.Create(newSessionBead("session-class-session")); err != nil {
+		t.Fatalf("Create session-class session bead: %v", err)
+	}
+	s := &Server{state: st}
+
+	snapshot := s.statusSessionSnapshot(context.Background())
+
+	if _, ok := snapshot.bySessionName["session-class-session"]; !ok {
+		t.Errorf("snapshot missing session-class-session; bySessionName = %+v, want the session-class store read", snapshot.bySessionName)
+	}
+	if _, ok := snapshot.bySessionName["work-ledger-session"]; ok {
+		t.Errorf("snapshot contains work-ledger-session; bySessionName = %+v, want session beads read off the session class, not the work ledger", snapshot.bySessionName)
+	}
+}
+
+// TestStatusSessionSnapshotNeverQueriesTheWorkLedger is the cost test. The work
+// ledger is stalled the way maintainer-city's is effectively stalled — a read
+// there costs multiples of statusStoreReadTimeout — so a session read routed to
+// it cannot finish and /status reports "sessions: loading session snapshot
+// timed out after 1s" for data sitting in a local store. Zero work-ledger List
+// calls pins the win structurally; the elapsed check pins that the snapshot no
+// longer waits out the budget.
+func TestStatusSessionSnapshotNeverQueriesTheWorkLedger(t *testing.T) {
+	st, work, sessions := splitClassState(t)
+	stallWorkLedger(t, work)
+	if _, err := sessions.Create(newSessionBead("session-class-session")); err != nil {
+		t.Fatalf("Create session-class session bead: %v", err)
+	}
+	s := &Server{state: st}
+
+	start := time.Now()
+	snapshot := s.statusSessionSnapshot(context.Background())
+	elapsed := time.Since(start)
+
+	if calls := work.listCalls.Load(); calls != 0 {
+		t.Errorf("work ledger received %d List call(s) for a session-class read; want 0", calls)
+	}
+	if elapsed >= statusStoreReadTimeout {
+		t.Errorf("statusSessionSnapshot took %s, at or past the %s budget; want a local session-class read", elapsed, statusStoreReadTimeout)
+	}
+	if len(snapshot.partialErrors) != 0 {
+		t.Errorf("partialErrors = %v, want none", snapshot.partialErrors)
+	}
+	if _, ok := snapshot.bySessionName["session-class-session"]; !ok {
+		t.Errorf("snapshot missing session-class-session; bySessionName = %+v", snapshot.bySessionName)
+	}
+}
+
+// TestStatusSessionSnapshotStoreIdentity pins WHICH store value the read path
+// is handed, in both city shapes. On a city that relocates nothing the
+// session-class accessor resolves to the very same store value CityBeadStore
+// returns, so this read is byte-identical there; on a split city it must be the
+// session-class store and nothing else. ScopedStoreLike sees the store the read
+// is about to go through, which makes it the honest observation point.
+func TestStatusSessionSnapshotStoreIdentity(t *testing.T) {
+	t.Run("single store", func(t *testing.T) {
+		st := newFakeState(t)
+		city := beads.NewMemStore()
+		st.cityBeadStore = city
+		var observed beads.Store
+		st.scopedStoreFn = func(_ context.Context, existing beads.Store) (beads.Store, error) {
+			observed = existing
+			return nil, nil
+		}
+		s := &Server{state: st}
+
+		_ = s.statusSessionSnapshot(context.Background())
+
+		if observed != st.CityBeadStore() {
+			t.Errorf("read store = %p, want CityBeadStore %p — a city that relocates nothing must stay byte-identical", observed, st.CityBeadStore())
+		}
+		if observed != st.SessionsBeadStore().Store {
+			t.Errorf("read store = %p, want SessionsBeadStore %p", observed, st.SessionsBeadStore().Store)
+		}
+	})
+
+	t.Run("sessions relocated", func(t *testing.T) {
+		st, work, sessions := splitClassState(t)
+		var observed beads.Store
+		st.scopedStoreFn = func(_ context.Context, existing beads.Store) (beads.Store, error) {
+			observed = existing
+			return nil, nil
+		}
+		s := &Server{state: st}
+
+		_ = s.statusSessionSnapshot(context.Background())
+
+		if observed != beads.Store(sessions) {
+			t.Errorf("read store = %p, want the session-class store %p (work ledger is %p)", observed, sessions, work)
+		}
+	})
+}
+
+// TestStatusSessionSnapshotFailsLoudWithoutSessionClassStore pins Invariant 0
+// for this projection: when the work store is present but the session class is
+// not reachable, /status must say it cannot see the class. Falling back to the
+// work ledger is what made the mis-routing invisible in the first place, so the
+// work ledger's session bead must not appear and must not be queried.
+func TestStatusSessionSnapshotFailsLoudWithoutSessionClassStore(t *testing.T) {
+	st, work, _ := splitClassState(t)
+	if _, err := work.Create(newSessionBead("work-ledger-session")); err != nil {
+		t.Fatalf("Create work-ledger session bead: %v", err)
+	}
+	s := &Server{state: sessionClassUnavailableState{st}}
+
+	snapshot := s.statusSessionSnapshot(context.Background())
+
+	joined := strings.Join(snapshot.partialErrors, "; ")
+	if !strings.Contains(joined, "sessions: session-class bead store unavailable") {
+		t.Errorf("partialErrors = %v, want the session-class store reported unavailable", snapshot.partialErrors)
+	}
+	if _, ok := snapshot.bySessionName["work-ledger-session"]; ok {
+		t.Errorf("snapshot contains work-ledger-session; bySessionName = %+v, want no silent fallback to the work ledger", snapshot.bySessionName)
+	}
+	if calls := work.listCalls.Load(); calls != 0 {
+		t.Errorf("work ledger received %d List call(s) after the session class went unavailable; want 0", calls)
+	}
+}
+
+// TestStatusSessionSnapshotSilentWhenNoStoreConfigured keeps the beadless city
+// quiet: with no store at all there is no class to be unable to see, so the
+// snapshot stays empty and reports nothing, exactly as before.
+func TestStatusSessionSnapshotSilentWhenNoStoreConfigured(t *testing.T) {
+	st := newFakeState(t) // cityBeadStore left nil
+	s := &Server{state: st}
+
+	snapshot := s.statusSessionSnapshot(context.Background())
+
+	if len(snapshot.partialErrors) != 0 {
+		t.Errorf("partialErrors = %v, want none for a city with no bead store", snapshot.partialErrors)
+	}
+	if len(snapshot.bySessionName) != 0 {
+		t.Errorf("bySessionName = %+v, want empty", snapshot.bySessionName)
+	}
+}
+
+// TestStatusBodyNamedSessionUsesSessionClassStore carries the routing all the
+// way to the wire: a named session materialized in the session-class store must
+// render its persisted state, not "reserved-unmaterialized", on a split city.
+func TestStatusBodyNamedSessionUsesSessionClassStore(t *testing.T) {
+	st, work, sessions := splitClassState(t)
+	identity := st.cfg.NamedSessions[0].QualifiedName()
+	runtimeName := config.NamedSessionRuntimeName(st.cityName, st.cfg.Workspace, identity)
+	if _, err := sessions.Create(newSessionBead(runtimeName)); err != nil {
+		t.Fatalf("Create named-session bead: %v", err)
+	}
+	// A decoy under a different name on the work ledger: reading there answers
+	// "reserved-unmaterialized" for the named session, which is the pre-fix body.
+	if _, err := work.Create(newSessionBead("work-ledger-session")); err != nil {
+		t.Fatalf("Create work-ledger session bead: %v", err)
+	}
+	s := &Server{state: st}
+
+	body := s.buildStatusBody(context.Background(), false)
+
+	if len(body.NamedSessionDetails) != 1 {
+		t.Fatalf("NamedSessionDetails = %+v, want exactly one row", body.NamedSessionDetails)
+	}
+	if got := body.NamedSessionDetails[0].Status; got != string(session.StateActive) {
+		t.Errorf("named session %q status = %q, want %q — the session-class store holds it", identity, got, session.StateActive)
+	}
+	if body.SessionCountsDetail == nil || body.SessionCountsDetail.Active != 1 {
+		t.Errorf("SessionCountsDetail = %+v, want Active=1 from the session-class store", body.SessionCountsDetail)
+	}
+}


### PR DESCRIPTION
## The defect

`statusSessionSnapshot` built the status body's entire session view from
`CityBeadStore()` — it read **session-class** beads out of the **work** store.

```go
store := s.state.CityBeadStore()   // internal/api/handler_status.go:487
```

On a converged split city the sessions class is relocated to the local SQLite
binding, so the beads it wanted are not in the work store at all and the
snapshot comes back empty. On maintainer-city the work class is cross-region
hosted Postgres (us-west-2 RDS) where one read costs **4.386s** (54ms RTT over
~83 serialized round trips, 87% network) against a 1s `statusStoreReadTimeout`.
So `/status` paid a multi-second remote round trip to learn nothing, blew the
budget, and reported:

```
sessions: loading session snapshot timed out after 1s
```

for data sitting in a local store. That is **class routing**, not timeout
calibration — raising the budget would only have made the wrong read slower.

`State` already exposes the right accessor, and every session/wait handler
already uses it (`handler_sessions.go`, `huma_handlers_waits.go`,
`huma_handlers_sessions_*.go`, …). The status projection was the last reader
still on the work ledger.

## The fix

- Route `statusSessionSnapshot` through `SessionsBeadStore()`, matching the
  shape every other session reader uses.
- Keep `beads.SessionStore` through the `ScopedStoreLike` clone so the class
  stays statically visible at the read instead of being re-wrapped from a raw
  store.
- **Fail loudly**: when the class store is missing while the work store is
  present, report `sessions: session-class bead store unavailable` rather than
  silently falling back to the work ledger. A silent fallback is exactly how
  this defect stayed invisible. A city with no bead store at all stays quiet,
  as before.

## Audit of every store access in `handler_status.go`

| Line | Read | Class | Store used | Correct? |
|---|---|---|---|---|
| 84 | `cacheLiveOr503` gate + `CacheAgeS` envelope | work | `CityBeadStore()` | ✅ gates the body's expensive work-class legs |
| 91 | `waitForChange` long-poll | — (event bus) | `EventProvider()` | ✅ not a store |
| 143 → 506 | session snapshot: agent running/suspended, named-session status, pool expansion, session counts | **sessions** | ~~`CityBeadStore()`~~ → **`SessionsBeadStore()`** | ❌ → ✅ **fixed here** |
| 545 | ctx-bound clone of the snapshot's store | sessions | `ScopedStoreLike(…)` | ✅ follows the corrected store |
| 266 → 635 | per-rig open / in_progress / ready | work | `BeadStores()` | ✅ rig work ledgers |
| 266 → 646 | city open / in_progress + ready federation | work | `CityBeadStore()` | ✅ work counts belong on the work ledger |
| 279 | mail totals / unread | messaging | `MailProviders()` | ✅ already class-routed at construction (`newCityMailProvider` → `resolveMailMessagesStore`) |
| 318 → `store_health.go:86` | `counting retained bead rows` | work | `CityBeadStore()` | ✅ correctly aimed — it counts what *remains* on the work ledger post-migration |
| 342 | `cityBeadsDiagnostic()` | work | controller's city-store diagnostic | ✅ describes the work store by definition |
| 343 | `conditionalWritesStatus()` | all | controller-latched snapshot | ✅ controller owns every store handle |
| 818 / 862 | `statusListStoreWithTimeout` / `statusReadyStoreWithTimeout` | caller's | store passed in | ✅ generic helpers, no store of their own |

Sessions was the only mis-aimed read in the file.

Two things deliberately **not** changed, both recorded in code comments:

- The liveness gate is not extended to the sessions store. A `CachingStore`
  that cannot serve from cache falls through to its backing store rather than
  answering empty, so a priming sessions binding surfaces as a `sessions:`
  partial error — never a silent zero-session fleet. Extending the gate would
  add 503s without removing a silent-wrong path.
- `statusWorkCounts` still omits graph-class ready work on a split city. That
  divergence from `GET /beads/ready` is pre-existing and documented in place as
  its own slice (this read is cache-only and error-lenient by design, the
  opposite of the graph leg's fail-loud contract).

## Tests

New: `internal/api/handler_status_session_class_test.go`.

Red before the fix:

```
handler_status_session_class_test.go:87: snapshot missing session-class-session;
  bySessionName = map[work-ledger-session:{... state:active}], want the session-class store read

handler_status_session_class_test.go:114: work ledger received 1 List call(s) for a session-class read; want 0
handler_status_session_class_test.go:117: statusSessionSnapshot took 1.0009248s, at or past the 1s budget
handler_status_session_class_test.go:120: partialErrors = [sessions: loading session snapshot timed out after 1s], want none
```

That third line is the maintainer-city symptom, reproduced in a unit test.

Coverage:

- **Routing** — a session bead seeded only in the class store is seen; a decoy
  in the work ledger is not.
- **Cost** — the work ledger receives **zero** `List` calls for a session read,
  so the multi-second round trip is structurally not paid. The work ledger is
  latched (not slept) so "cannot answer inside the budget" is deterministic.
- **Byte-identity** — `ScopedStoreLike` observes the exact store value the read
  goes through; on a single-store city that must be the *same pointer* as
  `CityBeadStore()`, on a split city the class store.
- **Fail-loud** — class store missing + work store present ⇒ partial error, the
  work ledger's session bead absent, and zero work-ledger queries.
- **Quiet** — no bead store at all ⇒ no partial error (unchanged).
- **End to end** — `buildStatusBody` renders a named session's real state
  instead of `reserved-unmaterialized` on a split city.

Byte-identity proven by mutation, both directions caught:

- read a store that is not the class store → `single_store` subtest fails
  (`read store = 0x…830, want CityBeadStore 0x…7a0`)
- reinstate the silent work-store fallback → fail-loud test fails
  (`work ledger received 2 List call(s) after the session class went unavailable`)

The pre-existing `internal/api` suite passes untouched, which is the practical
byte-identity gate: every existing status test runs a single-store city.

## Gates

`go build ./...` · `go vet ./...` · `gofmt` · `golangci-lint 2.10.1` (0 issues) ·
`go test ./internal/api/...` · `go test ./cmd/gc` (serial, 690s) ·
`go test ./internal/...` · `scripts/check-core-boundary.sh` ·
`make check-split-topology-rows` — all green.

The resource census caught a `time.Sleep` in the first draft of the cost test;
replaced with a latch rather than bumping the baseline, so the census is green
with no lockstepped-artifact churn.

Bead: `ga-ioyvj`. Sibling set filed as `ga-j89yo` (eight session-class
resolutions on `CityBeadStore()` in the agent/output/watch paths — same defect,
outside this file, left for its own slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
