### PR TITLE
docs: update bd priority output examples

### DIFF
--- a/docs/reference/internal/beads-topology.md
+++ b/docs/reference/internal/beads-topology.md
@@ -117,7 +117,7 @@ But from `repo-a`, `bd` only sees its own:
 ```shell
 $ cd repo-a
 $ bd list
-○ riga-gne ● P2 work in repo-a
+○ riga-gne P2 work in repo-a
 
 $ bd show rigb-h2t
 no issue found: rigb-h2t

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -308,12 +308,12 @@ Watch the bead progress with `--watch`:
 ```shell
 ~/my-project
 $ gc bd show mp-ff9 --watch
-○ mp-ff9 · Write hello world in python to the file hello.py   [● P2 · OPEN]
+○ mp-ff9 · Write hello world in python to the file hello.py   [P2 · OPEN]
 Owner: Chris Sells · Type: task
 Created: 2026-04-07 · Updated: 2026-04-07
 
 BLOCKS
-  ← ○ mp-4tl: input convoy for mp-ff9 ● P2
+  ← ○ mp-4tl: input convoy for mp-ff9 P2
 
 Watching for changes... (Press Ctrl+C to exit)
 ```

--- a/docs/tutorials/06-beads.md
+++ b/docs/tutorials/06-beads.md
@@ -55,17 +55,17 @@ A bead is a unit of work with an ID, a title, a status, and a type. We use the
 ```shell
 ~/my-city
 $ bd list
-○ mc-0ez ● P2 Mix wet ingredients
-○ mc-265 ● P2 Combine wet and dry
-○ mc-79s ● P2 pancakes
-○ mc-9vb ● P2 Finalize workflow
-○ mc-a4l ● P2 Refactor auth module
-○ mc-b8g ● P2 Mix dry ingredients
-○ mc-d4g ● P2 Sprint 42
-○ mc-io4 ● P2 mayor
-○ mc-k3q ● P2 Serve
-○ mc-nia ● P2 Cook the pancakes
-○ mc-xp7 ● P2 Update API docs
+○ mc-0ez P2 Mix wet ingredients
+○ mc-265 P2 Combine wet and dry
+○ mc-79s P2 pancakes
+○ mc-9vb P2 Finalize workflow
+○ mc-a4l P2 Refactor auth module
+○ mc-b8g P2 Mix dry ingredients
+○ mc-d4g P2 Sprint 42
+○ mc-io4 P2 mayor
+○ mc-k3q P2 Serve
+○ mc-nia P2 Cook the pancakes
+○ mc-xp7 P2 Update API docs
 
 --------------------------------------------------------------------------------
 Total: 11 issues (11 open, 0 in progress)
@@ -166,8 +166,8 @@ $ bd close mc-ykp
 ✓ Closed mc-ykp — Fix the login bug: Closed
 
 $ bd list --status open --flat
-○ mc-a4l [● P2] [feature] - Refactor auth module
-○ mc-xp7 [● P2] [task]    - Update API docs
+○ mc-a4l [P2] [feature] - Refactor auth module
+○ mc-xp7 [P2] [task]    - Update API docs
 ```
 
 Note that the flag is `--status` (`--state` is a different command for state
@@ -184,7 +184,7 @@ what the city is doing right now, query the store:
 ```shell
 ~/my-city
 $ bd list --status in_progress --flat
-◐ mc-io4 [● P2] [session] - mayor
+◐ mc-io4 [P2] [session] - mayor
 ```
 
 Because work lives in the store rather than in memory, agent sessions are
@@ -208,7 +208,7 @@ $ bd label add mc-a4l frontend
 ✓ Added label 'frontend' to mc-a4l
 
 $ bd list --label priority:high --flat
-○ mc-a4l [● P2] [feature] - Refactor auth module
+○ mc-a4l [P2] [feature] - Refactor auth module
 ```
 
 `bd label add` takes a single label per call — apply multiples one at a time.
@@ -450,11 +450,11 @@ yours too.)
 ```shell
 ~/my-city
 $ bd list --status open --type task --flat
-○ mc-xp7 [● P2] [task] - Update API docs
-○ mc-b8g [● P2] [task] - Mix dry ingredients (blocks: mc-265)
+○ mc-xp7 [P2] [task] - Update API docs
+○ mc-b8g [P2] [task] - Mix dry ingredients (blocks: mc-265)
 
 $ bd show mc-a4l
-○ mc-a4l · Refactor auth module   [● P2 · OPEN]
+○ mc-a4l · Refactor auth module   [P2 · OPEN]
 Owner: dbox · Type: feature
 Created: 2026-04-08 · Updated: 2026-04-08
 
@@ -465,8 +465,8 @@ METADATA
   reviewer: sky
 
 BLOCKS
-  ← ○ mc-xp7: Update API docs ● P2
-  ← ○ mc-d4g: Sprint 42 ● P2
+  ← ○ mc-xp7: Update API docs P2
+  ← ○ mc-d4g: Sprint 42 P2
 
 $ bd close mc-a4l
 ✓ Closed mc-a4l — Refactor auth module: Closed

--- a/release-gates/ga-h2vm5j-bd-output-priority-glyph-gate.md
+++ b/release-gates/ga-h2vm5j-bd-output-priority-glyph-gate.md
@@ -1,0 +1,24 @@
+# Release gate: bd output priority glyph examples
+
+- Deploy bead: `ga-h2vm5j`
+- Build bead: `ga-bkhc6i`
+- Review bead: `ga-if6ipt`
+- Reviewed commit: `e0d21d9479891b13bff73fb5c56d2c4075c316f4`
+- Base: `origin/main@b4ef85b8f42530fbe49e18a0a077d0a9f00c3ca1`
+- Evaluated: 2026-08-15
+- Result: **PASS**
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-if6ipt` is closed with `verdict: pass` for the reviewed commit. |
+| 2 | Acceptance criteria met | **PASS** | The three published documentation examples and two frozen tutorial copies remove only the obsolete priority-position `● ` prefix. An independent repository scan found zero remaining `● P0` through `● P4` examples under `docs/` or `test/`. The status legend and its `○`, `◐`, `●`, `✓`, and `❄` status-position glyphs remain unchanged. The edits preserve literal command output and introduce no new terminology, links, pages, diagrams, generated docs, or body H1 headings. |
+| 3 | Tests pass | **PASS** | `make check-docs` passed with **13 PASS records, 0 FAIL, 0 SKIP** (11 top-level tests plus 2 schema subtests). `make test` passed with JSON terminal evidence of **39,182 test PASS, 0 FAIL, 184 test SKIP** and **170 package PASS, 0 FAIL, 18 no-test package SKIP**. The test SKIPs are pre-existing platform, integration, and build-tag exclusions unrelated to this five-file Markdown diff; the docs-owned suite had zero skips. `diff_tests_executed`: none (no test files in the diff). `waiver_ref`: none. |
+| 4 | No high-severity review findings open | **PASS** | Review bead records no style or security findings and no unresolved HIGH findings. |
+| 5 | Final branch is clean | **PASS** | The reviewed worktree was clean after both test commands and the content scans; this checklist is the only deployer-authored artifact and is committed separately. |
+| 6 | Branch diverges cleanly from main | **PASS** | No existing PR carries the reviewed commit. `git merge-tree --write-tree origin/main e0d21d9479891b13bff73fb5c56d2c4075c316f4` exited 0 and produced tree `fea4a5745386b113a3d9a96f004a9a8934af8b88`; merge base is `6e7fb75304bbf930d194ab6c4b5fdb0ef4180cb1`. |
+| 7 | Single feature theme | **PASS** | All five changed Markdown files refresh one literal `bd` output convention: priority is rendered as `P2` without the obsolete dot prefix. |
+
+## Release decision
+
+All seven criteria pass. The deploy source is the exact reviewed commit above;
+the gate checklist is the only additional commit on the isolated deploy branch.

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
@@ -265,7 +265,7 @@ dispatched it to the `claude` agent. You can watch it progress:
 ```shell
 ~/my-city
 $ bd show mp-ff9 --watch
-✓ mp-ff9 · Write hello world in python to the file hello.py   [● P2 · CLOSED]
+✓ mp-ff9 · Write hello world in python to the file hello.py   [P2 · CLOSED]
 Owner: Chris Sells · Assignee: claude-mp-208 · Type: task
 Created: 2026-04-07 · Updated: 2026-04-07
 
@@ -273,7 +273,7 @@ NOTES
 Done: created project README.md
 
 PARENT
-  ↑ ○ mp-6yh: sling-mp-ff9 ● P2
+  ↑ ○ mp-6yh: sling-mp-ff9 P2
 
 Watching for changes... (Press Ctrl+C to exit)
 ```

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/06-beads.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/06-beads.md
@@ -19,14 +19,14 @@ A bead is a unit of work with an ID, a title, a status, and a type. We use the `
 ```shell
 ~/my-city
 $ bd list
-○ mc-194 ● P2 pancakes
-├── ○ mc-194.3 ● P2 Combine wet and dry
-├── ○ mc-194.4 ● P2 Cook the pancakes
-└── ○ mc-194.5 ● P2 Serve
-○ mc-a4l ● P2 Refactor auth module
-○ mc-d4g ● P2 Sprint 42
-○ mc-io4 ● P2 mayor
-○ mc-xp7 ● P2 Update API docs
+○ mc-194 P2 pancakes
+├── ○ mc-194.3 P2 Combine wet and dry
+├── ○ mc-194.4 P2 Cook the pancakes
+└── ○ mc-194.5 P2 Serve
+○ mc-a4l P2 Refactor auth module
+○ mc-d4g P2 Sprint 42
+○ mc-io4 P2 mayor
+○ mc-xp7 P2 Update API docs
 
 Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred
 ```
@@ -101,8 +101,8 @@ $ bd close mc-ykp
 ✓ Closed mc-ykp — Fix the login bug: Closed
 
 $ bd list --status open --flat
-○ mc-a4l [● P2] [feature] - Refactor auth module
-○ mc-xp7 [● P2] [task]    - Update API docs
+○ mc-a4l [P2] [feature] - Refactor auth module
+○ mc-xp7 [P2] [task]    - Update API docs
 ```
 
 Note that the flag is `--status` (`--state` is a different command for state dimensions).
@@ -114,8 +114,8 @@ The bead store is effectively the execution state of the entire system. Every se
 ```shell
 ~/my-city
 $ bd list --status in_progress --flat
-◐ mc-io4 [● P2] [session] - mayor
-◐ mc-a4l [● P2] [feature] - Refactor auth module
+◐ mc-io4 [P2] [session] - mayor
+◐ mc-a4l [P2] [feature] - Refactor auth module
 ```
 
 This is what makes Gas City crash-safe. Work isn't held in memory or tracked by a running process — it's persisted in the store. If an agent dies, its beads stay open. When the agent restarts, its hooks discover the same work and pick up where it left off. If the whole city stops and restarts, the bead store is the ground truth for what was happening and what still needs to happen.
@@ -135,7 +135,7 @@ $ bd label add mc-a4l frontend
 ✓ Added label 'frontend' to mc-a4l
 
 $ bd list --label priority:high --flat
-○ mc-a4l [● P2] [feature] - Refactor auth module
+○ mc-a4l [P2] [feature] - Refactor auth module
 ```
 
 `bd label add` takes a single label per call — apply multiples one at a time.
@@ -327,11 +327,11 @@ You don't usually work with beads directly. The higher-level commands — `gc se
 ```shell
 ~/my-city
 $ bd list --status open --type task --flat
-○ mc-xp7 [● P2] [task] - Update API docs
-○ mc-2wx.1 [● P2] [task] - Mix dry ingredients (parent: mc-2wx, blocks: mc-2wx.3)
+○ mc-xp7 [P2] [task] - Update API docs
+○ mc-2wx.1 [P2] [task] - Mix dry ingredients (parent: mc-2wx, blocks: mc-2wx.3)
 
 $ bd show mc-a4l
-○ mc-a4l · Refactor auth module   [● P2 · OPEN]
+○ mc-a4l · Refactor auth module   [P2 · OPEN]
 Owner: dbox · Type: feature
 Created: 2026-04-08 · Updated: 2026-04-08
 
@@ -342,10 +342,10 @@ METADATA
   reviewer: sky
 
 PARENT
-  ↑ ○ mc-d4g: Sprint 42 ● P2
+  ↑ ○ mc-d4g: Sprint 42 P2
 
 BLOCKS
-  ← ○ mc-xp7: Update API docs ● P2
+  ← ○ mc-xp7: Update API docs P2
 
 $ bd close mc-a4l
 ✓ Closed mc-a4l — Refactor auth module: Closed


### PR DESCRIPTION
## What this changes

Updates the Gas City tutorials and internal beads-topology reference to match
current `bd` output. Priority now appears as `P2` instead of the obsolete
`● P2`, while status glyphs such as `○` for open and `●` for blocked remain
unchanged.

The frozen tutorial copies are updated alongside the published pages so the
documentation examples and their acceptance fixtures stay synchronized.

## Review notes

- The change is limited to three documentation pages and two frozen tutorial copies.
- No commands, configuration, generated reference content, or runtime behavior change.
- Review the distinction between the removed priority prefix and the preserved status glyphs.

## Test plan

- [x] `make check-docs`
- [x] `make test`
- [x] Repository scan confirms no stale `● P0` through `● P4` examples remain under `docs/` or `test/`
- [x] Release gate: [`release-gates/ga-h2vm5j-bd-output-priority-glyph-gate.md`](release-gates/ga-h2vm5j-bd-output-priority-glyph-gate.md)
