### PR TITLE
fix(nudge): treat a reaped backing bead as terminal in dead-letter prune (#5278)

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -2543,8 +2543,11 @@ func recoverExpiredInFlightNudgesWithClock(state *nudgeQueueState, front *nudgeq
 }
 
 // pruneDeadQueuedNudges removes dead-letter items older than defaultQueuedNudgeDeadRetention
-// when a durable terminal bead record exists in the store. Items without a confirmed terminal
-// bead are retained so terminal history is not lost if the bead store write failed.
+// once the store confirms the item is terminal — either a durable terminal bead record, or
+// the backing bead's outright absence (reaped by wisp compaction / retention sweeps), which
+// is treated as terminal since there is nothing left to confirm against. Items whose bead
+// still exists but isn't confirmed terminal are retained so terminal history is not lost if
+// the bead store write failed.
 func pruneDeadQueuedNudges(state *nudgeQueueState, front *nudgequeue.Store, now, deadline time.Time) error {
 	return pruneDeadQueuedNudgesWithClock(state, front, now, deadline, clock.Real{})
 }
@@ -2570,7 +2573,12 @@ func pruneDeadQueuedNudgesWithClock(state *nudgeQueueState, front *nudgequeue.St
 				filtered = append(filtered, item)
 				continue
 			}
-			if !ok || !nudgequeue.IsTerminalState(shadow.State) {
+			// !ok falls straight through to the retention check below: the
+			// backing bead has been reaped (label lookup found nothing, no
+			// store error). Terminalize is a documented no-op on a missing
+			// bead, so there is nothing left to repair — absence is itself
+			// the strongest possible terminal signal.
+			if ok && !nudgequeue.IsTerminalState(shadow.State) {
 				// Repair historical dead-letter entries whose queue state was
 				// durable but whose backing bead never received terminal state.
 				reason := strings.TrimSpace(item.LastError)
@@ -2586,13 +2594,21 @@ func pruneDeadQueuedNudgesWithClock(state *nudgeQueueState, front *nudgequeue.St
 					continue
 				}
 				shadow, ok, err = front.FindIncludingTerminal(item.ID)
-				if err != nil || !ok || !nudgequeue.IsTerminalState(shadow.State) {
+				if err != nil {
 					filtered = append(filtered, item)
 					continue
 				}
+				if ok && !nudgequeue.IsTerminalState(shadow.State) {
+					filtered = append(filtered, item)
+					continue
+				}
+				// !ok here means the bead was reaped between our two lookups
+				// (or raced the repair write) — also a terminal signal.
 			}
 			if !item.DeadAt.IsZero() && item.DeadAt.Before(cutoff) {
-				// Terminal bead confirmed in store — safe to prune once past retention.
+				// Terminal bead confirmed in store, or the bead is confirmed
+				// reaped — either way there is nothing left to confirm
+				// against, and DeadAt past retention makes this safe to prune.
 				continue
 			}
 		}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4335,6 +4335,49 @@ func TestPruneDeadQueuedNudges_RetainsItemsWithoutBeadID(t *testing.T) {
 	}
 }
 
+func TestPruneDeadQueuedNudges_PrunesWhenBackingBeadReaped(t *testing.T) {
+	// Regression for #5278: a dead-letter item whose backing bead was
+	// deleted out from under it (wisp compaction / retention sweep, not a
+	// normal Close) must still be pruned once past retention. Bead absence
+	// -- a clean label-lookup miss with no store error -- is the strongest
+	// possible terminal signal; retaining it forever (as before this fix)
+	// makes every future prune pass pay a store lookup for an item that can
+	// never be repaired, since Terminalize is a documented no-op on a
+	// missing bead.
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	now := time.Now().UTC()
+	item := newQueuedNudgeWithOptions("worker", "reaped dead letter", "session", now.Add(-2*time.Hour), queuedNudgeOptions{
+		ID:        "n-dead-reaped",
+		SessionID: "gc-worker",
+	})
+	beadID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected backing nudge bead to be created")
+	}
+	item.BeadID = beadID
+	item.LastError = "expired"
+	item.DeadAt = now.Add(-2 * time.Hour)
+
+	// Simulate a retention sweep reaping the shadow bead entirely -- not a
+	// Close, an actual Delete, so the label lookup finds nothing at all.
+	if err := store.Delete(beadID); err != nil {
+		t.Fatalf("Delete(%s): %v", beadID, err)
+	}
+
+	state := &nudgeQueueState{Dead: []queuedNudge{item}}
+	if err := pruneDeadQueuedNudges(state, nudgeFrontDoor(store), now, noMaintenanceDeadline()); err != nil {
+		t.Fatalf("pruneDeadQueuedNudges: %v", err)
+	}
+	if len(state.Dead) != 0 {
+		t.Fatalf("dead = %d, want 0 (reaped bead past retention must be pruned)", len(state.Dead))
+	}
+}
+
 func TestEnqueueSupersedes_SameAgentSourceReference(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()


### PR DESCRIPTION
Fixes #5278.

Dead-letter nudges whose backing bead was reaped (wisp compaction / retention sweep) could never be pruned, so every `gc nudge drain` paid a store lookup per dead entry forever. Reporter measured 3,088 dead entries -> 134.5s drain vs a 15s hook budget (149x after manually truncating `.dead`). Combined with a separate issue (#4297, timeout exit code 0), this silently killed nudge/mail delivery city-wide with no error, log line, or counter.

**Root cause:** `nudgequeue.Store.Terminalize` tolerates a missing bead as a no-op (returns `nil` even when there is nothing to terminalize), so after a reap the retry `FindIncludingTerminal` call still comes back `!ok`, and the entry was retained unconditionally. `find()` resolves by label (`"nudge:<id>"`), and a clean `!ok` with `err == nil` only happens when the label search finds zero beads -- an unambiguous "bead is gone" signal, not a transient/error condition (those are handled separately and still retain the item).

**Fix:** when the store confirms the backing bead is genuinely absent (not present, no error), treat that as terminal instead of retaining forever. Applies to both the initial lookup and the post-repair-attempt lookup in `pruneDeadQueuedNudgesWithClock` (`cmd/gc/cmd_nudge.go`).

Root-cause fix only (the issue's suggested direction #1) -- did not build a per-caller drain deadline or a hard cap/ring buffer on `.dead`, both of which are defense-in-depth for different failure modes and felt like scope creep beyond what actually broke.

**Testing:** `TestPruneDeadQueuedNudges_PrunesWhenBackingBeadReaped` -- creates a real dead-letter item with a backing bead, then actually `Delete()`s the bead (a true reap, matching the report's compaction scenario). RED: item retained pre-fix. GREEN: pruned post-fix. The two existing related tests (bead-exists-but-not-yet-terminal repair, no-BeadID retention) still pass unchanged, confirming this only changes behavior for the bead-truly-absent case. `go test ./cmd/gc/... -run Nudge` and `go vet ./cmd/gc/...` both clean.

No local reproduction of the reporter's exact 134s/149x timing was possible (no live city with a multi-thousand-entry dead-letter queue available here), but the mechanism match is exact and the regression test proves the retained-forever behavior directly.

---

Generated with [Claude Code](https://claude.com/claude-code)