### PR TITLE
test(cmd/gc): stop the checkout-rooted dolt leak that fails every run

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -7198,14 +7198,16 @@ func TestOrderTrackingRetentionWatchdog_LogsPrunedCount(t *testing.T) {
 	}
 }
 
-func TestOrderTrackingRetentionWatchdog_NilCfgSkipsWithoutPanic(_ *testing.T) {
+func TestOrderTrackingRetentionWatchdog_NilCfgSkipsWithoutPanic(t *testing.T) {
+	requireNoLeakedDoltAfterForPaths(t, repoRootForLint(t))
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
 	cr := &CityRuntime{
-		cityName:  "test-city",
-		cfg:       nil, // nil cfg: watchdog must not panic
-		stdout:    io.Discard,
-		stderr:    io.Discard,
-		logPrefix: "gc test",
+		cityName:            "test-city",
+		cfg:                 nil, // nil cfg: watchdog must not panic
+		standaloneCityStore: beads.NewMemStore(),
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
 	}
 	// Must not panic.
 	cr.runOrderTrackingRetentionWatchdog(now)

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -686,6 +686,37 @@ func TestSnapshotDoltProcessesForConfigRootsCatchesSourceTreeLeak(t *testing.T) 
 	}
 }
 
+func TestDoltLeakGuardedTestingMLeakRootsIncludeCheckoutRoot(t *testing.T) {
+	tempRoot := filepath.Join("/tmp", "gct12345-678")
+	checkoutRoot := filepath.Join(t.TempDir(), "gascity")
+	sourceRoot := filepath.Join(checkoutRoot, "cmd", "gc")
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkoutRoot, "go.mod"), []byte("module example.com/gascity\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	g := &doltLeakGuardedTestingM{
+		tempRoot:     tempRoot,
+		sourceRoot:   sourceRoot,
+		checkoutRoot: checkoutRootForTestSource(sourceRoot),
+	}
+
+	if roots := g.leakRoots(); len(roots) != 3 || roots[2] != checkoutRoot {
+		t.Fatalf("leakRoots() = %q, want checkout root %q", roots, checkoutRoot)
+	}
+}
+
+func TestCheckoutRootForTestSourceRejectsUnexpectedLayout(t *testing.T) {
+	sourceRoot := filepath.Join(t.TempDir(), "cmd", "gc")
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := checkoutRootForTestSource(sourceRoot); got != "" {
+		t.Fatalf("checkoutRootForTestSource() = %q, want empty without go.mod", got)
+	}
+}
+
 // An unresolved root must narrow the snapshot, never widen it to match every
 // dolt server on the host — the reaping paths would then kill real cities.
 func TestSnapshotDoltProcessesForConfigRootsIgnoresEmptyRoots(t *testing.T) {

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -117,6 +117,7 @@ type doltLeakGuardedTestingM struct {
 	// an unscoped guard would reap the developer's own city servers, which
 	// legitimately start and stop during a long test run.
 	sourceRoot   string
+	checkoutRoot string
 	cleanupPaths []string
 }
 
@@ -133,7 +134,27 @@ func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...s
 		m:            m,
 		tempRoot:     tempRoot,
 		sourceRoot:   sourceRoot,
+		checkoutRoot: checkoutRootForTestSource(sourceRoot),
 		cleanupPaths: cleanupPaths,
+	}
+}
+
+// checkoutRootForTestSource returns the nearest repository root above cmd/gc's
+// package directory. The go.mod check is a fail-closed safety guard: if the
+// test binary ever runs from an unexpected directory, the process reaper must
+// narrow its scope rather than treating an arbitrary ancestor as test-owned.
+func checkoutRootForTestSource(sourceRoot string) string {
+	if sourceRoot == "" {
+		return ""
+	}
+	for root := filepath.Clean(sourceRoot); ; root = filepath.Dir(root) {
+		if info, err := os.Stat(filepath.Join(root, "go.mod")); err == nil && !info.IsDir() {
+			return root
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			return ""
+		}
 	}
 }
 
@@ -141,13 +162,13 @@ func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...s
 // sql-server whose --config lies under any of them is this run's to detect and
 // reap.
 func (g *doltLeakGuardedTestingM) leakRoots() []string {
-	return []string{g.tempRoot, g.sourceRoot}
+	return []string{g.tempRoot, g.sourceRoot, g.checkoutRoot}
 }
 
 // nonEmptyLeakRoots is leakRoots minus unresolved entries, for diagnostics that
 // name the roots a leak was found under.
 func (g *doltLeakGuardedTestingM) nonEmptyLeakRoots() []string {
-	roots := make([]string, 0, 2)
+	roots := make([]string, 0, 3)
 	for _, root := range g.leakRoots() {
 		if root != "" {
 			roots = append(roots, root)


### PR DESCRIPTION
Fixes #4673.

## What was wrong

`TestOrderTrackingRetentionWatchdog_NilCfgSkipsWithoutPanic` built a `CityRuntime` with a nil `cfg` and no store. The watchdog fell through to opening a real beads store, and with no city path to resolve against, that rooted a managed dolt sql-server inside the source checkout at `cmd/gc/.beads/dolt`. The test returned without stopping it.

The leak guard detected this correctly and failed the package after every test in it had passed. That combination reads as a flake and is not one.

## Evidence

On a pristine worktree at `main`, with `cmd/gc/.beads` removed first:

```
before:  FAIL  cmd/gc test dolt leak guard: leaked 1 dolt sql-server process(es)
               argv config = <checkout>/cmd/gc/.gc/runtime/packs/dolt/dolt-config.yaml
after:   ok    no .beads directory created
```

The provider's own state file names the data directory inside the checkout:

```json
{"running":true,"pid":...,"data_dir":"<checkout>/cmd/gc/.beads/dolt"}
```

and its log records one `Starting server` line per suite run, so this happens on every run rather than intermittently.

## The fix

Give the test a `beads.NewMemStore()` so the watchdog never opens a real store.

## Second change: the guard's leak roots

The guard previously scoped itself to the temp root and `cmd/gc`. It now also treats the repository checkout as test-owned, so a server rooted anywhere in the tree is seen rather than only one directory below it.

The checkout root is found by walking up from `cmd/gc` to the nearest `go.mod`, and returns empty when it finds none. That direction is deliberate: an unexpected working directory narrows the reaper's scope rather than promoting an arbitrary ancestor to test-owned.

This does widen what the reaper kills. A dolt server running from inside the checkout during a test run is now in scope. Servers outside the checkout, including a city living elsewhere on disk, are unaffected.

## Test plan

`TestDoltLeakGuardedTestingMLeakRootsIncludeCheckoutRoot` asserts the checkout root is among the leak roots. `TestCheckoutRootForTestSourceRejectsUnexpectedLayout` asserts the fail-closed empty return when no `go.mod` is found, which is the assertion that keeps the widening from becoming unbounded.

The full fast `cmd/gc` suite fails before this change and passes after, measured on a clean worktree at `main` rather than in the worktree where the problem was first seen. `golangci-lint` reports 0 issues.
