### PR TITLE
fix(rig): judge a relative rig path against the city, not the caller's cwd

### DIFF
--- a/internal/config/site_binding_durability_test.go
+++ b/internal/config/site_binding_durability_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -190,5 +192,73 @@ func TestApplySiteBindingsSkipsDurabilityAuditOnSyntheticFS(t *testing.T) {
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("synthetic FS was probed against the host: %q", warnings)
+	}
+}
+
+// TestApplySiteBindingsJudgesRelativeRigPathsAgainstTheCity runs the audit
+// against the real probe, because this is the one caller that reaches it with a
+// relative path and every other test in this file stubs the probe with a
+// function that ignores cityRoot entirely.
+//
+// city.toml may write a rig path relative to the city, and the rest of the
+// codebase joins it onto the city root (internal/rig/topology.go). This audit
+// reads rig.Path verbatim, so before the resolution moved into Classify the
+// verdict came from wherever the process happened to be running — a controller
+// started from a tmpfs working directory warned that a rig safely under the city
+// was about to be lost, and told the operator to move it under the city
+// directory it was already in.
+//
+// The registration guard cannot exercise this: validateRequest refuses a
+// non-absolute ProvisionRequest.Path before the check runs. The boot audit is
+// where the bug was reachable, so it is where the real probe belongs.
+func TestApplySiteBindingsJudgesRelativeRigPathsAgainstTheCity(t *testing.T) {
+	cityRoot := t.TempDir()
+
+	// tmpfs is what makes the working directory discriminating. Without it the
+	// pre-fix and post-fix verdicts agree and a pass would mean nothing, so skip
+	// loudly instead.
+	ephemeralDir, err := os.MkdirTemp("/dev/shm", "gc-site-binding-cwd-*")
+	if err != nil {
+		t.Skipf("no usable tmpfs to run from: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(ephemeralDir); err != nil {
+			t.Logf("removing %s: %v", ephemeralDir, err)
+		}
+	})
+	if got := pathdurability.Classify(cityRoot, ephemeralDir).Class; got != pathdurability.Ephemeral {
+		t.Skipf("working directory classifies as %q, not %q; the relative-path bug is invisible here", got, pathdurability.Ephemeral)
+	}
+
+	// doomed is the control. It is an absolute path on the same tmpfs, so it must
+	// warn in this very run — otherwise silence for the relative binding would
+	// prove only that the audit had stopped warning about anything.
+	doomed := filepath.Join(ephemeralDir, "doomed")
+	cfg := bindRigs(t, cityRoot, map[string]string{
+		"backend": "rigs/backend",
+		"doomed":  doomed,
+	})
+
+	t.Chdir(ephemeralDir)
+
+	warnings, err := ApplySiteBindings(fsys.OSFS{}, cityRoot, cfg)
+	if err != nil {
+		t.Fatalf("ApplySiteBindings: %v", err)
+	}
+	var control, relative []string
+	for _, w := range warnings {
+		switch {
+		case strings.Contains(w, doomed):
+			control = append(control, w)
+		case strings.Contains(w, "rigs/backend"):
+			relative = append(relative, w)
+		}
+	}
+	if len(control) != 1 {
+		t.Fatalf("the control binding on tmpfs did not warn exactly once (got %d), so this test cannot "+
+			"tell a fixed audit from a silent one: %q", len(control), warnings)
+	}
+	if len(relative) != 0 {
+		t.Fatalf("a rig path relative to the city was judged against the working directory: %q", relative)
 	}
 }

--- a/internal/pathdurability/durability.go
+++ b/internal/pathdurability/durability.go
@@ -85,10 +85,21 @@ var (
 // Classify reports whether path is likely to survive replacement of the process
 // that registered it, judged relative to cityRoot.
 //
+// A relative path is resolved against cityRoot, matching how the rest of the
+// codebase reads a rig path out of city.toml. Resolving it against the process
+// working directory instead would produce a confident verdict about an unrelated
+// directory: probeDevice's ancestor walk terminates at "." rather than running
+// out of ancestors, so such a path reaches Unknown only if stat(".") itself
+// fails, and the fail-open rule below would not catch the mistake.
+//
 // It never returns an error: a probe that cannot reach a conclusion yields
 // Unknown, so a caller on an unsupported platform or an unreadable mount is
 // never blocked by a check that could not run.
 func Classify(cityRoot, path string) Result {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cityRoot, path)
+	}
+
 	cityDev, _, cityErr := probeDevice(resolveSymlinks(cityRoot))
 
 	dev, probed, err := probeDevice(resolveSymlinks(path))

--- a/internal/pathdurability/durability_test.go
+++ b/internal/pathdurability/durability_test.go
@@ -115,6 +115,42 @@ func TestClassifyAcceptsCityRootedBindings(t *testing.T) {
 	}
 }
 
+// TestClassifyResolvesRelativePathsAgainstTheCityRoot covers the shape city.toml
+// actually allows: a rig path written relative to the city, which the rest of the
+// codebase joins onto the city root (see internal/rig/topology.go). Judged against
+// the process working directory instead, such a path yields a confident verdict
+// about an unrelated directory — and because probeDevice's ancestor walk
+// terminates at "." rather than running out of ancestors, it falls back to
+// Unknown only if stat(".") itself fails, so in practice the fail-open escape
+// hatch does not save it.
+func TestClassifyResolvesRelativePathsAgainstTheCityRoot(t *testing.T) {
+	mounts := hostedPodMounts()
+	mounts.install(t)
+
+	t.Run("relative path under the city is durable", func(t *testing.T) {
+		got := Classify("/city", "rigs/backend")
+		if got.Class != CityDevice {
+			t.Fatalf("Classify(/city, rigs/backend).Class = %q, want %q", got.Class, CityDevice)
+		}
+		if got.Probed != "/city/rigs/backend" {
+			t.Fatalf("Probed = %q, want /city/rigs/backend", got.Probed)
+		}
+	})
+
+	// Control: relative paths must not be blanket-accepted. One that escapes the
+	// city onto tmpfs still has to be caught, which a fix that simply trusted any
+	// non-absolute path would miss.
+	t.Run("relative path escaping onto tmpfs is still caught", func(t *testing.T) {
+		got := Classify("/city", "../tmp/adopt")
+		if got.Class != Ephemeral {
+			t.Fatalf("Classify(/city, ../tmp/adopt).Class = %q, want %q", got.Class, Ephemeral)
+		}
+		if got.Filesystem != "tmpfs" {
+			t.Fatalf("Filesystem = %q, want tmpfs", got.Filesystem)
+		}
+	})
+}
+
 // TestClassifyRejectsNonPersistentPaths is the guard direction. /var/tmp is the
 // case a "/tmp" prefix denylist misses: inside a pod it is on the overlay
 // rootfs and dies with the container just the same.

--- a/internal/rig/path_durability_test.go
+++ b/internal/rig/path_durability_test.go
@@ -1,6 +1,7 @@
 package rig
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -83,5 +84,51 @@ func TestRigPathDurabilityFindingIsSilentWhenUnprobeable(t *testing.T) {
 	}
 	if warning != "" {
 		t.Fatalf("unprobeable path warned %q, want silence", warning)
+	}
+}
+
+// TestCheckRigPathDurabilityJudgesRelativePathsAgainstTheCity exercises the real
+// probe rather than a synthetic Result. Every other test in this file hands
+// rigPathDurabilityFinding a verdict directly, which is exactly why a bug in how
+// the path reaches the probe could survive them all: a rig path relative to the
+// city was classified against the process working directory.
+//
+// This is defense in depth, not a reproduction of a reachable failure. Provision
+// cannot deliver a relative path here — validateRequest rejects a non-absolute
+// ProvisionRequest.Path before the durability check runs, and the CLI resolves a
+// bare relative argument against the city before that (resolveRigAddPath). The
+// caller that did reach Classify with a relative path is the boot audit in
+// internal/config, which reads rig paths verbatim from city.toml. This test
+// calls checkRigPathDurability directly, below validateRequest, so the guard
+// stays honest if a future caller loses that resolution.
+//
+// The working directory is moved onto a filesystem the probe calls ephemeral, so
+// the pre-fix behavior is a hard refusal and the post-fix behavior is silence.
+func TestCheckRigPathDurabilityJudgesRelativePathsAgainstTheCity(t *testing.T) {
+	cityPath := t.TempDir()
+
+	// /dev/shm is tmpfs on Linux, which is what makes this discriminating. If it
+	// is absent or shares a device with the city, the test cannot tell the two
+	// behaviors apart, so skip loudly rather than pass for the wrong reason.
+	ephemeralDir, err := os.MkdirTemp("/dev/shm", "gc-rig-cwd-*")
+	if err != nil {
+		t.Skipf("no usable tmpfs to run from: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(ephemeralDir); err != nil {
+			t.Logf("removing %s: %v", ephemeralDir, err)
+		}
+	})
+	if got := pathdurability.Classify(cityPath, ephemeralDir).Class; got != pathdurability.Ephemeral {
+		t.Skipf("working directory classifies as %q, not %q; the relative-path bug is invisible here", got, pathdurability.Ephemeral)
+	}
+	t.Chdir(ephemeralDir)
+
+	warning, err := checkRigPathDurability(cityPath, "rigs/backend", false)
+	if err != nil {
+		t.Fatalf("a rig path relative to the city was refused: %v", err)
+	}
+	if warning != "" {
+		t.Fatalf("a rig path relative to the city warned %q, want silence", warning)
 	}
 }


### PR DESCRIPTION
`pathdurability.Classify` judged a relative rig path against the process's working
directory instead of the city. `city.toml` may hold a rig path relative to the city root,
and the rest of the codebase joins it onto the city before use
(`internal/rig/topology.go:46-47`) — the classifier did not.

## Where this was reachable

The **boot audit** in `internal/config/site_binding_durability.go` reads `rig.Path`
verbatim out of the site binding. A controller started from a working directory on tmpfs
warned that a rig safely under the city was about to be lost:

```
rig "backend" is bound to rigs/backend, which is on tmpfs and does not survive a
restart of this machine or container: the rig content is lost on the next restart.
Move it under the city directory (...) and re-register it with `gc rig add`
```

`rigs/backend` was already under the city directory, on the durable device — exactly where
the message told the operator to move it.

**Correction to an earlier draft of this PR:** it claimed `gc rig add rigs/backend` was
refused outright. That is not reachable, and three reviewers independently caught it.
`validateRequest` (`internal/rig/deps.go`) rejects a non-absolute `ProvisionRequest.Path`
before the durability check runs, and the CLI resolves a bare relative argument against the
city first (`resolveRigAddPath`, `cmd/gc/cmd_rig.go`). Fixing `Classify` hardens the
registration path too, but as **defense in depth behind two existing guards** — not as a
repair of a live refusal. The advisory audit was the only production victim.

## Why the fail-open rule did not catch it

`Classify` has an escape hatch: an unprobeable path returns `Unknown` and the caller lets
it through. `probeDevice` walks up the ancestors of the path it is given, and for a
relative path that walk terminates at `"."` rather than running out of ancestors. So it
reaches `Unknown` only if `stat(".")` itself fails — in practice it always produces a
**confident verdict about the wrong directory**. The fail-open rule protects against "I
cannot tell", not against "I answered a different question".

## The fix

```go
if !filepath.IsAbs(path) {
    path = filepath.Join(cityRoot, path)
}
```

Kept in `Classify` rather than pushed to the two callers. A relative rig path meaning
*city-relative* is a settled convention here — `topology.go`, `detectRigReAdd`,
`RigComplete` and `resolveStoreScopeRoot` all encode it — and `Classify` already takes
`cityRoot` and already promises "judged relative to `cityRoot`" in its doc comment. The
alternative (a strict absolute-only contract) cannot be enforced at this layer: `Classify`
has no error channel by contract and panics are banned, so the realistic strict variant is
`relative → Unknown`, which fails open and would leave the boot audit permanently blind to
genuinely doomed bindings. Pushing the join to callers also duplicates it in two places and
re-creates this exact omission the next time a caller appears.

## Tests

Three, all written red first and mutation-proven.

**`internal/config`** — the audit that was actually broken, against the **real** probe.
Every other test in that file stubs the classifier with `func(_, path string)`, which
ignores `cityRoot` entirely, so none of them could see this. It carries an absolute-tmpfs
control binding that must warn **in the same run**, so silence for the relative binding
cannot come from an audit that stopped warning at all. Reverting the fix reds it with the
operator-facing message quoted above.

**`internal/pathdurability`** — the durable case, plus the control that keeps it honest:
`Classify("/city", "../tmp/adopt")`, a relative path that escapes onto tmpfs, must still
come back `Ephemeral`. Without it, a fix that simply accepted every relative path would
pass.

**`internal/rig`** — the first test in that file to exercise the real probe instead of
handing `rigPathDurabilityFinding` a synthetic `Result`. It calls `checkRigPathDurability`
directly, below `validateRequest`, so the guard stays honest if a future caller loses the
resolution.

All three skip loudly rather than passing vacuously when the host has no tmpfs to
distinguish the two behaviours.

## Mutations confirmed red

- revert the `IsAbs`/`Join` → the config audit test and both new probe tests fail;
- accept every relative path unconditionally → the escape control fails;
- join against `/` instead of `cityRoot` → the fake-mount subtest fails;
- drop the trailing path segment → the `Probed` assertion fails.

Fixes ga-o1qbw.
