### PR TITLE
fix(sessionlog): seed codex tail model from the nearest preceding turn_context

### DIFF
--- a/internal/sessionlog/codex_usage.go
+++ b/internal/sessionlog/codex_usage.go
@@ -242,12 +242,16 @@ func boundedContextPercentage(inputTokens, contextWindow int) int {
 //
 // Model comes from the latest preceding turn_context payload.model; when no
 // turn_context falls inside the tail window it is seeded from the session's
-// first turn_context via a bounded head scan (codexHeadModel), since the model
-// is constant across a rollout — this keeps long-lived sessions, whose
-// turn_context has long scrolled past the tail window, from minting model facts
-// with an empty (and therefore unpriced) model. It is empty only when no
-// turn_context exists within the head-scan cap (token_count itself carries no
-// model). MessageID is the cumulative-total identity
+// first turn_context via a bounded head scan (codexHeadModel). A codex rollout
+// normally re-announces one model on every turn_context, so that first model
+// prices the tail — this keeps long-lived sessions, whose turn_context has long
+// scrolled past the tail window, from minting model facts with an empty (and
+// therefore unpriced) model. When the head scan instead observes two distinct
+// models it declines to guess and seeds empty, so a genuine mid-rollout switch
+// falls back to the honest unpriced floor rather than a possibly-wrong price
+// (see codexHeadModel and the mid-switch duplicate-collapse handling below). The
+// seed is empty when no turn_context exists within the head-scan cap
+// (token_count itself carries no model). MessageID is the cumulative-total identity
 // ("total:<total_tokens>") so the exact-duplicate token_count emissions the
 // CLI produces collapse to a single entry (the last observed wins, except a
 // first-observed non-empty Model is kept — a duplicate re-emitted after a
@@ -349,19 +353,25 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 // seed existed.
 const codexModelSeedScanCap = 1 << 20 // 1 MiB
 
-// codexHeadModel scans from the start of the rollout for the first
-// turn_context.model, returning "" when none is found within
-// codexModelSeedScanCap bytes. The model is constant across a codex rollout
-// (every turn_context re-announces the same model), so the first occurrence is
-// the session's model; it seeds ExtractCodexTailUsage for the common case where
-// the turn_context has scrolled out of the tail window. Bounded and early-exit,
-// so a long session never re-reads its whole transcript.
+// codexHeadModel scans from the start of the rollout for the session model,
+// returning "" when none is found within codexModelSeedScanCap bytes. A codex
+// rollout normally re-announces the same model on every turn_context, so the
+// first occurrence names the session's model; it seeds ExtractCodexTailUsage for
+// the common case where the turn_context has scrolled out of the tail window. To
+// avoid mispricing a rollout that DID switch models before the tail, the scan
+// keeps reading within the cap and returns "" as soon as it observes a second,
+// distinct turn_context.model: an ambiguous head cannot safely name one model,
+// so it falls back to the honest unpriced floor rather than guessing the first.
+// The scan is bounded by codexModelSeedScanCap, so a long session never re-reads
+// its whole transcript; a switch that occurs after the cap but before the tail
+// window is not observable here and remains seeded with the first model.
 func codexHeadModel(r io.ReadSeeker) (string, error) {
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return "", err
 	}
 	scanner := bufio.NewScanner(io.LimitReader(r, codexModelSeedScanCap))
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	seed := ""
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -378,13 +388,25 @@ func codexHeadModel(r io.ReadSeeker) (string, error) {
 		if err := json.Unmarshal(entry.Payload, &payload); err != nil {
 			continue
 		}
-		if payload.Model != "" {
-			return payload.Model, nil
+		if payload.Model == "" {
+			continue
+		}
+		if seed == "" {
+			seed = payload.Model
+			continue
+		}
+		if payload.Model != seed {
+			// A genuine mid-rollout switch within the head window: the head cannot
+			// name a single session model, so seed empty and let pricing fall back
+			// to the unpriced floor instead of a possibly-wrong first model.
+			return "", nil
 		}
 	}
 	// A truncated final line at the cap boundary is expected and tolerated (same
-	// posture as splitLines); scanner.Err() is intentionally ignored.
-	return "", nil
+	// posture as splitLines); an oversized pre-turn_context line likewise stops
+	// the scan early and degrades to an empty seed (the pre-seed behavior).
+	// scanner.Err() is intentionally ignored.
+	return seed, nil
 }
 
 // ExtractCodexTailUsageFromSearchPaths reads codex tail usage only after

--- a/internal/sessionlog/codex_usage.go
+++ b/internal/sessionlog/codex_usage.go
@@ -241,17 +241,15 @@ func boundedContextPercentage(inputTokens, contextWindow int) int {
 //   - CacheCreationTokens = 0 (codex reports no cache-write tokens)
 //
 // Model comes from the latest preceding turn_context payload.model; when no
-// turn_context falls inside the tail window it is seeded from the session's
-// first turn_context via a bounded head scan (codexHeadModel). A codex rollout
-// normally re-announces one model on every turn_context, so that first model
-// prices the tail — this keeps long-lived sessions, whose turn_context has long
-// scrolled past the tail window, from minting model facts with an empty (and
-// therefore unpriced) model. When the head scan instead observes two distinct
-// models it declines to guess and seeds empty, so a genuine mid-rollout switch
-// falls back to the honest unpriced floor rather than a possibly-wrong price
-// (see codexHeadModel and the mid-switch duplicate-collapse handling below). The
-// seed is empty when no turn_context exists within the head-scan cap
-// (token_count itself carries no model). MessageID is the cumulative-total identity
+// turn_context falls inside the tail window it is recovered from the nearest
+// turn_context preceding that window by a bounded backward scan
+// (codexPrecedingModel). That nearest preceding announcement is the model in
+// effect for the tail, so it prices the tail — this keeps long-lived sessions,
+// whose turn_context has long scrolled past the tail window, from minting model
+// facts with an empty (and therefore unpriced) model, and it honors a
+// mid-rollout model switch wherever it happened. The recovered model is empty
+// when no turn_context falls within codexModelSeedScanBudget bytes before the
+// window (token_count itself carries no model). MessageID is the cumulative-total identity
 // ("total:<total_tokens>") so the exact-duplicate token_count emissions the
 // CLI produces collapse to a single entry (the last observed wins, except a
 // first-observed non-empty Model is kept — a duplicate re-emitted after a
@@ -268,12 +266,12 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
 
-	// Seed the model from the session's first turn_context before scanning the
-	// tail: in a long-lived session the turn_context has scrolled out of the
-	// tail window, so without this seed every recent invocation records an empty
-	// model. Runs before readTail because readTail leaves the read offset at the
-	// tail; codexHeadModel re-seeks to the start itself.
-	seedModel, err := codexHeadModel(f)
+	// Recover the model in effect for the tail before scanning it: in a
+	// long-lived session the turn_context has scrolled out of the tail window,
+	// so without this seed every recent invocation records an empty model. Runs
+	// before readTail because readTail leaves the read offset at the tail;
+	// codexPrecedingModel re-seeks itself.
+	seedModel, err := codexPrecedingModel(f)
 	if err != nil {
 		return nil, err
 	}
@@ -345,34 +343,53 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	return usages, nil
 }
 
-// codexModelSeedScanCap bounds how far into a rollout codexHeadModel scans for
-// the session's model. The first turn_context sits within the first ~60 KiB of
-// real rollouts (session_meta plus the opening turn's context); 1 MiB is
-// generous headroom while keeping the scan bounded for multi-MB transcripts. A
-// model not found within the cap falls back to empty — no worse than before the
-// seed existed.
-const codexModelSeedScanCap = 1 << 20 // 1 MiB
+// codexModelSeedScanBudget bounds how far back from the tail window
+// codexPrecedingModel scans for the model in effect there. Real rollouts
+// re-announce the model on every turn_context, so the nearest preceding one
+// normally sits within a few KiB of the window; 1 MiB is generous headroom
+// while keeping the backward scan bounded for multi-MB transcripts. A model not
+// found within the budget falls back to empty — no worse than before the seed
+// existed.
+const codexModelSeedScanBudget = 1 << 20 // 1 MiB
 
-// codexHeadModel scans from the start of the rollout for the session model,
-// returning "" when none is found within codexModelSeedScanCap bytes. A codex
-// rollout normally re-announces the same model on every turn_context, so the
-// first occurrence names the session's model; it seeds ExtractCodexTailUsage for
-// the common case where the turn_context has scrolled out of the tail window. To
-// avoid mispricing a rollout that DID switch models before the tail, the scan
-// keeps reading within the cap and returns "" as soon as it observes a second,
-// distinct turn_context.model: an ambiguous head cannot safely name one model,
-// so it falls back to the honest unpriced floor rather than guessing the first.
-// The scan is bounded by codexModelSeedScanCap, so a long session never re-reads
-// its whole transcript; a switch that occurs after the cap but before the tail
-// window is not observable here and remains seeded with the first model.
-func codexHeadModel(r io.ReadSeeker) (string, error) {
-	if _, err := r.Seek(0, io.SeekStart); err != nil {
+// codexPrecedingModel returns the model named by the last turn_context that
+// precedes the tail window, which is the model in effect for the tail when no
+// turn_context falls inside the window itself. It returns "" when the tail
+// window already covers the whole file (the in-window scan then sees every
+// turn_context and needs no seed) and when no turn_context appears within
+// codexModelSeedScanBudget bytes before the window.
+//
+// Taking the NEAREST preceding announcement rather than the session's first
+// makes the result right-or-empty by construction: a mid-rollout model switch
+// at any point before the window is honored, so the tail is never labeled with
+// a model the session has already switched away from.
+func codexPrecedingModel(r io.ReadSeeker) (string, error) {
+	size, err := r.Seek(0, io.SeekEnd)
+	if err != nil {
 		return "", err
 	}
-	scanner := bufio.NewScanner(io.LimitReader(r, codexModelSeedScanCap))
+	windowStart := size - tailChunkSize
+	if windowStart <= 0 {
+		return "", nil
+	}
+	rangeStart := windowStart - codexModelSeedScanBudget
+	if rangeStart < 0 {
+		rangeStart = 0
+	}
+	if _, err := r.Seek(rangeStart, io.SeekStart); err != nil {
+		return "", err
+	}
+	scanner := bufio.NewScanner(io.LimitReader(r, windowStart-rangeStart))
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
-	seed := ""
+	// A budget-truncated range begins mid-line; drop that leading partial line
+	// the way readTailWindow's startsMidLine handling does.
+	skipFirst := rangeStart > 0
+	model := ""
 	for scanner.Scan() {
+		if skipFirst {
+			skipFirst = false
+			continue
+		}
 		line := scanner.Bytes()
 		if len(line) == 0 {
 			continue
@@ -388,25 +405,15 @@ func codexHeadModel(r io.ReadSeeker) (string, error) {
 		if err := json.Unmarshal(entry.Payload, &payload); err != nil {
 			continue
 		}
-		if payload.Model == "" {
-			continue
-		}
-		if seed == "" {
-			seed = payload.Model
-			continue
-		}
-		if payload.Model != seed {
-			// A genuine mid-rollout switch within the head window: the head cannot
-			// name a single session model, so seed empty and let pricing fall back
-			// to the unpriced floor instead of a possibly-wrong first model.
-			return "", nil
+		if payload.Model != "" {
+			model = payload.Model
 		}
 	}
-	// A truncated final line at the cap boundary is expected and tolerated (same
-	// posture as splitLines); an oversized pre-turn_context line likewise stops
+	// A line straddling the window boundary is truncated here and fails to
+	// parse; the in-window scan reads it whole. An oversized line likewise stops
 	// the scan early and degrades to an empty seed (the pre-seed behavior).
-	// scanner.Err() is intentionally ignored.
-	return seed, nil
+	// scanner.Err() is intentionally ignored, matching splitLines.
+	return model, nil
 }
 
 // ExtractCodexTailUsageFromSearchPaths reads codex tail usage only after

--- a/internal/sessionlog/codex_usage.go
+++ b/internal/sessionlog/codex_usage.go
@@ -248,8 +248,9 @@ func boundedContextPercentage(inputTokens, contextWindow int) int {
 // whose turn_context has long scrolled past the tail window, from minting model
 // facts with an empty (and therefore unpriced) model, and it honors a
 // mid-rollout model switch wherever it happened. The recovered model is empty
-// when no turn_context falls within codexModelSeedScanBudget bytes before the
-// window (token_count itself carries no model). MessageID is the cumulative-total identity
+// when no turn_context is in reach of that scan or the scan cannot complete —
+// an unpriced model fact is a truer report than a stale one, and token_count
+// itself carries no model. MessageID is the cumulative-total identity
 // ("total:<total_tokens>") so the exact-duplicate token_count emissions the
 // CLI produces collapse to a single entry (the last observed wins, except a
 // first-observed non-empty Model is kept — a duplicate re-emitted after a
@@ -266,17 +267,24 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
 
-	// Recover the model in effect for the tail before scanning it: in a
-	// long-lived session the turn_context has scrolled out of the tail window,
-	// so without this seed every recent invocation records an empty model. Runs
-	// before readTail because readTail leaves the read offset at the tail;
-	// codexPrecedingModel re-seeks itself.
-	seedModel, err := codexPrecedingModel(f)
+	// One size snapshot feeds both windows. The seed and the tail read are
+	// adjacent halves of the same file, so deriving them from separate SeekEnd
+	// calls would leave the bytes appended in between — these rollouts are
+	// appended to while they are read — inside neither.
+	size, err := f.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, err
 	}
 
-	data, _, err := readTail(f, tailChunkSize)
+	// Recover the model in effect for the tail before scanning it: in a
+	// long-lived session the turn_context has scrolled out of the tail window,
+	// so without this seed every recent invocation records an empty model.
+	seedModel, err := codexPrecedingModel(f, size-tailChunkSize)
+	if err != nil {
+		return nil, err
+	}
+
+	data, _, err := readTailAt(f, size, tailChunkSize)
 	if err != nil {
 		return nil, err
 	}
@@ -301,29 +309,8 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 			}
 			continue
 		}
-		if entry.Type != "event_msg" || payload.Type != "token_count" || payload.Info == nil {
-			continue
-		}
-		last := payload.Info.LastTokenUsage
-		input := last.InputTokens - last.CachedInputTokens
-		if input < 0 {
-			input = 0
-		}
-		contextWindowTokens := 0
-		if payload.Info.ModelContextWindow != nil {
-			contextWindowTokens = *payload.Info.ModelContextWindow
-		}
-		u := TailUsage{
-			EntryUUID:           entry.Timestamp,
-			MessageID:           fmt.Sprintf("total:%d", payload.Info.TotalTokenUsage.TotalTokens),
-			Model:               turnModel,
-			InputTokens:         input,
-			OutputTokens:        last.OutputTokens,
-			ReasoningTokens:     last.ReasoningOutputTokens,
-			CacheReadTokens:     last.CachedInputTokens,
-			ContextWindowTokens: contextWindowTokens,
-		}
-		if u.InputTokens <= 0 && u.OutputTokens <= 0 && u.ReasoningTokens <= 0 && u.CacheReadTokens <= 0 {
+		u, ok := codexTokenCountUsage(entry, payload, turnModel)
+		if !ok {
 			continue
 		}
 		if i, seen := byMessageID[u.MessageID]; seen {
@@ -343,6 +330,39 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	return usages, nil
 }
 
+// codexTokenCountUsage converts a token_count entry into a TailUsage labeled
+// with model, the model in effect when the invocation ran. It reports false for
+// an entry that carries no usable per-call usage: a different entry type, a
+// rate-limit-only refresh (null info), or an all-zero per-call usage.
+func codexTokenCountUsage(entry codexRawEntry, payload codexUsagePayload, model string) (TailUsage, bool) {
+	if entry.Type != "event_msg" || payload.Type != "token_count" || payload.Info == nil {
+		return TailUsage{}, false
+	}
+	last := payload.Info.LastTokenUsage
+	input := last.InputTokens - last.CachedInputTokens
+	if input < 0 {
+		input = 0
+	}
+	contextWindowTokens := 0
+	if payload.Info.ModelContextWindow != nil {
+		contextWindowTokens = *payload.Info.ModelContextWindow
+	}
+	u := TailUsage{
+		EntryUUID:           entry.Timestamp,
+		MessageID:           fmt.Sprintf("total:%d", payload.Info.TotalTokenUsage.TotalTokens),
+		Model:               model,
+		InputTokens:         input,
+		OutputTokens:        last.OutputTokens,
+		ReasoningTokens:     last.ReasoningOutputTokens,
+		CacheReadTokens:     last.CachedInputTokens,
+		ContextWindowTokens: contextWindowTokens,
+	}
+	if u.InputTokens <= 0 && u.OutputTokens <= 0 && u.ReasoningTokens <= 0 && u.CacheReadTokens <= 0 {
+		return TailUsage{}, false
+	}
+	return u, true
+}
+
 // codexModelSeedScanBudget bounds how far back from the tail window
 // codexPrecedingModel scans for the model in effect there. Real rollouts
 // re-announce the model on every turn_context, so the nearest preceding one
@@ -352,23 +372,32 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 // existed.
 const codexModelSeedScanBudget = 1 << 20 // 1 MiB
 
-// codexPrecedingModel returns the model named by the last turn_context that
-// precedes the tail window, which is the model in effect for the tail when no
-// turn_context falls inside the window itself. It returns "" when the tail
-// window already covers the whole file (the in-window scan then sees every
-// turn_context and needs no seed) and when no turn_context appears within
-// codexModelSeedScanBudget bytes before the window.
+// codexSeedScanLineMax bounds the longest JSONL line codexPrecedingModel can
+// read, matching the line budget splitLines uses for the tail window.
+const codexSeedScanLineMax = 256 * 1024
+
+// codexPrecedingModel returns the model named by the last turn_context starting
+// before windowStart, the offset the tail window begins at. That is the model in
+// effect for the tail when no turn_context falls inside the window itself. The
+// caller passes windowStart rather than letting this re-derive it, so the seed
+// and the tail read are two views of one size snapshot: on a rollout being
+// appended to, two independent snapshots leave the bytes written in between in
+// neither window.
+//
+// It returns "" when the tail window already covers the whole file (the
+// in-window scan then sees every turn_context and needs no seed), when no
+// turn_context appears within codexModelSeedScanBudget bytes before the window,
+// and when an over-long line truncates the scan mid-range.
+//
+// A seek or read failure is not degraded that way: it is returned as an error
+// and so fails the whole extraction. That is stricter than readTailWindowAt,
+// whose preceding-byte peek swallows the same two errors and defaults to false.
+// Which contract both should keep is tracked as ga-8gku9.
 //
 // Taking the NEAREST preceding announcement rather than the session's first
-// makes the result right-or-empty by construction: a mid-rollout model switch
-// at any point before the window is honored, so the tail is never labeled with
-// a model the session has already switched away from.
-func codexPrecedingModel(r io.ReadSeeker) (string, error) {
-	size, err := r.Seek(0, io.SeekEnd)
-	if err != nil {
-		return "", err
-	}
-	windowStart := size - tailChunkSize
+// keeps a mid-rollout model switch honored: the tail is not labeled with a model
+// the session had already switched away from by the time the window starts.
+func codexPrecedingModel(r io.ReadSeeker, windowStart int64) (string, error) {
 	if windowStart <= 0 {
 		return "", nil
 	}
@@ -376,44 +405,93 @@ func codexPrecedingModel(r io.ReadSeeker) (string, error) {
 	if rangeStart < 0 {
 		rangeStart = 0
 	}
+	// The budget cut can land either inside a line or exactly on a line start,
+	// so peek the preceding byte the way readTailWindow does instead of assuming
+	// a partial line whenever the range is truncated. Only the decision is
+	// shared: readTailWindow swallows a failed peek, this returns it (ga-8gku9).
+	skipPartialFirst, err := codexStartsMidLine(r, rangeStart)
+	if err != nil {
+		return "", err
+	}
 	if _, err := r.Seek(rangeStart, io.SeekStart); err != nil {
 		return "", err
 	}
-	scanner := bufio.NewScanner(io.LimitReader(r, windowStart-rangeStart))
-	scanner.Buffer(make([]byte, 256*1024), 256*1024)
-	// A budget-truncated range begins mid-line; drop that leading partial line
-	// the way readTailWindow's startsMidLine handling does.
-	skipFirst := rangeStart > 0
+	// Read one max-line allowance past windowStart so the line straddling the
+	// boundary is consumed whole here. readTail starts at exactly windowStart
+	// with no line-boundary snapping, so the in-window scan sees only that
+	// line's suffix and cannot parse it. Lines that start at or after
+	// windowStart belong to the in-window scan and end this one.
+	scanner := bufio.NewScanner(io.LimitReader(r, windowStart-rangeStart+codexSeedScanLineMax))
+	scanner.Buffer(make([]byte, codexSeedScanLineMax), codexSeedScanLineMax)
+	consumed := int64(0)
+	scanner.Split(func(data []byte, atEOF bool) (int, []byte, error) {
+		advance, token, err := bufio.ScanLines(data, atEOF)
+		consumed += int64(advance)
+		return advance, token, err
+	})
+
 	model := ""
+	lineStart := int64(0)
 	for scanner.Scan() {
-		if skipFirst {
-			skipFirst = false
+		start := rangeStart + lineStart
+		lineStart = consumed
+		if start >= windowStart {
+			break
+		}
+		if skipPartialFirst {
+			skipPartialFirst = false
 			continue
 		}
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var entry codexRawEntry
-		if err := json.Unmarshal(line, &entry); err != nil {
-			continue
-		}
-		if entry.Type != "turn_context" {
-			continue
-		}
-		var payload codexUsagePayload
-		if err := json.Unmarshal(entry.Payload, &payload); err != nil {
-			continue
-		}
-		if payload.Model != "" {
-			model = payload.Model
+		if m := codexTurnContextModel(scanner.Bytes()); m != "" {
+			model = m
 		}
 	}
-	// A line straddling the window boundary is truncated here and fails to
-	// parse; the in-window scan reads it whole. An oversized line likewise stops
-	// the scan early and degrades to an empty seed (the pre-seed behavior).
-	// scanner.Err() is intentionally ignored, matching splitLines.
+	if scanner.Err() != nil {
+		// A line past codexSeedScanLineMax aborts the scan mid-range, so a
+		// switch announced after it is unseen. Reporting the model found before
+		// it would replace an honest unpriced $0 with a plausible wrong price
+		// that no later sweep corrects, so degrade to the empty seed instead.
+		return "", nil
+	}
 	return model, nil
+}
+
+// codexStartsMidLine reports whether offset falls inside a line rather than on a
+// line start, by peeking the byte before it.
+func codexStartsMidLine(r io.ReadSeeker, offset int64) (bool, error) {
+	if offset <= 0 {
+		return false, nil
+	}
+	if _, err := r.Seek(offset-1, io.SeekStart); err != nil {
+		return false, err
+	}
+	var prev [1]byte
+	if _, err := io.ReadFull(r, prev[:]); err != nil {
+		return false, err
+	}
+	return prev[0] != '\n', nil
+}
+
+// codexTurnContextModel returns the model a turn_context line announces, or ""
+// when the line is not a turn_context or names no model. Malformed lines are
+// tolerated silently: a scan bounded by byte offsets can begin or end inside a
+// line, matching splitLines.
+func codexTurnContextModel(line []byte) string {
+	if len(line) == 0 {
+		return ""
+	}
+	var entry codexRawEntry
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return ""
+	}
+	if entry.Type != "turn_context" {
+		return ""
+	}
+	var payload codexUsagePayload
+	if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+		return ""
+	}
+	return payload.Model
 }
 
 // ExtractCodexTailUsageFromSearchPaths reads codex tail usage only after

--- a/internal/sessionlog/codex_usage.go
+++ b/internal/sessionlog/codex_usage.go
@@ -1,8 +1,10 @@
 package sessionlog
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -238,9 +240,14 @@ func boundedContextPercentage(inputTokens, contextWindow int) int {
 //   - ReasoningTokens = last reasoning_output_tokens
 //   - CacheCreationTokens = 0 (codex reports no cache-write tokens)
 //
-// Model comes from the latest preceding turn_context payload.model — empty
-// when no turn_context falls inside the tail window (token_count itself
-// carries no model). MessageID is the cumulative-total identity
+// Model comes from the latest preceding turn_context payload.model; when no
+// turn_context falls inside the tail window it is seeded from the session's
+// first turn_context via a bounded head scan (codexHeadModel), since the model
+// is constant across a rollout — this keeps long-lived sessions, whose
+// turn_context has long scrolled past the tail window, from minting model facts
+// with an empty (and therefore unpriced) model. It is empty only when no
+// turn_context exists within the head-scan cap (token_count itself carries no
+// model). MessageID is the cumulative-total identity
 // ("total:<total_tokens>") so the exact-duplicate token_count emissions the
 // CLI produces collapse to a single entry (the last observed wins, except a
 // first-observed non-empty Model is kept — a duplicate re-emitted after a
@@ -257,6 +264,16 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
 
+	// Seed the model from the session's first turn_context before scanning the
+	// tail: in a long-lived session the turn_context has scrolled out of the
+	// tail window, so without this seed every recent invocation records an empty
+	// model. Runs before readTail because readTail leaves the read offset at the
+	// tail; codexHeadModel re-seeks to the start itself.
+	seedModel, err := codexHeadModel(f)
+	if err != nil {
+		return nil, err
+	}
+
 	data, _, err := readTail(f, tailChunkSize)
 	if err != nil {
 		return nil, err
@@ -266,7 +283,7 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	// byMessageID maps a cumulative-total identity to its index in usages so
 	// duplicate token_count emissions collapse to a single entry.
 	byMessageID := make(map[string]int)
-	var turnModel string
+	turnModel := seedModel
 	for _, line := range splitLines(data) {
 		var entry codexRawEntry
 		if err := json.Unmarshal(line, &entry); err != nil {
@@ -322,6 +339,52 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 		usages = append(usages, u)
 	}
 	return usages, nil
+}
+
+// codexModelSeedScanCap bounds how far into a rollout codexHeadModel scans for
+// the session's model. The first turn_context sits within the first ~60 KiB of
+// real rollouts (session_meta plus the opening turn's context); 1 MiB is
+// generous headroom while keeping the scan bounded for multi-MB transcripts. A
+// model not found within the cap falls back to empty — no worse than before the
+// seed existed.
+const codexModelSeedScanCap = 1 << 20 // 1 MiB
+
+// codexHeadModel scans from the start of the rollout for the first
+// turn_context.model, returning "" when none is found within
+// codexModelSeedScanCap bytes. The model is constant across a codex rollout
+// (every turn_context re-announces the same model), so the first occurrence is
+// the session's model; it seeds ExtractCodexTailUsage for the common case where
+// the turn_context has scrolled out of the tail window. Bounded and early-exit,
+// so a long session never re-reads its whole transcript.
+func codexHeadModel(r io.ReadSeeker) (string, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	scanner := bufio.NewScanner(io.LimitReader(r, codexModelSeedScanCap))
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry codexRawEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry.Type != "turn_context" {
+			continue
+		}
+		var payload codexUsagePayload
+		if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+			continue
+		}
+		if payload.Model != "" {
+			return payload.Model, nil
+		}
+	}
+	// A truncated final line at the cap boundary is expected and tolerated (same
+	// posture as splitLines); scanner.Err() is intentionally ignored.
+	return "", nil
 }
 
 // ExtractCodexTailUsageFromSearchPaths reads codex tail usage only after

--- a/internal/sessionlog/codex_usage_test.go
+++ b/internal/sessionlog/codex_usage_test.go
@@ -32,6 +32,57 @@ func codexTurnContextLine(ts, model string) string {
 	return fmt.Sprintf(`{"timestamp":%q,"type":"turn_context","payload":{"turn_id":"019d9845-45f6-70d2-86e8-53d8a44a830f","cwd":"/work/dir","current_date":"2026-04-16","timezone":"Etc/UTC","approval_policy":"never","sandbox_policy":{"type":"danger-full-access"},"model":%q,"personality":"pragmatic"}}`, ts, model)
 }
 
+// codexLineBytes is the on-disk size of one line written by
+// writeCodexUsageLines, including its trailing newline. Byte-exact sizes are
+// what let a test place the tail-window or seed-budget edge on a chosen byte.
+func codexLineBytes(line string) int64 {
+	return int64(len(line)) + 1
+}
+
+// codexLinesBytes is the on-disk size of lines written by writeCodexUsageLines.
+func codexLinesBytes(lines []string) int64 {
+	total := int64(0)
+	for _, line := range lines {
+		total += codexLineBytes(line)
+	}
+	return total
+}
+
+// codexFillerLine returns a response_item line occupying exactly n bytes on
+// disk, newline included. Filler carries no usage and no model, so it only
+// moves the offsets the window and budget edges are measured from.
+func codexFillerLine(t *testing.T, n int64) string {
+	t.Helper()
+	line := func(content string) string {
+		return fmt.Sprintf(
+			`{"timestamp":"2026-04-16T21:50:00.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":%q}}`,
+			content)
+	}
+	pad := n - codexLineBytes(line(""))
+	if pad < 0 {
+		t.Fatalf("filler size %d is smaller than the %d-byte envelope", n, codexLineBytes(line("")))
+	}
+	return line(strings.Repeat("x", int(pad)))
+}
+
+// codexFillerLines returns filler lines occupying exactly total bytes on disk,
+// each short enough for the seed scanner's line buffer so the filler itself
+// never aborts a scan.
+func codexFillerLines(t *testing.T, total int64) []string {
+	t.Helper()
+	const chunk = 16 * 1024
+	var lines []string
+	for total > 0 {
+		n := int64(chunk)
+		if total < 2*chunk {
+			n = total // fold the remainder in rather than emit a sub-envelope line
+		}
+		lines = append(lines, codexFillerLine(t, n))
+		total -= n
+	}
+	return lines
+}
+
 func codexSessionMetaLine(ts, cwd string) string {
 	return fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"id":"019d9845-4273-7ee3-a7d7-15b71ec6f096","timestamp":%q,"cwd":%q,"originator":"codex-tui","cli_version":"0.121.0","source":"cli","model_provider":"openai"}}`, ts, ts, cwd)
 }
@@ -207,10 +258,10 @@ func TestExtractCodexTailUsageModelMissing(t *testing.T) {
 // TestExtractCodexTailUsageModelBeyondTailWindow pins the long-session fix: the
 // model is announced once in a turn_context near the top, then the session runs
 // long enough that the turn_context scrolls past the tail window before the
-// recent token_count events. The model is constant across a codex rollout, so a
-// bounded head scan must still recover it — otherwise mc's long-lived
-// dispatcher/wisp sessions mint model facts with an empty model that the pricing
-// lookup treats as unpriced (the "burn $/hr reads 0" gap).
+// recent token_count events. A bounded backward scan from the window must still
+// reach that announcement — otherwise mc's long-lived dispatcher/wisp sessions
+// mint model facts with an empty model that the pricing lookup treats as
+// unpriced (the "burn $/hr reads 0" gap).
 func TestExtractCodexTailUsageModelBeyondTailWindow(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-longsession.jsonl")
 	lines := []string{
@@ -241,7 +292,7 @@ func TestExtractCodexTailUsageModelBeyondTailWindow(t *testing.T) {
 	}
 	for i, u := range usages {
 		if u.Model != "gpt-5.6-terra" {
-			t.Errorf("usages[%d].Model = %q, want gpt-5.6-terra (recovered from the head turn_context beyond the tail window)", i, u.Model)
+			t.Errorf("usages[%d].Model = %q, want gpt-5.6-terra (recovered by the backward scan from the turn_context preceding the tail window)", i, u.Model)
 		}
 	}
 }
@@ -370,6 +421,178 @@ func TestExtractCodexTailUsageInWindowModelOverridesSeed(t *testing.T) {
 	}
 	if usages[0].Model != "gpt-5.7-nova" {
 		t.Errorf("usages[0].Model = %q, want gpt-5.7-nova (an in-window turn_context overrides the seed)", usages[0].Model)
+	}
+}
+
+// TestExtractCodexTailUsageSeedsModelStraddlingWindowBoundary pins the line that
+// belongs to neither scan. The backward seed covers [rangeStart, windowStart)
+// and readTail starts at exactly windowStart with no line-boundary snapping, so
+// a turn_context whose bytes span windowStart is a prefix for one scan and a
+// suffix for the other and parses for neither. Dropping it prices the tail with
+// the model the session already switched away from, and because a minted usage
+// fact's idempotency key excludes the model, that wrong price is durable.
+func TestExtractCodexTailUsageSeedsModelStraddlingWindowBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-straddle.jsonl")
+	head := []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+	}
+	straddling := codexTurnContextLine("2026-04-16T22:00:12.000Z", "gpt-5.7-nova")
+	tail := []string{
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+		codexTokenCountLine("2026-04-16T22:10:45.100Z", 34114, 17888, 15232, 309, 28),
+	}
+	// windowStart is tailChunkSize bytes before EOF, so sizing everything after
+	// the switch announcement to tailChunkSize minus half that line's length
+	// puts windowStart in the middle of it.
+	straddlingBytes := codexLineBytes(straddling)
+	afterStraddling := int64(tailChunkSize) - straddlingBytes/2
+
+	lines := make([]string, 0, len(head)+2+len(tail))
+	lines = append(lines, head...)
+	lines = append(lines, straddling)
+	lines = append(lines, codexFillerLine(t, afterStraddling-codexLinesBytes(tail)))
+	lines = append(lines, tail...)
+	writeCodexUsageLines(t, path, lines)
+
+	// The case only exists while windowStart lands strictly inside the switch
+	// announcement, so pin the geometry rather than let it drift silently.
+	straddlingStart := codexLinesBytes(head)
+	windowStart := codexLinesBytes(lines) - int64(tailChunkSize)
+	if windowStart <= straddlingStart || windowStart >= straddlingStart+straddlingBytes-1 {
+		t.Fatalf("windowStart %d does not fall strictly inside the straddling turn_context [%d,%d)",
+			windowStart, straddlingStart, straddlingStart+straddlingBytes)
+	}
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 2 {
+		t.Fatalf("got %d usages, want 2: %+v", len(usages), usages)
+	}
+	for i, u := range usages {
+		if u.Model != "gpt-5.7-nova" {
+			t.Errorf("usages[%d].Model = %q, want gpt-5.7-nova (the switch announced on the line straddling the window boundary)", i, u.Model)
+		}
+	}
+}
+
+// TestExtractCodexTailUsageOversizedSeedLineFallsBackToEmpty pins the honest
+// floor when the backward scan cannot finish. Codex rollouts embed whole tool
+// outputs and file reads in a single response_item line, so a line past the seed
+// scanner's buffer is ordinary; it aborts the scan mid-range and leaves any
+// later switch unseen. Reporting the model found before that line replaces an
+// obvious unpriced $0 with a plausible wrong price that no later sweep corrects,
+// and the oversized line stays in range across a long stretch of file growth, so
+// it would mislabel every sweep in that stretch rather than one.
+func TestExtractCodexTailUsageOversizedSeedLineFallsBackToEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-oversized.jsonl")
+	writeCodexUsageLines(t, path, []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+		codexFillerLine(t, codexSeedScanLineMax+1024),
+		codexTurnContextLine("2026-04-16T22:00:12.000Z", "gpt-5.7-nova"),
+		// Push both announcements out of the tail window.
+		codexFillerLine(t, int64(tailChunkSize)+4096),
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+	})
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 1 {
+		t.Fatalf("got %d usages, want 1: %+v", len(usages), usages)
+	}
+	if usages[0].Model != "" {
+		t.Errorf("usages[0].Model = %q, want empty: an aborted seed scan never saw the gpt-5.7-nova switch after the oversized line, so the honest unpriced floor is the only correct answer", usages[0].Model)
+	}
+}
+
+// TestExtractCodexTailUsageSeedsModelAtBudgetLineStart pins the budget edge. The
+// seed range is truncated to codexModelSeedScanBudget bytes before the window,
+// and that cut can land exactly on a line boundary — readTailWindow documents
+// the same thing and peeks the preceding byte to tell the two apart. Skipping
+// the first line unconditionally drops a complete turn_context that is the only
+// announcement in reach.
+func TestExtractCodexTailUsageSeedsModelAtBudgetLineStart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-budgetedge.jsonl")
+	head := []string{codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir")}
+	announcement := codexTurnContextLine("2026-04-16T22:00:12.000Z", "gpt-5.7-nova")
+	tail := []string{
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+		codexTokenCountLine("2026-04-16T22:10:45.100Z", 34114, 17888, 15232, 309, 28),
+	}
+	// rangeStart is codexModelSeedScanBudget+tailChunkSize bytes before EOF, so
+	// sizing the announcement and everything after it to exactly that many bytes
+	// starts the announcement on rangeStart itself.
+	inRange := int64(codexModelSeedScanBudget) + int64(tailChunkSize)
+
+	lines := make([]string, 0, len(head)+8+len(tail))
+	lines = append(lines, head...)
+	lines = append(lines, announcement)
+	lines = append(lines, codexFillerLines(t, inRange-codexLineBytes(announcement)-codexLinesBytes(tail))...)
+	lines = append(lines, tail...)
+	writeCodexUsageLines(t, path, lines)
+
+	announcementStart := codexLinesBytes(head)
+	rangeStart := codexLinesBytes(lines) - inRange
+	if rangeStart != announcementStart {
+		t.Fatalf("rangeStart %d does not land on the announcement's first byte %d", rangeStart, announcementStart)
+	}
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 2 {
+		t.Fatalf("got %d usages, want 2: %+v", len(usages), usages)
+	}
+	for i, u := range usages {
+		if u.Model != "gpt-5.7-nova" {
+			t.Errorf("usages[%d].Model = %q, want gpt-5.7-nova (a complete turn_context starting on the budget edge is not a partial line)", i, u.Model)
+		}
+	}
+}
+
+// TestCodexPrecedingModelUsesCallerWindow pins the seed's window contract: it
+// scans the range ending at the offset the caller passes, and lines starting at
+// or after that offset belong to the in-window scan. ExtractCodexTailUsage takes
+// one Seek(0, io.SeekEnd) and threads it into both reads on that basis, so a
+// rollout appended to mid-extraction cannot grow a gap between them.
+func TestCodexPrecedingModelUsesCallerWindow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-window.jsonl")
+	head := []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+	}
+	lines := append(append([]string{}, head...), codexTurnContextLine("2026-04-16T22:00:12.000Z", "gpt-5.7-nova"))
+	writeCodexUsageLines(t, path, lines)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close() //nolint:errcheck // read-only test file
+
+	// A window starting exactly where the switch is announced excludes it: that
+	// line is the in-window scan's to read.
+	model, err := codexPrecedingModel(f, codexLinesBytes(head))
+	if err != nil {
+		t.Fatalf("codexPrecedingModel: %v", err)
+	}
+	if model != "gpt-5.6-terra" {
+		t.Errorf("model = %q, want gpt-5.6-terra for a window starting at the switch announcement", model)
+	}
+
+	// A window starting after it includes it.
+	model, err = codexPrecedingModel(f, codexLinesBytes(lines))
+	if err != nil {
+		t.Fatalf("codexPrecedingModel: %v", err)
+	}
+	if model != "gpt-5.7-nova" {
+		t.Errorf("model = %q, want gpt-5.7-nova for a window starting past the switch announcement", model)
 	}
 }
 

--- a/internal/sessionlog/codex_usage_test.go
+++ b/internal/sessionlog/codex_usage_test.go
@@ -204,6 +204,48 @@ func TestExtractCodexTailUsageModelMissing(t *testing.T) {
 	}
 }
 
+// TestExtractCodexTailUsageModelBeyondTailWindow pins the long-session fix: the
+// model is announced once in a turn_context near the top, then the session runs
+// long enough that the turn_context scrolls past the tail window before the
+// recent token_count events. The model is constant across a codex rollout, so a
+// bounded head scan must still recover it — otherwise mc's long-lived
+// dispatcher/wisp sessions mint model facts with an empty model that the pricing
+// lookup treats as unpriced (the "burn $/hr reads 0" gap).
+func TestExtractCodexTailUsageModelBeyondTailWindow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-longsession.jsonl")
+	lines := []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+	}
+	// Filler > tailChunkSize so the turn_context is outside the tail window that
+	// readTail scans; these response_item lines carry no usage and are skipped.
+	filler := strings.Repeat("x", 2048)
+	for i := 0; i < (tailChunkSize/2048)+8; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"timestamp":"2026-04-16T21:50:%02d.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":%q}}`,
+			i%60, filler))
+	}
+	// Recent invocations sit in the tail window with no nearby turn_context.
+	lines = append(lines,
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+		codexTokenCountLine("2026-04-16T22:10:45.100Z", 34114, 17888, 15232, 309, 28),
+	)
+	writeCodexUsageLines(t, path, lines)
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 2 {
+		t.Fatalf("got %d usages, want 2: %+v", len(usages), usages)
+	}
+	for i, u := range usages {
+		if u.Model != "gpt-5.6-terra" {
+			t.Errorf("usages[%d].Model = %q, want gpt-5.6-terra (recovered from the head turn_context beyond the tail window)", i, u.Model)
+		}
+	}
+}
+
 func TestExtractCodexTailMetaUsesLatestRealUsageShape(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "2026", "04", "16", "rollout-2026-04-16T21-49-29-meta.jsonl")

--- a/internal/sessionlog/codex_usage_test.go
+++ b/internal/sessionlog/codex_usage_test.go
@@ -246,6 +246,51 @@ func TestExtractCodexTailUsageModelBeyondTailWindow(t *testing.T) {
 	}
 }
 
+// TestExtractCodexTailUsageAmbiguousHeadModelSeedsEmpty pins the mid-rollout
+// switch fix: when the head scan observes MORE THAN ONE distinct
+// turn_context.model before the tail window (a genuine mid-rollout model
+// switch), the head cannot name a single session model. Seeding from the first
+// model would silently mislabel post-switch tail usage with the pre-switch
+// model — trading an obvious unpriced $0 for a plausible wrong price. The scan
+// must instead fall back to the honest unpriced floor (empty model), exactly as
+// if no head model were found, so any in-tail turn_context still wins.
+func TestExtractCodexTailUsageAmbiguousHeadModelSeedsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-headswitch.jsonl")
+	lines := []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		// Two distinct models announced near the top: a real mid-rollout switch,
+		// both within the bounded head-scan window.
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+		codexTurnContextLine("2026-04-16T21:49:31.901Z", "gpt-5.7-nova"),
+	}
+	// Filler > tailChunkSize so BOTH head turn_contexts scroll out of the tail
+	// window; the recent token_counts sit in the tail with no in-window model.
+	filler := strings.Repeat("x", 2048)
+	for i := 0; i < (tailChunkSize/2048)+8; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"timestamp":"2026-04-16T21:50:%02d.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":%q}}`,
+			i%60, filler))
+	}
+	lines = append(lines,
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+		codexTokenCountLine("2026-04-16T22:10:45.100Z", 34114, 17888, 15232, 309, 28),
+	)
+	writeCodexUsageLines(t, path, lines)
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 2 {
+		t.Fatalf("got %d usages, want 2: %+v", len(usages), usages)
+	}
+	for i, u := range usages {
+		if u.Model != "" {
+			t.Errorf("usages[%d].Model = %q, want empty (an ambiguous multi-model head must not seed a guess)", i, u.Model)
+		}
+	}
+}
+
 func TestExtractCodexTailMetaUsesLatestRealUsageShape(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "2026", "04", "16", "rollout-2026-04-16T21-49-29-meta.jsonl")

--- a/internal/sessionlog/codex_usage_test.go
+++ b/internal/sessionlog/codex_usage_test.go
@@ -246,24 +246,21 @@ func TestExtractCodexTailUsageModelBeyondTailWindow(t *testing.T) {
 	}
 }
 
-// TestExtractCodexTailUsageAmbiguousHeadModelSeedsEmpty pins the mid-rollout
-// switch fix: when the head scan observes MORE THAN ONE distinct
-// turn_context.model before the tail window (a genuine mid-rollout model
-// switch), the head cannot name a single session model. Seeding from the first
-// model would silently mislabel post-switch tail usage with the pre-switch
-// model — trading an obvious unpriced $0 for a plausible wrong price. The scan
-// must instead fall back to the honest unpriced floor (empty model), exactly as
-// if no head model were found, so any in-tail turn_context still wins.
-func TestExtractCodexTailUsageAmbiguousHeadModelSeedsEmpty(t *testing.T) {
+// TestExtractCodexTailUsageSeedsNearestPrecedingModel pins the mid-rollout
+// switch case: two distinct turn_context models are announced before the tail
+// window, so the seed must name the LAST one — the model actually in effect
+// when the tail invocations ran. Seeding the session's first model instead
+// would silently mislabel post-switch tail usage with the pre-switch model,
+// trading an obvious unpriced $0 for a plausible wrong price.
+func TestExtractCodexTailUsageSeedsNearestPrecedingModel(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-headswitch.jsonl")
 	lines := []string{
 		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
-		// Two distinct models announced near the top: a real mid-rollout switch,
-		// both within the bounded head-scan window.
+		// Two distinct models announced near the top: a real mid-rollout switch.
 		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
 		codexTurnContextLine("2026-04-16T21:49:31.901Z", "gpt-5.7-nova"),
 	}
-	// Filler > tailChunkSize so BOTH head turn_contexts scroll out of the tail
+	// Filler > tailChunkSize so BOTH turn_contexts scroll out of the tail
 	// window; the recent token_counts sit in the tail with no in-window model.
 	filler := strings.Repeat("x", 2048)
 	for i := 0; i < (tailChunkSize/2048)+8; i++ {
@@ -285,9 +282,94 @@ func TestExtractCodexTailUsageAmbiguousHeadModelSeedsEmpty(t *testing.T) {
 		t.Fatalf("got %d usages, want 2: %+v", len(usages), usages)
 	}
 	for i, u := range usages {
-		if u.Model != "" {
-			t.Errorf("usages[%d].Model = %q, want empty (an ambiguous multi-model head must not seed a guess)", i, u.Model)
+		if u.Model != "gpt-5.7-nova" {
+			t.Errorf("usages[%d].Model = %q, want gpt-5.7-nova (the nearest turn_context preceding the tail window, not the session's first)", i, u.Model)
 		}
+	}
+}
+
+// TestExtractCodexTailUsageSwitchBeyondSeedBudget pins the case a head scan
+// gets wrong: the pre-switch model is announced so far back that it falls
+// outside the backward budget entirely, and the post-switch model sits between
+// the budget edge and the tail window. The backward scan must find the nearest
+// preceding turn_context; a scan anchored at the head of the file would never
+// see the switch and would price the tail with the stale model.
+func TestExtractCodexTailUsageSwitchBeyondSeedBudget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-farswitch.jsonl")
+	lines := []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+	}
+	filler := strings.Repeat("x", 2048)
+	fillerLine := func(i int) string {
+		return fmt.Sprintf(
+			`{"timestamp":"2026-04-16T21:50:%02d.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":%q}}`,
+			i%60, filler)
+	}
+	// Filler > codexModelSeedScanBudget so the pre-switch turn_context is out of
+	// backward-scan reach.
+	for i := 0; i < (codexModelSeedScanBudget/2048)+8; i++ {
+		lines = append(lines, fillerLine(i))
+	}
+	lines = append(lines, codexTurnContextLine("2026-04-16T22:00:12.000Z", "gpt-5.7-nova"))
+	// Filler > tailChunkSize so the post-switch turn_context is out of the tail
+	// window too — reachable only by the backward scan.
+	for i := 0; i < (tailChunkSize/2048)+8; i++ {
+		lines = append(lines, fillerLine(i))
+	}
+	lines = append(lines,
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+		codexTokenCountLine("2026-04-16T22:10:45.100Z", 34114, 17888, 15232, 309, 28),
+	)
+	writeCodexUsageLines(t, path, lines)
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 2 {
+		t.Fatalf("got %d usages, want 2: %+v", len(usages), usages)
+	}
+	for i, u := range usages {
+		if u.Model != "gpt-5.7-nova" {
+			t.Errorf("usages[%d].Model = %q, want gpt-5.7-nova (the model in effect at the tail, switched to beyond the seed budget)", i, u.Model)
+		}
+	}
+}
+
+// TestExtractCodexTailUsageInWindowModelOverridesSeed pins that a turn_context
+// inside the tail window always beats a non-empty backward-scan seed: the seed
+// only stands in for an announcement the window cannot see.
+func TestExtractCodexTailUsageInWindowModelOverridesSeed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-inwindow.jsonl")
+	lines := []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.6-terra"),
+	}
+	// Filler > tailChunkSize so the first turn_context is only reachable by the
+	// backward scan, which seeds gpt-5.6-terra.
+	filler := strings.Repeat("x", 2048)
+	for i := 0; i < (tailChunkSize/2048)+8; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"timestamp":"2026-04-16T21:50:%02d.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":%q}}`,
+			i%60, filler))
+	}
+	// A switch announced inside the tail window must override that seed.
+	lines = append(lines,
+		codexTurnContextLine("2026-04-16T22:10:30.000Z", "gpt-5.7-nova"),
+		codexTokenCountLine("2026-04-16T22:10:38.304Z", 15917, 15562, 10624, 355, 166),
+	)
+	writeCodexUsageLines(t, path, lines)
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 1 {
+		t.Fatalf("got %d usages, want 1: %+v", len(usages), usages)
+	}
+	if usages[0].Model != "gpt-5.7-nova" {
+		t.Errorf("usages[0].Model = %q, want gpt-5.7-nova (an in-window turn_context overrides the seed)", usages[0].Model)
 	}
 }
 

--- a/internal/sessionlog/tail.go
+++ b/internal/sessionlog/tail.go
@@ -93,6 +93,15 @@ func readTail(r io.ReadSeeker, n int64) ([]byte, bool, error) {
 	return data, startsMidLine, err
 }
 
+// readTailAt is readTail against a size snapshot the caller already took. A
+// caller that scans two windows of the same file uses it so both windows are
+// derived from one Seek: two independent SeekEnd snapshots of a file being
+// appended to disagree, leaving the bytes written in between in neither window.
+func readTailAt(r io.ReadSeeker, size, n int64) ([]byte, bool, error) {
+	data, startsMidLine, _, err := readTailWindowAt(r, size, n)
+	return data, startsMidLine, err
+}
+
 // readTailWindow also reports whether bytes before the returned window were
 // omitted. A truncated window can begin exactly on a line boundary, so that
 // state cannot be inferred from startsMidLine.
@@ -101,6 +110,12 @@ func readTailWindow(r io.ReadSeeker, n int64) ([]byte, bool, bool, error) {
 	if err != nil {
 		return nil, false, false, err
 	}
+	return readTailWindowAt(r, size, n)
+}
+
+// readTailWindowAt is readTailWindow against a size snapshot the caller already
+// took.
+func readTailWindowAt(r io.ReadSeeker, size, n int64) ([]byte, bool, bool, error) {
 	offset := size - n
 	if offset < 0 {
 		offset = 0


### PR DESCRIPTION
## What

`ExtractCodexTailUsage` scans only the last 64 KiB of a codex rollout, but the model is carried solely by `turn_context` lines — `event_msg`/`token_count` has none. In a long-lived session (a long-running dispatcher/worker) the most recent `turn_context` has scrolled out of that window, so every subsequent invocation was recorded with an empty `Model`.

Downstream, the invocation-cost pricing registry keys on `(provider, model)`, so an empty model is always **unpriced**: `Registry.Lookup` misses, `Estimate` returns `(0, false)`, and the invocation is attributed $0 forever — the window only ever moves further forward, so no later sweep repairs it.

## Root cause

Measured across 843 real host rollouts: **693 (82%)** have no `turn_context` in the last 64 KiB while a model *is* recoverable earlier. Short sessions, whose `turn_context` is still in-window, were fine — which is why the gap looked intermittent.

## Fix

Seed `turnModel` from a bounded **backward** scan (`codexPrecedingModel`) over the `codexModelSeedScanBudget` (1 MiB) preceding the tail window, taking the **nearest preceding** `turn_context.model`.

Nearest-preceding rather than the session's first announcement is forced by the data, not defensive over-engineering: **32/843 rollouts (3.8% aggregate, 61/500 = 12.2% in the July slice) announce two or more distinct models**, which a head/first-occurrence seed would mislabel. Because the seed is the announcement in effect where the window starts, the result is right-or-empty by construction — **0 mislabels across 1,584 seeded rollouts**.

An in-window `turn_context` still overrides the seed, preserving the mid-session-switch behavior the existing tests pin. A model not found within the budget falls back to empty (no worse than before).

Supporting details:

- The seed and the tail read share **one** `Seek(0, io.SeekEnd)` snapshot, threaded through the new `readTailAt`/`readTailWindowAt`. Two independent snapshots would leave the bytes appended in between — these rollouts are appended to while they are read — inside neither window.
- The seed reads one `codexSeedScanLineMax` (256 KiB) allowance past the window start so the line straddling the boundary is consumed whole by exactly one scan. `readTail` starts at exactly the boundary with no line snapping, so the in-window scan sees only an unparseable suffix of that line.
- A line longer than 256 KiB cannot be read, and it **aborts the seed scan mid-range**. The seed then degrades to empty, discarding any model already found before that line. A switch announced after the over-long line is unseen, so reporting the earlier model would replace an honest unpriced $0 with a plausible wrong price that no later sweep corrects — and because such a line stays in range across a long stretch of file growth, it would mislabel every sweep in that stretch rather than one.
- The seed's own seek/read failures are **not** degraded that way: they propagate and fail the whole usage extraction. That is stricter than `readTailWindowAt`, whose preceding-byte peek swallows the same two errors and defaults to `false`. The code documents the divergence; which contract both should keep is tracked as `ga-8gku9`.

## Coverage and residual risk

Recovery was measured at **646/693 (93.2%)** of affected rollouts.

The rest of the residual is worth knowing before it surprises someone:

- 38/693 (5.5%) have no `turn_context` within the 1 MiB budget at all.
- 9/693 (1.3%) hit an over-long line inside the budget, which aborts the scan and leaves the seed empty (see above).
- Sub-population variance is high: 98.8% recovery in the July slice against 44.0% in a heavier August slice. "93%" is not a stable figure; the metric to watch after ship is the fraction of codex invocations landing with an empty model.
- Missed rollouts skew large — median 3.27 MB against 0.71 MB for a recovered one — so the sessions that stay unpriced are systematically the long, costly ones. This is an incomplete fix rather than a defect: those rollouts keep the pre-PR behavior.

Follow-ups tracked separately: `ga-emblt` (make the seed lazy — measured 17.24 ms with the seed against 1.54 ms for the pre-PR tail-only shape on a 20 MB rollout) and `ga-6u1sd` (`ExtractCodexTailMeta` deliberately keeps unseeded tail-only semantics, because a seed would invalidate its `anchorFirstTotal` reasoning).

## Tests

Eight tests in `internal/sessionlog/codex_usage_test.go`, each pinning its own fixture geometry with explicit `t.Fatalf` guards so a fixture change cannot silently stop exercising the case:

- `TestExtractCodexTailUsageModelBeyondTailWindow` — the bug itself: a `turn_context` beyond the tail window is recovered. Red before the fix, green after.
- `TestExtractCodexTailUsageSeedsNearestPrecedingModel` — nearest preceding beats the session's first announcement.
- `TestExtractCodexTailUsageSwitchBeyondSeedBudget` — the switch a head scan would have mispriced.
- `TestExtractCodexTailUsageInWindowModelOverridesSeed` — an in-window `turn_context` always beats a non-empty seed.
- `TestExtractCodexTailUsageSeedsModelStraddlingWindowBoundary` — the line spanning the window boundary is consumed by exactly one scan.
- `TestExtractCodexTailUsageOversizedSeedLineFallsBackToEmpty` — an over-long line aborts the scan, and the seed degrades to empty rather than reporting a model that may already be stale.
- `TestExtractCodexTailUsageSeedsModelAtBudgetLineStart` — a budget cut landing exactly on a line start is not a partial line.
- `TestCodexPrecedingModelUsesCallerWindow` — the seed's window contract, exercised on the helper directly.

`go test ./internal/sessionlog` and `go test ./internal/worker` green; `go vet` clean.

## Revert safety

The change is additive and confined to `internal/sessionlog`; no exported signature changed. Already-emitted usage facts are keyed by `ModelIdempotencyKey(runID, upstreamReqID)`, which excludes the model, so a revert or a later re-sweep updates rows in place rather than duplicating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
