### PR TITLE
fix(controller): bump fsnotify to v1.10.1 to close Darwin FD leak

### DIFF
--- a/cmd/gc/controller_watcher_fd_test.go
+++ b/cmd/gc/controller_watcher_fd_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestWatchConfigTargets_CloseReturnsFDsToBaseline is the Darwin
+// regression for gastownhall/gascity#4504.
+//
+// gascity already calls Watcher.Close() in watchConfigTargets cleanup.
+// On Darwin, fsnotify v1.9.0 still leaked one kqueue-backed REG/DIR
+// descriptor per watched path (fsnotify#732). fsnotify#740, shipped in
+// v1.10.0, drops watches directly in Close(). This test asserts the
+// process FD count returns to the pre-watcher baseline after cleanup
+// and after a Close+NewWatcher restart — not a magic absolute threshold.
+func TestWatchConfigTargets_CloseReturnsFDsToBaseline(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: the kqueue Close() FD leak (fsnotify#732) is a Darwin/kqueue bug")
+	}
+
+	root := t.TempDir()
+	const nDirs = 40
+	targets := make([]config.WatchTarget, 0, nDirs)
+	for i := 0; i < nDirs; i++ {
+		p := filepath.Join(root, fmt.Sprintf("d%02d", i))
+		if err := os.Mkdir(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		targets = append(targets, config.WatchTarget{Path: p})
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+
+	baseline := countProcessFDs(t)
+	cleanup := watchConfigTargets(targets, &dirty, pokeCh, &stderr)
+	afterAdd := countProcessFDs(t)
+	held := afterAdd - baseline
+	if held < nDirs/2 {
+		t.Fatalf("watcher did not hold a measurable number of FDs (baseline=%d afterAdd=%d held=%d dirs=%d); test is not probing the leak; stderr=%q",
+			baseline, afterAdd, held, nDirs, stderr.String())
+	}
+
+	cleanup()
+	afterClose := waitForFDCountNear(t, baseline)
+	residual := afterClose - baseline
+	if residual > fdCountNoise {
+		t.Fatalf("FD count did not return to baseline after Watcher.Close(): baseline=%d afterAdd=%d afterClose=%d held=%d residual=%d; stderr=%q",
+			baseline, afterAdd, afterClose, held, residual, stderr.String())
+	}
+
+	// Supervisor reload path: Close then NewWatcher. Generation 2 must not
+	// inherit leaked FDs from generation 1.
+	restartBaseline := countProcessFDs(t)
+	cleanup2 := watchConfigTargets(targets, &dirty, pokeCh, &stderr)
+	afterAdd2 := countProcessFDs(t)
+	held2 := afterAdd2 - restartBaseline
+	if held2 < nDirs/2 {
+		cleanup2()
+		t.Fatalf("restarted watcher did not hold a measurable number of FDs (restartBaseline=%d afterAdd2=%d held2=%d); stderr=%q",
+			restartBaseline, afterAdd2, held2, stderr.String())
+	}
+	cleanup2()
+	afterClose2 := waitForFDCountNear(t, restartBaseline)
+	residual2 := afterClose2 - restartBaseline
+	if residual2 > fdCountNoise {
+		t.Fatalf("FD count did not return to baseline after watcher restart: restartBaseline=%d afterAdd2=%d afterClose2=%d held2=%d residual2=%d; stderr=%q",
+			restartBaseline, afterAdd2, afterClose2, held2, residual2, stderr.String())
+	}
+}
+
+// fdCountNoise is slack for FDs the Go runtime or test harness may open
+// while the test runs (not a leak threshold on the watch set). The
+// assertion is still return-to-baseline: residual must stay far below
+// the watcher's own held-while-open count.
+const fdCountNoise = 8
+
+func waitForFDCountNear(t *testing.T, baseline int) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var n int
+	for {
+		n = countProcessFDs(t)
+		if n-baseline <= fdCountNoise {
+			return n
+		}
+		if time.Now().After(deadline) {
+			return n
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func countProcessFDs(t *testing.T) int {
+	t.Helper()
+	n := 0
+	for fd := 0; fd < 10240; fd++ {
+		var st syscall.Stat_t
+		if err := syscall.Fstat(fd, &st); err == nil {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/gc/controller_watcher_fd_test.go
+++ b/cmd/gc/controller_watcher_fd_test.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -53,7 +52,7 @@ func TestWatchConfigTargets_CloseReturnsFDsToBaseline(t *testing.T) {
 	}
 
 	cleanup()
-	afterClose := waitForFDCountNear(t, baseline)
+	afterClose := countProcessFDs(t)
 	residual := afterClose - baseline
 	if residual > fdCountNoise {
 		t.Fatalf("FD count did not return to baseline after Watcher.Close(): baseline=%d afterAdd=%d afterClose=%d held=%d residual=%d; stderr=%q",
@@ -72,7 +71,7 @@ func TestWatchConfigTargets_CloseReturnsFDsToBaseline(t *testing.T) {
 			restartBaseline, afterAdd2, held2, stderr.String())
 	}
 	cleanup2()
-	afterClose2 := waitForFDCountNear(t, restartBaseline)
+	afterClose2 := countProcessFDs(t)
 	residual2 := afterClose2 - restartBaseline
 	if residual2 > fdCountNoise {
 		t.Fatalf("FD count did not return to baseline after watcher restart: restartBaseline=%d afterAdd2=%d afterClose2=%d held2=%d residual2=%d; stderr=%q",
@@ -84,23 +83,18 @@ func TestWatchConfigTargets_CloseReturnsFDsToBaseline(t *testing.T) {
 // while the test runs (not a leak threshold on the watch set). The
 // assertion is still return-to-baseline: residual must stay far below
 // the watcher's own held-while-open count.
+//
+// It also absorbs the two descriptors fsnotify tears down asynchronously.
+// The cleanup returned by watchConfigTargets is synchronous for everything
+// this test measures: it closes done, waits on registrationWG, calls
+// watcher.Close(), then blocks on <-eventLoopDone. fsnotify v1.10.1's
+// kqueue Close() unix.Close()es every watch descriptor inline before
+// returning (fsnotify#740) -- those are the ~nDirs FDs the leak was about,
+// so they are already released when cleanup() returns and the count needs
+// no settling wait. Only w.kq and w.closepipe[0] are closed later, in the
+// readEvents goroutine's defer, and that is at most 2 FDs against this
+// slack of 8.
 const fdCountNoise = 8
-
-func waitForFDCountNear(t *testing.T, baseline int) int {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	var n int
-	for {
-		n = countProcessFDs(t)
-		if n-baseline <= fdCountNoise {
-			return n
-		}
-		if time.Now().After(deadline) {
-			return n
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-}
 
 func countProcessFDs(t *testing.T) int {
 	t.Helper()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/danielgtaylor/huma/v2 v2.37.3
-	github.com/fsnotify/fsnotify v1.9.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-sql-driver/mysql v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d h1:I20T52WM8FGFgEGDGfmzVds0ZS73M3tc8GYB/Cy25vk=


### PR DESCRIPTION
## Summary

- On Darwin, recycling the supervisor config watcher leaked one kqueue-backed
  REG/DIR descriptor per watched path. `watchConfigTargets` already calls
  `Watcher.Close()` after registration goroutines finish
  (`cmd/gc/controller.go`); the leak is in fsnotify v1.9.0 itself
  (fsnotify/fsnotify#732).
- fsnotify v1.10.0 fixed this: "kqueue: drop watches directly in Close() to
  fix a file descriptor leak when recycling watchers" (fsnotify/fsnotify#740).
  This PR bumps `github.com/fsnotify/fsnotify` from v1.9.0 to v1.10.1. `go mod
  tidy` did not pull unrelated module upgrades.
- Adds a Darwin-only regression next to the existing `watchConfigTargets`
  tests: process FD count must return to the pre-watcher baseline after
  Close, and after a Close+NewWatcher restart. Non-Darwin platforms skip.

Addresses #4504.

Reported by @brettinternet. Independent reproduction and descriptor-numbering
evidence (kqueue replaced, REG/DIR FDs retained) from @atbrace.

## Testing

- [x] `gofmt -l cmd/gc/controller_watcher_fd_test.go` — empty (formatted)
- [x] `go vet ./cmd/gc ./internal/api` — exit 0
- [x] Darwin in-process fsnotify probe, 41 watched dirs, `syscall.Fstat` FD
      count:
      - v1.9.0: `baseline_fds=7 after_add=51 after_close=49 held_while_open=44 leaked_after_close=42`
      - v1.10.1: `baseline_fds=7 after_add=51 after_close=9 held_while_open=44 leaked_after_close=2`
- [x] `go test -count=1 -timeout 10m ./cmd/gc -run TestWatchConfigTargets_CloseReturnsFDsToBaseline -v` — PASS (0.03s)
- [x] `go test -count=1 -timeout 20m ./cmd/gc -run 'TestWatchConfigDirs|TestWatchConfigTargets|TestCityRuntimeReloadRestartsConfigWatcher'` — PASS (8.344s)
- [x] `go test -count=1 -timeout 10m ./internal/api -run 'TestLogFileWatcher'` — PASS (4.048s)
- [ ] `make check` — not run in full; scoped watcher/logwatcher tests above
      are the relevant gate
- [ ] `make check-docs` — N/A (no docs/ navigation change)
- [ ] `make test-integration` — not run; no supervisor lifecycle redesign
- [ ] `make lint-changed` / `golangci-lint` — not run. Local golangci-lint
      2.12.2 is built with Go 1.26.2; the repo targets Go 1.26.6. Pre-existing
      toolchain mismatch, not introduced by this change.

## Checklist

- [x] Linked an issue
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — none; dependency bump + regression
- [x] Called out breaking changes or migration notes — none. fsnotify v1.10.1
      requires Go 1.23+; gascity already requires Go 1.26.6.