### PR TITLE
fix(doctor): stop flagging bare human as a retired hold label

### DIFF
--- a/cmd/gc/doctor_hold_label_conventions.go
+++ b/cmd/gc/doctor_hold_label_conventions.go
@@ -21,16 +21,16 @@ var retiredHoldLabels = []string{
 	"blocked-on-upstream",
 	"blocked-prereq",
 	"human-hold",
-	"human",
 	"on-hold",
 }
 
 // holdLabelConventionsFixHint mirrors ga-tug8ry.1's disposition table.
-// engdocs/contributors/hold-label-conventions.md does not exist on
-// origin/main yet, so the hint must stand on its own rather than point at it.
+// Bare "human" is not a hold label (it answers who executes, not what the
+// bead is waiting on) and is intentionally absent. The hint stands on its
+// own rather than pointing at hold-label-conventions.md.
 const holdLabelConventionsFixHint = "Retired hold/blocked label in use (ga-tug8ry.1 taxonomy): " +
 	"arch-hold and blocked-prereq retire with no migration; blocked retires in favor of the " +
-	"native status field; blocked-by-operator, blocked-on-upstream, human-hold, and human " +
+	"native status field; blocked-by-operator, blocked-on-upstream, and human-hold " +
 	"migrate to hold:mayor; blocked-on-external migrates to hold:external; on-hold retires as " +
 	"already-superseded. Set a sanctioned hold label with " +
 	"'bd set-state <id> hold=mayor|external --reason \"...\"'."

--- a/cmd/gc/doctor_hold_label_conventions_test.go
+++ b/cmd/gc/doctor_hold_label_conventions_test.go
@@ -63,6 +63,55 @@ func TestHoldLabelConventionsCheckFlagsRetiredLabels(t *testing.T) {
 	}
 }
 
+func TestHoldLabelConventionsCheckBareHumanNotFlagged(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "H-1", Title: "operator card", Type: "task", Status: "open", Labels: []string{"human"}},
+		{ID: "H-2", Title: "mayor hold", Type: "task", Status: "open", Labels: []string{"hold:mayor"}},
+		{ID: "H-3", Title: "external hold", Type: "task", Status: "open", Labels: []string{"hold:external"}},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK (bare human is not a retired hold label): %#v", res.Status, res)
+	}
+	if len(res.Details) != 0 {
+		t.Errorf("Details = %v, want empty", res.Details)
+	}
+}
+
+func TestHoldLabelConventionsCheckFlagsHumanHold(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "R-1", Title: "legacy human hold", Type: "task", Status: "open", Labels: []string{"human-hold"}},
+		{ID: "H-1", Title: "operator card", Type: "task", Status: "open", Labels: []string{"human"}},
+		{ID: "H-2", Title: "mayor hold", Type: "task", Status: "open", Labels: []string{"hold:mayor"}},
+		{ID: "H-3", Title: "external hold", Type: "task", Status: "open", Labels: []string{"hold:external"}},
+	}, nil)
+
+	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })
+	res := check.Run(&doctor.CheckContext{})
+
+	if res.Status != doctor.StatusError {
+		t.Fatalf("Status = %v, want Error: %#v", res.Status, res)
+	}
+	if len(res.Details) != 1 {
+		t.Fatalf("Details = %v, want exactly 1 entry (human-hold only)", res.Details)
+	}
+	if !strings.Contains(res.Details[0], "human-hold") || !strings.Contains(res.Details[0], "R-1") {
+		t.Errorf("Details[0] = %q, want retired label human-hold on R-1", res.Details[0])
+	}
+	if strings.Contains(res.Details[0], `"human"`) {
+		t.Errorf("Details[0] = %q, must not flag bare human", res.Details[0])
+	}
+	if strings.Contains(res.FixHint, "and human migrate") || strings.Contains(res.FixHint, "human-hold, and human") {
+		t.Errorf("FixHint must not prescribe migrating bare human: %q", res.FixHint)
+	}
+	if !strings.Contains(res.FixHint, "human-hold") {
+		t.Errorf("FixHint should still mention human-hold: %q", res.FixHint)
+	}
+}
+
 func TestHoldLabelConventionsCheckOutOfScopeLabelsExactMatchOnly(t *testing.T) {
 	store := beads.NewMemStoreFrom(0, []beads.Bead{
 		{ID: "O-1", Title: "build blocker", Type: "task", Status: "open", Labels: []string{"build-blocker"}},
@@ -73,6 +122,7 @@ func TestHoldLabelConventionsCheckOutOfScopeLabelsExactMatchOnly(t *testing.T) {
 		{ID: "O-6", Title: "needs mayor", Type: "task", Status: "open", Labels: []string{"needs-mayor"}},
 		{ID: "O-7", Title: "needs mayor decision", Type: "task", Status: "open", Labels: []string{"needs-mayor-decision"}},
 		{ID: "O-8", Title: "mpr human hold", Type: "task", Status: "open", Labels: []string{"mpr-human-hold"}},
+		{ID: "O-9", Title: "bare human executor", Type: "task", Status: "open", Labels: []string{"human"}},
 	}, nil)
 
 	check := newHoldLabelConventionsCheck("/city", "city", func(string) (beads.Store, error) { return store, nil })

--- a/engdocs/contributors/hold-label-conventions.md
+++ b/engdocs/contributors/hold-label-conventions.md
@@ -73,7 +73,7 @@ worth a bug report, not a pattern to follow.
 |---|---|---|
 | `blocked-by-operator` | `hold:mayor` | "Operator" meant the human operator/mayor seat. |
 | `blocked-on-upstream` | `hold:mayor` | Means "next step in our own merge pipeline," not an external repo — despite the name, this is not a `hold:external` synonym. |
-| `human-hold`, bare `human` | `hold:mayor` | Both named the same "next actor is mayor" state as a bare label. Caution: a bare `human` label can also appear alone for an unrelated reason (a human merge/PR action needed) that is not a hold state at all — check the bead's own context before assuming `human` implies a hold. |
+| `human-hold` | `hold:mayor` | Named the "next actor is mayor" state as a bare label. Bare `human` is not a hold label — see the out-of-scope list. |
 | `blocked-on-external` | `hold:external` | Direct predecessor of `hold:external`; carry forward any `blocker_scope`/`external_blocker`/`external_pr`/`pr`/`repo` metadata unchanged. |
 | `blocked` | none — use native `status=blocked` | Redundant with the bead's own `Status` field; keeping both invites drift between them. |
 | `arch-hold` | none — owned by the `maintainer-pr-review` pack | Not a generic bd hold; it's that pack's own gate, cleared via `gc maintainer-pr-review clear-hold`. It only looked like one of ours because it lacks the `mpr-` prefix its sibling `mpr-human-hold` carries. |
@@ -83,6 +83,9 @@ worth a bug report, not a pattern to follow.
 **Explicitly out of scope — do not migrate these, they mean something
 different:**
 
+- `human` — answers "who executes this" (a human merge/PR action needed),
+  not "what is this bead waiting on." It is not a hold state. Keep
+  `human-hold` retired; that one named the hold.
 - `mpr-human-hold` and other `mpr-*` labels — owned end-to-end by the
   `maintainer-pr-review` pack, with its own metadata namespace and its own
   clearing tool. Not a generic bd hold label.


### PR DESCRIPTION
## Summary

- The hold-label conventions doctor check treated a bare `human` label as a
  retired hold synonym of `human-hold`. Bare `human` answers who executes a
  bead, not what it is waiting on.
- Two pre-existing doc statements already said this: the migration-table
  Notes caution, and the ga-tug8ry.2 skipped-bead record. The checker
  enforced the table's "Replace with" cell over both. This PR also adds
  bare `human` to the out-of-scope list; that entry did not pre-exist.
- Drop `human` from `retiredHoldLabels` and the fix hint. Keep flagging
  `human-hold`. Align the one migration-table row and list bare `human` with
  the other out-of-scope labels. `CanFix()` / `Fix()` stay a no-op.

Addresses #4837.

Reported by @jacobhausler.

## Testing

- [x] `gofmt -l cmd/gc/doctor_hold_label_conventions.go cmd/gc/doctor_hold_label_conventions_test.go` — empty (formatted)
- [x] `go vet ./cmd/gc` — exit 0
- [x] `go test -count=1 -timeout 20m -v ./cmd/gc -run 'TestHoldLabelConventions'` — PASS (8 tests, 3.457s)
- [ ] `make lint-changed LINT_CHANGED_REF=origin/main` — failed in this environment: golangci-lint was built with Go 1.25, repo targets Go 1.26.6. Pre-existing toolchain mismatch, not introduced by this change.
- [ ] `make check` — not run in full; scoped package tests above are the relevant gate
- [ ] `make check-docs` — not run; the doc change is `engdocs/`, not Mintlify `docs/`
- [ ] `make test-integration` — N/A (doctor unit check only; no runtime/controller change)

## Checklist

- [x] Linked an issue
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes — none. Live `human` labels stay as-is. `human-hold` is still retired.
