### PR TITLE
fix(api,controller): read and write session-class beads through the sessions store (ga-qbqij)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -2765,9 +2765,9 @@ func (cs *controllerState) Poke() {
 // WaitForSessionCommandable waits until the controller has reconciled an async
 // session create into a lifecycle state that can accept normal commands.
 func (cs *controllerState) WaitForSessionCommandable(ctx context.Context, sessionID string) (session.Info, error) {
-	store := cs.CityBeadStore()
+	store := cs.SessionsBeadStore().Store
 	if store == nil {
-		return session.Info{}, errors.New("city bead store is unavailable")
+		return session.Info{}, errors.New("session bead store is unavailable")
 	}
 	catalog, err := workerSessionCatalogWithConfig(cs.CityPath(), store, cs.SessionProvider(), cs.Config())
 	if err != nil {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -664,27 +664,9 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		}
 		result := cr.buildDesiredState(sessionBeads, startupTrace)
 		sessionBeads = cr.loadSessionBeadSnapshot()
-		result = refreshDesiredStateWithSessionBeads(
-			result,
-			cr.cityName,
-			cr.cityPath,
-			cr.cfg,
-			cr.sp,
-			cr.cityBeadStore(),
-			sessionBeads,
-			cr.stderr,
-		)
+		result = cr.refreshDesiredState(result, sessionBeads)
 		sessionBeads = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
-		result = refreshDesiredStateWithSessionBeads(
-			result,
-			cr.cityName,
-			cr.cityPath,
-			cr.cfg,
-			cr.sp,
-			cr.cityBeadStore(),
-			sessionBeads,
-			cr.stderr,
-		)
+		result = cr.refreshDesiredState(result, sessionBeads)
 		if ctx.Err() != nil {
 			return
 		}
@@ -1304,16 +1286,7 @@ func (cr *CityRuntime) tick(
 	sessionBeads = cr.loadSessionBeadSnapshot()
 	recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_demand", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	phaseStart = time.Now()
-	result = refreshDesiredStateWithSessionBeads(
-		result,
-		cr.cityName,
-		cr.cityPath,
-		cr.cfg,
-		cr.sp,
-		cr.cityBeadStore(),
-		sessionBeads,
-		cr.stderr,
-	)
+	result = cr.refreshDesiredState(result, sessionBeads)
 	recordPhase(TraceSiteDesiredStateBuild, "refresh_desired_state.before_sync", phaseStart, traceDesiredStateFields(result))
 	phaseStart = time.Now()
 	_ = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
@@ -1338,16 +1311,7 @@ func (cr *CityRuntime) tick(
 	reapStaleExtmsgParticipants(ctx, cr.sessionsBeadStore(), cr.stderr)
 	recordPhase(TraceSiteControllerTickPhase, "reap_stale_extmsg_participants", phaseStart, nil)
 	phaseStart = time.Now()
-	result = refreshDesiredStateWithSessionBeads(
-		result,
-		cr.cityName,
-		cr.cityPath,
-		cr.cfg,
-		cr.sp,
-		cr.cityBeadStore(),
-		sessionBeads,
-		cr.stderr,
-	)
+	result = cr.refreshDesiredState(result, sessionBeads)
 	recordPhase(TraceSiteDesiredStateBuild, "refresh_desired_state.after_sync", phaseStart, traceDesiredStateFields(result))
 
 	if manualReload != nil && manualReload.soft && manualReloadCompleted &&
@@ -3438,6 +3402,29 @@ func (cr *CityRuntime) buildDesiredState(sessionBeads *sessionBeadSnapshot, trac
 		return cr.buildFnWithSessionBeads(cr.cfg, cr.sp, sessionsStore.Store, unwrapWorkStores(cr.workBeadStores()), sessionBeads, trace)
 	}
 	return cr.buildFn(cr.cfg, cr.sp, sessionsStore.Store)
+}
+
+// refreshDesiredState re-applies the session-bead overlay to an already-built
+// desired state against a freshly loaded snapshot, so sessions that appeared
+// during the build are not missed.
+//
+// The store param has the same role as buildDesiredState's: it becomes
+// agentBuildParams.beadStore, which creates and updates session beads — the
+// overlay realizes a dependency floor by minting a `type=session` bead through
+// it. So it is the SESSIONS store, not the work store; on a relocated city the
+// work store would take a session-class create the class binding never sees and
+// the boot containment re-check names.
+func (cr *CityRuntime) refreshDesiredState(result DesiredStateResult, sessionBeads *sessionBeadSnapshot) DesiredStateResult {
+	return refreshDesiredStateWithSessionBeads(
+		result,
+		cr.cityName,
+		cr.cityPath,
+		cr.cfg,
+		cr.sp,
+		cr.sessionsBeadStore().Store,
+		sessionBeads,
+		cr.stderr,
+	)
 }
 
 func (cr *CityRuntime) loadDemandSnapshot(

--- a/cmd/gc/refresh_desired_state_class_routing_test.go
+++ b/cmd/gc/refresh_desired_state_class_routing_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// dependencyFloorCity is the smallest config that makes the session-bead
+// overlay realize a dependency floor: an always-on agent so the refresh has a
+// non-empty base to rebuild from, plus a pooled agent whose depends_on names a
+// second agent with no live session. Reconciling the pooled root makes the
+// controller mint the floor session for the dependency.
+func dependencyFloorCity() *config.City {
+	return &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Agents: []config.Agent{
+			{
+				Name:         "always-on",
+				Dir:          "gascity",
+				StartCommand: "true",
+			},
+			{
+				Name:              "db",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+			},
+			{
+				Name:              "api",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+				DependsOn:         []string{"gascity/db"},
+			},
+		},
+	}
+}
+
+// seedPoolRootSessionBead seeds the live pool session whose dependency floor the
+// overlay has to realize.
+func seedPoolRootSessionBead(t *testing.T, store beads.Store) {
+	t.Helper()
+	if _, err := store.Create(beads.Bead{
+		Title:  "api",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/api"},
+		Metadata: map[string]string{
+			"template":     "gascity/api",
+			"agent_name":   "gascity/api",
+			"session_name": "s-api-root",
+			"state":        "active",
+			"pool_managed": "true",
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatalf("seed pool root session bead: %v", err)
+	}
+}
+
+// TestRefreshDesiredStateWritesSessionBeadsToSessionsClass is the stranded-write
+// guard for the controller reconcile loop.
+//
+// cr.refreshDesiredState's store becomes agentBuildParams.beadStore, and the
+// session-bead overlay MINTS through it: realizeDependencyFloors ->
+// ensureDependencyOnlyTemplate -> selectOrCreateDependencyPoolSessionBead ->
+// CreateSessionInfo. Routed at the work store on a converged split city that
+// create is a stranded `type=session` bead — invisible to the sessions binding
+// and named by the per-boot containment re-check. It also recurs, because the
+// reuse check reads the sessions snapshot while the create wrote the work store,
+// so the floor can never satisfy itself.
+func TestRefreshDesiredStateWritesSessionBeadsToSessionsClass(t *testing.T) {
+	cityPath := t.TempDir()
+	workStore := beads.NewMemStore()
+	sessionsStore := beads.NewMemStore()
+	seedPoolRootSessionBead(t, sessionsStore)
+
+	cr := &CityRuntime{
+		cs:            &controllerState{cityBeadStore: workStore, cityName: "demo", cityPath: cityPath},
+		cfg:           dependencyFloorCity(),
+		sp:            runtime.NewFake(),
+		cityName:      "demo",
+		cityPath:      cityPath,
+		stderr:        io.Discard,
+		storageRoutes: relocatedSessionRoutes(sessionsStore),
+	}
+
+	sessionBeads := cr.loadSessionBeadSnapshot()
+	if sessionBeads == nil {
+		t.Fatal("session-bead snapshot is nil; the sessions store never loaded")
+	}
+	refreshed := cr.refreshDesiredState(DesiredStateResult{BeaconTime: time.Now().UTC()}, sessionBeads)
+
+	// The overlay must actually have realized the floor — otherwise the
+	// zero-work-store assertion below would hold for the trivial reason that
+	// nothing was created at all.
+	floor := false
+	for _, params := range refreshed.State {
+		if params.TemplateName == "gascity/db" && params.DependencyOnly {
+			floor = true
+		}
+	}
+	if !floor {
+		t.Fatal("fixture no longer realizes a dependency floor; the create path this guards is not being exercised")
+	}
+
+	work, err := workStore.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list work store: %v", err)
+	}
+	if len(work) != 0 {
+		t.Fatalf("STRANDED WRITE: work store holds %d bead(s) after a desired-state refresh (first: id=%s type=%s class=%v); session-class creates must land in the sessions binding",
+			len(work), work[0].ID, work[0].Type, coordclass.Classify(work[0]))
+	}
+
+	sessions, err := sessionsStore.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list sessions store: %v", err)
+	}
+	if len(sessions) < 2 {
+		t.Fatalf("sessions store holds %d bead(s); the realized dependency floor must be minted there alongside the seeded root", len(sessions))
+	}
+}
+
+// TestRefreshDesiredStateIsUnchangedOnSingleStoreCity is the byte-identity proof
+// for the refresh path on a city that relocates nothing: the store it threads is
+// the exact value cr.cityBeadStore() returns, and the realized floor is minted
+// into that one city store — the same place, and the same bead, as before the
+// accessor substitution.
+func TestRefreshDesiredStateIsUnchangedOnSingleStoreCity(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	seedPoolRootSessionBead(t, cityStore)
+
+	cr := &CityRuntime{
+		cs:       &controllerState{cityBeadStore: cityStore, cityName: "demo", cityPath: cityPath},
+		cfg:      dependencyFloorCity(),
+		sp:       runtime.NewFake(),
+		cityName: "demo",
+		cityPath: cityPath,
+		stderr:   io.Discard,
+	}
+	if got := cr.sessionsBeadStore().Store; got != cr.cityBeadStore() {
+		t.Fatal("default backend: the refresh path's sessions store must be the identical value cr.cityBeadStore() returns")
+	}
+
+	refreshed := cr.refreshDesiredState(DesiredStateResult{BeaconTime: time.Now().UTC()}, cr.loadSessionBeadSnapshot())
+	floor := false
+	for _, params := range refreshed.State {
+		if params.TemplateName == "gascity/db" && params.DependencyOnly {
+			floor = true
+		}
+	}
+	if !floor {
+		t.Fatal("single-store city: the dependency floor must still be realized")
+	}
+
+	all, err := cityStore.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list city store: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("city store holds %d bead(s), want 2 (the seeded root plus the realized floor); the single-store path must be unchanged", len(all))
+	}
+}

--- a/cmd/gc/usage_compute.go
+++ b/cmd/gc/usage_compute.go
@@ -226,7 +226,10 @@ func (cr *CityRuntime) emitDueComputeFacts(ctx context.Context, sessions []sessi
 	if sink == nil || sink == usage.Discard {
 		return
 	}
-	store := cr.cityBeadStore()
+	// Every bead this lane touches is a session bead (Get by session id,
+	// SetMetadata of the usage markers), so it reads the sessions class, not the
+	// work store. Identity to the work store on a city that relocates nothing.
+	store := cr.sessionsBeadStore().Store
 	if store == nil {
 		return
 	}

--- a/cmd/gc/usage_compute_class_routing_test.go
+++ b/cmd/gc/usage_compute_class_routing_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/usage"
+)
+
+// relocatedSessionRoutes builds storageRoutes that relocate ONLY the sessions
+// class, which is the shape of a city converged onto a sessions binding.
+func relocatedSessionRoutes(store beads.Store) *storageRoutes {
+	return &storageRoutes{
+		stores:  map[coordclass.Class]beads.Store{coordclass.ClassSessions: store},
+		binding: "test-sessions-binding",
+	}
+}
+
+// TestEmitDueComputeFactsReadsSessionsClass proves the usage lane reads and
+// writes the SESSIONS class, not the work store.
+//
+// Every bead this lane touches is a session bead: it Gets by session id and
+// SetMetadatas the two usage markers onto that bead. On a converged split city
+// the work store never held the row, so a work-store Get returns ErrNotFound,
+// the loop logs and continues, and usage/billing facts silently stop being
+// emitted for the whole fleet — a silent-drop, not a latency regression.
+func TestEmitDueComputeFactsReadsSessionsClass(t *testing.T) {
+	cityPath := t.TempDir()
+	sinkPath := filepath.Join(cityPath, ".gc", "usage.jsonl")
+
+	workStore := beads.NewMemStore()
+	sessionsStore := beads.NewMemStore()
+
+	meta := map[string]string{
+		"state":            string(session.StateAsleep),
+		"session_name":     "gc-demo-worker",
+		"awake_started_at": "2026-08-01T00:00:00Z",
+		"provider":         "codex",
+	}
+	bead, err := sessionsStore.Create(beads.Bead{
+		Type:     session.BeadType,
+		Status:   "open",
+		Title:    meta["session_name"],
+		Labels:   []string{session.LabelSession},
+		Metadata: meta,
+	})
+	if err != nil {
+		t.Fatalf("seed session bead in the relocated store: %v", err)
+	}
+
+	cs := &controllerState{
+		cityBeadStore: workStore,
+		usageSink:     usage.NewLocalSink(sinkPath),
+		cityName:      "demo",
+		cityPath:      cityPath,
+	}
+	cr := &CityRuntime{
+		cs:            cs,
+		cfg:           &config.City{},
+		sp:            runtime.NewFake(),
+		cityName:      "demo",
+		cityPath:      cityPath,
+		stderr:        io.Discard,
+		storageRoutes: relocatedSessionRoutes(sessionsStore),
+	}
+
+	info := session.Info{
+		ID:             bead.ID,
+		MetadataState:  meta["state"],
+		AwakeStartedAt: meta["awake_started_at"],
+	}
+	cr.emitDueComputeFacts(context.Background(), []session.Info{info}, false)
+
+	// The commit marker lands on the SESSION bead, in the sessions binding.
+	got, err := sessionsStore.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("re-read the relocated session bead: %v", err)
+	}
+	if got.Metadata[usageComputeEmittedAtKey] == "" {
+		t.Fatalf("session bead is missing %s; the usage lane read the work store, which never held it", usageComputeEmittedAtKey)
+	}
+
+	// And nothing was minted or stamped in the work store on the way.
+	work, err := workStore.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list work store: %v", err)
+	}
+	if len(work) != 0 {
+		t.Fatalf("work store holds %d bead(s) after a usage tick; the sessions class must not touch it: %v", len(work), work)
+	}
+}
+
+// TestSessionsBeadStoreIsWorkStoreWhenNothingRelocates is the byte-identity
+// proof for a city that relocates nothing: cr.sessionsBeadStore() hands back the
+// exact store value cr.cityBeadStore() returns, so the accessor substitution is
+// a no-op on every single-store city.
+func TestSessionsBeadStoreIsWorkStoreWhenNothingRelocates(t *testing.T) {
+	workStore := beads.NewMemStore()
+	cr := &CityRuntime{
+		cs:       &controllerState{cityBeadStore: workStore, cityName: "demo"},
+		cfg:      &config.City{},
+		cityName: "demo",
+		stderr:   io.Discard,
+	}
+	if got := cr.sessionsBeadStore().Store; got != cr.cityBeadStore() {
+		t.Fatal("default backend: cr.sessionsBeadStore().Store must be the identical value cr.cityBeadStore() returns")
+	}
+}

--- a/internal/api/handler_agent_output.go
+++ b/internal/api/handler_agent_output.go
@@ -75,7 +75,7 @@ func (s *Server) resolveAgentTranscript(name string, agentCfg config.Agent) (*ag
 		}
 	}
 	if state.sessionID != "" {
-		if store := s.state.CityBeadStore(); store != nil {
+		if store := s.state.SessionsBeadStore().Store; store != nil {
 			if catalog, err := s.workerSessionCatalog(store); err == nil {
 				if info, err := catalog.Get(state.sessionID); err == nil {
 					state.sessionKey = strings.TrimSpace(info.SessionKey)
@@ -84,7 +84,7 @@ func (s *Server) resolveAgentTranscript(name string, agentCfg config.Agent) (*ag
 		}
 	}
 
-	factory, err := s.workerFactory(s.state.CityBeadStore())
+	factory, err := s.workerFactory(s.state.SessionsBeadStore().Store)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (s *Server) trySessionLogOutputHuma(name string, agentCfg config.Agent, tai
 	if transcriptState.path == "" {
 		return nil, nil
 	}
-	factory, err := s.workerFactory(s.state.CityBeadStore())
+	factory, err := s.workerFactory(s.state.SessionsBeadStore().Store)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (s *Server) agentWorkerHandle(name string, cfg *config.City) agentPeekHandl
 		return nil
 	}
 	sessionName := agentSessionName(s.state.CityName(), name, cfg.Workspace.SessionTemplate)
-	handle, _ := s.workerHandleForSessionTarget(s.state.CityBeadStore(), sessionName)
+	handle, _ := s.workerHandleForSessionTarget(s.state.SessionsBeadStore().Store, sessionName)
 	return handle
 }
 

--- a/internal/api/handler_agent_output_stream.go
+++ b/internal/api/handler_agent_output_stream.go
@@ -133,7 +133,7 @@ func (s *Server) streamSessionLog(
 		}
 
 		// Use tail=1 (last compaction segment) to limit parsing scope.
-		factory, err := s.workerFactory(s.state.CityBeadStore())
+		factory, err := s.workerFactory(s.state.SessionsBeadStore().Store)
 		if err != nil {
 			return false
 		}
@@ -326,7 +326,7 @@ func (s *Server) streamSessionLogHuma(
 			return false
 		}
 
-		factory, err := s.workerFactory(s.state.CityBeadStore())
+		factory, err := s.workerFactory(s.state.SessionsBeadStore().Store)
 		if err != nil {
 			return false
 		}

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -457,7 +457,7 @@ func computeAgentState(suspended, quarantined, running bool, activeBead string, 
 // enrichSessionMeta populates model and context usage fields on the agent
 // response by reading the tail of the agent's session JSONL file.
 func (s *Server) enrichSessionMeta(resp *agentResponse, agentCfg config.Agent, qualifiedName string) {
-	factory, err := s.workerFactory(s.state.CityBeadStore())
+	factory, err := s.workerFactory(s.state.SessionsBeadStore().Store)
 	if err != nil {
 		return
 	}

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -53,7 +53,11 @@ func (s *Server) beadListAssigneeTerms(ctx context.Context, assignee string) []s
 	if assignee == "" {
 		return []string{""}
 	}
-	store := s.state.CityBeadStore()
+	// The ?assignee filter is applied to WORK beads, but the identifier it takes
+	// is resolved against SESSION beads, and the identity expansion below reads
+	// one — so this store is the sessions class even though the caller is a work
+	// query. Identity to the work store on a city that relocates nothing.
+	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		return []string{assignee}
 	}
@@ -96,7 +100,12 @@ func (s *Server) normalizeRawBeadAssignee(ctx context.Context, assignee string) 
 	if assignee == "" {
 		return "", nil
 	}
-	store := s.state.CityBeadStore()
+	// Sessions class, and a WRITE path: the materialize arm below CREATES a
+	// session bead when the named session has no canonical one, and the
+	// RepairTypeBestEffort heal writes to it. Through the work store on a
+	// relocated city that create is a stranded infrastructure bead — the class
+	// binding never sees it and the boot containment re-check names it.
+	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		return assignee, nil
 	}

--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -52,7 +52,7 @@ func (s *Server) extmsgDefaultAgentForConversation() func(extmsg.ConversationRef
 	if cfg == nil || len(cfg.ExtMsg.DefaultRoutes) == 0 {
 		return nil
 	}
-	store := s.state.CityBeadStore()
+	store := s.state.SessionsBeadStore().Store
 	return func(ref extmsg.ConversationRef) string {
 		agent := cfg.ExtMsgDefaultRouteAgent(ref.Provider, ref.AccountID)
 		if agent == "" {
@@ -73,7 +73,7 @@ func (s *Server) extmsgDefaultAgentForConversation() func(extmsg.ConversationRef
 // without materializing one. HandleOutbound uses it to authorize publishes on
 // agent-bound conversations.
 func (s *Server) extmsgResolveSessionSelector() func(ctx context.Context, selector string) (string, error) {
-	store := s.state.CityBeadStore()
+	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		return nil
 	}
@@ -94,7 +94,7 @@ func extmsgHandleLabel(value string) string {
 }
 
 func (s *Server) extmsgSessionHandleForSelector(selector string) string {
-	store := s.state.CityBeadStore()
+	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		return extmsgHandleLabel(selector)
 	}
@@ -135,7 +135,10 @@ func (s *Server) extmsgNotifyMembers(
 	explicitTarget string,
 ) {
 	svc := s.state.ExtMsgServices()
-	store := s.state.CityBeadStore()
+	// Sessions class, and a WRITE path: the member fan-out below materializes a
+	// configured named session that has no live bead yet, so through the work
+	// store on a relocated city every cold-wake mints a stranded session bead.
+	store := s.state.SessionsBeadStore().Store
 	if svc == nil || store == nil {
 		return
 	}

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -74,7 +74,7 @@ func (s *Server) resolveMailSendRecipientWithContext(ctx context.Context, recipi
 	if recipient == "human" {
 		return recipient, nil
 	}
-	store := s.state.CityBeadStore()
+	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		resolved, err := mail.ResolveRecipient(recipient, agentEntries(s.state.Config()))
 		if err != nil {
@@ -116,7 +116,7 @@ func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, reci
 	if recipient == "human" {
 		return []string{"human"}
 	}
-	store := s.state.CityBeadStore()
+	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		if resolved, err := mail.ResolveRecipient(recipient, agentEntries(s.state.Config())); err == nil {
 			if resolved == recipient {

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -231,7 +231,7 @@ func (s *Server) humaHandleExtMsgBind(ctx context.Context, input *ExtMsgBindInpu
 		// the delivery layer can cold-wake a session for. Persist the
 		// configured identity so the binding stays unambiguous even when
 		// a later config change makes the bare name ambiguous.
-		spec, ok, err := s.findNamedSessionSpecForTarget(s.state.CityBeadStore(), agentName)
+		spec, ok, err := s.findNamedSessionSpecForTarget(s.state.SessionsBeadStore().Store, agentName)
 		if err != nil {
 			return nil, apierr.InvalidRequest.Msg(fmt.Sprintf("resolving agent %q: %s", agentName, err))
 		}

--- a/internal/api/session_class_routing_test.go
+++ b/internal/api/session_class_routing_test.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// splitSessionState returns a fake State whose sessions class is RELOCATED to a
+// store distinct from the work store, plus the session it seeded there.
+//
+// This is the shape of a converged split city: session beads minted after
+// cutover exist only in the sessions binding, so a handler that resolves them
+// through CityBeadStore() reads a store that never held the row. The work store
+// is left deliberately empty of session beads — the assertion each test makes is
+// "the handler found it", and only a sessions-class read can.
+func splitSessionState(t *testing.T) (*fakeState, session.Info) {
+	t.Helper()
+	fs := newSessionFakeState(t)
+	relocated := beads.NewMemStore()
+	fs.sessionsBeadStore = relocated
+
+	mgr := session.NewManagerWithOptions(relocated, fs.sp)
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{
+		Template: "myrig/worker",
+		Title:    "Relocated",
+		Command:  "test-agent",
+		WorkDir:  t.TempDir(),
+		Provider: "test-agent",
+		Resume:   session.ProviderResume{},
+		Hints:    runtime.Config{},
+	})
+	if err != nil {
+		t.Fatalf("create session in relocated store: %v", err)
+	}
+	return fs, info
+}
+
+// TestResolveAgentSessionSubjectsReadsSessionsClass covers
+// resolveAgentSessionSubjects, the worker-operation watch path. Reading the work
+// store leaves session_id empty, so every worker.operation event for the agent
+// is matched on session_name alone and the id-keyed signals are dropped.
+func TestResolveAgentSessionSubjectsReadsSessionsClass(t *testing.T) {
+	fs, info := splitSessionState(t)
+	srv := New(fs)
+
+	// The watch resolves by the agent's derived session name, so point the
+	// relocated bead at it.
+	sessionName := agentSessionName(fs.CityName(), "myrig/worker", fs.cfg.Workspace.SessionTemplate)
+	if err := fs.sessionsBeadStore.SetMetadata(info.ID, "session_name", sessionName); err != nil {
+		t.Fatalf("stamp session_name: %v", err)
+	}
+
+	gotName, gotID := srv.resolveAgentSessionSubjects("myrig/worker", fs.cfg)
+	if gotName != sessionName {
+		t.Fatalf("session name = %q, want %q", gotName, sessionName)
+	}
+	if gotID != info.ID {
+		t.Fatalf("session id = %q, want %q (resolved through the work store, which never held the bead)", gotID, info.ID)
+	}
+}
+
+// TestBeadListAssigneeTermsReadsSessionsClass covers beadListAssigneeTerms. The
+// ?assignee filter is a WORK query, but the identifier it accepts is resolved
+// against SESSION beads: read from the work store the resolve misses and the
+// filter degrades to the raw term, so a list filtered by session id or alias
+// silently returns nothing.
+func TestBeadListAssigneeTermsReadsSessionsClass(t *testing.T) {
+	fs, info := splitSessionState(t)
+	srv := New(fs)
+
+	terms := srv.beadListAssigneeTerms(context.Background(), info.ID)
+	if len(terms) < 2 {
+		t.Fatalf("assignee terms = %v; want the session's expanded identity set, not the bare term", terms)
+	}
+	if !slices.Contains(terms, info.SessionName) {
+		t.Fatalf("assignee terms = %v; want them to include session_name %q", terms, info.SessionName)
+	}
+}
+
+// TestNormalizeRawBeadAssigneeReadsSessionsClass covers normalizeRawBeadAssignee.
+// This one is a WRITE path as well as a read: its materialize arm creates a
+// session bead. Routed at the work store on a converged city that create is a
+// stranded infrastructure bead the sessions binding never sees.
+func TestNormalizeRawBeadAssigneeReadsSessionsClass(t *testing.T) {
+	fs, info := splitSessionState(t)
+	srv := New(fs)
+
+	got, err := srv.normalizeRawBeadAssignee(context.Background(), info.ID)
+	if err != nil {
+		t.Fatalf("normalizeRawBeadAssignee: %v", err)
+	}
+	if got == "" {
+		t.Fatal("normalizeRawBeadAssignee returned empty; the session bead was not found")
+	}
+
+	// Nothing may have been minted in the work store on the way.
+	work, err := fs.cityBeadStore.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list work store: %v", err)
+	}
+	if len(work) != 0 {
+		t.Fatalf("work store holds %d bead(s) after an assignee normalize; session-class writes must not land there: %v", len(work), work)
+	}
+}
+
+// TestExtmsgSessionSelectorsReadSessionsClass covers the two extmsg selector
+// resolvers. Both feed delivery authorization, so a miss is a publish rejected
+// on a conversation the session legitimately owns.
+func TestExtmsgSessionSelectorsReadSessionsClass(t *testing.T) {
+	fs, info := splitSessionState(t)
+	srv := New(fs)
+
+	resolve := srv.extmsgResolveSessionSelector()
+	if resolve == nil {
+		t.Fatal("extmsgResolveSessionSelector returned nil")
+	}
+	id, err := resolve(context.Background(), info.ID)
+	if err != nil {
+		t.Fatalf("resolve selector: %v", err)
+	}
+	if id != info.ID {
+		t.Fatalf("resolved selector = %q, want %q", id, info.ID)
+	}
+
+	if handle := srv.extmsgSessionHandleForSelector(info.ID); handle == "" {
+		t.Fatal("extmsgSessionHandleForSelector returned empty for a relocated session")
+	}
+}
+
+// TestMailRecipientResolutionReadsSessionsClass covers the two mail recipient
+// resolvers. Both map a human-typed recipient onto a session's mailbox address,
+// so reading the work store sends mail to an address no session answers.
+func TestMailRecipientResolutionReadsSessionsClass(t *testing.T) {
+	fs, info := splitSessionState(t)
+	srv := New(fs)
+
+	if _, err := srv.resolveMailSendRecipientWithContext(context.Background(), info.ID); err != nil {
+		t.Fatalf("resolveMailSendRecipientWithContext: %v", err)
+	}
+
+	recipients := srv.resolveMailQueryRecipientsWithContext(context.Background(), info.SessionName)
+	if len(recipients) == 0 {
+		t.Fatal("resolveMailQueryRecipientsWithContext returned no recipients")
+	}
+}
+
+// TestResolveAgentTranscriptReadsSessionKeyFromSessionsClass covers the
+// session-catalog leg of resolveAgentTranscript. session_key is the provider's
+// own conversation identifier and is what DiscoverTranscript uses to pick the
+// right transcript file: read from the work store the catalog misses, the key
+// stays empty, and GET /agent/{name}/output falls back to workdir-only
+// discovery — which on a shared workdir serves ANOTHER agent's transcript.
+func TestResolveAgentTranscriptReadsSessionKeyFromSessionsClass(t *testing.T) {
+	fs, info := splitSessionState(t)
+	srv := New(fs)
+
+	sessionName := agentSessionName(fs.CityName(), "myrig/worker", fs.cfg.Workspace.SessionTemplate)
+	if err := fs.sessionsBeadStore.SetMetadata(info.ID, "session_name", sessionName); err != nil {
+		t.Fatalf("stamp session_name: %v", err)
+	}
+	const wantKey = "relocated-session-key"
+	if err := fs.sessionsBeadStore.SetMetadata(info.ID, "session_key", wantKey); err != nil {
+		t.Fatalf("stamp session_key: %v", err)
+	}
+
+	agentCfg, ok := findAgent(fs.cfg, "myrig/worker")
+	if !ok {
+		t.Fatal("fixture agent myrig/worker not found in config")
+	}
+	state, err := srv.resolveAgentTranscript("myrig/worker", agentCfg)
+	if err != nil {
+		t.Fatalf("resolveAgentTranscript: %v", err)
+	}
+	if state.sessionID != info.ID {
+		t.Fatalf("session id = %q, want %q", state.sessionID, info.ID)
+	}
+	if state.sessionKey != wantKey {
+		t.Fatalf("session key = %q, want %q (read from the work store, which never held the bead)", state.sessionKey, wantKey)
+	}
+}
+
+// TestSessionClassRoutingIsIdentityOnSingleStoreCity is the byte-identity proof
+// for a city that relocates nothing: every accessor the fixes moved to resolves
+// to the exact store value CityBeadStore() returns, so each substitution is a
+// no-op there. A regression that made SessionsBeadStore() diverge at the default
+// backend would fail here rather than in production.
+func TestSessionClassRoutingIsIdentityOnSingleStoreCity(t *testing.T) {
+	fs := newSessionFakeState(t)
+	if fs.sessionsBeadStore != nil {
+		t.Fatal("fixture must not relocate the sessions class")
+	}
+	if got := fs.SessionsBeadStore().Store; got != fs.CityBeadStore() {
+		t.Fatal("default backend: SessionsBeadStore().Store must be the identical value CityBeadStore() returns")
+	}
+}

--- a/internal/api/session_class_routing_test.go
+++ b/internal/api/session_class_routing_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -86,16 +88,22 @@ func TestBeadListAssigneeTermsReadsSessionsClass(t *testing.T) {
 // This one is a WRITE path as well as a read: its materialize arm creates a
 // session bead. Routed at the work store on a converged city that create is a
 // stranded infrastructure bead the sessions binding never sees.
+//
+// The assignee is the CONFIGURED NAMED SESSION, not a live bead ID: that is the
+// only input that reaches the create. A bead-ID assignee resolves on the first,
+// non-materializing pass, so the materialize arm — the sole arm that Creates —
+// never runs and the work-store assertion below cannot discriminate.
 func TestNormalizeRawBeadAssigneeReadsSessionsClass(t *testing.T) {
-	fs, info := splitSessionState(t)
+	fs, _ := splitSessionState(t)
 	srv := New(fs)
 
-	got, err := srv.normalizeRawBeadAssignee(context.Background(), info.ID)
+	const named = "myrig/worker"
+	got, err := srv.normalizeRawBeadAssignee(context.Background(), named)
 	if err != nil {
 		t.Fatalf("normalizeRawBeadAssignee: %v", err)
 	}
 	if got == "" {
-		t.Fatal("normalizeRawBeadAssignee returned empty; the session bead was not found")
+		t.Fatal("normalizeRawBeadAssignee returned empty; the named session was not resolved")
 	}
 
 	// Nothing may have been minted in the work store on the way.
@@ -104,7 +112,14 @@ func TestNormalizeRawBeadAssigneeReadsSessionsClass(t *testing.T) {
 		t.Fatalf("list work store: %v", err)
 	}
 	if len(work) != 0 {
-		t.Fatalf("work store holds %d bead(s) after an assignee normalize; session-class writes must not land there: %v", len(work), work)
+		t.Fatalf("STRANDED WRITE: work store holds %d bead(s) after an assignee normalize; session-class writes must not land there: %v", len(work), work)
+	}
+
+	// And the materialized bead is in the sessions binding. This also proves the
+	// create actually fired, so the assertion above is not passing for the
+	// trivial reason that nothing was written at all.
+	if _, err := session.ResolveSessionID(fs.sessionsBeadStore, named); err != nil {
+		t.Fatalf("named session was not materialized into the SESSIONS store: %v", err)
 	}
 }
 
@@ -114,6 +129,15 @@ func TestNormalizeRawBeadAssigneeReadsSessionsClass(t *testing.T) {
 func TestExtmsgSessionSelectorsReadSessionsClass(t *testing.T) {
 	fs, info := splitSessionState(t)
 	srv := New(fs)
+
+	// The handle source is stamped on the RELOCATED bead only, so the returned
+	// value names which store answered. Asserting non-empty cannot: on a miss
+	// extmsgSessionHandleForSelector falls back to extmsgHandleLabel(selector),
+	// which is non-empty for every non-empty selector.
+	const wantHandle = "relocated-alias"
+	if err := fs.sessionsBeadStore.SetMetadata(info.ID, "alias", wantHandle); err != nil {
+		t.Fatalf("stamp alias: %v", err)
+	}
 
 	resolve := srv.extmsgResolveSessionSelector()
 	if resolve == nil {
@@ -127,8 +151,62 @@ func TestExtmsgSessionSelectorsReadSessionsClass(t *testing.T) {
 		t.Fatalf("resolved selector = %q, want %q", id, info.ID)
 	}
 
-	if handle := srv.extmsgSessionHandleForSelector(info.ID); handle == "" {
-		t.Fatal("extmsgSessionHandleForSelector returned empty for a relocated session")
+	if handle := srv.extmsgSessionHandleForSelector(info.ID); handle != wantHandle {
+		t.Fatalf("extmsgSessionHandleForSelector = %q, want %q (the fallback label %q means the store that answered never held the bead)",
+			handle, wantHandle, extmsgHandleLabel(info.ID))
+	}
+}
+
+// TestExtmsgNotifyMembersMaterializesIntoSessionsClass covers the extmsg member
+// fan-out, the PR's #1 write site.
+//
+// A member that names a configured session with no live bead is materialized on
+// first receive: resolveSessionIDMaterializingNamedWithContext ->
+// materializeNamedSessionWithContext -> handle.Create. Through the work store on
+// a converged split city every cold-wake mints a `type=session` bead there — the
+// sessions binding never sees it and the boot containment re-check names it.
+//
+// The work store is not asserted empty here: the extmsg services are backed by
+// it in this fixture, so their own conversation beads live there legitimately.
+// The discriminating assertion is which store the SESSION bead landed in.
+func TestExtmsgNotifyMembersMaterializesIntoSessionsClass(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.sessionsBeadStore = beads.NewMemStore()
+
+	srv := New(fs)
+	t.Cleanup(srv.waitForBackground)
+
+	services := extmsg.NewServices(fs.cityBeadStore)
+	fs.extmsgSvc = &services
+
+	ref := extmsg.ConversationRef{
+		ScopeID:        "guild-1",
+		Provider:       "discord",
+		AccountID:      "acct-1",
+		ConversationID: "thread-1",
+		Kind:           extmsg.ConversationThread,
+	}
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	if _, err := services.Transcript.EnsureMembership(context.Background(), extmsg.EnsureMembershipInput{
+		Caller:         caller,
+		Conversation:   ref,
+		SessionID:      "myrig/worker",
+		BackfillPolicy: extmsg.MembershipBackfillSinceJoin,
+		Owner:          extmsg.MembershipOwnerManual,
+		Now:            time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("EnsureMembership(peer): %v", err)
+	}
+
+	// Nothing is excluded, so the fan-out must materialize the named member.
+	srv.extmsgNotifyMembers(context.Background(), ref, "Alice", "human", "hello peers", "", "")
+	srv.waitForBackground()
+
+	if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil {
+		t.Fatalf("STRANDED WRITE: session bead %q minted in the WORK store; session-class creates must land in the sessions binding", id)
+	}
+	if _, err := session.ResolveSessionID(fs.sessionsBeadStore, "myrig/worker"); err != nil {
+		t.Fatalf("named member was not materialized into the SESSIONS store: %v", err)
 	}
 }
 

--- a/internal/api/worker_operation_watch.go
+++ b/internal/api/worker_operation_watch.go
@@ -24,7 +24,7 @@ func (s *Server) resolveAgentSessionSubjects(name string, cfg *config.City) (str
 	}
 
 	sessionID := ""
-	if store := s.state.CityBeadStore(); store != nil {
+	if store := s.state.SessionsBeadStore().Store; store != nil {
 		if id, err := s.resolveSessionIDWithConfig(store, sessionName); err == nil {
 			sessionID = strings.TrimSpace(id)
 		}


### PR DESCRIPTION
Systematic sweep of every consumer of the city WORK store that is actually reading or writing CLASS-OWNED data, prompted by the `/status` session-snapshot instance (#5186). Full audit table in the linked bead; this PR carries the clear-cut, mechanically identical subset.

## Counts

- **148** non-test work-store accessor call sites enumerated across `internal/` and `cmd/gc/`
- **28** touch class-owned data through a work-store handle
- **20** behavioral mis-routes · **5** inert (store value never dereferenced) · **3** ambiguous
- **14** are silent-empty / silent-stale risks rather than latency-only
- **4** are stranded writes — a class-owned bead CREATED through a work-store handle

## What this PR fixes

23 call sites in 11 files, all pure accessor substitution: `CityBeadStore()` → `SessionsBeadStore().Store`, and `cr.cityBeadStore()` → `cr.sessionsBeadStore().Store`. No new accessor, no routing-semantics change. The four controller-refresh sites collapse into one `cr.refreshDesiredState` helper — the mirror of the `cr.buildDesiredState` sibling that already routed the same parameter correctly — so the routing has exactly one place to regress.

Class is decided by `coordclass.Classify` — the same function `cmd/gc/infra_class_migrate.go readInfraSnapshot` uses to select what migrates. Anything it calls non-Work that a work-store handle touches is either read from a store that never held it, or written where the binding will never see it.

Four sites were doing real damage on a converged split city:

| Site | Consequence |
|---|---|
| `cmd/gc/usage_compute.go:229` | Gets by session id and `SetMetadata`s the two usage markers onto session beads. The Get misses, the loop logs and continues, and **usage/billing facts silently stop being emitted for the whole fleet.** |
| `internal/api/handler_extmsg.go:138` | The member fan-out reaches `resolveSessionIDMaterializingNamedWithContext` → `handle.Create`, which mints a `type=session` bead. **Every extmsg cold-wake strands one.** |
| `internal/api/handler_beads.go:99` | Same materialize chain plus `RepairTypeBestEffort`. **Every named-assignee normalize strands one.** |
| `cmd/gc/city_runtime.go:673,684,1313,1347` | The desired-state refresh's store becomes `agentBuildParams.beadStore`, and the session-bead overlay mints a dependency floor through it. **Every controller tick on a `depends_on` city strands one — twice.** (Added in review; see below.) |

A stranded infrastructure bead is invisible to the sessions binding and is named by the per-boot containment re-check — the mechanism that made maintainer-city boot-fatal.

Also worth flagging: `handler_extmsg.go:97` sat one line above `:109`, which already used `SessionsBeadStore()`. The same function pair was reading two different stores.

### On `ga-j89yo`

Verified each of its eight sites individually rather than trusting the list. **Three were behavioral**; **five were inert** — `worker.Factory`'s transcript methods (`ReadTranscript`, `TailMeta`, `DiscoverTranscript`) route through `Factory.Adapter()` and never dereference `f.store`, and `session.NewManagerWithOptions` does no I/O at construction. The five move anyway so the next store-touching call added on those paths does not mis-route for free. The sweep found **eight more behavioral session-class sites the bead did not list**.

### Deliberately partial in `handler_beads.go`

Only the identifier resolution and the session-bead read/write move. The work-bead query and the work-bead write they feed stay on the work store — that is the correct split for a work handler that takes a session-shaped identifier, and both sites now say so in a comment.

## Review round: a fourth stranded write, and three guards that could not fail

Four majors from council review, all fixed here.

**1. `cmd/gc/city_runtime.go:673,684,1313,1347` — a stranded write the audit had stamped CORRECT.** Those sites passed `cr.cityBeadStore()` as `refreshDesiredStateWithSessionBeads`'s `store`, on the rationale that it was the work leg for assigned-work lookup. It is not: the function never calls `collectAssignedWorkBeads*`, and the parameter becomes `agentBuildParams.beadStore` (`agent_build_params.go:130`), whose every non-test use is session-class. `applySessionBeadDesiredOverlay` → `realizeDependencyFloors` → `ensureDependencyOnlyTemplate` → `selectOrCreateDependencyPoolSessionBead` → `createPoolSessionBeadWithAlias` → `CreateSessionInfo` **mints a `type=session` bead through it**. The sibling `cr.buildDesiredState` already passes `cr.sessionsBeadStore()` and its comment names the role exactly. It also recurs ~2× per tick: `reusableDependencyPoolSessionInfo` reads `bp.sessionBeads` while the create writes `bp.beadStore`, so the floor can never satisfy its own reuse check.

**2-4. The stranded-write guards did not bite.** Mutation-verified, each by reverting only its own site:

- `TestNormalizeRawBeadAssigneeReadsSessionsClass` passed a bead ID, which resolves on the first non-materializing pass, so the only arm that Creates never ran — the zero-work-store assertion was identical on both builds. Now passes the configured named session.
- `TestExtmsgSessionSelectorsReadSessionsClass` asserted `handle != ""`, which is unfalsifiable: the miss path returns `extmsgHandleLabel(selector)`, non-empty for every non-empty selector. Reverting `handler_extmsg.go:97` alone kept it green. Now stamps the handle source on the relocated bead only and asserts the value.
- `extmsgNotifyMembers` — this PR's #1 headline site — had **no** split-store coverage; reverting it left the entire `internal/api` suite green.

## Proofs

**Tests that fail without the fix** — `internal/api/session_class_routing_test.go` (8), `cmd/gc/usage_compute_class_routing_test.go` (2), `cmd/gc/refresh_desired_state_class_routing_test.go` (2). Each seeds a session bead in a *relocated* sessions store, leaves the work store empty, and asserts the handler found it. The three **stranded-write** sites additionally assert bead residency after a real create.

Every test is mutation-proven site-by-site — revert that one site, watch it fail, restore. Reds:

```
--- FAIL: TestResolveAgentSessionSubjectsReadsSessionsClass
--- FAIL: TestBeadListAssigneeTermsReadsSessionsClass
--- FAIL: TestNormalizeRawBeadAssigneeReadsSessionsClass
      STRANDED WRITE: work store holds 1 bead(s) after an assignee normalize
--- FAIL: TestExtmsgSessionSelectorsReadSessionsClass
      extmsgSessionHandleForSelector = "gc-1", want "relocated-alias"
--- FAIL: TestExtmsgNotifyMembersMaterializesIntoSessionsClass
      STRANDED WRITE: session bead "gc-3" minted in the WORK store
--- FAIL: TestMailRecipientResolutionReadsSessionsClass
--- FAIL: TestResolveAgentTranscriptReadsSessionKeyFromSessionsClass
--- FAIL: TestEmitDueComputeFactsReadsSessionsClass
--- FAIL: TestRefreshDesiredStateWritesSessionBeadsToSessionsClass
      STRANDED WRITE: work store holds 1 bead(s) after a desired-state refresh
      (first: id=gc-1 type=session class=sessions)
--- PASS: TestSessionClassRoutingIsIdentityOnSingleStoreCity        (identity proof — passes either way by design)
--- PASS: TestSessionsBeadStoreIsWorkStoreWhenNothingRelocates      (identity proof — passes either way by design)
--- PASS: TestRefreshDesiredStateIsUnchangedOnSingleStoreCity       (identity proof — passes either way by design)
```

**Single-store byte-identity** — three ways: (a) the identity tests assert `SessionsBeadStore().Store` and `cr.sessionsBeadStore().Store` are the *identical store value* the work accessors return when nothing is relocated (`resolveClassStore` returns `workStore` verbatim when `routes.storeFor` reports no relocation, `cmd/gc/class_store.go:254-262`); (b) behaviorally for the one path that writes — `TestRefreshDesiredStateIsUnchangedOnSingleStoreCity` runs the refresh on a city that relocates nothing and asserts the realized dependency floor is minted into the one city store, exactly where it landed before; (c) the full `internal/...` and `cmd/gc` suites pass unchanged.

**Fail-loud** — every fixed site keeps its `if store == nil` guard and returns the same typed error / empty result; none falls back to the work store when the sessions store is unavailable.

## Gates

`go build ./...` · `go vet ./...` · `gofmt` · `golangci-lint 2.10.1 ./...` → **0 issues** · `go test ./internal/...` green (157 packages) · `go test ./internal/api/...` green · `go test ./cmd/gc -timeout 25m` **serial** green (702s) · `scripts/check-core-boundary.sh` OK · `scripts/check-split-topology-rows.sh` OK.

## Filed, not fixed

Routing-semantics decisions, out of the stated fix scope:

- **ga-4dn4i** (P1) — convergence roots are `ClassGraph` by `Classify` but are minted and read in the work store. Stranded write, and `gc storage migrate` copies them to the graph binding while the engine keeps using the retained work-store copies → two divergent ledgers.
- **ga-nqdff** (P1) — `sourceWorkflowStores()` omits the graph store, so the sling singleton conflict guard finds no blocker on a graph-relocated city and **admits a duplicate workflow**.
- **ga-2agql** (P2) — `classStoresForID` is graph-only; `gcs-`/`gco-`/`gcn-`/`gcm-` ids 404 on by-id GET/PATCH.
- **ga-ystjm** (P2) — `readyDemandSnapshotFingerprint` omits the graph store, so graph ready-work never moves it and scale-up is missed.
- **ga-dgi1n** (P2) — `agentutil.findSessionNameByTemplate` matches `gc.session` (dot) not `gc:session`; a dead lookup that would become a live work-store session read if the typo alone were repaired.

Closes ga-qbqij. Companion to #5186 (which fixes `handler_status.go:487` on its own branch); no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5087 — removes three write paths (extmsg member fan-out, raw-assignee normalize, and the usage-facts lane) that minted stranded session beads through the work store on a converged split city, so fewer strands are produced going forward; it adds no recovery path for beads already stranded, which is what the filed issue asks for

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
