### PR TITLE
fix(sling): fall back to plain routing on implicit formula conflicts

### DIFF
--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -226,9 +226,27 @@ func checkNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, re
 				continue
 			}
 		}
-		return fmt.Errorf("bead %s already has attached %s %s", beadID, AttachmentLabel(attached), attached.ID)
+		return &MoleculeAttachedError{BeadID: beadID, Label: AttachmentLabel(attached), AttachmentID: attached.ID}
 	}
 	return nil
+}
+
+// MoleculeAttachedError reports that a bead already has a live, non-workflow
+// molecule/wisp attachment blocking a new formula attach. It is distinct from
+// sourceworkflow.ConflictError (a live graph.v2 workflow attachment) so
+// callers can use errors.As to tell the two conflict kinds apart: an implicit
+// default-formula sling may choose to fall back to plain routing on this
+// error, but must keep hard-failing on a workflow conflict or any other
+// error, since neither is the "unrelated molecule already attached" case the
+// fallback exists for.
+type MoleculeAttachedError struct {
+	BeadID       string
+	Label        string // AttachmentLabel(attached), e.g. "molecule" or "wisp"
+	AttachmentID string
+}
+
+func (e *MoleculeAttachedError) Error() string {
+	return fmt.Sprintf("bead %s already has attached %s %s", e.BeadID, e.Label, e.AttachmentID)
 }
 
 // CheckNoMoleculeChildren returns an error if the bead already has an attached

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -431,7 +431,7 @@ func rootOnlyVaporPourHint(formulaName string, recipe *formula.Recipe) string {
 
 // slingOnFormula handles the --on formula attachment path.
 func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", result)
+	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", false, result)
 	if err == nil {
 		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
 			result.BeadWarnings = append(result.BeadWarnings, hint)
@@ -469,7 +469,7 @@ func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, use
 
 // slingDefaultFormula handles the default formula attachment path.
 func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", result)
+	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", true, result)
 	if err == nil {
 		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
 			result.BeadWarnings = append(result.BeadWarnings, hint)
@@ -486,7 +486,17 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 // caller supplies the formula name, the sling method, and the error-label
 // prefix ("formula" vs "default formula"); graph-vs-legacy behavior is
 // byte-identical across both entry points.
-func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID, formulaName, method, errLabel string, result SlingResult) (SlingResult, error) {
+//
+// fallbackToPlainOnMoleculeConflict governs the legacy branch's reaction to a
+// *MoleculeAttachedError from CheckNoMoleculeChildren: an explicit --on
+// request (slingOnFormula) passes false and always hard-fails on a
+// pre-existing attachment, but an implicit default_sling_formula
+// (slingDefaultFormula) passes true, since the caller never actually asked
+// for a formula attach -- an unrelated live molecule/wisp should not block a
+// bare route, so that one specific error class falls back to plain bead
+// routing instead. Any other error (a live graph.v2 workflow conflict, or a
+// metadata-clear failure) keeps hard-failing regardless of this flag.
+func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID, formulaName, method, errLabel string, fallbackToPlainOnMoleculeConflict bool, result SlingResult) (SlingResult, error) {
 	a := opts.Target
 	formulaVars := BuildSlingFormulaVars(formulaName, beadID, opts.Vars, a, deps)
 	searchPaths := SlingFormulaSearchPaths(deps, a)
@@ -571,6 +581,17 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 	// live-workflow allowance could never fire. Attachments are always checked
 	// with CheckNoMoleculeChildren on this path.
 	if err := CheckNoMoleculeChildren(querier, beadID, deps.Store, &result); err != nil {
+		var molErr *MoleculeAttachedError
+		if fallbackToPlainOnMoleculeConflict && errors.As(err, &molErr) {
+			// The caller never asked for this formula attach -- it was only
+			// implied by the target's default_sling_formula config -- so an
+			// unrelated live molecule/wisp is not a reason to block the
+			// sling. Warn and route as a plain bead instead, so gc.routed_to
+			// still gets set. A workflow conflict or metadata-clear error is
+			// not this specific error class and keeps hard-failing above.
+			result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf("skipped attaching %s %q on %s: %v; routed as a plain bead instead", errLabel, formulaName, beadID, molErr))
+			return finalize(opts, deps, beadID, "bead", result)
+		}
 		return result, fmt.Errorf("%w", err)
 	}
 	run := func() (SlingResult, error) {

--- a/internal/sling/sling_core_test.go
+++ b/internal/sling/sling_core_test.go
@@ -88,3 +88,51 @@ func TestAttachFormulaToBeadEntryShapes(t *testing.T) {
 		}
 	})
 }
+
+// TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached pins the
+// REPAIR SCOPE for ga-ueugmi: a bare sling (no explicit --on/--formula) to a
+// target whose config carries a default_sling_formula must not hard-fail when
+// the bead already has a live attached molecule from an unrelated workflow --
+// the caller never asked for a formula attach, so the implicit default should
+// yield to plain routing (and warn) instead of blocking the sling and leaving
+// gc.routed_to unset. An explicit --on/--formula request must keep
+// hard-failing in this situation (TestOnFormulaExistingMoleculeErrors in
+// cmd/gc/cmd_sling_test.go) -- only the implicit default-formula path falls
+// back.
+func TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Type: "task", Status: "open", Assignee: "reviewer-session"},
+		{ID: "MOL-1", Type: "molecule", Status: "open", ParentID: "BL-1"},
+	}, nil)
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	runner := newFakeRunner()
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+
+	a := config.Agent{Name: "builder", MaxActiveSessions: intPtr(1), DefaultSlingFormula: stringPtr("code-review")}
+	opts := SlingOpts{Target: a, BeadOrFormula: "BL-1", NoConvoy: true}
+
+	result, err := DoSling(opts, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("DoSling default-formula with attached molecule: expected no error (fallback to plain route), got %v", err)
+	}
+	if result.Method != "bead" {
+		t.Errorf("Method = %q, want %q (fell back to plain bead routing)", result.Method, "bead")
+	}
+	if result.FormulaName != "" {
+		t.Errorf("FormulaName = %q, want empty (formula was not attached)", result.FormulaName)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (plain route must still execute, so gc.routed_to gets set)", len(runner.calls))
+	}
+
+	var warned bool
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "MOL-1") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("BeadWarnings = %v, want a warning naming the skipped attachment MOL-1", result.BeadWarnings)
+	}
+}

--- a/release-gates/ga-vqwsoj-sling-molecule-fallback-gate.md
+++ b/release-gates/ga-vqwsoj-sling-molecule-fallback-gate.md
@@ -1,0 +1,39 @@
+# Release gate: default-formula sling fallback
+
+- **Deploy bead:** `ga-vqwsoj`
+- **Build bead:** `ga-darmzs` (implementation source: `ga-ueugmi`)
+- **Review bead:** `ga-hc2j1e`
+- **Reviewed source:** `7f8984ca081d5813c2d011ec576ae7d470046544`
+- **Base checked:** `origin/main` at `a4e4cc2bfac251b65116d536addbb4a7be9d95cd`
+- **Isolated gate branch:** `deploy/ga-vqwsoj-gate`
+- **Verdict:** **PASS**
+
+`docs/PROJECT_MANIFEST.md` is absent from both the reviewed source and current
+`origin/main`, so there are no additional repository-local release criteria to
+apply beyond the seven deployer criteria below.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-hc2j1e` records `verdict: pass` for the authoritative deploy source `7f8984ca081d5813c2d011ec576ae7d470046544`. It also records fresh style, security, specification, build, vet, and focused-test evidence. |
+| 2 | Acceptance criteria met | PASS | Direct inspection confirms that a live non-workflow formula attachment now returns the typed `MoleculeAttachedError`; only the implicit `default_sling_formula` path handles that type by warning and calling the normal plain-bead `finalize` path. The explicit `--on` path passes the fallback flag as false, and workflow conflicts or unrelated errors still hard-fail. The fallback therefore still performs the route write that records `gc.routed_to`. `TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached` passed and verifies a single plain-route call plus a warning naming the blocking attachment. The separately reviewed `--notify` pack-config repair is commit `36df5542ed61f58ad62b9b53fa4f3047e40db094` in the local-only `gc-management` repository and is intentionally outside this PR. |
+| 3 | Tests pass | PASS | With the rootless Podman socket configured and the repository-pinned Dolt `2.1.7` image present, the documented fast CI-equivalent command `GO_TEST_TIMEOUT=30m make test-fast-parallel` passed all 10 runner jobs, 0 FAIL, 0 SKIP. `go test -json -count=1 ./internal/sling` produced 239 PASS, 0 FAIL, 0 SKIP. `diff_tests_executed`: `TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached` PASS. `waiver_ref`: none. `go vet ./...` and `go build ./...` also passed. |
+| 4 | No high-severity review findings open | PASS | The review records `style_findings: none`, `security_findings: none`, and no unresolved HIGH finding. Independent gate inspection found no new high-severity issue. |
+| 5 | Final branch is clean | PASS | The detached worktree at the reviewed source was clean before this checklist was added. This checklist is the only gate-owned file and is committed on the isolated deploy branch; a post-commit cleanliness check is required before push. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first after the already-merged pre-flight. No pull request carries the reviewed SHA in the base repository. `git merge-base origin/main 7f8984ca081d5813c2d011ec576ae7d470046544` returned `a4e4cc2bfac251b65116d536addbb4a7be9d95cd`; `git merge-tree --write-tree origin/main 7f8984ca081d5813c2d011ec576ae7d470046544` returned 0 and produced tree `5d2798160d4bcfacbad566e071d3963cd58c354b`. No bounded self-rebase was needed. |
+| 7 | Single feature theme | PASS | Both reviewed commits and all three changed files belong to `internal/sling` and implement one behavior: preserve bare dispatch when an implicit default formula cannot attach to a bead that already has a live formula attachment, without weakening explicit formula-request conflicts. |
+
+## Additional static evidence
+
+- `gofmt -l` over all three changed Go files — PASS, no output.
+- `git diff --check origin/main...7f8984ca081d5813c2d011ec576ae7d470046544` — PASS.
+- `go vet ./...` — PASS.
+- `go build ./...` — PASS.
+
+## Reviewed history
+
+```text
+dc9e652369 test(sling): red — default-formula sling must not hard-fail on attached molecule (refs ga-ueugmi)
+7f8984ca08 feat: green — mol-code-review handback: gc sling to builder hard-fails on molecule-attached review bead (refs ga-ueugmi)
+```


### PR DESCRIPTION
## What this changes

When `gc sling` inherits a target's `default_sling_formula` and the bead already has a live formula attachment, the command now emits a warning and performs the normal plain-bead dispatch. The route still records `gc.routed_to`, so an unrelated attachment no longer strands the handoff.

Explicit `--on` requests remain strict. Formula v2 workflow conflicts and unrelated attachment errors also continue to fail instead of silently weakening the requested operation.

## Review notes

- The new typed attachment error limits the fallback to the specific non-workflow conflict that can safely degrade.
- The fallback is enabled only for the implicit default-formula entry point; explicit formula selection is unchanged.
- There are no configuration, migration, API, or wire-format changes.

## Test plan

- [x] `go test -json -count=1 ./internal/sling` — 239 PASS, 0 FAIL, 0 SKIP; the new regression test executed and passed
- [x] `GO_TEST_TIMEOUT=30m make test-fast-parallel` — all 10 sharded jobs passed
- [x] `go vet ./...` and `go build ./...`
- [x] Release gate: [`release-gates/ga-vqwsoj-sling-molecule-fallback-gate.md`](release-gates/ga-vqwsoj-sling-molecule-fallback-gate.md)
