### PR TITLE
fix(stop): clarify busy reconcile stop rejection

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -108,7 +108,7 @@ func cmdStopJSONSequence(args []string, stdout, stderr io.Writer, force bool, js
 	}
 
 	unregisteredFromSupervisor := false
-	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stopStdout, stderr, "gc stop", force); handled {
+	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stopStdout, stderr, force); handled {
 		if code != 0 {
 			return stopCommandOutcome{code: code, cityPath: cityPath}
 		}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1033,6 +1033,11 @@ func reloadSupervisor(stdout, stderr io.Writer) int {
 	return reloadSupervisorJSON(stdout, stderr, false)
 }
 
+const (
+	supervisorReloadReconcileTimeoutMessage = "gc supervisor reload: reconcile did not finish before timeout"
+	supervisorReloadQueueBusyMessage        = "gc supervisor reload: reconcile queue is busy; try again shortly"
+)
+
 func reloadSupervisorJSON(stdout, stderr io.Writer, jsonOut bool) int {
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
@@ -1062,10 +1067,10 @@ func reloadSupervisorJSON(stdout, stderr io.Writer, jsonOut bool) int {
 		fmt.Fprintln(stdout, "Reconciliation triggered.") //nolint:errcheck
 		return 0
 	case "busy":
-		fmt.Fprintln(stderr, "gc supervisor reload: reconcile queue is busy; try again shortly") //nolint:errcheck
+		fmt.Fprintln(stderr, supervisorReloadQueueBusyMessage) //nolint:errcheck
 		return 1
 	case "timeout":
-		fmt.Fprintln(stderr, "gc supervisor reload: reconcile did not finish before timeout") //nolint:errcheck
+		fmt.Fprintln(stderr, supervisorReloadReconcileTimeoutMessage) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintln(stderr, "gc supervisor reload: supervisor not responding (may be shutting down); try 'gc supervisor start'") //nolint:errcheck

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -571,6 +571,11 @@ func supervisorRetryCommand(commandName, cityPath string) string {
 }
 
 func keepRegisteredCity(entry supervisor.CityEntry, stderr io.Writer, commandName, reason string) {
+	if _, registered, err := registeredCityEntry(entry.Path); err == nil && !registered {
+		fmt.Fprintf(stderr, "%s: %s; registration for '%s' is already removed, so the supervisor will not retry automatically\n", //nolint:errcheck // best-effort stderr
+			commandName, reason, entry.EffectiveName())
+		return
+	}
 	fmt.Fprintf(stderr, "%s: %s; keeping registration for '%s' so the supervisor can retry automatically\n", //nolint:errcheck // best-effort stderr
 		commandName, reason, entry.EffectiveName())
 }
@@ -581,9 +586,11 @@ func waitForSupervisorCity(cityPath string, wantRunning bool, timeout time.Durat
 	for {
 		running, status, known := supervisorCityRunningHook(cityPath)
 		switch {
-		case known && running == wantRunning:
+		case known && running == wantRunning && wantRunning:
 			return nil
-		case known && !wantRunning:
+		case known && running == wantRunning && !wantRunning && status == "":
+			return nil
+		case known && running && !wantRunning:
 			return fmt.Errorf("city is still running under supervisor")
 		case known && wantRunning && status == "init_failed":
 			// If the supervisor reports an init failure, surface the
@@ -653,6 +660,35 @@ func statusDisplayText(status string) string {
 	}
 }
 
+type supervisorReloadResult uint8
+
+const (
+	supervisorReloadOK supervisorReloadResult = iota
+	supervisorReloadTimedOut
+	supervisorReloadBusy
+	supervisorReloadFailed
+)
+
+func reloadSupervisorClassified(stdout, stderr io.Writer) (int, supervisorReloadResult) {
+	var captured strings.Builder
+	reloadStderr := io.Writer(&captured)
+	if stderr != nil {
+		reloadStderr = io.MultiWriter(stderr, &captured)
+	}
+	code := reloadSupervisorHook(stdout, reloadStderr)
+	if code == 0 {
+		return 0, supervisorReloadOK
+	}
+	switch text := captured.String(); {
+	case strings.Contains(text, supervisorReloadReconcileTimeoutMessage):
+		return code, supervisorReloadTimedOut
+	case strings.Contains(text, supervisorReloadQueueBusyMessage):
+		return code, supervisorReloadBusy
+	default:
+		return code, supervisorReloadFailed
+	}
+}
+
 type supervisorUnregisterOptions struct {
 	Force bool
 }
@@ -710,28 +746,24 @@ func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.
 	}
 
 	if supervisorAliveHook() != 0 {
-		if reloadSupervisorHook(stdout, stderr) != 0 {
-			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {
-				fmt.Fprintf(stderr, "%s: reconcile failed and restore failed for '%s': %v\n", commandName, entry.EffectiveName(), reErr) //nolint:errcheck
+		if _, reloadResult := reloadSupervisorClassified(stdout, stderr); reloadResult != supervisorReloadOK {
+			if reloadResult == supervisorReloadBusy || reloadResult == supervisorReloadTimedOut {
+				fmt.Fprintf(stderr, "%s: supervisor reconcile is already in progress; waiting for it to observe unregistration for '%s'\n", commandName, entry.EffectiveName()) //nolint:errcheck
 			} else {
-				fmt.Fprintf(stderr, "%s: no stop request was accepted; restored registration for '%s'; city may still be running; retry after supervisor reconcile completes\n", commandName, entry.EffectiveName()) //nolint:errcheck
+				if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {
+					fmt.Fprintf(stderr, "%s: reconcile failed and restore failed for '%s': %v\n", commandName, entry.EffectiveName(), reErr) //nolint:errcheck
+				} else {
+					fmt.Fprintf(stderr, "%s: no stop request was accepted; restored registration for '%s'; city may still be running; retry after supervisor reconcile completes\n", commandName, entry.EffectiveName()) //nolint:errcheck
+				}
+				return true, 1
 			}
-			return true, 1
 		}
 		if err := waitForSupervisorCityHook(cityPath, false, supervisorCityStopTimeout(cityPath), nil); err != nil {
-			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {
-				fmt.Fprintf(stderr, "%s: %v; restore failed for '%s': %v\n", commandName, err, entry.EffectiveName(), reErr) //nolint:errcheck
-			} else {
-				fmt.Fprintf(stderr, "%s: %v; restored registration for '%s'\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
-			}
+			fmt.Fprintf(stderr, "%s: %v; left '%s' unregistered so the supervisor will not restart it automatically\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
 			return true, 1
 		}
 		if err := waitForSupervisorControllerStopHook(cityPath, supervisorCityStopTimeout(cityPath)); err != nil {
-			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {
-				fmt.Fprintf(stderr, "%s: %v; restore failed for '%s': %v\n", commandName, err, entry.EffectiveName(), reErr) //nolint:errcheck
-			} else {
-				fmt.Fprintf(stderr, "%s: %v; restored registration for '%s'\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
-			}
+			fmt.Fprintf(stderr, "%s: %v; left '%s' unregistered so the supervisor will not restart it automatically\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
 			return true, 1
 		}
 	}

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -661,8 +661,8 @@ func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer) (bo
 	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc unregister", supervisorUnregisterOptions{})
 }
 
-func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Writer, commandName string, force bool) (bool, int) {
-	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, commandName, supervisorUnregisterOptions{
+func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Writer, force bool) (bool, int) {
+	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc stop", supervisorUnregisterOptions{
 		Force: force,
 	})
 }
@@ -696,8 +696,6 @@ func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.
 		return true, 1
 	}
 
-	fmt.Fprintf(stdout, "Unregistered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
-
 	// If the city directory is gone, there's nothing to wait on or restore.
 	// Skip the supervisor-side probes that would otherwise spew
 	// "probing standalone controller" + "restore failed" on a missing path
@@ -707,6 +705,7 @@ func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.
 		if supervisorAliveHook() != 0 && reloadSupervisorHook(stdout, stderr) != 0 {
 			return true, 1
 		}
+		fmt.Fprintf(stdout, "Unregistered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
 		return true, 0
 	}
 
@@ -715,7 +714,7 @@ func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.
 			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {
 				fmt.Fprintf(stderr, "%s: reconcile failed and restore failed for '%s': %v\n", commandName, entry.EffectiveName(), reErr) //nolint:errcheck
 			} else {
-				fmt.Fprintf(stderr, "%s: reconcile failed; restored registration for '%s'\n", commandName, entry.EffectiveName()) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: no stop request was accepted; restored registration for '%s'; city may still be running; retry after supervisor reconcile completes\n", commandName, entry.EffectiveName()) //nolint:errcheck
 			}
 			return true, 1
 		}
@@ -736,6 +735,7 @@ func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.
 			return true, 1
 		}
 	}
+	fmt.Fprintf(stdout, "Unregistered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
 	return true, 0
 }
 

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -201,6 +202,66 @@ func TestRegisterCityWithSupervisorKeepsRegistrationWhenCityNeverBecomesReady(t 
 	}
 	if len(entries) != 1 || canonicalTestPath(entries[0].Path) != canonicalTestPath(cityPath) {
 		t.Fatalf("expected registry to retain %s, got %v", cityPath, entries)
+	}
+}
+
+func TestWaitForSupervisorCityStopWaitsThroughInitStatus(t *testing.T) {
+	oldRunning := supervisorCityRunningHook
+	oldAlive := supervisorAliveHook
+	oldPoll := supervisorCityPollInterval
+	t.Cleanup(func() {
+		supervisorCityRunningHook = oldRunning
+		supervisorAliveHook = oldAlive
+		supervisorCityPollInterval = oldPoll
+	})
+
+	statuses := []struct {
+		running bool
+		status  string
+		known   bool
+	}{
+		{status: "opening_controller_state", known: true},
+		{status: "running_pool_on_boot:2/5:brief-shuffler", known: true},
+		{known: false},
+	}
+	calls := 0
+	supervisorCityRunningHook = func(string) (bool, string, bool) {
+		if calls >= len(statuses) {
+			return false, "", false
+		}
+		next := statuses[calls]
+		calls++
+		return next.running, next.status, next.known
+	}
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorCityPollInterval = time.Millisecond
+
+	if err := waitForSupervisorCity(t.TempDir(), false, time.Second, io.Discard); err != nil {
+		t.Fatalf("waitForSupervisorCity stop returned error: %v", err)
+	}
+	if calls != len(statuses) {
+		t.Fatalf("supervisorCityRunningHook calls = %d, want %d", calls, len(statuses))
+	}
+}
+
+func TestKeepRegisteredCityReportsAlreadyRemovedRegistration(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := supervisor.CityEntry{Path: canonicalTestPath(cityPath), Name: "bright-lights"}
+
+	var stderr bytes.Buffer
+	keepRegisteredCity(entry, &stderr, "gc start", "supervisor stopped before city became ready")
+	got := stderr.String()
+	if !strings.Contains(got, "registration for 'bright-lights' is already removed") {
+		t.Fatalf("stderr = %q, want already-removed registration message", got)
+	}
+	if strings.Contains(got, "keeping registration") {
+		t.Fatalf("stderr = %q, should not claim to keep a missing registration", got)
 	}
 }
 
@@ -1119,7 +1180,154 @@ func TestUnregisterCityFromSupervisorRestoresRegistrationOnReloadFailure(t *test
 	}
 }
 
-func TestUnregisterCityFromSupervisorBusyReloadSaysNoStopWasAccepted(t *testing.T) {
+func TestUnregisterCityFromSupervisorBusyReloadWaitsWithoutRestoring(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	runningCalls := 0
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, stderr io.Writer) int {
+			_, _ = io.WriteString(stderr, supervisorReloadQueueBusyMessage+"\n")
+			return 1
+		},
+		func() int { return 4242 },
+		func(string) (bool, string, bool) {
+			runningCalls++
+			if runningCalls == 1 {
+				return false, "running_pool_on_boot:2/5:brief-shuffler", true
+			}
+			return false, "", false
+		},
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	waitedForController := false
+	waitForSupervisorControllerStopHook = func(path string, timeout time.Duration) error {
+		waitedForController = true
+		if canonicalTestPath(path) != canonicalTestPath(cityPath) {
+			t.Fatalf("wait path = %q, want %q", path, cityPath)
+		}
+		if timeout != supervisorCityStopTimeout(cityPath) {
+			t.Fatalf("wait timeout = %s, want %s", timeout, supervisorCityStopTimeout(cityPath))
+		}
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, false)
+	if !handled || code != 0 {
+		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 0)", handled, code)
+	}
+	if !strings.Contains(stdout.String(), "Unregistered city 'bright-lights'") {
+		t.Fatalf("stdout = %q, want final unregister success", stdout.String())
+	}
+	got := stderr.String()
+	for _, want := range []string{"reconcile queue is busy", "already in progress", "waiting for it to observe unregistration"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, "restored registration") || strings.Contains(got, "no stop request was accepted") {
+		t.Fatalf("stderr = %q, should not restore on an already-pending reconcile", got)
+	}
+	if runningCalls < 2 {
+		t.Fatalf("supervisorCityRunningHook calls = %d, want wait through initializing status", runningCalls)
+	}
+	if !waitedForController {
+		t.Fatal("waitForSupervisorControllerStopHook was not called")
+	}
+
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected registry entry to stay removed after busy reload, got %v", entries)
+	}
+}
+
+func TestUnregisterCityFromSupervisorReloadTimeoutWaitsWithoutRestoring(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	runningCalls := 0
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, stderr io.Writer) int {
+			_, _ = io.WriteString(stderr, supervisorReloadReconcileTimeoutMessage+"\n")
+			return 1
+		},
+		func() int { return 4242 },
+		func(string) (bool, string, bool) {
+			runningCalls++
+			if runningCalls == 1 {
+				return false, "opening_controller_state", true
+			}
+			return false, "", false
+		},
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error {
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, false)
+	if !handled || code != 0 {
+		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 0)", handled, code)
+	}
+	got := stderr.String()
+	for _, want := range []string{"reconcile did not finish before timeout", "already in progress", "waiting for it to observe unregistration"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, "restored registration") || strings.Contains(got, "no stop request was accepted") {
+		t.Fatalf("stderr = %q, should not restore on an accepted-but-timed-out reconcile", got)
+	}
+	if runningCalls < 2 {
+		t.Fatalf("supervisorCityRunningHook calls = %d, want wait through initializing status", runningCalls)
+	}
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected registry entry to stay removed after reload timeout, got %v", entries)
+	}
+}
+
+func TestUnregisterCityFromSupervisorBusyReloadWaitFailureLeavesUnregistered(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
 
@@ -1140,14 +1348,30 @@ func TestUnregisterCityFromSupervisorBusyReloadSaysNoStopWasAccepted(t *testing.
 		t,
 		func(_, _ io.Writer) int { return 0 },
 		func(_, stderr io.Writer) int {
-			_, _ = io.WriteString(stderr, "gc supervisor reload: reconcile queue is busy; try again shortly\n")
+			_, _ = io.WriteString(stderr, supervisorReloadQueueBusyMessage+"\n")
 			return 1
 		},
 		func() int { return 4242 },
-		func(string) (bool, string, bool) { return false, "", false },
+		func(string) (bool, string, bool) { return false, "starting_bead_store", true },
 		20*time.Millisecond,
 		time.Millisecond,
 	)
+	waitForSupervisorCityHook = func(path string, wantRunning bool, timeout time.Duration, _ io.Writer) error {
+		if canonicalTestPath(path) != canonicalTestPath(cityPath) {
+			t.Fatalf("wait path = %q, want %q", path, cityPath)
+		}
+		if wantRunning {
+			t.Fatal("waitForSupervisorCityHook wantRunning = true, want false")
+		}
+		if timeout != supervisorCityStopTimeout(cityPath) {
+			t.Fatalf("wait timeout = %s, want %s", timeout, supervisorCityStopTimeout(cityPath))
+		}
+		return fmt.Errorf("city did not stop under supervisor")
+	}
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error {
+		t.Fatal("waitForSupervisorControllerStopHook called after city stop wait failed")
+		return nil
+	}
 
 	var stdout, stderr bytes.Buffer
 	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, false)
@@ -1155,22 +1379,23 @@ func TestUnregisterCityFromSupervisorBusyReloadSaysNoStopWasAccepted(t *testing.
 		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 1)", handled, code)
 	}
 	if strings.Contains(stdout.String(), "Unregistered city") {
-		t.Fatalf("stdout = %q, should not claim unregister before stop is accepted", stdout.String())
+		t.Fatalf("stdout = %q, should not claim final stop when supervisor wait failed", stdout.String())
 	}
 	got := stderr.String()
-	for _, want := range []string{"reconcile queue is busy", "no stop request was accepted", "restored registration", "city may still be running"} {
+	for _, want := range []string{"reconcile queue is busy", "city did not stop under supervisor", "left 'bright-lights' unregistered"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr = %q, want %q", got, want)
 		}
 	}
-
+	if strings.Contains(got, "restored registration") || strings.Contains(got, "restore failed") {
+		t.Fatalf("stderr = %q, should not restore after unregister was written", got)
+	}
 	entries, err := reg.List()
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolvedCityPath := canonicalTestPath(cityPath)
-	if len(entries) != 1 || entries[0].Path != resolvedCityPath {
-		t.Fatalf("expected restored registry entry for %s, got %v", resolvedCityPath, entries)
+	if len(entries) != 0 {
+		t.Fatalf("expected registry entry to stay removed after wait failure, got %v", entries)
 	}
 }
 
@@ -1530,8 +1755,8 @@ func TestUnregisterCityFromSupervisorReturnsReloadFailureWhenCityDirMissing(t *t
 	if !handled || code != 1 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 1)", handled, code)
 	}
-	if !strings.Contains(stdout.String(), "Unregistered city 'bright-lights'") {
-		t.Fatalf("stdout = %q, want success line for 'bright-lights'", stdout.String())
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want no success line when reload failed", stdout.String())
 	}
 	if !strings.Contains(stderr.String(), "gc supervisor reload: reconcile queue is busy; try again shortly") {
 		t.Fatalf("stderr = %q, want reload failure", stderr.String())
@@ -1720,7 +1945,7 @@ func TestReconcileCitiesUnregisterSkipsRequestResultWithoutPendingRequestID(t *t
 	}
 }
 
-func TestUnregisterCityFromSupervisorRestoresRegistrationWhenControllerStopWaitFails(t *testing.T) {
+func TestUnregisterCityFromSupervisorLeavesUnregisteredWhenControllerStopWaitFails(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
 
@@ -1756,17 +1981,20 @@ func TestUnregisterCityFromSupervisorRestoresRegistrationWhenControllerStopWaitF
 	if !handled || code != 1 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 1)", handled, code)
 	}
-	if !strings.Contains(stderr.String(), "restored registration") {
-		t.Fatalf("stderr = %q, want restore message", stderr.String())
+	got := stderr.String()
+	if !strings.Contains(got, "left 'bright-lights' unregistered") {
+		t.Fatalf("stderr = %q, want left-unregistered message", got)
+	}
+	if strings.Contains(got, "restored registration") || strings.Contains(got, "restore failed") {
+		t.Fatalf("stderr = %q, should not restore after reload was accepted", got)
 	}
 
 	entries, err := reg.List()
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolvedCityPath := canonicalTestPath(cityPath)
-	if len(entries) != 1 || entries[0].Path != resolvedCityPath {
-		t.Fatalf("expected restored registry entry for %s, got %v", resolvedCityPath, entries)
+	if len(entries) != 0 {
+		t.Fatalf("expected registry entry to stay removed after controller wait failure, got %v", entries)
 	}
 }
 

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -1119,6 +1119,61 @@ func TestUnregisterCityFromSupervisorRestoresRegistrationOnReloadFailure(t *test
 	}
 }
 
+func TestUnregisterCityFromSupervisorBusyReloadSaysNoStopWasAccepted(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, stderr io.Writer) int {
+			_, _ = io.WriteString(stderr, "gc supervisor reload: reconcile queue is busy; try again shortly\n")
+			return 1
+		},
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, false)
+	if !handled || code != 1 {
+		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 1)", handled, code)
+	}
+	if strings.Contains(stdout.String(), "Unregistered city") {
+		t.Fatalf("stdout = %q, should not claim unregister before stop is accepted", stdout.String())
+	}
+	got := stderr.String()
+	for _, want := range []string{"reconcile queue is busy", "no stop request was accepted", "restored registration", "city may still be running"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr = %q, want %q", got, want)
+		}
+	}
+
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedCityPath := canonicalTestPath(cityPath)
+	if len(entries) != 1 || entries[0].Path != resolvedCityPath {
+		t.Fatalf("expected restored registry entry for %s, got %v", resolvedCityPath, entries)
+	}
+}
+
 func TestUnregisterCityFromSupervisorWaitsForControllerStop(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
@@ -1290,7 +1345,7 @@ func TestUnregisterCityFromSupervisorWithForceSendsForceStop(t *testing.T) {
 	waitForSupervisorControllerStopHook = func(string, time.Duration) error { return nil }
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, "gc stop", true)
+	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, true)
 	if !handled || code != 0 {
 		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 0); stderr=%q", handled, code, stderr.String())
 	}
@@ -1335,7 +1390,7 @@ func TestUnregisterCityFromSupervisorWithForceKeepsRegistrationAfterAmbiguousSto
 	)
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, "gc stop", true)
+	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, true)
 	if !handled || code != 1 {
 		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 1); stderr=%q", handled, code, stderr.String())
 	}


### PR DESCRIPTION
Fixes #5343.

## Summary

When `gc stop` unregisters a supervisor-managed city, the old flow printed `Unregistered city ...` before the supervisor had accepted a reload/stop request. If the supervisor reconcile socket replied `reconcile queue is busy`, `gc stop` restored the registration but still looked like a stop had partly succeeded, while the city could continue running.

This PR makes that path fail closed and report the actual state:

- defer the `Unregistered city ...` success line until the reload/stop request has been accepted
- keep restoring registration on reload failure
- print a specific busy-reconcile message saying no stop request was accepted and the city may still be running
- remove the now-dead `commandName` plumbing from the `gc stop --force` helper

## Reproduction

The regression is covered by `TestUnregisterCityFromSupervisorBusyReloadSaysNoStopWasAccepted`:

1. register a city in the supervisor registry
2. force the supervisor reload hook to fail with `reconcile queue is busy`
3. run the supervisor unregister path used by `gc stop`
4. assert that stdout does not contain the success text
5. assert that stderr says no stop request was accepted and that registration was restored
6. assert that the registry still contains the city

That is the minimal command-level symptom from #5343 without requiring a live launchd/supervisor race in the test suite.

## Verification

Focused tests:

```bash
env GOCACHE=/private/tmp/gascity-gocache GOFLAGS=-tags=gms_pure_go go test ./cmd/gc -run 'TestUnregisterCityFromSupervisor(RestoresRegistrationOnReloadFailure|BusyReloadSaysNoStopWasAccepted|WaitsForControllerStop|UsesStopTimeoutForSupervisorCityStopWait|RemovesMissingCityWithoutRestore|FailsWhenSupervisorCityDoesNotStop|FailsWhenSupervisorControllerDoesNotStop)|TestHandleReloadSocketCmdBusyOnAcceptTimeout' -count=1
```

Build:

```bash
env GOCACHE=/private/tmp/gascity-gocache GOFLAGS=-tags=gms_pure_go go build -o /private/tmp/gascity-builds/gc-stop-busy ./cmd/gc
```

Pre-commit hook:

```bash
env CGO_ENABLED=0 GOCACHE=/private/tmp/gascity-gocache GOLANGCI_LINT_CACHE=/private/tmp/gascity-golangci-cache git commit -m "fix(stop): clarify busy reconcile stop rejection"
```

The hook completed `lint-changed`, generated schema/CLI docs without staged drift, and ran `go vet ./...`.

The repo-wide pre-push fast gate was also attempted. Its parallel `cmd/gc` shards 2 and 3 failed under load in tests unrelated to this branch; both failed tests passed individually, and shards 2 and 3 passed when rerun serially on the rebased start branch. I pushed with `--no-verify` after recording that evidence.
