### PR TITLE
fix(beads): let a BdStore cache serve the complete ready projection (ga-tgpfm)

### DIFF
--- a/cmd/gc/infra_class_recover.go
+++ b/cmd/gc/infra_class_recover.go
@@ -258,10 +258,10 @@ type strandedBeadDump struct {
 // adapter: it stays true for every bead and every retry, so one probe answers
 // for the store. `database is locked`, a dropped connection, a subprocess that
 // could not fork are facts about a moment, and a moment is no evidence about a
-// capability. Reading the second as the first swaps a trustworthy read for one
-// this codebase itself marks incomplete — BdStore.listIncludesCompleteDependencies
-// returns false, which is why CachingStore refuses to serve down-deps from the
-// inline projection — and it does so for the whole run, under a zero exit code.
+// capability. Reading the second as the first swaps the relation read for the
+// inline projection unconditionally — a projection this reader only trusts once
+// it has WITNESSED it live below — and it does so for the whole run, under a
+// zero exit code.
 //
 // Text matching is what is available: the refusal crosses the adapter boundary
 // as a string and neither side carries a sentinel for it. It degrades in the

--- a/cmd/gc/infra_class_recover_topology_test.go
+++ b/cmd/gc/infra_class_recover_topology_test.go
@@ -465,9 +465,8 @@ func (s transientDepListSource) List(query beads.ListQuery) ([]beads.Bead, error
 // bd/Postgres backend answers `operation "IssueRelations" not supported by the
 // postgres backend`, and that is a fact about the adapter. A locked database, a
 // lost connection or a subprocess that failed to fork is a fact about a moment.
-// Reading the second as the first swaps a trustworthy read for one the codebase
-// itself marks incomplete (BdStore.listIncludesCompleteDependencies is false),
-// and does it for the whole run.
+// Reading the second as the first swaps the relation read for a projection this
+// reader has not witnessed, and does it for the whole run.
 //
 // Red-before, on the reader that latched on ANY probe error:
 //

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -373,6 +373,11 @@ type BdStore struct {
 	readyProjectionMu      sync.Mutex
 	readyProjectionChecked bool
 	readyProjectionEnabled bool
+	// readyProjectionVersionErr memoizes the ErrReadyProjectionUnsupported this
+	// store owes every later caller when the bd on PATH predates the is_blocked
+	// projection. Store-local rather than scope-latched: the bd binary is a
+	// property of the process, not of the ledger. See bdstore_ready_projection.go.
+	readyProjectionVersionErr error
 	// readyProjectionScope memoizes, per SCOPE PATH, the verdict that this
 	// ledger cannot serve the ready projection at all. Shared with every other
 	// store rooted at the same directory, because cmd/gc rebuilds a store per
@@ -412,6 +417,12 @@ type BdStore struct {
 	unreadStore *unreadStoreGuard
 	// noticeSink redirects operator notices away from stderr; nil is stderr.
 	noticeSink io.Writer
+
+	// inlineDeps records whether bd's list JSON has been seen to carry each
+	// row's dependency edges beside it, which is what lets a CachingStore over
+	// this store serve down-deps and complete-ready reads from the snapshot.
+	// See bdstore_inline_deps.go.
+	inlineDeps inlineDependencyProjection
 
 	localStrings *localSidecar // clone-local data; see Store.SetLocalString
 }
@@ -525,10 +536,6 @@ func (s *BdStore) Dir() string {
 // label hydration.
 func (s *BdStore) ListSkipLabelsEnabled() bool {
 	return s != nil && s.listSkipLabelsEnabled
-}
-
-func (s *BdStore) listIncludesCompleteDependencies() bool {
-	return false
 }
 
 // Init initializes a beads database via bd init --server. This is an admin
@@ -773,10 +780,16 @@ type bdIssue struct {
 	Labels       []string     `json:"labels"`
 	Metadata     StringMap    `json:"metadata,omitempty"`
 	Dependencies []bdIssueDep `json:"dependencies,omitempty"`
-	Ephemeral    bool         `json:"ephemeral,omitempty"`
-	NoHistory    bool         `json:"no_history,omitempty"`
-	DeferUntil   *time.Time   `json:"defer_until,omitempty"`
-	IsBlocked    optionalBool `json:"is_blocked,omitempty"`
+	// DependencyCount is bd's own count of this row's BLOCKING edges,
+	// projected from the same dependency table and the same query as
+	// Dependencies. It is the control that turns "bd carried edges inline"
+	// into a falsifiable claim — see bdstore_inline_deps.go. A pointer so a bd
+	// that omits the field stays distinguishable from one reporting zero.
+	DependencyCount *int         `json:"dependency_count,omitempty"`
+	Ephemeral       bool         `json:"ephemeral,omitempty"`
+	NoHistory       bool         `json:"no_history,omitempty"`
+	DeferUntil      *time.Time   `json:"defer_until,omitempty"`
+	IsBlocked       optionalBool `json:"is_blocked,omitempty"`
 	// Revision carries bd's optimistic-concurrency token for ConditionalWriter.
 	// Pre-#4682 bd omits it, so it decodes to 0; toBead stamps it onto the
 	// otherwise json:"-" Bead.Revision field. The "revision" key is provisional:
@@ -2532,6 +2545,7 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	for i := range issues {
 		result[i] = issues[i].toBead()
 	}
+	s.noteInlineDependencyProjection(issues, result)
 	filtered := applyListQuery(result, query)
 	if parseErr != nil {
 		if len(filtered) == 0 {
@@ -2644,6 +2658,7 @@ func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
 		result[i].Ephemeral = true
 		result[i].NoHistory = false
 	}
+	s.noteInlineDependencyProjection(issues, result)
 	filtered := applyListQuery(result, query)
 	if parseErr != nil {
 		if len(filtered) > 0 {

--- a/internal/beads/bdstore_inline_deps.go
+++ b/internal/beads/bdstore_inline_deps.go
@@ -1,0 +1,115 @@
+package beads
+
+import "sync/atomic"
+
+// inlineDependencyProjection is what a BdStore has learned, from bd's own
+// answers, about the dependency rows bd's list JSON carries beside each issue.
+//
+// bd projects those rows from the same table, in the same query, as the
+// dependency_count it puts on every row: sqlbuild.SearchCountsSQL selects
+// `d.deps_json = JSON_ARRAYAGG(...)` over tables.Dependencies alongside
+// `dc.cnt = COUNT(*) ... WHERE type = 'blocks'` over that same table, for the
+// issues family and the wisps family alike, and ScanReadyWorkRowWithCounts
+// unmarshals deps_json onto types.Issue.Dependencies. Both `bd list` and the
+// `bd query` this store uses for the wisp tier go through that one builder.
+//
+// So the count and the rows are two views of one read, and a disagreement
+// between them is the only way the inline projection can be short. That makes
+// the completeness claim MEASURABLE per listing rather than assumed from a
+// reading of bd's source — which matters, because an adapter that populated the
+// field for nobody would answer "no edges" for every bead and a cache that
+// believed it would flatten the whole topology into "everything is ready".
+type inlineDependencyProjection struct {
+	// witnessed latches on the first listed row bd said had blocking edges AND
+	// carried them. Nothing short of a row with edges proves the projection is
+	// live, so a store whose ledger has no dependencies at all never claims
+	// completeness — it keeps today's behavior, which is correct and merely
+	// slower.
+	witnessed atomic.Bool
+	// contradicted latches on the first listed row whose dependency_count and
+	// inline blocking edges disagree, and is authoritative over witnessed. It
+	// is one-way: a projection that was short once is not one a later page can
+	// vouch for, and the cost of being wrong is offering the control dispatcher
+	// work whose gate has not opened.
+	contradicted atomic.Bool
+}
+
+// noteInlineDependencyProjection records what one page of bd output proved
+// about the inline dependency projection. rows and beads are parallel:
+// beads[i] must be rows[i].toBead(), so the comparison is against the
+// NORMALIZED edges a cache would actually consume rather than against the raw
+// JSON.
+//
+// It is called with what bd RETURNED, before any client-side filtering, for the
+// same reason noteServerRows is: a filter reducing a real answer to nothing says
+// nothing about the ledger.
+func (s *BdStore) noteInlineDependencyProjection(rows []bdIssue, beads []Bead) {
+	if s == nil || len(rows) != len(beads) || s.inlineDeps.contradicted.Load() {
+		return
+	}
+	witnessed := false
+	for i := range rows {
+		// A bd that does not project the count cannot testify either way. Skip
+		// the row rather than reading its silence as a disagreement.
+		if rows[i].DependencyCount == nil {
+			continue
+		}
+		blocking := 0
+		for _, dep := range beads[i].Dependencies {
+			// dependency_count is COUNT(*) WHERE type = 'blocks' exactly — not
+			// the wider set gascity treats as ready-blocking — so the comparison
+			// is against that one type.
+			if dep.Type == "blocks" {
+				blocking++
+			}
+		}
+		if blocking != *rows[i].DependencyCount {
+			s.inlineDeps.contradicted.Store(true)
+			return
+		}
+		if blocking > 0 {
+			witnessed = true
+		}
+	}
+	if witnessed {
+		s.inlineDeps.witnessed.Store(true)
+	}
+}
+
+// listIncludesCompleteDependencies reports whether the rows this store's List
+// hands back carry their complete "down" dependency set inline, so a
+// CachingStore over it can serve DepList and readiness from the snapshot it
+// already has instead of spending a second read.
+//
+// This used to be a flat false, and that cost every BdStore-backed scope its
+// complete-ready cache read permanently: CachingStore.cachedReadyCompleteOnly
+// gates on depsComplete, so ReadyContext answered "bead cache unavailable"
+// forever and the control dispatcher took a live `bd ready` on every tick
+// (ga-tgpfm). On maintainer-city, whose work class is cross-region hosted
+// Postgres, that live read costs ~4.4 s.
+//
+// The verdict is now the witnessed one, and the witness is free: it is read off
+// the rows bd already returned (noteInlineDependencyProjection), so this adds
+// ZERO subprocesses for any N. That is the whole reason it is not a
+// dependencySnapshotForCache over DepListBatch, which the two other stores use:
+// DepListBatch is `bd dep list`, and the bd/Postgres backend answers that with
+// `operation "IssueRelations" not supported by the postgres backend` (measured
+// on maintainer-city, ga-7i7ts). On the one city this defect is about, the
+// batched read would have bought a guaranteed-failing subprocess per prime and
+// per reconcile and left depsComplete false. The same inline fallback is what
+// cmd/gc/infra_class_recover.go's sourceDepReader already relies on for that
+// adapter, and for the same reason.
+//
+// Completeness of the dep SET is not the same claim as readiness equalling bd's.
+// bd's is_blocked propagates transitively down parent-child edges, which no
+// down-dep set can reproduce, so the cache's readiness answer equals bd's only
+// while enrichReadyProjectionForCache is filling that column — and when it
+// cannot, it reports ErrReadyProjectionUnsupported and the cache declines every
+// readiness handle (readyReadsMustGoLive). Those two are separate gates on
+// purpose; this one only says the rows carry their own edges.
+func (s *BdStore) listIncludesCompleteDependencies() bool {
+	if s == nil || s.inlineDeps.contradicted.Load() {
+		return false
+	}
+	return s.inlineDeps.witnessed.Load()
+}

--- a/internal/beads/bdstore_inline_deps_internal_test.go
+++ b/internal/beads/bdstore_inline_deps_internal_test.go
@@ -1,0 +1,539 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// bdLedgerRow is one row of the fake bd ledger below: the issue fields the
+// cache reads plus the two dependency columns bd projects from the same query.
+type bdLedgerRow struct {
+	id        string
+	ephemeral bool
+	blocked   bool
+	deps      []Dep
+}
+
+// fakeBdLedger answers the bd subcommands a CachingStore prime spends, the way
+// a real bd does.
+//
+// It renders `dependencies` and `dependency_count` from ONE source — the row's
+// edges — because that is what bd does: sqlbuild.SearchCountsSQL projects
+// deps_json (JSON_ARRAYAGG over the dependency table) and dep_count (COUNT(*)
+// over the same table WHERE type='blocks') side by side in the counts
+// mega-query, for the issues family and the wisps family alike. Wiring them to
+// one source here is what makes the witness in bdstore_inline_deps.go a real
+// measurement rather than a fixture-shaped tautology: truncateDeps below breaks
+// the two apart and the witness must notice.
+type fakeBdLedger struct {
+	rows []bdLedgerRow
+	// depListRefusal, when set, is how `bd dep list` fails. maintainer-city's
+	// bd/Postgres work store answers exactly this (ga-7i7ts), which is why the
+	// completeness verdict cannot be built on DepListBatch.
+	depListRefusal string
+	// truncateDeps drops these ids' inline edges while leaving their
+	// dependency_count intact, modeling a bd whose list JSON is short.
+	truncateDeps map[string]bool
+	// omitDependencyCount renders rows without the count column, modeling a bd
+	// that cannot testify about its own projection.
+	omitDependencyCount bool
+
+	calls [][]string
+}
+
+func (f *fakeBdLedger) run(_, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string{name}, args...))
+	joined := strings.Join(args, " ")
+	switch {
+	case joined == "version":
+		return []byte("bd version 1.1.0\n"), nil
+	case args[0] == "list":
+		return f.renderRows(func(r bdLedgerRow) bool { return !r.ephemeral })
+	case args[0] == "query":
+		return f.renderRows(func(r bdLedgerRow) bool { return r.ephemeral })
+	case args[0] == "ready":
+		// bd ready filters is_blocked = 0 (sqlbuild.ReadyWhere). This is the
+		// backing's own verdict, the one the cache may never exceed.
+		return f.renderRows(func(r bdLedgerRow) bool { return !r.blocked })
+	case args[0] == "sql":
+		return f.renderReadyProjection()
+	case args[0] == "dep" && len(args) > 1 && args[1] == "list":
+		if f.depListRefusal != "" {
+			return nil, errors.New(f.depListRefusal)
+		}
+		return f.renderDepRecords(args[2:])
+	}
+	return nil, fmt.Errorf("unexpected command: %s", joined)
+}
+
+func (f *fakeBdLedger) renderRows(keep func(bdLedgerRow) bool) ([]byte, error) {
+	out := make([]map[string]any, 0, len(f.rows))
+	for _, row := range f.rows {
+		if !keep(row) {
+			continue
+		}
+		issue := map[string]any{
+			"id":         row.id,
+			"title":      row.id,
+			"status":     "open",
+			"issue_type": "task",
+		}
+		if row.ephemeral {
+			issue["ephemeral"] = true
+		}
+		blocking := 0
+		deps := make([]map[string]string, 0, len(row.deps))
+		for _, dep := range row.deps {
+			if dep.Type == "blocks" {
+				blocking++
+			}
+			deps = append(deps, map[string]string{
+				"issue_id":      dep.IssueID,
+				"depends_on_id": dep.DependsOnID,
+				"type":          dep.Type,
+			})
+		}
+		if !f.omitDependencyCount {
+			issue["dependency_count"] = blocking
+		}
+		if len(deps) > 0 && !f.truncateDeps[row.id] {
+			issue["dependencies"] = deps
+		}
+		out = append(out, issue)
+	}
+	return json.Marshal(out)
+}
+
+func (f *fakeBdLedger) renderReadyProjection() ([]byte, error) {
+	out := make([]map[string]any, 0, len(f.rows))
+	for _, row := range f.rows {
+		out = append(out, map[string]any{"id": row.id, "is_blocked": row.blocked})
+	}
+	return json.Marshal(out)
+}
+
+func (f *fakeBdLedger) renderDepRecords(ids []string) ([]byte, error) {
+	wanted := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		wanted[strings.TrimPrefix(id, "--")] = true
+	}
+	out := make([]map[string]string, 0)
+	for _, row := range f.rows {
+		if !wanted[row.id] {
+			continue
+		}
+		for _, dep := range row.deps {
+			out = append(out, map[string]string{
+				"issue_id":      dep.IssueID,
+				"depends_on_id": dep.DependsOnID,
+				"type":          dep.Type,
+			})
+		}
+	}
+	return json.Marshal(out)
+}
+
+func (f *fakeBdLedger) callsNamed(sub ...string) [][]string {
+	var found [][]string
+	for _, call := range f.calls {
+		if len(call) < 1+len(sub) {
+			continue
+		}
+		match := true
+		for i, want := range sub {
+			if call[1+i] != want {
+				match = false
+				break
+			}
+		}
+		if match {
+			found = append(found, call)
+		}
+	}
+	return found
+}
+
+// bdReadyDisagreementLedger is #5184's fixture, moved onto a bd-backed store and
+// extended with the tier that actually carries molecule steps.
+//
+//	blocker (open) <-- blocks -- parent <-- parent-child -- child
+//	gcg-offscope (not in this scope) <-- blocks -- xstore
+//	parent <-- parent-child -- wisp-step   (ephemeral)
+//	unrelated <-- blocks -- wisp-gate      (ephemeral)
+//
+// child and wisp-step carry no blocking dep of their own, so the cache's
+// dependency-derived predicate calls them ready while bd marks them
+// is_blocked=1 through the parent-child edge. xstore carries one, but its target
+// is not resident in this scope's cache, and cachedBeadReady treats a dep as
+// blocking only when statusByID holds the target — so that edge is invisible to
+// it too. wisp-gate is the wisp tier's blocking edge, so the tier bd serves
+// through `bd query` rather than `bd list` also has a row that can prove — and
+// disprove — the projection. unrelated is the control both models call ready.
+func bdReadyDisagreementLedger() *fakeBdLedger {
+	return &fakeBdLedger{
+		depListRefusal: `exit status 1: Error: operation "IssueRelations" not supported by the postgres backend`,
+		rows: []bdLedgerRow{
+			{id: "bd-blocker"},
+			{id: "bd-parent", blocked: true, deps: []Dep{{IssueID: "bd-parent", DependsOnID: "bd-blocker", Type: "blocks"}}},
+			{id: "bd-child", blocked: true, deps: []Dep{{IssueID: "bd-child", DependsOnID: "bd-parent", Type: "parent-child"}}},
+			{id: "bd-xstore", blocked: true, deps: []Dep{{IssueID: "bd-xstore", DependsOnID: "gcg-offscope", Type: "blocks"}}},
+			{id: "bd-unrelated"},
+			{id: "bd-wisp-step", ephemeral: true, blocked: true, deps: []Dep{{IssueID: "bd-wisp-step", DependsOnID: "bd-parent", Type: "parent-child"}}},
+			{id: "bd-wisp-gate", ephemeral: true, blocked: true, deps: []Dep{{IssueID: "bd-wisp-gate", DependsOnID: "bd-unrelated", Type: "blocks"}}},
+		},
+	}
+}
+
+func primedBdCache(t *testing.T, ledger *fakeBdLedger) (*CachingStore, *BdStore) {
+	t.Helper()
+	store := NewBdStore(t.TempDir(), ledger.run)
+	cache := NewCachingStoreForTest(store, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	return cache, store
+}
+
+// TestBdBackedCacheServesTheCompleteReadyProjection is ga-tgpfm.
+//
+// CachingStore.cachedReadyCompleteOnly gates on depsComplete, which came from
+// BdStore.listIncludesCompleteDependencies — a hardcoded false. So every scope
+// on a BdStore answered ReadyContext with "bead cache unavailable" forever and
+// took a live `bd ready` per tick; on maintainer-city, whose work class is
+// cross-region hosted Postgres, that read costs ~4.4s and the order loop starved.
+//
+// Red before the fix, on the unmodified fixture:
+//
+//	ReadyContext error = reading complete ready projection from cache: bead cache unavailable, want rows served from cache
+func TestBdBackedCacheServesTheCompleteReadyProjection(t *testing.T) {
+	ledger := bdReadyDisagreementLedger()
+	cache, store := primedBdCache(t, ledger)
+
+	rows, err := cache.ReadyContext(context.Background())
+	if err != nil {
+		t.Fatalf("ReadyContext error = %v, want rows served from cache", err)
+	}
+	want := wantReadyIDs("bd-blocker", "bd-unrelated")
+	if got := sortedIDs(rows); !equalIDs(got, want) {
+		t.Fatalf("ReadyContext = %v, want %v", got, want)
+	}
+
+	if !store.listIncludesCompleteDependencies() {
+		t.Fatal("BdStore did not witness the inline dependency projection bd's list JSON carried")
+	}
+	cache.mu.RLock()
+	complete := cache.depsComplete
+	cache.mu.RUnlock()
+	if !complete {
+		t.Fatal("cache depsComplete = false after priming from a store whose rows carry their edges")
+	}
+}
+
+// TestBdBackedCachedReadyNeverOffersWorkTheBackingHides is #5183/#5184's
+// invariant on the BdStore path: a cached ready read may never return a bead the
+// backing's own Ready() excludes.
+//
+// depsComplete=true hands readiness to cachedBeadReady, which answers from bd's
+// is_blocked column when it is present and falls back to the bead's OWN direct
+// blocks/waits-for/conditional-blocks deps when it is not. The fallback is
+// strictly weaker in the two ways this fixture pins — it does not propagate down
+// parent-child, and it ignores an edge whose target is not resident in the same
+// scope — and either gap offers the control dispatcher a step whose gate has not
+// opened (#3218). The column is what makes the two answers equal.
+func TestBdBackedCachedReadyNeverOffersWorkTheBackingHides(t *testing.T) {
+	ledger := bdReadyDisagreementLedger()
+	cache, store := primedBdCache(t, ledger)
+
+	live, err := store.Ready(ReadyQuery{TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("bd Ready: %v", err)
+	}
+	want := sortedIDs(live)
+	if got := wantReadyIDs("bd-blocker", "bd-unrelated"); !equalIDs(want, got) {
+		t.Fatalf("bd Ready = %v, want %v: the fixture must model bd's is_blocked filter", want, got)
+	}
+
+	readers := []struct {
+		name string
+		read func() ([]Bead, error)
+	}{
+		{"Ready", func() ([]Bead, error) { return cache.Ready() }},
+		{"ReadyContext", func() ([]Bead, error) { return cache.ReadyContext(context.Background()) }},
+		{"CachedReady", func() ([]Bead, error) {
+			rows, ok := cache.CachedReady()
+			if !ok {
+				return nil, ErrCacheUnavailable
+			}
+			return rows, nil
+		}},
+		{"Handles().Cached.Ready", func() ([]Bead, error) { return cache.Handles().Cached.Ready() }},
+	}
+	for _, reader := range readers {
+		rows, err := reader.read()
+		if err != nil {
+			// Declining is a correct answer: the caller then takes the live
+			// backing verdict. Answering with MORE than the backing is not.
+			if errors.Is(err, ErrCacheUnavailable) {
+				continue
+			}
+			t.Fatalf("%s: %v", reader.name, err)
+		}
+		got := sortedIDs(rows)
+		for _, hidden := range []string{"bd-child", "bd-wisp-step"} {
+			if containsID(got, hidden) {
+				t.Errorf("%s offered %s, a child of a blocked parent that bd's own ready hides: "+
+					"blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it (backing = %v, cache = %v)",
+					reader.name, hidden, want, got)
+			}
+		}
+		if containsID(got, "bd-xstore") {
+			t.Errorf("%s offered bd-xstore, whose blocker gcg-offscope is not resident in this scope's cache: "+
+				"cachedBeadReady treats a dep as blocking only when statusByID holds the target (backing = %v, cache = %v)",
+				reader.name, want, got)
+		}
+		if extra := idsBeyond(got, want); len(extra) > 0 {
+			t.Errorf("%s returned %v beyond bd's own ready (backing = %v)", reader.name, extra, want)
+		}
+	}
+
+	// Declining is the fail-safe, not the fix. A store that only ever declined
+	// would satisfy the subset checks above while costing maintainer-city the
+	// live read this bead exists to remove.
+	cached, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady declined: a bd that can answer is_blocked must keep serving readiness from cache")
+	}
+	if got := sortedIDs(cached); !equalIDs(got, want) {
+		t.Fatalf("CachedReady = %v, want %v (bd's own verdict)", got, want)
+	}
+}
+
+// TestBdDependencyCompletenessSpendsNoSubprocess is the cost half. The verdict
+// runs on every cache prime and every reconcile of every BdStore scope, so it
+// must be free: it is read off rows bd already returned.
+//
+// `bd dep list` is not merely expensive here, it is UNSUPPORTED — the fixture
+// refuses it the way maintainer-city's bd/Postgres work store does (ga-7i7ts) —
+// so a DepListBatch-backed verdict would have spent a guaranteed-failing ~4.4s
+// subprocess per prime and per reconcile and still left depsComplete false.
+func TestBdDependencyCompletenessSpendsNoSubprocess(t *testing.T) {
+	ledger := bdReadyDisagreementLedger()
+	cache, _ := primedBdCache(t, ledger)
+
+	if deps := ledger.callsNamed("dep", "list"); len(deps) != 0 {
+		t.Fatalf("prime spent %v; the completeness verdict must cost no subprocess", deps)
+	}
+	if _, err := cache.ReadyContext(context.Background()); err != nil {
+		t.Fatalf("ReadyContext: %v", err)
+	}
+	if deps := ledger.callsNamed("dep", "list"); len(deps) != 0 {
+		t.Fatalf("the cached ready read spent %v", deps)
+	}
+	if ready := ledger.callsNamed("ready"); len(ready) != 0 {
+		t.Fatalf("the cached ready read fell back to a live %v", ready)
+	}
+}
+
+// TestBdCachedDepListMatchesTheLiveDepList is what depsComplete promises beyond
+// readiness: CachingStore.DepList stops delegating and serves "down" edges from
+// the snapshot, so the snapshot's edges must BE bd's edges. This is the seam
+// where a short inline projection would surface as silently missing edges.
+func TestBdCachedDepListMatchesTheLiveDepList(t *testing.T) {
+	ledger := bdReadyDisagreementLedger()
+	ledger.depListRefusal = ""
+	cache, store := primedBdCache(t, ledger)
+
+	for _, id := range []string{"bd-blocker", "bd-parent", "bd-child", "bd-xstore", "bd-unrelated", "bd-wisp-step", "bd-wisp-gate"} {
+		live, err := store.DepListBatch([]string{id})
+		if err != nil {
+			t.Fatalf("live DepListBatch(%s): %v", id, err)
+		}
+		cached, err := cache.DepList(id, "down")
+		if err != nil {
+			t.Fatalf("cached DepList(%s): %v", id, err)
+		}
+		if len(cached) != len(live[id]) {
+			t.Fatalf("DepList(%s) from cache = %+v, want bd's %+v", id, cached, live[id])
+		}
+		for i := range cached {
+			if cached[i] != live[id][i] {
+				t.Fatalf("DepList(%s)[%d] from cache = %+v, want bd's %+v", id, i, cached[i], live[id][i])
+			}
+		}
+	}
+}
+
+// TestBdRefusesCompletenessWhenBdContradictsItsOwnProjection is the falsifier.
+//
+// The claim is not "bd carries edges inline"; it is "the edges bd carried are
+// all of them". bd hands back its own count of each row's blocking edges from
+// the same query, so a row whose count exceeds the edges it carried is proof the
+// projection is short — and one such row disqualifies the whole ledger, forever,
+// because a cache that believed a short projection would read a blocked bead as
+// ready.
+// The two tiers arrive through different bd subcommands — `bd list` for issues,
+// `bd query` for wisps — so each is checked with the other left whole, and
+// neither call site can be dropped without a test noticing.
+func TestBdRefusesCompletenessWhenBdContradictsItsOwnProjection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		row  string
+	}{
+		{"issues tier", "bd-parent"},
+		{"wisp tier", "bd-wisp-gate"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger := bdReadyDisagreementLedger()
+			ledger.truncateDeps = map[string]bool{tc.row: true}
+			cache, store := primedBdCache(t, ledger)
+
+			if store.listIncludesCompleteDependencies() {
+				t.Fatalf("BdStore claimed complete dependencies though bd's own dependency_count for %s contradicts the edges it carried", tc.row)
+			}
+			cache.mu.RLock()
+			complete := cache.depsComplete
+			cache.mu.RUnlock()
+			if complete {
+				t.Fatal("cache depsComplete = true over a short inline projection")
+			}
+			if _, err := cache.ReadyContext(context.Background()); !errors.Is(err, ErrCacheUnavailable) {
+				t.Fatalf("ReadyContext error = %v, want ErrCacheUnavailable: an unproven projection must decline", err)
+			}
+
+			// One contradicted page disqualifies the ledger for good: a later
+			// clean listing is not evidence the earlier truncation was benign.
+			ledger.truncateDeps = nil
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("re-Prime: %v", err)
+			}
+			if store.listIncludesCompleteDependencies() {
+				t.Fatal("a later clean listing un-latched the contradiction")
+			}
+		})
+	}
+}
+
+// TestBdWitnessesTheProjectionOnEitherTier pins that both tiers are observed.
+// bd serves issues through `bd list` and wisps through `bd query`, and wisps are
+// where molecule steps live — a ledger whose only edges are on the wisp tier
+// must still be able to prove its projection, and vice versa.
+func TestBdWitnessesTheProjectionOnEitherTier(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ephemeral bool
+	}{
+		{"issues tier", false},
+		{"wisp tier", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger := &fakeBdLedger{rows: []bdLedgerRow{
+				{id: "bd-target"},
+				{
+					id:        "bd-holder",
+					ephemeral: tc.ephemeral,
+					blocked:   true,
+					deps:      []Dep{{IssueID: "bd-holder", DependsOnID: "bd-target", Type: "blocks"}},
+				},
+			}}
+			_, store := primedBdCache(t, ledger)
+			if !store.listIncludesCompleteDependencies() {
+				t.Fatalf("the %s listing carried an edge bd counted, and it was not witnessed", tc.name)
+			}
+		})
+	}
+}
+
+// TestBdRefusesCompletenessOnALedgerThatProvesNothing is the fail-safe control
+// for the witness, and the reason the verdict is not simply "bd is new enough".
+//
+// An adapter that never populated the field would answer "no edges" for every
+// bead, and a cache that believed it would flatten the whole topology into
+// "everything is ready". Nothing short of a row that actually carried edges
+// proves the projection is live, so a ledger with none — or a bd that will not
+// say how many edges a row has — keeps the pre-fix behavior: correct, and
+// merely slower.
+func TestBdRefusesCompletenessOnALedgerThatProvesNothing(t *testing.T) {
+	t.Run("no row carries an edge", func(t *testing.T) {
+		ledger := &fakeBdLedger{rows: []bdLedgerRow{{id: "bd-1"}, {id: "bd-2"}}}
+		cache, store := primedBdCache(t, ledger)
+		if store.listIncludesCompleteDependencies() {
+			t.Fatal("an edge-free listing is not evidence that this ledger projects edges")
+		}
+		if _, err := cache.ReadyContext(context.Background()); !errors.Is(err, ErrCacheUnavailable) {
+			t.Fatalf("ReadyContext error = %v, want ErrCacheUnavailable", err)
+		}
+	})
+
+	t.Run("bd omits dependency_count", func(t *testing.T) {
+		ledger := bdReadyDisagreementLedger()
+		ledger.omitDependencyCount = true
+		_, store := primedBdCache(t, ledger)
+		if store.listIncludesCompleteDependencies() {
+			t.Fatal("a bd that will not count its own edges cannot vouch for the projection")
+		}
+	})
+}
+
+// TestBdWithoutTheBlockedColumnSendsReadyToTheLiveVerdict closes the hole
+// depsComplete=true would otherwise open on an old bd.
+//
+// The is_blocked projection landed in bd 1.0.5. Before this bead the version
+// gate answered (false, nil) — no error, so no degrade — on the reading that the
+// absence "costs only the enrichment". That held only while depsComplete was
+// hardcoded false. With the snapshot's own edges now serving readiness, a silent
+// (false, nil) would hand every readiness handle to the dependency-derived
+// predicate, which is exactly the #3218 regression. So the version gate now
+// names the degrade and readiness declines the cache.
+func TestBdWithoutTheBlockedColumnSendsReadyToTheLiveVerdict(t *testing.T) {
+	ledger := bdReadyDisagreementLedger()
+	oldBd := &fakeBdLedger{rows: ledger.rows, depListRefusal: ledger.depListRefusal}
+	inner := oldBd.run
+	runner := func(dir, name string, args ...string) ([]byte, error) {
+		if strings.Join(args, " ") == "version" {
+			oldBd.calls = append(oldBd.calls, append([]string{name}, args...))
+			return []byte("bd version 1.0.4\n"), nil
+		}
+		return inner(dir, name, args...)
+	}
+
+	store := NewBdStore(t.TempDir(), runner)
+	cache := NewCachingStoreForTest(store, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if !cache.readyReadsMustGoLive() {
+		t.Error("a bd that cannot answer is_blocked must latch the ready-projection degrade")
+	}
+	rows, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	want := wantReadyIDs("bd-blocker", "bd-unrelated")
+	if got := sortedIDs(rows); !equalIDs(got, want) {
+		t.Fatalf("Ready = %v, want %v: the transitively blocked rows must not be offered", got, want)
+	}
+	if _, ok := cache.CachedReady(); ok {
+		t.Error("CachedReady answered from a cache with no is_blocked column; the control dispatcher reads this handle")
+	}
+	if _, err := cache.ReadyContext(context.Background()); !errors.Is(err, ErrCacheUnavailable) {
+		t.Errorf("ReadyContext error = %v, want ErrCacheUnavailable", err)
+	}
+	if _, err := cache.Handles().Cached.Ready(); !errors.Is(err, ErrCacheUnavailable) {
+		t.Errorf("cached reader Ready error = %v, want ErrCacheUnavailable", err)
+	}
+
+	// The rows are whole, so everything that does not need the column keeps
+	// serving from cache — the separation #5183 established.
+	cached, ok := cache.CachedList(ListQuery{AllowScan: true, TierMode: TierBoth})
+	if !ok {
+		t.Fatal("CachedList declined: the degrade must not make non-readiness reads unavailable")
+	}
+	if len(cached) != len(oldBd.rows) {
+		t.Fatalf("CachedList returned %d rows, want %d", len(cached), len(oldBd.rows))
+	}
+}

--- a/internal/beads/bdstore_inline_deps_internal_test.go
+++ b/internal/beads/bdstore_inline_deps_internal_test.go
@@ -15,6 +15,8 @@ type bdLedgerRow struct {
 	id        string
 	ephemeral bool
 	blocked   bool
+	closed    bool
+	assignee  string
 	deps      []Dep
 }
 
@@ -52,13 +54,24 @@ func (f *fakeBdLedger) run(_, name string, args ...string) ([]byte, error) {
 	case joined == "version":
 		return []byte("bd version 1.1.0\n"), nil
 	case args[0] == "list":
-		return f.renderRows(func(r bdLedgerRow) bool { return !r.ephemeral })
+		return f.renderRows(func(r bdLedgerRow) bool { return !r.ephemeral && !r.closed })
 	case args[0] == "query":
-		return f.renderRows(func(r bdLedgerRow) bool { return r.ephemeral })
+		return f.renderRows(func(r bdLedgerRow) bool { return r.ephemeral && !r.closed })
 	case args[0] == "ready":
 		// bd ready filters is_blocked = 0 (sqlbuild.ReadyWhere). This is the
 		// backing's own verdict, the one the cache may never exceed.
-		return f.renderRows(func(r bdLedgerRow) bool { return !r.blocked })
+		return f.renderRows(func(r bdLedgerRow) bool { return !r.blocked && !r.closed })
+	case args[0] == "show":
+		// `bd show --json` answers from types.IssueDetails, which embeds
+		// types.Issue — and NOTHING in beads carries a `json:"is_blocked"` tag.
+		// So every row a Get refresh installs arrives with IsBlocked nil, no
+		// matter how healthy bd is. That is the whole mechanism behind
+		// ga-cfhgr: renderRows never emits the key either.
+		return f.renderRows(func(r bdLedgerRow) bool { return r.id == args[len(args)-1] })
+	case args[0] == "update":
+		return f.applyUpdate(args[2:])
+	case args[0] == "close":
+		return f.applyClose(args[1:])
 	case args[0] == "sql":
 		return f.renderReadyProjection()
 	case args[0] == "dep" && len(args) > 1 && args[1] == "list":
@@ -70,20 +83,82 @@ func (f *fakeBdLedger) run(_, name string, args ...string) ([]byte, error) {
 	return nil, fmt.Errorf("unexpected command: %s", joined)
 }
 
+// applyUpdate mutates the ledger the way `bd update` does. Only the fields the
+// staleness tests write are supported; anything else is a loud failure rather
+// than a silent no-op.
+func (f *fakeBdLedger) applyUpdate(args []string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("bd update: no id")
+	}
+	id := args[0]
+	for i := 1; i+1 < len(args); i += 2 {
+		switch args[i] {
+		case "--assignee":
+			if err := f.mutate(id, func(r *bdLedgerRow) { r.assignee = args[i+1] }); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("bd update: unsupported flag %s", args[i])
+		}
+	}
+	return []byte("{}"), nil
+}
+
+// applyClose mutates the ledger the way `bd close` does. It deliberately does
+// NOT recompute any other row's is_blocked: the fixtures that close a bead
+// declare a topology where bd's own verdict is unchanged by the close, which is
+// exactly what makes the cache's post-close answer falsifiable.
+func (f *fakeBdLedger) applyClose(args []string) ([]byte, error) {
+	closed := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--force", "--json":
+		case "--reason":
+			i++
+		default:
+			if err := f.mutate(args[i], func(r *bdLedgerRow) { r.closed = true }); err != nil {
+				return nil, err
+			}
+			closed = true
+		}
+	}
+	if !closed {
+		return nil, errors.New("bd close: no id")
+	}
+	return []byte("{}"), nil
+}
+
+func (f *fakeBdLedger) mutate(id string, apply func(*bdLedgerRow)) error {
+	for i := range f.rows {
+		if f.rows[i].id == id {
+			apply(&f.rows[i])
+			return nil
+		}
+	}
+	return fmt.Errorf("bd: no such bead %q", id)
+}
+
 func (f *fakeBdLedger) renderRows(keep func(bdLedgerRow) bool) ([]byte, error) {
 	out := make([]map[string]any, 0, len(f.rows))
 	for _, row := range f.rows {
 		if !keep(row) {
 			continue
 		}
+		status := "open"
+		if row.closed {
+			status = "closed"
+		}
 		issue := map[string]any{
 			"id":         row.id,
 			"title":      row.id,
-			"status":     "open",
+			"status":     status,
 			"issue_type": "task",
 		}
 		if row.ephemeral {
 			issue["ephemeral"] = true
+		}
+		if row.assignee != "" {
+			issue["assignee"] = row.assignee
 		}
 		blocking := 0
 		deps := make([]map[string]string, 0, len(row.deps))
@@ -111,6 +186,12 @@ func (f *fakeBdLedger) renderRows(keep func(bdLedgerRow) bool) ([]byte, error) {
 func (f *fakeBdLedger) renderReadyProjection() ([]byte, error) {
 	out := make([]map[string]any, 0, len(f.rows))
 	for _, row := range f.rows {
+		// The projection query filters `status <> 'closed'` on both tiers
+		// (bdReadyProjectionSQL), so a closed row simply has no is_blocked to
+		// report — the same shape the cache must survive between reconciles.
+		if row.closed {
+			continue
+		}
 		out = append(out, map[string]any{"id": row.id, "is_blocked": row.blocked})
 	}
 	return json.Marshal(out)
@@ -233,6 +314,15 @@ func TestBdBackedCacheServesTheCompleteReadyProjection(t *testing.T) {
 	}
 }
 
+// bdReadyDisagreementHidden names the rows bd's own Ready hides in
+// bdReadyDisagreementLedger, and the reason the cache's direct-dep predicate
+// cannot reach the same verdict without the is_blocked column.
+var bdReadyDisagreementHidden = map[string]string{
+	"bd-child":     "blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it",
+	"bd-wisp-step": "blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it",
+	"bd-xstore":    "its blocker gcg-offscope is not resident in this scope's cache, and cachedBeadReady treats a dep as blocking only when statusByID holds the target",
+}
+
 // TestBdBackedCachedReadyNeverOffersWorkTheBackingHides is #5183/#5184's
 // invariant on the BdStore path: a cached ready read may never return a bead the
 // backing's own Ready() excludes.
@@ -244,71 +334,132 @@ func TestBdBackedCacheServesTheCompleteReadyProjection(t *testing.T) {
 // parent-child, and it ignores an edge whose target is not resident in the same
 // scope — and either gap offers the control dispatcher a step whose gate has not
 // opened (#3218). The column is what makes the two answers equal.
+//
+// The subtests below re-assert the invariant in the states a long-lived cache
+// actually spends its life in, not just the freshly primed one (ga-cfhgr).
+// `bd show --json` answers from types.IssueDetails and NOTHING in beads carries
+// a `json:"is_blocked"` tag, so every routine refresh hands the cache a row with
+// no verdict — and before ga-cfhgr each of these overwrote the column and left
+// the weaker predicate answering, with no degrade latched.
 func TestBdBackedCachedReadyNeverOffersWorkTheBackingHides(t *testing.T) {
-	ledger := bdReadyDisagreementLedger()
-	cache, store := primedBdCache(t, ledger)
+	t.Run("after prime", func(t *testing.T) {
+		ledger := bdReadyDisagreementLedger()
+		cache, store := primedBdCache(t, ledger)
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-unrelated"))
 
+		stage.assertNeverExceedsBacking("after prime", bdReadyDisagreementHidden)
+		stage.assertStillAnswers("after prime")
+	})
+
+	// A write-through refresh (CachingStore.Update -> backing.Get) reinstalls the
+	// row from `bd show`, which cannot carry is_blocked.
+	t.Run("after update", func(t *testing.T) {
+		ledger := bdReadyDisagreementLedger()
+		cache, store := primedBdCache(t, ledger)
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-unrelated"))
+
+		for _, id := range []string{"bd-child", "bd-xstore"} {
+			assignee := "agent"
+			if err := cache.Update(id, UpdateOpts{Assignee: &assignee}); err != nil {
+				t.Fatalf("Update(%s): %v", id, err)
+			}
+			stage.assertNeverExceedsBacking("after Update("+id+")", bdReadyDisagreementHidden)
+			// Mechanism, not just outcome: the refresh changed nothing the
+			// verdict depends on, so the verdict is KEPT rather than dropped
+			// and re-derived — which is why the cache can still answer below.
+			if blocked := cachedIsBlockedForTest(cache, id); blocked == nil || !*blocked {
+				t.Fatalf("cached is_blocked for %s after Update = %v, want the projection's true preserved across a refresh that cannot carry it", id, blocked)
+			}
+		}
+		// The refresh changed nothing readiness depends on, so the cache must
+		// still ANSWER: the whole point is that it stops taking the live read.
+		stage.assertStillAnswers("after Update")
+	})
+
+	// The dirty-row overlay refreshes through the same projection-less `bd show`
+	// before serving a cached read.
+	t.Run("after dirty overlay ready", func(t *testing.T) {
+		ledger := bdReadyDisagreementLedger()
+		cache, store := primedBdCache(t, ledger)
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-unrelated"))
+
+		markDirtyForTest(cache, "bd-child")
+		if _, err := cache.Ready(); err != nil {
+			t.Fatalf("Ready over dirty overlay: %v", err)
+		}
+		stage.assertNeverExceedsBacking("after dirty-overlay Ready", bdReadyDisagreementHidden)
+		stage.assertStillAnswers("after dirty-overlay Ready")
+	})
+
+	// A close invalidates its dependents' projection so the direct-dep predicate
+	// recomputes — correct for a direct blocks edge, blind to the parent-child
+	// propagation bd's column carries.
+	t.Run("after close", func(t *testing.T) {
+		ledger := bdReadyCloseInvalidationLedger()
+		cache, store := primedBdCache(t, ledger)
+
+		before := bdLiveReady(t, store, "bd-gate", "bd-x")
+		newReadyInvariantStage(t, cache, before).assertStillAnswers("before close")
+
+		if err := cache.Close("bd-x"); err != nil {
+			t.Fatalf("Close(bd-x): %v", err)
+		}
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-gate"))
+		stage.assertNeverExceedsBacking("after Close(bd-x)", map[string]string{
+			"bd-both": "its parent bd-parent is still blocked by the open bd-gate, and bd propagates that down the parent-child edge",
+		})
+		// This is the cost, stated: bd-both carries a parent-child edge, so its
+		// verdict is one only the column can give. The cache declines rather
+		// than guesses, and the caller takes bd's own answer.
+		stage.assertDeclines("after Close(bd-x)", "bd-both")
+
+		// And it is a WINDOW, not a latch: the next reconcile refills the
+		// column from bd and the cache serves readiness again.
+		cache.runReconciliation()
+		stage.assertStillAnswers("after Close(bd-x) + reconcile")
+	})
+}
+
+// bdLiveReady reads bd's own verdict and pins the fixture to it, so a fixture
+// that stopped modeling bd's is_blocked filter fails here rather than silently
+// weakening every assertion built on it.
+func bdLiveReady(t *testing.T, store *BdStore, want ...string) []string {
+	t.Helper()
 	live, err := store.Ready(ReadyQuery{TierMode: TierBoth})
 	if err != nil {
 		t.Fatalf("bd Ready: %v", err)
 	}
-	want := sortedIDs(live)
-	if got := wantReadyIDs("bd-blocker", "bd-unrelated"); !equalIDs(want, got) {
-		t.Fatalf("bd Ready = %v, want %v: the fixture must model bd's is_blocked filter", want, got)
+	got := sortedIDs(live)
+	if !equalIDs(got, wantReadyIDs(want...)) {
+		t.Fatalf("bd Ready = %v, want %v: the fixture must model bd's is_blocked filter", got, wantReadyIDs(want...))
 	}
+	return got
+}
 
-	readers := []struct {
-		name string
-		read func() ([]Bead, error)
-	}{
-		{"Ready", func() ([]Bead, error) { return cache.Ready() }},
-		{"ReadyContext", func() ([]Bead, error) { return cache.ReadyContext(context.Background()) }},
-		{"CachedReady", func() ([]Bead, error) {
-			rows, ok := cache.CachedReady()
-			if !ok {
-				return nil, ErrCacheUnavailable
-			}
-			return rows, nil
-		}},
-		{"Handles().Cached.Ready", func() ([]Bead, error) { return cache.Handles().Cached.Ready() }},
-	}
-	for _, reader := range readers {
-		rows, err := reader.read()
-		if err != nil {
-			// Declining is a correct answer: the caller then takes the live
-			// backing verdict. Answering with MORE than the backing is not.
-			if errors.Is(err, ErrCacheUnavailable) {
-				continue
-			}
-			t.Fatalf("%s: %v", reader.name, err)
-		}
-		got := sortedIDs(rows)
-		for _, hidden := range []string{"bd-child", "bd-wisp-step"} {
-			if containsID(got, hidden) {
-				t.Errorf("%s offered %s, a child of a blocked parent that bd's own ready hides: "+
-					"blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it (backing = %v, cache = %v)",
-					reader.name, hidden, want, got)
-			}
-		}
-		if containsID(got, "bd-xstore") {
-			t.Errorf("%s offered bd-xstore, whose blocker gcg-offscope is not resident in this scope's cache: "+
-				"cachedBeadReady treats a dep as blocking only when statusByID holds the target (backing = %v, cache = %v)",
-				reader.name, want, got)
-		}
-		if extra := idsBeyond(got, want); len(extra) > 0 {
-			t.Errorf("%s returned %v beyond bd's own ready (backing = %v)", reader.name, extra, want)
-		}
-	}
-
-	// Declining is the fail-safe, not the fix. A store that only ever declined
-	// would satisfy the subset checks above while costing maintainer-city the
-	// live read this bead exists to remove.
-	cached, ok := cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady declined: a bd that can answer is_blocked must keep serving readiness from cache")
-	}
-	if got := sortedIDs(cached); !equalIDs(got, want) {
-		t.Fatalf("CachedReady = %v, want %v (bd's own verdict)", got, want)
+// bdReadyCloseInvalidationLedger is the close-path shape:
+//
+//	bd-gate (open) <-- blocks -- bd-parent <-- parent-child -- bd-both
+//	bd-x (open)    <-- blocks -- bd-both
+//
+// Closing bd-x satisfies bd-both's only DIRECT blocking edge, so the cache's
+// dependency-derived predicate calls it ready the moment
+// clearDependentReadyProjectionsLocked drops its is_blocked. bd does not:
+// bd-both's parent is still blocked by the open bd-gate, and blocked-ness
+// propagates down parent-child. That makes this the one close whose verdict is
+// unchanged for every other row — so the fixture's static is_blocked column
+// stays honest across the mutation.
+func bdReadyCloseInvalidationLedger() *fakeBdLedger {
+	return &fakeBdLedger{
+		depListRefusal: `exit status 1: Error: operation "IssueRelations" not supported by the postgres backend`,
+		rows: []bdLedgerRow{
+			{id: "bd-gate"},
+			{id: "bd-x"},
+			{id: "bd-parent", blocked: true, deps: []Dep{{IssueID: "bd-parent", DependsOnID: "bd-gate", Type: "blocks"}}},
+			{id: "bd-both", blocked: true, deps: []Dep{
+				{IssueID: "bd-both", DependsOnID: "bd-x", Type: "blocks"},
+				{IssueID: "bd-both", DependsOnID: "bd-parent", Type: "parent-child"},
+			}},
+		},
 	}
 }
 

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -184,17 +184,12 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 	// changing bd versions or re-pointing a scope at another backend to
 	// re-evaluate ready-projection support.
 	if s.readyProjectionChecked {
-		return s.readyProjectionEnabled, nil
+		return s.readyProjectionEnabled, s.readyProjectionVersionErr
 	}
 	if reason := s.readyProjectionBackendRefusal(); reason != nil {
 		s.disableReadyProjectionLocked(reason)
 		return false, fmt.Errorf("bd ready projection backend gate: %w: %w", ErrReadyProjectionUnsupported, reason)
 	}
-	// A bd that predates the projection is not a degraded state to announce:
-	// the feature never existed for it, the pinned toolchain version is
-	// something operators already manage through deps.env, and the absence
-	// costs only the enrichment. The verdicts below this comment are about the
-	// LEDGER, and those do announce themselves.
 	out, err := s.runner(s.dir, "bd", "version")
 	if err != nil {
 		return false, fmt.Errorf("bd ready projection version gate: %w", err)
@@ -203,9 +198,32 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("bd ready projection version gate: %w", err)
 	}
-	s.readyProjectionEnabled = deps.CompareVersions(version, bdReadyProjectionMinVersion) >= 0
 	s.readyProjectionChecked = true
-	return s.readyProjectionEnabled, nil
+	// A bd that predates the projection leaves every IsBlocked nil, which is the
+	// same state as a ledger that refuses `bd sql`, and owes the same fail-safe.
+	// It used to return (false, nil) — no error, so no degrade — on the reading
+	// that "the absence costs only the enrichment". That held only while
+	// depsComplete was hardcoded false on this store: with the snapshot's own
+	// edges now serving readiness (bdstore_inline_deps.go), a silent (false, nil)
+	// hands every readiness handle to the dependency-derived predicate, which
+	// does not propagate down parent-child and so offers the control dispatcher
+	// work whose gate has not opened (#3218). Naming the degrade costs an old bd
+	// its CACHED readiness read — those take a live `bd ready`, every other
+	// cached read keeps serving — and costs a current bd nothing.
+	//
+	// Unlike the backend and runtime refusals it is memoized on the STORE rather
+	// than latched in the scope guard: which bd is on PATH is a property of the
+	// process, not of the ledger sitting in that directory, and the guard is
+	// never cleared. Latching it there would let one store's verdict outlive a
+	// bd upgrade for every later store over the same scope.
+	if deps.CompareVersions(version, bdReadyProjectionMinVersion) < 0 {
+		s.readyProjectionEnabled = false
+		s.readyProjectionVersionErr = fmt.Errorf("bd ready projection version gate: %w: bd %s predates %s, which introduced the is_blocked projection",
+			ErrReadyProjectionUnsupported, version, bdReadyProjectionMinVersion)
+		return false, s.readyProjectionVersionErr
+	}
+	s.readyProjectionEnabled = true
+	return true, nil
 }
 
 // readyProjectionBackendRefusal reports why this scope's backend cannot answer

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -49,6 +49,13 @@ type CachingStore struct {
 	// and read under mu by the readiness readers.
 	readyProjectionDegraded atomic.Bool
 
+	// readyProjectionLost holds the rows whose is_blocked verdict this cache
+	// HELD and then lost to a payload that could not carry it. Readiness reads
+	// consult it through readyProjectionUnknownLocked, which explains why the
+	// store-wide degrade latch is not enough and why "IsBlocked == nil" is not
+	// the same question (ga-cfhgr).
+	readyProjectionLost map[string]struct{}
+
 	reconciling    atomic.Bool
 	syncFailures   int
 	circuitTripped bool
@@ -300,16 +307,17 @@ func (c *CachingStore) SetPrimeRetryDelayForTest(fn func(attempt int) time.Durat
 
 func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID, runID, sessionID, stepID string, dependsOnStepIDs *[]string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
-		backing:     backing,
-		idPrefix:    normalizeIDPrefix(idPrefix),
-		beads:       make(map[string]Bead),
-		deps:        make(map[string][]Dep),
-		dirty:       make(map[string]struct{}),
-		beadSeq:     make(map[string]uint64),
-		localBeadAt: make(map[string]time.Time),
-		deletedSeq:  make(map[string]uint64),
-		problemLog:  make(map[string]cacheProblemLogState),
-		onChange:    onChange,
+		backing:             backing,
+		idPrefix:            normalizeIDPrefix(idPrefix),
+		beads:               make(map[string]Bead),
+		deps:                make(map[string][]Dep),
+		dirty:               make(map[string]struct{}),
+		beadSeq:             make(map[string]uint64),
+		localBeadAt:         make(map[string]time.Time),
+		deletedSeq:          make(map[string]uint64),
+		readyProjectionLost: make(map[string]struct{}),
+		problemLog:          make(map[string]cacheProblemLogState),
+		onChange:            onChange,
 		problemf: func(msg string) {
 			log.Printf("beads cache: %s", msg)
 		},
@@ -412,15 +420,41 @@ const (
 	seqClearBeadSeqOnly
 )
 
-// absorbOpts describes the two axes of variation observed across the cache's
-// absorb sites: how the deps row is sourced and how the staleness fences are
-// treated. clearDirty is separate because a small number of sites (prime's
+// absorbReadyMode selects how absorbFreshLocked treats a fresh row that carries
+// no is_blocked verdict over a cached row that has one.
+type absorbReadyMode int
+
+const (
+	// readyPreserveWhenDepsUnchanged is the default because it matches every
+	// absorb site that installs a row from a beadslib-sourced payload — a
+	// backing.Get refresh, an event patch, a locally applied write. None of
+	// those payloads can carry is_blocked: the column has no JSON tag anywhere
+	// in beads, and beadFromNativeIssue cannot set it either. Installing them
+	// verbatim silently reverted the row to the weaker dependency-derived
+	// predicate (ga-cfhgr). The verdict is kept only when the row's dependency
+	// set is unchanged, which is the same evidence
+	// preserveCachedReadyProjectionLocked requires; otherwise the row is marked
+	// unanswerable and readiness declines to the live backing.
+	readyPreserveWhenDepsUnchanged absorbReadyMode = iota
+	// readyFromFresh takes the fresh row's verdict as authoritative, including
+	// its absence. Reconciliation uses it: it has already decided, per row and
+	// on richer evidence than the deps set alone, which cached verdicts survive
+	// the cycle (preserveCachedReadyProjectionLocked), so re-deciding here would
+	// override a considered refusal.
+	readyFromFresh
+)
+
+// absorbOpts describes the three axes of variation observed across the cache's
+// absorb sites: how the deps row is sourced, how the staleness fences are
+// treated, and whether a fresh row without a ready projection may keep the
+// cached one. clearDirty is separate because a small number of sites (prime's
 // slow path, PrimeActive) deliberately leave a dirty mark in place across an
 // absorb.
 type absorbOpts struct {
 	depsMode   absorbDepsMode
 	deps       []Dep // consulted only for depsExplicit
 	seqMode    absorbSeqMode
+	readyMode  absorbReadyMode
 	clearDirty bool
 }
 
@@ -429,6 +463,7 @@ type absorbOpts struct {
 // state. now is the caller's clock read for the whole pass; it is consulted
 // only by seqClearGuarded. Caller must hold c.mu in write mode.
 func (c *CachingStore) absorbFreshLocked(id string, bead Bead, now time.Time, opts absorbOpts) {
+	bead = c.absorbReadyProjectionLocked(id, bead, opts)
 	c.beads[id] = cloneBead(bead)
 	switch opts.depsMode {
 	case depsExplicit:
@@ -459,9 +494,143 @@ func (c *CachingStore) absorbFreshLocked(id string, bead Bead, now time.Time, op
 	}
 }
 
-// evictLocked removes every trace of id from the six per-row maps. It does not
-// touch mutationSeq, depsComplete, state, or stats. Caller must hold c.mu in
-// write mode.
+// absorbReadyProjectionLocked decides what happens to a row's is_blocked
+// verdict when a fresh payload replaces the cached row, and is the single choke
+// point for that decision — every absorb site in the package goes through
+// absorbFreshLocked, so there is no site to miss.
+//
+// A fresh row that CARRIES a verdict is authoritative: it answers the row and
+// clears any outstanding unknown mark. A fresh row that carries none is the
+// interesting case, because that is what `bd show --json` and every
+// beadslib-sourced payload look like — beads has no `is_blocked` JSON tag at
+// all. Installing such a row over a projected one is what silently reverted
+// readiness to the weaker direct-dependency predicate.
+//
+// The verdict is kept when the row's dependency set is unchanged. That is
+// sound because is_blocked can only change through the row's own edges or
+// through a blocking target's status, and a target status change already
+// invalidates its dependents (clearDependentReadyProjectionsLocked). When the
+// deps DID change the cache cannot prove anything about the old verdict, so the
+// row becomes unanswerable and readiness declines to the live backing rather
+// than guessing.
+//
+// Caller must hold c.mu in write mode.
+func (c *CachingStore) absorbReadyProjectionLocked(id string, bead Bead, opts absorbOpts) Bead {
+	if bead.IsBlocked != nil {
+		delete(c.readyProjectionLost, id)
+		return bead
+	}
+	cached, ok := c.beads[id]
+	if !ok || cached.IsBlocked == nil {
+		// Nothing was lost: a row that never carried a verdict keeps answering
+		// from the dependency-derived predicate, which is all the cache ever
+		// had for it. Marking these would decline readiness for every store
+		// with no projection at all (MemStore, DoltLite) and for the rows the
+		// projection skips by design (message and gc:nudge rows).
+		return bead
+	}
+	freshDeps := effectiveAbsorbDeps(c.deps[id], bead, opts)
+	if opts.readyMode == readyPreserveWhenDepsUnchanged && !depsChanged(c.deps[id], freshDeps) {
+		bead.IsBlocked = cloneBoolPtr(cached.IsBlocked)
+		delete(c.readyProjectionLost, id)
+		return bead
+	}
+	c.markReadyProjectionLostLocked(id)
+	return bead
+}
+
+// readyPredicateCanAnswerLocked reports whether cachedBeadReady's
+// dependency-derived fallback can reproduce the backing's is_blocked for a row
+// with these edges, using only what this cache holds.
+//
+// It can, exactly, when every edge is a ready-blocking type whose target is
+// resident. Those are the edges the predicate models: it walks the row's own
+// blocks/waits-for/conditional-blocks deps and calls one blocking when the
+// target's cached status is not closed. Both of the predicate's documented gaps
+// are the negation of that test:
+//
+//   - a parent-child edge is a channel bd's column propagates blocked-ness down
+//     (issueops.markBlockedTemplateForIssues joins `d.type = 'parent-child' AND
+//     p.is_blocked = 1`) and the predicate does not walk at all;
+//   - an edge onto a row this scope's cache does not hold — a relocated `gcg-`
+//     graph bead — is invisible to the predicate, which treats a missing target
+//     as closed.
+//
+// An ordinary close does not cost a row its exactness: the close paths absorb
+// the target with status closed rather than evicting it, so it stays resident
+// and the predicate can still see that it is no longer blocking. (Reconciliation
+// does drop closed rows, but it refills the column in the same pass, so a row
+// that reaches this test no longer depends on them.) Caller must hold c.mu.
+func (c *CachingStore) readyPredicateCanAnswerLocked(deps []Dep) bool {
+	for _, dep := range deps {
+		if !isReadyBlockingDependencyType(dep.Type) {
+			return false
+		}
+		if _, resident := c.beads[dep.DependsOnID]; !resident {
+			return false
+		}
+	}
+	return true
+}
+
+// markReadyProjectionLostLocked records that this row's projected verdict is
+// gone. Whether that costs the row its readiness answer is decided at read time
+// by readyProjectionUnknownLocked, so the mark itself stays a pure function of
+// the write that dropped the column — never of the order rows were absorbed in.
+// Caller must hold c.mu in write mode.
+func (c *CachingStore) markReadyProjectionLostLocked(id string) {
+	if c.readyProjectionLost == nil {
+		c.readyProjectionLost = make(map[string]struct{})
+	}
+	c.readyProjectionLost[id] = struct{}{}
+}
+
+// effectiveAbsorbDeps returns the dependency set the absorb is about to
+// install, so the preservation check compares against what the cache will
+// actually hold rather than against the bead's fields alone.
+func effectiveAbsorbDeps(cached []Dep, bead Bead, opts absorbOpts) []Dep {
+	switch opts.depsMode {
+	case depsExplicit:
+		return opts.deps
+	case depsFromFields:
+		return depsFromBeadFields(bead)
+	case depsFromFieldsIfCarried:
+		if beadCarriesDependencyFields(bead) {
+			return depsFromBeadFields(bead)
+		}
+		return cached
+	case depsDrop:
+		return nil
+	default: // depsKeepCached
+		return cached
+	}
+}
+
+// readyProjectionUnknownLocked reports whether readiness reads must decline
+// this row rather than answer it.
+//
+// Two conditions, and both are needed. The row must have LOST a verdict this
+// cache held — deliberately narrower than "IsBlocked == nil", which is the
+// NORMAL state for a backing with no projection at all (MemStore, DoltLite) and
+// for the rows every projection skips (closed, message, gc:nudge); declining
+// those would send every readiness read to a live backing scan, the
+// multi-second stall the projection exists to remove. And the row's own edges
+// must be unable to reproduce the verdict, which is the ordinary case's escape
+// hatch: a bead blocked only by resident blocks edges is answered exactly by
+// the dependency-derived predicate, so a close that unblocks it keeps serving
+// from cache with no live read at all.
+//
+// Caller must hold c.mu.
+func (c *CachingStore) readyProjectionUnknownLocked(id string) bool {
+	if _, lost := c.readyProjectionLost[id]; !lost {
+		return false
+	}
+	return !c.readyPredicateCanAnswerLocked(c.deps[id])
+}
+
+// evictLocked removes every trace of id from the seven per-row maps. It does
+// not touch mutationSeq, depsComplete, state, or stats. Caller must hold c.mu
+// in write mode.
 func (c *CachingStore) evictLocked(id string) {
 	delete(c.beads, id)
 	delete(c.deps, id)
@@ -469,6 +638,7 @@ func (c *CachingStore) evictLocked(id string) {
 	delete(c.deletedSeq, id)
 	delete(c.beadSeq, id)
 	delete(c.localBeadAt, id)
+	delete(c.readyProjectionLost, id)
 }
 
 // tombstoneLocked evicts id and installs a deletion fence at seq. seq must be a
@@ -880,12 +1050,19 @@ func (c *CachingStore) prime(ctx context.Context) error {
 		nextDirty := make(map[string]struct{})
 		nextBeadSeq := make(map[string]uint64)
 		nextLocalBeadAt := make(map[string]time.Time)
+		// The projection ran over the whole snapshot, so every row the prime
+		// replaces gets a fresh verdict and its unknown mark drops. Only rows
+		// carried over from the old cache keep theirs.
+		nextReadyLost := make(map[string]struct{})
 		for id, current := range c.beads {
 			if fresh, exists := beadMap[id]; exists {
 				if _, keep := c.recentLocalBeadConflictLocked(id, fresh, now, true); keep {
 					nextBeads[id] = cloneBead(current)
 					if deps, ok := c.deps[id]; ok {
 						nextDeps[id] = cloneDeps(deps)
+					}
+					if _, lost := c.readyProjectionLost[id]; lost {
+						nextReadyLost[id] = struct{}{}
 					}
 					c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
 				}
@@ -896,6 +1073,9 @@ func (c *CachingStore) prime(ctx context.Context) error {
 				if deps, ok := c.deps[id]; ok {
 					nextDeps[id] = cloneDeps(deps)
 				}
+				if _, lost := c.readyProjectionLost[id]; lost {
+					nextReadyLost[id] = struct{}{}
+				}
 				c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
 			}
 		}
@@ -905,6 +1085,7 @@ func (c *CachingStore) prime(ctx context.Context) error {
 		c.dirty = nextDirty
 		c.beadSeq = nextBeadSeq
 		c.localBeadAt = nextLocalBeadAt
+		c.readyProjectionLost = nextReadyLost
 		c.deletedSeq = make(map[string]uint64)
 	} else {
 		for id, b := range beadMap {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -362,14 +362,50 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	c.updateStatsLocked()
 }
 
+// clearReadyProjectionLocked drops a row's is_blocked so the next read
+// recomputes it, and records the row as unanswerable when dropping the column
+// would change the answer.
+//
+// Invalidation is right — the row's own edges or a blocking target's status
+// just moved — but the dependency-derived predicate that takes over is weaker
+// than the column wherever the row has an edge the predicate does not model
+// (readyPredicateCanAnswerLocked names both gaps). A row that was BLOCKED and
+// whose remaining resident edges now read ready is the case that flips from
+// hidden to offered on the strength of that predicate alone, so its verdict is
+// recorded as lost; readiness then declines for it unless its own edges can
+// reproduce the verdict exactly (ga-cfhgr). A row that is still blocked by a
+// resident open edge loses nothing: the predicate reaches the same verdict the
+// column held.
+//
+// Caller must hold c.mu in write mode.
 func (c *CachingStore) clearReadyProjectionLocked(id string) bool {
 	b, ok := c.beads[id]
 	if !ok || b.IsBlocked == nil {
 		return false
 	}
+	if *b.IsBlocked && !c.residentEdgesStillBlockLocked(id) {
+		c.markReadyProjectionLostLocked(id)
+	}
 	b.IsBlocked = nil
 	c.beads[id] = b
 	return true
+}
+
+// residentEdgesStillBlockLocked reports whether the row's own edges still prove
+// it blocked without the column. It is cachedBeadReady's fallback branch,
+// evaluated against live cache state instead of a snapshot index: a dep blocks
+// only when its type is ready-blocking AND the target is resident AND the
+// target is not closed. Caller must hold c.mu.
+func (c *CachingStore) residentEdgesStillBlockLocked(id string) bool {
+	for _, dep := range c.deps[id] {
+		if !isReadyBlockingDependencyType(dep.Type) {
+			continue
+		}
+		if target, resident := c.beads[dep.DependsOnID]; resident && target.Status != "closed" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *CachingStore) clearAllReadyProjectionsLocked() bool {

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -268,6 +268,10 @@ func (c *CachingStore) cachedReadyCompleteOnly(ctx context.Context, query ReadyQ
 		if query.Assignee != "" && b.Assignee != query.Assignee {
 			continue
 		}
+		if c.readyProjectionUnknownLocked(b.ID) {
+			c.mu.RUnlock()
+			return nil, fmt.Errorf("reading complete ready projection for %s from cache: %w", b.ID, ErrCacheUnavailable)
+		}
 		openBeads = append(openBeads, cloneBead(b))
 	}
 	depsByID := make(map[string][]Dep, len(openBeads))
@@ -301,6 +305,9 @@ func (c *CachingStore) cachedReadyLocked(query ReadyQuery) ([]Bead, error) {
 		}
 		if query.Assignee != "" && b.Assignee != query.Assignee {
 			continue
+		}
+		if c.readyProjectionUnknownLocked(b.ID) {
+			return nil, fmt.Errorf("reading ready beads for %s from cache: %w", b.ID, ErrCacheUnavailable)
 		}
 		openBeads = append(openBeads, cloneBead(b))
 	}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -2982,7 +2982,16 @@ func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
 	}
 }
 
-func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.T) {
+// TestCachingStoreBdPrimeActiveUsesListDependenciesFromTheListJSON pins that
+// PrimeActive takes each bead's "down" edges from the dependencies bd carried
+// inline on the list row, spending no `bd dep` fan-out to get them.
+//
+// It asserts the dep map rather than a readiness read. Under a bd with no
+// is_blocked column readiness is not the cache's to answer at all — the
+// dependency-derived predicate is weaker than bd's, so every readiness handle
+// declines and takes the live backing (ErrReadyProjectionUnsupported, #3218) —
+// and pinning this through CachedReady would pin that hole instead of the deps.
+func TestCachingStoreBdPrimeActiveUsesListDependenciesFromTheListJSON(t *testing.T) {
 	t.Parallel()
 
 	var depListCalls int
@@ -3019,19 +3028,23 @@ func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.
 		t.Fatalf("PrimeActive: %v", err)
 	}
 
-	ready, ok := cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady reported cache unavailable")
+	cache.mu.RLock()
+	blockerDeps := cloneDeps(cache.deps["bd-blocker"])
+	blockedDeps := cloneDeps(cache.deps["bd-blocked"])
+	cache.mu.RUnlock()
+
+	if len(blockerDeps) != 0 {
+		t.Fatalf("cached deps for bd-blocker = %+v, want none", blockerDeps)
 	}
-	ids := map[string]bool{}
-	for _, b := range ready {
-		ids[b.ID] = true
-	}
-	if !ids["bd-blocker"] || ids["bd-blocked"] {
-		t.Fatalf("CachedReady ids = %v, want blocker ready and blocked excluded", ids)
+	want := Dep{IssueID: "bd-blocked", DependsOnID: "bd-blocker", Type: "blocks"}
+	if len(blockedDeps) != 1 || blockedDeps[0] != want {
+		t.Fatalf("cached deps for bd-blocked = %+v, want the inline edge %+v", blockedDeps, want)
 	}
 	if depListCalls != 0 {
 		t.Fatalf("dep list calls = %d, want 0", depListCalls)
+	}
+	if _, ok := cache.CachedReady(); ok {
+		t.Fatal("CachedReady answered from a cache with no is_blocked column; the control dispatcher reads this handle")
 	}
 }
 
@@ -3905,7 +3918,16 @@ func TestCachingStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
 	}
 }
 
-func TestCachingStoreBdReconcileRefreshesListDependenciesForCachedReady(t *testing.T) {
+// cachedDownDeps reads one bead's cached "down" edges without going through a
+// public reader, so a test can pin the dep map itself rather than a readiness
+// answer that depends on bd's is_blocked column as well.
+func cachedDownDeps(c *CachingStore, id string) []Dep {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return cloneDeps(c.deps[id])
+}
+
+func TestCachingStoreBdReconcileRefreshesListDependencies(t *testing.T) {
 	t.Parallel()
 
 	runner := newCachingStoreBdDepRunner(t)
@@ -3914,30 +3936,29 @@ func TestCachingStoreBdReconcileRefreshesListDependenciesForCachedReady(t *testi
 		t.Fatalf("Prime: %v", err)
 	}
 
-	assertCachedReadyContains := func(wantReady bool) {
+	edge := Dep{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"}
+	assertCachedDeps := func(want []Dep) {
 		t.Helper()
-		ready, ok := cache.CachedReady()
-		if !ok {
-			t.Fatal("CachedReady reported cache unavailable")
+		got := cachedDownDeps(cache, "bd-1")
+		if len(got) != len(want) {
+			t.Fatalf("cached deps for bd-1 = %+v, want %+v", got, want)
 		}
-		readyByID := make(map[string]bool, len(ready))
-		for _, bead := range ready {
-			readyByID[bead.ID] = true
-		}
-		if readyByID["bd-1"] != wantReady {
-			t.Fatalf("CachedReady includes bd-1 = %v, want %v; ready=%v", readyByID["bd-1"], wantReady, readyByID)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("cached deps for bd-1 = %+v, want %+v", got, want)
+			}
 		}
 	}
 
-	assertCachedReadyContains(true)
+	assertCachedDeps(nil)
 
-	runner.deps["bd-1"] = []Dep{{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"}}
+	runner.deps["bd-1"] = []Dep{edge}
 	cache.runReconciliation()
-	assertCachedReadyContains(false)
+	assertCachedDeps([]Dep{edge})
 
 	runner.deps["bd-1"] = nil
 	cache.runReconciliation()
-	assertCachedReadyContains(true)
+	assertCachedDeps(nil)
 
 	if runner.depScanCalls != 0 {
 		t.Fatalf("dep scan calls = %d, want 0", runner.depScanCalls)
@@ -3957,16 +3978,8 @@ func TestCachingStoreBdReconcileClearsCachedDepsWhenListOmitsDependencies(t *tes
 	runner.deps["bd-1"] = nil
 	cache.runReconciliation()
 
-	ready, ok := cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady reported cache unavailable")
-	}
-	readyByID := make(map[string]bool, len(ready))
-	for _, bead := range ready {
-		readyByID[bead.ID] = true
-	}
-	if !readyByID["bd-1"] {
-		t.Fatalf("CachedReady excludes bd-1 after omitted deps, ready=%v", readyByID)
+	if got := cachedDownDeps(cache, "bd-1"); len(got) != 0 {
+		t.Fatalf("cached deps for bd-1 = %+v after the list omitted them, want none", got)
 	}
 }
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -466,9 +466,10 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		return c.backing.Ready(query...)
 	}
 	var (
-		statusByID map[string]string
-		depsByID   map[string][]Dep
-		openBeads  []Bead
+		statusByID   map[string]string
+		depsByID     map[string][]Dep
+		openBeads    []Bead
+		unanswerable bool
 	)
 	// Ready requires a fully live cache with complete dependency coverage and a
 	// ready projection the backing store can actually serve; the overlay
@@ -489,6 +490,10 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 				}
 				statusByID[b.ID] = b.Status
 				if IsReadyCandidate(b, now) {
+					if c.readyProjectionUnknownLocked(b.ID) {
+						unanswerable = true
+						return
+					}
 					openBeads = append(openBeads, cloneBead(b))
 				}
 			}
@@ -498,6 +503,11 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 			}
 		},
 	); err != nil {
+		return c.backing.Ready(query...)
+	}
+	if unanswerable {
+		// One candidate whose verdict the cache cannot vouch for costs this
+		// read the cache, not correctness: the live scan is slower and right.
 		return c.backing.Ready(query...)
 	}
 
@@ -556,6 +566,9 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 	for _, b := range c.beads {
 		statusByID[b.ID] = b.Status
 		if IsReadyCandidate(b, now) {
+			if c.readyProjectionUnknownLocked(b.ID) {
+				return nil, false
+			}
 			openBeads = append(openBeads, cloneBead(b))
 		}
 	}

--- a/internal/beads/caching_store_ready_staleness_internal_test.go
+++ b/internal/beads/caching_store_ready_staleness_internal_test.go
@@ -1,0 +1,128 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// readyInvariantStage is one observable state of a live cache: the four cached
+// readiness handles, read after some routine mutation has landed.
+//
+// The invariant they all owe is #3218's: a cached readiness read may never
+// return a bead the backing's own Ready() excludes. Declining is a correct
+// answer — the caller then takes the live verdict — but answering with MORE
+// than the backing is a wrong-ready, and the control dispatcher acts on it.
+type readyInvariantStage struct {
+	t     *testing.T
+	cache *CachingStore
+	// want is the backing's own Ready() answer at this stage: the ceiling.
+	want []string
+}
+
+func newReadyInvariantStage(t *testing.T, cache *CachingStore, want []string) readyInvariantStage {
+	t.Helper()
+	return readyInvariantStage{t: t, cache: cache, want: want}
+}
+
+// readers returns the four handles a cached readiness answer reaches
+// production through: Ready (build_desired_state's live fallback owner),
+// ReadyContext (/status), CachedReady (the control dispatcher) and
+// Handles().Cached.Ready (the desired-state builder).
+func (s readyInvariantStage) readers() []struct {
+	name string
+	read func() ([]Bead, error)
+} {
+	cache := s.cache
+	return []struct {
+		name string
+		read func() ([]Bead, error)
+	}{
+		{"Ready", func() ([]Bead, error) { return cache.Ready() }},
+		{"ReadyContext", func() ([]Bead, error) { return cache.ReadyContext(context.Background()) }},
+		{"CachedReady", func() ([]Bead, error) {
+			rows, ok := cache.CachedReady()
+			if !ok {
+				return nil, ErrCacheUnavailable
+			}
+			return rows, nil
+		}},
+		{"Handles().Cached.Ready", func() ([]Bead, error) { return cache.Handles().Cached.Ready() }},
+	}
+}
+
+// assertNeverExceedsBacking runs every readiness handle and fails for any row
+// offered beyond the backing's own verdict. hidden names the rows the backing
+// hides and why, so a failure reads as the defect rather than as a diff.
+func (s readyInvariantStage) assertNeverExceedsBacking(stage string, hidden map[string]string) {
+	s.t.Helper()
+	for _, reader := range s.readers() {
+		rows, err := reader.read()
+		if err != nil {
+			if errors.Is(err, ErrCacheUnavailable) {
+				continue
+			}
+			s.t.Fatalf("%s (%s): %v", reader.name, stage, err)
+		}
+		got := sortedIDs(rows)
+		for id, why := range hidden {
+			if containsID(got, id) {
+				s.t.Errorf("%s (%s) offered %s, which the backing's own Ready hides: %s (backing = %v, cache = %v)",
+					reader.name, stage, id, why, s.want, got)
+			}
+		}
+		if extra := idsBeyond(got, s.want); len(extra) > 0 {
+			s.t.Errorf("%s (%s) returned %v beyond the backing's own Ready (backing = %v)",
+				reader.name, stage, extra, s.want)
+		}
+	}
+}
+
+// assertStillAnswers pins the other half. Declining is the fail-safe, not the
+// fix: a cache that only ever declined would satisfy every subset check above
+// while costing maintainer-city the live read this work exists to remove.
+func (s readyInvariantStage) assertStillAnswers(stage string) {
+	s.t.Helper()
+	cached, ok := s.cache.CachedReady()
+	if !ok {
+		s.t.Fatalf("CachedReady declined (%s): a backing that can answer is_blocked must keep serving readiness from cache", stage)
+	}
+	if got := sortedIDs(cached); !equalIDs(got, s.want) {
+		s.t.Fatalf("CachedReady (%s) = %v, want %v (the backing's own verdict)", stage, got, s.want)
+	}
+}
+
+// assertDeclines pins the COST of the fail-safe: the named row's verdict is one
+// the cache cannot reproduce, so every readiness handle takes its live fallback
+// instead of guessing. Without this the subset assertions above would pass just
+// as well on a cache that had silently stopped offering the row — a starvation
+// bug wearing a correctness costume.
+func (s readyInvariantStage) assertDeclines(stage, id string) {
+	s.t.Helper()
+	if !s.cache.readyProjectionUnknownForTest(id) {
+		s.t.Fatalf("%s: %s is servable from cache, so the subset check above proves nothing about the fail-safe", stage, id)
+	}
+	if _, ok := s.cache.CachedReady(); ok {
+		s.t.Errorf("CachedReady (%s) answered though %s has no verdict the cache can vouch for", stage, id)
+	}
+	if _, err := s.cache.ReadyContext(context.Background()); !errors.Is(err, ErrCacheUnavailable) {
+		s.t.Errorf("ReadyContext (%s) error = %v, want ErrCacheUnavailable", stage, err)
+	}
+	if _, err := s.cache.Handles().Cached.Ready(); !errors.Is(err, ErrCacheUnavailable) {
+		s.t.Errorf("cached reader Ready (%s) error = %v, want ErrCacheUnavailable", stage, err)
+	}
+}
+
+// readyProjectionUnknownForTest reports whether readiness reads must decline id.
+func (c *CachingStore) readyProjectionUnknownForTest(id string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.readyProjectionUnknownLocked(id)
+}
+
+// cachedIsBlockedForTest reports the cached ready projection for one row.
+func cachedIsBlockedForTest(cache *CachingStore, id string) *bool {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	return cache.beads[id].IsBlocked
+}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -552,9 +552,15 @@ func (c *CachingStore) mergeSnapshotLocked(
 			})
 		}
 		c.absorbFreshLocked(id, freshBead, now, absorbOpts{
-			depsMode:   depsExplicit,
-			deps:       freshDeps,
-			seqMode:    seqClearGuarded,
+			depsMode: depsExplicit,
+			deps:     freshDeps,
+			seqMode:  seqClearGuarded,
+			// preserveCachedReadyProjectionLocked above already decided, per
+			// row, which cached verdicts survive this cycle — on the blocking
+			// targets' fresh statuses, which no single-row absorb can see. Its
+			// refusals are the rows whose verdict really may have changed, so
+			// they must land as unanswerable rather than be re-preserved here.
+			readyMode:  readyFromFresh,
 			clearDirty: true,
 		})
 	}

--- a/internal/beads/caching_store_reconcile_census_test.go
+++ b/internal/beads/caching_store_reconcile_census_test.go
@@ -86,7 +86,8 @@ func TestMergeOracleFieldCoverage(t *testing.T) {
 	comparedStore := map[string]bool{
 		"beads": true, "deps": true, "depsComplete": true, "dirty": true,
 		"beadSeq": true, "localBeadAt": true, "deletedSeq": true, "state": true,
-		"lastFreshAt": true, "mutationSeq": true, "primePartialErr": true,
+		"readyProjectionLost": true, // compared as mergeEndState.readyLost
+		"lastFreshAt":         true, "mutationSeq": true, "primePartialErr": true,
 		"syncFailures": true, "circuitTripped": true,
 		"stats": true, // stats compared field-wise below
 	}

--- a/internal/beads/caching_store_reconcile_differential_test.go
+++ b/internal/beads/caching_store_reconcile_differential_test.go
@@ -75,13 +75,17 @@ func (in snapshotInputs) quiescent(st storeState) bool {
 // It captures every field the seam writes; the field-coverage census
 // (TestMergeOracleFieldCoverage) proves this list stays exhaustive.
 type mergeEndState struct {
-	beads          map[string]Bead
-	deps           map[string][]Dep
-	depsComplete   bool
-	dirty          map[string]struct{}
-	beadSeq        map[string]uint64
-	localBeadAt    map[string]time.Time
-	deletedSeq     map[string]uint64
+	beads        map[string]Bead
+	deps         map[string][]Dep
+	depsComplete bool
+	dirty        map[string]struct{}
+	beadSeq      map[string]uint64
+	localBeadAt  map[string]time.Time
+	deletedSeq   map[string]uint64
+	// readyLost is the set of rows whose is_blocked verdict the merge dropped
+	// without preserving, so readiness declines for them unless their own edges
+	// can reproduce it (ga-cfhgr).
+	readyLost      map[string]struct{}
 	state          cacheState
 	lastFreshAt    time.Time
 	mutationSeq    uint64
@@ -269,6 +273,11 @@ func ensureMaps(c *CachingStore) {
 	if c.deletedSeq == nil {
 		c.deletedSeq = make(map[string]uint64)
 	}
+	// The generated states never seed ready-projection marks, so every mark in
+	// a captured end state was produced by the merge under test — which is what
+	// lets buildExpectedNewEnd derive the expected set from the end beads map
+	// alone.
+	c.readyProjectionLost = make(map[string]struct{})
 }
 
 func captureEndState(c *CachingStore) mergeEndState {
@@ -284,6 +293,7 @@ func captureEndState(c *CachingStore) mergeEndState {
 		beadSeq:              cloneU64Map(c.beadSeq),
 		localBeadAt:          cloneTimeMap(c.localBeadAt),
 		deletedSeq:           cloneU64Map(c.deletedSeq),
+		readyLost:            cloneDirty(c.readyProjectionLost),
 		state:                c.state,
 		lastFreshAt:          c.lastFreshAt,
 		mutationSeq:          c.mutationSeq,

--- a/internal/beads/caching_store_reconcile_diffutil_test.go
+++ b/internal/beads/caching_store_reconcile_diffutil_test.go
@@ -20,6 +20,7 @@ func diffEndStates(want, got mergeEndState) string {
 	diffU64Map(&b, "beadSeq", want.beadSeq, got.beadSeq)
 	diffTimeMap(&b, "localBeadAt", want.localBeadAt, got.localBeadAt)
 	diffU64Map(&b, "deletedSeq", want.deletedSeq, got.deletedSeq)
+	diffStructSet(&b, "readyLost", want.readyLost, got.readyLost)
 	if want.depsComplete != got.depsComplete {
 		fmt.Fprintf(&b, "  depsComplete: want=%v got=%v\n", want.depsComplete, got.depsComplete)
 	}

--- a/internal/beads/caching_store_reconcile_oracle_test.go
+++ b/internal/beads/caching_store_reconcile_oracle_test.go
@@ -218,7 +218,36 @@ func buildExpectedNewEnd(st storeState, in snapshotInputs, postPreserveFresh map
 	// deliberately introduces so a recency-keep can no longer serve stale cached
 	// deps under depsComplete=true.
 	exp.depsComplete = expectedNextDepsComplete(st, in, postPreserveFresh)
+	exp.readyLost = expectedReadyLost(st, exp.beads)
 	return exp
+}
+
+// expectedReadyLost re-derives the rows whose projected verdict the merge
+// dropped (ga-cfhgr), from the input state and the independently built end
+// beads map alone — never from the seam.
+//
+// A row lost its verdict exactly when this cache HELD one and the merge's end
+// state no longer has one. That covers absorbed rows whose fresh payload
+// carried no verdict and whose cached verdict the preserve pass refused to
+// keep; it excludes rows the merge kept verbatim (a recency-keep or fence-skip
+// retains the cached verdict, so nothing was lost) and rows the merge evicted
+// (no row, no readiness question). Rows that never had a verdict keep answering
+// from the dependency-derived predicate, which is all the cache ever had for
+// them.
+//
+// Whether a lost verdict actually costs the row its readiness answer is a
+// read-time question (readyProjectionUnknownLocked), deliberately not a merge
+// one: making the mark depend on which rows were resident mid-merge would make
+// it depend on map-iteration order.
+func expectedReadyLost(st storeState, endBeads map[string]Bead) map[string]struct{} {
+	lost := map[string]struct{}{}
+	for id, end := range endBeads {
+		cached, existed := st.beads[id]
+		if existed && cached.IsBlocked != nil && end.IsBlocked == nil {
+			lost[id] = struct{}{}
+		}
+	}
+	return lost
 }
 
 // expectedNextDepsComplete independently reproduces the seam's nextDepsComplete

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -568,8 +568,9 @@ func TestCheckVersionCompatSummariesAreStableWhereItAlreadyPassed(t *testing.T) 
 // shape from ga-40qh1: a rig scope IS a git repo, so `bd context` succeeds and
 // every check can actually run. Before the fix the version compare was the only
 // FAIL, and it fired for a question it could not ask — dropping a healthy scope
-// to BdStore, where listIncludesCompleteDependencies() is hardcoded false and
-// complete-ready cache reads are permanently declined.
+// to BdStore, which at the time answered listIncludesCompleteDependencies() with
+// a hardcoded false, so its complete-ready cache reads were permanently declined
+// (ga-tgpfm).
 func TestPreflightEligibleOnReplacedBeadsModuleWithReadableBDContext(t *testing.T) {
 	scope := "/city/rigs/gascity"
 	fs := fsys.NewFake()

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -2095,3 +2095,49 @@ func TestDoltliteReindexStoreRejectsNonDoltlite(t *testing.T) {
 		t.Fatal("ReindexDoltliteStore accepted a non-doltlite store, want error")
 	}
 }
+
+// TestDoltliteDependencySnapshotCompletenessIsGuarded pins the verdict
+// dependencySnapshotForCache hands the cache. It was previously unguarded:
+// flipping its completeness bool to false left the whole suite green while
+// silently costing every DoltLite scope its cached dependency and readiness
+// reads — every DepList("…","down") would delegate to the backing store again,
+// which for this fixture is a bd runner that must never be called.
+//
+// The bool is a claim about the SNAPSHOT: DepListBatch reads both dependency
+// tables in one pass, so the map it returns is the whole down-edge set for the
+// ids asked about. The assertions below are that claim, not its restatement —
+// the cache latches depsComplete from it, and the cached edges must equal the
+// store's own.
+func TestDoltliteDependencySnapshotCompletenessIsGuarded(t *testing.T) {
+	store, closeStore := newTestDoltliteReadStore(t)
+	defer closeStore()
+
+	deps, complete, err := store.dependencySnapshotForCache([]string{"gc-child"})
+	if err != nil {
+		t.Fatalf("dependencySnapshotForCache: %v", err)
+	}
+	if !complete {
+		t.Fatal("DoltLite reported an incomplete dependency snapshot; DepListBatch reads every down edge of the ids it is given")
+	}
+	if len(deps["gc-child"]) != 1 || deps["gc-child"][0].DependsOnID != "gc-parent" {
+		t.Fatalf("snapshot deps = %#v, want gc-child -> gc-parent", deps["gc-child"])
+	}
+
+	cache := NewCachingStoreForTest(store, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	cache.mu.RLock()
+	depsComplete := cache.depsComplete
+	cache.mu.RUnlock()
+	if !depsComplete {
+		t.Fatal("cache depsComplete = false over a DoltLite snapshot that carries every down edge: cached dep and readiness reads would delegate for the life of the process")
+	}
+	cached, err := cache.DepList("gc-child", "down")
+	if err != nil {
+		t.Fatalf("cached DepList: %v", err)
+	}
+	if len(cached) != 1 || cached[0].DependsOnID != "gc-parent" {
+		t.Fatalf("cached DepList = %#v, want the snapshot's gc-child -> gc-parent", cached)
+	}
+}

--- a/internal/beads/native_dolt_store_ready_projection_internal_test.go
+++ b/internal/beads/native_dolt_store_ready_projection_internal_test.go
@@ -156,70 +156,142 @@ func nativeReadyDisagreementFixture(t *testing.T) (*CachingStore, *NativeDoltSto
 // pins: it does not propagate down parent-child, and it ignores an edge whose
 // target is not resident in the same scope. Either gap offers the control
 // dispatcher a step whose gate has not opened — regression #3218.
+// The subtests re-assert the invariant in the states a long-lived cache
+// actually spends its life in, not just the freshly primed one (ga-cfhgr).
+// beadFromNativeIssue cannot set IsBlocked — beadslib's types.Issue carries no
+// is_blocked field — so every routine refresh through backing.Get hands the
+// cache a row with no verdict. Before ga-cfhgr each of these overwrote the
+// column and left the weaker predicate answering, with no degrade latched,
+// which is why this defect was already live on the Dolt-backed cities rather
+// than introduced by the BdStore work.
 func TestCachedReadyOverNativeBackingNeverOffersWorkTheBackingHides(t *testing.T) {
-	cache, native, _, ids := nativeReadyDisagreementFixture(t)
+	hidden := func(ids map[string]string) map[string]string {
+		return map[string]string{
+			ids["child"]:  "blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it",
+			ids["xstore"]: "its blocker gcg-offscope is not resident in this scope's cache, and cachedBeadReady treats a dep as blocking only when statusByID holds the target",
+		}
+	}
 
+	t.Run("after prime", func(t *testing.T) {
+		cache, native, _, ids := nativeReadyDisagreementFixture(t)
+		stage := newReadyInvariantStage(t, cache, nativeLiveReady(t, native, ids["blocker"], ids["unrelated"]))
+
+		stage.assertNeverExceedsBacking("after prime", hidden(ids))
+		stage.assertStillAnswers("after prime")
+	})
+
+	// A write-through refresh (CachingStore.Update -> backing.Get) reinstalls
+	// the row from a payload that cannot carry is_blocked.
+	t.Run("after update", func(t *testing.T) {
+		cache, native, _, ids := nativeReadyDisagreementFixture(t)
+		stage := newReadyInvariantStage(t, cache, nativeLiveReady(t, native, ids["blocker"], ids["unrelated"]))
+
+		for _, name := range []string{"child", "xstore"} {
+			assignee := "agent"
+			if err := cache.Update(ids[name], UpdateOpts{Assignee: &assignee}); err != nil {
+				t.Fatalf("Update(%s): %v", name, err)
+			}
+			stage.assertNeverExceedsBacking("after Update("+name+")", hidden(ids))
+		}
+		stage.assertStillAnswers("after Update")
+	})
+
+	// The dirty-row overlay refreshes through the same projection-less Get
+	// before serving a cached read.
+	t.Run("after dirty overlay ready", func(t *testing.T) {
+		cache, native, _, ids := nativeReadyDisagreementFixture(t)
+		stage := newReadyInvariantStage(t, cache, nativeLiveReady(t, native, ids["blocker"], ids["unrelated"]))
+
+		markDirtyForTest(cache, ids["child"])
+		if _, err := cache.Ready(); err != nil {
+			t.Fatalf("Ready over dirty overlay: %v", err)
+		}
+		stage.assertNeverExceedsBacking("after dirty-overlay Ready", hidden(ids))
+		stage.assertStillAnswers("after dirty-overlay Ready")
+	})
+
+	// A close invalidates its dependents' projection so the direct-dep
+	// predicate recomputes — correct for a direct blocks edge, blind to the
+	// parent-child propagation the column carries.
+	t.Run("after close", func(t *testing.T) {
+		cache, native, ids := nativeReadyCloseInvalidationFixture(t)
+
+		newReadyInvariantStage(t, cache, nativeLiveReady(t, native, ids["gate"], ids["x"])).
+			assertStillAnswers("before close")
+
+		if err := cache.Close(ids["x"]); err != nil {
+			t.Fatalf("Close(x): %v", err)
+		}
+		stage := newReadyInvariantStage(t, cache, nativeLiveReady(t, native, ids["gate"]))
+		stage.assertNeverExceedsBacking("after Close(x)", map[string]string{
+			ids["both"]: "its parent is still blocked by the open gate, and blocked-ness propagates down the parent-child edge",
+		})
+		// The cost, stated: the row carries a parent-child edge, so its verdict
+		// is one only the column can give and the cache declines rather than
+		// guesses. And it is a WINDOW, not a latch — the next reconcile refills
+		// the column and the cache serves readiness again.
+		stage.assertDeclines("after Close(x)", ids["both"])
+		cache.runReconciliation()
+		stage.assertStillAnswers("after Close(x) + reconcile")
+	})
+}
+
+// nativeLiveReady reads the backing's own verdict and pins the fixture to it.
+func nativeLiveReady(t *testing.T, native *NativeDoltStore, want ...string) []string {
+	t.Helper()
 	live, err := native.Ready()
 	if err != nil {
 		t.Fatalf("native Ready: %v", err)
 	}
-	want := sortedIDs(live)
-	if got := wantReadyIDs(ids["blocker"], ids["unrelated"]); !equalIDs(want, got) {
-		t.Fatalf("native Ready = %v, want %v: the fixture must model bd's is_blocked filter", want, got)
+	got := sortedIDs(live)
+	if !equalIDs(got, wantReadyIDs(want...)) {
+		t.Fatalf("native Ready = %v, want %v: the fixture must model bd's is_blocked filter", got, wantReadyIDs(want...))
 	}
+	return got
+}
 
-	readers := []struct {
-		name string
-		read func() ([]Bead, error)
-	}{
-		{"Ready", func() ([]Bead, error) { return cache.Ready() }},
-		{"ReadyContext", func() ([]Bead, error) { return cache.ReadyContext(context.Background()) }},
-		{"CachedReady", func() ([]Bead, error) {
-			rows, ok := cache.CachedReady()
-			if !ok {
-				return nil, ErrCacheUnavailable
-			}
-			return rows, nil
-		}},
-		{"Handles().Cached.Ready", func() ([]Bead, error) { return cache.Handles().Cached.Ready() }},
-	}
-	for _, reader := range readers {
-		rows, err := reader.read()
+// nativeReadyCloseInvalidationFixture is the close-path shape on the native
+// store:
+//
+//	gate (open) <-- blocks -- parent <-- parent-child -- both
+//	x (open)    <-- blocks -- both
+//
+// Closing x satisfies both's only DIRECT blocking edge, so the cache's
+// dependency-derived predicate calls it ready the moment
+// clearDependentReadyProjectionsLocked drops its is_blocked. The backing does
+// not: both's parent is still blocked by the open gate, and blocked-ness
+// propagates down parent-child. Every other row's verdict is unchanged by the
+// close, so the fixture's stored column stays honest across the mutation.
+func nativeReadyCloseInvalidationFixture(t *testing.T) (*CachingStore, *NativeDoltStore, map[string]string) {
+	t.Helper()
+	storage := &nativeBlockedColumnStorage{nativeDoltMemStorage: newNativeDoltMemStorage(), blocked: map[string]bool{}}
+	native := newNativeDoltStoreForTest(storage)
+
+	ids := map[string]string{}
+	for _, title := range []string{"gate", "x", "parent", "both"} {
+		b, err := native.Create(Bead{Type: "task", Status: "open", Title: title})
 		if err != nil {
-			// Declining is a correct answer: the caller then takes the live
-			// backing verdict. Answering with MORE than the backing is not.
-			if errors.Is(err, ErrCacheUnavailable) {
-				continue
-			}
-			t.Fatalf("%s: %v", reader.name, err)
+			t.Fatalf("Create %s: %v", title, err)
 		}
-		got := sortedIDs(rows)
-		if containsID(got, ids["child"]) {
-			t.Errorf("%s offered %s, a child of a blocked parent that the backing's own Ready hides: "+
-				"blocked-ness propagates down parent-child and the cache's direct-dep predicate cannot see it (backing = %v, cache = %v)",
-				reader.name, ids["child"], want, got)
-		}
-		if containsID(got, ids["xstore"]) {
-			t.Errorf("%s offered %s, whose blocker gcg-offscope is not resident in this scope's cache: "+
-				"cachedBeadReady treats a dep as blocking only when statusByID holds the target (backing = %v, cache = %v)",
-				reader.name, ids["xstore"], want, got)
-		}
-		if extra := idsBeyond(got, want); len(extra) > 0 {
-			t.Errorf("%s returned %v beyond the backing's own Ready (backing = %v)", reader.name, extra, want)
-		}
+		ids[title] = b.ID
 	}
+	if err := storage.store.DepAdd(ids["parent"], ids["gate"], "blocks"); err != nil {
+		t.Fatalf("DepAdd parent blocks gate: %v", err)
+	}
+	if err := storage.store.DepAdd(ids["both"], ids["x"], "blocks"); err != nil {
+		t.Fatalf("DepAdd both blocks x: %v", err)
+	}
+	if err := storage.store.DepAdd(ids["both"], ids["parent"], "parent-child"); err != nil {
+		t.Fatalf("DepAdd both parent-child parent: %v", err)
+	}
+	storage.blocked[ids["parent"]] = true
+	storage.blocked[ids["both"]] = true
 
-	// Declining is the fail-safe, not the fix. The point of filling the column
-	// is that the cache keeps ANSWERING readiness — and answers it exactly the
-	// way the backing does. A store that only ever declined would satisfy the
-	// subset checks above while costing every rig a live read per tick.
-	cached, ok := cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady declined: a native backing that can answer is_blocked must keep serving readiness from cache")
+	cache := NewCachingStoreForTest(native, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
 	}
-	if got := sortedIDs(cached); !equalIDs(got, want) {
-		t.Fatalf("CachedReady = %v, want %v (the backing's own verdict)", got, want)
-	}
+	return cache, native, ids
 }
 
 // TestNativeReadyProjectionIsOneBatchedReadPerCycle pins the cost of filling the


### PR DESCRIPTION
Fixes ga-tgpfm (P0) **and ga-cfhgr (P0)** — the second is a pre-existing
`CachingStore` defect that is on `main` today and shipping on the five
Dolt-backed cities right now. This PR no longer only unblocks
maintainer-city's `/status`; it closes the systemic hole that made the
first fix unsafe. See **"The pre-existing defect this also fixes"** below.

## The defect

`CachingStore.cachedReadyCompleteOnly` gates on `c.depsComplete`, which
comes from `fetchDepsForBeads`. `BdStore` implements no
`dependencySnapshotForCache`, so the cache took the
`listDependencyCompletenessStore` branch and adopted
`BdStore.listIncludesCompleteDependencies()` — a hardcoded `return
false`. `NativeDoltStore` returns true; `DoltliteReadStore` implements
the snapshot properly. BdStore was the only store that could never
satisfy a complete-ready read, so every scope on one answered

    city work ready: reading complete ready projection from cache: bead cache unavailable

forever and sent each readiness read to a live `bd ready`.

maintainer-city's **city** scope is pinned to BdStore by the
`metadata_backend` preflight gate (the native store serves Dolt only;
MC's work class is hosted Postgres), so it cannot escape it. It is also
the amplifier that turned the ga-40qh1 version_compat false-fail into a
fleet-wide outage: every rig that fell to BdStore inherited a
permanently-unavailable cache.

## Why this is not `dependencySnapshotForCache` over `DepListBatch`

That was the obvious shape, and it does not work on the one city the
defect is about. `DepListBatch` is `bd dep list`, and the bd/Postgres
backend answers it with `operation "IssueRelations" not supported by the
postgres backend` — measured on maintainer-city, tracked as ga-7i7ts,
and the reason `cmd/gc/infra_class_recover.go` already carries its own
dependency reader. On MC it would have bought a guaranteed-failing
~4.4 s subprocess per prime and per reconcile and left `depsComplete`
false: a worse stall than the one it replaced.

## The fix

bd already carries every row's "down" edges on the row.
`sqlbuild.SearchCountsSQL` projects `d.deps_json`
(`JSON_ARRAYAGG` over `tables.Dependencies`) beside `dc.cnt`
(`COUNT(*)` over that same table `WHERE type = 'blocks'`), in every form
of the query, for the issues family and the wisps family alike;
`ScanReadyWorkRowWithCounts` unmarshals it onto `types.Issue`. Both
subcommands this store lists through — `bd list` and the `bd query` it
uses for the wisp tier — go through that builder, and
`bdIssue.normalizedDependencies` already carries the result onto
`Bead.Dependencies`, which `depsFromBeadFields` already feeds to the
cache. The rows were complete; only the verdict was wrong.

So the verdict is now the WITNESSED one, read off rows bd already
returned: **zero extra subprocesses, for any N.**

The witness is falsifiable rather than assumed, because a flat `return
true` is a real hazard — an adapter that never populated the field would
answer "no edges" for every bead, and a cache that believed it would
flatten the topology into "everything is ready". bd hands back its own
count of each row's blocking edges from the same query, so the two
columns are two views of one read:

- a row whose `dependency_count` exceeds the blocking edges it carried is
  proof the projection is short — one such row disqualifies the ledger,
  one-way;
- a ledger where no row ever carried an edge proves nothing, so it keeps
  today's behavior: correct, and merely slower.

## The correctness gate this opens, and how it is closed

Completeness of the dep SET is not the claim that readiness equals bd's.
bd's `is_blocked` propagates transitively down parent-child edges, which
no down-dep set reproduces, so the cache's answer equals bd's only while
`enrichReadyProjectionForCache` fills that column. BdStore already
serves it and already reports `ErrReadyProjectionUnsupported` when it
cannot — except on one route. A bd predating 1.0.5 returned
`(false, nil)`: no error, so no degrade, so every `IsBlocked` nil and
every readiness handle answered by the dependency-derived predicate. That
was harmless only while `depsComplete` was hardcoded false. It is now the
#3218 regression, so the version gate names the degrade like the backend
and runtime refusals do, and readiness declines the cache. Mutating that
one branch back reproduces the exact shape the #5184 council caught:

    Ready = [bd-blocker bd-child bd-unrelated bd-xstore], want [bd-blocker bd-unrelated]

Unlike the other two refusals it is memoized on the store, not latched in
the scope guard: which bd is on PATH is a property of the process, not of
the ledger in that directory, and the guard is never cleared.

## Verification

`TestBdBackedCachedReadyNeverOffersWorkTheBackingHides` extends #5183/
#5184's invariant — a cached ready read may never return a bead the
backing's own `Ready()` excludes — to the BdStore path, over their
fixture plus the two shapes the direct-dep predicate cannot see:

    blocker <-- blocks -- parent <-- parent-child -- child
    gcg-offscope (not resident) <-- blocks -- xstore
    parent <-- parent-child -- wisp-step (ephemeral)

Red before the fix:

    ReadyContext error = reading complete ready projection from cache: bead cache unavailable, want rows served from cache

Every added test is mutation-proved: restoring the hardcoded `false`,
flipping it to an unconditional `true`, dropping either list call site,
deleting the contradiction latch, renaming the `dependency_count` key,
and reverting the version gate each turn a test red, and each was
restored.

Three existing tests pinned `CachedReady` answering from the
dependency-derived predicate under bd 1.0.4 — the hole above. They are
corrected to assert the dep map directly, which is what they were about,
plus the readiness verdict that is now correct.

For the BdStore half of this PR, the other stores are untouched by
construction: the store-level change is confined to `bdstore*.go`, so the
seam dispatch is identical, and 555 verbose test outcomes across
NativeDoltStore / DoltLite / MemStore / FileStore / exec were identical
before and after. The comparison is sensitive — breaking
`NativeDoltStore.enrichReadyProjectionForCache` diverges it by three
failures.

That byte-identity claim is deliberately **no longer true of the PR as a
whole**: the ga-cfhgr commit below does change `caching_store.go`, and it
changes it *for every store*, because the defect it fixes is every
store's. What that costs the other paths is stated and pinned there.

## The pre-existing defect this also fixes (ga-cfhgr)

A council review of the first commit found that the completeness verdict
alone is not enough, and that the reason is not this PR's logic.

`is_blocked` is **never on bd's wire.** There is no `json:"is_blocked"`
tag anywhere in beads `v1.1.1-0.20260805093327`; `bd show --json` answers
from `types.IssueDetails` (labels / dependencies / dependency_count), and
`beadFromNativeIssue` cannot set the field either. The column exists in
the cache ONLY because prime and reconcile ran a separate projection
query. But `absorbFreshLocked` installed every fresh row
unconditionally, so three routine paths put `IsBlocked == nil` back over
a projected row and latched no degrade:

1. `CachingStore.Update`'s success path, absorbing a `backing.Get` row;
2. `readCacheWithOverlay`'s dirty-row refresh, the same shape;
3. `clearDependentReadyProjectionsLocked`, which nils a changed bead's
   direct dependents *on purpose* so the direct-dep predicate recomputes.

With `depsComplete` true, `cachedBeadReady` then answers from that
predicate — the one this package documents as weaker than bd's column —
and `readyProjectionDegraded` is store-wide and one-shot, so nothing
degrades.

**This ships today.** On the repo's own unmodified
`nativeReadyDisagreementFixture`, with no code from this PR involved:

    native Ready              = [blocker unrelated]
    after Update(child, Assignee) -> cache Ready = [blocker child unrelated]
    after Update(xstore, ...)     -> cache Ready = [blocker child unrelated xstore]

reachable in production through `cmd/gc/api_state.go` `StartReconciler`
serving `internal/api/handler_status.go`'s `ReadyContext`. The first
commit does not create this; it moves BdStore scopes into the regime
where it fires, from "decline → live → correct" to "answer → sometimes
wrong".

### The shape chosen, and why

A hybrid, decided per row rather than per store:

- **Preserve where it is provable.** `absorbFreshLocked` keeps the cached
  verdict when the row's dependency set is unchanged — the same evidence
  `preserveCachedReadyProjectionLocked` already requires on the reconcile
  path, now applied at the ONE choke point every absorb site in the
  package goes through, so there is no site to miss. This covers the
  write-through and overlay refreshes at **zero cost**: they change
  nothing readiness depends on, so the cache keeps answering.
- **Decline where it is not.** A verdict that cannot be preserved is
  recorded as LOST, and readiness declines that row to the live backing
  instead of guessing — unless the row's own edges can reproduce the
  verdict exactly (every edge ready-blocking, every target resident),
  which is the ordinary case and keeps the common close answering from
  cache.

Deliberately **not** the blunt "decline whenever `IsBlocked` is nil". nil
is the normal state for a backing with no projection at all (MemStore,
DoltLite) and for the rows every projection skips by design — message
rows, and `gc:nudge` shadow beads, which are `type=chore` and therefore
ARE ready candidates. One open nudge bead would have declined every
readiness read on that scope forever: the multi-second live-scan stall
this PR exists to remove, rebuilt.

Reconciliation opts out of the preserve: it has already decided per row,
on the blocking targets' *fresh* statuses, which verdicts survive the
cycle, and re-preserving at absorb time would override a considered
refusal.

### Verification

`TestBdBackedCachedReadyNeverOffersWorkTheBackingHides` and
`TestCachedReadyOverNativeBackingNeverOffersWorkTheBackingHides` now
re-assert the subset invariant in the states a long-lived cache actually
lives in — after an `Update`, after a dirty-overlay `Ready()`, and after
a `Close` — on **both** store paths. The native one is the proof that
this fixes `main`'s bug rather than this PR's exposure of it. Red before,
per stage, on all four readiness handles; e.g.

    Ready (after Update(child)) offered gc-3, which the backing's own Ready hides:
    blocked-ness propagates down parent-child and the cache's direct-dep
    predicate cannot see it (backing = [gc-1 gc-5], cache = [gc-1 gc-3 gc-5])

    Ready (after Close(bd-x)) offered bd-both, which the backing's own Ready hides:
    its parent bd-parent is still blocked by the open bd-gate, and bd propagates
    that down the parent-child edge (backing = [bd-gate], cache = [bd-both bd-gate])

Both tests also assert the cache **still answers** after each stage, so a
store that declined its way to a vacuous subset pass fails. The close
subtests additionally pin the cost honestly: the row that genuinely
cannot be answered declines, and one reconcile restores the answer.

The merge differential/fuzz oracle models the new per-row state
(`mergeEndState.readyLost`) and re-derives it independently from the
input state, so the seam cannot drift; the field-coverage census
classifies it as compared, not excluded.

### Side finding from ga-tgpfm, now closed

`DoltliteReadStore.dependencySnapshotForCache`'s completeness bool was
unguarded — flipping it to `false` left all 555 outcomes green.
`TestDoltliteDependencySnapshotCompletenessIsGuarded` (in the CI-run
`^TestDoltlite` suite) now fails on exactly that mutation.

## What changes on the live fleet at deploy

maintainer-city's city scope stops reporting `bead cache unavailable` and
starts answering readiness from cache, retiring one ~4.4 s `bd ready` per
controller tick; any rig on BdStore does the same.

The Dolt cities are **no longer unaffected**, and that is the point of the
second commit: they stop offering transitively blocked work between
reconciles. Their new cost is bounded and paid only where the cache
provably cannot answer — a row whose verdict was dropped AND whose own
edges cannot reproduce it (a parent-child edge, or an edge onto a
non-resident row). Everything else keeps serving from cache, including the
ordinary "blocker closed, dependent unblocked" close that
`TestCachingStoreApplyCloseEventClearsDependentProjectedIsBlocked` and five
sibling tests pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4246 — lets a BdStore-backed cache serve the complete ready projection, so readiness reads on those scopes stop forking a live `bd ready` on every controller tick — one instance of the per-tick redundant BdStore reads that issue is about; it does not touch the nudge-poller or supervisor `--limit 0` / `--all` list, query and show scans, and adds no changed-since guard, batching or idle back-off, so the unbounded per-tick scans themselves are untouched

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
