### PR TITLE
fix(zcode): a probe that could not run is a spawn failure, not an old node (ga-xx7x9)

### DIFF
--- a/cmd/gc/city_runtime_server_lifecycle_test.go
+++ b/cmd/gc/city_runtime_server_lifecycle_test.go
@@ -280,6 +280,14 @@ func (p *forceLifecycleProvider) ListRunning(prefix string) ([]string, error) {
 	return running, err
 }
 
+// Stop is recorded so the trace says whether the late sweep even ATTEMPTED a
+// stop — an empty lateRunning and a stop that did not take look identical
+// otherwise (ga-0q686).
+func (p *forceLifecycleProvider) Stop(name string) error {
+	p.record("Stop:" + name)
+	return p.Fake.Stop(name)
+}
+
 func (p *forceLifecycleProvider) ConfigureServer() error { return nil }
 
 func (p *forceLifecycleProvider) TeardownServer() error {
@@ -391,6 +399,8 @@ func TestCityRuntimeForceShutdownTearsDownAfterLateAsyncSweep(t *testing.T) {
 		t.Fatalf("TeardownServer landed before the last (late-async) ListRunning (events: %v); a session created between the sweeps would be killed ungracefully", ev)
 	}
 	if sp.IsRunning("worker") {
-		t.Fatal("force shutdown missed the late async-started runtime")
+		// The four assertions above all print ev; this one did not, so the only
+		// assertion that ever fires was the only undiagnosable one (ga-0q686).
+		t.Fatalf("force shutdown missed the late async-started runtime (events: %v)", ev)
 	}
 }

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -549,6 +549,44 @@ func TestHarnessKeepsTheAdapterStderrThatNamesAFailure(t *testing.T) {
 	}
 }
 
+// Five of the six preconditions are pure env/filesystem tests; only the node
+// floor check forks, and a fork that fails under load is not a version verdict.
+func TestNodeProbeSpawnFailureIsNotReportedAsAnOldNode(t *testing.T) {
+	t.Parallel()
+
+	killed := filepath.Join(t.TempDir(), "killed-node")
+	if err := os.WriteFile(killed, []byte("#!/bin/sh\nkill -9 $$\n"), 0o755); err != nil {
+		t.Fatalf("write killed-node: %v", err)
+	}
+	h := newHarness(t, map[string]string{"ZCODE_NODE_BIN": killed})
+
+	if _, code := h.run("hello\n"); code != 78 {
+		t.Fatalf("exit code = %d, want 78 (EX_CONFIG)", code)
+	}
+	if !strings.Contains(h.stderr, "could not run") {
+		t.Fatalf("a killed probe was not named as a spawn failure; stderr = %q", h.stderr)
+	}
+	// 137 = 128+SIGKILL, the OOM signature the saturated-box flake would carry.
+	if !strings.Contains(h.stderr, "exit 137") {
+		t.Fatalf("stderr lost the probe's exit status; stderr = %q", h.stderr)
+	}
+
+	// The other half: a node that really is too old must still be a config error,
+	// or the guard above would wave through the case the floor check exists for.
+	old := filepath.Join(t.TempDir(), "old-node")
+	if err := os.WriteFile(old, []byte("#!/bin/sh\necho v18.0.0\n"), 0o755); err != nil {
+		t.Fatalf("write old-node: %v", err)
+	}
+	h = newHarness(t, map[string]string{"ZCODE_NODE_BIN": old})
+
+	if _, code := h.run("hello\n"); code != 78 {
+		t.Fatalf("exit code = %d, want 78 (EX_CONFIG)", code)
+	}
+	if !strings.Contains(h.stderr, "is v18.0.0") {
+		t.Fatalf("a genuinely old node was not reported as a version problem; stderr = %q", h.stderr)
+	}
+}
+
 // Behavior 3: gc's pre-Enter Escape and stray control bytes never reach the
 // model.
 func TestControlBytesAreStripped(t *testing.T) {

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -122,6 +122,9 @@ type harness struct {
 	mirrorDir string
 	workDir   string
 	env       map[string]string
+	// stderr holds the last run's stderr. The adapter's die_config sites all
+	// exit 78 and only stderr says which precondition tripped (ga-xx7x9).
+	stderr string
 }
 
 func newHarness(t *testing.T, stubEnv map[string]string) *harness {
@@ -199,17 +202,21 @@ func (h *harness) run(stdin string) (string, int) {
 
 	cmd := h.command()
 	cmd.Stdin = strings.NewReader(stdin)
-	var out strings.Builder
+	var out, errOut strings.Builder
 	cmd.Stdout = &out
-	cmd.Stderr = io.Discard
+	cmd.Stderr = &errOut
 	err := cmd.Run()
+	h.stderr = errOut.String()
 	code := 0
 	if err != nil {
 		var exitErr *exec.ExitError
 		if !asExitError(err, &exitErr) {
-			h.t.Fatalf("run adapter: %v (stdout=%s)", err, out.String())
+			h.t.Fatalf("run adapter: %v (stdout=%s, stderr=%s)", err, out.String(), h.stderr)
 		}
 		code = exitErr.ExitCode()
+	}
+	if code != 0 && h.stderr != "" {
+		h.t.Logf("adapter exited %d: %s", code, strings.TrimSpace(h.stderr))
 	}
 	return out.String(), code
 }
@@ -226,12 +233,13 @@ func asExitError(err error, target **exec.ExitError) bool {
 // session starts the adapter with a live stdin pipe so a test can drive turns
 // and signals independently.
 type session struct {
-	t    *testing.T
-	cmd  *exec.Cmd
-	in   io.WriteCloser
-	mu   sync.Mutex
-	out  strings.Builder
-	done chan struct{}
+	t      *testing.T
+	cmd    *exec.Cmd
+	in     io.WriteCloser
+	mu     sync.Mutex
+	out    strings.Builder
+	errOut strings.Builder
+	done   chan struct{}
 }
 
 func (h *harness) start() *session {
@@ -246,11 +254,11 @@ func (h *harness) start() *session {
 	if err != nil {
 		h.t.Fatalf("stdout pipe: %v", err)
 	}
-	cmd.Stderr = io.Discard
+	s := &session{t: h.t, cmd: cmd, in: in, done: make(chan struct{})}
+	cmd.Stderr = &s.errOut
 	if err := cmd.Start(); err != nil {
 		h.t.Fatalf("start adapter: %v", err)
 	}
-	s := &session{t: h.t, cmd: cmd, in: in, done: make(chan struct{})}
 	go func() {
 		defer close(s.done)
 		buf := make([]byte, 4096)
@@ -368,6 +376,10 @@ func (s *session) wait() (string, int) {
 		code = exitErr.ExitCode()
 	}
 	<-s.done
+	// errOut is only safe to read once Wait has joined exec's copier.
+	if code != 0 && s.errOut.Len() > 0 {
+		s.t.Logf("adapter exited %d: %s", code, strings.TrimSpace(s.errOut.String()))
+	}
 	return s.output(), code
 }
 
@@ -519,6 +531,24 @@ func TestResumeUsesSingleArgvForm(t *testing.T) {
 	}
 }
 
+// The adapter's six die_config sites all exit 78, so a bare exit code cannot
+// say which precondition tripped. TestControlBytesAreStripped flaked at 78
+// under a saturated parallel sweep and blocked a push with nothing to go on,
+// because the harness discarded stderr (ga-xx7x9).
+func TestHarnessKeepsTheAdapterStderrThatNamesAFailure(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t, nil)
+	delete(h.env, "ZCODE_API_KEY")
+
+	if _, code := h.run("hello\n"); code != 78 {
+		t.Fatalf("exit code = %d, want 78 (EX_CONFIG)", code)
+	}
+	if !strings.Contains(h.stderr, "ZCODE_API_KEY is unset") {
+		t.Fatalf("harness dropped the reason for exit 78; stderr = %q", h.stderr)
+	}
+}
+
 // Behavior 3: gc's pre-Enter Escape and stray control bytes never reach the
 // model.
 func TestControlBytesAreStripped(t *testing.T) {
@@ -539,7 +569,7 @@ func TestControlBytesAreStripped(t *testing.T) {
 			h := newHarness(t, nil)
 			_, code := h.run(tc.stdin)
 			if code != 0 {
-				t.Fatalf("exit code = %d, want 0", code)
+				t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, strings.TrimSpace(h.stderr))
 			}
 			if got := h.prompts(); !equalStrings(got, tc.want) {
 				t.Fatalf("prompts = %q, want %q", got, tc.want)

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -71,7 +71,18 @@ if [[ -z "$NODE_BIN" ]]; then
 fi
 # The bundle imports node:sqlite, so the real floor is 22.5, not 20. A distro
 # node 18 on PATH dies with a bare "No such built-in module: node:sqlite".
-node_version="$("$NODE_BIN" --version 2>/dev/null || true)"
+# A saturated box can fail the fork itself; that is transient, not a version
+# verdict, so retry once and keep the probe's own stderr (ga-xx7x9).
+node_probe_status=0
+for attempt in 1 2; do
+    node_probe="$("$NODE_BIN" --version 2>&1)" && { node_probe_status=0; break; }
+    node_probe_status=$?
+    [[ $attempt -eq 1 ]] && sleep 0.2
+done
+if (( node_probe_status != 0 )); then
+    die_config "$NODE_BIN --version could not run (exit $node_probe_status): ${node_probe:-no output} — a spawn failure, not a version problem"
+fi
+node_version="$node_probe"
 if ! printf '%s\n' "${node_version#v}" | awk -F. '{exit !($1 > 22 || ($1 == 22 && $2 >= 5))}'; then
     die_config "$NODE_BIN is ${node_version:-an unknown version}; the ZCode bundle needs node >= 22.5 (it imports node:sqlite) — set ZCODE_NODE_BIN"
 fi


### PR DESCRIPTION
## Symptom

`TestControlBytesAreStripped` flakes at `exit code = 78, want 0` **with no
stderr at all**. It is not only a local-push nuisance — it failed CI on
#5492, an unrelated rig-path change, and cleared on a plain rerun with no
code change.

## Cause

Of the adapter's six `die_config` preconditions, five are pure env/filesystem
tests (`-z`, `-r`, `command -v` — a shell builtin, no fork). Exactly **one**
requires a successful `fork`+`exec`, and it discarded the reason:

```sh
node_version="$("$NODE_BIN" --version 2>/dev/null || true)"
```

`2>/dev/null || true` turns any spawn failure into an empty version string,
which the awk floor test then rejects as a permanent config verdict. Three
materially different conditions collapsed to one indistinguishable exit 78:

| condition | reported as | correct? |
|---|---|---|
| node is genuinely v18.0.0 | `is v18.0.0` | yes |
| binary exists, cannot exec | `an unknown version` | **no** |
| probe killed mid-run | `an unknown version` | **no** |

Under `make test-fast-parallel`, sized to saturate the box, the harness's
node stub is a `python3` script, so the probe pays a full interpreter cold
start. A transient fork `EAGAIN` or an OOM kill lands in row 3 and is
misreported as "your node is too old".

## Fix

Capture the probe's exit status and stderr instead of dropping them, and
retry once — `EAGAIN` is transient by definition. A killed probe now reports:

```
zcode-repl: .../killed-node --version could not run (exit 137): no output
            — a spawn failure, not a version problem
```

137 = 128+SIGKILL, the OOM signature, so the next occurrence names its own
cause.

## Verification

Red → green, two-sided, extending the existing diagnosability test rather
than adding a file:

- old code + OOM-killed probe → `is an unknown version` (test fails)
- new code + OOM-killed probe → `could not run (exit 137)` (test passes)
- new code + a real v18.0.0 → still `is v18.0.0`, still a config error

Full `internal/worker/adapters/zcode` package green (25.9s); `go vet` clean.

The first commit on this branch is the separate diagnosability change that
makes the harness keep adapter stderr at all — without it the failure above
is invisible.

Closes ga-xx7x9.