### PR TITLE
fix(supervisor): tear down the provider server on managed city stop (#5175)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -203,9 +203,17 @@ type CityRuntime struct {
 
 	shutdownOnce             sync.Once
 	preserveSessionsShutdown atomic.Bool
-	forceStopShutdown        *atomic.Bool
-	logPrefix                string // "gc start" or "gc supervisor"
-	stdout, stderr           io.Writer
+	// ownedCity is set true once run() begins, i.e. once this runtime has
+	// passed every init-failure/discard point and is the process actually
+	// driving the city. It gates the shutdown-time server teardown: a
+	// discarded half-built runtime (e.g. adoption of an already-running
+	// city, or a controller-lock/socket/token failure) calls shutdown()
+	// without ever owning the city, and must not tear down the live city's
+	// shared server out from under it.
+	ownedCity         atomic.Bool
+	forceStopShutdown *atomic.Bool
+	logPrefix         string // "gc start" or "gc supervisor"
+	stdout, stderr    io.Writer
 }
 
 const runtimeDemandSnapshotMaxAge = 30 * time.Second
@@ -451,6 +459,10 @@ func (cr *CityRuntime) crashTrack() crashTracker {
 // the per-city main loop — it watches config, reconciles agents, runs
 // wisp GC, and dispatches orders.
 func (cr *CityRuntime) run(ctx context.Context) {
+	// Reaching run() means every init-failure/discard point is behind us:
+	// this runtime is the live owner of the city, so its shutdown() is the
+	// one allowed to tear the provider's shared server down.
+	cr.ownedCity.Store(true)
 	defer cr.shutdown()
 
 	dirty := cr.configDirty
@@ -3838,12 +3850,21 @@ func (cr *CityRuntime) shutdown() {
 				fmt.Fprintf(cr.stderr, "%s: shutdown session listing failed: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
 			}
 		}
+		// sweepEnumerated tracks whether every stop pass this shutdown ran
+		// actually listed the fleet. A failed ListRunning yields an empty
+		// slice, so gracefulStopAll stops nothing — tearing the server down
+		// after that would turn a transient listing error into an ungraceful
+		// mass kill of sessions we never enumerated. Partial failures count
+		// as not-enumerated too: we did not see the whole fleet, so we must
+		// not kill-server on the strength of a subset.
+		sweepEnumerated := listErr == nil
 		store := cr.sessionsBeadStore()
 		markCityStopSessionSleepReason(sessionFrontDoor(store.Store), cr.stderr)
 		gracefulStopAllWithForceSignal(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 		if !asyncStartsDrained && cr.forceStopRequested() {
 			lateRunning, lateListErr := cr.sp.ListRunning("")
 			if lateListErr != nil {
+				sweepEnumerated = false
 				if runtime.IsPartialListError(lateListErr) {
 					fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing partially failed; stopping %d visible agent(s): %v\n", cr.logPrefix, len(lateRunning), lateListErr) //nolint:errcheck // best-effort stderr
 				} else {
@@ -3855,14 +3876,23 @@ func (cr *CityRuntime) shutdown() {
 				gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 			}
 		}
-		// With every session stopped, tear down the provider's shared server,
-		// exactly like the standalone stop path (cmdStopBody ->
-		// teardownServerForStop). Without this, a supervisor-managed stop
-		// leaks the city's tmux server (mayor session included) until someone
-		// kills it by hand (#5175). The preserve-sessions shutdown returned
-		// above, before the session stops — preserved sessions live inside
-		// this server, so keeping it up there is by design, not an omission.
-		teardownServerForStop(cr.sp, cr.stderr)
+		// With every enumerated session stopped, tear down the provider's
+		// shared server, exactly like the standalone stop path (cmdStopBody
+		// -> teardownServerForStop). Without this, a supervisor-managed stop
+		// leaks the city's tmux server until someone kills it by hand
+		// (#5175). Two guards keep the kill-server narrow:
+		//   - ownedCity: only a runtime that reached run() owns this city.
+		//     A discarded half-built runtime (adoption of an already-running
+		//     city; a controller-lock/socket/token failure) calls shutdown()
+		//     too, and must never kill the live owner's server.
+		//   - sweepEnumerated: only tear down after a stop that actually
+		//     listed the fleet, never on the empty slice a failed list leaves.
+		// The preserve-sessions shutdown returned above, before the session
+		// stops — preserved sessions live inside this server, so keeping it
+		// up there is by design, not an omission.
+		if cr.ownedCity.Load() && sweepEnumerated {
+			teardownServerForStop(cr.sp, cr.stderr, fmt.Sprintf("%s: city '%s'", cr.logPrefix, cr.cityName))
+		}
 	})
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -3855,6 +3855,14 @@ func (cr *CityRuntime) shutdown() {
 				gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 			}
 		}
+		// With every session stopped, tear down the provider's shared server,
+		// exactly like the standalone stop path (cmdStopBody ->
+		// teardownServerForStop). Without this, a supervisor-managed stop
+		// leaks the city's tmux server (mayor session included) until someone
+		// kills it by hand (#5175). The preserve-sessions shutdown returned
+		// above, before the session stops — preserved sessions live inside
+		// this server, so keeping it up there is by design, not an omission.
+		teardownServerForStop(cr.sp, cr.stderr)
 	})
 }
 

--- a/cmd/gc/city_runtime_server_lifecycle_test.go
+++ b/cmd/gc/city_runtime_server_lifecycle_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// serverLifecycleCityRuntime builds a minimal city runtime over the given
+// provider, mirroring the shape the supervisor's managed-stop paths drive:
+// stopManagedCity / the run loop's deferred cr.shutdown() are the only ways a
+// supervisor-managed city ever stops, so CityRuntime.shutdown() is where the
+// managed path either tears the provider server down or leaks it (#5175).
+func serverLifecycleCityRuntime(t *testing.T, sp runtime.Provider) *CityRuntime {
+	t.Helper()
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	return newTestCityRuntime(t, CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+}
+
+// TestCityRuntimeShutdownTearsDownProviderServer pins the managed-stop half
+// of #5175: a full (non-preserving) CityRuntime.shutdown() must tear down the
+// provider's shared server after stopping the sessions, exactly like the
+// standalone stop path (cmdStopBody -> teardownServerForStop) already does.
+// Without it, a supervisor-managed `gc stop` reports "City stopped." while
+// the city's tmux server — mayor session included — keeps running until
+// someone kills it by hand.
+func TestCityRuntimeShutdownTearsDownProviderServer(t *testing.T) {
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
+	cr := serverLifecycleCityRuntime(t, sp)
+
+	cr.shutdown()
+
+	sp.mu.Lock()
+	eventsSnapshot := append([]string(nil), sp.events...)
+	sp.mu.Unlock()
+
+	teardowns := 0
+	lastListRunning := -1
+	firstTeardown := -1
+	for i, e := range eventsSnapshot {
+		switch e {
+		case "TeardownServer":
+			teardowns++
+			if firstTeardown == -1 {
+				firstTeardown = i
+			}
+		case "ListRunning":
+			lastListRunning = i
+		}
+	}
+	if teardowns != 1 {
+		t.Fatalf("shutdown called TeardownServer %d time(s), want exactly 1 (events: %v): the managed stop path must not leak the provider server (#5175)", teardowns, eventsSnapshot)
+	}
+	if lastListRunning == -1 || lastListRunning > firstTeardown {
+		t.Fatalf("TeardownServer must come after the session-stop sweep's ListRunning (events: %v)", eventsSnapshot)
+	}
+
+	// The Once makes "exactly once" a property of the process: a second
+	// shutdown call must not tear the (next supervisor's) server down again.
+	cr.shutdown()
+	sp.mu.Lock()
+	total := 0
+	for _, e := range sp.events {
+		if e == "TeardownServer" {
+			total++
+		}
+	}
+	sp.mu.Unlock()
+	if total != 1 {
+		t.Fatalf("a second shutdown called TeardownServer again (%d calls total)", total)
+	}
+}
+
+// TestCityRuntimeShutdownPreservingSessionsKeepsServer pins the deliberate
+// asymmetry: preserve-mode shutdown hands live sessions to the next
+// supervisor for re-adoption, and those sessions live inside the provider
+// server — tearing it down would kill exactly what preserve mode exists to
+// keep. The server must survive a preserving shutdown.
+func TestCityRuntimeShutdownPreservingSessionsKeepsServer(t *testing.T) {
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
+	cr := serverLifecycleCityRuntime(t, sp)
+
+	cr.preserveSessionsOnShutdown()
+	cr.shutdown()
+
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	for _, e := range sp.events {
+		if e == "TeardownServer" {
+			t.Fatalf("preserve-mode shutdown tore down the provider server (events: %v); preserved sessions cannot outlive their server", sp.events)
+		}
+	}
+}
+
+// TestCityRuntimeShutdownWithoutServerLifecycleProviderIsANoOp pins that a
+// provider without the optional ServerLifecycleProvider extension shuts down
+// exactly as before — the teardown hook is a type-asserted no-op, not a new
+// requirement on every provider.
+func TestCityRuntimeShutdownWithoutServerLifecycleProviderIsANoOp(t *testing.T) {
+	cr := serverLifecycleCityRuntime(t, runtime.NewFake())
+	cr.shutdown() // must not panic
+}

--- a/cmd/gc/city_runtime_server_lifecycle_test.go
+++ b/cmd/gc/city_runtime_server_lifecycle_test.go
@@ -2,13 +2,20 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session/sessiontest"
 )
 
 // serverLifecycleCityRuntime builds a minimal city runtime over the given
@@ -44,27 +51,19 @@ func serverLifecycleCityRuntime(t *testing.T, sp runtime.Provider) *CityRuntime 
 	})
 }
 
-// TestCityRuntimeShutdownTearsDownProviderServer pins the managed-stop half
-// of #5175: a full (non-preserving) CityRuntime.shutdown() must tear down the
-// provider's shared server after stopping the sessions, exactly like the
-// standalone stop path (cmdStopBody -> teardownServerForStop) already does.
-// Without it, a supervisor-managed `gc stop` reports "City stopped." while
-// the city's tmux server — mayor session included — keeps running until
-// someone kills it by hand.
-func TestCityRuntimeShutdownTearsDownProviderServer(t *testing.T) {
-	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
-	cr := serverLifecycleCityRuntime(t, sp)
+// markOwnedForTest simulates run() having taken ownership of the city, the
+// gate that lets shutdown() tear the shared server down. Tests that drive
+// shutdown() directly never call run(), so they set it explicitly; a test
+// that omits it is asserting the un-owned (discarded-runtime) behavior.
+func markOwnedForTest(cr *CityRuntime) { cr.ownedCity.Store(true) }
 
-	cr.shutdown()
-
-	sp.mu.Lock()
-	eventsSnapshot := append([]string(nil), sp.events...)
-	sp.mu.Unlock()
-
-	teardowns := 0
-	lastListRunning := -1
-	firstTeardown := -1
-	for i, e := range eventsSnapshot {
+// teardownEvents returns, from a recorded event stream, the number of
+// TeardownServer calls, the index of the first one (or -1), and the index of
+// the last ListRunning (or -1). Every teardown-ordering assertion below reads
+// these three, so they live in one place rather than three copy-pasted scans.
+func teardownEvents(events []string) (teardowns, firstTeardown, lastListRunning int) {
+	firstTeardown, lastListRunning = -1, -1
+	for i, e := range events {
 		switch e {
 		case "TeardownServer":
 			teardowns++
@@ -75,26 +74,82 @@ func TestCityRuntimeShutdownTearsDownProviderServer(t *testing.T) {
 			lastListRunning = i
 		}
 	}
+	return teardowns, firstTeardown, lastListRunning
+}
+
+func (p *lifecycleOrderProvider) snapshotEvents() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.events...)
+}
+
+// TestCityRuntimeShutdownTearsDownProviderServer pins the managed-stop half
+// of #5175: a full (non-preserving) CityRuntime.shutdown() by the runtime that
+// owns the city must tear down the provider's shared server after stopping the
+// sessions, exactly like the standalone stop path (cmdStopBody ->
+// teardownServerForStop) already does. Without it, a supervisor-managed
+// `gc stop` reports "City stopped." while the city's tmux server keeps running
+// until someone kills it by hand.
+func TestCityRuntimeShutdownTearsDownProviderServer(t *testing.T) {
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
+	cr := serverLifecycleCityRuntime(t, sp)
+	markOwnedForTest(cr)
+
+	cr.shutdown()
+
+	teardowns, firstTeardown, lastListRunning := teardownEvents(sp.snapshotEvents())
 	if teardowns != 1 {
-		t.Fatalf("shutdown called TeardownServer %d time(s), want exactly 1 (events: %v): the managed stop path must not leak the provider server (#5175)", teardowns, eventsSnapshot)
+		t.Fatalf("shutdown called TeardownServer %d time(s), want exactly 1 (events: %v): the managed stop path must not leak the provider server (#5175)", teardowns, sp.snapshotEvents())
 	}
 	if lastListRunning == -1 || lastListRunning > firstTeardown {
-		t.Fatalf("TeardownServer must come after the session-stop sweep's ListRunning (events: %v)", eventsSnapshot)
+		t.Fatalf("TeardownServer must come after the session-stop sweep's ListRunning (events: %v)", sp.snapshotEvents())
 	}
 
-	// The Once makes "exactly once" a property of the process: a second
+	// The Once makes "exactly once" a property of this runtime: a second
 	// shutdown call must not tear the (next supervisor's) server down again.
 	cr.shutdown()
-	sp.mu.Lock()
-	total := 0
-	for _, e := range sp.events {
-		if e == "TeardownServer" {
-			total++
-		}
+	if teardowns, _, _ := teardownEvents(sp.snapshotEvents()); teardowns != 1 {
+		t.Fatalf("a second shutdown called TeardownServer again (%d calls total)", teardowns)
 	}
-	sp.mu.Unlock()
-	if total != 1 {
-		t.Fatalf("a second shutdown called TeardownServer again (%d calls total)", total)
+}
+
+// TestCityRuntimeShutdownWithoutOwnershipKeepsServer is the core of the
+// draft-and-fix in #5196: a runtime that never reached run() does not own the
+// city. The supervisor calls its shutdown() anyway on every init-failure /
+// discard path — a failed adoption of an already-running city, a
+// controller-lock/socket/token failure — and if that teardown were
+// unconditional it would run kill-server on the LIVE owner's shared socket,
+// killing every session. An un-owned shutdown must stop nothing's server.
+func TestCityRuntimeShutdownWithoutOwnershipKeepsServer(t *testing.T) {
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
+	cr := serverLifecycleCityRuntime(t, sp)
+	// Deliberately NOT markOwnedForTest: this models the discarded runtime.
+
+	cr.shutdown()
+
+	if teardowns, _, _ := teardownEvents(sp.snapshotEvents()); teardowns != 0 {
+		t.Fatalf("an un-owned shutdown tore down the provider server %d time(s) (events: %v); a discarded runtime must never kill the live owner's server", teardowns, sp.snapshotEvents())
+	}
+}
+
+// TestCityRuntimeShutdownSkipsTeardownWhenListRunningFailed pins the second
+// guard: a failed ListRunning yields an empty slice, so gracefulStopAll stops
+// nothing. Tearing the server down after that would convert a transient
+// listing error into an ungraceful mass kill of sessions we never enumerated.
+// The runtime owns the city here, so only the listing failure holds teardown.
+func TestCityRuntimeShutdownSkipsTeardownWhenListRunningFailed(t *testing.T) {
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake(), listErr: errors.New("tmux unreachable")}
+	cr := serverLifecycleCityRuntime(t, sp)
+	markOwnedForTest(cr)
+
+	cr.shutdown()
+
+	teardowns, _, lastListRunning := teardownEvents(sp.snapshotEvents())
+	if lastListRunning == -1 {
+		t.Fatalf("expected shutdown to attempt a ListRunning sweep (events: %v)", sp.snapshotEvents())
+	}
+	if teardowns != 0 {
+		t.Fatalf("shutdown tore down the server %d time(s) after a failed enumeration (events: %v); kill-server must not run on a fleet we never listed", teardowns, sp.snapshotEvents())
 	}
 }
 
@@ -102,20 +157,18 @@ func TestCityRuntimeShutdownTearsDownProviderServer(t *testing.T) {
 // asymmetry: preserve-mode shutdown hands live sessions to the next
 // supervisor for re-adoption, and those sessions live inside the provider
 // server — tearing it down would kill exactly what preserve mode exists to
-// keep. The server must survive a preserving shutdown.
+// keep. The server must survive a preserving shutdown even by the owning
+// runtime.
 func TestCityRuntimeShutdownPreservingSessionsKeepsServer(t *testing.T) {
 	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
 	cr := serverLifecycleCityRuntime(t, sp)
+	markOwnedForTest(cr)
 
 	cr.preserveSessionsOnShutdown()
 	cr.shutdown()
 
-	sp.mu.Lock()
-	defer sp.mu.Unlock()
-	for _, e := range sp.events {
-		if e == "TeardownServer" {
-			t.Fatalf("preserve-mode shutdown tore down the provider server (events: %v); preserved sessions cannot outlive their server", sp.events)
-		}
+	if teardowns, _, _ := teardownEvents(sp.snapshotEvents()); teardowns != 0 {
+		t.Fatalf("preserve-mode shutdown tore down the provider server %d time(s) (events: %v); preserved sessions cannot outlive their server", teardowns, sp.snapshotEvents())
 	}
 }
 
@@ -125,5 +178,163 @@ func TestCityRuntimeShutdownPreservingSessionsKeepsServer(t *testing.T) {
 // requirement on every provider.
 func TestCityRuntimeShutdownWithoutServerLifecycleProviderIsANoOp(t *testing.T) {
 	cr := serverLifecycleCityRuntime(t, runtime.NewFake())
+	markOwnedForTest(cr)
 	cr.shutdown() // must not panic
+}
+
+// forceLifecycleProvider is a gated-start provider that also records
+// ListRunning / TeardownServer ordering and satisfies ServerLifecycleProvider.
+// Its first ListRunning releases the gated start and waits for it to land, so
+// a force shutdown that abandoned the async-start wait takes a SECOND
+// ListRunning to catch the late session — exactly the path the teardown must
+// still run after (and only after).
+type forceLifecycleProvider struct {
+	*gatedStartProvider
+	evMu   sync.Mutex
+	events []string
+}
+
+func newForceLifecycleProvider() *forceLifecycleProvider {
+	return &forceLifecycleProvider{gatedStartProvider: newGatedStartProvider()}
+}
+
+func (p *forceLifecycleProvider) record(ev string) {
+	p.evMu.Lock()
+	p.events = append(p.events, ev)
+	p.evMu.Unlock()
+}
+
+func (p *forceLifecycleProvider) snapshotEvents() []string {
+	p.evMu.Lock()
+	defer p.evMu.Unlock()
+	return append([]string(nil), p.events...)
+}
+
+func (p *forceLifecycleProvider) ListRunning(prefix string) ([]string, error) {
+	p.evMu.Lock()
+	p.events = append(p.events, "ListRunning")
+	call := 0
+	for _, e := range p.events {
+		if e == "ListRunning" {
+			call++
+		}
+	}
+	p.evMu.Unlock()
+
+	running, err := p.Fake.ListRunning(prefix)
+	if call == 1 {
+		p.release("worker")
+		deadline := time.Now().Add(2 * time.Second)
+		for !p.IsRunning("worker") && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	return running, err
+}
+
+func (p *forceLifecycleProvider) ConfigureServer() error { return nil }
+
+func (p *forceLifecycleProvider) TeardownServer() error {
+	p.record("TeardownServer")
+	return nil
+}
+
+var (
+	_ runtime.Provider                = (*forceLifecycleProvider)(nil)
+	_ runtime.ServerLifecycleProvider = (*forceLifecycleProvider)(nil)
+)
+
+// TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep is the force-mode
+// ordering proof the single-ListRunning fakes above cannot give: under a force
+// stop with an async start still pending, shutdown() takes a second
+// ListRunning to catch the late session, and the teardown must land AFTER that
+// second sweep — never between the two, when a just-created session is still
+// live. It also confirms the owned+enumerated gate lets the teardown through
+// on the force path.
+func TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 30, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newForceLifecycleProvider()
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{ShutdownTimeout: "500ms"},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	forceStop := &atomic.Bool{}
+	forceStop.Store(true)
+	cr := &CityRuntime{
+		cfg:                 cfg,
+		sp:                  sp,
+		rec:                 events.Discard,
+		standaloneCityStore: store,
+		asyncStartLimiter:   newAsyncStartLimiter(maxParallelStartsPerTick(cfg)),
+		forceStopShutdown:   forceStop,
+		logPrefix:           "gc test",
+		stdout:              ioDiscard{},
+		stderr:              ioDiscard{},
+	}
+	markOwnedForTest(cr)
+
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{{info: sessiontest.SeedBead(t, session), tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
+		withAsyncStartTracker(&cr.asyncStarts),
+	); got != 1 {
+		t.Fatalf("woken = %d, want 1", got)
+	}
+	sp.waitForStarts(t, 1)
+
+	cr.shutdown()
+
+	ev := sp.snapshotEvents()
+	teardowns, firstTeardown, lastListRunning := teardownEvents(ev)
+	listRunnings := 0
+	for _, e := range ev {
+		if e == "ListRunning" {
+			listRunnings++
+		}
+	}
+	if listRunnings < 2 {
+		t.Fatalf("ListRunning calls = %d, want a second snapshot for force async-start cleanup (events: %v)", listRunnings, ev)
+	}
+	if teardowns != 1 {
+		t.Fatalf("force shutdown called TeardownServer %d time(s), want exactly 1 (events: %v)", teardowns, ev)
+	}
+	if firstTeardown < lastListRunning {
+		t.Fatalf("TeardownServer landed before the last (late-async) ListRunning (events: %v); a session created between the sweeps would be killed ungracefully", ev)
+	}
+	if sp.IsRunning("worker") {
+		t.Fatal("force shutdown missed the late async-started runtime")
+	}
 }

--- a/cmd/gc/city_runtime_server_lifecycle_test.go
+++ b/cmd/gc/city_runtime_server_lifecycle_test.go
@@ -192,10 +192,26 @@ type forceLifecycleProvider struct {
 	*gatedStartProvider
 	evMu   sync.Mutex
 	events []string
+
+	workerStarted chan struct{}
+	startedOnce   sync.Once
 }
 
 func newForceLifecycleProvider() *forceLifecycleProvider {
-	return &forceLifecycleProvider{gatedStartProvider: newGatedStartProvider()}
+	return &forceLifecycleProvider{
+		gatedStartProvider: newGatedStartProvider(),
+		workerStarted:      make(chan struct{}),
+	}
+}
+
+// Start signals workerStarted once the released gated start has actually
+// landed in the fake, so ListRunning can wait on it instead of polling.
+func (p *forceLifecycleProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	err := p.gatedStartProvider.Start(ctx, name, cfg)
+	if err == nil && name == "worker" {
+		p.startedOnce.Do(func() { close(p.workerStarted) })
+	}
+	return err
 }
 
 func (p *forceLifecycleProvider) record(ev string) {
@@ -224,9 +240,9 @@ func (p *forceLifecycleProvider) ListRunning(prefix string) ([]string, error) {
 	running, err := p.Fake.ListRunning(prefix)
 	if call == 1 {
 		p.release("worker")
-		deadline := time.Now().Add(2 * time.Second)
-		for !p.IsRunning("worker") && time.Now().Before(deadline) {
-			time.Sleep(10 * time.Millisecond)
+		select {
+		case <-p.workerStarted:
+		case <-time.After(hangBudget):
 		}
 	}
 	return running, err

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -370,7 +370,7 @@ func cmdStopBodyWithoutSuccess(cityPath string, cfg *config.City, force bool, st
 	// not in the current config).
 	stopOrphans(sp, desired, cfg, sessionFrontDoor(sessStore), graceTimeout, recorder, stdout, stderr)
 
-	teardownServerForStop(sp, stderr)
+	teardownServerForStop(sp, stderr, "gc stop")
 
 	// Stop bead store's backing service after agents.
 	if err := shutdownBeadsProviderForStop(cityPath); err != nil {
@@ -381,13 +381,18 @@ func cmdStopBodyWithoutSuccess(cityPath string, cfg *config.City, force bool, st
 	return code
 }
 
-func teardownServerForStop(sp runtime.Provider, stderr io.Writer) {
+// teardownServerForStop terminates a provider's shared server after every
+// session has been stopped. logPrefix identifies the caller in the error
+// line: the standalone path passes "gc stop", the supervisor-managed path
+// passes its own "<logPrefix>: city '<name>'" so a teardown warning reads
+// like every other managed-shutdown error.
+func teardownServerForStop(sp runtime.Provider, stderr io.Writer, logPrefix string) {
 	lifecycle, ok := sp.(runtime.ServerLifecycleProvider)
 	if !ok {
 		return
 	}
 	if err := lifecycle.TeardownServer(); err != nil {
-		fmt.Fprintf(stderr, "gc stop: teardown server: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: teardown server: %v\n", logPrefix, err) //nolint:errcheck // best-effort stderr
 	}
 }
 

--- a/cmd/gc/cmd_stop_server_lifecycle_test.go
+++ b/cmd/gc/cmd_stop_server_lifecycle_test.go
@@ -20,12 +20,17 @@ type lifecycleOrderProvider struct {
 	mu          sync.Mutex
 	events      []string
 	teardownErr error
+	listErr     error // when set, ListRunning returns it (empty slice), modeling a failed enumeration
 }
 
 func (p *lifecycleOrderProvider) ListRunning(prefix string) ([]string, error) {
 	p.mu.Lock()
 	p.events = append(p.events, "ListRunning")
+	listErr := p.listErr
 	p.mu.Unlock()
+	if listErr != nil {
+		return nil, listErr
+	}
 	return p.Fake.ListRunning(prefix)
 }
 


### PR DESCRIPTION
`gc stop` on a supervisor-managed city reports "City stopped." but the city's `tmux -L <city>` server — mayor session included — survives indefinitely (repro in #5175: everything else exits; the tmux server is the durable leak; repeated cycles accumulate one orphaned server per socket).

**Root cause.** Only the standalone stop path calls the server teardown: `cmdStopBody` → `teardownServerForStop` → `runtime.ServerLifecycleProvider.TeardownServer` (cmd/gc/cmd_stop.go). The managed path — `stopManagedCity`, `stopManagedCityPreservingSessions`, and the city run loop's deferred `CityRuntime.shutdown()` — stops every session but never tears the shared server down.

**Fix.** `CityRuntime.shutdown()` now calls `teardownServerForStop(cr.sp, cr.stderr)` after the session stops (including the late force-stop sweep), mirroring `cmdStopBody`'s ordering. One call site; the existing type-assert keeps non-lifecycle providers untouched.

**Preserve-sessions is deliberately unchanged.** The preserving shutdown returns before the session stops and never reaches the teardown: preserved sessions live inside that server, so keeping it up for supervisor re-adoption is by design, not an omission. `TestCityRuntimeShutdownPreservingSessionsKeepsServer` pins that.

**Tests.** `TestCityRuntimeShutdownTearsDownProviderServer` fails on stock main (no TeardownServer call) and passes with the fix; it also pins ordering (after the session sweep) and once-ness across repeat shutdowns. A no-lifecycle-provider case pins that nothing new is required of other providers. Reuses `lifecycleOrderProvider` from the standalone-stop lifecycle tests.

Fixes #5175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
