### PR TITLE
fix(runtime/exec): tear down the box when the start op fails

### DIFF
--- a/internal/runtime/exec/exec.go
+++ b/internal/runtime/exec/exec.go
@@ -129,10 +129,22 @@ func (p *Provider) cancellationError(ctxErr error, stderr string, args []string)
 	return fmt.Errorf("exec provider %s %s: %w", p.script, strings.Join(args, " "), cancelErr)
 }
 
+// startCollisionPhrases are the adapter stderr idioms that mean "a live session
+// already owns this name". exec is the only provider that INFERS
+// [runtime.ErrSessionExists] from the adapter's message instead of returning it
+// structurally, so this list is the whole detector — and packs word the refusal
+// differently ("already exists" and "already running" are both in use).
+//
+// Under-matching is the dangerous direction: the sentinel is what stops
+// cleanupAfterStartFailure from tearing down the box a healthy session is
+// already running in, so an unrecognized phrasing costs a live session. A false
+// match only forgoes cleanup of one box.
+var startCollisionPhrases = []string{"already exists", "already running"}
+
 // runError maps an ordinary (non-cancellation) cmd.Run failure onto the
 // provider's contract: exit code 2 is an unknown operation treated as success
-// (forward compatible, nil error), a "start ... already exists" collision maps
-// to [runtime.ErrSessionExists], and everything else wraps the adapter's stderr.
+// (forward compatible, nil error), a start-op name collision maps to
+// [runtime.ErrSessionExists], and everything else wraps the adapter's stderr.
 func (p *Provider) runError(runErr error, stderr string, args []string) error {
 	var exitErr *exec.ExitError
 	if errors.As(runErr, &exitErr) && exitErr.ExitCode() == 2 {
@@ -142,10 +154,22 @@ func (p *Provider) runError(runErr error, stderr string, args []string) error {
 	if errMsg == "" {
 		errMsg = runErr.Error()
 	}
-	if len(args) > 0 && args[0] == "start" && strings.Contains(strings.ToLower(errMsg), "already exists") {
+	if len(args) > 0 && args[0] == "start" && isStartCollision(errMsg) {
 		return fmt.Errorf("%w: exec provider %s %s: %s", runtime.ErrSessionExists, p.script, strings.Join(args, " "), errMsg)
 	}
 	return fmt.Errorf("exec provider %s %s: %s", p.script, strings.Join(args, " "), errMsg)
+}
+
+// isStartCollision reports whether a failed start op's message says the name is
+// already taken by a live session.
+func isStartCollision(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	for _, phrase := range startCollisionPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 // runWithTTY executes the script with the terminal inherited (for Attach).
@@ -170,20 +194,38 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 		return fmt.Errorf("exec provider: marshaling start config: %w", err)
 	}
 	if _, err = p.runWithContext(ctx, p.startTimeout, data, "start", name); err != nil {
-		return err
+		return p.cleanupAfterStartFailure(name, err)
 	}
 
 	if err := p.dismissStartupDialogs(ctx, name, cfg); err != nil {
-		if stopErr := p.Stop(name); stopErr != nil {
-			return errors.Join(
-				fmt.Errorf("exec provider: dismissing startup dialogs: %w", err),
-				fmt.Errorf("exec provider: cleanup after startup failure: %w", stopErr),
-			)
-		}
-		return fmt.Errorf("exec provider: dismissing startup dialogs: %w", err)
+		return p.cleanupAfterStartFailure(name, fmt.Errorf("exec provider: dismissing startup dialogs: %w", err))
 	}
 
 	return nil
+}
+
+// cleanupAfterStartFailure tears down the box the adapter may already have
+// created before startErr, and returns the error Start should report. By the
+// time the `start` op fails the box usually exists — the adapter provisions it
+// and then blocks polling for readiness, so the common failure is gc hitting
+// its own startTimeout with the box already up. Without this teardown that box
+// is orphaned, and because a fresh session name is minted per attempt the retry
+// leaks another one.
+//
+// The [runtime.ErrSessionExists] case is the exception: a name collision means
+// a LIVE session already owns that box, and stopping it would destroy a healthy
+// session rather than clean up after this attempt.
+//
+// Stop deliberately runs on its own background context (see run), so cleanup
+// still happens when the caller's context is the thing that died.
+func (p *Provider) cleanupAfterStartFailure(name string, startErr error) error {
+	if errors.Is(startErr, runtime.ErrSessionExists) {
+		return startErr
+	}
+	if stopErr := p.Stop(name); stopErr != nil {
+		return errors.Join(startErr, fmt.Errorf("exec provider: cleanup after startup failure: %w", stopErr))
+	}
+	return startErr
 }
 
 // supportsSeparableLaunch reports whether the pack un-welds provisioning from the

--- a/internal/runtime/exec/exec_test.go
+++ b/internal/runtime/exec/exec_test.go
@@ -246,6 +246,169 @@ func TestStart(t *testing.T) {
 	}
 }
 
+// startFailureScript fails the start op with the given stderr message after the
+// adapter has already created the box (recorded in createFile), and logs every
+// stop call to stopFile. This is the shape of the sandbox leak: the box exists
+// by the time start reports failure.
+func startFailureScript(createFile, stopFile, startStderr string) string {
+	return `
+op="$1"
+name="$2"
+
+case "$op" in
+  start)
+    cat > /dev/null
+    echo "$name" >> "` + createFile + `"
+    echo "` + startStderr + `" >&2
+    exit 1
+    ;;
+  stop) echo "stop $name" >> "` + stopFile + `" ;;
+  *) exit 2 ;;
+esac
+`
+}
+
+func TestStartTearsDownBoxWhenStartOpFails(t *testing.T) {
+	dir := t.TempDir()
+	createFile := filepath.Join(dir, "create.log")
+	stopFile := filepath.Join(dir, "stop.log")
+	script := writeScript(t, dir, startFailureScript(createFile, stopFile, "readiness timeout"))
+	p := NewProvider(script)
+
+	err := p.Start(context.Background(), "test-sess", runtime.Config{})
+	if err == nil {
+		t.Fatal("Start succeeded, want start-op failure")
+	}
+	if !strings.Contains(err.Error(), "readiness timeout") {
+		t.Fatalf("Start error = %v, want the adapter's start failure", err)
+	}
+	if got := readLog(t, createFile); !strings.Contains(got, "test-sess") {
+		t.Fatalf("create log = %q, want the adapter to have created the box", got)
+	}
+	if got := readLog(t, stopFile); !strings.Contains(got, "stop test-sess") {
+		t.Fatalf("stop log = %q, want the box torn down after start failure", got)
+	}
+}
+
+// TestStartDoesNotTearDownWhenSessionAlreadyExists is the guard on the teardown
+// above: an "already exists" collision means a LIVE session owns that name, so
+// tearing down would destroy a healthy session's box. mockProviderScript makes
+// that observable — its stop op removes the running marker, so a teardown here
+// would leave the first session dead.
+func TestStartDoesNotTearDownWhenSessionAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	script := writeScript(t, dir, mockProviderScript(stateDir))
+	p := NewProvider(script)
+
+	if err := p.Start(context.Background(), "test-sess", runtime.Config{}); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+
+	err := p.Start(context.Background(), "test-sess", runtime.Config{})
+	if !errors.Is(err, runtime.ErrSessionExists) {
+		t.Fatalf("second Start error = %v, want ErrSessionExists", err)
+	}
+	if !p.IsRunning("test-sess") {
+		t.Fatal("colliding Start tore down the live session's box; ErrSessionExists must skip cleanup")
+	}
+}
+
+// TestStartCollisionPhrasingsSkipTeardown pins the collision vocabulary the
+// teardown guard depends on. exec is the only provider that INFERS
+// ErrSessionExists from the adapter's stderr rather than returning it
+// structurally, and real packs phrase the collision differently ("already
+// running" is the wording of a live pack whose start op refuses to double-start
+// a session). Any phrasing that is not recognized gets the live session's box
+// torn down, so under-matching here is a session-killing bug, not cosmetics.
+func TestStartCollisionPhrasingsSkipTeardown(t *testing.T) {
+	phrasings := map[string]string{
+		"exists":  `session "test-sess" already exists`,
+		"running": `session "test-sess" already running`,
+	}
+	for name, stderr := range phrasings {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			createFile := filepath.Join(dir, "create.log")
+			stopFile := filepath.Join(dir, "stop.log")
+			script := writeScript(t, dir, startFailureScript(createFile, stopFile, stderr))
+			p := NewProvider(script)
+
+			err := p.Start(context.Background(), "test-sess", runtime.Config{})
+			if !errors.Is(err, runtime.ErrSessionExists) {
+				t.Errorf("Start error = %v, want ErrSessionExists for %q", err, stderr)
+			}
+			if got := readLog(t, stopFile); got != "" {
+				t.Errorf("stop log = %q, want no teardown of a live session's box", got)
+			}
+		})
+	}
+}
+
+// TestStartTearsDownBoxWhenStartOpIsCanceled covers the production failure path:
+// the adapter creates the box and then blocks past gc's own start deadline. The
+// teardown must still run even though the caller's context is already dead.
+func TestStartTearsDownBoxWhenStartOpIsCanceled(t *testing.T) {
+	dir := t.TempDir()
+	createFile := filepath.Join(dir, "create.log")
+	stopFile := filepath.Join(dir, "stop.log")
+	script := writeScript(t, dir, `
+op="$1"
+name="$2"
+
+case "$op" in
+  start)
+    cat > /dev/null
+    echo "$name" >> "`+createFile+`"
+    sleep `+startupWatchBlockingSleep+`
+    ;;
+  stop) echo "stop $name" >> "`+stopFile+`" ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script)
+	p.startTimeout = 200 * time.Millisecond
+
+	err := p.Start(context.Background(), "test-sess", runtime.Config{})
+	if err == nil {
+		t.Fatal("Start succeeded, want deadline failure")
+	}
+	if got := readLog(t, createFile); !strings.Contains(got, "test-sess") {
+		t.Fatalf("create log = %q, want the adapter to have created the box", got)
+	}
+	if got := readLog(t, stopFile); !strings.Contains(got, "stop test-sess") {
+		t.Fatalf("stop log = %q, want the box torn down after a canceled start", got)
+	}
+}
+
+func TestStartReportsCleanupFailureAlongsideStartFailure(t *testing.T) {
+	dir := t.TempDir()
+	script := writeScript(t, dir, `
+op="$1"
+
+case "$op" in
+  start) cat > /dev/null; echo "readiness timeout" >&2; exit 1 ;;
+  stop)  echo "sandbox delete refused" >&2; exit 1 ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script)
+
+	err := p.Start(context.Background(), "test-sess", runtime.Config{})
+	if err == nil {
+		t.Fatal("Start succeeded, want start-op failure")
+	}
+	if !strings.Contains(err.Error(), "readiness timeout") {
+		t.Errorf("Start error = %v, want the original start failure preserved", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox delete refused") {
+		t.Errorf("Start error = %v, want the cleanup failure reported too", err)
+	}
+}
+
 func TestStart_ReturnsDialogDismissalError(t *testing.T) {
 	dir := t.TempDir()
 	stopFile := filepath.Join(dir, "stop.log")


### PR DESCRIPTION
## The defect

`exec.Provider.Start` returned the `start` op's error without stopping the box
the adapter had already created:

```go
if _, err = p.runWithContext(ctx, p.startTimeout, data, "start", name); err != nil {
    return err
}
```

For any pack that provisions the box and *then* polls for readiness, the box is
already up by the time `start` reports failure, so each failed start orphans
one. Because a fresh session name is minted per attempt, the retry orphans
another, and so on.

The sibling `internal/runtime/k8s/provider.go:211-217` defines exactly this
cleanup (`cleanup deletes the pod on any startup failure after creation`) and
runs it on every post-create failure. `exec` ran it too — but only when *dialog
dismissal* failed, never when the start op itself did. That asymmetry is the
bug.

## The fix

Both failure paths now route through `cleanupAfterStartFailure`, so the
asymmetry is gone by construction instead of by duplication. `Stop` runs on its
own `context.Background()` (via `run` → `runWithTimeout`), so cleanup still
fires when the caller's context is the thing that died — which is the common
case, since the usual failure is the provider hitting its own 120s
`startTimeout`.

Teardown is skipped for `runtime.ErrSessionExists`: a name collision means a
*live* session owns that box, and stopping it would kill a healthy session
rather than clean up after this attempt.

## The sentinel had to be widened first

That guard is only as good as the sentinel, and `exec` is the one provider that
*infers* `ErrSessionExists` from adapter stderr rather than returning it
structurally (k8s, ssh, herdr and fake all return it directly). `runError`
matched a single phrasing, `"already exists"`. A pack that refuses a
double-start with `"already running"` fell straight through the guard and would
have had its live session's box torn down by the new cleanup — a regression
strictly worse than the leak being fixed.

`isStartCollision` now covers both phrasings. The failure modes are asymmetric:
under-matching costs a live session, over-matching only forgoes cleanup of one
box, so the list is deliberately biased toward skipping teardown.

## Tests

- `TestStartTearsDownBoxWhenStartOpFails` — the leak shape: adapter creates the
  box, then start fails. Asserts the box is torn down.
- `TestStartDoesNotTearDownWhenSessionAlreadyExists` — behavioural guard, using
  the existing `mockProviderScript` whose `stop` removes the running marker, so
  a wrong teardown leaves the first session dead.
- `TestStartCollisionPhrasingsSkipTeardown` — pins the collision vocabulary both
  phrasings must map to the sentinel and must not stop the box.
- `TestStartTearsDownBoxWhenStartOpIsCanceled` — the production path: the
  adapter blocks past the start deadline; cleanup must still run on a dead
  context.
- `TestStartReportsCleanupFailureAlongsideStartFailure` — a failed teardown is
  surfaced next to the original error, not swallowed.

Each guard was verified by mutation: deleting the `ErrSessionExists` early
return fails only `TestStartDoesNotTearDownWhenSessionAlreadyExists` (the
teardown test still passes, so it discriminates the guard specifically), and
narrowing `startCollisionPhrases` back to one entry fails the `running` subtest
with `stop log = "stop test-sess\n"` — the live box torn down — while the
`exists` subtest still passes.

## Not addressed here

Two sites share this defect class and are deliberately left alone, because
neither can be fixed by mirroring this patch:

1. `provisionBox` — for a pack with a separable launch, a `provision` op failure
   returns with no teardown. `runError` only maps collisions when
   `args[0] == "start"`, so a provision collision has no sentinel and a teardown
   there would delete live boxes.
2. `internal/runtime/seam_adapter.go:63-66` — `seamProvider.Start` returns a
   `Provision` failure with no teardown while its `Launch` failure path (:68-81)
   does tear down: the same asymmetry one layer up, generic to all providers. An
   unguarded `Teardown` there would delete live sessions for every provider,
   since k8s returns `ErrSessionExists`/`ErrSessionInitializing` for a live pod.

Both want the sentinel extended to the provision op first.

## Gates

`go build ./...`, `go vet ./...`, `make test`, and the `.githooks` pre-commit
(lint + doc-gen + vet) and pre-push (sharded fast suite) hooks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)