### PR TITLE
fix(controller): serialize config watcher replacement

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2294,18 +2294,29 @@ func (cr *CityRuntime) restartConfigWatcher() {
 	if cr.tomlPath == "" {
 		return
 	}
-	cr.stopConfigWatcher()
 
 	dirty := cr.configDirty
 	if dirty == nil {
 		dirty = &atomic.Bool{}
 		cr.configDirty = dirty
 	}
-	cleanup := watchConfigTargets(cr.configWatcherTargets(), dirty, cr.pokeCh, cr.stderr)
+	cr.replaceConfigWatcher(func() func() {
+		return watchConfigTargets(cr.configWatcherTargets(), dirty, cr.pokeCh, cr.stderr)
+	})
+}
 
+func (cr *CityRuntime) replaceConfigWatcher(start func() func()) {
+	// Serialize the whole replace operation. Locking stop and install
+	// separately lets concurrent reloads both create a watcher, after which
+	// the second install overwrites the first cleanup handle and permanently
+	// leaks its recursive fsnotify registrations.
 	cr.watchMu.Lock()
-	cr.watchCleanup = cleanup
-	cr.watchMu.Unlock()
+	defer cr.watchMu.Unlock()
+	if cleanup := cr.watchCleanup; cleanup != nil {
+		cr.watchCleanup = nil
+		cleanup()
+	}
+	cr.watchCleanup = start()
 }
 
 func (cr *CityRuntime) stopConfigWatcher() {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -7387,6 +7387,40 @@ func TestWarnIfClosedOrderTrackingBacklogLarge_CapFormatAtLimit(t *testing.T) {
 	}
 }
 
+func TestReplaceConfigWatcherSerializesConcurrentRestarts(t *testing.T) {
+	cr := &CityRuntime{}
+	var active atomic.Int64
+	var maxActive atomic.Int64
+	start := func() func() {
+		n := active.Add(1)
+		for {
+			old := maxActive.Load()
+			if n <= old || maxActive.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		return func() { active.Add(-1) }
+	}
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cr.replaceConfigWatcher(start)
+		}()
+	}
+	wg.Wait()
+	cr.stopConfigWatcher()
+
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("maximum active config watchers = %d, want 1", got)
+	}
+	if got := active.Load(); got != 0 {
+		t.Fatalf("active config watchers after stop = %d, want 0", got)
+	}
+}
+
 func TestWarnIfClosedOrderTrackingBacklogLarge_SilentOnNilStore(_ *testing.T) {
 	// nil store: must not panic.
 	warnIfClosedOrderTrackingBacklogLarge([]beads.Store{nil}, io.Discard)


### PR DESCRIPTION
## Summary

- serialize the complete config-watcher replacement operation
- prevent concurrent reloads from overwriting cleanup handles and orphaning recursive fsnotify watchers
- add a concurrent regression test that proves at most one watcher remains active

This was observed in production as repeated full-repository watcher sets: the supervisor reached roughly 6,500 open descriptors, runtime probes timed out, and the shared tmux runtime repeatedly disappeared.

## Testing

- [ ] `make check`
- [ ] `make check-docs` (not applicable; no docs changed)
- [ ] `make test-integration`
- [x] Regression test passed repeatedly on the deployed source lineage
- [ ] Focused `cmd/gc` test on current `origin/main` (blocked by unrelated existing `newMemoryOrderDispatcher` argument-count compile errors in order-dispatch tests)

## Checklist

- [x] Explained why a separate issue is not needed: the race, production evidence, and regression are fully captured here
- [x] Added tests for the behavior change
- [x] No user-facing docs change
- [x] No breaking change or migration
