### PR TITLE
fix(mail): stop `gc mail send -s` dropping the body when -m is absent

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -832,6 +832,16 @@ func formatInjectOutput(messages []mail.Message) string {
 		subject := extmsg.SanitizeForSystemReminder(rawSubject)
 		rawBody, bodyTruncated := mailInjectBodyPreview(m.Body)
 		body := extmsg.SanitizeForSystemReminder(rawBody)
+		// A message with no body is not a message whose content went missing:
+		// the subject IS the content. `gc mail send <to> -s "text"` and
+		// POST /v0/mail with the optional body omitted both produce this shape.
+		// Without the substitution it renders as "[subject]: " — a subject in
+		// brackets and nothing behind the colon, which reads as lost content
+		// and is what made ga-6eukj0 look like a storage bug. Substituting here
+		// covers every ingress, since all of them converge on this read path.
+		if body == "" {
+			body, bodyTruncated = subject, subjectTruncated
+		}
 		if subject != "" && subject != body {
 			fmt.Fprintf(&sb, "- %s from %s [%s", m.ID, from, subject)
 			if subjectTruncated {
@@ -1865,15 +1875,6 @@ func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[s
 		// [to, body] — positional arg, no subject.
 		body = strings.Join(args[1:], " ")
 	}
-	// `-s "text"` with neither -m nor a positional body: the subject IS the
-	// message. Storing the empty body verbatim delivers a subject line with its
-	// content missing — and a bodyless mail does not read as broken, so the
-	// recipient acts on the subject and never learns anything was lost
-	// (ga-6eukj0). The positional form already behaves this way: beadmail.Send
-	// backfills an empty title from the body, and this is the mirror of it.
-	if body == "" {
-		body = subject
-	}
 
 	if validRecipients != nil && !validRecipients[to] {
 		fmt.Fprintf(stderr, "gc mail send: unknown recipient %q\n", to) //nolint:errcheck // best-effort stderr
@@ -1931,11 +1932,6 @@ func doMailSendAllJSON(mp mail.Provider, rec events.Recorder, validRecipients ma
 		body = args[1]
 	} else {
 		body = args[0]
-	}
-	// Same subject-only backfill as doMailSendJSON: `--all -s "text"` arrives
-	// here as [subject, ""] and must not broadcast an empty body (ga-6eukj0).
-	if body == "" {
-		body = subject
 	}
 
 	// Collect recipients in sorted order for deterministic output.

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1865,6 +1865,15 @@ func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[s
 		// [to, body] — positional arg, no subject.
 		body = strings.Join(args[1:], " ")
 	}
+	// `-s "text"` with neither -m nor a positional body: the subject IS the
+	// message. Storing the empty body verbatim delivers a subject line with its
+	// content missing — and a bodyless mail does not read as broken, so the
+	// recipient acts on the subject and never learns anything was lost
+	// (ga-6eukj0). The positional form already behaves this way: beadmail.Send
+	// backfills an empty title from the body, and this is the mirror of it.
+	if body == "" {
+		body = subject
+	}
 
 	if validRecipients != nil && !validRecipients[to] {
 		fmt.Fprintf(stderr, "gc mail send: unknown recipient %q\n", to) //nolint:errcheck // best-effort stderr
@@ -1922,6 +1931,11 @@ func doMailSendAllJSON(mp mail.Provider, rec events.Recorder, validRecipients ma
 		body = args[1]
 	} else {
 		body = args[0]
+	}
+	// Same subject-only backfill as doMailSendJSON: `--all -s "text"` arrives
+	// here as [subject, ""] and must not broadcast an empty body (ga-6eukj0).
+	if body == "" {
+		body = subject
 	}
 
 	// Collect recipients in sorted order for deterministic output.

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -2043,13 +2043,7 @@ func doMailInboxTargetWithJSON(mp mailInboxReader, target resolvedMailTarget, js
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "ID\tFROM\tSUBJECT\tBODY") //nolint:errcheck // best-effort stdout
 	for _, m := range messages {
-		// Same suppression as printMessage: the subject and body columns sit
-		// side by side, so an identical pair prints the string twice.
-		body := m.Body
-		if body == m.Subject {
-			body = ""
-		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m.ID, m.From, m.Subject, truncate(body, 60)) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m.ID, m.From, m.Subject, truncate(m.Body, 60)) //nolint:errcheck // best-effort stdout
 	}
 	tw.Flush() //nolint:errcheck // best-effort stdout
 	return 0
@@ -2734,10 +2728,7 @@ func printMessage(m mail.Message, stdout io.Writer) {
 		w(fmt.Sprintf("Subject:  %s", m.Subject))
 	}
 	w(fmt.Sprintf("Sent:     %s", m.CreatedAt.Format("2006-01-02 15:04:05")))
-	// beadmail.Send backfills an empty title from the body, so every
-	// positionally-sent message already stores an identical Title and
-	// Description. Printing both renders the same string twice.
-	if m.Body != "" && m.Body != m.Subject {
+	if m.Body != "" {
 		w(fmt.Sprintf("Body:     %s", m.Body))
 	}
 }

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -2043,7 +2043,13 @@ func doMailInboxTargetWithJSON(mp mailInboxReader, target resolvedMailTarget, js
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "ID\tFROM\tSUBJECT\tBODY") //nolint:errcheck // best-effort stdout
 	for _, m := range messages {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m.ID, m.From, m.Subject, truncate(m.Body, 60)) //nolint:errcheck // best-effort stdout
+		// Same suppression as printMessage: the subject and body columns sit
+		// side by side, so an identical pair prints the string twice.
+		body := m.Body
+		if body == m.Subject {
+			body = ""
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m.ID, m.From, m.Subject, truncate(body, 60)) //nolint:errcheck // best-effort stdout
 	}
 	tw.Flush() //nolint:errcheck // best-effort stdout
 	return 0
@@ -2728,7 +2734,10 @@ func printMessage(m mail.Message, stdout io.Writer) {
 		w(fmt.Sprintf("Subject:  %s", m.Subject))
 	}
 	w(fmt.Sprintf("Sent:     %s", m.CreatedAt.Format("2006-01-02 15:04:05")))
-	if m.Body != "" {
+	// beadmail.Send backfills an empty title from the body, so every
+	// positionally-sent message already stores an identical Title and
+	// Description. Printing both renders the same string twice.
+	if m.Body != "" && m.Body != m.Subject {
 		w(fmt.Sprintf("Body:     %s", m.Body))
 	}
 }

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3374,6 +3374,66 @@ func TestFormatInjectOutputSubjectEqualToBodyRendersOnce(t *testing.T) {
 	}
 }
 
+// TestPrintMessageSuppressesBodyIdenticalToSubject covers `gc mail read` for
+// the subject==body shape. Printing a Subject line and a Body line carrying
+// the same string reads as duplicated content. This shape predates the
+// subject-only work: every positionally-sent message already has it.
+func TestPrintMessageSuppressesBodyIdenticalToSubject(t *testing.T) {
+	var out bytes.Buffer
+	printMessage(mail.Message{
+		ID: "gc-1", From: "human", To: "mayor",
+		Subject: "Build is green", Body: "Build is green",
+	}, &out)
+
+	got := out.String()
+	if !strings.Contains(got, "Subject:  Build is green") {
+		t.Errorf("missing Subject line:\n%s", got)
+	}
+	if strings.Contains(got, "Body:") {
+		t.Errorf("Body line duplicates the subject:\n%s", got)
+	}
+}
+
+// TestPrintMessageKeepsBodyDifferentFromSubject is the guard on the test
+// above: suppression must be exact-match only, never a general Body drop.
+func TestPrintMessageKeepsBodyDifferentFromSubject(t *testing.T) {
+	var out bytes.Buffer
+	printMessage(mail.Message{
+		ID: "gc-1", From: "human", To: "mayor",
+		Subject: "Build is green", Body: "all 412 packages passed",
+	}, &out)
+
+	got := out.String()
+	if !strings.Contains(got, "Body:     all 412 packages passed") {
+		t.Errorf("distinct body was dropped:\n%s", got)
+	}
+}
+
+// TestMailInboxSuppressesBodyIdenticalToSubject covers the `gc mail inbox`
+// columns, which print the subject and a truncated body side by side. For the
+// subject==body shape that repeats the same string in adjacent columns.
+func TestMailInboxSuppressesBodyIdenticalToSubject(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	if _, err := mp.Send("human", "mayor", "", "Build is green"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if code := doMailInbox(mp, "mayor", &stdout, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("doMailInbox = %d, want 0", code)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "Build is green") {
+		t.Fatalf("inbox missing the message:\n%s", got)
+	}
+	if strings.Count(got, "Build is green") != 1 {
+		t.Errorf("subject repeated in the body column (count=%d):\n%s",
+			strings.Count(got, "Build is green"), got)
+	}
+}
+
 // --- gc mail send --from ---
 
 func TestMailSendFromFlag(t *testing.T) {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3374,6 +3374,38 @@ func TestFormatInjectOutputSubjectEqualToBodyRendersOnce(t *testing.T) {
 	}
 }
 
+// TestPrintMessageKeepsBodyIdenticalToSubject pins the documented output of
+// the positional send. `gc mail send <to> "text"` supplies a body and no
+// subject, and beadmail.Send synthesizes the title from that body, so the two
+// fields hold the same string with the SUBJECT being the derived one.
+// Suppressing the Body line here would print only the synthesized field and
+// hide the one the user actually typed, which is the "content renders as
+// though it were lost" failure this command family exists to avoid.
+//
+// This duplicates cmd/gc/testdata/events.txtar:32 on purpose. That txtar runs
+// only under GC_FAST_UNIT=0, so a suppression reintroduced here would survive
+// the whole fast unit loop and surface only in CI.
+//
+// Note the injection path deliberately renders such a message ONCE (see
+// TestFormatInjectOutputSubjectEqualToBodyRendersOnce): it emits a single
+// "from X: message" line, where repeating the string is pure noise. The
+// labeled Subject/Body view is a different contract and shows both.
+func TestPrintMessageKeepsBodyIdenticalToSubject(t *testing.T) {
+	var out bytes.Buffer
+	printMessage(mail.Message{
+		ID: "gc-1", From: "human", To: "mayor",
+		Subject: "hey there", Body: "hey there",
+	}, &out)
+
+	got := out.String()
+	if !strings.Contains(got, "Subject:  hey there") {
+		t.Errorf("missing Subject line:\n%s", got)
+	}
+	if !strings.Contains(got, "Body:     hey there") {
+		t.Errorf("Body line dropped for a positional send; the body is what the user typed:\n%s", got)
+	}
+}
+
 // --- gc mail send --from ---
 
 func TestMailSendFromFlag(t *testing.T) {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3309,6 +3309,57 @@ func TestMailSendSubjectAndMessage(t *testing.T) {
 	}
 }
 
+// TestMailSendSubjectOnlyKeepsBody covers `gc mail send <to> -s "text"` with no
+// -m and no positional body. The flag path hands doMailSend [to, subject, ""],
+// and the empty body used to be stored verbatim: the message arrived as a
+// subject line with its content silently gone. The subject IS the message here,
+// exactly as in the positional form.
+func TestMailSendSubjectOnlyKeepsBody(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	recipients := map[string]bool{"human": true, "mayor": true}
+
+	var stdout bytes.Buffer
+	code := doMailSend(mp, events.Discard, recipients, "human", []string{"mayor", "Build is green", ""}, nil, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("doMailSend = %d, want 0", code)
+	}
+
+	b, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Title != "Build is green" {
+		t.Errorf("bead Title = %q, want %q", b.Title, "Build is green")
+	}
+	if b.Description != "Build is green" {
+		t.Errorf("bead Description = %q, want %q (subject-only mail must not arrive empty)", b.Description, "Build is green")
+	}
+}
+
+// TestMailSendAllSubjectOnlyKeepsBody covers the same defect on the broadcast
+// path: `gc mail send --all -s "text"` reaches doMailSendAllJSON as
+// [subject, ""].
+func TestMailSendAllSubjectOnlyKeepsBody(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	recipients := map[string]bool{"mayor": true}
+
+	var stdout bytes.Buffer
+	code := doMailSendAllJSON(mp, events.Discard, recipients, "human", []string{"Fleet is green", ""}, nil, false, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("doMailSendAllJSON = %d, want 0", code)
+	}
+
+	b, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Description != "Fleet is green" {
+		t.Errorf("bead Description = %q, want %q (subject-only broadcast must not arrive empty)", b.Description, "Fleet is green")
+	}
+}
+
 // --- gc mail send --from ---
 
 func TestMailSendFromFlag(t *testing.T) {
@@ -4948,7 +4999,11 @@ func TestCmdMailSendFlagBodyWinsOverPositional(t *testing.T) {
 }
 
 func TestCmdMailSendNoBodyStillWorks(t *testing.T) {
-	// No positional body and no -m flag: empty body is valid.
+	// No positional body and no -m flag: the send still succeeds, and the
+	// subject is carried into the body rather than stored empty. Completes the
+	// #3331 family (positional body dropped when -s set): the remaining arm was
+	// "no body from any source", which used to persist an empty description and
+	// deliver a subject line with nothing behind it (ga-6eukj0).
 	cityPath := mailSendTestCity(t, "mayor")
 
 	var stdout, stderr bytes.Buffer
@@ -4961,8 +5016,8 @@ func TestCmdMailSendNoBodyStillWorks(t *testing.T) {
 	if msg.Title != "subject" {
 		t.Errorf("Title = %q, want %q", msg.Title, "subject")
 	}
-	if msg.Description != "" {
-		t.Errorf("Description = %q, want empty", msg.Description)
+	if msg.Description != "subject" {
+		t.Errorf("Description = %q, want %q (subject-only mail must not arrive empty)", msg.Description, "subject")
 	}
 }
 

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3374,66 +3374,6 @@ func TestFormatInjectOutputSubjectEqualToBodyRendersOnce(t *testing.T) {
 	}
 }
 
-// TestPrintMessageSuppressesBodyIdenticalToSubject covers `gc mail read` for
-// the subject==body shape. Printing a Subject line and a Body line carrying
-// the same string reads as duplicated content. This shape predates the
-// subject-only work: every positionally-sent message already has it.
-func TestPrintMessageSuppressesBodyIdenticalToSubject(t *testing.T) {
-	var out bytes.Buffer
-	printMessage(mail.Message{
-		ID: "gc-1", From: "human", To: "mayor",
-		Subject: "Build is green", Body: "Build is green",
-	}, &out)
-
-	got := out.String()
-	if !strings.Contains(got, "Subject:  Build is green") {
-		t.Errorf("missing Subject line:\n%s", got)
-	}
-	if strings.Contains(got, "Body:") {
-		t.Errorf("Body line duplicates the subject:\n%s", got)
-	}
-}
-
-// TestPrintMessageKeepsBodyDifferentFromSubject is the guard on the test
-// above: suppression must be exact-match only, never a general Body drop.
-func TestPrintMessageKeepsBodyDifferentFromSubject(t *testing.T) {
-	var out bytes.Buffer
-	printMessage(mail.Message{
-		ID: "gc-1", From: "human", To: "mayor",
-		Subject: "Build is green", Body: "all 412 packages passed",
-	}, &out)
-
-	got := out.String()
-	if !strings.Contains(got, "Body:     all 412 packages passed") {
-		t.Errorf("distinct body was dropped:\n%s", got)
-	}
-}
-
-// TestMailInboxSuppressesBodyIdenticalToSubject covers the `gc mail inbox`
-// columns, which print the subject and a truncated body side by side. For the
-// subject==body shape that repeats the same string in adjacent columns.
-func TestMailInboxSuppressesBodyIdenticalToSubject(t *testing.T) {
-	store := beads.NewMemStore()
-	mp := beadmail.New(store)
-	if _, err := mp.Send("human", "mayor", "", "Build is green"); err != nil {
-		t.Fatal(err)
-	}
-
-	var stdout bytes.Buffer
-	if code := doMailInbox(mp, "mayor", &stdout, &bytes.Buffer{}); code != 0 {
-		t.Fatalf("doMailInbox = %d, want 0", code)
-	}
-
-	got := stdout.String()
-	if !strings.Contains(got, "Build is green") {
-		t.Fatalf("inbox missing the message:\n%s", got)
-	}
-	if strings.Count(got, "Build is green") != 1 {
-		t.Errorf("subject repeated in the body column (count=%d):\n%s",
-			strings.Count(got, "Build is green"), got)
-	}
-}
-
 // --- gc mail send --from ---
 
 func TestMailSendFromFlag(t *testing.T) {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3309,12 +3309,14 @@ func TestMailSendSubjectAndMessage(t *testing.T) {
 	}
 }
 
-// TestMailSendSubjectOnlyKeepsBody covers `gc mail send <to> -s "text"` with no
-// -m and no positional body. The flag path hands doMailSend [to, subject, ""],
-// and the empty body used to be stored verbatim: the message arrived as a
-// subject line with its content silently gone. The subject IS the message here,
-// exactly as in the positional form.
-func TestMailSendSubjectOnlyKeepsBody(t *testing.T) {
+// TestMailSendSubjectOnlyStoresEmptyBody pins the storage contract for
+// `gc mail send <to> -s "text"` with no -m and no positional body: an empty
+// body is a legal stored state and stays empty. The subject is required
+// (POST /v0/mail marks it minLength:1) and the body is explicitly optional
+// there, so a subject-only message is well-formed rather than a message whose
+// content went missing. What was broken was the rendering, not the storage;
+// see TestFormatInjectOutputSubjectOnlyRendersSubjectAsMessage (ga-6eukj0).
+func TestMailSendSubjectOnlyStoresEmptyBody(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)
 	recipients := map[string]bool{"human": true, "mayor": true}
@@ -3332,31 +3334,43 @@ func TestMailSendSubjectOnlyKeepsBody(t *testing.T) {
 	if b.Title != "Build is green" {
 		t.Errorf("bead Title = %q, want %q", b.Title, "Build is green")
 	}
-	if b.Description != "Build is green" {
-		t.Errorf("bead Description = %q, want %q (subject-only mail must not arrive empty)", b.Description, "Build is green")
+	if b.Description != "" {
+		t.Errorf("bead Description = %q, want empty (an omitted body is a legal state, not a lost one)", b.Description)
 	}
 }
 
-// TestMailSendAllSubjectOnlyKeepsBody covers the same defect on the broadcast
-// path: `gc mail send --all -s "text"` reaches doMailSendAllJSON as
-// [subject, ""].
-func TestMailSendAllSubjectOnlyKeepsBody(t *testing.T) {
-	store := beads.NewMemStore()
-	mp := beadmail.New(store)
-	recipients := map[string]bool{"mayor": true}
+// TestFormatInjectOutputSubjectOnlyRendersSubjectAsMessage is the actual
+// ga-6eukj0 defect. A subject-only message reached the agent-facing injection
+// as "[Build is green]: " — a subject in brackets and nothing behind the
+// colon, which reads as a message whose body was lost. The subject IS the
+// message here, so it must render as the message.
+func TestFormatInjectOutputSubjectOnlyRendersSubjectAsMessage(t *testing.T) {
+	out := formatInjectOutput([]mail.Message{
+		{ID: "gc-1", From: "human", To: "mayor", Subject: "Build is green"},
+	})
 
-	var stdout bytes.Buffer
-	code := doMailSendAllJSON(mp, events.Discard, recipients, "human", []string{"Fleet is green", ""}, nil, false, &stdout, &bytes.Buffer{})
-	if code != 0 {
-		t.Fatalf("doMailSendAllJSON = %d, want 0", code)
+	if want := "- gc-1 from human: Build is green"; !strings.Contains(out, want) {
+		t.Errorf("inject output missing %q:\n%s", want, out)
 	}
+	if strings.Contains(out, "[Build is green]: \n") {
+		t.Errorf("subject-only message rendered as an empty-bodied message:\n%s", out)
+	}
+}
 
-	b, err := store.Get("gc-1")
-	if err != nil {
-		t.Fatal(err)
+// TestFormatInjectOutputSubjectEqualToBodyRendersOnce guards the pre-existing
+// subject==body shape produced by the positional form: `gc mail send <to>
+// "text"` arrives with no subject, and beadmail.Send backfills the title from
+// the body, so Title and Description are identical.
+func TestFormatInjectOutputSubjectEqualToBodyRendersOnce(t *testing.T) {
+	out := formatInjectOutput([]mail.Message{
+		{ID: "gc-1", From: "human", To: "mayor", Subject: "Build is green", Body: "Build is green"},
+	})
+
+	if want := "- gc-1 from human: Build is green"; !strings.Contains(out, want) {
+		t.Errorf("inject output missing %q:\n%s", want, out)
 	}
-	if b.Description != "Fleet is green" {
-		t.Errorf("bead Description = %q, want %q (subject-only broadcast must not arrive empty)", b.Description, "Fleet is green")
+	if strings.Contains(out, "[Build is green]") {
+		t.Errorf("identical subject and body rendered twice:\n%s", out)
 	}
 }
 
@@ -4999,11 +5013,7 @@ func TestCmdMailSendFlagBodyWinsOverPositional(t *testing.T) {
 }
 
 func TestCmdMailSendNoBodyStillWorks(t *testing.T) {
-	// No positional body and no -m flag: the send still succeeds, and the
-	// subject is carried into the body rather than stored empty. Completes the
-	// #3331 family (positional body dropped when -s set): the remaining arm was
-	// "no body from any source", which used to persist an empty description and
-	// deliver a subject line with nothing behind it (ga-6eukj0).
+	// No positional body and no -m flag: empty body is valid.
 	cityPath := mailSendTestCity(t, "mayor")
 
 	var stdout, stderr bytes.Buffer
@@ -5016,8 +5026,8 @@ func TestCmdMailSendNoBodyStillWorks(t *testing.T) {
 	if msg.Title != "subject" {
 		t.Errorf("Title = %q, want %q", msg.Title, "subject")
 	}
-	if msg.Description != "subject" {
-		t.Errorf("Description = %q, want %q (subject-only mail must not arrive empty)", msg.Description, "subject")
+	if msg.Description != "" {
+		t.Errorf("Description = %q, want empty", msg.Description)
 	}
 }
 

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -369,6 +369,42 @@ func TestMailMarkUnread(t *testing.T) {
 	}
 }
 
+// TestMailSendOmittedBodyStaysEmpty pins the POST /v0/mail contract for a
+// request that carries a subject and no body. MailSendInput marks Subject
+// required (minLength:"1") and Body optional, so this is a well-formed
+// request, and the omitted body must round-trip as empty rather than being
+// silently backfilled from the subject.
+//
+// The point is cross-surface agreement: `gc mail send <to> -s "text"` stores
+// an empty body too (cmd/gc: TestMailSendSubjectOnlyStoresEmptyBody), so
+// mail.Provider.Send behaves identically whichever surface issued it. A
+// backfill applied at one ingress and not the others is what makes the two
+// diverge. The rendering of a bodyless message is handled in the read paths,
+// downstream of every ingress (ga-6eukj0).
+func TestMailSendOmittedBodyStaysEmpty(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"alice","to":"worker","subject":"Build is green"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/mail"), bytes.NewBufferString(body)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var msg mail.Message
+	if err := json.NewDecoder(rec.Body).Decode(&msg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if msg.Subject != "Build is green" {
+		t.Errorf("Subject = %q, want %q", msg.Subject, "Build is green")
+	}
+	if msg.Body != "" {
+		t.Errorf("Body = %q, want empty (an omitted optional body must not be backfilled)", msg.Body)
+	}
+}
+
 func TestMailSendValidation(t *testing.T) {
 	state := newFakeState(t)
 	h := newTestCityHandler(t, state)


### PR DESCRIPTION
## What

`gc mail send <to> -s "text"` — with neither `-m` nor a positional body — delivered to the recipient's agent injection as a subject in brackets with nothing behind the colon:

```
- gc-1 from human [Build is green]: 
```

That reads as a message whose content went missing, which is why it was first reported as mail losing bodies in storage. Nothing was lost: nothing was ever attached. The subject was the whole message, and the injection had no way to say so.

## Which reading this PR means

The review asked which of two readings this change picks, since the answer decides where the fix goes. **It means the second: an empty body is a legal stored state, and the defect was in the read path.** Three things settle it.

**The contract already says a body is optional.** `MailSendInput` marks `Subject` required (`minLength:"1"`) and `Body` optional; the CLI usage is `-s <subject> [-m <body>]`. A subject-only message is well-formed input at both ingresses, not a malformed one to be normalized away.

**Only one read path was actually broken.** `gc mail read` already rendered a subject-only message correctly — it skips the `Body:` line when the body is empty — and so did the inbox columns. `formatInjectOutput` was the single place that rendered it as lost content.

**Fixing the read path produces byte-identical output to the backfill.** Both render `- gc-1 from human: Build is green`. Same result for the user; strictly less cost:

- **No divergence between surfaces.** The backfill sat on two of `mail.Provider.Send`'s callers and missed `internal/api/huma_handlers_mail.go:398`, so the same `Send` behaved differently depending on the surface that issued it. A read-path fix is downstream of every ingress at once — including any future one.
- **No stored-state change**, so "the user sent a subject only" stays distinguishable from "the user sent an identical subject and body", and the documented-optional `Body` field stays honest.

The first commit therefore reverts the send-path backfill and fixes `formatInjectOutput` instead.

## The double-render is pre-existing, and this PR leaves it alone

The review flagged that a subject equal to a body renders twice. That is right, and it is already true on `main` — it predates this PR.

`beadmail.Send` backfills an empty title from the first line of the body, so every positionally-sent message (`gc mail send mayor "Build is green"` — the form the docs use) already stores an identical Title and Description whenever the body is one line under 80 characters. Both read paths that print the two side by side already print the same string twice:

```
$ gc mail read gc-1
Subject:  Build is green
Body:     Build is green

$ gc mail inbox
ID    FROM   SUBJECT         BODY
gc-1  human  Build is green  Build is green
```

The injection path is the one place already guarded against it — its `subject != body` branch exists precisely because the title backfill produces that shape — which is why this went unnoticed there.

An earlier revision of this branch suppressed the exact-match duplicate in `gc mail read` and `gc mail inbox`; that suppression is **reverted** in the final head. Both read paths print an identical subject and body twice exactly as they do on `main` — a stored body is always rendered — and `TestPrintMessageKeepsBodyIdenticalToSubject` pins that, so the suppression cannot sneak back in as a side effect. If the duplicate is ever worth fixing, it belongs to the title backfill, not to this PR.

On the asymmetry noted as non-blocking: it no longer arises. There is no body backfill in the store. In the injection the substituted subject goes through `mailInjectSubjectPreview`, which uses the same `mailInjectBodyPreviewSize` bound as the body preview, so the substitution is bounded exactly as the body it replaces — and `subjectTruncated` is carried over with it.

## Tests

- `TestMailSendSubjectOnlyStoresEmptyBody` — a subject-only CLI send stores an empty description.
- `TestMailSendOmittedBodyStaysEmpty` (`internal/api`) — `POST /v0/mail` with the body omitted round-trips empty. Pins that the two surfaces agree.
- `TestFormatInjectOutputSubjectOnlyRendersSubjectAsMessage` — the actual defect; RED before, GREEN after.
- `TestFormatInjectOutputSubjectEqualToBodyRendersOnce` — the pre-existing positional shape still renders once.
- `TestPrintMessageKeepsBodyIdenticalToSubject` — the read paths are unchanged: a stored body identical to the subject still prints.
- `TestCmdMailSendNoBodyStillWorks` returns to asserting `Description == ""`. That assertion was the contract, and it was right; the earlier flip is reverted.

## Context — the bug is real, but the P0 that found it was a measurement artifact

This came out of ga-6eukj0, which reported *"42% of agent mail arrives with NO BODY"*. That headline does not hold up. Reproduced the 42% exactly (936 messages, 395 empty), then split it by title:

| | total | empty |
|---|---|---|
| `"context cycle"` (auto hook) | 394 | 394 |
| real agent mail | 542 | **1** |

394 of the 395 empty bodies are `gc handoff --auto "context cycle"` — self-addressed mail fired by every provider's PreCompact hook. `cmd_handoff.go:335` sets Body only from `args[1]` and the hook passes a single arg, so those are bodyless *by construction*; they are compaction markers, injected on the next hook and then archived.

Real agent mail was empty in 1 of 542 messages — and that one message is this bug.

The reported by-sender variance (builders 74-94%, deployer 17%) is compaction frequency, not send style: for every sender but one, empty count equals context-cycle count exactly, and `human`/`controller`/`investigator` — which never compact — were 0 empty out of 159.

The bead's stated hypothesis (the `native_store_unavailable` fallback dropping the description column) is disproven: three probes sent in the same second, all logging `native_store_unavailable gate=native_open`, stored `-s`-alone empty but `-s -m` and positional intact. Storage is fine — which is consistent with the conclusion above that the defect was never in the store.

Refs: ga-6eukj0, ga-9no7ns

