### PR TITLE
test(api): pin both rig-path containment passes (ga-qe7qm)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1923,20 +1923,44 @@ func (cs *controllerState) DeleteAgent(name string) error {
 // staying byte-identical. The error wraps configedit.ErrValidation so the async
 // failure mapper renders invalid_request and the sync mapper renders a 4xx rather
 // than a 500.
+// The two passes are separate functions so each can be pinned on its own: a
+// test that only ever calls assertRigPathWithinCity cannot tell which pass
+// rejected, so a pass could rot to a no-op without reddening anything (ga-qe7qm).
 func assertRigPathWithinCity(cityPath, resolved string) error {
-	// Lexical check first: rejects "../" escapes and absolute paths that resolve
-	// to a sibling/parent of the city. Normalize both sides so a symlinked city
-	// ancestor (cityPath raw, resolved already resolveStoreScopeRoot-resolved)
-	// doesn't register as a false-positive escape.
-	normalizedCity := pathutil.NormalizePathForCompare(cityPath)
-	normalizedTarget := pathutil.NormalizePathForCompare(resolved)
-	if err := relWithinCity(normalizedCity, normalizedTarget); err != nil {
+	if err := lexicalContainment(cityPath, resolved); err != nil {
 		return err
 	}
-	// Symlink-aware check: a "../"-free lexical path can still escape through a
-	// symlinked ancestor (e.g. <city>/link -> /outside, then a clone into
-	// link/rig). Canonicalize the city root and the nearest EXISTING ancestor of
-	// the (not-yet-created) target and re-check containment on the real paths.
+	return symlinkAwareContainment(cityPath, resolved)
+}
+
+// lexicalContainment is the first containment pass: it rejects "../" escapes and
+// absolute paths that resolve to a sibling/parent of the city. Both sides are
+// normalized so a symlinked city ancestor (cityPath raw, resolved already
+// resolveStoreScopeRoot-resolved) doesn't register as a false-positive escape.
+//
+// pathutil.NormalizePathForCompare resolves symlinks, so this pass already
+// rejects a symlinked-ancestor escape on its own; it is not purely lexical in
+// effect. What it does NOT do is fail closed when a component cannot be
+// canonicalized — NormalizePathForCompare swallows every EvalSymlinks error and
+// falls back to the lexical form. symlinkAwareContainment covers that gap.
+func lexicalContainment(cityPath, resolved string) error {
+	return relWithinCity(
+		pathutil.NormalizePathForCompare(cityPath),
+		pathutil.NormalizePathForCompare(resolved),
+	)
+}
+
+// symlinkAwareContainment is the second containment pass. It canonicalizes the
+// city root and the nearest EXISTING ancestor of the (not-yet-created) target
+// and re-checks containment on the real paths.
+//
+// It is a genuine second opinion, not decoration: unlike lexicalContainment it
+// fails CLOSED when a path component cannot be canonicalized at all (a symlink
+// loop, a non-directory component, an unsearchable ancestor). In those cases
+// NormalizePathForCompare silently synthesizes an in-city-looking path and the
+// first pass accepts; this pass refuses. TestSymlinkAwareContainmentIsLoadBearing
+// pins exactly those inputs.
+func symlinkAwareContainment(cityPath, resolved string) error {
 	realCity, err := filepath.EvalSymlinks(cityPath)
 	if err != nil {
 		realCity = filepath.Clean(cityPath)

--- a/cmd/gc/api_state_rig_path_containment_test.go
+++ b/cmd/gc/api_state_rig_path_containment_test.go
@@ -104,24 +104,36 @@ func TestBothContainmentPassesRejectSymlinkEscapeIndependently(t *testing.T) {
 func TestSymlinkAwareContainmentIsLoadBearing(t *testing.T) {
 	cityDir := t.TempDir()
 
-	// A symlink loop: EvalSymlinks returns ELOOP, which is not os.IsNotExist.
-	loop := filepath.Join(cityDir, "loop")
-	if err := os.Symlink(loop, loop); err != nil {
-		t.Skipf("symlinks unsupported on this platform: %v", err)
+	type loadBearingCase struct {
+		name string
+		path string
 	}
-	// A regular file used as a directory component: ENOTDIR, also not IsNotExist.
+
+	// A regular file used as a directory component: EvalSymlinks returns ENOTDIR,
+	// which is not os.IsNotExist. This arm needs no symlink, so keep it out from
+	// under the symlink-support skip below — it exercises a distinct EvalSymlinks
+	// error class and must run on every platform.
 	if err := os.WriteFile(filepath.Join(cityDir, "plainfile"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	for _, tc := range []struct {
-		name string
-		path string
-	}{
-		{"symlink loop", filepath.Join(cityDir, "loop")},
-		{"path under a symlink loop", filepath.Join(cityDir, "loop", "rig")},
+	cases := []loadBearingCase{
 		{"path under a regular file", filepath.Join(cityDir, "plainfile", "rig")},
-	} {
+	}
+
+	// A symlink loop: EvalSymlinks returns ELOOP, also not os.IsNotExist. These
+	// arms need symlink support, so add them only when it is available instead of
+	// skipping the whole test (which would also drop the ENOTDIR arm above).
+	loop := filepath.Join(cityDir, "loop")
+	if err := os.Symlink(loop, loop); err != nil {
+		t.Logf("symlinks unsupported on this platform, exercising only the ENOTDIR arm: %v", err)
+	} else {
+		cases = append(cases,
+			loadBearingCase{"symlink loop", loop},
+			loadBearingCase{"path under a symlink loop", filepath.Join(cityDir, "loop", "rig")},
+		)
+	}
+
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := lexicalContainment(cityDir, tc.path); err != nil {
 				t.Fatalf("precondition: lexicalContainment(%q) = %v, want nil. "+
@@ -245,5 +257,60 @@ func TestProvisionRigFromGitRejectsSymlinkEscape(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(outsideDir, "absent")); !os.IsNotExist(err) {
 		t.Fatalf("ProvisionRigFromGit created %s outside the city: stat err = %v",
 			filepath.Join(outsideDir, "absent"), err)
+	}
+}
+
+// TestTeardownPartialRigRefusesUncanonicalizablePathThroughGlue pins the second
+// containment pass through the production glue on a LOAD-BEARING input — one the
+// first (lexical) pass accepts and only symlinkAwareContainment refuses. The
+// isolation tests above call the two passes directly, and the escape tests above
+// use symlink-escape inputs the FIRST pass already rejects, so none of them would
+// redden if symlinkAwareContainment were dropped from assertRigPathWithinCity.
+// This drives the highest-value destructive caller (TeardownPartialRig fences
+// os.RemoveAll on a CreatedDir read back from a durable, attacker-influenceable-
+// over-time record) with a path-under-a-regular-file target: EvalSymlinks returns
+// ENOTDIR, so NormalizePathForCompare synthesizes an in-city path (first pass
+// accepts) while realPathForContainment fails closed (second pass rejects).
+// Deleting or reordering the symlinkAwareContainment call in assertRigPathWithinCity
+// lets the RemoveAll proceed and reddens this test. No symlink is needed, so it
+// runs on every platform.
+func TestTeardownPartialRigRefusesUncanonicalizablePathThroughGlue(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	// A regular file used as a directory component yields ENOTDIR, which is not
+	// os.IsNotExist, so the first pass accepts the synthesized in-city path and
+	// only the fail-closed second pass rejects it.
+	plainfile := filepath.Join(cityDir, "plainfile")
+	if err := os.WriteFile(plainfile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	createdDir := filepath.Join(cityDir, "plainfile", "rig")
+
+	// Precondition: this pins the second pass only where the FIRST pass accepts.
+	// If normalization ever changed so the lexical pass rejects this input, the
+	// test no longer proves the second pass is load-bearing through the glue.
+	if err := lexicalContainment(cityDir, createdDir); err != nil {
+		t.Fatalf("precondition: lexicalContainment(%q) = %v, want nil", createdDir, err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{Workspace: config.Workspace{Name: "city1"}},
+		runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	err := cs.TeardownPartialRig(context.Background(),
+		api.RigProvisionManifest{RigName: "evil", CreatedDir: createdDir})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("TeardownPartialRig(CreatedDir=%q) err = %v, want ErrValidation: the second "+
+			"containment pass must refuse the RemoveAll on an uncanonicalizable path through the glue", createdDir, err)
+	}
+	// The RemoveAll must have been refused before any side effect: the regular
+	// file the rejected path tunnels through is still present and unmodified.
+	if b, err := os.ReadFile(plainfile); err != nil || string(b) != "x" {
+		t.Fatalf("TeardownPartialRig disturbed the escape target: ReadFile(%q) = %q, %v; want %q, nil",
+			plainfile, b, err, "x")
 	}
 }

--- a/cmd/gc/api_state_rig_path_containment_test.go
+++ b/cmd/gc/api_state_rig_path_containment_test.go
@@ -1,0 +1,249 @@
+package main
+
+// Negative coverage for the city-root containment guard on the API rig-create
+// paths (ga-qe7qm). The pre-existing tests were all POSITIVE: they pinned that
+// an in-city rig under a symlinked city is ACCEPTED, and the only negative
+// (TestControllerStateCreateRigRejectsOutOfCityPath) used "../escape" and a
+// foreign absolute tempdir. Nothing anywhere exercised the symlink-escape
+// rejection, and nothing referenced the second pass at all — neutering it to
+// `return nil` left every selection green.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/configedit"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// escapeLayout builds <root>/city with an escaping symlink <city>/link ->
+// <root>/outside, and an existing <root>/outside/evil. It returns the city dir
+// and the outside dir.
+func escapeLayout(t *testing.T) (cityDir, outsideDir string) {
+	t.Helper()
+	root := t.TempDir()
+	cityDir = filepath.Join(root, "city")
+	outsideDir = filepath.Join(root, "outside")
+	for _, d := range []string{cityDir, filepath.Join(outsideDir, "evil")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(cityDir, "link")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	return cityDir, outsideDir
+}
+
+// TestAssertRigPathWithinCityRejectsSymlinkEscape is the negative the guard
+// never had: a "../"-free path that escapes the city through a symlinked
+// ancestor must be refused, both when the leaf exists (the sync CreateRig
+// shape) and when it does not (the git_url clone shape realPathForContainment
+// was written for).
+func TestAssertRigPathWithinCityRejectsSymlinkEscape(t *testing.T) {
+	cityDir, _ := escapeLayout(t)
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"existing leaf", "link/evil"},
+		{"absent leaf (git_url clone destination)", "link/absent"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := filepath.Join(cityDir, tc.path)
+			if err := assertRigPathWithinCity(cityDir, raw); !errors.Is(err, configedit.ErrValidation) {
+				t.Errorf("assertRigPathWithinCity(raw %q) = %v, want ErrValidation", raw, err)
+			}
+			// The real call sites resolve through resolveStoreScopeRoot first, so
+			// pin that shape too — it is the one an API caller actually reaches.
+			resolved := resolveStoreScopeRoot(cityDir, tc.path)
+			if err := assertRigPathWithinCity(cityDir, resolved); !errors.Is(err, configedit.ErrValidation) {
+				t.Errorf("assertRigPathWithinCity(resolved %q) = %v, want ErrValidation", resolved, err)
+			}
+		})
+	}
+}
+
+// TestBothContainmentPassesRejectSymlinkEscapeIndependently is the control the
+// escape test above needs. assertRigPathWithinCity short-circuits on the first
+// pass, so an end-to-end negative passes even if the second pass is a no-op —
+// that is precisely how the second pass went unpinned. This asserts EACH pass
+// rejects the escape on its own, so neither can rot to `return nil` silently.
+func TestBothContainmentPassesRejectSymlinkEscapeIndependently(t *testing.T) {
+	cityDir, _ := escapeLayout(t)
+
+	for _, leaf := range []string{"link/evil", "link/absent"} {
+		target := resolveStoreScopeRoot(cityDir, leaf)
+		if err := lexicalContainment(cityDir, target); !errors.Is(err, configedit.ErrValidation) {
+			t.Errorf("lexicalContainment(%q) = %v, want ErrValidation "+
+				"(the FIRST pass stopped catching the symlink escape)", leaf, err)
+		}
+		if err := symlinkAwareContainment(cityDir, target); !errors.Is(err, configedit.ErrValidation) {
+			t.Errorf("symlinkAwareContainment(%q) = %v, want ErrValidation "+
+				"(the SECOND pass stopped catching the symlink escape)", leaf, err)
+		}
+	}
+}
+
+// TestSymlinkAwareContainmentIsLoadBearing pins the inputs on which the second
+// pass is the ONLY rejector, disproving the claim that it is unreachable
+// defense-in-depth subsumed by the first pass.
+//
+// pathutil.NormalizePathForCompare swallows every EvalSymlinks error and walks
+// up to the nearest resolvable ancestor, so for a path it cannot canonicalize
+// at all it synthesizes an in-city-looking result and the first pass ACCEPTS.
+// realPathForContainment returns the error instead, so the second pass fails
+// closed. Delete the second pass and these inputs become accepted.
+func TestSymlinkAwareContainmentIsLoadBearing(t *testing.T) {
+	cityDir := t.TempDir()
+
+	// A symlink loop: EvalSymlinks returns ELOOP, which is not os.IsNotExist.
+	loop := filepath.Join(cityDir, "loop")
+	if err := os.Symlink(loop, loop); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	// A regular file used as a directory component: ENOTDIR, also not IsNotExist.
+	if err := os.WriteFile(filepath.Join(cityDir, "plainfile"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"symlink loop", filepath.Join(cityDir, "loop")},
+		{"path under a symlink loop", filepath.Join(cityDir, "loop", "rig")},
+		{"path under a regular file", filepath.Join(cityDir, "plainfile", "rig")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := lexicalContainment(cityDir, tc.path); err != nil {
+				t.Fatalf("precondition: lexicalContainment(%q) = %v, want nil. "+
+					"This test is only meaningful where the FIRST pass accepts; if "+
+					"normalization changed so it now rejects, this arm no longer "+
+					"proves the second pass is load-bearing and must be rebuilt.", tc.path, err)
+			}
+			if err := symlinkAwareContainment(cityDir, tc.path); !errors.Is(err, configedit.ErrValidation) {
+				t.Errorf("symlinkAwareContainment(%q) = %v, want ErrValidation: the "+
+					"second pass is the only thing refusing an uncanonicalizable path", tc.path, err)
+			}
+		})
+	}
+}
+
+// TestContainmentPassesAcceptLegitimateInCityRigs is the other half of the
+// control: a guard that rejects everything is as useless as one that rejects
+// nothing. Every arm here must be ACCEPTED by both passes.
+func TestContainmentPassesAcceptLegitimateInCityRigs(t *testing.T) {
+	root := t.TempDir()
+	realCity := filepath.Join(root, "real", "city")
+	if err := os.MkdirAll(filepath.Join(realCity, "present"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The city reached through a symlinked ancestor — the shape resolveStoreScopeRoot
+	// exists to support, and the one a too-eager guard would break.
+	linkedCity := filepath.Join(root, "linkcity")
+	if err := os.Symlink(realCity, linkedCity); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		city string
+		leaf string
+	}{
+		{"existing rig, real city", realCity, "present"},
+		{"absent rig, real city", realCity, "notyet"},
+		{"existing rig, symlinked city", linkedCity, "present"},
+		{"absent rig, symlinked city", linkedCity, "notyet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target := resolveStoreScopeRoot(tc.city, tc.leaf)
+			if err := lexicalContainment(tc.city, target); err != nil {
+				t.Errorf("lexicalContainment(%q, %q) = %v, want nil", tc.city, target, err)
+			}
+			if err := symlinkAwareContainment(tc.city, target); err != nil {
+				t.Errorf("symlinkAwareContainment(%q, %q) = %v, want nil", tc.city, target, err)
+			}
+			if err := assertRigPathWithinCity(tc.city, target); err != nil {
+				t.Errorf("assertRigPathWithinCity(%q, %q) = %v, want nil", tc.city, target, err)
+			}
+		})
+	}
+}
+
+// TestControllerStateCreateRigRejectsSymlinkEscape drives the rejection through
+// the real sync entry point, so the guard is pinned where it is actually wired
+// and not only as a free function. A rejected rig must also leave no trace in
+// config and must not have created anything outside the city.
+func TestControllerStateCreateRigRejectsSymlinkEscape(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir, outsideDir := escapeLayout(t)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	cs := newControllerState(context.Background(), &config.City{Workspace: config.Workspace{Name: "city1"}},
+		runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	for _, p := range []string{"link/evil", "link/absent"} {
+		if err := cs.CreateRig(config.Rig{Name: "evil", Path: p}); !errors.Is(err, configedit.ErrValidation) {
+			t.Errorf("CreateRig(path=%q) err = %v, want ErrValidation", p, err)
+		}
+	}
+	if got := cs.Config(); got != nil && len(got.Rigs) != 0 {
+		t.Fatalf("a rejected rig leaked into config: %+v", got.Rigs)
+	}
+	// The guard runs before any filesystem side effect, so the escape target
+	// must be untouched: no MkdirAll, no store write outside the city.
+	if _, err := os.Stat(filepath.Join(outsideDir, "absent")); !os.IsNotExist(err) {
+		t.Fatalf("CreateRig created %s outside the city: stat err = %v", filepath.Join(outsideDir, "absent"), err)
+	}
+	if entries, err := os.ReadDir(filepath.Join(outsideDir, "evil")); err != nil {
+		t.Fatalf("read escape target: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("CreateRig planted %d entries in %s outside the city", len(entries), filepath.Join(outsideDir, "evil"))
+	}
+}
+
+// TestProvisionRigFromGitRejectsSymlinkEscape pins the async git_url path. The
+// clone destination is server-derived and absent, so this is the missing-leaf
+// case realPathForContainment exists for. The rejection must happen before the
+// clone: no manifest callback may fire, or a RemoveAll teardown would later be
+// pointed outside the city.
+func TestProvisionRigFromGitRejectsSymlinkEscape(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir, outsideDir := escapeLayout(t)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	cs := newControllerState(context.Background(), &config.City{Workspace: config.Workspace{Name: "city1"}},
+		runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	manifested := 0
+	onManifest := func(api.RigProvisionManifest) error { manifested++; return nil }
+
+	_, err := cs.ProvisionRigFromGit(context.Background(),
+		config.Rig{Name: "evil", Path: "link/absent"},
+		"https://github.com/example/repo.git", nil, onManifest)
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("ProvisionRigFromGit(path=link/absent) err = %v, want ErrValidation", err)
+	}
+	if manifested != 0 {
+		t.Errorf("manifest callback fired %d times for a rejected path; the guard must "+
+			"run before the record-then-create handshake", manifested)
+	}
+	if _, err := os.Stat(filepath.Join(outsideDir, "absent")); !os.IsNotExist(err) {
+		t.Fatalf("ProvisionRigFromGit created %s outside the city: stat err = %v",
+			filepath.Join(outsideDir, "absent"), err)
+	}
+}


### PR DESCRIPTION
## Summary

Test-only, plus one behaviour-preserving extraction. No behaviour change.

`assertRigPathWithinCity` guards every HTTP rig-create entry point — the sync
path (`controllerState.CreateRig`), the async `git_url` path
(`ProvisionRigFromGit`), and the physical teardown (`TeardownPartialRig`) — so a
remote API caller cannot steer the server's `MkdirAll`+store-write or its
clone/`RemoveAll` outside the city root. It runs two containment passes.

**Nothing pinned either pass.** No test referenced `relWithinCity` or
`realPathForContainment`, no test exercised a symlink escape on either API
rig-create path, and neutering the second pass to `return nil` left every
relevant selection green. This PR:

1. splits the two passes into `lexicalContainment` and
   `symlinkAwareContainment`, so each is independently falsifiable — a test
   that only calls `assertRigPathWithinCity` cannot tell *which* pass rejected,
   which is exactly how this rotted unnoticed;
2. adds the missing coverage: five negatives and one accept-side control.

## The "dead code" claim was investigated and disproved

The finding that prompted this work claimed the symlink-aware second pass is
unreachable — subsumed by the first — so the escape it exists to catch goes
unchecked. **That claim is false**, and the `pass2-nil` arm below is the direct
evidence: with the second pass neutered, all three end-to-end escape negatives
stay GREEN. Escapes were never unchecked.

The original observation was right; the inference from it was not. Over a real
escape layout (`<city>/link -> <root>/outside`) **both** passes reject, in all
four call shapes — raw and `resolveStoreScopeRoot`-resolved, existing and absent
leaf. The sweep saw the lexical pass reject first and concluded the second was
dead.

The second pass is a live backstop, not decoration. `pathutil.NormalizePathForCompare`
swallows every `EvalSymlinks` error and walks up to the nearest resolvable
ancestor, synthesizing an in-city-looking path — so for a path it cannot
canonicalize at all, **pass 1 accepts**. `realPathForContainment` returns the
error instead, so pass 2 fails closed. `TestSymlinkAwareContainmentIsLoadBearing`
pins three such inputs: a symlink loop, a path under a symlink loop, and a path
under a regular file (`ELOOP` and `ENOTDIR` are both non-`IsNotExist`).

## Mutation table — re-runnable

Every arm was confirmed to **build and vet** before its result was read; a
mutation that breaks the build proves nothing. Note that `pathutil` is
referenced *only* inside `lexicalContainment`, so the `pass1-nil` and `both-nil`
arms must keep the import live (`_ = pathutil.NormalizePathForCompare(cityPath)`)
or they fail to compile and prove nothing.

Selection used:

```
go test ./cmd/gc/ -count=1 -run \
 'TestAssertRigPathWithinCity|TestBothContainmentPasses|TestSymlinkAwareContainmentIsLoadBearing|TestContainmentPassesAccept|TestControllerStateCreateRigRejects|TestProvisionRigFromGitRejects'
```

| arm | mutation | result |
|---|---|---|
| baseline | none | **14/14 PASS** |
| `pass2-nil` | `symlinkAwareContainment` → `return nil` | **RED:** `BothContainmentPassesRejectSymlinkEscapeIndependently`, `SymlinkAwareContainmentIsLoadBearing`.<br>**GREEN (kept):** the three end-to-end escape negatives — with pass 2 dead, escapes are still refused by pass 1. *This is the evidence the reported claim is false.* |
| `pass1-nil` | `lexicalContainment` → `return nil` (import kept live) | **RED:** `BothContainmentPassesRejectSymlinkEscapeIndependently`.<br>**GREEN (kept):** the end-to-end escape negatives — pass 2 catches genuine escapes on its own too. |
| `both-nil` | both passes → `return nil` | **RED: all five negatives**, so none of them is vacuous. Also reddens three pre-existing negatives (`ProvisionRigFromGitRejectsEscapingRelativePath`, `ProvisionRigFromGitRejectsSymlinkedParent`, `ControllerStateCreateRigRejectsOutOfCityPath`). |
| `relwithin-always-reject` *(control)* | `relWithinCity` → always return the containment error | **RED:** `ContainmentPassesAcceptLegitimateInCityRigs` and both pre-existing accept tests (`AcceptsResolvedTargetUnderSymlinkedCity`, `AcceptsWhenBothSidesResolved`) — so this is not a guard that rejects everything. |

`TestSymlinkAwareContainmentIsLoadBearing` also goes RED under the control arm,
by design: its `t.Fatalf` precondition asserts pass 1 *accepts* the input, and
says so — if normalization ever changes such that pass 1 starts rejecting, that
arm no longer proves anything and must be rebuilt rather than silently passing.

## Testing

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` (`GC_FAST_UNIT=1 go test -p=4 -count=1 -timeout 15m ./...`) — **PASS**, 170 packages, exit 0
- [x] `scripts/check-core-boundary.sh` — OK
- [x] `scripts/check-residency-boundary.sh` — OK
- [x] `.githooks/pre-commit` ran on the staged change (`lint-changed ./cmd/gc`: 0 issues; doc-gen; `go vet ./...`)
- [ ] `make check-docs` — n/a, no docs/navigation/link changes
- [ ] `make test-integration` — n/a, no runtime, controller, or workflow behaviour change

## Checklist

- [x] Linked an issue — `ga-qe7qm`
- [x] Added or updated tests for behavior changes — this PR *is* the tests; the
      only non-test change is the extraction, which is behaviour-preserving
- [x] Updated docs for user-facing changes — none; no user-facing surface changed
- [x] Called out breaking changes or migration notes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
