### PR TITLE
fix(nudge): prune dead letters after backing beads are reaped

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -2585,14 +2585,18 @@ func pruneDeadQueuedNudgesWithClock(state *nudgeQueueState, front *nudgequeue.St
 					filtered = append(filtered, item)
 					continue
 				}
-				shadow, ok, err = front.FindIncludingTerminal(item.ID)
-				if err != nil || !ok || !nudgequeue.IsTerminalState(shadow.State) {
-					filtered = append(filtered, item)
-					continue
-				}
+				// Terminalize's own error return is sufficient confirmation:
+				// nil means either the bead was really terminalized, or it
+				// tolerated a missing bead as a no-op because the bead was
+				// already reaped by an unrelated retention sweep (wisp
+				// compaction etc.). Re-querying FindIncludingTerminal here
+				// would never find a reaped bead again, so entries whose
+				// bead is gone would be retained forever and pay a store
+				// lookup on every sweep (gastownhall/gascity#5278).
 			}
 			if !item.DeadAt.IsZero() && item.DeadAt.Before(cutoff) {
-				// Terminal bead confirmed in store — safe to prune once past retention.
+				// Terminal (or the backing bead is gone entirely) — safe to
+				// prune once past retention.
 				continue
 			}
 		}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4335,6 +4335,47 @@ func TestPruneDeadQueuedNudges_RetainsItemsWithoutBeadID(t *testing.T) {
 	}
 }
 
+func TestPruneDeadQueuedNudges_PrunesItemsWhoseBeadWasReaped(t *testing.T) {
+	// Regression (gastownhall/gascity#5278): a dead-letter item whose BeadID
+	// once pointed at a real bead, but that bead was later reaped by an
+	// unrelated retention sweep (wisp compaction etc.), must still become
+	// prunable by age. The repair path can never re-confirm "found +
+	// terminal" for a bead that no longer exists, so before the fix such
+	// items were retained forever and paid a store lookup on every sweep.
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	now := time.Now().UTC()
+	item := newQueuedNudgeWithOptions("worker", "stale dead letter", "session", now.Add(-3*time.Hour), queuedNudgeOptions{
+		ID:        "n-dead-reaped",
+		SessionID: "gc-worker",
+	})
+	beadID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected backing nudge bead to be created")
+	}
+	item.BeadID = beadID
+	item.LastError = "expired"
+	item.DeadAt = now.Add(-2 * time.Hour) // older than defaultQueuedNudgeDeadRetention (1h)
+
+	// Simulate the backing bead being reaped by an unrelated retention sweep,
+	// independent of the nudge queue's own lifecycle.
+	if err := store.Delete(beadID); err != nil {
+		t.Fatalf("Delete(%s): %v", beadID, err)
+	}
+
+	state := &nudgeQueueState{Dead: []queuedNudge{item}}
+	if err := pruneDeadQueuedNudges(state, nudgeFrontDoor(store), now, noMaintenanceDeadline()); err != nil {
+		t.Fatalf("pruneDeadQueuedNudges: %v", err)
+	}
+	if len(state.Dead) != 0 {
+		t.Fatalf("dead = %d, want 0 -- a dead-letter item whose bead was reaped and is past retention must still be prunable", len(state.Dead))
+	}
+}
+
 func TestEnqueueSupersedes_SameAgentSourceReference(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/cmd/gc/sling_nudge_backlog_test.go
+++ b/cmd/gc/sling_nudge_backlog_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -8,15 +9,22 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 )
 
+// deadBacklogID returns a zero-padded ID so that lexicographic order (the
+// nudgequeue.SortState ID tiebreak, used when every item shares the same
+// DeadAt/CreatedAt as seeded here) matches seed/index order 0..n-1.
+func deadBacklogID(i int) string {
+	return fmt.Sprintf("nudge-dead-%04d", i)
+}
+
 func seedDeadBacklog(t *testing.T, cityPath string, now time.Time, n int) map[string]string {
 	t.Helper()
 	buckets := make(map[string]string, n)
 	if err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
 		for i := 0; i < n; i++ {
-			id := time.Duration(i).String()
-			buckets["nudge-dead-"+id] = "dead"
+			id := deadBacklogID(i)
+			buckets[id] = "dead"
 			state.Dead = append(state.Dead, queuedNudge{
-				ID: "nudge-dead-" + id, BeadID: "bead-dead-" + id,
+				ID: id, BeadID: "bead-" + id,
 				Agent: "gascity/deployer", Source: "sling", Message: "backlog",
 				CreatedAt: now.Add(-2 * time.Hour), DeadAt: now.Add(-2 * time.Hour),
 				LastError: "expired",
@@ -27,6 +35,22 @@ func seedDeadBacklog(t *testing.T, cityPath string, now time.Time, n int) map[st
 		t.Fatalf("seeding backlog: %v", err)
 	}
 	return buckets
+}
+
+// deadBacklogProcessed returns how many leading (by seed/index order, which
+// SortState's ID tiebreak preserves here) dead items the maintenance sweep
+// repairs-and-prunes before nudgeEnqueueMaintenanceBudget elapses. Each
+// processed item costs advancingNudgeStoreDeadItemOps store ops at the given
+// latency; the sweep checks the deadline before processing each item, so the
+// count is the number of items whose cumulative cost falls at-or-under the
+// budget.
+func deadBacklogProcessed(backlog int, latency time.Duration) int {
+	itemCost := time.Duration(advancingNudgeStoreDeadItemOps) * latency
+	processed := int(nudgeEnqueueMaintenanceBudget/itemCost) + 1
+	if processed > backlog {
+		processed = backlog
+	}
+	return processed
 }
 
 type enqueueTiming struct {
@@ -60,13 +84,23 @@ func timeEnqueue(t *testing.T, backlog int, latency time.Duration) enqueueTiming
 		t.Fatalf("advancing store ops (backlog=%d) = %d, want at most %d", backlog, timing.operations, maxOps)
 	}
 
+	processed := deadBacklogProcessed(backlog, latency)
+	survivors := backlog - processed
 	buckets := nudgeQueueBucketsByID(t, cityPath)
-	if got, want := len(buckets), len(seededBuckets)+1; got != want {
-		t.Fatalf("queued item count (backlog=%d) = %d, want %d; buckets=%v", backlog, got, want, buckets)
+	if got, want := len(buckets), survivors+1; got != want {
+		t.Fatalf("queued item count (backlog=%d) = %d, want %d (processed=%d survived=%d); buckets=%v", backlog, got, want, processed, survivors, buckets)
 	}
-	for id, wantBucket := range seededBuckets {
-		if bucket := buckets[id]; bucket != wantBucket {
-			t.Fatalf("seeded queued nudge %q bucket = %q, want %q; buckets=%v", id, bucket, wantBucket, buckets)
+	for i := 0; i < backlog; i++ {
+		id := deadBacklogID(i)
+		bucket, present := buckets[id]
+		if i < processed {
+			if present {
+				t.Fatalf("dead nudge %q (i=%d, backlog=%d) still present as %q, want repaired-and-pruned; buckets=%v", id, i, backlog, bucket, buckets)
+			}
+			continue
+		}
+		if bucket != seededBuckets[id] {
+			t.Fatalf("surviving dead nudge %q (i=%d, backlog=%d) bucket = %q, want %q; buckets=%v", id, i, backlog, bucket, seededBuckets[id], buckets)
 		}
 	}
 	if bucket := buckets[item.ID]; bucket != "pending" {

--- a/cmd/gc/sling_nudge_budget_test.go
+++ b/cmd/gc/sling_nudge_budget_test.go
@@ -11,8 +11,14 @@ import (
 )
 
 const (
-	advancingNudgeStoreSetupOps    = 1
-	advancingNudgeStoreDeadItemOps = 4
+	advancingNudgeStoreSetupOps = 1
+	// advancingNudgeStoreDeadItemOps is the store-op cost of repairing one dead
+	// backlog item during a maintenance sweep: FindIncludingTerminal (List) to
+	// check terminal state, then Terminalize (SetMetadataBatch + Close) to repair
+	// it. Terminalize's own nil return is sufficient confirmation (see
+	// pruneDeadQueuedNudgesWithClock, gastownhall/gascity#5278), so there is no
+	// second FindIncludingTerminal call to account for here.
+	advancingNudgeStoreDeadItemOps = 3
 )
 
 type advancingNudgeStore struct {
@@ -194,13 +200,23 @@ func TestSlingNudgeEnqueueBudgetPreservesQueuedItems(t *testing.T) {
 		t.Fatalf("advancing store ops = %d, want at most %d to prove the maintenance budget cut in", ops, maxOps)
 	}
 
+	processed := deadBacklogProcessed(deadBacklog, latency)
+	survivors := deadBacklog - processed
 	buckets := nudgeQueueBucketsByID(t, cityPath)
-	if got, want := len(buckets), len(seededBuckets)+1; got != want {
-		t.Fatalf("queued item count = %d, want %d; buckets=%v", got, want, buckets)
+	if got, want := len(buckets), survivors+4+1; got != want {
+		t.Fatalf("queued item count = %d, want %d (processed=%d survived=%d dead of %d, plus 4 preserved plus new); buckets=%v", got, want, processed, survivors, deadBacklog, buckets)
 	}
-	for id, wantBucket := range seededBuckets {
-		if bucket := buckets[id]; bucket != wantBucket {
-			t.Fatalf("seeded queued nudge %q bucket = %q, want %q; buckets=%v", id, bucket, wantBucket, buckets)
+	for i := 0; i < deadBacklog; i++ {
+		id := fmt.Sprintf("nudge-dead-preserve-%03d", i)
+		bucket, present := buckets[id]
+		if i < processed {
+			if present {
+				t.Fatalf("dead nudge %q (i=%d) still present as %q, want repaired-and-pruned; buckets=%v", id, i, bucket, buckets)
+			}
+			continue
+		}
+		if bucket != seededBuckets[id] {
+			t.Fatalf("surviving dead nudge %q (i=%d) bucket = %q, want %q; buckets=%v", id, i, bucket, seededBuckets[id], buckets)
 		}
 	}
 	for i := 0; i < 2; i++ {

--- a/release-gates/ga-j250d0-dead-letter-reaped-bead-pruning-gate.md
+++ b/release-gates/ga-j250d0-dead-letter-reaped-bead-pruning-gate.md
@@ -1,0 +1,93 @@
+# Release Gate: prune dead-letter nudges after backing-bead reaping
+
+- Deploy bead: `ga-j250d0`
+- Build bead: `ga-18w8e5`
+- Review bead: `ga-osffxo`
+- Reviewed source: `48c0eb6cf380a6e0e075340b189e93748c532cd8`
+- Provenance branch: `builder/ga-ev4kfb` (not a push target)
+- Base checked: `origin/main@5bbbb643f8fee5b2736e534eae879158e9f6facd`
+- Evaluated: 2026-08-16
+- Verdict: **PASS**
+
+The deploy bead's original description still names the previously rejected
+commit `544b16526d2f505a67d14cd7ef98b7111e2f5258`. The resubmission review,
+typed `metadata.commit`, reviewer mail, and reviewer verdict all supersede it
+with the git-resolved commit above. The new two-commit stack is content-identical
+to the original review and adds the required `(refs ga-18w8e5)` provenance to
+both subjects.
+
+`docs/PROJECT_MANIFEST.md` is absent from this checkout and from current
+`origin/main`; this checklist applies the active deployer release criteria and
+the repository testing policy in `TESTING.md`.
+
+## Gate checklist
+
+Criterion 6 was evaluated first, after the already-merged pre-flight found no
+pull request carrying the reviewed source.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-osffxo` is closed with reason `pass`; its verdict step `ga-a21008` records `VERDICT: PASS` for the exact reviewed source. All five review steps are closed. |
+| 2 | Acceptance criteria met | **PASS** | Code inspection confirms that successful `Terminalize` is sufficient to prune an expired dead-letter entry even when its backing bead was already reaped. `Terminalize` explicitly treats a missing bead as a nil-error no-op. The new regression test proves the reaped-bead case, and the two latency/budget tests prove the reduced three-store-operation repair path and correct survivor accounting. The reviewer's spec step reports the required issue directive covered, optional considerations unchanged, and no uncovered criteria. |
+| 3 | Tests pass | **PASS** | The required process gate passed all 7 job scopes. The fast gate passed 9 of 10 job scopes; its sole failure, `TestProviderLiveClaudeKindPath`, is attributable under criterion 3a as documented below. All three diff-owned tests executed by name and passed with zero skips. Build, full lint, format, vet, and the CI policy lane passed. |
+| 4 | No high-severity review findings open | **PASS** | Review steps report `style_findings: none`, no OWASP-relevant surface, no uncovered criteria, and a final PASS. Unresolved HIGH count: `0`. |
+| 5 | Final branch is clean | **PASS** | The reviewed source was tested in isolated worktree `/var/tmp/ga-j250d0-gate.fcoXlB/repo`; `git status --short --branch` reported only detached HEAD and no changes before this checklist was added. `git diff --check origin/main...48c0eb6c` produced no output. Repository hooks resolve to `.githooks`. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree origin/main 48c0eb6cf380a6e0e075340b189e93748c532cd8` exited 0 and produced tree `4401e14821181eff58b24179917bd05e591342e5`; no self-rebase was needed. The reviewed SHA and both parent commits resolve in Git. |
+| 7 | Single feature theme | **PASS** | The two-commit TDD stack changes four files under `cmd/gc`, all within nudge dead-letter cleanup: the pruning behavior, its new regression test, and the two budget/backlog tests updated for the reduced store-operation count. No independent feature is bundled. |
+
+The mandatory ancestry-scope guard also passed before branch creation:
+
+```text
+assert_deploy_ancestry_scope origin/main 48c0eb6cf380a6e0e075340b189e93748c532cd8 ga-j250d0 ga-18w8e5
+exit 0
+```
+
+## Test evidence
+
+Environment setup before test execution:
+
+- `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`
+- `TESTCONTAINERS_RYUK_DISABLED=true`
+- Rootless Podman 5.8.4 and its socket were confirmed available.
+
+Commands and counts:
+
+- `make test-cmd-gc-process-parallel`: **7 PASS job scopes, 0 FAIL, 0 SKIP** (six process shards plus `productmetrics-testhook`).
+- `make test-fast-parallel`: **9 PASS job scopes, 1 attributed FAIL, 0 SKIP**; all six `cmd/gc` shards passed.
+- Focused diff-owned run: **3 PASS, 0 FAIL, 0 SKIP**.
+- `make test-ci-policy`: **PASS**.
+- `go build ./...`: **PASS**.
+- `make lint`: **PASS**, 0 issues.
+- `make fmt-check`: **PASS**, no diff.
+- `go vet ./...`: **PASS**.
+
+`diff_tests_executed`:
+
+- `TestPruneDeadQueuedNudges_PrunesItemsWhoseBeadWasReaped`: PASS
+- `TestSlingNudgeEnqueueBoundedByBacklog`: PASS
+- `TestSlingNudgeEnqueueBudgetPreservesQueuedItems`: PASS
+
+`test_counts`: required job gates **16 PASS / 1 attributed FAIL / 0 SKIP**;
+diff-owned tests **3 PASS / 0 FAIL / 0 SKIP**.
+
+`skip_justification`: not applicable — zero skips.
+
+`waiver_ref`: none required.
+
+`policy_lane`: `make test-ci-policy` — PASS.
+
+`failure_attribution`:
+
+- `TestProviderLiveClaudeKindPath` -> `ga-cqq3hs.1`. The failing test is in
+  `internal/runtime/herdr/kindpath_live_test.go`, while this diff touches only
+  four `cmd/gc` nudge files. A focused run at current
+  `origin/main@5bbbb643f8fee5b2736e534eae879158e9f6facd` failed with the same
+  `agent_pane_busy` / `w1:p1 is not an available shell` signature. It is not
+  diff-owned, has a live tracker, reproduces on the base, and has no path
+  overlap, satisfying all four criterion-3a clauses.
+
+## Gate decision
+
+The reviewed change is conflict-free with current main, has complete
+diff-owned execution evidence, and introduces no un-attributed test failure.
+It is eligible for an isolated deploy branch and pull request.


### PR DESCRIPTION
## What this changes

Dead-letter nudge maintenance now removes entries after their retention window even when the associated bead has already been reaped. Previously, cleanup re-queried the store after a successful terminalization attempt; a deleted backing bead could never be found by that second query, so its dead-letter entry survived every sweep and repeatedly paid another store lookup. Large stale backlogs could therefore stretch foreground `gc sling --nudge` work beyond the hook budget.

The cleanup path now treats `Terminalize` returning nil as sufficient confirmation. That contract covers both a bead that was terminalized and a missing bead that was already removed by another retention sweep. Existing fail-open behavior is unchanged: entries are retained when the store is unavailable, lookup or terminalization fails, or the dead-letter retention window has not elapsed.

## Review notes

- The behavior change is confined to `cmd/gc` nudge-queue maintenance.
- The implementation relies on the existing missing-bead no-op contract of `nudgequeue.Store.Terminalize`.
- The budget tests model the reduced repair cost and verify both bounded processing and preservation of unprocessed queue entries.
- There are no config, API, wire-format, or migration changes.

## Test plan

- [x] Run the process-backed `cmd/gc` shard gate with `make test-cmd-gc-process-parallel`.
- [x] Exercise the reaped-backing-bead regression and both nudge budget/backlog tests by name.
- [x] Run build, formatting, lint, vet, and the repository policy lane.
- [x] Release gate: [`release-gates/ga-j250d0-dead-letter-reaped-bead-pruning-gate.md`](release-gates/ga-j250d0-dead-letter-reaped-bead-pruning-gate.md)
