### PR TITLE
fix(mail): keep a self-handoff addressed to one session on both sides (ga-28neu4)

### DIFF
--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -194,7 +194,21 @@ func (p *Provider) SendHandoff(intent mail.HandoffIntent) (mail.Message, error) 
 	labels = append(labels, "thread:"+intent.ThreadID)
 	labels = append(labels, intent.ExtraLabels...)
 
-	b, err := p.createMessageBead(intent.Subject, intent.Body, from, intent.To, labels, metadata)
+	// A self-handoff (gc handoff, and the gc handoff --auto that PreCompact
+	// fires) names one session on both sides. resolveSenderRoute can re-render
+	// that address -- an aliasless pool member addresses itself by its raw
+	// session ID and resolves to its session_name -- so carry the resolved form
+	// to the recipient too. Left unequal, the stored row shows two different
+	// strings for one session and every consumer that compares sender against
+	// recipient reads a self-addressed marker as agent-to-agent mail (ga-28neu4).
+	// Delivery is unaffected either way: both renderings are in the session's
+	// own RecipientRoutesFromInfo route set.
+	to := intent.To
+	if from != "" && strings.TrimSpace(to) == strings.TrimSpace(intent.From) {
+		to = from
+	}
+
+	b, err := p.createMessageBead(intent.Subject, intent.Body, from, to, labels, metadata)
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail handoff: %w", err)
 	}

--- a/internal/mail/beadmail/handoff_self_address_test.go
+++ b/internal/mail/beadmail/handoff_self_address_test.go
@@ -1,0 +1,145 @@
+package beadmail
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// poolSessionDirectory resolves selectors against a fixed session set. It
+// models the production shape of a pool member: the session bead carries a
+// session_name ("builder-<id>") but no alias, so the only address its own
+// commands can name it by is the raw session ID.
+type poolSessionDirectory struct {
+	infos []session.Info
+}
+
+func (d poolSessionDirectory) resolve(selector string) (session.Info, error) {
+	for _, info := range d.infos {
+		for _, route := range session.RecipientRoutesFromInfo(info) {
+			if route == selector {
+				return info, nil
+			}
+		}
+	}
+	return session.Info{}, session.ErrSessionNotFound
+}
+
+func (d poolSessionDirectory) ResolveAddress(selector string, _ bool) (session.Info, error) {
+	return d.resolve(selector)
+}
+
+func (d poolSessionDirectory) ResolveMailboxAddress(selector string, _ bool) (session.Info, error) {
+	return d.resolve(selector)
+}
+
+func (d poolSessionDirectory) ListAddresses(bool) ([]session.Info, error) {
+	return d.infos, nil
+}
+
+var (
+	pooledBuilder = session.Info{
+		ID:                  "gm-wisp-gpenji",
+		SessionNameMetadata: "builder-gm-wisp-gpenji",
+	}
+	namedMayor = session.Info{
+		ID:                  "gm-wisp-mayor01",
+		Alias:               "mayor",
+		SessionNameMetadata: "mayor",
+	}
+	fleetDirectory = poolSessionDirectory{infos: []session.Info{pooledBuilder, namedMayor}}
+)
+
+// TestSendHandoffSelfAddressedPersistsOneAddress proves that a self-handoff --
+// the shape gc handoff --auto sends from the PreCompact hook, where the caller
+// passes ONE address as both From and To -- must not persist as two different
+// addresses.
+//
+// SendHandoff normalizes only the From side (resolveSenderRoute ->
+// senderDisplayAddress, beadmail.go:189/233) and stores intent.To verbatim as
+// the bead Assignee (beadmail.go:197/213). For a pooled session with no alias,
+// addressed by its own raw session ID, senderDisplayAddress falls through to
+// the SessionNameMetadata branch (beadmail.go:249-251) and rewrites From to
+// "builder-<id>" while Assignee stays "<id>".
+//
+// Both strings name the same session and delivery is unaffected --
+// matchesRecipientRoute compares the assignee against
+// session.RecipientRoutesFromInfo, which contains the ID -- but the persisted
+// row now reads as agent-to-agent mail to every consumer that compares the two
+// fields.
+func TestSendHandoffSelfAddressedPersistsOneAddress(t *testing.T) {
+	store := beads.NewMemStore()
+	p := NewWithSessionDirectory(store, fleetDirectory)
+
+	const selfAddress = "gm-wisp-gpenji"
+	msg, err := p.SendHandoff(mail.HandoffIntent{
+		From:        selfAddress,
+		To:          selfAddress,
+		Subject:     "context cycle",
+		ThreadID:    "thread-deadbeef",
+		ExtraLabels: []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("SendHandoff: %v", err)
+	}
+
+	b, err := store.Get(msg.ID)
+	if err != nil {
+		t.Fatalf("Get %s: %v", msg.ID, err)
+	}
+	if b.From != b.Assignee {
+		t.Errorf("self-handoff persisted as cross-agent mail: bead From = %q, Assignee = %q; want both to name the same address",
+			b.From, b.Assignee)
+	}
+	if msg.From != msg.To {
+		t.Errorf("self-handoff message From = %q, To = %q; want both to name the same address", msg.From, msg.To)
+	}
+}
+
+// TestSelfHandoffFromPooledSessionStaysInItsOwnInbox falsifies the delivery
+// half of ga-28neu4: the claim that a compaction marker whose From and
+// Assignee differ "lands in someone else's inbox and fires a real 'you have
+// mail' notification".
+//
+// It does not. matchesRecipientRoute compares the bead assignee against
+// session.RecipientRoutesFromInfo by exact string equality, and that route set
+// contains the session's own ID -- so the marker is delivered to exactly the
+// session that sent it, and is invisible to every other mailbox.
+func TestSelfHandoffFromPooledSessionStaysInItsOwnInbox(t *testing.T) {
+	store := beads.NewMemStore()
+	p := NewWithSessionDirectory(store, fleetDirectory)
+
+	msg, err := p.SendHandoff(mail.HandoffIntent{
+		From:        pooledBuilder.ID,
+		To:          pooledBuilder.ID,
+		Subject:     "context cycle",
+		ThreadID:    "thread-deadbeef",
+		ExtraLabels: []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("SendHandoff: %v", err)
+	}
+
+	// The sending session sees its own marker, addressed by either of the two
+	// renderings of its address.
+	for _, selector := range []string{pooledBuilder.ID, pooledBuilder.SessionNameMetadata} {
+		got, err := p.Inbox(selector)
+		if err != nil {
+			t.Fatalf("Inbox(%q): %v", selector, err)
+		}
+		if len(got) != 1 || got[0].ID != msg.ID {
+			t.Errorf("Inbox(%q) = %d message(s), want exactly the marker %s", selector, len(got), msg.ID)
+		}
+	}
+
+	// No other mailbox sees it. This is the claim ga-28neu4 rests on.
+	others, err := p.Inbox("mayor")
+	if err != nil {
+		t.Fatalf("Inbox(mayor): %v", err)
+	}
+	if len(others) != 0 {
+		t.Errorf("Inbox(mayor) = %d message(s), want 0; a self-addressed compaction marker leaked into another agent's inbox", len(others))
+	}
+}


### PR DESCRIPTION
Investigation of ga-28neu4, which reported that 148 context-cycle compaction markers a day were
being addressed to other agents and firing false "you have mail" notifications.

**That is not happening, and never was: 0 of 826 markers all-time are addressed to another agent.**
But the report was an honest reading of what the store actually says, and this PR fixes the reason it
says the wrong thing.

## Root cause

`SendHandoff` normalizes only the sender. `intent.From` goes through `resolveSenderRoute`
(`beadmail.go:189` → `:233`), while `intent.To` is stored verbatim as the bead assignee
(`:197` → `:213`). An aliasless pool member can only address itself by its raw session ID, so
`senderDisplayAddress` falls through to the `SessionNameMetadata` branch (`:249-251`) and rewrites
From to `builder-<id>` while Assignee stays `<id>`.

`gc handoff --auto` — the PreCompact hook — passes one address for both sides
(`cmd/gc/cmd_handoff.go:314`). So a self-handoff persists as two different strings naming one session:

```
created_by                assignee            n
builder-gm-wisp-gpenji    gm-wisp-gpenji     44
builder-gm-wisp-chmzwy    gm-wisp-chmzwy     23
...                       17 sessions, same shape every row
```

Classified properly (`created_by = assignee OR created_by LIKE CONCAT('%-', assignee)`), the 826
context-cycle markers in the city store are 515 self_exact + 311 self_renamed + **0 cross_agent**.

## Delivery was never affected

`matchesRecipientRoute` (`beadmail.go:1157`) is exact string equality against
`session.RecipientRoutesFromInfo` (`internal/session/address_directory.go:208`), whose route set
contains the session's own ID, alias, session name and alias history. A marker assigned to
`gm-wisp-gpenji` can only match that session's own route set. There is no mechanism by which these
land in another agent's mailbox.

The cost was interpretive, not operational — but it is a real cost: any consumer comparing sender
against recipient reads 311 self-addressed markers as agent-to-agent mail, which is exactly the
false P2 this PR is filed under.

## The fix

Carry the resolved sender address to the recipient when the intent names the same address on both
sides. Four lines. It changes how the row reads, never where it lands.

## Tests

- `TestSendHandoffSelfAddressedPersistsOneAddress` — RED before the change with the exact production
  strings, GREEN after. This is the reproduction.
- `TestSelfHandoffFromPooledSessionStaysInItsOwnInbox` — **passes before and after.** It asserts the
  marker reaches its own session's inbox under both renderings of its address and is absent from
  another agent's inbox. Green on unmodified code is the executable disproof of the reported leak;
  green after the change is the regression guard that this PR did not move delivery.

## Out of scope

`Provider.Send` has the same from-resolved/to-verbatim shape, but for ordinary agent-to-agent mail
the two addresses genuinely differ, so it produces no artifact. Only a self-send from an aliasless
pooled session could hit it. Left alone deliberately.

Refs: ga-28neu4
