### PR TITLE
test: clarify dashboard BFF hang-detector deadlines

### DIFF
--- a/internal/api/dashboardbff/enrichment_cache_test.go
+++ b/internal/api/dashboardbff/enrichment_cache_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runproj"
-	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // enrichmentCacheTestServer stands up a fake supervisor that counts sessions and
@@ -108,7 +107,7 @@ func TestRunTailerManagerRebindDiscardsInFlightEnrichment(t *testing.T) {
 	}()
 	select {
 	case <-started:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("old enrichment compute did not start")
 	}
 
@@ -116,7 +115,7 @@ func TestRunTailerManagerRebindDiscardsInFlightEnrichment(t *testing.T) {
 	unblock()
 	select {
 	case <-oldDone:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("old enrichment compute did not finish")
 	}
 

--- a/internal/api/dashboardbff/hangbudget_test.go
+++ b/internal/api/dashboardbff/hangbudget_test.go
@@ -1,0 +1,31 @@
+package dashboardbff
+
+import "github.com/gastownhall/gascity/internal/testutil"
+
+// hangBudget is the wall-clock ceiling for every pure hang-detector wait in
+// this package's tests: a select that waits for a goroutine-signal channel
+// (readyCh, doneCh, a started/done marker, ...) and fails the test if that
+// signal never arrives.
+//
+// It is a HANG DETECTOR, not a latency assertion. No test in this package
+// waits on it to prove the system is fast — the real assertions always come
+// after the wait returns, and nothing waits the budget out on a passing run
+// because the channel fires the instant its condition is met. Raising this
+// number does not make the suite slower; lowering it does not make it
+// stricter. It only changes how long a genuinely wedged test takes to report,
+// so a hang fails at the line that wedged instead of taking the whole package
+// down via Go's -timeout backstop.
+//
+// Set to exactly testutil.GoroutineRaceTimeout (1x, no multiplier applied):
+// unlike cmd/gc's hangBudget (6x, justified there by measured CPU-starvation
+// over-runs recorded against ga-h51wa1), this package has no over-run
+// evidence of its own. A test that needs more headroom because of measured
+// over-runs should earn it with its own evidence-backed comment, not inherit
+// a blanket multiplier from another package.
+//
+// DO NOT tune hangBudget to make a failing test pass. A test asserting a
+// latency bound must keep its own explicit deadline plus a comment naming
+// the bound. A test asserting a negative ("nothing arrives within X") must
+// likewise keep its own short deadline — hangBudget is the wrong tool there
+// and would add unnecessary dead wait time to a passing run.
+const hangBudget = testutil.GoroutineRaceTimeout

--- a/internal/api/dashboardbff/runcensus_test.go
+++ b/internal/api/dashboardbff/runcensus_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runproj"
-	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 func TestRunCensusSourceServesOnlyWarmAggregateCounts(t *testing.T) {
@@ -71,7 +70,7 @@ func TestRunProjectionSourceReturnsImmediatelyWhileColdLoadIsPending(t *testing.
 	t.Cleanup(p.Stop)
 	select {
 	case <-started:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("background cold load did not start")
 	}
 
@@ -86,7 +85,7 @@ func TestRunProjectionSourceReturnsImmediatelyWhileColdLoadIsPending(t *testing.
 		if projection.Ready || !projection.Partial || len(projection.Beads) != 0 {
 			t.Fatalf("cold projection = %+v, want empty partial warming snapshot", projection)
 		}
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("RunProjection blocked on the unfinished cold load")
 	}
 }

--- a/internal/api/dashboardbff/rundetail_eager_test.go
+++ b/internal/api/dashboardbff/rundetail_eager_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runproj"
-	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // seedRunLog writes a minimal one-run event log under dir/.gc/events.jsonl and
@@ -29,7 +28,7 @@ func waitReady(t *testing.T, tl *cityRunTailer) {
 	t.Helper()
 	select {
 	case <-tl.readyCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatalf("cold replay for %q did not complete within deadline", tl.name)
 	}
 }
@@ -139,12 +138,12 @@ func TestPlaneStartDoesNotBlockOnColdLoad(t *testing.T) {
 
 	select {
 	case <-started:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("background cold replay did not start")
 	}
 	select {
 	case <-startReturned:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("Plane.Start blocked on the held cold replay")
 	}
 

--- a/internal/api/dashboardbff/rundetail_stream_test.go
+++ b/internal/api/dashboardbff/rundetail_stream_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runproj"
-	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 // sseFrame is one parsed SSE frame: its id (empty when the frame carried none),
@@ -184,12 +183,12 @@ func TestRunDetailStreamFirstFrame(t *testing.T) {
 		if frameOK {
 			t.Fatal("old path-bound detail stream emitted another frame instead of closing")
 		}
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("old path-bound detail stream stayed open after city rebind")
 	}
 	select {
 	case <-oldTailer.doneCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("old path-bound tailer did not stop")
 	}
 	p.runTailers.mu.Lock()

--- a/internal/api/dashboardbff/runtailer_test.go
+++ b/internal/api/dashboardbff/runtailer_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runproj"
-	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 type fakeResolver struct {
@@ -150,7 +149,7 @@ func TestRunTailerColdLoadAndLiveTail(t *testing.T) {
 
 	select {
 	case <-tl.readyCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("cold replay did not complete")
 	}
 	waitForLanes(t, tl, 1)
@@ -182,7 +181,7 @@ func TestRunTailerManagerRebindsChangedEventsPath(t *testing.T) {
 	first := m.ensure("alpha", firstPath)
 	select {
 	case <-first.readyCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("first cold replay did not complete")
 	}
 	waitForLanes(t, first, 1)
@@ -196,12 +195,12 @@ func TestRunTailerManagerRebindsChangedEventsPath(t *testing.T) {
 	}
 	select {
 	case <-first.doneCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("replaced path-bound tailer did not stop")
 	}
 	select {
 	case <-replacement.readyCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		t.Fatal("replacement cold replay did not complete")
 	}
 	waitForLanes(t, replacement, 1)
@@ -234,7 +233,7 @@ func TestRunTailerLogsColdLoadFailureOnce(t *testing.T) {
 	tailer := m.ensure("alpha", filepath.Join(t.TempDir(), ".gc", "events.jsonl"))
 	select {
 	case <-tailer.readyCh:
-	case <-time.After(testutil.GoroutineRaceTimeout):
+	case <-time.After(hangBudget):
 		cancel()
 		wg.Wait()
 		t.Fatal("cold replay attempt did not complete")

--- a/release-gates/ga-oet3z5-dashboardbff-hang-budget-gate.md
+++ b/release-gates/ga-oet3z5-dashboardbff-hang-budget-gate.md
@@ -1,0 +1,117 @@
+# Release Gate: dashboard BFF hang-budget migration
+
+Date: 2026-08-21  
+Deployer: `gascity/deployer`  
+Deploy bead: `ga-oet3z5`  
+Build bead: `ga-42mt5x.2`  
+Review bead: `ga-iroh78`  
+Reviewed commit: `e1e5972b46655be23cca75620ed1926d81ed16f3`  
+Base checked: `origin/main` at `151168c76b7b5902676ade495c15b13b59186a8b`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout. This evaluation
+therefore uses the deployer release criteria, `TESTING.md`, and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-iroh78` is closed with verdict `pass` for the exact reviewed commit. Its independent run recorded 136 PASS, 0 FAIL, 0 SKIP in `internal/api/dashboardbff` and a clean fast gate. |
+| 2 | Acceptance criteria met | PASS | The diff adds one package-local `hangBudget` derived at exactly 1x `testutil.GoroutineRaceTimeout`, documents that it is a pure hang detector rather than a latency assertion, and converts exactly 14 direct floor-as-deadline waits. Every converted site waits for a goroutine-lifecycle signal; the scenario-input, polling, and negative-assertion timers remain unchanged. No direct `time.After(testutil.ExecRaceTimeout/GoroutineRaceTimeout)` use remains in the package. |
+| 3 | Tests pass | PASS | The exact reviewed commit passed the focused package run (136 PASS, 0 FAIL, 0 SKIP), all seven tests containing changed waits passed by name, the required fast retry passed 10/10 jobs, and build, vet, workflow policy, and dashboard CI passed. The complete 40-job local CI union finished with 36 PASS jobs, 4 FAIL jobs, 0 SKIP jobs. Three non-diff failures are attributed below after exact-main reproduction; the fourth was the tracked SQLite cleanup race, did not reproduce on main, and was cleared only by a complete clean `make test-fast-parallel` retry whose unit-core lane passed. `diff_tests_executed` and attribution details are below. `waiver_ref: none`. |
+| 4 | No high-severity review findings open | PASS | The reviewer recorded no security findings, blockers, HIGH, or CRITICAL findings. The change is test-only and introduces no production, dependency, authentication, data, configuration, or wire surface. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` was empty at the reviewed commit after all test and dashboard-generation checks. This checklist is the deployer's only additional tracked change and is committed separately on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. `git merge-tree --write-tree origin/main e1e5972b46655be23cca75620ed1926d81ed16f3` succeeded against current main and produced tree `9f93af739291dd658bc59f47aa4463d4be580d1f`; no self-rebase was needed. The ancestry-scope guard passed for deploy bead `ga-oet3z5` plus its confirmed build bead `ga-42mt5x.2`. |
+| 7 | Single feature theme | PASS | The one-commit range changes only six test files in `internal/api/dashboardbff`: a shared hang-detector budget plus the 14 package-local wait conversions it serves. |
+
+## Acceptance Evidence
+
+- `git diff` removes 14 direct
+  `time.After(testutil.GoroutineRaceTimeout)` deadlines and replaces each with
+  `time.After(hangBudget)`.
+- `internal/api/dashboardbff/hangbudget_test.go` defines the package-local
+  constant at 1x the existing floor and documents why it must not be used for
+  latency bounds or negative assertions.
+- All converted waits guard lifecycle signal channels such as `started`,
+  `oldDone`, `readyCh`, `doneCh`, and `startReturned`.
+- A fresh package grep found no remaining direct
+  `time.After(testutil.ExecRaceTimeout)` or
+  `time.After(testutil.GoroutineRaceTimeout)` use.
+- Existing scenario-input and negative/polling windows, including the
+  package's explicit two- and five-second timers, were not widened.
+
+## Test Evidence
+
+`test_counts`:
+
+- `go test -count=1 -json ./internal/api/dashboardbff/...`: 136 PASS,
+  0 FAIL, 0 SKIP.
+- `make test-local-full-parallel`: 40 jobs completed; 36 PASS, 4 FAIL,
+  0 SKIP. The failures were all outside the diff and were either attributed
+  under criterion 3a or cleared through the documented retry path below.
+- `GO_TEST_TIMEOUT=30m make test-fast-parallel` retry: 10 PASS, 0 FAIL,
+  0 SKIP jobs, including a clean `unit-core` lane.
+
+`diff_tests_executed`:
+
+- `TestRunTailerManagerRebindDiscardsInFlightEnrichment` PASS
+- `TestRunProjectionSourceReturnsImmediatelyWhileColdLoadIsPending` PASS
+- `TestPlaneStartDoesNotBlockOnColdLoad` PASS
+- `TestRunDetailStreamFirstFrame` PASS
+- `TestRunTailerColdLoadAndLiveTail` PASS
+- `TestRunTailerManagerRebindsChangedEventsPath` PASS
+- `TestRunTailerLogsColdLoadFailureOnce` PASS
+- `hangbudget_test.go` adds shared test-only configuration and contains no test
+  function of its own.
+
+`skip_justification`: none needed; the focused diff-owned run reported 0 SKIP
+and every changed-wait test passed by name.  
+`waiver_ref`: none.
+
+`failure_attribution`:
+
+- `TestBdFlagManifestCurrent` -> `ga-f0uceo`. The candidate does not touch
+  `internal/bdflags`; the identical installed-`bd` flag drift reproduced on
+  `origin/main@151168c76b7b5902676ade495c15b13b59186a8b`.
+- `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr`. The
+  candidate does not touch `internal/runtime/tmux`; both empty-binding failures
+  reproduced on the exact base ref.
+- `TestSQLiteWriterFenceSIGKILLAtReservationBoundaries/WAL_without_SHM/reservation-open-pending`
+  hit the contention-family cleanup race tracked by `ga-ggrykt`, but its exact
+  base-ref run passed. It was therefore not attributed. A subsequent complete
+  fast/unit retry passed 10/10 jobs, including `unit-core`.
+
+`policy_lane`: `make test-ci-policy` PASS (5 runner-policy tests, 15 suite-
+coverage tests, `scripts/cipolicy`, and the focused static-scope contract).
+
+Additional required checks:
+
+- `go build ./...` PASS
+- `go vet ./...` PASS
+- `make dashboard-ci` PASS
+- `git diff --check origin/main...HEAD` PASS
+
+## Commands Run
+
+```text
+git fetch origin main
+gh api repos/gastownhall/gascity/commits/e1e5972b46655be23cca75620ed1926d81ed16f3/pulls
+git merge-tree --write-tree origin/main e1e5972b46655be23cca75620ed1926d81ed16f3
+git diff --check origin/main...e1e5972b46655be23cca75620ed1926d81ed16f3
+go test -count=1 -json ./internal/api/dashboardbff/...
+GO_TEST_TIMEOUT=30m make test-local-full-parallel
+go test -count=1 -run '^TestSQLiteWriterFenceSIGKILLAtReservationBoundaries$' -v ./internal/storebinding/sqlite  # exact base; PASS
+go test -tags integration -count=1 -run '^TestBdFlagManifestCurrent$' -v ./internal/bdflags  # exact base; reproduced FAIL
+go test -tags integration -count=1 -run '^TestGetKeyBinding_CapturesDefaultBinding(WithArgs)?$' -v ./internal/runtime/tmux  # exact base; reproduced FAIL
+GO_TEST_TIMEOUT=30m make test-fast-parallel
+go build ./...
+go vet ./...
+make test-ci-policy
+make dashboard-ci
+```
+
+## Decision
+
+PASS. The reviewed commit satisfies all seven release criteria and is ready on
+an isolated deploy branch for merge-authority review.


### PR DESCRIPTION
## What this changes

Dashboard BFF concurrency tests now use a package-level `hangBudget` for 14 waits whose only purpose is to detect a goroutine that never starts, finishes, or shuts down. This makes those deadlines explicit hang detectors and gives the package one place to adjust them if measured scheduler contention later warrants it.

This is test-only: production behavior and runtime latency expectations do not change.

## Review notes

- `hangBudget` remains exactly 1x `testutil.GoroutineRaceTimeout`; this change does not lengthen the existing floor.
- Scenario-input timeouts, polling deadlines, and negative-assertion windows remain independent and unchanged.
- The converted waits are limited to lifecycle signal channels in `internal/api/dashboardbff` tests.

## Test plan

- [x] Run `go test -count=1 ./internal/api/dashboardbff/...` and verify all changed-wait tests execute without skips.
- [x] Run `GO_TEST_TIMEOUT=30m make test-fast-parallel`.
- [x] Run `go build ./...`, `go vet ./...`, `make test-ci-policy`, and `make dashboard-ci`.
- [x] Release gate: [`release-gates/ga-oet3z5-dashboardbff-hang-budget-gate.md`](release-gates/ga-oet3z5-dashboardbff-hang-budget-gate.md)