### PR TITLE
fix(storage): resolve HQ's pinned work prefix the way the city mints it

### DIFF
--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -694,15 +694,20 @@ func resolveCityStoragePlan(cityPath string, cfg *config.City) (*storebinding.St
 // a description must not be able to trip the drift refusal that exists to
 // protect recorded pins.
 func cityStorageWorkPins(cityPath string, cfg *config.City) storebinding.WorkPinInputs {
-	hqPrefix := ""
-	if cfg != nil {
-		hqPrefix = cfg.ResolvedWorkspacePrefix
-	}
+	// The pin has to state the prefix HQ actually mints under, which is the
+	// full three-step resolution and not the resolved field alone: no default
+	// city.toml declares [workspace] prefix, so an ordinary city derives its
+	// prefix from its name. Reading the field alone sent every such city to
+	// the fallback, and a fallback that repeats a rig's prefix collides with
+	// it. The rig arm below already resolves through Rig.EffectivePrefix.
+	//
+	// The fallback now stands only where the city resolves no prefix at all,
+	// rather than standing in for every city that leaves the field unset.
 	pins := storebinding.WorkPinInputs{
 		ConfigContext: storageWorkConfigContext(cityPath, cfg),
 		HQ: storebinding.WorkScopePin{
 			Scope:       storebinding.HQScope(),
-			Prefix:      storageWorkPrefix(hqPrefix, "gc"),
+			Prefix:      storageWorkPrefix(config.EffectiveHQPrefix(cfg), "gc"),
 			OpenerID:    storageWorkOpenerID(cfg),
 			ComponentID: "hq",
 			PhysicalID:  storageWorkPhysicalID(cityPath),
@@ -733,11 +738,17 @@ func cityStorageWorkPins(cityPath string, cfg *config.City) storebinding.WorkPin
 
 // storageWorkConfigContext digests the configuration the pins were derived
 // from, so a plan carries a canonical reference to the inputs that produced it.
+//
+// It digests the same resolved values the pins carry, not the raw fields they
+// were resolved from. Hashing a field the pin no longer reads would let two
+// cities whose HQ pins genuinely differ share one digest, and the digest exists
+// precisely to tell those two apart. The rig line already digests the resolved
+// prefix for the same reason.
 func storageWorkConfigContext(cityPath string, cfg *config.City) storebinding.ConfigRefDigest {
 	sum := sha256.New()
 	fmt.Fprintln(sum, cityPath) //nolint:errcheck // hashing a writer that cannot fail
 	if cfg != nil {
-		fmt.Fprintln(sum, cfg.ResolvedWorkspacePrefix) //nolint:errcheck // hashing a writer that cannot fail
+		fmt.Fprintln(sum, config.EffectiveHQPrefix(cfg)) //nolint:errcheck // hashing a writer that cannot fail
 		for _, rig := range cfg.Rigs {
 			fmt.Fprintf(sum, "%s\x00%s\x00%s\x00%t\n", rig.Name, rig.EffectivePrefix(), rig.Path, rig.Suspended) //nolint:errcheck // hashing a writer that cannot fail
 		}

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -2018,3 +2018,111 @@ func TestFailedNoteWriteReleasesTheBindingItJustOpened(t *testing.T) {
 		t.Errorf("the opened binding was closed %d time(s), want exactly 1: a boot that refuses must not keep the engine it opened", closes)
 	}
 }
+
+// TestStorageWorkPinsResolveHQPrefixTheSameWayTheCityMintsIt covers the HQ pin
+// for a city that never declares a workspace prefix, which is the ordinary
+// case: [workspace] prefix is not in the default city.toml.
+//
+// HQ then mints under the prefix derived from the city name, and the pin has
+// to state that same value. Pinning a fixed literal instead makes the pin
+// disagree with reality for every such city, and the disagreement is only
+// visible when some rig genuinely holds the literal: two pinned work scopes
+// land on one prefix and the resolver refuses the pair, so a city that boots
+// today cannot boot once it configures [storage].
+//
+// gc is the natural prefix for a rig tracking gascity, so this is not exotic.
+// The rig arm of the same function already resolves through
+// Rig.EffectivePrefix; only HQ read a raw field and a literal.
+func TestStorageWorkPinsResolveHQPrefixTheSameWayTheCityMintsIt(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.City{
+		// Neither ResolvedWorkspacePrefix nor Workspace.Prefix is set, so the
+		// prefix comes from the city name, exactly as EffectiveHQPrefix's
+		// third step resolves it.
+		ResolvedWorkspaceName: "ds-research",
+		Rigs: []config.Rig{
+			{Name: "gascity", Prefix: "gc", Path: filepath.Join(root, "gascity")},
+		},
+	}
+
+	want := config.EffectiveHQPrefix(cfg)
+	if want == "" {
+		t.Fatal("the city derives no HQ prefix, so this case cannot state what the pin should carry")
+	}
+
+	pins := cityStorageWorkPins(root, cfg)
+	if pins.HQ.Prefix != want {
+		t.Errorf("HQ pinned prefix %q, want %q: the pin disagrees with the prefix HQ mints under",
+			pins.HQ.Prefix, want)
+	}
+
+	// The consequence the operator meets. A pin that repeats the rig's prefix
+	// collides with it, and the resolver refuses any pair where one prefix
+	// selects the other.
+	registry := storebinding.NewProviderRegistry()
+	if err := registry.Freeze(); err != nil {
+		t.Fatalf("freezing an empty registry: %v", err)
+	}
+	if _, err := storebinding.ResolveStoragePlan(registry, cfg.EffectiveStorage(), pins, root); err != nil {
+		t.Fatalf("a city with a rig at prefix %q cannot resolve its storage plan: %v", cfg.Rigs[0].Prefix, err)
+	}
+}
+
+// TestStorageWorkPinsUseADeclaredWorkspacePrefix covers the middle step of the
+// resolution, where a city declares [workspace] prefix but nothing has
+// populated the resolved field. That path reached the pin only after this
+// function stopped reading the resolved field alone; before, such a city was
+// pinned at the fallback while HQ minted under its declared prefix.
+//
+// The pin carries storageWorkPrefix's normalisation of the declared value, not
+// the raw value. That normalisation is older than this resolution and applies
+// equally to the resolved field, so a declared prefix that is not already
+// lower case and dash-free still pins a value the backend does not mint under.
+// Canonicalising prefixes once for both minting and pinning is issue #5204.
+func TestStorageWorkPinsUseADeclaredWorkspacePrefix(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.City{
+		ResolvedWorkspaceName: "ds-research",
+		Workspace:             config.Workspace{Prefix: "hq"},
+		Rigs: []config.Rig{
+			{Name: "gascity", Prefix: "gc", Path: filepath.Join(root, "gascity")},
+		},
+	}
+
+	pins := cityStorageWorkPins(root, cfg)
+	if pins.HQ.Prefix != "hq" {
+		t.Errorf("HQ pinned prefix %q, want %q: a declared workspace prefix does not reach the pin",
+			pins.HQ.Prefix, "hq")
+	}
+	// The declared value wins over the name-derived one, which is the ordering
+	// EffectiveHQPrefix states.
+	if derived := config.DeriveBeadsPrefix("ds-research"); pins.HQ.Prefix == derived {
+		t.Errorf("HQ pinned the name-derived prefix %q over the declared one", derived)
+	}
+}
+
+// TestStorageWorkConfigContextDistinguishesDerivedHQPrefixes covers the digest
+// that states which configuration a plan was resolved from.
+//
+// Two cities can leave the workspace prefix unset and still pin different HQ
+// prefixes, because the prefix is then derived from the city name. A digest
+// taken over the unset field alone reads those two as the same configuration
+// while their pins disagree, which is the one thing the digest exists to
+// prevent.
+func TestStorageWorkConfigContextDistinguishesDerivedHQPrefixes(t *testing.T) {
+	root := t.TempDir()
+	research := &config.City{ResolvedWorkspaceName: "ds-research"}
+	factory := &config.City{ResolvedWorkspaceName: "gas-town"}
+
+	if config.EffectiveHQPrefix(research) == config.EffectiveHQPrefix(factory) {
+		t.Fatalf("both cities derive prefix %q, so this case cannot tell the digests apart",
+			config.EffectiveHQPrefix(research))
+	}
+	if cityStorageWorkPins(root, research).HQ.Prefix == cityStorageWorkPins(root, factory).HQ.Prefix {
+		t.Fatal("the two cities pin the same HQ prefix, so the digest has nothing to distinguish")
+	}
+
+	if storageWorkConfigContext(root, research) == storageWorkConfigContext(root, factory) {
+		t.Error("two cities with different HQ pins share one config digest, so a plan cannot name the configuration it came from")
+	}
+}


### PR DESCRIPTION
A city that configures `[storage]` and has a rig at prefix `gc` cannot boot. It
fails with `invalid pinned work scope: scopes rig:gascity and hq cannot be
selected by prefix`, which names neither the value it folded them onto nor the
config key that would move it. `gc` is the natural prefix for a rig tracking
this repo, so the shape is not exotic.

## Cause

`cityStorageWorkPins` read `cfg.ResolvedWorkspacePrefix` and fell back to the
literal `"gc"`. That field is only the first of the three steps
`config.EffectiveHQPrefix` resolves, and no default `city.toml` declares
`[workspace] prefix`, so an ordinary city skipped straight to the fallback while
HQ minted under a prefix derived from its name. For this city HQ mints `dr-`
and the pin claimed `gc`, colliding with the rig that really is `gc`.

The disagreement stays invisible until some rig genuinely holds the literal.
`internal/storebinding/plan_work.go:169` then refuses the pair, and a city that
boots today stops booting the moment it configures `[storage]`.

The rig arm of the same function already resolved through
`Rig.EffectivePrefix()`. Only HQ read a raw field, and the two fallbacks
(`"gc"` and `"gr"`) were chosen not to collide with each other; nothing
protected the HQ default from a rig whose prefix genuinely is `gc`.

## The same asymmetry, second site

`storageWorkConfigContext` digests the inputs a plan was resolved from. Its rig
line already digested `rig.EffectivePrefix()`; its HQ line digested the raw
`ResolvedWorkspacePrefix`. Once the pin stopped reading that field, two cities
whose HQ pins genuinely differ hashed to one digest, which is the case the
digest exists to tell apart. Both sites now digest and pin the same resolved
value.

Cities that do set `ResolvedWorkspacePrefix` are unaffected in both places:
`EffectiveHQPrefix` returns a non-empty resolved field verbatim, so the pin and
the digest are byte-identical to before for them.

## Tests

Three, each confirmed to fail when the change is reverted:

- the HQ pin carries the prefix the city derives, and a city named `ds-research`
  with a rig at prefix `gc` resolves its storage plan (this arm reproduces the
  operator-visible refusal above);
- a declared `[workspace] prefix` reaches the pin, which is the middle
  resolution step that previously could not reach it at all;
- two cities that derive different prefixes produce different config digests.

The third fails against a tree that has the pin fix but not the digest fix, so
it isolates the second site rather than riding on the first.

## Not included

`storageWorkPrefix` lower-cases and strips edge dashes, and nothing applies that
normalisation to the prefix the backend actually mints under, so a declared
`HQ` mints `HQ-` while the pin says `hq`. That gap predates this change and is
unchanged by it: the same normalisation was already applied to
`ResolvedWorkspacePrefix` on the old path. Filed as #5204 with three fix
candidates, since narrowing it means canonicalising prefixes once for both
minting and pinning.
