### PR TITLE
fix(session): recognize unique alias owner as canonical

### DIFF
--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -372,6 +372,7 @@ func lookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec, incl
 	candidates := make([]beads.Bead, 0, 4)
 	seen := make(map[string]bool)
 	var runtimeSessionNameMatches []beads.Bead
+	var aliasMatches []beads.Bead
 
 	if spec.Identity != "" {
 		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, NamedSessionIdentityMetadata, spec.Identity)
@@ -407,18 +408,24 @@ func lookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec, incl
 		}
 	}
 
+	if spec.Identity != "" {
+		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, "alias", spec.Identity)
+		if err != nil {
+			return ConfiguredNamedSessionLookup{}, fmt.Errorf("listing alias-matching named session candidates: %w", err)
+		}
+		aliasMatches = matches
+		candidates = appendUniqueNamedSessionCandidates(candidates, seen, matches)
+		if bead, ok := FindCanonicalNamedSessionBead(candidates, spec); ok {
+			return ConfiguredNamedSessionLookup{Canonical: bead, HasCanonical: true}, nil
+		}
+	}
+
 	if !includeConflict {
 		return ConfiguredNamedSessionLookup{}, nil
 	}
 
 	conflictCandidates := append([]beads.Bead{}, runtimeSessionNameMatches...)
-	if spec.Identity != "" {
-		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, "alias", spec.Identity)
-		if err != nil {
-			return ConfiguredNamedSessionLookup{}, fmt.Errorf("listing alias conflicts: %w", err)
-		}
-		conflictCandidates = appendUniqueNamedSessionCandidates(conflictCandidates, make(map[string]bool, len(conflictCandidates)+len(matches)), matches)
-	}
+	conflictCandidates = appendUniqueNamedSessionCandidates(conflictCandidates, make(map[string]bool, len(conflictCandidates)+len(aliasMatches)), aliasMatches)
 	if bead, conflict := FindNamedSessionConflict(conflictCandidates, spec); conflict {
 		return ConfiguredNamedSessionLookup{Conflict: bead, HasConflict: true}, nil
 	}
@@ -583,6 +590,31 @@ func FindCanonicalNamedSessionInfo(candidates []Info, spec NamedSessionSpec) (In
 			return i, true
 		}
 	}
+	// Mirrors the alias-based pass in FindCanonicalNamedSessionBead: gated by
+	// NamedSessionInfoMatchesSpec (the backing-template check) and unique
+	// among only the template-matching alias candidates.
+	if identity != "" {
+		var aliasCanonical Info
+		aliasMatchCount := 0
+		for _, i := range candidates {
+			if !IsSessionBeadOrRepairableInfo(i) || i.Closed || !NamedSessionInfoContinuityEligible(i) {
+				continue
+			}
+			if !NamedSessionInfoMatchesSpec(i, spec) {
+				continue
+			}
+			if strings.TrimSpace(i.Alias) != identity {
+				continue
+			}
+			aliasMatchCount++
+			if aliasMatchCount == 1 {
+				aliasCanonical = i
+			}
+		}
+		if aliasMatchCount == 1 {
+			return aliasCanonical, true
+		}
+	}
 	return Info{}, false
 }
 
@@ -673,6 +705,41 @@ func FindCanonicalNamedSessionBead(candidates []beads.Bead, spec NamedSessionSpe
 		sn := strings.TrimSpace(b.Metadata["session_name"])
 		if sn == spec.SessionName || sn == identity {
 			return b, true
+		}
+	}
+	// A bead whose only configured-named-session signal is `alias == identity`
+	// (no exact configured_named_identity/session_name metadata) is its own
+	// canonical session when it is the sole live, eligible, template-matching
+	// candidate. Gating on NamedSessionBeadMatchesSpec -- the same backing-
+	// template check pass two already requires -- keeps an unrelated bead that
+	// merely has alias set to the reserved identity, with no corroborating
+	// template/agent_name signal, from being promoted here (ga-4of1nc); it
+	// falls through to the existing conflict detection instead, which still
+	// flags it unconditionally. Requiring uniqueness among only the
+	// template-matching alias candidates -- not a bare sole-live-candidate
+	// count -- keeps a true collision (two distinct live beads that both
+	// genuinely match the backing template) falling through to conflict
+	// detection instead of one silently winning as first-match.
+	if identity != "" {
+		var aliasCanonical beads.Bead
+		aliasMatchCount := 0
+		for _, b := range candidates {
+			if !IsSessionBeadOrRepairable(b) || b.Status == "closed" || !NamedSessionContinuityEligible(b) {
+				continue
+			}
+			if !NamedSessionBeadMatchesSpec(b, spec) {
+				continue
+			}
+			if strings.TrimSpace(b.Metadata["alias"]) != identity {
+				continue
+			}
+			aliasMatchCount++
+			if aliasMatchCount == 1 {
+				aliasCanonical = b
+			}
+		}
+		if aliasMatchCount == 1 {
+			return aliasCanonical, true
 		}
 	}
 	return beads.Bead{}, false

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -714,3 +714,176 @@ func TestNamedSessionResolutionCandidates_NilStore(t *testing.T) {
 		t.Fatalf("got %v, want nil for nil store", got)
 	}
 }
+
+// The following tests pin the ga-1ycmli regression: a live session bead whose
+// only configured-named-session signal is `alias == identity` (no exact
+// configured_named_identity/session_name metadata) must resolve as its own
+// canonical session, not as a conflict with itself. See ga-89kxkd.
+
+func TestFindCanonicalNamedSessionBead_AliasSoleLiveCandidateIsCanonical(t *testing.T) {
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	candidates := []beads.Bead{
+		{
+			ID:     "alias-only",
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"alias": spec.Identity,
+			},
+		},
+	}
+
+	bead, ok := FindCanonicalNamedSessionBead(candidates, spec)
+	if !ok {
+		t.Fatal("FindCanonicalNamedSessionBead() = not found, want the sole alias-matching live bead recognized as canonical")
+	}
+	if bead.ID != "alias-only" {
+		t.Fatalf("FindCanonicalNamedSessionBead().ID = %q, want %q", bead.ID, "alias-only")
+	}
+}
+
+func TestFindCanonicalNamedSessionBead_AliasMatchNotPromotedWithSecondLiveCandidate(t *testing.T) {
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	candidates := []beads.Bead{
+		{
+			ID:     "alias-a",
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"alias": spec.Identity,
+			},
+		},
+		{
+			ID:     "alias-b",
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"alias": spec.Identity,
+			},
+		},
+	}
+
+	if bead, ok := FindCanonicalNamedSessionBead(candidates, spec); ok {
+		t.Fatalf("FindCanonicalNamedSessionBead() = %q, want no canonical winner between two live alias-matching beads", bead.ID)
+	}
+	if conflict, ok := FindNamedSessionConflict(candidates, spec); !ok {
+		t.Fatal("FindNamedSessionConflict() = not found, want the unresolved alias collision still surfaced as a conflict")
+	} else if conflict.ID != "alias-a" {
+		t.Fatalf("FindNamedSessionConflict().ID = %q, want %q", conflict.ID, "alias-a")
+	}
+}
+
+func TestFindCanonicalNamedSessionInfo_AliasSoleLiveCandidateIsCanonical(t *testing.T) {
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	b := beads.Bead{
+		ID:     "alias-only",
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias": spec.Identity,
+		},
+	}
+
+	info, ok := FindCanonicalNamedSessionInfo([]Info{infoFromPersistedBead(b)}, spec)
+	if !ok {
+		t.Fatal("FindCanonicalNamedSessionInfo() = not found, want the sole alias-matching live Info recognized as canonical")
+	}
+	if info.ID != "alias-only" {
+		t.Fatalf("FindCanonicalNamedSessionInfo().ID = %q, want %q", info.ID, "alias-only")
+	}
+}
+
+func TestFindCanonicalNamedSessionInfo_AliasMatchNotPromotedWithSecondLiveCandidate(t *testing.T) {
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	beadsIn := []beads.Bead{
+		{
+			ID:     "alias-a",
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"alias": spec.Identity,
+			},
+		},
+		{
+			ID:     "alias-b",
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"alias": spec.Identity,
+			},
+		},
+	}
+	infos := make([]Info, len(beadsIn))
+	for i, b := range beadsIn {
+		infos[i] = infoFromPersistedBead(b)
+	}
+
+	if info, ok := FindCanonicalNamedSessionInfo(infos, spec); ok {
+		t.Fatalf("FindCanonicalNamedSessionInfo() = %q, want no canonical winner between two live alias-matching Infos", info.ID)
+	}
+	if conflict, ok := FindNamedSessionConflictInfo(infos, spec); !ok {
+		t.Fatal("FindNamedSessionConflictInfo() = not found, want the unresolved alias collision still surfaced as a conflict")
+	} else if conflict.ID != "alias-a" {
+		t.Fatalf("FindNamedSessionConflictInfo().ID = %q, want %q", conflict.ID, "alias-a")
+	}
+}
+
+// TestLookupConfiguredNamedSession_AliasOnlyLiveBeadResolvesCanonical pins the
+// mayor's literal ga-1ycmli repro end-to-end through the real store-backed
+// entry point gc mail send depends on: (1) no live session bead yet for the
+// configured alias resolves empty, (2) once the session's bead exists with
+// only `alias` set (no exact canonical metadata), the lookup must recognize
+// it as its own canonical session rather than reporting a conflict against
+// itself.
+func TestLookupConfiguredNamedSession_AliasOnlyLiveBeadResolvesCanonical(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+
+	before, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession(before): %v", err)
+	}
+	if before.HasCanonical || before.HasConflict {
+		t.Fatalf("lookup before session start = %+v, want empty result", before)
+	}
+
+	live, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias": spec.Identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(live): %v", err)
+	}
+
+	after, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession(after): %v", err)
+	}
+	if after.HasConflict {
+		t.Fatalf("lookup after session start reported a conflict with its own bead %q, want no conflict", after.Conflict.ID)
+	}
+	if !after.HasCanonical {
+		t.Fatal("lookup after session start = no canonical, want the live alias-only bead recognized as its own session")
+	}
+	if after.Canonical.ID != live.ID {
+		t.Fatalf("Canonical.ID = %q, want %q", after.Canonical.ID, live.ID)
+	}
+}

--- a/release-gates/ga-rcroz7-named-session-alias-canonical-gate.md
+++ b/release-gates/ga-rcroz7-named-session-alias-canonical-gate.md
@@ -119,6 +119,43 @@ failure_attribution: TestHumaBinary_CityCreateAsync -> ga-lpfjhc + ga-6bnc42 + e
 waiver_ref: ga-cqq3hs standing tracked-failure authorization; ga-6bnc42 beads#4566 authorization; mayor-2026-08-20-herdr-pane-standing
 ```
 
+## Pre-push Hook Evidence
+
+The first guarded push of gate commit
+`a28611688cadbb697fa8b14baf691f3f94f72497` ran the repository's 10-job fast
+matrix. Nine jobs passed; `unit-core` failed on two tracked tests outside the
+candidate subsystem. The push itself was rejected and nothing reached the
+remote on that attempt.
+
+- FAIL — WAIVED: `TestProviderLiveClaudeKindPath` repeated the exact
+  `agent_pane_busy` / startup-delivery timeout signature already tracked on
+  `ga-fh1flg` and covered by `mayor-2026-08-20-herdr-pane-standing`. The
+  specific pre-push occurrence was logged and read back.
+- FAIL — WAIVED: `TestDoStartSession_TreatsDeadlineAfterPostReadyAsSuccessWhenSessionAlive`
+  returned `context deadline exceeded` instead of success under the fast
+  matrix. This first recorded post-ready recurrence is tracked by
+  `ga-vve1ws`; its exact failure, log, and candidate head were verified in the
+  ledger. `go list -deps ./internal/runtime/tmux` confirms the failing package
+  does not depend on `internal/session`, so the named-session lookup diff
+  cannot affect `doStartSession`, `fakeStartOps`, context timing, or tmux
+  startup behavior.
+
+Under the standing tracked-failure authorization on `ga-cqq3hs`, these two
+specific-head failures permit `git push --no-verify`: both have exact trackers,
+neither is diff-owned or reachable from the candidate, both are preserved as
+FAIL — WAIVED, and both occurrences were recorded before bypassing the hook.
+The bypass authorizes only the push; merge authority and all remote CI checks
+remain unchanged.
+
+```text
+pre_push_cmd: LOCAL_TEST_JOBS=5 CMD_GC_PROCESS_TOTAL=6 ./scripts/test-local-parallel fast
+pre_push_counts: 9 PASS jobs, 1 FAIL job, 0 SKIP jobs (10 total); 2 top-level test failures
+pre_push_logs: /var/tmp/gc-local-tests.tD3CWw
+failure_attribution: TestProviderLiveClaudeKindPath -> ga-fh1flg + mayor-2026-08-20-herdr-pane-standing + separate-subsystem no-mechanism proof
+failure_attribution: TestDoStartSession_TreatsDeadlineAfterPostReadyAsSuccessWhenSessionAlive -> ga-vve1ws + dependency-graph no-mechanism proof
+push_disposition: authorized --no-verify under ga-cqq3hs standing tracked-failure rule
+```
+
 ## Pre-flight
 
 GitHub's commit-to-PR lookup returned no PR for the reviewed source after the

--- a/release-gates/ga-rcroz7-named-session-alias-canonical-gate.md
+++ b/release-gates/ga-rcroz7-named-session-alias-canonical-gate.md
@@ -1,0 +1,144 @@
+# Release Gate: named-session alias canonical detection
+
+Deploy bead: `ga-rcroz7`  
+Review bead: `ga-d3whdg`  
+Build bead: `ga-89kxkd`  
+Reviewed source: `15285684898d752028a52b36c81a364a2d63898a`  
+Base: `origin/main@187e53828754894096fc295cea4baca909fe9a96`  
+Gate date: 2026-08-21
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree. This record uses
+the seven release criteria in the deployer contract and the repository's
+documented test requirements in
+`engdocs/contributors/release-gate-criteria-conventions.md` and `TESTING.md`.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-d3whdg` is closed with verdict PASS for the exact reviewed source. |
+| 2 | Acceptance criteria met | PASS | A unique, live, eligible alias candidate with the correct named-session template/spec is promoted to canonical in both Bead and Info lookup shapes; multiple matching live candidates still fall through to the existing conflict path. The five focused regression and collision-safety tests pass by name. Direction A stamping hardening remains intentionally out of scope. |
+| 3 | Tests pass | PASS | The race-enabled `internal/session` suite reports 1,078 PASS, 0 FAIL, 0 SKIP; all five diff-owned tests pass by name. The documented 40-job local CI union reports 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP. Its six raw failures are each tracked, outside the changed subsystem, logged on their trackers, and preserved below as FAIL — WAIVED under the mayor's standing tracked-failure authorization. `make test-ci-policy`, `go build ./...`, `go vet ./...`, targeted lint, lint-new, formatting, and diff checks pass. |
+| 4 | No high-severity review findings open | PASS | The reviewer found no security, correctness, dependency, or style issue. The alias pass retains the pre-existing liveness/eligibility gates, adds template/spec corroboration and uniqueness, and does not weaken true-collision detection. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty before adding this gate record; `git diff --check origin/main...HEAD` passes. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main 15285684898d752028a52b36c81a364a2d63898a` succeeded against the recorded base and produced `c29c3baa0582a6aa30484d1141e306f7ce01eb71`. `assert_deploy_ancestry_scope` passed for the deploy, review, and build bead IDs. No self-rebase was required. |
+| 7 | Single feature theme | PASS | Two commits change only `internal/session/named_config.go` and its test file to fix one named-session alias self-conflict behavior. |
+
+## Acceptance Evidence
+
+- `FindCanonicalNamedSessionBead` and `FindCanonicalNamedSessionInfo` each add
+  the same alias-based canonical pass.
+- The pass requires a repairable/live bead, named-session continuity
+  eligibility, a matching named-session spec, and exactly one qualifying alias
+  candidate.
+- Two-candidate Bead and Info tests prove a genuine collision is not promoted
+  to an arbitrary canonical winner.
+- `LookupConfiguredNamedSession` resolves the sole legitimate alias owner after
+  session start instead of reporting that session as conflicting with itself.
+- No API shape, configuration, persistence schema, dependency, or unrelated
+  runtime provider changes.
+
+## Test Evidence
+
+```text
+test_cmd: go test -race -json -count=1 -timeout 15m ./internal/session/...
+test_counts: 1,078 PASS, 0 FAIL, 0 SKIP
+focused_log: /var/tmp/ga-rcroz7-session-race.json
+diff_tests_executed:
+  TestFindCanonicalNamedSessionBead_AliasSoleLiveCandidateIsCanonical=PASS
+  TestFindCanonicalNamedSessionBead_AliasMatchNotPromotedWithSecondLiveCandidate=PASS
+  TestFindCanonicalNamedSessionInfo_AliasSoleLiveCandidateIsCanonical=PASS
+  TestFindCanonicalNamedSessionInfo_AliasMatchNotPromotedWithSecondLiveCandidate=PASS
+  TestLookupConfiguredNamedSession_AliasOnlyLiveBeadResolvesCanonical=PASS
+waiver_ref: none for diff-owned tests
+
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+test_counts: 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP (40 total)
+full_log: /var/tmp/ga-rcroz7-full.out
+full_logs: /var/tmp/gc-local-tests.OIsZkW
+
+base_control: exact origin/main@187e53828754894096fc295cea4baca909fe9a96 under the same 40-job topology
+base_counts: 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP
+base_full_log: /var/tmp/ga-hgtxtq-base.AlrVxt/base-full.out
+base_logs: /var/tmp/gc-local-tests.5SMCnj
+
+policy_lane: make test-ci-policy — PASS
+build_lane: go build ./... — PASS
+static_lane: go vet ./... — PASS
+lint_lane: golangci-lint ./internal/session/... — PASS, 0 issues
+lint_new_lane: make lint-new from merge-base 599afe65be39c327a70a2986948a79b0993d8c45 — PASS, 0 new issues
+format_lane: make fmt-check-changed — PASS
+diff_lane: git diff --check origin/main...HEAD — PASS
+```
+
+`make lint-affected` selected every reverse dependent of `internal/session` and
+reported 179 pre-existing repository diagnostics, including stale shared-cache
+paths under deleted `/var/tmp` worktrees. The candidate-specific `lint-new`
+lane and direct `internal/session` lint both report zero issues; the failed
+repository-wide reverse-dependent scan is retained in
+`/var/tmp/ga-rcroz7-lint-mergebase.out` and is not represented as green.
+
+### Raw failures and standing disposition
+
+The failures below remain failures in the raw output. None is diff-owned, and
+none is in the changed `internal/session` subsystem. Each occurrence was
+written to and read back from its tracker before this gate was signed. The
+standing authorization recorded on `ga-cqq3hs` allows a builder or deployer to
+proceed only when every failure has a specific tracker, the diff cannot reach
+the failure mechanism, the occurrence is logged, and the gate preserves the
+raw result as FAIL — WAIVED. Those conditions are satisfied here.
+
+- FAIL — WAIVED: `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix`
+  failed after a Dolt socket I/O timeout and invalid connection during parallel
+  `cmd/gc` fixture bootstrap. Tracker: `ga-p6p2rt`. The named-session lookup
+  diff cannot affect Dolt connection creation, bootstrap, or circuit-breaker
+  behavior.
+- FAIL — WAIVED: `TestBdFlagManifestCurrent` reported the tracked installed-`bd`
+  manifest skew. Tracker: `ga-f0uceo`. The exact failure reproduced on the
+  recorded base, and the diff cannot alter `internal/bdflags` or the host CLI.
+- FAIL — WAIVED: `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` observed the tracked empty
+  host-tmux default key table. Tracker: `ga-afqddr`. Both reproduced on the
+  recorded base; the diff cannot reach `internal/runtime/tmux`.
+- FAIL — WAIVED: `TestProviderLiveClaudeKindPath` hit the tracked
+  `agent_pane_busy` signature. Tracker: `ga-fh1flg`; standing disposition:
+  `mayor-2026-08-20-herdr-pane-standing`. It also occurred in the exact-base
+  control, and the diff cannot reach the herdr provider or pane allocation.
+- FAIL — WAIVED: `TestHumaBinary_CityCreateAsync` failed during fixture store
+  initialization with the exact `gastownhall/beads#4566` pending dirty
+  `issues`-table schema-migration signature. Trackers: `ga-lpfjhc` and
+  `ga-6bnc42`. The occurrence was logged with deploy/build IDs, and the diff has
+  no plausible schema-migration or store-bootstrap mechanism.
+
+```text
+failure_attribution: TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix -> ga-p6p2rt + separate-subsystem no-mechanism proof
+failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo + exact-base reproduction + separate-subsystem no-mechanism proof
+failure_attribution: TestGetKeyBinding_CapturesDefaultBinding{,WithArgs} -> ga-afqddr + exact-base reproduction + separate-subsystem no-mechanism proof
+failure_attribution: TestProviderLiveClaudeKindPath -> ga-fh1flg + mayor-2026-08-20-herdr-pane-standing + exact-base occurrence + separate-subsystem no-mechanism proof
+failure_attribution: TestHumaBinary_CityCreateAsync -> ga-lpfjhc + ga-6bnc42 + exact beads#4566 signature + separate-subsystem no-mechanism proof
+waiver_ref: ga-cqq3hs standing tracked-failure authorization; ga-6bnc42 beads#4566 authorization; mayor-2026-08-20-herdr-pane-standing
+```
+
+## Pre-flight
+
+GitHub's commit-to-PR lookup returned no PR for the reviewed source after the
+final `origin/main` refresh. The target has not already merged or been
+superseded through a PR, so normal isolated-branch deployment applies. The
+builder branch is provenance only.
+
+## Commands
+
+```text
+git fetch origin
+git merge-tree --write-tree origin/main 15285684898d752028a52b36c81a364a2d63898a
+assert_deploy_ancestry_scope origin/main 15285684898d752028a52b36c81a364a2d63898a ga-rcroz7 ga-89kxkd ga-d3whdg
+git diff --check origin/main...HEAD
+go test -race -json -count=1 -timeout 15m ./internal/session/...
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+make test-ci-policy
+go build ./...
+go vet ./...
+golangci-lint run --allow-parallel-runners ./internal/session/...
+make lint-new
+make fmt-check-changed
+```


### PR DESCRIPTION
## What this changes

Configured named sessions can now recognize their own live session when the session is reachable only through its configured alias. After a named session starts, commands such as `gc mail send <alias>` no longer report that sole legitimate session as conflicting with itself.

The fix applies consistently to both the bead-backed CLI lookup and the Info-shaped API lookup. A real collision remains an error: if two live sessions both qualify for the alias, neither is silently chosen.

## Review notes

- The new alias pass requires the existing liveness and continuity checks, a matching named-session template/spec, and exactly one qualifying candidate.
- Bead and Info lookup paths use symmetric rules.
- Reserved-name decoys without corroborating template metadata still fall through to conflict detection.
- Manager-side canonical metadata stamping is intentionally unchanged; that is separate hardening work.

## Test plan

- [x] Run the race-enabled `internal/session` suite: 1,078 PASS, 0 FAIL, 0 SKIP.
- [x] Verify all five alias-canonical and true-collision regression tests pass by name.
- [x] Run the documented 40-job local CI union and audit every raw failure against the recorded standing dispositions.
- [x] Run policy, build, vet, candidate-specific lint, formatting, and diff checks.
- [x] Release gate: [`release-gates/ga-rcroz7-named-session-alias-canonical-gate.md`](release-gates/ga-rcroz7-named-session-alias-canonical-gate.md)