### PR TITLE
fix: write-orphaned class residents are reachable by id again

### DIFF
--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -74,10 +74,21 @@ package main
 //     storage and says nothing about a bead the work ledger still serves. See
 //     resolve.
 //
-// Served here: show, update (fields and metadata, including --claim),
-// release-if-current, and dep list. `gc bd heartbeat` is not — it is rewritten
-// to a metadata update before this hook runs — and neither is the general query
-// surface, which bd_relocated_classes.go refuses on its own terms.
+// Served here: show, update (fields and metadata, including --claim), close,
+// reopen, release-if-current, and dep list. `gc bd heartbeat` is not — it is
+// rewritten to a metadata update before this hook runs — and neither is the
+// general query surface, which bd_relocated_classes.go refuses on its own
+// terms.
+//
+// close and reopen are here for the same reason update is, one lifecycle step
+// further on. A class store MINTS ids from its binding workspace's own prefix,
+// so a synthetic it creates with no id — an input convoy, a patrol root, a
+// wisp — carries a WORK prefix while residing only in the binding. Reads found
+// those (the class leg is probed for every id); the close that would retire one
+// was not a by-ID verb at all, so it never opened this door, fell through to a
+// subprocess pointed at the prefix store, and died there with bd's not-found.
+// Every such open bead was a permanent ready-frontier polluter with no
+// supported drain path.
 //
 // # Ownership is decided before servability
 //
@@ -163,6 +174,14 @@ const (
 	// work ledger and left the step open in the binding forever: a molecule
 	// that stalls with no error anywhere.
 	bdByIDUpdate bdByIDVerb = "update"
+	// bdByIDClose is `gc bd close <id> [--json]`, and bdByIDReopen its undo.
+	//
+	// They are the drain verbs for a class resident: the row a class store
+	// minted under a work-shaped id has no other way to be retired, because
+	// every prefix-routed lane resolves it against a ledger that never held
+	// it. Only the bare form is served — see parseBdByIDCloseArgs.
+	bdByIDClose  bdByIDVerb = "close"
+	bdByIDReopen bdByIDVerb = "reopen"
 )
 
 // bdByIDDepDirectionUp asks for the beads that depend ON the subject; the
@@ -206,6 +225,12 @@ func parseBdByIDOp(bdArgs []string) (bdByIDOp, bool) {
 		return bdByIDOp{Verb: bdByIDShow, ID: id, JSON: jsonOut}, true
 	case "update":
 		op, _, ok := parseBdByIDUpdateArgs(bdArgs[1:])
+		return op, ok
+	case "close":
+		op, _, ok := parseBdByIDCloseArgs(bdByIDClose, bdArgs[1:])
+		return op, ok
+	case "reopen":
+		op, _, ok := parseBdByIDCloseArgs(bdByIDReopen, bdArgs[1:])
 		return op, ok
 	case "release-if-current":
 		id, assignee, ok, err := parseBdReleaseIfCurrentArgs(bdArgs)
@@ -358,13 +383,69 @@ func bdByIDUpdateWritesFields(op bdByIDOp, metadata map[string]string) bool {
 		len(metadata) > 0
 }
 
+// parseBdByIDCloseArgs parses the tail of `gc bd close` and `gc bd reopen`.
+//
+// rejected names the first flag that stopped this from being served, the same
+// way parseBdByIDUpdateArgs does, so a refusal can say WHICH spelling kept the
+// command off this surface.
+//
+// The served form is one bare id plus --json, and that is the whole of what the
+// closed contract can express: GraphStore.Close and GraphStore.Reopen take an
+// id and return an error. bd's -r/--reason/--reason-file/--session carry text
+// the contract has nowhere to put, and --claim-next/--continue/--force/
+// --no-auto/--suggest-next name workflow this arm does not run. Serving any of
+// them by ignoring it would report a command as executed after silently
+// changing what it meant — the partial write this whole surface exists to
+// remove.
+//
+// Several ids stay unrecognized for a different reason: a batch spans stores,
+// so it would need per-id routing with partial-failure semantics bd's exit
+// contract does not express. The refusal path keeps such a batch honest when
+// one of its ids is class-owned; it is never half-applied here.
+func parseBdByIDCloseArgs(verb bdByIDVerb, args []string) (op bdByIDOp, rejected string, ok bool) {
+	op = bdByIDOp{Verb: verb}
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			if op.ID != "" || arg == "" {
+				// A second positional is a batch, not a flag: there is no
+				// spelling to name, and naming the id would read as a claim
+				// about that id rather than about the shape.
+				return bdByIDOp{}, "", false
+			}
+			op.ID = arg
+			continue
+		}
+		if arg == "--json" {
+			op.JSON = true
+			continue
+		}
+		name, _, _ := strings.Cut(arg, "=")
+		return bdByIDOp{}, name, false
+	}
+	if op.ID == "" {
+		return bdByIDOp{}, "", false
+	}
+	return op, "", true
+}
+
 // bdByIDUnservedFlag names the flag that kept an otherwise-routable invocation
 // off this surface, or "" when the shape itself was never one this serves.
 func bdByIDUnservedFlag(bdArgs []string) string {
-	if len(bdArgs) == 0 || bdArgs[0] != "update" {
+	if len(bdArgs) == 0 {
 		return ""
 	}
-	_, rejected, ok := parseBdByIDUpdateArgs(bdArgs[1:])
+	var rejected string
+	var ok bool
+	switch bdArgs[0] {
+	case "update":
+		_, rejected, ok = parseBdByIDUpdateArgs(bdArgs[1:])
+	case "close":
+		_, rejected, ok = parseBdByIDCloseArgs(bdByIDClose, bdArgs[1:])
+	case "reopen":
+		_, rejected, ok = parseBdByIDCloseArgs(bdByIDReopen, bdArgs[1:])
+	default:
+		return ""
+	}
 	if ok {
 		return ""
 	}
@@ -662,6 +743,10 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		return doBdByIDDepList(resolution.Graph, op, stdout, stderr), true
 	case bdByIDUpdate:
 		return doBdByIDUpdate(resolution.Graph, op, door.bindingName(), stdout, stderr), true
+	case bdByIDClose:
+		return doBdByIDClose(resolution.Graph, op, door.bindingName(), stdout, stderr), true
+	case bdByIDReopen:
+		return doBdByIDReopen(resolution.Graph, op, door.bindingName(), stdout, stderr), true
 	}
 	// Unreachable while the verb set and this switch agree, and a refusal
 	// rather than a fall-through because the two disagreeing is exactly the
@@ -1181,6 +1266,44 @@ func doBdByIDUpdate(graph storebinding.GraphStore, op bdByIDOp, binding string, 
 		return 1
 	}
 	return printBdByIDBead(updated, op.JSON, binding, stdout, stderr)
+}
+
+// doBdByIDClose retires a class-store bead through the closed graph contract.
+//
+// The already-closed answer is the STORE's: the contract's Close carries the
+// canonical no-op semantics, and a "is it closed yet" check here would be a
+// second implementation of a rule the store already has, free to drift from it.
+func doBdByIDClose(graph storebinding.GraphStore, op bdByIDOp, binding string, stdout, stderr io.Writer) int {
+	return doBdByIDLifecycleWrite(graph, op, "close", graph.Close, binding, stdout, stderr)
+}
+
+// doBdByIDReopen is doBdByIDClose's undo, and exists for the same reason: a
+// drain that can close a class resident but not reopen one is a one-way door.
+func doBdByIDReopen(graph storebinding.GraphStore, op bdByIDOp, binding string, stdout, stderr io.Writer) int {
+	return doBdByIDLifecycleWrite(graph, op, "reopen", graph.Reopen, binding, stdout, stderr)
+}
+
+// doBdByIDLifecycleWrite applies a status transition through the closed graph
+// contract, then re-reads and renders what the store now holds.
+//
+// The re-read is doBdByIDUpdate's rule, for doBdByIDUpdate's reason: bd prints
+// the row after a mutation and callers have learned to trust that output, so
+// rendering the request back would report what was asked for rather than what
+// the store now holds. On these two verbs that difference is the whole signal —
+// a binding whose read leg and write leg resolve against different tiers is
+// visible here as an error, and invisible to a caller that only echoed the
+// verb.
+func doBdByIDLifecycleWrite(graph storebinding.GraphStore, op bdByIDOp, verb string, write func(string) error, binding string, stdout, stderr io.Writer) int {
+	if err := write(op.ID); err != nil {
+		fmt.Fprintf(stderr, "gc bd %s: %s: %v\n", verb, op.ID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	written, err := graph.Get(op.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd %s: %s was written and could not be re-read: %v\n", verb, op.ID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return printBdByIDBead(written, op.JSON, binding, stdout, stderr)
 }
 
 // printBdByIDNotFound renders genuine absence in bd's own shape so existing

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -97,6 +97,16 @@ package main
 // bead, and the command would hang or answer about the wrong workspace. It is
 // refused instead, before the subprocess.
 //
+// Ownership is proven two ways, and the second exists because the first covers
+// only half the population. A RESERVED prefix proves it from the argv alone —
+// that namespace is minted by the class store and nowhere else. RESIDENCE
+// proves it for everything else: a MUTATION whose positional ids are
+// unambiguous is probed against the class binding, and a hit refuses the same
+// way. Without that second proof a work-prefixed class resident got no
+// protection at all — its `--notes` update or its `delete` fell through to a
+// ledger that cannot hold it and died with bd's not-found, which reads as "the
+// bead is gone" rather than "you addressed the wrong store".
+//
 // The two questions are answered by different code on purpose, and answering
 // them with one function was a real defect rather than a hypothetical. The
 // served parsers reject every flag they do not implement, so "can this be
@@ -125,9 +135,20 @@ package main
 // binding and — on a born-split city — re-proves its invariant with a full work
 // store census. That is once per process, memoized with every other one-shot
 // command's routing, but it is not free, so it is paid only by an invocation
-// that could concern a class-owned bead: a served by-ID form, or an argv that
-// addresses a reserved-prefix id. An ordinary work mutation addresses only work
-// ids and never enters.
+// that could concern a class-owned bead: a served by-ID form, an argv that
+// addresses a reserved-prefix id, or a MUTATION with unambiguous positional
+// ids. An ordinary work READ or SELECTOR never enters; a mutation addressing
+// ids enters exactly once per process.
+//
+// The mutation arm is the widening, and the id shape is why it cannot be
+// narrower. A class store mints from its binding workspace's own prefix and
+// `gc storage migrate` preserves ids, so "gc-123" says nothing about which
+// store holds the row — only a probe does, and skipping it is what sent every
+// unserved mutation of a class resident to the ledger that cannot hold it.
+// Reads and selectors stay outside because they address no subject whose
+// residence could decide anything: a selector QUOTES ids, and a read that this
+// surface serves is already inside. An ambiguous scan stays outside too, for
+// the plainest reason — it yields no ids to probe.
 
 import (
 	"encoding/json"
@@ -647,6 +668,43 @@ func (d bdByIDClassDoor) resolve(id string) (bdByIDResolution, error) {
 	return resolution, nil
 }
 
+// firstResident returns the first id the class binding actually holds, or ""
+// when it holds none of them.
+//
+// It is bounded by construction: the ids come from one mutation argv, which is
+// a handful of tokens, and the probe stops at the first hit. Residence — not
+// the reserved-prefix rule — is the only thing that can decide ownership for
+// these, so a failure to READ is a failure to decide and surfaces as one
+// (resolve's classification, unchanged).
+func (d bdByIDClassDoor) firstResident(ids []string) (string, error) {
+	for _, id := range ids {
+		resolution, err := d.resolve(id)
+		if err != nil {
+			return "", err
+		}
+		if resolution.Found {
+			return id, nil
+		}
+	}
+	return "", nil
+}
+
+// bdByIDMutationSubjects returns the bead ids a write-mutation argv ADDRESSES,
+// or nil when the argv is not a mutation or cannot be scanned into ids.
+//
+// It reads bdMutationWriteIDs, the scanner doBd's exact-ID collision guard
+// already trusts for the same argv, so the two agree on what a mutation
+// addresses rather than each deciding it. An ambiguous scan yields nil: an
+// unrecognized flag may or may not consume the next token, and a guess here
+// would probe residence for a value rather than a subject.
+func bdByIDMutationSubjects(bdArgs []string) []string {
+	ids, ok, ambiguous := bdMutationWriteIDs(bdArgs)
+	if !ok || ambiguous {
+		return nil
+	}
+	return ids
+}
+
 // bdIDIsClassReserved reports whether id carries a reserved class id prefix.
 // Those prefixes are minted only by the relocated class stores, so such an id
 // existing anywhere else is not a thing bd can answer for.
@@ -674,16 +732,16 @@ func bdIDIsClassReserved(id string) bool {
 func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr io.Writer) (int, bool) {
 	op, served := parseBdByIDOp(bdArgs)
 	named, namesClassBead := bdArgsNameClassOwnedBead(bdArgs)
-	if !served && !namesClassBead {
+	mutationIDs := bdByIDMutationSubjects(bdArgs)
+	if !served && !namesClassBead && len(mutationIDs) == 0 {
 		// Nothing here can concern a class-owned bead, so the binding is not
 		// opened and the funnel is not entered.
 		//
 		// This is also the cost gate. Entering the funnel resolves a plan and
 		// opens a database, and the born-split arm re-proves its invariant with
-		// a full work-store census; a work mutation that addresses only work
-		// ids must not pay that. A non-reserved positional id on update/close
-		// needs the exact-ID collision guard doBd already applies to it, not
-		// class routing — the class store has no claim on it.
+		// a full work-store census; a read or selector that addresses no
+		// subject must not pay that, and neither must a mutation whose argv
+		// cannot be scanned into ids at all — there would be nothing to probe.
 		return 0, false
 	}
 	door, routed, err := openBdByIDClassFrontDoor(cityPath)
@@ -695,10 +753,26 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		return 0, false
 	}
 	if !served {
-		// The invocation addresses a bead only the class binding could own, in
-		// a spelling this surface does not serve. A reserved prefix is proof of
-		// ownership on its own, so no residence probe is needed to know the
-		// work store cannot answer.
+		if !namesClassBead {
+			// No reserved prefix to lean on, so ownership is proven by
+			// RESIDENCE: this is an unserved mutation, and if the class binding
+			// holds any of its subjects the work store cannot answer for it.
+			resident, err := door.firstResident(mutationIDs)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1, true
+			}
+			if resident == "" {
+				// Every subject is a work bead. bd is still their truth and the
+				// passthrough answers byte-identically — including doBd's own
+				// exact-ID collision guard, which this arm must not displace.
+				return 0, false
+			}
+			named = resident
+		}
+		// The invocation addresses a bead the class binding owns, in a spelling
+		// this surface does not serve. Forwarding it would run the command
+		// against the one ledger that cannot hold the bead.
 		return refuseClassOwnedTarget(door, bdByIDRefusedVerb(bdArgs), named, bdByIDUnservedFlag(bdArgs), stderr)
 	}
 

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -90,6 +90,10 @@ package main
 // Every such open bead was a permanent ready-frontier polluter with no
 // supported drain path.
 //
+// A close this door serves does NOT reach the ADR-0009 work-record close gate,
+// which doBd runs later. The coverage boundary and why it is sound are recorded
+// where the gate defines itself, in work_record_gate.go's header.
+//
 // # Ownership is decided before servability
 //
 // An operation that is NOT served but whose subject the class store owns does

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -430,12 +430,17 @@ func TestBdByIDDoesNotRouteAnIDInAValuePosition(t *testing.T) {
 // operation this surface does not serve, whose subject the class binding owns,
 // must not reach bd: bd opens the work workspace, cannot see the bead, and
 // either blocks on it or mutates whatever its substring resolver found there.
+//
+// `delete` is the example because it is the one write-mutation verb this
+// surface deliberately still does not serve: it is destructive and rare, and an
+// operator drains a class resident with close. close/reopen moved onto the
+// served set with ga-axin6 (TestBdCloseReservedPrefixServedInProcess).
 func TestBdByIDRefusesAnUnservedVerbOnAClassOwnedBead(t *testing.T) {
 	cityPath, classStore := foreignProviderCity(t)
-	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "not yours to close", Type: "task"})
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "not yours to delete", Type: "task"})
 
 	var stdout, stderr bytes.Buffer
-	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", bead.ID}, &stdout, &stderr)
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"delete", bead.ID}, &stdout, &stderr)
 	if !handled {
 		t.Fatal("an unserved mutation of a class-owned bead was handed to the bd subprocess")
 	}
@@ -448,7 +453,7 @@ func TestBdByIDRefusesAnUnservedVerbOnAClassOwnedBead(t *testing.T) {
 	if got, err := classStore.Get(bead.ID); err != nil {
 		t.Fatalf("re-reading the refused bead: %v", err)
 	} else if got.Status == "closed" {
-		t.Error("the refused close reached the class binding anyway")
+		t.Error("the refused delete reached the class binding anyway")
 	}
 }
 
@@ -662,14 +667,17 @@ func TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation(t *testing.T) {
 // it rather than where it would be cheapest:
 //
 //   - An UNSERVED verb enters only when the argv addresses a reserved-prefix
-//     id. `gc bd close gc-123` and `gc bd delete gc-123` are pure work
-//     invocations — this surface would refuse them or nothing — so they pay
-//     nothing and keep the exact-ID collision guard doBd already applies.
+//     id. `gc bd delete gc-123` is a pure work invocation — this surface would
+//     refuse it or nothing — so it pays nothing and keeps the exact-ID
+//     collision guard doBd already applies.
 //   - A SERVED verb always enters, including on a work-shaped id, because the
-//     residence probe is the only thing that finds a migrated row: `gc storage
-//     migrate` preserves ids, so a work-shaped id can be class-resident, and a
-//     WRITE that skipped the probe would close the retained copy and leave the
+//     residence probe is the only thing that finds a class-resident row: a
+//     class store mints from its own workspace prefix and `gc storage migrate`
+//     preserves ids, so a work-shaped id can be class-resident, and a WRITE
+//     that skipped the probe would close the retained copy and leave the
 //     binding's row open — the molecule stall this surface exists to remove.
+//     That is why close and reopen entered the funnel with ga-axin6: they are
+//     served now, and the id shape cannot tell a resident from a work bead.
 //
 // The observer is the registry constructor, because "the routes came back nil"
 // would still pass if the funnel had resolved a plan and thrown it away.
@@ -681,18 +689,18 @@ func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *te
 		args  []string
 		enter bool
 	}{
-		"unserved work close":       {[]string{"close", "gc-123"}, false},
-		"unserved work delete":      {[]string{"delete", "gc-123"}, false},
-		"unserved work reopen":      {[]string{"reopen", "gc-123"}, false},
-		"unserved update spelling":  {[]string{"update", "gc-123", "--notes", "x"}, false},
-		"work list":                 {[]string{"list", "--status", "open"}, false},
-		"work dep tree":             {[]string{"dep", "tree", "gc-123"}, false},
-		"quoted id in a value":      {[]string{"list", "--metadata-field", "workflow_id=" + reserved}, false},
-		"class mutation":            {[]string{"update", reserved, "--status", "closed"}, true},
-		"class close":               {[]string{"close", reserved}, true},
-		"class id in an id flag":    {[]string{"list", "--parent", reserved}, true},
-		"served read on a work id":  {[]string{"show", "gc-123"}, true},
-		"served write on a work id": {[]string{"update", "gc-123", "--status", "closed"}, true},
+		"unserved work delete":       {[]string{"delete", "gc-123"}, false},
+		"unserved update spelling":   {[]string{"update", "gc-123", "--notes", "x"}, false},
+		"work list":                  {[]string{"list", "--status", "open"}, false},
+		"work dep tree":              {[]string{"dep", "tree", "gc-123"}, false},
+		"quoted id in a value":       {[]string{"list", "--metadata-field", "workflow_id=" + reserved}, false},
+		"class mutation":             {[]string{"update", reserved, "--status", "closed"}, true},
+		"class close":                {[]string{"close", reserved}, true},
+		"class id in an id flag":     {[]string{"list", "--parent", reserved}, true},
+		"served read on a work id":   {[]string{"show", "gc-123"}, true},
+		"served write on a work id":  {[]string{"update", "gc-123", "--status", "closed"}, true},
+		"served close on a work id":  {[]string{"close", "gc-123"}, true},
+		"served reopen on a work id": {[]string{"reopen", "gc-123"}, true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			resetCLIStorageRoutes(t)
@@ -717,6 +725,8 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		bdByIDRelease: true,
 		bdByIDDepList: true,
 		bdByIDUpdate:  true,
+		bdByIDClose:   true,
+		bdByIDReopen:  true,
 	}
 	for _, args := range [][]string{
 		{"show", "gcg-1"},
@@ -727,6 +737,10 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		{"dep", "list", "gcg-1", "--direction=up"},
 		{"update", "gcg-1", "--status", "closed"},
 		{"update", "gcg-1", "--set-metadata", "gc.outcome=pass", "--status=closed"},
+		{"close", "gcg-1"},
+		{"close", "gcg-1", "--json"},
+		{"reopen", "gcg-1"},
+		{"reopen", "gcg-1", "--json"},
 	} {
 		op, ok := parseBdByIDOp(args)
 		if !ok {
@@ -747,7 +761,12 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		{"dep", "tree", "gcg-1"},
 		{"dep", "list"},
 		{"dep", "list", "gcg-1", "--direction=sideways"},
-		{"close", "gcg-1"},
+		{"close"},
+		{"close", "gcg-1", "gcg-2"},
+		{"close", "gcg-1", "--reason", "done"},
+		{"close", "gcg-1", "--force"},
+		{"reopen", "gcg-1", "-r", "wrong call"},
+		{"delete", "gcg-1"},
 		{"list"},
 	} {
 		if op, ok := parseBdByIDOp(args); ok {
@@ -785,9 +804,13 @@ func TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead(t *testing.T) {
 		{"show", bead.ID, "--as-of", "2026-01-01"},
 		{"show", "--id", bead.ID},
 		{"dep", "tree", bead.ID},
-		{"close", bead.ID},
 		{"delete", bead.ID},
 		{"update", bead.ID, "--notes", "a note"},
+		{"close", bead.ID, "--reason", "done"},
+		// A root flag BEFORE the verb is bd's own spelling and gc forwards argv
+		// verbatim, so the served parsers — which key on argv[0] — do not
+		// recognize it. Ownership still does, which is the whole point of
+		// deciding the two questions separately.
 		{"--json", "close", bead.ID},
 		{"list", "--parent", bead.ID},
 	}
@@ -878,4 +901,437 @@ func reservedClassID(t *testing.T, suffix string) string {
 		t.Fatalf("no reserved id prefix is registered for the %q class", config.BeadClassGraph)
 	}
 	return prefix + "-" + suffix
+}
+
+// The tests below cover the write-orphaned class resident: a bead whose id
+// carries a WORK prefix but whose only row lives in the class binding.
+//
+// It is the population the class store MINTS rather than the one the migration
+// carried across — a class-store Create with no id mints from the binding
+// workspace's own prefix, which on a converged city is a work prefix — and it
+// is write-unreachable without a residence lane: reads reach it (the door
+// probes the class leg for every id) while writes route by prefix at a ledger
+// that never held the row.
+
+// classResidentWorkShapedBead seeds a bead with an explicit WORK-shaped id into
+// the class binding only, and proves the id carries no reserved prefix so the
+// test exercises the residence probe rather than the prefix rule.
+func classResidentWorkShapedBead(t *testing.T, classStore beads.Store, id, title string) beads.Bead {
+	t.Helper()
+	created, err := classStore.Create(beads.Bead{ID: id, Title: title, Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding %s in the class binding: %v", id, err)
+	}
+	if bdIDIsClassReserved(created.ID) {
+		t.Fatalf("the fixture id %q carries a reserved class prefix; it cannot exercise the residence probe", created.ID)
+	}
+	return created
+}
+
+// workStoreFor opens the city's own work ledger — the store the bd subprocess
+// is pointed at — so a test can assert what a routed write did NOT do there.
+func workStoreFor(t *testing.T, cityPath string) beads.Store {
+	t.Helper()
+	store, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		t.Fatalf("opening the work store at %s: %v", cityPath, err)
+	}
+	return store
+}
+
+// TestBdCloseServesClassResidentWorkPrefixedBead is the ga-axin6 regression.
+//
+// 793 open beads on the measured city carry a work prefix and reside only in
+// the coordination-class store. `gc bd close` was not a by-ID verb at all, so
+// the invocation never opened the class door: it fell through to a bd
+// subprocess pointed at the prefix store, which reported "no issue found" after
+// a managed-backend connect. There was no residency lane for close — the miss
+// was structural, not a misfire — and every such bead was a permanent
+// ready-frontier polluter with no supported drain path.
+func TestBdCloseServesClassResidentWorkPrefixedBead(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", relic.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident work-shaped id fell through to the bd subprocess, which opens the ledger that never held it: %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("closing %s exited %d: %s", relic.ID, code, stderr.String())
+	}
+	after, err := classStore.Get(relic.ID)
+	if err != nil {
+		t.Fatalf("re-reading the closed relic: %v", err)
+	}
+	if after.Status != "closed" {
+		t.Errorf("status = %q, want closed", after.Status)
+	}
+	if !strings.Contains(stderr.String(), "served in process") {
+		t.Errorf("the routed close does not say where it was served from: %q", stderr.String())
+	}
+	// The work ledger is where the passthrough sent this command. It never held
+	// the bead, and a routed close must not have minted one there either.
+	if _, err := workStoreFor(t, cityPath).Get(relic.ID); err == nil {
+		t.Errorf("the work store holds %s after a routed close; the write reached the ledger the bead was never in", relic.ID)
+	}
+}
+
+// TestBdClosePrefixStoreBeadKeepsPassthrough is T1's control, and it must fail
+// DIFFERENTLY: T1 asserts the door answered, this asserts the passthrough is
+// still reached. A residence probe that turned into an unconditional route to
+// the binding would pass T1 and fail here.
+func TestBdClosePrefixStoreBeadKeepsPassthrough(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	normal, err := workStoreFor(t, cityPath).Create(beads.Bead{Title: "an ordinary work bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	if _, err := classStore.Get(normal.ID); err == nil {
+		t.Fatalf("the class binding also holds %s; the control proves nothing", normal.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", normal.ID}, &stdout, &stderr)
+	if handled {
+		t.Fatalf("a work-resident id was answered by the door (exit %d): %s%s", code, stdout.String(), stderr.String())
+	}
+	for _, b := range allBeads(t, classStore) {
+		t.Errorf("the class binding holds %s (%q) after a passthrough close; the probe must read, never write", b.ID, b.Title)
+	}
+}
+
+// TestBdCloseReservedPrefixServedInProcess flips the reserved-prefix arm from a
+// refusal to a served close. The old behavior is pinned by
+// TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead, which loses its `close`
+// row here.
+//
+// Absence keeps its own rule: a reserved-prefix id is minted by the class store
+// and nowhere else, so a close of one that is not there reports genuine absence
+// in bd's own shape rather than falling through to a ledger that never held it.
+func TestBdCloseReservedPrefixServedInProcess(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	bead := mustCreateClassBead(t, classStore, beads.Bead{Title: "a reserved-prefix step", Type: "task"})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", bead.ID}, &stdout, &stderr)
+	if !handled || code != 0 {
+		t.Fatalf("closing the reserved-prefix bead %s = (%d, %t): %s", bead.ID, code, handled, stderr.String())
+	}
+	after, err := classStore.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", bead.ID, err)
+	}
+	if after.Status != "closed" {
+		t.Errorf("status = %q, want closed", after.Status)
+	}
+
+	missing := reservedClassID(t, "notthere")
+	stdout.Reset()
+	stderr.Reset()
+	code, handled = maybeRouteBdByID(cityPath, "", []string{"close", missing}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("an absent reserved-prefix close fell through to the bd subprocess")
+	}
+	if code == 0 {
+		t.Errorf("closing an absent bead exited 0 with stdout %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "no issue found") {
+		t.Errorf("genuine absence is not reported in bd's own shape: %q", stderr.String())
+	}
+}
+
+// TestBdCloseUnrepresentableFlagStaysOffTheDoor pins the closed-contract floor.
+//
+// storebinding.GraphStore.Close takes an id and nothing else, so bd's
+// --reason/--reason-file/--session carry text the store has nowhere to put, and
+// --claim-next/--continue/--force/--no-auto/--suggest-next name workflow this
+// arm does not run. Serving any of them by dropping it would report a command
+// as executed after silently changing what it meant — the partial-write failure
+// this whole surface exists to remove.
+func TestBdCloseUnrepresentableFlagStaysOffTheDoor(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+
+	for _, args := range [][]string{
+		{"close", "--reason", "done", relic.ID},
+		{"close", relic.ID, "--reason-file", "/tmp/why"},
+		{"close", relic.ID, "--claim-next"},
+		{"close", relic.ID, "--force"},
+		{"reopen", relic.ID, "-r", "wrong call"},
+		{"close", relic.ID, "gc-relic2"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			if op, ok := parseBdByIDOp(args); ok {
+				t.Fatalf("%v was recognized as %q; a spelling the closed contract cannot represent must not be served", args, op.Verb)
+			}
+			var stdout, stderr bytes.Buffer
+			if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
+				t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+			}
+			after, err := classStore.Get(relic.ID)
+			if err != nil {
+				t.Fatalf("re-reading %s: %v", relic.ID, err)
+			}
+			if after.Status == "closed" {
+				t.Errorf("%v wrote to the class binding anyway", args)
+			}
+		})
+	}
+}
+
+// TestBdReopenServesClassResident is T1's mirror. reopen is the undo of the
+// sweep this fix enables, and a drain that can close a resident but not reopen
+// one is a one-way door.
+func TestBdReopenServesClassResident(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "closed too eagerly")
+	if err := classStore.Close(relic.ID); err != nil {
+		t.Fatalf("pre-closing the relic: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"reopen", relic.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident reopen fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("reopening %s exited %d: %s", relic.ID, code, stderr.String())
+	}
+	after, err := classStore.Get(relic.ID)
+	if err != nil {
+		t.Fatalf("re-reading the reopened relic: %v", err)
+	}
+	if after.Status == "closed" {
+		t.Errorf("status = %q; the routed reopen did not land", after.Status)
+	}
+}
+
+// TestBdCloseAlreadyClosedIsStoreContractNoOp pins that the already-closed
+// answer is the STORE's and is not re-derived here. The routed arm calls
+// Close and renders what the store then holds; a CLI-side "is it already
+// closed" check would be a second implementation of a contract the store
+// already has, and the two would drift.
+func TestBdCloseAlreadyClosedIsStoreContractNoOp(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "closed twice")
+
+	for i := 1; i <= 2; i++ {
+		var stdout, stderr bytes.Buffer
+		code, handled := maybeRouteBdByID(cityPath, "", []string{"close", relic.ID}, &stdout, &stderr)
+		if !handled {
+			t.Fatalf("close #%d fell through to the bd subprocess: %q", i, stderr.String())
+		}
+		if code != 0 {
+			t.Fatalf("close #%d exited %d: %s", i, code, stderr.String())
+		}
+		after, err := classStore.Get(relic.ID)
+		if err != nil {
+			t.Fatalf("re-reading after close #%d: %v", i, err)
+		}
+		if after.Status != "closed" {
+			t.Fatalf("status after close #%d = %q, want closed (no status regression)", i, after.Status)
+		}
+	}
+}
+
+// TestBdCloseDualResidentWritesServingCopy pins the multi-residency rule: a
+// write lands in the first store of the surface's OWN by-id probe order whose
+// Get answers — the same order that surface's reads use.
+//
+// The door's order is [class binding, work-store-via-subprocess], so the class
+// copy is both the copy `gc bd show` serves and the copy `gc bd close` writes.
+// Read/write coherence on one surface is the property; agreeing with the API's
+// order (prefix-first) is not, and cannot be had by routing — draining the
+// duplicate copies is what retires the divergence.
+func TestBdCloseDualResidentWritesServingCopy(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	shadow, err := work.Create(beads.Bead{Title: "the retained work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	resident := classResidentWorkShapedBead(t, classStore, shadow.ID, "the class-binding copy")
+
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"close", resident.ID}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("closing the dual-resident %s = (%d, %t): %s", resident.ID, code, handled, stderr.String())
+	}
+	classCopy, err := classStore.Get(resident.ID)
+	if err != nil {
+		t.Fatalf("re-reading the class copy: %v", err)
+	}
+	if classCopy.Status != "closed" {
+		t.Errorf("the class copy's status = %q, want closed", classCopy.Status)
+	}
+	workCopy, err := work.Get(shadow.ID)
+	if err != nil {
+		t.Fatalf("re-reading the work copy: %v", err)
+	}
+	if workCopy.Status == "closed" {
+		t.Errorf("the work copy was closed too; one id, one owner, one write")
+	}
+
+	// The read the same surface serves must agree with the write it just made.
+	stdout.Reset()
+	stderr.Reset()
+	if code, handled := maybeRouteBdByID(cityPath, "", []string{"show", resident.ID, "--json"}, &stdout, &stderr); !handled || code != 0 {
+		t.Fatalf("showing the dual-resident %s = (%d, %t): %s", resident.ID, code, handled, stderr.String())
+	}
+	var shown []beads.Bead
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+		t.Fatalf("decoding the routed show %q: %v", stdout.String(), err)
+	}
+	if len(shown) != 1 || shown[0].Status != "closed" {
+		t.Errorf("the routed show reports %+v; the surface's read and its write disagree about which copy is authoritative", shown)
+	}
+}
+
+// TestBdCloseRigFlagRefusedForClassResident keeps the new verbs inside the
+// existing --rig rule: the flag names a WORK scope, a relocated class is not
+// partitioned by rig, and serving it anyway would ignore a flag the operator
+// reached for to be MORE specific.
+func TestBdCloseRigFlagRefusedForClassResident(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+
+	for _, args := range [][]string{{"close", relic.ID}, {"reopen", relic.ID}} {
+		t.Run(args[0], func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, "r1", args, &stdout, &stderr)
+			if !handled || code == 0 {
+				t.Fatalf("%v under --rig r1 = (%d, %t): %s", args, code, handled, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "--rig r1") {
+				t.Errorf("the refusal does not name the pinned rig: %q", stderr.String())
+			}
+			after, err := classStore.Get(relic.ID)
+			if err != nil {
+				t.Fatalf("re-reading %s: %v", relic.ID, err)
+			}
+			if after.Status == "closed" {
+				t.Errorf("the refused %v wrote to the class binding anyway", args)
+			}
+		})
+	}
+}
+
+// TestBdCloseSingleStoreCityByteIdentical is the compatibility row: a city that
+// authors no [storage] routes nothing here, so `gc bd close` reaches the
+// passthrough exactly as it does today — and pays nothing for the privilege.
+// The registry counter is the observer, because "handled=false" would also hold
+// if the funnel had resolved a plan and thrown it away.
+func TestBdCloseSingleStoreCityByteIdentical(t *testing.T) {
+	cityPath := oneShotCLICity(t, "")
+	refuseInfraMigrationSource(t)
+	captureCLIStorageStderr(t)
+	registries := countStorageRegistryConstructions(t)
+
+	for _, args := range [][]string{{"close", "gc-1"}, {"reopen", "gc-1"}, {"close", reservedClassID(t, "anything")}} {
+		var stdout, stderr bytes.Buffer
+		if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
+			t.Errorf("an unrelocated city answered %v here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+		}
+	}
+	if *registries != 0 {
+		t.Errorf("an unrelocated city constructed %d provider registr(ies) for a close; the bypass must short-circuit first", *registries)
+	}
+}
+
+// TestBdCloseUnopenableBindingSurfacesNotAbsence is invariant 3 on the write
+// path. A class store that cannot answer must produce the store's own error:
+// reading "the binding could not be read" as "the bead is not there" is the
+// root-loss shape, and on a WRITE it additionally means the command silently
+// moves to the ledger that cannot hold the bead.
+func TestBdCloseUnopenableBindingSurfacesNotAbsence(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+	failure := errors.New("the class binding is having a bad day")
+	failClassBindingReads(t, cityPath, failure)
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", relic.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("a failing class-store read fell through to the bd subprocess, which cannot hold the bead")
+	}
+	if code == 0 {
+		t.Errorf("a failing read exited 0 with stdout %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), failure.Error()) {
+		t.Errorf("the failure does not carry the store's cause: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "no issue found") {
+		t.Errorf("a failing read was reported as an absent bead: %q", stderr.String())
+	}
+}
+
+// getOnlyClassStore answers reads from a real store and fails every write with
+// a fixed error, which is the shape of a binding whose read leg and write leg
+// resolve against different tiers (a cache/SQLite read in front of a
+// bd-exec/Dolt write that misses the row).
+type getOnlyClassStore struct {
+	beads.Store
+	writeErr error
+}
+
+func (s getOnlyClassStore) Update(string, beads.UpdateOpts) error { return s.writeErr }
+func (s getOnlyClassStore) Close(string) error                    { return s.writeErr }
+func (s getOnlyClassStore) Reopen(string) error                   { return s.writeErr }
+
+// stubClassBindingStore replaces this city's resolved class stores with store,
+// for the whole of one test.
+func stubClassBindingStore(t *testing.T, cityPath string, store beads.Store) {
+	t.Helper()
+	routes := cliStorageRoutes(cityPath)
+	if routes == nil {
+		t.Fatal("the city resolved no routes to substitute")
+	}
+	restore := make(map[coordclass.Class]beads.Store, len(routes.stores))
+	for class, previous := range routes.stores {
+		restore[class] = previous
+		routes.stores[class] = store
+	}
+	t.Cleanup(func() {
+		for class, previous := range restore {
+			routes.stores[class] = previous
+		}
+	})
+}
+
+// TestDoorUpdateAfterFoundSurfacesStoreErrorVerbatim pins the OTHER proximate
+// cause of the reported write failure, which is not a routing defect at all.
+//
+// If a binding's Get answers from one tier while its Update resolves through
+// another that misses the row, the door engages, the store reports bd's own
+// not-found wording, and an operator reads it as the routing bug. The
+// distinguishing signal is that the failure is LOUD and store-named: exit 1
+// with the store's error verbatim, never a silent success and never a
+// fall-through to the subprocess that would re-run the command elsewhere.
+func TestDoorUpdateAfterFoundSurfacesStoreErrorVerbatim(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+	skew := fmt.Errorf("resolving issue: no issue found matching %q: %w", relic.ID, beads.ErrNotFound)
+	stubClassBindingStore(t, cityPath, getOnlyClassStore{Store: classStore, writeErr: skew})
+
+	for _, args := range [][]string{
+		{"update", relic.ID, "--status", "closed"},
+		{"close", relic.ID},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr)
+			if !handled {
+				t.Fatalf("%v fell through to the bd subprocess after the class store answered its Get", args)
+			}
+			if code == 0 {
+				t.Fatalf("%v exited 0 on a store whose write reported not-found: %q", args, stdout.String())
+			}
+			if !strings.Contains(stderr.String(), skew.Error()) {
+				t.Errorf("the failure does not carry the store's error verbatim: %q", stderr.String())
+			}
+			if !strings.Contains(stderr.String(), relic.ID) {
+				t.Errorf("the failure does not name the bead: %q", stderr.String())
+			}
+		})
+	}
 }

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -663,21 +663,23 @@ func TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation(t *testing.T) {
 // binding, and on a born-split city re-proves the invariant with a full,
 // unpaginated work-store census.
 //
-// The line this draws is servability, and it is drawn where correctness allows
-// it rather than where it would be cheapest:
+// The line this draws is SUBJECT, and it is drawn where correctness allows it
+// rather than where it would be cheapest:
 //
-//   - An UNSERVED verb enters only when the argv addresses a reserved-prefix
-//     id. `gc bd delete gc-123` is a pure work invocation — this surface would
-//     refuse it or nothing — so it pays nothing and keeps the exact-ID
-//     collision guard doBd already applies.
 //   - A SERVED verb always enters, including on a work-shaped id, because the
 //     residence probe is the only thing that finds a class-resident row: a
 //     class store mints from its own workspace prefix and `gc storage migrate`
 //     preserves ids, so a work-shaped id can be class-resident, and a WRITE
 //     that skipped the probe would close the retained copy and leave the
 //     binding's row open — the molecule stall this surface exists to remove.
-//     That is why close and reopen entered the funnel with ga-axin6: they are
-//     served now, and the id shape cannot tell a resident from a work bead.
+//     That is why close and reopen entered the funnel with ga-axin6.
+//   - An UNSERVED MUTATION enters when its positional ids can be scanned,
+//     because the same id shape says nothing about residence there either, and
+//     the answer decides whether the command is refused or forwarded to a
+//     ledger that cannot hold the bead.
+//   - A READ, a SELECTOR, and an argv whose scan is AMBIGUOUS pay nothing. The
+//     first two address no subject; the third yields no ids to probe. These are
+//     the hot per-tick invocations.
 //
 // The observer is the registry constructor, because "the routes came back nil"
 // would still pass if the funnel had resolved a plan and thrown it away.
@@ -689,11 +691,11 @@ func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *te
 		args  []string
 		enter bool
 	}{
-		"unserved work delete":       {[]string{"delete", "gc-123"}, false},
-		"unserved update spelling":   {[]string{"update", "gc-123", "--notes", "x"}, false},
 		"work list":                  {[]string{"list", "--status", "open"}, false},
 		"work dep tree":              {[]string{"dep", "tree", "gc-123"}, false},
 		"quoted id in a value":       {[]string{"list", "--metadata-field", "workflow_id=" + reserved}, false},
+		"ambiguous mutation scan":    {[]string{"delete", "gc-123", "--bogus", "v"}, false},
+		"mutation with no id":        {[]string{"delete", "--from-file", "ids.txt"}, false},
 		"class mutation":             {[]string{"update", reserved, "--status", "closed"}, true},
 		"class close":                {[]string{"close", reserved}, true},
 		"class id in an id flag":     {[]string{"list", "--parent", reserved}, true},
@@ -701,6 +703,8 @@ func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *te
 		"served write on a work id":  {[]string{"update", "gc-123", "--status", "closed"}, true},
 		"served close on a work id":  {[]string{"close", "gc-123"}, true},
 		"served reopen on a work id": {[]string{"reopen", "gc-123"}, true},
+		"unserved work delete":       {[]string{"delete", "gc-123"}, true},
+		"unserved update spelling":   {[]string{"update", "gc-123", "--notes", "x"}, true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			resetCLIStorageRoutes(t)
@@ -1049,32 +1053,51 @@ func TestBdCloseReservedPrefixServedInProcess(t *testing.T) {
 // arm does not run. Serving any of them by dropping it would report a command
 // as executed after silently changing what it meant — the partial-write failure
 // this whole surface exists to remove.
+//
+// Unserved is not forwarded. Residency proves ownership for these too, so each
+// one is refused with the offending spelling named rather than handed to a
+// ledger that would answer bd's misleading not-found about it.
 func TestBdCloseUnrepresentableFlagStaysOffTheDoor(t *testing.T) {
 	cityPath, classStore := foreignProviderCity(t)
 	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
 
-	for _, args := range [][]string{
-		{"close", "--reason", "done", relic.ID},
-		{"close", relic.ID, "--reason-file", "/tmp/why"},
-		{"close", relic.ID, "--claim-next"},
-		{"close", relic.ID, "--force"},
-		{"reopen", relic.ID, "-r", "wrong call"},
-		{"close", relic.ID, "gc-relic2"},
+	for _, tc := range []struct {
+		args []string
+		flag string
+	}{
+		{[]string{"close", "--reason", "done", relic.ID}, "--reason"},
+		{[]string{"close", relic.ID, "--reason-file", "/tmp/why"}, "--reason-file"},
+		{[]string{"close", relic.ID, "--claim-next"}, "--claim-next"},
+		{[]string{"close", relic.ID, "--force"}, "--force"},
+		{[]string{"reopen", relic.ID, "-r", "wrong call"}, "-r"},
+		// A batch names no flag: the shape is what kept it off the surface, and
+		// naming an id there would read as a claim about that id.
+		{[]string{"close", relic.ID, "gc-relic2"}, ""},
 	} {
-		t.Run(strings.Join(args, " "), func(t *testing.T) {
-			if op, ok := parseBdByIDOp(args); ok {
-				t.Fatalf("%v was recognized as %q; a spelling the closed contract cannot represent must not be served", args, op.Verb)
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			if op, ok := parseBdByIDOp(tc.args); ok {
+				t.Fatalf("%v was recognized as %q; a spelling the closed contract cannot represent must not be served", tc.args, op.Verb)
 			}
 			var stdout, stderr bytes.Buffer
-			if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
-				t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+			code, handled := maybeRouteBdByID(cityPath, "", tc.args, &stdout, &stderr)
+			if !handled {
+				t.Fatalf("%v fell through to the bd subprocess, which cannot hold %s", tc.args, relic.ID)
+			}
+			if code == 0 {
+				t.Errorf("%v exited 0: %s", tc.args, stdout.String())
+			}
+			if !strings.Contains(stderr.String(), relic.ID) {
+				t.Errorf("the refusal does not name the resident bead: %q", stderr.String())
+			}
+			if tc.flag != "" && !strings.Contains(stderr.String(), tc.flag) {
+				t.Errorf("the refusal does not name %s: %q", tc.flag, stderr.String())
 			}
 			after, err := classStore.Get(relic.ID)
 			if err != nil {
 				t.Fatalf("re-reading %s: %v", relic.ID, err)
 			}
 			if after.Status == "closed" {
-				t.Errorf("%v wrote to the class binding anyway", args)
+				t.Errorf("%v wrote to the class binding anyway", tc.args)
 			}
 		})
 	}
@@ -1262,6 +1285,142 @@ func TestBdCloseUnopenableBindingSurfacesNotAbsence(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "no issue found") {
 		t.Errorf("a failing read was reported as an absent bead: %q", stderr.String())
+	}
+}
+
+// TestBdUpdateUnservedSpellingOnResidentRefusesNamingFlag is the residency half
+// of "ownership is decided before servability".
+//
+// Ownership used to be provable only from a RESERVED prefix in the argv, so a
+// work-prefixed class resident got no protection at all: its unserved mutation
+// fell through to a ledger that cannot hold it and died with bd's not-found —
+// the same wrong-store error, the same wall-clock cost, and a diagnosis that
+// sends an operator to look for a bead that is not missing. Residency proves
+// ownership just as well, and the refusal names the flag.
+func TestBdUpdateUnservedSpellingOnResidentRefusesNamingFlag(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+	normal, err := workStoreFor(t, cityPath).Create(beads.Bead{Title: "an ordinary work bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+
+	// Every unserved mutation verb, not just update. `delete` is the one this
+	// surface deliberately never serves, and it carries no flag to name — the
+	// VERB is what cannot be represented — so it is the row that proves the
+	// refusal comes from residency rather than from flag rejection.
+	for _, tc := range []struct {
+		args []string
+		flag string
+	}{
+		{[]string{"update", relic.ID, "--notes", "x"}, bdByIDUpdateUnrepresentable},
+		{[]string{"delete", relic.ID}, ""},
+	} {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, "", tc.args, &stdout, &stderr)
+			if !handled {
+				t.Fatalf("an unserved mutation of a class resident fell through to the bd subprocess: %q", stderr.String())
+			}
+			if code == 0 {
+				t.Errorf("the refusal exited 0: %q", stdout.String())
+			}
+			for _, want := range []string{relic.ID, "class binding"} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Errorf("the refusal does not name %q: %q", want, stderr.String())
+				}
+			}
+			if tc.flag != "" && !strings.Contains(stderr.String(), tc.flag) {
+				t.Errorf("the refusal does not name %s: %q", tc.flag, stderr.String())
+			}
+			if strings.Contains(stderr.String(), "no issue found") {
+				t.Errorf("the refusal wears bd's absence shape: %q", stderr.String())
+			}
+			after, err := classStore.Get(relic.ID)
+			if err != nil {
+				t.Fatalf("re-reading %s: %v", relic.ID, err)
+			}
+			if len(after.Metadata) != 0 || after.Status == "closed" {
+				t.Errorf("the refused mutation wrote anyway: status=%q metadata=%v", after.Status, after.Metadata)
+			}
+		})
+
+		// The control: the same spelling against a bead the class binding does
+		// NOT hold keeps its existing path, so the residency check cannot have
+		// become a blanket refusal of unserved mutations.
+		control := append([]string{}, tc.args...)
+		for i, arg := range control {
+			if arg == relic.ID {
+				control[i] = normal.ID
+			}
+		}
+		t.Run("control "+strings.Join(control, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code, handled := maybeRouteBdByID(cityPath, "", control, &stdout, &stderr); handled {
+				t.Errorf("an unserved mutation of a work-resident bead was refused here (exit %d): %s%s", code, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+// TestBdMutationAmbiguousScanNeverEntersFunnel keeps the widened cost gate off
+// the one argv shape it cannot read.
+//
+// An unrecognized flag may or may not consume the next token, so
+// bdMutationWriteIDs reports ambiguity rather than a guess — and an ambiguous
+// scan yields no ids to probe residence for. Entering the funnel to probe
+// nothing would be pure cost, and doBd's own fail-closed guard is what answers
+// that argv.
+func TestBdMutationAmbiguousScanNeverEntersFunnel(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+
+	args := []string{"close", relic.ID, "--bogus", "value"}
+	if _, _, ambiguous := bdMutationWriteIDs(args); !ambiguous {
+		t.Fatalf("bdMutationWriteIDs(%v) is not ambiguous; this fixture cannot exercise the gate", args)
+	}
+
+	resetCLIStorageRoutes(t)
+	registries := countStorageRegistryConstructions(t)
+	var stdout, stderr bytes.Buffer
+	if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
+		t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+	}
+	if *registries != 0 {
+		t.Errorf("an ambiguous mutation scan constructed %d provider registr(ies); it has no ids to probe", *registries)
+	}
+}
+
+// TestBdSelectorVerbsNeverEnterFunnel is the other half of the widened gate,
+// and the line it draws: a MUTATION addressing ids enters, a read or a selector
+// never does.
+//
+// A selector quotes ids rather than addressing them — `--metadata-field
+// workflow_id=<id>` selects rows by a field they carry — so there is no subject
+// whose residence could decide anything, and these are the hot per-tick
+// invocations that must keep paying nothing.
+func TestBdSelectorVerbsNeverEnterFunnel(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
+
+	for _, args := range [][]string{
+		{"list", "--metadata-field", "workflow_id=" + relic.ID},
+		{"list", "--label", relic.ID},
+		{"list", "--status", "open"},
+		{"search", relic.ID},
+		{"dep", "tree", relic.ID},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			resetCLIStorageRoutes(t)
+			registries := countStorageRegistryConstructions(t)
+			var stdout, stderr bytes.Buffer
+			if code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr); handled {
+				t.Errorf("%v was answered here (exit %d): %s%s", args, code, stdout.String(), stderr.String())
+			}
+			if *registries != 0 {
+				t.Errorf("%v constructed %d provider registr(ies); a read or selector must pay nothing", args, *registries)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/order_dispatch_bench_test.go
+++ b/cmd/gc/order_dispatch_bench_test.go
@@ -90,7 +90,12 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PreFix_ReparsePerTick", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		// nil routes is the identity routing of a single-store city, which is
+		// what this fixture writes — the benchmark counts config reparses and
+		// takes no position on storage relocation. The four PRODUCTION wiring
+		// sites must pass the resolved routes; that is asserted separately by
+		// TestOrderDispatchConstructorDeliversRoutesToTheWispBirth.
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		// Reproduce the pre-fix storeFn verbatim (order_dispatch.go:431-433
 		// before the ga-237xpr fix): ignore the dispatcher's cached cfg and
 		// go through the nil-cfg path, which reloads city.toml + every pack
@@ -110,7 +115,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PostFix_CachedConfig", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		now := time.Now()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1915,7 +1915,10 @@ func TestOrderDispatchDoesNotReparseConfigPerTick(t *testing.T) {
 		Interval: "1h",
 		Exec:     "true",
 	}}
-	ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+	// nil routes is the identity routing of a single-store city, which is what
+	// this fixture writes; the test counts config reparses and takes no
+	// position on storage relocation.
+	ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 
 	before := loadCityConfigCalls.Load()
 	now := time.Now()

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -23,6 +23,45 @@ import (
 // The gate ships warn-only by default — violations are logged but the close
 // proceeds — so existing open beads migrate without breakage. Set
 // GC_WORK_RECORD_ENFORCE to a truthy value to make violations block the close.
+//
+// # What the gate does NOT see: a close the by-ID class door served
+//
+// doBd runs the by-ID class door (cmd_bd_by_id.go maybeRouteBdByID) BEFORE this
+// gate, and a routed close returns from doBd without reaching it. So on a city
+// that relocates a coordination class, `gc bd close <id>` and `gc bd update
+// <id> --status closed` are gated only when they fall through to the bd
+// subprocess. This is a coverage boundary, and it is recorded here rather than
+// closed because closing it would mean re-deriving the gate against a store
+// this file does not resolve.
+//
+// It is narrower than it sounds, in three steps:
+//
+//   - This gate reads the PREFIX store (the caller's resolved work scope). A
+//     bead resident only in the class binding was never visible to it: the Get
+//     missed and the loop skipped the id. Routing those closes through the door
+//     removed nothing, because there was nothing to remove.
+//   - The canonical worker spelling was already outside. graph-worker.md renders
+//     `gc bd update <id> --set-metadata gc.outcome=pass --status closed`, and a
+//     served update on a class-owned bead has been answered by the door since
+//     that verb landed — well before close joined it.
+//   - What the door's close DOES take from the gate is the DUAL-RESIDENT case,
+//     and that population is real rather than hypothetical. `gc storage migrate`
+//     copies every non-work bead with its id preserved and keeps the source
+//     (readInfraSnapshot / infra_class_migrate.go), and coordclass.Classify
+//     routes ANY bead carrying gc.root_bead_id to ClassGraph
+//     (isWorkflowMetadata) — including a plain task-typed molecule work step
+//     with no gc.kind, which is exactly isWorkRecordGatedBead's population. On a
+//     migrated city those steps exist in both stores, and before the door served
+//     close, this gate evaluated them against the work store's RETAINED copy —
+//     the one frozen at migration time, not the one the close now writes. So the
+//     gate's pre-door verdict on a dual resident was already a verdict about a
+//     stale row.
+//
+// The drain path for that population is the sweep, not this gate: the HTTP
+// by-id lane probes prefix-first (internal/api appendClassResidencyFallback),
+// so it still reaches the retained work copy, and raw bd against the work scope
+// still reaches it too. The CLI door now wins by residency and writes the class
+// copy. Both copies have to be drained either way, which is the sweep's job.
 
 // workRecordEnforceEnvVar gates whether work-record violations block the close
 // (enforce) or are logged only (warn-only, the default).

--- a/internal/api/class_store_test.go
+++ b/internal/api/class_store_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -242,27 +244,22 @@ func TestBeadGetSurvivesAShadowingRigOutage(t *testing.T) {
 	}
 }
 
-// TestBeadStoresForIDDoesNotCoverMigratedLegacyIDs pins the limitation the
-// resolver's doc now states instead of the coverage the doc used to claim.
+// TestClassArmStillDoesNotCoverMigratedLegacyIDs pins the limitation of the
+// CLASS ARM specifically, which the residency fallback does not remove.
 //
-// `gc storage migrate` copies the work store's infrastructure slice with ids
-// PRESERVED and never deletes the source (infra_class_migrate.go). So a
-// relocated bead can carry an HQ-prefixed id — which is OUTSIDE the class
-// namespace, so the class arm never fires for it, and the configured-prefix
-// resolver answers it from the work store's retained copy. The relocated store
-// is not even a candidate.
-//
-// cmd/gc/cmd_bd_by_id.go covers this case the other way, by probing residence
-// for every id rather than routing on the prefix. This path has no equivalent;
-// the assertion exists so the gap cannot be forgotten or silently closed.
-func TestBeadStoresForIDDoesNotCoverMigratedLegacyIDs(t *testing.T) {
-	st, graph, city, _ := relocatedGraphRouteState(t)
+// storeref.ClassCandidates gates on the class NAMESPACE before it builds a
+// list, so a bead `gc storage migrate` relocated with its HQ-prefixed id kept
+// gets nil back from it — that is a property of the namespace rule and stays
+// true. What changed is that the resolver no longer STOPS there: the fallback
+// appends the class binding behind the prefix-routed candidates, which is what
+// TestBeadStoresForIDAppendsClassResidencyFallback covers. Keeping this
+// assertion separate keeps the two claims from being confused for each other.
+func TestClassArmStillDoesNotCoverMigratedLegacyIDs(t *testing.T) {
+	st, graph, _, _ := relocatedGraphRouteState(t)
 	st.cfg.Workspace.Prefix = "mc"
 
-	s := New(st)
-	got := s.beadStoresForID("mc-123")
-	if len(got) != 1 || got[0] != city {
-		t.Fatalf("beadStoresForID(mc-123) = %v (len %d), want only the city work store %p — a legacy-prefixed id is outside the class namespace; graph is %p", got, len(got), city, graph)
+	if got := New(st).classStoresForID("mc-123", nil); got != nil {
+		t.Fatalf("classStoresForID(mc-123) = %v, want nil — a legacy-prefixed id is outside the class namespace; graph is %p", got, graph)
 	}
 }
 
@@ -327,6 +324,349 @@ func TestBeadStoresForIDShadowingRigPrefixStillWinsOnDefaultCity(t *testing.T) {
 	if len(got) != 1 || got[0] != rig {
 		t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want only the shadowing rig store %p", prefix, got, len(got), rig)
 	}
+}
+
+// The tests below cover the residency fallback: the leg that reaches a bead
+// RESIDENT in the class binding under a work-shaped id.
+//
+// Two populations wear that shape. `gc storage migrate` preserves ids, so every
+// row it relocated kept its HQ/rig-era prefix; and a class store MINTS from its
+// own binding workspace's prefix, so a synthetic created there with no id — an
+// input convoy, a patrol root, a wisp — is born work-shaped and class-resident.
+// Both are outside the class namespace, so the class arm never fires for them,
+// and before the fallback the prefix resolver answered them from the work store
+// alone: a 404 on every read and every write of a bead the city really holds.
+
+// classResidentWorkShapedID seeds a bead into the graph store under an id in
+// the WORK prefix's namespace, and proves no other candidate store holds it.
+func classResidentWorkShapedID(t *testing.T, graph beads.Store, id string) string {
+	t.Helper()
+	return seedWithPinnedID(t, graph, id, "class-resident under a work prefix")
+}
+
+// seedWithPinnedID creates a bead under an exact id, which is what makes these
+// fixtures able to model an id the class binding holds and a prefix store
+// routes elsewhere.
+func seedWithPinnedID(t *testing.T, store beads.Store, id, title string) string {
+	t.Helper()
+	mem, ok := store.(*beads.MemStore)
+	if !ok {
+		t.Fatalf("fixture store is %T, want *beads.MemStore so the test can pin the seeded id", store)
+	}
+	mem.HonorExplicitIDs = true
+	created, err := mem.Create(beads.Bead{ID: id, Title: title})
+	if err != nil {
+		t.Fatalf("seeding %s: %v", id, err)
+	}
+	if created.ID != id {
+		t.Fatalf("the fixture store minted %q instead of the pinned %q", created.ID, id)
+	}
+	return id
+}
+
+// TestBeadStoresForIDAppendsClassResidencyFallback is the resolver-level
+// contract, arm by arm. It replaces TestBeadStoresForIDDoesNotCoverMigratedLegacyIDs,
+// which pinned this coverage gap so it could not be forgotten; this is the
+// close-out.
+//
+// The fallback is APPENDED, never inserted: every store the resolver already
+// returned keeps its position and its precedence, so no answer this path
+// already served can change. What changes is only what happens after all of
+// them have missed.
+func TestBeadStoresForIDAppendsClassResidencyFallback(t *testing.T) {
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+
+	t.Run("configured prefix arm", func(t *testing.T) {
+		st, graph, city, _ := relocatedGraphRouteState(t)
+		st.cfg.Workspace.Prefix = "mc"
+
+		got := New(st).beadStoresForID("mc-123")
+		if len(got) != 2 || got[0] != city || got[1] != graph {
+			t.Fatalf("beadStoresForID(mc-123) = %v (len %d), want [city %p, graph %p] — the prefix store keeps the lead, the class binding is the fallback", got, len(got), city, graph)
+		}
+	})
+
+	t.Run("routes.jsonl arm", func(t *testing.T) {
+		st, graph, _, rig := relocatedGraphRouteState(t)
+		st.cfg.Workspace.Prefix = "mc"
+		writeRoutesJSONL(t, st.cityPath, `{"prefix":"rt","path":"rigs/myrig"}`)
+
+		got := New(st).beadStoresForID("rt-1")
+		if len(got) != 2 || got[0] != rig || got[1] != graph {
+			t.Fatalf("beadStoresForID(rt-1) = %v (len %d), want [rig %p, graph %p]", got, len(got), rig, graph)
+		}
+	})
+
+	t.Run("legacy scan arm", func(t *testing.T) {
+		st, graph, city, rig := relocatedGraphRouteState(t)
+		st.cfg.Workspace.Prefix = "mc"
+
+		got := New(st).beadStoresForID("zz-1")
+		if len(got) != 3 || got[0] != city || got[1] != rig || got[2] != graph {
+			t.Fatalf("beadStoresForID(zz-1) = %v (len %d), want [city %p, rig %p, graph %p]", got, len(got), city, rig, graph)
+		}
+	})
+
+	t.Run("class arm is untouched", func(t *testing.T) {
+		st, graph, city, _ := relocatedGraphRouteState(t)
+
+		got := New(st).beadStoresForID(prefix + "-1")
+		if len(got) != 2 || got[0] != graph || got[1] != city {
+			t.Fatalf("beadStoresForID(%s-1) = %v (len %d), want the class arm's own [graph %p, city %p] with no second graph leg", prefix, got, len(got), graph, city)
+		}
+	})
+
+	// A rig whose store IS the relocated class store. State hands out shared
+	// store INSTANCES in the file provider — sortedRigNames dedupes by store
+	// identity for exactly that reason — so an arm can already contain the store
+	// the fallback would add. Appending it a second time would probe the same
+	// store twice, and on the fail-fast by-id path a duplicated failing leg is a
+	// duplicated 500 attributed to a store already reported.
+	t.Run("class store already among the candidates", func(t *testing.T) {
+		st, graph, city, _ := relocatedGraphRouteState(t)
+		st.cfg.Workspace.Prefix = "mc"
+		st.cfg.Rigs[0].Prefix = "rw"
+		st.stores["myrig"] = graph
+
+		s := New(st)
+		if got := s.beadStoresForID("rw-1"); len(got) != 1 || got[0] != graph {
+			t.Fatalf("beadStoresForID(rw-1) = %v (len %d), want only the graph store %p once", got, len(got), graph)
+		}
+		if got := s.beadStoresForID("zz-1"); len(got) != 2 || got[0] != city || got[1] != graph {
+			t.Fatalf("beadStoresForID(zz-1) = %v (len %d), want [city %p, graph %p] with the graph leg listed once", got, len(got), city, graph)
+		}
+	})
+
+	t.Run("single-store city is identity", func(t *testing.T) {
+		st := newFakeState(t)
+		city := beads.NewMemStore()
+		rig := beads.NewMemStore()
+		st.cityBeadStore = city
+		st.stores = map[string]beads.Store{"myrig": rig}
+		st.cfg.Workspace.Prefix = "mc"
+		st.cfg.Rigs = []config.Rig{{Name: "myrig", Path: filepath.Join(st.cityPath, "rigs", "myrig"), Prefix: "rw"}}
+
+		s := New(st)
+		if got := s.beadStoresForID("mc-123"); len(got) != 1 || got[0] != city {
+			t.Fatalf("beadStoresForID(mc-123) = %v (len %d), want only the city store %p", got, len(got), city)
+		}
+		if got := s.beadStoresForID("rw-1"); len(got) != 1 || got[0] != rig {
+			t.Fatalf("beadStoresForID(rw-1) = %v (len %d), want only the rig store %p", got, len(got), rig)
+		}
+		if got := s.beadStoresForID("zz-1"); len(got) != 2 || got[0] != city || got[1] != rig {
+			t.Fatalf("beadStoresForID(zz-1) = %v (len %d), want the unchanged legacy scan [city %p, rig %p]", got, len(got), city, rig)
+		}
+	})
+}
+
+// TestBeadGetServesClassResident is the read half through the real handler:
+// GET /v0/bead/{id} answered 404 for a bead the city holds, because the
+// prefix-routed work store was the only candidate.
+func TestBeadGetServesClassResident(t *testing.T) {
+	st, graph, city, _ := relocatedGraphRouteState(t)
+	st.cfg.Workspace.Prefix = "mc"
+	id := classResidentWorkShapedID(t, graph, "mc-relic1")
+	if _, err := city.Get(id); err == nil {
+		t.Fatalf("the work store also holds %s; the fixture proves nothing", id)
+	}
+
+	out, err := New(st).humaHandleBeadGet(context.Background(), &BeadGetInput{ID: id})
+	if err != nil {
+		t.Fatalf("GET bead %s: %v — a class-resident work-shaped id is unreachable by id", id, err)
+	}
+	if out.Body.ID != id {
+		t.Fatalf("resolved bead id = %q, want %q", out.Body.ID, id)
+	}
+}
+
+// TestBeadCloseLandsInClassStoreForWorkPrefixedResident is the write half,
+// across every mutating by-id handler.
+//
+// No handler changes: each one probes beadStoresForID in order, stops at the
+// first store whose Get answers, and then binds its write to THAT store —
+// "once Get succeeded in this store, treat Update-ErrNotFound as a
+// concurrent-delete race rather than try the next store". Read/write coherence
+// on this surface is therefore structural, and adding a read leg adds the write
+// leg with it.
+func TestBeadCloseLandsInClassStoreForWorkPrefixedResident(t *testing.T) {
+	const renamed = "renamed by the api"
+	for name, tc := range map[string]struct {
+		setup  func(*testing.T, beads.Store, string)
+		mutate func(*Server, string) error
+		verify func(*testing.T, beads.Bead)
+	}{
+		"close": {
+			mutate: func(s *Server, id string) error {
+				_, err := s.humaHandleBeadClose(context.Background(), &BeadCloseInput{ID: id})
+				return err
+			},
+			verify: func(t *testing.T, b beads.Bead) {
+				if b.Status != "closed" {
+					t.Errorf("status = %q, want closed", b.Status)
+				}
+			},
+		},
+		"delete": {
+			mutate: func(s *Server, id string) error {
+				_, err := s.humaHandleBeadDelete(context.Background(), &BeadDeleteInput{ID: id})
+				return err
+			},
+			verify: func(t *testing.T, b beads.Bead) {
+				if b.Status != "closed" {
+					t.Errorf("status = %q, want closed (DELETE is a soft close on this surface)", b.Status)
+				}
+			},
+		},
+		"update": {
+			mutate: func(s *Server, id string) error {
+				title := renamed
+				_, err := s.humaHandleBeadUpdate(context.Background(), &BeadUpdateInput{ID: id, Body: beadUpdateBody{Title: &title}})
+				return err
+			},
+			verify: func(t *testing.T, b beads.Bead) {
+				if b.Title != renamed {
+					t.Errorf("title = %q, want %q", b.Title, renamed)
+				}
+			},
+		},
+		"assign": {
+			setup: func(t *testing.T, graph beads.Store, id string) {
+				held := "previous-holder"
+				if err := graph.Update(id, beads.UpdateOpts{Assignee: &held}); err != nil {
+					t.Fatalf("seeding an assignee on %s: %v", id, err)
+				}
+			},
+			mutate: func(s *Server, id string) error {
+				in := &BeadAssignInput{ID: id}
+				in.Body.Assignee = ""
+				_, err := s.humaHandleBeadAssign(context.Background(), in)
+				return err
+			},
+			verify: func(t *testing.T, b beads.Bead) {
+				if b.Assignee != "" {
+					t.Errorf("assignee = %q, want the routed assign to have cleared it", b.Assignee)
+				}
+			},
+		},
+		"reopen": {
+			setup: func(t *testing.T, graph beads.Store, id string) {
+				if err := graph.Close(id); err != nil {
+					t.Fatalf("pre-closing %s: %v", id, err)
+				}
+			},
+			mutate: func(s *Server, id string) error {
+				_, err := s.humaHandleBeadReopen(context.Background(), &BeadReopenInput{ID: id})
+				return err
+			},
+			verify: func(t *testing.T, b beads.Bead) {
+				if b.Status == "closed" {
+					t.Errorf("status = %q, want reopened", b.Status)
+				}
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			st, graph, city, _ := relocatedGraphRouteState(t)
+			st.cfg.Workspace.Prefix = "mc"
+			id := classResidentWorkShapedID(t, graph, "mc-relic1")
+			if tc.setup != nil {
+				tc.setup(t, graph, id)
+			}
+
+			if err := tc.mutate(New(st), id); err != nil {
+				t.Fatalf("%s %s: %v — the write 404'd on a bead resident in the class binding", name, id, err)
+			}
+			if _, err := city.Get(id); err == nil {
+				t.Errorf("the work store holds %s after the routed %s; the write must land in the store whose Get answered", id, name)
+			}
+			after, err := graph.Get(id)
+			if err != nil {
+				t.Fatalf("re-reading %s from the class binding: %v", id, err)
+			}
+			tc.verify(t, after)
+		})
+	}
+}
+
+// TestBeadWriteDualResidentPrefersPrefixStore is the ambiguity pin and the
+// control in one: for an id BOTH stores hold, the API keeps answering — and now
+// writing — from the prefix store, byte-identically to pre-fix behavior.
+//
+// The migration never deletes its source, so a relocated bead can be resident
+// in both. Appending the class leg BEHIND is what keeps that population's
+// answers unchanged; a class-first order here would silently repoint every
+// dual-resident id at the other copy.
+func TestBeadWriteDualResidentPrefersPrefixStore(t *testing.T) {
+	st, graph, city, _ := relocatedGraphRouteState(t)
+	st.cfg.Workspace.Prefix = "mc"
+	id := classResidentWorkShapedID(t, graph, "mc-dual1")
+	seedWithPinnedID(t, city, id, "the retained work copy")
+
+	s := New(st)
+	out, err := s.humaHandleBeadGet(context.Background(), &BeadGetInput{ID: id})
+	if err != nil {
+		t.Fatalf("GET bead %s: %v", id, err)
+	}
+	if out.Body.Title != "the retained work copy" {
+		t.Fatalf("GET served %q, want the prefix store's copy — the added leg must not re-answer an id the resolver already resolved", out.Body.Title)
+	}
+	if _, err := s.humaHandleBeadClose(context.Background(), &BeadCloseInput{ID: id}); err != nil {
+		t.Fatalf("close %s: %v", id, err)
+	}
+	workCopy, err := city.Get(id)
+	if err != nil {
+		t.Fatalf("re-reading the work copy: %v", err)
+	}
+	if workCopy.Status != "closed" {
+		t.Errorf("the work copy's status = %q, want closed — the write must follow the read", workCopy.Status)
+	}
+	classCopy, err := graph.Get(id)
+	if err != nil {
+		t.Fatalf("re-reading the class copy: %v", err)
+	}
+	if classCopy.Status == "closed" {
+		t.Errorf("the class copy was closed too; one id, one owner, one write")
+	}
+}
+
+// TestBeadMissThenUnreachableClassStoreIs500Not404 keeps the fail-fast doctrine
+// on the added leg: an unreachable store must not be reported as a missing
+// bead. The added leg slightly STRENGTHENS the rule — a prefix miss followed by
+// an unreachable class store used to be a confident 404, and is now a 500 — and
+// the control proves the change is about reachability, not about turning every
+// miss into an error.
+func TestBeadMissThenUnreachableClassStoreIs500Not404(t *testing.T) {
+	t.Run("unreachable class store", func(t *testing.T) {
+		st, graph, _, _ := relocatedGraphRouteState(t)
+		st.cfg.Workspace.Prefix = "mc"
+		st.graphBeadStore = getFailStore{Store: graph, err: errors.New("infra binding unreachable")}
+
+		_, err := New(st).humaHandleBeadGet(context.Background(), &BeadGetInput{ID: "mc-relic1"})
+		var statusErr huma.StatusError
+		if !errors.As(err, &statusErr) {
+			t.Fatalf("GET returned %T %v, want a Huma status error", err, err)
+		}
+		if statusErr.GetStatus() != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500 — an unreachable store reported as a missing bead is the root-loss shape", statusErr.GetStatus())
+		}
+	})
+
+	t.Run("clean miss stays 404", func(t *testing.T) {
+		st, _, _, _ := relocatedGraphRouteState(t)
+		st.cfg.Workspace.Prefix = "mc"
+
+		_, err := New(st).humaHandleBeadGet(context.Background(), &BeadGetInput{ID: "mc-relic1"})
+		var statusErr huma.StatusError
+		if !errors.As(err, &statusErr) {
+			t.Fatalf("GET returned %T %v, want a Huma status error", err, err)
+		}
+		if statusErr.GetStatus() != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404 — a bead no store holds is absent, not an outage", statusErr.GetStatus())
+		}
+	})
 }
 
 // TestBeadGetResolvesARelocatedGraphID is the evidence behind the one command

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -185,6 +185,24 @@ func (s *Server) findStore(rig string) beads.Store {
 // returned, which is what keeps that fail-fast rule from costing availability:
 // an added store can only be probed after the previously-answering ones have
 // already missed.
+//
+// # The residency fallback
+//
+// Every arm that resolves by PREFIX ends with the relocated class store
+// appended behind whatever it resolved (appendClassResidencyFallback). Prefix
+// routing answers "which namespace is this id in", and on a relocated city that
+// is not the same question as "which store holds this bead": `gc storage
+// migrate` preserves ids, and a class store MINTS from its own binding
+// workspace's prefix, so a bead can RESIDE in the class binding under a
+// work-shaped id. Those ids are outside the class namespace, so the class arm
+// never fires for them, and without the fallback the prefix store — which never
+// held the row, or holds only the migration's retained copy — was the whole
+// candidate set.
+//
+// It is appended, never inserted, for the reason above: the head of every list
+// is byte-identical to what this resolver returned before, so no answer it
+// already served can change, and the fallback is reached only where the
+// resolver had already given up.
 func (s *Server) beadStoresForID(id string) []beads.Store {
 	id = strings.TrimSpace(id)
 	// Built once and shared by both prefix resolvers below: they answer
@@ -206,11 +224,11 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 	}
 
 	if store := resolveStoreByConfiguredIDPrefix(id, configured); store != nil {
-		return []beads.Store{store}
+		return s.appendClassResidencyFallback([]beads.Store{store})
 	}
 	if prefix := beadPrefix(id); prefix != "" {
 		if store := s.resolveStoreByPrefix(prefix); store != nil {
-			return []beads.Store{store}
+			return s.appendClassResidencyFallback([]beads.Store{store})
 		}
 	}
 
@@ -223,7 +241,47 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 	for _, rigName := range rigNames {
 		candidates = append(candidates, stores[rigName])
 	}
-	return candidates
+	return s.appendClassResidencyFallback(candidates)
+}
+
+// appendClassResidencyFallback appends the relocated class store behind the
+// prefix-routed candidates, so a bead that RESIDES in the class binding under a
+// work-shaped id — a migration-preserved id, or a synthetic the class store
+// minted from its own workspace prefix — stays reachable by id, reads and
+// writes alike, after every prefix-routed store has missed.
+//
+// This is the residence probe internal/api did not have. cmd/gc's by-ID door
+// has always asked the class store about EVERY id rather than only about
+// prefixed ones (cmd/gc/cmd_bd_by_id.go, bdByIDClassDoor.resolve), which is why
+// the CLI could read those beads while this path 404'd them; the two surfaces
+// now answer the same question, each in its own probe order.
+//
+// Appending BEHIND is what keeps every currently-served answer identical — the
+// added-legs-sit-behind doctrine this resolver documents about itself — and it
+// is also what bounds the cost: the extra Get happens only on a by-id operation
+// that was about to 404 anyway.
+//
+// Relocation is decided by STORE IDENTITY, never by a marker file or a
+// migration flag, which is the same rule classStoresForID and
+// storeref.ClassCandidates apply. On a city that relocates nothing this
+// function is the identity and every list stays byte-identical.
+//
+// GRAPH ONLY, exactly as classStoresForID scopes itself: the served split shape
+// is storageSplitWhole — all five infrastructure classes name one binding — so
+// the graph store IS the binding. If per-class fan-out is ever served, this has
+// to resolve per class, alongside the same change in cmd/gc's single class door
+// (openBdByIDClassFrontDoor's "one door for every reserved prefix" note).
+func (s *Server) appendClassResidencyFallback(candidates []beads.Store) []beads.Store {
+	graph := s.state.GraphBeadStore().Store
+	if graph == nil || graph == s.state.CityBeadStore() {
+		return candidates
+	}
+	for _, candidate := range candidates {
+		if candidate == graph {
+			return candidates
+		}
+	}
+	return append(candidates, graph)
 }
 
 // classStoresForID returns the by-id candidate probe list for a relocated
@@ -237,14 +295,17 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 // a work store that legitimately holds an id inside the class namespace stays
 // reachable behind the class store.
 //
-// NOT covered here: a bead `gc storage migrate` relocated with its id PRESERVED
-// (infra_class_migrate.go). That id keeps its HQ/rig-era prefix, so it is
-// outside the class namespace, the arm never fires, and the configured-prefix
-// resolver below answers it from the work store — which still holds the
-// migration's retained source copy, frozen at migration time. Covering it needs
-// a residence probe that asks the class store about every id; that is what
-// cmd/gc/cmd_bd_by_id.go's bdByIDClassDoor.resolve does, and this path has no
-// equivalent yet.
+// NOT covered by THIS arm: a bead that resides in the class binding under an id
+// outside the class namespace — one `gc storage migrate` relocated with its id
+// PRESERVED (infra_class_migrate.go), or one the class store minted from a
+// binding workspace whose own prefix is a work prefix. The namespace gate
+// declines those before a list is built, and that stays true: the arm answers a
+// question about the NAMESPACE.
+//
+// What covers them is the residence fallback beadStoresForID appends behind
+// every prefix-routed arm (appendClassResidencyFallback) — the same probe
+// cmd/gc/cmd_bd_by_id.go's bdByIDClassDoor.resolve performs, for the same
+// reason. So this arm's decline is no longer the end of the resolution.
 //
 // GRAPH ONLY. Sessions, orders and nudges have relocated-store accessors on
 // State, but adding them here would change which stores answer for gcs-/gco-/

--- a/internal/storeref/class_candidates.go
+++ b/internal/storeref/class_candidates.go
@@ -96,11 +96,15 @@ type PrefixedStore struct {
 //
 // What covers it is a residence probe — asking the class store about EVERY id
 // rather than only about prefixed ones. cmd/gc/cmd_bd_by_id.go's
-// bdByIDClassDoor.resolve does exactly that, for exactly this reason. Nothing
-// on the internal/api by-id path does, so there a legacy-prefixed relocated
-// bead is still answered from the work store's retained pre-migration copy (the
-// migration never deletes its source). Giving that path a residence probe is
-// open work, not a property of this function.
+// bdByIDClassDoor.resolve does exactly that, for exactly this reason;
+// cmd/gc/by_id_store_route.go's classRoutedStoreForID takes the same [class,
+// work] list when this resolver declines; and internal/api's by-id resolver
+// appends the class store behind its prefix-routed candidates
+// (appendClassResidencyFallback). Each caller owns that probe, because each
+// one's fallback ORDER is a property of its own surface — the CLI door leads
+// with the class store, the API appends behind the stores it already served.
+// This function stays the NAMESPACE rule and must not be described as if it
+// were the residence rule.
 func ClassCandidates(id string, routing ClassRouting) []beads.Store {
 	id = strings.TrimSpace(id)
 	if routing.Class == nil || routing.Class == routing.Work {


### PR DESCRIPTION
793 open beads on the measured city carry a rig/city prefix but **reside in a coordination-class store**, not in the store their prefix routes writes to. They are graph-native synthetics — input convoys, patrol roots, wisps — created through the class door with no id, so the binding workspace minted them from *its* prefix, which on a converged city is a work prefix. Reads reach them; writes route by prefix and hard-fail. Each one is a permanent `HasOpenWork` / ready-frontier polluter with no supported drain path (live example: a patrol root wedged open since June suppressed its order the entire time).

### Three by-id lanes; two lacked a residence probe

| Lane | Before |
|---|---|
| One-shot call sites (`classRoutedStoreForID`) | **Already had it** — `[class, work]` when the namespace gate cannot decide |
| CLI `gc bd` door | Probes the class leg for every id — but only for the verbs it serves, and **`close`/`reopen` were not in the verb set at all** |
| City HTTP API (`beadStoresForID`) | **No probe.** Documented as open work in two header essays, in nearly identical words |

So this completes two lanes to match a shipped pattern; it invents nothing.

**Slice 1 — CLI (`7aa1dbc5c7`).** `close` and `reopen` become served by-ID verbs, so the door's existing residence probe routes them exactly as it already routes `update`/`--claim`/`release-if-current`/`dep list`. Only the bare form: `GraphStore.Close(string) error` carries no reason and no workflow coupling, so bd's `-r/--reason/--reason-file/--session` and `--claim-next/--continue/--force/--no-auto/--suggest-next` make the invocation unrecognized rather than half-executed. `delete` and batch close stay unserved.

**Slice 2 — CLI (`5290e09149`), independently reviewable and revertible.** Ownership was provable only from a reserved prefix in the argv. Residency proves it too: an unserved mutation with unambiguous positional ids is probed against the class binding and refused with the offending flag named, instead of falling through to bd's misleading not-found. Widens the cost gate from *verb* to *subject* — reads, selectors and ambiguous scans still pay nothing.

**Slice 3 — API (`f76e3f47c7`).** `appendClassResidencyFallback` appends the class store **behind** the candidates each prefix arm already produced. Zero handler changes, zero wire changes, `openapi.json` untouched. Each handler already binds its write store to the store whose `Get` answered, so read/write coherence is structural.

**Multi-residency rule:** a write lands in the first store of the surface's own probe order whose `Get` answers — the same order that surface's reads use. CLI: class-first. API: prefix-first. Each surface is internally coherent; the cross-surface divergence for dual-resident ids is acknowledged, unchanged from today's read side, and retired by the sweep, not by routing. Pinned by `TestBdCloseDualResidentWritesServingCopy` and `TestBeadWriteDualResidentPrefersPrefixStore`.

**ADR-0009 note (`52151f8e52`, doc-only).** A door-routed close does not reach the work-record close gate. The bypass is recorded next to the gate's own coverage claim, along with why it is sound and which population it actually affects (dual-resident migrated work steps).

### Reviewer's attention
- **Mixed-batch atomicity.** `gc bd close gc-work1 gc-relic1` used to close `gc-work1` and error on the resident; it now refuses both. The one input that is "partial success → atomic refusal" rather than "error → correct".
- **404 → 500 on the API.** A prefix miss followed by an *unreachable* class store is now 500. That is the resolver's own fail-fast doctrine ("an unreachable store must not be reported as a missing bead"), with a 404 control asserted alongside.
- **Flag-order asymmetry (follow-up, not fixed here).** `gc bd close gcg-1` is served; `gc bd --json close gcg-1` is not — the served parsers key on `argv[0]`. Pre-existing for `show`; sharper now that close has both a served and an unserved spelling.
- **`delete` on a resident is a refusal with no `gc` alternative** — `close` covers the drain, but the message does not say so.
- **T14 is a pin, not a cure.** If the deploy branch has the read-leg/write-leg tier skew, the door now surfaces it loudly with bd's own not-found wording — which will *look* like this bug. The design's binding-leg verification is not optional before porting.

**Gates:** `go vet ./...` clean · `go test ./cmd/gc -count=1 -timeout 1800s` green (769s) · `go test ./internal/api/... ./internal/storeref/...` green incl. `TestOpenAPISpecInSync` · `make test` green · 19 designed tests + 2 review-gap tests, each core one demonstrated RED first, each control's teeth proven by mutation. Three-lens adversarial review completed pre-PR (design conformance / invariants / test adequacy); findings folded in or filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
