### PR TITLE
fix(pool): pool workers claim under their session name, not a rebinding slot alias

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -886,7 +886,11 @@ func buildDesiredStateWithSessionBeads(
 					continue
 				}
 				tp.PoolSlot = poolSlot
-				setTemplateEnvIdentity(&tp, qualifiedInstance)
+				if usesTransientPoolSlotIdentity(cfgAgent) {
+					clearPoolTemplateRuntimeIdentity(&tp)
+				} else {
+					setTemplateEnvIdentity(&tp, qualifiedInstance)
+				}
 				installAgentSideEffects(bp, instanceAgent, tp, stderr)
 				desired[tp.SessionName] = tp
 			}
@@ -2694,7 +2698,11 @@ func ensureDependencyOnlyTemplate(
 		}
 		tp.DependencyOnly = true
 		tp.PoolSlot = poolSlot
-		setTemplateEnvIdentity(&tp, qualifiedInstance)
+		if usesTransientPoolSlotIdentity(cfgAgent) {
+			clearPoolTemplateRuntimeIdentity(&tp)
+		} else {
+			setTemplateEnvIdentity(&tp, qualifiedInstance)
+		}
 		installAgentSideEffects(bp, resolveAgent, tp, stderr)
 		desired[tp.SessionName] = tp
 		return
@@ -2996,10 +3004,14 @@ func realizePoolDesiredSessions(
 			// pool_slot metadata from before singleton normalization.
 			tp.PoolSlot = 0
 		} else {
-			tp.Alias = qualifiedInstance
 			tp.InstanceName = qualifiedInstance
 			tp.PoolSlot = poolSlot
-			setPoolTemplateRuntimeIdentityInfo(&tp, qualifiedInstance, sbInfo)
+			if usesTransientPoolSlotIdentity(cfgAgent) {
+				clearPoolTemplateRuntimeIdentity(&tp)
+			} else {
+				tp.Alias = qualifiedInstance
+				setPoolTemplateRuntimeIdentityInfo(&tp, qualifiedInstance, sbInfo)
+			}
 		}
 		installAgentSideEffects(bp, resolveAgent, tp, stderr)
 		desired[tp.SessionName] = tp
@@ -3173,6 +3185,32 @@ func safeWorkspaceName(value string, maxLen int) string {
 		}
 	}
 	return strings.Trim(b.String(), ".-_")
+}
+
+// usesTransientPoolSlotIdentity reports whether cfgAgent's pool members are
+// identified by a rebinding numeric slot ("rig/claude-1") rather than a stable
+// name. Such a slot is bookkeeping, not identity: the controller hands it to a
+// fresh session whenever the previous holder dies, so a work bead assigned to
+// it names a chair, not an occupant.
+//
+// That distinction decides whether a session may claim under the name.
+// `gc hook --claim` writes GC_ALIAS as the assignee (#4981), which is correct
+// for the stable identities — a configured named session, a canonical singleton
+// pool member, a namepool name like "nux" — because those double as the
+// session's mail address and stay put across restarts. A numeric slot does not,
+// and claiming under it produced ownership no reconciler guard could resolve to
+// a live session: the drain guard saw no assigned work and drained live
+// claim-holders. Transient slots therefore stay out of every identity channel
+// (bead alias, GC_ALIAS, GC_AGENT/BEADS_ACTOR) and the session claims under its
+// own session name, restoring the original unaliased-pool design (bc2ee15ac4).
+func usesTransientPoolSlotIdentity(cfgAgent *config.Agent) bool {
+	if cfgAgent == nil {
+		return false
+	}
+	if strings.TrimSpace(cfgAgent.Namepool) != "" || len(cfgAgent.NamepoolNames) > 0 {
+		return false
+	}
+	return !cfgAgent.UsesCanonicalSingletonPoolIdentity()
 }
 
 func poolDesiredRequestIdentity(cfgAgent *config.Agent, slot int) (*config.Agent, string, int) {
@@ -3972,7 +4010,21 @@ func createPoolSessionBeadWithGuardedAlias(
 		Slot:      slot,
 		Metadata:  metadata,
 	}
+	// A transient slot is never reserved as an alias: it is not an identity, so
+	// there is nothing to guard against collision and nothing to persist. The
+	// resolvedTmuxAlias lock lane below is unaffected — that one guards a
+	// runtime handle, not ownership.
+	//
+	// alias and persistAlias are deliberately different things. alias is the
+	// mutual-exclusion key: two controller goroutines racing the same slot must
+	// not both create a bead for it, and that is true whether or not the slot is
+	// an identity. persistAlias is what lands in the bead. For a transient slot
+	// the exclusion still applies and the persistence does not.
 	alias := strings.TrimSpace(qualifiedInstance)
+	persistAlias := alias
+	if usesTransientPoolSlotIdentity(cfgAgent) {
+		persistAlias = ""
+	}
 	if bp.beadStore == nil {
 		return createPoolSessionBeadWithAlias(bp.beadStore, template, bp.city, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity, resolvedTmuxAlias)
 	}
@@ -3992,8 +4044,15 @@ func createPoolSessionBeadWithGuardedAlias(
 	lockErr := session.WithCitySessionIdentifierLocks(bp.cityPath, lockIDs, func() error {
 		createIdentity := identity
 		if alias != "" {
+			// The availability probe runs on the SLOT string even when the slot
+			// will not be persisted as an alias: it matches on session_name,
+			// alias, AND agent_name (session.ensureSessionAliasAvailable), and a
+			// transient pool bead still persists the slot as agent_name. So the
+			// occupancy question — including its released/closed exclusions — is
+			// answered identically either way; only the persistence is
+			// conditional.
 			if err := session.EnsureAliasAvailableWithConfig(bp.beadStore, bp.city, alias, ""); err == nil {
-				createIdentity.Alias = alias
+				createIdentity.Alias = persistAlias
 			}
 		}
 		var err error

--- a/cmd/gc/build_desired_state_pool_info.go
+++ b/cmd/gc/build_desired_state_pool_info.go
@@ -57,19 +57,38 @@ func setPoolTemplateRuntimeIdentityInfo(tp *TemplateParams, desiredAlias string,
 		return
 	}
 	if strings.TrimSpace(info.Alias) != strings.TrimSpace(desiredAlias) && poolRuntimeAliasIsDeferredInfo(info) {
-		tp.Alias = ""
-		if tp.Env == nil {
-			tp.Env = make(map[string]string)
-		}
-		tp.Env["GC_ALIAS"] = ""
-		if tp.SessionName != "" {
-			tp.Env["GC_AGENT"] = tp.SessionName
-		}
-		tp.EnvIdentityStamped = false
+		clearPoolTemplateRuntimeIdentity(tp)
 		return
 	}
 	tp.Alias = desiredAlias
 	setTemplateEnvIdentity(tp, desiredAlias)
+}
+
+// clearPoolTemplateRuntimeIdentity leaves a pool spawn with no public identity:
+// no alias, an explicitly BLANK GC_ALIAS, and GC_AGENT on the session name.
+//
+// Blanking GC_ALIAS rather than skipping the stamp is load-bearing.
+// resolveTemplate seeds GC_ALIAS with the agent's bare qualified name for every
+// session (template_resolve.go), so a skipped stamp would leave every member of
+// a pool advertising the SAME identity — worse than per-slot names, because
+// then two live workers claim under one string. The empty value is also what
+// tmux session creation reads as "unset this key" (`env -u`).
+//
+// This was already the deferred-alias behavior for a slot whose name was
+// unavailable; unaliased pools make it the ordinary case.
+func clearPoolTemplateRuntimeIdentity(tp *TemplateParams) {
+	if tp == nil {
+		return
+	}
+	tp.Alias = ""
+	if tp.Env == nil {
+		tp.Env = make(map[string]string)
+	}
+	tp.Env["GC_ALIAS"] = ""
+	if tp.SessionName != "" {
+		tp.Env["GC_AGENT"] = tp.SessionName
+	}
+	tp.EnvIdentityStamped = false
 }
 
 // claimPoolSlotWithConfigInfo is the session.Info sibling of

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5364,8 +5364,8 @@ func TestBuildDesiredState_NewPoolSessionBeadDefersAliasWhenConcreteAliasTaken(t
 		Metadata: map[string]string{
 			"template":       "rig/manual",
 			"agent_name":     "rig/manual",
-			"alias":          "rig/claude-1",
-			"session_name":   "manual-rig-claude-1",
+			"alias":          "rig/furiosa",
+			"session_name":   "manual-rig-furiosa",
 			"state":          "awake",
 			"session_origin": "manual",
 			"manual_session": "true",
@@ -5382,6 +5382,11 @@ func TestBuildDesiredState_NewPoolSessionBeadDefersAliasWhenConcreteAliasTaken(t
 			StartCommand:      "true",
 			MaxActiveSessions: intPtr(3),
 			ScaleCheck:        "printf 1",
+			// A NAMEPOOL agent: its members are identified by stable pool names
+			// ("furiosa"), which still persist as aliases, so the alias-conflict
+			// deferral lane this test covers is still reachable. Transient numeric
+			// slots never take an alias at all, so they have nothing to defer.
+			NamepoolNames: []string{"furiosa"},
 		}},
 	}
 
@@ -5402,8 +5407,8 @@ func TestBuildDesiredState_NewPoolSessionBeadDefersAliasWhenConcreteAliasTaken(t
 	if created.ID == "" {
 		t.Fatalf("did not create a managed pool session bead; beads=%#v", sessionBeads)
 	}
-	if got := created.Metadata["agent_name"]; got != "rig/claude-1" {
-		t.Fatalf("created agent_name = %q, want concrete slot identity", got)
+	if got := created.Metadata["agent_name"]; got != "rig/furiosa" {
+		t.Fatalf("created agent_name = %q, want namepool identity", got)
 	}
 	if got := created.Metadata["alias"]; got != "" {
 		t.Fatalf("created alias = %q, want deferred until alias guard accepts it", got)
@@ -5438,8 +5443,8 @@ func TestBuildDesiredState_NewPoolSessionBeadDefersAliasWhenConcreteAliasTaken(t
 	if got.Metadata["alias"] != "" {
 		t.Fatalf("synced alias = %q, want still deferred after conflict", got.Metadata["alias"])
 	}
-	if got.Metadata[poolAliasConflictMetadataKey] != "rig/claude-1" {
-		t.Fatalf("pool_alias_conflict = %q, want rig/claude-1", got.Metadata[poolAliasConflictMetadataKey])
+	if got.Metadata[poolAliasConflictMetadataKey] != "rig/furiosa" {
+		t.Fatalf("pool_alias_conflict = %q, want rig/furiosa", got.Metadata[poolAliasConflictMetadataKey])
 	}
 	if !strings.Contains(syncStderr.String(), "unavailable") {
 		t.Fatalf("sync stderr %q does not mention alias conflict", syncStderr.String())
@@ -5527,6 +5532,75 @@ func TestSelectOrCreatePoolSessionBead_SerializesAliasCheckAndCreate(t *testing.
 		if got := bead.Metadata["pool_slot"]; got != "1" {
 			t.Fatalf("pool bead %s pool_slot = %q, want 1", bead.ID, got)
 		}
+	}
+}
+
+// TestSelectOrCreatePoolSessionBead_AliasedPoolStillCASesTheSlot keeps the
+// alias-reservation CAS covered on the lane that still persists an alias.
+// Unaliasing transient slots removed the alias tiebreaker from the test above,
+// so this pins it where it survives: a canonical singleton, whose bare identity
+// never rebinds. Exactly one racer may own that alias.
+func TestSelectOrCreatePoolSessionBead_AliasedPoolStillCASesTheSlot(t *testing.T) {
+	store := newBlockingPoolCreateStore("claude")
+	cityPath := t.TempDir()
+	// max_active_sessions=1 with no namepool: a canonical singleton pool member,
+	// identified by the bare agent name rather than a slot.
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(1)}
+	if usesTransientPoolSlotIdentity(&cfgAgent) {
+		t.Fatal("fixture agent is transient; this test must exercise the lane that still persists an alias")
+	}
+	newBuildParams := func() *agentBuildParams {
+		return &agentBuildParams{
+			cityPath:     cityPath,
+			beadStore:    store,
+			sessionBeads: &sessionBeadSnapshot{},
+			agents:       []config.Agent{cfgAgent},
+		}
+	}
+
+	done := make(chan struct{}, 2)
+	create := func() {
+		_, _, _ = selectOrCreatePoolSessionBead(newBuildParams(), &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
+		done <- struct{}{}
+	}
+	go create()
+	go create()
+
+	select {
+	case <-store.firstCreateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first pool create did not start")
+	}
+	select {
+	case <-store.secondCreateStarted:
+		close(store.releaseFirstCreate)
+		close(store.releaseSecondCreate)
+		t.Fatal("second pool create reached the store before the first finished; alias lock did not serialize create")
+	case <-time.After(150 * time.Millisecond):
+		close(store.releaseFirstCreate)
+		select {
+		case <-store.secondCreateStarted:
+			close(store.releaseSecondCreate)
+		case <-time.After(time.Second):
+			t.Fatal("second pool create did not start after the first completed")
+		}
+	}
+	for i := 0; i < 2; i++ {
+		<-done
+	}
+
+	sessionBeads, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("load session beads: %v", err)
+	}
+	aliasOwners := 0
+	for _, bead := range sessionBeads {
+		if bead.Metadata["alias"] == "claude" {
+			aliasOwners++
+		}
+	}
+	if aliasOwners != 1 {
+		t.Fatalf("canonical singleton alias owners = %d, want exactly one; beads=%#v", aliasOwners, sessionBeads)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3261,8 +3261,10 @@ func TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity(t *test
 	if got.Metadata["agent_name"] != "rig/claude-1" {
 		t.Fatalf("agent_name = %q, want concrete slot identity", got.Metadata["agent_name"])
 	}
-	if got.Metadata["alias"] != "rig/claude-1" {
-		t.Fatalf("alias = %q, want concrete slot identity", got.Metadata["alias"])
+	// The slot identity lives in agent_name / title / label / pool_slot, never in
+	// the alias — see TestBuildDesiredState_PoolSlotSessionBeadCarriesNoSlotAlias.
+	if got.Metadata["alias"] != "" {
+		t.Fatalf("alias = %q, want empty for a transient pool slot", got.Metadata["alias"])
 	}
 	if got.Metadata["pool_slot"] != "1" {
 		t.Fatalf("pool_slot = %q, want 1", got.Metadata["pool_slot"])
@@ -5508,14 +5510,23 @@ func TestSelectOrCreatePoolSessionBead_SerializesAliasCheckAndCreate(t *testing.
 	if err != nil {
 		t.Fatalf("load session beads: %v", err)
 	}
-	aliasOwners := 0
+	// The race still produces one bead per goroutine — it did before this change
+	// too, where the loser's EnsureAliasAvailable probe failed and it was created
+	// without an alias. What changed is the discriminator: a transient slot is
+	// never persisted as an alias, so BOTH beads are unaliased and the slot lives
+	// only in agent_name / pool_slot. That is the pair claimPoolSlotWithConfigInfo's
+	// used-slot map and the duplicate-repair lanes already resolve the loser by,
+	// so nothing that resolved the duplicate before depends on the alias.
 	for _, bead := range sessionBeads {
-		if bead.Metadata["alias"] == "claude-1" {
-			aliasOwners++
+		if got := bead.Metadata["alias"]; got != "" {
+			t.Fatalf("pool bead %s alias = %q, want empty for a transient slot; beads=%#v", bead.ID, got, sessionBeads)
 		}
-	}
-	if aliasOwners != 1 {
-		t.Fatalf("pool alias owners = %d, want exactly one; beads=%#v", aliasOwners, sessionBeads)
+		if got := bead.Metadata["agent_name"]; got != "claude-1" {
+			t.Fatalf("pool bead %s agent_name = %q, want the slot identity", bead.ID, got)
+		}
+		if got := bead.Metadata["pool_slot"]; got != "1" {
+			t.Fatalf("pool bead %s pool_slot = %q, want 1", bead.ID, got)
+		}
 	}
 }
 
@@ -5748,7 +5759,9 @@ func TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates(t *testing.
 		t.Fatalf("session bead creates max concurrency = %d, want at least %d", got, poolRealizeParallelism)
 	}
 
-	aliases := make(map[string]bool, requestCount)
+	// Transient pool slots carry no public alias, so per-entry distinctness is
+	// asserted on the logical instance name — the channel the slot still rides.
+	instances := make(map[string]bool, requestCount)
 	sessionNames := make(map[string]bool, requestCount)
 	slots := make(map[int]bool, requestCount)
 	for name, tp := range desired {
@@ -5756,13 +5769,16 @@ func TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates(t *testing.
 			t.Fatalf("duplicate desired session name %q across pool entries", name)
 		}
 		sessionNames[name] = true
-		if tp.Alias == "" {
-			t.Fatalf("desired entry %q has empty alias; want unique per-slot alias", name)
+		if tp.Alias != "" {
+			t.Fatalf("desired entry %q alias = %q, want empty for a transient pool slot", name, tp.Alias)
 		}
-		if aliases[tp.Alias] {
-			t.Fatalf("duplicate alias %q across desired entries (session %q)", tp.Alias, name)
+		if tp.InstanceName == "" {
+			t.Fatalf("desired entry %q has empty instance name; want unique per-slot identity", name)
 		}
-		aliases[tp.Alias] = true
+		if instances[tp.InstanceName] {
+			t.Fatalf("duplicate instance name %q across desired entries (session %q)", tp.InstanceName, name)
+		}
+		instances[tp.InstanceName] = true
 		if slots[tp.PoolSlot] {
 			t.Fatalf("duplicate pool_slot %d across desired entries (session %q)", tp.PoolSlot, name)
 		}
@@ -8646,14 +8662,17 @@ func TestBuildDesiredState_StoreBackedPoolUsesLogicalInstanceIdentity(t *testing
 		if tp.PoolSlot != slot {
 			t.Fatalf("PoolSlot(%q) = %d, want %d", tp.InstanceName, tp.PoolSlot, slot)
 		}
-		if tp.Alias != tp.InstanceName {
-			t.Fatalf("Alias(%q) = %q, want %q", tp.InstanceName, tp.Alias, tp.InstanceName)
+		// The slot is the LOGICAL instance identity (InstanceName / PoolSlot) but
+		// never a public one: a rebinding slot must not reach GC_ALIAS, or the
+		// worker claims work under a name that outlives it.
+		if tp.Alias != "" {
+			t.Fatalf("Alias(%q) = %q, want empty for a transient pool slot", tp.InstanceName, tp.Alias)
 		}
-		if got := tp.Env["GC_AGENT"]; got != tp.InstanceName {
-			t.Fatalf("GC_AGENT(%q) = %q, want %q", tp.InstanceName, got, tp.InstanceName)
+		if got := tp.Env["GC_ALIAS"]; got != "" {
+			t.Fatalf("GC_ALIAS(%q) = %q, want empty for a transient pool slot", tp.InstanceName, got)
 		}
-		if got := tp.Env["GC_ALIAS"]; got != tp.InstanceName {
-			t.Fatalf("GC_ALIAS(%q) = %q, want %q", tp.InstanceName, got, tp.InstanceName)
+		if got := tp.Env["GC_AGENT"]; got != tp.SessionName {
+			t.Fatalf("GC_AGENT(%q) = %q, want session name %q", tp.InstanceName, got, tp.SessionName)
 		}
 		delete(want, tp.InstanceName)
 	}
@@ -8709,11 +8728,16 @@ func TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings(t
 	if got.InstanceName != wantInstance {
 		t.Fatalf("InstanceName = %q, want %q", got.InstanceName, wantInstance)
 	}
-	if got.Alias != wantInstance {
-		t.Fatalf("Alias = %q, want %q", got.Alias, wantInstance)
+	// Binding qualification governs the logical instance name and the work dir;
+	// the public identity stays empty because the slot is transient.
+	if got.Alias != "" {
+		t.Fatalf("Alias = %q, want empty for a transient pool slot", got.Alias)
 	}
-	if got.Env["GC_AGENT"] != wantInstance {
-		t.Fatalf("GC_AGENT = %q, want %q", got.Env["GC_AGENT"], wantInstance)
+	if got.Env["GC_ALIAS"] != "" {
+		t.Fatalf("GC_ALIAS = %q, want empty for a transient pool slot", got.Env["GC_ALIAS"])
+	}
+	if got.Env["GC_AGENT"] != got.SessionName {
+		t.Fatalf("GC_AGENT = %q, want session name %q", got.Env["GC_AGENT"], got.SessionName)
 	}
 	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "ops.worker-1")
 	if got.WorkDir != wantWorkDir {
@@ -10399,8 +10423,10 @@ func TestSelectOrCreateDependencyPoolSessionBead_SkipsDrained(t *testing.T) {
 	if got := result.AgentName; got != "claude-1" {
 		t.Fatalf("dependency agent_name = %q, want claude-1", got)
 	}
-	if got := result.Alias; got != "claude-1" {
-		t.Fatalf("dependency alias = %q, want claude-1", got)
+	// The slot rides agent_name / title / pool_slot; it is not an alias, so a
+	// dependency-floor worker claims under its session name like any pool member.
+	if got := result.Alias; got != "" {
+		t.Fatalf("dependency alias = %q, want empty for a transient pool slot", got)
 	}
 	if got := result.PoolSlot; got != "1" {
 		t.Fatalf("dependency pool_slot = %q, want 1", got)
@@ -11687,9 +11713,16 @@ func TestBuildDesiredState_PoolBeadIdentityAgreesAcrossRealizeAndCanonicalHelper
 		t.Fatalf("canonicalSessionIdentity qn = %q, want %q", helperQN, want)
 	}
 
-	if realizeAlias := realizeTP.Env["GC_ALIAS"]; realizeAlias != helperQN {
-		t.Fatalf("realize GC_ALIAS = %q, canonical helper qn = %q — runtime identity diverged across rediscovery/realize",
-			realizeAlias, helperQN)
+	// A transient pool slot has no public identity, so the agreement is on the
+	// LOGICAL instance name — the channel that still carries the slot. GC_ALIAS
+	// must be blank on both sides; a slot leaking back into it is the ownership
+	// bug this test now guards against from the other direction.
+	if realizeTP.InstanceName != helperQN {
+		t.Fatalf("realize InstanceName = %q, canonical helper qn = %q — logical identity diverged across rediscovery/realize",
+			realizeTP.InstanceName, helperQN)
+	}
+	if realizeAlias := realizeTP.Env["GC_ALIAS"]; realizeAlias != "" {
+		t.Fatalf("realize GC_ALIAS = %q, want empty for a transient pool slot", realizeAlias)
 	}
 	if want := "gascity/dog"; realizeTP.Env["GC_TEMPLATE"] != want {
 		t.Fatalf("realize GC_TEMPLATE = %q, want base %q", realizeTP.Env["GC_TEMPLATE"], want)

--- a/cmd/gc/pool_slot_unaliased_test.go
+++ b/cmd/gc/pool_slot_unaliased_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
@@ -96,6 +99,80 @@ func TestBuildDesiredState_PoolSlotSessionBeadCarriesNoSlotAlias(t *testing.T) {
 	}
 	if tp.PoolSlot != 1 {
 		t.Fatalf("pool slot TemplateParams.PoolSlot = %d, want 1", tp.PoolSlot)
+	}
+}
+
+// TestPoolSlotStaysUnaliasedAcrossReconcileTicks is the CROSS-TICK pin, and the
+// one that matters: every other test in this file is unit-shaped and nothing in
+// them crosses build -> sync -> spawn.
+//
+// A production tick is buildDesiredState -> syncSessionBeads -> session start
+// (city_runtime.go). Creating the bead unaliased is not enough, because
+// syncSessionBeads re-derives an alias of its own from tp.InstanceName /
+// agent_name — both still slot-form on purpose, since the slot IS the logical
+// instance name. If those fallbacks are not gated on the same predicate the
+// create path uses, tick 1 writes the slot straight back onto the bead and the
+// session starts from a re-aliased bead with GC_ALIAS=slot baked in. The claim
+// is slot-form again and the treadmill continues, with every unit test still
+// green.
+//
+// So this runs the real order twice and asserts the alias stays empty through
+// both. skipClose=true matches the reconciler's own call.
+func TestPoolSlotStaysUnaliasedAcrossReconcileTicks(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := transientSlotPoolConfig()
+	clk := &clock.Fake{Time: time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)}
+
+	var beadID string
+	for tick := 1; tick <= 2; tick++ {
+		var stderr bytes.Buffer
+		dsResult := buildDesiredState("test-city", cityPath, clk.Now(), cfg, runtime.NewFake(), store, &stderr)
+		syncSessionBeads(cityPath, store, dsResult.State, runtime.NewFake(), allConfiguredDS(dsResult.State), cfg, clk, &stderr, true)
+
+		sessionBeads, err := loadSessionBeads(store)
+		if err != nil {
+			t.Fatalf("tick %d: load session beads: %v", tick, err)
+		}
+		if len(sessionBeads) != 1 {
+			t.Fatalf("tick %d: session beads = %d, want 1; beads=%#v", tick, len(sessionBeads), sessionBeads)
+		}
+		got := sessionBeads[0]
+		if beadID == "" {
+			beadID = got.ID
+		} else if got.ID != beadID {
+			t.Fatalf("tick %d: session bead id = %q, want the tick-1 bead %q (sync minted a duplicate)", tick, got.ID, beadID)
+		}
+
+		if alias := got.Metadata["alias"]; alias != "" {
+			t.Fatalf("tick %d: pool slot bead alias = %q, want empty — syncSessionBeads re-stamped the slot as an "+
+				"ownership identity, so the session starts with GC_ALIAS=%s and claims slot-form again; stderr=%q",
+				tick, alias, alias, stderr.String())
+		}
+		if history := got.Metadata["alias_history"]; strings.TrimSpace(history) != "" {
+			t.Fatalf("tick %d: pool slot bead alias_history = %q, want empty", tick, history)
+		}
+		// The slot must still be recorded where it belongs, or the unaliasing
+		// would have destroyed slot accounting instead of relocating it.
+		if got.Metadata["agent_name"] != "rig/claude-1" || got.Metadata["pool_slot"] != "1" {
+			t.Fatalf("tick %d: slot accounting lost: agent_name=%q pool_slot=%q",
+				tick, got.Metadata["agent_name"], got.Metadata["pool_slot"])
+		}
+
+		// The env the session would actually spawn with, read through the same
+		// runtime projection session start uses (it overrides tp.Env).
+		info, err := sessionFrontDoor(store).Get(got.ID)
+		if err != nil {
+			t.Fatalf("tick %d: project session info: %v", tick, err)
+		}
+		env := sessionpkg.RuntimeEnvWithSessionContext(info, 1, 1, "tok")
+		if env["GC_ALIAS"] != "" {
+			t.Fatalf("tick %d: spawn GC_ALIAS = %q, want empty", tick, env["GC_ALIAS"])
+		}
+		if want := got.Metadata["session_name"]; env["BEADS_ACTOR"] != want {
+			t.Fatalf("tick %d: spawn BEADS_ACTOR = %q, want the session name %q — this is the string the claim writes",
+				tick, env["BEADS_ACTOR"], want)
+		}
 	}
 }
 
@@ -235,7 +312,6 @@ func TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim(t *testing.T) {
 
 	released := releaseOrphanedPoolAssignments(
 		store,
-		beads.SessionStore{Store: store},
 		testPoolReleaseConfig(),
 		"",
 		nil,

--- a/cmd/gc/pool_slot_unaliased_test.go
+++ b/cmd/gc/pool_slot_unaliased_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/session/sessiontest"
+)
+
+// Pool members identified by a rebinding numeric slot ("rig/claude-1") must
+// never carry that slot in an IDENTITY channel — not in the session bead's
+// metadata["alias"], and not in the spawn env's GC_ALIAS/GC_AGENT/BEADS_ACTOR.
+//
+// #4981 made `gc hook --claim` prefer GC_ALIAS. That is right for named agents
+// (a stable identity bd can match actor-to-assignee on) and wrong for pool
+// slots, which the controller rebinds to a fresh session whenever a holder
+// dies. With the slot in GC_ALIAS, pool workers claimed under a name no
+// reconciler guard enumerates, so the drain guard saw no assigned work and
+// drained live claim-holders ~2min in. Restoring the original unaliased-pool
+// design (bc2ee15ac4) puts the claim back on the session name, which every
+// guard already enumerates — no guard change needed.
+//
+// Slot bookkeeping does NOT ride the alias: agent_name, title, the agent:<name>
+// label, pool_slot, and the canonical-instance record all still carry it, and
+// nonExpandingPoolIdentitySlot reads every one of them.
+
+func transientSlotPoolConfig() *config.City {
+	return &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "claude",
+			Dir:               "rig",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "printf 1",
+		}},
+	}
+}
+
+// TestBuildDesiredState_PoolSlotSessionBeadCarriesNoSlotAlias inverts the
+// pre-fix pin (TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity
+// asserted alias == "rig/claude-1"). The slot identity must survive in every
+// bookkeeping channel and in none of the identity channels.
+func TestBuildDesiredState_PoolSlotSessionBeadCarriesNoSlotAlias(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), transientSlotPoolConfig(), runtime.NewFake(), store, io.Discard)
+
+	sessionBeads, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("load session beads: %v", err)
+	}
+	if len(sessionBeads) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(sessionBeads))
+	}
+	got := sessionBeads[0]
+
+	if alias := got.Metadata["alias"]; alias != "" {
+		t.Fatalf("pool slot session bead alias = %q, want empty: a rebinding slot must not be an ownership identity", alias)
+	}
+	// Slot accounting channels must all survive the unaliasing.
+	if got.Metadata["agent_name"] != "rig/claude-1" {
+		t.Fatalf("agent_name = %q, want concrete slot identity", got.Metadata["agent_name"])
+	}
+	if got.Metadata["pool_slot"] != "1" {
+		t.Fatalf("pool_slot = %q, want 1", got.Metadata["pool_slot"])
+	}
+	if got.Title != "rig/claude-1" {
+		t.Fatalf("title = %q, want concrete slot identity", got.Title)
+	}
+	if !containsString(got.Labels, "agent:rig/claude-1") {
+		t.Fatalf("labels = %#v, want concrete slot agent label", got.Labels)
+	}
+	if got.Metadata[sessionpkg.CanonicalInstanceNameMetadata] != "rig/claude-1" {
+		t.Fatalf("canonical instance record = %q, want concrete slot identity", got.Metadata[sessionpkg.CanonicalInstanceNameMetadata])
+	}
+
+	tp, ok := dsResult.State[got.Metadata["session_name"]]
+	if !ok {
+		t.Fatalf("desired state missing created session %q; keys=%v", got.Metadata["session_name"], mapKeys(dsResult.State))
+	}
+	if tp.Alias != "" {
+		t.Fatalf("pool slot TemplateParams.Alias = %q, want empty", tp.Alias)
+	}
+	if env := tp.Env["GC_ALIAS"]; env != "" {
+		t.Fatalf("pool slot GC_ALIAS = %q, want empty; template_resolve seeds the bare template here, so it must be blanked, not skipped", env)
+	}
+	if env := tp.Env["GC_AGENT"]; env != tp.SessionName {
+		t.Fatalf("pool slot GC_AGENT = %q, want the session name %q", env, tp.SessionName)
+	}
+	if tp.PoolSlot != 1 {
+		t.Fatalf("pool slot TemplateParams.PoolSlot = %d, want 1", tp.PoolSlot)
+	}
+}
+
+// TestPoolSlotSessionRuntimeIdentityIsSessionName pins the end of the chain the
+// claim actually reads. The spawn env is mergeEnv(tp.Env, RuntimeEnvWithSessionContext),
+// so the RUNTIME projection wins — blanking tp.Env alone would be inert. With the
+// bead unaliased, runtimePublicAlias falls to empty and AssigneeIdentifier falls to
+// the persisted session name, which is what `gc hook --claim` then writes as the
+// assignee (hookSessionAgentForQuery: GC_ALIAS -> BEADS_ACTOR -> ...).
+func TestPoolSlotSessionRuntimeIdentityIsSessionName(t *testing.T) {
+	const sessionName = "claude-gcg-session-x"
+	info := sessiontest.SeedBead(t, beads.Bead{
+		ID:     "gcg-session-x",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:rig/claude-1"},
+		Metadata: map[string]string{
+			"template":             "rig/claude",
+			"agent_name":           "rig/claude-1",
+			"session_name":         sessionName,
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+
+	if got := sessionpkg.AssigneeIdentifier(info); got != sessionName {
+		t.Fatalf("AssigneeIdentifier = %q, want the session name %q — this is the string BEADS_ACTOR and the claim both use", got, sessionName)
+	}
+	env := sessionpkg.RuntimeEnvWithSessionContext(info, 1, 1, "tok")
+	if env["GC_ALIAS"] != "" {
+		t.Fatalf("runtime GC_ALIAS = %q, want empty for an unaliased pool slot", env["GC_ALIAS"])
+	}
+	if env["BEADS_ACTOR"] != sessionName {
+		t.Fatalf("runtime BEADS_ACTOR = %q, want the session name %q", env["BEADS_ACTOR"], sessionName)
+	}
+	if env["GC_AGENT"] != sessionName {
+		t.Fatalf("runtime GC_AGENT = %q, want the session name %q", env["GC_AGENT"], sessionName)
+	}
+}
+
+// TestNamedSessionRuntimeIdentityStaysAliasFirst is the #4981 / ga-i44k control:
+// unaliasing pool slots must not touch named agents, whose stable alias is what
+// keeps bd's actor==assignee close check passing.
+func TestNamedSessionRuntimeIdentityStaysAliasFirst(t *testing.T) {
+	info := sessiontest.SeedBead(t, beads.Bead{
+		ID:     "gcg-session-mayor",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":                  "mayor",
+			"session_name":              "mayor",
+			"alias":                     "mayor",
+			"configured_named_session":  "true",
+			"configured_named_identity": "mayor",
+		},
+	})
+	if got := sessionpkg.AssigneeIdentifier(info); got != "mayor" {
+		t.Fatalf("named AssigneeIdentifier = %q, want alias-first \"mayor\"", got)
+	}
+	if env := sessionpkg.RuntimeEnvWithSessionContext(info, 1, 1, "tok"); env["GC_ALIAS"] != "mayor" || env["BEADS_ACTOR"] != "mayor" {
+		t.Fatalf("named runtime identity = GC_ALIAS %q / BEADS_ACTOR %q, want both \"mayor\"", env["GC_ALIAS"], env["BEADS_ACTOR"])
+	}
+}
+
+// TestCanonicalSingletonPoolKeepsStableAlias is the carve-out control. A
+// max_active_sessions=1 pool member is identified by the bare agent name, which
+// never rebinds and doubles as its mail/nudge address, so it stays aliased —
+// only rebinding slot names are unaliased.
+func TestCanonicalSingletonPoolKeepsStableAlias(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			Dir:               "cashmaster",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			ScaleCheck:        "printf 1",
+		}},
+	}
+
+	buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	sessionBeads, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("load session beads: %v", err)
+	}
+	if len(sessionBeads) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(sessionBeads))
+	}
+	if got := sessionBeads[0].Metadata["alias"]; got != "cashmaster/refinery" {
+		t.Fatalf("canonical singleton alias = %q, want the stable canonical identity", got)
+	}
+}
+
+// TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim is the deploy
+// self-heal pin. Beads still assigned slot-form when the fix lands map to no
+// live session (pool beads no longer answer to slot names), so orphan release
+// reopens them and a fresh worker re-claims under its session name. No manual
+// bead surgery.
+func TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "live pool session, unaliased",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"agent_name":           "worker-1",
+			"session_name":         "worker-gcg-session-x",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "in-flight work claimed slot-form before the fix",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker-1",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	if work, err = store.Get(work.ID); err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		beads.SessionStore{Store: store},
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s] — a stale slot-form assignee names no live session once pool beads are unaliased", released, work.ID)
+	}
+}

--- a/cmd/gc/session_alias_assignment_guard_test.go
+++ b/cmd/gc/session_alias_assignment_guard_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session/sessiontest"
+)
+
+// A numeric pool slot ("gascity/gc.run-operator-1") is a REBINDING name: the
+// controller hands it to a fresh session whenever the previous holder dies, so
+// it cannot identify an owner. #4981 flipped `gc hook --claim` to prefer
+// GC_ALIAS, and pool spawns stamped the slot into GC_ALIAS, so pool claims
+// silently moved from the session name (which every reconciler guard
+// enumerates) to the slot form (which none of them do) — the reconciler drained
+// claim-holding workers as "orphaned" ~2min after the claim.
+//
+// The fix unaliases transient pool slots upstream, so the guards stay narrow on
+// purpose. These are NEGATIVE pins: a slot-form assignee must match NO session,
+// including the session currently bound to that slot. If a future change makes
+// the guards enumerate slot aliases, a rebind would let a fresh session shield
+// (or inherit) a dead session's claim — the ambiguity this design rejects.
+
+// legacyAliasedPoolSessionBead is a pre-fix pool session bead: it still carries
+// the slot in metadata["alias"], the shape in-flight beads have at deploy time.
+func legacyAliasedPoolSessionBead(id, sessionName, alias, aliasHistory string) beads.Bead {
+	metadata := map[string]string{
+		"template":             "worker",
+		"session_name":         sessionName,
+		poolManagedMetadataKey: boolMetadata(true),
+		"pool_slot":            "1",
+		"alias":                alias,
+	}
+	if aliasHistory != "" {
+		metadata["alias_history"] = aliasHistory
+	}
+	return beads.Bead{
+		ID:       id,
+		Type:     sessionBeadType,
+		Status:   "open",
+		Labels:   []string{sessionBeadLabel},
+		Metadata: metadata,
+	}
+}
+
+func aliasGuardConfig() *config.City {
+	return &config.City{Agents: []config.Agent{{Name: "worker"}}}
+}
+
+// mustCreateInProgressWork seeds a work bead already claimed by assignee, the
+// shape a pool agent leaves behind while it is running a step.
+func mustCreateInProgressWork(t *testing.T, store beads.Store, assignee string) beads.Bead {
+	t.Helper()
+	work, err := store.Create(beads.Bead{
+		Title:    "pool work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: assignee,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+	return got
+}
+
+// TestDrainGuardsKeepPoolSessionClaimingUnderItsSessionName is the goal-state
+// control: with pool claims written session-name form, every guard already sees
+// them with no guard change at all. This is what the upstream unaliasing buys.
+func TestDrainGuardsKeepPoolSessionClaimingUnderItsSessionName(t *testing.T) {
+	const sessionName = "gc__run-operator-gcg-session-x"
+	store := beads.NewMemStore()
+	info := sessiontest.SeedBead(t, legacyAliasedPoolSessionBead("gcg-session-x", sessionName, "", ""))
+	mustCreateInProgressWork(t, store, sessionName)
+
+	has, err := sessionHasOpenAssignedWorkForConfigInfo(store, nil, info, aliasGuardConfig())
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForConfigInfo: %v", err)
+	}
+	if !has {
+		t.Fatal("orphan-drain guard missed a session-name-form pool claim; the whole fix rests on this form being visible")
+	}
+
+	closeGate, err := sessionHasOpenAssignedWorkForReachableStoreForCloseGate("", aliasGuardConfig(), store, nil, info)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForReachableStoreForCloseGate: %v", err)
+	}
+	if !closeGate {
+		t.Fatal("drain-ack close gate missed a session-name-form pool claim")
+	}
+}
+
+// TestAssignmentGuardsIgnoreTransientPoolSlotAliases is the negative pin. Even
+// for the session that currently holds the slot, a slot-form assignee must not
+// register as assigned work: slot names rebind, so honoring them would let the
+// next holder answer for the previous holder's abandoned claim.
+func TestAssignmentGuardsIgnoreTransientPoolSlotAliases(t *testing.T) {
+	store := beads.NewMemStore()
+	info := sessiontest.SeedBead(t, legacyAliasedPoolSessionBead(
+		"gcg-session-x", "gc__run-operator-gcg-session-x", "gascity/gc.run-operator-1", "gascity/gc.run-operator-0"))
+
+	for _, assignee := range []string{"gascity/gc.run-operator-1", "gascity/gc.run-operator-0"} {
+		mustCreateInProgressWork(t, store, assignee)
+	}
+
+	has, err := sessionHasOpenAssignedWorkForConfigInfo(store, nil, info, aliasGuardConfig())
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForConfigInfo: %v", err)
+	}
+	if has {
+		t.Fatal("a transient pool slot alias registered as assigned work; slot names rebind, so slot-form " +
+			"ownership must never keep a session alive")
+	}
+
+	closeGate, err := sessionHasOpenAssignedWorkForReachableStoreForCloseGate("", aliasGuardConfig(), store, nil, info)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForReachableStoreForCloseGate: %v", err)
+	}
+	if closeGate {
+		t.Fatal("the drain-ack close gate honored a transient pool slot alias")
+	}
+
+	if sessionBeadHasAssignedWorkInfo([]beads.Bead{{ID: "wb", Status: "in_progress", Assignee: "gascity/gc.run-operator-1"}}, info) {
+		t.Fatal("the pool reuse predicate honored a transient pool slot alias")
+	}
+}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1638,8 +1638,20 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		isManagedPool := origin == "ephemeral"
 		isPoolInstance := poolSlot > 0
+		// A transient pool slot is the LOGICAL instance name (tp.InstanceName,
+		// b.Metadata["agent_name"]) and never an ownership identity, so the
+		// fallbacks below must not resurrect it as one. Leaving managedAlias empty
+		// is what disables the whole alias lane for these beads: the create arm
+		// skips meta["alias"], needsAliasSync compares "" against an already-empty
+		// alias, and needsManagedPoolAliasValidation requires a non-empty alias.
+		//
+		// Without this gate the create path's unaliasing survives exactly zero
+		// production ticks — buildDesiredState hands sync a slot-form
+		// InstanceName, sync writes it straight back, and the session starts from
+		// a re-aliased bead (see TestPoolSlotStaysUnaliasedAcrossReconcileTicks).
+		transientPoolSlot := usesTransientPoolSlotIdentity(findAgentByTemplate(cfg, tp.TemplateName))
 		managedAlias := strings.TrimSpace(tp.Alias)
-		if managedAlias == "" && isManagedPool && isPoolInstance {
+		if managedAlias == "" && isManagedPool && isPoolInstance && !transientPoolSlot {
 			managedAlias = strings.TrimSpace(tp.InstanceName)
 		}
 
@@ -1693,7 +1705,11 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if slot, err := strconv.Atoi(strings.TrimSpace(b.Metadata["pool_slot"])); err == nil && slot > 0 {
 				poolSlot = slot
 				isPoolInstance = true
-				if managedAlias == "" {
+				// Same rule on the exists-recovery lane: agent_name carries the slot
+				// for a transient pool member, so reading it here would re-alias the
+				// bead the moment a tick rediscovers pool_slot from the store rather
+				// than from tp.
+				if managedAlias == "" && !transientPoolSlot {
 					if cfgAgent := findAgentByTemplate(cfg, tp.TemplateName); cfgAgent != nil && cfgAgent.UsesCanonicalSingletonPoolIdentity() {
 						managedAlias = cfgAgent.QualifiedName()
 					} else {

--- a/cmd/gc/session_classifier_info_equiv_test.go
+++ b/cmd/gc/session_classifier_info_equiv_test.go
@@ -76,6 +76,30 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 				"session_name": "worker-ga-pool",
 			},
 		},
+		"pool-alias-claim": {
+			// A LEGACY pool bead: minted before pool slots were unaliased, so it
+			// still carries a slot in alias/alias_history. Both values are distinct
+			// from the ID, the session_name, and each other, so the
+			// assignment-identifier rows below compare a genuinely alias-bearing
+			// bead — and must agree, on both the raw and Info form, that the
+			// slot is NOT an assignment identity (see
+			// TestAssignmentGuardsIgnoreTransientPoolSlotAliases). The "named"
+			// fixture cannot exercise this: its alias equals its session_name, so
+			// the difference collapses on dedup.
+			ID:     "gcg-session-alias",
+			Type:   session.BeadType,
+			Title:  "worker",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":      "worker",
+				"pool_managed":  "true",
+				"pool_slot":     "1",
+				"state":         "awake",
+				"session_name":  "gc__run-operator-gcg-session-alias",
+				"alias":         "gascity/gc.run-operator-1",
+				"alias_history": "gascity/gc.run-operator-0",
+			},
+		},
 		"pool-managed-flag-only": {
 			ID:     "ga-poolflag",
 			Type:   session.BeadType,

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"bufio"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -591,25 +592,137 @@ func waitForReport(t *testing.T, cityDir, agentName string, timeout time.Duratio
 	return nil // unreachable
 }
 
-func waitForAgentRunning(t *testing.T, cityDir, agentName string, timeout time.Duration) {
+// waitForPoolMemberReports resolves a pool template's live members and returns
+// each member's report keyed by its SLOT identity ("worker-1", "worker-2").
+//
+// A pool member of an expanding pool has no public alias: the slot rebinds to a
+// fresh session whenever a holder dies, so it is bookkeeping rather than
+// identity, and the session's GC_AGENT / BEADS_ACTOR resolve to its runtime
+// session name instead. The report script keys its file on $GC_AGENT, so the
+// filename is the session name and the test cannot construct it in advance.
+//
+// The slot is still stamped on the session bead as agent_name, so
+// `gc session list --json` is the stable channel that maps a slot the test DOES
+// know to the session name it does not. Discovery goes through the same CLI
+// contract sessionAssigneeForTemplate already relies on, and the per-member wait
+// then reuses waitForReport so the container-provider fallback still applies.
+//
+// Non-expanding (max=1) pools keep their canonical identity and alias, so they
+// need none of this — call waitForReport with the agent name directly.
+func waitForPoolMemberReports(t *testing.T, cityDir, template string, slots []string, timeout time.Duration) map[string]*e2eReport {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		out, err := gc(cityDir, "session", "list", "--state", "all")
+
+	sessionNames := waitForPoolMemberSessionNames(t, cityDir, template, slots, timeout)
+	reports := make(map[string]*e2eReport, len(slots))
+	for _, slot := range slots {
+		reports[slot] = waitForReport(t, cityDir, sessionNames[slot], timeout)
+	}
+	return reports
+}
+
+// waitForPoolMemberSessionNames maps each requested slot identity to the runtime
+// session name of the live session currently holding it.
+func waitForPoolMemberSessionNames(t *testing.T, cityDir, template string, slots []string, timeout time.Duration) map[string]string {
+	t.Helper()
+
+	var resolved map[string]string
+	found := pollUntil(timeout, 200*time.Millisecond, func() bool {
+		out, err := gc(cityDir, "session", "list", "--json", "--template", template, "--state", "all")
 		if err == nil {
-			for _, line := range strings.Split(out, "\n") {
-				fields := strings.Fields(line)
-				if len(fields) < 6 {
-					continue
+			var sessionList struct {
+				Sessions []struct {
+					Template    string `json:"template"`
+					Closed      bool   `json:"closed"`
+					State       string `json:"state"`
+					Alias       string `json:"alias"`
+					AgentName   string `json:"agent_name"`
+					SessionName string `json:"session_name"`
+				} `json:"sessions"`
+			}
+			if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &sessionList); jsonErr == nil {
+				found := make(map[string]string, len(slots))
+				for _, s := range sessionList.Sessions {
+					if s.Closed || strings.TrimSpace(s.Template) != template {
+						continue
+					}
+					name := strings.TrimSpace(s.SessionName)
+					slot := strings.TrimSpace(s.AgentName)
+					if name == "" || slot == "" {
+						continue
+					}
+					// A rebinding slot must not be advertised as an alias. Fail
+					// loudly rather than silently falling back: an alias here means
+					// the unaliasing regressed and the session is claiming work
+					// under a name that outlives it.
+					if alias := strings.TrimSpace(s.Alias); alias != "" {
+						t.Fatalf("pool member %q (template %q) advertises alias %q; expanding-pool slots must stay unaliased", slot, template, alias)
+					}
+					found[slot] = name
 				}
-				state := fields[2]
-				target := fields[4]
-				if target == agentName && state == "active" {
-					return
+				if haveAllSlots(found, slots) {
+					resolved = found
+					return true
 				}
 			}
 		}
-		time.Sleep(500 * time.Millisecond)
+		return false
+	})
+	if found {
+		return resolved
+	}
+
+	out, _ := gc(cityDir, "session", "list", "--json", "--template", template, "--state", "all")
+	t.Fatalf("timed out resolving session names for template %q slots %v within %s\nsessions:\n%s", template, slots, timeout, out)
+	return nil
+}
+
+// pollUntil calls fn on a fixed cadence until it reports success or timeout
+// elapses, returning whether it succeeded. It is the one place the integration
+// helpers spend wall time waiting on a condition they cannot subscribe to, so
+// new waits reuse this cadence instead of open-coding another sleep loop.
+func pollUntil(timeout, interval time.Duration, fn func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
+}
+
+func haveAllSlots(found map[string]string, slots []string) bool {
+	for _, slot := range slots {
+		if found[slot] == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func waitForAgentRunning(t *testing.T, cityDir, agentName string, timeout time.Duration) {
+	t.Helper()
+	if pollUntil(timeout, 500*time.Millisecond, func() bool {
+		out, err := gc(cityDir, "session", "list", "--state", "all")
+		if err != nil {
+			return false
+		}
+		for _, line := range strings.Split(out, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 6 {
+				continue
+			}
+			state := fields[2]
+			target := fields[4]
+			if target == agentName && state == "active" {
+				return true
+			}
+		}
+		return false
+	}) {
+		return
 	}
 	out, _ := gc(cityDir, "session", "list", "--state", "all")
 	t.Fatalf("agent %q not active within %s\nsessions:\n%s", agentName, timeout, out)

--- a/test/integration/e2e_multi_test.go
+++ b/test/integration/e2e_multi_test.go
@@ -62,21 +62,43 @@ func TestE2E_MultiAgent_PoolAndFixed(t *testing.T) {
 	}
 	cityDir := setupE2ECity(t, nil, city)
 
-	// Fixed agent uses bare name.
+	// The two agents sit on opposite sides of the ownership rule, and the
+	// contrast is the point of this test.
+	//
+	// A FIXED agent has one stable identity, so it keeps its alias and answers
+	// to its bare name.
 	fixedReport := waitForReport(t, cityDir, "fixed", e2eDefaultTimeout())
 	if !fixedReport.has("GC_AGENT", "fixed") {
-		t.Errorf("fixed agent GC_AGENT: got %v", fixedReport.getAll("GC_AGENT"))
+		t.Errorf("fixed agent GC_AGENT: got %v, want [fixed]", fixedReport.getAll("GC_AGENT"))
+	}
+	if got := fixedReport.get("GC_ALIAS"); got != "fixed" {
+		t.Errorf("fixed agent GC_ALIAS = %q, want \"fixed\": a stable identity keeps its alias", got)
 	}
 
-	// Pool agents use numbered names.
-	for _, name := range []string{"pooled-1", "pooled-2"} {
-		report := waitForReport(t, cityDir, name, e2eDefaultTimeout())
-		if !report.has("GC_AGENT", name) {
-			t.Errorf("%s GC_AGENT: got %v", name, report.getAll("GC_AGENT"))
+	// A POOL member's slot rebinds to a fresh session whenever a holder dies, so
+	// the slot is bookkeeping and the session owns work under its own session
+	// name. Its report is therefore keyed by the session name, not "pooled-N".
+	reports := waitForPoolMemberReports(t, cityDir, "pooled", []string{"pooled-1", "pooled-2"}, e2eDefaultTimeout())
+	seen := make(map[string]string, len(reports))
+	for _, slot := range []string{"pooled-1", "pooled-2"} {
+		report := reports[slot]
+		agent := report.get("GC_AGENT")
+		if agent == slot {
+			t.Errorf("%s GC_AGENT = %q: an expanding-pool member must not claim under its rebinding slot", slot, agent)
+		}
+		if agent == "" {
+			t.Errorf("%s has no GC_AGENT", slot)
+		}
+		if got := report.get("GC_ALIAS"); got != "" {
+			t.Errorf("%s GC_ALIAS = %q, want empty for an unaliased pool slot", slot, got)
 		}
 		if !report.has("CUSTOM_TYPE", "pooled") {
-			t.Errorf("%s missing CUSTOM_TYPE=pooled", name)
+			t.Errorf("%s missing CUSTOM_TYPE=pooled", slot)
 		}
+		if prev, dup := seen[agent]; dup {
+			t.Errorf("%s and %s report the same GC_AGENT %q; pool members must stay distinct", prev, slot, agent)
+		}
+		seen[agent] = slot
 	}
 }
 

--- a/test/integration/e2e_pool_test.go
+++ b/test/integration/e2e_pool_test.go
@@ -21,14 +21,21 @@ func TestE2E_Pool_InstanceNaming(t *testing.T) {
 	}
 	cityDir := setupE2ECity(t, nil, city)
 
-	r1 := waitForReport(t, cityDir, "worker-1", e2eDefaultTimeout())
-	r2 := waitForReport(t, cityDir, "worker-2", e2eDefaultTimeout())
-
-	if !r1.has("GC_AGENT", "worker-1") {
-		t.Errorf("worker-1 GC_AGENT: got %v, want [worker-1]", r1.getAll("GC_AGENT"))
-	}
-	if !r2.has("GC_AGENT", "worker-2") {
-		t.Errorf("worker-2 GC_AGENT: got %v, want [worker-2]", r2.getAll("GC_AGENT"))
+	// The slot names are real and still stamped on the session bead (agent_name),
+	// which is how the members are discovered here. What they are NOT is public
+	// identity: an expanding-pool slot rebinds to a fresh session whenever a
+	// holder dies, so each member owns work under its own session name and its
+	// GC_AGENT is that name, not "worker-N".
+	reports := waitForPoolMemberReports(t, cityDir, "worker", []string{"worker-1", "worker-2"}, e2eDefaultTimeout())
+	for _, slot := range []string{"worker-1", "worker-2"} {
+		if agent := reports[slot].get("GC_AGENT"); agent == slot {
+			t.Errorf("%s GC_AGENT = %q: an expanding-pool member must not claim under its rebinding slot", slot, agent)
+		} else if agent == "" {
+			t.Errorf("%s has no GC_AGENT", slot)
+		}
+		if got := reports[slot].get("GC_ALIAS"); got != "" {
+			t.Errorf("%s GC_ALIAS = %q, want empty for an unaliased pool slot", slot, got)
+		}
 	}
 }
 
@@ -51,6 +58,11 @@ func TestE2E_Pool_MaxOneUsesCanonicalIdentity(t *testing.T) {
 	if !report.has("GC_AGENT", "singleton") {
 		t.Errorf("singleton GC_AGENT: got %v, want [singleton]", report.getAll("GC_AGENT"))
 	}
+	// The canonical singleton identity never rebinds, so unlike an expanding
+	// pool slot it stays a public alias and keeps answering to its own name.
+	if got := report.get("GC_ALIAS"); got != "singleton" {
+		t.Errorf("singleton GC_ALIAS = %q, want \"singleton\": a non-rebinding identity keeps its alias", got)
+	}
 }
 
 // TestE2E_Pool_WithDir verifies that pool agents with a dir get the
@@ -68,18 +80,19 @@ func TestE2E_Pool_WithDir(t *testing.T) {
 	}
 	cityDir := setupE2ECity(t, nil, city)
 
-	// Pool instances with dir: qualified names include dir prefix.
-	r1 := waitForReport(t, cityDir, "workdir/dirpool-1", e2eDefaultTimeout())
-	r2 := waitForReport(t, cityDir, "workdir/dirpool-2", e2eDefaultTimeout())
+	// Pool instances with a dir: the qualified SLOT names include the dir prefix,
+	// and remain the discovery key even though they are not the members' public
+	// identity.
+	reports := waitForPoolMemberReports(t, cityDir, "workdir/dirpool",
+		[]string{"workdir/dirpool-1", "workdir/dirpool-2"}, e2eDefaultTimeout())
 
 	wantDir := filepath.Join(cityDir, "workdir")
 
 	// Both instances share the same workdir (no template expansion).
-	if cwd := r1.get("CWD"); !sameE2EPath(t, cwd, wantDir) {
-		t.Errorf("dirpool-1 CWD = %q, want %q", cwd, wantDir)
-	}
-	if cwd := r2.get("CWD"); !sameE2EPath(t, cwd, wantDir) {
-		t.Errorf("dirpool-2 CWD = %q, want %q", cwd, wantDir)
+	for _, slot := range []string{"workdir/dirpool-1", "workdir/dirpool-2"} {
+		if cwd := reports[slot].get("CWD"); !sameE2EPath(t, cwd, wantDir) {
+			t.Errorf("%s CWD = %q, want %q", slot, cwd, wantDir)
+		}
 	}
 }
 
@@ -97,11 +110,10 @@ func TestE2E_Pool_SharedDir(t *testing.T) {
 	}
 	cityDir := setupE2ECity(t, nil, city)
 
-	r1 := waitForReport(t, cityDir, "shared-1", e2eDefaultTimeout())
-	r2 := waitForReport(t, cityDir, "shared-2", e2eDefaultTimeout())
+	reports := waitForPoolMemberReports(t, cityDir, "shared", []string{"shared-1", "shared-2"}, e2eDefaultTimeout())
 
-	cwd1 := r1.get("CWD")
-	cwd2 := r2.get("CWD")
+	cwd1 := reports["shared-1"].get("CWD")
+	cwd2 := reports["shared-2"].get("CWD")
 
 	if cwd1 != cwd2 {
 		t.Errorf("shared pool instances have different CWDs: %q vs %q", cwd1, cwd2)
@@ -123,15 +135,21 @@ func TestE2E_Pool_EnvPerInstance(t *testing.T) {
 	}
 	cityDir := setupE2ECity(t, nil, city)
 
-	r1 := waitForReport(t, cityDir, "envpool-1", e2eDefaultTimeout())
-	r2 := waitForReport(t, cityDir, "envpool-2", e2eDefaultTimeout())
+	reports := waitForPoolMemberReports(t, cityDir, "envpool", []string{"envpool-1", "envpool-2"}, e2eDefaultTimeout())
+	r1, r2 := reports["envpool-1"], reports["envpool-2"]
 
-	// Each instance gets unique GC_AGENT.
-	if !r1.has("GC_AGENT", "envpool-1") {
-		t.Errorf("envpool-1 GC_AGENT: got %v", r1.getAll("GC_AGENT"))
+	// Each instance still gets a UNIQUE GC_AGENT — it is now the member's own
+	// session name rather than its slot, which is the whole point: the identity
+	// a pool member claims under has to be one that dies with it.
+	a1, a2 := r1.get("GC_AGENT"), r2.get("GC_AGENT")
+	if a1 == "" || a2 == "" {
+		t.Errorf("pool members missing GC_AGENT: %q / %q", a1, a2)
 	}
-	if !r2.has("GC_AGENT", "envpool-2") {
-		t.Errorf("envpool-2 GC_AGENT: got %v", r2.getAll("GC_AGENT"))
+	if a1 == a2 {
+		t.Errorf("pool members share GC_AGENT %q, want distinct per-session identities", a1)
+	}
+	if a1 == "envpool-1" || a2 == "envpool-2" {
+		t.Errorf("pool members claim under their rebinding slots: %q / %q", a1, a2)
 	}
 
 	// Both share custom env.


### PR DESCRIPTION
## The regression

#4981 aligned the bead actor with the canonical alias and flipped the claim-assignee precedence in `gc hook --claim`:

```diff
-  assignee := firstNonEmptyHookValue(sessionName, sessionID, alias, agentForQuery, resolvedAgentName)
+  assignee := firstNonEmptyHookValue(alias, agentForQuery, resolvedAgentName, sessionName, sessionID)
```

For a **named** agent that was correct — a stable alias is what keeps bd's `actor == assignee` close check passing. For a **pool worker** it was not, because pool spawns stamp the slot into `GC_ALIAS` via `setTemplateEnvIdentity`. Claims silently moved off the session name — which every reconciler assignment guard enumerates (`sessionAssignmentIdentifierRaw*`) — and onto `<agent>-1`, which none of them do.

The result is a treadmill. The supervisor logs the in-progress assignment and drains that same session as `orphaned` seconds later; drain-ack finalize then releases the claim with no outcome. Any pool step longer than the drain window loops forever.

## Slot vs. session ownership

A pool slot is a chair, not an occupant: the controller hands `rig/claude-1` to a fresh session whenever the previous holder dies, so a work bead assigned to that string names no one in particular. Widening the guards to accept slot aliases would have "fixed" the drain at the cost of letting the *next* holder answer for the previous holder's abandoned claim. The fix goes upstream instead: a transient slot never enters an identity channel, and the session claims under its own session name, which the existing guards already see. **No guard and no hook change** — this restores the original unaliased-pool design (`bc2ee15ac4`), whose own note says session forms are the fallback "for UNALIASED pool workers".

Where the slot stops going: `metadata["alias"]`, `GC_ALIAS`, and by consequence `GC_AGENT`/`BEADS_ACTOR`. Where it still goes: `agent_name`, title, the `agent:<name>` label, `pool_slot`, and the canonical-instance record — every slot-accounting reader already prefers those.

Scoped to **rebinding** slots. Canonical singletons (`max_active_sessions=1`) and namepool members keep their alias: those names never rebind and double as the session's mail/nudge address, the same reason a configured named session keeps its own.

Two non-obvious details, both load-bearing:
- **`GC_ALIAS` is blanked, not skipped.** `resolveTemplate` seeds it with the agent's bare qualified name for every session, so a skipped stamp would leave every pool member advertising *one shared identity* — worse than per-slot names, because then two live workers claim under the same string.
- **The bead decides the spawn env, not `tp.Env`.** Session start merges `mergeEnv(tp.Env, RuntimeEnvWithSessionContext(info))`, so the runtime projection wins. Unaliasing the bead is what makes `AssigneeIdentifier` fall through to the session name, which realigns `BEADS_ACTOR` and the API assign-normalization lane at the same time.

## The sync re-stamp (why the first fix didn't hold)

Unaliasing at the create path survived **zero** reconcile ticks. A tick is `buildDesiredState → syncSessionBeads → session start`, and sync derives an alias of its own:

```go
managedAlias := strings.TrimSpace(tp.Alias)
if managedAlias == "" && isManagedPool && isPoolInstance {
    managedAlias = strings.TrimSpace(tp.InstanceName)   // still the slot, by design
}
```

So sync wrote the slot straight back and sessions started from a re-aliased bead — with every unit test green. Two more lanes had the same hole (the sync-create fallback, and the exists-recovery fallback reading `agent_name`). All three funnel through one `managedAlias`, so the fix is the same predicate at its two derivation points; leaving it empty disables the alias lane wholesale.

This was caught in review, not by the suite — the pin that matters is `TestPoolSlotStaysUnaliasedAcrossReconcileTicks`: it runs the real tick order **twice** with `skipClose=true` and asserts the alias stays empty through both, reading the spawn env through the same `RuntimeEnvWithSessionContext` projection session start uses. It fails on **tick 1** without the gate. The three unit-shaped tests written first all passed against the pre-fix code.

Also included: negative pins that a slot-form assignee matches **no** session (including the current slot holder); an alias-first control for named agents so #4981 doesn't regress; a canonical-singleton control for the carve-out; and a deploy self-heal pin — beads still assigned slot-form resolve to no live session, so orphan release reopens them and fresh workers re-claim under their session names, no bead surgery. Two existing tests were re-pointed rather than deleted (alias-conflict deferral → namepool fixture; alias-reservation CAS → canonical singleton).

## Verification

Shipped to maintainer-city as `mc-aliasguard-e0e598c480`. Live after deploy: the unaliased generation spawned, claims land session-form, claims survive far past the drain window that previously killed them (one bead that never survived 2 minutes across dozens of attempts held one claim 25+ minutes and progressed), the first step closed `pass` within 3 minutes, and all seven previously-wedged adopt-pr molecules resumed simultaneous execution.

Gates: `go vet ./cmd/gc ./internal/session` clean, `go test ./internal/session/...` green, `env -u OPENAI_API_KEY go test ./cmd/gc -count=1 -timeout 1800s` green (790s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3367 — changes pool workers to claim under their session name instead of a rebinding slot alias, and pins that a slot-form assignee resolves to no live session — which settles the assignee value class that the filed issue's root-cause analysis rests on. It adds no claim-time slot-ownership record, so the durable bead-to-slot mapping that issue asks for is untouched and still open.
- Related to #5048 — removes the rebinding pool-slot name from a worker's runtime identity — GC_ALIAS is blanked and GC_AGENT/BEADS_ACTOR become the sanitized session name — so a pool worker now advertises and claims under the same session form the dispatcher writes, which is the identity-form mismatch described in that issue. It does not change the dispatcher's assignee-writing path or the dog's own poll, so it is not confirmed to cover that stranding on its own.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->