### PR TITLE
test(orders): pass nil routes to newMemoryOrderDispatcher in test call sites

### DIFF
--- a/cmd/gc/order_dispatch_bench_test.go
+++ b/cmd/gc/order_dispatch_bench_test.go
@@ -90,7 +90,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PreFix_ReparsePerTick", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		// Reproduce the pre-fix storeFn verbatim (order_dispatch.go:431-433
 		// before the ga-237xpr fix): ignore the dispatcher's cached cfg and
 		// go through the nil-cfg path, which reloads city.toml + every pack
@@ -110,7 +110,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PostFix_CachedConfig", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		now := time.Now()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1915,7 +1915,7 @@ func TestOrderDispatchDoesNotReparseConfigPerTick(t *testing.T) {
 		Interval: "1h",
 		Exec:     "true",
 	}}
-	ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+	ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 
 	before := loadCityConfigCalls.Load()
 	now := time.Now()


### PR DESCRIPTION
## What's broken

`13886fbee` (#4682, "perf(gc): stop the order dispatcher reparsing city+pack TOML every tick") added a leading `*storageRoutes` parameter to `newMemoryOrderDispatcher` but missed updating three test call sites (two in `order_dispatch_bench_test.go`, one in `order_dispatch_test.go`). This leaves `cmd/gc` unable to compile on current `main` — `go build`/`go vet`/`go test` all fail package-wide:

```
cmd/gc/order_dispatch_bench_test.go:93:78: not enough arguments in call to newMemoryOrderDispatcher
cmd/gc/order_dispatch_bench_test.go:113:78: not enough arguments in call to newMemoryOrderDispatcher
cmd/gc/order_dispatch_test.go:1918:77: not enough arguments in call to newMemoryOrderDispatcher
```

Reproduces on a completely fresh, untouched checkout of `main` — not specific to any other change.

## Fix

Pass `nil` at all three call sites, matching the existing production call sites' documented convention (`buildOrderDispatcher`'s `//nolint:unparam` comment: "routes is nil in current callers") and the function's own doc comment ("nil is the identity routing of a single-store city") — exactly the single-store fixtures these tests use.

## Verification

- `go build ./...` and `go vet ./...` clean repo-wide (both failed before this fix).
- `go test ./cmd/gc/... -run TestOrderDispatchDoesNotReparseConfigPerTick` and the full `BenchmarkOrderDispatchReparseAvoidance` pass.

No issue filed for this — it's a compile-blocker on `main` itself rather than a reported bug, so opening directly with the fix + citation of the offending commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)