### PR TITLE
fix(ci): scope workflow write permissions to the jobs that need them (ga-n6gvg8.3)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   runner-policy:
@@ -46,6 +45,10 @@ jobs:
     needs: runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dispatch-labeled-pr-suite.yml
+++ b/.github/workflows/dispatch-labeled-pr-suite.yml
@@ -6,7 +6,6 @@ on:
       - labeled
 
 permissions:
-  actions: write
   contents: read
   pull-requests: read
 
@@ -17,6 +16,10 @@ jobs:
       github.event.label.name == 'needs-mac' ||
       github.event.label.name == 'needs-review-formulas'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     steps:
       # This workflow never checks out or runs pull request code. It reads the
       # trusted base allowlist, then dispatches a dedicated workflow with the

--- a/.github/workflows/docs-autofix.yml
+++ b/.github/workflows/docs-autofix.yml
@@ -31,8 +31,6 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
-  pull-requests: write
   actions: read
 
 concurrency:
@@ -46,6 +44,10 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
     steps:
       # Trusted side only: base repo default branch, never the PR head.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/scripts/workflow_permissions_test.go
+++ b/scripts/workflow_permissions_test.go
@@ -1,0 +1,74 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestWorkflowWritePermissionsAreJobScoped guards against Scorecard
+// TokenPermissions regressions (alerts 67, 68, 248): each of these
+// workflows previously granted a write permission at workflow level, where
+// every job inherits it, when only one job actually needs it.
+func TestWorkflowWritePermissionsAreJobScoped(t *testing.T) {
+	type workflowFile struct {
+		Permissions map[string]string `yaml:"permissions"`
+		Jobs        map[string]struct {
+			Permissions map[string]string `yaml:"permissions"`
+		} `yaml:"jobs"`
+	}
+
+	cases := []struct {
+		file       string
+		writeJob   string
+		wantWrites []string
+	}{
+		{
+			file:       "docs-autofix.yml",
+			writeJob:   "autofix",
+			wantWrites: []string{"contents", "pull-requests"},
+		},
+		{
+			file:       "codeql.yml",
+			writeJob:   "analyze",
+			wantWrites: []string{"security-events"},
+		},
+		{
+			file:       "dispatch-labeled-pr-suite.yml",
+			writeJob:   "dispatch-suite",
+			wantWrites: []string{"actions"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			path := filepath.Join(repoRoot(t), ".github", "workflows", tc.file)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.file, err)
+			}
+			var wf workflowFile
+			if err := yaml.Unmarshal(data, &wf); err != nil {
+				t.Fatalf("parse %s: %v", tc.file, err)
+			}
+
+			for scope, level := range wf.Permissions {
+				if level == "write" {
+					t.Errorf("%s: workflow-level permissions must be read-only, got %s: write", tc.file, scope)
+				}
+			}
+
+			job, ok := wf.Jobs[tc.writeJob]
+			if !ok {
+				t.Fatalf("%s: expected job %q not found", tc.file, tc.writeJob)
+			}
+			for _, scope := range tc.wantWrites {
+				if got := job.Permissions[scope]; got != "write" {
+					t.Errorf("%s: job %q must declare %s: write, got %q", tc.file, tc.writeJob, scope, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Scorecard TokenPermissions alerts flagged top-level `permissions:` write grants that every job in the workflow inherits, when only one job in each actually needs the write:

- **#248** `docs-autofix.yml`: top-level `contents: write` + `pull-requests: write`
- **#68** `codeql.yml`: top-level `security-events: write`
- **#67** `dispatch-labeled-pr-suite.yml`: top-level `actions: write`

## Fix

Mirrors the job-scoped permissions pattern already established in `govulncheck.yml`: drop the workflow-level `permissions:` block to read-only, add an explicit job-level `permissions:` block (which fully **replaces**, not merges with, the workflow default) on only the job that needs the write.

| File | Workflow default (before → after) | Job-scoped write (added) |
|---|---|---|
| `docs-autofix.yml` | `contents:write, pull-requests:write, actions:read` → `actions:read` | `autofix`: `contents:write, pull-requests:write, actions:read` |
| `codeql.yml` | `actions:read, contents:read, security-events:write` → `actions:read, contents:read` | `analyze`: adds `security-events:write` (`runner-policy` keeps the read-only default) |
| `dispatch-labeled-pr-suite.yml` | `actions:write, contents:read, pull-requests:read` → `contents:read, pull-requests:read` | `dispatch-suite`: adds `actions:write` |

No behavior change — same effective token scope per job, just declared at the job boundary instead of inherited from the workflow default. Checkout trust boundaries, artifact access, PR comment/push, and dispatch behavior are all unchanged.

## Test plan

- [x] Added `scripts/workflow_permissions_test.go`: asserts workflow-level `permissions:` stays write-free and each named job (`autofix`, `analyze`, `dispatch-suite`) declares its write grant explicitly. Verified **red** against the pre-fix YAML (`git stash` the three workflow files, re-run — test fails), **green** after.
- [x] `actionlint` clean on all three edited workflow files.
- [x] `go vet ./...` clean.
- [x] Full `go test ./scripts/...` (89s) passing, including the unrelated `cipolicy` hash-pinning suite (confirms this change is outside that package's scope — it validates only `ci.yml`, `nightly.yml`, and `setup-gascity-ubuntu`).
- [x] `make test-fast-parallel` (pre-push hook) passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)