### PR TITLE
Fix pre-claim entry-step reminders for attached formulas

### DIFF
--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -89,7 +89,14 @@ func wispStepAssignees() []string {
 //  4. If no molecule bead is assigned to the agent, follow the molecule_id
 //     bridge: an attached (v1) formula routes only the source work bead and
 //     stamps its molecule_id with the (unrouted, unassigned) root, so resolve
-//     the root's active step through that bridge.
+//     the root's active step through that bridge. Two bridge sources are
+//     tried, claimed state first: (a) the source bead is already
+//     in_progress+assigned — the state that exists once the agent has claimed
+//     it; (b) the source bead is still open+unassigned but carries
+//     gc.routed_to for one of the agent's identities — the state that exists
+//     at the exact wake (gc prime / nudge) the bridge is meant to serve,
+//     before any claim has happened. Trying (a) first prefers an
+//     already-claimed molecule over a merely-routed one when both exist.
 //  5. If no molecule_id bridge exists either, fall back to any in-progress bead
 //     with a non-empty Description (legacy behavior for agents not running a
 //     formula).
@@ -181,8 +188,10 @@ func resolveActiveMolecule(store beads.Store, assignees []string) (*beads.Bead, 
 // attached (v1) source work bead. Attached formulas route only the source bead
 // and stamp its molecule_id metadata with the (unrouted, unassigned) molecule
 // root, so resolveActiveMolecule — which filters molecule roots by assignee —
-// never matches. This bridges from the routed, assignee-owned source bead to
-// its root via the molecule_id metadata key.
+// never matches. This bridges from the source bead to its root via the
+// molecule_id metadata key, trying the claimed (in_progress+assigned) source
+// state first and falling back to the pre-claim (open, gc.routed_to) state —
+// see resolveActiveWispStep's doc comment, step 4.
 //
 // Returns nil on any error or when no bridge bead is found — callers treat nil
 // as "no bridge available" and fall through to the legacy path.
@@ -193,17 +202,58 @@ func resolveMoleculeRootViaBridge(store beads.Store, assignees []string) *beads.
 		TierMode:  beads.TierBoth,
 		Limit:     10,
 	})
-	if err != nil {
-		return nil
+	if err == nil {
+		if root := firstMoleculeRootFrom(store, results); root != nil {
+			return root
+		}
 	}
-	for i := range results {
-		rootID := strings.TrimSpace(results[i].Metadata[beadmeta.MoleculeIDMetadataKey])
+	return resolveMoleculeRootViaRoutedBridge(store, assignees)
+}
+
+// resolveMoleculeRootViaRoutedBridge finds the molecule root reachable from a
+// source work bead that has been routed but not yet claimed: still
+// status=open and unassigned, carrying gc.routed_to for one of the agent's
+// identities. cliBeadRouter.Route (cmd/gc/cmd_sling.go) stamps gc.routed_to
+// alone at sling time, deliberately leaving status and assignee untouched so
+// the tier-3 pool query can select on --unassigned — this is the bridge
+// source's state at the exact wake (gc prime / nudge) that is supposed to
+// carry the agent into the molecule, before any claim has happened.
+//
+// ListQuery.Metadata is single-valued, so identities are tried one at a time.
+// Best-effort: a list error for one identity is skipped, not fatal, so a
+// later identity still gets a chance.
+//
+// Returns nil when no routed bridge bead is found for any identity.
+func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *beads.Bead {
+	for _, identity := range assignees {
+		results, err := store.List(beads.ListQuery{
+			Status:   "open",
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: identity},
+			TierMode: beads.TierBoth,
+			Limit:    10,
+		})
+		if err != nil {
+			continue
+		}
+		if root := firstMoleculeRootFrom(store, results); root != nil {
+			return root
+		}
+	}
+	return nil
+}
+
+// firstMoleculeRootFrom returns the molecule root reachable via molecule_id
+// from the first candidate bead that carries one. Returns nil when no
+// candidate carries a resolvable molecule_id.
+func firstMoleculeRootFrom(store beads.Store, candidates []beads.Bead) *beads.Bead {
+	for i := range candidates {
+		rootID := strings.TrimSpace(candidates[i].Metadata[beadmeta.MoleculeIDMetadataKey])
 		if rootID == "" {
 			continue
 		}
 		root, err := store.Get(rootID)
 		if err != nil {
-			log.Printf("wisp step inject: molecule_id %q on bead %s did not resolve: %v", rootID, results[i].ID, err)
+			log.Printf("wisp step inject: molecule_id %q on bead %s did not resolve: %v", rootID, candidates[i].ID, err)
 			continue
 		}
 		return &root

--- a/cmd/gc/wisp_step_inject_prewake_test.go
+++ b/cmd/gc/wisp_step_inject_prewake_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// mustCreateOpen creates a bead and leaves it in the default open state.
+func mustCreateOpen(t *testing.T, store *beads.MemStore, b beads.Bead) beads.Bead {
+	t.Helper()
+	created, err := store.Create(b)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return created
+}
+
+// TestResolveActiveWispStep_PreClaimBridgeMisses reproduces ga-cjjtkh: an
+// attached (v1) molecule is never entered because the molecule_id bridge cannot
+// resolve at the moment the injection actually runs.
+//
+// Live shape this mirrors (beads rig, 2026-08-14T23:41:23Z):
+//
+//	be-08y  molecule root, gc.formula_name=mol-deployer-gate, open, UNASSIGNED
+//	be-01h be-34a be-770 be-awb  4 steps, open, no labels, no assignee
+//	be-9b8  source bead, gc.routed_to=beads/deployer, molecule_id=be-08y
+//
+// cliBeadRouter.Route (cmd/gc/cmd_sling.go:776) stamps ONLY gc.routed_to, so at
+// wake/nudge time the source bead is still status=open and unassigned — the
+// tier-3 pool query (`bd ready --metadata-field gc.routed_to=X --unassigned`)
+// requires exactly that. But resolveMoleculeRootViaBridge
+// (cmd/gc/wisp_step_inject.go:189-198) lists with Status:"in_progress" +
+// Assignees, so it cannot match the very bead it is meant to bridge from.
+//
+// The injection at cmd/gc/cmd_nudge.go:454 therefore returns "" on the wake that
+// is supposed to carry the agent into its molecule. The agent works the source
+// bead plainly, closes it, and the molecule leaks with every step untouched
+// (created_at == updated_at).
+func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Molecule root: attached formulas deliberately leave it unrouted and
+	// unassigned (sling_core.go:585-594).
+	root := mustCreateOpen(t, store, beads.Bead{
+		Title: "mol-deployer-gate",
+		Type:  "molecule",
+	})
+
+	// Step children: open, unassigned, no labels — invisible to every
+	// work_query by design.
+	step := mustCreateOpen(t, store, beads.Bead{
+		Title:       "Step 1: verify the gate",
+		Description: "Run the deployer gate checks",
+		Type:        "step",
+		ParentID:    root.ID,
+	})
+
+	// Source work bead in its REAL post-sling, pre-claim state: routed, carrying
+	// molecule_id, but still open and unassigned.
+	source := mustCreateOpen(t, store, beads.Bead{
+		Title:       "needs-deploy: ship the reviewed branch",
+		Description: "Deploy the reviewed work",
+		Type:        "task",
+	})
+	if err := store.SetMetadata(source.ID, beadmeta.MoleculeIDMetadataKey, root.ID); err != nil {
+		t.Fatalf("SetMetadata(molecule_id): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, beadmeta.RoutedToMetadataKey, "beads/deployer"); err != nil {
+		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
+	}
+
+	// This is the wake: gc nudge --inject calls wispStepInjectionContent, which
+	// resolves against the agent's identities.
+	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("ORPHAN REPRODUCED: molecule %s has entry step %s, but the bridge "+
+			"resolved nothing at wake time because source bead %s is still "+
+			"status=open/unassigned. Nothing tells the agent the molecule exists; "+
+			"it works the source bead plainly and all %d steps leak untouched.",
+			root.ID, step.ID, source.ID, 1)
+	}
+	if got.ID != step.ID {
+		t.Fatalf("got %q, want entry step %q", got.ID, step.ID)
+	}
+}
+
+// TestResolveActiveWispStep_PostClaimBridgeResolves is the control that isolates
+// the cause to the status/assignee filter alone. It is byte-identical to the
+// test above except the source bead is in_progress and assigned — the state that
+// only exists AFTER the agent has already claimed and begun working. Here the
+// bridge resolves fine.
+//
+// Together the pair show the defect is an ordering inversion, not a missing
+// mechanism: the bridge requires post-claim state to deliver a pre-claim
+// instruction.
+func TestResolveActiveWispStep_PostClaimBridgeResolves(t *testing.T) {
+	store := beads.NewMemStore()
+
+	root := mustCreateOpen(t, store, beads.Bead{
+		Title: "mol-deployer-gate",
+		Type:  "molecule",
+	})
+	step := mustCreateOpen(t, store, beads.Bead{
+		Title:       "Step 1: verify the gate",
+		Description: "Run the deployer gate checks",
+		Type:        "step",
+		ParentID:    root.ID,
+	})
+
+	// Same bead, but claimed: in_progress + assigned.
+	source := mustCreateInProgress(t, store, beads.Bead{
+		Title:       "needs-deploy: ship the reviewed branch",
+		Description: "Deploy the reviewed work",
+		Type:        "task",
+		Assignee:    "deployer-gm-wisp-sl677d",
+	})
+	if err := store.SetMetadata(source.ID, beadmeta.MoleculeIDMetadataKey, root.ID); err != nil {
+		t.Fatalf("SetMetadata(molecule_id): %v", err)
+	}
+
+	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("control failed: bridge did not resolve even post-claim")
+	}
+	if got.ID != step.ID {
+		t.Fatalf("got %q, want entry step %q", got.ID, step.ID)
+	}
+}

--- a/release-gates/ga-e9idpt-preclaim-molecule-entry-bridge-gate.md
+++ b/release-gates/ga-e9idpt-preclaim-molecule-entry-bridge-gate.md
@@ -1,0 +1,64 @@
+# Release gate: pre-claim molecule entry bridge
+
+- Deploy bead: `ga-e9idpt`
+- Source bead: `ga-y42bwf`
+- Review bead: `ga-szq6h2`
+- Reviewed source: `11ca6d2aebecee76409456af4f46754b9e2abb9d`
+- Feature cut point: `9979bed7b795020803eee1815dbe77fe83032266`
+- Base: `origin/main` at `d7e1c3aea47ebe910e7301c844ad488fa1142020`
+- Deploy branch: `deploy/ga-e9idpt-gate`
+- Gate result: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is absent from both the reviewed source and current
+main, so this checklist applies the seven release criteria supplied by the
+deployer policy.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-szq6h2` records an unambiguous `Review verdict: PASS` for reviewed commit `11ca6d2aebecee76409456af4f46754b9e2abb9d`. |
+| 2 | Acceptance criteria met | **PASS** | The two new pre-claim bridge tests pass; the claimed-bead lookup remains first; the fallback searches open source beads by `gc.routed_to` across agent identities with `TierBoth` and a limit of 10; lookup errors remain advisory/best-effort. All 17 focused resolver/reminder tests pass. `go build ./...` and `go vet ./...` pass. The PR review notes call out the pool-shared metadata behavior. |
+| 3 | Tests pass | **PASS** | See detailed test evidence below. No diff-owned test failed or skipped. The documented suites were run with the repository-pinned `bd` v1.1.0 build (`8e4e59d39`) and the rootless podman environment configured before execution. |
+| 4 | No high-severity review findings open | **PASS** | The PASS review reports no unresolved HIGH findings; count: 0. |
+| 5 | Final branch is clean | **PASS** | The detached worktree at the exact reviewed source reported an empty `git status --short`, and `git diff --check` passed before this gate artifact was added. |
+| 6 | Branch diverges cleanly from main | **PASS** | Pre-flight found no PR carrying the reviewed source. `git merge-tree --write-tree origin/main 11ca6d2aebecee76409456af4f46754b9e2abb9d` exited 0 and produced tree `5f1fd63600be0d74bdc14fcf354156cf5301e6bf`; merge base is `9979bed7b795020803eee1815dbe77fe83032266`. No self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | The two reviewed commits touch only `cmd/gc/wisp_step_inject.go` and its focused test file, implementing one behavior: resolving a formula entry step during the pre-claim wake window. |
+
+## Test evidence
+
+- `test_cmd: make test-local-full-parallel`
+  - Raw sharded result: 32 PASS jobs, 8 red jobs.
+  - Six red jobs were local shared-store/startup collisions; all seven named
+    tests from those jobs passed when rerun serially against the reviewed
+    commit: 7 PASS, 0 FAIL, 0 SKIP.
+  - Two red jobs were the known host tmux 3.7b default-binding incompatibility.
+    The same two tests fail identically on current `origin/main`, so they are
+    baseline-only and do not bear on this `cmd/gc` change.
+  - Effective gate accounting: 38 PASS jobs, 0 feature FAIL, 2 justified
+    baseline SKIP-equivalents.
+- `test_cmd: make test-fast-parallel`
+  - Raw result: 9 PASS jobs, 1 red job. The red job contained one SQLite
+    SIGKILL boundary test whose child missed its 10-second startup deadline
+    under shard saturation.
+  - The exact test passed in isolation immediately afterward: 5 subtests PASS,
+    0 FAIL, 0 SKIP (1.33s). Effective result: 10 PASS jobs, 0 FAIL.
+- `test_cmd: go test -json -count=1 ./cmd/gc -run 'TestResolveActiveWispStep|TestFormatWispStepReminder|TestWispStepAssignees'`
+  - Counts: 17 PASS, 0 FAIL, 0 SKIP.
+  - `diff_tests_executed:`
+    - `TestResolveActiveWispStep_PreClaimBridgeMisses` — PASS
+    - `TestResolveActiveWispStep_PostClaimBridgeResolves` — PASS
+  - `waiver_ref: none`
+- `go build ./...` — PASS
+- `go vet ./...` — PASS
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=9979bed7b795020803eee1815dbe77fe83032266 make lint-affected` — PASS, 0 issues
+- `make fmt-check-changed` — PASS
+- `make check-docs` — PASS
+- `git diff --check` — PASS
+- Git hooks are active: `core.hooksPath=.githooks`.
+
+## Review focus
+
+The fallback is deliberately advisory. Because `gc.routed_to` metadata is
+single-valued and a pool route may identify multiple eligible agents, more
+than one pool member can see the same read-only step reminder. Claiming remains
+the arbitration mechanism; the deploy does not alter sling routing, reaping,
+or prompt behavior.


### PR DESCRIPTION
## What this changes

`gc prime` and wake nudges can now resolve the entry step of an attached formula before the routed work bead is claimed. Previously, the bridge only matched in-progress assigned beads, so a formula could be scaffolded successfully but never surface its first actionable step during the pre-claim window.

The existing claimed-bead lookup still takes precedence. A bounded fallback now checks open routed source beads by `gc.routed_to`, allowing the attached formula's entry step to appear without changing claim or routing semantics.

## Review notes

- The fallback checks each configured identity because `gc.routed_to` metadata is single-valued; it is limited to open beads, both storage tiers, and ten results per identity.
- Pool routing may show the same advisory reminder to more than one eligible pool member. The reminder is read-only, and the bead claim remains the arbitration mechanism.
- Sling routing, reaping, and prompt behavior are unchanged.

## Test plan

- [x] Run all 17 focused entry-step resolver and reminder tests, including both new pre-claim bridge cases.
- [x] Run the documented fast and full local suites, then isolate and rerun any host-concurrency or baseline-only failures by name.
- [x] Run `go build ./...`, `go vet ./...`, affected lint, formatting, and documentation checks.
- [x] Release gate: [`release-gates/ga-e9idpt-preclaim-molecule-entry-bridge-gate.md`](release-gates/ga-e9idpt-preclaim-molecule-entry-bridge-gate.md)
