### PR TITLE
test(integration): replace hardcoded Dolt startup waits

### DIFF
--- a/release-gates/ga-1iowjo-dolt-integration-timeout-constants-gate.md
+++ b/release-gates/ga-1iowjo-dolt-integration-timeout-constants-gate.md
@@ -1,0 +1,97 @@
+# Release Gate: Dolt integration timeout constants
+
+Gate date: 2026-08-20
+
+Deploy bead: `ga-1iowjo`
+
+Review bead: `ga-thuouz`
+
+Original reviewed source: `09c63aa404929089238c7499a762001d8892f999`
+
+Gated source after bounded rebases: `fcf1009a8bdad843d6f6f0217178edfa80dc36fc`
+
+Base checked: `origin/main@4f4a37b28c9cfaa1ebe1c587576b69663a47f078`
+
+Merge base: `3218c505668fb043a89531a4ec1299d15a7e68d7`
+
+Clean merge tree: `84ac27b2a57ff6d7c2bc1d23a66708f6b519de06`
+
+Overall result: **PASS — 7/7 criteria**.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Review bead `ga-thuouz` is closed with a final PASS after merge-authority waiver `mayor-2026-08-20-ga-thuouz-c1`. Two bounded, force-with-lease rebases were recorded on the deploy bead: `09c63aa404929089238c7499a762001d8892f999` → `3410d0e4f4cc9c9ba3992c5d0855f6bb1f0e04cd` → `fcf1009a8bdad843d6f6f0217178edfa80dc36fc`. |
+| 2 | Acceptance criteria met | PASS | The two hardcoded 15-second waits now use named timeout constants, and the AST guard prevents literal regression. On the gated source, `TestDoltConfigWiringExternalHost`, `TestDoltConfigTimeoutsUseNamedConstants`, and `TestBdStoreMailWispInsert` passed with the pinned Dolt image available through the rootless Podman socket. |
+| 3 | Tests pass | PASS | The documented full command selected 40 jobs: 36 PASS, 4 FAIL, 0 SKIP. All four raw failures are independently attributed below; no candidate-owned test failed. Focused candidate-owned results were 3 PASS, 0 FAIL, 1 merge-authority-waived SKIP. `make test-ci-policy` and `go vet ./...` passed on the exact gated source. |
+| 4 | No high-severity review findings open | PASS | Review records no style, security, or blocking code finding; the only review block was the now-resolved diff-file SKIP waiver. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty before this checklist was authored; `git diff --check origin/main...HEAD` and `gofmt -l` on all changed Go files produced no findings. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 against `origin/main@4f4a37b28c9cfaa1ebe1c587576b69663a47f078` and produced tree `84ac27b2a57ff6d7c2bc1d23a66708f6b519de06`. Ancestry scope passed for the deploy, build, and review bead IDs; no `.claude/**` path is introduced. |
+| 7 | Single feature theme | PASS | The two candidate commits touch only three `test/integration` files and serve one behavior: replacing hardcoded Dolt startup waits with named hang budgets plus a static regression guard. |
+
+## Test evidence
+
+Environment:
+
+- `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`
+- `TESTCONTAINERS_RYUK_DISABLED=true`
+- cached pinned images include `dolthub/dolt-sql-server:2.1.7` and
+  `dolthub/dolt:2.1.7`
+
+Full command:
+
+```text
+LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+40 jobs selected: 36 PASS, 4 FAIL, 0 SKIP
+raw exit: 2 (attributed failures below)
+logs: /var/tmp/gc-local-tests.wfGUMn
+```
+
+Focused candidate-owned command:
+
+```text
+go test -count=1 -tags integration -timeout 30m ./test/integration/ \
+  -run '^(TestDoltConfigWiringExternalHost|TestDoltConfigTimeoutsUseNamedConstants|TestBdStoreConformance|TestBdStoreMailWispInsert)$' -v
+```
+
+`diff_tests_executed`:
+
+- `TestDoltConfigWiringExternalHost` — PASS (3.65s)
+- `TestDoltConfigTimeoutsUseNamedConstants` — PASS (0.00s)
+- `TestBdStoreMailWispInsert` — PASS (4.48s)
+- `TestBdStoreConformance` — SKIP (0.00s), covered by
+  `waiver_ref: mayor-2026-08-20-ga-thuouz-c1`
+
+`skip_justification`: `TestBdStoreConformance` begins with an unconditional
+pre-existing `t.Skip`; the candidate's same-file change is confined to seven
+constant-block lines. Mayor independently verified that mechanism and granted
+the candidate-scoped waiver above.
+
+`policy_lane`: `make test-ci-policy` — PASS.
+
+`go_vet`: `go vet ./...` — PASS.
+
+## Failure attribution
+
+- `TestProviderLiveClaudeKindPath` (`agent_pane_busy` on `w1:p1`) → tracker
+  `ga-fh1flg`; candidate has no `internal/runtime/herdr`, session, tmux, or
+  pane-allocation path. Applied standing merge-authority disposition
+  `waiver_ref: mayor-2026-08-20-herdr-pane-standing` / memory key
+  `herdr-pane-busy-standing-disposition` at gated source
+  `fcf1009a8bdad843d6f6f0217178edfa80dc36fc`; use is recorded on the deploy
+  bead.
+- `TestBdFlagManifestCurrent` → tracker `ga-f0uceo`; not diff-owned, no path
+  overlap, and the integration-tagged focused test failed identically on exact
+  current base `4f4a37b28c9cfaa1ebe1c587576b69663a47f078` because the installed `bd`
+  exposes flags absent from the repository manifest.
+- `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` → tracker `ga-afqddr`;
+  neither is diff-owned, there is no `internal/runtime/tmux` overlap, and both
+  failed identically on exact current base
+  `4f4a37b28c9cfaa1ebe1c587576b69663a47f078` with empty host tmux default
+  bindings.
+
+All other full-suite jobs passed. The attributed failures have tracked IDs,
+base/mechanism proof, and no candidate path overlap; criterion 3 therefore
+passes under the repository's non-diff-owned failure policy.

--- a/test/integration/bdstore_test.go
+++ b/test/integration/bdstore_test.go
@@ -23,6 +23,13 @@ import (
 const (
 	bdInitTimeout          = 60 * time.Second
 	doltServerStartupLimit = 10 * time.Second
+	// doltServerReadyTimeout budgets startDoltServerOnAllInterfaces's
+	// TCP-dial readiness wait (dolt_config_test.go). Kept separate from
+	// doltServerStartupLimit — same shape of wait, but a distinct call
+	// site — so a future tuning of one doesn't silently retune the other;
+	// that kind of implicit coupling is what let runBDInitCompat's timeout
+	// drift out of sync with bdInitTimeout in the first place (ga-gajll3).
+	doltServerReadyTimeout = 60 * time.Second
 )
 
 // TestBdStoreConformance runs the beads conformance suite against BdStore

--- a/test/integration/dolt_config_test.go
+++ b/test/integration/dolt_config_test.go
@@ -140,7 +140,7 @@ func TestDoltConfigWiringExternalHost(t *testing.T) {
 // with bd v0.60.0 (which lacks --skip-agents).
 func runBDInitCompat(t *testing.T, env []string, dir, prefix, port string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), bdInitTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bdBinary, "init", "--server",
 		"--server-host", "127.0.0.1", "--server-port", port,
@@ -149,7 +149,7 @@ func runBDInitCompat(t *testing.T, env []string, dir, prefix, port string) {
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
-		t.Fatalf("bd init timed out: %s", out)
+		t.Fatalf("bd init timed out after %s: %s", bdInitTimeout, out)
 	}
 	if err != nil {
 		t.Fatalf("bd init: exit status %v: %s", err, out)
@@ -196,7 +196,7 @@ func startDoltServerOnAllInterfaces(t *testing.T, env []string, dataDir string) 
 	go func() { waitCh <- cmd.Wait() }()
 
 	// Wait for server to be ready.
-	deadline := time.Now().Add(15 * time.Second)
+	deadline := time.Now().Add(doltServerReadyTimeout)
 	addr := net.JoinHostPort("127.0.0.1", port)
 	for {
 		conn, dialErr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
@@ -214,7 +214,7 @@ func startDoltServerOnAllInterfaces(t *testing.T, env []string, dataDir string) 
 			<-waitCh
 			_ = logFile.Close()
 			logBytes, _ := os.ReadFile(logPath)
-			t.Fatalf("dolt sql-server did not become ready on %s within 15s:\n%s", addr, logBytes)
+			t.Fatalf("dolt sql-server did not become ready on %s within %s:\n%s", addr, doltServerReadyTimeout, logBytes)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/test/integration/dolt_config_timeout_test.go
+++ b/test/integration/dolt_config_timeout_test.go
@@ -1,0 +1,70 @@
+package integration
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestDoltConfigTimeoutsUseNamedConstants statically guards the class of bug
+// fixed in ga-gajll3: runBDInitCompat and startDoltServerOnAllInterfaces each
+// carried their own hardcoded timeout literal that silently drifted out of
+// sync with bdInitTimeout, the constant their siblings in bdstore_test.go use
+// for the same class of wait. It parses dolt_config_test.go and asserts each
+// call site passes a named constant, not a bare literal, so a future edit
+// can't reintroduce the drift without this test going red.
+func TestDoltConfigTimeoutsUseNamedConstants(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "dolt_config_test.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing dolt_config_test.go: %v", err)
+	}
+
+	var initTimeoutArgs, readyDeadlineArgs []ast.Expr
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch {
+		case sel.Sel.Name == "WithTimeout" && len(call.Args) == 2:
+			// context.WithTimeout(context.Background(), <budget>)
+			initTimeoutArgs = append(initTimeoutArgs, call.Args[1])
+		case sel.Sel.Name == "Add" && len(call.Args) == 1:
+			// time.Now().Add(<budget>) — receiver must itself be time.Now().
+			if recv, ok := sel.X.(*ast.CallExpr); ok {
+				if recvSel, ok := recv.Fun.(*ast.SelectorExpr); ok && recvSel.Sel.Name == "Now" {
+					readyDeadlineArgs = append(readyDeadlineArgs, call.Args[0])
+				}
+			}
+		}
+		return true
+	})
+
+	if len(initTimeoutArgs) != 1 {
+		t.Fatalf("expected exactly 1 context.WithTimeout call in dolt_config_test.go, found %d — update this test's scoping", len(initTimeoutArgs))
+	}
+	if len(readyDeadlineArgs) != 1 {
+		t.Fatalf("expected exactly 1 time.Now().Add call in dolt_config_test.go, found %d — update this test's scoping", len(readyDeadlineArgs))
+	}
+
+	requireNamedConstant(t, "runBDInitCompat's context.WithTimeout budget", initTimeoutArgs[0], "bdInitTimeout")
+	requireNamedConstant(t, "startDoltServerOnAllInterfaces's readiness deadline", readyDeadlineArgs[0], "doltServerReadyTimeout")
+}
+
+func requireNamedConstant(t *testing.T, what string, expr ast.Expr, want string) {
+	t.Helper()
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		t.Fatalf("%s must reference the named constant %s, not a bare literal expression (got %T) — hardcoded timeout literals drift out of sync silently; see ga-gajll3", what, want, expr)
+	}
+	if ident.Name != want {
+		t.Fatalf("%s = %s, want %s", what, ident.Name, want)
+	}
+}


### PR DESCRIPTION
## What this changes

Dolt integration tests now use named startup budgets instead of duplicated 15-second literals. The external-host wiring test has enough time for cold initialization under host load, and timeout failures report the actual configured budget.

A small AST-based regression test requires both startup call sites to keep using the named constants, preventing the literals and their diagnostics from drifting apart again.

## Review notes

- This is test-only; no production runtime behavior or public API changes.
- `bdInitTimeout` and `doltServerReadyTimeout` are hang-detector ceilings, so passing tests do not become slower.
- The main review surface is the constant choice and the static guard's identification of the two call sites.

## Test plan

- [x] Container-backed focused Dolt integration tests under the pinned image
- [x] Full sharded local CI-equivalent sweep; host-owned failures are attributed in the gate record
- [x] `make test-ci-policy`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-1iowjo-dolt-integration-timeout-constants-gate.md`](release-gates/ga-1iowjo-dolt-integration-timeout-constants-gate.md)