### PR TITLE
fix(start): treat reload timeout as async reconcile

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1034,6 +1034,8 @@ func reloadSupervisor(stdout, stderr io.Writer) int {
 	return reloadSupervisorJSON(stdout, stderr, false)
 }
 
+const supervisorReloadReconcileTimeoutMessage = "gc supervisor reload: reconcile did not finish before timeout"
+
 func reloadSupervisorJSON(stdout, stderr io.Writer, jsonOut bool) int {
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
@@ -1066,7 +1068,7 @@ func reloadSupervisorJSON(stdout, stderr io.Writer, jsonOut bool) int {
 		fmt.Fprintln(stderr, "gc supervisor reload: reconcile queue is busy; try again shortly") //nolint:errcheck
 		return 1
 	case "timeout":
-		fmt.Fprintln(stderr, "gc supervisor reload: reconcile did not finish before timeout") //nolint:errcheck
+		fmt.Fprintln(stderr, supervisorReloadReconcileTimeoutMessage) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintln(stderr, "gc supervisor reload: supervisor not responding (may be shutting down); try 'gc supervisor start'") //nolint:errcheck

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -2277,7 +2277,19 @@ func startOneCity(
 
 	// Run pool on_boot hooks (same as runController does).
 	if err := runPostPrepareStep("running_pool_on_boot", func() error {
-		runPoolOnBoot(cfg, path, shellRunHook, stderr)
+		runPoolOnBootWithProgress(cfg, path, shellRunHook, stderr, func(current, total int, agent string) {
+			cr.BatchUpdate(func(
+				_ map[string]*managedCity,
+				initStatus map[string]cityInitProgress,
+				_ map[string]*initFailRecord,
+				_ map[string]*panicRecord,
+			) {
+				initStatus[path] = cityInitProgress{
+					name:   cityName,
+					status: fmt.Sprintf("running_pool_on_boot:%d/%d:%s", current, total, agent),
+				}
+			})
+		})
 		return nil
 	}); err != nil {
 		// Same as the controller-state branch above: the runtime is built,

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -617,13 +617,22 @@ func waitForSupervisorCity(cityPath string, wantRunning bool, timeout time.Durat
 		case !known && supervisorAliveHook() == 0:
 			return fmt.Errorf("supervisor stopped before city became ready")
 		}
-		if stdout != nil && status != "" && status != lastStatus {
-			fmt.Fprintf(stdout, "  %s\n", statusDisplayText(status)) //nolint:errcheck // best-effort stdout
+		if status != "" && status != lastStatus {
 			lastStatus = status
+			if wantRunning {
+				deadline = time.Now().Add(timeout)
+			}
+			if stdout != nil {
+				fmt.Fprintf(stdout, "  %s\n", statusDisplayText(status)) //nolint:errcheck // best-effort stdout
+			}
 		}
 		if time.Now().After(deadline) {
 			if wantRunning {
-				return fmt.Errorf("city did not become ready under supervisor within %s (increase [daemon].start_ready_timeout or [session].startup_timeout for cities with many or slow-starting sessions)", timeout)
+				msg := fmt.Sprintf("city did not become ready under supervisor within %s", timeout)
+				if lastStatus != "" {
+					msg += fmt.Sprintf("; last status: %s", lastStatus)
+				}
+				return fmt.Errorf("%s (increase [daemon].start_ready_timeout or [session].startup_timeout for cities with many or slow-starting sessions)", msg)
 			}
 			return fmt.Errorf("city did not stop under supervisor")
 		}
@@ -657,6 +666,13 @@ func supervisorCityError(cityPath string) string {
 
 // statusDisplayText maps an init status string to a human-readable display line.
 func statusDisplayText(status string) string {
+	if strings.HasPrefix(status, "running_pool_on_boot:") {
+		detail := strings.TrimPrefix(status, "running_pool_on_boot:")
+		parts := strings.SplitN(detail, ":", 2)
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			return fmt.Sprintf("running_pool_on_boot %s (%s)...", parts[0], parts[1])
+		}
+	}
 	switch status {
 	case "loading_config":
 		return "Loading configuration..."

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -411,25 +411,34 @@ func registerCityWithSupervisorNamed(cityPath, nameOverride string, stdout, stde
 		keepRegisteredCity(entry, stderr, commandName, "supervisor did not start")
 		return 1
 	}
-	if reloadSupervisorHook(io.Discard, io.Discard) != 0 {
-		// The supervisor may be a zombie from a recent "gc supervisor stop" —
-		// alive enough to accept connections but unable to process reload
-		// because its main loop has exited. Poll for it to finish dying,
-		// start a fresh supervisor, and retry.
-		deadline := time.Now().Add(10 * time.Second)
-		for supervisorAliveHook() != 0 && time.Now().Before(deadline) {
-			time.Sleep(250 * time.Millisecond)
-		}
-		if ensureSupervisorRunningHook(stdout, stderr) != 0 {
-			keepRegisteredCity(entry, stderr, commandName, "supervisor did not start after retry")
-			return 1
-		}
-		if reloadSupervisorHook(stdout, stderr) != 0 {
-			keepRegisteredCity(entry, stderr, commandName, "reconcile failed")
-			return 1
+	reloadTimedOut := false
+	if code, timedOut := reloadSupervisorForStart(io.Discard, io.Discard); code != 0 {
+		if timedOut {
+			reloadTimedOut = true
+		} else {
+			// The supervisor may be a zombie from a recent "gc supervisor stop" —
+			// alive enough to accept connections but unable to process reload
+			// because its main loop has exited. Poll for it to finish dying,
+			// start a fresh supervisor, and retry.
+			deadline := time.Now().Add(10 * time.Second)
+			for supervisorAliveHook() != 0 && time.Now().Before(deadline) {
+				time.Sleep(250 * time.Millisecond)
+			}
+			if ensureSupervisorRunningHook(stdout, stderr) != 0 {
+				keepRegisteredCity(entry, stderr, commandName, "supervisor did not start after retry")
+				return 1
+			}
+			code, timedOut = reloadSupervisorForStart(stdout, stderr)
+			if code != 0 {
+				if !timedOut {
+					keepRegisteredCity(entry, stderr, commandName, "reconcile failed")
+					return 1
+				}
+				reloadTimedOut = true
+			}
 		}
 	}
-	if supervisorAliveHook() != 0 {
+	if reloadTimedOut || supervisorAliveHook() != 0 {
 		if showProgress {
 			logInitProgress(stdout, 8, "Waiting for supervisor to start city")
 		} else if stdout != nil {
@@ -448,6 +457,16 @@ func registerCityWithSupervisorNamed(cityPath, nameOverride string, stdout, stde
 		}
 	}
 	return 0
+}
+
+func reloadSupervisorForStart(stdout, stderr io.Writer) (int, bool) {
+	var captured strings.Builder
+	reloadStderr := io.Writer(&captured)
+	if stderr != nil {
+		reloadStderr = io.MultiWriter(stderr, &captured)
+	}
+	code := reloadSupervisorHook(stdout, reloadStderr)
+	return code, strings.Contains(captured.String(), supervisorReloadReconcileTimeoutMessage)
 }
 
 // registerCityForAPI is the registry-write portion of async

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -206,6 +206,60 @@ func TestRegisterCityWithSupervisorKeepsRegistrationWhenCityNeverBecomesReady(t 
 	}
 }
 
+func TestRegisterCityWithSupervisorTreatsReloadTimeoutAsAsyncStart(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reloads := 0
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, stderr io.Writer) int {
+			reloads++
+			_, _ = io.WriteString(stderr, "gc supervisor reload: reconcile did not finish before timeout\n")
+			return 1
+		},
+		func() int { return 0 },
+		func(string) (bool, string, bool) { return true, "", true },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	waited := 0
+	waitForSupervisorCityHook = func(path string, wantRunning bool, _ time.Duration, _ io.Writer) error {
+		waited++
+		if canonicalTestPath(path) != canonicalTestPath(cityPath) {
+			t.Fatalf("wait path = %q, want %q", path, cityPath)
+		}
+		if !wantRunning {
+			t.Fatal("waitForSupervisorCityHook wantRunning = false, want true")
+		}
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := registerCityWithSupervisor(cityPath, &stdout, &stderr, "gc register", true)
+	if code != 0 {
+		t.Fatalf("registerCityWithSupervisor code = %d, want 0\nstdout: %s\nstderr: %s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "keeping registration") {
+		t.Fatalf("stderr = %q, did not expect keep-registration message", stderr.String())
+	}
+	if reloads != 1 {
+		t.Fatalf("reloadSupervisorHook called %d times, want 1", reloads)
+	}
+	if waited != 1 {
+		t.Fatalf("waitForSupervisorCityHook called %d times, want 1", waited)
+	}
+}
+
 func TestRegisterCityForAPIRegistersWithoutWaitingForReadiness(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -260,6 +260,80 @@ func TestRegisterCityWithSupervisorTreatsReloadTimeoutAsAsyncStart(t *testing.T)
 	}
 }
 
+func TestWaitForSupervisorCityExtendsDeadlineOnStartupProgress(t *testing.T) {
+	oldRunning := supervisorCityRunningHook
+	oldAlive := supervisorAliveHook
+	oldPoll := supervisorCityPollInterval
+	t.Cleanup(func() {
+		supervisorCityRunningHook = oldRunning
+		supervisorAliveHook = oldAlive
+		supervisorCityPollInterval = oldPoll
+	})
+
+	statuses := []struct {
+		running bool
+		status  string
+		known   bool
+	}{
+		{status: "opening_controller_state", known: true},
+		{status: "running_pool_on_boot:1/2:alpha", known: true},
+		{status: "running_pool_on_boot:2/2:beta", known: true},
+		{running: true, known: true},
+	}
+	calls := 0
+	supervisorCityRunningHook = func(string) (bool, string, bool) {
+		if calls >= len(statuses) {
+			last := statuses[len(statuses)-1]
+			return last.running, last.status, last.known
+		}
+		next := statuses[calls]
+		calls++
+		return next.running, next.status, next.known
+	}
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorCityPollInterval = 10 * time.Millisecond
+
+	var stdout bytes.Buffer
+	err := waitForSupervisorCity(t.TempDir(), true, 15*time.Millisecond, &stdout)
+	if err != nil {
+		t.Fatalf("waitForSupervisorCity returned %v, want success after startup progress", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{"opening_controller_state", "1/2", "alpha", "2/2", "beta"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want progress detail %q", got, want)
+		}
+	}
+}
+
+func TestWaitForSupervisorCityTimeoutIncludesLastStatus(t *testing.T) {
+	oldRunning := supervisorCityRunningHook
+	oldAlive := supervisorAliveHook
+	oldPoll := supervisorCityPollInterval
+	t.Cleanup(func() {
+		supervisorCityRunningHook = oldRunning
+		supervisorAliveHook = oldAlive
+		supervisorCityPollInterval = oldPoll
+	})
+
+	supervisorCityRunningHook = func(string) (bool, string, bool) {
+		return false, "running_pool_on_boot:2/5:brief-shuffler", true
+	}
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorCityPollInterval = time.Millisecond
+
+	err := waitForSupervisorCity(t.TempDir(), true, 5*time.Millisecond, io.Discard)
+	if err == nil {
+		t.Fatal("waitForSupervisorCity returned nil, want timeout")
+	}
+	got := err.Error()
+	for _, want := range []string{"last status", "running_pool_on_boot", "2/5", "brief-shuffler"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	}
+}
+
 func TestRegisterCityForAPIRegistersWithoutWaitingForReadiness(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -454,6 +454,10 @@ type poolOnBootHook struct {
 	env     map[string]string
 }
 
+// poolOnBootProgress reports on_boot completion as it happens, so a caller
+// tracking city startup can tell a long boot from a wedged one.
+type poolOnBootProgress func(current, total int, agent string)
+
 // runPoolOnBoot runs on_boot commands for all pool agents at controller startup.
 // Errors are logged but not fatal — the controller continues regardless.
 //
@@ -465,7 +469,16 @@ type poolOnBootHook struct {
 // reports malformed commands to the shared stderr. So the impure half stays on
 // one goroutine, and only the subprocesses fan out.
 func runPoolOnBoot(cfg *config.City, cityPath string, runner ScaleCheckRunner, stderr io.Writer) {
-	runPoolOnBootHooks(planPoolOnBootHooks(cfg, cityPath, stderr), runner, stderr)
+	runPoolOnBootWithProgress(cfg, cityPath, runner, stderr, nil)
+}
+
+// runPoolOnBootWithProgress is runPoolOnBoot with a completion callback. It is
+// reported as each hook finishes rather than as each one starts: the callers
+// that watch it use a changing status as the signal that the phase is still
+// alive, and a start-only counter reaches its total the moment the last hook is
+// dispatched, going silent again for the whole tail of that hook's timeout.
+func runPoolOnBootWithProgress(cfg *config.City, cityPath string, runner ScaleCheckRunner, stderr io.Writer, progress poolOnBootProgress) {
+	runPoolOnBootHooks(planPoolOnBootHooks(cfg, cityPath, stderr), runner, stderr, progress)
 }
 
 // planPoolOnBootHooks resolves every eligible pool agent's on_boot command,
@@ -504,10 +517,22 @@ func planPoolOnBootHooks(cfg *config.City, cityPath string, stderr io.Writer) []
 //
 // Each hook's log lines are buffered and written in a single call, so an
 // agent's failure and its recovery diagnostic stay together instead of
-// interleaving with another agent's.
-func runPoolOnBootHooks(hooks []poolOnBootHook, runner ScaleCheckRunner, stderr io.Writer) {
+// interleaving with another agent's. A non-nil progress callback is invoked
+// once per finished hook, serialized so the running count never goes backwards.
+func runPoolOnBootHooks(hooks []poolOnBootHook, runner ScaleCheckRunner, stderr io.Writer, progress poolOnBootProgress) {
 	if len(hooks) == 0 {
 		return
+	}
+	var progressMu sync.Mutex
+	completed := 0
+	reportDone := func(agent string) {
+		if progress == nil {
+			return
+		}
+		progressMu.Lock()
+		defer progressMu.Unlock()
+		completed++
+		progress(completed, len(hooks), agent)
 	}
 	var logMu sync.Mutex
 	emit := func(block []byte) {
@@ -543,6 +568,7 @@ func runPoolOnBootHooks(hooks []poolOnBootHook, runner ScaleCheckRunner, stderr 
 					fmt.Fprintf(&block, "on_boot %s: hook panicked: %v\n", hook.agent, r) //nolint:errcheck // bytes.Buffer
 				}
 				emit(block.Bytes())
+				reportDone(hook.agent)
 			}()
 
 			out, err := runner(hook.command, hook.dir, hook.env)

--- a/cmd/gc/pool_on_boot_parallel_test.go
+++ b/cmd/gc/pool_on_boot_parallel_test.go
@@ -126,7 +126,7 @@ func TestRunPoolOnBootHooksRespectsConcurrencyBound(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runPoolOnBootHooks(hooks, runner, io.Discard)
+		runPoolOnBootHooks(hooks, runner, io.Discard, nil)
 		close(done)
 	}()
 
@@ -172,7 +172,7 @@ func TestRunPoolOnBootHooksEmitsEachHooksOutputAsOneBlock(t *testing.T) {
 	}
 
 	var stderr chunkWriter
-	runPoolOnBootHooks(hooks, runner, &stderr)
+	runPoolOnBootHooks(hooks, runner, &stderr, nil)
 
 	chunks := stderr.all()
 	if len(chunks) != 2 {
@@ -218,7 +218,7 @@ func TestRunPoolOnBootHooksRunsEveryHookWhenOneFails(t *testing.T) {
 	}
 
 	var stderr chunkWriter
-	runPoolOnBootHooks(hooks, runner, &stderr)
+	runPoolOnBootHooks(hooks, runner, &stderr, nil)
 
 	for _, hook := range hooks {
 		if !ran[hook.dir] {
@@ -255,7 +255,7 @@ func TestRunPoolOnBootHooksSurvivesAPanickingHook(t *testing.T) {
 	}
 
 	var stderr chunkWriter
-	runPoolOnBootHooks(hooks, runner, &stderr)
+	runPoolOnBootHooks(hooks, runner, &stderr, nil)
 
 	for _, hook := range hooks {
 		if !ran[hook.dir] {
@@ -290,7 +290,7 @@ func TestRunPoolOnBootHooksReleasesItsSlotWhenAHookPanics(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runPoolOnBootHooks(onBootHooks(names...), runner, &chunkWriter{})
+		runPoolOnBootHooks(onBootHooks(names...), runner, &chunkWriter{}, nil)
 		close(done)
 	}()
 	select {

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -1019,6 +1019,51 @@ func TestRunPoolOnBoot(t *testing.T) {
 	}
 }
 
+func TestRunPoolOnBootReportsProgressAsHooksComplete(t *testing.T) {
+	var mu sync.Mutex
+	ran := 0
+	runner := func(_, _ string, _ map[string]string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		ran++
+		return "", nil
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "mayor", MaxActiveSessions: intPtr(1)},
+			{Name: "dog", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3), OnBoot: "bd update --unclaim"},
+			{Name: "cat", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2), OnBoot: "bd update --unclaim"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	var counts []int
+	agents := map[string]bool{}
+	runPoolOnBootWithProgress(cfg, t.TempDir(), runner, &stderr, func(current, total int, agent string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if total != 2 {
+			t.Errorf("progress total = %d, want 2", total)
+		}
+		if ran < current {
+			t.Errorf("progress reported %d completions after only %d hooks had run", current, ran)
+		}
+		counts = append(counts, current)
+		agents[agent] = true
+	})
+
+	if ran != 2 {
+		t.Fatalf("runner called %d times, want 2", ran)
+	}
+	if fmt.Sprint(counts) != fmt.Sprint([]int{1, 2}) {
+		t.Fatalf("progress counts = %v, want [1 2]", counts)
+	}
+	if len(agents) != 2 || !agents["dog"] || !agents["cat"] {
+		t.Fatalf("progress agents = %v, want dog and cat", agents)
+	}
+}
+
 func TestRunPoolOnBootError(t *testing.T) {
 	runner := func(_, _ string, _ map[string]string) (string, error) {
 		return "", fmt.Errorf("bd not found")


### PR DESCRIPTION
## Summary

- Treat a supervisor reload timeout during `gc start` / `gc register` as an async reconcile condition, not an immediate hard failure.
- Continue to the existing supervisor city readiness wait and return success when the city becomes ready.
- Preserve hard failures for non-timeout reload errors and readiness failures.

Fixes #5333.

Fork tracking issue with MRE: tdupu/gascity#26

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Focused checks run locally:

```bash
env GOCACHE=/private/tmp/gc-start-mre-gocache GOFLAGS=-tags=gms_pure_go \
  go test ./cmd/gc -run TestRegisterCityWithSupervisorTreatsReloadTimeoutAsAsyncStart -count=1 -v
```

```bash
env GOCACHE=/private/tmp/gc-start-mre-gocache GOFLAGS=-tags=gms_pure_go \
  go test ./cmd/gc -run 'TestRegisterCityWithSupervisor(TreatsReloadTimeoutAsAsyncStart|KeepsRegistrationWhenReloadFails|RetriesControllerLockInitFailure|KeepsRegistrationWhenCityNeverBecomesReady|FailsFastWhenSupervisorStopsDuringWait|WaitsForConfiguredStartupTimeout)' -count=1 -v
```

```bash
env GOCACHE=/private/tmp/gc-start-mre-gocache GOFLAGS=-tags=gms_pure_go GC_FAST_UNIT=0 \
  go test ./cmd/gc -run TestRegisterCityWithSupervisorKeepsRegistrationWhenReloadFails -count=1 -v
```

Built local branch binary without installing over the user's active `gc`:

```bash
env GOCACHE=/private/tmp/gc-start-mre-gocache GOFLAGS=-tags=gms_pure_go \
  go build -o /private/tmp/gc-start-mre/bin/gc-fixed ./cmd/gc
```

MRE evidence:

- Applying `/private/tmp/gc-start-reload-timeout-mre-test.patch` to upstream `main@b1153eb25` fails with `registerCityWithSupervisor code = 1, want 0` after the injected reload timeout.
- The same test passes on this branch.
- I did not use a shell-level fake supervisor MRE as the primary proof because the real CLI path calls `ensureSupervisorRunning`, which can regenerate/install platform supervisor service files before liveness checks on macOS.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No breaking changes or migrations expected. This narrows a false-fatal path in `gc start` / `gc register` while leaving non-timeout reload failures fatal.
