### PR TITLE
fix(build): derive BUILD_TIME from HEAD commit date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ INSTALL_DIR := $(BIN_DIR)
 VERSION    := $(shell tag=$$(git describe --tags --exact-match 2>/dev/null || true); if [ -n "$$tag" ]; then printf '%s' "$$tag" | sed 's/^v//'; else echo "dev"; fi)
 COMMIT     := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DIRTY      := $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo "-dirty" || true)
-BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+BUILD_TIME := $(shell git show -s --format=%cI HEAD 2>/dev/null || echo unknown)
 
 LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT)$(DIRTY) \

--- a/release-gates/ga-xxh2cz-source-derived-build-time-gate.md
+++ b/release-gates/ga-xxh2cz-source-derived-build-time-gate.md
@@ -1,0 +1,89 @@
+# Release gate: ga-xxh2cz — source-derived build time
+
+**Deploy bead:** `ga-xxh2cz`  
+**Source bead:** `ga-wf71cz`  
+**Build bead:** `ga-vx62cc`  
+**Reviewed commit:** `279316bde0bbdbe3c29ac762a0b9fb14cfcbced9`  
+**Source branch:** `builder/ga-vx62cc` (provenance only)  
+**Deploy branch:** `deploy/ga-xxh2cz-gate`  
+**Base:** `origin/main` at `f25eec9381331c6e747c4f565b51baf2cf152316`  
+**Evaluated:** 2026-08-18 (America/Los_Angeles)
+
+**Verdict:** **FAIL — WAIVED; no candidate-owned failure**
+
+The patch replaces wall-clock `BUILD_TIME` with the immutable HEAD commit date
+and adds a deterministic source-level regression test. The required full-union
+sweep preserved four unrelated failures across four jobs. All four have
+independent ownership evidence and no plausible call path from the two-file
+provenance diff, so they are waived without converting the recorded sweep to
+green.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `gascity/reviewer` independently re-reviewed exact commit `279316bde0bbdbe3c29ac762a0b9fb14cfcbced9` in round 2 and sent durable PASS mail `gm-wisp-lyrolh`. |
+| 2 | Acceptance criteria met | PASS — 2 explicit waivers | `TestBuildTimeIsSourceDerivedNotWallClock` proves the value is derived from `git show --format=%cI HEAD`, rejects wall-clock derivation, and requires the non-git fallback. `TestBuildStampsWorkingTreeDirtiness` preserves the dirty marker. Mayor mails `gm-wisp-2rpri4` and `gm-wisp-o7ixlp` explicitly waive a live linker/cache timing test and the pre-existing `gc version --long` coverage gap; both mails were independently peek-verified. |
+| 3 | Required tests pass | **FAIL — WAIVED** | `Makefile` is a `shared` path in `.github/workflows/ci.yml`, so `make test-local-full-parallel` ran the 40-job full union. Result: 36 PASS, 4 FAIL. The four failures are attributed below; none is candidate-owned. Focused provenance, policy, build, vet, format, and lint gates passed. |
+| 4 | No HIGH-severity review findings open | PASS | Round-2 review reports no blockers, majors, minors, style findings, or security findings. |
+| 5 | Final branch is clean | PASS | The exact reviewed commit had a clean worktree before this gate record; `git diff --check origin/main...HEAD` passed. |
+| 6 | Branch diverges cleanly from main | PASS | The candidate is 3 commits ahead and 2 behind current main. `git merge-tree --write-tree --messages origin/main HEAD` completed without conflict and produced tree `49f615beebcadf47d15ce03c19763bb1593f875b`. |
+| 7 | Change is cohesive and reviewable | PASS | The branch-wide diff is one Makefile assignment plus one 41-line regression test in `scripts/build_provenance_test.go`: 42 insertions, 1 deletion, one build-provenance theme. |
+
+## Focused and static evidence
+
+- `go test -count=1 -v ./scripts/...`: PASS, including
+  `TestBuildTimeIsSourceDerivedNotWallClock` and
+  `TestBuildStampsWorkingTreeDirtiness`.
+- `make -pn` resolved `BUILD_TIME` to
+  `2026-08-18T17:37:13-07:00`, exactly matching `git show -s --format=%cI
+  HEAD`.
+- `make build`: PASS. `./bin/gc version --long` reported
+  `dev (commit: 279316bde0, built: 2026-08-18T17:37:13-07:00)`.
+- `go build ./...`: PASS.
+- `go vet ./...`: PASS.
+- `make test-ci-policy`: PASS.
+- `make fmt-check-changed`: PASS; no changed existing Go files.
+- `make lint-affected`: PASS; no affected lint paths selected.
+- `git diff --check origin/main...HEAD`: PASS.
+
+## Required full-union evidence
+
+```text
+PATH=/var/tmp/gc-gate-ga-f8it32-tools/bin:$PATH \
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+TESTCONTAINERS_RYUK_DISABLED=true TMPDIR=/var/tmp LOCAL_TEST_JOBS=4 \
+make test-local-full-parallel
+```
+
+Result: **36 jobs passed, 4 jobs failed**. Logs are under
+`/var/tmp/gc-local-tests.c8zBvw`.
+
+### Waived, non-candidate failures
+
+1. `cmd-gc-process-4-of-6` —
+   `TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep` missed the
+   late-started runtime. `ga-550z2h` contains a forced reproduction, confirmed
+   test-only root cause, validated fix, and prior occurrence on this exact
+   Makefile BUILD_TIME feature. A focused `-count=20` rerun reproduced twice,
+   consistent with that tracker. The candidate touches neither `cmd/gc` nor
+   lifecycle code.
+2. `integration-packages-runtime-tmux-2-of-3` and `-3-of-3` —
+   `TestGetKeyBinding_CapturesDefaultBinding` and its `WithArgs` sibling saw an
+   empty host tmux 3.7b default key table. This host-specific signature is
+   tracked by `ga-afqddr`; the candidate touches no runtime/tmux path.
+3. `integration-rest-full-1-of-8` — `TestCleanInstallTutorialPath` received a
+   circuit-breaker cleanup diagnostic before the expected issue prefix on
+   stdout. `ga-hrdd3h` tracks the current recurrence; `ga-rsktma` records the
+   mayor's signature-specific attribution ruling for this machine-state
+   trigger. The candidate neither invokes nor changes beads output handling.
+
+There were no candidate-owned failures. These waivers preserve the literal
+FAIL result and do not weaken or delete any test.
+
+## Disposition
+
+- Proceed from the isolated `deploy/ga-xxh2cz-gate` branch only.
+- Open a pull request from that branch; never push or open from
+  `builder/ga-vx62cc`.
+- Route merge authority to mayor/mpr. The deployer does not merge.

--- a/scripts/build_provenance_test.go
+++ b/scripts/build_provenance_test.go
@@ -2,12 +2,10 @@ package scripts_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 )
 
 // buildRecipe extracts the command lines of the Makefile's `build` target.
@@ -128,43 +126,5 @@ func TestBuildTimeIsSourceDerivedNotWallClock(t *testing.T) {
 	if !strings.Contains(expr, "unknown") {
 		t.Fatalf("BUILD_TIME must fall back to a literal value when git metadata is "+
 			"unavailable (e.g. a non-git build context), got: %s", expr)
-	}
-}
-
-// TestBuildTimeIsDeterministicAcrossInvocations executes the Makefile's
-// extracted BUILD_TIME shell expression twice, more than a second apart, and
-// asserts byte-identical output. This is the property that actually makes
-// the link step cache-hit eligible for an unchanged source tree: a
-// wall-clock BUILD_TIME would reliably differ once a second has elapsed; a
-// source-derived one will not.
-func TestBuildTimeIsDeterministicAcrossInvocations(t *testing.T) {
-	makefile := readMakefile(t)
-
-	buildTime := regexp.MustCompile(`(?m)^BUILD_TIME\s*:?=\s*\$\(shell (.+)\)$`).FindStringSubmatch(makefile)
-	if len(buildTime) != 2 {
-		t.Fatal("Makefile defines no BUILD_TIME := $(shell ...) variable")
-	}
-	expr := buildTime[1]
-	root := repoRoot(t)
-
-	run := func() string {
-		t.Helper()
-		cmd := exec.Command("sh", "-c", expr)
-		cmd.Dir = root
-		out, err := cmd.Output()
-		if err != nil {
-			t.Fatalf("running extracted BUILD_TIME expression %q: %v", expr, err)
-		}
-		return string(out)
-	}
-
-	first := run()
-	time.Sleep(1100 * time.Millisecond)
-	second := run()
-	if first != second {
-		t.Fatalf("BUILD_TIME expression is not deterministic across invocations one "+
-			"second apart on an unchanged tree — got %q then %q; a non-deterministic "+
-			"value defeats the link step's cache key even when source is unchanged",
-			first, second)
 	}
 }

--- a/scripts/build_provenance_test.go
+++ b/scripts/build_provenance_test.go
@@ -2,10 +2,12 @@ package scripts_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // buildRecipe extracts the command lines of the Makefile's `build` target.
@@ -85,5 +87,84 @@ func TestBuildStampsWorkingTreeDirtiness(t *testing.T) {
 	}
 	if !strings.Contains(commitFlag[1], "$(DIRTY)") {
 		t.Fatalf("main.commit must carry $(DIRTY) so a modified tree is visible in `gc version --long`, got: %s", commitFlag[1])
+	}
+}
+
+// TestBuildTimeIsSourceDerivedNotWallClock asserts that BUILD_TIME is a
+// function of the source tree (the HEAD commit's date), not the wall clock.
+//
+// ldflags participate in the link step's cache key. A wall-clock BUILD_TIME
+// changes on every invocation, so `-X main.date=$(BUILD_TIME)` guarantees a
+// cache miss on every link even when the source is byte-identical to the
+// build that just ran — each miss stores a fresh ~270MB binary in the shared
+// GOCACHE that nothing will ever reuse (ga-vx62cc). The commit date is
+// stable for a given tree, so identical-source relinks become cache hits,
+// and this is also the standard reproducible-build posture (cf.
+// SOURCE_DATE_EPOCH).
+func TestBuildTimeIsSourceDerivedNotWallClock(t *testing.T) {
+	makefile := readMakefile(t)
+
+	buildTime := regexp.MustCompile(`(?m)^BUILD_TIME\s*:?=\s*(.+)$`).FindStringSubmatch(makefile)
+	if len(buildTime) != 2 {
+		t.Fatal("Makefile defines no BUILD_TIME variable")
+	}
+	expr := buildTime[1]
+
+	if strings.Contains(expr, "date -u") {
+		t.Fatalf("BUILD_TIME must not be derived from the wall clock (date -u) — that "+
+			"changes on every invocation and makes the link step's ldflags cache key "+
+			"guaranteed to miss even for byte-identical source, got: %s", expr)
+	}
+	if !strings.Contains(expr, "git") || !strings.Contains(expr, "show") {
+		t.Fatalf("BUILD_TIME must be derived from `git show` on HEAD so it is a function "+
+			"of the source tree, not the clock, got: %s", expr)
+	}
+	if !strings.Contains(expr, "%cI") {
+		t.Fatalf("BUILD_TIME must use the commit date format %%cI (ISO 8601), got: %s", expr)
+	}
+	if !strings.Contains(expr, "HEAD") {
+		t.Fatalf("BUILD_TIME must read the HEAD commit's date, got: %s", expr)
+	}
+	if !strings.Contains(expr, "unknown") {
+		t.Fatalf("BUILD_TIME must fall back to a literal value when git metadata is "+
+			"unavailable (e.g. a non-git build context), got: %s", expr)
+	}
+}
+
+// TestBuildTimeIsDeterministicAcrossInvocations executes the Makefile's
+// extracted BUILD_TIME shell expression twice, more than a second apart, and
+// asserts byte-identical output. This is the property that actually makes
+// the link step cache-hit eligible for an unchanged source tree: a
+// wall-clock BUILD_TIME would reliably differ once a second has elapsed; a
+// source-derived one will not.
+func TestBuildTimeIsDeterministicAcrossInvocations(t *testing.T) {
+	makefile := readMakefile(t)
+
+	buildTime := regexp.MustCompile(`(?m)^BUILD_TIME\s*:?=\s*\$\(shell (.+)\)$`).FindStringSubmatch(makefile)
+	if len(buildTime) != 2 {
+		t.Fatal("Makefile defines no BUILD_TIME := $(shell ...) variable")
+	}
+	expr := buildTime[1]
+	root := repoRoot(t)
+
+	run := func() string {
+		t.Helper()
+		cmd := exec.Command("sh", "-c", expr)
+		cmd.Dir = root
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("running extracted BUILD_TIME expression %q: %v", expr, err)
+		}
+		return string(out)
+	}
+
+	first := run()
+	time.Sleep(1100 * time.Millisecond)
+	second := run()
+	if first != second {
+		t.Fatalf("BUILD_TIME expression is not deterministic across invocations one "+
+			"second apart on an unchanged tree — got %q then %q; a non-deterministic "+
+			"value defeats the link step's cache key even when source is unchanged",
+			first, second)
 	}
 }


### PR DESCRIPTION
Summary

- derive BUILD_TIME from the immutable HEAD commit date instead of the wall clock
- preserve a literal fallback for non-git build contexts
- add deterministic regression coverage for source-derived build provenance

Release gate

- reviewer PASS on source commit 279316bde0bbdbe3c29ac762a0b9fb14cfcbced9
- gate record: release-gates/ga-xxh2cz-source-derived-build-time-gate.md at deploy commit 6629b1321970237cee123df4043c3a2cb9a8dca3
- focused scripts, policy, build, vet, format, lint, and provenance checks passed
- mandatory pre-push fast gate: 10 of 10 jobs passed
- full union: 36 of 40 jobs passed; four non-candidate failures preserved as FAIL — WAIVED under ga-550z2h, ga-afqddr, ga-hrdd3h, and the ga-rsktma signature ruling

Coverage waivers

Mayor mails gm-wisp-2rpri4 and gm-wisp-o7ixlp explicitly waive a live linker timing test and the pre-existing gc version long coverage gap. Both were independently verified during deploy evaluation.

Tracking

Deploy bead ga-xxh2cz; source bead ga-wf71cz; build bead ga-vx62cc. Merge authority remains with mayor/mpr.