### PR TITLE
fix(dispatch): stop control beads under a workflow root that already settled

### DIFF
--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -196,6 +196,18 @@ func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (Co
 // teardown or a missing-root orphan close.
 const controlRootCanceledCloseReason = "control closed: workflow root canceled via run cancel"
 
+// controlRootSettledCloseReason is stamped on a control bead closed because its
+// workflow root had already settled, distinguishing terminal-root residue from
+// a cancellation, a skip teardown, or a missing-root orphan close.
+const controlRootSettledCloseReason = "control closed: workflow root already settled"
+
+// closeOrphanedControl is the root-state gate every control bead passes through
+// before its kind-specific processing: it reports handled=true when the bead's
+// workflow root is in a state that makes further work invalid. Three states
+// qualify — the root is gone (orphan), the root was canceled, or the root has
+// already settled. The finalizer is exempt because it is the bead that settles
+// the root, and the teardown tail is exempt because it runs after settlement by
+// contract.
 func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, bool, error) {
 	if bead.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflowFinalize {
 		return ControlResult{}, false, nil
@@ -216,6 +228,27 @@ func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOption
 		// teeth.
 		if rootCanceled(root) {
 			return closeCanceledControl(store, bead, opts, rootID, rootStoreRef)
+		}
+		// A settled (closed) root is equally durable a stop signal. The
+		// finalizer closes the root BEFORE its bulk
+		// CloseSubtreeWithMetadataExcept sweep so a crash leaves the finalizer
+		// open to retry, but that sweep is all-or-nothing: when it fails —
+		// store contention is the reported trigger — the finalizer returns
+		// early and every control under the now-terminal root stays open and
+		// keeps minting attempts. gastownhall/gascity#5389 measured a
+		// downstream step still retrying almost 5 hours after its root
+		// recorded gc.outcome=fail and closed_at, which understates the run's
+		// true wall-clock and cost for anything reading the root alone.
+		// Gating per control makes settlement converge incrementally instead
+		// of depending on one bulk write succeeding.
+		if rootSettled(root) {
+			teardown, err := isTeardownTailControl(store, bead, rootID)
+			if err != nil {
+				return ControlResult{}, false, fmt.Errorf("%s: resolving teardown tail under settled root %s: %w", bead.ID, rootID, err)
+			}
+			if !teardown {
+				return closeSettledControl(store, bead, opts, rootID, rootStoreRef)
+			}
 		}
 		return ControlResult{}, false, nil
 	} else if !errors.Is(err, beads.ErrNotFound) {
@@ -248,6 +281,62 @@ func rootCanceled(root beads.Bead) bool {
 		return true
 	}
 	return strings.TrimSpace(root.Metadata[beadmeta.CancelRequestedMetadataKey]) != ""
+}
+
+// rootSettled reports whether a workflow root has reached a terminal state.
+// Closure is the signal, not any particular gc.outcome: the finalizer closes a
+// root with pass/fail/skipped, and an operator hand-close is just as terminal.
+// rootCanceled is checked first by the caller, so cancellation keeps its own
+// distinct close path.
+func rootSettled(root beads.Bead) bool {
+	return root.Status == "closed"
+}
+
+// isTeardownTailControl reports whether a control belongs to the teardown tail,
+// which runs AFTER the root settles by contract — its pass condition may branch
+// on ROOT_OUTCOME, which only finalize produces (#5271). teardownTailExclusion
+// keeps that tail out of the finalizer's own terminal sweep for the same
+// reason, and it is the authoritative definition, so the settled-root gate
+// defers to it rather than restating the rule.
+//
+// The cheap arm answers for retry and ralph controls, which expandRetry /
+// expandRalph mint with cloneStep and so inherit the host step's
+// gc.scope_role; only the first attempt strips it. Fanout and scope-check
+// controls are stamped gc.scope_role=control instead and keep only gc.step_id
+// as their link back to a teardown step, so they need the subtree read. That
+// read happens only under an already-terminal root, at most once per control
+// before the gate closes it, never on the live dispatch path.
+func isTeardownTailControl(store beads.Store, bead beads.Bead, rootID string) (bool, error) {
+	if bead.Metadata[beadmeta.ScopeRoleMetadataKey] == beadmeta.ScopeRoleTeardown {
+		return true, nil
+	}
+	if strings.TrimSpace(bead.Metadata[beadmeta.StepIDMetadataKey]) == "" {
+		return false, nil
+	}
+	exclude, err := teardownTailExclusion(store, rootID)
+	if err != nil {
+		return false, err
+	}
+	return exclude(bead), nil
+}
+
+// closeSettledControl closes a control bead whose workflow root has already
+// settled, stamping gc.outcome=skipped so the residue is indistinguishable from
+// the residue the finalizer's own sweep closes. It is deliberately not a
+// failure: the control never ran to a verdict, and stamping fail would pollute
+// outcome aggregation with beads that never executed.
+func closeSettledControl(store beads.Store, bead beads.Bead, opts ProcessOptions, rootID, rootStoreRef string) (ControlResult, bool, error) {
+	opts.tracef("process-control bead=%s kind=%s close reason=root_settled root=%s store_ref=%s",
+		bead.ID, bead.Metadata[beadmeta.KindMetadataKey], rootID, rootStoreRef)
+	closeMetadata := map[string]string{
+		beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped,
+		"close_reason":              controlRootSettledCloseReason,
+	}
+	clearControllerSpawnErrorMetadata(closeMetadata)
+	if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
+		return ControlResult{}, true, fmt.Errorf("%s: closing settled control: %w", bead.ID, err)
+	}
+	return ControlResult{Processed: true, Action: "settled-workflow"}, true, nil
 }
 
 // closeCanceledControl closes a control bead whose workflow root was canceled,

--- a/internal/dispatch/terminal_root_gate_test.go
+++ b/internal/dispatch/terminal_root_gate_test.go
@@ -1,0 +1,170 @@
+package dispatch
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// newTerminalRootRetryControl builds the minimal graph the retry dispatcher
+// needs to spawn attempt 2: a workflow root, a retry control, and a closed
+// attempt 1 that classifies transient (the INFRA_TIMEOUT shape from
+// gastownhall/gascity#5389). extraControlMetadata is merged onto the control.
+func newTerminalRootRetryControl(t *testing.T, store beads.Store, rootOutcome string, extraControlMetadata map[string]string) (control beads.Bead) {
+	t.Helper()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Type:     "molecule",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if rootOutcome != "" {
+		if _, err := store.CloseAll([]string{root.ID}, map[string]string{"gc.outcome": rootOutcome}); err != nil {
+			t.Fatalf("close root %s: %v", rootOutcome, err)
+		}
+	}
+
+	controlMetadata := map[string]string{
+		"gc.kind":             "retry",
+		"gc.root_bead_id":     root.ID,
+		"gc.root_store_ref":   "rig:gascity",
+		"gc.step_ref":         "mol-test.finalize",
+		"gc.step_id":          "finalize",
+		"gc.max_attempts":     "5",
+		"gc.on_exhausted":     "hard_fail",
+		"gc.source_step_spec": `{"id":"finalize","title":"Finalize","type":"task","retry":{"max_attempts":5}}`,
+		"gc.control_epoch":    "1",
+	}
+	for key, value := range extraControlMetadata {
+		controlMetadata[key] = value
+	}
+	control = mustCreate(t, store, beads.Bead{Title: "finalize", Metadata: controlMetadata})
+
+	attempt := mustCreate(t, store, beads.Bead{
+		Title: "finalize attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id":   root.ID,
+			"gc.step_ref":       "mol-test.finalize.attempt.1",
+			"gc.attempt":        "1",
+			"gc.outcome":        "fail",
+			"gc.failure_class":  "transient",
+			"gc.failure_reason": "INFRA_TIMEOUT",
+		},
+	})
+	mustClose(t, store, attempt.ID)
+	mustDep(t, store, control.ID, attempt.ID, "blocks")
+	return control
+}
+
+// TestProcessControlStopsControlWhenWorkflowRootTerminallyClosed pins the
+// terminal-root gate reported as gastownhall/gascity#5389: once a workflow root
+// has recorded a terminal gc.outcome and closed_at, control beads under it must
+// stop spawning work.
+//
+// processWorkflowFinalize closes the root (runtime.go) BEFORE its bulk
+// CloseSubtreeWithMetadataExcept sweep, deliberately, so a crash leaves the
+// finalizer open to retry. That sweep is all-or-nothing: under store contention
+// it fails wholesale and the finalizer returns early, leaving the root closed
+// and every control under it still open. Without this gate those controls keep
+// being dispatched and keep minting attempts — the reporter measured a
+// downstream step still retrying 5 hours after its root recorded gc.outcome=fail.
+// The gate is per-control and idempotent, so settlement converges even when the
+// bulk sweep never succeeds.
+func TestProcessControlStopsControlWhenWorkflowRootTerminallyClosed(t *testing.T) {
+	t.Parallel()
+
+	for _, rootOutcome := range []string{"fail", "pass", "skipped"} {
+		t.Run(rootOutcome, func(t *testing.T) {
+			t.Parallel()
+			store := beads.NewMemStore()
+			control := newTerminalRootRetryControl(t, store, rootOutcome, nil)
+
+			var traceBuf bytes.Buffer
+			opts := ProcessOptions{Tracef: func(format string, args ...any) {
+				fmt.Fprintf(&traceBuf, format, args...)
+				traceBuf.WriteByte('\n')
+			}}
+
+			result, err := ProcessControl(store, mustGet(t, store, control.ID), opts)
+			if err != nil {
+				t.Fatalf("ProcessControl: %v", err)
+			}
+			if !result.Processed || result.Action != "settled-workflow" {
+				t.Fatalf("result = %+v, want processed settled-workflow", result)
+			}
+			if result.Created != 0 {
+				t.Fatalf("created %d bead(s) under a terminally closed root, want 0", result.Created)
+			}
+
+			after := mustGet(t, store, control.ID)
+			if after.Status != "closed" {
+				t.Fatalf("control status = %q, want closed", after.Status)
+			}
+			// Residue closed by the gate must be indistinguishable from residue
+			// closed by the finalizer's own sweep, which stamps skipped.
+			if got := after.Metadata["gc.outcome"]; got != "skipped" {
+				t.Fatalf("gc.outcome = %q, want skipped", got)
+			}
+			// Residue is not a failure: stamping fail here would pollute
+			// outcome aggregation with beads that never ran.
+			if got := after.Metadata["gc.failure_reason"]; got != "" {
+				t.Fatalf("gc.failure_reason = %q, want empty", got)
+			}
+			if got := after.Metadata["gc.failure_class"]; got != "" {
+				t.Fatalf("gc.failure_class = %q, want empty", got)
+			}
+			if !bytes.Contains(traceBuf.Bytes(), []byte("close reason=root_settled")) {
+				t.Fatalf("trace missing root_settled close reason; got:\n%s", traceBuf.String())
+			}
+		})
+	}
+}
+
+// TestProcessControlKeepsTeardownTailRunningUnderTerminalRoot guards the
+// contract #5271 established: a teardown step's control runs AFTER the root
+// settles by design — its pass condition may branch on ROOT_OUTCOME, which only
+// finalize produces. teardownTailExclusion keeps that tail out of the
+// finalizer's own sweep for the same reason, so the terminal-root gate must
+// exempt it too or the adopt-pr settlement deadlock comes straight back.
+//
+// expandRetry mints a retry control via cloneStep, so the control inherits the
+// host step's gc.scope_role; only the first attempt strips it.
+func TestProcessControlKeepsTeardownTailRunningUnderTerminalRoot(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	control := newTerminalRootRetryControl(t, store, "fail", map[string]string{
+		"gc.scope_ref":  "teardown",
+		"gc.scope_role": "teardown",
+	})
+
+	result, err := ProcessControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if result.Action != "retry" || result.Created != 1 {
+		t.Fatalf("result = %+v, want the teardown tail to keep running (retry, created 1)", result)
+	}
+	if after := mustGet(t, store, control.ID); after.Status != "open" {
+		t.Fatalf("teardown control status = %q, want open", after.Status)
+	}
+}
+
+// TestProcessControlKeepsRunningUnderOpenRoot pins the hot path: an open root is
+// not a stop signal, so the gate must not change ordinary dispatch.
+func TestProcessControlKeepsRunningUnderOpenRoot(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	control := newTerminalRootRetryControl(t, store, "", nil)
+
+	result, err := ProcessControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if result.Action != "retry" || result.Created != 1 {
+		t.Fatalf("result = %+v, want normal retry dispatch under an open root", result)
+	}
+}


### PR DESCRIPTION
Reported in #5389 (thanks @dkisselev-zz — the report was precise enough to land straight on the mechanism).

## Root cause

`closeOrphanedControl` (`internal/dispatch/runtime.go`) is the root-state gate every control bead passes through before its kind-specific processing. It recognized two root states as stop signals — root **missing** (orphan) and root **canceled** — but **not a root already closed with a terminal outcome**. So once a workflow root settles, every control bead under it keeps being dispatched and keeps minting attempts.

The window is unbounded because of how settlement is ordered. `processWorkflowFinalize` closes the root *before* its bulk `molecule.CloseSubtreeWithMetadataExcept` sweep. That ordering is deliberate and correct — if the process dies after the root close, the finalizer is still open and the next serve cycle retries. But the sweep is all-or-nothing: when it fails (the reported run had sustained bead-store contention, `INFRA_TIMEOUT` on every attempt) the finalizer returns early via `recordWorkflowFinalizeError` and stays open, the root is **already closed**, and nothing stops the subtree.

That is the reporter's measurement: a downstream step still retrying on its own ralph controller almost 5 hours after the root recorded `gc.outcome=fail` and `closed_at`. Anything reading the root alone — a dashboard, an alert, a cost report — under-reports both wall-clock and cost for that entire window. Worth noting that `mapRunPhase` already treats a closed root as history ("root-terminality wins"), which is exactly why the continued burn was invisible.

## Fix

Gate per control rather than relying on one bulk write: a settled root closes each control bead the next time the dispatcher touches it, so settlement converges incrementally whether or not the sweep ever succeeds.

Residue is closed `gc.outcome=skipped`, matching what the finalizer's own sweep stamps. Deliberately not a failure — the control never ran to a verdict, and stamping `fail` would pollute outcome aggregation with beads that never executed.

## The teardown tail is exempt

This is the part that makes the change less trivial than it looks. Teardown runs **after** the root settles by contract — its pass condition may branch on `ROOT_OUTCOME`, which only finalize produces. That is precisely what #5271 fixed (the adopt-pr settlement deadlock), and `teardownTailExclusion` exists to keep the tail out of the finalizer's own sweep for the same reason. A naive "root closed → stop everything" gate re-breaks it, so the gate defers to `teardownTailExclusion` rather than restating the rule.

The cheap arm covers retry and ralph controls, which `expandRetry`/`expandRalph` mint via `cloneStep` and therefore *inherit* `gc.scope_role=teardown` (only the first attempt strips it). Fanout and scope-check controls are stamped `gc.scope_role=control` and keep only `gc.step_id` as their link back to a teardown step, so those need the subtree read — which happens only under an already-terminal root, at most once per control before the gate closes it, never on the live dispatch path.

## Why neither option from the issue

The issue asked for either (1) delaying the root's `closed_at` until the DAG settles, or (2) a separate "all descendants settled" signal. Neither is needed. The root's close is already ordered correctly and the finalizer already waits on all graph sinks; the defect was that settlement wasn't *enforced* afterwards. Bounding the residue window to a dispatcher cycle is what makes `closed_at` an accurate settle time — with no new metadata or wire surface.

## Known limits (stated, not hidden)

- This stops **work**. It does not replace the sweep for closing passive residue: an open scope body under a settled root dispatches nothing, so it is left to the sweep.
- `closeOrphanedControl` returns early when `gc.root_store_ref` is empty, so neither the pre-existing cancel gate nor this one fires on rows lacking it. graph.v2 stamps it. Unchanged here, not widened.
- Because the reporter asked for things this deliberately does not build, a maintainer should decide whether it closes #5389 — I did not use a closing keyword.

## Tests

`internal/dispatch/terminal_root_gate_test.go`:

- `TestProcessControlStopsControlWhenWorkflowRootTerminallyClosed` — the red test. Before this change, `ProcessControl` on a retry controller whose root was already closed `gc.outcome=fail` returned `{Action:retry Created:1}`: it minted attempt 2 under a terminally closed root. Subtests cover `fail`/`pass`/`skipped`.
- `TestProcessControlKeepsTeardownTailRunningUnderTerminalRoot` — guards the #5271 contract.
- `TestProcessControlKeepsRunningUnderOpenRoot` — pins the hot path; an open root is not a stop signal.

An alternative hypothesis was tested and disproved rather than argued: "`abort_scope` propagates fail upward onto the root." It cannot — `abortScope` closes `snapshot.body`, and `resolveScopeBody` only ever selects `gc.kind==scope` beads, while a graph.v2 root is `gc.kind==workflow`. A probe confirmed a failing scope member closes the scope *body* and leaves the root `open`. `processWorkflowFinalize` is the only dispatcher path that closes a graph.v2 root.

## Verification

`go test ./internal/dispatch/` (full package); `go test ./cmd/gc/ -run 'Dispatch|Control|Workflow|Finalize|Graph|Convoy|Wisp|Teardown|Order'` → ok 50s; `internal/{formula,molecule,sling,sourceworkflow,graphroute,runproj}` ok; `go vet` clean; pre-commit lint clean; pre-push `make test-fast-parallel` → all fast jobs passed.
