### PR TITLE
fix(ci): reconcile the residency baseline with the #5250/#5264 merge race

### DIFF
--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -88,9 +88,8 @@ cmd/gc/session_beads.go	workAssignmentStores	c:beads.Store-literal	1
 cmd/gc/session_reconciler.go	reachableStoresForSession	a:workAssignmentStores	1
 cmd/gc/session_reconciler.go	reachableStoresForSession	ast:returns-store-list	1
 cmd/gc/session_reconciler.go	reachableStoresForSession	c:beads.Store-literal	2
-cmd/gc/session_reconciler.go	reachableStoresForSessionInfo	a:workAssignmentStores	1
+cmd/gc/session_reconciler.go	reachableStoresForSessionInfo	a:workAssignmentStores	3
 cmd/gc/session_reconciler.go	reachableStoresForSessionInfo	ast:returns-store-list	1
-cmd/gc/session_reconciler.go	reachableStoresForSessionInfo	c:beads.Store-literal	2
 internal/api/dashport_support.go	BeadStores	a:BeadStores	1
 internal/api/dashport_support.go	BeadStores	ast:returns-store-list	1
 internal/api/handler_agents.go	findActiveBeadForAssigneesWithFreshness	a:BeadStores	1


### PR DESCRIPTION
Main is red for every open PR: #5250 (merged 07:56:10) and #5264 (merged 07:56:11) were each green alone, but S0's boundary baseline was computed before #5250's F3 refactor of `reachableStoresForSessionInfo`. Delta is exactly that one function — two raw `beads.Store` literals replaced by `workAssignmentStores` calls (net enumeration sites unchanged at 123; the literal rows retire as a shrink, the calls stay S2's migration target). Both guard halves re-emitted with their own tools and green.

Main-red unbreaker — same class as #5247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)