### PR TITLE
fix(beads): emit bead.* from one-shot CLI mutations of a relocated coordination class (G16/G17)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1606,9 +1606,9 @@ func (cs *controllerState) ScopedStoreLike(ctx context.Context, existing beads.S
 // NudgesBeadStore returns the store backing the nudge-queue shadow beads. At the
 // default backend resolveNudgesStore returns cityBeadStore, so this is byte-identical
 // to CityBeadStore; when [beads.classes.nudges] is relocated it returns the per-class
-// store. cs.eventProv is the recorder (an events.Recorder), matching how the city mail
-// store is wired (newCityMailProvider), so relocated writes through this store emit
-// bead.* exactly like the controller's own nudge writes. The result is wrapped in the
+// store. cs.eventProv is passed for signature parity with the other accessors and is
+// ignored by resolveNudgesStore; the controller's emission comes from the CachingStore
+// around its work ledger, not from this argument. The result is wrapped in the
 // strongly-typed beads.NudgesStore so the nudges class is statically visible to callers;
 // the wrapper carries the same underlying store value, so runtime behavior is unchanged.
 func (cs *controllerState) NudgesBeadStore() beads.NudgesStore {
@@ -1620,8 +1620,8 @@ func (cs *controllerState) NudgesBeadStore() beads.NudgesStore {
 // SessionsBeadStore returns the store backing session-class beads. At the default
 // backend resolveSessionStore returns cityBeadStore, so this is byte-identical to
 // CityBeadStore; when [beads.classes.sessions] is relocated it returns the per-class
-// store. cs.eventProv is the recorder, matching the nudges/mail wiring, so relocated
-// session writes emit bead.* exactly like the controller's own session writes. The
+// store. cs.eventProv is passed for signature parity and ignored by
+// resolveSessionStore, exactly as it is for every other class. The
 // result is wrapped in the strongly-typed beads.SessionStore so the session class is
 // statically visible to callers; the wrapper carries the same underlying store value,
 // so runtime behavior is unchanged.
@@ -1636,8 +1636,10 @@ func (cs *controllerState) SessionsBeadStore() beads.SessionStore {
 // when [beads.classes.graph] is relocated it returns the dedicated graph store at the
 // legacy .gc/beads.sqlite location (or the gcg Postgres schema). cs.eventProv is
 // passed for signature parity with the other accessors but is ignored by
-// resolveGraphStore: the graph store stays event-silent, matching the prior Router
-// graph leg. The result is wrapped in the strongly-typed beads.GraphStore so the
+// resolveGraphStore, as it is for every class: a class store carries no emitting
+// layer, and on this side the controller's CachingStore is the emitter. The
+// one-shot CLI's side is covered by class_store_emit.go. The result is wrapped in
+// the strongly-typed beads.GraphStore so the
 // graph class is statically visible to callers; the wrapper carries the same
 // underlying store value, so runtime behavior is unchanged.
 func (cs *controllerState) GraphBeadStore() beads.GraphStore {

--- a/cmd/gc/class_store.go
+++ b/cmd/gc/class_store.go
@@ -109,9 +109,12 @@ func (cr *CityRuntime) graphBeadStore() beads.GraphStore {
 }
 
 // sessionsBeadStore returns the runtime's session/session-wait bead store: the
-// configured session class store (with the controller recorder so relocated
-// session writes emit bead.*) when [beads.classes.sessions] relocates sessions,
-// else the work store. Byte-identical to cityBeadStore() at the default bd backend.
+// configured session class store when [beads.classes.sessions] relocates
+// sessions, else the work store. The recorder is passed for signature parity
+// and is not what makes a write observable — the controller's emission comes
+// from the CachingStore around its work ledger, and a relocated class store has
+// no such layer on this side (class_store_emit.go covers the one-shot CLI's).
+// Byte-identical to cityBeadStore() at the default bd backend.
 // Returned as the strongly-typed beads.SessionStore so the session class stays
 // statically visible; the wrapper carries the same underlying store value.
 func (cr *CityRuntime) sessionsBeadStore() beads.SessionStore {
@@ -251,7 +254,13 @@ func (s *beadPolicyGraphStore) graphApplierFor(_ coordclass.Class) beads.GraphAp
 // agree.
 //
 // cfg, cityPath and rec stay in the signature for the per-scope work routing
-// that resolves elsewhere; they are not read here.
+// that resolves elsewhere; they are not read here. rec in particular does NOT
+// make a relocated write observable, for any class: a class store is a bare
+// bead engine with no emitting layer, and what a caller passes here changes
+// nothing about that. Emission is decided where the ROUTES are built, once —
+// the one-shot CLI funnel gives its stores an emit target
+// (storageRoutes.withCLIEmission), and the controller's boot does not, because
+// its own emitter already covers it. See class_store_emit.go.
 func resolveClassStore(routes *storageRoutes, workStore beads.Store, cfg *config.City, cityPath, class string, rec events.Recorder) beads.Store {
 	_ = cfg
 	_ = cityPath
@@ -311,9 +320,9 @@ func resolveSessionStore(routes *storageRoutes, workStore beads.Store, cfg *conf
 
 // resolveGraphStore returns the beads.Store backing the GRAPH coordination
 // class. Identity today: the work store. When graph relocates, the dedicated
-// graph-store dispatch plugs in at resolveClassStore (graph uses its own legacy
-// .gc/ location and is event-silent by design, so rec is accepted for signature
-// parity with the other resolve*Store helpers and ignored here).
+// graph-store dispatch plugs in at resolveClassStore. rec is accepted for
+// signature parity with the other resolve*Store helpers and ignored here, as it
+// is for every class: see resolveClassStore.
 func resolveGraphStore(routes *storageRoutes, workStore beads.Store, cfg *config.City, cityPath string, rec events.Recorder) beads.Store {
 	return resolveClassStore(routes, workStore, cfg, cityPath, config.BeadClassGraph, rec)
 }

--- a/cmd/gc/class_store_emit.go
+++ b/cmd/gc/class_store_emit.go
@@ -146,8 +146,10 @@ type classStoreEmission struct {
 //
 // events.WithoutStartupSweep is what makes a per-mutation open safe: the sweep
 // exists to recover rotating-* files a crash stranded, it belongs to the
-// supervisor's long-lived recorder, and running it here would both scan the log
-// directory on every mutation and race that recorder mid-rotation.
+// supervisor's long-lived recorder, and running it here would race that
+// recorder mid-rotation. It does not make the open free — NewFileRecorder reads
+// the log directory either way, to continue the sequence past the archives —
+// only unraced.
 func (s *emittingClassStore) emit(emissions ...classStoreEmission) {
 	if len(emissions) == 0 {
 		return

--- a/cmd/gc/class_store_emit.go
+++ b/cmd/gc/class_store_emit.go
@@ -1,0 +1,722 @@
+package main
+
+// bead.* emission for the one-shot CLI's relocated coordination classes.
+//
+// A split city serves graph, sessions, messaging, orders and nudges from a
+// binding the controller opens at boot and one-shot commands open through the
+// funnel (cli_storage_routes.go). The controller's copy of the city's work
+// ledger sits under a CachingStore, whose notifyChange appends a bead.* row to
+// <city>/.gc/events.jsonl after every mutation. The binding has no such layer
+// on either side, so every write a one-shot command made to a relocated class —
+// `gc bd close` of a gcg- step, `gc sling`, `gc formula cook`, the control
+// dispatcher's one-shot arm, mail, nudges — landed in the store and appended
+// nothing.
+//
+// What that costs is not the events: it is every consumer that reconstructs
+// state by folding them. The event-sourced run projection never saw a
+// worker-side close, so a molecule's steps rendered "Running" forever and the
+// wisp reap made it permanent by deleting the rows the fold would have needed
+// to recover from. The event-delta lanes read the same journal from a cursor,
+// so on a split city they read an empty delta and conclude nothing happened.
+//
+// # One target, injected once
+//
+// Emission is not a property of a store; it is a property of the PROCESS that
+// opened it. The controller has a live event bus and its own emitter, and a
+// second one on the same mutation is a double row in the log — worse on the
+// reconcile path, where the cache re-absorbs rows in bulk and a per-row emitter
+// turns absorption into a flood.
+//
+// So the emit target is set on the ROUTES, at the one construction that belongs
+// to a one-shot command (resolveCLIStorageRoutes), and never at the one that
+// belongs to the controller (openStorageRoutes). The controller path is
+// therefore untouched by construction rather than by a runtime test that could
+// answer wrongly: it never reaches this file at all.
+// TestClassStoreEmitTargetHasExactlyOneInjectionSite pins the single injector,
+// because "the controller does not emit" is a claim about the call graph and
+// nothing else keeps a second injector from appearing.
+//
+// # Why the wrapper forwards so much
+//
+// A relocated class store is a bare bead engine: openStorageRoutes hands back
+// whatever the binding's provider opened (a *beads.SQLiteStore for the built-in
+// binding, a *beads.NativeDoltStore for a workspace one) with no wrapper of any
+// kind. Emission therefore has to arrive as one, and a wrapper is exactly how
+// this repo loses capabilities: the optional interfaces are discovered by type
+// assertion, so a method the wrapper does not carry does not fail — the caller
+// simply stops matching and takes a slower or weaker path, silently. Every
+// method either engine declares is forwarded here, and
+// TestEmittingClassStoreKeepsEveryEngineCapability fails if either grows one
+// this file does not.
+//
+// # What it emits, and what it deliberately does not
+//
+// The payload is the canonical bead snapshot CachingStore.notifyChange emits —
+// json.Marshal of the post-write bead, decodable by beads.DecodeBeadEventPayload
+// and foldable by the run projection — with the run/session/step correlation
+// resolved onto the typed envelope from the same metadata keys and through the
+// same helpers. bead.closed rides only a genuine open→closed transition, because
+// the export boundary drops bead.updated and a metadata write to a closed bead
+// that rode bead.closed would re-close it in every replay.
+//
+// Tx is NOT shadowed. A transaction's effect is whatever its body did, and this
+// layer cannot know which beads changed without re-reading the store around
+// every call — so a Tx-shaped write on a relocated class stays event-dark, as it
+// was before this file. That is a known gap rather than an oversight; closing it
+// needs a touched-id set from the Tx itself.
+//
+// Emission is best-effort, per the one-shot recorder precedent: the mutation has
+// already committed when the row is written, so a journal that cannot be opened
+// must not turn a landed close into a failed command. Failures are surfaced once
+// per process through classStoreEmitWarn rather than swallowed, because a
+// dropped terminal event that nobody hears about is the failure this file
+// exists to end.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// withCLIEmission makes every class store these routes serve append a canonical
+// bead.* event to cityPath's journal after each successful mutation, and
+// returns the routes.
+//
+// It is the ONE injector. Nil routes (a city that relocates nothing) and an
+// empty city path are returned untouched, so a single-store city reaches none
+// of this and its class resolvers keep returning the caller's own store value.
+//
+// Each distinct leaf store is wrapped exactly once, and every class it serves
+// gets that same wrapper value. Store identity is load-bearing: callers dedup
+// scan candidates in a map[beads.Store], so a wrapper per class would turn one
+// binding into five and re-scan it five times.
+func (r *storageRoutes) withCLIEmission(cityPath string) *storageRoutes {
+	cityPath = strings.TrimSpace(cityPath)
+	if r == nil || cityPath == "" || len(r.stores) == 0 {
+		return r
+	}
+	emitting := make(map[beads.Store]beads.Store, 1)
+	for class, store := range r.stores {
+		if store == nil {
+			continue
+		}
+		wrapped, ok := emitting[store]
+		if !ok {
+			wrapped = &emittingClassStore{Store: store, cityPath: cityPath}
+			emitting[store] = wrapped
+		}
+		r.stores[class] = wrapped
+	}
+	r.emitCityPath = cityPath
+	return r
+}
+
+// emittingClassStore is a relocated class store that appends a bead.* event
+// after each successful mutation. The embedded Store carries the required
+// surface; every optional capability either bead engine declares is forwarded
+// explicitly below.
+type emittingClassStore struct {
+	beads.Store
+	cityPath string
+}
+
+// ---------------------------------------------------------------------------
+// Emission.
+
+// classStoreEmission is one pending row: the event type and the bead snapshot
+// to carry as its payload.
+type classStoreEmission struct {
+	eventType string
+	bead      beads.Bead
+}
+
+// emit appends one row per emission to the city's journal through a single
+// recorder, which owns the cross-process sequence and locking.
+//
+// events.WithoutStartupSweep is what makes a per-mutation open safe: the sweep
+// exists to recover rotating-* files a crash stranded, it belongs to the
+// supervisor's long-lived recorder, and running it here would both scan the log
+// directory on every mutation and race that recorder mid-rotation.
+func (s *emittingClassStore) emit(emissions ...classStoreEmission) {
+	if len(emissions) == 0 {
+		return
+	}
+	rec, err := newClassStoreEmitRecorder(s.cityPath)
+	if err != nil {
+		warnClassStoreEmit(fmt.Errorf("opening the event log of %s: %w", s.cityPath, err))
+		return
+	}
+	defer rec.Close() //nolint:errcheck // best-effort: emission never surfaces I/O errors
+	actor := eventActor()
+	for _, emission := range emissions {
+		if strings.TrimSpace(emission.bead.ID) == "" {
+			continue
+		}
+		payload, err := json.Marshal(emission.bead)
+		if err != nil {
+			warnClassStoreEmit(fmt.Errorf("marshaling the %s payload of %s: %w", emission.eventType, emission.bead.ID, err))
+			continue
+		}
+		stepID := emission.bead.Metadata[beadmeta.StepIDMetadataKey]
+		rec.Record(events.Event{
+			Type:             emission.eventType,
+			Actor:            actor,
+			Subject:          emission.bead.ID,
+			RunID:            beadmeta.ResolveRunID(emission.bead.Metadata, emission.bead.ID, ""),
+			SessionID:        emission.bead.Metadata[beadmeta.SessionIDMetadataKey],
+			StepID:           stepID,
+			DependsOnStepIDs: beads.NativeStepDependencies(emission.bead.Metadata, stepID),
+			Payload:          payload,
+		})
+	}
+}
+
+// snapshot re-reads the post-write bead so the payload is the authoritative
+// fresh state, which is what the controller's emitter does for the same reason.
+//
+// A read miss reports ok=false and the caller skips the row rather than
+// emitting a bare id: an empty snapshot does not merely say less, it CLOBBERS
+// the fold, because a projection applying it overwrites the row's title, status
+// and run membership with nothing.
+//
+// Dependency edges are hydrated because the controller's payload carries them
+// and a consumer comparing the two shapes would otherwise read the CLI's as an
+// edge removal.
+func (s *emittingClassStore) snapshot(id string) (beads.Bead, bool) {
+	bead, err := s.Get(id)
+	if err != nil || strings.TrimSpace(bead.ID) == "" {
+		return beads.Bead{}, false
+	}
+	if deps, err := s.DepList(id, "down"); err == nil {
+		bead.Dependencies = deps
+		bead.Needs = nil
+	}
+	return bead, true
+}
+
+// emitCreated records bead.created for a landed create. A post-write read miss
+// falls back to what the store returned, which is a full snapshot rather than a
+// bare id, so a create is never dropped on a store with read-after-write lag.
+func (s *emittingClassStore) emitCreated(created beads.Bead, err error) {
+	if err != nil {
+		return
+	}
+	if strings.TrimSpace(created.ID) == "" {
+		warnClassStoreEmit(errors.New("bead.created skipped: the create returned an empty id"))
+		return
+	}
+	bead, ok := s.snapshot(created.ID)
+	if !ok {
+		bead = created
+	}
+	s.emit(classStoreEmission{eventType: events.BeadCreated, bead: bead})
+}
+
+// emitUpdated records bead.updated for a write that cannot have changed the
+// bead's terminal state — metadata, assignment, dependency edges, a reopen. A
+// read miss skips the row rather than emitting a bare id.
+func (s *emittingClassStore) emitUpdated(id string) {
+	bead, ok := s.snapshot(id)
+	if !ok {
+		warnClassStoreEmit(fmt.Errorf("bead.updated skipped: %s could not be re-read after the write", id))
+		return
+	}
+	s.emit(classStoreEmission{eventType: events.BeadUpdated, bead: bead})
+}
+
+// emitAfterUpdate records the lifecycle edge a landed Update produced.
+//
+// bead.closed rides only a genuine open→closed transition. A metadata write to
+// an already-closed bead is an update, matching the controller's emitter: the
+// export boundary drops bead.updated, so a close edge must ride bead.closed —
+// and a false one would re-close the bead in every replay of the log.
+//
+// On a read miss the row is synthesized from the write's own status when it
+// carried one, so a committed close still rides bead.closed with a non-empty
+// status, and skipped otherwise.
+func (s *emittingClassStore) emitAfterUpdate(id string, opts beads.UpdateOpts, wasClosed bool) {
+	bead, ok := s.snapshot(id)
+	if !ok {
+		if opts.Status == nil {
+			warnClassStoreEmit(fmt.Errorf("bead.updated skipped: %s could not be re-read after the update", id))
+			return
+		}
+		bead = beads.Bead{ID: id, Status: *opts.Status, Metadata: maps.Clone(opts.Metadata)}
+	}
+	eventType := events.BeadUpdated
+	if !wasClosed && beadStatusIsClosed(bead.Status) {
+		eventType = events.BeadClosed
+	}
+	s.emit(classStoreEmission{eventType: eventType, bead: bead})
+}
+
+// emitClosed records bead.closed for a close this store proved committed.
+//
+// Unlike the update path a read miss still emits, with the id and the status the
+// close established: the terminal transition is a fact, and dropping it is the
+// exact silence the seam exists to end.
+func (s *emittingClassStore) emitClosed(id string) {
+	bead, ok := s.snapshot(id)
+	if !ok {
+		bead = beads.Bead{ID: id}
+	}
+	bead.Status = beadStatusClosed
+	s.emit(classStoreEmission{eventType: events.BeadClosed, bead: bead})
+}
+
+// closedBefore reports whether a bead was already closed before a write. A read
+// that fails answers "not closed", which is the safe direction: the write's own
+// post-state then decides, and an event that says closed when the bead is closed
+// is never wrong.
+func (s *emittingClassStore) closedBefore(id string) bool {
+	bead, err := s.Get(id)
+	return err == nil && beadStatusIsClosed(bead.Status)
+}
+
+// snapshotBeforeDelete captures the pre-delete beads, because there is nothing
+// to read afterwards. Dependency edges are not hydrated: bead.deleted removes
+// the row from the fold, so its edges cannot matter.
+func (s *emittingClassStore) snapshotBeforeDelete(ids ...string) []beads.Bead {
+	out := make([]beads.Bead, 0, len(ids))
+	for _, id := range ids {
+		if bead, err := s.Get(id); err == nil && strings.TrimSpace(bead.ID) != "" {
+			out = append(out, bead)
+			continue
+		}
+		out = append(out, beads.Bead{ID: id})
+	}
+	return out
+}
+
+// emitDeleted records bead.deleted for each pre-delete snapshot.
+func (s *emittingClassStore) emitDeleted(snapshots []beads.Bead) {
+	emissions := make([]classStoreEmission, 0, len(snapshots))
+	for _, bead := range snapshots {
+		emissions = append(emissions, classStoreEmission{eventType: events.BeadDeleted, bead: bead})
+	}
+	s.emit(emissions...)
+}
+
+// emitGraphApplyCreated records bead.created for every bead a graph apply
+// materialized. A graph apply IS the create path for a molecule — it writes the
+// root and its steps in one plan — so a relocated apply that emitted nothing
+// would leave the run projection with steps it never saw begin. A per-bead read
+// miss skips that bead rather than dropping the batch.
+func (s *emittingClassStore) emitGraphApplyCreated(result *beads.GraphApplyResult, err error) {
+	if err != nil || result == nil || len(result.IDs) == 0 {
+		return
+	}
+	emissions := make([]classStoreEmission, 0, len(result.IDs))
+	for _, id := range result.IDs {
+		if strings.TrimSpace(id) == "" {
+			continue
+		}
+		bead, ok := s.snapshot(id)
+		if !ok {
+			warnClassStoreEmit(fmt.Errorf("bead.created skipped: graph-applied %s could not be re-read", id))
+			continue
+		}
+		emissions = append(emissions, classStoreEmission{eventType: events.BeadCreated, bead: bead})
+	}
+	s.emit(emissions...)
+}
+
+// ---------------------------------------------------------------------------
+// The required surface. Each method delegates and then emits; the delegation is
+// the whole behavior, so a failed write emits nothing.
+
+func (s *emittingClassStore) Create(bead beads.Bead) (beads.Bead, error) {
+	created, err := s.Store.Create(bead)
+	s.emitCreated(created, err)
+	return created, err
+}
+
+func (s *emittingClassStore) Update(id string, opts beads.UpdateOpts) error {
+	wasClosed := s.closedBefore(id)
+	if err := s.Store.Update(id, opts); err != nil {
+		return err
+	}
+	s.emitAfterUpdate(id, opts, wasClosed)
+	return nil
+}
+
+func (s *emittingClassStore) Close(id string) error {
+	if err := s.Store.Close(id); err != nil {
+		return err
+	}
+	s.emitClosed(id)
+	return nil
+}
+
+func (s *emittingClassStore) Reopen(id string) error {
+	if err := s.Store.Reopen(id); err != nil {
+		return err
+	}
+	s.emitUpdated(id)
+	return nil
+}
+
+// CloseAll emits one bead.closed per bead that actually transitioned. The
+// pre-state is captured first so a bead already closed produces no row, and the
+// post-state is confirmed so a bead the backing store declined to close
+// produces none either.
+func (s *emittingClassStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	wasOpen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		wasOpen[id] = !s.closedBefore(id)
+	}
+	n, err := s.Store.CloseAll(ids, metadata)
+	var emissions []classStoreEmission
+	for _, id := range ids {
+		if !wasOpen[id] {
+			continue
+		}
+		bead, ok := s.snapshot(id)
+		if !ok || !beadStatusIsClosed(bead.Status) {
+			continue
+		}
+		emissions = append(emissions, classStoreEmission{eventType: events.BeadClosed, bead: bead})
+	}
+	s.emit(emissions...)
+	return n, err
+}
+
+func (s *emittingClassStore) Delete(id string) error {
+	snapshots := s.snapshotBeforeDelete(id)
+	if err := s.Store.Delete(id); err != nil {
+		return err
+	}
+	s.emitDeleted(snapshots)
+	return nil
+}
+
+func (s *emittingClassStore) SetMetadata(id, key, value string) error {
+	if err := s.Store.SetMetadata(id, key, value); err != nil {
+		return err
+	}
+	s.emitUpdated(id)
+	return nil
+}
+
+func (s *emittingClassStore) SetMetadataBatch(id string, values map[string]string) error {
+	if err := s.Store.SetMetadataBatch(id, values); err != nil {
+		return err
+	}
+	s.emitUpdated(id)
+	return nil
+}
+
+// DepAdd emits for the bead whose edges changed. The snapshot hydrates edges
+// through DepList, so the payload reflects the new one.
+func (s *emittingClassStore) DepAdd(issueID, dependsOnID, depType string) error {
+	if err := s.Store.DepAdd(issueID, dependsOnID, depType); err != nil {
+		return err
+	}
+	s.emitUpdated(issueID)
+	return nil
+}
+
+func (s *emittingClassStore) DepRemove(issueID, dependsOnID string) error {
+	if err := s.Store.DepRemove(issueID, dependsOnID); err != nil {
+		return err
+	}
+	s.emitUpdated(issueID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Optional capabilities. Every method either bead engine declares appears here,
+// so wrapping cannot silently narrow what a caller's type assertion finds. A
+// method the underlying store does not implement answers with the sentinel the
+// beads package publishes for it, or with the zero value where the question is
+// a capability question and the honest answer is "no".
+
+func (s *emittingClassStore) CreateWithStorage(bead beads.Bead, storage beads.StorageClass) (beads.Bead, error) {
+	creator, ok := s.Store.(beads.StorageCreateStore)
+	if !ok {
+		return beads.Bead{}, fmt.Errorf("creating with a storage class: %T does not support it", s.Store)
+	}
+	created, err := creator.CreateWithStorage(bead, storage)
+	s.emitCreated(created, err)
+	return created, err
+}
+
+func (s *emittingClassStore) CreateWithForeignID(bead beads.Bead) (beads.Bead, error) {
+	creator, ok := s.Store.(interface {
+		CreateWithForeignID(beads.Bead) (beads.Bead, error)
+	})
+	if !ok {
+		return beads.Bead{}, fmt.Errorf("creating with a foreign id: %T does not support it", s.Store)
+	}
+	created, err := creator.CreateWithForeignID(bead)
+	s.emitCreated(created, err)
+	return created, err
+}
+
+func (s *emittingClassStore) UpdateIfMatch(id string, revision int64, opts beads.UpdateOpts) error {
+	writer, ok := beads.ConditionalWriterFor(s.Store)
+	if !ok {
+		return beads.ErrConditionalWriteUnsupported
+	}
+	wasClosed := s.closedBefore(id)
+	if err := writer.UpdateIfMatch(id, revision, opts); err != nil {
+		return err
+	}
+	s.emitAfterUpdate(id, opts, wasClosed)
+	return nil
+}
+
+func (s *emittingClassStore) CloseIfMatch(id string, revision int64) error {
+	writer, ok := beads.ConditionalWriterFor(s.Store)
+	if !ok {
+		return beads.ErrConditionalWriteUnsupported
+	}
+	if err := writer.CloseIfMatch(id, revision); err != nil {
+		return err
+	}
+	s.emitClosed(id)
+	return nil
+}
+
+func (s *emittingClassStore) DeleteIfMatch(id string, revision int64) error {
+	writer, ok := beads.ConditionalWriterFor(s.Store)
+	if !ok {
+		return beads.ErrConditionalWriteUnsupported
+	}
+	snapshots := s.snapshotBeforeDelete(id)
+	if err := writer.DeleteIfMatch(id, revision); err != nil {
+		return err
+	}
+	s.emitDeleted(snapshots)
+	return nil
+}
+
+// CompareAndSetMetadataKey emits only when the swap actually happened: a
+// refused compare changed nothing, and a row saying otherwise would make every
+// fold disagree with the store.
+func (s *emittingClassStore) CompareAndSetMetadataKey(id, key, expected, next string) (bool, error) {
+	swapper, ok := s.Store.(interface {
+		CompareAndSetMetadataKey(string, string, string, string) (bool, error)
+	})
+	if !ok {
+		return false, beads.ErrConditionalWriteUnsupported
+	}
+	swapped, err := swapper.CompareAndSetMetadataKey(id, key, expected, next)
+	if err == nil && swapped {
+		s.emitUpdated(id)
+	}
+	return swapped, err
+}
+
+func (s *emittingClassStore) Claim(id, assignee string) (beads.Bead, bool, error) {
+	claimer, ok := s.Store.(interface {
+		Claim(string, string) (beads.Bead, bool, error)
+	})
+	if !ok {
+		return beads.Bead{}, false, beads.ErrConditionalWriteUnsupported
+	}
+	bead, claimed, err := claimer.Claim(id, assignee)
+	if err == nil && claimed {
+		s.emitUpdated(id)
+	}
+	return bead, claimed, err
+}
+
+func (s *emittingClassStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
+	releaser, ok := s.Store.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		return false, beads.ErrConditionalReleaseUnsupported
+	}
+	released, err := releaser.ReleaseIfCurrent(id, expectedAssignee)
+	if err == nil && released {
+		s.emitUpdated(id)
+	}
+	return released, err
+}
+
+func (s *emittingClassStore) DeleteBatch(ids []string) error {
+	deleter, ok := s.Store.(beads.BatchDeleter)
+	if !ok {
+		return beads.ErrBatchDeleteUnsupported
+	}
+	snapshots := s.snapshotBeforeDelete(ids...)
+	if err := deleter.DeleteBatch(ids); err != nil {
+		return err
+	}
+	s.emitDeleted(snapshots)
+	return nil
+}
+
+func (s *emittingClassStore) ApplyGraphPlan(ctx context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) {
+	applier, ok := beads.GraphApplyFor(s.Store)
+	if !ok {
+		return nil, fmt.Errorf("applying a graph plan: %T does not support it", s.Store)
+	}
+	result, err := applier.ApplyGraphPlan(ctx, plan)
+	s.emitGraphApplyCreated(result, err)
+	return result, err
+}
+
+func (s *emittingClassStore) ApplyGraphPlanWithStorage(ctx context.Context, plan *beads.GraphApplyPlan, storage beads.StorageClass) (*beads.GraphApplyResult, error) {
+	applier, ok := s.Store.(beads.StorageGraphApplyStore)
+	if !ok {
+		return nil, fmt.Errorf("applying a graph plan with a storage class: %T does not support it", s.Store)
+	}
+	result, err := applier.ApplyGraphPlanWithStorage(ctx, plan, storage)
+	s.emitGraphApplyCreated(result, err)
+	return result, err
+}
+
+func (s *emittingClassStore) ReadyContext(ctx context.Context, query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	reader, ok := s.Store.(beads.ContextReadyReader)
+	if !ok {
+		return nil, beads.ErrReadyContextUnsupported
+	}
+	return reader.ReadyContext(ctx, query...)
+}
+
+func (s *emittingClassStore) Count(ctx context.Context, query beads.ListQuery, excludeTypes ...string) (int, error) {
+	counter, ok := s.Store.(beads.Counter)
+	if !ok {
+		return 0, beads.ErrCountUnsupported
+	}
+	return counter.Count(ctx, query, excludeTypes...)
+}
+
+func (s *emittingClassStore) WaitForParentProjection(ctx context.Context, parentID, childID, scope string) error {
+	waiter, ok := s.Store.(beads.ParentProjectionWaiter)
+	if !ok {
+		return nil
+	}
+	return waiter.WaitForParentProjection(ctx, parentID, childID, scope)
+}
+
+func (s *emittingClassStore) DepMetadata(issueID, dependsOnID string) (string, bool, error) {
+	reader, ok := s.Store.(interface {
+		DepMetadata(string, string) (string, bool, error)
+	})
+	if !ok {
+		return "", false, nil
+	}
+	return reader.DepMetadata(issueID, dependsOnID)
+}
+
+func (s *emittingClassStore) SequenceFloor() (int64, error) {
+	floor, ok := s.Store.(interface{ SequenceFloor() (int64, error) })
+	if !ok {
+		return 0, fmt.Errorf("reading the sequence floor: %T does not keep one", s.Store)
+	}
+	return floor.SequenceFloor()
+}
+
+func (s *emittingClassStore) SetSequenceFloor(seq int64) error {
+	floor, ok := s.Store.(interface{ SetSequenceFloor(int64) error })
+	if !ok {
+		return fmt.Errorf("setting the sequence floor: %T does not keep one", s.Store)
+	}
+	return floor.SetSequenceFloor(seq)
+}
+
+func (s *emittingClassStore) AdvanceSequenceFloor(seq int64) {
+	if floor, ok := s.Store.(interface{ AdvanceSequenceFloor(int64) }); ok {
+		floor.AdvanceSequenceFloor(seq)
+	}
+}
+
+func (s *emittingClassStore) CloseStore() error {
+	closer, ok := s.Store.(interface{ CloseStore() error })
+	if !ok {
+		return nil
+	}
+	return closer.CloseStore()
+}
+
+func (s *emittingClassStore) IDPrefix() string {
+	prefixer, ok := s.Store.(interface{ IDPrefix() string })
+	if !ok {
+		return ""
+	}
+	return prefixer.IDPrefix()
+}
+
+func (s *emittingClassStore) StoreHealthPath() string {
+	pather, ok := s.Store.(interface{ StoreHealthPath() string })
+	if !ok {
+		return ""
+	}
+	return pather.StoreHealthPath()
+}
+
+func (s *emittingClassStore) AtomicTx() bool {
+	atomic, ok := s.Store.(interface{ AtomicTx() bool })
+	return ok && atomic.AtomicTx()
+}
+
+func (s *emittingClassStore) SupportsEphemeralGraphApply() bool {
+	supporter, ok := s.Store.(interface{ SupportsEphemeralGraphApply() bool })
+	return ok && supporter.SupportsEphemeralGraphApply()
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics and small shared helpers.
+
+// beadStatusClosed is the one spelling of the terminal status this file writes.
+const beadStatusClosed = "closed"
+
+// beadStatusIsClosed reports whether a status is the terminal one, tolerating
+// the whitespace and casing a hand-written status can carry.
+func beadStatusIsClosed(status string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), beadStatusClosed)
+}
+
+// newClassStoreEmitRecorder opens the city's journal for one emission batch.
+func newClassStoreEmitRecorder(cityPath string) (*events.FileRecorder, error) {
+	return events.NewFileRecorder(
+		filepath.Join(cityPath, citylayout.RuntimeRoot, "events.jsonl"),
+		classStoreEmitWarnWriter{},
+		events.WithoutStartupSweep(),
+	)
+}
+
+// classStoreEmitWarnWriter funnels the recorder's own stderr diagnostics — a
+// flock timeout that dropped a row, a short write, a rotation failure — into
+// the warn-once path, so a dropped terminal event is visible rather than
+// discarded. It always reports a full write, which is what a recorder's stderr
+// sink has to do.
+type classStoreEmitWarnWriter struct{}
+
+func (classStoreEmitWarnWriter) Write(p []byte) (int, error) {
+	if msg := strings.TrimSpace(string(p)); msg != "" {
+		warnClassStoreEmit(errors.New(msg))
+	}
+	return len(p), nil
+}
+
+// classStoreEmitWarn is the emission-diagnostic sink. It is a package variable
+// so a test can capture what would otherwise be a one-line warning; the default
+// prints the first diagnostic and suppresses the rest, so a broken event log is
+// neither silent nor a flood in a worker's stderr.
+var classStoreEmitWarn = warnClassStoreEmitOncePerProcess()
+
+func warnClassStoreEmitOncePerProcess() func(error) {
+	var once sync.Once
+	return func(err error) {
+		once.Do(func() {
+			fmt.Fprintf(os.Stderr, "gc: class-store event emission: %v (further emission errors suppressed)\n", err) //nolint:errcheck // best-effort stderr
+		})
+	}
+}
+
+// warnClassStoreEmit routes one diagnostic through the current sink.
+func warnClassStoreEmit(err error) { classStoreEmitWarn(err) }

--- a/cmd/gc/class_store_emit_test.go
+++ b/cmd/gc/class_store_emit_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -32,6 +34,25 @@ import (
 //     PROVEN able to observe an event, so "zero" cannot pass by accident;
 //  3. what lands is readable by a journal CURSOR consumer — the shape the
 //     event-delta lanes read (TestClassStoreEmissionIsVisibleToACursorConsumer).
+//
+// # Those three prove the WRAPPER; two more prove the WIRING
+//
+// The three above hand the funnel routes the TEST has already wrapped. That is
+// the right shape for asserting emission SEMANTICS — it isolates them from
+// migration, providers and plan resolution — but it means the shipped injection
+// never runs, and a review caught exactly what that costs: rewriting the one
+// production call as withCLIEmission("") left all three green while emission was
+// entirely dead in production, because an empty city path early-returns
+// unwrapped.
+//
+// So the two gates at the bottom of this file never say withCLIEmission at all.
+// They stand up a city that has really converged onto a binding and enter
+// through the real constructors — resolveCLIStorageRoutes for the one-shot side
+// (TestOneShotCLIWritesEmitBeadEventsOnAMigratedCity) and openStorageRoutes for
+// the controller's (TestControllerRoutesFromOpenStorageRoutesCarryNoEmitTarget)
+// — so a mutation at either injection point reddens a DIFFERENT one of them.
+// The lesson generalizes: a gate that constructs the thing under test cannot
+// also be the gate that proves it is constructed.
 
 // splitClassRoutes builds the routes a split city resolves: every
 // infrastructure class served by one binding store, work left alone. It is the
@@ -259,9 +280,17 @@ func TestControllerClassRoutesStayEventSilentUnderReconcileShapedWrites(t *testi
 }
 
 // The structural half of gate 2: the emit target is injected in exactly one
-// place. "The controller never emits" is a claim about the call graph, and a
-// second injection site is how a claim like that stops being true without
-// anybody noticing.
+// place, ON the resolved routes, WITH the city path. "The controller never
+// emits" is a claim about the call graph, and a second injection site is how a
+// claim like that stops being true without anybody noticing.
+//
+// It checks the argument and the receiver, not just the name, because the first
+// cut of this guard checked neither and a mutant survived it: rewriting the
+// shipped call as withCLIEmission("") kept it green while production emission
+// was entirely dead (the empty path early-returns unwrapped). A syntactic guard
+// a semantic mutant walks past is worse than none, since it reads as coverage.
+// The gates that actually prove the wiring are the two production-seam tests
+// below; this one keeps the SHAPE from drifting.
 func TestClassStoreEmitTargetHasExactlyOneInjectionSite(t *testing.T) {
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -269,6 +298,7 @@ func TestClassStoreEmitTargetHasExactlyOneInjectionSite(t *testing.T) {
 	}
 	fset := token.NewFileSet()
 	sites := map[string]int{}
+	var shape []string
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -284,14 +314,37 @@ func TestClassStoreEmitTargetHasExactlyOneInjectionSite(t *testing.T) {
 				return true
 			}
 			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if ok && sel.Sel != nil && sel.Sel.Name == "withCLIEmission" {
-				sites[name]++
+			if !ok || sel.Sel == nil || sel.Sel.Name != "withCLIEmission" {
+				return true
+			}
+			sites[name]++
+			// The receiver must be the routes value the gate just resolved,
+			// and the argument must be the city path the funnel was asked
+			// about — never a literal, which is how an injection gets
+			// silently neutered while still reading as one.
+			if _, ok := sel.X.(*ast.Ident); !ok {
+				shape = append(shape, fmt.Sprintf("%s: receiver is %T, want the resolved routes identifier", name, sel.X))
+			}
+			if len(call.Args) != 1 {
+				shape = append(shape, fmt.Sprintf("%s: %d argument(s), want exactly the city path", name, len(call.Args)))
+				return true
+			}
+			arg, ok := call.Args[0].(*ast.Ident)
+			if !ok {
+				shape = append(shape, fmt.Sprintf("%s: argument is %T, want the cityPath identifier (a literal cannot be the city the funnel was asked about)", name, call.Args[0]))
+				return true
+			}
+			if arg.Name != "cityPath" {
+				shape = append(shape, fmt.Sprintf("%s: argument is %q, want cityPath", name, arg.Name))
 			}
 			return true
 		})
 	}
 	if len(sites) != 1 || sites["cli_storage_routes.go"] != 1 {
 		t.Fatalf("withCLIEmission is called from %v, want exactly one call in cli_storage_routes.go: the controller path is untouched only while the one-shot funnel is the sole injector", sites)
+	}
+	if len(shape) > 0 {
+		t.Fatalf("the injection does not have the shape that makes it one:\n  %s", strings.Join(shape, "\n  "))
 	}
 }
 
@@ -747,5 +800,133 @@ func TestEmittingClassStoreStillSatisfiesTheHookClaimRoute(t *testing.T) {
 	wrapped := splitClassRoutes(beads.NewMemStore()).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
 	if _, err := newHookClaimClassRoute(wrapped); err != nil {
 		t.Fatalf("the hook claim route refused the emitting class store: %v", err)
+	}
+}
+
+// PRODUCTION SEAM, gate 1. The gates above seed the funnel memo with routes the
+// TEST already wrapped, which proves the wrapper and proves nothing about the
+// wiring: replacing the shipped injection with withCLIEmission("") leaves them
+// all green while production emission is entirely dead.
+//
+// This one never says withCLIEmission. It stands up a city that has converged
+// onto its binding and enters through the same doors a one-shot command enters
+// through — the `gc mail` provider root and the by-id class front door — so the
+// only thing that can put an emit target on the store is resolveCLIStorageRoutes
+// itself. It is red against a neutered injection, and red against no injection.
+func TestOneShotCLIWritesEmitBeadEventsOnAMigratedCity(t *testing.T) {
+	t.Run("mail send through the gc mail provider root", func(t *testing.T) {
+		cityPath, _ := migratedOneShotCLICity(t)
+		captureCLIStorageStderr(t)
+
+		sender, code := openCityMailProvider(io.Discard, "gc mail send")
+		if sender == nil {
+			t.Fatalf("openCityMailProvider returned no provider (code=%d)", code)
+		}
+		sent, err := sender.Send("worker", "mayor", "PR ready", "please review the auth PR")
+		if err != nil {
+			t.Fatalf("gc mail send: %v", err)
+		}
+
+		created := 0
+		for _, evt := range beadEvents(readCityJournal(t, cityPath)) {
+			if evt.Subject == sent.ID && evt.Type == events.BeadCreated {
+				created++
+			}
+		}
+		if created != 1 {
+			t.Fatalf("a one-shot mail send on a migrated city appended %d bead.created row(s) for %s, want exactly 1: the shipped injection at resolveCLIStorageRoutes is what puts the emit target on the messaging class store",
+				created, sent.ID)
+		}
+	})
+
+	t.Run("graph close through the by-id class front door", func(t *testing.T) {
+		cityPath, _ := migratedOneShotCLICity(t)
+		captureCLIStorageStderr(t)
+
+		door, routed, err := openBdByIDClassFrontDoor(cityPath)
+		if err != nil {
+			t.Fatalf("opening the class front door: %v", err)
+		}
+		if !routed {
+			t.Fatal("a migrated city reported no relocated class at the by-id front door")
+		}
+		step, err := door.Graph.Create(beads.Bead{
+			Title:  "implement",
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				beadmeta.KindMetadataKey:       "check",
+				beadmeta.RootBeadIDMetadataKey: "gcg-root-e2e",
+				beadmeta.StepIDMetadataKey:     "implement",
+			},
+		})
+		if err != nil {
+			t.Fatalf("creating a graph-class step through the front door: %v", err)
+		}
+		if err := door.Graph.Close(step.ID); err != nil {
+			t.Fatalf("closing %s through the front door: %v", step.ID, err)
+		}
+
+		var got []string
+		for _, evt := range beadEvents(readCityJournal(t, cityPath)) {
+			if evt.Subject == step.ID {
+				got = append(got, evt.Type)
+			}
+		}
+		want := []string{events.BeadCreated, events.BeadClosed}
+		if !slices.Equal(got, want) {
+			t.Fatalf("the one-shot graph lifecycle of %s appended %v, want %v: without the shipped injection the run projection never sees the step begin or end",
+				step.ID, got, want)
+		}
+	})
+}
+
+// PRODUCTION SEAM, gate 2 (the control). Routes built by the REAL
+// openStorageRoutes — the controller's constructor — carry no emit target and
+// serve no emitting store, so a wrap added there is caught here rather than
+// discovered as a double row in a city's log.
+//
+// The type assertion is the load-bearing half. A behavioral "the city journal
+// stayed empty" would pass a mutant that wrapped with the BINDING root instead
+// of the city path, because those events land somewhere this test never looks.
+func TestControllerRoutesFromOpenStorageRoutesCarryNoEmitTarget(t *testing.T) {
+	cityPath, cfg := migratedOneShotCLICity(t)
+	captureCLIStorageStderr(t)
+
+	plan, err := resolveCityStoragePlan(cityPath, cfg)
+	if err != nil {
+		t.Fatalf("resolving the storage plan: %v", err)
+	}
+	routes, err := openStorageRoutes(plan, mustResolveInfraTarget(t, cityPath, cfg))
+	if err != nil {
+		t.Fatalf("opening the controller's storage routes: %v", err)
+	}
+	defer routes.close() //nolint:errcheck // the test asserts on the routes, not on the close
+
+	if routes.emitCityPath != "" {
+		t.Errorf("openStorageRoutes set an emit target %q; only the one-shot funnel may set one", routes.emitCityPath)
+	}
+	served := 0
+	for class, store := range routes.stores {
+		served++
+		if _, emitting := store.(*emittingClassStore); emitting {
+			t.Errorf("the controller's %s store is an emitting wrapper; the controller emits through its own CachingStore and a second emitter is a double row in the log", class)
+		}
+	}
+	if served == 0 {
+		t.Fatal("the controller's routes serve no class; this gate has lost its subject")
+	}
+
+	// And behaviorally, for the emit target this file would use.
+	store := resolveGraphStore(routes, beads.NewMemStore(), cfg, cityPath, nil)
+	step, err := store.Create(beads.Bead{Title: "controller write", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("creating through the controller's class store: %v", err)
+	}
+	if err := store.Close(step.ID); err != nil {
+		t.Fatalf("closing through the controller's class store: %v", err)
+	}
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 0 {
+		t.Fatalf("the controller's class routes appended %d bead event(s), want 0: %s", len(got), eventSummary(got))
 	}
 }

--- a/cmd/gc/class_store_emit_test.go
+++ b/cmd/gc/class_store_emit_test.go
@@ -1,0 +1,751 @@
+package main
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// The three gates this seam has to hold, and the control that keeps the second
+// one honest:
+//
+//  1. a mutation through the class front door appends exactly ONE bead.* event
+//     to the city's journal (TestClassStoreDoorMutation…);
+//  2. the controller/runtime side of the same resolver appends NONE
+//     (TestControllerClassRoutes…), and that is asserted against a fixture
+//     PROVEN able to observe an event, so "zero" cannot pass by accident;
+//  3. what lands is readable by a journal CURSOR consumer — the shape the
+//     event-delta lanes read (TestClassStoreEmissionIsVisibleToACursorConsumer).
+
+// splitClassRoutes builds the routes a split city resolves: every
+// infrastructure class served by one binding store, work left alone. It is the
+// shape openStorageRoutes produces, so a test that does NOT call
+// withCLIEmission is holding the CONTROLLER's routes.
+func splitClassRoutes(class beads.Store) *storageRoutes {
+	routes := &storageRoutes{stores: make(map[coordclass.Class]beads.Store), binding: "infra"}
+	for _, c := range coordclass.Classes() {
+		if c.IsInfrastructure() {
+			routes.stores[c] = class
+		}
+	}
+	return routes
+}
+
+// cityJournalPath is where a city's events land, and where the emitter is
+// expected to append.
+func cityJournalPath(cityPath string) string {
+	return filepath.Join(cityPath, citylayout.RuntimeRoot, "events.jsonl")
+}
+
+// readCityJournal returns every event in the city's log, in sequence order.
+func readCityJournal(t *testing.T, cityPath string) []events.Event {
+	t.Helper()
+	path := cityJournalPath(cityPath)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	rec, err := events.NewFileRecorder(path, io.Discard, events.WithoutStartupSweep())
+	if err != nil {
+		t.Fatalf("opening the city journal: %v", err)
+	}
+	defer rec.Close() //nolint:errcheck // read-only in a test
+	all, err := rec.List(events.Filter{})
+	if err != nil {
+		t.Fatalf("reading the city journal: %v", err)
+	}
+	return all
+}
+
+// beadEvents keeps only the bead.* rows, which are the ones this seam is about.
+func beadEvents(all []events.Event) []events.Event {
+	var out []events.Event
+	for _, e := range all {
+		if strings.HasPrefix(e.Type, "bead.") {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// seedClassBead writes a graph-class bead straight into the leaf store, which
+// is deliberately NOT the emitting wrapper: a fixture that emitted while
+// seeding would make every "exactly one event" assertion meaningless.
+func seedClassBead(t *testing.T, leaf beads.Store, stepID string) beads.Bead {
+	t.Helper()
+	bead, err := leaf.Create(beads.Bead{
+		Title:  "step",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:          "check",
+			beadmeta.RootBeadIDMetadataKey:    "gcg-root-1",
+			beadmeta.StepIDMetadataKey:        stepID,
+			beadmeta.SessionIDMetadataKey:     "sess-1",
+			beadmeta.LogicalBeadIDMetadataKey: "logical-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seeding the class store: %v", err)
+	}
+	return bead
+}
+
+// GATE 1. A mutation through the class front door the one-shot commands open
+// appends exactly one bead.* event, carrying the fresh snapshot and the
+// correlation ids a run projection folds on.
+//
+// This is the production symptom: on a split city a worker's close of a
+// graph-class step landed in the binding and appended nothing, so the
+// event-sourced run view rendered the step "Running" forever.
+//
+// Every relocated class is a row, not just graph. resolveClassStore discarded
+// its recorder for ALL of them, and the supported split moves all five at once
+// — a seam that only covered graph would leave a mail write, a nudge
+// terminalization and an order close just as dark as before.
+func TestClassStoreDoorMutationEmitsExactlyOneBeadEvent(t *testing.T) {
+	for _, row := range []struct {
+		name  string
+		close func(t *testing.T, cityPath, id string)
+	}{
+		{
+			name: "graph, through the by-id class front door",
+			close: func(t *testing.T, cityPath, id string) {
+				door, routed, err := openBdByIDClassFrontDoor(cityPath)
+				if err != nil {
+					t.Fatalf("opening the class front door: %v", err)
+				}
+				if !routed {
+					t.Fatal("the class front door reported no relocated class on a split city")
+				}
+				if err := door.Graph.Close(id); err != nil {
+					t.Fatalf("closing %s through the class front door: %v", id, err)
+				}
+			},
+		},
+		{name: "orders", close: closeThroughClassResolver(resolveOrderStore)},
+		{name: "nudges", close: closeThroughClassResolver(resolveNudgesStore)},
+		{name: "messaging", close: closeThroughClassResolver(resolveMailMessagesStore)},
+		{name: "sessions", close: closeThroughClassResolver(resolveSessionStore)},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			leaf := beads.NewMemStore()
+			seedCLIStorageRoutes(t, cityPath, splitClassRoutes(leaf).withCLIEmission(cityPath))
+
+			bead := seedClassBead(t, leaf, "implement")
+			if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 0 {
+				t.Fatalf("seeding the leaf store emitted %d bead event(s); the fixture must be silent", len(got))
+			}
+
+			row.close(t, cityPath, bead.ID)
+
+			got := beadEvents(readCityJournal(t, cityPath))
+			if len(got) != 1 {
+				t.Fatalf("a class-store close appended %d bead event(s), want exactly 1: %s", len(got), eventSummary(got))
+			}
+			evt := got[0]
+			if evt.Type != events.BeadClosed {
+				t.Errorf("event type = %q, want %q", evt.Type, events.BeadClosed)
+			}
+			if evt.Subject != bead.ID {
+				t.Errorf("event subject = %q, want %q", evt.Subject, bead.ID)
+			}
+			if evt.RunID != "gcg-root-1" {
+				t.Errorf("event run id = %q, want the run chain's root %q", evt.RunID, "gcg-root-1")
+			}
+			if evt.StepID != "implement" {
+				t.Errorf("event step id = %q, want %q", evt.StepID, "implement")
+			}
+			if evt.SessionID != "sess-1" {
+				t.Errorf("event session id = %q, want %q", evt.SessionID, "sess-1")
+			}
+			snapshot, ok := beads.DecodeBeadEventPayload(evt.Payload)
+			if !ok {
+				t.Fatalf("the payload does not decode through the shared bead decoder: %s", evt.Payload)
+			}
+			if snapshot.ID != bead.ID {
+				t.Errorf("payload id = %q, want %q", snapshot.ID, bead.ID)
+			}
+			if !strings.EqualFold(snapshot.Status, "closed") {
+				t.Errorf("payload status = %q, want closed: a fold that reads this decides the step is still running", snapshot.Status)
+			}
+		})
+	}
+}
+
+// closeThroughClassResolver closes a bead through one class's CLI resolver,
+// entered the way a one-shot command enters it: through the memoized funnel,
+// not through routes the test hands in directly.
+func closeThroughClassResolver(resolve func(*storageRoutes, beads.Store, *config.City, string, events.Recorder) beads.Store) func(*testing.T, string, string) {
+	return func(t *testing.T, cityPath, id string) {
+		t.Helper()
+		store := resolve(cliStorageRoutes(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+		if err := store.Close(id); err != nil {
+			t.Fatalf("closing %s through the class resolver: %v", id, err)
+		}
+	}
+}
+
+// GATE 2 (the control). The CONTROLLER's routes — the ones openStorageRoutes
+// builds, which never carry an emit target — stay silent under a
+// reconcile-shaped absorption, even when the resolver is handed a live
+// recorder. The controller reaches its own emission through the CachingStore;
+// a second emitter on this path is a double-emit, and on the reconcile path it
+// is the cache-reconcile flood.
+//
+// The control is falsifiable rather than vacuous: the same mutations through
+// the CLI-emitting twin of the same routes DO land in the same journal, so a
+// fixture that could not observe an event fails here before it can certify
+// silence.
+func TestControllerClassRoutesStayEventSilentUnderReconcileShapedWrites(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	controllerRoutes := splitClassRoutes(leaf)
+
+	if controllerRoutes.emitCityPath != "" {
+		t.Fatalf("controller-shaped routes carry emit target %q; only the one-shot funnel may set one", controllerRoutes.emitCityPath)
+	}
+
+	// A live recorder, exactly as the controller passes one to the resolvers.
+	rec, err := events.NewFileRecorder(cityJournalPath(cityPath), io.Discard)
+	if err != nil {
+		t.Fatalf("opening the city journal: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	absorbed := seedClassBead(t, leaf, "absorb")
+	store := resolveGraphStore(controllerRoutes, beads.NewMemStore(), nil, cityPath, rec)
+
+	// The reconcile shape: the runtime re-writes rows it just read.
+	closed := "closed"
+	if err := store.Update(absorbed.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("reconcile-shaped update: %v", err)
+	}
+	if err := store.SetMetadata(absorbed.ID, "gc.absorbed", "1"); err != nil {
+		t.Fatalf("reconcile-shaped metadata write: %v", err)
+	}
+
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 0 {
+		t.Fatalf("the controller's class routes appended %d bead event(s), want 0: %s", len(got), eventSummary(got))
+	}
+
+	// The control's own control: prove this fixture CAN see an emission, so the
+	// zero above is a fact about the controller path and not about the harness.
+	emitting := splitClassRoutes(leaf).withCLIEmission(cityPath)
+	observable := seedClassBead(t, leaf, "observable")
+	if err := resolveGraphStore(emitting, beads.NewMemStore(), nil, cityPath, nil).Close(observable.ID); err != nil {
+		t.Fatalf("closing through the emitting twin: %v", err)
+	}
+	witness := beadEvents(readCityJournal(t, cityPath))
+	if len(witness) != 1 || witness[0].Subject != observable.ID {
+		t.Fatalf("the emitting twin appended %d bead event(s) for %s, want exactly 1: this fixture cannot observe emission, so the silence assertion above proves nothing", len(witness), observable.ID)
+	}
+}
+
+// The structural half of gate 2: the emit target is injected in exactly one
+// place. "The controller never emits" is a claim about the call graph, and a
+// second injection site is how a claim like that stops being true without
+// anybody noticing.
+func TestClassStoreEmitTargetHasExactlyOneInjectionSite(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading cmd/gc: %v", err)
+	}
+	fset := token.NewFileSet()
+	sites := map[string]int{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if ok && sel.Sel != nil && sel.Sel.Name == "withCLIEmission" {
+				sites[name]++
+			}
+			return true
+		})
+	}
+	if len(sites) != 1 || sites["cli_storage_routes.go"] != 1 {
+		t.Fatalf("withCLIEmission is called from %v, want exactly one call in cli_storage_routes.go: the controller path is untouched only while the one-shot funnel is the sole injector", sites)
+	}
+}
+
+// GATE 3. What the door mutation appends is readable by a journal CURSOR
+// consumer — read from a recorded position forward, which is how the
+// event-delta lanes consume bead.* — with the run/step correlation on the
+// envelope rather than buried in the payload.
+func TestClassStoreEmissionIsVisibleToACursorConsumer(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	seedCLIStorageRoutes(t, cityPath, splitClassRoutes(leaf).withCLIEmission(cityPath))
+
+	consumer, err := events.NewFileRecorder(cityJournalPath(cityPath), io.Discard)
+	if err != nil {
+		t.Fatalf("opening the journal consumer: %v", err)
+	}
+	t.Cleanup(func() { _ = consumer.Close() })
+
+	// Something already in the log, so the cursor is a real position and not 0.
+	consumer.Record(events.Event{Type: "city.started", Actor: "test"})
+	cursor, err := consumer.LatestSeq()
+	if err != nil {
+		t.Fatalf("reading the cursor: %v", err)
+	}
+	if cursor == 0 {
+		t.Fatal("cursor is 0 after a recorded event")
+	}
+
+	bead := seedClassBead(t, leaf, "verify")
+	door, routed, err := openBdByIDClassFrontDoor(cityPath)
+	if err != nil || !routed {
+		t.Fatalf("opening the class front door: routed=%v err=%v", routed, err)
+	}
+	if err := door.Graph.Close(bead.ID); err != nil {
+		t.Fatalf("closing %s through the class front door: %v", bead.ID, err)
+	}
+
+	delta, err := consumer.List(events.Filter{AfterSeq: cursor})
+	if err != nil {
+		t.Fatalf("reading the delta: %v", err)
+	}
+	got := beadEvents(delta)
+	if len(got) != 1 {
+		t.Fatalf("a consumer resuming at seq %d saw %d bead event(s), want exactly 1: %s", cursor, len(got), eventSummary(got))
+	}
+	if got[0].Seq <= cursor {
+		t.Errorf("delta event seq = %d, want > cursor %d: a row at or below the cursor is invisible to a resuming lane", got[0].Seq, cursor)
+	}
+	if got[0].RunID == "" || got[0].StepID == "" {
+		t.Errorf("delta event carries run=%q step=%q; a delta lane keys on both", got[0].RunID, got[0].StepID)
+	}
+}
+
+// A close is a close only when the bead was open. eventexport drops
+// bead.updated, so a close edge that rode bead.updated would never reach a
+// consumer — and a metadata write to an already-closed bead that rode
+// bead.closed would re-close it in every fold that replays the log.
+func TestClassStoreEmissionPromotesToClosedOnlyOnTheTransition(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	routes := splitClassRoutes(leaf).withCLIEmission(cityPath)
+	store := resolveGraphStore(routes, beads.NewMemStore(), nil, cityPath, nil)
+
+	bead := seedClassBead(t, leaf, "transition")
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := store.SetMetadata(bead.ID, "gc.note", "after"); err != nil {
+		t.Fatalf("metadata write on a closed bead: %v", err)
+	}
+
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 2 {
+		t.Fatalf("got %d bead event(s), want 2: %s", len(got), eventSummary(got))
+	}
+	if got[0].Type != events.BeadClosed {
+		t.Errorf("first event = %q, want %q", got[0].Type, events.BeadClosed)
+	}
+	if got[1].Type != events.BeadUpdated {
+		t.Errorf("second event = %q, want %q: a metadata write to a closed bead is not a close", got[1].Type, events.BeadUpdated)
+	}
+}
+
+// Create and delete are the other two lifecycle edges a fold needs. Delete has
+// to carry the PRE-delete snapshot, because there is nothing to read after.
+func TestClassStoreEmissionCoversCreateAndDelete(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	routes := splitClassRoutes(leaf).withCLIEmission(cityPath)
+	store := resolveGraphStore(routes, beads.NewMemStore(), nil, cityPath, nil)
+
+	created, err := store.Create(beads.Bead{Title: "fresh", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 2 {
+		t.Fatalf("got %d bead event(s), want 2: %s", len(got), eventSummary(got))
+	}
+	if got[0].Type != events.BeadCreated || got[0].Subject != created.ID {
+		t.Errorf("first event = %q/%q, want %q/%q", got[0].Type, got[0].Subject, events.BeadCreated, created.ID)
+	}
+	if got[1].Type != events.BeadDeleted || got[1].Subject != created.ID {
+		t.Errorf("second event = %q/%q, want %q/%q", got[1].Type, got[1].Subject, events.BeadDeleted, created.ID)
+	}
+	snapshot, ok := beads.DecodeBeadEventPayload(got[1].Payload)
+	if !ok || snapshot.Title != "fresh" {
+		t.Errorf("bead.deleted payload = %s, want the pre-delete snapshot", got[1].Payload)
+	}
+}
+
+// A city that relocates nothing must reach none of this: the resolver hands
+// back the caller's own store VALUE, and no journal appears.
+func TestSingleStoreCityIsUntouchedByTheEmitSeam(t *testing.T) {
+	cityPath := t.TempDir()
+	work := beads.NewMemStore()
+
+	var none *storageRoutes
+	if got := none.withCLIEmission(cityPath); got != nil {
+		t.Fatalf("withCLIEmission on nil routes = %v, want nil: a city that relocates nothing has no class store to wrap", got)
+	}
+	store := resolveGraphStore(none.withCLIEmission(cityPath), work, nil, cityPath, nil)
+	if store != beads.Store(work) {
+		t.Fatal("the resolver did not return the caller's own store on a city that relocates nothing")
+	}
+	if _, err := store.Create(beads.Bead{Title: "work", Type: "task"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := os.Stat(cityJournalPath(cityPath)); !os.IsNotExist(err) {
+		t.Fatalf("a single-store city grew an event log at %s", cityJournalPath(cityPath))
+	}
+}
+
+// Store identity has to survive the wrap: callers dedup scan candidates in a
+// map keyed by beads.Store, so a fresh wrapper per resolution would turn one
+// store into N and re-scan the binding once per class.
+func TestEmittingClassStoreIsIdentityStableAcrossResolutions(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	routes := splitClassRoutes(leaf).withCLIEmission(cityPath)
+
+	graph := resolveGraphStore(routes, beads.NewMemStore(), nil, cityPath, nil)
+	again := resolveGraphStore(routes, beads.NewMemStore(), nil, cityPath, nil)
+	if graph != again {
+		t.Error("two resolutions of the same class returned different store values")
+	}
+	orders := resolveOrderStore(routes, beads.NewMemStore(), nil, cityPath, nil)
+	if graph != orders {
+		t.Error("two classes served by one binding resolved to different store values; the store-identity dedup counts them twice")
+	}
+	if graph == beads.Store(leaf) {
+		t.Error("the resolved class store is the un-augmented leaf; nothing would emit")
+	}
+}
+
+// Wrapping a store is how capabilities get lost, and a lost capability is
+// silent: the caller's type assertion simply stops matching and it takes a
+// slower or weaker path. Both engines a binding can be served from are pinned.
+func TestEmittingClassStoreKeepsEveryEngineCapability(t *testing.T) {
+	cityPath := t.TempDir()
+	wrapped := splitClassRoutes(beads.NewMemStore()).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
+	wrapper := reflect.TypeOf(wrapped)
+
+	for _, engine := range []reflect.Type{
+		reflect.TypeOf(&beads.SQLiteStore{}),
+		reflect.TypeOf(&beads.NativeDoltStore{}),
+	} {
+		var missing []string
+		for i := 0; i < engine.NumMethod(); i++ {
+			method := engine.Method(i)
+			got, ok := wrapper.MethodByName(method.Name)
+			if !ok {
+				missing = append(missing, method.Name)
+				continue
+			}
+			// Compare the signatures without their receivers.
+			if got.Type.String() != strings.Replace(method.Type.String(), engine.String(), wrapper.String(), 1) {
+				missing = append(missing, method.Name+" (signature differs)")
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Errorf("the emitting class store drops %v from %s; every one is a capability assertion that stops matching", missing, engine)
+		}
+	}
+}
+
+// Emission is best-effort by contract: the mutation has already committed when
+// the event is written, so a journal that cannot be opened must not turn a
+// landed close into a failed command.
+func TestClassStoreEmissionFailureDoesNotFailTheMutation(t *testing.T) {
+	cityPath := t.TempDir()
+	// A regular file where the runtime directory belongs: the recorder's
+	// MkdirAll fails, and every open after it.
+	if err := os.WriteFile(filepath.Join(cityPath, citylayout.RuntimeRoot), []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("seeding the blocked runtime root: %v", err)
+	}
+	leaf := beads.NewMemStore()
+	routes := splitClassRoutes(leaf).withCLIEmission(cityPath)
+	store := resolveGraphStore(routes, beads.NewMemStore(), nil, cityPath, nil)
+
+	var warned []string
+	restore := classStoreEmitWarn
+	classStoreEmitWarn = func(err error) { warned = append(warned, err.Error()) }
+	t.Cleanup(func() { classStoreEmitWarn = restore })
+
+	bead := seedClassBead(t, leaf, "besteffort")
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("close returned %v; emission is best-effort and must not fail a committed mutation", err)
+	}
+	if got, err := leaf.Get(bead.ID); err != nil || !strings.EqualFold(got.Status, "closed") {
+		t.Fatalf("the close did not land: bead=%+v err=%v", got, err)
+	}
+	if len(warned) == 0 {
+		t.Error("a journal that cannot be opened produced no diagnostic; a dropped terminal event must not be silent")
+	}
+}
+
+// The controller's payload carries dependency edges; a class store's row does
+// not carry them in its bead JSON, so the emitter hydrates them. Without this a
+// consumer holding both shapes reads the CLI's payload as an edge REMOVAL.
+func TestClassStoreEmissionHydratesDependencyEdges(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	store := resolveGraphStore(splitClassRoutes(leaf).withCLIEmission(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+
+	blocker := seedClassBead(t, leaf, "blocker")
+	blocked := seedClassBead(t, leaf, "blocked")
+	if err := store.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("dep add: %v", err)
+	}
+
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 1 || got[0].Type != events.BeadUpdated {
+		t.Fatalf("got %d bead event(s) %s, want one bead.updated", len(got), eventSummary(got))
+	}
+	snapshot, ok := beads.DecodeBeadEventPayload(got[0].Payload)
+	if !ok {
+		t.Fatalf("payload does not decode: %s", got[0].Payload)
+	}
+	if len(snapshot.Dependencies) != 1 || snapshot.Dependencies[0].DependsOnID != blocker.ID {
+		t.Errorf("payload dependencies = %+v, want the edge just added to %s", snapshot.Dependencies, blocker.ID)
+	}
+}
+
+// A post-write read miss must never produce a bare-id payload. An empty
+// snapshot does not say less than a full one — it CLOBBERS the fold, because a
+// projection applying it overwrites title, status and run membership with
+// nothing. The one exception is a close, whose transition is proven committed.
+func TestClassStoreEmissionNeverEmitsABareIDPayload(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := &readMissAfterWriteStore{MemStore: beads.NewMemStore()}
+	store := resolveGraphStore(splitClassRoutes(leaf).withCLIEmission(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+
+	var warned []string
+	restore := classStoreEmitWarn
+	classStoreEmitWarn = func(err error) { warned = append(warned, err.Error()) }
+	t.Cleanup(func() { classStoreEmitWarn = restore })
+
+	bead := seedClassBead(t, leaf, "readmiss")
+	leaf.missing = true
+
+	if err := store.SetMetadata(bead.ID, "gc.note", "x"); err != nil {
+		t.Fatalf("metadata write: %v", err)
+	}
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 0 {
+		t.Fatalf("a refresh miss emitted %s; a bare-id payload detaches the bead from its run", eventSummary(got))
+	}
+	if len(warned) == 0 {
+		t.Error("a skipped emission produced no diagnostic; a dropped row must not be silent")
+	}
+
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 1 || got[0].Type != events.BeadClosed {
+		t.Fatalf("got %s, want one bead.closed: a committed close is a fact and must survive a refresh miss", eventSummary(got))
+	}
+	snapshot, ok := beads.DecodeBeadEventPayload(got[0].Payload)
+	if !ok || !strings.EqualFold(snapshot.Status, "closed") {
+		t.Errorf("bead.closed payload = %s, want a closed status from the write's own transition", got[0].Payload)
+	}
+}
+
+// readMissAfterWriteStore models a store whose read-after-write lags: the
+// mutation lands and the refresh finds nothing.
+type readMissAfterWriteStore struct {
+	*beads.MemStore
+	missing bool
+}
+
+func (s *readMissAfterWriteStore) Get(id string) (beads.Bead, error) {
+	if s.missing {
+		return beads.Bead{}, beads.ErrNotFound
+	}
+	return s.MemStore.Get(id)
+}
+
+// A landed conditional release is a state change a fold has to see: the bead
+// went from claimed to claimable, and a reader that missed it keeps showing an
+// owner who has walked away.
+func TestClassStoreEmissionCoversConditionalRelease(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	store := resolveGraphStore(splitClassRoutes(leaf).withCLIEmission(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+
+	bead := seedClassBead(t, leaf, "release")
+	assignee := "worker-1"
+	inProgress := "in_progress"
+	if err := leaf.Update(bead.ID, beads.UpdateOpts{Assignee: &assignee, Status: &inProgress}); err != nil {
+		t.Fatalf("claiming the bead: %v", err)
+	}
+
+	releaser, ok := store.(beads.ConditionalAssignmentReleaser)
+	if !ok {
+		t.Fatalf("the emitting class store dropped ConditionalAssignmentReleaser (%T)", store)
+	}
+	released, err := releaser.ReleaseIfCurrent(bead.ID, assignee)
+	if err != nil || !released {
+		t.Fatalf("release: released=%v err=%v", released, err)
+	}
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 1 || got[0].Type != events.BeadUpdated || got[0].Subject != bead.ID {
+		t.Fatalf("got %s, want one bead.updated for %s", eventSummary(got), bead.ID)
+	}
+
+	// A release that does not fire changes nothing, and must say nothing.
+	if _, err := releaser.ReleaseIfCurrent(bead.ID, "someone-else"); err != nil {
+		t.Fatalf("no-op release: %v", err)
+	}
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 1 {
+		t.Fatalf("a release that did not fire appended a row: %s", eventSummary(got))
+	}
+}
+
+// The recorder reports its own trouble — a flock timeout that dropped a row, a
+// short write — to a stderr sink rather than an error return. That sink is
+// wired into the warn path, because a dropped terminal event nobody hears about
+// is the exact failure this seam exists to end.
+func TestClassStoreEmitWarnWriterFunnelsRecorderDiagnostics(t *testing.T) {
+	var warned []string
+	restore := classStoreEmitWarn
+	classStoreEmitWarn = func(err error) { warned = append(warned, err.Error()) }
+	t.Cleanup(func() { classStoreEmitWarn = restore })
+
+	writer := classStoreEmitWarnWriter{}
+	msg := []byte("events: append failed: no space left on device\n")
+	n, err := writer.Write(msg)
+	if err != nil || n != len(msg) {
+		t.Fatalf("Write = (%d, %v), want (%d, nil): a recorder stderr sink must report a full write", n, err, len(msg))
+	}
+	if len(warned) != 1 || !strings.Contains(warned[0], "no space left on device") {
+		t.Fatalf("warnings = %v, want the recorder's own diagnostic", warned)
+	}
+	if n, err := writer.Write([]byte("   \n")); err != nil || n != 4 {
+		t.Fatalf("blank Write = (%d, %v), want (4, nil)", n, err)
+	}
+	if len(warned) != 1 {
+		t.Errorf("a blank diagnostic produced a warning: %v", warned)
+	}
+}
+
+// eventSummary renders a journal slice for a failure message.
+func eventSummary(all []events.Event) string {
+	if len(all) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, 0, len(all))
+	for _, e := range all {
+		payload, _ := json.Marshal(e.Subject)
+		parts = append(parts, e.Type+"/"+string(payload))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// The dispatcher's serve loop must not wake on its OWN emissions. Its
+// control-bead writes now append bead.* rows, and an unfiltered wake buys a
+// heavy ready re-scan and a controller poke per dispatch burst — the loop
+// paying itself to re-read what it just wrote.
+func TestWorkflowServeWakeIgnoresSelfActorEvents(t *testing.T) {
+	prevDebounce := workflowServeWakeDebounce
+	workflowServeWakeDebounce = time.Millisecond
+	t.Cleanup(func() { workflowServeWakeDebounce = prevDebounce })
+
+	prevActor := workflowServeSelfActor
+	t.Cleanup(func() { workflowServeSelfActor = prevActor })
+
+	deliver := func(actor string) chan workflowWatchResult {
+		ch := make(chan workflowWatchResult, 1)
+		ch <- workflowWatchResult{evt: events.Event{Type: events.BeadClosed, Subject: "gcg-1", Actor: actor}}
+		return ch
+	}
+
+	workflowServeSelfActor = func() (string, bool) { return "dispatcher-1", true }
+	if wake, err := waitForRelevantWorkflowWakeWithTrace(deliver("dispatcher-1"), 15*time.Millisecond, -1); err != nil || wake {
+		t.Fatalf("self-actor event: wake=%v err=%v, want no wake", wake, err)
+	}
+	if wake, err := waitForRelevantWorkflowWakeWithTrace(deliver("worker-7"), time.Second, -1); err != nil || !wake {
+		t.Fatalf("foreign-actor event: wake=%v err=%v, want a wake", wake, err)
+	}
+
+	// The fallback identity is shared by every foreign CLI writer, so it must
+	// never filter: suppressing a wake there would strand ready work.
+	workflowServeSelfActor = func() (string, bool) { return "human", false }
+	if wake, err := waitForRelevantWorkflowWakeWithTrace(deliver("human"), time.Second, -1); err != nil || !wake {
+		t.Fatalf("unusable identity: wake=%v err=%v, want a wake with no self-filter", wake, err)
+	}
+}
+
+// class_store_emit.go is on the claim-CAS allowlist
+// (turn_bound_claim_invariants_test.go) as a FORWARDER, not as a pull path.
+// That exception is only true while the file's single claim call is the one
+// inside its own Claim method, so it is checked rather than promised.
+func TestClassStoreEmitOnlyForwardsClaims(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "class_store_emit.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing class_store_emit.go: %v", err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "Claim" {
+				return true
+			}
+			if fn.Name.Name != "Claim" {
+				t.Errorf("%s claims; this file may only forward a claim from its own Claim method, and the allowlist entry says so", fn.Name.Name)
+			}
+			return true
+		})
+	}
+}
+
+// The claim capability is why the wrapper carries Claim at all: the hook's
+// binding probe is a type assertion, and a wrapper that dropped the method
+// would degrade `gc hook --claim` to "this binding cannot claim" on every split
+// city — silently, because that degrade is a designed fallback.
+func TestEmittingClassStoreStillSatisfiesTheHookClaimRoute(t *testing.T) {
+	cityPath := t.TempDir()
+	wrapped := splitClassRoutes(beads.NewMemStore()).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
+	if _, err := newHookClaimClassRoute(wrapped); err != nil {
+		t.Fatalf("the hook claim route refused the emitting class store: %v", err)
+	}
+}

--- a/cmd/gc/cli_session_store.go
+++ b/cmd/gc/cli_session_store.go
@@ -14,9 +14,10 @@ import (
 // the store verbatim there), so wrapping is byte-identical until a session
 // relocation is configured.
 //
-// The recorder is nil: a one-shot CLI command has no live event bus, matching
-// today's behavior where these paths emit no bead events. Threading a recorder
-// so relocated CLI writes emit bead.* is a separate follow-up.
+// The recorder is nil, and passing one would change nothing: resolveSessionStore
+// ignores it. What makes a relocated one-shot write observable is the emit
+// target the funnel puts on the ROUTES (class_store_emit.go), which
+// cliStorageRoutes has already applied by the time this returns.
 func cliSessionStore(store beads.Store, cfg *config.City, cityPath string) beads.Store {
 	return resolveSessionStore(cliStorageRoutes(cityPath), store, cfg, cityPath, nil)
 }

--- a/cmd/gc/cli_storage_routes.go
+++ b/cmd/gc/cli_storage_routes.go
@@ -150,7 +150,12 @@ func resolveCLIStorageRoutes(cityPath string) *storageRoutes {
 	}
 	routes, err := storageBootGate(cityPath, cfg, cliStorageLogPrefix, nil, cliStorageStderr)
 	if err == nil {
-		return routes
+		// The one and only place a class store is given an emit target. A
+		// one-shot command has no live event bus, so without this its writes to
+		// a relocated class land in a store nothing observes; the controller
+		// resolves its routes through openStorageRoutes, never here, so its
+		// side stays exactly as it was. See class_store_emit.go.
+		return routes.withCLIEmission(cityPath)
 	}
 	// Once, here, rather than at each call site: a command that discards the
 	// store error still has to leave the operator holding the remedy.

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -610,9 +610,25 @@ func waitForRelevantWorkflowWake(eventCh <-chan workflowWatchResult, sleepDur ti
 	return waitForRelevantWorkflowWakeWithTrace(eventCh, sleepDur, -1)
 }
 
+// workflowServeSelfActor names this process in the event log, and says whether
+// that name is usable as an identity.
+//
+// The serve loop's own control-bead writes append bead.* events now that a
+// relocated class store emits (class_store_emit.go), and waking on those buys
+// an extra heavy ready re-scan and a controller poke per dispatch burst.
+// eventActor's terminal fallback is "human", which every foreign CLI writer
+// shares, so filtering on it would suppress legitimate wakes: an identity is
+// usable only when it is neither empty nor that fallback. It is a variable so a
+// test can pin both arms.
+var workflowServeSelfActor = func() (string, bool) {
+	actor := eventActor()
+	return actor, actor != "" && actor != "human"
+}
+
 func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sleepDur time.Duration, idleSweeps int) (bool, error) {
 	timer := time.NewTimer(sleepDur)
 	defer timer.Stop()
+	selfActor, selfUsable := workflowServeSelfActor()
 
 	for {
 		select {
@@ -621,6 +637,16 @@ func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sl
 				return false, res.err
 			}
 			if workflowEventRelevant(res.evt) {
+				if selfUsable && res.evt.Actor == selfActor {
+					// Our own emission. drainWorkflowServeWork already loops
+					// until no control bead is processed, so nothing
+					// discoverable from this loop's own writes can be missed by
+					// ignoring them — while a foreign bead.* event (the worker
+					// close this emission exists to make visible) still wakes
+					// the loop immediately.
+					workflowTracef("serve ignore-self-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
+					continue
+				}
 				if idleSweeps >= 0 {
 					workflowTracef("serve wake-event type=%s subject=%s idle_sweeps=%d sleep=%s", res.evt.Type, res.evt.Subject, idleSweeps, sleepDur)
 				} else {

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -87,6 +87,13 @@ type storageRoutes struct {
 	// binding names the non-work binding these routes were opened from, for
 	// diagnostics.
 	binding string
+	// emitCityPath is the city whose event log these routes' class stores
+	// append bead.* events to, and it is set on exactly one construction:
+	// the one-shot CLI funnel's (cli_storage_routes.go). openStorageRoutes
+	// leaves it empty, so the controller's routes carry no emit target and
+	// its CachingStore stays the only emitter on that side — see
+	// class_store_emit.go for why the two must not both emit.
+	emitCityPath string
 }
 
 // storeFor returns the store serving a class and whether these routes relocate

--- a/cmd/gc/turn_bound_claim_invariants_test.go
+++ b/cmd/gc/turn_bound_claim_invariants_test.go
@@ -25,6 +25,17 @@ import (
 //     then immediately executes the work in the same process — it has no turn to
 //     outlive, which is why the hook fences do not apply to it.
 //
+// One entry is not a pull path and is here for a different reason:
+//
+//   - class_store_emit.go FORWARDS a claim; it cannot originate one. It is the
+//     relocated class store's emission wrapper, and it holds no id, no assignee
+//     and no policy — its Claim exists only so the capability survives wrapping,
+//     because claim_class_route.go's binding probe is a type assertion and a
+//     wrapper without the method degrades `gc hook --claim` to "this binding
+//     cannot claim" on every split city. The invariant this guard protects —
+//     the controller never assigns — is untouched: nothing here decides to
+//     claim, and the callers that do are still exactly the four above.
+//
 // Adding a file here is a design decision about pull semantics; make it
 // deliberately.
 var claimCASAllowedFiles = map[string]bool{
@@ -32,6 +43,7 @@ var claimCASAllowedFiles = map[string]bool{
 	"claim_class_route.go": true,
 	"cmd_bd_by_id.go":      true,
 	"cmd_agent_script.go":  true,
+	"class_store_emit.go":  true,
 }
 
 // claimCASMarkers are the two shapes a claim compare-and-swap takes in this

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -707,13 +707,13 @@ func (c *CachingStore) notifyChange(eventType string, b Bead) {
 	// step_id is the semantic native execution step carried explicitly by the
 	// lifecycle bead. Non-work beads (sessions, mail, …) carry none → omitted.
 	stepID := b.Metadata[beadmeta.StepIDMetadataKey]
-	c.onChange(eventType, b.ID, runID, sessionID, stepID, nativeStepDependencies(b.Metadata, stepID), payload)
+	c.onChange(eventType, b.ID, runID, sessionID, stepID, NativeStepDependencies(b.Metadata, stepID), payload)
 }
 
-// nativeStepDependencies returns the explicit, canonical native topology fact.
+// NativeStepDependencies returns the explicit, canonical native topology fact.
 // It never derives edges from physical bead dependencies or other mutable state:
 // absent/malformed metadata is UNKNOWN (nil), while a canonical [] is a known root.
-func nativeStepDependencies(metadata map[string]string, stepID string) *[]string {
+func NativeStepDependencies(metadata map[string]string, stepID string) *[]string {
 	if !validTopologyStepID(stepID) {
 		return nil
 	}

--- a/internal/beads/native_step_topology_test.go
+++ b/internal/beads/native_step_topology_test.go
@@ -22,8 +22,8 @@ func TestNativeStepDependenciesReadsOnlyCanonicalMetadata(t *testing.T) {
 		{name: "malformed is unknown", stepID: "step-b", metadata: map[string]string{beadmeta.NativeStepDependenciesMetadataKey: `not-json`}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := nativeStepDependencies(tc.metadata, tc.stepID); !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("nativeStepDependencies() = %#v, want %#v", got, tc.want)
+			if got := NativeStepDependencies(tc.metadata, tc.stepID); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("NativeStepDependencies() = %#v, want %#v", got, tc.want)
 			}
 		})
 	}

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -73,11 +73,12 @@ type FileRecorder struct {
 
 	// skipSweep suppresses the one-shot startup sweep of orphaned rotating-*
 	// files (WithoutStartupSweep). Transient per-open recorders — the
-	// per-mutation class-store emitter is the one in tree — set it so they
-	// neither pay a directory scan on the hot path nor race the supervisor's
-	// long-lived recorder, which owns rotation recovery. Crash recovery of
-	// orphaned rotating files is unchanged: the long-lived recorder still
-	// sweeps.
+	// per-mutation class-store emitter is the one in tree — set it so they do
+	// not race the supervisor's long-lived recorder, which owns rotation
+	// recovery. It does NOT make the open scan-free: ReadLatestSeq consults
+	// the archives to continue the sequence, so every open reads the
+	// directory regardless. Crash recovery of orphaned rotating files is
+	// unchanged: the long-lived recorder still sweeps.
 	skipSweep bool
 }
 
@@ -119,9 +120,13 @@ func WithArchiveRetainAge(d time.Duration) FileRecorderOption {
 // WithoutStartupSweep suppresses the one-shot orphaned-rotating-file sweep that
 // NewFileRecorder otherwise runs on open. Transient per-open recorders — one
 // that opens, writes and closes inside a single mutation — pass it so they do
-// not scan the log directory on every open and, crucially, do not race the
-// supervisor's long-lived recorder mid-rotation: a concurrent sweep can
-// double-gzip the same in-flight rotating-* file through a shared .tmp path.
+// not race the supervisor's long-lived recorder mid-rotation: a concurrent
+// sweep can double-gzip the same in-flight rotating-* file through a shared
+// .tmp path. What it skips is the sweep's RECOVERY WORK — a directory pass that
+// gzips and renames the files a crash stranded — not the open's directory read,
+// which happens either way because ReadLatestSeq consults the archives to
+// continue the sequence.
+//
 // The long-lived recorder keeps the sweep, so crash recovery of orphaned
 // rotating files is unaffected, and stranded rotating files stay readable
 // through the in-flight read path meanwhile.

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -70,6 +70,15 @@ type FileRecorder struct {
 	archiveRetainAge      time.Duration
 	recordCount           uint64
 	lastSizeCheck         time.Time
+
+	// skipSweep suppresses the one-shot startup sweep of orphaned rotating-*
+	// files (WithoutStartupSweep). Transient per-open recorders — the
+	// per-mutation class-store emitter is the one in tree — set it so they
+	// neither pay a directory scan on the hot path nor race the supervisor's
+	// long-lived recorder, which owns rotation recovery. Crash recovery of
+	// orphaned rotating files is unchanged: the long-lived recorder still
+	// sweeps.
+	skipSweep bool
 }
 
 // FileRecorderOption customizes a FileRecorder at construction time.
@@ -105,6 +114,19 @@ func WithRotationCheckInterval(d time.Duration) FileRecorderOption {
 // all archives forever.
 func WithArchiveRetainAge(d time.Duration) FileRecorderOption {
 	return func(r *FileRecorder) { r.archiveRetainAge = d }
+}
+
+// WithoutStartupSweep suppresses the one-shot orphaned-rotating-file sweep that
+// NewFileRecorder otherwise runs on open. Transient per-open recorders — one
+// that opens, writes and closes inside a single mutation — pass it so they do
+// not scan the log directory on every open and, crucially, do not race the
+// supervisor's long-lived recorder mid-rotation: a concurrent sweep can
+// double-gzip the same in-flight rotating-* file through a shared .tmp path.
+// The long-lived recorder keeps the sweep, so crash recovery of orphaned
+// rotating files is unaffected, and stranded rotating files stay readable
+// through the in-flight read path meanwhile.
+func WithoutStartupSweep() FileRecorderOption {
+	return func(r *FileRecorder) { r.skipSweep = true }
 }
 
 // RotationResult is returned by ForceRotate (and B-3's API endpoint)
@@ -164,8 +186,24 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 		return nil, fmt.Errorf("creating event log directory: %w", err)
 	}
 
-	if err := reapOrphanedRotatingFiles(filepath.Dir(path), stderr); err != nil {
-		fmt.Fprintf(stderr, "events: rotation: orphan sweep: %v\n", err) //nolint:errcheck // best-effort stderr
+	// Options are applied before the sweep so WithoutStartupSweep can suppress
+	// it; file and seq are filled in after the (optional) sweep and the open.
+	r := &FileRecorder{
+		path:                  path,
+		stderr:                stderr,
+		maxSize:               0,
+		rotationCheckRecords:  defaultRotationCheckRecords,
+		rotationCheckInterval: defaultRotationCheckInterval,
+		lastSizeCheck:         time.Now(),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	if !r.skipSweep {
+		if err := reapOrphanedRotatingFiles(filepath.Dir(path), stderr); err != nil {
+			fmt.Fprintf(stderr, "events: rotation: orphan sweep: %v\n", err) //nolint:errcheck // best-effort stderr
+		}
 	}
 
 	maxSeq, err := ReadLatestSeq(path)
@@ -178,19 +216,8 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 		return nil, fmt.Errorf("opening event log: %w", err)
 	}
 
-	r := &FileRecorder{
-		path:                  path,
-		file:                  file,
-		seq:                   maxSeq,
-		stderr:                stderr,
-		maxSize:               0,
-		rotationCheckRecords:  defaultRotationCheckRecords,
-		rotationCheckInterval: defaultRotationCheckInterval,
-		lastSizeCheck:         time.Now(),
-	}
-	for _, opt := range opts {
-		opt(r)
-	}
+	r.file = file
+	r.seq = maxSeq
 	return r, nil
 }
 


### PR DESCRIPTION
## Why

On a split city (`[storage]` relocating the five infrastructure classes to a
binding), `openStorageRoutes` hands back a **bare bead engine** — a
`*beads.SQLiteStore` or `*beads.NativeDoltStore` with no `CachingStore` and no
wrapper of any kind. `resolveClassStore` then discarded its recorder for **every**
class (`_ = rec`), so every write a one-shot command made to a relocated bead
landed in the store and appended **nothing** to `<city>/.gc/events.jsonl`:
`gc bd close` of a `gcg-` step, `gc sling`, the control dispatcher's one-shot arm,
mail, nudges, orders.

The cost is not the events, it is every consumer that reconstructs state by
folding them:

- **Run projections.** `runproj.Fold` never saw a worker-side close, so a
  molecule's steps rendered "Running" forever (`unknown_run`), made permanent by
  the wisp reap deleting the rows a later fold would have needed to recover
  from. Production: 277/290 claimed `gcg` beads with no terminal event.
- **Event-delta lanes (#5296).** They resume from a journal cursor and read
  bead.* deltas; on a split city that delta is empty, so the lanes conclude
  nothing happened.

This is **G16/G17** in `engdocs/plans/infra-class-sqlite-stores/GRAPH-READ-GAP-ANALYSIS.md`
(§ "Graph-store mutations emit bead.* events"), and it is why every graph.v2
molecule since ~Aug 7 emits zero `bead.*` events.

It is generic SDK behaviour — a relocated coordination class is a supported OSS
topology — so it lands on OSS `main` first and reaches maintainer-city on the
next train.

## What

**One injection site.** Emission is a property of the PROCESS that opened the
store, not of the store. The controller has a live event bus and its own emitter,
and a second one on the same mutation is a duplicate row in the log — worse on
the reconcile path, where the cache re-absorbs rows in bulk. So the emit target
is set on the **routes**, at the one construction that belongs to a one-shot
command (`resolveCLIStorageRoutes`), and never at the controller's
(`openStorageRoutes`). The controller path is untouched **by construction**: it
never reaches the new file at all. `TestClassStoreEmitTargetHasExactlyOneInjectionSite`
pins that the injector stays single, because "the controller does not emit" is a
claim about the call graph and nothing else keeps a second injector from
appearing.

Because the wrap happens where the routes are built, every consumer inherits it
— `resolveClassStore` for all five classes AND the by-id class front door /
claim route, which reach the binding through `graphClassBinding` rather than
through the resolver.

**The wrapper forwards everything.** A class store's optional capabilities are
discovered by type assertion, so a method a wrapper drops does not fail — the
caller silently takes a weaker path. Every method both bead engines declare is
forwarded, and `TestEmittingClassStoreKeepsEveryEngineCapability` fails if
either grows one this file does not. `Claim` is forwarded for exactly that
reason: the hook's binding probe is an assertion, and dropping the method would
degrade `gc hook --claim` to "this binding cannot claim" on every split city.
`class_store_emit.go` is therefore added to the claim-CAS allowlist as a
**forwarder** — checked, not promised, by an AST guard that its only claim call
sits inside its own `Claim` method.

**Payload parity with the controller's emitter.** The canonical bead snapshot
(`beads.DecodeBeadEventPayload`-decodable), run/session/step correlation on the
typed envelope, dependency edges hydrated, native step topology through the
now-exported `beads.NativeStepDependencies` rather than a second copy of the
rule. `bead.closed` rides only a genuine open→closed transition. A post-write
read miss skips the row rather than emitting a bare id that would clobber the
fold — except a committed close, which is a fact.

**Best-effort, and loud about it.** The mutation has already committed when the
row is written, so a journal that cannot be opened must not fail the command;
failures surface once per process instead of being swallowed. The per-mutation
recorder skips the startup rotation sweep (`events.WithoutStartupSweep`) so it
cannot race the supervisor's long-lived recorder mid-rotation.

**Serve loop self-filter.** The dispatcher's control-bead writes now append
`bead.*` rows; an unfiltered wake would buy a heavy ready re-scan and a
controller poke per dispatch burst. The filter never fires on the ambiguous
`"human"` fallback identity, which every foreign CLI writer shares.

**Doc corrections.** Five comments claimed relocated writes already emitted, or
that the graph store was "event-silent by design". Passing a recorder to a class
resolver has never made a relocated write observable, for any class.

Not covered, deliberately: `Tx`-shaped writes. A transaction's effect is
whatever its body did, and this layer cannot know which beads changed without
re-reading around every call. Documented as a known gap, not an oversight.

## Gates

Red-first, all three.

1. **Exactly one event per door mutation** — red on the un-injected seam
   (`appended 0 bead event(s), want exactly 1`), green after. Five rows: graph
   through the by-id class front door, plus orders / nudges / messaging /
   sessions through their own CLI resolvers, because `resolveClassStore`
   discarded the recorder for all of them and the supported split moves all five
   at once.
2. **No-storm control** — the controller's routes stay silent under a
   reconcile-shaped absorption even when handed a live recorder. The control is
   falsifiable rather than vacuous: the same mutations through the CLI-emitting
   twin of the same routes DO land in the same journal, so a fixture that could
   not observe an event fails before it can certify silence. Plus the structural
   half (single injector).
3. **Cursor consumer** — the exact shape the #5296 delta lanes read: record a
   cursor, mutate, resume at `Filter{AfterSeq: cursor}`, and see the row with
   `seq > cursor` and run/step correlation on the envelope.

Ported from the original integ-branch fix where still applicable: dependency-edge
hydration, never-a-bare-id-payload, close-vs-update transition semantics,
conditional-release emission, recorder-diagnostic funnelling, single-store
byte-identity, store-identity stability, serve-loop self-actor filter.

## Verification

- `go test ./cmd/gc -count=1 -timeout 1800s` — ok (943s)
- `go test ./internal/events/... ./internal/beads/...` — ok
- `go test ./internal/api/... ./internal/storebinding/... ./internal/dispatch/... ./internal/runproj/...` — ok
- `go test ./scripts/...` + `scripts/check-residency-boundary.sh` — both residency halves clean (no new enumeration vocabulary, no new raw-store-list signature)
- `go vet ./...` — clean
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
