### PR TITLE
fix(cmd/gc): route session-, graph- and convergence-class reads to their owning store

### DIFF
--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -327,6 +327,35 @@ func resolveGraphStore(routes *storageRoutes, workStore beads.Store, cfg *config
 	return resolveClassStore(routes, workStore, cfg, cityPath, config.BeadClassGraph, rec)
 }
 
+// scopeIsCity reports whether a scope store the caller opened at storePath is
+// the city's own store rather than a rig's.
+//
+// This is the predicate behind every graph-class routing decision, and it is
+// deliberately one function. Graph bindings are city-keyed: resolveClassStore
+// holds a single city-level store per class, so there is no per-rig binding to
+// route to, and `gc storage migrate` copies only the city work store. Any
+// coordination surface that answers "does this scope take the graph class?"
+// must answer it the same way, or two sibling surfaces end up reading different
+// databases for beads of one class.
+func scopeIsCity(cityPath, storePath string) bool {
+	return samePath(resolveStoreScopeRoot(cityPath, storePath), cityPath)
+}
+
+// scopeGraphStore routes a scope store to the city's graph-class binding when
+// the scope IS the city, and returns the store it was handed otherwise.
+//
+// Control beads and convergence roots are both ClassGraph and both live under a
+// city-keyed binding, so they share this one rule rather than each spelling it
+// out. When the routes relocate nothing — every city with no [storage] section,
+// and every rig scope — this returns the exact store value it was given, so
+// optional-capability type assertions the callers make against it keep working.
+func scopeGraphStore(cityPath, storePath string, cfg *config.City, scopeStore beads.Store) beads.Store {
+	if !scopeIsCity(cityPath, storePath) {
+		return scopeStore
+	}
+	return resolveGraphStore(cliStorageRoutes(cityPath), scopeStore, cfg, cityPath, nil)
+}
+
 // moleculeClassStore returns the store a compiled recipe's molecule must be
 // materialized in: graphStore when the beads instantiating it produces are
 // graph class, and the caller's own scope/work store otherwise.

--- a/cmd/gc/cli_class_stores.go
+++ b/cmd/gc/cli_class_stores.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+// cliSessionsRelocated reports whether the city at cityPath binds the sessions
+// coordination class to a store of its own. Commands that sweep city + rig
+// scopes need this: class routing is city-keyed, so under a relocation every
+// scope's cliSessionStore resolves to the SAME sessions store and a per-scope
+// session pass repeats itself once per rig.
+func cliSessionsRelocated(cityPath string) bool {
+	_, relocated := cliStorageRoutes(cityPath).storeFor(coordclass.ClassSessions)
+	return relocated
+}
+
+// cliNudgesStore routes a generic CLI one-shot work store to the nudges
+// coordination-class store, so a [beads.classes.nudges] relocation reaches
+// one-shot commands the same way it reaches the running controller (which routes
+// through CityRuntime.nudgesBeadStore). It is the nudges twin of cliSessionStore,
+// and exists because the controller and the CLI had drifted: the nudge-mail
+// sweep watchdog at city_runtime.go routed while `gc order sweep-nudge-mail` did
+// not, so the same sweep read different stores depending on who ran it.
+//
+// Identity to the input store at the default single-store backend, so wrapping
+// is byte-identical until a nudges relocation is configured.
+func cliNudgesStore(store beads.Store, cfg *config.City, cityPath string) beads.NudgesStore {
+	return beads.NudgesStore{Store: resolveNudgesStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)}
+}
+
+// cliMailStore routes a generic CLI one-shot work store to the messaging
+// coordination-class store. It is the messaging twin of cliSessionStore; see
+// cliNudgesStore for why the CLI needs its own seam.
+//
+// Messaging and sessions are distinct classes even though today's only servable
+// split shape (storageSplitWhole) puts them in the same binding: a mail bead is
+// ClassMessaging, the mailbox identity it resolves against is ClassSessions, and
+// the two route independently.
+func cliMailStore(store beads.Store, cfg *config.City, cityPath string) beads.MailStore {
+	return beads.MailStore{Store: resolveMailMessagesStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)}
+}

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -331,11 +331,16 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
 					return errExit
 				}
+				// --all-rigs builds its own city leg instead of going through
+				// openConvergeStore, so it needs the same graph-class routing;
+				// otherwise `gc converge list --all-rigs` is the one surface that
+				// still reads the city's retained work-store copies.
 				store, err := openStoreAtForCity(rctx.CityPath, rctx.CityPath)
 				if err != nil {
 					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
 					return errExit
 				}
+				store = convergeCityScopeStore(store, rctx.CityPath, "")
 				if err := appendEntries("", store); err != nil {
 					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
 					return errExit
@@ -356,6 +361,10 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 				}
 				sort.Strings(rigs)
 				for _, rig := range rigs {
+					// Rig scopes stay on their rig work store, matching
+					// buildConvergenceScopes and controlScopeTakesGraphClass:
+					// class routing is city-keyed, so routing rig scopes to the
+					// one graph binding would merge every rig's loops into it.
 					store, err := openStoreAtForCity(rigPathByName[rig], rctx.CityPath)
 					if err != nil {
 						fmt.Fprintf(stderr, "gc converge list: rig %q: %v\n", rig, err) //nolint:errcheck
@@ -810,6 +819,14 @@ type convergeTestGateJSONResult struct {
 // context it opens the city/HQ store; with a rig context it opens that
 // rig's store so rig-scoped convergence loops are visible. It also returns
 // the resolved context for callers that need the city path.
+//
+// The returned store is CLASS-ROUTED for the city scope: convergence beads are
+// graph class, and the controller's city scope reads and writes them in the
+// graph binding (buildConvergenceScopes). A CLI that opened the work store
+// instead would answer "no convergence loops" on a relocated city — a confident
+// empty, at exit 0, about a loop that is running. storePath is returned
+// unrouted on purpose; it is the scope root, and every caller that passes it
+// to a gate command wants the directory, not the database.
 func openConvergeStore(stderr io.Writer, cmdName string) (beads.Store, resolvedContext, string, int) {
 	rctx, err := resolveContext()
 	if err != nil {
@@ -828,7 +845,19 @@ func openConvergeStore(stderr io.Writer, cmdName string) (beads.Store, resolvedC
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck
 		return nil, resolvedContext{}, "", 1
 	}
-	return store, rctx, storePath, 0
+	return convergeCityScopeStore(store, rctx.CityPath, rctx.RigName), rctx, storePath, 0
+}
+
+// convergeCityScopeStore routes a converge scope's store to the graph class when
+// — and only when — the scope is the CITY. It mirrors the controller's split in
+// buildConvergenceScopes, and it is the same city-only rule
+// controlScopeTakesGraphClass applies to control beads: there is one graph
+// binding per city, so a rig scope keeps its own work ledger.
+func convergeCityScopeStore(store beads.Store, cityPath, rigName string) beads.Store {
+	if rigName != "" {
+		return store
+	}
+	return resolveGraphStore(cliStorageRoutes(cityPath), store, nil, cityPath, nil)
 }
 
 func convergeStorePathForContext(rctx resolvedContext) (string, error) {

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -340,7 +340,7 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
 					return errExit
 				}
-				store = convergeCityScopeStore(store, rctx.CityPath, "")
+				store = scopeGraphStore(rctx.CityPath, rctx.CityPath, nil, store)
 				if err := appendEntries("", store); err != nil {
 					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
 					return errExit
@@ -845,19 +845,28 @@ func openConvergeStore(stderr io.Writer, cmdName string) (beads.Store, resolvedC
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck
 		return nil, resolvedContext{}, "", 1
 	}
-	return convergeCityScopeStore(store, rctx.CityPath, rctx.RigName), rctx, storePath, 0
+	return convergeScopeStore(rctx.CityPath, rctx.RigName, storePath, store), rctx, storePath, 0
 }
 
-// convergeCityScopeStore routes a converge scope's store to the graph class when
-// — and only when — the scope is the CITY. It mirrors the controller's split in
-// buildConvergenceScopes, and it is the same city-only rule
-// controlScopeTakesGraphClass applies to control beads: there is one graph
-// binding per city, so a rig scope keeps its own work ledger.
-func convergeCityScopeStore(store beads.Store, cityPath, rigName string) beads.Store {
+// convergeScopeStore returns the store a converge scope reads and writes.
+//
+// Convergence roots are ClassGraph, so a city scope goes through the city's
+// graph binding while a rig scope keeps its own work ledger. The routing itself
+// is scopeGraphStore's, shared with control dispatch, so the two coordination
+// surfaces cannot drift apart.
+//
+// The rig short-circuit is not redundant with scopeGraphStore's own city test.
+// That test is by PATH, and nothing forbids registering a rig at the city root,
+// where its path IS the city path. The controller's convergence scope map keys
+// on rig NAME (buildConvergenceScopes), so such a rig's roots are written to its
+// own store; routing this leg by path would send the CLI to a binding the
+// controller never writes for that rig — the read/write asymmetry this whole
+// change exists to remove.
+func convergeScopeStore(cityPath, rigName, storePath string, store beads.Store) beads.Store {
 	if rigName != "" {
 		return store
 	}
-	return resolveGraphStore(cliStorageRoutes(cityPath), store, nil, cityPath, nil)
+	return scopeGraphStore(cityPath, storePath, nil, store)
 }
 
 func convergeStorePathForContext(rctx resolvedContext) (string, error) {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -640,7 +640,7 @@ func sourceWorkflowLockScopeForStoreRef(cityPath string, cfg *config.City, defau
 // the dispatcher would exit non-zero and crash-loop. A rig scope therefore stays
 // entirely on its own store, exactly as it does today.
 func controlScopeTakesGraphClass(cityPath, storePath string) bool {
-	return samePath(resolveStoreScopeRoot(cityPath, storePath), cityPath)
+	return scopeIsCity(cityPath, storePath)
 }
 
 // controlGraphBinding returns the store this scope's control beads live in when
@@ -690,10 +690,7 @@ func controlStoreDescription(cityPath, storePath string) string {
 // runner, same scope issue prefix, same instance for the optional-capability
 // assertions (DepListBatch, UpdateAll) the scope-skip paths make against it.
 func controlGraphStore(cityPath, storePath string, cfg *config.City, scopeStore beads.Store) beads.Store {
-	if !controlScopeTakesGraphClass(cityPath, storePath) {
-		return scopeStore
-	}
-	return resolveGraphStore(cliStorageRoutes(cityPath), scopeStore, cfg, cityPath, nil)
+	return scopeGraphStore(cityPath, storePath, cfg, scopeStore)
 }
 
 // openControlStoreAtForCity resolves the control store for a city or rig SCOPE.

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -898,7 +898,76 @@ func findBeadScopeAcrossStores(cityPath, beadID string, warningWriter io.Writer)
 		}
 		return store, rig.Path, nil
 	}
+
+	// The city and rig SCOPE stores are the copies a migration retained and the
+	// rig's own ledger; neither is the city graph binding a split city relocates
+	// its control beads into. A city-scoped molecule materializes graph-class
+	// control beads there and routes them to a rig by name, so the manual entry
+	// point must consult that binding before declaring an id unreachable — the
+	// same leg the serve loop federates.
+	if store, storePath, err := graphBindingResidentScope(cityPath, cfg, beadID); err == nil {
+		return store, storePath, nil
+	} else if !errors.Is(err, beads.ErrNotFound) {
+		return nil, "", fmt.Errorf("getting bead %q from the city graph binding: %w", beadID, err)
+	}
 	return nil, "", fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+}
+
+// graphBindingResidentScope resolves the SCOPE that owns a control bead which
+// lives only in the city graph binding, for the manual `gc convoy control <id>`
+// entry point. It returns beads.ErrNotFound when the city relocates no graph
+// class or the bead is absent from the binding, so findBeadScopeAcrossStores
+// falls through to its own not-found exactly as it did before on unsplit cities.
+//
+// The store returned is the WORK leg, not the graph leg. controlBeadLedger keeps
+// the scope store first and consults the binding as an ADDITIONAL leg, so the
+// work class — the input convoy an execution snapshot reads — must resolve where
+// it actually lives. A binding-resident bead routed to a rig therefore resolves
+// to that RIG's scope, mirroring the serve loop whose rig-scoped scan is what
+// surfaces the bead; a bead with no rig route resolves to the city scope, whose
+// own graph hop reads the binding directly. Deriving residence from the bead
+// rather than defaulting to the city is what keeps a rig-routed bead from losing
+// its input-convoy store.
+//
+// A REFUSING binding is skipped, not surfaced: a standing refusal is a fact about
+// the city's storage configuration and none about a particular bead, the graph
+// plane is already down by the boot gate's own verdict, and the bead is equally
+// unreachable to every scope — so this returns not-found and lets the caller
+// report it, exactly as controlGraphExtraLeg skips the same leg on the serve side.
+func graphBindingResidentScope(cityPath string, cfg *config.City, beadID string) (beads.Store, string, error) {
+	binding, relocated := controlGraphBinding(cityPath, cityPath)
+	if !relocated || binding == nil {
+		return nil, "", beads.ErrNotFound
+	}
+	if _, refused := binding.(refusedClassStore); refused {
+		warnControlGraphLegRefused(cityPath)
+		return nil, "", beads.ErrNotFound
+	}
+	bead, err := binding.Get(beadID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Residence: a bead routed to a rig belongs to that rig's scope, whose work
+	// store owns the input convoy. Anything else belongs to the city scope, whose
+	// own graph hop resolves the binding directly.
+	if cfg != nil {
+		if rigContext := workflowExecutionRigContext(bead); rigContext != "" {
+			if rig, ok := rigByName(cfg, rigContext); ok {
+				store, err := openControlStoreAtForCity(rig.Path, cityPath, cfg)
+				if err != nil {
+					return nil, "", fmt.Errorf("opening rig store %q for binding-resident control bead %q: %w", rig.Name, beadID, err)
+				}
+				return store, rig.Path, nil
+			}
+		}
+	}
+
+	cityStore, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening city store for binding-resident control bead %q: %w", beadID, err)
+	}
+	return cityStore, cityPath, nil
 }
 
 func findUniqueBeadAcrossStoresView(cityPath, beadID string) (convoyStoreView, beads.Bead, error) {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"maps"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unicode/utf8"
@@ -201,11 +203,9 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 	// a work bead, the synthetic drain-unit ones included, so it owns both the
 	// input convoy whose tracks edges the execution snapshot below reads and the
 	// unit convoys a drain mints alongside its members.
-	graphStore := controlGraphStore(cityPath, storePath, cfg, store)
-
-	bead, err := graphStore.Get(beadID)
+	graphStore, bead, err := controlBeadLedger(cityPath, storePath, cfg, store, beadID)
 	if err != nil {
-		return fmt.Errorf("loading control bead %s from the %s for scope %q: %w", beadID, controlStoreDescription(cityPath, storePath), storePath, err)
+		return err
 	}
 
 	opts := dispatch.ProcessOptions{CityPath: cityPath, StorePath: storePath}
@@ -261,7 +261,7 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 			// class actually relocated: on every other city graphStore IS
 			// store, and an empty tail keeps each of those reads on the single
 			// direct call it makes today.
-			if controlGraphRelocated(cityPath, storePath) {
+			if graphStore != store {
 				opts.MemberStores = []beads.Store{store}
 			}
 		case "retry-eval":
@@ -629,16 +629,24 @@ func sourceWorkflowLockScopeForStoreRef(cityPath string, cfg *config.City, defau
 // resolves its control beads through the graph class instead of staying on the
 // store the scope opened.
 //
-// Only the CITY scope does. The scope guard is load-bearing: resolveClassStore
-// holds a single city-level store per class, so there is no per-scope graph
-// binding to route a RIG to, and `gc storage migrate` copies only the city work
-// store (openInfraMigrationSource), so a rig's control beads were never carried
-// into the binding in the first place. Redirecting a rig scope at the city
-// binding would point both the readiness scan and the dispatch at a database
-// that has never held that rig's beads — every rig-scoped control bead would
-// read as "bead not found", which IsTransientControllerError does not match, so
-// the dispatcher would exit non-zero and crash-loop. A rig scope therefore stays
-// entirely on its own store, exactly as it does today.
+// Only the CITY scope does, and "instead of" is the whole content of the word
+// only. resolveClassStore holds a single city-level store per class, so there is
+// no per-rig graph binding, and `gc storage migrate` copies only the city work
+// store (openInfraMigrationSource) — a rig scope has no retained copy to be
+// misled by and no binding of its own to move to, so it keeps the store it
+// opened. That store is also the only place its WORK leg exists, which is the
+// load-bearing half: the dispatch reads a control bead's input convoy from it.
+//
+// It does NOT follow that the city binding never holds beads routed to a rig.
+// It does. A city-scoped molecule materializes graph-class control beads into
+// the city binding and then stamps gc.routed_to=<rig>/<agent>, so the binding
+// accumulates a rig dispatcher's queue while the rig's own ledger stays empty of
+// it — 148 such beads stranded on the live city before this was found, against 0
+// ever processed. Reading that as "a rig's beads are never in the binding" is
+// what let a dispatcher scan a structurally empty ledger for a month and report
+// idle rather than fail. A rig scope reaches those beads through
+// controlGraphExtraLeg, which is an ADDITIONAL leg precisely because this
+// predicate is false for it.
 func controlScopeTakesGraphClass(cityPath, storePath string) bool {
 	return scopeIsCity(cityPath, storePath)
 }
@@ -662,6 +670,128 @@ func controlGraphBinding(cityPath, storePath string) (beads.Store, bool) {
 func controlGraphRelocated(cityPath, storePath string) bool {
 	_, relocated := controlGraphBinding(cityPath, storePath)
 	return relocated
+}
+
+// controlGraphExtraLeg returns the city's graph binding when a scope must read
+// it IN ADDITION to the store it opened, and whether that is the case at all.
+//
+// This is the complement of controlGraphBinding, not a second copy of it, and
+// the two together are the whole routing rule:
+//
+//   - A CITY scope reads the binding INSTEAD of its own store. `gc storage
+//     migrate` copies the class out and RETAINS the source, so the work ledger's
+//     rows are frozen at cutover; unioning them back in would re-offer ids the
+//     binding has already finished and the drain loop would never return.
+//   - A RIG scope reads the binding AS WELL AS its own store. A rig is never a
+//     migration target, so it has no retained copies to be misled by — but the
+//     binding is CITY-keyed, and a city-scoped molecule materializes its control
+//     beads there and then routes them to a rig's dispatcher by name. Those beads
+//     are unreachable from the rig directory's own `bd`, which is how a
+//     dispatcher ends up scanning forever against a ledger that structurally
+//     cannot hold its queue.
+//
+// The two ledgers hold disjoint ids today precisely because a rig is never a
+// migration target, so there is no live copy for the second leg to shadow.
+// Callers still take the scope store first; see controlReadyFallbackReady for
+// the scan side and controlBeadLedger for the dispatch side.
+//
+// A REFUSING binding is not a leg. On a city the one-shot funnel refused, every
+// infrastructure class resolves to refusedClassStore, whose every read returns
+// the standing refusal — so federating it would turn a city-level storage
+// misconfiguration into a hard scan error on EVERY rig dispatcher, and a scan
+// error is fatal to the drain loop, so all rig control dispatch would crash-loop
+// on a city that is otherwise still serving work. classRoutedStoreForID states
+// the governing rule for exactly this error: a standing refusal "is a fact about
+// the city and none about a particular bead — and a refused city still serves
+// WORK from its work ledger." A rig's own control beads are that case, so the
+// refusal establishes nothing about them and its own store still answers. The
+// beads the skipped leg would have carried belong to a graph plane that is down
+// by this build's own verdict, already reported by the boot gate, and equally
+// unreachable to the CITY dispatcher.
+//
+// The identity gate the sibling surfaces apply (relocatedGraphLegFrom, and
+// classRoutedStoreForID's `class == work`) is deliberately not restated here:
+// this arm runs only for a RIG scope, whose store is that rig's own bd/Dolt
+// handle and never the city's binding, and the scan-side caller holds no store
+// handle to compare against at all — it shells `bd` for its scope leg.
+func controlGraphExtraLeg(cityPath, storePath string) (beads.Store, bool) {
+	if controlScopeTakesGraphClass(cityPath, storePath) {
+		return nil, false
+	}
+	binding, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	if !relocated || binding == nil {
+		return nil, false
+	}
+	if _, refused := binding.(refusedClassStore); refused {
+		warnControlGraphLegRefused(cityPath)
+		return nil, false
+	}
+	return binding, true
+}
+
+// controlGraphLegRefusedOnce keeps the refusal notice to one line per process.
+// The dispatcher re-asks this question every tick, and a standing refusal does
+// not change until the city's storage config does.
+var controlGraphLegRefusedOnce sync.Once
+
+// warnControlGraphLegRefused reports the one thing the skip is not allowed to
+// hide: control beads the city binding holds for this rig are unreachable until
+// the storage refusal is resolved, so a queue that looks empty may not be.
+func warnControlGraphLegRefused(cityPath string) {
+	controlGraphLegRefusedOnce.Do(func() {
+		log.Printf("control-ready: city %s refuses its storage configuration, so rig control dispatch reads only its own store; any control beads in the city graph binding stay unreachable until `gc storage` is resolved", cityPath)
+	})
+}
+
+// controlBeadLedger returns the ledger that actually holds beadID, together with
+// the bead, so ProcessControl's idempotence gate and every mutation the dispatch
+// makes act on ONE copy.
+//
+// This resolves the GRAPH leg only. The caller keeps its scope store as the WORK
+// leg, and that asymmetry is the point rather than an oversight: the binding is
+// city-keyed for the graph CLASS, and the work class is not relocated at all, so
+// a rig scope here lands on (rig work store, city graph binding) — structurally
+// the same shape as the city arm's (city work store, city graph binding), not a
+// new one. Measured on the live city: the stranded control beads and their
+// workflow root are `gcg-` and binding-resident, while the input convoy those
+// same beads name in gc.input_convoy_id is `ga-xz2hu`, absent from the binding
+// and present in the rig store. Re-entering the whole dispatch at the city scope
+// would fix the graph leg and break the work leg, which is what EmitCurrent reads
+// the convoy's tracks edges from.
+//
+// Residence rather than scope alone is what lets the readiness scan federate
+// safely: a federated scan hands the drain loop ids the scope store does not
+// hold, and resolving those against the scope store returns "bead not found",
+// which IsTransientControllerError does not match — drainWorkflowServeWork
+// returns it as fatal and the dispatcher session exits and crash-loops.
+//
+// The scope store's own class hop stays FIRST, so every id it holds resolves
+// exactly where it resolves today and the extra leg is consulted only for ids
+// that would otherwise be a hard not-found.
+func controlBeadLedger(cityPath, storePath string, cfg *config.City, scopeStore beads.Store, beadID string) (beads.Store, beads.Bead, error) {
+	primary := controlGraphStore(cityPath, storePath, cfg, scopeStore)
+	bead, err := primary.Get(beadID)
+	if err == nil {
+		return primary, bead, nil
+	}
+	extra, federated := controlGraphExtraLeg(cityPath, storePath)
+	if !federated || !errors.Is(err, beads.ErrNotFound) {
+		return nil, beads.Bead{}, fmt.Errorf("loading control bead %s from the %s for scope %q: %w",
+			beadID, controlStoreDescription(cityPath, storePath), storePath, err)
+	}
+	graphBead, graphErr := extra.Get(beadID)
+	if graphErr != nil {
+		// BOTH legs are joined rather than one wrapped and one rendered, because
+		// the binding's error is the one that decides whether this dispatch is
+		// fatal. A binding that is briefly unreachable must reach
+		// IsTransientControllerError as a typed error and be retried; rendering
+		// it with %v leaves that classification to substring matching on the
+		// message, which is luck rather than a contract, and losing the coin
+		// flip exits the dispatcher session.
+		return nil, beads.Bead{}, fmt.Errorf("loading control bead %s for scope %q: not in the %s, and not in the city graph binding: %w",
+			beadID, storePath, controlStoreDescription(cityPath, storePath), errors.Join(err, graphErr))
+	}
+	return extra, graphBead, nil
 }
 
 // controlStoreDescription names the ledger a control-bead read actually went to,

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -940,14 +940,22 @@ func sessionMailboxAddresses(b beads.Bead) []string {
 	return session.MailboxAddresses(b)
 }
 
-func resolveMailIdentityCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
+// The mail identity/target resolver family below reads only session-class beads:
+// session-ID resolution, the gc:session enumeration behind named-target matching,
+// and mailbox-identity metadata. Its store parameter is therefore named sessStore
+// and every caller must hand it a session-class store (cliSessionStore at a CLI
+// root, cr.sessionsBeadStore().Store in the controller) — the resolvers do no
+// routing of their own, so a [beads.classes.sessions] relocation reaches mail
+// identity resolution exactly once, at the root that opened the store. Mail
+// *messages* are a different class and travel through mail.Provider, not here.
+func resolveMailIdentityCached(sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
 	if sender, ok := reservedMailSenderIdentity(identifier); ok {
 		return sender, nil
 	}
-	sessionID, err := resolveSessionID(store, identifier)
+	sessionID, err := resolveSessionID(sessStore, identifier)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
-			if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
+			if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(sessStore, identifier, cache); targetErr != nil {
 				return "", targetErr
 			} else if matched {
 				return target.display, nil
@@ -958,7 +966,7 @@ func resolveMailIdentityCached(store beads.Store, identifier string, cache *mail
 		}
 		return "", err
 	}
-	address, err := session.NewStore(beads.SessionStore{Store: store}).MailboxAddress(sessionID)
+	address, err := session.NewStore(beads.SessionStore{Store: sessStore}).MailboxAddress(sessionID)
 	if err != nil {
 		return "", err
 	}
@@ -968,18 +976,18 @@ func resolveMailIdentityCached(store beads.Store, identifier string, cache *mail
 	return address, nil
 }
 
-func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
-	return resolveMailIdentityWithConfigCached(cityPath, cfg, store, identifier, nil)
+func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, sessStore beads.Store, identifier string) (string, error) {
+	return resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, identifier, nil)
 }
 
-func resolveMailIdentityWithConfigCached(cityPath string, cfg *config.City, store beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
+func resolveMailIdentityWithConfigCached(cityPath string, cfg *config.City, sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
 	if sender, ok := reservedMailSenderIdentity(identifier); ok {
 		return sender, nil
 	}
-	if store != nil && cfg != nil {
-		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, identifier)
+	if sessStore != nil && cfg != nil {
+		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, sessStore, identifier)
 		if err == nil {
-			address, err := session.NewStore(beads.SessionStore{Store: store}).MailboxAddress(sessionID)
+			address, err := session.NewStore(beads.SessionStore{Store: sessStore}).MailboxAddress(sessionID)
 			if err != nil {
 				return "", err
 			}
@@ -992,7 +1000,7 @@ func resolveMailIdentityWithConfigCached(cityPath string, cfg *config.City, stor
 			return "", err
 		}
 	}
-	if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
+	if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(sessStore, identifier, cache); targetErr != nil {
 		return "", targetErr
 	} else if matched {
 		return target.display, nil
@@ -1000,19 +1008,19 @@ func resolveMailIdentityWithConfigCached(cityPath string, cfg *config.City, stor
 	if address, ok := configuredMailboxAddressWithConfig(cityPath, cfg, identifier); ok {
 		return address, nil
 	}
-	return resolveMailIdentityCached(store, identifier, cache)
+	return resolveMailIdentityCached(sessStore, identifier, cache)
 }
 
-func resolveMailRecipientIdentity(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
-	return resolveMailRecipientIdentityCached(cityPath, cfg, store, identifier, nil)
+func resolveMailRecipientIdentity(cityPath string, cfg *config.City, sessStore beads.Store, identifier string) (string, error) {
+	return resolveMailRecipientIdentityCached(cityPath, cfg, sessStore, identifier, nil)
 }
 
-func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, store beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
+func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
 		return "human", nil
 	}
-	if store != nil {
-		sessionID, err := session.ResolveSessionIDByExactID(store, identifier)
+	if sessStore != nil {
+		sessionID, err := session.ResolveSessionIDByExactID(sessStore, identifier)
 		if err == nil {
 			return sessionID, nil
 		}
@@ -1020,7 +1028,7 @@ func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, store
 			return "", err
 		}
 	}
-	if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
+	if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(sessStore, identifier, cache); targetErr != nil {
 		return "", targetErr
 	} else if matched {
 		return target.display, nil
@@ -1028,7 +1036,7 @@ func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, store
 	if normalizeNamedSessionTarget(identifier) == controllerMailIdentity {
 		return "", session.ErrSessionNotFound
 	}
-	return resolveMailIdentityWithConfigCached(cityPath, cfg, store, identifier, cache)
+	return resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, identifier, cache)
 }
 
 func configuredMailboxAddress(identifier string) (string, bool) {
@@ -1060,12 +1068,12 @@ func configuredMailboxAddressWithConfig(cityPath string, cfg *config.City, ident
 	return spec.Identity, true
 }
 
-func listLiveSessionMailboxesCached(store beads.Store, cache *mailIdentitySessionCache) (map[string]bool, error) {
+func listLiveSessionMailboxesCached(sessStore beads.Store, cache *mailIdentitySessionCache) (map[string]bool, error) {
 	recipients := map[string]bool{"human": true}
-	if store == nil {
+	if sessStore == nil {
 		return recipients, nil
 	}
-	all, err := listMailIdentitySessions(store, cache)
+	all, err := listMailIdentitySessions(sessStore, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,16 +1120,16 @@ func ambientMailTargetConfig() (string, *config.City) {
 // resolution. It preserves the pre-typed cache semantics exactly: the default
 // direct union with IncludeClosed implicit-false (loadOpenSessionInfos), with the
 // per-loop closed filter kept in the callers.
-func listMailIdentitySessions(store beads.Store, cache *mailIdentitySessionCache) ([]session.Info, error) {
+func listMailIdentitySessions(sessStore beads.Store, cache *mailIdentitySessionCache) ([]session.Info, error) {
 	if cache == nil {
-		return loadOpenSessionInfos(store)
+		return loadOpenSessionInfos(sessStore)
 	}
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 	if cache.fetched {
 		return cache.list, nil
 	}
-	list, err := loadOpenSessionInfos(store)
+	list, err := loadOpenSessionInfos(sessStore)
 	if err != nil {
 		return nil, err
 	}
@@ -1130,12 +1138,12 @@ func listMailIdentitySessions(store beads.Store, cache *mailIdentitySessionCache
 	return list, nil
 }
 
-func resolveLiveConfiguredNamedMailTargetCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, bool, error) {
+func resolveLiveConfiguredNamedMailTargetCached(sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, bool, error) {
 	identifier = normalizeNamedSessionTarget(identifier)
-	if store == nil || identifier == "" || identifier == "human" || strings.Contains(identifier, "/") {
+	if sessStore == nil || identifier == "" || identifier == "human" || strings.Contains(identifier, "/") {
 		return resolvedMailTarget{}, false, nil
 	}
-	all, err := listMailIdentitySessions(store, cache)
+	all, err := listMailIdentitySessions(sessStore, cache)
 	if err != nil {
 		return resolvedMailTarget{}, false, err
 	}
@@ -1180,26 +1188,19 @@ func resolveLiveConfiguredNamedMailTargetCached(store beads.Store, identifier st
 	}
 }
 
-func resolveMailTargets(store beads.Store, identifier string) (resolvedMailTarget, error) {
-	return resolveMailTargetsCached(store, identifier, nil)
+func resolveMailTargets(sessStore beads.Store, identifier string) (resolvedMailTarget, error) {
+	return resolveMailTargetsCached(sessStore, identifier, nil)
 }
 
-func resolveMailTargetsWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (resolvedMailTarget, error) {
-	return resolveMailTargetsWithConfigCached(cityPath, cfg, store, identifier, nil)
+func resolveMailTargetsWithConfig(cityPath string, cfg *config.City, sessStore beads.Store, identifier string) (resolvedMailTarget, error) {
+	return resolveMailTargetsWithConfigCached(cityPath, cfg, sessStore, identifier, nil)
 }
 
-func resolveMailTargetsWithConfigCached(cityPath string, cfg *config.City, store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
+func resolveMailTargetsWithConfigCached(cityPath string, cfg *config.City, sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
 		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, nil
 	}
-	if store != nil && cfg != nil {
-		// Route the session-ID resolve and the mailbox-identity bead read through
-		// the session coordination-class store so a [beads.classes.sessions]
-		// relocation reaches mail target resolution. Identity at the default
-		// backend. (Mirrors cmd_nudge's sessStore routing; the sibling resolvers
-		// resolveMailTargetsCached / resolveMailIdentityWithConfigCached carry the
-		// same pre-existing gap and are swept on the mail DI pass.)
-		sessStore := cliSessionStore(store, cfg, cityPath)
+	if sessStore != nil && cfg != nil {
 		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, sessStore, identifier)
 		if err == nil {
 			b, err := sessStore.Get(sessionID)
@@ -1219,17 +1220,17 @@ func resolveMailTargetsWithConfigCached(cityPath string, cfg *config.City, store
 			return resolvedMailTarget{}, err
 		}
 	}
-	return resolveMailTargetsCached(store, identifier, cache)
+	return resolveMailTargetsCached(sessStore, identifier, cache)
 }
 
-func resolveMailTargetsCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
+func resolveMailTargetsCached(sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
 		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, nil
 	}
-	sessionID, err := resolveSessionID(store, identifier)
+	sessionID, err := resolveSessionID(sessStore, identifier)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
-			if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
+			if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(sessStore, identifier, cache); targetErr != nil {
 				return resolvedMailTarget{}, targetErr
 			} else if matched {
 				return target, nil
@@ -1240,7 +1241,7 @@ func resolveMailTargetsCached(store beads.Store, identifier string, cache *mailI
 		}
 		return resolvedMailTarget{}, err
 	}
-	addresses, err := session.NewStore(beads.SessionStore{Store: store}).MailboxAddresses(sessionID)
+	addresses, err := session.NewStore(beads.SessionStore{Store: sessStore}).MailboxAddresses(sessionID)
 	if err != nil {
 		return resolvedMailTarget{}, err
 	}
@@ -1266,7 +1267,7 @@ func resolveMailTargetsForCommand(identifier string, stderr io.Writer, cmdName s
 		return resolvedMailTarget{}, false
 	}
 	cityPath, cfg := ambientMailTargetConfig()
-	target, err := resolveMailTargetsWithConfig(cityPath, cfg, store, identifier)
+	target, err := resolveMailTargetsWithConfig(cityPath, cfg, cliSessionStore(store, cfg, cityPath), identifier)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 		return resolvedMailTarget{}, false
@@ -1291,9 +1292,10 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 	// Memoize the gc:session enumeration so multi-candidate retry shares one
 	// broad scan instead of issuing one per candidate (ga-q6ct Layer 2).
 	cityPath, cfg := ambientMailTargetConfig()
+	sessStore := cliSessionStore(store, cfg, cityPath)
 	cache := &mailIdentitySessionCache{}
 	for _, c := range candidates {
-		target, err := resolveMailTargetsWithConfigCached(cityPath, cfg, store, c, cache)
+		target, err := resolveMailTargetsWithConfigCached(cityPath, cfg, sessStore, c, cache)
 		if err == nil {
 			return target, true
 		}
@@ -1306,14 +1308,14 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 	return resolvedMailTarget{}, false
 }
 
-func resolveDefaultMailSenderForCommand(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string) (string, bool) {
-	return resolveDefaultMailSenderForCommandCached(cityPath, cfg, store, stderr, cmdName, nil)
+func resolveDefaultMailSenderForCommand(cityPath string, cfg *config.City, sessStore beads.Store, stderr io.Writer, cmdName string) (string, bool) {
+	return resolveDefaultMailSenderForCommandCached(cityPath, cfg, sessStore, stderr, cmdName, nil)
 }
 
-func resolveDefaultMailSenderForCommandCached(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string, cache *mailIdentitySessionCache) (string, bool) {
+func resolveDefaultMailSenderForCommandCached(cityPath string, cfg *config.City, sessStore beads.Store, stderr io.Writer, cmdName string, cache *mailIdentitySessionCache) (string, bool) {
 	candidates := defaultMailIdentityCandidates()
 	for _, c := range candidates {
-		sender, err := resolveMailIdentityWithConfigCached(cityPath, cfg, store, c, cache)
+		sender, err := resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, c, cache)
 		if err == nil {
 			return sender, true
 		}
@@ -1346,7 +1348,8 @@ func resolveRawMailTargetForStorelessProvider(identifier string, stderr io.Write
 		return resolvedMailTarget{}, false
 	}
 	if err == nil && store != nil {
-		target, resolveErr := resolveMailTargets(store, identifier)
+		cityPath, cfg := ambientMailTargetConfig()
+		target, resolveErr := resolveMailTargets(cliSessionStore(store, cfg, cityPath), identifier)
 		if resolveErr == nil {
 			return target, true
 		}
@@ -1727,12 +1730,19 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	// Every read below is session-class (live-mailbox enumeration, sender and
+	// recipient identity), so route once here; the resolvers take the routed
+	// store. store itself stays the work store for the nudge path.
+	var sessStore beads.Store
+	if store != nil {
+		sessStore = cliSessionStore(store, cfg, cityPath)
+	}
 	// Memoize the gc:session enumeration so identity resolution (sender +
 	// recipient + listLiveSessionMailboxes) shares one broad scan instead of
 	// issuing one per call site (ga-q6ct Layer 3).
 	idCache := &mailIdentitySessionCache{}
 	if store != nil {
-		validRecipients, err = listLiveSessionMailboxesCached(store, idCache)
+		validRecipients, err = listLiveSessionMailboxesCached(sessStore, idCache)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: listing live sessions: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1743,7 +1753,7 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 	if sender == "" {
 		if store != nil {
 			var ok bool
-			sender, ok = resolveDefaultMailSenderForCommandCached(cityPath, cfg, store, stderr, "gc mail send", idCache)
+			sender, ok = resolveDefaultMailSenderForCommandCached(cityPath, cfg, sessStore, stderr, "gc mail send", idCache)
 			if !ok {
 				return 1
 			}
@@ -1751,7 +1761,7 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 			sender = defaultMailIdentity()
 		}
 	} else if sender != "human" && store != nil {
-		sender, err = resolveMailIdentityWithConfigCached(cityPath, cfg, store, sender, idCache)
+		sender, err = resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, sender, idCache)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1789,7 +1799,7 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 		}
 	}
 	if !all && len(args) > 0 && store != nil {
-		canonicalTo, err := resolveMailRecipientIdentityCached(cityPath, cfg, store, args[0], idCache)
+		canonicalTo, err := resolveMailRecipientIdentityCached(cityPath, cfg, sessStore, args[0], idCache)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: unknown recipient %q: %v\n", args[0], err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -2212,7 +2222,7 @@ func cmdMailReplyJSON(args []string, subject, message string, notify bool, jsonO
 		}
 		if sender != "human" {
 			if store != nil {
-				resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail reply")
+				resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, cliSessionStore(store, cfg, cityPath), stderr, "gc mail reply")
 				if !ok {
 					return 1
 				}

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -2088,14 +2088,23 @@ func cmdOrderSweepNudgeMail(nudgeTTL, mailTTL time.Duration, dryRun, quiet bool,
 	statePtr := &nudgeState
 
 	now := time.Now()
+	// Route each phase to its coordination class, the way the controller's
+	// nudge-mail sweep watchdog already does (city_runtime.go, via
+	// nudgesBeadStore/mailBeadStore). Left unrouted, the CLI sweep reads an empty
+	// backlog on a relocated city and reports success while the real one grows.
+	// cfg is nil deliberately: resolveClassStore ignores it, and loading config
+	// here would stomp the process-wide feature-flag globals (see the
+	// resolveCLIStorageRoutes doc).
+	nudges := cliNudgesStore(store, nil, cityPath)
+	mail := cliMailStore(store, nil, cityPath)
 	if dryRun {
-		return cmdOrderSweepNudgeMailDryRun(store, statePtr, now, nudgeTTL, mailTTL, quiet, stdout, stderr)
+		return cmdOrderSweepNudgeMailDryRun(nudges, mail, statePtr, now, nudgeTTL, mailTTL, quiet, stdout, stderr)
 	}
-	return cmdOrderSweepNudgeMailRun(store, statePtr, now, nudgeTTL, mailTTL, quiet, stdout, stderr)
+	return cmdOrderSweepNudgeMailRun(nudges, mail, statePtr, now, nudgeTTL, mailTTL, quiet, stdout, stderr)
 }
 
-func cmdOrderSweepNudgeMailDryRun(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, quiet bool, stdout, stderr io.Writer) int {
-	counts, err := countStaleNudgeMail(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
+func cmdOrderSweepNudgeMailDryRun(nudges beads.NudgesStore, mail beads.MailStore, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, quiet bool, stdout, stderr io.Writer) int {
+	counts, err := countStaleNudgeMail(nudges, mail, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-nudge-mail: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -2112,8 +2121,8 @@ func cmdOrderSweepNudgeMailDryRun(store beads.Store, nudgeState *nudgequeue.Stat
 	return 0
 }
 
-func cmdOrderSweepNudgeMailRun(store beads.Store, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, quiet bool, stdout, stderr io.Writer) int {
-	result, sweepErr := sweepStaleNudgeMail(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
+func cmdOrderSweepNudgeMailRun(nudges beads.NudgesStore, mail beads.MailStore, nudgeState *nudgequeue.State, now time.Time, nudgeTTL, mailTTL time.Duration, quiet bool, stdout, stderr io.Writer) int {
+	result, sweepErr := sweepStaleNudgeMail(nudges, mail, nudgeState, now, nudgeTTL, mailTTL, nudgeMailSweepCloseBudget)
 
 	if sweepErr != nil {
 		// Per-bead errors are joined via errors.Join (Unwrap() []error): print each

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1671,7 +1671,7 @@ func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Stor
 		}
 	}
 
-	if err := enqueueQueuedNudgeWithStore(target.cityPath, beads.NudgesStore{Store: store}, newQueuedNudgeWithOptions(target.agent.QualifiedName(), msg, "sling", now, queuedNudgeOptionsFromTarget(target))); err != nil {
+	if err := enqueueQueuedNudgeWithStore(target.cityPath, cliNudgesStore(store, target.cfg, target.cityPath), newQueuedNudgeWithOptions(target.agent.QualifiedName(), msg, "sling", now, queuedNudgeOptionsFromTarget(target))); err != nil {
 		telemetry.RecordNudge(context.Background(), target.agent.QualifiedName(), err)
 		fmt.Fprintf(stderr, "warning: bead routed but nudge failed: %v\n", err) //nolint:errcheck // best-effort
 		return

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -708,11 +708,13 @@ func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (wait
 	if store == nil {
 		return result, code
 	}
-	// Route SESSION/wait access to the session coordination-class store; the
-	// nudge lookup rides a NudgesStore over the same work store. Identity today.
+	// Route SESSION/wait access to the session coordination-class store and the
+	// nudge lookup to the nudges class store. Identity today; on a relocated city
+	// an unrouted nudge read is silent-empty, which re-delivers a nudge that was
+	// already delivered.
 	cfg, _ := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	sessFront := sessionFrontDoor(cliSessionStore(store, cfg, cityPath))
-	nudges := beads.NudgesStore{Store: store}
+	nudges := cliNudgesStore(store, cfg, cityPath)
 	w, err := sessFront.GetWait(waitID)
 	if err != nil {
 		if errors.Is(err, sessionpkg.ErrNotAWait) {
@@ -997,7 +999,7 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 	dependencies := waitDependencyReaderFunc(func(depID string) (beads.Bead, error) {
 		return loadWaitDependencyBead(cityPath, store, depID)
 	})
-	return prepareWaitWakeStateWithSnapshot(cliSessionFrontDoor(store, cfg, cityPath), dependencies, beads.NudgesStore{Store: store}, now, nil)
+	return prepareWaitWakeStateWithSnapshot(cliSessionFrontDoor(store, cfg, cityPath), dependencies, cliNudgesStore(store, cfg, cityPath), now, nil)
 }
 
 func prepareWaitWakeStateWithSnapshot(sessFront *sessionpkg.Store, dependencies waitDependencyReader, nudges beads.NudgesStore, now time.Time, sessionBeads *sessionBeadSnapshot) (map[string]bool, error) {
@@ -1131,15 +1133,15 @@ func lookupSessionBeadByIDInfo(sessFront *sessionpkg.Store, id string) (sessionp
 
 func dispatchReadyWaitNudges(cityPath string, store beads.Store, _ runtime.Provider, now time.Time) error {
 	// Single-store wrapper: fan the one work store into the session and nudges
-	// class params so existing test call sites stay untouched. Route the session
-	// arm through the session coordination-class store (via cliSessionFrontDoor)
-	// so a [beads.classes.sessions] relocation reaches it; identity to the work
-	// store today.
+	// class params so existing test call sites stay untouched. Both arms route
+	// through their coordination-class store (cliSessionFrontDoor, cliNudgesStore)
+	// so a [beads.classes.*] relocation reaches them; identity to the work store
+	// today.
 	var cfg *config.City
 	if strings.TrimSpace(cityPath) != "" {
 		cfg, _ = loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 	}
-	return dispatchReadyWaitNudgesWithSnapshot(cityPath, cfg, cliSessionFrontDoor(store, cfg, cityPath), beads.NudgesStore{Store: store}, now, nil)
+	return dispatchReadyWaitNudgesWithSnapshot(cityPath, cfg, cliSessionFrontDoor(store, cfg, cityPath), cliNudgesStore(store, cfg, cityPath), now, nil)
 }
 
 func dispatchReadyWaitNudgesWithSnapshot(cityPath string, cfg *config.City, sessFront *sessionpkg.Store, nudges beads.NudgesStore, now time.Time, sessionBeads *sessionBeadSnapshot) error {

--- a/cmd/gc/control_rig_graph_federation_test.go
+++ b/cmd/gc/control_rig_graph_federation_test.go
@@ -1,0 +1,662 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// The rig arm of the control-class split.
+//
+// TestControlDispatchRigScopeStaysOnItsOwnStore pins the other half: a rig scope
+// keeps its own store, because `gc storage migrate` copies only the CITY work
+// store, so a rig has no frozen retained copies to be misled by. That reasoning
+// is sound and unchanged. What it did not cover is that a rig dispatcher's
+// control beads are not all rig-resident in the first place.
+//
+// A workflow materializes its control beads into the ledger that owns the
+// graph class, and the class binding is CITY-keyed — one per city, regardless
+// of which rig's dispatcher the beads are then routed to. So a rig dispatcher's
+// queue is split across two ledgers: the beads its own workflows minted in the
+// rig store, and the beads a city-scoped molecule minted in the binding and
+// routed to it. Measured on a live city: 148 open control beads carrying
+// gc.routed_to=<rig>/core.control-dispatcher sat in the binding while the
+// dispatcher's every readiness scan asked only the rig store and got `[]` —
+// exit 0, empty array, "no work", forever.
+//
+// The two sets have DISJOINT ids, which is what makes a union safe rather than
+// ambiguous: the rig store was never a migration target, so no id is co-resident
+// and no leg can shadow a live copy with a stale one. Verified on the same live
+// city — all 20 graph-class control beads carrying the rig's own id prefix were
+// absent from the rig store.
+//
+// The scope store stays the FIRST leg, so every id it holds resolves exactly
+// where it resolves today and the rig dispatchers already draining their own
+// ledgers are untouched.
+
+// rigFederationFixture stands up a split city with a rig scope, a fake `bd` on
+// PATH answering for the rig leg, and a memory-backed city graph binding.
+//
+// The fake bd is what makes the scope leg observable: the shell arm of the
+// fallback reads through it, so a bead in its payload can only have come from
+// the scope leg, and a bead in the binding can only have come from the graph
+// leg. Without that separation a union test cannot tell a merged answer from a
+// single leg that happened to hold both.
+//
+// GC_CITY is set because that is how a rig-scoped dispatcher actually finds its
+// city. tryControlReadyFromCacheOrFallback derives the city from the scope dir
+// via cityForStoreDir, which prefers the env over walking up the filesystem —
+// and it has to: rigs are routinely OUTSIDE the city tree (on the live city,
+// GC_DIR=/data/projects/beads under GC_CITY=/data/projects/maintainer-city), so
+// filesystem discovery from the rig dir would find no city at all and the whole
+// federation would silently not apply. The .gc marker is what makes the env
+// value pass validateCityPath.
+func rigFederationFixture(t *testing.T, bdPayload string) (cityPath, rigPath string, binding *beads.MemStore) {
+	t.Helper()
+	configureIsolatedRuntimeEnv(t)
+
+	cityPath = t.TempDir()
+	rigPath = filepath.Join(cityPath, "rigs", "fixture")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir city runtime root: %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	// The payload is baked in, so the fake bd answers every invocation with the
+	// rig leg's ready set whatever flags the caller passed.
+	tmp := t.TempDir()
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte("#!/bin/sh\nprintf '%s' '"+bdPayload+"'\n"), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_BEADS", "bd")
+
+	return cityPath, rigPath, beads.NewMemStore()
+}
+
+func controlLegIDs(items []beads.Bead) []string {
+	out := make([]string, 0, len(items))
+	for _, b := range items {
+		out = append(out, b.ID)
+	}
+	return out
+}
+
+func containsID(items []beads.Bead, id string) bool {
+	for _, b := range items {
+		if b.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestControlReadyFallbackRigScopeFederatesTheCityGraphBinding is the readiness
+// half: a rig-scoped scan must see the control beads a city-scoped molecule
+// routed to it, not just the ones its own rig minted.
+func TestControlReadyFallbackRigScopeFederatesTheCityGraphBinding(t *testing.T) {
+	cityPath, rigPath, binding := rigFederationFixture(t, `[{"id":"ga-rig-resident"}]`)
+	routed, err := binding.Create(beads.Bead{Title: "check 1", Type: "task"})
+	if err != nil {
+		t.Fatalf("seed the binding: %v", err)
+	}
+
+	// PREMISE. Without the routes seeded there is no second leg at all, so the
+	// scan sees only the fake bd's payload. If this control ever returns the
+	// binding's bead the test below proves nothing: the id would be reachable
+	// through the scope leg and a union would be indistinguishable from today.
+	seedCLIStorageRoutes(t, cityPath, nil)
+	unsplit, err := controlReadyFallbackReady(rigPath, cityPath, nil, false)
+	if err != nil {
+		t.Fatalf("premise scan: %v", err)
+	}
+	if containsID(unsplit, routed.ID) {
+		t.Fatalf("premise failed: an unsplit city already returned the binding's bead (%v); "+
+			"the scope leg can reach it, so this fixture cannot distinguish a federated answer", controlLegIDs(unsplit))
+	}
+	if !containsID(unsplit, "ga-rig-resident") {
+		t.Fatalf("premise failed: the scope leg did not answer at all (%v); the fake bd is not wired", controlLegIDs(unsplit))
+	}
+
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+	got, err := controlReadyFallbackReady(rigPath, cityPath, nil, false)
+	if err != nil {
+		t.Fatalf("federated scan: %v", err)
+	}
+	if !containsID(got, routed.ID) {
+		t.Errorf("the rig-scoped readiness scan returned %v, missing the binding's control bead; "+
+			"every control bead a city-scoped molecule routes to this rig strands unread and the dispatcher idles forever", controlLegIDs(got))
+	}
+	if !containsID(got, "ga-rig-resident") {
+		t.Errorf("the rig-scoped readiness scan returned %v, missing its OWN store's bead; "+
+			"the graph leg replaced the scope leg instead of joining it, trading one dead arm for another", controlLegIDs(got))
+	}
+}
+
+// TestControlReadyFallbackCityScopeStillReadsOnlyTheBinding is the control that
+// keeps the city arm from being swept into the union.
+//
+// A city scope reads the binding INSTEAD of its own store, and that asymmetry is
+// load-bearing: `gc storage migrate` retains a frozen copy of every migrated
+// control bead in the work ledger, so unioning the two legs there would re-offer
+// ids the binding has already finished and the drain loop would never return.
+func TestControlReadyFallbackCityScopeStillReadsOnlyTheBinding(t *testing.T) {
+	cityPath, _, binding := rigFederationFixture(t, `[{"id":"ga-stale-retained-copy"}]`)
+	live, err := binding.Create(beads.Bead{Title: "check 1", Type: "task"})
+	if err != nil {
+		t.Fatalf("seed the binding: %v", err)
+	}
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+	got, err := controlReadyFallbackReady(cityPath, cityPath, nil, false)
+	if err != nil {
+		t.Fatalf("city-scoped scan: %v", err)
+	}
+	if containsID(got, "ga-stale-retained-copy") {
+		t.Errorf("the city-scoped scan returned %v, which includes the work ledger's retained copy; "+
+			"those are the frozen ids the migration left behind and re-offering them re-enters control kinds the binding already finished", controlLegIDs(got))
+	}
+	if !containsID(got, live.ID) {
+		t.Errorf("the city-scoped scan returned %v, missing the binding's live bead", controlLegIDs(got))
+	}
+}
+
+// TestControlReadyFallbackSingleStoreRigScopeIsUnchanged pins the invisibility
+// rule: a city that relocates no class gets exactly the one leg it always had.
+func TestControlReadyFallbackSingleStoreRigScopeIsUnchanged(t *testing.T) {
+	cityPath, rigPath, _ := rigFederationFixture(t, `[{"id":"ga-only-leg"}]`)
+	seedCLIStorageRoutes(t, cityPath, nil)
+
+	got, err := controlReadyFallbackReady(rigPath, cityPath, nil, false)
+	if err != nil {
+		t.Fatalf("single-store scan: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ga-only-leg" {
+		t.Errorf("single-store rig scan = %v, want exactly [ga-only-leg]; "+
+			"a city with no [storage] section must take none of the federation", controlLegIDs(got))
+	}
+}
+
+// TestControlDispatchRigScopeResolvesAGraphResidentControlBead is the dispatch
+// half, and it is the half that makes the readiness half safe to ship.
+//
+// A federated scan hands the drain loop ids the scope store does not hold. If
+// the dispatch still resolved every id against the scope store, each one would
+// come back "bead not found" — which IsTransientControllerError does not match,
+// so drainWorkflowServeWork returns it as fatal and the dispatcher session exits
+// and crash-loops. Enumerating a bead the dispatch cannot then load is strictly
+// worse than not enumerating it, so the two must land together.
+func TestControlDispatchRigScopeResolvesAGraphResidentControlBead(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "fixture")
+	rigStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+	// The workflow root is canceled and lives ONLY in the binding, so the
+	// dispatcher's disposition is a direct readout of which ledger it read:
+	// root found and canceled means gc.outcome=canceled, root absent means
+	// gc.final_disposition=orphaned_workflow.
+	root, err := binding.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	control := newControlBead(t, binding, root.ID)
+
+	// PREMISE: the rig store does not hold this id. Without this the dispatch
+	// could be resolving it locally and the assertions below would pass for the
+	// wrong reason.
+	if _, err := rigStore.Get(control.ID); err == nil {
+		t.Fatalf("premise failed: the rig store already holds %s, so this test cannot show the graph leg was consulted", control.ID)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, rigPath, rigStore, control.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("rig-scoped dispatch of a graph-resident control bead: %v; "+
+			"a federated readiness scan enumerates these ids, so a fatal not-found here crash-loops the dispatcher session", err)
+	}
+
+	got := beadByID(t, binding, control.ID)
+	if got.Status != "closed" {
+		t.Errorf("graph-resident control bead status = %q, want closed in the binding; the dispatch wrote somewhere else", got.Status)
+	}
+	if outcome := got.Metadata[beadmeta.OutcomeMetadataKey]; outcome != beadmeta.OutcomeCanceled {
+		t.Errorf("gc.outcome = %q, want %q; the dispatcher resolved the root somewhere other than the binding",
+			outcome, beadmeta.OutcomeCanceled)
+	}
+}
+
+// TestControlBeadLedgerResolvesTheGraphLegWithoutMovingTheWorkLeg pins the
+// asymmetry that makes the rig arm correct, and is the reason the dispatch
+// resolves residence rather than re-entering the whole run at the city scope.
+//
+// The binding is city-keyed for the GRAPH class only; the work class is not
+// relocated at all. So a rig scope lands on (rig work store, city graph
+// binding) — the same shape as the city arm's (city work store, city graph
+// binding), with only the graph leg moving.
+//
+// Measured on the live city: the stranded control beads and their workflow root
+// are `gcg-` and binding-resident, while the input convoy those same beads name
+// in gc.input_convoy_id is `ga-xz2hu` — absent from the binding, present in the
+// rig store. Moving the work leg to the city would fix the graph read and break
+// EmitCurrent, which reads that convoy's tracks edges from the work leg.
+func TestControlBeadLedgerResolvesTheGraphLegWithoutMovingTheWorkLeg(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "fixture")
+	rigStore := beads.NewMemStore()
+	// MemStore assigns its own sequential ids and each store counts
+	// independently, so a bead in each would land on the SAME id and the scope
+	// leg would legitimately shadow the binding. Offset the binding's sequence so
+	// the two ledgers are disjoint, which is what residence is on the live city.
+	binding := beads.NewMemStoreFrom(100, nil, nil)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+
+	local, err := rigStore.Create(beads.Bead{Title: "rig-resident", Type: "task"})
+	if err != nil {
+		t.Fatalf("create rig bead: %v", err)
+	}
+	resident, err := binding.Create(beads.Bead{Title: "binding-resident", Type: "task"})
+	if err != nil {
+		t.Fatalf("create binding bead: %v", err)
+	}
+
+	// PREMISE: the two ledgers hold DISJOINT ids. Without this the assertions
+	// below cannot distinguish "resolved the binding" from "found a same-id bead
+	// in the rig store first".
+	if _, err := rigStore.Get(resident.ID); err == nil {
+		t.Fatalf("premise failed: the rig store also holds %s, so this test cannot show which leg answered", resident.ID)
+	}
+	if _, err := binding.Get(local.ID); err == nil {
+		t.Fatalf("premise failed: the binding also holds %s, so the leg-order assertion below is vacuous", local.ID)
+	}
+
+	gotStore, gotBead, err := controlBeadLedger(cityPath, rigPath, cfg, rigStore, resident.ID)
+	if err != nil {
+		t.Fatalf("controlBeadLedger for a binding-resident id: %v", err)
+	}
+	if gotBead.ID != resident.ID {
+		t.Errorf("resolved bead = %q, want %q", gotBead.ID, resident.ID)
+	}
+	// Identity is the wrong assertion here — the routes layer hands back an
+	// equivalent handle, not the seeded pointer. Prove it is the binding by
+	// writing through it and reading the result out of the binding.
+	probe, err := gotStore.Create(beads.Bead{Title: "probe", Type: "task"})
+	if err != nil {
+		t.Fatalf("write through the resolved graph leg: %v", err)
+	}
+	if _, err := binding.Get(probe.ID); err != nil {
+		t.Errorf("wrote %s through the resolved graph leg but the city graph binding does not hold it (%v); "+
+			"the dispatch would gate and mutate a ledger nothing else reads", probe.ID, err)
+	}
+	if _, err := rigStore.Get(probe.ID); err == nil {
+		t.Errorf("the resolved graph leg wrote %s into the rig's own store, want the city graph binding", probe.ID)
+	}
+
+	gotStore, gotBead, err = controlBeadLedger(cityPath, rigPath, cfg, rigStore, local.ID)
+	if err != nil {
+		t.Fatalf("controlBeadLedger for a rig-resident id: %v", err)
+	}
+	if gotStore != beads.Store(rigStore) {
+		t.Errorf("graph leg for a rig-resident id = %T, want the rig's own store; the scope store must stay the first leg", gotStore)
+	}
+	if gotBead.ID != local.ID {
+		t.Errorf("resolved bead = %q, want %q", gotBead.ID, local.ID)
+	}
+}
+
+// TestControlDispatchRigScopePrefersItsOwnStore pins leg ORDER.
+//
+// The scope store is the first leg. On the live city the two ledgers hold
+// disjoint ids so order cannot change an answer, but that disjointness is a
+// property of today's migration scope (rig stores are never migration targets),
+// not an invariant anything enforces. Pinning the order means a future migration
+// that does produce a co-resident id degrades to "the rig's own copy wins" —
+// exactly what a rig dispatcher does today — rather than silently flipping every
+// rig-scoped dispatch onto the binding.
+func TestControlDispatchRigScopePrefersItsOwnStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "fixture")
+	rigStore := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+	root, err := rigStore.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	control := newControlBead(t, rigStore, root.ID)
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, rigPath, rigStore, control.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("rig-scoped dispatch of a rig-resident control bead: %v", err)
+	}
+	if got := beadByID(t, rigStore, control.ID); got.Status != "closed" {
+		t.Errorf("rig control bead status = %q, want closed in the rig's own store", got.Status)
+	}
+	empty, err := binding.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("list city binding: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("city binding holds %d bead(s) after a rig-resident dispatch, want 0; "+
+			"the graph leg took precedence over the rig's own store", len(empty))
+	}
+}
+
+// TestControlGraphExtraLegRoutingRule is the routing rule itself, stated once
+// for every scope shape, so the cache leg and the fallback leg cannot drift
+// apart the way control dispatch and convergence did.
+func TestControlGraphExtraLegRoutingRule(t *testing.T) {
+	binding := beads.NewMemStore()
+
+	t.Run("split rig scope gains the binding as a second leg", func(t *testing.T) {
+		cityPath := t.TempDir()
+		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+		got, federated := controlGraphExtraLeg(cityPath, filepath.Join(cityPath, "rigs", "ra"))
+		if !federated || !sameStorePtr(got, binding) {
+			t.Errorf("controlGraphExtraLeg for a split rig scope = (%v, %v), want the city binding; "+
+				"the control beads a city molecule routes to this rig are unreachable without it", got, federated)
+		}
+	})
+
+	t.Run("split city scope takes no extra leg", func(t *testing.T) {
+		cityPath := t.TempDir()
+		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+		if got, federated := controlGraphExtraLeg(cityPath, cityPath); federated {
+			t.Errorf("controlGraphExtraLeg for a split city scope = (%v, true), want no extra leg; "+
+				"the city reads the binding INSTEAD of its store, and unioning in the retained copies re-offers finished ids", got)
+		}
+	})
+
+	t.Run("single-store rig scope takes no extra leg", func(t *testing.T) {
+		cityPath := t.TempDir()
+		seedCLIStorageRoutes(t, cityPath, nil)
+		if got, federated := controlGraphExtraLeg(cityPath, filepath.Join(cityPath, "rigs", "ra")); federated {
+			t.Errorf("controlGraphExtraLeg on a city that relocates nothing = (%v, true), want no extra leg; "+
+				"this whole change must be invisible to a city with no [storage] section", got)
+		}
+	})
+}
+
+// TestControlGraphExtraLegSkipsARefusingBinding keeps a storage refusal from
+// being converted into a per-tick failure of the whole readiness scan.
+//
+// A refusal is this build's standing verdict about the CITY, not a fault in any
+// one read: it says the [storage] shape is one this binary cannot resolve, and a
+// refused city still serves work from its work ledger. Federating that verdict
+// in as a second leg would make every leg-fails-loud path in
+// controlReadyFallbackReady return it, so a rig dispatcher that reads its own
+// ledger perfectly well would stop scanning at all — a strictly worse outcome
+// than the pre-federation behavior on the same city.
+func TestControlGraphExtraLegSkipsARefusingBinding(t *testing.T) {
+	refusal := errors.New("unsupported [storage] shape")
+
+	t.Run("a refusing binding is not federated", func(t *testing.T) {
+		cityPath := t.TempDir()
+		seedCLIStorageRoutes(t, cityPath, refusingStorageRoutes("infra", refusal))
+		if got, federated := controlGraphExtraLeg(cityPath, filepath.Join(cityPath, "rigs", "ra")); federated {
+			t.Errorf("controlGraphExtraLeg on a refused city = (%v, true), want no extra leg; "+
+				"every readiness scan on this rig now fails on a verdict about the city instead of reading the ledger it can reach", got)
+		}
+	})
+
+	// The control. It must fail DIFFERENTLY: same call, same scope shape, a
+	// binding that is merely relocated rather than refused. Without it the
+	// negative above would also pass if controlGraphExtraLeg had simply stopped
+	// federating anything.
+	t.Run("control: a resolvable binding on the same shape still federates", func(t *testing.T) {
+		cityPath := t.TempDir()
+		binding := beads.NewMemStore()
+		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+		got, federated := controlGraphExtraLeg(cityPath, filepath.Join(cityPath, "rigs", "ra"))
+		if !federated || !sameStorePtr(got, binding) {
+			t.Errorf("controlGraphExtraLeg for a resolvable split rig scope = (%v, %v), want the binding; "+
+				"the refusal skip above is vacuous if nothing federates", got, federated)
+		}
+	})
+}
+
+// TestControlReadyCacheSourcesRouteTheSameLegsAsTheFallback pins the two scan
+// arms to one routing rule.
+//
+// The serve loop takes the CACHE arm first on every tick; the fallback runs only
+// when a leg is dirty, still priming, or the bd compatibility mode needs a tier
+// CachedReady cannot serve. So the cache arm is the production path, and the two
+// agreeing about WHICH ledgers hold this scope's queue is the whole safety
+// property: a queue drawn from a different set of stores than the dispatch
+// mutates is exactly the divergence this defect was.
+//
+// Asserted structurally — leg count and the binding's position — rather than by
+// comparing scan output, because the two arms legitimately return different bead
+// values (one snapshots, one reads live) and only their ROUTING has to match.
+func TestControlReadyCacheSourcesRouteTheSameLegsAsTheFallback(t *testing.T) {
+	t.Run("split rig scope snapshots its own store AND the binding", func(t *testing.T) {
+		cityPath, rigPath, binding := rigFederationFixture(t, `[]`)
+		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+		sources, err := controlReadyCacheSources(rigPath, cityPath, nil)
+		if err != nil {
+			t.Fatalf("controlReadyCacheSources for a split rig scope: %v", err)
+		}
+		if len(sources) != 2 {
+			t.Fatalf("cache sources for a split rig scope = %d leg(s), want 2; "+
+				"the cached arm reads a narrower set than the fallback and the queue flips with cache freshness", len(sources))
+		}
+		if sameStorePtr(sources[0], binding) {
+			t.Errorf("cache leg[0] is the binding, want the scope's own store first; leg order decides which copy wins on a co-resident id")
+		}
+		if !sameStorePtr(sources[1], binding) {
+			t.Errorf("cache leg[1] = %T, want the city graph binding; the beads a city molecule routed to this rig stay unread on the cached arm", sources[1])
+		}
+	})
+
+	t.Run("split city scope snapshots only the binding", func(t *testing.T) {
+		cityPath, _, binding := rigFederationFixture(t, `[]`)
+		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+		sources, err := controlReadyCacheSources(cityPath, cityPath, nil)
+		if err != nil {
+			t.Fatalf("controlReadyCacheSources for a split city scope: %v", err)
+		}
+		if len(sources) != 1 || !sameStorePtr(sources[0], binding) {
+			t.Fatalf("cache sources for a split city scope = %d leg(s), want exactly the binding; "+
+				"unioning the work store back in re-offers the frozen copies the migration retained", len(sources))
+		}
+	})
+
+	t.Run("single-store rig scope snapshots one store", func(t *testing.T) {
+		cityPath, rigPath, binding := rigFederationFixture(t, `[]`)
+		seedCLIStorageRoutes(t, cityPath, nil)
+
+		sources, err := controlReadyCacheSources(rigPath, cityPath, nil)
+		if err != nil {
+			t.Fatalf("controlReadyCacheSources for a single-store rig scope: %v", err)
+		}
+		if len(sources) != 1 {
+			t.Fatalf("cache sources for a single-store rig scope = %d leg(s), want 1; "+
+				"a city with no [storage] section must take none of the federation", len(sources))
+		}
+		if sameStorePtr(sources[0], binding) {
+			t.Errorf("the single leg is the unrouted binding, want the scope's own store")
+		}
+	})
+}
+
+// TestCachedControlReadyUnionRequiresEveryLeg pins all-or-nothing.
+//
+// A federated scope's queue is only complete if every leg answered. Returning
+// the warm legs' beads when one is cold would be indistinguishable from a
+// complete answer at the call site — the fallback would never run, and the scan
+// would silently report a short queue as the whole queue. That is the same
+// "exit 0, empty array, no work" shape as the defect this federation fixes, just
+// intermittent, which is worse.
+func TestCachedControlReadyUnionRequiresEveryLeg(t *testing.T) {
+	newPrimed := func(t *testing.T, title string) (*beads.CachingStore, string) {
+		t.Helper()
+		store := beads.NewMemStore()
+		bead, err := store.Create(beads.Bead{Title: title, Type: "task"})
+		if err != nil {
+			t.Fatalf("seed %s: %v", title, err)
+		}
+		cache := beads.NewCachingStore(store, nil)
+		if err := cache.PrimeActive(); err != nil {
+			t.Fatalf("prime %s: %v", title, err)
+		}
+		return cache, bead.ID
+	}
+
+	warm, warmID := newPrimed(t, "warm leg")
+	other, otherID := newPrimed(t, "second warm leg")
+	cold := beads.NewCachingStore(beads.NewMemStore(), nil)
+
+	// PREMISE: an unprimed cache really is cold, so the negative below is about
+	// the union's policy and not about a cache that happens to answer anyway.
+	if _, ok := cold.CachedReady(); ok {
+		t.Fatal("premise failed: an unprimed CachingStore answered CachedReady; this test cannot show a cold leg forces the fallback")
+	}
+
+	if got, ok := cachedControlReadyUnion([]*beads.CachingStore{warm, cold}); ok {
+		t.Errorf("cachedControlReadyUnion with one cold leg = (%d bead(s), true), want a miss; "+
+			"a partial union reads as a complete queue and the fallback never runs", len(got))
+	}
+	if got, ok := cachedControlReadyUnion([]*beads.CachingStore{cold, warm}); ok {
+		t.Errorf("cachedControlReadyUnion with the cold leg FIRST = (%d bead(s), true), want a miss; "+
+			"leg order must not decide whether a short answer escapes", len(got))
+	}
+
+	// The control: every leg warm unions, so the miss above is the cold leg and
+	// not the union refusing to merge at all.
+	got, ok := cachedControlReadyUnion([]*beads.CachingStore{warm, other})
+	if !ok {
+		t.Fatal("cachedControlReadyUnion with every leg warm missed; the cached arm can never answer a federated scope and every tick pays the fallback")
+	}
+	if !containsID(got, warmID) || !containsID(got, otherID) {
+		t.Errorf("warm union = %v, want both %s and %s; one leg's beads were dropped", controlLegIDs(got), warmID, otherID)
+	}
+}
+
+// TestControlReadyScanRigScopeFederatesTheBindingOnBothArms is the end-to-end
+// producer assertion, taken through the exact entry point the serve loop calls.
+//
+// The three fallback tests above call controlReadyFallbackReady directly, which
+// leaves the production path — nextWorkflowServeBeads ->
+// tryControlReadyFromCacheOrFallback -> the cache arm — unexercised for a
+// federated scope. This runs the real entry for both arms against one fixture,
+// so cache/fallback parity is pinned on OUTPUT and not only on routing.
+func TestControlReadyScanRigScopeFederatesTheBindingOnBothArms(t *testing.T) {
+	agentCfg := config.Agent{Name: config.ControlDispatcherAgentName}
+	route := agentCfg.QualifiedName()
+	rigResident := `[{"id":"ga-rig-resident","title":"rig check","issue_type":"task","status":"open",` +
+		`"metadata":{"` + beadmeta.RunTargetMetadataKey + `":"` + route + `"}}]`
+
+	for _, tc := range []struct {
+		name  string
+		beads config.BeadsConfig
+	}{
+		{name: "cached arm", beads: config.BeadsConfig{}},
+		{name: "fallback arm", beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath, rigPath, binding := rigFederationFixture(t, rigResident)
+			seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+			root, err := binding.Create(beads.Bead{
+				Title:    "workflow",
+				Type:     "task",
+				Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+			})
+			if err != nil {
+				t.Fatalf("create workflow root: %v", err)
+			}
+			routed := newRoutedControlBead(t, binding, root.ID, route)
+
+			got := controlReadyScan(t, rigPath, agentCfg, tc.beads)
+			if !slices.Contains(got, routed.ID) {
+				t.Errorf("rig-scoped control-ready queue = %v, missing the binding's control bead %s; "+
+					"this is the live defect — 148 beads routed here sat unread while the dispatcher reported idle", got, routed.ID)
+			}
+			if !slices.Contains(got, "ga-rig-resident") {
+				t.Errorf("rig-scoped control-ready queue = %v, missing the rig's OWN control bead; "+
+					"the binding replaced the scope leg instead of joining it", got)
+			}
+		})
+	}
+}
+
+// TestControlReadyScanRigScopeStopsOfferingABeadTheDispatchClosed is the
+// termination property at a rig scope, and it is the assertion that makes the
+// federated queue safe rather than merely fuller.
+//
+// drainWorkflowServeWork loops until its queue comes back empty, with no
+// iteration bound and no sleep between passes. Adding a leg to the scan without
+// the dispatch resolving that same leg would produce ids the dispatch cannot
+// find (fatal, crash-loop) or ids it closes in a different ledger than the scan
+// reads (a queue that never empties, a loop that never returns). The fixed point
+// below is what rules both out: scan, dispatch, scan again, empty.
+func TestControlReadyScanRigScopeStopsOfferingABeadTheDispatchClosed(t *testing.T) {
+	agentCfg := config.Agent{Name: config.ControlDispatcherAgentName}
+	route := agentCfg.QualifiedName()
+
+	cityPath, rigPath, binding := rigFederationFixture(t, `[]`)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+	rigStore := beads.NewMemStore()
+
+	root, err := binding.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	live := newRoutedControlBead(t, binding, root.ID, route)
+
+	if got := controlReadyScan(t, rigPath, agentCfg, config.BeadsConfig{}); !slices.Contains(got, live.ID) {
+		t.Fatalf("control-ready queue before dispatch = %v, want it to contain %s", got, live.ID)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherWithStoreAndConfig(cityPath, rigPath, rigStore, live.ID, cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("rig-scoped control dispatch: %v", err)
+	}
+	if closed := beadByID(t, binding, live.ID); closed.Status != "closed" {
+		t.Fatalf("binding control bead status = %q, want closed; the dispatch wrote a ledger the scan does not read", closed.Status)
+	}
+
+	if got := controlReadyScan(t, rigPath, agentCfg, config.BeadsConfig{}); len(got) != 0 {
+		t.Fatalf("control-ready queue after dispatch = %v, want empty; "+
+			"the serve loop re-offers a bead the dispatch already finished and drainWorkflowServeWork never returns", got)
+	}
+}

--- a/cmd/gc/control_rig_graph_federation_test.go
+++ b/cmd/gc/control_rig_graph_federation_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -242,6 +243,152 @@ func TestControlDispatchRigScopeResolvesAGraphResidentControlBead(t *testing.T) 
 	if outcome := got.Metadata[beadmeta.OutcomeMetadataKey]; outcome != beadmeta.OutcomeCanceled {
 		t.Errorf("gc.outcome = %q, want %q; the dispatcher resolved the root somewhere other than the binding",
 			outcome, beadmeta.OutcomeCanceled)
+	}
+}
+
+// TestRunControlDispatcherResolvesACityGraphBindingResidentControlBead is the
+// MANUAL twin of the serve-path dispatch test above, and it closes the operator
+// half of the same gap.
+//
+// The automated serve loop reaches a binding-resident control bead because it
+// scans every scope and federates the city graph binding as an extra leg. The
+// manual `gc convoy control <id>` entry point instead resolves a single id
+// through findBeadScopeAcrossStores, which probes only the work store and the rig
+// control stores — never the binding. On a [beads.classes.graph]-relocated city a
+// city-scoped molecule materializes its graph-class control beads into that
+// binding, so the operator's recovery command returned `loading bead <id>: ...
+// not found` for exactly the class of beads this routing exists to serve, and
+// precisely when the automated path is wedged and an operator reaches for the
+// manual one.
+//
+// The canceled workflow root lives ONLY in the binding, so the dispatcher's
+// disposition is a direct readout of which ledger it resolved the bead from: a
+// canceled root closes the control bead gc.outcome=canceled; a missing root
+// closes it gc.final_disposition=orphaned_workflow.
+func TestRunControlDispatcherResolvesACityGraphBindingResidentControlBead(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"),
+		[]byte("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	binding := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+	root, err := binding.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.CancelRequestedMetadataKey: "operator",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	control := newControlBead(t, binding, root.ID)
+
+	// PREMISE: the city work store does not hold this id, so a pass can only come
+	// from consulting the binding rather than from a local resolve.
+	workStore, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	if _, err := workStore.Get(control.ID); err == nil {
+		t.Fatalf("premise failed: the city work store already holds %s, so this test cannot show the binding was consulted", control.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcher(control.ID, &stdout, &stderr); err != nil {
+		t.Fatalf("manual dispatch of a binding-resident control bead: %v; "+
+			"`gc convoy control <id>` cannot reach a graph-class control bead the serve loop already federates", err)
+	}
+
+	got := beadByID(t, binding, control.ID)
+	if got.Status != "closed" {
+		t.Errorf("binding-resident control bead status = %q, want closed in the binding; the manual dispatch wrote somewhere else", got.Status)
+	}
+	if outcome := got.Metadata[beadmeta.OutcomeMetadataKey]; outcome != beadmeta.OutcomeCanceled {
+		t.Errorf("gc.outcome = %q, want %q; the manual dispatch resolved the root somewhere other than the binding",
+			outcome, beadmeta.OutcomeCanceled)
+	}
+}
+
+// TestFindBeadScopeAcrossStoresRoutesABindingResidentRigBeadToItsRigScope pins
+// the WORK leg the manual entry point must keep for a rig-routed binding-resident
+// control bead.
+//
+// controlBeadLedger keeps the scope store FIRST and consults the binding as an
+// ADDITIONAL leg, so the scope findBeadScopeAcrossStores returns becomes the work
+// leg — the ledger that owns the input convoy an execution snapshot reads. A
+// city-scoped molecule stamps gc.routed_to=<rig>/core.control-dispatcher on the
+// control beads it materializes into the binding and hands to a rig; the input
+// convoy those beads name lives in that RIG's store, not the city's. Resolving
+// such a bead to the city scope would satisfy the graph read (the binding
+// federates either way) but strand the input convoy, so residence must be derived
+// from the bead's route rather than defaulted to the city.
+func TestFindBeadScopeAcrossStoresRoutesABindingResidentRigBeadToItsRigScope(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "fixture")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig path: %v", err)
+	}
+	cityTOML := "[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n" +
+		"[[rigs]]\nname = \"fixture\"\npath = \"" + rigPath + "\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	binding := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+
+	root, err := binding.Create(beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	control := newControlBead(t, binding, root.ID)
+	// The live stranded beads carry gc.routed_to=<rig>/core.control-dispatcher;
+	// gc.run_target (what newRoutedControlBead sets) is a different key the
+	// execution-route resolver does not read, so route the bead explicitly.
+	if err := binding.Update(control.ID, beads.UpdateOpts{
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "fixture/core.control-dispatcher"},
+	}); err != nil {
+		t.Fatalf("route control bead to the rig: %v", err)
+	}
+
+	// PREMISE: neither the city work store nor the rig control store holds the id,
+	// so the scope can only have come from consulting the binding.
+	cityStore, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	if _, err := cityStore.Get(control.ID); err == nil {
+		t.Fatalf("premise failed: the city work store holds %s", control.ID)
+	}
+	rigStore, err := openStoreAtForCity(rigPath, cityPath)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	if _, err := rigStore.Get(control.ID); err == nil {
+		t.Fatalf("premise failed: the rig store holds %s", control.ID)
+	}
+
+	_, storePath, err := findBeadScopeAcrossStores(cityPath, control.ID, io.Discard)
+	if err != nil {
+		t.Fatalf("findBeadScopeAcrossStores for a rig-routed binding-resident control bead: %v; "+
+			"the manual entry point never consults the city graph binding", err)
+	}
+	if filepath.Clean(storePath) != filepath.Clean(rigPath) {
+		t.Errorf("resolved scope path = %q, want the rig path %q; a rig-routed binding-resident bead must keep its rig work leg, "+
+			"or its input convoy is stranded on the wrong store", storePath, rigPath)
 	}
 }
 

--- a/cmd/gc/converge_scope_store_test.go
+++ b/cmd/gc/converge_scope_store_test.go
@@ -1,22 +1,24 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// convergeCityScopeStore is the CLI half of the convergence-residence split.
-// The controller's city scope writes convergence roots into the graph binding
-// (buildConvergenceScopes); `gc converge` has to read and write the same one.
-// When it does not, the CLI reads the work ledger for relocated graph ids and
-// reports every live convergence root as missing — #5125's bug class, and the
-// reason a `gc converge status` can look clean while the engine is stranding.
+// scopeGraphStore is the routing half of the convergence-residence split, shared
+// with control dispatch. The controller's city scope writes convergence roots
+// into the graph binding (buildConvergenceScopes); `gc converge` has to read and
+// write the same one. When it does not, the CLI reads the work ledger for
+// relocated graph ids and reports every live convergence root as missing —
+// #5125's bug class, and the reason a `gc converge status` can look clean while
+// the engine is stranding.
 //
 // The rig arm is the other half of the same rule: class routing is city-keyed,
 // so there is ONE graph binding per city. Routing rig scopes through it would
 // merge every rig's convergence loops into a ledger keyed by nothing.
-func TestConvergeCityScopeStoreRoutesCityToGraphAndRigToWork(t *testing.T) {
+func TestScopeGraphStoreRoutesCityToGraphAndRigToWork(t *testing.T) {
 	class := beads.NewMemStore()
 
 	t.Run("split city scope takes the graph binding", func(t *testing.T) {
@@ -24,9 +26,9 @@ func TestConvergeCityScopeStoreRoutesCityToGraphAndRigToWork(t *testing.T) {
 		work := beads.NewMemStore()
 		seedCLIStorageRoutes(t, cityPath, splitEnvRoutes(class))
 
-		got := convergeCityScopeStore(work, cityPath, "")
+		got := scopeGraphStore(cityPath, cityPath, nil, work)
 		if !sameStorePtr(got, class) {
-			t.Error("the city converge scope did not resolve to the graph binding; " +
+			t.Error("the city scope did not resolve to the graph binding; " +
 				"the CLI would read the work ledger for relocated graph ids and report every live convergence root as missing")
 		}
 	})
@@ -36,9 +38,9 @@ func TestConvergeCityScopeStoreRoutesCityToGraphAndRigToWork(t *testing.T) {
 		rig := beads.NewMemStore()
 		seedCLIStorageRoutes(t, cityPath, splitEnvRoutes(class))
 
-		got := convergeCityScopeStore(rig, cityPath, "ra")
+		got := scopeGraphStore(cityPath, filepath.Join(cityPath, "rigs", "ra"), nil, rig)
 		if !sameStorePtr(got, rig) {
-			t.Error("the rig converge scope was routed off its own work ledger; " +
+			t.Error("the rig scope was routed off its own work ledger; " +
 				"there is one graph binding per city, so every rig's convergence loops would collapse into it")
 		}
 	})
@@ -48,10 +50,46 @@ func TestConvergeCityScopeStoreRoutesCityToGraphAndRigToWork(t *testing.T) {
 		work := beads.NewMemStore()
 		seedCLIStorageRoutes(t, cityPath, nil)
 
-		got := convergeCityScopeStore(work, cityPath, "")
+		got := scopeGraphStore(cityPath, cityPath, nil, work)
 		if !sameStorePtr(got, work) {
 			t.Error("a city that relocates nothing must get its own store back unchanged; " +
 				"the class resolver's identity branch is what keeps this fix invisible to every single-store city")
 		}
 	})
+}
+
+// TestConvergeRigScopeIgnoresPathBasedCityTest pins the one place converge's
+// scope test is deliberately NOT scopeGraphStore's.
+//
+// scopeGraphStore decides city-ness by PATH, which is right for control
+// dispatch. Convergence has a second constraint: the controller's scope map
+// keys on rig NAME (buildConvergenceScopes), and nothing forbids registering a
+// rig at the city root. For such a rig the path test says "city" — so routing
+// the CLI's rig leg by path alone would read the graph binding while the
+// controller writes that rig's roots to its own store. That is the exact
+// read/write asymmetry this change removes, reintroduced through the back door.
+//
+// This is the assertion that fails if someone later "simplifies" the rig
+// short-circuit in openConvergeStore away as redundant.
+func TestConvergeRigScopeIgnoresPathBasedCityTest(t *testing.T) {
+	cityPath := t.TempDir()
+	class := beads.NewMemStore()
+	rigAtCityRoot := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, splitEnvRoutes(class))
+
+	// The premise: by path alone this scope reads as the city, so the shared
+	// helper routes it. Without this control the test below could pass because
+	// the routes were never seeded rather than because the guard held.
+	if routed := scopeGraphStore(cityPath, cityPath, nil, rigAtCityRoot); !sameStorePtr(routed, class) {
+		t.Fatal("premise failed: scopeGraphStore did not route a city-path scope to the binding, " +
+			"so this test cannot distinguish the rig guard from an unseeded route")
+	}
+
+	// openConvergeStore's rig leg returns the scope store untouched for any
+	// non-empty rig name, whatever its path resolves to.
+	if got := convergeScopeStore(cityPath, "rig-at-city-root", cityPath, rigAtCityRoot); !sameStorePtr(got, rigAtCityRoot) {
+		t.Error("a rig registered at the city root was routed to the city graph binding; " +
+			"the controller keys convergence scopes by rig name and writes that rig's roots to its own store, " +
+			"so the CLI would read a database the controller never writes for it")
+	}
 }

--- a/cmd/gc/converge_scope_store_test.go
+++ b/cmd/gc/converge_scope_store_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// convergeCityScopeStore is the CLI half of the convergence-residence split.
+// The controller's city scope writes convergence roots into the graph binding
+// (buildConvergenceScopes); `gc converge` has to read and write the same one.
+// When it does not, the CLI reads the work ledger for relocated graph ids and
+// reports every live convergence root as missing — #5125's bug class, and the
+// reason a `gc converge status` can look clean while the engine is stranding.
+//
+// The rig arm is the other half of the same rule: class routing is city-keyed,
+// so there is ONE graph binding per city. Routing rig scopes through it would
+// merge every rig's convergence loops into a ledger keyed by nothing.
+func TestConvergeCityScopeStoreRoutesCityToGraphAndRigToWork(t *testing.T) {
+	class := beads.NewMemStore()
+
+	t.Run("split city scope takes the graph binding", func(t *testing.T) {
+		cityPath := t.TempDir()
+		work := beads.NewMemStore()
+		seedCLIStorageRoutes(t, cityPath, splitEnvRoutes(class))
+
+		got := convergeCityScopeStore(work, cityPath, "")
+		if !sameStorePtr(got, class) {
+			t.Error("the city converge scope did not resolve to the graph binding; " +
+				"the CLI would read the work ledger for relocated graph ids and report every live convergence root as missing")
+		}
+	})
+
+	t.Run("split rig scope keeps its own work ledger", func(t *testing.T) {
+		cityPath := t.TempDir()
+		rig := beads.NewMemStore()
+		seedCLIStorageRoutes(t, cityPath, splitEnvRoutes(class))
+
+		got := convergeCityScopeStore(rig, cityPath, "ra")
+		if !sameStorePtr(got, rig) {
+			t.Error("the rig converge scope was routed off its own work ledger; " +
+				"there is one graph binding per city, so every rig's convergence loops would collapse into it")
+		}
+	})
+
+	t.Run("single-store city scope is identity", func(t *testing.T) {
+		cityPath := t.TempDir()
+		work := beads.NewMemStore()
+		seedCLIStorageRoutes(t, cityPath, nil)
+
+		got := convergeCityScopeStore(work, cityPath, "")
+		if !sameStorePtr(got, work) {
+			t.Error("a city that relocates nothing must get its own store back unchanged; " +
+				"the class resolver's identity branch is what keeps this fix invisible to every single-store city")
+		}
+	})
+}

--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -52,7 +52,7 @@ func setupConvergenceRuntime(t *testing.T) (*CityRuntime, *beads.MemStore) {
 
 	// Initialize the city/HQ convergence scope (mimics initConvergenceHandler).
 	cr.convScopes = map[string]*convergenceScope{
-		"": cr.newConvergenceScope("", store, cr.cityPath, []string{sharedTestFormulaDir}),
+		"": cr.newConvergenceScope("", store, cr.cityPath, []string{sharedTestFormulaDir}, false),
 	}
 
 	return cr, store
@@ -76,7 +76,7 @@ func addConvergenceRigScope(cr *CityRuntime, rig string, store beads.Store) *con
 }
 
 func addConvergenceRigScopeAt(cr *CityRuntime, rig string, store beads.Store, storePath string) *convergenceScope {
-	scope := cr.newConvergenceScope(rig, store, storePath, []string{sharedTestFormulaDir})
+	scope := cr.newConvergenceScope(rig, store, storePath, []string{sharedTestFormulaDir}, false)
 	cr.convScopes[rig] = scope
 	if cr.cfg != nil {
 		found := false
@@ -539,7 +539,7 @@ func TestConvergence_GateConditionUsesRigStorePath(t *testing.T) {
 
 func TestConvergence_TickIsolatesPanickingScope(t *testing.T) {
 	cr, _ := setupConvergenceRuntime(t)
-	cr.convScopes[""] = cr.newConvergenceScope("", getPanicStore{Store: beads.NewMemStore()}, cr.cityPath, []string{sharedTestFormulaDir})
+	cr.convScopes[""] = cr.newConvergenceScope("", getPanicStore{Store: beads.NewMemStore()}, cr.cityPath, []string{sharedTestFormulaDir}, false)
 	hqScope(t, cr).adapter.activeIndex = map[string]string{"panic-root": "test-agent"}
 
 	rigStore := beads.NewMemStore()
@@ -583,7 +583,7 @@ func TestConvergence_StartupReconcileMarksFailedScopeComplete(t *testing.T) {
 	cr.convScopes[""] = cr.newConvergenceScope("", convergenceListErrorStore{
 		Store: beads.NewMemStore(),
 		err:   errors.New("injected list failure"),
-	}, cr.cityPath, []string{sharedTestFormulaDir})
+	}, cr.cityPath, []string{sharedTestFormulaDir}, false)
 
 	rigStore := beads.NewMemStore()
 	rigScope := addConvergenceRigScope(cr, "healthy-rig", rigStore)
@@ -1003,7 +1003,7 @@ metadata = { "gc.routed_to" = "pool/worker", "gc.execution_routed_to" = "pool/wo
 	}
 
 	store := beads.NewMemStore()
-	adapter := newConvergenceStoreAdapter(store, []string{dir})
+	adapter := newConvergenceStoreAdapter(store, []string{dir}, false)
 	parent, err := store.Create(beads.Bead{Title: "root", Type: "convergence"})
 	if err != nil {
 		t.Fatalf("creating parent: %v", err)
@@ -1083,7 +1083,7 @@ title = "Work {{convoy_id}}"
 	}
 
 	store := beads.NewMemStore()
-	adapter := newConvergenceStoreAdapter(store, []string{dir})
+	adapter := newConvergenceStoreAdapter(store, []string{dir}, false)
 	parent, err := store.Create(beads.Bead{Title: "root", Type: "convergence"})
 	if err != nil {
 		t.Fatalf("creating parent: %v", err)
@@ -1102,7 +1102,7 @@ title = "Work {{convoy_id}}"
 
 func TestConvergenceIndex_PopulateAndQuery(t *testing.T) {
 	store := beads.NewMemStore()
-	adapter := newConvergenceStoreAdapter(store, nil)
+	adapter := newConvergenceStoreAdapter(store, nil, false)
 
 	// Create some convergence beads in various states.
 	active, _ := store.Create(beads.Bead{Title: "active", Type: "convergence", Status: "in_progress"})
@@ -1142,7 +1142,7 @@ func TestConvergenceIndex_PopulateAndQuery(t *testing.T) {
 
 func TestConvergenceIndex_MaintainedOnStateTransitions(t *testing.T) {
 	store := beads.NewMemStore()
-	adapter := newConvergenceStoreAdapter(store, nil)
+	adapter := newConvergenceStoreAdapter(store, nil, false)
 
 	// Start with an empty index.
 	adapter.activeIndex = make(map[string]string)

--- a/cmd/gc/convergence_store.go
+++ b/cmd/gc/convergence_store.go
@@ -11,7 +11,9 @@ import (
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/convergence"
+	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/graphv2"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
@@ -25,14 +27,15 @@ import (
 type convergenceStoreAdapter struct {
 	store              beads.Store
 	formulaSearchPaths []string          // search paths for formula compilation in PourWisp
+	relocated          bool              // store is a class binding, not this scope's work ledger
 	activeIndex        map[string]string // bead ID → target agent; nil until populateIndex
 	indexReady         atomic.Bool       // true once populateIndex has completed
 }
 
 var _ convergence.Store = (*convergenceStoreAdapter)(nil)
 
-func newConvergenceStoreAdapter(store beads.Store, formulaSearchPaths []string) *convergenceStoreAdapter {
-	return &convergenceStoreAdapter{store: store, formulaSearchPaths: formulaSearchPaths}
+func newConvergenceStoreAdapter(store beads.Store, formulaSearchPaths []string, relocated bool) *convergenceStoreAdapter {
+	return &convergenceStoreAdapter{store: store, formulaSearchPaths: formulaSearchPaths, relocated: relocated}
 }
 
 // populateIndex performs a one-time scan of all beads to build the
@@ -168,7 +171,7 @@ func (a *convergenceStoreAdapter) PourSpeculativeWisp(parentID, formula, idempot
 	return a.pourWisp(parentID, formula, idempotencyKey, vars, evaluatePrompt, true)
 }
 
-func (a *convergenceStoreAdapter) pourWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string, deferAssignees bool) (string, error) {
+func (a *convergenceStoreAdapter) pourWisp(parentID, formulaName, idempotencyKey string, vars map[string]string, evaluatePrompt string, deferAssignees bool) (string, error) {
 	// Idempotency: check if a wisp with this key already exists (crash-retry safety).
 	// Fail closed on lookup errors to prevent duplicate wisps.
 	existing, found, err := a.FindByIdempotencyKey(idempotencyKey)
@@ -187,19 +190,41 @@ func (a *convergenceStoreAdapter) pourWisp(parentID, formula, idempotencyKey str
 	if evaluatePrompt != "" {
 		cookVars["evaluate_prompt"] = evaluatePrompt
 	}
-	isGraphV2, _, err := graphv2.IsGraphV2Formula(formula, a.formulaSearchPaths)
+	isGraphV2, _, err := graphv2.IsGraphV2Formula(formulaName, a.formulaSearchPaths)
 	if err != nil {
-		return "", fmt.Errorf("checking formulas v2 contract for convergence wisp %q: %w", formula, err)
+		return "", fmt.Errorf("checking formulas v2 contract for convergence wisp %q: %w", formulaName, err)
 	}
 	if isGraphV2 {
-		return "", fmt.Errorf("convergence wisps do not support v2 formula %q; use a v1 formula until convergence has an explicit input convoy target", formula)
+		return "", fmt.Errorf("convergence wisps do not support v2 formula %q; use a v1 formula until convergence has an explicit input convoy target", formulaName)
 	}
-	result, err := molecule.Cook(context.Background(), a.store, formula, a.formulaSearchPaths, molecule.Options{
+	opts := molecule.Options{
 		Vars:           cookVars,
 		ParentID:       parentID,
 		IdempotencyKey: idempotencyKey,
 		DeferAssignees: deferAssignees,
-	})
+	}
+	// molecule.Cook's body, inlined only so the compiled recipe can be classified
+	// before anything is written — the same reason gc formula cook inlines it.
+	// "Convergence pours a wisp" is the name of the operation, not a guarantee
+	// about what the formula compiles to: a v1 POURED formula compiles to a
+	// molecule whose every bead is ClassWork.
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), formulaName, a.formulaSearchPaths, cookVars)
+	if err != nil {
+		return "", fmt.Errorf("compiling formula %q: %w", formulaName, err)
+	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, opts); err != nil {
+		return "", err
+	}
+	if a.relocated && recipeCoordClass(recipe) != coordclass.ClassGraph {
+		// Refuse rather than split the molecule off its parent. The convergence
+		// root is graph class and lives in a.store; a work-class molecule poured
+		// there is a strand the per-boot containment re-check will make fatal,
+		// and poured anywhere else is a child orphaned from its parent across a
+		// store boundary. Neither is recoverable by the loop itself, so this is
+		// the one place that can still say no.
+		return "", fmt.Errorf("convergence formula %q compiles to work-class beads, which cannot be poured into the relocated graph binding this convergence scope is served from; make the formula root-only (phase = \"vapor\") so it compiles to a graph-class wisp, or move the loop to a rig scope", formulaName)
+	}
+	result, err := molecule.Instantiate(context.Background(), a.store, recipe, opts)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -69,21 +69,40 @@ func (s *convergenceScope) triggerName(prefix string) string {
 // store from the current config: the city/HQ store plus every bound rig
 // store. Returns nil when no city store is available yet, in which case
 // callers leave the existing scopes untouched.
+//
+// The CITY scope takes the GRAPH-class store. A convergence root is graph class
+// — coordclass.Classify has an explicit typeConvergence arm — and so are the
+// wisps it pours. Minting them in the work store made the engine self-consistent
+// but left `gc storage migrate` to copy every root into the graph binding while
+// the engine kept reading and writing the retained work-store copies: two
+// divergent convergence ledgers, and every root minted after cutover a strand
+// the per-boot containment re-check names. That re-check is what made
+// maintainer-city boot-fatal at ~42 strands/hour (#5127's bug class).
+//
+// RIG scopes keep their rig WORK store. This is the same city-only rule
+// controlScopeTakesGraphClass (cmd_convoy_dispatch.go) already applies to
+// control beads, which are ClassGraph too, and it is forced: class routing is
+// city-keyed, so there is ONE graph binding per city. Routing rig scopes to it
+// would merge every rig's convergence loops into a single ledger keyed by
+// nothing, and the scopes would stop being scopes.
 func (cr *CityRuntime) buildConvergenceScopes() map[string]*convergenceScope {
 	cityStore := cr.cityBeadStore()
 	if cityStore == nil {
 		return nil
 	}
+	_, graphRelocated := graphClassBinding(cr.storageRoutes)
 	scopes := map[string]*convergenceScope{
-		"": cr.newConvergenceScope("", cityStore, cr.cityPath, cr.cfg.FormulaLayers.City),
+		"": cr.newConvergenceScope("", cr.graphBeadStore().Store, cr.cityPath, cr.cfg.FormulaLayers.City, graphRelocated),
 	}
 	rigStorePaths := cr.convergenceRigStorePaths()
 	for rigName, store := range cr.rigBeadStores() {
 		if store == nil {
 			continue
 		}
+		// relocated=false: a rig scope's store IS that rig's work ledger, so a
+		// work-class pour belongs there and must not be refused.
 		scopes[rigName] = cr.newConvergenceScope(
-			rigName, store, rigStorePaths[rigName], cr.cfg.FormulaLayers.SearchPaths(rigName))
+			rigName, store, rigStorePaths[rigName], cr.cfg.FormulaLayers.SearchPaths(rigName), false)
 	}
 	return scopes
 }
@@ -126,8 +145,15 @@ func (cr *CityRuntime) rebuildConvergenceHandler() {
 // newConvergenceScope wires a store adapter and convergence handler for a
 // single bead store. Each rig scope resolves formulas through that rig's
 // formula search paths so rig-local formulas are honored.
-func (cr *CityRuntime) newConvergenceScope(rig string, store beads.Store, storePath string, formulaSearchPaths []string) *convergenceScope {
-	adapter := newConvergenceStoreAdapter(store, formulaSearchPaths)
+//
+// storePath stays the scope's ROOT DIRECTORY (the city path, or the rig path)
+// even when store is a relocated class store: it is what the handler hands to
+// gate commands as their working directory, not a database locator. relocated
+// says whether store is a class binding the scope directory's own `bd` cannot
+// reach; the adapter needs it to refuse pouring work-class molecules into the
+// infrastructure binding.
+func (cr *CityRuntime) newConvergenceScope(rig string, store beads.Store, storePath string, formulaSearchPaths []string, relocated bool) *convergenceScope {
+	adapter := newConvergenceStoreAdapter(store, formulaSearchPaths, relocated)
 	return &convergenceScope{
 		rig:       rig,
 		storePath: storePath,

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -198,6 +198,62 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveAssigneeStaysAssigned(t *testin
 	}
 }
 
+// releaseOrphanedPoolAssignments takes the session-class store separately from
+// the work store, and falls back to the work store when the caller passes nil.
+// That fallback is the whole safety margin for a caller that has not been
+// threaded through the session front door yet: without it the live re-read runs
+// against a nil store, answers "no live session", and a running agent's work is
+// unassigned out from under it.
+//
+// Reaching that leg takes an empty session snapshot — with the live session in
+// the snapshot, openSessionOwnsWork skips the bead two gates earlier and the
+// re-read never happens. That is the shape a session minted after the snapshot
+// load has, which is the race the re-read exists to close.
+func TestReleaseOrphanedPoolAssignments_NilSessionsStoreFallsBackToWorkStore(t *testing.T) {
+	store := beads.NewMemStore()
+	live, err := store.Create(beads.Bead{
+		Title:    "live worker",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Labels:   []string{sessionBeadLabel},
+		Metadata: map[string]string{"session_name": "worker-mc-live"},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "routed work",
+		Assignee: live.Metadata["session_name"],
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set in_progress: %v", err)
+	}
+	work, _ = store.Get(work.ID)
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		nil, // no session-class store: the work store has to answer the liveness re-read
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		nil, // empty snapshot: the two snapshot gates miss, so the live re-read decides
+		[]beads.Bead{work},
+		nil, nil, nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("a live assignee was released with a nil sessions store, got %v; "+
+			"the nil fallback to the work store is what keeps this re-read able to see the session bead", released)
+	}
+	got, _ := store.Get(work.ID)
+	if got.Assignee != live.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want %q — the live session's work was unassigned under it", got.Assignee, live.Metadata["session_name"])
+	}
+}
+
 // emitDeadAssigneeReopenedEvents records one typed event per reopened bead,
 // carrying the dead assignee and route read off the pre-filter snapshot.
 func TestEmitDeadAssigneeReopenedEvents_EmitsTypedPayload(t *testing.T) {

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -237,7 +237,7 @@ func TestReleaseOrphanedPoolAssignments_NilSessionsStoreFallsBackToWorkStore(t *
 
 	released := releaseOrphanedPoolAssignments(
 		store,
-		nil, // no session-class store: the work store has to answer the liveness re-read
+		beads.SessionStore{}, // unset session-class store: the work store has to answer the liveness re-read
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		"",
 		nil, // empty snapshot: the two snapshot gates miss, so the live re-read decides

--- a/cmd/gc/dispatch_control_ready.go
+++ b/cmd/gc/dispatch_control_ready.go
@@ -288,16 +288,71 @@ func beadsToHookBeads(items []beads.Bead) []hookBead {
 // could not: dirty, still priming, or a bd compatibility mode that requires
 // --include-ephemeral (a tier CachedReady can't serve).
 //
-// It reads whichever ledger the control dispatcher will actually dispatch
-// against. On a scope whose graph class has been relocated to a binding, that is
-// an in-process Ready() on the binding: `bd` in dir speaks to the work store,
-// and the control beads there are the copies the migration retained, which no
-// longer receive the workflow's mutations. Enumerating those would hand the
-// drain loop a queue of ids the dispatch then no-ops on forever.
+// It reads whichever ledger(s) the control dispatcher will actually dispatch
+// against, which controlGraphBinding and controlGraphExtraLeg answer between
+// them:
+//
+//   - A CITY scope whose graph class relocated reads the binding INSTEAD of its
+//     own store. `bd` in dir speaks to the work store, and the control beads
+//     there are the copies the migration retained, which no longer receive the
+//     workflow's mutations. Enumerating those would hand the drain loop a queue
+//     of ids the dispatch then no-ops on forever.
+//   - A RIG scope on that same city reads its own store AND the binding. Its
+//     queue is split across both — its own workflows minted control beads
+//     locally, and city-scoped molecules minted theirs in the city-keyed binding
+//     and routed them here by name — so a scope-only scan answers `[]` for a
+//     queue that is not empty.
+//
+// Every leg fails LOUD, matching `gc ready`: a work query has nowhere to say
+// "this answer is short", so a leg that errors must not degrade to a partial
+// array that reads as "no work".
 func controlReadyFallbackReady(dir, cityPath string, env map[string]string, includeEphemeral bool) ([]beads.Bead, error) {
 	if binding, relocated := controlGraphBinding(cityPath, dir); relocated {
 		return controlReadyBindingReady(dir, binding, includeEphemeral)
 	}
+	scoped, err := controlReadyScopeShellReady(dir, env, includeEphemeral)
+	if err != nil {
+		return nil, err
+	}
+	binding, federated := controlGraphExtraLeg(cityPath, dir)
+	if !federated {
+		return scoped, nil
+	}
+	graphRows, err := controlReadyBindingReady(dir, binding, includeEphemeral)
+	if err != nil {
+		return nil, err
+	}
+	return mergeControlReadyLegs(scoped, graphRows), nil
+}
+
+// mergeControlReadyLegs unions the legs in order, first leg winning on a
+// duplicate id, then restores canonical ready order over the whole set.
+//
+// The global re-sort is a deliberate divergence from `gc ready`'s federation,
+// which preserves per-leg order. evaluateControlReady's inputs are documented as
+// canonical (see filterReadyByAssignee), and its assignee tiers cap at
+// workflowServeScanLimit by truncating the head of that order — so leaving the
+// graph leg's rows appended after the scope leg's would let leg membership, not
+// readiness, decide which beads survive the cap.
+func mergeControlReadyLegs(legs ...[]beads.Bead) []beads.Bead {
+	var merged []beads.Bead
+	seen := make(map[string]struct{})
+	for _, leg := range legs {
+		for _, b := range leg {
+			if _, ok := seen[b.ID]; ok {
+				continue
+			}
+			seen[b.ID] = struct{}{}
+			merged = append(merged, b)
+		}
+	}
+	beads.SortBeadsReadyOrder(merged)
+	return merged
+}
+
+// controlReadyScopeShellReady is the scope leg: the batched ready scan taken by
+// shelling `bd` in the scope directory, exactly as it always was.
+func controlReadyScopeShellReady(dir string, env map[string]string, includeEphemeral bool) ([]beads.Bead, error) {
 	query := fmt.Sprintf("bd --readonly --sandbox ready --json --exclude-type=%s --limit=%d", controlReadyExcludeType, controlReadyFallbackLimit)
 	if includeEphemeral {
 		query += " --include-ephemeral"
@@ -360,68 +415,113 @@ var controlReadyCacheRegistry = struct {
 }{byDir: make(map[string]*controlReadyCacheEntry)}
 
 type controlReadyCacheEntry struct {
-	cache    *beads.CachingStore
+	caches   []*beads.CachingStore
 	primedAt time.Time
 }
 
-// controlReadyCacheFor returns a short-lived, best-effort in-process ready
-// snapshot for dir, reusing one primed within controlReadyCacheTTL instead of
-// re-priming on every drain-loop tick. Returns nil whenever the cache cannot
-// be built or trusted; callers must treat nil as "fall back to a live bd
-// query", not as an error -- an unopenable store here is possible in scopes
-// this readiness scan does not normally run against (e.g. test fixtures with
-// no rig configured) and the sibling control-bead-processing path
+// controlReadyCachesFor returns a short-lived, best-effort in-process ready
+// snapshot per leg for dir, reusing a set primed within controlReadyCacheTTL
+// instead of re-priming on every drain-loop tick. Returns nil whenever the
+// caches cannot be built or trusted; callers must treat nil as "fall back to a
+// live bd query", not as an error -- an unopenable store here is possible in
+// scopes this readiness scan does not normally run against (e.g. test fixtures
+// with no rig configured) and the sibling control-bead-processing path
 // (runControlDispatcherInStore) would already be failing loudly if it were a
 // real production gap.
 //
-// The snapshot is taken over the SAME store runControlDispatcherWithStoreAndConfig
-// dispatches against: controlGraphStore resolves the scope's graph class, so the
-// queue and the mutation are one ledger. They must not diverge. A queue drawn
-// from the work store while the dispatch closes the binding's copy re-offers the
-// same id every tick -- ProcessControl no-ops on the already-closed copy, and
-// drainWorkflowServeWork counts a no-op as progress -- so the drain loop never
-// returns; and the beads the dispatch CREATES (fanout fragments, retry attempts,
-// drain units) would land in a ledger the scan never reads, stalling the
-// workflow at its first hop.
+// The snapshots are taken over the SAME ledgers
+// runControlDispatcherWithStoreAndConfig dispatches against —
+// controlReadyCacheSources applies the routing rule controlBeadLedger resolves
+// against — so the queue and the mutation are the same set. They must not
+// diverge. A queue drawn from the work store while the dispatch closes the
+// binding's copy re-offers the same id every tick -- ProcessControl no-ops on
+// the already-closed copy, and drainWorkflowServeWork counts a no-op as progress
+// -- so the drain loop never returns; and the beads the dispatch CREATES (fanout
+// fragments, retry attempts, drain units) would land in a ledger the scan never
+// reads, stalling the workflow at its first hop.
+//
+// A leg that fails to prime discards the whole set. A partial set would be a
+// short queue that reads as a complete one, which is the same silent-underread
+// shape as scanning the wrong ledger entirely.
 //
 // Known limitation (low-impact, not fixed here): concurrent callers racing a
 // stale/missing entry for the same dir each independently open+prime their
-// own store rather than coalescing behind one in-flight prime -- last writer
+// own stores rather than coalescing behind one in-flight prime -- last writer
 // into controlReadyCacheRegistry wins. Same class of gap already accepted
 // for CachingStore.List/Ready cache-miss reads; worth revisiting with a
 // singleflight if overlapping invocations against the same city/dir become
 // common (e.g. a restart handoff window), but the control-dispatcher serve
-// loop's typical call pattern is sequential-per-tick per dir.
-func controlReadyCacheFor(dir, cityPath string, cfg *config.City) *beads.CachingStore {
+// loop's typical call pattern is sequential-per-tick per dir. Note the entries
+// are keyed by scope dir, so on a split city every rig dispatcher primes the
+// shared city binding independently (ga-n6gnr).
+func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.CachingStore {
 	controlReadyCacheRegistry.mu.Lock()
 	entry, ok := controlReadyCacheRegistry.byDir[dir]
 	fresh := ok && time.Since(entry.primedAt) < controlReadyCacheTTL
 	controlReadyCacheRegistry.mu.Unlock()
 	if fresh {
-		return entry.cache
+		return entry.caches
 	}
 
-	// The snapshot must be taken over the store the dispatch will mutate. When
-	// the scope's graph class is relocated that is the binding, and the scope
-	// store is not opened at all — it would be a bd process this scan never reads.
-	source, relocated := controlGraphBinding(cityPath, dir)
-	if !relocated {
-		opened, err := openControlStoreAtForCity(dir, cityPath, cfg)
-		if err != nil {
+	sources, err := controlReadyCacheSources(dir, cityPath, cfg)
+	if err != nil {
+		return nil
+	}
+	caches := make([]*beads.CachingStore, 0, len(sources))
+	for _, source := range sources {
+		cs := beads.NewCachingStore(source, nil)
+		if err := cs.PrimeActive(); err != nil {
+			log.Printf("control-ready cache: pre-prime failed for %s: %v (falling back to a live bd query)", dir, err)
 			return nil
 		}
-		source = opened
-	}
-	cs := beads.NewCachingStore(source, nil)
-	if err := cs.PrimeActive(); err != nil {
-		log.Printf("control-ready cache: pre-prime failed for %s: %v (falling back to a live bd query)", dir, err)
-		return nil
+		caches = append(caches, cs)
 	}
 
 	controlReadyCacheRegistry.mu.Lock()
-	controlReadyCacheRegistry.byDir[dir] = &controlReadyCacheEntry{cache: cs, primedAt: time.Now()}
+	controlReadyCacheRegistry.byDir[dir] = &controlReadyCacheEntry{caches: caches, primedAt: time.Now()}
 	controlReadyCacheRegistry.mu.Unlock()
-	return cs
+	return caches
+}
+
+// controlReadyCacheSources returns the ordered ledgers to snapshot, applying the
+// same routing rule as controlReadyFallbackReady so the cached answer and the
+// fallback answer cannot disagree about which stores hold this scope's queue.
+func controlReadyCacheSources(dir, cityPath string, cfg *config.City) ([]beads.Store, error) {
+	// A relocated CITY scope does not open its scope store at all — that would
+	// be a bd process this scan never reads.
+	if binding, relocated := controlGraphBinding(cityPath, dir); relocated {
+		return []beads.Store{binding}, nil
+	}
+	scoped, err := openControlStoreAtForCity(dir, cityPath, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if binding, federated := controlGraphExtraLeg(cityPath, dir); federated {
+		return []beads.Store{scoped, binding}, nil
+	}
+	return []beads.Store{scoped}, nil
+}
+
+// cachedControlReadyUnion merges the cached ready sets, requiring EVERY leg to
+// answer from cache. A leg that is dirty or still priming sends the whole scan
+// to the fallback rather than to a short answer assembled from the legs that
+// happened to be warm.
+func cachedControlReadyUnion(caches []*beads.CachingStore) ([]beads.Bead, bool) {
+	if len(caches) == 0 {
+		return nil, false
+	}
+	if len(caches) == 1 {
+		return caches[0].CachedReady()
+	}
+	legs := make([][]beads.Bead, 0, len(caches))
+	for _, cache := range caches {
+		ready, ok := cache.CachedReady()
+		if !ok {
+			return nil, false
+		}
+		legs = append(legs, ready)
+	}
+	return mergeControlReadyLegs(legs...), true
 }
 
 // tryControlReadyFromCacheOrFallback answers a control-dispatcher readiness
@@ -443,8 +543,8 @@ func tryControlReadyFromCacheOrFallback(workQuery, dir string, env map[string]st
 	envList := mergeRuntimeEnv(os.Environ(), env)
 
 	if !parsed.includeEphemeral {
-		if cache := controlReadyCacheFor(dir, cityPath, cfg); cache != nil {
-			if ready, ok := cache.CachedReady(); ok {
+		if caches := controlReadyCachesFor(dir, cityPath, cfg); len(caches) > 0 {
+			if ready, ok := cachedControlReadyUnion(caches); ok {
 				return beadsToHookBeads(evaluateControlReady(ready, parsed, envList)), true, nil
 			}
 		}

--- a/cmd/gc/doctor_session_model.go
+++ b/cmd/gc/doctor_session_model.go
@@ -35,7 +35,7 @@ func (c *sessionModelDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResul
 		r.Message = fmt.Sprintf("session model diagnostics skipped: %v", err)
 		return r
 	}
-	all, err := loadSessionModelDoctorBeads(store)
+	all, err := loadSessionModelDoctorBeads(store, cliSessionStore(store, c.cfg, c.cityPath))
 	if err != nil {
 		r.Status = doctor.StatusWarning
 		r.Message = fmt.Sprintf("session model diagnostics skipped: %v", err)
@@ -124,7 +124,14 @@ func (c *sessionModelDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResul
 	return r
 }
 
-func loadSessionModelDoctorBeads(store beads.Store) ([]beads.Bead, error) {
+// loadSessionModelDoctorBeads reads the two halves of the session-ownership
+// diagnostic from two coordination classes: the session union comes from
+// sessStore (session class) and the open/in-progress work legs from workStore
+// (work class). They are the same store until a [beads.classes.sessions]
+// relocation splits them, at which point reading both from the work store made
+// the session union come back empty and the check report "session ownership is
+// consistent" on a city whose session model was broken.
+func loadSessionModelDoctorBeads(workStore, sessStore beads.Store) ([]beads.Bead, error) {
 	type listStep struct {
 		name  string
 		query beads.ListQuery
@@ -153,7 +160,7 @@ func loadSessionModelDoctorBeads(store beads.Store) ([]beads.Bead, error) {
 		{Type: session.BeadType, IncludeClosed: true, Sort: beads.SortCreatedAsc},
 		{Label: session.LabelSession, IncludeClosed: true, Sort: beads.SortCreatedAsc},
 	} {
-		items, err := store.List(q)
+		items, err := sessStore.List(q)
 		if err != nil {
 			return nil, fmt.Errorf("session beads: %w", err)
 		}
@@ -170,7 +177,7 @@ func loadSessionModelDoctorBeads(store beads.Store) ([]beads.Bead, error) {
 		return sessionUnion[i].CreatedAt.Before(sessionUnion[j].CreatedAt)
 	})
 	for _, step := range steps {
-		items, err := store.List(step.query)
+		items, err := workStore.List(step.query)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", step.name, err)
 		}

--- a/cmd/gc/doctor_session_model_test.go
+++ b/cmd/gc/doctor_session_model_test.go
@@ -35,7 +35,7 @@ func TestLoadSessionModelDoctorBeadsAvoidsBroadOpenWorkScan(t *testing.T) {
 		t.Fatalf("Update(session closed): %v", err)
 	}
 
-	got, err := loadSessionModelDoctorBeads(store)
+	got, err := loadSessionModelDoctorBeads(store, store)
 	if err != nil {
 		t.Fatalf("loadSessionModelDoctorBeads: %v", err)
 	}
@@ -56,6 +56,45 @@ func TestLoadSessionModelDoctorBeadsAvoidsBroadOpenWorkScan(t *testing.T) {
 	}
 	if !store.sawStatus["open"] || !store.sawStatus["in_progress"] {
 		t.Fatalf("status queries = %+v, want open and in_progress", store.sawStatus)
+	}
+}
+
+// TestLoadSessionModelDoctorBeadsReadsSessionUnionFromSessionStore pins the
+// two-class split: under a [beads.classes.sessions] relocation the session beads
+// live in a different store from the work beads. Reading both legs from the work
+// store returned an empty session union and the check reported "session ownership
+// is consistent" on a city whose session model was broken.
+func TestLoadSessionModelDoctorBeadsReadsSessionUnionFromSessionStore(t *testing.T) {
+	workStore := beads.NewMemStore()
+	sessStore := beads.NewMemStore()
+
+	work, err := workStore.Create(beads.Bead{Title: "open work", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(open work): %v", err)
+	}
+	sessionBead, err := sessStore.Create(beads.Bead{
+		Title:  "session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	got, err := loadSessionModelDoctorBeads(workStore, sessStore)
+	if err != nil {
+		t.Fatalf("loadSessionModelDoctorBeads: %v", err)
+	}
+	ids := make(map[string]bool, len(got))
+	for _, bead := range got {
+		ids[bead.ID] = true
+	}
+	if !ids[sessionBead.ID] {
+		t.Fatalf("session bead %s missing from relocated-sessions read; got IDs %+v", sessionBead.ID, ids)
+	}
+	if !ids[work.ID] {
+		t.Fatalf("work bead %s missing; got IDs %+v", work.ID, ids)
 	}
 }
 

--- a/cmd/gc/doctor_work_option_metadata.go
+++ b/cmd/gc/doctor_work_option_metadata.go
@@ -80,6 +80,14 @@ func (c *workOptionMetadataMigrationCheck) collect() (targets []workOptionMigrat
 			scopes = append(scopes, struct{ label, path string }{"rig " + rig.Name, rig.Path})
 		}
 	}
+	// The session-cleanup leg below is session class, not work class, and it
+	// WRITES. Under a [beads.classes.sessions] relocation every scope routes to
+	// the one relocated sessions store, so the leg would mint a duplicate target
+	// — and a duplicate SetMetadataBatch — once per rig; dedupe by bead id in
+	// that case only. Without a relocation each scope is a distinct store and
+	// owns its own beads, so no dedupe.
+	sessionsRelocated := cliSessionsRelocated(c.cityPath)
+	seenSessionBead := map[string]bool{}
 	for _, sc := range scopes {
 		if c.newStore == nil || strings.TrimSpace(sc.path) == "" {
 			continue
@@ -106,7 +114,8 @@ func (c *workOptionMetadataMigrationCheck) collect() (targets []workOptionMigrat
 				migrations: migrations,
 			})
 		}
-		sessions, err := loadSessionBeads(store)
+		sessStore := cliSessionStore(store, c.cfg, c.cityPath)
+		sessions, err := loadSessionBeads(sessStore)
 		if err != nil {
 			skipped = append(skipped, fmt.Sprintf("%s skipped: listing session beads: %v", sc.label, err))
 			continue
@@ -116,9 +125,15 @@ func (c *workOptionMetadataMigrationCheck) collect() (targets []workOptionMigrat
 			if cleanup == nil {
 				continue
 			}
+			if sessionsRelocated {
+				if seenSessionBead[b.ID] {
+					continue
+				}
+				seenSessionBead[b.ID] = true
+			}
 			targets = append(targets, workOptionMigrationTarget{
 				label:          sc.label,
-				store:          store,
+				store:          sessStore,
 				beadID:         b.ID,
 				sessionCleanup: cleanup,
 			})

--- a/cmd/gc/frontdoor_di_guard_test.go
+++ b/cmd/gc/frontdoor_di_guard_test.go
@@ -358,6 +358,18 @@ func TestMetadataInfoOnlyFilesStayOnInfoSnapshot(t *testing.T) {
 // so it is intentionally absent from the routed-files list. The positive cliSessionStore(
 // tripwire protects the routed delivery arm; as a non-front-door router this guard is
 // a regression canary for the file, not a completeness proof.
+//
+// cmd_mail.go routes at its store-opening ROOTS rather than per-read, because every
+// store access in its identity/target resolver family is session-class: session-ID
+// resolution, the gc:session enumeration behind named-target matching, and mailbox
+// identity. The five roots — resolveMailTargetsForCommand,
+// resolveDefaultMailTargetsForCommand, resolveRawMailTargetForStorelessProvider,
+// cmdMailSendJSON, cmdMailReplyJSON — derive cliSessionStore(store, cfg, cityPath) and
+// hand it down; the whole resolver family therefore names its parameter sessStore and
+// does NO routing of its own, so a relocation is applied exactly once per command.
+// Mail MESSAGES are a different coordination class and never travel through these
+// resolvers — they go through mail.Provider. The two out-of-file callers
+// (cmd_handoff.go, prime_auto_handoff_inject.go) already hold a routed sessStore.
 var sessionRelocationRoutedFiles = []string{
 	"cmd_session_wake.go",
 	"cmd_session_pin.go",
@@ -381,6 +393,7 @@ var sessionRelocationRoutedFiles = []string{
 	"cmd_runtime_heartbeat.go",
 	"cmd_wait.go",
 	"cmd_nudge.go",
+	"cmd_mail.go",
 }
 
 // sessionRelocationForbidden are the UNROUTED session-front-door constructions a

--- a/cmd/gc/nudge_mail_sweep_test.go
+++ b/cmd/gc/nudge_mail_sweep_test.go
@@ -453,7 +453,7 @@ func TestCmdOrderSweepNudgeMailRun_NothingToClose(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	if !strings.Contains(stdout.String(), "nothing to close") {
 		t.Errorf("expected 'nothing to close' message, got: %q", stdout.String())
 	}
@@ -468,7 +468,7 @@ func TestCmdOrderSweepNudgeMailRun_NormalOutput(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	out := stdout.String()
 	if !strings.Contains(out, "nudge-mail-sweep: closed") {
 		t.Errorf("expected 'nudge-mail-sweep: closed' in output, got: %q", out)
@@ -491,7 +491,7 @@ func TestCmdOrderSweepNudgeMailRun_CapReachedMessage(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	if !strings.Contains(stdout.String(), "cap reached") {
 		t.Errorf("expected 'cap reached' in output when budget is full, got: %q", stdout.String())
 	}
@@ -508,7 +508,7 @@ func TestCmdOrderSweepNudgeMailRun_PerBeadErrorPrintedToStderr(t *testing.T) {
 	store := &nudgeSweepFailingClose{MemStore: mem, failIDs: map[string]bool{failID: true}}
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	if !strings.Contains(stderr.String(), "ERROR") {
 		t.Errorf("expected ERROR line on stderr for failing bead, got: %q", stderr.String())
 	}
@@ -523,7 +523,7 @@ func TestCmdOrderSweepNudgeMailRun_QuietSuppressesOutput(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, true, &stdout, &stderr)
+	cmdOrderSweepNudgeMailRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, true, &stdout, &stderr)
 	if stdout.String() != "" {
 		t.Errorf("expected empty stdout with --quiet, got: %q", stdout.String())
 	}
@@ -534,7 +534,7 @@ func TestCmdOrderSweepNudgeMailDryRun_NothingToClose(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailDryRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	if !strings.Contains(stdout.String(), "nothing to close") {
 		t.Errorf("expected 'nothing to close' for empty store dry-run, got: %q", stdout.String())
 	}
@@ -549,7 +549,7 @@ func TestCmdOrderSweepNudgeMailDryRun_ShowsWouldClose(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailDryRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	out := stdout.String()
 	if !strings.HasPrefix(out, "[DRY RUN]") {
 		t.Errorf("expected '[DRY RUN]' prefix, got: %q", out)
@@ -571,7 +571,7 @@ func TestCmdOrderSweepNudgeMailDryRun_NoBeadsClosed(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
 	var stdout, stderr bytes.Buffer
-	cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	cmdOrderSweepNudgeMailDryRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 
 	// The bead should remain open.
 	open, _ := store.ListOpen()
@@ -597,7 +597,7 @@ func TestCmdOrderSweepNudgeMailDryRun_ListErrorReturnsNonZero(t *testing.T) {
 	store := &nudgeSweepFailingList{MemStore: beads.NewMemStoreFrom(100, nil, nil)}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepNudgeMailDryRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	code := cmdOrderSweepNudgeMailDryRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	if code == 0 {
 		t.Errorf("expected non-zero exit code on list error, got %d", code)
 	}
@@ -617,7 +617,7 @@ func TestCmdOrderSweepNudgeMailRun_ListErrorReturnsNonZero(t *testing.T) {
 	store := &nudgeSweepFailingList{MemStore: beads.NewMemStoreFrom(100, nil, nil)}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepNudgeMailRun(store, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
+	code := cmdOrderSweepNudgeMailRun(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, nudgeMailSweepDefaultMailTTL, false, &stdout, &stderr)
 	if code == 0 {
 		t.Errorf("expected non-zero exit code on list error, got %d", code)
 	}

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads/splittest"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/session"
@@ -108,6 +110,7 @@ func TestSplitTopologyConformance(t *testing.T) {
 	t.Run("I14-projection-coherence", func(t *testing.T) { forEachTopology(t, conformanceProjectionCoherence) })
 	t.Run("I15-work-query-federation", func(t *testing.T) { forEachTopologyWithRig(t, conformanceWorkQueryFederation) })
 	t.Run("I16-federated-read-tier", func(t *testing.T) { forEachTopology(t, conformanceFederatedReadTier) })
+	t.Run("I17-convergence-scope-residence", func(t *testing.T) { forEachTopologyWithRig(t, conformanceConvergenceResidence) })
 }
 
 // conformanceReadyFederation (I1) guards the "no work" fail-open: a worker
@@ -362,6 +365,252 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 	if reloaded.Status != "in_progress" || reloaded.Assignee != sess.ID {
 		t.Errorf("live holder's wisp = status %q assignee %q, want in_progress/%s (claim wrongfully released — the orphan-release TOCTOU class)", reloaded.Status, reloaded.Assignee, sess.ID)
 	}
+}
+
+// conformanceConvergenceResidence (I17) pins which store each convergence scope
+// is served from, and what that scope is allowed to pour into it.
+//
+// A convergence root is graph class — coordclass.Classify has an explicit
+// typeConvergence arm — and so are the wisps the loop pours. The city scope
+// minted them through the CITY store anyway, which is self-consistent right up
+// until the city splits: `gc storage migrate` copies every root into the graph
+// binding, the engine keeps reading and writing the retained work-store copies,
+// and the city then has two divergent convergence ledgers with every root minted
+// after cutover a strand the per-boot containment re-check names. That re-check
+// is what made maintainer-city boot-fatal at ~42 strands/hour, and it is #5127's
+// bug class exactly: infrastructure beads born in the work store on a split city.
+//
+// RIG scopes keeping their rig work store is not a symmetry violation. Class
+// routing is CITY-keyed — one graph binding per city, not one per rig — so
+// routing rig scopes to it would merge every rig's loops into a single ledger
+// keyed by nothing, and the scopes would stop being scopes. It is the same
+// city-only rule controlScopeTakesGraphClass already applies to control beads,
+// which are ClassGraph too.
+//
+// The pour arm is what that asymmetry costs. "Convergence pours a wisp" names
+// the operation, not what the formula compiles to: a v1 POURED formula compiles
+// to a molecule whose every bead is ClassWork, and work does not belong in the
+// infrastructure binding. On a relocated city scope that pour must be REFUSED,
+// because landing it strands work-class beads in the binding and landing it
+// anywhere else orphans children from their parent across a store boundary —
+// neither recoverable by the loop itself. Everywhere the store IS the scope's
+// own work ledger (every rig scope, and the city scope of a single-store city)
+// the identical pour must still succeed, or the fix broke every legacy loop.
+func conformanceConvergenceResidence(t *testing.T, e splitEnv) {
+	e.cfg.FormulaLayers = config.FormulaLayers{City: []string{convergenceResidenceFormulaDir(t)}}
+	cr := &CityRuntime{
+		cityPath:            e.cityPath,
+		cityName:            e.cfg.Workspace.Name,
+		cfg:                 e.cfg,
+		rec:                 events.Discard,
+		storageRoutes:       e.routes,
+		standaloneCityStore: e.work,
+		standaloneRigStores: e.rigStores,
+	}
+	scopes := cr.buildConvergenceScopes()
+	city, rigScope := scopes[""], scopes[e.rigName]
+	if city == nil {
+		t.Fatal("buildConvergenceScopes returned no city scope")
+	}
+	if rigScope == nil {
+		t.Fatalf("buildConvergenceScopes returned no scope for rig %q; the rig arm of this invariant would be vacuous", e.rigName)
+	}
+
+	if !sameStorePtr(city.store, e.graphStore()) {
+		t.Errorf("the city convergence scope is not served from the graph-class store; on a split city every root it mints is a strand the per-boot containment re-check makes boot-fatal")
+	}
+	if city.adapter.relocated != e.split {
+		t.Errorf("city scope adapter relocated = %v, want %v; the adapter cannot refuse a work-class pour it does not know it would be stranding", city.adapter.relocated, e.split)
+	}
+	// storePath stays the scope's ROOT DIRECTORY even when the store moved: it is
+	// the working directory the handler hands to gate commands, not a database
+	// locator, and following the store into the binding would run every gate in
+	// the wrong tree.
+	if city.storePath != e.cityPath {
+		t.Errorf("city scope storePath = %q, want the city root %q — it is the gate command's cwd, not a store locator", city.storePath, e.cityPath)
+	}
+
+	if !sameStorePtr(rigScope.store, e.rig) {
+		t.Errorf("the %q convergence scope is not served from that rig's work store; class routing is city-keyed, so pointing rig scopes at the one graph binding merges every rig's loops into a single ledger", e.rigName)
+	}
+	if rigScope.adapter.relocated {
+		t.Error("rig scope adapter reports relocated=true; a rig scope's store IS its work ledger, so a work-class pour belongs there and must not be refused")
+	}
+	if want := resolveStoreScopeRoot(e.cityPath, e.cfg.Rigs[0].Path); rigScope.storePath != want {
+		t.Errorf("rig scope storePath = %q, want the rig root %q", rigScope.storePath, want)
+	}
+
+	// A root created through the scope's own adapter — the call the engine makes
+	// — must be resident in that scope's store and in NO other leg. Two ledgers
+	// holding the same loop is the divergence, not a failed write.
+	cityRoot := convergenceRootIn(t, city, "city convergence loop")
+	assertConvergenceRootResident(t, e, cityRoot, e.graphStore(), "city")
+	rigRoot := convergenceRootIn(t, rigScope, "rig convergence loop")
+	assertConvergenceRootResident(t, e, rigRoot, e.rig, "rig "+e.rigName)
+
+	// vapor compiles root-only, so its one bead carries gc.kind=wisp and is graph
+	// class: it belongs wherever the scope is served from, on both topologies.
+	assertConvergencePours(t, city, cityRoot, convergenceVaporFormula, 1, e.graphStore(), "city")
+	assertConvergencePours(t, rigScope, rigRoot, convergenceVaporFormula, 1, e.rig, "rig "+e.rigName)
+
+	// poured compiles to a molecule root plus a child step, every bead ClassWork.
+	// A scope serving its own work ledger must still run it — that is every rig
+	// scope, and the city scope of a single-store city.
+	assertConvergencePours(t, rigScope, rigRoot, convergencePouredFormula, 2, e.rig, "rig "+e.rigName)
+	if !e.split {
+		assertConvergencePours(t, city, cityRoot, convergencePouredFormula, 2, e.work, "city")
+		return
+	}
+	assertConvergenceRefusesWorkClassPour(t, e, city, cityRoot)
+}
+
+// convergenceRootIn creates a convergence loop root through a scope's own
+// adapter and pins that it classifies as graph class — without which every
+// residence assertion built on it is about nothing.
+func convergenceRootIn(t *testing.T, scope *convergenceScope, title string) beads.Bead {
+	t.Helper()
+	id, err := scope.adapter.CreateConvergenceBead(title)
+	if err != nil {
+		t.Fatalf("creating a convergence root through the %q scope: %v", scope.rig, err)
+	}
+	root, err := scope.store.Get(id)
+	if err != nil {
+		t.Fatalf("convergence root %s is not readable from the store its own scope just wrote it to: %v", id, err)
+	}
+	if got := coordclass.Classify(root); got != coordclass.ClassGraph {
+		t.Fatalf("convergence root %s classifies as %v, want ClassGraph; the residence assertions below it would be vacuous", id, got)
+	}
+	return root
+}
+
+// assertConvergenceRootResident pins that a convergence root lives in want and
+// leaves no copy in any other leg of the fixture.
+func assertConvergenceRootResident(t *testing.T, e splitEnv, root beads.Bead, want beads.Store, scopeName string) {
+	t.Helper()
+	if _, err := want.Get(root.ID); err != nil {
+		t.Fatalf("the %s scope's convergence root %s is not resident in the store that scope is served from: %v", scopeName, root.ID, err)
+	}
+	legs := map[string]beads.Store{"work": e.work, "rig": e.rig}
+	if e.split {
+		legs["class"] = e.class
+	}
+	for legName, leg := range legs {
+		if sameStorePtr(leg, want) {
+			continue
+		}
+		if _, err := leg.Get(root.ID); !errors.Is(err, beads.ErrNotFound) {
+			t.Errorf("the %s scope's convergence root %s also resolves in the %s store (err=%v); a loop with a copy in two ledgers is what the containment re-check reports as a strand", scopeName, root.ID, legName, err)
+		}
+	}
+}
+
+// assertConvergencePours pins that a scope can instantiate formulaName into the
+// store it was handed, that the result is parented on the loop root, and that
+// re-pouring under the same idempotency key returns the same bead — which is
+// also how the crash-retry lookup is pinned to the store the pour wrote to.
+func assertConvergencePours(t *testing.T, scope *convergenceScope, parent beads.Bead, formulaName string, iter int, want beads.Store, scopeName string) {
+	t.Helper()
+	key := fmt.Sprintf("converge:%s:iter:%d", parent.ID, iter)
+	id, err := scope.adapter.PourWisp(parent.ID, formulaName, key, nil, "")
+	if err != nil {
+		t.Fatalf("the %s scope could not pour %q: %v", scopeName, formulaName, err)
+	}
+	poured, err := want.Get(id)
+	if err != nil {
+		t.Fatalf("the %s scope poured %q as %s, which is not resident in the store that scope is served from: %v", scopeName, formulaName, id, err)
+	}
+	if poured.ParentID != parent.ID {
+		t.Errorf("the %s scope poured %s with parent %q, want the convergence root %s", scopeName, id, poured.ParentID, parent.ID)
+	}
+	again, err := scope.adapter.PourWisp(parent.ID, formulaName, key, nil, "")
+	if err != nil {
+		t.Fatalf("the %s scope could not re-pour %q under the same idempotency key: %v", scopeName, formulaName, err)
+	}
+	if again != id {
+		t.Errorf("the %s scope re-poured %q as %s under the key that already produced %s; the idempotency lookup is reading a different store than the pour writes to, so every crash-retry pours a second molecule", scopeName, formulaName, again, id)
+	}
+}
+
+// assertConvergenceRefusesWorkClassPour is the split-only arm: a work-class
+// formula must be refused by a relocated city scope, and refused BEFORE
+// anything is written. A partial molecule in the binding is the same strand
+// minus the error.
+func assertConvergenceRefusesWorkClassPour(t *testing.T, e splitEnv, scope *convergenceScope, parent beads.Bead) {
+	t.Helper()
+	beforeClass, beforeWork := countBeads(t, scope.store), countBeads(t, e.work)
+	id, err := scope.adapter.PourWisp(parent.ID, convergencePouredFormula, fmt.Sprintf("converge:%s:iter:2", parent.ID), nil, "")
+	if err == nil {
+		t.Fatalf("the relocated city scope poured work-class formula %q as %s into the graph binding; those beads are exactly the strand the per-boot containment re-check makes boot-fatal", convergencePouredFormula, id)
+	}
+	if !strings.Contains(err.Error(), "work-class") {
+		t.Errorf("refusal for %q = %v, want a message naming the work-class compile and the remedy", convergencePouredFormula, err)
+	}
+	if after := countBeads(t, scope.store); after != beforeClass {
+		t.Errorf("the refused pour still wrote to the graph binding: %d -> %d beads", beforeClass, after)
+	}
+	if after := countBeads(t, e.work); after != beforeWork {
+		t.Errorf("the refused pour fell back to the WORK store: %d -> %d beads. Pouring elsewhere orphans the molecule from the convergence root it is parented on, across a store boundary", beforeWork, after)
+	}
+}
+
+// Formula names for I17's pour arm.
+const (
+	convergenceVaporFormula  = "conv-residence-vapor"
+	convergencePouredFormula = "conv-residence-poured"
+)
+
+// convergenceResidenceFormulaDir writes the two formula shapes I17's pour arm
+// discriminates between, rather than borrowing a shared fixture whose phase
+// could change under it:
+//
+//   - vapor: phase = "vapor" with no pour, which compile.go turns into a
+//     RootOnly recipe whose single root is a task carrying gc.kind=wisp — graph
+//     class.
+//   - poured: a plain v1 formula, whose root is a "molecule" container and whose
+//     step is a bare task — every bead ClassWork.
+//
+// The compile outcome is ASSERTED here, not assumed. If a compiler change made
+// both shapes graph class, the refusal arm would pass while testing nothing.
+func convergenceResidenceFormulaDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(body), 0o644); err != nil {
+			t.Fatalf("writing formula %s: %v", name, err)
+		}
+	}
+	write(convergenceVaporFormula, fmt.Sprintf("formula = %q\nversion = 1\nphase = \"vapor\"\n\n[[steps]]\nid = \"probe\"\ntitle = \"Probe\"\n", convergenceVaporFormula))
+	write(convergencePouredFormula, fmt.Sprintf("formula = %q\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n", convergencePouredFormula))
+
+	for _, tt := range []struct {
+		name string
+		want coordclass.Class
+	}{
+		{convergenceVaporFormula, coordclass.ClassGraph},
+		{convergencePouredFormula, coordclass.ClassWork},
+	} {
+		recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), tt.name, []string{dir}, nil)
+		if err != nil {
+			t.Fatalf("compiling formula %s: %v", tt.name, err)
+		}
+		if got := recipeCoordClass(recipe); got != tt.want {
+			t.Fatalf("formula %s compiles to %v, want %v; I17's pour arm discriminates on exactly this and would be vacuous", tt.name, got, tt.want)
+		}
+	}
+	return dir
+}
+
+// countBeads is the total-row oracle for the "nothing was written" half of a
+// refusal. countGraphClassBeads cannot serve it: the molecule a work-class pour
+// would leave behind classifies as ClassWork and would not be counted.
+func countBeads(t *testing.T, store beads.Store) int {
+	t.Helper()
+	list, err := store.List(beads.ListQuery{IncludeClosed: true, TierMode: beads.TierBoth, AllowScan: true})
+	if err != nil {
+		t.Fatalf("listing beads for the total-row count: %v", err)
+	}
+	return len(list)
 }
 
 // conformanceByIDWriteResidence (I3) guards the by-id WRITE-residence class,

--- a/cmd/gc/upstream_wiring_test.go
+++ b/cmd/gc/upstream_wiring_test.go
@@ -90,6 +90,17 @@ func TestResolveTemplateRendersAbstractUpstreamPerHarness(t *testing.T) {
 		{"codex", config.UpstreamEnvBinding{BaseURL: "OPENAI_BASE_URL", APIKey: "OPENAI_API_KEY"}, "OPENAI_BASE_URL", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"},
 	} {
 		t.Run(tc.harness, func(t *testing.T) {
+			// The otherKey assertion below is about what the UPSTREAM BINDING
+			// renders, but tp.Env is the merged session env, and
+			// processenv.ProviderProcessPassthroughEnv deliberately forwards
+			// every IsProviderCredentialEnv key it finds in os.Environ() so an
+			// agent can reach whatever providers the controller can. On a
+			// developer or fleet box that exports the other harness's key, that
+			// forwarding — not the binding — puts otherKey in the map. Pin it
+			// empty: the sweep skips empty values, so the only thing left that
+			// can write otherKey is the binding under test.
+			t.Setenv(tc.otherKey, "")
+
 			params := upstreamTestParams(t, city)
 			params.providers = map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none", UpstreamEnv: tc.binding}}
 			agent := &config.Agent{Name: "runner", Upstream: "bedrock"}

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -68,11 +68,15 @@ cmd/gc/cmd_convoy.go	resolveOwningStoreDir	a:openConvoyStores	1
 cmd/gc/cmd_convoy_dispatch.go	cmdWorkflowDelete	a:openConvoyStores	1
 cmd/gc/cmd_convoy_dispatch.go	collectSourceWorkflowMatches	a:openSourceWorkflowStores	1
 cmd/gc/cmd_convoy_dispatch.go	controlGraphBinding	b:graphClassBinding	1
+cmd/gc/cmd_convoy_dispatch.go	controlGraphExtraLeg	b:graphClassBinding	1
 cmd/gc/cmd_convoy_dispatch.go	findUniqueBeadAcrossStoresView	a:openSourceWorkflowStores	1
 cmd/gc/cmd_convoy_dispatch.go	openSourceWorkflowStores	a:openSourceWorkflowStores	1
 cmd/gc/cmd_convoy_dispatch.go	runControlDispatcherWithStoreAndConfig	c:beads.Store-literal	1
 cmd/gc/cmd_wait.go	loadWaitDependencyBead	a:convoyStoreCandidates	1
 cmd/gc/convergence_tick.go	buildConvergenceScopes	a:rigBeadStores	1
+cmd/gc/convergence_tick.go	buildConvergenceScopes	b:graphClassBinding	1
+cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	ast:returns-store-list	1
+cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	c:beads.Store-literal	3
 cmd/gc/doctor_order_tracking_retention.go	Run	c:beads.Store-literal	1
 cmd/gc/formula_cook_attach_class.go	attachGraftClassRefusal	b:graphClassBinding	1
 cmd/gc/order_dispatch.go	gateStoresFor	ast:returns-store-list	1


### PR DESCRIPTION
## What

Four fixes from a sweep of split-store (infra-class) misrouting in `cmd/gc`.
On a city that has relocated a coordination class, several call sites still
read or wrote through the work ledger, so relocated ids simply looked absent.
Single-store cities were never affected, which is why these survived: the
identity branch of the class resolver makes every one of them a no-op there.

| commit | site | symptom on a split city |
| --- | --- | --- |
| `795b2fc` | nudges, mail identity, doctor session reads | session-class ids read from the work ledger |
| `cd83850` | orphan-release liveness | liveness judged against the wrong store |
| `57a568f` | convergence roots | `gc converge status` reports a clean city while live roots are stranded |
| `1b3057f` | (test only) per-harness upstream test | fails on any machine that exports a real provider key |

## The convergence fix is a hybrid, deliberately

Convergence roots are `Type: "convergence"`, which `coordclass` maps to
`ClassGraph`. The obvious fix — route all convergence traffic to the graph
binding — is wrong, because **class routing is city-keyed: there is exactly one
graph binding per city.** Sending rig scopes through it would merge every rig's
convergence loops into a ledger keyed by nothing.

So:

- the **city** convergence scope takes the graph binding, on *both* the
  controller path (`buildConvergenceScopes`) and the CLI path
  (`convergeCityScopeStore`, covering `gc converge` and the separate
  `--all-rigs` city leg);
- every **rig** scope stays on its own work ledger.

This is the same rule `controlScopeTakesGraphClass` already applies to control
beads.

A relocated scope must also refuse work-class pours, since a formula compiling
to molecule steps cannot live in the graph binding. `pourWisp` inlines
`molecule.Cook`'s body so the recipe is classified *before* anything is
written, then errors naming the two ways out (make the formula root-only via
`phase = "vapor"`, or move the loop to a rig scope). The inlining is faithful:
`Cook` nil-guards `opts.Vars`, and `pourWisp` always passes a non-nil map.

## Migration

No migration step is needed in the documented order. `readInfraSnapshot`
already copies every non-`ClassWork` bead, so a city that runs
`gc infra-class migrate` and *then* takes this binary carries its live
convergence roots across the re-point intact. The reverse order (upgrade
before migrate) can strand work-store roots; that pathological case is
tracked separately.

## Tests

- `I17-convergence-scope-residence` in the two-topology conformance fixture,
  which runs every invariant against the same city built both single-store and
  split.
- `converge_scope_store_test.go` pinning the three routing decisions
  (split city → graph, split rig → own ledger, single-store → identity).

**Mutation-verified:** reverting `convergeCityScopeStore` to a passthrough
fails *only* the split-city arm; the rig and single-store arms stay green. A
conformance row that does not fail when the fix is reverted is coverage of a
path it never touches.

## The test-only commit

`TestResolveTemplateRendersAbstractUpstreamPerHarness` asserts the other
harness's key is absent from `tp.Env`, but `tp.Env` is the merged session env
and `ProviderProcessPassthroughEnv` deliberately forwards every
`IsProviderCredentialEnv` key it finds in `os.Environ()`. On a machine
exporting `OPENAI_API_KEY` the *passthrough* — not the binding — puts the key
there, and the test fails accusing the binding of a leak it did not cause.

CI never saw this because CI runs credential-free, and the sharded local
targets never saw it because `scripts/test-go-test-shard` runs under `env -i`
with a scrubbed allowlist. It reproduces only on a plain `go test ./cmd/gc/`
from a developer shell. Fixed by pinning the key empty for the subtest; swept
the four sibling packages that mention provider credentials with the same
ambient env to confirm this was the only site.

## Verification

`go build ./...`, `go vet ./...`, `scripts/check-split-topology-rows.sh`,
`scripts/check-core-boundary.sh`, and the full `make test-fast-parallel` gate
(all 10 jobs) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)