### PR TITLE
fix(formula): prevent duplicate and mis-rooted attachments

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -950,15 +950,24 @@ store, copy them into the binding with
 					_, _ = fmt.Fprintf(stderr, "Auto-burned stale molecule %s\n", id)
 				}
 
+				attachBead, err := attachStore.Get(attach)
+				if err != nil {
+					return formulaCommandError(stderr, "gc formula cook: attach", jsonOutput, fmt.Errorf("attach bead %s: %w", attach, err))
+				}
+
 				result, err := molecule.Attach(cmd.Context(), attachStore, recipe, attach, molecule.AttachOptions{
 					Title:          title,
 					Vars:           cookVars,
 					IdempotencyKey: graphRootKey,
-					// attach names its own root: a workflow_id/molecule_id it
-					// carries is a separate attachment (just ruled out above),
-					// not a container it lives inside, so ResolveRunID's
-					// chain-walk must not run here.
-					SelfRoot: true,
+					// CheckNoMoleculeChildren above only rules out a molecule
+					// already ATTACHED TO attach (downward). It says nothing
+					// about whether attach is itself a step INSIDE a live
+					// workflow (upward, via gc.root_bead_id) -- self-root
+					// only when attach carries no gc.root_bead_id of its own,
+					// otherwise ResolveRunID's chain-walk must run so a
+					// workflow step grafts onto the real root, not itself
+					// (ga-er5u7k).
+					SelfRoot: attachBead.Metadata[beadmeta.RootBeadIDMetadataKey] == "",
 				})
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook: attach", jsonOutput, err)

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/graphroute"
 	"github.com/gastownhall/gascity/internal/graphv2"
 	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/sling"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/spf13/cobra"
 )
@@ -931,10 +932,33 @@ store, copy them into the binding with
 				// its own graph leg through resolveGraphStore, which already
 				// names the binding, and its work leg is only read for an input
 				// convoy this arm never mints.
+				//
+				// Unlike the graph.v2 arm above, this path had no
+				// existing-attachment guard at all: attach targets a
+				// caller-named bead rather than a workflow-scoped step, so a
+				// bead that already carries a live molecule/workflow
+				// attachment (e.g. a sling finishing-sling wrapper) could
+				// accumulate a second, unrelated one on every cook --attach
+				// (ga-qiplt2). CheckNoMoleculeChildren is the same guard
+				// sling's own legacy (non-graph) attach path uses before
+				// instantiating a molecule (sling_core.go).
+				var attachCheck sling.SlingResult
+				if err := sling.CheckNoMoleculeChildren(attachStore, attach, attachStore, &attachCheck); err != nil {
+					return formulaCommandError(stderr, "gc formula cook: attach", jsonOutput, err)
+				}
+				for _, id := range attachCheck.AutoBurned {
+					_, _ = fmt.Fprintf(stderr, "Auto-burned stale molecule %s\n", id)
+				}
+
 				result, err := molecule.Attach(cmd.Context(), attachStore, recipe, attach, molecule.AttachOptions{
 					Title:          title,
 					Vars:           cookVars,
 					IdempotencyKey: graphRootKey,
+					// attach names its own root: a workflow_id/molecule_id it
+					// carries is a separate attachment (just ruled out above),
+					// not a container it lives inside, so ResolveRunID's
+					// chain-walk must not run here.
+					SelfRoot: true,
 				})
 				if err != nil {
 					return formulaCommandError(stderr, "gc formula cook: attach", jsonOutput, err)

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -1290,6 +1290,100 @@ title = "Do work"
 	}
 }
 
+// TestFormulaCookAttachChainWalksWhenTargetIsWorkflowStep is the regression
+// for the mayor's ga-er5u7k ruling on PR #5424: sling.CheckNoMoleculeChildren
+// above only rules out a molecule already attached TO the target (downward,
+// the TestFormulaCookAttachRefusesWhenTargetAlreadyHasMoleculeAttached case).
+// It says nothing about whether the target is itself a step INSIDE a live
+// workflow (upward, via gc.root_bead_id). Unconditional SelfRoot: true
+// wrongly rooted that step's new sub-DAG at the step's own id instead of
+// chain-walking to the workflow's true root.
+func TestFormulaCookAttachChainWalksWhenTargetIsWorkflowStep(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(withBuiltinProviderAliasesTOMLForTest(`
+[workspace]
+name = "my-city"
+provider = "claude"
+
+[daemon]
+formula_v2 = true
+`, "claude")+testControlDispatcherAgentTOML("")), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "plain-work.formula.toml"), []byte(`
+formula = "plain-work"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	root, err := store.Create(beads.Bead{Title: "true workflow root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	target, err := store.Create(beads.Bead{
+		Title:    "workflow step",
+		Type:     "task",
+		Assignee: "reviewer",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"plain-work", "--attach", target.ID})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula cook --attach: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	selfRooted, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": target.ID},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+		AllowScan:     true,
+	})
+	if err != nil {
+		t.Fatalf("list roots rooted at target: %v", err)
+	}
+	if len(selfRooted) != 0 {
+		t.Fatalf("beads rooted at the workflow STEP's own id = %+v, want the sub-DAG chain-walked to the true workflow root %s instead", selfRooted, root.ID)
+	}
+
+	chainWalked, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": root.ID},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+		AllowScan:     true,
+	})
+	if err != nil {
+		t.Fatalf("list roots rooted at true root: %v", err)
+	}
+	if len(chainWalked) == 0 {
+		t.Fatalf("no beads rooted at the true workflow root %s: chain-walk did not run", root.ID)
+	}
+}
+
 // TestFormulaCookStandaloneGraphV2StampsRunRootStoreScope locks in that a
 // standalone `gc formula cook <graph.v2-formula>` (no --attach) stamps the run
 // root with its store/scope identity (gc.root_store_ref + gc.scope_kind), the

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -1204,6 +1204,92 @@ title = "Do work for {{convoy_id}}"
 	}
 }
 
+// TestFormulaCookAttachRefusesWhenTargetAlreadyHasMoleculeAttached locks in
+// that the non-graph (v1) `--attach` arm refuses to attach a second molecule
+// onto a bead that already carries a live molecule attachment, instead of
+// silently creating a duplicate wrapper rooted at the same target
+// (ga-qiplt2). The graph.v2 arm above already guards this via
+// existingFormulaCookGraphV2Root / sourceworkflow conflict checks; the v1
+// arm called molecule.Attach directly with no equivalent guard, so a bead
+// already carrying a "finishing sling" molecule attachment (molecule_id
+// metadata pointing at a live wrapper) could accumulate a second, unrelated
+// wrapper on every cook --attach invocation.
+func TestFormulaCookAttachRefusesWhenTargetAlreadyHasMoleculeAttached(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(withBuiltinProviderAliasesTOMLForTest(`
+[workspace]
+name = "my-city"
+provider = "claude"
+
+[daemon]
+formula_v2 = true
+`, "claude")+testControlDispatcherAgentTOML("")), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "plain-work.formula.toml"), []byte(`
+formula = "plain-work"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	wrapper, err := store.Create(beads.Bead{Title: "existing molecule wrapper", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create wrapper: %v", err)
+	}
+	target, err := store.Create(beads.Bead{
+		Title:    "review target",
+		Type:     "task",
+		Assignee: "reviewer",
+		Metadata: map[string]string{beadmeta.MoleculeIDMetadataKey: wrapper.ID},
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"plain-work", "--attach", target.ID})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("formula cook --attach = nil error, want refusal because %s already has attached molecule %s\nstdout=%s\nstderr=%s", target.ID, wrapper.ID, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "already has attached") {
+		t.Fatalf("stderr = %q, want it to mention the existing attachment", stderr.String())
+	}
+
+	roots, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": target.ID},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+		AllowScan:     true,
+	})
+	if err != nil {
+		t.Fatalf("list roots rooted at target: %v", err)
+	}
+	if len(roots) != 0 {
+		t.Fatalf("beads rooted at target = %+v, want none (refusal must create nothing)", roots)
+	}
+}
+
 // TestFormulaCookStandaloneGraphV2StampsRunRootStoreScope locks in that a
 // standalone `gc formula cook <graph.v2-formula>` (no --attach) stamps the run
 // root with its store/scope identity (gc.root_store_ref + gc.scope_kind), the

--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -221,6 +221,54 @@ func TestAttachResolvesRootFromRunChainNotOwnID(t *testing.T) {
 	assertAllBeadsHaveRootID(t, store, result.IDMapping, root.ID)
 }
 
+// TestAttachSelfRootIgnoresSiblingMoleculeAttachment is the regression for
+// ga-qiplt2. workflow_id/molecule_id metadata on a bead is overloaded: it
+// means "I am a step INSIDE this workflow" for a grafted wisp (the
+// TestAttachResolvesRootFromRunChainNotOwnID case above, where chain-walking
+// to the container's root is correct), but it also means "a molecule is
+// ATTACHED TO me, tracking separate work about me" for a sling
+// finishing-sling target (the attach target is not part of the attached
+// molecule's DAG at all). Callers that know the attach target is its own
+// root — cmd/gc's `gc formula cook --attach` v1 arm, guarded by
+// sling.CheckNoMoleculeChildren for the live-attachment case — must be able
+// to opt out of the chain-walk so a NEW attach onto a bead that already has
+// an unrelated sibling molecule attached roots the new sub-DAG at the target
+// itself, not at the sibling.
+func TestAttachSelfRootIgnoresSiblingMoleculeAttachment(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// A pre-existing, unrelated molecule attached TO the target (sling's
+	// "finishing sling" pattern) -- NOT a container the target lives inside.
+	sibling, err := store.Create(beads.Bead{Title: "sibling molecule wrapper", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create sibling molecule: %v", err)
+	}
+	target, err := store.Create(beads.Bead{
+		Title: "review target",
+		Type:  "task",
+		Metadata: map[string]string{
+			"molecule_id": sibling.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create attach target: %v", err)
+	}
+
+	recipe := makeWorkflowRecipe("mol-code-review", "run", "eval")
+
+	result, err := Attach(context.Background(), store, recipe, target.ID, AttachOptions{SelfRoot: true})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// The new sub-DAG must be rooted at the attach TARGET, never chain-walked
+	// to the unrelated sibling molecule's id.
+	if result.WorkflowRootID != target.ID {
+		t.Errorf("WorkflowRootID = %q, want %q (attach target, not sibling wrapper %q)", result.WorkflowRootID, target.ID, sibling.ID)
+	}
+	assertAllBeadsHaveRootID(t, store, result.IDMapping, target.ID)
+}
+
 // Test 3: Blocking dep prevents premature unblock
 func TestAttachBlockingDepPreventsClose(t *testing.T) {
 	store := beads.NewMemStore()

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -184,6 +184,17 @@ type AttachOptions struct {
 	// Callers should always use IdempotencyKey together with ExpectedEpoch
 	// to ensure crash-recovery correctness.
 	ExpectedEpoch int
+
+	// SelfRoot roots the new sub-DAG at attachBeadID itself instead of
+	// chain-walking attachBeadID's workflow_id/molecule_id metadata via
+	// beadmeta.ResolveRunID. Set this when the caller knows attachBeadID is
+	// its own root and any workflow_id/molecule_id it carries names a
+	// SEPARATE attachment (e.g. a sling finishing-sling wrapper tracking
+	// work about attachBeadID), not a container attachBeadID lives inside.
+	// Leave false (default) for the run-chain case the chain-walk exists
+	// for: a wisp/step bead grafted mid-workflow, whose workflow_id truly
+	// does name the containing workflow's root (gcg-wisp-y785sz).
+	SelfRoot bool
 }
 
 // ErrEpochConflict is returned when AttachOptions.ExpectedEpoch does not match
@@ -255,7 +266,19 @@ func Attach(ctx context.Context, store beads.Store, recipe *formula.Recipe, atta
 	// (maintainer-city incident gcg-wisp-y785sz). A genuine top-level head
 	// with no run chain still self-roots via its own id (ResolveRunID's
 	// selfID fallback).
-	rootBeadID := beadmeta.ResolveRunID(parentBead.Metadata, attachBeadID, "")
+	//
+	// opts.SelfRoot skips the chain-walk entirely. workflow_id/molecule_id
+	// is overloaded: it also means "a molecule is ATTACHED TO me" (sling's
+	// finishing-sling pattern) rather than "I am a step INSIDE that
+	// molecule" -- the attach target is not part of the attached molecule's
+	// DAG at all, so chain-walking through it resolves to the wrong root
+	// and lets a second, unrelated attachment accumulate on the same target
+	// (ga-qiplt2). Callers in that position already know attachBeadID is
+	// its own root and opt in explicitly.
+	rootBeadID := attachBeadID
+	if !opts.SelfRoot {
+		rootBeadID = beadmeta.ResolveRunID(parentBead.Metadata, attachBeadID, "")
+	}
 	rootStoreRef := parentBead.Metadata[beadmeta.RootStoreRefMetadataKey]
 
 	// Idempotency: check for existing sub-DAG with the same key.

--- a/release-gates/ga-2ktqg2-formula-cook-attach-guard-gate.md
+++ b/release-gates/ga-2ktqg2-formula-cook-attach-guard-gate.md
@@ -1,0 +1,116 @@
+# Release Gate: Formula Cook Attach Guard and Self-Rooting
+
+- Deploy bead: `ga-2ktqg2`
+- Build bead: `ga-qiplt2`
+- Originally reviewed commit: `b27bae0ae9e8d9111bf726ab9a4fc30e52eca2f2`
+- Evaluated re-gate commit: `4ef3bfd26f643a4b0d0beaf8eb22616211f8e42b`
+- Base: `origin/main@8c73625b974ce8d3d68d54ab42062e6247c47036`
+- Deploy mode: remote
+- Deploy branch: `deploy/ga-2ktqg2-gate`
+- Verdict: **FAIL — WAIVED BY MAYOR**
+
+The evaluated commit is a mechanical rebase of the reviewed change. A direct
+four-file comparison between the original reviewed commit and the evaluated
+commit is empty, so the reviewer-approved content did not drift. The associated
+PR preflight found no pull request for the evaluated commit. Criterion 6 was
+evaluated first and again after the long test run.
+
+The repository does not contain `docs/PROJECT_MANIFEST.md`; this record applies
+the seven criteria in the active deployer contract and the evidence convention
+in `engdocs/contributors/release-gate-criteria-conventions.md`.
+
+The technical test gate remains a failure. The Mayor's 2026-08-18 standing
+authorization in `ga-vb82ss`, section 3, permits deployment when every failing
+test has a specific tracker, the diff has no plausible mechanism to reach the
+failure, each occurrence is logged on its tracker, and the gate preserves the
+failure as waived rather than rewriting it green. All four conditions are met
+below; no failure is in a changed file or the formula-attachment/molecule-rooting
+subsystem.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `ga-2ktqg2` records an independent reviewer PASS for `b27bae0ae9e8d9111bf726ab9a4fc30e52eca2f2`. The four reviewed files are byte-identical at the evaluated re-gate commit `4ef3bfd26f643a4b0d0beaf8eb22616211f8e42b`. |
+| 2 | Acceptance criteria met | **PASS** | The v1 `gc formula cook --attach` path now calls the existing `sling.CheckNoMoleculeChildren` guard before mutation, and the regression test proves a live existing attachment is refused without creating beads. `molecule.AttachOptions.SelfRoot` is opt-in and roots this caller's sub-DAG at the explicit attach target; the new test proves sibling molecule metadata cannot mis-root it, while the pre-existing run-chain test proves default chain-walking remains intact. Build, vet, policy, lint, and boundary checks pass. |
+| 3 | Tests pass | **FAIL — WAIVED** | `make test-local-full-parallel` ran all required fast, process-backed cmd/gc, and integration lanes: **25 PASS jobs, 15 FAIL jobs, 0 SKIP jobs**. Both diff-owned tests PASS by name with 0 FAIL and 0 SKIP. Every failure is non-diff-owned, specifically tracked, logged on that tracker, and structurally unreachable from the changed formula/molecule path; see the attribution table. `waiver_ref`: Mayor's 2026-08-18 standing authorization recorded in `ga-vb82ss`, section 3. |
+| 4 | No high-severity review findings open | **PASS** | The review records no blocking security, correctness, or style finding. Unresolved HIGH findings: `0`. |
+| 5 | Final branch is clean | **PASS** | Before this checklist was created, `git status --porcelain=v1` was empty at the evaluated commit. `git diff --check origin/main...HEAD` produced no output. `git config core.hooksPath` reports `.githooks`. |
+| 6 | Branch diverges cleanly from main | **PASS** | No associated PR exists. After a fresh `git fetch origin main`, `git merge-base --is-ancestor origin/main 4ef3bfd26f643a4b0d0beaf8eb22616211f8e42b` succeeds; the merge base is exactly `8c73625b974ce8d3d68d54ab42062e6247c47036`. Rechecked after the full test union; no self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | One commit changes four files in one feature: prevent duplicate v1 formula attachments and keep their sub-DAG rooted at the caller-named target. No independent behavior is bundled. |
+
+## Test evidence
+
+Environment established before criterion 3:
+
+- Rootless Podman socket active at `unix:///run/user/1000/podman/podman.sock`.
+- `TESTCONTAINERS_RYUK_DISABLED=true`.
+- Cached `docker.io/dolthub/dolt-sql-server:2.1.7` matches `deps.env`'s
+  `DOLT_VERSION=2.1.7` pin.
+- No `dolt-tests-via-podman` cairn entry exists for this rig.
+
+Required and supporting commands:
+
+- `make test-local-full-parallel` with `DOCKER_HOST` and
+  `TESTCONTAINERS_RYUK_DISABLED` passed through `EXTRA_TEST_ENV`: **25 PASS
+  jobs, 15 FAIL jobs, 0 SKIP jobs** across the runner's 40 named jobs. Logs:
+  `/var/tmp/gc-local-tests.DGBY77`.
+- `go test -count=1 -v ./cmd/gc -run '^TestFormulaCookAttachRefusesWhenTargetAlreadyHasMoleculeAttached$'`:
+  **1 PASS, 0 FAIL, 0 SKIP**.
+- `go test -count=1 -v ./internal/molecule -run '^TestAttachSelfRootIgnoresSiblingMoleculeAttachment$'`:
+  **1 PASS, 0 FAIL, 0 SKIP**.
+- `go test -count=1 -v ./internal/molecule -run '^TestAttachResolvesRootFromRunChainNotOwnID$'`:
+  **1 PASS, 0 FAIL, 0 SKIP**; verifies the opt-in did not change the default
+  run-chain contract.
+- `make test-ci-policy`: PASS.
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected`:
+  PASS, 0 issues.
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make fmt-check-changed`:
+  PASS.
+- `make check-gomod-replace check-native-dependency-surface check-eventexport-isolation check-core-boundary test-native-doltlite-beads`:
+  PASS.
+- `make vet`: PASS.
+- `go build ./...`: PASS.
+
+`diff_tests_executed`:
+
+- `TestFormulaCookAttachRefusesWhenTargetAlreadyHasMoleculeAttached`: PASS.
+- `TestAttachSelfRootIgnoresSiblingMoleculeAttachment`: PASS.
+
+`test_counts`: required full union `25 PASS jobs / 15 FAIL jobs / 0 SKIP
+jobs`; diff-owned tests `2 PASS / 0 FAIL / 0 SKIP`.
+
+`skip_justification`: not applicable — the runner reported zero skipped jobs,
+and neither diff-owned test skipped.
+
+`waiver_ref`: Mayor's 2026-08-18 ruling in `ga-vb82ss`, section 3 (broadened
+standing authorization for fully tracked failures outside the diff's reachable
+files/subsystem). The gate remains **FAIL — WAIVED**.
+
+## Failure attribution
+
+| Failure(s) | Tracker | Structural mechanism proof |
+|---|---|---|
+| `TestBdFlagManifestCurrent` | `ga-f0uceo` | Reads the installed `bd --help` surface from `internal/bdflags`; the candidate changes neither that package nor the external binary. Occurrence logged on the tracker. |
+| `TestGetKeyBinding_CapturesDefaultBinding`, `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `ga-afqddr` | Depend on host tmux 3.7b's default keytable in `internal/runtime/tmux`; formula cook and molecule attachment do not reach it. Occurrences logged. |
+| `TestBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore` | `ga-227zz7` | Stops in fixture setup at `beads.OpenNativeStorage`'s hard 15-second schema-open context, before the test reaches its assertions. It never invokes `gc formula cook`; the new tracker was created and read back in this gate session. |
+| `TestAdoptPRFormulaCompileAndRun`, `TestAdoptPRFormulaRetriesTransientReviewerStep`, `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries`, `TestPersonalWorkFormulaCompileAndRun`, `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash`, `TestGraphWorkflowSuccessPath`, `TestGraphWorkflowFailureRunsCleanup`, `TestHumaBinary_CityCreateAsync` | `ga-lpfjhc` | All eight stop during throwaway-city `gc init` with the exact `gastownhall/beads#4566` dirty-table migration error, before any formula execution or molecule attachment. Occurrences logged together on the tracker. |
+| `TestCustomTypesCheck_TableDrift` | `ga-6pnurv` | Fails only in `testing.TempDir` cleanup in `internal/doctor`; the candidate cannot reach that package's cleanup writer. Occurrence logged; its reviewed budget fix remains pending in deploy bead `ga-t33q83`. |
+| `TestSQLiteLegacySnapshotSIGKILLAtBoundaries/legacy-claim-release-after` | `ga-5dsf6n` | Times out in the standalone `internal/storebinding/sqlite` child protocol under parallel load; no formula/molecule code participates. Occurrence logged. |
+| `TestDoltConfigWiringExternalHost` | `ga-gajll3` | Exceeds the integration helper's hard `bd init` timeout after initialization succeeds, before the candidate path is invoked. Occurrence logged; the tracker records the unmerged timeout fix. |
+| `TestCleanInstallTutorialPath` | `ga-hrdd3h` | Fails because circuit-breaker diagnostics contaminate `bd config get issue_prefix` output; formula attachment and molecule rooting cannot affect that subprocess stdout. Occurrence logged. |
+
+## Waiver disposition
+
+Criterion 3 remains **FAIL**. The 15 red jobs contain only the tracked
+signatures above. None failed in `cmd/gc/cmd_formula.go`,
+`cmd/gc/cmd_formula_test.go`, `internal/molecule/molecule.go`,
+`internal/molecule/attach_test.go`, or the attachment/rooting behavior they
+exercise. The one same-package cmd/gc failure stopped in native fixture-store
+setup and never called the changed command path. Both diff-owned regressions
+passed independently by name.
+
+Under the standing Mayor authorization recorded in `ga-vb82ss`, this retained
+failure is waived for deployment. Cut and push only the isolated deploy branch,
+open the pull request, publish deploy clearance on its exact gated head, and
+route merge authority to mayor/mpr. The deployer does not merge.


### PR DESCRIPTION
## What this changes

`gc formula cook --attach` now refuses to create a second live molecule on a target that already has one. The refusal happens before mutation, so repeated or competing attach attempts cannot leave duplicate wrappers or partial work behind.

For a valid v1 attach, the new sub-DAG is rooted at the caller-named target instead of following unrelated `workflow_id` or `molecule_id` metadata already present on that target. This prevents every new step from being silently rooted under a sibling molecule.

## Review notes

- The command reuses the existing `sling.CheckNoMoleculeChildren` guard used by the legacy sling path, including its stale-molecule cleanup behavior.
- `molecule.AttachOptions.SelfRoot` is opt-in and enabled only for this `gc formula cook --attach` path. Its zero value preserves existing chain-walk behavior for grafted workflow steps and every other caller.
- Graph v2 behavior, configuration, APIs, and persisted schema are unchanged.

## Test plan

- [x] Run the duplicate-attachment regression and verify refusal creates no beads.
- [x] Run the self-rooting regression and the existing run-chain regression by name.
- [x] Run affected lint, formatting, policy, boundary, native DoltLite, build, and vet checks.
- [x] Exercise the required fast, process-backed cmd/gc, and integration lanes; diff-owned tests pass, with tracked non-diff infrastructure failures and their standing waiver recorded in the gate.
- [x] Release gate: [`release-gates/ga-2ktqg2-formula-cook-attach-guard-gate.md`](release-gates/ga-2ktqg2-formula-cook-attach-guard-gate.md)
