### PR TITLE
fix(bd): commit the beads runtime config write, scoped to config (#5286)

### DIFF
--- a/cmd/gc/gc_beads_bd_runtime_config_commit_test.go
+++ b/cmd/gc/gc_beads_bd_runtime_config_commit_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureBdRuntimeConfigValue_* are regression tests for #5286: Gas City
+// writes issue_prefix/types.custom into the Dolt `config` table with a raw
+// INSERT and never commits it. Against an external Dolt server, config is
+// not registered in dolt_ignore, so the database is left with a permanently
+// dirty working set that blocks the next beads schema migration touching
+// config, with no in-band recovery in server mode.
+//
+// These tests exercise the real shell functions (extracted from the script,
+// same technique as TestServerReachableReflectsDoltExit) against a fake
+// `dolt` binary that logs the SQL text of every `sql -q` invocation, so the
+// tests can assert on exactly which statements were issued without a live
+// Dolt server.
+
+func ensureBdRuntimeConfigTestScript(t *testing.T) string {
+	t.Helper()
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	src := string(scriptBytes)
+	var b strings.Builder
+	b.WriteString("connect_host() { printf '127.0.0.1'; }\n")
+	for _, fn := range []string{
+		"die",
+		"valid_sql_name",
+		"valid_custom_types_value",
+		"validate_bd_runtime_config_value",
+		"is_retryable_error",
+		"sleep_ms",
+		"server_sql",
+		"server_sql_retry",
+		"ensure_bd_runtime_config_value",
+		"ensure_bd_runtime_issue_prefix",
+	} {
+		b.WriteString(extractShellFunction(t, src, fn))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// writeFakeSQLLoggingDolt writes a fake `dolt` that logs the query text of
+// every `sql -q <query>` invocation to FAKE_DOLT_LOG (one line per call) and
+// fails any query matching a DOLT_ADD/DOLT_COMMIT call when
+// FAKE_DOLT_COMMIT_FAIL is set, printing FAKE_DOLT_COMMIT_ERROR to stderr.
+// All other queries (the runtime config INSERT) always succeed, matching a
+// healthy server for the part of this flow #5286 does not touch.
+func writeFakeSQLLoggingDolt(t *testing.T, dir string) {
+	t.Helper()
+	p := filepath.Join(dir, "dolt")
+	body := `#!/bin/sh
+log_file=${FAKE_DOLT_LOG:-/dev/null}
+prev=""
+query=""
+for arg in "$@"; do
+  if [ "$prev" = "-q" ]; then
+    query="$arg"
+  fi
+  prev="$arg"
+done
+printf '%s\n' "$query" >> "$log_file"
+case "$query" in
+  *DOLT_ADD*|*DOLT_COMMIT*)
+    if [ -n "${FAKE_DOLT_COMMIT_FAIL:-}" ]; then
+      echo "${FAKE_DOLT_COMMIT_ERROR:-simulated commit failure}" >&2
+      exit 1
+    fi
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}
+
+func TestEnsureBdRuntimeConfigValue_CommitsScopedToConfigTable(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+
+	binDir := t.TempDir()
+	writeFakeSQLLoggingDolt(t, binDir)
+	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
+
+	script := ensureBdRuntimeConfigTestScript(t) + "\nensure_bd_runtime_issue_prefix testdb tf\n"
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOLT_PORT=42188",
+		"DOLT_USER=root",
+		"DOLT_PASSWORD=",
+		"FAKE_DOLT_LOG="+logFile,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ensure_bd_runtime_issue_prefix failed: %v\noutput: %s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(logBytes)
+
+	if !strings.Contains(log, "INSERT INTO config") {
+		t.Fatalf("expected the runtime config INSERT to still happen; log:\n%s", log)
+	}
+	if !strings.Contains(log, "DOLT_ADD('config')") {
+		t.Fatalf("expected a scoped CALL DOLT_ADD('config') after the write (#5286); log:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_ADD('.')") {
+		t.Fatalf("commit must be scoped to the config table, not DOLT_ADD('.') -- an unscoped add would sweep any other dirty table into Gas City's commit, the exact hash-drift hazard #5286 warns against; log:\n%s", log)
+	}
+	if !strings.Contains(log, "DOLT_COMMIT") {
+		t.Fatalf("expected a CALL DOLT_COMMIT after staging the config write (#5286); log:\n%s", log)
+	}
+}
+
+func TestEnsureBdRuntimeConfigValue_FailsOpenOnCommitError(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+
+	binDir := t.TempDir()
+	writeFakeSQLLoggingDolt(t, binDir)
+	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
+
+	script := ensureBdRuntimeConfigTestScript(t) + "\nensure_bd_runtime_issue_prefix testdb tf\n"
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOLT_PORT=42188",
+		"DOLT_USER=root",
+		"DOLT_PASSWORD=",
+		"FAKE_DOLT_LOG="+logFile,
+		"FAKE_DOLT_COMMIT_FAIL=1",
+		"FAKE_DOLT_COMMIT_ERROR=simulated lock wait timeout",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("a commit failure must not block provisioning (fail-open per #5286's proposed fix); err: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "simulated lock wait timeout") {
+		t.Fatalf("a real commit failure must be reported, never swallowed (#5286); output:\n%s", out)
+	}
+}
+
+func TestEnsureBdRuntimeConfigValue_TreatsNothingToCommitAsSuccess(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+
+	binDir := t.TempDir()
+	writeFakeSQLLoggingDolt(t, binDir)
+	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
+
+	script := ensureBdRuntimeConfigTestScript(t) + "\nensure_bd_runtime_issue_prefix testdb tf\n"
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOLT_PORT=42188",
+		"DOLT_USER=root",
+		"DOLT_PASSWORD=",
+		"FAKE_DOLT_LOG="+logFile,
+		"FAKE_DOLT_COMMIT_FAIL=1",
+		"FAKE_DOLT_COMMIT_ERROR=nothing to commit",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("an idempotent no-op commit must not fail provisioning; err: %v\noutput: %s", err, out)
+	}
+	if strings.Contains(string(out), "warning:") {
+		t.Fatalf("an idempotent 'nothing to commit' re-run should not be reported as a warning; output:\n%s", out)
+	}
+}

--- a/cmd/gc/gc_beads_bd_runtime_config_commit_test.go
+++ b/cmd/gc/gc_beads_bd_runtime_config_commit_test.go
@@ -85,26 +85,43 @@ exit 0
 	}
 }
 
-func TestEnsureBdRuntimeConfigValue_CommitsScopedToConfigTable(t *testing.T) {
-	t.Parallel()
-	if _, err := exec.LookPath("bash"); err != nil {
+// runEnsureBdRuntimeConfigScript runs ensure_bd_runtime_issue_prefix against
+// the fake dolt binary once, with any scenario-specific environment appended
+// on top of the baseline set. The three scenario tests below all funnel
+// through this single exec.Command call site rather than each constructing
+// their own -- the repo's resource census
+// (internal/testpolicy/resourcecensus) tracks os/exec.Command/CommandContext
+// call sites as a checked resource with a pinned baseline, and three
+// near-identical scenarios sharing one real subprocess invocation is the
+// correct shape here, not three copies of the same command construction.
+func runEnsureBdRuntimeConfigScript(t *testing.T, logFile string, extraEnv ...string) (stdout []byte, err error) {
+	t.Helper()
+	if _, lookErr := exec.LookPath("bash"); lookErr != nil {
 		t.Skip("bash not available; skipping shell-function test")
 	}
 
 	binDir := t.TempDir()
 	writeFakeSQLLoggingDolt(t, binDir)
-	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
 
 	script := ensureBdRuntimeConfigTestScript(t) + "\nensure_bd_runtime_issue_prefix testdb tf\n"
 	cmd := exec.Command("bash", "-c", script)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env,
 		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"DOLT_PORT=42188",
 		"DOLT_USER=root",
 		"DOLT_PASSWORD=",
 		"FAKE_DOLT_LOG="+logFile,
 	)
-	out, err := cmd.CombinedOutput()
+	cmd.Env = append(cmd.Env, extraEnv...)
+	return cmd.CombinedOutput()
+}
+
+func TestEnsureBdRuntimeConfigValue_CommitsScopedToConfigTable(t *testing.T) {
+	t.Parallel()
+	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
+
+	out, err := runEnsureBdRuntimeConfigScript(t, logFile)
 	if err != nil {
 		t.Fatalf("ensure_bd_runtime_issue_prefix failed: %v\noutput: %s", err, out)
 	}
@@ -131,26 +148,12 @@ func TestEnsureBdRuntimeConfigValue_CommitsScopedToConfigTable(t *testing.T) {
 
 func TestEnsureBdRuntimeConfigValue_FailsOpenOnCommitError(t *testing.T) {
 	t.Parallel()
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not available; skipping shell-function test")
-	}
-
-	binDir := t.TempDir()
-	writeFakeSQLLoggingDolt(t, binDir)
 	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
 
-	script := ensureBdRuntimeConfigTestScript(t) + "\nensure_bd_runtime_issue_prefix testdb tf\n"
-	cmd := exec.Command("bash", "-c", script)
-	cmd.Env = append(os.Environ(),
-		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"DOLT_PORT=42188",
-		"DOLT_USER=root",
-		"DOLT_PASSWORD=",
-		"FAKE_DOLT_LOG="+logFile,
+	out, err := runEnsureBdRuntimeConfigScript(t, logFile,
 		"FAKE_DOLT_COMMIT_FAIL=1",
 		"FAKE_DOLT_COMMIT_ERROR=simulated lock wait timeout",
 	)
-	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("a commit failure must not block provisioning (fail-open per #5286's proposed fix); err: %v\noutput: %s", err, out)
 	}
@@ -161,26 +164,12 @@ func TestEnsureBdRuntimeConfigValue_FailsOpenOnCommitError(t *testing.T) {
 
 func TestEnsureBdRuntimeConfigValue_TreatsNothingToCommitAsSuccess(t *testing.T) {
 	t.Parallel()
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not available; skipping shell-function test")
-	}
-
-	binDir := t.TempDir()
-	writeFakeSQLLoggingDolt(t, binDir)
 	logFile := filepath.Join(t.TempDir(), "dolt-calls.log")
 
-	script := ensureBdRuntimeConfigTestScript(t) + "\nensure_bd_runtime_issue_prefix testdb tf\n"
-	cmd := exec.Command("bash", "-c", script)
-	cmd.Env = append(os.Environ(),
-		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"DOLT_PORT=42188",
-		"DOLT_USER=root",
-		"DOLT_PASSWORD=",
-		"FAKE_DOLT_LOG="+logFile,
+	out, err := runEnsureBdRuntimeConfigScript(t, logFile,
 		"FAKE_DOLT_COMMIT_FAIL=1",
 		"FAKE_DOLT_COMMIT_ERROR=nothing to commit",
 	)
-	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("an idempotent no-op commit must not fail provisioning; err: %v\noutput: %s", err, out)
 	}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -607,6 +607,28 @@ ensure_bd_runtime_config_value() {
     # bd v1.0.3 rejects `bd config set issue_prefix`; GC still needs raw
     # bd commands to see GC's config in the DB-backed config table.
     server_sql_retry "USE \`$db\`; INSERT INTO config (\`key\`, value) VALUES ('$key', '$value') ON DUPLICATE KEY UPDATE value = VALUES(value)" >/dev/null || die "failed to set bd runtime $key for $db"
+
+    # Commit the write. config is not registered in dolt_ignore, so a
+    # database left uncommitted here stays permanently dirty against an
+    # external Dolt server -- the next beads schema migration touching
+    # config (e.g. 0030_migrate_local_metadata_keys.up.sql already does)
+    # refuses to run against every affected database at once, with no
+    # in-band recovery in server mode (`bd dolt commit` is embedded-only)
+    # (gcy-XXXX).
+    #
+    # Scoped to `config` specifically -- CALL DOLT_ADD('.') would sweep
+    # whatever else happens to be dirty at this moment into Gas City's own
+    # commit, the same hash-drift hazard the read-only probe's dolt_ignore
+    # registration above is careful to avoid. Fail-open: the value is
+    # already durably written by the INSERT above, so a commit failure is
+    # reported but must never block provisioning.
+    local commit_output
+    if ! commit_output=$(server_sql "USE \`$db\`; CALL DOLT_ADD('config'); CALL DOLT_COMMIT('-m', 'gc: sync beads runtime config', '--author', 'gascity-builder <builder@gascity.local>')" 2>&1); then
+        case "$commit_output" in
+            *"nothing to commit"*|*"Nothing to commit"*) : ;;  # idempotent re-run: value unchanged, nothing staged
+            *) echo "warning: failed to commit bd runtime config ($key) for $db: $commit_output" >&2 ;;
+        esac
+    fi
 }
 
 ensure_doltlite_runtime_config_value() {


### PR DESCRIPTION
Fixes #5286.

`ensure_bd_runtime_config_value` (in `examples/bd/assets/scripts/gc-beads-bd.sh`) writes `issue_prefix`/`types.custom` into the Dolt `config` table with a raw `INSERT` and never commits it. `config` isn't in `dolt_ignore`, so every city/rig database GC provisions against an external Dolt server is left permanently dirty. Reporter measured 15 of 21 live databases affected. The bite: beads refuses schema migrations against a dirty table, and the suggested recovery (`bd dolt commit`) doesn't work in server mode at all (it returns early on `ServerMode` before reaching the `LenientOpen` branch that exists specifically to break this deadlock) -- so there's no in-band recovery once a migration touches `config` (one already has: `0030_migrate_local_metadata_keys.up.sql`).

**Fix:** added a scoped commit (`CALL DOLT_ADD('config')` + `CALL DOLT_COMMIT`) right after the existing `INSERT`, following the correctly-scoped precedent in `examples/bd/dolt/commands/compact/run.sh`'s `version_dirty_dolt_ignore` rather than the unscoped `CALL DOLT_ADD('.')` pattern elsewhere in the codebase (which is only safe in that other call site because nothing else is expected to be dirty at that specific moment). Uses the established `gascity-builder <builder@gascity.local>` commit-author convention.

Fail-open per the issue's explicit requirement: a commit failure is reported (stderr `warning:`) but doesn't block provisioning -- must survive e.g. a read-only replica. The idempotent "nothing to commit" case is silently accepted.

**Testing:** extracted the real shell functions and ran them under `bash -c` against a fake `dolt` binary that logs every `sql -q` call and can be told to fail on demand (matches this repo's existing `TestServerReachableReflectsDoltExit` idiom, since a true integration test needs a live Dolt server not available here):
- `CommitsScopedToConfigTable` -- asserts `DOLT_ADD('config')` + `DOLT_COMMIT` happen, and that unscoped `DOLT_ADD('.')` does NOT appear. RED pre-fix.
- `FailsOpenOnCommitError` -- a real commit failure is reported but doesn't block. RED pre-fix.
- `TreatsNothingToCommitAsSuccess` -- idempotent re-run stays silent.

All three GREEN after the fix. `bash -n`/`sh -n` clean, existing `gc-beads-bd` lint/behavior suite unaffected, `go vet ./cmd/gc/...` clean.

**Out of scope:** already-provisioned databases stay dirty after this code fix -- a one-time backfill commit against already-affected live databases is a separate operational follow-up, not something this change does.

---

Generated with [Claude Code](https://claude.com/claude-code)