### PR TITLE
fix(dolt): defer compact quarantine for a proven concurrent-writer same-count in-place UPDATE (ga-ewo6j)

### DIFF
--- a/examples/bd/dolt/assets/scripts/compact-same-count-drift-proof.sh
+++ b/examples/bd/dolt/assets/scripts/compact-same-count-drift-proof.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# compact-same-count-drift-proof.sh — in-place-modification proof for the
+# post-flatten same-count table value-hash drift case (ga-ewo6j).
+#
+# verify_counts flags same_count_hash_drift when a table's value hash changes
+# but its row count does NOT — an in-place row modification. On a high-write DB
+# the beads/mail workload commits such UPDATEs (mail read/archive, bead
+# close/status change) every few seconds, so one lands inside the flatten verify
+# window on ~every run. Hard-quarantining it blocks ALL future GC of the DB and
+# is the production memory-exhaustion failure the compactor header warns about.
+#
+# Unlike the gain+drift case, a same-count in-place modification cannot be proven
+# safe by "additive only": the pre-flight row's value legitimately changed, so
+# there is no unchanged-row anchor and no absorbed-writer DOLT_DIFF proof
+# analogous to Option A (compact-gain-drift-proof.sh). This proof is therefore
+# only ever a SECOND gate, applied by the caller AFTER a concurrent writer is
+# HEAD-proven (writer_race_detected=1): it confirms the drift has the SHAPE of a
+# benign in-place UPDATE — every same-count-drifted table's pre-flight..flatten
+# content diff modifies rows and removes NONE of them. Any removed pre-flight
+# row, a diff that fails to explain the drift, or a probe failure fails closed
+# and falls through to quarantine.
+#
+# Depends on `query_single_cell` and `valid_table_name` from run.sh.
+
+# same_count_drift_is_writer_explained <db> <from_head> <to_head> <tables>
+# Returns 0 iff every listed table's <from>..<to> content diff removes zero rows
+# AND modifies at least one row (the drift is an explained in-place UPDATE).
+# Returns non-zero (fail closed) if either commit endpoint is missing, the table
+# list is empty, a table name is invalid, a diff probe fails or returns a
+# non-numeric result, any pre-flight row was removed, or no row was modified.
+same_count_drift_is_writer_explained() {
+  _sc_db="$1"
+  _sc_from="$2"
+  _sc_to="$3"
+  _sc_tables="$4"
+  # Without both commit endpoints there is nothing to diff against — fail closed.
+  [ -n "$_sc_from" ] && [ -n "$_sc_to" ] || return 1
+  _sc_seen=0
+  for _sc_t in $_sc_tables; do
+    _sc_seen=1
+    valid_table_name "$_sc_t" || return 1
+    # No pre-flight row may be removed. A removed row is data loss, not a benign
+    # in-place UPDATE, regardless of the proven concurrent writer.
+    if ! _sc_removed=$(query_single_cell "$_sc_db" \
+      "same-count drift preservation diff probe failed for table=$_sc_t" \
+      "SELECT COUNT(*) FROM DOLT_DIFF('$_sc_from', '$_sc_to', '$_sc_t') WHERE diff_type = 'removed'"); then
+      return 1
+    fi
+    case "$_sc_removed" in
+      0) ;;                    # no pre-flight row removed
+      ''|*[!0-9]*) return 1 ;; # empty/non-numeric probe result — fail closed
+      *) return 1 ;;           # one or more pre-flight rows removed — data loss
+    esac
+    # The drift must be explained by at least one modified row. A same-count hash
+    # drift the diff cannot account for (zero modified rows) is unexplained and
+    # fails closed.
+    if ! _sc_modified=$(query_single_cell "$_sc_db" \
+      "same-count drift modification diff probe failed for table=$_sc_t" \
+      "SELECT COUNT(*) FROM DOLT_DIFF('$_sc_from', '$_sc_to', '$_sc_t') WHERE diff_type = 'modified'"); then
+      return 1
+    fi
+    case "$_sc_modified" in
+      ''|*[!0-9]*|0) return 1 ;; # empty/non-numeric/zero — drift unexplained
+      *) ;;                       # at least one modified row explains the drift
+    esac
+  done
+  # An empty table list is not a proof of preservation.
+  [ "$_sc_seen" = "1" ] || return 1
+  return 0
+}

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -253,6 +253,8 @@ PACK_DIR="${GC_PACK_DIR:-$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 # shellcheck disable=SC1091
 . "$PACK_DIR/assets/scripts/compact-gain-drift-proof.sh"
+# shellcheck disable=SC1091
+. "$PACK_DIR/assets/scripts/compact-same-count-drift-proof.sh"
 
 if [ "${GC_DOLT_MANAGED_LOCAL:-}" = "1" ]; then
   managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
@@ -1154,6 +1156,7 @@ verify_counts() {
   verify_counts_saw_row_decrease=0
   verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
+  verify_counts_same_count_drift_tables=""
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
@@ -1252,6 +1255,7 @@ verify_counts() {
         printf 'compact: db=%s table=%s value hash changed after flatten without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         verify_counts_saw_same_count_hash_drift=1
+        verify_counts_same_count_drift_tables="$verify_counts_same_count_drift_tables $t"
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten table value hash changed without row-count increase"
@@ -2182,6 +2186,7 @@ flatten_database() {
   verify_counts_saw_row_decrease=0
   verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
+  verify_counts_same_count_drift_tables=""
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
@@ -2729,6 +2734,58 @@ flatten_database() {
       fi
       rm -f "$preflight_tmp"
       return 0
+    fi
+    # Downgrade quarantine -> defer for a concurrent-writer in-place UPDATE
+    # (ga-ewo6j). A same-count table value-hash drift is an in-place row
+    # modification: the row count is unchanged but the value hash moved. On a
+    # high-write DB the beads/mail workload commits such UPDATEs (mail
+    # read/archive, bead close/status change) every few seconds, so one lands in
+    # the flatten verify window on ~every run; hard-quarantining it blocks all
+    # future GC of the DB and is the production memory-exhaustion failure this
+    # compactor guards against. Defer ONLY when BOTH hold, else fail closed and
+    # quarantine below:
+    #   * a concurrent writer is HEAD-proven (writer_race_detected=1). A stable
+    #     HEAD means no writer, which is the corruption signal — unlike gain+drift
+    #     there is NO absorbed-writer DOLT_DIFF fallback here, because a same-count
+    #     in-place modification has no unchanged-row anchor and is byte-for-byte
+    #     indistinguishable from corruption without an independent writer signal.
+    #   * the drift has the shape of a benign in-place UPDATE:
+    #     same_count_drift_is_writer_explained diffs the pre-flight snapshot HEAD
+    #     against the flatten commit for every same-count-drifted table and proves
+    #     rows were MODIFIED with NONE of the pre-flight rows removed. Any removed
+    #     row, an unexplained/empty diff, or a probe failure fails closed.
+    # same_count_hash_drift is the ONLY failure category here; a mix with gain,
+    # decrease, table-list drift, or a probe failure still quarantines below.
+    if [ "$writer_race_detected" = "1" ] && \
+       [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ] && \
+       [ "${verify_counts_saw_gain:-0}" != "1" ] && \
+       [ "${verify_counts_saw_gain_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
+       [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
+       [ "${verify_counts_saw_probe_failure:-0}" != "1" ] && \
+       same_count_drift_is_writer_explained "$db" "$head" "$flatten_head" "$verify_counts_same_count_drift_tables"; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — same-count table value hash drift proven concurrent-writer in-place UPDATE via DOLT_DIFF(%s..%s) for tables [%s] (rows modified, none removed), not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" "$head" "$flatten_head" "${verify_counts_same_count_drift_tables# }" >&2
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "$compacted_from_head" "$local_branch" "$remote_branch"; then
+        rm -f "$preflight_tmp"
+        return 1
+      fi
+      rm -f "$preflight_tmp"
+      return 0
+    fi
+    # A proven writer plus a same-count drift that the DOLT_DIFF proof could NOT
+    # clear (a pre-flight row was removed, the drift was unexplained, or a probe
+    # failed) fails closed here: the writer proof alone cannot license an
+    # unprovable in-place mutation, so quarantine stands. Emitted only when
+    # same-count drift is the sole hard category (a mix is reported just below).
+    if [ "$writer_race_detected" = "1" ] && \
+       [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ] && \
+       [ "${verify_counts_saw_gain_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_row_decrease:-0}" != "1" ]; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s), but same-count value hash drift could not be proven a benign in-place UPDATE (row removed, drift unexplained, or diff probe failed); failing closed, quarantine unchanged\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
     fi
     if [ "$writer_race_detected" = "1" ] && \
        { [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] || \

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -754,7 +754,7 @@ case "$query" in
     # probe, which reports writercommit so HEAD has moved past the flatten's own
     # commit. verify_counts still sees compactcommit (gain+drift) because it does
     # not probe HEAD and the "$(current_head)" gates read the real state.
-    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "writer_race_same_count_hash_drift" ] || [ "$mode" = "same_count_hash_drift_writer_removed_row" ] || [ "$mode" = "same_count_hash_drift_writer_diff_probe_fails" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.postverify-head-calls"
       calls=0
       if [ -f "$calls_file" ]; then
@@ -852,7 +852,7 @@ case "$query" in
       print_cell ""
       exit 0
     fi
-    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ] || [ "$mode" = "writer_race_same_count_hash_drift" ] || [ "$mode" = "same_count_hash_drift_writer_removed_row" ] || [ "$mode" = "same_count_hash_drift_writer_diff_probe_fails" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -1036,6 +1036,40 @@ case "$query" in
     fi
     print_cell 10
     exit 0
+    ;;
+  *"DOLT_DIFF("*"diff_type = 'removed'"*|*"DOLT_DIFF("*"diff_type = 'modified'"*)
+    # Content diff probe for the same-count in-place-UPDATE proof (ga-ewo6j).
+    # Keyed on the "diff_type = 'removed'"/"'modified'" clauses, which are unique
+    # to same_count_drift_is_writer_explained — the gain-drift and first-commit
+    # probes use "diff_type <> 'added'" — so this arm never shadows them. It MUST
+    # precede the generic *"SELECT COUNT(*) FROM"*"beads"* arm below (these are
+    # SELECT COUNT(*) FROM DOLT_DIFF(...) queries) or that arm would answer with
+    # a table row count. removed must be 0 and modified > 0 to prove a benign
+    # in-place UPDATE; data-loss/probe-failure variants fail the proof closed.
+    case "$mode" in
+      writer_race_same_count_hash_drift)
+        case "$query" in
+          *"diff_type = 'removed'"*) print_cell 0 ;;
+          *"diff_type = 'modified'"*) print_cell 3 ;;
+          *) print_cell 0 ;;
+        esac
+        exit 0
+        ;;
+      same_count_hash_drift_writer_removed_row)
+        case "$query" in
+          *"diff_type = 'removed'"*) print_cell 1 ;;
+          *"diff_type = 'modified'"*) print_cell 2 ;;
+          *) print_cell 0 ;;
+        esac
+        exit 0
+        ;;
+      same_count_hash_drift_writer_diff_probe_fails)
+        printf 'diff probe unavailable\n' >&2
+        exit 55
+        ;;
+    esac
+    printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
+    exit 64
     ;;
   *"SELECT COUNT(*) FROM"*"beads"*)
     if [ "$mode" = "row_count_failure" ]; then
@@ -3221,6 +3255,87 @@ func TestCompactScriptIntegrityReasonOutranksEarlierProbeFailure(t *testing.T) {
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed without row-count increase" {
 		t.Fatalf("quarantine reason should prefer integrity failure over earlier probe failure, got %q", reason)
+	}
+}
+
+// A concurrent in-place UPDATE (mail read/archive, bead close/status change on a
+// high-write DB) commits inside the flatten verify window, leaving the row count
+// unchanged but drifting the table value hash. HEAD moves past the flatten's own
+// commit, so the writer is proven, and a DOLT_DIFF of the pre-flight snapshot
+// against the flatten commit shows the drifted rows were modified with none
+// removed — a benign in-place UPDATE, not corruption. The run must defer
+// (skip-and-retry) instead of writing the blocking quarantine marker that
+// chronically re-quarantined high-write DBs and starved GC (ga-ewo6j).
+func TestCompactScriptDefersSameCountHashDriftWithProvenWriter(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_same_count_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	if !strings.Contains(out, "table=beads value hash changed after flatten without row-count increase") {
+		t.Fatalf("output missing same-count hash drift evidence:\n%s", out)
+	}
+	if !strings.Contains(out, "in-place UPDATE") {
+		t.Fatalf("output missing same-count in-place UPDATE defer message:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if !strings.Contains(string(logData), "DOLT_DIFF(") {
+		t.Fatalf("same-count drift defer should probe DOLT_DIFF for row preservation:\n%s", logData)
+	}
+}
+
+// Fail closed: even with a proven writer, a DOLT_DIFF that shows a pre-flight row
+// was REMOVED (not merely modified) is not a benign in-place UPDATE — a removed
+// row is data loss — so the same-count drift must still quarantine.
+func TestCompactScriptQuarantinesSameCountHashDriftWhenPreflightRowRemoved(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "same_count_hash_drift_writer_removed_row", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite a removed pre-flight row during same-count drift:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten INTEGRITY check failed") {
+		t.Fatalf("output missing integrity quarantine notice:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("removed pre-flight row must block full GC:\n%s", logData)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); statErr != nil {
+		t.Fatalf("removed pre-flight row should write quarantine marker: %v", statErr)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if _, statErr := os.Stat(pendingGC); !os.IsNotExist(statErr) {
+		t.Fatalf("removed pre-flight row must not write pending-GC marker; stat=%v", statErr)
+	}
+}
+
+// Fail closed: if the DOLT_DIFF preservation probe itself fails, the same-count
+// drift cannot be proven a benign in-place UPDATE and must still quarantine,
+// even with a proven writer.
+func TestCompactScriptQuarantinesSameCountHashDriftWhenDiffProbeFails(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "same_count_hash_drift_writer_diff_probe_fails", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite same-count drift diff-probe failure:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten INTEGRITY check failed") {
+		t.Fatalf("output missing integrity quarantine notice:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("same-count drift diff-probe failure must block full GC:\n%s", logData)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); statErr != nil {
+		t.Fatalf("same-count drift diff-probe failure should write quarantine marker: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Problem

`gc dolt compact`'s post-flatten integrity check has three defer paths that
downgrade a blocking quarantine to skip-and-retry when a concurrent writer is
proven:

- gain+drift, HEAD-proven
- gain+drift, additive-only (Option A, #2846)
- row-decrease, HEAD-proven

All three explicitly require `verify_counts_saw_same_count_hash_drift != 1`, and
there is **no** defer path for the same-count case. A concurrent in-place UPDATE
that lands in the flatten verify window — the row count is unchanged but a
table's value hash drifts — therefore always falls through to a **hard
quarantine**.

On a high-write DB (mail/coordination, where `bd:update` and mail-read commits
land every few seconds) such an UPDATE lands on ~every flatten, so the DB
re-quarantines on ~every run. A quarantine marker blocks **all** future GC of
the DB — the unbounded-bloat / memory-exhaustion failure the compactor header
explicitly warns about. Observed in production: a mail/coordination DB grew to
several GB on disk for ~2k rows and flooded the operator inbox with one
`compact-quarantine` alert per run.

## Fix

Add a same-count defer path that fires **only when both** hold, else fails
closed and quarantines:

1. a concurrent writer is HEAD-proven (`writer_race_detected=1`); **and**
2. `same_count_drift_is_writer_explained` proves — via `DOLT_DIFF` of the
   pre-flight snapshot HEAD against the flatten commit for every
   same-count-drifted table — that rows were **modified** with **none of the
   pre-flight rows removed**.

Any removed pre-flight row, an unexplained/empty diff, or a probe failure fails
closed and quarantine stands.

### Why no absorbed-writer fallback (unlike gain+drift)

gain+drift can be proven benign with no HEAD movement because "additive-only"
leaves every pre-flight row **unchanged** as an anchor. A same-count in-place
modification has no such anchor — it is byte-for-byte indistinguishable from
corruption without an independent writer signal — so a **stable-HEAD** same-count
drift remains the corruption signal and still quarantines. The frequent
production case (committed `bd:update`/mail writes move HEAD) is covered.

## Changes

- **New** `examples/bd/dolt/assets/scripts/compact-same-count-drift-proof.sh` —
  `same_count_drift_is_writer_explained`, mirroring the gain-drift Option A
  proof helper. Ships via the existing `all:assets` embed.
- `examples/bd/dolt/commands/compact/run.sh` — source the new helper; track
  `verify_counts_same_count_drift_tables`; add the same-count defer block and an
  accurate fail-closed diagnostic.
- `examples/bd/dolt/dog_exec_scripts_test.go` — `DOLT_DIFF` content-probe mock
  (keyed on the `diff_type = 'removed'`/`'modified'` clauses so it never shadows
  the gain-drift/first-commit probes) plus three tests.

## Tests (TDD)

- `TestCompactScriptDefersSameCountHashDriftWithProvenWriter` — the fix: proven
  writer + benign in-place UPDATE ⇒ defer (exit 0, pending-GC marker, no
  quarantine, no GC).
- `TestCompactScriptQuarantinesSameCountHashDriftWhenPreflightRowRemoved` — fail
  closed on a removed pre-flight row.
- `TestCompactScriptQuarantinesSameCountHashDriftWhenDiffProbeFails` — fail
  closed on a diff-probe failure.
- Pre-existing stable-HEAD same-count corruption case still quarantines; full
  `examples/bd/dolt` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
