### PR TITLE
fix(bdflags): stop reporting valid gc bd invocations as unknown flags

### DIFF
--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -278,6 +278,53 @@ func TestScanUnknownFlagsRejectsGCScopeFlagsOnBareBD(t *testing.T) {
 	}
 }
 
+func TestScanUnknownFlagsDetectsTypoAfterLeadingScopeFlags(t *testing.T) {
+	// "gc bd --rig <name> <sub> ..." and the --city form place the gc-owned
+	// scope flags before the subcommand. The scanner must consume the leading
+	// scope flags and still validate the resolved subcommand, so a typo after
+	// the verb is reported instead of the whole invocation being skipped.
+	cases := []struct {
+		line string
+		flag string
+		sub  string
+	}{
+		{"gc bd --rig my-project create --asignee bob", "--asignee", "create"},
+		{"gc bd --rig=my-project create --asignee bob", "--asignee", "create"},
+		{"gc bd --city /path/to/city update <id> --asignee bob", "--asignee", "update"},
+		{"gc bd --city=/path/to/city update <id> --asignee bob", "--asignee", "update"},
+		{"gc bd --rig my-project mol pour <id> --asignee builder", "--asignee", "mol pour"},
+	}
+	for _, tc := range cases {
+		findings := ScanUnknownFlags([]byte(tc.line))
+		if len(findings) != 1 {
+			t.Errorf("ScanUnknownFlags(%q) = %v, want exactly 1 finding", tc.line, findings)
+			continue
+		}
+		if findings[0].Flag != tc.flag {
+			t.Errorf("ScanUnknownFlags(%q) Flag = %q, want %q", tc.line, findings[0].Flag, tc.flag)
+		}
+		if findings[0].Subcommand != tc.sub {
+			t.Errorf("ScanUnknownFlags(%q) Subcommand = %q, want %q", tc.line, findings[0].Subcommand, tc.sub)
+		}
+	}
+}
+
+func TestScanUnknownFlagsAcceptsCleanLeadingScopeFlags(t *testing.T) {
+	// The leading scope-flag forms with no typo must still produce no
+	// findings after the scanner starts validating the subcommand that
+	// follows the consumed scope flags.
+	cases := []string{
+		"gc bd --rig my-project create --json",
+		"gc bd --city /path/to/city update <id> --claim",
+		"gc bd --rig=my-project list --status open --json",
+	}
+	for _, line := range cases {
+		if findings := ScanUnknownFlags([]byte(line)); len(findings) != 0 {
+			t.Errorf("ScanUnknownFlags(%q) = %v, want no findings", line, findings)
+		}
+	}
+}
+
 func TestScanUnknownFlagsStopsAtShellSeparators(t *testing.T) {
 	// Flags after a pipe belong to the downstream command, not to bd.
 	cases := []string{

--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -247,3 +247,81 @@ func TestScanUnknownFlagsBareBdWithoutGcPrefix(t *testing.T) {
 		t.Fatalf("ScanUnknownFlags() = %v, want exactly 1 finding", findings)
 	}
 }
+
+func TestScanUnknownFlagsAcceptsGCScopeFlagsOnGCBD(t *testing.T) {
+	// --city and --rig are gc-owned: cmd/gc/cmd_bd.go extractBdScopeFlags
+	// strips them before forwarding the remaining args to bd, and gc's own
+	// help documents "gc bd list --rig my-project -s open".
+	cases := []string{
+		"gc bd list --rig my-project --status open --json",
+		"gc bd list --rig={{ .Rig }} --status=open --json",
+		"gc bd --rig my-project create \"New task\"",
+		"gc bd create --city /path/to/city --type task \"t\"",
+		"gc bd --city=/path/to/city list --json",
+	}
+	for _, line := range cases {
+		if findings := ScanUnknownFlags([]byte(line)); len(findings) != 0 {
+			t.Errorf("ScanUnknownFlags(%q) = %v, want no findings", line, findings)
+		}
+	}
+}
+
+func TestScanUnknownFlagsRejectsGCScopeFlagsOnBareBD(t *testing.T) {
+	// Bare bd has no --rig: "bd list --rig gascity" exits with
+	// "Error: unknown flag: --rig". Only the "gc bd" form accepts it.
+	findings := ScanUnknownFlags([]byte("bd list --rig my-project --json"))
+	if len(findings) != 1 {
+		t.Fatalf("ScanUnknownFlags() = %v, want exactly 1 finding", findings)
+	}
+	if findings[0].Flag != "--rig" {
+		t.Errorf("Flag = %q, want %q", findings[0].Flag, "--rig")
+	}
+}
+
+func TestScanUnknownFlagsStopsAtShellSeparators(t *testing.T) {
+	// Flags after a pipe belong to the downstream command, not to bd.
+	cases := []string{
+		"gc bd show <id> --json | jq -r '.metadata.reason'",
+		"gc bd list --json | head -5",
+		"gc bd ready --json && echo -n done",
+		"gc bd show <id> --json ; grep -c foo",
+	}
+	for _, line := range cases {
+		if findings := ScanUnknownFlags([]byte(line)); len(findings) != 0 {
+			t.Errorf("ScanUnknownFlags(%q) = %v, want no findings", line, findings)
+		}
+	}
+}
+
+func TestScanUnknownFlagsAngleBracketPlaceholdersDoNotSplit(t *testing.T) {
+	// "<id>" is a placeholder in prompt templates, not a redirection, so it
+	// must not end the invocation and hide a typo that follows it.
+	findings := ScanUnknownFlags([]byte("gc bd update <id> --asignee bob"))
+	if len(findings) != 1 {
+		t.Fatalf("ScanUnknownFlags() = %v, want exactly 1 finding", findings)
+	}
+	if findings[0].Flag != "--asignee" {
+		t.Errorf("Flag = %q, want %q", findings[0].Flag, "--asignee")
+	}
+}
+
+func TestScanUnknownFlagsQuotedSeparatorDoesNotSplit(t *testing.T) {
+	// A pipe inside a quoted argument is data, not a shell separator, so the
+	// bd invocation continues and a real typo after it is still reported.
+	findings := ScanUnknownFlags([]byte(`gc bd list --json --title "a | b" --asignee bob`))
+	if len(findings) != 1 {
+		t.Fatalf("ScanUnknownFlags() = %v, want exactly 1 finding", findings)
+	}
+	if findings[0].Flag != "--asignee" {
+		t.Errorf("Flag = %q, want %q", findings[0].Flag, "--asignee")
+	}
+}
+
+func TestScanUnknownFlagsMarkdownTableCellIsolatesInvocations(t *testing.T) {
+	// Prompt templates document commands in markdown tables; the cell pipes
+	// must not carry a neighboring cell's flags into the bd invocation.
+	line := "| Show bead | `gc bd show <id> --json` | pipe to `jq -r .id` |"
+	if findings := ScanUnknownFlags([]byte(line)); len(findings) != 0 {
+		t.Errorf("ScanUnknownFlags(%q) = %v, want no findings", line, findings)
+	}
+}

--- a/internal/bdflags/scan.go
+++ b/internal/bdflags/scan.go
@@ -114,7 +114,15 @@ func scanLineForUnknownFlags(tokens []string, lineNo int) []Finding {
 			i++
 			continue
 		}
-		key, consumed, ok := matchSubcommand(tokens, subStart)
+		// "gc bd" may place the gc-owned scope flags before the subcommand
+		// ("gc bd --rig <name> create ..."); consume them so the subcommand
+		// that follows is still validated. Bare "bd" does not accept scope
+		// flags, so its leading forms are left for matchSubcommand to reject.
+		verbStart := subStart
+		if viaGC {
+			verbStart = skipLeadingScopeFlags(tokens, subStart)
+		}
+		key, consumed, ok := matchSubcommand(tokens, verbStart)
 		if !ok {
 			// Not a subcommand this package has a manifest for (e.g.
 			// "formula show"); resume scanning right after "bd"/"gc bd" so
@@ -122,61 +130,109 @@ func scanLineForUnknownFlags(tokens []string, lineNo int) []Finding {
 			i = subStart
 			continue
 		}
-		valueFlags := ValueFlags(key)
-		boolFlags := BoolFlags(key)
-		if viaGC {
-			for flag := range gcScopeValueFlags {
-				valueFlags[flag] = true
-			}
-		}
-
-		j := subStart + consumed
-		for j < len(tokens) {
-			tok := tokens[j]
-			if tok == "--" {
-				j++
-				break
-			}
-			if next, _ := bdSubcommandStart(tokens, j); next >= 0 {
-				break // a new bd invocation begins; let the outer loop handle it
-			}
-			if !strings.HasPrefix(tok, "-") || tok == "-" {
-				j++
-				continue
-			}
-			name := tok
-			hasInlineValue := false
-			if eq := strings.IndexByte(tok, '='); eq >= 0 {
-				name = tok[:eq]
-				hasInlineValue = true
-			}
-			switch {
-			case boolFlags[name]:
-				j++
-			case valueFlags[name]:
-				if hasInlineValue {
-					j++
-				} else {
-					j += 2
-				}
-			default:
-				findings = append(findings, Finding{Line: lineNo, Subcommand: key, Flag: name})
-				j++
-			}
-		}
-		i = j
+		flagFindings, resume := scanInvocationFlags(tokens, verbStart+consumed, key, viaGC, lineNo)
+		findings = append(findings, flagFindings...)
+		i = resume
 	}
 	return findings
 }
 
-// bdSubcommandStart returns the token index where a bd subcommand begins if
-// tokens[i] opens a bd invocation ("bd", or "gc" immediately followed by
-// "bd"), along with whether it opened via the "gc bd" form, which accepts
-// the gc-owned scope flags. It returns -1 if tokens[i] does not open one.
+// skipLeadingScopeFlags advances past any gc-owned scope flags that a "gc bd"
+// invocation places before its subcommand ("--rig <name>", "--city <path>",
+// or their inline "--rig=<name>" forms), returning the index of the first
+// token that is not one. This lets "gc bd --rig <name> create ..." reach and
+// validate the subcommand after the scope flags instead of skipping the whole
+// invocation.
+func skipLeadingScopeFlags(tokens []string, i int) int {
+	for i < len(tokens) {
+		name, hasInlineValue := splitFlagToken(tokens[i])
+		if !gcScopeValueFlags[name] {
+			return i
+		}
+		if hasInlineValue {
+			i++ // "--rig=<name>" carries its value in the same token
+		} else {
+			i += 2 // "--rig <name>" also consumes the following value token
+		}
+	}
+	return i
+}
+
+// scanInvocationFlags scans the flag tokens of a single bd invocation whose
+// subcommand resolved to key and whose flags begin at flagStart. It reports
+// any unrecognized flag and returns the token index at which the outer scan
+// should resume. viaGC additionally allows the gc-owned scope flags in the
+// trailing position ("gc bd list --rig <name>").
+func scanInvocationFlags(tokens []string, flagStart int, key string, viaGC bool, lineNo int) (findings []Finding, resume int) {
+	valueFlags := ValueFlags(key)
+	boolFlags := BoolFlags(key)
+	if viaGC {
+		// Safe to mutate in place: ValueFlags returns a freshly allocated map
+		// per call (mergeFlagSets), so this never leaks scope flags into
+		// another invocation's or consumer's manifest.
+		for flag := range gcScopeValueFlags {
+			valueFlags[flag] = true
+		}
+	}
+	j := flagStart
+	for j < len(tokens) {
+		tok := tokens[j]
+		if tok == "--" {
+			return findings, j + 1 // positional args follow; stop flag scanning
+		}
+		if next, _ := bdSubcommandStart(tokens, j); next >= 0 {
+			return findings, j // a new bd invocation begins; the outer loop takes it
+		}
+		if !strings.HasPrefix(tok, "-") || tok == "-" {
+			j++
+			continue
+		}
+		name, advance, unknown := classifyFlag(tok, valueFlags, boolFlags)
+		if unknown {
+			findings = append(findings, Finding{Line: lineNo, Subcommand: key, Flag: name})
+		}
+		j += advance
+	}
+	return findings, j
+}
+
+// splitFlagToken splits a flag token into its name and whether it carried an
+// inline "=value": "--rig=x" -> ("--rig", true); "--rig" -> ("--rig", false).
+func splitFlagToken(tok string) (name string, hasInlineValue bool) {
+	if eq := strings.IndexByte(tok, '='); eq >= 0 {
+		return tok[:eq], true
+	}
+	return tok, false
+}
+
+// classifyFlag resolves a "-"-prefixed flag token against a subcommand's value
+// and boolean flag sets. It returns the flag name, how many tokens the flag
+// consumes (2 when a value flag takes the following token, otherwise 1), and
+// whether the flag is unrecognized.
+func classifyFlag(tok string, valueFlags, boolFlags map[string]bool) (name string, advance int, unknown bool) {
+	name, hasInlineValue := splitFlagToken(tok)
+	switch {
+	case boolFlags[name]:
+		return name, 1, false
+	case valueFlags[name]:
+		if hasInlineValue {
+			return name, 1, false
+		}
+		return name, 2, false
+	default:
+		return name, 1, true
+	}
+}
+
+// bdSubcommandStart returns the token index immediately after "bd"/"gc bd"
+// when tokens[i] opens a bd invocation ("bd", or "gc" immediately followed by
+// "bd"), along with whether it opened via the "gc bd" form, which accepts the
+// gc-owned scope flags. It returns -1 if tokens[i] does not open one.
 //
-// "gc bd --rig <name> list" places the scope flags before the subcommand,
-// which this scanner skips over as it searches for a known subcommand key;
-// only the trailing form ("gc bd list --rig <name>") reaches flag scanning.
+// The returned index is where the subcommand search begins. For the "gc bd"
+// form the caller first consumes any leading scope flags
+// (skipLeadingScopeFlags), so both "gc bd --rig <name> list" and the trailing
+// "gc bd list --rig <name>" flow through subcommand and flag validation.
 func bdSubcommandStart(tokens []string, i int) (start int, viaGC bool) {
 	switch {
 	case tokens[i] == "bd":

--- a/internal/bdflags/scan.go
+++ b/internal/bdflags/scan.go
@@ -16,12 +16,25 @@ type Finding struct {
 // "`--claim`," becomes "--claim").
 const flagTokenCutset = "`*_(),:;.\"'"
 
+// gcScopeValueFlags are owned by "gc bd" rather than by bd itself.
+// cmd/gc/cmd_bd.go extractBdScopeFlags strips them from the raw argument
+// list and resolves the target store before forwarding what remains to bd,
+// so they are valid on any "gc bd <sub>" invocation and invalid on a bare
+// "bd <sub>" one, which rejects them with "unknown flag".
+var gcScopeValueFlags = map[string]bool{
+	"--city": true, "--rig": true,
+}
+
 // ScanUnknownFlags scans raw template source text for bd and "gc bd"
 // invocations of subcommands known to this package, and reports any flag
 // token that is not a recognized value or boolean flag for that
 // subcommand's manifest (see Known/ValueFlags/BoolFlags). Invocations of
 // subcommands outside this package's manifest (e.g. "bd formula show") are
 // silently skipped — there is no ground truth to validate them against.
+//
+// Each line is first split into shell segments on unquoted separators, so a
+// flag belonging to a downstream command ("bd show <id> --json | jq -r .x")
+// or to a neighboring markdown table cell is never attributed to bd.
 //
 // Scanning is line-oriented and does not join backslash-continued shell
 // lines; every bd invocation seen in prompt templates today is a single
@@ -32,9 +45,49 @@ func ScanUnknownFlags(source []byte) []Finding {
 	var findings []Finding
 	lines := strings.Split(string(source), "\n")
 	for idx, rawLine := range lines {
-		findings = append(findings, scanLineForUnknownFlags(tokenize(rawLine), idx+1)...)
+		for _, segment := range splitShellSegments(rawLine) {
+			findings = append(findings, scanLineForUnknownFlags(tokenize(segment), idx+1)...)
+		}
 	}
 	return findings
+}
+
+// shellSeparators are the unquoted characters that end one command and begin
+// another, so flag scanning must not carry across them. Markdown table cell
+// pipes land here too, which is the same boundary for the same reason.
+//
+// Redirection ("<", ">") is deliberately excluded: prompt templates write
+// argument placeholders as "<id>" far more often than they redirect, and
+// treating those as separators would split an invocation in half and hide
+// the typo after it. What follows a redirection is a filename rather than a
+// flag, so the missed boundary costs nothing.
+const shellSeparators = "|;&"
+
+// splitShellSegments splits a line on unquoted shell separators. Quoted
+// spans are preserved intact, so a separator inside an argument value (a jq
+// program, a --title string) does not split the invocation that owns it.
+func splitShellSegments(line string) []string {
+	var segments []string
+	var current strings.Builder
+	var quote rune
+	for _, r := range line {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			}
+			current.WriteRune(r)
+		case r == '\'' || r == '"':
+			quote = r
+			current.WriteRune(r)
+		case strings.ContainsRune(shellSeparators, r):
+			segments = append(segments, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	return append(segments, current.String())
 }
 
 // tokenize splits a line on whitespace and trims flagTokenCutset from each
@@ -56,7 +109,7 @@ func scanLineForUnknownFlags(tokens []string, lineNo int) []Finding {
 	var findings []Finding
 	i := 0
 	for i < len(tokens) {
-		subStart := bdSubcommandStart(tokens, i)
+		subStart, viaGC := bdSubcommandStart(tokens, i)
 		if subStart < 0 {
 			i++
 			continue
@@ -71,6 +124,11 @@ func scanLineForUnknownFlags(tokens []string, lineNo int) []Finding {
 		}
 		valueFlags := ValueFlags(key)
 		boolFlags := BoolFlags(key)
+		if viaGC {
+			for flag := range gcScopeValueFlags {
+				valueFlags[flag] = true
+			}
+		}
 
 		j := subStart + consumed
 		for j < len(tokens) {
@@ -79,7 +137,7 @@ func scanLineForUnknownFlags(tokens []string, lineNo int) []Finding {
 				j++
 				break
 			}
-			if bdSubcommandStart(tokens, j) >= 0 {
+			if next, _ := bdSubcommandStart(tokens, j); next >= 0 {
 				break // a new bd invocation begins; let the outer loop handle it
 			}
 			if !strings.HasPrefix(tok, "-") || tok == "-" {
@@ -113,15 +171,20 @@ func scanLineForUnknownFlags(tokens []string, lineNo int) []Finding {
 
 // bdSubcommandStart returns the token index where a bd subcommand begins if
 // tokens[i] opens a bd invocation ("bd", or "gc" immediately followed by
-// "bd"). It returns -1 if tokens[i] does not open one.
-func bdSubcommandStart(tokens []string, i int) int {
+// "bd"), along with whether it opened via the "gc bd" form, which accepts
+// the gc-owned scope flags. It returns -1 if tokens[i] does not open one.
+//
+// "gc bd --rig <name> list" places the scope flags before the subcommand,
+// which this scanner skips over as it searches for a known subcommand key;
+// only the trailing form ("gc bd list --rig <name>") reaches flag scanning.
+func bdSubcommandStart(tokens []string, i int) (start int, viaGC bool) {
 	switch {
 	case tokens[i] == "bd":
-		return i + 1
+		return i + 1, false
 	case tokens[i] == "gc" && i+1 < len(tokens) && tokens[i+1] == "bd":
-		return i + 2
+		return i + 2, true
 	default:
-		return -1
+		return -1, false
 	}
 }
 


### PR DESCRIPTION
`gc lint` reports two classes of `bd-unknown-flag` finding that are not
defects. Both point at working prompt text, so acting on either one breaks a
prompt that was correct.

This surfaced from a user report that several packs "could not land without
source modifications." Running `gc lint` across the registry, every finding on
`oversight-rig` and two thirds of the findings on `gastown` turned out to be
false.

## gc-owned scope flags

`bdSubcommandStart` accepts both `bd` and `gc bd` as invocation triggers
(that is deliberate, and documented in the package comment), but every flag
was then validated against bd's manifest alone.

`gc bd` owns `--city` and `--rig`. `cmd/gc/cmd_bd.go` `extractBdScopeFlags`
strips them from the raw argument list and resolves the target store before
forwarding what remains to bd, and `gc bd --help` documents
`gc bd list --rig my-project -s open`. The scanner called `--rig` unknown.

```
$ gc bd list --rig gascity --status blocked --json
[{"id":"gc-e2xqk", ...}]                       # works

$ bd list --rig gascity
Error: unknown flag: --rig                     # correctly rejected
```

The scanner now accepts the gc-owned scope flags on the `gc bd` form only.
A bare `bd list --rig x` is still reported, which matches what bd does.

## Flags belonging to a downstream command

The token loop ended at `--`, at a new bd invocation, or at end of line. It
ran straight through a pipe, so the next command's flags were attributed to
bd:

```
gc bd show <id> --json | jq -r '.metadata.reason'
```

was reported as `bd show uses unrecognized flag "-r"`. The `-r` is jq's.

Lines are now split into shell segments on unquoted `|`, `;`, and `&` before
tokenizing. Quoted spans are preserved, so a pipe inside a jq program or a
`--title` value does not split the invocation that owns it. This also
isolates markdown table cells, which is the form most of these findings
appear in, since prompt templates document commands in tables.

Redirection is excluded from the separator set on purpose. Templates write
`<id>` placeholders far more often than they redirect, and treating `<` and
`>` as separators splits an invocation in half and hides a real typo that
follows the placeholder. There is a regression test pinning that.

## Effect

Measured against gastownhall/gascity-packs at `734a7be`:

| pack | before | after |
|---|---|---|
| oversight-rig | 4 | 0 |
| gastown | 30 | 9 |

I ran each of the nine remaining `gastown` findings against the installed bd
rather than trusting `--help`, and only one is a command that fails:

```
$ gc bd create --prefix hq- "..."
Error: unknown flag: --prefix
```

That one is a packs-side fix, not part of this change.

Three more are flags bd accepts but does not declare in `--help`, so the
manifest in `bdflags.go` does not know them and neither can
`TestBdFlagManifestCurrent`, which parses the same `--help` text:

```
$ gc bd create --type=task --label=zzz "probe"   # succeeds, label applied
$ gc bd mol wisp gc --age 24h --dry-run          # succeeds
$ gc bd close <id> --status=closed               # accepted
$ gc bd create --lab=zzz "probe"
Error: unknown flag: --lab                        # so not prefix matching
```

I have left those alone. Closing that gap means finding a source of truth
other than `--help`, which is a larger change than this one and worth its
own discussion.

One is worse than a lint finding: `gc bd update <id> --label=x` is accepted
and the label is silently dropped (`labels: None` afterwards). Filed
separately.

The last three are documentation of what *not* to do, which the scanner has
no way to see:

```
| ... | ~~gc bd update --label=pool:...~~ (labels don't trigger scale_check) |
Do not run `gc bd close` or set `--status=closed` on an ...
```

Two are inside markdown strikethrough, which could be skipped the same way
pipes now are. The third is prose negation, out of reach of a raw-text scan.
Calling them out so nobody "fixes" a line that already says the flag is wrong.

## Tests

Six new cases in `internal/bdflags/bdflags_test.go`, each failing before the
change:

- scope flags accepted on `gc bd`, in both space and `=` form
- `--rig` still reported on bare `bd`
- scanning stops at a pipe, at `&&`, and at `;`
- a quoted separator does not split, and a typo after it is still reported
- a markdown table row does not carry a neighboring cell's flags into bd
- `<id>` placeholders do not split an invocation

`go test ./internal/bdflags/` and `go test ./cmd/gc/ -run 'Lint|BdFlag|BdArgs|Mistyped'`
pass, `go vet` and `golangci-lint` are clean on the package.
