### PR TITLE
fix(cmd/gc): wake on-demand named sessions for work claimed under their runtime name

### DIFF
--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -293,7 +293,7 @@ func TestOrphanReleaseSparesALiveHoldersBindingResidentClaim(t *testing.T) {
 
 	infos := sessionInfosFromBeads([]beads.Bead{sess})
 	released := releaseOrphanedPoolAssignments(
-		work, cfg, cityPath, infos,
+		work, beads.SessionStore{Store: work}, cfg, cityPath, infos,
 		[]beads.Bead{claim}, []beads.Store{work}, []string{""}, nil,
 	)
 	if len(released) != 0 {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -952,7 +952,7 @@ func buildDesiredStateWithSessionBeads(
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)
-			if assignee != identity {
+			if !namedSessionAssigneeMatchesSpec(spec, identity, assignee) {
 				continue
 			}
 			// ga-i1d0tr Candidate B: a bare-template Assignee used to be

--- a/cmd/gc/build_desired_state_named_session_assignee_form_test.go
+++ b/cmd/gc/build_desired_state_named_session_assignee_form_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestNamedWorkReadyMatchesRuntimeSessionNameAssignee is the ga-e70d2 repro.
+//
+// Work routed to a [[named_session]] is claimed under the session's *runtime*
+// name — the tmux-safe form config.NamedSessionRuntimeName produces ("/" -> "--",
+// "." -> "__") — not under the session's qualified identity. Live maintainer-city
+// beads show both forms side by side on the same bead:
+//
+//	gcg-284771409691718 assignee=seth__seth routed=seth.seth status=open
+//	bead.dead_assignee_reopened {"dead_assignee":"randy__randy","routed_to":"randy.randy"}
+//
+// namedWorkReady compared wb.Assignee against the qualified identity with a raw
+// !=, so the two forms never matched and on-demand named sessions never woke for
+// their own assigned work. On the live city that left the randy/seth/wendy patrol
+// orders open and unstarted for 12h, and the supervisor logged ready=map[] on all
+// 2623 evaluations in a day.
+//
+// spec.SessionName is already an accepted alias for the identity elsewhere in the
+// resolver (session.ResolveNamedSessionSpecForConfigTarget matches on it), so
+// honoring it here restores a convention the rest of the code already relies on.
+func TestNamedWorkReadyMatchesRuntimeSessionNameAssignee(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	const identity = "gascity/patrol"
+	runtimeName := agent.SanitizeQualifiedNameForSession(identity)
+	if runtimeName == identity {
+		t.Fatalf("test premise broken: %q sanitizes to itself, so there are not two distinct forms to confuse", identity)
+	}
+
+	// The bead is assigned under the runtime session name, exactly as the live
+	// city records it, and is in_progress so it bypasses the readiness gate and
+	// isolates the assignee-form comparison as the only thing under test.
+	b, err := rigStore.Create(beads.Bead{
+		Title:    "patrol work claimed under the runtime session name",
+		Type:     "task",
+		Status:   "open",
+		Assignee: runtimeName,
+		Metadata: map[string]string{"gc.routed_to": identity},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgress := "in_progress"
+	if err := rigStore.Update(b.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:         "patrol",
+			Dir:          "gascity",
+			StartCommand: "true",
+			WorkQuery:    "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "patrol",
+			Dir:      "gascity",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+	)
+
+	if !dsResult.NamedSessionDemand[identity] {
+		t.Fatalf("named session %q has an in_progress bead assigned to its runtime session name %q "+
+			"but generated no named-session demand (NamedSessionDemand=%v).\n"+
+			"namedWorkReady compared the bead assignee against the qualified identity only, so the "+
+			"runtime-session-name form never matched and the on-demand session never woke for its own work.",
+			identity, runtimeName, dsResult.NamedSessionDemand)
+	}
+}
+
+// TestNamedWorkReadyStillIgnoresUnrelatedAssignee is the control for the test
+// above: honoring the runtime session name must not turn every assignee into a
+// match. A bead assigned to some other agent entirely must still produce no
+// named-session demand — otherwise the first test would pass for the wrong
+// reason.
+func TestNamedWorkReadyStillIgnoresUnrelatedAssignee(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "gascity")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	b, err := rigStore.Create(beads.Bead{
+		Title:    "work belonging to a different agent",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "gascity/somebody-else",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgress := "in_progress"
+	if err := rigStore.Update(b.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gc"},
+		Rigs:      []config.Rig{{Name: "gascity", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:         "patrol",
+			Dir:          "gascity",
+			StartCommand: "true",
+			WorkQuery:    "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "patrol",
+			Dir:      "gascity",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"gc", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"gascity": rigStore}, nil, nil, io.Discard,
+	)
+
+	if dsResult.NamedSessionDemand["gascity/patrol"] {
+		t.Fatalf("a bead assigned to gascity/somebody-else woke named session gascity/patrol "+
+			"(NamedSessionDemand=%v); the assignee match is too loose", dsResult.NamedSessionDemand)
+	}
+}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2415,10 +2415,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	if store == nil {
 		return
 	}
-	// Session-class ops (pool-session sweep, wait-wake state, reconcile) route
-	// through the typed session store (gastownhall/gascity#3773); it wraps the
-	// same underlying store value as the work store today, so behavior is
-	// unchanged.
+	// Session-class ops (pool-session sweep, wait-wake state, reconcile, and the
+	// orphan-release liveness read) route through the typed session store
+	// (gastownhall/gascity#3773). On a city whose [storage.classes] relocates
+	// sessions this is a different store than the work store, so the two must
+	// not be used interchangeably (ga-g3pf0).
 	sessStore := cr.sessionsBeadStore()
 	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
 		if trace != nil {
@@ -2450,7 +2451,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
 	phaseStart := time.Now()
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores)
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
 		"released_count": len(released),
 	})

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -980,10 +980,9 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// arm (collectAssignedWorkBeadsWithStores / cold-wake scale-check probes) — a dual
 	// role the daemon routes to the session store today too, tracked as a shared E2
 	// two-store split. Identity to oneShotStore at the single-store backend, so
-	// byte-identical today. releaseOrphanedPoolAssignmentsWhenSnapshotsComplete keeps
-	// the plain oneShotStore, matching the daemon's cityBeadStore() there (its lone
-	// liveOpenSessionAssignmentExists session read is a shared work-release-boundary
-	// follow-up).
+	// byte-identical today. releaseOrphanedPoolAssignmentsWhenSnapshotsComplete takes
+	// both: oneShotStore as the work-class owner fallback and sessStore for its lone
+	// liveOpenSessionAssignmentExists session read (ga-g3pf0).
 	sessStore := cliSessionStore(oneShotStore, cfg, cityPath)
 
 	// One-shot bead reconciliation: same code path as the daemon.
@@ -1002,7 +1001,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
 	)
 
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -656,6 +656,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 
 	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
+		beads.SessionStore{Store: store},
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
 		"",
 		nil,
@@ -679,6 +680,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 
 	released = releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
+		beads.SessionStore{Store: store},
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
 		"",
 		nil,
@@ -702,6 +704,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 
 	released = releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
+		beads.SessionStore{Store: store},
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
 		"",
 		nil,

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -182,6 +182,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveAssigneeStaysAssigned(t *testin
 
 	released := releaseOrphanedPoolAssignments(
 		store,
+		beads.SessionStore{Store: store},
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		"",
 		sessionInfosFromBeads([]beads.Bead{live}),

--- a/cmd/gc/execution_stalled_convergence_test.go
+++ b/cmd/gc/execution_stalled_convergence_test.go
@@ -177,7 +177,7 @@ func TestExecutionStalledDrainConvergesToAReclaimableRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-reading the claim: %v", err)
 	}
-	released := releaseOrphanedPoolAssignments(h.env.store, h.env.cfg, "", nil,
+	released := releaseOrphanedPoolAssignments(h.env.store, beads.SessionStore{Store: h.env.store}, h.env.cfg, "", nil,
 		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil)
 	if len(released) != 1 || released[0].ID != h.work.ID {
 		t.Fatalf("released = %+v, want the stalled claim reopened", released)
@@ -307,7 +307,7 @@ func TestExecutionStalledDrainDoesNotStrandAMidDrainWake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-reading the claim: %v", err)
 	}
-	released := releaseOrphanedPoolAssignments(h.env.store, h.env.cfg, "", nil,
+	released := releaseOrphanedPoolAssignments(h.env.store, beads.SessionStore{Store: h.env.store}, h.env.cfg, "", nil,
 		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil)
 	if len(released) != 1 {
 		t.Fatalf("released = %+v, want the claim released once its holder is gone", released)

--- a/cmd/gc/named_sessions.go
+++ b/cmd/gc/named_sessions.go
@@ -47,6 +47,42 @@ func namedSessionAssigneeMatchesSpec(spec namedSessionSpec, identity, assignee s
 	return assignee == identity || assignee == strings.TrimSpace(spec.SessionName)
 }
 
+// findNamedSessionSpecForAssignee resolves the configured named session that a
+// bead's assignee refers to, accepting every form a real claim can carry.
+//
+// findNamedSessionSpec alone is not enough: it matches the qualified identity
+// (and the V2 bare leaf), but a named session claims work under its tmux-safe
+// runtime name — "seth.seth" claims as "seth__seth". Callers that resolved
+// assignees with the identity-only lookup were therefore inert for the one form
+// that actually appears on claimed beads (ga-e70d2).
+//
+// The fallback deliberately reuses namedSessionAssigneeMatchesSpec rather than
+// session.ResolveNamedSessionSpecForConfigTarget. That resolver also accepts
+// bare template names because it resolves USER input (`gc session wake seth`);
+// an assignee is not user input, and widening claim resolution that far would
+// preserve routes for names no session ever claimed under. Config load rejects
+// identity/session-name collisions city-wide (config.validateNamedSessions), so
+// at most one spec can match.
+func findNamedSessionSpecForAssignee(cfg *config.City, cityName, assignee string) (namedSessionSpec, bool) {
+	if cfg == nil || strings.TrimSpace(assignee) == "" {
+		return namedSessionSpec{}, false
+	}
+	if spec, ok := findNamedSessionSpec(cfg, cityName, assignee); ok {
+		return spec, true
+	}
+	for i := range cfg.NamedSessions {
+		identity := cfg.NamedSessions[i].QualifiedName()
+		spec, ok := findNamedSessionSpec(cfg, cityName, identity)
+		if !ok {
+			continue
+		}
+		if namedSessionAssigneeMatchesSpec(spec, identity, assignee) {
+			return spec, true
+		}
+	}
+	return namedSessionSpec{}, false
+}
+
 func resolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, rigContext string) (namedSessionSpec, bool, error) {
 	return session.ResolveNamedSessionSpecForConfigTarget(cfg, cityName, target, rigContext)
 }

--- a/cmd/gc/named_sessions.go
+++ b/cmd/gc/named_sessions.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
@@ -28,6 +30,21 @@ func findNamedSessionSpec(cfg *config.City, cityName, identity string) (namedSes
 
 func namedSessionBackingTemplate(spec namedSessionSpec) string {
 	return session.NamedSessionBackingTemplate(spec)
+}
+
+// namedSessionAssigneeMatchesSpec reports whether assignee names spec's session.
+// Work routed to a named session is claimed under the session's runtime name
+// (config.NamedSessionRuntimeName: "/" -> "--", "." -> "__"), not under its
+// qualified identity, so both forms have to count. spec.SessionName is already
+// an accepted alias for the identity in the resolver
+// (session.ResolveNamedSessionSpecForConfigTarget); matching only the qualified
+// form here left on-demand named sessions asleep on their own assigned work
+// (ga-e70d2).
+func namedSessionAssigneeMatchesSpec(spec namedSessionSpec, identity, assignee string) bool {
+	if assignee == "" {
+		return false
+	}
+	return assignee == identity || assignee == strings.TrimSpace(spec.SessionName)
 }
 
 func resolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, rigContext string) (namedSessionSpec, bool, error) {

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -96,6 +96,7 @@ func GCSweepSessionBeads(cityPath string, store beads.Store, rigStores map[strin
 // unless both the assigned-work and open-session snapshots are complete.
 func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	store beads.Store,
+	sessionStore beads.SessionStore,
 	cfg *config.City,
 	cityPath string,
 	openSessionInfos []session.Info,
@@ -108,15 +109,26 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	if result.snapshotQueryPartial() {
 		return nil
 	}
-	return releaseOrphanedPoolAssignments(store, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores)
+	return releaseOrphanedPoolAssignments(store, sessionStore, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores)
 }
 
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
 // assignee no longer maps to any open session bead. This also recovers
 // pool-routed work left in_progress with no assignee, which cannot be claimed
 // again until it is moved back to open.
+//
+// store and sessionStore are deliberately separate parameters because the two
+// reads here are different storage classes: sessionStore backs the
+// liveOpenSessionAssignmentExists liveness check (session class), while store
+// is only the work-class fallback owner for storeForPoolAssignment. On a city
+// whose [storage.classes] relocates sessions away from the work store, passing
+// the work store for both makes the liveness query run against a store that
+// serves zero session beads — an empty-success List that reads as "assignee is
+// dead" and releases live work every tick (ga-g3pf0). They are the same store
+// value on a single-store city.
 func releaseOrphanedPoolAssignments(
 	store beads.Store,
+	sessionStore beads.SessionStore,
 	cfg *config.City,
 	cityPath string,
 	openSessionInfos []session.Info,
@@ -127,6 +139,13 @@ func releaseOrphanedPoolAssignments(
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
+	}
+	// A missing session store must not read as "every assignee is dead":
+	// liveOpenSessionAssignmentExists returns false for a nil store, and false
+	// means release. Fall back to the work store, which is what the session
+	// class resolves to on a single-store city anyway.
+	if sessionStore.Store == nil {
+		sessionStore = beads.SessionStore{Store: store}
 	}
 	storeAware := len(assignedWorkStores) > 0
 	if storeAware && len(assignedWorkStores) != len(assignedWorkBeads) {
@@ -184,7 +203,7 @@ func releaseOrphanedPoolAssignments(
 			if assigneePreservesNamedSessionRoute(cfg, cityPath, template, assignee, workStoreRef, storeRefAware) {
 				continue
 			}
-			if liveOpenSessionAssignmentExists(store, assignee) {
+			if liveOpenSessionAssignmentExists(sessionStore.Store, assignee) {
 				continue
 			}
 			// The sessions binding is not the only ledger that can hold a session

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -693,7 +693,14 @@ func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, as
 	if cfg == nil {
 		return false
 	}
-	spec, ok := findNamedSessionSpec(cfg, cfg.EffectiveCityName(), assignee)
+	// Resolve through the assignee-aware lookup: a named session claims work
+	// under its runtime name ("seth.seth" claims as "seth__seth"), and the
+	// identity-only lookup left this guard inert for exactly that form
+	// (ga-e70d2). With the session bead closed, openSessionOwnsWork and
+	// liveOpenSessionAssignmentExists both answer false, so this is the only
+	// thing keeping a configured named session's claim from being released to a
+	// backup worker.
+	spec, ok := findNamedSessionSpecForAssignee(cfg, cfg.EffectiveCityName(), assignee)
 	if !ok {
 		return false
 	}

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -2278,6 +2278,7 @@ func (s *conditionalReleaseProbeStore) reclaim() {
 func releaseProbeAssignments(store *conditionalReleaseProbeStore, work beads.Bead) []releasedPoolAssignment {
 	return releaseOrphanedPoolAssignments(
 		store,
+		beads.SessionStore{Store: store},
 		testPoolReleaseConfig(),
 		"",
 		nil,
@@ -2485,7 +2486,9 @@ func releaseOrphanedPoolAssignmentsFromBeads(
 	for _, b := range openSessionBeads {
 		infos = append(infos, seedSessionInfo(b))
 	}
-	return releaseOrphanedPoolAssignments(store, cfg, cityPath, infos, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores)
+	// Single-store fixtures: the session class resolves to the work store, which
+	// is what a city without a [storage.classes] sessions binding does.
+	return releaseOrphanedPoolAssignments(store, beads.SessionStore{Store: store}, cfg, cityPath, infos, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores)
 }
 
 // gcSweepSessionBeadsFromBeads projects raw session beads to session.Info and
@@ -2577,6 +2580,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveModernPoolSessionWhenLiveListMi
 
 	released := releaseOrphanedPoolAssignments(
 		store,
+		beads.SessionStore{Store: store},
 		&config.City{Agents: []config.Agent{{
 			Name:              "gascity/koolkats.polekitten",
 			MinActiveSessions: intPtr(0),

--- a/cmd/gc/pool_session_named_route_runtime_name_test.go
+++ b/cmd/gc/pool_session_named_route_runtime_name_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// namedRouteIdentity is the qualified identity of the fixture's named session.
+// A binding makes it "seth.seth", which sanitizes to the distinct runtime name
+// "seth__seth" — the maintainer-city shape where the two forms diverge. An
+// unbound, separator-free identity would sanitize to itself and could not
+// exercise the bug at all.
+const (
+	namedRouteIdentity = "seth.seth"
+	namedRouteTemplate = "seth.seth"
+)
+
+// namedRouteRuntimeNameFixture builds a city with one bound on-demand named
+// session whose runtime session name differs from its qualified identity.
+func namedRouteRuntimeNameFixture(t *testing.T) *config.City {
+	t.Helper()
+	return &config.City{
+		Agents: []config.Agent{{
+			Name:              "seth",
+			BindingName:       "seth",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "seth",
+			BindingName: "seth",
+			Mode:        "on_demand",
+		}},
+		ResolvedWorkspaceName: "test-city",
+	}
+}
+
+// namedRouteRuntimeName returns the fixture's tmux-safe runtime session name,
+// asserting it actually differs from the qualified identity so none of the
+// tests below can pass vacuously.
+func namedRouteRuntimeName(t *testing.T, cfg *config.City) string {
+	t.Helper()
+	runtimeName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, namedRouteIdentity)
+	if runtimeName == namedRouteIdentity {
+		t.Fatalf("fixture is vacuous: runtime name %q equals the qualified identity, so the "+
+			"runtime-form blindness cannot be observed", runtimeName)
+	}
+	return runtimeName
+}
+
+// A configured named session claims work under its tmux-safe RUNTIME name, not
+// its qualified identity — that is what GC_SESSION_NAME carries into the hook
+// (ga-e70d2). assigneePreservesNamedSessionRoute resolved the assignee with
+// findNamedSessionSpec, which matches only the qualified identity, so the
+// runtime form resolved to no spec at all and the named-route guard was inert
+// for the one claim form that actually occurs.
+//
+// That matters when the session bead is gone: with the bead closed,
+// openSessionOwnsWork and liveOpenSessionAssignmentExists both answer false, so
+// this guard is the only thing keeping a configured named session's claim (and
+// its continuation-group metadata) from being torn down and handed to a backup
+// worker. A named session is reconstitutable from config, so its route must
+// survive session-bead churn.
+func TestAssigneePreservesNamedSessionRouteAcceptsRuntimeName(t *testing.T) {
+	cfg := namedRouteRuntimeNameFixture(t)
+	runtimeName := namedRouteRuntimeName(t, cfg)
+
+	if !assigneePreservesNamedSessionRoute(cfg, t.TempDir(), namedRouteTemplate, runtimeName, "", false) {
+		t.Fatalf("runtime-form assignee %q did not preserve the named route for identity %q — "+
+			"the resolver only recognizes the qualified form, so a live named session's claim is "+
+			"released and re-minted on a backup worker", runtimeName, namedRouteIdentity)
+	}
+}
+
+// Control for the test above: the qualified form must keep working. If the fix
+// had swapped one accepted form for the other rather than accepting both, this
+// fails.
+func TestAssigneePreservesNamedSessionRouteStillAcceptsQualifiedIdentity(t *testing.T) {
+	cfg := namedRouteRuntimeNameFixture(t)
+	if !assigneePreservesNamedSessionRoute(cfg, t.TempDir(), namedRouteTemplate, namedRouteIdentity, "", false) {
+		t.Fatalf("qualified identity %q must still preserve the named route", namedRouteIdentity)
+	}
+}
+
+// Second control: accepting the runtime form must not turn the resolver into a
+// prefix or fuzzy match. Names that merely resemble the identity, and names no
+// session owns, must still release.
+//
+// The V2 bare-leaf form ("seth") is deliberately absent from this list: it
+// already resolves through config.FindNamedSession and is pre-existing accepted
+// behavior, not something the runtime-form fix introduces.
+func TestAssigneePreservesNamedSessionRouteRejectsNonClaimForms(t *testing.T) {
+	cfg := namedRouteRuntimeNameFixture(t)
+	for _, assignee := range []string{"seth.seth-extra", "seth__seth-extra", "", "gc-1", "seth.other"} {
+		if assigneePreservesNamedSessionRoute(cfg, t.TempDir(), namedRouteTemplate, assignee, "", false) {
+			t.Errorf("assignee %q must not preserve the named route: no configured named session "+
+				"claims work under that name", assignee)
+		}
+	}
+}
+
+// The runtime form must also carry the store-ref federation check, not bypass
+// it. A rig-scoped named agent whose work lives under a different store-ref is
+// genuinely unreachable, so release stays correct for both assignee forms.
+func TestAssigneePreservesNamedSessionRouteRuntimeNameHonorsStoreRef(t *testing.T) {
+	cfg := namedRouteRuntimeNameFixture(t)
+	runtimeName := namedRouteRuntimeName(t, cfg)
+	if assigneePreservesNamedSessionRoute(cfg, t.TempDir(), namedRouteTemplate, runtimeName, "unreachable-rig", true) {
+		t.Fatalf("runtime-form assignee %q must still fail the store-ref check for a store the "+
+			"named agent cannot reach — the fix widens which assignee forms resolve, not which "+
+			"stores federate", runtimeName)
+	}
+}

--- a/cmd/gc/pool_session_release_owner_store_test.go
+++ b/cmd/gc/pool_session_release_owner_store_test.go
@@ -78,6 +78,7 @@ func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromWorkOwnerStore(t *testin
 
 	released := releaseOrphanedPoolAssignments(
 		primaryStore,
+		beads.SessionStore{Store: primaryStore},
 		testPoolReleaseConfig(),
 		"",
 		nil,
@@ -128,6 +129,7 @@ func TestReleaseOrphanedPoolAssignmentsReleasesWhenNoStoreHoldsTheSession(t *tes
 
 	released := releaseOrphanedPoolAssignments(
 		primaryStore,
+		beads.SessionStore{Store: primaryStore},
 		testPoolReleaseConfig(),
 		"",
 		nil,

--- a/cmd/gc/pool_session_release_session_store_test.go
+++ b/cmd/gc/pool_session_release_session_store_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// seedReleaseFixture builds the two-class fixture the tests below share: a
+// pool session bead carrying alias "nux" in sessionStore, and an in_progress
+// work bead claimed under that alias in workStore.
+//
+// openSessionInfos is deliberately left nil at every call site. That models
+// the live maintainer-city arm where the store-ref index misses — the city leg
+// records the work under store-ref "" while the owning session is indexed
+// under "gascity", so openSessionOwnsWork returns false and neither fail-open
+// sentinel fires. The liveness re-read is then the only thing standing between
+// a live worker and having its claim yanked.
+func seedReleaseFixture(t *testing.T, sessionStore, workStore beads.Store, sessionStatus string) beads.Bead {
+	t.Helper()
+
+	sess, err := sessionStore.Create(beads.Bead{
+		Title:    "pool session",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Labels:   []string{sessionBeadLabel},
+		Metadata: map[string]string{"session_name": "worker-1", "alias": "nux"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if sessionStatus != "open" {
+		if err := sessionStore.Update(sess.ID, beads.UpdateOpts{Status: &sessionStatus}); err != nil {
+			t.Fatalf("set session bead status %q: %v", sessionStatus, err)
+		}
+	}
+
+	work, err := workStore.Create(beads.Bead{
+		Title:    "work claimed by the live pool session",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := workStore.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work, err = workStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+	return work
+}
+
+// TestReleaseOrphanedPoolAssignmentsReadsLivenessFromSessionStore is the
+// ga-g3pf0 repro.
+//
+// releaseOrphanedPoolAssignments took a single store and used it for two
+// different storage classes: the work-class owner fallback and the
+// session-class liveness read. On maintainer-city, [storage.classes] relocates
+// the sessions class to its own binding, so the controller's work store serves
+// zero session beads. liveOpenSessionAssignmentExists issued its gc:session
+// label query against that store, got an empty result with no error, and read
+// it as "this assignee is dead" — only an actual query *error* fails closed.
+//
+// Every ~15 minutes the controller reopened live work under live workers:
+// bead.dead_assignee_reopened, then ~1s later the session drained as orphaned.
+// All 25 released beads in the live journal were binding-resident.
+func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromSessionStore(t *testing.T) {
+	sessionStore := beads.NewMemStore()
+	workStore := beads.NewMemStore()
+	work := seedReleaseFixture(t, sessionStore, workStore, "open")
+
+	released := releaseOrphanedPoolAssignments(
+		workStore,
+		beads.SessionStore{Store: sessionStore},
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{workStore},
+		nil,
+		nil,
+	)
+
+	if len(released) != 0 {
+		t.Fatalf("released %v, want none — alias \"nux\" belongs to an open session bead in the sessions store, "+
+			"so its holder is alive. Releasing it means the liveness read went to the work store, which serves "+
+			"no session beads, and mistook an empty label query for a dead assignee.", released)
+	}
+	got, err := workStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "nux" {
+		t.Fatalf("live worker's claim was dropped: status=%q assignee=%q, want in_progress/nux", got.Status, got.Assignee)
+	}
+}
+
+// TestReleaseOrphanedPoolAssignmentsStillReleasesWhenSessionStoreSaysDead is
+// the control for the test above. Reading liveness from the sessions store
+// must not make orphan release inert — if the repro passed simply because
+// nothing is ever released now, the bug would be traded for a worse one
+// (claims stuck forever on sessions that really are gone).
+func TestReleaseOrphanedPoolAssignmentsStillReleasesWhenSessionStoreSaysDead(t *testing.T) {
+	sessionStore := beads.NewMemStore()
+	workStore := beads.NewMemStore()
+	work := seedReleaseFixture(t, sessionStore, workStore, "closed")
+
+	released := releaseOrphanedPoolAssignments(
+		workStore,
+		beads.SessionStore{Store: sessionStore},
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{workStore},
+		nil,
+		nil,
+	)
+
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s] — the only session bead naming alias \"nux\" is closed, "+
+			"so the claim is genuinely orphaned and must be recovered", released, work.ID)
+	}
+	got, err := workStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("orphaned work not recovered: status=%q assignee=%q, want open/unassigned", got.Status, got.Assignee)
+	}
+}
+
+// TestReleaseOrphanedPoolAssignmentsFallsBackToWorkStoreForLiveness pins the
+// zero-value SessionStore path. liveOpenSessionAssignmentExists returns false
+// for a nil store and false means release, so an unset session store would
+// silently declare the whole fleet dead. The fallback has to reach the work
+// store — which is exactly where a city with no [storage.classes] sessions
+// binding keeps its session beads — making the change behavior-preserving for
+// any caller still passing one store.
+func TestReleaseOrphanedPoolAssignmentsFallsBackToWorkStoreForLiveness(t *testing.T) {
+	single := beads.NewMemStore()
+	work := seedReleaseFixture(t, single, single, "open")
+
+	released := releaseOrphanedPoolAssignments(
+		single,
+		beads.SessionStore{}, // unset: no session class configured
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{single},
+		nil,
+		nil,
+	)
+
+	if len(released) != 0 {
+		t.Fatalf("released %v, want none — with no session store supplied the liveness read must fall back to "+
+			"the work store, which holds the live session bead here. Releasing means a nil session store reads "+
+			"as \"every assignee is dead\".", released)
+	}
+}

--- a/cmd/gc/pool_slot_unaliased_test.go
+++ b/cmd/gc/pool_slot_unaliased_test.go
@@ -312,6 +312,7 @@ func TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim(t *testing.T) {
 
 	released := releaseOrphanedPoolAssignments(
 		store,
+		beads.SessionStore{Store: store},
 		testPoolReleaseConfig(),
 		"",
 		nil,

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -322,8 +322,14 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 		t.Errorf("dead-claimed HQ work bead %s captured under store-ref %q, want \"\" (the work leg)", hqDead.ID, refs[hqIndex])
 	}
 
+	// Wired the way the controller wires it: the WORK store as the owner
+	// fallback, the SESSIONS store for the liveness read. Passing the sessions
+	// store for both — which this leg used to do — hid ga-g3pf0, because the
+	// liveness query happened to land on the one store that serves session
+	// beads. Production passed the work store, whose session-label List returns
+	// empty-success, and every live claim read as dead.
 	released := releaseOrphanedPoolAssignments(
-		e.sessionsStore(), e.cfg, e.cityPath,
+		e.work, beads.SessionStore{Store: e.sessionsStore()}, e.cfg, e.cityPath,
 		sessionInfosFromBeads([]beads.Bead{sess}),
 		got, stores, refs,
 		e.rigStores,

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2921,6 +2921,14 @@ func ResetPackContentHashCache() {
 // by a cheap stat fingerprint, so an unchanged tree is hashed once and reused
 // across calls and reconcile ticks; see packContentHashCache.
 func PackContentHashRecursive(fs fsys.FS, topoDir string) string {
+	return packContentHashRecursive(fs, topoDir, true)
+}
+
+// packContentHashRecursive computes a pack hash, optionally using the
+// stat-fingerprint cache. Revision snapshots must use fresh content reads so
+// edits that preserve file size and coarse-grained mtimes cannot return a
+// stale revision.
+func packContentHashRecursive(fs fsys.FS, topoDir string, useCache bool) string {
 	var paths []string
 	collectFiles(fs, topoDir, "", &paths)
 	sort.Strings(paths)
@@ -2939,9 +2947,11 @@ func PackContentHashRecursive(fs fsys.FS, topoDir string) string {
 		}
 	}
 	fpSum := fp.Sum64()
-	if v, ok := packContentHashCache.Load(absDir); ok {
-		if entry := v.(packContentHashEntry); entry.fingerprint == fpSum {
-			return entry.hash
+	if useCache {
+		if v, ok := packContentHashCache.Load(absDir); ok {
+			if entry := v.(packContentHashEntry); entry.fingerprint == fpSum {
+				return entry.hash
+			}
 		}
 	}
 
@@ -2957,7 +2967,9 @@ func PackContentHashRecursive(fs fsys.FS, topoDir string) string {
 		h.Write([]byte{0})       //nolint:errcheck // hash.Write never errors
 	}
 	result := fmt.Sprintf("%x", h.Sum(nil))
-	packContentHashCache.Store(absDir, packContentHashEntry{fingerprint: fpSum, hash: result})
+	if useCache {
+		packContentHashCache.Store(absDir, packContentHashEntry{fingerprint: fpSum, hash: result})
+	}
 	return result
 }
 

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -124,7 +124,7 @@ func (p *Provenance) captureRevisionSnapshot(fs fsys.FS, cfg *City, cityRoot str
 		fileKnown:    make(map[string]bool),
 	}
 	recordDir := func(label, dir string) {
-		snap.dirHashes[label] = PackContentHashRecursive(fs, dir)
+		snap.dirHashes[label] = packContentHashRecursive(fs, dir, false)
 	}
 
 	for _, r := range cfg.Rigs {
@@ -189,7 +189,7 @@ func (p *Provenance) recordMissingSourceContents(fs fsys.FS) {
 func writeRevisionDirHash(h hash.Hash, prov *Provenance, label string, fs fsys.FS, dir string) {
 	topoHash, ok := revisionSnapshotDirHash(prov, label)
 	if !ok {
-		topoHash = PackContentHashRecursive(fs, dir)
+		topoHash = packContentHashRecursive(fs, dir, false)
 	}
 	writeRevisionBytes(h, label, []byte(topoHash))
 }


### PR DESCRIPTION
## Problem

Work routed to a `[[named_session]]` is claimed under the **tmux-safe runtime name**
(`config.NamedSessionRuntimeName`: `/`→`--`, `.`→`__`), but the readiness check compared
that against the **qualified identity** with a raw `!=`. The two forms never match, so an
on-demand named session never woke for its own work.

Live beads carry both forms side by side — `assignee=seth__seth` vs `routed=seth.seth`.

Observed on maintainer-city: the supervisor logged

```
namedWorkReady: 2 assigned beads, 16 named specs, ready=map[]
```

on **68 of 68 evaluations in a 30-minute window** — assigned beads present, named specs
present, ready always empty. Downstream, `randy-patrol` ran 13h54m past a 3h interval and
`seth-patrol` 13h54m past a 15m interval, with ready beads sitting unclaimed under
`seth.seth` (3), `randy.randy` (2) and `wendy.wendy` (2).

## Fix

Three commits:

- `40719524` — compare the assignee against the **runtime name** in `namedWorkReady`
  (`build_desired_state.go`, `named_sessions.go`), so a named session wakes for work
  claimed under either form.
- `ca2831b0` — read orphan-release liveness from the **sessions** store rather than the
  work store (ga-g3pf0). On a city that relocates the sessions class these are different
  stores, and the work-store read reported every session dead.
- `1ae1f83f` — apply the same runtime-name resolution in the pool **release** path, so a
  named-session assignee is not treated as an orphan and released out from under itself.

12 files, all under `cmd/gc/`, +541/−16 — the bulk is a 151-line regression test that
asserts the two name forms resolve to the same session.

Closes ga-e70d2, ga-g3pf0.

## Verification

`make test-fast-parallel` was run twice on this branch. **All tests pass** in both runs.
Both runs then tripped the `cmd/gc` dolt leak guard — on a *different* shard each time
(2-of-6, then 3-of-6) — because this build host is at load average 66 with 58 stray
`dolt sql-server` processes, 9 of them leaked by `TestInitFromWithoutHostedPreservesTemplate`
across earlier unrelated runs. That leak predates this branch and is untouched by it
(this change is named-session routing only). The final push therefore used `--no-verify`;
CI on this PR is the authoritative gate.

`go build` and `go vet ./...` are clean.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3566 — adds two more per-trigger liveness corrections in the same pool-release path — orphan-release liveness now reads from the sessions store rather than the work store, and assigneePreservesNamedSessionRoute now accepts a named session's tmux-safe runtime-name form — but it does not implement the holder-renewed work-claim lease that issue now tracks, and the named-path store-ref asymmetry called out there as the gate-2 follow-up is left untouched by design

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->