### PR TITLE
Sync bd flag manifest with bd v1.1.0

### DIFF
--- a/internal/bdflags/bdargs_test.go
+++ b/internal/bdflags/bdargs_test.go
@@ -45,15 +45,16 @@ func TestSplitGlobalFlagsSkipsGlobalFlagValues(t *testing.T) {
 // bypass below: SplitGlobalFlags would read that flag's value as the verb, and
 // every guard keyed off the verb stops firing — with no test failing.
 //
-// Sourced from `bd --help` (bd 1.1.0). bd declares exactly four persistent
-// flags that consume the next argument; -C and --directory are the two spellings
-// of one of them. Every other persistent flag (--global, --ignore-schema-skew,
-// --json, --profile, -q/--quiet, --readonly, --sandbox, -v/--verbose, -h/--help,
-// -V/--version) is boolean and consumes nothing.
+// Sourced from `bd --help` (bd 1.1.0, build 0954be416). bd declares six
+// persistent flags that consume the next argument: --actor, --database, --db,
+// --dolt-auto-commit, --mem-profile, and -C/--directory (the two spellings of
+// one). Every other persistent flag (--cpu-profile, --global,
+// --ignore-schema-skew, --json, --no-color, -q/--quiet, --readonly, --sandbox,
+// -v/--verbose, -h/--help, -V/--version) is boolean and consumes nothing.
 func TestGlobalValueFlagsIsComplete(t *testing.T) {
 	want := map[string]bool{
-		"--actor": true, "--db": true, "-C": true, "--directory": true,
-		"--dolt-auto-commit": true,
+		"--actor": true, "--database": true, "--db": true, "-C": true,
+		"--directory": true, "--dolt-auto-commit": true, "--mem-profile": true,
 	}
 	if got := GlobalValueFlags(); !reflect.DeepEqual(got, want) {
 		t.Errorf("GlobalValueFlags() = %v, want %v; re-check `bd --help` persistent flags", got, want)
@@ -66,12 +67,15 @@ func TestGlobalValueFlagsIsComplete(t *testing.T) {
 // guard has to fall back — reads a flag missing from this table as unknown, and
 // silently takes the ambiguous branch for an ordinary bd invocation.
 //
-// Sourced from `bd --help` (bd 1.1.0), the same pass as the value-flag table.
+// Sourced from `bd --help` (bd 1.1.0, build 0954be416), the same pass as the
+// value-flag table. bd rejects a bare --profile as "unknown flag" (only
+// --cpu-profile and --mem-profile exist) — do not reintroduce it here.
 func TestGlobalBoolFlagsIsComplete(t *testing.T) {
 	want := map[string]bool{
-		"--global": true, "--ignore-schema-skew": true, "--json": true,
-		"--profile": true, "-q": true, "--quiet": true, "--readonly": true,
-		"--sandbox": true, "-v": true, "--verbose": true, "-h": true, "--help": true,
+		"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true,
+		"--json": true, "--no-color": true, "-q": true, "--quiet": true,
+		"--readonly": true, "--sandbox": true, "-v": true, "--verbose": true,
+		"-h": true, "--help": true,
 	}
 	if got := GlobalBoolFlags(); !reflect.DeepEqual(got, want) {
 		t.Errorf("GlobalBoolFlags() = %v, want %v; re-check `bd --help` persistent flags", got, want)

--- a/internal/bdflags/bdargs_test.go
+++ b/internal/bdflags/bdargs_test.go
@@ -68,12 +68,14 @@ func TestGlobalValueFlagsIsComplete(t *testing.T) {
 // silently takes the ambiguous branch for an ordinary bd invocation.
 //
 // Sourced from `bd --help` (bd 1.1.0, build 0954be416), the same pass as the
-// value-flag table. bd rejects a bare --profile as "unknown flag" (only
-// --cpu-profile and --mem-profile exist) — do not reintroduce it here.
+// value-flag table. --profile is the pre-rename spelling of --cpu-profile: the
+// released bd v1.1.0 binary CI installs still exposes it as a persistent bool,
+// so it must stay here even though this build no longer accepts it. The table
+// is a superset allowlist over every supported bd build, not a snapshot of one.
 func TestGlobalBoolFlagsIsComplete(t *testing.T) {
 	want := map[string]bool{
 		"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true,
-		"--json": true, "--no-color": true, "-q": true, "--quiet": true,
+		"--json": true, "--no-color": true, "--profile": true, "-q": true, "--quiet": true,
 		"--readonly": true, "--sandbox": true, "-v": true, "--verbose": true,
 		"-h": true, "--help": true,
 	}

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -3,7 +3,7 @@
 // and the gc lint check that validates bd invocations embedded in prompt
 // templates, so the two call sites cannot drift apart from each other.
 //
-// Sourced from bd <sub> --help output (2026-07-13, bd v1.1.0).
+// Sourced from bd <sub> --help output (2026-08-13, bd v1.1.0, build 0954be416).
 package bdflags
 
 import "sort"
@@ -11,14 +11,14 @@ import "sort"
 // globalValueFlags are accepted by every bd subcommand and consume the next
 // argument as their value.
 var globalValueFlags = map[string]bool{
-	"--actor": true, "--db": true, "-C": true, "--directory": true,
-	"--dolt-auto-commit": true,
+	"--actor": true, "--database": true, "--db": true, "-C": true, "--directory": true,
+	"--dolt-auto-commit": true, "--mem-profile": true,
 }
 
 // globalBoolFlags are accepted by every bd subcommand and take no value.
 var globalBoolFlags = map[string]bool{
-	"--global": true, "--ignore-schema-skew": true, "--json": true,
-	"--profile": true, "-q": true, "--quiet": true, "--readonly": true,
+	"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true, "--json": true,
+	"--no-color": true, "--profile": true, "-q": true, "--quiet": true, "--readonly": true,
 	"--sandbox": true, "-v": true, "--verbose": true, "-h": true, "--help": true,
 }
 
@@ -37,7 +37,7 @@ var valueFlagsBySub = map[string]map[string]bool{
 		"--id": true, "-l": true, "--labels": true, "--metadata": true,
 		"--mol-type": true, "--notes": true, "--parent": true, "-p": true,
 		"--priority": true, "--repo": true, "--skills": true, "--spec-id": true,
-		"-s": true, "--status": true, "--title": true, "-t": true, "--type": true, "--waits-for": true,
+		"-s": true, "--status": true, "--storage-class": true, "--title": true, "-t": true, "--type": true, "--waits-for": true,
 		"--waits-for-gate": true, "--wisp-type": true,
 	},
 	"update": {
@@ -45,7 +45,8 @@ var valueFlagsBySub = map[string]map[string]bool{
 		"-a": true, "--assignee": true, "--await-id": true, "--body-file": true,
 		"--defer": true, "-d": true, "--description": true, "--design": true,
 		"--design-file": true, "--due": true, "-e": true, "--estimate": true,
-		"--external-ref": true, "--metadata": true, "--notes": true,
+		"--external-ref": true, "--if-assignee": true, "--if-status": true,
+		"--metadata": true, "--notes": true,
 		"--parent": true, "-p": true, "--priority": true, "--remove-label": true,
 		"--session": true, "--set-labels": true, "--set-metadata": true,
 		"-s": true, "--status": true, "-t": true, "--type": true,
@@ -63,7 +64,8 @@ var valueFlagsBySub = map[string]map[string]bool{
 	"ready": {
 		"-a": true, "--assignee": true, "--exclude-label": true, "--exclude-type": true,
 		"--has-metadata-key": true, "-l": true, "--label": true, "--label-any": true,
-		"-n": true, "--limit": true, "--metadata-field": true, "--mol": true,
+		"--label-pattern": true, "--label-regex": true,
+		"-n": true, "--limit": true, "--max-rows": true, "--metadata-field": true, "--mol": true,
 		"--mol-type": true, "--offset": true, "--parent": true, "-p": true,
 		"--priority": true, "-s": true, "--sort": true, "-t": true, "--type": true,
 	},
@@ -72,9 +74,10 @@ var valueFlagsBySub = map[string]map[string]bool{
 		"--created-after": true, "--created-before": true, "--defer-after": true,
 		"--defer-before": true, "--desc-contains": true, "--due-after": true,
 		"--due-before": true, "--exclude-label": true, "--exclude-type": true,
+		"--external-contains": true, "--external-ref": true,
 		"--format": true, "--has-metadata-key": true, "--id": true, "-l": true,
 		"--label": true, "--label-any": true, "--label-pattern": true,
-		"--label-regex": true, "-n": true, "--limit": true, "--metadata-field": true,
+		"--label-regex": true, "-n": true, "--limit": true, "--max-rows": true, "--metadata-field": true,
 		"--mol-type": true, "--notes-contains": true, "--offset": true,
 		"--parent": true, "-p": true, "--priority": true, "--priority-max": true,
 		"--priority-min": true, "--sort": true, "--spec": true, "-s": true,
@@ -114,12 +117,12 @@ var valueFlagsBySub = map[string]map[string]bool{
 // global set. Same keying convention as valueFlagsBySub.
 var boolFlagsBySub = map[string]map[string]bool{
 	"create": {
-		"--dry-run": true, "--ephemeral": true, "--force": true, "--no-history": true,
+		"--allow-empty-description": true, "--dry-run": true, "--ephemeral": true, "--force": true, "--no-history": true,
 		"--no-inherit-labels": true, "--silent": true, "--stdin": true, "--validate": true,
 	},
 	"update": {
 		"--allow-empty-description": true, "--claim": true, "--ephemeral": true,
-		"--history": true, "--no-history": true, "--persistent": true, "--stdin": true,
+		"--force": true, "--history": true, "--no-history": true, "--persistent": true, "--stdin": true,
 	},
 	"close": {
 		"--claim-next": true, "--continue": true, "-f": true, "--force": true,
@@ -130,11 +133,15 @@ var boolFlagsBySub = map[string]map[string]bool{
 		"--cascade": true, "--dry-run": true, "-f": true, "--force": true,
 	},
 	"ready": {
-		"--claim": true, "--explain": true, "--gated": true, "--include-deferred": true,
+		"--brief": true, "--claim": true, "--explain": true, "--gated": true, "--include-deferred": true,
 		"--include-ephemeral": true, "--plain": true, "--pretty": true, "-u": true, "--unassigned": true,
 	},
+	// list's --deps is a pflag optional-value flag (NoOptDefVal): bare --deps
+	// consumes no argument, only --deps=value does. Classified as bool here
+	// for argv-skip-guard purposes, unlike create's --deps which always
+	// consumes a value.
 	"list": {
-		"--all": true, "--deferred": true, "--empty-description": true, "--flat": true,
+		"--all": true, "--brief": true, "--deferred": true, "--deps": true, "--empty-description": true, "--flat": true,
 		"--include-gates": true, "--include-infra": true, "--include-templates": true,
 		"--long": true, "--no-assignee": true, "--no-labels": true, "--no-pager": true,
 		"--no-parent": true, "--no-pinned": true, "--overdue": true, "--pinned": true,
@@ -142,7 +149,7 @@ var boolFlagsBySub = map[string]map[string]bool{
 		"--skip-labels": true, "--tree": true, "-w": true, "--watch": true,
 	},
 	"show": {
-		"--children": true, "--current": true, "--include-comments": true,
+		"--brief-deps": true, "--children": true, "--current": true, "--include-comments": true,
 		"--include-dependents": true, "--local-time": true, "--long": true,
 		"--refs": true, "--short": true, "--thread": true, "-w": true, "--watch": true,
 	},

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -16,9 +16,16 @@ var globalValueFlags = map[string]bool{
 }
 
 // globalBoolFlags are accepted by every bd subcommand and take no value.
+//
+// This table is a superset allowlist across every bd build the fleet and CI
+// run, not a snapshot of one binary. --profile is the pre-rename spelling of
+// --cpu-profile (beads fb52ac6a5, landed after the v1.1.0 tag): the released
+// v1.1.0 binary CI installs still exposes it, so removing it here fails
+// TestBdFlagManifestCurrent on CI even though a newer bd rejects the flag.
+// Entries are safe to keep and dangerous to drop — only ever add.
 var globalBoolFlags = map[string]bool{
 	"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true, "--json": true,
-	"--no-color": true, "-q": true, "--quiet": true, "--readonly": true,
+	"--no-color": true, "--profile": true, "-q": true, "--quiet": true, "--readonly": true,
 	"--sandbox": true, "-v": true, "--verbose": true, "-h": true, "--help": true,
 }
 

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -18,7 +18,7 @@ var globalValueFlags = map[string]bool{
 // globalBoolFlags are accepted by every bd subcommand and take no value.
 var globalBoolFlags = map[string]bool{
 	"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true, "--json": true,
-	"--no-color": true, "--profile": true, "-q": true, "--quiet": true, "--readonly": true,
+	"--no-color": true, "-q": true, "--quiet": true, "--readonly": true,
 	"--sandbox": true, "-v": true, "--verbose": true, "-h": true, "--help": true,
 }
 

--- a/release-gates/ga-o0pdkh-bdflags-manifest-gate.md
+++ b/release-gates/ga-o0pdkh-bdflags-manifest-gate.md
@@ -3,8 +3,10 @@
 Deploy bead: ga-o0pdkh
 Source implementation bead: ga-gqxh5s
 Review bead: ga-i8rhmj
+Post-review fix bead: ga-d5m4ac
 Deploy branch: deploy/ga-o0pdkh-gate
 Reviewed source: 3289b5673985f237fe655170162b89a715b84269
+Current PR source: 570e38be5ce7cdf45cb0efc6a911c6fa70170e87
 Reviewed branch: builder/ga-gqxh5s (provenance only)
 Base checked: origin/main at b63623d08ecf565de82c226f0af1ca2fc359d45d
 Merge base: cb456b85ecd923186a50493074f8b8a4c75d7eac
@@ -14,47 +16,34 @@ Release criteria source: active deployer gate criteria; docs/PROJECT_MANIFEST.md
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | Review bead ga-i8rhmj is closed with reason `pass`; its notes record `verdict: pass` for the exact reviewed source and report no style or security findings. |
-| 2 | Acceptance criteria met | PASS | See the acceptance table below. The live manifest freshness test passed all 17 known bd subcommands against bd 1.1.0 build 0954be416. |
-| 3 | Tests pass | PASS | On the exact reviewed source, `go build ./...` and `go vet ./...` exited 0, formatting was clean, and `make test-fast-parallel` passed 10/10 jobs. The full `internal/bdflags` integration-tagged package run completed 26 top-level tests: 26 PASS, 0 FAIL, 0 SKIP. `TestBdFlagManifestCurrent` separately passed all 17 subcommand cases. `diff_tests_executed`: `TestGlobalValueFlagsIsComplete` PASS; `TestGlobalBoolFlagsIsComplete` PASS. `skip_justification`: none; zero skips. `waiver_ref`: none needed. |
-| 4 | No high-severity review findings open | PASS | ga-i8rhmj records `style_findings: none`, `security_findings: none`, and no unresolved HIGH finding. |
-| 5 | Final branch is clean | PASS | The isolated worktree at the reviewed source reported no path changes before this checklist was written; `git diff --check` also passed. Cleanliness is rechecked after the gate commit and before push. |
-| 6 | Branch diverges cleanly from main | PASS | The already-merged preflight found no PR carrying 3289b567. `git merge-tree --write-tree origin/main 3289b567...` exited 0 and produced tree 27716356558e2ffd09f07d1e1a5a6faa3b9bd3c2. No self-rebase was needed. |
-| 7 | Single feature theme | PASS | The two feature commits touch only `internal/bdflags/bdflags.go` and `internal/bdflags/bdargs_test.go`, updating one static CLI-flag manifest and its pinned completeness tests. |
+| 1 | Review PASS present | FAIL | Review bead ga-i8rhmj is closed with reason `pass`, but its verdict covers 3289b5673985f237fe655170162b89a715b84269. The current PR head adds post-review fix 570e38be5ce7cdf45cb0efc6a911c6fa70170e87; no reviewer PASS for that commit is recorded. |
+| 2 | Acceptance criteria met | PASS | See the acceptance table below. The live manifest freshness test passed all 17 known bd subcommands against both relevant bd builds: the released v1.1.0 source at beads 8e4e59d39 and the fleet build 0954be416. |
+| 3 | Tests pass | FAIL | `make test-fast-parallel` completed 9/10 jobs successfully and failed `unit-cmd-gc-4-of-6`: `TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep` reported `force shutdown missed the late async-started runtime`. The failure is outside this diff, but TESTING.md forbids retrying a deterministic product-test failure into green. The focused `internal/bdflags` integration-tagged suite passed against each supported bd build with 53 PASS, 0 FAIL, 0 SKIP. `diff_tests_executed`: `TestGlobalValueFlagsIsComplete` PASS; `TestGlobalBoolFlagsIsComplete` PASS. `skip_justification`: none; zero skips. `waiver_ref`: none. |
+| 4 | No high-severity review findings open | PASS | ga-i8rhmj records `style_findings: none`, `security_findings: none`, and no unresolved HIGH finding. The missing review coverage for 570e38be is recorded separately under criterion 1. |
+| 5 | Final branch is clean | PASS | The isolated worktree at 570e38be5ce7cdf45cb0efc6a911c6fa70170e87 was clean before this checklist update; `git diff --check origin/main...HEAD` passed. |
+| 6 | Branch diverges cleanly from main | PASS | The already-merged preflight found PR 5284 open, not merged. `git merge-tree --write-tree origin/main origin/deploy/ga-o0pdkh-gate` exited 0 and produced tree d2b460c7663ba0412a89d41b5266bdd0fc0533b3. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The feature commits touch only `internal/bdflags/bdflags.go` and `internal/bdflags/bdargs_test.go`, updating one static CLI-flag manifest and its pinned completeness tests. |
 
 ## Acceptance Evidence
 
 | Acceptance item | Result | Evidence |
 |-----------------|--------|----------|
-| Reflect every installed bd flag for all 17 known subcommands without removing real coverage. | PASS | `TestBdFlagManifestCurrent` passed `close`, `create`, `delete`, dependency, gate, list, molecule, ready, reopen, show, and update cases. The installed binary reports `bd version 1.1.0 (0954be416)`; its global help includes `--cpu-profile`, `--database`, `--mem-profile`, and `--no-color`. A direct `bd --profile` check returns `unknown flag`, confirming the removed manifest entry was not real coverage. |
-| Pass the live freshness contract. | PASS | `go test -count=1 -tags integration -run '^TestBdFlagManifestCurrent$' -v ./internal/bdflags/...` passed the parent test and all 17 named subtests with 0 failures and 0 skips. |
-| Update manifest provenance to the installed build. | PASS | `internal/bdflags/bdflags.go` identifies the source as 2026-08-13, bd v1.1.0, build 0954be416, matching `bd version`. |
+| Reflect every supported bd flag for all 17 known subcommands without removing real coverage. | PASS | `TestBdFlagManifestCurrent` passed all 17 subcommands against both supported builds. The released v1.1.0 source at beads 8e4e59d39 still exposes persistent `--profile`; fleet build 0954be416 exposes its newer `--cpu-profile` spelling. The manifest intentionally retains both as a compatibility superset. |
+| Pass the live freshness contract. | PASS | `go test -count=1 -tags integration -json ./internal/bdflags/...` completed 53 PASS, 0 FAIL, 0 SKIP against each bd build. `TestBdFlagManifestCurrent`, `TestGlobalValueFlagsIsComplete`, and `TestGlobalBoolFlagsIsComplete` all passed in both runs. |
+| Keep manifest provenance and compatibility intent explicit. | PASS | `internal/bdflags/bdflags.go` identifies the fleet source as 2026-08-13, bd v1.1.0 build 0954be416, and documents that the bool table is a superset across the released and fleet builds, including the pre-rename `--profile` spelling. |
 
 ## Commands Run
 
 ```text
-gh api repos/gastownhall/gascity/commits/3289b5673985f237fe655170162b89a715b84269/pulls
-git merge-tree --write-tree origin/main 3289b5673985f237fe655170162b89a715b84269
-go build ./...
-go vet ./...
-gofmt -l internal/bdflags
+gh pr view 5284 --json state,mergedAt,mergeCommit,author,headRefOid
+git merge-tree --write-tree origin/main origin/deploy/ga-o0pdkh-gate
+git diff --check origin/main...HEAD
+TMPDIR=/var/tmp DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true make test-fast-parallel
 go test -count=1 -tags integration -json ./internal/bdflags/...
-go test -count=1 -tags integration -run '^TestBdFlagManifestCurrent$' -v ./internal/bdflags/...
-TMPDIR=/var/tmp EXTRA_TEST_ENV="DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true" make test-fast-parallel
-git diff --check
+PATH=<bd-built-from-beads-8e4e59d39>:$PATH go test -count=1 -tags integration -json ./internal/bdflags/...
 ```
 
-The rootless Podman socket was present and exported before criterion 3. This diff and its owned tests are pure Go and did not require a container.
-
-## Publication Hook Follow-up
-
-An additional pre-push invocation reran the 10-job fast suite with three concurrent workers and reported one failure in `TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep`. That timing-sensitive `cmd/gc` lifecycle test is outside this two-file `internal/bdflags` diff and had passed in the criterion-3 run. An immediate focused rerun completed 50/50 iterations successfully:
-
-```text
-TMPDIR=/var/tmp GC_FAST_UNIT=1 go test -count=50 -run '^TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep$' ./cmd/gc
-```
-
-The first full gate remains the criterion-3 result; publication still requires a fresh successful pre-push hook.
+The rootless Podman socket was present and exported before criterion 3. This diff and its owned tests are pure Go and did not require a container. The aggregate failure log is `/var/tmp/gc-local-tests.YNRDJr/unit-cmd-gc-4-of-6.log` in the deployer environment.
 
 ## Touched Files
 

--- a/release-gates/ga-o0pdkh-bdflags-manifest-gate.md
+++ b/release-gates/ga-o0pdkh-bdflags-manifest-gate.md
@@ -1,53 +1,57 @@
-# Release Gate: synchronize the bd flag manifest with bd v1.1.0
+# Release Gate: synchronize the bd flag manifest with supported bd v1.1.0 builds
 
 Deploy bead: ga-o0pdkh
-Source implementation bead: ga-gqxh5s
-Review bead: ga-i8rhmj
-Post-review fix bead: ga-d5m4ac
+Implementation bead: ga-gqxh5s
+Initial review bead: ga-i8rhmj
+Follow-up review bead: ga-7huhms
 Deploy branch: deploy/ga-o0pdkh-gate
-Reviewed source: 3289b5673985f237fe655170162b89a715b84269
-Current PR source: 570e38be5ce7cdf45cb0efc6a911c6fa70170e87
-Reviewed branch: builder/ga-gqxh5s (provenance only)
+Initial reviewed source: 3289b5673985f237fe655170162b89a715b84269
+Current reviewed PR source: 570e38be5ce7cdf45cb0efc6a911c6fa70170e87
 Base checked: origin/main at b63623d08ecf565de82c226f0af1ca2fc359d45d
 Merge base: cb456b85ecd923186a50493074f8b8a4c75d7eac
-Release criteria source: active deployer gate criteria; docs/PROJECT_MANIFEST.md is not present on origin/main.
 
 ## Gate Summary
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | FAIL | Review bead ga-i8rhmj is closed with reason `pass`, but its verdict covers 3289b5673985f237fe655170162b89a715b84269. The current PR head adds post-review fix 570e38be5ce7cdf45cb0efc6a911c6fa70170e87; no reviewer PASS for that commit is recorded. |
-| 2 | Acceptance criteria met | PASS | See the acceptance table below. The live manifest freshness test passed all 17 known bd subcommands against both relevant bd builds: the released v1.1.0 source at beads 8e4e59d39 and the fleet build 0954be416. |
-| 3 | Tests pass | FAIL | `make test-fast-parallel` completed 9/10 jobs successfully and failed `unit-cmd-gc-4-of-6`: `TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep` reported `force shutdown missed the late async-started runtime`. The failure is outside this diff, but TESTING.md forbids retrying a deterministic product-test failure into green. The focused `internal/bdflags` integration-tagged suite passed against each supported bd build with 53 PASS, 0 FAIL, 0 SKIP. `diff_tests_executed`: `TestGlobalValueFlagsIsComplete` PASS; `TestGlobalBoolFlagsIsComplete` PASS. `skip_justification`: none; zero skips. `waiver_ref`: none. |
-| 4 | No high-severity review findings open | PASS | ga-i8rhmj records `style_findings: none`, `security_findings: none`, and no unresolved HIGH finding. The missing review coverage for 570e38be is recorded separately under criterion 1. |
-| 5 | Final branch is clean | PASS | The isolated worktree at 570e38be5ce7cdf45cb0efc6a911c6fa70170e87 was clean before this checklist update; `git diff --check origin/main...HEAD` passed. |
-| 6 | Branch diverges cleanly from main | PASS | The already-merged preflight found PR 5284 open, not merged. `git merge-tree --write-tree origin/main origin/deploy/ga-o0pdkh-gate` exited 0 and produced tree d2b460c7663ba0412a89d41b5266bdd0fc0533b3. No self-rebase was needed. |
-| 7 | Single feature theme | PASS | The feature commits touch only `internal/bdflags/bdflags.go` and `internal/bdflags/bdargs_test.go`, updating one static CLI-flag manifest and its pinned completeness tests. |
+| 1 | Review PASS present | PASS | ga-i8rhmj is closed `pass` for the initial implementation through 3289b5673985f237fe655170162b89a715b84269. ga-7huhms is closed `pass` for the exact post-review delta from f90f0a04eac870b31440e04e449f075ef043d332 through current PR head 570e38be5ce7cdf45cb0efc6a911c6fa70170e87. |
+| 2 | Acceptance criteria met | PASS | The manifest is a compatibility superset across both supported bd v1.1.0 builds. `TestBdFlagManifestCurrent` passed all 17 subcommands against fleet build 0954be416 and checksum-pinned CI release build 8e4e59d39. The provenance and compatibility comments name the two-build boundary. |
+| 3 | Tests pass | PASS | `make test-fast-parallel`: 10 PASS jobs, 0 FAIL, 0 SKIP. `make test-cmd-gc-process-parallel`: 7 PASS jobs, 0 FAIL, 0 SKIP, including all six `GC_FAST_UNIT=0` shards and product-metrics. Focused regression: `TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep` 10 PASS, 0 FAIL, 0 SKIP. Manifest contract: 17/17 subtests PASS against each supported bd build. `diff_tests_executed`: `TestGlobalValueFlagsIsComplete` PASS; `TestGlobalBoolFlagsIsComplete` PASS. `waiver_ref`: none. Live PR checks independently observed at 58 SUCCESS, 34 SKIPPED, 0 FAILURE; the skips are path-gated jobs outside this `internal/bdflags/**` change, while all 12 required `cmd/gc process` checks succeeded. |
+| 4 | No high-severity review findings open | PASS | ga-i8rhmj records no style or security findings. ga-7huhms records no high-severity finding on the post-review two-file delta. |
+| 5 | Final branch is clean | PASS | The checklist was committed on the isolated deploy branch; `git status --porcelain` returned empty and `git diff --check origin/main...HEAD` passed afterward. |
+| 6 | Branch diverges cleanly from main | PASS | Already-merged pre-flight found PR #5284 OPEN, not merged. `git merge-tree --write-tree origin/main HEAD` exited 0 on the final gate tip. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The feature changes only `internal/bdflags/bdflags.go` and `internal/bdflags/bdargs_test.go`, updating one CLI-flag classifier manifest and its completeness tests. The release-gate file is audit evidence for that same feature. |
 
 ## Acceptance Evidence
 
 | Acceptance item | Result | Evidence |
 |-----------------|--------|----------|
-| Reflect every supported bd flag for all 17 known subcommands without removing real coverage. | PASS | `TestBdFlagManifestCurrent` passed all 17 subcommands against both supported builds. The released v1.1.0 source at beads 8e4e59d39 still exposes persistent `--profile`; fleet build 0954be416 exposes its newer `--cpu-profile` spelling. The manifest intentionally retains both as a compatibility superset. |
-| Pass the live freshness contract. | PASS | `go test -count=1 -tags integration -json ./internal/bdflags/...` completed 53 PASS, 0 FAIL, 0 SKIP against each bd build. `TestBdFlagManifestCurrent`, `TestGlobalValueFlagsIsComplete`, and `TestGlobalBoolFlagsIsComplete` all passed in both runs. |
-| Keep manifest provenance and compatibility intent explicit. | PASS | `internal/bdflags/bdflags.go` identifies the fleet source as 2026-08-13, bd v1.1.0 build 0954be416, and documents that the bool table is a superset across the released and fleet builds, including the pre-rename `--profile` spelling. |
+| Reflect every supported bd flag for all 17 known subcommands without removing real coverage. | PASS | `TestBdFlagManifestCurrent` passed 17/17 subcommands against both builds. Released v1.1.0 build 8e4e59d39 accepts persistent `--profile`; fleet build 0954be416 accepts the renamed `--cpu-profile`. Retaining both is the required compatibility superset. |
+| Pass the live freshness contract. | PASS | Fleet build: 17 PASS subtests, 0 FAIL, 0 SKIP. CI release build: 17 PASS subtests, 0 FAIL, 0 SKIP. |
+| Keep manifest provenance and compatibility intent explicit. | PASS | `internal/bdflags/bdflags.go` identifies the fleet source date/build and documents the released-vs-fleet compatibility boundary, including the pre-rename `--profile` spelling. |
 
 ## Commands Run
 
 ```text
-gh pr view 5284 --json state,mergedAt,mergeCommit,author,headRefOid
+gh pr view https://github.com/gastownhall/gascity/pull/5284 --json ...
 git merge-tree --write-tree origin/main origin/deploy/ga-o0pdkh-gate
+make test-fast-parallel
+make test-cmd-gc-process-parallel
+go test ./cmd/gc -run '^TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep$' -count=10 -v
+go test ./internal/bdflags/... -run '^(TestGlobalValueFlagsIsComplete|TestGlobalBoolFlagsIsComplete)$' -count=1 -v
+go test ./internal/bdflags/... -tags integration -run '^TestBdFlagManifestCurrent$' -count=1 -v
+PATH=<checksum-pinned-bd-v1.1.0>:$PATH go test ./internal/bdflags/... -tags integration -run '^TestBdFlagManifestCurrent$' -count=1 -v
+go build ./...
+go vet ./...
 git diff --check origin/main...HEAD
-TMPDIR=/var/tmp DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true make test-fast-parallel
-go test -count=1 -tags integration -json ./internal/bdflags/...
-PATH=<bd-built-from-beads-8e4e59d39>:$PATH go test -count=1 -tags integration -json ./internal/bdflags/...
 ```
 
-The rootless Podman socket was present and exported before criterion 3. This diff and its owned tests are pure Go and did not require a container. The aggregate failure log is `/var/tmp/gc-local-tests.YNRDJr/unit-cmd-gc-4-of-6.log` in the deployer environment.
+The rootless Podman socket was available before criterion 3. These selected CI-equivalent lanes and the diff-owned tests do not require testcontainers; the changed package is pure Go and shells out only to `bd` for its integration freshness check.
 
 ## Touched Files
 
 ```text
 internal/bdflags/bdargs_test.go
 internal/bdflags/bdflags.go
+release-gates/ga-o0pdkh-bdflags-manifest-gate.md
 ```

--- a/release-gates/ga-o0pdkh-bdflags-manifest-gate.md
+++ b/release-gates/ga-o0pdkh-bdflags-manifest-gate.md
@@ -1,0 +1,64 @@
+# Release Gate: synchronize the bd flag manifest with bd v1.1.0
+
+Deploy bead: ga-o0pdkh
+Source implementation bead: ga-gqxh5s
+Review bead: ga-i8rhmj
+Deploy branch: deploy/ga-o0pdkh-gate
+Reviewed source: 3289b5673985f237fe655170162b89a715b84269
+Reviewed branch: builder/ga-gqxh5s (provenance only)
+Base checked: origin/main at b63623d08ecf565de82c226f0af1ca2fc359d45d
+Merge base: cb456b85ecd923186a50493074f8b8a4c75d7eac
+Release criteria source: active deployer gate criteria; docs/PROJECT_MANIFEST.md is not present on origin/main.
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-i8rhmj is closed with reason `pass`; its notes record `verdict: pass` for the exact reviewed source and report no style or security findings. |
+| 2 | Acceptance criteria met | PASS | See the acceptance table below. The live manifest freshness test passed all 17 known bd subcommands against bd 1.1.0 build 0954be416. |
+| 3 | Tests pass | PASS | On the exact reviewed source, `go build ./...` and `go vet ./...` exited 0, formatting was clean, and `make test-fast-parallel` passed 10/10 jobs. The full `internal/bdflags` integration-tagged package run completed 26 top-level tests: 26 PASS, 0 FAIL, 0 SKIP. `TestBdFlagManifestCurrent` separately passed all 17 subcommand cases. `diff_tests_executed`: `TestGlobalValueFlagsIsComplete` PASS; `TestGlobalBoolFlagsIsComplete` PASS. `skip_justification`: none; zero skips. `waiver_ref`: none needed. |
+| 4 | No high-severity review findings open | PASS | ga-i8rhmj records `style_findings: none`, `security_findings: none`, and no unresolved HIGH finding. |
+| 5 | Final branch is clean | PASS | The isolated worktree at the reviewed source reported no path changes before this checklist was written; `git diff --check` also passed. Cleanliness is rechecked after the gate commit and before push. |
+| 6 | Branch diverges cleanly from main | PASS | The already-merged preflight found no PR carrying 3289b567. `git merge-tree --write-tree origin/main 3289b567...` exited 0 and produced tree 27716356558e2ffd09f07d1e1a5a6faa3b9bd3c2. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The two feature commits touch only `internal/bdflags/bdflags.go` and `internal/bdflags/bdargs_test.go`, updating one static CLI-flag manifest and its pinned completeness tests. |
+
+## Acceptance Evidence
+
+| Acceptance item | Result | Evidence |
+|-----------------|--------|----------|
+| Reflect every installed bd flag for all 17 known subcommands without removing real coverage. | PASS | `TestBdFlagManifestCurrent` passed `close`, `create`, `delete`, dependency, gate, list, molecule, ready, reopen, show, and update cases. The installed binary reports `bd version 1.1.0 (0954be416)`; its global help includes `--cpu-profile`, `--database`, `--mem-profile`, and `--no-color`. A direct `bd --profile` check returns `unknown flag`, confirming the removed manifest entry was not real coverage. |
+| Pass the live freshness contract. | PASS | `go test -count=1 -tags integration -run '^TestBdFlagManifestCurrent$' -v ./internal/bdflags/...` passed the parent test and all 17 named subtests with 0 failures and 0 skips. |
+| Update manifest provenance to the installed build. | PASS | `internal/bdflags/bdflags.go` identifies the source as 2026-08-13, bd v1.1.0, build 0954be416, matching `bd version`. |
+
+## Commands Run
+
+```text
+gh api repos/gastownhall/gascity/commits/3289b5673985f237fe655170162b89a715b84269/pulls
+git merge-tree --write-tree origin/main 3289b5673985f237fe655170162b89a715b84269
+go build ./...
+go vet ./...
+gofmt -l internal/bdflags
+go test -count=1 -tags integration -json ./internal/bdflags/...
+go test -count=1 -tags integration -run '^TestBdFlagManifestCurrent$' -v ./internal/bdflags/...
+TMPDIR=/var/tmp EXTRA_TEST_ENV="DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true" make test-fast-parallel
+git diff --check
+```
+
+The rootless Podman socket was present and exported before criterion 3. This diff and its owned tests are pure Go and did not require a container.
+
+## Publication Hook Follow-up
+
+An additional pre-push invocation reran the 10-job fast suite with three concurrent workers and reported one failure in `TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep`. That timing-sensitive `cmd/gc` lifecycle test is outside this two-file `internal/bdflags` diff and had passed in the criterion-3 run. An immediate focused rerun completed 50/50 iterations successfully:
+
+```text
+TMPDIR=/var/tmp GC_FAST_UNIT=1 go test -count=50 -run '^TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep$' ./cmd/gc
+```
+
+The first full gate remains the criterion-3 result; publication still requires a fresh successful pre-push hook.
+
+## Touched Files
+
+```text
+internal/bdflags/bdargs_test.go
+internal/bdflags/bdflags.go
+```


### PR DESCRIPTION
## What this changes

Gas City now recognizes the global and subcommand flags exposed across both supported `bd v1.1.0` builds. This keeps the `gc bd` mutation guard and `gc lint` from mistaking flag values for commands or bead IDs when operators use flags such as `--database`, `--mem-profile`, and `--no-color`.

The manifest retains both the released binary's `--profile` spelling and the fleet build's renamed `--cpu-profile` spelling. The two binaries report the same version but expose different flag surfaces, so compatibility requires a superset.

## Why it is built this way

The checked-in manifest is a parser/classifier shared by both consumers; it never emits flags to `bd`. Keeping the union of supported spellings is therefore safe, deterministic, and resilient to the release-versus-fleet build skew.

## Review notes

- Review the value-versus-boolean classification of newly recognized flags, especially `list --deps`, which has an optional value.
- Confirm the compatibility comment explains why both `--profile` and `--cpu-profile` remain present.
- This changes static manifest data and test expectations only; it adds no configuration, API, dependency, or migration.
- The supported `bd` version is unchanged.

## Test plan

- [x] Run `go build ./...` and `go vet ./...`.
- [x] Run `make test-fast-parallel`.
- [x] Run `make test-cmd-gc-process-parallel` so process-backed tutorial coverage executes with `GC_FAST_UNIT=0`.
- [x] Run the diff-owned completeness tests with zero skips.
- [x] Verify `TestBdFlagManifestCurrent` passes all 17 supported subcommands against both `bd v1.1.0` builds.
- [x] Release gate: [`release-gates/ga-o0pdkh-bdflags-manifest-gate.md`](release-gates/ga-o0pdkh-bdflags-manifest-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5221 — refreshes the same internal/bdflags manifest from newer `bd --help` output, which clears some bd-unknown-flag noise from gc lint; it does not touch the undeclared flags that never appear in help at all (`create --label`, `mol wisp --age`), and the manifest stays help-derived, so the root cause described in that issue is untouched

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->