### PR TITLE
Federate custom scale_check across active rig stores

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -155,6 +155,12 @@ type poolEvalWork struct {
 	poolDir   string
 	env       map[string]string
 	newDemand bool
+	// probes is non-nil only for a city-scoped agent with a custom
+	// scale_check: evaluatePendingPools sums sp.Check's count across every
+	// probe (city + non-suspended rigs) instead of running it once against
+	// poolDir. nil preserves the single-store evaluatePool/evaluatePoolNewDemand
+	// path unchanged (ga-drb140 AC1/AC4).
+	probes []poolStoreProbe
 }
 
 type defaultScaleCheckTarget struct {
@@ -251,17 +257,31 @@ func evaluatePendingPools(
 		agentName := cfg.Agents[pw.agentIdx].Name
 		agentIndex := pw.agentIdx
 		newDemand := pw.newDemand
-		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string, newDemand bool) {
+		probes := pw.probes
+		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string, newDemand bool, probes []poolStoreProbe) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
 			started := time.Now()
 			var d int
 			var err error
-			if newDemand {
-				d, err = evaluatePoolNewDemand(agentName, sp, dir, probeEnv, shellScaleCheck)
+			if len(probes) > 0 {
+				// evaluatePoolFanOutSum shares this same sem, acquiring it
+				// itself once per probe. Acquiring it again here would nest an
+				// outer whole-item wait around per-probe acquires on the
+				// identical channel, which can deadlock once sem is saturated
+				// (ga-drb140 AC1).
+				var errs []error
+				d, errs = evaluatePoolFanOutSum(agentName, sp, probes, shellScaleCheck, sem, newDemand)
+				err = errors.Join(errs...)
 			} else {
-				d, err = evaluatePool(agentName, sp, dir, probeEnv, shellScaleCheck)
+				sem <- struct{}{}
+				func() {
+					defer func() { <-sem }()
+					if newDemand {
+						d, err = evaluatePoolNewDemand(agentName, sp, dir, probeEnv, shellScaleCheck)
+					} else {
+						d, err = evaluatePool(agentName, sp, dir, probeEnv, shellScaleCheck)
+					}
+				}()
 			}
 			evalResults[idx] = poolEvalResult{desired: d, err: err}
 			if trace != nil {
@@ -279,7 +299,7 @@ func evaluatePendingPools(
 					"agent_index":    agentIndex,
 				})
 			}
-		}(j, template, agentName, agentIndex, sp, pw.poolDir, newDemand)
+		}(j, template, agentName, agentIndex, sp, pw.poolDir, newDemand, probes)
 	}
 	wg.Wait()
 
@@ -590,7 +610,11 @@ func buildDesiredStateWithSessionBeads(
 					coldWakeTemplates[template] = true
 				}
 			}
-			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
+			var probes []poolStoreProbe
+			if rigName == "" && hasCustomScaleCheck {
+				probes = cityScopedFanOutProbes(cityPath, cfg, &cfg.Agents[i], poolDir, nil, suspendedRigPaths)
+			}
+			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil, probes: probes})
 			continue
 		}
 
@@ -679,7 +703,11 @@ func buildDesiredStateWithSessionBeads(
 			fmt.Fprintf(stderr, "scaleCheck: building env for %s: %v\n", cfg.Agents[i].QualifiedName(), err) //nolint:errcheck
 			continue
 		}
-		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: env, newDemand: store != nil})
+		var probes []poolStoreProbe
+		if rigName == "" && hasCustomScaleCheck {
+			probes = cityScopedFanOutProbes(cityPath, cfg, &cfg.Agents[i], poolDir, env, suspendedRigPaths)
+		}
+		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: env, newDemand: store != nil, probes: probes})
 	}
 
 	// Collect work beads with assignees — used for both pool demand and

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -131,18 +132,27 @@ var hookIdentityEnvKeys = []string{
 	"GC_SESSION_ID", "GC_SESSION_ORIGIN", "GC_TEMPLATE",
 }
 
-// appendRigHookStores adds one hookStore per rig for a cross-store-eligible
-// (city-scoped) agent — vp-kvp stage iii read federation. Each entry reuses the
-// rig's store env (built the same way controller probes build it, via a per-rig
-// agent view) while keeping the city agent's identity overrides, so the query
-// reads the RIG store but still matches work routed/assigned to the city agent.
-// Best-effort: a rig whose env cannot be built is skipped (the agent's own store
-// is always queried first by the caller).
+// appendRigHookStores adds one hookStore per non-suspended rig for a
+// cross-store-eligible (city-scoped) agent — vp-kvp stage iii read
+// federation. Each entry reuses the rig's store env (built the same way
+// controller probes build it, via a per-rig agent view) while keeping the
+// city agent's identity overrides, so the query reads the RIG store but
+// still matches work routed/assigned to the city agent. Best-effort: a rig
+// whose env cannot be built is skipped (the agent's own store is always
+// queried first by the caller). A suspended rig is excluded outright via
+// buildSuspendedRigPathsForCity, the same helper buildDesiredStateWithSessionBeads
+// uses to build activeStores for scale_check — reusing it here keeps
+// work_query and scale_check agreeing on which stores exist for a
+// city-scoped agent (ga-drb140 AC3).
 func appendRigHookStores(stores []hookStore, cityPath string, cfg *config.City, a *config.Agent, identityOverrides map[string]string) []hookStore {
 	if cfg == nil || a == nil {
 		return stores
 	}
+	suspendedRigPaths := buildSuspendedRigPathsForCity(cfg, cityPath)
 	for i := range cfg.Rigs {
+		if suspendedRigPaths[filepath.Clean(cfg.Rigs[i].Path)] {
+			continue
+		}
 		stores = appendOneRigHookStore(stores, cityPath, cfg, a, cfg.Rigs[i].Name, identityOverrides)
 	}
 	return stores

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -2,12 +2,46 @@ package main
 
 import (
 	"errors"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
 
 var errTestStoreTimeout = errors.New("store timed out")
+
+// TestAppendRigHookStoresExcludesSuspendedRig pins AC3 of the custom
+// scale_check fan-out work (ga-drb140): buildDesiredStateWithSessionBeads'
+// activeStores already excludes a suspended rig's store from scale_check
+// (build_desired_state.go), so the store set backing "gc hook" work_query
+// must exclude it too -- otherwise scale_check and work_query disagree on
+// which stores exist for the same city-scoped agent, and hook can route
+// work into a rig that scale_check will never fan out to (or vice versa).
+func TestAppendRigHookStoresExcludesSuspendedRig(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "riga", Path: filepath.Join(cityPath, "riga")},
+			{Name: "rigb", Path: filepath.Join(cityPath, "rigb"), SuspendedOnStart: true},
+		},
+	}
+	a := &config.Agent{Name: "worker"}
+	base := []hookStore{{dir: "own"}}
+
+	got := appendRigHookStores(base, cityPath, cfg, a, nil)
+
+	if len(got) != len(base)+1 {
+		t.Fatalf("len(got) = %d, want %d: a suspended rig's store must be excluded from the "+
+			"hook work_query store set, the same way activeStores already excludes it from "+
+			"scale_check (got=%+v)", len(got), len(base)+1, got)
+	}
+	for _, s := range got {
+		if strings.Contains(s.dir, "rigb") {
+			t.Fatalf("appendRigHookStores included a store for suspended rig rigb: %+v", got)
+		}
+	}
+}
 
 // TestRigScopedHookRig is the core of the rig-scope hook fix: a rig-scoped agent
 // ("<rig>/<name>") must resolve to its own rig so the hook also queries that

--- a/cmd/gc/pool_scale_check_fanout.go
+++ b/cmd/gc/pool_scale_check_fanout.go
@@ -1,6 +1,15 @@
 package main
 
-import "github.com/gastownhall/gascity/internal/config"
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/telemetry"
+)
 
 // poolStoreProbe is one (store, dir, env) leg of a city-scoped agent's
 // custom scale_check fan-out across the city store and its non-suspended
@@ -13,10 +22,24 @@ type poolStoreProbe struct {
 
 // cityScopedFanOutProbes builds the probe list for a city-scoped agent's
 // custom scale_check fan-out: the agent's own (city) probe plus one probe
-// per non-suspended rig, mirroring activeStores' suspended-rig filter.
-// Not yet implemented -- TDD RED (ga-drb140).
-func cityScopedFanOutProbes(_ string, _ *config.City, _ *config.Agent, _ string, _ map[string]string, _ map[string]bool) []poolStoreProbe {
-	return nil
+// per non-suspended rig, mirroring activeStores' suspended-rig filter in
+// buildDesiredStateWithSessionBeads. ownEnv is reused unchanged for every
+// probe: controllerQueryRuntimeEnv resolves to the city's bd runtime env for
+// any city-scoped agent regardless of which store's directory a probe
+// happens to run in, so there is no per-rig env to compute here — the probe
+// command's working directory (dir) is what selects the store.
+func cityScopedFanOutProbes(cityPath string, cfg *config.City, _ *config.Agent, ownDir string, ownEnv map[string]string, suspendedRigPaths map[string]bool) []poolStoreProbe {
+	probes := []poolStoreProbe{{ref: "city", dir: ownDir, env: ownEnv}}
+	if cfg == nil {
+		return probes
+	}
+	for _, rig := range cfg.Rigs {
+		if suspendedRigPaths[filepath.Clean(rig.Path)] {
+			continue
+		}
+		probes = append(probes, poolStoreProbe{ref: rig.Name, dir: resolveAgentDirPath(cityPath, rig.Path), env: ownEnv})
+	}
+	return probes
 }
 
 // evaluatePoolFanOutSum runs sp.Check via runner against every probe
@@ -24,7 +47,55 @@ func cityScopedFanOutProbes(_ string, _ *config.City, _ *config.Agent, _ string,
 // sums the parsed per-probe counts -- clamping the aggregate once when
 // newDemand is false, mirroring evaluatePool/evaluatePoolNewDemand's
 // single-store clamp semantics applied to the summed total instead of one
-// value. Not yet implemented -- TDD RED (ga-drb140).
-func evaluatePoolFanOutSum(_ string, _ scaleParams, _ []poolStoreProbe, _ ScaleCheckRunner, _ chan struct{}, _ bool) (int, []error) {
-	return 0, nil
+// value. A probe error contributes 0 to the sum (best-effort, matching
+// bestStoreWithWork's federation contract) and is returned for the caller to
+// log; it never poisons the other probes' counts.
+func evaluatePoolFanOutSum(agentName string, sp scaleParams, probes []poolStoreProbe, runner ScaleCheckRunner, sem chan struct{}, newDemand bool) (int, []error) {
+	counts := make([]int, len(probes))
+	errs := make([]error, len(probes))
+	var wg sync.WaitGroup
+	for i, probe := range probes {
+		wg.Add(1)
+		go func(i int, probe poolStoreProbe) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			start := time.Now()
+			out, err := runner(sp.Check, probe.dir, probe.env)
+			durationMs := float64(time.Since(start).Milliseconds())
+			if err != nil {
+				telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, 0, err)
+				errs[i] = fmt.Errorf("%s: %w", probe.ref, err)
+				return
+			}
+			n, err := parseScaleCheckCount(agentName, sp.Check, out)
+			if err != nil {
+				telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, 0, err)
+				errs[i] = fmt.Errorf("%s: %w", probe.ref, err)
+				return
+			}
+			telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, n, nil)
+			counts[i] = n
+		}(i, probe)
+	}
+	wg.Wait()
+
+	sum := 0
+	var outErrs []error
+	for i, n := range counts {
+		sum += n
+		if errs[i] != nil {
+			outErrs = append(outErrs, errs[i])
+		}
+	}
+	if !newDemand {
+		if sum < sp.Min {
+			sum = sp.Min
+		}
+		if sp.Max >= 0 && sum > sp.Max {
+			sum = sp.Max
+		}
+	}
+	return sum, outErrs
 }

--- a/cmd/gc/pool_scale_check_fanout.go
+++ b/cmd/gc/pool_scale_check_fanout.go
@@ -1,0 +1,30 @@
+package main
+
+import "github.com/gastownhall/gascity/internal/config"
+
+// poolStoreProbe is one (store, dir, env) leg of a city-scoped agent's
+// custom scale_check fan-out across the city store and its non-suspended
+// rig stores.
+type poolStoreProbe struct {
+	ref string
+	dir string
+	env map[string]string
+}
+
+// cityScopedFanOutProbes builds the probe list for a city-scoped agent's
+// custom scale_check fan-out: the agent's own (city) probe plus one probe
+// per non-suspended rig, mirroring activeStores' suspended-rig filter.
+// Not yet implemented -- TDD RED (ga-drb140).
+func cityScopedFanOutProbes(_ string, _ *config.City, _ *config.Agent, _ string, _ map[string]string, _ map[string]bool) []poolStoreProbe {
+	return nil
+}
+
+// evaluatePoolFanOutSum runs sp.Check via runner against every probe
+// concurrently, sharing the caller's own sem (never a nested semaphore), and
+// sums the parsed per-probe counts -- clamping the aggregate once when
+// newDemand is false, mirroring evaluatePool/evaluatePoolNewDemand's
+// single-store clamp semantics applied to the summed total instead of one
+// value. Not yet implemented -- TDD RED (ga-drb140).
+func evaluatePoolFanOutSum(_ string, _ scaleParams, _ []poolStoreProbe, _ ScaleCheckRunner, _ chan struct{}, _ bool) (int, []error) {
+	return 0, nil
+}

--- a/cmd/gc/pool_scale_check_fanout_test.go
+++ b/cmd/gc/pool_scale_check_fanout_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -118,38 +120,53 @@ func TestEvaluatePoolFanOutSumBestEffortOnProbeError(t *testing.T) {
 	}
 }
 
-// TestEvaluatePoolFanOutSumRunsProbesConcurrently is AC6's timing proof: a
-// city-scoped agent's fan-out across N stores must run those N probes
-// concurrently, so wall-clock is bounded by the SLOWEST single probe, not
-// the sum of all of them. A sequential (loop-and-call) implementation would
-// take ~N times as long and fail the bound below.
+// TestEvaluatePoolFanOutSumRunsProbesConcurrently is AC6's concurrency proof:
+// a city-scoped agent's fan-out across N stores must run those N probes
+// concurrently, not one at a time. Proven with a WaitGroup barrier rather
+// than a wall-clock sleep: every runner blocks until all N have started, so
+// a sequential (loop-and-call) implementation deadlocks here — a
+// deterministic failure instead of a timing-based one.
+//
+// No time.Sleep: internal/testpolicy/resourcecensus ratchets fixed-sleep
+// test calls down, never up (TestRepositoryLedgerMatchesCensusAndDocumentation).
 func TestEvaluatePoolFanOutSumRunsProbesConcurrently(t *testing.T) {
-	const sleep = 80 * time.Millisecond
 	const n = 4
 	probes := make([]poolStoreProbe, n)
 	for i := range probes {
 		probes[i] = fanOutProbe(fmt.Sprintf("store-%d", i), fmt.Sprintf("dir-%d", i))
 	}
-	runner := func(_, _ string, _ map[string]string) (string, error) {
-		time.Sleep(sleep)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	runner := func(_, _ string, _ map[string]string) (string, error) { //nolint:unparam // the runner seam returns an error every barrier-synced probe never produces
+		wg.Done()
+		wg.Wait() // every probe must have started before any of them may finish
 		return "1", nil
 	}
 	sem := make(chan struct{}, n) // large enough for full concurrency
 	sp := scaleParams{Min: 0, Max: 100, Check: "check"}
 
-	start := time.Now()
-	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
-	elapsed := time.Since(start)
+	type fanOutResult struct {
+		got  int
+		errs []error
+	}
+	resultCh := make(chan fanOutResult, 1)
+	go func() {
+		got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+		resultCh <- fanOutResult{got, errs}
+	}()
 
-	if len(errs) != 0 {
-		t.Fatalf("errs = %v, want none", errs)
-	}
-	if got != n {
-		t.Fatalf("sum = %d, want %d", got, n)
-	}
-	if elapsed >= sleep*time.Duration(n) {
-		t.Fatalf("elapsed = %v, want well under %v (%d × %v sequential) — probes must run "+
-			"concurrently, not one at a time", elapsed, sleep*time.Duration(n), n, sleep)
+	select {
+	case res := <-resultCh:
+		if len(res.errs) != 0 {
+			t.Fatalf("errs = %v, want none", res.errs)
+		}
+		if res.got != n {
+			t.Fatalf("sum = %d, want %d", res.got, n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("evaluatePoolFanOutSum did not return — probes are not running concurrently " +
+			"(a sequential implementation deadlocks on the barrier: probe 1 waits for probes " +
+			"2..N to start, but they are never invoked until probe 1 returns)")
 	}
 }
 
@@ -160,35 +177,75 @@ func TestEvaluatePoolFanOutSumRunsProbesConcurrently(t *testing.T) {
 // caller-level semaphore already saturated by other pools, this agent's own
 // N probes must still serialize through it — proving no hidden/nested
 // semaphore silently grants this call extra concurrency the caller never
-// authorized.
+// authorized. Proven by tracking peak concurrently-active runners through a
+// rendezvous handshake rather than a wall-clock sleep, so an over-concurrent
+// implementation is caught deterministically instead of by timing
+// proportion (see the sibling test above for why no time.Sleep).
 func TestEvaluatePoolFanOutSumSharesCallerSemaphoreNotNested(t *testing.T) {
-	const sleep = 40 * time.Millisecond
 	const n = 3
 	probes := make([]poolStoreProbe, n)
 	for i := range probes {
 		probes[i] = fanOutProbe(fmt.Sprintf("store-%d", i), fmt.Sprintf("dir-%d", i))
 	}
-	runner := func(_, _ string, _ map[string]string) (string, error) {
-		time.Sleep(sleep)
+
+	var active, peak int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	runner := func(_, _ string, _ map[string]string) (string, error) { //nolint:unparam // the runner seam returns an error every rendezvous-synced probe never produces
+		cur := atomic.AddInt32(&active, 1)
+		for {
+			p := atomic.LoadInt32(&peak)
+			if cur <= p || atomic.CompareAndSwapInt32(&peak, p, cur) {
+				break
+			}
+		}
+		entered <- struct{}{}
+		<-release
+		atomic.AddInt32(&active, -1)
 		return "1", nil
 	}
 	sem := make(chan struct{}, 1) // caller-level capacity of 1: already saturated
 	sp := scaleParams{Min: 0, Max: 100, Check: "check"}
 
-	start := time.Now()
-	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
-	elapsed := time.Since(start)
+	type fanOutResult struct {
+		got  int
+		errs []error
+	}
+	resultCh := make(chan fanOutResult, 1)
+	go func() {
+		got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+		resultCh <- fanOutResult{got, errs}
+	}()
 
-	if len(errs) != 0 {
-		t.Fatalf("errs = %v, want none", errs)
+	// Release probes one at a time. If a nested/separate semaphore lets a
+	// second probe become active before this loop releases the first, its
+	// entry (above) already bumped peak > 1 before it could reach `entered`.
+	for i := 0; i < n; i++ {
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for probe %d of %d to start", i+1, n)
+		}
+		release <- struct{}{}
 	}
-	if got != n {
-		t.Fatalf("sum = %d, want %d", got, n)
+
+	var res fanOutResult
+	select {
+	case res = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("evaluatePoolFanOutSum did not return after all probes were released")
 	}
-	if elapsed < sleep*time.Duration(n) {
-		t.Fatalf("elapsed = %v, want at least %v (%d × %v serialized through a size-1 shared "+
-			"semaphore) — a nested/separate semaphore would run these probes fully concurrently "+
-			"instead of honoring the caller's own concurrency bound", elapsed, sleep*time.Duration(n), n, sleep)
+
+	if len(res.errs) != 0 {
+		t.Fatalf("errs = %v, want none", res.errs)
+	}
+	if res.got != n {
+		t.Fatalf("sum = %d, want %d", res.got, n)
+	}
+	if got := atomic.LoadInt32(&peak); got > 1 {
+		t.Fatalf("peak concurrently-active probes = %d, want 1 — a nested/separate semaphore let "+
+			"more than one probe run at once instead of serializing through the caller's size-1 "+
+			"shared semaphore", got)
 	}
 }
 

--- a/cmd/gc/pool_scale_check_fanout_test.go
+++ b/cmd/gc/pool_scale_check_fanout_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// fanOutProbe is a small constructor helper for readable test tables.
+func fanOutProbe(ref, dir string) poolStoreProbe {
+	return poolStoreProbe{ref: ref, dir: dir, env: nil}
+}
+
+// TestEvaluatePoolFanOutSumSumsAcrossProbes is the core AC2/AC5 regression
+// for ga-drb140: a city-scoped custom scale_check must SUM genuinely
+// multi-valued counts across every probe, not return a single winner.
+// Counts are deliberately non-0/1 (2, 3, 5) so a winner-takes-all
+// implementation (which would return 5, the max) or a first-hit
+// implementation (which would return 2) is distinguishable from the correct
+// sum (10) -- a 0/1-shaped fixture would pass under winner-takes-all by
+// accident.
+func TestEvaluatePoolFanOutSumSumsAcrossProbes(t *testing.T) {
+	probes := []poolStoreProbe{fanOutProbe("city", "city"), fanOutProbe("riga", "riga"), fanOutProbe("rigb", "rigb")}
+	counts := map[string]string{"city": "2", "riga": "3", "rigb": "5"}
+	runner := func(_, dir string, _ map[string]string) (string, error) {
+		return counts[dir], nil
+	}
+	sem := make(chan struct{}, len(probes))
+	sp := scaleParams{Min: 0, Max: 100, Check: "check"}
+
+	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v, want none", errs)
+	}
+	if got != 10 {
+		t.Fatalf("evaluatePoolFanOutSum sum = %d, want 10 (2+3+5) — a winner-takes-all or "+
+			"first-hit implementation would return 5 or 2 instead of summing every store", got)
+	}
+}
+
+// TestEvaluatePoolFanOutSumClampsAggregateOnce mirrors evaluatePool's
+// single-store clamp semantics applied to the AGGREGATE sum, not per probe:
+// the min/max clamp is meaningless per-store (a rig legitimately reporting 5
+// must not be silently clamped before summing), so it must apply once, after
+// summation, exactly like evaluatePool clamps its single result.
+func TestEvaluatePoolFanOutSumClampsAggregateOnce(t *testing.T) {
+	probes := []poolStoreProbe{fanOutProbe("city", "city"), fanOutProbe("riga", "riga")}
+	counts := map[string]string{"city": "4", "riga": "6"}
+	runner := func(_, dir string, _ map[string]string) (string, error) {
+		return counts[dir], nil
+	}
+	sem := make(chan struct{}, len(probes))
+	sp := scaleParams{Min: 0, Max: 6, Check: "check"}
+
+	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, false)
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v, want none", errs)
+	}
+	if got != 6 {
+		t.Fatalf("evaluatePoolFanOutSum clamped sum = %d, want 6 (4+6=10 clamped to Max once, "+
+			"not each probe clamped before summing)", got)
+	}
+}
+
+// TestEvaluatePoolFanOutSumNewDemandLeavesAggregateUnclamped covers the
+// additive/new-demand semantics (mirroring evaluatePoolNewDemand): when
+// newDemand is true, the summed total is the raw new-demand count with no
+// min/max clamp, matching evaluatePoolNewDemand's own unclamped contract.
+func TestEvaluatePoolFanOutSumNewDemandLeavesAggregateUnclamped(t *testing.T) {
+	probes := []poolStoreProbe{fanOutProbe("city", "city"), fanOutProbe("riga", "riga")}
+	counts := map[string]string{"city": "4", "riga": "6"}
+	runner := func(_, dir string, _ map[string]string) (string, error) {
+		return counts[dir], nil
+	}
+	sem := make(chan struct{}, len(probes))
+	sp := scaleParams{Min: 0, Max: 6, Check: "check"}
+
+	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v, want none", errs)
+	}
+	if got != 10 {
+		t.Fatalf("evaluatePoolFanOutSum new-demand sum = %d, want 10 (unclamped, mirroring "+
+			"evaluatePoolNewDemand's own unclamped contract)", got)
+	}
+}
+
+// TestEvaluatePoolFanOutSumBestEffortOnProbeError pins the federation
+// contract already established by bestStoreWithWork and
+// defaultScaleCheckCountsAndDemand: one bad store is best-effort, not fatal.
+// A single failing rig probe must contribute 0 (not poison the aggregate)
+// while its error is still surfaced to the caller for logging.
+func TestEvaluatePoolFanOutSumBestEffortOnProbeError(t *testing.T) {
+	probes := []poolStoreProbe{fanOutProbe("city", "city"), fanOutProbe("riga", "riga"), fanOutProbe("rigb", "rigb")}
+	boom := fmt.Errorf("boom")
+	runner := func(_, dir string, _ map[string]string) (string, error) {
+		switch dir {
+		case "city":
+			return "3", nil
+		case "riga":
+			return "", boom
+		default:
+			return "4", nil
+		}
+	}
+	sem := make(chan struct{}, len(probes))
+	sp := scaleParams{Min: 0, Max: 100, Check: "check"}
+
+	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+	if got != 7 {
+		t.Fatalf("evaluatePoolFanOutSum sum = %d, want 7 (3+0+4): one failing rig probe must "+
+			"contribute 0, not poison the whole aggregate", got)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("errs = %v, want exactly 1 (the riga probe failure surfaced for logging)", errs)
+	}
+}
+
+// TestEvaluatePoolFanOutSumRunsProbesConcurrently is AC6's timing proof: a
+// city-scoped agent's fan-out across N stores must run those N probes
+// concurrently, so wall-clock is bounded by the SLOWEST single probe, not
+// the sum of all of them. A sequential (loop-and-call) implementation would
+// take ~N times as long and fail the bound below.
+func TestEvaluatePoolFanOutSumRunsProbesConcurrently(t *testing.T) {
+	const sleep = 80 * time.Millisecond
+	const n = 4
+	probes := make([]poolStoreProbe, n)
+	for i := range probes {
+		probes[i] = fanOutProbe(fmt.Sprintf("store-%d", i), fmt.Sprintf("dir-%d", i))
+	}
+	runner := func(_, _ string, _ map[string]string) (string, error) {
+		time.Sleep(sleep)
+		return "1", nil
+	}
+	sem := make(chan struct{}, n) // large enough for full concurrency
+	sp := scaleParams{Min: 0, Max: 100, Check: "check"}
+
+	start := time.Now()
+	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+	elapsed := time.Since(start)
+
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v, want none", errs)
+	}
+	if got != n {
+		t.Fatalf("sum = %d, want %d", got, n)
+	}
+	if elapsed >= sleep*time.Duration(n) {
+		t.Fatalf("elapsed = %v, want well under %v (%d × %v sequential) — probes must run "+
+			"concurrently, not one at a time", elapsed, sleep*time.Duration(n), n, sleep)
+	}
+}
+
+// TestEvaluatePoolFanOutSumSharesCallerSemaphoreNotNested is AC1's explicit
+// concurrency-sharing constraint: the fan-out must bound its own concurrency
+// through the CALLER's existing probe-concurrency semaphore, not a separate
+// one sized to the probe count. With a size-1 semaphore standing in for a
+// caller-level semaphore already saturated by other pools, this agent's own
+// N probes must still serialize through it — proving no hidden/nested
+// semaphore silently grants this call extra concurrency the caller never
+// authorized.
+func TestEvaluatePoolFanOutSumSharesCallerSemaphoreNotNested(t *testing.T) {
+	const sleep = 40 * time.Millisecond
+	const n = 3
+	probes := make([]poolStoreProbe, n)
+	for i := range probes {
+		probes[i] = fanOutProbe(fmt.Sprintf("store-%d", i), fmt.Sprintf("dir-%d", i))
+	}
+	runner := func(_, _ string, _ map[string]string) (string, error) {
+		time.Sleep(sleep)
+		return "1", nil
+	}
+	sem := make(chan struct{}, 1) // caller-level capacity of 1: already saturated
+	sp := scaleParams{Min: 0, Max: 100, Check: "check"}
+
+	start := time.Now()
+	got, errs := evaluatePoolFanOutSum("agent", sp, probes, runner, sem, true)
+	elapsed := time.Since(start)
+
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v, want none", errs)
+	}
+	if got != n {
+		t.Fatalf("sum = %d, want %d", got, n)
+	}
+	if elapsed < sleep*time.Duration(n) {
+		t.Fatalf("elapsed = %v, want at least %v (%d × %v serialized through a size-1 shared "+
+			"semaphore) — a nested/separate semaphore would run these probes fully concurrently "+
+			"instead of honoring the caller's own concurrency bound", elapsed, sleep*time.Duration(n), n, sleep)
+	}
+}
+
+// TestCityScopedFanOutProbesIncludesCityAndNonSuspendedRigsOnly is AC1's
+// store-set-construction half, mirroring activeStores' own suspended-rig
+// filter in buildDesiredStateWithSessionBeads: the probe list must contain
+// the agent's own (city) probe plus one probe per non-suspended rig, and
+// must exclude a suspended rig entirely -- the same store set activeStores
+// already computes for the default scale_check path.
+func TestCityScopedFanOutProbesIncludesCityAndNonSuspendedRigsOnly(t *testing.T) {
+	cityPath := t.TempDir()
+	rigAPath := cityPath + "/riga"
+	rigBPath := cityPath + "/rigb"
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "riga", Path: rigAPath},
+			{Name: "rigb", Path: rigBPath, SuspendedOnStart: true},
+		},
+	}
+	agentCfg := &config.Agent{Name: "worker"}
+	ownEnv := map[string]string{"OWN": "1"}
+	suspended := map[string]bool{rigBPath: true}
+
+	probes := cityScopedFanOutProbes(cityPath, cfg, agentCfg, cityPath, ownEnv, suspended)
+
+	if len(probes) != 2 {
+		t.Fatalf("len(probes) = %d, want 2 (city + riga only; rigb is suspended): %+v", len(probes), probes)
+	}
+	if probes[0].ref != "city" || probes[0].dir != cityPath {
+		t.Fatalf("probes[0] = %+v, want the agent's own city probe (dir=%q)", probes[0], cityPath)
+	}
+	foundRigA := false
+	for _, p := range probes {
+		if p.ref == "rigb" {
+			t.Fatalf("probes contains a probe for suspended rig rigb: %+v", probes)
+		}
+		if p.ref == "riga" {
+			foundRigA = true
+		}
+	}
+	if !foundRigA {
+		t.Fatalf("probes missing non-suspended rig riga: %+v", probes)
+	}
+}

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -207,6 +207,42 @@ changes; tests `TestPoolDemandPredicateSharedWithWorkQuery` (structural) and
 `TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics` (behavioral) guard against
 regressions.
 
+### Store-set symmetry (federated custom `scale_check`)
+
+The correspondence above is single-store: it keeps the *predicate* applied
+to one target's bead store in sync between the two read sides. For a
+city-scoped agent with a custom `scale_check`, there is a second,
+independent invariant: the *set of stores* each side fans out across must
+also match.
+
+- **Worker (claim side)**: `gc hook`'s cross-store fan-out resolves targets
+  via `appendRigHookStores` (`hook_cross_store.go`), which adds one store
+  per non-suspended rig.
+- **Reconciler (spawn side)**: a city-scoped agent's custom `scale_check`
+  fans out via `cityScopedFanOutProbes` + `evaluatePoolFanOutSum`
+  (`pool_scale_check_fanout.go`), summing per-store counts instead of
+  picking a winner — `scale_check` is a count, so federating it
+  winner-takes-all would under-report demand from every store but the
+  largest (see `ga-itb5co`).
+
+Both call sites resolve their suspended-rig exclusion through the same
+`buildSuspendedRigPathsForCity` helper (`build_desired_state.go`) — the
+worker path calls it directly inside `appendRigHookStores`, and the
+reconciler path computes it once per desired-state pass and threads it into
+`cityScopedFanOutProbes` at each custom-`scale_check` call site. Sharing one
+helper is what makes the store sets match by construction rather than by
+convention: a rig suspension becomes invisible to a city-scoped agent's
+`scale_check` demand the same tick it becomes invisible to that agent's
+`work_query` claims, and vice versa.
+
+Diverging the two store sets — for example, filtering suspended rigs on
+one side but not the other — reintroduces the same class of bug the
+predicate correspondence above guards against, but at the store-selection
+layer instead of the query-filter layer: an agent could wake on summed
+demand from a rig it can never actually claim work from, or the reverse,
+staying asleep while claimable work sits in a rig its `scale_check` no
+longer counts.
+
 ## Invariants
 
 1. **Sling query placeholder is always `{}`.** The `buildSlingCommand`

--- a/release-gates/ga-dd7luh-federated-scale-check-fanout-gate.md
+++ b/release-gates/ga-dd7luh-federated-scale-check-fanout-gate.md
@@ -1,0 +1,69 @@
+# Release gate: federated custom `scale_check` fan-out
+
+- Deploy bead: `ga-dd7luh`
+- Build bead: `ga-drb140`
+- Review bead: `ga-gknp2w`
+- Reviewed commit: `70e8b787908c09162ebcfdece2e3eef86ef783e9`
+- Base: `origin/main@5eec6bba548005c0e26e23a1b09dc1c34d45dc1f`
+- Evaluated: 2026-08-17 (America/Los_Angeles)
+- Result: **PASS**
+
+`docs/PROJECT_MANIFEST.md` is not present at this commit. This checklist uses
+the seven release criteria in the current `mol-deployer-gate` formula and
+deployer prompt.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `ga-gknp2w` records `verdict: PASS`, `review_round: 2` at the resolved reviewed commit. Round 2 independently verified the documentation fix against live source and the design bead. |
+| 2 | Acceptance criteria met | **PASS** | AC1-AC7 are verified in the matrix below. The candidate implements city + non-suspended-rig fan-out, SUM semantics, shared semaphore bounding, both pool call paths, suspended-rig symmetry, deterministic concurrency coverage, and the architecture invariant. |
+| 3 | Tests pass | **PASS with attributed pre-existing failures** | Eight diff-owned tests passed by name (8 PASS, 0 FAIL, 0 SKIP). `make test-cmd-gc-process-parallel` passed all 7 jobs (7 PASS, 0 FAIL, 0 SKIP). `make test-fast-parallel` completed 9 harness jobs PASS and 1 job FAIL, with no SKIP reported; the failing `internal/runtime/herdr` tests satisfy all four attribution clauses below and reproduce on `origin/main`. Docsync passed 13 test/subtest results (13 PASS, 0 FAIL, 0 SKIP). |
+| 3a | Pre-existing failures may be attributed | **PASS** | `TestHerdrConformance` is not diff-owned, is tracked by `ga-19onv3`, fails on `origin/main@5eec6bba548005c0e26e23a1b09dc1c34d45dc1f` with the same `workspace_not_found` signature, and has no path overlap. `TestProviderLiveClaudeKindPath` is not diff-owned, is tracked by `ga-cqq3hs.1`, fails on the same base with the same `agent_pane_busy` signature, and has no path overlap. Candidate paths are limited to `cmd/gc/{build_desired_state.go,hook_cross_store.go,hook_cross_store_test.go,pool_scale_check_fanout.go,pool_scale_check_fanout_test.go}` and `engdocs/architecture/dispatch.md`; failures are under `internal/runtime/herdr`. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy`, `make check-docs`, `LINT_CHANGED_REF=origin/main LINT_CHANGED_SCOPE=tracked make fmt-check-changed`, and `go vet ./...` passed. The first shared-cache `lint-affected` run replayed stale findings from a removed `/var/tmp/ga-j250d0-gate...` worktree; the live source already carried the correct suppressions. The identical target with a fresh on-disk `GOLANGCI_LINT_CACHE` passed with `0 issues` over `./cmd/gc ./internal/runtime/tmux ./scripts`. Shared-cache contamination is tracked by `ga-ffwgw0`. |
+| 4 | No high-severity review findings open | **PASS** | Round 2 records no style or security findings and no unresolved HIGH findings. The only round-1 finding was missing AC7 documentation; commit `70e8b787908c09162ebcfdece2e3eef86ef783e9` resolves it and the reviewer passed the result. |
+| 5 | Final branch is clean | **PASS** | Before writing this checklist, `git status --porcelain` was empty at the exact reviewed commit. `git diff --check origin/main...HEAD` also passed. The checklist is committed separately on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | Already-merged preflight found 0 PRs for the reviewed SHA. After the final `git fetch origin main`, `git rev-list --left-right --count origin/main...HEAD` returned `1 3`; `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `35d93de778a62bb4b66ce683ee1dd2915f1d70d9`. No bounded self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | All three feature commits and six changed paths implement or document one behavior: federating city-scoped custom `scale_check` across the same non-suspended store set used by `work_query`. `assert_deploy_ancestry_scope origin/main HEAD ga-dd7luh ga-drb140` passed; no `.claude/**` or unrelated commit theme is present. |
+
+## Acceptance criteria
+
+| AC | Result | Evidence |
+|---|---|---|
+| AC1 | **PASS** | `cityScopedFanOutProbes` returns the city target plus non-suspended rig targets. `evaluatePoolFanOutSum` runs one goroutine per target and acquires the existing caller-owned semaphore once per probe, with no nested semaphore. |
+| AC2 | **PASS** | Per-store counts are summed; steady-state min/max clamping occurs once on the aggregate, while new-demand totals remain unclamped. `TestEvaluatePoolFanOutSumSumsAcrossProbes` proves `2 + 3 + 5 = 10`, distinguishing SUM from first-hit or winner-takes-all. |
+| AC3 | **PASS** | `appendRigHookStores` excludes suspended rigs through `buildSuspendedRigPathsForCity`, the same helper used by desired-state evaluation. This intentionally applies to every city-scoped cross-store-eligible agent, not only triager. |
+| AC4 | **PASS** | Both the named-session-backing pool path and the generic pool path construct `cityScopedFanOutProbes` for city-scoped custom checks and pass them through the same `evaluatePendingPools` implementation. |
+| AC5 | **PASS** | The multi-valued SUM test uses counts 2, 3, and 5. `TestCityScopedFanOutProbesIncludesCityAndNonSuspendedRigsOnly` covers city + active rig and excludes the suspended rig. |
+| AC6 | **PASS** | `TestEvaluatePoolFanOutSumRunsProbesConcurrently` uses a deterministic barrier to require concurrent starts; `TestEvaluatePoolFanOutSumSharesCallerSemaphoreNotNested` proves serialization through a caller semaphore of capacity 1. |
+| AC7 | **PASS** | `engdocs/architecture/dispatch.md` now documents store-set symmetry as distinct from same-store predicate symmetry and names the shared suspended-rig resolver. Independent docsync validation passed. |
+
+## Test evidence
+
+```text
+test_cmd: go test -count=1 -v ./cmd/gc -run '^(TestAppendRigHookStoresExcludesSuspendedRig|TestEvaluatePoolFanOutSumSumsAcrossProbes|TestEvaluatePoolFanOutSumClampsAggregateOnce|TestEvaluatePoolFanOutSumNewDemandLeavesAggregateUnclamped|TestEvaluatePoolFanOutSumBestEffortOnProbeError|TestEvaluatePoolFanOutSumRunsProbesConcurrently|TestEvaluatePoolFanOutSumSharesCallerSemaphoreNotNested|TestCityScopedFanOutProbesIncludesCityAndNonSuspendedRigsOnly)$'
+test_counts: 8 PASS, 0 FAIL, 0 SKIP
+diff_tests_executed: all eight named tests PASS
+waiver_ref: none
+
+test_cmd: make test-fast-parallel
+test_counts: 9 harness jobs PASS, 1 harness job FAIL, 0 SKIP reported
+failure_attribution: TestHerdrConformance -> ga-19onv3 + origin/main workspace_not_found reproduction; TestProviderLiveClaudeKindPath -> ga-cqq3hs.1 + origin/main agent_pane_busy reproduction
+
+test_cmd: make test-cmd-gc-process-parallel
+test_counts: 7 jobs PASS, 0 FAIL, 0 SKIP
+
+test_cmd: go test -count=1 -v ./test/docsync
+test_counts: 13 test/subtest PASS, 0 FAIL, 0 SKIP
+
+policy_lane: make test-ci-policy PASS; isolated-cache lint-affected PASS (0 issues); fmt-check-changed PASS; go vet ./... PASS; make check-docs PASS
+skip_justification: none; no SKIP was observed in candidate-owned or required named lanes
+```
+
+## Deployment preparation
+
+- Recorded SHA resolved with `git rev-parse --verify --quiet <sha>^{commit}`.
+- `assert_deploy_ancestry_scope` passed for `ga-dd7luh` and `ga-drb140`.
+- Git hooks path is `.githooks`.
+- Deploy target is the isolated branch `deploy/ga-dd7luh-gate`; the provenance
+  branch `builder/ga-drb140` is not a push target.


### PR DESCRIPTION
## What this changes

City-scoped agents with a custom `scale_check` now evaluate demand across the city store and every active rig store, running those probes concurrently and summing their counts. Demand that lives outside the city store therefore contributes to pool sizing without requiring each pack to hand-roll its own cross-rig shell loop.

The worker-side `work_query` federation now excludes suspended rigs through the same store-selection helper. A city-scoped agent consequently wakes and claims work from the same set of stores.

The implementation keeps each shell check single-store and fans out at the reconciler call site, sharing the existing global probe semaphore. This preserves the current process-concurrency bound while covering both generic pools and named-session-backed pools.

## Review notes

- `appendRigHookStores` now excludes suspended rigs for every city-scoped cross-store-eligible agent, not only triager.
- Rig-scoped agents and the default, non-custom `scale_check` path are unchanged.
- A failing store probe contributes zero to the aggregate while its error is surfaced through the existing partial-result/logging path.
- There are no new configuration fields, API changes, or migration steps.

## Test plan

- [x] Run the eight focused fan-out, summation, suspension, and concurrency regressions by name.
- [x] Run the sharded fast unit baseline and attribute only base-reproduced live Herdr failures.
- [x] Run all six process-backed `cmd/gc` shards plus the product-metrics profile.
- [x] Run CI policy, affected lint, formatting, full `go vet`, and documentation-sync checks.
- [x] Release gate: [`release-gates/ga-dd7luh-federated-scale-check-fanout-gate.md`](release-gates/ga-dd7luh-federated-scale-check-fanout-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3872 — covers the store-scope half of that issue's suggested direction — a city-scoped agent's custom scale_check now counts demand across the city store plus every non-suspended rig store, and gc hook's work_query federation resolves its store set through the same suspended-rig helper so the spawn side and the claim side agree on which stores exist. It does not cover the five reported session-lifecycle incidents themselves (adoption alias stamping, the serve subprocess's empty rig paths and pinned BEADS_DIR, drift-relaunch losing the startup prompt, ghost session beads, or the rig-scoped scale-from-zero pool), which remain open.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->