### PR TITLE
Fix push ownership checks for reused builder branches

### DIFF
--- a/release-gates/ga-bf39j8-push-ownership-branch-reuse-gate.md
+++ b/release-gates/ga-bf39j8-push-ownership-branch-reuse-gate.md
@@ -1,0 +1,45 @@
+# Release gate: push-ownership branch reuse (`ga-bf39j8`)
+
+- Gate result: **PASS**
+- Reviewed commit: `813d27f5cb9727a8b84a7589b7ee95c59abe3c29`
+- Gated commit after bounded self-rebase: `323ae11493cfb19da07e820f1097e4e4a20f956f`
+- Base ref: `origin/main@8c73625b974ce8d3d68d54ab42062e6247c47036`
+- Deploy mode: remote
+- Evaluation date: 2026-08-19
+- Full-suite logs: `/var/tmp/gc-local-tests.U2ksqv`
+
+`docs/PROJECT_MANIFEST.md` is not present at the evaluated ref. This gate uses
+the canonical criteria in `mol-deployer-gate.formula.toml`, the current
+deployer prompt, and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Reviewer PASS present for deployed commit | **PASS** | The reviewer recorded an independent PASS for resolved commit `813d27f5cb9727a8b84a7589b7ee95c59abe3c29`. The bounded helper replayed that exact one-commit change onto current main as `323ae11493cfb19da07e820f1097e4e4a20f956f`; no content changes were added. |
+| 2 | Acceptance criteria met | **PASS** | The guard now substitutes a declared live successor only after a fresh read confirms the branch-derived bead is inactive. The relationship must be explicit through `metadata.branch` or `metadata.build_bead`; unrelated concurrent work is rejected, an active predecessor stays authoritative, and read/parse failure remains fail-closed. The five added `branch_reused_*` cases exercise those obligations. |
+| 3 | Tests pass | **PASS** | With rootless Podman enabled and the pinned testcontainers image `dolthub/dolt-sql-server:1.32.4` cached, the documented CI-equivalent command `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true GO_TEST_TIMEOUT=30m make test-local-full-parallel` completed **33 PASS / 7 FAIL / 0 SKIP jobs**. All seven failures are attributed under criterion 3a; none is diff-owned. The diff-owned shell suite completed **35 PASS / 0 FAIL / 0 SKIP**, including all five new cases, and the Go wrapper `TestPushOwnershipGuard` passed. A later pre-push fast run completed **9 PASS / 1 FAIL / 0 SKIP jobs**; its sole failure is also attributed under 3a. |
+| 3a | Pre-existing failures attributable | **PASS** | The diff changes only `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`; it cannot compile into or execute any failing Go package, cannot change the installed `bd` flag surface, and cannot change the host tmux key table or Dolt fixture startup timing. This is a structural mechanism proof, stronger than a probabilistic base rerun, and there is no path overlap. Exact trackers: `TestBdFlagManifestCurrent` -> `ga-f0uceo`; `TestGetKeyBinding_CapturesDefaultBinding` -> `ga-afqddr`; `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-k3fxvj`; `TestAdoptPRFormulaRetriesTransientReviewerStep`, `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries`, and `TestPersonalWorkFormulaCompileAndRun` with the beads#4566 dirty-table signature -> `ga-lpfjhc`; `TestDoltConfigWiringExternalHost` -> `ga-gajll3` (fix `e669302f4b7e046768bf81622cd90242a4cff289` verified not on current `origin/main`); pre-push `TestDisableAndPurgeRejectsPeerSuccessorReplacedDuringCleanProof` -> `ga-s759zk` / upstream issue #4653, which records the same load-sensitive race under parallel `make test`. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy` passed: 5 runner-policy tests, 15 suite-coverage tests, the `scripts/cipolicy` package, and the focused static-scope suite. `shellcheck` on both changed scripts, `bash -n`, `zsh -n`, `LINT_CHANGED_REF=origin/main make lint-affected`, `LINT_CHANGED_REF=origin/main make fmt-check-changed`, and `go vet ./...` all passed. The affected lint/format selectors correctly reported no changed Go build inputs or Go files. |
+| 4 | No unresolved HIGH review findings | **PASS** | The independent reviewer reported no defects; unresolved HIGH count is 0. |
+| 5 | Final branch clean | **PASS** | `git status --porcelain` was empty before this checklist was written. This checklist is the only gate artifact added afterward. |
+| 6 | Branch diverges cleanly from main | **PASS** | Initial staleness was resolved only through the mandated bounded helper: `813d27f5cb9727a8b84a7589b7ee95c59abe3c29` -> `323ae11493cfb19da07e820f1097e4e4a20f956f`. The helper completed its force-with-lease push, `origin/builder/ga-bf39j8` was independently verified at the after SHA, and `origin/main@8c73625b974ce8d3d68d54ab42062e6247c47036` is an ancestor of the gated commit. |
+| 7 | Single feature theme | **PASS** | The one-commit, two-file change is confined to one subsystem: push-ownership guard branch-reuse resolution and its regression tests. |
+
+## Test-integrity fields
+
+- `test_cmd`: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true GO_TEST_TIMEOUT=30m make test-local-full-parallel`
+- `test_counts`: full union `33 PASS / 7 FAIL / 0 SKIP jobs`; pre-push fast attempt `9 PASS / 1 FAIL / 0 SKIP jobs`; all failures attributed above
+- `diff_tests_executed`: all 35 cases in `scripts/test-push-ownership-guard.sh` PASS, including the five new `branch_reused_*` cases; Go wrapper `TestPushOwnershipGuard` PASS
+- `skip_justification`: none; the runner reported no job-level or diff-owned skip
+- `waiver_ref`: `ga-lpfjhc` carries the existing mayor standing authorization for the exact beads#4566 dirty-table signature; no diff-owned waiver was used
+- `policy_lane`: `make test-ci-policy` PASS
+- `failure_attribution`: `TestBdFlagManifestCurrent` -> `ga-f0uceo`; tmux default-binding tests -> `ga-afqddr` / `ga-k3fxvj`; beads#4566 review-formula fixture failures -> `ga-lpfjhc`; `TestDoltConfigWiringExternalHost` -> `ga-gajll3`; `TestDisableAndPurgeRejectsPeerSuccessorReplacedDuringCleanProof` -> `ga-s759zk` / upstream #4653; structural proof is the shell-only diff with zero path or execution overlap
+
+## Disposition
+
+All criteria pass. Proceed from the gated SHA to the isolated
+`deploy/ga-bf39j8-gate` branch, push that branch only, open the pull request,
+publish deploy clearance on the exact PR head, and route the merge-request to
+the merge authority. The deployer does not merge.

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -115,6 +115,24 @@ _pog_read_with_retry() {
     return 1
 }
 
+# _pog_branch_id_bead_inactive <id>: true (rc 0) only if a FRESH bd show
+# confirms <id>'s status is neither in_progress nor open -- i.e. the branch-
+# derived bead is no longer the live claim. Fails safe: any read/parse
+# failure returns 1 (treat as still-active / not confirmed inactive), so an
+# unreachable bd never triggers the branch-reuse override below -- it just
+# falls through to the existing branch-id-wins path, which itself blocks
+# safely on the same failure via assert_bead_still_claimed's own read.
+_pog_branch_id_bead_inactive() {
+    local id="$1"
+    local json
+    json="$(_pog_read_with_retry bd show "$id" --json)" || return 1
+    [[ -n "$json" ]] || return 1
+    jq -e '.' <<<"$json" >/dev/null 2>&1 || return 1
+    local st
+    st="$(jq -r '.[0].status // empty' <<<"$json" 2>/dev/null || true)"
+    [[ "$st" != "in_progress" && "$st" != "open" && -n "$st" ]]
+}
+
 # _pog_resolve_bead_id: prints the bead id this push should be checked
 # against; prints nothing if none can be resolved. Resolution order:
 #   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* —
@@ -137,6 +155,18 @@ _pog_read_with_retry() {
 # legitimately drift from bd's bookkeeping. EXCEPTION: deploy/*-gate
 # branches (see below) embed the id of the bead being gated, not the bead
 # this push is for, so for that branch shape the live assignee wins instead.
+# EXCEPTION (branch reuse, ga-bf39j8): a branch name can be reused across a
+# sequence of beads — a predecessor bead closes and a live successor bead
+# continues the identical work on the identical branch name. When the
+# branch-derived bead is confirmed no longer live (a fresh bd show shows it's
+# not in_progress/open) AND a DIFFERENT in-progress bead in this session's
+# own assignment list declares itself that bead's continuation via
+# metadata.branch (matching the literal branch name) or metadata.build_bead
+# (matching the branch-derived id), that successor id wins instead. This is
+# an explicit declared-link check, not a blind "first in-progress bead"
+# pick — a session identity routinely holds several unrelated in-progress
+# beads at once, so picking one without a relational check would validate
+# this push against a totally unrelated concurrent task.
 #
 # KNOWN LIMITATION of path 2 (confirmed by manual repro, not yet filed as
 # its own bead): the fallback query itself filters on --status=in_progress,
@@ -207,6 +237,24 @@ _pog_resolve_bead_id() {
             return
         fi
         printf '%s' "$assignee_id"
+        return
+    fi
+
+    # BRANCH REUSE (ga-bf39j8): see the EXCEPTION note above the function
+    # doc comment. Look for a live in-progress bead that explicitly declares
+    # itself the branch-derived bead's continuation, but only act on it once
+    # the branch-derived bead is confirmed no longer live — an explicit link
+    # to a still-active bead is not this guard's problem to resolve, it just
+    # falls through to the ordinary disagreement warning below.
+    local successor_id=""
+    if [[ -n "$branch_id" ]]; then
+        successor_id="$(jq -r --arg br "$branch" --arg bid "$branch_id" \
+            '[.[] | select(.metadata.branch == $br or .metadata.build_bead == $bid)][0].id // empty' \
+            <<<"${list_json:-[]}" 2>/dev/null || true)"
+    fi
+    if [[ -n "$successor_id" && "$successor_id" != "$branch_id" ]] && _pog_branch_id_bead_inactive "$branch_id"; then
+        echo "push-ownership-guard: NOTE branch $branch was reused after $branch_id closed; this session's in-progress $successor_id declares itself that bead's continuation (metadata.branch/build_bead), using $successor_id instead" >&2
+        printf '%s' "$successor_id"
         return
     fi
 

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -556,6 +556,199 @@ test_bead_id_fallback_used_when_branch_no_match() {
     rm -rf "$repo" "$fbd"
 }
 
+# ---------------------------------------------------------------------------
+# Branch reuse (ga-bf39j8): the same branch name can be reused across a
+# sequence of beads over time -- e.g. a build bead closes, and a review bead
+# continues work on the IDENTICAL branch. The branch-derived id then names a
+# CLOSED predecessor, not this push's actual bead, and the plain
+# branch-wins rule permanently blocks every future push on that branch.
+# Concrete real repro (see ga-bf39j8's own notes for the full chain, verified
+# against live bd data twice): branch builder/ga-pyp2oh, bead ga-pyp2oh
+# closed, a review bead (e.g. ga-zpo) with metadata.branch ==
+# "builder/ga-pyp2oh" and metadata.build_bead == "ga-14w" (an intermediate
+# closed bead) still in_progress under the same session identity. The fix
+# only overrides when a candidate among this session's own in-progress beads
+# EXPLICITLY declares itself the branch's continuation (metadata.branch
+# equal to the literal current branch name, or metadata.build_bead equal to
+# the closed branch-derived id) AND a fresh read confirms the branch-derived
+# bead is actually no longer active. An explicit declared link is required,
+# not just "any in-progress bead under this assignee": this shared assignee
+# identity routinely holds several unrelated in-progress beads at once (see
+# the cardinality test below), and picking one blind would validate this
+# push against totally unrelated work.
+# ---------------------------------------------------------------------------
+
+test_bead_id_branch_reused_prefers_open_successor_when_branch_bead_closed() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-newsuc) printf '[{"id":"ga-newsuc","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-newsuc","metadata":{"branch":"builder/ga-oldbld-my-feature","build_bead":"ga-oldbld"}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -eq 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" && grep -qx "ga-newsuc" <<<"$show_ids"; then
+        record_pass "resolve/branch-reused-prefers-open-successor-when-branch-bead-closed (rc=0, checked ga-oldbld (found closed) then verified ownership fresh against live successor ga-newsuc)"
+    else
+        record_fail "resolve/branch-reused-prefers-open-successor-when-branch-bead-closed" "expected rc=0 with bd show called against both ga-oldbld (closure check) and ga-newsuc (final ownership check), got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# Same fixture, but the successor declares itself via metadata.branch alone
+# (no build_bead key at all) -- pins that either signal independently is
+# sufficient, not just their conjunction.
+test_bead_id_branch_reused_successor_match_via_branch_metadata_alone() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-newsuc) printf '[{"id":"ga-newsuc","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-newsuc","metadata":{"branch":"builder/ga-oldbld-my-feature"}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -eq 0 ]] && grep -qx "ga-newsuc" <<<"$show_ids"; then
+        record_pass "resolve/branch-reused-successor-match-via-branch-metadata-alone (rc=0, metadata.branch alone is sufficient)"
+    else
+        record_fail "resolve/branch-reused-successor-match-via-branch-metadata-alone" "expected rc=0 with ga-newsuc checked, got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# Same fixture again, successor declares itself via metadata.build_bead alone
+# (metadata.branch absent) -- the mirror image of the test above.
+test_bead_id_branch_reused_successor_match_via_build_bead_metadata_alone() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-newsuc) printf '[{"id":"ga-newsuc","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-newsuc","metadata":{"build_bead":"ga-oldbld"}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -eq 0 ]] && grep -qx "ga-newsuc" <<<"$show_ids"; then
+        record_pass "resolve/branch-reused-successor-match-via-build-bead-metadata-alone (rc=0, metadata.build_bead alone is sufficient)"
+    else
+        record_fail "resolve/branch-reused-successor-match-via-build-bead-metadata-alone" "expected rc=0 with ga-newsuc checked, got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# Safety/cardinality (the reasoning that ruled out a plain "any live claim
+# wins" fix): the shared assignee identity routinely holds several
+# unrelated in-progress beads at once. An in-progress bead with no
+# metadata.branch/build_bead tying it to THIS branch or to the closed
+# branch-derived bead must never be silently substituted -- the guard must
+# keep blocking on the real (closed) branch-derived bead instead.
+test_bead_id_branch_reused_does_not_pick_unrelated_inprogress_bead_as_successor() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    printf '[{"id":"ga-unrel8d","metadata":{}}]' > "$fbd/fake-bd-state/list-json"
+    write_show_json "$fbd" "ga-oldbld" "closed" "agent-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    if [[ $rc -ne 0 ]] && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor (rc=$rc, unrelated concurrent bead correctly ignored, blocks on the real closed bead)"
+    else
+        record_fail "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor" "expected non-zero rc mentioning status+--no-verify (an unrelated in-progress bead under the same assignee must never be silently substituted), got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# The override must require CONFIRMED inactivity, not just the existence of
+# a declared successor candidate: if the branch-derived bead is still
+# active, it remains authoritative even though a (differently-purposed)
+# in-progress successor-shaped bead exists.
+test_bead_id_branch_reused_does_not_override_when_branch_bead_still_active() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-newsuc) printf '[{"id":"ga-newsuc","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-newsuc","metadata":{"branch":"builder/ga-oldbld-my-feature","build_bead":"ga-oldbld"}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -eq 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" && ! grep -qx "ga-newsuc" <<<"$show_ids"; then
+        record_pass "resolve/branch-reused-does-not-override-when-branch-bead-still-active (rc=0, final ownership check used still-active ga-oldbld only, never queried ga-newsuc)"
+    else
+        record_fail "resolve/branch-reused-does-not-override-when-branch-bead-still-active" "expected rc=0 with bd show called against ga-oldbld only (still-active branch bead must remain authoritative, not be overridden), got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 # Regression (ga-wwswme): deploy/*-gate branches embed the id of the bead
 # being GATED, which is routinely CLOSED by the time the gate branch is
 # pushed (that's the whole point of a deploy gate) — the plain branch-wins
@@ -855,6 +1048,11 @@ run_all() {
     test_bead_id_branch_wins_and_warns_on_disagreement
     test_bead_id_branch_resolves_multi_level_subbead_id
     test_bead_id_fallback_used_when_branch_no_match
+    test_bead_id_branch_reused_prefers_open_successor_when_branch_bead_closed
+    test_bead_id_branch_reused_successor_match_via_branch_metadata_alone
+    test_bead_id_branch_reused_successor_match_via_build_bead_metadata_alone
+    test_bead_id_branch_reused_does_not_pick_unrelated_inprogress_bead_as_successor
+    test_bead_id_branch_reused_does_not_override_when_branch_bead_still_active
     test_bead_id_deploy_gate_branch_prefers_live_assignee
     test_bead_id_deploy_gate_branch_allows_when_no_live_assignee
     test_bead_id_deploy_gate_branch_blocks_when_assignee_lookup_fails


### PR DESCRIPTION
## What this changes

Push ownership checks now recognize when a long-lived builder branch has moved from a closed predecessor bead to an active successor. If the successor explicitly identifies the same branch or predecessor, the guard validates the push against that live work item instead of permanently rejecting the branch as stale.

The guard remains fail-closed: it only substitutes the successor after a fresh read confirms the predecessor is inactive, and unreadable or malformed bead state still blocks the push.

## Review notes

- The change is confined to branch-to-bead resolution in `scripts/push-ownership-guard.sh` and its shell regression suite.
- Successor selection requires an explicit `metadata.branch` or `metadata.build_bead` relationship; unrelated concurrent assignments are ignored.
- Existing `deploy/*-gate` behavior and the final ownership checks are unchanged.

## Test plan

- [x] Run all 35 push-ownership-guard shell cases, including the five new branch-reuse cases.
- [x] Run shellcheck plus Bash and Zsh syntax validation.
- [x] Run the full local CI-equivalent union with rootless Podman and verify every diff-owned test passes; attributed host/infrastructure failures are documented in the gate.
- [x] Run the repository policy lane and `go vet ./...`.
- [x] Release gate: [`release-gates/ga-bf39j8-push-ownership-branch-reuse-gate.md`](release-gates/ga-bf39j8-push-ownership-branch-reuse-gate.md)
