### PR TITLE
test(pidutil): skip TestCmdline_FailsClosedWhenUnreadable on darwin too

### DIFF
--- a/cmd/gc/order_dispatch_bench_test.go
+++ b/cmd/gc/order_dispatch_bench_test.go
@@ -90,7 +90,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PreFix_ReparsePerTick", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		// Reproduce the pre-fix storeFn verbatim (order_dispatch.go:431-433
 		// before the ga-237xpr fix): ignore the dispatcher's cached cfg and
 		// go through the nil-cfg path, which reloads city.toml + every pack
@@ -110,7 +110,7 @@ func BenchmarkOrderDispatchTick(b *testing.B) {
 
 	b.Run("PostFix_CachedConfig", func(b *testing.B) {
 		before := loadCityConfigCalls.Load()
-		ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+		ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 		now := time.Now()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1915,7 +1915,7 @@ func TestOrderDispatchDoesNotReparseConfigPerTick(t *testing.T) {
 		Interval: "1h",
 		Exec:     "true",
 	}}
-	ad := newMemoryOrderDispatcher(aa, cityDir, cfg, events.Discard, io.Discard)
+	ad := newMemoryOrderDispatcher(nil, aa, cityDir, cfg, events.Discard, io.Discard)
 
 	before := loadCityConfigCalls.Load()
 	now := time.Now()

--- a/internal/pidutil/cmdline_portable_test.go
+++ b/internal/pidutil/cmdline_portable_test.go
@@ -128,6 +128,9 @@ func TestCmdline_FailsClosedWhenUnreadable(t *testing.T) {
 	if runtime.GOOS == "linux" {
 		t.Skip("on linux /proc answers directly, so the ps stub cannot make argv unreadable")
 	}
+	if runtime.GOOS == "darwin" {
+		t.Skip("on darwin platformCmdline reads kern.procargs2 directly (cmdline_darwin.go), so the ps stub cannot make argv unreadable either")
+	}
 
 	binDir := t.TempDir()
 	// A ps that produces nothing, so the non-/proc path has no argv to offer.


### PR DESCRIPTION
## What's broken

`TestCmdline_FailsClosedWhenUnreadable` simulates "argv unreadable" by poisoning `ps` on `PATH` with a script that always fails, then asserts `AliveWithCmdline(self, ...)` fails closed (returns `false`). That only actually tests something on the platform build where `platformCmdline` shells out to `ps` (`cmdline_other.go`, `//go:build !darwin`) — Linux already skips (it reads `/proc/<pid>/cmdline` directly, never touching `ps`), and Darwin's own `platformCmdline` (`cmdline_darwin.go`) reads argv via `unix.SysctlRaw("kern.procargs2", pid)`, a native syscall that also never shells out to `ps`. Confirmed by tracing `psCmdline`'s only production caller: `cmdline_other.go`'s `platformCmdline`, never reached on darwin.

So on Darwin the `ps` stub has no effect: `Cmdline(os.Getpid())` correctly resolves the real argv via `kern.procargs2` (self-introspection doesn't need the cross-session entitlement other-process introspection does — the same asymmetry #5201 hit for `ps -o rss=`), and `AliveWithCmdline` correctly returns `true`. The test was asserting the wrong thing on this platform, not observing a real fail-open regression — production behavior here is correct and safe.

## Fix

Skip the test on darwin too, alongside the existing linux skip, with a comment naming why. Does not add a darwin-specific equivalent test for the same fail-closed property — that would need a way to force `kern.procargs2` itself to fail (e.g. an invalid/recycled PID), a separate, larger change than unblocking the current false failure; left for a follow-up if the coverage gap matters enough to close.

## Verification

`go test ./internal/pidutil/...` full package green, target test now `SKIP`s cleanly with an explanatory message; `go vet ./internal/pidutil/...` and gofmt clean.

No issue filed for this — found while diagnosing a locally-reproducible test failure on a clean `main` checkout, unrelated to any feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)