### PR TITLE
fix(cmd/gc): probe the work bead's owner store for orphan-release liveness

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -165,6 +165,10 @@ func releaseOrphanedPoolAssignments(
 		if agentCfg == nil || !agentCfg.SupportsGenericEphemeralSessions() {
 			continue
 		}
+		// Resolved before the liveness gates because the graph-resident-session
+		// probe below reads the same store; the missing-store report stays where
+		// it was, so a bead skipped by a liveness gate never reaches it.
+		ownerStore := assignedWorkOwnerStore(cfg, store, rigStores, assignedWorkStores, i, wb)
 		if assignee == "" {
 			if wb.Status != "in_progress" {
 				continue
@@ -183,20 +187,24 @@ func releaseOrphanedPoolAssignments(
 			if liveOpenSessionAssignmentExists(store, assignee) {
 				continue
 			}
+			// The sessions binding is not the only ledger that can hold a session
+			// bead. Graph-resident run sessions (gcg-session-*) are written into
+			// the same store as the work they drive, so on a city whose graph
+			// binding is separate from the sessions binding the probe above is
+			// structurally blind to every graph-run assignee and releases live
+			// claims. A session bead of that shape lives in the work bead's own
+			// owner store, so probing that one store after the sessions store
+			// misses closes the gap without enumerating every attached store.
+			if ownerStore != nil && liveOpenSessionAssignmentExists(ownerStore, assignee) {
+				continue
+			}
 		}
 
-		var ownerStore beads.Store
-		if storeAware {
-			if i >= len(assignedWorkStores) || assignedWorkStores[i] == nil {
+		if ownerStore == nil {
+			if storeAware {
 				log.Printf("releaseOrphanedPoolAssignments: missing owner store for assigned work %q at index %d", wb.ID, i)
-				continue
 			}
-			ownerStore = assignedWorkStores[i]
-		} else {
-			ownerStore = storeForPoolAssignment(cfg, store, rigStores, wb)
-			if ownerStore == nil {
-				continue
-			}
+			continue
 		}
 		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, wb.Status, assignee) {
 			continue
@@ -211,6 +219,21 @@ func releaseOrphanedPoolAssignments(
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	return released
+}
+
+// assignedWorkOwnerStore resolves the store that owns the assigned work bead at
+// index i: the index-aligned snapshot store when the caller supplied one (the
+// store-aware form), otherwise the routed/prefix fallback. A nil result means
+// the snapshot is misaligned or no store resolves, and the caller must skip the
+// bead rather than guess at a store.
+func assignedWorkOwnerStore(cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, assignedWorkStores []beads.Store, i int, wb beads.Bead) beads.Store {
+	if len(assignedWorkStores) > 0 {
+		if i >= len(assignedWorkStores) {
+			return nil
+		}
+		return assignedWorkStores[i]
+	}
+	return storeForPoolAssignment(cfg, cityStore, rigStores, wb)
 }
 
 func detachedProbeAllowsOrphanRelease(wb beads.Bead) (bool, bool) {

--- a/cmd/gc/pool_session_release_owner_store_test.go
+++ b/cmd/gc/pool_session_release_owner_store_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// seedOwnerStoreReleaseFixture builds the two-store shape these tests share: a
+// pool session bead carrying alias "nux" plus the in_progress work bead claimed
+// under that alias, both in sessionStore/workStore as the caller directs.
+//
+// openSessionInfos is deliberately nil at every call site. That models the arm
+// where the store-ref index misses — the work is recorded under one store-ref
+// while the owning session is indexed under another, so openSessionOwnsWork
+// returns false and neither fail-open sentinel fires. The liveness re-read is
+// then the only thing standing between a live worker and having its claim
+// yanked.
+func seedOwnerStoreReleaseFixture(t *testing.T, sessionStore, workStore beads.Store, sessionStatus string) beads.Bead {
+	t.Helper()
+
+	sess, err := sessionStore.Create(beads.Bead{
+		Title:    "pool session",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Labels:   []string{sessionBeadLabel},
+		Metadata: map[string]string{"session_name": "worker-1", "alias": "nux"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if sessionStatus != "open" {
+		if err := sessionStore.Update(sess.ID, beads.UpdateOpts{Status: &sessionStatus}); err != nil {
+			t.Fatalf("set session bead status %q: %v", sessionStatus, err)
+		}
+	}
+
+	work, err := workStore.Create(beads.Bead{
+		Title:    "work claimed by the live pool session",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := workStore.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work, err = workStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+	return work
+}
+
+// TestReleaseOrphanedPoolAssignmentsReadsLivenessFromWorkOwnerStore is the
+// repro. The orphan-release liveness probe read only the primary store, but a
+// city that relocates a class keeps session beads elsewhere: graph-resident run
+// sessions (gcg-session-*) are written into the same store as the work they
+// drive, and the primary store then serves zero of them.
+//
+// liveOpenSessionAssignmentExists issues its gc:session label query against a
+// store that cannot answer, gets an empty result with no error, and reads
+// empty-success as "this assignee is dead" — only an actual query error fails
+// closed. The controller then reopens live work under a live worker, and the
+// session drains as orphaned moments later.
+//
+// The work bead's own owner store is exactly where such a session bead lives,
+// so probing it after the primary probe misses closes the gap without
+// enumerating every attached store.
+func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromWorkOwnerStore(t *testing.T) {
+	primaryStore := beads.NewMemStore() // serves no relocated session beads
+	ownerStore := beads.NewMemStore()   // holds the session bead AND its work
+	work := seedOwnerStoreReleaseFixture(t, ownerStore, ownerStore, "open")
+
+	released := releaseOrphanedPoolAssignments(
+		primaryStore,
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{ownerStore},
+		nil,
+		nil,
+	)
+
+	if len(released) != 0 {
+		t.Fatalf("released %v, want none — alias \"nux\" belongs to an open session bead co-resident with the "+
+			"work in its owner store, so its holder is alive. Releasing it means liveness was read only from the "+
+			"primary store, which serves no session beads here.", released)
+	}
+	got, err := ownerStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "nux" {
+		t.Fatalf("live worker's claim was dropped: status=%q assignee=%q, want in_progress/nux", got.Status, got.Assignee)
+	}
+}
+
+// TestReleaseOrphanedPoolAssignmentsReleasesWhenNoStoreHoldsTheSession is the
+// control: with no session bead in EITHER store the claim is genuinely
+// orphaned and must still be recovered, so the extra probe cannot have traded
+// a false release for claims stuck forever on sessions that really are gone.
+func TestReleaseOrphanedPoolAssignmentsReleasesWhenNoStoreHoldsTheSession(t *testing.T) {
+	primaryStore := beads.NewMemStore()
+	ownerStore := beads.NewMemStore()
+	work, err := ownerStore.Create(beads.Bead{
+		Title:    "work whose holder is gone",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := ownerStore.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	if work, err = ownerStore.Get(work.ID); err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		primaryStore,
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{ownerStore},
+		nil,
+		nil,
+	)
+
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s] — no store holds a session bead naming alias \"nux\"", released, work.ID)
+	}
+}


### PR DESCRIPTION
`releaseOrphanedPoolAssignments` validates an assignee's liveness with `liveOpenSessionAssignmentExists(store, …)` against the primary store only. On a city whose `[storage.classes]` relocates a bead class, the session bead that proves the assignee alive can live in the *work bead's own owner store* instead — the primary-store query then empty-succeeds, empty-success reads as "assignee dead", and live in-progress work is released out from under its worker every reconcile pass.

The fix adds a second probe against the work bead's owner store (`assignedWorkStores[i]` when store-aware, else the `storeForPoolAssignment` fallback) before releasing. Strictly conservative: any hit skips the release, so the only behavior change is *fewer* spurious releases.

`TestReleaseOrphanedPoolAssignmentsReadsLivenessFromWorkOwnerStore` fails on the pre-fix code (`released [{gc-2 0}], want none`) and pins the new probe; the control (no session bead in any store) still releases, so the probe is not a blanket suppression. The pinned `TestReleaseOrphanedPoolAssignments_*` suite (including both rig-store cases) stays green.

Found while diagnosing the maintainer-city adopt-pr stall (shipped there as part of `mc-aliasguard-e0e598c480`); it is independent of the pool-identity fix in #5241 and reviewable on its own.

Gates: `go vet ./cmd/gc ./internal/session` clean; targeted + pinned suites green; full `env -u OPENAI_API_KEY go test ./cmd/gc -count=1 -timeout 1800s` green on the combined stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3566 — adds a second, cross-store liveness probe to the orphan-release path so a live holder whose session bead sits in the work bead's own owner store is no longer stripped — one more predicate in the bundle that the filed issue proposes collapsing under a holder-renewed work-claim lease; it does not implement that lease, and the named-session route asymmetry noted there is untouched

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->