### PR TITLE
test(herdr): isolate kind-path lifecycle names

### DIFF
--- a/internal/runtime/herdr/kindpath_live_test.go
+++ b/internal/runtime/herdr/kindpath_live_test.go
@@ -35,6 +35,54 @@ func TestKindPathNamesAreUnique(t *testing.T) {
 	}
 }
 
+// TestKindPathNamesWorkThroughFakeProviderLifecycle hermetically covers what
+// TestProviderLiveClaudeKindPath cannot in a claude-less sandbox: that
+// kindPathNames()'s PID-salted session/agent names actually thread correctly
+// through the same New/Start/GetMeta/IsRunning/ObserveLiveness call sequence,
+// using the fake-herdr harness from newFakeHerdrProvider
+// (panebinding_provider_test.go) instead of a live herdr server and claude
+// binary.
+//
+// ga-hmd2gu review round 1: TestKindPathNamesAreUnique proves the generated
+// names are distinct, but never threads them through a real provider call
+// sequence — exactly what a claude-absent skip leaves unverified everywhere
+// this test runs without a live claude binary.
+func TestKindPathNamesWorkThroughFakeProviderLifecycle(t *testing.T) {
+	session, agent := kindPathNames()
+	p, _, _ := newFakeHerdrProviderForSession(t, session)
+	listenHerdrSocket(t, session)
+
+	ctx := context.Background()
+	cfg := runtime.Config{
+		Command: "claude",
+		Env:     map[string]string{"GC_SESSION_ID": session + "-session"},
+	}
+	if err := p.Start(ctx, agent, cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// herdr registered the agent under the session name (kind path).
+	if _, ok, err := p.c.getAgent(ctx, agent); err != nil || !ok {
+		t.Fatalf("agent get %s = ok=%v, %v; want registered", agent, ok, err)
+	}
+	if mode, _ := p.GetMeta(agent, metaBoundMode); mode != bindModeAgent {
+		t.Errorf("bound mode = %q; want %q", mode, bindModeAgent)
+	}
+	if pane, _ := p.GetMeta(agent, metaBoundPane); pane == "" {
+		t.Error("bound pane empty after kind Start")
+	}
+
+	if !p.IsRunning(agent) {
+		t.Error("IsRunning = false after kind Start")
+	}
+	if live := p.ObserveLiveness(agent, nil); !live.Running || !live.Alive {
+		t.Errorf("ObserveLiveness = %+v; want Running=true Alive=true", live)
+	}
+	if err := p.Start(ctx, agent, cfg); !errors.Is(err, runtime.ErrSessionExists) {
+		t.Errorf("re-issued Start = %v; want ErrSessionExists", err)
+	}
+}
+
 var kindPathSessionSeq int64
 
 // kindPathNames returns the herdr session name and pane/agent name that

--- a/internal/runtime/herdr/kindpath_live_test.go
+++ b/internal/runtime/herdr/kindpath_live_test.go
@@ -3,12 +3,43 @@ package herdr
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+// TestKindPathNamesAreUnique guards the fix for ga-fh1flg: TestProviderLive-
+// ClaudeKindPath used to claim the static herdr session "gctest-kind" and
+// pane/agent name "kindsmoke", which concurrent fleet runs of this same test
+// collided on (agent_pane_busy / herdr server never becoming ready). Each
+// call must return names distinct from the last, salted with this process's
+// PID so concurrent fleet processes can't collide either.
+func TestKindPathNamesAreUnique(t *testing.T) {
+	s1, a1 := kindPathNames()
+	s2, a2 := kindPathNames()
+	if s1 == s2 {
+		t.Errorf("kindPathNames() session names not unique across calls: both %q", s1)
+	}
+	if a1 == a2 {
+		t.Errorf("kindPathNames() agent names not unique across calls: both %q", a1)
+	}
+	pid := fmt.Sprintf("%d", os.Getpid())
+	if !strings.Contains(s1, pid) || !strings.Contains(a1, pid) {
+		t.Errorf("kindPathNames() = (%q, %q); want both to contain pid %s so concurrent fleet processes cannot collide", s1, a1, pid)
+	}
+}
+
+// kindPathNames returns the herdr session name and pane/agent name that
+// TestProviderLiveClaudeKindPath claims. TODO(ga-fh1flg): still static —
+// TestKindPathNamesAreUnique documents the required (not yet met) contract.
+func kindPathNames() (session, agent string) {
+	return "gctest-kind", "kindsmoke"
+}
 
 // TestProviderLiveClaudeKindPath drives the herdr ≥0.7.5 kind-launch path
 // against a real herdr AND a real claude binary: Start places a shell pane
@@ -27,48 +58,49 @@ func TestProviderLiveClaudeKindPath(t *testing.T) {
 		t.Skip("claude not installed")
 	}
 
-	p := New("gctest-kind", t.TempDir(), t.TempDir(), 0, 0)
-	_ = p.Stop("kindsmoke")
-	t.Cleanup(func() { _ = p.Stop("kindsmoke"); _ = p.TeardownServer() })
+	session, agent := kindPathNames()
+	p := New(session, t.TempDir(), t.TempDir(), 0, 0)
+	_ = p.Stop(agent)
+	t.Cleanup(func() { _ = p.Stop(agent); _ = p.TeardownServer() })
 
 	ctx := context.Background()
 	cfg := runtime.Config{
 		WorkDir: t.TempDir(),
 		Command: "claude",
-		Env:     map[string]string{"GC_SESSION_ID": "gctest-kind-session"},
+		Env:     map[string]string{"GC_SESSION_ID": session + "-session"},
 	}
-	if err := p.Start(ctx, "kindsmoke", cfg); err != nil {
+	if err := p.Start(ctx, agent, cfg); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
 	// herdr registered the agent under the session name (kind path).
-	if _, ok, err := p.c.getAgent(ctx, "kindsmoke"); err != nil || !ok {
-		t.Fatalf("agent get kindsmoke = ok=%v, %v; want registered", ok, err)
+	if _, ok, err := p.c.getAgent(ctx, agent); err != nil || !ok {
+		t.Fatalf("agent get %s = ok=%v, %v; want registered", agent, ok, err)
 	}
-	if mode, _ := p.GetMeta("kindsmoke", metaBoundMode); mode != bindModeAgent {
+	if mode, _ := p.GetMeta(agent, metaBoundMode); mode != bindModeAgent {
 		t.Errorf("bound mode = %q; want %q", mode, bindModeAgent)
 	}
-	if pane, _ := p.GetMeta("kindsmoke", metaBoundPane); pane == "" {
+	if pane, _ := p.GetMeta(agent, metaBoundPane); pane == "" {
 		t.Error("bound pane empty after kind Start")
 	}
 
-	if !p.IsRunning("kindsmoke") {
+	if !p.IsRunning(agent) {
 		t.Error("IsRunning = false after kind Start")
 	}
-	if live := p.ObserveLiveness("kindsmoke", nil); !live.Running || !live.Alive {
+	if live := p.ObserveLiveness(agent, nil); !live.Running || !live.Alive {
 		t.Errorf("ObserveLiveness = %+v; want Running=true Alive=true", live)
 	}
-	if err := p.Start(ctx, "kindsmoke", cfg); !errors.Is(err, runtime.ErrSessionExists) {
+	if err := p.Start(ctx, agent, cfg); !errors.Is(err, runtime.ErrSessionExists) {
 		t.Errorf("re-issued Start = %v; want ErrSessionExists", err)
 	}
 
-	if err := p.Stop("kindsmoke"); err != nil {
+	if err := p.Stop(agent); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
-	for i := 0; i < 15 && p.IsRunning("kindsmoke"); i++ {
+	for i := 0; i < 15 && p.IsRunning(agent); i++ {
 		time.Sleep(200 * time.Millisecond)
 	}
-	if p.IsRunning("kindsmoke") {
+	if p.IsRunning(agent) {
 		t.Error("IsRunning = true after Stop")
 	}
 }

--- a/internal/runtime/herdr/kindpath_live_test.go
+++ b/internal/runtime/herdr/kindpath_live_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,11 +35,16 @@ func TestKindPathNamesAreUnique(t *testing.T) {
 	}
 }
 
+var kindPathSessionSeq int64
+
 // kindPathNames returns the herdr session name and pane/agent name that
-// TestProviderLiveClaudeKindPath claims. TODO(ga-fh1flg): still static —
-// TestKindPathNamesAreUnique documents the required (not yet met) contract.
+// TestProviderLiveClaudeKindPath claims, salted with this process's PID and
+// a per-process call counter so concurrent fleet runs of this test can never
+// collide on the same herdr session/pane.
 func kindPathNames() (session, agent string) {
-	return "gctest-kind", "kindsmoke"
+	n := atomic.AddInt64(&kindPathSessionSeq, 1)
+	pid := os.Getpid()
+	return fmt.Sprintf("gctest-kind-%d-%d", pid, n), fmt.Sprintf("kindsmoke-%d-%d", pid, n)
 }
 
 // TestProviderLiveClaudeKindPath drives the herdr ≥0.7.5 kind-launch path

--- a/internal/runtime/herdr/panebinding_provider_test.go
+++ b/internal/runtime/herdr/panebinding_provider_test.go
@@ -34,6 +34,14 @@ var paneBindSession int64
 func newFakeHerdrProvider(t *testing.T) (*Provider, string, string) {
 	t.Helper()
 	session := fmt.Sprintf("gctest-pb-%d-%d", os.Getpid(), atomic.AddInt64(&paneBindSession, 1))
+	return newFakeHerdrProviderForSession(t, session)
+}
+
+// newFakeHerdrProviderForSession is newFakeHerdrProvider with caller-supplied
+// session naming, for callers (e.g. kindpath_live_test.go) that must exercise
+// their own generated names rather than this file's own sequence.
+func newFakeHerdrProviderForSession(t *testing.T, session string) (*Provider, string, string) {
+	t.Helper()
 	state := t.TempDir()
 	metaDir := t.TempDir()
 	script := filepath.Join(t.TempDir(), "herdr")

--- a/release-gates/ga-zron27-herdr-kindpath-names-gate.md
+++ b/release-gates/ga-zron27-herdr-kindpath-names-gate.md
@@ -8,7 +8,7 @@ Evaluated rebased commit: `62ee9f212bc33051f6e1e1a9375e86bee0e1db72`
 Local deploy branch: `deploy/ga-zron27-gate-r3-20260820`  
 Base: `origin/main@7c817e0640fae801631043005f1d54b17ce3e97c`  
 Gate evaluated: 2026-08-20  
-Verdict: **FAIL**
+Verdict: **PASS — MAYOR WAIVER APPLIED**
 
 `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses
 the release criteria in the deployer prompt together with `TESTING.md` and
@@ -20,7 +20,7 @@ the release criteria in the deployer prompt together with `TESTING.md` and
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | Closed review bead `ga-hmd2gu` records round-2 `REVIEW VERDICT: PASS`. `git diff --exit-code 2ec870e236eb32fef0fa7af56281981b34f2afce 62ee9f212bc33051f6e1e1a9375e86bee0e1db72 -- internal/runtime/herdr/kindpath_live_test.go internal/runtime/herdr/panebinding_provider_test.go` returned 0, proving the rebased candidate's reviewed content is byte-identical. |
 | 2 | Acceptance criteria met | PASS | The PID-plus-atomic-counter name generator and both required hermetic proofs are present. `TestKindPathNamesAreUnique` and `TestKindPathNamesWorkThroughFakeProviderLifecycle` both passed in a fresh focused run. |
-| 3 | Tests pass | **FAIL** | The guarded push's `make test-fast-parallel` run failed in `unit-core` because the diff-owned `TestProviderLiveClaudeKindPath` returned `agent_pane_busy` for unique agent `kindsmoke-3319807-4` targeting pane `w1:p1`. The other nine emitted fast-gate logs passed. A diff-owned failure is a hard failure and cannot be attributed or retried into green; `waiver_ref: none`. Required broader jobs were skipped fail-fast. |
+| 3 | Tests pass | **PASS — WAIVED** | The guarded push's `make test-fast-parallel` run completed 9 PASS jobs / 1 FAIL job. The diff-owned `TestProviderLiveClaudeKindPath` returned `agent_pane_busy` for unique agent `kindsmoke-3319807-4` targeting pane `w1:p1`; it remains preserved as **FAIL — WAIVED**. The two hermetic diff-owned tests passed. The prior exact reviewed-content full union completed 33 PASS / 7 FAIL jobs, with this same live-test signature as the only diff-owned failure; a subsequent unchanged-content 40-job run reported the `internal/runtime/herdr` package green twice and no `agent_pane_busy` occurrence. Mayor granted a bead-, test-, and mechanism-specific waiver after independently confirming the same pane-readiness failure on the untouched sibling `TestProviderLive`. `waiver_ref: mayor-2026-08-20-ga-zron27-c3` (granted by mayor; audited on `ga-zron27.2` and mail `gm-wisp-l7c8y2`). |
 | 4 | No high-severity review findings open | PASS | The round-2 review verdict is PASS with no unresolved HIGH finding. |
 | 5 | Final branch is clean | PASS | `git status --short --branch` was clean on the rebased deploy branch before this gate record was written. No source edits were made by deployer. |
 | 6 | Branch diverges cleanly from main | PASS | The bounded replay completed without conflict. `git merge-base --is-ancestor origin/main 62ee9f212bc33051f6e1e1a9375e86bee0e1db72` returned 0 and the merge base is exactly `origin/main@7c817e0640fae801631043005f1d54b17ce3e97c`. The subsequent guarded push was rejected because its pre-push test gate failed, so no remote deploy branch was created. |
@@ -45,13 +45,28 @@ TestKindPathNamesWorkThroughFakeProviderLifecycle: PASS
 ```
 
 This is the same lower-level pane-availability failure recorded in the prior
-gate and tracked by `ga-nqlb8q`, but the tracker is not a waiver. The modified
-live test itself failed in this release evaluation, so the non-diff-owned
-failure attribution protocol does not apply.
+gate and tracked by `ga-nqlb8q`. The modified live test itself failed, so the
+non-diff-owned attribution protocol does not apply. Instead, mayor supplied
+the explicit criterion-3 waiver required by the prior disposition.
+
+## Mayor waiver
+
+Mayor granted `mayor-2026-08-20-ga-zron27-c3` specifically for
+`TestProviderLiveClaudeKindPath` failing as `agent_pane_busy` / pane-not-ready
+on this bead. The ruling does not dispute that the test is diff-owned. It is
+based on mechanism proof outside the diff: reviewer `ga-hmd2gu` reproduced
+the identical failure on untouched sibling `TestProviderLive`, while the two
+hermetic tests prove PID-plus-counter names are unique and traverse the real
+provider lifecycle shape.
+
+The scope is deliberately narrow. Any other test, failure mechanism, or bead
+requires normal attribution or a separate waiver. The raw fast result remains
+9 PASS / 1 FAIL; this record does not rewrite it green.
 
 ## Disposition
 
-- No remote deploy branch, PR, clearance status, or merge was created.
-- Return to builder: the modified live test must produce a real PASS under the
-  required gate, or merge authority must record an explicit waiver. The
-  deployer cannot grant that waiver.
+- The explicit merge-authority waiver now satisfies the prior disposition.
+- Push the isolated deploy branch with this preserved record and open its PR.
+- Per the mayor's current standing rule, do not mail or route a merge request
+  until maintainer-pr-review has produced a clear artifact for that PR.
+- The deployer does not merge.

--- a/release-gates/ga-zron27-herdr-kindpath-names-gate.md
+++ b/release-gates/ga-zron27-herdr-kindpath-names-gate.md
@@ -1,0 +1,57 @@
+# Release Gate: ga-zron27 - herdr kind-path name isolation
+
+Deploy bead: `ga-zron27`  
+Review bead: `ga-hmd2gu`  
+Source build bead: `ga-fh1flg`  
+Reviewed content commit: `2ec870e236eb32fef0fa7af56281981b34f2afce`  
+Evaluated rebased commit: `62ee9f212bc33051f6e1e1a9375e86bee0e1db72`  
+Local deploy branch: `deploy/ga-zron27-gate-r3-20260820`  
+Base: `origin/main@7c817e0640fae801631043005f1d54b17ce3e97c`  
+Gate evaluated: 2026-08-20  
+Verdict: **FAIL**
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate uses
+the release criteria in the deployer prompt together with `TESTING.md` and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Closed review bead `ga-hmd2gu` records round-2 `REVIEW VERDICT: PASS`. `git diff --exit-code 2ec870e236eb32fef0fa7af56281981b34f2afce 62ee9f212bc33051f6e1e1a9375e86bee0e1db72 -- internal/runtime/herdr/kindpath_live_test.go internal/runtime/herdr/panebinding_provider_test.go` returned 0, proving the rebased candidate's reviewed content is byte-identical. |
+| 2 | Acceptance criteria met | PASS | The PID-plus-atomic-counter name generator and both required hermetic proofs are present. `TestKindPathNamesAreUnique` and `TestKindPathNamesWorkThroughFakeProviderLifecycle` both passed in a fresh focused run. |
+| 3 | Tests pass | **FAIL** | The guarded push's `make test-fast-parallel` run failed in `unit-core` because the diff-owned `TestProviderLiveClaudeKindPath` returned `agent_pane_busy` for unique agent `kindsmoke-3319807-4` targeting pane `w1:p1`. The other nine emitted fast-gate logs passed. A diff-owned failure is a hard failure and cannot be attributed or retried into green; `waiver_ref: none`. Required broader jobs were skipped fail-fast. |
+| 4 | No high-severity review findings open | PASS | The round-2 review verdict is PASS with no unresolved HIGH finding. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean on the rebased deploy branch before this gate record was written. No source edits were made by deployer. |
+| 6 | Branch diverges cleanly from main | PASS | The bounded replay completed without conflict. `git merge-base --is-ancestor origin/main 62ee9f212bc33051f6e1e1a9375e86bee0e1db72` returned 0 and the merge base is exactly `origin/main@7c817e0640fae801631043005f1d54b17ce3e97c`. The subsequent guarded push was rejected because its pre-push test gate failed, so no remote deploy branch was created. |
+| 7 | Single feature theme | PASS | The three rebased commits touch only two `internal/runtime/herdr` test files and one theme: isolating kind-path lifecycle test names and proving those names through the provider lifecycle. |
+
+## Criterion 3 evidence
+
+The pre-push fast gate wrote logs to `/var/tmp/gc-local-tests.bdq9Kc`.
+`unit-core.log` records:
+
+```text
+--- FAIL: TestProviderLiveClaudeKindPath (0.33s)
+kindpath_live_test.go:127: Start: herdr: start "kindsmoke-3319807-4":
+agent_pane_busy: agent target pane w1:p1 is not an available shell
+```
+
+Focused hermetic verification on the same rebased SHA passed:
+
+```text
+TestKindPathNamesAreUnique: PASS
+TestKindPathNamesWorkThroughFakeProviderLifecycle: PASS
+```
+
+This is the same lower-level pane-availability failure recorded in the prior
+gate and tracked by `ga-nqlb8q`, but the tracker is not a waiver. The modified
+live test itself failed in this release evaluation, so the non-diff-owned
+failure attribution protocol does not apply.
+
+## Disposition
+
+- No remote deploy branch, PR, clearance status, or merge was created.
+- Return to builder: the modified live test must produce a real PASS under the
+  required gate, or merge authority must record an explicit waiver. The
+  deployer cannot grant that waiver.


### PR DESCRIPTION
## Summary

- salt live herdr kind-path test names with PID plus an atomic counter
- prove generated names are unique
- prove the names traverse the fake-provider lifecycle

## Release gate

- deploy bead: ga-zron27
- review bead: ga-hmd2gu
- evaluated candidate: 62ee9f212bc33051f6e1e1a9375e86bee0e1db72
- gate record: release-gates/ga-zron27-herdr-kindpath-names-gate.md
- verdict: PASS — MAYOR WAIVER APPLIED
- waiver: mayor-2026-08-20-ga-zron27-c3

The fast gate completed 9 PASS / 1 FAIL. Diff-owned TestProviderLiveClaudeKindPath remains explicitly preserved as FAIL — WAIVED for the agent_pane_busy / pane-not-ready signature only. The two hermetic diff-owned tests passed, and the same lower-level signature was independently reproduced on the untouched sibling TestProviderLive.

This PR awaits maintainer-pr-review. No merge request has been sent to mayor, and the deployer has not merged.