### PR TITLE
feat(hook): stamp gc.claimed_at write-once in the claim hook

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -1052,15 +1052,21 @@ func hookClaimThroughStore(beadID, assignee string, claim func() (beads.Bead, bo
 // bead to its work that the close gate later reads, ADR-0009) plus the durable
 // session back-reference gc.session_id / gc.session_name (#2843) so the dashboard
 // run-detail can resolve which session executed a pool step after the transient
-// Assignee is cleared on close. graphroute leaves pool steps unbound at route time,
-// deferring the session binding to this claim (graphroute.go:200-203).
+// Assignee is cleared on close, plus gc.claimed_at (OBS-001), the write-once claim
+// timestamp that feeds the created→claimed and claimed→started latency-watch
+// transitions. graphroute leaves pool steps unbound at route time, deferring the
+// session binding to this claim (graphroute.go:200-203).
 //
 // The patch is compare-and-skipped against the bead's current metadata and the
 // write is issued only when at least one key actually changes: this runs again on
 // every hook tick via the existing_assignment / ready_assignment adoption paths, so
 // an unconditional write would emit a bead.updated per tick per in-progress bead
-// (the cache-reconcile flood class). Best-effort: a missing repo, detached HEAD,
-// absent session, or write error never blocks the claim.
+// (the cache-reconcile flood class). gc.claimed_at is the one key in this patch
+// that cannot use "differs from current → overwrite" — time.Now() differs from any
+// stored value on every tick by construction, so it would defeat the compare-and-
+// skip guard by itself. hookClaimIdentityPatch instead treats it as write-once:
+// stamped only when absent, never touched again once set. Best-effort: a missing
+// repo, detached HEAD, absent session, or write error never blocks the claim.
 func stampHookClaimIdentity(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) (beads.Bead, bool) {
 	patch := hookClaimIdentityPatch(bead, opts, ops, dir)
 	sessionID := hookClaimSessionID(opts.Env)
@@ -1119,8 +1125,21 @@ func hookClaimLifecycleCandidate(bead beads.Bead, opts hookClaimOptions) bool {
 // session with no worktree still needs its back-reference — but never on control
 // beads, which stay session-free by graphroute's design
 // (ApplyGraphControlRouteBinding), even when a control-dispatcher session claims one
-// through this same hook path. An empty result means every key is already current,
-// so the caller issues no write.
+// through this same hook path.
+//
+// gc.claimed_at (OBS-001) is a fourth, differently-shaped entry: unlike the three
+// keys above, it is WRITE-ONCE, stamped only when absent from the bead's current
+// metadata and never touched again. A naive claimed_at = now() would differ from
+// the stored value on every tick by construction and defeat the compare-and-skip
+// protection the rest of this function relies on (see stampHookClaimIdentity's doc
+// comment on the flood-class risk). It is also unconditional across control and
+// non-control beads alike: a claim timestamp answers "when was this claimed",
+// which is meaningful regardless of session identity, so it is not gated on
+// IsControlKind, GC_SESSION_ID, or a resolvable worktree branch the way the other
+// three keys are.
+//
+// An empty result means every key is already current, so the caller issues no
+// write.
 func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string) map[string]string {
 	patch := map[string]string{}
 	if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
@@ -1136,6 +1155,9 @@ func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClai
 			strings.TrimSpace(bead.Metadata[beadmeta.SessionNameMetadataKey]) != sessionName {
 			patch[beadmeta.SessionNameMetadataKey] = sessionName
 		}
+	}
+	if strings.TrimSpace(bead.Metadata[beadmeta.ClaimedAtMetadataKey]) == "" {
+		patch[beadmeta.ClaimedAtMetadataKey] = time.Now().UTC().Format(time.RFC3339)
 	}
 	return patch
 }

--- a/cmd/gc/cmd_hook_claim_claimed_at_test.go
+++ b/cmd/gc/cmd_hook_claim_claimed_at_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// claimedAtNoWorktreeOps is a minimal hookClaimOps for exercising
+// hookClaimIdentityPatch directly: no worktree, no session-identity plumbing
+// beyond what the patch function itself reads.
+func claimedAtNoWorktreeOps() hookClaimOps {
+	return hookClaimOps{ResolveWorkBranch: func(string) string { return "" }}
+}
+
+// requireRecentRFC3339 fails the test unless raw parses as RFC3339 and lands
+// within the last 10 seconds — proving the patch stamped "now", not a
+// hardcoded or stale value.
+func requireRecentRFC3339(t *testing.T, raw string) {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("gc.claimed_at = %q is not RFC3339: %v", raw, err)
+	}
+	if age := time.Since(ts); age < 0 || age > 10*time.Second {
+		t.Fatalf("gc.claimed_at = %q is not a recent timestamp (age %s)", raw, age)
+	}
+}
+
+// TestHookClaimIdentityPatchStampsClaimedAtWhenAbsent covers a bead's first
+// claim: gc.claimed_at is absent from its metadata, so the patch must set it
+// to a fresh, valid RFC3339 UTC timestamp.
+func TestHookClaimIdentityPatchStampsClaimedAtWhenAbsent(t *testing.T) {
+	bead := beads.Bead{ID: "hw-first", Status: "open", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: "worker",
+	}}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, claimedAtNoWorktreeOps(), "/tmp/work")
+
+	raw, ok := patch[beadmeta.ClaimedAtMetadataKey]
+	if !ok {
+		t.Fatalf("patch = %v, want gc.claimed_at present on a bead with no prior claim", patch)
+	}
+	requireRecentRFC3339(t, raw)
+}
+
+// TestHookClaimIdentityPatchClaimedAtWriteOnce is the flood-class regression
+// test: a bead that already carries gc.claimed_at (simulating the metadata
+// state after the FIRST call's patch landed) must NOT get the key re-issued
+// on a second call, even though time.Now() always differs from the stored
+// value. This is the specific trap OBS-001 calls out — a naive
+// claimed_at = now() would defeat hookClaimIdentityPatch's compare-and-skip
+// by construction and flood bead.updated on every hook tick for every
+// in-progress bead. Absence from the returned map (not equality of value) is
+// the thing under test, since equality would trivially pass even for a
+// unconditional re-stamp that happened to land in the same second.
+func TestHookClaimIdentityPatchClaimedAtWriteOnce(t *testing.T) {
+	bead := beads.Bead{ID: "hw-second", Status: "open", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: "worker",
+	}}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
+	ops := claimedAtNoWorktreeOps()
+
+	first := hookClaimIdentityPatch(bead, opts, ops, "/tmp/work")
+	stamped, ok := first[beadmeta.ClaimedAtMetadataKey]
+	if !ok {
+		t.Fatalf("first call patch = %v, want gc.claimed_at present", first)
+	}
+
+	// Simulate the store now holding the value the first call decided.
+	bead.Metadata[beadmeta.ClaimedAtMetadataKey] = stamped
+
+	second := hookClaimIdentityPatch(bead, opts, ops, "/tmp/work")
+	if _, ok := second[beadmeta.ClaimedAtMetadataKey]; ok {
+		t.Fatalf("second call patch = %v, want gc.claimed_at ABSENT (write-once; no re-stamp once set)", second)
+	}
+}
+
+// TestHookClaimIdentityPatchClaimedAtForControlBead pins the deliberate
+// design choice that gc.claimed_at is unconditional: unlike
+// gc.session_id/gc.session_name (skipped for control-kind beads because
+// control steps stay session-free by graphroute's design), a claim timestamp
+// is meaningful for every claimed bead regardless of kind — the bead's own
+// description frames it purely as "when was this claimed", with no
+// control-bead carve-out. A control bead with no prior gc.claimed_at must
+// still receive one.
+func TestHookClaimIdentityPatchClaimedAtForControlBead(t *testing.T) {
+	bead := beads.Bead{ID: "hc-check", Status: "open", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: "check",
+	}}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, claimedAtNoWorktreeOps(), "/tmp/work")
+
+	raw, ok := patch[beadmeta.ClaimedAtMetadataKey]
+	if !ok {
+		t.Fatalf("patch = %v, want gc.claimed_at present on a control bead's first claim", patch)
+	}
+	requireRecentRFC3339(t, raw)
+	if _, ok := patch[beadmeta.SessionIDMetadataKey]; ok {
+		t.Fatalf("patch = %v, want gc.session_id absent on a control bead (unaffected by the claimed_at change)", patch)
+	}
+}
+
+// TestHookClaimIdentityPatchClaimedAtWithoutSessionOrWorktree proves
+// gc.claimed_at is not gated on session identity or a resolvable worktree
+// branch: a session-less, worktree-less claim is still a genuine claim and
+// must still get a claim timestamp.
+func TestHookClaimIdentityPatchClaimedAtWithoutSessionOrWorktree(t *testing.T) {
+	bead := beads.Bead{ID: "hw-bare", Status: "open", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: "worker",
+	}}
+	opts := hookClaimOptions{} // no GC_SESSION_ID, no GC_SESSION_NAME
+
+	patch := hookClaimIdentityPatch(bead, opts, claimedAtNoWorktreeOps(), "/tmp/work")
+
+	if len(patch) != 1 {
+		t.Fatalf("patch = %v, want exactly gc.claimed_at (no session, no branch)", patch)
+	}
+	raw, ok := patch[beadmeta.ClaimedAtMetadataKey]
+	if !ok {
+		t.Fatalf("patch = %v, want gc.claimed_at present", patch)
+	}
+	requireRecentRFC3339(t, raw)
+}
+
+// TestHookClaimIdentityPatchClaimedAtDoesNotDisturbExistingKeys guards the
+// three pre-existing compare-and-skip keys against interference from the new
+// write-once key: a bead needing a branch update and carrying a stale session
+// name, but already carrying gc.claimed_at, must patch exactly the stale keys
+// and nothing else.
+func TestHookClaimIdentityPatchClaimedAtDoesNotDisturbExistingKeys(t *testing.T) {
+	bead := beads.Bead{ID: "hw-mixed", Status: "open", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:        "worker",
+		beadmeta.WorkBranchMetadataKey:  "bd-old",
+		beadmeta.SessionIDMetadataKey:   "mc-sess1",
+		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
+		beadmeta.ClaimedAtMetadataKey:   "2026-01-01T00:00:00Z",
+	}}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
+	ops := hookClaimOps{ResolveWorkBranch: func(string) string { return "bd-new" }}
+
+	patch := hookClaimIdentityPatch(bead, opts, ops, "/tmp/work")
+
+	want := map[string]string{beadmeta.WorkBranchMetadataKey: "bd-new"}
+	if len(patch) != len(want) || patch[beadmeta.WorkBranchMetadataKey] != want[beadmeta.WorkBranchMetadataKey] {
+		t.Fatalf("patch = %v, want %v (claimed_at already set must stay out of the patch)", patch, want)
+	}
+	if _, ok := patch[beadmeta.ClaimedAtMetadataKey]; ok {
+		t.Fatalf("patch = %v, want gc.claimed_at absent (already current)", patch)
+	}
+}

--- a/cmd/gc/cmd_hook_claim_stamp_test.go
+++ b/cmd/gc/cmd_hook_claim_stamp_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -73,6 +74,33 @@ func noopStampWorkMeta(context.Context, string, []string, string, string, map[st
 // the city and opens the session store, which a test binary deliberately refuses.
 func noopStampSessionClaim(string, string) error { return nil }
 
+// popClaimedAt extracts and validates the write-once gc.claimed_at entry from
+// a fresh-claim patch, returning the remaining keys so the caller can assert
+// them by exact equality without hardcoding the dynamic clock value. It fails
+// the test if the key is absent, unparseable, or not recent — every claim in
+// this file's fresh-claim tests is expected to carry one.
+func popClaimedAt(t *testing.T, patch map[string]string) map[string]string {
+	t.Helper()
+	raw, ok := patch[beadmeta.ClaimedAtMetadataKey]
+	if !ok {
+		t.Fatalf("patch = %v, want gc.claimed_at present on a fresh claim", patch)
+	}
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("gc.claimed_at = %q is not RFC3339: %v", raw, err)
+	}
+	if age := time.Since(ts); age < 0 || age > 10*time.Second {
+		t.Fatalf("gc.claimed_at = %q is not a recent timestamp (age %s)", raw, age)
+	}
+	rest := make(map[string]string, len(patch)-1)
+	for k, v := range patch {
+		if k != beadmeta.ClaimedAtMetadataKey {
+			rest[k] = v
+		}
+	}
+	return rest
+}
+
 // poolClaimOps builds the seam for a pool slot claiming an unassigned,
 // route-matched candidate: the runner yields it, Claim returns it owned by us,
 // the branch resolver returns branch, and StampWorkMeta is captured by spy.
@@ -136,8 +164,9 @@ func TestDoHookClaimStampsSessionIdentity(t *testing.T) {
 		beadmeta.SessionIDMetadataKey:   "mc-sess1",
 		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
 	}
-	if !reflect.DeepEqual(spy.patch, want) {
-		t.Fatalf("patch = %v, want %v", spy.patch, want)
+	rest := popClaimedAt(t, spy.patch)
+	if !reflect.DeepEqual(rest, want) {
+		t.Fatalf("patch (minus gc.claimed_at) = %v, want %v", rest, want)
 	}
 	if spy.beadID != "hw-pool" || spy.assignee != "gc__role-mc-sess1" {
 		t.Fatalf("stamp target = bead %q assignee %q, want hw-pool / gc__role-mc-sess1", spy.beadID, spy.assignee)
@@ -172,8 +201,12 @@ func TestDoHookClaimStampsSessionIdentityOnAdoption(t *testing.T) {
 		beadmeta.SessionIDMetadataKey:   "mc-sess1",
 		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
 	}
-	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
-		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v}", spy.calls, spy.patch, want)
+	if spy.calls != 1 {
+		t.Fatalf("stamp calls = %d, want 1", spy.calls)
+	}
+	rest := popClaimedAt(t, spy.patch)
+	if !reflect.DeepEqual(rest, want) {
+		t.Fatalf("patch (minus gc.claimed_at) = %v, want %v", rest, want)
 	}
 }
 
@@ -198,15 +231,22 @@ func TestDoHookClaimStampsSessionIdentityWithoutWorktree(t *testing.T) {
 		beadmeta.SessionIDMetadataKey:   "mc-sess1",
 		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
 	}
-	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
-		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (session id/name even with no worktree)", spy.calls, spy.patch, want)
+	if spy.calls != 1 {
+		t.Fatalf("stamp calls = %d, want 1", spy.calls)
+	}
+	rest := popClaimedAt(t, spy.patch)
+	if !reflect.DeepEqual(rest, want) {
+		t.Fatalf("patch (minus gc.claimed_at) = %v, want %v (session id/name even with no worktree)", rest, want)
 	}
 }
 
 // TestDoHookClaimSkipsStampWhenIdentityUnchanged pins the mandatory idempotence
-// guard (sessionVerify #2): a candidate already carrying the current branch AND
-// session identity produces NO write, so the per-tick adoption re-run does not
-// flood bead.updated events.
+// guard (sessionVerify #2): a candidate already carrying the current branch,
+// session identity, AND a prior gc.claimed_at produces NO write, so the per-tick
+// adoption re-run does not flood bead.updated events. gc.claimed_at must be
+// preset here too (write-once): without it, this "everything unchanged"
+// candidate would still get a fresh claimed_at added to its patch, falsely
+// failing the "no write" assertion.
 func TestDoHookClaimSkipsStampWhenIdentityUnchanged(t *testing.T) {
 	spy := &stampMetaSpy{}
 	current := map[string]string{
@@ -214,9 +254,10 @@ func TestDoHookClaimSkipsStampWhenIdentityUnchanged(t *testing.T) {
 		"gc.work_branch":  "bd-hw-idem",
 		"gc.session_id":   "mc-sess1",
 		"gc.session_name": "gc__role-mc-sess1",
+		"gc.claimed_at":   "2026-01-01T00:00:00Z",
 	}
 	ops := poolClaimOps(
-		`[{"id":"hw-idem","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-hw-idem","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1"}}]`,
+		`[{"id":"hw-idem","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-hw-idem","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1","gc.claimed_at":"2026-01-01T00:00:00Z"}}]`,
 		current,
 		"bd-hw-idem",
 		spy,
@@ -232,8 +273,9 @@ func TestDoHookClaimSkipsStampWhenIdentityUnchanged(t *testing.T) {
 }
 
 // TestDoHookClaimStampsOnlyChangedIdentityKeys proves the patch is minimal: a
-// candidate whose session identity is current but whose branch changed writes ONLY
-// the branch, leaving the unchanged session keys out of the patch.
+// candidate whose session identity and gc.claimed_at are current but whose branch
+// changed writes ONLY the branch, leaving the unchanged keys (including
+// gc.claimed_at, preset here since it is write-once) out of the patch.
 func TestDoHookClaimStampsOnlyChangedIdentityKeys(t *testing.T) {
 	spy := &stampMetaSpy{}
 	current := map[string]string{
@@ -241,9 +283,10 @@ func TestDoHookClaimStampsOnlyChangedIdentityKeys(t *testing.T) {
 		"gc.work_branch":  "bd-old",
 		"gc.session_id":   "mc-sess1",
 		"gc.session_name": "gc__role-mc-sess1",
+		"gc.claimed_at":   "2026-01-01T00:00:00Z",
 	}
 	ops := poolClaimOps(
-		`[{"id":"hw-partial","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-old","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1"}}]`,
+		`[{"id":"hw-partial","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-old","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1","gc.claimed_at":"2026-01-01T00:00:00Z"}}]`,
 		current,
 		"bd-new",
 		spy,
@@ -263,7 +306,11 @@ func TestDoHookClaimStampsOnlyChangedIdentityKeys(t *testing.T) {
 // policy (sessionVerify #3): a control-dispatcher session claiming a control bead
 // (gc.kind in ControlKinds) must NOT acquire a session back-reference — control
 // steps stay session-free by graphroute's design — while gc.work_branch is still
-// stamped as before.
+// stamped as before. gc.claimed_at, unlike the session keys, is UNCONDITIONAL: a
+// claim timestamp is meaningful for every claimed bead regardless of kind, so a
+// control bead's first claim still stamps it (OBS-001; see also
+// TestHookClaimIdentityPatchClaimedAtForControlBead for the direct-patch unit
+// test pinning this same decision).
 func TestDoHookClaimSkipsSessionIdentityForControlBead(t *testing.T) {
 	spy := &stampMetaSpy{}
 	ops := poolClaimOps(
@@ -278,14 +325,19 @@ func TestDoHookClaimSkipsSessionIdentityForControlBead(t *testing.T) {
 		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
 	}
 	want := map[string]string{beadmeta.WorkBranchMetadataKey: "bd-hc-check"}
-	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
-		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (no session keys on a control bead)", spy.calls, spy.patch, want)
+	if spy.calls != 1 {
+		t.Fatalf("stamp calls = %d, want 1", spy.calls)
+	}
+	rest := popClaimedAt(t, spy.patch)
+	if !reflect.DeepEqual(rest, want) {
+		t.Fatalf("patch (minus gc.claimed_at) = %v, want %v (no session keys on a control bead, but claimed_at IS stamped)", rest, want)
 	}
 }
 
 // TestDoHookClaimSkipsSessionIdentityWhenNoSessionID: a non-session run (no
 // GC_SESSION_ID) has no session bead to reference, so neither session key is
-// stamped even when GC_SESSION_NAME happens to be set.
+// stamped even when GC_SESSION_NAME happens to be set. gc.claimed_at is still
+// stamped: it is not gated on session identity.
 func TestDoHookClaimSkipsSessionIdentityWhenNoSessionID(t *testing.T) {
 	spy := &stampMetaSpy{}
 	ops := poolClaimOps(
@@ -302,8 +354,12 @@ func TestDoHookClaimSkipsSessionIdentityWhenNoSessionID(t *testing.T) {
 		t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
 	}
 	want := map[string]string{beadmeta.WorkBranchMetadataKey: "bd-hw-nosess"}
-	if spy.calls != 1 || !reflect.DeepEqual(spy.patch, want) {
-		t.Fatalf("stamp = {calls:%d patch:%v}, want {1 %v} (no session id ⇒ no session keys)", spy.calls, spy.patch, want)
+	if spy.calls != 1 {
+		t.Fatalf("stamp calls = %d, want 1", spy.calls)
+	}
+	rest := popClaimedAt(t, spy.patch)
+	if !reflect.DeepEqual(rest, want) {
+		t.Fatalf("patch (minus gc.claimed_at) = %v, want %v (no session id ⇒ no session keys, but claimed_at IS stamped)", rest, want)
 	}
 }
 
@@ -363,17 +419,19 @@ func TestDoHookClaimEmitsStartedOnlyAfterDurableSessionReadback(t *testing.T) {
 // between a durable claim-time identity stamp and event recording. A later hook
 // tick adopts the same in-progress assignment, verifies its durable identity,
 // and must re-emit the idempotent started fact rather than leave a permanent
-// lifecycle gap.
+// lifecycle gap. The adopted bead already carries gc.claimed_at from its
+// original claim (write-once), so the adoption tick must not re-stamp it.
 func TestDoHookClaimAdoptionReconcilesDurableStartedFact(t *testing.T) {
 	spy := &stampMetaSpy{}
 	meta := map[string]string{
 		"gc.routed_to": "worker", beadmeta.RootBeadIDMetadataKey: "gcg-run",
 		beadmeta.StepIDMetadataKey: "build", beadmeta.SessionIDMetadataKey: "mc-sess1",
 		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
+		beadmeta.ClaimedAtMetadataKey:   "2026-01-01T00:00:00Z",
 	}
 	ops := hookClaimOps{
 		Runner: func(string, string) (string, error) {
-			return `[{"id":"gcg-attempt","status":"in_progress","assignee":"gc__role-mc-sess1","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"gcg-run","gc.step_id":"build","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1"}}]`, nil
+			return `[{"id":"gcg-attempt","status":"in_progress","assignee":"gc__role-mc-sess1","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"gcg-run","gc.step_id":"build","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1","gc.claimed_at":"2026-01-01T00:00:00Z"}}]`, nil
 		},
 		ResolveWorkBranch: func(string) string { return "" },
 		StampWorkMeta:     spy.fn,

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -787,16 +787,19 @@ func TestDoHookClaimStampsWorkBranch(t *testing.T) {
 }
 
 // TestDoHookClaimSkipsStampWhenBranchUnchanged guards the idempotent path: a
-// claim whose bead already carries the resolved branch performs no stamp write.
+// claim whose bead already carries the resolved branch AND a prior
+// gc.claimed_at performs no stamp write. gc.claimed_at must be preset here too
+// (write-once): without it, this bead's "first claim" would always add the
+// key to the patch and falsely fail the "no write" assertion.
 func TestDoHookClaimSkipsStampWhenBranchUnchanged(t *testing.T) {
 	var stampCalls int
 	runner := func(string, string) (string, error) {
-		return `[{"id":"hw-idem","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-hw-idem"}}]`, nil
+		return `[{"id":"hw-idem","status":"open","metadata":{"gc.routed_to":"worker","gc.work_branch":"bd-hw-idem","gc.claimed_at":"2026-01-01T00:00:00Z"}}]`, nil
 	}
 	ops := hookClaimOps{
 		Runner: runner,
 		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
-			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker", "gc.work_branch": "bd-hw-idem"}}, true, nil
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker", "gc.work_branch": "bd-hw-idem", "gc.claimed_at": "2026-01-01T00:00:00Z"}}, true, nil
 		},
 		ResolveWorkBranch: func(string) string { return "bd-hw-idem" },
 		StampWorkMeta: func(_ context.Context, _ string, _ []string, _, _ string, _ map[string]string) error {

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -39,18 +39,26 @@ const Namespace = "gc."
 // cmd/. Keep this block sorted by identifier; the Go compiler rejects duplicate
 // identifiers, giving us a free compile-time uniqueness guarantee.
 const (
-	AttemptLogMetadataKey                = "gc.attempt_log"
-	AttemptMetadataKey                   = "gc.attempt"
-	BondMetadataKey                      = "gc.bond"
-	BondVarsMetadataKey                  = "gc.bond_vars"
-	BoundStepIDMetadataKey               = "gc.bound_step_id"
-	BrainParentSIDMetadataKey            = "gc.brain_parent_sid"
-	CancelRequestedMetadataKey           = "gc.cancel_requested"
-	CheckInfraRetryMetadataKey           = "gc.check_infra_retry"
-	CheckModeMetadataKey                 = "gc.check_mode"
-	CheckPathMetadataKey                 = "gc.check_path"
-	CheckTimeoutMetadataKey              = "gc.check_timeout"
-	CityPathMetadataKey                  = "gc.city_path"
+	AttemptLogMetadataKey      = "gc.attempt_log"
+	AttemptMetadataKey         = "gc.attempt"
+	BondMetadataKey            = "gc.bond"
+	BondVarsMetadataKey        = "gc.bond_vars"
+	BoundStepIDMetadataKey     = "gc.bound_step_id"
+	BrainParentSIDMetadataKey  = "gc.brain_parent_sid"
+	CancelRequestedMetadataKey = "gc.cancel_requested"
+	CheckInfraRetryMetadataKey = "gc.check_infra_retry"
+	CheckModeMetadataKey       = "gc.check_mode"
+	CheckPathMetadataKey       = "gc.check_path"
+	CheckTimeoutMetadataKey    = "gc.check_timeout"
+	CityPathMetadataKey        = "gc.city_path"
+	// ClaimedAtMetadataKey records the RFC3339 UTC instant a bead was first
+	// claimed through `gc hook --claim`. It is write-once: the claim hook
+	// stamps it only when absent from the bead's current metadata and never
+	// overwrites an already-present value, unlike the compare-and-overwrite
+	// keys in this same claim-time patch (see hookClaimIdentityPatch in
+	// cmd/gc/cmd_hook_claim.go). Feeds the created→claimed and
+	// claimed→started latency-watch transitions (OBS-001).
+	ClaimedAtMetadataKey                 = "gc.claimed_at"
 	ClosedByAttemptMetadataKey           = "gc.closed_by_attempt"
 	ContinuationGroupMetadataKey         = "gc.continuation_group"
 	ControlDispatcherFallbackMetadataKey = "gc.control_dispatcher_fallback"
@@ -361,6 +369,7 @@ var KnownMetadataKeys = []string{
 	CheckPathMetadataKey,
 	CheckTimeoutMetadataKey,
 	CityPathMetadataKey,
+	ClaimedAtMetadataKey,
 	ClosedByAttemptMetadataKey,
 	ContinuationGroupMetadataKey,
 	ControlEpochMetadataKey,


### PR DESCRIPTION
## Summary

An audit of claim-hook metadata found `gc.claimed_at` unset on every measured in-flight bead, making the `created→claimed` and `claimed→started` lifecycle transitions unmeasurable (OBS-001, `dr-3msk6`). `hookClaimIdentityPatch` now stamps `gc.claimed_at` (RFC3339 UTC) the first time a bead is claimed, but only when the key is absent from current metadata.

Unlike the three existing compare-and-overwrite keys in this same patch (`gc.work_branch`, `gc.session_id`, `gc.session_name`), `gc.claimed_at` can't use "differs from stored → overwrite": a live clock value always differs from any stored value, which would defeat the claim hook's compare-and-skip guard and flood `bead.updated` on every hook tick for every in-progress bead. The stamp is unconditional across control and non-control beads and isn't gated on session identity or a resolvable work branch, since a claim timestamp is meaningful for any claimed bead.

`gc.verified_at` (a related but separate lifecycle gap) is out of scope for this change — tracked separately as `dr-3msk6.11`.

## Testing

- [x] `make build`, `go vet`, lint clean
- [x] Unit tests colocated with the change (`cmd_hook_claim_claimed_at_test.go`, `cmd_hook_claim_stamp_test.go`, `cmd_hook_test.go`), covering: absent-key stamp on fresh claim, write-once no-restamp on second claim, control-bead unconditional stamp, no-session/no-worktree stamp, and non-interference with the three existing compare-and-skip keys
- [x] Mutation-tested: making the stamp unconditional fails the two write-once tests; removing the stamp fails all four — guard is load-bearing, tests are non-vacuous