### PR TITLE
Stabilize order-gate and stop-fallback shard tests

### DIFF
--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -534,7 +534,7 @@ func TestCmdStopSupervisorManagedInvalidCityTomlWaitsForControllerStop(t *testin
 	}
 
 	var stdout, stderr lockedBuffer
-	code := cmdStop([]string{cityDir}, &stdout, &stderr, 1*time.Millisecond, false)
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
 	if code != 0 {
 		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
@@ -727,7 +727,7 @@ func TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity(t *testing.T
 	waitForSupervisorControllerStopHook = func(string, time.Duration) error { return nil }
 
 	var stdout, stderr lockedBuffer
-	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, 1*time.Millisecond, false, true)
+	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, 0, false, true)
 	if code != 0 {
 		t.Fatalf("cmdStopJSON() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
@@ -794,7 +794,7 @@ func TestCmdStopJSONReportsUnregisteredTrueWhenSupervisorNotRunning(t *testing.T
 	}
 
 	var stdout, stderr lockedBuffer
-	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, 1*time.Millisecond, false, true)
+	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, 0, false, true)
 	if code != 0 {
 		t.Fatalf("cmdStopJSON() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -534,7 +534,7 @@ func TestCmdStopSupervisorManagedInvalidCityTomlWaitsForControllerStop(t *testin
 	}
 
 	var stdout, stderr lockedBuffer
-	code := cmdStop([]string{cityDir}, &stdout, &stderr, time.Second, false)
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 1*time.Millisecond, false)
 	if code != 0 {
 		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
@@ -727,7 +727,7 @@ func TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity(t *testing.T
 	waitForSupervisorControllerStopHook = func(string, time.Duration) error { return nil }
 
 	var stdout, stderr lockedBuffer
-	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, time.Second, false, true)
+	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, 1*time.Millisecond, false, true)
 	if code != 0 {
 		t.Fatalf("cmdStopJSON() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
@@ -794,7 +794,7 @@ func TestCmdStopJSONReportsUnregisteredTrueWhenSupervisorNotRunning(t *testing.T
 	}
 
 	var stdout, stderr lockedBuffer
-	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, time.Second, false, true)
+	code := cmdStopJSON([]string{cityDir}, &stdout, &stderr, 1*time.Millisecond, false, true)
 	if code != 0 {
 		t.Fatalf("cmdStopJSON() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}

--- a/cmd/gc/order_gate_budget_test.go
+++ b/cmd/gc/order_gate_budget_test.go
@@ -189,11 +189,18 @@ func drainOrderDispatch(t *testing.T, m *memoryOrderDispatcher) {
 
 // barrierCheckScript returns a condition-check shell script for the
 // concurrent-overlap fixtures below. Every check registers itself in liveDir
-// (a mktemp'd file, removed on exit via trap) and then waits up to ~1s (50 *
-// 20ms polls) to observe at least 2 registrations before exiting 0; it always
-// exits normally so the trap unregisters. A nonzero startDelay simulates a
-// check whose own subprocess spawn was delayed — host contention, a
-// straggler — before it ever gets to register.
+// (a mktemp'd file, removed on exit via trap) and then holds that
+// registration for the full ~1s window (50 * 20ms polls), regardless of when
+// it personally observes a sibling: a seen flag latches on any poll that
+// finds >= 2 registrations, and only that flag — checked once the window is
+// over — decides exit 0 vs exit 1. It always exits normally so the trap
+// unregisters. Holding to the end of the window (rather than exiting the
+// instant a sibling is seen) makes overlap detection independent of which
+// pair happens to notice each other first, so a straggler that starts late
+// but still within the window is guaranteed to be seen by, and see, whoever
+// is still holding. A nonzero startDelay simulates a check whose own
+// subprocess spawn was delayed — host contention, a straggler — before it
+// ever gets to register.
 func barrierCheckScript(liveDir, ranMarker string, startDelay time.Duration) string {
 	var delay string
 	if startDelay > 0 {
@@ -201,7 +208,8 @@ func barrierCheckScript(liveDir, ranMarker string, startDelay time.Duration) str
 	}
 	return fmt.Sprintf(
 		`%[3]smkdir -p %[1]s; echo . >> %[2]s; f=$(mktemp %[1]s/w.XXXXXX); trap 'rm -f "$f"' EXIT; `+
-			`i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge 2 ]; then exit 0; fi; sleep 0.02; i=$((i+1)); done; exit 1`,
+			`seen=0; i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge 2 ]; then seen=1; fi; sleep 0.02; i=$((i+1)); done; `+
+			`if [ "$seen" -eq 1 ]; then exit 0; else exit 1; fi`,
 		liveDir, ranMarker, delay)
 }
 

--- a/cmd/gc/order_gate_budget_test.go
+++ b/cmd/gc/order_gate_budget_test.go
@@ -187,6 +187,24 @@ func drainOrderDispatch(t *testing.T, m *memoryOrderDispatcher) {
 	}
 }
 
+// barrierCheckScript returns a condition-check shell script for the
+// concurrent-overlap fixtures below. Every check registers itself in liveDir
+// (a mktemp'd file, removed on exit via trap) and then waits up to ~1s (50 *
+// 20ms polls) to observe at least 2 registrations before exiting 0; it always
+// exits normally so the trap unregisters. A nonzero startDelay simulates a
+// check whose own subprocess spawn was delayed — host contention, a
+// straggler — before it ever gets to register.
+func barrierCheckScript(liveDir, ranMarker string, startDelay time.Duration) string {
+	var delay string
+	if startDelay > 0 {
+		delay = fmt.Sprintf("sleep %.3f; ", startDelay.Seconds())
+	}
+	return fmt.Sprintf(
+		`%[3]smkdir -p %[1]s; echo . >> %[2]s; f=$(mktemp %[1]s/w.XXXXXX); trap 'rm -f "$f"' EXIT; `+
+			`i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge 2 ]; then exit 0; fi; sleep 0.02; i=$((i+1)); done; exit 1`,
+		liveDir, ranMarker, delay)
+}
+
 // TestConditionChecksRunConcurrentlyWithinTheirCap is the parallel half of the
 // leg, and it proves real overlap rather than measuring wall clock.
 //
@@ -218,12 +236,7 @@ func TestConditionChecksRunConcurrentlyWithinTheirCap(t *testing.T) {
 			cityPath, cfg, _ := newExecOrderFixture(t)
 			liveDir := filepath.Join(t.TempDir(), "live")
 			ranMarker := filepath.Join(t.TempDir(), "ran")
-			// Register, then wait up to ~1s to see a sibling registration. Exit
-			// 0 only on overlap; always exit normally so the trap unregisters.
-			check := fmt.Sprintf(
-				`mkdir -p %[1]s; echo . >> %[3]s; f=$(mktemp %[1]s/w.XXXXXX); trap 'rm -f "$f"' EXIT; `+
-					`i=0; while [ $i -lt 50 ]; do if [ "$(ls %[1]s | wc -l)" -ge 2 ]; then exit 0; fi; sleep 0.02; i=$((i+1)); done; exit 1`,
-				liveDir, wave, ranMarker)
+			check := barrierCheckScript(liveDir, ranMarker, 0)
 
 			aa := make([]orders.Order, 0, wave)
 			for i := range wave {
@@ -259,6 +272,76 @@ func TestConditionChecksRunConcurrentlyWithinTheirCap(t *testing.T) {
 				t.Fatalf("%d of %d checks ran; the fire count above is not measuring overlap", got, wave)
 			}
 		})
+	}
+}
+
+// TestConditionCheckOverlapSurvivesAStragglerStart is the deterministic
+// regression for ga-v9gt79: under real sharded process load,
+// TestConditionChecksRunConcurrentlyWithinTheirCap's cap-admits-the-wave arm
+// flaked 3-of-4 instead of 4-of-4. The cause is not a Go-level dispatch bug —
+// order_dispatch.go's goroutine fan-out and triggers.go's subprocess
+// execution both fire all four checks concurrently, unconditionally — it is
+// that the OLD check script unregisters itself the instant it personally
+// sees a sibling, so the real overlap tolerance was bounded by however fast
+// the fastest pair happened to notice each other, not by the ~1s poll
+// budget. Under host contention a straggler's subprocess spawn can be
+// delayed past that effective window, so by the time it registers, its
+// siblings have already succeeded and vanished.
+//
+// This reproduces that shape on demand, without depending on real,
+// non-deterministic host contention: three checks start immediately and one
+// starts after an artificial delay comfortably inside the ~1s window. A
+// check that holds its registration for the full window — rather than
+// exiting the instant it personally detects a sibling — must still be seen
+// by a late-starting sibling, so all four fire regardless of which pair
+// notices which first.
+func TestConditionCheckOverlapSurvivesAStragglerStart(t *testing.T) {
+	const wave = 4
+	prev := orderConditionCheckConcurrency
+	orderConditionCheckConcurrency = wave
+	t.Cleanup(func() { orderConditionCheckConcurrency = prev })
+
+	cityPath, cfg, _ := newExecOrderFixture(t)
+	liveDir := filepath.Join(t.TempDir(), "live")
+	ranMarker := filepath.Join(t.TempDir(), "ran")
+
+	const stragglerDelay = 300 * time.Millisecond
+	aa := make([]orders.Order, 0, wave)
+	for i := range wave {
+		var delay time.Duration
+		if i == wave-1 {
+			delay = stragglerDelay
+		}
+		aa = append(aa, orders.Order{
+			Name:         fmt.Sprintf("straggler-order-%d", i),
+			Exec:         "true",
+			Trigger:      "condition",
+			Check:        barrierCheckScript(liveDir, ranMarker, delay),
+			CheckTimeout: "10s",
+		})
+	}
+	store := beads.NewMemStore()
+	var rec memRecorder
+	m := newSplitOrderDispatcher(t, cityPath, cfg, aa, store, beads.NewMemStore(), &rec)
+	m.maxDispatchesPerTick = 0
+	m.execRun = func(context.Context, string, string, []string) ([]byte, error) { return nil, nil }
+
+	m.dispatch(context.Background(), cityPath, time.Now())
+	drainOrderDispatch(t, m)
+
+	if got := len(trackingBeads(t, m.ordersStoreFor(store), labelOrderTracking)); got != wave {
+		t.Fatalf("%d of %d orders fired with a %s straggler start: a check must hold its registration for the "+
+			"full overlap window so a late-starting sibling still sees it, not just whichever pair happened to "+
+			"notice each other first", got, wave, stragglerDelay)
+	}
+	// Control: every check DID run, so a shortfall above is "no overlap" and
+	// not "the straggler's order never got checked".
+	data, err := os.ReadFile(ranMarker)
+	if err != nil {
+		t.Fatalf("no check ran at all: %v", err)
+	}
+	if got := strings.Count(string(data), "."); got != wave {
+		t.Fatalf("%d of %d checks ran; the fire count above is not measuring overlap", got, wave)
 	}
 }
 

--- a/release-gates/ga-b8i2nl-cmd-gc-shard-flake-fixes-gate.md
+++ b/release-gates/ga-b8i2nl-cmd-gc-shard-flake-fixes-gate.md
@@ -1,0 +1,157 @@
+# Release gate: ga-b8i2nl — cmd/gc shard flake fixes
+
+**Verdict:** **FAIL — WAIVED BY MAYOR**
+
+**Evaluated:** 2026-08-18 (America/Los_Angeles)
+
+**Deploy bead:** `ga-b8i2nl`
+
+**Build bead:** `ga-agtlhi`
+
+**Review bead:** `ga-g1h0pq`
+
+**Reviewed commit:** `e4b2d4f1a9aeb3c959ac342de157667e506efac7`
+
+**Base:** `origin/main@a565081fb87c13de8366594ad40ddfd731469539`
+
+**Deploy mode:** remote (`origin` and `fork` are GitHub remotes)
+
+**Deploy branch:** `deploy/ga-b8i2nl-gate`
+
+The original technical gate remains a failure. Criterion 3 failed on a
+same-package `cmd/gc` process test and two other failures that passed in the
+exact-base comparison, so the release-gate attribution policy did not permit
+them to be treated as pre-existing. The Mayor's bead-specific 2026-08-18
+ruling, recorded verbatim in `ga-b8i2nl`, explicitly authorizes this deploy to
+proceed without rewriting that result as green.
+
+The inherited bead title describes the older deploy lineage. The reviewed
+artifact evaluated here is test-only: order-gate concurrency coverage and the
+stop-fallback timeout correction added while repairing that lineage's gate
+failures.
+
+`docs/PROJECT_MANIFEST.md` is absent from both this checkout and
+`origin/main`; this record evaluates the active seven release criteria from
+the deployer contract and the sharded test commands documented in
+`TESTING.md`.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-g1h0pq` records `REVIEW VERDICT: PASS` for the exact reviewed commit and carries the earlier PASS evidence from `ga-4knhwk`. |
+| 2 | Acceptance criteria met | PASS | The reviewed diff is limited to two `cmd/gc` test files. It preserves the order-gate assertions while making overlap coverage tolerate a deliberately delayed check, and changes three stop-test call sites from a live `time.Second` cap to production's normal `0` timeout path. All 11 changed top-level tests pass. |
+| 3 | Tests pass | **FAIL — WAIVED** | The changed tests and most required lanes pass, but the 40-job full sweep has six failed jobs. Only the two tmux failures and tutorial-path output failure meet all four attribution clauses under the original policy. The Mayor explicitly waived this failed criterion for `ga-b8i2nl`; the original counts and failures remain recorded below. |
+| 4 | No high-severity review findings open | PASS | Reviewer recorded no blocking or HIGH findings. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty at the reviewed commit immediately before this gate file was written. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --messages origin/main <reviewed-sha>` exited 0 and produced tree `df90120dbedfda362a3bc8824ea5b4f4b2190daa`. The lineage is three commits behind and four ahead of current main, but merges without conflict. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | All four lineage commits and both changed files stay within `cmd/gc` test reliability for the same deploy retry. No production behavior or second package is introduced. |
+
+## Pre-flight
+
+The recorded SHA resolves to the full commit above. The GitHub commit-to-PR
+query returned no associated pull requests, so the target has not already
+merged and is not a closed or superseded PR.
+
+## Criterion 3 evidence
+
+The gate used CI-pinned Dolt `2.1.7` and official `bd 1.1.0`, with temporary
+files on `/var/tmp`. The rootless Podman socket and testcontainers environment
+were configured before testing. The shared Go build cache was not cleaned or
+relocated.
+
+### Diff-owned tests
+
+Command:
+
+```text
+go test -json -count=1 -timeout 15m ./cmd/gc -run '^(TestOrderGateReadsScaleWithStoresNotOrders|TestOrderGateIssuesZeroLedgerReadsOnASplitCity|TestOrderGateStillReadsTheLedgerOnASingleStoreCity|TestConditionChecksRunConcurrentlyWithinTheirCap|TestConditionCheckOverlapSurvivesAStragglerStart|TestConditionCheckRunsExactlyOncePerOrderPerTick|TestGateIndexSuppressesDispatchExactlyAsTheLiveGateDid|TestOrderTrackingSweepStillReadsEveryLegTheGateNoLongerDoes|TestCmdStopSupervisorManagedInvalidCityTomlWaitsForControllerStop|TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity|TestCmdStopJSONReportsUnregisteredTrueWhenSupervisorNotRunning)$'
+```
+
+Top-level counts: **11 PASS, 0 FAIL, 0 SKIP**. Five nested table/subtest cases
+also passed.
+
+`diff_tests_executed`:
+
+- `TestOrderGateReadsScaleWithStoresNotOrders` — PASS
+- `TestOrderGateIssuesZeroLedgerReadsOnASplitCity` — PASS
+- `TestOrderGateStillReadsTheLedgerOnASingleStoreCity` — PASS
+- `TestConditionChecksRunConcurrentlyWithinTheirCap` — PASS
+- `TestConditionCheckOverlapSurvivesAStragglerStart` — PASS
+- `TestConditionCheckRunsExactlyOncePerOrderPerTick` — PASS
+- `TestGateIndexSuppressesDispatchExactlyAsTheLiveGateDid` — PASS
+- `TestOrderTrackingSweepStillReadsEveryLegTheGateNoLongerDoes` — PASS
+- `TestCmdStopSupervisorManagedInvalidCityTomlWaitsForControllerStop` — PASS
+- `TestCmdStopJSONReportsUnregisteredTrueForSupervisorManagedCity` — PASS
+- `TestCmdStopJSONReportsUnregisteredTrueWhenSupervisorNotRunning` — PASS
+
+`waiver_ref`: Mayor's 2026-08-18 bead-specific ruling recorded verbatim in
+`ga-b8i2nl`, section 1 ("ga-b8i2nl: WAIVED").
+
+`skip_justification`: none required; zero changed tests skipped.
+
+### Documented full sweep
+
+Command: `LOCAL_TEST_JOBS=4 make test-local-full-parallel`, with the prepared
+container and pinned-tool environment.
+
+Log directory: `/var/tmp/gc-local-tests.fOxz0A`.
+
+Job counts: **34 PASS, 6 FAIL, 0 SKIP** out of 40 jobs.
+
+Five of six `cmd/gc` process shards passed; all six `cmd/gc` integration
+package shards, all four integration-core shards, both PR REST-smoke shards,
+all formula lanes, product-metrics, and static self-tests passed.
+
+### Failure attribution
+
+These failures satisfy all four attribution clauses:
+
+- `TestGetKeyBinding_CapturesDefaultBinding` → `ga-afqddr`; exact base result
+  in `/var/tmp/gc-local-tests.0azm2T`: FAIL with the same empty default binding.
+- `TestGetKeyBinding_CapturesDefaultBindingWithArgs` → `ga-afqddr`; exact base
+  result in `/var/tmp/gc-local-tests.0azm2T`: FAIL with the same empty binding.
+- `TestCleanInstallTutorialPath` → `ga-rsktma`; exact base direct result: FAIL
+  with the same circuit-breaker cleanup text contaminating the expected `tra`
+  prefix. The `test/integration` package does not overlap this diff.
+
+These failures cannot be attributed:
+
+- `TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore` → active
+  fix-deploy tracker `ga-vb82ss`. Candidate result: FAIL because
+  `OpenNativeStorage(rig)` exceeded its schema-initialization deadline. The
+  failing test and this diff are both in package `cmd/gc`, so mandatory clause
+  4 (no package/path overlap) fails regardless of base behavior.
+- `TestSQLiteLegacySnapshotSIGKILLAtBoundaries/legacy-private-recovery-before`
+  → `ga-5dsf6n`. Candidate result: FAIL waiting 10 seconds for the SQLite
+  child-protocol line. Exact base's full unit-core job passed, so clause 3
+  (proven pre-existing) fails; the different subcase that failed in an earlier
+  candidate does not repair that proof.
+- `TestHumaBinary_SessionMessageAsync` → `ga-lpfjhc`. Candidate result: FAIL
+  during fixture-city initialization with the tracked beads#4566 dirty-table
+  migration signature. The same exact-base full sweep did not fail this test,
+  so clause 3 fails.
+
+### Policy and static lanes
+
+- `policy_lane: make test-ci-policy` — PASS
+- `GOLANGCI_LINT_CACHE=/var/tmp/gc-gate-ga-b8i2nl-lint-cache LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected` — PASS, 0 issues; conservatively expanded to the full repository because the reviewed lineage predates an upstream-deleted dashboard asset
+- `make fmt-check-changed` — PASS (`no changed existing Go files`)
+- `go build ./cmd/gc/...` — PASS
+- `go vet ./cmd/gc/...` — PASS
+- `git diff --check origin/main...HEAD` — PASS
+
+## Waiver disposition
+
+The technical gate result is still **FAIL**. The Mayor's 2026-08-18 ruling
+explicitly names `ga-b8i2nl` as allowed to proceed because every failure is
+mapped to a specific tracker: `ga-afqddr`, `ga-rsktma`, `ga-vb82ss`,
+`ga-5dsf6n`, or `ga-lpfjhc`. This test-only diff changes order-gate coverage
+and three stop-test timeout arguments; it has no plausible mechanism to reach
+tmux bindings, tutorial-path installation, Dolt teardown/schema
+initialization, SQLite SIGKILL boundaries, or async session messaging. No
+failure is in a file or subsystem this diff changes.
+
+The bead-specific waiver supersedes the earlier no-push disposition and
+authorizes pushing this isolated deploy branch, opening its pull request, and
+routing merge authority to mayor/mpr. No rig agent merges the pull request.


### PR DESCRIPTION
## Summary

- Preserve order-gate concurrency coverage while tolerating the deliberately delayed straggler start used by the test.
- Switch three stop-fallback tests from a live one-second cap to production's normal config-derived `0` timeout path.
- Keep this lineage test-only; no production behavior changes.

## Testing

- [x] Eleven diff-owned top-level tests: 11 PASS, 0 FAIL, 0 SKIP; five nested cases also passed.
- [x] Full `cmd/gc` package regression: 9,021 PASS, 0 FAIL, 99 environment-gated SKIP.
- [x] Policy, full-repository lint, formatting, `go build ./cmd/gc/...`, and `go vet ./cmd/gc/...` passed on the reviewed SHA.
- [x] Repository push gate: all 10 fast jobs passed.
- [ ] The retained broad sweep remains red: 34 PASS / 6 FAIL / 0 SKIP jobs. Criterion 3 remains **FAIL — WAIVED** under the Mayor's explicit 2026-08-18 ruling recorded on `ga-b8i2nl`; every original failure and tracker remains in the gate artifact.

## Release gate

- Reviewed commit: `e4b2d4f1a9aeb3c959ac342de157667e506efac7`
- Review bead: `ga-g1h0pq` — PASS
- Build bead: `ga-agtlhi`
- Deploy bead: `ga-b8i2nl`
- Gate record: `release-gates/ga-b8i2nl-cmd-gc-shard-flake-fixes-gate.md`
- Merge authority remains with mayor/mpr; this PR is not self-merged.
