### PR TITLE
fix(sling): suppress false dropped-instructions hint

### DIFF
--- a/internal/sling/sling_attached_hint_test.go
+++ b/internal/sling/sling_attached_hint_test.go
@@ -1,0 +1,66 @@
+package sling
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+type fakeQuerier struct {
+	b beads.Bead
+}
+
+func (f fakeQuerier) Get(_ string) (beads.Bead, error) {
+	return f.b, nil
+}
+
+// TestAttachedHintSuppressedWhenIssueVarCarriesBead is the ga-tj5jbm RED
+// test: the legacy sling path always auto-stamps gc.var.issue = beadID
+// (BuildSlingFormulaVars), and every route-table formula resolves the bead
+// back via `bd show $ROOT_ID` (Route B). The advisory must not fire when
+// that route is live.
+func TestAttachedHintSuppressedWhenIssueVarCarriesBead(t *testing.T) {
+	const beadID = "ga-oaz41a"
+	userVars := []string{"slug=" + beadID} // what deacon-dispatch.sh passes
+	vars := BuildSlingFormulaVars("mol-plan-breakdown", beadID, userVars, config.Agent{}, SlingDeps{})
+	if got := vars["issue"]; got != beadID {
+		t.Fatalf("precondition: legacy path must stamp issue var; got %q", got)
+	}
+	q := fakeQuerier{b: beads.Bead{ID: beadID, Description: "instructions the agent needs"}}
+	if hint := attachedBeadInstructionsDroppedHint(q, beadID, userVars); hint != "" {
+		t.Fatalf("FALSE POSITIVE: hint fired even though gc.var.issue carries the bead:\n  %s", hint)
+	}
+}
+
+// TestAttachedHintFiresWhenIssueVarNotStamped guards against deleting the
+// hint outright: when the caller explicitly voids the issue var (so Route B
+// genuinely isn't live) and supplies no context_path/requirements_path
+// either, the bead's instructions really are invisible to the formula and
+// the advisory should still fire.
+func TestAttachedHintFiresWhenIssueVarNotStamped(t *testing.T) {
+	const beadID = "ga-oaz41a"
+	userVars := []string{"issue="}
+	q := fakeQuerier{b: beads.Bead{ID: beadID, Description: "instructions the agent needs"}}
+	hint := attachedBeadInstructionsDroppedHint(q, beadID, userVars)
+	if hint == "" {
+		t.Fatalf("hint should still fire when no route (issue var, context_path, requirements_path) carries the bead's description")
+	}
+}
+
+// TestAttachedHintSuppressedWhenContextOrRequirementsPathSupplied preserves
+// the pre-existing behavior: the caller-supplied context_path/
+// requirements_path route (#3681) suppresses the hint regardless of the
+// issue var's state.
+func TestAttachedHintSuppressedWhenContextOrRequirementsPathSupplied(t *testing.T) {
+	const beadID = "ga-oaz41a"
+	q := fakeQuerier{b: beads.Bead{ID: beadID, Description: "instructions the agent needs"}}
+	for _, userVars := range [][]string{
+		{"issue=", "context_path=/tmp/ctx"},
+		{"issue=", "requirements_path=/tmp/reqs.md"},
+	} {
+		if hint := attachedBeadInstructionsDroppedHint(q, beadID, userVars); hint != "" {
+			t.Fatalf("hint should stay suppressed when context_path/requirements_path is supplied: vars=%v hint=%q", userVars, hint)
+		}
+	}
+}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -442,23 +442,40 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 
 // attachedBeadInstructionsDroppedHint returns a sling-time diagnostic when
 // --on/default-formula attaches a formula to an existing bead whose own
-// description carries real instructions. The formula wisp root's own
+// description carries real instructions and no route into the formula's
+// rendered context is available for it. The formula wisp root's own
 // description is always the FORMULA's own boilerplate
-// (internal/formula/compile.go rootDesc), never the target bead's text, and
-// no formula var exposes the bead's Description either — so a bead's
-// instructions are otherwise silently invisible to the formula's rendered
-// context, unless the caller explicitly carries them in via
-// context_path/requirements_path (#3681). It changes neither routing nor
-// the materialized wisp.
+// (internal/formula/compile.go rootDesc), never the target bead's text.
+// Two routes carry it in instead: the caller-supplied
+// context_path/requirements_path (#3681), and the legacy sling path's
+// auto-stamped `gc.var.issue`, which every route-table step template
+// resolves and re-fetches via `bd show` (Route B, added 2026-08-02). The
+// hint only fires when neither route is live — in practice, only when the
+// caller explicitly voids `issue=`, since BuildSlingFormulaVars stamps it
+// automatically otherwise. It changes neither routing nor the materialized
+// wisp.
 func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, userVars []string) string {
 	if querier == nil || beadID == "" {
 		return ""
 	}
+	// BuildSlingFormulaVars auto-stamps gc.var.issue = beadID whenever
+	// beadID != "", unless the caller explicitly overrides it — so assume
+	// Route B is live unless userVars says otherwise.
+	issueVarCarriesBead := true
 	for _, v := range userVars {
-		key, _, ok := strings.Cut(v, "=")
-		if ok && (key == "context_path" || key == "requirements_path") {
-			return ""
+		key, value, ok := strings.Cut(v, "=")
+		if !ok {
+			continue
 		}
+		switch key {
+		case "context_path", "requirements_path":
+			return ""
+		case "issue":
+			issueVarCarriesBead = value != ""
+		}
+	}
+	if issueVarCarriesBead {
+		return ""
 	}
 	bead, err := querier.Get(beadID)
 	if err != nil || strings.TrimSpace(bead.Description) == "" {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2420,11 +2420,15 @@ func TestSlingAttachFormula(t *testing.T) {
 
 // TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped is the regression
 // for #3681: --on/AttachFormula never carries the target bead's own
-// description into the formula's rendered context — the wisp root's
-// description is always the formula's own boilerplate, and no formula var
-// exposes the bead's text either. A caller relying on the bead's
-// description as the actual build instructions silently gets a brainstorm
-// that never saw them. Warn instead of changing routing/materialization.
+// description into the formula's rendered context via the wisp root (its
+// description is always the formula's own boilerplate). A caller relying
+// on the bead's description as the actual build instructions silently gets
+// a brainstorm that never saw them — unless some other route carries it
+// in. Since 2026-08-02 the legacy path auto-stamps gc.var.issue = beadID,
+// and every route-table formula resolves it back via `bd show` (Route B),
+// so this test must explicitly void that route (issue=) to exercise the
+// genuinely-silent case; see ga-tj5jbm. Warn instead of changing
+// routing/materialization.
 func TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped(t *testing.T) {
 	runner := newFakeRunner()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
@@ -2436,7 +2440,7 @@ func TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped(t *testing.T) {
 		t.Fatal(err)
 	}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
-	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{})
+	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{Vars: []string{"issue="}})
 	if err != nil {
 		t.Fatalf("AttachFormula: %v", err)
 	}

--- a/release-gates/ga-92j70e-sling-dropped-instructions-hint-gate.md
+++ b/release-gates/ga-92j70e-sling-dropped-instructions-hint-gate.md
@@ -1,0 +1,109 @@
+# Release Gate: sling dropped-instructions hint
+
+Deploy bead: `ga-92j70e`  
+Review bead: `ga-7tyvef`  
+Reviewed source: `aa7173b9f9e06ec2f3125cff45999bb87adbfe8c`  
+Base: `origin/main@8070d4741f6fd9fd010c9c3170f5a7fc3861387c`  
+Gate date: 2026-08-20
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree. This record uses
+the seven release criteria in the deployer contract and the repository's
+documented test commands in `TESTING.md`.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-7tyvef` is closed with a PASS reason for the exact reviewed source; duplicate review bead `ga-jhva9w` was closed without changing that verdict. |
+| 2 | Acceptance criteria met | PASS | The advisory now recognizes the legacy sling path's automatic `gc.var.issue = beadID` stamp, still fires when the caller explicitly clears `issue`, and remains suppressed when `context_path` or `requirements_path` carries instructions. The four behavior regressions pass under the race detector. |
+| 3 | Tests pass | PASS | The focused sling suite reports 212 top-level PASS, 0 FAIL, 0 SKIP under `-race`; all 155 runnable tests in the added/modified test files pass by name. The required 40-job union reports 33 PASS jobs, 7 FAIL jobs, 0 job-level SKIP. All eight top-level failures are tracked, not diff-owned, and structurally unreachable from the changed advisory formatter; the two beads#4566 occurrences are preserved below as FAIL — WAIVED under mayor's standing authorization. `make test-ci-policy` and `go vet ./...` pass. |
+| 4 | No high-severity review findings open | PASS | Reviewer reports no style, security, or wire-path findings and no blocking issues. The narrower graph.v2 advisory limitation is explicitly non-blocking and outside this legacy-path fix. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty at the reviewed source before adding this gate record; `git diff --check origin/main...aa7173b9...` passed. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main aa7173b9...` succeeded against `origin/main@8070d474...`, producing `8c84ef760710660c3d19647d26deb1dda478e344`. `assert_deploy_ancestry_scope` passed for the deploy, review, and build bead IDs. |
+| 7 | Single feature theme | PASS | One commit changes only three `internal/sling` files for the attached-bead dropped-instructions advisory and its directly coupled tests. |
+
+## Acceptance Evidence
+
+- `TestAttachedHintSuppressedWhenIssueVarCarriesBead`: PASS.
+- `TestAttachedHintFiresWhenIssueVarNotStamped`: PASS.
+- `TestAttachedHintSuppressedWhenContextOrRequirementsPathSupplied`: PASS.
+- `TestSlingAttachFormulaWarnsWhenBeadDescriptionDropped`: PASS.
+- Direct inspection confirms `BuildSlingFormulaVars` stamps `issue=beadID` on
+  the legacy route unless the caller explicitly overrides it.
+- The diff changes no wire type, API, dependency, config schema, persistence,
+  or dispatch behavior; it controls only whether an advisory string is shown.
+
+## Test Evidence
+
+```text
+test_cmd: go test -race -v -count=1 -timeout 300s ./internal/sling/...
+test_counts: 212 top-level PASS, 0 FAIL, 0 SKIP
+diff_tests_executed: 155 PASS, 0 FAIL, 0 SKIP (all runnable tests in the added/modified test files resolved by name)
+waiver_ref: none for diff-owned tests
+focused_log: /var/tmp/ga-92j70e-sling-focused.log
+
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+test_counts: 33 PASS jobs, 7 FAIL jobs, 0 job-level SKIP (40 total)
+full_logs: /var/tmp/gc-local-tests.AAn5nv
+
+policy_lane: make test-ci-policy — PASS
+static_lane: go vet ./... — PASS
+```
+
+### Raw failures and attribution
+
+The failures below remain failures in the raw output. They are not rewritten
+as green. None is in a file added or modified by this diff.
+
+- FAIL — WAIVED: `TestCleanInstallTutorialPath` and
+  `TestHumaBinary_CityCreateAsync` failed during fixture initialization with
+  the exact `gastownhall/beads#4566` dirty-table schema-migration signature.
+  Root tracker: `ga-lpfjhc`. This candidate cannot reach Dolt schema migration
+  or store bootstrap. Both occurrences were logged on `ga-lpfjhc`, satisfying
+  the standing authorization recorded by mayor on `ga-6bnc42`; the raw results
+  are preserved here as FAIL — WAIVED.
+- FAIL — attributed: `TestSQLiteLegacySnapshotSIGKILLAtBoundaries` ->
+  `ga-11wvsd`. The timeout is in `internal/storebinding/sqlite`, which the
+  changed advisory formatter cannot reach.
+- FAIL — attributed: `TestExportMirrorPublishesTheUserTurnBeforeTheReply` ->
+  `ga-8ehfod`. That tracker was filed from this run for visibility, not used as
+  independent pre-existing proof; structural separation carries attribution:
+  the zcode adapter test does not invoke sling attachment or the changed pure
+  formatter.
+- FAIL — attributed: `TestBdFlagManifestCurrent` -> `ga-f0uceo`. The candidate
+  cannot alter the installed `bd` binary or `internal/bdflags` manifest.
+- FAIL — attributed: `TestConditionChecksRunConcurrentlyWithinTheirCap` ->
+  `ga-e7cxrg`. The failure is in order condition-check concurrency; the changed
+  pure post-attach advisory formatter cannot alter order scheduling.
+- FAIL — attributed: `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr`. They run
+  in the separate tmux provider and match the tracked empty-host-keytable
+  signature.
+
+```text
+failure_attribution: TestCleanInstallTutorialPath + TestHumaBinary_CityCreateAsync -> ga-lpfjhc + standing authorization ga-6bnc42; exact beads#4566 signature; no schema/bootstrap mechanism
+failure_attribution: TestSQLiteLegacySnapshotSIGKILLAtBoundaries -> ga-11wvsd + separate-package no-mechanism proof
+failure_attribution: TestExportMirrorPublishesTheUserTurnBeforeTheReply -> ga-8ehfod + structural call-path proof (tracker is same-run visibility only)
+failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo + structural no-mechanism proof
+failure_attribution: TestConditionChecksRunConcurrentlyWithinTheirCap -> ga-e7cxrg + pure-formatter/order-scheduler separation
+failure_attribution: TestGetKeyBinding_CapturesDefaultBinding{,WithArgs} -> ga-afqddr + separate-provider path proof
+```
+
+## Pre-flight
+
+GitHub's commit-to-PR lookup returned no PR for the reviewed source. The target
+has not already merged or been superseded through a PR, so normal isolated-
+branch deployment applies.
+
+## Commands
+
+```text
+git fetch origin main
+git merge-tree --write-tree origin/main aa7173b9f9e06ec2f3125cff45999bb87adbfe8c
+assert_deploy_ancestry_scope origin/main aa7173b9f9e06ec2f3125cff45999bb87adbfe8c ga-92j70e ga-7tyvef ga-tj5jbm
+git diff --check origin/main...aa7173b9f9e06ec2f3125cff45999bb87adbfe8c
+go test -race -v -count=1 -timeout 300s ./internal/sling/...
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+make test-ci-policy
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

`gc sling` no longer warns that a bead's instructions were dropped when the normal legacy formula path has already carried that bead through the automatically stamped `gc.var.issue` value. The warning still appears when a caller explicitly clears `issue`, and remains suppressed when `context_path` or `requirements_path` supplies the instructions instead.

This removes a false-positive warning from ordinary formula dispatch without changing attachment, routing, or the rendered workflow itself.

## Review notes

- The implementation aligns the advisory with `BuildSlingFormulaVars`, which stamps `issue=beadID` unless the caller overrides it.
- This is intentionally limited to the proven legacy sling behavior. It does not claim to solve the narrower graph.v2 case where a formula has removed all legacy issue references.
- No wire types, persistence, configuration, or dispatch semantics change.

## Test plan

- [x] Run the full `internal/sling` suite under the race detector and resolve every test in the added/modified test files by name.
- [x] Exercise the default stamped issue variable, explicit empty issue variable, and context/requirements-path cases.
- [x] Run the documented 40-job local CI union and audit every raw failure against diff ownership and existing trackers.
- [x] Run the repository policy lane and `go vet ./...`.
- [x] Release gate: [`release-gates/ga-92j70e-sling-dropped-instructions-hint-gate.md`](release-gates/ga-92j70e-sling-dropped-instructions-hint-gate.md)
