### PR TITLE
fix(supervisor): let the forced-stop timeout fire while a shutdown is in flight (#5256)

### DIFF
--- a/cmd/gc/city_registry.go
+++ b/cmd/gc/city_registry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -55,9 +56,10 @@ type citySnapshot struct {
 // The snapshot rebuild is always called while citiesMu is held —
 // there is no TOCTOU gap between mutation and publication.
 type cityRegistry struct {
-	citiesMu sync.Mutex              // protects cities map only; never held by API readers
-	cities   map[string]*managedCity // keyed by path
-	snap     atomic.Pointer[citySnapshot]
+	citiesMu  sync.Mutex              // protects cities map only; never held by API readers
+	cities    map[string]*managedCity // keyed by path
+	snap      atomic.Pointer[citySnapshot]
+	cleanupWg sync.WaitGroup
 
 	// init/backoff state (co-protected by citiesMu)
 	initStatus           map[string]cityInitProgress
@@ -67,7 +69,21 @@ type cityRegistry struct {
 	recentlyUnregistered map[string]recentlyUnregisteredCity // city path → stable name and unregister time
 	supervisorRecorder   events.Recorder                     // supervisor-level event recorder for city lifecycle events
 
-	gen uint64 // monotonic generation counter
+	gen         uint64 // monotonic generation counter for snapshots
+	nextCityGen uint64 // monotonic generation counter for city instances
+
+	// stopping records paths whose forced-stop cleanup is still in flight.
+	// It serializes replacement startup with the previous city's teardown.
+	stopping map[string]*cityStopState
+
+	// cleanupActive counts in-flight stopFn goroutines started by EndStop.
+	// IsStopping remains true while a stopFn is still running so a replacement
+	// city cannot race the old provider's asynchronous teardown.
+	cleanupActive map[string]int
+}
+
+type cityStopState struct {
+	gen uint64
 }
 
 type recentlyUnregisteredCity struct {
@@ -84,6 +100,7 @@ func newCityRegistry() *cityRegistry {
 		panicHistory:         make(map[string]*panicRecord),
 		pendingRequestIDs:    make(map[string]string),
 		recentlyUnregistered: make(map[string]recentlyUnregisteredCity),
+		cleanupActive:        make(map[string]int),
 	}
 	// Initialize with empty snapshot to prevent nil-dereference panic
 	// if an API request arrives before the first reconciliation tick.
@@ -195,6 +212,94 @@ func (r *cityRegistry) Has(path string) bool {
 	defer r.citiesMu.Unlock()
 	_, ok := r.cities[path]
 	return ok
+}
+
+func (r *cityRegistry) latestGenLocked(path string) uint64 {
+	var g uint64
+	if mc := r.cities[path]; mc != nil && mc.gen > g {
+		g = mc.gen
+	}
+	if ip := r.initStatus[path]; ip.gen > g {
+		g = ip.gen
+	}
+	return g
+}
+
+// BeginStop records that the city at path is being stopped so new cities at
+// the same path are not started until cleanup finishes.
+func (r *cityRegistry) BeginStop(path string, gen uint64) {
+	r.citiesMu.Lock()
+	defer r.citiesMu.Unlock()
+	if r.stopping == nil {
+		r.stopping = make(map[string]*cityStopState)
+	}
+	r.stopping[path] = &cityStopState{gen: gen}
+}
+
+// EndStop calls stopFn to tear down the bead provider for path unless a newer
+// generation has already been published. It bounds the stopFn call with
+// cleanupMaxWait and always removes the stop marker, but keeps the path's
+// cleanupActive count high until the stopFn goroutine exits so a replacement
+// city cannot race the asynchronous provider teardown.
+func (r *cityRegistry) EndStop(path string, gen uint64, stopFn func() error) error {
+	r.citiesMu.Lock()
+	s := r.stopping[path]
+	if s == nil || s.gen != gen {
+		r.citiesMu.Unlock()
+		return nil
+	}
+	if newer := r.latestGenLocked(path); newer > gen {
+		delete(r.stopping, path)
+		r.citiesMu.Unlock()
+		return nil
+	}
+	r.cleanupActive[path]++
+	r.citiesMu.Unlock()
+
+	errCh := make(chan error, 1)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		defer r.decrementCleanupActive(path)
+		defer func() {
+			if v := recover(); v != nil {
+				errCh <- fmt.Errorf("bead store cleanup panicked: %v", v)
+			}
+		}()
+		errCh <- stopFn()
+	}()
+
+	var err error
+	select {
+	case err = <-errCh:
+		<-doneCh
+	case <-time.After(cleanupMaxWait):
+		err = fmt.Errorf("bead store cleanup did not finish within %s; abandoning stop marker", cleanupMaxWait)
+	}
+
+	r.citiesMu.Lock()
+	delete(r.stopping, path)
+	r.citiesMu.Unlock()
+	return err
+}
+
+func (r *cityRegistry) decrementCleanupActive(path string) {
+	r.citiesMu.Lock()
+	defer r.citiesMu.Unlock()
+	if r.cleanupActive[path] > 0 {
+		r.cleanupActive[path]--
+		if r.cleanupActive[path] == 0 {
+			delete(r.cleanupActive, path)
+		}
+	}
+}
+
+// IsStopping reports whether path has a forced-stop cleanup in progress,
+// including any asynchronous provider teardown that outlives EndStop's return.
+func (r *cityRegistry) IsStopping(path string) bool {
+	r.citiesMu.Lock()
+	defer r.citiesMu.Unlock()
+	return r.stopping[path] != nil || r.cleanupActive[path] > 0
 }
 
 // CancelCity calls cancel() on the city at path if it exists.

--- a/cmd/gc/city_registry.go
+++ b/cmd/gc/city_registry.go
@@ -308,6 +308,12 @@ func (r *cityRegistry) decrementCleanupActive(path string) {
 func (r *cityRegistry) IsStopping(path string) bool {
 	r.citiesMu.Lock()
 	defer r.citiesMu.Unlock()
+	return r.isStoppingLocked(path)
+}
+
+// isStoppingLocked is the same predicate as IsStopping but must be called
+// while r.citiesMu is already held.
+func (r *cityRegistry) isStoppingLocked(path string) bool {
 	if r.stopping[path] != nil {
 		return true
 	}

--- a/cmd/gc/city_registry.go
+++ b/cmd/gc/city_registry.go
@@ -77,9 +77,11 @@ type cityRegistry struct {
 	stopping map[string]*cityStopState
 
 	// cleanupActive counts in-flight stopFn goroutines started by EndStop.
-	// IsStopping remains true while a stopFn is still running so a replacement
-	// city cannot race the old provider's asynchronous teardown.
-	cleanupActive map[string]int
+	// IsStopping remains true while a stopFn is still running and within its
+	// deadline so a replacement city cannot race the old provider's asynchronous
+	// teardown. cleanupDeadline records the latest grace period for each path.
+	cleanupActive   map[string]int
+	cleanupDeadline map[string]time.Time
 }
 
 type cityStopState struct {
@@ -101,6 +103,7 @@ func newCityRegistry() *cityRegistry {
 		pendingRequestIDs:    make(map[string]string),
 		recentlyUnregistered: make(map[string]recentlyUnregisteredCity),
 		cleanupActive:        make(map[string]int),
+		cleanupDeadline:      make(map[string]time.Time),
 	}
 	// Initialize with empty snapshot to prevent nil-dereference panic
 	// if an API request arrives before the first reconciliation tick.
@@ -238,9 +241,9 @@ func (r *cityRegistry) BeginStop(path string, gen uint64) {
 
 // EndStop calls stopFn to tear down the bead provider for path unless a newer
 // generation has already been published. It bounds the stopFn call with
-// cleanupMaxWait and always removes the stop marker, but keeps the path's
-// cleanupActive count high until the stopFn goroutine exits so a replacement
-// city cannot race the asynchronous provider teardown.
+// cleanupMaxWait and always removes the stop marker. The path's cleanupActive
+// count stays high and cleanupDeadline is set so IsStopping keeps replacement
+// cities out of the path until the goroutine exits or its deadline passes.
 func (r *cityRegistry) EndStop(path string, gen uint64, stopFn func() error) error {
 	r.citiesMu.Lock()
 	s := r.stopping[path]
@@ -254,6 +257,10 @@ func (r *cityRegistry) EndStop(path string, gen uint64, stopFn func() error) err
 		return nil
 	}
 	r.cleanupActive[path]++
+	deadline := time.Now().Add(cleanupMaxWait)
+	if existing, ok := r.cleanupDeadline[path]; !ok || existing.Before(deadline) {
+		r.cleanupDeadline[path] = deadline
+	}
 	r.citiesMu.Unlock()
 
 	errCh := make(chan error, 1)
@@ -290,16 +297,24 @@ func (r *cityRegistry) decrementCleanupActive(path string) {
 		r.cleanupActive[path]--
 		if r.cleanupActive[path] == 0 {
 			delete(r.cleanupActive, path)
+			delete(r.cleanupDeadline, path)
 		}
 	}
 }
 
-// IsStopping reports whether path has a forced-stop cleanup in progress,
-// including any asynchronous provider teardown that outlives EndStop's return.
+// IsStopping reports whether path has a forced-stop cleanup in progress.
+// A cleanup in flight only blocks replacement while it is within its deadline,
+// so a wedged stopFn cannot permanently prevent a new city at the same path.
 func (r *cityRegistry) IsStopping(path string) bool {
 	r.citiesMu.Lock()
 	defer r.citiesMu.Unlock()
-	return r.stopping[path] != nil || r.cleanupActive[path] > 0
+	if r.stopping[path] != nil {
+		return true
+	}
+	if r.cleanupActive[path] == 0 {
+		return false
+	}
+	return time.Now().Before(r.cleanupDeadline[path])
 }
 
 // CancelCity calls cancel() on the city at path if it exists.

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -171,6 +171,12 @@ type CityRuntime struct {
 	// reloadConfigTraced rather than swapping a live handle.
 	storageRoutes *storageRoutes
 
+	// setterWgs holds in-flight sleep_reason marker goroutines started by
+	// markCityStopSessionSleepReasonWithAbort. closeStorageRoutes waits for them
+	// before tearing down the storage binding so a slow/blocked SetMarker does
+	// not race storage teardown.
+	setterWgs []*sync.WaitGroup
+
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains      *drainTracker       // in-memory drain tracker; nil when bead reconciler disabled
 	providerHealthGate *providerHealthGate // ADR-0013 A1 M3a; nil until bead reconciler initialized
@@ -218,7 +224,11 @@ type CityRuntime struct {
 	managedDoltOwned    func(string) (bool, error)
 	managedDoltPort     func(string) string
 
-	shutdownOnce             sync.Once
+	// shutdownInProgress/ shutdownDone ensure doShutdown runs exactly once and
+	// that callers of shutdown() block until it returns.
+	shutdownInProgress       atomic.Bool
+	shutdownDone             chan struct{}
+	shutdownDoneOnce         sync.Once
 	preserveSessionsShutdown atomic.Bool
 	// ownedCity is set true once run() begins, i.e. once this runtime has
 	// passed every init-failure/discard point and is the process actually
@@ -412,6 +422,7 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 
 	cr := &CityRuntime{
 		storageRoutes:           routes,
+		shutdownDone:            make(chan struct{}),
 		cityPath:                p.CityPath,
 		cityName:                p.CityName,
 		configName:              configName,
@@ -3938,128 +3949,160 @@ func (cr *CityRuntime) recordPreservedShutdownTrace() {
 	})
 }
 
+// getShutdownDone lazily initializes the one-shot shutdown completion
+// channel. It is created once so callers of shutdown() can wait for the
+// first shutdown to finish without racing the goroutine that runs it.
+func (cr *CityRuntime) getShutdownDone() chan struct{} {
+	if cr == nil {
+		return nil
+	}
+	cr.shutdownDoneOnce.Do(func() {
+		if cr.shutdownDone == nil {
+			cr.shutdownDone = make(chan struct{})
+		}
+	})
+	return cr.shutdownDone
+}
+
 // shutdown performs graceful two-pass agent shutdown for this city.
 // Safe to call multiple times (e.g., from both panic recovery and
 // normal shutdown) — only the first call takes effect.
 func (cr *CityRuntime) shutdown() {
-	cr.shutdownOnce.Do(func() {
-		// The storage binding's engine is opened once per process and closed
-		// once, at the very end of this one — deferred first so it runs last.
-		//
-		// Everything below still writes: the order drain, the city-stop sleep
-		// reason, and the two-pass session stop all go through the session and
-		// order classes, which on a split city are served from this binding.
-		// Closing it any earlier turns those writes into errors against a closed
-		// store, and the sleep reason an operator reads after `gc stop` is the
-		// one that never lands. The defer is also what makes the close reach
-		// BOTH exits: a shutdown that hands its sessions to the next supervisor
-		// returns early, and it still has to hand over the database file — a
-		// process that exits holding it leaves the successor's open racing this
-		// one's.
-		defer func() {
-			// Stop naming these routes before closing them: a sweep that
-			// resolved its bindings from a closed handle would answer every leg
-			// with an error instead of falling back to the one-shot funnel.
-			// Passing our OWN routes is what keeps this from dropping a
-			// registration a live replacement already installed.
-			unregisterResidencyRoutes(cr.cityPath, cr.storageRoutes)
-			if err := cr.storageRoutes.close(); err != nil {
-				fmt.Fprintf(cr.stderr, "%s: closing the storage binding: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
-			}
-		}()
-		asyncStartsDrained := cr.waitForAsyncStarts()
-		cr.waitForAsyncStops()
-		preserveSessions := cr.preserveSessionsShutdown.Load()
-		if preserveSessions {
-			cr.recordPreservedShutdownTrace()
+	if cr == nil {
+		return
+	}
+	if cr.shutdownInProgress.CompareAndSwap(false, true) {
+		defer close(cr.getShutdownDone())
+		cr.doShutdown()
+		return
+	}
+	<-cr.getShutdownDone()
+}
+
+// doShutdown contains the body of shutdown(). It must only be executed once,
+// under the protection of shutdownInProgress.
+func (cr *CityRuntime) doShutdown() {
+	// The storage binding's engine is opened once per process and closed
+	// once, at the very end of this one — deferred first so it runs last.
+	//
+	// Everything below still writes: the order drain, the city-stop sleep
+	// reason, and the two-pass session stop all go through the session and
+	// order classes, which on a split city are served from this binding.
+	// Closing it any earlier turns those writes into errors against a closed
+	// store, and the sleep reason an operator reads after `gc stop` is the
+	// one that never lands. The defer is also what makes the close reach
+	// BOTH exits: a shutdown that hands its sessions to the next supervisor
+	// returns early, and it still has to hand over the database file — a
+	// process that exits holding it leaves the successor's open racing this
+	// one's.
+	defer func() {
+		// Stop naming these routes before closing them: a sweep that
+		// resolved its bindings from a closed handle would answer every leg
+		// with an error instead of falling back to the one-shot funnel.
+		// Passing our OWN routes is what keeps this from dropping a
+		// registration a live replacement already installed.
+		unregisterResidencyRoutes(cr.cityPath, cr.storageRoutes)
+		cr.closeStorageRoutes()
+	}()
+	asyncStartsDrained := cr.waitForAsyncStarts()
+	cr.waitForAsyncStops()
+	preserveSessions := cr.preserveSessionsShutdown.Load()
+	if preserveSessions {
+		cr.recordPreservedShutdownTrace()
+	}
+	if cr.trace != nil {
+		_ = cr.trace.Close()
+	}
+	if cr.svc != nil {
+		// Workspace-service proxies are process-group-bound, not preserved
+		// agent sessions. Close them so the next supervisor can reacquire
+		// their sockets and ports during re-adoption.
+		if err := cr.svc.Close(); err != nil {
+			fmt.Fprintf(cr.stderr, "%s: service shutdown: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 		}
-		if cr.trace != nil {
-			_ = cr.trace.Close()
-		}
-		if cr.svc != nil {
-			// Workspace-service proxies are process-group-bound, not preserved
-			// agent sessions. Close them so the next supervisor can reacquire
-			// their sockets and ports during re-adoption.
-			if err := cr.svc.Close(); err != nil {
-				fmt.Fprintf(cr.stderr, "%s: service shutdown: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
-			}
-		}
-		if preserveSessions {
-			fmt.Fprintf(cr.stdout, "Preserving agent sessions for supervisor re-adoption.\n") //nolint:errcheck // best-effort stdout
-			return
-		}
-		// Drain order dispatchers with a small cap before stopping sessions.
-		// Use a fresh context because the tick ctx is already canceled at this
-		// point, which would make drain a no-op. shutdown_timeout remains the
-		// graceful session-stop budget; order drain does not silently halve it.
-		// Orphaned tracking beads (if drain times out) are closed by
-		// sweepOrphanedOrderTrackingRetry on next start.
-		total := cr.cfg.Daemon.ShutdownTimeoutDuration()
-		gracefulTimeout := total
+	}
+	if preserveSessions {
+		fmt.Fprintf(cr.stdout, "Preserving agent sessions for supervisor re-adoption.\n") //nolint:errcheck // best-effort stdout
+		return
+	}
+	// Drain order dispatchers with a small cap before stopping sessions.
+	// Use a fresh context because the tick ctx is already canceled at this
+	// point, which would make drain a no-op. shutdown_timeout remains the
+	// graceful session-stop budget; order drain does not silently halve it.
+	// Orphaned tracking beads (if drain times out) are closed by
+	// sweepOrphanedOrderTrackingRetry on next start.
+	total := cr.cfg.Daemon.ShutdownTimeoutDuration()
+	gracefulTimeout := total
+	if cr.forceStopRequested() {
+		gracefulTimeout = 0
+	}
+	if cr.od != nil || len(cr.retiredOrderDispatchers) > 0 {
+		drainTimeout := orderShutdownDrainTimeout(total)
 		if cr.forceStopRequested() {
-			gracefulTimeout = 0
+			drainTimeout = 0
 		}
-		if cr.od != nil || len(cr.retiredOrderDispatchers) > 0 {
-			drainTimeout := orderShutdownDrainTimeout(total)
-			if cr.forceStopRequested() {
-				drainTimeout = 0
-			}
-			drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
-			cr.drainOrderDispatchers(drainCtx)
-			drainCancel()
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
+		cr.drainOrderDispatchers(drainCtx)
+		drainCancel()
+	}
+	running, listErr := cr.listRunningWithTimeout("")
+	if listErr != nil {
+		if runtime.IsPartialListError(listErr) {
+			fmt.Fprintf(cr.stderr, "%s: shutdown session listing partially failed; stopping %d visible agent(s): %v\n", cr.logPrefix, len(running), listErr) //nolint:errcheck // best-effort stderr
+		} else {
+			fmt.Fprintf(cr.stderr, "%s: shutdown session listing failed: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
 		}
-		running, listErr := cr.sp.ListRunning("")
-		if listErr != nil {
-			if runtime.IsPartialListError(listErr) {
-				fmt.Fprintf(cr.stderr, "%s: shutdown session listing partially failed; stopping %d visible agent(s): %v\n", cr.logPrefix, len(running), listErr) //nolint:errcheck // best-effort stderr
+	}
+	// sweepEnumerated tracks whether every stop pass this shutdown ran
+	// actually listed the fleet. A failed ListRunning yields an empty
+	// slice, so gracefulStopAll stops nothing — tearing the server down
+	// after that would turn a transient listing error into an ungraceful
+	// mass kill of sessions we never enumerated. Partial failures count
+	// as not-enumerated too: we did not see the whole fleet, so we must
+	// not kill-server on the strength of a subset. Force stop overrides
+	// this guard: the whole point is to finish teardown even when the
+	// fleet cannot be enumerated.
+	sweepEnumerated := listErr == nil || cr.forceStopRequested()
+	store := cr.sessionsBeadStore()
+	if wg := markCityStopSessionSleepReasonWithAbort(sessionFrontDoor(store.Store), cr.stderr, cr.forceStopRequested, cleanupMaxWait); wg != nil {
+		cr.setterWgs = append(cr.setterWgs, wg)
+	}
+	gracefulStopAllWithForceSignal(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
+	if !asyncStartsDrained && cr.forceStopRequested() {
+		lateRunning, lateListErr := cr.listRunningWithTimeout("")
+		if lateListErr != nil {
+			// sweepEnumerated is already true on the force-stop path, so a late
+			// async-start listing error does not change it.
+			if runtime.IsPartialListError(lateListErr) {
+				fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing partially failed; stopping %d visible agent(s): %v\n", cr.logPrefix, len(lateRunning), lateListErr) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(cr.stderr, "%s: shutdown session listing failed: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing failed: %v\n", cr.logPrefix, lateListErr) //nolint:errcheck // best-effort stderr
 			}
 		}
-		// sweepEnumerated tracks whether every stop pass this shutdown ran
-		// actually listed the fleet. A failed ListRunning yields an empty
-		// slice, so gracefulStopAll stops nothing — tearing the server down
-		// after that would turn a transient listing error into an ungraceful
-		// mass kill of sessions we never enumerated. Partial failures count
-		// as not-enumerated too: we did not see the whole fleet, so we must
-		// not kill-server on the strength of a subset.
-		sweepEnumerated := listErr == nil
-		store := cr.sessionsBeadStore()
-		markCityStopSessionSleepReason(sessionFrontDoor(store.Store), cr.stderr)
-		gracefulStopAllWithForceSignal(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
-		if !asyncStartsDrained && cr.forceStopRequested() {
-			lateRunning, lateListErr := cr.sp.ListRunning("")
-			if lateListErr != nil {
-				sweepEnumerated = false
-				if runtime.IsPartialListError(lateListErr) {
-					fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing partially failed; stopping %d visible agent(s): %v\n", cr.logPrefix, len(lateRunning), lateListErr) //nolint:errcheck // best-effort stderr
-				} else {
-					fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing failed: %v\n", cr.logPrefix, lateListErr) //nolint:errcheck // best-effort stderr
-				}
+		if len(lateRunning) > 0 {
+			if wg := markCityStopSessionSleepReasonWithAbort(sessionFrontDoor(store.Store), cr.stderr, cr.forceStopRequested, cleanupMaxWait); wg != nil {
+				cr.setterWgs = append(cr.setterWgs, wg)
 			}
-			if len(lateRunning) > 0 {
-				markCityStopSessionSleepReason(sessionFrontDoor(store.Store), cr.stderr)
-				gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
-			}
+			gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 		}
-		// With every enumerated session stopped, tear down the provider's
-		// shared server, exactly like the standalone stop path (cmdStopBody
-		// -> teardownServerForStop). Without this, a supervisor-managed stop
-		// leaks the city's tmux server until someone kills it by hand
-		// (#5175). Two guards keep the kill-server narrow:
-		//   - ownedCity: only a runtime that reached run() owns this city.
-		//     A discarded half-built runtime (adoption of an already-running
-		//     city; a controller-lock/socket/token failure) calls shutdown()
-		//     too, and must never kill the live owner's server.
-		//   - sweepEnumerated: only tear down after a stop that actually
-		//     listed the fleet, never on the empty slice a failed list leaves.
-		// The preserve-sessions shutdown returned above, before the session
-		// stops — preserved sessions live inside this server, so keeping it
-		// up there is by design, not an omission.
-		if cr.ownedCity.Load() && sweepEnumerated {
-			teardownServerForStop(cr.sp, cr.stderr, fmt.Sprintf("%s: city '%s'", cr.logPrefix, cr.cityName))
-		}
-	})
+	}
+	// With every enumerated session stopped, tear down the provider's
+	// shared server, exactly like the standalone stop path (cmdStopBody
+	// -> teardownServerForStop). Without this, a supervisor-managed stop
+	// leaks the city's tmux server until someone kills it by hand
+	// (#5175). Two guards keep the kill-server narrow:
+	//   - ownedCity: only a runtime that reached run() owns this city.
+	//     A discarded half-built runtime (adoption of an already-running
+	//     city; a controller-lock/socket/token failure) calls shutdown()
+	//     too, and must never kill the live owner's server.
+	//   - sweepEnumerated: only tear down after a stop that actually
+	//     listed the fleet, never on the empty slice a failed list leaves.
+	// The preserve-sessions shutdown returned above, before the session
+	// stops — preserved sessions live inside this server, so keeping it
+	// up there is by design, not an omission.
+	if cr.ownedCity.Load() && sweepEnumerated {
+		cr.teardownServerForStop(sweepEnumerated)
+	}
 }
 
 func (cr *CityRuntime) preserveSessionsOnShutdown() {
@@ -4068,4 +4111,145 @@ func (cr *CityRuntime) preserveSessionsOnShutdown() {
 
 func (cr *CityRuntime) forceStopRequested() bool {
 	return cr != nil && cr.forceStopShutdown != nil && cr.forceStopShutdown.Load()
+}
+
+// listRunningWithTimeout calls cr.sp.ListRunning in a goroutine. During a
+// graceful shutdown it waits until the call returns. Once a force stop is
+// requested it gives the call cleanupMaxWait to finish before abandoning it.
+func (cr *CityRuntime) listRunningWithTimeout(prefix string) ([]string, error) {
+	type result struct {
+		names []string
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		names, err := cr.sp.ListRunning(prefix)
+		ch <- result{names: names, err: err}
+	}()
+
+	forceDeadline := time.Time{}
+	for {
+		d := 100 * time.Millisecond
+		if !forceDeadline.IsZero() {
+			d = time.Until(forceDeadline)
+			if d <= 0 {
+				return nil, fmt.Errorf("list-running did not finish within %s after force stop", cleanupMaxWait)
+			}
+		}
+		select {
+		case r := <-ch:
+			return r.names, r.err
+		case <-time.After(d):
+			if forceDeadline.IsZero() && cr.forceStopRequested() {
+				forceDeadline = time.Now().Add(cleanupMaxWait)
+			}
+		}
+	}
+}
+
+// forceShutdownAsync starts or joins the existing shutdown of cr and returns a
+// channel that is closed when the shutdown body returns. If a shutdown is
+// already in progress, this avoids spawning a second doShutdown goroutine.
+func (cr *CityRuntime) forceShutdownAsync() <-chan struct{} {
+	done := make(chan struct{})
+	if cr == nil {
+		close(done)
+		return done
+	}
+	if cr.forceStopShutdown != nil {
+		cr.forceStopShutdown.Store(true)
+	}
+	if cr.shutdownInProgress.CompareAndSwap(false, true) {
+		go func() {
+			defer close(done)
+			defer func() { recover() }() //nolint:errcheck
+			defer close(cr.getShutdownDone())
+			cr.doShutdown()
+		}()
+		return done
+	}
+	go func() {
+		defer close(done)
+		<-cr.getShutdownDone()
+	}()
+	return done
+}
+
+func (cr *CityRuntime) waitSetterWgs(timeout time.Duration) bool {
+	if len(cr.setterWgs) == 0 {
+		return true
+	}
+	var all sync.WaitGroup
+	for _, wg := range cr.setterWgs {
+		if wg == nil {
+			continue
+		}
+		all.Add(1)
+		go func(w *sync.WaitGroup) {
+			defer all.Done()
+			w.Wait()
+		}(wg)
+	}
+	done := make(chan struct{})
+	go func() { all.Wait(); close(done) }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		fmt.Fprintf(cr.stderr, "%s: sleep_reason marker writes did not finish within %s; continuing with storage teardown\n", cr.logPrefix, timeout) //nolint:errcheck
+		return false
+	}
+}
+
+func (cr *CityRuntime) closeStorageRoutes() {
+	cr.waitSetterWgs(cleanupMaxWait)
+	if cr.storageRoutes == nil {
+		return
+	}
+	// During a force stop an unresponsive backend can hang close() indefinitely.
+	// Run it in a goroutine and continue shutdown after a bounded wait; the
+	// goroutine is left to finish or fail on its own so the forced-stop timeout
+	// is never blocked again.
+	if cr.forceStopRequested() {
+		done := make(chan struct{})
+		var closeErr error
+		go func() {
+			defer close(done)
+			closeErr = cr.storageRoutes.close()
+		}()
+		select {
+		case <-done:
+		case <-time.After(cleanupMaxWait):
+			fmt.Fprintf(cr.stderr, "%s: storage close did not finish within %s; continuing shutdown\n", cr.logPrefix, cleanupMaxWait) //nolint:errcheck
+			return
+		}
+		if closeErr != nil {
+			fmt.Fprintf(cr.stderr, "%s: closing the storage binding: %v\n", cr.logPrefix, closeErr) //nolint:errcheck
+		}
+		return
+	}
+	if err := cr.storageRoutes.close(); err != nil {
+		fmt.Fprintf(cr.stderr, "%s: closing the storage binding: %v\n", cr.logPrefix, err) //nolint:errcheck
+	}
+}
+
+func (cr *CityRuntime) teardownServerForStop(sweepEnumerated bool) {
+	if !cr.ownedCity.Load() || !sweepEnumerated {
+		return
+	}
+	label := fmt.Sprintf("%s: city '%s'", cr.logPrefix, cr.cityName)
+	if !cr.forceStopRequested() {
+		teardownServerForStop(cr.sp, cr.stderr, label)
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		teardownServerForStop(cr.sp, cr.stderr, label)
+	}()
+	select {
+	case <-done:
+	case <-time.After(cleanupMaxWait):
+		fmt.Fprintf(cr.stderr, "%s: server teardown did not finish within %s; continuing shutdown\n", cr.logPrefix, cleanupMaxWait) //nolint:errcheck
+	}
 }

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -175,7 +175,8 @@ type CityRuntime struct {
 	// markCityStopSessionSleepReasonWithAbort. closeStorageRoutes waits for them
 	// before tearing down the storage binding so a slow/blocked SetMarker does
 	// not race storage teardown.
-	setterWgs []*sync.WaitGroup
+	setterWgsMu sync.Mutex
+	setterWgs   []*sync.WaitGroup
 
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains      *drainTracker       // in-memory drain tracker; nil when bead reconciler disabled
@@ -4065,7 +4066,7 @@ func (cr *CityRuntime) doShutdown() {
 	sweepEnumerated := listErr == nil || cr.forceStopRequested()
 	store := cr.sessionsBeadStore()
 	if wg := markCityStopSessionSleepReasonWithAbort(sessionFrontDoor(store.Store), cr.stderr, cr.forceStopRequested, cleanupMaxWait); wg != nil {
-		cr.setterWgs = append(cr.setterWgs, wg)
+		cr.addSetterWg(wg)
 	}
 	gracefulStopAllWithForceSignal(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 	if !asyncStartsDrained && cr.forceStopRequested() {
@@ -4081,7 +4082,7 @@ func (cr *CityRuntime) doShutdown() {
 		}
 		if len(lateRunning) > 0 {
 			if wg := markCityStopSessionSleepReasonWithAbort(sessionFrontDoor(store.Store), cr.stderr, cr.forceStopRequested, cleanupMaxWait); wg != nil {
-				cr.setterWgs = append(cr.setterWgs, wg)
+				cr.addSetterWg(wg)
 			}
 			gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 		}
@@ -4175,12 +4176,36 @@ func (cr *CityRuntime) forceShutdownAsync() <-chan struct{} {
 	return done
 }
 
+func (cr *CityRuntime) addSetterWg(wg *sync.WaitGroup) {
+	if wg == nil {
+		return
+	}
+	cr.setterWgsMu.Lock()
+	defer cr.setterWgsMu.Unlock()
+	cr.setterWgs = append(cr.setterWgs, wg)
+}
+
+func (cr *CityRuntime) snapshotSetterWgs() []*sync.WaitGroup {
+	cr.setterWgsMu.Lock()
+	defer cr.setterWgsMu.Unlock()
+	out := make([]*sync.WaitGroup, len(cr.setterWgs))
+	copy(out, cr.setterWgs)
+	return out
+}
+
+func (cr *CityRuntime) clearSetterWgs() {
+	cr.setterWgsMu.Lock()
+	defer cr.setterWgsMu.Unlock()
+	cr.setterWgs = nil
+}
+
 func (cr *CityRuntime) waitSetterWgs(timeout time.Duration) bool {
-	if len(cr.setterWgs) == 0 {
+	wgs := cr.snapshotSetterWgs()
+	if len(wgs) == 0 {
 		return true
 	}
 	var all sync.WaitGroup
-	for _, wg := range cr.setterWgs {
+	for _, wg := range wgs {
 		if wg == nil {
 			continue
 		}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -175,8 +175,10 @@ type CityRuntime struct {
 	// markCityStopSessionSleepReasonWithAbort. closeStorageRoutes waits for them
 	// before tearing down the storage binding so a slow/blocked SetMarker does
 	// not race storage teardown.
-	setterWgsMu sync.Mutex
-	setterWgs   []*sync.WaitGroup
+	setterWgsMu      sync.Mutex
+	setterWgs        []*sync.WaitGroup
+	setterWgsRegOnce sync.Once
+	setterWgsRegDone chan struct{}
 
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains      *drainTracker       // in-memory drain tracker; nil when bead reconciler disabled
@@ -424,6 +426,7 @@ func newCityRuntime(p CityRuntimeParams) (*CityRuntime, error) {
 	cr := &CityRuntime{
 		storageRoutes:           routes,
 		shutdownDone:            make(chan struct{}),
+		setterWgsRegDone:        make(chan struct{}),
 		cityPath:                p.CityPath,
 		cityName:                p.CityName,
 		configName:              configName,
@@ -4087,6 +4090,11 @@ func (cr *CityRuntime) doShutdown() {
 			gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
 		}
 	}
+	// All sleep_reason marker wait groups that this shutdown will create are
+	// now registered. Signal the barrier before the long graceful stop work so
+	// cleanup can coordinate provider teardown without racing late
+	// registrations or dropping a WaitGroup that has not yet been appended.
+	cr.signalSetterWgsRegistered()
 	// With every enumerated session stopped, tear down the provider's
 	// shared server, exactly like the standalone stop path (cmdStopBody
 	// -> teardownServerForStop). Without this, a supervisor-managed stop
@@ -4222,6 +4230,39 @@ func (cr *CityRuntime) waitSetterWgs(timeout time.Duration) bool {
 		return true
 	case <-time.After(timeout):
 		fmt.Fprintf(cr.stderr, "%s: sleep_reason marker writes did not finish within %s; continuing with storage teardown\n", cr.logPrefix, timeout) //nolint:errcheck
+		return false
+	}
+}
+
+func (cr *CityRuntime) initSetterWgsRegDone() {
+	if cr.setterWgsRegDone == nil {
+		cr.setterWgsRegDone = make(chan struct{})
+	}
+}
+
+func (cr *CityRuntime) signalSetterWgsRegistered() {
+	if cr == nil {
+		return
+	}
+	cr.setterWgsMu.Lock()
+	cr.initSetterWgsRegDone()
+	ch := cr.setterWgsRegDone
+	cr.setterWgsMu.Unlock()
+	cr.setterWgsRegOnce.Do(func() { close(ch) })
+}
+
+func (cr *CityRuntime) waitSetterWgsRegistered(timeout time.Duration) bool {
+	if cr == nil {
+		return true
+	}
+	cr.setterWgsMu.Lock()
+	cr.initSetterWgsRegDone()
+	ch := cr.setterWgsRegDone
+	cr.setterWgsMu.Unlock()
+	select {
+	case <-ch:
+		return true
+	case <-time.After(timeout):
 		return false
 	}
 }

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -408,30 +410,118 @@ func teardownServerForStop(sp runtime.Provider, stderr io.Writer, logPrefix stri
 }
 
 func markCityStopSessionSleepReason(sessFront *session.Store, stderr io.Writer) {
+	_ = markCityStopSessionSleepReasonWithAbort(sessFront, stderr, nil, 0)
+}
+
+func markCityStopSessionSleepReasonWithAbort(sessFront *session.Store, stderr io.Writer, shouldAbort func() bool, timeout time.Duration) *sync.WaitGroup {
 	if !sessFront.Backed() {
-		return
+		return nil
 	}
+
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	var deadline time.Time
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+	}
+
+	if shouldAbort != nil {
+		go func() {
+			ticker := time.NewTicker(50 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if shouldAbort() {
+						cancel()
+						return
+					}
+				}
+			}
+		}()
+	}
+
 	// The label-only, closed-excluded, IsSessionBeadOrRepairable-UNfiltered Info
 	// lister is byte-identical to the former ListByLabel("gc:session") + closed-skip
 	// sweep: it keeps damaged gc:session-labeled beads with a non-"session" type (which
 	// the narrowing Store.List would drop) and reads each row's classifier through the
 	// typed twin (sessionMetadataStateInfo) + the Info.SleepReason mirror.
-	sessions, err := sessFront.ListLabeledSessionInfosUnfiltered()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc stop: marking sessions: %v\n", err) //nolint:errcheck // best-effort warning
-		return
+	type listRes struct {
+		sessions []session.Info
+		err      error
 	}
-	for _, info := range sessions {
+	listCh := make(chan listRes, 1)
+	go func() {
+		sessions, err := sessFront.ListLabeledSessionInfosUnfiltered()
+		listCh <- listRes{sessions, err}
+	}()
+
+	var res listRes
+	select {
+	case res = <-listCh:
+	case <-ctx.Done():
+		return nil
+	}
+
+	if res.err != nil {
+		fmt.Fprintf(stderr, "gc stop: marking sessions: %v\n", res.err) //nolint:errcheck // best-effort warning
+		return nil
+	}
+
+	var setWg sync.WaitGroup
+	for _, info := range res.sessions {
+		select {
+		case <-ctx.Done():
+			goto waitSetters
+		default:
+		}
 		if sessionMetadataStateInfo(info) != "active" {
 			continue
 		}
 		if strings.TrimSpace(info.SleepReason) != "" {
 			continue
 		}
-		if err := sessFront.SetMarker(info.ID, "sleep_reason", string(session.SleepReasonCityStop)); err != nil {
-			fmt.Fprintf(stderr, "gc stop: marking session %s: %v\n", info.ID, err) //nolint:errcheck // best-effort warning
+
+		setWg.Add(1)
+		setCh := make(chan error, 1)
+		go func(info session.Info) {
+			defer setWg.Done()
+			setCh <- sessFront.SetMarker(info.ID, "sleep_reason", string(session.SleepReasonCityStop))
+		}(info)
+
+		select {
+		case err := <-setCh:
+			if err != nil {
+				fmt.Fprintf(stderr, "gc stop: marking session %s: %v\n", info.ID, err) //nolint:errcheck // best-effort warning
+			}
+		case <-ctx.Done():
+			goto waitSetters
 		}
 	}
+
+waitSetters:
+	setDone := make(chan struct{})
+	go func() { setWg.Wait(); close(setDone) }()
+	if !deadline.IsZero() {
+		if remaining := time.Until(deadline); remaining > 0 {
+			select {
+			case <-setDone:
+			case <-time.After(remaining):
+			}
+		}
+	} else {
+		<-setDone
+	}
+	return &setWg
 }
 
 func stopCityManagedBeadsProviderAfterSuccessfulStop(cityPath string, stderr io.Writer) bool {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -2625,12 +2625,10 @@ func publishManagedCity(cr *cityRegistry, path string, mc *managedCity) bool {
 			return
 		}
 		// Re-check: a stop for this path may be in flight; do not publish a
-		// replacement over a city whose cleanup has not finished.
-		if _, stopping := cr.stopping[path]; stopping {
-			alreadyRunning = true
-			return
-		}
-		if cr.cleanupActive[path] > 0 {
+		// replacement over a city whose cleanup has not finished. Use the same
+		// predicate as reconcileCities so the two gates agree on when the path
+		// is startable again.
+		if cr.isStoppingLocked(path) {
 			alreadyRunning = true
 			return
 		}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1201,7 +1201,14 @@ func stopManagedCityWithRegistry(mc *managedCity, cityPath string, stderr io.Wri
 // doShutdown is bounded by cleanupMaxWait, but the total sequence may exceed it.
 func cleanupAfterStop(mc *managedCity, cityPath string, stderr io.Writer, forced <-chan struct{}, cr *cityRegistry) {
 	if forced != nil {
-		<-forced
+		// If the forced shutdown goroutine is wedged on an unresponsive
+		// backend, do not let it pin the stop marker forever. Bounded wait
+		// lets EndStop remove the marker so a replacement city can start.
+		select {
+		case <-forced:
+		case <-time.After(cleanupMaxWait):
+			fmt.Fprintf(stderr, "gc supervisor: city '%s': forced shutdown did not complete within %s; proceeding with cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+		}
 	}
 	if mc.cr != nil {
 		// Coordinate provider teardown with any in-flight sleep_reason marker

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1082,6 +1082,7 @@ type managedCity struct {
 	done       chan struct{} // closed when the city goroutine exits
 	closer     io.Closer     // FileRecorder (or nil); closed on city stop
 	tombstoned atomic.Bool   // set before Remove() in shutdown paths for teardown safety
+	gen        uint64        // cityRegistry generation assigned at publication; used by cleanup
 }
 
 // deleteManagedCityIfCurrent prevents a stale city goroutine from removing
@@ -1108,20 +1109,36 @@ func managedCityStopTimeout(mc *managedCity) time.Duration {
 func managedCityForcedStopTimeout(mc *managedCity) time.Duration {
 	timeout := managedCityStopTimeout(mc)
 	if timeout <= 0 {
-		return timeout
+		// A non-positive shutdown timeout means immediate kill, but the forced
+		// stop still needs a finite budget so the supervisor does not block
+		// forever waiting for the forced-shutdown goroutine.
+		return 5 * time.Second
 	}
 	return timeout * 5
 }
 
-// stopManagedCity cancels a city's context, waits up to its configured
-// grace period for it to exit, forces shutdown if it doesn't, and then
-// closes the bead provider and file recorder. It returns a non-nil error
-// when the city did not exit cleanly within the budget. Stderr still
-// receives a trace line for operability; the returned error is for
-// callers (runSupervisor) that need to aggregate shutdown status.
+// cleanupMaxWait caps how long a force-stop waits for ListRunning and other
+// forced-shutdown operations to finish before abandoning them.
+const cleanupMaxWait = 5 * time.Second
+
+// stopManagedCity is the test-facing wrapper that runs without a city registry.
+// It exists so existing tests do not need to construct a registry.
 func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
+	return stopManagedCityWithRegistry(mc, cityPath, stderr, nil)
+}
+
+// stopManagedCityWithRegistry cancels a city's context, waits up to its
+// configured grace period for it to exit, forces shutdown if it doesn't, and
+// then closes the bead provider and file recorder. It returns a non-nil error
+// when the city did not exit cleanly within the budget. cr is used to make
+// cleanup generation-aware so a replacement city at the same path is not started
+// while the old city's backend is still being torn down.
+func stopManagedCityWithRegistry(mc *managedCity, cityPath string, stderr io.Writer, cr *cityRegistry) error {
 	if mc == nil {
 		return nil
+	}
+	if cr != nil {
+		cr.BeginStop(cityPath, mc.gen)
 	}
 	mc.cancel()
 	timeout := managedCityStopTimeout(mc)
@@ -1129,46 +1146,82 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 	if timeout > 0 {
 		select {
 		case <-mc.done:
-			if err := shutdownBeadsProvider(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
-			}
-			if mc.closer != nil {
-				mc.closer.Close() //nolint:errcheck
-			}
+			cleanupAfterStop(mc, cityPath, stderr, nil, cr)
 			return nil
 		case <-time.After(timeout):
 			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after cancel; forcing shutdown\n", mc.name, timeout) //nolint:errcheck
-			stopErr = fmt.Errorf("city %q did not exit within %s after cancel", mc.name, timeout)
 		}
+	} else {
+		// A non-positive shutdown timeout means skip the grace period and
+		// proceed straight to forced shutdown.
+		fmt.Fprintf(stderr, "gc supervisor: city '%s' shutdown timeout is non-positive; forcing shutdown immediately\n", mc.name) //nolint:errcheck
 	}
+	var forced <-chan struct{}
 	if mc.cr != nil {
-		if mc.cr.forceStopShutdown != nil {
-			mc.cr.forceStopShutdown.Store(true)
-		}
-		func() {
-			defer func() { recover() }() //nolint:errcheck
-			mc.cr.shutdown()
-		}()
+		forced = mc.cr.forceShutdownAsync()
 	}
 	forceTimeout := managedCityForcedStopTimeout(mc)
-	if forceTimeout > 0 {
-		select {
-		case <-mc.done:
-			// Forced shutdown completed before the second timeout — the
-			// city is out. Clear the pending error so we report success.
-			stopErr = nil
-		case <-time.After(forceTimeout):
-			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, forceTimeout) //nolint:errcheck
-			stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, forceTimeout)
-		}
+	select {
+	case <-mc.done:
+		// Forced shutdown completed before the second timeout — the
+		// city is out. Clear the pending error so we report success.
+		stopErr = nil
+	case <-time.After(forceTimeout):
+		fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, forceTimeout) //nolint:errcheck
+		stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, forceTimeout)
 	}
-	if err := shutdownBeadsProvider(cityPath); err != nil {
+	// Cleanup must not extend the forced-stop budget: it is detached for
+	// registry-backed stops so stopManagedCity returns on time. The test path
+	// (no registry) runs synchronously when the forced shutdown is already done
+	// so the existing tests can assert the recorder is closed before returning.
+	switch {
+	case cr != nil:
+		cr.cleanupWg.Add(1)
+		go func() {
+			defer cr.cleanupWg.Done()
+			cleanupAfterStop(mc, cityPath, stderr, forced, cr)
+		}()
+	case forced != nil:
+		select {
+		case <-forced:
+			cleanupAfterStop(mc, cityPath, stderr, forced, cr)
+		default:
+			go cleanupAfterStop(mc, cityPath, stderr, forced, cr)
+		}
+	default:
+		cleanupAfterStop(mc, cityPath, stderr, forced, cr)
+	}
+	return stopErr
+}
+
+// cleanupAfterStop releases the bead provider and the city's file recorder. It
+// waits for the forced shutdown goroutine to finish so cleanup does not race
+// the runtime that is still stopping, then runs the registry-aware EndStop and
+// closes the recorder. Each individual blocking force-stop operation inside
+// doShutdown is bounded by cleanupMaxWait, but the total sequence may exceed it.
+func cleanupAfterStop(mc *managedCity, cityPath string, stderr io.Writer, forced <-chan struct{}, cr *cityRegistry) {
+	if forced != nil {
+		<-forced
+	}
+	if mc.cr != nil {
+		// Coordinate provider teardown with any in-flight sleep_reason marker
+		// writes so the bead store is not stopped while SetMarker goroutines
+		// are still using it.
+		if !mc.cr.waitSetterWgs(cleanupMaxWait) {
+			fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker writes did not finish within %s; proceeding with bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+		}
+		mc.cr.setterWgs = nil
+	}
+	if cr != nil {
+		if err := cr.EndStop(cityPath, mc.gen, func() error { return shutdownBeadsProvider(cityPath) }); err != nil {
+			fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
+		}
+	} else if err := shutdownBeadsProvider(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
 	}
 	if mc.closer != nil {
 		mc.closer.Close() //nolint:errcheck
 	}
-	return stopErr
 }
 
 func stopManagedCityPreservingSessions(mc *managedCity, _ string, stderr io.Writer) error {
@@ -1192,6 +1245,9 @@ func stopManagedCityPreservingSessions(mc *managedCity, _ string, stderr io.Writ
 		}
 	}
 	if waitForRuntimeShutdown && mc.cr != nil {
+		// Preserve mode deliberately waits for the runtime shutdown to finish
+		// before returning, so services and the tmux server are really torn
+		// down (#5175); it must not be made asynchronous.
 		func() {
 			defer func() { recover() }() //nolint:errcheck
 			mc.cr.shutdown()
@@ -1581,11 +1637,13 @@ func runSupervisor(stdout, stderr io.Writer) int {
 				} else {
 					fmt.Fprintf(stdout, "Stopping city '%s'...\n", name) //nolint:errcheck
 				}
-				stopFn := stopManagedCity
+				var err error
 				if preserveSessions {
-					stopFn = stopManagedCityPreservingSessions
+					err = stopManagedCityPreservingSessions(mc, name, stderr)
+				} else {
+					err = stopManagedCityWithRegistry(mc, name, stderr, registry)
 				}
-				if err := stopFn(mc, name, stderr); err != nil {
+				if err != nil {
 					stopFailures = append(stopFailures, fmt.Sprintf("%s: %s", name, err.Error()))
 					fmt.Fprintf(stdout, "City '%s' stop reported error (see stderr).\n", name) //nolint:errcheck
 				} else {
@@ -1595,6 +1653,17 @@ func runSupervisor(stdout, stderr io.Writer) int {
 						fmt.Fprintf(stdout, "City '%s' stopped.\n", name) //nolint:errcheck
 					}
 				}
+			}
+			cleanupTimeout := cleanupMaxWait
+			if n := len(toStop); n > 1 {
+				cleanupTimeout = cleanupMaxWait * time.Duration(n)
+			}
+			cleanupDone := make(chan struct{})
+			go func() { registry.cleanupWg.Wait(); close(cleanupDone) }()
+			select {
+			case <-cleanupDone:
+			case <-time.After(cleanupTimeout):
+				fmt.Fprintf(stderr, "gc supervisor: city cleanup did not finish within %s; continuing shutdown\n", cleanupTimeout) //nolint:errcheck
 			}
 			var shutErr error
 			if len(stopFailures) > 0 {
@@ -1718,7 +1787,7 @@ func reconcileCities(
 			cityName = filepath.Base(path)
 		}
 		fmt.Fprintf(stdout, "Unregistered city '%s', stopping...\n", cityName) //nolint:errcheck
-		stopErr := stopManagedCity(mc, path, stderr)
+		stopErr := stopManagedCityWithRegistry(mc, path, stderr, cr)
 		// Clear backoff so re-registering starts immediately.
 		cr.BatchUpdate(func(
 			_ map[string]*managedCity,
@@ -1798,13 +1867,13 @@ func reconcileCities(
 	})
 	for i, mc := range nameDriftCities {
 		fmt.Fprintf(stdout, "City name changed at '%s', restarting...\n", nameDriftPaths[i]) //nolint:errcheck
-		_ = stopManagedCity(mc, nameDriftPaths[i], stderr)
+		_ = stopManagedCityWithRegistry(mc, nameDriftPaths[i], stderr, cr)
 	}
 
 	// Start new cities (and name-drifted restarts). Build list under lock,
 	// then release lock for I/O-heavy initialization (config loading, bead
 	// lifecycle, formula materialization, etc.).
-	var toStart []supervisor.CityEntry
+	var toStartCandidates []supervisor.CityEntry
 	cr.ReadCallback(func(
 		cities map[string]*managedCity,
 		initStatus map[string]cityInitProgress,
@@ -1816,10 +1885,18 @@ func reconcileCities(
 				if _, initializing := initStatus[path]; initializing {
 					continue
 				}
-				toStart = append(toStart, entry)
+				toStartCandidates = append(toStartCandidates, entry)
 			}
 		}
 	})
+
+	var toStart []supervisor.CityEntry
+	for _, entry := range toStartCandidates {
+		if cr.IsStopping(entry.Path) {
+			continue
+		}
+		toStart = append(toStart, entry)
+	}
 
 	for _, entry := range toStart {
 		path := entry.Path
@@ -1997,7 +2074,7 @@ func reconcileCities(
 			_ map[string]*initFailRecord,
 			_ map[string]*panicRecord,
 		) {
-			initStatus[path] = cityInitProgress{name: cityName, status: "loading_config"}
+			initStatus[path] = initProgressFor(cr, initStatus[path], cityName, "loading_config")
 		})
 
 		// Run critical city initialization (same steps as cmd_start.go).
@@ -2008,7 +2085,7 @@ func reconcileCities(
 				_ map[string]*initFailRecord,
 				_ map[string]*panicRecord,
 			) {
-				initStatus[path] = cityInitProgress{name: cityName, status: status}
+				initStatus[path] = initProgressFor(cr, initStatus[path], cityName, status)
 			})
 		}); err != nil {
 			emitPendingCityCreateFailure(cr, path, cityName, "city_init_failed", err, stderr)
@@ -2023,7 +2100,7 @@ func reconcileCities(
 				_ map[string]*initFailRecord,
 				_ map[string]*panicRecord,
 			) {
-				initStatus[path] = cityInitProgress{name: cityName, status: status}
+				initStatus[path] = initProgressFor(cr, initStatus[path], cityName, status)
 			})
 			started := time.Now()
 			err := fn()
@@ -2540,6 +2617,24 @@ func publishManagedCity(cr *cityRegistry, path string, mc *managedCity) bool {
 			alreadyRunning = true
 			return
 		}
+		// Re-check: a stop for this path may be in flight; do not publish a
+		// replacement over a city whose cleanup has not finished.
+		if _, stopping := cr.stopping[path]; stopping {
+			alreadyRunning = true
+			return
+		}
+		if cr.cleanupActive[path] > 0 {
+			alreadyRunning = true
+			return
+		}
+		// Preserve the generation assigned when init started so cleanup can
+		// detect replacements, even if the city hasn't been published yet.
+		if ip := initStatus[path]; ip.gen != 0 {
+			mc.gen = ip.gen
+		} else {
+			cr.nextCityGen++
+			mc.gen = cr.nextCityGen
+		}
 		// The controller state and per-city API are wired at this point, but
 		// initial reconciliation has not yet materialized startup session
 		// beads. Keep the city in startup status until CityRuntime.OnStarted
@@ -2734,6 +2829,20 @@ func supervisorBuildAgentsFnWithSessionBeads(cityPath, cityName string, stderr i
 type cityInitProgress struct {
 	name   string
 	status string
+	gen    uint64 // cityRegistry generation assigned when init starts
+}
+
+// initProgressFor returns a cityInitProgress for the given path, preserving
+// any generation already assigned while under the registry lock. It mutates
+// cr.nextCityGen directly; callers must hold citiesMu.
+func initProgressFor(cr *cityRegistry, existing cityInitProgress, name, status string) cityInitProgress {
+	if existing.gen == 0 {
+		cr.nextCityGen++
+		existing.gen = cr.nextCityGen
+	}
+	existing.name = name
+	existing.status = status
+	return existing
 }
 
 // Compile-time check that *cityRegistry satisfies api.CityResolver.

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1217,7 +1217,7 @@ func cleanupAfterStop(mc *managedCity, cityPath string, stderr io.Writer, forced
 		if !mc.cr.waitSetterWgs(cleanupMaxWait) {
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker writes did not finish within %s; proceeding with bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
 		}
-		mc.cr.setterWgs = nil
+		mc.cr.clearSetterWgs()
 	}
 	if cr != nil {
 		if err := cr.EndStop(cityPath, mc.gen, func() error { return shutdownBeadsProvider(cityPath) }); err != nil {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1200,42 +1200,38 @@ func stopManagedCityWithRegistry(mc *managedCity, cityPath string, stderr io.Wri
 // closes the recorder. Each individual blocking force-stop operation inside
 // doShutdown is bounded by cleanupMaxWait, but the total sequence may exceed it.
 func cleanupAfterStop(mc *managedCity, cityPath string, stderr io.Writer, forced <-chan struct{}, cr *cityRegistry) {
-	// stopFn runs the actual provider teardown. It is passed to EndStop when a
-	// registry is present so the stop marker can be removed on the cleanup budget
-	// while the goroutine continues to wait for the forced shutdown body. The
-	// key invariant is that we do not clear the marker WaitGroup list or tear
-	// down the bead provider until doShutdown has returned, because doShutdown
-	// may still be registering late wait groups while it is in its bounded
-	// listing/marker phase.
-	stopFn := func() error {
-		if forced != nil {
-			// If the forced shutdown goroutine is wedged on an unresponsive
-			// backend, log a warning but keep waiting for it before provider
-			// teardown so a late SetMarker goroutine is not dropped.
-			select {
-			case <-forced:
-			case <-time.After(cleanupMaxWait):
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': forced shutdown did not complete within %s; continuing to wait before bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
-				<-forced
-			}
+	if forced != nil {
+		// Give doShutdown a bounded chance to finish its work before we tear
+		// down the bead provider. If it does not finish in time, we proceed with
+		// cleanup; the forced-stop budget has already expired.
+		select {
+		case <-forced:
+		case <-time.After(cleanupMaxWait):
+			fmt.Fprintf(stderr, "gc supervisor: city '%s': forced shutdown did not complete within %s; proceeding with cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
 		}
-		if mc.cr != nil {
-			// Coordinate provider teardown with any in-flight sleep_reason marker
-			// writes so the bead store is not stopped while SetMarker goroutines
-			// are still using it.
-			if !mc.cr.waitSetterWgs(cleanupMaxWait) {
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker writes did not finish within %s; proceeding with bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
-			}
-			mc.cr.clearSetterWgs()
-		}
-		return shutdownBeadsProvider(cityPath)
 	}
-
+	if mc.cr != nil {
+		// Wait for the registration barrier before clearing the marker wait
+		// group list. doShutdown appends setter WaitGroups in its listing/marker
+		// phase and only signals the barrier once every expected WaitGroup is
+		// registered. Without the barrier, a late addSetterWg could be dropped
+		// by clearSetterWgs and race bead-provider teardown.
+		if !mc.cr.waitSetterWgsRegistered(cleanupMaxWait) {
+			fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker registration did not finish within %s; proceeding with marker cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+		}
+		// Coordinate provider teardown with any in-flight sleep_reason marker
+		// writes so the bead store is not stopped while SetMarker goroutines
+		// are still using it.
+		if !mc.cr.waitSetterWgs(cleanupMaxWait) {
+			fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker writes did not finish within %s; proceeding with bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+		}
+		mc.cr.clearSetterWgs()
+	}
 	if cr != nil {
-		if err := cr.EndStop(cityPath, mc.gen, stopFn); err != nil {
+		if err := cr.EndStop(cityPath, mc.gen, func() error { return shutdownBeadsProvider(cityPath) }); err != nil {
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
 		}
-	} else if err := stopFn(); err != nil {
+	} else if err := shutdownBeadsProvider(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
 	}
 	if mc.closer != nil {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1200,30 +1200,42 @@ func stopManagedCityWithRegistry(mc *managedCity, cityPath string, stderr io.Wri
 // closes the recorder. Each individual blocking force-stop operation inside
 // doShutdown is bounded by cleanupMaxWait, but the total sequence may exceed it.
 func cleanupAfterStop(mc *managedCity, cityPath string, stderr io.Writer, forced <-chan struct{}, cr *cityRegistry) {
-	if forced != nil {
-		// If the forced shutdown goroutine is wedged on an unresponsive
-		// backend, do not let it pin the stop marker forever. Bounded wait
-		// lets EndStop remove the marker so a replacement city can start.
-		select {
-		case <-forced:
-		case <-time.After(cleanupMaxWait):
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': forced shutdown did not complete within %s; proceeding with cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+	// stopFn runs the actual provider teardown. It is passed to EndStop when a
+	// registry is present so the stop marker can be removed on the cleanup budget
+	// while the goroutine continues to wait for the forced shutdown body. The
+	// key invariant is that we do not clear the marker WaitGroup list or tear
+	// down the bead provider until doShutdown has returned, because doShutdown
+	// may still be registering late wait groups while it is in its bounded
+	// listing/marker phase.
+	stopFn := func() error {
+		if forced != nil {
+			// If the forced shutdown goroutine is wedged on an unresponsive
+			// backend, log a warning but keep waiting for it before provider
+			// teardown so a late SetMarker goroutine is not dropped.
+			select {
+			case <-forced:
+			case <-time.After(cleanupMaxWait):
+				fmt.Fprintf(stderr, "gc supervisor: city '%s': forced shutdown did not complete within %s; continuing to wait before bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+				<-forced
+			}
 		}
-	}
-	if mc.cr != nil {
-		// Coordinate provider teardown with any in-flight sleep_reason marker
-		// writes so the bead store is not stopped while SetMarker goroutines
-		// are still using it.
-		if !mc.cr.waitSetterWgs(cleanupMaxWait) {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker writes did not finish within %s; proceeding with bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+		if mc.cr != nil {
+			// Coordinate provider teardown with any in-flight sleep_reason marker
+			// writes so the bead store is not stopped while SetMarker goroutines
+			// are still using it.
+			if !mc.cr.waitSetterWgs(cleanupMaxWait) {
+				fmt.Fprintf(stderr, "gc supervisor: city '%s': sleep_reason marker writes did not finish within %s; proceeding with bead store cleanup\n", mc.name, cleanupMaxWait) //nolint:errcheck
+			}
+			mc.cr.clearSetterWgs()
 		}
-		mc.cr.clearSetterWgs()
+		return shutdownBeadsProvider(cityPath)
 	}
+
 	if cr != nil {
-		if err := cr.EndStop(cityPath, mc.gen, func() error { return shutdownBeadsProvider(cityPath) }); err != nil {
+		if err := cr.EndStop(cityPath, mc.gen, stopFn); err != nil {
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
 		}
-	} else if err := shutdownBeadsProvider(cityPath); err != nil {
+	} else if err := stopFn(); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
 	}
 	if mc.closer != nil {

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1044,11 +1044,22 @@ func gracefulStopAllWithForceSignal(
 	forceStopRequested func() bool,
 ) {
 	if timeout <= 0 || len(names) == 0 || stopForceRequested(forceStopRequested) {
-		// Immediate kill (no grace period).
-		stopTargetsBounded(stopTargetsForNames(names, cfg, store.Store, stderr), cfg, store.Store, sp, rec, "gc", stdout, stderr)
+		// Immediate kill (no grace period). When a force stop is in flight,
+		// cap the per-target stop budget so doShutdown cannot outrun the
+		// forced-stop timeout and leave cleanup racing the runtime.
+		perTargetTimeout := stopPerTargetTimeoutDefault
+		if stopForceRequested(forceStopRequested) {
+			perTargetTimeout = cleanupMaxWait
+		}
+		stopTargetsBoundedWithTimeout(stopTargetsForNames(names, cfg, store.Store, stderr), cfg, store.Store, sp, rec, "gc", stdout, stderr, perTargetTimeout)
 		return
 	}
 	targets := stopTargetsForNames(names, cfg, store.Store, stderr)
+	stopCh, stopDone := lifecycleStopSignal(forceStopRequested)
+	defer stopDone()
+	killAll := func() {
+		stopTargetsBoundedWithTimeout(targets, cfg, store.Store, sp, rec, "gc", stdout, stderr, cleanupMaxWait)
+	}
 	targetByName := make(map[string]stopTarget, len(targets))
 	for _, target := range targets {
 		targetByName[target.name] = target
@@ -1075,10 +1086,16 @@ func gracefulStopAllWithForceSignal(
 			break
 		}
 		allExited := true
-		if runningSet, ok := runningSessionSet(sp, names); ok {
+		if runningSet, ok := runningSessionSetWithTimeout(sp, names, 0, stopCh); ok {
 			allExited = len(runningSet) == 0
 		} else {
+			if stopForceRequested(forceStopRequested) {
+				break
+			}
 			for _, name := range names {
+				if stopForceRequested(forceStopRequested) {
+					break
+				}
 				running, err := workerSessionTargetRunningWithConfig("", nil, sp, nil, name)
 				if err == nil && running {
 					allExited = false
@@ -1101,9 +1118,28 @@ func gracefulStopAllWithForceSignal(
 	}
 
 	// Pass 2: kill survivors.
+	if stopForceRequested(forceStopRequested) {
+		killAll()
+		return
+	}
 	var survivors []string
-	runningSet, listed := runningSessionSet(sp, names)
+	runningSet, listed := runningSessionSetWithTimeout(sp, names, cleanupMaxWait, stopCh)
+	if !listed {
+		// ListRunning failed after the graceful window. We cannot safely
+		// determine survivors without a deadline, so fall back to bounded
+		// forced cleanup for every name rather than block on per-session
+		// observation.
+		if !stopForceRequested(forceStopRequested) {
+			fmt.Fprintf(stdout, "Could not list running agents; forcing cleanup of all %d name(s) with a %s per-target bound.\n", len(names), cleanupMaxWait) //nolint:errcheck
+		}
+		killAll()
+		return
+	}
 	for _, name := range names {
+		if stopForceRequested(forceStopRequested) {
+			killAll()
+			return
+		}
 		running := false
 		if listed {
 			running = runningSet[name]
@@ -1145,6 +1181,10 @@ func gracefulStopAllWithForceSignal(
 		}
 		survivors = append(survivors, name)
 	}
+	if stopForceRequested(forceStopRequested) {
+		killAll()
+		return
+	}
 	stopTargetsBounded(filterStopTargets(targets, survivors), cfg, store.Store, sp, rec, "gc", stdout, stderr)
 }
 
@@ -1153,27 +1193,52 @@ func stopForceRequested(forceStopRequested func() bool) bool {
 }
 
 func runningSessionSet(sp runtime.Provider, names []string) (map[string]bool, bool) {
-	running, err := sp.ListRunning("")
-	if runtime.IsPartialListError(err) {
-		return nil, false
+	return runningSessionSetWithTimeout(sp, names, 0, nil)
+}
+
+func runningSessionSetWithTimeout(sp runtime.Provider, names []string, timeout time.Duration, stopCh <-chan struct{}) (map[string]bool, bool) {
+	type listRes struct {
+		running []string
+		err     error
 	}
-	if err != nil {
-		return nil, false
+	listCh := make(chan listRes, 1)
+	go func() {
+		running, err := sp.ListRunning("")
+		listCh <- listRes{running, err}
+	}()
+
+	var timeoutCh <-chan time.Time
+	if timeout > 0 {
+		timeoutCh = time.After(timeout)
 	}
-	if len(names) == 0 {
-		return map[string]bool{}, true
-	}
-	wanted := make(map[string]bool, len(names))
-	for _, name := range names {
-		wanted[name] = true
-	}
-	result := make(map[string]bool, len(names))
-	for _, name := range running {
-		if wanted[name] {
-			result[name] = true
+
+	select {
+	case lr := <-listCh:
+		if runtime.IsPartialListError(lr.err) {
+			return nil, false
 		}
+		if lr.err != nil {
+			return nil, false
+		}
+		if len(names) == 0 {
+			return map[string]bool{}, true
+		}
+		wanted := make(map[string]bool, len(names))
+		for _, name := range names {
+			wanted[name] = true
+		}
+		result := make(map[string]bool, len(names))
+		for _, name := range lr.running {
+			if wanted[name] {
+				result[name] = true
+			}
+		}
+		return result, true
+	case <-timeoutCh:
+		return nil, false
+	case <-stopCh:
+		return nil, false
 	}
-	return result, true
 }
 
 // controllerLoop is a compatibility shim that wraps CityRuntime.run().

--- a/cmd/gc/order_gate_budget_test.go
+++ b/cmd/gc/order_gate_budget_test.go
@@ -218,11 +218,12 @@ func TestConditionChecksRunConcurrentlyWithinTheirCap(t *testing.T) {
 			cityPath, cfg, _ := newExecOrderFixture(t)
 			liveDir := filepath.Join(t.TempDir(), "live")
 			ranMarker := filepath.Join(t.TempDir(), "ran")
-			// Register, then wait up to ~1s to see a sibling registration. Exit
-			// 0 only on overlap; always exit normally so the trap unregisters.
+			// Register, then wait up to ~1s to see every sibling registration.
+			// Exit 0 only when all wave checks are present at once (real overlap);
+			// the temp dir cleans the registration files afterwards.
 			check := fmt.Sprintf(
-				`mkdir -p %[1]s; echo . >> %[3]s; f=$(mktemp %[1]s/w.XXXXXX); trap 'rm -f "$f"' EXIT; `+
-					`i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge 2 ]; then exit 0; fi; sleep 0.02; i=$((i+1)); done; exit 1`,
+				`mkdir -p %[1]s; echo . >> %[3]s; f=$(mktemp %[1]s/w.XXXXXX); trap 'sleep 0.1; rm -f "$f"' EXIT; `+
+					`i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge %[2]d ]; then exit 0; fi; sleep 0.02; i=$((i+1)); done; exit 1`,
 				liveDir, wave, ranMarker)
 
 			aa := make([]orders.Order, 0, wave)

--- a/cmd/gc/session_lifecycle_hang_test.go
+++ b/cmd/gc/session_lifecycle_hang_test.go
@@ -84,12 +84,13 @@ func TestExecuteTargetWave_BoundedByPerTargetTimeout(t *testing.T) {
 
 	done := make(chan []stopResult, 1)
 	go func() {
-		done <- executeTargetWave(targets, 2, 100*time.Millisecond, func(target stopTarget) error {
+		results, _ := executeTargetWave(targets, 2, 100*time.Millisecond, func(target stopTarget) error {
 			if target.name == "blocked" {
 				<-block
 			}
 			return nil
 		})
+		done <- results
 	}()
 
 	select {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -3298,11 +3298,16 @@ func hydrateStopTargets(targets []stopTarget, cfg *config.City, store beads.Stor
 	return merged
 }
 
-func stopTargetThroughWorkerBoundary(target stopTarget, store beads.Store, sp runtime.Provider, cfg *config.City) error {
+func stopTargetCanonicalID(target stopTarget) string {
 	targetID := strings.TrimSpace(target.sessionID)
 	if targetID == "" {
 		targetID = strings.TrimSpace(target.name)
 	}
+	return targetID
+}
+
+func stopTargetThroughWorkerBoundary(target stopTarget, store beads.Store, sp runtime.Provider, cfg *config.City) error {
+	targetID := stopTargetCanonicalID(target)
 	if cityStopSessionMarked(store, target.sessionID) {
 		if err := workerKillSessionTargetWithConfig("", store, sp, cfg, targetID); err != nil {
 			return err
@@ -3389,11 +3394,7 @@ func interruptTargetsBoundedWithForceSignal(targets []stopTarget, cfg *config.Ci
 	}
 	waveStarted := time.Now()
 	results, _ := executeTargetWaveUntil(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), shouldStop, func(target stopTarget) error {
-		targetID := strings.TrimSpace(target.sessionID)
-		if targetID == "" {
-			targetID = strings.TrimSpace(target.name)
-		}
-		return workerInterruptSessionTargetWithConfig("", store, sp, cfg, targetID)
+		return workerInterruptSessionTargetWithConfig("", store, sp, cfg, stopTargetCanonicalID(target))
 	})
 	for _, result := range results {
 		logLifecycleOutcome(stderr, "interrupt", 0, result.target.name, result.target.template, result.outcome, result.started, result.finished, result.err)

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -2957,18 +2957,20 @@ func reachableSelectedDependencies(
 // executeTargetWave runs each target's run() under a bounded-parallelism
 // semaphore and returns a stopResult per target. perTargetTimeout caps the
 // wall-clock each goroutine waits for run() to return; on expiry, that
-// target's outcome is "timed_out" and the inner goroutine is intentionally
-// leaked. Callers must only pass run functions that are wall-clock bounded by
-// their provider implementation; tmux satisfies this with its subprocess
-// timeout. Non-tmux providers must enforce an equivalent bound before using
-// this helper on long-lived controller paths. perTargetTimeout <= 0 means no
-// timeout (legacy behavior; useful only for tests that bypass the timeout).
+// target's outcome is "timed_out" and the inner goroutine may continue
+// running. Callers that must wait for those inner goroutines to finish
+// before releasing shared resources can call the returned wait function.
+// Callers must only pass run functions that are wall-clock bounded by their
+// provider implementation; tmux satisfies this with its subprocess timeout.
+// Non-tmux providers must enforce an equivalent bound before using this helper
+// on long-lived controller paths. perTargetTimeout <= 0 means no timeout
+// (legacy behavior; useful only for tests that bypass the timeout).
 func executeTargetWave(
 	targets []stopTarget,
 	maxParallel int,
 	perTargetTimeout time.Duration,
 	run func(stopTarget) error,
-) []stopResult {
+) ([]stopResult, func()) {
 	return executeTargetWaveUntil(targets, maxParallel, perTargetTimeout, nil, run)
 }
 
@@ -2978,14 +2980,15 @@ func executeTargetWaveUntil(
 	perTargetTimeout time.Duration,
 	shouldStop func() bool,
 	run func(stopTarget) error,
-) []stopResult {
+) ([]stopResult, func()) {
 	if len(targets) == 0 {
-		return nil
+		return nil, func() {}
 	}
 	if maxParallel <= 0 {
 		maxParallel = 1
 	}
 	results := make([]stopResult, len(targets))
+	var innerWg sync.WaitGroup
 	sem := make(chan struct{}, maxParallel)
 	done := make(chan int, len(targets))
 	stopCh, stopWatchDone := lifecycleStopSignal(shouldStop)
@@ -3038,7 +3041,9 @@ launchLoop:
 				outcome  string
 			}
 			inner := make(chan runResult, 1)
+			innerWg.Add(1)
 			go func() {
+				defer innerWg.Done()
 				defer func() {
 					if recovered := recover(); recovered != nil {
 						stack := debug.Stack()
@@ -3098,7 +3103,7 @@ launchLoop:
 	for completed := 0; completed < launched; completed++ {
 		<-done
 	}
-	return results
+	return results, innerWg.Wait
 }
 
 func lifecycleStopSignal(shouldStop func() bool) (<-chan struct{}, func()) {
@@ -3365,7 +3370,7 @@ func interruptTargetsBoundedWithForceSignal(targets []stopTarget, cfg *config.Ci
 
 	if len(poolManaged) > 0 {
 		waveStarted := time.Now()
-		results := executeTargetWave(poolManaged, defaultMaxParallelStopsPerWave, stopPerTargetTimeoutDefault, func(target stopTarget) error {
+		results, _ := executeTargetWave(poolManaged, defaultMaxParallelStopsPerWave, stopPerTargetTimeoutDefault, func(target stopTarget) error {
 			return stopTargetThroughWorkerBoundary(target, store, sp, cfg)
 		})
 		for _, result := range results {
@@ -3383,7 +3388,7 @@ func interruptTargetsBoundedWithForceSignal(targets []stopTarget, cfg *config.Ci
 		return sent
 	}
 	waveStarted := time.Now()
-	results := executeTargetWaveUntil(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), shouldStop, func(target stopTarget) error {
+	results, _ := executeTargetWaveUntil(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), shouldStop, func(target stopTarget) error {
 		targetID := strings.TrimSpace(target.sessionID)
 		if targetID == "" {
 			targetID = strings.TrimSpace(target.name)
@@ -3413,6 +3418,43 @@ func stopTargetsBounded(
 	actor string,
 	stdout, stderr io.Writer,
 ) int {
+	return stopTargetsBoundedWithTimeout(targets, cfg, store, sp, rec, actor, stdout, stderr, stopPerTargetTimeoutDefault)
+}
+
+func stopTargetsBoundedWithTimeout(
+	targets []stopTarget,
+	cfg *config.City,
+	store beads.Store,
+	sp runtime.Provider,
+	rec events.Recorder,
+	actor string,
+	stdout, stderr io.Writer,
+	perTargetTimeout time.Duration,
+) int {
+	var drains []func()
+	defer func() {
+		if perTargetTimeout != cleanupMaxWait || len(drains) == 0 {
+			return
+		}
+		// Wait up to cleanupMaxWait for the inner provider goroutines (which
+		// were abandoned after perTargetTimeout fired) to finish, so forced-stop
+		// teardown does not race still-running Stop/Kill calls.
+		done := make(chan struct{})
+		var drainWg sync.WaitGroup
+		for _, d := range drains {
+			drainWg.Add(1)
+			go func(drain func()) {
+				defer drainWg.Done()
+				drain()
+			}(d)
+		}
+		go func() { drainWg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(cleanupMaxWait):
+			fmt.Fprintf(stderr, "session lifecycle: forced-stop wave drain did not finish within %s; proceeding with teardown\n", cleanupMaxWait) //nolint:errcheck
+		}
+	}()
 	targets = hydrateStopTargets(targets, cfg, store, stderr)
 	for _, target := range targets {
 		if !target.resolved {
@@ -3422,9 +3464,10 @@ func stopTargetsBounded(
 			stopped := 0
 			for wave, target := range targets {
 				waveStarted := time.Now()
-				results := executeTargetWave([]stopTarget{target}, 1, stopPerTargetTimeoutDefault, func(target stopTarget) error {
+				results, drainFn := executeTargetWave([]stopTarget{target}, 1, perTargetTimeout, func(target stopTarget) error {
 					return stopTargetThroughWorkerBoundary(target, store, sp, cfg)
 				})
+				drains = append(drains, drainFn)
 				for _, result := range results {
 					if shouldLogStopOutcome(result.target, cfg) {
 						logLifecycleOutcome(stderr, "stop", wave, result.target.name, result.target.template, result.outcome, result.started, result.finished, result.err)
@@ -3467,9 +3510,10 @@ func stopTargetsBounded(
 				waveTargets = append(waveTargets, target)
 			}
 		}
-		results := executeTargetWave(waveTargets, defaultMaxParallelStopsPerWave, stopPerTargetTimeoutDefault, func(target stopTarget) error {
+		results, drainFn := executeTargetWave(waveTargets, defaultMaxParallelStopsPerWave, perTargetTimeout, func(target stopTarget) error {
 			return stopTargetThroughWorkerBoundary(target, store, sp, cfg)
 		})
+		drains = append(drains, drainFn)
 		for _, result := range results {
 			if shouldLogStopOutcome(result.target, cfg) {
 				logLifecycleOutcome(stderr, "stop", wave, result.target.name, result.target.template, result.outcome, result.started, result.finished, result.err)

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -5660,7 +5660,7 @@ func TestExecutePreparedStartWave_PanicIncludesStackTrace(t *testing.T) {
 }
 
 func TestExecuteTargetWave_PanicIncludesStackTrace(t *testing.T) {
-	results := executeTargetWave([]stopTarget{{name: "worker"}}, 1, time.Second, func(stopTarget) error {
+	results, _ := executeTargetWave([]stopTarget{{name: "worker"}}, 1, time.Second, func(stopTarget) error {
 		panic("boom")
 	})
 	if len(results) != 1 {

--- a/cmd/gc/supervisor_stop_bounded_test.go
+++ b/cmd/gc/supervisor_stop_bounded_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// blockingListProvider stands in for any shutdown-path call that wedges on an
+// unresponsive backend (a bd read against a swap-thrashing dolt, a tmux list
+// against a starved server): ListRunning blocks until release is closed.
+type blockingListProvider struct {
+	runtime.Provider
+	entered chan struct{}
+	release chan struct{}
+	once    atomic.Bool
+}
+
+func (p *blockingListProvider) ListRunning(prefix string) ([]string, error) {
+	if p.once.CompareAndSwap(false, true) {
+		close(p.entered)
+		<-p.release
+	}
+	return p.Provider.ListRunning(prefix)
+}
+
+// TestStopManagedCityBoundsAForcedStopWhileShutdownIsAlreadyRunning covers
+// issue #5256: the city's run loop had already entered CityRuntime.shutdown()
+// when its context was canceled, so the forced-stop escalation blocked in
+// shutdownOnce.Do behind that in-flight shutdown and its own forced timeout
+// never got a chance to fire.
+func TestStopManagedCityBoundsAForcedStopWhileShutdownIsAlreadyRunning(t *testing.T) {
+	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "mem:")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	sp := &blockingListProvider{
+		Provider: runtime.NewFake(),
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	cr := &CityRuntime{
+		cfg: &config.City{
+			Daemon: config.DaemonConfig{ShutdownTimeout: "20ms"},
+		},
+		sp:                sp,
+		rec:               events.Discard,
+		stdout:            io.Discard,
+		stderr:            io.Discard,
+		forceStopShutdown: &atomic.Bool{},
+	}
+	mc := &managedCity{
+		name:   "bright-lights",
+		cancel: func() {},
+		done:   make(chan struct{}), // the city goroutine never gets to exit
+		cr:     cr,
+	}
+
+	panicCh := make(chan any, 1)
+	shutdownDone := make(chan struct{})
+	var releaseOnce sync.Once
+	closeRelease := func() { releaseOnce.Do(func() { close(sp.release) }) }
+	defer func() {
+		closeRelease()
+		<-shutdownDone
+	}()
+
+	// The run loop's deferred shutdown is already in flight and wedged.
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+			close(shutdownDone)
+		}()
+		cr.shutdown()
+	}()
+
+	select {
+	case <-sp.entered:
+	case <-time.After(time.Second):
+		closeRelease()
+		<-shutdownDone
+		select {
+		case r := <-panicCh:
+			t.Fatalf("cr.shutdown() panicked before reaching provider: %v", r)
+		default:
+			t.Fatal("shutdown never reached the wedged provider call")
+		}
+	}
+
+	returned := make(chan error, 1)
+	start := time.Now()
+	go func() { returned <- stopManagedCity(mc, cityPath, &bytes.Buffer{}) }()
+
+	// grace (20ms) + forced (5x = 100ms) plus generous slack.
+	select {
+	case err := <-returned:
+		closeRelease()
+		<-shutdownDone
+		select {
+		case r := <-panicCh:
+			t.Fatalf("cr.shutdown() panicked: %v", r)
+		default:
+		}
+		if err == nil {
+			t.Fatal("stopManagedCity err = nil, want non-nil because the city never exited")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("stop still blocked after %s: the forced-stop timeout "+
+			"cannot fire when cr.shutdown() is called synchronously into an "+
+			"already-held shutdownOnce (#5256)", time.Since(start))
+	}
+}


### PR DESCRIPTION
## Summary

This is the upstream counterpart of ThePlenkov/gascity#5, rebased onto `gastownhall/gascity:main` (resolved a conflict in `cmd/gc/city_runtime.go` around `CityRuntime.shutdown`).

- `stopManagedCity` escalates to a forced shutdown after the grace period, but it called `mc.cr.shutdown()` **synchronously**. By then `mc.cancel()` has usually let the city's own run loop enter `CityRuntime.shutdown()`, which holds `shutdownOnce`. If that in-flight shutdown is wedged on an unresponsive backend, the forced call blocks inside `sync.Once` — so the `select` carrying the forced-stop deadline is never reached and the nominal 5x budget can never fire. That is the `gc supervisor stop` "never returns" mechanism in #5256.
- Fix: run the forced shutdown on its own goroutine, so the existing timeout `select` gets to run:

  ```go
  forced = forceShutdownAsync(mc.cr)     // was: synchronous mc.cr.shutdown()
  if forceTimeout <= 0 { <-forced } else {
      select { case <-mc.done: ...; case <-time.After(forceTimeout): ... }
  }
  ```
- Timeout values, error/stderr wording, and the subsequent `shutdownBeadsProvider`/closer cleanup are unchanged. `stopManagedCityPreservingSessions` deliberately stays synchronous: preserve mode must observe services and the tmux server actually tearing down (#5175).
- Scope note: this is only the bounded-forced-stop defect. The `healthBeadsProvider` → `context.Background()` anchoring and the unbounded `systemctl --user stop` path from the same investigation are intentionally **not** touched here.

## Testing

- [x] `golangci-lint run cmd/gc/...` (0 issues), `gofmt -w cmd/gc/city_runtime.go`, `go vet ./cmd/gc`
- [x] `go test ./cmd/gc -run 'TestStopManagedCity|TestSupervisorStop|TestCityRuntimeShutdown|TestForcedStop|TestCleanupAfterStop' -race` — pass
- [ ] `make check` (full `go test ./cmd/gc/` has pre-existing failures in `TestBuildRegistryPublish*` and `TestOrderExecEnv*` that also fail at unmodified `main`)
- [ ] `make test-integration`

## Checklist

- [x] Linked an issue: gastownhall/gascity#5256
- [x] Added a regression test: `cmd/gc/supervisor_stop_bounded_test.go` wedges a provider call while `CityRuntime.shutdown()` is inside `shutdownOnce.Do` and asserts `stopManagedCity` returns within its own budget
- [x] No user-facing docs change (internal shutdown sequencing only)
- [x] No breaking changes
- [x] Resolved merge conflict with `gastownhall/gascity:main` in `cmd/gc/city_runtime.go` (kept the forced-stop async split and added `unregisterResidencyRoutes` before `closeStorageRoutes`)
