### PR TITLE
fix(beads): retry serialization conflicts on NativeDoltStore Close and Reopen

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1118,8 +1118,47 @@ func (s *NativeDoltStore) Close(id string) error {
 		return err
 	}
 	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
+
+	return retryOnNativeDoltSerializationConflict(func() error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		return s.closeOnce(ctx, storage, id)
+	})
+}
+
+// closeOnce performs one complete close attempt, read included. A retry calls
+// this whole operation rather than just the write, so every attempt decides
+// from freshly read state.
+//
+// Replaying the write is safe because a serialization conflict guarantees the
+// write did not land, and because every CloseIssue path commits exactly once.
+// There are three such paths and they do not share a mechanism, so the property
+// is stated per branch rather than asserted for "both backends":
+//
+//   - dolt.DoltStore, permanent bead: withRetryTx/withWriteTx (issues.go
+//     CloseIssue).
+//   - dolt.DoltStore, active wisp: CloseIssue branches to closeWisp, which uses
+//     a bare BeginTx/Commit with a deferred Rollback and deliberately no
+//     withRetryTx. Its own comment says not to add one, which is precisely why
+//     the retry belongs out here: that path has no internal retry at all.
+//   - embeddeddolt.EmbeddedDoltStore: one withConn transaction.
+//
+// Single-commit is the whole argument, so contrast it with a real two-commit
+// caller rather than a guessed one: beadslib's RunInTransaction commits the
+// regular tx and the ignored tx separately and can fail after the first landed,
+// which is why its callers cannot simply replay. SetMetadataBatch is NOT such a
+// caller despite the shape of its name; it calls storage.UpdateIssue directly,
+// which branches the same three ways Close does: permanent Dolt under
+// withRetryTx, active wisps through updateWisp's bare BeginTx/Commit, and
+// embedded under withConn. Close has no two-commit window on any branch.
+//
+// The re-read is what makes an attempt correct in the presence of OTHER
+// writers, which is a live case rather than a hypothetical: the retry sleeps
+// between attempts, so a concurrent actor can close the bead in that gap. The
+// short-circuit returns nil instead of issuing a redundant CloseIssue, and
+// recomputing the reason per attempt keeps it consistent with the state the
+// attempt actually observed.
+func (s *NativeDoltStore) closeOnce(ctx context.Context, storage beadslib.Storage, id string) error {
 	current, err := storage.GetIssue(ctx, id)
 	if err != nil {
 		return nativeStoreError(id, err)
@@ -1144,8 +1183,29 @@ func (s *NativeDoltStore) Reopen(id string) error {
 		return err
 	}
 	defer release()
-	ctx, cancel := nativeDoltOperationContext(context.TODO())
-	defer cancel()
+
+	return retryOnNativeDoltSerializationConflict(func() error {
+		ctx, cancel := nativeDoltOperationContext(context.TODO())
+		defer cancel()
+		return s.reopenOnce(ctx, storage, id)
+	})
+}
+
+// reopenOnce is closeOnce's mirror and is safe to replay for the same reason:
+// a serialization conflict means the write did not land, and the re-read
+// short-circuits an already-open bead. The two short-circuits are separate
+// lines testing separate statuses, so each is proven by its own test rather
+// than by symmetry with the other.
+//
+// The empty reason below is load-bearing, not incidental. beadslib's
+// ReopenIssue performs UpdateIssue and then, ONLY when reason is non-empty, a
+// separate AddComment in its own transaction. Passing a real reason would
+// therefore split this into two independent writes and reintroduce exactly the
+// window this function does not otherwise have: if the update commits and the
+// comment conflicts, the replay re-reads, sees StatusOpen, short-circuits, and
+// the comment is silently dropped. Anything that starts passing a reason has to
+// move the comment inside the retried unit or make its loss explicit.
+func (s *NativeDoltStore) reopenOnce(ctx context.Context, storage beadslib.Storage, id string) error {
 	current, err := storage.GetIssue(ctx, id)
 	if err != nil {
 		return nativeStoreError(id, err)

--- a/internal/beads/native_dolt_store_close_retry_test.go
+++ b/internal/beads/native_dolt_store_close_retry_test.go
@@ -1,0 +1,277 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// closeReopenSpy serves an issue whose status can flip mid-retry, so a replayed
+// attempt re-reads current state rather than a frozen snapshot. That is the
+// whole point: Close and Reopen re-read inside the attempt, so a replay decides
+// from what the store holds now.
+//
+// The mutate callback controls the status flip independently of the returned
+// error, which lets a test model a concurrent writer closing the bead BETWEEN
+// attempts. Read that word literally: the callback runs synchronously inside
+// the failing attempt, before it returns its conflict, so these tests do not
+// exercise backoff timing and deleting the sleep would not turn them red. What
+// they do establish is the property that matters, that a replay re-reads and
+// short-circuits on state another actor left behind. Testing the timing itself
+// would need an injectable backoff, which is not worth building for this.
+//
+// Note what these tests deliberately do NOT model: a conflict reported after
+// this store's own write committed. That cannot happen on this path, because
+// every CloseIssue branch commits exactly once (permanent, wisp, and embedded
+// alike). See closeOnce's comment in native_dolt_store.go for the per-branch
+// argument; do not restate it here, since the two copies drifted once already.
+type closeReopenSpy struct {
+	*nativeDoltStorageSpy
+	gets    int32
+	mutates int32
+}
+
+// newCloseSpy returns a spy whose issue starts open. closeIssue runs mutate,
+// which decides what that attempt does to the stored status and what it
+// returns, so a test can model "a concurrent actor closed it before the replay"
+// as easily as "this attempt lost the race and nothing landed".
+func newCloseSpy(mutate func(attempt int32, markClosed func()) error) *closeReopenSpy {
+	spy := &closeReopenSpy{}
+	closed := int32(0)
+	spy.nativeDoltStorageSpy = &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			atomic.AddInt32(&spy.gets, 1)
+			status := beadslib.StatusOpen
+			if atomic.LoadInt32(&closed) == 1 {
+				status = beadslib.StatusClosed
+			}
+			return &beadslib.Issue{ID: id, Status: status, IssueType: beadslib.TypeTask, Priority: 2}, nil
+		},
+		closeIssue: func(context.Context, string, string, string, string) error {
+			n := atomic.AddInt32(&spy.mutates, 1)
+			return mutate(n, func() { atomic.StoreInt32(&closed, 1) })
+		},
+	}
+	return spy
+}
+
+func TestNativeDoltStoreCloseRetriesSerializationConflict(t *testing.T) {
+	spy := newCloseSpy(func(attempt int32, markClosed func()) error {
+		if attempt == 1 {
+			// Lost the race: nothing landed.
+			return errors.New(serializationConflictErr)
+		}
+		markClosed()
+		return nil
+	})
+	store := newNativeDoltStoreForTest(spy)
+
+	if err := store.Close("gc-1"); err != nil {
+		t.Fatalf("Close after one serialization conflict: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&spy.mutates); got != 2 {
+		t.Fatalf("CloseIssue attempts = %d, want 2 (one conflict, one retry)", got)
+	}
+}
+
+// TestNativeDoltStoreCloseReplayShortCircuitsWhenAnotherActorClosedTheBead
+// covers why the re-read has to sit INSIDE the retried unit. This store loses
+// the race and a different writer closes the bead before the replay runs. The
+// replay must notice that and not issue a second close.
+//
+// The assertion that carries the weight is the CloseIssue count. Hoisting the
+// read out of the retry would leave the replay deciding from the first
+// snapshot, which still said open, and the count would be 2. The GetIssue
+// count is what proves the re-read actually happened rather than the status
+// short-circuit being reached some other way.
+func TestNativeDoltStoreCloseReplayShortCircuitsWhenAnotherActorClosedTheBead(t *testing.T) {
+	spy := newCloseSpy(func(attempt int32, markClosed func()) error {
+		if attempt == 1 {
+			// This attempt lost the race and wrote nothing; a concurrent
+			// actor closed the bead before the replay reads again. The
+			// flip is synchronous here, so this models ordering, not
+			// backoff timing.
+			markClosed()
+			return errors.New(serializationConflictErr)
+		}
+		t.Errorf("CloseIssue called %d times; the replay must short-circuit on the already-closed bead", attempt)
+		return nil
+	})
+	store := newNativeDoltStoreForTest(spy)
+
+	if err := store.Close("gc-1"); err != nil {
+		t.Fatalf("Close when another actor closed the bead mid-retry: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&spy.mutates); got != 1 {
+		t.Fatalf("CloseIssue attempts = %d, want 1 (the replay must not re-close)", got)
+	}
+	if got := atomic.LoadInt32(&spy.gets); got != 2 {
+		t.Fatalf("GetIssue reads = %d, want 2 (the replay must re-read, not reuse the first snapshot)", got)
+	}
+}
+
+func TestNativeDoltStoreCloseStopsAtAttemptLimit(t *testing.T) {
+	spy := newCloseSpy(func(int32, func()) error {
+		return errors.New(serializationConflictErr)
+	})
+	store := newNativeDoltStoreForTest(spy)
+
+	err := store.Close("gc-1")
+	if err == nil {
+		t.Fatal("Close with unrelenting conflicts: got nil, want the serialization error")
+	}
+	if !isNativeDoltSerializationConflict(err) {
+		t.Fatalf("returned error lost its serialization-conflict identity: %v", err)
+	}
+	if got := atomic.LoadInt32(&spy.mutates); got != int32(nativeWriteAttempts) {
+		t.Fatalf("CloseIssue attempts = %d, want %d", got, nativeWriteAttempts)
+	}
+}
+
+func TestNativeDoltStoreCloseDoesNotRetryNonConflictErrors(t *testing.T) {
+	spy := newCloseSpy(func(int32, func()) error {
+		return errors.New("Error 1062 (23000): duplicate entry")
+	})
+	store := newNativeDoltStoreForTest(spy)
+
+	err := store.Close("gc-1")
+	if err == nil || !strings.Contains(err.Error(), "duplicate entry") {
+		t.Fatalf("Close error = %v, want the duplicate-entry error", err)
+	}
+	if got := atomic.LoadInt32(&spy.mutates); got != 1 {
+		t.Fatalf("CloseIssue attempts = %d, want 1 (non-conflict errors must not retry)", got)
+	}
+}
+
+// TestNativeDoltStoreCloseAllRecoversWhenTheCloseConflictsAfterMetadataLanded
+// is the originally reported failure, at the level it was reported. CloseAll
+// calls the retried SetMetadataBatch and then Close. While Close was unretried,
+// a conflict there returned an error with the metadata already written, leaving
+// a bead carrying close metadata that was never closed. That reached users as
+// an HTTP 500 on session suspend.
+//
+// This test drives CloseAll rather than Close so the asymmetry itself is
+// guarded. Reverting the Close wrap alone leaves every direct-Close test in
+// this file failing, but nothing would record that the pairing is the point.
+func TestNativeDoltStoreCloseAllRecoversWhenTheCloseConflictsAfterMetadataLanded(t *testing.T) {
+	var (
+		closed   int32
+		metadata int32
+		closes   int32
+	)
+	issue := func(id string) *beadslib.Issue {
+		status := beadslib.StatusOpen
+		if atomic.LoadInt32(&closed) == 1 {
+			status = beadslib.StatusClosed
+		}
+		return &beadslib.Issue{ID: id, Status: status, IssueType: beadslib.TypeTask, Priority: 2}
+	}
+	spy := &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			return issue(id), nil
+		},
+		// CloseAll's own precondition read goes through Get, which uses
+		// SearchIssues rather than GetIssue.
+		searchIssues: func(_ context.Context, _ string, filter beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			out := make([]*beadslib.Issue, 0, len(filter.IDs))
+			for _, id := range filter.IDs {
+				out = append(out, issue(id))
+			}
+			return out, nil
+		},
+		updateIssue: func(context.Context, string, map[string]interface{}, string) error {
+			atomic.AddInt32(&metadata, 1)
+			return nil
+		},
+		closeIssue: func(context.Context, string, string, string, string) error {
+			if atomic.AddInt32(&closes, 1) == 1 {
+				return errors.New(serializationConflictErr)
+			}
+			atomic.StoreInt32(&closed, 1)
+			return nil
+		},
+	}
+	store := newNativeDoltStoreForTest(spy)
+
+	n, err := store.CloseAll([]string{"gc-1"}, map[string]string{"gc.close_reason": "suspended"})
+	if err != nil {
+		t.Fatalf("CloseAll with one conflicting close: got %v, want nil", err)
+	}
+	if n != 1 {
+		t.Fatalf("CloseAll closed = %d, want 1", n)
+	}
+	if got := atomic.LoadInt32(&closes); got != 2 {
+		t.Fatalf("CloseIssue attempts = %d, want 2 (one conflict, one retry)", got)
+	}
+	// The metadata write must not be replayed by the Close retry: the two are
+	// separately retried units, and only the inner one lost its race.
+	if got := atomic.LoadInt32(&metadata); got != 1 {
+		t.Fatalf("metadata writes = %d, want 1 (the Close retry must not re-run SetMetadataBatch)", got)
+	}
+}
+
+// newReopenSpy mirrors newCloseSpy for the opposite transition: the issue
+// starts closed and reopenIssue decides what each attempt does.
+func newReopenSpy(mutate func(attempt int32, markOpen func()) error) *closeReopenSpy {
+	spy := &closeReopenSpy{}
+	opened := int32(0)
+	spy.nativeDoltStorageSpy = &nativeDoltStorageSpy{
+		getIssue: func(_ context.Context, id string) (*beadslib.Issue, error) {
+			atomic.AddInt32(&spy.gets, 1)
+			status := beadslib.StatusClosed
+			if atomic.LoadInt32(&opened) == 1 {
+				status = beadslib.StatusOpen
+			}
+			return &beadslib.Issue{ID: id, Status: status, IssueType: beadslib.TypeTask, Priority: 2}, nil
+		},
+		reopenIssue: func(context.Context, string, string, string) error {
+			n := atomic.AddInt32(&spy.mutates, 1)
+			return mutate(n, func() { atomic.StoreInt32(&opened, 1) })
+		},
+	}
+	return spy
+}
+
+func TestNativeDoltStoreReopenRetriesSerializationConflict(t *testing.T) {
+	spy := newReopenSpy(func(attempt int32, markOpen func()) error {
+		if attempt == 1 {
+			return errors.New(serializationConflictErr)
+		}
+		markOpen()
+		return nil
+	})
+	store := newNativeDoltStoreForTest(spy)
+
+	if err := store.Reopen("gc-1"); err != nil {
+		t.Fatalf("Reopen after one serialization conflict: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&spy.mutates); got != 2 {
+		t.Fatalf("ReopenIssue attempts = %d, want 2 (one conflict, one retry)", got)
+	}
+}
+
+// Reopen carries the same already-in-target-state short-circuit as Close, so it
+// inherits the same replay behavior. Proven separately rather than assumed by
+// symmetry: the two guards are different lines against different statuses.
+func TestNativeDoltStoreReopenReplayShortCircuitsWhenAnotherActorReopenedTheBead(t *testing.T) {
+	spy := newReopenSpy(func(attempt int32, markOpen func()) error {
+		if attempt == 1 {
+			markOpen()
+			return errors.New(serializationConflictErr)
+		}
+		t.Errorf("ReopenIssue called %d times; the replay must short-circuit on the already-open bead", attempt)
+		return nil
+	})
+	store := newNativeDoltStoreForTest(spy)
+
+	if err := store.Reopen("gc-1"); err != nil {
+		t.Fatalf("Reopen when another actor reopened the bead mid-retry: got %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&spy.mutates); got != 1 {
+		t.Fatalf("ReopenIssue attempts = %d, want 1 (the replay must not re-open)", got)
+	}
+}


### PR DESCRIPTION
`CloseAll` calls the retried `SetMetadataBatch` and then an unretried `Close` for each bead. A Dolt serialization conflict on that `Close` left metadata written to a bead that never closed. Hardening only the first call had made the asymmetry worse: the half that survived a conflict was the half that did not matter. Users saw this as an HTTP 500 on session suspend, and CI saw it as a flake in `TestHumaBinary_SessionMessageAsync`.

This wraps `Close` and `Reopen` in the store's existing serialization-conflict retry, the same one `Create` and `Tx` already use.

### Why the retry is needed at this layer

The default backend has none. beadslib's embedded Dolt store, which `OpenBestAvailable` selects unless a config asks for server mode, runs `CloseIssue` as a bare `withConn` transaction, so a conflict surfaces straight to the caller. The server-mode store retries internally via `withRetryTx` and reaches this wrapper only after exhausting its own budget.

### Why replaying is safe

A serialization conflict guarantees the write did not land, and every `CloseIssue` path commits exactly once. There are three such paths and they do not share a mechanism, so the property holds per branch rather than by a single appeal:

- the permanent bead goes through `withRetryTx`/`withWriteTx`;
- an active wisp branches to `closeWisp`, a bare `BeginTx`/`Commit` that deliberately carries no `withRetryTx`, which makes it the branch that most wants an outer retry;
- the embedded backend runs one `withConn` transaction.

For contrast against a real two-commit caller rather than a guessed one: `RunInTransaction` commits the regular transaction and the ignored transaction separately and can fail with the first already committed, which is why its callers cannot simply replay. `SetMetadataBatch` is not one of them despite the name; it calls `UpdateIssue` directly. `Close` has no two-commit window on any branch.

Two details are load-bearing rather than incidental:

- Extracting `closeOnce`/`reopenOnce` puts the re-read inside the retried unit, so each attempt decides from fresh state. That matters against other writers, not against this store's own replay: the retry sleeps between attempts and a concurrent actor can close the bead in that gap.
- The reopen reason stays empty. beadslib's `ReopenIssue` performs a separate `AddComment` transaction when the reason is non-empty, which would split this into two independent writes and create the window the rest of the change relies on not existing.

### Tests

`internal/beads/native_dolt_store_close_retry_test.go` asserts the **mutation count**, not just the returned error. A replay that re-issued the write would still return `nil` while performing exactly the write this change exists to prevent. The motivating failure is guarded at the `CloseAll` level so the asymmetry itself is covered and not only its halves. Reverting either wrap turns the tests red at both levels.

### What this does not do, and why #5228 stays open

The retry classifier is untouched. `isNativeDoltSerializationConflict` matches error 1213, SQLSTATE 40001, and Dolt's conflict wording, but not a lock-wait timeout reported as `Error 1205 (HY000)`, so a 1205 still surfaces after one attempt here, exactly as it already does for the pre-existing `Create` and `Tx` wrappers. Widening the classifier changes retry behavior on call sites this change does not own and needs its own replay-safety argument per site.

The remaining unretried writes on this store also need per-site arguments, and they differ materially: `ReleaseIfCurrent` is a compare-and-swap, `Tx` composes caller-supplied operations whose replay safety belongs to the caller, and `Create` with `compensateFailedCreate` is a rollback pair where retrying one half alone could compensate a create that later succeeds.

Both items stay tracked in #5228, so this PR refs the issue rather than closing it.

### Test plan

- `go test ./internal/beads/ -run 'CloseRetry|Close|Reopen'`
- `go build ./...` and `go vet ./...`
- Full fast unit sweep green at this head.

### Review scope

Point fix inside the existing `NativeDoltStore` boundary: two files, no new package, no schema or public contract change, no new orchestration shape. Fixes a user-visible 500 and a CI flake.

Refs #5228
