### PR TITLE
gc bd: reject a structurally-invalid --assignee (empty role, e.g. "cairn/") instead of forwarding it

### DIFF
--- a/cmd/gc/bd_assignee_shape.go
+++ b/cmd/gc/bd_assignee_shape.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// bdAssigneeShapeRefusal reports whether a `gc bd update` invocation carries
+// a structurally-invalid, non-empty --assignee value: one with an empty rig
+// or role segment (e.g. "cairn/", "/pm", "a//b"). Such a value is invisible
+// to both tiers of standard discovery -- exact --assignee=<role> matching
+// and --unassigned matching -- so a bead written with it becomes silently
+// unreachable by every agent. See crn-23jqc (the 2026-08-15 cairn incident
+// this guard defends against) for the root-cause writer bug.
+//
+// Deliberately narrower than a full value validator: "" is the documented
+// idiom for clearing an assignee and must keep working, so only a
+// non-empty-but-malformed value is refused.
+//
+// Scoped to the "update" subcommand -- the only write path a caller uses to
+// set --assignee on an existing bead through this seam. Runs after the
+// bdMutationWriteIDs guard has already validated the flag shape is
+// unambiguous for "update" (or doBd has already returned 1), so every flag
+// encountered here is a known value-consuming or boolean flag.
+func bdAssigneeShapeRefusal(args []string) (string, bool) {
+	if len(args) == 0 || args[0] != "update" {
+		return "", false
+	}
+	valueFlags := bdSubcmdValueFlags("update")
+	boolFlags := bdSubcmdBoolFlags("update")
+
+	positional := false
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if positional {
+			continue
+		}
+		if arg == "--" {
+			positional = true
+			continue
+		}
+		if !strings.HasPrefix(arg, "-") {
+			continue
+		}
+		// --flag=value form: value is embedded, no next-arg consumed.
+		if eq := strings.Index(arg, "="); eq >= 0 {
+			if flagName := arg[:eq]; flagName == "--assignee" || flagName == "-a" {
+				if msg, bad := bdAssigneeShapeInvalid(arg[eq+1:]); bad {
+					return msg, true
+				}
+			}
+			continue
+		}
+		flagName := strings.TrimLeft(arg, "-")
+		longForm := "--" + flagName
+		shortForm := "-" + flagName // only meaningful when flagName is 1 char
+		isAssignee := longForm == "--assignee" || (len(flagName) == 1 && shortForm == "-a")
+
+		if valueFlags[longForm] || (len(flagName) == 1 && valueFlags[shortForm]) {
+			// Known value-consuming flag: its value is the next argument.
+			if isAssignee && i+1 < len(args) {
+				if msg, bad := bdAssigneeShapeInvalid(args[i+1]); bad {
+					return msg, true
+				}
+			}
+			i++
+			continue
+		}
+		if boolFlags[longForm] || (len(flagName) == 1 && boolFlags[shortForm]) {
+			// Known boolean flag (e.g. --claim): no value to inspect.
+			continue
+		}
+		// Unknown flag shape: bdMutationWriteIDs already fails closed on this
+		// before doBd ever reaches this guard, so this arm is unreachable in
+		// practice. Nothing further to check.
+	}
+	return "", false
+}
+
+// bdAssigneeShapeInvalid reports whether value is non-empty and contains an
+// empty rig or role segment (leading slash, trailing slash, or a doubled
+// slash). Empty is always valid -- it is the documented clear idiom.
+func bdAssigneeShapeInvalid(value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+	if !strings.HasPrefix(value, "/") && !strings.HasSuffix(value, "/") && !strings.Contains(value, "//") {
+		return "", false
+	}
+	return fmt.Sprintf("gc bd: refusing --assignee=%q: %q has an empty rig or role segment\n(a \"<rig>/\" value is invisible to both --assignee and --unassigned\ndiscovery; see crn-23jqc)\n", value, value), true
+}

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -363,6 +363,16 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	// Assignee shape guard (crn-23jqc): refuse a non-empty --assignee value
+	// with an empty rig or role segment (e.g. "cairn/", "/pm", "a//b") before
+	// it reaches bd. Such a value is invisible to both --assignee=<role>
+	// exact matching and --unassigned matching, so a bead written with it
+	// becomes silently unreachable by every agent. "" (clear) is unaffected.
+	if msg, refused := bdAssigneeShapeRefusal(bdArgs); refused {
+		fmt.Fprint(stderr, msg) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
 	// Work-record close gate (ADR-0009): a close routed through the SDK seam
 	// must satisfy the typed work-record contract (gc.work_outcome present;
 	// shipped ⇒ gc.work_commit reachable on gc.work_branch). Warn-only by default;

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2069,6 +2069,66 @@ func TestRewriteBdHeartbeatArgs(t *testing.T) {
 	})
 }
 
+// TestBdAssigneeShapeRefusal pins the crn-23jqc defense-in-depth fix: `gc bd
+// update` refuses a non-empty --assignee value with an empty rig or role
+// segment (e.g. "cairn/", "/pm", "a//b") instead of forwarding it to bd,
+// while still allowing the documented "" clear idiom and any properly-
+// segmented value through. Such a malformed value is invisible to both
+// standard discovery tiers (exact --assignee=<role> match and --unassigned),
+// so a bead written with it becomes silently unreachable -- the 2026-08-15
+// cairn incident this bead defends against.
+func TestBdAssigneeShapeRefusal(t *testing.T) {
+	// Fake bd that echoes its argv to stdout and exits 0 -- proves a case
+	// reached the exec.Command forward, as opposed to being refused first.
+	const echoArgsFakeBdScript = `#!/bin/sh
+echo "$@"
+exit 0
+`
+	cases := []struct {
+		name    string
+		args    []string
+		refused bool
+	}{
+		{"trailing-slash-empty-role", []string{"update", "demo-abc", "--assignee=cairn/"}, true},
+		{"leading-slash-empty-rig-space-form", []string{"update", "demo-abc", "--assignee", "/pm"}, true},
+		{"double-slash-empty-middle-segment", []string{"update", "demo-abc", "--assignee=a//b"}, true},
+		{"empty-value-clears-assignee", []string{"update", "demo-abc", "--assignee="}, false},
+		{"fully-qualified-value", []string{"update", "demo-abc", "--assignee=cairn/pm"}, false},
+		{"bare-role-no-rig", []string{"update", "demo-abc", "--assignee=deep-investigator"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			silentFallbackTestSetup(t, echoArgsFakeBdScript)
+
+			var stdout, stderr bytes.Buffer
+			got := doBd(tc.args, &stdout, &stderr)
+
+			if tc.refused {
+				if got == 0 {
+					t.Fatalf("doBd(%v) = 0, want non-zero (refused)", tc.args)
+				}
+				if !strings.Contains(stderr.String(), "empty rig or role segment") {
+					t.Fatalf("stderr = %q, want empty-rig-or-role-segment refusal", stderr.String())
+				}
+				if !strings.Contains(stderr.String(), "crn-23jqc") {
+					t.Fatalf("stderr = %q, want crn-23jqc reference", stderr.String())
+				}
+				if stdout.String() != "" {
+					t.Fatalf("stdout = %q, want empty -- bd must never be invoked on a refusal", stdout.String())
+				}
+				return
+			}
+			if got != 0 {
+				t.Fatalf("doBd(%v) = %d, want 0 (forwarded); stderr=%q", tc.args, got, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "demo-abc") {
+				t.Fatalf("stdout = %q, want forwarded args echoed by fake bd", stdout.String())
+			}
+		})
+	}
+}
+
 // TestBdMutationWriteID covers the compatibility shim (first-ID extraction).
 func TestBdMutationWriteID(t *testing.T) {
 	t.Run("extracts id from write subcommands", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Deploy-gate PR for ga-qxpxku, cut from the reviewed-PASS commit 27e5ca5a87237d93c38ad5e06f315d47502ff835 (review bead ga-w73v3f, source branch builder/ga-w73v3f, molecule ga-zrlsj8).

Adds bdAssigneeShapeRefusal/bdAssigneeShapeInvalid (cmd/gc/bd_assignee_shape.go), wired into doBd's pre-forward validation seam. Refuses a non-empty --assignee value with an empty rig or role segment (leading slash, trailing slash, doubled slash); empty string still clears an assignee, --claim untouched.

## Gate results
- Build: clean (`make build`)
- Smoke (`make test-integration-rest-smoke`): 6/6 rest-smoke failures, all the same non-diff-owned HOME-override supervisor-start signature, attributed to ga-61x8jh
- Pre-push hook (`test-fast-parallel`): 1 failure, TestProviderLiveClaudeKindPath (internal/runtime/herdr, agent_pane_busy fleet-contention flake), attributed to ga-cqq3hs.1
- Prior rejection_reason on this bead also cited a stale bd-flag-manifest issue (bd v1.1.0, tracked by ga-d5m4ac) — re-verified this cycle and internal/bdflags now passes clean, no longer reproduces

All attributions satisfy the four-clause non-diff-owned-gate-failure policy (not diff-owned, tracked, proven pre-existing, no path overlap). Full attribution notes recorded on ga-qxpxku. Pushed with `--no-verify` per that policy's standing authorization, attribution recorded first.

Routed to mayor for merge — not merged by this session.

## Test plan
- [x] make build
- [x] make test-integration-rest-smoke (failures attributed, see above)
- [x] pre-push fast suite (failure attributed, see above)
- [ ] mayor merge