### PR TITLE
fix(test-harness): stop leaking managed dolt servers on uncleanly-killed runs

### DIFF
--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -483,6 +483,33 @@ func TestIsStaleCmdGCTestConfigPathSkipsLegacyUnownedRoot(t *testing.T) {
 	}
 }
 
+// A dolt server whose config sits under a Go t.TempDir() root
+// (Test<Name><rand>/...) with the config file gone from disk is the
+// signature of a run killed before its reap ran (timeout, panic, SIGKILL):
+// TestMain's cleanup removed the temp root while the server lived on
+// (observed 2026-08-21: 242 such servers accumulated over five weeks and
+// exhausted a host's gascity-test.slice pids quota). The gone config marks
+// it stale; a config still on disk marks a live concurrent run.
+func TestIsStaleCmdGCTestConfigPathReapsAbandonedGoTempDirRoot(t *testing.T) {
+	tempParent := t.TempDir()
+
+	goneConfig := filepath.Join(tempParent, "TestAbandoned1234", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if !isStaleCmdGCTestConfigPath(goneConfig, nil, tempParent) {
+		t.Fatalf("abandoned go tempdir config path %q (file gone) not classified as stale", goneConfig)
+	}
+
+	liveConfig := filepath.Join(tempParent, "TestLive1234", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if err := os.MkdirAll(filepath.Dir(liveConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveConfig, []byte("listener:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isStaleCmdGCTestConfigPath(liveConfig, nil, tempParent) {
+		t.Fatalf("live go tempdir config path %q (file on disk) classified as stale", liveConfig)
+	}
+}
+
 // TestSnapshotDoltProcessPIDs_EnumeratorErrorIsFatal pins that a
 // discovery error is reported via Fatalf so test runs surface
 // enumeration failures directly rather than silently treating them

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -1198,7 +1198,9 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 	go func() { done <- cmd.Wait() }()
 
 	signals := make(chan os.Signal, 2)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	// SIGQUIT included so a `go test -timeout` signal wave reaching the
+	// watchdog still tears the dolt server down instead of orphaning it.
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	defer signal.Stop(signals)
 
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -456,7 +456,11 @@ func isAbandonedGoTempDirConfigPath(configPath, tempParent string) bool {
 	if _, ok := activeTestRootUnder(filepath.Clean(configPath), filepath.Clean(tempParent), []string{"Test"}); !ok {
 		return false
 	}
-	_, err := os.Stat(configPath)
+	// Bounded like statConfigPathState: configPath comes from an arbitrary
+	// host process's argv and may sit on a hung NFS/FUSE mount. A timeout
+	// returns ctx.Err() rather than ErrNotExist, so a stuck mount degrades
+	// to "not stale" (protect) instead of wedging the startup sweep.
+	_, err := statWithTimeout(configPath)
 	return errors.Is(err, os.ErrNotExist)
 }
 

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -448,10 +448,12 @@ func isStaleCmdGCTestConfigPathWithPIDCheck(configPath string, activeRoots []str
 
 // isAbandonedGoTempDirConfigPath classifies configs under a Go t.TempDir()
 // root (Test<Name><rand>/...) that carry no gct<pid>-/gcx<pid>- owner
-// component. Those appear when a run dies uncleanly (timeout, panic,
-// SIGKILL): TestMain's temp-root cleanup removes the config from disk while
-// the dolt server lives on. The missing config file is the stale signal —
-// a concurrent live run keeps its config on disk until its servers stop.
+// component. Those appear when the config is removed from disk while the
+// dolt server lives on: TestMain's temp-root cleanup on an uncleanly-ended
+// run (timeout or panic), or an external temp wipe (harness/CI/
+// systemd-tmpfiles) after a SIGKILL that TestMain cannot trap. The missing
+// config file is the stale signal — a concurrent live run keeps its config
+// on disk until its servers stop.
 func isAbandonedGoTempDirConfigPath(configPath, tempParent string) bool {
 	if _, ok := activeTestRootUnder(filepath.Clean(configPath), filepath.Clean(tempParent), []string{"Test"}); !ok {
 		return false

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -308,7 +308,10 @@ func (g *doltLeakGuardedTestingM) waitForFinalScanToClear(
 func (g *doltLeakGuardedTestingM) installSignalHandler() func() {
 	signals := make(chan os.Signal, 2)
 	done := make(chan struct{})
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	// SIGQUIT is what `go test -timeout` raises on a hung shard (see
+	// dolttest.Guard, which handles it for the same reason): without it the
+	// binary dies before reaping and every managed dolt server leaks.
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		select {
 		case sig := <-signals:
@@ -438,9 +441,23 @@ func isStaleCmdGCTestConfigPathWithPIDCheck(configPath string, activeRoots []str
 	}
 	ownerPID, ok := cmdGCTestConfigOwnerPID(configPath, tempParent)
 	if !ok {
-		return false
+		return isAbandonedGoTempDirConfigPath(configPath, tempParent)
 	}
 	return !pidAliveFn(ownerPID)
+}
+
+// isAbandonedGoTempDirConfigPath classifies configs under a Go t.TempDir()
+// root (Test<Name><rand>/...) that carry no gct<pid>-/gctshard<pid>- owner
+// component. Those appear when a run dies uncleanly (timeout, panic,
+// SIGKILL): TestMain's temp-root cleanup removes the config from disk while
+// the dolt server lives on. The missing config file is the stale signal —
+// a concurrent live run keeps its config on disk until its servers stop.
+func isAbandonedGoTempDirConfigPath(configPath, tempParent string) bool {
+	if _, ok := activeTestRootUnder(filepath.Clean(configPath), filepath.Clean(tempParent), []string{"Test"}); !ok {
+		return false
+	}
+	_, err := os.Stat(configPath)
+	return errors.Is(err, os.ErrNotExist)
 }
 
 func cmdGCTestConfigOwnerPID(configPath string, tempParent string) (int, bool) {

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -447,7 +447,7 @@ func isStaleCmdGCTestConfigPathWithPIDCheck(configPath string, activeRoots []str
 }
 
 // isAbandonedGoTempDirConfigPath classifies configs under a Go t.TempDir()
-// root (Test<Name><rand>/...) that carry no gct<pid>-/gctshard<pid>- owner
+// root (Test<Name><rand>/...) that carry no gct<pid>-/gcx<pid>- owner
 // component. Those appear when a run dies uncleanly (timeout, panic,
 // SIGKILL): TestMain's temp-root cleanup removes the config from disk while
 // the dolt server lives on. The missing config file is the stale signal —

--- a/scripts/lib/test-slice.sh
+++ b/scripts/lib/test-slice.sh
@@ -17,6 +17,12 @@
 
 GC_TEST_SLICE_UNIT="gascity-test.slice"
 
+# Per-run task cap: half the slice-wide TasksMax hosts typically provision
+# (16384). Bounds the blast radius of one leaky or runaway run — without
+# it, accumulated leaks from a single scope can exhaust the slice quota
+# and fork-reject every later test run. Override per host via env.
+: "${GC_TEST_SLICE_TASKS_MAX:=8192}"
+
 # Test seam: the self-test overrides the cgroup membership probe with a
 # fixture file because /proc/self/cgroup cannot be faked.
 : "${GC_TEST_SLICE_CGROUP_FILE:=/proc/self/cgroup}"
@@ -48,6 +54,7 @@ gc_test_slice_should_wrap() {
   # real command to it (containers and stale sessions can pass the checks
   # above yet fail systemd-run). Fall back to plain execution otherwise.
   systemd-run --user --slice="$GC_TEST_SLICE_UNIT" --scope --collect --quiet \
+    --property=TasksMax="$GC_TEST_SLICE_TASKS_MAX" \
     -- true >/dev/null 2>&1 || return 1
 }
 
@@ -58,7 +65,8 @@ gc_test_slice_should_wrap() {
 gc_test_slice_reexec() {
   if gc_test_slice_should_wrap; then
     GC_TEST_SLICE_ENROLLED=1 exec systemd-run --user \
-      --slice="$GC_TEST_SLICE_UNIT" --scope --collect --quiet -- "$@"
+      --slice="$GC_TEST_SLICE_UNIT" --scope --collect --quiet \
+      --property=TasksMax="$GC_TEST_SLICE_TASKS_MAX" -- "$@"
   fi
   return 0
 }

--- a/scripts/test-slice-enroll-test
+++ b/scripts/test-slice-enroll-test
@@ -172,6 +172,7 @@ run_entry() {
   local name="$1" cgroup_file="$2"
   shift 2
   if ! out="$(env -u GC_TEST_NO_SLICE -u GC_TEST_SLICE_ENROLLED \
+    -u GC_TEST_SLICE_TASKS_MAX \
     PATH="$scen_bin" \
     GC_TEST_SLICE_CGROUP_FILE="$cgroup_file" \
     "$@" \

--- a/scripts/test-slice-enroll-test
+++ b/scripts/test-slice-enroll-test
@@ -192,7 +192,7 @@ expect_log_lines() {
   fi
 }
 
-probe_args="--user --slice=gascity-test.slice --scope --collect --quiet -- true"
+probe_args="--user --slice=gascity-test.slice --scope --collect --quiet --property=TasksMax=8192 -- true"
 
 # Scenario: explicit opt-out runs plain without touching systemd at all.
 new_scenario opt-out
@@ -258,7 +258,7 @@ expect_log_lines wrap "$sdr_log" 2
 if [[ "$(head -n1 "$sdr_log")" != "$probe_args" ]]; then
   fail "wrap: unexpected probe args: $(head -n1 "$sdr_log")"
 fi
-want_wrap_args="--user --slice=gascity-test.slice --scope --collect --quiet -- $entry alpha beta"
+want_wrap_args="--user --slice=gascity-test.slice --scope --collect --quiet --property=TasksMax=8192 -- $entry alpha beta"
 if [[ "$(sed -n 2p "$sdr_log")" != "$want_wrap_args" ]]; then
   fail "wrap: unexpected wrap args: $(sed -n 2p "$sdr_log")"
 fi


### PR DESCRIPTION
## Why

Leaked test `dolt sql-server`s (~57 threads each) accumulate whenever a `cmd/gc` test run dies uncleanly. Observed 2026-08-21: 242 of them built up over 5 weeks on one host and exhausted its `gascity-test.slice` pids quota (16384) — from then on every fork in the test slice was rejected and all subsequent test runs failed.

Root cause: `go test -timeout` raises **SIGQUIT**, but the `cmd/gc` dolt leak guard and the test watchdog only handled SIGINT/SIGTERM (`test/dolttest`'s Guard already handles SIGQUIT for exactly this reason — `cmd/gc` never got the same fix). The timed-out binary dies before `reapManagedDoltTestProcesses()` runs; the servers reparent to PID 1 and nothing ever reaps them, because the startup sweep's matcher only recognises `gct<pid>-`/`gctshard<pid>-` roots, not Go `t.TempDir()` roots.

## What

- **SIGQUIT handling** in the `cmd/gc` leak guard (`path_helpers_test.go`) and the managed-dolt test watchdog (`dolt_start_managed.go`), mirroring `dolttest.Guard`: timed-out shards now reap their servers before dying.
- **Self-healing sweep**: the startup sweep also reaps servers whose config sits under a Go `t.TempDir()` root (`Test*/...`) with the config file gone from disk — the signature of a run killed before its reap ran (SIGKILL/panic). A concurrent live run keeps its config on disk, so it is never touched. Pinned legacy-unowned-root behavior is unchanged (existing test still passes).
- **Blast radius**: `test-slice.sh` enrolls test scopes with `--property=TasksMax=8192` (half the slice quota hosts typically provision), so one leaky run can no longer starve the slice for every later run. `scripts/test-slice-enroll-test` expectations updated.

## Verified

- `go vet ./cmd/gc` clean; `go test ./cmd/gc -run 'TestIsStaleCmdGCTestConfigPath|TestManagedDoltSQLServerSysProcAttr'` passes (new test `TestIsStaleCmdGCTestConfigPathReapsAbandonedGoTempDirRoot` covers gone-config = stale, on-disk config = live).
- `go test ./scripts` passes; shellcheck clean on `test-slice.sh`.

Companion infra change (host reaper patterns + per-scope TasksMax in `gc-test-run`): gascity/infra#1547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)