### PR TITLE
feat(cmd/gc): assigned-work spine through the residency resolver (S2)

### DIFF
--- a/cmd/gc/assigned_work_class_binding_test.go
+++ b/cmd/gc/assigned_work_class_binding_test.go
@@ -13,6 +13,16 @@ import (
 
 // The ga-whzrt rows: a claim a rig-scoped worker HOLDS on the leading
 // class-binding arm must reach the wake machinery, and nothing else must.
+//
+// S2 PORT: the arm's ref is no longer the classBindingAssignedWorkStoreRef
+// constant but whatever assignedWorkClaimRefs resolves for the city, and the
+// split is expressed as SERVED ROUTES rather than as a [storage] section in
+// cfg. Those are the same change: the constant was the empty string because the
+// reconciler's leading arm happens to be the binding, and the cfg shape gate
+// answered "no split" for a city whose section was deleted after it had served
+// one. Both facts now come from the routes.
+//
+// The rows themselves are unchanged, which is the point of a pin.
 
 func rigScopedWakeFixture(t *testing.T) (*config.City, string, []sessionpkg.Info) {
 	t.Helper()
@@ -43,16 +53,39 @@ func rigScopedWakeFixture(t *testing.T) (*config.City, string, []sessionpkg.Info
 // exact identity — so the wake filter must keep it.
 func TestSessionWakeFilterKeepsAClaimOnTheClassBindingArm(t *testing.T) {
 	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
 	work := []beads.Bead{{ID: "gcg-1", Status: "in_progress", Assignee: "test-city--worker-1"}}
-	refs := []string{classBindingAssignedWorkStoreRef}
+	refs := []string{""}
 
-	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, infos, work, refs)
+	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, binding, infos, work, refs)
 
 	if len(kept) != 1 || kept[0].ID != "gcg-1" {
 		t.Fatalf("filtered work = %#v, want the binding-resident claim kept", kept)
 	}
-	if len(keptRefs) != 1 || keptRefs[0] != classBindingAssignedWorkStoreRef {
+	if len(keptRefs) != 1 || keptRefs[0] != "" {
 		t.Fatalf("filtered refs = %#v, want the binding arm's ref preserved", keptRefs)
+	}
+}
+
+// The mixed-version row (§7 attack 2): the same claim recorded under the
+// BINDING's own ref rather than under the leading arm's "". Nothing emits that
+// ref today — the census records the binding arm as the city arm — but S3 makes
+// it a distinct census leg, and a city rolling from one binary to the other has
+// rows of both shapes in flight. One filter has to read both.
+func TestSessionWakeFilterKeepsAClaimRecordedUnderTheBindingRef(t *testing.T) {
+	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	work := []beads.Bead{{ID: "gcg-1", Status: "in_progress", Assignee: "test-city--worker-1"}}
+	refs := []string{"class:gmnos"}
+
+	// A work-led plane: the leading store is NOT the binding, so the binding
+	// carries its own ref and both spellings are in the accepted set.
+	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, beads.NewMemStore(), infos, work, refs)
+
+	if len(kept) != 1 || kept[0].ID != "gcg-1" || len(keptRefs) != 1 || keptRefs[0] != "class:gmnos" {
+		t.Fatalf("filtered work = %#v refs = %#v, want the claim kept under the binding's own ref", kept, keptRefs)
 	}
 }
 
@@ -62,10 +95,12 @@ func TestSessionWakeFilterKeepsAClaimOnTheClassBindingArm(t *testing.T) {
 // and not a blanket "keep the leading arm".
 func TestSessionWakeFilterStillDropsAForeignClaimOnTheClassBindingArm(t *testing.T) {
 	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
 	work := []beads.Bead{{ID: "gcg-1", Status: "in_progress", Assignee: "test-city--someone-else"}}
-	refs := []string{classBindingAssignedWorkStoreRef}
+	refs := []string{""}
 
-	kept, _ := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, infos, work, refs)
+	kept, _ := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, binding, infos, work, refs)
 
 	if len(kept) != 0 {
 		t.Fatalf("filtered work = %#v, want a foreign assignee dropped", kept)
@@ -77,10 +112,12 @@ func TestSessionWakeFilterStillDropsAForeignClaimOnTheClassBindingArm(t *testing
 // session of the template on one another's stores.
 func TestSessionWakeFilterKeepsTemplateMatchesRigScoped(t *testing.T) {
 	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
 	work := []beads.Bead{{ID: "gcg-1", Status: "in_progress", Assignee: "riga/worker"}}
-	refs := []string{classBindingAssignedWorkStoreRef}
+	refs := []string{""}
 
-	kept, _ := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, infos, work, refs)
+	kept, _ := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, binding, infos, work, refs)
 
 	if len(kept) != 0 {
 		t.Fatalf("filtered work = %#v, want a template-key match to stay scoped to its rig store", kept)
@@ -93,12 +130,14 @@ func TestSessionWakeFilterKeepsTemplateMatchesRigScoped(t *testing.T) {
 // arm renders as "no-wake-reason" and recycles a live claim holder.
 func TestClassBindingClaimYieldsAnAssignedWorkWakeReason(t *testing.T) {
 	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
 	work := []beads.Bead{{ID: "gcg-1", Status: "in_progress", Assignee: "test-city--worker-1"}}
-	refs := []string{classBindingAssignedWorkStoreRef}
+	refs := []string{""}
 
-	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, infos, work, refs)
+	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, binding, infos, work, refs)
 	readyFlags := readyAssignedFlagsForBeads(
-		map[storeScopedBeadKey]bool{{StoreRef: classBindingAssignedWorkStoreRef, ID: "gcg-1"}: true},
+		map[storeScopedBeadKey]bool{{StoreRef: "", ID: "gcg-1"}: true},
 		kept, keptRefs)
 
 	input := buildAwakeInputFromReconciler(
@@ -123,20 +162,16 @@ func TestClassBindingClaimYieldsAnAssignedWorkWakeReason(t *testing.T) {
 // ledger a routed claim was written into.
 func TestReachableStoresScanTheClassBindingOnASplitCity(t *testing.T) {
 	cfg, cityPath, infos := rigScopedWakeFixture(t)
-	cfg.Storage = infraSplitConfig(filepath.Join(cityPath, "infra")).Storage
-	binding := beads.NewMemStore()   // the sessions/graph binding the reconciler leads with
-	rigStore := beads.NewMemStore()  // the rig work store
-	cityStore := beads.NewMemStore() // unrelated: proves the extra leg is the LEADING store, not a fan-out
+	binding := beads.NewMemStore()  // the sessions/graph binding the reconciler leads with
+	rigStore := beads.NewMemStore() // the rig work store
+	seedSplitRoutes(t, cityPath, binding)
 
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, binding, map[string]beads.Store{"riga": rigStore}, infos[0])
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, binding, map[string]beads.Store{"riga": rigStore}, infos[0])
 	if err != nil {
-		t.Fatalf("reachableStoresForSessionInfo: %v", err)
+		t.Fatalf("assignedWorkPlanForSessionInfo: %v", err)
 	}
-	if len(stores) != 2 || stores[0] != rigStore || stores[1] != binding {
-		t.Fatalf("reachable stores = %#v, want [rig store, class binding] in that order", stores)
-	}
-	if sameStoreSet(stores, cityStore) {
-		t.Fatal("an unrelated store leaked into the scan")
+	if got := planStores(t, plan); !sameStores(got, rigStore, binding) {
+		t.Fatalf("reachable stores = %#v, want [rig store, class binding] in that order", got)
 	}
 }
 
@@ -144,23 +179,15 @@ func TestReachableStoresScanTheClassBindingOnASplitCity(t *testing.T) {
 // today. The extra leg is a property of the SPLIT, not a general widening.
 func TestReachableStoresStayRigScopedOnASingleStoreCity(t *testing.T) {
 	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	seedNoRoutes(t, cityPath)
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, infos[0])
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, infos[0])
 	if err != nil {
-		t.Fatalf("reachableStoresForSessionInfo: %v", err)
+		t.Fatalf("assignedWorkPlanForSessionInfo: %v", err)
 	}
-	if len(stores) != 1 || stores[0] != rigStore {
-		t.Fatalf("reachable stores = %#v, want only the rig store on a city that relocates nothing", stores)
+	if got := planStores(t, plan); !sameStores(got, rigStore) {
+		t.Fatalf("reachable stores = %#v, want only the rig store on a city that relocates nothing", got)
 	}
-}
-
-func sameStoreSet(stores []beads.Store, want beads.Store) bool {
-	for _, s := range stores {
-		if s == want {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/gc/assigned_work_residency.go
+++ b/cmd/gc/assigned_work_residency.go
@@ -1,0 +1,142 @@
+package main
+
+// The assigned-work spine's residency, resolved through internal/storeref.
+//
+// One question — "which stores can hold work assigned to this identity?" — asked
+// once, for the wake filter, the drain and close gates, the retired-session
+// sweeps, the drain-ack release and the orphan-release ownership index. Before
+// this, each of them built its own list from workAssignmentStores plus, at the
+// split-aware minority, a per-site re-derivation of the class leg. Two of those
+// re-derivations were the incidents this slice is named for.
+//
+// # The leg set is SCOPE plus RESIDENCY, and only residency is the resolver's
+//
+// Which WORK legs an identity can reach is its agent's scope: a rig-scoped agent
+// claims in its rig, a city-scoped one federates across every store (vp-kvp).
+// That is a config fact, and the resolver never re-invents it — the scope
+// decides which work legs the topology is built WITH, exactly the "it is told,
+// it does not decide" contract the topology constructors carry. What the
+// resolver owns is the part every site was getting wrong: every relocated class
+// binding is a leg, LAST, on every one of these scans.
+//
+// # What un-shape-gating changed
+//
+// The pre-S2 class leg was `classBindingLegForSessionScan(cfg, store)`: gated on
+// cfg's [storage] shape, and returning the store the caller already held. Both
+// halves were wrong in a way that showed up in production.
+//
+//   - Reading CFG rather than the opened ROUTES means a city whose [storage]
+//     section was DELETED after it had served a split answers "no split", so the
+//     scan silently reads the work ledger its infrastructure beads were moved
+//     off. Through the routes the same city fails LOUD with the refusal that
+//     names the remedy.
+//   - Returning the CALLER'S store makes the leg a no-op for every scan that
+//     leads with the work store — `gc session close`, drain-ack, the
+//     stranded-repair sweep. Those are the RELEASE paths, so a claim claim-time
+//     routing wrote into the binding had no automatic reopen lane at all and was
+//     hand-released by an operator (ga-j4ob9).
+//
+// # Widening the release path's view may never widen what it releases
+//
+// A release-side false positive is claim LOSS, not a missed wake. So the legs
+// this file adds to the release scans are matched by two counterweights that
+// stay exactly as they were: the ownership index now grants a holder the same
+// leg set (so a LIVE holder's binding-resident claim is owned, not orphaned),
+// and releaseOrphanedPoolAssignments keeps the #5242 owner-store liveness probe
+// after the primary one. TestOrphanReleaseSparesALiveHoldersBindingResidentClaim
+// is the control, and it fails as a lost claim rather than as a strand.
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// assignedWorkSweepPlan is the leg set every assigned-work scan reads: the work
+// legs it was handed, then every relocated class binding.
+//
+// identifiers are the assignee spellings the caller will query for. The resolver
+// does not read them — WHICH stores answer does not depend on WHOSE claims are
+// asked about — but carrying them keeps the intent self-describing at the call
+// site, which is where a future per-identity narrowing would land.
+func assignedWorkSweepPlan(cityPath string, cfg *config.City, work beads.Store, rigs map[string]beads.Store, identifiers []string) (storeref.ResolvedPlan, error) {
+	return storeref.Plan(
+		storeref.AssignedWork{Identifiers: identifiers},
+		residencyTopologyForCity(cityPath, cfg, work, rigs),
+	)
+}
+
+// assignedWorkPlanForSessionInfo is the plan the session-reachability scans
+// read: the work legs this session's agent can claim in, plus every binding.
+//
+// A cross-store-eligible (city-scoped) session federates across the leading
+// store and every rig store (vp-kvp); a session whose template/agent cannot be
+// resolved takes the same fan-out (the legacy keep-on-match fail-safe); a
+// rig-bound session gets its ONE rig store; a rig-less agent gets the leading
+// store. Only the work legs differ between those arms — the binding is in all
+// four, because a claim this session holds can live there whatever its scope.
+//
+// It errors only when a resolved rig store is missing, or when the city's
+// storage is refused.
+func assignedWorkPlanForSessionInfo(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info) (storeref.ResolvedPlan, error) {
+	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
+	agentCfg := sessionAgentConfigInfo(cfg, info)
+	if agentCfg == nil || agentIsCrossStoreEligible(agentCfg) {
+		return assignedWorkSweepPlan(cityPath, cfg, store, rigStores, identifiers)
+	}
+	storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
+	if storeRef == "" {
+		return assignedWorkSweepPlan(cityPath, cfg, store, nil, identifiers)
+	}
+	rigStore, ok := rigStores[storeRef]
+	if !ok || rigStore == nil {
+		return storeref.ResolvedPlan{}, fmt.Errorf("rig store %q unavailable for session %q", storeRef, info.SessionNameMetadata)
+	}
+	return assignedWorkSweepPlan(cityPath, cfg, rigStore, nil, identifiers)
+}
+
+// assignedWorkClaimRefs returns the store-refs a claim held by ONE session can
+// be recorded under, whatever the holder's rig scope: the leading work arm and
+// every relocated class binding.
+//
+// This replaces the classBindingAssignedWorkStoreRef constant. The constant was
+// the empty string because on a converged split the reconciler's LEADING arm is
+// the binding, so the census records a binding-resident claim under the city
+// ref — true today and an accident of the E2 dual role rather than a fact about
+// residency. Taking the refs from the topology keeps that answer where it is
+// still true (a leading binding collapses onto the work ref) and adds the
+// binding's own ref where it is not, which is what lets one filter read a city
+// mid-rollout: old census rows under "" and new ones under "class:*".
+//
+// It cannot fail. A refused city still records claims under its refusing
+// binding's ref, and answering "no refs" there would drop every claim-holder on
+// that city into the no-wake-reason drain — the failure the refusal is supposed
+// to prevent, delivered by the guard against it.
+func assignedWorkClaimRefs(cityPath string, cfg *config.City, leading beads.Store) []string {
+	refs := residencyTopologyForCity(cityPath, cfg, leading, nil).ClaimRefs()
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, string(ref))
+	}
+	return out
+}
+
+// assignedWorkScanComplete turns a partial pass into an error for the gates that
+// answer "does this session still hold work?".
+//
+// Those gates decide whether a session may be drained, closed or recycled, and
+// their callers already refuse the decision on an error. A leg that went dark
+// has told them nothing, so reporting a smaller answer as authoritative is how a
+// live claim-holder gets drained mid-step. Retain rather than reap (gc-ft31x).
+func assignedWorkScanComplete(res storeref.WalkResult) error {
+	if !res.Partial {
+		return nil
+	}
+	if len(res.LegErrors) > 0 {
+		return fmt.Errorf("assigned-work scan could not read every leg: %w", res.LegErrors[0])
+	}
+	return fmt.Errorf("assigned-work scan could not read every leg")
+}

--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -240,15 +240,15 @@ func TestRetiredSessionSweepReleasesABindingResidentClaim(t *testing.T) {
 // a live worker, not as a strand.
 // SEAM PIN — DO NOT FOLD INTO AN END-TO-END TEST.
 //
-// Three independent defences keep a live holder's claim: this slice's close gate
+// Three independent defenses keep a live holder's claim: this slice's close gate
 // (the session is never retired), the widened ownership index (the release scan
-// owns the leg), and #5242's owner-store liveness probe. Defence in depth is
+// owns the leg), and #5242's owner-store liveness probe. Defense in depth is
 // what makes the system safe and is also what makes an end-to-end test blind:
 // remove any ONE of the three and a whole-tick test still passes, because the
 // other two cover for it. Only a seam-level pin can fail on a single removal.
 //
 // This test and TestOpenSessionStoreRefIndexOwnsTheLeadingArmForARigBoundHolder
-// are the only guards on the ownership-index defence. Deleting either, or
+// are the only guards on the ownership-index defense. Deleting either, or
 // rewriting it against the reconciler tick, silently retires the guard.
 //
 // The fixture is arranged so that ONLY the widened ownership index can save the
@@ -347,7 +347,7 @@ func TestCloseGateSeesALiveHoldersBindingResidentClaim(t *testing.T) {
 
 // SEAM PIN — DO NOT FOLD INTO AN END-TO-END TEST. See the note on
 // TestOrphanReleaseSparesALiveHoldersBindingResidentClaim: these two are the
-// only guards on the ownership-index defence, and defence in depth means a
+// only guards on the ownership-index defense, and defense in depth means a
 // whole-tick test cannot see the index being removed.
 //
 // The ownership index is the counterweight the row above rests on: a rig-scoped

--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"io"
+	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -236,6 +238,19 @@ func TestRetiredSessionSweepReleasesABindingResidentClaim(t *testing.T) {
 // Release-side false positives are claim LOSS, so widening what the release path
 // can SEE may never widen what it releases. This row fails as a lost claim under
 // a live worker, not as a strand.
+// SEAM PIN — DO NOT FOLD INTO AN END-TO-END TEST.
+//
+// Three independent defences keep a live holder's claim: this slice's close gate
+// (the session is never retired), the widened ownership index (the release scan
+// owns the leg), and #5242's owner-store liveness probe. Defence in depth is
+// what makes the system safe and is also what makes an end-to-end test blind:
+// remove any ONE of the three and a whole-tick test still passes, because the
+// other two cover for it. Only a seam-level pin can fail on a single removal.
+//
+// This test and TestOpenSessionStoreRefIndexOwnsTheLeadingArmForARigBoundHolder
+// are the only guards on the ownership-index defence. Deleting either, or
+// rewriting it against the reconciler tick, silently retires the guard.
+//
 // The fixture is arranged so that ONLY the widened ownership index can save the
 // claim: the session bead is graph-resident (in the binding), while the claim
 // and both liveness probes' stores are the WORK ledger, so the #5242 primary and
@@ -330,6 +345,11 @@ func TestCloseGateSeesALiveHoldersBindingResidentClaim(t *testing.T) {
 	}
 }
 
+// SEAM PIN — DO NOT FOLD INTO AN END-TO-END TEST. See the note on
+// TestOrphanReleaseSparesALiveHoldersBindingResidentClaim: these two are the
+// only guards on the ownership-index defence, and defence in depth means a
+// whole-tick test cannot see the index being removed.
+//
 // The ownership index is the counterweight the row above rests on: a rig-scoped
 // holder now OWNS the leading arm for its own exact identities, so the release
 // path's widened view cannot reap it. This is the I10 assertion flip its own
@@ -401,8 +421,9 @@ func TestRegisteredControllerRoutesAnswerResidencyWithoutASecondOpen(t *testing.
 	cityPath := t.TempDir()
 	seedNoRoutes(t, cityPath) // the one-shot funnel says "no split"
 	binding := beads.NewMemStore()
-	registerResidencyRoutes(cityPath, splitRoutes(binding))
-	t.Cleanup(func() { unregisterResidencyRoutes(cityPath) })
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes)
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
 
 	work := beads.NewMemStore()
 	plan, err := assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, nil, nil)
@@ -413,13 +434,144 @@ func TestRegisteredControllerRoutesAnswerResidencyWithoutASecondOpen(t *testing.
 		t.Fatalf("sweep legs = %v, want the REGISTERED binding behind the work leg", got)
 	}
 
-	unregisterResidencyRoutes(cityPath)
+	unregisterResidencyRoutes(cityPath, routes)
 	plan, err = assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, nil, nil)
 	if err != nil {
 		t.Fatalf("assignedWorkSweepPlan after unregister: %v", err)
 	}
 	if got := planStores(t, plan); !sameStores(got, work) {
 		t.Fatalf("sweep legs after unregister = %v, want the one-shot funnel's answer back", got)
+	}
+}
+
+// OWNERSHIP-SAFE UNREGISTRATION. Registration is keyed by city path, and two
+// runtimes for one city overlap in production: the supervisor builds a
+// replacement runtime BEFORE it learns whether it can take the controller lock,
+// and a hung predecessor still holds both. A delete-by-key unregister lets the
+// loser's shutdown remove a registration that is no longer its own, and the
+// still-live winner's release sweeps then fall back to the one-shot funnel —
+// either a second handle on the same binding root or, on a city the funnel
+// cannot resolve, a binding-blind release sweep with ga-j4ob9 back and silent.
+//
+// Same shape as cmd_supervisor.go's unlink-only-if-ours socket removal.
+func TestUnregisterResidencyRoutesOnlyDropsItsOwnRegistration(t *testing.T) {
+	cityPath := t.TempDir()
+	seedNoRoutes(t, cityPath) // the funnel would answer "no split" — the fallback is visible
+	loser := splitRoutes(beads.NewMemStore())
+	winnerBinding := beads.NewMemStore()
+	winner := splitRoutes(winnerBinding)
+
+	registerResidencyRoutes(cityPath, loser)
+	registerResidencyRoutes(cityPath, winner)
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, winner) })
+
+	// The loser's shutdown defer runs after the winner has registered.
+	unregisterResidencyRoutes(cityPath, loser)
+
+	work := beads.NewMemStore()
+	plan, err := assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, nil, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, work, winnerBinding) {
+		t.Fatalf("sweep legs = %v, want [work, the WINNER's binding] — a losing runtime's shutdown dropped a registration that was not its own, and the live one's release sweep is now binding-blind", got)
+	}
+
+	// And the winner's own unregister still works: ownership-safety must not
+	// turn into a registration that can never be released.
+	unregisterResidencyRoutes(cityPath, winner)
+	plan, err = assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, nil, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan after the owner unregistered: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, work) {
+		t.Fatalf("sweep legs = %v, want the funnel's answer back after the owner released its registration", got)
+	}
+}
+
+// The other half of the blocker: registration must not happen before the
+// controller lock is taken, or a replacement that loses the lock has already
+// pointed the live predecessor's sweeps at a handle it is about to close.
+// Asserted at the source, because the ordering is the invariant and no unit
+// test can stage two supervisors.
+func TestResidencyRegistrationHappensUnderTheControllerLock(t *testing.T) {
+	root := repoRootForResidency(t)
+	for _, tt := range []struct {
+		file      string
+		mustHave  bool
+		rationale string
+	}{
+		{"cmd/gc/city_runtime.go", false, "newCityRuntime runs BEFORE the supervisor takes the controller lock; registering there hands a losing replacement the live city's spine"},
+		{"cmd/gc/cmd_supervisor.go", true, "the supervisor registers only after acquireControllerLock succeeds"},
+		{"cmd/gc/controller.go", true, "the standalone controller already holds the lock before it builds the runtime"},
+	} {
+		body, err := os.ReadFile(filepath.Join(root, tt.file))
+		if err != nil {
+			t.Fatalf("reading %s: %v", tt.file, err)
+		}
+		// A word boundary, so unregisterResidencyRoutes( is not a hit.
+		if got := regexp.MustCompile(`(^|[^A-Za-z0-9_])registerResidencyRoutes\(`).Match(body); got != tt.mustHave {
+			t.Errorf("%s calls registerResidencyRoutes = %v, want %v: %s", tt.file, got, tt.mustHave, tt.rationale)
+		}
+	}
+}
+
+func repoRootForResidency(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the test's working directory")
+		}
+		dir = parent
+	}
+}
+
+// FOLD-IN 4: the cross-store close gates (the cleanup-of-record lane) sit on the
+// same close-then-release path this slice widened, and they were binding-blind
+// on a work-led plane — invisible to the boundary census too, because they
+// range a rig map rather than calling a named enumerator. A session whose
+// binding-resident claim they cannot see is closed, and the retired-session
+// sweep this slice taught to read the binding then releases the claim it is
+// executing.
+func TestCrossStoreCloseGateSeesABindingResidentClaim(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	cfg := residencyTestConfig()
+
+	sessionBead := beads.Bead{
+		ID:       "gcs-1",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Metadata: map[string]string{"session_name": "test-city--worker-1"},
+	}
+	claim, err := binding.Create(beads.Bead{
+		Title:    "graph step the live worker is executing",
+		Type:     "task",
+		Assignee: "test-city--worker-1",
+	})
+	if err != nil {
+		t.Fatalf("seed the binding-resident claim: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := binding.Update(claim.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("claim it: %v", err)
+	}
+
+	has, err := sessionHasOpenAssignedWorkForConfig(cityPath, cfg, beads.NewMemStore(), nil, sessionBead)
+	if err != nil {
+		t.Fatalf("cross-store close gate: %v", err)
+	}
+	if !has {
+		t.Fatal("the cross-store close gate reports a live claim-holder as holding nothing; it closes the session bead and the retired-session sweep releases the claim underneath the worker")
 	}
 }
 

--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -1,0 +1,474 @@
+package main
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// S2 pins: the assigned-work spine reads Plan(AssignedWork).
+//
+// The §3.3 discipline — every migrated site lands with a before/after pin that
+// asserts the resolver's leg list is IDENTICAL to the hand-rolled one where the
+// site was already right, and states the DOCUMENTED delta where it was not.
+// The pre-S2 list is written out literally in each row rather than computed, so
+// a future change to either side has to change a row.
+
+// seedSplitRoutes gives cityPath a served whole-split binding without opening
+// one. It seeds the one-shot funnel's memo, which is the same seam the by-id and
+// order-dispatch class tests already use: the topology constructors read OPENED
+// ROUTES, so a test that only sets cfg.Storage is describing a city whose config
+// says "split" and whose routes say nothing.
+func seedSplitRoutes(t *testing.T, cityPath string, binding beads.Store) {
+	t.Helper()
+	resetCLIStorageRoutes(t)
+	resetCLIResidencyBindings()
+	t.Cleanup(resetCLIResidencyBindings)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = splitRoutes(binding) })
+}
+
+// seedNoRoutes is the single-store control: a city that relocates nothing.
+func seedNoRoutes(t *testing.T, cityPath string) {
+	t.Helper()
+	resetCLIStorageRoutes(t)
+	resetCLIResidencyBindings()
+	t.Cleanup(resetCLIResidencyBindings)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() { entry.routes = nil })
+}
+
+// planStores walks a plan through the executor and reports the stores it reads,
+// in order — the list the migrated site used to build by hand.
+func planStores(t *testing.T, plan storeref.ResolvedPlan) []beads.Store {
+	t.Helper()
+	var out []beads.Store
+	if _, err := storeref.Walk(plan, func(l storeref.Leg) (bool, error) {
+		out = append(out, l.Store)
+		return false, nil
+	}); err != nil {
+		t.Fatalf("walking the plan: %v", err)
+	}
+	return out
+}
+
+func sameStores(got []beads.Store, want ...beads.Store) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Byte-identity pins for the sweep leg set.
+// ---------------------------------------------------------------------------
+
+// T0: a city that relocates nothing reads exactly the legs the pre-S2
+// workAssignmentStores(store, rigStores) built — the leading store, then the rig
+// stores by name. No probe, no binding, nothing added.
+func TestAssignedWorkSweepPlanIsByteIdenticalOnASingleStoreCity(t *testing.T) {
+	cityPath := t.TempDir()
+	seedNoRoutes(t, cityPath)
+	work, alpha, bravo := beads.NewMemStore(), beads.NewMemStore(), beads.NewMemStore()
+	cfg := residencyTestConfig()
+
+	plan, err := assignedWorkSweepPlan(cityPath, cfg, work, map[string]beads.Store{"bravo": bravo, "alpha": alpha}, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, work, alpha, bravo) {
+		t.Fatalf("sweep legs = %v, want [work, rig:alpha, rig:bravo] — the pre-S2 list verbatim", got)
+	}
+}
+
+// T1: the controller's split city, where the leading store IS the binding (the
+// reconciler leads with the sessions-class store and the whole split serves all
+// five classes from one engine). The binding leg collapses onto the leading one,
+// so the list is the pre-S2 list and the city pays nothing for the seam.
+func TestAssignedWorkSweepPlanCollapsesALeadingBindingLeg(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	alpha := beads.NewMemStore()
+
+	plan, err := assignedWorkSweepPlan(cityPath, residencyTestConfig(), binding, map[string]beads.Store{"alpha": alpha}, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, binding, alpha) {
+		t.Fatalf("sweep legs = %v, want [binding(leading), rig:alpha]: a leg that resolved back to the leading store must not be read twice", got)
+	}
+}
+
+// THE DOCUMENTED DELTA (ga-j4ob9). A scan that leads with the WORK store on a
+// split city used to add `classBindingLegForSessionScan(cfg, store)` — which
+// returns the store it was handed, so the "binding leg" was the work store
+// again and deduped to nothing. The release path was therefore structurally
+// blind to every claim claim-time routing had written into the binding. The
+// resolver adds the REAL binding, last.
+func TestAssignedWorkSweepPlanAddsTheRealBindingToAWorkLedScan(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	work, alpha := beads.NewMemStore(), beads.NewMemStore()
+
+	plan, err := assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, map[string]beads.Store{"alpha": alpha}, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, work, alpha, binding) {
+		t.Fatalf("sweep legs = %v, want [work, rig:alpha, binding LAST] — a work-led release scan that cannot see the binding releases a routed claim by nothing", got)
+	}
+}
+
+// Un-shape-gated: the binding comes from the OPENED ROUTES, so a city whose
+// [storage] section was deleted after it had served a split fails LOUD instead
+// of silently answering from the work ledger the classes were moved off.
+func TestAssignedWorkSweepPlanFailsLoudOnARefusedCity(t *testing.T) {
+	cityPath := t.TempDir()
+	resetCLIStorageRoutes(t)
+	resetCLIResidencyBindings()
+	t.Cleanup(resetCLIResidencyBindings)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() {
+		entry.routes = refusingStorageRoutes("infra", errStorageRefusedForTest{})
+	})
+
+	if _, err := assignedWorkSweepPlan(cityPath, residencyTestConfig(), beads.NewMemStore(), nil, nil); err == nil {
+		t.Fatal("a refused city planned an assigned-work sweep; a work-only sweep on a refused city is the answer that looks like success and reads the wrong ledger")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The session-scoped plan: what reachableStoresForSessionInfo used to answer.
+// ---------------------------------------------------------------------------
+
+// A rig-bound session reads its own rig store and the binding, in that order —
+// byte-identical to the pre-S2 workAssignmentStores(rigStore, nil, binding). The
+// city work store must NOT appear: reachability is the agent's SCOPE, and the
+// resolver is told which work legs the scope has rather than deciding it.
+func TestSessionAssignedWorkPlanStaysRigScopedAndAddsTheBinding(t *testing.T) {
+	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	rigStore, cityStore := beads.NewMemStore(), beads.NewMemStore()
+
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, infos[0])
+	if err != nil {
+		t.Fatalf("assignedWorkPlanForSessionInfo: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, rigStore, binding) {
+		t.Fatalf("session legs = %v, want [rig store, binding]", got)
+	}
+}
+
+// Control: the same session on a city that relocates nothing reads one leg. The
+// extra leg is a property of the SPLIT, not a general widening.
+func TestSessionAssignedWorkPlanStaysSingleLeggedOnASingleStoreCity(t *testing.T) {
+	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	seedNoRoutes(t, cityPath)
+	rigStore, cityStore := beads.NewMemStore(), beads.NewMemStore()
+
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, infos[0])
+	if err != nil {
+		t.Fatalf("assignedWorkPlanForSessionInfo: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, rigStore) {
+		t.Fatalf("session legs = %v, want only the rig store", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The release path: it must SEE a graph-resident claim, and a LIVE holder's
+// claim must survive every leg that newly became visible. The two rows fail
+// differently on purpose — the first as a strand, the second as claim LOSS.
+// ---------------------------------------------------------------------------
+
+// ga-j4ob9: a session died without drain-ack while holding a claim claim-time
+// routing had written into the binding. The retired-session sweep leads with the
+// WORK store here (the `gc session close` / stranded-repair shape), so before S2
+// no leg of it could see the claim and the babysitter hand-released them.
+func TestRetiredSessionSweepReleasesABindingResidentClaim(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	work := beads.NewMemStore()
+	cfg := residencyTestConfig()
+
+	sessionBead := beads.Bead{ID: "gcs-dead-1", Metadata: map[string]string{"session_name": "worker-1"}}
+	step, err := binding.Create(beads.Bead{
+		ID:       "gcg-step-1",
+		Title:    "graph step claimed by a session that then died",
+		Type:     "task",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("seed the binding-resident claim: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := binding.Update(step.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("claim the step: %v", err)
+	}
+
+	unclaimWorkAssignedToRetiredSessionBead(cityPath, cfg, work, nil, sessionBead, "", io.Discard)
+
+	got, err := binding.Get(step.ID)
+	if err != nil {
+		t.Fatalf("re-read the step: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("the retired-session sweep left %s as status=%q assignee=%q; a dead session's binding-resident claim has no other automatic reopen lane (ga-j4ob9)", step.ID, got.Status, got.Assignee)
+	}
+}
+
+// THE CONTROL THAT MUST FAIL DIFFERENTLY. The same newly visible leg, but the
+// holder is ALIVE: an open session bead whose identities include the assignee.
+// Release-side false positives are claim LOSS, so widening what the release path
+// can SEE may never widen what it releases. This row fails as a lost claim under
+// a live worker, not as a strand.
+// The fixture is arranged so that ONLY the widened ownership index can save the
+// claim: the session bead is graph-resident (in the binding), while the claim
+// and both liveness probes' stores are the WORK ledger, so the #5242 primary and
+// owner-store probes both miss. Pre-S2 the index answered "this rig-scoped
+// holder owns only rig:riga", the leading-arm claim looked orphaned, and a live
+// worker had its work reopened underneath it.
+func TestOrphanReleaseSparesALiveHoldersBindingResidentClaim(t *testing.T) {
+	cfg, cityPath, _ := rigScopedWakeFixture(t)
+	cfg.Agents[0].MaxActiveSessions = intPtr(3)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	work := beads.NewMemStore()
+
+	sess, err := binding.Create(beads.Bead{
+		Title:    "live pool session, graph-resident",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Labels:   []string{sessionBeadLabel},
+		Metadata: map[string]string{"template": "riga/worker", "session_name": "test-city--worker-1", "pool_managed": "true"},
+	})
+	if err != nil {
+		t.Fatalf("create the live session bead: %v", err)
+	}
+	claim, err := work.Create(beads.Bead{
+		Title:    "claim the live worker is executing",
+		Type:     "task",
+		Assignee: "test-city--worker-1",
+		Metadata: map[string]string{"gc.routed_to": "riga/worker"},
+	})
+	if err != nil {
+		t.Fatalf("create the claimed work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := work.Update(claim.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark the claim in_progress: %v", err)
+	}
+	if claim, err = work.Get(claim.ID); err != nil {
+		t.Fatalf("reload the claimed work bead: %v", err)
+	}
+
+	infos := sessionInfosFromBeads([]beads.Bead{sess})
+	released := releaseOrphanedPoolAssignments(
+		work, cfg, cityPath, infos,
+		[]beads.Bead{claim}, []beads.Store{work}, []string{""}, nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released %v — a LIVE holder's claim was taken back on a leg the release path now reads; that is claim loss, not a strand", released)
+	}
+	got, err := work.Get(claim.ID)
+	if err != nil {
+		t.Fatalf("re-read the claim: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "test-city--worker-1" {
+		t.Fatalf("the live worker's claim is status=%q assignee=%q, want in_progress/test-city--worker-1", got.Status, got.Assignee)
+	}
+}
+
+// The FIRST counterweight, and the one that fires earliest: a live rig-scoped
+// holder with a binding-resident claim must read as "still has assigned work",
+// so the drain/close lane never retires it and the retired-session sweep — the
+// scan this slice taught to see the binding — is never pointed at it at all.
+//
+// This row fails as a session closed out from under a live claim; the strand row
+// above fails as a claim nobody reopens. Two signatures, one leg set.
+func TestCloseGateSeesALiveHoldersBindingResidentClaim(t *testing.T) {
+	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	rigStore := beads.NewMemStore()
+
+	claim, err := binding.Create(beads.Bead{
+		Title:    "graph step the live worker is executing",
+		Type:     "task",
+		Assignee: "test-city--worker-1",
+	})
+	if err != nil {
+		t.Fatalf("seed the binding-resident claim: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := binding.Update(claim.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("claim it: %v", err)
+	}
+
+	// The work-led plane: the scan's leading store is NOT the binding.
+	has, err := sessionHasOpenAssignedWorkForReachableStore(
+		cityPath, cfg, beads.NewMemStore(), map[string]beads.Store{"riga": rigStore}, infos[0])
+	if err != nil {
+		t.Fatalf("close gate: %v", err)
+	}
+	if !has {
+		t.Fatal("the close gate reports a live claim-holder as holding nothing; its session bead is retired and the retired-session sweep then releases the claim it is executing")
+	}
+}
+
+// The ownership index is the counterweight the row above rests on: a rig-scoped
+// holder now OWNS the leading arm for its own exact identities, so the release
+// path's widened view cannot reap it. This is the I10 assertion flip its own
+// comment asked for.
+func TestOpenSessionStoreRefIndexOwnsTheLeadingArmForARigBoundHolder(t *testing.T) {
+	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+
+	index := makeOpenSessionStoreRefIndex(cityPath, cfg, binding, infos, true)
+	identity := "test-city--worker-1"
+	if !openSessionOwnsWork(nil, index, identity, "riga", true) {
+		t.Error("the index dropped the holder's own rig leg")
+	}
+	if !openSessionOwnsWork(nil, index, identity, "", true) {
+		t.Error("the index does not own the leading arm for its own rig-bound holder; a claim claim-time routing wrote there is released under a live worker (ga-j4ob9's counterweight)")
+	}
+	if openSessionOwnsWork(nil, index, "test-city--someone-else", "", true) {
+		t.Error("the index owns the leading arm for a FOREIGN identity; the widening is per-identity ownership, not a blanket keep")
+	}
+}
+
+// The refs the wake filter and the ownership index match against come from the
+// resolver, not from a constant. On a work-led plane the binding's own ref is
+// in the set too, which is what lets a mixed-version city — old census rows
+// under "" during a rollout, new ones under "class:*" — be read by one filter.
+func TestAssignedWorkClaimRefsCarryTheBindingRef(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	work := beads.NewMemStore()
+
+	refs := assignedWorkClaimRefs(cityPath, residencyTestConfig(), work)
+	if len(refs) != 2 || refs[0] != "" || refs[1] != "class:gmnos" {
+		t.Fatalf("claim refs = %#v, want the leading work arm and the binding", refs)
+	}
+
+	// The controller's shape: the leading store IS the binding, so the census
+	// records ONE ref and the filter must match exactly that one.
+	if got := assignedWorkClaimRefs(cityPath, residencyTestConfig(), binding); len(got) != 1 || got[0] != "" {
+		t.Fatalf("claim refs on a leading-binding city = %#v, want just the leading arm", got)
+	}
+}
+
+// A refused city still has claims recorded under its binding's ref, so the ref
+// answer has to exist where a PLAN correctly refuses. Losing it would drain
+// every claim-holder on the city the refusal is about.
+func TestAssignedWorkClaimRefsSurviveARefusedCity(t *testing.T) {
+	cityPath := t.TempDir()
+	resetCLIStorageRoutes(t)
+	resetCLIResidencyBindings()
+	t.Cleanup(resetCLIResidencyBindings)
+	entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+	entry.once.Do(func() {
+		entry.routes = refusingStorageRoutes("infra", errStorageRefusedForTest{})
+	})
+
+	refs := assignedWorkClaimRefs(cityPath, residencyTestConfig(), beads.NewMemStore())
+	if len(refs) != 2 || refs[0] != "" {
+		t.Fatalf("claim refs on a refused city = %#v, want the work arm and the refusing binding's ref", refs)
+	}
+}
+
+// The controller must not open a SECOND binding for a city it already serves:
+// a duplicate managed-Dolt server or a second sqlite writer is a worse bug than
+// the blindness this slice closes. A runtime registers the routes it opened at
+// boot, and the spine answers from those.
+func TestRegisteredControllerRoutesAnswerResidencyWithoutASecondOpen(t *testing.T) {
+	cityPath := t.TempDir()
+	seedNoRoutes(t, cityPath) // the one-shot funnel says "no split"
+	binding := beads.NewMemStore()
+	registerResidencyRoutes(cityPath, splitRoutes(binding))
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath) })
+
+	work := beads.NewMemStore()
+	plan, err := assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, nil, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, work, binding) {
+		t.Fatalf("sweep legs = %v, want the REGISTERED binding behind the work leg", got)
+	}
+
+	unregisterResidencyRoutes(cityPath)
+	plan, err = assignedWorkSweepPlan(cityPath, residencyTestConfig(), work, nil, nil)
+	if err != nil {
+		t.Fatalf("assignedWorkSweepPlan after unregister: %v", err)
+	}
+	if got := planStores(t, plan); !sameStores(got, work) {
+		t.Fatalf("sweep legs after unregister = %v, want the one-shot funnel's answer back", got)
+	}
+}
+
+// A gate that asks "does this session still hold work" must fail CLOSED when a
+// leg went dark: "one ledger could not be read" reported as "holds nothing" is
+// how a live claim-holder gets drained.
+func TestAssignedWorkGateFailsClosedOnADegradedLeg(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "riga", Path: "/tmp/riga"}},
+		Agents:    []config.Agent{{Name: "worker", Scope: "city"}},
+	}
+	cityPath := t.TempDir()
+	seedNoRoutes(t, cityPath)
+	info := sessionInfosFromBeads([]beads.Bead{{
+		ID:     "gcs-1",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "test-city--worker-1",
+			"state":        "active",
+		},
+	}})[0]
+
+	has, err := sessionHasOpenAssignedWorkForReachableStore(
+		cityPath, cfg, beads.NewMemStore(),
+		map[string]beads.Store{"riga": failingListStore{}}, info)
+	if err == nil {
+		t.Fatal("a rig store that could not be read reported \"no assigned work\" with no error; the drain arm reads that as a session holding nothing")
+	}
+	if has {
+		t.Fatal("a failed scan reported assigned work")
+	}
+}
+
+// failingListStore is a work leg that has gone dark: every assignee query fails.
+type failingListStore struct{ beads.Store }
+
+func (failingListStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, errDarkLeg{}
+}
+
+func (failingListStore) ListByAssignee(string, string, int) ([]beads.Bead, error) {
+	return nil, errDarkLeg{}
+}
+
+type errDarkLeg struct{}
+
+func (errDarkLeg) Error() string { return "leg is dark" }
+
+var _ sessionpkg.Info // keep the typed session import honest across edits

--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -9,22 +9,6 @@ import (
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
-// classBindingAssignedWorkStoreRef names the store-ref the assigned-work
-// collection records for its LEADING arm — the store the controller reconciler
-// leads with, which on a converged split city IS the relocated
-// coordination-class binding (coordClassStoreCandidates, called with an empty
-// cityRef from collectAssignedWorkBeadsWithStores).
-//
-// The VALUE must stay empty. It is not a label chosen for this arm; it is the
-// same empty string assignedWorkStoreRefForAgent returns for every agent with no
-// configured rig, and the two are compared to each other here, in
-// assignedWorkIndexReachableFromAgent, and in openSessionOwnsWork. Renaming it
-// (to, say, "class:sessions") would make a rig-less agent stop matching its own
-// city-store work in all three places — a wake/demand regression far larger than
-// the trace clarity it would buy. The constant exists so the arm can be NAMED at
-// the sites that reason about it, without changing what it is.
-const classBindingAssignedWorkStoreRef = ""
-
 func assignedWorkStoreRefForAgent(cityPath string, cfg *config.City, agentCfg *config.Agent) string {
 	if cfg == nil || agentCfg == nil {
 		return ""
@@ -82,11 +66,12 @@ func sessionAgentConfigInfo(cfg *config.City, info sessionpkg.Info) *config.Agen
 	return findAgentByTemplate(cfg, template)
 }
 
-// openSessionReachableStoreRefInfo returns the store-ref under which an open
+// openSessionReachableStoreRefInfo returns the store-refs under which an open
 // session bead owns assigned work, for makeOpenSessionStoreRefIndex. The SESSION
-// side reads typed session.Info (WI-5 W3 per-parameter split, migrated alongside
-// reachableStoresForSession); store-ref resolution stays cfg-derived. A
-// cross-store eligible (city-scoped) session federates across every store
+// side reads typed session.Info (WI-5 W3 per-parameter split); the refs come
+// from the residency resolver.
+//
+// A cross-store eligible (city-scoped) session federates across every store
 // (vp-kvp), so it is indexed under crossStoreOpenSessionStoreRef — a wildcard
 // openSessionOwnsWork matches against any work store-ref. This mirrors the
 // cross-store ownership the demand and session-wake filters already grant
@@ -94,17 +79,29 @@ func sessionAgentConfigInfo(cfg *config.City, info sessionpkg.Info) *config.Agen
 // live city-scoped holder's rig-routed work and a backup worker is minted on the
 // same bead (#3453). A session whose template/agent cannot be resolved falls back
 // to unresolvedOpenSessionStoreRef (also a wildcard), preserving the legacy
-// keep-on-match fail-safe; every other session stays scoped to its configured
-// rig's store-ref.
-func openSessionReachableStoreRefInfo(cityPath string, cfg *config.City, info sessionpkg.Info) string {
+// keep-on-match fail-safe.
+//
+// Every other session is its configured rig's store-ref PLUS the refs a claim
+// can be recorded under whatever the holder's rig scope (assignedWorkClaimRefs:
+// the leading work arm and every relocated class binding). That addition is the
+// counterweight to this slice widening what the release path can SEE: claim-time
+// class routing writes a rig-scoped agent's claim into the binding, the
+// orphan-release scan now reads that leg, and an index that still answered
+// "this holder owns only its rig" would let the scan reap a LIVE worker's claim
+// — claim loss, not a missed wake. It is the same widening the wake filter
+// already applies to the same identities (ga-whzrt), which is what makes the two
+// mechanisms answer one question instead of two.
+// claimRefs is the city-level answer from assignedWorkClaimRefs, resolved once
+// by the caller because it is a property of the CITY and this runs per session.
+func openSessionReachableStoreRefInfo(cityPath string, cfg *config.City, claimRefs []string, info sessionpkg.Info) []string {
 	agentCfg := sessionAgentConfigInfo(cfg, info)
 	if agentCfg == nil {
-		return unresolvedOpenSessionStoreRef
+		return []string{unresolvedOpenSessionStoreRef}
 	}
 	if agentIsCrossStoreEligible(agentCfg) {
-		return crossStoreOpenSessionStoreRef
+		return []string{crossStoreOpenSessionStoreRef}
 	}
-	return assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
+	return append([]string{assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)}, claimRefs...)
 }
 
 func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agentCfg *config.Agent, storeRefs []string, index int) bool {
@@ -189,6 +186,7 @@ func filterAssignedWorkBeadsForPoolDemand(
 func filterAssignedWorkBeadsForSessionWake(
 	cfg *config.City,
 	cityPath string,
+	leading beads.Store,
 	sessionInfos []sessionpkg.Info,
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStoreRefs []string,
@@ -199,6 +197,7 @@ func filterAssignedWorkBeadsForSessionWake(
 	if cfg == nil {
 		return assignedWorkBeads, assignedWorkStoreRefs
 	}
+	claimRefs := assignedWorkClaimRefs(cityPath, cfg, leading)
 	reachableRefsByAssignee := make(map[string]map[string]struct{})
 	// crossStore identities belong to city-scoped (cross-store-eligible) agents
 	// and are reachable from ANY store (vp-kvp). They bypass the per-ref match.
@@ -250,22 +249,31 @@ func filterAssignedWorkBeadsForSessionWake(
 		storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
 		for _, id := range sessionBeadAssigneeIdentitiesInfo(sb) {
 			add(id, storeRef)
-			// A claim this session HOLDS can also live on the leading
-			// class-binding arm, whatever the owning agent's rig scope: on a
-			// split city that is where claim-time class routing writes the
-			// assignee (claim_class_route.go), and even on a single-store city
-			// the agent's own hook fan-out reaches the city store
-			// (appendCityHookStore) — so a bead it can claim was being dropped
-			// here for a store it demonstrably reads. Dropping it is what left a
-			// claim-holder with AwakeDecision{Reason:""} and drained it down the
-			// no-wake-reason arm while it owned in-progress work (ga-whzrt).
+			// A claim this session HOLDS can also live on the leading work arm
+			// or in a relocated class binding, whatever the owning agent's rig
+			// scope: on a split city the binding is where claim-time class
+			// routing writes the assignee (claim_class_route.go), and even on a
+			// single-store city the agent's own hook fan-out reaches the city
+			// store (appendCityHookStore) — so a bead it can claim was being
+			// dropped here for a store it demonstrably reads. Dropping it is
+			// what left a claim-holder with AwakeDecision{Reason:""} and drained
+			// it down the no-wake-reason arm while it owned in-progress work
+			// (ga-whzrt).
+			//
+			// The refs come from the resolver rather than from a constant, so a
+			// city mid-rollout is readable by ONE filter: the census records a
+			// binding-resident claim under "" while the reconciler's leading arm
+			// is the binding, and under the binding's own "class:*" ref once it
+			// is a distinct census leg. Both are in the set.
 			//
 			// This widens COLLECTION only. The match is still this session's own
 			// exact assignee identity, so no bead belonging to anyone else
 			// becomes visible; the template key below deliberately does NOT get
-			// the extra arm, because a template match is a scope statement
+			// the extra arms, because a template match is a scope statement
 			// rather than an ownership one.
-			add(id, classBindingAssignedWorkStoreRef)
+			for _, ref := range claimRefs {
+				add(id, ref)
+			}
 		}
 		add(template, storeRef)
 	}

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -75,7 +75,7 @@ func TestFilterAssignedWorkBeadsForSessionWakeKeepsOnlyReachableAssigneeSources(
 	}
 	storeRefs := []string{"", "riga", "", "riga", "rigb", "rigb"}
 
-	got, gotRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, sessionInfosFromBeads(sessions), work, storeRefs)
+	got, gotRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, nil, sessionInfosFromBeads(sessions), work, storeRefs)
 
 	wantIDs := []string{"city-named", "rig-named", "city-session", "rig-session"}
 	wantRefs := []string{"", "riga", "", "riga"}
@@ -126,7 +126,7 @@ func TestFilterAssignedWorkBeadsForSessionWakeCityScopedAgentIsCrossStoreEligibl
 	}
 	storeRefs := []string{"", "riga"} // city store + rig store
 
-	got, gotRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, nil, work, storeRefs)
+	got, gotRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, nil, nil, work, storeRefs)
 
 	if len(got) != 2 {
 		t.Fatalf("city-scoped %q must be reachable from BOTH stores; got %d: %#v", identity, len(got), got)
@@ -430,9 +430,9 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 		t.Fatalf("stranded-bead lookup must find rig-store work for a city-scoped session; found=%v bead=%q want=%q", found, bead.ID, rigWork.ID)
 	}
 
-	stranded, err := collectSessionAssignedWork(cityPath, cfg, cityStore, rigStores, session)
+	stranded, err := collectSessionAssignedWorkInfo(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session))
 	if err != nil {
-		t.Fatalf("collectSessionAssignedWork: %v", err)
+		t.Fatalf("collectSessionAssignedWorkInfo: %v", err)
 	}
 	if len(stranded) != 1 || stranded[0].bead.ID != rigWork.ID {
 		t.Fatalf("stranded-work collector must include rig-store work for a city-scoped session; got %#v", stranded)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -360,6 +360,12 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The assigned-work spine's scans are free functions reached from both
+	// planes and carry no runtime, so they resolve this city's bindings by
+	// PATH. Registering the routes opened here is what keeps them off the
+	// one-shot funnel, which would open a second handle on the same binding
+	// root — a duplicate managed-Dolt server or a second sqlite writer.
+	registerResidencyRoutes(p.CityPath, routes)
 
 	sweepOrphanedOrderTrackingAtBoot(routes, p.CityPath, p.Cfg, p.Rec, p.Stderr)
 
@@ -2486,7 +2492,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	cr.recordReconcileTraceInputs(trace, openInfos, desiredState, poolDesired, workSet, traceWorkRequested, readyWaitSet, result, recordPhase)
 
 	phaseStart = time.Now()
-	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, openInfos, assignedWorkBeads, assignedWorkStoreRefs)
+	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, store, openInfos, assignedWorkBeads, assignedWorkStoreRefs)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.filter_assigned_work_for_wake", phaseStart, map[string]any{
 		"assigned_work_bead_count":       len(assignedWorkBeads),
 		"awake_assigned_work_bead_count": len(awakeAssignedWorkBeads),
@@ -3853,6 +3859,10 @@ func (cr *CityRuntime) shutdown() {
 		// process that exits holding it leaves the successor's open racing this
 		// one's.
 		defer func() {
+			// Stop naming these routes before closing them: a sweep that
+			// resolved its bindings from a closed handle would answer every leg
+			// with an error instead of falling back to the one-shot funnel.
+			unregisterResidencyRoutes(cr.cityPath)
 			if err := cr.storageRoutes.close(); err != nil {
 				fmt.Fprintf(cr.stderr, "%s: closing the storage binding: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 			}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -360,12 +360,11 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The assigned-work spine's scans are free functions reached from both
-	// planes and carry no runtime, so they resolve this city's bindings by
-	// PATH. Registering the routes opened here is what keeps them off the
-	// one-shot funnel, which would open a second handle on the same binding
-	// root — a duplicate managed-Dolt server or a second sqlite writer.
-	registerResidencyRoutes(p.CityPath, routes)
+	// NOTE: the routes are NOT registered as this city's residency answer here.
+	// Construction happens before the supervisor knows whether it can take the
+	// controller lock, and a replacement that loses it would have repointed the
+	// live city's release sweeps at a binding it is about to close. The lock
+	// holder registers — see registerResidencyRoutes.
 
 	sweepOrphanedOrderTrackingAtBoot(routes, p.CityPath, p.Cfg, p.Rec, p.Stderr)
 
@@ -2452,6 +2451,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	} else {
 		phaseStart = time.Now()
 		if sweepUndesiredPoolSessionBeads(
+			cr.cityPath,
 			sessStore,
 			rigStores,
 			sessionBeads,
@@ -2956,6 +2956,7 @@ func poolSweepWouldDrain(sessionBeads *sessionBeadSnapshot, desiredState map[str
 }
 
 func sweepUndesiredPoolSessionBeads(
+	cityPath string,
 	store beads.SessionStore,
 	rigStores map[string]beads.Store,
 	sessionBeads *sessionBeadSnapshot,
@@ -3064,7 +3065,7 @@ func sweepUndesiredPoolSessionBeads(
 		// front door.
 		candidates = append(candidates, info)
 	}
-	return len(GCSweepSessionBeads(store.Store, rigStores, candidates))
+	return len(GCSweepSessionBeads(cityPath, store.Store, rigStores, candidates))
 }
 
 func poolSessionBeadRuntimeRunning(bead beads.Bead, sp runtime.Provider, processNames []string) (bool, error) {
@@ -3862,7 +3863,9 @@ func (cr *CityRuntime) shutdown() {
 			// Stop naming these routes before closing them: a sweep that
 			// resolved its bindings from a closed handle would answer every leg
 			// with an error instead of falling back to the one-shot funnel.
-			unregisterResidencyRoutes(cr.cityPath)
+			// Passing our OWN routes is what keeps this from dropping a
+			// registration a live replacement already installed.
+			unregisterResidencyRoutes(cr.cityPath, cr.storageRoutes)
 			if err := cr.storageRoutes.close(); err != nil {
 				fmt.Fprintf(cr.stderr, "%s: closing the storage binding: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 			}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -78,6 +78,7 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -252,6 +253,7 @@ func TestSweepUndesiredPoolSessionBeads_UsesProcessNameFallback(t *testing.T) {
 	}
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -309,6 +311,7 @@ func TestSweepUndesiredPoolSessionBeads_RunningProbeAvoidsFullObservation(t *tes
 	sp.SetActivity("worker-bd-running", time.Now())
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -350,6 +353,7 @@ func TestSweepUndesiredPoolSessionBeads_UsesRuntimeLivenessObservation(t *testin
 	}
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		newSessionBeadSnapshot([]beads.Bead{bead}),
@@ -404,6 +408,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsProtectedCreateBeforeRuntimeProbe(t
 	sp := runtime.NewFake()
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2427,6 +2432,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsCreatingState(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2480,6 +2486,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecentlyCreated(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2528,6 +2535,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsStaleCreatingState(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2569,6 +2577,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2608,6 +2617,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecentCreationCompleteAfterWakeReco
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2649,6 +2659,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsActiveWithoutCreationCompleteAt(t 
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2696,6 +2707,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsAwakeStateInPreWakeWindow(t *testin
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2745,6 +2757,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecoveredActiveBead(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2796,6 +2809,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsFreshRestartAfterPriorCrash(t *test
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2842,6 +2856,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2878,6 +2893,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2928,6 +2944,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsExpiredPendingCreateClaimLease(t *
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -2967,6 +2984,7 @@ func TestSweepUndesiredPoolSessionBeads_UsesPendingCreateStartedAtForCreatingSta
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -3018,6 +3036,7 @@ func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -3076,6 +3095,7 @@ func TestSweepUndesiredPoolSessionBeads_ClosesMissingOrStaleSessionName(t *testi
 			}
 
 			closed := sweepUndesiredPoolSessionBeads(
+				"",
 				beads.SessionStore{Store: store},
 				nil,
 				newSessionBeadSnapshot([]beads.Bead{bead}),
@@ -3122,6 +3142,7 @@ func TestSweepUndesiredPoolSessionBeads_KeepsAssignedSessionsOpen(t *testing.T) 
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,
@@ -3165,6 +3186,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPartialAssignedSnapshot(t *testing.
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
+		"",
 		beads.SessionStore{Store: store},
 		nil,
 		sessionBeads,

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -753,11 +753,7 @@ func releaseUnexecutedClaimsForSession(cityPath, sessionName string, stderr io.W
 	if cfg != nil {
 		rigStores = buildStandaloneRigStores(cfg, cityPath, io.Discard)
 	}
-	var classStores []beads.Store
-	if binding, relocated := graphClassBinding(cliStorageRoutes(cityPath)); relocated { // residency:allow same binding probe `gc session close` uses to hand its release the graph leg
-		classStores = append(classStores, binding)
-	}
-	releaseUnexecutedClaimsOnDrainAck(store, rigStores, sessionBead, drainAckReleaseBudget, stderr, classStores...)
+	releaseUnexecutedClaimsOnDrainAck(cityPath, cfg, store, rigStores, sessionBead, drainAckReleaseBudget, stderr)
 }
 
 // drainAckReleaseBudget bounds the whole held-claim release pass.

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1847,24 +1847,17 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer, jsonOutput ...bool
 	// the close path was previously missing (gastownhall/gascity#2625).
 	//
 	// The scan leads with the WORK store here, unlike the reconciler's, which
-	// leads with the sessions-class store. On a split city that difference is
-	// the whole release tier for relocated work: claim-time class routing
+	// leads with the sessions-class store. On a split city that difference used
+	// to be the whole release tier for relocated work: claim-time class routing
 	// (claim_class_route.go) can leave an in_progress assignee in the graph
-	// binding, and a work-led scan cannot see it. So the binding is handed in as
-	// a class leg — the same graphClassBinding identity the claim routes on, from
-	// the same one-shot funnel — and dropped again on a city that relocates
-	// nothing.
+	// binding, and a work-led scan cannot see it. The binding is now a leg of
+	// the sweep's own plan (assignedWorkSweepPlan), so this site hands in
+	// nothing and a city that relocates nothing still reads one store.
 	var rigStores map[string]beads.Store
-	var classStores []beads.Store
 	if cityErr == nil && cfg != nil {
 		rigStores = buildStandaloneRigStores(cfg, cityPath, stderr)
 	}
-	if cityErr == nil {
-		if binding, relocated := graphClassBinding(cliStorageRoutes(cityPath)); relocated {
-			classStores = append(classStores, binding)
-		}
-	}
-	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, closedSessionBead, "", stderr, classStores...)
+	unclaimWorkAssignedToRetiredSessionBead(cityPath, cfg, store, rigStores, closedSessionBead, "", stderr)
 
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1031,7 +1031,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		poolDesired = make(map[string]int)
 	}
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
-	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, oneShotStore, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	reconcileSessionBeadsAtPathWithNamedDemand(
 		sigCtx, cityPath, sessionBeads.OpenForReconcile(), sessionBeads, ds, cfgNames, cfg, sp, sessStore,
 		nil, awakeAssignedWorkBeads, rigStores, nil, dt, nil, poolDesired,

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -2250,6 +2250,14 @@ func reconcileCities(
 			continue
 		}
 
+		// The lock holder — and only the lock holder — is this process's
+		// residency answer for the city. The runtime above already opened its
+		// binding, but registering it at construction time would let a
+		// replacement that LOSES this lock repoint the live city's release
+		// sweeps at a handle it is about to close. Same reason the socket is
+		// started after the lock rather than before it.
+		registerResidencyRoutes(path, cityRuntime.storageRoutes)
+
 		// Start controller socket AFTER the alreadyRunning check so we
 		// never destroy a live city's socket or leak a listener.
 		sockPath := controllerSocketPath(path)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1380,6 +1380,12 @@ func runController(
 		return 1
 	}
 
+	// This process is the city's controller — the lock above says so — so its
+	// opened binding is the residency answer the assigned-work spine reads.
+	// Registered here rather than inside newCityRuntime because the supervisor
+	// path constructs a runtime before it knows whether it holds the lock.
+	registerResidencyRoutes(cityPath, cr.storageRoutes)
+
 	// Install controller-managed bead stores even when the HTTP API is
 	// disabled. Standalone runtime still needs cached city/rig stores for
 	// session-bead sync and rig-scoped wake decisions.

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -57,7 +57,7 @@ func TestRepairStrandedPoolWorkerBead_ReopensAfterConfirmationWindow(t *testing.
 	session.Metadata[strandedEventEmittedKey] = now.Add(-strandedRepairConfirmGrace - time.Minute).Format(time.RFC3339)
 
 	var stderr bytes.Buffer
-	repaired := repairStrandedPoolWorkerBead(store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr)
+	repaired := repairStrandedPoolWorkerBead("", nil, store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr)
 	if !repaired {
 		t.Fatalf("expected repair to close the session bead; stderr=%q", stderr.String())
 	}
@@ -83,7 +83,7 @@ func TestRepairStrandedPoolWorkerBead_DefersInsideConfirmationWindow(t *testing.
 	session.Metadata[strandedEventEmittedKey] = now.Format(time.RFC3339) // just observed
 
 	var stderr bytes.Buffer
-	if repairStrandedPoolWorkerBead(store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr) {
+	if repairStrandedPoolWorkerBead("", nil, store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr) {
 		t.Fatalf("must not repair inside the confirmation window")
 	}
 	gotWork, _ := store.Get(work.ID)
@@ -119,7 +119,7 @@ func TestRepairStrandedPoolWorkerBead_DefersAndKeepsSessionOpenWhenUnassignFails
 	session.Metadata[strandedEventEmittedKey] = now.Add(-strandedRepairConfirmGrace - time.Minute).Format(time.RFC3339)
 
 	var stderr bytes.Buffer
-	if repairStrandedPoolWorkerBead(store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr) {
+	if repairStrandedPoolWorkerBead("", nil, store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr) {
 		t.Fatal("repair must return false when an unassign does not land")
 	}
 	gotWork, _ := base.Get(work.ID)
@@ -143,7 +143,7 @@ func TestRepairStrandedPoolWorkerBead_DefersWithoutStrandedMarker(t *testing.T) 
 	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 
 	var stderr bytes.Buffer
-	if repairStrandedPoolWorkerBead(store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr) {
+	if repairStrandedPoolWorkerBead("", nil, store, nil, seedSessionInfo(session), "worker", &clock.Fake{Time: now}, &stderr) {
 		t.Fatalf("must not repair without a stranded marker")
 	}
 	gotWork, _ := store.Get(work.ID)

--- a/cmd/gc/drain_ack_release_test.go
+++ b/cmd/gc/drain_ack_release_test.go
@@ -90,8 +90,13 @@ func TestDrainAckReleasesUnexecutedClaims(t *testing.T) {
 		Title: "held in the relocated binding", Type: "task",
 	}, "in_progress", "worker-1")
 
+	// The binding is a leg of the sweep's own plan now, not an argument: the
+	// city SERVES it, so the routes are what say so.
+	cityPath := t.TempDir()
+	seedSplitRoutes(t, cityPath, binding)
+
 	var stderr bytes.Buffer
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr, binding)
+	releaseUnexecutedClaimsOnDrainAck(cityPath, nil, work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
 
 	for _, tc := range []struct {
 		name  string
@@ -120,7 +125,7 @@ func TestDrainAckLeavesForeignClaimsAlone(t *testing.T) {
 	}, "in_progress", "worker-2")
 
 	var stderr bytes.Buffer
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
+	releaseUnexecutedClaimsOnDrainAck("", nil, work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
 
 	status, assignee := drainAckBeadStatus(t, work, foreign.ID)
 	if status != "in_progress" || assignee != "worker-2" {
@@ -139,7 +144,7 @@ func TestDrainAckLeavesPreassignedOpenSiblingsAlone(t *testing.T) {
 	}, "open", "worker-1")
 
 	var stderr bytes.Buffer
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
+	releaseUnexecutedClaimsOnDrainAck("", nil, work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
 
 	status, assignee := drainAckBeadStatus(t, work, sibling.ID)
 	if status != "open" || assignee != "worker-1" {
@@ -160,7 +165,7 @@ func TestDrainAckLeavesClosedWorkAlone(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
+	releaseUnexecutedClaimsOnDrainAck("", nil, work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
 
 	if status, _ := drainAckBeadStatus(t, work, done.ID); status != "closed" {
 		t.Fatalf("closed bead %s became status=%q after drain-ack, want it left closed", done.ID, status)
@@ -182,7 +187,7 @@ func TestDrainAckLeavesSessionAndMailBeadsAlone(t *testing.T) {
 	}, "in_progress", "worker-1")
 
 	var stderr bytes.Buffer
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
+	releaseUnexecutedClaimsOnDrainAck("", nil, work, nil, drainAckSessionBead(), drainAckReleaseBudget, &stderr)
 
 	for _, id := range []string{sessionRow.ID, message.ID} {
 		status, assignee := drainAckBeadStatus(t, work, id)
@@ -208,7 +213,7 @@ func TestDrainAckReleaseHonorsItsBudget(t *testing.T) {
 
 	var stderr bytes.Buffer
 	// A budget that cannot admit even the first leg.
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), -time.Second, &stderr)
+	releaseUnexecutedClaimsOnDrainAck("", nil, work, nil, drainAckSessionBead(), -time.Second, &stderr)
 
 	status, assignee := drainAckBeadStatus(t, work, held.ID)
 	if status != "in_progress" || assignee != "worker-1" {
@@ -229,7 +234,7 @@ func TestDrainAckReleaseWithinBudgetStillReleases(t *testing.T) {
 	}, "in_progress", "worker-1")
 
 	var stderr bytes.Buffer
-	releaseUnexecutedClaimsOnDrainAck(work, nil, drainAckSessionBead(), time.Minute, &stderr)
+	releaseUnexecutedClaimsOnDrainAck("", nil, work, nil, drainAckSessionBead(), time.Minute, &stderr)
 
 	status, assignee := drainAckBeadStatus(t, work, held.ID)
 	if status != "open" || assignee != "" {

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -286,7 +286,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBead_UsesLiveOpenOwnership(t *testin
 	}
 
 	unclaimWorkAssignedToRetiredSessionBead(
-		cache,
+		"", nil, cache,
 		nil,
 		beads.Bead{ID: "retired-session"},
 		"worker",
@@ -318,7 +318,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBead_IncludesEphemeralWork(t *testin
 	}
 
 	unclaimWorkAssignedToRetiredSessionBead(
-		store,
+		"", nil, store,
 		nil,
 		beads.Bead{ID: "retired-session"},
 		"worker",
@@ -359,7 +359,7 @@ func TestReassignWorkAssignedToRetiredSessionBead_IncludesEphemeralWork(t *testi
 	}
 
 	reassignWorkAssignedToRetiredSessionBead(
-		store,
+		"", nil, store,
 		nil,
 		beads.Bead{ID: "retired-session"},
 		"replacement-session",

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -78,13 +78,13 @@ func PoolSessionName(template, beadID string) string {
 // typed session.Info projection (WI-5 W4); the close is a session-class op
 // routed through the session front door. Returns the IDs of session beads
 // that were closed.
-func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, sessionInfos []session.Info) []string {
+func GCSweepSessionBeads(cityPath string, store beads.Store, rigStores map[string]beads.Store, sessionInfos []session.Info) []string {
 	var closed []string
 	for _, info := range sessionInfos {
 		if info.Closed {
 			continue
 		}
-		if !closeSessionInfoIfUnassigned(store, rigStores, nil, info, "gc_swept", time.Now().UTC(), nil) {
+		if !closeSessionInfoIfUnassigned(cityPath, store, rigStores, nil, info, "gc_swept", time.Now().UTC(), nil) {
 			continue
 		}
 		closed = append(closed, info.ID)

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -137,7 +137,7 @@ func releaseOrphanedPoolAssignments(
 		log.Printf("releaseOrphanedPoolAssignments: assigned work/store-ref length mismatch: work=%d storeRefs=%d", len(assignedWorkBeads), len(assignedWorkStoreRefs))
 	}
 
-	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, openSessionInfos, storeRefAware)
+	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, store, openSessionInfos, storeRefAware)
 	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionInfos)*5)
 	for _, info := range openSessionInfos {
 		if info.Closed {
@@ -295,11 +295,13 @@ const unresolvedOpenSessionStoreRef = "\x00unresolved"
 // The \x00 prefix cannot collide with a real rig name.
 const crossStoreOpenSessionStoreRef = "\x00crossstore"
 
-func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSessionInfos []session.Info, storeRefAware bool) map[string]map[string]struct{} {
+func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, leading beads.Store, openSessionInfos []session.Info, storeRefAware bool) map[string]map[string]struct{} {
 	index := make(map[string]map[string]struct{}, len(openSessionInfos)*5)
 	if !storeRefAware {
 		return index
 	}
+	// A property of the CITY, so it is resolved once rather than per session.
+	claimRefs := assignedWorkClaimRefs(cityPath, cfg, leading)
 	for _, info := range openSessionInfos {
 		if info.Closed {
 			continue
@@ -308,9 +310,11 @@ func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSession
 		// through Info for both the store-ref resolution and the assignee
 		// identities (WI-5 W4 — the boundary projection this loop used to carry
 		// moved to the snapshot's load edge).
-		storeRef := openSessionReachableStoreRefInfo(cityPath, cfg, info)
+		storeRefs := openSessionReachableStoreRefInfo(cityPath, cfg, claimRefs, info)
 		for _, id := range sessionBeadAssigneeIdentitiesInfo(info) {
-			addOpenSessionStoreRef(index, id, storeRef)
+			for _, storeRef := range storeRefs {
+				addOpenSessionStoreRef(index, id, storeRef)
+			}
 		}
 	}
 	return index

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -2495,7 +2495,7 @@ func gcSweepSessionBeadsFromBeads(store beads.Store, sessionBeads []beads.Bead) 
 	for _, b := range sessionBeads {
 		infos = append(infos, seedSessionInfo(b))
 	}
-	return GCSweepSessionBeads(store, nil, infos)
+	return GCSweepSessionBeads("", store, nil, infos)
 }
 
 func TestDirectSessionBeadIDCandidates_DerivesModernPoolSessionBeadID(t *testing.T) {

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -108,12 +108,27 @@ func residencyTopologyForCity(cityPath string, cfg *config.City, work beads.Stor
 }
 
 // registerResidencyRoutes records the routes a long-running runtime opened at
-// boot as this process's answer for cityPath. Wired into newCityRuntime, and
-// released by unregisterResidencyRoutes when the runtime closes them.
+// boot as this process's answer for cityPath.
 //
-// The one-shot memo for that city is dropped alongside, so a command that
-// already resolved the funnel in this process cannot keep answering from a
-// second set of handles.
+// # Call it only while holding the controller lock
+//
+// The lock is what makes "one registration per city" true. A supervisor builds
+// a replacement runtime — opening its own binding — BEFORE it learns whether the
+// predecessor has released the lock, so registering at construction time lets a
+// replacement that then LOSES the lock repoint a live city's release sweeps at a
+// handle it is about to close. Registering after the lock is taken means the
+// loser never registers at all, and the live runtime's registration stands
+// untouched. (`runController` already holds the lock before it constructs.)
+//
+// # What the memo drop does and does not do
+//
+// dropCLIResidencyBindings clears only the DERIVED per-city binding grouping
+// this file memoizes, so a later resolution re-reads the registry instead of a
+// pre-registration answer. It does NOT close or invalidate the one-shot
+// cliStorageRoutes funnel: a handle that funnel already opened in this process
+// stays open, and the 21 non-test sites that call cliStorageRoutes directly
+// keep using it. Neutralizing the funnel is not this slice's scope; keeping the spine off
+// it is.
 func registerResidencyRoutes(cityPath string, routes *storageRoutes) {
 	if cityPath == "" {
 		return
@@ -128,15 +143,27 @@ func registerResidencyRoutes(cityPath string, routes *storageRoutes) {
 	dropCLIResidencyBindings(key)
 }
 
-// unregisterResidencyRoutes drops a runtime's registration. The routes it named
-// are the runtime's to close; this only stops the spine from naming them.
-func unregisterResidencyRoutes(cityPath string) {
+// unregisterResidencyRoutes drops a runtime's registration, and ONLY its own.
+// The routes it named are the runtime's to close; this just stops the spine from
+// naming them.
+//
+// routes is the caller's own *storageRoutes, and the delete is conditional on
+// the registry still holding exactly that pointer — the same
+// unlink-only-if-ours discipline the supervisor uses for its socket. A
+// delete-by-key would let a runtime that lost the controller lock remove a
+// registration a live one had already replaced it with, and the live city's
+// release sweeps would fall back to the one-shot funnel: a second handle on the
+// binding root, or on a city the funnel cannot resolve, a binding-blind release
+// sweep with ga-j4ob9 back and silent.
+func unregisterResidencyRoutes(cityPath string, routes *storageRoutes) {
 	if cityPath == "" {
 		return
 	}
 	key := filepath.Clean(cityPath)
 	residencyRoutesMu.Lock()
-	delete(residencyRoutesByCity, key)
+	if current, ok := residencyRoutesByCity[key]; ok && current == routes {
+		delete(residencyRoutesByCity, key)
+	}
 	residencyRoutesMu.Unlock()
 	dropCLIResidencyBindings(key)
 }

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -86,6 +86,80 @@ func (cr *CityRuntime) residencyTopology() storeref.Topology {
 	return assembleResidencyTopology(cr.cfg, cr.cityBeadStore(), cr.rigBeadStores(), bindings, refused)
 }
 
+// residencyTopologyForCity builds a topology over the caller's own opened work
+// legs and the bindings THIS process serves for cityPath.
+//
+// It is the constructor for the assigned-work spine, whose scans are reached
+// from both planes through the same free functions — a reconciler tick and a
+// one-shot `gc session close` both call the same release sweep, and neither
+// carries a CityRuntime down to it. So the binding half is resolved by city
+// rather than by handle: a controller REGISTERS the routes it opened at boot
+// (registerResidencyRoutes) and every other caller falls back to the one-shot
+// funnel. That registration is not a convenience — resolving a controller's
+// bindings through the one-shot funnel would open a SECOND handle on the same
+// binding root, a duplicate managed-Dolt server or a second sqlite writer,
+// which is a worse bug than the blindness this closes.
+func residencyTopologyForCity(cityPath string, cfg *config.City, work beads.Store, rigs map[string]beads.Store) storeref.Topology {
+	if routes, ok := registeredResidencyRoutes(cityPath); ok {
+		bindings, refused := residencyBindingsFromRoutes(routes)
+		return assembleResidencyTopology(cfg, work, rigs, bindings, refused)
+	}
+	return cliResidencyTopology(cityPath, cfg, work, rigs)
+}
+
+// registerResidencyRoutes records the routes a long-running runtime opened at
+// boot as this process's answer for cityPath. Wired into newCityRuntime, and
+// released by unregisterResidencyRoutes when the runtime closes them.
+//
+// The one-shot memo for that city is dropped alongside, so a command that
+// already resolved the funnel in this process cannot keep answering from a
+// second set of handles.
+func registerResidencyRoutes(cityPath string, routes *storageRoutes) {
+	if cityPath == "" {
+		return
+	}
+	key := filepath.Clean(cityPath)
+	residencyRoutesMu.Lock()
+	if residencyRoutesByCity == nil {
+		residencyRoutesByCity = make(map[string]*storageRoutes, 1)
+	}
+	residencyRoutesByCity[key] = routes
+	residencyRoutesMu.Unlock()
+	dropCLIResidencyBindings(key)
+}
+
+// unregisterResidencyRoutes drops a runtime's registration. The routes it named
+// are the runtime's to close; this only stops the spine from naming them.
+func unregisterResidencyRoutes(cityPath string) {
+	if cityPath == "" {
+		return
+	}
+	key := filepath.Clean(cityPath)
+	residencyRoutesMu.Lock()
+	delete(residencyRoutesByCity, key)
+	residencyRoutesMu.Unlock()
+	dropCLIResidencyBindings(key)
+}
+
+// registeredResidencyRoutes reports the runtime-registered routes for a city.
+// The bool distinguishes "this process serves the city and relocates nothing"
+// (registered nil routes) from "no runtime here", which is what keeps a
+// single-store controller off the one-shot funnel entirely.
+func registeredResidencyRoutes(cityPath string) (*storageRoutes, bool) {
+	if cityPath == "" {
+		return nil, false
+	}
+	residencyRoutesMu.Lock()
+	defer residencyRoutesMu.Unlock()
+	routes, ok := residencyRoutesByCity[filepath.Clean(cityPath)]
+	return routes, ok
+}
+
+var (
+	residencyRoutesMu     sync.Mutex
+	residencyRoutesByCity map[string]*storageRoutes
+)
+
 // cliResidencyBindingsEntry is one city's resolved bindings, computed at most
 // once per process.
 type cliResidencyBindingsEntry struct {
@@ -140,6 +214,13 @@ func cliResidencyBindings(cityPath string) ([]storeref.ClassBinding, error) {
 func resetCLIResidencyBindings() {
 	cliResidencyBindingsMu.Lock()
 	cliResidencyBindingsByCity = nil
+	cliResidencyBindingsMu.Unlock()
+}
+
+// dropCLIResidencyBindings drops one city's memoized funnel answer.
+func dropCLIResidencyBindings(key string) {
+	cliResidencyBindingsMu.Lock()
+	delete(cliResidencyBindingsByCity, key)
 	cliResidencyBindingsMu.Unlock()
 }
 

--- a/cmd/gc/session_alias_assignment_guard_test.go
+++ b/cmd/gc/session_alias_assignment_guard_test.go
@@ -81,7 +81,7 @@ func TestDrainGuardsKeepPoolSessionClaimingUnderItsSessionName(t *testing.T) {
 	info := sessiontest.SeedBead(t, legacyAliasedPoolSessionBead("gcg-session-x", sessionName, "", ""))
 	mustCreateInProgressWork(t, store, sessionName)
 
-	has, err := sessionHasOpenAssignedWorkForConfigInfo(store, nil, info, aliasGuardConfig())
+	has, err := sessionHasOpenAssignedWorkForConfigInfo("", aliasGuardConfig(), store, nil, info)
 	if err != nil {
 		t.Fatalf("sessionHasOpenAssignedWorkForConfigInfo: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestAssignmentGuardsIgnoreTransientPoolSlotAliases(t *testing.T) {
 		mustCreateInProgressWork(t, store, assignee)
 	}
 
-	has, err := sessionHasOpenAssignedWorkForConfigInfo(store, nil, info, aliasGuardConfig())
+	has, err := sessionHasOpenAssignedWorkForConfigInfo("", aliasGuardConfig(), store, nil, info)
 	if err != nil {
 		t.Fatalf("sessionHasOpenAssignedWorkForConfigInfo: %v", err)
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1007,14 +1007,21 @@ func coordClassStoreCandidates(cfg *config.City, cityStore beads.Store, rigStore
 // in (claim_class_route.go escalates off the work store), and a leg that
 // resolved back to the leading store is deduped rather than scanned twice.
 //
-// These sweeps are VOID and their callers have no error channel, so a leg that
-// fails is logged by visit and the pass continues — deliberately NOT the
+// These sweeps are VOID and their callers have no error channel, so a leg whose
+// read fails is logged by visit and the pass continues — deliberately NOT the
 // resolver's fail-loud policy, because the alternative on a best-effort
 // idempotent sweep is releasing less on this tick and no diagnosis at all. The
 // gates that DO have an error channel consume the policy
-// (assignedWorkScanComplete). The bool this returns lets a caller that reports
-// a result — the stranded-repair path reads unclaimResult.Failed — refuse to
-// call a repair clean when a leg was never read.
+// (assignedWorkScanComplete).
+//
+// So be precise about what the bool means: visit returns nothing, so the
+// executor never sees a leg error and res.Partial is always false here. It
+// reports only that the city HAD a resolvable leg set — false is the refused
+// city, where every infrastructure class answers with the refusal and a
+// work-only sweep would release from the wrong ledger. Per-leg read failures
+// are surfaced by visit's own stderr line and, for the one caller that reports
+// a result, by unclaimResult.Failed; that is what stops the stranded-repair
+// path from calling a repair clean.
 func sweepAssignedWorkLegs(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, identifiers []string, stderr io.Writer, visit func(index int, s beads.Store)) bool {
 	if store == nil {
 		return false
@@ -1360,7 +1367,7 @@ func unclaimWorkAssignedToRetiredSessionInfo(
 		}
 	})
 	if !complete {
-		fmt.Fprintf(stderr, "session beads: the release sweep for retired session %s could not read every leg; not reporting a clean repair\n", retiredSession.ID) //nolint:errcheck
+		fmt.Fprintf(stderr, "session beads: the release sweep for retired session %s could not resolve this city's leg set; not reporting a clean repair\n", retiredSession.ID) //nolint:errcheck
 		res.Failed++
 	}
 	return res
@@ -1654,7 +1661,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		canonical, ok := bySessionName[sn]
 		if ok && canonical.ID != b.ID {
-			if closeSessionBeadIfUnassigned(store, rigStores, cfg, b, "duplicate", clk.Now().UTC(), stderr) {
+			if closeSessionBeadIfUnassigned(cityPath, store, rigStores, cfg, b, "duplicate", clk.Now().UTC(), stderr) {
 				openBeads[i].Status = "closed"
 			}
 		}
@@ -1699,7 +1706,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if strings.TrimSpace(b.Metadata["session_name"]) == spec.SessionName {
 				continue
 			}
-			if !closeSessionBeadIfRuntimeStoppedAndUnassigned(store, rigStores, sp, cfg, b, "reconfigured", "reconfigured named session", now, stderr) {
+			if !closeSessionBeadIfRuntimeStoppedAndUnassigned(cityPath, store, rigStores, sp, cfg, b, "reconfigured", "reconfigured named session", now, stderr) {
 				blockedReconfiguredNamedIdentities[identity] = true
 				continue
 			}
@@ -1778,7 +1785,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					if strings.TrimSpace(open.Metadata["session_name"]) != sn {
 						continue
 					}
-					if closeSessionBeadIfUnassigned(store, rigStores, cfg, open, "duplicate", now, stderr) {
+					if closeSessionBeadIfUnassigned(cityPath, store, rigStores, cfg, open, "duplicate", now, stderr) {
 						openBeads[i].Status = "closed"
 					}
 				}
@@ -2370,7 +2377,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				continue
 			}
 			if configuredNames[sn] {
-				if closeSessionBeadIfRuntimeStoppedAndUnassigned(store, rigStores, sp, cfg, b, "suspended", "suspended session", now, stderr) {
+				if closeSessionBeadIfRuntimeStoppedAndUnassigned(cityPath, store, rigStores, sp, cfg, b, "suspended", "suspended session", now, stderr) {
 					if idx, ok := indexBySessionName[sn]; ok {
 						openBeads[idx].Status = "closed"
 					}
@@ -2384,7 +2391,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 						}
 					}
 				}
-				if closeSessionBeadIfRuntimeStoppedAndUnassigned(store, rigStores, sp, cfg, b, "orphaned", "orphaned session", now, stderr) {
+				if closeSessionBeadIfRuntimeStoppedAndUnassigned(cityPath, store, rigStores, sp, cfg, b, "orphaned", "orphaned session", now, stderr) {
 					if idx, ok := indexBySessionName[sn]; ok {
 						openBeads[idx].Status = "closed"
 					}
@@ -3039,6 +3046,7 @@ func sweepProcessTableOrphans(
 }
 
 func closeSessionBeadIfRuntimeStoppedAndUnassigned(
+	cityPath string,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sp runtime.Provider,
@@ -3052,7 +3060,7 @@ func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, b, cfg)
+	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(cityPath, cfg, store, rigStores, b)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", b.ID, err) //nolint:errcheck
 		return false
@@ -3063,7 +3071,7 @@ func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	if !stopRuntimeBeforeSessionBeadMutation(store, sp, cfg, b, stopReason, stderr) {
 		return false
 	}
-	hasAssignedWork, err = sessionHasOpenAssignedWorkForConfig(store, rigStores, b, cfg)
+	hasAssignedWork, err = sessionHasOpenAssignedWorkForConfig(cityPath, cfg, store, rigStores, b)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", b.ID, err) //nolint:errcheck
 		return false

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // sessionBeadLabel is the label for all session beads.
@@ -564,6 +565,7 @@ func reopenClosedConfiguredNamedSessionBead(
 }
 
 func retireDuplicateConfiguredNamedSessionBeads(
+	cityPath string,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sp runtime.Provider,
@@ -626,7 +628,7 @@ func retireDuplicateConfiguredNamedSessionBeads(
 				fmt.Fprintf(stderr, "session beads: archiving duplicate named session %s: %v\n", b.ID, err) //nolint:errcheck
 				continue
 			}
-			reassignWorkAssignedToRetiredSessionBead(store, rigStores, b, openBeads[winner].ID, stderr)
+			reassignWorkAssignedToRetiredSessionBead(cityPath, cfg, store, rigStores, b, openBeads[winner].ID, stderr)
 			reassignStateAssignedToRetiredSessionBead(store, b.ID, openBeads[winner].ID, now, stderr)
 			if b.Metadata == nil {
 				b.Metadata = make(map[string]string, len(batch))
@@ -663,6 +665,7 @@ func retireDuplicateConfiguredNamedSessionBeads(
 // survives for the class-(c) sync path. TestRetireDuplicateRowsMatchesBeads pins
 // the both-ways equivalence.
 func retireDuplicateConfiguredNamedSessionRows(
+	cityPath string,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sp runtime.Provider,
@@ -727,7 +730,7 @@ func retireDuplicateConfiguredNamedSessionRows(
 				fmt.Fprintf(stderr, "session beads: archiving duplicate named session %s: %v\n", info.ID, err) //nolint:errcheck
 				continue
 			}
-			reassignWorkAssignedToRetiredSessionInfo(store, rigStores, info, rows[winner].Info.ID, stderr)
+			reassignWorkAssignedToRetiredSessionInfo(cityPath, cfg, store, rigStores, info, rows[winner].Info.ID, stderr)
 			reassignStateAssignedToRetiredSessionBead(store, info.ID, rows[winner].Info.ID, now, stderr)
 			rows[idx].Info = rows[idx].Info.ApplyPatch(batch)
 		}
@@ -787,6 +790,8 @@ func namedSessionWinsCanonicalRepairInfo(candidate, incumbent session.Info, cano
 }
 
 func retireRemovedConfiguredNamedSessionBead(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sp runtime.Provider,
@@ -812,7 +817,7 @@ func retireRemovedConfiguredNamedSessionBead(
 		fmt.Fprintf(stderr, "session beads: archiving removed named session %s: %v\n", b.ID, err) //nolint:errcheck
 		return false
 	}
-	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, b, retiredSessionFallbackRoute(b), stderr)
+	unclaimWorkAssignedToRetiredSessionBead(cityPath, cfg, store, rigStores, b, retiredSessionFallbackRoute(b), stderr)
 	cancelStateAssignedToRetiredSessionBead(store, b.ID, now, stderr)
 	return true
 }
@@ -991,63 +996,45 @@ func coordClassStoreCandidates(cfg *config.City, cityStore beads.Store, rigStore
 	return candidates
 }
 
-// workAssignmentStores is the work-class candidate builder for the
-// session-retirement reachability scans (unclaim/reassign): the city work store
-// prepended to every rig work store, ordered by rig name. Today every class
-// collapses to the same concrete store, so this returns the work arm of the
-// single-store city; a future per-class split routes work creates/queries here
-// without touching the call sites. Unlike coordClassStoreCandidates it has no
-// cfg/suspended context (the retirement scans run per session bead without a
-// suspension frame), so it fans out across all live rig stores by name.
+// sweepAssignedWorkLegs runs visit over the leg set a session-retirement scan
+// reads — the city/leading work store, every rig work store by name, then every
+// relocated class binding — and reports whether every leg was read.
 //
-// extra appends the stores a caller knows can ALSO hold work this session owns
-// but that are not work stores — today the relocated coordination-class binding,
-// which claim-time routing (claim_class_route.go) can write an in_progress
-// assignee into on a split city. A caller whose leading store already IS that
-// binding passes nothing: duplicates are dropped, so the leg cannot be scanned
-// twice. It goes LAST because it is the ledger of last resort, the same order
-// the claim reaches it in.
-func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store, extra ...beads.Store) []beads.Store {
+// It is the one place the unclaim/reassign/drain-ack family gets its stores, so
+// "release reads the stores the claim can land in" is true by construction
+// rather than by four lists that have to be kept in step. The binding goes LAST
+// because it is the ledger of last resort, the same order the claim reaches it
+// in (claim_class_route.go escalates off the work store), and a leg that
+// resolved back to the leading store is deduped rather than scanned twice.
+//
+// These sweeps are VOID and their callers have no error channel, so a leg that
+// fails is logged by visit and the pass continues — deliberately NOT the
+// resolver's fail-loud policy, because the alternative on a best-effort
+// idempotent sweep is releasing less on this tick and no diagnosis at all. The
+// gates that DO have an error channel consume the policy
+// (assignedWorkScanComplete). The bool this returns lets a caller that reports
+// a result — the stranded-repair path reads unclaimResult.Failed — refuse to
+// call a repair clean when a leg was never read.
+func sweepAssignedWorkLegs(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, identifiers []string, stderr io.Writer, visit func(index int, s beads.Store)) bool {
 	if store == nil {
-		return nil
-	}
-	stores := []beads.Store{store}
-	names := make([]string, 0, len(rigStores))
-	for name, rs := range rigStores {
-		if rs == nil {
-			continue
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		stores = append(stores, rigStores[name])
-	}
-	for _, candidate := range extra {
-		if candidate == nil || workAssignmentStoresHave(stores, candidate) {
-			continue
-		}
-		stores = append(stores, candidate)
-	}
-	return stores
-}
-
-// workAssignmentStoresHave reports whether candidate is already a leg. The
-// sessions and graph classes are served from ONE binding on a converged split
-// (openStorageRoutes keys every assigned class to the engine it opened), so a
-// reconciler scan led by the sessions-class store is already reading the store a
-// caller would add here.
-func workAssignmentStoresHave(stores []beads.Store, candidate beads.Store) bool {
-	key, ok := storePointerKey(candidate)
-	if !ok {
 		return false
 	}
-	for _, existing := range stores {
-		if existingKey, ok := storePointerKey(existing); ok && existingKey == key {
-			return true
-		}
+	plan, err := assignedWorkSweepPlan(cityPath, cfg, store, rigStores, identifiers)
+	if err != nil {
+		// A refused city: its infrastructure classes answer nothing, and a
+		// work-only sweep would release from the wrong ledger. Say so — the
+		// refusal names the remedy, and a release pass that silently did
+		// nothing is indistinguishable from one that found nothing.
+		fmt.Fprintf(stderr, "session beads: no assigned-work leg set for this city: %v\n", err) //nolint:errcheck
+		return false
 	}
-	return false
+	index := 0
+	res, walkErr := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		visit(index, leg.Store)
+		index++
+		return false, nil
+	})
+	return walkErr == nil && !res.Partial
 }
 
 // unclaimResult reports the outcome of one unassign sweep over a retired
@@ -1068,20 +1055,24 @@ type unclaimResult struct {
 }
 
 // unclaimWorkAssignedToRetiredSessionBead detaches every work bead a retired
-// session still owns, across the reachability scan workAssignmentStores builds.
+// session still owns, across the leg set sweepAssignedWorkLegs resolves.
 //
-// classStores are the non-work ledgers this caller knows can also hold work the
-// session owns. The reconciler leads with the sessions-class store, which on a
-// converged split IS the binding, so it passes none; a caller that leads with
-// the WORK store — `gc session close` — passes the relocated graph binding, or a
-// claim that claim_class_route.go routed there would be released by nothing.
+// The binding is one of those legs on every caller now, which it was not before:
+// the reconciler leads with the sessions-class store (on a converged split, the
+// binding itself), while `gc session close` and the stranded-repair sweep lead
+// with the WORK store and used to hand the leg in by hand — or, in the Info
+// twin's case, not at all. A claim claim_class_route.go routed into the binding
+// was released by nothing on those paths, and a session that died without
+// drain-ack stranded it until an operator ran `gc bd release-if-current`
+// (ga-j4ob9).
 func unclaimWorkAssignedToRetiredSessionBead(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sessionBead beads.Bead,
 	fallbackRoute string,
 	stderr io.Writer,
-	classStores ...beads.Store,
 ) {
 	if store == nil || strings.TrimSpace(sessionBead.ID) == "" {
 		return
@@ -1091,7 +1082,7 @@ func unclaimWorkAssignedToRetiredSessionBead(
 	}
 	identifiers := sessionAssignmentIdentifiers(sessionBead)
 	seen := make(map[string]struct{})
-	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores, classStores...) {
+	sweepAssignedWorkLegs(cityPath, cfg, store, rigStores, identifiers, stderr, func(storeIndex int, ownerStore beads.Store) {
 		wa := workAssignmentForStore(beads.WorkStore{Store: ownerStore})
 		for _, status := range []string{"open", "in_progress"} {
 			for _, assignee := range identifiers {
@@ -1124,7 +1115,7 @@ func unclaimWorkAssignedToRetiredSessionBead(
 				}
 			}
 		}
-	}
+	})
 }
 
 // releaseUnexecutedClaimsOnDrainAck gives back every in_progress WORK bead this
@@ -1146,19 +1137,20 @@ func unclaimWorkAssignedToRetiredSessionBead(
 // second implementation of "release this session's work" is a second chance to
 // disagree with the first.
 //
-// classStores are the non-work ledgers that can also hold work this session
-// owns — today the relocated coordination-class binding, which claim-time
-// routing (claim_class_route.go) writes in_progress assignees into on a split
-// city. Without it a graph-resident claim would be released by nothing.
-// budget bounds the whole pass; see drainAckReleaseBudget for why drain-ack in
-// particular must not wait on a slow store.
+// The leg set is sweepAssignedWorkLegs' — the same one the retired-session
+// sweep reads, which is the point: "demand and sweep read the same stores" holds
+// by construction, and a graph-resident claim is released here by the same leg
+// that would have released it there. budget bounds the whole pass; see
+// drainAckReleaseBudget for why drain-ack in particular must not wait on a slow
+// store.
 func releaseUnexecutedClaimsOnDrainAck(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	sessionBead beads.Bead,
 	budget time.Duration,
 	stderr io.Writer,
-	classStores ...beads.Store,
 ) {
 	if store == nil || strings.TrimSpace(sessionBead.ID) == "" {
 		return
@@ -1169,14 +1161,20 @@ func releaseUnexecutedClaimsOnDrainAck(
 	identifiers := sessionAssignmentIdentifiers(sessionBead)
 	seen := make(map[string]struct{})
 	deadline := time.Now().Add(budget)
-	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores, classStores...) { // residency:allow same leg set as unclaimWorkAssignedToRetiredSessionBead; resolving it separately would let the two release paths disagree
+	expired := false
+	sweepAssignedWorkLegs(cityPath, cfg, store, rigStores, identifiers, stderr, func(storeIndex int, ownerStore beads.Store) {
+		if expired {
+			return
+		}
 		if time.Now().After(deadline) {
+			expired = true
 			fmt.Fprintf(stderr, "session beads: held-claim release for draining session %s ran out of its %s budget; remaining legs are left to the dead-assignee sweep\n", sessionBead.ID, budget) //nolint:errcheck
 			return
 		}
 		wa := workAssignmentForStore(beads.WorkStore{Store: ownerStore})
 		for _, assignee := range identifiers {
 			if time.Now().After(deadline) {
+				expired = true
 				fmt.Fprintf(stderr, "session beads: held-claim release for draining session %s ran out of its %s budget; remaining identities are left to the dead-assignee sweep\n", sessionBead.ID, budget) //nolint:errcheck
 				return
 			}
@@ -1203,10 +1201,12 @@ func releaseUnexecutedClaimsOnDrainAck(
 				}
 			}
 		}
-	}
+	})
 }
 
 func reassignWorkAssignedToRetiredSessionBead(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	retiredSession beads.Bead,
@@ -1221,7 +1221,7 @@ func reassignWorkAssignedToRetiredSessionBead(
 	}
 	identifiers := sessionAssignmentIdentifiers(retiredSession)
 	seen := make(map[string]struct{})
-	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores) {
+	sweepAssignedWorkLegs(cityPath, cfg, store, rigStores, identifiers, stderr, func(storeIndex int, ownerStore beads.Store) {
 		wa := workAssignmentForStore(beads.WorkStore{Store: ownerStore})
 		for _, status := range []string{"open", "in_progress"} {
 			for _, assignee := range identifiers {
@@ -1245,7 +1245,7 @@ func reassignWorkAssignedToRetiredSessionBead(
 				}
 			}
 		}
-	}
+	})
 }
 
 // reassignWorkAssignedToRetiredSessionInfo is the session.Info form of
@@ -1254,6 +1254,8 @@ func reassignWorkAssignedToRetiredSessionBead(
 // work-store fan-out and per-bead reassignment stay bead-shaped (ClassWork). It
 // is byte-identical to the raw form; the raw form survives for the sync path.
 func reassignWorkAssignedToRetiredSessionInfo(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	retiredSession session.Info,
@@ -1268,7 +1270,7 @@ func reassignWorkAssignedToRetiredSessionInfo(
 	}
 	identifiers := sessionAssignmentIdentifiersInfo(retiredSession)
 	seen := make(map[string]struct{})
-	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores) {
+	sweepAssignedWorkLegs(cityPath, cfg, store, rigStores, identifiers, stderr, func(storeIndex int, ownerStore beads.Store) {
 		wa := workAssignmentForStore(beads.WorkStore{Store: ownerStore})
 		for _, status := range []string{"open", "in_progress"} {
 			for _, assignee := range identifiers {
@@ -1292,7 +1294,7 @@ func reassignWorkAssignedToRetiredSessionInfo(
 				}
 			}
 		}
-	}
+	})
 }
 
 // unclaimWorkAssignedToRetiredSessionInfo is the session.Info form of
@@ -1301,7 +1303,14 @@ func reassignWorkAssignedToRetiredSessionInfo(
 // work-store fan-out and per-bead release stay bead-shaped (ClassWork). It is
 // byte-identical to the raw form and returns the same unclaimResult; the raw
 // form survives for the whole-bead retirement and closed-session release paths.
+//
+// Failed counts a leg the sweep could not read as well as a release that
+// errored: the stranded-repair caller reads it to avoid reporting a clean repair
+// — or closing the session bead — when the work might still be assigned
+// somewhere it never looked.
 func unclaimWorkAssignedToRetiredSessionInfo(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	retiredSession session.Info,
@@ -1317,13 +1326,14 @@ func unclaimWorkAssignedToRetiredSessionInfo(
 	}
 	identifiers := sessionAssignmentIdentifiersInfo(retiredSession)
 	seen := make(map[string]struct{})
-	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores) {
+	complete := sweepAssignedWorkLegs(cityPath, cfg, store, rigStores, identifiers, stderr, func(storeIndex int, ownerStore beads.Store) {
 		wa := workAssignmentForStore(beads.WorkStore{Store: ownerStore})
 		for _, status := range []string{"open", "in_progress"} {
 			for _, assignee := range identifiers {
 				work, err := wa.OpenAssignedTo(assignee, status, beads.TierBoth, true)
 				if err != nil {
 					fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s via %q: %v\n", retiredSession.ID, assignee, err) //nolint:errcheck
+					res.Failed++
 					continue
 				}
 				for _, item := range work {
@@ -1348,6 +1358,10 @@ func unclaimWorkAssignedToRetiredSessionInfo(
 				}
 			}
 		}
+	})
+	if !complete {
+		fmt.Fprintf(stderr, "session beads: the release sweep for retired session %s could not read every leg; not reporting a clean repair\n", retiredSession.ID) //nolint:errcheck
+		res.Failed++
 	}
 	return res
 }
@@ -1406,6 +1420,8 @@ const strandedRepairCloseReason = "stranded-repair"
 // bead, so the caller mirrors MarkClosed onto the snapshot and prunes the
 // worktree exactly as the clean close path does.
 func repairStrandedPoolWorkerBead(
+	cityPath string,
+	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info session.Info,
@@ -1428,7 +1444,7 @@ func repairStrandedPoolWorkerBead(
 	if first.IsZero() || now.Sub(first) < strandedRepairConfirmGrace {
 		return false // inside the confirmation window — defer the destructive clear
 	}
-	res := unclaimWorkAssignedToRetiredSessionInfo(store, rigStores, info, fallbackRoute, stderr)
+	res := unclaimWorkAssignedToRetiredSessionInfo(cityPath, cfg, store, rigStores, info, fallbackRoute, stderr)
 	if res.Failed > 0 {
 		// At least one unassign did not land. Do NOT close the session bead or
 		// report a repair: closing now would strand the still-assigned work
@@ -1691,7 +1707,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			openBeads[i].Status = "closed"
 		}
 		openBeads = retireDuplicateConfiguredNamedSessionBeads(
-			store, rigStores, sp, cfg, cityName, openBeads, bySessionName, indexBySessionName, now, stderr,
+			cityPath, store, rigStores, sp, cfg, cityName, openBeads, bySessionName, indexBySessionName, now, stderr,
 		)
 	}
 
@@ -2330,7 +2346,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if isNamedSessionBead(b) {
 				identity := namedSessionIdentity(b)
 				if identity != "" && (cfg == nil || config.FindNamedSession(cfg, identity) == nil) {
-					if retireRemovedConfiguredNamedSessionBead(store, rigStores, sp, b, now, stderr) {
+					if retireRemovedConfiguredNamedSessionBead(cityPath, cfg, store, rigStores, sp, b, now, stderr) {
 						if idx, ok := indexBySessionName[sn]; ok {
 							openBeads[idx].Status = "open"
 							if openBeads[idx].Metadata == nil {

--- a/cmd/gc/session_beads_mail_release_test.go
+++ b/cmd/gc/session_beads_mail_release_test.go
@@ -179,7 +179,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBeadLeavesMailBeadUntouched(t *testi
 	}
 
 	var stderr bytes.Buffer
-	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "fallback/worker", &stderr)
+	unclaimWorkAssignedToRetiredSessionBead("", nil, store, nil, sessionBead, "fallback/worker", &stderr)
 
 	gotMail, err := store.Get(mailBead.ID)
 	if err != nil {

--- a/cmd/gc/session_beads_retire_rows_recorder_test.go
+++ b/cmd/gc/session_beads_retire_rows_recorder_test.go
@@ -67,7 +67,7 @@ func TestRetireDuplicateRows_RecordsTypedRetirementForShadow(t *testing.T) {
 		{Info: sessiontest.SeedBead(t, mustGet(t, store, loser))},
 	}
 
-	retireDuplicateConfiguredNamedSessionRows(store, nil, runtime.NewFake(), cfg, cityName, rows, now, nil)
+	retireDuplicateConfiguredNamedSessionRows("", store, nil, runtime.NewFake(), cfg, cityName, rows, now, nil)
 
 	// The loser's typed retirement must have recorded the compared canonical-identity
 	// clears; the winner must not have been retired.

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1847,7 +1847,7 @@ func TestRetireDuplicateConfiguredNamedSessionBeads_DoesNotStopWinnerSharingSess
 	indexBySessionName := map[string]int{sessionName: 1}
 
 	retired := retireDuplicateConfiguredNamedSessionBeads(
-		store, nil, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
+		"", store, nil, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
 	)
 
 	if !sp.IsRunning(sessionName) {
@@ -1974,7 +1974,7 @@ func TestRetireDuplicateConfiguredNamedSessionBeads_StopFailureKeepsRuntimeOwner
 	}
 
 	retired := retireDuplicateConfiguredNamedSessionBeads(
-		store, nil, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
+		"", store, nil, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
 	)
 
 	if !sp.IsRunning(loserSessionName) {
@@ -2032,7 +2032,7 @@ func TestRetireRemovedConfiguredNamedSessionBead_StopFailureKeepsRuntimeOwner(t 
 	}
 
 	var stderr bytes.Buffer
-	retired := retireRemovedConfiguredNamedSessionBead(store, nil, sp, b, now, &stderr)
+	retired := retireRemovedConfiguredNamedSessionBead("", nil, store, nil, sp, b, now, &stderr)
 
 	if retired {
 		t.Fatal("retireRemovedConfiguredNamedSessionBead returned true after runtime stop failed")
@@ -7765,7 +7765,7 @@ func TestUnclaimResetsInProgressStatus(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "myrig/codex-max", &stderr)
+	unclaimWorkAssignedToRetiredSessionBead("", nil, store, nil, sessionBead, "myrig/codex-max", &stderr)
 
 	gotInProgress, err := store.Get(work.ID)
 	if err != nil {
@@ -7821,7 +7821,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBeadPreservesRunTargetRoute(t *testi
 	}
 
 	var stderr bytes.Buffer
-	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "fallback/worker", &stderr)
+	unclaimWorkAssignedToRetiredSessionBead("", nil, store, nil, sessionBead, "fallback/worker", &stderr)
 
 	got, err := store.Get(work.ID)
 	if err != nil {
@@ -7881,7 +7881,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBeadClearsSessionAffinity(t *testing
 	}
 
 	var stderr bytes.Buffer
-	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "fallback/worker", &stderr)
+	unclaimWorkAssignedToRetiredSessionBead("", nil, store, nil, sessionBead, "fallback/worker", &stderr)
 
 	got, err := store.Get(work.ID)
 	if err != nil {
@@ -8287,7 +8287,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBeadClearsRigStoreSessionIdentifiers
 
 	var stderr bytes.Buffer
 	unclaimWorkAssignedToRetiredSessionBead(
-		store,
+		"", nil, store,
 		map[string]beads.Store{"frontend": rigStore},
 		sessionBead,
 		"frontend/codex-max",
@@ -8372,7 +8372,7 @@ func TestReassignWorkAssignedToRetiredSessionBeadReassignsRigStoreSessionIdentif
 
 	var stderr bytes.Buffer
 	reassignWorkAssignedToRetiredSessionBead(
-		store,
+		"", nil, store,
 		map[string]beads.Store{"frontend": rigStore},
 		retired,
 		successor.ID,

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2096,6 +2096,7 @@ func TestCloseSessionBeadIfRuntimeStoppedAndUnassigned_RechecksAssignedWorkAfter
 
 	var stderr bytes.Buffer
 	closed := closeSessionBeadIfRuntimeStoppedAndUnassigned(
+		"",
 		store, nil, sp, nil, b, "suspended", "suspended session", now, &stderr,
 	)
 
@@ -2139,6 +2140,7 @@ func TestCloseSessionBeadIfRuntimeStoppedAndUnassigned_StopLeavesRunningKeepsBea
 
 	var stderr bytes.Buffer
 	closed := closeSessionBeadIfRuntimeStoppedAndUnassigned(
+		"",
 		store, nil, sp, nil, b, "orphaned", "orphaned session", now, &stderr,
 	)
 
@@ -2206,6 +2208,7 @@ func TestCloseSessionBeadIfRuntimeStoppedAndUnassignedPreservesConfiguredNamedSe
 
 	var stderr bytes.Buffer
 	closed := closeSessionBeadIfRuntimeStoppedAndUnassigned(
+		"",
 		store, nil, sp, cfg, b, "suspended", "suspended session", now, &stderr,
 	)
 
@@ -8233,7 +8236,7 @@ func TestCloseSessionBeadIfUnassignedRefusesWhenRigStoreWorkAssignedBySessionNam
 
 	var stderr bytes.Buffer
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	if closeSessionBeadIfUnassigned(store, map[string]beads.Store{"demo": rigStore}, nil, sessionBead, "stale-session", now, &stderr) {
+	if closeSessionBeadIfUnassigned("", store, map[string]beads.Store{"demo": rigStore}, nil, sessionBead, "stale-session", now, &stderr) {
 		t.Fatal("closeSessionBeadIfUnassigned returned true; want false because rig-store work is still assigned by session_name")
 	}
 	got, err := store.Get(sessionBead.ID)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2036,7 +2036,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if configuredNames[name] {
 						reason = "suspended"
 					}
-					hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForConfigInfo(store, rigStores, infoByID[id], cfg)
+					hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForConfigInfo(cityPath, cfg, store, rigStores, infoByID[id])
 					if assignedErr != nil {
 						fmt.Fprintf(stderr, "session reconciler: checking assigned work before %s drain for %s: %v\n", reason, name, assignedErr) //nolint:errcheck
 						continue
@@ -2453,7 +2453,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				holdsClaim := false
 				claimKnown := true
 				if !exempt && (!floorExempt || claimHolderThreshold > 0) {
-					has, err := sessionHasInProgressAssignedWorkForConfig(store, rigStores, infoByID[id], cfg)
+					has, err := sessionHasInProgressAssignedWorkForConfig(cityPath, cfg, store, rigStores, infoByID[id])
 					if err != nil {
 						// Fail safe: an unreadable claim check must not recycle a
 						// session that may hold in-progress work. Mirrors the drain
@@ -3906,28 +3906,36 @@ func resolvePreservedConfiguredNamedSessionTemplate(
 }
 
 // sessionHasOpenAssignedWorkForConfig uses the same configured-named-session
-// fallback identity strategy as sessionAssigneeMatches, but queries all known
-// stores instead of a single configured reachable store. Use this cross-store
-// query for cleanup-of-record paths that must not orphan work in any attached
-// store; callers preserve fail-closed behavior by refusing close decisions on
-// query errors.
-func sessionHasOpenAssignedWorkForConfig(store beads.Store, rigStores map[string]beads.Store, session beads.Bead, cfg *config.City) (bool, error) {
-	return sessionHasOpenAssignedWorkInStores(store, rigStores, sessionAssignmentIdentifiersForConfig(session, cfg))
+// fallback identity strategy as sessionAssigneeMatches, but queries every store
+// the city serves instead of a single configured reachable store. Use this
+// cross-store query for cleanup-of-record paths that must not orphan work in any
+// attached store; callers preserve fail-closed behavior by refusing close
+// decisions on query errors.
+//
+// "Every store" is the residency resolver's answer, not a range over the rig
+// map. This gate sits on the CLOSE-then-release lane — it decides whether a
+// session bead may be retired, and the retired-session sweep releases whatever
+// that session still holds — so a leg it cannot see is a claim released under a
+// live worker. On a work-led plane the relocated binding was exactly such a leg
+// (ga-j4ob9), and this gate was invisible to the boundary census too, because it
+// ranged a map rather than calling a named enumerator.
+func sessionHasOpenAssignedWorkForConfig(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, session beads.Bead) (bool, error) {
+	return sessionHasOpenAssignedWorkInStores(cityPath, cfg, store, rigStores, sessionAssignmentIdentifiersForConfig(session, cfg))
 }
 
 // sessionHasOpenAssignedWorkForConfigInfo is the session.Info form of
 // sessionHasOpenAssignedWorkForConfig for the reconciler forward pass (the raw
 // form stays for the repair/cleanup lanes that hold a raw bead). The work-store
 // probe stays bead-shaped; only the assignment-identifier derivation reads Info.
-func sessionHasOpenAssignedWorkForConfigInfo(store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info, cfg *config.City) (bool, error) {
-	return sessionHasOpenAssignedWorkInStores(store, rigStores, sessionAssignmentIdentifiersForConfigInfo(info, cfg))
+func sessionHasOpenAssignedWorkForConfigInfo(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info) (bool, error) {
+	return sessionHasOpenAssignedWorkInStores(cityPath, cfg, store, rigStores, sessionAssignmentIdentifiersForConfigInfo(info, cfg))
 }
 
 // sessionHasInProgressAssignedWorkForConfig reports only claimed work for
 // progress-stall recycle. Open assigned work has not been claimed yet and must
 // not suppress claim-less parked-session recovery.
-func sessionHasInProgressAssignedWorkForConfig(store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info, cfg *config.City) (bool, error) {
-	return sessionHasAssignedWorkInStoresForStatuses(store, rigStores, sessionAssignmentIdentifiersForConfigInfo(info, cfg), []string{"in_progress"})
+func sessionHasInProgressAssignedWorkForConfig(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info) (bool, error) {
+	return sessionHasAssignedWorkInStoresForStatuses(cityPath, cfg, store, rigStores, sessionAssignmentIdentifiersForConfigInfo(info, cfg), []string{"in_progress"})
 }
 
 // sessionHasOpenAssignedWorkForReachableStore reports whether any open or
@@ -4606,6 +4614,19 @@ func collectSessionAssignedWorkInfo(cityPath string, cfg *config.City, store bea
 					if sessionpkg.IsSessionBeadOrRepairable(item) {
 						continue
 					}
+					// FIRST LEG WINS, across legs — this key is the bare id, not
+					// (leg, id) like the release sweeps'. For a DUAL-RESIDENT id
+					// (the same id claimed in both the work ledger and the
+					// binding, which `gc storage migrate` preserving ids makes
+					// real) only the first leg's copy is collected, so a caller
+					// that mutates what this returns leaves the binding copy
+					// in_progress. That is the ga-dk345 dual-resident
+					// carry-forward, deliberately unresolved in S2: making it
+					// coherent is a placement question, not a lookup one, and it
+					// belongs with S5's create routing. Do not "fix" it by
+					// keying on (leg, id) here — this collector's consumers
+					// report ONE stranded bead per id, and a doubled list reads
+					// as double the strand.
 					if _, dup := seen[item.ID]; dup {
 						continue
 					}
@@ -4646,20 +4667,37 @@ func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (b
 	return sessionHasOpenAssignedWorkInStoreByIdentifiers(store, sessionAssignmentIdentifiers(session))
 }
 
-func sessionHasOpenAssignedWorkInStores(store beads.Store, rigStores map[string]beads.Store, identifiers []string) (bool, error) {
-	return sessionHasAssignedWorkInStoresForStatuses(store, rigStores, identifiers, []string{"open", "in_progress"})
+func sessionHasOpenAssignedWorkInStores(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, identifiers []string) (bool, error) {
+	return sessionHasAssignedWorkInStoresForStatuses(cityPath, cfg, store, rigStores, identifiers, []string{"open", "in_progress"})
 }
 
-func sessionHasAssignedWorkInStoresForStatuses(store beads.Store, rigStores map[string]beads.Store, identifiers []string, statuses []string) (bool, error) {
-	if has, err := sessionHasAssignedWorkInStoreByIdentifiersForStatuses(store, identifiers, statuses); err != nil || has {
-		return has, err
+// sessionHasAssignedWorkInStoresForStatuses is the cross-store existence probe:
+// the whole city's assigned-work leg set, read in plan order, stopping at the
+// first leg that answers. It fails CLOSED on a leg that went dark for the same
+// reason assignedWorkExistsForSession does — the callers are close decisions.
+func sessionHasAssignedWorkInStoresForStatuses(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, identifiers []string, statuses []string) (bool, error) {
+	plan, err := assignedWorkSweepPlan(cityPath, cfg, store, rigStores, identifiers)
+	if err != nil {
+		return false, err
 	}
-	for _, rs := range rigStores {
-		if has, err := sessionHasAssignedWorkInStoreByIdentifiersForStatuses(rs, identifiers, statuses); err != nil || has {
-			return has, err
+	var found bool
+	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		has, err := sessionHasAssignedWorkInStoreByIdentifiersForStatuses(leg.Store, identifiers, statuses)
+		if err != nil {
+			return false, err
+		}
+		found = has
+		return has, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		if err := assignedWorkScanComplete(res); err != nil {
+			return false, err
 		}
 	}
-	return false, nil
+	return found, nil
 }
 
 func sessionHasOpenAssignedWorkInStoreByIdentifiers(store beads.Store, identifiers []string) (bool, error) {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
@@ -1395,7 +1396,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	// rows, returning the folded row set (retired losers carry their retire batch).
 	if cfg != nil {
 		rows = retireDuplicateConfiguredNamedSessionRows(
-			store, rigStores, sp, cfg, cityName, rows, clk.Now().UTC(), stderr,
+			cityPath, store, rigStores, sp, cfg, cityName, rows, clk.Now().UTC(), stderr,
 		)
 	}
 	recordPhase(TraceSiteSessionReconcileHealRetire, "session_reconcile.heal_and_retire_duplicates", phaseStart, map[string]any{
@@ -3739,7 +3740,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// unclaimWorkAssignedToRetiredSessionInfo, the Info form of the same detach primitive
 			// named-session retirement uses.
 			if !storeQueryPartial &&
-				repairStrandedPoolWorkerBead(store, rigStores, infoByID[target.info.ID], retiredSessionFallbackRouteInfo(infoByID[target.info.ID]), clk, stderr) {
+				repairStrandedPoolWorkerBead(cityPath, cfg, store, rigStores, infoByID[target.info.ID], retiredSessionFallbackRouteInfo(infoByID[target.info.ID]), clk, stderr) {
 				tick.markClosed(target.info.ID)
 				pruneAgentHomeWorktreeIfSafeInfo(infoByID[target.info.ID], cityPath, cfg, stderr)
 			}
@@ -3940,16 +3941,51 @@ func sessionHasOpenAssignedWorkForReachableStore(
 	info sessionpkg.Info,
 ) (bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, store, rigStores, info)
+	return assignedWorkExistsForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (bool, error) {
+		return sessionHasOpenAssignedWorkInStoreByIdentifiers(s, identifiers)
+	})
+}
+
+// assignedWorkExistsForSession is the existence probe every "does this session
+// still hold work?" gate runs: the resolver's leg set, read in plan order,
+// stopping at the first leg that answers yes.
+//
+// It fails CLOSED on a leg that could not be read. A rig going dark is a
+// PartialDegrade leg in the plan, so the pass completes and reports Partial
+// instead of aborting — but for THIS question a smaller answer presented as
+// authoritative is "the session holds nothing", and the drain arm acts on it.
+// Every caller already refuses its decision on an error, so the honest report is
+// an error (gc-ft31x: retain rather than reap).
+func assignedWorkExistsForSession(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	info sessionpkg.Info,
+	probe func(beads.Store) (bool, error),
+) (bool, error) {
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
 	if err != nil {
 		return false, err
 	}
-	for _, s := range stores {
-		if has, err := sessionHasOpenAssignedWorkInStoreByIdentifiers(s, identifiers); err != nil || has {
-			return has, err
+	var found bool
+	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		has, err := probe(leg.Store)
+		if err != nil {
+			return false, err
+		}
+		found = has
+		return has, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		if err := assignedWorkScanComplete(res); err != nil {
+			return false, err
 		}
 	}
-	return false, nil
+	return found, nil
 }
 
 // sessionHasOpenAssignedWorkForReachableStoreForCloseGate is the drain-ack
@@ -3979,16 +4015,9 @@ func sessionHasOpenAssignedWorkForReachableStoreForCloseGate(
 	info sessionpkg.Info,
 ) (bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, store, rigStores, info)
-	if err != nil {
-		return false, err
-	}
-	for _, s := range stores {
-		if has, err := sessionHasOpenAssignedWorkInStoreByIdentifiersForCloseGate(s, identifiers); err != nil || has {
-			return has, err
-		}
-	}
-	return false, nil
+	return assignedWorkExistsForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (bool, error) {
+		return sessionHasOpenAssignedWorkInStoreByIdentifiersForCloseGate(s, identifiers)
+	})
 }
 
 func sessionHasOpenAssignedWorkInStoreByIdentifiersForCloseGate(store beads.Store, identifiers []string) (bool, error) {
@@ -4116,100 +4145,9 @@ func sessionHasAwakeAssignedWorkForReachableStore(
 	info sessionpkg.Info,
 ) (bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, store, rigStores, info)
-	if err != nil {
-		return false, err
-	}
-	for _, s := range stores {
-		if has, err := sessionHasAwakeAssignedWorkInStoreByIdentifiers(s, identifiers); err != nil || has {
-			return has, err
-		}
-	}
-	return false, nil
-}
-
-// reachableStoresForSession returns the store(s) in which the session's assigned
-// work can live, applying the same cross-store model as openSessionReachableStoreRefInfo.
-// A cross-store-eligible (city-scoped) session federates across the primary store
-// and every rig store (vp-kvp); a session whose template/agent can't be resolved
-// falls back to the same fan-out (legacy keep-on-match fail-safe); a rig-bound
-// session routes to its one rig store; every other session routes to the primary
-// store. The slice is ordered primary-first so "first match" callers keep their
-// historical ordering. Returns an error only when a resolved rig store is missing.
-func reachableStoresForSession(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, session beads.Bead) ([]beads.Store, error) {
-	agentCfg := sessionAgentConfig(cfg, session)
-	if agentCfg == nil || agentIsCrossStoreEligible(agentCfg) {
-		// Cross-store-eligible work lives in the work-class candidate set: the
-		// primary work store plus every rig work store. The downstream
-		// List{Assignee,Status} probes are work queries, so this is the work
-		// arm; on a single-store city it collapses to the same store the
-		// session probes use (identity).
-		return workAssignmentStores(store, rigStores), nil
-	}
-	storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
-	if storeRef == "" {
-		return []beads.Store{store}, nil
-	}
-	rigStore, ok := rigStores[storeRef]
-	if !ok || rigStore == nil {
-		return nil, fmt.Errorf("rig store %q unavailable for session %q", storeRef, session.Metadata["session_name"])
-	}
-	return []beads.Store{rigStore}, nil
-}
-
-// reachableStoresForSessionInfo is the session.Info form of
-// reachableStoresForSession (the raw form stays for the raw-by-design stranded
-// diagnostic collector). The store fan-out is work-class and stays bead-shaped;
-// only the agent/name resolution reads Info.
-//
-// Every branch also scans the relocated coordination-class binding, when the
-// city has one (classBindingLegForSessionScan). A claim this session holds can
-// live there by design on a split city — claim_class_route.go writes the
-// assignee into the binding for a bead no work store holds — and a scan that
-// cannot see it reports a claim-holder as having no assigned work, which is what
-// let the drain arm recycle a live worker mid-step (ga-whzrt). The binding goes
-// LAST, through workAssignmentStores' documented extra leg, so the work stores
-// keep answering first and a pointer-identical leg is deduped rather than
-// scanned twice.
-func reachableStoresForSessionInfo(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info) ([]beads.Store, error) {
-	binding := classBindingLegForSessionScan(cfg, store)
-	agentCfg := sessionAgentConfigInfo(cfg, info)
-	if agentCfg == nil || agentIsCrossStoreEligible(agentCfg) {
-		return workAssignmentStores(store, rigStores, binding), nil
-	}
-	storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
-	if storeRef == "" {
-		return workAssignmentStores(store, nil, binding), nil
-	}
-	rigStore, ok := rigStores[storeRef]
-	if !ok || rigStore == nil {
-		return nil, fmt.Errorf("rig store %q unavailable for session %q", storeRef, info.SessionNameMetadata)
-	}
-	return workAssignmentStores(rigStore, nil, binding), nil
-}
-
-// classBindingLegForSessionScan returns the relocated coordination-class binding
-// a session's assigned work can also live in, or nil for a city that relocates
-// nothing.
-//
-// It reads the binding off the store the caller already holds rather than
-// opening one. This build serves exactly one split shape — work on the reserved
-// binding and ALL five infrastructure classes, sessions and graph included, on
-// ONE shared binding (storageSplitWhole; every other arrangement is refused at
-// boot, storage_boot.go) — and the controller reconciler leads with the
-// sessions-class store. So on a city that relocates anything at all, the leading
-// store IS the graph binding a routed claim writes into, and naming it costs no
-// second handle, no second open, and no plumbing through the reconciler's
-// call chain. A city with no [storage] section relocates nothing and gets nil,
-// which workAssignmentStores drops.
-func classBindingLegForSessionScan(cfg *config.City, store beads.Store) beads.Store {
-	if cfg == nil || cfg.Storage == nil {
-		return nil
-	}
-	if shape, _ := storageSplitShapeOf(cfg.EffectiveStorage()); shape != storageSplitWhole {
-		return nil
-	}
-	return store
+	return assignedWorkExistsForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (bool, error) {
+		return sessionHasAwakeAssignedWorkInStoreByIdentifiers(s, identifiers)
+	})
 }
 
 // firstOpenAssignedWorkBeadForReachableStore returns the first open or
@@ -4233,16 +4171,31 @@ func firstOpenAssignedWorkBeadForReachableStore(
 	info sessionpkg.Info,
 ) (beads.Bead, bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, store, rigStores, info)
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
 	if err != nil {
 		return beads.Bead{}, false, err
 	}
-	for _, s := range stores {
-		if bead, found, err := firstOpenAssignedWorkBeadInStoreByIdentifiers(s, identifiers); err != nil || found {
-			return bead, found, err
+	var (
+		bead  beads.Bead
+		found bool
+	)
+	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		b, ok, err := firstOpenAssignedWorkBeadInStoreByIdentifiers(leg.Store, identifiers)
+		if err != nil {
+			return false, err
+		}
+		bead, found = b, ok
+		return ok, nil
+	})
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	if !found {
+		if err := assignedWorkScanComplete(res); err != nil {
+			return beads.Bead{}, false, err
 		}
 	}
-	return beads.Bead{}, false, nil
+	return bead, found, nil
 }
 
 func firstOpenAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
@@ -4620,68 +4573,17 @@ func formatStrandedMessage(template, sessionName string, ids []string) string {
 		prefix, len(ids), strings.Join(shown, ","), suffix)
 }
 
-// collectSessionAssignedWork returns the open/in_progress work beads
-// assigned to the session, excluding session beads themselves, along
-// with the store that owns each work bead. Mirrors the identifier
-// resolution and store routing of sessionHasOpenAssignedWorkForReachableStore
-// so the diagnostic path lists and mutates exactly the beads the gate
-// considered when deciding to emit.
+// collectSessionAssignedWorkInfo returns the open/in_progress work beads
+// assigned to the session, excluding session beads themselves, along with the
+// store that owns each work bead. It reads the same leg set the gate read
+// (assignedWorkPlanForSessionInfo) so the diagnostic lists and mutates exactly
+// the beads the gate considered when deciding to emit.
 //
-// Without this alignment the gate could see assigned work (via the
-// config-derived named-session identity, or via a rig-store-routed
-// query) while the collector queried only the bare bead identifiers
-// against every store — producing a "0 stranded beads" message in the
-// exact failure mode the diagnostic exists to surface.
-func collectSessionAssignedWork(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, session beads.Bead) ([]strandedAssignedWork, error) {
-	identifiers := sessionAssignmentIdentifiersForConfig(session, cfg)
-	seen := make(map[string]struct{})
-	out := make([]strandedAssignedWork, 0, 4)
-	collect := func(s beads.Store) error {
-		if s == nil {
-			return nil
-		}
-		wa := workAssignmentForStore(beads.WorkStore{Store: s})
-		for _, status := range []string{"open", "in_progress"} {
-			for _, assignee := range identifiers {
-				if assignee == "" {
-					continue
-				}
-				items, err := wa.OpenAssignedTo(assignee, status, beads.TierBoth, true)
-				if err != nil {
-					return err
-				}
-				for _, item := range items {
-					if sessionpkg.IsSessionBeadOrRepairable(item) {
-						continue
-					}
-					if _, dup := seen[item.ID]; dup {
-						continue
-					}
-					seen[item.ID] = struct{}{}
-					out = append(out, strandedAssignedWork{bead: item, store: s})
-				}
-			}
-		}
-		return nil
-	}
-	// Route to the same store(s) the gate routed to.
-	stores, err := reachableStoresForSession(cityPath, cfg, store, rigStores, session)
-	if err != nil {
-		return out, err
-	}
-	for _, s := range stores {
-		if err := collect(s); err != nil {
-			return out, err
-		}
-	}
-	return out, nil
-}
-
-// collectSessionAssignedWorkInfo is the session.Info form of
-// collectSessionAssignedWork: the session-side identity resolution and store
-// routing read Info (via sessionAssignmentIdentifiersForConfigInfo and
-// reachableStoresForSessionInfo, both equivalence-proven), while the work-bead
-// walk stays bead-shaped (ClassWork). Byte-identical to the raw form.
+// Without that alignment the gate could see assigned work — via the
+// config-derived named-session identity, via a rig-store-routed query, or in a
+// relocated class binding — while the collector queried somewhere else,
+// producing a "0 stranded beads" message in the exact failure mode the
+// diagnostic exists to surface.
 func collectSessionAssignedWorkInfo(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, info sessionpkg.Info) ([]strandedAssignedWork, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
 	seen := make(map[string]struct{})
@@ -4714,14 +4616,20 @@ func collectSessionAssignedWorkInfo(cityPath string, cfg *config.City, store bea
 		}
 		return nil
 	}
-	stores, err := reachableStoresForSessionInfo(cityPath, cfg, store, rigStores, info)
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
 	if err != nil {
 		return out, err
 	}
-	for _, s := range stores {
-		if err := collect(s); err != nil {
-			return out, err
-		}
+	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		return false, collect(leg.Store)
+	})
+	if err != nil {
+		return out, err
+	}
+	// A leg that went dark cannot be reported as "nothing stranded there": the
+	// diagnostic's whole job is to name what a session left behind.
+	if err := assignedWorkScanComplete(res); err != nil {
+		return out, err
 	}
 	return out, nil
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3261,12 +3261,12 @@ func TestCollectSessionAssignedWorkIncludesAssignedWisp(t *testing.T) {
 		t.Fatalf("Create wisp work: %v", err)
 	}
 
-	got, err := collectSessionAssignedWork("", nil, store, nil, session)
+	got, err := collectSessionAssignedWorkInfo("", nil, store, nil, sessionInfosFromBeads([]beads.Bead{session})[0])
 	if err != nil {
-		t.Fatalf("collectSessionAssignedWork: %v", err)
+		t.Fatalf("collectSessionAssignedWorkInfo: %v", err)
 	}
 	if len(got) != 1 || got[0].bead.ID != work.ID {
-		t.Fatalf("collectSessionAssignedWork = %#v, want assigned wisp %s", got, work.ID)
+		t.Fatalf("collectSessionAssignedWorkInfo = %#v, want assigned wisp %s", got, work.ID)
 	}
 }
 

--- a/cmd/gc/session_w3_split_equiv_test.go
+++ b/cmd/gc/session_w3_split_equiv_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -19,15 +20,15 @@ import (
 // sessionAgentConfig -> sessionAgentConfigInfo swap differs between the two; the
 // cross-store / store-ref resolution is identical, so byte-identity here is the
 // per-parameter split's proof.
-func rawOpenSessionReachableStoreRefRef(cityPath string, cfg *config.City, sb beads.Bead) string {
+func rawOpenSessionReachableStoreRefRef(cityPath string, cfg *config.City, claimRefs []string, sb beads.Bead) []string {
 	agentCfg := sessionAgentConfig(cfg, sb)
 	if agentCfg == nil {
-		return unresolvedOpenSessionStoreRef
+		return []string{unresolvedOpenSessionStoreRef}
 	}
 	if agentIsCrossStoreEligible(agentCfg) {
-		return crossStoreOpenSessionStoreRef
+		return []string{crossStoreOpenSessionStoreRef}
 	}
-	return assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
+	return append([]string{assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)}, claimRefs...)
 }
 
 // TestOpenSessionReachableStoreRefInfoMatchesRaw pins the §4 split site the
@@ -37,8 +38,11 @@ func TestOpenSessionReachableStoreRefInfoMatchesRaw(t *testing.T) {
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}, {Name: "mayor"}}}
 	for _, sb := range oracleSessionBeadShapes() {
 		info := sessiontest.SeedBead(t, sb)
-		if got, want := openSessionReachableStoreRefInfo("", cfg, info), rawOpenSessionReachableStoreRefRef("", cfg, sb); got != want {
-			t.Errorf("openSessionReachableStoreRef(%s): info=%q raw=%q", sb.ID, got, want)
+		claimRefs := assignedWorkClaimRefs("", cfg, beads.NewMemStore())
+		got := openSessionReachableStoreRefInfo("", cfg, claimRefs, info)
+		want := rawOpenSessionReachableStoreRefRef("", cfg, claimRefs, sb)
+		if !slices.Equal(got, want) {
+			t.Errorf("openSessionReachableStoreRef(%s): info=%v raw=%v", sb.ID, got, want)
 		}
 	}
 }

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -23,6 +23,7 @@ import (
 // Live-query failures fail closed: the bead stays open until assignment can be
 // re-verified.
 func closeSessionBeadIfUnassigned(
+	cityPath string,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	cfg *config.City,
@@ -34,7 +35,7 @@ func closeSessionBeadIfUnassigned(
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, session, cfg)
+	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(cityPath, cfg, store, rigStores, session)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", session.ID, err) //nolint:errcheck
 		return false
@@ -56,6 +57,7 @@ func closeSessionBeadIfUnassigned(
 // sessionFrontDoor and run the extmsg/orphaned-work release cascade). Byte-
 // identical to the raw form for the GCSweep close op.
 func closeSessionInfoIfUnassigned(
+	cityPath string,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	cfg *config.City,
@@ -67,7 +69,7 @@ func closeSessionInfoIfUnassigned(
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfigInfo(store, rigStores, info, cfg)
+	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfigInfo(cityPath, cfg, store, rigStores, info)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", info.ID, err) //nolint:errcheck
 		return false

--- a/cmd/gc/session_wtick_twins_test.go
+++ b/cmd/gc/session_wtick_twins_test.go
@@ -279,7 +279,7 @@ func TestRetireDuplicateRowsMatchesBeads(t *testing.T) {
 				indexBySessionName[sn] = i
 			}
 		}
-		retireDuplicateConfiguredNamedSessionBeads(store, nil, sp, cfg, cityName, rawBeads, bySessionName, indexBySessionName, now, nil)
+		retireDuplicateConfiguredNamedSessionBeads("", store, nil, sp, cfg, cityName, rawBeads, bySessionName, indexBySessionName, now, nil)
 	}
 	runRows := func(store beads.Store, sp *runtime.Fake) {
 		rowBeads := loadOpen(t, store)
@@ -287,7 +287,7 @@ func TestRetireDuplicateRowsMatchesBeads(t *testing.T) {
 		for i, b := range rowBeads {
 			rows[i] = session.ReconcileSession{Info: sessiontest.SeedBead(t, b)}
 		}
-		retireDuplicateConfiguredNamedSessionRows(store, nil, sp, cfg, cityName, rows, now, nil)
+		retireDuplicateConfiguredNamedSessionRows("", store, nil, sp, cfg, cityName, rows, now, nil)
 	}
 
 	t.Run("stop-succeeds-loser-retired-and-stopped", func(t *testing.T) {

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -57,13 +57,25 @@ import (
 //
 // Others pin behavior main HAS but should not keep. Those carry a KNOWN GAP
 // paragraph naming the divergence, the assertions that move when it closes, and
-// the slice that closes it — I1 and I2 (the HQ work store is in neither arm of
-// the controller's cross-store scan on a split city), I5 (the RELEASE tier does
-// not follow the now class-routed claim: crash recovery, on_death/on_boot and
-// the retired-session sweep are all still work-only) and I10 (the wake filter
-// has no coordination-class reachability arm). Leaving such a leg UNSEEDED is the
-// failure mode this convention exists to prevent: the invariant then reads as
-// coverage of a path it never touches.
+// the slice that closes it. Leaving such a leg UNSEEDED is the failure mode this
+// convention exists to prevent: the invariant then reads as coverage of a path
+// it never touches.
+//
+// The list, current as of the residency resolver's S2 slice:
+//
+//   - OPEN — I1 and I2: the HQ work store is in neither arm of the controller's
+//     cross-store scan on a split city. That is the census/demand side, and S3
+//     closes it (the D6 flip: the binding becomes a leg BESIDE the city work
+//     store instead of replacing it).
+//   - CLOSED by S2 — I5's release-tier gap. Crash recovery, the retired-session
+//     sweep, `gc session close` and drain-ack all resolve the same leg set from
+//     the city's routes (assignedWorkSweepPlan), so a class-routed claim is
+//     released by the same pass that releases a work-store one. What remains
+//     open there is ga-zp3uj, named in I5's own text: the AGENT-SIDE recovery
+//     tiers are raw bd commands in a work directory and stay topology-blind.
+//   - CLOSED — I10's wake-filter gap (ga-whzrt, #5250) and its ownership-index
+//     half (ga-j4ob9, S2). Both mechanisms now resolve their refs from the
+//     city's residency topology, and I10 asserts they agree.
 //
 // # Which authority an invariant is pinning
 //

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -751,7 +751,15 @@ func conformanceHookClaimClassRouting(t *testing.T, e splitEnv, workBeadID strin
 //     binding. That is a property of the topology rather than of any call site,
 //     which is exactly why it is asserted rather than assumed.
 //   - `gc session close` leads with the WORK store (openCityStore), so it cannot
-//     see the binding on its own and is handed the graph binding as a class leg.
+//     see the binding on its own.
+//
+// S2 UPDATE (ga-j4ob9): the second scan is no longer HANDED the binding by its
+// call site. Both rows now resolve the same leg set from the city's own routes
+// (assignedWorkSweepPlan), which is what closes the case the hand-threading
+// never covered — the Info-form retired-session sweep, which took no class leg
+// at all, so a dead session's binding-resident claim had no automatic reopen
+// lane. The rows below are unchanged in what they assert; only the mechanism
+// that puts the binding in the scan moved.
 //
 // What is NOT closed here, and is ga-zp3uj: the agent-side recovery tiers
 // (`bd list --status in_progress`, on_death, on_boot) are raw bd commands in the
@@ -764,20 +772,22 @@ func assertClassRoutedClaimIsReleasable(t *testing.T, e splitEnv) {
 	for _, tt := range []struct {
 		name    string
 		leading beads.Store
-		class   []beads.Store
 	}{
 		{
 			name:    "reconciler scan — leads with the sessions-class store, which IS the binding",
 			leading: e.sessionsStore(),
 		},
 		{
-			name:    "gc session close — leads with the work store and is handed the binding",
+			name:    "gc session close — leads with the work store and resolves the binding from the routes",
 			leading: e.work,
-			class:   []beads.Store{e.class},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if !workAssignmentStoresReach(workAssignmentStores(tt.leading, e.rigStores, tt.class...), e.class) {
+			plan, err := assignedWorkSweepPlan(e.cityPath, e.cfg, tt.leading, e.rigStores, nil)
+			if err != nil {
+				t.Fatalf("resolving the release scan's leg set: %v", err)
+			}
+			if !workAssignmentStoresReach(planStores(t, plan), e.class) {
 				t.Fatalf("no leg of the release scan is the class binding; a claim routed there is released by nothing")
 			}
 			sessionBead := beads.Bead{ID: "gcg-retired-session", Metadata: map[string]string{"session_name": "worker-1"}}
@@ -786,7 +796,7 @@ func assertClassRoutedClaimIsReleasable(t *testing.T, e splitEnv) {
 				status:   "in_progress",
 				assignee: sessionBead.ID,
 			})
-			unclaimWorkAssignedToRetiredSessionBead(tt.leading, e.rigStores, sessionBead, "", io.Discard, tt.class...)
+			unclaimWorkAssignedToRetiredSessionBead(e.cityPath, e.cfg, tt.leading, e.rigStores, sessionBead, "", io.Discard)
 			released, err := e.class.Get(step.ID)
 			if err != nil {
 				t.Fatalf("reading the claimed graph step back from the binding: %v", err)
@@ -1157,24 +1167,28 @@ func conformanceWarmTickDemand(t *testing.T, e splitEnv) {
 // bead came out of; both resolve from cfg plus the holder's own identities, so a
 // legacy city and a split city cannot diverge.
 //
-// The two mechanisms no longer answer the same question, and that is deliberate.
+// The two mechanisms now answer the SAME question, which is the S2 flip this
+// row's own note asked for ("if you widen the ownership index, update its
+// assertion here and re-check that both sub-topologies still agree").
 //
-//   - The WAKE filter now keeps a claim on the LEADING arm when the assignee is
-//     one of the holder's own exact identities, whatever the holder's rig scope.
+//   - The WAKE filter keeps a claim on the LEADING arm when the assignee is one
+//     of the holder's own exact identities, whatever the holder's rig scope.
 //     That arm is the relocated class binding on a split city — where claim-time
 //     class routing writes the assignee — and the city store on a legacy one,
 //     which a rig-scoped agent's hook fan-out reaches anyway
 //     (appendCityHookStore). Dropping the claim left a live holder with
 //     AwakeDecision{Reason:""} and the no-wake-reason drain recycled it mid-step
-//     (ga-whzrt). Both sub-topologies keep it, so the conformance property holds.
-//   - The ownership INDEX is unchanged and stays rig-scoped. It is a fast path
-//     for orphan release, and its last-resort live-session probe already spares
-//     a class-resident claim (I2 proves that), so the gap it leaves is a
-//     per-tick cost rather than a wrong answer. Widening it is a release-path
-//     change with its own blast radius and belongs to its own slice.
+//     (ga-whzrt).
+//   - The ownership INDEX now grants the same arm to the same identities. It had
+//     to move WITH the release path's own widening, not after it: the
+//     orphan-release scan reads the binding as a leg now, so an index that still
+//     answered "this holder owns only its rig" would let the scan reap a LIVE
+//     worker's binding-resident claim. A missed wake costs a cycle; a false
+//     release is claim loss (ga-j4ob9).
 //
-// If you widen the ownership index, update its assertion here and re-check that
-// both sub-topologies still agree.
+// Both sub-topologies answer identically, which is the conformance property:
+// neither mechanism reads which physical store a bead came out of, and the refs
+// they compare come from the city's own residency topology.
 func conformanceWakeOwnershipFastPath(t *testing.T, e splitEnv) {
 	sess, err := e.sessionsStore().Create(splitEnvPoolSessionBead(e.qualified, "executor-1"))
 	if err != nil {
@@ -1198,22 +1212,29 @@ func conformanceWakeOwnershipFastPath(t *testing.T, e splitEnv) {
 	}
 
 	infos := sessionInfosFromBeads([]beads.Bead{sess})
+	leading := e.sessionsStore()
 	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(
-		e.cfg, e.cityPath, infos,
+		e.cfg, e.cityPath, leading, infos,
 		[]beads.Bead{wisp, rigWork}, []string{"", e.rigName},
 	)
-	index := makeOpenSessionStoreRefIndex(e.cityPath, e.cfg, infos, true)
+	index := makeOpenSessionStoreRefIndex(e.cityPath, e.cfg, leading, infos, true)
 
 	if len(kept) != 2 || kept[0].ID != wisp.ID || kept[1].ID != rigWork.ID ||
-		len(keptRefs) != 2 || keptRefs[0] != classBindingAssignedWorkStoreRef || keptRefs[1] != e.rigName {
+		len(keptRefs) != 2 || keptRefs[0] != "" || keptRefs[1] != e.rigName {
 		t.Fatalf("wake filter kept %d beads (ids %v refs %v), want the leading-arm claim %s under ref %q AND the rig-store claim %s under ref %q",
-			len(kept), assignedWorkIDs(kept), keptRefs, wisp.ID, classBindingAssignedWorkStoreRef, rigWork.ID, e.rigName)
+			len(kept), assignedWorkIDs(kept), keptRefs, wisp.ID, "", rigWork.ID, e.rigName)
 	}
 	if !openSessionOwnsWork(nil, index, sess.ID, e.rigName, true) {
 		t.Error("the ownership index does not own the rig-store leg for its own rig-bound holder — orphan release would fall to the per-bead live probe every tick")
 	}
-	if openSessionOwnsWork(nil, index, sess.ID, "", true) {
-		t.Error("the ownership index owns the leading-store leg for a rig-bound holder; reachability is cfg-derived and must answer the same on both topologies. If you are landing the coordination-class reachability arm, update this assertion and the single-store one together.")
+	if !openSessionOwnsWork(nil, index, sess.ID, "", true) {
+		t.Error("the ownership index does not own the leading-store leg for its own rig-bound holder; the orphan-release scan reads that leg now, so a LIVE worker's claim written there is reaped — claim loss, not a missed wake (ga-j4ob9)")
+	}
+	// The widening is per-identity ownership, not a blanket keep of the leading
+	// arm: a foreign assignee on the same leg is still not owned, which is what
+	// keeps orphan release able to recover a genuinely dead holder's claim.
+	if openSessionOwnsWork(nil, index, "some-other-session", "", true) {
+		t.Error("the ownership index owns the leading-store leg for a FOREIGN identity; that would make every binding-resident claim unreleasable")
 	}
 }
 

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -182,6 +182,13 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 		e.routes = splitEnvRoutes(e.class)
 	}
 	writeSplitTopologyCityConfig(t, cityPath, rigPath, split)
+	// The assigned-work spine resolves a city's bindings BY PATH, because its
+	// scans are free functions reached from both planes. Registering the routes
+	// this fixture staged is the same thing newCityRuntime does with the ones
+	// storageBootGate opened, so both subtests answer residency from the routes
+	// the env decided rather than from a second funnel.
+	registerResidencyRoutes(cityPath, e.routes)
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath) })
 	if opts.rig {
 		e.attachRigLeg(t, rigPath)
 	}

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -188,7 +188,7 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 	// storageBootGate opened, so both subtests answer residency from the routes
 	// the env decided rather than from a second funnel.
 	registerResidencyRoutes(cityPath, e.routes)
-	t.Cleanup(func() { unregisterResidencyRoutes(cityPath) })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, e.routes) })
 	if opts.rig {
 		e.attachRigLeg(t, rigPath)
 	}

--- a/internal/storeref/residency_agreement_test.go
+++ b/internal/storeref/residency_agreement_test.go
@@ -2,6 +2,7 @@ package storeref
 
 import (
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -281,15 +282,21 @@ func TestSweepAndDemandReadTheSameStores(t *testing.T) {
 				t.Fatalf("the assigned-work sweep reads\n %s\nwhile demand reads\n %s\n— a claim on a leg only one of them has is invisible to the other", got, want)
 			}
 
-			// Claim escalation is the deliberate ASYMMETRY of the intent pair:
-			// the same leg set, the opposite order, so a co-resident id is
-			// claimed where the reader serves it. Same set, different string.
+			// Claim escalation reads the SAME legs in the SAME order as the
+			// sweep — work first, binding last — and only the mode differs
+			// (FirstOwner vs Union). That agreement is the point: a claim may
+			// only land where the sweep can see it, and it must land on the
+			// copy the sweep would attribute the row to.
+			//
+			// The documented ASYMMETRY of the intent pair is escalation vs
+			// ByID, not escalation vs sweep: ByID leads with the binding
+			// because it is the sole minter, escalation leads with work because
+			// the claim must land where the reader serves from. That row is
+			// pinned in TestReaderAgreement (2b), which is where it belongs —
+			// it needs a co-resident id to be meaningful.
 			escalation := mustPlan(t, AssignedWork{Purpose: AssignedWorkClaimEscalation}, f.topo)
-			if got, want := refSet(escalation), refSet(sweep); !equalStringSets(got, want) {
-				t.Fatalf("claim escalation reads legs %v and the sweep reads %v; a claim may only land where the sweep can see it", got, want)
-			}
-			if len(sweep.Legs) > 1 && escalation.String() == sweep.String() {
-				t.Fatal("claim escalation and the sweep render identically; the order asymmetry is a documented property of the pair and must stay visible")
+			if got, want := escalation.Refs(), sweep.Refs(); !slices.Equal(got, want) {
+				t.Fatalf("claim escalation reads legs %v and the sweep reads %v, in that order; a claim may only land where the sweep can see it", got, want)
 			}
 		})
 	}

--- a/internal/storeref/residency_agreement_test.go
+++ b/internal/storeref/residency_agreement_test.go
@@ -259,6 +259,42 @@ func TestReaderAgreement(t *testing.T) {
 	}
 }
 
+// TestSweepAndDemandReadTheSameStores is the S2 half of the property: the
+// surface that COUNTS claimable work and the surface that SWEEPS an identity's
+// claims must read the same leg SET, or a claim lands somewhere no release, gate
+// or re-wake pass looks.
+//
+// It is asserted rather than assumed because the two used to be built by
+// different hands — the demand federation in one file, the retirement sweeps in
+// another, the drain-ack release in a third. Sharing planWorkFederation makes it
+// true by construction; this row is what fails if someone gives one of them its
+// own builder again.
+func TestSweepAndDemandReadTheSameStores(t *testing.T) {
+	for _, f := range allTopologies() {
+		if f.topo.Refused != nil {
+			continue
+		}
+		t.Run(f.name, func(t *testing.T) {
+			demand := mustPlan(t, RoutedWork{}, f.topo)
+			sweep := mustPlan(t, AssignedWork{}, f.topo)
+			if got, want := sweep.String(), demand.String(); got != want {
+				t.Fatalf("the assigned-work sweep reads\n %s\nwhile demand reads\n %s\n— a claim on a leg only one of them has is invisible to the other", got, want)
+			}
+
+			// Claim escalation is the deliberate ASYMMETRY of the intent pair:
+			// the same leg set, the opposite order, so a co-resident id is
+			// claimed where the reader serves it. Same set, different string.
+			escalation := mustPlan(t, AssignedWork{Purpose: AssignedWorkClaimEscalation}, f.topo)
+			if got, want := refSet(escalation), refSet(sweep); !equalStringSets(got, want) {
+				t.Fatalf("claim escalation reads legs %v and the sweep reads %v; a claim may only land where the sweep can see it", got, want)
+			}
+			if len(sweep.Legs) > 1 && escalation.String() == sweep.String() {
+				t.Fatal("claim escalation and the sweep render identically; the order asymmetry is a documented property of the pair and must stay visible")
+			}
+		})
+	}
+}
+
 // legThatContributed reports the first leg of a union plan that holds id — the
 // leg first-leg-wins attributes the row to.
 func legThatContributed(t *testing.T, p ResolvedPlan, id string) StoreRef {

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -605,24 +605,11 @@ type UnionResult[T any] struct {
 // already paid for (internal/api's graphPlaneUnavailable carries exactly these).
 func Union[T any](p ResolvedPlan, id func(T) string, fn func(Leg) ([]T, error)) (UnionResult[T], error) {
 	var out UnionResult[T]
-	if p.Mode != ModeUnion {
-		return out, fmt.Errorf("storeref: Union needs a %s plan, got %s", ModeUnion, p.Mode)
-	}
 	seen := make(map[string]bool)
-	for _, leg := range p.Legs {
-		items, err := fn(leg.Leg)
-		if err != nil {
-			if leg.OnError == PolicyRefusalTolerated && IsStandingRefusal(err) {
-				continue
-			}
-			if leg.OnError != PolicyPartialDegrade {
-				out.Items = nil
-				out.Partial = true
-				return out, fmt.Errorf("reading %s: %w", legName(leg.Leg.Ref), err)
-			}
-			out.Partial = true
-			out.LegErrors = append(out.LegErrors, LegError{Ref: leg.Leg.Ref, Err: err})
-			continue
+	walked, err := Walk(p, func(leg Leg) (bool, error) {
+		items, ferr := fn(leg)
+		if ferr != nil {
+			return false, ferr
 		}
 		for _, item := range items {
 			if id != nil {
@@ -634,6 +621,78 @@ func Union[T any](p ResolvedPlan, id func(T) string, fn func(Leg) ([]T, error)) 
 				}
 			}
 			out.Items = append(out.Items, item)
+		}
+		return false, nil
+	})
+	out.Partial = walked.Partial
+	out.LegErrors = walked.LegErrors
+	if err != nil {
+		out.Items = nil
+		out.Partial = true
+		return out, err
+	}
+	return out, nil
+}
+
+// WalkResult is what a leg-by-leg pass over a Union plan reports beyond the
+// caller's own side effects: whether it stopped early and where, and the honest
+// statement of which legs went dark.
+type WalkResult struct {
+	// Stopped reports that visit asked to stop, and StoppedAt names the leg it
+	// stopped on. A pass that read every leg leaves both zero.
+	Stopped   bool
+	StoppedAt StoreRef
+
+	// Visited counts the legs visit was called for, degraded legs included.
+	Visited int
+
+	// Partial marks a pass that could not read every leg it planned to. A
+	// consumer answering an EXISTENCE question must treat it as "cannot prove
+	// absence" and retain rather than reap — a partial pass reported as a clean
+	// "this session holds nothing" is the drain-a-live-holder shape.
+	Partial   bool
+	LegErrors []LegError
+}
+
+// Walk visits every leg of a Union plan in order, honoring per-leg ErrPolicy,
+// and stops early when visit returns stop.
+//
+// It is the executor for the union questions whose answer is not a merged row
+// set: an existence probe that must stop at the first leg that answers, a
+// release sweep that mutates as it goes, a pass bounded by a time budget. Those
+// are the sites that used to build a []beads.Store and read it themselves — and
+// reading it themselves is how the leg order, the dedupe rule and the fail-loud
+// policy came to be restated once per site.
+//
+// Union is implemented on top of this, so the two executors cannot disagree
+// about what a leg failure means.
+func Walk(p ResolvedPlan, visit func(Leg) (stop bool, err error)) (WalkResult, error) {
+	var out WalkResult
+	if p.Mode != ModeUnion {
+		return out, fmt.Errorf("storeref: Walk needs a %s plan, got %s", ModeUnion, p.Mode)
+	}
+	for _, leg := range p.Legs {
+		out.Visited++
+		stop, err := visit(leg.Leg)
+		if err != nil {
+			if leg.OnError == PolicyRefusalTolerated && IsStandingRefusal(err) {
+				// A refused city still serves WORK, and a leg carrying this
+				// policy was only ever consulted in case the binding held the
+				// answer. The city is refused, not degraded.
+				continue
+			}
+			if leg.OnError != PolicyPartialDegrade {
+				out.Partial = true
+				return out, fmt.Errorf("reading %s: %w", legName(leg.Leg.Ref), err)
+			}
+			out.Partial = true
+			out.LegErrors = append(out.LegErrors, LegError{Ref: leg.Leg.Ref, Err: err})
+			continue
+		}
+		if stop {
+			out.Stopped = true
+			out.StoppedAt = leg.Leg.Ref
+			return out, nil
 		}
 	}
 	return out, nil

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -138,6 +138,40 @@ type Topology struct {
 // caller's own read: no probe, no funnel, byte-identical to the pre-split path.
 func (t Topology) IsSingleStore() bool { return len(t.Bindings) == 0 }
 
+// ClaimRefs returns the store-refs a claim held by ONE identity can be recorded
+// under, whatever work scope the holder has: the work arm, then every relocated
+// class binding this city serves.
+//
+// This is the wake filter's and the orphan-release index's question, and it is
+// answered from the topology rather than from a Plan for two reasons. The
+// asker matches persisted census refs and reads no store, so a plan's executor
+// has nothing to do. And a REFUSED city still has claims recorded under its
+// binding's ref, so the answer has to exist exactly where a plan correctly
+// refuses — losing it there would drop every claim-holder on the city the
+// refusal is about into the no-wake-reason drain.
+//
+// Legs that resolved to the same store collapse, so a city whose leading arm IS
+// its binding answers with the one ref its census actually records. That
+// collapse is why this is a Topology method and not a list of binding refs: the
+// dedupe needs the stores.
+func (t Topology) ClaimRefs() []StoreRef {
+	refs := []StoreRef{t.Work.Ref}
+	seen := map[beads.Store]bool{}
+	if t.Work.Store != nil {
+		seen[t.Work.Store] = true
+	}
+	for _, b := range t.orderedBindings() {
+		if b.Leg.Store != nil {
+			if seen[b.Leg.Store] {
+				continue
+			}
+			seen[b.Leg.Store] = true
+		}
+		refs = append(refs, b.Leg.Ref)
+	}
+	return refs
+}
+
 // BindingFor returns the binding serving class c, if any.
 func (t Topology) BindingFor(c coordclass.Class) (ClassBinding, bool) {
 	for _, b := range t.orderedBindings() {

--- a/internal/storeref/walk_test.go
+++ b/internal/storeref/walk_test.go
@@ -1,0 +1,170 @@
+package storeref
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Walk is the executor for the union questions whose answer is not a merged row
+// set — an existence probe that stops at the first yes, a release sweep that
+// mutates as it goes, a pass bounded by a time budget. Those were the sites that
+// used to hand-roll a []beads.Store and read it themselves, so the executor has
+// to carry the same per-leg error policy Union does or the migration would trade
+// one restatement for another.
+
+func TestWalkVisitsEveryLegInPlanOrder(t *testing.T) {
+	f := newT2()
+	plan := mustPlan(t, AssignedWork{}, f.topo)
+
+	var visited []string
+	res, err := Walk(plan, func(l Leg) (bool, error) {
+		visited = append(visited, string(l.Ref))
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Walk over healthy legs: %v", err)
+	}
+	if got, want := strings.Join(visited, ">"), `>rig:alpha>rig:bravo>class:gmnos`; got != want {
+		t.Fatalf("Walk visited %q, want the sweep plan's own order %q", got, want)
+	}
+	if res.Stopped || res.Partial || res.Visited != 4 {
+		t.Fatalf("Walk result = %+v, want a complete four-leg pass", res)
+	}
+}
+
+func TestWalkStopsAtTheFirstLegThatAnswers(t *testing.T) {
+	f := newT2()
+	plan := mustPlan(t, AssignedWork{}, f.topo)
+
+	visits := 0
+	res, err := Walk(plan, func(l Leg) (bool, error) {
+		visits++
+		return l.Ref == RigRef("alpha"), nil
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !res.Stopped || res.StoppedAt != RigRef("alpha") {
+		t.Fatalf("Walk result = %+v, want a stop at rig:alpha", res)
+	}
+	if visits != 2 {
+		t.Fatalf("Walk read %d legs after the answer, want it to stop at the second: an existence probe that keeps reading pays for every leg of every tick", visits)
+	}
+}
+
+// A Fatal leg failing fails the whole pass with the store NAMED. On the release
+// and gate paths that is the difference between "this session holds nothing" and
+// "one ledger could not be read", and reading the second as the first is how a
+// live claim-holder gets drained.
+func TestWalkFatalLegFailsTheWholePassWithTheStoreNamed(t *testing.T) {
+	f := newT2()
+	boom := errors.New("binding unreachable")
+	f.bindings[ClassRef(infraClasses)].listErr = boom
+	plan := mustPlan(t, AssignedWork{}, f.topo)
+
+	_, err := Walk(plan, func(l Leg) (bool, error) {
+		if _, lerr := l.Store.ListOpen(); lerr != nil {
+			return false, lerr
+		}
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("an unreadable BINDING leg completed the walk; a work-only answer is indistinguishable from \"the DAG finished\"")
+	}
+	if !errors.Is(err, boom) || !strings.Contains(err.Error(), "class:gmnos") {
+		t.Fatalf("Walk error = %v, want the failure wrapped and the leg named", err)
+	}
+}
+
+// Control that fails DIFFERENTLY: a rig leg failing is one scope reporting a
+// hole. The pass completes, and the result says so rather than presenting a
+// smaller answer as authoritative.
+func TestWalkRigLegFailureIsPartialNotFatal(t *testing.T) {
+	f := newT2()
+	boom := errors.New("rig dark")
+	f.rigs["alpha"].listErr = boom
+	plan := mustPlan(t, AssignedWork{}, f.topo)
+
+	var visited []string
+	res, err := Walk(plan, func(l Leg) (bool, error) {
+		if _, lerr := l.Store.ListOpen(); lerr != nil {
+			return false, lerr
+		}
+		visited = append(visited, string(l.Ref))
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("a PartialDegrade leg aborted the walk: %v", err)
+	}
+	if !res.Partial || len(res.LegErrors) != 1 || res.LegErrors[0].Ref != RigRef("alpha") {
+		t.Fatalf("Walk result = %+v, want Partial with rig:alpha named", res)
+	}
+	if got, want := strings.Join(visited, ">"), `>rig:bravo>class:gmnos`; got != want {
+		t.Fatalf("Walk visited %q after the degraded leg, want %q — the remaining legs still answer", got, want)
+	}
+}
+
+// The one tolerated non-fault: a standing storage refusal on a leg whose policy
+// tolerates it. Nothing in this build plans a RefusalTolerated union leg, so the
+// case is asserted on a hand-built plan rather than left unexercised.
+func TestWalkToleratesAStandingRefusalOnATolerantLeg(t *testing.T) {
+	f := newT1()
+	refusal := newRefusal()
+	binding := f.bindings[ClassRef(infraClasses)]
+	binding.listErr = refusal
+
+	plan := ResolvedPlan{Mode: ModeUnion, Legs: []PlanLeg{
+		{Leg: f.topo.Work, Role: RoleAuthority, OnError: PolicyFatal},
+		{Leg: f.topo.Bindings[0].Leg, Role: RoleResidenceProbe, OnError: PolicyRefusalTolerated},
+	}}
+	res, err := Walk(plan, func(l Leg) (bool, error) {
+		if _, lerr := l.Store.ListOpen(); lerr != nil {
+			return false, lerr
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("a tolerated standing refusal failed the walk: %v", err)
+	}
+	if res.Partial {
+		t.Fatalf("a tolerated refusal marked the result Partial: %+v — the city is refused, not degraded", res)
+	}
+}
+
+func TestWalkRefusesANonUnionPlan(t *testing.T) {
+	f := newT1()
+	plan := mustPlan(t, ByID{ID: graphNamespacedID}, f.topo)
+	if _, err := Walk(plan, func(Leg) (bool, error) { return false, nil }); err == nil {
+		t.Fatal("Walk accepted a FirstOwner plan; a by-id probe list has ResolveOwner's short-circuit, not this one's")
+	}
+}
+
+// Union is implemented ON Walk so the two executors cannot disagree about leg
+// order or error policy — which would be this contract's own bug class, one
+// level up. Asserted rather than assumed: the two must report the same partial
+// legs for the same failure.
+func TestUnionAndWalkAgreeAboutADegradedLeg(t *testing.T) {
+	f := newT2()
+	boom := errors.New("rig dark")
+	f.rigs["bravo"].listErr = boom
+	plan := mustPlan(t, AssignedWork{}, f.topo)
+
+	union, err := Union(plan, beadID, listOpenLeg)
+	if err != nil {
+		t.Fatalf("Union: %v", err)
+	}
+	walk, err := Walk(plan, func(l Leg) (bool, error) {
+		_, lerr := l.Store.ListOpen()
+		return false, lerr
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if union.Partial != walk.Partial || len(union.LegErrors) != len(walk.LegErrors) {
+		t.Fatalf("Union reported (partial=%v, %d leg errors) and Walk (partial=%v, %d) for the same failure", union.Partial, len(union.LegErrors), walk.Partial, len(walk.LegErrors))
+	}
+	if union.LegErrors[0].Ref != walk.LegErrors[0].Ref {
+		t.Fatalf("Union named %q and Walk named %q", union.LegErrors[0].Ref, walk.LegErrors[0].Ref)
+	}
+}

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -63,7 +63,6 @@ cmd/gc/cmd_convoy_dispatch.go	controlGraphBinding	b:graphClassBinding	1
 cmd/gc/cmd_convoy_dispatch.go	findUniqueBeadAcrossStoresView	a:openSourceWorkflowStores	1
 cmd/gc/cmd_convoy_dispatch.go	openSourceWorkflowStores	a:openSourceWorkflowStores	1
 cmd/gc/cmd_convoy_dispatch.go	runControlDispatcherWithStoreAndConfig	c:beads.Store-literal	1
-cmd/gc/cmd_session.go	cmdSessionClose	b:graphClassBinding	1
 cmd/gc/cmd_wait.go	loadWaitDependencyBead	a:convoyStoreCandidates	1
 cmd/gc/convergence_tick.go	buildConvergenceScopes	a:rigBeadStores	1
 cmd/gc/doctor_order_tracking_retention.go	Run	c:beads.Store-literal	1
@@ -78,18 +77,6 @@ cmd/gc/ready_federation.go	readyRigLegStores	ast:returns-store-list	1
 cmd/gc/ready_federation.go	relocatedGraphLegStore	b:graphClassBinding	1
 cmd/gc/route_recovery.go	recoverUnroutedWorkRoutes	a:rigBeadStores	1
 cmd/gc/session_beads.go	coordClassStoreCandidates	a:coordClassStoreCandidates	1
-cmd/gc/session_beads.go	reassignWorkAssignedToRetiredSessionBead	a:workAssignmentStores	1
-cmd/gc/session_beads.go	reassignWorkAssignedToRetiredSessionInfo	a:workAssignmentStores	1
-cmd/gc/session_beads.go	unclaimWorkAssignedToRetiredSessionBead	a:workAssignmentStores	1
-cmd/gc/session_beads.go	unclaimWorkAssignedToRetiredSessionInfo	a:workAssignmentStores	1
-cmd/gc/session_beads.go	workAssignmentStores	a:workAssignmentStores	1
-cmd/gc/session_beads.go	workAssignmentStores	ast:returns-store-list	1
-cmd/gc/session_beads.go	workAssignmentStores	c:beads.Store-literal	1
-cmd/gc/session_reconciler.go	reachableStoresForSession	a:workAssignmentStores	1
-cmd/gc/session_reconciler.go	reachableStoresForSession	ast:returns-store-list	1
-cmd/gc/session_reconciler.go	reachableStoresForSession	c:beads.Store-literal	2
-cmd/gc/session_reconciler.go	reachableStoresForSessionInfo	a:workAssignmentStores	3
-cmd/gc/session_reconciler.go	reachableStoresForSessionInfo	ast:returns-store-list	1
 internal/api/dashport_support.go	BeadStores	a:BeadStores	1
 internal/api/dashport_support.go	BeadStores	ast:returns-store-list	1
 internal/api/handler_agents.go	findActiveBeadForAssigneesWithFreshness	a:BeadStores	1


### PR DESCRIPTION
S2 of the residency-resolver migration (epic ga-qdt5y, bead ga-dk345): the assigned-work spine consumes `Plan(AssignedWork)` — wake filter, session reachability gates, the orphan-release ownership index (the ga-j4ob9 fix: dead-session claims on binding-resident work finally have an automatic reopen lane), the retired-session unclaim/reassign family, the cross-store close gates, and #5265's drain-ack release, all through one seam.

- `storeref` gains `Walk` (executor for existence probes and mutating sweeps — consumers cannot disassemble plans) and `Topology.ClaimRefs()` (claim-ref vocabulary survives a refused city).
- **Release-path safety is the load-bearing evidence**: every visibility widening carries an independent counterweight, each pinned by a real on-disk mutation with a distinct failure signature (strand / premature-retirement / claim-loss ×2); the live-holder control was rebuilt to defeat all masking defences so only the widened index saves it — and both seam pins carry DO-NOT-FOLD headers because defence-in-depth makes end-to-end detection structurally impossible.
- Gates fail closed on degraded legs ("does this session hold work?" refuses partial answers); sweeps stay void-with-completeness per §3.3.
- Council round: the routes registry's lifecycle made ownership-safe (pointer-guarded unregister + registration moved under the controller lock — a superseded runtime can no longer erase the live runtime's registration and silently revive binding-blind releases; the lock-failure registration leak died with it). The ForConfig close gates — invisible to both guard halves because they ranged the rig map — were routed through the resolver in-slice rather than deferred.
- Retired: the whole `a:workAssignmentStores` pattern family (13 baseline rows / 15 hits, zero additions), `classBindingLegForSessionScan`, `classBindingAssignedWorkStoreRef`, and the fork-F3 shape generalizes un-shape-gated.
- New agreement property: `Plan(RoutedWork)` and the sweep render identically — "demand and sweep read the same stores" is asserted, not assumed.

Council: approve-with-changes → blocker + 7 fold-ins all landed (fix commit `bcb734d397`). Full `cmd/gc` 874s green on the final tree; protected suites green with the two comment-authorized row updates (I10 flip, I5 mechanical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
