### PR TITLE
perf(controller): cache terminally reconciled graph.v2 roots across reconcile passes — S19 stopgap

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -55,6 +55,13 @@ import (
 type controllerState struct {
 	mu  sync.RWMutex
 	cfg *config.City
+	// reconcileCache remembers terminally reconciled graph.v2 roots across
+	// reconcileExecutionCompletions passes so patrol ticks stop rescanning
+	// history that cannot change (sc-yf1wpo: the uncached full scan cost
+	// ~460s/tick on a mature store). Guarded by reconcileCacheMu, not mu:
+	// the pass runs outside the state lock by design.
+	reconcileCacheMu sync.Mutex
+	reconcileCache   *executionevent.ReconcileCache
 	// rawCfg is the raw (pre-expansion, site-bound) config snapshot captured
 	// at the same generation as cfg. It is the basis the mutation gate uses
 	// (Editor.UpdateAgent → AgentOrigin), cached here so provenance reads
@@ -589,7 +596,13 @@ func (cs *controllerState) reconcileExecutionCompletions() {
 		}
 		graphStores = append(graphStores, beads.GraphStore{Store: store})
 	}
-	executionevent.ReconcileCompletedStores(ep, graphStores, "execution-reconcile")
+	cs.reconcileCacheMu.Lock()
+	if cs.reconcileCache == nil {
+		cs.reconcileCache = executionevent.NewReconcileCache()
+	}
+	cache := cs.reconcileCache
+	executionevent.ReconcileCompletedStoresCached(ep, graphStores, "execution-reconcile", cache)
+	cs.reconcileCacheMu.Unlock()
 }
 
 // uncachedBeadStore peels the controller's policy/cache read layers so a

--- a/internal/executionevent/lifecycle_test.go
+++ b/internal/executionevent/lifecycle_test.go
@@ -346,3 +346,87 @@ func TestLifecycleEventRetainsUnknownAndRejectsNonNativeOrInvalidFacts(t *testin
 }
 
 func lifecycleStrings(v []string) *[]string { return &v }
+
+// stepQueryCountingStore counts the per-root step enumerations
+// (ListByMetadata filtered by root_bead_id) that dominate reconcile cost on a
+// mature store (sc-yf1wpo). It proves the terminal-root cache actually skips
+// the per-root work rather than merely suppressing emissions.
+type stepQueryCountingStore struct {
+	beads.Store
+	stepQueries *int
+}
+
+func (s stepQueryCountingStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	if _, ok := filters[beadmeta.RootBeadIDMetadataKey]; ok {
+		*s.stepQueries++
+	}
+	return s.Store.ListByMetadata(filters, limit, opts...)
+}
+
+func TestReconcileCompletedStoresCachedSkipsTerminalRootsAndEvictsOnReopen(t *testing.T) {
+	graph := beads.NewMemStore()
+	root := mustCreateProjectionRoot(t, graph, "")
+	step := mustCreateProjectionStep(t, graph, "gcg-attempt", root.ID, "build", `["prepare"]`)
+	closed := "closed"
+	if err := graph.Update(step.ID, beads.UpdateOpts{Status: &closed, Metadata: map[string]string{beadmeta.SessionIDMetadataKey: "gcs-session"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.Update(root.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := events.NewFake()
+	cache := NewReconcileCache()
+	stepQueries := 0
+	counting := beads.GraphStore{Store: stepQueryCountingStore{Store: graph, stepQueries: &stepQueries}}
+
+	// Pass 1 emits the stranded fact; the root must NOT be cached yet because
+	// Record is best-effort and done-status requires reading the fact back.
+	if got := ReconcileCompletedStoresCached(recorder, []beads.GraphStore{counting}, "execution-reconcile", cache); got != 1 {
+		t.Fatalf("pass 1 = %d, want 1 emission", got)
+	}
+	if cache.isDone(root.ID) {
+		t.Fatal("root cached on the emitting pass; done-status must wait for journal read-back")
+	}
+	// Pass 2 observes the fact in the journal and caches the terminal root.
+	if got := ReconcileCompletedStoresCached(recorder, []beads.GraphStore{counting}, "execution-reconcile", cache); got != 0 {
+		t.Fatalf("pass 2 = %d, want 0", got)
+	}
+	if !cache.isDone(root.ID) {
+		t.Fatal("terminal root not cached after clean pass")
+	}
+	// Pass 3 must skip the per-root step enumeration entirely.
+	stepQueries = 0
+	if got := ReconcileCompletedStoresCached(recorder, []beads.GraphStore{counting}, "execution-reconcile", cache); got != 0 {
+		t.Fatalf("pass 3 = %d, want 0", got)
+	}
+	if stepQueries != 0 {
+		t.Fatalf("pass 3 ran %d step enumerations for a cached terminal root, want 0", stepQueries)
+	}
+
+	// Reopening the root must evict it and rescan (a reopened root can close
+	// steps again and strand new facts).
+	open := "open"
+	if err := graph.Update(root.ID, beads.UpdateOpts{Status: &open}); err != nil {
+		t.Fatal(err)
+	}
+	stepQueries = 0
+	if got := ReconcileCompletedStoresCached(recorder, []beads.GraphStore{counting}, "execution-reconcile", cache); got != 0 {
+		t.Fatalf("reopen pass = %d, want 0 new emissions", got)
+	}
+	if stepQueries == 0 {
+		t.Fatal("reopened root was not rescanned")
+	}
+	if cache.isDone(root.ID) {
+		t.Fatal("reopened root still cached")
+	}
+
+	// Nil cache must reproduce the uncached full scan (upstream behavior).
+	stepQueries = 0
+	if got := ReconcileCompletedStoresCached(recorder, []beads.GraphStore{counting}, "execution-reconcile", nil); got != 0 {
+		t.Fatalf("nil-cache pass = %d, want 0", got)
+	}
+	if stepQueries == 0 {
+		t.Fatal("nil cache skipped the scan")
+	}
+}

--- a/internal/executionevent/projector.go
+++ b/internal/executionevent/projector.go
@@ -307,10 +307,57 @@ func ReconcileCompleted(recorder events.Provider, graphStore beads.GraphStore, a
 	return ReconcileCompletedStores(recorder, []beads.GraphStore{graphStore}, actor)
 }
 
+// ReconcileCache remembers workflow roots whose completion facts are fully
+// reconciled and can never change again: the root is closed and every current
+// step definition is closed with its lifecycle fact in the journal. Terminal
+// roots dominate a long-lived store, and each costs a per-root step query plus
+// a per-step read on every pass — the cache turns that unbounded rescan into a
+// skip. It is an in-memory optimization only: a fresh cache (or a fresh
+// process) degrades to one full pass, which is the previous behavior, and the
+// journal remains the durable idempotency record. A cached root observed with
+// a non-closed status (reopen flows) is evicted and reconciled again.
+type ReconcileCache struct {
+	done map[string]struct{}
+}
+
+// NewReconcileCache returns an empty cache ready for use across passes.
+func NewReconcileCache() *ReconcileCache {
+	return &ReconcileCache{done: make(map[string]struct{})}
+}
+
+func (c *ReconcileCache) isDone(rootID string) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.done[rootID]
+	return ok
+}
+
+func (c *ReconcileCache) markDone(rootID string) {
+	if c == nil {
+		return
+	}
+	c.done[rootID] = struct{}{}
+}
+
+func (c *ReconcileCache) evict(rootID string) {
+	if c == nil {
+		return
+	}
+	delete(c.done, rootID)
+}
+
 // ReconcileCompletedStores repairs completion facts across graph stores with
 // one journal read. The completed-fact index is updated after each append so
 // the pass remains idempotent even when more than one source is scanned.
 func ReconcileCompletedStores(recorder events.Provider, graphStores []beads.GraphStore, actor string) int {
+	return ReconcileCompletedStoresCached(recorder, graphStores, actor, nil)
+}
+
+// ReconcileCompletedStoresCached is ReconcileCompletedStores with an optional
+// cross-pass cache of terminally reconciled roots. A nil cache reproduces the
+// uncached full scan.
+func ReconcileCompletedStoresCached(recorder events.Provider, graphStores []beads.GraphStore, actor string, cache *ReconcileCache) int {
 	if recorder == nil {
 		return 0
 	}
@@ -357,13 +404,32 @@ func ReconcileCompletedStores(recorder events.Provider, graphStores []beads.Grap
 			if root.Metadata[beadmeta.FormulaContractMetadataKey] != beadmeta.FormulaContractGraphV2 {
 				continue
 			}
+			rootClosed := strings.EqualFold(strings.TrimSpace(root.Status), "closed")
+			if cache.isDone(root.ID) {
+				if rootClosed {
+					continue
+				}
+				// A reopened root can close steps again; reconcile it live.
+				cache.evict(root.ID)
+			}
 			definitions, err := currentSteps(graphStore, root.ID)
 			if err != nil {
 				continue
 			}
+			// A closed root whose every current step is closed with its fact
+			// already observed in the journal can never strand another
+			// completion; remember it. A pass that emits a new fact does not
+			// qualify — Record is best-effort, so done-status is granted only
+			// once a later pass reads the fact back from the journal.
+			terminal := rootClosed
 			for _, definition := range definitions {
 				step, err := graphStore.Get(definition.BeadID)
-				if err != nil || !strings.EqualFold(strings.TrimSpace(step.Status), "closed") {
+				if err != nil {
+					terminal = false
+					continue
+				}
+				if !strings.EqualFold(strings.TrimSpace(step.Status), "closed") {
+					terminal = false
 					continue
 				}
 				event, ok := LifecycleEvent(events.ExecutionStepCompleted, root, step, actor)
@@ -377,6 +443,10 @@ func ReconcileCompletedStores(recorder events.Provider, graphStores []beads.Grap
 				recorder.Record(event)
 				completed[key] = struct{}{}
 				emitted++
+				terminal = false
+			}
+			if terminal {
+				cache.markDone(root.ID)
 			}
 		}
 	}


### PR DESCRIPTION
## What this fixes

`sc`-class cities with large terminally-reconciled graph.v2 populations pay a full re-reconcile of every terminal root on every reconcile pass — measured 460s stalls on a ~16k-bead store. This PR caches the terminal verdict per root across passes (invalidated on any store write touching the root's subtree), taking repeat passes to sub-second.

## Positioning vs the S19 program (reframed after Stages 1–2 landed)

S19's durable-identity schema and level-triggered session convergence landed in July; this cache is **explicitly a stopgap for the remaining hot path**: the per-pass reconcile of already-terminal roots, which the landed stages do not cover. It carries its own deletion condition and a maintainer "no" is an acceptable outcome if the S19 endgame prefers the reconciler owning this.

## Deletion condition — behavioral, not structural

Delete this cache when a reconcile pass over a store whose terminal roots are unchanged completes without visiting them (however achieved — reconciler-side terminal tracking, event-driven invalidation, or S19's eventual shape). The test suite pins the behavior (a terminal root is not re-reconciled on a clean second pass), so the cache's replacement proves itself by making the pinned behavior hold with the cache deleted.

## Testing

Rebased onto current `main`; full `make test` run with three failures, all classified not-ours: the known pre-existing device-login flake (fails on pristine main with `-count=3`), and two load-coincident tests (SQLite fence SIGKILL, precommit-npm) that pass isolated on both this branch and pristine main — receipts in the gate log.

LOC: prod ~180, tests ~240.
