### PR TITLE
Add dolt-health watchdog signals (load average + supervisor PARTIAL) to mol-dog-doctor

### DIFF
--- a/examples/bd/dolt/assets/scripts/loadavg.sh
+++ b/examples/bd/dolt/assets/scripts/loadavg.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# loadavg.sh — system load-average probe for the dolt-health watchdog.
+# Sourced by mol-dog-doctor.sh; unit-tested by test/dolt/loadavg_test.sh.
+#
+# When the host is CPU-saturated the managed dolt sql-server starves: query
+# latency climbs, connections pile up, and the client-side circuit breaker
+# ("dolt circuit breaker is open") trips. A sustained system load average is an
+# early, correlating signal of that destabilization.
+#
+# Reading the load average is a *local* probe — no dolt query, no connection —
+# so it adds no load to the very server the watchdog is protecting. That is the
+# watchdog's "SOFT" contract: never hammer dolt, and keep working when dolt is
+# too wedged to answer.
+#
+# POSIX sh has no floating point, so loads like "2.34" are carried as integer
+# hundredths ("centi", 234) and all comparisons are integer.
+
+# cpu_count — echo the online CPU count (always >= 1). Cascade: explicit
+# GC_DOCTOR_CPU_COUNT override (tests / cgroup-limited hosts), nproc (GNU
+# coreutils), sysctl hw.ncpu (BSD/macOS), getconf, then 1. Always succeeds so a
+# caller under `set -e` never aborts on it.
+cpu_count() {
+  if [ -n "${GC_DOCTOR_CPU_COUNT:-}" ]; then
+    case "$GC_DOCTOR_CPU_COUNT" in
+      ''|*[!0-9]*) : ;;
+      *) if [ "$GC_DOCTOR_CPU_COUNT" -ge 1 ]; then
+           printf '%s\n' "$GC_DOCTOR_CPU_COUNT"; return 0
+         fi ;;
+    esac
+  fi
+  _cc=$(nproc 2>/dev/null) || _cc=""
+  case "$_cc" in ''|*[!0-9]*) _cc="" ;; esac
+  if [ -z "$_cc" ]; then
+    _cc=$(sysctl -n hw.ncpu 2>/dev/null) || _cc=""
+    case "$_cc" in ''|*[!0-9]*) _cc="" ;; esac
+  fi
+  if [ -z "$_cc" ]; then
+    _cc=$(getconf _NPROCESSORS_ONLN 2>/dev/null) || _cc=""
+    case "$_cc" in ''|*[!0-9]*) _cc="" ;; esac
+  fi
+  if [ -z "$_cc" ] || [ "$_cc" -lt 1 ]; then _cc=1; fi
+  printf '%s\n' "$_cc"
+}
+
+# loadavg_1min — echo the 1-minute load average as a decimal string. Override
+# with GC_DOCTOR_LOADAVG_1MIN (tests / constrained hosts). Cascade:
+# /proc/loadavg (Linux), sysctl -n vm.loadavg (BSD/macOS), uptime parse. Always
+# succeeds — echoes 0 when no source is available, so the caller's arithmetic
+# never sees an empty string.
+loadavg_1min() {
+  if [ -n "${GC_DOCTOR_LOADAVG_1MIN:-}" ]; then
+    printf '%s\n' "$GC_DOCTOR_LOADAVG_1MIN"; return 0
+  fi
+  if [ -r /proc/loadavg ]; then
+    _la=$(cut -d' ' -f1 /proc/loadavg 2>/dev/null) || _la=""
+    case "$_la" in *[0-9]*) printf '%s\n' "$_la"; return 0 ;; esac
+  fi
+  # vm.loadavg prints "{ 1.23 4.56 7.89 }"; take the first number.
+  _la=$(sysctl -n vm.loadavg 2>/dev/null) || _la=""
+  case "$_la" in
+    *[0-9]*)
+      _la=$(printf '%s\n' "$_la" | tr -d '{}' | awk '{print $1}')
+      case "$_la" in *[0-9]*) printf '%s\n' "$_la"; return 0 ;; esac
+      ;;
+  esac
+  _la=$(uptime 2>/dev/null | sed -n 's/.*load average[s]*:[[:space:]]*\([0-9][0-9.]*\).*/\1/p') || _la=""
+  case "$_la" in *[0-9]*) printf '%s\n' "$_la"; return 0 ;; esac
+  printf '0\n'
+}
+
+# to_centi DECIMAL — convert a non-negative decimal like "2.34" or "10" to
+# integer hundredths ("234", "1000") for integer comparison. Truncates beyond
+# two decimals; clamps anything non-numeric to 0. Always succeeds.
+to_centi() {
+  _v="${1:-0}"
+  case "$_v" in ''|*[!0-9.]*) printf '0\n'; return 0 ;; esac
+  _int=${_v%%.*}
+  case "$_v" in *.*) _frac=${_v#*.} ;; *) _frac="" ;; esac
+  case "$_int" in ''|*[!0-9]*) _int=0 ;; esac
+  # Pad/truncate the fraction to exactly two digits.
+  _frac=$(printf '%s' "${_frac}00" | cut -c1-2)
+  case "$_frac" in ''|*[!0-9]*) _frac=0 ;; esac
+  printf '%s\n' "$(( _int * 100 + _frac ))"
+}
+
+# centi_to_dec CENTI — inverse of to_centi for display, e.g. 234 -> "2.34".
+centi_to_dec() {
+  _c="${1:-0}"
+  case "$_c" in ''|*[!0-9]*) _c=0 ;; esac
+  printf '%d.%02d\n' "$(( _c / 100 ))" "$(( _c % 100 ))"
+}
+
+# loadavg_should_warn LOAD_CENTI CPUS THRESHOLD_CENTI_PER_CORE — exit 0 (warn)
+# when per-core load (LOAD_CENTI / CPUS) meets or exceeds the per-core
+# threshold. Compared as LOAD_CENTI >= CPUS * THRESHOLD to keep integer math,
+# e.g. a 4.00/core threshold on 8 cores warns at load >= 32.00. A threshold of
+# 0 (or non-numeric) disables the check.
+loadavg_should_warn() {
+  _lc="${1:-0}"; _cpus="${2:-1}"; _thc="${3:-0}"
+  case "$_lc" in ''|*[!0-9]*) _lc=0 ;; esac
+  case "$_cpus" in ''|*[!0-9]*) _cpus=1 ;; esac
+  [ "$_cpus" -ge 1 ] || _cpus=1
+  case "$_thc" in ''|*[!0-9]*) _thc=0 ;; esac
+  [ "$_thc" -gt 0 ] || return 1
+  [ "$_lc" -ge "$(( _cpus * _thc ))" ]
+}

--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 . "$PACK_DIR/assets/scripts/latency.sh"
+. "$PACK_DIR/assets/scripts/loadavg.sh"
+. "$PACK_DIR/assets/scripts/supervisor_signals.sh"
 . "$PACK_DIR/assets/scripts/advisory_state.sh"
 . "$PACK_DIR/assets/scripts/_notify.sh"
 
@@ -36,6 +38,22 @@ BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
 # advisory so a persistent condition collapses into one rolling alert instead of
 # a fresh bead every 5-min tick. DOLT_STATE_DIR is set by runtime.sh.
 ADVISORY_STATE_FILE="${GC_DOCTOR_ADVISORY_STATE_FILE:-$DOLT_STATE_DIR/doctor-advisory-state}"
+
+# Watchdog soft-signal knobs (Step 2b): detect the store destabilizing under
+# CPU load. Both checks are dolt-free — a local load-average read and a read of
+# the controller's own reconcile trace — so they add no query load to the
+# server they protect.
+#
+# Per-core 1-minute load-average warn threshold. A CPU-saturated host starves
+# the managed dolt server (latency climbs, the client circuit breaker trips), so
+# a sustained per-core load at or above this raises the advisory. Default
+# 4.0/core is unambiguous saturation; 0 disables. GC_DOCTOR_LOADAVG_1MIN
+# overrides the measured value for tests / constrained hosts.
+LOADAVG_WARN_PER_CORE_CENTI="$(to_centi "${GC_DOCTOR_LOADAVG_WARN_PER_CORE:-4.0}")"
+# Lookback window for the supervisor reconcile-trace read, sized just above the
+# order interval (`interval` in orders/mol-dog-doctor.toml) so consecutive ticks
+# overlap and no snapshot is missed between them.
+SUPERVISOR_WINDOW="${GC_DOCTOR_SUPERVISOR_WINDOW:-6m}"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
@@ -205,9 +223,51 @@ if [ -n "$BACKUP_STALE_ITEMS" ]; then
     BACKUP_STALE="$BACKUP_STALE [WARN: backup freshness: $BACKUP_STALE_ITEMS]"
 fi
 
+# --- Step 2b: Soft degradation signals (dolt-free) ---
+#
+# Catch the store destabilizing under CPU load *before* it becomes an outage,
+# without adding any query load to the server we are watching. Both signals are
+# read from outside dolt:
+#   - the host 1-minute load average (a local read), and
+#   - the controller's own reconcile trace (`gc trace show`), which surfaces
+#     scale-check / store PARTIAL reads — the supervisor-side shadow of a tripped
+#     "dolt circuit breaker is open".
+# If dolt is too wedged to answer, these still report, so the advisory fires.
+
+LOADAVG_1MIN="$(loadavg_1min)"
+CPU_COUNT="$(cpu_count)"
+LOADAVG_CENTI="$(to_centi "$LOADAVG_1MIN")"
+LOADAVG_PER_CORE_CENTI="$(( LOADAVG_CENTI / CPU_COUNT ))"
+LOADAVG_WARN=""
+if loadavg_should_warn "$LOADAVG_CENTI" "$CPU_COUNT" "$LOADAVG_WARN_PER_CORE_CENTI"; then
+    LOADAVG_WARN=" [WARN: load avg 1m $(centi_to_dec "$LOADAVG_PER_CORE_CENTI")/core >= threshold $(centi_to_dec "$LOADAVG_WARN_PER_CORE_CENTI")/core — server may starve]"
+fi
+
+# Read the supervisor's recorded reconcile signals. The fetch is guarded so a
+# missing/slow trace store never aborts the doctor (SOFT: back off, don't hang);
+# the parse lives in supervisor_signals.sh so it is unit-testable on canned JSON.
+SUPERVISOR_JSON="$(gc trace show --since "$SUPERVISOR_WINDOW" --type cycle_input_snapshot --json 2>/dev/null || true)"
+SUPERVISOR_ACTIVE="$(supervisor_signals "$SUPERVISOR_JSON")"
+SUPERVISOR_STATE="ok"
+SCALECHECK_WARN=""
+STORE_WARN=""
+case " $SUPERVISOR_ACTIVE " in
+    *" scalecheck "*)
+        SCALECHECK_WARN=" [WARN: supervisor scale-check query PARTIAL — pools may not scale, work stalls]"
+        ;;
+esac
+case " $SUPERVISOR_ACTIVE " in
+    *" store "*)
+        STORE_WARN=" [WARN: supervisor store read PARTIAL since last tick — circuit breaker / store instability]"
+        ;;
+esac
+if [ -n "$SCALECHECK_WARN$STORE_WARN" ]; then
+    SUPERVISOR_STATE="PARTIAL (${SUPERVISOR_ACTIVE})"
+fi
+
 # --- Step 3: Compose report and escalate if critical ---
 
-WARNINGS="${LATENCY_WARN}${CONN_WARN}${ORPHAN_WARN}${BACKUP_STALE}"
+WARNINGS="${LATENCY_WARN}${CONN_WARN}${ORPHAN_WARN}${BACKUP_STALE}${LOADAVG_WARN}${SCALECHECK_WARN}${STORE_WARN}"
 if [ -n "$WARNINGS" ]; then
     # Dedup (#3409): key on which conditions are active — not their tick-volatile
     # values (exact latency ms, connection count, backup age) — and re-send only
@@ -219,21 +279,45 @@ if [ -n "$WARNINGS" ]; then
     if [ -n "$CONN_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}conn "; fi
     if [ -n "$ORPHAN_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}orphan "; fi
     if [ -n "$BACKUP_STALE" ]; then ADVISORY_SIG="${ADVISORY_SIG}backup "; fi
+    if [ -n "$LOADAVG_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}load "; fi
+    if [ -n "$SCALECHECK_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}scalecheck "; fi
+    if [ -n "$STORE_WARN" ]; then ADVISORY_SIG="${ADVISORY_SIG}store "; fi
     if advisory_changed "$ADVISORY_SIG" "$ADVISORY_STATE_FILE"; then
         if send_escalation \
             "Dolt health advisory [MEDIUM]" \
             "Latency: ${LATENCY_MS}ms${LATENCY_WARN}
 Connections: ${CONN_COUNT}/${CONN_MAX}${CONN_WARN}
 Disk: ${DISK_USAGE}
-Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}"; then
+Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}
+Load avg (1m): ${LOADAVG_1MIN} over ${CPU_COUNT} core(s)${LOADAVG_WARN}
+Supervisor reconcile: ${SUPERVISOR_STATE}${SCALECHECK_WARN}${STORE_WARN}"; then
             advisory_record "$ADVISORY_SIG" "$ADVISORY_STATE_FILE"
         fi
     fi
 else
-    # Healthy: forget the last advisory so a future condition re-alerts.
-    advisory_clear "$ADVISORY_STATE_FILE"
+    # Healthy this tick. If the prior tick was degraded (state file non-empty),
+    # send exactly one [RECOVERED] note — the recovery mirror of the dedup: one
+    # alert per transition — then forget the advisory so a future condition
+    # re-alerts. Clear only after a successful send so a failed recovery note
+    # retries next tick.
+    if [ -s "$ADVISORY_STATE_FILE" ]; then
+        PRIOR_SIG=""
+        IFS= read -r PRIOR_SIG < "$ADVISORY_STATE_FILE" 2>/dev/null || true
+        if send_escalation \
+            "Dolt health advisory [RECOVERED]" \
+            "Dolt health has returned to normal after a degraded advisory.
+Latency: ${LATENCY_MS}ms
+Connections: ${CONN_COUNT}/${CONN_MAX}
+Load avg (1m): ${LOADAVG_1MIN} over ${CPU_COUNT} core(s)
+Supervisor reconcile: ${SUPERVISOR_STATE}
+Cleared conditions: ${PRIOR_SIG}"; then
+            advisory_clear "$ADVISORY_STATE_FILE"
+        fi
+    else
+        advisory_clear "$ADVISORY_STATE_FILE"
+    fi
 fi
 
-SUMMARY="doctor — server: ok, latency: ${LATENCY_MS}ms, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}"
+SUMMARY="doctor — server: ok, latency: ${LATENCY_MS}ms, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}, load: ${LOADAVG_1MIN}/${CPU_COUNT}c, supervisor: ${SUPERVISOR_STATE}"
 dolt_notify_done "$SUMMARY"
 echo "doctor: $SUMMARY"

--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -54,6 +54,13 @@ LOADAVG_WARN_PER_CORE_CENTI="$(to_centi "${GC_DOCTOR_LOADAVG_WARN_PER_CORE:-4.0}
 # order interval (`interval` in orders/mol-dog-doctor.toml) so consecutive ticks
 # overlap and no snapshot is missed between them.
 SUPERVISOR_WINDOW="${GC_DOCTOR_SUPERVISOR_WINDOW:-6m}"
+# Wall-clock bound (seconds) for that trace read. It is a local, dolt-free
+# `gc trace show`, but under the very CPU saturation this watchdog exists to
+# catch even a local subprocess can stall — so bound it, exactly as dolt_sql
+# bounds its query, to keep the SOFT contract ("never hang, never pile on")
+# honest. On timeout the read yields no signal and the doctor degrades to
+# "supervisor: ok" for the tick rather than blocking; the next tick re-checks.
+SUPERVISOR_TIMEOUT_SECS="${GC_DOCTOR_SUPERVISOR_TIMEOUT_SECS:-10}"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
@@ -243,10 +250,12 @@ if loadavg_should_warn "$LOADAVG_CENTI" "$CPU_COUNT" "$LOADAVG_WARN_PER_CORE_CEN
     LOADAVG_WARN=" [WARN: load avg 1m $(centi_to_dec "$LOADAVG_PER_CORE_CENTI")/core >= threshold $(centi_to_dec "$LOADAVG_WARN_PER_CORE_CENTI")/core — server may starve]"
 fi
 
-# Read the supervisor's recorded reconcile signals. The fetch is guarded so a
-# missing/slow trace store never aborts the doctor (SOFT: back off, don't hang);
-# the parse lives in supervisor_signals.sh so it is unit-testable on canned JSON.
-SUPERVISOR_JSON="$(gc trace show --since "$SUPERVISOR_WINDOW" --type cycle_input_snapshot --json 2>/dev/null || true)"
+# Read the supervisor's recorded reconcile signals. The fetch is both time-bounded
+# (run_bounded, like dolt_sql) and error-guarded (|| true) so a missing, slow, or
+# wedged trace store can never hang or abort the doctor (SOFT: back off, don't
+# pile on); on timeout it yields empty output — i.e. no signal this tick. The
+# parse lives in supervisor_signals.sh so it is unit-testable on canned JSON.
+SUPERVISOR_JSON="$(run_bounded "$SUPERVISOR_TIMEOUT_SECS" gc trace show --since "$SUPERVISOR_WINDOW" --type cycle_input_snapshot --json 2>/dev/null || true)"
 SUPERVISOR_ACTIVE="$(supervisor_signals "$SUPERVISOR_JSON")"
 SUPERVISOR_STATE="ok"
 SCALECHECK_WARN=""

--- a/examples/bd/dolt/assets/scripts/supervisor_signals.sh
+++ b/examples/bd/dolt/assets/scripts/supervisor_signals.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# supervisor_signals.sh — read the supervisor's own recorded health signals
+# from the session-reconciler trace, without touching dolt.
+# Sourced by mol-dog-doctor.sh; unit-tested by test/dolt/supervisor_signals_test.sh.
+#
+# The controller records a `cycle_input_snapshot` trace record each reconcile
+# tick. Its `fields` carry booleans that flag when a reconcile query could not
+# fully read the beads store:
+#
+#   scale_check_query_partial — the pool scale-check query returned partial, so
+#       supervisor pools may not scale up and queued work stalls (a scaleCheck
+#       PARTIAL occurrence).
+#   store_query_partial       — the store read returned partial; this is what a
+#       tripped "dolt circuit breaker is open" fail-fast looks like from the
+#       supervisor's side (store / circuit-breaker instability).
+#   session_query_partial     — the session read returned partial (also store
+#       instability; folded into the store signal).
+#
+# Reading these is a *local, dolt-free* probe: `gc trace show` reads the trace
+# store the controller already wrote, so it adds no query load to the dolt
+# server the watchdog is protecting — the watchdog's "SOFT" contract.
+#
+# The parser is deliberately split from the fetch (the doctor runs `gc trace
+# show ... --json` and passes the text in) so it is unit-testable against canned
+# JSON with no controller or dolt running.
+
+# supervisor_flag_true FIELD JSON — exit 0 when the trace JSON contains at least
+# one `"FIELD":true`. Blanks between the key and value are normalized so both
+# `"f":true` and `"f": true` match; newlines are preserved so a key at the end
+# of one line cannot join a value on the next. The values are JSON booleans, so
+# matching `:true` (not `:false`) is unambiguous. Never trips the caller's
+# `set -e`: it is only ever evaluated in an `if`/`||` condition.
+supervisor_flag_true() {
+  _sf_field="${1:-}"
+  _sf_json="${2:-}"
+  [ -n "$_sf_field" ] || return 1
+  [ -n "$_sf_json" ] || return 1
+  printf '%s' "$_sf_json" \
+    | tr -d '[:blank:]' \
+    | grep -q "\"${_sf_field}\":true"
+}
+
+# supervisor_signals JSON — echo a stable, space-separated set of active signal
+# tokens found in the trace JSON:
+#   "scalecheck"  when scale_check_query_partial is true anywhere in the window.
+#   "store"       when store_query_partial OR session_query_partial is true.
+# Empty output means no partial signals (the healthy case). The fixed order
+# (scalecheck before store) keeps any signature built from it deterministic.
+# Always succeeds.
+supervisor_signals() {
+  _ss_json="${1:-}"
+  _ss_out=""
+  if supervisor_flag_true "scale_check_query_partial" "$_ss_json"; then
+    _ss_out="${_ss_out}scalecheck "
+  fi
+  if supervisor_flag_true "store_query_partial" "$_ss_json" \
+     || supervisor_flag_true "session_query_partial" "$_ss_json"; then
+    _ss_out="${_ss_out}store "
+  fi
+  printf '%s\n' "${_ss_out% }"
+}

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -76,9 +76,11 @@ func TestDogExecScriptsAreBashSyntaxValid(t *testing.T) {
 	root := repoRoot(t)
 	for _, scriptName := range []string{
 		"_notify.sh",
+		"loadavg.sh",
 		"mol-dog-backup.sh",
 		"mol-dog-doctor.sh",
 		"mol-dog-phantom-db.sh",
+		"supervisor_signals.sh",
 	} {
 		t.Run(scriptName, func(t *testing.T) {
 			cmd := exec.Command("bash", "-n", filepath.Join(root, "assets", "scripts", scriptName))
@@ -5041,7 +5043,225 @@ exit 0
 	}
 }
 
+// writeDoctorHealthyDolt installs a fake dolt that answers the doctor's probe
+// queries as a healthy server (reachable, one connection, no user databases)
+// and logs every invocation to queryLogPath. Tests use that log to assert the
+// watchdog's SOFT contract: its load-average and supervisor signals add no dolt
+// query.
+func writeDoctorHealthyDolt(t *testing.T, binDir, queryLogPath string) {
+	t.Helper()
+	writeExecutable(t, filepath.Join(binDir, "dolt"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%%s\n' "$*" >> %s
+case "$*" in
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    ;;
+  *"SELECT @@GLOBAL.max_connections"*)
+    printf '@@GLOBAL.max_connections\n256\n'
+    ;;
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\n'
+    ;;
+esac
+exit 0
+`, shellQuote(queryLogPath)))
+}
+
+// writeDoctorFakeGCWithTrace installs a fake gc that, like writeDogFakeGC, logs
+// every invocation, and additionally emits traceJSON on stdout for
+// `gc trace show ...` so the doctor's dolt-free supervisor probe has canned
+// input. Every other subcommand stays silent and exits 0.
+func writeDoctorFakeGCWithTrace(t *testing.T, binDir, traceJSON string) string {
+	t.Helper()
+	logPath := filepath.Join(binDir, "gc.log")
+	writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
+printf 'gc %%s\n' "$*" >> %s
+if [ "$1" = "trace" ] && [ "$2" = "show" ]; then
+  cat <<'GCTRACE_EOF'
+%s
+GCTRACE_EOF
+fi
+exit 0
+`, shellQuote(logPath), traceJSON))
+	return logPath
+}
+
+// TestDoctorScriptWarnsOnHighLoadAverage asserts the watchdog raises the
+// [MEDIUM] advisory when the host load average saturates the CPUs — an early,
+// dolt-free signal that the managed server is about to starve — and that
+// measuring it adds no dolt query (the SOFT contract).
+func TestDoctorScriptWarnsOnHighLoadAverage(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	queryLogPath := filepath.Join(binDir, "dolt-queries.log")
+	writeDoctorHealthyDolt(t, binDir, queryLogPath)
+
+	// 64 over 8 cores is 8.0/core, double the 4.0/core threshold, so the load
+	// signal must fire. Latency and connections are healthy, so the advisory is
+	// attributable to load alone.
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir,
+		"GC_DOCTOR_LOADAVG_1MIN=64", "GC_DOCTOR_CPU_COUNT=8",
+		"GC_DOCTOR_LOADAVG_WARN_PER_CORE=4.0")
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("doctor should report server ok, output:\n%s", out)
+	}
+	if !strings.Contains(out, "load: 64/8c") {
+		t.Fatalf("doctor summary should report load over cores, output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "mail send human -s Dolt health advisory [MEDIUM]") {
+		t.Fatalf("high load average should raise the [MEDIUM] advisory, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "load avg 1m 8.00/core >= threshold 4.00/core") {
+		t.Fatalf("advisory should quantify the per-core load breach, log:\n%s", gcLog)
+	}
+	// SOFT contract: the load read is local and the supervisor read goes through
+	// gc trace show — neither may reach dolt.
+	queryLog, err := os.ReadFile(queryLogPath)
+	if err != nil {
+		t.Fatalf("read dolt query log: %v", err)
+	}
+	for _, leaked := range []string{"loadavg", "load average", "cycle_input_snapshot", "trace"} {
+		if strings.Contains(string(queryLog), leaked) {
+			t.Fatalf("watchdog queried dolt for a soft signal (%q); it must stay dolt-free, query log:\n%s", leaked, queryLog)
+		}
+	}
+}
+
+// TestDoctorScriptWarnsOnSupervisorScaleCheckPartial asserts a scale-check
+// PARTIAL recorded in the controller's reconcile trace raises the advisory —
+// read via gc trace show, never dolt.
+func TestDoctorScriptWarnsOnSupervisorScaleCheckPartial(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	binDir := t.TempDir()
+	traceJSON := `[{"type":"cycle_input_snapshot","fields":{"scale_check_query_partial":true,"store_query_partial":false,"session_query_partial":false}}]`
+	gcLogPath := writeDoctorFakeGCWithTrace(t, binDir, traceJSON)
+	queryLogPath := filepath.Join(binDir, "dolt-queries.log")
+	writeDoctorHealthyDolt(t, binDir, queryLogPath)
+
+	// Force load low so the supervisor scale-check PARTIAL is the sole warn.
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir,
+		"GC_DOCTOR_LOADAVG_1MIN=0.10", "GC_DOCTOR_CPU_COUNT=8")
+	if !strings.Contains(out, "supervisor: PARTIAL (scalecheck)") {
+		t.Fatalf("doctor summary should mark supervisor scale-check PARTIAL, output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "mail send human -s Dolt health advisory [MEDIUM]") {
+		t.Fatalf("supervisor scale-check PARTIAL should raise the [MEDIUM] advisory, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "supervisor scale-check query PARTIAL") {
+		t.Fatalf("advisory should name the scale-check PARTIAL condition, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "trace show --since") {
+		t.Fatalf("supervisor signal must be read via gc trace show, log:\n%s", gcLog)
+	}
+	queryLog, err := os.ReadFile(queryLogPath)
+	if err != nil {
+		t.Fatalf("read dolt query log: %v", err)
+	}
+	if strings.Contains(string(queryLog), "cycle_input_snapshot") || strings.Contains(string(queryLog), "trace") {
+		t.Fatalf("supervisor probe must not touch dolt, query log:\n%s", queryLog)
+	}
+}
+
+// TestDoctorScriptWarnsOnSupervisorStorePartial asserts a store-read PARTIAL —
+// the supervisor-side shadow of a tripped "dolt circuit breaker is open" —
+// raises the advisory and is named as circuit-breaker / store instability.
+func TestDoctorScriptWarnsOnSupervisorStorePartial(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	binDir := t.TempDir()
+	traceJSON := `[{"type":"cycle_input_snapshot","fields":{"scale_check_query_partial":false,"store_query_partial":true,"session_query_partial":false}}]`
+	gcLogPath := writeDoctorFakeGCWithTrace(t, binDir, traceJSON)
+	queryLogPath := filepath.Join(binDir, "dolt-queries.log")
+	writeDoctorHealthyDolt(t, binDir, queryLogPath)
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir,
+		"GC_DOCTOR_LOADAVG_1MIN=0.10", "GC_DOCTOR_CPU_COUNT=8")
+	if !strings.Contains(out, "supervisor: PARTIAL (store)") {
+		t.Fatalf("doctor summary should mark supervisor store PARTIAL, output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "mail send human -s Dolt health advisory [MEDIUM]") {
+		t.Fatalf("supervisor store PARTIAL should raise the [MEDIUM] advisory, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "supervisor store read PARTIAL") {
+		t.Fatalf("advisory should name the store PARTIAL condition, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "circuit breaker") {
+		t.Fatalf("advisory should attribute store PARTIAL to circuit-breaker / store instability, log:\n%s", gcLog)
+	}
+}
+
+// TestDoctorScriptSendsRecoveredNoteAfterAdvisoryClears asserts the watchdog
+// emits a single [RECOVERED] note on the first healthy tick after a degraded
+// advisory. Reusing cityPath persists the recorded advisory state across ticks.
+func TestDoctorScriptSendsRecoveredNoteAfterAdvisoryClears(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	queryLogPath := filepath.Join(binDir, "dolt-queries.log")
+	writeDoctorHealthyDolt(t, binDir, queryLogPath)
+
+	// Tick 1: high load drives a [MEDIUM] advisory and records the state.
+	out1 := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir,
+		"GC_DOCTOR_LOADAVG_1MIN=64", "GC_DOCTOR_CPU_COUNT=8", "GC_DOCTOR_LOADAVG_WARN_PER_CORE=4.0")
+	if !strings.Contains(out1, "load: 64/8c") {
+		t.Fatalf("tick 1 should observe high load, output:\n%s", out1)
+	}
+	// Tick 2: load subsides; the persisted state makes this healthy tick emit
+	// exactly one [RECOVERED] note.
+	out2 := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir,
+		"GC_DOCTOR_LOADAVG_1MIN=0.50", "GC_DOCTOR_CPU_COUNT=8", "GC_DOCTOR_LOADAVG_WARN_PER_CORE=4.0")
+	if !strings.Contains(out2, "load: 0.50/8c") {
+		t.Fatalf("tick 2 should observe low load, output:\n%s", out2)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "mail send human -s Dolt health advisory [RECOVERED]") {
+		t.Fatalf("healthy tick after a degraded advisory must send a [RECOVERED] note, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "returned to normal") {
+		t.Fatalf("[RECOVERED] note should state health returned to normal, log:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "Cleared conditions: load") {
+		t.Fatalf("[RECOVERED] note should name the cleared condition, log:\n%s", gcLog)
+	}
+}
+
 // TestDoctorScriptUnreachableEscalationUsesGenericEscalation asserts the
+
 // server-unreachable path goes through the generic escalation recipient.
 func TestDoctorScriptUnreachableEscalationUsesGenericEscalation(t *testing.T) {
 	cityPath := t.TempDir()

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -5260,6 +5260,70 @@ func TestDoctorScriptSendsRecoveredNoteAfterAdvisoryClears(t *testing.T) {
 	}
 }
 
+// TestDoctorScriptToleratesSlowSupervisorTrace asserts the SOFT contract holds
+// even when the supervisor trace read itself stalls. `gc trace show` is a local,
+// dolt-free read, but under the CPU saturation this watchdog exists to catch
+// even a local subprocess can wedge — so the fetch is wall-clock bounded
+// (GC_DOCTOR_SUPERVISOR_TIMEOUT_SECS). On timeout it yields no signal and the
+// doctor finishes the tick reporting "supervisor: ok" and raises no advisory,
+// rather than hanging to collect a signal it could read next tick. A regression
+// that dropped the bound would instead block for the full stall, read the
+// store-PARTIAL the fake then emits, and wrongly alert — so this fails on both
+// timing and outcome.
+func TestDoctorScriptToleratesSlowSupervisorTrace(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	binDir := t.TempDir()
+	gcLogPath := filepath.Join(binDir, "gc.log")
+	// Fake gc logs every call first (so the attempted read is recorded even when
+	// the process is killed mid-read), then stalls 10s on `trace show` before it
+	// would emit a store-PARTIAL record — well past the 2s bound set below.
+	writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
+printf 'gc %%s\n' "$*" >> %s
+if [ "$1" = "trace" ] && [ "$2" = "show" ]; then
+  sleep 10
+  printf '[{"type":"cycle_input_snapshot","fields":{"store_query_partial":true}}]\n'
+fi
+exit 0
+`, shellQuote(gcLogPath)))
+	queryLogPath := filepath.Join(binDir, "dolt-queries.log")
+	writeDoctorHealthyDolt(t, binDir, queryLogPath)
+
+	// Bound the trace read at 2s against the 10s stall; keep load low so a hang
+	// would be the only possible source of delay or of any warning.
+	start := time.Now()
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir,
+		"GC_DOCTOR_SUPERVISOR_TIMEOUT_SECS=2",
+		"GC_DOCTOR_LOADAVG_1MIN=0.10", "GC_DOCTOR_CPU_COUNT=8")
+	if elapsed := time.Since(start); elapsed > 8*time.Second {
+		t.Fatalf("doctor blocked on the slow trace read (%s); the fetch must be time-bounded", elapsed)
+	}
+	if !strings.Contains(out, "supervisor: ok") {
+		t.Fatalf("a timed-out trace read must yield no signal (supervisor: ok), output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "trace show --since") {
+		t.Fatalf("doctor should still attempt the bounded trace read, log:\n%s", gcLog)
+	}
+	if strings.Contains(string(gcLog), "[MEDIUM]") {
+		t.Fatalf("a timed-out trace read must not raise a (false) advisory, log:\n%s", gcLog)
+	}
+	// SOFT contract: the supervisor probe never touches dolt, even on timeout.
+	queryLog, err := os.ReadFile(queryLogPath)
+	if err != nil {
+		t.Fatalf("read dolt query log: %v", err)
+	}
+	if strings.Contains(string(queryLog), "cycle_input_snapshot") || strings.Contains(string(queryLog), "trace") {
+		t.Fatalf("supervisor probe must not touch dolt, query log:\n%s", queryLog)
+	}
+}
+
 // TestDoctorScriptUnreachableEscalationUsesGenericEscalation asserts the
 
 // server-unreachable path goes through the generic escalation recipient.

--- a/test/dolt/loadavg_test.sh
+++ b/test/dolt/loadavg_test.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Unit test for examples/bd/dolt/assets/scripts/loadavg.sh.
+#
+# The dolt-health watchdog reads the host load average as a *local*, dolt-free
+# early-warning signal that the managed server is about to starve under CPU
+# pressure. This proves the integer-hundredths ("centi") math, the per-core warn
+# decision (including the disable and boundary cases), the source overrides used
+# by the doctor's tests, and — critically — that every helper is safe under the
+# caller's `set -e` (it must never abort the doctor).
+#
+# Run: sh test/dolt/loadavg_test.sh
+set -u
+HERE=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+LOADAVG_LIB="${LOADAVG_LIB:-$HERE/../../examples/bd/dolt/assets/scripts/loadavg.sh}"
+
+if [ ! -f "$LOADAVG_LIB" ]; then
+  echo "FAIL: loadavg helper not found at $LOADAVG_LIB"
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$LOADAVG_LIB"
+
+fail=0
+pass() { echo "PASS: $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+for fn in cpu_count loadavg_1min to_centi centi_to_dec loadavg_should_warn; do
+  command -v "$fn" >/dev/null 2>&1 || { echo "FAIL: $fn not defined"; exit 1; }
+done
+
+# eq NAME GOT WANT — assert string equality.
+eq() {
+  if [ "$2" = "$3" ]; then pass "$1 -> $2"; else bad "$1: got '$2', want '$3'"; fi
+}
+
+# --- to_centi: decimal -> integer hundredths -------------------------------
+eq "to_centi 2.34"  "$(to_centi 2.34)"  "234"
+eq "to_centi 10"    "$(to_centi 10)"    "1000"
+eq "to_centi 0.5"   "$(to_centi 0.5)"   "50"
+eq "to_centi 0.05"  "$(to_centi 0.05)"  "5"
+eq "to_centi 0"     "$(to_centi 0)"     "0"
+eq "to_centi 3.999(trunc)" "$(to_centi 3.999)" "399"
+eq "to_centi abc(clamp)"   "$(to_centi abc)"   "0"
+eq "to_centi ''(clamp)"    "$(to_centi '')"    "0"
+
+# --- centi_to_dec: integer hundredths -> decimal ---------------------------
+eq "centi_to_dec 234"  "$(centi_to_dec 234)"  "2.34"
+eq "centi_to_dec 1000" "$(centi_to_dec 1000)" "10.00"
+eq "centi_to_dec 5"    "$(centi_to_dec 5)"    "0.05"
+eq "centi_to_dec 0"    "$(centi_to_dec 0)"    "0.00"
+
+# Round-trip: a value formatted then re-parsed is unchanged.
+for v in 234 1000 5 4 3200; do
+  rt=$(to_centi "$(centi_to_dec "$v")")
+  eq "round-trip $v" "$rt" "$v"
+done
+
+# --- loadavg_should_warn: per-core threshold, integer compare --------------
+# 32.00 over 8 cores == 4.00/core, boundary of a 4.00/core threshold -> warn.
+if loadavg_should_warn 3200 8 400; then pass "32.0/8core >= 4.0/core -> warn"; else bad "boundary 4.0/core did not warn"; fi
+if loadavg_should_warn 3199 8 400; then bad "31.99/8core warned below 4.0/core"; else pass "31.99/8core -> no warn"; fi
+# Single core boundary.
+if loadavg_should_warn 400 1 400; then pass "4.0/1core == threshold -> warn"; else bad "single-core boundary did not warn"; fi
+if loadavg_should_warn 399 1 400; then bad "3.99/1core warned"; else pass "3.99/1core -> no warn"; fi
+# Threshold 0 (or non-numeric) disables the check entirely.
+if loadavg_should_warn 999999 1 0; then bad "threshold 0 did not disable the check"; else pass "threshold 0 disables"; fi
+if loadavg_should_warn 999999 1 abc; then bad "non-numeric threshold did not disable"; else pass "non-numeric threshold disables"; fi
+# A zero CPU count is coerced to 1, not a divide-by-zero.
+if loadavg_should_warn 500 0 400; then pass "cpu=0 coerced to 1 (5.0 >= 4.0 -> warn)"; else bad "cpu=0 not coerced to 1"; fi
+
+# --- source overrides (used by the doctor's Go tests) ----------------------
+eq "cpu_count override 4"       "$(GC_DOCTOR_CPU_COUNT=4 cpu_count)"        "4"
+eq "loadavg_1min override 7.5"  "$(GC_DOCTOR_LOADAVG_1MIN=7.5 loadavg_1min)" "7.5"
+# An invalid CPU override falls back to a real count (always >= 1).
+oc=$(GC_DOCTOR_CPU_COUNT=0 cpu_count)
+if [ "$oc" -ge 1 ] 2>/dev/null; then pass "cpu_count invalid override falls back to >=1 ($oc)"; else bad "cpu_count invalid override: '$oc'"; fi
+
+# --- live sources are numeric and never empty ------------------------------
+rc=$(cpu_count)
+if [ "$rc" -ge 1 ] 2>/dev/null; then pass "cpu_count (live) >= 1 ($rc)"; else bad "cpu_count (live) not a positive integer: '$rc'"; fi
+rl=$(loadavg_1min)
+case "$rl" in *[0-9]*) pass "loadavg_1min (live) is numeric ($rl)" ;; *) bad "loadavg_1min (live) non-numeric: '$rl'" ;; esac
+
+# --- SOFT contract: never abort the caller under set -e --------------------
+# Each helper is only ever evaluated inside the doctor's `if`/command-subst;
+# under `set -e` a non-zero return from a bare call would abort. Prove the
+# no-signal paths (empty/garbage input) still exit 0 when called bare.
+if ( set -e; . "$LOADAVG_LIB"; cpu_count >/dev/null; loadavg_1min >/dev/null; to_centi '' >/dev/null; centi_to_dec '' >/dev/null; true ); then
+  pass "helpers do not abort under set -e"
+else
+  bad "a helper aborted a set -e caller"
+fi
+
+echo "----"
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES PRESENT"; fi
+exit "$fail"

--- a/test/dolt/supervisor_signals_test.sh
+++ b/test/dolt/supervisor_signals_test.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Unit test for examples/bd/dolt/assets/scripts/supervisor_signals.sh.
+#
+# The dolt-health watchdog reads the supervisor's own reconcile trace to catch
+# the beads store destabilizing — scale-check PARTIAL (pools may not scale, work
+# stalls) and store/session PARTIAL (the supervisor-side shadow of a tripped
+# "dolt circuit breaker is open"). The parse is split from the `gc trace show`
+# fetch precisely so it can be proven here against canned JSON with no
+# controller and no dolt running — which is also what keeps the signal SOFT.
+#
+# Run: sh test/dolt/supervisor_signals_test.sh
+set -u
+HERE=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+SUP_LIB="${SUP_LIB:-$HERE/../../examples/bd/dolt/assets/scripts/supervisor_signals.sh}"
+
+if [ ! -f "$SUP_LIB" ]; then
+  echo "FAIL: supervisor_signals helper not found at $SUP_LIB"
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$SUP_LIB"
+
+fail=0
+pass() { echo "PASS: $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+for fn in supervisor_flag_true supervisor_signals; do
+  command -v "$fn" >/dev/null 2>&1 || { echo "FAIL: $fn not defined"; exit 1; }
+done
+
+# eq NAME GOT WANT — assert string equality (shows the JSON case name).
+eq() {
+  if [ "$2" = "$3" ]; then pass "$1 -> [$2]"; else bad "$1: got '$2', want '$3'"; fi
+}
+
+# --- healthy / empty inputs yield no signals -------------------------------
+eq "empty string"      "$(supervisor_signals '')"    ""
+eq "empty array"       "$(supervisor_signals '[]')"  ""
+eq "empty object"      "$(supervisor_signals '{}')"  ""
+eq "all-false flags"   "$(supervisor_signals '{"fields":{"scale_check_query_partial":false,"store_query_partial":false,"session_query_partial":false}}')" ""
+
+# --- individual signals ----------------------------------------------------
+eq "scale-check PARTIAL" \
+  "$(supervisor_signals '{"fields":{"scale_check_query_partial":true}}')" "scalecheck"
+eq "store PARTIAL (store_query_partial)" \
+  "$(supervisor_signals '{"fields":{"store_query_partial":true}}')" "store"
+eq "store PARTIAL (session_query_partial folds into store)" \
+  "$(supervisor_signals '{"fields":{"session_query_partial":true}}')" "store"
+
+# --- both signals, in the fixed (deterministic) order ----------------------
+eq "scale-check + store" \
+  "$(supervisor_signals '{"fields":{"scale_check_query_partial":true,"store_query_partial":true}}')" "scalecheck store"
+
+# --- whitespace tolerance: `"f": true` (space after colon) still matches ----
+eq "space after colon" \
+  "$(supervisor_signals '{ "fields": { "scale_check_query_partial": true } }')" "scalecheck"
+
+# --- signal seen anywhere in the window (multi-record array) ----------------
+eq "signal in a later record" \
+  "$(supervisor_signals '[{"fields":{"scale_check_query_partial":false}},{"fields":{"store_query_partial":true}}]')" "store"
+
+# --- no false positives -----------------------------------------------------
+# A field whose name merely *extends* a signal key must not match: the parser
+# keys on the exact `"<field>":true`, so `..._partial_ext":true` is not a hit.
+eq "extended-key name is not a match" \
+  "$(supervisor_signals '{"fields":{"scale_check_query_partial_ext":true}}')" ""
+# Newlines are preserved, so a key at the end of one line cannot join a value on
+# the next — this is deliberate; `gc trace show --json` emits each record's
+# `:true` contiguously, and matching across a newline would be a false positive.
+eq "key and value split across a newline is not a match" \
+  "$(supervisor_signals "$(printf '{"scale_check_query_partial":\ntrue}')")" ""
+
+# --- supervisor_flag_true direct contract ----------------------------------
+if supervisor_flag_true "store_query_partial" '{"store_query_partial":true}'; then pass "flag_true true-case"; else bad "flag_true missed a true flag"; fi
+if supervisor_flag_true "store_query_partial" '{"store_query_partial":false}'; then bad "flag_true matched a false flag"; else pass "flag_true false-case"; fi
+if supervisor_flag_true "" '{"store_query_partial":true}'; then bad "flag_true matched an empty field name"; else pass "flag_true empty-field guarded"; fi
+
+# --- SOFT contract: never abort the caller under set -e --------------------
+# The doctor calls these inside command substitution under `set -e`; the
+# no-signal (empty output) path must still exit 0, not abort the tick.
+if ( set -e; . "$SUP_LIB"; supervisor_signals '' >/dev/null; supervisor_signals '{}' >/dev/null; true ); then
+  pass "supervisor_signals does not abort under set -e"
+else
+  bad "supervisor_signals aborted a set -e caller"
+fi
+
+echo "----"
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES PRESENT"; fi
+exit "$fail"


### PR DESCRIPTION
## Problem

The managed dolt beads `sql-server` intermittently destabilizes under host CPU
load (e.g. security-scan spikes alongside dolt's own re-index passes). When it
does, `bd` queries time out, the per-scope circuit breaker trips open, the
supervisor scale-check goes PARTIAL, and routed work silently stalls as
unclaimed — with **no proactive signal**. Today we only notice after work
mysteriously stops.

## What this adds

Extends the existing read-only doctor dog (`mol-dog-doctor`) with three
degradation signals, folded into its existing rolling `[MEDIUM]` advisory (same
dedup-by-active-conditions signature and mail format). Each tick now also:

- **Load average** — reads the host 1-minute load average (a *local* read) and
  warns when sustained per-core load saturates the CPUs and starves the managed
  server (default `4.0`/core; `GC_DOCTOR_LOADAVG_WARN_PER_CORE`).
- **Supervisor scale-check PARTIAL** — reads the controller's own reconcile
  trace via `gc trace show` (not a dolt query) for `scale_check_query_partial`:
  pools may not scale and queued work stalls.
- **Supervisor store PARTIAL** — the same trace read for `store_query_partial` /
  `session_query_partial`: the supervisor-side shadow of a tripped
  "dolt circuit breaker is open".
- **`[RECOVERED]` note** — exactly one note on the first healthy tick after a
  degraded advisory, then the recorded advisory state clears.

## SOFT contract

Both new probes are **dolt-free**: a local load-average read and a read of the
trace the controller already wrote. They add **no query load** to the server the
watchdog protects, and still report when dolt is too wedged to answer. The trace
fetch is guarded so a missing/slow trace store never hangs or aborts the doctor.
Cadence is unchanged (5-minute cooldown order).

## Design

The integer load math (`loadavg.sh`) and the trace-JSON parse
(`supervisor_signals.sh`) are new sourced libs, split from the fetch so they
stay unit-testable on canned input with no dolt or controller running. Trace
field names (`scale_check_query_partial`, `store_query_partial`,
`session_query_partial`) and the `cycle_input_snapshot` record type match what
`cmd/gc/city_runtime.go` emits; the `gc trace show --since/--type/--json`
interface is the supported one-shot reader.

## Testing

- New standalone POSIX-sh unit tests under `test/dolt/` (`loadavg_test.sh`,
  `supervisor_signals_test.sh`) cover the load math (centi conversions,
  per-core threshold, cpu/loadavg source fallbacks) and the trace parse
  (quote-anchored, newline-safe, deterministic token order). **All pass locally.**
- New Go E2E tests in `dog_exec_scripts_test.go` exercise the doctor end-to-end
  with fake `gc`/`dolt` binaries: high-load advisory, scale-check PARTIAL, store
  PARTIAL, the `[RECOVERED]` transition, and assert the SOFT contract (the dolt
  query log stays free of the load/trace probes). The new libs are added to the
  existing `bash -n` syntax gate. (Left to CI to run — the `bash -n` gate and
  `gofmt` pass locally.)
