### PR TITLE
fix(config): deflake TestSkipRevisionSnapshot_StillDetectsPackContentChange

### DIFF
--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -736,7 +737,32 @@ func TestSkipRevisionSnapshot_StillDetectsPackContentChange(t *testing.T) {
 			}
 			before := Revision(fsys.OSFS{}, prov, cfg, dir)
 
-			writeFile(t, dir, "packs/shared/prompts/worker.md", "edited prompt body\n")
+			// Revision reaches the pack tree through PackContentHashRecursive,
+			// which memoizes each tree behind a cheap per-file (size, mtime)
+			// stat fingerprint — so an edit preserving BOTH is served the stale
+			// hash by design. The fixture body and the replacement used to be
+			// the same length (19 bytes each), leaving mtime as the only
+			// discriminator; on a runner whose timestamp granularity is coarser
+			// than this subtest's runtime both writes share an mtime and the
+			// revision does not move. That is the flake in gastownhall/gascity
+			// ga-b675vk, which failed unrelated PRs #5357/#5358.
+			//
+			// Keep the replacement a different length so the fingerprint moves
+			// at any mtime resolution — the same discipline
+			// TestPackContentHashRecursiveCachesUnchangedTree already applies
+			// with "prompt a (edited, longer)". The guard below fails loudly
+			// rather than flakily if a later edit reintroduces a same-size body.
+			const editedPrompt = "edited prompt body, deliberately a different length\n"
+			promptPath := filepath.Join(dir, "packs", "shared", "prompts", "worker.md")
+			info, err := os.Stat(promptPath)
+			if err != nil {
+				t.Fatalf("stat prompt: %v", err)
+			}
+			if info.Size() == int64(len(editedPrompt)) {
+				t.Fatalf("replacement body must differ in length from the %d-byte original; "+
+					"a same-size edit can reuse the memoized pack content hash and flake", info.Size())
+			}
+			writeFile(t, dir, "packs/shared/prompts/worker.md", editedPrompt)
 
 			reloadedCfg, reloadedProv, err := LoadWithIncludesOptions(fsys.OSFS{}, cityPath, tc.opts)
 			if err != nil {


### PR DESCRIPTION
Fixes the `packages-core-2-of-4` flake that has been failing **unrelated** PRs
(#5357, #5358) since `9b190a4c9e` (#4917) landed. Tracked as `ga-b675vk`.

```
--- FAIL: TestSkipRevisionSnapshot_StillDetectsPackContentChange
    revision_test.go:748: pack content edit did not change the revision;
                          reconciler change detection would be blind
```

## Root cause

`Revision()` reaches pack trees through `PackContentHashRecursive`
(`internal/config/pack.go:2919`), which memoizes each tree behind a cheap
per-file **(size, mtime)** stat fingerprint and returns the cached hash when
neither has moved (`pack.go:2939-2941`).

The two bodies in this test were **exactly the same length**:

| | value | bytes |
|---|---|---|
| fixture (`revision_test.go:679`) | `"worker prompt body\n"` | 19 |
| edit (`revision_test.go:739`) | `"edited prompt body\n"` | 19 |

So the size half of the fingerprint never moved, leaving **mtime as the sole
discriminator**. The subtest completes in well under a millisecond, so on a
runner whose timestamp granularity is coarser than that, both writes land in
one granule and share an mtime — the fingerprint is unchanged, the stale hash
is reused, and the revision does not move.

That also explains the observed signature: it reproduced on two PRs with
completely disjoint diffs (neither touches `internal/config`), the failing
subtest differed between runs (`default+skip_snapshot` vs `skip_snapshot`
only), and an isolated shard run passed.

## Evidence

Verified deterministically by forcing the two writes to share an mtime
(`os.Chtimes`) on an otherwise unmodified tree:

1. **Same size + same mtime → revision is blind.** `before == after` in
   **both** arms, reproducing the CI message exactly.
2. **Clearing `packContentHashCache` between loads restores detection** in both
   arms — which rules out `LoadOptions.SkipRevisionSnapshot` (#4917) as the
   cause. Both arms funnel through `PackContentHashRecursive`; the default arm
   just calls it at load time via `captureRevisionSnapshot` instead of at
   `Revision` time.
3. **A different-length body detects the edit even with mtime frozen.**

Locally (btrfs) 2000 rapid rewrites never once shared an mtime, which is why
this only ever fails on CI and never in isolation.

## The fix

Make the replacement a different length so the fingerprint moves at **any**
mtime resolution, and add a size guard so a future same-size edit fails loudly
instead of flakily.

This matches the discipline `TestPackContentHashRecursiveCachesUnchangedTree`
already applies in the same package, which deliberately edits with
`"prompt a (edited, longer)"` (`pack_test.go:1053-1054`). A sweep of every
repeated `writeFile` pair under `internal/config` found this test to be the
only same-size offender.

## Scope

Test-only; no production behavior changes. The **(size, mtime) blind spot in
`PackContentHashRecursive` itself is pre-existing and explicitly documented**
as an accepted tradeoff at `pack.go:2899-2901`; deciding whether to tighten it
is an architecture call and is tracked separately, not bundled here.

## Verification

- `TestSkipRevisionSnapshot_StillDetectsPackContentChange` — 50/50 passes
- full `internal/config` package — green
- `go vet ./internal/config/` — clean
- guard confirmed to fire (reverting to a 19-byte body fails with the intended message, not the flaky one)
