### PR TITLE
fix(dashboard): count agents with active graph.v2 work as running

### DIFF
--- a/internal/api/handler_agents_graph_work.go
+++ b/internal/api/handler_agents_graph_work.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// graphSessionAssigneeInfix is the literal separating an agent's session name
+// from the wisp session id in a graph-resident (graph.v2) work bead's assignee.
+// A relocated graph store names wisp assignees
+// "<sessionName>-gcg-session-<uuid>", where <sessionName> is exactly
+// agent.SessionNameFor(city, qualifiedName, template) — the same string the
+// runtime provider is probed with by statusProviderRunning. Splitting on this
+// infix recovers the agent session-name prefix, so work executed under an
+// agent-agnostic wisp session is still attributed to the agent that owns it.
+//
+// Confirmed against a live relocated graph store: every in-progress wisp
+// assignee has the form "<sanitized-agent-name>-gcg-session-<32 hex>", e.g.
+// "bd__dog-gcg-session-917c4dd26bd772e2463919029a889e0e".
+const graphSessionAssigneeInfix = "-gcg-session-"
+
+// graphActiveWorkListLimit bounds the single in-progress graph-store list the
+// agent/status read path issues per request. It is a safety cap on a healthy
+// fleet's concurrent wisp count, not a correctness bound: the index only keeps
+// one bead per distinct agent session-name prefix.
+const graphActiveWorkListLimit = 512
+
+// graphAgentWork is a single agent's active graph-resident work: the id of an
+// in-progress wisp bead assigned to the agent and the bead's last-activity
+// time. The timestamp feeds computeAgentState so a graph-working agent reads
+// "working" (recent) rather than "waiting" (stale), even though its named
+// provider session is not the one executing the work.
+type graphAgentWork struct {
+	beadID       string
+	lastActivity time.Time
+}
+
+// graphActiveWorkBySession lists the relocated graph store's in-progress beads
+// once and indexes them by the agent session-name prefix embedded in each wisp
+// assignee. It is computed a single time per request and shared across the
+// per-agent status and agent-list loops, so those loops never fan a query per
+// agent.
+//
+// On a default (single-store) city the graph class is not relocated, so
+// GraphBeadStore().Store equals CityBeadStore() (or is nil) and this returns
+// nil — every downstream lookup misses and the read path stays byte-identical
+// to the pre-seam single-store behavior. Only a city that has RELOCATED its
+// graph class to a dedicated store is scanned, matching the guard the other
+// relocated-graph legs use (see isGraphConvoyID in handler_convoys.go).
+func (s *Server) graphActiveWorkBySession() map[string]graphAgentWork {
+	graphStore := s.state.GraphBeadStore().Store
+	if graphStore == nil || graphStore == s.state.CityBeadStore() {
+		return nil
+	}
+	inProgress, err := graphStore.List(beads.ListQuery{
+		Status: "in_progress",
+		Limit:  graphActiveWorkListLimit,
+		Sort:   beads.SortCreatedDesc,
+	})
+	if err != nil || len(inProgress) == 0 {
+		return nil
+	}
+	bySession := make(map[string]graphAgentWork, len(inProgress))
+	for _, b := range inProgress {
+		prefix, ok := sessionPrefixFromWispAssignee(b.Assignee)
+		if !ok {
+			continue
+		}
+		// SortCreatedDesc lists newest first, so the first bead seen for a
+		// prefix is the freshest wisp; keep it and skip older duplicates.
+		if _, exists := bySession[prefix]; exists {
+			continue
+		}
+		bySession[prefix] = graphAgentWork{
+			beadID:       b.ID,
+			lastActivity: beadActivityTime(b),
+		}
+	}
+	return bySession
+}
+
+// sessionPrefixFromWispAssignee splits a graph wisp assignee of the form
+// "<sessionName>-gcg-session-<uuid>" into its "<sessionName>" prefix. It
+// reports ok=false for an assignee that carries no wisp-session infix (a plain
+// exact-assignee bead) or whose prefix would be empty.
+func sessionPrefixFromWispAssignee(assignee string) (string, bool) {
+	i := strings.Index(assignee, graphSessionAssigneeInfix)
+	if i <= 0 {
+		return "", false
+	}
+	return assignee[:i], true
+}
+
+// beadActivityTime returns a bead's most recent activity timestamp, preferring
+// UpdatedAt and falling back to CreatedAt for legacy rows whose UpdatedAt is
+// zero (mirroring the UpdatedBefore fallback in beads.ListQuery.Matches).
+func beadActivityTime(b beads.Bead) time.Time {
+	if !b.UpdatedAt.IsZero() {
+		return b.UpdatedAt
+	}
+	return b.CreatedAt
+}

--- a/internal/api/handler_agents_graph_work_test.go
+++ b/internal/api/handler_agents_graph_work_test.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// bdDogState builds a city with a single city-scoped agent "bd.dog" (session
+// name "bd__dog") whose named provider session is NOT running, a distinct city
+// store, and no rig work stores. The caller opts into the relocated-graph leg
+// by wiring st.graphBeadStore. This mirrors a maintainer-city agent whose work
+// runs under agent-agnostic graph.v2 wisp sessions.
+func bdDogState(t *testing.T) *fakeState {
+	t.Helper()
+	st := newFakeState(t)
+	// A singleton agent (MaxActiveSessions=1, no pool overrides) so it expands
+	// to exactly one identity "bd.dog" with session name "bd__dog".
+	st.cfg.Agents = []config.Agent{{Name: "dog", BindingName: "bd", MaxActiveSessions: intPtr(1)}}
+	st.cfg.NamedSessions = nil
+	st.cfg.Rigs = nil
+	st.stores = map[string]beads.Store{}
+	st.cityBeadStore = beads.NewMemStore()
+	return st
+}
+
+// seedGraphWisp creates an in-progress bead in store whose assignee is the wisp
+// form "<sessionName>-gcg-session-<uuid>" and returns its id. This is exactly
+// the shape a relocated graph store carries for live agent work (verified
+// against the maintainer-city graph sqlite).
+func seedGraphWisp(t *testing.T, store beads.Store, sessionName, uuid string) string {
+	t.Helper()
+	b, err := store.Create(beads.Bead{Type: "task", Title: "wisp step"})
+	if err != nil {
+		t.Fatalf("Create wisp bead: %v", err)
+	}
+	status := "in_progress"
+	assignee := sessionName + "-gcg-session-" + uuid
+	if err := store.Update(b.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update wisp bead: %v", err)
+	}
+	return b.ID
+}
+
+// getAgentByName drives GET /v0/city/<city>/agents through the full handler and
+// returns the response row for the given qualified agent name.
+func getAgentByName(t *testing.T, st *fakeState, name string) agentResponse {
+	t.Helper()
+	srv := New(st)
+	h := newTestCityHandlerWith(t, st, srv)
+	req := httptest.NewRequest("GET", cityURL(st, "/agents"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /agents status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp struct {
+		Items []agentResponse `json:"items"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode /agents: %v", err)
+	}
+	for _, a := range resp.Items {
+		if a.Name == name {
+			return a
+		}
+	}
+	t.Fatalf("agent %q not found in /agents response (%d items)", name, len(resp.Items))
+	return agentResponse{}
+}
+
+// TestGraphResidentWorkCountsAsRunning pins the core fix: on a RELOCATED-graph
+// city, an agent whose only signal of life is an in-progress wisp bead in the
+// dedicated graph store (its named provider session is down) is counted in
+// agents.running by the status handler and reads "working" — not "stopped" —
+// via /v0/agents, with its active_bead pointing at the graph bead.
+func TestGraphResidentWorkCountsAsRunning(t *testing.T) {
+	st := bdDogState(t)
+	graph := beads.NewMemStore()
+	st.graphBeadStore = graph
+	beadID := seedGraphWisp(t, graph, "bd__dog", "917c4dd26bd772e2463919029a889e0e")
+
+	// (b) Status handler counts the agent as running.
+	body := New(st).buildStatusBody(context.Background(), false)
+	if body.Agents.Total != 1 {
+		t.Fatalf("agents.total = %d, want 1", body.Agents.Total)
+	}
+	if body.Agents.Running != 1 {
+		t.Errorf("agents.running = %d, want 1 (graph-resident work must count)", body.Agents.Running)
+	}
+	if body.Running != 1 {
+		t.Errorf("top-level running = %d, want 1", body.Running)
+	}
+
+	// (a) /v0/agents reports the agent working with the graph bead active.
+	got := getAgentByName(t, st, "bd.dog")
+	if got.State != "working" {
+		t.Errorf("agent state = %q, want %q", got.State, "working")
+	}
+	if !got.Running {
+		t.Errorf("agent running = false, want true")
+	}
+	if got.ActiveBead != beadID {
+		t.Errorf("agent active_bead = %q, want %q", got.ActiveBead, beadID)
+	}
+}
+
+// TestGraphResidentSingleStoreByteIdentical pins the single-store invariant:
+// with the graph class NOT relocated (GraphBeadStore() == CityBeadStore()), the
+// graph leg is inert — the very same wisp bead placed in the shared store is
+// ignored, so the agent stays stopped and uncounted, byte-identical to the
+// pre-seam behavior. This is the regression guard for the relocation gate.
+func TestGraphResidentSingleStoreByteIdentical(t *testing.T) {
+	st := bdDogState(t)
+	// graphBeadStore left nil => GraphBeadStore() falls back to the city store.
+	if st.GraphBeadStore().Store != st.CityBeadStore() {
+		t.Fatalf("precondition: expected single-store (graph == city)")
+	}
+	// Same wisp bead as the relocated test, but in the shared city store.
+	seedGraphWisp(t, st.cityBeadStore, "bd__dog", "917c4dd26bd772e2463919029a889e0e")
+
+	body := New(st).buildStatusBody(context.Background(), false)
+	if body.Agents.Running != 0 {
+		t.Errorf("agents.running = %d, want 0 (single-store must not prefix-match)", body.Agents.Running)
+	}
+	if body.Running != 0 {
+		t.Errorf("top-level running = %d, want 0", body.Running)
+	}
+
+	got := getAgentByName(t, st, "bd.dog")
+	if got.State != "stopped" {
+		t.Errorf("agent state = %q, want %q (single-store byte-identical)", got.State, "stopped")
+	}
+	if got.Running {
+		t.Errorf("agent running = true, want false")
+	}
+	if got.ActiveBead != "" {
+		t.Errorf("agent active_bead = %q, want empty", got.ActiveBead)
+	}
+}
+
+// TestGraphResidentNegativeNoMatchingWorkStaysStopped proves the prefix match is
+// agent-specific: a relocated graph store holding an in-progress wisp for a
+// DIFFERENT agent leaves bd.dog stopped and uncounted.
+func TestGraphResidentNegativeNoMatchingWorkStaysStopped(t *testing.T) {
+	st := bdDogState(t)
+	graph := beads.NewMemStore()
+	st.graphBeadStore = graph
+	// Work for a different agent session ("other__cat"), not bd__dog.
+	seedGraphWisp(t, graph, "other__cat", "deadbeefdeadbeefdeadbeefdeadbeef")
+
+	body := New(st).buildStatusBody(context.Background(), false)
+	if body.Agents.Running != 0 {
+		t.Errorf("agents.running = %d, want 0 (no matching wisp for bd.dog)", body.Agents.Running)
+	}
+
+	got := getAgentByName(t, st, "bd.dog")
+	if got.State != "stopped" {
+		t.Errorf("agent state = %q, want %q", got.State, "stopped")
+	}
+}
+
+// TestGraphResidentNoDoubleCountWhenAlsoProviderRunning pins that an agent that
+// is BOTH provider-running and has graph-resident work is counted exactly once.
+func TestGraphResidentNoDoubleCountWhenAlsoProviderRunning(t *testing.T) {
+	st := bdDogState(t)
+	graph := beads.NewMemStore()
+	st.graphBeadStore = graph
+	seedGraphWisp(t, graph, "bd__dog", "917c4dd26bd772e2463919029a889e0e")
+	if err := st.sp.Start(context.Background(), "bd__dog", runtime.Config{}); err != nil {
+		t.Fatalf("Start(bd__dog): %v", err)
+	}
+
+	body := New(st).buildStatusBody(context.Background(), false)
+	if body.Agents.Running != 1 {
+		t.Errorf("agents.running = %d, want 1 (running || graph work counts once)", body.Agents.Running)
+	}
+	if body.Running != 1 {
+		t.Errorf("top-level running = %d, want 1", body.Running)
+	}
+}
+
+// TestSessionPrefixFromWispAssignee unit-tests the assignee splitter that backs
+// the graph work index.
+func TestSessionPrefixFromWispAssignee(t *testing.T) {
+	tests := []struct {
+		assignee   string
+		wantPrefix string
+		wantOK     bool
+	}{
+		{"bd__dog-gcg-session-917c4dd26bd772e2463919029a889e0e", "bd__dog", true},
+		{"gc__implementation-worker-gcg-session-abc123", "gc__implementation-worker", true},
+		{"bd__dog", "", false},                  // plain exact-assignee bead
+		{"", "", false},                         // empty assignee
+		{"-gcg-session-abc", "", false},         // empty prefix rejected
+		{"someone-else-in_progress", "", false}, // no wisp infix
+	}
+	for _, tt := range tests {
+		gotPrefix, gotOK := sessionPrefixFromWispAssignee(tt.assignee)
+		if gotPrefix != tt.wantPrefix || gotOK != tt.wantOK {
+			t.Errorf("sessionPrefixFromWispAssignee(%q) = (%q, %v), want (%q, %v)",
+				tt.assignee, gotPrefix, gotOK, tt.wantPrefix, tt.wantOK)
+		}
+	}
+}

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -169,6 +169,10 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 	}
 	perRigAgentTotals := make(map[string]int, len(cfg.Rigs))
 	perRigAgentsSuspended := make(map[string]int, len(cfg.Rigs))
+	// Active graph-resident work, indexed once per request by agent session
+	// name. On a single-store city this is nil, so every lookup below misses
+	// and the counts stay byte-identical to the provider-only behavior.
+	graphWork := s.graphActiveWorkBySession()
 	for _, a := range cfg.Agents {
 		rigName := workdirutil.ConfiguredRigName(s.state.CityPath(), a, cfg.Rigs)
 		scope := "city"
@@ -188,7 +192,12 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 			sessName := agentSessionName(cityName, ea.qualifiedName, sessTmpl)
 			info, hasInfo := sessionSnapshot.bySessionName[sessName]
 			running := statusProviderRunning(sp, sessName)
-			if running {
+			// An agent whose work runs under a relocated-graph wisp session is
+			// effectively running even when its named provider session is down.
+			// hasGraphWork is always false on a single-store city.
+			_, hasGraphWork := graphWork[sessName]
+			effectiveRunning := running || hasGraphWork
+			if effectiveRunning {
 				rawRunning++
 			}
 			suspended := ea.suspended || a.Suspended || (rigName != "" && suspendedRigs[rigName]) || (hasInfo && info.state == session.StateSuspended)
@@ -200,14 +209,14 @@ func (s *Server) buildStatusBody(ctx context.Context, lite bool) StatusBody {
 				ac.Suspended++
 			case s.state.IsQuarantined(sessName):
 				ac.Quarantined++
-			case running:
+			case effectiveRunning:
 				ac.Running++
 			}
 
 			detail := StatusAgentDetail{
 				QualifiedName: ea.qualifiedName,
 				Scope:         scope,
-				Running:       running,
+				Running:       effectiveRunning,
 				Suspended:     suspended,
 				SessionName:   sessName,
 				GroupName:     groupName,

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -49,6 +49,11 @@ func (s *Server) humaHandleAgentList(ctx context.Context, input *AgentListInput)
 		}
 	}
 
+	// Active graph-resident work, indexed once per request by agent session
+	// name (nil on a single-store city). Computed after the cache-hit return
+	// so a cached response never pays for the graph-store list.
+	graphWork := s.graphActiveWorkBySession()
+
 	var agents []agentResponse
 	for _, a := range cfg.Agents {
 		// Provenance is a property of the declared agent, shared by every
@@ -65,11 +70,17 @@ func (s *Server) humaHandleAgentList(ctx context.Context, input *AgentListInput)
 
 			sessionName := agentSessionName(cityName, ea.qualifiedName, sessTmpl)
 			running := sp.IsRunning(sessionName)
+			// Fold active graph-resident (wisp) work into the running signal so
+			// an agent whose work executes under an agent-agnostic wisp session
+			// is reported running even when its named provider session is down.
+			// hasGraphWork is always false on a single-store city.
+			gw, hasGraphWork := graphWork[sessionName]
+			effectiveRunning := running || hasGraphWork
 
-			if input.Running == "true" && !running {
+			if input.Running == "true" && !effectiveRunning {
 				continue
 			}
-			if input.Running == "false" && running {
+			if input.Running == "false" && effectiveRunning {
 				continue
 			}
 
@@ -95,7 +106,7 @@ func (s *Server) humaHandleAgentList(ctx context.Context, input *AgentListInput)
 			resp := agentResponse{
 				Name:              ea.qualifiedName,
 				Description:       ea.description,
-				Running:           running,
+				Running:           effectiveRunning,
 				Suspended:         suspended,
 				Rig:               ea.rig,
 				Pool:              ea.pool,
@@ -123,8 +134,21 @@ func (s *Server) humaHandleAgentList(ctx context.Context, input *AgentListInput)
 			}
 
 			resp.ActiveBead = s.findActiveBeadForAssignees(ea.rig, sessionID, sessionName, ea.qualifiedName)
+			// A relocated-graph wisp names its assignee after the session, not
+			// the work store, so the work-store lookup above misses it. Fall
+			// back to the graph bead and use its timestamp as the activity
+			// signal so the state reads "working", not "stopped".
+			if hasGraphWork {
+				if resp.ActiveBead == "" {
+					resp.ActiveBead = gw.beadID
+				}
+				if lastActivity == nil {
+					la := gw.lastActivity
+					lastActivity = &la
+				}
+			}
 			quarantined := s.state.IsQuarantined(sessionName)
-			resp.State = computeAgentState(suspended, quarantined, running, resp.ActiveBead, lastActivity)
+			resp.State = computeAgentState(suspended, quarantined, effectiveRunning, resp.ActiveBead, lastActivity)
 
 			if wantPeek && running {
 				if output, err := sp.Peek(sessionName, 5); err == nil {
@@ -186,6 +210,11 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 
 	sessionName := agentSessionName(cityName, name, cfg.Workspace.SessionTemplate)
 	running := sp.IsRunning(sessionName)
+	// Fold active graph-resident (wisp) work into the running signal so a
+	// graph-working agent reports running even when its named provider session
+	// is down. hasGraphWork is always false on a single-store city.
+	gw, hasGraphWork := s.graphActiveWorkBySession()[sessionName]
+	effectiveRunning := running || hasGraphWork
 
 	suspended := agentCfg.Suspended
 	if v, err := sp.GetMeta(sessionName, "suspended"); err == nil && v == "true" {
@@ -215,7 +244,7 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 	resp := agentResponse{
 		Name:              name,
 		Description:       agentCfg.Description,
-		Running:           running,
+		Running:           effectiveRunning,
 		Suspended:         suspended,
 		Rig:               agentCfg.Dir,
 		Provider:          provider,
@@ -245,8 +274,21 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 	}
 
 	resp.ActiveBead = s.findLiveActiveBeadForAssignees(agentCfg.Dir, sessionID, sessionName, name)
+	// A relocated-graph wisp names its assignee after the session, not the work
+	// store, so the work-store lookup above misses it. Fall back to the graph
+	// bead and use its timestamp as the activity signal so the state reads
+	// "working", not "stopped".
+	if hasGraphWork {
+		if resp.ActiveBead == "" {
+			resp.ActiveBead = gw.beadID
+		}
+		if lastActivity == nil {
+			la := gw.lastActivity
+			lastActivity = &la
+		}
+	}
 	quarantined := s.state.IsQuarantined(sessionName)
-	resp.State = computeAgentState(suspended, quarantined, running, resp.ActiveBead, lastActivity)
+	resp.State = computeAgentState(suspended, quarantined, effectiveRunning, resp.ActiveBead, lastActivity)
 
 	if running && provider == "claude" && canAttributeSession(agentCfg, name, cfg, s.state.CityPath()) {
 		s.enrichSessionMeta(&resp, agentCfg, name)


### PR DESCRIPTION
## What

The Agents pane showed "0 running" while the fleet was actively working. On a relocated-graph city (e.g. maintainer-city) agent work runs under agent-agnostic `gcg-session-<uuid>` **wisp** sessions, so `statusProviderRunning` — which probes the runtime for a session named exactly for the config agent (`bd__dog`) — never matches, and `findActiveBeadForAssignees` fans out over the **work stores only**, never the relocated graph store. So every agent read `stopped` / `running:0` even while its wisp actively executed its graph.v2 work. The only link from work→agent is the graph bead's `assignee`, which has the form `<sessionName>-gcg-session-<uuid>`.

## Change

Adds a graph-store leg (`graphActiveWorkBySession`) that lists the relocated graph store's in-progress beads **once per request** and attributes each to an agent by the session-name prefix embedded in the wisp `assignee` (split on `-gcg-session-`, which is exactly `agent.SessionNameFor(...)`). An agent with active graph-resident work is folded into the running signal (`effectiveRunning := running || hasGraphWork`) across the status count, the `/v0/agents` list + detail, and `computeAgentState` — so it reads `working` (with the bead's activity time) and is counted in `agents.running`.

Guarded exactly like the other relocated-graph legs (`graphStore != nil && graphStore != CityBeadStore()`): on a single-store city the map is nil, every lookup misses, and the read path is **byte-identical** to before — `TestGraphResidentSingleStoreByteIdentical` seeds the same wisp bead into the shared city store and asserts the agent stays `stopped`/uncounted. `computeAgentState`'s signature is unchanged; `ListQuery` gains no prefix field. No wire/OpenAPI impact (`TestOpenAPISpecInSync` passes; codegen produced no diff).

## Tests

`internal/api/handler_agents_graph_work_test.go` — working-counted, single-store-inert, negative (no match), no-double-count, and the assignee-splitter unit. The assignee format was confirmed against the live relocated graph store (`bd__dog`, `gc__run-operator`, `gc__implementation-reviewer`, … — each `SanitizeQualifiedNameForSession(qualifiedName)`). Full `internal/api` suite green (91s); `go vet` + `gofmt` clean.

## Context

Part of a plan to durably fix + gate the dashboard projection. Sibling PRs: run-view staleness #5393, projection gate #5399. This is the agents-pane graph-read slice (gap N15 in the graph-read-gap analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
