### PR TITLE
fix(dolt): a quarantine alert that never lands should say so (ga-u2wiy)

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -3101,10 +3101,9 @@ gc_only_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
-    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
-    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
-    print_existing_quarantine_marker "$db" "$quarantine_marker" "$quarantine_reason" "$quarantine_created_at"
+    # Same operator-visible state as a scheduled refusal, so it reports the
+    # same way: stdout alone leaves the quarantine off the bus entirely.
+    report_existing_quarantine "$db"
     return 1
   fi
 

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1508,7 +1508,7 @@ write_compact_marker() {
       if mail_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at"; then
         record_marker_notify_state "$quarantine_dir" "$db" "$reason" 1
       else
-        record_marker_notify_state "$quarantine_dir" "$db" "$reason" 0
+        record_marker_notify_state "$quarantine_dir" "$db" "$reason" 0 "$quarantine_notify_error"
       fi
     else
       record_marker_notify_state "$quarantine_dir" "$db" "$reason" 0

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1531,6 +1531,14 @@ emit_compact_quarantine_event() {
 # marker. Empty means delivered; callers reset it before each attempt.
 quarantine_notify_error=""
 
+# mail_compact_quarantine_alert DB TYPE MARKER REASON [CREATED_AT]
+#   Send the quarantine alert; return 0 on delivery, 1 on a failed send with
+#   the reason recorded in quarantine_notify_error. CONTRACT: call this ONLY as
+#   a condition (e.g. `if mail_compact_quarantine_alert ...`), never as a bare
+#   statement. The internal _ca_err=$(gc mail send ...) capture runs under
+#   `set -eu`, so a bare-statement call would abort the whole compaction run on
+#   a failed send -- the exact silent mid-cycle failure this alert exists to
+#   prevent.
 mail_compact_quarantine_alert() {
   _ca_db="$1"
   _ca_type="$2"

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1539,7 +1539,11 @@ mail_compact_quarantine_alert() {
   _ca_created_at="${5:-<unknown>}"
   _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
   quarantine_notify_error=""
-  if _ca_err=$(gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" 2>&1 >/dev/null); then
+  exec 4>&1
+  _ca_err=$(gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" 2>&1 1>&4)
+  _ca_status=$?
+  exec 4>&-
+  if [ "$_ca_status" -eq 0 ]; then
     return 0
   fi
   # A quarantine nobody is told about is a quarantine nobody clears, so an

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1527,6 +1527,10 @@ emit_compact_quarantine_event() {
   gc event emit dolt.compact.quarantine --actor controller --message "$_ca_msg" || true
 }
 
+# quarantine_notify_error holds why the last alert did not land, for the
+# marker. Empty means delivered; callers reset it before each attempt.
+quarantine_notify_error=""
+
 mail_compact_quarantine_alert() {
   _ca_db="$1"
   _ca_type="$2"
@@ -1534,9 +1538,15 @@ mail_compact_quarantine_alert() {
   _ca_reason="$4"
   _ca_created_at="${5:-<unknown>}"
   _ca_msg="db=$_ca_db type=$_ca_type marker=$_ca_path reason=$_ca_reason created_at=$_ca_created_at recipient=$compact_alert_to"
-  if gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg"; then
+  quarantine_notify_error=""
+  if _ca_err=$(gc mail send "$compact_alert_to" --from controller -s "dolt compact quarantine: $_ca_db $_ca_type" -m "$_ca_msg" 2>&1 >/dev/null); then
     return 0
   fi
+  # A quarantine nobody is told about is a quarantine nobody clears, so an
+  # undelivered alert has to be as loud as the quarantine itself.
+  quarantine_notify_error=$(printf '%s' "$_ca_err" | tr '\n' ' ' | cut -c1-200)
+  printf 'compact: db=%s quarantine alert did not reach recipient %s: %s\n' \
+    "$_ca_db" "$compact_alert_to" "${quarantine_notify_error:-<no error output>}" >&2
   return 1
 }
 
@@ -1583,16 +1593,19 @@ marker_should_notify() {
 
 # record_marker_notify_state DIR DB REASON EMITTED
 #   Patches only the notify-bookkeeping fields (seen_count, notify_count,
-#   last_notified_ts, last_notified_reason) onto DB's existing marker in
-#   DIR, preserving every other field byte-for-byte. EMITTED=1 bumps
-#   notify_count and stamps last_notified_ts/last_notified_reason; EMITTED=0
-#   only bumps seen_count. A missing marker or write failure is a silent
+#   last_notified_ts, last_notified_reason, last_notify_error) onto DB's
+#   existing marker in DIR, preserving every other field byte-for-byte.
+#   EMITTED=1 bumps notify_count, stamps last_notified_ts/last_notified_reason
+#   and clears last_notify_error; EMITTED=0 bumps seen_count and records
+#   ERROR, so a marker stuck at notify_count=0 says why instead of leaving
+#   the operator to guess. A missing marker or write failure is a silent
 #   no-op — bookkeeping must never block or fail compaction.
 record_marker_notify_state() {
   _mn_dir="$1"
   _mn_db="$2"
   _mn_reason="$3"
   _mn_emitted="$4"
+  _mn_error="${5:-}"
 
   _mn_marker=$(compact_marker_path "$_mn_dir" "$_mn_db")
   [ -f "$_mn_marker" ] && [ -r "$_mn_marker" ] || return 0
@@ -1605,10 +1618,12 @@ record_marker_notify_state() {
   case "$_mn_notify_count" in ''|*[!0-9]*) _mn_notify_count=0 ;; esac
   _mn_last_ts=$(compact_marker_value "$_mn_dir" "$_mn_db" last_notified_ts || true)
   _mn_last_reason=$(compact_marker_value "$_mn_dir" "$_mn_db" last_notified_reason || true)
+  _mn_last_error="$_mn_error"
   if [ "$_mn_emitted" = "1" ]; then
     _mn_notify_count=$((_mn_notify_count + 1))
     _mn_last_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     _mn_last_reason="$_mn_reason"
+    _mn_last_error=""
   fi
 
   _mn_old_umask=$(umask)
@@ -1618,7 +1633,7 @@ record_marker_notify_state() {
     return 0
   }
   umask "$_mn_old_umask"
-  if ! awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_mn_marker" > "$_mn_tmp" 2>/dev/null; then
+  if ! awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason|last_notify_error)=/' "$_mn_marker" > "$_mn_tmp" 2>/dev/null; then
     rm -f "$_mn_tmp"
     return 0
   fi
@@ -1627,6 +1642,7 @@ record_marker_notify_state() {
     printf 'notify_count=%s\n' "$_mn_notify_count"
     printf 'last_notified_ts=%s\n' "$_mn_last_ts"
     printf 'last_notified_reason=%s\n' "$_mn_last_reason"
+    printf 'last_notify_error=%s\n' "$_mn_last_error"
   } >> "$_mn_tmp" 2>/dev/null; then
     rm -f "$_mn_tmp"
     return 0
@@ -1647,6 +1663,8 @@ record_marker_notify_state() {
 #   elapses, instead of once ever or on every single cycle.
 report_existing_quarantine() {
   db="$1"
+  # One run reports many dbs; a prior db's send failure is not this db's.
+  quarantine_notify_error=""
   quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
   quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
   quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
@@ -1662,7 +1680,7 @@ report_existing_quarantine() {
       quarantine_alert_emitted=1
     fi
   fi
-  record_marker_notify_state "$quarantine_dir" "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted"
+  record_marker_notify_state "$quarantine_dir" "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted" "$quarantine_notify_error"
 }
 
 ensure_compact_marker_writable() {

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -331,7 +331,10 @@ func runCompactScriptCommand(t *testing.T, mode string) (string, string, error) 
 // fixtures. It logs every invocation and, when the returned mail-failure
 // sentinel file exists, fails `gc mail send` so tests can exercise the
 // script's mail-delivery failure path. The sentinel does not exist by
-// default, so mail succeeds unless a test opts in.
+// default, so mail succeeds unless a test opts in. On a successful mail
+// send it prints a stdout confirmation line, mirroring real `gc mail
+// send`'s stdout-on-success behavior, so callers can assert that the
+// caller script actually surfaces it instead of swallowing it.
 func writeCompactFakeGC(t *testing.T, binDir string) (logPath, mailFailPath string) {
 	t.Helper()
 	logPath = filepath.Join(binDir, "gc.log")
@@ -345,6 +348,10 @@ fi
 if [ "${1:-}" = "mail" ] && [ "${2:-}" = "send" ] && [ -f %s ]; then
   printf 'fake gc: mail send failed\n' >&2
   exit 1
+fi
+if [ "${1:-}" = "mail" ] && [ "${2:-}" = "send" ]; then
+  printf 'gc mail send: message sent\n'
+  exit 0
 fi
 exit 0
 `, shellQuote(logPath), shellQuote(mailFailPath)))
@@ -3699,6 +3706,20 @@ func TestCompactScriptQuarantineBlocksSecondCycleAfterRowCountDecrease(t *testin
 	}
 	if strings.Contains(string(logData), "DOLT_GC") {
 		t.Fatalf("quarantined database must not run full GC:\n%s", logData)
+	}
+}
+
+func TestCompactScriptQuarantineAlertSuccessConfirmationIsVisible(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+
+	// A successful quarantine alert send still has a live stdout stream;
+	// capturing stderr for the failure path must not discard it.
+	if !strings.Contains(firstOut, "gc mail send: message sent") {
+		t.Fatalf("a successful quarantine alert send must surface its own confirmation, not swallow it:\n%s", firstOut)
 	}
 }
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -3772,6 +3772,44 @@ func TestCompactScriptQuarantineMailFailureIsRetriedNextCycle(t *testing.T) {
 	}
 }
 
+func TestCompactScriptUndeliverableQuarantineAlertRecordsWhyInMarker(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	if err := os.WriteFile(fixture.mailFailFile, nil, 0o644); err != nil {
+		t.Fatalf("arm mail-failure sentinel: %v", err)
+	}
+
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500", "GC_DOLT_COMPACT_ALERT_TO=nobody")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+
+	// An alert that never lands is how five cities stayed fail-closed for a
+	// month: notify_count=0, and nothing anywhere saying why.
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if got := compactMarkerValue(t, marker, "last_notify_error"); !strings.Contains(got, "mail send failed") {
+		t.Fatalf("marker must record why the alert did not land, got %q", got)
+	}
+	if !strings.Contains(firstOut, "quarantine alert did not reach recipient") || !strings.Contains(firstOut, "nobody") {
+		t.Fatalf("compact must name the unreachable recipient:\n%s", firstOut)
+	}
+
+	// The field describes the CURRENT alerting state, so a delivered alert
+	// has to clear it rather than leave a stale cause behind.
+	if err := os.Remove(fixture.mailFailFile); err != nil {
+		t.Fatalf("disarm mail-failure sentinel: %v", err)
+	}
+	secondOut, err := fixture.run(t, "below_threshold", "GC_DOLT_COMPACT_ALERT_TO=nobody")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+	if got := compactMarkerValue(t, marker, "last_notify_error"); got != "" {
+		t.Fatalf("a delivered alert must clear last_notify_error, got %q", got)
+	}
+	if got := compactMarkerValue(t, marker, "notify_count"); got != "1" {
+		t.Fatalf("delivered alert should count once, got %q", got)
+	}
+}
+
 func TestCompactScriptQuarantineReasonChangeReMails(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -4379,6 +4379,35 @@ func TestCompactScriptGCOnlyFlagReclaimsBelowThresholdWithFullGC(t *testing.T) {
 	}
 }
 
+func TestCompactScriptGCOnlyQuarantineRefusalStillReports(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+	before := len(compactGCLogLinesWithPrefix(readCompactGCLog(t, fixture), "gc event emit dolt.compact.quarantine"))
+
+	out, err := fixture.runWithArgs(t, "below_threshold", []string{"--gc-only"})
+	if err == nil {
+		t.Fatalf("gc-only reclaim succeeded despite quarantine:\n%s", out)
+	}
+	if !strings.Contains(out, "integrity quarantine marker exists") {
+		t.Fatalf("gc-only must explain the quarantine:\n%s", out)
+	}
+
+	// A gc-only refusal is the same operator-visible state as a scheduled
+	// one. Reporting it to stdout alone is how four cities held a quarantine
+	// for weeks with zero events on the bus (ga-u2wiy).
+	log := readCompactGCLog(t, fixture)
+	if after := len(compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")); after != before+1 {
+		t.Fatalf("gc-only refusal must emit a dolt.compact.quarantine event, want %d got %d\nlog:\n%s", before+1, after, log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if got := compactMarkerValue(t, marker, "seen_count"); got != "2" {
+		t.Fatalf("gc-only refusal must count as a sighting, got seen_count=%q", got)
+	}
+}
+
 func TestCompactScriptGCOnlyFlagHonorsOnlyDBFlag(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	if err := os.MkdirAll(filepath.Join(fixture.dataDir, "cache", ".dolt"), 0o755); err != nil {


### PR DESCRIPTION
Every Dolt-backed city on the dev fleet has compaction fail-closed on an integrity quarantine marker, and not one of the six quarantines was ever reported to a human. Two independent reasons, both fixed here.

## 1. The alert failed silently for a month

The compact-quarantine alert defaults to recipient `mayor`. None of the affected cities has a mayor, so `gc mail send` failed on every cycle, the failure was absorbed into `notify_count=0`, and the markers sat at `seen_count=177 / notify_count=0` for up to 35 days without ever saying why.

The marker is the durable artifact an operator actually reads, so it now carries the cause:

- `mail_compact_quarantine_alert` captures the send's stderr and prints a distinct `quarantine alert did not reach recipient <who>: <why>` line.
- `record_quarantine_notify_state` stamps `last_notify_error` on failure and clears it on delivery.

A marker stuck at `notify_count=0` now explains itself instead of leaving a month-long silence to be found by accident.

## 2. `--gc-only` skipped the reporting path entirely

The scheduled compact path and the bare-GC path both route an existing quarantine through `report_existing_quarantine` — emit `dolt.compact.quarantine`, send the gated alert, record the sighting. The `--gc-only` reclaim path printed to stdout and returned, so a city whose reclaim ran on that path held a quarantine entirely off the bus.

That is the measured difference across this box: trust 0 quarantine events in 4 days, platform 0 in 26, orchestration 1 in 13, substrate 4 in 33 — against gas-city-inc's 12. gas-city-inc is the one city taking a scheduled path.

## Scope

Bookkeeping still never blocks compaction, and dedup is unchanged. This adds the missing cause and closes the one path that bypassed reporting; it does not change **who** is mailed or **when**.

The `mayor`-as-default recipient question is a separate design decision and stays open on ga-u2wiy.

## Tests

`dog_exec_scripts_test.go` covers both: an alert whose send fails records `last_notify_error` and prints the recipient and reason, and `--gc-only` on an existing quarantine takes the same reporting path as the scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2348 — addresses the operator-visibility half of that issue: a quarantine alert that fails to send now records and prints why it did not land, and the --gc-only reclaim path emits the quarantine event and records the sighting instead of only printing to stdout. It does not address the concurrent-write race that creates the false-positive quarantines in the first place, nor gc doctor surfacing quarantine markers.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->