### PR TITLE
feat: cross-city gc mail — remote mail send|reply|inbox via --context + [supervisor.hardened] grant-gated second listener

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1450,7 +1450,16 @@ a non-running recipient. Unread mail alone does not request a wake.
 Use --from to override the sender identity.
 Use --to as an alternative to the positional <to> argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
-Use --all to broadcast to all live sessions (excluding sender and "human").`,
+Use --all to broadcast to all live sessions (excluding sender and "human").
+
+With --context/--city-url the message is sent to a REMOTE city over the
+control plane (a hardened city requires the context's grant_command). The
+sender then defaults to "<local city>/<identity>" (e.g. citadel/mayor) so the
+far side knows which city to answer with 'gc --context <city> mail send';
+--from overrides it. The remote city stores an unknown sender literally, but
+if it has a session whose alias equals that string (a rig named after the
+sending city) the message binds to that session — do not name a rig after a
+city that mails you. --all and --notify are refused for a remote city.`,
 		Example: `  gc mail send mayor "Build is green"
   gc mail send mayor -s "Build is green"
   gc mail send myrig/witness -s "Need investigation" -m "Attach logs from the last failed run"
@@ -1493,7 +1502,11 @@ func newMailInboxCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `List all unread messages for a session alias or human.
 
 Shows message ID, sender, subject, and body in a table. The recipient defaults
-to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human". Pass a session alias to view another inbox.`,
+to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human". Pass a session alias to view another inbox.
+
+With --context/--city-url the inbox is read from a REMOTE city; with no
+argument it lists mail addressed to this client's remote identity
+("<local city>/<identity>") — where a far-side 'gc mail reply' lands.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailInboxWithJSON(args, jsonOut, stdout, stderr) != 0 {
@@ -1562,7 +1575,11 @@ Inherits the thread ID from the original message for conversation tracking.
 Use --notify to request a recipient turn after replying. In a managed city,
 it can request a wake for a non-running recipient.
 Unread mail alone does not request a wake.
-Use -s/--subject for the reply subject and -m/--message for the reply body.`,
+Use -s/--subject for the reply subject and -m/--message for the reply body.
+
+With --context/--city-url the reply is sent inside a REMOTE city (the reply
+is addressed by that city to the original sender); the sender is
+"<local city>/<identity>" and --notify is refused.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			code := 0
@@ -1705,6 +1722,17 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 }
 
 func cmdMailSendJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, jsonOut bool, stdout, stderr io.Writer) int {
+	// Remote city: forward the mutation over the control plane before any local
+	// provider/store work (mirrors gc sling). A "no city discoverable" error is
+	// deferred to the local path so it reports exactly as before; a genuine
+	// resolution error (bad --context, remote client build failure) fails now,
+	// non-fallbackably (gate G1).
+	if remoteC, isRemote, remoteTgt, rerr := resolveWriteTarget(); rerr != nil && !isCityDiscoveryNotFound(rerr) {
+		fmt.Fprintf(stderr, "gc mail send: %v\n", rerr) //nolint:errcheck // best-effort stderr
+		return 1
+	} else if isRemote {
+		return cmdMailSendRemote(remoteC, remoteTgt, args, notify, all, from, to, subject, message, jsonOut, stdout, stderr)
+	}
 	mp, code := openCityMailProvider(stderr, "gc mail send")
 	if mp == nil {
 		return code
@@ -1946,6 +1974,14 @@ func cmdMailInbox(args []string, stdout, stderr io.Writer) int {
 }
 
 func cmdMailInboxWithJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	// Remote city: read the far-side mailbox over the control plane (see
+	// mail_remote.go). Same deferral of "no city discoverable" as mail send.
+	if remoteC, isRemote, remoteTgt, rerr := resolveReadTargetEcho(); rerr != nil && !isCityDiscoveryNotFound(rerr) {
+		fmt.Fprintf(stderr, "gc mail inbox: %v\n", rerr) //nolint:errcheck // best-effort stderr
+		return 1
+	} else if isRemote {
+		return cmdMailInboxRemote(remoteC, remoteTgt, args, jsonOut, stdout, stderr)
+	}
 	mp, code := openCityMailProvider(stderr, "gc mail inbox")
 	if mp == nil {
 		return code
@@ -2169,6 +2205,13 @@ func cmdMailReplyJSON(args []string, subject, message string, notify bool, jsonO
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail reply: missing message ID") //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	// Remote city: forward the reply over the control plane (see mail_remote.go).
+	if remoteC, isRemote, remoteTgt, rerr := resolveWriteTarget(); rerr != nil && !isCityDiscoveryNotFound(rerr) {
+		fmt.Fprintf(stderr, "gc mail reply: %v\n", rerr) //nolint:errcheck // best-effort stderr
+		return 1
+	} else if isRemote {
+		return cmdMailReplyRemote(remoteC, remoteTgt, args, subject, message, notify, jsonOut, stdout, stderr)
 	}
 
 	mp, code := openCityMailProvider(stderr, "gc mail reply")

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citywriteauth"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/events"
@@ -1374,6 +1375,38 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc supervisor: read-auth: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	// [supervisor.hardened]: an OPTIONAL second listener that serves the same
+	// mux with its own write-auth verifier, so a TLS-fronted remote port requires
+	// a signed grant on every mutation while the primary (loopback) listener keeps
+	// serving first-party callers that mint no grant. Resolve its verifier
+	// fail-closed BEFORE any listener binds: a hardened port must never come up
+	// ungated, and a misconfigured one must not leave the primary running while
+	// the hardened plane silently failed to start.
+	hardenedCfg := supCfg.Supervisor.Hardened
+	var hardenedVerifier *citywriteauth.Verifier
+	if hardenedCfg.Enabled() {
+		v, err := api.ResolveHardenedWriteAuthVerifier(hardenedCfg.WriteAuthVerifyKey)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc supervisor: hardened listener: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		if readOnly {
+			// The mux is built read-only for a non-loopback primary bind without
+			// allow_mutations; a grant-gated listener over a read-only mux would
+			// accept grants and still refuse every mutation — refuse the config.
+			fmt.Fprintf(stderr, "gc supervisor: hardened listener: the primary bind %s is read-only (non-loopback without allow_mutations); a hardened listener needs a mutation-capable mux\n", bind) //nolint:errcheck
+			return 1
+		}
+		if hardenedCfg.BindOrDefault() == bind && hardenedCfg.Port == port {
+			fmt.Fprintf(stderr, "gc supervisor: hardened listener: %s:%d is the primary listener address; use a distinct port\n", bind, port) //nolint:errcheck
+			return 1
+		}
+		if err := api.HardenedVerifierKidsDisjoint(supCfg.Supervisor.WriteAuthVerifyKey, hardenedCfg.WriteAuthVerifyKey); err != nil {
+			fmt.Fprintf(stderr, "gc supervisor: hardened listener: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		hardenedVerifier = v
+	}
 	// G23: a hardened supervisor bind (non-loopback + allow_mutations) previously
 	// booted silent. Emit the loud unauthenticated-read-plane warning (shared with
 	// the standalone controller seam) so an operator sees the read surface needs a
@@ -1436,6 +1469,22 @@ func runSupervisor(stdout, stderr io.Writer) int {
 			"gc supervisor: WARNING: API binding to ephemeral port %d -- "+
 				"set port = 8372 in ~/.gc/supervisor.toml\n", port)
 	}
+	// Bind the hardened listener BEFORE either listener starts serving, so a
+	// hardened bind failure (port taken, overlapping bind) never leaves the
+	// primary accepting requests for a window that the hardened plane then
+	// fails to join: startup is all-or-nothing across both listeners.
+	var hardenedLis net.Listener
+	var hardenedAddr string
+	if hardenedVerifier != nil {
+		hardenedAddr = net.JoinHostPort(hardenedCfg.BindOrDefault(), strconv.Itoa(hardenedCfg.Port))
+		var hardenedErr error
+		hardenedLis, hardenedErr = net.Listen("tcp", hardenedAddr)
+		if hardenedErr != nil {
+			_ = apiLis.Close()
+			fmt.Fprintf(stderr, "gc supervisor: hardened listener: listen %s failed: %v\n", hardenedAddr, hardenedErr) //nolint:errcheck
+			return 1
+		}
+	}
 	go func() {
 		if err := apiMux.Serve(apiLis); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fmt.Fprintf(stderr, "gc supervisor: api: %v\n", err) //nolint:errcheck
@@ -1448,6 +1497,27 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	}()
 	fmt.Fprintf(stdout, "Supervisor API listening on http://%s\n", addr) //nolint:errcheck
 	writeSupervisorDashboardStartup(stdout, dashboardMounted, readOnly, bind, port)
+
+	if hardenedLis != nil {
+		hardenedBind := hardenedCfg.BindOrDefault()
+		hardenedSrv := &http.Server{Handler: apiMux.HardenedHandler(hardenedVerifier)}
+		go func() {
+			if err := hardenedSrv.Serve(hardenedLis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				fmt.Fprintf(stderr, "gc supervisor: hardened listener: %v\n", err) //nolint:errcheck
+			}
+		}()
+		defer func() {
+			shutCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+			defer c()
+			hardenedSrv.Shutdown(shutCtx) //nolint:errcheck
+		}()
+		fmt.Fprintf(stdout, "Supervisor hardened API listening on http://%s (every city mutation requires a signed X-GC-City-Write grant)\n", hardenedAddr) //nolint:errcheck
+		if hardenedBind != "127.0.0.1" && hardenedBind != "localhost" && hardenedBind != "::1" {
+			// gc has no TLS of its own and the read plane on this listener is the
+			// primary's: name the exposure exactly as the G23 warning does.
+			warnUnauthenticatedReadPlane(stderr, hardenedBind, true, hardenedReadAuthInstalled(supCfg))
+		}
+	}
 
 	// External event forwarders consume the typed supervisor stream without
 	// configuring [events.export]. Allow that long-lived supervisor unit to arm
@@ -2738,3 +2808,11 @@ type cityInitProgress struct {
 
 // Compile-time check that *cityRegistry satisfies api.CityResolver.
 var _ api.CityResolver = (*cityRegistry)(nil)
+
+// hardenedReadAuthInstalled reports whether the primary listener's read-auth
+// verifier is installed (the hardened listener shares it), for the hardened
+// listener's non-loopback read-plane warning.
+func hardenedReadAuthInstalled(supCfg supervisor.Config) bool {
+	v, err := api.ResolveReadAuthVerifier(supCfg.Supervisor.ReadAuthVerifyKey, supCfg.Supervisor.ReadAuthRequired)
+	return err == nil && v != nil
+}

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -6771,3 +6771,125 @@ func TestRunSupervisorNoWarningForLowAPIPort(t *testing.T) {
 		t.Errorf("stdout = %q, want API listening message for low port", stdout.String())
 	}
 }
+
+// writeSupervisorBootFixture writes supervisor.toml under a fresh GC_HOME and
+// pre-occupies the control-socket path so runSupervisor returns right after the
+// API listeners come up (the same trick as the ephemeral-port tests).
+func writeSupervisorBootFixture(t *testing.T, cfg string) {
+	t.Helper()
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	if err := os.WriteFile(supervisor.ConfigPath(), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sockPath := filepath.Join(supervisor.RuntimeDir(), "supervisor.sock")
+	if err := os.MkdirAll(sockPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sockPath, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// freeAnyLoopbackPort returns a currently free loopback port (any range; the
+// ephemeral-port warning applies only to the PRIMARY listener).
+func freeAnyLoopbackPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// [supervisor.hardened] with a verify key boots a second, grant-gated listener
+// next to the primary one and announces it.
+func TestRunSupervisorHardenedListenerBoots(t *testing.T) {
+	port := freeLowLoopbackPort(t)
+	hardenedPort := freeAnyLoopbackPort(t)
+	writeSupervisorBootFixture(t, "[supervisor]\nport = "+strconv.Itoa(port)+"\n\n[supervisor.hardened]\nport = "+strconv.Itoa(hardenedPort)+"\nwrite_auth_verify_key = \"peer:QAXnBkSUJFXHA/sCICfJ1auCLZn4Lq4xWT8ASnAsEWY=\"\n")
+	var stdout, stderr bytes.Buffer
+	_ = runSupervisor(&stdout, &stderr)
+	if !strings.Contains(stdout.String(), "Supervisor API listening on http://127.0.0.1:"+strconv.Itoa(port)) {
+		t.Errorf("stdout = %q, want primary listening line", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Supervisor hardened API listening on http://127.0.0.1:"+strconv.Itoa(hardenedPort)) {
+		t.Errorf("stdout = %q, want hardened listening line", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "hardened listener:") {
+		t.Errorf("stderr = %q, hardened boot must not error", stderr.String())
+	}
+}
+
+// A hardened port WITHOUT a verify key is a fail-closed boot error: no listener
+// (primary included) comes up, so a hardened plane can never start ungated.
+func TestRunSupervisorHardenedListenerRequiresKey(t *testing.T) {
+	port := freeLowLoopbackPort(t)
+	writeSupervisorBootFixture(t, "[supervisor]\nport = "+strconv.Itoa(port)+"\n\n[supervisor.hardened]\nport = "+strconv.Itoa(freeAnyLoopbackPort(t))+"\n")
+	var stdout, stderr bytes.Buffer
+	if code := runSupervisor(&stdout, &stderr); code == 0 {
+		t.Errorf("exit = 0, want non-zero for a hardened listener without a key")
+	}
+	if !strings.Contains(stderr.String(), "hardened listener") || !strings.Contains(stderr.String(), "write_auth_verify_key") {
+		t.Errorf("stderr = %q, want hardened key error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "listening") {
+		t.Errorf("stdout = %q, no listener may come up when the hardened config is invalid", stdout.String())
+	}
+}
+
+// A hardened port equal to the primary address is refused before binding.
+func TestRunSupervisorHardenedListenerRefusesPrimaryAddress(t *testing.T) {
+	port := freeLowLoopbackPort(t)
+	writeSupervisorBootFixture(t, "[supervisor]\nport = "+strconv.Itoa(port)+"\n\n[supervisor.hardened]\nport = "+strconv.Itoa(port)+"\nwrite_auth_verify_key = \"peer:QAXnBkSUJFXHA/sCICfJ1auCLZn4Lq4xWT8ASnAsEWY=\"\n")
+	var stdout, stderr bytes.Buffer
+	if code := runSupervisor(&stdout, &stderr); code == 0 {
+		t.Errorf("exit = 0, want non-zero when the hardened port equals the primary")
+	}
+	if !strings.Contains(stderr.String(), "distinct port") {
+		t.Errorf("stderr = %q, want distinct-port error", stderr.String())
+	}
+}
+
+// A hardened key that shares a kid with the primary write-auth key is refused
+// at boot (cross-listener single-use replay).
+func TestRunSupervisorHardenedListenerRefusesSharedKid(t *testing.T) {
+	port := freeLowLoopbackPort(t)
+	const key = "\"peer:QAXnBkSUJFXHA/sCICfJ1auCLZn4Lq4xWT8ASnAsEWY=\""
+	writeSupervisorBootFixture(t, "[supervisor]\nport = "+strconv.Itoa(port)+"\nwrite_auth_verify_key = "+key+"\n\n[supervisor.hardened]\nport = "+strconv.Itoa(freeAnyLoopbackPort(t))+"\nwrite_auth_verify_key = "+key+"\n")
+	var stdout, stderr bytes.Buffer
+	if code := runSupervisor(&stdout, &stderr); code == 0 {
+		t.Errorf("exit = 0, want non-zero for a shared kid")
+	}
+	if !strings.Contains(stderr.String(), "kids must be disjoint") {
+		t.Errorf("stderr = %q, want disjoint-kid error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "listening") {
+		t.Errorf("stdout = %q, no listener may come up", stdout.String())
+	}
+}
+
+// A hardened port that cannot be bound fails startup before the primary ever
+// serves (all-or-nothing across both listeners).
+func TestRunSupervisorHardenedListenerBindFailureIsAllOrNothing(t *testing.T) {
+	port := freeLowLoopbackPort(t)
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	taken := occupied.Addr().(*net.TCPAddr).Port
+	writeSupervisorBootFixture(t, "[supervisor]\nport = "+strconv.Itoa(port)+"\n\n[supervisor.hardened]\nport = "+strconv.Itoa(taken)+"\nwrite_auth_verify_key = \"peer:QAXnBkSUJFXHA/sCICfJ1auCLZn4Lq4xWT8ASnAsEWY=\"\n")
+	var stdout, stderr bytes.Buffer
+	if code := runSupervisor(&stdout, &stderr); code == 0 {
+		t.Errorf("exit = 0, want non-zero when the hardened port is taken")
+	}
+	if !strings.Contains(stderr.String(), "hardened listener: listen") {
+		t.Errorf("stderr = %q, want hardened listen error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "listening") {
+		t.Errorf("stdout = %q, the primary must not announce before the hardened bind succeeds", stdout.String())
+	}
+}

--- a/cmd/gc/mail_remote.go
+++ b/cmd/gc/mail_remote.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/mail"
+)
+
+// Remote mail: `gc --context <peer> mail send|reply|inbox` operate a REMOTE
+// city over the control plane. The remote server resolves the recipient and
+// stores the message; the sender identity is asserted by this client (the
+// city-write grant proves which city sent it, the from string says who inside
+// that city). Local-only modes are refused with a clear message rather than
+// silently degraded: --all needs the local live-session enumeration and
+// --notify needs local nudge delivery, neither of which the mail API models.
+//
+// Sender identity: a remote city cannot resolve this session's alias, so the
+// default sender is city-qualified — "<local city>/<identity>" (e.g.
+// citadel/mayor) — which is what the far side sees in `gc mail inbox` and
+// what tells its operator to answer with `gc --context <city> mail send …`.
+// --from overrides it verbatim. gc has no cross-city addressing, so a plain
+// `gc mail reply` on the far side lands in THAT city's store, addressed to
+// the qualified sender; `gc --context <peer> mail inbox` (no argument) reads
+// exactly that mailbox back.
+
+// remoteMailIdentity returns the identity part of the default remote sender:
+// the first non-empty of GC_ALIAS, GC_AGENT, GC_SESSION_ID, else "human". The
+// alias/agent names lead because they are meaningful to a peer city; a bare
+// session id (the local default, see defaultMailIdentityCandidates) is opaque
+// outside the city that minted it.
+func remoteMailIdentity() string {
+	for _, k := range []string{"GC_ALIAS", "GC_AGENT", "GC_SESSION_ID"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return "human"
+}
+
+// localCityNameForRemoteMail returns the effective name of the LOCAL city the
+// caller is operating from (explicit city env, then cwd discovery), or "" when
+// no local city is discoverable. It never consults the remote target.
+func localCityNameForRemoteMail() string {
+	var cityPath string
+	if ctx, handled, err := resolveContextFromCityEnv(); handled && err == nil {
+		cityPath = ctx.CityPath
+	} else if ctx, err := resolveContextFromDir(); err == nil {
+		cityPath = ctx.CityPath
+	}
+	if cityPath == "" {
+		return ""
+	}
+	cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
+	if err != nil {
+		cfg = nil
+	}
+	return strings.TrimSpace(loadedCityName(cfg, cityPath))
+}
+
+// remoteMailSender resolves the sender for a remote mail mutation: an explicit
+// --from (whitespace-trimmed, otherwise as given), else
+// "<local city>/<identity>" (identity alone when no local city is
+// discoverable). The peer stores an unknown sender literally; if the peer
+// happens to have a session whose alias equals this string (a rig named after
+// the sending city), its beadmail binds the message to that session — so a
+// peer must not name a rig after a city that mails it (see the runbook).
+func remoteMailSender(from string) string {
+	if from = strings.TrimSpace(from); from != "" {
+		return from
+	}
+	id := remoteMailIdentity()
+	if city := localCityNameForRemoteMail(); city != "" {
+		return city + "/" + id
+	}
+	return id
+}
+
+// remoteMailSubject mirrors the beadmail provider's title derivation for a
+// send without -s: the API requires a non-empty subject (minLength 1), so
+// derive it from the first non-blank body line (truncated). It returns "" only
+// when neither the subject nor the body carries any non-blank text — the
+// caller refuses that locally instead of round-tripping to a 422.
+func remoteMailSubject(subject, body string) string {
+	if subject = strings.TrimSpace(subject); subject != "" {
+		return subject
+	}
+	title := strings.TrimSpace(strings.SplitN(strings.TrimLeft(body, " \t\r\n"), "\n", 2)[0])
+	if len(title) > 80 {
+		title = title[:77] + "..."
+	}
+	return title
+}
+
+// cmdMailSendRemote is the remote arm of `gc mail send`. args are the
+// positional [to, body...] (after --to has been folded in by the caller).
+func cmdMailSendRemote(c *api.Client, target *remoteTarget, args []string, notify, all bool, from, to, subject, message string, jsonOut bool, stdout, stderr io.Writer) int {
+	fail := func(code, msg string) int {
+		if jsonOut {
+			return writeJSONError(stdout, stderr, code, msg, 1)
+		}
+		fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if all {
+		return fail("unsupported_remote", "gc mail send: --all is not supported for a remote city (live-session enumeration is local); address one recipient")
+	}
+	if notify {
+		return fail("unsupported_remote", "gc mail send: --notify delivery for a remote city lands separately; send without --notify")
+	}
+	if to != "" {
+		args = append([]string{to}, args...)
+	}
+	if len(args) < 1 {
+		return fail("invalid_arguments", "gc mail send: missing recipient")
+	}
+	recipient := args[0]
+	body := message
+	if body == "" && len(args) > 1 {
+		body = strings.Join(args[1:], " ")
+	}
+	derivedSubject := remoteMailSubject(subject, body)
+	if derivedSubject == "" {
+		return fail("invalid_arguments", "gc mail send: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>] (a non-blank subject or body is required)")
+	}
+	sender := remoteMailSender(from)
+	if !jsonOut {
+		fmt.Fprintln(stderr, formatRemoteTarget(target)) //nolint:errcheck // best-effort stderr
+	}
+	m, err := c.SendMail(api.MailSendRequest{
+		From:    sender,
+		To:      recipient,
+		Subject: derivedSubject,
+		Body:    body,
+	})
+	if err != nil {
+		return fail("mail_send_failed", "gc mail send: "+err.Error())
+	}
+	if jsonOut {
+		summary := summarizeMailMessage(m)
+		return writeCLIJSONLineOrExit(stdout, stderr, "gc mail send", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.send", Action: "send", ID: m.ID, Message: &summary, Messages: []mailMessageSummary{summary}, Count: intRef(1)})
+	}
+	fmt.Fprintf(stdout, "Sent message %s to %s (as %s)\n", m.ID, m.To, m.From) //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+// cmdMailReplyRemote is the remote arm of `gc mail reply <id> [body...]`.
+func cmdMailReplyRemote(c *api.Client, target *remoteTarget, args []string, subject, message string, notify, jsonOut bool, stdout, stderr io.Writer) int {
+	fail := func(code, msg string) int {
+		if jsonOut {
+			return writeJSONError(stdout, stderr, code, msg, 1)
+		}
+		fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if len(args) < 1 {
+		return fail("invalid_arguments", "gc mail reply: missing message ID")
+	}
+	if notify {
+		return fail("unsupported_remote", "gc mail reply: --notify delivery for a remote city lands separately; reply without --notify")
+	}
+	id := args[0]
+	body := message
+	if body == "" && len(args) > 1 {
+		body = strings.Join(args[1:], " ")
+	}
+	sender := remoteMailSender("")
+	if !jsonOut {
+		fmt.Fprintln(stderr, formatRemoteTarget(target)) //nolint:errcheck // best-effort stderr
+	}
+	reply, err := c.ReplyMail(id, api.MailReplyRequest{From: sender, Subject: subject, Body: body})
+	if err != nil {
+		return fail("mail_reply_failed", "gc mail reply: "+err.Error())
+	}
+	if jsonOut {
+		summary := summarizeMailMessage(reply)
+		return writeCLIJSONLineOrExit(stdout, stderr, "gc mail reply", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.reply", Action: "reply", ID: reply.ID, Message: &summary, Messages: []mailMessageSummary{summary}, Count: intRef(1)})
+	}
+	fmt.Fprintf(stdout, "Replied to %s — sent message %s to %s (as %s)\n", id, reply.ID, reply.To, reply.From) //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+// remoteInboxReader adapts the remote client's inbox list to the
+// mailInboxReader seam so the remote inbox renders exactly like a local one:
+// it pages through the server's keyset pagination until the mailbox is
+// exhausted (a local inbox lists every unread message, so a single capped page
+// would silently truncate), and a partial aggregate read — one rig's provider
+// failed server-side — is an error, not an authoritative short list (remote
+// reads are non-fallbackable, gate G1).
+type remoteInboxReader struct{ c *api.Client }
+
+// remoteInboxMaxPages bounds the paging loop so a server that keeps returning
+// a cursor cannot spin the client forever; at the server's default page size
+// this is far beyond any real unread mailbox.
+const remoteInboxMaxPages = 200
+
+func (r remoteInboxReader) Inbox(recipient string) ([]mail.Message, error) {
+	var out []mail.Message
+	cursor := ""
+	for page := 0; page < remoteInboxMaxPages; page++ {
+		cr, err := r.c.ListMailInboxPage(recipient, "", cursor, 0)
+		if err != nil {
+			return nil, err
+		}
+		if cr.Body.Partial {
+			return nil, fmt.Errorf("remote inbox read is partial (%s); not rendering an incomplete mailbox", strings.Join(cr.Body.PartialErrors, "; "))
+		}
+		out = append(out, cr.Body.Items...)
+		if cr.Body.NextCursor == "" || len(cr.Body.Items) == 0 {
+			return out, nil
+		}
+		cursor = cr.Body.NextCursor
+	}
+	return nil, fmt.Errorf("remote inbox read exceeded %d pages; refusing to render a possibly incomplete mailbox", remoteInboxMaxPages)
+}
+
+// cmdMailInboxRemote is the remote arm of `gc mail inbox [recipient]`. With no
+// recipient it reads the mailbox of this client's own remote sender identity
+// ("<local city>/<identity>") — where a far-side `gc mail reply` lands.
+func cmdMailInboxRemote(c *api.Client, target *remoteTarget, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	recipient := ""
+	if len(args) > 0 {
+		recipient = strings.TrimSpace(args[0])
+	}
+	if recipient == "" {
+		recipient = remoteMailSender("")
+	}
+	if !jsonOut {
+		fmt.Fprintln(stderr, formatRemoteTarget(target)) //nolint:errcheck // best-effort stderr
+	}
+	return doMailInboxTargetWithJSON(remoteInboxReader{c}, resolvedMailTarget{display: recipient, recipients: []string{recipient}}, jsonOut, stdout, stderr)
+}

--- a/cmd/gc/mail_remote_test.go
+++ b/cmd/gc/mail_remote_test.go
@@ -1,0 +1,444 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/clientcontext"
+)
+
+const remoteMailMessageJSON = `{"id":"mc-wisp-1","from":"alpha/mayor","to":"mayor","subject":"hello","body":"round trip","created_at":"2026-08-18T17:00:00Z","read":false}`
+
+// clearRemoteMailIdentityEnv strips the identity env so tests control the
+// default remote sender deterministically.
+func clearRemoteMailIdentityEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"GC_ALIAS", "GC_AGENT", "GC_SESSION_ID", "GC_CITY", "GC_CITY_PATH", "GC_CITY_ROOT", "GC_RIG", "GC_DIR"} {
+		t.Setenv(k, "")
+	}
+}
+
+// seedLocalCity creates a minimal local city named "alpha" and points the
+// explicit city env at it, so the remote sender resolves "<local city>/…".
+func seedLocalCity(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "alpha-home")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"alpha\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", dir)
+	return dir
+}
+
+// The default remote sender is city-qualified ("<local city>/<identity>") with
+// alias > agent > session id, and --from wins verbatim.
+func TestRemoteMailSender(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	if got := remoteMailSender("citadel/mayor"); got != "citadel/mayor" {
+		t.Errorf("--from must pass verbatim, got %q", got)
+	}
+	// Chdir to a non-city dir so cwd discovery cannot find a real city.
+	t.Chdir(t.TempDir())
+	if got := remoteMailSender(""); got != "human" {
+		t.Errorf("no city, no identity: want human, got %q", got)
+	}
+	t.Setenv("GC_SESSION_ID", "s-1")
+	if got := remoteMailSender(""); got != "s-1" {
+		t.Errorf("session id fallback: got %q", got)
+	}
+	t.Setenv("GC_AGENT", "rig/worker")
+	if got := remoteMailSender(""); got != "rig/worker" {
+		t.Errorf("agent beats session id: got %q", got)
+	}
+	t.Setenv("GC_ALIAS", "mayor")
+	if got := remoteMailSender(""); got != "mayor" {
+		t.Errorf("alias beats agent: got %q", got)
+	}
+	seedLocalCity(t)
+	if got := remoteMailSender(""); got != "alpha/mayor" {
+		t.Errorf("city-qualified sender: got %q", got)
+	}
+}
+
+func TestRemoteMailSubject(t *testing.T) {
+	if got := remoteMailSubject("s", "b"); got != "s" {
+		t.Errorf("explicit subject: %q", got)
+	}
+	if got := remoteMailSubject("", "first line\nsecond"); got != "first line" {
+		t.Errorf("first-line derivation: %q", got)
+	}
+	long := strings.Repeat("x", 100)
+	if got := remoteMailSubject("", long); len(got) != 80 || !strings.HasSuffix(got, "...") {
+		t.Errorf("truncation: %d %q", len(got), got)
+	}
+	// A body that starts with blank lines still yields a non-empty subject
+	// (the API requires minLength 1), and an all-blank body yields "" so the
+	// caller refuses locally instead of round-tripping to a 422.
+	if got := remoteMailSubject("", "\n\n  hello\nworld"); got != "hello" {
+		t.Errorf("leading blank lines: %q", got)
+	}
+	if got := remoteMailSubject("  ", "\n \t\n"); got != "" {
+		t.Errorf("all-blank must be empty, got %q", got)
+	}
+}
+
+// Local-only modes are refused before the wire is touched.
+func TestCmdMailSendRemote_RefusesLocalOnlyModes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server must not be contacted for a refused mode")
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+	cases := []struct {
+		name        string
+		notify, all bool
+		args        []string
+		want        string
+	}{
+		{"all", false, true, []string{"body"}, "--all"},
+		{"notify", true, false, []string{"mayor", "body"}, "--notify"},
+		{"no-recipient", false, false, nil, "missing recipient"},
+		{"no-body", false, false, []string{"mayor"}, "usage"},
+		{"blank-body", false, false, []string{"mayor", "\n\t "}, "usage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			code := cmdMailSendRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), tc.args, tc.notify, tc.all, "", "", "", "", false, &out, &errb)
+			if code == 0 || !strings.Contains(errb.String(), tc.want) {
+				t.Errorf("exit=%d stderr=%q (want %q)", code, errb.String(), tc.want)
+			}
+		})
+	}
+	// Reply refuses --notify the same way.
+	var out, errb bytes.Buffer
+	if code := cmdMailReplyRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mc-1"}, "", "b", true, false, &out, &errb); code == 0 || !strings.Contains(errb.String(), "--notify") {
+		t.Errorf("reply --notify: exit=%d stderr=%q", code, errb.String())
+	}
+}
+
+// A remote send POSTs /v0/city/{city}/mail with the CSRF header, the
+// city-qualified sender, and a derived subject when -s is absent; it echoes the
+// resolved target on stderr and renders the server's message.
+func TestCmdMailSendRemote_PostsAndRenders(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("GC_ALIAS", "mayor")
+	seedLocalCity(t)
+
+	var gotPath, gotReq, gotMethod string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotReq, gotMethod = r.URL.Path, r.Header.Get("X-GC-Request"), r.Method
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(remoteMailMessageJSON))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := cmdMailSendRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mayor", "round trip"}, false, false, "", "", "", "", false, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit %d; stderr=%q", code, errb.String())
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v0/city/mc/mail" || gotReq == "" {
+		t.Errorf("method=%q path=%q req=%q", gotMethod, gotPath, gotReq)
+	}
+	if gotBody["to"] != "mayor" || gotBody["from"] != "alpha/mayor" || gotBody["subject"] != "round trip" || gotBody["body"] != "round trip" {
+		t.Errorf("body=%v", gotBody)
+	}
+	if !strings.Contains(out.String(), "Sent message mc-wisp-1 to mayor (as alpha/mayor)") {
+		t.Errorf("stdout=%q", out.String())
+	}
+	if !strings.Contains(errb.String(), "target:") || !strings.Contains(errb.String(), "mc @") {
+		t.Errorf("remote send did not echo the resolved target: %q", errb.String())
+	}
+}
+
+// --to / -s / -m and --from are honored; --json emits the local mail.send shape
+// and no human target echo.
+func TestCmdMailSendRemote_FlagsAndJSON(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(remoteMailMessageJSON))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := cmdMailSendRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), nil, false, false, "citadel/mayor", "mayor", "hello", "round trip", true, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit %d; stderr=%q", code, errb.String())
+	}
+	if gotBody["to"] != "mayor" || gotBody["from"] != "citadel/mayor" || gotBody["subject"] != "hello" || gotBody["body"] != "round trip" {
+		t.Errorf("body=%v", gotBody)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("output not JSON: %v (%q)", err, out.String())
+	}
+	if got["ok"] != true || got["command"] != "mail.send" || got["id"] != "mc-wisp-1" {
+		t.Errorf("json=%v", got)
+	}
+	if strings.Contains(errb.String(), "target:") {
+		t.Errorf("json mode leaked the human target echo: %q", errb.String())
+	}
+}
+
+// A server error surfaces (non-fallbackable) with a non-zero exit.
+func TestCmdMailSendRemote_ServerErrorSurfaces(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"title":"Unauthorized","status":401,"detail":"write grant required"}`))
+	}))
+	defer srv.Close()
+	var out, errb bytes.Buffer
+	code := cmdMailSendRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mayor", "x"}, false, false, "", "", "", "", false, &out, &errb)
+	if code == 0 || !strings.Contains(errb.String(), "gc mail send:") {
+		t.Errorf("exit=%d stderr=%q", code, errb.String())
+	}
+}
+
+// A remote reply POSTs /v0/city/{city}/mail/{id}/reply with the qualified
+// sender and renders the reply.
+func TestCmdMailReplyRemote_Posts(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("GC_ALIAS", "mayor")
+	seedLocalCity(t)
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"mc-wisp-2","from":"alpha/mayor","to":"jadegate/mayor","subject":"Re: hello","body":"ack","created_at":"2026-08-18T17:01:00Z","read":false,"reply_to":"mc-wisp-1"}`))
+	}))
+	defer srv.Close()
+	var out, errb bytes.Buffer
+	code := cmdMailReplyRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mc-wisp-1", "ack"}, "", "", false, false, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit %d; stderr=%q", code, errb.String())
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v0/city/mc/mail/mc-wisp-1/reply" {
+		t.Errorf("method=%q path=%q", gotMethod, gotPath)
+	}
+	if gotBody["from"] != "alpha/mayor" || gotBody["body"] != "ack" {
+		t.Errorf("body=%v", gotBody)
+	}
+	if !strings.Contains(out.String(), "Replied to mc-wisp-1 — sent message mc-wisp-2 to jadegate/mayor (as alpha/mayor)") {
+		t.Errorf("stdout=%q", out.String())
+	}
+}
+
+// A remote inbox GETs /v0/city/{city}/mail?agent=… — the explicit recipient,
+// or this client's own qualified identity by default — and renders like a
+// local inbox.
+func TestCmdMailInboxRemote_ListsAndDefaultsRecipient(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("GC_ALIAS", "mayor")
+	seedLocalCity(t)
+	var gotAgents []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/city/mc/mail" || r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		gotAgents = append(gotAgents, r.URL.Query().Get("agent"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[` + remoteMailMessageJSON + `],"total":1}`))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	if code := cmdMailInboxRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mayor"}, false, &out, &errb); code != 0 {
+		t.Fatalf("exit %d; stderr=%q", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "mc-wisp-1") || !strings.Contains(out.String(), "alpha/mayor") {
+		t.Errorf("stdout=%q", out.String())
+	}
+	out.Reset()
+	errb.Reset()
+	if code := cmdMailInboxRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), nil, true, &out, &errb); code != 0 {
+		t.Fatalf("exit %d; stderr=%q", code, errb.String())
+	}
+	if len(gotAgents) != 2 || gotAgents[0] != "mayor" || gotAgents[1] != "alpha/mayor" {
+		t.Errorf("agent params=%v", gotAgents)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("output not JSON: %v (%q)", err, out.String())
+	}
+	if got["recipient"] != "alpha/mayor" {
+		t.Errorf("json recipient=%v", got["recipient"])
+	}
+}
+
+// End-to-end dispatch: with --context set, `gc mail send|reply|inbox` route to
+// the remote city instead of the (absent) local store, and the sticky/flag
+// resolution never falls back locally on a remote error.
+func TestCmdMail_ContextDispatchesRemote(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	var hits []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"items":[],"total":0}`))
+		default:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(remoteMailMessageJSON))
+		}
+	}))
+	defer srv.Close()
+	// A loopback http URL is accepted for a context (TLS is required only for
+	// non-loopback hosts).
+	prev := contextFlag
+	contextFlag = "peer"
+	t.Cleanup(func() { contextFlag = prev })
+	var out, errb bytes.Buffer
+	if code := doContextAdd(clientcontext.Context{Name: "peer", URL: srv.URL, City: "mc"}, &out, &errb); code != 0 {
+		t.Fatalf("seed context: %q", errb.String())
+	}
+
+	out.Reset()
+	errb.Reset()
+	if code := cmdMailSendJSON([]string{"mayor", "hi"}, false, false, "", "", "", "", false, &out, &errb); code != 0 {
+		t.Fatalf("send exit %d; stderr=%q", code, errb.String())
+	}
+	if code := cmdMailReplyJSON([]string{"mc-wisp-1", "ack"}, "", "", false, false, &out, &errb); code != 0 {
+		t.Fatalf("reply exit %d; stderr=%q", code, errb.String())
+	}
+	if code := cmdMailInboxWithJSON([]string{"mayor"}, false, &out, &errb); code != 0 {
+		t.Fatalf("inbox exit %d; stderr=%q", code, errb.String())
+	}
+	want := []string{"POST /v0/city/mc/mail", "POST /v0/city/mc/mail/mc-wisp-1/reply", "GET /v0/city/mc/mail"}
+	if strings.Join(hits, ",") != strings.Join(want, ",") {
+		t.Errorf("hits=%v want %v", hits, want)
+	}
+}
+
+// The remote inbox pages through the server's keyset pagination until the
+// mailbox is exhausted, and a partial aggregate read is an error rather than a
+// silently short list.
+func TestCmdMailInboxRemote_PagesAndRefusesPartial(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	var cursors []string
+	partial := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c := r.URL.Query().Get("cursor")
+		cursors = append(cursors, c)
+		w.Header().Set("Content-Type", "application/json")
+		if partial {
+			_, _ = w.Write([]byte(`{"items":[` + remoteMailMessageJSON + `],"total":1,"partial":true,"partial_errors":["rig alpha: provider timeout"]}`))
+			return
+		}
+		switch c {
+		case "":
+			_, _ = w.Write([]byte(`{"items":[` + remoteMailMessageJSON + `],"total":3,"next_cursor":"p2"}`))
+		case "p2":
+			_, _ = w.Write([]byte(`{"items":[` + strings.Replace(remoteMailMessageJSON, "mc-wisp-1", "mc-wisp-2", 1) + `],"total":3,"next_cursor":"p3"}`))
+		default:
+			_, _ = w.Write([]byte(`{"items":[` + strings.Replace(remoteMailMessageJSON, "mc-wisp-1", "mc-wisp-3", 1) + `],"total":3}`))
+		}
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	if code := cmdMailInboxRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mayor"}, false, &out, &errb); code != 0 {
+		t.Fatalf("exit %d; stderr=%q", code, errb.String())
+	}
+	if strings.Join(cursors, ",") != ",p2,p3" {
+		t.Errorf("cursors=%v (want first page, p2, p3)", cursors)
+	}
+	for _, id := range []string{"mc-wisp-1", "mc-wisp-2", "mc-wisp-3"} {
+		if !strings.Contains(out.String(), id) {
+			t.Errorf("stdout missing %s: %q", id, out.String())
+		}
+	}
+	partial = true
+	out.Reset()
+	errb.Reset()
+	if code := cmdMailInboxRemote(remoteTestClient(t, srv.URL), remoteTestTarget(srv.URL), []string{"mayor"}, false, &out, &errb); code == 0 || !strings.Contains(errb.String(), "partial") || !strings.Contains(errb.String(), "provider timeout") {
+		t.Errorf("partial read must fail: exit=%d stderr=%q stdout=%q", code, errb.String(), out.String())
+	}
+	if strings.Contains(out.String(), "mc-wisp") {
+		t.Errorf("partial read rendered messages: %q", out.String())
+	}
+}
+
+// Dispatch matrix beyond the happy path: a remote failure surfaces non-zero
+// with no local fallback; GC_NO_API plus --context is a loud conflict; and
+// with no remote selector and no local city, the "no city" error is the local
+// one (the remote arm never engages).
+func TestCmdMail_ContextDispatchMatrix(t *testing.T) {
+	clearRemoteMailIdentityEnv(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"title":"Internal","status":500,"detail":"boom"}`))
+	}))
+	defer srv.Close()
+	var out, errb bytes.Buffer
+	if code := doContextAdd(clientcontext.Context{Name: "peer", URL: srv.URL, City: "mc"}, &out, &errb); code != 0 {
+		t.Fatalf("seed context: %q", errb.String())
+	}
+	prev := contextFlag
+	t.Cleanup(func() { contextFlag = prev })
+
+	// 1. Remote failure: non-zero, no "Sent message", no local fallback.
+	contextFlag = "peer"
+	out.Reset()
+	errb.Reset()
+	if code := cmdMailSendJSON([]string{"mayor", "hi"}, false, false, "", "", "", "", false, &out, &errb); code == 0 || strings.Contains(out.String(), "Sent message") || !strings.Contains(errb.String(), "gc mail send:") {
+		t.Errorf("remote failure: exit=%d stdout=%q stderr=%q", code, out.String(), errb.String())
+	}
+	// 2. GC_NO_API + --context is a conflict, surfaced before any wire call.
+	t.Setenv("GC_NO_API", "1")
+	out.Reset()
+	errb.Reset()
+	if code := cmdMailSendJSON([]string{"mayor", "hi"}, false, false, "", "", "", "", false, &out, &errb); code == 0 || !strings.Contains(errb.String(), "GC_NO_API") {
+		t.Errorf("GC_NO_API conflict: exit=%d stderr=%q", code, errb.String())
+	}
+	t.Setenv("GC_NO_API", "")
+	// 3. No remote selector, no local city: the local "not in a city" error,
+	//    i.e. the remote arm stays out of the way.
+	contextFlag = ""
+	out.Reset()
+	errb.Reset()
+	if code := cmdMailSendJSON([]string{"mayor", "hi"}, false, false, "", "", "", "", false, &out, &errb); code == 0 || !strings.Contains(errb.String(), "city") {
+		t.Errorf("no city: exit=%d stderr=%q", code, errb.String())
+	}
+	if strings.Contains(errb.String(), "target:") {
+		t.Errorf("no remote selector must not echo a remote target: %q", errb.String())
+	}
+}

--- a/cmd/gc/remote_client.go
+++ b/cmd/gc/remote_client.go
@@ -114,6 +114,26 @@ func resolveReadTarget() (remoteClient *api.Client, isRemote bool, cityPath stri
 	return nil, false, ctx.CityPath, nil
 }
 
+// resolveReadTargetEcho is resolveReadTarget for a READ command that also
+// wants to echo the resolved remote target (the way mutating commands do): it
+// returns the *remoteTarget alongside the no-fallback remote client. For a
+// LOCAL target it returns isRemote=false and a nil client; the caller uses its
+// existing local seam.
+func resolveReadTargetEcho() (remoteClient *api.Client, isRemote bool, target *remoteTarget, err error) {
+	ctx, err := resolveContextAllowRemote()
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if ctx.Remote != nil {
+		c, berr := buildRemoteClient(ctx.Remote)
+		if berr != nil {
+			return nil, true, ctx.Remote, berr
+		}
+		return c, true, ctx.Remote, nil
+	}
+	return nil, false, nil, nil
+}
+
 // resolveWriteTarget resolves a MUTATING command's target. It is the write-side
 // sibling of resolveReadTarget: identical context resolution, but a remote
 // client is built with buildRemoteWriteClient so it carries the city-write grant

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2418,6 +2418,10 @@ List all unread messages for a session alias or human.
 Shows message ID, sender, subject, and body in a table. The recipient defaults
 to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human". Pass a session alias to view another inbox.
 
+With --context/--city-url the inbox is read from a REMOTE city; with no
+argument it lists mail addressed to this client's remote identity
+("&lt;local city&gt;/&lt;identity&gt;") — where a far-side 'gc mail reply' lands.
+
 ```
 gc mail inbox [session] [flags]
 ```
@@ -2490,6 +2494,10 @@ it can request a wake for a non-running recipient.
 Unread mail alone does not request a wake.
 Use -s/--subject for the reply subject and -m/--message for the reply body.
 
+With --context/--city-url the reply is sent inside a REMOTE city (the reply
+is addressed by that city to the original sender); the sender is
+"&lt;local city&gt;/&lt;identity&gt;" and --notify is refused.
+
 ```
 gc mail reply <id> [-s subject] [-m body] [flags]
 ```
@@ -2513,6 +2521,15 @@ Use --from to override the sender identity.
 Use --to as an alternative to the positional &lt;to&gt; argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
 Use --all to broadcast to all live sessions (excluding sender and "human").
+
+With --context/--city-url the message is sent to a REMOTE city over the
+control plane (a hardened city requires the context's grant_command). The
+sender then defaults to "&lt;local city&gt;/&lt;identity&gt;" (e.g. citadel/mayor) so the
+far side knows which city to answer with 'gc --context &lt;city&gt; mail send';
+--from overrides it. The remote city stores an unknown sender literally, but
+if it has a session whose alias equals that string (a rig named after the
+sending city) the message binds to that session — do not name a rig after a
+city that mails you. --all and --notify are refused for a remote city.
 
 ```
 gc mail send [<to>] [<body>] [flags]

--- a/docs/runbooks/remote-hardened-city.md
+++ b/docs/runbooks/remote-hardened-city.md
@@ -101,6 +101,45 @@ public hostname in `[supervisor] allowed_hosts` or every request dies **421**.
 The standalone `gc controller` allows any host (the network front is the
 boundary), so it needs no `allowed_hosts`.
 
+**Supervisor that is ALSO a local control plane: `[supervisor.hardened]`.**
+`[supervisor] write_auth_verify_key` gates *every* per-city mutation on the
+supervisor's single listener — including the ones first-party callers make with
+only the CSRF header (the dashboard SPA, workspace-service adapters such as a
+chat bridge posting `POST /v0/city/{c}/session/{id}/messages`, the local gc
+client). On a machine where the supervisor is the trusted loopback control
+plane *and* must accept remote writes, put the grant gate on a **second
+listener** instead and leave the primary loopback listener as it is:
+
+```toml
+[supervisor]
+port = 8372                       # primary, loopback, first-party (unchanged)
+allowed_hosts = ["city.example.ts.net"]
+
+[supervisor.hardened]
+bind = "127.0.0.1"                # default; reachable only through the TLS front on this host
+port = 8447
+write_auth_verify_key = "peer:<base64 ed25519 pubkey>"   # REQUIRED; no unverified ack knob
+```
+
+The hardened listener serves the same mux, host/CORS/audit chain, and
+read-auth posture as the primary, with its own write gate **plus a front door
+the primary does not have**: it refuses (403) every supervisor-scope mutation
+(above all `POST /v0/city` — city creation with a caller-chosen
+`start_command`, which write-auth exempts because a not-yet-created city has
+no name to bind a grant to), the whole `/svc/*` workspace-service pass-through
+(any method — a GET can be a WebSocket upgrade the proxy then tunnels), and any
+protocol upgrade on any path. Only safe reads and grant-signed
+`/v0/city/{city}/…` mutations are served. Front the hardened port with your
+TLS edge (e.g. `tailscale serve --https=8443 http://127.0.0.1:8447`,
+tailnet-only) and register that URL as the peer's context. Boot is fail-closed
+and all-or-nothing: an enabled hardened port without a key, a hardened port
+equal to the primary address, a hardened kid that also appears in the primary
+key list (each verifier keeps its own single-use replay guard), a read-only
+primary bind, or a hardened bind failure refuses to start with **no** listener
+up. `GC_CITY_WRITE_PUBKEY` is *not* consulted for the hardened key — that env
+override belongs to the primary gate. The read plane on the hardened port is
+exactly the primary's (see §1), so it still needs the network front.
+
 ## 4. Configure the client context
 
 ```bash
@@ -156,6 +195,33 @@ gc --context prod events --follow --type rig.provision.progress \
 existing-bead** shape only: `gc --context prod sling <agent> <bead-id>`. Inline
 text, `--stdin`, and the 1-arg target-inference form are refused (a remote city
 cannot see your local rig config or create a local bead).
+
+### 5a. Cross-city mail (city ↔ city, real sender identity)
+
+Two hardened cities can mail each other with `gc` alone — no ssh, no
+`--from human`. Each city holds its own private key and configures the *peer's*
+public key (kid = peer city name) on its hardened listener:
+
+```bash
+# on city A (context "b" points at city B's hardened port; grant signed with A's key, kid "a")
+gc --context b mail send mayor -s "hello from A" -m "…"
+# -> stored in B with From "a/<A's identity>" (e.g. a/mayor); B's `gc mail inbox mayor` shows it.
+gc --context b mail inbox           # mail addressed to "a/<identity>" inside B — where B's plain `gc mail reply` lands
+# on city B, answering
+gc --context a mail send mayor -s "Re: hello from A" -m "…"
+```
+
+The sender defaults to `<local city>/<identity>` (`--from` overrides it); `--all`
+and `--notify` are refused for a remote city. gc has no cross-city addressing
+yet, so answer with `gc --context <city> mail send`, not a bare `gc mail reply`.
+`gc --context <peer> mail inbox` pages through the peer's whole unread mailbox
+and refuses to render a partial (degraded) read.
+
+**Naming rule.** The peer stores an unknown sender literally, but if it has a
+*session* whose alias equals the qualified sender (a rig named after the sending
+city, so `citadel/mayor` is one of its own agents) its beadmail binds the
+message to that local session and a reply routes there. Do not name a rig after
+a city that mails you.
 
 ## 6. Failure and resume recipes
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1234,6 +1234,15 @@ func (c *Client) GetStatus() (CachedRead[StatusView], error) {
 // callers can surface _cache_age_s on --json output and a staleness banner
 // on human output.
 func (c *Client) ListMailInbox(agent, rig string) (CachedRead[MailListView], error) {
+	return c.ListMailInboxPage(agent, rig, "", 0)
+}
+
+// ListMailInboxPage is ListMailInbox with explicit keyset paging: cursor is
+// the previous page's MailListView.NextCursor ("" for the first page) and
+// limit caps the page (0 = server default). The server never returns more than
+// one page per call, so a caller that wants the whole mailbox loops until
+// NextCursor is empty.
+func (c *Client) ListMailInboxPage(agent, rig, cursor string, limit int) (CachedRead[MailListView], error) {
 	if err := c.requireCityScope(); err != nil {
 		return CachedRead[MailListView]{}, err
 	}
@@ -1243,6 +1252,13 @@ func (c *Client) ListMailInbox(agent, rig string) (CachedRead[MailListView], err
 	}
 	if rig != "" {
 		params.Rig = &rig
+	}
+	if cursor != "" {
+		params.Cursor = &cursor
+	}
+	if limit > 0 {
+		l := int64(limit)
+		params.Limit = &l
 	}
 	resp, err := c.cw.GetV0CityByCityNameMailWithResponse(context.Background(), c.cityName, params)
 	if err != nil {
@@ -1288,6 +1304,82 @@ func (c *Client) GetMail(id, rig string) (CachedRead[mail.Message], error) {
 		Body:       mailMessageFromGen(*resp.JSON200),
 		AgeSeconds: cacheAgeFromResponse(resp.HTTPResponse),
 	}, nil
+}
+
+// MailSendRequest carries the parameters of a mail send for Client.SendMail.
+type MailSendRequest struct {
+	Rig     string // optional rig whose mail provider receives the message
+	From    string // sender identity stored verbatim by the server (empty = server default)
+	To      string // recipient (server-side resolution)
+	Subject string // required by the API (minLength 1)
+	Body    string
+}
+
+// SendMail creates a message via POST /v0/city/{cityName}/mail. It is a
+// mutation: on a remote client it carries the city-write grant the transport
+// mints per request; on a local client the CSRF header alone applies.
+func (c *Client) SendMail(req MailSendRequest) (mail.Message, error) {
+	if err := c.requireCityScope(); err != nil {
+		return mail.Message{}, err
+	}
+	body := genclient.SendMailJSONRequestBody{To: req.To, Subject: req.Subject}
+	setStrPtr(&body.Rig, req.Rig)
+	setStrPtr(&body.From, req.From)
+	setStrPtr(&body.Body, req.Body)
+	params := &genclient.SendMailParams{XGCRequest: "true"}
+	resp, err := c.cw.SendMailWithResponse(context.Background(), c.cityName, params, body)
+	if err != nil {
+		return mail.Message{}, &connError{err: fmt.Errorf("request failed: %w", err)}
+	}
+	if resp == nil {
+		return mail.Message{}, &connError{err: fmt.Errorf("nil response")}
+	}
+	if err := apiErrorFromResponse(resp.StatusCode(), pdOf(resp)); err != nil {
+		return mail.Message{}, err
+	}
+	if resp.JSON201 == nil {
+		return mail.Message{}, fmt.Errorf("API returned %d with no body", resp.StatusCode())
+	}
+	return mailMessageFromGen(*resp.JSON201), nil
+}
+
+// MailReplyRequest carries the parameters of a mail reply for Client.ReplyMail.
+type MailReplyRequest struct {
+	Rig     string // optional rig hint for locating the original message
+	From    string // sender identity stored verbatim by the server (empty = server default)
+	Subject string // optional; the server derives "Re: …" when empty
+	Body    string
+}
+
+// ReplyMail replies to message id via POST /v0/city/{cityName}/mail/{id}/reply.
+// The server addresses the reply to the original sender. It is a mutation and
+// carries the same write credential as SendMail.
+func (c *Client) ReplyMail(id string, req MailReplyRequest) (mail.Message, error) {
+	if err := c.requireCityScope(); err != nil {
+		return mail.Message{}, err
+	}
+	body := genclient.ReplyMailJSONRequestBody{}
+	setStrPtr(&body.From, req.From)
+	setStrPtr(&body.Subject, req.Subject)
+	setStrPtr(&body.Body, req.Body)
+	params := &genclient.ReplyMailParams{XGCRequest: "true"}
+	if req.Rig != "" {
+		params.Rig = &req.Rig
+	}
+	resp, err := c.cw.ReplyMailWithResponse(context.Background(), c.cityName, id, params, body)
+	if err != nil {
+		return mail.Message{}, &connError{err: fmt.Errorf("request failed: %w", err)}
+	}
+	if resp == nil {
+		return mail.Message{}, &connError{err: fmt.Errorf("nil response")}
+	}
+	if err := apiErrorFromResponse(resp.StatusCode(), pdOf(resp)); err != nil {
+		return mail.Message{}, err
+	}
+	if resp.JSON201 == nil {
+		return mail.Message{}, fmt.Errorf("API returned %d with no body", resp.StatusCode())
+	}
+	return mailMessageFromGen(*resp.JSON201), nil
 }
 
 // CountMail fetches total/unread message counts via

--- a/internal/api/decode_mail.go
+++ b/internal/api/decode_mail.go
@@ -23,6 +23,10 @@ type MailListView struct {
 	Total         int
 	Partial       bool
 	PartialErrors []string
+	// NextCursor is the keyset cursor for the next page, or "" on the last
+	// page. Callers that need the whole mailbox (the CLI inbox) page until it
+	// is empty; the server caps each page (defaultPaginationLimit).
+	NextCursor string
 }
 
 // mailMessageFromGen translates one genclient.Message into mail.Message.
@@ -75,6 +79,9 @@ func mailListFromGen(body *genclient.MailListBody) MailListView {
 	}
 	if body.PartialErrors != nil {
 		out.PartialErrors = append([]string(nil), *body.PartialErrors...)
+	}
+	if body.NextCursor != nil {
+		out.NextCursor = *body.NextCursor
 	}
 	if body.Items == nil {
 		return out

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -233,19 +233,49 @@ func (sm *SupervisorMux) serveCityHookProxy(w http.ResponseWriter, r *http.Reque
 //   - /svc/* paths bypass CSRF/read-only entirely (workspace services apply
 //     their own publication rules).
 func (sm *SupervisorMux) Handler() http.Handler {
+	return sm.handlerWithAuth(sm.writeAuth, sm.readAuth, nil)
+}
+
+// HardenedHandler returns the handler for the OPTIONAL hardened listener
+// ([supervisor.hardened]): the same mux, host/CORS/audit chain, and read-auth
+// posture as Handler(), but with city-scoped mutations gated on the given
+// write-auth verifier regardless of whether the primary listener gates them.
+// This is what lets one supervisor serve first-party loopback callers (which
+// mint no grant) on the primary listener while a TLS-fronted remote port
+// requires a signed X-GC-City-Write grant on every mutation. A nil verifier is
+// a programming error — the caller resolves the key fail-closed first — and is
+// refused here as well so a hardened listener can never come up ungated.
+func (sm *SupervisorMux) HardenedHandler(writeAuth *citywriteauth.Verifier) http.Handler {
+	if writeAuth == nil {
+		panic("api: HardenedHandler requires a write-auth verifier")
+	}
+	return sm.handlerWithAuth(writeAuth, sm.readAuth, hardenedListenerGuard)
+}
+
+// handlerWithAuth builds the full middleware chain around the mux with the
+// given write/read verifiers (either may be nil = that gate not installed).
+// extraGuard, when non-nil, wraps AROUND the write/read gates (still inside
+// host/CORS/audit) so it runs first: a request it refuses never reaches the
+// gates and can never consume a single-use grant. The hardened listener uses
+// it to refuse the surfaces its per-request grant model cannot cover (see
+// hardenedListenerGuard).
+func (sm *SupervisorMux) handlerWithAuth(writeAuth, readAuth *citywriteauth.Verifier, extraGuard func(http.Handler) http.Handler) http.Handler {
 	var root http.Handler = http.HandlerFunc(sm.ServeHTTP)
 	// When a verifying key is configured, gate city-scoped mutations on a
 	// signed grant. Wrapping root (innermost, after host/CORS checks) gives the
 	// middleware the request body to bind the grant to, just before dispatch.
-	if sm.writeAuth != nil {
-		root = writeAuthMiddleware(sm.writeAuth, sm.readOnly, root)
+	if writeAuth != nil {
+		root = writeAuthMiddleware(writeAuth, sm.readOnly, root)
 	}
 	// When a verifying key is configured, gate city-scoped reads on a signed
 	// grant. Disjoint from the write gate by method (GET/HEAD vs mutations), so
 	// the relative wrap order is correctness-irrelevant; both stay innermost
 	// (after host/CORS) so preflight and host rejection never need a grant.
-	if sm.readAuth != nil {
-		root = readAuthMiddleware(sm.readAuth, root)
+	if readAuth != nil {
+		root = readAuthMiddleware(readAuth, root)
+	}
+	if extraGuard != nil {
+		root = extraGuard(root)
 	}
 	audit := requestAuditConfig{
 		recorder:       sm.supervisorEventRecorder(),

--- a/internal/api/writeauth.go
+++ b/internal/api/writeauth.go
@@ -370,6 +370,30 @@ func ResolveWriteAuthVerifier(configKey string, configRequired bool) (*citywrite
 		}
 		return nil, nil // not enabled
 	}
+	return newWriteAuthVerifier(raw)
+}
+
+// ResolveHardenedWriteAuthVerifier resolves the verifier for the OPTIONAL
+// [supervisor.hardened] listener from its config key ONLY. It is always
+// required: an enabled hardened listener without a key is a fail-closed boot
+// error, and there is deliberately no unverified-acknowledgement knob — the
+// listener's whole purpose is to require grants. GC_CITY_WRITE_PUBKEY is NOT
+// consulted here: that env override belongs to the primary listener's gate,
+// and letting it silently satisfy (or replace) the hardened key would make the
+// two planes' trust anchors indistinguishable. The epoch floor and cid env
+// controls are shared with the primary verifier (one revocation plane).
+func ResolveHardenedWriteAuthVerifier(configKey string) (*citywriteauth.Verifier, error) {
+	raw := strings.TrimSpace(configKey)
+	if raw == "" {
+		return nil, errors.New("hardened listener enabled but no write_auth_verify_key configured")
+	}
+	return newWriteAuthVerifier(raw)
+}
+
+// newWriteAuthVerifier builds a write-auth verifier from a non-empty
+// "kid:base64pub[,…]" key list plus the shared ops-plane env controls
+// (GC_CITY_WRITE_EPOCH_FLOOR, GC_CITY_WRITE_CID).
+func newWriteAuthVerifier(raw string) (*citywriteauth.Verifier, error) {
 	keys, err := parseVerifyKeys(raw)
 	if err != nil {
 		return nil, err
@@ -441,6 +465,112 @@ func InstallWriteAuth(sm *SupervisorMux, configKey string, configRequired bool, 
 	}
 	if v != nil {
 		sm.WithWriteAuth(v)
+	}
+	return nil
+}
+
+// hardenedListenerGuard is the extra front door of the OPTIONAL hardened
+// listener ([supervisor.hardened]). The write-auth gate alone is scoped to
+// city-scoped object mutations, which is right for the primary listener (its
+// other surfaces are first-party) but leaves three doors open on a listener
+// whose entire reason to exist is "remote peers may only make grant-signed
+// per-city writes":
+//   - supervisor-scope mutations — above all POST /v0/city (city registry
+//     creation, which scaffolds a city with a caller-chosen start_command and
+//     is exempt from write-auth because a not-yet-created city has no
+//     path-resident name to bind a grant to) — are refused outright (403);
+//   - the /svc/* workspace-service pass-through is refused for EVERY method: a
+//     GET can be a WebSocket upgrade that the reverse proxy then tunnels as a
+//     long-lived bidirectional stream, which no single-use, request-bound grant
+//     can gate;
+//   - any protocol upgrade (Connection: Upgrade / Upgrade:) is refused for the
+//     same reason, on every path, so a future upgrade-capable route can never
+//     slip past the per-request grant model.
+//
+// Safe reads (GET/HEAD/OPTIONS) elsewhere pass — the hardened read plane is the
+// primary's by design (see supervisor.HardenedListener). Everything that passes
+// this guard and is a mutation then meets writeAuthMiddleware.
+func hardenedListenerGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isServiceSubresourcePath(r.URL.Path) {
+			problemHardenedServiceRefused.writeTo(w)
+			return
+		}
+		if isProtocolUpgradeRequest(r) {
+			problemHardenedUpgradeRefused.writeTo(w)
+			return
+		}
+		if !isSafeReadMethod(r.Method) {
+			if _, ok := cityScopedObjectMutation(r.URL.Path); !ok {
+				problemHardenedSupervisorScopeRefused.writeTo(w)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isProtocolUpgradeRequest reports whether the request asks for a protocol
+// switch (WebSocket, h2c, …): an Upgrade header, or a Connection header that
+// lists the upgrade token. Header values are matched case-insensitively per
+// RFC 9110 §7.6.1 / §7.8.
+func isProtocolUpgradeRequest(r *http.Request) bool {
+	if strings.TrimSpace(r.Header.Get("Upgrade")) != "" {
+		return true
+	}
+	for _, v := range r.Header.Values("Connection") {
+		for _, tok := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var (
+	problemHardenedServiceRefused = problemBody{
+		status: http.StatusForbidden,
+		body:   []byte(`{"status":403,"title":"Forbidden","detail":"workspace-service (/svc) requests are not served on the hardened listener"}`),
+	}
+	problemHardenedUpgradeRefused = problemBody{
+		status: http.StatusForbidden,
+		body:   []byte(`{"status":403,"title":"Forbidden","detail":"protocol upgrades are not served on the hardened listener"}`),
+	}
+	problemHardenedSupervisorScopeRefused = problemBody{
+		status: http.StatusForbidden,
+		body:   []byte(`{"status":403,"title":"Forbidden","detail":"only grant-signed per-city mutations (/v0/city/{city}/...) are served on the hardened listener"}`),
+	}
+)
+
+// HardenedVerifierKidsDisjoint refuses a hardened key list that shares a kid
+// with the primary listener's key list. Each verifier keeps its own in-memory
+// single-use (jti) replay guard, so a grant whose kid verifies on BOTH
+// listeners could be consumed once on each — the same request-bound mutation
+// executed twice. Disjoint kids make a hardened-listener grant unverifiable on
+// the primary (and vice versa), which closes that cross-listener replay
+// without coupling the two verifiers. Both arguments are raw "kid:b64[,…]"
+// lists; a malformed list is reported as such (the callers also parse them).
+func HardenedVerifierKidsDisjoint(primaryKey, hardenedKey string) error {
+	primary := strings.TrimSpace(primaryKey)
+	if env := strings.TrimSpace(os.Getenv("GC_CITY_WRITE_PUBKEY")); env != "" {
+		primary = env // the env override IS the primary's effective key list
+	}
+	if primary == "" {
+		return nil
+	}
+	pk, err := parseVerifyKeys(primary)
+	if err != nil {
+		return fmt.Errorf("primary write_auth_verify_key: %w", err)
+	}
+	hk, err := parseVerifyKeys(hardenedKey)
+	if err != nil {
+		return fmt.Errorf("hardened write_auth_verify_key: %w", err)
+	}
+	for kid := range hk {
+		if _, dup := pk[kid]; dup {
+			return fmt.Errorf("hardened write_auth_verify_key kid %q is also a primary write-auth kid; kids must be disjoint (each listener keeps its own single-use replay guard, so a shared kid would let one grant execute once per listener)", kid)
+		}
 	}
 	return nil
 }

--- a/internal/api/writeauth_test.go
+++ b/internal/api/writeauth_test.go
@@ -1056,3 +1056,197 @@ func TestResolveWriteAuthVerifier_WarnsOnKeyWithoutCID(t *testing.T) {
 		}
 	})
 }
+
+// A hardened listener serves the SAME mux as the primary listener but with its
+// own write-auth verifier: a first-party mutation carrying only the CSRF header
+// passes the primary handler (gate off there) yet is refused with 401 by the
+// hardened handler, and a valid request-bound grant is admitted on the hardened
+// handler. This is the [supervisor.hardened] contract — one supervisor that is
+// both the trusted loopback control plane and a grant-gated remote city.
+func TestSupervisorMux_HardenedHandlerGatesOnlyItsOwnListener(t *testing.T) {
+	now := time.Now()
+	pub, priv := mustKeypair(t)
+	v := newTestWriteVerifier(t, pub, now)
+	sm := NewSupervisorMux(nil, nil, false, "test", "", now).WithAnyHostAllowed()
+	if sm.writeAuth != nil {
+		t.Fatal("primary write-auth must stay off in this scenario")
+	}
+	primary := httptest.NewServer(sm.Handler())
+	defer primary.Close()
+	hardened := httptest.NewServer(sm.HardenedHandler(v))
+	defer hardened.Close()
+
+	post := func(base string, grant string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, base+"/v0/city/acme/mail", strings.NewReader(`{}`))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("X-GC-Request", "true")
+		if grant != "" {
+			req.Header.Set(writeAuthHeader, grant)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do: %v", err)
+		}
+		return resp
+	}
+	isWriteAuthReject := func(resp *http.Response) bool {
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			return false
+		}
+		body, _ := io.ReadAll(resp.Body)
+		return strings.Contains(string(body), writeAuthHeader)
+	}
+
+	// Primary: first-party mutation is not turned away by write-auth.
+	if isWriteAuthReject(post(primary.URL, "")) {
+		t.Fatal("primary listener gated a first-party mutation although its write-auth is off")
+	}
+	// Hardened: the same request without a grant is refused.
+	if !isWriteAuthReject(post(hardened.URL, "")) {
+		t.Fatal("hardened listener admitted a grant-less mutation")
+	}
+	// Hardened: a valid, request-bound grant is admitted (the backend-less mux
+	// then answers whatever it answers — but never the write-auth rejection).
+	tok := mintToken(t, priv, grantFor(now, "acme", http.MethodPost, "/v0/city/acme/mail", []byte(`{}`), "jti-hardened-1"))
+	if isWriteAuthReject(post(hardened.URL, tok)) {
+		t.Fatal("hardened listener refused a valid grant")
+	}
+	// Reads stay ungated on the hardened listener (its read plane is the primary's).
+	resp, err := http.Get(hardened.URL + "/v0/city/acme/mail")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if isWriteAuthReject(resp) {
+		t.Fatal("hardened listener applied write-auth to a read")
+	}
+}
+
+// HardenedHandler can never come up ungated: a nil verifier is refused.
+func TestSupervisorMux_HardenedHandlerRefusesNilVerifier(t *testing.T) {
+	sm := NewSupervisorMux(nil, nil, false, "test", "", time.Now()).WithAnyHostAllowed()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("HardenedHandler(nil) must panic")
+		}
+	}()
+	_ = sm.HardenedHandler(nil)
+}
+
+// The hardened verifier resolves from ITS config key only: an empty key is a
+// fail-closed error even when GC_CITY_WRITE_PUBKEY (the primary's env override)
+// is set, and a malformed key errors.
+func TestResolveHardenedWriteAuthVerifier(t *testing.T) {
+	pub, _ := mustKeypair(t)
+	b64 := base64.StdEncoding.EncodeToString(pub)
+	t.Setenv("GC_CITY_WRITE_PUBKEY", "k1:"+b64)
+	if v, err := ResolveHardenedWriteAuthVerifier(""); err == nil || v != nil {
+		t.Fatalf("empty hardened key must fail closed regardless of GC_CITY_WRITE_PUBKEY, got v=%v err=%v", v, err)
+	}
+	if _, err := ResolveHardenedWriteAuthVerifier("k1:not-base64!!"); err == nil {
+		t.Fatal("malformed hardened key must error")
+	}
+	v, err := ResolveHardenedWriteAuthVerifier("citadel:" + b64)
+	if err != nil || v == nil {
+		t.Fatalf("valid hardened key: v=%v err=%v", v, err)
+	}
+}
+
+// The hardened listener's front door: supervisor-scope mutations (above all
+// POST /v0/city — city creation with a caller-chosen start_command, exempt from
+// write-auth by design), the /svc pass-through (any method: a GET can be a
+// WebSocket upgrade the proxy then tunnels), and protocol upgrades on any path
+// are refused with 403; safe reads and grant-signed per-city mutations pass to
+// the gates behind it. The primary handler is untouched by the guard.
+func TestSupervisorMux_HardenedHandlerRefusesUngatableSurfaces(t *testing.T) {
+	now := time.Now()
+	pub, priv := mustKeypair(t)
+	v := newTestWriteVerifier(t, pub, now)
+	sm := NewSupervisorMux(nil, nil, false, "test", "", now).WithAnyHostAllowed()
+	primary := httptest.NewServer(sm.Handler())
+	defer primary.Close()
+	hardened := httptest.NewServer(sm.HardenedHandler(v))
+	defer hardened.Close()
+
+	do := func(base, method, path string, hdr map[string]string) (int, string) {
+		t.Helper()
+		req, err := http.NewRequest(method, base+path, strings.NewReader(`{}`))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("X-GC-Request", "true")
+		for k, val := range hdr {
+			req.Header.Set(k, val)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(body)
+	}
+	refused := func(code int, body, marker string) bool {
+		return code == http.StatusForbidden && strings.Contains(body, marker)
+	}
+
+	// 1. Supervisor-scope mutation: city registry creation is refused on the
+	//    hardened listener even with the CSRF header, and NOT by this guard on
+	//    the primary.
+	if code, body := do(hardened.URL, http.MethodPost, "/v0/city", nil); !refused(code, body, "hardened listener") {
+		t.Fatalf("hardened POST /v0/city: %d %s (want 403 hardened refusal)", code, body)
+	}
+	if code, body := do(primary.URL, http.MethodPost, "/v0/city", nil); refused(code, body, "hardened listener") {
+		t.Fatalf("primary POST /v0/city was refused by the hardened guard: %d %s", code, body)
+	}
+	// Other non-city mutation surfaces on the same listener are refused too.
+	if code, body := do(hardened.URL, http.MethodPost, "/api/client-errors", nil); !refused(code, body, "hardened listener") {
+		t.Fatalf("hardened POST /api/client-errors: %d %s", code, body)
+	}
+	// 2. /svc pass-through: every method, GET included.
+	for _, m := range []string{http.MethodGet, http.MethodPost, "MKCOL"} {
+		if code, body := do(hardened.URL, m, "/v0/city/acme/svc/app/x", nil); !refused(code, body, "/svc") {
+			t.Fatalf("hardened %s /svc: %d %s", m, code, body)
+		}
+	}
+	// 3. Protocol upgrades on any path, either header spelling.
+	if code, body := do(hardened.URL, http.MethodGet, "/v0/city/acme/mail", map[string]string{"Connection": "keep-alive, Upgrade", "Upgrade": "websocket"}); !refused(code, body, "upgrade") {
+		t.Fatalf("hardened websocket upgrade: %d %s", code, body)
+	}
+	if code, body := do(hardened.URL, http.MethodGet, "/v0/city/acme/mail", map[string]string{"Connection": "UPGRADE"}); !refused(code, body, "upgrade") {
+		t.Fatalf("hardened Connection: UPGRADE (case-insensitive): %d %s", code, body)
+	}
+	// 4. Safe reads and grant-signed per-city mutations pass the guard.
+	if code, body := do(hardened.URL, http.MethodGet, "/v0/city/acme/mail", map[string]string{"Connection": "keep-alive"}); code == http.StatusForbidden {
+		t.Fatalf("hardened plain GET refused: %d %s", code, body)
+	}
+	tok := mintToken(t, priv, grantFor(now, "acme", http.MethodPost, "/v0/city/acme/mail", []byte(`{}`), "jti-guard-1"))
+	if code, body := do(hardened.URL, http.MethodPost, "/v0/city/acme/mail", map[string]string{writeAuthHeader: tok}); code == http.StatusForbidden || (code == http.StatusUnauthorized && strings.Contains(body, writeAuthHeader)) {
+		t.Fatalf("hardened grant-signed per-city mutation refused: %d %s", code, body)
+	}
+}
+
+// Kids must be disjoint between the primary and hardened key lists (each
+// verifier has its own single-use replay guard); the primary's
+// GC_CITY_WRITE_PUBKEY env override counts as its effective list.
+func TestHardenedVerifierKidsDisjoint(t *testing.T) {
+	pub, _ := mustKeypair(t)
+	b64 := base64.StdEncoding.EncodeToString(pub)
+	t.Setenv("GC_CITY_WRITE_PUBKEY", "")
+	if err := HardenedVerifierKidsDisjoint("", "peer:"+b64); err != nil {
+		t.Fatalf("no primary key: %v", err)
+	}
+	if err := HardenedVerifierKidsDisjoint("k1:"+b64, "peer:"+b64+",k2:"+b64); err != nil {
+		t.Fatalf("disjoint kids: %v", err)
+	}
+	if err := HardenedVerifierKidsDisjoint("k1:"+b64+",peer:"+b64, "peer:"+b64); err == nil {
+		t.Fatal("overlapping kid must be refused")
+	}
+	t.Setenv("GC_CITY_WRITE_PUBKEY", "peer:"+b64)
+	if err := HardenedVerifierKidsDisjoint("", "peer:"+b64); err == nil {
+		t.Fatal("overlap via the primary's env override must be refused")
+	}
+}

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -57,6 +57,40 @@ type Section struct {
 	// open. See config.APIConfig for the key format and full semantics.
 	ReadAuthVerifyKey string `toml:"read_auth_verify_key,omitempty"`
 	ReadAuthRequired  bool   `toml:"read_auth_required,omitempty"`
+	// Hardened is an OPTIONAL second listener ([supervisor.hardened]) that
+	// serves the same mux as the primary listener but with a write-auth verify
+	// key of its own, so every per-city mutation arriving on it must carry a
+	// signed X-GC-City-Write grant while the primary (loopback) listener keeps
+	// serving first-party callers — the dashboard SPA, workspace-service
+	// adapters, the local gc client — that mint no grant. It exists for the
+	// deployment where one supervisor must be BOTH the trusted local control
+	// plane and a grant-gated remote city (front the hardened port with a TLS /
+	// private-network edge; gc has no TLS of its own). See HardenedListener.
+	Hardened HardenedListener `toml:"hardened,omitempty"`
+}
+
+// HardenedListener holds the [supervisor.hardened] table: an additional
+// grant-gated listener. Enabled when Port > 0. WriteAuthVerifyKey is REQUIRED
+// when enabled — there is no unverified acknowledgement knob for this listener
+// because its whole purpose is to require grants; a hardened port without a key
+// is a boot error (fail closed). The read plane on it is exactly the primary
+// listener's (city-scoped read-auth applies to both when configured).
+type HardenedListener struct {
+	Bind               string `toml:"bind,omitempty"`
+	Port               int    `toml:"port,omitempty"`
+	WriteAuthVerifyKey string `toml:"write_auth_verify_key,omitempty"`
+}
+
+// Enabled reports whether the hardened listener is configured (Port > 0).
+func (h HardenedListener) Enabled() bool { return h.Port > 0 }
+
+// BindOrDefault returns the hardened bind address, defaulting to "127.0.0.1"
+// (the intended posture: reachable only through the TLS front on this host).
+func (h HardenedListener) BindOrDefault() string {
+	if h.Bind == "" {
+		return "127.0.0.1"
+	}
+	return h.Bind
 }
 
 // PublicationConfig holds machine-wide publication policy for workspace

--- a/internal/supervisor/config_test.go
+++ b/internal/supervisor/config_test.go
@@ -408,3 +408,43 @@ func TestRegistryRegisterPanicsOnHostPath(t *testing.T) {
 	}()
 	_ = reg.Register(t.TempDir(), "test-city")
 }
+
+func TestLoadConfigHardenedListener(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supervisor.toml")
+	if err := os.WriteFile(path, []byte(`
+[supervisor]
+allowed_hosts = ["city.example.ts.net"]
+
+[supervisor.hardened]
+port = 8447
+write_auth_verify_key = "peer:QAXnBkSUJFXHA/sCICfJ1auCLZn4Lq4xWT8ASnAsEWY="
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := cfg.Supervisor.Hardened
+	if !h.Enabled() || h.Port != 8447 {
+		t.Errorf("Hardened = %#v, want enabled on 8447", h)
+	}
+	if h.BindOrDefault() != "127.0.0.1" {
+		t.Errorf("Hardened.BindOrDefault() = %q, want loopback default", h.BindOrDefault())
+	}
+	if h.WriteAuthVerifyKey != "peer:QAXnBkSUJFXHA/sCICfJ1auCLZn4Lq4xWT8ASnAsEWY=" {
+		t.Errorf("Hardened.WriteAuthVerifyKey = %q", h.WriteAuthVerifyKey)
+	}
+	// Absent table => disabled.
+	if err := os.WriteFile(path, []byte("[supervisor]\nport = 8372\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Supervisor.Hardened.Enabled() {
+		t.Errorf("Hardened must be disabled when the table is absent: %#v", cfg.Supervisor.Hardened)
+	}
+}


### PR DESCRIPTION
## Summary

Two commits that together make **city ↔ city mail with a real sender identity** possible with `gc` alone (no ssh, no `--from human`), for a supervisor that must stay the trusted loopback control plane *and* accept grant-signed remote writes.

1. **`feat(cli): route gc mail send|reply|inbox to a remote city via --context`**
   `gc --context <peer> mail send|reply|inbox` were refused ("remote support is being enabled incrementally") although the control plane already exposes `POST /v0/city/{c}/mail` (with `from`), `POST /mail/{id}/reply` and the inbox GET. This routes them through the existing remote transport (`resolveWriteTarget` / `resolveReadTarget`, same pattern as `sling_remote.go`), adds `api.Client.SendMail/ReplyMail`, and defaults the sender to `<local city>/<identity>` (alias > agent > session id > human; `--from` overrides) so the far side knows which city to answer. `--all` / `--notify` are refused remotely; the target is echoed to stderr like sling / rig add; help + `docs/reference/cli.md` regenerated (mail hunks only).

2. **`feat(supervisor): [supervisor.hardened] — a second, grant-gated API listener`**
   `[supervisor] write_auth_verify_key` gates *every* per-city mutation on the single listener — including first-party callers that mint no grant (dashboard SPA, workspace-service adapters posting session messages, the local gc client). So a supervisor that is also a local control plane could not require grants on its remote path without 401-ing itself, and tailnet/VPN-exposed supervisors ran with an unauthenticated write plane. `[supervisor.hardened] {bind,port,write_auth_verify_key}` adds an optional second listener over the same mux, wrapped in `writeAuthMiddleware` with its own key **plus a front door** (`hardenedListenerGuard`) that refuses supervisor-scope mutations (notably `POST /v0/city` — city creation with a caller-chosen `start_command`, which write-auth exempts by design), every `/svc/*` request (a GET can be a WebSocket upgrade the proxy then tunnels), and any protocol upgrade. Fail-closed & all-or-nothing boot: missing key, shared kid with the primary key list (each verifier has its own single-use replay guard), hardened port = primary, read-only primary, or hardened bind failure → no listener comes up. `GC_CITY_WRITE_PUBKEY` is not consulted for the hardened key. Runbook: `[supervisor.hardened]` section + §5a cross-city mail.

## Deployment shape this enables

```
city A supervisor ── 127.0.0.1:8372 (first-party, unchanged) 
                  └─ 127.0.0.1:8447 [supervisor.hardened] verify kid "b" ◄── tailscale serve :8443 (TLS, tailnet-only) ◄── city B: gc --context a mail send mayor
```
Each city keeps its own ed25519 key; only public keys cross the wire (`gc context add … --grant-command 'gc-write-mint --kid b --key … --city a'`).

## Testing

- `go test ./internal/supervisor ./internal/api -run 'Hardened|WriteAuth|Mail'`, `go test ./cmd/gc -run 'RemoteMail|MailSendRemote|MailReplyRemote|MailInboxRemote|CmdMail_Context|TestRunSupervisor'` — all green on this branch (upstream/main + these two commits).
- Live smoke (patched binary): isolated supervisor with `[supervisor.hardened]` → primary POST not gated, hardened POST without grant → `401 missing X-GC-City-Write grant`, hardened GET 200; `gc --context … mail send` with a `gc-write-mint` grant reaches the handler; against a real supervisor via a loopback context: send → `Sent message … (as <city>/<id>)`, inbox shows the qualified sender, reply → addressed back to it.
- Independent security review (2 rounds, deep) of the listener commit: round-1 findings (grant-less `POST /v0/city` on the hardened port, `/svc` websocket bypass, cross-listener jti replay via shared kid, non-atomic bind) are all fixed and confirmed closed in round 2.

## Latent upstream gap (not fixed here — flagging)

The same reviewer noted that upstream's *documented* hardened posture (primary bind `0.0.0.0` + `write_auth_verify_key`, `docs/runbooks/remote-hardened-city.md` §3) has the identical holes the new guard closes on the hardened listener: `POST /v0/city` (city creation) is reachable with only the CSRF header, and a `/svc` GET upgrade tunnels through the write gate. `hardenedListenerGuard` could be applied to a non-loopback grant-gated primary as well; I left that out to keep this PR's contract change scoped — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
