### PR TITLE
fix(storage): resolve the boot plan on every gc storage status exit path

### DIFF
--- a/cmd/gc/cmd_storage.go
+++ b/cmd/gc/cmd_storage.go
@@ -391,6 +391,30 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 		fmt.Fprintf(stdout, "  %-9s -> %s\n", class, storage.Classes.BindingFor(class)) //nolint:errcheck // best-effort stdout
 	}
 
+	// Resolve the boot plan once, on every path, the way doStorageMigrate
+	// does. This command's exit code is a deploy gate — "a city boot refuses
+	// must not report may-serve here" — and that contract used to hold only on
+	// the born-split path below, the one path that resolved the plan. The
+	// served path and the no-binding path returned 0 without ever asking.
+	//
+	// Resolution is safe to do unconditionally: it builds a registry,
+	// absolutizes the city root and computes a plan. It opens no store.
+	//
+	// A refusal is reported and carried into the exit code rather than
+	// returned on, because it is the moment an operator most needs the rest of
+	// the readout.
+	plan, planErr := resolveCityStoragePlan(request.CityPath, request.Cfg)
+	if planErr != nil {
+		fmt.Fprintf(stdout, "boot plan: REFUSED — a city boot would not serve this configuration: %v\n", planErr) //nolint:errcheck // best-effort stdout
+	}
+	// exitServing folds that refusal into every otherwise-successful return.
+	exitServing := func() int {
+		if planErr != nil {
+			return 1
+		}
+		return 0
+	}
+
 	target, ok, err := resolveInfraBindingTarget(request.CityPath, request.Cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", logPrefix, err) //nolint:errcheck // best-effort stderr
@@ -405,10 +429,9 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 			// serves classes it does not.
 			provider := storage.Bindings[binding].Provider
 			fmt.Fprintf(stdout, "binding: %s\n  provider: %s (not this build's engine; serves under the born-split discipline)\n", binding, provider) //nolint:errcheck // best-effort stdout
-			// The same resolution and seam check boot performs, so this
-			// command's exit code keeps its deploy-gate contract: a city boot
-			// refuses must not report may-serve here.
-			plan, planErr := resolveCityStoragePlan(request.CityPath, request.Cfg)
+			// The seam check boot performs, against the plan resolved above.
+			// A refusal has already been reported in the body; there is no
+			// plan to check the seam against, so the readout stops here.
 			if planErr != nil {
 				fmt.Fprintf(stderr, "%s: %v\n", logPrefix, planErr) //nolint:errcheck // best-effort stderr
 				return 1
@@ -430,7 +453,7 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 			switch report.Outcome {
 			case infraMigrationConverged:
 				fmt.Fprintln(stdout, "born-split: clean — the work store holds no infrastructure bead, so the binding may serve.") //nolint:errcheck // best-effort stdout
-				return 0
+				return exitServing()
 			case infraMigrationBornSplitBlocked:
 				fmt.Fprintf(stdout, "born-split: BLOCKED — the work store holds %d infrastructure bead(s) the binding cannot read: %s\n", //nolint:errcheck // best-effort stdout
 					len(report.Stranded), strings.Join(report.Stranded, ", "))
@@ -441,7 +464,7 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 			}
 		}
 		fmt.Fprintln(stdout, "binding: none — every class is served by the work store, and nothing migrates.") //nolint:errcheck // best-effort stdout
-		return 0
+		return exitServing()
 	}
 	fmt.Fprintf(stdout, "binding: %s\n  database: %s\n  marker:   %s\n  manifest: %s\n", //nolint:errcheck // best-effort stdout
 		target.Binding, target.Database, target.MarkerPath(), target.ManifestPath())
@@ -482,7 +505,7 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 	}
 	if !recorded {
 		fmt.Fprintln(stdout, "converged: yes (no proven-copy manifest, so stranded-write detection is off for this city)") //nolint:errcheck // best-effort stdout
-		return 0
+		return exitServing()
 	}
 	gap, err := classifyInfraContainmentGap(request.CityPath, target, proven)
 	if err != nil {
@@ -500,7 +523,7 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 		fmt.Fprintf(stdout, "blocking invariant: the binding cannot read these beads. Stop every writer and copy them in with `%s`\n", storageRecoveryInstruction()) //nolint:errcheck // best-effort stdout
 		return 1
 	}
-	return 0
+	return exitServing()
 }
 
 // cityMigrationGuardDirectory returns the city .gc directory the migration

--- a/cmd/gc/storage_boot_test.go
+++ b/cmd/gc/storage_boot_test.go
@@ -2018,3 +2018,38 @@ func TestFailedNoteWriteReleasesTheBindingItJustOpened(t *testing.T) {
 		t.Errorf("the opened binding was closed %d time(s), want exactly 1: a boot that refuses must not keep the engine it opened", closes)
 	}
 }
+
+// TestStorageStatusCarriesBootPlanRefusalOnUnresolvedPaths pins the deploy-gate
+// contract doStorageStatus claims for itself: "a city boot refuses must not
+// report may-serve here". That held only on the born-split path, which was the
+// one path that resolved the plan; the served path and the no-binding path
+// returned 0 without ever asking whether boot would refuse.
+//
+// The stdout assertions are the load-bearing half. Carrying the refusal into
+// the exit code is easy to get right by returning early on the plan error, and
+// that suppresses the readout at exactly the moment an operator needs it. These
+// assertions fail such a fix.
+func TestStorageStatusCarriesBootPlanRefusalOnUnresolvedPaths(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{}
+
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = func() (*storebinding.ProviderRegistry, error) {
+		return nil, errors.New("no storage provider registry for this build")
+	}
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+
+	var stdout, stderr bytes.Buffer
+	code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Errorf("status = 0 for a city whose boot plan refuses; exit code is the deploy gate\nstdout: %s\nstderr: %s",
+			stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "city: "+cityPath) {
+		t.Errorf("plan refusal suppressed the status header:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "binding: none") {
+		t.Errorf("plan refusal suppressed the status body:\n%s", stdout.String())
+	}
+}


### PR DESCRIPTION
Fixes #5219.

## What was wrong

`doStorageStatus` has three exit paths and resolved the boot plan on exactly one of them, while its own comment claimed the contract for all three:

> so this command's exit code keeps its deploy-gate contract: a city boot refuses must not report may-serve here

Only the born-split path (`ok == false`, shape `storageSplitWhole`) called `resolveCityStoragePlan`. The other two returned 0 without ever asking whether boot would refuse:

- `ok == false` with a shape that is not `storageSplitWhole`, which prints `binding: none`
- `ok == true`, the real infra binding target, which prints binding, database, marker, manifest and the convergence and hold checks

The second of those is the served-split city, the configuration an operator is most likely to run status against before a cutover. `doStorageMigrate` already resolves the plan unconditionally at the top of its run.

So exit 0 conflated "plan checked, would serve" with "plan never checked", and agents and scripts gate on exit status.

## The fix

Resolve the plan once, up front, the way migrate does, and carry a refusal into each success return.

A refusal does not return early. It is reported as a line in the status body and the rest of the readout still prints, because a boot that will not serve is the moment an operator most needs the binding, marker, manifest and convergence detail. The born-split path now reuses the plan resolved up front instead of resolving a second time.

Resolving unconditionally is safe, and this was verified rather than assumed: `resolveCityStoragePlan` builds a provider registry (register then freeze), absolutizes the city root, and calls `ResolveStoragePlan`. That path opens no store, takes no lock, and mutates nothing.

It is not entirely free of filesystem access: with an explicit SQLite binding configured, provider construction canonicalizes the graph path, which stats and resolves symlinks. That is read-only, and the command already did the same work unconditionally through `resolveInfraBindingTarget`, so this adds one more call of a kind already on every invocation rather than a new class of behavior. `TestStorageStatusCreatesNothing` fingerprints the binding tree either side of a served-path status call and asserts nothing changed; it is untouched and still passes.

## Behaviour change

A caller gating on `gc storage status` against a city whose boot plan refuses now gets a non-zero exit where it previously got 0. That is the point of the change: the previous 0 was not a statement that the city may serve, it was the absence of a check.

## Test plan

`TestStorageStatusCarriesBootPlanRefusalOnUnresolvedPaths` drives the no-binding path with a registry constructor that refuses, and asserts both halves:

- the exit code is non-zero
- the status header and body were still printed

The second assertion is the load-bearing one. Carrying the refusal into the exit code is easy to get right by returning early on the plan error, and that suppresses the readout exactly when it is needed. An exit-code-only test would stay green against that; this one does not.

Verified red against the parent commit for the right reason: exit 0 with the body printed.

`storage_boot_test.go:1517` asserts exit 0 on a served born-split path and was the case to watch. It stays green, so the plan resolves cleanly there.

Full `cmd/gc` package suite green, `go vet` clean, `golangci-lint` reports 0 issues.
