### PR TITLE
fix(beads): invalidate a dependent's ready projection on a status CHANGE, not on the field's presence (ga-fnmb5)

### DIFF
--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -235,6 +235,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		}
 	case "bead.updated":
 		existing, cached := c.beads[b.ID]
+		// Read before absorb: dependents' readiness turns on this row's status,
+		// so only a real transition may invalidate their projection.
+		statusChanged := !cached || existing.Status != b.Status
 		if !cached || beadChanged(existing, b, false) {
 			c.noteMutationLocked(b.ID)
 			c.absorbFreshLocked(b.ID, b, time.Now(), absorbOpts{
@@ -248,7 +251,10 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			c.noteMutationLocked(b.ID)
 			mutated = true
 		}
-		if hasCacheEventField(fields, "status") && c.clearDependentReadyProjectionsLocked(b.ID) {
+		// Gating on the field's PRESENCE re-entered the reconcile loop: the
+		// emitter always carries status, and clearing nils is_blocked (ga-fnmb5).
+		if statusChanged && hasCacheEventField(fields, "status") &&
+			c.clearDependentReadyProjectionsLocked(b.ID) {
 			mutated = true
 		}
 	case "bead.closed":

--- a/internal/beads/caching_store_reconcile_internal_test.go
+++ b/internal/beads/caching_store_reconcile_internal_test.go
@@ -805,3 +805,73 @@ func TestPrimeFailureThenReconcileConverges(t *testing.T) {
 		t.Fatalf("cachedReadyOnly = %#v, want to include %s", got, missed.ID)
 	}
 }
+
+// The controller feeds every bead event on the bus — including the cache's own
+// cache-reconcile emissions — straight back into ApplyEvent on the same store.
+func TestUnchangedStatusEventDoesNotReopenTheReconcileLoop(t *testing.T) {
+	mem := NewMemStore()
+	blocker, err := mem.Create(Bead{Title: "blocker"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	blocked := true
+	dependent, err := mem.Create(Bead{Title: "dependent", IsBlocked: &blocked})
+	if err != nil {
+		t.Fatalf("Create dependent: %v", err)
+	}
+	if err := mem.DepAdd(dependent.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	var emitted []string
+	cs := NewCachingStoreForTest(mem, func(eventType, beadID string, _ json.RawMessage) {
+		emitted = append(emitted, eventType+":"+beadID)
+	})
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	cs.runReconciliation()
+	emitted = nil
+
+	// The reconcile emitter always carries status, whether or not it changed.
+	payload, err := json.Marshal(blocker)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	cs.ApplyEvent("bead.updated", payload)
+
+	cs.mu.RLock()
+	cachedDependent, ok := cs.beads[dependent.ID]
+	cs.mu.RUnlock()
+	if !ok {
+		t.Fatalf("dependent %s dropped from cache", dependent.ID)
+	}
+	if cachedDependent.IsBlocked == nil {
+		t.Fatalf("an event that changed nothing invalidated %s's ready projection", dependent.ID)
+	}
+
+	cs.runReconciliation()
+	if len(emitted) != 0 {
+		t.Fatalf("reconcile re-emitted after a no-op event: %v", emitted)
+	}
+
+	// The other half: a real transition must still invalidate the dependent, or
+	// the guard above would silently pin a stale ready projection.
+	inProgress := "in_progress"
+	if err := mem.Update(blocker.ID, UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("Update blocker: %v", err)
+	}
+	moved := cloneBead(blocker)
+	moved.Status = inProgress
+	if payload, err = json.Marshal(moved); err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	cs.ApplyEvent("bead.updated", payload)
+
+	cs.mu.RLock()
+	cachedDependent = cs.beads[dependent.ID]
+	cs.mu.RUnlock()
+	if cachedDependent.IsBlocked != nil {
+		t.Fatalf("a real status change left %s's ready projection stale", dependent.ID)
+	}
+}


### PR DESCRIPTION
## The bug

Every city in the fleet is emitting `bead.updated` continuously from actor
`cache-reconcile`, with **byte-identical payloads**, forever. Measured
mid-rotation:

| city | events/hr | beads | share of that city's event bus |
|---|---|---|---|
| maintainer-city | 107,518 | 2,448 | **100%** |
| platform | 17,657 | | 96% |
| gas-city-inc | 11,984 | 112 | |
| orchestration | 11,023 | | 93% |
| trust | 11,023 | | 93% |
| substrate | 3,657 | | 84% |

**~151,000 spurious events/hour fleet-wide (~3.6M/day.)**

## The loop

Four links, and cutting any one closes it:

1. Reconcile sees cached `IsBlocked == nil` vs fresh non-nil, `beadChanged`
   fires, it emits `bead.updated` and absorbs the fresh row.
2. `cmd/gc/api_state.go:539` hands that event straight back into
   `ApplyEvent` on the **same** `CachingStore`. There is no actor filter —
   the `evt.Actor != "cache-reconcile"` check there only skips `cs.Poke()`.
3. `handleBeadEvent`'s `bead.updated` case cleared **dependents'** ready
   projections because the payload merely *carried* a status field. Every
   reconcile emission does.
4. `clearReadyProjectionLocked` sets `IsBlocked = nil`; with `depsComplete`
   false, `clearAllReadyProjectionsLocked` does it to every cached row.

→ back to 1.

## The fix

Link 3. Gate the dependent invalidation on the status having actually
**changed**, not on the field being present in the payload. A real
transition still invalidates; a no-op event no longer does.

## Why not an actor filter at link 2

Deliberately not done. `"cache-reconcile"` names a *role*, not an
*instance* — in a multi-process topology another process's reconcile
emission is exactly how this process's cache learns. Skipping by actor
string would break that silently. With link 3 cut, the re-apply is merely
wasteful, not a loop.

## Evidence that this is link 3 and not `depsChanged`

Across the 112 flooding gas-city-inc beads the payload key-sets span 20
distinct shapes (`priority` absent from 49; description/labels/metadata/
dependencies/assignee come and go) and **31 of the beads have no
dependencies at all**. `is_blocked` is present in **all 20** shapes, 100%.

## Verification

TDD, red → green. Mutation-checked in **both** directions — the test
asserts a no-op event leaves the dependent's projection intact *and* that a
real status change still invalidates it, so each mutation fails on its own
distinct assertion. (The first draft only covered the negative half:
hardwiring `statusChanged := false` left the entire `internal/beads` package
green. That gap is now closed.)

Full `internal/beads` suite green (21.3s); `go vet` clean.

Closes ga-fnmb5. Baseline for post-deploy verification is on ga-65mxl.