### PR TITLE
fix(dolt-cleanup): drop rss= from the reap-stage ps scan (#5201)

### DIFF
--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -403,10 +403,20 @@ func readDoltSQLServerArgv(pid int) ([]string, bool) {
 	return argv, true
 }
 
+// psOutputFormat is the -o field spec passed to `ps` for process discovery.
+// Deliberately excludes rss=: some macOS hosts require an entitlement to
+// report resource-usage fields (%mem/vsz/rss/time) for processes outside the
+// caller's own session, and ps exits non-zero for the *entire* invocation
+// when it can't — turning a clean, zero-orphan scan into a reported
+// dolt-cleanup reap-stage error (gastownhall/gascity#5201). RSSBytes is
+// cosmetic-only downstream (planOrphanReap classifies purely on
+// ConfigPath/DataDir/CWDState, never on RSS), so it is not worth requesting.
+const psOutputFormat = "pid=,lstart=,command="
+
 func psLStartCommandLines() ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), psEnumerationTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "ps", "-ax", "-o", "pid=,rss=,lstart=,command=")
+	cmd := exec.CommandContext(ctx, "ps", "-ax", "-o", psOutputFormat)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -421,17 +431,13 @@ func psLStartCommandLines() ([]string, error) {
 }
 
 func parseDoltPSLine(line string, pidPorts map[int][]int) (DoltProcInfo, bool) {
-	fields, command := consumeLeadingFields(line, 7)
-	if len(fields) != 7 || command == "" {
+	fields, command := consumeLeadingFields(line, 6)
+	if len(fields) != 6 || command == "" {
 		return DoltProcInfo{}, false
 	}
 	pid, err := strconv.Atoi(fields[0])
 	if err != nil || pid <= 0 {
 		return DoltProcInfo{}, false
-	}
-	rssKB, err := strconv.ParseInt(fields[1], 10, 64)
-	if err != nil || rssKB < 0 {
-		rssKB = 0
 	}
 	argv := parseDoltPSCommandLine(command)
 	if !looksLikeDoltSQLServer(argv) {
@@ -441,13 +447,12 @@ func parseDoltPSLine(line string, pidPorts map[int][]int) (DoltProcInfo, bool) {
 		PID:           pid,
 		Argv:          argv,
 		Ports:         pidPorts[pid],
-		RSSBytes:      rssKB * 1024,
-		StartIdentity: strings.Join(fields[2:7], " "),
+		StartIdentity: strings.Join(fields[1:6], " "),
 	}, true
 }
 
 func argvFromPSLine(line string) ([]string, bool) {
-	_, command := consumeLeadingFields(line, 7)
+	_, command := consumeLeadingFields(line, 6)
 	if command == "" {
 		return nil, false
 	}

--- a/cmd/gc/dolt_cleanup_discovery_test.go
+++ b/cmd/gc/dolt_cleanup_discovery_test.go
@@ -134,7 +134,10 @@ func TestLooksLikeDoltSQLServer(t *testing.T) {
 }
 
 func TestParseDoltPSLine_DoltSQLServer(t *testing.T) {
-	line := "  78306  65392 Sun May 17 09:31:24 2026 /usr/local/bin/dolt sql-server --config /tmp/TestGcBeadsBdStartUsesRootBeadsDataDir802378814/001/.gc/runtime/packs/dolt/dolt-config.yaml --host 127.0.0.1"
+	// No rss= token: gastownhall/gascity#5201 dropped it from the requested ps
+	// fields, since some macOS hosts reject the whole ps invocation when it
+	// asks for resource-usage fields on other sessions' processes.
+	line := "  78306  Sun May 17 09:31:24 2026 /usr/local/bin/dolt sql-server --config /tmp/TestGcBeadsBdStartUsesRootBeadsDataDir802378814/001/.gc/runtime/packs/dolt/dolt-config.yaml --host 127.0.0.1"
 	got, ok := parseDoltPSLine(line, map[int][]int{78306: {3306}})
 	if !ok {
 		t.Fatal("parseDoltPSLine did not recognize dolt sql-server")
@@ -142,8 +145,8 @@ func TestParseDoltPSLine_DoltSQLServer(t *testing.T) {
 	if got.PID != 78306 {
 		t.Fatalf("PID = %d, want 78306", got.PID)
 	}
-	if got.RSSBytes != 65392*1024 {
-		t.Fatalf("RSSBytes = %d, want %d", got.RSSBytes, int64(65392*1024))
+	if got.RSSBytes != 0 {
+		t.Fatalf("RSSBytes = %d, want 0 (rss= is no longer requested from ps, gastownhall/gascity#5201)", got.RSSBytes)
 	}
 	if !reflect.DeepEqual(got.Ports, []int{3306}) {
 		t.Fatalf("Ports = %v, want [3306]", got.Ports)
@@ -157,7 +160,7 @@ func TestParseDoltPSLine_DoltSQLServer(t *testing.T) {
 }
 
 func TestParseDoltPSLine_PreservesSpacedConfigPath(t *testing.T) {
-	line := "12345 1024 Sun May 17 09:31:24 2026 dolt sql-server --config /tmp/Test With Space/config.yaml --port 3306"
+	line := "12345 Sun May 17 09:31:24 2026 dolt sql-server --config /tmp/Test With Space/config.yaml --port 3306"
 	got, ok := parseDoltPSLine(line, nil)
 	if !ok {
 		t.Fatal("parseDoltPSLine did not recognize dolt sql-server")
@@ -168,9 +171,23 @@ func TestParseDoltPSLine_PreservesSpacedConfigPath(t *testing.T) {
 }
 
 func TestParseDoltPSLine_IgnoresNonDolt(t *testing.T) {
-	line := "12345 1024 Sun May 17 09:31:24 2026 mysqld --config /tmp/TestX/config.yaml"
+	line := "12345 Sun May 17 09:31:24 2026 mysqld --config /tmp/TestX/config.yaml"
 	if got, ok := parseDoltPSLine(line, nil); ok {
 		t.Fatalf("parseDoltPSLine = %+v, want ignored", got)
+	}
+}
+
+// TestPSOutputFormatExcludesRSS pins gastownhall/gascity#5201: some macOS
+// hosts require an entitlement to report resource-usage fields (%mem/vsz/
+// rss/time) for processes outside the caller's own session, and `ps` exits
+// non-zero for the *entire* invocation when it can't — turning a clean,
+// zero-orphan scan into a reported dolt-cleanup reap-stage error. RSSBytes
+// is cosmetic-only downstream (planOrphanReap classifies purely on
+// ConfigPath/DataDir/CWDState, never on RSS), so requesting rss= here is not
+// worth trading away the whole scan for.
+func TestPSOutputFormatExcludesRSS(t *testing.T) {
+	if strings.Contains(psOutputFormat, "rss=") {
+		t.Fatalf("psOutputFormat = %q, must not request rss= (gastownhall/gascity#5201)", psOutputFormat)
 	}
 }
 

--- a/cmd/gc/order_dispatch_bench_test.go
+++ b/cmd/gc/order_dispatch_bench_test.go
@@ -90,7 +90,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PreFix_ReparsePerTick", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		// Reproduce the pre-fix storeFn verbatim (order_dispatch.go:431-433
 		// before the ga-237xpr fix): ignore the dispatcher's cached cfg and
 		// go through the nil-cfg path, which reloads city.toml + every pack
@@ -110,7 +110,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PostFix_CachedConfig", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		now := time.Now()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1915,7 +1915,7 @@ func TestOrderDispatchDoesNotReparseConfigPerTick(t *testing.T) {
 		Interval: "1h",
 		Exec:     "true",
 	}}
-	ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+	ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 
 	before := loadCityConfigCalls.Load()
 	now := time.Now()


### PR DESCRIPTION
Fixes #5201.

## What's broken

`gc dolt-cleanup`'s reap stage unconditionally failed (`errors_total:1`, `stage:"reap"`) on macOS hosts where `ps` requires an entitlement to report resource-usage fields (%mem/vsz/rss/time) for processes outside the caller's own session — even when there are zero real orphan databases/processes to reap. `psLStartCommandLines()` requested `rss=` as one of the `-o` fields; `ps` exits non-zero for the *entire* invocation when it can't satisfy that field for another session's process, and the function had no fallback, so the error propagated all the way up to a reported reap-stage failure regardless of actual orphan state.

`RSSBytes` parsed from this call is cosmetic-only downstream: `planOrphanReap` classifies reap-vs-protect purely on `ConfigPath`/`DataDir`/`CWDState` (confirmed by reading `cmd/gc/dolt_cleanup_reaper.go`), and the only other consumer is the summary's `bytes_freed_rss` field. Not worth trading away the whole scan for.

## Fix

Drop `rss=` from the requested `ps` fields entirely (now `"pid=,lstart=,command="`), and adjust the two line parsers (`parseDoltPSLine`, `argvFromPSLine`) from 7 leading fields to 6. `RSSBytes` on this path is now always its int64 zero value — the fallback `ps`-based discovery path (hosts without `/proc`) never reported it as anything but cosmetic anyway; the `/proc`-based path (`readProcRSSBytes`, Linux) is unaffected and still reports real RSS.

## Verification

- Updated the three existing `parseDoltPSLine` fixtures to the new 6-field `ps` line shape (no `rss=` token) and added `TestPSOutputFormatExcludesRSS`, a regression guard pinning that the requested field spec never re-adds `rss=`.
- Live-verified the exact new `ps -ax -o "pid=,lstart=,command="` invocation succeeds end-to-end on Darwin.
- Full `go test ./cmd/gc/...` green (including the broader dolt-cleanup/reap/wisp-gc suites, no regressions); `go vet ./...` and `go build ./...` clean repo-wide; gofmt clean.

Stacks on #5251 (pre-existing, unrelated `cmd/gc` compile blocker on `main`) purely to compile in isolation — this branch deliberately excludes that fix so it stays its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)