### PR TITLE
test(storebinding): give migration-guard helper a hang budget

### DIFF
--- a/internal/storebinding/migration_guard_unix_test.go
+++ b/internal/storebinding/migration_guard_unix_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/gastownhall/gascity/internal/testutil"
 )
 
+// migrationGuardHangBudget bounds the helper-readiness wait below — no assertion depends on
+// how long it takes, so this is a hang detector, not a latency assertion, and raising it does
+// not slow a passing run because the wait returns the instant "ready" arrives.
+// testutil.ExecRaceTimeout (10s) is a floor, not a target (TESTING.md "Floors, ceilings, and
+// inputs"): the helper re-execs the test binary and must clear Go runtime + package init, flag
+// parse and test enumeration, and an AcquireMigrationGuard call before it can print its ready
+// line. The sibling storebinding/sqlite fence helper follows the same re-exec-then-signal shape
+// and was measured taking up to 3.02s at 48 concurrent children under memory pressure (ga-ap7lpd),
+// which is what motivated its own hang budget (ga-sptey3); this one has no SQLite open/schema
+// work in the path, so it is expected to be cheaper, not more expensive. Mirrors the precedent in
+// cmd/gc/hangbudget_test.go (hangBudget = 6 * testutil.GoroutineRaceTimeout); 6x ExecRaceTimeout
+// is 60s, well under the 20m gate package timeout.
+const migrationGuardHangBudget = 6 * testutil.ExecRaceTimeout
+
 func TestAcquireMigrationGuardClaimsAreRefCountedAndBoundToCityGeneration(t *testing.T) {
 	directory := testMigrationGuardDirectory(t)
 	guard, err := AcquireMigrationGuard(context.Background(), directory, Generation(7))
@@ -342,7 +356,7 @@ func TestAcquireMigrationGuardExcludesSecondProcessAndRecoversAfterSIGKILL(t *te
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(testutil.ExecRaceTimeout):
+	case <-time.After(migrationGuardHangBudget):
 		t.Fatal("helper did not acquire its migration guard")
 	}
 	if err := command.Process.Signal(syscall.Signal(0)); err != nil {

--- a/release-gates/ga-d7ve5d-storebinding-migration-guard-hang-budget-gate.md
+++ b/release-gates/ga-d7ve5d-storebinding-migration-guard-hang-budget-gate.md
@@ -1,0 +1,118 @@
+# Release Gate: storebinding migration-guard hang budget
+
+Deploy bead: `ga-d7ve5d`  
+Review bead: `ga-i1r52s`  
+Build bead: `ga-42mt5x.10`  
+Reviewed source: `054f470452b7c145cbf7e02bd78be2a8115ddfc1`  
+Base: `origin/main@7a36644ade7e2d21043dac51cc00937e238c2100`  
+Gate date: 2026-08-20
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree. This record uses
+the seven release criteria in the deployer contract and the repository's
+documented test commands in `TESTING.md`.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-i1r52s` is closed PASS for the exact reviewed source. |
+| 2 | Acceptance criteria met | PASS | The migration-guard helper readiness wait now uses a documented 60-second hang budget derived as `6 * testutil.ExecRaceTimeout`; the deadline and diagnostic use the same value. Passing waits still return immediately. |
+| 3 | Tests pass | PASS | The focused top-level storebinding suite reports 331 PASS groups, 0 FAIL, 0 SKIP under `-race`; all eight runnable tests in the modified file pass by name. The required 40-job union reports 35 PASS jobs, 5 FAIL jobs, 0 job-level SKIP. All six top-level failures are tracked and structurally unreachable from this package-local `_test.go` diff. `make test-ci-policy`, `go vet ./...`, and gofmt pass. |
+| 4 | No high-severity review findings open | PASS | The reviewer found no security, correctness, or style issue; the change matches the established hang-budget precedent. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty before adding this gate record; `git diff --check origin/main...054f4704...` passes. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main 054f4704...` succeeded against `origin/main@7a36644a...`, producing `e5ed8be77ffcd391d69e6c58dab47644ec2783c7`. `assert_deploy_ancestry_scope` passed for the deploy, review, and build bead IDs. |
+| 7 | Single feature theme | PASS | One commit changes one `internal/storebinding` test file to apply the repository's hang-budget convention to one migration-guard child readiness wait. |
+
+## Acceptance Evidence
+
+- `migrationGuardHangBudget` is documented and derives from the central
+  `testutil.ExecRaceTimeout` floor rather than duplicating a duration literal.
+- `TestAcquireMigrationGuardExcludesSecondProcessAndRecoversAfterSIGKILL`
+  uses the new budget in both the context deadline and timeout diagnostic.
+- The changed SIGKILL recovery test passes under `-race` in 0.11s, confirming
+  the value is an outer hang ceiling rather than a latency accommodation.
+- No production file, wire type, configuration, persistence path, or runtime
+  behavior changes.
+
+## Test Evidence
+
+```text
+test_cmd: go test -race -v -count=1 -timeout 300s ./internal/storebinding
+test_counts: 331 PASS groups, 0 FAIL, 0 SKIP (1,082 test/subtest starts)
+diff_tests_executed: 8 PASS, 0 FAIL, 0 SKIP
+  TestAcquireMigrationGuardClaimsAreRefCountedAndBoundToCityGeneration PASS
+  TestMigrationGuardFileReleaserRetriesOnlyPendingStages PASS
+  TestRejectedMigrationGuardCleanupRetainsRetryOwnershipBeforeFlock PASS
+  TestAcquireMigrationGuardReturnsCleanupCapableGuardAfterCanceledAcquisitionCleanupFails PASS
+  TestAcquireWriterFenceRejectsReplacedMigrationGuardDirectoryBeforeProviderMutation PASS
+  TestRejectedWriterFenceCleanupReleasesOwnedClaimAfterDirectoryReplacement PASS
+  TestAcquireMigrationGuardExcludesSecondProcessAndRecoversAfterSIGKILL PASS
+  TestMigrationGuardHelperProcess PASS
+waiver_ref: none for diff-owned tests
+focused_log: /var/tmp/ga-d7ve5d-storebinding-focused.log
+
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+test_counts: 35 PASS jobs, 5 FAIL jobs, 0 job-level SKIP (40 total)
+full_logs: /var/tmp/gc-local-tests.uRVygn
+
+policy_lane: make test-ci-policy — PASS
+static_lane: go vet ./... — PASS
+format_lane: gofmt check on changed Go file — PASS
+```
+
+### Raw failures and attribution
+
+The failures below remain failures in the raw output. None is diff-owned. The
+candidate changes only `internal/storebinding/migration_guard_unix_test.go`;
+Go compiles package-local `_test.go` files only into that package's test binary,
+so this diff cannot execute in `cmd/gc`, `internal/bdflags`,
+`internal/runtime/tmux`, or `test/integration`. The candidate-owned package
+passed both the focused race run and the required union's `unit-core` lane.
+
+- FAIL — attributed: `TestSessionReconcilerTraceGH1654WorkRequestedStartCandidates/named_session_post-kill`
+  -> `ga-hgjlhi`. The tracked five-second async-start bound expired under
+  shard-parallel load. This occurrence was recorded and read back.
+- FAIL — attributed: `TestBdFlagManifestCurrent` -> `ga-f0uceo`. The installed
+  `bd` flag surface is ahead of the checked-in manifest; this exact signature
+  predates the candidate. The occurrence was recorded and read back.
+- FAIL — attributed: `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr`. The host
+  tmux default key table is empty; this exact signature predates the candidate.
+  Both occurrences were recorded and read back.
+- FAIL — attributed: `TestE2E_SuspendResume_City` -> `ga-yc0e3a`. The expected
+  `citysus.report` did not arrive under load. The tracker contains exact
+  candidate/base A/B evidence for this signature; this occurrence was recorded
+  and read back.
+- FAIL — attributed: `TestCleanInstallTutorialPath` -> `ga-hrdd3h`. Beads
+  circuit-breaker cleanup diagnostics contaminated the expected `issue_prefix`
+  stdout; this exact signature predates the candidate. The occurrence was
+  recorded and read back.
+
+```text
+failure_attribution: TestSessionReconcilerTraceGH1654WorkRequestedStartCandidates/named_session_post-kill -> ga-hgjlhi + separate-package no-mechanism proof
+failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo + separate-package no-mechanism proof
+failure_attribution: TestGetKeyBinding_CapturesDefaultBinding{,WithArgs} -> ga-afqddr + separate-package no-mechanism proof
+failure_attribution: TestE2E_SuspendResume_City -> ga-yc0e3a + prior exact candidate/base A/B + separate-package no-mechanism proof
+failure_attribution: TestCleanInstallTutorialPath -> ga-hrdd3h + separate-package no-mechanism proof
+```
+
+## Pre-flight
+
+GitHub's commit-to-PR lookup returned no PR for the reviewed source after the
+final `origin/main` refresh. The target has not already merged or been
+superseded through a PR, so normal isolated-branch deployment applies. The
+shared builder branch has since moved; its newer tip was treated as provenance
+only and was not used.
+
+## Commands
+
+```text
+git fetch origin
+git merge-tree --write-tree origin/main 054f470452b7c145cbf7e02bd78be2a8115ddfc1
+assert_deploy_ancestry_scope origin/main 054f470452b7c145cbf7e02bd78be2a8115ddfc1 ga-d7ve5d ga-i1r52s ga-42mt5x.10
+git diff --check origin/main...054f470452b7c145cbf7e02bd78be2a8115ddfc1
+go test -race -v -count=1 -timeout 300s ./internal/storebinding
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+make test-ci-policy
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

The storebinding migration-guard process test now gives its helper-readiness wait a dedicated 60-second hang-detection budget. It previously used the shared 10-second process-race floor directly, which made the test vulnerable to false timeouts when a loaded host delayed child-process startup.

The helper still returns as soon as it is ready, so passing tests do not become slower. The larger value only bounds how long a genuinely wedged helper may run before the test reports a timeout.

## Review notes

- The change is test-only; production migration guards and store behavior are unchanged.
- The context deadline and timeout diagnostic use the same derived budget.
- The multiplier follows the repository's existing hang-budget convention and stays below the package's outer timeout.

## Test plan

- [x] Run the complete top-level `internal/storebinding` package under the race detector and verify every test in the modified file executes without skips.
- [x] Run the repository's 40-job local CI-equivalent suite with the documented Podman environment.
- [x] Run CI policy checks and `go vet ./...`.
- [x] Release gate: [`release-gates/ga-d7ve5d-storebinding-migration-guard-hang-budget-gate.md`](release-gates/ga-d7ve5d-storebinding-migration-guard-hang-budget-gate.md)
