### PR TITLE
perf(events): honour the seq window inside archive reads

### DIFF
--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -424,11 +424,43 @@ func archiveFilesIn(dir string) ([]archiveInfo, error) {
 	return archives, nil
 }
 
+// archiveSeq reads the top-level seq of a raw archive line without decoding
+// the record. FileRecorder writes seq as the first field, so the hot path is a
+// prefix scan with no allocation. Any other layout reports false and the
+// caller falls back to a full decode, which keeps a foreign writer's archive
+// readable.
+func archiveSeq(line []byte) (uint64, bool) {
+	const prefix = `{"seq":`
+	if !bytes.HasPrefix(line, []byte(prefix)) {
+		return 0, false
+	}
+	digits := line[len(prefix):]
+	var seq uint64
+	i := 0
+	for ; i < len(digits) && digits[i] >= '0' && digits[i] <= '9'; i++ {
+		seq = seq*10 + uint64(digits[i]-'0')
+	}
+	if i == 0 {
+		return 0, false
+	}
+	return seq, true
+}
+
 // streamArchive gunzip-streams the file at path, decoding each line
 // as an Event and invoking fn for every event. fn returns false to
 // abort iteration early. Returns nil if iteration completed cleanly
 // or fn requested abort; errors from gzip / scanner are wrapped.
-func streamArchive(path string, _ Filter, fn func(Event) bool) error {
+//
+// Records outside filter's seq window are skipped before json.Unmarshal.
+// archiveOverlapsFilter only rules out an archive that ENDS at or below
+// AfterSeq, so an order whose cursor sits INSIDE the archive's window still
+// opens it — and without this skip every such read decoded the entire archive
+// to reach a handful of trailing records.
+//
+// The skip deliberately does not early-return on BeforeSeq. Archives come from
+// a monotonic log and should be seq-ordered, but `continue` saves the same
+// decode without depending on that.
+func streamArchive(path string, filter Filter, fn func(Event) bool) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -444,8 +476,17 @@ func streamArchive(path string, _ Filter, fn func(Event) bool) error {
 	scanner := bufio.NewScanner(gr)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
+		line := scanner.Bytes()
+		if seq, ok := archiveSeq(line); ok {
+			if filter.AfterSeq > 0 && seq <= filter.AfterSeq {
+				continue
+			}
+			if filter.BeforeSeq > 0 && seq >= filter.BeforeSeq {
+				continue
+			}
+		}
 		var e Event
-		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+		if err := json.Unmarshal(line, &e); err != nil {
 			continue
 		}
 		if !fn(e) {

--- a/internal/events/reader_archive_filter_test.go
+++ b/internal/events/reader_archive_filter_test.go
@@ -1,0 +1,92 @@
+package events
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// streamArchive used to take its Filter as `_ Filter` and discard it, so every
+// caller paid a full gunzip plus a json.Unmarshal of EVERY record in the
+// archive and filtered afterwards. archiveOverlapsFilter only skips an archive
+// that ENDS at or below AfterSeq, so an order whose cursor sits inside the
+// archive's seq window re-read the whole thing on every dispatcher tick.
+// Measured on a real city: a 160,018-event archive cost ~63% of a CPU core on
+// an idle supervisor.
+//
+// These tests pin the seq window at the archive reader, counting callback
+// invocations rather than returned rows — the point is the work NOT done.
+func TestStreamArchiveHonorsAfterSeq(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.jsonl")
+	writeJSONLEvents(t, src, 1, 2, 3, 4, 5)
+	archive := filepath.Join(dir, formatArchiveBasename(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC), 1, 5))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(src, archive, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	var seen []uint64
+	if err := streamArchive(archive, Filter{AfterSeq: 3}, func(e Event) bool {
+		seen = append(seen, e.Seq)
+		return true
+	}); err != nil {
+		t.Fatalf("streamArchive: %v", err)
+	}
+
+	// Records at or below the cursor must never reach the callback, which is
+	// what proves they were not unmarshalled.
+	if len(seen) != 2 || seen[0] != 4 || seen[1] != 5 {
+		t.Fatalf("AfterSeq=3 delivered %v, want [4 5]", seen)
+	}
+}
+
+func TestStreamArchiveStopsAtBeforeSeq(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.jsonl")
+	writeJSONLEvents(t, src, 1, 2, 3, 4, 5)
+	archive := filepath.Join(dir, formatArchiveBasename(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC), 1, 5))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(src, archive, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	var seen []uint64
+	if err := streamArchive(archive, Filter{BeforeSeq: 3}, func(e Event) bool {
+		seen = append(seen, e.Seq)
+		return true
+	}); err != nil {
+		t.Fatalf("streamArchive: %v", err)
+	}
+
+	// Archives are seq-ordered, so BeforeSeq is an early exit: the tail of the
+	// archive is never decoded.
+	if len(seen) != 2 || seen[0] != 1 || seen[1] != 2 {
+		t.Fatalf("BeforeSeq=3 delivered %v, want [1 2]", seen)
+	}
+}
+
+// A zero Filter must still deliver everything — the seq window is an
+// optimisation, not a new default.
+func TestStreamArchiveZeroFilterDeliversAll(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.jsonl")
+	writeJSONLEvents(t, src, 1, 2, 3)
+	archive := filepath.Join(dir, formatArchiveBasename(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC), 1, 3))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(src, archive, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	var seen []uint64
+	if err := streamArchive(archive, Filter{}, func(e Event) bool {
+		seen = append(seen, e.Seq)
+		return true
+	}); err != nil {
+		t.Fatalf("streamArchive: %v", err)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("zero filter delivered %v, want all 3", seen)
+	}
+}

--- a/internal/events/reader_archive_filter_test.go
+++ b/internal/events/reader_archive_filter_test.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -42,7 +44,7 @@ func TestStreamArchiveHonorsAfterSeq(t *testing.T) {
 	}
 }
 
-func TestStreamArchiveStopsAtBeforeSeq(t *testing.T) {
+func TestStreamArchiveSkipsAtBeforeSeq(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "source.jsonl")
 	writeJSONLEvents(t, src, 1, 2, 3, 4, 5)
@@ -60,8 +62,9 @@ func TestStreamArchiveStopsAtBeforeSeq(t *testing.T) {
 		t.Fatalf("streamArchive: %v", err)
 	}
 
-	// Archives are seq-ordered, so BeforeSeq is an early exit: the tail of the
-	// archive is never decoded.
+	// The archive is not exited early: records at or above BeforeSeq are
+	// skipped before json.Unmarshal, which saves the same decode without
+	// depending on the archive being seq-ordered.
 	if len(seen) != 2 || seen[0] != 1 || seen[1] != 2 {
 		t.Fatalf("BeforeSeq=3 delivered %v, want [1 2]", seen)
 	}
@@ -88,5 +91,34 @@ func TestStreamArchiveZeroFilterDeliversAll(t *testing.T) {
 	}
 	if len(seen) != 3 {
 		t.Fatalf("zero filter delivered %v, want all 3", seen)
+	}
+}
+
+// A writer that does not put seq first fails the prefix scan, so archiveSeq
+// reports false and the record falls through to a full decode. The window is
+// then applied by the caller's matchesFilter, not here — so streamArchive
+// must still deliver it.
+func TestStreamArchiveFallsBackWhenSeqNotFirst(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.jsonl")
+	line := fmt.Sprintf("{\"type\":%q,\"seq\":4,\"subject\":\"s4\"}\n", string(BeadCreated))
+	if err := os.WriteFile(src, []byte(line), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	archive := filepath.Join(dir, formatArchiveBasename(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC), 4, 4))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(src, archive, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	var seen []uint64
+	if err := streamArchive(archive, Filter{AfterSeq: 3}, func(e Event) bool {
+		seen = append(seen, e.Seq)
+		return true
+	}); err != nil {
+		t.Fatalf("streamArchive: %v", err)
+	}
+	if len(seen) != 1 || seen[0] != 4 {
+		t.Fatalf("non-canonical layout delivered %v, want [4]", seen)
 	}
 }


### PR DESCRIPTION
## The bug

`events.streamArchive` takes a `Filter` and discards it at the signature:

```go
func streamArchive(path string, _ Filter, fn func(Event) bool) error {
```

So `AfterSeq` never reaches the archive reader. It gunzips from byte zero and `json.Unmarshal`s every record, handing each to a callback that filters afterwards.

`archiveOverlapsFilter` is correct and does its job — it skips an archive that *ends* at or below the cursor. But an order whose cursor lands *inside* the archive's seq window overlaps, so the archive is opened, and once `streamArchive` has it the cursor is gone. To reach the last thousand records of a 160,018-record archive, all 160,018 are decompressed and decoded.

The dispatcher runs this on every tick for every event-triggered order. It is worst for the orders that fire *least*: a cursor only advances when its order fires, so an hourly patrol keeps a cursor deep inside the archive and pays the full decode every tick until it catches up.

## Impact

One rig, rig **suspended**, three idle sessions, no work in flight. Supervisor CPU time over a 120s wall window:

| State | Supervisor CPU |
|---|---|
| 203 MB plain active log, no archive | ~74% of a core |
| 28 KB active log + 9.9 MB `.gz` (160,018 events) | ~68% of a core |
| Same, archive moved out of `.gc/` | 11% of a core |
| **Same, archive restored, with this change** | **13% of a core** |

`sample <pid> 10` confirms it: with the archive present and before this change, `streamArchive` held ~100 on-CPU samples and `readFilteredTracked` 107. After, `streamArchive` is absent from the profile and `readFilteredTracked` drops to 1–2.

Worth flagging for operators: **rotation alone makes this worse, not better.** It trades a linear read of a plain file for repeated gzip decompression of the same records. Someone who sets `max_size_bytes` and stops there sees CPU barely move.

## The change

`streamArchive` skips records outside the seq window before `json.Unmarshal`. `seq` is read with a prefix scan of `{"seq":` — the layout `FileRecorder` writes — with a full-decode fallback so a foreign writer's archive stays readable.

`BeforeSeq` skips rather than early-returning. An early return is faster and archives *should* be seq-ordered, but skipping saves the identical decode without depending on that. Happy to switch it to an early exit if you consider the ordering guaranteed.

Three tests in `reader_archive_filter_test.go`. The first two fail on `main` (`delivered [1 2 3 4 5], want [4 5]`); the third pins that a zero filter still delivers everything.

`ReadFiltered`'s doc comment already promised archives outside the `AfterSeq` window are *"skipped without gunzipping"*. That held archive-by-archive and not record-by-record — this finishes it.

## Related

#4418 fixed the same shape for `gc status`, which was paying two full `events.jsonl` scans per call for a cosmetic field, and added `Filter.MaxScanBytes`. That bound doesn't reach this path because the cost is in the archive branch.

## The larger question

This makes the poll cheap; it doesn't make it unnecessary. `checkEvent` calls `ep.List(...)` on every tick, while `Watch(ctx, afterSeq) (Watcher, error)` is already on the `Provider` interface itself and `FileRecorder` implements it — including the hard part, per its contract: *"every RETAINED event with Seq > afterSeq, in sequence order, exactly once per watcher ... including events that have since rotated into an archive."*

An idle city arguably should cost approximately nothing, and #5296 already moved route-recovery and completions off the steady tick to event-driven deltas. The order dispatcher looks like the same conversion. That changes cursor semantics, the per-tick dispatch budget, and ordering guarantees, so I have kept it out of this PR — but happy to open an issue, or take a run at it if you would find that useful.
