### PR TITLE
fix(beads): stop city endpoint changes hard-failing on an uninitialized inherited rig (ga-5k989)

### DIFF
--- a/cmd/gc/cmd_beads_city.go
+++ b/cmd/gc/cmd_beads_city.go
@@ -205,7 +205,7 @@ func doBeadsCityEndpoint(fs fsys.FS, cityPath string, opts cityEndpointOptions, 
 		fmt.Fprintf(stderr, "%s: snapshot canonical files: %v\n", name, err) //nolint:errcheck
 		return 1
 	}
-	if err := ensureCanonicalScopeMetadataIfPresent(fs, cityPath); err != nil {
+	if err := requireCanonicalizedScopeMetadata(fs, cityPath); err != nil {
 		writeCityEndpointRollbackError(fs, stderr, snapshots, name, "canonicalizing metadata", err)
 		return 1
 	}
@@ -217,7 +217,7 @@ func doBeadsCityEndpoint(fs fsys.FS, cityPath string, opts cityEndpointOptions, 
 		if !plan.Update {
 			continue
 		}
-		if err := ensureCanonicalScopeMetadataIfPresent(fs, plan.Rig.Path); err != nil {
+		if err := canonicalizeScopeMetadataIfPresent(fs, plan.Rig.Path); err != nil {
 			writeCityEndpointRollbackError(fs, stderr, snapshots, name, "canonicalizing inherited rig metadata", err)
 			return 1
 		}

--- a/cmd/gc/cmd_beads_city_test.go
+++ b/cmd/gc/cmd_beads_city_test.go
@@ -573,6 +573,106 @@ func TestDoBeadsCityUseExternalPreservesCompatOnlyExplicitRigs(t *testing.T) {
 	}
 }
 
+// TestDoBeadsCityUseExternalToleratesUninitializedInheritedRig is the ga-5k989
+// regression: a city endpoint change swept an inherited rig that carries no
+// .beads/metadata.json and hard-failed on it, so every controller start of a
+// city with such a rig exited 1 and crash-looped with no recovery path. An
+// inherited rig the city has never initialized is not a reason to refuse to
+// reconfigure the city, and the rigs that DO have canonical metadata must still
+// be canonicalized in the same run.
+func TestDoBeadsCityUseExternalToleratesUninitializedInheritedRig(t *testing.T) {
+	for name, uninitialized := range map[string]func(t *testing.T) string{
+		// The shape that killed fresh-03479: the rig root itself is gone
+		// (a /tmp path that did not survive the pod replacement) while the
+		// city's persisted config still registers it.
+		"rig root vanished": func(t *testing.T) string {
+			t.Helper()
+			return filepath.Join(t.TempDir(), "adopt")
+		},
+		// The rig root is there but was never `bd init`ed.
+		"rig root present but never initialized": func(t *testing.T) string {
+			t.Helper()
+			dir := filepath.Join(t.TempDir(), "adopt")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			return dir
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("GC_BEADS", "bd")
+
+			cityDir := t.TempDir()
+			readyDir := filepath.Join(t.TempDir(), "frontend")
+			if err := os.MkdirAll(readyDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			uninitializedDir := uninitialized(t)
+
+			writeCityEndpointCityConfigWithCompat(t, cityDir, config.DoltConfig{Host: "old-city.example.com", Port: 3306}, []config.Rig{
+				{Name: "frontend", Path: readyDir, Prefix: "fe"},
+				{Name: "adopt", Path: uninitializedDir, Prefix: "ad"},
+			})
+			writeRigEndpointMetadata(t, cityDir, "hq")
+			writeRigEndpointMetadata(t, readyDir, "fe")
+			writeRigEndpointCanonicalConfig(t, cityDir, contract.ConfigState{IssuePrefix: "gc", EndpointOrigin: contract.EndpointOriginCityCanonical, EndpointStatus: contract.EndpointStatusVerified, DoltHost: "old-city.example.com", DoltPort: "3306"})
+			writeRigEndpointCanonicalConfig(t, readyDir, contract.ConfigState{IssuePrefix: "fe", EndpointOrigin: contract.EndpointOriginInheritedCity, EndpointStatus: contract.EndpointStatusVerified, DoltHost: "old-city.example.com", DoltPort: "3306"})
+
+			var stdout, stderr bytes.Buffer
+			code := doBeadsCityEndpoint(fsys.OSFS{}, cityDir, cityEndpointOptions{External: true, Host: "db.example.com", Port: "4406", User: "city-user", AdoptUnverified: true}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("doBeadsCityEndpoint() = %d, want 0; stderr = %s", code, stderr.String())
+			}
+
+			cityState := readRigEndpointConfigState(t, cityDir)
+			if cityState.EndpointOrigin != contract.EndpointOriginCityCanonical || cityState.DoltHost != "db.example.com" || cityState.DoltPort != "4406" {
+				t.Fatalf("city state = %+v", cityState)
+			}
+			readyState := readRigEndpointConfigState(t, readyDir)
+			if readyState.EndpointOrigin != contract.EndpointOriginInheritedCity || readyState.DoltHost != "db.example.com" || readyState.DoltPort != "4406" || readyState.DoltUser != "city-user" {
+				t.Fatalf("initialized rig was not canonicalized alongside the skipped one: %+v", readyState)
+			}
+			if got := readCityEndpointRigCompat(t, cityDir, "frontend"); got.DoltHost != "db.example.com" || got.DoltPort != "4406" {
+				t.Fatalf("frontend city.toml rig compat = %+v", got)
+			}
+			if _, err := os.Stat(filepath.Join(uninitializedDir, ".beads", "metadata.json")); !os.IsNotExist(err) {
+				t.Fatalf("an uninitialized rig must not gain a fabricated metadata.json, stat err = %v", err)
+			}
+		})
+	}
+}
+
+// TestDoBeadsCityUseExternalRejectsUnusableInheritedRigMetadata is the control
+// for the skip above. A metadata.json that exists but pins no dolt_database is
+// a misconfigured store, not an uninitialized one: it must still be fatal, or
+// the ga-5k989 fix would swallow a real topology error.
+func TestDoBeadsCityUseExternalRejectsUnusableInheritedRigMetadata(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	cityDir := t.TempDir()
+	brokenDir := filepath.Join(t.TempDir(), "adopt")
+	if err := os.MkdirAll(filepath.Join(brokenDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(brokenDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeCityEndpointCityConfigWithCompat(t, cityDir, config.DoltConfig{Host: "old-city.example.com", Port: 3306}, []config.Rig{{Name: "adopt", Path: brokenDir, Prefix: "ad"}})
+	writeRigEndpointMetadata(t, cityDir, "hq")
+	writeRigEndpointCanonicalConfig(t, cityDir, contract.ConfigState{IssuePrefix: "gc", EndpointOrigin: contract.EndpointOriginCityCanonical, EndpointStatus: contract.EndpointStatusVerified, DoltHost: "old-city.example.com", DoltPort: "3306"})
+	writeRigEndpointCanonicalConfig(t, brokenDir, contract.ConfigState{IssuePrefix: "ad", EndpointOrigin: contract.EndpointOriginInheritedCity, EndpointStatus: contract.EndpointStatusVerified, DoltHost: "old-city.example.com", DoltPort: "3306"})
+
+	var stdout, stderr bytes.Buffer
+	code := doBeadsCityEndpoint(fsys.OSFS{}, cityDir, cityEndpointOptions{External: true, Host: "db.example.com", Port: "4406", AdoptUnverified: true}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doBeadsCityEndpoint() = %d, want 1; stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing pinned dolt_database") {
+		t.Fatalf("stderr = %q, want the unusable-metadata diagnosis", stderr.String())
+	}
+}
+
 func TestDoBeadsCityUseExternalAdoptUnverifiedSkipsValidation(t *testing.T) {
 	skipSlowCmdGCTest(t, "exercises managed bd provider transition behavior; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -127,7 +127,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 	}
 	if strings.TrimSpace(rig.Path) == "" {
 		// Unbound rig: the downstream helpers join paths against rig.Path
-		// (snapshotRigEndpointFiles, ensureCanonicalScopeMetadataIfPresent,
+		// (snapshotRigEndpointFiles, requireCanonicalizedScopeMetadata,
 		// syncRigManagedPortArtifact, etc.). Empty rig.Path would produce
 		// relative `.beads/...` writes under the current working directory
 		// instead of erroring cleanly.
@@ -187,7 +187,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		fmt.Fprintf(stderr, "gc rig set-endpoint: snapshot canonical files: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := ensureCanonicalScopeMetadataIfPresent(fs, rig.Path); err != nil {
+	if err := requireCanonicalizedScopeMetadata(fs, rig.Path); err != nil {
 		writeRigEndpointRollbackError(fs, stderr, snapshots, "canonicalizing metadata", err)
 		return 1
 	}
@@ -363,29 +363,30 @@ func requireCanonicalScopeMetadata(fs fsys.FS, scopeRoot string) error {
 	return nil
 }
 
-// ensureCanonicalScopeMetadataIfPresent canonicalizes an existing scope's
-// metadata to server mode, for the endpoint commands (`gc rig set-endpoint`,
-// `gc beads city use-managed`/`use-external`).
+// requireCanonicalizedScopeMetadata canonicalizes to server mode the metadata of
+// the scope an endpoint command is reconfiguring: the rig named by
+// `gc rig set-endpoint <rig>`, and the city's own scope in
+// `gc beads city use-managed`/`use-external`.
+//
+// That scope must already carry a usable .beads/metadata.json. It is the store
+// whose topology the operator asked to rewrite, so an absent or unpinned file
+// means there is nothing to rewrite, and the command fails rather than invent a
+// store the operator never initialized.
 //
 // It announces the mode change for the same reason ensureCanonicalScopeMetadata
 // does: this is the identical rewrite through a different door, and a warning
 // that depends on which command performed the flip is a warning an operator
 // cannot rely on.
-func ensureCanonicalScopeMetadataIfPresent(fs fsys.FS, scopeRoot string) error {
-	path := filepath.Join(scopeRoot, ".beads", "metadata.json")
-	doltDatabase, err := func() (string, error) {
-		if err := requireCanonicalScopeMetadata(fs, scopeRoot); err != nil {
-			return "", err
-		}
-		doltDatabase, _, err := contract.ReadDoltDatabase(fs, path)
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(doltDatabase), nil
-	}()
+func requireCanonicalizedScopeMetadata(fs fsys.FS, scopeRoot string) error {
+	if err := requireCanonicalScopeMetadata(fs, scopeRoot); err != nil {
+		return err
+	}
+	path := scopeMetadataPath(scopeRoot)
+	doltDatabase, _, err := contract.ReadDoltDatabase(fs, path)
 	if err != nil {
 		return err
 	}
+	doltDatabase = strings.TrimSpace(doltDatabase)
 	announceStorageModeChange(fs, path, "server", doltDatabase)
 	_, err = contract.EnsureCanonicalMetadata(fs, path, contract.MetadataState{
 		Database:     "dolt",
@@ -394,6 +395,30 @@ func ensureCanonicalScopeMetadataIfPresent(fs fsys.FS, scopeRoot string) error {
 		DoltDatabase: doltDatabase,
 	})
 	return err
+}
+
+// canonicalizeScopeMetadataIfPresent is requireCanonicalizedScopeMetadata for a
+// scope the operator did not name: the inherited rigs a city endpoint change
+// sweeps along. A rig registered with the city but never initialized has no
+// .beads/metadata.json, and that is not a reason to refuse to reconfigure the
+// city — hard-failing there took down every start of a city carrying such a rig,
+// with no recovery path (ga-5k989).
+//
+// Absent means absent, and nothing else. A metadata.json that exists but pins no
+// dolt_database is a misconfigured store rather than an uninitialized one, and
+// still fails: the skip must not become a way to lose a real topology error.
+func canonicalizeScopeMetadataIfPresent(fs fsys.FS, scopeRoot string) error {
+	if _, err := fs.Stat(scopeMetadataPath(scopeRoot)); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return requireCanonicalizedScopeMetadata(fs, scopeRoot)
+}
+
+func scopeMetadataPath(scopeRoot string) string {
+	return filepath.Join(scopeRoot, ".beads", "metadata.json")
 }
 
 func syncRigManagedPortArtifact(cityPath, rigPath string, cityState, rigState contract.ConfigState) error {

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -213,7 +213,7 @@ func TestDoRigSetEndpointInheritWritesManagedInheritedRigConfig(t *testing.T) {
 	}
 }
 
-func TestEnsureCanonicalScopeMetadataIfPresentPreservesExistingManagedProbeDatabase(t *testing.T) {
+func TestRequireCanonicalizedScopeMetadataPreservesExistingManagedProbeDatabase(t *testing.T) {
 	scopeDir := t.TempDir()
 	metadataPath := filepath.Join(scopeDir, ".beads", "metadata.json")
 	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o700); err != nil {
@@ -227,8 +227,8 @@ func TestEnsureCanonicalScopeMetadataIfPresentPreservesExistingManagedProbeDatab
 	}); err != nil {
 		t.Fatalf("EnsureCanonicalMetadata: %v", err)
 	}
-	if err := ensureCanonicalScopeMetadataIfPresent(fsys.OSFS{}, scopeDir); err != nil {
-		t.Fatalf("ensureCanonicalScopeMetadataIfPresent: %v", err)
+	if err := requireCanonicalizedScopeMetadata(fsys.OSFS{}, scopeDir); err != nil {
+		t.Fatalf("requireCanonicalizedScopeMetadata: %v", err)
 	}
 	got, ok, err := contract.ReadDoltDatabase(fsys.OSFS{}, metadataPath)
 	if err != nil {
@@ -237,6 +237,52 @@ func TestEnsureCanonicalScopeMetadataIfPresentPreservesExistingManagedProbeDatab
 	if !ok || got != strings.ToUpper(managedDoltProbeDatabase) {
 		t.Fatalf("dolt_database = %q, ok=%v; want existing reserved name preserved", got, ok)
 	}
+}
+
+// TestCanonicalizeScopeMetadataIfPresentSkipsOnlyAbsentMetadata pins the split
+// the ga-5k989 fix rests on: absent means skip, and every other reason the
+// metadata cannot be canonicalized still errors.
+func TestCanonicalizeScopeMetadataIfPresentSkipsOnlyAbsentMetadata(t *testing.T) {
+	t.Run("absent metadata is not an error and fabricates nothing", func(t *testing.T) {
+		scopeDir := filepath.Join(t.TempDir(), "never-initialized")
+		if err := canonicalizeScopeMetadataIfPresent(fsys.OSFS{}, scopeDir); err != nil {
+			t.Fatalf("canonicalizeScopeMetadataIfPresent: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(scopeDir, ".beads", "metadata.json")); !os.IsNotExist(err) {
+			t.Fatalf("skipping a scope must not write its metadata, stat err = %v", err)
+		}
+	})
+
+	t.Run("metadata without a pinned dolt_database still errors", func(t *testing.T) {
+		scopeDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(scopeDir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(scopeDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		err := canonicalizeScopeMetadataIfPresent(fsys.OSFS{}, scopeDir)
+		if err == nil || !strings.Contains(err.Error(), "missing pinned dolt_database") {
+			t.Fatalf("canonicalizeScopeMetadataIfPresent error = %v, want missing pinned dolt_database", err)
+		}
+	})
+
+	t.Run("present metadata is canonicalized exactly as the named scope is", func(t *testing.T) {
+		scopeDir := t.TempDir()
+		metadataPath := filepath.Join(scopeDir, ".beads", "metadata.json")
+		if err := os.MkdirAll(filepath.Dir(metadataPath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(metadataPath, []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := canonicalizeScopeMetadataIfPresent(fsys.OSFS{}, scopeDir); err != nil {
+			t.Fatalf("canonicalizeScopeMetadataIfPresent: %v", err)
+		}
+		if mode := readScopeDoltMode(t, scopeDir); mode != "server" {
+			t.Fatalf("dolt_mode = %q, want server", mode)
+		}
+	})
 }
 
 func TestDoRigSetEndpointInheritMirrorsExternalCity(t *testing.T) {

--- a/cmd/gc/storage_mode_rewrite_test.go
+++ b/cmd/gc/storage_mode_rewrite_test.go
@@ -193,17 +193,23 @@ func TestTheStorageModeAnnouncementNamesARecoveryThatSURVIVESTheNextBoot(t *test
 // per-command warning always has.
 //
 // `gc rig set-endpoint` and `gc beads city use-managed`/`use-external` reach
-// their own canonicalizer (ensureCanonicalScopeMetadataIfPresent in
-// cmd_rig_endpoint.go) rather than the init one, and they perform the identical
-// embedded→server rewrite. A warning that depends on which command the operator
-// happened to run is a warning nobody can rely on.
+// their own canonicalizers (requireCanonicalizedScopeMetadata for the scope the
+// command names, canonicalizeScopeMetadataIfPresent for the inherited rigs a
+// city endpoint change sweeps along, both in cmd_rig_endpoint.go) rather than
+// the init one, and they perform the identical embedded→server rewrite. A
+// warning that depends on which command the operator happened to run — or on
+// which of the two endpoint doors the scope arrived through — is a warning
+// nobody can rely on.
 func TestEveryDoorThatFlipsTheStorageModeAnnouncesIt(t *testing.T) {
 	for name, canonicalize := range map[string]func(scope string) error{
 		"init path": func(scope string) error {
 			return ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, scope, "jc")
 		},
-		"endpoint path": func(scope string) error {
-			return ensureCanonicalScopeMetadataIfPresent(fsys.OSFS{}, scope)
+		"endpoint path, named scope": func(scope string) error {
+			return requireCanonicalizedScopeMetadata(fsys.OSFS{}, scope)
+		},
+		"endpoint path, inherited rig": func(scope string) error {
+			return canonicalizeScopeMetadataIfPresent(fsys.OSFS{}, scope)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pathdurability/durability.go
+++ b/internal/pathdurability/durability.go
@@ -62,10 +62,12 @@ const (
 
 // ephemeralFilesystems maps a superblock magic to the name shown to operators.
 //
-// tmpfs covers /tmp on a systemd host, /dev/shm, and every Kubernetes emptyDir.
-// overlayfs covers the container rootfs, which is what makes an in-pod path
-// like /var/tmp ephemeral even though it is not /tmp — the reason a prefix
-// denylist cannot do this job.
+// tmpfs covers /tmp on a systemd host, /dev/shm, and a Kubernetes emptyDir
+// declared with medium: Memory. A default emptyDir is a kubelet-host directory
+// bind-mounted into the pod, so statfs reports the host filesystem instead and
+// it lands in OtherDevice — warned about, not refused. overlayfs covers the
+// container rootfs, which is what makes an in-pod path like /var/tmp ephemeral
+// even though it is not /tmp — the reason a prefix denylist cannot do this job.
 var ephemeralFilesystems = map[uint32]string{
 	magicTmpfs:     "tmpfs",
 	magicRamfs:     "ramfs",


### PR DESCRIPTION
Fixes ga-5k989. Also fixes root cause #1 of ga-yc5rc.

## The bug

`ensureCanonicalScopeMetadataIfPresent` was named "IfPresent" but had require
semantics: its first act was to call `requireCanonicalScopeMetadata`, which
returns `missing canonical metadata <path>` when `.beads/metadata.json` does not
exist. One of its three callers is the loop over a city's *inherited rig plans*,
so a single rig registered with the city but never initialized made every
`gc beads city use-external` / `use-managed` fail:

```
gc beads city use-external: canonicalizing inherited rig metadata: missing canonical metadata /tmp/adopt/.beads/metadata.json
```

exitCode 1 at controller startup -> CrashLoopBackOff with no recovery path
(ga-hnle2). It killed city `fresh-03479` (ga-5k989) and, with
`/workspace/aprig/.beads/metadata.json`, `gc-controller/controller-2053b66b9f7f03d87b37a865`
over 186 restarts (ga-yc5rc root cause #1).

## The three call sites and their policies

| Call site | Scope | Policy |
| --- | --- | --- |
| `cmd/gc/cmd_rig_endpoint.go` `doRigSetEndpoint` | the rig named by `gc rig set-endpoint <rig>` | **fails closed** — unchanged |
| `cmd/gc/cmd_beads_city.go:208` | the city's own store | **fails closed** — unchanged; the city is the scope being reconfigured |
| `cmd/gc/cmd_beads_city.go:220` | each *inherited* rig plan | **skips when metadata.json is absent** — this was the defect |

The first two now call `requireCanonicalizedScopeMetadata` (renamed, behaviour
byte-identical to today). The third calls the new
`canonicalizeScopeMetadataIfPresent`, which `Stat`s the path and returns `nil`
only on `errors.Is(err, os.ErrNotExist)` — no string matching — and otherwise
delegates to the require variant.

Absent means absent and nothing else. A metadata.json that *exists* but pins no
`dolt_database` is a misconfigured store, not an uninitialized one, and still
fails. `requireCanonicalScopeMetadata` itself is untouched.

The rename is deliberate: reusing the old name would have let a caller keep the
wrong policy silently. Renaming forced the compiler to surface all five call
sites (3 production, 2 test).

## Test evidence

These tests are the point of the PR, so here is proof they discriminate rather
than an assertion that they do.

### 1. Before the fix — new test is RED with the production message

```
=== RUN   TestDoBeadsCityUseExternalToleratesUninitializedInheritedRig/rig_root_vanished
    cmd_beads_city_test.go:624: doBeadsCityEndpoint() = 1, want 0; stderr = rig "adopt" still declares path in city.toml; ...
        gc beads city use-external: canonicalizing inherited rig metadata: missing canonical metadata /data/tmp/.../003/adopt/.beads/metadata.json
--- FAIL: TestDoBeadsCityUseExternalToleratesUninitializedInheritedRig (0.13s)
    --- FAIL: .../rig_root_vanished (0.10s)
    --- FAIL: .../rig_root_present_but_never_initialized (0.03s)
=== RUN   TestDoBeadsCityUseExternalRejectsUnusableInheritedRigMetadata
--- PASS: TestDoBeadsCityUseExternalRejectsUnusableInheritedRigMetadata (0.03s)
```

The failure message is byte-identical to the one from the ga-5k989 incident. The
malformed-metadata control already passed pre-fix, as expected — that path fails
closed today and must keep doing so.

### 2. After the fix, revert ONLY the production change, keep the tests — RED again

```
--- FAIL: TestDoBeadsCityUseExternalToleratesUninitializedInheritedRig (0.08s)
    --- FAIL: .../rig_root_vanished: doBeadsCityEndpoint() = 1, want 0; ... canonicalizing inherited rig metadata: missing canonical metadata .../adopt/.beads/metadata.json
    --- FAIL: .../rig_root_present_but_never_initialized
--- FAIL: TestCanonicalizeScopeMetadataIfPresentSkipsOnlyAbsentMetadata/absent_metadata_is_not_an_error_and_fabricates_nothing
    cmd_rig_endpoint_test.go:249: canonicalizeScopeMetadataIfPresent: missing canonical metadata .../never-initialized/.beads/metadata.json
```

### 3. Make the skip too broad (swallow every Stat error) — the controls catch it

```
--- FAIL: TestDoBeadsCityUseExternalRejectsUnusableInheritedRigMetadata (0.01s)
    cmd_beads_city_test.go:669: doBeadsCityEndpoint() = 0, want 1; ...
--- FAIL: TestCanonicalizeScopeMetadataIfPresentSkipsOnlyAbsentMetadata/metadata_without_a_pinned_dolt_database_still_errors
    cmd_rig_endpoint_test.go:266: canonicalizeScopeMetadataIfPresent error = <nil>, want missing pinned dolt_database
```

### 4. With the fix — GREEN

```
go test ./cmd/gc/ -run 'RigEndpoint|CanonicalMetadata|StorageModeRewrite|BeadsCity|CanonicalizeScopeMetadata|EveryDoorThatFlips' -count=1
ok  	github.com/gastownhall/gascity/cmd/gc	2.889s
```

`TestDoRigSetEndpointRequiresCanonicalMetadata` is untouched and green — the
named-scope door still fails closed.

The new tests deliberately do **not** call `skipSlowCmdGCTest`, so they run in the
default fast suite instead of becoming a check that cannot fail.

## Also

`TestEveryDoorThatFlipsTheStorageModeAnnouncesIt` grew from 2 table entries to 3
(`init path`, `endpoint path, named scope`, `endpoint path, inherited rig`), so
the announce guarantee now covers both endpoint doors rather than one.

## Gates

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l cmd/gc/` — clean
- `make test-fast-parallel` — All fast jobs passed (10 jobs, all 6 `cmd/gc` shards)
- `make test-cmd-gc-process-parallel` — all 6 `cmd-gc-process` shards ok. The
  `productmetrics-testhook` job fails, but it fails identically on the unmodified
  base commit `be633d9c37` in a disposable worktree, so it is pre-existing and
  unrelated (this change touches no startup or pack-discovery path):
  `TestProductMetricsTaggedBinaryProcessContracts/control_flow_bypasses_city_and_pack_state: gc help exceeded process deadline`
- pre-commit hook ran (`core.hooksPath` = `.githooks`): `lint-changed: ./cmd/gc  0 issues.`

## Note on branch base

This branch was cut from the worktree's HEAD, which carries two commits not yet
on `origin/main` (`be633d9c37`, `89426fa3ab`). They ride along in this PR.
