### PR TITLE
test(dispatch): arm the strict-close double on the path the dispatcher uses (ga-a6zy9 Slice 2)

### DIFF
--- a/internal/beadmeta/control_close.go
+++ b/internal/beadmeta/control_close.go
@@ -2,10 +2,11 @@ package beadmeta
 
 import "strings"
 
-// SelfClosingControlKinds lists the control kinds whose completion closes a
-// graph node OTHER than the control bead itself. Every other member of
-// ControlKinds closes only itself, so only these kinds can create the
-// "blocked by my own closer" cycle that ControlClosesNode detects.
+// SelfClosingControlKinds lists the control kinds that close a graph node OTHER
+// than the control bead itself, where that node is identified by the compiler
+// and so can carry a declared dependency edge back onto the control. Those are
+// the kinds that can mint the "blocked by my own closer" cycle ControlClosesNode
+// detects, and the only ones the compiler can rule out statically.
 //
 // Behavior owners (internal/dispatch/runtime.go):
 //
@@ -14,9 +15,19 @@ import "strings"
 //   - KindWorkflowFinalize — processWorkflowFinalize closes the workflow root
 //     named by the control's gc.root_bead_id.
 //
+// Other control kinds are NOT limited to closing themselves: a retry-eval closes
+// the logical bead named by its gc.logical_bead_id, and a ralph iteration
+// control closes its own logical bead, in both cases while the logical bead
+// holds a blocks edge onto the control. Those pairs are safe only because
+// internal/dispatch/retry.go closes the control before the logical bead in every
+// terminal branch — safety by ordering, enforced at runtime by the strict-close
+// test double rather than statically here. They are excluded from this set
+// because the edge is minted at dispatch time from runtime metadata, not
+// declared by the compiler, so ControlClosesNode cannot see it.
+//
 // TestControlClosesNodeOnlyForSelfClosingKinds pins this set against
-// ControlClosesNode, so adding a control kind that closes a foreign node
-// forces the question here instead of silently minting a new cycle.
+// ControlClosesNode, so adding a control kind that closes a compiler-identified
+// foreign node forces the question here instead of silently minting a new cycle.
 var SelfClosingControlKinds = []string{
 	KindScopeCheck,
 	KindWorkflowFinalize,

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -87,6 +88,125 @@ func TestProcessRetryEvalPassClosesLogical(t *testing.T) {
 	}
 	if logicalAfter.Metadata["gc.output_json"] != `{"ok":true}` {
 		t.Fatalf("logical gc.output_json = %q, want propagated output", logicalAfter.Metadata["gc.output_json"])
+	}
+}
+
+// newRetryEvalOrderingFixture builds the shape every terminal retry-eval branch
+// closes through: a logical bead blocked by its own eval. The eval must close
+// before the logical bead or bd refuses the second close, so each branch that
+// closes both is only correct by ordering — nothing structural enforces it.
+// Returns the logical and eval beads on a store that enforces bd's refusal.
+func newRetryEvalOrderingFixture(t *testing.T, runOutcome map[string]string) (*strictCloseStore, beads.Bead, beads.Bead) {
+	t.Helper()
+
+	store := newStrictCloseStore()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "demo.review",
+			"gc.max_attempts": "3",
+			"gc.on_exhausted": "hard_fail",
+		},
+	})
+	runMeta := map[string]string{
+		"gc.kind":            "retry-run",
+		"gc.root_bead_id":    root.ID,
+		"gc.step_ref":        "demo.review.run.1",
+		"gc.logical_bead_id": logical.ID,
+		"gc.attempt":         "1",
+		"gc.max_attempts":    "3",
+		"gc.on_exhausted":    "hard_fail",
+	}
+	for k, v := range runOutcome {
+		runMeta[k] = v
+	}
+	run1 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "review attempt 1",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: runMeta,
+	})
+	eval1 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review eval 1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-eval",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "demo.review.eval.1",
+			"gc.logical_bead_id": logical.ID,
+			"gc.attempt":         "1",
+			"gc.max_attempts":    "3",
+			"gc.on_exhausted":    "hard_fail",
+		},
+	})
+	mustDepAdd(t, store, logical.ID, eval1.ID, "blocks")
+	mustDepAdd(t, store, eval1.ID, run1.ID, "blocks")
+	return store, logical, eval1
+}
+
+func TestProcessRetryEvalHardFailClosesEvalBeforeLogical(t *testing.T) {
+	t.Parallel()
+
+	store, logical, eval1 := newRetryEvalOrderingFixture(t, map[string]string{
+		"gc.outcome":        "fail",
+		"gc.failure_class":  "hard",
+		"gc.failure_reason": "boom",
+	})
+
+	result, err := ProcessControl(store, eval1, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(retry-eval hard): %v", err)
+	}
+	if !result.Processed || result.Action != "hard-fail" {
+		t.Fatalf("result = %+v, want processed hard-fail", result)
+	}
+
+	evalAfter := mustGetBead(t, store, eval1.ID)
+	if evalAfter.Status != "closed" || evalAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("eval = status %q outcome %q, want closed/fail", evalAfter.Status, evalAfter.Metadata["gc.outcome"])
+	}
+	logicalAfter := mustGetBead(t, store, logical.ID)
+	if logicalAfter.Status != "closed" || logicalAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("logical = status %q outcome %q, want closed/fail", logicalAfter.Status, logicalAfter.Metadata["gc.outcome"])
+	}
+	if got := logicalAfter.Metadata["gc.final_disposition"]; got != beadmeta.DispositionHardFail {
+		t.Fatalf("logical gc.final_disposition = %q, want %q", got, beadmeta.DispositionHardFail)
+	}
+}
+
+func TestProcessRetryEvalCanceledClosesEvalBeforeLogical(t *testing.T) {
+	t.Parallel()
+
+	store, logical, eval1 := newRetryEvalOrderingFixture(t, map[string]string{
+		"gc.outcome": "canceled",
+	})
+
+	result, err := ProcessControl(store, eval1, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(retry-eval canceled): %v", err)
+	}
+	if !result.Processed || result.Action != "canceled" {
+		t.Fatalf("result = %+v, want processed canceled", result)
+	}
+
+	evalAfter := mustGetBead(t, store, eval1.ID)
+	if evalAfter.Status != "closed" || evalAfter.Metadata["gc.outcome"] != "canceled" {
+		t.Fatalf("eval = status %q outcome %q, want closed/canceled", evalAfter.Status, evalAfter.Metadata["gc.outcome"])
+	}
+	logicalAfter := mustGetBead(t, store, logical.ID)
+	if logicalAfter.Status != "closed" || logicalAfter.Metadata["gc.outcome"] != "canceled" {
+		t.Fatalf("logical = status %q outcome %q, want closed/canceled", logicalAfter.Status, logicalAfter.Metadata["gc.outcome"])
 	}
 }
 
@@ -1904,7 +2024,7 @@ func TestProcessScopeCheckSkipsOpenRetryDescendantsOnAbort(t *testing.T) {
 			"gc.formula_contract": "graph.v2",
 		},
 	})
-	body := mustCreateWorkflowBead(t, store, beads.Bead{
+	mustCreateWorkflowBead(t, store, beads.Bead{
 		Title: "body",
 		Type:  "task",
 		Metadata: map[string]string{
@@ -1965,7 +2085,6 @@ func TestProcessScopeCheckSkipsOpenRetryDescendantsOnAbort(t *testing.T) {
 		},
 	})
 	mustDepAdd(t, store, control.ID, failed.ID, "blocks")
-	mustDepAdd(t, store, body.ID, control.ID, "blocks")
 	mustDepAdd(t, store, logical.ID, eval1.ID, "blocks")
 	mustDepAdd(t, store, eval1.ID, run1.ID, "blocks")
 
@@ -2000,7 +2119,7 @@ func TestProcessScopeCheckSkipsOpenRalphIterationDescendantsOnAbort(t *testing.T
 			"gc.formula_contract": "graph.v2",
 		},
 	})
-	body := mustCreateWorkflowBead(t, store, beads.Bead{
+	mustCreateWorkflowBead(t, store, beads.Bead{
 		Title: "body",
 		Type:  "task",
 		Metadata: map[string]string{
@@ -2070,7 +2189,6 @@ func TestProcessScopeCheckSkipsOpenRalphIterationDescendantsOnAbort(t *testing.T
 		},
 	})
 	mustDepAdd(t, store, control.ID, failed.ID, "blocks")
-	mustDepAdd(t, store, body.ID, control.ID, "blocks")
 	mustDepAdd(t, store, logical.ID, iterationControl.ID, "blocks")
 	mustDepAdd(t, store, iterationControl.ID, iterationChild.ID, "blocks")
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -394,9 +394,7 @@ func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 	})
 
 	mustDepAdd(t, store, control.ID, failed.ID, "blocks")
-	mustDepAdd(t, store, body.ID, control.ID, "blocks")
 	mustDepAdd(t, store, cleanup.ID, body.ID, "blocks")
-	mustDepAdd(t, store, futureMember.ID, control.ID, "blocks")
 	mustDepAdd(t, store, futureControl.ID, futureMember.ID, "blocks")
 
 	result, err := ProcessControl(store, control, ProcessOptions{})
@@ -433,17 +431,148 @@ func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 			t.Fatalf("%s outcome = %q, want skipped", beadID, got)
 		}
 	}
-	memberDeps, err := store.DepList(futureMember.ID, "down")
+	controlDeps, err := store.DepList(futureControl.ID, "down")
 	if err != nil {
-		t.Fatalf("dep list future member: %v", err)
+		t.Fatalf("dep list future control: %v", err)
 	}
-	if len(memberDeps) != 1 || memberDeps[0].DependsOnID != control.ID || memberDeps[0].Type != "blocks" {
-		t.Fatalf("future member deps = %+v, want preserved block on %s", memberDeps, control.ID)
+	if len(controlDeps) != 1 || controlDeps[0].DependsOnID != futureMember.ID || controlDeps[0].Type != "blocks" {
+		t.Fatalf("future control deps = %+v, want preserved block on %s", controlDeps, futureMember.ID)
 	}
 
 	cleanupReady := mustReadyContains(t, store, cleanup.ID)
 	if !cleanupReady {
 		t.Fatalf("cleanup %s should be ready after body fails closed", cleanup.ID)
+	}
+}
+
+// TestProcessScopeCheckAbortRefusesMemberBlockedOnInFlightControl pins the shape
+// that TestProcessScopeCheckAbortsScopeOnFailure deliberately omits: a scope
+// member whose only blocker is the scope-check currently aborting the scope.
+// skipScopeMembers judges such a member skippable — runtime.go excludes the
+// in-flight control from the pending set, and canSkipScopeMemberWithDeps only
+// consults that set — then closes it with an unforced update, which real bd
+// refuses. Production mints exactly this shape today: every open scope-check in
+// the fleet is blocked on by its molecule's workflow-finalize.
+//
+// The assertion below is the current, wrong behavior, pinned so the eventual fix
+// is visible as a diff rather than a silent flip. When ga-4ote2 lands this test
+// should assert a clean abort instead.
+func TestProcessScopeCheckAbortRefusesMemberBlockedOnInFlightControl(t *testing.T) {
+	t.Parallel()
+
+	store := newStrictCloseStore()
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": "wf-1",
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	failed := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "preflight",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "fail",
+		},
+	})
+	control := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for preflight",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	control = mustGetBead(t, store, control.ID)
+	futureMember := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "implement",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+		},
+	})
+
+	mustDepAdd(t, store, control.ID, failed.ID, "blocks")
+	mustDepAdd(t, store, futureMember.ID, control.ID, "blocks")
+
+	_, err := ProcessControl(store, control, ProcessOptions{})
+	if err == nil {
+		t.Fatalf("ProcessControl(scope-check fail) succeeded; expected the blocked-close refusal from ga-4ote2")
+	}
+	if !strings.Contains(err.Error(), "cannot close blocked issue") {
+		t.Fatalf("ProcessControl error = %v, want a blocked-close refusal naming %s", err, futureMember.ID)
+	}
+	if bodyAfter := mustGetBead(t, store, body.ID); bodyAfter.Status != "open" {
+		t.Fatalf("body status = %q, want open — the abort failed before reaching the body close", bodyAfter.Status)
+	}
+}
+
+// TestProcessScopeCheckAbortRefusesLegacyBodyBlockedOnControl pins the original
+// ga-a6zy9 deadlock: the pre-Slice-4 topology where the scope body carries a
+// blocks edge to the very scope-check that closes it. Slice 4 stopped minting
+// this shape, so no live store should contain it, but nothing prevents a formula
+// or a hand-built fixture from reintroducing it — and under real bd it is
+// unrecoverable, because the control can never close the body it is blocked by.
+func TestProcessScopeCheckAbortRefusesLegacyBodyBlockedOnControl(t *testing.T) {
+	t.Parallel()
+
+	store := newStrictCloseStore()
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": "wf-1",
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	failed := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "preflight",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "fail",
+		},
+	})
+	control := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for preflight",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	control = mustGetBead(t, store, control.ID)
+
+	mustDepAdd(t, store, control.ID, failed.ID, "blocks")
+	mustDepAdd(t, store, body.ID, control.ID, "blocks")
+
+	_, err := ProcessControl(store, control, ProcessOptions{})
+	if err == nil {
+		t.Fatalf("ProcessControl(legacy body self-edge) succeeded; expected the ga-a6zy9 deadlock refusal")
+	}
+	if !strings.Contains(err.Error(), "cannot close blocked issue") {
+		t.Fatalf("ProcessControl error = %v, want a blocked-close refusal naming body %s", err, body.ID)
+	}
+	if bodyAfter := mustGetBead(t, store, body.ID); bodyAfter.Status != "open" {
+		t.Fatalf("body status = %q, want open — bd refuses to close a bead blocked by the closing control", bodyAfter.Status)
 	}
 }
 
@@ -2282,28 +2411,105 @@ func newStrictCloseStore() *strictCloseStore {
 	return &strictCloseStore{MemStore: beads.NewMemStore()}
 }
 
-func (s *strictCloseStore) Close(id string) error {
+// blockingDepTypes are the dep types real bd treats as blocking a close. The
+// empty string is included because DepAdd stores the caller's type verbatim and
+// bd defaults an unset type to "blocks" — MemStore's own ready-query filter
+// (memstore.go) omits "" and would under-report here, so this mirrors bd rather
+// than the in-memory store it wraps.
+var blockingDepTypes = map[string]bool{
+	"":                   true,
+	"blocks":             true,
+	"waits-for":          true,
+	"conditional-blocks": true,
+}
+
+// openBlockersOf returns the unclosed beads that block id. "Unclosed" rather
+// than "open" is deliberate: an in_progress blocker blocks a close in bd just as
+// an open one does, and MemStore's ready filter agrees (status != "closed").
+func (s *strictCloseStore) openBlockersOf(id string) ([]string, error) {
 	deps, err := s.DepList(id, "down")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var openBlockers []string
 	for _, dep := range deps {
-		if dep.Type != "blocks" {
+		if !blockingDepTypes[dep.Type] {
 			continue
 		}
 		blocker, err := s.Get(dep.DependsOnID)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		if blocker.Status == "open" {
+		if blocker.Status != "closed" {
 			openBlockers = append(openBlockers, blocker.ID)
 		}
 	}
+	return openBlockers, nil
+}
+
+// errCloseBlocked mirrors the refusal real bd raises (beads #4893). The wording
+// matters: "cannot close blocked issue" is the needle the dispatcher's tier
+// table matches on to classify the refusal as semantic rather than availability
+// (control.go), so a double that phrases it differently would exercise neither
+// the refusal nor its classification.
+func (s *strictCloseStore) errCloseBlocked(id string, openBlockers []string) error {
+	return fmt.Errorf("cannot close blocked issue: %s is blocked by [%s]", id, strings.Join(openBlockers, " "))
+}
+
+// Close is stricter than production. BdStore.close and CloseAll both emit
+// "bd close --force" (bdstore.go bdCloseArgs), and --force bypasses bd's
+// blocked-close guard, so real bd never refuses on this path. The override is
+// kept anyway as a belt-and-braces guard for the fallback in
+// updateMetadataAndClose: a test that trips it has built a shape whose safety
+// depends on --force, which is worth knowing even though production survives it.
+// The load-bearing override is Update, below.
+func (s *strictCloseStore) Close(id string) error {
+	openBlockers, err := s.openBlockersOf(id)
+	if err != nil {
+		return err
+	}
 	if len(openBlockers) > 0 {
-		return fmt.Errorf("cannot close %s: blocked by open issues %v", id, openBlockers)
+		return s.errCloseBlocked(id, openBlockers)
 	}
 	return s.MemStore.Close(id)
+}
+
+// Update enforces the same refusal as Close. The dispatcher does not close beads
+// through Close: updateMetadataAndClose sets Status="closed" via Update and only
+// falls back to Close when that did not take (control.go). A double that guarded
+// Close alone therefore never fired on the path production actually uses, which
+// let a swap of any control's close ordering — closing the bead a control closes
+// before the control itself — pass the whole suite while deadlocking the fleet.
+// That is the ga-a6zy9 failure mode.
+func (s *strictCloseStore) Update(id string, opts beads.UpdateOpts) error {
+	if opts.Status != nil && *opts.Status == "closed" {
+		openBlockers, err := s.openBlockersOf(id)
+		if err != nil {
+			return err
+		}
+		if len(openBlockers) > 0 {
+			return s.errCloseBlocked(id, openBlockers)
+		}
+	}
+	return s.MemStore.Update(id, opts)
+}
+
+// UpdateAll enforces the same refusal as Update, and is the batch path that
+// matters: skipScopeMembers (runtime.go) prefers UpdateAll via the
+// scopeSkipBatchUpdater interface and only falls back to per-id Update when the
+// store lacks it. BdStore.UpdateAll emits a plain "bd update --status closed"
+// with no --force (bdstore.go), unlike CloseAll, so bd can and does refuse it.
+// MemStore has no UpdateAll of its own; declaring it here is what makes the
+// double take the same branch production takes. See ga-4ote2.
+func (s *strictCloseStore) UpdateAll(ids []string, opts beads.UpdateOpts) (int, error) {
+	updated := 0
+	for _, id := range ids {
+		if err := s.Update(id, opts); err != nil {
+			return updated, err
+		}
+		updated++
+	}
+	return updated, nil
 }
 
 func TestProcessWorkflowFinalizeClosesWorkflow(t *testing.T) {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -450,13 +450,20 @@ func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 // member whose only blocker is the scope-check currently aborting the scope.
 // skipScopeMembers judges such a member skippable — runtime.go excludes the
 // in-flight control from the pending set, and canSkipScopeMemberWithDeps only
-// consults that set — then closes it with an unforced update, which real bd
-// refuses. Production mints exactly this shape today: every open scope-check in
-// the fleet is blocked on by its molecule's workflow-finalize.
+// consults that set — then closes it with an unforced update, which bd refuses.
+//
+// The compiler mints this shape directly. formula/graph.go mints one scope-check
+// per scoped step, carrying that step's gc.scope_ref, and rewriteGraphRefs then
+// repoints every reference at a scoped step onto that step's scope-check —
+// leaving the raw name only for the body the control closes. So a scoped step B
+// that needs same-scope sibling A compiles to "B needs A-scope-check", with B
+// and the control sharing a scope_ref. When A fails, B is an open member of the
+// very scope its own blocker is aborting.
 //
 // The assertion below is the current, wrong behavior, pinned so the eventual fix
 // is visible as a diff rather than a silent flip. When ga-4ote2 lands this test
-// should assert a clean abort instead.
+// should assert a clean abort — and must also assert the member's edge onto the
+// control survives, or a fix that simply deletes the dep would pass it.
 func TestProcessScopeCheckAbortRefusesMemberBlockedOnInFlightControl(t *testing.T) {
 	t.Parallel()
 
@@ -2411,11 +2418,24 @@ func newStrictCloseStore() *strictCloseStore {
 	return &strictCloseStore{MemStore: beads.NewMemStore()}
 }
 
-// blockingDepTypes are the dep types real bd treats as blocking a close. The
-// empty string is included because DepAdd stores the caller's type verbatim and
-// bd defaults an unset type to "blocks" — MemStore's own ready-query filter
-// (memstore.go) omits "" and would under-report here, so this mirrors bd rather
-// than the in-memory store it wraps.
+// The rules below mirror bd's close policy as measured against the installed
+// binaries, not as read off a source tree: the version banners on these dev
+// builds are unreliable (one reports its build ref as whatever branch it was
+// compiled on), so behavior is the only trustworthy evidence. Each rule cites
+// the observation that pins it; the probe transcripts are recorded on ga-a6zy9.
+//
+// The guard on the update path is beads #5206, which refuses a status update
+// that crosses a bead into done. It is not #4893 — that one guards "bd close",
+// a path BdStore always bypasses with --force (bdCloseArgs, bdstore.go).
+
+// blockingDepTypes are the dep types that stop a close. The empty string is in
+// the set because MemStore.DepAdd stores the caller's type verbatim, while bd
+// normalizes an unset type to "blocks" when the dep is added — "bd dep add"
+// with no --type reports "(blocks)" and stores dependency_type "blocks", so bd
+// never holds a ""-typed dep to evaluate in the first place. Mirroring bd's
+// behavior from a MemStore-backed double therefore means treating "" as
+// blocking; MemStore's own ready filter (memstore.go) omits it and would
+// under-report.
 var blockingDepTypes = map[string]bool{
 	"":                   true,
 	"blocks":             true,
@@ -2423,9 +2443,15 @@ var blockingDepTypes = map[string]bool{
 	"conditional-blocks": true,
 }
 
-// openBlockersOf returns the unclosed beads that block id. "Unclosed" rather
-// than "open" is deliberate: an in_progress blocker blocks a close in bd just as
-// an open one does, and MemStore's ready filter agrees (status != "closed").
+// blockerStopsClose reports whether a blocker in the given status stops a close.
+// Pinned blockers are exempt in bd — pinning a blocker lets the blocked bead
+// close — and closed ones obviously are. Everything else stops it, in_progress
+// included, which is why this is not a status == "open" test.
+func blockerStopsClose(status string) bool {
+	return status != "closed" && status != "pinned"
+}
+
+// openBlockersOf returns the beads whose status stops a close of id.
 func (s *strictCloseStore) openBlockersOf(id string) ([]string, error) {
 	deps, err := s.DepList(id, "down")
 	if err != nil {
@@ -2440,20 +2466,61 @@ func (s *strictCloseStore) openBlockersOf(id string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if blocker.Status != "closed" {
+		if blockerStopsClose(blocker.Status) {
 			openBlockers = append(openBlockers, blocker.ID)
 		}
 	}
 	return openBlockers, nil
 }
 
-// errCloseBlocked mirrors the refusal real bd raises (beads #4893). The wording
-// matters: "cannot close blocked issue" is the needle the dispatcher's tier
-// table matches on to classify the refusal as semantic rather than availability
-// (control.go), so a double that phrases it differently would exercise neither
+// errCloseBlocked mirrors bd's blocked-close refusal. The wording matters:
+// "cannot close blocked issue" is the needle the dispatcher's tier table
+// matches on to classify the refusal as semantic rather than availability
+// (control.go), so a double that phrased it differently would exercise neither
 // the refusal nor its classification.
 func (s *strictCloseStore) errCloseBlocked(id string, openBlockers []string) error {
 	return fmt.Errorf("cannot close blocked issue: %s is blocked by [%s]", id, strings.Join(openBlockers, " "))
+}
+
+// errCloseOpenChildren mirrors bd's open-children refusal, which is a separate
+// rule from the blocked-dep one and carries its own wording.
+func (s *strictCloseStore) errCloseOpenChildren(id string, open int) error {
+	return fmt.Errorf("cannot close %s: %d open child issue(s); close children first or use --force to override", id, open)
+}
+
+// refuseClose returns the refusal bd would raise for closing id, or nil if bd
+// would allow it.
+func (s *strictCloseStore) refuseClose(id string) error {
+	current, err := s.Get(id)
+	if err != nil {
+		return err
+	}
+	// bd gates the policy on crossing INTO done, so restating closed as closed
+	// is allowed even with an open child or an open blocker. Idempotent
+	// re-processing is this codebase's stated convergence mechanism, so a double
+	// that refused a re-close would be stricter than production in exactly the
+	// direction that produces false failures.
+	if current.Status == "closed" {
+		return nil
+	}
+	// Children first: a bead with both an open child and an open blocker is
+	// refused for the child, so evaluating blockers first would report the wrong
+	// rule.
+	children, err := s.Children(current.ID)
+	if err != nil {
+		return err
+	}
+	if len(children) > 0 {
+		return s.errCloseOpenChildren(id, len(children))
+	}
+	openBlockers, err := s.openBlockersOf(id)
+	if err != nil {
+		return err
+	}
+	if len(openBlockers) > 0 {
+		return s.errCloseBlocked(id, openBlockers)
+	}
+	return nil
 }
 
 // Close is stricter than production. BdStore.close and CloseAll both emit
@@ -2464,12 +2531,8 @@ func (s *strictCloseStore) errCloseBlocked(id string, openBlockers []string) err
 // depends on --force, which is worth knowing even though production survives it.
 // The load-bearing override is Update, below.
 func (s *strictCloseStore) Close(id string) error {
-	openBlockers, err := s.openBlockersOf(id)
-	if err != nil {
+	if err := s.refuseClose(id); err != nil {
 		return err
-	}
-	if len(openBlockers) > 0 {
-		return s.errCloseBlocked(id, openBlockers)
 	}
 	return s.MemStore.Close(id)
 }
@@ -2483,12 +2546,8 @@ func (s *strictCloseStore) Close(id string) error {
 // That is the ga-a6zy9 failure mode.
 func (s *strictCloseStore) Update(id string, opts beads.UpdateOpts) error {
 	if opts.Status != nil && *opts.Status == "closed" {
-		openBlockers, err := s.openBlockersOf(id)
-		if err != nil {
+		if err := s.refuseClose(id); err != nil {
 			return err
-		}
-		if len(openBlockers) > 0 {
-			return s.errCloseBlocked(id, openBlockers)
 		}
 	}
 	return s.MemStore.Update(id, opts)
@@ -2498,7 +2557,9 @@ func (s *strictCloseStore) Update(id string, opts beads.UpdateOpts) error {
 // matters: skipScopeMembers (runtime.go) prefers UpdateAll via the
 // scopeSkipBatchUpdater interface and only falls back to per-id Update when the
 // store lacks it. BdStore.UpdateAll emits a plain "bd update --status closed"
-// with no --force (bdstore.go), unlike CloseAll, so bd can and does refuse it.
+// with no --force (bdstore.go), unlike CloseAll, so bd refuses it — measured
+// against both bd binaries installed on this host, which reject an unforced
+// "update --status closed" on a blocked bead and accept it on an unblocked one.
 // MemStore has no UpdateAll of its own; declaring it here is what makes the
 // double take the same branch production takes. See ga-4ote2.
 func (s *strictCloseStore) UpdateAll(ids []string, opts beads.UpdateOpts) (int, error) {
@@ -2510,6 +2571,162 @@ func (s *strictCloseStore) UpdateAll(ids []string, opts beads.UpdateOpts) (int, 
 		updated++
 	}
 	return updated, nil
+}
+
+// TestStrictCloseStoreMirrorsBdClosePolicy covers the double itself. It exists
+// because an unexercised rule in this store is indistinguishable from a missing
+// one — the Close-only guard this file used to carry looked correct for as long
+// as it went unexercised, and the whole point of the store is to be a rule the
+// dispatcher cannot route around. Every case below mirrors a behavior measured
+// against a real bd binary; if bd's policy changes, these are the assertions
+// that should fail first.
+func TestStrictCloseStoreMirrorsBdClosePolicy(t *testing.T) {
+	t.Parallel()
+
+	closed := "closed"
+	newBead := func(t *testing.T, store *strictCloseStore, title string) beads.Bead {
+		t.Helper()
+		return mustCreateWorkflowBead(t, store, beads.Bead{Title: title, Type: "task"})
+	}
+	newChild := func(t *testing.T, store *strictCloseStore, title, parentID string) beads.Bead {
+		t.Helper()
+		return mustCreateWorkflowBead(t, store, beads.Bead{Title: title, Type: "task", ParentID: parentID})
+	}
+	setStatus := func(t *testing.T, store *strictCloseStore, id, status string) {
+		t.Helper()
+		// Go through MemStore so setting up a fixture never trips the policy
+		// under test.
+		if err := store.MemStore.Update(id, beads.UpdateOpts{Status: &status}); err != nil {
+			t.Fatalf("seed status %s=%s: %v", id, status, err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		build   func(t *testing.T, store *strictCloseStore) string
+		wantErr string
+	}{
+		{
+			name: "open blocker refuses",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, blocker := newBead(t, store, "subject"), newBead(t, store, "blocker")
+				mustDepAdd(t, store, subject.ID, blocker.ID, "blocks")
+				return subject.ID
+			},
+			wantErr: "cannot close blocked issue",
+		},
+		{
+			name: "in_progress blocker refuses",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, blocker := newBead(t, store, "subject"), newBead(t, store, "blocker")
+				mustDepAdd(t, store, subject.ID, blocker.ID, "blocks")
+				setStatus(t, store, blocker.ID, "in_progress")
+				return subject.ID
+			},
+			wantErr: "cannot close blocked issue",
+		},
+		{
+			name: "closed blocker allows",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, blocker := newBead(t, store, "subject"), newBead(t, store, "blocker")
+				mustDepAdd(t, store, subject.ID, blocker.ID, "blocks")
+				setStatus(t, store, blocker.ID, "closed")
+				return subject.ID
+			},
+		},
+		{
+			name: "pinned blocker allows",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, blocker := newBead(t, store, "subject"), newBead(t, store, "blocker")
+				mustDepAdd(t, store, subject.ID, blocker.ID, "blocks")
+				setStatus(t, store, blocker.ID, "pinned")
+				return subject.ID
+			},
+		},
+		{
+			name: "untyped dep refuses because MemStore stores it verbatim",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, blocker := newBead(t, store, "subject"), newBead(t, store, "blocker")
+				mustDepAdd(t, store, subject.ID, blocker.ID, "")
+				return subject.ID
+			},
+			wantErr: "cannot close blocked issue",
+		},
+		{
+			name: "non-blocking dep type allows",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, related := newBead(t, store, "subject"), newBead(t, store, "related")
+				mustDepAdd(t, store, subject.ID, related.ID, "related")
+				return subject.ID
+			},
+		},
+		{
+			name: "open child refuses with its own rule",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				parent := newBead(t, store, "parent")
+				newChild(t, store, "child", parent.ID)
+				return parent.ID
+			},
+			wantErr: "open child issue(s)",
+		},
+		{
+			name: "closed child allows",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				parent := newBead(t, store, "parent")
+				child := newChild(t, store, "child", parent.ID)
+				setStatus(t, store, child.ID, "closed")
+				return parent.ID
+			},
+		},
+		{
+			name: "open child outranks open blocker",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				parent, blocker := newBead(t, store, "parent"), newBead(t, store, "blocker")
+				newChild(t, store, "child", parent.ID)
+				mustDepAdd(t, store, parent.ID, blocker.ID, "blocks")
+				return parent.ID
+			},
+			wantErr: "open child issue(s)",
+		},
+		{
+			name: "re-closing an already-closed bead is exempt from both rules",
+			build: func(t *testing.T, store *strictCloseStore) string {
+				subject, blocker := newBead(t, store, "subject"), newBead(t, store, "blocker")
+				newChild(t, store, "child", subject.ID)
+				mustDepAdd(t, store, subject.ID, blocker.ID, "blocks")
+				setStatus(t, store, subject.ID, "closed")
+				return subject.ID
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newStrictCloseStore()
+			subjectID := tc.build(t, store)
+
+			err := store.Update(subjectID, beads.UpdateOpts{Status: &closed})
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Update(%s, closed) = %v, want success", subjectID, err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Update(%s, closed) succeeded, want refusal containing %q", subjectID, tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("Update(%s, closed) = %v, want refusal containing %q", subjectID, err, tc.wantErr)
+			}
+
+			// UpdateAll is the batch path skipScopeMembers prefers; it must
+			// agree with Update or the guard is only half-armed.
+			store2 := newStrictCloseStore()
+			subjectID2 := tc.build(t, store2)
+			_, batchErr := store2.UpdateAll([]string{subjectID2}, beads.UpdateOpts{Status: &closed})
+			if (batchErr != nil) != (err != nil) {
+				t.Fatalf("UpdateAll disagrees with Update: UpdateAll=%v, Update=%v", batchErr, err)
+			}
+		})
+	}
 }
 
 func TestProcessWorkflowFinalizeClosesWorkflow(t *testing.T) {


### PR DESCRIPTION
## The guard was inert

`strictCloseStore` exists to make dispatch tests fail the way real `bd` fails: it refuses to close a bead that an open bead blocks. It overrode `Close(id)` only.

The dispatcher does not close through `Close`. `updateMetadataAndClose` (`control.go`) sets `Status="closed"` via `Update`, and falls back to `Close` only if that did not take. So the double never fired on the path production uses.

Measured, not assumed — swap the two closes in a terminal retry branch so the logical bead closes while its eval still blocks it:

| branch | before | after |
|---|---|---|
| pass | SURVIVED | KILLED |
| hard | SURVIVED | KILLED |
| canceled | SURVIVED | KILLED |
| soft-fail | SURVIVED | KILLED |
| exhausted | SURVIVED | KILLED |

Every kill carries production's exact error: `cannot close blocked issue: gc-2 is blocked by [gc-4]`. The probe uses real on-disk edits with a restore trap, a marker check so a mutation that fails to apply aborts rather than reporting a false kill, and an unmutated baseline that must pass first. A reviewer reproduced the whole table independently.

That failure shape is not hypothetical. Every retry eval in live data is an open bead blocking the open control that closes it, safe only because `retry.go` closes the control first. Nothing enforced that ordering.

## The policy is measured, not read

Two reviewers disagreed about whether `bd` even refuses an unforced `update --status closed`: one read beads main and said yes, the other read `deps.env` (`BD_VERSION=v1.1.0`) and go.mod (`bf97b73749ac`) and said the guard exists in nothing we pin. Both were reading source. Running the binaries settles it:

```
/opt/beads/releases/mc-enterprise-912d2cee0980/bd   (banner: 1.1.0)   rc=1
/home/ubuntu/.local/bin/bd                          (banner: 1.2.1)   rc=1
  cannot close blocked issue: probe-10d is blocked by [probe-qsk]
CONTROL — same command, unblocked bead:             rc=0, closes cleanly
```

**Version banners are not evidence here.** The `/opt` build self-reports `1.1.0` yet has the guard, and names whatever branch it was compiled on as its build ref. So ga-4ote2 is live, not latent.

Probing the rest of the policy found four places the double diverged from `bd`:

| case | bd | double before |
|---|---|---|
| `pinned` blocker | allows | refused |
| re-close an already-closed bead (open blocker or child) | allows — gates on crossing *into* done | refused |
| open parent-child child | **refuses**, own wording, checked *before* blockers | not modeled at all |
| untyped dep | normalizes to `blocks` at add time, then refuses | refused, but documented with the wrong reason |

The last two matter most. The open-children rule is a whole second half of the policy that the double was silent on — the same inertness class this PR set out to kill, one guard over. And the already-closed exemption is the one direction that produces *false* failures, since idempotent re-processing is how this codebase converges.

The citation was also wrong: the update-path guard is beads **#5206**, not #4893. #4893 guards `bd close` — a path `BdStore` always bypasses with `--force` (`bdCloseArgs`).

## What changed

- **`Update` armed**, plus **`UpdateAll`** — `skipScopeMembers` prefers the batch path via `scopeSkipBatchUpdater` and `MemStore` has no `UpdateAll`, so a per-id-only guard would miss it.
- **All four fidelity gaps closed**, each mirroring a measurement.
- **The double now has its own test.** An unexercised rule in it is indistinguishable from a missing one — exactly how the `Close`-only guard stayed inert while looking correct. Ten cases, asserted through both `Update` and `UpdateAll` so the batch path cannot drift. Mutating each rule kills precisely its own case (5/5, passing control).
- **Two branches had no coverage at all.** `hard` and `canceled` never built the blocking shape. Added `newRetryEvalOrderingFixture` and a test for each.

## Two red tests were real bugs, not stale fixtures

An earlier read of mine blamed all the redness on the pre-Slice-4 body self-edge. That was wrong, and worth stating because it is the trap this PR is about — the tempting fix was to edit fixtures until the suite went green, which would have deleted exactly the coverage being added.

- **`ga-4ote2` (filed, P1).** A scope member blocked by the in-flight scope-check is judged skippable — `runtime.go` excludes the control from the `pending` set and `canSkipScopeMemberWithDeps` only consults that set — then closed by an unforced update, which bd refuses. **The compiler mints this shape:** `graph.go` mints one scope-check per scoped step carrying that step's `gc.scope_ref`, and `rewriteGraphRefs` repoints every reference at a scoped step onto that step's scope-check. So a step needing a same-scope sibling compiles to a bead blocked by the very control that aborts its scope. (An earlier draft cited a fleet query about `workflow-finalize` instead; that edge is real but irrelevant — finalize carries no `gc.scope_ref`, so it is never a scope member.) Pinned as current (wrong) behavior so the fix shows up as a diff.
- **The legacy self-edge** is unrecoverable under real bd. Pinned by its own test so a formula cannot silently reintroduce it.

`runtime_test.go` explicitly asserts the futureMember `blocks` edge **survives** the abort, so deleting it to go green would have deleted an assertion. Split instead: abort semantics keep their test, the two broken shapes get theirs. The only fixture lines removed are the stale self-edges in two retry tests where nothing asserted them. A reviewer checked every deletion for silently-weakened coverage and found none.

Also corrects `SelfClosingControlKinds`' doc comment, which claimed every other control kind closes only itself. Retry and ralph controls close a foreign logical bead that blocks them — safe by ordering, not by self-closure.

## Notes for whoever fixes ga-4ote2

- `skipScopeMembers` has **two** unforced branches — `UpdateAll` (runtime.go:1554) and a per-id `Update` fallback (:1562). Moving only the batch one leaves it half-fixed.
- `CloseAll` is a sound target: it writes metadata first via `setMetadataBatchAll` (a metadata-only update, unrefusable) and then closes with `--force`, so `gc.outcome=skipped` is not dropped.
- Do **not** simply flip the pinning test to "clean abort" — carry over a dep-preservation assertion, or a fix that just deletes the offending dep would pass.

## Verification

- `go build ./...`, `go vet ./...` clean; `gofmt` clean
- `internal/dispatch`, `internal/beadmeta`, `internal/formula`, `internal/beads` pass
- `go test ./internal/...` otherwise passes except `internal/worker/adapters/zcode`, which hangs waiting on an external agent CLI subprocess (live-provider harness)
- `make test` does **not** complete: `cmd/gc` hangs on an unbounded network `git` call under packman's repo-cache write lock. Reproduced twice; evidence appended to **ga-r0epd**. Pre-existing — this diff is test-only in `internal/dispatch` plus a comment-only edit, verified mechanically, so it cannot affect the `cmd/gc` binary.

Refs: ga-a6zy9 (Slice 2 of 4; Slices 1/3/4 merged as #5199/#5497/#5202), ga-4ote2, ga-r0epd
