### PR TITLE
fix(herdr): honor XDG config home for session sockets

### DIFF
--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -603,13 +603,26 @@ func (c *client) ensurePlacement(ctx context.Context, wsLabel, tabLabel, cwd str
 
 // ── shared session-server lifecycle ──────────────────────────────────────────
 
-// socketPath is the unix socket for this client's herdr session.
+// socketPath is the unix socket for this client's herdr session. Must match
+// wherever the herdr binary itself resolves its config/state directory —
+// confirmed empirically (`XDG_CONFIG_HOME=X herdr --help` prints
+// "Config: X/herdr/config.toml" regardless of $HOME; with XDG_CONFIG_HOME
+// unset it falls back to "$HOME/.config/herdr/…") to be standard XDG Base
+// Directory precedence, i.e. exactly os.UserConfigDir() on this platform. A
+// plain os.UserHomeDir()+".config" join (the prior implementation) silently
+// ignores XDG_CONFIG_HOME, so it diverges from herdr's own resolution in any
+// environment that sets XDG_CONFIG_HOME while pointing $HOME elsewhere —
+// this fleet's agent sandboxes do exactly that. The result: this client
+// dials a socket no herdr process ever binds, so serverAlive() reads false
+// against a perfectly healthy server ("did not become ready"), and every
+// retry launches a redundant herdr server contending for the same pane
+// ("agent_pane_busy") — ga-nqlb8q.
 func (c *client) socketPath() string {
-	home, _ := os.UserHomeDir()
+	configDir, _ := os.UserConfigDir()
 	if c.session == "" || c.session == "default" {
-		return filepath.Join(home, ".config", "herdr", "herdr.sock")
+		return filepath.Join(configDir, "herdr", "herdr.sock")
 	}
-	return filepath.Join(home, ".config", "herdr", "sessions", c.session, "herdr.sock")
+	return filepath.Join(configDir, "herdr", "sessions", c.session, "herdr.sock")
 }
 
 // serverAlive reports whether the session-server is actually accepting

--- a/internal/runtime/herdr/client_test.go
+++ b/internal/runtime/herdr/client_test.go
@@ -1,0 +1,47 @@
+package herdr
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// socketPath must resolve the SAME directory herdr itself uses for its
+// config/socket state, or this client dials a path no herdr server ever
+// binds: serverAlive() then always reads false against a healthy server
+// ("did not become ready"), and every retry launches a redundant herdr
+// server contending for the same pane ("agent_pane_busy") — ga-nqlb8q.
+// Verified empirically against the herdr binary itself: `XDG_CONFIG_HOME=X
+// herdr --help` prints "Config: X/herdr/config.toml" regardless of $HOME,
+// and with XDG_CONFIG_HOME unset it falls back to "$HOME/.config/herdr/…" —
+// standard XDG Base Directory precedence, which os.UserConfigDir()
+// implements and the old os.UserHomeDir()+".config" join did not: a sandbox
+// that sets XDG_CONFIG_HOME to the real user's config dir while redirecting
+// $HOME elsewhere (this fleet's agent sandboxes do exactly that) made the
+// old code compute a path no herdr process ever binds.
+
+func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir()) // deliberately different; must be ignored
+
+	c := newClient("xdgtest", "")
+	if got, want := c.socketPath(), filepath.Join(xdg, "herdr", "sessions", "xdgtest", "herdr.sock"); got != want {
+		t.Errorf("socketPath() = %q; want %q", got, want)
+	}
+
+	c.session = "default"
+	if got, want := c.socketPath(), filepath.Join(xdg, "herdr", "herdr.sock"); got != want {
+		t.Errorf("socketPath() (default session) = %q; want %q", got, want)
+	}
+}
+
+func TestSocketPathFallsBackToHomeConfigWhenXDGUnset(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	c := newClient("hometest", "")
+	if got, want := c.socketPath(), filepath.Join(home, ".config", "herdr", "sessions", "hometest", "herdr.sock"); got != want {
+		t.Errorf("socketPath() = %q; want %q", got, want)
+	}
+}

--- a/internal/runtime/herdr/panebinding_provider_test.go
+++ b/internal/runtime/herdr/panebinding_provider_test.go
@@ -30,8 +30,8 @@ import (
 var paneBindSession int64
 
 // newFakeHerdrProvider builds a Provider whose client shells out to a fake
-// herdr script. Returns the provider, its session name, and the state dir.
-func newFakeHerdrProvider(t *testing.T) (*Provider, string, string) {
+// herdr script. Returns the provider and the state dir.
+func newFakeHerdrProvider(t *testing.T) (*Provider, string) {
 	t.Helper()
 	session := fmt.Sprintf("gctest-pb-%d-%d", os.Getpid(), atomic.AddInt64(&paneBindSession, 1))
 	state := t.TempDir()
@@ -144,7 +144,7 @@ esac
 	// would be per-test wall-clock the resource census cannot see (it counts
 	// only time.Sleep written directly in a _test.go).
 	p.c.settleDelay = time.Millisecond
-	return p, session, state
+	return p, state
 }
 
 // fakeCalls returns the verbs the fake herdr recorded.
@@ -166,23 +166,22 @@ func setState(t *testing.T, state, flag string) {
 
 // listenHerdrSocket plants a live unix listener at the session's socket path so
 // ConfigureServer's serverAlive dial succeeds without launching a real server.
-func listenHerdrSocket(t *testing.T, session string) {
+// Must resolve the path through p.c.socketPath() itself, not a hand-rolled
+// reconstruction — a second copy of that logic silently drifts from the real
+// one (ga-nqlb8q: it did, once socketPath() started honoring XDG_CONFIG_HOME).
+func listenHerdrSocket(t *testing.T, p *Provider) {
 	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
+	sock := p.c.socketPath()
+	if err := os.MkdirAll(filepath.Dir(sock), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	dir := filepath.Join(home, ".config", "herdr", "sessions", session)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	l, err := net.Listen("unix", filepath.Join(dir, "herdr.sock"))
+	l, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
 		_ = l.Close()
-		_ = os.RemoveAll(dir)
+		_ = os.RemoveAll(filepath.Dir(sock))
 	})
 }
 
@@ -201,7 +200,7 @@ func bindTestPane(t *testing.T, p *Provider, name, mode string) {
 // The storm-killer: with no registry name but the bound pane busy running the
 // agent, IsRunning must stay true so the reconciler never re-issues Start.
 func TestIsRunningSurvivesNameClearViaPaneBinding(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "busy")
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 	if !p.IsRunning("gastown__witness") {
@@ -211,7 +210,7 @@ func TestIsRunningSurvivesNameClearViaPaneBinding(t *testing.T) {
 
 // Without a binding, an unregistered name is a genuinely absent session.
 func TestIsRunningFalseWhenNameClearedAndNoBinding(t *testing.T) {
-	p, _, _ := newFakeHerdrProvider(t)
+	p, _ := newFakeHerdrProvider(t)
 	if p.IsRunning("gastown__witness") {
 		t.Fatal("IsRunning = true with no live name and no pane binding")
 	}
@@ -221,7 +220,7 @@ func TestIsRunningFalseWhenNameClearedAndNoBinding(t *testing.T) {
 // the reconciler can restart it; a bare-shell session in the same pane state
 // IS running (the shell is the session).
 func TestIsRunningModeAwareAtShellPrompt(t *testing.T) {
-	p, _, _ := newFakeHerdrProvider(t)
+	p, _ := newFakeHerdrProvider(t)
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 	if p.IsRunning("gastown__witness") {
 		t.Fatal("IsRunning = true for an exited agent (pane at shell prompt); restarts would never happen")
@@ -236,8 +235,8 @@ func TestIsRunningModeAwareAtShellPrompt(t *testing.T) {
 // WITHOUT touching placement: each wrongful placement leaked a pane, which is
 // the unbounded shell storm.
 func TestStartReturnsSessionExistsWithoutPlacementWhenNameCleared(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "busy")
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 
@@ -255,8 +254,8 @@ func TestStartReturnsSessionExistsWithoutPlacementWhenNameCleared(t *testing.T) 
 // the shell pane (with cwd baked in), `agent start --kind claude --pane`
 // launches into it, and the binding + agent mode are persisted.
 func TestStartKindPathRegistersAndPersistsBinding(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{
 		Command: "claude --dangerously-skip-permissions",
@@ -291,8 +290,8 @@ func TestStartKindPathRegistersAndPersistsBinding(t *testing.T) {
 // A non-kind command is exec'd through the pane shell (raw path): no herdr
 // agent registration, shell mode persisted, pane still the session handle.
 func TestStartRawPathExecsThroughPaneShell(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{Command: "python3 worker.py --queue main"}
 	if err := p.Start(context.Background(), "gastown__worker", cfg); err != nil {
@@ -315,8 +314,8 @@ func TestStartRawPathExecsThroughPaneShell(t *testing.T) {
 // invalid_agent_name — a hot retry loop found live), while the sidecar keeps
 // the exact gc name for enumeration.
 func TestStartMapsSessionNameToValidHerdrName(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	if err := p.Start(context.Background(), "Indigo--anthony", runtime.Config{Command: "claude"}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -344,8 +343,8 @@ func TestStartMapsSessionNameToValidHerdrName(t *testing.T) {
 // just the first: reconciler churn can leave several behind, and a survivor
 // lingers forever (its shell pane with it).
 func TestStartRecyclesAllStaleTabs(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "stale_tabs")
 	// An existing workspace forces the findTab path (workspace list must hit).
 	oldWorkspaceList := "workspace_list)\n  : > \"$STATE/placement_attempted\"\n  printf '%s' '{\"result\":{\"workspaces\":[]}}' ;;"
@@ -387,7 +386,7 @@ func rewriteFake(t *testing.T, p *Provider, old, replacement string) {
 // closePane never issued ⇒ panes piled up), even for an exited agent whose
 // pane idles at a prompt — and clear the sidecar.
 func TestStopClosesPaneViaBindingWhenNameCleared(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 
 	if err := p.Stop("gastown__witness"); err != nil {
@@ -405,7 +404,7 @@ func TestStopClosesPaneViaBindingWhenNameCleared(t *testing.T) {
 // must fall back to the bound pane too, or the reconciler still sees
 // Running=false each tick and drives Start.
 func TestObserveLivenessFallsBackToBoundPane(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "busy")
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 
@@ -427,7 +426,7 @@ func TestObserveLivenessFallsBackToBoundPane(t *testing.T) {
 // An exited agent (pane at bare prompt, agent mode) reads as not running so
 // the reconciler restarts it.
 func TestObserveLivenessExitedAgentReadsDead(t *testing.T) {
-	p, _, _ := newFakeHerdrProvider(t)
+	p, _ := newFakeHerdrProvider(t)
 	bindTestPane(t, p, "gastown__witness", bindModeAgent)
 	if got := p.ObserveLiveness("gastown__witness", nil); got.Running || got.Alive {
 		t.Fatalf("ObserveLiveness = %+v for an exited agent; want zero", got)
@@ -438,7 +437,7 @@ func TestObserveLivenessExitedAgentReadsDead(t *testing.T) {
 // sessions never register an agent, so listing by registry alone hides them
 // from every session-enumeration consumer (orphan detection, gc ls).
 func TestListRunningIncludesUnregisteredBoundSessions(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "busy")
 	for _, name := range []string{"gastown__worker-1", "gastown__worker-2", "other__worker"} {
 		bindTestPane(t, p, name, bindModeShell)
@@ -463,7 +462,7 @@ func TestListRunningIncludesUnregisteredBoundSessions(t *testing.T) {
 
 // A bound session whose pane is gone must not be listed (and is pruned).
 func TestListRunningSkipsGonePanes(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 	setState(t, state, "pane_gone")
 	bindTestPane(t, p, "gastown__worker-1", bindModeShell)
 	if err := p.SetMeta("gastown__worker-1", metaBoundName, "gastown__worker-1"); err != nil {

--- a/internal/runtime/herdr/staleserver_test.go
+++ b/internal/runtime/herdr/staleserver_test.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 )
 
-// shortHome returns a short temp dir set as $HOME. The default t.TempDir()
-// (/var/folders/… on macOS) blows past the 104-byte unix-socket sun_path limit
-// once socketPath() appends .config/herdr/sessions/<name>/herdr.sock, so we root
-// under /tmp instead.
+// shortHome points socketPath()'s config-dir resolution at a short, isolated
+// temp dir via $XDG_CONFIG_HOME — the env var os.UserConfigDir() consults
+// before $HOME (see socketPath's doc comment) — so these tests never touch
+// the real user's ~/.config/herdr/sessions/. The default t.TempDir()
+// (/var/folders/… on macOS) blows past the 104-byte unix-socket sun_path
+// limit once socketPath() appends herdr/sessions/<name>/herdr.sock, so we
+// root under /tmp instead.
 func shortHome(t *testing.T) {
 	t.Helper()
-	home, err := os.MkdirTemp("/tmp", "hdr")
+	configHome, err := os.MkdirTemp("/tmp", "hdr")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
-	t.Setenv("HOME", home)
+	t.Cleanup(func() { _ = os.RemoveAll(configHome) })
+	t.Setenv("XDG_CONFIG_HOME", configHome)
 }
 
 // A stale socket inode — left by a herdr server that exited uncleanly — must not

--- a/internal/runtime/herdr/startup_delivery_confirm_test.go
+++ b/internal/runtime/herdr/startup_delivery_confirm_test.go
@@ -23,8 +23,8 @@ import (
 // `agent prompt --wait`, so herdr verifies the submission actually started a
 // turn instead of reporting ok the instant the text is typed.
 func TestStartupDeliveryPromptsWithConfirmation(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
 	if err := p.Start(context.Background(), "gastown__witness", cfg); err != nil {
@@ -49,8 +49,8 @@ func TestStartupDeliveryPromptsWithConfirmation(t *testing.T) {
 // bare Enter cannot do anything else — followed by a confirming wait. No
 // re-prompt: retyping would double the text in the box.
 func TestStartupDeliveryStallRecoversWithEnter(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_stalled")
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
@@ -80,8 +80,8 @@ func TestStartupDeliveryStallRecoversWithEnter(t *testing.T) {
 // strand must be recorded durably on the sidecar so it is machine-visible
 // and countable — stderr alone is discarded in daemon contexts.
 func TestStartupDeliveryUnconfirmedRecordsSidecarMarker(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_stalled")
 	setState(t, state, "wait_times_out")
 
@@ -110,8 +110,8 @@ func TestStartupDeliveryUnconfirmedRecordsSidecarMarker(t *testing.T) {
 // the Enter is withheld, because there it would answer the dialog rather than
 // no-op on an empty input box.
 func TestStartupDeliveryStallOnBlockedAgentWithholdsEnter(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_stalled")
 	setState(t, state, "agent_blocked")
 
@@ -143,8 +143,8 @@ func TestStartupDeliveryStallOnBlockedAgentWithholdsEnter(t *testing.T) {
 // recorded, because "submitted but unsettled" is not proof the turn is
 // running.
 func TestStartupDeliveryTimeoutNeverBlindEnters(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_times_out")
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
@@ -175,8 +175,8 @@ func TestStartupDeliveryTimeoutNeverBlindEnters(t *testing.T) {
 // the requested states, so dropping "blocked" from startupConfirmStates fails
 // this test.
 func TestStartupDeliveryBlockedConfirmsWithoutRecovery(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "prompt_blocked")
 
 	cfg := runtime.Config{Command: "claude", Nudge: "Run gc hook --claim --json now."}
@@ -196,8 +196,8 @@ func TestStartupDeliveryBlockedConfirmsWithoutRecovery(t *testing.T) {
 // to confirm against: the legacy paste+settle+Enter path stays, best-effort
 // by construction, and must not record an unconfirmed marker.
 func TestStartupDeliveryUnregisteredPaneFallsBackToPaste(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 
 	cfg := runtime.Config{Command: "python3 worker.py", Nudge: "Read your brief."}
 	if err := p.Start(context.Background(), "gastown__worker", cfg); err != nil {
@@ -219,8 +219,8 @@ func TestStartupDeliveryUnregisteredPaneFallsBackToPaste(t *testing.T) {
 // sidecar) must not outlive a life whose delivery confirms — a stale marker
 // would false-positive the named-session delivery backstop built on it.
 func TestStartupDeliveryConfirmedClearsStaleMarker(t *testing.T) {
-	p, session, _ := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, _ := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
 		t.Fatal(err)
 	}
@@ -241,8 +241,8 @@ func TestStartupDeliveryConfirmedClearsStaleMarker(t *testing.T) {
 // exactly the false positive the delivery backstop reading this key would
 // act on.
 func TestStartupDeliveryClearsStaleMarkerOnAdopt(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	setState(t, state, "name_taken")
 	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
 		t.Fatal(err)
@@ -265,8 +265,8 @@ func TestStartupDeliveryClearsStaleMarkerOnAdopt(t *testing.T) {
 // delivered, so nothing in this life can justify a marker, and a prior life's
 // must not be inherited.
 func TestStartupDeliveryClearsStaleMarkerWithNoStartupText(t *testing.T) {
-	p, session, state := newFakeHerdrProvider(t)
-	listenHerdrSocket(t, session)
+	p, state := newFakeHerdrProvider(t)
+	listenHerdrSocket(t, p)
 	if err := p.SetMeta("gastown__witness", metaStartupUnconfirmed, "stale prior-life record"); err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestStartupDeliveryClearsStaleMarkerWithNoStartupText(t *testing.T) {
 // The interface-facing WaitForIdle keeps its proceed-either-way contract; the
 // outcome lets Start record WHY a strand happened.
 func TestWaitForIdleOutcomeMapping(t *testing.T) {
-	p, _, state := newFakeHerdrProvider(t)
+	p, state := newFakeHerdrProvider(t)
 
 	if got := p.waitForIdleOutcome(context.Background(), "gastown__witness", time.Second); got != idleWaitNoAgent {
 		t.Fatalf("unregistered agent outcome = %q; want %q", got, idleWaitNoAgent)

--- a/release-gates/ga-nsaq0t-herdr-config-home-gate.md
+++ b/release-gates/ga-nsaq0t-herdr-config-home-gate.md
@@ -1,0 +1,106 @@
+# Release Gate: herdr config-home socket resolution
+
+Deploy bead: `ga-nsaq0t`  
+Review bead: `ga-nqlb8q`  
+Reviewed source: `4ca2c3158e1c2065b898ba29eaaa1a02eaca5931`  
+Base: `origin/main@7e92a87f18f323575fa6cce98070a4a42b02bdfb`  
+Gate date: 2026-08-20
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree. This record uses
+the seven release criteria in the deployer contract and the repository's
+documented test commands in `TESTING.md`.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-nqlb8q` is closed with reason `pass`; its notes record `verdict: pass` for the exact reviewed source. |
+| 2 | Acceptance criteria met | PASS | `socketPath` now uses `os.UserConfigDir`, so the client follows herdr's `XDG_CONFIG_HOME` precedence. The two new config-home tests pass, the test socket listeners share the production resolver, and both real-binary regressions (`TestProviderLive` and `TestProviderLiveClaudeKindPath`) pass. |
+| 3 | Tests pass | PASS | The focused herdr suite reports 80 top-level PASS, 0 FAIL, 0 SKIP; all 28 test functions in added/modified test files pass by name. The required 40-job union reports 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP. All six failures are tracked, not diff-owned, and structurally unreachable from this herdr-only diff; the beads#4566 occurrence is preserved below as FAIL — WAIVED under the mayor's standing authorization. `make test-ci-policy` and `go vet ./...` pass. |
+| 4 | No high-severity review findings open | PASS | Reviewer reports no style or security blockers and no uncovered acceptance criteria; unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty at the reviewed source before adding this gate record; `git diff --check origin/main...4ca2c315...` also passed. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main 4ca2c315...` succeeded against `origin/main@7e92a87f...`, producing `b1bf09a26a79a91b41333f2d1f6e10a2e9cf15a2`. `assert_deploy_ancestry_scope` passed for `ga-nsaq0t` and review bead `ga-nqlb8q`. |
+| 7 | Single feature theme | PASS | The two reviewed commits touch only `internal/runtime/herdr`: XDG-aware socket discovery plus the directly coupled test-helper and regression updates. |
+
+## Acceptance Evidence
+
+- `TestSocketPathHonorsXDGConfigHomeOverHome`: PASS.
+- `TestSocketPathFallsBackToHomeConfigWhenXDGUnset`: PASS.
+- `TestProviderLive`: PASS in 1.35s with the real `herdr` binary.
+- `TestProviderLiveClaudeKindPath`: PASS in 4.17s with real `herdr` and
+  `claude` binaries.
+- All 28 test functions in the four diff-owned test files report PASS by name:
+  2 config-home tests, 13 pane-binding tests, 2 stale-server tests, and 11
+  startup-delivery tests.
+- Diff contains no dependency, API, configuration-schema, or migration change.
+
+## Test Evidence
+
+```text
+test_cmd: go test -v -count=1 -timeout 300s ./internal/runtime/herdr/...
+test_counts: 80 top-level PASS, 0 FAIL, 0 SKIP
+diff_tests_executed: 28 PASS, 0 FAIL, 0 SKIP (every test function in the four touched *_test.go files resolved by name)
+waiver_ref: none for diff-owned tests
+focused_log: /var/tmp/ga-nsaq0t-herdr-focused.log
+
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+test_counts: 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP (40 total)
+full_logs: /var/tmp/gc-local-tests.WpoCur
+
+policy_lane: make test-ci-policy — PASS
+static_lane: go vet ./... — PASS
+```
+
+### Raw failures and attribution
+
+The failures below remain failures in the raw output. They are not rewritten
+as green. None is in a test file added or modified by this diff.
+
+- FAIL — WAIVED: `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix`
+  failed during fixture initialization with the exact
+  `gastownhall/beads#4566` dirty-issues schema-migration signature. Tracked by
+  `ga-qyh9cb` and root tracker `ga-lpfjhc`. The candidate changes only herdr
+  socket discovery and cannot reach Dolt schema migration or store bootstrap.
+  This occurrence was logged on `ga-lpfjhc`, satisfying the standing
+  authorization recorded by mayor on `ga-6bnc42`; the raw result is preserved
+  here as FAIL — WAIVED.
+- FAIL — attributed: `TestBdFlagManifestCurrent` -> `ga-f0uceo`. The candidate
+  cannot alter the bdflags manifest.
+- FAIL — attributed: `TestSweep_ReapsRealDoltDataDirAfterSIGKILL` ->
+  `ga-vbyn8v` (fix awaiting deployment). The candidate cannot reach
+  `examples/gastown` or `internal/doltorphan`.
+- FAIL — attributed: `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr`. They run
+  in the separate tmux provider and reproduce the tracked empty-default-table
+  host signature.
+- FAIL — attributed: `TestCleanInstallTutorialPath` -> `ga-hrdd3h`. The
+  failure is the tracked beads circuit-breaker stdout-contamination signature;
+  the candidate cannot affect that logging or tutorial capture.
+
+```text
+failure_attribution: TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix -> ga-qyh9cb + ga-lpfjhc + standing authorization ga-6bnc42; exact beads#4566 signature; no schema/bootstrap mechanism
+failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo + structural no-mechanism proof
+failure_attribution: TestSweep_ReapsRealDoltDataDirAfterSIGKILL -> ga-vbyn8v + structural no-mechanism proof
+failure_attribution: TestGetKeyBinding_CapturesDefaultBinding{,WithArgs} -> ga-afqddr + separate-provider path proof
+failure_attribution: TestCleanInstallTutorialPath -> ga-hrdd3h + structural no-mechanism proof
+```
+
+## Pre-flight
+
+Team-authored PR [#5435](https://github.com/gastownhall/gascity/pull/5435)
+is OPEN at the exact reviewed source, mergeable, and has no comments or reviews.
+It has not merged, and no external contributor has engaged it. The deploy source
+remains the recorded SHA; the provenance branch is not a deploy push target.
+
+## Commands
+
+```text
+git fetch origin main
+git merge-tree --write-tree origin/main 4ca2c3158e1c2065b898ba29eaaa1a02eaca5931
+assert_deploy_ancestry_scope origin/main 4ca2c3158e1c2065b898ba29eaaa1a02eaca5931 ga-nsaq0t ga-nqlb8q
+git diff --check origin/main...4ca2c3158e1c2065b898ba29eaaa1a02eaca5931
+go test -v -count=1 -timeout 300s ./internal/runtime/herdr/...
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+make test-ci-policy
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

The herdr runtime now resolves session sockets from the same user config directory as the herdr binary. When `XDG_CONFIG_HOME` and `HOME` point at different roots, Gas City can find the server it just started instead of timing out with “server did not become ready” and launching a redundant server that contends for the pane.

The fake-herdr test listeners use the production socket resolver as well, keeping the test harness from drifting from runtime behavior.

## Review notes

- Socket discovery uses Go's `os.UserConfigDir`, preserving the normal `$HOME/.config` fallback while honoring `XDG_CONFIG_HOME`.
- There are no API, config-schema, dependency, or migration changes.
- The remaining test-file edits remove an obsolete helper return value and update its callers; they do not change session behavior.

## Test plan

- [x] Run the full `internal/runtime/herdr` package with real herdr and Claude binaries; confirm both live-provider regressions and every touched test pass without skips.
- [x] Run the documented 40-job local CI union with the rootless Podman test environment configured; audit all raw failures against their existing trackers and diff ownership.
- [x] Run the repository policy lane and `go vet ./...`.
- [x] Release gate: [`release-gates/ga-nsaq0t-herdr-config-home-gate.md`](release-gates/ga-nsaq0t-herdr-config-home-gate.md)
