### PR TITLE
fix(hook): rotate work across tied stores

### DIFF
--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -265,8 +265,14 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 // is selected: every store's query still matches this agent's own identity, so
 // no bead becomes visible that was not already routed or assigned to it.
 //
-// Ties keep the slice order, so an equally-ranked candidate in the agent's own
-// store still wins — the pre-existing behavior whenever ranking is a wash.
+// An exact tie rotates across every store tied for the best rank, using
+// hookTieBreakClock rather than always keeping the first-seen store. Always
+// preferring slice order (in practice, the agent's own store, since it is
+// stores[0]) meant a tie that persisted across calls — the common case for a
+// steady stream of same-tier, same-priority work — starved every other tied
+// store forever: the comparison is deterministic and re-runs identically on
+// every hook invocation (ga-kbbg9a). Rotating only changes WHICH tied store
+// wins; a candidate that is not tied for the best rank is never affected.
 //
 // Two deliberate carve-outs from ranking:
 //   - A tier-0 (in_progress) candidate in the PRIMARY store short-circuits.
@@ -297,9 +303,8 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 	firstHit := false
 	unrankable := false
 
-	var bestOut string
-	var bestStore hookStore
 	var bestRank hookCandidateRank
+	var bestTied []hookRankedStore
 	haveBest := false
 
 	// When the federated reader is pinned to the primary leg, that leg is the
@@ -349,8 +354,12 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		if rank.tier == hookTierInProgress && sameHookStore(st, primary) {
 			return out, st, nil
 		}
-		if !haveBest || rank.less(bestRank) {
-			bestOut, bestStore, bestRank, haveBest = out, st, rank, true
+		switch {
+		case !haveBest || rank.less(bestRank):
+			bestRank, haveBest = rank, true
+			bestTied = append(bestTied[:0], hookRankedStore{out: out, store: st})
+		case rank == bestRank:
+			bestTied = append(bestTied, hookRankedStore{out: out, store: st})
 		}
 	}
 
@@ -367,7 +376,11 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		return firstHitOut, firstHitStore, nil
 	}
 	if haveBest {
-		return bestOut, bestStore, nil
+		winner := bestTied[0]
+		if len(bestTied) > 1 {
+			winner = bestTied[hookTieBreakIndex(len(bestTied), hookTieBreakClock())]
+		}
+		return winner.out, winner.store, nil
 	}
 	if firstHit {
 		return firstHitOut, firstHitStore, nil
@@ -376,6 +389,14 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		return ownStoreOut, hookStore{}, ownStoreErr
 	}
 	return lastOut, hookStore{}, nil
+}
+
+// hookRankedStore pairs one store's work-query output with the store it came
+// from. bestStoreWithWork accumulates one per store tied for the best rank,
+// held only long enough to resolve the tie.
+type hookRankedStore struct {
+	out   string
+	store hookStore
 }
 
 // hookTieBreakClock returns the time bestStoreWithWork uses to rotate an
@@ -467,8 +488,12 @@ type hookCandidateRank struct {
 }
 
 // less reports whether r should be picked ahead of other. Equal ranks report
-// false in both directions, so callers that only replace on a strict improvement
-// keep the store slice order as the tiebreak.
+// false in both directions: less alone never breaks a tie, so each caller
+// decides how to. bestHookCandidateRank (below) only replaces its incumbent
+// on a strict improvement, so it keeps the first row seen. bestStoreWithWork
+// instead accumulates every candidate tied for the best rank and rotates
+// among them (see its doc comment) — the tie itself is the same regardless of
+// caller; only what happens with it differs.
 func (r hookCandidateRank) less(other hookCandidateRank) bool {
 	if r.tier != other.tier {
 		return r.tier < other.tier

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -378,6 +378,21 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 	return lastOut, hookStore{}, nil
 }
 
+// hookTieBreakClock returns the time bestStoreWithWork uses to rotate an
+// exact-rank tie across stores (see its doc comment). A package-level var so
+// tests can pin it; production always uses the real clock.
+var hookTieBreakClock = time.Now
+
+// hookTieBreakIndex picks which of n exact-rank-tied stores wins, rotating
+// with t so the same tie does not resolve to the same store on every call. A
+// fresh process (gc hook's normal invocation shape) has no in-memory state to
+// round-robin with, so the rotation source has to be something that varies
+// between invocations on its own — wall-clock time — rather than a counter.
+// n must be > 0.
+func hookTieBreakIndex(n int, t time.Time) int {
+	return int(uint64(t.UnixNano()) % uint64(n))
+}
+
 // hookFederationPinnedToPrimary reports whether this store set is the shape
 // scopeFederatedHookStores USED to produce: the primary runs the city-wide
 // federated command and every extra carries its own single-store override. That

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -345,7 +345,7 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		if !firstHit {
 			firstHitOut, firstHitStore, firstHit = out, st, true
 		}
-		rank, ok := bestHookCandidateRank(ready)
+		rank, id, ok := bestHookCandidateRank(ready)
 		if !ok {
 			unrankable = true
 			continue
@@ -357,9 +357,17 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		switch {
 		case !haveBest || rank.less(bestRank):
 			bestRank, haveBest = rank, true
-			bestTied = append(bestTied[:0], hookRankedStore{out: out, store: st})
-		case rank == bestRank:
-			bestTied = append(bestTied, hookRankedStore{out: out, store: st})
+			bestTied = append(bestTied[:0], hookRankedStore{out: out, store: st, id: id})
+		case rank == bestRank && !hookTiedIDSeen(bestTied, id):
+			// A migrated bead (`gc storage migrate` copies, never deletes) can be
+			// ready from more than one store under the SAME id: the same row, not
+			// two tied pieces of work. Rotating across a duplicate would put a
+			// later store ahead of the primary for no reason — nothing about the
+			// work differs — and breaks the rig-first-city-last fan-out order the
+			// class-escalation claim loop depends on. An empty id (unidentifiable
+			// row) is never treated as a duplicate, so unranked-id fixtures keep
+			// rotating exactly as before.
+			bestTied = append(bestTied, hookRankedStore{out: out, store: st, id: id})
 		}
 	}
 
@@ -392,11 +400,28 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 }
 
 // hookRankedStore pairs one store's work-query output with the store it came
-// from. bestStoreWithWork accumulates one per store tied for the best rank,
-// held only long enough to resolve the tie.
+// from and the winning candidate's id. bestStoreWithWork accumulates one per
+// store tied for the best rank, held only long enough to resolve the tie.
 type hookRankedStore struct {
 	out   string
 	store hookStore
+	id    string
+}
+
+// hookTiedIDSeen reports whether id already has an entry in tied. An empty id
+// (a row bestHookCandidateRank could not read an "id" field from) never
+// counts as seen, so unidentifiable rows fall back to the pre-existing
+// rotate-every-entry behavior rather than being silently collapsed.
+func hookTiedIDSeen(tied []hookRankedStore, id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, t := range tied {
+		if t.id == id {
+			return true
+		}
+	}
+	return false
 }
 
 // hookTieBreakClock returns the time bestStoreWithWork uses to rotate an
@@ -453,7 +478,7 @@ func hookOwnResumeAnswer(out string, now time.Time) (string, bool) {
 	if !workQueryHasReadyWork(ready) {
 		return "", false
 	}
-	rank, ok := bestHookCandidateRank(ready)
+	rank, _, ok := bestHookCandidateRank(ready)
 	if !ok || rank.tier != hookTierInProgress {
 		return "", false
 	}
@@ -506,20 +531,22 @@ func (r hookCandidateRank) less(other hookCandidateRank) bool {
 // — not JSON, not a JSON array, or an array holding a non-object — which the
 // caller treats as "do not reorder on a comparison that was not made" rather
 // than as an absence of work.
-func bestHookCandidateRank(ready string) (hookCandidateRank, bool) {
+func bestHookCandidateRank(ready string) (hookCandidateRank, string, bool) {
 	var rows []map[string]any
 	if err := json.Unmarshal([]byte(strings.TrimSpace(ready)), &rows); err != nil {
-		return hookCandidateRank{}, false
+		return hookCandidateRank{}, "", false
 	}
 	best := hookCandidateRank{}
+	bestID := ""
 	found := false
 	for _, row := range rows {
 		rank := hookRankCandidate(row)
 		if !found || rank.less(best) {
 			best, found = rank, true
+			bestID, _ = row["id"].(string)
 		}
 	}
-	return best, found
+	return best, bestID, found
 }
 
 // hookRankCandidate reads one row's tier and priority. An unrecognized status or

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -221,6 +221,38 @@ func TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime(t *testing.T) {
 	}
 }
 
+// TestBestStoreWithWorkDoesNotRotateOnACoResidentDuplicateID is the
+// regression test for a gap in ga-kbbg9a's own rotation: a bead migrated
+// with `gc storage migrate` (copies, never deletes) is visible as ready from
+// MORE than one store under the SAME id — the exact same row, not two tied
+// pieces of work. An id-blind tie-break can rotate onto a later store ahead
+// of the primary even though nothing about the work differs, which breaks
+// the rig-first-city-last fan-out order TestClassEscalationWaitsForEveryWorkLeg
+// and TestClassEscalationStillReachesABindingOnlyBead
+// (hook_claim_class_fanout_test.go) depend on. Two DIFFERENT ids at the same
+// rank must still rotate (TestBestStoreWithWorkRotatesExactTies) — only a
+// shared id must not.
+func TestBestStoreWithWorkDoesNotRotateOnACoResidentDuplicateID(t *testing.T) {
+	stores := []hookStore{{dir: "riga"}, {dir: "city"}}
+	run := func(_, _ string, _ []string) (string, error) {
+		// Same id, same rank, from every store: a co-resident duplicate, not
+		// two different pieces of work.
+		return `[{"id":"dup-1","assignee":"worker-1"}]`, nil
+	}
+
+	// Offset 1 is exactly the clock value TestBestStoreWithWorkRotatesExactTies
+	// uses to prove rotation moves off the first store; here the tied
+	// candidates share an id, so it must NOT move off riga.
+	withHookTieBreakClock(t, time.Unix(0, 1))
+	_, got, err := bestStoreWithWork("q", stores, stores[0], run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga: a tie between two copies of the SAME bead id must keep slice order, not rotate", got.dir)
+	}
+}
+
 // TestHookTieBreakIndex pins the rotation formula directly: it must stay
 // within [0, n) and must not collapse to a constant across varying clock
 // values, which is exactly what would silently reintroduce the starvation
@@ -360,7 +392,7 @@ func TestBestHookCandidateRank(t *testing.T) {
 		{"array of non-objects is unrankable", `["a"]`, hookCandidateRank{}, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := bestHookCandidateRank(tc.ready)
+			got, _, ok := bestHookCandidateRank(tc.ready)
 			if ok != tc.ok {
 				t.Fatalf("ok = %v, want %v", ok, tc.ok)
 			}

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -118,35 +119,129 @@ func TestBestStoreWithWorkPrefersHigherPriorityInALaterStore(t *testing.T) {
 }
 
 // TestBestStoreWithWorkDoesNotInvertTheBug guards the other direction: a
-// higher-priority candidate in the agent's OWN store must still win, and so must
-// an equal-priority one (ties keep slice order). A fix that simply preferred the
-// federated store would pass the regression test above and be just as wrong.
+// higher-priority candidate in the agent's OWN store must still win. A fix
+// that simply preferred the federated store would pass the regression test
+// above and be just as wrong.
+//
+// (An "equal priority keeps slice order" case used to live here too,
+// asserting that a tie always resolved to the own store. That assertion WAS
+// the permanent-starvation bug ga-kbbg9a exists to fix — see
+// TestBestStoreWithWorkRotatesExactTies and
+// TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime below for its
+// replacement.)
 func TestBestStoreWithWorkDoesNotInvertTheBug(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == "city" {
+			return `[{"id":"ci-1","priority":1}]`, nil
+		}
+		return `[{"id":"va-1","priority":3}]`, nil
+	}
+	_, gotStore, err := bestStoreWithWork("q", stores, stores[0], run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if gotStore.dir != "city" {
+		t.Fatalf("store.dir = %q, want city (P1 in own store beats rig P3)", gotStore.dir)
+	}
+}
+
+// withHookTieBreakClock pins bestStoreWithWork's tie-break clock for the
+// duration of the test, restoring the real clock on cleanup.
+func withHookTieBreakClock(t *testing.T, now time.Time) {
+	t.Helper()
+	orig := hookTieBreakClock
+	hookTieBreakClock = func() time.Time { return now }
+	t.Cleanup(func() { hookTieBreakClock = orig })
+}
+
+// TestBestStoreWithWorkRotatesExactTies is the fix ga-kbbg9a exists for: an
+// exact rank tie resolved to the same store on every call because the
+// selection loop only replaced its incumbent on a STRICT improvement — ties
+// left the first-seen store (stores[0], the agent's own store) as the
+// incumbent forever, starving every other tied store regardless of how many
+// hook calls ran. Pinning the tie-break clock to two different instants
+// proves the winner now depends on the clock rather than always being the
+// first store in the slice.
+func TestBestStoreWithWorkRotatesExactTies(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == "city" {
+			return `[{"id":"ci-1","priority":1}]`, nil
+		}
+		return `[{"id":"va-1","priority":1}]`, nil
+	}
+
+	withHookTieBreakClock(t, time.Unix(0, 0))
+	_, gotCity, err := bestStoreWithWork("q", stores, stores[0], run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if gotCity.dir != "city" {
+		t.Fatalf("store.dir = %q, want city at tie-break clock offset 0", gotCity.dir)
+	}
+
+	withHookTieBreakClock(t, time.Unix(0, 1))
+	_, gotRiga, err := bestStoreWithWork("q", stores, stores[0], run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if gotRiga.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga at tie-break clock offset 1 — an exact tie must not always resolve to the same store", gotRiga.dir)
+	}
+}
+
+// TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime is the direct
+// regression test for the reported symptom: gc hook run repeatedly against an
+// UNCHANGED four-way exact tie (mirroring the bead's live measurement — city,
+// gascity, cairn, and beads all at tier=routed/P1) must eventually surface
+// every tied store, not just the first one in the slice, forever.
+func TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "gascity"}, {dir: "cairn"}, {dir: "beads"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		return `[{"id":"tied-` + dir + `","priority":1}]`, nil
+	}
+
+	orig := hookTieBreakClock
+	defer func() { hookTieBreakClock = orig }()
+
+	seen := map[string]bool{}
+	for i := 0; i < len(stores); i++ {
+		offset := int64(i)
+		hookTieBreakClock = func() time.Time { return time.Unix(0, offset) }
+		_, gotStore, err := bestStoreWithWork("q", stores, stores[0], run)
+		if err != nil {
+			t.Fatalf("call %d: err: %v", i, err)
+		}
+		seen[gotStore.dir] = true
+	}
+
+	if len(seen) <= 1 {
+		t.Fatalf("repeated calls against an unchanged tie only ever selected %v — starvation is still permanent", seen)
+	}
+}
+
+// TestHookTieBreakIndex pins the rotation formula directly: it must stay
+// within [0, n) and must not collapse to a constant across varying clock
+// values, which is exactly what would silently reintroduce the starvation
+// bug.
+func TestHookTieBreakIndex(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		rigRow   string
-		wantDir  string
-		wantNote string
+		n    int
+		nano int64
+		want int
 	}{
-		{"own store higher priority", `[{"id":"va-1","priority":3}]`, "city", "P1 in own store beats rig P3"},
-		{"equal priority keeps slice order", `[{"id":"va-1","priority":1}]`, "city", "tie must not move the selection"},
+		{2, 0, 0},
+		{2, 1, 1},
+		{2, 2, 0},
+		{4, 0, 0},
+		{4, 3, 3},
+		{4, 4, 0},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			stores := []hookStore{{dir: "city"}, {dir: "riga"}}
-			run := func(_, dir string, _ []string) (string, error) {
-				if dir == "city" {
-					return `[{"id":"ci-1","priority":1}]`, nil
-				}
-				return tc.rigRow, nil
-			}
-			_, gotStore, err := bestStoreWithWork("q", stores, stores[0], run)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-			if gotStore.dir != tc.wantDir {
-				t.Fatalf("store.dir = %q, want %q (%s)", gotStore.dir, tc.wantDir, tc.wantNote)
-			}
-		})
+		got := hookTieBreakIndex(tc.n, time.Unix(0, tc.nano))
+		if got != tc.want {
+			t.Fatalf("hookTieBreakIndex(%d, unix-nano %d) = %d, want %d", tc.n, tc.nano, got, tc.want)
+		}
 	}
 }
 

--- a/release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md
+++ b/release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md
@@ -1,0 +1,139 @@
+# Release Gate: cross-store hook tie rotation
+
+Deploy bead: `ga-hgtxtq`
+
+Review bead: `ga-rdex4v`
+
+Build bead: `ga-kbbg9a`
+
+Reviewed source: `b8626685d1778b24eee014ec7be9c1e6ba770d47`
+
+Base: `origin/main@187e53828754894096fc295cea4baca909fe9a96`
+
+Gate date: 2026-08-21
+
+**Verdict: PENDING MAYOR ADJUDICATION.** The reviewed behavior and every
+diff-owned test pass, but the documented 40-job candidate sweep contains three
+candidate-only wall-clock failures that one exact-base control did not
+reproduce. Two failures are in the changed `cmd/gc` package, so the no-path-
+overlap attribution clause is not satisfied; the third is a tracked Dolt
+fixture timeout outside the diff, but this control did not prove it
+pre-existing. Under mayor correction `gm-wisp-giaqmv`, a single clean base
+observation is not enough to classify a wall-clock timeout as caused by the
+candidate. No waiver has been self-granted. Nothing is pushed and no pull
+request exists while criterion 3 is unresolved.
+
+`docs/PROJECT_MANIFEST.md` is absent from this repository. This record uses the
+seven release criteria in the deployer contract and the documented commands in
+`TESTING.md` and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Gate Results
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Closed review bead `ga-rdex4v` records `verdict: pass` for the exact reviewed source. |
+| 2 | Acceptance criteria met | PASS | Exact ties rotate across distinct bead IDs; co-resident duplicate IDs remain deduplicated; strict rank improvements, primary-store in-progress short-circuiting, and class-escalation behavior remain intact. All focused and repetition checks pass. |
+| 3 | Tests pass | **PENDING** | The candidate 40-job union reports 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP. Three deterministic failures reproduce on the exact base and are attributable below. `TestTutorial01`, `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix`, and `TestDoltConfigWiringExternalHost` fail only on the candidate in this A/B sample. They are not diff-owned, but their wall-clock nature and the two `cmd/gc` path overlaps prevent either a branch-regression verdict or a deployer-authored waiver from this single comparison. |
+| 3a | Pre-existing failures attributed | **PENDING** | `TestBdFlagManifestCurrent` and both tmux key-binding tests reproduce on the exact base with active trackers and no path overlap. The other three candidate failures do not satisfy every attribution clause. Mayor adjudication is required; no builder bounce is justified from one timing observation. |
+| 3b | Policy/lint lane | PASS | Required policy lane `make test-ci-policy` passes. `go build ./...`, `go vet ./...`, changed formatting, and `git diff --check` pass. An auxiliary affected-lint run selected the full repository because the reviewed source predates a base-only release-gate file and failed on 182 unrelated repository/cache diagnostics; no diagnostic names either changed `cmd/gc` file. |
+| 4 | No high-severity review findings open | PASS | The reviewer recorded PASS and no open HIGH finding. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty at the exact reviewed source before this checklist was written. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --messages origin/main b8626685...` exited 0 against current `origin/main`, producing tree `bd3b73056d40beaab7c6d7374fe040f14895a599`. `assert_deploy_ancestry_scope` passed for `ga-hgtxtq`, `ga-kbbg9a`, and `ga-rdex4v`. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | Three commits modify only cross-store hook selection and its tests in `cmd/gc`; all changes serve one starvation fix. |
+
+## Acceptance Evidence
+
+- `bestStoreWithWork` accumulates every distinct candidate tied at the best
+  rank and selects among them with a clock-derived index, so repeated fresh
+  `gc hook` processes do not permanently prefer `stores[0]`.
+- Equal-ranked rows sharing one bead ID are deduplicated before rotation. A
+  copied/migrated bead therefore does not masquerade as two pieces of work or
+  invert the rig-first-city-last fan-out order.
+- An empty/unidentifiable ID is not deduplicated, preserving the existing
+  fallback behavior for unrankable fixtures.
+- A primary-store in-progress candidate still returns immediately; a better
+  tier or priority still beats every worse candidate before tie-breaking.
+
+## Test Evidence
+
+The rootless Podman socket was active before the full run:
+`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock` and
+`TESTCONTAINERS_RYUK_DISABLED=true`. The cached pinned image
+`docker.io/dolthub/dolt-sql-server:2.1.7` was present.
+
+### Diff-owned and acceptance tests
+
+```text
+test_cmd: go test -json -count=1 ./cmd/gc -run '^(TestBestStoreWithWorkDoesNotInvertTheBug|TestBestStoreWithWorkRotatesExactTies|TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime|TestBestStoreWithWorkDoesNotRotateOnACoResidentDuplicateID|TestHookTieBreakIndex|TestBestHookCandidateRank|TestBestStoreWithWorkShortCircuitsOwnInProgress|TestBestStoreWithWorkPrefersHigherPriorityInALaterStore|TestBestStoreWithWorkRanksTierAheadOfPriority)$'
+test_counts: all named tests and subtests PASS, 0 FAIL, 0 SKIP
+focused_log: /var/tmp/ga-hgtxtq-focused.json
+
+repeat_cmd: go test -json -count=30 ./cmd/gc -run '^(TestClassEscalationStillReachesABindingOnlyBead|TestClassEscalationWaitsForEveryWorkLeg)$'
+repeat_counts: 60 PASS, 0 FAIL, 0 SKIP
+repeat_log: /var/tmp/ga-hgtxtq-class-escalation-30.json
+
+diff_tests_executed:
+  TestBestStoreWithWorkDoesNotInvertTheBug PASS
+  TestBestStoreWithWorkRotatesExactTies PASS
+  TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime PASS
+  TestBestStoreWithWorkDoesNotRotateOnACoResidentDuplicateID PASS
+  TestHookTieBreakIndex PASS
+  TestBestHookCandidateRank and all subtests PASS
+waiver_ref: none for diff-owned tests
+```
+
+### Candidate and exact-base full unions
+
+```text
+candidate_ref: b8626685d1778b24eee014ec7be9c1e6ba770d47
+candidate_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+candidate_counts: 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP (40 total)
+candidate_logs: /var/tmp/gc-local-tests.l3r6cX
+candidate_transcript: /var/tmp/ga-hgtxtq-full.out
+
+base_ref: 187e53828754894096fc295cea4baca909fe9a96
+base_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m make test-local-full-parallel
+base_counts: 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP (40 total)
+base_logs: /var/tmp/gc-local-tests.5SMCnj
+base_transcript: /var/tmp/ga-hgtxtq-base.AlrVxt/base-full.out
+
+policy_lane: make test-ci-policy -- PASS
+build_lane: go build ./... -- PASS
+static_lane: go vet ./... -- PASS
+format_lane: LINT_CHANGED_REF=origin/main make fmt-check-changed -- PASS
+diff_check: git diff --check origin/main...HEAD -- PASS
+```
+
+### Candidate failures and disposition
+
+| Failing test | Candidate job | Base result | Disposition |
+|---|---|---|---|
+| `TestBdFlagManifestCurrent` | `integration-packages-core-1-of-4` | FAIL with the same signature in `integration-packages-core-4-of-4` | Attributed to `ga-f0uceo`; not diff-owned and no path overlap. |
+| `TestGetKeyBinding_CapturesDefaultBinding` | `integration-packages-runtime-tmux-2-of-3` | FAIL with the same empty-default signature | Attributed to `ga-afqddr`; not diff-owned and no path overlap. |
+| `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `integration-packages-runtime-tmux-3-of-3` | FAIL with the same empty-default signature | Attributed to `ga-afqddr`; not diff-owned and no path overlap. |
+| `TestTutorial01/controller` | `cmd-gc-process-3-of-6` | PASS job | **UNRESOLVED**: controller socket wall-clock timeout; not diff-owned, but package overlaps the diff and one clean base run cannot establish causation. |
+| `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix` | `cmd-gc-process-4-of-6` | PASS job | **UNRESOLVED**: dirty-schema / init timing signature tracked by `ga-qyh9cb`; not diff-owned, but package overlaps the diff and did not reproduce in this base run. |
+| `TestDoltConfigWiringExternalHost` | `integration-rest-full-2-of-8` | PASS job | **UNRESOLVED**: 36-second `bd init` timeout with fix lineage `ga-gajll3` / `ga-thuouz`; no path overlap, but this control did not prove the failure pre-existing. |
+
+The exact base has its own six failing jobs, all outside this diff:
+`TestFileRecorderWatchAfterLatestStartsAtEOF`,
+`TestProviderLiveClaudeKindPath`, both tmux tests,
+`TestE2E_SuspendResume_City`, `TestPersonalWorkFormulaCompileAndRun`, and
+`TestBdFlagManifestCurrent`. Those failures demonstrate substantial host/load
+noise but do not themselves waive a different candidate failure.
+
+## Pre-flight and Disposition
+
+GitHub's base-repository commit-to-PR lookup returned no PR for the reviewed
+source, and the bead contains no prior PR URL. There is no merged, closed, or
+superseded target to reconcile.
+
+Deploy mode is remote. `origin` is the base/fetch remote and its dry-run push
+is unavailable, so a future PASS would push the isolated branch to `fork`.
+GitHub authentication is active.
+
+Criterion 3 remains unresolved under correction `gm-wisp-giaqmv`. This gate
+record stays local and unpushed; no PR, deploy-clearance status, or merge
+request is permitted until mayor adjudication supplies a waiver or directs
+the corrected repeat protocol.

--- a/release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md
+++ b/release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md
@@ -8,7 +8,7 @@ Build bead: `ga-kbbg9a`
 
 Reviewed source: `b8626685d1778b24eee014ec7be9c1e6ba770d47`
 
-Base: `origin/main@5ba4d6e653f0b0c4241a565399ea558cd98c1e1d`
+Base: `origin/main@08461bb390c8720cde505ae769638c8ccbcb2e53`
 
 Gate date: 2026-08-21
 
@@ -36,7 +36,7 @@ seven release criteria in the deployer contract and the documented commands in
 | 3b | Policy/lint lane | PASS | Required policy lane `make test-ci-policy` passes. `go build ./...`, `go vet ./...`, changed formatting, and `git diff --check` pass. An auxiliary affected-lint run selected the full repository because the reviewed source predates a base-only release-gate file and failed on 182 unrelated repository/cache diagnostics; no diagnostic names either changed `cmd/gc` file. |
 | 4 | No high-severity review findings open | PASS | The reviewer recorded PASS and no open HIGH finding. Unresolved HIGH count: 0. |
 | 5 | Final branch is clean | PASS | `git status --porcelain` was empty at the exact reviewed source before this checklist was written. |
-| 6 | Branch diverges cleanly from main | PASS | After the mayor ruling, `git merge-tree --write-tree origin/main b8626685d1778b24eee014ec7be9c1e6ba770d47` exited 0 against `origin/main@5ba4d6e653f0b0c4241a565399ea558cd98c1e1d`, producing tree `8c32de4c915504ff1b374a5062bde8c4bd21cb29`. The newer main changes do not touch `cmd/gc/hook_cross_store.go` or its test. `assert_deploy_ancestry_scope` passed for `ga-hgtxtq`, `ga-kbbg9a`, and `ga-rdex4v`. No self-rebase was needed. |
+| 6 | Branch diverges cleanly from main | PASS | After the guarded push, `git merge-tree --write-tree origin/main b8626685d1778b24eee014ec7be9c1e6ba770d47` exited 0 against `origin/main@08461bb390c8720cde505ae769638c8ccbcb2e53`, producing tree `bf32180957642c3e9e826cce0eccfb7b654f3394`. The newer main changes are confined to credential-provider tests, named-session alias handling, and their gate records; they do not touch `cmd/gc/hook_cross_store.go` or its test. `assert_deploy_ancestry_scope` passed for `ga-hgtxtq`, `ga-kbbg9a`, and `ga-rdex4v`. No self-rebase was needed. |
 | 7 | Single feature theme | PASS | Three commits modify only cross-store hook selection and its tests in `cmd/gc`; all changes serve one starvation fix. |
 
 ## Acceptance Evidence
@@ -100,6 +100,7 @@ build_lane: go build ./... -- PASS
 static_lane: go vet ./... -- PASS
 format_lane: LINT_CHANGED_REF=origin/main make fmt-check-changed -- PASS
 diff_check: git diff --check origin/main...HEAD -- PASS
+pre_push_lane: LOCAL_TEST_JOBS=2 CMD_GC_PROCESS_TOTAL=6 ./scripts/test-local-parallel fast -- 10 PASS jobs, 0 FAIL, 0 SKIP
 ```
 
 ### Candidate failures and disposition

--- a/release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md
+++ b/release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md
@@ -8,20 +8,17 @@ Build bead: `ga-kbbg9a`
 
 Reviewed source: `b8626685d1778b24eee014ec7be9c1e6ba770d47`
 
-Base: `origin/main@187e53828754894096fc295cea4baca909fe9a96`
+Base: `origin/main@5ba4d6e653f0b0c4241a565399ea558cd98c1e1d`
 
 Gate date: 2026-08-21
 
-**Verdict: PENDING MAYOR ADJUDICATION.** The reviewed behavior and every
-diff-owned test pass, but the documented 40-job candidate sweep contains three
-candidate-only wall-clock failures that one exact-base control did not
-reproduce. Two failures are in the changed `cmd/gc` package, so the no-path-
-overlap attribution clause is not satisfied; the third is a tracked Dolt
-fixture timeout outside the diff, but this control did not prove it
-pre-existing. Under mayor correction `gm-wisp-giaqmv`, a single clean base
-observation is not enough to classify a wall-clock timeout as caused by the
-candidate. No waiver has been self-granted. Nothing is pushed and no pull
-request exists while criterion 3 is unresolved.
+**Verdict: PASS.** The reviewed behavior and every diff-owned test pass. The
+documented candidate and exact-base 40-job unions each report 34 PASS / 6 FAIL
+/ 0 SKIP, with different failure membership. Mayor ruling `gm-wisp-cwndyl`
+clears criterion 3 as PASS-with-attribution: this equal-count, disjoint-set
+result is two samples from the suite's documented timing-noise distribution,
+not evidence that the candidate added failures. The ruling explicitly directs
+the deployer not to spend another repetition sweep. No waiver was self-granted.
 
 `docs/PROJECT_MANIFEST.md` is absent from this repository. This record uses the
 seven release criteria in the deployer contract and the documented commands in
@@ -34,12 +31,12 @@ seven release criteria in the deployer contract and the documented commands in
 |---|---|---|---|
 | 1 | Review PASS present | PASS | Closed review bead `ga-rdex4v` records `verdict: pass` for the exact reviewed source. |
 | 2 | Acceptance criteria met | PASS | Exact ties rotate across distinct bead IDs; co-resident duplicate IDs remain deduplicated; strict rank improvements, primary-store in-progress short-circuiting, and class-escalation behavior remain intact. All focused and repetition checks pass. |
-| 3 | Tests pass | **PENDING** | The candidate 40-job union reports 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP. Three deterministic failures reproduce on the exact base and are attributable below. `TestTutorial01`, `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix`, and `TestDoltConfigWiringExternalHost` fail only on the candidate in this A/B sample. They are not diff-owned, but their wall-clock nature and the two `cmd/gc` path overlaps prevent either a branch-regression verdict or a deployer-authored waiver from this single comparison. |
-| 3a | Pre-existing failures attributed | **PENDING** | `TestBdFlagManifestCurrent` and both tmux key-binding tests reproduce on the exact base with active trackers and no path overlap. The other three candidate failures do not satisfy every attribution clause. Mayor adjudication is required; no builder bounce is justified from one timing observation. |
+| 3 | Tests pass | PASS | Candidate and exact-base full unions each report 34 PASS jobs, 6 FAIL jobs, 0 job-level SKIP, with disjoint failure membership. Every diff-owned and acceptance test passes, including 60/60 class-escalation controls. Mayor ruling `gm-wisp-cwndyl` clears the three candidate-only wall-clock failures by non-attribution and directs no further resampling. Raw failures remain recorded below. |
+| 3a | Pre-existing failures attributed | PASS | `TestBdFlagManifestCurrent` and both tmux key-binding tests reproduce on the exact base with active trackers and no path overlap. The remaining timing-only failures carry documented flake lineage (`ga-qyh9cb`, `ga-gajll3`/`ga-thuouz`, and tutorial-path beads `ga-hrdd3h`/`ga-io7xwr`) and are covered by the mayor's explicit non-attribution ruling `gm-wisp-cwndyl`; this is a merge-authority decision, not a deployer-authored waiver. |
 | 3b | Policy/lint lane | PASS | Required policy lane `make test-ci-policy` passes. `go build ./...`, `go vet ./...`, changed formatting, and `git diff --check` pass. An auxiliary affected-lint run selected the full repository because the reviewed source predates a base-only release-gate file and failed on 182 unrelated repository/cache diagnostics; no diagnostic names either changed `cmd/gc` file. |
 | 4 | No high-severity review findings open | PASS | The reviewer recorded PASS and no open HIGH finding. Unresolved HIGH count: 0. |
 | 5 | Final branch is clean | PASS | `git status --porcelain` was empty at the exact reviewed source before this checklist was written. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --messages origin/main b8626685...` exited 0 against current `origin/main`, producing tree `bd3b73056d40beaab7c6d7374fe040f14895a599`. `assert_deploy_ancestry_scope` passed for `ga-hgtxtq`, `ga-kbbg9a`, and `ga-rdex4v`. No self-rebase was needed. |
+| 6 | Branch diverges cleanly from main | PASS | After the mayor ruling, `git merge-tree --write-tree origin/main b8626685d1778b24eee014ec7be9c1e6ba770d47` exited 0 against `origin/main@5ba4d6e653f0b0c4241a565399ea558cd98c1e1d`, producing tree `8c32de4c915504ff1b374a5062bde8c4bd21cb29`. The newer main changes do not touch `cmd/gc/hook_cross_store.go` or its test. `assert_deploy_ancestry_scope` passed for `ga-hgtxtq`, `ga-kbbg9a`, and `ga-rdex4v`. No self-rebase was needed. |
 | 7 | Single feature theme | PASS | Three commits modify only cross-store hook selection and its tests in `cmd/gc`; all changes serve one starvation fix. |
 
 ## Acceptance Evidence
@@ -112,9 +109,9 @@ diff_check: git diff --check origin/main...HEAD -- PASS
 | `TestBdFlagManifestCurrent` | `integration-packages-core-1-of-4` | FAIL with the same signature in `integration-packages-core-4-of-4` | Attributed to `ga-f0uceo`; not diff-owned and no path overlap. |
 | `TestGetKeyBinding_CapturesDefaultBinding` | `integration-packages-runtime-tmux-2-of-3` | FAIL with the same empty-default signature | Attributed to `ga-afqddr`; not diff-owned and no path overlap. |
 | `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `integration-packages-runtime-tmux-3-of-3` | FAIL with the same empty-default signature | Attributed to `ga-afqddr`; not diff-owned and no path overlap. |
-| `TestTutorial01/controller` | `cmd-gc-process-3-of-6` | PASS job | **UNRESOLVED**: controller socket wall-clock timeout; not diff-owned, but package overlaps the diff and one clean base run cannot establish causation. |
-| `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix` | `cmd-gc-process-4-of-6` | PASS job | **UNRESOLVED**: dirty-schema / init timing signature tracked by `ga-qyh9cb`; not diff-owned, but package overlaps the diff and did not reproduce in this base run. |
-| `TestDoltConfigWiringExternalHost` | `integration-rest-full-2-of-8` | PASS job | **UNRESOLVED**: 36-second `bd init` timeout with fix lineage `ga-gajll3` / `ga-thuouz`; no path overlap, but this control did not prove the failure pre-existing. |
+| `TestTutorial01/controller` | `cmd-gc-process-3-of-6` | PASS job | FAIL — ATTRIBUTION CLEARED by `gm-wisp-cwndyl`: wall-clock controller timeout with tutorial-path flake lineage `ga-hrdd3h` / `ga-io7xwr`; weaker tracker link is recorded as such. |
+| `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix` | `cmd-gc-process-4-of-6` | PASS job | FAIL — ATTRIBUTION CLEARED by `gm-wisp-cwndyl`: same tracked wall-clock failure previously adjudicated on another gate; tracker `ga-qyh9cb`. |
+| `TestDoltConfigWiringExternalHost` | `integration-rest-full-2-of-8` | PASS job | FAIL — ATTRIBUTION CLEARED by `gm-wisp-cwndyl`: hardcoded 15-second `bd init` timeout lineage `ga-gajll3` / `ga-thuouz`; no path overlap. |
 
 The exact base has its own six failing jobs, all outside this diff:
 `TestFileRecorderWatchAfterLatestStartsAtEOF`,
@@ -133,7 +130,8 @@ Deploy mode is remote. `origin` is the base/fetch remote and its dry-run push
 is unavailable, so a future PASS would push the isolated branch to `fork`.
 GitHub authentication is active.
 
-Criterion 3 remains unresolved under correction `gm-wisp-giaqmv`. This gate
-record stays local and unpushed; no PR, deploy-clearance status, or merge
-request is permitted until mayor adjudication supplies a waiver or directs
-the corrected repeat protocol.
+Mayor ruling `gm-wisp-cwndyl` clears criterion 3 by non-attribution and directs
+the deployer to push and proceed without another repetition sweep. The ruling
+is based on identical 34/6/0 candidate and base counts with disjoint failure
+sets, documented timing-flake history for the candidate-only failures, and a
+fully green diff-owned surface. Normal isolated-branch deployment now applies.


### PR DESCRIPTION
## What this changes

`gc hook` now gives every store a chance when multiple city and rig stores offer work at the same best rank. Previously, stable store ordering always selected the first tied store, so city-scoped agents could indefinitely miss otherwise eligible rig work.

Tie rotation applies only after tier and priority comparison. Rows that represent the same bead in multiple co-resident stores are deduplicated before selection, preventing a copied or migrating bead from gaining extra weight.

## Review notes

- The change is limited to cross-store hook selection and its tests.
- Strictly better tiers and priorities still win before tie rotation.
- A primary-store item already assigned to the current agent still short-circuits immediately.
- Empty or unidentifiable bead IDs retain their existing fallback behavior.

## Test plan

- [x] Exercise exact-tie rotation across stores and repeated fresh selections.
- [x] Verify duplicate bead IDs do not invert rig-first/city-last behavior.
- [x] Verify tier, priority, and own-in-progress precedence remain unchanged.
- [x] Run class-escalation controls repeatedly: 60 PASS, 0 FAIL, 0 SKIP.
- [x] Run the guarded 10-job fast matrix: 10 PASS, 0 FAIL, 0 SKIP.
- [x] Audit the full release evidence in [the release gate](release-gates/ga-hgtxtq-hook-cross-store-tie-break-gate.md).
