### PR TITLE
fix(dispatch): trust pinned checks across pack upgrades

### DIFF
--- a/internal/config/historical_cache_trust.go
+++ b/internal/config/historical_cache_trust.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/pathutil"
+)
+
+// TrustedHistoricalFormulaCacheRoots returns historical cache roots that are
+// equivalent to roots derived from the city's currently trusted formula
+// layers. It fails closed: malformed lockfiles, non-canonical cache paths,
+// dirty checkouts, unrelated repositories, and different pack subpaths all
+// produce no roots.
+//
+// A running workflow retains the absolute asset path resolved when its formula
+// was materialized. Pack upgrades move the current formula layer to another
+// content-addressed cache directory, but the old checkout remains immutable.
+// This resolver admits that old path only when the candidate cache key binds
+// the same locked source to its checked-out commit and the path maps to the
+// same relative formula/asset root as an active layer.
+func TrustedHistoricalFormulaCacheRoots(cityRoot, candidatePath string, formulaSearchPaths []string) []string {
+	if strings.TrimSpace(cityRoot) == "" || !filepath.IsAbs(candidatePath) {
+		return nil
+	}
+	cacheRoot, err := GlobalRepoCacheRoot()
+	if err != nil {
+		return nil
+	}
+	candidateCache, candidateKey, ok := repoCacheEntryForPath(cacheRoot, candidatePath)
+	if !ok {
+		return nil
+	}
+
+	lockData, err := os.ReadFile(filepath.Join(cityRoot, "packs.lock"))
+	if err != nil {
+		return nil
+	}
+	var lock remoteImportLockfile
+	if _, err := toml.Decode(string(lockData), &lock); err != nil {
+		return nil
+	}
+
+	var candidateCommit string
+	if err := WithRepoCacheReadLock(cacheRoot, func() error {
+		var readErr error
+		candidateCommit, readErr = runRepoCacheGit(candidateCache, "rev-parse", "HEAD")
+		return readErr
+	}); err != nil {
+		return nil
+	}
+	candidateCommit = strings.ToLower(strings.TrimSpace(candidateCommit))
+	if !isFullGitObjectID(candidateCommit) {
+		return nil
+	}
+
+	for source, entry := range lock.Packs {
+		if strings.TrimSpace(entry.Commit) == "" || candidateKey != RepoCacheKey(source, candidateCommit) {
+			continue
+		}
+		activeCache := filepath.Join(cacheRoot, RepoCacheKey(source, entry.Commit))
+		roots := equivalentHistoricalRoots(activeCache, candidateCache, candidatePath, formulaSearchPaths)
+		if len(roots) == 0 {
+			continue
+		}
+		if err := validateInstalledRemoteCacheLocked(source, cacheRoot, activeCache, entry.Commit); err != nil {
+			return nil
+		}
+		if !validateHistoricalCandidate(source, cacheRoot, candidateCache, candidateCommit, candidatePath) {
+			return nil
+		}
+		return roots
+	}
+	return nil
+}
+
+func validateHistoricalCandidate(source, cacheRoot, cacheDir, commit, candidatePath string) bool {
+	rel, err := filepath.Rel(cacheDir, candidatePath)
+	if err != nil || rel == "." || pathutil.IsOutsideDir(rel) {
+		return false
+	}
+	return WithRepoCacheReadLock(cacheRoot, func() error {
+		// Historical caches are dormant rather than actively pinned. Revalidate
+		// them on every execution instead of using the current-cache memo: a
+		// nested file edit can leave both the cache root and index fingerprint
+		// unchanged after an earlier successful validation.
+		if err := validateInstalledRemoteCache(source, cacheDir, commit); err != nil {
+			return err
+		}
+		_, err := runRepoCacheGit(cacheDir, "ls-files", "--error-unmatch", "--", filepath.ToSlash(rel))
+		return err
+	}) == nil
+}
+
+func repoCacheEntryForPath(cacheRoot, candidatePath string) (cacheDir, key string, ok bool) {
+	cacheRoot = filepath.Clean(cacheRoot)
+	candidatePath = filepath.Clean(candidatePath)
+	if !pathutil.PathWithin(cacheRoot, candidatePath) {
+		return "", "", false
+	}
+	rel, err := filepath.Rel(cacheRoot, candidatePath)
+	if err != nil || rel == "." || pathutil.IsOutsideDir(rel) {
+		return "", "", false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) < 2 || !isLowerHex(parts[0], 64) {
+		return "", "", false
+	}
+	cacheDir = filepath.Join(cacheRoot, parts[0])
+	if !pathutil.PathWithin(cacheDir, candidatePath) {
+		return "", "", false
+	}
+	return cacheDir, parts[0], true
+}
+
+func equivalentHistoricalRoots(activeCache, candidateCache, candidatePath string, formulaSearchPaths []string) []string {
+	var roots []string
+	add := func(relativeRoot string) {
+		root := filepath.Join(candidateCache, relativeRoot)
+		if !pathutil.PathWithin(root, candidatePath) {
+			return
+		}
+		for _, existing := range roots {
+			if pathutil.SamePath(existing, root) {
+				return
+			}
+		}
+		roots = append(roots, root)
+	}
+	for _, formulaPath := range formulaSearchPaths {
+		formulaPath = strings.TrimSpace(formulaPath)
+		if formulaPath == "" || !pathutil.PathWithin(activeCache, formulaPath) {
+			continue
+		}
+		rel, err := filepath.Rel(activeCache, filepath.Clean(formulaPath))
+		if err != nil || pathutil.IsOutsideDir(rel) {
+			continue
+		}
+		add(rel)
+		add(filepath.Join(filepath.Dir(rel), "assets"))
+		if filepath.Base(rel) == "formulas" {
+			add(filepath.Dir(rel))
+		}
+	}
+	return roots
+}
+
+func isFullGitObjectID(value string) bool {
+	return isLowerHex(value, 40) || isLowerHex(value, 64)
+}
+
+func isLowerHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	for _, c := range value {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/config/historical_cache_trust_test.go
+++ b/internal/config/historical_cache_trust_test.go
@@ -1,0 +1,212 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestTrustedHistoricalFormulaCacheRootsAllowsSameSourceUpgrade(t *testing.T) {
+	fixture := newHistoricalTrustFixture(t, "", "", "")
+	fixture.stubGit(t)
+	roots := TrustedHistoricalFormulaCacheRoots(fixture.cityRoot, fixture.checkPath, []string{fixture.activeFormulas})
+	if !pathWithinAnyTestRoot(fixture.checkPath, roots) {
+		t.Fatalf("historical same-source check path was not trusted; roots=%v", roots)
+	}
+}
+
+func TestTrustedHistoricalFormulaCacheRootsRejectsUnsafeHistory(t *testing.T) {
+	tests := []struct {
+		name              string
+		candidateSource   string
+		candidateKey      string
+		candidatePackPath string
+		activeStatus      string
+		historyStatus     string
+		removeHistoryGit  bool
+		malformedLock     bool
+		untrackedCheck    bool
+	}{
+		{
+			name:            "unrelated repository",
+			candidateSource: "https://github.com/attacker/other.git//packs/review",
+		},
+		{
+			name:              "different pack subpath in same repository",
+			candidatePackPath: filepath.Join("packs", "other", "assets", "scripts", "checks", "unit-fast.sh"),
+		},
+		{
+			name:         "malformed cache key",
+			candidateKey: "not-a-canonical-cache-key",
+		},
+		{
+			name:          "dirty historical checkout",
+			historyStatus: " M assets/scripts/checks/unit-fast.sh",
+		},
+		{
+			name:         "dirty active checkout",
+			activeStatus: " M formulas/review.toml",
+		},
+		{
+			name:             "missing historical git metadata",
+			removeHistoryGit: true,
+		},
+		{
+			name:          "malformed city lockfile",
+			malformedLock: true,
+		},
+		{
+			name:           "untracked historical check",
+			untrackedCheck: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newHistoricalTrustFixture(t, tt.candidateSource, tt.candidateKey, tt.candidatePackPath)
+			fixture.activeStatus = tt.activeStatus
+			fixture.historyStatus = tt.historyStatus
+			fixture.untrackedCheck = tt.untrackedCheck
+			if tt.removeHistoryGit {
+				if err := os.RemoveAll(filepath.Join(fixture.historyCache, ".git")); err != nil {
+					t.Fatalf("remove historical .git: %v", err)
+				}
+			}
+			if tt.malformedLock {
+				writeTestFile(t, fixture.cityRoot, "packs.lock", "[packs\n")
+			}
+			fixture.stubGit(t)
+
+			roots := TrustedHistoricalFormulaCacheRoots(fixture.cityRoot, fixture.checkPath, []string{fixture.activeFormulas})
+			if len(roots) != 0 {
+				t.Fatalf("unsafe historical path received trusted roots: %v", roots)
+			}
+		})
+	}
+}
+
+func TestTrustedHistoricalFormulaCacheRootsRevalidatesHistoricalCheckout(t *testing.T) {
+	fixture := newHistoricalTrustFixture(t, "", "", "")
+	fixture.stubGit(t)
+
+	first := TrustedHistoricalFormulaCacheRoots(fixture.cityRoot, fixture.checkPath, []string{fixture.activeFormulas})
+	if !pathWithinAnyTestRoot(fixture.checkPath, first) {
+		t.Fatalf("initial clean historical checkout was not trusted; roots=%v", first)
+	}
+	fixture.historyStatus = " M packs/review/assets/scripts/checks/unit-fast.sh"
+	second := TrustedHistoricalFormulaCacheRoots(fixture.cityRoot, fixture.checkPath, []string{fixture.activeFormulas})
+	if len(second) != 0 {
+		t.Fatalf("dirty historical checkout bypassed trust through a cached validation: %v", second)
+	}
+}
+
+type historicalTrustFixture struct {
+	cityRoot       string
+	currentCommit  string
+	historyCommit  string
+	activeCache    string
+	historyCache   string
+	activeFormulas string
+	checkPath      string
+	activeStatus   string
+	historyStatus  string
+	untrackedCheck bool
+}
+
+func newHistoricalTrustFixture(t *testing.T, candidateSource, candidateKey, candidatePackPath string) *historicalTrustFixture {
+	t.Helper()
+	const (
+		source        = "https://github.com/example/workflows.git//packs/review"
+		currentCommit = "1111111111111111111111111111111111111111"
+		historyCommit = "2222222222222222222222222222222222222222"
+	)
+	if candidateSource == "" {
+		candidateSource = source
+	}
+	if candidateKey == "" {
+		candidateKey = RepoCacheKey(candidateSource, historyCommit)
+	}
+	if candidatePackPath == "" {
+		candidatePackPath = filepath.Join("packs", "review", "assets", "scripts", "checks", "unit-fast.sh")
+	}
+	root := t.TempDir()
+	gcHome := filepath.Join(root, "gc-home")
+	t.Setenv("GC_HOME", gcHome)
+	cityRoot := filepath.Join(root, "city")
+	cacheRoot := filepath.Join(gcHome, "cache", "repos")
+	activeCache := filepath.Join(cacheRoot, RepoCacheKey(source, currentCommit))
+	historyCache := filepath.Join(cacheRoot, candidateKey)
+	activeFormulas := filepath.Join(activeCache, "packs", "review", "formulas")
+	checkPath := filepath.Join(historyCache, candidatePackPath)
+	for _, dir := range []string{
+		cityRoot,
+		filepath.Join(activeCache, ".git"),
+		activeFormulas,
+		filepath.Join(historyCache, ".git"),
+		filepath.Dir(checkPath),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeTestFile(t, cityRoot, "packs.lock", fmt.Sprintf(`
+schema = 1
+
+[packs.%q]
+commit = %q
+`, source, currentCommit))
+	writeTestFile(t, filepath.Dir(checkPath), filepath.Base(checkPath), "#!/bin/sh\nexit 0\n")
+	return &historicalTrustFixture{
+		cityRoot:       cityRoot,
+		currentCommit:  currentCommit,
+		historyCommit:  historyCommit,
+		activeCache:    activeCache,
+		historyCache:   historyCache,
+		activeFormulas: activeFormulas,
+		checkPath:      checkPath,
+	}
+}
+
+func (f *historicalTrustFixture) stubGit(t *testing.T) {
+	t.Helper()
+	previousRunGit := runRepoCacheGit
+	runRepoCacheGit = func(dir string, args ...string) (string, error) {
+		if slices.Equal(args, []string{"rev-parse", "HEAD"}) {
+			switch dir {
+			case f.activeCache:
+				return f.currentCommit, nil
+			case f.historyCache:
+				return f.historyCommit, nil
+			}
+		}
+		if slices.Equal(args, []string{"status", "--porcelain"}) {
+			switch dir {
+			case f.activeCache:
+				return f.activeStatus, nil
+			case f.historyCache:
+				return f.historyStatus, nil
+			}
+		}
+		if len(args) == 4 && slices.Equal(args[:3], []string{"ls-files", "--error-unmatch", "--"}) && dir == f.historyCache {
+			if f.untrackedCheck {
+				return "", fmt.Errorf("path is not tracked")
+			}
+			return args[3], nil
+		}
+		return "", fmt.Errorf("unexpected git call in %s: %v", dir, args)
+	}
+	t.Cleanup(func() {
+		runRepoCacheGit = previousRunGit
+		ResetRemoteCacheValidationCache()
+	})
+}
+
+func pathWithinAnyTestRoot(path string, roots []string) bool {
+	for _, root := range roots {
+		if pathWithinDir(path, root) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -261,6 +261,13 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	// tree even when the script lives in the city tree.
 	trustedAbsRoots := ralphCheckTrustedAbsoluteRoots(cityPath, storePath, opts.FormulaSearchPaths)
 	if filepath.IsAbs(checkPath) && !pathWithinAny(checkPath, trustedAbsRoots) {
+		resolveHistoricalRoots := opts.historicalFormulaCacheRoots
+		if resolveHistoricalRoots == nil {
+			resolveHistoricalRoots = config.TrustedHistoricalFormulaCacheRoots
+		}
+		trustedAbsRoots = append(trustedAbsRoots, resolveHistoricalRoots(cityPath, checkPath, opts.FormulaSearchPaths)...)
+	}
+	if filepath.IsAbs(checkPath) && !pathWithinAny(checkPath, trustedAbsRoots) {
 		return convergence.GateResult{}, fmt.Errorf("%s: absolute gc.check_path %q escapes trusted roots", bead.ID, checkPath)
 	}
 	scriptPath, err := convergence.ResolveConditionPath(cityPath, scriptBase, checkPath)

--- a/internal/dispatch/ralph_check_asset_test.go
+++ b/internal/dispatch/ralph_check_asset_test.go
@@ -97,6 +97,58 @@ path = "../assets/scripts/checks/review-approved.sh"
 	}
 }
 
+func TestRunRalphCheckAcceptsHistoricalRootResolvedByPackTrust(t *testing.T) {
+	tmp := t.TempDir()
+	cityPath := filepath.Join(tmp, "city")
+	storePath := filepath.Join(tmp, "store")
+	historicalAssets := filepath.Join(tmp, "cache", "historical", "assets")
+	for _, dir := range []string{cityPath, storePath, filepath.Join(historicalAssets, "scripts", "checks")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	checkPath := filepath.Join(historicalAssets, "scripts", "checks", "unit-fast.sh")
+	if err := os.WriteFile(checkPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check: %v", err)
+	}
+	activeFormulas := filepath.Join(tmp, "cache", "active", "formulas")
+	resolverCalled := false
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-historical-pack",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    checkPath,
+			"gc.check_timeout": "30s",
+		},
+	}
+
+	result, err := runRalphCheck(store, check, beads.Bead{ID: "run-historical-pack", Type: "task"}, 1, ProcessOptions{
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: []string{activeFormulas},
+		historicalFormulaCacheRoots: func(gotCity, gotCandidate string, gotFormulaPaths []string) []string {
+			resolverCalled = true
+			if gotCity != cityPath || gotCandidate != checkPath {
+				t.Fatalf("resolver args city=%q candidate=%q, want %q and %q", gotCity, gotCandidate, cityPath, checkPath)
+			}
+			if len(gotFormulaPaths) != 1 || gotFormulaPaths[0] != activeFormulas {
+				t.Fatalf("resolver formula paths=%v, want [%s]", gotFormulaPaths, activeFormulas)
+			}
+			return []string{historicalAssets}
+		},
+	})
+	if err != nil {
+		t.Fatalf("historical same-pack check path should be accepted: %v", err)
+	}
+	if !resolverCalled {
+		t.Fatal("historical cache trust resolver was not called")
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("outcome = %q, want %q; stderr=%q", result.Outcome, convergence.GatePass, result.Stderr)
+	}
+}
+
 // A resolved asset path must still be rejected when its layer is NOT among the
 // trusted FormulaSearchPaths — confirming the feature widens trust only to the
 // formula layers actually in play, not to arbitrary absolute paths.

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -41,9 +41,13 @@ type ProcessOptions struct {
 	CityPath           string
 	StorePath          string
 	FormulaSearchPaths []string
-	PrepareFragment    func(*formula.FragmentRecipe, beads.Bead) error
-	PrepareRecipe      func(*formula.Recipe, beads.Bead) error
-	RecycleSession     func(beads.Bead) error
+	// historicalFormulaCacheRoots is the test seam for resolving cache roots
+	// retained by in-flight workflows across pack upgrades. Production callers
+	// use config.TrustedHistoricalFormulaCacheRoots.
+	historicalFormulaCacheRoots func(cityRoot, candidatePath string, formulaSearchPaths []string) []string
+	PrepareFragment             func(*formula.FragmentRecipe, beads.Bead) error
+	PrepareRecipe               func(*formula.Recipe, beads.Bead) error
+	RecycleSession              func(beads.Bead) error
 	// RequiredArtifactStat checks required-artifact files. When nil, the
 	// dispatcher uses os.Stat.
 	RequiredArtifactStat func(path string) (os.FileInfo, error)


### PR DESCRIPTION
## Summary

- keep exec checks from already-materialized workflows runnable after their pack is upgraded
- admit historical cache paths only for the same locked repository and equivalent pack-relative formula/asset root
- freshly validate the historical checkout and require the exact check file to be tracked
- preserve rejection of unrelated caches, sibling pack subpaths, dirty checkouts, malformed keys, untracked files, and symlink escapes

## Production reproduction

A graph workflow materialized an absolute `gc.check_path` from a content-addressed pack cache. After the city advanced that pack pin, the control dispatcher trusted only the new `FormulaSearchPaths` and quarantined the still-valid in-flight check as escaping trusted roots. The same condition reproduced across a second pack upgrade while the workflow remained open.

## Live verification

- exercised the resolver against the real historical `da4ecf3` fab-pack cache and the later locked `67f2042` cache; it admitted only the equivalent historical assets/pack roots
- installed a local integration build containing this commit plus the independent workflow-anchor fix from #5474
- the supported supervisor drift restart preserved sessions and reached `startup.ready=true` on build `8f068a12e`
- post-restart snapshot: 20 active sessions, 16 in-progress Trader workflows, 12 Trader closes in 10 minutes, and no new trusted-root quarantine, 429, quota, panic, or fatal signal
- the original quarantined control bead had already been force-finalized as changes-required before installation, so closed workflow history was not reopened or rewritten for a synthetic replay

## Tests

- RED/GREEN regression for same-source historical trust
- fail-closed security matrix for unrelated source, different pack subpath, malformed cache key/lockfile, missing Git metadata, dirty active/history checkout, and untracked check files
- stale validation-cache regression proving historical cleanliness is rechecked every execution
- dispatch coordination test plus existing unrelated-cache and symlink-escape regressions
- `go test -count=10` focused config/dispatch tests
- `go test ./internal/config ./internal/dispatch`
- resource census ledger
- `make fmt-check`
- `make lint` (0 issues)
- `make vet`
- mandatory pre-push fast suite: all ten jobs passed, including all six `cmd/gc` shards and the repository-wide core package sweep

Draft pending maintainer review.