### PR TITLE
fix(session): restore safe named-session alias resolution

### DIFF
--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -419,10 +419,52 @@ func lookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec, incl
 		}
 		conflictCandidates = appendUniqueNamedSessionCandidates(conflictCandidates, make(map[string]bool, len(conflictCandidates)+len(matches)), matches)
 	}
+	for _, candidate := range conflictCandidates {
+		if namedSessionCandidateIsSelf(candidate, spec) {
+			return ConfiguredNamedSessionLookup{Canonical: candidate, HasCanonical: true}, nil
+		}
+	}
 	if bead, conflict := FindNamedSessionConflict(conflictCandidates, spec); conflict {
 		return ConfiguredNamedSessionLookup{Conflict: bead, HasConflict: true}, nil
 	}
 	return ConfiguredNamedSessionLookup{}, nil
+}
+
+// namedSessionCandidateIsSelf reports whether a bead reached only through
+// conflict-scoped queries (session_name/alias) actually denotes spec's own
+// identity rather than a foreign claimant. It defers to
+// FindCanonicalNamedSessionBead for every signal that function already
+// treats as authoritative, then adds exactly one narrower fallback: a live,
+// continuity-eligible session bead whose alias exactly equals spec.Identity
+// is that identity's own self-claimed session (see alias.go), even when it
+// carries no configured_named_session/configured_named_identity flag and no
+// corroborating template/agent_name match. Canonical detection never queries
+// the store by alias, so such a bead was previously visible only to conflict
+// detection — surfacing as "X conflicts with configured named session X"
+// (ga-t3a0fv, corroborated by ga-1ycmli).
+//
+// The fallback requires the candidate's session_name to be empty. By the
+// time a candidate reaches this point, the earlier canonical rounds have
+// already failed to match its session_name against spec.SessionName and
+// spec.Identity — so a candidate with a *non-empty* session_name here is
+// declaring a runtime session name that provably differs from spec's own,
+// which is real evidence of a genuinely distinct session squatting on a
+// reused alias, not spec's own bead under a different label. Only the
+// absence of any competing session_name claim makes the alias trustworthy.
+func namedSessionCandidateIsSelf(b beads.Bead, spec NamedSessionSpec) bool {
+	if spec.Identity == "" {
+		return false
+	}
+	if _, ok := FindCanonicalNamedSessionBead([]beads.Bead{b}, spec); ok {
+		return true
+	}
+	if !IsSessionBeadOrRepairable(b) || b.Status == "closed" || !NamedSessionContinuityEligible(b) {
+		return false
+	}
+	if strings.TrimSpace(b.Metadata["session_name"]) != "" {
+		return false
+	}
+	return strings.TrimSpace(b.Metadata["alias"]) == spec.Identity
 }
 
 func listConfiguredNamedSessionBeadsByMetadata(store beads.Store, key, value string) ([]beads.Bead, error) {

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -432,39 +432,45 @@ func lookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec, incl
 
 // namedSessionCandidateIsSelf reports whether a bead reached only through
 // conflict-scoped queries (session_name/alias) actually denotes spec's own
-// identity rather than a foreign claimant. It defers to
-// FindCanonicalNamedSessionBead for every signal that function already
-// treats as authoritative, then adds exactly one narrower fallback: a live,
-// continuity-eligible session bead whose alias exactly equals spec.Identity
-// is that identity's own self-claimed session (see alias.go), even when it
-// carries no configured_named_session/configured_named_identity flag and no
-// corroborating template/agent_name match. Canonical detection never queries
-// the store by alias, so such a bead was previously visible only to conflict
-// detection — surfacing as "X conflicts with configured named session X"
-// (ga-t3a0fv, corroborated by ga-1ycmli).
+// identity rather than a foreign claimant. It defers entirely to
+// FindCanonicalNamedSessionBead, the same signal canonical detection itself
+// treats as authoritative.
 //
-// The fallback requires the candidate's session_name to be empty. By the
-// time a candidate reaches this point, the earlier canonical rounds have
-// already failed to match its session_name against spec.SessionName and
-// spec.Identity — so a candidate with a *non-empty* session_name here is
-// declaring a runtime session name that provably differs from spec's own,
-// which is real evidence of a genuinely distinct session squatting on a
-// reused alias, not spec's own bead under a different label. Only the
-// absence of any competing session_name claim makes the alias trustworthy.
+// This previously also trusted a narrower fallback: a live,
+// continuity-eligible session bead whose alias exactly equals spec.Identity
+// and whose session_name is empty, even with no
+// configured_named_session/configured_named_identity flag and no
+// corroborating template/agent_name match (ga-t3a0fv round 1). Review
+// (ga-t3a0fv round 2) showed that fallback is unsafe: on (bead, spec) alone,
+// a genuine not-yet-named self bead is byte-for-byte indistinguishable from
+// an unrelated bead that merely claims the same alias with nothing else set
+// — see TestLookupConfiguredNamedSession_UnrelatedAliasOnlyBeadNotTrustedAsSelf.
+// A bead with empty session_name costs nothing to create, so trusting bare
+// alias+empty-session_name let a decoy silently resolve as canonical self
+// instead of surfacing as a conflict: a fail-safe-to-fail-unsafe regression.
+// The fallback was removed rather than narrowed further, because every
+// signal tried (template/agent_name match, creation recency, city/rig
+// scope) either broke existing intentionally-bare test fixtures or failed
+// to actually distinguish the two cases the reviewer's PoC turned on.
+//
+// The underlying problem the fallback was trying to solve is real and still
+// open (ga-1ycmli): a live singleton named-session bead that never got
+// configured_named_identity stamped at creation is unmailable while
+// running, because canonical detection can't see it and conflict detection
+// is all that's left. The fix needs either eager identity-metadata stamping
+// at bead-creation time in the wisp/molecule dispatch path, or a
+// caller-supplied runtime-liveness assertion threaded in from the worker
+// boundary — internal/session may not import internal/worker directly (see
+// AGENTS.md layering invariants), so that check can only be injected from a
+// caller that already has worker.Handle access. Both directions need
+// scoping beyond this function; see the follow-up bead linked from
+// ga-t3a0fv's notes.
 func namedSessionCandidateIsSelf(b beads.Bead, spec NamedSessionSpec) bool {
 	if spec.Identity == "" {
 		return false
 	}
-	if _, ok := FindCanonicalNamedSessionBead([]beads.Bead{b}, spec); ok {
-		return true
-	}
-	if !IsSessionBeadOrRepairable(b) || b.Status == "closed" || !NamedSessionContinuityEligible(b) {
-		return false
-	}
-	if strings.TrimSpace(b.Metadata["session_name"]) != "" {
-		return false
-	}
-	return strings.TrimSpace(b.Metadata["alias"]) == spec.Identity
+	_, ok := FindCanonicalNamedSessionBead([]beads.Bead{b}, spec)
+	return ok
 }
 
 func listConfiguredNamedSessionBeadsByMetadata(store beads.Store, key, value string) ([]beads.Bead, error) {

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -522,20 +522,30 @@ func TestLookupConfiguredNamedSession_AcceptsTypeOnlyCanonicalBead(t *testing.T)
 	}
 }
 
-// TestLookupConfiguredNamedSession_LiveSessionOnlyTaggedByAliasResolvesCanonical
-// is the regression test for ga-t3a0fv / ga-1ycmli: a live session bead that
-// denotes spec's identity only through its self-claimed alias (no
-// configured_named_session flag, no configured_named_identity, no matching
-// session_name, template, or agent_name) must resolve as the caller's own
-// canonical session, not as a foreign bead conflicting with itself. This was
-// the reported "'X' conflicts with configured named session 'X'" shape.
-func TestLookupConfiguredNamedSession_LiveSessionOnlyTaggedByAliasResolvesCanonical(t *testing.T) {
+// TestLookupConfiguredNamedSession_AliasOnlyBeadWithoutOtherSignalsConflicts
+// is the corrected-understanding regression test for ga-t3a0fv round 2: a
+// bead whose ONLY signal is a bare alias match (no configured_named_session
+// flag, no configured_named_identity, no session_name, no matching template
+// or agent_name) is not trusted as spec's own canonical session — it is
+// reported as a conflict, exactly like any other unrelated bead that claims
+// the same alias. Round 1 of ga-t3a0fv trusted this shape as canonical self
+// (on the theory that an empty session_name meant "no competing claim"),
+// but that is indistinguishable from a zero-cost decoy an attacker (or an
+// unrelated buggy process) can plant with the same three lines of metadata
+// — see TestLookupConfiguredNamedSession_UnrelatedAliasOnlyBeadNotTrustedAsSelf,
+// which uses a byte-for-byte identical bead/spec shape and must also
+// conflict rather than resolve canonical. The original bug this was trying
+// to fix (ga-1ycmli: a live singleton named-session bead that never got its
+// identity metadata stamped is unmailable while running) is still open;
+// closing it safely needs a caller-supplied signal beyond what (bead, spec)
+// alone can provide.
+func TestLookupConfiguredNamedSession_AliasOnlyBeadWithoutOtherSignalsConflicts(t *testing.T) {
 	store := beads.NewMemStore()
 	spec := NamedSessionSpec{
 		Identity:    "pack-author.pack-author",
 		SessionName: "test-city--pack-author",
 	}
-	live, err := store.Create(beads.Bead{
+	aliasOnly, err := store.Create(beads.Bead{
 		Type:   BeadType,
 		Status: "open",
 		Labels: []string{LabelSession},
@@ -544,21 +554,52 @@ func TestLookupConfiguredNamedSession_LiveSessionOnlyTaggedByAliasResolvesCanoni
 		},
 	})
 	if err != nil {
-		t.Fatalf("Create(live): %v", err)
+		t.Fatalf("Create(aliasOnly): %v", err)
 	}
 
 	lookup, err := LookupConfiguredNamedSession(store, spec)
 	if err != nil {
 		t.Fatalf("LookupConfiguredNamedSession: %v", err)
 	}
-	if lookup.HasConflict {
-		t.Fatalf("HasConflict = true (conflict bead %q), want the live alias-tagged bead recognized as canonical, not a conflict", lookup.Conflict.ID)
+	if lookup.HasCanonical {
+		t.Fatalf("HasCanonical = true (bead %q), want a bare alias-only bead treated as a conflict, not trusted as canonical self", lookup.Canonical.ID)
 	}
-	if !lookup.HasCanonical {
-		t.Fatal("HasCanonical = false, want true")
+	if !lookup.HasConflict {
+		t.Fatal("HasConflict = false, want true")
 	}
-	if lookup.Canonical.ID != live.ID {
-		t.Fatalf("Canonical.ID = %q, want %q", lookup.Canonical.ID, live.ID)
+	if lookup.Conflict.ID != aliasOnly.ID {
+		t.Fatalf("Conflict.ID = %q, want %q", lookup.Conflict.ID, aliasOnly.ID)
+	}
+}
+
+// TestLookupConfiguredNamedSession_UnrelatedAliasOnlyBeadNotTrustedAsSelf is
+// the reviewer's suggested regression test for ga-t3a0fv round 2 (same
+// logic, adapted to this file's error-checking convention): a decoy bead
+// that merely claims spec's alias, with nothing else set, must never
+// resolve as canonical self. It is metadata-identical to the "self" bead in
+// TestLookupConfiguredNamedSession_AliasOnlyBeadWithoutOtherSignalsConflicts
+// — the two tests together are the actual boundary this fix draws: no
+// predicate over (bead, spec) alone can tell a genuine not-yet-named self
+// bead apart from this decoy, so neither is trusted.
+func TestLookupConfiguredNamedSession_UnrelatedAliasOnlyBeadNotTrustedAsSelf(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{Identity: "mayor", SessionName: "test-city--mayor"}
+	decoy, err := store.Create(beads.Bead{
+		Type:     BeadType,
+		Status:   "open",
+		Labels:   []string{LabelSession},
+		Metadata: map[string]string{"alias": spec.Identity},
+	})
+	if err != nil {
+		t.Fatalf("Create(decoy): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if lookup.HasCanonical && lookup.Canonical.ID == decoy.ID {
+		t.Fatalf("decoy bead with bare alias claim trusted as canonical self")
 	}
 }
 
@@ -652,20 +693,21 @@ func TestLookupConfiguredNamedSession_AliasMatchWithMismatchedSessionNameStillCo
 	}
 }
 
-// TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSessionNameConflict
-// used to assert that a session_name conflict is reported ahead of an alias
-// conflict when both are present. Post ga-t3a0fv, an exact alias match to
-// spec.Identity is no longer a conflict candidate at all — it denotes spec's
-// own live session — so resolution must short-circuit to that bead as
-// canonical rather than falling through to the unrelated session_name
-// collision.
-func TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSessionNameConflict(t *testing.T) {
+// TestLookupConfiguredNamedSession_SessionNameConflictReportedOverBareAliasMatch
+// restores the pre-ga-t3a0fv-round-1 ordering: when a session_name conflict
+// and a bare alias-only match are both present, the session_name conflict is
+// what surfaces. Round 1 of ga-t3a0fv briefly made an exact alias match
+// short-circuit to canonical ahead of this collision; round 2 reverted that
+// (see TestLookupConfiguredNamedSession_AliasOnlyBeadWithoutOtherSignalsConflicts)
+// because the alias-only signal alone cannot distinguish spec's own
+// not-yet-named bead from an unrelated decoy claiming the same alias.
+func TestLookupConfiguredNamedSession_SessionNameConflictReportedOverBareAliasMatch(t *testing.T) {
 	store := beads.NewMemStore()
 	spec := NamedSessionSpec{
 		Identity:    "mayor",
 		SessionName: "test-city--mayor",
 	}
-	live, err := store.Create(beads.Bead{
+	if _, err := store.Create(beads.Bead{
 		Type:   BeadType,
 		Status: "open",
 		Labels: []string{LabelSession},
@@ -674,11 +716,10 @@ func TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSession
 			"template":   "other",
 			"agent_name": "other",
 		},
-	})
-	if err != nil {
-		t.Fatalf("Create(live self bead): %v", err)
+	}); err != nil {
+		t.Fatalf("Create(alias-only bead): %v", err)
 	}
-	if _, err := store.Create(beads.Bead{
+	conflict, err := store.Create(beads.Bead{
 		Type:   BeadType,
 		Status: "open",
 		Labels: []string{LabelSession},
@@ -687,7 +728,8 @@ func TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSession
 			"template":     "other",
 			"agent_name":   "other",
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create(session_name conflict): %v", err)
 	}
 
@@ -695,14 +737,14 @@ func TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSession
 	if err != nil {
 		t.Fatalf("LookupConfiguredNamedSession: %v", err)
 	}
-	if lookup.HasConflict {
-		t.Fatalf("HasConflict = true (conflict bead %q), want the live self bead recognized as canonical", lookup.Conflict.ID)
+	if lookup.HasCanonical {
+		t.Fatalf("HasCanonical = true (bead %q), want the session_name conflict reported instead of the bare alias match resolved canonical", lookup.Canonical.ID)
 	}
-	if !lookup.HasCanonical {
-		t.Fatal("HasCanonical = false, want true")
+	if !lookup.HasConflict {
+		t.Fatal("HasConflict = false, want true")
 	}
-	if lookup.Canonical.ID != live.ID {
-		t.Fatalf("Canonical.ID = %q, want %q", lookup.Canonical.ID, live.ID)
+	if lookup.Conflict.ID != conflict.ID {
+		t.Fatalf("Conflict.ID = %q, want %q", lookup.Conflict.ID, conflict.ID)
 	}
 }
 

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -522,26 +522,71 @@ func TestLookupConfiguredNamedSession_AcceptsTypeOnlyCanonicalBead(t *testing.T)
 	}
 }
 
-func TestLookupConfiguredNamedSession_ReportsSessionNameConflictBeforeAliasConflict(t *testing.T) {
+// TestLookupConfiguredNamedSession_LiveSessionOnlyTaggedByAliasResolvesCanonical
+// is the regression test for ga-t3a0fv / ga-1ycmli: a live session bead that
+// denotes spec's identity only through its self-claimed alias (no
+// configured_named_session flag, no configured_named_identity, no matching
+// session_name, template, or agent_name) must resolve as the caller's own
+// canonical session, not as a foreign bead conflicting with itself. This was
+// the reported "'X' conflicts with configured named session 'X'" shape.
+func TestLookupConfiguredNamedSession_LiveSessionOnlyTaggedByAliasResolvesCanonical(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{
+		Identity:    "pack-author.pack-author",
+		SessionName: "test-city--pack-author",
+	}
+	live, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Status: "open",
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias": spec.Identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(live): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if lookup.HasConflict {
+		t.Fatalf("HasConflict = true (conflict bead %q), want the live alias-tagged bead recognized as canonical, not a conflict", lookup.Conflict.ID)
+	}
+	if !lookup.HasCanonical {
+		t.Fatal("HasCanonical = false, want true")
+	}
+	if lookup.Canonical.ID != live.ID {
+		t.Fatalf("Canonical.ID = %q, want %q", lookup.Canonical.ID, live.ID)
+	}
+}
+
+// TestLookupConfiguredNamedSession_DifferentIdentitySimilarAliasStillConflicts
+// guards ga-t3a0fv's second acceptance criterion: the self-match fix stays
+// keyed on exact identity equivalence, not substring/prefix similarity. A
+// bead whose alias merely resembles spec's identity is never fetched as a
+// self candidate (the store query itself is an exact-value filter) and must
+// not suppress a genuine, unrelated session_name collision.
+func TestLookupConfiguredNamedSession_DifferentIdentitySimilarAliasStillConflicts(t *testing.T) {
 	store := beads.NewMemStore()
 	spec := NamedSessionSpec{
 		Identity:    "mayor",
 		SessionName: "test-city--mayor",
 	}
-	aliasConflict, err := store.Create(beads.Bead{
+	if _, err := store.Create(beads.Bead{
 		Type:   BeadType,
+		Status: "open",
 		Labels: []string{LabelSession},
 		Metadata: map[string]string{
-			"alias":      spec.Identity,
-			"template":   "other",
-			"agent_name": "other",
+			"alias": "mayor-backup",
 		},
-	})
-	if err != nil {
-		t.Fatalf("Create(alias conflict): %v", err)
+	}); err != nil {
+		t.Fatalf("Create(similar but different identity): %v", err)
 	}
-	sessionNameConflict, err := store.Create(beads.Bead{
+	conflict, err := store.Create(beads.Bead{
 		Type:   BeadType,
+		Status: "open",
 		Labels: []string{LabelSession},
 		Metadata: map[string]string{
 			"session_name": spec.SessionName,
@@ -550,7 +595,7 @@ func TestLookupConfiguredNamedSession_ReportsSessionNameConflictBeforeAliasConfl
 		},
 	})
 	if err != nil {
-		t.Fatalf("Create(session_name conflict): %v", err)
+		t.Fatalf("Create(conflict): %v", err)
 	}
 
 	lookup, err := LookupConfiguredNamedSession(store, spec)
@@ -558,10 +603,106 @@ func TestLookupConfiguredNamedSession_ReportsSessionNameConflictBeforeAliasConfl
 		t.Fatalf("LookupConfiguredNamedSession: %v", err)
 	}
 	if !lookup.HasConflict {
+		t.Fatal("HasConflict = false, want true — a similarly-named but distinct alias must not suppress a genuine session_name collision")
+	}
+	if lookup.Conflict.ID != conflict.ID {
+		t.Fatalf("Conflict.ID = %q, want %q", lookup.Conflict.ID, conflict.ID)
+	}
+}
+
+// TestLookupConfiguredNamedSession_AliasMatchWithMismatchedSessionNameStillConflicts
+// guards the boundary of the ga-t3a0fv self-match fix: the alias fallback in
+// namedSessionCandidateIsSelf only trusts an exact alias match when the
+// candidate declares no session_name at all. A bead that reused spec's alias
+// while running under a visibly different session_name (a "squatter") is
+// real evidence of a distinct live session, not spec's own bead under a
+// different label, and must still be reported as a conflict — mirroring
+// cmd/gc's TestResolveSessionIDWithConfig_ReservedNamedTargetConflictsWithLiveAlias.
+func TestLookupConfiguredNamedSession_AliasMatchWithMismatchedSessionNameStillConflicts(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	squatter, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Status: "open",
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "s-gc-squatter",
+			"alias":        spec.Identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(squatter): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if lookup.HasCanonical {
+		t.Fatalf("HasCanonical = true (bead %q), want the mismatched-session_name squatter treated as a conflict, not self", lookup.Canonical.ID)
+	}
+	if !lookup.HasConflict {
 		t.Fatal("HasConflict = false, want true")
 	}
-	if lookup.Conflict.ID != sessionNameConflict.ID {
-		t.Fatalf("Conflict.ID = %q, want session_name conflict %q before alias conflict %q", lookup.Conflict.ID, sessionNameConflict.ID, aliasConflict.ID)
+	if lookup.Conflict.ID != squatter.ID {
+		t.Fatalf("Conflict.ID = %q, want %q", lookup.Conflict.ID, squatter.ID)
+	}
+}
+
+// TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSessionNameConflict
+// used to assert that a session_name conflict is reported ahead of an alias
+// conflict when both are present. Post ga-t3a0fv, an exact alias match to
+// spec.Identity is no longer a conflict candidate at all — it denotes spec's
+// own live session — so resolution must short-circuit to that bead as
+// canonical rather than falling through to the unrelated session_name
+// collision.
+func TestLookupConfiguredNamedSession_AliasSelfMatchResolvesCanonicalOverSessionNameConflict(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	live, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Status: "open",
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias":      spec.Identity,
+			"template":   "other",
+			"agent_name": "other",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(live self bead): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Status: "open",
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": spec.SessionName,
+			"template":     "other",
+			"agent_name":   "other",
+		},
+	}); err != nil {
+		t.Fatalf("Create(session_name conflict): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if lookup.HasConflict {
+		t.Fatalf("HasConflict = true (conflict bead %q), want the live self bead recognized as canonical", lookup.Conflict.ID)
+	}
+	if !lookup.HasCanonical {
+		t.Fatal("HasCanonical = false, want true")
+	}
+	if lookup.Canonical.ID != live.ID {
+		t.Fatalf("Canonical.ID = %q, want %q", lookup.Canonical.ID, live.ID)
 	}
 }
 

--- a/release-gates/ga-t3a0fv-round-2-security-revert-gate.md
+++ b/release-gates/ga-t3a0fv-round-2-security-revert-gate.md
@@ -1,0 +1,138 @@
+# Release Gate: ga-t3a0fv round-2 security revert
+
+- Deploy bead: `ga-qtnd2d`
+- Review bead: `ga-t3a0fv`
+- Reviewed source: `342e8f901b97dac3714b0acc01ac1f243f0ae9c1`
+- Source branch: `builder/ga-t3a0fv` (provenance only)
+- Base evaluated: `origin/main@7c817e0640fae801631043005f1d54b17ce3e97c`
+- Merge base: `a6341f8b1b13dc677ac3d23a8db1e94092da5896`
+- Deploy branch: `deploy/ga-t3a0fv-gate`
+- Verdict: **PASS**
+
+This is the security-only round-2 landing accepted by the mayor in
+`gm-wisp-op6nw8`. It intentionally does **not** satisfy the original live
+named-session mail criterion. That work is formally descoped to P0
+`ga-1ycmli`; this gate does not represent it as fixed. The accepted scope is
+to remove round 1's unsafe alias-only self-match and retain the distinct-
+identity collision boundary.
+
+`docs/PROJECT_MANIFEST.md` is absent, so this checklist uses the seven release
+criteria in the active deployer protocol and the CI-path conventions in
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | The reviewer independently verified round 2 at the exact reviewed SHA, including build, vet, session, API anti-hijack, and CLI conflict tests. The reviewer escalated only the scope decision; the mayor accepted the verified security revert as a partial resolution in `gm-wisp-op6nw8` and directed that no round 3 be opened. |
+| 2 | Acceptance criteria met | **PASS (approved partial)** | The accepted criterion is met: a bare alias-only bead is not promoted to canonical self, mismatched or similar identities remain conflicts, and canonical resolution still uses the established authoritative signals. Original criterion #1—mailing a live named session without workarounds—is explicitly unmet and continues on `ga-1ycmli` (P0, mayor-owned). |
+| 3 | Tests pass | **PASS with attributed infrastructure failures** | All five diff-owned tests passed by exact name with 0 skips; the full `internal/session/...` suite, build, vet, acceptance tier A, all 12 `cmd/gc` process shards (including `TestTutorial01`), fast baseline, and synthetic-merge affected static lane passed. The raw 46-job CI-equivalent union recorded 41 PASS / 5 FAIL; every failure and rerun is preserved below. Four failure classes have exact-base or existing tracked attribution. The remaining Dolt serialization failure passed 3/3 in isolation and passed the complete 19-test shard on the current-main synthetic merge, which is the tree the PR will test. `waiver_ref: none`. |
+| 4 | No high-severity review findings open | **PASS** | Round 1's high-severity alias-hijack finding is closed by complete removal of the unsafe fallback. The reviewer independently traced the safe canonical matcher and found no residual variant. Unresolved HIGH count for this accepted scope: `0`. |
+| 5 | Final branch is clean | **PASS** | The isolated branch started at the exact reviewed SHA with a clean index/worktree. `git diff --check` and `gofmt -l` on both touched Go files produced no output. Hooks resolve through `.githooks`; the gate commit is hook-verified and the final branch status is clean. |
+| 6 | Branch diverges cleanly from main | **PASS** | No existing PR targeted the reviewed SHA or isolated branch. `git merge-tree --write-tree origin/main 342e8f901b...` completed without conflict (tree `0524c44059a3dd8437006a2632d5aa96a6d7bb86`). The canonical ancestry-scope guard accepted both candidate commits under `ga-t3a0fv` / `ga-qtnd2d` and found no denylisted path. No self-rebase was permitted or needed because criterion 6 passed. |
+| 7 | Single feature theme | **PASS** | The two-file diff is one security-revert theme in named-session lookup: remove unsafe alias-only identity trust and add regression coverage for the restored conflict boundary. No API, configuration, or unrelated behavior is bundled. |
+
+## Diff-owned test evidence
+
+At exact reviewed SHA `342e8f901b`:
+
+- `TestLookupConfiguredNamedSession_AliasOnlyBeadWithoutOtherSignalsConflicts`: PASS
+- `TestLookupConfiguredNamedSession_UnrelatedAliasOnlyBeadNotTrustedAsSelf`: PASS
+- `TestLookupConfiguredNamedSession_DifferentIdentitySimilarAliasStillConflicts`: PASS
+- `TestLookupConfiguredNamedSession_AliasMatchWithMismatchedSessionNameStillConflicts`: PASS
+- `TestLookupConfiguredNamedSession_SessionNameConflictReportedOverBareAliasMatch`: PASS
+
+`diff_tests_executed`: `5 PASS / 0 FAIL / 0 SKIP`.
+
+`skip_justification`: not applicable—no diff-owned test skipped.
+
+`waiver_ref`: none required.
+
+## CI-equivalent test evidence
+
+The exact reviewed source ran:
+
+- `go test -count=1 ./internal/session/...`: PASS.
+- `go build ./...`: PASS.
+- `go vet ./...`: PASS.
+- `DOCKER_HOST=... TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=2 CMD_GC_PROCESS_TOTAL=12 make test-local-full-parallel`: 46 jobs selected, 41 PASS / 5 FAIL. Raw logs: `/var/tmp/gc-local-tests.Py5Sbj`.
+- Fast unit baseline: PASS.
+- All 12 `cmd/gc` process shards: PASS, including `TestTutorial01`.
+- Product-metrics test hook: PASS.
+- The unaffected integration shards other than the failures below: PASS.
+
+The clean synthetic merge of the reviewed source onto current main
+(`cec869c862`, tree equivalent for PR evaluation) ran:
+
+- `make test-acceptance`: PASS; tier A completed in 93.817s.
+- The complete `integration-rest-full-2-of-8` shard: PASS, all 19 tests in
+  151.763s; log
+  `/var/tmp/gc-local-tests.Ewy3RI/integration-rest-full-2-of-8.log`.
+- CI policy tests, module replacement guard, native dependency guard, event
+  export isolation, hosted-service core boundary, and native DoltLite tests:
+  PASS.
+- `make lint-affected` with a clean isolated golangci cache: PASS, `0 issues`
+  across the full reverse-dependent package set.
+- `make fmt-check-changed check-docs build`, `./bin/gc version`, and
+  `./bin/gc --help`: PASS.
+
+The first two lint invocations used the shared golangci cache and surfaced
+diagnostics for already-deleted `/var/tmp/ga-j250d0-gate...` paths. Repeating
+the same synthetic-merge command with a task-isolated on-disk golangci cache
+produced `0 issues`; no source change was made between those runs.
+
+The K8s conformance step was not run locally because this host does not have
+the `GC_K8S_AVAILABLE` CI secret/cluster. The workflow condition skips that
+step in the same environment. The change does not touch the K8s provider.
+
+## Failure attribution
+
+The initial union's red results remain red in the raw record:
+
+1. `integration-packages-core-1-of-4` failed
+   `TestBdFlagManifestCurrent` because the host's locally patched `bd 1.1.0`
+   advertises flags beyond the repository manifest. Exact current
+   `origin/main@7c817e0640` reproduced the failure. The complete core shard
+   passed with the checksum-pinned official CI `bd 1.1.0`. Tracker:
+   `ga-f0uceo`.
+2. Runtime-tmux shards 2 and 3 failed
+   `TestGetKeyBinding_CapturesDefaultBinding` and its `WithArgs` case because
+   host tmux 3.7b returned an empty filtered default key table. Both tests
+   reproduced on exact current main. Tracker: `ga-afqddr`.
+3. The first rest-full-1 run polluted `TestCleanInstallTutorialPath` stdout
+   with circuit-breaker cleanup output. That path is already fixed on current
+   main; the focused candidate test passed with the official CI `bd`. A later
+   full-shard retry cleared it and instead hit the tracked
+   `TestE2E_SuspendResume_City` missing-`citysus.report` flake, which passed in
+   the initial union and has prior exact-base A/B evidence. Tracker:
+   `ga-yc0e3a`.
+4. Rest-full-2 twice observed
+   `TestHumaBinary_SessionMessageAsync` leaking a Dolt Error 1213
+   serialization conflict as HTTP 500 at suspend. The exact reviewed source
+   passed the test 3/3 in isolation; exact current main passed the complete
+   shard twice; and the current-main synthetic merge passed the complete
+   shard fresh. The candidate-path raw failure is not rewritten as green and
+   is tracked separately as `ga-67pslx`.
+5. `make test-docker` failed before reaching candidate behavior because this
+   host's Podman-backed buildx container driver leaves images only in its
+   build cache when the script omits `--load`. Exact current main reproduced
+   the same missing-image failure. Tracker: `ga-5icabz`.
+6. The first actual push's fast gate timed out after 10 seconds waiting for a
+   SQLite child protocol line in
+   `TestSQLiteGraphSnapshotSIGKILLAtBoundaries/graph-snapshot-copy-after`.
+   The identical fast gate passed immediately beforehand during push dry-run,
+   all other packages passed, and the candidate does not touch the SQLite
+   store boundary. Tracker: `ga-ap7lpd`; log:
+   `/var/tmp/gc-local-tests.VuDbRq/unit-core.log`.
+7. The next unchanged push retry passed the SQLite test but missed the
+   SIGTERM marker in
+   `TestRunBoundedPython3FallbackSendsSigtermBeforeKill`. The immediately
+   preceding identical fast run passed that package, all other packages in
+   the retry passed, and the candidate does not touch the example Dolt
+   fallback. Tracker: `ga-o67333`; log:
+   `/var/tmp/gc-local-tests.IZcfJG/unit-core.log`.
+
+None of these failures overlaps the two changed files or the alias-only trust
+logic. The final integrated tree passes the candidate-owned tests, required
+process coverage, acceptance suite, and the only non-attributable full-shard
+failure from the old reviewed tree.


### PR DESCRIPTION
## Summary

- Remove the unsafe alias-only self-match fallback from named-session lookup.
- Restore fail-safe conflict behavior for uncorroborated alias claims.
- Add regression coverage for alias-only decoys, similar identities, mismatched runtime names, and conflict precedence.

This is a mayor-approved security-only partial landing. It intentionally does not fix the underlying inability to mail an unstamped live named session; that cross-layer design work remains tracked separately as P0.

## Review notes

The implementation defers self-identification entirely to the existing canonical matcher. No API, configuration, or wire format changes are included.

Tracked work: `ga-qtnd2d`.

Detailed release evidence and preserved failure attribution: [release gate](release-gates/ga-t3a0fv-round-2-security-revert-gate.md).

## Test plan

- Five diff-owned named-session regression tests by exact name: 5 pass, 0 fail, 0 skip.
- Full `internal/session/...`, `go build ./...`, and `go vet ./...`.
- Acceptance tier A and all 12 `cmd/gc` process shards, including `TestTutorial01`.
- Fast pre-push gate at constrained concurrency.
- CI policy/boundary checks and affected static analysis on the current-main synthetic merge.