### PR TITLE
fix(scripts): don't let an unrelated in-progress bead block a different deploy-gate push

### DIFF
--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -137,7 +137,13 @@ _pog_read_with_retry() {
 #      an unrelated in-progress bead, e.g. one correctly held open for its
 #      own merge-tracking, was blocking pushes for a completely different
 #      deploy/*-gate branch because path 2 took .[0] of the match list
-#      unconditionally).
+#      unconditionally). This single-match requirement applies to EVERY
+#      branch shape that falls through to the fallback, not only
+#      deploy/*-gate — a non-gate branch that encodes no bead id and a
+#      session holding 2+ in-progress beads now resolves to nothing and is
+#      not checked at all. Deliberate: .[0] of an unordered multi-match was
+#      never sound enforcement in either direction. Pinned by
+#      test_bead_id_general_branch_ignores_ambiguous_inprogress_beads.
 # If both resolve and disagree, the branch match wins (it's the more
 # specific signal) and a warning goes to stderr — this is a best-effort
 # cross-check, not a hard failure, since branch-naming habits can

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -128,9 +128,16 @@ _pog_read_with_retry() {
 #      wrong (and possibly closed) parent/child bead instead of the actual
 #      grandchild bead the branch is for. The literal 6-char-only pattern
 #      would misresolve to the root bead on any sub-bead's own branch.
-#   2. Falls back to this session's single in-progress assignment
+#   2. Falls back to this session's in-progress assignment
 #      (bd list --assignee="$GC_AGENT" --status=in_progress --json) when
-#      the branch name doesn't match.
+#      the branch name doesn't match. Only resolves when that query returns
+#      EXACTLY one bead — two or more in-progress beads for this session is
+#      not a positive identification of which one (if any) this push is
+#      for, so it resolves the same as finding none (ga-1qepfl mechanism 2:
+#      an unrelated in-progress bead, e.g. one correctly held open for its
+#      own merge-tracking, was blocking pushes for a completely different
+#      deploy/*-gate branch because path 2 took .[0] of the match list
+#      unconditionally).
 # If both resolve and disagree, the branch match wins (it's the more
 # specific signal) and a warning goes to stderr — this is a best-effort
 # cross-check, not a hard failure, since branch-naming habits can
@@ -154,10 +161,14 @@ _pog_read_with_retry() {
 # Confirmed via manual repro, see
 # test_fallback_cannot_detect_staleness_after_status_leaves_in_progress in
 # scripts/test-push-ownership-guard.sh. The fallback query shape matches
-# ga-fip9ps.1's own spec verbatim; widening it (e.g. dropping the status
-# filter) trades this gap for ambiguous multi-match resolution against an
-# agent's whole bead history, which is a real design decision for whoever
-# owns that tradeoff, not a mechanical fix — left for a follow-up bead.
+# ga-fip9ps.1's own spec verbatim; widening it further (e.g. dropping the
+# status filter) would trade this gap for ambiguous multi-match resolution
+# against an agent's whole bead history, which is a real design decision for
+# whoever owns that tradeoff, not a mechanical fix — left for a follow-up
+# bead. (The narrower multi-match case that --status=in_progress alone can
+# already produce — more than one bead simultaneously in_progress under the
+# same assignee — is handled: see the single-match requirement on path 2
+# above, ga-1qepfl.)
 # Prints nothing (not an error) when neither resolves — the caller treats
 # that as "nothing to check," which is what lets Layer A wire this in
 # unconditionally without blocking every push in the repo.
@@ -183,7 +194,23 @@ _pog_resolve_bead_id() {
         else
             local list_json
             if list_json="$(_pog_read_with_retry bd list --assignee="$GC_AGENT" --status=in_progress --json)"; then
-                assignee_id="$(jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true)"
+                # A single in-progress bead is a positive identity signal;
+                # two or more is not -- picking .[0] from an unordered
+                # multi-match would silently assert ownership of whichever
+                # bead the query happens to list first, which is not
+                # evidence it corresponds to THIS push (ga-1qepfl: an
+                # unrelated in-progress bead, e.g. one correctly held open
+                # for its own merge-tracking, blocked pushes for a
+                # completely different deploy/*-gate branch). Leaving
+                # assignee_id empty here is a clean, successful read that
+                # found no single answer -- the same "nothing to check"
+                # outcome as finding zero, not the read-failure ambiguity
+                # assignee_read_failed exists to catch.
+                local assignee_count
+                assignee_count="$(jq -r 'length' <<<"$list_json" 2>/dev/null || echo 0)"
+                if [[ "$assignee_count" == "1" ]]; then
+                    assignee_id="$(jq -r '.[0].id // empty' <<<"$list_json" 2>/dev/null || true)"
+                fi
             else
                 assignee_read_failed=1
             fi

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -679,6 +679,35 @@ test_bead_id_deploy_gate_branch_ignores_ambiguous_inprogress_beads() {
     rm -rf "$repo" "$fbd"
 }
 
+# Companion to the deploy-gate test above, on the GENERAL fallback path: the
+# single-match requirement lives in shared path 2, not in the deploy/*-gate
+# branch shape, so it applies to every branch whose name doesn't encode a
+# bead id (chore/…, docs/…) too. That is a deliberate relaxation — with 2+
+# concurrent in-progress beads this session's push is no longer checked
+# against ANY of them, including past an active hold:mayor. It is the right
+# tradeoff (picking .[0] of an unordered multi-match could just as easily
+# have checked a healthy bead and allowed a push whose real bead was held),
+# but it is a real behavior change and is pinned here so a future edit to
+# path 2 is a visible decision on both branch shapes. The show-json fixture
+# below is deliberately hold:mayor and must never be consulted: if
+# resolution ever falls back to guessing a candidate, this blocks and the
+# assertion catches it.
+test_bead_id_general_branch_ignores_ambiguous_inprogress_beads() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "chore/unrelated-cleanup")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    printf '[{"id":"ga-held01"},{"id":"ga-other9"}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-held01" "in_progress" "agent-x" "tmpl-x" '["hold:mayor"]'
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]] && ! grep -qi "BLOCKED" <<<"$out"; then
+        record_pass "resolve/general-branch-ignores-ambiguous-inprogress-beads (rc=0, multi-match leaves nothing to check on a non-gate branch too)"
+    else
+        record_fail "resolve/general-branch-ignores-ambiguous-inprogress-beads" "expected rc=0 and no BLOCKED text (2+ in-progress beads is not a positive id of this push's bead on any branch shape), got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 test_retry_recovers_bead_id_fallback_from_transient_failure() {
     local repo fbd out rc
     repo="$(new_repo_with_branch "chore/unrelated-cleanup")"
@@ -891,6 +920,7 @@ run_all() {
     test_bead_id_deploy_gate_branch_allows_when_no_live_assignee
     test_bead_id_deploy_gate_branch_blocks_when_assignee_lookup_fails
     test_bead_id_deploy_gate_branch_ignores_ambiguous_inprogress_beads
+    test_bead_id_general_branch_ignores_ambiguous_inprogress_beads
     test_retry_recovers_bead_id_fallback_from_transient_failure
     test_allow_when_no_bead_id_resolvable
     test_fallback_cannot_detect_staleness_after_status_leaves_in_progress

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -647,6 +647,38 @@ test_bead_id_deploy_gate_branch_blocks_when_assignee_lookup_fails() {
     rm -rf "$repo" "$fbd"
 }
 
+# Regression (ga-1qepfl mechanism 2, found by gascity/reviewer 2026-08-18,
+# verified by the mayor): the assignee fallback took .[0] of whatever
+# `bd list --status=in_progress` returned, so a session holding an UNRELATED
+# in-progress bead (e.g. one correctly held open for its own merge-tracking)
+# had that bead's status/assignee/hold-labels checked against a completely
+# different deploy/*-gate push — and could block it, even though the
+# blocking bead was doing exactly what it was told to do (real repro: bead
+# ga-3fw26n, legitimately held for its own merge-tracking, blocked pushes for
+# an unrelated deploy-gate branch). Two or more in-progress beads for this
+# session is not a positive identification of which one (if any) this push
+# is for, so it must resolve the same as finding none: nothing to check,
+# allowed — not the fail-closed ambiguity path above, which is reserved for
+# a failed read, not a successful read with too many answers. `bd show` must
+# never be called on either candidate id — with no show-json configured, the
+# fake exits 1 on any show, which would surface as a BLOCKED line if
+# resolution ever fell back to guessing one of them (same technique as
+# deploy-gate-branch-allows-when-no-live-assignee above).
+test_bead_id_deploy_gate_branch_ignores_ambiguous_inprogress_beads() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "deploy/ga-bucf4p-gate")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    printf '[{"id":"ga-3fw26n"},{"id":"ga-other02"}]' > "$fbd/fake-bd-state/list-json"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]] && ! grep -qi "BLOCKED" <<<"$out"; then
+        record_pass "resolve/deploy-gate-branch-ignores-ambiguous-inprogress-beads (rc=0, two unrelated in-progress beads leave nothing to check)"
+    else
+        record_fail "resolve/deploy-gate-branch-ignores-ambiguous-inprogress-beads" "expected rc=0 and no BLOCKED text (an unrelated in-progress bead must not be checked against a different branch's push), got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 test_retry_recovers_bead_id_fallback_from_transient_failure() {
     local repo fbd out rc
     repo="$(new_repo_with_branch "chore/unrelated-cleanup")"
@@ -858,6 +890,7 @@ run_all() {
     test_bead_id_deploy_gate_branch_prefers_live_assignee
     test_bead_id_deploy_gate_branch_allows_when_no_live_assignee
     test_bead_id_deploy_gate_branch_blocks_when_assignee_lookup_fails
+    test_bead_id_deploy_gate_branch_ignores_ambiguous_inprogress_beads
     test_retry_recovers_bead_id_fallback_from_transient_failure
     test_allow_when_no_bead_id_resolvable
     test_fallback_cannot_detect_staleness_after_status_leaves_in_progress


### PR DESCRIPTION
## Summary

- push-ownership-guard's `deploy/*-gate` resolution path deliberately discards the branch-embedded bead id (it names the *gated* bead, which is routinely already closed by push time) and falls back to `bd list --assignee="$GC_AGENT" --status=in_progress --json`. It previously took `.[0]` of that result unconditionally.
- A session can legitimately hold more than one in-progress bead at once (confirmed live: this exact session had 3 simultaneous in-progress beads while working this fix). When it does, the fallback could resolve to a completely unrelated bead and block a deploy-gate push that had nothing to do with it.
- Real repro (ga-1qepfl, mechanism 2): `ga-3fw26n`, a bead correctly held `in_progress` for its own merge-tracking, blocked pushes for unrelated `deploy/*-gate` branches from the same session identity. The blocking bead wasn't misbehaving — it was doing exactly what it was told to do. There was no error on the blocking side to fix, only the false-positive match on the guard side.
- No metadata anywhere links a deploy-gate tracking bead back to the branch/gated-bead it corresponds to, so this fix takes the smallest available correct signal: only trust the assignee fallback when the query returns **exactly one** in-progress bead. Zero or 2+ matches both resolve to "nothing to check" (ALLOW) — the same outcome as no assignment at all — rather than the fail-closed ambiguity sentinel, which stays reserved for genuine read failures (`assignee_read_failed`).
- Mechanism 1 (pooled-identity mismatch, same parent bead) is a separate, already-scoped-out fix and is not touched here.

## Test plan

- [x] New regression test `test_bead_id_deploy_gate_branch_ignores_ambiguous_inprogress_beads`: `deploy/ga-bucf4p-gate` branch, two unrelated in-progress beads in the assignee fallback, no `bd show` fixture configured for either — asserts the push is allowed (rc=0, no BLOCKED text). Confirmed RED against unmodified code (reproduced the real block), then GREEN after the fix.
- [x] Full suite: `bash scripts/test-push-ownership-guard.sh` — 31/31 passing, including all three pre-existing deploy-gate tests (prefers-live-assignee, allows-when-no-live-assignee, blocks-when-assignee-lookup-fails) and every general-path test.
- [x] `shellcheck scripts/push-ownership-guard.sh` — zero findings.
- [x] Pre-push fast suite (`make test-fast-parallel`) — all green on this branch.

Refs: ga-1qepfl