### PR TITLE
fix(beads): retry native Dolt updates that lose a serialization race

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -942,10 +942,17 @@ func (s *NativeDoltStore) Update(id string, opts UpdateOpts) error {
 		return err
 	}
 	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
-	err = storage.RunInTransaction(ctx, fmt.Sprintf("gc: update bead %s", id), func(tx beadslib.Transaction) error {
-		return s.applyUpdateInTx(ctx, tx, id, opts)
+	// Retry a lost serialization race rather than surfacing it to the caller:
+	// a concurrent writer to the same bead store is normal (the supervisor,
+	// the reconciler and an operator request all write during city startup),
+	// and without this an ordinary conflict fails the write permanently and
+	// reaches the API as a 500.
+	err = retryOnNativeDoltSerializationConflict(func() error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		return storage.RunInTransaction(ctx, fmt.Sprintf("gc: update bead %s", id), func(tx beadslib.Transaction) error {
+			return s.applyUpdateInTx(ctx, tx, id, opts)
+		})
 	})
 	if err != nil {
 		return nativeStoreError(id, err)
@@ -1377,9 +1384,47 @@ func (s *NativeDoltStore) SetMetadata(id, key, value string) error {
 }
 
 const (
-	nativeMetadataWriteAttempts     = 3
-	nativeMetadataWriteRetryBackoff = 25 * time.Millisecond
+	nativeWriteAttempts     = 3
+	nativeWriteRetryBackoff = 25 * time.Millisecond
 )
+
+// retryOnNativeDoltSerializationConflict runs attempt until it succeeds, fails
+// with something other than a Dolt serialization conflict, or exhausts
+// nativeWriteAttempts.
+//
+// Re-running the whole attempt is safe: it re-reads inside a fresh transaction
+// and therefore builds on the competing transaction's committed rows rather
+// than overwriting them from a stale read. In the conflict this guards against,
+// the regular-table commit is the one that loses the race and nothing lands.
+// isNativeDoltSerializationConflict classifies on error text and cannot tell
+// which of beadslib's commit points failed, so a conflict reported after the
+// regular commit already succeeded would replay the attempt; callers must
+// therefore keep each attempt idempotent under replay, which the metadata
+// merge, label add/remove and reparent operations are.
+//
+// Each attempt gets its own operation context, so an earlier attempt's deadline
+// cannot doom the retries.
+//
+// Every other error is returned on the first try. Retrying a genuine fault only
+// multiplies write load and hides the cause behind a slower failure.
+//
+// Callers hold the storage read lock across every attempt, so the backoff sleeps
+// inside this loop delay anything waiting to take s.mu for writing (store close
+// and the reconnect handle swap) by at most the total backoff. Holding it is
+// deliberate: releasing between attempts would let the handle be swapped
+// mid-retry, so a retry could run against a different storage than the one whose
+// transaction it is repeating.
+func retryOnNativeDoltSerializationConflict(attempt func() error) error {
+	var err error
+	for n := 1; n <= nativeWriteAttempts; n++ {
+		err = attempt()
+		if err == nil || !isNativeDoltSerializationConflict(err) || n == nativeWriteAttempts {
+			return err
+		}
+		time.Sleep(time.Duration(n) * nativeWriteRetryBackoff)
+	}
+	return err
+}
 
 // SetMetadataBatch sets multiple metadata keys on a bead.
 func (s *NativeDoltStore) SetMetadataBatch(id string, kvs map[string]string) error {
@@ -1389,16 +1434,11 @@ func (s *NativeDoltStore) SetMetadataBatch(id string, kvs map[string]string) err
 	}
 	defer release()
 
-	for attempt := 1; attempt <= nativeMetadataWriteAttempts; attempt++ {
+	return retryOnNativeDoltSerializationConflict(func() error {
 		ctx, cancel := nativeDoltOperationContext(context.TODO())
-		err = s.setMetadataBatchOnce(ctx, storage, id, kvs)
-		cancel()
-		if err == nil || !isNativeDoltSerializationConflict(err) || attempt == nativeMetadataWriteAttempts {
-			return err
-		}
-		time.Sleep(time.Duration(attempt) * nativeMetadataWriteRetryBackoff)
-	}
-	return err
+		defer cancel()
+		return s.setMetadataBatchOnce(ctx, storage, id, kvs)
+	})
 }
 
 // setMetadataBatchOnce performs one complete metadata read-merge-write attempt.

--- a/internal/beads/native_dolt_store_update_retry_test.go
+++ b/internal/beads/native_dolt_store_update_retry_test.go
@@ -1,0 +1,79 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// serializationConflictErr is the verbatim error Dolt returns when a write
+// transaction loses a serialization race. Reproduced from a CI failure of
+// TestHumaBinary_SessionMessageAsync, where a concurrent supervisor write made
+// a session suspend fail permanently and surface as HTTP 500.
+const serializationConflictErr = "sql commit (regular): Error 1213 (40001): serialization failure: " +
+	"this transaction conflicts with a committed transaction from another client, try restarting transaction."
+
+// conflictThenOKStorage fails the first failures transactions with a
+// serialization conflict, then succeeds, counting every attempt.
+func conflictThenOKStorage(failures int32, attempts *int32) *nativeDoltStorageSpy {
+	return &nativeDoltStorageSpy{
+		runInTransaction: func(context.Context, string, func(beadslib.Transaction) error) error {
+			if atomic.AddInt32(attempts, 1) <= failures {
+				return errors.New(serializationConflictErr)
+			}
+			return nil
+		},
+	}
+}
+
+func TestNativeDoltStoreUpdateRetriesSerializationConflict(t *testing.T) {
+	var attempts int32
+	store := newNativeDoltStoreForTest(conflictThenOKStorage(1, &attempts))
+
+	if err := store.Update("gc-1", UpdateOpts{Metadata: map[string]string{"state": "suspended"}}); err != nil {
+		t.Fatalf("Update after one serialization conflict: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("transaction attempts = %d, want 2 (one conflict, one retry)", got)
+	}
+}
+
+func TestNativeDoltStoreUpdateStopsAtAttemptLimit(t *testing.T) {
+	var attempts int32
+	store := newNativeDoltStoreForTest(conflictThenOKStorage(int32(nativeWriteAttempts), &attempts))
+
+	err := store.Update("gc-1", UpdateOpts{Metadata: map[string]string{"state": "suspended"}})
+	if err == nil {
+		t.Fatal("Update with unrelenting conflicts: got nil, want the serialization error")
+	}
+	if !isNativeDoltSerializationConflict(err) {
+		t.Fatalf("returned error lost its serialization-conflict identity: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != int32(nativeWriteAttempts) {
+		t.Fatalf("transaction attempts = %d, want %d", got, nativeWriteAttempts)
+	}
+}
+
+func TestNativeDoltStoreUpdateDoesNotRetryNonConflictErrors(t *testing.T) {
+	var attempts int32
+	// A constraint violation is a genuine fault: retrying it only multiplies
+	// the write load and hides the real error behind a slower failure.
+	store := newNativeDoltStoreForTest(&nativeDoltStorageSpy{
+		runInTransaction: func(context.Context, string, func(beadslib.Transaction) error) error {
+			atomic.AddInt32(&attempts, 1)
+			return errors.New("Error 1062 (23000): duplicate entry")
+		},
+	})
+
+	err := store.Update("gc-1", UpdateOpts{Metadata: map[string]string{"state": "suspended"}})
+	if err == nil || !strings.Contains(err.Error(), "duplicate entry") {
+		t.Fatalf("Update error = %v, want the duplicate-entry error", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("transaction attempts = %d, want 1 (non-conflict errors must not retry)", got)
+	}
+}

--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -903,9 +903,13 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /suspend: %v", err)
 	}
+	// Read the body before asserting: a bare status number is not diagnosable
+	// from a CI log, and this assertion has failed in CI with a 500 whose cause
+	// was unrecoverable afterwards.
+	suspBody, _ := io.ReadAll(io.LimitReader(suspResp.Body, 4096))
 	_ = suspResp.Body.Close()
 	if suspResp.StatusCode != http.StatusOK {
-		t.Fatalf("POST /suspend status = %d, want 200", suspResp.StatusCode)
+		t.Fatalf("POST /suspend status = %d, want 200; body=%s", suspResp.StatusCode, strings.TrimSpace(string(suspBody)))
 	}
 	t.Logf("suspended session %q", sessionID)
 


### PR DESCRIPTION
## What was wrong

`NativeDoltStore.Update` ran its transaction exactly once. When a concurrent writer won the race, Dolt returned a serialization conflict (SQLSTATE 40001, "try restarting transaction") and the write failed permanently.

Nothing in the session manager or the API classifies that error, so it fell through `humaSessionManagerError` to `humaStoreError` and reached the client as a 500. The suspend route does not declare 500; it declares 401, 403, 404, 409 and 503 (`internal/api/supervisor_city_routes.go:404`), so this was an unhandled path rather than intended behavior.

Concurrent writes to a city's bead store are ordinary. The supervisor, the reconciler and an operator request all write during city startup. On a loaded machine the window widens enough to hit regularly, which is why this only ever failed in CI.

`SetMetadataBatch` already retried this exact error class three times with backoff. `Update`, in the same file, did not.

## The fix

Both paths now share `retryOnNativeDoltSerializationConflict`, so the two cannot drift apart.

Retrying is safe for the reason `setMetadataBatchOnce` already documents: Dolt reports a 40001 only for a transaction that did not commit, and each attempt re-reads inside a fresh transaction rather than overwriting from a stale read. Each attempt also gets its own operation context, so one attempt's deadline cannot doom the retries. Every other error still fails on the first try, since retrying a genuine fault multiplies write load and hides the cause behind a slower failure.

Also renames `nativeMetadataWrite*` to `nativeWrite*`, since the constants now govern more than metadata writes.

## Test plan

The failure signature, from `TestHumaBinary_SessionMessageAsync`:

```
updating suspension state: sql commit (regular): Error 1213 (40001): serialization failure:
this transaction conflicts with a committed transaction from another client, try restarting transaction.
```

- Reproduced locally by saturating all cores, which is what a loaded CI runner supplies: 2 of 4 runs failed before the change, 6 of 6 pass after.
- Three unit tests drive `Update` through the real transaction path using the existing storage spy, so they fail if the retry is removed: retry-then-succeed, stop-at-attempt-limit, and no-retry-for-non-conflict-errors.
- `go test ./internal/beads/` green, including under `-race`. `go vet` and `golangci-lint` clean.
- `go vet -tags integration ./test/integration/` run separately and clean. `make vet` is `go vet ./...` with no build tags, so it never compiles the integration file this PR edits.

The integration test now reports the response body on a non-200 suspend. A bare status number was not diagnosable from a CI log, which is what made this take three CI failures to identify.

## Scope

Every other mutating method on `NativeDoltStore` still commits one-shot and fails on the same conflict: `ApplyGraphPlanWithStorage`, `Create`, `ReleaseIfCurrent`, `Close`, `Reopen`, `Tx`, `Delete`, `DepAdd`, `DepRemove`, `persistCreatedDependencies` and `compensateFailedCreate`.

They are deliberately not swept in here. Retry is only safe where an attempt is idempotent under replay, and several of these need that argument made individually: `ReleaseIfCurrent` is a compare-and-swap, `Tx` is a caller-composed batch, and `Create`/`compensateFailedCreate` are a rollback pair. Tracked in #5228, which also records the sharpest instance: `CloseAll` calls the now-retried `SetMetadataBatch` and then the unretried `Close` per bead, so a conflict on the second call leaves metadata written on a bead that never closed.

This fixes one flake. It does not turn main green on its own: the same failing runs also break `packages-core`, `packages-runtime-tmux` and `cmd/gc process` shards.
