### PR TITLE
fix(pool): derive a pool session's runtime name from its identity, not its bead ID (ga-vcjr9)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2896,6 +2896,13 @@ func realizePoolDesiredSessions(
 				case errors.Is(err, errPoolSessionCreateProviderRed):
 					// debug-level: fires every tick during a red episode; not operator noise
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (provider red, fresh create blocked)\n", qualifiedName, err) //nolint:errcheck
+				case errors.Is(err, errPoolSessionNameUnavailable):
+					// The slot's runtime name is a function of its identity, so
+					// it cannot be worked around by minting another one — that
+					// is exactly the leak this replaced. The holder is named in
+					// the error because a stalled slot is only diagnosable if
+					// the operator can see who is sitting on the name.
+					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (slot stalled on its own runtime name; retrying next tick)\n", qualifiedName, err) //nolint:errcheck
 				default:
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 				}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4049,10 +4049,16 @@ func createPoolSessionBeadWithGuardedAlias(
 	if err != nil {
 		return session.Info{}, err
 	}
+	// A transient slot is a rebinding chair, not an occupant identity. It drives
+	// two decisions here: its runtime session_name must step aside from the bare
+	// slot (TransientSlot, consumed in derivePoolSessionName), and it is never
+	// persisted as an alias (persistAlias below).
+	transientSlot := usesTransientPoolSlotIdentity(cfgAgent)
 	identity := poolSessionCreateIdentity{
-		AgentName: qualifiedInstance,
-		Slot:      slot,
-		Metadata:  metadata,
+		AgentName:     qualifiedInstance,
+		Slot:          slot,
+		Metadata:      metadata,
+		TransientSlot: transientSlot,
 	}
 	// A transient slot is never reserved as an alias: it is not an identity, so
 	// there is nothing to guard against collision and nothing to persist. The
@@ -4066,7 +4072,7 @@ func createPoolSessionBeadWithGuardedAlias(
 	// the exclusion still applies and the persistence does not.
 	alias := strings.TrimSpace(qualifiedInstance)
 	persistAlias := alias
-	if usesTransientPoolSlotIdentity(cfgAgent) {
+	if transientSlot {
 		persistAlias = ""
 	}
 	if bp.beadStore == nil {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3307,9 +3307,12 @@ func TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity(t *test
 		t.Fatalf("labels = %#v, want concrete slot agent label", got.Labels)
 	}
 	// The runtime name is derived from the slot identity, never from the bead
-	// ID — that derivation is the ga-vcjr9 leak.
-	if want := poolIdentitySessionName("rig/claude-1", "rig/claude"); got.Metadata["session_name"] != want {
-		t.Fatalf("session_name = %q, want the slot's identity-derived runtime name %q", got.Metadata["session_name"], want)
+	// ID — that derivation is the ga-vcjr9 leak. A transient slot then steps
+	// aside onto "<identity>-pool" so the rebinding slot never becomes the
+	// runtime name (and therefore GC_AGENT), guarded by
+	// TestE2E_MultiAgent_PoolAndFixed (#5241).
+	if want := poolRuntimeSessionName(nil, "rig/claude-1", "rig/claude", true); got.Metadata["session_name"] != want {
+		t.Fatalf("session_name = %q, want the transient slot's identity-derived runtime name %q", got.Metadata["session_name"], want)
 	}
 	if beadOwnsPoolSessionName(got) {
 		t.Fatalf("session_name = %q is still bead-ID derived", got.Metadata["session_name"])
@@ -5746,9 +5749,9 @@ func TestCreatePoolSessionBeadWithGuardedAliasDropsTmuxAliasWhenIdentifierLockFa
 		t.Fatalf("createPoolSessionBeadWithGuardedAlias: %v", err)
 	}
 
-	want := poolIdentitySessionName("worker-1", "worker")
+	want := poolRuntimeSessionName(nil, "worker-1", "worker", true)
 	if got := info.SessionNameMetadata; got != want {
-		t.Fatalf("session_name = %q, want pool identity fallback %q when tmux_alias lock fails", got, want)
+		t.Fatalf("session_name = %q, want transient pool identity fallback %q when tmux_alias lock fails", got, want)
 	}
 	if strings.Contains(stderr.String(), "creating without alias") && strings.Contains(info.SessionNameMetadata, "crew--test-city") {
 		t.Fatalf("lock failure warning emitted but session_name still used tmux_alias: %q", info.SessionNameMetadata)
@@ -8576,8 +8579,8 @@ func TestBuildDesiredState_UsesBeadNamedPoolSessionsForScaleCheckDemand(t *testi
 	if tp.TemplateName != "worker" {
 		t.Fatalf("TemplateName = %q, want worker", tp.TemplateName)
 	}
-	if got := poolIdentitySessionName("worker-1", "worker"); sessionName != got {
-		t.Fatalf("session name = %q, want the slot's identity-derived runtime name %q", sessionName, got)
+	if got := poolRuntimeSessionName(nil, "worker-1", "worker", true); sessionName != got {
+		t.Fatalf("session name = %q, want the transient slot's identity-derived runtime name %q", sessionName, got)
 	}
 
 	sessionBeads, err := store.ListByLabel(sessionBeadLabel, 0)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5720,9 +5720,9 @@ func TestCreatePoolSessionBeadWithGuardedAliasDropsTmuxAliasWhenIdentifierLockFa
 		t.Fatalf("createPoolSessionBeadWithGuardedAlias: %v", err)
 	}
 
-	want := PoolSessionName("worker", info.ID)
+	want := poolIdentitySessionName("worker-1", "worker")
 	if got := info.SessionNameMetadata; got != want {
-		t.Fatalf("session_name = %q, want unique pool fallback %q when tmux_alias lock fails", got, want)
+		t.Fatalf("session_name = %q, want pool identity fallback %q when tmux_alias lock fails", got, want)
 	}
 	if strings.Contains(stderr.String(), "creating without alias") && strings.Contains(info.SessionNameMetadata, "crew--test-city") {
 		t.Fatalf("lock failure warning emitted but session_name still used tmux_alias: %q", info.SessionNameMetadata)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -33,6 +33,25 @@ type listFailStore struct {
 	beads.Store
 }
 
+// failingSessionBeadCreateStore refuses to create session beads so create-error
+// paths can be exercised.
+type failingSessionBeadCreateStore struct {
+	*beads.MemStore
+}
+
+func (s *failingSessionBeadCreateStore) Create(bead beads.Bead) (beads.Bead, error) {
+	if bead.Type == sessionBeadType {
+		return beads.Bead{}, errors.New("session bead create failed")
+	}
+	return s.MemStore.Create(bead)
+}
+
+// Tx forwards fn(s) rather than delegating to the promoted MemStore.Tx, which
+// would pass the embedded *MemStore into fn and bypass the Create override.
+func (s *failingSessionBeadCreateStore) Tx(msg string, fn func(beads.Tx) error) error {
+	return s.MemStore.Tx(msg, func(beads.Tx) error { return fn(s) })
+}
+
 func (s listFailStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
 	return nil, errors.New("list failed")
 }
@@ -3287,8 +3306,13 @@ func TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity(t *test
 	if !containsString(got.Labels, "agent:rig/claude-1") {
 		t.Fatalf("labels = %#v, want concrete slot agent label", got.Labels)
 	}
-	if !beadOwnsPoolSessionName(got) {
-		t.Fatalf("session_name = %q should be the bead-owned pool runtime name", got.Metadata["session_name"])
+	// The runtime name is derived from the slot identity, never from the bead
+	// ID — that derivation is the ga-vcjr9 leak.
+	if want := poolIdentitySessionName("rig/claude-1", "rig/claude"); got.Metadata["session_name"] != want {
+		t.Fatalf("session_name = %q, want the slot's identity-derived runtime name %q", got.Metadata["session_name"], want)
+	}
+	if beadOwnsPoolSessionName(got) {
+		t.Fatalf("session_name = %q is still bead-ID derived", got.Metadata["session_name"])
 	}
 }
 
@@ -5495,45 +5519,51 @@ func TestSelectOrCreatePoolSessionBead_SerializesAliasCheckAndCreate(t *testing.
 		t.Fatal("first pool create did not start")
 	}
 
+	// The loser is still blocked on the identifier lock, so it can neither
+	// reach the store nor return.
 	select {
 	case <-store.secondCreateStarted:
 		close(store.releaseFirstCreate)
-		close(store.releaseSecondCreate)
 		t.Fatal("second pool create reached the store before first create finished; alias lock did not serialize create")
-	case <-time.After(150 * time.Millisecond):
+	case r := <-results:
 		close(store.releaseFirstCreate)
-		select {
-		case <-store.secondCreateStarted:
-			close(store.releaseSecondCreate)
-		case <-time.After(time.Second):
-			t.Fatal("second pool create did not start after first create completed")
-		}
+		t.Fatalf("a create returned while the first still held the lock: %#v", r)
+	case <-time.After(150 * time.Millisecond):
 	}
+	close(store.releaseFirstCreate)
 
+	// Exactly one racer may own the slot. The loser is refused rather than
+	// handed a second runtime name for the same identity — that second name was
+	// a second sandbox box nothing would address again (ga-vcjr9).
+	winners, losers := 0, 0
 	for i := 0; i < 2; i++ {
 		result := <-results
-		if result.err != nil {
-			t.Fatalf("selectOrCreatePoolSessionBead result %d: %v", i+1, result.err)
+		switch {
+		case result.err == nil:
+			winners++
+			if result.info.ID == "" {
+				t.Fatalf("winning create returned an empty session: %#v", result)
+			}
+			if result.slot != 1 {
+				t.Fatalf("winning create slot = %d, want 1", result.slot)
+			}
+		case errors.Is(result.err, errPoolSessionNameUnavailable):
+			losers++
+		default:
+			t.Fatalf("selectOrCreatePoolSessionBead: %v", result.err)
 		}
-		if result.info.ID == "" {
-			t.Fatalf("selectOrCreatePoolSessionBead result %d returned empty session", i+1)
-		}
-		if result.slot != 1 {
-			t.Fatalf("selectOrCreatePoolSessionBead result %d slot = %d, want 1", i+1, result.slot)
-		}
+	}
+	if winners != 1 || losers != 1 {
+		t.Fatalf("winners=%d losers=%d, want exactly one of each", winners, losers)
 	}
 
 	sessionBeads, err := loadSessionBeads(store)
 	if err != nil {
 		t.Fatalf("load session beads: %v", err)
 	}
-	// The race still produces one bead per goroutine — it did before this change
-	// too, where the loser's EnsureAliasAvailable probe failed and it was created
-	// without an alias. What changed is the discriminator: a transient slot is
-	// never persisted as an alias, so BOTH beads are unaliased and the slot lives
-	// only in agent_name / pool_slot. That is the pair claimPoolSlotWithConfigInfo's
-	// used-slot map and the duplicate-repair lanes already resolve the loser by,
-	// so nothing that resolved the duplicate before depends on the alias.
+	if len(sessionBeads) != 1 {
+		t.Fatalf("session beads = %d, want 1 for a single slot; beads=%#v", len(sessionBeads), sessionBeads)
+	}
 	for _, bead := range sessionBeads {
 		if got := bead.Metadata["alias"]; got != "" {
 			t.Fatalf("pool bead %s alias = %q, want empty for a transient slot; beads=%#v", bead.ID, got, sessionBeads)
@@ -5586,17 +5616,13 @@ func TestSelectOrCreatePoolSessionBead_AliasedPoolStillCASesTheSlot(t *testing.T
 	select {
 	case <-store.secondCreateStarted:
 		close(store.releaseFirstCreate)
-		close(store.releaseSecondCreate)
 		t.Fatal("second pool create reached the store before the first finished; alias lock did not serialize create")
-	case <-time.After(150 * time.Millisecond):
+	case <-done:
 		close(store.releaseFirstCreate)
-		select {
-		case <-store.secondCreateStarted:
-			close(store.releaseSecondCreate)
-		case <-time.After(time.Second):
-			t.Fatal("second pool create did not start after the first completed")
-		}
+		t.Fatal("a create returned while the first still held the lock")
+	case <-time.After(150 * time.Millisecond):
 	}
+	close(store.releaseFirstCreate)
 	for i := 0; i < 2; i++ {
 		<-done
 	}
@@ -8550,11 +8576,8 @@ func TestBuildDesiredState_UsesBeadNamedPoolSessionsForScaleCheckDemand(t *testi
 	if tp.TemplateName != "worker" {
 		t.Fatalf("TemplateName = %q, want worker", tp.TemplateName)
 	}
-	if !strings.HasPrefix(sessionName, "worker-") {
-		t.Fatalf("session name = %q, want worker-<beadID>", sessionName)
-	}
-	if strings.HasSuffix(sessionName, "-1") {
-		t.Fatalf("session name = %q, want bead-derived name instead of slot alias", sessionName)
+	if got := poolIdentitySessionName("worker-1", "worker"); sessionName != got {
+		t.Fatalf("session name = %q, want the slot's identity-derived runtime name %q", sessionName, got)
 	}
 
 	sessionBeads, err := store.ListByLabel(sessionBeadLabel, 0)
@@ -10363,7 +10386,7 @@ func TestSelectOrCreatePoolSessionBead_DoesNotRetagDuplicateConcreteSlot(t *test
 }
 
 func TestSelectOrCreatePoolSessionBead_DoesNotReserveFreshSlotOnCreateError(t *testing.T) {
-	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
+	store := &failingSessionBeadCreateStore{MemStore: beads.NewMemStore()}
 	snapshot := &sessionBeadSnapshot{}
 	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
 	usedSlots := map[int]bool{}
@@ -10831,7 +10854,13 @@ func TestSelectOrCreatePoolSessionBeadPicksEarliestReusableSingletonCandidate(t 
 	}
 }
 
-func TestSelectOrCreateDependencyPoolSessionBead_DefersAliasWhenConcreteAliasTaken(t *testing.T) {
+// TestSelectOrCreateDependencyPoolSessionBead_BlocksWhenConcreteAliasTaken:
+// a manual session holding "claude-1" as its alias owns that handle, so the
+// pool slot whose identity derives the same runtime name cannot have it. The
+// create fails closed and retries next tick against the same name rather than
+// minting a bead-ID-scoped sibling box (ga-vcjr9). The operator sees the
+// holder named in the error.
+func TestSelectOrCreateDependencyPoolSessionBead_BlocksWhenConcreteAliasTaken(t *testing.T) {
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{
 		Title:  "manual session",
@@ -10857,18 +10886,16 @@ func TestSelectOrCreateDependencyPoolSessionBead_DefersAliasWhenConcreteAliasTak
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "claude")
-	if err != nil {
-		t.Fatalf("selectOrCreateDependencyPoolSessionBead: %v", err)
+	_, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "claude")
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("selectOrCreateDependencyPoolSessionBead error = %v, want errPoolSessionNameUnavailable", err)
 	}
-	if got := result.AgentName; got != "claude-1" {
-		t.Fatalf("dependency agent_name = %q, want claude-1", got)
+	sessions, listErr := store.ListByLabel(sessionBeadLabel, 0)
+	if listErr != nil {
+		t.Fatalf("ListByLabel(%q): %v", sessionBeadLabel, listErr)
 	}
-	if got := result.Alias; got != "" {
-		t.Fatalf("dependency alias = %q, want deferred until alias guard accepts it", got)
-	}
-	if got := result.PoolSlot; got != "1" {
-		t.Fatalf("dependency pool_slot = %q, want 1", got)
+	if len(sessions) != 1 {
+		t.Fatalf("session beads = %d, want only the manual holder; a blocked slot must not mint a sibling", len(sessions))
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4351,13 +4351,21 @@ func TestControlDispatcherTickRepairsRigRouteAndRestartsRuntimeMissingDispatcher
 	// materializing its replacement, so allow its bounded multi-tick convergence
 	// path without relying on the targeted dispatcher signal. Wait after each
 	// pass so the next tick observes committed async-start state instead of racing
-	// four reconciles ahead of their completion.
+	// several reconciles ahead of their completion.
+	//
+	// The replacement's runtime name is the dead session's name — it is derived
+	// from the dispatcher identity, not from a bead ID (ga-vcjr9) — so the retire
+	// must commit before the create can claim it, and the create before the
+	// start. The main ticks drive retire + re-materialize; the targeted
+	// dispatcher signal then starts the replacement the same way it started the
+	// original above.
 	for tick := range 4 {
 		runMainTick()
 		if !cr.waitForAsyncStarts() {
 			t.Fatalf("replacement async starts did not settle after recovery tick %d", tick+1)
 		}
 	}
+	cr.controlDispatcherTick(context.Background())
 	recoveryDeadline := time.NewTimer(testutil.GoroutineRaceTimeout)
 	recoveryTicker := time.NewTicker(10 * time.Millisecond)
 	defer recoveryDeadline.Stop()

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"log"
 	"path"
@@ -61,12 +63,50 @@ type releasedPoolAssignment struct {
 	Index int
 }
 
-// PoolSessionName derives the tmux session name for a pool worker session.
-// Format: {basename(template)}-{beadID} (e.g., "claude-mc-xyz").
-// Named sessions with an alias use the alias instead.
+// PoolSessionName derives the legacy bead-ID-scoped session name for a pool
+// worker session. Format: {basename(template)}-{beadID} (e.g., "claude-mc-xyz").
+//
+// Fresh pool session beads no longer get their runtime name from this
+// derivation — see poolIdentitySessionName. It survives as the recognizer for
+// beads created before the change (beadOwnsPoolSessionName and the slot-recovery
+// fallbacks in build_desired_state.go still read it).
 func PoolSessionName(template, beadID string) string {
 	base := path.Base(template)
 	return agent.SanitizeQualifiedNameForSession(base) + "-" + beadID
+}
+
+// poolIdentitySessionName returns the runtime session name for a pool
+// instance. It is a pure function of the resolved pool identity — the
+// qualified instance name the planner derives from config and slot — so every
+// create attempt for the same slot addresses the same runtime box.
+//
+// It deliberately does not embed the session bead ID. A bead-ID-scoped name
+// mints a fresh runtime identity on every attempt, and because the runtime
+// name is the sandbox name (and therefore the pod name), a pool whose start op
+// keeps failing then leaks one box per attempt with nothing left to address the
+// previous one by. That is ga-vcjr9: desired=1, 602 pods.
+func poolIdentitySessionName(identity, template string) string {
+	base := strings.TrimSpace(identity)
+	if base == "" {
+		base = targetBasename(template)
+	}
+	if base == "" {
+		base = "pool"
+	}
+	return boundSessionNameLength(agent.SanitizeQualifiedNameForSession(base))
+}
+
+// boundSessionNameLength keeps a derived name inside the explicit-name length
+// limit without giving up identity stability: the shortened form carries a
+// digest of the full name, so identities sharing a long prefix stay distinct
+// and each identity always shortens to the same result.
+func boundSessionNameLength(name string) string {
+	if len(name) <= session.MaxExplicitSessionNameLen {
+		return name
+	}
+	sum := sha256.Sum256([]byte(name))
+	suffix := "-" + hex.EncodeToString(sum[:])[:10]
+	return name[:session.MaxExplicitSessionNameLen-len(suffix)] + suffix
 }
 
 // GCSweepSessionBeads closes open session beads that have no remaining

--- a/cmd/gc/pool_session_name_churn_test.go
+++ b/cmd/gc/pool_session_name_churn_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// poolChurnIdentity is the pool instance identity used by the churn tests: a
+// concrete slot on an expanding pool, exactly as poolDesiredRequestIdentity
+// hands it to the create path.
+func poolChurnIdentity() poolSessionCreateIdentity {
+	return poolSessionCreateIdentity{AgentName: "gastown/bd.dog-1", Slot: 1}
+}
+
+const poolChurnTemplate = "gastown/bd.dog"
+
+// TestPoolSessionCreate_FailedRetriesAddressOneRuntimeName is the ga-vcjr9
+// regression pin. On cherry a pool whose start op failed every tick produced a
+// NEW runtime session name per attempt (bd__dog-<beadID>), and because the
+// runtime name is the sandbox pod name, 600+ pods for a pool whose desired
+// count was 1.
+//
+// The loop modeled here is the measured one: create the pool session bead,
+// fail the start, roll the bead back as failed_create (the reconciler's
+// rollbackPendingCreateClears path), repeat. The invariant is that every
+// attempt for the same pool identity addresses the SAME runtime box.
+func TestPoolSessionCreate_FailedRetriesAddressOneRuntimeName(t *testing.T) {
+	store := beads.NewMemStore()
+	front := sessionFrontDoor(store)
+	identity := poolChurnIdentity()
+
+	seen := map[string]struct{}{}
+	for attempt := 1; attempt <= 5; attempt++ {
+		now := time.Date(2026, 8, 15, 0, 0, attempt, 0, time.UTC)
+		info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, now, identity, "")
+		if err != nil {
+			t.Fatalf("attempt %d: createPoolSessionBeadWithAlias: %v", attempt, err)
+		}
+		name := strings.TrimSpace(info.SessionNameMetadata)
+		if name == "" {
+			t.Fatalf("attempt %d: empty session_name on %s", attempt, info.ID)
+		}
+		seen[name] = struct{}{}
+		// The start op failed; the reconciler rolls the pending create back by
+		// closing the bead as failed_create.
+		if !closeFailedCreateBead(front, info.ID, now, io.Discard) {
+			t.Fatalf("attempt %d: closeFailedCreateBead(%s) failed", attempt, info.ID)
+		}
+	}
+
+	if len(seen) != 1 {
+		t.Fatalf("5 failed create attempts minted %d distinct runtime session names %v; want 1 — every extra name is a leaked sandbox box (ga-vcjr9)", len(seen), sortedNameSet(seen))
+	}
+}
+
+// TestPoolSessionCreate_NameIsIndependentOfBeadID is the direct statement of
+// the structural invariant: the runtime name is a pure function of the
+// configured pool identity, so no bead ID can appear in it.
+func TestPoolSessionCreate_NameIsIndependentOfBeadID(t *testing.T) {
+	store := beads.NewMemStore()
+	identity := poolChurnIdentity()
+
+	info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
+	}
+	name := strings.TrimSpace(info.SessionNameMetadata)
+	if strings.Contains(name, info.ID) {
+		t.Fatalf("session_name %q embeds bead ID %q; the runtime name must derive from the pool identity alone (ga-vcjr9)", name, info.ID)
+	}
+	if want := poolIdentitySessionName(identity.AgentName, poolChurnTemplate); name != want {
+		t.Fatalf("session_name = %q, want %q (pool identity derivation)", name, want)
+	}
+}
+
+// TestPoolSessionCreate_DistinctSlotsGetDistinctNames is the control for the
+// test above: a fix that collapsed every pool session onto one name would pass
+// the churn test and destroy the pool. Distinct slots must stay distinct.
+func TestPoolSessionCreate_DistinctSlotsGetDistinctNames(t *testing.T) {
+	store := beads.NewMemStore()
+
+	names := map[string]struct{}{}
+	for slot := 1; slot <= 3; slot++ {
+		identity := poolSessionCreateIdentity{
+			AgentName: "gastown/bd.dog-" + string(rune('0'+slot)),
+			Slot:      slot,
+		}
+		info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, time.Now().UTC(), identity, "")
+		if err != nil {
+			t.Fatalf("slot %d: createPoolSessionBeadWithAlias: %v", slot, err)
+		}
+		names[strings.TrimSpace(info.SessionNameMetadata)] = struct{}{}
+	}
+	if len(names) != 3 {
+		t.Fatalf("3 distinct pool slots produced %d distinct session names %v; want 3", len(names), sortedNameSet(names))
+	}
+}
+
+// TestPoolSessionCreate_LiveHolderKeepsItsNameAndBlocksTheSlot is the MANDATORY
+// reverse control. Reusing a name is only safe when the previous holder is
+// dead. While a live session bead holds the pool identity's runtime name, a
+// fresh create must NOT hand that name out — and must NOT fall back to minting
+// a bead-ID-suffixed sibling either, because that fallback is the leak.
+//
+// A fix that reuses the name over a living session is strictly worse than the
+// leak it replaces: it points a second agent at a box that already has one.
+func TestPoolSessionCreate_LiveHolderKeepsItsNameAndBlocksTheSlot(t *testing.T) {
+	store := beads.NewMemStore()
+	identity := poolChurnIdentity()
+
+	live, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("live createPoolSessionBeadWithAlias: %v", err)
+	}
+	liveName := strings.TrimSpace(live.SessionNameMetadata)
+
+	second, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, time.Now().UTC(), identity, "")
+	if err == nil {
+		t.Fatalf("second create returned session_name %q while %s is live; want a typed unavailable error", second.SessionNameMetadata, live.ID)
+	}
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("second create error = %v, want errPoolSessionNameUnavailable", err)
+	}
+
+	stored, getErr := store.Get(live.ID)
+	if getErr != nil {
+		t.Fatalf("store.Get(%s): %v", live.ID, getErr)
+	}
+	if got := strings.TrimSpace(stored.Metadata["session_name"]); got != liveName {
+		t.Fatalf("live session_name = %q, want %q (a blocked create must not disturb the live holder)", got, liveName)
+	}
+	if stored.Status == "closed" {
+		t.Fatalf("live session bead %s was closed by a blocked create", live.ID)
+	}
+
+	all, listErr := store.ListByLabel(sessionBeadLabel, 0)
+	if listErr != nil {
+		t.Fatalf("ListByLabel(%q): %v", sessionBeadLabel, listErr)
+	}
+	for _, b := range all {
+		if b.ID == live.ID {
+			continue
+		}
+		t.Fatalf("blocked create left session bead %s (session_name %q) behind; no suffixed sibling may be minted", b.ID, b.Metadata["session_name"])
+	}
+}
+
+// TestPoolSessionCreate_ConfiguredNamedSessionOwnerReusesItsOwnName closes the
+// selfOwner=="" gap. A pool that materializes a configured named session's
+// identity must be allowed to claim that identity's reserved runtime name;
+// otherwise the config reservation rejects it on every tick and — before the
+// fix — the rejection was what minted a fresh suffixed name each time.
+func TestPoolSessionCreate_ConfiguredNamedSessionOwnerReusesItsOwnName(t *testing.T) {
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		NamedSessions: []config.NamedSession{{Name: "crew", Template: "worker"}},
+	}
+	reserved := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "crew")
+
+	store := beads.NewMemStore()
+	info, err := createPoolSessionBeadWithAlias(store, "worker", cfg, newSessionBeadSnapshot(nil), time.Now().UTC(),
+		poolSessionCreateIdentity{AgentName: "crew"}, reserved)
+	if err != nil {
+		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
+	}
+	if got := strings.TrimSpace(info.SessionNameMetadata); got != reserved {
+		t.Fatalf("session_name = %q, want the reserved runtime name %q for its own configured owner", got, reserved)
+	}
+}
+
+// TestPoolSessionCreate_ForeignConfiguredReservationStillBlocks is the control
+// for the test above: passing the owner through must not turn the config
+// reservation off for a pool that does NOT own the reserved name.
+func TestPoolSessionCreate_ForeignConfiguredReservationStillBlocks(t *testing.T) {
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		NamedSessions: []config.NamedSession{{Name: "crew", Template: "worker"}},
+	}
+	reserved := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "crew")
+
+	store := beads.NewMemStore()
+	_, err := createPoolSessionBeadWithAlias(store, "worker", cfg, newSessionBeadSnapshot(nil), time.Now().UTC(),
+		poolSessionCreateIdentity{AgentName: "squatter"}, reserved)
+	if err == nil {
+		t.Fatal("createPoolSessionBeadWithAlias claimed a name reserved for a different configured named session")
+	}
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("error = %v, want errPoolSessionNameUnavailable", err)
+	}
+}
+
+func sortedNameSet(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/gc/pool_session_name_churn_test.go
+++ b/cmd/gc/pool_session_name_churn_test.go
@@ -39,7 +39,15 @@ func TestPoolSessionCreate_FailedRetriesAddressOneRuntimeName(t *testing.T) {
 	seen := map[string]struct{}{}
 	for attempt := 1; attempt <= 5; attempt++ {
 		now := time.Date(2026, 8, 15, 0, 0, attempt, 0, time.UTC)
-		info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, now, identity, "")
+		// A fresh tick snapshot, loaded before the previous attempt's rollback
+		// is visible to it — the production shape, and the one that catches a
+		// fix whose retry stalls on its own dead predecessor.
+		open, err := loadSessionBeads(store)
+		if err != nil {
+			t.Fatalf("attempt %d: loadSessionBeads: %v", attempt, err)
+		}
+		snapshot := newSessionBeadSnapshot(open)
+		info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, snapshot, now, identity, "")
 		if err != nil {
 			t.Fatalf("attempt %d: createPoolSessionBeadWithAlias: %v", attempt, err)
 		}

--- a/cmd/gc/pool_session_name_holder_test.go
+++ b/cmd/gc/pool_session_name_holder_test.go
@@ -171,3 +171,74 @@ func TestPoolSessionCreate_FailedCreateHolderReleasesItsName(t *testing.T) {
 type discardWriter struct{}
 
 func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// degradedQueryStore answers writes and Get normally but fails every metadata
+// query — the shape of a store whose backend is reachable enough to have
+// written this tick's beads but cannot serve the reservation scan.
+type degradedQueryStore struct {
+	beads.Store
+	err error
+}
+
+func (s degradedQueryStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if len(q.Metadata) > 0 {
+		return nil, s.err
+	}
+	return s.Store.List(q)
+}
+
+// TestPoolSessionCreate_LiveHolderBlocksEvenWhenTheStoreScanCannotAnswer is the
+// case only the in-tick snapshot check can catch, and the reason that check
+// exists as a separate layer rather than as a duplicate of the store scan.
+//
+// derivePoolSessionName deliberately proceeds on the identity-derived name when
+// the reservation scan errors: the name is idempotent per slot, so an
+// unverified claim re-addresses the slot's own box, and refusing would stall
+// every unaliased pool create for as long as the store is unhappy. That
+// tolerance is only safe because the snapshot of this tick's open beads is
+// consulted FIRST. Lose the ordering, or lose the snapshot check, and a
+// degraded store becomes a licence to point a second agent at a live session's
+// box — the one outcome worse than the leak.
+func TestPoolSessionCreate_LiveHolderBlocksEvenWhenTheStoreScanCannotAnswer(t *testing.T) {
+	mem := beads.NewMemStore()
+	identity := poolChurnIdentity()
+
+	live, err := createPoolSessionBeadWithAlias(mem, poolChurnTemplate, nil, nil, time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("live create: %v", err)
+	}
+	open, err := loadSessionBeads(mem)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	snapshot := newSessionBeadSnapshot(open)
+
+	degraded := degradedQueryStore{Store: mem, err: errors.New("gateway unreachable")}
+	second, err := createPoolSessionBeadWithAlias(degraded, poolChurnTemplate, nil, snapshot, time.Now().UTC(), identity, "")
+	if err == nil {
+		t.Fatalf("create handed %q to a second bead while %s holds it live, because the store scan could not answer", second.SessionNameMetadata, live.ID)
+	}
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("create error = %v, want errPoolSessionNameUnavailable", err)
+	}
+}
+
+// TestPoolSessionCreate_DegradedStoreStillCreatesWithoutALiveHolder is the
+// discriminating control for the test above: the tolerance it guards must
+// actually be there. With the same unanswerable store and no live holder in the
+// snapshot, the create proceeds — otherwise a degraded store would stall every
+// pool in the city, which is the failure mode the fail-closed derive was
+// specifically designed not to have.
+func TestPoolSessionCreate_DegradedStoreStillCreatesWithoutALiveHolder(t *testing.T) {
+	mem := beads.NewMemStore()
+	identity := poolChurnIdentity()
+
+	degraded := degradedQueryStore{Store: mem, err: errors.New("gateway unreachable")}
+	info, err := createPoolSessionBeadWithAlias(degraded, poolChurnTemplate, nil, newSessionBeadSnapshot(nil), time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("create refused on a degraded store with nothing holding the name: %v", err)
+	}
+	if want := poolIdentitySessionName(identity.AgentName, poolChurnTemplate); strings.TrimSpace(info.SessionNameMetadata) != want {
+		t.Fatalf("session_name = %q, want %q", info.SessionNameMetadata, want)
+	}
+}

--- a/cmd/gc/pool_session_name_holder_test.go
+++ b/cmd/gc/pool_session_name_holder_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// seedPoolSessionBead creates a pool session bead through the production create
+// path and then rewrites the metadata the test cares about, so the fixture
+// stays a real bead rather than a hand-rolled approximation of one.
+func seedPoolSessionBead(t *testing.T, store beads.Store, identity poolSessionCreateIdentity, overrides map[string]string) sessionpkg.Info {
+	t.Helper()
+	info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, nil, time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("seeding pool session bead: %v", err)
+	}
+	front := sessionFrontDoor(store)
+	for k, v := range overrides {
+		if err := front.SetMarker(info.ID, k, v); err != nil {
+			t.Fatalf("seeding %s=%q on %s: %v", k, v, info.ID, err)
+		}
+	}
+	return info
+}
+
+// TestPoolSessionCreate_LegacyBeadIDHolderDoesNotStallTheSlot is the day-one
+// migration guard, and the one condition the fix could not ship without.
+//
+// Failing the create closed is only safe if the names that are actually held on
+// a running fleet get released. The live holder on cherry is an OPEN, asleep
+// pool bead (gcg-session-a11f2898) that has no pod, holds the pool alias
+// "bd.dog-1", and — critically — holds the LEGACY bead-ID-scoped session_name
+// this change stops minting. If the identity-derived name collided with that
+// holder, the fail-closed derive would convert a 115-pods/hour leak into a
+// permanently stalled pool on the first tick after deploy: strictly worse,
+// because a leak is visible and a silent stall is not.
+//
+// It does not collide, and this pins why: the holder reserves the name it was
+// minted with, and that is a different string from the one identity derives.
+func TestPoolSessionCreate_LegacyBeadIDHolderDoesNotStallTheSlot(t *testing.T) {
+	store := beads.NewMemStore()
+	identity := poolChurnIdentity()
+
+	holder := seedPoolSessionBead(t, store, identity, nil)
+	legacyName := PoolSessionName(poolChurnTemplate, holder.ID)
+	front := sessionFrontDoor(store)
+	// The live cherry shape: asleep, no runtime box, still open, still holding
+	// the pool alias and the bead-ID-scoped runtime name.
+	for k, v := range map[string]string{
+		"session_name": legacyName,
+		"alias":        "bd.dog-1",
+		"state":        string(sessionpkg.StateAsleep),
+		"sleep_reason": "runtime-missing",
+	} {
+		if err := front.SetMarker(holder.ID, k, v); err != nil {
+			t.Fatalf("seeding %s on holder: %v", k, err)
+		}
+	}
+
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, newSessionBeadSnapshot(open), time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("create stalled behind the legacy bead-ID holder %s (session_name %q): %v — a fail-closed derive that cannot get past the names already on a running fleet is a permanent pool outage, not a fix", holder.ID, legacyName, err)
+	}
+	got := strings.TrimSpace(info.SessionNameMetadata)
+	if want := poolIdentitySessionName(identity.AgentName, poolChurnTemplate); got != want {
+		t.Fatalf("session_name = %q, want the identity-derived %q", got, want)
+	}
+	if got == legacyName {
+		t.Fatalf("new create claimed the legacy holder's own name %q", legacyName)
+	}
+}
+
+// TestPoolSessionCreate_SweptSlotReleasesItsNameForTheNextAttempt pins the
+// release rule the fail-closed derive rests on. A retired pool slot is closed
+// with an ordinary reason (orphaned, gc_swept) rather than failed_create, so
+// the failed_create release in internal/session/names.go does not apply to it;
+// what releases the name is the pool carve-out, and that carve-out reads two
+// metadata keys this create path writes. If either stops being written the
+// slot's name is reserved by a dead bead forever and the pool never starts
+// again.
+func TestPoolSessionCreate_SweptSlotReleasesItsNameForTheNextAttempt(t *testing.T) {
+	store := beads.NewMemStore()
+	identity := poolChurnIdentity()
+	front := sessionFrontDoor(store)
+
+	retired := seedPoolSessionBead(t, store, identity, nil)
+	retiredName := strings.TrimSpace(retired.SessionNameMetadata)
+	if _, err := front.Close(retired.ID, "orphaned", time.Now().UTC()); err != nil {
+		t.Fatalf("closing retired slot: %v", err)
+	}
+
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, newSessionBeadSnapshot(open), time.Now().UTC(), identity, "")
+	if err != nil {
+		t.Fatalf("create stalled behind swept slot %s: %v", retired.ID, err)
+	}
+	if got := strings.TrimSpace(info.SessionNameMetadata); got != retiredName {
+		t.Fatalf("replacement session_name = %q, want the slot's own name %q back", got, retiredName)
+	}
+}
+
+// TestPoolSessionCreate_SweptSlotWithoutPoolMarkersStillBlocks is the
+// discriminating control for the test above. The release is not "closed beads
+// let go"; it is specifically the pool_managed + ephemeral carve-out. Strip one
+// of those markers and the same closed bead reserves the name permanently — so
+// the test above genuinely proves the markers are being written, rather than
+// passing because closure alone is enough.
+func TestPoolSessionCreate_SweptSlotWithoutPoolMarkersStillBlocks(t *testing.T) {
+	store := beads.NewMemStore()
+	identity := poolChurnIdentity()
+	front := sessionFrontDoor(store)
+
+	retired := seedPoolSessionBead(t, store, identity, map[string]string{"session_origin": ""})
+	if _, err := front.Close(retired.ID, "orphaned", time.Now().UTC()); err != nil {
+		t.Fatalf("closing retired slot: %v", err)
+	}
+
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	_, err = createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, newSessionBeadSnapshot(open), time.Now().UTC(), identity, "")
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("create error = %v, want errPoolSessionNameUnavailable — without the pool markers a closed bead reserves its explicit name for good", err)
+	}
+}
+
+// TestPoolSessionCreate_FailedCreateHolderReleasesItsName is the other half of
+// the availability story, and the one the retry loop depends on every tick: the
+// rollback closes a failed attempt as failed_create, and the very next attempt
+// must be able to claim the same name. If it could not, the fail-closed derive
+// would stall the slot after a single failed start — which is the leak's own
+// failure mode wearing different clothes.
+func TestPoolSessionCreate_FailedCreateHolderReleasesItsName(t *testing.T) {
+	store := beads.NewMemStore()
+	identity := poolChurnIdentity()
+	front := sessionFrontDoor(store)
+	now := time.Now().UTC()
+
+	first := seedPoolSessionBead(t, store, identity, nil)
+	firstName := strings.TrimSpace(first.SessionNameMetadata)
+	if !closeFailedCreateBead(front, first.ID, now, discardWriter{}) {
+		t.Fatalf("closeFailedCreateBead(%s) failed", first.ID)
+	}
+
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	info, err := createPoolSessionBeadWithAlias(store, poolChurnTemplate, nil, newSessionBeadSnapshot(open), now, identity, "")
+	if err != nil {
+		t.Fatalf("retry after a rolled-back attempt: %v", err)
+	}
+	if got := strings.TrimSpace(info.SessionNameMetadata); got != firstName {
+		t.Fatalf("retry session_name = %q, want the same %q — a retry that changes name is a new runtime box", got, firstName)
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/cmd/gc/pool_session_name_holder_test.go
+++ b/cmd/gc/pool_session_name_holder_test.go
@@ -197,7 +197,7 @@ func (s degradedQueryStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 // every unaliased pool create for as long as the store is unhappy. That
 // tolerance is only safe because the snapshot of this tick's open beads is
 // consulted FIRST. Lose the ordering, or lose the snapshot check, and a
-// degraded store becomes a licence to point a second agent at a live session's
+// degraded store becomes a license to point a second agent at a live session's
 // box — the one outcome worse than the leak.
 func TestPoolSessionCreate_LiveHolderBlocksEvenWhenTheStoreScanCannotAnswer(t *testing.T) {
 	mem := beads.NewMemStore()

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1908,7 +1908,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					// bead-ID name is a fresh runtime box per attempt, which is
 					// the ga-vcjr9 leak. Same derivation as the planner's
 					// create path (derivePoolSessionName).
-					createdSessionName = poolIdentitySessionName(agentName, qualifiedTemplate)
+					createdSessionName = poolRuntimeSessionName(cfg, agentName, qualifiedTemplate)
 					if err := sessFront.SetMarker(newBead.ID, "session_name", createdSessionName); err != nil {
 						finalizeErr = err
 						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1908,7 +1908,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					// bead-ID name is a fresh runtime box per attempt, which is
 					// the ga-vcjr9 leak. Same derivation as the planner's
 					// create path (derivePoolSessionName).
-					createdSessionName = poolRuntimeSessionName(cfg, agentName, qualifiedTemplate)
+					createdSessionName = poolRuntimeSessionName(cfg, agentName, qualifiedTemplate, transientPoolSlot)
 					if err := sessFront.SetMarker(newBead.ID, "session_name", createdSessionName); err != nil {
 						finalizeErr = err
 						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1904,7 +1904,11 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			finalizeCreatedSessionName := func() {
 				createdSessionName = strings.TrimSpace(newBead.Metadata["session_name"])
 				if isPoolInstance {
-					createdSessionName = PoolSessionName(qualifiedTemplate, newBead.ID)
+					// Derived from the pool identity, never the bead ID: a
+					// bead-ID name is a fresh runtime box per attempt, which is
+					// the ga-vcjr9 leak. Same derivation as the planner's
+					// create path (derivePoolSessionName).
+					createdSessionName = poolIdentitySessionName(agentName, qualifiedTemplate)
 					if err := sessFront.SetMarker(newBead.ID, "session_name", createdSessionName); err != nil {
 						finalizeErr = err
 						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -3428,7 +3428,7 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 			t.Fatalf("new bead %s reused visible owner bead %s session_name %q", b.ID, owner.ID, ownerSessionName)
 		}
 		if b.ID != owner.ID && b.Metadata["pool_slot"] == "2" {
-			if got, want := b.Metadata["session_name"], PoolSessionName(template, b.ID); got != want {
+			if got, want := b.Metadata["session_name"], poolIdentitySessionName(b.Metadata["agent_name"], template); got != want {
 				t.Fatalf("new pool bead session_name = %q, want %q", got, want)
 			}
 		}
@@ -3466,7 +3466,7 @@ func TestSyncSessionBeads_FinalizesPoolSessionNameUnderAliasLock(t *testing.T) {
 	if len(all) != 1 {
 		t.Fatalf("session bead count = %d, want 1", len(all))
 	}
-	if got, want := all[0].Metadata["session_name"], PoolSessionName(template, all[0].ID); got != want {
+	if got, want := all[0].Metadata["session_name"], poolIdentitySessionName(alias, template); got != want {
 		t.Fatalf("session_name = %q, want %q", got, want)
 	}
 }
@@ -4418,26 +4418,6 @@ func TestSyncSessionBeads_PreservesStablePoolAliasConflictMetadataWhenAliasLockF
 	}
 	if !strings.Contains(stderr.String(), "locking alias") {
 		t.Fatalf("stderr %q does not mention alias lock failure", stderr.String())
-	}
-}
-
-func TestCreatePoolSessionBead_MetadataFailureLeavesReachablePlaceholder(t *testing.T) {
-	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
-	template := "pack/worker"
-
-	if _, err := createPoolSessionBead(sessionFrontDoor(store), template, time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC), poolSessionCreateIdentity{}); err == nil {
-		t.Fatal("createPoolSessionBead returned nil error, want session_name metadata failure")
-	}
-
-	all := allSessionBeads(t, store)
-	if len(all) != 1 {
-		t.Fatalf("created %d session beads, want 1 failed-create bead", len(all))
-	}
-	if got := strings.TrimSpace(all[0].Metadata["session_name"]); got == "" {
-		t.Fatalf("failed pool bead session_name is empty: %+v", all[0])
-	}
-	if got, final := all[0].Metadata["session_name"], PoolSessionName(template, all[0].ID); got == final {
-		t.Fatalf("failed pool bead session_name = final name %q even though SetMetadata failed", got)
 	}
 }
 

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,6 +23,12 @@ const poolManagedMetadataKey = "pool_managed"
 // a fresh runtime identity, because minting a fresh name per attempt is what
 // leaks a sandbox box per attempt (ga-vcjr9).
 var errPoolSessionNameUnavailable = errors.New("pool session name unavailable")
+
+// poolRuntimeNameSuffix separates a pool instance's runtime name from the
+// runtime name config reserves for a configured named session built on the same
+// agent. Both identities are the agent's; only one of them may own the bare
+// name, and config's claim wins.
+const poolRuntimeNameSuffix = "-pool"
 
 type explicitBeadIDStore interface {
 	IDPrefix() string
@@ -330,7 +337,7 @@ func derivePoolSessionName(store beads.Store, cfg *config.City, template string,
 	sessionName := resolvedTmuxAlias
 	switch {
 	case sessionName == "":
-		sessionName = poolIdentitySessionName(identity.AgentName, template)
+		sessionName = poolRuntimeSessionName(cfg, identity.AgentName, template)
 	case identity.Slot > 1:
 		// Slot 1 keeps the bare alias; higher slots carry their slot number so
 		// a multi-instance pool sharing one configured alias still maps each
@@ -344,7 +351,18 @@ func derivePoolSessionName(store beads.Store, cfg *config.City, template string,
 		if errors.Is(err, sessionpkg.ErrSessionNameExists) {
 			return "", fmt.Errorf("%w: template %q identity %q wants %q: %w", errPoolSessionNameUnavailable, template, identity.AgentName, sessionName, err)
 		}
-		return "", fmt.Errorf("checking pool session_name for template %q: %w", template, err)
+		if resolvedTmuxAlias != "" {
+			return "", fmt.Errorf("checking pool session_name for template %q: %w", template, err)
+		}
+		// The reservation scan could not answer — a degraded store, not a
+		// collision. Proceed on the identity-derived name: unlike the bead-ID
+		// name it replaced, it is idempotent per pool slot, so an unverified
+		// claim addresses the box this slot already owns instead of
+		// provisioning another one. Refusing would stall every unaliased pool
+		// create for as long as the store is unhappy. A resolved tmux_alias is
+		// a name the operator chose and may be shared, so that lane keeps its
+		// fail-closed behavior.
+		log.Printf("pool session_name check for template %q could not answer; proceeding on identity-derived %q: %v", template, sessionName, err)
 	}
 	return sessionName, nil
 }
@@ -362,6 +380,41 @@ func ensurePoolSessionNameAvailable(store beads.Store, cfg *config.City, snapsho
 	return sessionpkg.EnsureSessionNameAvailableWithConfigForOwner(store, cfg, name, "", selfOwner)
 }
 
+// poolRuntimeSessionName is the runtime session name for a pool instance with
+// no configured tmux_alias. It is poolIdentitySessionName, except that a pool
+// instance of an agent that is ALSO a configured named session's template
+// shares that agent's identity and would otherwise land on the name config
+// reserves for the named session. The pool is a different runtime box, so it
+// steps aside onto a distinct name — still identity-derived, still free of the
+// bead ID.
+func poolRuntimeSessionName(cfg *config.City, identityName, template string) string {
+	name := poolIdentitySessionName(identityName, template)
+	if configuredNamedSessionReservesRuntimeName(cfg, name) {
+		name += poolRuntimeNameSuffix
+	}
+	return name
+}
+
+// configuredNamedSessionReservesRuntimeName reports whether name is the runtime
+// session name config reserves for some configured named session. It mirrors
+// the reservation loop in session.ensureConfiguredSessionNameAvailable so the
+// pool can step aside before that check rejects it.
+func configuredNamedSessionReservesRuntimeName(cfg *config.City, name string) bool {
+	if cfg == nil || strings.TrimSpace(name) == "" {
+		return false
+	}
+	for _, named := range cfg.NamedSessions {
+		reserved := strings.TrimSpace(named.QualifiedName())
+		if reserved == "" {
+			continue
+		}
+		if config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, reserved) == name {
+			return true
+		}
+	}
+	return false
+}
+
 func validateResolvedPoolTmuxAlias(template, resolvedTmuxAlias string) (string, error) {
 	resolvedTmuxAlias = strings.TrimSpace(resolvedTmuxAlias)
 	if resolvedTmuxAlias == "" {
@@ -376,6 +429,13 @@ func validateResolvedPoolTmuxAlias(template, resolvedTmuxAlias string) (string, 
 
 // openSessionNameTaken reports whether any open session bead in the snapshot
 // already advertises name as its session_name.
+//
+// An OPEN bead holds its name even when its state is failed_create: the
+// pending-create lease has not expired, the desired-state map is keyed by
+// session name, and handing the name out twice collapses the two beads onto one
+// entry. The rollback closes the bead, and a closed one is not in this snapshot,
+// so the retry the rollback exists to enable gets the name back on the next
+// tick.
 func openSessionNameTaken(snapshot *sessionBeadSnapshot, name string) bool {
 	if snapshot == nil || strings.TrimSpace(name) == "" {
 		return false

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -39,6 +39,15 @@ type poolSessionCreateIdentity struct {
 	Alias     string
 	Slot      int
 	Metadata  map[string]string
+	// TransientSlot marks a pool slot that is a rebinding chair, not an
+	// occupant identity (an expanding pool with no namepool and no canonical
+	// singleton — usesTransientPoolSlotIdentity). The runtime session name for
+	// such a slot must step aside from the bare slot string so the slot never
+	// reaches the identity channel via GC_AGENT (#5241; the transient sibling
+	// of the ga-vcjr9 leak). It threads through the create path without a
+	// signature change so the many zero-value create-path callers are
+	// unaffected.
+	TransientSlot bool
 }
 
 func isPoolManagedSessionBead(bead beads.Bead) bool {
@@ -335,14 +344,25 @@ func derivePoolSessionName(store beads.Store, cfg *config.City, template string,
 		return "", err
 	}
 	sessionName := resolvedTmuxAlias
+	// identityName is the bare identity-derived name before any transient
+	// step-aside. A transient slot's runtime name steps aside from it (…-pool),
+	// so the runtime-name availability check below no longer covers the identity
+	// itself; the guard after it re-asserts the identity on this unaliased lane.
+	identityName := ""
 	switch {
 	case sessionName == "":
-		sessionName = poolRuntimeSessionName(cfg, identity.AgentName, template)
+		identityName = poolIdentitySessionName(identity.AgentName, template)
+		sessionName = poolRuntimeSessionName(cfg, identity.AgentName, template, identity.TransientSlot)
 	case identity.Slot > 1:
 		// Slot 1 keeps the bare alias; higher slots carry their slot number so
 		// a multi-instance pool sharing one configured alias still maps each
-		// slot onto its own stable box.
-		sessionName += "-" + strconv.Itoa(identity.Slot)
+		// slot onto its own stable box. Assemble the full logical name including
+		// the "-<slot>" suffix, then shorten the whole thing: a tmux_alias valid
+		// exactly at MaxExplicitSessionNameLen would otherwise overflow once the
+		// suffix is appended and fail ValidateExplicitName below, locking that
+		// slot out of creation forever. boundSessionNameLength is a no-op for the
+		// common short alias, so ordinary names keep their exact form.
+		sessionName = boundSessionNameLength(sessionName + "-" + strconv.Itoa(identity.Slot))
 	}
 	if _, err := sessionpkg.ValidateExplicitName(sessionName); err != nil {
 		return "", fmt.Errorf("derived pool session_name for template %q: %w", template, err)
@@ -364,6 +384,27 @@ func derivePoolSessionName(store beads.Store, cfg *config.City, template string,
 		// fail-closed behavior.
 		log.Printf("pool session_name check for template %q could not answer; proceeding on identity-derived %q: %v", template, sessionName, err)
 	}
+	// A transient slot's runtime name stepped aside from its bare identity, so
+	// the check above validated "<identity>-pool", not the identity itself. Re-
+	// assert the identity: another live session already holding this concrete
+	// identity must fail the slot closed, not mint a sibling box next to it
+	// (ga-vcjr9 — the loser of a race for one identity is refused, guarded by
+	// TestSelectOrCreateDependencyPoolSessionBead_BlocksWhenConcreteAliasTaken).
+	// The config-reserved step-aside is deliberately exempt: there the pool is
+	// meant to coexist with its configured named-session peer, which owns the
+	// bare name by design.
+	if identity.TransientSlot && identityName != "" && identityName != sessionName &&
+		!configuredNamedSessionReservesRuntimeName(cfg, identityName) {
+		if err := ensurePoolSessionNameAvailable(store, cfg, snapshot, identityName, identity.AgentName); err != nil {
+			if errors.Is(err, sessionpkg.ErrSessionNameExists) {
+				return "", fmt.Errorf("%w: template %q identity %q already held: %w", errPoolSessionNameUnavailable, template, identity.AgentName, err)
+			}
+			// Degraded store: the identity guard is best-effort. The runtime name
+			// already validated as available and is idempotent per slot, so
+			// proceed rather than stall the create — same posture as above.
+			log.Printf("pool identity availability check for template %q could not answer; proceeding on identity-derived %q: %v", template, sessionName, err)
+		}
+	}
 	return sessionName, nil
 }
 
@@ -381,16 +422,30 @@ func ensurePoolSessionNameAvailable(store beads.Store, cfg *config.City, snapsho
 }
 
 // poolRuntimeSessionName is the runtime session name for a pool instance with
-// no configured tmux_alias. It is poolIdentitySessionName, except that a pool
-// instance of an agent that is ALSO a configured named session's template
-// shares that agent's identity and would otherwise land on the name config
-// reserves for the named session. The pool is a different runtime box, so it
-// steps aside onto a distinct name — still identity-derived, still free of the
-// bead ID.
-func poolRuntimeSessionName(cfg *config.City, identityName, template string) string {
+// no configured tmux_alias. It is poolIdentitySessionName, except that it steps
+// aside onto a distinct "<name>-pool" name — still identity-derived, still free
+// of the bead ID — in two cases:
+//
+//   - the pool instance shares an agent that is ALSO a configured named
+//     session's template, so poolIdentitySessionName would land on the name
+//     config reserves for the named session; or
+//   - transientSlot is true, meaning identityName is a transient pool slot
+//     ("pooled-1") rather than an occupant identity. clearPoolTemplateRuntimeIdentity
+//     puts GC_AGENT on the session name, so the name must not BE the slot or the
+//     slot leaks into the identity channel (#5241; the transient sibling of the
+//     ga-vcjr9 pod leak). Namepool and canonical-singleton pools are not
+//     transient, so they keep the bare identity-derived name.
+func poolRuntimeSessionName(cfg *config.City, identityName, template string, transientSlot bool) string {
 	name := poolIdentitySessionName(identityName, template)
-	if configuredNamedSessionReservesRuntimeName(cfg, name) {
-		name += poolRuntimeNameSuffix
+	if transientSlot || configuredNamedSessionReservesRuntimeName(cfg, name) {
+		// Fold the suffix into the length bound: poolIdentitySessionName already
+		// clamped name to MaxExplicitSessionNameLen, so appending the suffix to a
+		// boundary-length identity would overflow and fail ValidateExplicitName on
+		// the create path. boundSessionNameLength is a no-op for the common short
+		// name, so ordinary pools keep the exact "<name>-pool" step-aside form; a
+		// boundary-length identity shortens deterministically to a distinct, valid
+		// name that still steps aside from the reserved runtime name.
+		name = boundSessionNameLength(name + poolRuntimeNameSuffix)
 	}
 	return name
 }

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -16,6 +16,13 @@ import (
 
 const poolManagedMetadataKey = "pool_managed"
 
+// errPoolSessionNameUnavailable reports that the pool identity's runtime
+// session name is currently held by something else. The create fails closed:
+// the slot is retried next tick against the SAME name rather than being handed
+// a fresh runtime identity, because minting a fresh name per attempt is what
+// leaks a sandbox box per attempt (ga-vcjr9).
+var errPoolSessionNameUnavailable = errors.New("pool session name unavailable")
+
 type explicitBeadIDStore interface {
 	IDPrefix() string
 }
@@ -210,10 +217,11 @@ func createPoolSessionBead(
 }
 
 // createPoolSessionBeadWithAlias creates a pool session bead and persists its
-// session_name. When resolvedTmuxAlias is non-empty, that name is used in
-// place of the universal PoolSessionName derivation when the live store and
-// config reservation checks allow it. If the alias is already reserved, the
-// bead ID is appended as a "-<beadID>" suffix and that fallback is checked too.
+// session_name. The runtime name is resolved BEFORE the bead exists, because it
+// is a pure function of the pool identity (the resolved tmux_alias, else the
+// qualified instance name) and no longer of the bead ID. A name that is already
+// held fails the create outright rather than minting a fresh runtime identity —
+// see errPoolSessionNameUnavailable.
 func createPoolSessionBeadWithAlias(
 	store beads.Store,
 	template string,
@@ -238,11 +246,12 @@ func createPoolSessionBeadWithAlias(
 	} else {
 		title = agentName
 	}
-	explicitID := poolSessionExplicitBeadID(store, instanceToken)
-	sessionName := pendingPoolSessionName(template, instanceToken)
-	if explicitID != "" {
-		sessionName = PoolSessionName(template, explicitID)
+	identity.AgentName = agentName
+	sessionName, err := derivePoolSessionName(store, cfg, template, identity, resolvedTmuxAlias, sessionBeads)
+	if err != nil {
+		return sessionpkg.Info{}, err
 	}
+	explicitID := poolSessionExplicitBeadID(store, instanceToken)
 	meta := map[string]string{
 		"template":                  template,
 		"agent_name":                agentName,
@@ -279,8 +288,8 @@ func createPoolSessionBeadWithAlias(
 	if identity.Slot > 0 {
 		meta[sessionpkg.CanonicalPoolSlotMetadata] = strconv.Itoa(identity.Slot)
 	}
-	// CreateSessionInfo projects the just-created bead (no post-create store.Get),
-	// so the returned session_name derivation + fold below run over Info directly.
+	// CreateSessionInfo projects the just-created bead (no post-create store.Get).
+	// The session_name is already final in meta, so there is no second write.
 	info, err := sessionFrontDoor(store).CreateSessionInfo(sessionpkg.CreateSpec{
 		ID:        explicitID,
 		Title:     title,
@@ -294,59 +303,63 @@ func createPoolSessionBeadWithAlias(
 	// pool-create path now that the bead ID exists (no-op unless the shadow
 	// harness is enabled).
 	recordLegacyCompareWrites(info.ID, "poolSessionCreate", meta)
-	sessionName, err = derivePoolSessionName(store, cfg, template, info.ID, resolvedTmuxAlias, sessionBeads)
-	if err != nil {
-		_ = sessionFrontDoor(store).CloseWithoutReason(info.ID)
-		return sessionpkg.Info{}, err
-	}
-	if info.SessionNameMetadata != sessionName {
-		// Byte-identical single-key SetMetadata write (SetMarker), then fold the new
-		// session_name onto the returned Info instead of hand-mirroring a raw bead.
-		if err := sessionFrontDoor(store).SetMarker(info.ID, "session_name", sessionName); err != nil {
-			_ = sessionFrontDoor(store).CloseWithoutReason(info.ID)
-			return sessionpkg.Info{}, err
-		}
-		info = info.ApplyPatch(sessionpkg.MetadataPatch{"session_name": sessionName})
-	}
 	if sessionBeads != nil {
 		sessionBeads.addInfo(info)
 	}
 	return info, nil
 }
 
-// derivePoolSessionName picks the session_name for a fresh pool bead. When
-// resolvedTmuxAlias is non-empty and unreserved in the live store, config, and
-// current open snapshot, it wins; otherwise the bead ID is appended as a
-// deterministic suffix.
-func derivePoolSessionName(store beads.Store, cfg *config.City, template, beadID, resolvedTmuxAlias string, snapshot *sessionBeadSnapshot) (string, error) {
+// derivePoolSessionName picks the session_name for a fresh pool bead. The
+// name is a pure function of the pool's configured identity: the resolved
+// tmux_alias (disambiguated by pool slot when the agent expands past the first
+// one, since one alias cannot name two boxes), else the qualified instance name
+// the planner derived from config and slot. Retrying a slot therefore always
+// addresses the same runtime box.
+//
+// When the name is already held the create fails closed with
+// errPoolSessionNameUnavailable. It used to append "-<beadID>" instead, which
+// is what turned "this name is busy" into "provision another sandbox": every
+// attempt minted a runtime identity that nothing would ever address again
+// (ga-vcjr9). Stalling one slot for a tick is the cheap failure; leaking a box
+// per tick is not.
+func derivePoolSessionName(store beads.Store, cfg *config.City, template string, identity poolSessionCreateIdentity, resolvedTmuxAlias string, snapshot *sessionBeadSnapshot) (string, error) {
 	resolvedTmuxAlias, err := validateResolvedPoolTmuxAlias(template, resolvedTmuxAlias)
 	if err != nil {
 		return "", err
 	}
-	if resolvedTmuxAlias == "" {
-		return PoolSessionName(template, beadID), nil
-	}
 	sessionName := resolvedTmuxAlias
-	if err := ensurePoolSessionNameAvailable(store, cfg, snapshot, sessionName, beadID); err != nil {
-		if !errors.Is(err, sessionpkg.ErrSessionNameExists) {
-			return "", fmt.Errorf("checking pool session_name for template %q: %w", template, err)
-		}
-		sessionName = resolvedTmuxAlias + "-" + beadID
+	switch {
+	case sessionName == "":
+		sessionName = poolIdentitySessionName(identity.AgentName, template)
+	case identity.Slot > 1:
+		// Slot 1 keeps the bare alias; higher slots carry their slot number so
+		// a multi-instance pool sharing one configured alias still maps each
+		// slot onto its own stable box.
+		sessionName += "-" + strconv.Itoa(identity.Slot)
 	}
 	if _, err := sessionpkg.ValidateExplicitName(sessionName); err != nil {
 		return "", fmt.Errorf("derived pool session_name for template %q: %w", template, err)
 	}
-	if err := ensurePoolSessionNameAvailable(store, cfg, snapshot, sessionName, beadID); err != nil {
-		return "", fmt.Errorf("derived pool session_name for template %q: %w", template, err)
+	if err := ensurePoolSessionNameAvailable(store, cfg, snapshot, sessionName, identity.AgentName); err != nil {
+		if errors.Is(err, sessionpkg.ErrSessionNameExists) {
+			return "", fmt.Errorf("%w: template %q identity %q wants %q: %w", errPoolSessionNameUnavailable, template, identity.AgentName, sessionName, err)
+		}
+		return "", fmt.Errorf("checking pool session_name for template %q: %w", template, err)
 	}
 	return sessionName, nil
 }
 
-func ensurePoolSessionNameAvailable(store beads.Store, cfg *config.City, snapshot *sessionBeadSnapshot, name, selfID string) error {
-	if openSessionNameTaken(snapshot, name, selfID) {
+// ensurePoolSessionNameAvailable answers whether a fresh pool bead may claim
+// name. selfOwner is the pool's own configured identity: without it the
+// reservation checks in internal/session cannot tell "this identity reclaiming
+// its own runtime name" from "a stranger squatting it", and they reject the
+// pool's own name forever (the config-reservation and identifier-collision
+// lanes both key off it).
+func ensurePoolSessionNameAvailable(store beads.Store, cfg *config.City, snapshot *sessionBeadSnapshot, name, selfOwner string) error {
+	if openSessionNameTaken(snapshot, name) {
 		return fmt.Errorf("%w: %q conflicts with live pool snapshot", sessionpkg.ErrSessionNameExists, name)
 	}
-	return sessionpkg.EnsureSessionNameAvailableWithConfig(store, cfg, name, selfID)
+	return sessionpkg.EnsureSessionNameAvailableWithConfigForOwner(store, cfg, name, "", selfOwner)
 }
 
 func validateResolvedPoolTmuxAlias(template, resolvedTmuxAlias string) (string, error) {
@@ -362,15 +375,12 @@ func validateResolvedPoolTmuxAlias(template, resolvedTmuxAlias string) (string, 
 }
 
 // openSessionNameTaken reports whether any open session bead in the snapshot
-// (other than selfID) already advertises name as its session_name.
-func openSessionNameTaken(snapshot *sessionBeadSnapshot, name, selfID string) bool {
+// already advertises name as its session_name.
+func openSessionNameTaken(snapshot *sessionBeadSnapshot, name string) bool {
 	if snapshot == nil || strings.TrimSpace(name) == "" {
 		return false
 	}
 	for _, b := range snapshot.OpenInfos() {
-		if b.ID == selfID {
-			continue
-		}
 		if strings.TrimSpace(b.SessionNameMetadata) == name {
 			return true
 		}

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -573,3 +573,128 @@ func TestPoolIdentitySessionNameShortensDeterministically(t *testing.T) {
 		t.Fatalf("two distinct long identities shortened to the same name %q", first)
 	}
 }
+
+// TestDerivePoolSessionNameBoundsAliasedSlotSuffix pins the length-limit
+// boundary on the aliased multi-slot lane: a tmux_alias valid at exactly the
+// explicit-name limit must not be locked out of creation once
+// derivePoolSessionName appends "-<slot>" for a higher slot. Before the suffix
+// was folded into the deterministic shortening, alias+"-2" overflowed
+// MaxExplicitSessionNameLen and failed ValidateExplicitName, so the slot could
+// never create. The final name must shorten to a valid explicit name, and
+// distinct slots must still map to distinct boxes.
+func TestDerivePoolSessionNameBoundsAliasedSlotSuffix(t *testing.T) {
+	alias := strings.Repeat("a", session.MaxExplicitSessionNameLen) // valid exactly at the limit
+	if _, err := session.ValidateExplicitName(alias); err != nil {
+		t.Fatalf("precondition: %d-char alias should be a valid explicit name: %v", len(alias), err)
+	}
+
+	slot2, err := derivePoolSessionName(nil, nil, "claude", poolSessionCreateIdentity{AgentName: "claude-2", Slot: 2}, alias, nil)
+	if err != nil {
+		t.Fatalf("derivePoolSessionName(slot 2): %v", err)
+	}
+	if len(slot2) > session.MaxExplicitSessionNameLen {
+		t.Fatalf("slot-2 name %q is %d chars, max %d", slot2, len(slot2), session.MaxExplicitSessionNameLen)
+	}
+	if _, err := session.ValidateExplicitName(slot2); err != nil {
+		t.Fatalf("slot-2 name %q is not a valid explicit session name: %v", slot2, err)
+	}
+
+	again, err := derivePoolSessionName(nil, nil, "claude", poolSessionCreateIdentity{AgentName: "claude-2", Slot: 2}, alias, nil)
+	if err != nil {
+		t.Fatalf("derivePoolSessionName(slot 2 again): %v", err)
+	}
+	if again != slot2 {
+		t.Fatalf("derivePoolSessionName is not deterministic for a shortened aliased slot: %q vs %q", slot2, again)
+	}
+
+	slot3, err := derivePoolSessionName(nil, nil, "claude", poolSessionCreateIdentity{AgentName: "claude-3", Slot: 3}, alias, nil)
+	if err != nil {
+		t.Fatalf("derivePoolSessionName(slot 3): %v", err)
+	}
+	if slot3 == slot2 {
+		t.Fatalf("boundary-length slots 2 and 3 collapsed onto the same name %q", slot2)
+	}
+}
+
+// TestPoolRuntimeSessionNameStepsAsideForTransientSlot pins the #5241 identity
+// invariant at the derivation boundary. A transient pool slot ("pooled-1") is a
+// rebinding chair, not an occupant, so it must never become the runtime session
+// name: clearPoolTemplateRuntimeIdentity puts GC_AGENT on the session name, and
+// if that name is the bare slot the transient slot leaks straight into the
+// identity channel — the sibling of the ga-vcjr9 pod churn, guarded end-to-end
+// by TestE2E_MultiAgent_PoolAndFixed. The transient step-aside reuses the
+// existing "-pool" suffix: stable per slot, distinct from the slot, distinct per
+// slot, non-empty. A non-transient slot keeps the bare identity-derived name, so
+// namepool and canonical-singleton pools are unaffected.
+func TestPoolRuntimeSessionNameStepsAsideForTransientSlot(t *testing.T) {
+	const slot1 = "pooled-1"
+	got := poolRuntimeSessionName(nil, slot1, "pooled", true)
+	if got == slot1 {
+		t.Fatalf("transient slot runtime name %q must differ from the bare slot %q", got, slot1)
+	}
+	if got == "" {
+		t.Fatal("transient slot runtime name must be non-empty")
+	}
+	if want := slot1 + poolRuntimeNameSuffix; got != want {
+		t.Fatalf("poolRuntimeSessionName(transient) = %q, want %q", got, want)
+	}
+	if again := poolRuntimeSessionName(nil, slot1, "pooled", true); again != got {
+		t.Fatalf("poolRuntimeSessionName(transient) is not deterministic: %q vs %q", got, again)
+	}
+	if slot2 := poolRuntimeSessionName(nil, "pooled-2", "pooled", true); slot2 == got {
+		t.Fatalf("distinct transient slots collapsed onto the same runtime name %q", got)
+	}
+	if plain := poolRuntimeSessionName(nil, slot1, "pooled", false); plain != slot1 {
+		t.Fatalf("non-transient slot runtime name = %q, want bare identity %q", plain, slot1)
+	}
+}
+
+// TestDerivePoolSessionNameStepsAsideForTransientSlot pins the create-path end of
+// the same invariant: derivePoolSessionName must carry the identity's
+// TransientSlot flag into poolRuntimeSessionName so the persisted session_name
+// (and therefore GC_AGENT) is never the bare slot.
+func TestDerivePoolSessionNameStepsAsideForTransientSlot(t *testing.T) {
+	got, err := derivePoolSessionName(nil, nil, "pooled", poolSessionCreateIdentity{AgentName: "pooled-1", Slot: 1, TransientSlot: true}, "", nil)
+	if err != nil {
+		t.Fatalf("derivePoolSessionName: %v", err)
+	}
+	if got == "pooled-1" {
+		t.Fatalf("transient slot session_name %q must differ from the bare slot", got)
+	}
+	if want := "pooled-1" + poolRuntimeNameSuffix; got != want {
+		t.Fatalf("derivePoolSessionName(transient) = %q, want %q", got, want)
+	}
+}
+
+// TestPoolRuntimeSessionNameBoundsPoolSuffix pins the length-limit boundary on
+// the named-session step-aside lane: when a pool instance's identity name is
+// valid at exactly the explicit-name limit AND collides with a configured named
+// session's reserved runtime name, poolRuntimeSessionName appends "-pool" to
+// step aside. Before the suffix was folded into the deterministic shortening,
+// name+"-pool" overflowed MaxExplicitSessionNameLen and the unaliased pool
+// create then failed ValidateExplicitName. The stepped-aside name must shorten
+// to a valid explicit name and must not land back on the reserved name.
+func TestPoolRuntimeSessionNameBoundsPoolSuffix(t *testing.T) {
+	identity := strings.Repeat("a", session.MaxExplicitSessionNameLen) // valid exactly at the limit
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{{Name: identity, Template: "claude"}},
+	}
+	base := poolIdentitySessionName(identity, "claude")
+	if !configuredNamedSessionReservesRuntimeName(cfg, base) {
+		t.Fatalf("precondition: expected named session to reserve pool identity name %q", base)
+	}
+
+	got := poolRuntimeSessionName(cfg, identity, "claude", false)
+	if len(got) > session.MaxExplicitSessionNameLen {
+		t.Fatalf("stepped-aside name %q is %d chars, max %d", got, len(got), session.MaxExplicitSessionNameLen)
+	}
+	if _, err := session.ValidateExplicitName(got); err != nil {
+		t.Fatalf("stepped-aside name %q is not a valid explicit session name: %v", got, err)
+	}
+	if got == base {
+		t.Fatalf("poolRuntimeSessionName did not step aside from reserved name %q", base)
+	}
+	if again := poolRuntimeSessionName(cfg, identity, "claude", false); again != got {
+		t.Fatalf("poolRuntimeSessionName is not deterministic: %q vs %q", got, again)
+	}
+}

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
@@ -68,6 +71,8 @@ func TestCreatePoolSessionBead_UsesExplicitIDThroughCachingStore(t *testing.T) {
 			return mustMarshalBDIssueJSON(t, created, false), nil
 		case "show":
 			return mustMarshalBDIssueJSON(t, created, true), nil
+		case "list":
+			return []byte(`[]`), nil
 		case "update":
 			return nil, fmt.Errorf("unexpected bd update after explicit create: %v", args)
 		default:
@@ -85,7 +90,7 @@ func TestCreatePoolSessionBead_UsesExplicitIDThroughCachingStore(t *testing.T) {
 	if !strings.HasPrefix(bead.ID, "mc-session-") {
 		t.Fatalf("bead.ID = %q, want explicit mc-session-* ID", bead.ID)
 	}
-	wantSessionName := PoolSessionName("gascity/claude", bead.ID)
+	wantSessionName := poolIdentitySessionName("gascity/claude", "gascity/claude")
 	if got := bead.SessionNameMetadata; got != wantSessionName {
 		t.Fatalf("session_name = %q, want %q", got, wantSessionName)
 	}
@@ -99,9 +104,8 @@ func TestCreatePoolSessionBead_UsesExplicitIDThroughCachingStore(t *testing.T) {
 	}
 }
 
-func TestCreatePoolSessionBeadWithAlias_UpdatesExplicitIDBeadToResolvedAlias(t *testing.T) {
+func TestCreatePoolSessionBeadWithAlias_WritesResolvedAliasInTheExplicitIDCreate(t *testing.T) {
 	var created beads.Bead
-	var updatedMetadata string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		if name != "bd" {
 			return nil, fmt.Errorf("unexpected command %q", name)
@@ -132,19 +136,7 @@ func TestCreatePoolSessionBeadWithAlias_UpdatesExplicitIDBeadToResolvedAlias(t *
 		case "list":
 			return []byte(`[]`), nil
 		case "update":
-			if got := args[2]; got != created.ID {
-				return nil, fmt.Errorf("bd update id = %q, want %q", got, created.ID)
-			}
-			updatedMetadata = testFlagValue(args, "--set-metadata")
-			if updatedMetadata == "" {
-				return nil, fmt.Errorf("bd update missing --set-metadata: %v", args)
-			}
-			key, value, ok := strings.Cut(updatedMetadata, "=")
-			if !ok || key != "session_name" {
-				return nil, fmt.Errorf("bd update metadata = %q, want session_name=<alias>", updatedMetadata)
-			}
-			created.Metadata[key] = value
-			return []byte(`{"id":"` + created.ID + `"}`), nil
+			return nil, fmt.Errorf("unexpected bd update: the resolved session_name must land in the create write: %v", args)
 		default:
 			return nil, fmt.Errorf("unexpected bd args: %v", args)
 		}
@@ -160,8 +152,8 @@ func TestCreatePoolSessionBeadWithAlias_UpdatesExplicitIDBeadToResolvedAlias(t *
 	if !strings.HasPrefix(bead.ID, "mc-session-") {
 		t.Fatalf("bead.ID = %q, want explicit mc-session-* ID", bead.ID)
 	}
-	if updatedMetadata != "session_name=crew--gastown" {
-		t.Fatalf("updated metadata = %q, want session_name=crew--gastown", updatedMetadata)
+	if got := created.Metadata["session_name"]; got != "crew--gastown" {
+		t.Fatalf("created metadata session_name = %q, want crew--gastown", got)
 	}
 	if got := bead.SessionNameMetadata; got != "crew--gastown" {
 		t.Fatalf("session_name = %q, want resolved alias", got)
@@ -309,16 +301,16 @@ func TestExistingPoolSlot_CanonicalSingletonReturnsZero(t *testing.T) {
 	}
 }
 
-func TestCreatePoolSessionBeadWithAlias_FallsBackToPoolNameWhenAliasEmpty(t *testing.T) {
+func TestCreatePoolSessionBeadWithAlias_FallsBackToPoolIdentityNameWhenAliasEmpty(t *testing.T) {
 	store := beads.NewMemStore()
 
 	bead, err := createPoolSessionBeadWithAlias(store, "claude", nil, nil, time.Now().UTC(), poolSessionCreateIdentity{}, "")
 	if err != nil {
 		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
 	}
-	want := PoolSessionName("claude", bead.ID)
+	want := poolIdentitySessionName("", "claude")
 	if got := bead.SessionNameMetadata; got != want {
-		t.Fatalf("session_name = %q, want %q (universal fallback)", got, want)
+		t.Fatalf("session_name = %q, want %q (pool identity fallback)", got, want)
 	}
 }
 
@@ -341,7 +333,14 @@ func TestCreatePoolSessionBeadWithAlias_UsesResolvedAlias(t *testing.T) {
 	}
 }
 
-func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDOnCollision(t *testing.T) {
+// The four tests below used to assert that a name collision minted
+// "<name>-<beadID>". That fallback is the ga-vcjr9 leak: the suffixed name is a
+// fresh runtime identity, so a pool whose start keeps failing provisions a new
+// sandbox box per attempt and abandons the previous one. Each now asserts the
+// fail-closed contract instead — the create is refused with a typed error and
+// leaves no bead behind, so the slot retries next tick against the same name.
+
+func TestCreatePoolSessionBeadWithAlias_FailsClosedOnSnapshotCollision(t *testing.T) {
 	store := beads.NewMemStore()
 	snapshot := newSessionBeadSnapshot(nil)
 
@@ -354,18 +353,18 @@ func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDOnCollision(t *testing.T) {
 	}
 
 	second, err := createPoolSessionBeadWithAlias(store, "crew-gastown", nil, snapshot, time.Now().UTC(), poolSessionCreateIdentity{}, "crew--gastown")
-	if err != nil {
-		t.Fatalf("second createPoolSessionBeadWithAlias: %v", err)
+	if err == nil {
+		t.Fatalf("second createPoolSessionBeadWithAlias returned %q; want errPoolSessionNameUnavailable", second.SessionNameMetadata)
 	}
-	want := "crew--gastown-" + second.ID
-	if got := second.SessionNameMetadata; got != want {
-		t.Fatalf("second session_name = %q, want %q (collision suffix)", got, want)
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("second createPoolSessionBeadWithAlias error = %v, want errPoolSessionNameUnavailable", err)
 	}
+	assertOnlySessionBead(t, store, first.ID)
 }
 
-func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDForOutOfSnapshotLiveCollision(t *testing.T) {
+func TestCreatePoolSessionBeadWithAlias_FailsClosedOnOutOfSnapshotLiveCollision(t *testing.T) {
 	store := beads.NewMemStore()
-	_, err := store.Create(beads.Bead{
+	existing, err := store.Create(beads.Bead{
 		Title:  "manual session",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel},
@@ -377,17 +376,14 @@ func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDForOutOfSnapshotLiveCollisi
 		t.Fatalf("create existing session bead: %v", err)
 	}
 
-	bead, err := createPoolSessionBeadWithAlias(store, "crew-gastown", nil, newSessionBeadSnapshot(nil), time.Now().UTC(), poolSessionCreateIdentity{}, "crew--gastown")
-	if err != nil {
-		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
+	_, err = createPoolSessionBeadWithAlias(store, "crew-gastown", nil, newSessionBeadSnapshot(nil), time.Now().UTC(), poolSessionCreateIdentity{}, "crew--gastown")
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("createPoolSessionBeadWithAlias error = %v, want errPoolSessionNameUnavailable for a live out-of-snapshot collision", err)
 	}
-	want := "crew--gastown-" + bead.ID
-	if got := bead.SessionNameMetadata; got != want {
-		t.Fatalf("session_name = %q, want %q for live out-of-snapshot collision", got, want)
-	}
+	assertOnlySessionBead(t, store, existing.ID)
 }
 
-func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDForClosedSessionNameCollision(t *testing.T) {
+func TestCreatePoolSessionBeadWithAlias_FailsClosedOnClosedSessionNameCollision(t *testing.T) {
 	store := beads.NewMemStore()
 	existing, err := store.Create(beads.Bead{
 		Title:  "closed session",
@@ -404,17 +400,17 @@ func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDForClosedSessionNameCollisi
 		t.Fatalf("close existing session bead: %v", err)
 	}
 
-	bead, err := createPoolSessionBeadWithAlias(store, "crew-gastown", nil, newSessionBeadSnapshot(nil), time.Now().UTC(), poolSessionCreateIdentity{}, "crew--gastown")
-	if err != nil {
-		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
+	_, err = createPoolSessionBeadWithAlias(store, "crew-gastown", nil, newSessionBeadSnapshot(nil), time.Now().UTC(), poolSessionCreateIdentity{}, "crew--gastown")
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("createPoolSessionBeadWithAlias error = %v, want errPoolSessionNameUnavailable for a closed session-name collision", err)
 	}
-	want := "crew--gastown-" + bead.ID
-	if got := bead.SessionNameMetadata; got != want {
-		t.Fatalf("session_name = %q, want %q for closed session-name collision", got, want)
+	if _, getErr := store.Get(existing.ID); getErr != nil {
+		t.Fatalf("store.Get(%s): %v", existing.ID, getErr)
 	}
+	assertOnlySessionBead(t, store)
 }
 
-func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDForConfiguredNamedSessionReservation(t *testing.T) {
+func TestCreatePoolSessionBeadWithAlias_FailsClosedOnConfiguredNamedSessionReservation(t *testing.T) {
 	store := beads.NewMemStore()
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
@@ -425,13 +421,30 @@ func TestCreatePoolSessionBeadWithAlias_AppendsBeadIDForConfiguredNamedSessionRe
 	}
 	reserved := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "crew")
 
-	bead, err := createPoolSessionBeadWithAlias(store, "worker", cfg, newSessionBeadSnapshot(nil), time.Now().UTC(), poolSessionCreateIdentity{}, reserved)
-	if err != nil {
-		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
+	_, err := createPoolSessionBeadWithAlias(store, "worker", cfg, newSessionBeadSnapshot(nil), time.Now().UTC(), poolSessionCreateIdentity{}, reserved)
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("createPoolSessionBeadWithAlias error = %v, want errPoolSessionNameUnavailable for a foreign configured named-session reservation", err)
 	}
-	want := reserved + "-" + bead.ID
-	if got := bead.SessionNameMetadata; got != want {
-		t.Fatalf("session_name = %q, want %q for configured named-session reservation", got, want)
+	assertOnlySessionBead(t, store)
+}
+
+// assertOnlySessionBead fails unless the store's OPEN session beads are exactly
+// the given ones. A refused create must not leave a bead — and therefore a
+// runtime name — behind.
+func assertOnlySessionBead(t *testing.T, store beads.Store, want ...string) {
+	t.Helper()
+	all, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel(%q): %v", sessionBeadLabel, err)
+	}
+	got := make([]string, 0, len(all))
+	for _, b := range all {
+		got = append(got, b.ID)
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("session beads = %v, want %v", got, want)
 	}
 }
 
@@ -466,31 +479,48 @@ func TestDerivePoolSessionName(t *testing.T) {
 	tests := []struct {
 		name     string
 		template string
-		beadID   string
+		identity string
+		slot     int
 		alias    string
 		snapshot *sessionBeadSnapshot
 		want     string
 	}{
 		{
-			name:     "empty alias falls back to PoolSessionName",
+			name:     "empty alias falls back to the pool identity",
 			template: "claude",
-			beadID:   "gc-1",
+			identity: "claude-1",
 			alias:    "",
 			snapshot: nil,
-			want:     "claude-gc-1",
+			want:     "claude-1",
 		},
 		{
-			name:     "whitespace-only alias falls back to PoolSessionName",
+			name:     "whitespace-only alias falls back to the pool identity",
 			template: "claude",
-			beadID:   "gc-1",
+			identity: "claude-1",
 			alias:    "   ",
 			snapshot: nil,
-			want:     "claude-gc-1",
+			want:     "claude-1",
 		},
 		{
-			name:     "resolved alias wins when no collision",
+			name:     "identity is sanitized for tmux",
+			template: "gastown/bd.dog",
+			identity: "gastown/bd.dog-1",
+			alias:    "",
+			snapshot: nil,
+			want:     "gastown--bd__dog-1",
+		},
+		{
+			name:     "empty identity falls back to the template basename",
+			template: "gastown/bd.dog",
+			identity: "",
+			alias:    "",
+			snapshot: nil,
+			want:     "bd__dog",
+		},
+		{
+			name:     "resolved alias wins over the identity",
 			template: "crew-gastown",
-			beadID:   "gc-2",
+			identity: "crew-gastown-1",
 			alias:    "crew--gastown",
 			snapshot: nil,
 			want:     "crew--gastown",
@@ -498,7 +528,7 @@ func TestDerivePoolSessionName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := derivePoolSessionName(nil, nil, tt.template, tt.beadID, tt.alias, tt.snapshot)
+			got, err := derivePoolSessionName(nil, nil, tt.template, poolSessionCreateIdentity{AgentName: tt.identity, Slot: tt.slot}, tt.alias, tt.snapshot)
 			if err != nil {
 				t.Fatalf("derivePoolSessionName: %v", err)
 			}
@@ -509,17 +539,37 @@ func TestDerivePoolSessionName(t *testing.T) {
 	}
 }
 
-func TestDerivePoolSessionNameRejectsInvalidCollisionSuffix(t *testing.T) {
+func TestDerivePoolSessionNameFailsClosedOnSnapshotCollision(t *testing.T) {
 	snapshot := newSessionBeadSnapshot([]beads.Bead{{
 		ID:     "existing",
 		Status: "open",
 		Metadata: map[string]string{
-			"session_name": strings.Repeat("a", 64),
+			"session_name": "claude-1",
 		},
 	}})
 
-	_, err := derivePoolSessionName(nil, nil, "crew", "gc-1", strings.Repeat("a", 64), snapshot)
-	if err == nil {
-		t.Fatal("derivePoolSessionName: want error when collision suffix would exceed explicit session name length")
+	_, err := derivePoolSessionName(nil, nil, "claude", poolSessionCreateIdentity{AgentName: "claude-1", Slot: 1}, "", snapshot)
+	if !errors.Is(err, errPoolSessionNameUnavailable) {
+		t.Fatalf("derivePoolSessionName error = %v, want errPoolSessionNameUnavailable", err)
+	}
+}
+
+// TestPoolIdentitySessionNameShortensDeterministically pins the length bound:
+// an identity longer than an explicit session name may be must still map to one
+// stable name, and two long identities must not collapse onto the same one.
+func TestPoolIdentitySessionNameShortensDeterministically(t *testing.T) {
+	long := strings.Repeat("a", 80)
+	first := poolIdentitySessionName(long+"-1", "claude")
+	if first != poolIdentitySessionName(long+"-1", "claude") {
+		t.Fatal("poolIdentitySessionName is not deterministic for a shortened identity")
+	}
+	if len(first) > session.MaxExplicitSessionNameLen {
+		t.Fatalf("shortened name %q is %d chars, max %d", first, len(first), session.MaxExplicitSessionNameLen)
+	}
+	if _, err := session.ValidateExplicitName(first); err != nil {
+		t.Fatalf("shortened name %q is not a valid explicit session name: %v", first, err)
+	}
+	if second := poolIdentitySessionName(long+"-2", "claude"); second == first {
+		t.Fatalf("two distinct long identities shortened to the same name %q", first)
 	}
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -11731,7 +11731,16 @@ func TestFailedCreateIsKnownState(t *testing.T) {
 	}
 }
 
-func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *testing.T) {
+// TestReconcileSessionBeads_FailedCreatePoolSlotIsReplacedUnderTheSameRuntimeName
+// pins the retry shape ga-vcjr9 turned into a pod leak. A failed create no
+// longer frees its slot by handing the replacement a NEW runtime name — the
+// name is a pure function of the slot identity, so the replacement addresses
+// the same box. That makes the pending-create lease load-bearing: while the
+// failed bead is still open it holds the identity, and the pool waits one tick
+// rather than running two beads under one name. Once the lease expires and the
+// reconciler closes the bead, the next tick allocates a fresh bead under the
+// same runtime name.
+func TestReconcileSessionBeads_FailedCreatePoolSlotIsReplacedUnderTheSameRuntimeName(t *testing.T) {
 	cases := []struct {
 		name             string
 		startedAt        time.Time
@@ -11785,25 +11794,12 @@ func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *
 			if err != nil {
 				t.Fatalf("Create failed-create bead: %v", err)
 			}
+			runtimeName := failedBead.Metadata["session_name"]
 
 			var stdout, stderr bytes.Buffer
-			dsResult := buildDesiredState(cfg.EffectiveCityName(), t.TempDir(), clk.Now().UTC(), cfg, sp, store, &stderr)
-			if _, ok := dsResult.State[failedBead.Metadata["session_name"]]; ok {
-				t.Fatalf("desired state reused failed-create bead %s; state=%#v", failedBead.ID, dsResult.State)
-			}
-
-			var fresh TemplateParams
-			for _, tp := range dsResult.State {
-				if tp.TemplateName == "worker" {
-					fresh = tp
-					break
-				}
-			}
-			if fresh.SessionName == "" {
-				t.Fatalf("desired state did not allocate a fresh worker session; state=%#v stderr:\n%s", dsResult.State, stderr.String())
-			}
-			if fresh.SessionName == failedBead.Metadata["session_name"] {
-				t.Fatalf("fresh session name = %q, want different from failed-create bead", fresh.SessionName)
+			firstTick := buildDesiredState(cfg.EffectiveCityName(), t.TempDir(), clk.Now().UTC(), cfg, sp, store, &stderr)
+			if len(firstTick.State) != 0 {
+				t.Fatalf("open failed-create lease must hold its identity, but the first tick planned %#v; stderr:\n%s", firstTick.State, stderr.String())
 			}
 
 			sessions, err := loadSessionBeads(store)
@@ -11811,23 +11807,20 @@ func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *
 				t.Fatalf("loadSessionBeads: %v", err)
 			}
 			cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
-			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessionInfosFromBeads(sessions), dsResult.ScaleCheckCounts))
+			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, firstTick.AssignedWorkBeads, sessionInfosFromBeads(sessions), firstTick.ScaleCheckCounts))
 			if poolDesired == nil {
 				poolDesired = make(map[string]int)
 			}
-			mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+			mergeNamedSessionDemand(poolDesired, firstTick.NamedSessionDemand, cfg)
 
-			woken := reconcileSessionBeads(
-				context.Background(), sessions, dsResult.State, cfgNames,
-				cfg, sp, store, nil, dsResult.AssignedWorkBeads, nil, newDrainTracker(), poolDesired,
-				dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+			reconcileSessionBeads(
+				context.Background(), sessions, firstTick.State, cfgNames,
+				cfg, sp, store, nil, firstTick.AssignedWorkBeads, nil, newDrainTracker(), poolDesired,
+				firstTick.StoreQueryPartial, nil, cfg.EffectiveCityName(),
 				nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 			)
-			if woken != 1 {
-				t.Fatalf("woken = %d, want 1 for fresh replacement session; stdout:\n%s\nstderr:\n%s", woken, stdout.String(), stderr.String())
-			}
-			if !sp.IsRunning(fresh.SessionName) {
-				t.Fatalf("fresh session %q is not running after reconcile; stdout:\n%s\nstderr:\n%s", fresh.SessionName, stdout.String(), stderr.String())
+			if sp.IsRunning(runtimeName) {
+				t.Fatalf("reconcile started %q for a failed-create bead", runtimeName)
 			}
 
 			gotFailed, err := store.Get(failedBead.ID)
@@ -11840,13 +11833,26 @@ func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *
 			if gotFailed.Status == "open" && gotFailed.Metadata["state"] != string(sessionpkg.StateFailedCreate) {
 				t.Fatalf("open failed-create bead state = %q, want %q", gotFailed.Metadata["state"], sessionpkg.StateFailedCreate)
 			}
+
+			var secondTickStderr bytes.Buffer
+			secondTick := buildDesiredState(cfg.EffectiveCityName(), t.TempDir(), clk.Now().UTC(), cfg, sp, store, &secondTickStderr)
+			tp, planned := secondTick.State[runtimeName]
 			if gotFailed.Status == "open" {
-				var secondTickStderr bytes.Buffer
-				secondTick := buildDesiredState(cfg.EffectiveCityName(), t.TempDir(), clk.Now().UTC(), cfg, sp, store, &secondTickStderr)
-				if _, ok := secondTick.State[failedBead.Metadata["session_name"]]; ok {
-					t.Fatalf("second tick reused failed-create bead %s; state=%#v stderr:\n%s", failedBead.ID, secondTick.State, secondTickStderr.String())
+				if planned {
+					t.Fatalf("second tick planned %q while the failed-create lease is still open; stderr:\n%s", runtimeName, secondTickStderr.String())
+				}
+			} else {
+				if !planned {
+					t.Fatalf("second tick did not replace the closed failed-create slot under %q; state=%#v stderr:\n%s", runtimeName, secondTick.State, secondTickStderr.String())
+				}
+				if got := tp.Env["GC_SESSION_ID"]; got == failedBead.ID {
+					t.Fatalf("replacement reused the failed-create bead %s; a fresh bead must back the reused runtime name", failedBead.ID)
+				}
+				if tp.SessionName != runtimeName {
+					t.Fatalf("replacement session name = %q, want the slot's stable runtime name %q", tp.SessionName, runtimeName)
 				}
 			}
+
 			if strings.Contains(stderr.String(), "unknown state") {
 				t.Errorf("reconciler logged unknown state for failed-create bead: %s", stderr.String())
 			}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -11778,7 +11778,14 @@ func TestReconcileSessionBeads_FailedCreatePoolSlotIsReplacedUnderTheSameRuntime
 				Type:   sessionBeadType,
 				Labels: []string{sessionBeadLabel, "agent:worker-1"},
 				Metadata: map[string]string{
-					"session_name":              "worker-1",
+					// A transient pool slot's runtime session_name steps aside from
+					// the bare slot identity ("worker-1") onto "worker-1-pool" so the
+					// slot never reaches GC_AGENT (#5241). agent_name/pool_slot stay
+					// the identity, exactly as the create path (derivePoolSessionName
+					// with TransientSlot) persists it; the replacement re-derives the
+					// same "worker-1-pool" and fails closed on the open lease, so the
+					// slot still holds its identity for one tick.
+					"session_name":              "worker-1-pool",
 					"agent_name":                "worker-1",
 					"template":                  "worker",
 					"state":                     string(sessionpkg.StateFailedCreate),

--- a/internal/runtime/exec/exec.go
+++ b/internal/runtime/exec/exec.go
@@ -189,16 +189,23 @@ func (p *Provider) runWithTTY(args ...string) error {
 // trust, bypass permissions) in Go using Peek + SendKeys, sharing the
 // same logic as the tmux provider via [runtime.AcceptStartupDialogs].
 func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	// Was this name already occupied before we touched it? Asked structurally,
+	// before the attempt, because it is the only question whose answer cannot
+	// be garbled by how the adapter happens to word a refusal — and it is the
+	// question the teardown below actually depends on.
+	occupiedBefore, occupancyKnown := p.boxOccupancy(name)
+	foreignBox := occupancyKnown && occupiedBefore
+
 	data, err := marshalStartConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("exec provider: marshaling start config: %w", err)
 	}
 	if _, err = p.runWithContext(ctx, p.startTimeout, data, "start", name); err != nil {
-		return p.cleanupAfterStartFailure(name, err)
+		return p.cleanupAfterStartFailure(name, err, foreignBox)
 	}
 
 	if err := p.dismissStartupDialogs(ctx, name, cfg); err != nil {
-		return p.cleanupAfterStartFailure(name, fmt.Errorf("exec provider: dismissing startup dialogs: %w", err))
+		return p.cleanupAfterStartFailure(name, fmt.Errorf("exec provider: dismissing startup dialogs: %w", err), foreignBox)
 	}
 
 	return nil
@@ -212,14 +219,27 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 // is orphaned, and because a fresh session name is minted per attempt the retry
 // leaks another one.
 //
-// The [runtime.ErrSessionExists] case is the exception: a name collision means
-// a LIVE session already owns that box, and stopping it would destroy a healthy
-// session rather than clean up after this attempt.
+// Two conditions skip the teardown, because in both of them the box belongs to
+// a live session rather than to this attempt, and stopping it would destroy a
+// healthy session:
+//
+//   - [runtime.ErrSessionExists] — the adapter refused in wording
+//     startCollisionPhrases recognizes.
+//   - foreignBox — the adapter reported the box already up BEFORE this attempt
+//     ran, which is the same fact established structurally instead of by
+//     reading prose. That distinction stopped being academic when session names
+//     became a function of agent identity: a retry now deliberately re-targets
+//     the name the previous attempt used, so collisions are steady state, and a
+//     phrasing this package has never seen would otherwise tear down a live
+//     agent's box on an ordinary retry (ga-vcjr9). A pack that cannot answer
+//     `is-running` reports neither occupancy nor vacancy and keeps the previous
+//     behaviour exactly — the gate only ever withholds a teardown, never adds
+//     one.
 //
 // Stop deliberately runs on its own background context (see run), so cleanup
 // still happens when the caller's context is the thing that died.
-func (p *Provider) cleanupAfterStartFailure(name string, startErr error) error {
-	if errors.Is(startErr, runtime.ErrSessionExists) {
+func (p *Provider) cleanupAfterStartFailure(name string, startErr error, foreignBox bool) error {
+	if foreignBox || errors.Is(startErr, runtime.ErrSessionExists) {
 		return startErr
 	}
 	if stopErr := p.Stop(name); stopErr != nil {
@@ -609,11 +629,31 @@ func (p *Provider) Interrupt(name string) error {
 // IsRunning checks if the session is alive: script is-running <name>
 // Returns true only if stdout is "true". Errors → false.
 func (p *Provider) IsRunning(name string) bool {
+	occupied, _ := p.boxOccupancy(name)
+	return occupied
+}
+
+// boxOccupancy asks `is-running <name>` and reports both the answer and
+// whether there was one. Only a literal "true" or "false" is an answer; an op
+// error, an unknown op (exit 2 on a pack with no is-running), or empty output
+// means the adapter could not tell.
+//
+// [Provider.IsRunning] flattens that to a bool because its callers only need
+// "treat as not running". A caller deciding whether it may destroy the box
+// needs the distinction: "no" authorizes a teardown, "I don't know" must not.
+func (p *Provider) boxOccupancy(name string) (occupied, definite bool) {
 	out, err := p.run(nil, "is-running", name)
 	if err != nil {
-		return false
+		return false, false
 	}
-	return strings.TrimSpace(out) == "true"
+	switch strings.TrimSpace(out) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 // IsAttached reports terminal attachment via `script is-attached <name>`

--- a/internal/runtime/exec/exec.go
+++ b/internal/runtime/exec/exec.go
@@ -233,7 +233,7 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 //     phrasing this package has never seen would otherwise tear down a live
 //     agent's box on an ordinary retry (ga-vcjr9). A pack that cannot answer
 //     `is-running` reports neither occupancy nor vacancy and keeps the previous
-//     behaviour exactly — the gate only ever withholds a teardown, never adds
+//     behavior exactly — the gate only ever withholds a teardown, never adds
 //     one.
 //
 // Stop deliberately runs on its own background context (see run), so cleanup

--- a/internal/runtime/exec/exec_reuse_test.go
+++ b/internal/runtime/exec/exec_reuse_test.go
@@ -127,7 +127,7 @@ func TestStartStillTearsDownAVacantBoxItFailedToFill(t *testing.T) {
 // TestStartPreCheckDoesNotChangeBehaviourForPacksThatCannotReportOccupancy
 // bounds the blast radius. A pack with no `is-running` op answers exit 2
 // (unknown op), which is not an occupancy answer in either direction. Such a
-// pack must keep exactly today's behaviour — attempt the start, tear down on
+// pack must keep exactly today's behavior — attempt the start, tear down on
 // failure, and fall back to the stderr phrase detector for collisions — rather
 // than losing the teardown that stopped the original ga-vcjr9 pod leak.
 func TestStartPreCheckDoesNotChangeBehaviourForPacksThatCannotReportOccupancy(t *testing.T) {

--- a/internal/runtime/exec/exec_reuse_test.go
+++ b/internal/runtime/exec/exec_reuse_test.go
@@ -1,0 +1,202 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// occupiedBoxScript is an adapter whose box for `name` is already up and whose
+// start op refuses in wording the phrase detector does NOT recognize. It
+// answers `is-running` structurally, the way a pack that can report occupancy
+// does.
+func occupiedBoxScript(startLog, stopLog, refusal string) string {
+	return `
+op="$1"
+name="$2"
+
+case "$op" in
+  is-running) echo "true" ;;
+  start)
+    cat > /dev/null
+    echo "$name" >> "` + startLog + `"
+    echo "` + refusal + `" >&2
+    exit 1
+    ;;
+  stop) echo "stop $name" >> "` + stopLog + `" ;;
+  *) exit 2 ;;
+esac
+`
+}
+
+// vacantBoxScript is the same adapter with the box absent: `is-running` answers
+// "false" and the start op fails for an ordinary reason.
+func vacantBoxScript(startLog, stopLog string) string {
+	return `
+op="$1"
+name="$2"
+
+case "$op" in
+  is-running) echo "false" ;;
+  start)
+    cat > /dev/null
+    echo "$name" >> "` + startLog + `"
+    echo "readiness timeout" >&2
+    exit 1
+    ;;
+  stop) echo "stop $name" >> "` + stopLog + `" ;;
+  *) exit 2 ;;
+esac
+`
+}
+
+// TestStartNeverTearsDownABoxThatWasAlreadyOccupied is the ga-vcjr9
+// composition guard between identity-stable session names and the start-failure
+// teardown.
+//
+// Before identity-stable naming every start attempt used a fresh bead-ID name,
+// so a collision meant "somebody else's box" and was rare. Now a pool retry
+// deliberately re-targets the slot's own name, which makes collisions
+// steady-state — and exec is the only provider that infers ErrSessionExists
+// from the adapter's *stderr wording*. A pack whose refusal is phrased outside
+// startCollisionPhrases falls through that guard, and
+// cleanupAfterStartFailure then tears down a live agent's box. Losing an
+// agent's work is strictly worse than the leak this whole effort is closing.
+//
+// So the teardown stops depending on the wording. Occupancy is established
+// structurally before the attempt, and a box that was already up is never one
+// this attempt may destroy — whatever the adapter said on the way out.
+func TestStartNeverTearsDownABoxThatWasAlreadyOccupied(t *testing.T) {
+	// Deliberately none of startCollisionPhrases.
+	refusals := map[string]string{
+		"in use":     "session is in use by another agent",
+		"conflict":   "409 conflict: name taken",
+		"busy":       "box busy",
+		"no message": "",
+	}
+
+	for label, refusal := range refusals {
+		t.Run(label, func(t *testing.T) {
+			dir := t.TempDir()
+			startLog := filepath.Join(dir, "start.log")
+			stopLog := filepath.Join(dir, "stop.log")
+			p := NewProvider(writeScript(t, dir, occupiedBoxScript(startLog, stopLog, refusal)))
+
+			err := p.Start(context.Background(), "test-sess", runtime.Config{})
+			if err == nil {
+				t.Fatal("Start succeeded, want the adapter's refusal")
+			}
+			if got := readLog(t, stopLog); got != "" {
+				t.Fatalf("stop log = %q, want no teardown: that box was up before this attempt and belongs to a live session", got)
+			}
+		})
+	}
+}
+
+// TestStartStillTearsDownAVacantBoxItFailedToFill is the discriminating control
+// for the guard above. Same adapter shape, same failing start — the only
+// difference is that occupancy was structurally answered "false" before the
+// attempt, so the box that exists afterwards is this attempt's own and the
+// ga-vcjr9 teardown must still fire. Without this control the guard could be
+// satisfied by never tearing anything down, which is the leak it replaced.
+func TestStartStillTearsDownAVacantBoxItFailedToFill(t *testing.T) {
+	dir := t.TempDir()
+	startLog := filepath.Join(dir, "start.log")
+	stopLog := filepath.Join(dir, "stop.log")
+	p := NewProvider(writeScript(t, dir, vacantBoxScript(startLog, stopLog)))
+
+	err := p.Start(context.Background(), "test-sess", runtime.Config{})
+	if err == nil {
+		t.Fatal("Start succeeded, want the adapter's start failure")
+	}
+	if errors.Is(err, runtime.ErrSessionExists) {
+		t.Fatalf("Start error = %v, want the adapter's failure, not a collision", err)
+	}
+	if got := readLog(t, startLog); !strings.Contains(got, "test-sess") {
+		t.Fatalf("start log = %q, want the start op attempted against a vacant box", got)
+	}
+	if got := readLog(t, stopLog); !strings.Contains(got, "stop test-sess") {
+		t.Fatalf("stop log = %q, want the box this attempt created torn down", got)
+	}
+}
+
+// TestStartPreCheckDoesNotChangeBehaviourForPacksThatCannotReportOccupancy
+// bounds the blast radius. A pack with no `is-running` op answers exit 2
+// (unknown op), which is not an occupancy answer in either direction. Such a
+// pack must keep exactly today's behaviour — attempt the start, tear down on
+// failure, and fall back to the stderr phrase detector for collisions — rather
+// than losing the teardown that stopped the original ga-vcjr9 pod leak.
+func TestStartPreCheckDoesNotChangeBehaviourForPacksThatCannotReportOccupancy(t *testing.T) {
+	dir := t.TempDir()
+	createFile := filepath.Join(dir, "create.log")
+	stopFile := filepath.Join(dir, "stop.log")
+	// startFailureScript answers every op other than start/stop with exit 2.
+	p := NewProvider(writeScript(t, dir, startFailureScript(createFile, stopFile, "readiness timeout")))
+
+	err := p.Start(context.Background(), "test-sess", runtime.Config{})
+	if err == nil {
+		t.Fatal("Start succeeded, want the adapter's start failure")
+	}
+	if got := readLog(t, stopFile); !strings.Contains(got, "stop test-sess") {
+		t.Fatalf("stop log = %q, want the ga-vcjr9 teardown preserved for occupancy-blind packs", got)
+	}
+}
+
+// TestBoxOccupancy pins the three-valued contract directly: only an explicit
+// "true"/"false" is an answer. Anything else — an op error, an unknown op, a
+// pack that prints nothing — is "I could not tell", and callers must not read
+// it as vacancy.
+func TestBoxOccupancy(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantOccupied bool
+		wantDefinite bool
+	}{
+		{
+			name:         "true",
+			body:         "case \"$1\" in is-running) echo true ;; *) exit 2 ;; esac",
+			wantOccupied: true,
+			wantDefinite: true,
+		},
+		{
+			name:         "false",
+			body:         "case \"$1\" in is-running) echo false ;; *) exit 2 ;; esac",
+			wantOccupied: false,
+			wantDefinite: true,
+		},
+		{
+			name:         "unknown op",
+			body:         "exit 2",
+			wantOccupied: false,
+			wantDefinite: false,
+		},
+		{
+			name:         "op error",
+			body:         "echo 'adapter unreachable' >&2; exit 1",
+			wantOccupied: false,
+			wantDefinite: false,
+		},
+		{
+			name:         "silent",
+			body:         "exit 0",
+			wantOccupied: false,
+			wantDefinite: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := NewProvider(writeScript(t, dir, tc.body))
+			occupied, definite := p.boxOccupancy("test-sess")
+			if occupied != tc.wantOccupied || definite != tc.wantDefinite {
+				t.Fatalf("boxOccupancy = (%v, %v), want (%v, %v)", occupied, definite, tc.wantOccupied, tc.wantDefinite)
+			}
+		})
+	}
+}

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -178,7 +178,7 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 		pod := &existing[0]
 		if pod.Status.Phase == corev1.PodRunning {
 			// Stale-pod detection: is the session's tmux server alive?
-			alive, definitive, probeErr := p.probeTmuxLiveness(ctx, pod.Name)
+			alive, definitive, probeErr := p.probeTmuxLiveness(ctx, pod)
 			if alive {
 				return fmt.Errorf("%w: session %q (pod: %s)", runtime.ErrSessionExists, name, pod.Name)
 			}
@@ -708,15 +708,28 @@ const livenessProbeAttempts = 2
 // probeTmuxLiveness asks whether the session's tmux server is alive inside pod.
 //
 // It returns three-valued, not two: alive, and whether the answer is
-// definitive. A definitive answer means the probe actually ran inside the
-// container — `tmux has-session` exited, zero or non-zero. An indefinite
-// answer means the exec never got there (SPDY dial failure, apiserver error,
-// stream timeout, canceled context), which says nothing at all about tmux.
+// definitive. A definitive answer means something actually established the
+// fact — either the pod's own status says the agent container is not running,
+// or `tmux has-session` ran inside it and exited. An indefinite answer means
+// the exec never got there (SPDY dial failure, apiserver error, stream timeout,
+// canceled context), which says nothing at all about tmux.
 //
 // Collapsing those two into "not alive" is how a transport flake becomes a
 // deleted pod. Callers that act destructively on a negative must require
 // definitive; callers that only defer may ignore it.
-func (p *Provider) probeTmuxLiveness(ctx context.Context, podName string) (alive, definitive bool, err error) {
+func (p *Provider) probeTmuxLiveness(ctx context.Context, pod *corev1.Pod) (alive, definitive bool, err error) {
+	// The pod's status is a second, independent channel, and it settles the
+	// case the exec cannot: a pod whose phase is Running but whose agent
+	// container is not (crash loop, OOM, terminated) answers every exec with an
+	// apiserver-level error that is indistinguishable from a flake. Reading
+	// that as "I could not tell" would leave a genuinely broken pod in place
+	// forever. The container not running IS a definitive tmux negative, and it
+	// comes from the list we already did rather than from the connection that
+	// is in doubt.
+	if running, known := agentContainerRunning(pod); known && !running {
+		return false, true, fmt.Errorf("agent container in pod %s is not running", pod.Name)
+	}
+	podName := pod.Name
 	for attempt := 0; attempt < livenessProbeAttempts; attempt++ {
 		_, err = p.ops.execInPod(ctx, podName, "agent",
 			[]string{"tmux", "has-session", "-t", tmuxSession}, nil)
@@ -735,6 +748,21 @@ func (p *Provider) probeTmuxLiveness(ctx context.Context, podName string) (alive
 		}
 	}
 	return false, false, err
+}
+
+// agentContainerRunning reports whether the pod's agent container is running,
+// and whether the pod status said anything about it at all. A status that has
+// not been populated yet is not evidence either way.
+func agentContainerRunning(pod *corev1.Pod) (running, known bool) {
+	if pod == nil {
+		return false, false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == "agent" {
+			return cs.State.Running != nil, true
+		}
+	}
+	return false, false
 }
 
 // findRunningPod finds a running pod by session label.

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -177,19 +177,29 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 	if err == nil && len(existing) > 0 {
 		pod := &existing[0]
 		if pod.Status.Phase == corev1.PodRunning {
-			// Check if tmux is alive — stale pod detection.
-			_, tmuxErr := p.ops.execInPod(ctx, pod.Name, "agent",
-				[]string{"tmux", "has-session", "-t", tmuxSession}, nil)
-			if tmuxErr == nil {
+			// Stale-pod detection: is the session's tmux server alive?
+			alive, definitive, probeErr := p.probeTmuxLiveness(ctx, pod.Name)
+			if alive {
 				return fmt.Errorf("%w: session %q (pod: %s)", runtime.ErrSessionExists, name, pod.Name)
 			}
-			// tmux dead — but if the pod is young, workspace init may still
-			// be blocking the tmux server from starting. Don't delete pods
-			// that are still within the startup window.
+			// tmux not answering — but if the pod is young, workspace init may
+			// still be blocking the tmux server from starting. Don't delete
+			// pods that are still within the startup window.
 			if time.Since(pod.CreationTimestamp.Time) < startupGracePeriod {
 				return fmt.Errorf("%w: session %q (pod: %s)", runtime.ErrSessionInitializing, name, pod.Name)
 			}
-			// Stale pod — tmux dead and past grace period, recreate.
+			if !definitive {
+				// Past the grace period the next statement deletes this pod.
+				// Only a probe that actually ran inside the container may
+				// authorize that: an apiserver or kubelet transport failure
+				// says nothing about tmux, and treating it as a negative
+				// destroys a live agent's box and the work in it. Report the
+				// established "I could not tell" signal so the caller defers
+				// instead of recreating.
+				return fmt.Errorf("%w: tmux liveness probe for session %q (pod: %s) could not answer: %w",
+					runtime.ErrRuntimeUnavailable, name, pod.Name, probeErr)
+			}
+			// Stale pod — tmux definitively dead and past grace period, recreate.
 		}
 		// Clean up existing pod.
 		_ = p.ops.deletePod(ctx, pod.Name, 5)
@@ -688,6 +698,44 @@ func (p *Provider) CopyTo(name, src, relDst string) error {
 }
 
 // --- Internal helpers ---
+
+// livenessProbeAttempts is how many times probeTmuxLiveness will ask before
+// reporting that it could not tell. The exec path through the apiserver and
+// kubelet flakes independently of the pod, and a single blip is not evidence
+// about tmux; two unanswered attempts in a row are at least a pattern.
+const livenessProbeAttempts = 2
+
+// probeTmuxLiveness asks whether the session's tmux server is alive inside pod.
+//
+// It returns three-valued, not two: alive, and whether the answer is
+// definitive. A definitive answer means the probe actually ran inside the
+// container — `tmux has-session` exited, zero or non-zero. An indefinite
+// answer means the exec never got there (SPDY dial failure, apiserver error,
+// stream timeout, canceled context), which says nothing at all about tmux.
+//
+// Collapsing those two into "not alive" is how a transport flake becomes a
+// deleted pod. Callers that act destructively on a negative must require
+// definitive; callers that only defer may ignore it.
+func (p *Provider) probeTmuxLiveness(ctx context.Context, podName string) (alive, definitive bool, err error) {
+	for attempt := 0; attempt < livenessProbeAttempts; attempt++ {
+		_, err = p.ops.execInPod(ctx, podName, "agent",
+			[]string{"tmux", "has-session", "-t", tmuxSession}, nil)
+		if err == nil {
+			return true, true, nil
+		}
+		var exitErr execerr.ExitError
+		if errors.As(err, &exitErr) && exitErr.Exited() {
+			// The command ran in the container and reported no session. That
+			// is a real tmux negative — the same discrimination Provider.Exec
+			// already draws between an exit status and a transport failure.
+			return false, true, err
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return false, false, err
+}
 
 // findRunningPod finds a running pod by session label.
 // carrier returns the tmux carrier that drives this provider's sessions over

--- a/internal/runtime/k8s/provider_stale_probe_test.go
+++ b/internal/runtime/k8s/provider_stale_probe_test.go
@@ -127,6 +127,45 @@ func TestStartDeletesStalePodOnDefinitiveTmuxNegative(t *testing.T) {
 	}
 }
 
+// TestStartRecreatesAPodWhoseAgentContainerIsNotRunning closes the gap the
+// probe guard would otherwise open. A pod can be phase Running while its agent
+// container is crash-looping or terminated, and every exec into it then fails
+// at the apiserver with an error shaped exactly like a transport flake. If that
+// read as "I could not tell", a genuinely broken pod would never be replaced —
+// the guard would trade one stall for another.
+//
+// The pod's own status settles it. That is a second observation channel,
+// independent of the connection in doubt, so a not-running container is a
+// definitive tmux negative and the pod is recreated.
+func TestStartRecreatesAPodWhoseAgentContainerIsNotRunning(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	addAgedRunningPod(fake, "gc-test-agent", "gc-test-agent")
+	fake.pods["gc-test-agent"].Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "agent",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 137}},
+	}}
+	// Every exec fails the way the apiserver fails for a dead container —
+	// deliberately not an ExitError, so only the pod status can decide.
+	fake.execFunc = func(pod string, cmd []string) (string, error) {
+		if len(cmd) > 1 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			return "", errors.New("error executing command in container: container is not running")
+		}
+		return "", nil
+	}
+	// Block the recreate so the test ends at the decision it is about, the
+	// same way TestStartDeletesOldPodWithDeadTmux does.
+	fake.createErr = errors.New("intentional: verify deletion only")
+
+	err := p.Start(context.Background(), "gc-test-agent", staleProbeConfig())
+	if errors.Is(err, runtime.ErrRuntimeUnavailable) {
+		t.Fatalf("Start deferred on a pod whose agent container is dead: %v — a broken pod would never be replaced", err)
+	}
+	if got := deletedPods(fake); len(got) == 0 {
+		t.Fatal("a pod whose agent container is not running must be recreated, not deferred forever")
+	}
+}
+
 // TestStartRetriesAnUnansweredLivenessProbeBeforeGivingUp keeps the guard from
 // converting every transient blip into a stalled slot: one flake followed by a
 // definitive answer must be resolved on the answer, not on the flake.

--- a/internal/runtime/k8s/provider_stale_probe_test.go
+++ b/internal/runtime/k8s/provider_stale_probe_test.go
@@ -1,0 +1,160 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	execerr "k8s.io/client-go/util/exec"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// addAgedRunningPod adds a Running pod created far enough in the past that the
+// startup grace period has expired — the window in which Start is willing to
+// delete a same-name pod it judges stale.
+func addAgedRunningPod(fake *fakeK8sOps, name, sessionLabel string) {
+	fake.pods[name] = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Labels:            map[string]string{"app": "gc-agent", "gc-session": sessionLabel},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * startupGracePeriod)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func deletedPods(fake *fakeK8sOps) []string {
+	var out []string
+	for _, c := range fake.calls {
+		if c.method == "deletePod" {
+			out = append(out, c.pod)
+		}
+	}
+	return out
+}
+
+func staleProbeConfig() runtime.Config {
+	return runtime.Config{
+		Command:      "claude",
+		ProcessNames: []string{"claude"},
+		Env:          map[string]string{"GC_AGENT": "mayor", "GC_CITY": "/workspace"},
+	}
+}
+
+// TestStartDoesNotDeleteLivePodWhenTmuxProbeCannotAnswer is the ga-vcjr9
+// companion guard. Start decides a same-name Running pod is stale by exec'ing
+// `tmux has-session` inside it, and it used to read ANY error from that exec as
+// "tmux is dead" — including an apiserver/kubelet transport failure that never
+// reached the container. Past the startup grace period that verdict deletes the
+// pod, so one spurious exec failure destroys a live agent's box and the work in
+// it.
+//
+// This only became load-bearing with identity-stable pool names. While every
+// start attempt minted a fresh name the pre-check never found a pod at all;
+// now every pool retry re-targets the slot's own name and takes this path.
+func TestStartDoesNotDeleteLivePodWhenTmuxProbeCannotAnswer(t *testing.T) {
+	transportFailures := map[string]error{
+		"dial refused":     errors.New("error dialing backend: dial tcp 10.0.0.7:10250: connect: connection refused"),
+		"apiserver 500":    errors.New("error sending request: Internal error occurred: error executing command in container"),
+		"stream timeout":   errors.New("exec in pod gc-test-agent: i/o timeout"),
+		"context canceled": context.Canceled,
+	}
+
+	for label, transportErr := range transportFailures {
+		t.Run(label, func(t *testing.T) {
+			fake := newFakeK8sOps()
+			p := newProviderWithOps(fake)
+			addAgedRunningPod(fake, "gc-test-agent", "gc-test-agent")
+			fake.setExecResult("gc-test-agent",
+				[]string{"tmux", "has-session", "-t", "main"}, "", transportErr)
+
+			err := p.Start(context.Background(), "gc-test-agent", staleProbeConfig())
+			if err == nil {
+				t.Fatal("Start succeeded on an unanswerable liveness probe; it must defer, not recreate")
+			}
+			if !errors.Is(err, runtime.ErrRuntimeUnavailable) {
+				t.Fatalf("Start error = %v, want ErrRuntimeUnavailable (the probe could not answer)", err)
+			}
+			if got := deletedPods(fake); len(got) != 0 {
+				t.Fatalf("Start deleted %v on a probe that never reached the pod; a transport failure is not a tmux negative", got)
+			}
+			for _, c := range fake.calls {
+				if c.method == "createPod" {
+					t.Fatal("Start created a replacement pod while the incumbent's liveness was unknown")
+				}
+			}
+		})
+	}
+}
+
+// TestStartDeletesStalePodOnDefinitiveTmuxNegative is the discriminating
+// control for the test above. Same pod, same age, same code path — the only
+// difference is that the probe genuinely ran inside the container and reported
+// no session (a non-zero exit). That IS a tmux negative, and the stale pod must
+// still be recreated. Without this control the guard above could be satisfied
+// by never deleting anything.
+func TestStartDeletesStalePodOnDefinitiveTmuxNegative(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	addAgedRunningPod(fake, "gc-test-agent", "gc-test-agent")
+
+	// `tmux has-session` ran and exited 1: no such session. The real
+	// execInPod surfaces this as a client-go ExitError, the same shape
+	// Provider.Exec already dispatches on.
+	probed := 0
+	fake.execFunc = func(pod string, cmd []string) (string, error) {
+		if len(cmd) > 1 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			probed++
+			if probed == 1 {
+				return "", execerr.CodeExitError{
+					Err:  errors.New("no server running on /tmp/tmux-1000/default"),
+					Code: 1,
+				}
+			}
+		}
+		return "", nil
+	}
+
+	if err := p.Start(context.Background(), "gc-test-agent", staleProbeConfig()); err != nil {
+		t.Fatalf("Start on a definitively stale pod: %v", err)
+	}
+	if got := deletedPods(fake); len(got) == 0 {
+		t.Fatal("a definitively dead tmux past the grace period must still recreate the pod")
+	}
+}
+
+// TestStartRetriesAnUnansweredLivenessProbeBeforeGivingUp keeps the guard from
+// converting every transient blip into a stalled slot: one flake followed by a
+// definitive answer must be resolved on the answer, not on the flake.
+func TestStartRetriesAnUnansweredLivenessProbeBeforeGivingUp(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	addAgedRunningPod(fake, "gc-test-agent", "gc-test-agent")
+
+	probes := 0
+	fake.execFunc = func(pod string, cmd []string) (string, error) {
+		if len(cmd) > 1 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			probes++
+			if probes == 1 {
+				return "", errors.New("error dialing backend: connection reset by peer")
+			}
+			return "", nil // second probe answers: tmux is alive
+		}
+		return "", nil
+	}
+
+	err := p.Start(context.Background(), "gc-test-agent", staleProbeConfig())
+	if !errors.Is(err, runtime.ErrSessionExists) {
+		t.Fatalf("Start error = %v, want ErrSessionExists — the retry answered that the session is live", err)
+	}
+	if probes < 2 {
+		t.Fatalf("liveness probe ran %d time(s); an unanswered probe must be retried before a verdict", probes)
+	}
+	if got := deletedPods(fake); len(got) != 0 {
+		t.Fatalf("Start deleted %v after the retry reported a live session", got)
+	}
+}

--- a/internal/runtime/k8s/provider_stale_probe_test.go
+++ b/internal/runtime/k8s/provider_stale_probe_test.go
@@ -16,7 +16,7 @@ import (
 // addAgedRunningPod adds a Running pod created far enough in the past that the
 // startup grace period has expired — the window in which Start is willing to
 // delete a same-name pod it judges stale.
-func addAgedRunningPod(fake *fakeK8sOps, name, sessionLabel string) {
+func addAgedRunningPod(fake *fakeK8sOps, name, sessionLabel string) { //nolint:unparam // name varies with the session under test
 	fake.pods[name] = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
@@ -106,7 +106,7 @@ func TestStartDeletesStalePodOnDefinitiveTmuxNegative(t *testing.T) {
 	// execInPod surfaces this as a client-go ExitError, the same shape
 	// Provider.Exec already dispatches on.
 	probed := 0
-	fake.execFunc = func(pod string, cmd []string) (string, error) {
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
 		if len(cmd) > 1 && cmd[0] == "tmux" && cmd[1] == "has-session" {
 			probed++
 			if probed == 1 {
@@ -147,7 +147,7 @@ func TestStartRecreatesAPodWhoseAgentContainerIsNotRunning(t *testing.T) {
 	}}
 	// Every exec fails the way the apiserver fails for a dead container —
 	// deliberately not an ExitError, so only the pod status can decide.
-	fake.execFunc = func(pod string, cmd []string) (string, error) {
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
 		if len(cmd) > 1 && cmd[0] == "tmux" && cmd[1] == "has-session" {
 			return "", errors.New("error executing command in container: container is not running")
 		}
@@ -175,7 +175,7 @@ func TestStartRetriesAnUnansweredLivenessProbeBeforeGivingUp(t *testing.T) {
 	addAgedRunningPod(fake, "gc-test-agent", "gc-test-agent")
 
 	probes := 0
-	fake.execFunc = func(pod string, cmd []string) (string, error) {
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
 		if len(cmd) > 1 && cmd[0] == "tmux" && cmd[1] == "has-session" {
 			probes++
 			if probes == 1 {

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -12,6 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	execerr "k8s.io/client-go/util/exec"
+
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/shellquote"
 )
@@ -781,10 +783,14 @@ func TestStartDeletesOldPodWithDeadTmux(t *testing.T) {
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	// tmux dead — genuinely stale.
+	// tmux dead — genuinely stale. `tmux has-session` RAN in the container and
+	// exited 1, which is what makes this a stale pod rather than an
+	// unreachable one; the real execInPod surfaces that as a client-go
+	// ExitError wrapping tmux's stderr, and Start now requires that
+	// distinction before it will delete a Running pod (ga-vcjr9).
 	fake.setExecResult("gc-test-agent",
 		[]string{"tmux", "has-session", "-t", "main"}, "",
-		fmt.Errorf("no server running on /tmp/tmux-1000/default"))
+		execerr.CodeExitError{Err: fmt.Errorf("no server running on /tmp/tmux-1000/default"), Code: 1})
 
 	// Block createPod so Start() stops after deletion — we only need to
 	// verify the stale pod was cleaned up, not the full startup.

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -45,6 +45,11 @@ const (
 	autoSessionNamePrefix     = "s-"
 )
 
+// MaxExplicitSessionNameLen is the longest explicit session name
+// [ValidateExplicitName] accepts. Callers that derive a name from an identity
+// of unbounded length need it to shorten deterministically instead of failing.
+const MaxExplicitSessionNameLen = explicitSessionNameMaxLen
+
 type sessionIdentifierReservationLockEntry struct {
 	mu   sync.Mutex
 	refs int


### PR DESCRIPTION
Closes the name-churn half of ga-vcjr9: a pool whose start op kept failing
produced a **new runtime session name per attempt**, and because the runtime
name is the sandbox name and therefore the pod name, cherry accumulated
**115.6 new sandbox pods/hour for a pool whose desired count was 1** (two full
inventories 95 min apart: 253 → 435 pods, 183 new names, 1 deletion in the
window, so the level is not confounded by deletion).

## The isolating control

`mayor` and `bd.dog` ran on the same controller, same tick, same 30s cadence,
same persistent start failure. `mayor` has a stable explicit name and failed to
start **137 times** — it has exactly **one** pod. `bd.dog` is bead-ID-suffixed
and has **602**. Only the naming differs.

## The invariant

A pool slot's runtime session name is a pure function of its configured
identity — the resolved `tmux_alias` (plus the slot number once the pool expands
past its first instance), else the qualified instance name the planner already
derives from config and slot — and **never** of a bead ID. Both minting sites
route through it. N consecutive failures therefore address ONE box, and the leak
is impossible by construction rather than rate-limited.

Supporting changes: the name is resolved before the bead exists (no
create-then-close); a held name fails the create closed with a typed
`errPoolSessionNameUnavailable` the planner already treats as "skip, retry next
tick"; the pool passes its own identity as `selfOwner` so the reservation checks
can tell it reclaiming its own name from a stranger squatting it; and a pool
instance of an agent that is also a configured named session's template steps
aside onto `<name>-pool`.

## Why the two provider commits are part of this and not follow-ups

Identity-stable names change the risk profile of two code paths that were
previously never exercised on a pool retry, and both of them can destroy a live
agent's box — an outcome strictly worse than the leak.

**`internal/runtime/k8s`.** `Start` decided a same-name Running pod was stale by
exec'ing `tmux has-session` inside it, and read **any** error from that exec as
"tmux is dead" — including an apiserver or kubelet transport failure that never
reached the container. Past the grace period that verdict deletes the pod. While
every attempt minted a fresh name this pre-check never found a pod at all; now
every pool retry takes this path. A delete now requires a definitive negative:
the command ran in the container and exited, or the pod's own status says the
agent container is not running. An unanswered probe is retried once and then
reported as `runtime.ErrRuntimeUnavailable` so the caller defers.

**`internal/runtime/exec`.** exec is the only provider that infers
`ErrSessionExists` from the adapter's stderr wording, and that sentinel is the
only thing stopping `cleanupAfterStartFailure` from tearing down the box a
healthy session is running in. Collisions were rare; they are now steady state.
The teardown is gated on occupancy established structurally before the attempt.
The gate is additive by construction — it only ever withholds a teardown, and a
pack that cannot answer `is-running` keeps today's behaviour exactly, including
the teardown that stopped the original pod leak.

## Cost, stated plainly

Replacing a failed pool session takes one extra reconcile tick (the dead bead
must close before the replacement claims the same name), and a foreign holder of
a slot's name stalls that slot with the holder named in the log instead of
silently provisioning a second box. Both are fail-stop and diagnosable; what
they replace was fail-open at 115 pods/hour.

## Proof

`TestPoolSessionCreate_FailedRetriesAddressOneRuntimeName` runs the measured
loop (create → start fails → close as failed_create → repeat) through a live
tick snapshot and pins one name across five attempts. **Ported to
`origin/enterprise` unmodified it reports five** —
`[bd__dog-gc-1 … bd__dog-gc-5]` — while its distinct-slots control passes on the
same tree.

Every guard was broken deliberately and shown red, each with a control that
came out differently:

| break | reddens | control that stayed green |
|---|---|---|
| restore the per-attempt suffix on collision | live-holder, foreign-reservation, swept-without-markers | churn test (its loop closes each bead, so no collision arises — the pre-fix tree run is what covers that path) |
| ignore live holders in the tick snapshot | live-holder-through-a-degraded-store | degraded store with no holder still creates |
| treat any exec error as a definitive tmux negative | both transport guards | definitive-negative control + all 20 pre-existing `TestStart*` |
| drop the pod-status channel | dead-agent-container recreate | everything else |
| ignore the exec occupancy gate | occupied-box teardown | vacant-box teardown + occupancy-blind pack + all 21 pre-existing exec `TestStart*` |
| stop writing `session_origin=ephemeral` | swept-slot release | without-markers control |

`openSessionNameTaken` initially could not be made to fail — the live-store scan
caught every case the tests posed. It is not redundant, and the added test says
where it is load-bearing: `derivePoolSessionName` deliberately proceeds on the
identity-derived name when the reservation scan errors, and that tolerance is
only safe because the tick snapshot is consulted first.

Refs: ga-vcjr9, ga-o51te

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3393 — removes the opaque bead-ID suffix from pool session names — a pool slot's runtime name is now derived from its identity (e.g. `gastown--bd__dog-1` instead of `bd__dog-gc-session-<hex>`), which is the unreadable `gc-session-<id>` form that issue complains about; it does not implement the proposed `gastown_<type>-<rig>-<name>` format, does not move naming into the SDK `internal/agent/session_name.go` layer, and pool members are still distinguished by slot number rather than by pool name, so pre-existing sessions keep their old names

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->