### PR TITLE
fix(test): make force-shutdown late-async-sweep wait deterministic (ga-550z2h)

### DIFF
--- a/cmd/gc/city_runtime_server_lifecycle_test.go
+++ b/cmd/gc/city_runtime_server_lifecycle_test.go
@@ -239,11 +239,18 @@ func (p *forceLifecycleProvider) ListRunning(prefix string) ([]string, error) {
 
 	running, err := p.Fake.ListRunning(prefix)
 	if call == 1 {
+		// Block unconditionally rather than racing hangBudget: under
+		// concurrent shard load the released Start goroutine can be
+		// scheduler-delayed past any fixed budget, so a bounded wait here
+		// let this call fall through with the stale pre-release snapshot
+		// while "worker" was still landing — and with nothing between the
+		// two sweeps to catch up, the late sweep missed it too (ga-550z2h).
+		// gatedStartProvider.Start cannot block or error for "worker" here
+		// once released, so this can only wedge on a genuine bug, which a
+		// real hang (caught by go test's own timeout, with a goroutine
+		// dump) surfaces better than a silently-wrong assertion would.
 		p.release("worker")
-		select {
-		case <-p.workerStarted:
-		case <-time.After(hangBudget):
-		}
+		<-p.workerStarted
 	}
 	return running, err
 }


### PR DESCRIPTION
## Summary

`TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep` flaked under concurrent
fast-shard load, blocking at least 7 independent, unrelated pushes (ga-vb82ss,
ga-c3k0xe, ga-vx62cc, ga-xxh2cz, ga-phymuo, and others) via the shared
non-diff-owned-gate-failure protocol.

## Root cause

`forceLifecycleProvider.ListRunning`'s first sweep raced a bounded `hangBudget`
wait against the async-start goroutine's `workerStarted` close. Under concurrent
shard load the released goroutine could be scheduler-delayed past any fixed
budget, so the bounded wait fell through with a stale pre-release snapshot while
`"worker"` was still landing — and with nothing between the two sweeps to catch
up, the late sweep missed it too.

## Fix

Replace the bounded `select` with an unconditional `<-p.workerStarted` wait.
`gatedStartProvider.Start` cannot block or error for `"worker"` here once
released, so this can only wedge on a genuine bug — which a real hang (caught by
`go test`'s own timeout, with a goroutine dump) surfaces better than a silently-
wrong assertion would.

Test-file-only change; no production code touched.

## Validation

- Forced reproduction (shrunk timeout + artificial delay) reproduced the original
  failure 8/10 runs.
- Same reproduction harness against the fix: 20/20 clean.
- Target test under `-race -count=30`: clean.
- Full `cmd/gc` package: clean (324.9s).
- This PR's own push went through the full local `test-local-parallel fast` gate
  (10 parallel jobs, including `unit-core`) clean on the second attempt — the
  first attempt failed on `TestProviderLiveClaudeKindPath`
  (`internal/runtime/herdr`), an unrelated live-tmux-pane test tracked by
  ga-fh1flg; the retry passed with no code changes, consistent with that bead's
  own diagnosis of transient fleet-load pane contention.

## Related, independent work

PR #5331 ("test(cmd/gc): close the force-shutdown late-async-sweep race",
`fix-force-shutdown-late-async-test-race`, currently open) fixes the same
underlying flaky test via a different mechanism — making the first sweep wait
for the async-start tracker to drain, rather than replacing the bounded wait
with an unconditional one here. Flagging for reviewer/mayor reconciliation
rather than attempting to unify the two approaches myself; both should not land
independently against the same test.

## Context

This bead carried `hold:mayor` pending an explicit authorization ruling, lifted
2026-08-18 with instruction to commit on `builder/ga-550z2h` with the evidence
chain already in the bead's notes, push, and route a merge request the normal
way. The herdr flake (ga-fh1flg) is explicitly out of scope for this change —
tracked separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)