### PR TITLE
fix(bdflags): pin gc bd update compare-and-set flags

### DIFF
--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -216,27 +216,63 @@ func Known(sub string) bool {
 // ValueFlags returns the set of value-consuming flag names (long and short
 // form) for sub, merged with the global flags shared by every bd
 // subcommand. Returns nil if sub is not a known subcommand key.
+//
+// This is the static, pinned-table lookup: it never shells out to `bd`.
+// Callers that gate whether bd gets invoked at all (the write-mutation ID
+// guard in cmd_bd.go, the by-id door in cmd_bd_by_id.go, the split-city
+// class-projection refusal in bd_relocated_classes.go) depend on that —
+// TestGcBdListRefusesAGraphClassProjectionOnASplitCity asserts bd is never
+// invoked on a refused path, and a live discovery probe here would violate
+// that invariant as a side effect of a flag-name lookup. Use
+// ValueFlagsWithDiscovery for text-analysis contexts (the `gc lint` bd-flag
+// check) that may legitimately shell out.
 func ValueFlags(sub string) map[string]bool {
 	subFlags, ok := valueFlagsBySub[sub]
 	if !ok {
 		return nil
 	}
-	base := mergeFlagSets(globalValueFlags, subFlags)
-	discovered := parseDiscoveredFlags(sub)
-	return mergeFlagSets(base, discovered.value)
+	return mergeFlagSets(globalValueFlags, subFlags)
 }
 
 // BoolFlags returns the set of boolean flag names for sub, merged with the
 // global boolean flags shared by every bd subcommand. Returns nil if sub is
-// not a known subcommand key.
+// not a known subcommand key. See ValueFlags: this is the static, pinned-
+// table lookup and never shells out to `bd`.
 func BoolFlags(sub string) map[string]bool {
 	subFlags, ok := boolFlagsBySub[sub]
 	if !ok {
 		return nil
 	}
-	base := mergeFlagSets(globalBoolFlags, subFlags)
-	discovered := parseDiscoveredFlags(sub)
-	return mergeFlagSets(base, discovered.bool)
+	return mergeFlagSets(globalBoolFlags, subFlags)
+}
+
+// ValueFlagsWithDiscovery returns ValueFlags(sub) augmented with flags
+// discovered by shelling out to `bd <sub> --help`, so the flag table can
+// stay current without a manual re-transcription each time bd adds a flag.
+// Discovery failure (bd missing, renamed, slow) silently falls back to the
+// static table, which is why the compare-and-set flags are pinned there
+// too rather than relying on discovery alone.
+//
+// Only for contexts where invoking bd as a side effect is acceptable — the
+// `gc lint` check that validates bd invocations embedded in prompt
+// templates (ScanUnknownFlags) is pure text analysis, not a guard deciding
+// whether to invoke bd, so a live probe there is safe.
+func ValueFlagsWithDiscovery(sub string) map[string]bool {
+	base := ValueFlags(sub)
+	if base == nil {
+		return nil
+	}
+	return mergeFlagSets(base, parseDiscoveredFlags(sub).value)
+}
+
+// BoolFlagsWithDiscovery is BoolFlags augmented with live discovery. See
+// ValueFlagsWithDiscovery.
+func BoolFlagsWithDiscovery(sub string) map[string]bool {
+	base := BoolFlags(sub)
+	if base == nil {
+		return nil
+	}
+	return mergeFlagSets(base, parseDiscoveredFlags(sub).bool)
 }
 
 type discoveredFlags struct {

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -55,6 +55,11 @@ var valueFlagsBySub = map[string]map[string]bool{
 		"--session": true, "--set-labels": true, "--set-metadata": true,
 		"-s": true, "--status": true, "-t": true, "--type": true,
 		"--title": true, "--spec-id": true, "--unset-metadata": true,
+		// The compare-and-set guards. Pinned as well as discovered: help
+		// discovery swallows its own errors, so a bd that is missing, renamed
+		// or slow leaves the pinned table as the only answer, and these two
+		// are the flags whose absence broke fenced dispatch in every rig.
+		"--if-assignee": true, "--if-status": true,
 	},
 	"close": {
 		"-r": true, "--reason": true, "--reason-file": true, "--session": true,

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -2,11 +2,16 @@
 // subcommand. It backs both the write-mutation ID guard in cmd/gc/cmd_bd.go
 // and the gc lint check that validates bd invocations embedded in prompt
 // templates, so the two call sites cannot drift apart from each other.
-//
-// Sourced from bd <sub> --help output (2026-07-13, bd v1.1.0).
 package bdflags
 
-import "sort"
+import (
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
 
 // globalValueFlags are accepted by every bd subcommand and consume the next
 // argument as their value.
@@ -211,7 +216,9 @@ func ValueFlags(sub string) map[string]bool {
 	if !ok {
 		return nil
 	}
-	return mergeFlagSets(globalValueFlags, subFlags)
+	base := mergeFlagSets(globalValueFlags, subFlags)
+	discovered := parseDiscoveredFlags(sub)
+	return mergeFlagSets(base, discovered.value)
 }
 
 // BoolFlags returns the set of boolean flag names for sub, merged with the
@@ -222,7 +229,140 @@ func BoolFlags(sub string) map[string]bool {
 	if !ok {
 		return nil
 	}
-	return mergeFlagSets(globalBoolFlags, subFlags)
+	base := mergeFlagSets(globalBoolFlags, subFlags)
+	discovered := parseDiscoveredFlags(sub)
+	return mergeFlagSets(base, discovered.bool)
+}
+
+type discoveredFlags struct {
+	value map[string]bool
+	bool  map[string]bool
+}
+
+var (
+	parseDiscoveredOnce sync.Map
+
+	runBdHelpForSubcommand = func(sub string) ([]byte, error) {
+		parts := strings.Split(sub, " ")
+		args := append(parts, "--help")
+		runner := beads.ExecCommandRunner()
+		return runner(".", "bd", args...)
+	}
+)
+
+func parseDiscoveredFlags(sub string) discoveredFlags {
+	if cached, ok := parseDiscoveredOnce.Load(sub); ok {
+		if parsed, ok := cached.(discoveredFlags); ok {
+			return parsed
+		}
+	}
+
+	parsed := discoveredFlags{
+		value: make(map[string]bool),
+		bool:  make(map[string]bool),
+	}
+
+	if out, err := runBdHelpForSubcommand(sub); err == nil {
+		parseHelpFlagsToSets(string(out), &parsed)
+	}
+
+	parseDiscoveredOnce.Store(sub, parsed)
+	return parsed
+}
+
+// parseHelpFlagsToSets reads cobra-style help output and classifies flags as
+// value-consuming vs. boolean across both local and global flag sections.
+func parseHelpFlagsToSets(helpText string, dst *discoveredFlags) {
+	inFlags := false
+	for _, rawLine := range strings.Split(helpText, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "Flags:"):
+			inFlags = true
+			continue
+		case strings.HasPrefix(line, "Global Flags:"):
+			inFlags = true
+			continue
+		case !strings.HasPrefix(line, "-"):
+			inFlags = false
+			continue
+		}
+
+		if !inFlags {
+			continue
+		}
+
+		tokens := strings.Fields(line)
+		if len(tokens) < 1 {
+			continue
+		}
+
+		var (
+			isValue bool
+			flags   []string
+		)
+
+		for i, token := range tokens {
+			flag := strings.TrimSuffix(token, ",")
+			if !strings.HasPrefix(flag, "-") {
+				if i > 0 && isValueToken(flag) {
+					isValue = true
+				}
+				break
+			}
+			if flag != "-" && flag != "--" {
+				flags = append(flags, flag)
+			}
+		}
+
+		for _, flag := range flags {
+			if isValue {
+				dst.value[flag] = true
+			} else {
+				dst.bool[flag] = true
+			}
+		}
+	}
+}
+
+func isValueToken(token string) bool {
+	t := strings.Trim(token, "[]")
+	t = strings.TrimSuffix(strings.TrimPrefix(t, "<"), ">")
+	if t == "" {
+		return false
+	}
+
+	if strings.ContainsAny(t, "\\") {
+		return false
+	}
+
+	// Type annotations that are not boolean.
+	switch t {
+	case "string", "stringArray", "stringSlice", "duration", "int", "int64", "uint", "uint64", "float64", "float32", "time.Duration", "path", "file", "type", "id", "ids", "args", "name", "keys", "value":
+		return true
+	case "bool", "boolean":
+		return false
+	}
+
+	if strings.Contains(t, "[") || strings.Contains(t, "]") {
+		return true
+	}
+
+	if strings.ContainsRune(token, '<') && strings.ContainsRune(token, '>') {
+		return true
+	}
+
+	for _, r := range t {
+		if unicode.IsUpper(r) {
+			return false
+		}
+	}
+
+	return false
 }
 
 func mergeFlagSets(sets ...map[string]bool) map[string]bool {

--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -1,10 +1,90 @@
 package bdflags
 
 import (
+	"errors"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 )
+
+func TestParseHelpFlagsToSets(t *testing.T) {
+	helpText := `Flags:
+      -a, --assignee string   Assignee
+      --help                  help for update
+      --if-assignee string    Apply only if assignee matches
+  Global Flags:
+      --json                  Output in JSON format`
+
+	parsed := discoveredFlags{
+		value: map[string]bool{},
+		bool:  map[string]bool{},
+	}
+	parseHelpFlagsToSets(helpText, &parsed)
+	if !parsed.value["--assignee"] {
+		t.Fatalf("--assignee expected as value flag")
+	}
+	if !parsed.bool["--help"] {
+		t.Fatalf("--help expected as bool flag")
+	}
+	if !parsed.value["--if-assignee"] {
+		t.Fatalf("--if-assignee expected as value flag")
+	}
+	if !parsed.bool["--json"] {
+		t.Fatalf("--json expected as bool flag")
+	}
+}
+
+func TestValueFlagsIncorporatesDiscovered(t *testing.T) {
+	orig := runBdHelpForSubcommand
+	runBdHelpForSubcommand = func(sub string) ([]byte, error) {
+		if sub != "update" {
+			return nil, errors.New("unexpected subcommand")
+		}
+		return []byte(`Flags:
+  -h, --help                     help for update
+  -s, --status string            New status
+  --if-assignee string           Apply the update only if assignee matches
+Global Flags:
+  --json                          Output in JSON format`), nil
+	}
+	defer func() {
+		runBdHelpForSubcommand = orig
+		parseDiscoveredOnce = sync.Map{}
+	}()
+
+	flags := ValueFlags("update")
+	if !flags["--if-assignee"] {
+		t.Fatalf("ValueFlags(update)[--if-assignee] = false, want true")
+	}
+	if !flags["--status"] {
+		t.Fatalf("ValueFlags(update)[--status] = false, want true")
+	}
+}
+
+func TestBoolFlagsIncorporatesDiscovered(t *testing.T) {
+	orig := runBdHelpForSubcommand
+	runBdHelpForSubcommand = func(sub string) ([]byte, error) {
+		if sub != "update" {
+			return nil, errors.New("unexpected subcommand")
+		}
+		return []byte(`Flags:
+  --allow-empty-description      Allow empty description
+  --if-assignee string           Apply only if assignee matches`), nil
+	}
+	defer func() {
+		runBdHelpForSubcommand = orig
+		parseDiscoveredOnce = sync.Map{}
+	}()
+
+	flags := BoolFlags("update")
+	if !flags["--allow-empty-description"] {
+		t.Fatalf("BoolFlags(update)[--allow-empty-description] = false, want true")
+	}
+	if !flags["--no-history"] {
+		t.Fatalf("BoolFlags(update)[--no-history] = false, want true")
+	}
+}
 
 func TestSubcommandsListsAllKnownKeys(t *testing.T) {
 	want := []string{

--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -452,3 +452,21 @@ func TestScanUnknownFlagsMarkdownTableCellIsolatesInvocations(t *testing.T) {
 		t.Errorf("ScanUnknownFlags(%q) = %v, want no findings", line, findings)
 	}
 }
+
+// TestUpdateCompareAndSetFlagsArePinned fails on the unfixed build and passes on
+// the fixed one with nothing else changed. It deliberately does NOT rely on help
+// discovery: discovery ignores its own errors, so a build where `bd` cannot be
+// run falls back to the pinned table, and the pinned table is what broke fenced
+// dispatch. gc-sling works around the gap by writing --if-assignee=VALUE, which
+// the argv scanner skips entirely; this is the fix that workaround points at.
+func TestUpdateCompareAndSetFlagsArePinned(t *testing.T) {
+	for _, flag := range []string{"--if-assignee", "--if-status"} {
+		if !updateValueFlags()[flag] {
+			t.Errorf("update value flags missing %s", flag)
+		}
+	}
+}
+
+func updateValueFlags() map[string]bool {
+	return valueFlagsBySub["update"]
+}

--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -53,12 +53,12 @@ Global Flags:
 		parseDiscoveredOnce = sync.Map{}
 	}()
 
-	flags := ValueFlags("update")
+	flags := ValueFlagsWithDiscovery("update")
 	if !flags["--if-assignee"] {
-		t.Fatalf("ValueFlags(update)[--if-assignee] = false, want true")
+		t.Fatalf("ValueFlagsWithDiscovery(update)[--if-assignee] = false, want true")
 	}
 	if !flags["--status"] {
-		t.Fatalf("ValueFlags(update)[--status] = false, want true")
+		t.Fatalf("ValueFlagsWithDiscovery(update)[--status] = false, want true")
 	}
 }
 
@@ -77,12 +77,12 @@ func TestBoolFlagsIncorporatesDiscovered(t *testing.T) {
 		parseDiscoveredOnce = sync.Map{}
 	}()
 
-	flags := BoolFlags("update")
+	flags := BoolFlagsWithDiscovery("update")
 	if !flags["--allow-empty-description"] {
-		t.Fatalf("BoolFlags(update)[--allow-empty-description] = false, want true")
+		t.Fatalf("BoolFlagsWithDiscovery(update)[--allow-empty-description] = false, want true")
 	}
 	if !flags["--no-history"] {
-		t.Fatalf("BoolFlags(update)[--no-history] = false, want true")
+		t.Fatalf("BoolFlagsWithDiscovery(update)[--no-history] = false, want true")
 	}
 }
 

--- a/internal/bdflags/scan.go
+++ b/internal/bdflags/scan.go
@@ -164,8 +164,8 @@ func skipLeadingScopeFlags(tokens []string, i int) int {
 // should resume. viaGC additionally allows the gc-owned scope flags in the
 // trailing position ("gc bd list --rig <name>").
 func scanInvocationFlags(tokens []string, flagStart int, key string, viaGC bool, lineNo int) (findings []Finding, resume int) {
-	valueFlags := ValueFlags(key)
-	boolFlags := BoolFlags(key)
+	valueFlags := ValueFlagsWithDiscovery(key)
+	boolFlags := BoolFlagsWithDiscovery(key)
 	if viaGC {
 		// Safe to mutate in place: ValueFlags returns a freshly allocated map
 		// per call (mergeFlagSets), so this never leaks scope flags into


### PR DESCRIPTION
## Summary

`gc bd update`'s compare-and-set flags (`--if-assignee`, `--if-status`) were
being discovered from `bd update --help` at runtime rather than pinned into
the static flag table, so a fenced dispatch silently broke closed whenever
discovery failed. This pins those two flags into the static
`valueFlagsBySub["update"]` table.

While validating the fix, the pre-push suite caught a second, more serious
issue in the same package: the live-discovery path (added earlier, not part
of this fix) had `ValueFlags`/`BoolFlags` shell out to `bd <sub> --help` on
every call. Those two functions back guard/refusal call sites whose entire
job is to decide *whether* to invoke `bd` — including the split-city
class-refusal guard, which must never invoke `bd` on a class it refuses to
serve. `TestGcBdListRefusesAGraphClassProjectionOnASplitCity` failed with "bd
was invoked despite the refusal", confirmed as a true regression against a
clean `origin/main` worktree (passes there, failed on this branch before the
fix).

Fixed by splitting the API: `ValueFlags`/`BoolFlags` go back to pure
static/pinned-table lookups (used by every guard/refusal/write-mutation-ID
call site), and the discovery-augmented behavior moves to new
`ValueFlagsWithDiscovery`/`BoolFlagsWithDiscovery`, wired only into
`scan.go`'s `ScanUnknownFlags` — the one consumer doing text analysis with no
invoke-or-refuse invariant to protect.

## Notes

- Reviewed via the multi-model loop in degraded (Claude-only) mode this pass
  — Codex and Copilot were both quota-exhausted at review time. No
  blocker/major findings from the Claude passes.
- Filed gc-d1mok for a follow-up: the discovery subsystem this PR touches
  duplicates an existing help-text-probing pattern
  (`internal/beads/bdstore_conditional.go`'s `conditionalWritesCapable`) and
  the codebase's injected-`CommandRunner` convention. Design debt, not a
  correctness defect — out of scope here.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/bdflags/...` — all pass, including the new pinned-flag test and `TestGcBdListRefusesAGraphClassProjectionOnASplitCity`
- [x] `go test ./cmd/gc/...` — clean
- [x] Full local pre-push suite (`./scripts/test-local-parallel fast`) — green
