### PR TITLE
fix: recognize dolt port collision messages

### DIFF
--- a/cmd/gc/dolt_start_address_in_use_retry_window_test.go
+++ b/cmd/gc/dolt_start_address_in_use_retry_window_test.go
@@ -379,8 +379,8 @@ func installStartManagedDoltLoopStubs(t *testing.T, stubs startManagedDoltLoopSt
 
 // TestStartManagedDoltProcessWithOptions_AddressInUseSamePortRetrySucceeds
 // drives the full loop body through the address-in-use branch. The first
-// attempt simulates dolt failing to bind (log returns the address-in-use
-// substring); the wait helper returns available (probe shim) so the loop
+// attempt simulates the current dolt server failing to bind (log returns its
+// "Port N already in use" message); the wait helper returns available so the loop
 // retries the SAME port; the second attempt succeeds (waitReady returns
 // Ready=true). PR contract:
 //
@@ -413,7 +413,7 @@ func TestStartManagedDoltProcessWithOptions_AddressInUseSamePortRetrySucceeds(t 
 		},
 		logSuffixFn: func(_ string, _ int64) (string, error) {
 			atomic.AddInt32(&logCalls, 1)
-			return "panic: listen tcp 0.0.0.0:17777: bind: address already in use\n", nil
+			return "Port 17777 already in use.\n", nil
 		},
 		portAvailableFn: func(_ string, _ int) bool { return true }, // wait succeeds → retry same port
 		retryWindow:     50 * time.Millisecond,

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -283,7 +283,7 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 		})
 
 		startupOutput, readErr := managedDoltLogSuffixFn(layout.LogFile, logOffset)
-		if readErr == nil && strings.Contains(strings.ToLower(startupOutput), "address already in use") {
+		if readErr == nil && managedDoltStartupReportsAddressInUse(startupOutput) {
 			report.AddressInUse = true
 			// Wait briefly on the originally requested port to outlast a
 			// TIME_WAIT socket before bumping ports. See
@@ -307,6 +307,32 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 	}
 
 	return report, fmt.Errorf("dolt server could not find a free port after repeated address-in-use failures (last port %d)", report.Port)
+}
+
+// managedDoltStartupReportsAddressInUse recognizes bind failures emitted by
+// both the operating system and newer dolt releases. Dolt 2.1.7 reports
+// "Port <number> already in use" instead of the traditional
+// "address already in use" text.
+func managedDoltStartupReportsAddressInUse(output string) bool {
+	lower := strings.ToLower(output)
+	if strings.Contains(lower, "address already in use") {
+		return true
+	}
+
+	for _, line := range strings.Split(lower, "\n") {
+		fields := strings.Fields(line)
+		for i := 0; i+4 < len(fields); i++ {
+			if fields[i] != "port" || fields[i+2] != "already" || fields[i+3] != "in" ||
+				strings.TrimRight(fields[i+4], ".:;,!") != "use" {
+				continue
+			}
+			if _, err := strconv.Atoi(strings.Trim(fields[i+1], "[]():")); err == nil {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // managedDoltLockReleaseTimeoutFn resolves the configured wait window for


### PR DESCRIPTION
## What changed

- recognize Dolt's current `Port <number> already in use` startup error
- preserve support for the traditional `address already in use` wording
- exercise the managed-server retry loop with the exact Dolt 2.1.7 message

## Why

Dolt 2.1.7 changed the bind-failure text emitted during managed startup. Gas City only classified logs containing `address already in use`, so it returned a generic startup failure instead of retrying the port or selecting another available port.

## Validation

- `make build`
- `go vet ./cmd/gc ./internal/runtime/herdr`
- `go test -count=1 ./cmd/gc -run AddressInUse`
- `go test -count=1 ./internal/runtime/herdr`
- pre-commit hook: staged formatting, generated-doc check, full `go vet ./...`

`make test-fast-parallel` is not green on current upstream `main` in this WSL environment. The unchanged `examples/bd/dolt` package consistently reports its live-SQL fixtures as `skipped (no remote)` and the run later strands `internal/api`; the six `cmd/gc` shards completed. The diff does not touch the failing example or API packages.
