### PR TITLE
fix(cmd/gc): discover worktree liveness independent of the gc-owned root (ga-1xaqgo.1)

### DIFF
--- a/cmd/gc/bead_worktree_liveness.go
+++ b/cmd/gc/bead_worktree_liveness.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/pathutil"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
@@ -200,4 +202,51 @@ func liveSessionWorktreeDirs(snapshot *sessionBeadSnapshot) []string {
 		add(info.WorkerDir)
 	}
 	return dirs
+}
+
+// worktreeLiveness pairs one Git worktree with whether a live process or
+// active session is working in it. It is the stable, reusable output of
+// discoverWorktreeLiveness: the single shared boundary between "which
+// worktrees does git know about, and which of them are live" and any caller
+// that acts on that fact. The reaper is one such caller — it additionally
+// restricts itself to gc-owned paths before ever considering removal — and
+// reconciler capacity accounting (ga-1xaqgo.3) is another; both read this
+// same result instead of each running their own git-worktree-list plus
+// liveness cross-product.
+type worktreeLiveness struct {
+	Path   string
+	Branch string
+	Live   bool
+	Reason string
+}
+
+// discoverWorktreeLiveness reports liveness for every worktree git knows
+// about in rigRoot's repository — including the main checkout — independent
+// of which directory created or owns each one. It applies no root
+// convention (.gc/worktrees, .claude/worktrees, or anywhere else) and no
+// bead or reap-eligibility filtering: scope decisions belong entirely to the
+// caller.
+//
+// live must already have been gathered by the caller via
+// collectLiveWorktreeStateFn, matching worktreeIsLive's own contract: when
+// live.scanned is false the scan is indeterminate, and every result here
+// reports Live=false with an empty Reason rather than a guessed answer. The
+// caller is responsible for treating that indeterminate case as fail-closed,
+// exactly as it already must before calling worktreeIsLive directly —
+// discoverWorktreeLiveness does not itself decide what an unknown liveness
+// state should protect.
+func discoverWorktreeLiveness(rigRoot string, live liveWorktreeState, sessionDirs []string) ([]worktreeLiveness, error) {
+	worktrees, err := git.New(rigRoot).WorktreeList()
+	if err != nil {
+		return nil, fmt.Errorf("listing worktrees for %s: %w", rigRoot, err)
+	}
+	results := make([]worktreeLiveness, 0, len(worktrees))
+	for _, wt := range worktrees {
+		wl := worktreeLiveness{Path: wt.Path, Branch: wt.Branch}
+		if live.scanned {
+			wl.Live, wl.Reason = worktreeIsLive(wt.Path, live, sessionDirs)
+		}
+		results = append(results, wl)
+	}
+	return results, nil
 }

--- a/cmd/gc/bead_worktree_liveness_discovery_test.go
+++ b/cmd/gc/bead_worktree_liveness_discovery_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/pathutil"
+)
+
+// TestDiscoverWorktreeLiveness_ReportsWorktreeOutsideGcOwnedRoot is the RED
+// regression for ga-1xaqgo.1: a live process whose cwd is inside a Git
+// worktree registered outside the gc-owned .gc/worktrees root (mirroring a
+// worktree Claude Code's own EnterWorktree tool would create under
+// .claude/worktrees) was previously omitted entirely, because the only path
+// from "list of worktrees" to "is it live" was reapClosedBeadWorktrees's
+// pass-1 loop, which discards anything outside .gc/worktrees/<rig>/ before
+// liveness is ever computed for it (bead_worktree_reaper.go's
+// pathutil.PathWithin scope check). discoverWorktreeLiveness applies no root
+// convention, so the same foreign worktree must be visible and correctly
+// reported live here even though the reaper will still never act on it.
+func TestDiscoverWorktreeLiveness_ReportsWorktreeOutsideGcOwnedRoot(t *testing.T) {
+	_, rigRoot := initReapRig(t)
+
+	foreign := filepath.Join(t.TempDir(), ".claude", "worktrees", "some-session")
+	if err := os.MkdirAll(filepath.Dir(foreign), 0o755); err != nil {
+		t.Fatalf("mkdir foreign worktree parent: %v", err)
+	}
+	mustGit(t, rigRoot, "worktree", "add", "-b", "foreign-branch", foreign)
+
+	live := liveWorktreeState{scanned: true, cwds: []string{pathutil.NormalizePathForCompare(foreign)}}
+
+	results, err := discoverWorktreeLiveness(rigRoot, live, nil)
+	if err != nil {
+		t.Fatalf("discoverWorktreeLiveness: %v", err)
+	}
+
+	var found *worktreeLiveness
+	for i := range results {
+		if pathutil.SamePath(results[i].Path, foreign) {
+			found = &results[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("discoverWorktreeLiveness omitted worktree %s outside the gc-owned root; results=%+v", foreign, results)
+	}
+	if !found.Live {
+		t.Fatalf("discoverWorktreeLiveness reported %s as not live despite a live process cwd inside it (reason=%q)", foreign, found.Reason)
+	}
+}
+
+// TestDiscoverWorktreeLiveness_IncludesMainCheckout proves discovery is not
+// scoped to per-bead worktrees at all: the rig's own main working tree (which
+// WorktreeList also returns) is reported too, with the correct liveness for
+// its own cwd. Downstream callers (the reaper) are responsible for filtering
+// this down to what they may act on; discovery itself filters nothing.
+func TestDiscoverWorktreeLiveness_IncludesMainCheckout(t *testing.T) {
+	_, rigRoot := initReapRig(t)
+
+	live := liveWorktreeState{scanned: true, cwds: []string{pathutil.NormalizePathForCompare(rigRoot)}}
+
+	results, err := discoverWorktreeLiveness(rigRoot, live, nil)
+	if err != nil {
+		t.Fatalf("discoverWorktreeLiveness: %v", err)
+	}
+
+	var found *worktreeLiveness
+	for i := range results {
+		if pathutil.SamePath(results[i].Path, rigRoot) {
+			found = &results[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("discoverWorktreeLiveness omitted the main checkout %s; results=%+v", rigRoot, results)
+	}
+	if !found.Live {
+		t.Fatalf("discoverWorktreeLiveness reported main checkout %s as not live despite a live process cwd there", rigRoot)
+	}
+}
+
+// TestDiscoverWorktreeLiveness_ScanUnavailableReportsNotLiveNoReason pins the
+// contract mirrored from worktreeIsLive: discoverWorktreeLiveness does not
+// itself fail closed. When live.scanned is false the scan is indeterminate,
+// every result reports Live=false with an empty Reason, and the caller —
+// exactly as it already must before calling worktreeIsLive directly — is
+// responsible for treating an indeterminate scan as fail-closed rather than
+// reading a false Live as a confirmed idle worktree.
+func TestDiscoverWorktreeLiveness_ScanUnavailableReportsNotLiveNoReason(t *testing.T) {
+	_, rigRoot := initReapRig(t)
+
+	results, err := discoverWorktreeLiveness(rigRoot, liveWorktreeState{scanned: false}, nil)
+	if err != nil {
+		t.Fatalf("discoverWorktreeLiveness: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("discoverWorktreeLiveness returned no results for a repo with a main checkout")
+	}
+	for _, r := range results {
+		if r.Live || r.Reason != "" {
+			t.Fatalf("result %+v: want Live=false Reason=\"\" when the liveness scan is indeterminate", r)
+		}
+	}
+}
+
+// TestDiscoverWorktreeLiveness_InvalidRigRootErrors proves a rig whose path
+// does not resolve to a Git repository returns an error rather than a silent
+// empty result, matching git.Git.WorktreeList's own error contract.
+func TestDiscoverWorktreeLiveness_InvalidRigRootErrors(t *testing.T) {
+	notARepo := t.TempDir()
+
+	_, err := discoverWorktreeLiveness(notARepo, liveWorktreeState{scanned: true}, nil)
+	if err == nil {
+		t.Fatal("discoverWorktreeLiveness returned no error for a non-repository rigRoot")
+	}
+}

--- a/cmd/gc/bead_worktree_reaper.go
+++ b/cmd/gc/bead_worktree_reaper.go
@@ -148,10 +148,21 @@ func reapClosedBeadWorktrees(
 		}
 		rigWorktreeDir := filepath.Join(wtRoot, rigName)
 
-		worktrees, err := git.New(rigRoot).WorktreeList()
+		// discoverWorktreeLiveness is the single shared scan: it enumerates
+		// every worktree git knows about for this rig — including ones
+		// outside .gc/worktrees entirely — and computes liveness for each
+		// against the pass's authoritative live set. Pass 1 below still
+		// narrows to gc-owned candidates before anything is ever reaped;
+		// pass 2 reuses the liveness already computed here instead of
+		// re-scanning per candidate.
+		worktreeLivenessResults, err := discoverWorktreeLiveness(rigRoot, live, liveSessionDirs)
 		if err != nil {
 			fmt.Fprintf(stderr, "reapClosedBeadWorktrees: listing worktrees for rig %s (%s): %v\n", rigName, rigRoot, err) //nolint:errcheck
 			continue
+		}
+		livenessByPath := make(map[string]worktreeLiveness, len(worktreeLivenessResults))
+		for _, wl := range worktreeLivenessResults {
+			livenessByPath[wl.Path] = wl
 		}
 
 		// Pass 1: discover reap-eligible candidates — closed bead, and old
@@ -160,7 +171,7 @@ func reapClosedBeadWorktrees(
 		// borrow-veto scan below can run as a single batched query per rig
 		// (FR-3) instead of once per worktree.
 		var candidates []reapCandidate
-		for _, wt := range worktrees {
+		for _, wt := range worktreeLivenessResults {
 			worktreePath := wt.Path
 
 			// Only per-bead worktrees under this rig's .gc/worktrees/<rig>/
@@ -270,14 +281,15 @@ func reapClosedBeadWorktrees(
 
 			// Liveness gate (fail closed). Protect the tree when a live process
 			// or active session is working in it, or when liveness could not be
-			// determined at all.
+			// determined at all. Reuses the liveness already computed by
+			// discoverWorktreeLiveness above rather than re-scanning.
 			if reason == "" {
 				switch {
 				case !live.scanned:
 					reason = "liveness scan unavailable (failing closed, protecting all)"
 				default:
-					if isLive, why := worktreeIsLive(worktreePath, live, liveSessionDirs); isLive {
-						reason = "live: " + why
+					if wl := livenessByPath[worktreePath]; wl.Live {
+						reason = "live: " + wl.Reason
 					}
 				}
 			}

--- a/cmd/gc/bead_worktree_reaper_integration_test.go
+++ b/cmd/gc/bead_worktree_reaper_integration_test.go
@@ -229,6 +229,36 @@ func TestReapClosedBeadWorktrees_DryRunRemovesNothing(t *testing.T) {
 	}
 }
 
+// TestReapClosedBeadWorktrees_NeverActsOnWorktreeOutsideGcOwnedRoot locks in
+// the other half of ga-1xaqgo.1: now that discoverWorktreeLiveness (used by
+// this function) reports liveness for every worktree git knows about,
+// including ones outside .gc/worktrees, the reaper's own scope restriction
+// must still keep such a worktree completely untouched — not reaped, and not
+// even listed as protected, since it was never a candidate this rig owns.
+func TestReapClosedBeadWorktrees_NeverActsOnWorktreeOutsideGcOwnedRoot(t *testing.T) {
+	cityPath, rigRoot := initReapRig(t)
+	// Mirrors a worktree Claude Code's own EnterWorktree tool would create:
+	// registered with git, but outside any .gc/worktrees convention.
+	foreign := filepath.Join(t.TempDir(), ".claude", "worktrees", "some-session")
+	if err := os.MkdirAll(filepath.Dir(foreign), 0o755); err != nil {
+		t.Fatalf("mkdir foreign worktree parent: %v", err)
+	}
+	mustGit(t, rigRoot, "worktree", "add", "-b", "foreign-branch", foreign)
+	store := beads.NewMemStoreFrom(1, nil, nil) // no beads — the foreign worktree names none
+	cfg := reapTestConfig(rigRoot)
+	injectLiveness(t, liveWorktreeState{scanned: true, cwds: []string{pathutil.NormalizePathForCompare(foreign)}})
+
+	var stderr bytes.Buffer
+	report := reapClosedBeadWorktrees(cityPath, cfg, map[string]beads.Store{"mrig": store}, nil, false, events.Discard, nil, &stderr)
+
+	if len(report.Reaped) != 0 || len(report.Protected) != 0 {
+		t.Fatalf("reaper acted on or reported a worktree outside its owned root: Reaped=%+v Protected=%+v", report.Reaped, report.Protected)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("foreign worktree %s was removed or unstattable: %v", foreign, err)
+	}
+}
+
 // TestReapClosedBeadWorktrees_SkipsOpenBead confirms a worktree whose bead is
 // still open is untouched and not reported as reaped or protected.
 func TestReapClosedBeadWorktrees_SkipsOpenBead(t *testing.T) {


### PR DESCRIPTION
Fixes ga-1xaqgo.1 — cause A of the ga-1xaqgo epic ("gc cannot see work in
Claude-Code EnterWorktree worktrees").

## The bug

`reapClosedBeadWorktrees` filtered a rig's worktree list down to
`.gc/worktrees/<rig>/` **before** liveness was ever computed. A worktree
created outside that convention — e.g. under `.claude/worktrees/`, exactly
what Claude Code's own `EnterWorktree` tool creates — was invisible to the
liveness gate entirely, not merely excluded from reap eligibility. Scope
restriction and liveness discovery were conflated in one loop.

## The fix

`discoverWorktreeLiveness` (`cmd/gc/bead_worktree_liveness.go`) enumerates
every worktree git knows about for a rig's repository (including the main
checkout) and reports liveness for each, with no root-convention or
bead/reap-eligibility filtering — scope decisions stay entirely with the
caller. It mirrors `worktreeIsLive`'s existing fail-closed contract: when
the liveness scan is indeterminate (`scanned == false`), every result
reports `Live=false, Reason=""` rather than guessing, and the caller remains
responsible for treating that as protect-everything.

`reapClosedBeadWorktrees` now sources its candidate list from this function
and reuses the already-computed liveness instead of re-scanning per
candidate. Its own scope restriction to gc-owned paths is **unchanged** —
this PR separates "which worktrees exist and are they live" from "which of
those this reaper may act on," it doesn't touch the latter.

The result is a plain `worktreeLiveness{Path, Branch, Live, Reason}` struct,
not an interface — satisfying the bead's "reusable by downstream capacity
accounting without a speculative interface" requirement for the blocked
child `ga-1xaqgo.3` (reconciler capacity accounting for externally created
worktrees).

## Testing

- RED regression (`TestDiscoverWorktreeLiveness_ReportsWorktreeOutsideGcOwnedRoot`)
  confirmed the omission first: a live process cwd inside a worktree under
  `.claude/worktrees` was invisible pre-fix.
- Three more discovery-layer tests cover the main-checkout inclusion,
  fail-closed behavior on an indeterminate scan, and an invalid-rig-root
  error path.
- A new reaper-layer regression
  (`TestReapClosedBeadWorktrees_NeverActsOnWorktreeOutsideGcOwnedRoot`) locks
  in that a foreign worktree is never reaped or even reported, keeping the
  "never delete/kill/auto-terminate a discovered foreign worktree" guarantee
  covered at the layer that actually deletes.
- All pre-existing reaper tests (49) still pass unchanged.
- `go vet ./...` clean, `gofmt -l` clean on all changed files.
- `make test-fast-parallel` passed (push-gate gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)