### PR TITLE
fix(gc): route API calls to the supervisor hosting the city

### DIFF
--- a/cmd/gc/apiroute.go
+++ b/cmd/gc/apiroute.go
@@ -32,13 +32,29 @@ var (
 //
 // A standalone controller (gc controller / gc serve) and a supervisor-managed
 // city both answer the per-city controller socket — the supervisor hosts that
-// controller in-process. When the socket is alive, apiClient routes to the
-// standalone HTTP endpoint if the city configures an [api] port, otherwise
-// returns nil so the caller uses its local fallback; when the socket is not
-// alive it returns the supervisor-managed client. Maintenance commands have no
-// local fallback, so they use maintenanceAPIClient, which additionally routes a
-// supervisor-managed city (alive socket, no standalone [api] port) to the
-// supervisor client rather than reporting controller-down. (gascity ga-tp7)
+// controller in-process — so liveness alone cannot say which endpoint serves
+// the API. The controller reports that itself, and routing keys on it:
+//
+//   - supervisor-hosted: the supervisor serves this city on its own port via
+//     city-scoped routes and IGNORES the city's [api] port, so route to the
+//     supervisor client. Routing to the configured standalone port instead
+//     sends every call to a listener that does not exist; the call fails and
+//     the caller drops into a local fallback that constructs a fresh,
+//     process-local runtime. That fallback cannot reach a runtime the
+//     supervisor owns in memory — an ACP session lives in the supervisor
+//     process, so `gc session submit` failed with "ACP provider does not own
+//     session" while the supervisor held it. Falling back is only sound for
+//     state that lives on disk, not for process-owned runtimes.
+//   - standalone: route to the standalone HTTP endpoint when city.toml
+//     configures a usable [api] port, else return nil for the local fallback.
+//   - unknown (a controller predating the identity command): keep the
+//     pre-existing standalone-only routing rather than inferring a role.
+//
+// When the socket is not alive it returns the supervisor-managed client.
+// Maintenance commands have no local fallback, so they use
+// maintenanceAPIClient, which additionally routes an unknown-mode managed city
+// (alive socket, no standalone [api] port) to the supervisor client rather
+// than reporting controller-down. (gascity ga-tp7)
 func apiClient(cityPath string) *api.Client {
 	// Remote routing is NOT handled here. A remote target is refused upstream by
 	// the capability gate in resolveContext (Phase 1) and, once enabled, will be
@@ -57,14 +73,20 @@ func apiClient(cityPath string) *api.Client {
 	} else if warn != "" {
 		fmt.Fprintln(os.Stderr, "warning: "+warn) //nolint:errcheck // best-effort stderr
 	}
-	if apiRouteControllerAliveHook(cityPath) != 0 {
-		// Alive socket: use the standalone HTTP endpoint when configured, else
-		// return nil so the caller takes its local fallback. A supervisor-managed
-		// city (no standalone [api] port) reaches the supervisor client only via
-		// maintenanceAPIClient, which has no local fallback.
-		return standaloneControllerClient(cityPath)
+	identity := controllerIdentityHook(cityPath)
+	if identity.PID == 0 {
+		return apiRouteSupervisorClientHook(cityPath)
 	}
-	return apiRouteSupervisorClientHook(cityPath)
+	if identity.HostingMode == controllerHostingSupervisor {
+		// The supervisor owns this city. Its client is the only endpoint that
+		// reaches the live runtime; a nil result means there is no usable API,
+		// so return that rather than a standalone port nothing is serving.
+		return apiRouteSupervisorClientHook(cityPath)
+	}
+	// Standalone, or a legacy controller whose mode is unknown: use the
+	// standalone HTTP endpoint when configured, else return nil so the caller
+	// takes its local fallback.
+	return standaloneControllerClient(cityPath)
 }
 
 // standaloneControllerClient builds an API client for a standalone controller

--- a/cmd/gc/apiroute_test.go
+++ b/cmd/gc/apiroute_test.go
@@ -17,6 +17,23 @@ func writeCityTOMLForRoute(t *testing.T, dir, body string) string {
 	return dir
 }
 
+// withAPIRouteHooks pins every seam the routing ladder consults so a subtest is
+// hermetic no matter which one the implementation reads: the controller
+// identity probe (hosting mode plus the liveness PID), the legacy liveness
+// hook that maintenanceAPIClient still uses, and the supervisor client builder.
+// A pid of 0 means no controller is answering the socket.
+func withAPIRouteHooks(t *testing.T, pid int, mode controllerHostingMode, supervisor *api.Client) {
+	t.Helper()
+	withControllerHosting(t, pid, mode)
+	origAlive, origSup := apiRouteControllerAliveHook, apiRouteSupervisorClientHook
+	apiRouteControllerAliveHook = func(string) int { return pid }
+	apiRouteSupervisorClientHook = func(string) *api.Client { return supervisor }
+	t.Cleanup(func() {
+		apiRouteControllerAliveHook = origAlive
+		apiRouteSupervisorClientHook = origSup
+	})
+}
+
 // TestStandaloneControllerClient covers the decision that gates apiClient's
 // fall-through: a standalone controller endpoint is built only when city.toml
 // names a usable [api] port on a loopback bind (or allows mutations). Every
@@ -54,36 +71,54 @@ func TestStandaloneControllerClient(t *testing.T) {
 	}
 }
 
-// TestAPIClientRouting covers apiClient's routing: the standalone endpoint when
-// the socket is alive and an [api] port is configured, nil (the caller's local
-// fallback) when alive without a standalone port, the supervisor client when the
-// socket is down, and nil under the GC_NO_API escape hatch. The supervisor
-// fall-through for a managed city with no [api] port is scoped to maintenance —
-// see TestMaintenanceAPIClientRoutesToSupervisor. (gascity ga-tp7)
+// TestAPIClientRouting covers apiClient's routing ladder, which keys on the
+// controller's self-reported hosting mode: the supervisor client when the
+// supervisor hosts the city (its standalone [api] port is ignored in that
+// mode), the standalone endpoint for a standalone controller with an [api]
+// port, nil (the caller's local fallback) when no usable endpoint exists, the
+// supervisor client when the socket is down, and nil under the GC_NO_API
+// escape hatch. A controller predating the identity command reports an unknown
+// mode and keeps the pre-existing standalone-only routing; its supervisor
+// fall-through stays scoped to maintenance — see
+// TestMaintenanceAPIClientRoutesToSupervisor. (gascity ga-tp7)
 func TestAPIClientRouting(t *testing.T) {
 	sentinel := api.NewClient("http://supervisor.sentinel:1")
 
-	restore := func(alive func(string) int, sup func(string) *api.Client) {
-		apiRouteControllerAliveHook = alive
-		apiRouteSupervisorClientHook = sup
-	}
-	origAlive, origSup := apiRouteControllerAliveHook, apiRouteSupervisorClientHook
-	t.Cleanup(func() { restore(origAlive, origSup) })
-
-	t.Run("controller-alive-no-api-port-returns-nil", func(t *testing.T) {
-		// General commands have a local fallback, so apiClient returns nil here
-		// (no global supervisor fall-through).
+	t.Run("supervisor-hosted-uses-supervisor-client", func(t *testing.T) {
 		t.Setenv("GC_NO_API", "")
-		restore(func(string) int { return 4242 }, func(string) *api.Client { return sentinel })
+		withAPIRouteHooks(t, 4242, controllerHostingSupervisor, sentinel)
 		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n")
-		if got := apiClient(dir); got != nil {
-			t.Fatalf("apiClient = %p, want nil (general commands use local fallback)", got)
+		if got := apiClient(dir); got != sentinel {
+			t.Fatalf("apiClient = %p, want supervisor sentinel %p", got, sentinel)
 		}
 	})
 
-	t.Run("controller-alive-with-api-port-uses-standalone", func(t *testing.T) {
+	// Regression: a supervisor-managed city may still carry an [api] port in
+	// city.toml, but supervisor mode ignores it, so nothing listens there.
+	// Routing to that dead endpoint made every mutating command fail its API
+	// call and drop into a local fallback, which cannot reach a process-owned
+	// runtime (an ACP session lives in the supervisor's memory).
+	t.Run("supervisor-hosted-ignores-standalone-api-port", func(t *testing.T) {
 		t.Setenv("GC_NO_API", "")
-		restore(func(string) int { return 4242 }, func(string) *api.Client { return sentinel })
+		withAPIRouteHooks(t, 4242, controllerHostingSupervisor, sentinel)
+		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n[api]\nport = 9443\n")
+		if got := apiClient(dir); got != sentinel {
+			t.Fatalf("apiClient = %p, want supervisor sentinel %p (supervisor mode ignores [api] port)", got, sentinel)
+		}
+	})
+
+	t.Run("supervisor-hosted-without-supervisor-client-returns-nil", func(t *testing.T) {
+		t.Setenv("GC_NO_API", "")
+		withAPIRouteHooks(t, 4242, controllerHostingSupervisor, nil)
+		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n[api]\nport = 9443\n")
+		if got := apiClient(dir); got != nil {
+			t.Fatalf("apiClient = %p, want nil; the standalone port is not served under supervisor hosting", got)
+		}
+	})
+
+	t.Run("standalone-hosted-with-api-port-uses-standalone", func(t *testing.T) {
+		t.Setenv("GC_NO_API", "")
+		withAPIRouteHooks(t, 4242, controllerHostingStandalone, sentinel)
 		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n[api]\nport = 8080\n")
 		got := apiClient(dir)
 		if got == nil {
@@ -94,9 +129,42 @@ func TestAPIClientRouting(t *testing.T) {
 		}
 	})
 
+	t.Run("standalone-hosted-without-api-port-returns-nil", func(t *testing.T) {
+		t.Setenv("GC_NO_API", "")
+		withAPIRouteHooks(t, 4242, controllerHostingStandalone, sentinel)
+		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n")
+		if got := apiClient(dir); got != nil {
+			t.Fatalf("apiClient = %p, want nil (general commands use local fallback)", got)
+		}
+	})
+
+	t.Run("legacy-unknown-hosting-with-api-port-uses-standalone", func(t *testing.T) {
+		t.Setenv("GC_NO_API", "")
+		withAPIRouteHooks(t, 4242, controllerHostingUnknown, sentinel)
+		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n[api]\nport = 8080\n")
+		got := apiClient(dir)
+		if got == nil {
+			t.Fatalf("apiClient = nil, want standalone client")
+		}
+		if got == sentinel {
+			t.Fatalf("apiClient returned supervisor sentinel, want standalone client")
+		}
+	})
+
+	t.Run("legacy-unknown-hosting-without-api-port-returns-nil", func(t *testing.T) {
+		// General commands have a local fallback, so apiClient returns nil here
+		// (no global supervisor fall-through).
+		t.Setenv("GC_NO_API", "")
+		withAPIRouteHooks(t, 4242, controllerHostingUnknown, sentinel)
+		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n")
+		if got := apiClient(dir); got != nil {
+			t.Fatalf("apiClient = %p, want nil (general commands use local fallback)", got)
+		}
+	})
+
 	t.Run("controller-down-uses-supervisor", func(t *testing.T) {
 		t.Setenv("GC_NO_API", "")
-		restore(func(string) int { return 0 }, func(string) *api.Client { return sentinel })
+		withAPIRouteHooks(t, 0, controllerHostingUnknown, sentinel)
 		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n[api]\nport = 8080\n")
 		if got := apiClient(dir); got != sentinel {
 			t.Fatalf("apiClient = %p, want supervisor sentinel %p", got, sentinel)
@@ -105,7 +173,7 @@ func TestAPIClientRouting(t *testing.T) {
 
 	t.Run("escape-hatch-returns-nil", func(t *testing.T) {
 		t.Setenv("GC_NO_API", "1")
-		restore(func(string) int { return 4242 }, func(string) *api.Client { return sentinel })
+		withAPIRouteHooks(t, 4242, controllerHostingSupervisor, sentinel)
 		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n")
 		if got := apiClient(dir); got != nil {
 			t.Fatalf("apiClient = %p, want nil under GC_NO_API escape hatch", got)
@@ -114,10 +182,12 @@ func TestAPIClientRouting(t *testing.T) {
 }
 
 // TestMaintenanceAPIClientRoutesToSupervisor proves the maintenance-scoped
-// fall-through: when the controller socket is alive but the supervisor-managed
-// city omits a standalone [api] port, maintenanceAPIClient routes to the
-// supervisor-managed client (maintenance has no local fallback), where general
-// commands' apiClient returns nil. (gascity ga-tp7)
+// fall-through that survives for controllers predating the identity command:
+// the socket is alive but reports an unknown hosting mode and the city omits a
+// standalone [api] port, so apiClient returns nil while maintenanceAPIClient
+// (which has no local fallback) still reaches the supervisor-managed client.
+// A controller that reports supervisor hosting is routed by apiClient itself —
+// see TestAPIClientRouting. (gascity ga-tp7)
 func TestMaintenanceAPIClientRoutesToSupervisor(t *testing.T) {
 	sentinel := api.NewClient("http://supervisor.sentinel:1")
 	origAlive, origSup := apiRouteControllerAliveHook, apiRouteSupervisorClientHook
@@ -126,8 +196,9 @@ func TestMaintenanceAPIClientRoutesToSupervisor(t *testing.T) {
 		apiRouteSupervisorClientHook = origSup
 	})
 
-	t.Run("alive-no-api-port-routes-to-supervisor", func(t *testing.T) {
+	t.Run("alive-unknown-hosting-no-api-port-routes-to-supervisor", func(t *testing.T) {
 		t.Setenv("GC_NO_API", "")
+		withControllerHosting(t, 4242, controllerHostingUnknown)
 		apiRouteControllerAliveHook = func(string) int { return 4242 }
 		apiRouteSupervisorClientHook = func(string) *api.Client { return sentinel }
 		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n")
@@ -142,6 +213,7 @@ func TestMaintenanceAPIClientRoutesToSupervisor(t *testing.T) {
 
 	t.Run("escape-hatch-skips-supervisor", func(t *testing.T) {
 		t.Setenv("GC_NO_API", "1")
+		withControllerHosting(t, 4242, controllerHostingUnknown)
 		apiRouteControllerAliveHook = func(string) int { return 4242 }
 		apiRouteSupervisorClientHook = func(string) *api.Client { return sentinel }
 		dir := writeCityTOMLForRoute(t, t.TempDir(), "name = \"t\"\n")


### PR DESCRIPTION
## Problem

A standalone controller (`gc controller` / `gc serve`) and a supervisor-managed city both answer the per-city controller socket, because the supervisor hosts that controller in-process. Liveness alone cannot tell them apart, but `apiClient` treated every live socket as standalone:

```go
if apiRouteControllerAliveHook(cityPath) != 0 {
    return standaloneControllerClient(cityPath)
}
return apiRouteSupervisorClientHook(cityPath)
```

Supervisor mode ignores the city's `[api]` port and serves the city on the supervisor's own port via city-scoped routes. So for a supervisor-managed city with `[api] port = 9443`, the returned client targeted a listener that does not exist; the call failed and `api.ShouldFallback` sent the command into its local fallback. Without an `[api]` port the same path returned `nil` and reached the same fallback.

The local fallback is only sound for state that lives on disk. An ACP session lives in the supervisor's memory, so the fallback built a fresh process-local provider that did not own the connection:

```
gc session submit: sending message to session: session not found: ACP provider does not own session "mayor"
```

Fixes #5262.

## Fix

Key the routing on the hosting mode the controller already reports over the same socket (`identify` → `hosting_mode`), the signal `ensureNoStandaloneController` already uses for this ownership question:

- **supervisor-hosted** → supervisor client. A `nil` result means there is no usable API, so it returns that rather than a standalone port nothing is serving.
- **standalone** → the `[api]` port endpoint when configured, else `nil` for the caller's local fallback.
- **unknown** (a controller predating the identity command) → the previous standalone-only routing, rather than inferring a role.
- **socket down** → supervisor client, unchanged.

The identity probe replaces the liveness ping rather than adding a round-trip, since it reports the PID too and already falls back to `controllerAlive` for older controllers.

`maintenanceAPIClient` keeps its supervisor fall-through, which now covers only the unknown-mode legacy controller, because `apiClient` resolves the supervisor-hosted case directly. Its comment says so.

## Tests

`TestAPIClientRouting` now pins every seam the ladder consults through one helper, so each subtest is hermetic regardless of which hook the implementation reads, and covers:

- supervisor-hosted uses the supervisor client
- **supervisor-hosted ignores a configured standalone `[api]` port** — the regression for this bug
- supervisor-hosted with no supervisor client returns `nil` rather than a dead standalone endpoint
- standalone-hosted with/without an `[api]` port
- legacy unknown hosting with/without an `[api]` port (pre-existing behavior preserved)
- controller down, and the `GC_NO_API` escape hatch

Verified failure direction first: against the unmodified implementation the three supervisor-hosted cases fail, including one that returns a client aimed at the dead `9443` endpoint. The standalone, legacy-unknown, controller-down and escape-hatch cases pass before and after, so the pre-existing routing is unchanged.

`TestMaintenanceAPIClientRoutesToSupervisor` now pins the hosting mode to unknown so it exercises the legacy fall-through it is named for, instead of passing incidentally through the controller-down path.

## Test plan

- `go test ./cmd/gc/ -run 'TestAPIClientRouting|TestMaintenanceAPIClientRoutesToSupervisor|TestStandaloneControllerClient' -count=1` passes
- Full `go test ./cmd/gc/ -count=1` passes
- `go vet ./cmd/gc/`, `go build ./...`, and `golangci-lint` (via the pre-commit hook) clean

Two unrelated environment-induced failure classes appear on this machine and are not caused by this change: fixture commits fail when a global `commit.gpgsign=true` leaks into tests, and one template test fails when `OPENAI_API_KEY` is present in the environment. Both pass when those are neutralized.
