### PR TITLE
fix(release): create dispatch-path RC tags with a dedicated release-tagger app token

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -48,11 +48,26 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Mint release-tagger token
+        # Only the dispatch path creates the tag (the push path arrives with it
+        # already existing). The workflow's default GITHUB_TOKEN is not a bypass
+        # actor on the "Protect release tags" ruleset, so ref creation under
+        # refs/tags/v* is denied (GH013) — this burned the v1.4.1-rc1 dispatch.
+        # The gastownhall-release-tagger app is an Integration bypass actor on
+        # that ruleset; its short-lived token is used solely for the tag push.
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: tagger-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.RELEASE_TAGGER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TAGGER_APP_PRIVATE_KEY }}
+
       - name: Resolve RC tag
         id: rc
         env:
           DISPATCH_TAG: ${{ inputs.tag_name }}
           EVENT_NAME: ${{ github.event_name }}
+          TAGGER_TOKEN: ${{ steps.tagger-token.outputs.token || '' }}
         run: |
           set -euo pipefail
 
@@ -82,10 +97,14 @@ jobs:
               echo "ERROR: push event for $tag did not leave a local tag ref" >&2
               exit 1
             fi
+            if [ -z "${TAGGER_TOKEN}" ]; then
+              echo "ERROR: cannot create $tag — the tag ruleset restricts refs/tags/v* creation and no release-tagger token is available (RELEASE_TAGGER_APP_ID / RELEASE_TAGGER_APP_PRIVATE_KEY secrets missing?). Either configure the gastownhall-release-tagger app (see RELEASING.md) or push the tag manually and re-dispatch." >&2
+              exit 1
+            fi
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "$tag" -m "Release $tag" "$commit"
-            git push origin "refs/tags/$tag"
+            git push "https://x-access-token:${TAGGER_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$tag"
             echo "Created tag $tag at $commit"
           fi
 

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -104,7 +104,11 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "$tag" -m "Release $tag" "$commit"
-            git push "https://x-access-token:${TAGGER_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$tag"
+            # actions/checkout persists the default GITHUB_TOKEN as an
+            # http.extraheader that outranks URL-embedded credentials; blank it
+            # for this one push so the app token actually authenticates.
+            git -c "http.https://github.com/.extraheader=" \
+              push "https://x-access-token:${TAGGER_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$tag"
             echo "Created tag $tag at $commit"
           fi
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,6 +39,16 @@ archives for linux/darwin × amd64/arm64, and creates a GitHub **draft
 prerelease** with generated GoReleaser notes and downloadable assets. It does
 not update the Homebrew tap, create attestations, or mark the release latest.
 
+Tag creation on the dispatch path uses the **gastownhall-release-tagger**
+GitHub App (an `Integration` bypass actor on the "Protect release tags"
+ruleset), minted per-run from the `RELEASE_TAGGER_APP_ID` /
+`RELEASE_TAGGER_APP_PRIVATE_KEY` repository secrets — the workflow's default
+`GITHUB_TOKEN` is deliberately NOT a bypass actor, so arbitrary workflows
+cannot create, move, or delete `v*` tags. If the app secrets are missing the
+dispatch path fails with instructions instead of a bare `GH013`; the
+manual-tag path below always works for members of the release-maintainers
+bypass team.
+
 You can also push an existing RC tag manually:
 
 ```bash


### PR DESCRIPTION
## Problem

Every `rc-release.yml` **dispatch** run that needs to create the RC tag dies at the push:

```
remote: error: GH013: Repository rule violations found for refs/tags/v1.4.1-rc1.
remote: - Cannot create ref due to creations being restricted.
```

The "Protect release tags" ruleset (16109967) restricts `refs/tags/v*` creation/update/deletion to one bypass team, and the workflow's default `GITHUB_TOKEN` is not (and should not be) a bypass actor. The v1.4.1-rc1 dry run hit this and had to fall back to RELEASING.md's manual-tag path.

## Fix

Mint a short-lived installation token from a dedicated **`gastownhall-release-tagger`** GitHub App (mirroring the existing homebrew-tap app pattern, same pinned `create-github-app-token` action) on the dispatch path only, and use it solely for the tag push. If the app secrets are absent, the step fails with actionable instructions instead of a bare GH013. The default `GITHUB_TOKEN` deliberately stays off the bypass list — arbitrary workflows still cannot create, move, or delete `v*` tags.

RELEASING.md documents the mechanism and keeps the manual-tag path as the always-works fallback.

## One-time setup required before this works (org admin)

1. Create the org GitHub App `gastownhall-release-tagger`: webhook off, repository permission **Contents: Read and write** only, install on **gastownhall/gascity** only.
2. Generate a private key; set the repo secrets `RELEASE_TAGGER_APP_ID` and `RELEASE_TAGGER_APP_PRIVATE_KEY`.
3. Add the app as an `Integration` bypass actor on ruleset 16109967 (scriptable once the app ID exists).

Deploy keys were considered first (fully self-serve) but are disabled by org policy; the blanket "GitHub Actions" integration as bypass actor was rejected as too broad (it would let any workflow — hence anyone with write access via a branch workflow file — create/move/delete release tags).

Guards: workflow YAML parses; `scripts/cipolicy` + `scripts` policy tests green (rc-release.yml is not hash-pinned by cipolicy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)