### PR TITLE
fix(formula): teardown tails are not finalize sinks — ends the adopt-pr settlement deadlock

### DIFF
--- a/docs/reference/specs/formula-spec-v2.md
+++ b/docs/reference/specs/formula-spec-v2.md
@@ -528,7 +528,9 @@ The v2 compiler must emit a flat, topologically ordered graph:
 - **`workflow-finalize` is appended.** A control step with ID
   `workflow-finalize` (kind `workflow-finalize`) is added depending on
   every sink step, so it becomes Ready exactly when all other work is
-  terminal.
+  terminal. Steps carrying `gc.scope_role = "teardown"` are excluded from
+  the sink set: teardown runs after the workflow settles (section 3.5), so
+  gating settlement on it would deadlock the run.
 - **The root blocks on the finalize step.** The workflow root bead is made
   to depend on `workflow-finalize` (or, when a recipe has no finalize step,
   on every step whose `gc.kind` is not one of the generated `run`, `check`,
@@ -909,6 +911,17 @@ pass/fail, closes the workflow root with that outcome (root first, so a
 crash retries finalization), closes generated spec sidecars, and — on pass
 only — propagates closure across the `gc.source_bead_id` chain. Failures
 intentionally leave parent source beads open for investigation.
+
+**Teardown is post-settlement.** Teardown work
+(`gc.scope_role = "teardown"`) is the one part of a workflow that outlives
+settlement: it never blocks `workflow-finalize`, and finalize's terminal
+close — which skips every other still-open member once the root is
+terminal — leaves the teardown step and its retry attempts open so they
+still run. A teardown step may therefore read the run's final
+`gc.outcome`, which is what makes "clean up on pass, preserve the
+workspace on fail" expressible. Its own outcome never re-grades the root;
+a teardown that fails after settlement is a relic to sweep, not a failed
+run.
 
 ## 4. Accepted But Inert
 

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -851,14 +851,20 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	if _, err := sourceworkflow.CloseSpecSidecarsForRoot(store, rootID, sourceworkflow.WorkflowSpecSidecarClosedReason); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing workflow spec sidecars: %w", rootID, err))
 	}
-	// A terminal root makes every still-open generated member non-executable.
-	// Close the remainder as one ordered, idempotent batch before completing
-	// the finalizer. This also repairs partially materialized workflows whose
-	// unused steps were never reached by ordinary dependency progression.
-	if _, err := molecule.CloseSubtreeWithMetadata(store, rootID, map[string]string{
+	// A terminal root makes every still-open generated member non-executable —
+	// except the teardown tail, which is executable precisely because the root
+	// is now terminal. Close the remainder as one ordered, idempotent batch
+	// before completing the finalizer. This also repairs partially materialized
+	// workflows whose unused steps were never reached by ordinary dependency
+	// progression.
+	excludeTeardown, err := teardownTailExclusion(store, rootID)
+	if err != nil {
+		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: resolving teardown members: %w", rootID, err))
+	}
+	if _, err := molecule.CloseSubtreeWithMetadataExcept(store, rootID, map[string]string{
 		beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped,
 		"close_reason":              sourceworkflow.WorkflowSkippedCloseReason,
-	}); err != nil {
+	}, excludeTeardown); err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing terminal workflow members: %w", rootID, err))
 	}
 	if outcome == beadmeta.OutcomePass {
@@ -883,6 +889,41 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	}
 
 	return ControlResult{Processed: true, Action: "workflow-" + outcome}, nil
+}
+
+// teardownTailExclusion builds the predicate that keeps the teardown tail out
+// of the terminal sweep. Teardown work runs after the root settles by contract
+// (its pass condition may branch on the run outcome), so force-closing it at
+// settlement would skip the very step that releases the workflow's resources.
+//
+// The tail is the teardown-scoped members plus every attempt of the same step:
+// retry expansion strips gc.scope_role from the first attempt, leaving gc.step_id
+// as the only durable link back to the teardown step.
+func teardownTailExclusion(store beads.Store, rootID string) (func(beads.Bead) bool, error) {
+	members, err := molecule.ListSubtree(store, rootID)
+	if err != nil {
+		return nil, err
+	}
+	teardownStepIDs := make(map[string]struct{})
+	for _, member := range members {
+		if member.Metadata[beadmeta.ScopeRoleMetadataKey] != beadmeta.ScopeRoleTeardown {
+			continue
+		}
+		if stepID := strings.TrimSpace(member.Metadata[beadmeta.StepIDMetadataKey]); stepID != "" {
+			teardownStepIDs[stepID] = struct{}{}
+		}
+	}
+	return func(member beads.Bead) bool {
+		if member.Metadata[beadmeta.ScopeRoleMetadataKey] == beadmeta.ScopeRoleTeardown {
+			return true
+		}
+		stepID := strings.TrimSpace(member.Metadata[beadmeta.StepIDMetadataKey])
+		if stepID == "" {
+			return false
+		}
+		_, ok := teardownStepIDs[stepID]
+		return ok
+	}, nil
 }
 
 func preflightSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions) error {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
@@ -10073,4 +10074,476 @@ func TestAbortScopeSharedConvergence(t *testing.T) {
 			t.Fatalf("trace missing %q:\n%s", want, traceText)
 		}
 	}
+}
+
+// Teardown-scoped work is post-settlement by contract: a teardown step's pass
+// condition may (and for worktree cleanup does) branch on the root outcome that
+// only workflow-finalize produces. These tests pin both halves of that contract
+// (ga-99u0u): finalize does not wait for the teardown tail, and finalize's
+// terminal sweep does not skip-close it either.
+
+// TestProcessWorkflowFinalizeSettlesWithOpenTeardownTail pins the runtime half:
+// settlement proceeds with an open teardown control + attempt, the tail survives
+// the terminal sweep, and a non-teardown straggler is still swept.
+func TestProcessWorkflowFinalizeSettlesWithOpenTeardownTail(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            "workflow",
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "Body",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindScope,
+			beadmeta.ScopeRoleMetadataKey:  beadmeta.ScopeRoleBody,
+			beadmeta.RootBeadIDMetadataKey: workflow.ID,
+			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomePass,
+		},
+	})
+	teardownControl := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Clean up the worktree (retry)",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindRetry,
+			beadmeta.OriginalKindMetadataKey: beadmeta.KindCleanup,
+			beadmeta.RootBeadIDMetadataKey:   workflow.ID,
+			beadmeta.ScopeRefMetadataKey:     "body",
+			beadmeta.ScopeRoleMetadataKey:    beadmeta.ScopeRoleTeardown,
+			beadmeta.StepIDMetadataKey:       "cleanup-worktree",
+			beadmeta.MaxAttemptsMetadataKey:  "3",
+			beadmeta.OnExhaustedMetadataKey:  "hard_fail",
+		},
+	})
+	teardownAttempt := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Clean up the worktree",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindCleanup,
+			beadmeta.RootBeadIDMetadataKey: workflow.ID,
+			beadmeta.StepIDMetadataKey:     "cleanup-worktree",
+			beadmeta.ControlForMetadataKey: "cleanup-worktree",
+			beadmeta.AttemptMetadataKey:    "1",
+		},
+	})
+	straggler := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "partially materialized step that can no longer execute",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: workflow.ID,
+			beadmeta.StepRefMetadataKey:    "unused",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindWorkflowFinalize,
+			beadmeta.RootBeadIDMetadataKey: workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+	mustDepAdd(t, store, finalizer.ID, body.ID, "blocks")
+	mustDepAdd(t, store, teardownControl.ID, teardownAttempt.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("workflow result = %+v, want processed workflow-pass", result)
+	}
+
+	rootAfter := mustGetBead(t, store, workflow.ID)
+	if rootAfter.Status != "closed" || rootAfter.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomePass {
+		t.Fatalf("root status/outcome = %q/%q, want closed/pass",
+			rootAfter.Status, rootAfter.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+	for _, id := range []string{teardownControl.ID, teardownAttempt.ID} {
+		after := mustGetBead(t, store, id)
+		if after.Status != "open" {
+			t.Fatalf("teardown member %s status = %q (outcome %q), want open: the real cleanup must still run after settlement",
+				id, after.Status, after.Metadata[beadmeta.OutcomeMetadataKey])
+		}
+	}
+	// Control for the exemption predicate: the sweep still repairs partial
+	// materializations, so a non-teardown straggler is closed skipped.
+	stragglerAfter := mustGetBead(t, store, straggler.ID)
+	if stragglerAfter.Status != "closed" {
+		t.Fatalf("non-teardown straggler status = %q, want closed", stragglerAfter.Status)
+	}
+	if got := stragglerAfter.Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomeSkipped {
+		t.Fatalf("non-teardown straggler gc.outcome = %q, want skipped", got)
+	}
+}
+
+// TestProcessWorkflowFinalizePendsOnOpenNonTeardownBlocker is the control for
+// the sink change: settlement still gates on real work.
+func TestProcessWorkflowFinalizePendsOnOpenNonTeardownBlocker(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            "workflow",
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+		},
+	})
+	work := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "Work",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: workflow.ID},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindWorkflowFinalize,
+			beadmeta.RootBeadIDMetadataKey: workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+	mustDepAdd(t, store, finalizer.ID, work.ID, "blocks")
+
+	if _, err := ProcessControl(store, finalizer, ProcessOptions{}); !errors.Is(err, ErrControlPending) {
+		t.Fatalf("ProcessControl(workflow-finalize) err = %v, want ErrControlPending", err)
+	}
+	if after := mustGetBead(t, store, workflow.ID); after.Status != "open" {
+		t.Fatalf("root status = %q, want open while a non-teardown blocker is open", after.Status)
+	}
+}
+
+const teardownSettlementFormula = `
+formula = "teardown-settlement"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "work"
+title = "Work"
+metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "member", "gc.on_fail" = "abort_scope" }
+
+[steps.retry]
+max_attempts = 3
+on_exhausted = "hard_fail"
+
+[[steps]]
+id = "body"
+title = "Body"
+needs = ["work"]
+metadata = { "gc.kind" = "scope", "gc.scope_role" = "body", "gc.scope_name" = "worktree" }
+
+[[steps]]
+id = "cleanup-worktree"
+title = "Clean up the worktree"
+needs = ["body"]
+metadata = { "gc.kind" = "cleanup", "gc.scope_ref" = "body", "gc.scope_role" = "teardown" }
+
+[steps.retry]
+max_attempts = 3
+on_exhausted = "hard_fail"
+`
+
+// cookTeardownMolecule materializes the teardown-settlement formula into store
+// exactly as the real materializer would (compile → instantiate) and returns the
+// workflow root ID.
+func cookTeardownMolecule(t *testing.T, store beads.Store) string {
+	t.Helper()
+	formulatest.EnableV2ForTest(t)
+	prevGraphApply := molecule.IsGraphApplyEnabled()
+	molecule.SetGraphApplyEnabled(true)
+	t.Cleanup(func() { molecule.SetGraphApplyEnabled(prevGraphApply) })
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "teardown-settlement.toml"), []byte(teardownSettlementFormula), 0o644); err != nil {
+		t.Fatalf("writing formula: %v", err)
+	}
+	result, err := molecule.Cook(context.Background(), store, "teardown-settlement", []string{dir}, molecule.Options{})
+	if err != nil {
+		t.Fatalf("Cook: %v", err)
+	}
+	if result.RootID == "" {
+		t.Fatal("Cook returned no root bead")
+	}
+	return result.RootID
+}
+
+// runMolecule drives a materialized molecule to quiescence with a fake worker
+// and the control dispatcher, mirroring how a city actually converges: every
+// ready control bead is served by ProcessControl, and every ready work bead is
+// closed by the worker.
+//
+// Controls are served before work in each round because that is the real
+// timing: the dispatcher ticks in seconds while an agent takes minutes on a
+// work bead, so the state a worker observes is the state after the dispatcher
+// has drained everything ready.
+//
+// The worker reproduces the pack's premature-teardown guard: a cleanup attempt
+// picked up before the root has settled closes transient ("root_not_closed_yet")
+// because the run outcome it must branch on does not exist yet. Non-teardown
+// work closes with workOutcome.
+func runMolecule(t *testing.T, store beads.Store, rootID, workOutcome string) {
+	t.Helper()
+	const maxRounds = 60
+	for round := 0; round < maxRounds; round++ {
+		members, err := molecule.ListSubtree(store, rootID)
+		if err != nil {
+			t.Fatalf("listing molecule members: %v", err)
+		}
+		slices.SortFunc(members, func(a, b beads.Bead) int { return strings.Compare(a.ID, b.ID) })
+		teardownSteps := teardownStepIDs(members)
+
+		progressed := false
+		for _, servingControls := range []bool{true, false} {
+			for _, member := range members {
+				current := mustGetBead(t, store, member.ID)
+				if current.Status != "open" || current.ID == rootID {
+					continue
+				}
+				kind := current.Metadata[beadmeta.KindMetadataKey]
+				if kind == beadmeta.KindSpec || kind == beadmeta.KindScope {
+					// Sidecars and scope latches are closed by the runtime,
+					// never by a worker.
+					continue
+				}
+				if beadmeta.IsControlKind(kind) != servingControls {
+					continue
+				}
+				if !allBlockersClosed(t, store, current.ID) {
+					continue
+				}
+				if servingControls {
+					_, err := ProcessControl(store, current, ProcessOptions{})
+					if errors.Is(err, ErrControlPending) {
+						continue
+					}
+					if err != nil {
+						t.Fatalf("ProcessControl(%s kind=%s): %v", current.ID, kind, err)
+					}
+					progressed = true
+					continue
+				}
+				closeAsWorker(t, store, current, rootID, workOutcome, teardownSteps)
+				progressed = true
+			}
+			if progressed && servingControls {
+				// A served control can make more controls ready; re-observe
+				// before handing anything to a worker.
+				break
+			}
+		}
+		if !progressed {
+			return
+		}
+	}
+	t.Fatalf("molecule %s never reached quiescence:\n%s", rootID, memberReport(t, store, rootID))
+}
+
+func allBlockersClosed(t *testing.T, store beads.Store, beadID string) bool {
+	t.Helper()
+	deps, err := store.DepList(beadID, "down")
+	if err != nil {
+		t.Fatalf("dep list %s: %v", beadID, err)
+	}
+	for _, dep := range deps {
+		if dep.Type != "blocks" {
+			continue
+		}
+		if mustGetBead(t, store, dep.DependsOnID).Status != "closed" {
+			return false
+		}
+	}
+	return true
+}
+
+func closeAsWorker(t *testing.T, store beads.Store, bead beads.Bead, rootID, workOutcome string, teardownSteps map[string]bool) {
+	t.Helper()
+	metadata := map[string]string{beadmeta.OutcomeMetadataKey: workOutcome}
+	if workOutcome == beadmeta.OutcomeFail {
+		metadata[beadmeta.FailureClassMetadataKey] = beadmeta.FailureClassHard
+		metadata[beadmeta.FailureReasonMetadataKey] = "work_failed"
+	}
+	if isTeardownAttempt(bead, teardownSteps) {
+		if mustGetBead(t, store, rootID).Status == "closed" {
+			// The root outcome exists: the real cleanup can branch on it.
+			metadata = map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomePass}
+		} else {
+			metadata = map[string]string{
+				beadmeta.OutcomeMetadataKey:       beadmeta.OutcomeFail,
+				beadmeta.FailureClassMetadataKey:  beadmeta.FailureClassTransient,
+				beadmeta.FailureReasonMetadataKey: "root_not_closed_yet",
+			}
+		}
+	}
+	if err := updateMetadataAndClose(store, bead.ID, metadata); err != nil {
+		t.Fatalf("worker close %s: %v", bead.ID, err)
+	}
+}
+
+// teardownStepIDs collects the gc.step_id of every teardown-scoped member. The
+// same step runs for every attempt, so this is what identifies an attempt as
+// teardown work — the attempt beads themselves are inconsistent about it
+// (attempt 1 has gc.scope_role stripped by retry expansion; re-spawned attempts
+// inherit it from the frozen step spec).
+func teardownStepIDs(members []beads.Bead) map[string]bool {
+	out := make(map[string]bool)
+	for _, member := range members {
+		if member.Metadata[beadmeta.ScopeRoleMetadataKey] != beadmeta.ScopeRoleTeardown {
+			continue
+		}
+		if stepID := member.Metadata[beadmeta.StepIDMetadataKey]; stepID != "" {
+			out[stepID] = true
+		}
+	}
+	return out
+}
+
+func isTeardownAttempt(bead beads.Bead, teardownSteps map[string]bool) bool {
+	if bead.Metadata[beadmeta.AttemptMetadataKey] == "" {
+		return false
+	}
+	return teardownSteps[bead.Metadata[beadmeta.StepIDMetadataKey]]
+}
+
+func memberReport(t *testing.T, store beads.Store, rootID string) string {
+	t.Helper()
+	members, err := molecule.ListSubtree(store, rootID)
+	if err != nil {
+		t.Fatalf("listing molecule members: %v", err)
+	}
+	slices.SortFunc(members, func(a, b beads.Bead) int { return strings.Compare(a.ID, b.ID) })
+	lines := make([]string, 0, len(members))
+	for _, member := range members {
+		lines = append(lines, strings.Join([]string{
+			"  " + member.ID,
+			member.Status,
+			"kind=" + member.Metadata[beadmeta.KindMetadataKey],
+			"step_ref=" + member.Metadata[beadmeta.StepRefMetadataKey],
+			"outcome=" + member.Metadata[beadmeta.OutcomeMetadataKey],
+		}, " "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// teardownTailBeads returns the teardown retry control and its single attempt.
+// Exactly one attempt is the assertion: a second attempt means the cleanup was
+// dispatched before the root settled and burned a transient retry on the
+// root-outcome guard.
+func teardownTailBeads(t *testing.T, store beads.Store, rootID string) (control, attempt beads.Bead) {
+	t.Helper()
+	members, err := molecule.ListSubtree(store, rootID)
+	if err != nil {
+		t.Fatalf("listing molecule members: %v", err)
+	}
+	teardownSteps := teardownStepIDs(members)
+	attempts := make([]beads.Bead, 0, 1)
+	for _, member := range members {
+		switch {
+		case member.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindRetry &&
+			member.Metadata[beadmeta.ScopeRoleMetadataKey] == beadmeta.ScopeRoleTeardown:
+			control = member
+		case isTeardownAttempt(member, teardownSteps):
+			attempts = append(attempts, member)
+		}
+	}
+	if control.ID == "" {
+		t.Fatalf("no teardown retry control in molecule:\n%s", memberReport(t, store, rootID))
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("teardown attempts = %d, want exactly 1 (extra attempts mean the cleanup ran before settlement):\n%s",
+			len(attempts), memberReport(t, store, rootID))
+	}
+	return control, attempts[0]
+}
+
+func assertNoOpenMembers(t *testing.T, store beads.Store, rootID string) {
+	t.Helper()
+	members, err := molecule.ListSubtree(store, rootID)
+	if err != nil {
+		t.Fatalf("listing molecule members: %v", err)
+	}
+	for _, member := range members {
+		if member.Status == "open" {
+			t.Fatalf("molecule %s still has open members after convergence:\n%s", rootID, memberReport(t, store, rootID))
+		}
+	}
+}
+
+// TestTeardownTailClosesItselfAfterSettlement is the end-to-end control: a
+// molecule materialized from a formula with a retry-managed teardown step
+// converges to zero open members with no hand-close. Settlement happens first
+// (the teardown tail is not a finalize blocker), the real cleanup then passes
+// its root-outcome guard, and the retry control closes itself.
+//
+// It also pins the outcome-poisoning regression: before the fix, the teardown
+// control was a finalize sink, so its attempts exhausted transient
+// "root_not_closed_yet" and hard-failed, flipping a green run to fail.
+func TestTeardownTailClosesItselfAfterSettlement(t *testing.T) {
+	store := beads.NewMemStore()
+	rootID := cookTeardownMolecule(t, store)
+
+	runMolecule(t, store, rootID, beadmeta.OutcomePass)
+
+	root := mustGetBead(t, store, rootID)
+	if root.Status != "closed" {
+		t.Fatalf("root status = %q, want closed:\n%s", root.Status, memberReport(t, store, rootID))
+	}
+	if got := root.Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomePass {
+		t.Fatalf("root gc.outcome = %q, want pass — a teardown control must not grade the run:\n%s",
+			got, memberReport(t, store, rootID))
+	}
+
+	control, attempt := teardownTailBeads(t, store, rootID)
+	control = mustGetBead(t, store, control.ID)
+	attempt = mustGetBead(t, store, attempt.ID)
+	if got := attempt.Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomePass {
+		t.Fatalf("teardown attempt %s gc.outcome = %q, want pass (it must run, not be skip-closed)", attempt.ID, got)
+	}
+	if got := attempt.Metadata["close_reason"]; got == sourceworkflow.WorkflowSkippedCloseReason {
+		t.Fatalf("teardown attempt %s was swept by the terminal close, not executed", attempt.ID)
+	}
+	if got := control.Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomePass {
+		t.Fatalf("teardown control %s gc.outcome = %q, want pass (the dispatcher must serve it after settlement)", control.ID, got)
+	}
+	if got := control.Metadata["close_reason"]; got == sourceworkflow.WorkflowSkippedCloseReason {
+		t.Fatalf("teardown control %s was swept by the terminal close, not served", control.ID)
+	}
+	assertNoOpenMembers(t, store, rootID)
+}
+
+// TestTeardownTailClosesItselfAfterFailedSettlement pins the fail branch: the
+// run settles fail, the teardown still runs afterwards (that is how
+// preserve-the-worktree-on-failure becomes reachable), and its own outcome
+// never re-grades the root.
+func TestTeardownTailClosesItselfAfterFailedSettlement(t *testing.T) {
+	store := beads.NewMemStore()
+	rootID := cookTeardownMolecule(t, store)
+
+	runMolecule(t, store, rootID, beadmeta.OutcomeFail)
+
+	root := mustGetBead(t, store, rootID)
+	if root.Status != "closed" {
+		t.Fatalf("root status = %q, want closed:\n%s", root.Status, memberReport(t, store, rootID))
+	}
+	if got := root.Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomeFail {
+		t.Fatalf("root gc.outcome = %q, want fail:\n%s", got, memberReport(t, store, rootID))
+	}
+
+	control, attempt := teardownTailBeads(t, store, rootID)
+	if got := mustGetBead(t, store, attempt.ID).Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomePass {
+		t.Fatalf("teardown attempt %s gc.outcome = %q, want pass after a failed settlement", attempt.ID, got)
+	}
+	if got := mustGetBead(t, store, control.ID).Metadata[beadmeta.OutcomeMetadataKey]; got != beadmeta.OutcomePass {
+		t.Fatalf("teardown control %s gc.outcome = %q, want pass after a failed settlement", control.ID, got)
+	}
+	assertNoOpenMembers(t, store, rootID)
 }

--- a/internal/formula/graph.go
+++ b/internal/formula/graph.go
@@ -180,6 +180,17 @@ func graphSinkStepIDs(steps []*Step) []string {
 		if step == nil {
 			continue
 		}
+		// Teardown-scoped work is post-settlement by contract: its pass
+		// condition may (and for worktree cleanup does) branch on the root
+		// outcome that only workflow-finalize produces. Sinking it here closes
+		// that loop into a settlement deadlock — finalize waits on the
+		// teardown, the teardown waits on the outcome finalize would have
+		// written. Retry/ralph controls minted from a teardown step retain
+		// gc.scope_role=teardown, so one predicate covers the raw step and
+		// every control shape derived from it.
+		if step.Metadata[beadmeta.ScopeRoleMetadataKey] == beadmeta.ScopeRoleTeardown {
+			continue
+		}
 		switch step.Metadata[beadmeta.KindMetadataKey] {
 		case "workflow-finalize", "spec":
 			continue

--- a/internal/formula/graph_test.go
+++ b/internal/formula/graph_test.go
@@ -436,6 +436,158 @@ func TestNeedsScopeCheckTracksBeadmetaExemptKinds(t *testing.T) {
 	}
 }
 
+// teardownSinkFormula builds the mol-adopt-pr-v2 / mol-scoped-work shape: a
+// body scope over one member step, plus a cleanup step that needs the body.
+// role is the cleanup step's gc.scope_role, which is the only variable under
+// test.
+func teardownSinkFormula(role string) *Formula {
+	return &Formula{
+		Steps: []*Step{
+			{
+				ID:    "work",
+				Title: "Work",
+				Type:  "task",
+				Metadata: map[string]string{
+					beadmeta.ScopeRefMetadataKey:  "body",
+					beadmeta.ScopeRoleMetadataKey: beadmeta.ScopeRoleMember,
+					beadmeta.OnFailMetadataKey:    "abort_scope",
+				},
+				Retry: &RetrySpec{MaxAttempts: 3, OnExhausted: "hard_fail"},
+			},
+			{
+				ID:    "body",
+				Title: "Body",
+				Type:  "task",
+				Needs: []string{"work"},
+				Metadata: map[string]string{
+					beadmeta.KindMetadataKey:      beadmeta.KindScope,
+					beadmeta.ScopeRoleMetadataKey: beadmeta.ScopeRoleBody,
+					beadmeta.ScopeNameMetadataKey: "worktree",
+				},
+			},
+			{
+				ID:    "cleanup-worktree",
+				Title: "Clean up the worktree",
+				Type:  "task",
+				Needs: []string{"body"},
+				Metadata: map[string]string{
+					beadmeta.KindMetadataKey:      beadmeta.KindCleanup,
+					beadmeta.ScopeRefMetadataKey:  "body",
+					beadmeta.ScopeRoleMetadataKey: role,
+				},
+				Retry: &RetrySpec{MaxAttempts: 3, OnExhausted: "hard_fail"},
+			},
+		},
+	}
+}
+
+func compileGraphSteps(t *testing.T, f *Formula) []*Step {
+	t.Helper()
+	expanded, err := ApplyRetries(f.Steps)
+	if err != nil {
+		t.Fatalf("ApplyRetries: %v", err)
+	}
+	f.Steps = expanded
+	ApplyGraphControls(f)
+	return collectGraphSteps(f.Steps)
+}
+
+// TestWorkflowFinalizeExcludesTeardownSinks pins the settlement contract for
+// teardown-scoped work (ga-99u0u): teardown runs AFTER the root settles, so it
+// must never be a workflow-finalize sink. Sinking it deadlocks settlement —
+// finalize blocks on the teardown retry control, the control blocks on its
+// attempt, and the attempt's own pass condition waits for the root outcome
+// only finalize can produce.
+func TestWorkflowFinalizeExcludesTeardownSinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("teardown role never gates finalize", func(t *testing.T) {
+		t.Parallel()
+
+		steps := compileGraphSteps(t, teardownSinkFormula(beadmeta.ScopeRoleTeardown))
+		finalizer := findGraphStepByID(steps, "workflow-finalize")
+		if finalizer == nil {
+			t.Fatal("missing workflow-finalize")
+		}
+		if !containsString(finalizer.Needs, "body") {
+			t.Fatalf("workflow-finalize needs = %v, want the body scope latch", finalizer.Needs)
+		}
+		for _, excluded := range []string{
+			"cleanup-worktree",
+			"cleanup-worktree.attempt.1",
+			"cleanup-worktree-scope-check",
+		} {
+			if containsString(finalizer.Needs, excluded) {
+				t.Fatalf("workflow-finalize needs = %v, must not include teardown step %q", finalizer.Needs, excluded)
+			}
+		}
+	})
+
+	// Control: the same cleanup step differing only in gc.scope_role still
+	// reaches finalize through its minted scope-check. Proves the exclusion
+	// keys on the teardown role, not on gc.kind=cleanup and not on retry
+	// controls in general.
+	t.Run("member role still gates finalize", func(t *testing.T) {
+		t.Parallel()
+
+		steps := compileGraphSteps(t, teardownSinkFormula(beadmeta.ScopeRoleMember))
+		finalizer := findGraphStepByID(steps, "workflow-finalize")
+		if finalizer == nil {
+			t.Fatal("missing workflow-finalize")
+		}
+		if !containsString(finalizer.Needs, "cleanup-worktree-scope-check") {
+			t.Fatalf("workflow-finalize needs = %v, want the member-role cleanup's scope-check", finalizer.Needs)
+		}
+	})
+
+	// Control: an unscoped retry-managed step keeps its control as a sink, so
+	// the exclusion cannot be silently swallowing every retry control.
+	t.Run("unscoped retry control still gates finalize", func(t *testing.T) {
+		t.Parallel()
+
+		f := teardownSinkFormula(beadmeta.ScopeRoleTeardown)
+		f.Steps = append(f.Steps, &Step{
+			ID:    "notify",
+			Title: "Notify",
+			Type:  "task",
+			Retry: &RetrySpec{MaxAttempts: 2, OnExhausted: "hard_fail"},
+		})
+		steps := compileGraphSteps(t, f)
+		finalizer := findGraphStepByID(steps, "workflow-finalize")
+		if finalizer == nil {
+			t.Fatal("missing workflow-finalize")
+		}
+		if !containsString(finalizer.Needs, "notify") {
+			t.Fatalf("workflow-finalize needs = %v, want the unscoped retry control", finalizer.Needs)
+		}
+	})
+
+	// Control: a bare (non-retry) teardown step is excluded too — the sink
+	// rule is about the teardown role, not about the control shapes retry
+	// expansion happens to mint.
+	t.Run("bare teardown step never gates finalize", func(t *testing.T) {
+		t.Parallel()
+
+		f := teardownSinkFormula(beadmeta.ScopeRoleTeardown)
+		cleanup := findGraphStepByID(f.Steps, "cleanup-worktree")
+		if cleanup == nil {
+			t.Fatal("missing cleanup-worktree in fixture")
+		}
+		cleanup.Retry = nil
+		steps := compileGraphSteps(t, f)
+		finalizer := findGraphStepByID(steps, "workflow-finalize")
+		if finalizer == nil {
+			t.Fatal("missing workflow-finalize")
+		}
+		if containsString(finalizer.Needs, "cleanup-worktree") {
+			t.Fatalf("workflow-finalize needs = %v, must not include the bare teardown step", finalizer.Needs)
+		}
+		if !containsString(finalizer.Needs, "body") {
+			t.Fatalf("workflow-finalize needs = %v, want the body scope latch", finalizer.Needs)
+		}
+	})
+}
+
 func findGraphStepByID(steps []*Step, id string) *Step {
 	for _, step := range steps {
 		if step != nil && step.ID == id {

--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -101,6 +101,17 @@ func CloseSubtree(store beads.Store, rootID string) (int, error) {
 // descendant-first, blocker-first ordering and is idempotent for an already
 // closed subtree.
 func CloseSubtreeWithMetadata(store beads.Store, rootID string, metadata map[string]string) (int, error) {
+	return CloseSubtreeWithMetadataExcept(store, rootID, metadata, nil)
+}
+
+// CloseSubtreeWithMetadataExcept is CloseSubtreeWithMetadata with an exclusion
+// predicate: any member for which exclude reports true is left untouched. A nil
+// predicate closes the whole subtree.
+//
+// The exclusion exists for members that stay executable after their molecule
+// reaches a terminal state — teardown work, which by contract runs after the
+// root settles. Callers own the policy; this function only skips.
+func CloseSubtreeWithMetadataExcept(store beads.Store, rootID string, metadata map[string]string, exclude func(beads.Bead) bool) (int, error) {
 	matched, err := ListSubtree(store, rootID)
 	if err != nil {
 		return 0, err
@@ -148,6 +159,9 @@ func CloseSubtreeWithMetadata(store beads.Store, rootID string, metadata map[str
 	ids := make([]string, 0, len(matched))
 	for _, bead := range matched {
 		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		if exclude != nil && exclude(bead) {
 			continue
 		}
 		ids = append(ids, bead.ID)


### PR DESCRIPTION
Fixes the settlement deadlock that made every adopt-pr molecule require one hand-close to finish (bead ga-99u0u): the teardown step's retry control — minted by `expandRetry` because teardown carries `[steps.retry]` — became a `workflow-finalize` sink via `graphSinkStepIDs`' unreferenced-step rule, producing the triangle: finalize blocks on the control → the control waits on its attempt → the attempt cannot pass until `ROOT_OUTCOME` → which only finalize produces. Worse latent case, reproduced end-to-end in this PR's red tail: if the control ever got served, three transient `root_not_closed_yet` attempts exhaust to `fail` and **poison a fully-green run to FAIL** via the scope re-grade.

Two patches, each proven independently necessary (isolation runs):
1. `graphSinkStepIDs` skips `scope_role=teardown` steps — finalize no longer needs the teardown tail. Formula-compile verification on the real `mol-adopt-pr-v2.toml`: exactly one dep edge removed (107→106), step set byte-identical; the other five teardown-bearing pack formulas compile with zero dep changes (their teardown was always explicitly referenced).
2. The terminal subtree sweep exempts the teardown tail (`CloseSubtreeWithMetadataExcept` + `dispatch.teardownTailExclusion`) — without it, settlement instantly skip-closes the real cleanup and leaks the worktree every time (patch-1-only isolation red).

E2E: root settles pass → cleanup attempt passes its guard → the retry control serves itself pass → zero open members, no hand-close. Docs: the sink exclusion and sweep exemption added to `formula-spec-v2.md` (user-visible contract).

Deploy note: pre-fix molecules keep the bad dep edge — the one-time sweep (teardown-scope retry/ralph controls with closed bodies → close skipped) is folded into the staged relic-sweep runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
