### PR TITLE
fix(beads): fill the ready projection from `bd blocked` where `bd sql` is refused

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -373,6 +373,10 @@ type BdStore struct {
 	readyProjectionMu      sync.Mutex
 	readyProjectionChecked bool
 	readyProjectionEnabled bool
+	// readyProjectionDoorValue names which bd verb fills this scope's
+	// is_blocked column: `bd sql` where the backend implements it, `bd blocked`
+	// where it does not. See bdstore_ready_projection.go.
+	readyProjectionDoorValue readyProjectionDoor
 	// readyProjectionVersionErr memoizes the ErrReadyProjectionUnsupported this
 	// store owes every later caller when the bd on PATH predates the is_blocked
 	// projection. Store-local rather than scope-latched: the bd binary is a

--- a/internal/beads/bdstore_inline_deps_internal_test.go
+++ b/internal/beads/bdstore_inline_deps_internal_test.go
@@ -18,6 +18,13 @@ type bdLedgerRow struct {
 	closed    bool
 	assignee  string
 	deps      []Dep
+	// offscope marks a row bd's ledger HOLDS but this scope's cache never
+	// receives: gc routes relocated classes (the `gcg-` graph beads) to another
+	// store, so `bd list` and `bd query` for this scope do not hand it over.
+	// bd's own answers — ready, sql, blocked — still see it, which is what
+	// makes an edge onto it invisible to the cache's predicate and visible to
+	// bd's column.
+	offscope bool
 }
 
 // fakeBdLedger answers the bd subcommands a CachingStore prime spends, the way
@@ -54,13 +61,15 @@ func (f *fakeBdLedger) run(_, name string, args ...string) ([]byte, error) {
 	case joined == "version":
 		return []byte("bd version 1.1.0\n"), nil
 	case args[0] == "list":
-		return f.renderRows(func(r bdLedgerRow) bool { return !r.ephemeral && !r.closed })
+		return f.renderRows(func(r bdLedgerRow) bool { return !r.ephemeral && !r.closed && !r.offscope })
 	case args[0] == "query":
-		return f.renderRows(func(r bdLedgerRow) bool { return r.ephemeral && !r.closed })
+		return f.renderRows(func(r bdLedgerRow) bool { return r.ephemeral && !r.closed && !r.offscope })
 	case args[0] == "ready":
 		// bd ready filters is_blocked = 0 (sqlbuild.ReadyWhere). This is the
 		// backing's own verdict, the one the cache may never exceed.
 		return f.renderRows(func(r bdLedgerRow) bool { return !r.blocked && !r.closed })
+	case args[0] == "blocked":
+		return f.renderBlocked()
 	case args[0] == "show":
 		// `bd show --json` answers from types.IssueDetails, which embeds
 		// types.Issue — and NOTHING in beads carries a `json:"is_blocked"` tag.
@@ -197,6 +206,67 @@ func (f *fakeBdLedger) renderReadyProjection() ([]byte, error) {
 	return json.Marshal(out)
 }
 
+// renderBlocked answers `bd blocked --json` the way issueops.GetBlockedIssuesInTx
+// does, in both halves, because only the second half can falsify the door built
+// on it:
+//
+//  1. Seed from the denormalized is_blocked column —
+//     `WHERE is_blocked = 1 AND status <> 'closed'` — which is the same column
+//     `bd ready` filters with `is_blocked = 0` above. Rendering both from
+//     bdLedgerRow.blocked is what makes the two answers provably the same
+//     closure here as they are in bd.
+//  2. Narrow to rows whose blocker bd can NAME: an active blocking dep whose
+//     target is a live ledger row, or failing that any parent-child edge, whose
+//     parent is attributed without regard to the parent's own state. A row with
+//     neither is dropped from bd's OUTPUT even though its column says blocked.
+//
+// Modeling (2) is the point. Without it every fixture row would come back and
+// a gc-side reader that mistook membership for the column would pass for the
+// wrong reason.
+func (f *fakeBdLedger) renderBlocked() ([]byte, error) {
+	live := make(map[string]struct{}, len(f.rows))
+	for _, row := range f.rows {
+		if !row.closed {
+			live[row.id] = struct{}{}
+		}
+	}
+	out := make([]map[string]any, 0, len(f.rows))
+	for _, row := range f.rows {
+		if !row.blocked || row.closed {
+			continue
+		}
+		var blockers []string
+		for _, dep := range row.deps {
+			if !isReadyBlockingDependencyType(dep.Type) {
+				continue
+			}
+			if _, ok := live[dep.DependsOnID]; !ok {
+				continue
+			}
+			blockers = append(blockers, dep.DependsOnID)
+		}
+		if len(blockers) == 0 {
+			for _, dep := range row.deps {
+				if dep.Type == "parent-child" {
+					blockers = []string{dep.DependsOnID}
+					break
+				}
+			}
+		}
+		if len(blockers) == 0 {
+			continue
+		}
+		out = append(out, map[string]any{
+			"id":               row.id,
+			"title":            row.id,
+			"status":           "open",
+			"blocked_by":       blockers,
+			"blocked_by_count": len(blockers),
+		})
+	}
+	return json.Marshal(out)
+}
+
 func (f *fakeBdLedger) renderDepRecords(ids []string) ([]byte, error) {
 	wanted := make(map[string]bool, len(ids))
 	for _, id := range ids {
@@ -242,9 +312,10 @@ func (f *fakeBdLedger) callsNamed(sub ...string) [][]string {
 // extended with the tier that actually carries molecule steps.
 //
 //	blocker (open) <-- blocks -- parent <-- parent-child -- child
-//	gcg-offscope (not in this scope) <-- blocks -- xstore
+//	gcg-offscope (in bd's ledger, not in this cache) <-- blocks -- xstore
 //	parent <-- parent-child -- wisp-step   (ephemeral)
 //	unrelated <-- blocks -- wisp-gate      (ephemeral)
+//	unrelated <-- waits-for -- gate-open   (gate already opened)
 //
 // child and wisp-step carry no blocking dep of their own, so the cache's
 // dependency-derived predicate calls them ready while bd marks them
@@ -254,6 +325,24 @@ func (f *fakeBdLedger) callsNamed(sub ...string) [][]string {
 // it too. wisp-gate is the wisp tier's blocking edge, so the tier bd serves
 // through `bd query` rather than `bd list` also has a row that can prove — and
 // disprove — the projection. unrelated is the control both models call ready.
+//
+// Two rows exist so the projection can be disproved in BOTH directions.
+//
+// gcg-offscope is xstore's blocker as a row of bd's ledger rather than as a
+// dangling id. That is the only internally consistent way to state what the
+// fixture claims: bd's recompute joins the target table
+// (issueops.shouldBeBlockedDisjunction), so a dep onto an id bd cannot see
+// leaves is_blocked = 0 and bd's ready OFFERS the row. A cross-store blocker is
+// therefore a row bd holds and gc's class routing keeps out of THIS cache,
+// which is exactly what offscope models. It is itself blocked so bd's ready
+// hides it too, keeping every backing-verdict assertion in this file unchanged.
+//
+// gate-open is the reverse disagreement, and it is what makes "absence means
+// not blocked" falsifiable. Its waits-for gate has opened, so bd's column reads
+// is_blocked = 0 and bd's ready OFFERS it — while the cache's direct-dep
+// predicate, which calls any non-closed blocking target a blocker, would HIDE
+// it. A projection that leaves unblocked rows nil instead of writing false
+// falls back to that predicate and starves the row.
 func bdReadyDisagreementLedger() *fakeBdLedger {
 	return &fakeBdLedger{
 		depListRefusal: `exit status 1: Error: operation "IssueRelations" not supported by the postgres backend`,
@@ -262,7 +351,9 @@ func bdReadyDisagreementLedger() *fakeBdLedger {
 			{id: "bd-parent", blocked: true, deps: []Dep{{IssueID: "bd-parent", DependsOnID: "bd-blocker", Type: "blocks"}}},
 			{id: "bd-child", blocked: true, deps: []Dep{{IssueID: "bd-child", DependsOnID: "bd-parent", Type: "parent-child"}}},
 			{id: "bd-xstore", blocked: true, deps: []Dep{{IssueID: "bd-xstore", DependsOnID: "gcg-offscope", Type: "blocks"}}},
+			{id: "gcg-offscope", offscope: true, blocked: true, deps: []Dep{{IssueID: "gcg-offscope", DependsOnID: "bd-blocker", Type: "blocks"}}},
 			{id: "bd-unrelated"},
+			{id: "bd-gate-open", deps: []Dep{{IssueID: "bd-gate-open", DependsOnID: "bd-unrelated", Type: "waits-for"}}},
 			{id: "bd-wisp-step", ephemeral: true, blocked: true, deps: []Dep{{IssueID: "bd-wisp-step", DependsOnID: "bd-parent", Type: "parent-child"}}},
 			{id: "bd-wisp-gate", ephemeral: true, blocked: true, deps: []Dep{{IssueID: "bd-wisp-gate", DependsOnID: "bd-unrelated", Type: "blocks"}}},
 		},
@@ -271,7 +362,28 @@ func bdReadyDisagreementLedger() *fakeBdLedger {
 
 func primedBdCache(t *testing.T, ledger *fakeBdLedger) (*CachingStore, *BdStore) {
 	t.Helper()
-	store := NewBdStore(t.TempDir(), ledger.run)
+	return primeBdCacheOverScope(t, ledger, t.TempDir())
+}
+
+// primedBdCacheOnUnimplementedBackend primes the same fixture over a scope whose
+// metadata names a backend gc does not register — maintainer-city's shape. That
+// scope's `bd sql` is withheld by the backend gate, so its is_blocked column can
+// only come from `bd blocked`.
+func primedBdCacheOnUnimplementedBackend(t *testing.T, ledger *fakeBdLedger) (*CachingStore, *BdStore) {
+	t.Helper()
+	scope := t.TempDir()
+	writeScopeMetadata(t, scope, map[string]any{
+		"database":   "dolt",
+		"backend":    "postgres",
+		"dolt_mode":  "server",
+		"project_id": "d2e95604-e869-478c-ad1a-ddee6e8bc3fc",
+	})
+	return primeBdCacheOverScope(t, ledger, scope)
+}
+
+func primeBdCacheOverScope(t *testing.T, ledger *fakeBdLedger, scope string) (*CachingStore, *BdStore) {
+	t.Helper()
+	store := NewBdStore(scope, ledger.run)
 	cache := NewCachingStoreForTest(store, nil)
 	if err := cache.Prime(context.Background()); err != nil {
 		t.Fatalf("Prime: %v", err)
@@ -298,7 +410,7 @@ func TestBdBackedCacheServesTheCompleteReadyProjection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadyContext error = %v, want rows served from cache", err)
 	}
-	want := wantReadyIDs("bd-blocker", "bd-unrelated")
+	want := wantReadyIDs("bd-blocker", "bd-gate-open", "bd-unrelated")
 	if got := sortedIDs(rows); !equalIDs(got, want) {
 		t.Fatalf("ReadyContext = %v, want %v", got, want)
 	}
@@ -345,10 +457,59 @@ func TestBdBackedCachedReadyNeverOffersWorkTheBackingHides(t *testing.T) {
 	t.Run("after prime", func(t *testing.T) {
 		ledger := bdReadyDisagreementLedger()
 		cache, store := primedBdCache(t, ledger)
-		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-unrelated"))
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-gate-open", "bd-unrelated"))
 
 		stage.assertNeverExceedsBacking("after prime", bdReadyDisagreementHidden)
 		stage.assertStillAnswers("after prime")
+	})
+
+	// The same invariant on the scope whose column comes from `bd blocked`
+	// instead of `bd sql` — maintainer-city's shape, where the backend gate
+	// withholds `bd sql` because gc does not implement the backend.
+	//
+	// Both halves are load-bearing and they pull in opposite directions.
+	// assertNeverExceedsBacking would pass vacuously on a cache that declined
+	// every readiness read, which is exactly today's behavior and exactly what
+	// this door exists to stop; assertStillAnswers is what makes the subset
+	// claim mean something. Red before the fix:
+	//
+	//	CachedReady declined (bd blocked door, after prime): a backing that can answer is_blocked must keep serving readiness from cache
+	t.Run("bd blocked door", func(t *testing.T) {
+		ledger := bdReadyDisagreementLedger()
+		cache, store := primedBdCacheOnUnimplementedBackend(t, ledger)
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-gate-open", "bd-unrelated"))
+
+		stage.assertNeverExceedsBacking("bd blocked door, after prime", bdReadyDisagreementHidden)
+		stage.assertStillAnswers("bd blocked door, after prime")
+
+		// The gate's whole reason for withholding `bd sql` on an unregistered
+		// backend is that gc cannot assume that backend's SCHEMA. So the door
+		// must not have been opened by accident.
+		if calls := ledger.callsNamed("sql"); len(calls) != 0 {
+			t.Fatalf("an unimplemented backend spent %v; the schema assumption behind `bd sql` is exactly what the gate refuses", calls)
+		}
+		if calls := ledger.callsNamed("blocked"); len(calls) == 0 {
+			t.Fatal("no `bd blocked` was spent; the column cannot have come from bd")
+		}
+
+		// Absence means NOT BLOCKED, written rather than left nil. bd-gate-open
+		// is the row that can tell the difference: its waits-for gate has
+		// opened, so bd offers it, while the direct-dependency predicate a nil
+		// verdict falls back to calls its open target a blocker and hides it.
+		if blocked := cachedIsBlockedForTest(cache, "bd-gate-open"); blocked == nil || *blocked {
+			t.Fatalf("cached is_blocked for bd-gate-open = %v, want false written explicitly: a nil verdict hands the row to the weaker predicate, which starves it", blocked)
+		}
+		for _, id := range []string{"bd-child", "bd-wisp-step", "bd-xstore"} {
+			if blocked := cachedIsBlockedForTest(cache, id); blocked == nil || !*blocked {
+				t.Fatalf("cached is_blocked for %s = %v, want bd's true", id, blocked)
+			}
+		}
+
+		// One subprocess per prime, not one per bead: the door is a whole-scope
+		// projection exactly as `bd sql` was.
+		if calls := ledger.callsNamed("blocked"); len(calls) != 1 {
+			t.Fatalf("prime spent %d `bd blocked` calls, want exactly 1 for the whole scope: %v", len(calls), calls)
+		}
 	})
 
 	// A write-through refresh (CachingStore.Update -> backing.Get) reinstalls the
@@ -356,7 +517,7 @@ func TestBdBackedCachedReadyNeverOffersWorkTheBackingHides(t *testing.T) {
 	t.Run("after update", func(t *testing.T) {
 		ledger := bdReadyDisagreementLedger()
 		cache, store := primedBdCache(t, ledger)
-		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-unrelated"))
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-gate-open", "bd-unrelated"))
 
 		for _, id := range []string{"bd-child", "bd-xstore"} {
 			assignee := "agent"
@@ -381,7 +542,7 @@ func TestBdBackedCachedReadyNeverOffersWorkTheBackingHides(t *testing.T) {
 	t.Run("after dirty overlay ready", func(t *testing.T) {
 		ledger := bdReadyDisagreementLedger()
 		cache, store := primedBdCache(t, ledger)
-		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-unrelated"))
+		stage := newReadyInvariantStage(t, cache, bdLiveReady(t, store, "bd-blocker", "bd-gate-open", "bd-unrelated"))
 
 		markDirtyForTest(cache, "bd-child")
 		if _, err := cache.Ready(); err != nil {
@@ -664,7 +825,7 @@ func TestBdWithoutTheBlockedColumnSendsReadyToTheLiveVerdict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ready: %v", err)
 	}
-	want := wantReadyIDs("bd-blocker", "bd-unrelated")
+	want := wantReadyIDs("bd-blocker", "bd-gate-open", "bd-unrelated")
 	if got := sortedIDs(rows); !equalIDs(got, want) {
 		t.Fatalf("Ready = %v, want %v: the transitively blocked rows must not be offered", got, want)
 	}
@@ -684,7 +845,16 @@ func TestBdWithoutTheBlockedColumnSendsReadyToTheLiveVerdict(t *testing.T) {
 	if !ok {
 		t.Fatal("CachedList declined: the degrade must not make non-readiness reads unavailable")
 	}
-	if len(cached) != len(oldBd.rows) {
-		t.Fatalf("CachedList returned %d rows, want %d", len(cached), len(oldBd.rows))
+	// Every row bd hands THIS scope, which is every row but the relocated one:
+	// gc routes `gcg-` beads to another store, so `bd list`/`bd query` never
+	// return them here.
+	resident := 0
+	for _, row := range oldBd.rows {
+		if !row.offscope {
+			resident++
+		}
+	}
+	if len(cached) != resident {
+		t.Fatalf("CachedList returned %d rows, want %d", len(cached), resident)
 	}
 }

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -134,7 +135,7 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 	if len(ids) == 0 {
 		return items, nil
 	}
-	enabled, err := s.bdReadyProjectionEnabled()
+	door, enabled, err := s.bdReadyProjectionEnabled()
 	if err != nil {
 		return items, err
 	}
@@ -142,7 +143,7 @@ func (s *BdStore) enrichReadyProjectionForCache(items []Bead) ([]Bead, error) {
 		return items, nil
 	}
 
-	projection, err := s.fetchReadyProjection(ids)
+	projection, err := s.fetchReadyProjection(door, ids)
 	if err != nil {
 		return items, err
 	}
@@ -169,14 +170,36 @@ func skipBDReadyProjectionEnrichment(item Bead) bool {
 		beadHasLabel(item, "gc:nudge")
 }
 
-func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
+// readyProjectionDoor names the bd verb that fills the is_blocked column for
+// one scope.
+//
+// There are two, and which one a scope takes is decided by the backend gate
+// below rather than by preference. They are NOT interchangeable: `bd sql`
+// returns the column verbatim for every active row, while `bd blocked` returns
+// only the rows bd can name a blocker for (see fetchReadyProjectionViaBlocked).
+// So the SQL door stays primary wherever it works, and the blocked door is
+// reached only where the alternative is no column at all.
+type readyProjectionDoor int
+
+const (
+	// readyProjectionDoorSQL projects `select id,is_blocked from issues|wisps`.
+	// It is the column itself, and it is what every Dolt and DoltLite scope
+	// takes — unchanged by this file's second door.
+	readyProjectionDoorSQL readyProjectionDoor = iota
+	// readyProjectionDoorBlocked projects `bd blocked --json`, bd's own verb
+	// over its own blocked role. It answers on every backend, including the
+	// hosted-Postgres work stores where `bd sql` is not implemented.
+	readyProjectionDoorBlocked
+)
+
+func (s *BdStore) bdReadyProjectionEnabled() (readyProjectionDoor, bool, error) {
 	// The scope verdict outranks anything this store object knows: a store
 	// built after some other store over the same scope reached it must neither
 	// re-spend the discovery nor re-announce it. It still REPORTS the degrade,
 	// on every call, because that error is how each cache over the scope learns
 	// to decline its readiness reads.
 	if cause := s.latchedReadyProjectionDegrade(); cause != nil {
-		return false, fmt.Errorf("bd ready projection scope verdict: %w: %w", ErrReadyProjectionUnsupported, cause)
+		return readyProjectionDoorSQL, false, fmt.Errorf("bd ready projection scope verdict: %w: %w", ErrReadyProjectionUnsupported, cause)
 	}
 	s.readyProjectionMu.Lock()
 	defer s.readyProjectionMu.Unlock()
@@ -184,19 +207,26 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 	// changing bd versions or re-pointing a scope at another backend to
 	// re-evaluate ready-projection support.
 	if s.readyProjectionChecked {
-		return s.readyProjectionEnabled, s.readyProjectionVersionErr
+		return s.readyProjectionDoorValue, s.readyProjectionEnabled, s.readyProjectionVersionErr
 	}
-	if reason := s.readyProjectionBackendRefusal(); reason != nil {
-		s.disableReadyProjectionLocked(reason)
-		return false, fmt.Errorf("bd ready projection backend gate: %w: %w", ErrReadyProjectionUnsupported, reason)
+	// A backend gc does not implement no longer costs the scope its column: it
+	// costs the scope `bd sql`. The gate's reason for withholding that call is
+	// that gc cannot assume an unknown backend's SCHEMA carries gc's
+	// issues/wisps projection — and that reason does not reach `bd blocked`,
+	// which is bd's own verb over bd's own role, answered by whatever storage
+	// bd opened.
+	door := readyProjectionDoorSQL
+	if s.readyProjectionBackendRefusal() != nil {
+		door = readyProjectionDoorBlocked
 	}
+	s.readyProjectionDoorValue = door
 	out, err := s.runner(s.dir, "bd", "version")
 	if err != nil {
-		return false, fmt.Errorf("bd ready projection version gate: %w", err)
+		return door, false, fmt.Errorf("bd ready projection version gate: %w", err)
 	}
 	version, err := parseBDVersion(string(out))
 	if err != nil {
-		return false, fmt.Errorf("bd ready projection version gate: %w", err)
+		return door, false, fmt.Errorf("bd ready projection version gate: %w", err)
 	}
 	s.readyProjectionChecked = true
 	// A bd that predates the projection leaves every IsBlocked nil, which is the
@@ -220,10 +250,23 @@ func (s *BdStore) bdReadyProjectionEnabled() (bool, error) {
 		s.readyProjectionEnabled = false
 		s.readyProjectionVersionErr = fmt.Errorf("bd ready projection version gate: %w: bd %s predates %s, which introduced the is_blocked projection",
 			ErrReadyProjectionUnsupported, version, bdReadyProjectionMinVersion)
-		return false, s.readyProjectionVersionErr
+		return door, false, s.readyProjectionVersionErr
 	}
 	s.readyProjectionEnabled = true
-	return true, nil
+	return door, true, nil
+}
+
+// switchToBlockedDoor records that this scope's `bd sql` was refused at
+// runtime, so every later fetch — and every store built later over the same
+// scope object — goes straight to the blocked door.
+//
+// It is deliberately NOT latched in the scope guard: the guard's verdict is
+// "this scope cannot serve the projection at all", and a scope that can serve
+// it through `bd blocked` has not reached that verdict.
+func (s *BdStore) switchToBlockedDoor() {
+	s.readyProjectionMu.Lock()
+	defer s.readyProjectionMu.Unlock()
+	s.readyProjectionDoorValue = readyProjectionDoorBlocked
 }
 
 // readyProjectionBackendRefusal reports why this scope's backend cannot answer
@@ -289,7 +332,7 @@ func (s *BdStore) latchReadyProjectionDegrade(cause error) {
 	}
 	_, _ = fmt.Fprintf(s.noticeWriter(),
 		"gc: ready-projection enrichment disabled for %s: %v\n"+
-			"gc: ready reads on this scope answer from a live `bd ready` instead of the cache; other cached reads keep serving and no further bd sql is spent.\n",
+			"gc: ready reads on this scope answer from a live `bd ready` instead of the cache; other cached reads keep serving and no further projection subprocess is spent.\n",
 		s.dir, cause)
 }
 
@@ -316,8 +359,7 @@ func (s *BdStore) latchReadyProjectionUnsupported(cause error) {
 	s.disableReadyProjectionLocked(cause)
 }
 
-func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
-	result := make(map[string]bool, len(ids))
+func (s *BdStore) fetchReadyProjection(door readyProjectionDoor, ids []string) (map[string]bool, error) {
 	wanted := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
 		if id == "" {
@@ -346,8 +388,13 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 		wanted[id] = struct{}{}
 	}
 	if len(wanted) == 0 {
-		return result, nil
+		return map[string]bool{}, nil
 	}
+
+	if door == readyProjectionDoorBlocked {
+		return s.projectViaBlockedDoor(wanted, nil)
+	}
+	result := make(map[string]bool, len(wanted))
 
 	// bd exposes this as an active-row projection: the SQL filters out closed
 	// rows so cache prime/reconcile cost stays O(active work) instead of
@@ -363,12 +410,12 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 			// Belt-and-braces to the backend gate: a scope whose metadata does
 			// not name its backend, or names one gc implements while bd opened
 			// it some other way, only learns this from bd's own answer. It is a
-			// permanent property of the ledger, so it is latched rather than
-			// re-discovered — the unlatched version of this call cost
+			// permanent property of the ledger, so the door is switched rather
+			// than re-discovered — the unswitched version of this call cost
 			// maintainer-city a failing 6-16s subprocess on every prime and
 			// every reconcile, indefinitely.
-			s.latchReadyProjectionUnsupported(err)
-			return nil, fmt.Errorf("bd sql ready projection: %w: %w", ErrReadyProjectionUnsupported, err)
+			s.switchToBlockedDoor()
+			return s.projectViaBlockedDoor(wanted, err)
 		}
 		return nil, fmt.Errorf("bd sql ready projection: %w", err)
 	}
@@ -390,4 +437,150 @@ func (s *BdStore) fetchReadyProjection(ids []string) (map[string]bool, error) {
 
 func readyProjectionSQL() string {
 	return "select id,is_blocked from issues where status <> 'closed' union all select id,is_blocked from wisps where status <> 'closed'"
+}
+
+// projectViaBlockedDoor runs the blocked door and classifies its failure the
+// way the SQL door's is classified, because the two failures mean different
+// things and owe different verdicts.
+//
+// bd refusing the VERB is a permanent property of the ledger in front of the
+// process, so it latches: the scope is out of doors and every later cache over
+// it is told so without spending a subprocess. Anything else — a timeout, a
+// connection reset, a busy server — is this cycle's failure, so it is returned
+// plain. That leaves the snapshot partial (CachingStore.applyReadyProjection),
+// which already declines cached readiness reads, and the next reconcile retries.
+// Latching a blip would cost a long-lived dispatcher its projection for the life
+// of the process.
+//
+// withheld, when non-nil, is bd's own refusal of `bd sql`. It rides along on
+// the latched cause so an operator who meets the notice can see both doors at
+// once instead of one. A caller that arrived here from the backend gate passes
+// nil and the gate's reason is read back below — on the failure path only, so
+// the healthy path costs no metadata read per cycle.
+func (s *BdStore) projectViaBlockedDoor(wanted map[string]struct{}, withheld error) (map[string]bool, error) {
+	projection, err := s.fetchReadyProjectionViaBlocked(wanted)
+	if err == nil {
+		return projection, nil
+	}
+	if !isBdBlockedUnsupported(err) {
+		return nil, err
+	}
+	if withheld == nil {
+		withheld = s.readyProjectionBackendRefusal()
+	}
+	cause := err
+	if withheld != nil {
+		cause = fmt.Errorf("%w; bd sql was withheld: %w", err, withheld)
+	}
+	s.latchReadyProjectionUnsupported(cause)
+	return nil, fmt.Errorf("bd ready projection: %w: %w", ErrReadyProjectionUnsupported, cause)
+}
+
+// isBdBlockedUnsupported reports whether bd refused the blocked verb itself, as
+// opposed to failing while answering it.
+//
+// It matches on bd's text for the same reason its `bd sql` sibling does: no
+// sentinel crosses the subprocess boundary, so the error arrives as bytes. The
+// classification is deliberately narrow and fails SAFE in both directions — a
+// refusal it fails to recognize costs a retry per cycle rather than a wrong
+// answer, and a blip it misreads as a refusal costs the projection, never the
+// readiness verdict, because the degrade sends readiness to a live `bd ready`.
+func isBdBlockedUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "blocked") {
+		return false
+	}
+	return strings.Contains(msg, "unknown command") ||
+		strings.Contains(msg, "not supported") ||
+		strings.Contains(msg, "not yet supported") ||
+		strings.Contains(msg, "unsupported")
+}
+
+// bdBlockedRow is the one field gc reads off `bd blocked --json`. bd renders a
+// full types.BlockedIssue there — the whole issue plus BlockedBy and
+// BlockedByCount — and gc wants none of it: membership in the response IS the
+// verdict.
+type bdBlockedRow struct {
+	ID string `json:"id"`
+}
+
+// fetchReadyProjectionViaBlocked fills the is_blocked column from `bd blocked
+// --json` for a scope whose backend does not implement `bd sql`.
+//
+// # Why this is the same column
+//
+// bd's blocked verb is not a direct-dependency answer. It seeds its row set
+// with `SELECT id FROM issues|wisps WHERE is_blocked = 1 AND status <> 'closed'
+// AND status <> 'pinned'` (issueops.GetBlockedIssuesInTx) — literally the
+// denormalized, transitively-propagated column that bd's own ready filters with
+// `is_blocked = 0` (sqlbuild.BuildReadyWorkWhere). Same column, same closure,
+// so a child of a blocked parent reads blocked here exactly as it does to
+// `bd ready`. That equality is the whole reason this door is allowed to exist:
+// a subtly different definition would offer the control dispatcher work whose
+// gate has not opened (#3218).
+//
+// # Absence means not blocked, explicitly
+//
+// bd returns only blocked rows, so every requested id missing from the response
+// is written false rather than left absent. Leaving it absent would leave
+// Bead.IsBlocked nil, and cachedBeadReady then falls back to the bead's OWN
+// direct blocks/waits-for/conditional-blocks deps — the weaker predicate this
+// projection exists to replace. The write is unconditional for that reason.
+//
+// # The one place it is not the column
+//
+// After seeding from is_blocked, bd narrows its OUTPUT to rows whose blocker it
+// can NAME: an active blocking dep whose target is a resident non-closed row,
+// or, failing that, any parent-child edge. A row carrying is_blocked = 1 with
+// neither is dropped from the response and therefore reads false here. bd's own
+// recompute (issueops.shouldBeBlockedDisjunction) can only produce such a row
+// from a stale flag — the state `bd recompute-blocked` and `bd sync` exist to
+// repair, and the state issueops.countStaleIsBlockedSQL counts — or from a
+// waits-for onto a spawner that closed while its gate stayed shut, which in a
+// gc-minted graph is also a molecule step and so carries the parent-child edge
+// that attributes it (formula.collectRecipeDeps mints waits-for only between
+// steps of one formula). Measured on maintainer-city's hosted-Postgres work
+// store: 117 active rows, `bd blocked` names 3, `bd ready` returns 112, and the
+// remaining 3 are accounted for by bd's own non-is_blocked ready predicates (2
+// in_progress rows, which bd's ready never returns because cmd/bd/ready.go
+// hardcodes Status "open", and 1 molecule, which sqlbuild.ReadyWorkExcludeTypes
+// drops) — zero unattributable rows.
+//
+// This is why the SQL door stays primary rather than being replaced: where
+// `bd sql` works it returns the column with no attribution filter at all.
+//
+// # Cost
+//
+// One subprocess per cache prime and per reconcile, independent of the number
+// of beads: bd answers the whole scope in one call the way `bd sql` did. Inside
+// bd the work scales with the BLOCKED set, not the ledger — 2·|blocked|
+// dependency lookups plus a batched row fetch. Measured against maintainer-city
+// live: 2.9s, against a `bd sql` that costs 6.5s there and then fails. What it
+// buys is every readiness read between reconciles, which today each spend a
+// live `bd ready` at ~2.5-4.4s.
+func (s *BdStore) fetchReadyProjectionViaBlocked(wanted map[string]struct{}) (map[string]bool, error) {
+	out, err := s.runner(s.dir, "bd", "blocked", "--json")
+	if err != nil {
+		return nil, fmt.Errorf("bd blocked ready projection: %w", err)
+	}
+	var rows []bdBlockedRow
+	if err := json.Unmarshal(extractJSON(out), &rows); err != nil {
+		return nil, fmt.Errorf("bd blocked ready projection: parsing JSON: %w", err)
+	}
+	blocked := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if row.ID == "" {
+			continue
+		}
+		blocked[row.ID] = struct{}{}
+	}
+	result := make(map[string]bool, len(wanted))
+	for id := range wanted {
+		_, isBlocked := blocked[id]
+		result[id] = isBlocked
+	}
+	return result, nil
 }

--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -71,6 +71,17 @@ type readyProjectionScopeGuard struct {
 	// rather than sync.Once for the reason verdictClaimed is: the winner writes
 	// to a sink an operator owns, and no other caller should wait behind it.
 	announced atomic.Bool
+	// blockedDoor latches that some store over this scope proved `bd sql`
+	// refused at runtime while `bd blocked` answered, so every later store
+	// starts on the blocked door instead of re-deriving the SQL door from
+	// metadata and re-spending the failing 6-16s `bd sql`. It is orthogonal to
+	// degrade: degrade means "this scope cannot serve the projection at all"
+	// (both doors gone), while blockedDoor means "the SQL door is proven
+	// refused, use `bd blocked`" — a scope answering through the blocked door
+	// has NOT reached the degrade verdict. Set once, never cleared, for the same
+	// reason degrade is: the backend in front of the process does not regain
+	// `bd sql` mid-run, and re-probing costs the very subprocess this saves.
+	blockedDoor atomic.Bool
 }
 
 // readyProjectionGuards memoizes one guard per resolved scope path. It grows by
@@ -214,9 +225,13 @@ func (s *BdStore) bdReadyProjectionEnabled() (readyProjectionDoor, bool, error) 
 	// that gc cannot assume an unknown backend's SCHEMA carries gc's
 	// issues/wisps projection — and that reason does not reach `bd blocked`,
 	// which is bd's own verb over bd's own role, answered by whatever storage
-	// bd opened.
+	// bd opened. The second reason a fresh store starts on the blocked door is
+	// the scope-latched runtime refusal: a metadata-registered backend bd
+	// nevertheless opened embedded (isBdSQLUnsupportedInEmbeddedMode) had its
+	// `bd sql` proven refused by an earlier store, and switchToBlockedDoor
+	// recorded that on the shared guard so this rebuild does not re-spend it.
 	door := readyProjectionDoorSQL
-	if s.readyProjectionBackendRefusal() != nil {
+	if s.readyProjectionBackendRefusal() != nil || s.readyProjectionBlockedDoorLatched() {
 		door = readyProjectionDoorBlocked
 	}
 	s.readyProjectionDoorValue = door
@@ -256,17 +271,39 @@ func (s *BdStore) bdReadyProjectionEnabled() (readyProjectionDoor, bool, error) 
 	return door, true, nil
 }
 
-// switchToBlockedDoor records that this scope's `bd sql` was refused at
-// runtime, so every later fetch — and every store built later over the same
-// scope object — goes straight to the blocked door.
+// switchToBlockedDoor records that this scope's `bd sql` was refused at runtime
+// while `bd blocked` answers, so this store and every store built later over the
+// same scope go straight to the blocked door.
 //
-// It is deliberately NOT latched in the scope guard: the guard's verdict is
-// "this scope cannot serve the projection at all", and a scope that can serve
-// it through `bd blocked` has not reached that verdict.
+// The choice is latched in the scope guard, not just on this store object,
+// because cmd/gc builds a store per request and the control-ready scan rebuilds
+// one per scope every controlReadyCacheTTL: a store-local flag would let the
+// next store re-derive the SQL door from metadata and re-spend the failing
+// 6-16s `bd sql` a few times a minute, forever. It is a DISTINCT verdict from
+// the degrade the guard also carries — "SQL door proven refused, use `bd
+// blocked`", not "this scope is out of doors at all" — so it rides its own
+// field (readyProjectionScopeGuard.blockedDoor), which bdReadyProjectionEnabled
+// consults before the metadata-derived door.
 func (s *BdStore) switchToBlockedDoor() {
 	s.readyProjectionMu.Lock()
 	defer s.readyProjectionMu.Unlock()
 	s.readyProjectionDoorValue = readyProjectionDoorBlocked
+	if g := s.readyProjectionGuard(); g != nil {
+		g.blockedDoor.Store(true)
+	}
+}
+
+// readyProjectionBlockedDoorLatched reports whether some store over this scope
+// already proved `bd sql` refused at runtime and switched to the blocked door.
+// A fresh store consults it before deriving the door from metadata, so the
+// proven refusal survives the per-request / per-controlReadyCacheTTL store
+// rebuilds instead of re-spending the failing `bd sql` on each one.
+func (s *BdStore) readyProjectionBlockedDoorLatched() bool {
+	g := s.readyProjectionGuard()
+	if g == nil {
+		return false
+	}
+	return g.blockedDoor.Load()
 }
 
 // readyProjectionBackendRefusal reports why this scope's backend cannot answer
@@ -410,10 +447,15 @@ func (s *BdStore) fetchReadyProjection(door readyProjectionDoor, ids []string) (
 			// Belt-and-braces to the backend gate: a scope whose metadata does
 			// not name its backend, or names one gc implements while bd opened
 			// it some other way, only learns this from bd's own answer. It is a
-			// permanent property of the ledger, so the door is switched rather
-			// than re-discovered — the unswitched version of this call cost
-			// maintainer-city a failing 6-16s subprocess on every prime and
-			// every reconcile, indefinitely.
+			// permanent property of the ledger, so switchToBlockedDoor latches
+			// the choice in the scope guard — shared by every store rooted here
+			// — and every later rebuild consults it before the metadata-derived
+			// door. Without that scope latch the switch lived only on this store
+			// object, and cmd/gc rebuilds the store per request while the
+			// control-ready scan rebuilds one per scope every
+			// controlReadyCacheTTL: the next store re-picked the SQL door and
+			// re-spent this failing 6-16s subprocess on every prime and every
+			// reconcile, indefinitely.
 			s.switchToBlockedDoor()
 			return s.projectViaBlockedDoor(wanted, err)
 		}

--- a/internal/beads/bdstore_ready_projection_capability_internal_test.go
+++ b/internal/beads/bdstore_ready_projection_capability_internal_test.go
@@ -19,9 +19,16 @@ import (
 // status.
 const bdEmbeddedSQLRefusal = "exit status 1: Error: 'bd sql' is not yet supported in embedded mode"
 
-// embeddedSQLRunner answers `bd version` like bd 1.1.0 and refuses `bd sql` the
-// way a bd serving a backend it cannot open a SQL session against does.
-func embeddedSQLRunner() *recordingRunner {
+// bdBlockedRefusal is how a bd too old to carry the blocked verb — or one whose
+// storage cannot answer it — fails gc's runner.
+const bdBlockedRefusal = "exit status 1: Error: unknown command \"blocked\" for \"bd\""
+
+// noProjectionDoorRunner answers `bd version` like bd 1.1.0 and refuses BOTH
+// projection doors: `bd sql` the way a bd serving a backend it cannot open a
+// SQL session against does, and `bd blocked` the way a bd that has no such verb
+// does. It is the only state in which a scope is genuinely out of doors, which
+// is what the latch has always meant.
+func noProjectionDoorRunner() *recordingRunner {
 	r := &recordingRunner{}
 	r.reply = func(args []string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -30,6 +37,27 @@ func embeddedSQLRunner() *recordingRunner {
 			return []byte("bd version 1.1.0\n"), nil
 		case len(args) > 0 && args[0] == "sql":
 			return nil, errors.New(bdEmbeddedSQLRefusal)
+		case len(args) > 0 && args[0] == "blocked":
+			return nil, errors.New(bdBlockedRefusal)
+		}
+		return nil, fmt.Errorf("unexpected command: %s", joined)
+	}
+	return r
+}
+
+// blockedDoorRunner is maintainer-city's live shape: `bd sql` is not
+// implemented on the backend bd opened, and `bd blocked` answers.
+func blockedDoorRunner(reply string) *recordingRunner {
+	r := &recordingRunner{}
+	r.reply = func(args []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case joined == "version":
+			return []byte("bd version 1.1.0\n"), nil
+		case len(args) > 0 && args[0] == "sql":
+			return nil, errors.New(bdEmbeddedSQLRefusal)
+		case len(args) > 0 && args[0] == "blocked":
+			return []byte(reply), nil
 		}
 		return nil, fmt.Errorf("unexpected command: %s", joined)
 	}
@@ -65,13 +93,13 @@ func activeWorkBeads() []Bead {
 // subprocess, forever.
 //
 // The refusal is a permanent property of the ledger in front of the process, so
-// it is latched: bd is asked exactly once and the operator is told once. The
-// latch silences the SUBPROCESS and the NOTICE, not the verdict — every later
-// enrichment still reports the degrade, because that error is how each cache
-// over this scope learns to send its readiness reads to the live backing
+// it is latched: each door is tried exactly once and the operator is told once.
+// The latch silences the SUBPROCESS and the NOTICE, not the verdict — every
+// later enrichment still reports the degrade, because that error is how each
+// cache over this scope learns to send its readiness reads to the live backing
 // (CachingStore.readyReadsMustGoLive).
 func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
-	runner := embeddedSQLRunner()
+	runner := noProjectionDoorRunner()
 	notices := &bytes.Buffer{}
 	s := NewBdStore(t.TempDir(), runner.run, WithBdStoreNoticeSink(notices))
 
@@ -79,8 +107,10 @@ func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
 	if !errors.Is(err, ErrReadyProjectionUnsupported) {
 		t.Fatalf("first enrich error = %v, want ErrReadyProjectionUnsupported", err)
 	}
-	if !strings.Contains(err.Error(), "not yet supported in embedded mode") {
-		t.Errorf("degrade does not carry bd's cause: %v", err)
+	for _, want := range []string{"not yet supported in embedded mode", `unknown command "blocked"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("degrade does not carry %q; both doors must be named or an operator cannot tell which one to fix: %v", want, err)
+		}
 	}
 	for _, b := range first {
 		if b.IsBlocked != nil {
@@ -95,14 +125,16 @@ func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
 		}
 	}
 
-	sqlCalls := 0
-	for _, call := range runner.calls {
-		if len(call) > 1 && call[1] == "sql" {
-			sqlCalls++
+	for _, verb := range []string{"sql", "blocked"} {
+		calls := 0
+		for _, call := range runner.calls {
+			if len(call) > 1 && call[1] == verb {
+				calls++
+			}
 		}
-	}
-	if sqlCalls != 1 {
-		t.Fatalf("bd sql ran %d times across 5 enrichments (calls=%v); the latch must spend exactly one", sqlCalls, runner.calls)
+		if calls != 1 {
+			t.Fatalf("bd %s ran %d times across 5 enrichments (calls=%v); the latch must spend exactly one of each door", verb, calls, runner.calls)
+		}
 	}
 	if len(silentCycles) != 0 {
 		t.Fatalf("enrich cycles %v stopped naming the degrade; a cache that primes on one of them would serve readiness from a projection it does not have", silentCycles)
@@ -115,11 +147,17 @@ func TestReadyProjectionLatchesOnTheEmbeddedModeRefusal(t *testing.T) {
 	}
 }
 
-// TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd is the
-// capability gate proper. `bd sql` support is a property of the BACKEND, not of
-// the bd release, so a scope whose metadata names a backend this build does not
-// implement never gets asked — not even for its version.
-func TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd(t *testing.T) {
+// TestReadyProjectionOnAnUnimplementedBackendTakesTheBlockedDoor is the
+// capability gate proper, restated now that the gate selects a door rather than
+// switching the projection off.
+//
+// `bd sql` support is a property of the BACKEND, and the gate's reason for
+// withholding it on a backend gc does not implement is that gc cannot assume
+// that backend's SCHEMA carries gc's issues/wisps projection. That reason does
+// not reach `bd blocked`, which is bd's own verb over its own blocked role, so
+// the scope gets its column from there instead of losing it. `bd sql` is still
+// never spent — that is the part of the gate that must not regress.
+func TestReadyProjectionOnAnUnimplementedBackendTakesTheBlockedDoor(t *testing.T) {
 	scope := t.TempDir()
 	writeScopeMetadata(t, scope, map[string]any{
 		"database":   "dolt",
@@ -127,7 +165,50 @@ func TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd(t *testin
 		"dolt_mode":  "server",
 		"project_id": "d2e95604-e869-478c-ad1a-ddee6e8bc3fc",
 	})
-	runner := embeddedSQLRunner()
+	runner := blockedDoorRunner(`[{"id":"mc-2","blocked_by_count":1,"blocked_by":["mc-1"]}]`)
+	notices := &bytes.Buffer{}
+	s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
+
+	out, err := s.enrichReadyProjectionForCache(activeWorkBeads())
+	if err != nil {
+		t.Fatalf("enrichReadyProjectionForCache on an unimplemented backend = %v, want the blocked door to serve it", err)
+	}
+	byID := make(map[string]Bead, len(out))
+	for _, b := range out {
+		byID[b.ID] = b
+	}
+	// mc-1 is absent from bd's answer, which means NOT BLOCKED and must be
+	// written as such: left nil it falls to the direct-dependency predicate the
+	// projection exists to replace.
+	for id, wantBlocked := range map[string]bool{"mc-1": false, "mc-2": true} {
+		got := byID[id].IsBlocked
+		if got == nil || *got != wantBlocked {
+			t.Errorf("bead %s is_blocked = %v, want &%v", id, got, wantBlocked)
+		}
+	}
+	for _, call := range runner.calls {
+		if len(call) > 1 && call[1] == "sql" {
+			t.Fatalf("an unimplemented backend spent %v; gc cannot assume that backend's schema", runner.calls)
+		}
+	}
+	if notices.Len() != 0 {
+		t.Errorf("a scope that can answer the projection printed a degrade notice:\n%s", notices.String())
+	}
+}
+
+// TestReadyProjectionLatchesAnUnimplementedBackendWhoseBlockedDoorAlsoFails is
+// the fail-closed half: when neither door answers, the scope reaches exactly the
+// verdict it reached before this door existed, with the same bound — one notice,
+// one attempt per door.
+func TestReadyProjectionLatchesAnUnimplementedBackendWhoseBlockedDoorAlsoFails(t *testing.T) {
+	scope := t.TempDir()
+	writeScopeMetadata(t, scope, map[string]any{
+		"database":   "dolt",
+		"backend":    "postgres",
+		"dolt_mode":  "server",
+		"project_id": "d2e95604-e869-478c-ad1a-ddee6e8bc3fc",
+	})
+	runner := noProjectionDoorRunner()
 	notices := &bytes.Buffer{}
 	s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
 
@@ -136,18 +217,27 @@ func TestReadyProjectionRefusesAnUnimplementedBackendWithoutSpawningBd(t *testin
 		if !errors.Is(err, ErrReadyProjectionUnsupported) {
 			t.Fatalf("enrich #%d error = %v, want ErrReadyProjectionUnsupported on every cycle", i, err)
 		}
-		if !strings.Contains(err.Error(), `unsupported backend "postgres"`) {
-			t.Errorf("degrade #%d does not name the backend: %v", i, err)
+		if !strings.Contains(err.Error(), `unknown command "blocked"`) {
+			t.Errorf("degrade #%d does not name the door that failed: %v", i, err)
 		}
 		for _, b := range out {
 			if b.IsBlocked != nil {
-				t.Errorf("bead %s was enriched by an unsupported backend", b.ID)
+				t.Errorf("bead %s was enriched by a scope with no working door", b.ID)
 			}
 		}
 	}
 
-	if len(runner.calls) != 0 {
-		t.Fatalf("an unimplemented backend was asked %v; the gate must spend no subprocess", runner.calls)
+	blockedCalls := 0
+	for _, call := range runner.calls {
+		if len(call) > 1 && call[1] == "sql" {
+			t.Fatalf("an unimplemented backend spent %v; gc cannot assume that backend's schema", runner.calls)
+		}
+		if len(call) > 1 && call[1] == "blocked" {
+			blockedCalls++
+		}
+	}
+	if blockedCalls != 1 {
+		t.Fatalf("bd blocked ran %d times across 3 enrichments (calls=%v); the latch must spend exactly one", blockedCalls, runner.calls)
 	}
 	if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
 		t.Fatalf("operator notice printed %d times, want exactly 1:\n%s", got, notices.String())
@@ -173,7 +263,7 @@ func TestReadyProjectionVerdictIsPerScopeAcrossStoreRebuilds(t *testing.T) {
 		t.Helper()
 		var calls [][]string
 		for i := 1; i <= 5; i++ {
-			runner := embeddedSQLRunner()
+			runner := noProjectionDoorRunner()
 			s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
 			if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
 				t.Fatalf("rebuild #%d enrich error = %v, want ErrReadyProjectionUnsupported", i, err)
@@ -188,8 +278,17 @@ func TestReadyProjectionVerdictIsPerScopeAcrossStoreRebuilds(t *testing.T) {
 		writeScopeMetadata(t, scope, map[string]any{"database": "dolt", "backend": "postgres"})
 		notices := &bytes.Buffer{}
 		calls := rebuild(t, scope, notices)
-		if len(calls) != 0 {
-			t.Fatalf("rebuilt stores spent %v; the gate must spend no subprocess", calls)
+		blockedCalls := 0
+		for _, call := range calls {
+			if len(call) > 1 && call[1] == "sql" {
+				t.Fatalf("rebuilt stores spent %v; the gate must never let `bd sql` reach an unimplemented backend", calls)
+			}
+			if len(call) > 1 && call[1] == "blocked" {
+				blockedCalls++
+			}
+		}
+		if blockedCalls != 1 {
+			t.Fatalf("bd blocked ran %d times across 5 stores over one scope (calls=%v); the latch must survive the rebuild", blockedCalls, calls)
 		}
 		if got := strings.Count(notices.String(), "ready-projection enrichment disabled"); got != 1 {
 			t.Fatalf("operator notice printed %d times across 5 stores over one scope, want exactly 1:\n%s", got, notices.String())
@@ -225,7 +324,7 @@ func TestReadyProjectionNoticeDoesNotClaimReadinessIsUnaffected(t *testing.T) {
 	scope := t.TempDir()
 	writeScopeMetadata(t, scope, map[string]any{"database": "dolt", "backend": "postgres"})
 	notices := &bytes.Buffer{}
-	s := NewBdStore(scope, embeddedSQLRunner().run, WithBdStoreNoticeSink(notices))
+	s := NewBdStore(scope, noProjectionDoorRunner().run, WithBdStoreNoticeSink(notices))
 	if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
 		t.Fatalf("enrich error = %v, want ErrReadyProjectionUnsupported", err)
 	}
@@ -236,7 +335,7 @@ func TestReadyProjectionNoticeDoesNotClaimReadinessIsUnaffected(t *testing.T) {
 			t.Errorf("notice claims %q, which is not what the degrade does:\n%s", banned, notice)
 		}
 	}
-	for _, want := range []string{"live `bd ready`", "other cached reads keep serving", "no further bd sql is spent"} {
+	for _, want := range []string{"live `bd ready`", "other cached reads keep serving", "no further projection subprocess is spent"} {
 		if !strings.Contains(notice, want) {
 			t.Errorf("notice does not say %q:\n%s", want, notice)
 		}
@@ -305,13 +404,13 @@ func TestReadyProjectionUnreadableMetadataFallsThroughToTheLatch(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte("{not json"), 0o644); err != nil {
 		t.Fatalf("write metadata.json: %v", err)
 	}
-	runner := embeddedSQLRunner()
+	runner := noProjectionDoorRunner()
 	s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(&bytes.Buffer{}))
 
 	if _, err := s.enrichReadyProjectionForCache(activeWorkBeads()); !errors.Is(err, ErrReadyProjectionUnsupported) {
 		t.Fatalf("enrich error = %v, want the runtime latch verdict", err)
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("calls = %v, want the version probe and one refused sql", runner.calls)
+	if len(runner.calls) != 3 {
+		t.Fatalf("calls = %v, want the version probe, one refused sql and the refused blocked door behind it", runner.calls)
 	}
 }

--- a/internal/beads/bdstore_ready_projection_capability_internal_test.go
+++ b/internal/beads/bdstore_ready_projection_capability_internal_test.go
@@ -315,6 +315,74 @@ func TestReadyProjectionVerdictIsPerScopeAcrossStoreRebuilds(t *testing.T) {
 	})
 }
 
+// TestReadyProjectionRuntimeBlockedDoorSurvivesStoreRebuilds bounds the OTHER
+// runtime verdict: not "this scope is out of doors" (the latch above), but "this
+// scope's `bd sql` is refused while `bd blocked` answers", which must persist
+// per scope exactly as the degrade does.
+//
+// The metadata names a backend this build registers (dolt), so the capability
+// gate returns the SQL door — `bd sql` is not withheld up front. Only bd's
+// runtime refusal ("not yet supported in embedded mode") reveals the backend was
+// opened embedded, and `bd blocked` answers in its place. A choice recorded only
+// on the store object is re-derived on every rebuild: cmd/gc builds a store per
+// request and the control-ready scan rebuilds one per scope every
+// controlReadyCacheTTL (3s), so the SQL door would be re-picked and the failing
+// 6-16s `bd sql` re-spent a few times a minute, forever — the exact pathology
+// this door was added to remove. Latching the choice in the scope guard lets a
+// fresh store start on the blocked door with no `bd sql` spent, while still
+// serving the column on every rebuild.
+func TestReadyProjectionRuntimeBlockedDoorSurvivesStoreRebuilds(t *testing.T) {
+	scope := t.TempDir()
+	// A registered backend: the gate returns the SQL door, so `bd sql` is
+	// attempted and only bd's runtime refusal routes to the blocked door.
+	writeScopeMetadata(t, scope, map[string]any{"database": "dolt", "backend": "dolt", "dolt_mode": "server"})
+	notices := &bytes.Buffer{}
+
+	var calls [][]string
+	for i := 1; i <= 5; i++ {
+		runner := blockedDoorRunner(`[{"id":"mc-2","blocked_by_count":1,"blocked_by":["mc-1"]}]`)
+		s := NewBdStore(scope, runner.run, WithBdStoreNoticeSink(notices))
+		out, err := s.enrichReadyProjectionForCache(activeWorkBeads())
+		if err != nil {
+			t.Fatalf("rebuild #%d enrich = %v, want the blocked door to serve the column", i, err)
+		}
+		byID := make(map[string]Bead, len(out))
+		for _, b := range out {
+			byID[b.ID] = b
+		}
+		for id, wantBlocked := range map[string]bool{"mc-1": false, "mc-2": true} {
+			got := byID[id].IsBlocked
+			if got == nil || *got != wantBlocked {
+				t.Errorf("rebuild #%d bead %s is_blocked = %v, want &%v", i, id, got, wantBlocked)
+			}
+		}
+		calls = append(calls, runner.calls...)
+	}
+
+	sqlCalls, blockedCalls := 0, 0
+	for _, call := range calls {
+		if len(call) > 1 && call[1] == "sql" {
+			sqlCalls++
+		}
+		if len(call) > 1 && call[1] == "blocked" {
+			blockedCalls++
+		}
+	}
+	// Exactly one: the runtime refusal is proven once on the first store, then
+	// the blocked-door choice persists across rebuilds. More than one is the
+	// re-spend defect; zero would mean the runtime-refusal path was never
+	// exercised (a vacuous pass).
+	if sqlCalls != 1 {
+		t.Fatalf("bd sql ran %d times across 5 stores over one scope (calls=%v); want exactly 1 — the refused `bd sql` must be spent once and the blocked-door choice must survive the rebuild", sqlCalls, calls)
+	}
+	if blockedCalls != 5 {
+		t.Fatalf("bd blocked ran %d times across 5 stores over one scope (calls=%v); every rebuild must still serve the column through the blocked door", blockedCalls, calls)
+	}
+	if notices.Len() != 0 {
+		t.Errorf("a scope that answers through the blocked door printed a degrade notice:\n%s", notices.String())
+	}
+}
+
 // TestReadyProjectionNoticeDoesNotClaimReadinessIsUnaffected pins the operator
 // line to what actually happens. An earlier draft said "no work is lost", which
 // named the wrong risk: the degraded predicate is permissive, not lossy, so the


### PR DESCRIPTION

## Summary

`BdStore` now has two doors onto bd's `is_blocked` column instead of one.
`bd sql` stays primary wherever it works — every Dolt and DoltLite scope
runs byte-identically. A scope whose backend gc does not implement, or
whose bd refuses `bd sql` at runtime, now gets its column from
`bd blocked --json` instead of losing it.

## Problem

`fetchReadyProjection` filled the cache's `is_blocked` column by shelling
`bd sql`. bd refuses that verb unless it holds a SQL session
(`cmd/bd/sql.go`: *"'bd sql' is not yet supported in embedded mode"*), which
a hosted-Postgres work store never does. #5183 bounded the damage with a
backend-capability gate and a per-scope latch, so the failing 6-16s
subprocess is spent at most once — but the scope then has NO column at all,
every bead's `IsBlocked` is nil, and `CachingStore.readyReadsMustGoLive`
sends every readiness read to a live `bd ready`.

That is maintainer-city's last non-latency error:

    city work ready: reading complete ready projection from cache: bead cache unavailable

Measured live against MC's hosted-Postgres work store: `bd sql` costs 6.5s
and then fails; `bd blocked --json` answers in 2.9s; `bd ready` costs 2.5s
and is what every readiness read pays today.

## Why `bd blocked` is the same column

`bd blocked` is not a direct-dependency answer. `issueops.GetBlockedIssuesInTx`
seeds its row set with

    SELECT id FROM issues|wisps WHERE is_blocked = 1 AND status <> 'closed' AND status <> 'pinned'

— the denormalized, transitively-propagated column that bd's own ready
filters with `is_blocked = 0` (`sqlbuild.BuildReadyWorkWhere`). Same column,
same closure: a child of a blocked parent reads blocked to `bd blocked`
exactly as it does to `bd ready`. A subtly different definition here would
re-create #3218, so the equality is what licenses the door.

Absence means NOT blocked and is written as `false`, never left nil: a nil
verdict falls back to the bead's own direct blocks/waits-for/conditional-blocks
deps, which is the weaker predicate this projection exists to replace.

## Where it is not the column, stated

After seeding from `is_blocked`, bd narrows its OUTPUT to rows whose blocker
it can NAME — an active blocking dep onto a resident non-closed row, or
failing that any parent-child edge. A row carrying `is_blocked = 1` with
neither is dropped and therefore reads `false` here. bd's own recompute
(`issueops.shouldBeBlockedDisjunction`) can only produce such a row from a
stale flag (what `bd recompute-blocked`/`bd sync` repair and
`countStaleIsBlockedSQL` counts) or from a waits-for onto a spawner that
closed with its gate still shut — which in a gc-minted graph is also a
molecule step and so carries the parent-child edge that attributes it.

Measured on maintainer-city: 117 active rows, `bd blocked` names 3,
`bd ready` returns 112, and the 3 in neither are accounted for by bd's own
non-is_blocked ready predicates (2 `in_progress` rows, which `bd ready` never
returns because `cmd/bd/ready.go` hardcodes `Status: "open"`, and 1 molecule,
dropped by `sqlbuild.ReadyWorkExcludeTypes`). Zero unattributable rows.

This is why the SQL door stays primary rather than being replaced: where
`bd sql` works it returns the column with no attribution filter at all.

## Fail-closed

- The backend gate still never lets `bd sql` reach a backend gc does not
  implement — its reason was gc's inability to assume that backend's SCHEMA,
  and that reason does not reach `bd blocked`, which is bd's own verb over
  its own role.
- bd refusing the blocked VERB latches exactly as before, naming both doors,
  with one operator notice and one attempt per door per scope.
- Any other `bd blocked` failure (timeout, reset, busy server) is this
  cycle's failure: returned plain, which leaves the snapshot partial and
  already declines cached readiness, and retried next reconcile. Latching a
  blip would cost a long-lived dispatcher its projection for the process.

## Cost

One subprocess per cache prime and per reconcile, independent of bead count:
bd answers the whole scope in one call the way `bd sql` did. Inside bd the
work scales with the BLOCKED set, not the ledger. What it buys is every
readiness read between reconciles, each of which spends a live `bd ready`
today.

## Tests

`TestBdBackedCachedReadyNeverOffersWorkTheBackingHides` gains a
`bd blocked door` subtest over the standard fixture, which grows two rows so
the door can be disproved in both directions: `gcg-offscope` (a row bd's
ledger holds and gc's class routing keeps out of this cache, which is the
only internally consistent way to state a cross-store blocker — bd's
recompute joins the target table, so a dangling id leaves `is_blocked = 0`)
and `bd-gate-open` (a waits-for whose gate has opened, so bd offers it while
the direct-dep predicate would hide it). The fake ledger's `bd blocked`
models both halves of `GetBlockedIssuesInTx`, including the attribution
narrowing.

Mutation-proved, five ways:

- delete the blocked door → `CachedReady declined (bd blocked door, after prime): a backing that can answer is_blocked must keep serving readiness from cache`
- absence leaves nil → `CachedReady (bd blocked door, after prime) = [bd-blocker bd-unrelated], want [bd-blocker bd-gate-open bd-unrelated]` and `bead mc-1 is_blocked = <nil>, want &false`
- drop the fake's parent attribution → `Ready (bd blocked door, after prime) offered bd-child, which the backing's own Ready hides` on all four readiness handles
- route every scope to the blocked door → `TestReadyProjectionOnAnImplementedBackendIsUnchanged` fails for dolt, doltlite and unset
- remove the offscope blocker row → `Ready (bd blocked door, after prime) offered bd-xstore, which the backing's own Ready hides`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
