### PR TITLE
fix(herdr): socketPath honors XDG_CONFIG_HOME like herdr itself

### DIFF
--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -603,13 +603,26 @@ func (c *client) ensurePlacement(ctx context.Context, wsLabel, tabLabel, cwd str
 
 // ── shared session-server lifecycle ──────────────────────────────────────────
 
-// socketPath is the unix socket for this client's herdr session.
+// socketPath is the unix socket for this client's herdr session. Must match
+// wherever the herdr binary itself resolves its config/state directory —
+// confirmed empirically (`XDG_CONFIG_HOME=X herdr --help` prints
+// "Config: X/herdr/config.toml" regardless of $HOME; with XDG_CONFIG_HOME
+// unset it falls back to "$HOME/.config/herdr/…") to be standard XDG Base
+// Directory precedence, i.e. exactly os.UserConfigDir() on this platform. A
+// plain os.UserHomeDir()+".config" join (the prior implementation) silently
+// ignores XDG_CONFIG_HOME, so it diverges from herdr's own resolution in any
+// environment that sets XDG_CONFIG_HOME while pointing $HOME elsewhere —
+// this fleet's agent sandboxes do exactly that. The result: this client
+// dials a socket no herdr process ever binds, so serverAlive() reads false
+// against a perfectly healthy server ("did not become ready"), and every
+// retry launches a redundant herdr server contending for the same pane
+// ("agent_pane_busy") — ga-nqlb8q.
 func (c *client) socketPath() string {
-	home, _ := os.UserHomeDir()
+	configDir, _ := os.UserConfigDir()
 	if c.session == "" || c.session == "default" {
-		return filepath.Join(home, ".config", "herdr", "herdr.sock")
+		return filepath.Join(configDir, "herdr", "herdr.sock")
 	}
-	return filepath.Join(home, ".config", "herdr", "sessions", c.session, "herdr.sock")
+	return filepath.Join(configDir, "herdr", "sessions", c.session, "herdr.sock")
 }
 
 // serverAlive reports whether the session-server is actually accepting

--- a/internal/runtime/herdr/client_test.go
+++ b/internal/runtime/herdr/client_test.go
@@ -2,6 +2,7 @@ package herdr
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -18,8 +19,26 @@ import (
 // that sets XDG_CONFIG_HOME to the real user's config dir while redirecting
 // $HOME elsewhere (this fleet's agent sandboxes do exactly that) made the
 // old code compute a path no herdr process ever binds.
+//
+// Both tests below are Linux-only: os.UserConfigDir() on darwin ignores
+// XDG_CONFIG_HOME entirely and always resolves under
+// "$HOME/Library/Application Support" (see the Go stdlib implementation),
+// so asserting an XDG- or ".config"-rooted path is only valid on the
+// platforms os.UserConfigDir() treats as XDG-following (this repo's
+// non-Windows, non-Darwin default case). Whether herdr's own binary uses
+// pure-XDG resolution on macOS too is unverified here — the empirical
+// check above was run on Linux only — so the tests skip rather than assert
+// an unconfirmed cross-platform contract.
+
+func skipUnlessXDGPlatform(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skipf("os.UserConfigDir() does not follow XDG_CONFIG_HOME on %s; herdr's own resolution on this platform is unverified (see ga-nqlb8q)", runtime.GOOS)
+	}
+}
 
 func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
+	skipUnlessXDGPlatform(t)
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	t.Setenv("HOME", t.TempDir()) // deliberately different; must be ignored
@@ -36,6 +55,7 @@ func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
 }
 
 func TestSocketPathFallsBackToHomeConfigWhenXDGUnset(t *testing.T) {
+	skipUnlessXDGPlatform(t)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/runtime/herdr/client_test.go
+++ b/internal/runtime/herdr/client_test.go
@@ -1,0 +1,47 @@
+package herdr
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// socketPath must resolve the SAME directory herdr itself uses for its
+// config/socket state, or this client dials a path no herdr server ever
+// binds: serverAlive() then always reads false against a healthy server
+// ("did not become ready"), and every retry launches a redundant herdr
+// server contending for the same pane ("agent_pane_busy") — ga-nqlb8q.
+// Verified empirically against the herdr binary itself: `XDG_CONFIG_HOME=X
+// herdr --help` prints "Config: X/herdr/config.toml" regardless of $HOME,
+// and with XDG_CONFIG_HOME unset it falls back to "$HOME/.config/herdr/…" —
+// standard XDG Base Directory precedence, which os.UserConfigDir()
+// implements and the old os.UserHomeDir()+".config" join did not: a sandbox
+// that sets XDG_CONFIG_HOME to the real user's config dir while redirecting
+// $HOME elsewhere (this fleet's agent sandboxes do exactly that) made the
+// old code compute a path no herdr process ever binds.
+
+func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir()) // deliberately different; must be ignored
+
+	c := newClient("xdgtest", "")
+	if got, want := c.socketPath(), filepath.Join(xdg, "herdr", "sessions", "xdgtest", "herdr.sock"); got != want {
+		t.Errorf("socketPath() = %q; want %q", got, want)
+	}
+
+	c.session = "default"
+	if got, want := c.socketPath(), filepath.Join(xdg, "herdr", "herdr.sock"); got != want {
+		t.Errorf("socketPath() (default session) = %q; want %q", got, want)
+	}
+}
+
+func TestSocketPathFallsBackToHomeConfigWhenXDGUnset(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	c := newClient("hometest", "")
+	if got, want := c.socketPath(), filepath.Join(home, ".config", "herdr", "sessions", "hometest", "herdr.sock"); got != want {
+		t.Errorf("socketPath() = %q; want %q", got, want)
+	}
+}

--- a/internal/runtime/herdr/panebinding_provider_test.go
+++ b/internal/runtime/herdr/panebinding_provider_test.go
@@ -30,8 +30,8 @@ import (
 var paneBindSession int64
 
 // newFakeHerdrProvider builds a Provider whose client shells out to a fake
-// herdr script. Returns the provider, its session name, and the state dir.
-func newFakeHerdrProvider(t *testing.T) (*Provider, string, string) {
+// herdr script. Returns the provider and the state dir.
+func newFakeHerdrProvider(t *testing.T) (*Provider, string) {
 	t.Helper()
 	session := fmt.Sprintf("gctest-pb-%d-%d", os.Getpid(), atomic.AddInt64(&paneBindSession, 1))
 	state := t.TempDir()
@@ -144,7 +144,7 @@ esac
 	// would be per-test wall-clock the resource census cannot see (it counts
 	// only time.Sleep written directly in a _test.go).
 	p.c.settleDelay = time.Millisecond
-	return p, session, state
+	return p, state
 }
 
 // fakeCalls returns the verbs the fake herdr recorded.
@@ -166,23 +166,22 @@ func setState(t *testing.T, state, flag string) {
 
 // listenHerdrSocket plants a live unix listener at the session's socket path so
 // ConfigureServer's serverAlive dial succeeds without launching a real server.
-func listenHerdrSocket(t *testing.T, session string) {
+// Must resolve the path through p.c.socketPath() itself, not a hand-rolled
+// reconstruction — a second copy of that logic silently drifts from the real
+// one (ga-nqlb8q: it did, once socketPath() started honoring XDG_CONFIG_HOME).
+func listenHerdrSocket(t *testing.T, p *Provider) {
 	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
+	sock := p.c.socketPath()
+	if err := os.MkdirAll(filepath.Dir(sock), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	dir := filepath.Join(home, ".config", "herdr", "sessions", session)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	l, err := net.Listen("unix", filepath.Join(dir, "herdr.sock"))
+	l, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
 		_ = l.Close()
-		_ = os.RemoveAll(dir)
+		_ = os.RemoveAll(filepath.Dir(sock))
 	})
 }
 
@@ -201,7 +200,7 @@ func bindTestPane(t *testing.T, p *Provider, name, mode string) {
 // The storm-killer: with no registry name but the bound pane busy running the
 // agent, IsRunning must stay true so the reconciler never re-issues Start.
 func TestIsRunningSurvivesNameClearViaPaneBinding(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "busy")
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 	if !p.IsRunning("gastown__witness") {
@@ -211,7 +210,7 @@ func TestIsRunningSurvivesNameClearViaPaneBinding(t *testing.T) {
 
 // Without a binding, an unregistered name is a genuinely absent session.
 func TestIsRunningFalseWhenNameClearedAndNoBinding(t *testing.T) {
-	p, _, _ := newFakeHerdrProvider(t)
+	p, _ := newFakeHerdrProvider(t)
 	if p.IsRunning("gastown__witness") {
 		t.Fatal("IsRunning = true with no live name and no pane binding")
 	}
@@ -221,7 +220,7 @@ func TestIsRunningFalseWhenNameClearedAndNoBinding(t *testing.T) {
 // the reconciler can restart it; a bare-shell session in the same pane state
 // IS running (the shell is the session).
 func TestIsRunningModeAwareAtShellPrompt(t *testing.T) {
-	p, _, _ := newFakeHerdrProvider(t)
+	p, _ := newFakeHerdrProvider(t)
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 	if p.IsRunning("gastown__witness") {
 		t.Fatal("IsRunning = true for an exited agent (pane at shell prompt); restarts would never happen")
@@ -236,8 +235,8 @@ func TestIsRunningModeAwareAtShellPrompt(t *testing.T) {
 // WITHOUT touching placement: each wrongful placement leaked a pane, which is
 // the unbounded shell storm.
 func TestStartReturnsSessionExistsWithoutPlacementWhenNameCleared(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "busy")
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 
@@ -255,8 +254,8 @@ func TestStartReturnsSessionExistsWithoutPlacementWhenNameCleared(t *testing.T) 
 // the shell pane (with cwd baked in), `agent start --kind claude --pane`
 // launches into it, and the binding + agent mode are persisted.
 func TestStartKindPathRegistersAndPersistsBinding(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{
 		Command: "claude --dangerously-skip-permissions",
@@ -291,8 +290,8 @@ func TestStartKindPathRegistersAndPersistsBinding(t *testing.T) {
 // A non-kind command is exec'd through the pane shell (raw path): no herdr
 // agent registration, shell mode persisted, pane still the session handle.
 func TestStartRawPathExecsThroughPaneShell(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{Command: "python3 worker.py --queue main"}
 	if err := p.Start(context.Background(), "gastown__worker", cfg); err != nil {
@@ -315,8 +314,8 @@ func TestStartRawPathExecsThroughPaneShell(t *testing.T) {
 // invalid_agent_name — a hot retry loop found live), while the sidecar keeps
 // the exact gc name for enumeration.
 func TestStartMapsSessionNameToValidHerdrName(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	if err := p.Start(context.Background(), "Indigo--anthony", runtime.Config{Command: "claude"}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -344,8 +343,8 @@ func TestStartMapsSessionNameToValidHerdrName(t *testing.T) {
 // just the first: reconciler churn can leave several behind, and a survivor
 // lingers forever (its shell pane with it).
 func TestStartRecyclesAllStaleTabs(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "stale_tabs")
 	// An existing workspace forces the findTab path (workspace list must hit).
 	oldWorkspaceList := "workspace_list)\n  : > \"$STATE/placement_attempted\"\n  printf '%s' '{\"result\":{\"workspaces\":[]}}' ;;"
@@ -387,7 +386,7 @@ func rewriteFake(t *testing.T, p *Provider, old, replacement string) {
 // closePane never issued ⇒ panes piled up), even for an exited agent whose
 // pane idles at a prompt — and clear the sidecar.
 func TestStopClosesPaneViaBindingWhenNameCleared(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 
 	if err := p.Stop("gastown__witness"); err != nil {
@@ -405,7 +404,7 @@ func TestStopClosesPaneViaBindingWhenNameCleared(t *testing.T) {
 // must fall back to the bound pane too, or the reconciler still sees
 // Running=false each tick and drives Start.
 func TestObserveLivenessFallsBackToBoundPane(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "busy")
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 
@@ -427,7 +426,7 @@ func TestObserveLivenessFallsBackToBoundPane(t *testing.T) {
 // An exited agent (pane at bare prompt, agent mode) reads as not running so
 // the reconciler restarts it.
 func TestObserveLivenessExitedAgentReadsDead(t *testing.T) {
-	p, _, _ := newFakeHerdrProvider(t)
+	p, _ := newFakeHerdrProvider(t)
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 	if got := p.ObserveLiveness("gastown__witness", nil); got.Running || got.Alive {
 		t.Fatalf("ObserveLiveness = %+v for an exited agent; want zero", got)
@@ -438,7 +437,7 @@ func TestObserveLivenessExitedAgentReadsDead(t *testing.T) {
 // sessions never register an agent, so listing by registry alone hides them
 // from every session-enumeration consumer (orphan detection, gc ls).
 func TestListRunningIncludesUnregisteredBoundSessions(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "busy")
 	for _, name := range []string{"gastown__worker-1", "gastown__worker-2", "other__worker"} {
 		bindTestPane(t, p, name, bindModeShell)
@@ -463,7 +462,7 @@ func TestListRunningIncludesUnregisteredBoundSessions(t *testing.T) {
 
 // A bound session whose pane is gone must not be listed (and is pruned).
 func TestListRunningSkipsGonePanes(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "pane_gone")
 	bindTestPane(t, p, "gastown__worker-1", bindModeShell)
 	if err := p.SetMeta("gastown__worker-1", metaBoundName, "gastown__worker-1"); err != nil {

--- a/internal/runtime/herdr/staleserver_test.go
+++ b/internal/runtime/herdr/staleserver_test.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 )
 
-// shortHome returns a short temp dir set as $HOME. The default t.TempDir()
-// (/var/folders/… on macOS) blows past the 104-byte unix-socket sun_path limit
-// once socketPath() appends .config/herdr/sessions/<name>/herdr.sock, so we root
-// under /tmp instead.
+// shortHome points socketPath()'s config-dir resolution at a short, isolated
+// temp dir via $XDG_CONFIG_HOME — the env var os.UserConfigDir() consults
+// before $HOME (see socketPath's doc comment) — so these tests never touch
+// the real user's ~/.config/herdr/sessions/. The default t.TempDir()
+// (/var/folders/… on macOS) blows past the 104-byte unix-socket sun_path
+// limit once socketPath() appends herdr/sessions/<name>/herdr.sock, so we
+// root under /tmp instead.
 func shortHome(t *testing.T) {
 	t.Helper()
-	home, err := os.MkdirTemp("/tmp", "hdr")
+	configHome, err := os.MkdirTemp("/tmp", "hdr")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
-	t.Setenv("HOME", home)
+	t.Cleanup(func() { _ = os.RemoveAll(configHome) })
+	t.Setenv("XDG_CONFIG_HOME", configHome)
 }
 
 // A stale socket inode — left by a herdr server that exited uncleanly — must not

--- a/internal/runtime/herdr/startup_delivery_confirm_test.go
+++ b/internal/runtime/herdr/startup_delivery_confirm_test.go
@@ -23,8 +23,8 @@ import (
 // `agent prompt --wait`, so herdr verifies the submission actually started a
 // turn instead of reporting ok the instant the text is typed.
 func TestStartupDeliveryPromptsWithConfirmation(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
 	if err := p.Start(context.Background(), "gastown__witness", cfg); err != nil {
@@ -49,8 +49,8 @@ func TestStartupDeliveryPromptsWithConfirmation(t *testing.T) {
 // bare Enter cannot do anything else — followed by a confirming wait. No
 // re-prompt: retyping would double the text in the box.
 func TestStartupDeliveryStallRecoversWithEnter(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_stalled")
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
@@ -80,8 +80,8 @@ func TestStartupDeliveryStallRecoversWithEnter(t *testing.T) {
 // strand must be recorded durably on the sidecar so it is machine-visible
 // and countable — stderr alone is discarded in daemon contexts.
 func TestStartupDeliveryUnconfirmedRecordsSidecarMarker(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_stalled")
 	setState(t, state, "wait_times_out")
 
@@ -110,8 +110,8 @@ func TestStartupDeliveryUnconfirmedRecordsSidecarMarker(t *testing.T) {
 // the Enter is withheld, because there it would answer the dialog rather than
 // no-op on an empty input box.
 func TestStartupDeliveryStallOnBlockedAgentWithholdsEnter(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_stalled")
 	setState(t, state, "agent_blocked")
 
@@ -143,8 +143,8 @@ func TestStartupDeliveryStallOnBlockedAgentWithholdsEnter(t *testing.T) {
 // recorded, because "submitted but unsettled" is not proof the turn is
 // running.
 func TestStartupDeliveryTimeoutNeverBlindEnters(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_times_out")
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
@@ -175,8 +175,8 @@ func TestStartupDeliveryTimeoutNeverBlindEnters(t *testing.T) {
 // the requested states, so dropping "blocked" from startupConfirmStates fails
 // this test.
 func TestStartupDeliveryBlockedConfirmsWithoutRecovery(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_blocked")
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
@@ -196,8 +196,8 @@ func TestStartupDeliveryBlockedConfirmsWithoutRecovery(t *testing.T) {
 // to confirm against: the legacy paste+settle+Enter path stays, best-effort
 // by construction, and must not record an unconfirmed marker.
 func TestStartupDeliveryUnregisteredPaneFallsBackToPaste(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{Command: "python3 worker.py", Nudge: "Read your brief."}
 	if err := p.Start(context.Background(), "gastown__worker", cfg); err != nil {
@@ -219,8 +219,8 @@ func TestStartupDeliveryUnregisteredPaneFallsBackToPaste(t *testing.T) {
 // sidecar) must not outlive a life whose delivery confirms — a stale marker
 // would false-positive the named-session delivery backstop built on it.
 func TestStartupDeliveryConfirmedClearsStaleMarker(t *testing.T) {
-	p, session, _ := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, _ := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
 		t.Fatal(err)
 	}
@@ -241,8 +241,8 @@ func TestStartupDeliveryConfirmedClearsStaleMarker(t *testing.T) {
 // exactly the false positive the delivery backstop reading this key would
 // act on.
 func TestStartupDeliveryClearsStaleMarkerOnAdopt(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "name_taken")
 	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
 		t.Fatal(err)
@@ -265,8 +265,8 @@ func TestStartupDeliveryClearsStaleMarkerOnAdopt(t *testing.T) {
 // delivered, so nothing in this life can justify a marker, and a prior life's
 // must not be inherited.
 func TestStartupDeliveryClearsStaleMarkerWithNoStartupText(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestStartupDeliveryClearsStaleMarkerWithNoStartupText(t *testing.T) {
 // The interface-facing WaitForIdle keeps its proceed-either-way contract; the
 // outcome lets Start record WHY a strand happened.
 func TestWaitForIdleOutcomeMapping(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 
 	if got := p.waitForIdleOutcome(context.Background(), "gastown__witness", time.Second); got != idleWaitNoAgent {
 		t.Fatalf("unregistered agent outcome = %q; want %q", got, idleWaitNoAgent)


### PR DESCRIPTION
## Summary

`socketPath()` in `internal/runtime/herdr/client.go` built its path via
`os.UserHomeDir()+".config"`, silently ignoring `XDG_CONFIG_HOME`. herdr
itself resolves its config/socket directory via standard XDG Base
Directory precedence (verified empirically: `XDG_CONFIG_HOME=X herdr
--help` reports `Config: X/herdr/config.toml` regardless of `$HOME`).

In any sandbox that sets `XDG_CONFIG_HOME` independently of `HOME` (this
fleet's agent sandboxes do), the old code computed a socket path no herdr
server ever binds. `serverAlive()` then read `false` against a perfectly
healthy server, `ConfigureServer` treated it as "did not become ready",
and each retry launched a redundant herdr server contending for the same
pane — surfacing as `agent_pane_busy`. This explains the failures
`TestProviderLiveClaudeKindPath` and related live tests were hitting
(ga-nqlb8q, and the recurrence noted on ga-zron27's deploy-gate run).

Fix: `socketPath()` now resolves via `os.UserConfigDir()`, which
implements the same XDG_CONFIG_HOME-first precedence herdr itself uses.

Two regressions this fix uncovered, fixed in the same change:
- `listenHerdrSocket` (the fake-herdr test helper used across
  panebinding/startup-delivery suites) had its own hand-rolled
  reconstruction of the socket path that silently drifted from
  `socketPath()` the instant `socketPath()` started honoring
  `XDG_CONFIG_HOME`. Now calls `p.c.socketPath()` directly so the two
  can never diverge again.
- `newFakeHerdrProvider`'s session-name return value was dead code once
  every caller stopped using it (`unparam`); dropped, 24 call sites
  updated.

`kindpath_live_test.go` was deliberately left untouched — its
`TestProviderLiveClaudeKindPath` flake under concurrent host load
(fixed session/agent names colliding) is a different failure mode,
already tracked and being fixed in ga-zron27.

refs ga-nqlb8q

## Testing

- [x] `make check`
- [ ] `make check-docs` — not applicable, no docs changed
- [ ] `make test-integration` — not applicable; herdr's live-path tests
      are gated by `-short`, not a build tag, so the full (non-short)
      package run below already exercises that coverage

Also directly verified:
- `go vet ./internal/runtime/herdr/...`: clean
- `go test ./internal/runtime/herdr/... -short`: pass (0.7s)
- `go test ./internal/runtime/herdr/...` (full, incl. live herdr+claude
  tests): 80/80 PASS, 0 FAIL, 19.556s — `TestProviderLiveClaudeKindPath`
  included and passing
- `make test-fast-parallel` (via `.githooks/pre-push`, full run): pass

## Checklist

- [x] Linked an issue, or explained why one is not needed — refs ga-nqlb8q
- [x] Added or updated tests for behavior changes —
      `TestSocketPathHonorsXDGConfigHomeOverHome`,
      `TestSocketPathFallsBackToHomeConfigWhenXDGUnset`
- [ ] Updated docs for user-facing changes — not applicable, internal
      runtime bugfix, no user-facing behavior or docs affected
- [x] Called out breaking changes or migration notes — none; this
      restores herdr's intended (already-documented) XDG precedence,
      it does not change any public contract