### PR TITLE
feat(cmd/gc): census and claim path through the residency resolver (S3)

### DIFF
--- a/cmd/gc/assigned_work_class_binding_test.go
+++ b/cmd/gc/assigned_work_class_binding_test.go
@@ -89,6 +89,43 @@ func TestSessionWakeFilterKeepsAClaimRecordedUnderTheBindingRef(t *testing.T) {
 	}
 }
 
+// The S3 row the one above pre-declared: the same claim under the binding's own
+// ref, seen from the RECONCILER'S plane — where the leading store IS the
+// binding, because buildDesiredState hands the census its sessions-class store.
+//
+// That combination is the one production actually runs, and it is where the ref
+// vocabulary can strand a claim: the census now labels binding-resident rows
+// "class:*", so if the accepted set is derived from a topology whose work leg is
+// ALSO the binding, the two collapse to one ref and the new label matches
+// nothing. A ref the census emits and the wake filter rejects is ga-whzrt with
+// the arrow reversed — the claim is collected and then dropped, and its holder
+// drains with no wake reason.
+func TestSessionWakeFilterKeepsABindingRefClaimOnTheReconcilerPlane(t *testing.T) {
+	cfg, cityPath, infos := rigScopedWakeFixture(t)
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return work })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+
+	// Exactly what the census produces for this claim on this city.
+	candidates, err := censusStoreCandidates(cityPath, cfg, binding, nil, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	bindingRef := candidates[len(candidates)-1].ref
+	if bindingRef == "" {
+		t.Fatalf("the census labeled the binding leg %q; this row is about the DISTINCT label", bindingRef)
+	}
+	workBeads := []beads.Bead{{ID: "gcg-1", Status: "in_progress", Assignee: "test-city--worker-1"}}
+
+	kept, keptRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, binding, infos, workBeads, []string{bindingRef})
+
+	if len(kept) != 1 || kept[0].ID != "gcg-1" || len(keptRefs) != 1 || keptRefs[0] != bindingRef {
+		t.Fatalf("filtered work = %#v refs = %#v, want the claim kept under %q — the census emits that ref and the filter must accept it", kept, keptRefs, bindingRef)
+	}
+}
+
 // Control: the same bead in the same arm, assigned to an unrelated identity. The
 // widening is COLLECTION only, so this must still be dropped — a different
 // outcome from the row above, which is what proves the keep is identity-scoped

--- a/cmd/gc/assigned_work_residency.go
+++ b/cmd/gc/assigned_work_residency.go
@@ -115,8 +115,16 @@ func assignedWorkPlanForSessionInfo(cityPath string, cfg *config.City, store bea
 // binding's ref, and answering "no refs" there would drop every claim-holder on
 // that city into the no-wake-reason drain — the failure the refusal is supposed
 // to prevent, delivered by the guard against it.
+//
+// The work leg comes from censusWorkLeg, NOT from the caller's leading store,
+// and that is load-bearing: this set is matched against refs the CENSUS emitted,
+// and the census resolves its work leg the same way. Taking the caller's leading
+// store here would, on the reconciler's plane, make the work leg and the binding
+// the same store — collapsing their two refs into one — while the census (which
+// has the runtime's real work store) emitted both. Every binding-resident claim
+// would then be collected and rejected.
 func assignedWorkClaimRefs(cityPath string, cfg *config.City, leading beads.Store) []string {
-	refs := residencyTopologyForCity(cityPath, cfg, leading, nil).ClaimRefs()
+	refs := residencyTopologyForCity(cityPath, cfg, censusWorkLeg(cityPath, leading), nil).ClaimRefs()
 	out := make([]string, 0, len(refs))
 	for _, ref := range refs {
 		out = append(out, string(ref))

--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -422,7 +422,7 @@ func TestRegisteredControllerRoutesAnswerResidencyWithoutASecondOpen(t *testing.
 	seedNoRoutes(t, cityPath) // the one-shot funnel says "no split"
 	binding := beads.NewMemStore()
 	routes := splitRoutes(binding)
-	registerResidencyRoutes(cityPath, routes)
+	registerResidencyRoutes(cityPath, routes, nil)
 	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
 
 	work := beads.NewMemStore()
@@ -461,8 +461,8 @@ func TestUnregisterResidencyRoutesOnlyDropsItsOwnRegistration(t *testing.T) {
 	winnerBinding := beads.NewMemStore()
 	winner := splitRoutes(winnerBinding)
 
-	registerResidencyRoutes(cityPath, loser)
-	registerResidencyRoutes(cityPath, winner)
+	registerResidencyRoutes(cityPath, loser, nil)
+	registerResidencyRoutes(cityPath, winner, nil)
 	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, winner) })
 
 	// The loser's shutdown defer runs after the winner has registered.

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -404,7 +404,7 @@ func buildDesiredStateWithSessionBeads(
 	// not swallowed: undercounting running sessions can misclassify a pool as
 	// cold and trigger a spurious scale-from-zero probe.
 	subPhaseStart := time.Now()
-	allOpenSessionInfos, openSessionBeadsErr := collectAllOpenSessionInfos(cfg, store, rigStores, suspendedRigPaths)
+	allOpenSessionInfos, openSessionBeadsErr := collectAllOpenSessionInfos(cityPath, cfg, store, rigStores, suspendedRigPaths)
 	recordDemandSubPhase(trace, "demand_snapshot.collect_open_session_beads", subPhaseStart, map[string]any{
 		"beads":   len(allOpenSessionInfos),
 		"partial": openSessionBeadsErr != nil,
@@ -712,7 +712,7 @@ func buildDesiredStateWithSessionBeads(
 	assignedReadyCache := newReadyDemandCache()
 	if store != nil {
 		subPhaseStart = time.Now()
-		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, readyAssigned, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads, assignedReadyCache)
+		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, readyAssigned, storePartial = collectAssignedWorkBeadsWithStores(cityPath, cfg, store, rigStores, suspendedRigPaths, sessionBeads, assignedReadyCache)
 		recordDemandSubPhase(trace, "demand_snapshot.collect_assigned_work", subPhaseStart, map[string]any{
 			"beads":   len(assignedWorkBeads),
 			"partial": storePartial,
@@ -750,7 +750,7 @@ func buildDesiredStateWithSessionBeads(
 		// the cold pool never wakes for it.
 		subPhaseStart = time.Now()
 		var unassignedRoutedPartial bool
-		unassignedRoutedBeads, unassignedRoutedStores, unassignedRoutedStoreRefs, unassignedRoutedPartial = collectOpenUnassignedRoutedWork(cfg, store, rigStores, suspendedRigPaths, stderr)
+		unassignedRoutedBeads, unassignedRoutedStores, unassignedRoutedStoreRefs, unassignedRoutedPartial = collectOpenUnassignedRoutedWork(cityPath, cfg, store, rigStores, suspendedRigPaths, stderr)
 		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
 		// Same pass, same reason, different legacy form: a route stamped at a
 		// live slot ("<base>-N") is a load-balancing HINT that every raw reader
@@ -1102,25 +1102,35 @@ func buildSuspendedRigPathsForCity(cfg *config.City, cityPath string) map[string
 	return suspendedRigPaths
 }
 
-// collectAllOpenSessionInfos gathers every open session bead across the city
-// and non-suspended rig stores and projects each onto session.Info at the
-// collection edge, so no raw *beads.Bead escapes into the running-session
-// counting loop. Closed beads are dropped (equivalently: projected Info with
-// .Closed true). Partial-result errors still contribute their partial slice and
-// join into the returned error; any hard error is returned with an empty slice
-// for that store.
+// collectAllOpenSessionInfos gathers every open session bead across the session
+// census legs and projects each onto session.Info at the collection edge, so no
+// raw *beads.Bead escapes into the running-session counting loop. Closed beads
+// are dropped (equivalently: projected Info with .Closed true). Partial-result
+// errors still contribute their partial slice and join into the returned error;
+// any hard error is returned with an empty slice for that store.
+//
+// The fold is FIRST-LEG-WINS by session id, which the pre-resolver arm did not
+// need: it read one store per scope, so no id could appear twice. The session
+// plan leads with the sessions binding and keeps the work ledger behind it, and
+// a migrated city legitimately holds the same session bead in both — the
+// migration preserves ids and never deletes back. Counting that session twice
+// would make a pool read as over-scaled and reap a live worker.
 func collectAllOpenSessionInfos(
+	cityPath string,
 	cfg *config.City,
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
 ) ([]session.Info, error) {
-	// Sessions arm of the reconciler frame: iterate the session-class candidate
-	// fan-out (city + non-suspended rigs). CachingStore-wrapped stores are used
-	// when available. On a single-store city this hits the same store the work
-	// arm queries (identity); routing through the shared per-class candidate
-	// builder keeps the work-vs-session split structurally explicit.
-	stores := coordClassStoreCandidates(cfg, cityStore, rigStores, suspendedRigPaths, "city")
+	// Sessions arm of the reconciler frame, over the Plan(Session) leg set: the
+	// sessions binding, the city work store, then the serving rigs.
+	// CachingStore-wrapped stores are used when available.
+	stores, legErr := sessionCensusStoreCandidates(cityPath, cfg, cityStore, rigStores, suspendedRigPaths)
+	if legErr != nil {
+		// A refused city. Undercounting running sessions misclassifies a pool as
+		// cold, so this is reported rather than answered with zero.
+		return nil, legErr
+	}
 
 	type storeResult struct {
 		infos []session.Info
@@ -1145,23 +1155,30 @@ func collectAllOpenSessionInfos(
 
 	var allInfos []session.Info
 	var errs []error
+	seen := make(map[string]struct{})
+	keep := func(infos []session.Info) {
+		for _, info := range infos {
+			if info.Closed {
+				continue
+			}
+			if id := strings.TrimSpace(info.ID); id != "" {
+				if _, dup := seen[id]; dup {
+					continue
+				}
+				seen[id] = struct{}{}
+			}
+			allInfos = append(allInfos, info)
+		}
+	}
 	for _, r := range results {
 		if r.err != nil {
 			errs = append(errs, r.err)
 			if beads.IsPartialResult(r.err) {
-				for _, info := range r.infos {
-					if !info.Closed {
-						allInfos = append(allInfos, info)
-					}
-				}
+				keep(r.infos)
 			}
 			continue
 		}
-		for _, info := range r.infos {
-			if !info.Closed {
-				allInfos = append(allInfos, info)
-			}
-		}
+		keep(r.infos)
 	}
 	if len(errs) > 0 {
 		return allInfos, errors.Join(errs...)
@@ -1222,16 +1239,21 @@ func refreshDesiredStateWithSessionBeads(
 	return refreshed
 }
 
-// collectAssignedWorkBeads queries each store (city + rigs) for actionable
-// assigned work. It includes in-progress assigned work plus open assigned
-// work that is actually ready. Routed-but-unassigned pool queue work is
-// intentionally excluded here, except stranded in-progress pool work with no
-// assignee is included so reconciliation can reopen it for normal claiming.
+// collectAssignedWorkBeads queries ONE store for actionable assigned work. It
+// includes in-progress assigned work plus open assigned work that is actually
+// ready. Routed-but-unassigned pool queue work is intentionally excluded here,
+// except stranded in-progress pool work with no assignee is included so
+// reconciliation can reopen it for normal claiming.
+//
+// The city path is empty by construction, which makes this the SINGLE-STORE
+// form: no city path means no registered runtime and no funnel, so the census
+// resolves to the one store handed in. Callers that need the city's real leg
+// set — every production caller — use collectAssignedWorkBeadsWithStores.
 func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
 ) ([]beads.Bead, bool) {
-	result, _, _, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil, nil)
+	result, _, _, _, partial := collectAssignedWorkBeadsWithStores("", cfg, cityStore, nil, nil, nil)
 	return result, partial
 }
 
@@ -1245,6 +1267,7 @@ func collectAssignedWorkBeads(
 // store ref + bead ID so a ready bead in one store cannot mark a blocked open
 // bead with the same ID in another store as ready (storeScopedBeadKey).
 func collectAssignedWorkBeadsWithStores(
+	cityPath string,
 	cfg *config.City,
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
@@ -1253,14 +1276,21 @@ func collectAssignedWorkBeadsWithStores(
 	caches ...*readyDemandCache,
 ) ([]beads.Bead, []beads.Store, []string, map[storeScopedBeadKey]bool, bool) {
 	cache := optionalReadyDemandCache(caches)
-	// Work arm of the reconciler frame: iterate the work-class candidate fan-out
-	// (city + non-suspended rigs). The city store carries the empty store-ref so
-	// the index-aligned workBeads/workStores slices stay per-bead aligned for the
-	// canonicalize/stamp writers. CachingStore-wrapped stores are used; creating
-	// raw bdStoreForCity per rig spawns bd subprocesses on every tick, saturating
-	// dolt. On a single-store city this is the same store the sessions arm
-	// iterates (identity).
-	stores := coordClassStoreCandidates(cfg, cityStore, rigStores, suspendedRigPaths, "")
+	// Work arm of the reconciler frame, over the Plan(Census) leg set: the city
+	// work store under the empty store-ref, the serving rigs under their names,
+	// then every relocated class binding under its own "class:*" ref. The refs
+	// keep the index-aligned workBeads/workStores slices per-bead aligned for the
+	// canonicalize/stamp writers, and naming the binding distinctly is what lets
+	// a dead claim on a city-scope WORK bead be captured at all (D6).
+	// CachingStore-wrapped stores are used; creating raw bdStoreForCity per rig
+	// spawns bd subprocesses on every tick, saturating dolt.
+	stores, legErr := censusStoreCandidates(cityPath, cfg, cityStore, rigStores, suspendedRigPaths, censusRefBare)
+	if legErr != nil {
+		// A refused city has told this scan nothing, and an empty assigned-work
+		// snapshot presented as complete is the drain-a-live-holder shape. Report
+		// it partial so every consumer retains rather than reaps.
+		return nil, nil, nil, nil, true
+	}
 
 	type storeAssignedWorkResult struct {
 		ref       string // store ref these beads came from (empty = city store)
@@ -4473,32 +4503,33 @@ func canonicalizeLegacyBoundUnassignedRoutedWork(cfg *config.City, workBeads []b
 // read per store per tick so the raw-status filter runs, which costs a
 // backing-store round trip the cached read did not — the accepted tradeoff for
 // not counting blocked work as demand.
-func collectOpenUnassignedRoutedWork(cfg *config.City, store beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, stderr io.Writer) ([]beads.Bead, []beads.Store, []string, bool) {
+func collectOpenUnassignedRoutedWork(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, stderr io.Writer) ([]beads.Bead, []beads.Store, []string, bool) {
 	if cfg == nil {
 		return nil, nil, nil, false
 	}
-	// Work arm (unassigned-routed re-home scan): iterate the work-class
-	// candidate fan-out, labeling the city store "city" for the diagnostic
-	// ref. Identity on a single-store city.
-	stores := coordClassStoreCandidates(cfg, store, rigStores, suspendedRigPaths, "city")
+	// Work arm (unassigned-routed re-home scan), over the Plan(Census) leg set.
+	// Refs are the canonical scoped spelling the rows' gc.root_store_ref is
+	// matched against; a binding keeps its own "class:*" ref, which reads back as
+	// city scope.
+	stores, legErr := censusStoreCandidates(cityPath, cfg, store, rigStores, suspendedRigPaths, censusRefScoped)
+	if legErr != nil {
+		// The only demand signal this set feeds is openControlDispatcherDemand,
+		// and a refused city reporting zero would drain a live dispatcher. Say so
+		// and retain.
+		fmt.Fprintf(stderr, "collectOpenUnassignedRoutedWork: no census leg set for this city: %v\n", legErr) //nolint:errcheck
+		return nil, nil, nil, true
+	}
 
 	var workBeads []beads.Bead
 	var workStores []beads.Store
 	var workStoreRefs []string
 	var partial bool
 	seen := make(map[storeScopedBeadKey]struct{})
-	for sourceIndex, source := range stores {
+	for _, source := range stores {
 		if source.store == nil {
 			continue
 		}
-		storeRef := "rig:" + strings.TrimSpace(source.ref)
-		if sourceIndex == 0 {
-			cityName := strings.TrimSpace(cfg.Workspace.Name)
-			if cityName == "" {
-				cityName = "city"
-			}
-			storeRef = "city:" + cityName
-		}
+		storeRef := source.ref
 		// Live so the backing store's raw --status=open filter excludes blocked/
 		// deferred work: this unassigned-routed set feeds openControlDispatcherDemand
 		// and the route-repair passes, and mapBdStatus would otherwise collapse a
@@ -4618,6 +4649,12 @@ func normalizeDemandStoreRef(storeRef string) string {
 	storeRef = strings.TrimSpace(storeRef)
 	switch {
 	case storeRef == "city", strings.HasPrefix(storeRef, "city:"):
+		return "city"
+	// A class binding is a CITY-scope store, so it normalizes onto the city
+	// exactly as it did when it WAS the census's city leg. Leaving it as its own
+	// scope would split a graph-class row's demand key from the ready-routed key
+	// the same row is matched against.
+	case storeref.IsClassRef(storeRef):
 		return "city"
 	case strings.HasPrefix(storeRef, "rig:"):
 		return "rig:" + strings.TrimSpace(strings.TrimPrefix(storeRef, "rig:"))
@@ -4826,6 +4863,16 @@ func canonicalContinuationClaimStoreRef(cityName, storeRef string) (string, bool
 	storeRef = strings.TrimSpace(storeRef)
 	switch {
 	case storeRef == "":
+		if cityName == "" {
+			return "", false
+		}
+		return "city:" + cityName, true
+	// A binding leg canonicalizes to the city, the scope it serves. Before the
+	// census named it separately, a binding-resident continuation row arrived
+	// under the city ref and was a candidate; answering "not canonical" here
+	// would silently retire the continuation backstop for every graph-class step
+	// on a split city.
+	case storeref.IsClassRef(storeRef):
 		if cityName == "" {
 			return "", false
 		}

--- a/cmd/gc/build_desired_state_blocked_demand_test.go
+++ b/cmd/gc/build_desired_state_blocked_demand_test.go
@@ -36,7 +36,7 @@ func TestCollectOpenUnassignedRoutedWorkExcludesBlocked(t *testing.T) {
 	}
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 
-	work, _, _, partial := collectOpenUnassignedRoutedWork(cfg, store, nil, nil, io.Discard)
+	work, _, _, partial := collectOpenUnassignedRoutedWork("", cfg, store, nil, nil, io.Discard)
 	if partial {
 		t.Errorf("collectOpenUnassignedRoutedWork reported partial on a healthy live read")
 	}
@@ -79,7 +79,7 @@ func TestCollectOpenUnassignedRoutedWorkReportsPartialOnLiveOutage(t *testing.T)
 	store := liveOpenListErrorStore{Store: beads.NewMemStore(), err: errors.New("live open list outage")}
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 
-	work, _, _, partial := collectOpenUnassignedRoutedWork(cfg, store, nil, nil, io.Discard)
+	work, _, _, partial := collectOpenUnassignedRoutedWork("", cfg, store, nil, nil, io.Discard)
 
 	if !partial {
 		t.Errorf("collectOpenUnassignedRoutedWork did not report partial on a live List outage (fail-open-to-zero, gc-ft31x)")
@@ -277,7 +277,7 @@ func TestCollectAssignedWorkBeadsExcludesBlockedFromDemandButReaperStillSeesIt(t
 	}
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, _, _, readyAssigned, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, _, _, readyAssigned, partial := collectAssignedWorkBeadsWithStores("", cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -321,7 +321,7 @@ func TestCollectAllOpenSessionInfos(t *testing.T) {
 			t.Fatalf("close session bead: %v", err)
 		}
 
-		infos, err := collectAllOpenSessionInfos(&config.City{}, cityStore, nil, nil)
+		infos, err := collectAllOpenSessionInfos("", &config.City{}, cityStore, nil, nil)
 		if err != nil {
 			t.Fatalf("collectAllOpenSessionInfos: %v", err)
 		}
@@ -354,7 +354,7 @@ func TestCollectAllOpenSessionInfos(t *testing.T) {
 		}
 		store := &partialSessionListStore{MemStore: backing}
 
-		infos, err := collectAllOpenSessionInfos(&config.City{}, store, nil, nil)
+		infos, err := collectAllOpenSessionInfos("", &config.City{}, store, nil, nil)
 		if err == nil {
 			t.Fatal("collectAllOpenSessionInfos returned nil error on a partial-result store")
 		}
@@ -373,6 +373,12 @@ func TestCollectAllOpenSessionInfos(t *testing.T) {
 		rigPath := filepath.Clean("/c/rigs/rig-A")
 		cfg := &config.City{Rigs: []config.Rig{{Name: "rig-A", Path: rigPath}}}
 
+		// DISTINCT id sequences. The session census folds first-leg-wins by id
+		// (a migrated city holds the same session bead in the binding and in the
+		// work ledger, and counting it twice reaps a live worker), and two bare
+		// MemStores both mint "gc-1" — a fixture collision, not two sessions.
+		// Real stores cannot collide: config.ValidateRigs rejects duplicate
+		// prefixes.
 		cityStore := beads.NewMemStore()
 		cityBead, err := cityStore.Create(beads.Bead{
 			Status: "open", Type: sessionBeadType,
@@ -381,7 +387,7 @@ func TestCollectAllOpenSessionInfos(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create city session bead: %v", err)
 		}
-		rigStore := beads.NewMemStore()
+		rigStore := beads.NewMemStoreFrom(100, nil, nil)
 		if _, err := rigStore.Create(beads.Bead{
 			Status: "open", Type: sessionBeadType,
 			Metadata: map[string]string{"template": "rig-A/worker", "state": "active"},
@@ -391,7 +397,7 @@ func TestCollectAllOpenSessionInfos(t *testing.T) {
 		rigStores := map[string]beads.Store{"rig-A": rigStore}
 
 		// Control: with the rig live, both sessions are collected.
-		liveInfos, err := collectAllOpenSessionInfos(cfg, cityStore, rigStores, nil)
+		liveInfos, err := collectAllOpenSessionInfos("", cfg, cityStore, rigStores, nil)
 		if err != nil {
 			t.Fatalf("collectAllOpenSessionInfos (live rig): %v", err)
 		}
@@ -401,7 +407,7 @@ func TestCollectAllOpenSessionInfos(t *testing.T) {
 
 		// Suspending the rig drops its store from the fan-out.
 		suspended := map[string]bool{rigPath: true}
-		infos, err := collectAllOpenSessionInfos(cfg, cityStore, rigStores, suspended)
+		infos, err := collectAllOpenSessionInfos("", cfg, cityStore, rigStores, suspended)
 		if err != nil {
 			t.Fatalf("collectAllOpenSessionInfos (suspended rig): %v", err)
 		}
@@ -2103,7 +2109,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialInProgressSurvivors(t *testing
 		t.Fatalf("reload work bead: %v", err)
 	}
 
-	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores("", &config.City{}, store, nil, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -2134,7 +2140,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
 		t.Fatalf("create work bead: %v", err)
 	}
 
-	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
+	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores("", &config.City{}, store, nil, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -2181,7 +2187,7 @@ func TestCollectAssignedWorkBeads_SkipsReadyProbeForInProgressAssignee(t *testin
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
 
-	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores("", &config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -2227,6 +2233,7 @@ func TestCollectAssignedWorkBeads_SkipsCityReadyProbeForRigInProgressAssignee(t 
 	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
 
 	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2298,7 +2305,7 @@ func TestCollectAssignedWorkBeads_ReadyProbeStillRunsForOtherAssignees(t *testin
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, readySession})
 
-	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores("", &config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -2362,7 +2369,7 @@ func TestCollectAssignedWorkBeads_ReadyProbeIncludesActiveSessionAssignees(t *te
 	}
 	snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, sleepySession})
 
-	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	got, _, _, _, partial := collectAssignedWorkBeadsWithStores("", &config.City{}, store, nil, nil, snapshot)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -2433,6 +2440,7 @@ func TestCollectAssignedWorkBeads_ReadyProbeExcludesFutureNamedSessionRuntimeAss
 	}
 
 	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		cfg,
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2484,6 +2492,7 @@ func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
 	}
 
 	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2544,6 +2553,7 @@ func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *t
 	}
 
 	got, stores, storeRefs, _, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2629,6 +2639,7 @@ func TestCollectAssignedWorkBeadsWithStores_ReadinessIsStoreScoped(t *testing.T)
 	}
 
 	got, _, _, readyAssigned, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -2720,6 +2731,7 @@ func TestCollectAssignedWorkBeadsWithStores_SkipSetIsStoreScopedAcrossSameID(t *
 	})
 
 	got, _, _, _, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -12397,6 +12409,7 @@ func TestCollectOpenUnassignedRoutedWorkKeepsSameIDAcrossStoreScopes(t *testing.
 	}
 
 	work, _, refs, _ := collectOpenUnassignedRoutedWork(
+		"",
 		cfg,
 		cityStore,
 		map[string]beads.Store{"city": rigStore},
@@ -12459,9 +12472,15 @@ func TestCollectOpenUnassignedRoutedWorkReportsCanonicalStoreRefs(t *testing.T) 
 	}
 	var stderr bytes.Buffer
 	collectOpenUnassignedRoutedWork(
+		"",
 		cfg,
-		listFailStore{},
-		map[string]beads.Store{"fixture": listFailStore{}},
+		// Two DISTINCT failing stores. A zero-value listFailStore{} used twice is
+		// == to itself, so the census leg dedupe (a binding that resolved back to
+		// the work store must not be read twice) would legitimately collapse them
+		// into one leg and the rig diagnostic would never be emitted. Every
+		// production store is reference-identified; the fixture has to be too.
+		listFailStore{Store: beads.NewMemStore()},
+		map[string]beads.Store{"fixture": listFailStore{Store: beads.NewMemStore()}},
 		nil,
 		&stderr,
 	)

--- a/cmd/gc/build_desired_state_warm_crossstore_test.go
+++ b/cmd/gc/build_desired_state_warm_crossstore_test.go
@@ -64,7 +64,7 @@ func createWarmSessionBead(t *testing.T, store beads.Store) {
 // tests could silently pin the cold path and pass for the wrong reason.
 func requireWarm(t *testing.T, cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store) {
 	t.Helper()
-	infos, err := collectAllOpenSessionInfos(cfg, cityStore, rigStores, nil)
+	infos, err := collectAllOpenSessionInfos("", cfg, cityStore, rigStores, nil)
 	if err != nil {
 		t.Fatalf("collectAllOpenSessionInfos: %v", err)
 	}

--- a/cmd/gc/census_residency.go
+++ b/cmd/gc/census_residency.go
@@ -1,0 +1,234 @@
+package main
+
+// The reconciler frame's census legs, resolved through internal/storeref.
+//
+// One question — "which stores does a controller-tick sweep read?" — asked once,
+// for the session-iteration arm, the assigned-work arm and the unassigned-routed
+// arm. Before this they shared coordClassStoreCandidates, which built the list
+// from cfg alone and could name only two families: the store it was handed, and
+// the configured rigs. It had no way to name a relocated class binding, so the
+// binding reached the census only by being the store the caller HANDED it.
+//
+// # The E2 dual role, and why naming both legs is the whole slice
+//
+// buildDesiredState hands the census its SESSIONS-class store, which on a
+// converged split IS the binding. So the census covered the binding by accident,
+// as its "city" leg — and the city WORK store, which rigBeadStores() explicitly
+// deletes, was then in no leg at all. A city-scope routed WORK bead was
+// invisible to controller-tick demand: the pool never spawned for it, and a dead
+// claim on one was captured and released by nothing (D6, ga-88mxz;
+// split_topology_conformance_test.go pre-declared the flip rows for both halves).
+//
+// Plan(Census) names work AND the rigs AND every binding as DISTINCT ref'd legs,
+// which is exactly the shape that was missing. The work leg comes from the
+// runtime's own registration rather than from the store the arm was handed,
+// because the store it was handed is the one that used to stand in for it.
+//
+// # The suspension frame is threaded, not re-derived
+//
+// A suspended rig is routinely dark, and Plan marks a dark FederationTail leg's
+// failure PartialDegrade — which means retain-don't-reap. Left in, one suspended
+// rig would mark every census Partial and pin the fleet against every drain and
+// reap decision. The serving set is therefore computed by the caller that
+// already knows it and handed in: told, not deciding.
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// censusRefStyle names the store-ref vocabulary one census arm labels its rows
+// with. The two exist because the arms record refs for different readers: the
+// assigned-work arm's refs are matched against assignedWorkClaimRefs by the wake
+// filter, which has always spelled the city store as the empty string; the
+// unassigned-routed arm's are matched against gc.root_store_ref, which is
+// canonically scoped ("city:<name>" / "rig:<name>").
+type censusRefStyle int
+
+const (
+	// censusRefBare is the assigned-work arm's vocabulary: the city work store
+	// under the EMPTY ref (the ref every pre-split census row already carries),
+	// rigs under their bare name.
+	censusRefBare censusRefStyle = iota
+
+	// censusRefScoped is the session and unassigned-routed arms' vocabulary:
+	// "city:<name>" and "rig:<name>", the canonical gc.root_store_ref spelling.
+	censusRefScoped
+)
+
+// censusStoreCandidates resolves the WORK census leg set: the city work store,
+// the serving rig stores, then every relocated class binding, each with the
+// store-ref this arm labels its rows with.
+//
+// leading is the store the arm was handed — the sessions-class store on the
+// controller path. It is used as the work leg only when this process has not
+// registered one, which is every one-shot and test caller; a controller's own
+// work store comes from the registration, so the binding it hands in as its
+// leading store lands on the binding leg where it belongs instead of standing in
+// for work.
+//
+// It errors only on a REFUSED city, where every infrastructure class answers
+// with the refusal that names the remedy. A refused city must not get a
+// work-only census: that is the answer that looks like success while reading the
+// ledger the relocated classes were moved off.
+func censusStoreCandidates(
+	cityPath string,
+	cfg *config.City,
+	leading beads.Store,
+	rigStores map[string]beads.Store,
+	suspendedRigPaths map[string]bool,
+	style censusRefStyle,
+) ([]classStoreCandidate, error) {
+	return censusLegCandidates(storeref.Census{}, cityPath, cfg, leading, rigStores, suspendedRigPaths, style)
+}
+
+// sessionCensusStoreCandidates resolves the SESSION census leg set. It differs
+// from the work census in one way that matters: the sessions binding LEADS.
+//
+// The binding is the authority for the session class, so on a co-resident
+// session bead — the steady state of a migrated city, where `gc storage migrate`
+// preserves ids and never deletes back — the first-leg-wins fold must resolve to
+// the binding's row, not to the pre-relocation residue in the work ledger. That
+// is also the leg this arm has always read first, so a converged split's
+// leading answer is unchanged and what it gains is the work and rig legs behind
+// it (#5187's session-verb blindness: graph-run session beads in work stores are
+// real).
+func sessionCensusStoreCandidates(
+	cityPath string,
+	cfg *config.City,
+	leading beads.Store,
+	rigStores map[string]beads.Store,
+	suspendedRigPaths map[string]bool,
+) ([]classStoreCandidate, error) {
+	return censusLegCandidates(storeref.Session{}, cityPath, cfg, leading, rigStores, suspendedRigPaths, censusRefScoped)
+}
+
+func censusLegCandidates(
+	intent storeref.Intent,
+	cityPath string,
+	cfg *config.City,
+	leading beads.Store,
+	rigStores map[string]beads.Store,
+	suspendedRigPaths map[string]bool,
+	style censusRefStyle,
+) ([]classStoreCandidate, error) {
+	work := censusWorkLeg(cityPath, leading)
+	if work == nil {
+		// Not a topology the resolver can plan over, and not an error either:
+		// the pre-resolver builder returned one nil candidate that every arm
+		// then skipped, so returning no legs is the same answer without the nil.
+		return nil, nil
+	}
+	topo := residencyTopologyForCity(cityPath, cfg, work, servingRigStores(cfg, rigStores, suspendedRigPaths))
+	plan, err := storeref.Plan(intent, topo)
+	if err != nil {
+		return nil, err
+	}
+	// Enumerated through the resolver rather than executed through it: the arms
+	// read every leg CONCURRENTLY and fold their own per-arm partials, which is
+	// a fan-out shape Union cannot express. What they must not supply is the leg
+	// order or the error policy, and EachLeg hands over both.
+	var candidates []classStoreCandidate
+	storeref.EachLeg(plan, func(leg storeref.Leg, _ storeref.Role, onError storeref.ErrPolicy) {
+		candidates = append(candidates, classStoreCandidate{
+			store:   leg.Store,
+			ref:     censusRef(cfg, leg.Ref, style),
+			onError: onError,
+		})
+	})
+	return candidates, nil
+}
+
+// censusWorkLeg picks the store the CENSUS plans over as its work leg: the one
+// the runtime serving this city registered, and otherwise the store the caller
+// was handed.
+//
+// It is a named function with one caller too many on purpose. The refs the
+// census EMITS and the refs the wake filter ACCEPTS
+// (assignedWorkClaimRefs → Topology.ClaimRefs) have to be derived from the same
+// work leg, and they are resolved on different call paths with different
+// arguments. Resolve them differently and the two vocabularies diverge by one
+// entry: the census labels a binding-resident claim "class:*" while the filter's
+// accepted set collapsed the binding onto the work ref, so the claim is
+// collected and then dropped and its holder drains with no wake reason —
+// ga-whzrt, arriving through the fix for ga-whzrt.
+// TestSessionWakeFilterKeepsABindingRefClaimOnTheReconcilerPlane is the guard.
+func censusWorkLeg(cityPath string, leading beads.Store) beads.Store {
+	if registered := registeredCityWorkStore(cityPath); registered != nil {
+		return registered
+	}
+	return leading
+}
+
+// censusRef spells one plan leg in the vocabulary of one census arm.
+//
+// A binding keeps its own "class:*" ref in BOTH vocabularies. It is a city-scope
+// store, so every scope comparison folds it onto the city
+// (storeref.ScopeRigContext, and the demand/idle/continuation normalizers that
+// read it back) — but it is a DISTINCT store, and giving it the city's own ref
+// would recreate the substitution this slice exists to end: two legs, one name,
+// and no way for a wake filter or a partial-result diagnostic to say which one
+// answered.
+func censusRef(cfg *config.City, ref storeref.StoreRef, style censusRefStyle) string {
+	if storeref.IsClassRef(string(ref)) {
+		return string(ref)
+	}
+	if rig, ok := storeref.ScopeRigContext(string(ref)); ok && rig != "" {
+		if style == censusRefBare {
+			return rig
+		}
+		return string(ref)
+	}
+	if style == censusRefBare {
+		return ""
+	}
+	return "city:" + censusCityName(cfg)
+}
+
+// censusCityName is the workspace name the scoped vocabulary spells the city
+// leg with, defaulting to "city" exactly as the pre-resolver arm did.
+func censusCityName(cfg *config.City) string {
+	if cfg == nil {
+		return "city"
+	}
+	if name := strings.TrimSpace(cfg.Workspace.Name); name != "" {
+		return name
+	}
+	return "city"
+}
+
+// servingRigStores is the suspension FRAME: the rig legs a census may read.
+//
+// It keeps the pre-resolver rule exactly — a rig is a leg when it is DECLARED in
+// cfg.Rigs, its store is open, and its path is not suspended — so an entry in
+// the store map that config no longer declares stays out. What it does not keep
+// is cfg.Rigs ORDER: the resolver sorts rig legs by name, which is the order
+// `gc ready` and the API's fan-out already agree on, and having the census
+// disagree with them was one leg-ordering fact maintained in three places.
+//
+// residency:allow — a constructor INPUT, not a residency answer. It hands the
+// topology the frame it is TOLD (which rigs are serving) by filtering the
+// caller's own map; it consults no binding, no namespace and no leg order, and
+// its result goes nowhere but residencyTopologyForCity.
+func servingRigStores(cfg *config.City, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool) map[string]beads.Store {
+	if cfg == nil || len(rigStores) == 0 {
+		return nil
+	}
+	serving := make(map[string]beads.Store, len(rigStores))
+	for _, rig := range cfg.Rigs {
+		if suspendedRigPaths[filepath.Clean(rig.Path)] {
+			continue
+		}
+		if store, ok := rigStores[rig.Name]; ok && store != nil {
+			serving[rig.Name] = store
+		}
+	}
+	if len(serving) == 0 {
+		return nil
+	}
+	return serving
+}

--- a/cmd/gc/census_residency_test.go
+++ b/cmd/gc/census_residency_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// candidateRefs renders one census leg set as its refs, which is the half a
+// consumer persists and matches on.
+func candidateRefs(candidates []classStoreCandidate) []string {
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.ref)
+	}
+	return out
+}
+
+func equalRefs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// THE MIGRATION PIN, T0 half. A city that relocates nothing must get exactly the
+// leg set coordClassStoreCandidates built: the leading store first, then the
+// configured rigs, in each arm's own ref vocabulary. Byte-identical is the
+// acceptance criterion for every legacy deployment.
+func TestCensusCandidatesAreByteIdenticalOnASingleStoreCity(t *testing.T) {
+	cfg := residencyTestConfig()
+	work := beads.NewMemStore()
+	rigs := map[string]beads.Store{"alpha": beads.NewMemStore(), "bravo": beads.NewMemStore()}
+
+	bare, err := censusStoreCandidates("", cfg, work, rigs, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates(bare): %v", err)
+	}
+	if got, want := candidateRefs(bare), []string{"", "alpha", "bravo"}; !equalRefs(got, want) {
+		t.Fatalf("assigned-work arm refs = %v, want %v", got, want)
+	}
+	if bare[0].store != work {
+		t.Fatal("the leading candidate is not the store the arm was handed")
+	}
+
+	scoped, err := censusStoreCandidates("", cfg, work, rigs, nil, censusRefScoped)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates(scoped): %v", err)
+	}
+	if got, want := candidateRefs(scoped), []string{"city:test-city", "rig:alpha", "rig:bravo"}; !equalRefs(got, want) {
+		t.Fatalf("unassigned-routed arm refs = %v, want %v", got, want)
+	}
+
+	sessions, err := sessionCensusStoreCandidates("", cfg, work, rigs, nil)
+	if err != nil {
+		t.Fatalf("sessionCensusStoreCandidates: %v", err)
+	}
+	if got, want := candidateRefs(sessions), []string{"city:test-city", "rig:alpha", "rig:bravo"}; !equalRefs(got, want) {
+		t.Fatalf("session arm refs = %v, want %v", got, want)
+	}
+}
+
+// The suspension frame, at the census seam this time: a suspended rig is not a
+// leg. The control is the same call with no frame.
+func TestCensusCandidatesExcludeSuspendedRigs(t *testing.T) {
+	cfg := residencyTestConfig()
+	work := beads.NewMemStore()
+	rigs := map[string]beads.Store{"alpha": beads.NewMemStore(), "bravo": beads.NewMemStore()}
+	suspended := map[string]bool{filepath.Clean("/tmp/bravo"): true}
+
+	got, err := censusStoreCandidates("", cfg, work, rigs, suspended, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	if want := []string{"", "alpha"}; !equalRefs(candidateRefs(got), want) {
+		t.Fatalf("refs with bravo suspended = %v, want %v", candidateRefs(got), want)
+	}
+	control, err := censusStoreCandidates("", cfg, work, rigs, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates (control): %v", err)
+	}
+	if want := []string{"", "alpha", "bravo"}; !equalRefs(candidateRefs(control), want) {
+		t.Fatalf("control refs = %v, want %v — the exclusion above proves nothing if no frame also drops bravo", candidateRefs(control), want)
+	}
+}
+
+// A store map entry config no longer declares is not a leg, exactly as before:
+// the pre-resolver builder walked cfg.Rigs and looked each name up.
+func TestCensusCandidatesSkipUndeclaredRigStores(t *testing.T) {
+	cfg := residencyTestConfig()
+	rigs := map[string]beads.Store{"alpha": beads.NewMemStore(), "ghost": beads.NewMemStore()}
+	got, err := censusStoreCandidates("", cfg, beads.NewMemStore(), rigs, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	if want := []string{"", "alpha"}; !equalRefs(candidateRefs(got), want) {
+		t.Fatalf("refs = %v, want %v — a rig store city.toml does not declare is not a census leg", candidateRefs(got), want)
+	}
+}
+
+// THE D6 FLIP, at the unit seam. A controller that registered its work store
+// gets the binding as a leg BESIDE it, under its own class ref — not instead of
+// it. Before this slice the arm was handed the binding as its "city" leg and the
+// work store was in no leg at all.
+func TestCensusCandidatesNameTheWorkStoreAndTheBindingSeparately(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := residencyTestConfig()
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return work })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+
+	// The arm is handed the SESSIONS store, which on a converged split is the
+	// binding — exactly what buildDesiredState passes.
+	got, err := censusStoreCandidates(cityPath, cfg, binding, nil, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	if want := []string{"", string(storeref.ClassRef(wholeSplitClasses()))}; !equalRefs(candidateRefs(got), want) {
+		t.Fatalf("split-city census refs = %v, want %v — the binding must be a DISTINCT leg beside the work store (D6)", candidateRefs(got), want)
+	}
+	if got[0].store != work {
+		t.Fatal("the work leg is not the registered city work store; the binding is still standing in for it")
+	}
+	if got[1].store != binding {
+		t.Fatal("the second leg is not the binding")
+	}
+}
+
+// A refused city gets no census at all: every infrastructure class answers with
+// the refusal that names the remedy, and a work-only sweep reads the ledger the
+// classes were moved off.
+func TestCensusCandidatesRefuseARefusedCity(t *testing.T) {
+	cityPath := t.TempDir()
+	routes := splitRoutes(refusedClassStore{err: standingStorageRefusal{err: errStorageRefusedForTest{}}})
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return beads.NewMemStore() })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+
+	if _, err := censusStoreCandidates(cityPath, residencyTestConfig(), beads.NewMemStore(), nil, nil, censusRefBare); err == nil {
+		t.Fatal("a refused city produced a census leg set — that is the work-only answer that looks like success")
+	}
+	// Control: the same call on a city that relocates nothing succeeds, so the
+	// refusal above is the refusal and not a constructor that always errors.
+	if _, err := censusStoreCandidates("", residencyTestConfig(), beads.NewMemStore(), nil, nil, censusRefBare); err != nil {
+		t.Fatalf("a single-store city was refused a census: %v", err)
+	}
+}
+
+// The binding ref must read back as CITY scope through every normalizer that
+// compares scopes, or the census gains the leg and drops its rows in the same
+// commit.
+func TestBindingRefNormalizesOntoTheCityScope(t *testing.T) {
+	ref := string(storeref.ClassRef(wholeSplitClasses()))
+	if got := normalizeDemandStoreRef(ref); got != "city" {
+		t.Errorf("normalizeDemandStoreRef(%q) = %q, want \"city\"", ref, got)
+	}
+	if got := normalizeIdleClaimStoreRef(ref); got != "city" {
+		t.Errorf("normalizeIdleClaimStoreRef(%q) = %q, want \"city\"", ref, got)
+	}
+	if got, ok := canonicalContinuationClaimStoreRef("test-city", ref); !ok || got != "city:test-city" {
+		t.Errorf("canonicalContinuationClaimStoreRef(%q) = (%q, %v), want (\"city:test-city\", true)", ref, got, ok)
+	}
+	if !rootStoreRefMatchesCandidate("city:test-city", ref) {
+		t.Error("a city-scope root_store_ref no longer matches the binding candidate; every binding-resident routed row just left the demand scan")
+	}
+	// Control: a RIG-scoped root must still not match the binding, or the
+	// normalization has flattened the scope comparison into a tautology.
+	if rootStoreRefMatchesCandidate("rig:alpha", ref) {
+		t.Error("a rig-scoped root_store_ref matched the binding candidate")
+	}
+}
+
+// wholeSplitClasses is the class set this build's storage boot admits: all five
+// infrastructure classes on one binding. Derived rather than spelled, so the
+// ref stays the constructors' answer and not a literal a test can drift from.
+func wholeSplitClasses() []coordclass.Class {
+	classes := make([]coordclass.Class, 0, 5)
+	for _, c := range coordclass.Classes() {
+		if c.IsInfrastructure() {
+			classes = append(classes, c)
+		}
+	}
+	return classes
+}
+
+// The generated work_query's federation bit is a PROJECTION of Plan(RoutedWork):
+// a binding leg in the plan means the claimable set spans a store no bd
+// workspace can reach. The three answers that matter are pinned together
+// because they are the ones an operator's city can be in.
+func TestQueryTopologyProjectsTheRoutedWorkPlan(t *testing.T) {
+	cfg := residencyTestConfig()
+
+	// A city that relocates nothing: no binding leg, so `bd ready` is enough and
+	// the generated command is byte-identical to the one it always ran.
+	if routedWorkNeedsFederatedReader("", cfg) {
+		t.Error("a single-store city was told to use the federated reader; its generated query is supposed to be unchanged")
+	}
+
+	split := t.TempDir()
+	routes := splitRoutes(beads.NewMemStore())
+	registerResidencyRoutes(split, routes, nil)
+	t.Cleanup(func() { unregisterResidencyRoutes(split, routes) })
+	if !routedWorkNeedsFederatedReader(split, cfg) {
+		t.Error("a split city was told `bd ready` is enough; on such a city that reads the work ledger and answers with the copies the migration retained — a short array indistinguishable from \"no work\"")
+	}
+
+	// THE DELETED-[storage] TRAP. Plan REFUSES over a refused topology, and the
+	// projection must read that as "federate", not as "no split". The federated
+	// reader is the only one that carries the refusal to the operator; `bd ready`
+	// would quietly read the ledger the classes were moved off, forever.
+	refused := t.TempDir()
+	refusedRoutes := splitRoutes(refusedClassStore{err: standingStorageRefusal{err: errStorageRefusedForTest{}}})
+	registerResidencyRoutes(refused, refusedRoutes, nil)
+	t.Cleanup(func() { unregisterResidencyRoutes(refused, refusedRoutes) })
+	if !routedWorkNeedsFederatedReader(refused, cfg) {
+		t.Error("a REFUSED city was given the single-store reader — \"no work forever\", which is the exact trap the resolver's refusal exists to surface")
+	}
+}
+
+// A nil work store is not a topology to plan over, and returning one nil
+// candidate the arms skip is what the pre-resolver builder did. No legs, no
+// error.
+func TestCensusCandidatesAnswerNoLegsForANilStore(t *testing.T) {
+	got, err := censusStoreCandidates("", &config.City{}, nil, nil, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("a nil work store produced an error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d candidates for a nil work store, want none", len(got))
+	}
+}

--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // This file is the controller/CLI-side seam of the per-class store refactor.
@@ -382,28 +383,64 @@ func graphClassBinding(routes *storageRoutes) (beads.Store, bool) {
 // configured for, and whether its claimable work is spread across stores a
 // single `bd ready` in the agent's work directory cannot reach.
 //
-// The second question is graphClassBinding's, not config's, and the difference
-// is not academic. storageSplitShapeOf reads [storage] alone and answers "no
-// split" for a city whose section was DELETED after it had already served one —
-// the exact edit storage_boot.go's bypass note exists to catch. That city's
-// graph beads are in a binding, its boot refuses, and its routes serve every
-// infrastructure class from refusedClassStore; asking config would build it a
-// `bd ready` command that reads the work ledger and reports "no work" forever,
-// while asking the routes builds it the federated command, which fails loud with
-// the refusal that names the remedy. Same authority as resolveClassStore, same
-// answer, one place.
+// The second question is the RESOLVER'S, and it is answered as a projection of
+// Plan(RoutedWork) — the same plan the demand surface reads. A generated query
+// is the one consumer that cannot take a plan: its legs are bd subprocesses in a
+// workspace, and a relocated class binding is not a bd workspace at all. What it
+// can take is the plan's DECISION, which is exactly one bit: does the claimable
+// set live anywhere a bd workspace cannot reach? A binding leg in the plan means
+// yes, and the query is built around the federated reader.
 //
-// A nil cfg still resolves the routes: cliStorageRoutes reads the city's own
-// city.toml rather than the caller's snapshot, precisely because where a city
-// serves its classes from is a property of the CITY.
+// Projecting rather than re-asking is what stops the query from disagreeing with
+// the reader it drives. It also keeps the cityQueryTopology lesson intact:
+// storageSplitShapeOf reads [storage] alone and answers "no split" for a city
+// whose section was DELETED after it had already served one. That city's graph
+// beads are in a binding, its boot refuses, and Plan REFUSES over it — which is
+// projected here as FederatedReady, so the query is the federated one and fails
+// loud with the refusal that names the remedy, rather than a `bd ready` that
+// reads the work ledger and reports "no work" forever.
+//
+// A nil cfg still resolves the routes: the topology constructor reads the city's
+// own city.toml rather than the caller's snapshot, precisely because where a
+// city serves its classes from is a property of the CITY.
 func cityQueryTopology(cityPath string, cfg *config.City) config.QueryTopology {
 	topo := config.QueryTopology{}
 	if cfg != nil {
 		topo.Beads = cfg.Beads
 	}
-	_, topo.FederatedReady = graphClassBinding(cliStorageRoutes(cityPath))
+	topo.FederatedReady = routedWorkNeedsFederatedReader(cityPath, cfg)
 	return topo
 }
+
+// routedWorkNeedsFederatedReader reports whether this city's claimable set spans
+// a store no bd workspace can reach.
+//
+// The work legs of Plan(RoutedWork) are bd workspaces — the city work store and
+// the rigs — and the hook already fans out across them. The binding is not one,
+// so its presence in the plan is the whole answer. A REFUSED city answers yes:
+// the refusal is about a relocated class, and only the federated reader carries
+// it to the operator instead of silently reading the wrong ledger.
+//
+// The topology is built with no work legs on purpose. This asks about the SHAPE
+// of the city, not about a caller's opened stores, and every caller here — `gc
+// hook`, `gc prime`, `gc agent list`, the dispatch runtime — holds a different
+// set or none at all. Bindings do not depend on which work stores the caller
+// opened, so the answer is the same for all of them.
+func routedWorkNeedsFederatedReader(cityPath string, cfg *config.City) bool {
+	topo := residencyTopologyForCity(cityPath, cfg, queryTopologyWorkProbe{}, nil)
+	plan, err := storeref.Plan(storeref.RoutedWork{}, topo)
+	if err != nil {
+		return true
+	}
+	return plan.TouchesBinding()
+}
+
+// queryTopologyWorkProbe stands in for the work leg of a topology built to be
+// PLANNED over and never read. Plan refuses a legless topology — a Union that
+// reported zero rows as a complete answer is the silent-shrink shape — so the
+// leg has to exist; nothing in this file executes the plan, so it never answers
+// a call.
+type queryTopologyWorkProbe struct{ beads.Store }
 
 // newCityMailProvider builds the controller's mail provider as a two-store mail
 // provider: message beads persist in the messaging-class store, and mail's

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -668,7 +668,7 @@ func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, store
 	// report claims_errored instead of laundering a write failure into no_work.
 	claimsErrored := false
 	for len(remaining) > 0 {
-		_, selected, err := selectStoreWithWorkRetrying(workQuery, remaining, primary, run)
+		discovered, selected, err := selectStoreWithWorkRetrying(workQuery, remaining, primary, run)
 		if err != nil {
 			emitFailure(workQuery, err)
 			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -683,7 +683,7 @@ func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, store
 		if isZeroHookStore(selected) {
 			break // no remaining store has ready work
 		}
-		claimOutput, claimStore, err := claimStoreWithFallback(workQuery, remaining, selected, primary, run)
+		claimOutput, claimStore, err := claimStoreWithFallback(workQuery, remaining, selected, primary, discovered, run)
 		if err != nil {
 			emitFailure(workQuery, err)
 			fmt.Fprintf(stderr, "gc hook --claim: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_ready.go
+++ b/cmd/gc/cmd_ready.go
@@ -274,12 +274,14 @@ func cmdReady(opts readyOpts, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc ready: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	legs := readyFederationLegs(
-		loadedCityName(cfg, cityPath),
-		cityStore,
-		rigStores,
-		relocatedGraphLegStore(cityPath, cityStore),
-	)
+	legs, err := readyFederationLegs(cityPath, loadedCityName(cfg, cityPath), cfg, cityStore, rigStores)
+	if err != nil {
+		// A refused city: the plan carries the refusal that names the remedy, and
+		// a work-only answer here is a short array indistinguishable from "no
+		// work" for every work query this reader backs.
+		fmt.Fprintf(stderr, "gc ready: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	items, err := readyBeadsForOpts(legs, opts)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc ready: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_ready_test.go
+++ b/cmd/gc/cmd_ready_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/splittest"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/spf13/pflag"
 )
 
@@ -45,6 +46,55 @@ func mustCreateReadyBead(t *testing.T, store beads.Store, b beads.Bead) beads.Be
 		t.Fatalf("create %q: %v", b.Title, err)
 	}
 	return created
+}
+
+// mustReadyLegs assembles the reader's legs through the production seam, over
+// an explicitly stated binding. The leg list is a Plan(RoutedWork) projection
+// now, so it can fail — but only on a standing storage refusal, which no
+// fixture here stages.
+func mustReadyLegs(t *testing.T, cityName string, cityStore beads.Store, rigStores map[string]beads.Store, binding beads.Store) []readyLeg {
+	t.Helper()
+	legs, err := readyFederationLegsOverBinding(cityName, cityStore, rigStores, binding)
+	if err != nil {
+		t.Fatalf("readyFederationLegsOverBinding: %v", err)
+	}
+	return legs
+}
+
+// TestReadyReaderEscalatesThePlansPartialLegs pins the ONE place this reader
+// overrides the resolver's per-leg policy, and pins that it really is an
+// override.
+//
+// The plan marks a rig leg PartialDegrade — a scope reporting a hole, which the
+// API turns into a Partial 200 naming the rig. A CLI work query has no field for
+// that: its whole output is the array, and a short array is indistinguishable
+// from "no work". So this reader escalates every leg failure to fatal.
+//
+// Asserting the plan's verdict as well as the reader's behavior is what keeps
+// this honest. If the resolver ever made rig legs Fatal, this reader would agree
+// with it by accident and the escalation comment would become a lie nobody
+// notices.
+func TestReadyReaderEscalatesThePlansPartialLegs(t *testing.T) {
+	city := beads.NewMemStore()
+	rig := beads.NewMemStoreFrom(1000, nil, nil)
+	legs := mustReadyLegs(t, "mycity", city, map[string]beads.Store{"alpha": rig}, nil)
+	if len(legs) != 2 {
+		t.Fatalf("got %d legs, want the city and the rig", len(legs))
+	}
+	if legs[1].onError != storeref.PolicyPartialDegrade {
+		t.Fatalf("the rig leg's plan policy is %v, want PartialDegrade — this reader's escalation is only meaningful if there is something to escalate", legs[1].onError)
+	}
+
+	// And the reader fails loud on it anyway.
+	failing := []readyLeg{legs[0], {label: legs[1].label, store: listFailStore{Store: beads.NewMemStore()}, onError: legs[1].onError}}
+	if _, err := readyBeadsForOpts(failing, readyOpts{status: readyStatusInProgress}); err == nil {
+		t.Fatal("a degraded rig leg produced a clean answer; a short array here is indistinguishable from \"no work\"")
+	}
+	// Control: the same call over healthy legs succeeds, so the error above is
+	// the leg failure and not the fixture.
+	if _, err := readyBeadsForOpts(legs, readyOpts{status: readyStatusInProgress}); err != nil {
+		t.Fatalf("healthy legs errored: %v", err)
+	}
 }
 
 func readyWireIDs(rows []readyBead) []string {
@@ -454,7 +504,7 @@ func TestReadyDedupeIsFirstLegWins(t *testing.T) {
 	}
 
 	rows, err := readyBeadsForOpts(
-		readyFederationLegs("mycity", work, nil, graph),
+		mustReadyLegs(t, "mycity", work, nil, graph),
 		readyOpts{},
 	)
 	if err != nil {
@@ -476,7 +526,7 @@ func TestReadyFederationLegOrderMatchesTheAPIContract(t *testing.T) {
 	rigA := splittest.NewWorkStore(t, "ra")
 	graph := splittest.NewClassStore(t, config.BeadClassGraph)
 
-	legs := readyFederationLegs("mycity", city, map[string]beads.Store{
+	legs := mustReadyLegs(t, "mycity", city, map[string]beads.Store{
 		"rig-B":  rigB,
 		"rig-A":  rigA,
 		"mycity": splittest.NewWorkStore(t, "shadow"),
@@ -504,14 +554,14 @@ func TestReadySingleStoreCityFederatesOneLeg(t *testing.T) {
 	graph := splittest.NewClassStore(t, config.BeadClassGraph)
 	step := mustCreateReadyBead(t, graph, beads.Bead{Title: "graph step", Type: "task"})
 
-	legacy, err := readyBeadsForOpts(readyFederationLegs("mycity", city, nil, nil), readyOpts{})
+	legacy, err := readyBeadsForOpts(mustReadyLegs(t, "mycity", city, nil, nil), readyOpts{})
 	if err != nil {
 		t.Fatalf("gc ready: %v", err)
 	}
 	if got := readyWireIDs(legacy); !reflect.DeepEqual(got, []string{work.ID}) {
 		t.Fatalf("single-store ready = %v, want exactly [%s]; a legacy city must not gain a leg", got, work.ID)
 	}
-	split, err := readyBeadsForOpts(readyFederationLegs("mycity", city, nil, graph), readyOpts{})
+	split, err := readyBeadsForOpts(mustReadyLegs(t, "mycity", city, nil, graph), readyOpts{})
 	if err != nil {
 		t.Fatalf("gc ready: %v", err)
 	}
@@ -798,7 +848,7 @@ func TestReadyDefaultOrderIsTheCanonicalReadyOrder(t *testing.T) {
 	seeded = append(seeded, mustCreateReadyBead(t, graph, beads.Bead{Title: "graph urgent", Type: "task", Priority: readyPriority(1)}))
 	seeded = append(seeded, mustCreateReadyBead(t, city, beads.Bead{Title: "city backlog", Type: "task", Priority: readyPriority(3)}))
 
-	rows, err := readyBeadsForOpts(readyFederationLegs("mycity", city, nil, graph), readyOpts{})
+	rows, err := readyBeadsForOpts(mustReadyLegs(t, "mycity", city, nil, graph), readyOpts{})
 	if err != nil {
 		t.Fatalf("gc ready: %v", err)
 	}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -2256,7 +2256,7 @@ func reconcileCities(
 		// replacement that LOSES this lock repoint the live city's release
 		// sweeps at a handle it is about to close. Same reason the socket is
 		// started after the lock rather than before it.
-		registerResidencyRoutes(path, cityRuntime.storageRoutes)
+		registerResidencyRoutes(path, cityRuntime.storageRoutes, cityRuntime.cityBeadStore)
 
 		// Start controller socket AFTER the alreadyRunning check so we
 		// never destroy a live city's socket or leak a listener.

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1384,7 +1384,11 @@ func runController(
 	// opened binding is the residency answer the assigned-work spine reads.
 	// Registered here rather than inside newCityRuntime because the supervisor
 	// path constructs a runtime before it knows whether it holds the lock.
-	registerResidencyRoutes(cityPath, cr.storageRoutes)
+	// The work-store accessor is registered as a FUNC, not a value: the
+	// controllerState that owns the cached city store is installed a few
+	// statements below, so capturing the store here would capture a nil and the
+	// census would silently fall back to its leading (binding) store.
+	registerResidencyRoutes(cityPath, cr.storageRoutes, cr.cityBeadStore)
 
 	// Install controller-managed bead stores even when the HTTP API is
 	// disabled. Standalone runtime still needs cached city/rig stores for

--- a/cmd/gc/hook_claim_self_resume_residency_test.go
+++ b/cmd/gc/hook_claim_self_resume_residency_test.go
@@ -215,7 +215,7 @@ func TestGcReadyInProgressEnrichesBlockedBy(t *testing.T) {
 		t.Fatalf("adding the blocking dep: %v", err)
 	}
 
-	rows := readyRowsForAssignee(t, readyFederationLegs("mycity", work, nil, graph), "worker-1")
+	rows := readyRowsForAssignee(t, mustReadyLegs(t, "mycity", work, nil, graph), "worker-1")
 	if len(rows) != 1 || rows[0].ID != step.ID {
 		t.Fatalf("rows = %+v, want the one graph-resident in_progress step", rows)
 	}
@@ -249,7 +249,7 @@ func TestGcReadyInProgressServesUnblockedResumeRow(t *testing.T) {
 		t.Fatalf("closing the blocker: %v", err)
 	}
 
-	rows := readyRowsForAssignee(t, readyFederationLegs("mycity", work, nil, graph), "worker-1")
+	rows := readyRowsForAssignee(t, mustReadyLegs(t, "mycity", work, nil, graph), "worker-1")
 	if len(rows) != 1 {
 		t.Fatalf("rows = %+v, want the one in_progress step", rows)
 	}
@@ -278,7 +278,7 @@ func TestGcReadyNonInProgressArmsSkipEnrichment(t *testing.T) {
 		t.Fatalf("adding the blocking dep: %v", err)
 	}
 
-	legs := readyFederationLegs("mycity", work, nil, graph)
+	legs := mustReadyLegs(t, "mycity", work, nil, graph)
 	rows, err := readyBeadsForOpts(legs, readyOpts{status: "open"})
 	if err != nil {
 		t.Fatalf("readyBeadsForOpts: %v", err)

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -14,10 +14,12 @@ import (
 type hookStore struct {
 	dir string
 	env []string
-	// command overrides the shared work query for this store. Empty on every
-	// store of a single-store city, where one command is run against each store
-	// in turn; set only by scopeFederatedHookStores, which pins the city-wide
-	// reader to the primary and leaves the extras on the single-store command.
+	// command overrides the shared work query for this store, and is empty on
+	// every store production builds: one command is run against each leg in
+	// turn. It was set by scopeFederatedHookStores when that pinned the
+	// city-wide reader to the primary and left the extras on the single-store
+	// command; the extras are dropped now, so nothing sets it. Retired with the
+	// rest of that mechanism in ga-gu4xg.
 	command string
 }
 
@@ -30,37 +32,48 @@ func hookStoreCommand(st hookStore, command string) string {
 	return command
 }
 
-// scopeFederatedHookStores pins a city-wide work query to ONE store.
+// scopeFederatedHookStores collapses a city-wide work query onto ONE leg.
 //
-// The federated reader (`gc ready`) already covers the city store, every bound
-// rig store and the relocated graph leg in a single call, so running it once per
-// hookStore re-asks the same question R+1 times and re-opens every leg each
-// time — the store loop exists because `bd ready` reads exactly one store, and
-// that premise no longer holds for the tiers that were swapped.
+// # Leg relevance, taken from the plan rather than from the store list
 //
-// The extras are not dropped: the crash-recovery (`bd list --status
-// in_progress`) and ephemeral (`bd query`) tiers are still per-store reads the
-// city-wide reader does not answer, so collapsing the loop outright would
-// silently strip rig coverage from crash recovery. Instead every store after the
-// primary keeps the SINGLE-STORE command it ran before the swap, which is
-// exactly its previous cost and previous coverage; only the city-wide read is
-// deduplicated.
+// The hook's legs are bd WORKSPACES, and it fans out across them because
+// `bd ready` reads exactly one store. On a federated city that premise is gone:
+// the primary leg runs `gc ready`, whose own legs are Plan(RoutedWork) — the
+// city work store, the rigs ascending, the relocated binding last — so its
+// answer is a SUPERSET of every extra leg's, tier by tier. An extra can
+// therefore never contribute a candidate the primary did not already return; it
+// can only re-open every store and pay the federated legs again.
+//
+// So the relevant leg set for a federated claim read is exactly one leg, and
+// that is what this returns. On mc's topology it takes a hook tick from six
+// full work-query runs (one federated, five single-store) to one, and the
+// dropped five were each a strictly narrower view of the same city.
+//
+// # Why the extras are no longer coverage
+//
+// They used to be: the crash-recovery tier ran `bd list --status in_progress`
+// and the wisp probes ran `bd query`, neither of which the city-wide reader
+// answered, so collapsing the loop would have stripped rig coverage from crash
+// recovery. Both are closed now. The crash-recovery tier swapped to `gc ready
+// --status in_progress`, and every federated leg is read at
+// beads.FederatedReadTier, which spans the wisp tier — so the ephemeral rows a
+// per-store `bd query` used to find are in the federated answer.
+// TestTheFederatedReaderAnswersEveryTierTheExtrasUsedTo is the guard: if either
+// tier regresses to a single-store read, the extras have to come back.
+//
+// # The signal
 //
 // federatedCommand and singleStoreCommand are the two forms of the same agent's
-// query. They are equal for a custom (verbatim) work_query and on a city that
-// relocates nothing, and the call is then a no-op returning stores unchanged —
-// which is what keeps a single-store city byte-identical.
+// query. They are EQUAL for a custom (verbatim) work_query and on a city that
+// relocates nothing, and the call is then a no-op returning stores unchanged.
+// That is not an optimization detail: a custom work_query reads one store
+// whatever the topology, so the fan-out is its only coverage and must survive.
 func scopeFederatedHookStores(stores []hookStore, federatedCommand, singleStoreCommand string) []hookStore {
 	singleStoreCommand = strings.TrimSpace(singleStoreCommand)
 	if len(stores) < 2 || singleStoreCommand == "" || singleStoreCommand == strings.TrimSpace(federatedCommand) {
 		return stores
 	}
-	scoped := make([]hookStore, len(stores))
-	copy(scoped, stores)
-	for i := 1; i < len(scoped); i++ {
-		scoped[i].command = singleStoreCommand
-	}
-	return scoped
+	return stores[:1:1]
 }
 
 // hookStoreRunner runs a work query against one federated store's dir and env.
@@ -366,10 +379,19 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 }
 
 // hookFederationPinnedToPrimary reports whether this store set is the shape
-// scopeFederatedHookStores produces: the primary runs the city-wide federated
-// command and every extra carries its own single-store override. That is exactly
-// when a primary failure costs the federation rather than one leg, so it is read
-// off the store set rather than passed down as a flag.
+// scopeFederatedHookStores USED to produce: the primary runs the city-wide
+// federated command and every extra carries its own single-store override. That
+// is exactly when a primary failure costs the federation rather than one leg, so
+// it is read off the store set rather than passed down as a flag.
+//
+// NO PRODUCTION CALLER PRODUCES THAT SHAPE ANY MORE. scopeFederatedHookStores
+// now drops the extras outright, so a federated fan-out is one leg and this
+// answers false — the single leg's failure is surfaced by bestStoreWithWork's
+// own ownStoreErr path instead, with the same outcome. The mechanism is left
+// standing rather than deleted here because removing it also removes
+// bestStoreWithWork's federated-primary-failure semantics and their tests, which
+// is a provable deletion of its own and does not belong in the same commit as a
+// census leg-set change (ga-gu4xg).
 func hookFederationPinnedToPrimary(stores []hookStore, primary hookStore) bool {
 	if len(stores) < 2 {
 		return false
@@ -492,7 +514,22 @@ func hookRankCandidate(row map[string]any) hookCandidateRank {
 // is the primary (own) store; a federated store erroring at claim time is
 // best-effort and falls through to re-selection, mirroring bestStoreWithWork's
 // emit-on-timeout contract so a flaky rig store can't wedge the claim.
-func claimStoreWithFallback(command string, stores []hookStore, selected, primary hookStore, run hookStoreRunner) (string, hookStore, error) {
+//
+// # One leg means nothing to fall back TO, so there is nothing to re-validate
+//
+// The whole reason to re-read is the LATER store: draining as "no work" when a
+// federated peer still has ready routed work is the strand this exists to
+// prevent. A single-leg fan-out — every federated city after S3, where the
+// primary's reader answers for the whole plan — has no later store, so the
+// second read can only pay another full city-wide query for a row the claim
+// itself re-checks anyway (`bd update --claim` skips rows it cannot take). On
+// mc's topology that read is the more expensive half of the claim.
+//
+// discovered is the output selection already read from this store, moments ago.
+func claimStoreWithFallback(command string, stores []hookStore, selected, primary hookStore, discovered string, run hookStoreRunner) (string, hookStore, error) {
+	if len(stores) == 1 {
+		return discovered, selected, nil
+	}
 	selectedOut, err := run(hookStoreCommand(selected, command), selected.dir, selected.env)
 	if err != nil {
 		if sameHookStore(selected, primary) {
@@ -505,6 +542,22 @@ func claimStoreWithFallback(command string, stores []hookStore, selected, primar
 		return selectedOut, selected, nil
 	}
 	return bestStoreWithWork(command, stores, primary, run)
+}
+
+// hookClaimReadsPerTick counts the work-query runs one claim attempt performs
+// over a given leg set: one to select, and one to re-validate unless there is
+// nothing to fall back to. It exists so the cost this slice removes is asserted
+// rather than described (TestFederatedClaimTickIssuesOneWorkQueryRun).
+//
+// It is a CEILING, not a measurement. A tier-0 hit in the primary store
+// short-circuits bestStoreWithWork before the later legs run, and each RUN is
+// itself a tier ladder that exits on its first hit — so a real tick reads this
+// many times or fewer, never more. Do not quote it as an observed number.
+func hookClaimReadsPerTick(stores []hookStore) int {
+	if len(stores) == 1 {
+		return 1
+	}
+	return len(stores) + 1
 }
 
 // isZeroHookStore reports whether s is the zero hookStore that bestStoreWithWork

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -374,7 +374,7 @@ func TestClaimStoreWithFallbackFallsBackWhenSelectedStoreRerunsEmpty(t *testing.
 		}
 	}
 
-	out, gotStore, err := claimStoreWithFallback("q", stores, selected, stores[0], run)
+	out, gotStore, err := claimStoreWithFallback("q", stores, selected, stores[0], "", run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestClaimStoreWithFallbackUsesSelectedStoreWhenStillReady(t *testing.T) {
 		return `[{"id":"va-1"}]`, nil
 	}
 
-	out, gotStore, err := claimStoreWithFallback("q", stores, selected, stores[0], run)
+	out, gotStore, err := claimStoreWithFallback("q", stores, selected, stores[0], "", run)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/cmd/gc/hook_store_federated_scope_test.go
+++ b/cmd/gc/hook_store_federated_scope_test.go
@@ -24,12 +24,15 @@ func fiveRigHookStores() []hookStore {
 	return stores
 }
 
-// TestFederatedHookStoresIssueTheCityWideReaderOnce is the cost measurement.
+// TestFederatedHookStoresIssueTheCityWideReaderOnce is the cost measurement, and
+// after S3 it is a leg-count measurement too.
+//
 // `gc ready` federates the city store, every bound rig store and the relocated
-// graph leg in ONE call, so asking it once per hookStore multiplies the leg
-// fan-out by the store count for an answer that cannot differ between
-// iterations. The whole query must carry the city-wide reader exactly once
-// across the store list.
+// binding in ONE call — the legs are Plan(RoutedWork)'s — so its answer is a
+// SUPERSET of every extra leg's, for every tier of the generated query. Running
+// the extras therefore cannot change the selection; it only re-opens every store
+// and pays the federated legs again. The fan-out collapses to the one leg that
+// answers for the plan.
 func TestFederatedHookStoresIssueTheCityWideReaderOnce(t *testing.T) {
 	a := &config.Agent{Name: "worker"}
 	topo := federatedHookTopology()
@@ -43,30 +46,120 @@ func TestFederatedHookStoresIssueTheCityWideReaderOnce(t *testing.T) {
 		t.Fatalf("the federated work query names no `gc ready` reader: %q", federated)
 	}
 
-	scoped := scopeFederatedHookStores(fiveRigHookStores(), federated, singleStore)
+	stores := fiveRigHookStores()
+	scoped := scopeFederatedHookStores(stores, federated, singleStore)
+	if len(scoped) != 1 {
+		t.Fatalf("a %d-store federated hook tick still fans out to %d legs, want 1: the primary's reader already answers for every leg of the plan, so each extra is a whole extra work-query run for a strictly smaller view",
+			len(stores), len(scoped))
+	}
+	if !sameHookStore(scoped[0], stores[0]) {
+		t.Fatalf("the surviving leg is %q, want the agent's own (primary) store %q", scoped[0].dir, stores[0].dir)
+	}
 	total := 0
 	for _, st := range scoped {
 		total += strings.Count(hookStoreCommand(st, federated), "gc ready")
 	}
 	if total != perQuery {
-		t.Fatalf("a %d-store hook tick issues %d city-wide `gc ready` reads, want %d (one query's worth): the federated reader already covers every leg, so the extra %d re-open every store for the same answer",
-			len(scoped), total, perQuery, total-perQuery)
-	}
-
-	// The extras are scoped, not dropped: the crash-recovery and ephemeral tiers
-	// are still per-store `bd` reads the city-wide reader does not answer, so a
-	// blanket collapse would silently strip rig coverage from crash recovery.
-	for _, st := range scoped[1:] {
-		cmd := hookStoreCommand(st, federated)
-		if !strings.Contains(cmd, `bd list --status in_progress`) {
-			t.Fatalf("federated extra store %q lost the per-store crash-recovery tier: %q", st.dir, cmd)
-		}
-		if !strings.Contains(cmd, `ephemeral=true AND status=in_progress`) {
-			t.Fatalf("federated extra store %q lost the per-store ephemeral tier: %q", st.dir, cmd)
-		}
+		t.Fatalf("a %d-store hook tick issues %d city-wide `gc ready` reads, want %d (one query's worth)", len(stores), total, perQuery)
 	}
 	if got := hookStoreCommand(scoped[0], federated); got != federated {
-		t.Fatalf("the primary store no longer runs the federated query; the city-wide read has to happen somewhere")
+		t.Fatalf("the surviving store no longer runs the federated query; the city-wide read has to happen somewhere")
+	}
+}
+
+// The other half of the collapse, stated as the property it rests on: every tier
+// of the SINGLE-STORE command an extra leg used to run is answered by the
+// primary's federated command.
+//
+// The two tiers this was not always true of are named explicitly, because they
+// are the reason the extras existed. Both are closed now: the crash-recovery
+// tier swapped from `bd list --status in_progress` to `gc ready --status
+// in_progress` (federated), and the ephemeral `bd query` probes are covered
+// because every federated leg is read at beads.FederatedReadTier, which spans
+// the wisp tier. If either regresses to a single-store read, the extras have to
+// come back and this test says so.
+func TestTheFederatedReaderAnswersEveryTierTheExtrasUsedTo(t *testing.T) {
+	a := &config.Agent{Name: "worker"}
+	topo := federatedHookTopology()
+	federated := a.EffectiveWorkQueryFor(topo)
+
+	if strings.Contains(federated, bdListInProgressForTest) {
+		t.Fatalf("the federated work query still runs a SINGLE-STORE crash-recovery read (%q); an extra leg is the only thing that covered the other stores for it, and the fan-out no longer runs one: %q",
+			bdListInProgressForTest, federated)
+	}
+	if !strings.Contains(federated, "gc ready --status in_progress") {
+		t.Fatalf("the federated work query has no federated crash-recovery tier: %q", federated)
+	}
+	// The control: the SINGLE-STORE form does carry the reads this asserts are
+	// gone, so the assertions above are about the federated form and not about a
+	// query that lost its tiers entirely.
+	singleStoreTopo := topo
+	singleStoreTopo.FederatedReady = false
+	if !strings.Contains(a.EffectiveWorkQueryFor(singleStoreTopo), bdListInProgressForTest) {
+		t.Fatal("the single-store work query has no crash-recovery tier either; this test is comparing two empty things")
+	}
+}
+
+// bdListInProgressForTest is the single-store crash-recovery reader, spelled
+// here so the assertion above reads as the string an operator would grep for.
+const bdListInProgressForTest = "bd list --status in_progress"
+
+// TestFederatedClaimTickIssuesOneWorkQueryRun is the latency assertion for
+// ga-4qdfn, stated in the unit the incident is measured in: how many work-query
+// RUNS one `gc hook --claim` performs.
+//
+// On mc a run of the federated work query is several `gc ready` invocations,
+// each paying the whole plan's legs (a remote-postgres city leg, five rig legs,
+// the binding). Before S3 a six-leg city cost six runs to select plus one to
+// re-validate. The plan says the primary's reader answers for every one of those
+// legs, so the relevant leg count is one — and with one leg there is no later
+// store to fall back to, so the re-validation has nothing to do either.
+func TestFederatedClaimTickIssuesOneWorkQueryRun(t *testing.T) {
+	a := &config.Agent{Name: "worker"}
+	topo := federatedHookTopology()
+	singleStoreTopo := topo
+	singleStoreTopo.FederatedReady = false
+	federated := a.EffectiveWorkQueryFor(topo)
+
+	before := fiveRigHookStores()
+	after := scopeFederatedHookStores(before, federated, a.EffectiveWorkQueryFor(singleStoreTopo))
+
+	if got, want := hookClaimReadsPerTick(after), 1; got != want {
+		t.Fatalf("a federated claim tick runs the work query %d times, want %d", got, want)
+	}
+	if got := hookClaimReadsPerTick(before); got <= hookClaimReadsPerTick(after) {
+		t.Fatalf("the un-collapsed fan-out costs %d runs and the collapsed one %d; the measurement is not measuring anything", got, hookClaimReadsPerTick(after))
+	}
+
+	// And the claim really does act on the discovery output rather than paying
+	// for a second read of it.
+	one := after
+	calls := 0
+	run := func(string, string, []string) (string, error) {
+		calls++
+		return `[{"id":"gcg-1","status":"open"}]`, nil
+	}
+	out, store, err := claimStoreWithFallback(federated, one, one[0], one[0], `[{"id":"gcg-1","status":"open"}]`, run)
+	if err != nil {
+		t.Fatalf("claimStoreWithFallback: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("claim-time re-validation ran %d extra work queries on a single-leg city; there is no later store it could fall back to", calls)
+	}
+	if out != `[{"id":"gcg-1","status":"open"}]` || !sameHookStore(store, one[0]) {
+		t.Fatalf("claimStoreWithFallback = (%q, %q), want the discovery output on the one leg", out, store.dir)
+	}
+
+	// The control: with a real second leg the re-validation still happens, so
+	// the skip above is about having nowhere to fall back to and not about
+	// having removed the freshness read.
+	twoLegs := []hookStore{{dir: "city"}, {dir: "riga"}}
+	calls = 0
+	if _, _, err := claimStoreWithFallback("q", twoLegs, twoLegs[0], twoLegs[0], "stale", run); err != nil {
+		t.Fatalf("claimStoreWithFallback (two legs): %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("a two-leg claim performed %d re-validation reads, want 1", calls)
 	}
 }
 
@@ -150,7 +243,7 @@ func TestClaimStoreWithFallbackRunsTheSelectedStoresOwnCommand(t *testing.T) {
 		}
 		return `[]`, nil
 	}
-	if _, store, err := claimStoreWithFallback("federated query", stores, stores[1], stores[0], run); err != nil || store.dir != "riga" {
+	if _, store, err := claimStoreWithFallback("federated query", stores, stores[1], stores[0], "", run); err != nil || store.dir != "riga" {
 		t.Fatalf("claimStoreWithFallback = (%q, %v), want riga", store.dir, err)
 	}
 	if revalidated != "single-store query" {

--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // Session-bead metadata keys for the stalled-claim backstop. The state machine
@@ -474,6 +475,10 @@ func normalizeIdleClaimStoreRef(storeRef string) string {
 	storeRef = strings.TrimSpace(storeRef)
 	switch {
 	case storeRef == "", storeRef == "city", strings.HasPrefix(storeRef, "city:"):
+		return "city"
+	// A class binding is city scope: it is the same store the leading arm used
+	// to record under the city ref, now named as a leg of its own.
+	case storeref.IsClassRef(storeRef):
 		return "city"
 	case strings.HasPrefix(storeRef, "rig:"):
 		return "rig:" + strings.TrimSpace(strings.TrimPrefix(storeRef, "rig:"))

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1163,7 +1163,7 @@ func TestCollectAndReleaseOrphanPoolStepBead_Issue2793(t *testing.T) {
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores("", cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1214,7 +1214,7 @@ func TestCollectAndReleaseOrphanWorkflowRunTargetBead(t *testing.T) {
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores("", cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1264,7 +1264,7 @@ func TestCollectAndReleaseNonWorkflowRunTargetBeadStaysAssigned(t *testing.T) {
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
 
-	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	found, foundStores, foundStoreRefs, _, partial := collectAssignedWorkBeadsWithStores("", cfg, store, nil, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
 	}
@@ -1303,6 +1303,7 @@ func TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery
 	}
 
 	found, stores, _, _, partial := collectAssignedWorkBeadsWithStores(
+		"",
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		store,
 		nil,

--- a/cmd/gc/ready_federation.go
+++ b/cmd/gc/ready_federation.go
@@ -76,31 +76,49 @@ package main
 //
 // # Single-store cities take none of this
 //
-// relocatedGraphLegStore gates on STORE IDENTITY, the same rule the API's
-// relocatedGraphStore and cmd/gc's resolveClassStore use. A city that relocates
-// nothing gets no graph leg at all, so its answer is exactly the one leg it
-// always had.
+// The leg set is Plan(RoutedWork) over the city's topology, and a city that
+// relocates nothing has no binding in that topology — so it gets no graph leg at
+// all and its answer is exactly the one leg it always had. The gate is STORE
+// IDENTITY, the same rule the API's relocatedGraphStore and cmd/gc's
+// resolveClassStore use: a binding that resolved back to the work store is
+// deduped by the plan rather than federated twice.
 
 import (
 	"errors"
 	"fmt"
-	"sort"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
-// readyLeg is one federated source: the store plus the name a failure reports
-// it by. The label is what turns "the federation failed" into "the graph store
-// failed", which is the difference between a diagnosable outage and a silent
-// short answer.
+// readyLeg is one federated source: the store, the name a failure reports it by,
+// and the plan's verdict on what that failure MEANS. The label is what turns
+// "the federation failed" into "the graph store failed", which is the difference
+// between a diagnosable outage and a silent short answer.
+//
+// onError is carried rather than consulted, and that is the documented
+// divergence this file's header names: the plan marks a rig leg PartialDegrade,
+// and this reader escalates it to fatal because a CLI array has nowhere to say
+// "this is short". Carrying it keeps the escalation VISIBLE at the point it
+// happens — and lets TestReadyReaderEscalatesThePlansPartialLegs assert that
+// this reader is overriding a policy that really is PartialDegrade, rather than
+// quietly agreeing with a plan that never said so.
 type readyLeg struct {
-	label string
-	store beads.Store
+	label   string
+	store   beads.Store
+	onError storeref.ErrPolicy
 }
 
-// readyFederationLegs assembles the ordered leg list: the city store, the rig
-// stores by name ascending, then the relocated graph store.
+// readyFederationLegs assembles the ordered leg list from Plan(RoutedWork): the
+// city store, the rig stores by name ascending, then the relocated binding.
+//
+// The order is not restated here — it IS the plan's, which is the same plan the
+// controller's demand census resolves over one topology. That is what makes
+// "the reader the hook claims through and the reader the controller counts
+// demand with agree about which stores exist" true by construction rather than
+// by two lists kept in step (the leg-set half of reader agreement; the row half
+// is demand_serve_agreement_test.go).
 //
 // A rig whose name equals the city name is skipped, mirroring the API exactly:
 // State.BeadStores() keys the city store under CityName(), so the API's rig loop
@@ -108,32 +126,90 @@ type readyLeg struct {
 // keeps the two leg sequences identical by construction rather than by
 // coincidence.
 //
-// A nil store is dropped rather than federated: a nil entry would panic on first
-// read, and by the time the legs are assembled a store that could not be opened
-// has already failed the whole query at readyRigLegStores. Dropping here is
-// therefore a guard against a nil, not a silent degrade.
-func readyFederationLegs(cityName string, cityStore beads.Store, rigStores map[string]beads.Store, graph beads.Store) []readyLeg {
-	legs := make([]readyLeg, 0, len(rigStores)+2)
-	if cityStore != nil {
-		legs = append(legs, readyLeg{label: "city", store: cityStore})
+// A nil store is dropped by the plan rather than federated: a nil entry would
+// panic on first read, and by the time the legs are assembled a store that could
+// not be opened has already failed the whole query at readyRigLegStores.
+func readyFederationLegs(cityPath, cityName string, cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store) ([]readyLeg, error) {
+	return readyLegsForTopology(cliResidencyTopology(cityPath, cfg, cityStore, rigLegsExcludingCityName(cityName, rigStores)))
+}
+
+// readyFederationLegsOverBinding assembles the legs for an EXPLICITLY supplied
+// binding rather than one resolved from the city's routes.
+//
+// It is the seam relocatedGraphLegFrom was — "a caller that resolved the binding
+// from routes it already holds applies the SAME rule instead of restating it" —
+// carried forward now that the leg list comes from a plan. The identity gate is
+// unchanged: a binding that resolved back to the city's own work store is the
+// store already federated as the city leg, so there is no second store.
+func readyFederationLegsOverBinding(cityName string, cityStore beads.Store, rigStores map[string]beads.Store, binding beads.Store) ([]readyLeg, error) {
+	var bindings []storeref.ClassBinding
+	if leg := relocatedGraphLegFrom(binding, binding != nil, cityStore); leg != nil {
+		classes := infrastructureClasses()
+		bindings = []storeref.ClassBinding{{
+			Classes:  classes,
+			Prefixes: reservedPrefixesFor(classes),
+			Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: leg},
+		}}
 	}
-	rigNames := make([]string, 0, len(rigStores))
-	for name := range rigStores {
+	return readyLegsForTopology(assembleResidencyTopology(nil, cityStore, rigLegsExcludingCityName(cityName, rigStores), bindings, nil))
+}
+
+// readyLegsForTopology is the assembly itself: Plan(RoutedWork), enumerated
+// through the resolver and labeled.
+//
+// The leg set is resolved ONCE and read by three different arms (ready, list,
+// list-with-owner), which is why this enumerates rather than executing: the
+// policy travels with each leg to the arm that will read it. A refused city
+// produces no legs at all — Plan refuses first.
+func readyLegsForTopology(topo storeref.Topology) ([]readyLeg, error) {
+	plan, err := storeref.Plan(storeref.RoutedWork{}, topo)
+	if err != nil {
+		return nil, err
+	}
+	var legs []readyLeg
+	storeref.EachLeg(plan, func(leg storeref.Leg, _ storeref.Role, onError storeref.ErrPolicy) {
+		legs = append(legs, readyLeg{label: readyLegLabel(leg.Ref), store: leg.Store, onError: onError})
+	})
+	return legs, nil
+}
+
+// rigLegsExcludingCityName drops a rig keyed under the city's own name; see
+// readyFederationLegs.
+//
+// residency:allow — a constructor INPUT, not a residency answer. It drops a rig
+// keyed under the city's own name so the CLI and the API build the same
+// topology; it consults no binding, no namespace and no leg order, and its
+// result goes nowhere but a topology constructor.
+func rigLegsExcludingCityName(cityName string, rigStores map[string]beads.Store) map[string]beads.Store {
+	if _, collides := rigStores[cityName]; !collides {
+		return rigStores
+	}
+	out := make(map[string]beads.Store, len(rigStores)-1)
+	for name, store := range rigStores {
 		if name == cityName {
 			continue
 		}
-		rigNames = append(rigNames, name)
+		out[name] = store
 	}
-	sort.Strings(rigNames)
-	for _, name := range rigNames {
-		if store := rigStores[name]; store != nil {
-			legs = append(legs, readyLeg{label: "rig " + name, store: store})
-		}
+	return out
+}
+
+// readyLegLabel is the name a failing leg reports itself by. The three spellings
+// are the ones this command's diagnostics have always used, kept because they
+// are what an operator greps for and what the API's partial_errors say.
+func readyLegLabel(ref storeref.StoreRef) string {
+	switch {
+	case ref == storeref.WorkRef:
+		return "city"
+	case storeref.IsClassRef(string(ref)):
+		// Every binding this build serves carries the graph class (storage boot
+		// admits the whole split or nothing), and "graph" is the name the
+		// federation contract and the API's graphPlaneUnavailable already use.
+		return "graph"
+	default:
+		rig, _ := storeref.ScopeRigContext(string(ref))
+		return "rig " + rig
 	}
-	if graph != nil {
-		legs = append(legs, readyLeg{label: "graph", store: graph})
-	}
-	return legs
 }
 
 // readyRigLegStores opens the rig legs, failing the whole query when any BOUND
@@ -162,23 +238,21 @@ func readyRigLegStores(cfg *config.City, cityPath string) (map[string]beads.Stor
 	return nil, errors.Join(errs...)
 }
 
-// relocatedGraphLegStore returns the graph-class store to federate as the final
-// leg, or nil when the city has not relocated the class.
+// relocatedGraphLegFrom is the identity gate over an already-resolved binding:
+// a binding that resolved back to the city's own work store is the same store
+// already federated as the city leg, so there is no second store to add.
 //
-// The gate is store IDENTITY, not a marker file and not a migration flag: the
-// one-shot storage funnel reports whether it relocates the graph class at all,
-// and a binding that resolved back to the city's own work store is the same
-// store already federated as the city leg. Both answers mean "there is no second
-// store", which is what keeps a legacy city's bytes untouched.
-func relocatedGraphLegStore(cityPath string, cityStore beads.Store) beads.Store {
-	binding, relocated := graphClassBinding(cliStorageRoutes(cityPath))
-	return relocatedGraphLegFrom(binding, relocated, cityStore)
-}
-
-// relocatedGraphLegFrom is the identity gate itself, over an already-resolved
-// binding. It is separate from relocatedGraphLegStore so a caller that resolved
-// the binding from routes it already holds — the conformance fixture, and any
-// future in-process caller — applies the SAME rule instead of restating it.
+// The `==` is safe for the same reason residencyBindingsFromRoutes's map key is:
+// both operands are stores a constructor opened, and every one of those is
+// pointer-typed. An interface == on a value-typed store with an uncomparable
+// dynamic type panics — see storeref.storeSet, which is where that stopped being
+// hypothetical.
+//
+// Production no longer calls it — readyFederationLegs resolves the binding from
+// the city's routes and the plan's own dedupe applies the gate — but the
+// EXPLICIT-binding seam (readyFederationLegsOverBinding) still needs it, so a
+// caller that resolved the binding itself applies the same rule rather than
+// restating it.
 func relocatedGraphLegFrom(binding beads.Store, relocated bool, cityStore beads.Store) beads.Store {
 	if !relocated || binding == nil || binding == cityStore {
 		return nil
@@ -244,8 +318,10 @@ func federateListBeadsWithOwner(legs []readyLeg, q beads.ListQuery) ([]beads.Bea
 // deduped by id with the FIRST leg to return an id winning.
 //
 // Any leg error — including a partial read, which beads reports as an error
-// carrying rows — aborts the whole federation. See the file header: a CLI array
-// has nowhere to say "this is short".
+// carrying rows — aborts the whole federation, ESCALATING the plan's
+// PartialDegrade verdict on the rig legs. See the file header: a CLI array has
+// nowhere to say "this is short", so a degraded leg here would be served as a
+// short array indistinguishable from "no work".
 func federateBeadLegs(legs []readyLeg, read func(beads.Store) ([]beads.Bead, error)) ([]beads.Bead, error) {
 	var merged []beads.Bead
 	seen := make(map[string]bool)

--- a/cmd/gc/reconcile_ready_fanout_test.go
+++ b/cmd/gc/reconcile_ready_fanout_test.go
@@ -250,12 +250,12 @@ func TestCollectAssignedWorkBeadsCachedMatchesUncached(t *testing.T) {
 
 	uncachedStore := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
 	uncachedSnap := seed(uncachedStore)
-	wantBeads, _, _, wantReady, wantPartial := collectAssignedWorkBeadsWithStores(&config.City{}, uncachedStore, nil, nil, uncachedSnap)
+	wantBeads, _, _, wantReady, wantPartial := collectAssignedWorkBeadsWithStores("", &config.City{}, uncachedStore, nil, nil, uncachedSnap)
 
 	cachedStore := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
 	cachedSnap := seed(cachedStore)
 	cache := newReadyDemandCache()
-	gotBeads, _, _, gotReady, gotPartial := collectAssignedWorkBeadsWithStores(&config.City{}, cachedStore, nil, nil, cachedSnap, cache)
+	gotBeads, _, _, gotReady, gotPartial := collectAssignedWorkBeadsWithStores("", &config.City{}, cachedStore, nil, nil, cachedSnap, cache)
 
 	if wantPartial != gotPartial {
 		t.Fatalf("partial mismatch: uncached=%v cached=%v", wantPartial, gotPartial)

--- a/cmd/gc/residency_leg_agreement_test.go
+++ b/cmd/gc/residency_leg_agreement_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// The LEG-SET half of reader agreement.
+//
+// demand_serve_agreement_test.go pins the ROW half: one eligibility semantics in
+// two representations, asserted row by row. That corpus is blind to the question
+// this file asks, because a row can only be counted or served by a reader that
+// READS THE STORE IT LIVES IN. Every divergence in the D1–D9 family was
+// leg-shaped, not row-shaped: the demand read's city leg was the binding while
+// the claim read's was the work store, and the HQ work store was in neither (D6).
+//
+// After S3 both sides resolve their legs from one topology through the resolver
+// — the controller census through Plan(Census), the reader the hook claims
+// through (`gc ready`) through Plan(RoutedWork) — so the sets agree by
+// construction. This asserts that construction, and fails DIFFERENTLY from the
+// row corpus: a lost leg here is a set mismatch and a seeded bead no reader
+// serves, while a mis-ordered plan is a golden diff in
+// internal/storeref's corpus and nothing here.
+
+// legAgreementEnv is one city's opened stores, in the shape production hands
+// them to the two readers.
+type legAgreementEnv struct {
+	cityPath string
+	cityName string
+	cfg      *config.City
+	work     beads.Store
+	binding  beads.Store
+	rigs     map[string]beads.Store
+}
+
+func newLegAgreementEnv(t *testing.T, split bool, rigNames ...string) legAgreementEnv {
+	t.Helper()
+	e := legAgreementEnv{
+		cityPath: t.TempDir(),
+		cityName: "test-city",
+		cfg:      &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		work:     beads.NewMemStoreFrom(1, nil, nil),
+		rigs:     map[string]beads.Store{},
+	}
+	for i, name := range rigNames {
+		e.cfg.Rigs = append(e.cfg.Rigs, config.Rig{Name: name, Path: t.TempDir()})
+		// Distinct id sequences per store: two MemStores both minting "gc-1"
+		// would look like one co-resident bead to a first-leg-wins fold.
+		e.rigs[name] = beads.NewMemStoreFrom(1000*(i+1), nil, nil)
+	}
+	if split {
+		e.binding = beads.NewMemStoreFrom(500000, nil, nil)
+		routes := splitRoutes(e.binding)
+		registerResidencyRoutes(e.cityPath, routes, func() beads.Store { return e.work })
+		t.Cleanup(func() { unregisterResidencyRoutes(e.cityPath, routes) })
+	}
+	return e
+}
+
+// leading is the store production hands the census arms: the sessions-class
+// store, which on a converged split IS the binding.
+func (e legAgreementEnv) leading() beads.Store {
+	if e.binding != nil {
+		return e.binding
+	}
+	return e.work
+}
+
+// allLegs is every store this city can hold routed work in, which is what both
+// readers must cover between them.
+func (e legAgreementEnv) allLegs() []beads.Store {
+	legs := []beads.Store{e.work}
+	for _, rig := range e.cfg.Rigs {
+		legs = append(legs, e.rigs[rig.Name])
+	}
+	if e.binding != nil {
+		legs = append(legs, e.binding)
+	}
+	return legs
+}
+
+func (e legAgreementEnv) demandLegs(t *testing.T) []beads.Store {
+	t.Helper()
+	candidates, err := censusStoreCandidates(e.cityPath, e.cfg, e.leading(), e.rigs, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	out := make([]beads.Store, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.store)
+	}
+	return out
+}
+
+func (e legAgreementEnv) claimLegs(t *testing.T) []beads.Store {
+	t.Helper()
+	legs, err := readyFederationLegsOverBinding(e.cityName, e.work, e.rigs, e.binding)
+	if err != nil {
+		t.Fatalf("readyFederationLegsOverBinding: %v", err)
+	}
+	out := make([]beads.Store, 0, len(legs))
+	for _, l := range legs {
+		out = append(out, l.store)
+	}
+	return out
+}
+
+func sameStoreSequence(a, b []beads.Store) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDemandAndClaimReadTheSameLegsInTheSameOrder is the property. It runs over
+// the topologies the resolver's own corpus names: single-store, whole split,
+// whole split with rigs.
+func TestDemandAndClaimReadTheSameLegsInTheSameOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		split bool
+		rigs  []string
+	}{
+		{name: "T0-single-store", split: false},
+		{name: "T0-single-store-with-rigs", split: false, rigs: []string{"alpha", "bravo"}},
+		{name: "T1-whole-split", split: true},
+		{name: "T2-whole-split-with-rigs", split: true, rigs: []string{"alpha", "bravo"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newLegAgreementEnv(t, tc.split, tc.rigs...)
+			demand, claim := e.demandLegs(t), e.claimLegs(t)
+			if !sameStoreSequence(demand, claim) {
+				t.Fatalf("demand reads %d legs and the claim reader %d, or they disagree about the order. That is the D1-D9 divergence class: a bead in a leg only one side reads is either spawned-for-and-undrainable or claimable-and-uncounted",
+					len(demand), len(claim))
+			}
+			if !sameStoreSequence(demand, e.allLegs()) {
+				t.Fatalf("the agreed leg set is not every store this city holds routed work in (%d legs vs %d). Agreeing on a SMALLER set is agreement, and it is the failure this property exists to catch",
+					len(demand), len(e.allLegs()))
+			}
+		})
+	}
+}
+
+// TestEveryLegsRoutedWorkIsBothCountedAndClaimable is the same property stated
+// over rows: seed one open routed bead into EVERY leg, and require the demand
+// side and the claim reader to see the same set.
+func TestEveryLegsRoutedWorkIsBothCountedAndClaimable(t *testing.T) {
+	const target = "worker"
+	e := newLegAgreementEnv(t, true, "alpha", "bravo")
+
+	seeded := map[string]bool{}
+	for _, store := range e.allLegs() {
+		bead, err := store.Create(beads.Bead{
+			Title:    "routed work",
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: target},
+		})
+		if err != nil {
+			t.Fatalf("seed routed work: %v", err)
+		}
+		seeded[bead.ID] = true
+	}
+
+	counted := map[string]bool{}
+	for _, store := range e.demandLegs(t) {
+		rows, err := store.List(beads.ListQuery{Status: "open", TierMode: beads.FederatedReadTier})
+		if err != nil {
+			t.Fatalf("demand leg List: %v", err)
+		}
+		for _, row := range rows {
+			if seeded[row.ID] {
+				counted[row.ID] = true
+			}
+		}
+	}
+
+	claimable := map[string]bool{}
+	legs, err := readyFederationLegsOverBinding(e.cityName, e.work, e.rigs, e.binding)
+	if err != nil {
+		t.Fatalf("readyFederationLegsOverBinding: %v", err)
+	}
+	rows, err := readyBeadsForOpts(legs, readyOpts{
+		unassigned:     true,
+		metadataFields: []string{beadmeta.RoutedToMetadataKey + "=" + target},
+	})
+	if err != nil {
+		t.Fatalf("gc ready over the claim legs: %v", err)
+	}
+	for _, row := range rows {
+		if seeded[row.ID] {
+			claimable[row.ID] = true
+		}
+	}
+
+	for id := range seeded {
+		if !counted[id] {
+			t.Errorf("routed bead %s is CLAIMABLE but uncounted: the controller never mints demand for it, so no seat is ever spawned to take it", id)
+		}
+		if !claimable[id] {
+			t.Errorf("routed bead %s is COUNTED but unclaimable: a seat spawns for it, finds nothing, and drains — the spawn/idle treadmill", id)
+		}
+	}
+	if len(counted) != len(seeded) || len(claimable) != len(seeded) {
+		t.Fatalf("counted %d, claimable %d, seeded %d", len(counted), len(claimable), len(seeded))
+	}
+
+	// CONTROL, fixture rot: a bead in NO leg is in neither set, so the counts
+	// above are not both satisfied by a reader that returns everything.
+	orphan := beads.NewMemStoreFrom(900000, nil, nil)
+	stray, err := orphan.Create(beads.Bead{
+		Title: "unreachable", Type: "task", Status: "open",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: target},
+	})
+	if err != nil {
+		t.Fatalf("seed stray: %v", err)
+	}
+	if counted[stray.ID] || claimable[stray.ID] {
+		t.Fatal("a bead in no leg was reported by a reader; the fixture is not exercising the legs")
+	}
+}
+
+// TestDroppingALegBreaksAgreementAndNotTheRowCorpus is the differently-failing
+// control. A leg removed from ONE side leaves every row's eligibility semantics
+// untouched — the row corpus stays green — and shows up here as a set mismatch
+// plus a bead one reader cannot see.
+func TestDroppingALegBreaksAgreementAndNotTheRowCorpus(t *testing.T) {
+	e := newLegAgreementEnv(t, true, "alpha")
+	demand := e.demandLegs(t)
+	if len(demand) < 2 {
+		t.Fatalf("the fixture resolved %d legs; the control needs one to drop", len(demand))
+	}
+	mutated := demand[:len(demand)-1] // drop the binding, the D5/ga-whzrt shape
+
+	if sameStoreSequence(mutated, e.claimLegs(t)) {
+		t.Fatal("dropping a leg left the two readers agreeing; this control proves nothing")
+	}
+	// And the dropped leg really was carrying reachable work, so the mismatch is
+	// a lost answer rather than a lost empty.
+	if _, err := e.binding.Create(beads.Bead{Title: "binding-only", Type: "task", Status: "open"}); err != nil {
+		t.Fatalf("seed binding work: %v", err)
+	}
+	for _, store := range mutated {
+		rows, err := store.List(beads.ListQuery{Status: "open", TierMode: beads.FederatedReadTier})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		for _, row := range rows {
+			if row.Title == "binding-only" {
+				t.Fatal("the dropped leg's work is still reachable through the remaining legs; the fixture's stores are not distinct")
+			}
+		}
+	}
+}

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -64,26 +64,25 @@ func cliResidencyTopology(cityPath string, cfg *config.City, work beads.Store, r
 }
 
 // residencyTopology builds the controller's topology from the binding it opened
-// at boot and the stores it supervises.
+// at boot, its city work store, and the rig legs it is TOLD are serving.
 //
-// # It currently includes SUSPENDED rigs, and S3 must fix that before consuming it
+// # The suspension frame is a parameter, and that is load-bearing
 //
-// rigBeadStores() is every rig the runtime holds open, suspended or not. The
-// census path today does not read it raw: buildDesiredState computes
-// suspendedRigPaths (build_desired_state.go:401) and threads it into
-// collectAllOpenSessionInfos, which is what keeps a suspended rig out of the
-// scan. This constructor has no suspension frame to thread, so a Topology built
-// here carries the suspended rig as an ordinary FederationTail leg.
+// rigBeadStores() is every rig the runtime holds open, suspended or not, and a
+// suspended rig is routinely DARK — its store is an unavailableStore whose every
+// read returns the open error. Planning a census over it makes each result
+// Partial, and Partial means retain-don't-reap: one suspended rig would pin the
+// whole fleet's sessions against every drain and reap decision. So the serving
+// set arrives from the caller that already computed it
+// (buildSuspendedRigPathsForCity, threaded through the census arms) rather than
+// being re-derived here: the constructor is told, it does not decide.
 //
-// That is harmless while nothing consumes it — S0 changes no behavior — and it
-// is a REGRESSION the moment S3 routes the census through Plan(Census): a rig
-// suspended because it is dark would fail its leg, mark every census result
-// Partial, and trip the retain-don't-reap rule fleet-wide. S3 must pass the
-// suspension frame in (excluding suspended rigs from the map it hands here, the
-// "it is told, it does not decide" contract) before the first consumer lands.
-func (cr *CityRuntime) residencyTopology() storeref.Topology {
+// MintsReserved stays false for the same reason it does everywhere else —
+// nothing in this build verifies a binding's mint prefix — so the residence
+// probe stays in every plan.
+func (cr *CityRuntime) residencyTopology(servingRigs map[string]beads.Store) storeref.Topology {
 	bindings, refused := residencyBindingsFromRoutes(cr.storageRoutes)
-	return assembleResidencyTopology(cr.cfg, cr.cityBeadStore(), cr.rigBeadStores(), bindings, refused)
+	return assembleResidencyTopology(cr.cfg, cr.cityBeadStore(), servingRigs, bindings, refused)
 }
 
 // residencyTopologyForCity builds a topology over the caller's own opened work
@@ -100,11 +99,36 @@ func (cr *CityRuntime) residencyTopology() storeref.Topology {
 // binding root, a duplicate managed-Dolt server or a second sqlite writer,
 // which is a worse bug than the blindness this closes.
 func residencyTopologyForCity(cityPath string, cfg *config.City, work beads.Store, rigs map[string]beads.Store) storeref.Topology {
-	if routes, ok := registeredResidencyRoutes(cityPath); ok {
-		bindings, refused := residencyBindingsFromRoutes(routes)
+	if entry, ok := registeredResidencyEntry(cityPath); ok {
+		bindings, refused := residencyBindingsFromRoutes(entry.routes)
 		return assembleResidencyTopology(cfg, work, rigs, bindings, refused)
 	}
 	return cliResidencyTopology(cityPath, cfg, work, rigs)
+}
+
+// registeredCityWorkStore returns the CITY WORK store the runtime serving
+// cityPath opened at boot, or nil when no runtime here serves that city.
+//
+// The census needs it because the store its arms are HANDED is the sessions
+// leg, which on a converged split is the binding — and a census whose work leg
+// is the binding is the E2 dual role: the binding stands in for the city work
+// store, and a city-scope routed WORK bead is then in no leg at all (D6,
+// ga-88mxz). Naming both requires the work store, and reopening it from
+// cityPath would put a second handle on the work root, which is a worse bug
+// than the blindness it closes — the same argument that made the binding half a
+// registration rather than a funnel call.
+//
+// It is a func rather than a beads.Store because the runtime registers under
+// the controller lock, and its controllerState (which owns the cached city
+// store) is installed a few statements later. Reading the accessor at census
+// time rather than at registration time means the registration cannot capture a
+// nil.
+func registeredCityWorkStore(cityPath string) beads.Store {
+	entry, ok := registeredResidencyEntry(cityPath)
+	if !ok || entry.work == nil {
+		return nil
+	}
+	return entry.work()
 }
 
 // registerResidencyRoutes records the routes a long-running runtime opened at
@@ -129,16 +153,18 @@ func residencyTopologyForCity(cityPath string, cfg *config.City, work beads.Stor
 // stays open, and the 21 non-test sites that call cliStorageRoutes directly
 // keep using it. Neutralizing the funnel is not this slice's scope; keeping the spine off
 // it is.
-func registerResidencyRoutes(cityPath string, routes *storageRoutes) {
+// work is the runtime's city WORK-store accessor, read lazily (see
+// registeredCityWorkStore); pass nil from a caller that has none.
+func registerResidencyRoutes(cityPath string, routes *storageRoutes, work func() beads.Store) {
 	if cityPath == "" {
 		return
 	}
 	key := filepath.Clean(cityPath)
 	residencyRoutesMu.Lock()
 	if residencyRoutesByCity == nil {
-		residencyRoutesByCity = make(map[string]*storageRoutes, 1)
+		residencyRoutesByCity = make(map[string]residencyRegistration, 1)
 	}
-	residencyRoutesByCity[key] = routes
+	residencyRoutesByCity[key] = residencyRegistration{routes: routes, work: work}
 	residencyRoutesMu.Unlock()
 	dropCLIResidencyBindings(key)
 }
@@ -161,30 +187,38 @@ func unregisterResidencyRoutes(cityPath string, routes *storageRoutes) {
 	}
 	key := filepath.Clean(cityPath)
 	residencyRoutesMu.Lock()
-	if current, ok := residencyRoutesByCity[key]; ok && current == routes {
+	if current, ok := residencyRoutesByCity[key]; ok && current.routes == routes {
 		delete(residencyRoutesByCity, key)
 	}
 	residencyRoutesMu.Unlock()
 	dropCLIResidencyBindings(key)
 }
 
-// registeredResidencyRoutes reports the runtime-registered routes for a city.
+// residencyRegistration is what one long-running runtime declares about a city:
+// the class routes it opened at boot, and the accessor for the city WORK store
+// it supervises.
+type residencyRegistration struct {
+	routes *storageRoutes
+	work   func() beads.Store
+}
+
+// registeredResidencyEntry reports the runtime-registered stores for a city.
 // The bool distinguishes "this process serves the city and relocates nothing"
 // (registered nil routes) from "no runtime here", which is what keeps a
 // single-store controller off the one-shot funnel entirely.
-func registeredResidencyRoutes(cityPath string) (*storageRoutes, bool) {
+func registeredResidencyEntry(cityPath string) (residencyRegistration, bool) {
 	if cityPath == "" {
-		return nil, false
+		return residencyRegistration{}, false
 	}
 	residencyRoutesMu.Lock()
 	defer residencyRoutesMu.Unlock()
-	routes, ok := residencyRoutesByCity[filepath.Clean(cityPath)]
-	return routes, ok
+	entry, ok := residencyRoutesByCity[filepath.Clean(cityPath)]
+	return entry, ok
 }
 
 var (
 	residencyRoutesMu     sync.Mutex
-	residencyRoutesByCity map[string]*storageRoutes
+	residencyRoutesByCity map[string]residencyRegistration
 )
 
 // cliResidencyBindingsEntry is one city's resolved bindings, computed at most
@@ -259,6 +293,18 @@ func dropCLIResidencyBindings(key string) {
 // code describe the whole split this build serves (five classes, one binding)
 // and a per-class fan-out it does not (one class each). The tripwire that this
 // build produces only the former lives in the constructors' test, in one place.
+//
+// # Why a map keyed by beads.Store is safe HERE and is not in the resolver
+//
+// storeref.dedupeLegs cannot key a map on a store — beads.Store is an interface,
+// and an implementation whose dynamic type carries a slice is neither hashable
+// nor ==-able, so a caller's store panics it. This map is confined to the
+// CONSTRUCTORS: every value in it comes from routes.storeFor, which returns what
+// storage boot opened — a *SQLiteStore, a *BdStore, a *CachingStore or a
+// refusedClassStore, all pointer-typed and therefore reference-identified. Same
+// confinement for relocatedGraphLegFrom's `binding == cityStore`. A route that
+// ever yields a value-typed store makes both of these the resolver's bug, one
+// file over; reuse storeref's identity-based set at that point.
 func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding, error) {
 	byStore := map[beads.Store][]coordclass.Class{}
 	var order []beads.Store
@@ -302,6 +348,19 @@ func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordcl
 	}
 	sort.SliceStable(bindings, func(i, j int) bool { return bindings[i].Leg.Ref < bindings[j].Leg.Ref })
 	return bindings, refused
+}
+
+// infrastructureClasses is the class set a whole split relocates: every
+// coordination class but work. Derived from coordclass rather than listed, so a
+// sixth class joins every binding the day it is declared.
+func infrastructureClasses() []coordclass.Class {
+	classes := make([]coordclass.Class, 0, len(coordclass.Classes()))
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			classes = append(classes, class)
+		}
+	}
+	return classes
 }
 
 // reservedPrefixesFor returns the reserved id prefixes a class set mints.

--- a/cmd/gc/residency_topology_test.go
+++ b/cmd/gc/residency_topology_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -36,7 +37,7 @@ func TestControllerResidencyTopologyIsSingleStoreWithoutRoutes(t *testing.T) {
 	work := beads.NewMemStore()
 	cr := &CityRuntime{cfg: residencyTestConfig(), standaloneCityStore: work}
 
-	topo := cr.residencyTopology()
+	topo := cr.residencyTopology(cr.rigBeadStores())
 	if !topo.IsSingleStore() {
 		t.Fatalf("nil routes produced %d bindings, want none", len(topo.Bindings))
 	}
@@ -64,7 +65,7 @@ func TestControllerResidencyTopologyBuildsFromOpenedRoutes(t *testing.T) {
 		storageRoutes:       splitRoutes(binding),
 	}
 
-	topo := cr.residencyTopology()
+	topo := cr.residencyTopology(cr.rigBeadStores())
 	if len(topo.Bindings) != 1 {
 		t.Fatalf("got %d bindings, want 1 — the whole split is ONE store", len(topo.Bindings))
 	}
@@ -90,6 +91,46 @@ func TestControllerResidencyTopologyBuildsFromOpenedRoutes(t *testing.T) {
 	}
 }
 
+// THE S0 CARRY-FORWARD. A suspended rig is routinely DARK, and a dark
+// FederationTail leg makes every census result Partial — which means
+// retain-don't-reap fleet-wide. The constructor is TOLD which rigs are serving,
+// so the serving set never contains one.
+//
+// The control is the same topology built with the suspended rig INCLUDED: it
+// must produce the leg, or the assertion below would pass on a constructor that
+// simply lost all rig legs.
+func TestControllerResidencyTopologyIsToldWhichRigsAreServing(t *testing.T) {
+	cfg := residencyTestConfig()
+	cr := &CityRuntime{
+		cfg:                 cfg,
+		standaloneCityStore: beads.NewMemStore(),
+		standaloneRigStores: map[string]beads.Store{"alpha": beads.NewMemStore(), "bravo": beads.NewMemStore()},
+		storageRoutes:       splitRoutes(beads.NewMemStore()),
+	}
+	suspended := map[string]bool{filepath.Clean("/tmp/bravo"): true}
+
+	serving := cr.residencyTopology(servingRigStores(cfg, cr.rigBeadStores(), suspended))
+	census, err := storeref.Plan(storeref.Census{}, serving)
+	if err != nil {
+		t.Fatalf("Plan(Census): %v", err)
+	}
+	want := `Union(first-leg-wins): ""[Authority,Fatal] > rig:alpha[FederationTail,PartialDegrade] > class:gmnos[FederationTail,Fatal]`
+	if got := census.String(); got != want {
+		t.Fatalf("census over the SERVING rigs =\n %s\nwant\n %s", got, want)
+	}
+
+	// Control: with no suspension frame the bravo leg is present, so the row
+	// above is asserting exclusion rather than an empty rig set.
+	all := cr.residencyTopology(servingRigStores(cfg, cr.rigBeadStores(), nil))
+	control, err := storeref.Plan(storeref.Census{}, all)
+	if err != nil {
+		t.Fatalf("Plan(Census) over every rig: %v", err)
+	}
+	if !strings.Contains(control.String(), "rig:bravo") {
+		t.Fatalf("the control lost the bravo leg too (%s); the exclusion assertion above proves nothing", control.String())
+	}
+}
+
 // A refused city's routes serve every infrastructure class from a store that
 // refuses, and the topology must carry that verdict rather than degrade.
 func TestControllerResidencyTopologyCarriesTheStandingRefusal(t *testing.T) {
@@ -100,7 +141,7 @@ func TestControllerResidencyTopologyCarriesTheStandingRefusal(t *testing.T) {
 		storageRoutes:       splitRoutes(refusedClassStore{err: refusal}),
 	}
 
-	topo := cr.residencyTopology()
+	topo := cr.residencyTopology(cr.rigBeadStores())
 	if topo.Refused == nil {
 		t.Fatal("a refusing binding produced a topology with no refusal")
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -961,39 +961,19 @@ func compactSessionAssignmentIdentifiers(raw []string) []string {
 	return identifiers
 }
 
-// classStoreCandidate is one store in a per-class candidate fan-out, paired
-// with the store-ref label the controller records for beads it owns. The empty
-// ref is the city's canonical store-ref for assigned-work index alignment; the
-// session and unassigned-routed arms label the city store "city".
+// classStoreCandidate is one leg of a census fan-out, paired with the store-ref
+// label the controller records for beads it owns. The legs, their order and
+// their error policy come from Plan(Census) (census_residency.go); the ref
+// vocabulary is the arm's.
+//
+// onError travels with the leg so a consumer that wants to distinguish "a rig
+// went dark" from "the binding went dark" can. Today every arm folds either into
+// the same partial flag, which is the SAFE direction for all of them — a partial
+// census means retain rather than reap — so no arm reads it yet.
 type classStoreCandidate struct {
-	store beads.Store
-	ref   string
-}
-
-// coordClassStoreCandidates builds the index-aligned per-class candidate
-// fan-out the controller reconciler iterates each tick: the city store first
-// (labeled with cityRef), then every non-suspended configured rig store in
-// cfg.Rigs order. It is the single source of truth for the "city + rigs"
-// candidate list that the session-iteration arm and the work-collection arms
-// each build; both arms feed the same store today (identity), but expressing
-// them through one named builder keeps the work-vs-session split structurally
-// explicit and the workBeads/workStores slices per-bead aligned. cityRef
-// distinguishes the assigned-work arm (which records the city store under the
-// empty ref) from the session and unassigned arms (which label it "city").
-func coordClassStoreCandidates(cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, cityRef string) []classStoreCandidate {
-	candidates := []classStoreCandidate{{store: cityStore, ref: cityRef}}
-	if cfg == nil {
-		return candidates
-	}
-	for _, rig := range cfg.Rigs {
-		if suspendedRigPaths[filepath.Clean(rig.Path)] {
-			continue
-		}
-		if s, ok := rigStores[rig.Name]; ok {
-			candidates = append(candidates, classStoreCandidate{store: s, ref: rig.Name})
-		}
-	}
-	return candidates
+	store   beads.Store
+	ref     string
+	onError storeref.ErrPolicy
 }
 
 // sweepAssignedWorkLegs runs visit over the leg set a session-retirement scan

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -122,30 +122,21 @@ func TestSplitTopologyConformance(t *testing.T) {
 // rig store's own routed work alongside it. A leading store resolved to the WORK
 // class instead would read zero and drain the fleet.
 //
-// KNOWN GAP, pinned rather than asserted as desirable — the HQ WORK store leg.
-// The scan's arms are the leading store plus the RIG stores, and production
-// builds the rig arm as rigBeadStores(), which deletes the city entry
-// (city_runtime.go). On a split city the leading store is the class store, so
-// the HQ work store is in NEITHER arm and a city-scope routed WORK bead is
-// invisible to controller-tick demand — the same "no work" fail-open this
-// invariant is named for, live today.
+// THE TWO LEG SETS AGREE, and that is what this row now pins. The CLAIM read's
+// legs are enumerated in ready_federation.go's contract header: city work store,
+// then rigs by name ascending, then the relocated binding LAST. The DEMAND
+// read's legs are the same set, because both are now Plan(RoutedWork)/
+// Plan(Census) over one topology (S3) rather than two hand-maintained lists.
 //
-// THE TWO LEG SETS, named together so the delta stays one fact rather than two
-// hand-maintained lists. The CLAIM read's legs are enumerated in
-// ready_federation.go's contract header: city work store, then rigs by name
-// ascending, then the relocated binding LAST. The DEMAND read's legs are the
-// ones this row asserts: the leading sessions-class store (the binding on a
-// split city) plus rigBeadStores(). Their only difference is this row's subject
-// — the HQ work store, present in the claim set and absent from the demand set.
-// Every other divergence class between the two readers is closed at the row
-// level (demand_serve_predicate.go and its agreement conformance); this one is
-// a LEG-SET difference and is the last one outstanding. cmd_start.go already names the dual role
-// as a shared E2 two-store split. `gc session close` still reaches the HQ store
-// through unclaimWorkAssignedToRetiredSessionBead, so the bead is not lost
-// forever; the controller tick is what is blind. The hqWork row below asserts
-// today's asymmetric answer on both topologies. When the coordination-class /
-// HQ-work arm lands, that row's expectation flips to found-on-both and this
-// paragraph goes with it.
+// The HQ WORK store was the last leg-set divergence, and it is closed here. The
+// scan used to take the store it was HANDED as its city leg — the sessions-class
+// store, which on a converged split IS the binding — while the rig arm is
+// rigBeadStores(), which deletes the city entry. So the HQ work store was in
+// NEITHER arm and a city-scope routed WORK bead was invisible to controller-tick
+// demand: the "no work" fail-open this invariant is named for (D6, ga-88mxz).
+// Now the work store and the binding are DISTINCT ref'd legs, so the hqWork row
+// below is found on both topologies and the graph rows answer under the
+// binding's own "class:*" ref.
 func conformanceReadyFederation(t *testing.T, e splitEnv) {
 	durable := mintDurableGraphBead(t, e, "routed ready control bead", e.qualified)
 	wisp := e.mintWispWith(t, wispOpts{title: "routed ready wisp", routedTo: e.qualified})
@@ -172,7 +163,7 @@ func conformanceReadyFederation(t *testing.T, e splitEnv) {
 		t.Fatalf("HQ bead %s classifies as infrastructure; this leg is about the WORK class specifically", hqWork.ID)
 	}
 
-	found, stores, refs, partial := collectOpenUnassignedRoutedWork(e.cfg, e.sessionsStore(), e.rigStores, nil, os.Stderr)
+	found, stores, refs, partial := collectOpenUnassignedRoutedWork(e.cityPath, e.cfg, e.sessionsStore(), e.rigStores, nil, os.Stderr)
 	if partial {
 		t.Fatal("collectOpenUnassignedRoutedWork reported a partial scan; the demand read must be complete for this invariant to mean anything")
 	}
@@ -181,7 +172,15 @@ func conformanceReadyFederation(t *testing.T, e splitEnv) {
 	}
 
 	leadingOwner, ownerName := e.owner()
-	leadingRef, rigRef := "city:"+e.cfg.Workspace.Name, "rig:"+e.rigName
+	cityRef, rigRef := "city:"+e.cfg.Workspace.Name, "rig:"+e.rigName
+	// The graph-class rows answer from the leg that HOLDS them, under that leg's
+	// own ref: the binding's on a split city, the city work store's otherwise.
+	// Before S3 both spelled themselves "city:<name>", because the binding was
+	// the city leg.
+	leadingRef := cityRef
+	if e.split {
+		leadingRef = string(storeref.ClassRef(wholeSplitClasses()))
+	}
 	for _, tc := range []struct {
 		name    string
 		id      string
@@ -205,47 +204,36 @@ func conformanceReadyFederation(t *testing.T, e splitEnv) {
 		}
 	}
 
-	// The HQ work leg, stated per topology because the answer really differs.
-	// See the KNOWN GAP paragraph above: this pins what main does, not what it
-	// should do.
+	// The HQ work leg — the D6 subject, and the same answer on both topologies
+	// now that the city work store is a leg of its own rather than a store the
+	// binding stood in for.
 	hqIndex := beadIndexOf(found, hqWork.ID)
-	if e.split {
-		if hqIndex >= 0 {
-			t.Errorf("routed HQ work bead %s IS in the split-city demand scan (store-ref %q). Two things produce this and they need opposite responses: the HQ-work arm landed (flip this row to expect it on both topologies, drop this invariant's KNOWN GAP paragraph, and update I2's hq leg with it) — or the LEADING store regressed to the work class, which is the #5127/#5125 bug and shows up as the durable/wisp rows going missing above", hqWork.ID, refs[hqIndex])
-		}
-		return
-	}
 	if hqIndex < 0 {
-		t.Errorf("routed HQ work bead %s is missing from the single-store demand scan — on a legacy city the HQ work store IS the leading store, so this is the \"no work\" fail-open with nothing topological to blame", hqWork.ID)
-		return
+		t.Fatalf("routed HQ work bead %s is missing from the demand scan. On a legacy city the HQ work store IS the leading store; on a split city it is the Plan(Census) work leg. Either way this is the \"no work\" fail-open: a pool spawns for work its demand read cannot see, then drains (D6/ga-88mxz, closed by S3)", hqWork.ID)
 	}
 	if !sameStorePtr(stores[hqIndex], e.work) {
 		t.Errorf("routed HQ work bead %s was captured under a store that does not hold it", hqWork.ID)
 	}
-	if refs[hqIndex] != leadingRef {
-		t.Errorf("routed HQ work bead %s captured under store-ref %q, want %q", hqWork.ID, refs[hqIndex], leadingRef)
+	if refs[hqIndex] != cityRef {
+		t.Errorf("routed HQ work bead %s captured under store-ref %q, want %q", hqWork.ID, refs[hqIndex], cityRef)
 	}
 }
 
 // conformanceAssignedWorkCapture (I2) guards the post-claim half of the
 // spawn/drain treadmill and the orphan-release TOCTOU class. A claimed
 // (in_progress) routed bead whose assignee is a DEAD session must be captured by
-// collectAssignedWorkBeadsWithStores under the leading store's arm (owner store
-// aligned, store-ref "") so orphan release can recover it; a claimed bead held
-// by a LIVE open session must NOT be released. Both topologies expect the same
-// outcome — release exactly the dead claim — which on a split city means the
-// capture and the release both have to reach the CLASS store, because that is
-// the leading store the reconciler is handed.
+// collectAssignedWorkBeadsWithStores under the leg that HOLDS it — owner store
+// aligned, and labeled with that leg's ref — so orphan release can recover it; a
+// claimed bead held by a LIVE open session must NOT be released. Both topologies
+// expect the same outcome: release exactly the dead claims.
 //
-// KNOWN GAP, pinned rather than asserted as desirable — the HQ WORK store leg,
-// the same one I1 names. The capture arms are the leading store plus the rig
-// stores, and rigBeadStores() deletes the city entry, so on a split city a dead
-// claim on a city-scope WORK bead is captured by nothing and released by
-// nothing: the bead stays in_progress against a session that is gone until some
-// other path (`gc session close`'s unclaimWorkAssignedToRetiredSessionBead)
-// happens to reach it. The hqDead leg below asserts that asymmetry on both
-// topologies. When the HQ-work arm lands, it flips to released-on-both, together
-// with I1's hqWork row.
+// The HQ WORK store leg, the same one I1 names, is the D6 half. Before S3 the
+// capture arms were the leading store (the binding, on a split city) plus the
+// rig stores, and rigBeadStores() deletes the city entry — so a dead claim on a
+// city-scope WORK bead was captured by nothing and released by nothing, staying
+// in_progress against a session that is gone until `gc session close` happened
+// to reach it. Plan(Census) names the work store and the binding as distinct
+// legs, so hqDead recovers on both topologies.
 func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 	sess, err := e.sessionsStore().Create(splitEnvPoolSessionBead(e.qualified, "executor-1"))
 	if err != nil {
@@ -255,9 +243,16 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 	dead := e.mintWispWith(t, wispOpts{title: "dead-held claimed wisp", routedTo: e.qualified, status: "in_progress", assignee: splitEnvDeadAssignee})
 	hqDead := splitEnvDeadClaimedWorkBead(t, e.work, e.qualified)
 
-	got, stores, refs, _, partial := collectAssignedWorkBeadsWithStores(e.cfg, e.sessionsStore(), e.rigStores, nil, nil)
+	got, stores, refs, _, partial := collectAssignedWorkBeadsWithStores(e.cityPath, e.cfg, e.sessionsStore(), e.rigStores, nil, nil)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	// The graph-class wisps answer from the leg that holds them, under that
+	// leg's own ref: the binding's on a split city, the work store's ("") on a
+	// legacy one.
+	wispRef := ""
+	if e.split {
+		wispRef = string(storeref.ClassRef(wholeSplitClasses()))
 	}
 	for _, want := range []beads.Bead{live, dead} {
 		i := beadIndexOf(got, want.ID)
@@ -267,19 +262,21 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 		if !sameStorePtr(stores[i], e.sessionsStore()) {
 			t.Errorf("wisp %s captured with the wrong owner store — release would mutate a store that does not hold it", want.ID)
 		}
-		if refs[i] != "" {
-			t.Errorf("wisp %s captured under store-ref %q, want \"\" (the leading-store arm)", want.ID, refs[i])
+		if refs[i] != wispRef {
+			t.Errorf("wisp %s captured under store-ref %q, want %q", want.ID, refs[i], wispRef)
 		}
 	}
 
-	// The HQ leg's capture half, per topology. See the KNOWN GAP paragraph.
-	hqCaptured := beadIndexOf(got, hqDead.ID) >= 0
-	if hqCaptured != !e.split {
-		if e.split {
-			t.Errorf("dead-claimed HQ work bead %s IS captured on a split city. Either the HQ-work arm landed (flip this leg and I1's hqWork row to expect capture and release on both topologies, and drop both KNOWN GAP paragraphs) or the LEADING store regressed to the work class, which is the #5127/#5125 bug and shows up as the wisp rows above failing too", hqDead.ID)
-		} else {
-			t.Errorf("dead-claimed HQ work bead %s is NOT captured on a legacy city, where the HQ work store IS the leading store — post-claim HQ work has gone invisible to the reconciler", hqDead.ID)
-		}
+	// The HQ leg's capture half — the same answer on both topologies now.
+	hqIndex := beadIndexOf(got, hqDead.ID)
+	if hqIndex < 0 {
+		t.Fatalf("dead-claimed HQ work bead %s is NOT captured. The city work store is a Plan(Census) leg on both topologies; if this fails on the split arm the work leg has collapsed back onto the binding (D6 regression), and if it fails on both the leading store regressed (#5127/#5125, which also shows up as the wisp rows above)", hqDead.ID)
+	}
+	if !sameStorePtr(stores[hqIndex], e.work) {
+		t.Errorf("dead-claimed HQ work bead %s captured under a store that does not hold it", hqDead.ID)
+	}
+	if refs[hqIndex] != "" {
+		t.Errorf("dead-claimed HQ work bead %s captured under store-ref %q, want \"\" (the work leg)", hqDead.ID, refs[hqIndex])
 	}
 
 	released := releaseOrphanedPoolAssignments(
@@ -288,13 +285,7 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 		got, stores, refs,
 		e.rigStores,
 	)
-	// On a legacy city the HQ work store IS the leading store, so the dead HQ
-	// claim recovers alongside the dead wisp. On a split city it is in neither
-	// arm, so only the wisp does.
-	wantReleased := []string{dead.ID}
-	if !e.split {
-		wantReleased = append(wantReleased, hqDead.ID)
-	}
+	wantReleased := []string{dead.ID, hqDead.ID}
 	releasedIDs := make(map[string]bool, len(released))
 	for _, b := range released {
 		releasedIDs[b.ID] = true
@@ -307,16 +298,12 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 			t.Errorf("dead claim %s was not released; it stays assigned to a session that is gone", want)
 		}
 	}
-	if e.split {
-		// The gap, asserted rather than assumed: the HQ dead claim is still
-		// stranded after the release pass a split-city controller tick runs.
-		stranded, err := e.work.Get(hqDead.ID)
-		if err != nil {
-			t.Fatalf("reload HQ dead-claimed work bead: %v", err)
-		}
-		if stranded.Status != "in_progress" || stranded.Assignee != splitEnvDeadAssignee {
-			t.Errorf("HQ dead claim %s = status %q assignee %q, want it still stranded at in_progress/%s. If a controller-tick path now recovers it, the HQ-work arm has landed: update this leg, the capture check above and I1's hqWork row together", hqDead.ID, stranded.Status, stranded.Assignee, splitEnvDeadAssignee)
-		}
+	recovered, err := e.work.Get(hqDead.ID)
+	if err != nil {
+		t.Fatalf("reload HQ dead-claimed work bead: %v", err)
+	}
+	if recovered.Assignee != "" {
+		t.Errorf("HQ dead claim %s is still assigned to %q after the release pass a controller tick runs", hqDead.ID, recovered.Assignee)
 	}
 
 	reloaded, err := e.graphStore().Get(live.ID)
@@ -1704,7 +1691,7 @@ func conformanceCLIReadyDeadRigLeg(t *testing.T, e splitEnv) {
 		t.Fatalf("API partial_errors = %v, want the dead rig %q named", body.PartialErrors, deadRig)
 	}
 
-	legs := readyFederationLegs(loadedCityName(dead.cfg, dead.cityPath), dead.work, dead.rigStores, fixtureGraphLeg(dead))
+	legs := mustReadyLegs(t, loadedCityName(dead.cfg, dead.cityPath), dead.work, dead.rigStores, fixtureGraphLeg(dead))
 	rows, err := readyBeadsForOpts(legs, readyOpts{})
 	if err == nil {
 		t.Fatalf("gc ready served %d beads over the same dead %q leg; the API said that read was PARTIAL, and a bare array has nowhere to say so — the CLI's equivalent of Partial 200 is a non-zero exit", len(rows), deadRig)
@@ -1732,7 +1719,7 @@ func containsSubstring(list []string, want string) bool {
 // gate, so this exercises the leg-selection decision rather than restating it.
 func cliReadyIDs(t *testing.T, e splitEnv) []string {
 	t.Helper()
-	legs := readyFederationLegs(
+	legs := mustReadyLegs(t,
 		loadedCityName(e.cfg, e.cityPath),
 		e.work,
 		e.rigStores,
@@ -1898,7 +1885,7 @@ func conformanceFederatedInFlightTier(t *testing.T, e splitEnv, ownerName string
 		t.Fatalf("claiming the in-flight graph wisp %s: %v", claimed.ID, err)
 	}
 
-	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	legs := mustReadyLegs(t, loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
 	rows, err := readyBeadsForOpts(legs, readyOpts{status: readyStatusInProgress})
 	if err != nil {
 		t.Fatalf("gc ready --status in_progress over the fixture stores: %v", err)
@@ -2101,7 +2088,7 @@ func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 	}
 
 	// The way out the refusal names, on both topologies.
-	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	legs := mustReadyLegs(t, loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
 	readyIDs := func(status string) []string {
 		t.Helper()
 		rows, err := readyBeadsForOpts(legs, readyOpts{status: status, metadataFields: []string{selector}})
@@ -2264,7 +2251,7 @@ func conformanceWorkQueryFederation(t *testing.T, e splitEnv) {
 	}
 
 	routed := e.mintWispWith(t, wispOpts{title: "routed graph step", routedTo: e.qualified})
-	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	legs := mustReadyLegs(t, loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
 	rows, err := readyBeadsForOpts(legs, readyOpts{
 		unassigned:     true,
 		metadataFields: []string{beadmeta.RoutedToMetadataKey + "=" + e.qualified},
@@ -2347,7 +2334,7 @@ func conformanceWorkQueryClaimsWhatItSees(t *testing.T, e splitEnv) {
 // command.
 func assertFederatedReaderServes(t *testing.T, e splitEnv, graphBeadID, tier string, opts readyOpts) {
 	t.Helper()
-	legs := readyFederationLegs(loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
+	legs := mustReadyLegs(t, loadedCityName(e.cfg, e.cityPath), e.work, e.rigStores, fixtureGraphLeg(e))
 	rows, err := readyBeadsForOpts(legs, opts)
 	if err != nil {
 		t.Fatalf("the reader the split work_query's %s tier names failed over healthy stores: %v", tier, err)

--- a/cmd/gc/split_topology_env_test.go
+++ b/cmd/gc/split_topology_env_test.go
@@ -187,7 +187,11 @@ func newSplitEnvWith(t *testing.T, split bool, opts splitEnvOptions) splitEnv {
 	// this fixture staged is the same thing newCityRuntime does with the ones
 	// storageBootGate opened, so both subtests answer residency from the routes
 	// the env decided rather than from a second funnel.
-	registerResidencyRoutes(cityPath, e.routes)
+	// The work store is registered with them, for the same reason: the census
+	// arms are handed the SESSIONS store, and on a split city that is the
+	// binding — so without the runtime declaring its work store the census has
+	// no way to name the two apart, which is the E2 dual role itself.
+	registerResidencyRoutes(cityPath, e.routes, func() beads.Store { return e.work })
 	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, e.routes) })
 	if opts.rig {
 		e.attachRigLeg(t, rigPath)

--- a/internal/storeref/plan.go
+++ b/internal/storeref/plan.go
@@ -3,11 +3,16 @@ package storeref
 // The plan: which stores answer this question, in what order, and what a
 // per-leg failure means.
 //
-// A ResolvedPlan is DATA. It performs no I/O, it is comparable, and it prints
-// as the row format the conformance corpus pins. That is what lets a migration
-// slice assert "the store list this site builds today == the resolver's plan"
-// before it swaps in the executor, and what makes a leg-order change a diff in
-// a golden table rather than a paragraph in a review.
+// A ResolvedPlan is DATA. It performs no I/O and it prints as the row format
+// the conformance corpus pins. That is what lets a migration slice assert "the
+// store list this site builds today == the resolver's plan" before it swaps in
+// the executor, and what makes a leg-order change a diff in a golden table
+// rather than a paragraph in a review.
+//
+// It is NOT comparable — it carries a leg slice, so `==` on two plans does not
+// compile. Compare them the way the corpus does, through String(); comparing
+// their leg SETS is refSet's job in the tests, and it exists precisely because
+// the two comparisons have to fail differently.
 
 import (
 	"strconv"
@@ -184,6 +189,24 @@ func (p ResolvedPlan) String() string {
 		parts = append(parts, l.String())
 	}
 	return p.Mode.String() + ": " + strings.Join(parts, " > ")
+}
+
+// TouchesBinding reports whether any leg of this plan is a relocated class
+// binding.
+//
+// It is the one bit a consumer that cannot execute a plan can still act on: the
+// generated work_query's legs are bd SUBPROCESSES in a workspace, and a binding
+// is not a bd workspace, so "does the answer live anywhere a bd workspace cannot
+// reach" decides which reader the query is built around. Answering it from the
+// plan rather than by re-asking the routes is what keeps a generated query and
+// the reader it drives from disagreeing.
+func (p ResolvedPlan) TouchesBinding() bool {
+	for _, l := range p.Legs {
+		if IsClassRef(string(l.Leg.Ref)) {
+			return true
+		}
+	}
+	return false
 }
 
 // Refs returns the plan's leg refs in order — the census/wake vocabulary a

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -70,6 +70,7 @@ package storeref
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -469,16 +470,58 @@ func shadowLegsCovering(id string, legs []Leg) []Leg {
 // role, because that is the reason the leg is there.
 func dedupeLegs(p ResolvedPlan) ResolvedPlan {
 	out := p.Legs[:0]
-	seen := make(map[beads.Store]bool, len(p.Legs))
+	var seen storeSet
 	for _, l := range p.Legs {
-		if l.Leg.Store == nil || seen[l.Leg.Store] {
+		if !seen.addIfNew(l.Leg.Store) {
 			continue
 		}
-		seen[l.Leg.Store] = true
 		out = append(out, l)
 	}
 	p.Legs = out
 	return p
+}
+
+// storeSet tracks store identity for a dedupe pass without assuming a store can
+// be a map key.
+//
+// beads.Store is an INTERFACE, and an implementation whose dynamic type is a
+// struct carrying a slice or a map is not comparable: putting one in a map
+// panics with "hash of unhashable type", and so does ==. Plans are built over
+// whatever stores the caller opened, so the resolver cannot make that
+// assumption about them.
+//
+// An uncomparable store is therefore treated as distinct from everything. That
+// is the safe direction of the two: a duplicated leg is read twice, while a
+// wrongly-dropped one is a leg silently missing from a federated answer, which
+// is the whole failure class this package exists to close.
+//
+// Identity is ==, so two DIFFERENT backends behind a value-typed store that
+// happens to compare equal — a zero-size store double, say — read as one leg.
+// Every production store is reference-identified (a pointer, or a wrapper
+// carrying one), which is what makes == the right rule here.
+type storeSet struct{ seen []beads.Store }
+
+// addIfNew reports whether store is a leg worth keeping — non-nil, and not one
+// already added.
+func (s *storeSet) addIfNew(store beads.Store) bool {
+	if store == nil {
+		return false
+	}
+	if !comparableStore(store) {
+		return true
+	}
+	for _, have := range s.seen {
+		if comparableStore(have) && have == store {
+			return false
+		}
+	}
+	s.seen = append(s.seen, store)
+	return true
+}
+
+func comparableStore(store beads.Store) bool {
+	t := reflect.TypeOf(store)
+	return t != nil && t.Comparable()
 }
 
 // ResolveOwner probes a FirstOwner plan and pins the store that holds id.
@@ -632,6 +675,26 @@ func Union[T any](p ResolvedPlan, id func(T) string, fn func(Leg) ([]T, error)) 
 		return out, err
 	}
 	return out, nil
+}
+
+// EachLeg visits every leg of a plan in order, with the reason it is there and
+// the meaning of its failure. It performs NO I/O and cannot fail.
+//
+// It is the enumeration seam for a consumer that genuinely cannot run its reads
+// inside Walk: one that fans the legs out CONCURRENTLY (the controller's census
+// arms, which read every leg in parallel and fold per-arm partials), or one that
+// resolves the leg set once and reads it repeatedly under different queries (the
+// `gc ready` reader, whose three arms share one leg set).
+//
+// Those consumers still must not hand-roll a store list, because the two things
+// a hand-rolled list loses are the two things that were wrong at 31 call sites:
+// the leg ORDER and the per-leg error POLICY. EachLeg hands over both, so what a
+// consumer supplies is only its own fan-out shape. Walk remains the executor for
+// reads — the place a policy is APPLIED — and a consumer that can use it should.
+func EachLeg(p ResolvedPlan, visit func(leg Leg, role Role, onError ErrPolicy)) {
+	for _, l := range p.Legs {
+		visit(l.Leg, l.Role, l.OnError)
+	}
 }
 
 // WalkResult is what a leg-by-leg pass over a Union plan reports beyond the

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -379,6 +379,137 @@ func TestRigRefRoundTripsThroughScopeRigContext(t *testing.T) {
 	}
 }
 
+// The binding ref the census records has to read back as a CITY scope, and as a
+// class binding. Both facts are consumed outside this package by the ref
+// normalizers, so both are pinned against ClassRef's own output rather than
+// against a literal.
+func TestClassRefRoundTripsAsCityScope(t *testing.T) {
+	ref := string(ClassRef(infraClasses))
+	rig, ok := ScopeRigContext(ref)
+	if !ok || rig != "" {
+		t.Fatalf("ScopeRigContext(%q) = (%q, %v), want (\"\", true) — a binding is city scope", ref, rig, ok)
+	}
+	if !IsClassRef(ref) {
+		t.Fatalf("IsClassRef(%q) = false", ref)
+	}
+	// The control: the rig family must NOT read as a binding, or the
+	// normalizers would fold every rig leg onto the city.
+	if IsClassRef(string(RigRef("alpha"))) {
+		t.Fatal("IsClassRef accepted a rig ref")
+	}
+	if IsClassRef("class:") {
+		t.Fatal("IsClassRef accepted a token-less class ref")
+	}
+}
+
+// uncomparableStore is a store whose dynamic type carries a slice, so it can be
+// neither a map key nor an == operand. Real consumers have these — a test
+// double that pre-loads snapshots, or any store that embeds a []beads.Bead —
+// and a plan is built over whatever stores the caller opened.
+type uncomparableStore struct {
+	beads.Store
+	snapshot []beads.Bead
+}
+
+// A plan must never PANIC on the stores it is handed. The dedupe pass used to
+// put every leg in a map[beads.Store]bool, which is a runtime panic the moment
+// a caller's store is not hashable — an outage of the whole controller tick
+// dressed as an unrelated test double.
+func TestPlanAcceptsStoresThatCannotBeMapKeys(t *testing.T) {
+	work := uncomparableStore{Store: beads.NewMemStore(), snapshot: []beads.Bead{{ID: "ga-1"}}}
+	topo := Topology{Work: Leg{Ref: WorkRef, Store: work}}
+
+	plan, err := Plan(Census{}, topo)
+	if err != nil {
+		t.Fatalf("Plan(Census) over an uncomparable work store: %v", err)
+	}
+	if got, want := plan.String(), `Union(first-leg-wins): ""[Authority,Fatal]`; got != want {
+		t.Fatalf("plan = %q, want %q", got, want)
+	}
+	if got := topo.ClaimRefs(); len(got) != 1 || got[0] != WorkRef {
+		t.Fatalf("ClaimRefs = %v, want the work ref alone", got)
+	}
+	// The control: a COMPARABLE store repeated across two legs still collapses,
+	// so the fix widened what the dedupe tolerates rather than turning it off.
+	shared := beads.NewMemStore()
+	both := Topology{
+		Work:     Leg{Ref: WorkRef, Store: shared},
+		Bindings: []ClassBinding{{Classes: infraClasses, Leg: Leg{Ref: ClassRef(infraClasses), Store: shared}}},
+	}
+	collapsed, err := Plan(Census{}, both)
+	if err != nil {
+		t.Fatalf("Plan(Census) over a collapsed split: %v", err)
+	}
+	if len(collapsed.Legs) != 1 {
+		t.Fatalf("a binding that resolved back to the work store produced %d legs, want 1", len(collapsed.Legs))
+	}
+}
+
+// TouchesBinding is the one bit a consumer that cannot execute a plan acts on,
+// so it has to be true for exactly the plans that reach a binding.
+func TestTouchesBindingIsTrueForExactlyTheBindingPlans(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		f      topoFixture
+		intent Intent
+		want   bool
+	}{
+		{"single-store RoutedWork", newT0(), RoutedWork{}, false},
+		{"whole-split RoutedWork", newT1(), RoutedWork{}, true},
+		{"split+rigs RoutedWork", newT2(), RoutedWork{}, true},
+		// A work-only census reaches no binding even on a split city, which is
+		// what makes this a property of the PLAN and not of the topology.
+		{"whole-split work census", newT1(), Census{Classes: []coordclass.Class{coordclass.ClassWork}}, false},
+		{"whole-split graph census", newT1(), Census{Classes: []coordclass.Class{coordclass.ClassGraph}}, true},
+		{"whole-split Class(work)", newT1(), Class{C: coordclass.ClassWork}, false},
+		{"whole-split Class(graph)", newT1(), Class{C: coordclass.ClassGraph}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustPlan(t, tc.intent, tc.f.topo).TouchesBinding(); got != tc.want {
+				t.Fatalf("TouchesBinding() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// EachLeg is the enumeration seam for consumers that cannot run their reads
+// inside Walk. It must hand over the plan's ORDER and the plan's POLICY — those
+// are the two things a hand-rolled store list loses — and must perform no I/O,
+// because a consumer building a leg list has not decided to read anything yet.
+func TestEachLegHandsOverOrderAndPolicyWithoutReading(t *testing.T) {
+	f := newT2()
+	plan := mustPlan(t, RoutedWork{}, f.topo)
+
+	var refs []StoreRef
+	var policies []ErrPolicy
+	EachLeg(plan, func(leg Leg, _ Role, onError ErrPolicy) {
+		refs = append(refs, leg.Ref)
+		policies = append(policies, onError)
+	})
+
+	if len(refs) != len(plan.Legs) {
+		t.Fatalf("EachLeg visited %d legs, want %d", len(refs), len(plan.Legs))
+	}
+	for i, leg := range plan.Legs {
+		if refs[i] != leg.Leg.Ref || policies[i] != leg.OnError {
+			t.Fatalf("leg %d = (%q, %v), want (%q, %v) — the order or the policy did not survive", i, refs[i], policies[i], leg.Leg.Ref, leg.OnError)
+		}
+	}
+	// The policies really do differ across legs, so "hands over the policy" is
+	// an assertion and not a constant.
+	distinct := map[ErrPolicy]bool{}
+	for _, p := range policies {
+		distinct[p] = true
+	}
+	if len(distinct) < 2 {
+		t.Fatalf("every leg of RoutedWork x T2 carries the same policy (%v); this test cannot tell a consumer that drops the policy from one that keeps it", policies)
+	}
+	// No reads: the probe-counting fixture would have seen one.
+	if got := f.totalGets(); got != 0 {
+		t.Fatalf("EachLeg performed %d Gets; it is an enumeration, not an executor", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Plan rendering is the corpus's artifact, so its own shape is pinned here.
 

--- a/internal/storeref/storeref.go
+++ b/internal/storeref/storeref.go
@@ -42,17 +42,37 @@ import (
 // name. Unknown, legacy-bare, and incomplete refs return ok=false so callers
 // can apply an explicit compatibility fallback rather than mistaking them for
 // the city store.
+//
+// A "class:<token>" binding ref is CITY scope. A binding serves the whole
+// city's relocated classes and belongs to no rig, so it answers exactly as
+// "city:<name>" does — which is also what it answered before the census named
+// it as a leg of its own, when the reconciler's leading arm WAS the binding and
+// recorded it under the city ref. Reporting it scope-less instead would make
+// every binding-resident row invisible to the scope comparisons
+// (rootStoreRefMatchesCandidate and its siblings): the census would gain the
+// leg and lose the rows in the same commit.
 func ScopeRigContext(storeRef string) (rigContext string, ok bool) {
 	storeRef = strings.TrimSpace(storeRef)
 	switch {
 	case strings.HasPrefix(storeRef, "city:"):
 		return "", strings.TrimSpace(strings.TrimPrefix(storeRef, "city:")) != ""
+	case strings.HasPrefix(storeRef, classRefPrefix):
+		return "", strings.TrimSpace(strings.TrimPrefix(storeRef, classRefPrefix)) != ""
 	case strings.HasPrefix(storeRef, "rig:"):
 		rigContext = strings.TrimSpace(strings.TrimPrefix(storeRef, "rig:"))
 		return rigContext, rigContext != ""
 	default:
 		return "", false
 	}
+}
+
+// IsClassRef reports whether a store-ref names a relocated class binding. It is
+// the predicate the scope-vocabulary normalizers outside this package key on,
+// so "class:" appears as a literal in exactly one file.
+func IsClassRef(storeRef string) bool {
+	storeRef = strings.TrimSpace(storeRef)
+	return strings.HasPrefix(storeRef, classRefPrefix) &&
+		strings.TrimSpace(strings.TrimPrefix(storeRef, classRefPrefix)) != ""
 }
 
 // HasIDPrefix is the optional accessor a store implements to declare the id

--- a/internal/storeref/storeref_test.go
+++ b/internal/storeref/storeref_test.go
@@ -154,10 +154,17 @@ func TestScopeRigContext(t *testing.T) {
 		{name: "city", storeRef: "city:test-city", ok: true},
 		{name: "rig", storeRef: "rig:frontend", rigContext: "frontend", ok: true},
 		{name: "trims whitespace", storeRef: "  rig:frontend  ", rigContext: "frontend", ok: true},
+		// A class binding is a CITY-scope store: it serves the whole city's
+		// relocated classes and belongs to no rig. Answering ok=false here
+		// would make every binding-resident row look scope-less to
+		// rootStoreRefMatchesCandidate, which is how a census that names the
+		// binding as its own leg starts dropping the rows it just gained.
+		{name: "class binding", storeRef: "class:gmnos", ok: true},
 		{name: "empty", storeRef: ""},
 		{name: "bare legacy label", storeRef: "frontend"},
 		{name: "missing rig name", storeRef: "rig:"},
 		{name: "missing city name", storeRef: "city:"},
+		{name: "missing class token", storeRef: "class:"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			rigContext, ok := ScopeRigContext(tt.storeRef)

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -43,6 +43,10 @@ const WorkRef StoreRef = ""
 // RigRef is the canonical ref of a rig work store.
 func RigRef(name string) StoreRef { return StoreRef("rig:" + strings.TrimSpace(name)) }
 
+// classRefPrefix is the binding family's marker, spelled once so ClassRef and
+// the scope predicates that read it back cannot drift apart.
+const classRefPrefix = "class:"
+
 // ClassRef is the canonical ref of the binding serving a class set.
 //
 // The token is the classes' initials in name order, which identifies a binding
@@ -68,7 +72,7 @@ func ClassRef(classes []coordclass.Class) StoreRef {
 		seen[n] = true
 		token.WriteString(n[:1])
 	}
-	return StoreRef("class:" + token.String())
+	return StoreRef(classRefPrefix + token.String())
 }
 
 // Leg is one store the resolver can name, with the id prefix it was CONFIGURED
@@ -156,16 +160,11 @@ func (t Topology) IsSingleStore() bool { return len(t.Bindings) == 0 }
 // dedupe needs the stores.
 func (t Topology) ClaimRefs() []StoreRef {
 	refs := []StoreRef{t.Work.Ref}
-	seen := map[beads.Store]bool{}
-	if t.Work.Store != nil {
-		seen[t.Work.Store] = true
-	}
+	var seen storeSet
+	seen.addIfNew(t.Work.Store)
 	for _, b := range t.orderedBindings() {
-		if b.Leg.Store != nil {
-			if seen[b.Leg.Store] {
-				continue
-			}
-			seen[b.Leg.Store] = true
+		if b.Leg.Store != nil && !seen.addIfNew(b.Leg.Store) {
+			continue
 		}
 		refs = append(refs, b.Leg.Ref)
 	}

--- a/scripts/check-residency-boundary.sh
+++ b/scripts/check-residency-boundary.sh
@@ -190,6 +190,22 @@ run_self_test() {
 	printf 'package main\n\n// b would call rigBeadStores() but only in prose.\nfunc b() {}\n' >"$tmp/comment/cmd/gc/prose.go"
 	expect 0 "a comment naming the vocabulary is not a site" "$tmp/comment"
 
+	# THE ROGUE CONSUMER. storeref.EachLeg is the sanctioned enumeration seam, so
+	# a consumer that takes the legs and then reads them in its OWN order with
+	# its OWN error handling names no forbidden symbol: no []beads.Store literal,
+	# no .Leg.Store, no base enumerator. It passed both halves of this guard
+	# before c:storeref.EachLeg was ratcheted. A third consumer must be a
+	# reviewed baseline change, not a silent one.
+	fixture "$tmp/rogue" $'cmd/gc/existing.go\ta\ta:BeadStores\t1\n'
+	printf 'package main\n\nfunc rogue(p storeref.ResolvedPlan) {\n\tstoreref.EachLeg(p, func(leg storeref.Leg, _ storeref.Role, _ storeref.ErrPolicy) {\n\t\t_, _ = leg.Store.Get("ga-1")\n\t})\n}\n' >"$tmp/rogue/cmd/gc/rogue.go"
+	expect 1 "a NEW storeref.EachLeg consumer must fail" "$tmp/rogue"
+
+	# And its control: the same consumer, baselined, passes — so the row above
+	# ratchets growth rather than banning the seam the two real consumers need.
+	fixture "$tmp/rogue-baselined" $'cmd/gc/existing.go\ta\ta:BeadStores\t1\ncmd/gc/rogue.go\trogue\tc:storeref.EachLeg\t1\n'
+	printf 'package main\n\nfunc rogue(p storeref.ResolvedPlan) {\n\tstoreref.EachLeg(p, func(leg storeref.Leg, _ storeref.Role, _ storeref.ErrPolicy) {\n\t\t_, _ = leg.Store.Get("ga-1")\n\t})\n}\n' >"$tmp/rogue-baselined/cmd/gc/rogue.go"
+	expect 0 "a BASELINED storeref.EachLeg consumer must pass" "$tmp/rogue-baselined"
+
 	return $rc
 }
 

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -1,6 +1,17 @@
 # residency-boundary baseline: path <TAB> function <TAB> pattern <TAB> count.
 # SHRINK ONLY. Regenerate when a migration slice RETIRES sites; growth is a
 # new blind reader and the check refuses it. See scripts/check-residency-boundary.sh.
+#
+# Regenerate with BOTH emitters, or the halves disagree and one silently wins:
+#   scripts/check-residency-boundary.sh --emit-baseline          # the grep rows
+#   RESIDENCY_BASELINE_EMIT=1 go test ./scripts -v \
+#     -run TestResidencyResolverBoundary                         # the ast: rows
+#
+# A row here is a CENSUS entry, not a verdict. Some are genuine blind readers
+# awaiting a migration slice; others are sanctioned shapes whose growth is still
+# worth reviewing — internal/api/residency_by_id.go's three []storeref.Leg
+# returners are the WorkAxisRouter the resolver itself declares, and
+# c:storeref.EachLeg's two entries are the enumeration seam's only consumers.
 cmd/gc/api_state.go	BeadStores	a:BeadStores	1
 cmd/gc/api_state.go	BeadStores	ast:returns-store-list	1
 cmd/gc/api_state.go	beadEventStoresLocked	ast:returns-store-list	1
@@ -8,10 +19,7 @@ cmd/gc/api_state.go	beadEventStoresLocked	c:beads.Store-literal	1
 cmd/gc/api_state.go	buildStores	ast:returns-store-list	1
 cmd/gc/api_state.go	reconcileExecutionCompletions	c:beads.Store-literal	1
 cmd/gc/bd_relocated_classes.go	relocatedBeadClasses	d:ReservedClassPrefix	1
-cmd/gc/build_desired_state.go	collectAllOpenSessionInfos	a:coordClassStoreCandidates	1
-cmd/gc/build_desired_state.go	collectAssignedWorkBeadsWithStores	a:coordClassStoreCandidates	1
 cmd/gc/build_desired_state.go	collectAssignedWorkBeadsWithStores	ast:returns-store-list	1
-cmd/gc/build_desired_state.go	collectOpenUnassignedRoutedWork	a:coordClassStoreCandidates	1
 cmd/gc/build_desired_state.go	collectOpenUnassignedRoutedWork	ast:returns-store-list	1
 cmd/gc/by_id_store_route.go	classRouteCandidates	ast:returns-store-list	1
 cmd/gc/by_id_store_route.go	classRouteCandidates	b:storeref.ClassCandidates	1
@@ -19,6 +27,7 @@ cmd/gc/by_id_store_route.go	classRouteCandidates	c:beads.Store-literal	1
 cmd/gc/by_id_store_route.go	classRouteCandidates	d:ReservedClassPrefix	1
 cmd/gc/by_id_store_route.go	classRoutedStoreForID	b:graphClassBinding	1
 cmd/gc/by_id_store_route.go	classRoutedStoreForID	d:bdIDIsClassReserved	1
+cmd/gc/census_residency.go	censusLegCandidates	c:storeref.EachLeg	1
 cmd/gc/city_runtime.go	beadReconcileTick	a:rigBeadStores	1
 cmd/gc/city_runtime.go	buildStandaloneRigStores	ast:returns-store-list	1
 cmd/gc/city_runtime.go	openStandaloneRigStores	ast:returns-store-list	1
@@ -34,7 +43,6 @@ cmd/gc/city_runtime.go	syncBeadsAndUpdateIndex	a:rigBeadStores	1
 cmd/gc/city_runtime.go	tick	a:rigBeadStores	4
 cmd/gc/claim_class_route.go	holds	d:bdIDIsClassReserved	1
 cmd/gc/claim_class_route.go	hookClaimClassRouteForCity	b:graphClassBinding	1
-cmd/gc/class_store.go	cityQueryTopology	b:graphClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:graphClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:routes.storeFor	1
 cmd/gc/class_store.go	resolveClassStore	b:routes.storeFor	1
@@ -73,10 +81,9 @@ cmd/gc/order_store.go	appendOrdersSweepStore	ast:returns-store-list	1
 cmd/gc/order_store.go	orderTrackingSweepStoresForConfigTargets	ast:returns-store-list	1
 cmd/gc/order_store.go	orderTrackingSweepStoresFromTargets	ast:returns-store-list	1
 cmd/gc/order_store.go	rawOrderStores	ast:returns-store-list	1
+cmd/gc/ready_federation.go	readyLegsForTopology	c:storeref.EachLeg	1
 cmd/gc/ready_federation.go	readyRigLegStores	ast:returns-store-list	1
-cmd/gc/ready_federation.go	relocatedGraphLegStore	b:graphClassBinding	1
 cmd/gc/route_recovery.go	recoverUnroutedWorkRoutes	a:rigBeadStores	1
-cmd/gc/session_beads.go	coordClassStoreCandidates	a:coordClassStoreCandidates	1
 internal/api/dashport_support.go	BeadStores	a:BeadStores	1
 internal/api/dashport_support.go	BeadStores	ast:returns-store-list	1
 internal/api/handler_agents.go	findActiveBeadForAssigneesWithFreshness	a:BeadStores	1
@@ -95,6 +102,9 @@ internal/api/huma_handlers_convoys.go	humaHandleConvoyDelete	a:BeadStores	1
 internal/api/huma_handlers_convoys.go	humaHandleConvoyGet	a:BeadStores	1
 internal/api/huma_handlers_convoys.go	humaHandleConvoyList	a:BeadStores	1
 internal/api/huma_handlers_convoys.go	humaHandleConvoyRemove	a:BeadStores	1
+internal/api/residency_by_id.go	WorkLegsForID	ast:returns-store-list	1
+internal/api/residency_by_id.go	configuredPrefixLegs	ast:returns-store-list	1
 internal/api/residency_by_id.go	resolveLegByConfiguredIDPrefix	d:IDInNamespace	1
 internal/api/residency_by_id.go	unroutedWorkLegs	a:BeadStores	1
+internal/api/residency_by_id.go	unroutedWorkLegs	ast:returns-store-list	1
 internal/api/state.go	(file-scope)	a:BeadStores	1

--- a/scripts/residency-boundary-patterns.txt
+++ b/scripts/residency-boundary-patterns.txt
@@ -34,8 +34,20 @@ b:storeref.ClassCandidates	(^|[^A-Za-z0-9_])storeref\.ClassCandidates\(
 #     are applied; a literal list skips both, and so does a consumer that runs a
 #     resolved plan's legs itself. plan-leg-store-access has zero hits today, so
 #     the first one is a violation.
+#
+#     storeref.EachLeg is the SANCTIONED enumeration seam — it hands over the
+#     order and the policy, which is what a hand-rolled list loses — but it is
+#     still a way to get the stores out of a plan and read them yourself, so it
+#     is ratcheted rather than free. Two consumers are baselined (the census
+#     arms, which fan out concurrently; the `gc ready` reader, whose three arms
+#     share one leg set) and a third is a reviewed baseline change, not a
+#     silent one. Without this row a consumer could take the legs, read them in
+#     its own order with its own error handling, and pass both halves of the
+#     guard — which is the whole failure this file exists to prevent, wearing
+#     the resolver's name.
 c:beads.Store-literal	\[\]beads\.Store\{
 c:plan-leg-store-access	\.Leg\.Store($|[^A-Za-z0-9_])
+c:storeref.EachLeg	(^|[^A-Za-z0-9_])storeref\.EachLeg\(
 # (d) bespoke residence probes. The namespace gate is the resolver's, and a site
 #     that re-derives it is one `gc storage migrate` away from ga-axin6.
 d:IDInNamespace	(^|[^A-Za-z0-9_])IDInNamespace\(

--- a/scripts/residency_boundary_test.go
+++ b/scripts/residency_boundary_test.go
@@ -495,28 +495,39 @@ func scanStoreListSignatures(root string, dirs []string, allowlist map[string]bo
 	return found, nil
 }
 
-// isRawStoreList reports whether expr is []beads.Store or
-// map[string]beads.Store — the two shapes that hand a caller a probe list with
-// no leg order and no error policy attached.
+// isRawStoreList reports whether expr is []beads.Store, map[string]beads.Store
+// or []storeref.Leg — the shapes that hand a caller a probe list it will read
+// itself.
+//
+// The first two carry no leg order and no error policy at all. []storeref.Leg
+// is the subtler one: a consumer that enumerated a plan through EachLeg and
+// then RETURNS the bare legs has stripped the policy back off and handed the
+// next caller the same unpoliced list, one function further from the resolver.
+// The grep half ratchets the EachLeg call; this ratchets the shape it can be
+// laundered into.
 func isRawStoreList(expr ast.Expr) bool {
 	switch typed := expr.(type) {
 	case *ast.ArrayType:
-		return typed.Len == nil && isBeadsStore(typed.Elt)
+		return typed.Len == nil && (isBeadsStore(typed.Elt) || isStorerefLeg(typed.Elt))
 	case *ast.MapType:
 		key, ok := typed.Key.(*ast.Ident)
-		return ok && key.Name == "string" && isBeadsStore(typed.Value)
+		return ok && key.Name == "string" && (isBeadsStore(typed.Value) || isStorerefLeg(typed.Value))
 	default:
 		return false
 	}
 }
 
-func isBeadsStore(expr ast.Expr) bool {
+func isBeadsStore(expr ast.Expr) bool { return isQualifiedType(expr, "beads", "Store") }
+
+func isStorerefLeg(expr ast.Expr) bool { return isQualifiedType(expr, "storeref", "Leg") }
+
+func isQualifiedType(expr ast.Expr, pkg, name string) bool {
 	sel, ok := expr.(*ast.SelectorExpr)
-	if !ok || sel.Sel == nil || sel.Sel.Name != "Store" {
+	if !ok || sel.Sel == nil || sel.Sel.Name != name {
 		return false
 	}
-	pkg, ok := sel.X.(*ast.Ident)
-	return ok && pkg.Name == "beads"
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == pkg
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
S3 of the residency-resolver migration (epic ga-qdt5y, bead ga-7o5lh): census/demand and the hook claim path consume the resolver.

- **Suspension threaded first** (the S0 carry-forward): `(*CityRuntime).residencyTopology` takes the serving rig set — a suspended rig no longer risks a fleet-wide Partial/retain-don't-reap storm the day census consumed plans.
- **D6 closed**: the three census arms consume `Plan(Census)`/`Plan(Session)`; the census work leg is the registered city work store, not the sessions binding it happened to be handed (the E2 dual-role accident ends). The pre-declared conformance flip rows fired exactly as written (I1 `hqWork` countable, I2 `hqDead` captured and released on both topologies). Closes ga-88mxz's reverse half.
- **The hook's fan-out collapses 7→1 work-query runs per federated tick** (`gc ready`'s legs ARE `Plan(RoutedWork)`; the primary federated read answers for every leg, tier by tier). Honest latency ledger: per-run cost unchanged, so claim latency roughly halves (~126s→~63s idle-tick on mc's 6-leg city) — **the interim claim windows do not retire on this slice**; the remaining half is ga-4qdfn (binding-first inside the reader — constrained by co-residence ordering — plus one-process claim flow).
- Two latent defects died en route: `Plan` panicked on uncomparable caller-supplied stores (identity-based dedupe now), and the claim-ref vocabulary collapse that would have re-stranded exactly the claims this lane finds (both sides take `censusWorkLeg`; triple-guarded).
- **Rescue-removal trade named, approved delayed-with-retention**: with the extras gone, a dead bound rig means exit-1 retention loops instead of extra-leg tier-0 resume — seat kept, census Partial holds retain-don't-reap, resume on rig return (pinned). Ops cost: claim availability = min(leg availability). Companion bead ga-028k7 makes `suspend` a usable remedy in that shape.
- Council round: `storeref.EachLeg` (the sanctioned concurrent-fan-out seam) gained its own ratcheted grep + AST teeth + a permanent planted-rogue self-test after the council proved a rogue consumer could pass both guard halves.
- Follow-ups filed rather than buried: ga-3wqpg (per-session claim serialization), ga-gu4xg (now-unreachable hook federation code — a provable deletion), ga-028k7, ga-w8ucu, ga-vfpaf (the ps-timeout flake root-caused: 1s budget vs measured 1.09-1.13s at 13k processes — also a reconciler-liveness concern, not just test noise).

Gates: full cmd/gc green (878s); boundary halves with 6-row shrink + the new EachLeg pattern; leg-agreement property falsified-by-mutation; protected suites untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
