### PR TITLE
feat(pack registry): refuse a doomed publish name before submitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`gc pack registry publish` now refuses an unscoped pack name unless you
+  pass `--allow-unscoped-name`.** Registry pack names are scoped as
+  `<github-owner>/<pack>`, and the registry has always reserved bare names for
+  packs it already holds a claim for — but the CLI submitted one anyway, so the
+  refusal arrived only after the request had been created and parked in the
+  review queue as an unapprovable pending row. Publish now checks the name
+  locally, before any credential or publish traffic, and names the exact
+  `[pack].name` edit that fixes it. It also refuses a scope that is not the
+  lowercased GitHub owner of the source repository, which the registry rejects
+  with no override.
+
+  Upgrading: a publisher of a grandfathered bare name must add
+  `--allow-unscoped-name` to keep publishing under it — the registry still
+  accepts a bare name it already holds a claim for, and a local preflight
+  cannot see the claim table. New packs must set
+  `[pack].name = "<github-owner>/<pack>"` in `pack.toml`. `--name` no longer
+  stands in for a missing `[pack].name`, and it can no longer rename a pack at
+  publish time: the registry byte-compares it with `[pack].name`, so it can
+  only restate the name `pack.toml` already declares.
+
 ### Fixed
 
 - **`gc import add` of a local in-git pack now locks to HEAD, not the repo's

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/credentialprovider"
 	"github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/packregistry"
 	"github.com/spf13/cobra"
 )
 
@@ -103,18 +104,19 @@ func newRegistryGasworksCredentialSource(baseURL string) (registryCredentialSour
 }
 
 type registryPublishOptions struct {
-	RegistryURL   string
-	Name          string
-	Version       string
-	Ref           string
-	Description   string
-	Token         string
-	SessionCookie string
-	CSRFToken     string
-	DryRun        bool
-	Validate      bool
-	DevAuth       bool
-	DevAuthHandle string
+	RegistryURL       string
+	Name              string
+	AllowUnscopedName bool
+	Version           string
+	Ref               string
+	Description       string
+	Token             string
+	SessionCookie     string
+	CSRFToken         string
+	DryRun            bool
+	Validate          bool
+	DevAuth           bool
+	DevAuthHandle     string
 }
 
 func newRegistryPublishCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -131,6 +133,12 @@ The command requires a clean Git checkout whose current HEAD matches its
 configured upstream branch, then submits the GitHub repository, commit, pack
 path, pack name, and version to the registry API.
 
+Registry pack names are scoped as <github-owner>/<pack>, where <github-owner>
+is the lowercased GitHub owner of the source repository. [pack].name must
+already carry that scoped name: the registry compares it byte-for-byte with the
+requested name, and reserves unscoped names for packs it already holds a claim
+for. --allow-unscoped-name submits such a legacy unscoped name anyway.
+
 --dev-auth (localhost only) replaces all other credentials. Otherwise,
 authentication precedence is --token, GC_REGISTRY_TOKEN, a complete session
 cookie and CSRF-token pair from flags or the environment, a stored native
@@ -146,7 +154,8 @@ or use "gc pack registry login" to create a separate native Registry token.`,
 		},
 	}
 	cmd.Flags().StringVar(&opts.RegistryURL, "registry-url", "", "registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then "+defaultRegistryPublishURL)
-	cmd.Flags().StringVar(&opts.Name, "name", "", "registry pack name; defaults to [pack].name")
+	cmd.Flags().StringVar(&opts.Name, "name", "", "registry pack name; must equal [pack].name (the registry rejects a mismatch)")
+	cmd.Flags().BoolVar(&opts.AllowUnscopedName, "allow-unscoped-name", false, "submit an unscoped (bare) pack name; the registry accepts these only for names it already holds a claim for")
 	cmd.Flags().StringVar(&opts.Version, "version", "", "release version; defaults to [pack].version")
 	cmd.Flags().StringVar(&opts.Ref, "ref", "", "release ref label; defaults to the upstream branch name")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "release description; defaults to [pack].description")
@@ -201,6 +210,13 @@ func doRegistryPublish(ctx context.Context, packRoot string, opts registryPublis
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack registry publish: %v\n", err) //nolint:errcheck
 		return 1
+	}
+
+	// Warn before the dry-run early return: a dry run is exactly where a
+	// publisher checks what --allow-unscoped-name is about to do, and the flag
+	// only holds if the registry already holds a claim for the bare name.
+	if opts.AllowUnscopedName && !strings.Contains(request.RequestedName, "/") {
+		fmt.Fprintf(stderr, "gc pack registry publish: warning: submitting unscoped name %q; the registry accepts it only when it already holds a claim for that name\n", request.RequestedName) //nolint:errcheck
 	}
 
 	if opts.DryRun {
@@ -345,7 +361,10 @@ func buildRegistryPublishRequest(ctx context.Context, packRoot string, opts regi
 	}
 	name := strings.TrimSpace(registryFirstNonEmpty(opts.Name, manifest.Pack.Name))
 	if name == "" {
-		return registryPublishRequest{}, errors.New("pack name is required; set [pack].name or pass --name")
+		return registryPublishRequest{}, errors.New("pack name is required; set [pack].name in pack.toml")
+	}
+	if err := validateRegistryPublishName(name, manifest.Pack.Name, repoRef.RepoURL, opts.AllowUnscopedName); err != nil {
+		return registryPublishRequest{}, err
 	}
 	ref := repoRef.Ref
 	description := strings.TrimSpace(registryFirstNonEmpty(opts.Description, manifest.Pack.Description))
@@ -358,6 +377,73 @@ func buildRegistryPublishRequest(ctx context.Context, packRoot string, opts regi
 		RequestedRef:         ref,
 		RequestedDescription: description,
 	}, nil
+}
+
+// validateRegistryPublishName refuses locally what the registry refuses
+// remotely, so a doomed publish never burns a request slot or parks a dead row
+// in the review queue. It is the local twin of packNamePolicyViolation in the
+// registry's server/publish.ts, which enforces the same two namespace rules
+// first at validation and again at approve: unscoped names are reserved, and a
+// scoped name's scope must equal the lowercased GitHub owner of the source
+// repository. Only the reserved rule gets an escape hatch here, because the
+// registry does accept an unscoped name it already holds a claim for and a
+// local preflight cannot see the claim table; the scope rule has no
+// server-side override, so it has none here either.
+//
+// The checks are ordered so the first error a publisher sees leads to the one
+// correct fix, and each message is shaped by which half of the pair is wrong: a
+// bare --name against an already correctly scoped pack.toml prescribes fixing
+// the flag, every other mismatch prescribes the pack.toml edit. A pack.toml
+// declaring "mathcity" published as "tdupu/mathcity" reports the mismatch and
+// prescribes the pack.toml edit; dropping the scope to satisfy that message
+// instead reports the reserved name and prescribes the same edit. Both roads
+// end at [pack].name carrying the scoped name.
+func validateRegistryPublishName(name, manifestName, repoURL string, allowUnscoped bool) error {
+	if err := packregistry.ValidatePackName(name); err != nil {
+		return fmt.Errorf("%w; registry names are lowercase [a-z0-9-] segments in <github-owner>/<pack> form", err)
+	}
+	owner, err := registryGitHubRepoOwner(repoURL)
+	if err != nil {
+		return err
+	}
+	ownerLower := strings.ToLower(owner)
+	if manifestName == "" {
+		// --name can no longer stand in for a missing [pack].name: the registry
+		// rejects a nameless pack.toml outright, before it compares anything, so
+		// accepting the flag here would only build a request doomed on arrival.
+		// The suggestion is always rescoped to the repository owner rather than
+		// echoing --name back, because a foreign scope repeated verbatim names a
+		// pack.toml edit the very next run's scope check refuses.
+		bare := name
+		if _, rest, scoped := strings.Cut(name, "/"); scoped {
+			bare = rest
+		}
+		return fmt.Errorf("pack.toml does not declare [pack].name; the registry rejects such publishes, so set [pack].name = %q and push before publishing", ownerLower+"/"+bare)
+	}
+	if name != manifestName {
+		// A bare --name against an already correctly scoped pack.toml means the
+		// flag is the stale half, typically a CI workflow still passing the
+		// pre-scope name. Prescribing the pack.toml edit there would tell the
+		// publisher to drop the scope, and the next run would refuse the result as
+		// a reserved unscoped name.
+		manifestScope, _, manifestScoped := strings.Cut(manifestName, "/")
+		manifestIsPublishable := manifestScoped && manifestScope == ownerLower && packregistry.ValidatePackName(manifestName) == nil
+		if !strings.Contains(name, "/") && manifestIsPublishable {
+			return fmt.Errorf("--name %q does not match pack.toml [pack].name %q; the registry compares them byte-for-byte, and pack.toml already carries the correctly scoped name, so drop --name or pass --name %q", name, manifestName, manifestName)
+		}
+		return fmt.Errorf("--name %q does not match pack.toml [pack].name %q; the registry compares them byte-for-byte, so set [pack].name = %q and push before publishing", name, manifestName, name)
+	}
+	scope, rest, scoped := strings.Cut(name, "/")
+	if !scoped {
+		if allowUnscoped {
+			return nil
+		}
+		return fmt.Errorf("unscoped pack name %q is reserved by the registry; set [pack].name = %q and push before publishing, or pass --allow-unscoped-name if the registry already holds a claim for %q", name, ownerLower+"/"+name, name)
+	}
+	if scope != ownerLower {
+		return fmt.Errorf("pack name scope %q does not match the source repository owner %q; set [pack].name = %q and push before publishing", scope, owner, ownerLower+"/"+rest)
+	}
+	return nil
 }
 
 // registryPublishRepoRef carries the GitHub repository URL and release ref
@@ -452,9 +538,9 @@ func registryGitHubActionsRepoRef(commit string, opts registryPublishOptions) (r
 }
 
 // readRegistryPackManifest loads pack.toml from packRoot. It does not require
-// [pack].name: buildRegistryPublishRequest applies the --name fallback first
-// and reports a missing name only when neither the manifest nor the flag
-// supplies one, so the advertised --name override actually takes effect.
+// [pack].name; buildRegistryPublishRequest reports that, because the registry
+// rejects a pack.toml declaring no name at all and the resulting error can then
+// name the exact [pack].name edit that fixes the publish.
 func readRegistryPackManifest(packRoot string) (registryPackManifest, error) {
 	packToml := filepath.Join(packRoot, "pack.toml")
 	data, err := os.ReadFile(packToml)
@@ -534,6 +620,21 @@ func normalizeGitHubOwnerRepo(path string) (string, error) {
 		return "", fmt.Errorf("invalid GitHub owner/repo path %q", path)
 	}
 	return "https://github.com/" + path, nil
+}
+
+// registryGitHubRepoOwner cuts the owner login out of a publish request's
+// repository URL. Every such URL passes through normalizeGitHubOwnerRepo above,
+// on the upstream-remote path and the GitHub Actions fallback path alike, so
+// the https://github.com/<owner>/<repo> shape is guaranteed here. The error
+// exists so a future change to that normalization surfaces as a refused publish
+// rather than as a silently skipped namespace check.
+func registryGitHubRepoOwner(repoURL string) (string, error) {
+	if path, ok := strings.CutPrefix(strings.TrimSpace(repoURL), "https://github.com/"); ok {
+		if owner, _, cut := strings.Cut(path, "/"); cut && owner != "" {
+			return owner, nil
+		}
+	}
+	return "", fmt.Errorf("cannot derive the GitHub owner from repository URL %q", repoURL)
 }
 
 func registryPublishPackPath(repoRoot, packRoot string) (string, error) {

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -38,7 +38,7 @@ func TestBuildRegistryPublishRequestUsesCleanPushedGitHubHead(t *testing.T) {
 	if request.PackPath != "packs/demo" {
 		t.Fatalf("PackPath = %q", request.PackPath)
 	}
-	if request.RequestedName != "demo-pack" || request.RequestedVersion != "0.2.0" {
+	if request.RequestedName != "gastownhall/demo-pack" || request.RequestedVersion != "0.2.0" {
 		t.Fatalf("pack identity = %s %s", request.RequestedName, request.RequestedVersion)
 	}
 	if request.RequestedRef != "main" {
@@ -76,11 +76,16 @@ func TestBuildRegistryPublishRequestResolvesSymlinkedPackRoot(t *testing.T) {
 	}
 }
 
+// TestBuildRegistryPublishRequestAcceptsWebFormFieldOverrides covers the
+// web-form parity flags. --name is passed here too, but it can only restate the
+// name pack.toml already declares: the registry byte-compares the two, so
+// version, ref, and description are the fields an operator can actually
+// override at publish time.
 func TestBuildRegistryPublishRequestAcceptsWebFormFieldOverrides(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
 
 	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
-		Name:        "renamed-demo-pack",
+		Name:        "gastownhall/demo-pack",
 		Version:     "1.2.3",
 		Ref:         "release/v1.2.3",
 		Description: "Operator supplied release note.",
@@ -89,7 +94,7 @@ func TestBuildRegistryPublishRequestAcceptsWebFormFieldOverrides(t *testing.T) {
 		t.Fatalf("buildRegistryPublishRequest: %v", err)
 	}
 
-	if request.RequestedName != "renamed-demo-pack" {
+	if request.RequestedName != "gastownhall/demo-pack" {
 		t.Fatalf("RequestedName = %q", request.RequestedName)
 	}
 	if request.RequestedVersion != "1.2.3" {
@@ -115,7 +120,11 @@ func TestBuildRegistryPublishRequestRejectsDirtyTree(t *testing.T) {
 	}
 }
 
-func TestBuildRegistryPublishRequestNameFlagSatisfiesMissingManifestName(t *testing.T) {
+// TestBuildRegistryPublishRequestRejectsNameFlagWithoutManifestName pins the
+// deliberate behavior change: --name no longer stands in for a missing
+// [pack].name. The registry rejects a nameless pack.toml unconditionally, so
+// building that request only produced a publish doomed on arrival.
+func TestBuildRegistryPublishRequestRejectsNameFlagWithoutManifestName(t *testing.T) {
 	const manifestWithoutName = `[pack]
 version = "0.2.0"
 schema = 2
@@ -123,14 +132,14 @@ description = "Demo pack for registry publishing."
 `
 	_, packDir := setupRegistryPublishRepoManifest(t, manifestWithoutName)
 
-	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
 		Name: "flag-supplied-name",
 	}, false)
-	if err != nil {
-		t.Fatalf("buildRegistryPublishRequest: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "pack.toml does not declare [pack].name") {
+		t.Fatalf("err = %v, want missing [pack].name error", err)
 	}
-	if request.RequestedName != "flag-supplied-name" {
-		t.Fatalf("RequestedName = %q, want flag-supplied-name", request.RequestedName)
+	if want := `set [pack].name = "gastownhall/flag-supplied-name"`; !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %v, want scoped suggestion %q", err, want)
 	}
 }
 
@@ -142,8 +151,259 @@ schema = 2
 	_, packDir := setupRegistryPublishRepoManifest(t, manifestWithoutName)
 
 	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
-	if err == nil || !strings.Contains(err.Error(), "pack name is required") {
+	if err == nil || err.Error() != "pack name is required; set [pack].name in pack.toml" {
 		t.Fatalf("err = %v, want pack name required error", err)
+	}
+}
+
+// TestValidateRegistryPublishName pins the local twin of the registry's
+// packNamePolicyViolation (server/publish.ts), including the exact remediation
+// text and the check order that walks tdupu's two failed publish attempts to
+// the same pack.toml edit.
+func TestValidateRegistryPublishName(t *testing.T) {
+	const repoURL = "https://github.com/TDupu/mathcity"
+	long := strings.Repeat("a", 65)
+
+	for _, tc := range []struct {
+		name          string
+		packName      string
+		manifestName  string
+		allowUnscoped bool
+		want          string
+	}{
+		{
+			name:         "scoped name matching the lowercased owner",
+			packName:     "tdupu/mathcity",
+			manifestName: "tdupu/mathcity",
+		},
+		{
+			name:         "unscoped name is reserved",
+			packName:     "mathcity",
+			manifestName: "mathcity",
+			want:         `unscoped pack name "mathcity" is reserved by the registry; set [pack].name = "tdupu/mathcity" and push before publishing, or pass --allow-unscoped-name if the registry already holds a claim for "mathcity"`,
+		},
+		{
+			name:          "unscoped name allowed by flag",
+			packName:      "mathcity",
+			manifestName:  "mathcity",
+			allowUnscoped: true,
+		},
+		{
+			name:         "foreign scope names the owner in its original case",
+			packName:     "microsoft/mathcity",
+			manifestName: "microsoft/mathcity",
+			want:         `pack name scope "microsoft" does not match the source repository owner "TDupu"; set [pack].name = "tdupu/mathcity" and push before publishing`,
+		},
+		{
+			name:          "foreign scope has no escape hatch",
+			packName:      "microsoft/mathcity",
+			manifestName:  "microsoft/mathcity",
+			allowUnscoped: true,
+			want:          `pack name scope "microsoft" does not match the source repository owner "TDupu"; set [pack].name = "tdupu/mathcity" and push before publishing`,
+		},
+		{
+			name:         "name flag disagreeing with pack.toml",
+			packName:     "tdupu/mathcity",
+			manifestName: "mathcity",
+			want:         `--name "tdupu/mathcity" does not match pack.toml [pack].name "mathcity"; the registry compares them byte-for-byte, so set [pack].name = "tdupu/mathcity" and push before publishing`,
+		},
+		{
+			// A stale CI workflow still passing the pre-scope --name: pack.toml
+			// is the correct half, so prescribing the pack.toml edit would say
+			// drop the scope, and the next run would refuse that as reserved.
+			name:         "bare name flag against a correctly scoped pack.toml blames the flag",
+			packName:     "mathcity",
+			manifestName: "tdupu/mathcity",
+			want:         `--name "mathcity" does not match pack.toml [pack].name "tdupu/mathcity"; the registry compares them byte-for-byte, and pack.toml already carries the correctly scoped name, so drop --name or pass --name "tdupu/mathcity"`,
+		},
+		{
+			name:         "bare name flag against a foreign-scoped pack.toml still blames pack.toml",
+			packName:     "mathcity",
+			manifestName: "microsoft/mathcity",
+			want:         `--name "mathcity" does not match pack.toml [pack].name "microsoft/mathcity"; the registry compares them byte-for-byte, so set [pack].name = "mathcity" and push before publishing`,
+		},
+		{
+			// The manifest scope matches, but the pack segment is not registry
+			// name grammar, so "pass --name <manifest name>" would be advice the
+			// next run refuses outright.
+			name:         "bare name flag against an ungrammatical pack.toml name still blames pack.toml",
+			packName:     "mathcity",
+			manifestName: "tdupu/MathCity",
+			want:         `--name "mathcity" does not match pack.toml [pack].name "tdupu/MathCity"; the registry compares them byte-for-byte, so set [pack].name = "mathcity" and push before publishing`,
+		},
+		{
+			name:         "mismatch is reported before the scope refusal",
+			packName:     "microsoft/mathcity",
+			manifestName: "tdupu/mathcity",
+			want:         `--name "microsoft/mathcity" does not match pack.toml [pack].name "tdupu/mathcity"; the registry compares them byte-for-byte, so set [pack].name = "microsoft/mathcity" and push before publishing`,
+		},
+		{
+			name:     "pack.toml declares no name",
+			packName: "tdupu/mathcity",
+			want:     `pack.toml does not declare [pack].name; the registry rejects such publishes, so set [pack].name = "tdupu/mathcity" and push before publishing`,
+		},
+		{
+			name:     "pack.toml declares no name and the flag is unscoped",
+			packName: "mathcity",
+			want:     `pack.toml does not declare [pack].name; the registry rejects such publishes, so set [pack].name = "tdupu/mathcity" and push before publishing`,
+		},
+		{
+			// The suggestion rescopes a foreign --name to the repository owner
+			// rather than echoing it back; echoing it would name a pack.toml edit
+			// the next run refuses on the scope check.
+			name:     "pack.toml declares no name and the flag carries a foreign scope",
+			packName: "microsoft/mathcity",
+			want:     `pack.toml does not declare [pack].name; the registry rejects such publishes, so set [pack].name = "tdupu/mathcity" and push before publishing`,
+		},
+		{
+			name:         "uppercase is not registry name grammar",
+			packName:     "TDupu/mathcity",
+			manifestName: "TDupu/mathcity",
+			want:         `invalid pack name "TDupu/mathcity"; registry names are lowercase [a-z0-9-] segments in <github-owner>/<pack> form`,
+		},
+		{
+			name:         "segment longer than 64 characters",
+			packName:     long + "/pack",
+			manifestName: long + "/pack",
+			want:         `invalid pack name "` + long + `/pack": segment "` + long + `" exceeds 64 characters; registry names are lowercase [a-z0-9-] segments in <github-owner>/<pack> form`,
+		},
+		{
+			name:         "more than one scope segment",
+			packName:     "a/b/c",
+			manifestName: "a/b/c",
+			want:         `invalid pack name "a/b/c"; registry names are lowercase [a-z0-9-] segments in <github-owner>/<pack> form`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRegistryPublishName(tc.packName, tc.manifestName, repoURL, tc.allowUnscoped)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("validateRegistryPublishName = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateRegistryPublishName = nil, want %q", tc.want)
+			}
+			if err.Error() != tc.want {
+				t.Fatalf("validateRegistryPublishName = %q, want %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRegistryGitHubRepoOwner(t *testing.T) {
+	for _, tc := range []struct {
+		repoURL string
+		want    string
+	}{
+		{repoURL: "https://github.com/gastownhall/demo-packs", want: "gastownhall"},
+		{repoURL: "https://github.com/TDupu/mathcity", want: "TDupu"},
+		{repoURL: "https://gitlab.com/o/r"},
+		{repoURL: "https://github.com/soloowner"},
+	} {
+		t.Run(tc.repoURL, func(t *testing.T) {
+			owner, err := registryGitHubRepoOwner(tc.repoURL)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("registryGitHubRepoOwner(%q) = %q, want error", tc.repoURL, owner)
+				}
+				if want := "cannot derive the GitHub owner from repository URL"; !strings.Contains(err.Error(), want) {
+					t.Fatalf("err = %v, want %q", err, want)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("registryGitHubRepoOwner(%q): %v", tc.repoURL, err)
+			}
+			if owner != tc.want {
+				t.Fatalf("registryGitHubRepoOwner(%q) = %q, want %q", tc.repoURL, owner, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildRegistryPublishRequestRejectsBareName is tdupu's second publish
+// attempt: pack.toml declares a bare name, so the request the registry would
+// park forever as an unapprovable pending row never gets built.
+func TestBuildRegistryPublishRequestRejectsBareName(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("mathcity"))
+
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("err = %v, want reserved-name refusal", err)
+	}
+	if want := `set [pack].name = "gastownhall/mathcity"`; !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %v, want %q", err, want)
+	}
+}
+
+// TestBuildRegistryPublishRequestRejectsNameFlagManifestMismatch is tdupu's
+// first publish attempt: the correctly scoped --name disagreed with the bare
+// name pack.toml declares. The registry byte-compares them, so this must fail
+// locally and prescribe the pack.toml edit rather than dropping the scope.
+func TestBuildRegistryPublishRequestRejectsNameFlagManifestMismatch(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("mathcity"))
+
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
+		Name: "gastownhall/mathcity",
+	}, false)
+	if err == nil {
+		t.Fatal("buildRegistryPublishRequest succeeded, want --name mismatch refusal")
+	}
+	want := `--name "gastownhall/mathcity" does not match pack.toml [pack].name "mathcity"; ` +
+		`the registry compares them byte-for-byte, so set [pack].name = "gastownhall/mathcity" and push before publishing`
+	if err.Error() != want {
+		t.Fatalf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestBuildRegistryPublishRequestRejectsScopeOwnerMismatch(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("microsoft/demo-pack"))
+
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, false)
+	if err == nil {
+		t.Fatal("buildRegistryPublishRequest succeeded, want scope refusal")
+	}
+	want := `pack name scope "microsoft" does not match the source repository owner "gastownhall"; ` +
+		`set [pack].name = "gastownhall/demo-pack" and push before publishing`
+	if err.Error() != want {
+		t.Fatalf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestBuildRegistryPublishRequestAllowsClaimedBareNameWithFlag covers the
+// grandfathered publishers: the registry still accepts a bare name it already
+// holds a claim for, and a local preflight cannot see the claim table, so
+// --allow-unscoped-name has to submit the bare name unchanged.
+func TestBuildRegistryPublishRequestAllowsClaimedBareNameWithFlag(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("cacc-twin-team"))
+
+	request, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{
+		AllowUnscopedName: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("buildRegistryPublishRequest: %v", err)
+	}
+	if request.RequestedName != "cacc-twin-team" {
+		t.Fatalf("RequestedName = %q, want the bare name submitted unchanged", request.RequestedName)
+	}
+}
+
+// TestBuildRegistryPublishRequestActionsFallbackEnforcesScope proves the
+// namespace check reads the same owner the request is built from on the GitHub
+// Actions fallback path, where the repository comes from GITHUB_REPOSITORY
+// rather than an upstream remote.
+func TestBuildRegistryPublishRequestActionsFallbackEnforcesScope(t *testing.T) {
+	packDir, headSHA := setupRegistryPublishRepoDetachedManifest(t, registryPublishManifestNamed("mathcity"))
+	setSpoofedGitHubActionsEnv(t, headSHA)
+
+	_, err := buildRegistryPublishRequest(t.Context(), packDir, registryPublishOptions{}, true)
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("err = %v, want reserved-name refusal on the Actions fallback path", err)
+	}
+	if want := `set [pack].name = "gastownhall/mathcity"`; !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %v, want the GITHUB_REPOSITORY-derived suggestion %q", err, want)
 	}
 }
 
@@ -218,7 +478,7 @@ func TestSubmitRegistryPublishRequestSendsAuthenticatedPayload(t *testing.T) {
 			"publishRequest": {
 				"id": "prq_test",
 				"status": "pending_review",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0",
 				"repository": {"fullName": "gastownhall/demo-packs"},
 				"registryEntry": {"release": {"hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
@@ -235,7 +495,7 @@ func TestSubmitRegistryPublishRequestSendsAuthenticatedPayload(t *testing.T) {
 			RepoURL:          "https://github.com/gastownhall/demo-packs",
 			Commit:           strings.Repeat("1", 40),
 			PackPath:         "packs/demo",
-			RequestedName:    "demo-pack",
+			RequestedName:    "gastownhall/demo-pack",
 			RequestedVersion: "0.2.0",
 			RequestedRef:     "main",
 		},
@@ -245,7 +505,7 @@ func TestSubmitRegistryPublishRequestSendsAuthenticatedPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("submitRegistryPublishRequest: %v", err)
 	}
-	if got.RequestedName != "demo-pack" || got.RequestedVersion != "0.2.0" {
+	if got.RequestedName != "gastownhall/demo-pack" || got.RequestedVersion != "0.2.0" {
 		t.Fatalf("submitted body = %+v", got)
 	}
 	if submitted.ID != "prq_test" || submitted.Status != "pending_review" {
@@ -272,7 +532,7 @@ func TestSubmitRegistryPublishRequestSendsBearerToken(t *testing.T) {
 			"publishRequest": {
 				"id": "prq_token",
 				"status": "pending_review",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0",
 				"repository": {"fullName": "gastownhall/demo-packs"}
 			}
@@ -288,7 +548,7 @@ func TestSubmitRegistryPublishRequestSendsBearerToken(t *testing.T) {
 			RepoURL:          "https://github.com/gastownhall/demo-packs",
 			Commit:           strings.Repeat("1", 40),
 			PackPath:         "packs/demo",
-			RequestedName:    "demo-pack",
+			RequestedName:    "gastownhall/demo-pack",
 			RequestedVersion: "0.2.0",
 		},
 		registryPublishAuth{Token: "gcr_test_token"},
@@ -366,7 +626,7 @@ func TestDoRegistryPublishUsesStoredLoginToken(t *testing.T) {
 			"publishRequest": {
 				"id": "prq_stored",
 				"status": "pending_review",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0",
 				"repository": {"fullName": "gastownhall/demo-packs"}
 			}
@@ -429,7 +689,7 @@ func TestDoRegistryPublishUsesGasworksProviderWithoutPersistingEIA(t *testing.T)
 			"publishRequest": {
 				"id": "prq_provider",
 				"status": "pending_review",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0",
 				"repository": {"fullName": "gastownhall/demo-packs"}
 			}
@@ -592,7 +852,7 @@ func TestDoRegistryPublishProviderRefreshesOnceAfter401(t *testing.T) {
 				"publishRequest": {
 					"id": "prq_refreshed",
 					"status": "pending_review",
-					"requestedName": "demo-pack",
+					"requestedName": "gastownhall/demo-pack",
 					"requestedVersion": "0.2.0"
 				}
 			}`)),
@@ -916,7 +1176,7 @@ func TestDoRegistryPublishValidateFailsOnValidationError(t *testing.T) {
 			"publishRequest": {
 				"id": "prq_invalid",
 				"status": "rejected",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0",
 				"validationError": "pack.toml is missing a description"
 			}
@@ -960,7 +1220,7 @@ func TestDoRegistryPublishValidateFailsOnRejectedStatus(t *testing.T) {
 				"id": "prq_denied",
 				"status": "invalid",
 				"statusReason": "name already published at a higher version",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0"
 			}
 		}`))
@@ -1007,7 +1267,7 @@ func TestDoRegistryPublishStoredTokenSurvivesPartialCookieEnv(t *testing.T) {
 			"publishRequest": {
 				"id": "prq_partial",
 				"status": "pending_review",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0"
 			}
 		}`))
@@ -1070,7 +1330,7 @@ func TestDoRegistryPublishUsesGitHubActionsOIDC(t *testing.T) {
 			if payload.GitHubOIDCToken != "github-oidc-jwt" {
 				t.Fatalf("githubOidcToken = %q", payload.GitHubOIDCToken)
 			}
-			if payload.RequestedName != "demo-pack" || payload.RequestedVersion != "0.2.0" {
+			if payload.RequestedName != "gastownhall/demo-pack" || payload.RequestedVersion != "0.2.0" {
 				t.Fatalf("mint payload = %+v", payload.registryPublishRequest)
 			}
 			sawMint = true
@@ -1088,7 +1348,7 @@ func TestDoRegistryPublishUsesGitHubActionsOIDC(t *testing.T) {
 				"publishRequest": {
 					"id": "prq_actions",
 					"status": "pending_review",
-					"requestedName": "demo-pack",
+					"requestedName": "gastownhall/demo-pack",
 					"requestedVersion": "0.2.0",
 					"repository": {"fullName": "gastownhall/demo-packs"}
 				}
@@ -1166,7 +1426,7 @@ func TestDoRegistryPublishUsesGitHubActionsOIDCWithoutUpstream(t *testing.T) {
 				"publishRequest": {
 					"id": "prq_actions_detached",
 					"status": "pending_review",
-					"requestedName": "demo-pack",
+					"requestedName": "gastownhall/demo-pack",
 					"requestedVersion": "0.2.0",
 					"repository": {"fullName": "gastownhall/demo-packs"}
 				}
@@ -1456,12 +1716,127 @@ func TestDoRegistryPublishDryRunPrintsRequest(t *testing.T) {
 		"Registry: http://127.0.0.1:8080",
 		"Repository: https://github.com/gastownhall/demo-packs",
 		"Pack path: packs/demo",
-		"Pack: demo-pack 0.2.0",
+		"Pack: gastownhall/demo-pack 0.2.0",
 		"Dry run: publish request was not submitted.",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+// TestDoRegistryPublishBareNameFailsBeforeNetwork proves the namespace
+// preflight runs before any credential or publish traffic. The Actions OIDC
+// environment is present, so without the preflight this publish would mint a
+// token and submit; the failing HTTP client turns either into a test failure.
+func TestDoRegistryPublishBareNameFailsBeforeNetwork(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("mathcity"))
+	clearRegistryEnv(t)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-request-token")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://example.test/oidc")
+	failingRegistryHTTPClient(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: "https://registry.example.com",
+		Validate:    true,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want failure; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "reserved") {
+		t.Fatalf("stderr = %q, want reserved-name refusal", stderr.String())
+	}
+}
+
+func TestDoRegistryPublishAllowUnscopedNameWarnsAndSubmits(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("cacc-twin-team"))
+	clearRegistryEnv(t)
+	oldClient := registryPublishHTTPClient
+	defer func() { registryPublishHTTPClient = oldClient }()
+
+	var got registryPublishRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"publishRequest": {
+				"id": "prq_grandfathered",
+				"status": "pending_review",
+				"requestedName": "cacc-twin-team",
+				"requestedVersion": "0.2.0"
+			}
+		}`))
+	}))
+	defer server.Close()
+	registryPublishHTTPClient = server.Client()
+	if err := writeRegistryConfiguredToken(server.URL, "gcr_stored_token"); err != nil {
+		t.Fatalf("writeRegistryConfiguredToken: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL:       server.URL,
+		AllowUnscopedName: true,
+		Validate:          true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	if got.RequestedName != "cacc-twin-team" {
+		t.Fatalf("submitted requestedName = %q, want the bare name", got.RequestedName)
+	}
+	want := `gc pack registry publish: warning: submitting unscoped name "cacc-twin-team"; ` +
+		"the registry accepts it only when it already holds a claim for that name"
+	if !strings.Contains(stderr.String(), want) {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+}
+
+func TestDoRegistryPublishDryRunFailsOnReservedName(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("mathcity"))
+	clearRegistryEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL: "http://127.0.0.1:8080",
+		DryRun:      true,
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRegistryPublish = 0, want failure; stdout=%q", stdout.String())
+	}
+	if want := `set [pack].name = "gastownhall/mathcity"`; !strings.Contains(stderr.String(), want) {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+	if strings.Contains(stdout.String(), "Dry run:") {
+		t.Fatalf("stdout printed a dry-run block for a refused name:\n%s", stdout.String())
+	}
+}
+
+// TestDoRegistryPublishDryRunWarnsOnAllowedUnscopedName pins the warning ahead
+// of the --dry-run early return. A dry run is where a publisher inspects what
+// --allow-unscoped-name is about to submit, so it must carry the same caveat a
+// real submit does.
+func TestDoRegistryPublishDryRunWarnsOnAllowedUnscopedName(t *testing.T) {
+	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("cacc-twin-team"))
+	clearRegistryEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
+		RegistryURL:       "http://127.0.0.1:8080",
+		AllowUnscopedName: true,
+		DryRun:            true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Pack: cacc-twin-team 0.2.0") {
+		t.Fatalf("stdout = %q, want the dry-run block", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `warning: submitting unscoped name "cacc-twin-team"`) {
+		t.Fatalf("stderr = %q, want the unscoped-name warning on a dry run", stderr.String())
 	}
 }
 
@@ -1575,7 +1950,7 @@ func TestDoRegistryPublishUsesEnvironmentToken(t *testing.T) {
 			"publishRequest": {
 				"id": "prq_env",
 				"status": "pending_review",
-				"requestedName": "demo-pack",
+				"requestedName": "gastownhall/demo-pack",
 				"requestedVersion": "0.2.0",
 				"repository": {"fullName": "gastownhall/demo-packs"}
 			}
@@ -1817,7 +2192,7 @@ func TestSubmitRegistryPublishRequestReportsHTTPStatusForNonJSON(t *testing.T) {
 			RepoURL:          "https://github.com/gastownhall/demo-packs",
 			Commit:           strings.Repeat("1", 40),
 			PackPath:         ".",
-			RequestedName:    "demo-pack",
+			RequestedName:    "gastownhall/demo-pack",
 			RequestedVersion: "0.2.0",
 		},
 		registryPublishAuth{Token: "tok"},
@@ -2419,12 +2794,21 @@ func clearRegistryEnv(t *testing.T, overrides ...registryTestEnv) {
 	}
 }
 
-const registryPublishDemoManifest = `[pack]
-name = "demo-pack"
+// registryPublishManifestNamed renders the demo pack.toml with a caller-chosen
+// [pack].name, so a test can exercise a name the publish preflight refuses.
+func registryPublishManifestNamed(name string) string {
+	return `[pack]
+name = "` + name + `"
 version = "0.2.0"
 schema = 2
 description = "Demo pack for registry publishing."
 `
+}
+
+// registryPublishDemoManifest is the shared publish fixture. Its name is scoped
+// to the fixture repository's GitHub owner, because that is the only name shape
+// the registry accepts for a pack it does not already hold a claim for.
+var registryPublishDemoManifest = registryPublishManifestNamed("gastownhall/demo-pack")
 
 func setupRegistryPublishRepo(t *testing.T) (repo string, packDir string) {
 	t.Helper()
@@ -2452,25 +2836,25 @@ func setupRegistryPublishRepoManifest(t *testing.T, manifest string) (repo strin
 // runner metadata instead of an upstream tracking branch.
 func setupRegistryPublishRepoDetached(t *testing.T) (packDir string, headSHA string) {
 	t.Helper()
+	return setupRegistryPublishRepoDetachedManifest(t, registryPublishDemoManifest)
+}
+
+// setupRegistryPublishRepoDetachedManifest is setupRegistryPublishRepoDetached
+// with a caller-supplied pack.toml body, so a test can exercise the GitHub
+// Actions fallback path against a pack name the fallback-derived owner rejects.
+func setupRegistryPublishRepoDetachedManifest(t *testing.T, manifest string) (packDir string, headSHA string) {
+	t.Helper()
 	var repo string
-	repo, packDir = writeRegistryPublishPackRepo(t)
+	repo, packDir = writeRegistryPublishPackRepoManifest(t, manifest)
 	headSHA = runRegistryPublishGit(t, repo, "rev-parse", "HEAD")
 	runRegistryPublishGit(t, repo, "checkout", "--detach", "HEAD")
 	return packDir, headSHA
 }
 
-// writeRegistryPublishPackRepo initializes a Git repo containing a single demo
-// pack and commits it, returning the repo root and the pack directory. It does
-// not configure a remote or upstream; callers add whatever publish topology
-// they need.
-func writeRegistryPublishPackRepo(t *testing.T) (repo string, packDir string) {
-	t.Helper()
-	return writeRegistryPublishPackRepoManifest(t, registryPublishDemoManifest)
-}
-
 // writeRegistryPublishPackRepoManifest initializes a Git repo containing a
 // single demo pack whose pack.toml holds the given body, commits it, and
-// returns the repo root and the pack directory.
+// returns the repo root and the pack directory. It does not configure a remote
+// or upstream; callers add whatever publish topology they need.
 func writeRegistryPublishPackRepoManifest(t *testing.T, manifest string) (repo string, packDir string) {
 	t.Helper()
 	root := t.TempDir()
@@ -2509,7 +2893,7 @@ func TestWriteRegistryPublishSubmittedPinsRegistryURL(t *testing.T) {
 	writeRegistryPublishSubmitted(&buf, "https://registry.example.com", registryPublishSubmitted{
 		ID:               "prq_x",
 		Status:           "pending_review",
-		RequestedName:    "demo-pack",
+		RequestedName:    "gastownhall/demo-pack",
 		RequestedVersion: "1.2.0",
 	})
 	want := "Next: gc pack registry requests --registry-url https://registry.example.com prq_x"

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -1749,44 +1749,27 @@ func TestDoRegistryPublishBareNameFailsBeforeNetwork(t *testing.T) {
 	}
 }
 
-func TestDoRegistryPublishAllowUnscopedNameWarnsAndSubmits(t *testing.T) {
+// The grandfathered lane: --allow-unscoped-name suppresses the refusal, the bare name survives
+// into the request unrewritten, and the warning still fires. Asserted through --dry-run rather
+// than a loopback server, because the warning is deliberately emitted BEFORE the dry-run early
+// return and the request is fully built by then, so a server would only re-cover the submit path
+// TestSubmitRegistryPublishRequestSendsAuthenticatedPayload already owns — at the cost of one more
+// untagged HTTP test server, which internal/testpolicy/resourcecensus caps.
+func TestDoRegistryPublishAllowUnscopedNameWarnsAndKeepsBareName(t *testing.T) {
 	_, packDir := setupRegistryPublishRepoManifest(t, registryPublishManifestNamed("cacc-twin-team"))
 	clearRegistryEnv(t)
-	oldClient := registryPublishHTTPClient
-	defer func() { registryPublishHTTPClient = oldClient }()
-
-	var got registryPublishRequest
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("Decode request: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"publishRequest": {
-				"id": "prq_grandfathered",
-				"status": "pending_review",
-				"requestedName": "cacc-twin-team",
-				"requestedVersion": "0.2.0"
-			}
-		}`))
-	}))
-	defer server.Close()
-	registryPublishHTTPClient = server.Client()
-	if err := writeRegistryConfiguredToken(server.URL, "gcr_stored_token"); err != nil {
-		t.Fatalf("writeRegistryConfiguredToken: %v", err)
-	}
 
 	var stdout, stderr bytes.Buffer
 	code := doRegistryPublish(t.Context(), packDir, registryPublishOptions{
-		RegistryURL:       server.URL,
+		RegistryURL:       "https://registry.example.com",
 		AllowUnscopedName: true,
-		Validate:          true,
+		DryRun:            true,
 	}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
 	}
-	if got.RequestedName != "cacc-twin-team" {
-		t.Fatalf("submitted requestedName = %q, want the bare name", got.RequestedName)
+	if want := "Pack: cacc-twin-team 0.2.0"; !strings.Contains(stdout.String(), want) {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 	}
 	want := `gc pack registry publish: warning: submitting unscoped name "cacc-twin-team"; ` +
 		"the registry accepts it only when it already holds a claim for that name"

--- a/docs/guides/shareable-packs.md
+++ b/docs/guides/shareable-packs.md
@@ -135,6 +135,13 @@ gc pack registry show main:gastown      # prints a paste-ready import command
 gc pack registry publish .              # submit a pack (after gc pack registry login)
 ```
 
+Registry pack names are scoped as `<github-owner>/<pack>`. Before you publish,
+`[pack].name` must already carry that scoped name, and its scope must equal the
+lowercased GitHub owner of the source repository: publish submits the name
+`pack.toml` declares, and the registry compares the two byte-for-byte. Unscoped
+names are reserved — the registry accepts one only when it already holds a
+claim for it, which is what `--allow-unscoped-name` is for.
+
 See [Public Registry Packs](/guides/registry-showcase) for the first-party
 catalog and cache-freshness controls (`--refresh`, `GC_REGISTRY_FRESHNESS`), and
 [Understanding Packs](/guides/understanding-packs#registries-handles-and-sources)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3005,6 +3005,12 @@ The command requires a clean Git checkout whose current HEAD matches its
 configured upstream branch, then submits the GitHub repository, commit, pack
 path, pack name, and version to the registry API.
 
+Registry pack names are scoped as &lt;github-owner&gt;/&lt;pack&gt;, where &lt;github-owner&gt;
+is the lowercased GitHub owner of the source repository. [pack].name must
+already carry that scoped name: the registry compares it byte-for-byte with the
+requested name, and reserves unscoped names for packs it already holds a claim
+for. --allow-unscoped-name submits such a legacy unscoped name anyway.
+
 --dev-auth (localhost only) replaces all other credentials. Otherwise,
 authentication precedence is --token, GC_REGISTRY_TOKEN, a complete session
 cookie and CSRF-token pair from flags or the environment, a stored native
@@ -3018,12 +3024,13 @@ gc pack registry publish <path-to-pack-root> [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--allow-unscoped-name` | bool |  | submit an unscoped (bare) pack name; the registry accepts these only for names it already holds a claim for |
 | `--csrf-token` | string |  | registry CSRF token; defaults to GC_REGISTRY_CSRF_TOKEN |
 | `--description` | string |  | release description; defaults to [pack].description |
 | `--dev-auth` | bool |  | create a local dev-auth session before submitting; localhost only |
 | `--dev-auth-handle` | string | `local-cli` | dev-auth handle when --dev-auth is used |
 | `--dry-run` | bool |  | print the publish request without submitting |
-| `--name` | string |  | registry pack name; defaults to [pack].name |
+| `--name` | string |  | registry pack name; must equal [pack].name (the registry rejects a mismatch) |
 | `--ref` | string |  | release ref label; defaults to the upstream branch name |
 | `--registry-url` | string |  | registry app base URL; defaults to GC_REGISTRY_URL, the stored login default, then https://registry.gascity.com |
 | `--session-cookie` | string |  | registry_session cookie value or Cookie header; defaults to GC_REGISTRY_SESSION |


### PR DESCRIPTION
## Why

`gc pack registry publish` sent whatever name it was handed and let the registry decide. That cost a publisher of `tdupu/mathcity` two submissions and left an unpublishable row in the registry's review queue:

- attempt 1 requested `tdupu/mathcity` — refused, because `pack.toml` declared `mathcity` and the registry compares the two byte-for-byte;
- attempt 2 requested `mathcity` — validated cleanly, and can never be approved, because unscoped names are reserved.

Neither refusal was visible until after the request existed, and the first refusal's advice pointed at the name that produced the second problem.

## What this adds

`validateRegistryPublishName` in `buildRegistryPublishRequest` — the single choke point, so the upstream-remote path and the GitHub Actions fallback path are both covered — running four ordered checks:

1. name grammar, via `packregistry.ValidatePackName` (reused, not restated);
2. `pack.toml` declares no `[pack].name` — `--name` can no longer stand in for it, since the registry rejects a nameless manifest outright;
3. `--name` disagrees with `[pack].name` — the exact shape of attempt 1;
4. the namespace rules: unscoped names are reserved, and a scope must equal the lowercased GitHub owner of the source repo — the exact shape of attempt 2.

This is the local twin of `packNamePolicyViolation` in the registry server (gascity/registry#299), which enforces the same two rules at validation and again at approve.

## Message discipline

Every message names the one edit that fixes it, and none prescribes a name a later check refuses:

- a bare `--name` against an already correctly scoped `pack.toml` blames the **flag**, not the manifest — otherwise the advice would tell the publisher to drop a scope the next run then refuses as reserved;
- a suggestion is always rescoped to the repository owner rather than echoing a foreign scope back.

## Escape hatch

`--allow-unscoped-name` keeps the grandfathered bare names (`cacc-twin-team`) publishable, because a local preflight cannot see the registry's claim table. It prints a warning before the `--dry-run` early return, which is where a publisher checks what the flag is about to do. The scope rule has no server-side override, so it has none here either.

## Behaviour break

Publishers of grandfathered unscoped names must now pass `--allow-unscoped-name`. Noted in `CHANGELOG.md` under Unreleased → Changed with upgrading instructions.

## Verification

`gofmt -l cmd/gc` clean · `go build ./...` clean · `go vet ./cmd/gc/...` clean · `go test ./cmd/gc/... -run 'Registry|Publish' -count=1` ok (24s), including all 17 subtests of the new `TestValidateRegistryPublishName` table.

The full `go test ./cmd/gc/...` run fails in this environment on `TestResolveTemplateRendersAbstractUpstreamPerHarness`, which also fails on a clean tree here and passes under `env -u OPENAI_API_KEY` — a pre-existing ambient-env leak, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)