### PR TITLE
fix(sling): fire the dropped-instructions hint only where its remedy exists (ga-awchvd)

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -433,11 +433,57 @@ func rootOnlyVaporPourHint(formulaName string, recipe *formula.Recipe) string {
 func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
 	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", result)
 	if err == nil {
-		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
+		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars, opts.OnFormula, SlingFormulaSearchPaths(deps, opts.Target)); hint != "" {
 			result.BeadWarnings = append(result.BeadWarnings, hint)
 		}
 	}
 	return result, err
+}
+
+// beadInstructionCarrierVars are the two formula vars #3681 tells a caller to
+// pass so a bead's own instructions reach the formula's rendered context. One
+// list, read both by the "did the caller pass one" check and by the "can this
+// formula receive one" check, so the two can never drift apart.
+var beadInstructionCarrierVars = [...]string{"context_path", "requirements_path"}
+
+// formulaCanReceiveBeadInstructions reports whether f actually consumes either
+// of beadInstructionCarrierVars — by declaring it under [vars], or by
+// referencing {{var}} in the formula description or any step (Substitute
+// renders any supplied var, declared or not, so a formula may consume one
+// without declaring it).
+//
+// This gates the #3681 hint, and it is load-bearing rather than cosmetic.
+// Nothing rejects an undeclared --var anywhere on the path: buildSlingFormulaVars
+// accepts every key it is given, CollectVarValidationErrors
+// (internal/formula/parser.go) walks only the formula's DECLARED vars and so
+// never sees an extra one, and stampFormulaVars records the value as
+// gc.var.<name> metadata that no template reads. Against a formula consuming
+// neither var the advertised remedy is therefore inert: passing the var
+// silences this very hint (the userVars check below) while changing nothing the
+// agent sees — strictly worse than staying quiet, because it reads as fixed.
+// Fire only where the fix the hint names would actually land.
+func formulaCanReceiveBeadInstructions(f *formula.Formula) bool {
+	if f == nil {
+		return false
+	}
+	for _, name := range beadInstructionCarrierVars {
+		if def, ok := f.Vars[name]; ok && def != nil {
+			return true
+		}
+		placeholder := "{{" + name + "}}"
+		if strings.Contains(f.Description, placeholder) {
+			return true
+		}
+		for _, step := range f.Steps {
+			if step == nil {
+				continue
+			}
+			if strings.Contains(step.Title, placeholder) || strings.Contains(step.Description, placeholder) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // attachedBeadInstructionsDroppedHint returns a sling-time diagnostic when
@@ -450,18 +496,40 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 // context, unless the caller explicitly carries them in via
 // context_path/requirements_path (#3681). It changes neither routing nor
 // the materialized wisp.
-func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, userVars []string) string {
+//
+// The hint stays silent unless the attached formula can actually consume one
+// of those vars. A formula that consumes neither cannot be fixed by the
+// remedy this text names, and a caller who follows it anyway gets a silenced
+// warning and an unchanged rendered context — see
+// formulaCanReceiveBeadInstructions. Note this is a statement about the
+// RENDERED context only: a formula whose steps read the bead at runtime
+// (`bd show $ROOT_ID` off the wrapper's gc.var.issue) reaches the same text by
+// a different route, which is why the hint must not be read as "the agent
+// cannot see this bead".
+func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, userVars []string, formulaName string, searchPaths []string) string {
 	if querier == nil || beadID == "" {
 		return ""
 	}
 	for _, v := range userVars {
 		key, _, ok := strings.Cut(v, "=")
-		if ok && (key == "context_path" || key == "requirements_path") {
+		if !ok {
+			continue
+		}
+		if slices.Contains(beadInstructionCarrierVars[:], key) {
 			return ""
 		}
 	}
 	bead, err := querier.Get(beadID)
 	if err != nil || strings.TrimSpace(bead.Description) == "" {
+		return ""
+	}
+	// Load, never compile. This is a diagnostic on an attach that has already
+	// succeeded, and the compile-once rule earlier in this file exists to keep
+	// exactly this kind of second pass off the recipe path; LoadFormula is the
+	// parser-only resolve. An error here means the formula shape is unknowable,
+	// and an unactionable hint is the defect being avoided — stay silent.
+	f, loadErr := graphv2.LoadFormula(formulaName, searchPaths)
+	if loadErr != nil || !formulaCanReceiveBeadInstructions(f) {
 		return ""
 	}
 	return fmt.Sprintf("note: bead %s's description is not carried into the formula's rendered context — pass --var context_path=<dir> or --var requirements_path=<doc> to include your instructions, or the formula's brainstorm will not see them.", beadID)
@@ -471,7 +539,7 @@ func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, use
 func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
 	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", result)
 	if err == nil {
-		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
+		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars, opts.Target.EffectiveDefaultSlingFormula(), SlingFormulaSearchPaths(deps, opts.Target)); hint != "" {
 			result.BeadWarnings = append(result.BeadWarnings, hint)
 		}
 	}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/molecule"
@@ -2418,6 +2419,35 @@ func TestSlingAttachFormula(t *testing.T) {
 	}
 }
 
+// slingCtxVarFormulaDeps builds deps whose only formula layer holds a single
+// formula that DECLARES context_path, and returns it alongside the formula
+// name. The #3681 hint fires only where the remedy it names is available, so
+// the shared code-review fixture — which declares no vars at all — would make
+// every assertion below vacuous.
+func slingCtxVarFormulaDeps(t *testing.T) (SlingDeps, string) {
+	t.Helper()
+	const name = "ctx-var-formula"
+	dir := t.TempDir()
+	content := fmt.Sprintf("formula = %q\nversion = 1\n\n[vars]\n[vars.context_path]\ndescription = \"dir carrying the caller's instructions\"\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n", name)
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test"},
+		FormulaLayers: config.FormulaLayers{City: []string{dir}},
+	}
+	return testDeps(cfg, runtime.NewFake(), newFakeRunner().run), name
+}
+
+func hasBeadInstructionsDroppedHint(result SlingResult) bool {
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "not carried into the formula's rendered context") {
+			return true
+		}
+	}
+	return false
+}
+
 // TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped is the regression
 // for #3681: --on/AttachFormula never carries the target bead's own
 // description into the formula's rendered context — the wisp root's
@@ -2426,9 +2456,60 @@ func TestSlingAttachFormula(t *testing.T) {
 // description as the actual build instructions silently gets a brainstorm
 // that never saw them. Warn instead of changing routing/materialization.
 func TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped(t *testing.T) {
+	deps, formulaName := slingCtxVarFormulaDeps(t)
+	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Description: "follow ~/rigs/ultimate-brain-mcp patterns"})
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.AttachFormula(context.Background(), formulaName, b.ID, a, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	if !hasBeadInstructionsDroppedHint(result) {
+		t.Errorf("BeadWarnings = %#v, want a hint that the bead's description is dropped", result.BeadWarnings)
+	}
+}
+
+// TestSlingAttachFormulaNoWarningWhenContextPathProvided guards the
+// #3681 hint's scope: a caller who already passes context_path (or
+// requirements_path) has explicitly carried the instructions in some
+// form, so the generic hint would be noise.
+func TestSlingAttachFormulaNoWarningWhenContextPathProvided(t *testing.T) {
+	deps, formulaName := slingCtxVarFormulaDeps(t)
+	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Description: "follow ~/rigs/ultimate-brain-mcp patterns"})
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.AttachFormula(context.Background(), formulaName, b.ID, a, FormulaOpts{Vars: []string{"context_path=/tmp/spec"}})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	if hasBeadInstructionsDroppedHint(result) {
+		t.Errorf("BeadWarnings = %#v, want no drop hint once context_path is explicit", result.BeadWarnings)
+	}
+}
+
+// TestSlingAttachFormulaNoWarningWhenFormulaCannotReceiveContextVars is the
+// regression for ga-awchvd. The hint tells the caller to pass --var
+// context_path / requirements_path, but a formula that consumes neither
+// cannot be fixed that way: nothing rejects an undeclared var, so the value
+// is accepted, stamped as gc.var.<name> metadata, and read by nothing. The
+// advice would silence this very warning while changing nothing the agent
+// sees, which reads as fixed and is not. Every formula the deacon dispatch
+// table routes is this shape — none of the eight declares either var — so
+// before this gate the advisory fired on every automated sling in the fleet
+// with no reachable remedy.
+func TestSlingAttachFormulaNoWarningWhenFormulaCannotReceiveContextVars(t *testing.T) {
 	runner := newFakeRunner()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	// The shared code-review fixture declares no vars at all.
 	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Description: "follow ~/rigs/ultimate-brain-mcp patterns"})
 
 	s, err := New(deps)
@@ -2440,40 +2521,29 @@ func TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AttachFormula: %v", err)
 	}
-	found := false
-	for _, w := range result.BeadWarnings {
-		if strings.Contains(w, "not carried into the formula's rendered context") {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("BeadWarnings = %#v, want a hint that the bead's description is dropped", result.BeadWarnings)
+	if hasBeadInstructionsDroppedHint(result) {
+		t.Errorf("BeadWarnings = %#v, want no drop hint: the formula declares neither context_path nor requirements_path, so the remedy the hint names cannot work", result.BeadWarnings)
 	}
 }
 
-// TestSlingAttachFormulaNoWarningWhenContextPathProvided guards the
-// #3681 hint's scope: a caller who already passes context_path (or
-// requirements_path) has explicitly carried the instructions in some
-// form, so the generic hint would be noise.
-func TestSlingAttachFormulaNoWarningWhenContextPathProvided(t *testing.T) {
-	runner := newFakeRunner()
-	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
-	deps := testDeps(cfg, runtime.NewFake(), runner.run)
-	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task", Description: "follow ~/rigs/ultimate-brain-mcp patterns"})
-
-	s, err := New(deps)
-	if err != nil {
-		t.Fatal(err)
+// TestFormulaCanReceiveBeadInstructionsDetectsTemplateReference covers the
+// second way a formula consumes one of these vars: Substitute renders any
+// supplied var, declared or not, so a formula referencing {{requirements_path}}
+// in a step can receive it without an entry under [vars].
+func TestFormulaCanReceiveBeadInstructionsDetectsTemplateReference(t *testing.T) {
+	if formulaCanReceiveBeadInstructions(nil) {
+		t.Error("nil formula must not be reported as able to receive the vars")
 	}
-	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
-	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{Vars: []string{"context_path=/tmp/spec"}})
-	if err != nil {
-		t.Fatalf("AttachFormula: %v", err)
+	bare := &formula.Formula{Formula: "bare", Steps: []*formula.Step{{ID: "work", Title: "Work"}}}
+	if formulaCanReceiveBeadInstructions(bare) {
+		t.Error("formula declaring and referencing neither var must not be reported as able to receive them")
 	}
-	for _, w := range result.BeadWarnings {
-		if strings.Contains(w, "not carried into the formula's rendered context") {
-			t.Errorf("BeadWarnings = %#v, want no drop hint once context_path is explicit", result.BeadWarnings)
-		}
+	referencing := &formula.Formula{
+		Formula: "referencing",
+		Steps:   []*formula.Step{{ID: "work", Title: "Work", Description: "Read {{requirements_path}} first."}},
+	}
+	if !formulaCanReceiveBeadInstructions(referencing) {
+		t.Error("formula referencing {{requirements_path}} in a step must be reported as able to receive it")
 	}
 }
 


### PR DESCRIPTION
## Summary

`gc sling <target> <bead> --on <formula>` warns that the bead's description is
not carried into the formula's rendered context, and tells the caller to pass
`--var context_path=<dir>` or `--var requirements_path=<doc>`. The hint fires on
one condition — the caller passed neither var — and never checks whether the
formula being attached can consume either.

Where the formula consumes neither, that remedy is inert. Nothing rejects an
undeclared `--var` anywhere on the path: `buildSlingFormulaVars` accepts any key
it is given, `CollectVarValidationErrors` (`internal/formula/parser.go`) walks
only the formula's *declared* vars and so never sees an extra one, and
`stampFormulaVars` records the value as `gc.var.<name>` metadata that no
template reads. The var is accepted, stored, and rendered nowhere.

So a caller who follows the advice gets a **silenced warning and a byte-identical
rendered context**. That is worse than staying quiet, because a clean log reads
as fixed.

This is visible in the existing suite: `TestSlingAttachFormulaNoWarningWhenContextPathProvided`
asserted the hint goes quiet once `context_path` is passed — against the shared
`code-review` fixture, which declares no vars at all.

#3681 was reported against `build-base`/`compound-build`, which *do* declare
these vars, so the advice was sound there. The hint was simply never conditioned
on that being true.

## Fix

Gate the hint on its remedy being reachable. `formulaCanReceiveBeadInstructions`
reports whether the attached formula consumes either var — declared under
`[vars]`, or referenced as `{{var}}` in the formula description or a step, since
`Substitute` renders undeclared vars too.

The formula is resolved with `graphv2.LoadFormula` (parser-only, and
`Parser.Resolve` merges `extends` parents, so inherited declarations count). It
is never compiled, so the compile-once rule earlier in this file is untouched. An
unresolvable formula means an unknowable shape and stays silent — an unactionable
hint is the defect being avoided.

Correct in both directions: still fires for a formula built to receive the
instructions, silent for one that cannot use them.

## Why this matters in practice

In the city this was found in, **no formula declares or references either var** —
zero occurrences across every pack, every formula layer, and every template. All
eight formulas in the automated dispatch table are in that set, so the advisory
fired on every formula-dispatched bead in the fleet with no reachable remedy.

Worth stating explicitly, because the advisory's wording invites the opposite
conclusion: this is a statement about the **rendered context only**. It does not
mean the agent cannot see the bead. Seven of those eight formulas resolve the
content bead from the wisp wrapper's `gc.var.issue` and run `bd show $ROOT_ID`;
the eighth reads its bead from `bd list ... --json`, which carries the
description. The bead's own text reaches the agent either way. Added that
caveat to the function's doc comment so the next reader does not mistake the
warning for lost work.

## Test plan

- `TestSlingAttachFormulaNoWarningWhenFormulaCannotReceiveContextVars` — new; the
  RED case. Confirmed failing before the fix (hint present), passing after.
- `TestFormulaCanReceiveBeadInstructionsDetectsTemplateReference` — new; covers
  nil, the consumes-neither shape, and detection via a `{{requirements_path}}`
  step reference.
- `TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped` and
  `TestSlingAttachFormulaNoWarningWhenContextPathProvided` — repointed at a
  fixture that declares `context_path`. Both previously ran against a fixture
  that declares no vars, so under the new gate they would have passed
  vacuously; they now assert what their names claim. This is the whole blast
  radius — one behavioral test changed, and it is the one that encoded the
  ungated behavior.
- `go vet ./...` clean; full `go test ./...` sweep green (40,332 pass / 0 fail).

## Known limitation, deliberately left

The consumes-the-var check walks declared `[vars]` plus top-level step title and
description text. It does not read `description_file` bodies (resolved at compile
time, not load time) or recurse into nested `children` / `loop.body` steps. Both
would be false negatives — a *missing* advisory, never a wrong one — and the
declared-`[vars]` path, which is the documented way a formula receives a var,
covers them regardless of nesting. Happy to extend the text scan if a reviewer
would rather have it; it seemed like speculative reach for shapes no formula in
this city uses.
