### PR TITLE
fix(cmd/gc): unbreak the cmd/gc test build after the order-dispatcher routes change

### DIFF
--- a/cmd/gc/order_dispatch_bench_test.go
+++ b/cmd/gc/order_dispatch_bench_test.go
@@ -90,7 +90,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PreFix_ReparsePerTick", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		// Reproduce the pre-fix storeFn verbatim (order_dispatch.go:431-433
 		// before the ga-237xpr fix): ignore the dispatcher's cached cfg and
 		// go through the nil-cfg path, which reloads city.toml + every pack
@@ -110,7 +110,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PostFix_CachedConfig", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		now := time.Now()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1915,7 +1915,7 @@ func TestOrderDispatchDoesNotReparseConfigPerTick(t *testing.T) {
 		Interval: "1h",
 		Exec:     "true",
 	}}
-	ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+	ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 
 	before := loadCityConfigCalls.Load()
 	now := time.Now()


### PR DESCRIPTION
`origin/main` does not compile its own `cmd/gc` test package: #4682 gave `newMemoryOrderDispatcher` a leading `*storageRoutes` parameter and updated its two production call sites but not the three test call sites, so `go vet ./cmd/gc` (and any `go test ./cmd/gc`) fails at head:

```
vet: cmd/gc/order_dispatch_bench_test.go:93:78: not enough arguments in call to newMemoryOrderDispatcher
	have ([]orders.Order, string, *config.City, events.Recorder, io.Writer)
```

Three-line fix passing the routes the two production call sites already pass. Verified red on `ed267ad66b` (main) and green with the fix. Found while branching unrelated work off main; extracted standalone since it blocks anyone running the suite at head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
