### PR TITLE
test: tolerate Dolt shutdown tail in leak guard

### DIFF
--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // testReporter is the subset of *testing.T methods that
@@ -589,6 +590,8 @@ func TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap(t *testing.T
 		func() {},
 		func() { registeredReaped = true },
 		func(leaked []DoltProcInfo) { reapedLeaks = append(reapedLeaks, leaked...) },
+		time.Millisecond,
+		5*time.Millisecond,
 	)
 
 	if code != 1 {
@@ -623,6 +626,8 @@ func TestDoltLeakGuardedTestingMRunWithSweepsOrphanDirsAtStartup(t *testing.T) {
 		func() { order = append(order, "sweepOrphanDirs") },
 		func() {},
 		func([]DoltProcInfo) {},
+		time.Millisecond,
+		5*time.Millisecond,
 	)
 
 	if code != 0 {
@@ -630,6 +635,57 @@ func TestDoltLeakGuardedTestingMRunWithSweepsOrphanDirsAtStartup(t *testing.T) {
 	}
 	if len(order) < 3 || order[0] != "sweepStale" || order[1] != "sweepOrphanDirs" || order[2] != "runTests" {
 		t.Fatalf("call order = %v, want [sweepStale sweepOrphanDirs runTests ...]", order)
+	}
+}
+
+// A dolt sql-server that a test already told to stop can still be mid
+// graceful-shutdown the instant runTests() returns; ga-szv0ge found this
+// misclassified as a permanent leak under host contention. This simulates
+// the process clearing partway through the grace window: the final scan
+// reports it present on the first two polls and gone from the third poll
+// onward, well within the injected grace window, so the guard must not
+// fail the run or reap anything for it.
+func TestDoltLeakGuardedTestingMToleratesLeakClearingWithinGraceWindow(t *testing.T) {
+	tempRoot := filepath.Join(t.TempDir(), "gct-current")
+	clearing := DoltProcInfo{
+		PID: 2001,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(tempRoot, "TestCase", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	var scan int
+	enumerate := func() ([]DoltProcInfo, error) {
+		scan++
+		if scan == 1 {
+			return nil, nil // initial scan: nothing running yet
+		}
+		if scan <= 3 {
+			return []DoltProcInfo{clearing}, nil // first two final-scan polls: still mid shutdown
+		}
+		return nil, nil // cleared by the next poll, well within the grace window
+	}
+	g := newDoltLeakGuardedTestingM(nil, tempRoot)
+
+	var reapedLeaks []DoltProcInfo
+	code := g.runWith(
+		func() int { return 0 },
+		enumerate,
+		func(string) bool { return false },
+		func() {},
+		func() {},
+		func(leaked []DoltProcInfo) { reapedLeaks = append(reapedLeaks, leaked...) },
+		time.Millisecond,
+		200*time.Millisecond,
+	)
+
+	if code != 0 {
+		t.Fatalf("guard returned code %d, want 0: a leak that clears within the grace window must not fail the run", code)
+	}
+	if len(reapedLeaks) != 0 {
+		t.Fatalf("reaped leaks = %#v, want none: the process cleared on its own within the grace window", reapedLeaks)
 	}
 }
 

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -689,6 +689,65 @@ func TestDoltLeakGuardedTestingMToleratesLeakClearingWithinGraceWindow(t *testin
 	}
 }
 
+// waitForFinalScanToClear must surface a persistent final-scan enumeration
+// failure as its own error rather than dropping it. backoff.Retry (v4.3.0)
+// already unwraps the *backoff.PermanentError it returns internally and
+// hands back the inner error directly, so a later
+// errors.As(err, &permErr) against Retry's return value can never match --
+// ga-7r2h5i found this let a real enumeration failure fall through and get
+// reported as a clean run.
+func TestDoltLeakGuardedTestingMWaitForFinalScanToClearReturnsEnumerationError(t *testing.T) {
+	g := newDoltLeakGuardedTestingM(nil, t.TempDir())
+	scanErr := errors.New("reading /proc: permission denied")
+	enumerate := func() ([]DoltProcInfo, error) { return nil, scanErr }
+
+	leaked, err := g.waitForFinalScanToClear(enumerate, map[int]DoltProcInfo{}, time.Millisecond, 5*time.Millisecond)
+
+	if !errors.Is(err, scanErr) {
+		t.Fatalf("waitForFinalScanToClear err = %v, want it to be the enumeration failure %v", err, scanErr)
+	}
+	if leaked != nil {
+		t.Fatalf("leaked = %#v, want nil alongside a scan error", leaked)
+	}
+}
+
+// Same failure, exercised through runWith: a final-scan enumeration error
+// must fail the guard (code 1) and must not reap anything, since an
+// enumeration failure carries no process list to act on. Pre-fix, this
+// returned code 0 -- the swallowed error read as "no leak found".
+func TestDoltLeakGuardedTestingMRunWithFailsOnFinalScanError(t *testing.T) {
+	tempRoot := filepath.Join(t.TempDir(), "gct-current")
+	scanErr := errors.New("reading /proc: permission denied")
+	var scan int
+	enumerate := func() ([]DoltProcInfo, error) {
+		scan++
+		if scan == 1 {
+			return nil, nil // initial scan succeeds
+		}
+		return nil, scanErr // every final-scan poll fails
+	}
+	g := newDoltLeakGuardedTestingM(nil, tempRoot)
+
+	var reapedLeaks []DoltProcInfo
+	code := g.runWith(
+		func() int { return 0 },
+		enumerate,
+		func(string) bool { return false },
+		func() {},
+		func() {},
+		func(leaked []DoltProcInfo) { reapedLeaks = append(reapedLeaks, leaked...) },
+		time.Millisecond,
+		5*time.Millisecond,
+	)
+
+	if code != 1 {
+		t.Fatalf("guard returned code %d, want 1: a final-scan enumeration failure must fail the run, not be swallowed as a clean result", code)
+	}
+	if len(reapedLeaks) != 0 {
+		t.Fatalf("reaped leaks = %#v, want none: an enumeration failure carries no process list to reap", reapedLeaks)
+	}
+}
+
 // A dolt sql-server rooted in the source checkout rather than under the run's
 // temp root is the leak shape the guard used to miss entirely: cmd/gc's own
 // package dir is structurally outside tempRoot, so PathWithin(tempRoot, cfg)

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -849,3 +849,15 @@ func TestSnapshotDoltProcessesForConfigRootsIgnoresEmptyRoots(t *testing.T) {
 		t.Fatalf("empty roots matched %d process(es), want 0: %#v", len(got), got)
 	}
 }
+
+// The grace ceiling must stay a generous hang budget (ga-f5clwo), not drift
+// back toward round 2's 5s window, which still false-positived under host
+// contention (ga-d5nmtj gate evidence). The floor is picked independent of
+// config.DefaultDoltStopTimeout's exact value, so a future change to that
+// constant can't silently retighten this guard without a test noticing.
+func TestDoltLeakGuardGraceMaxElapsedTimeBudget(t *testing.T) {
+	const floor = 15 * time.Second
+	if doltLeakGuardGraceMaxElapsedTime < floor {
+		t.Fatalf("doltLeakGuardGraceMaxElapsedTime = %s, want >= %s", doltLeakGuardGraceMaxElapsedTime, floor)
+	}
+}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doltorphan"
 	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/testutil"
@@ -31,11 +32,22 @@ import (
 // (ga-szv0ge). The guard's real invariant is "no test leaves a dolt server
 // running forever," not "no test leaves a dolt server running for one more
 // scheduler tick after Run() returns" — mirrors the hang-budget framing in
-// ga-f5clwo. Sized well below normal package test timeouts so a genuine
-// leak (one that never clears, e.g. ga-vltdpl) still fails within seconds.
+// ga-f5clwo: this is a hang detector, not a latency SLO, so per ga-f5clwo's
+// own carve-out it gets "one shared generous budget" rather than per-test
+// tuning. Round 2's 5s budget still false-positived under host contention
+// (ga-d5nmtj gate evidence: PID 2911558 outlived the grace window, a later
+// scan found it already gone). Round 3 sets the ceiling to
+// config.DefaultDoltStopTimeout rather than a new arbitrary literal: that
+// constant is this same codebase's existing answer to "how long may a
+// managed dolt server take to actually stop" (its SIGTERM→SIGKILL grace,
+// cmd/gc/dolt_stop_managed.go), so the guard now tolerates exactly the
+// shutdown tail the system itself is already configured to allow — no
+// process the system considers to be stopping normally can trip it. Sized
+// well below normal package test timeouts so a genuine leak (one that never
+// clears, e.g. ga-vltdpl) still fails within tens of seconds, not minutes.
 const (
 	doltLeakGuardGraceInitialInterval = 250 * time.Millisecond
-	doltLeakGuardGraceMaxElapsedTime  = 5 * time.Second
+	doltLeakGuardGraceMaxElapsedTime  = config.DefaultDoltStopTimeout
 )
 
 func canonicalTestPath(path string) string {

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/gastownhall/gascity/internal/doltorphan"
 	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/testutil"
@@ -206,7 +207,7 @@ func (g *doltLeakGuardedTestingM) runWith(
 	sweepOrphanDirs func(),
 	reapRegistered func(),
 	reapLeaks func([]DoltProcInfo),
-	_, _ time.Duration,
+	graceInitialInterval, graceMaxElapsedTime time.Duration,
 ) int {
 	_ = sweepStale("startup")
 	sweepOrphanDirs()
@@ -222,11 +223,11 @@ func (g *doltLeakGuardedTestingM) runWith(
 
 	guardFailed := initialErr != nil
 	if initialErr == nil {
-		final, finalErr := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
+		leaked, finalErr := g.waitForFinalScanToClear(enumerate, initial, graceInitialInterval, graceMaxElapsedTime)
 		if finalErr != nil {
 			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: final scan failed: %v\n", finalErr) //nolint:errcheck
 			guardFailed = true
-		} else if leaked := diffDoltProcessSnapshots(initial, final); len(leaked) > 0 {
+		} else if len(leaked) > 0 {
 			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s\n", len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
 			writeDoltLeakReport(os.Stderr, leaked)
 			reapLeaks(leaked)
@@ -241,6 +242,49 @@ func (g *doltLeakGuardedTestingM) runWith(
 		return 1
 	}
 	return code
+}
+
+// waitForFinalScanToClear polls the final process-table scan, diffing
+// against initial each time, until it shows no candidates or
+// maxElapsedTime is exhausted. It tolerates the ordinary tail latency of a
+// dolt sql-server's graceful shutdown (already signaled to stop, not yet
+// reaped from the process table) without weakening detection of a process
+// still present when the grace window closes: the last observed diff is
+// what gets reported and reaped in that case, identical to a single
+// immediate scan finding the same result.
+func (g *doltLeakGuardedTestingM) waitForFinalScanToClear(
+	enumerate func() ([]DoltProcInfo, error),
+	initial map[int]DoltProcInfo,
+	initialInterval, maxElapsedTime time.Duration,
+) ([]DoltProcInfo, error) {
+	var leaked []DoltProcInfo
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = initialInterval
+	bo.MaxElapsedTime = maxElapsedTime
+
+	err := backoff.Retry(func() error {
+		final, finalErr := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
+		if finalErr != nil {
+			return backoff.Permanent(finalErr)
+		}
+		leaked = diffDoltProcessSnapshots(initial, final)
+		if len(leaked) == 0 {
+			return nil
+		}
+		return fmt.Errorf("%d dolt sql-server process(es) still present", len(leaked))
+	}, bo)
+	if err != nil {
+		var permErr *backoff.PermanentError
+		if errors.As(err, &permErr) {
+			return nil, permErr.Err
+		}
+		// Retries exhausted with a non-empty diff on the last poll: leaked
+		// already holds that observation, and the sentinel error above
+		// carries no information beyond "still non-empty" — fall through
+		// and report leaked, exactly like the old single-scan path did.
+	}
+	return leaked, nil
 }
 
 func (g *doltLeakGuardedTestingM) installSignalHandler() func() {

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -258,15 +258,24 @@ func (g *doltLeakGuardedTestingM) waitForFinalScanToClear(
 	initialInterval, maxElapsedTime time.Duration,
 ) ([]DoltProcInfo, error) {
 	var leaked []DoltProcInfo
+	var finalScanErr error
 
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = initialInterval
 	bo.MaxElapsedTime = maxElapsedTime
 
-	err := backoff.Retry(func() error {
-		final, finalErr := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
-		if finalErr != nil {
-			return backoff.Permanent(finalErr)
+	// backoff.Retry (v4.3.0) already unwraps a *backoff.PermanentError it
+	// returns internally and hands back the inner error directly, so
+	// type-asserting on Retry's own return value can never see a
+	// *backoff.PermanentError. Capture the scan error directly via this
+	// closure variable instead, mirroring leaked above: set at the same
+	// point backoff.Permanent(finalErr) is returned, read after Retry
+	// returns.
+	_ = backoff.Retry(func() error {
+		final, err := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
+		if err != nil {
+			finalScanErr = err
+			return backoff.Permanent(err)
 		}
 		leaked = diffDoltProcessSnapshots(initial, final)
 		if len(leaked) == 0 {
@@ -274,16 +283,13 @@ func (g *doltLeakGuardedTestingM) waitForFinalScanToClear(
 		}
 		return fmt.Errorf("%d dolt sql-server process(es) still present", len(leaked))
 	}, bo)
-	if err != nil {
-		var permErr *backoff.PermanentError
-		if errors.As(err, &permErr) {
-			return nil, permErr.Err
-		}
-		// Retries exhausted with a non-empty diff on the last poll: leaked
-		// already holds that observation, and the sentinel error above
-		// carries no information beyond "still non-empty" — fall through
-		// and report leaked, exactly like the old single-scan path did.
+	if finalScanErr != nil {
+		return nil, finalScanErr
 	}
+	// Retries exhausted with a non-empty diff on the last poll falls
+	// through here too: leaked already holds that observation, and the
+	// sentinel error returned by Retry in that case carries no
+	// information beyond "still non-empty".
 	return leaked, nil
 }
 

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -19,6 +19,24 @@ import (
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
+// doltLeakGuardGraceInitialInterval and doltLeakGuardGraceMaxElapsedTime
+// bound how long runWith tolerates a candidate leak surviving past
+// runTests() returning. A dolt sql-server that a test has already signaled
+// to stop still needs a bounded, non-zero amount of wall-clock time to
+// actually leave the process table (flush, close listeners, OS reap); under
+// host contention that ordinary shutdown tail can still be in flight the
+// instant the first final scan fires, which misclassifies a process
+// finishing an already-in-progress clean shutdown as a permanent leak
+// (ga-szv0ge). The guard's real invariant is "no test leaves a dolt server
+// running forever," not "no test leaves a dolt server running for one more
+// scheduler tick after Run() returns" — mirrors the hang-budget framing in
+// ga-f5clwo. Sized well below normal package test timeouts so a genuine
+// leak (one that never clears, e.g. ga-vltdpl) still fails within seconds.
+const (
+	doltLeakGuardGraceInitialInterval = 250 * time.Millisecond
+	doltLeakGuardGraceMaxElapsedTime  = 5 * time.Second
+)
+
 func canonicalTestPath(path string) string {
 	return testutil.CanonicalPath(path)
 }
@@ -178,7 +196,7 @@ func (g *doltLeakGuardedTestingM) nonEmptyLeakRoots() []string {
 }
 
 func (g *doltLeakGuardedTestingM) Run() int {
-	return g.runWith(g.m.Run, discoverDoltProcesses, g.sweepStaleCmdGCTestDoltProcesses, sweepOrphanDoltStoreDirs, reapManagedDoltTestProcesses, reapDoltLeakProcesses)
+	return g.runWith(g.m.Run, discoverDoltProcesses, g.sweepStaleCmdGCTestDoltProcesses, sweepOrphanDoltStoreDirs, reapManagedDoltTestProcesses, reapDoltLeakProcesses, doltLeakGuardGraceInitialInterval, doltLeakGuardGraceMaxElapsedTime)
 }
 
 func (g *doltLeakGuardedTestingM) runWith(
@@ -188,6 +206,7 @@ func (g *doltLeakGuardedTestingM) runWith(
 	sweepOrphanDirs func(),
 	reapRegistered func(),
 	reapLeaks func([]DoltProcInfo),
+	_, _ time.Duration,
 ) int {
 	_ = sweepStale("startup")
 	sweepOrphanDirs()

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.6
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/danielgtaylor/huma/v2 v2.37.3
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d
@@ -95,7 +96,6 @@ require (
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
 	github.com/bcicen/jstream v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect

--- a/release-gates/dolt-leak-guard-grace-period-gate.md
+++ b/release-gates/dolt-leak-guard-grace-period-gate.md
@@ -1,0 +1,61 @@
+# Release Gate: Dolt leak-guard grace period
+
+- Deploy bead: `ga-d5nmtj`
+- Review bead: `ga-7r2h5i`
+- Reviewed round-3 source: `917780062bc80b858fee3b5eadf3b25b6e7ede8d`
+- Evaluated source after bounded self-rebase: `f7f06b97d8a0e23dabfc1c7831c2cf8ee55db6e3`
+- Base: `origin/main@a4e4cc2bfac251b65116d536addbb4a7be9d95cd`
+- Deploy branch: `deploy/ga-d5nmtj-gate`
+- Verdict: **PASS**
+
+The description's round-2 `Commit:` field is superseded by the bead's
+round-3 metadata and re-review notes, both of which name `917780062b` as the
+reviewed deploy source. `docs/PROJECT_MANIFEST.md` is absent from this
+repository, so this checklist uses the seven release criteria in the active
+deployer protocol.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `ga-7r2h5i` closed PASS after independently validating the error-capture fix. `ga-d5nmtj` then records an independent round-3 re-review PASS for `917780062b`, including code-path tracing, scope verification, and the full targeted test family. |
+| 2 | Acceptance criteria met | **PASS** | Independent diff read and execution confirm: a Dolt process that exits within the injected grace window does not fail or reap; a process still present after the window still fails and is reaped; final-scan enumeration errors fail the guard instead of being swallowed; timing is injectable in tests; and the production ceiling uses `config.DefaultDoltStopTimeout` with an independent 15-second floor regression. `go build ./...` and `go vet ./...` are clean. |
+| 3 | Tests pass | **PASS** | Required high-contention process gate: 7 PASS jobs, 0 FAIL. Fast baseline: 10 PASS jobs, 0 FAIL. All six diff-owned top-level tests passed by name, with 0 FAIL and 0 SKIP. Direct provider-ledger package run passed, including `TestCatalogMatchesProductionWiringAndDocumentation`; `go mod tidy -diff` was clean. `waiver_ref: none`. |
+| 4 | No high-severity review findings open | **PASS** | Both review passes record no security/style blockers; the round-3 reviewer found no new failure. Unresolved HIGH count: `0`. |
+| 5 | Final branch is clean | **PASS** | Before adding this checklist, `git status --short --branch` reported only `## deploy/ga-d5nmtj-gate`. `git diff --check` and `gofmt -l` on changed Go files produced no output. Repository hooks resolve to `/home/jaword/projects/gascity/.githooks`. |
+| 6 | Branch diverges cleanly from main | **PASS** | No target PR existed for the reviewed SHA. The canonical bounded helper rebased isolated branch `deploy/ga-d5nmtj-gate` from `917780062b` to `f7f06b97d8` and returned `0`; current `origin/main` and waiver-fix commit `11edccc178` are ancestors of the evaluated head. The helper pushed with `--force-with-lease`, and the before/after SHAs are recorded on the bead. |
+| 7 | Single feature theme | **PASS** | The three-file diff is one `cmd/gc` test-harness reliability change: grace-period leak detection, its regression tests, and promotion of the already-present backoff v4 dependency from indirect to direct. No independent feature is bundled. |
+
+## Test evidence
+
+Environment setup before test execution:
+
+- `DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock`
+- `TESTCONTAINERS_RYUK_DISABLED=true`
+- Rootless Podman socket confirmed present.
+
+Commands and counts:
+
+- `LOCAL_TEST_JOBS=16 CMD_GC_PROCESS_TOTAL=6 make test-cmd-gc-process-parallel`: **7 PASS jobs, 0 FAIL** — six `cmd/gc` process shards plus `productmetrics-testhook`.
+- `LOCAL_TEST_JOBS=16 make test-fast-parallel`: **10 PASS jobs, 0 FAIL** — all six `cmd/gc` unit shards, `unit-core`, filesystem cross-compile, and both concurrency/guard self-tests.
+- `go test -count=1 -v ./cmd/gc/... -run '^(TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap|TestDoltLeakGuardedTestingMRunWithSweepsOrphanDirsAtStartup|TestDoltLeakGuardedTestingMToleratesLeakClearingWithinGraceWindow|TestDoltLeakGuardedTestingMWaitForFinalScanToClearReturnsEnumerationError|TestDoltLeakGuardedTestingMRunWithFailsOnFinalScanError|TestDoltLeakGuardGraceMaxElapsedTimeBudget)$'`: **6 PASS, 0 FAIL, 0 SKIP**.
+- `go test -count=1 -v ./internal/testutil/providerledger/...`: PASS; the renewed provider ledger and production wiring/documentation check execute successfully.
+- `go build ./...`: PASS.
+- `go vet ./...`: PASS.
+- `go mod tidy -diff`: PASS (no output).
+
+`diff_tests_executed`:
+
+- `TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap`: PASS
+- `TestDoltLeakGuardedTestingMRunWithSweepsOrphanDirsAtStartup`: PASS
+- `TestDoltLeakGuardedTestingMToleratesLeakClearingWithinGraceWindow`: PASS
+- `TestDoltLeakGuardedTestingMWaitForFinalScanToClearReturnsEnumerationError`: PASS
+- `TestDoltLeakGuardedTestingMRunWithFailsOnFinalScanError`: PASS
+- `TestDoltLeakGuardGraceMaxElapsedTimeBudget`: PASS
+
+`test_counts`: required job gates `17 PASS jobs / 0 FAIL`; diff-owned tests
+`6 PASS / 0 FAIL / 0 SKIP`.
+
+`skip_justification`: not applicable — zero skips.
+
+`waiver_ref`: none required.


### PR DESCRIPTION
## What this changes

The `cmd/gc` test leak guard now gives a Dolt server that has already been
signaled to stop a bounded grace window to leave the process table. This
prevents a normal shutdown tail from being reported as a permanent leak under
host contention.

The guard still fails and reaps a process that remains after the window, and
it now explicitly fails when the final process-table scan itself errors. The
grace ceiling reuses the existing managed-Dolt shutdown timeout, keeping the
test harness aligned with the shutdown behavior it is measuring.

## Review notes

- This changes the `cmd/gc` test harness only; shipped command behavior and
  public configuration are unchanged.
- The common path returns as soon as the first clean scan appears. The
  30-second value is a worst-case ceiling for a process that remains visible,
  not a fixed delay on every test run.
- Genuine leaks remain failures. The regression suite covers clearing,
  persistent-leak, and enumeration-error branches independently.
- `github.com/cenkalti/backoff/v4` is promoted from indirect to direct without
  a version change because the harness now imports it directly.

## Test plan

- [x] Run all six `cmd/gc` process shards plus the product-metrics hook under
  the documented high-contention local configuration.
- [x] Run the fast ten-job sharded baseline.
- [x] Run all six diff-owned tests verbosely by name and confirm zero skips.
- [x] Run `go build ./...`, `go vet ./...`, `go mod tidy -diff`, and the
  provider-ledger suite.
- [x] Release gate:
  [`release-gates/dolt-leak-guard-grace-period-gate.md`](release-gates/dolt-leak-guard-grace-period-gate.md)
