### PR TITLE
test(runproj): gate run projection end-to-end from bead.* events

### DIFF
--- a/internal/beads/runview_lifecycle_test.go
+++ b/internal/beads/runview_lifecycle_test.go
@@ -1,0 +1,141 @@
+package beads_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runproj"
+)
+
+// lifecycleRootID is the single graph.v2 run this test drives end to end.
+const lifecycleRootID = "gcg-lifecycle-root"
+
+// lifecycleCreatedAt timestamps every bead in the run so the projected updated_at
+// is populated (a run that happened at a real time), matching the sibling
+// round-trip test's fixture.
+var lifecycleCreatedAt = time.Date(2026, 7, 4, 8, 0, 0, 0, time.UTC)
+
+// TestRunViewLifecycleRoundTripFromNotifyChange is the producer-fidelity gate for
+// the run projection. TestRunViewRoundTripFromNotifyChange (this package) proves a
+// two-bead run survives the producer→fold→summary seam; this widens that to a full
+// graph.v2 lifecycle (created → in_progress → closed for every bead) emitted
+// through the REAL producer (CachingStore.notifyChange), and drives it all the way
+// into BOTH runproj.BuildRunSummary AND runproj.BuildRunDetail.
+//
+// It is the exact regression the run-view RCA describes: a store that stops
+// emitting bead.* for graph.v2 roots. If the producer drops those events the fold
+// starves, the summary loses the lane, and the detail loses its nodes — each of
+// which fails an assertion here. Because the events come from the production
+// marshal + run/session id-resolution path (not a hand-built payload), a wire-shape
+// or metadata drift between producer and consumer also trips this gate.
+func TestRunViewLifecycleRoundTripFromNotifyChange(t *testing.T) {
+	step1 := lifecycleRootID + ".1"
+	step2 := lifecycleRootID + ".2"
+
+	// Full lifecycle emitted through the real producer, ending terminal-success:
+	// root goes in_progress; each step is created, runs, then closes; the root
+	// closes last.
+	evts := recordThroughNotifyChange(t,
+		beadSeed{events.BeadCreated, lifecycleRoot("in_progress")},
+		beadSeed{events.BeadCreated, lifecycleStep(step1, "preflight", "open")},
+		beadSeed{events.BeadUpdated, lifecycleStep(step1, "preflight", "in_progress")},
+		beadSeed{events.BeadClosed, lifecycleStep(step1, "preflight", "closed")},
+		beadSeed{events.BeadCreated, lifecycleStep(step2, "review-loop", "open")},
+		beadSeed{events.BeadUpdated, lifecycleStep(step2, "review-loop", "in_progress")},
+		beadSeed{events.BeadClosed, lifecycleStep(step2, "review-loop", "closed")},
+		beadSeed{events.BeadClosed, lifecycleRoot("closed")},
+	)
+
+	folded := runproj.Fold(evts)
+	if len(folded) != 3 {
+		t.Fatalf("fold size = %d, want 3 (root + 2 steps); the fold starved", len(folded))
+	}
+	ordered := beadsInSeenOrder(evts, folded)
+
+	// Summary: the closed run must list in the historical bucket, with its formula.
+	summary := runproj.BuildRunSummary(runproj.FilterRunBeads(ordered))
+	var lane runproj.RunLane
+	found := false
+	for _, l := range summary.HistoricalLanes {
+		if l.ID == lifecycleRootID {
+			lane, found = l, true
+		}
+	}
+	if !found {
+		t.Fatalf("closed run %q not present in historical lanes — the projection starved.\nsummary=%+v", lifecycleRootID, summary)
+	}
+	if lane.Phase != "complete" {
+		t.Errorf("lane phase = %q, want complete (root closed)", lane.Phase)
+	}
+	if lane.Formula.Status != "known" || lane.Formula.Name != "mol-adopt-pr-v2" {
+		t.Errorf("lane formula = %+v, want known/mol-adopt-pr-v2", lane.Formula)
+	}
+
+	// Detail: the same folded snapshot must render a terminal DAG.
+	detail, err := runproj.BuildRunDetail(ordered, lifecycleRootID, 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	statusByNode := map[string]string{}
+	for _, node := range detail.Nodes {
+		statusByNode[node.ID] = node.Status
+	}
+	for _, id := range []string{lifecycleRootID, "preflight", "review-loop"} {
+		if statusByNode[id] != "completed" {
+			t.Errorf("node %q status = %q, want completed", id, statusByNode[id])
+		}
+	}
+	if detail.Phase != "complete" {
+		t.Errorf("detail.Phase = %q, want complete", detail.Phase)
+	}
+	if !detail.Progress.Terminal {
+		t.Error("detail.Progress.Terminal = false, want true — every node is terminal")
+	}
+}
+
+// lifecycleRoot builds the graph.v2 run-root bead at a given lifecycle status — the
+// marker set that makes the run project: gc.formula_contract=graph.v2 and
+// gc.kind=run drive lane grouping and detail eligibility; gc.formula names the
+// formula; gc.root_store_ref + gc.scope_kind/gc.scope_ref supply the run
+// identity/scope BuildRunDetail requires.
+func lifecycleRoot(status string) beads.Bead {
+	return beads.Bead{
+		ID:        lifecycleRootID,
+		Title:     "adopt PR #42",
+		Status:    status,
+		Type:      "molecule",
+		CreatedAt: lifecycleCreatedAt,
+		Metadata: map[string]string{
+			beadmeta.FormulaContractMetadataKey: "graph.v2",
+			beadmeta.KindMetadataKey:            "run",
+			beadmeta.FormulaMetadataKey:         "mol-adopt-pr-v2",
+			beadmeta.RunTargetMetadataKey:       "rig:demo",
+			beadmeta.RootStoreRefMetadataKey:    "rig:demo",
+			beadmeta.ScopeKindMetadataKey:       "rig",
+			beadmeta.ScopeRefMetadataKey:        "demo",
+		},
+	}
+}
+
+// lifecycleStep builds a graph.v2 run step rooted at lifecycleRootID:
+// gc.root_bead_id groups it under the root and gc.step_id is its semantic node id
+// in the detail DAG. id is the bead id, stepID the semantic step id.
+func lifecycleStep(id, stepID, status string) beads.Bead {
+	return beads.Bead{
+		ID:        id,
+		Title:     stepID,
+		Status:    status,
+		Type:      "task",
+		CreatedAt: lifecycleCreatedAt,
+		ParentID:  lifecycleRootID,
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       "step",
+			beadmeta.RootBeadIDMetadataKey: lifecycleRootID,
+			beadmeta.StepIDMetadataKey:     stepID,
+			beadmeta.StepRefMetadataKey:    "mol-adopt-pr-v2." + stepID,
+		},
+	}
+}

--- a/internal/runproj/golden_run_contract_test.go
+++ b/internal/runproj/golden_run_contract_test.go
@@ -1,0 +1,186 @@
+package runproj
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// This file is the end-to-end contract gate for the run projection. The rest of
+// the package's tests are split into two worlds that never meet: fold_test.go /
+// projector_test.go drive events → Fold but assert only the fold map, while the
+// golden and terminal-clamp tests load a []beads.Bead straight into
+// BuildRunSummary / BuildRunDetail and never touch Fold. Nothing chained a real
+// bead.* event stream all the way through Fold/Projector into the two builders —
+// so when a store stopped emitting bead.* for graph.v2 workflow roots the runs
+// silently vanished and no test failed.
+//
+// These tests close that gap: they synthesize a full-lifecycle bead.* event
+// stream (created → in_progress → closed), fold it through the Projector exactly
+// as the per-city tailer does, and assert BOTH BuildRunSummary (the lane lists)
+// and BuildRunDetail (the DAG renders) off the folded snapshot. If the fold
+// starves, the summary comes back empty and the detail loses its nodes — both of
+// which these assertions catch.
+//
+// The run beads are built with the package's shared graph.v2 run-bead builders
+// (clampRootBead / clampStepBead, detail_terminal_clamp_test.go): the exact
+// fixture the direct-build tests already trust, now driven through the event
+// chain instead of handed straight to the builders.
+
+// runBeadEvent wraps a full bead snapshot in a bead.* lifecycle event, marshaling
+// the whole bead (metadata included) as the raw payload — the shape
+// CachingStore.notifyChange emits and Fold/Projector decode. The package's
+// beadEvent (fold_test.go) marshals only id/status/type, so a run whose grouping
+// and rendering depend on metadata needs this fuller builder.
+func runBeadEvent(seq uint64, typ string, b beads.Bead) events.Event {
+	payload, _ := json.Marshal(b)
+	return events.Event{Seq: seq, Type: typ, Subject: b.ID, Payload: payload}
+}
+
+// projectRunBeads folds an event stream through a Projector and returns the beads
+// in first-seen order — the deterministic slice BuildRunSummary/BuildRunDetail
+// expect, and the exact path the live tailer feeds them.
+func projectRunBeads(evts []events.Event) []beads.Bead {
+	p := NewProjector()
+	p.Apply(evts)
+	return p.Beads()
+}
+
+// TestContractGraphV2RunProjectsThroughEventsToSummaryAndDetail drives a graph.v2
+// run's full lifecycle as a bead.* event stream and proves it renders end to end:
+// while its steps are in flight the run lists as an ACTIVE lane (the precise shape
+// that "went invisible" when the store stopped emitting bead.*), and once the root
+// closes it moves to the HISTORICAL lanes and BuildRunDetail renders every node
+// terminal with phase "complete".
+func TestContractGraphV2RunProjectsThroughEventsToSummaryAndDetail(t *testing.T) {
+	const rootID = "gcg-contract-run"
+
+	// Mid-flight: the root and both steps are created and driven to in_progress.
+	midFlight := []events.Event{
+		runBeadEvent(1, events.BeadCreated, clampRootBead(rootID, "open", nil)),
+		runBeadEvent(2, events.BeadUpdated, clampRootBead(rootID, "in_progress", nil)),
+		runBeadEvent(3, events.BeadCreated, clampStepBead(rootID, rootID+".1", "preflight", "open", nil)),
+		runBeadEvent(4, events.BeadUpdated, clampStepBead(rootID, rootID+".1", "preflight", "in_progress", nil)),
+		runBeadEvent(5, events.BeadCreated, clampStepBead(rootID, rootID+".2", "review-loop", "open", nil)),
+		runBeadEvent(6, events.BeadUpdated, clampStepBead(rootID, rootID+".2", "review-loop", "in_progress", nil)),
+	}
+	// Terminal: both steps then the root close.
+	terminal := []events.Event{
+		runBeadEvent(7, events.BeadClosed, clampStepBead(rootID, rootID+".1", "preflight", "closed", nil)),
+		runBeadEvent(8, events.BeadClosed, clampStepBead(rootID, rootID+".2", "review-loop", "closed", nil)),
+		runBeadEvent(9, events.BeadClosed, clampRootBead(rootID, "closed", nil)),
+	}
+
+	// Fold decodes every bead.* event: a decode starve (the run-view RCA signature)
+	// would drop snapshots and shrink this map, which is exactly what left the run
+	// view blank.
+	if folded := Fold(append(append([]events.Event{}, midFlight...), terminal...)); len(folded) != 3 {
+		t.Fatalf("Fold size = %d, want 3 (root + 2 steps); the fold starved", len(folded))
+	}
+
+	// Drive the same stream through the Projector in two passes, mirroring the live
+	// tailer: a cold pass over the in-flight events, then an incremental Apply of
+	// the closing events.
+	p := NewProjector()
+	p.Apply(midFlight)
+
+	midSummary := BuildRunSummary(FilterRunBeads(p.Beads()))
+	activeLane, ok := findLaneInGroup(midSummary.Lanes, rootID)
+	if !ok {
+		t.Fatalf("in-flight run %q not present as an active lane; the run went invisible.\nlanes=%+v", rootID, midSummary.Lanes)
+	}
+	if laneInGroup(midSummary.HistoricalLanes, rootID) {
+		t.Errorf("in-flight run %q already in historical lanes, want active only", rootID)
+	}
+	if activeLane.Phase == "complete" {
+		t.Errorf("in-flight lane phase = %q, want a non-terminal phase", activeLane.Phase)
+	}
+	// Formula identity must survive the event chain (it rides gc.formula metadata).
+	if activeLane.Formula.Status != "known" || activeLane.Formula.Name != "mol-adopt-pr-v2" {
+		t.Errorf("in-flight lane formula = %+v, want known/mol-adopt-pr-v2", activeLane.Formula)
+	}
+
+	// Live-tail the closing events onto the warm projector.
+	p.Apply(terminal)
+	finalBeads := p.Beads()
+
+	finalSummary := BuildRunSummary(FilterRunBeads(finalBeads))
+	if laneInGroup(finalSummary.Lanes, rootID) {
+		t.Errorf("closed run %q still in active lanes, want historical", rootID)
+	}
+	historicalLane, ok := findLaneInGroup(finalSummary.HistoricalLanes, rootID)
+	if !ok {
+		t.Fatalf("closed run %q not present in historical lanes; the run went invisible.\nhistorical=%+v", rootID, finalSummary.HistoricalLanes)
+	}
+	if historicalLane.Phase != "complete" {
+		t.Errorf("historical lane phase = %q, want complete", historicalLane.Phase)
+	}
+
+	// The same folded snapshot must render a terminal detail DAG.
+	detail, err := BuildRunDetail(finalBeads, rootID, 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	statuses := nodeStatusByID(detail)
+	for _, id := range []string{rootID, "preflight", "review-loop"} {
+		if statuses[id] != "completed" {
+			t.Errorf("node %q status = %q, want completed", id, statuses[id])
+		}
+	}
+	if detail.Phase != "complete" {
+		t.Errorf("detail.Phase = %q, want complete", detail.Phase)
+	}
+	if !detail.Progress.Terminal {
+		t.Error("detail.Progress.Terminal = false, want true — every node is terminal")
+	}
+}
+
+// TestContractFailedStepPresentsFailedNodeThroughEvents proves a step that closes
+// with gc.outcome=fail surfaces as a "failed" node once its lifecycle is projected
+// through the event chain. The root is left in_progress so the terminal-root clamp
+// stays inert: the "failed" status is unambiguously the work of presentationStatus
+// (detail_nodeshape.go), not the clamp.
+func TestContractFailedStepPresentsFailedNodeThroughEvents(t *testing.T) {
+	const rootID = "gcg-contract-fail"
+
+	evts := []events.Event{
+		runBeadEvent(1, events.BeadCreated, clampRootBead(rootID, "open", nil)),
+		runBeadEvent(2, events.BeadUpdated, clampRootBead(rootID, "in_progress", nil)),
+		// A clean preflight step: created → closed with no outcome → completed.
+		runBeadEvent(3, events.BeadCreated, clampStepBead(rootID, rootID+".1", "preflight", "open", nil)),
+		runBeadEvent(4, events.BeadClosed, clampStepBead(rootID, rootID+".1", "preflight", "closed", nil)),
+		// A review step that runs then closes failed: created → in_progress → closed
+		// carrying gc.outcome=fail.
+		runBeadEvent(5, events.BeadCreated, clampStepBead(rootID, rootID+".2", "review-loop", "open", nil)),
+		runBeadEvent(6, events.BeadUpdated, clampStepBead(rootID, rootID+".2", "review-loop", "in_progress", nil)),
+		runBeadEvent(7, events.BeadClosed, clampStepBead(rootID, rootID+".2", "review-loop", "closed",
+			map[string]string{beadmeta.OutcomeMetadataKey: "fail"})),
+	}
+
+	beadList := projectRunBeads(evts)
+
+	// The run with its failed step still lists (as an active lane — the root is
+	// in_progress, a failed review round pending retry).
+	summary := BuildRunSummary(FilterRunBeads(beadList))
+	if !laneInGroup(summary.Lanes, rootID) {
+		t.Fatalf("run %q with a failed step not present as an active lane.\nlanes=%+v", rootID, summary.Lanes)
+	}
+
+	detail, err := BuildRunDetail(beadList, rootID, 1, 100)
+	if err != nil {
+		t.Fatalf("BuildRunDetail: %v", err)
+	}
+	node, ok := nodeByID(detail, "review-loop")
+	if !ok {
+		t.Fatalf("failed step node %q not found; nodes=%+v", "review-loop", detail.Nodes)
+	}
+	if node.Status != "failed" {
+		t.Errorf("failed step node status = %q, want failed (closed + gc.outcome=fail)", node.Status)
+	}
+	if statuses := nodeStatusByID(detail); statuses["preflight"] != "completed" {
+		t.Errorf("clean step node status = %q, want completed", statuses["preflight"])
+	}
+}


### PR DESCRIPTION
## What

Adds the missing regression gate for the run projection. The `internal/runproj` tests were split into two worlds that never met: fold/projector tests drove `events → Fold` but asserted only the fold map, and the golden / terminal-clamp tests loaded a `[]beads.Bead` straight into `BuildRunSummary`/`BuildRunDetail` without ever touching `Fold`. **Nothing chained a real `bead.*` event stream through Fold/Projector into the two builders** — so when a store stopped emitting `bead.*` for graph.v2 workflow roots, runs silently went invisible and no test caught it.

## Tests (test-only, no production changes)

- `internal/runproj/golden_run_contract_test.go`
  - `TestContractGraphV2RunProjectsThroughEventsToSummaryAndDetail` — synthesizes a full-lifecycle `bead.*` stream (root + 2 steps, each `created → in_progress → closed`), drives it through `Fold` and a two-pass `Projector` (cold load then live-tail, exactly as the per-city tailer does), and asserts the run lists as an **active** lane mid-flight, moves to **historical** with `Phase=complete` on root close, and `BuildRunDetail` renders every node `completed` with `Progress.Terminal`. The mid-flight *"run went invisible"* assertion is exactly the regression that started this work.
  - `TestContractFailedStepPresentsFailedNodeThroughEvents` — a step closed with `gc.outcome=fail` surfaces as a `failed` node through the event chain (root left `in_progress` so the terminal clamp stays inert and the failure is unambiguously from `presentationStatus`).
- `internal/beads/runview_lifecycle_test.go` (`beads_test`) — the producer-fidelity variant: emits the same graph.v2 lifecycle through the **real producer** (`CachingStore.notifyChange`) and folds it, so a store that stops emitting `bead.*` — or a wire-shape / metadata drift — fails the gate.

Falsification-checked: dropping the root's `bead.*` events makes the run vanish from every summary bucket, proving the presence assertions actually catch the regression.

## Observations (surfaced, not fixed here)

- `snapshotForRun`'s dep synthesis (`snapshotDeps`) uses `members[0].ID` as the parent-edge root rather than the `rootID` it was given — only correct because the root's `created` event precedes its steps; a replayed/out-of-order log would mis-root the synthesized edges. Node identity/status are unaffected. Worth a follow-up.

## Context

Part of a plan to durably fix + gate the dashboard projection (every recent run-view breakage traces to projection reads/folds going blind, with no gate). Staleness robustness shipped as #5393; the agents-pane graph-read fix is a sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
