### PR TITLE
Reconcile file backup remotes after Dolt compaction

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -428,6 +428,7 @@ lock_pid_path="$lock_dir/pid"
 lock_cmd_path="$lock_dir/cmd"
 pending_gc_dir="$PACK_STATE_DIR/compact-pending-gc"
 pending_push_dir="$PACK_STATE_DIR/compact-pending-push"
+pending_push_backup_dir="$PACK_STATE_DIR/compact-pending-push-backup"
 quarantine_dir="$PACK_STATE_DIR/compact-quarantine"
 
 # DB discovery uses rig metadata.json files first (authoritative), with a
@@ -875,6 +876,28 @@ single_remote_name() {
     "SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"
 }
 
+# list_remotes emits one "name<TAB>url" line per configured remote, sorted by
+# name. The only current consumer is backup_remotes' scheme filter.
+list_remotes() {
+  db="$1"
+  out_tmp=$(mktemp)
+  err_tmp=$(mktemp)
+  if ! dolt_query "$db" "SELECT name, url FROM dolt_remotes ORDER BY name" > "$out_tmp" 2>"$err_tmp"; then
+    printf 'compact: db=%s remote listing probe failed\n' "$db" >&2
+    emit_error_file "$db" "$err_tmp"
+    rm -f "$out_tmp" "$err_tmp"
+    return 1
+  fi
+  awk 'NR>2 && /^\|/ {
+    line=$0
+    gsub(/^\| */, "", line)
+    gsub(/ *\|$/, "", line)
+    n=split(line, parts, /[ \t]*\|[ \t]*/)
+    if (n>=2) print parts[1] "\t" parts[2]
+  }' "$out_tmp"
+  rm -f "$out_tmp" "$err_tmp"
+}
+
 select_remote() {
   db="$1"
 
@@ -915,6 +938,31 @@ select_remote() {
   printf 'compact: db=%s multiple remotes found without origin; set GC_DOLT_COMPACT_REMOTE — fail\n' \
     "$db" >&2
   return 1
+}
+
+# backup_remotes emits the name of every configured remote that is a local
+# file:// path other than the authoritative remote — the set that
+# reconcile_backup_remotes fetches and pushes alongside the authoritative
+# push. Never matches by literal remote name; a remote qualifies purely by
+# scheme and by not being the authoritative pick.
+backup_remotes() {
+  db="$1"
+  authoritative="$2"
+  remotes_tmp=$(mktemp)
+  if ! list_remotes "$db" > "$remotes_tmp"; then
+    rm -f "$remotes_tmp"
+    return 1
+  fi
+  while read -r name url; do
+    [ -n "$name" ] || continue
+    [ "$name" = "$authoritative" ] && continue
+    case "$url" in
+      file://*)
+        printf '%s\n' "$name"
+        ;;
+    esac
+  done < "$remotes_tmp"
+  rm -f "$remotes_tmp"
 }
 
 fetch_remote() {
@@ -1624,7 +1672,7 @@ write_pending_push_marker() {
   local_branch="${7:-main}"
   remote_branch="${8:-$local_branch}"
 
-  write_compact_marker "$pending_push_dir" "$db" "$reason" \
+  write_compact_marker "${push_marker_dir:-$pending_push_dir}" "${push_marker_key:-$db}" "$reason" \
     "remote=$remote" \
     "expected_remote_head=$expected_remote_head" \
     "expected_remote_head_verified=$expected_remote_head_verified" \
@@ -1853,6 +1901,8 @@ push_remote_after_compaction() {
   compacted_from_head="${6:-}"
   local_branch="${7:-main}"
   remote_branch="${8:-$local_branch}"
+  push_marker_dir="${9:-$pending_push_dir}"
+  push_marker_key="${10:-$db}"
   [ -n "$remote" ] || return 0
   valid_branch_name "$local_branch" || {
     printf 'compact: db=%s invalid local branch=%s before remote push\n' "$db" "$local_branch" >&2
@@ -1990,8 +2040,41 @@ push_remote_after_compaction() {
     return 0
   fi
   rm -f "$push_err_tmp"
-  clear_compact_marker "$pending_push_dir" "$db"
+  clear_compact_marker "${push_marker_dir:-$pending_push_dir}" "${push_marker_key:-$db}"
   printf 'compact: db=%s remote=%s pushed compacted %s\n' "$db" "$remote" "$remote_branch"
+  return 0
+}
+
+# reconcile_backup_remotes pushes the compacted database to every file://
+# backup remote (backup_remotes), reusing push_remote_after_compaction's
+# fetch/verify/push protocol unchanged for each. Each backup remote gets its
+# own compact-pending-push-backup marker, namespaced by "$db.$name" so a
+# failure on one backup remote never collides with the authoritative push's
+# marker or another backup remote's marker. Always returns success: a backup
+# remote is a redundancy measure, never a condition the authoritative push
+# depends on.
+reconcile_backup_remotes() {
+  db="$1"
+  authoritative="$2"
+  compacted_from_head="$3"
+  local_branch="${4:-main}"
+  remote_branch="${5:-$local_branch}"
+
+  backup_tmp=$(mktemp)
+  if ! backup_remotes "$db" "$authoritative" > "$backup_tmp"; then
+    rm -f "$backup_tmp"
+    return 0
+  fi
+  while read -r name; do
+    [ -n "$name" ] || continue
+    if ! valid_remote_name "$name"; then
+      printf 'compact: db=%s backup remote name=%s invalid — skipping\n' "$db" "$name" >&2
+      continue
+    fi
+    push_remote_after_compaction "$db" "$name" "" 0 "initial" "$compacted_from_head" "$local_branch" "$remote_branch" \
+      "$pending_push_backup_dir" "$db.$name" || true
+  done < "$backup_tmp"
+  rm -f "$backup_tmp"
   return 0
 }
 
@@ -2811,8 +2894,12 @@ flatten_database() {
   if run_full_gc "$db" "flatten ok commits=$count->${after_count:-?} but" \
     "commits=$count->${after_count:-?}" "$start"; then
     clear_compact_marker "$pending_gc_dir" "$db"
-    push_remote_after_compaction "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "initial" "$compacted_from_head" "$local_branch" "$remote_branch"
-    return $?
+    primary_push_rc=0
+    push_remote_after_compaction "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "initial" "$compacted_from_head" "$local_branch" "$remote_branch" || primary_push_rc=$?
+    if [ -n "$remote" ]; then
+      reconcile_backup_remotes "$db" "$remote" "$compacted_from_head" "$local_branch" "$remote_branch" || true
+    fi
+    return "$primary_push_rc"
   fi
   write_compact_marker "$pending_gc_dir" "$db" "flatten succeeded but full GC failed" \
     "remote=$remote" "expected_remote_head=$expected_remote_head" \

--- a/examples/bd/dolt/compact_backup_remotes_test.go
+++ b/examples/bd/dolt/compact_backup_remotes_test.go
@@ -1,0 +1,113 @@
+package dolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin asserts that a
+// file:// backup remote gets fetched and pushed using the same
+// push_remote_after_compaction protocol as the authoritative remote, right
+// alongside the origin push, with no separate opt-in required.
+func TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	out, err := fixture.run(t, "backup_remote_reconcile", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact should succeed with a reconcilable file:// backup remote: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "DOLT_FETCH('backup')") {
+		t.Fatalf("file:// backup remote must be fetched during compaction:\n%s", log)
+	}
+	if !strings.Contains(log, "DOLT_PUSH('--force', '--set-upstream', 'backup', 'main')") {
+		t.Fatalf("file:// backup remote must be pushed using the same protocol as origin:\n%s", log)
+	}
+
+	primaryMarker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(primaryMarker); !os.IsNotExist(err) {
+		t.Fatalf("origin push succeeded; must not leave a pending-push marker (stat err=%v)", err)
+	}
+	backupMarker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push-backup", "beads.backup")
+	if _, err := os.Stat(backupMarker); !os.IsNotExist(err) {
+		t.Fatalf("backup push succeeded; must not leave a backup pending-push marker (stat err=%v)", err)
+	}
+}
+
+// TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush asserts that a
+// failed push to a file:// backup remote is deferred into its own
+// compact-pending-push-backup marker, namespaced separately from the
+// authoritative remote's compact-pending-push marker, and never blocks or
+// fails the authoritative push.
+func TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	out, err := fixture.run(t, "backup_remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("a failed backup push must not fail the overall compact run: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") {
+		t.Fatalf("authoritative remote must still be pushed when the backup push fails:\n%s", log)
+	}
+
+	primaryMarker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(primaryMarker); !os.IsNotExist(err) {
+		t.Fatalf("origin push succeeded; a failing backup push must not create a primary pending-push marker (stat err=%v)", err)
+	}
+
+	backupMarker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push-backup", "beads.backup")
+	if _, err := os.Stat(backupMarker); err != nil {
+		t.Fatalf("failed backup push must be deferred into a compact-pending-push-backup marker: %v\n%s", err, out)
+	}
+	if remote := compactMarkerValue(t, backupMarker, "remote"); remote != "backup" {
+		t.Fatalf("backup marker must record remote=backup, got %q", remote)
+	}
+}
+
+// TestCompactScriptExcludesNonFileRemotesAndAuthoritativeFromBackupReconciliation
+// asserts that backup reconciliation only ever targets file:// remotes other
+// than the authoritative remote: a non-file:// remote (e.g. a second hosted
+// mirror) is never fetched or pushed as a backup, and the authoritative
+// remote is never reconciled a second time against itself.
+func TestCompactScriptExcludesNonFileRemotesAndAuthoritativeFromBackupReconciliation(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	out, err := fixture.run(t, "backup_remote_filters_non_file_and_authoritative", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact should succeed with a mixed-scheme remote set: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "DOLT_FETCH('backup')") {
+		t.Fatalf("file:// backup remote must still be fetched:\n%s", log)
+	}
+	if !strings.Contains(log, "DOLT_PUSH('--force', '--set-upstream', 'backup', 'main')") {
+		t.Fatalf("file:// backup remote must still be pushed:\n%s", log)
+	}
+	if strings.Contains(log, "mirror") {
+		t.Fatalf("non-file:// remote must never be fetched or pushed as a backup:\n%s", log)
+	}
+	if got := strings.Count(log, "DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"); got != 1 {
+		t.Fatalf("authoritative remote must be pushed exactly once (as primary, not reconciled again as a backup), got %d:\n%s", got, log)
+	}
+}

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -445,6 +445,16 @@ print_cells() {
   done
   printf '+-------+\n'
 }
+print_remote_rows() {
+  printf '+------+-----+\n'
+  printf '| name | url |\n'
+  printf '+------+-----+\n'
+  while [ "$#" -ge 2 ]; do
+    printf '| %%s | %%s |\n' "$1" "$2"
+    shift 2
+  done
+  printf '+------+-----+\n'
+}
 current_head() {
   if [ "$mode" = "head_changes_before_flatten" ]; then
     calls_file="$state_file.head-calls"
@@ -497,7 +507,7 @@ set_hash() {
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin|backup_remote_reconcile|backup_remote_push_failure|backup_remote_filters_non_file_and_authoritative)
         print_cell 1
         ;;
       *)
@@ -528,6 +538,12 @@ case "$query" in
       explicit_backup_remote)
         print_cell 1
         ;;
+      backup_remote_reconcile|backup_remote_push_failure)
+        print_cell 2
+        ;;
+      backup_remote_filters_non_file_and_authoritative)
+        print_cell 3
+        ;;
       *)
         print_cell 0
         ;;
@@ -544,6 +560,20 @@ case "$query" in
         ;;
       *)
         print_cell ""
+        ;;
+    esac
+    exit 0
+    ;;
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
+    case "$mode" in
+      backup_remote_reconcile|backup_remote_push_failure)
+        print_remote_rows origin "https://example.test/beads" backup "file:///data/backup/beads"
+        ;;
+      backup_remote_filters_non_file_and_authoritative)
+        print_remote_rows backup "file:///data/backup/beads" mirror "https://mirror.test/beads" origin "https://example.test/beads"
+        ;;
+      *)
+        print_remote_rows
         ;;
     esac
     exit 0
@@ -1146,6 +1176,10 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'backup', 'main')"*)
+    if [ "$mode" = "backup_remote_push_failure" ]; then
+      printf 'push unavailable\n' >&2
+      exit 53
+    fi
     exit 0
     ;;
 esac

--- a/release-gates/ga-f8it32-compaction-backup-remotes-gate.md
+++ b/release-gates/ga-f8it32-compaction-backup-remotes-gate.md
@@ -1,0 +1,168 @@
+# Release gate: ga-f8it32 — compaction backup-remote reconciliation
+
+**Verdict:** **FAIL — WAIVED BY MAYOR**
+
+**Evaluated:** 2026-08-18 (America/Los_Angeles)
+
+**Deploy bead:** `ga-f8it32`
+
+**Build bead:** `ga-s52yku`
+
+**Review bead:** `ga-kiapum`
+
+**Reviewed commit:** `f590515412a08fa320876422786e6dac775a9849`
+
+**Base:** `origin/main@a565081fb87c13de8366594ad40ddfd731469539`
+
+**Deploy mode:** remote (`origin` and `fork` are GitHub remotes)
+
+**Deploy branch:** `deploy/ga-f8it32-gate`
+
+The original technical gate remains a failure. Criterion 3 failed because two
+non-diff-owned test failures did not reproduce in the same tests on the current
+base, so the release-gate attribution policy did not permit them to be treated
+as pre-existing failures. The Mayor's bead-specific 2026-08-18 ruling, recorded
+verbatim in `ga-f8it32`, explicitly authorizes this deploy to proceed without
+rewriting that result as green.
+
+`docs/PROJECT_MANIFEST.md` is absent from both this checkout and
+`origin/main`; this record evaluates the active seven release criteria from
+the deployer contract and the test commands documented in `TESTING.md`.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-kiapum` records `REVIEW VERDICT: PASS` for the exact reviewed commit. |
+| 2 | Acceptance criteria met | PASS | The diff adds a scheme-based `file://` backup-remote selector that excludes the authoritative remote, a separate `compact-pending-push-backup` marker namespace keyed by database and remote, and `reconcile_backup_remotes`, which reuses `push_remote_after_compaction`. Backup failures are isolated from the authoritative push. `run.sh` contains no hardcoded `usb` role/name. Three focused behavioral tests pass. |
+| 3 | Tests pass | **FAIL — WAIVED** | The focused diff-owned tests and the complete affected package pass, but the documented broad local sweep has two failures that cannot meet the mandatory pre-existing-failure attribution clause. The Mayor explicitly waived this failed criterion for `ga-f8it32`; the original counts and failures remain recorded below. |
+| 4 | No high-severity review findings open | PASS | Reviewer recorded no blocking or HIGH findings. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty at the reviewed commit immediately before this gate file was written. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --messages origin/main f590515412a08fa320876422786e6dac775a9849` exited 0 and produced tree `8726a41c432e0fabf14824e46ec7a4c227f0b0c1`. Merge base: `6fbd6bdaa260ca98fece2156df77d40204b9fc23`; base is one commit ahead and the feature is two commits ahead. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | Both commits and all three changed files concern one subsystem and behavior: Dolt compaction reconciliation for local backup remotes. |
+
+## Pre-flight
+
+The reviewed commit resolves to a commit object at the full SHA above.
+`gh api repos/gastownhall/gascity/commits/<reviewed-sha>/pulls` returned no
+associated pull requests, so the target has not already merged and is not a
+closed/superseded PR.
+
+## Criterion 3 evidence
+
+The test environment was prepared before execution:
+
+- `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`
+- `TESTCONTAINERS_RYUK_DISABLED=true`
+- cached `dolthub/dolt-sql-server:2.1.7` and related images present
+- CI-pinned Dolt `2.1.7` and official `bd 1.1.0` installed under
+  `/var/tmp/gc-gate-ga-f8it32-tools/bin`
+- `TMPDIR=/var/tmp`; the shared Go build cache was not cleaned or relocated
+
+### Diff-owned tests
+
+Command:
+
+```text
+go test -json -count=1 ./examples/bd/dolt -run '^(TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin|TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush|TestCompactScriptExcludesNonFileRemotesAndAuthoritativeFromBackupReconciliation)$'
+```
+
+Counts: **3 PASS, 0 FAIL, 0 SKIP**.
+
+`diff_tests_executed`:
+
+- `TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin` — PASS
+- `TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush` — PASS
+- `TestCompactScriptExcludesNonFileRemotesAndAuthoritativeFromBackupReconciliation` — PASS
+
+`waiver_ref`: Mayor's 2026-08-18 bead-specific ruling recorded verbatim in
+`ga-f8it32` under "TWO WAIVERS AND A STANDING AUTHORIZATION"; deployer
+notification `gm-wisp-if58ly`.
+
+`skip_justification`: none required; zero tests skipped.
+
+The complete affected package also passed:
+
+```text
+go test -json -count=1 ./examples/bd/dolt
+```
+
+Counts: **355 PASS, 0 FAIL, 0 SKIP**.
+
+### Documented broad sweep
+
+Command: `LOCAL_TEST_JOBS=4 make test-local-full-parallel` with the environment
+above. Candidate log directory: `/var/tmp/gc-local-tests.PczzF8`.
+
+Job counts: **35 PASS, 5 FAIL, 0 SKIP** out of 40 jobs. All six `cmd/gc`
+process shards, all integration-core shards, all integration `cmd/gc` shards,
+both PR REST-smoke shards, and product-metrics passed.
+
+The identical command and environment were rerun at exact base
+`origin/main@a565081fb87c13de8366594ad40ddfd731469539`. Base log directory:
+`/var/tmp/gc-local-tests.0azm2T`.
+
+### Failure attribution
+
+The following candidate failures satisfy all four attribution clauses: they
+are not diff-owned, each has a tracker, the exact test reproduced on the base,
+and their packages have no path overlap with this diff.
+
+- `TestProviderLiveClaudeKindPath` → `ga-fh1flg`; exact base reproduction:
+  `agent_pane_busy` on the live herdr/tmux pane.
+- `TestGetKeyBinding_CapturesDefaultBinding` → `ga-afqddr`; exact base
+  reproduction: expected `next-window`, received an empty binding.
+- `TestGetKeyBinding_CapturesDefaultBindingWithArgs` → `ga-afqddr`; exact base
+  reproduction: expected `choose-tree`, received an empty binding.
+- `TestCleanInstallTutorialPath` → `ga-rsktma`; exact base reproduction:
+  circuit-breaker cleanup text polluted `bd config get issue_prefix` output.
+  This is in the supplementary push/nightly full lane, not the PR REST-smoke
+  lane, but it was still base-verified.
+
+The following failures do **not** satisfy clause 3 (proven pre-existing by an
+exact-test failure on the base), so criterion 3 must fail:
+
+- `TestSQLiteLegacySnapshotSIGKILLAtBoundaries/legacy-claim-release-after`
+  → `ga-5dsf6n`. The candidate timed out after 10 seconds waiting for the
+  SQLite child-protocol line. The exact package/test passed in the base sweep.
+  Clauses 1, 2, and 4 pass; clause 3 fails.
+- `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash`
+  → `ga-lpfjhc`. The candidate encountered the known beads/Dolt dirty-table
+  signature, but this exact test passed in the base recovery shard. A sibling
+  base test reproduced the same environmental signature, which is not a
+  substitute for the policy's exact-test base proof. Clauses 1, 2, and 4 pass;
+  clause 3 fails.
+
+### Policy and static lanes
+
+- `policy_lane: make test-ci-policy` — PASS (runner policy, CI suite coverage,
+  `scripts/cipolicy`, and named static-scope checks)
+- `GOLANGCI_LINT_CACHE=/var/tmp/gc-gate-ga-f8it32-lint-cache LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected` — PASS, 0 issues
+- `make fmt-check-changed` — PASS (`no changed existing Go files`)
+- `go build ./...` — PASS
+- `go vet ./...` — PASS
+- `bash -n examples/bd/dolt/commands/compact/run.sh` — PASS
+- `git diff --check origin/main...f590515412a08fa320876422786e6dac775a9849` — PASS
+
+The first lint attempt used a poisoned shared golangci-lint cache containing
+paths under a deleted `/var/tmp` checkout. The required rerun with a fresh,
+on-disk golangci-lint cache passed with zero findings; no Go cache was cleaned.
+
+## Waiver disposition
+
+The technical gate result is still **FAIL**. The Mayor's 2026-08-18 ruling
+explicitly names `ga-f8it32` as allowed to proceed because the
+`TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash` failure matches
+the `ga-lpfjhc` / gastownhall/beads#4566 dirty-table-during-schema-migration
+signature and this compaction backup-remote diff has no plausible mechanism to
+touch schema migration or store bootstrap. The corroborating occurrence is
+logged on `ga-lpfjhc` with deploy bead `ga-f8it32`, build bead `ga-s52yku`, and
+the failing test name.
+
+The separate
+`TestSQLiteLegacySnapshotSIGKILLAtBoundaries/legacy-claim-release-after`
+failure remains recorded against `ga-5dsf6n`; it is not recast as a passing
+test or folded into the beads#4566 signature. The bead-specific waiver covers
+the failed criterion as recorded and authorizes pushing this isolated deploy
+branch, opening its pull request, and routing merge authority to mayor/mpr. No
+rig agent merges the pull request.


### PR DESCRIPTION
## Summary

- Discover every `file://` backup remote except the authoritative remote after Dolt compaction.
- Reconcile each backup through the existing post-compaction push path with a per-database, per-remote pending marker.
- Preserve the authoritative push return code and isolate backup push failures so they never block the primary result.

## Testing

- [x] Three diff-owned backup-reconciliation tests: 3 PASS, 0 FAIL, 0 SKIP.
- [x] Complete affected package (`./examples/bd/dolt`): 355 PASS, 0 FAIL, 0 SKIP.
- [x] Policy lane, affected lint, formatting, `go build ./...`, `go vet ./...`, shell syntax, and `git diff --check` passed on the reviewed SHA.
- [x] Repository push gate: all 10 fast jobs passed.
- [ ] The retained broad sweep remains red: 35 PASS / 5 FAIL / 0 SKIP jobs. Criterion 3 remains **FAIL — WAIVED** under the Mayor's bead-specific 2026-08-18 ruling recorded on `ga-f8it32`; the original failures and counts are preserved in the gate record.

## Release gate

- Reviewed commit: `f590515412a08fa320876422786e6dac775a9849`
- Review bead: `ga-kiapum` — PASS
- Build bead: `ga-s52yku`
- Deploy bead: `ga-f8it32`
- Gate record: `release-gates/ga-f8it32-compaction-backup-remotes-gate.md`
- Merge authority remains with mayor/mpr; this PR is not self-merged.
