### PR TITLE
perf(controller): orders and demand off the ledger — plane-narrowed plans, gate index, parallel condition waves (tick-S3)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4495,47 +4495,93 @@ func canonicalizeLegacyBoundUnassignedRoutedWork(cfg *config.City, workBeads []b
 }
 
 // collectOpenUnassignedRoutedWork gathers open, unassigned, pool-routed work from
-// the city store and every non-suspended rig store, index-aligned with the store
+// every leg the runtime plane serves routed work from, index-aligned with the store
 // and store ref that own each bead. It is the input collection for
 // canonicalizeLegacyBoundUnassignedRoutedWork: empty-assignee open work is dropped
 // by the assignee-keyed collectAssignedWorkBeadsWithStores passes, so the
-// migration re-home needs its own scan. The scan now issues one live backing
-// read per store per tick so the raw-status filter runs, which costs a
+// migration re-home needs its own scan. The scan issues one live backing
+// read per leg per tick so the raw-status filter runs, which costs a
 // backing-store round trip the cached read did not — the accepted tradeoff for
 // not counting blocked work as demand.
+//
+// # Two things changed here for the tick (ga-l7jdg)
+//
+// The leg set is Plan(RoutedWork) narrowed to the RUNTIME plane, not the census
+// sweep's. Routed work lives only in the graph store by operator ruling, so the
+// work-ledger leg could not hold this arm's answer and cost a remote round trip
+// per tick to prove it. routedWorkStoreCandidates carries the reasoning and the
+// single-store degradation.
+//
+// The legs are read CONCURRENTLY. This arm was the last sequential per-store
+// fan-out on the demand path — collectAssignedWorkBeadsWithStores has read its
+// legs in parallel for as long as it has had more than one — and the reads are
+// independent by construction: one live list per store, folded afterwards. The
+// fold stays serial and in PLAN ORDER, so the rows and their refs come out in
+// exactly the order the sequential loop produced.
+//
+// # What the repair passes riding on this read give up, and why it is nothing
+//
+// Three consumers besides the demand count read this set — the legacy-route
+// canonicalization, the control-dispatcher route repair, and the ready
+// selection — so narrowing the read narrows them too. It costs those passes
+// nothing they could have used: their whole purpose is to make a bead
+// POOL-DEMANDABLE, and a ledger-resident bead is not demandable from the runtime
+// plane whether or not its route is canonical. Canonicalizing one would produce
+// a tidier bead that still never spawns a seat. The lever that changes that is
+// `gc storage migrate` moving it to the binding, after which this arm sees it on
+// the very next tick; the lost-route half is separately converged off-tick by the
+// route-recovery backstop, which reads every leg (route_recovery_lane.go).
 func collectOpenUnassignedRoutedWork(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, suspendedRigPaths map[string]bool, stderr io.Writer) ([]beads.Bead, []beads.Store, []string, bool) {
 	if cfg == nil {
 		return nil, nil, nil, false
 	}
-	// Work arm (unassigned-routed re-home scan), over the Plan(Census) leg set.
 	// Refs are the canonical scoped spelling the rows' gc.root_store_ref is
 	// matched against; a binding keeps its own "class:*" ref, which reads back as
 	// city scope.
-	stores, legErr := censusStoreCandidates(cityPath, cfg, store, rigStores, suspendedRigPaths, censusRefScoped)
+	stores, legErr := routedWorkStoreCandidates(cityPath, cfg, store, rigStores, suspendedRigPaths, censusRefScoped)
 	if legErr != nil {
 		// The only demand signal this set feeds is openControlDispatcherDemand,
 		// and a refused city reporting zero would drain a live dispatcher. Say so
 		// and retain.
-		fmt.Fprintf(stderr, "collectOpenUnassignedRoutedWork: no census leg set for this city: %v\n", legErr) //nolint:errcheck
+		fmt.Fprintf(stderr, "collectOpenUnassignedRoutedWork: no routed-work leg set for this city: %v\n", legErr) //nolint:errcheck
 		return nil, nil, nil, true
 	}
+
+	type legResult struct {
+		rows []beads.Bead
+		err  error
+	}
+	results := make([]legResult, len(stores))
+	var wg sync.WaitGroup
+	for i, source := range stores {
+		if source.store == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, source classStoreCandidate) {
+			defer wg.Done()
+			// Live so the backing store's raw --status=open filter excludes blocked/
+			// deferred work: this unassigned-routed set feeds openControlDispatcherDemand
+			// and the route-repair passes, and mapBdStatus would otherwise collapse a
+			// blocked bead to "open" and let it count as spawn capacity or get its route
+			// re-stamped (EB-42o8/gc-nz5i; extends gc-4zb/#4395). See listOpenForControllerDemandLive.
+			rows, err := listOpenForControllerDemandLive(source.store)
+			results[i] = legResult{rows: rows, err: err}
+		}(i, source)
+	}
+	wg.Wait()
 
 	var workBeads []beads.Bead
 	var workStores []beads.Store
 	var workStoreRefs []string
 	var partial bool
 	seen := make(map[storeScopedBeadKey]struct{})
-	for _, source := range stores {
+	for i, source := range stores {
 		if source.store == nil {
 			continue
 		}
 		storeRef := source.ref
-		// Live so the backing store's raw --status=open filter excludes blocked/
-		// deferred work: this unassigned-routed set feeds openControlDispatcherDemand
-		// and the route-repair passes, and mapBdStatus would otherwise collapse a
-		// blocked bead to "open" and let it count as spawn capacity or get its route
-		// re-stamped (EB-42o8/gc-nz5i; extends gc-4zb/#4395). See listOpenForControllerDemandLive.
-		open, err := listOpenForControllerDemandLive(source.store)
+		open, err := results[i].rows, results[i].err
 		if err != nil {
 			// A failed live demand read must NOT read as zero demand: the only
 			// demand signal this set feeds is openControlDispatcherDemand (its

--- a/cmd/gc/census_residency.go
+++ b/cmd/gc/census_residency.go
@@ -83,7 +83,43 @@ func censusStoreCandidates(
 	suspendedRigPaths map[string]bool,
 	style censusRefStyle,
 ) ([]classStoreCandidate, error) {
-	return censusLegCandidates(storeref.Census{}, cityPath, cfg, leading, rigStores, suspendedRigPaths, style)
+	return censusLegCandidates(storeref.Census{}, storeref.PlaneReconcile, cityPath, cfg, leading, rigStores, suspendedRigPaths, style)
+}
+
+// routedWorkStoreCandidates resolves the ROUTED-WORK leg set for a
+// runtime-plane reader: Plan(RoutedWork) narrowed to the infra bindings.
+//
+// Two things make it a different question from censusStoreCandidates rather
+// than a cheaper version of it.
+//
+// The INTENT is RoutedWork, which is the surface `gc ready` and the hook claim
+// through. Sharing it is the reader-agreement property (internal/storeref's
+// TestSweepAndDemandReadTheSameStores): a bead the controller counts as demand
+// must be a bead a worker can claim, and the fastest way to break that is for
+// one of them to resolve its own leg list.
+//
+// The PLANE is runtime, and it narrows to the bindings because the operator
+// ruling is that routed work lives only in the graph store — "gc ready work will
+// never be in the work db" (ga-4qdfn) — so the ledger leg this arm used to read
+// SEQUENTIALLY, once per census leg, could not hold the answer. It was 8.1s of a
+// 24.2s demand leg on maintainer-city.
+//
+// The narrowing is the resolver's, not this file's: storeref.Narrow keeps the
+// plan's order, roles and per-leg error policies and only drops legs, so a
+// consumer cannot accidentally answer the latency question by reordering the
+// plan (#5148 co-residence — binding-LAST is deliberate).
+//
+// A city that relocates nothing narrows to its one work store, which there IS
+// its infra store.
+func routedWorkStoreCandidates(
+	cityPath string,
+	cfg *config.City,
+	leading beads.Store,
+	rigStores map[string]beads.Store,
+	suspendedRigPaths map[string]bool,
+	style censusRefStyle,
+) ([]classStoreCandidate, error) {
+	return censusLegCandidates(storeref.RoutedWork{}, storeref.PlaneRuntime, cityPath, cfg, leading, rigStores, suspendedRigPaths, style)
 }
 
 // sessionCensusStoreCandidates resolves the SESSION census leg set. It differs
@@ -104,11 +140,12 @@ func sessionCensusStoreCandidates(
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
 ) ([]classStoreCandidate, error) {
-	return censusLegCandidates(storeref.Session{}, cityPath, cfg, leading, rigStores, suspendedRigPaths, censusRefScoped)
+	return censusLegCandidates(storeref.Session{}, storeref.PlaneReconcile, cityPath, cfg, leading, rigStores, suspendedRigPaths, censusRefScoped)
 }
 
 func censusLegCandidates(
 	intent storeref.Intent,
+	plane storeref.Plane,
 	cityPath string,
 	cfg *config.City,
 	leading beads.Store,
@@ -126,6 +163,12 @@ func censusLegCandidates(
 	topo := residencyTopologyForCity(cityPath, cfg, work, servingRigStores(cfg, rigStores, suspendedRigPaths))
 	plan, err := storeref.Plan(intent, topo)
 	if err != nil {
+		return nil, err
+	}
+	// The plane is the CALLER's contract, applied after the residency question is
+	// answered: the census sweep converges and never narrows, the tick's
+	// routed-demand read is a latency contract and narrows to the infra binding.
+	if plan, err = storeref.Narrow(plan, plane); err != nil {
 		return nil, err
 	}
 	// Enumerated through the resolver rather than executed through it: the arms

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -232,7 +233,28 @@ type CityRuntime struct {
 	stdout, stderr    io.Writer
 }
 
-const runtimeDemandSnapshotMaxAge = 30 * time.Second
+// runtimeDemandSnapshotBackstopMaxAge bounds how long an EVENT-BACKED demand
+// snapshot may be reused before it is rebuilt regardless of what the ready
+// fingerprint says.
+//
+// It is a convergence backstop, not the freshness mechanism, and it used to be
+// neither. At 30s it sat at or below the patrol interval — and far below a slow
+// tick — which mattered because the age gate SHORT-CIRCUITS the fingerprint:
+// loadDemandSnapshot only computes readyDemandSnapshotFingerprint when the
+// snapshot is not already due. On maintainer-city's 373s tick the snapshot was
+// therefore always due, the fingerprint was never consulted, and the cache it
+// guards was dead code (ga-l7jdg).
+//
+// Freshness is the fingerprint's job: a claim, close or create anywhere in the
+// routed-demand leg set changes it and forces a rebuild in the same tick, and
+// the session fingerprint covers the session half. This bound exists for what
+// neither can see — a change no read of the ready set reflects — so it is set
+// well clear of any plausible tick rather than tuned for responsiveness.
+//
+// It applies ONLY on the event-backed path. A city with a configured scale_check
+// is not event-backed at all (demandSnapshotsEnabled), and keeps the per-tick
+// rebuild floored at scaleCheckDemandMinInterval below.
+const runtimeDemandSnapshotBackstopMaxAge = 5 * time.Minute
 
 // scaleCheckDemandMinInterval floors how often a patrol tick re-runs an agent
 // scale_check probe. scale_check demand cannot ride the event-backed
@@ -3615,7 +3637,7 @@ func (cr *CityRuntime) shouldRefreshDemandSnapshot(
 // tick. Non-patrol triggers bypass this entirely (see shouldRefreshDemandSnapshot).
 func (cr *CityRuntime) demandSnapshotPatrolMaxAge() time.Duration {
 	if cr.demandSnapshotsEnabled() {
-		return runtimeDemandSnapshotMaxAge
+		return runtimeDemandSnapshotBackstopMaxAge
 	}
 	// Snapshots are not event-backed. Without an event provider the cache
 	// cannot be invalidated by routed-work events, so patrol must rebuild every
@@ -3639,56 +3661,64 @@ func (cr *CityRuntime) demandSnapshotPatrolMaxAge() time.Duration {
 // demand probe reads, so a write anywhere in that set invalidates the cached
 // demand snapshot instead of letting it be reused for up to its max age.
 //
-// "Every store the probe reads" is the load-bearing part. The fingerprint hashed
-// the work store and the rigs; the probe's LEADING leg is the sessions-class
-// store, which on a converged split city is the graph binding — the store that
-// holds every routed graph step. So a step claimed or closed in the binding
-// changed nothing the fingerprint could see, and the controller went on
-// asserting demand for it for the rest of the snapshot window: phantom demand,
-// spawning seats for work that was already taken.
+// "Every store the probe reads" is the load-bearing part, and it is now answered
+// by the resolver: the legs are Plan(RoutedWork) narrowed to the RUNTIME plane —
+// the identical leg set the routed-demand read itself consumes
+// (routedWorkStoreCandidates). A fingerprint over a WIDER set than the read
+// invalidates the cache for changes the read cannot see; a fingerprint over a
+// NARROWER set licenses reuse of a snapshot that is already wrong. The old
+// hand-rolled list was the second kind: it hashed the work store and the rigs
+// and missed the graph binding where every routed step lives, so a step claimed
+// there changed nothing it could see and the controller kept asserting demand
+// for work already taken.
+//
+// The plane is what makes the check cheap. It used to issue one ReadyLive per
+// store — remote work ledger, binding, every rig — so asking "may I reuse the
+// cached demand?" cost several remote round trips on every patrol tick, to avoid
+// recomputing something cheaper (ga-l7jdg).
+//
+// Read through the resolver's Walk executor rather than an enumeration: a leg
+// read failure is HASHED rather than raised (a stable error must license reuse
+// exactly as a stable read does, or a dark store rebuilds the snapshot every
+// tick forever), so the visit never returns an error and the plan's per-leg
+// policy has nothing to escalate.
 func (cr *CityRuntime) readyDemandSnapshotFingerprint() string {
-	stores := []struct {
-		ref   string
-		store beads.Store
-	}{{ref: cr.cityName, store: cr.cityBeadStore()}}
-	// The demand probe's leading leg. Deduped by store identity: on a city that
-	// relocates nothing this IS the work store already hashed above, and hashing
-	// it twice would only double the read.
-	if sessions := cr.sessionsBeadStore().Store; !sameFingerprintStore(sessions, stores[0].store) {
-		stores = append(stores, struct {
-			ref   string
-			store beads.Store
-		}{ref: "class:sessions", store: sessions})
-	}
-	rigStores := cr.rigBeadStores()
-	refs := make([]string, 0, len(rigStores))
-	for ref := range rigStores {
-		refs = append(refs, ref)
-	}
-	sort.Strings(refs)
-	for _, ref := range refs {
-		stores = append(stores, struct {
-			ref   string
-			store beads.Store
-		}{ref: ref, store: rigStores[ref]})
-	}
-
 	h := fnv.New64a()
-	for _, entry := range stores {
-		_, _ = io.WriteString(h, entry.ref)
+	cfg := cr.serviceConfigSnapshot()
+	// The rig map is a constructor INPUT to the topology, not a residency answer
+	// — it is filtered by the configured suspension frame and handed straight to
+	// residencyTopology, which is what decides the legs. It stays on the
+	// residency-boundary census (baselined) because the census counts every
+	// consumer of a base enumerator, not only the wrong ones.
+	rigs := cr.rigBeadStores()
+	topo := cr.residencyTopology(servingRigStores(cfg, rigs, buildSuspendedRigPathsForCity(cfg, cr.cityPath)))
+	plan, err := storeref.Plan(storeref.RoutedWork{}, topo)
+	if err == nil {
+		plan, err = storeref.Narrow(plan, storeref.PlaneRuntime)
+	}
+	if err != nil {
+		// A refused city has no plan. Hash the refusal: it is stable while the
+		// refusal stands, and every arm downstream already reports it loudly.
+		_, _ = io.WriteString(h, "refused:")
+		_, _ = io.WriteString(h, err.Error())
+		return fmt.Sprintf("%x", h.Sum64())
+	}
+	_, _ = storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		ref := demandFingerprintRef(cr.cityName, leg.Ref)
+		_, _ = io.WriteString(h, ref)
 		_, _ = io.WriteString(h, "\x00")
-		if entry.store == nil {
+		if leg.Store == nil {
 			_, _ = io.WriteString(h, "<nil>")
 			_, _ = io.WriteString(h, "\x00")
-			continue
+			return false, nil
 		}
-		ready, err := beads.ReadyLive(entry.store, beads.ReadyQuery{TierMode: beads.TierBoth})
+		ready, err := beads.ReadyLive(leg.Store, beads.ReadyQuery{TierMode: beads.TierBoth})
 		if err != nil {
-			log.Printf("readyDemandSnapshotFingerprint: store %s: %v", entry.ref, err)
+			log.Printf("readyDemandSnapshotFingerprint: store %s: %v", ref, err)
 			_, _ = io.WriteString(h, "error:")
 			_, _ = io.WriteString(h, err.Error())
 			_, _ = io.WriteString(h, "\x00")
-			continue
+			return false, nil
 		}
 		sort.Slice(ready, func(i, j int) bool {
 			return ready[i].ID < ready[j].ID
@@ -3696,23 +3726,23 @@ func (cr *CityRuntime) readyDemandSnapshotFingerprint() string {
 		for _, bead := range ready {
 			writeReadyDemandFingerprintBead(h, bead)
 		}
-	}
+		return false, nil
+	})
 	return fmt.Sprintf("%x", h.Sum64())
 }
 
-// sameFingerprintStore reports whether two store handles are the same underlying
-// store, so the demand fingerprint reads each distinct store exactly once. It is
-// pointer identity — the same question workAssignmentStoresHave asks — because a
-// city that relocates nothing serves several coordination classes from one store
-// value, and a city that relocates them serves the sessions class from a
-// genuinely different one.
-func sameFingerprintStore(a, b beads.Store) bool {
-	if a == nil || b == nil {
-		return a == nil && b == nil
+// demandFingerprintRef spells a plan leg the way this fingerprint's log line
+// always has.
+func demandFingerprintRef(cityName string, ref storeref.StoreRef) string {
+	switch {
+	case ref == storeref.WorkRef:
+		return cityName
+	case storeref.IsClassRef(string(ref)):
+		return string(ref)
+	default:
+		rig, _ := storeref.ScopeRigContext(string(ref))
+		return rig
 	}
-	aKey, aOK := storePointerKey(a)
-	bKey, bOK := storePointerKey(b)
-	return aOK && bOK && aKey == bKey
 }
 
 func writeReadyDemandFingerprintBead(w io.Writer, bead beads.Bead) {

--- a/cmd/gc/demand_snapshot_budget_test.go
+++ b/cmd/gc/demand_snapshot_budget_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// The demand snapshot's read budget.
+//
+// load_demand_snapshot was 24.2s of a 373s maintainer-city tick, and two of its
+// three costs were reads of the remote work ledger that the operator invariant
+// says do not belong on the runtime plane at all (ga-l7jdg, bd memory
+// gascity-runtime-infra-store-invariant):
+//
+//   - the CACHE CHECK itself. readyDemandSnapshotFingerprint issued one ReadyLive
+//     per store — city ledger, sessions binding, every rig — so asking "may I
+//     reuse the snapshot?" cost more remote round trips than most legs.
+//   - collect_unassigned_routed, 8.1s: one live open-list per census leg,
+//     SEQUENTIALLY, for work the operator ruling says lives only in the graph
+//     store ("gc ready work will never be in the work db").
+//
+// The third, collect_assigned_work, deliberately keeps its ledger leg: a session
+// whose only claim is an HQ work bead must stay visible to the census or the
+// drain gate reaps a live holder (ga-w8ucu). Latency is not a reason to go blind
+// about who holds what.
+
+// TestDemandFingerprintIssuesZeroLedgerReadsOnASplitCity pins the cache check to
+// the infra binding.
+func TestDemandFingerprintIssuesZeroLedgerReadsOnASplitCity(t *testing.T) {
+	ledger := &countingReadyStore{Store: beads.NewMemStore()}
+	binding := &countingReadyStore{Store: beads.NewMemStore()}
+	cr := bindingFingerprintRuntime(t, ledger, binding)
+	routedStepIn(t, binding, "routed graph step")
+	routedStepIn(t, ledger, "routed work-ledger bead")
+
+	cr.readyDemandSnapshotFingerprint()
+
+	if ledger.readyCalls != 0 {
+		t.Fatalf("the demand cache check issued %d work-ledger Ready read(s), want 0 — at maintainer-city's ~5.4s RTT that is %v spent deciding whether to reuse a cache",
+			ledger.readyCalls, time.Duration(ledger.readyCalls)*5400*time.Millisecond)
+	}
+	// Control: the binding answered, so the zero above is a routing fact and not
+	// a fingerprint that stopped reading.
+	if binding.readyCalls != 1 {
+		t.Fatalf("binding Ready reads = %d, want exactly 1", binding.readyCalls)
+	}
+}
+
+// TestDemandFingerprintPatrolMaxAgeOutlivesATick is the other half of "the cache
+// can engage".
+//
+// The age gate SHORT-CIRCUITS the fingerprint — loadDemandSnapshot only computes
+// the fingerprint when the snapshot is not already due — so a max age at or below
+// the tick duration means the fingerprint is never consulted and the snapshot is
+// rebuilt every tick no matter how little changed. On maintainer-city the tick
+// was 373s against a 30s max age, and the whole cache was dead code.
+func TestDemandFingerprintPatrolMaxAgeOutlivesATick(t *testing.T) {
+	cr := bindingFingerprintRuntime(t, beads.NewMemStore(), beads.NewMemStore())
+	maxAge := cr.demandSnapshotPatrolMaxAge()
+	if !cr.demandSnapshotsEnabled() {
+		t.Fatal("the fixture is not event-backed, so the fingerprint path is not the one being measured")
+	}
+	// The default patrol interval is 30s and a tick may legitimately take
+	// several of them. A max age that does not clear that window makes the
+	// fingerprint unreachable.
+	if maxAge <= 2*time.Minute {
+		t.Fatalf("event-backed demand may be reused for %v; that is inside one slow tick, so the ready fingerprint below the age gate is never consulted and the snapshot rebuilds every tick", maxAge)
+	}
+}
+
+// TestCollectOpenUnassignedRoutedWorkReadsTheBindingAloneOnASplitCity is the
+// operator ruling on the routed-demand read: routed work lives ONLY in the graph
+// store, so the census legs the runtime plane serves it from are the bindings.
+func TestCollectOpenUnassignedRoutedWorkReadsTheBindingAloneOnASplitCity(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := residencyTestConfig()
+	ledgerBacking, bindingBacking := beads.NewMemStore(), beads.NewMemStore()
+	ledgerBacking.HonorExplicitIDs = true
+	bindingBacking.HonorExplicitIDs = true
+	ledger := &routedDemandCountingStore{Store: ledgerBacking}
+	binding := &routedDemandCountingStore{Store: bindingBacking}
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return ledger })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+
+	seedRoutedOpenBead(t, binding, "gcg-routed-1")
+	seedRoutedOpenBead(t, ledger, "ga-routed-1")
+
+	got, _, refs, partial := collectOpenUnassignedRoutedWork(cityPath, cfg, binding, nil, nil, io.Discard)
+	if partial {
+		t.Fatal("routed demand reported partial over healthy legs")
+	}
+	if ledger.listCalls != 0 {
+		t.Fatalf("routed demand issued %d work-ledger List(s), want 0 — routed work is not in the work db (operator ruling, ga-4qdfn)", ledger.listCalls)
+	}
+	if binding.listCalls == 0 {
+		t.Fatal("the binding was not read either; the ledger zero proves nothing")
+	}
+	if len(got) != 1 || got[0].ID != "gcg-routed-1" {
+		t.Fatalf("routed demand = %v, want the one binding-resident routed bead", beadIDsOf(got))
+	}
+	if len(refs) != len(got) {
+		t.Fatalf("refs = %v for %d bead(s); the index-aligned slices have drifted", refs, len(got))
+	}
+	if !storeref.IsClassRef(refs[0]) {
+		t.Fatalf("routed bead attributed to ref %q, want the binding's class ref", refs[0])
+	}
+}
+
+// TestCollectOpenUnassignedRoutedWorkReadsTheOnlyStoreOnASingleStoreCity is the
+// degradation half: with no binding, the work store IS the infra store.
+func TestCollectOpenUnassignedRoutedWorkReadsTheOnlyStoreOnASingleStoreCity(t *testing.T) {
+	backing := beads.NewMemStore()
+	backing.HonorExplicitIDs = true
+	store := &routedDemandCountingStore{Store: backing}
+	seedRoutedOpenBead(t, store, "ga-routed-1")
+
+	got, _, _, partial := collectOpenUnassignedRoutedWork("", residencyTestConfig(), store, nil, nil, io.Discard)
+	if partial {
+		t.Fatal("routed demand reported partial over a healthy single store")
+	}
+	if store.listCalls == 0 {
+		t.Fatal("a single-store city's routed demand read nothing; the runtime plane must degrade to \"the only store there is\"")
+	}
+	if len(got) != 1 || got[0].ID != "ga-routed-1" {
+		t.Fatalf("routed demand = %v, want the one routed bead", beadIDsOf(got))
+	}
+}
+
+func seedRoutedOpenBead(t *testing.T, store beads.Store, id string) {
+	t.Helper()
+	if _, err := store.Create(beads.Bead{
+		ID:       id,
+		Title:    id,
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	}); err != nil {
+		t.Fatalf("seed %q: %v", id, err)
+	}
+}
+
+// routedDemandCountingStore counts List round trips, which is the unit a remote leg's
+// latency is actually made of.
+type routedDemandCountingStore struct {
+	beads.Store
+	listCalls int
+}
+
+func (s *routedDemandCountingStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return s.Store.List(q)
+}

--- a/cmd/gc/doctor_route_recovery_quarantine_test.go
+++ b/cmd/gc/doctor_route_recovery_quarantine_test.go
@@ -63,7 +63,7 @@ func TestRouteRecoveryQuarantineCheckFixLiftsTheMarker(t *testing.T) {
 	}
 	// Control: the lifted bead is still a repair candidate. Lifting must re-arm
 	// the lane, not retire the bead.
-	report := newRouteRecoveryLane().backstopLeg(store)
+	report := newRouteRecoveryLane().backstopLeg(planeLeg{store: store})
 	if report.restored != 1 {
 		t.Fatalf("backstop restored %d after the quarantine was lifted, want 1", report.restored)
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -329,11 +329,37 @@ type orderDispatchTrackingIndex struct {
 	mu      sync.Mutex
 	entries map[string]map[string]orderTrackingSummary
 	errs    map[string]error
+
+	// stderr carries the ONE line a failed index read emits, once per store per
+	// tick. Without it a store whose index read fails would fall back to the
+	// per-order live gate silently and forever: the gate's answer stays correct,
+	// so nothing else complains, while the leg quietly costs one read per order
+	// per tick again — the exact regression this index exists to prevent, wearing
+	// a green test suite.
+	stderr io.Writer
 }
 
 type orderTrackingSummary struct {
+	// openTracking is an order-tracking bead at raw status "open" — the
+	// first gate's question ("is a dispatch already recorded in flight").
 	openTracking bool
-	lastRun      time.Time
+
+	// openWorkTracking is the STRICT gate's tracking half, and it is a
+	// deliberately wider question: any order-tracking bead that is not CLOSED,
+	// whatever its status. orders.Store.HasOpenWork has always read it that way
+	// (it filters `b.Status == "closed"`, not `!= "open"`), and an in_progress
+	// tracking bead really is a dispatch in flight. The two are separate fields
+	// rather than one because collapsing them would silently change whichever
+	// gate lost its own predicate.
+	openWorkTracking bool
+
+	lastRun time.Time
+
+	// openRoots are the non-closed beads carrying this order's order-run label
+	// that are NOT tracking beads: the wisp/molecule roots a dispatch stamps.
+	// Their subtree verdict is graph-owned and stays with wispRootHasOpenWork;
+	// the index's job is to find the roots without a query per order.
+	openRoots []beads.Bead
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -470,6 +496,100 @@ func newMemoryOrderDispatcher(routes *storageRoutes, aa []orders.Order, cityPath
 	}
 }
 
+// orderConditionCheckConcurrency bounds how many condition-check subprocesses a
+// single dispatch tick runs at once.
+//
+// A condition check is a `sh -c` fork with its own check_timeout (10s by
+// default), and the per-order loop used to run them one after another — so a
+// city with several condition orders paid the sum of their checks on the tick's
+// critical path, which is the variance in dispatch_orders' 55-92s range
+// (ga-l7jdg). They are independent external predicates, so the only thing
+// serializing them ever bought was a smaller process burst.
+//
+// It is a var so a test can pin it to 1 and prove the parallel path and the
+// serial path agree. The cap is small on purpose: these forks compete with the
+// controller's own work, and an unbounded pool on a city with fifty condition
+// orders is a fork bomb wearing a latency fix's name.
+var orderConditionCheckConcurrency = 8
+
+// orderDispatchCandidate is one order that cleared the tick's cheap gates and
+// carries the per-order state the fire loop needs.
+//
+// It exists so the condition checks can run between the two halves: resolution
+// and the open-tracking gate are index-served and serial, the checks are
+// subprocesses and concurrent, and the fire loop is serial again because the
+// dispatch budget's rotation is order-dependent.
+type orderDispatchCandidate struct {
+	idx           int
+	order         orders.Order
+	scoped        string
+	target        execStoreTarget
+	store         beads.Store
+	storeKey      string
+	gateStores    []beads.Store
+	gateStoreKeys []string
+
+	// triggerOpts is the exec env a condition check runs in; triggerErr is the
+	// failure building it, which the fire loop reports as a run outcome.
+	triggerOpts orders.TriggerOptions
+	triggerErr  error
+
+	// conditionResult is the prefetched verdict, nil for every trigger the
+	// parallel pass does not own.
+	conditionResult *orders.TriggerResult
+}
+
+// prefetchConditionResults runs every candidate condition check concurrently,
+// bounded by orderConditionCheckConcurrency.
+//
+// Only "condition" triggers go through here. The other four are pure clock or
+// cursor arithmetic evaluated in the fire loop, where their lastRun/cursor
+// closures already live.
+//
+// # What this changes about WHICH checks run
+//
+// The serial loop stopped evaluating orders once the dispatch budget was spent,
+// so a condition order late in the rotation had its check skipped on a busy
+// tick. This pass evaluates every candidate. That is the price of running them
+// concurrently — a wave has to be known before it can be launched — and it is
+// also the better answer: the budget now chooses which DUE orders to fire from a
+// complete picture instead of from wherever it happened to stop. The wall cost
+// is ceil(candidates/cap) checks deep rather than the sum of them.
+func (m *memoryOrderDispatcher) prefetchConditionResults(candidates []*orderDispatchCandidate, now time.Time) {
+	var pending []*orderDispatchCandidate
+	for _, cand := range candidates {
+		if cand.order.Trigger == "condition" && cand.triggerErr == nil {
+			pending = append(pending, cand)
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+	limit := orderConditionCheckConcurrency
+	if limit < 1 {
+		limit = 1
+	}
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	for _, cand := range pending {
+		wg.Add(1)
+		go func(cand *orderDispatchCandidate) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			// A condition trigger reads neither the last-run clock nor the event
+			// cursor, so the nil closures here are the honest statement of what
+			// the check consults: its own subprocess.
+			result := orders.CheckTriggerWithOptions(cand.order, now, nil, m.ep, nil, cand.triggerOpts)
+			cand.conditionResult = &result
+		}(cand)
+	}
+	// A canceled tick does not need special handling here: every check's own
+	// ConditionCtx is the tick's context, so cancellation kills the subprocesses
+	// and this wait returns with them.
+	wg.Wait()
+}
+
 func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, now time.Time) {
 	// Skip all order dispatch when the city is suspended. Use the
 	// dispatcher's in-scope city path so suspension state resolves
@@ -502,7 +622,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			}
 		}()
 	}()
-	trackingIndex := newOrderDispatchTrackingIndex()
+	trackingIndex := newOrderDispatchTrackingIndex(m.stderr)
 	budgetSpent := 0
 
 	total := len(m.aa)
@@ -521,6 +641,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		return m.maxDispatchesPerTick > 0 && budgetSpent >= m.maxDispatchesPerTick
 	}
 
+	// Phase 1: resolve and open-tracking-gate every order, in rotation order.
+	//
+	// It is separated from the fire loop below so the condition checks between
+	// them can run CONCURRENTLY. Everything here is cheap — store handles are
+	// memoized per target, and both gates are served from one index read per
+	// store — so doing it for every order costs the tick nothing and gives the
+	// parallel pass its complete work list.
+	candidates := make([]*orderDispatchCandidate, 0, total)
 	for offset := 0; offset < total; offset++ {
 		idx := (start + offset) % total
 		a := m.aa[idx]
@@ -583,6 +711,31 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			}
 		}
 
+		cand := &orderDispatchCandidate{
+			idx: idx, order: a, scoped: scoped,
+			target: target, store: store, storeKey: storeKey,
+			gateStores: storesForGate, gateStoreKeys: storeKeysForGate,
+		}
+		cand.triggerOpts, cand.triggerErr = orderTriggerOptionsForTarget(cityPath, m.cfg, target, a)
+		// Thread the dispatch tick's context into the condition check so a
+		// shutdown, reload, or canceled tick interrupts a slow check promptly
+		// instead of waiting out its (now operator-configurable) check_timeout.
+		cand.triggerOpts.ConditionCtx = ctx
+		candidates = append(candidates, cand)
+	}
+
+	m.prefetchConditionResults(candidates, now)
+
+	// Phase 2: the fire loop, in the same rotation order, over the same
+	// per-order state phase 1 resolved.
+	for _, cand := range candidates {
+		idx := cand.idx
+		a := cand.order
+		target := cand.target
+		store := cand.store
+		storesForGate, storeKeysForGate := cand.gateStores, cand.gateStoreKeys
+		scoped := cand.scoped
+
 		baseLastRunFn := trackingIndex.lastRunFunc(storesForGate, storeKeysForGate, orders.LastRunAcross(orderFrontDoorsForStores(storesForGate)))
 		var lastRunErr error
 		var lastRunFromCache bool
@@ -607,8 +760,8 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 				return cursor
 			}
 		}
-		triggerOpts, err := orderTriggerOptionsForTarget(cityPath, m.cfg, target, a)
-		if err != nil {
+		triggerOpts := cand.triggerOpts
+		if err := cand.triggerErr; err != nil {
 			redacted := redactOrderEnvError(err, os.Environ())
 			msg := fmt.Sprintf("building trigger env: %s", redacted)
 			logDispatchError(m.stderr, "gc: order dispatch: building trigger env for %s: %s", a.ScopedName(), redacted)
@@ -631,11 +784,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			}
 			continue
 		}
-		// Thread the dispatch tick's context into the condition check so a
-		// shutdown, reload, or canceled tick interrupts a slow check promptly
-		// instead of waiting out its (now operator-configurable) check_timeout.
-		triggerOpts.ConditionCtx = ctx
-		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
+		// A condition order's verdict was already computed by the parallel pass;
+		// re-running it here would fork the check a second time.
+		var result orders.TriggerResult
+		if cand.conditionResult != nil {
+			result = *cand.conditionResult
+		} else {
+			result = orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
+		}
 		if lastRunErr != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
 			continue
@@ -675,7 +831,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// skip this gate too (see the first-gate skip above).
 		if !a.NoWorkGate {
 			hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
-				return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
+				return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.wispRootHasOpenWork, m.hasOpenWorkStrict)
 			})
 			if err != nil {
 				if m.gateFailClosed(ctx, a, scoped, err) {
@@ -838,10 +994,11 @@ func (m *memoryOrderDispatcher) drain(ctx context.Context) bool {
 	}
 }
 
-func newOrderDispatchTrackingIndex() *orderDispatchTrackingIndex {
+func newOrderDispatchTrackingIndex(stderr io.Writer) *orderDispatchTrackingIndex {
 	return &orderDispatchTrackingIndex{
 		entries: make(map[string]map[string]orderTrackingSummary),
 		errs:    make(map[string]error),
+		stderr:  stderr,
 	}
 }
 
@@ -868,44 +1025,78 @@ func (idx *orderDispatchTrackingIndex) hasOpenTracking(
 	return false, nil
 }
 
+// hasOpenWork is the strict single-flight gate, served from the per-tick index.
+//
+// # What changed and why
+//
+// It used to end in `fallback(stores, scopedName)` — orders.Store.HasOpenWork,
+// one live `Label: order-run:<scoped>` list per gate store — and the dispatch
+// call site passed requireStrictFallback=true, so that fallback ran for EVERY
+// due order on EVERY gate store, every tick. On maintainer-city, where a gate
+// store was the remote work ledger at ~5.4s a query, that per-order multiplier
+// was most of the 86s dispatch_orders leg (ga-l7jdg).
+//
+// The evidence it looked for is the same evidence the index now reads once per
+// store: order-run-labeled beads, split into tracking records and wisp roots.
+// So the gate's ANSWER is unchanged and its COST is a property of the store
+// topology instead of the order count.
+//
+// The live fallback survives for exactly one case: a store whose index read
+// FAILED. There the index knows nothing, and answering "no open work" from a
+// hole is the duplicate-dispatch shape single-flight exists to prevent — so that
+// store, alone, pays the old per-order read and its error still propagates.
 func (idx *orderDispatchTrackingIndex) hasOpenWork(
 	stores []beads.Store,
 	storeKeys []string,
 	scopedName string,
-	fallback func([]beads.Store, string) (bool, error),
-	requireStrictFallback bool,
+	wispHasOpenWork func(beads.Store, beads.Bead) (bool, error),
+	fallback func(beads.Store, string) (bool, error),
 ) (bool, error) {
-	if idx == nil {
-		return fallback(stores, scopedName)
-	}
-	sawTrackingHistory := false
 	for i, store := range stores {
-		key := indexStoreKey(storeKeys, i)
 		if store == nil {
 			continue
 		}
-		entries, err := idx.entriesForStore(store, key)
-		if err != nil {
-			return false, err
-		}
-		if entries[scopedName].openTracking {
-			return true, nil
-		}
-		history, err := idx.historyEntriesForStore(store, key)
-		if err != nil {
-			return false, err
-		}
-		if summary, ok := history[scopedName]; ok {
-			if summary.openTracking {
+		if idx == nil {
+			open, err := fallback(store, scopedName)
+			if err != nil {
+				return false, err
+			}
+			if open {
 				return true, nil
 			}
-			sawTrackingHistory = true
+			continue
+		}
+		entries, err := idx.entriesForStore(store, indexStoreKey(storeKeys, i))
+		if err != nil {
+			// This store's index is a hole. Ask it directly rather than reading
+			// the hole as an absence of work.
+			open, ferr := fallback(store, scopedName)
+			if ferr != nil {
+				return false, ferr
+			}
+			if open {
+				return true, nil
+			}
+			continue
+		}
+		summary := entries[scopedName]
+		if summary.openWorkTracking {
+			return true, nil
+		}
+		if wispHasOpenWork == nil {
+			continue
+		}
+		for _, root := range summary.openRoots {
+			open, err := wispHasOpenWork(store, root)
+			if err != nil {
+				return false, err
+			}
+			if open {
+				return true, nil
+			}
 		}
 	}
-	if sawTrackingHistory && !requireStrictFallback {
-		return false, nil
-	}
-	return fallback(stores, scopedName)
+	return false, nil
 }
 
 func (idx *orderDispatchTrackingIndex) lastRunFunc(
@@ -1002,21 +1193,65 @@ func (idx *orderDispatchTrackingIndex) entriesForStore(store beads.Store, storeK
 		return entries, nil
 	}
 	idx.mu.Unlock()
-	runs, err := orders.NewStore(beads.OrdersStore{Store: store}).OpenRuns()
+	// ONE read per store per tick, for every order at once.
+	//
+	// The label-per-order queries this replaces could not be batched — a
+	// ListQuery matches one Label, and there are as many order-run labels as
+	// there are orders — so the index reads the store's whole NON-CLOSED corpus
+	// and folds it by label. IncludeClosed stays false and no Status is set,
+	// which is exactly orders.Store.HasOpenWork's own question ("not closed"),
+	// so a wisp root that has gone in_progress is still seen as work in flight.
+	//
+	// The cost trade is deliberate and is stated in round trips, the unit the
+	// tick's latency is actually made of: one scan beats N label queries the
+	// moment there is more than one order, and on the runtime plane the store
+	// being scanned is the local infra binding (gateStoresFor takes the work
+	// ledger off this list), where a scan is milliseconds.
+	// Unsorted: the fold is a set membership question per order, so paying the
+	// backend to order a whole open corpus would buy nothing. The tier is
+	// TierBoth, which is what orders.Store.HasOpenWork has always asked — and
+	// wider than OpenRuns' zero-value TierIssues, so a wisp-tier tracking bead
+	// that used to be invisible to the first gate now suppresses it. Wider is the
+	// safe direction for single-flight: it can only ever suppress a dispatch that
+	// already had work in flight.
+	items, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		AllowScan: true,
+		TierMode:  beads.TierBoth,
+	})
 	if err != nil {
-		wrapped := fmt.Errorf("listing order-tracking beads: %w", err)
+		wrapped := fmt.Errorf("listing order-run beads: %w", err)
 		idx.mu.Lock()
+		_, seen := idx.errs[storeKey]
 		idx.errs[storeKey] = wrapped
 		idx.mu.Unlock()
+		if !seen {
+			logDispatchError(idx.stderr, "gc: order dispatch: order-run index for store %s unavailable, falling back to one live gate read per order: %v", storeKey, wrapped)
+		}
 		return nil, wrapped
 	}
 	entries := make(map[string]orderTrackingSummary)
-	for _, run := range runs {
-		summary := entries[run.Scoped]
-		// OpenRuns filters Status=="open" in the query, so every returned run
-		// is open tracking work.
-		summary.openTracking = true
-		entries[run.Scoped] = summary
+	for _, b := range items {
+		if b.Status == "closed" {
+			continue
+		}
+		tracking := orders.IsTrackingBead(b)
+		for _, label := range b.Labels {
+			scoped, ok := orders.ScopedFromRunLabel(label)
+			if !ok {
+				continue
+			}
+			summary := entries[scoped]
+			switch {
+			case tracking:
+				summary.openWorkTracking = true
+				if b.Status == "open" {
+					summary.openTracking = true
+				}
+			default:
+				summary.openRoots = append(summary.openRoots, b)
+			}
+			entries[scoped] = summary
+		}
 	}
 	// A sibling gate goroutine may have populated this key while we listed;
 	// both computed the same result from the same store, so last writer wins.
@@ -1626,22 +1861,52 @@ func (m *memoryOrderDispatcher) ordersStoreKey() string {
 // gates on exactly the list it always did, and the whole-split shape this build
 // serves — where one binding serves both classes — reads that binding once
 // rather than twice per order per tick.
+//
+// # The runtime plane: the work legs come OFF a split city's gate
+//
+// Every read this list feeds — the open-work gate, the cooldown clock, the event
+// cursor — is a read of ORDER-RUN EVIDENCE, and a dispatch writes that evidence
+// through ordersStoreFor/graphStoreFor. On a split city both land in the
+// binding, so the target scope and the legacy city store are legs that cannot
+// hold the answer and are read anyway, once per order, per tick. On
+// maintainer-city that leg is remote postgres at ~5.4s and it was most of the
+// 86s dispatch_orders leg (ga-l7jdg; bd memory
+// gascity-runtime-infra-store-invariant: a work-ledger read on the runtime plane
+// is a misrouting bug by definition, not a cost to tune).
+//
+// So where a binding exists, this returns the binding legs ALONE. Where none
+// does — every single-store city — the work store IS the infra store and the
+// list is byte-identical to what it always was: the rule degrades to "the only
+// store there is", never to "no store at all".
+//
+// What that gives up, and what still converges: a tracking bead left in the work
+// ledger by a PRE-SPLIT dispatch is invisible to the gate. Nothing writes one
+// there any more (ordersStoreFor routes the class), and the wide reader is
+// untouched — runOrderTrackingSweepWatchdog still sweeps the city store and every
+// rig, so the residue is closed on its own cadence rather than gating forever.
+// The convergence lane does not narrow; only the latency lane does.
 func (m *memoryOrderDispatcher) gateStoresFor(cityPath string, store beads.Store, storeKey string, legacyStore beads.Store) ([]beads.Store, []string) {
-	storesForGate := []beads.Store{store}
-	storeKeysForGate := []string{storeKey}
+	workStores := []beads.Store{store}
+	workKeys := []string{storeKey}
 	if legacyStore != nil {
-		storesForGate = append(storesForGate, legacyStore)
-		storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
+		workStores = append(workStores, legacyStore)
+		workKeys = append(workKeys, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
 	}
-	if graphStore := m.graphStoreFor(store); graphStore != nil && !storeListContains(storesForGate, graphStore) {
-		storesForGate = append(storesForGate, graphStore)
-		storeKeysForGate = append(storeKeysForGate, m.graphStoreKey())
+	var infraStores []beads.Store
+	var infraKeys []string
+	if graphStore := m.graphStoreFor(store); graphStore != nil && !storeListContains(workStores, graphStore) {
+		infraStores = append(infraStores, graphStore)
+		infraKeys = append(infraKeys, m.graphStoreKey())
 	}
-	if ordersStore := m.ordersStoreFor(store); ordersStore != nil && !storeListContains(storesForGate, ordersStore) {
-		storesForGate = append(storesForGate, ordersStore)
-		storeKeysForGate = append(storeKeysForGate, m.ordersStoreKey())
+	if ordersStore := m.ordersStoreFor(store); ordersStore != nil &&
+		!storeListContains(workStores, ordersStore) && !storeListContains(infraStores, ordersStore) {
+		infraStores = append(infraStores, ordersStore)
+		infraKeys = append(infraKeys, m.ordersStoreKey())
 	}
-	return storesForGate, storeKeysForGate
+	if len(infraStores) > 0 {
+		return infraStores, infraKeys
+	}
+	return workStores, workKeys
 }
 
 // storeListContains reports whether stores already holds this exact store, so a
@@ -2189,22 +2454,6 @@ func isOrderWispDescendantDepType(depType string) bool {
 	default:
 		return false
 	}
-}
-
-func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, scopedName string) (bool, error) {
-	for _, store := range stores {
-		if store == nil {
-			continue
-		}
-		hasOpen, err := m.hasOpenWorkStrict(store, scopedName)
-		if err != nil {
-			return false, err
-		}
-		if hasOpen {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // orderGateTimeout bounds a single order's open-work gate. The strict gate

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -26,18 +26,45 @@ func countAndDelayGateQuery(mu *sync.Mutex, counter *int, delay time.Duration) {
 	time.Sleep(delay)
 }
 
-// gateTimeoutStore makes the strict open-work gate scan (the
-// `order-run:`-labeled, !IncludeClosed, Limit==0 List that hasOpenWorkStrict
-// issues) block past the per-order gate timeout, reproducing the #2893 hang
-// where storeHasOpenDescendants exceeds its budget under Dolt contention. Only
-// that exact query shape is delayed; every other read stays fast.
+// isOrderGateIndexQuery reports whether q is the per-tick gate INDEX read: one
+// unlabeled non-closed scan per gate store, folded by order-run label, that
+// replaced the per-order label lists (ga-l7jdg).
+//
+// Every #2893 fixture in this file recognizes it as a gate query alongside the
+// two label shapes it replaced. Recognizing only the old spellings would leave
+// the fixtures delaying a query the dispatcher no longer issues — the store
+// would answer instantly, the gate would never time out, and four fail-closed
+// regression tests would pass while testing nothing.
+func isOrderGateIndexQuery(q beads.ListQuery) bool {
+	return q.AllowScan && q.Label == "" && q.Status == "" && q.Assignee == "" &&
+		len(q.IDs) == 0 && len(q.Metadata) == 0 && !q.IncludeClosed && q.Limit == 0
+}
+
+// isOrderGateListQuery reports whether q is a read either open-work gate makes:
+// the per-tick index scan, the strict `order-run:`-labeled fallback, or the
+// open-tracking list.
+func isOrderGateListQuery(q beads.ListQuery) bool {
+	if isOrderGateIndexQuery(q) {
+		return true
+	}
+	if q.IncludeClosed || q.Limit != 0 {
+		return false
+	}
+	return strings.HasPrefix(q.Label, "order-run:") ||
+		(q.Label == labelOrderTracking && q.Status == "open")
+}
+
+// gateTimeoutStore makes the open-work gate's store read block past the
+// per-order gate timeout, reproducing the #2893 hang where
+// storeHasOpenDescendants exceeds its budget under Dolt contention. Only a gate
+// query shape is delayed; every other read stays fast.
 type gateTimeoutStore struct {
 	beads.Store
 	delay time.Duration
 }
 
 func (s *gateTimeoutStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+	if isOrderGateListQuery(query) {
 		time.Sleep(s.delay)
 	}
 	return s.Store.List(query)
@@ -110,7 +137,7 @@ type openWorkGateCallCountStore struct {
 }
 
 func (s *openWorkGateCallCountStore) List(q beads.ListQuery) ([]beads.Bead, error) {
-	if strings.HasPrefix(q.Label, "order-run:") && !q.IncludeClosed && q.Limit == 0 {
+	if isOrderGateListQuery(q) {
 		countAndDelayGateQuery(&s.mu, &s.gateCalls, s.delay)
 	}
 	return s.Store.List(q)
@@ -231,7 +258,7 @@ type trackingGateTimeoutStore struct {
 }
 
 func (s *trackingGateTimeoutStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if query.Label == labelOrderTracking && query.Status == "open" && !query.IncludeClosed && query.Limit == 0 {
+	if isOrderGateIndexQuery(query) || (query.Label == labelOrderTracking && query.Status == "open" && !query.IncludeClosed && query.Limit == 0) {
 		s.gateCount.Add(1)
 		time.Sleep(s.delay)
 	}
@@ -369,16 +396,7 @@ func (s *bothGatesCallCountStore) List(q beads.ListQuery) ([]beads.Bead, error) 
 }
 
 func (s *bothGatesCallCountStore) isGateQuery(q beads.ListQuery) bool {
-	if q.IncludeClosed || q.Limit != 0 {
-		return false
-	}
-	if q.Label == labelOrderTracking && q.Status == "open" {
-		return true
-	}
-	if strings.HasPrefix(q.Label, "order-run:") {
-		return true
-	}
-	return false
+	return isOrderGateListQuery(q)
 }
 
 func (s *bothGatesCallCountStore) gateCalls() int {

--- a/cmd/gc/order_dispatch_graph_store_test.go
+++ b/cmd/gc/order_dispatch_graph_store_test.go
@@ -192,9 +192,13 @@ func TestOrderDispatchSingleFlightGateSeesGraphResidentWisp(t *testing.T) {
 	m.lastRunCache = nil
 	m.cacheMu.Unlock()
 
-	hasOpen, err := m.hasOpenWorkInStoresStrict([]beads.Store{workStore, graphStore}, "reaper")
-	if err != nil {
-		t.Fatalf("open-work gate: %v", err)
+	hasOpen := false
+	for _, store := range []beads.Store{workStore, graphStore} {
+		open, err := m.hasOpenWorkStrict(store, "reaper")
+		if err != nil {
+			t.Fatalf("open-work gate: %v", err)
+		}
+		hasOpen = hasOpen || open
 	}
 	if !hasOpen {
 		t.Fatalf("open-work gate did not see open wisp root %s in the graph store", firstRoot.ID)

--- a/cmd/gc/order_dispatch_orders_store_test.go
+++ b/cmd/gc/order_dispatch_orders_store_test.go
@@ -260,16 +260,19 @@ func TestWebhookOrderDispatchTrackingBeadLandsInTheOrdersBinding(t *testing.T) {
 	}
 }
 
-// TestOrderDispatchGateFederatesTheOrdersBindingExactlyOnce pins the read half
-// of the single-flight gate.
+// TestOrderDispatchGateReadsTheBindingAloneOnASplitCity pins the read half of
+// the single-flight gate.
 //
 // The gate, the cooldown clock and the event cursor all read order-run evidence,
-// and after this change the tracking bead carrying it is in the binding. The
-// federation must therefore include the binding — and must include it ONCE: on
-// the whole-split shape this build serves, the graph class and the orders class
-// are the same binding, and appending it twice would read one database twice on
-// every gate of every order on every tick.
-func TestOrderDispatchGateFederatesTheOrdersBindingExactlyOnce(t *testing.T) {
+// and a dispatch writes that evidence through ordersStoreFor/graphStoreFor — so
+// on a split city it is in the binding. The federation must therefore include
+// the binding, ONCE (the whole-split shape serves both classes from one
+// database, and appending it twice reads it twice per order per tick) — and must
+// include NOTHING ELSE: the order's target scope is a work ledger that cannot
+// hold the answer, and reading it per order per tick was most of the 86s
+// dispatch_orders leg on maintainer-city (ga-l7jdg; bd memory
+// gascity-runtime-infra-store-invariant).
+func TestOrderDispatchGateReadsTheBindingAloneOnASplitCity(t *testing.T) {
 	cityPath, cfg, a := newExecOrderFixture(t)
 	workStore := beads.NewMemStore()
 	binding := beads.NewMemStore()
@@ -286,8 +289,11 @@ func TestOrderDispatchGateFederatesTheOrdersBindingExactlyOnce(t *testing.T) {
 	if !storeListContains(storesForGate, beads.Store(binding)) {
 		t.Fatalf("gate store list = %+v, missing the binding the tracking bead lives in; the marker the dispatch just wrote is invisible and the order re-fires every tick", storesForGate)
 	}
-	if len(storesForGate) != 2 {
-		t.Fatalf("gate store list = %d stores, want 2 (the target scope and the one binding serving both classes); one database is being read twice for every order on every tick", len(storesForGate))
+	if len(storesForGate) != 1 {
+		t.Fatalf("gate store list = %+v, want exactly the one binding serving both classes; a work-ledger leg on the runtime plane is a misrouting bug and the whole-split binding must not be read twice", storesForGate)
+	}
+	if storeListContains(storesForGate, beads.Store(workStore)) {
+		t.Fatal("the work ledger is still a gate leg; it cannot hold order-run evidence on a split city and reading it costs one remote round trip per order per tick")
 	}
 	if len(storeKeysForGate) != len(storesForGate) {
 		t.Fatalf("gate store keys = %d for %d stores; the cooldown cache key and the store it memoizes have drifted apart", len(storeKeysForGate), len(storesForGate))

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -6474,6 +6474,26 @@ func (s labelFailListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	return s.Store.List(query)
 }
 
+// openWorkFailListStore is a store that cannot answer the OPEN-WORK question,
+// whichever read the gate uses to ask it.
+//
+// The gate used to ask with one `order-run:<scoped>` list per order and now asks
+// once per store, unlabeled, through the per-tick index (ga-l7jdg). A fixture
+// pinned to only one of those two spellings stops simulating the outage the
+// moment the other one is the live path, and the order under test quietly
+// dispatches instead of failing closed — which is what this store exists to
+// prevent.
+type openWorkFailListStore struct {
+	beads.Store
+}
+
+func (s openWorkFailListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.HasPrefix(query.Label, "order-run:") || isOrderGateIndexQuery(query) {
+		return nil, fmt.Errorf("list failed for open work")
+	}
+	return s.Store.List(query)
+}
+
 // --- helpers ---
 
 func successfulExec(context.Context, string, string, []string) ([]byte, error) {
@@ -7222,10 +7242,7 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 		t.Fatal(err)
 	}
 	rigStore := beads.NewMemStore()
-	legacyStore := labelFailListStore{
-		Store:     beads.NewMemStore(),
-		failLabel: "order-run:rig-digest:rig:frontend",
-	}
+	legacyStore := openWorkFailListStore{Store: beads.NewMemStore()}
 
 	stderr := &bytes.Buffer{}
 	m := &memoryOrderDispatcher{
@@ -7303,6 +7320,10 @@ func TestOrderDispatchConditionUsesScopedEnv(t *testing.T) {
 
 func TestOrderDispatchSkipsRigCooldownWhenLegacyOpenWorkReadFails(t *testing.T) {
 	rigStore := beads.NewMemStore()
+	// The LAST-RUN read is what fails here, so the fixture fails only the
+	// `order-run:` label query LastRunAcross issues. The gate's own index read
+	// succeeds — that is the point: this test pins the last-run path, and its
+	// sibling above pins the gate path.
 	legacyStore := labelFailListStore{
 		Store:     beads.NewMemStore(),
 		failLabel: "order-run:rig-digest:rig:frontend",
@@ -10177,7 +10198,7 @@ func TestSweepClosedOrderTrackingRetentionAcrossStoresBounded_ZeroLimitDeletesNo
 func TestLastRunFuncGatesFallbackOnIndexMiss(t *testing.T) {
 	store := beads.NewMemStore()
 	const storeKey = "city"
-	idx := newOrderDispatchTrackingIndex()
+	idx := newOrderDispatchTrackingIndex(io.Discard)
 	indexed := time.Now().Add(-time.Hour)
 	// Pre-seed the history index so lastRunForStore reads it without listing
 	// the store. The "\x00history" suffix matches historyEntriesForStore's key.

--- a/cmd/gc/order_dispatch_tracking_index_race_test.go
+++ b/cmd/gc/order_dispatch_tracking_index_race_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 // unrelated PRs (gascity#3256, gascity#3261).
 //
 // memoryOrderDispatcher.dispatch builds ONE shared orderDispatchTrackingIndex
-// (order_dispatch.go: trackingIndex := newOrderDispatchTrackingIndex()) and
+// (order_dispatch.go: trackingIndex := newOrderDispatchTrackingIndex(m.stderr)) and
 // consults it from every order's open-work gate. gateOpenWorkBounded runs each
 // gate in its own goroutine and, on a per-order timeout OR ctx cancellation,
 // returns WITHOUT waiting for that goroutine (by design, to avoid stalling
@@ -31,7 +32,7 @@ import (
 // map. Under `-race` the unsynchronized access is reported deterministically;
 // making orderDispatchTrackingIndex guard its maps with a mutex fixes it.
 func TestOrderDispatchTrackingIndexConcurrentGatesAreRaceFree(t *testing.T) {
-	idx := newOrderDispatchTrackingIndex()
+	idx := newOrderDispatchTrackingIndex(io.Discard)
 	stores := []beads.Store{beads.NewMemStore()}
 
 	const (

--- a/cmd/gc/order_gate_budget_test.go
+++ b/cmd/gc/order_gate_budget_test.go
@@ -1,0 +1,416 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// The order-dispatch leg's read budget.
+//
+// dispatch_orders was 86.0s of a 373s maintainer-city tick (ga-l7jdg), and the
+// shape was per-ORDER reads against a remote work ledger: the strict open-work
+// gate called its live fallback for every due order on every gate store — the
+// requireStrictFallback flag was hardcoded true — and the event cursor listed
+// once per event order per store. At ~5.4s per remote-postgres query that
+// multiplies straight into the tick.
+//
+// Two properties fix it, and both are counted here rather than timed:
+//
+//  1. gate reads scale with STORES, not with orders — one index read per gate
+//     store per tick, shared by every order's gate; and
+//  2. the runtime plane issues ZERO reads against the work ledger — the
+//     order-run evidence a dispatch writes is orders class and graph class, and
+//     on a split city both are the binding (bd memory
+//     gascity-runtime-infra-store-invariant).
+
+// orderGateBudgetCity builds a split city whose order-run evidence lives in the
+// binding, with n always-due orders each already holding an open wisp — the
+// steady shape where a due order is suppressed rather than fired, which is
+// exactly when the strict gate runs.
+func orderGateBudgetCity(t *testing.T, n int) (*memoryOrderDispatcher, *latencyStore, *latencyStore, []orders.Order, string) {
+	t.Helper()
+	cityPath, cfg, _ := newExecOrderFixture(t)
+	ledgerBacking := beads.NewMemStore()
+	bindingBacking := beads.NewMemStore()
+	bindingBacking.IDPrefix = "gcg"
+	bindingBacking.HonorExplicitIDs = true
+
+	aa := make([]orders.Order, 0, n)
+	closed := "closed"
+	for i := range n {
+		a := orders.Order{
+			Name:     fmt.Sprintf("budget-order-%d", i),
+			Exec:     "true",
+			Trigger:  "cooldown",
+			Interval: "1ms",
+		}
+		aa = append(aa, a)
+		// A CLOSED tracking bead, so the order is in the cooldown history index
+		// and the run clock is served without a per-order LastRun query. This is
+		// the steady shape: an order that has run before and is due again.
+		front := orders.NewStore(beads.OrdersStore{Store: bindingBacking})
+		run, err := front.CreateRun(a.ScopedName(), orders.RunOpts{})
+		if err != nil {
+			t.Fatalf("seed tracking bead %d: %v", i, err)
+		}
+		if err := bindingBacking.Update(run.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+			t.Fatalf("close tracking bead %d: %v", i, err)
+		}
+		// An open root-only wisp carrying the order's order-run label: the gate
+		// must see it and suppress the fire. Root-only means the verdict needs no
+		// descendant read, so the count below is the INDEX cost and nothing else.
+		if _, err := bindingBacking.Create(beads.Bead{
+			ID:       fmt.Sprintf("gcg-budget-wisp-%d", i),
+			Title:    "wisp",
+			Labels:   []string{orders.RunLabel(a.ScopedName())},
+			Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWisp},
+		}); err != nil {
+			t.Fatalf("seed wisp %d: %v", i, err)
+		}
+	}
+
+	ledger := &latencyStore{Store: ledgerBacking}
+	binding := &latencyStore{Store: bindingBacking}
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, aa, ledger, binding, &rec)
+	m.maxDispatchesPerTick = 0 // unbounded: every order must reach its gate
+	return m, ledger, binding, aa, cityPath
+}
+
+// TestOrderGateReadsScaleWithStoresNotOrders is the budget: the gate's cost is a
+// property of the city's store topology, never of how many orders it runs.
+func TestOrderGateReadsScaleWithStoresNotOrders(t *testing.T) {
+	counts := map[int]int{}
+	for _, n := range []int{1, 10} {
+		m, ledger, binding, _, cityPath := orderGateBudgetCity(t, n)
+		m.dispatch(context.Background(), cityPath, time.Now().Add(time.Hour))
+		drainOrderDispatch(t, m)
+		if ledger.roundTrips != 0 {
+			t.Fatalf("%d order(s): the gate issued %d work-ledger round trip(s), want 0", n, ledger.roundTrips)
+		}
+		counts[n] = binding.roundTrips
+	}
+	if counts[1] != counts[10] {
+		t.Fatalf("the gate cost %d round trip(s) for 1 order and %d for 10; it scales with orders, so at maintainer-city's ~5.4s ledger RTT every added order is another %v of tick",
+			counts[1], counts[10], 5400*time.Millisecond)
+	}
+	if counts[1] == 0 {
+		t.Fatal("the gate issued no reads at all; the budget above is measuring a gate that stopped running")
+	}
+	// Control: the strict live fallback — the shape the index replaces — DOES
+	// scale with orders over the identical corpus. Without this the invariance
+	// above would also pass for a gate that had simply been deleted.
+	m, _, binding, aa, _ := orderGateBudgetCity(t, 10)
+	before := binding.roundTrips
+	for _, a := range aa {
+		if _, err := m.hasOpenWorkStrict(binding, a.ScopedName()); err != nil {
+			t.Fatalf("strict fallback for %s: %v", a.ScopedName(), err)
+		}
+	}
+	if got := binding.roundTrips - before; got <= counts[10] {
+		t.Fatalf("the per-order strict fallback cost %d round trip(s) for 10 orders and the index cost %d; the budget is not measuring anything", got, counts[10])
+	}
+}
+
+// TestOrderGateIssuesZeroLedgerReadsOnASplitCity is the operator invariant on
+// this leg: a dispatch tick's gate, cooldown clock and event cursor read the
+// infra binding and never the work ledger.
+func TestOrderGateIssuesZeroLedgerReadsOnASplitCity(t *testing.T) {
+	m, ledger, binding, _, cityPath := orderGateBudgetCity(t, 4)
+	m.dispatch(context.Background(), cityPath, time.Now().Add(time.Hour))
+	drainOrderDispatch(t, m)
+	if ledger.roundTrips != 0 {
+		t.Fatalf("the dispatch tick issued %d work-ledger round trip(s), want 0 — that is %v of tick at maintainer-city's RTT",
+			ledger.roundTrips, time.Duration(ledger.roundTrips)*5400*time.Millisecond)
+	}
+	// Control: the binding answered instead, so the zero above is a routing fact
+	// and not a tick that declined to gate.
+	if binding.roundTrips == 0 {
+		t.Fatal("the binding was not read either; the gate did not run and the ledger zero proves nothing")
+	}
+}
+
+// TestOrderGateStillReadsTheLedgerOnASingleStoreCity is the degradation half: a
+// city that relocates no class has no binding, and there the work store IS the
+// infra store. Narrowing it away would disable the gate outright.
+func TestOrderGateStillReadsTheLedgerOnASingleStoreCity(t *testing.T) {
+	cityPath, cfg, a := newExecOrderFixture(t)
+	backing := beads.NewMemStore()
+	backing.HonorExplicitIDs = true
+	if _, err := backing.Create(beads.Bead{
+		ID:       "ga-budget-wisp",
+		Title:    "wisp",
+		Labels:   []string{orders.RunLabel(a.ScopedName())},
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWisp},
+	}); err != nil {
+		t.Fatalf("seed wisp: %v", err)
+	}
+	store := &latencyStore{Store: backing}
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &memoryOrderDispatcher{
+		aa:             []orders.Order{a},
+		storeFn:        func(execStoreTarget) (beads.Store, error) { return store, nil },
+		storageRoutes:  nil,
+		cfg:            cfg,
+		cityName:       "test-city",
+		cityPath:       cityPath,
+		stderr:         io.Discard,
+		rec:            &memRecorder{},
+		execRun:        func(context.Context, string, string, []string) ([]byte, error) { return nil, nil },
+		dispatchCtx:    dispatchCtx,
+		dispatchCancel: cancel,
+	}
+	m.dispatch(context.Background(), cityPath, time.Now().Add(time.Hour))
+	drainOrderDispatch(t, m)
+	if store.roundTrips == 0 {
+		t.Fatal("a single-store city's gate read nothing; the runtime plane must degrade to \"the only store there is\", never to \"no store at all\"")
+	}
+}
+
+func drainOrderDispatch(t *testing.T, m *memoryOrderDispatcher) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if !m.drain(ctx) {
+		t.Fatal("order dispatch did not drain")
+	}
+}
+
+// TestConditionChecksRunConcurrentlyWithinTheirCap is the parallel half of the
+// leg, and it proves real overlap rather than measuring wall clock.
+//
+// Every check registers itself in a shared directory and then waits, bounded, to
+// SEE a sibling registered. Overlap is therefore the pass condition: with a cap
+// that admits more than one, the checks see each other and every order fires;
+// with a cap of one, no check ever sees a sibling and nothing fires. Each check
+// exits normally either way and removes its own registration on the way out, so
+// the two arms differ only in whether the pass ran them at the same time.
+//
+// The same fixture is its own control, and neither outcome is reachable by a
+// pass that simply stopped running checks: that one fires nothing AND leaves the
+// registration directory empty, which the first arm asserts against.
+func TestConditionChecksRunConcurrentlyWithinTheirCap(t *testing.T) {
+	const wave = 4
+	for _, tc := range []struct {
+		name    string
+		cap     int
+		wantRun int
+	}{
+		{name: "cap-admits-the-wave", cap: wave, wantRun: wave},
+		{name: "serial-cap-never-overlaps", cap: 1, wantRun: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := orderConditionCheckConcurrency
+			orderConditionCheckConcurrency = tc.cap
+			t.Cleanup(func() { orderConditionCheckConcurrency = prev })
+
+			cityPath, cfg, _ := newExecOrderFixture(t)
+			liveDir := filepath.Join(t.TempDir(), "live")
+			ranMarker := filepath.Join(t.TempDir(), "ran")
+			// Register, then wait up to ~1s to see a sibling registration. Exit
+			// 0 only on overlap; always exit normally so the trap unregisters.
+			check := fmt.Sprintf(
+				`mkdir -p %[1]s; echo . >> %[3]s; f=$(mktemp %[1]s/w.XXXXXX); trap 'rm -f "$f"' EXIT; `+
+					`i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge 2 ]; then exit 0; fi; sleep 0.02; i=$((i+1)); done; exit 1`,
+				liveDir, wave, ranMarker)
+
+			aa := make([]orders.Order, 0, wave)
+			for i := range wave {
+				aa = append(aa, orders.Order{
+					Name:         fmt.Sprintf("barrier-order-%d", i),
+					Exec:         "true",
+					Trigger:      "condition",
+					Check:        check,
+					CheckTimeout: "10s",
+				})
+			}
+			store := beads.NewMemStore()
+			var rec memRecorder
+			m := newSplitOrderDispatcher(t, cityPath, cfg, aa, store, beads.NewMemStore(), &rec)
+			m.maxDispatchesPerTick = 0
+			m.execRun = func(context.Context, string, string, []string) ([]byte, error) { return nil, nil }
+
+			m.dispatch(context.Background(), cityPath, time.Now())
+			drainOrderDispatch(t, m)
+
+			if got := len(trackingBeads(t, m.ordersStoreFor(store), labelOrderTracking)); got != tc.wantRun {
+				t.Fatalf("%d order(s) fired, want %d: with cap %d the %d checks %s",
+					got, tc.wantRun, tc.cap, wave,
+					map[bool]string{true: "overlap and see each other", false: "run one at a time and never do"}[tc.cap >= 2])
+			}
+			// Control: every check DID run, so a zero above is "no overlap" and
+			// not "no checks".
+			data, err := os.ReadFile(ranMarker)
+			if err != nil {
+				t.Fatalf("no check ran at all: %v", err)
+			}
+			if got := strings.Count(string(data), "."); got != wave {
+				t.Fatalf("%d of %d checks ran; the fire count above is not measuring overlap", got, wave)
+			}
+		})
+	}
+}
+
+// TestConditionCheckRunsExactlyOncePerOrderPerTick guards the seam between the
+// parallel pass and the fire loop: the loop must CONSUME the prefetched verdict,
+// not recompute it. A second evaluation would fork every check twice per tick —
+// a check storm wearing a latency fix's name — and would also make a check with
+// an observable side effect run twice.
+func TestConditionCheckRunsExactlyOncePerOrderPerTick(t *testing.T) {
+	cityPath, cfg, _ := newExecOrderFixture(t)
+	countDir := t.TempDir()
+	aa := make([]orders.Order, 0, 3)
+	for i := range 3 {
+		aa = append(aa, orders.Order{
+			Name:    fmt.Sprintf("counted-order-%d", i),
+			Exec:    "true",
+			Trigger: "condition",
+			Check:   fmt.Sprintf("echo . >> %s", filepath.Join(countDir, fmt.Sprintf("checks-%d", i))),
+		})
+	}
+	store := beads.NewMemStore()
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, aa, store, beads.NewMemStore(), &rec)
+	m.maxDispatchesPerTick = 0
+	m.execRun = func(context.Context, string, string, []string) ([]byte, error) { return nil, nil }
+
+	m.dispatch(context.Background(), cityPath, time.Now())
+	drainOrderDispatch(t, m)
+
+	for i := range 3 {
+		data, err := os.ReadFile(filepath.Join(countDir, fmt.Sprintf("checks-%d", i)))
+		if err != nil {
+			t.Fatalf("order %d: check never ran: %v", i, err)
+		}
+		if got := strings.Count(string(data), "."); got != 1 {
+			t.Fatalf("order %d's condition check ran %d time(s) in one tick, want 1", i, got)
+		}
+	}
+}
+
+// TestGateIndexSuppressesDispatchExactlyAsTheLiveGateDid ports the #2893/#2921
+// single-flight fixtures onto the index path: the gate's ANSWER must be
+// unchanged, whichever read produced it.
+//
+// Both shapes the strict gate recognizes are covered — an open TRACKING bead and
+// an open WISP subtree — and the control is the same city with the evidence
+// closed, which must fire.
+func TestGateIndexSuppressesDispatchExactlyAsTheLiveGateDid(t *testing.T) {
+	closed := "closed"
+	for _, tc := range []struct {
+		name string
+		seed func(t *testing.T, store *beads.MemStore, scoped string)
+		want int
+	}{
+		{
+			name: "open tracking bead",
+			seed: func(t *testing.T, store *beads.MemStore, scoped string) {
+				if _, err := orders.NewStore(beads.OrdersStore{Store: store}).CreateRun(scoped, orders.RunOpts{}); err != nil {
+					t.Fatalf("seed tracking bead: %v", err)
+				}
+			},
+			want: 0,
+		},
+		{
+			name: "open wisp subtree",
+			seed: func(t *testing.T, store *beads.MemStore, scoped string) {
+				root, err := store.Create(beads.Bead{
+					Title:    "wisp root",
+					Type:     "molecule",
+					Labels:   []string{orders.RunLabel(scoped)},
+					Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+				})
+				if err != nil {
+					t.Fatalf("seed wisp root: %v", err)
+				}
+				if _, err := store.Create(beads.Bead{
+					Title:    "open step",
+					Type:     "task",
+					ParentID: root.ID,
+					Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+				}); err != nil {
+					t.Fatalf("seed wisp step: %v", err)
+				}
+			},
+			want: 0,
+		},
+		{
+			name: "control: evidence closed, the order fires",
+			seed: func(t *testing.T, store *beads.MemStore, scoped string) {
+				run, err := orders.NewStore(beads.OrdersStore{Store: store}).CreateRun(scoped, orders.RunOpts{})
+				if err != nil {
+					t.Fatalf("seed tracking bead: %v", err)
+				}
+				if err := store.Update(run.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+					t.Fatalf("close tracking bead: %v", err)
+				}
+			},
+			want: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath, cfg, a := newExecOrderFixture(t)
+			a.Interval = "1ms"
+			binding := beads.NewMemStore()
+			binding.IDPrefix = "gcg"
+			tc.seed(t, binding, a.ScopedName())
+			before := len(trackingBeads(t, binding, labelOrderTracking))
+
+			var rec memRecorder
+			m := newSplitOrderDispatcher(t, cityPath, cfg, []orders.Order{a}, beads.NewMemStore(), binding, &rec)
+			m.execRun = func(context.Context, string, string, []string) ([]byte, error) { return nil, nil }
+			m.dispatch(context.Background(), cityPath, time.Now().Add(time.Hour))
+			drainOrderDispatch(t, m)
+
+			if got := len(trackingBeads(t, binding, labelOrderTracking)) - before; got != tc.want {
+				t.Fatalf("the index-served gate let %d new dispatch(es) through, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOrderTrackingSweepStillReadsEveryLegTheGateNoLongerDoes is the
+// convergence half of the plane doctrine on this leg.
+//
+// The gate narrowed to the infra binding because that is where a dispatch writes
+// its order-run evidence. That leaves one thing behind: a tracking bead a
+// PRE-SPLIT dispatch left in the work ledger, which the gate can no longer see.
+// It must not therefore be immortal — the wide reader is the order-tracking
+// sweep, and it is deliberately NOT narrowed. Runtime narrows for latency;
+// reconcile never narrows, because a store it skips is a store nothing
+// converges.
+func TestOrderTrackingSweepStillReadsEveryLegTheGateNoLongerDoes(t *testing.T) {
+	cityPath, cfg, _ := newExecOrderFixture(t)
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	binding.IDPrefix = "gcg"
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, nil, work, binding, &rec)
+
+	gateStores, _ := m.gateStoresFor(cityPath, work, "city\x00"+cityPath, nil)
+	if storeListContains(gateStores, beads.Store(work)) {
+		t.Fatal("the gate still reads the work ledger; this control is testing the wrong build")
+	}
+
+	sweepStores, err := orderTrackingSweepStoresFromTargets(
+		orderTrackingSweepTargetsForConfig(cityPath, cfg),
+		func(orderTrackingSweepTarget) (beads.Store, error) { return work, nil },
+	)
+	if err != nil {
+		t.Fatalf("orderTrackingSweepStoresFromTargets: %v", err)
+	}
+	if !sweepStoreListContains(sweepStores, beads.Store(work)) {
+		t.Fatalf("the order-tracking sweep no longer reads the work ledger either (%d leg(s)); a pre-split tracking bead there would gate nothing and be closed by nothing", len(sweepStores))
+	}
+}

--- a/cmd/gc/residency_leg_agreement_test.go
+++ b/cmd/gc/residency_leg_agreement_test.go
@@ -260,3 +260,113 @@ func TestDroppingALegBreaksAgreementAndNotTheRowCorpus(t *testing.T) {
 		}
 	}
 }
+
+// runtimeDemandLegs is the leg set the TICK's routed-demand read uses: the same
+// Plan(RoutedWork) as the claim reader, narrowed to the runtime plane.
+func (e legAgreementEnv) runtimeDemandLegs(t *testing.T) []beads.Store {
+	t.Helper()
+	candidates, err := routedWorkStoreCandidates(e.cityPath, e.cfg, e.leading(), e.rigs, nil, censusRefScoped)
+	if err != nil {
+		t.Fatalf("routedWorkStoreCandidates: %v", err)
+	}
+	out := make([]beads.Store, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.store)
+	}
+	return out
+}
+
+// TestRuntimeDemandNarrowsTheClaimPlanWithoutReorderingIt is the cross-consumer
+// half of reader agreement under the relevance descriptor.
+//
+// The tick's routed-demand read and the demand CACHE CHECK both narrow to the
+// runtime plane; `gc ready` — a separate process, and the surface a worker
+// claims through — does not. That is a deliberate asymmetry (retiring the CLI's
+// ledger leg is ga-4qdfn's slice, not this one), and it is only safe while the
+// narrowed set is a SUBSEQUENCE of the claim reader's: same plan, same order,
+// legs dropped and never added or moved.
+//
+// A reorder would be the D6-in-reverse failure the descriptor exists to prevent
+// — Plan(RoutedWork) puts the binding LAST so a co-resident id is attributed to
+// the work store on both sides (#5148) — and an ADDED leg would mean demand
+// counting work no claim can reach.
+func TestRuntimeDemandNarrowsTheClaimPlanWithoutReorderingIt(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		split bool
+		rigs  []string
+	}{
+		{name: "T0-single-store", split: false},
+		{name: "T0-single-store-with-rigs", split: false, rigs: []string{"alpha", "bravo"}},
+		{name: "T1-whole-split", split: true},
+		{name: "T2-whole-split-with-rigs", split: true, rigs: []string{"alpha", "bravo"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newLegAgreementEnv(t, tc.split, tc.rigs...)
+			claim := e.claimLegs(t)
+			runtime := e.runtimeDemandLegs(t)
+
+			// Subsequence: every runtime leg appears in the claim reader's list,
+			// in the same relative order.
+			i := 0
+			for _, leg := range claim {
+				if i < len(runtime) && runtime[i] == leg {
+					i++
+				}
+			}
+			if i != len(runtime) {
+				t.Fatalf("the runtime-plane demand legs are not a subsequence of the claim reader's: demand=%d claim=%d matched=%d — the descriptor reordered or invented a leg", len(runtime), len(claim), i)
+			}
+			if len(runtime) == 0 {
+				t.Fatal("the runtime plane resolved no leg at all; it must degrade to \"the only store there is\", never to \"no store\"")
+			}
+			switch {
+			case tc.split:
+				// Non-vacuity: on a split city the narrowing really drops legs,
+				// and the one it must keep is the binding.
+				if len(runtime) >= len(claim) {
+					t.Fatalf("the runtime plane kept %d of %d claim legs on a split city; it narrowed nothing", len(runtime), len(claim))
+				}
+				if runtime[0] != e.binding {
+					t.Fatal("the runtime plane's leg is not the binding; routed work lives only in the graph store (operator ruling)")
+				}
+			default:
+				if !sameStoreSequence(runtime, claim) {
+					t.Fatal("a city that relocates nothing narrowed its demand legs; there is no ledger to refuse when the work store IS the infra store")
+				}
+			}
+		})
+	}
+}
+
+// TestAssignedWorkCensusKeepsTheLedgerLegUnderTheDescriptor is the ga-w8ucu
+// guard, stated against the narrowing.
+//
+// The tick narrows the ROUTED-demand read to the binding because routed work
+// cannot be anywhere else. It must not narrow the ASSIGNED-work census, which
+// answers a different question — WHO HOLDS WHAT — and whose answer decides
+// whether a session is drained. A session whose only claim is an HQ work bead
+// has to stay visible there, or the drain gate reaps a live holder: symmetric
+// blindness is worse than a slow read.
+func TestAssignedWorkCensusKeepsTheLedgerLegUnderTheDescriptor(t *testing.T) {
+	e := newLegAgreementEnv(t, true, "alpha")
+	census, err := censusStoreCandidates(e.cityPath, e.cfg, e.leading(), e.rigs, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	var sawWork bool
+	for _, c := range census {
+		if c.store == e.work {
+			sawWork = true
+		}
+	}
+	if !sawWork {
+		t.Fatal("the assigned-work census lost its work-ledger leg; a session holding only an HQ claim now looks idle and the drain gate reaps it (ga-w8ucu)")
+	}
+	// Control: the routed-demand read over the SAME city really is narrower, so
+	// the assertion above is about the census and not about a descriptor that
+	// narrows nothing.
+	if runtime := e.runtimeDemandLegs(t); len(runtime) >= len(census) {
+		t.Fatalf("routed demand reads %d legs and the census %d; the two planes are not distinguishable here", len(runtime), len(census))
+	}
+}

--- a/cmd/gc/route_recovery.go
+++ b/cmd/gc/route_recovery.go
@@ -156,8 +156,8 @@ func (cr *CityRuntime) runRouteRecoveryBackstop(reason string) routeRecoveryRepo
 	// The convergence lane always says it ran. A clean pass that logs nothing is
 	// indistinguishable from a lane that stopped running, and this one runs on a
 	// background goroutine where nothing else would notice.
-	summary := fmt.Sprintf("pass reason=%s legs=%d reads=%d candidates=%d restored=%d quarantined=%d partial=%t took=%s",
-		reason, report.legs, report.legReads, report.candidates, report.restored, report.quarantined, report.partial,
+	summary := fmt.Sprintf("pass reason=%s legs=%d reads=%d candidates=%d restored=%d quarantined=%d off_plane_routed=%d partial=%t took=%s",
+		reason, report.legs, report.legReads, report.candidates, report.restored, report.quarantined, report.offPlaneRouted, report.partial,
 		report.duration.Round(time.Millisecond))
 	fmt.Fprintf(cr.stderr, "%s: route recovery (backstop): %s\n", cr.logPrefix, summary) //nolint:errcheck // best-effort stderr
 	return report
@@ -267,6 +267,11 @@ func (cr *CityRuntime) logRouteRecovery(report routeRecoveryReport) {
 		flap := fmt.Sprintf("STOPPED re-stamping %d flapping bead(s) after %d restores each (%s); another lane is clearing gc.routed_to — see `gc doctor` route-recovery-quarantine",
 			len(report.flapping), routeRecoveryFlapLimit, strings.Join(report.flapping, " "))
 		fmt.Fprintf(cr.stderr, "%s: route recovery (%s): %s\n", cr.logPrefix, report.lane, flap) //nolint:errcheck // best-effort stderr
+	}
+	if report.offPlaneRouted > 0 {
+		// Loud, because the tick's demand read cannot see these and therefore
+		// spawns nothing for them. The remedy is a migration, not a wider tick.
+		fmt.Fprintf(cr.stderr, "%s: route recovery (%s): %d open routed bead(s) sit on a work leg the runtime plane does not read, so no pool seat is spawned for them; run `gc storage migrate` to move them to the infra binding\n", cr.logPrefix, report.lane, report.offPlaneRouted) //nolint:errcheck // best-effort stderr
 	}
 	if report.quarantined > 0 {
 		fmt.Fprintf(cr.stderr, "%s: route recovery (%s): quarantined %d bead(s) for operator review (`gc doctor` route-recovery-quarantine)\n", cr.logPrefix, report.lane, report.quarantined) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/route_recovery_lane.go
+++ b/cmd/gc/route_recovery_lane.go
@@ -164,6 +164,20 @@ type routeRecoveryReport struct {
 	// legs counts the plan legs this pass was allowed to read. A pass reporting
 	// zero legs converged nothing, which must not read as "nothing to converge".
 	legs int
+	// offPlaneRouted counts OPEN, UNASSIGNED, pool-routed beads this pass found
+	// on a leg the RUNTIME plane refuses — the work ledger and the rigs.
+	//
+	// It is the visibility half of the tick's routed-demand narrowing. The
+	// controller's demand read is binding-only (routedWorkStoreCandidates, per
+	// the operator ruling that routed work lives only in the graph store), so a
+	// routed bead sitting on a work leg is demanded by nothing and spawns no
+	// seat. That is a MIGRATION defect rather than a demand bug — the remedy is
+	// `gc storage migrate`, not a wider tick — but a defect nobody can see is
+	// indistinguishable from an empty set, which is exactly the assumption the
+	// narrowing rests on. This lane already reads every leg's open corpus on its
+	// own cadence, so the count costs nothing and makes the assumption checkable.
+	offPlaneRouted int
+
 	// dropped counts named candidates this plane could not resolve. On the
 	// runtime plane it is the DELIVERED-BUT-OFF-PLANE class (§ lane header): the
 	// journal named a bead, the event arrived, and the bead lives on a leg this
@@ -186,6 +200,9 @@ func (r routeRecoveryReport) fields() map[string]any {
 		"leg_reads":   r.legReads,
 		"legs":        r.legs,
 		"quarantined": r.quarantined,
+	}
+	if r.offPlaneRouted > 0 {
+		out["off_plane_routed"] = r.offPlaneRouted
 	}
 	if r.dropped > 0 {
 		// Named, delivered, and not resolvable on this plane — the convergence
@@ -485,6 +502,10 @@ const (
 type planeLeg struct {
 	label string
 	store beads.Store
+	// binding reports whether this leg is a relocated class binding — the only
+	// legs the RUNTIME plane reads. The convergence lane uses it to say which of
+	// the legs it scanned are ones the tick cannot see.
+	binding bool
 }
 
 // planeLegLabel spells a plan leg the way the pre-lane log line did:
@@ -544,7 +565,11 @@ func walkPlaneLegs(plan storeref.ResolvedPlan, plane storePlane, visit func(plan
 		if leg.Store == nil || !planeReadsLeg(plane, leg.Ref, bindingOnly) {
 			return false, nil
 		}
-		return false, visit(planeLeg{label: planeLegLabel(leg.Ref), store: leg.Store})
+		return false, visit(planeLeg{
+			label:   planeLegLabel(leg.Ref),
+			store:   leg.Store,
+			binding: storeref.IsClassRef(string(leg.Ref)),
+		})
 	})
 	return result.Partial, walkErr
 }
@@ -629,11 +654,12 @@ func (l *routeRecoveryLane) backstopPassOnPlane(plan storeref.ResolvedPlan, reas
 	var errs []error
 	partial, walkErr := walkPlaneLegs(plan, plane, func(leg planeLeg) error {
 		report.legs++
-		legReport := l.backstopLeg(leg.store)
+		legReport := l.backstopLeg(leg)
 		report.candidates += legReport.candidates
 		report.restored += legReport.restored
 		report.quarantined += legReport.quarantined
 		report.legReads += legReport.legReads
+		report.offPlaneRouted += legReport.offPlaneRouted
 		report.flapping = append(report.flapping, legReport.flapping...)
 		return legReport.err
 	})
@@ -666,8 +692,9 @@ func (l *routeRecoveryLane) backstopPassOnPlane(plan storeref.ResolvedPlan, reas
 // The window between the re-verify and the write is narrowed, not closed. The
 // re-stamp stays monotonic (never worse than the prior blind write), so the
 // residual degrades to the pre-guard behavior rather than a new failure.
-func (l *routeRecoveryLane) backstopLeg(store beads.Store) routeRecoveryReport {
+func (l *routeRecoveryLane) backstopLeg(leg planeLeg) routeRecoveryReport {
 	report := routeRecoveryReport{lane: "backstop"}
+	store := leg.store
 	if store == nil {
 		return report
 	}
@@ -679,6 +706,12 @@ func (l *routeRecoveryLane) backstopLeg(store beads.Store) routeRecoveryReport {
 	}
 	var ids []string
 	for _, b := range items {
+		if !leg.binding && b.Status == "open" && strings.TrimSpace(b.Assignee) == "" &&
+			strings.TrimSpace(b.Metadata[beadmeta.RoutedToMetadataKey]) != "" {
+			// Already routed, on a leg the tick's demand read refuses: nothing
+			// will ever spawn a seat for it. See routeRecoveryReport.offPlaneRouted.
+			report.offPlaneRouted++
+		}
 		// Belt-and-braces with the Status:"open" query so the guarantee holds
 		// regardless of store-level filtering semantics: an assigned bead is
 		// already claimed and needs no route.

--- a/cmd/gc/route_recovery_test.go
+++ b/cmd/gc/route_recovery_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
+
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -295,7 +297,7 @@ func TestCityRuntimeRecoverUnroutedWorkRoutes(t *testing.T) {
 // lane, which is the unit the pre-lane restoreCarriedWorkRoutes was: one store,
 // one full live open read, one batched re-verify, no cross-pass accounting.
 func scanOneRouteRecoveryLeg(store beads.Store) (int, error) {
-	report := newRouteRecoveryLane().backstopLeg(store)
+	report := newRouteRecoveryLane().backstopLeg(planeLeg{store: store})
 	return report.restored, report.err
 }
 
@@ -381,5 +383,69 @@ func TestRouteRecoveryBackstopLegSkipsBlockedBead(t *testing.T) {
 	}
 	if route := strings.TrimSpace(mustRoutedTo(t, live, "EB-42o8")); route != "" {
 		t.Errorf("gc.routed_to = %q, want empty (a blocked bead must stay unrouted)", route)
+	}
+}
+
+// TestBackstopCountsRoutedWorkTheRuntimePlaneCannotSee pins the visibility half
+// of the tick's routed-demand narrowing (ga-l7jdg).
+//
+// The controller's demand read is binding-only, so a routed bead left on a work
+// leg is demanded by nothing and no seat is ever spawned for it. That is a
+// migration defect rather than a demand bug — but only if somebody counts it.
+// This lane already reads every leg's open corpus on its own cadence, so the
+// count is free and the assumption "there is no routed work out there" becomes
+// checkable instead of load-bearing.
+func TestBackstopCountsRoutedWorkTheRuntimePlaneCannotSee(t *testing.T) {
+	routed := func(id, assignee string) beads.Bead {
+		return beads.Bead{
+			ID:       id,
+			Title:    id,
+			Type:     "task",
+			Assignee: assignee,
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "pool/worker"},
+		}
+	}
+	for _, tc := range []struct {
+		name    string
+		leg     planeLeg
+		seed    beads.Bead
+		want    int
+		because string
+	}{
+		{
+			name: "unassigned routed work on a work leg",
+			leg:  planeLeg{label: "city"},
+			seed: routed("ga-off-plane", ""),
+			want: 1, because: "the tick's demand read refuses this leg, so nothing spawns for the bead",
+		},
+		{
+			name: "the same bead on the binding",
+			leg:  planeLeg{label: "class:gmnos", binding: true},
+			seed: routed("gcg-on-plane", ""),
+			want: 0, because: "the runtime plane reads the binding, so this bead IS demanded",
+		},
+		{
+			name: "a routed bead on a work leg that already has a holder",
+			leg:  planeLeg{label: "city"},
+			seed: routed("ga-held", "worker-1"),
+			want: 0, because: "an assigned bead needs no seat spawned for it",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			store.HonorExplicitIDs = true
+			if _, err := store.Create(tc.seed); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			leg := tc.leg
+			leg.store = store
+			report := newRouteRecoveryLane().backstopLeg(leg)
+			if report.err != nil {
+				t.Fatalf("backstop leg: %v", report.err)
+			}
+			if report.offPlaneRouted != tc.want {
+				t.Fatalf("off_plane_routed = %d, want %d: %s", report.offPlaneRouted, tc.want, tc.because)
+			}
+		})
 	}
 }

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -134,9 +134,30 @@ func TestSplitTopologyConformance(t *testing.T) {
 // rigBeadStores(), which deletes the city entry. So the HQ work store was in
 // NEITHER arm and a city-scope routed WORK bead was invisible to controller-tick
 // demand: the "no work" fail-open this invariant is named for (D6, ga-88mxz).
-// Now the work store and the binding are DISTINCT ref'd legs, so the hqWork row
-// below is found on both topologies and the graph rows answer under the
-// binding's own "class:*" ref.
+// Now the work store and the binding are DISTINCT ref'd legs.
+//
+// # The PLANE split, and why the split row's answer changed (tick-S3, ga-l7jdg)
+//
+// The demand read is now Plan(RoutedWork) narrowed to the RUNTIME plane. On a
+// split city that is the binding alone, because the operator ruling is that
+// routed work lives only in the graph store — "gc ready work will never be in
+// the work db" (ga-4qdfn) — and reading the remote work ledger on the tick is a
+// misrouting bug by definition, not a cost to amortize (bd memory
+// gascity-runtime-infra-store-invariant). It was 8.1s of a 24.2s demand leg.
+//
+// So this row asserts the plane, not a single answer: on a LEGACY city every
+// routed bead is still found (the work store IS the infra store there, and the
+// D6 assertion is unchanged), while on a SPLIT city the work-leg rows are
+// deliberately absent and the invariant they used to carry moves to two other
+// places, both asserted below:
+//
+//   - the rows that ARE demandable must still be complete and correctly
+//     attributed — the same fail-open, restated for the plane; and
+//   - a routed bead left on a work leg must not vanish silently. The
+//     route-recovery convergence lane reads every leg on its own cadence and
+//     counts them as off_plane_routed, loudly, with `gc storage migrate` as the
+//     named remedy (route_recovery_lane.go). "No reader sees it" would be D6
+//     again; "the tick does not, and the hourly lane says so" is the plane.
 func conformanceReadyFederation(t *testing.T, e splitEnv) {
 	durable := mintDurableGraphBead(t, e, "routed ready control bead", e.qualified)
 	wisp := e.mintWispWith(t, wispOpts{title: "routed ready wisp", routedTo: e.qualified})
@@ -181,19 +202,37 @@ func conformanceReadyFederation(t *testing.T, e splitEnv) {
 	if e.split {
 		leadingRef = string(storeref.ClassRef(wholeSplitClasses()))
 	}
-	for _, tc := range []struct {
-		name    string
-		id      string
-		store   beads.Store
-		wantRef string
+	// The graph-class rows are demandable on BOTH topologies: they live on the
+	// leading leg, which is the binding on a split city and the work store on a
+	// legacy one. The work-leg rows are demandable only where the work store is
+	// also the infra store.
+	rows := []struct {
+		name      string
+		id        string
+		store     beads.Store
+		wantRef   string
+		onRuntime bool
 	}{
-		{"durable routed control bead", durable.ID, leadingOwner, leadingRef},
-		{"routed wisp", wisp.ID, leadingOwner, leadingRef},
-		{"routed rig work bead", rigWork.ID, e.rig, rigRef},
-	} {
+		{"durable routed control bead", durable.ID, leadingOwner, leadingRef, true},
+		{"routed wisp", wisp.ID, leadingOwner, leadingRef, true},
+		{"routed rig work bead", rigWork.ID, e.rig, rigRef, !e.split},
+		// The D6 subject. On a legacy city the HQ work store IS the infra store
+		// and this row is found exactly as before; on a split city it is a work
+		// ledger the runtime plane refuses, and the convergence lane owns it.
+		{"routed HQ work bead", hqWork.ID, e.work, cityRef, !e.split},
+	}
+	demandable := 0
+	for _, tc := range rows {
 		i := beadIndexOf(found, tc.id)
+		if !tc.onRuntime {
+			if i >= 0 {
+				t.Errorf("%s %s surfaced in the runtime-plane demand scan; on a split city a work-leg read is a misrouting bug by definition (bd memory gascity-runtime-infra-store-invariant)", tc.name, tc.id)
+			}
+			continue
+		}
+		demandable++
 		if i < 0 {
-			t.Errorf("%s %s is missing from the cross-store demand scan — this is the exact \"no work\" fail-open: a pool spawns for work its demand read cannot see, then drains", tc.name, tc.id)
+			t.Errorf("%s %s is missing from the demand scan — this is the exact \"no work\" fail-open: a pool spawns for work its demand read cannot see, then drains (D6/ga-88mxz)", tc.name, tc.id)
 			continue
 		}
 		if !sameStorePtr(stores[i], tc.store) {
@@ -203,19 +242,23 @@ func conformanceReadyFederation(t *testing.T, e splitEnv) {
 			t.Errorf("%s %s captured under store-ref %q, want %q", tc.name, tc.id, refs[i], tc.wantRef)
 		}
 	}
+	// Control: the plane narrowed something on a split city and nothing on a
+	// legacy one, so neither arm of the row above is vacuous.
+	switch {
+	case e.split && demandable == len(rows):
+		t.Fatal("the split topology demanded every leg's routed work; the runtime plane narrowed nothing and this row is pinning the pre-invariant behavior")
+	case !e.split && demandable != len(rows):
+		t.Fatalf("the legacy topology demanded %d of %d rows; there is no ledger to refuse when the work store IS the infra store", demandable, len(rows))
+	}
 
-	// The HQ work leg — the D6 subject, and the same answer on both topologies
-	// now that the city work store is a leg of its own rather than a store the
-	// binding stood in for.
-	hqIndex := beadIndexOf(found, hqWork.ID)
-	if hqIndex < 0 {
-		t.Fatalf("routed HQ work bead %s is missing from the demand scan. On a legacy city the HQ work store IS the leading store; on a split city it is the Plan(Census) work leg. Either way this is the \"no work\" fail-open: a pool spawns for work its demand read cannot see, then drains (D6/ga-88mxz, closed by S3)", hqWork.ID)
-	}
-	if !sameStorePtr(stores[hqIndex], e.work) {
-		t.Errorf("routed HQ work bead %s was captured under a store that does not hold it", hqWork.ID)
-	}
-	if refs[hqIndex] != cityRef {
-		t.Errorf("routed HQ work bead %s captured under store-ref %q, want %q", hqWork.ID, refs[hqIndex], cityRef)
+	// The work-leg rows must not vanish silently: the convergence lane reads
+	// every leg and counts them, which is what makes "the tick cannot see it"
+	// different from "nothing can".
+	if e.split {
+		report := newRouteRecoveryLane().backstopLeg(planeLeg{label: "city", store: e.work})
+		if report.offPlaneRouted == 0 {
+			t.Errorf("the convergence lane reported no off-plane routed work for %s, which the runtime plane just refused; a bead no reader counts is D6 with extra steps", hqWork.ID)
+		}
 	}
 }
 

--- a/cmd/gc/tick_read_budget_test.go
+++ b/cmd/gc/tick_read_budget_test.go
@@ -30,6 +30,13 @@ import (
 // timing assertion on a loaded CI box. The latency injector below exists only so
 // the wall-clock half can be stated as narrative: at a stand-in RTT, this many
 // round trips is this many seconds.
+//
+// The remaining two hot legs carry their budgets in their own files, because
+// theirs are not zero and their fixtures are whole subsystems: order dispatch in
+// order_gate_budget_test.go (gate reads scale with STORES, not orders; zero
+// ledger round trips) and the demand snapshot in demand_snapshot_budget_test.go
+// (zero ledger round trips in the cache check and the routed-demand read). Same
+// gate, same unit, three files.
 
 // tickRTT is the stand-in for the remote ledger's per-query latency —
 // maintainer-city's work store answers in ~5.4s, scaled down to keep the

--- a/internal/orders/store.go
+++ b/internal/orders/store.go
@@ -240,6 +240,25 @@ func trackingTitle(scoped string) string { return labelOrderTitlePrefix + scoped
 // graph roots for scoped.
 func RunLabel(scoped string) string { return labelOrderRunPrefix + scoped }
 
+// ScopedFromRunLabel returns the scoped order name a run label names, and
+// reports whether label is a run label at all.
+//
+// It is RunLabel read backwards, and it exists so a caller that indexes a whole
+// store's order-run evidence in one read — rather than one label-filtered query
+// per order — parses the label with the function that wrote it. The prefix is
+// otherwise spelled as a literal at a dozen call sites, and an index that
+// disagreed with the writer about where the name starts would gate on nothing.
+func ScopedFromRunLabel(label string) (string, bool) {
+	if !strings.HasPrefix(label, labelOrderRunPrefix) {
+		return "", false
+	}
+	scoped := strings.TrimPrefix(label, labelOrderRunPrefix)
+	if scoped == "" {
+		return "", false
+	}
+	return scoped, true
+}
+
 // IsTrackingBead reports whether b is an order tracking record.
 func IsTrackingBead(b beads.Bead) bool { return beadLabelsContain(b.Labels, labelOrderTracking) }
 

--- a/internal/storeref/relevance.go
+++ b/internal/storeref/relevance.go
@@ -1,0 +1,141 @@
+package storeref
+
+// Relevance: which legs of a plan a caller's question can be answered from.
+//
+// # Why this is not a leg order
+//
+// The obvious way to make the controller's hot reads cheap is to put the
+// binding first and stop at the first hit. It is also the way that recreates the
+// D6 divergence in reverse: Plan(RoutedWork) puts the binding LAST on purpose
+// (#5148), because binding-last is what makes a co-resident id answer from the
+// work store on the demand side and from the work store on the claim side. A
+// consumer that reorders the plan for itself has silently disagreed with every
+// other consumer about which copy of a dual-resident bead is the real one.
+//
+// So the descriptor NARROWS and never reorders. A narrowed plan is a
+// subsequence of its parent: same modes, same roles, same per-leg error
+// policies, same relative order — with legs this plane may not read removed.
+// That is a property, not a convention: TestNarrowKeepsPlanOrderAndOnlyDropsLegs
+// asserts the subsequence directly, and the conformance corpus pins the rendered
+// rows.
+//
+// # The plane doctrine
+//
+// The plane is a property of the CALLER, and the two are deliberately NOT
+// complements.
+//
+//   - The RUNTIME plane is city operations: ticks, hooks, claims, sweeps,
+//     census. It is a LATENCY contract, and it narrows to the infra/class
+//     binding. Every bd operation on this plane hits the binding only; a
+//     work-ledger leg here is a misrouting bug by definition, not a cost to
+//     amortize (operator invariant 2026-08-15, bd memory
+//     gascity-runtime-infra-store-invariant, ga-l7jdg). It is why a claim needed
+//     a 240s window and why one tick leg cost 185s of a 360s tick.
+//   - The RECONCILE plane is the rare, separately-scheduled convergence lane. It
+//     is a CONVERGENCE contract and narrows NOTHING, because a store it skips is
+//     a store nothing converges: the runtime plane over that same binding is
+//     delta-only, so one dropped journal event would strand a binding-resident
+//     bead permanently.
+//
+// # Where the descriptor is applied, and why it is not applied in Plan()
+//
+// Plan() answers "which stores can hold the answer to this question". That is a
+// residency fact about the CITY and it does not change when a different process
+// asks. The plane is a fact about the CALLER. Keeping the two separable is what
+// lets one topology serve both lanes, lets a corpus row show the full plan and
+// its narrowing side by side, and lets the convergence lane converge exactly the
+// legs the runtime lane refused.
+//
+// # Why this surface needs no new boundary-guard row
+//
+// scripts/residency-boundary-patterns.txt ratchets every way a consumer can get
+// STORES out of a plan and read them itself — the `[]beads.Store` literal, the
+// `.Leg.Store` disassembly, and EachLeg, the sanctioned enumeration seam. Narrow
+// hands back a ResolvedPlan, the same type Plan already returns, so a consumer
+// still runs it through Union/Walk and the leg order and per-leg error policy are
+// still applied by the executor. There is no new way to hold a leg list, so there
+// is nothing new to count.
+//
+// # Per-template relevance is deliberately NOT a field here
+//
+// The original shape of this surface (ga-4qdfn item 1) was per-TEMPLATE leg
+// relevance: the topology knows which stores a given pool's routed work
+// materializes into, so a template whose formulas mint into the binding could
+// have its legs narrowed to the binding. The operator invariant supersedes it:
+// on the runtime plane the answer is the binding for EVERY template, so a
+// per-template field would vary nothing this build can produce. It goes in when
+// a plane needs two different answers for two templates, and not before.
+
+import (
+	"errors"
+	"strconv"
+)
+
+// Plane is the caller's contract — the descriptor a consumer narrows a plan
+// with. It is shared rather than re-derived per site: demand, the tick's delta
+// lanes and the readers they must agree with all pass the same value, so a
+// disagreement about which legs are relevant is a diff in one place.
+type Plane int
+
+const (
+	// PlaneRuntime is city operations: ticks, hooks, claims, sweeps, census.
+	// Infra/class binding only.
+	PlaneRuntime Plane = iota
+
+	// PlaneReconcile is the off-tick convergence lane, which reads every leg
+	// because converging them is the whole reason it exists.
+	PlaneReconcile
+)
+
+// String renders the plane as it appears in a corpus row and a diagnostic.
+func (p Plane) String() string {
+	switch p {
+	case PlaneRuntime:
+		return "runtime"
+	case PlaneReconcile:
+		return "reconcile"
+	default:
+		return "Plane(" + strconv.Itoa(int(p)) + ")"
+	}
+}
+
+// Narrow applies the descriptor: it returns the subsequence of p's legs this
+// plane may read, with the mode, the roles, the per-leg error policies and the
+// relative order untouched.
+//
+// It errors when the narrowing would leave nothing to read, for the same reason
+// Plan does: a legless plan is not an empty answer, and a Union over one reports
+// zero rows as a complete one.
+//
+// # The single-store degradation
+//
+// A city that relocates no class has no binding, and there its work store IS its
+// infra store. So the runtime rule is "the binding where one exists, otherwise
+// the plan unchanged" — it degrades to "the only store there is", never to "no
+// store at all", which would silently disable every runtime-plane reader on
+// every single-store city. The same degradation covers a city whose binding
+// resolved back to its work store: the plan's own dedupe already collapsed them,
+// so there is one leg and it is both.
+func Narrow(p ResolvedPlan, plane Plane) (ResolvedPlan, error) {
+	if len(p.Legs) == 0 {
+		return ResolvedPlan{}, errors.New("storeref: cannot narrow a plan with no legs — an empty leg list is a reader with nothing to read, not an empty answer")
+	}
+	if plane != PlaneRuntime || !p.TouchesBinding() {
+		return p, nil
+	}
+	out := p
+	out.Legs = make([]PlanLeg, 0, len(p.Legs))
+	for _, l := range p.Legs {
+		if IsClassRef(string(l.Leg.Ref)) {
+			out.Legs = append(out.Legs, l)
+		}
+	}
+	if len(out.Legs) == 0 {
+		// Unreachable while TouchesBinding is the gate above — they read the same
+		// predicate — but a narrowing that silently empties a plan is the exact
+		// shape this package exists to refuse, so it fails loud rather than
+		// relying on two predicates staying in step.
+		return ResolvedPlan{}, errors.New("storeref: narrowing to the " + plane.String() + " plane left no readable leg")
+	}
+	return out, nil
+}

--- a/internal/storeref/relevance_test.go
+++ b/internal/storeref/relevance_test.go
@@ -1,0 +1,146 @@
+package storeref
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The relevance descriptor's own properties.
+//
+// Narrow is a FILTER, and every test here exists to keep it one. The failure it
+// is guarding against is not "the wrong legs were dropped" — it is a controller
+// that answers the latency question by REORDERING the plan, because
+// Plan(RoutedWork) puts the binding last on purpose (#5148 co-residence) and a
+// consumer-side reorder recreates D6 in reverse.
+
+func TestNarrowKeepsPlanOrderAndOnlyDropsLegs(t *testing.T) {
+	for _, f := range allTopologies() {
+		if f.topo.Refused != nil {
+			continue
+		}
+		t.Run(f.name, func(t *testing.T) {
+			full := mustPlan(t, RoutedWork{}, f.topo)
+			narrowed, err := Narrow(full, PlaneRuntime)
+			if err != nil {
+				t.Fatalf("Narrow(runtime): %v", err)
+			}
+			if narrowed.Mode != full.Mode {
+				t.Fatalf("narrowing changed the mode from %s to %s; the descriptor selects legs, not executors", full.Mode, narrowed.Mode)
+			}
+			// Subsequence, not merely subset: the surviving legs appear in the
+			// SAME relative order, with the same role and policy.
+			var want []string
+			for _, l := range full.Legs {
+				if slices.ContainsFunc(narrowed.Legs, func(k PlanLeg) bool { return k.Leg.Ref == l.Leg.Ref }) {
+					want = append(want, l.String())
+				}
+			}
+			var got []string
+			for _, l := range narrowed.Legs {
+				got = append(got, l.String())
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("narrowed plan reads\n %v\nbut the full plan's surviving legs are\n %v\n— the descriptor reordered or re-policied a leg", got, want)
+			}
+		})
+	}
+}
+
+// TestNarrowRuntimeRefusesTheLedgerOnASplitCity is the operator invariant as a
+// resolver property (bd memory gascity-runtime-infra-store-invariant): a
+// runtime-plane caller may not even be HANDED a work-ledger leg.
+func TestNarrowRuntimeRefusesTheLedgerOnASplitCity(t *testing.T) {
+	f := newT2() // work ledger + two rigs + one binding: every leg family at once
+	full := mustPlan(t, RoutedWork{}, f.topo)
+	narrowed, err := Narrow(full, PlaneRuntime)
+	if err != nil {
+		t.Fatalf("Narrow(runtime): %v", err)
+	}
+	for _, l := range narrowed.Legs {
+		if !IsClassRef(string(l.Leg.Ref)) {
+			t.Fatalf("the runtime plane kept leg %q; on a split city it reads the infra binding and nothing else", l.Leg.Ref)
+		}
+	}
+	// Control: the narrowing is real. The full plan HAS the legs it dropped, so
+	// a Narrow that had simply returned its input would fail here.
+	if len(narrowed.Legs) >= len(full.Legs) {
+		t.Fatalf("the runtime plane kept %d of %d legs; it narrowed nothing", len(narrowed.Legs), len(full.Legs))
+	}
+}
+
+// TestNarrowReconcileNeverNarrows is the other half of the plane doctrine. The
+// two planes are NOT complements: the runtime plane is a latency contract and
+// narrows, while the reconcile plane is a CONVERGENCE contract and a leg it
+// skips is a leg nothing converges.
+func TestNarrowReconcileNeverNarrows(t *testing.T) {
+	for _, f := range allTopologies() {
+		if f.topo.Refused != nil {
+			continue
+		}
+		t.Run(f.name, func(t *testing.T) {
+			for _, in := range []struct {
+				name   string
+				intent Intent
+			}{
+				{"RoutedWork", RoutedWork{}},
+				{"AssignedWork(sweep)", AssignedWork{}},
+				{"Census(all)", Census{}},
+				{"Session", Session{}},
+			} {
+				full := mustPlan(t, in.intent, f.topo)
+				narrowed, err := Narrow(full, PlaneReconcile)
+				if err != nil {
+					t.Fatalf("%s: Narrow(reconcile): %v", in.name, err)
+				}
+				if got, want := narrowed.String(), full.String(); got != want {
+					t.Fatalf("%s: the reconcile plane rendered\n %s\nwant the full plan\n %s\n— convergence never narrows", in.name, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestNarrowRuntimeKeepsTheOnlyStoreASingleStoreCityHas pins the degradation
+// that keeps the invariant from disabling the runtime plane outright: a city
+// that relocates no class has no binding, and there its work store IS its infra
+// store.
+func TestNarrowRuntimeKeepsTheOnlyStoreASingleStoreCityHas(t *testing.T) {
+	f := newT0()
+	full := mustPlan(t, RoutedWork{}, f.topo)
+	narrowed, err := Narrow(full, PlaneRuntime)
+	if err != nil {
+		t.Fatalf("Narrow(runtime): %v", err)
+	}
+	if got, want := narrowed.String(), full.String(); got != want {
+		t.Fatalf("single-store city narrowed to\n %s\nwant\n %s\n— the rule must degrade to \"the only store there is\", never to \"no store at all\"", got, want)
+	}
+}
+
+// TestNarrowRefusesToProduceALeglessPlan mirrors Plan's own rule. A legless plan
+// is not an empty answer, it is a reader with nothing to read — and a Union over
+// one reports zero rows as a complete answer, which is the silent-shrink shape
+// this package exists to close.
+func TestNarrowRefusesToProduceALeglessPlan(t *testing.T) {
+	if _, err := Narrow(ResolvedPlan{Mode: ModeUnion}, PlaneRuntime); err == nil {
+		t.Fatal("narrowing a legless plan succeeded; an empty leg list must fail loud")
+	}
+	// Control: the same call over a plan WITH legs succeeds, so the refusal
+	// above is about the leg list and not about the call shape.
+	f := newT1()
+	if _, err := Narrow(mustPlan(t, RoutedWork{}, f.topo), PlaneRuntime); err != nil {
+		t.Fatalf("narrowing a real plan failed: %v", err)
+	}
+}
+
+func TestPlaneStringIsStable(t *testing.T) {
+	if got, want := PlaneRuntime.String(), "runtime"; got != want {
+		t.Fatalf("PlaneRuntime renders %q, want %q", got, want)
+	}
+	if got, want := PlaneReconcile.String(), "reconcile"; got != want {
+		t.Fatalf("PlaneReconcile renders %q, want %q", got, want)
+	}
+	if got := Plane(7).String(); !strings.Contains(got, "7") {
+		t.Fatalf("an unknown plane renders %q, which names nothing an operator can act on", got)
+	}
+}

--- a/internal/storeref/residency_agreement_test.go
+++ b/internal/storeref/residency_agreement_test.go
@@ -302,6 +302,97 @@ func TestSweepAndDemandReadTheSameStores(t *testing.T) {
 	}
 }
 
+// TestReaderAgreementHoldsUnderTheRelevanceDescriptor is the property that lets
+// the controller narrow its reads at all.
+//
+// Narrowing is the one change that can break agreement without changing a single
+// leg ORDER: if demand narrows and the claim surface does not, a bead is
+// claimable and never demanded (the stranded claim), and if the claim narrows
+// and demand does not, a bead is demanded and never claimable (the spawn/idle
+// treadmill). Both are D6, so the property is asserted PER PLANE: within one
+// plane, the surface that counts work and the surface that claims it must still
+// name the same beads.
+//
+// The narrowing's COST is asserted too, and deliberately: a work-ledger-resident
+// bead leaves the runtime plane's answer. That is the operator invariant working
+// as specified, not a regression — and it is the reason the convergence lane
+// reads every leg. Pinning it here means the day someone widens or forgets the
+// convergence half, the cost is written down in a test rather than discovered on
+// a city.
+func TestReaderAgreementHoldsUnderTheRelevanceDescriptor(t *testing.T) {
+	for _, f := range allTopologies() {
+		if f.topo.Refused != nil {
+			continue
+		}
+		t.Run(f.name, func(t *testing.T) {
+			seeded, _, _, _, _ := seedAgreementFixture(t, f)
+			fullDemand := mustPlan(t, RoutedWork{}, f.topo)
+			fullClaim := mustPlan(t, AssignedWork{Purpose: AssignedWorkClaimEscalation}, f.topo)
+
+			for _, plane := range []Plane{PlaneRuntime, PlaneReconcile} {
+				demandPlan, err := Narrow(fullDemand, plane)
+				if err != nil {
+					t.Fatalf("%s: narrowing demand: %v", plane, err)
+				}
+				claimPlan, err := Narrow(fullClaim, plane)
+				if err != nil {
+					t.Fatalf("%s: narrowing claim escalation: %v", plane, err)
+				}
+				demand, err := Union(demandPlan, beadID, listOpenLeg)
+				if err != nil {
+					t.Fatalf("%s: demand union: %v", plane, err)
+				}
+				var claimable []string
+				for _, id := range seeded {
+					if _, ok := claimLegFor(t, claimPlan, id); ok {
+						claimable = append(claimable, id)
+					}
+				}
+				sort.Strings(claimable)
+				if got, want := strings.Join(idsOf(demand.Items), ","), strings.Join(claimable, ","); got != want {
+					t.Fatalf("on the %s plane demand and claim disagree:\n demand:    %s\n claimable: %s", plane, got, want)
+				}
+			}
+
+			// The cost, and the control that the narrowing is real. On a split
+			// city the runtime answer is a STRICT subset of the reconcile one,
+			// and the bead it loses is the work-ledger-resident one — the class
+			// the tick's delta lanes count as `dropped` and the convergence lane
+			// repairs.
+			runtimePlan, err := Narrow(fullDemand, PlaneRuntime)
+			if err != nil {
+				t.Fatalf("narrowing demand: %v", err)
+			}
+			runtime, err := Union(runtimePlan, beadID, listOpenLeg)
+			if err != nil {
+				t.Fatalf("runtime demand union: %v", err)
+			}
+			full, err := Union(fullDemand, beadID, listOpenLeg)
+			if err != nil {
+				t.Fatalf("full demand union: %v", err)
+			}
+			for _, id := range idsOf(runtime.Items) {
+				if !slices.Contains(idsOf(full.Items), id) {
+					t.Fatalf("the runtime plane surfaced %q, which the full plan does not: narrowing added a bead", id)
+				}
+			}
+			switch {
+			case len(f.topo.Bindings) == 0:
+				if len(runtime.Items) != len(full.Items) {
+					t.Fatalf("a single-store city narrowed its demand from %d beads to %d; there is no ledger to refuse here", len(full.Items), len(runtime.Items))
+				}
+			default:
+				if containsID(runtime.Items, "ga-work-1") {
+					t.Fatal("the work-ledger-only bead survived the runtime plane; the invariant is not being applied")
+				}
+				if !containsID(full.Items, "ga-work-1") {
+					t.Fatal("the work-ledger-only bead is absent from the FULL plan too — fixture rot, so the cost assertion above proves nothing")
+				}
+			}
+		})
+	}
+}
+
 // legThatContributed reports the first leg of a union plan that holds id — the
 // leg first-leg-wins attributes the row to.
 func legThatContributed(t *testing.T, p ResolvedPlan, id string) StoreRef {

--- a/internal/storeref/residency_conformance_test.go
+++ b/internal/storeref/residency_conformance_test.go
@@ -226,6 +226,200 @@ var residencyCorpus = map[string]string{
 	"Class(sessions) x T6r":                `SingleOwner: class:gmnos[Authority,Fatal]`,
 }
 
+// runtimeCorpusIntents is the intent axis of the RUNTIME-PLANE corpus: the
+// questions a controller tick, a hook or a claim asks. The plane narrows them to
+// the infra binding, and these rows are what a consumer of the relevance
+// descriptor actually reads.
+func runtimeCorpusIntents() []struct {
+	name   string
+	intent Intent
+} {
+	return []struct {
+		name   string
+		intent Intent
+	}{
+		{"RoutedWork", RoutedWork{}},
+		{"AssignedWork(sweep)", AssignedWork{}},
+		{"AssignedWork(claim-escalation)", AssignedWork{Purpose: AssignedWorkClaimEscalation}},
+		{"Session", Session{}},
+		{"Census(all)", Census{}},
+		{"ByID(" + workShapedID + ")", ByID{ID: workShapedID}},
+	}
+}
+
+// residencyRuntimeCorpus pins the SAME plans narrowed to the runtime plane —
+// the operator invariant as a golden table (bd memory
+// gascity-runtime-infra-store-invariant).
+//
+// Read it beside residencyCorpus: every row here is a SUBSEQUENCE of the row
+// above with the same key, never a re-ordering. That is what makes the
+// descriptor a latency decision rather than a residency one, and
+// TestRuntimePlaneCorpus asserts the subsequence relation on every row rather
+// than trusting the two tables to be edited together.
+var residencyRuntimeCorpus = map[string]string{
+	// ---- T0: nothing to narrow. A city that relocates no class has no binding,
+	// and there the work store IS the infra store: the rule degrades to "the only
+	// store there is", never to "no store at all".
+	"RoutedWork@runtime x T0":                     `Union(first-leg-wins): ""[Authority,Fatal]`,
+	"AssignedWork(sweep)@runtime x T0":            `Union(first-leg-wins): ""[Authority,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T0": `FirstOwner: ""[Authority,Fatal]`,
+	"Session@runtime x T0":                        `Union(first-leg-wins): ""[Authority,Fatal]`,
+	"Census(all)@runtime x T0":                    `Union(first-leg-wins): ""[Authority,Fatal]`,
+	"ByID(ga-xyz)@runtime x T0":                   `FirstOwner: ""[WorkFallback,Fatal]`,
+
+	// ---- T1: the shape maintainer-city runs. Every runtime question is one
+	// local sqlite read; the remote work ledger is not a leg the tick can be
+	// handed. Note the ROLES are untouched — the binding is still the plan's
+	// FederationTail, because narrowing does not promote a leg it kept.
+	"RoutedWork@runtime x T1":                     `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(sweep)@runtime x T1":            `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T1": `FirstOwner: class:gmnos[FederationTail,Fatal]`,
+	"Session@runtime x T1":                        `Union(first-leg-wins): class:gmnos[Authority,Fatal]`,
+	"Census(all)@runtime x T1":                    `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"ByID(ga-xyz)@runtime x T1":                   `FirstOwner: class:gmnos[ResidenceProbe,RefusalTolerated]`,
+
+	// ---- T2/T4: the rig legs go too. A rig work store is a work ledger like any
+	// other, and the invariant is about the PLANE, not about which work store.
+	"RoutedWork@runtime x T2":                     `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(sweep)@runtime x T2":            `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T2": `FirstOwner: class:gmnos[FederationTail,Fatal]`,
+	"Session@runtime x T2":                        `Union(first-leg-wins): class:gmnos[Authority,Fatal]`,
+	"Census(all)@runtime x T2":                    `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"ByID(ga-xyz)@runtime x T2":                   `FirstOwner: class:gmnos[ResidenceProbe,RefusalTolerated]`,
+
+	// ---- T3: a refused city has no plan to narrow. The descriptor is applied
+	// AFTER Plan, so the refusal still arrives first and still names its remedy —
+	// narrowing must never be a way to get a work-only answer out of a refusal.
+	"RoutedWork@runtime x T3":                     "error: storage refused: run `gc storage migrate`",
+	"AssignedWork(sweep)@runtime x T3":            "error: storage refused: run `gc storage migrate`",
+	"AssignedWork(claim-escalation)@runtime x T3": "error: storage refused: run `gc storage migrate`",
+	"Session@runtime x T3":                        "error: storage refused: run `gc storage migrate`",
+	"Census(all)@runtime x T3":                    "error: storage refused: run `gc storage migrate`",
+	"ByID(ga-xyz)@runtime x T3":                   `FirstOwner: class:gmnos[ResidenceProbe,RefusalTolerated]`,
+
+	"RoutedWork@runtime x T4":                     `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(sweep)@runtime x T4":            `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T4": `FirstOwner: class:gmnos[FederationTail,Fatal]`,
+	"Session@runtime x T4":                        `Union(first-leg-wins): class:gmnos[Authority,Fatal]`,
+	"Census(all)@runtime x T4":                    `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"ByID(ga-xyz)@runtime x T4":                   `FirstOwner: class:gmnos[ResidenceProbe,RefusalTolerated]`,
+
+	// ---- T5: per-class split. BOTH bindings survive, in the plan's order. The
+	// plane says "the infra stores", not "one infra store" — a runtime reader
+	// that kept only the first would lose the sessions binding's rows.
+	"RoutedWork@runtime x T5":                     `Union(first-leg-wins): class:g[FederationTail,Fatal] > class:s[FederationTail,Fatal]`,
+	"AssignedWork(sweep)@runtime x T5":            `Union(first-leg-wins): class:g[FederationTail,Fatal] > class:s[FederationTail,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T5": `FirstOwner: class:g[FederationTail,Fatal] > class:s[FederationTail,Fatal]`,
+	"Session@runtime x T5":                        `Union(first-leg-wins): class:s[Authority,Fatal]`,
+	"Census(all)@runtime x T5":                    `Union(first-leg-wins): class:g[FederationTail,Fatal] > class:s[FederationTail,Fatal]`,
+	"ByID(ga-xyz)@runtime x T5":                   `FirstOwner: class:g[ResidenceProbe,RefusalTolerated] > class:s[ResidenceProbe,RefusalTolerated]`,
+
+	// ---- T6: the retirement shape, and the one row that is a HAZARD rather than
+	// a win. With the residence probe retired, ByID of a work-shaped id plans to
+	// the work leg ALONE — so there is no binding leg to narrow to and the
+	// runtime plane hands back the ledger. That is correct (the bead really is
+	// only reachable there) and it is exactly why the by-id path is not narrowed
+	// in production: on this topology narrowing buys nothing and the ledger read
+	// survives. Retiring it is resolver S5's mint-truthful work, not this
+	// descriptor's.
+	"RoutedWork@runtime x T6":                     `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(sweep)@runtime x T6":            `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T6": `FirstOwner: class:gmnos[FederationTail,Fatal]`,
+	"Session@runtime x T6":                        `Union(first-leg-wins): class:gmnos[Authority,Fatal]`,
+	"Census(all)@runtime x T6":                    `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"ByID(ga-xyz)@runtime x T6":                   `FirstOwner: ""[WorkFallback,Fatal]`,
+
+	"RoutedWork@runtime x T6r":                     `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(sweep)@runtime x T6r":            `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"AssignedWork(claim-escalation)@runtime x T6r": `FirstOwner: class:gmnos[FederationTail,Fatal]`,
+	"Session@runtime x T6r":                        `Union(first-leg-wins): class:gmnos[Authority,Fatal]`,
+	"Census(all)@runtime x T6r":                    `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
+	"ByID(ga-xyz)@runtime x T6r":                   `FirstOwner: class:gmnos[ResidenceProbe,RefusalTolerated]`,
+}
+
+// TestRuntimePlaneCorpus is the golden diff for the relevance descriptor, plus
+// the two properties a golden table alone cannot state: every runtime row is a
+// SUBSEQUENCE of its full row, and the reconcile plane changes nothing.
+func TestRuntimePlaneCorpus(t *testing.T) {
+	seen := make(map[string]bool, len(residencyRuntimeCorpus))
+	narrowedSomewhere := false
+	for _, f := range allTopologies() {
+		for _, in := range runtimeCorpusIntents() {
+			key := in.name + "@runtime x " + f.name
+			want, ok := residencyRuntimeCorpus[key]
+			if !ok {
+				t.Errorf("runtime corpus row %q is missing — every intent x topology pair must be pinned", key)
+				continue
+			}
+			seen[key] = true
+
+			full, err := Plan(in.intent, f.topo)
+			if err != nil {
+				if got := "error: " + err.Error(); got != want {
+					t.Errorf("%s\n got: %s\nwant: %s", key, got, want)
+				}
+				continue
+			}
+			narrowed, err := Narrow(full, PlaneRuntime)
+			if err != nil {
+				t.Errorf("%s: Narrow(runtime): %v", key, err)
+				continue
+			}
+			if got := narrowed.String(); got != want {
+				t.Errorf("%s\n got: %s\nwant: %s", key, got, want)
+			}
+			if !isLegSubsequence(narrowed, full) {
+				t.Errorf("%s: the runtime row\n %s\nis not a subsequence of the full row\n %s\n— the descriptor reordered a leg, which is the D6-in-reverse shape it exists to prevent", key, narrowed, full)
+			}
+			if len(narrowed.Legs) < len(full.Legs) {
+				narrowedSomewhere = true
+			}
+			// The reconcile plane is the same plan, always.
+			reconciled, err := Narrow(full, PlaneReconcile)
+			if err != nil {
+				t.Errorf("%s: Narrow(reconcile): %v", key, err)
+				continue
+			}
+			if got, wantFull := reconciled.String(), full.String(); got != wantFull {
+				t.Errorf("%s: the reconcile plane rendered\n %s\nwant the full plan\n %s", key, got, wantFull)
+			}
+		}
+	}
+	// Non-vacuity: if no row narrowed anything, this whole table is asserting
+	// that a no-op is a no-op.
+	if !narrowedSomewhere {
+		t.Fatal("no runtime row dropped a leg; the corpus is pinning a descriptor that narrows nothing")
+	}
+	var stale []string
+	for key := range residencyRuntimeCorpus {
+		if !seen[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("runtime corpus rows match no intent x topology pair (stale): %s", strings.Join(stale, ", "))
+	}
+	if len(seen) != len(runtimeCorpusIntents())*len(allTopologies()) {
+		t.Fatalf("runtime corpus covered %d rows, want %d", len(seen), len(runtimeCorpusIntents())*len(allTopologies()))
+	}
+}
+
+// isLegSubsequence reports whether narrowed's legs appear in full, in order,
+// with their roles and policies unchanged.
+func isLegSubsequence(narrowed, full ResolvedPlan) bool {
+	if narrowed.Mode != full.Mode {
+		return false
+	}
+	i := 0
+	for _, l := range full.Legs {
+		if i < len(narrowed.Legs) && narrowed.Legs[i].String() == l.String() {
+			i++
+		}
+	}
+	return i == len(narrowed.Legs)
+}
+
 // TestResidencyCorpus is the golden diff: every (intent, topology) pair the
 // corpus declares must render exactly the pinned plan.
 func TestResidencyCorpus(t *testing.T) {


### PR DESCRIPTION
Tick-S3 (bead ga-l7jdg): the last two hot tick legs — `dispatch_orders` (86s live) and `load_demand_snapshot` (24s) — plus the resolver plane-narrowing surface they consume.

- **`storeref.Narrow(plan, plane)`**: runtime narrows to the class bindings (a *subsequence* of the parent plan — reordering is structurally impossible, preserving #5148's binding-last co-residence); reconcile narrows nothing (the convergence contract). 48-row corpus, subsequence-pinned.
- **Orders**: the per-order strict label-List (~5.4s × N orders on the ledger) becomes one per-tick index over the binding gate legs; condition checks run in a bounded-parallel wave; #2893/#2921's suppression semantics port onto the index with a must-fire control. Zero ledger round-trips, asserted; reads scale with stores, not orders.
- **Demand**: the routed read and the freshness fingerprint consume the same narrowed plan concurrently; the event-backed max-age moves 30s→5m so the cache can actually engage (at 30s vs a 373s tick it was dead code). `collect_assigned_work` deliberately keeps its ledger leg (ga-w8ucu — latency is not a reason to go blind about who holds what).
- **D6 protection, not relaxation**: the split-topology row now asserts the *plane* with non-vacuity controls on both arms, and the convergence lane counts `off_plane_routed` loudly (zero extra reads) with `gc storage migrate` as the named remedy — off-plane routed work is visible-and-reported, never silently unroutable.

Projected steady tick: ~122s → **≈25s quiet / ≈34s under a full condition wave**. Remaining lever (the census ledger leg's 11.5s) is S4/TickView scope.

Chain: design → Opus impl → independent verify pass — **clean on all seven mutation probes** (binding-first reorder, all-stores gate, fold-drop, fingerprint un-narrow, age revert, off-plane counter delete, serial/uncapped concurrency mutants — each reddened its exact gate, differently). Full cmd/gc 839s green; both residency halves; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
