### PR TITLE
fix(reconcile): accrue wake failures for startup-dead sessions in the rollback path

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1465,7 +1465,12 @@ func runPreparedStartCandidate(
 				alive = obs.Alive
 			}
 			if err != nil || !running || !alive {
-				err = fmt.Errorf("session %q died during startup", item.candidate.name())
+				// Wrap the shared sentinel so this locally detected death is
+				// indistinguishable from a provider-reported one downstream
+				// (commitStartFailure's startup-death exception, #5442). The
+				// sentinel's own text is "session died during startup", so the
+				// rendered message keeps the substring existing tests pin.
+				err = fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, item.candidate.name())
 			}
 		}
 		phases.PostStartObserve = time.Since(postStartBegin)
@@ -2254,7 +2259,7 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 		return
 	}
-	if result.rollbackPending {
+	if result.rollbackPending && !errors.Is(result.err, runtime.ErrSessionDiedDuringStartup) {
 		if errors.Is(result.err, context.DeadlineExceeded) {
 			rec.Record(events.Event{
 				Type:    events.SessionColdStartTimeout,
@@ -2268,6 +2273,18 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 		// TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError).
 		// Genuine wake-failure accounting happens on the non-rollback path
 		// below via recordWakeFailure.
+		//
+		// EXCEPTION — startup death (#5442): the recreate-fresh loop only
+		// converges when the next attempt can succeed. A session that dies
+		// during startup on every attempt is discarded and re-minted every
+		// tick, and each fresh bead carries a zero wake_attempts counter, so
+		// the retry budget is never reached and the pool spins forever (the
+		// reported incident: 84 rollback/recreate cycles in ~22s with no
+		// quarantine). Startup deaths therefore skip this arm and fall
+		// through to the wake-failure tail below, where the SAME bead accrues
+		// across ticks until defaultMaxWakeAttempts trips the quarantine and
+		// the conversation reset. Post-startup rollbacks (provider errors,
+		// cold-start deadlines, session-exists mismatches) are unchanged.
 		if trace != nil {
 			trace.RecordOperation(TraceSiteLifecycleStartRollback, TraceReasonStart, result.outcome, "", tp.TemplateName, name, 0, traceRecordPayload{
 				"error": formatLifecycleError(result.err),

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -6238,6 +6238,51 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 	}
 }
 
+// The post-start liveness probe's own "died during startup" verdict must carry
+// runtime.ErrSessionDiedDuringStartup, exactly as a provider-reported death
+// does: commitStartFailure's startup-death exception (#5442) keys off the
+// sentinel, and this locally detected form is the shape the pool spin was
+// reported in.
+func TestExecutePreparedStartWave_StaleSessionKeyDeathWrapsStartupSentinel(t *testing.T) {
+	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
+	item := preparedStart{
+		candidate: startCandidate{
+			info: sessionpkg.Info{
+				ID:                  "gc-99",
+				SessionName:         "test-agent",
+				SessionNameMetadata: "test-agent",
+				SessionKey:          "stale-key-abc",
+				Template:            "worker",
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume stale-key-abc",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume stale-key-abc",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+		withStartStabilityWaiter(immediateStartStabilityWaiter),
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !errors.Is(results[0].err, runtime.ErrSessionDiedDuringStartup) {
+		t.Fatalf("err = %v, want it to wrap runtime.ErrSessionDiedDuringStartup", results[0].err)
+	}
+}
+
 func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *testing.T) {
 	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
 	item := preparedStart{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8480,6 +8480,116 @@ func TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError(t *testing.
 	}
 }
 
+// A pool member that dies during startup on every attempt must accrue the
+// ordinary wake-failure budget on its OWN bead instead of being rolled back and
+// re-minted every tick (#5442). Rolling it back closes the bead and the fresh
+// replacement starts at wake_attempts=0, so the reconciler spins forever with no
+// quarantine ever engaging — the reported incident was 84 cycles in ~22s. The
+// sibling TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError pins
+// the unchanged half: a non-startup start failure still rolls the pending create
+// back and still records no wake failure.
+func TestReconcileSessionBeads_StartupDeathAccruesWakeFailuresUntilQuarantine(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	sp.StartErrors = map[string]error{
+		"sky": fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, "sky"),
+	}
+	clk := &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}
+	cfg := &config.City{Agents: []config.Agent{{Name: "helper"}}}
+	desired := map[string]TemplateParams{
+		"sky": {
+			Command:      "test-cmd",
+			SessionName:  "sky",
+			TemplateName: "helper",
+		},
+	}
+
+	bead, err := store.Create(beads.Bead{
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:helper"},
+		Metadata: map[string]string{
+			"session_name":         "sky",
+			"pool_slot":            "1",
+			"pending_create_claim": "true",
+			"template":             "helper",
+			"state":                "creating",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "test-token",
+			"session_key":          "key-abc",
+			"started_config_hash":  "hash-abc",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(bead): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cfgNames := configuredSessionNames(cfg, "", store)
+	tick := func() beads.Bead {
+		t.Helper()
+		current, err := store.Get(bead.ID)
+		if err != nil {
+			t.Fatalf("Get(bead): %v", err)
+		}
+		reconcileSessionBeads(
+			context.Background(), []beads.Bead{current}, desired, cfgNames,
+			cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"helper": 1}, false, nil, "",
+			nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		)
+		updated, err := store.Get(bead.ID)
+		if err != nil {
+			t.Fatalf("Get(bead) after tick: %v", err)
+		}
+		return updated
+	}
+
+	for attempt := 1; attempt <= defaultMaxWakeAttempts; attempt++ {
+		got := tick()
+		if got.Status == "closed" {
+			t.Fatalf("attempt %d: startup-dead pending create was closed; a re-minted bead resets wake_attempts and the retry budget can never be reached", attempt)
+		}
+		if want := fmt.Sprintf("%d", attempt); got.Metadata["wake_attempts"] != want {
+			t.Fatalf("attempt %d: wake_attempts = %q, want %q", attempt, got.Metadata["wake_attempts"], want)
+		}
+		if got.Metadata["last_woke_at"] != "" {
+			t.Fatalf("attempt %d: last_woke_at = %q, want cleared so the next tick retries", attempt, got.Metadata["last_woke_at"])
+		}
+	}
+
+	final, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(bead) final: %v", err)
+	}
+	if final.Metadata["quarantined_until"] == "" {
+		t.Fatal("quarantined_until empty after the wake budget was spent; the startup-death loop is still unbounded")
+	}
+	quarantinedUntil, err := time.Parse(time.RFC3339, final.Metadata["quarantined_until"])
+	if err != nil {
+		t.Fatalf("parse quarantined_until %q: %v", final.Metadata["quarantined_until"], err)
+	}
+	if !quarantinedUntil.After(clk.Now()) {
+		t.Fatalf("quarantined_until = %v, want a future hold from %v", quarantinedUntil, clk.Now())
+	}
+	// The conversation reset recordWakeFailure performs is what makes the next
+	// attempt a first start rather than a resume of a conversation that no
+	// longer exists.
+	if final.Metadata["session_key"] != "" {
+		t.Fatalf("session_key = %q, want cleared by the wake-failure conversation reset", final.Metadata["session_key"])
+	}
+	if final.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want cleared by the wake-failure conversation reset", final.Metadata["started_config_hash"])
+	}
+
+	// One more tick while quarantined must not spend another attempt: the
+	// budget is what stops the spin.
+	after := tick()
+	if after.Metadata["wake_attempts"] != fmt.Sprintf("%d", defaultMaxWakeAttempts) {
+		t.Fatalf("wake_attempts = %q after a quarantined tick, want the budget to hold at %d", after.Metadata["wake_attempts"], defaultMaxWakeAttempts)
+	}
+}
+
 func TestReconcileSessionBeads_PoolScaleDownOrphansExcess(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{


### PR DESCRIPTION
Fixes #5442.

A pool session that dies during startup was rolled back and re-minted every tick with fresh counters, so the existing wake-failure budget (`recordWakeFailure` → quarantine at `defaultMaxWakeAttempts` + `ConversationResetPatch`) never engaged. Observed live: 84 identical iterations at ~22s cadence with quarantine never firing.

Fix: gate the `rollbackPending` arm on `!errors.Is(err, runtime.ErrSessionDiedDuringStartup)` so startup deaths fall through to the existing wake-failure tail — the same bead accrues attempts and quarantines at the budget. Post-startup rollbacks (provider errors, cold-start deadlines, session-exists mismatches, canceled-commit) are untouched. Also wraps the bare startup-death error at the post-start liveness check in the sentinel for uniform detection.

**Behavioral disclosures for maintainer assent:**
- **Slot-holding**: a startup-dead pool member now retains its pending bead/slot while attempts accrue (up to 5 tries + 5m quarantine) instead of recycling every tick; `staleCreatingStateTimeout` still bounds it. This is the backpressure the issue asks for, but it is a semantics change.
- **Trace-site shift**: startup deaths record through `TraceSiteLifecycleStartFailed` rather than `TraceSiteLifecycleStartRollback` — dashboards keyed on the rollback site will shift.

Note per the follow-up comment on #5442: the original issue text pointed at the resume gate; accruing there (or in the rollback arm while still closing the bead) is a no-op, since the close re-mints a bead with fresh counters — the negative-control test pins that symptom.

Tests: multi-tick accrual → quarantine+reset on a startup-dead pool session; post-startup deaths don't accrue via this arm; sentinel-wrap pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)