### PR TITLE
fix(packman): bound network git so a wedged remote cannot hold the machine-wide cache lock

### DIFF
--- a/cmd/gc/builtin_include_doctor_check_test.go
+++ b/cmd/gc/builtin_include_doctor_check_test.go
@@ -1317,6 +1317,7 @@ provider = "file"
 func TestBuiltinImportDoctorCheck_OKAfterInit(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
+	stubInitRemoteImports(t)
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"init", "--skip-provider-readiness", "--provider", "claude", dir}, &stdout, &stderr); code != 0 {
@@ -1467,6 +1468,7 @@ func TestMigrateLegacySystemPacksManifestPreservesImportOptions(t *testing.T) {
 func TestBuiltinImportDoctorCheck_FixSkipsResyncWhenNoOwnedMutation(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
+	stubInitRemoteImports(t)
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"init", "--skip-provider-readiness", "--provider", "claude", dir}, &stdout, &stderr); code != 0 {

--- a/cmd/gc/cmd_event_emit_test.go
+++ b/cmd/gc/cmd_event_emit_test.go
@@ -290,6 +290,7 @@ func TestEventEmitViaCLI(t *testing.T) {
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_SESSION", "fake")
 	configureIsolatedRuntimeEnv(t)
+	stubInitRemoteImports(t)
 
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer

--- a/cmd/gc/cwd_fallback_guard_test.go
+++ b/cmd/gc/cwd_fallback_guard_test.go
@@ -73,6 +73,7 @@ func TestCmdInit_ExplicitPathNonTerminalStillWorks(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	disableBootstrapForTests(t)
+	stubInitRemoteImports(t)
 
 	oldRegister := registerCityWithSupervisorTestHook
 	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
@@ -101,6 +102,7 @@ func TestCmdInit_NoArgsTerminalUnchanged(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	disableBootstrapForTests(t)
+	stubInitRemoteImports(t)
 
 	oldRegister := registerCityWithSupervisorTestHook
 	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -27,6 +27,27 @@ func disableBootstrapForTests(t *testing.T) {
 	t.Cleanup(func() { bootstrap.BootstrapPacks = old })
 }
 
+// stubInitRemoteImports makes finalizeInit's remote-import install hermetic.
+//
+// A full init clones gascity-packs over the network: the nested bundled source
+// gascity/roles is not recognized as bundled, so it misses the synthetic cache
+// and takes the real clone path (ga-73eoo). That single clone is most of the
+// runtime of every test that runs a real init, and packman performs it while
+// holding the machine-wide repo-cache write lock — so one wedged remote stalls
+// the whole suite and the pre-push hook with it (ga-r0epd).
+//
+// Use this only in tests whose subject is something other than import
+// installation. Tests that assert on the install itself must stub
+// ensureInitRemoteImportsInstalled directly with the behavior they mean to
+// exercise, the way TestFinalizeInitReportsRemoteImportInstallFailure does;
+// routing those through this helper would assert against a no-op.
+func stubInitRemoteImports(t *testing.T) {
+	t.Helper()
+	prev := ensureInitRemoteImportsInstalled
+	t.Cleanup(func() { ensureInitRemoteImportsInstalled = prev })
+	ensureInitRemoteImportsInstalled = func(string) error { return nil }
+}
+
 func stubInitDependencyChecks(t *testing.T) {
 	t.Helper()
 	oldLookPath := initLookPath

--- a/internal/gitcred/redact.go
+++ b/internal/gitcred/redact.go
@@ -32,6 +32,55 @@ func RedactUserinfo(rawURL string) string {
 	return "***@" + rebuilt
 }
 
+// ScrubSecrets masks any credential embedded in rawURL wherever it appears in
+// msg, and returns msg unchanged when rawURL carries no credential.
+//
+// RedactUserinfo is not enough on its own: it fixes up a URL the caller
+// interpolated, but git echoes the remote verbatim in transport failures, so an
+// error assembled from a subprocess's own output can still carry the token.
+//
+// Three maskings, because no one of them is sufficient. url.User.Password()
+// returns the DECODED password and url.User.String() re-encodes and normalizes,
+// so a percent-encoded credential git printed verbatim ("user:se%63ret")
+// matches neither — the raw authority substring is what catches that, and it
+// also covers URLs url.Parse rejects outright.
+func ScrubSecrets(msg, rawURL string) string {
+	trimmed := strings.TrimSpace(rawURL)
+	scrubbed := msg
+	if u, err := url.Parse(trimmed); err == nil && u.User != nil {
+		if pw, ok := u.User.Password(); ok && pw != "" {
+			scrubbed = strings.ReplaceAll(scrubbed, pw, "***")
+		}
+		if userinfo := u.User.String(); userinfo != "" {
+			scrubbed = strings.ReplaceAll(scrubbed, userinfo, "***")
+		}
+	}
+	if userinfo := rawURLUserinfo(trimmed); userinfo != "" {
+		scrubbed = strings.ReplaceAll(scrubbed, userinfo, "***")
+	}
+	return scrubbed
+}
+
+// rawURLUserinfo extracts the authority userinfo ("user:pass") from a URL string
+// even when url.Parse rejects it, so a malformed credential URL can still be
+// scrubbed. It returns "" when there is no scheme separator or no authority "@".
+func rawURLUserinfo(rawURL string) string {
+	sep := strings.Index(rawURL, "://")
+	if sep < 0 {
+		return ""
+	}
+	rest := rawURL[sep+3:]
+	authority := rest
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		authority = rest[:i]
+	}
+	at := strings.LastIndexByte(authority, '@')
+	if at < 0 {
+		return ""
+	}
+	return authority[:at]
+}
+
 // redactUserinfoString masks the userinfo of a URL that url.Parse rejected. It
 // replaces everything between "://" and the last "@" that precedes the first
 // "/" of the path (the authority-section "@") with "***". A string without a

--- a/internal/gitcred/redact_test.go
+++ b/internal/gitcred/redact_test.go
@@ -47,3 +47,70 @@ func TestRedactUserinfoNeverLeaksOnParseFailure(t *testing.T) {
 		}
 	}
 }
+
+// TestScrubSecrets covers the case RedactUserinfo cannot: a credential that
+// appears in text a subprocess produced rather than in a URL the caller
+// interpolated. git echoes the remote verbatim on transport failures, so the
+// token arrives already embedded in a sentence.
+func TestScrubSecrets(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     string
+		rawURL  string
+		leaked  string
+		wantSub string
+	}{
+		{
+			name:    "plain credential echoed by git",
+			msg:     "fatal: could not read from https://user:ghp_secret@github.com/org/repo",
+			rawURL:  "https://user:ghp_secret@github.com/org/repo",
+			leaked:  "ghp_secret",
+			wantSub: "github.com/org/repo",
+		},
+		{
+			// The subtle one. url.User.Password() returns the DECODED password
+			// and url.User.String() re-encodes, so neither matches the bytes git
+			// actually printed. Only the raw authority substring catches this.
+			name:    "percent-encoded credential echoed verbatim",
+			msg:     "fatal: authentication failed for https://user:se%63ret@github.com/org/repo",
+			rawURL:  "https://user:se%63ret@github.com/org/repo",
+			leaked:  "se%63ret",
+			wantSub: "github.com/org/repo",
+		},
+		{
+			name:    "url.Parse rejects the URL, token still masked",
+			msg:     "fatal: could not read from https://user:tok en@github.com/org/repo",
+			rawURL:  "https://user:tok en@github.com/org/repo",
+			leaked:  "tok en",
+			wantSub: "github.com/org/repo",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScrubSecrets(tc.msg, tc.rawURL)
+			if strings.Contains(got, tc.leaked) {
+				t.Errorf("ScrubSecrets leaked %q: %s", tc.leaked, got)
+			}
+			if !strings.Contains(got, tc.wantSub) {
+				t.Errorf("ScrubSecrets(%q) = %q, want it to keep %q", tc.msg, got, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestScrubSecretsLeavesCleanMessagesAlone pins that a message is returned
+// untouched when the URL carries no credential. Over-masking would corrupt
+// ordinary diagnostics.
+func TestScrubSecretsLeavesCleanMessagesAlone(t *testing.T) {
+	msg := "fatal: repository 'https://github.com/org/repo' not found"
+	for _, rawURL := range []string{
+		"https://github.com/org/repo",
+		"git@github.com:org/repo.git",
+		"file:///home/u/repo",
+		"",
+	} {
+		if got := ScrubSecrets(msg, rawURL); got != msg {
+			t.Errorf("ScrubSecrets(msg, %q) = %q, want it unchanged", rawURL, got)
+		}
+	}
+}

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -2,11 +2,14 @@
 package packman
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/config"
@@ -20,6 +23,34 @@ var (
 	runNetworkGit            = defaultRunNetworkGit
 	materializeSyntheticRepo = builtinpacks.MaterializeSyntheticRepo
 )
+
+// networkGitTimeout bounds every network git invocation.
+//
+// The bound belongs here rather than at the callers because the invariant it
+// protects is packman-local: EnsureRepoInCache clones while holding
+// WithRepoCacheWriteLock, so a git that never returns holds the machine-wide
+// repo-cache lock forever and every other gc process on the host that touches
+// pack state queues behind it. That is ga-r0epd — one wedged remote taking out
+// `gc help`, `make test` and the pre-push hook for every agent on the machine.
+//
+// Ten minutes is deliberately generous: it is far longer than any healthy pack
+// clone and short enough that a wedge resolves itself within one coffee break
+// instead of never. It is a var so tests can shrink it.
+var networkGitTimeout = 10 * time.Minute
+
+// networkGitWaitDelay caps how long a killed git's surviving children may keep
+// the output pipes open before they are SIGKILLed. This is not defensive
+// padding: a blackholed clone leaves git-remote-http holding the pipe, so
+// killing git alone leaves the call blocked in CombinedOutput and the deadline
+// buys nothing. It is a var so tests can shrink it; the real bound on a call is
+// networkGitTimeout + networkGitWaitDelay.
+var networkGitWaitDelay = 10 * time.Second
+
+// errNetworkGitTimeout marks a network git call killed by networkGitTimeout.
+// It is a distinct sentinel because "the deadline fired" and "the remote said
+// no" call for opposite responses, and callers that cannot tell them apart
+// tend to retry the wrong one.
+var errNetworkGitTimeout = errors.New("network git call timed out")
 
 // RepoCacheRoot returns the shared machine-local repo cache root,
 // honoring the GC_HOME override via config.GlobalRepoCacheRoot so the
@@ -319,13 +350,27 @@ func defaultRunNetworkGit(cityRoot, remoteURL, dir string, args ...string) (stri
 		return "", fmt.Errorf("loading git credentials for %s: %w", gitcred.RedactUserinfo(remoteURL), err)
 	}
 	cmdArgs := buildNetworkGitArgs(inj, args...)
-	cmd := exec.Command("git", cmdArgs...)
+	ctx, cancel := context.WithTimeout(context.Background(), networkGitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
 	cmd.Env = append(gitutil.HermeticEnv(), inj.Env...)
+	// git spawns helpers (git-remote-http, credential helpers) that inherit the
+	// output pipes, so killing git alone can leave CombinedOutput waiting on a
+	// pipe a child still holds. WaitDelay caps that second wait and SIGKILLs
+	// whatever is left, which is the difference between a bounded call and a
+	// bound that only looks like one.
+	cmd.WaitDelay = networkGitWaitDelay
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		// Check the deadline before classifying: a killed git produces little
+		// or no output, and auth classification reads output, so asking it
+		// first invites a confident wrong answer about why the call failed.
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("git %s: %w after %s: %s", strings.Join(args, " "), errNetworkGitTimeout, networkGitTimeout, strings.TrimSpace(string(out)))
+		}
 		if authErr := gitcred.ClassifyAuthError(remoteURL, inj, string(out), err); authErr != nil {
 			return "", authErr
 		}

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -45,7 +45,7 @@ var networkGitTimeout = 10 * time.Minute
 //
 // WaitDelay closes the parent's ends of those pipes; it does not signal anything
 // but the command's own process. Killing the descendants is
-// terminateNetworkGitGroup's job, and both are needed: the group kill stops the
+// configureNetworkGitDeadline's job, and both are needed: the group kill stops the
 // writers, WaitDelay unblocks the reader if one slips through anyway. It is a
 // var so tests can shrink it; the real bound on a call is networkGitTimeout +
 // networkGitWaitDelay.
@@ -56,7 +56,16 @@ var networkGitWaitDelay = 10 * time.Second
 // it is interrupted, so asking politely first is what keeps a timed-out clone
 // from leaving debris in the repo cache; the escalation is what makes the bound
 // hold when it ignores us.
-const networkGitTerminateGrace = 2 * time.Second
+//
+// What the grace actually bounds is that removal — an rm -rf of a partial
+// clone, which on a multi-GB pack over slow storage can exceed a second or two.
+// It is sized for that rather than for process teardown. Getting it wrong costs
+// tidiness rather than correctness: debris from a SIGKILL landing mid-removal
+// is reclaimed by the next holder of the cache write lock, which RemoveAll's a
+// checkout with no completion marker. The cost of the larger value is bounded
+// too — worst case 2x this appended to a call that has already waited
+// networkGitTimeout, and it elapses before WaitDelay's clock starts.
+const networkGitTerminateGrace = 5 * time.Second
 
 // errNetworkGitTimeout marks a network git call killed by networkGitTimeout.
 // It is a distinct sentinel because "the deadline fired" and "the remote said
@@ -350,6 +359,24 @@ func buildNetworkGitArgs(inj gitcred.Injection, args ...string) []string {
 	return cmdArgs
 }
 
+// redactNetworkGitArgs renders a git argv for an error message with any
+// credential masked. git's argv carries the remote verbatim, so a source with
+// userinfo (https://user:token@host/repo) puts the token in every failure line
+// this function's callers build — and those errors are logged and surfaced.
+//
+// The callers' own wraps redact the URL they interpolate, which makes the leak
+// easy to miss: the outer label reads "cloning ***@host/repo" while the inner
+// string still carries the raw token. Only args are rendered, never
+// inj.CfgArgs or inj.Env, which is where the injected credential material
+// actually lives.
+func redactNetworkGitArgs(args []string) string {
+	safe := make([]string, len(args))
+	for i, a := range args {
+		safe[i] = gitcred.RedactUserinfo(a)
+	}
+	return strings.Join(safe, " ")
+}
+
 // defaultRunNetworkGit is defaultRunGit plus per-invocation credential
 // injection and typed auth classification. Every network fetch/clone/ls-remote
 // runs through it so a matched credential rule authenticates the call and an
@@ -373,29 +400,29 @@ func defaultRunNetworkGit(cityRoot, remoteURL, dir string, args ...string) (stri
 	// cancel kills the command's own process, which leaves git-remote-http and
 	// index-pack alive — still writing into the cache directory this call is
 	// holding the write lock over. The next process to take that lock can then
-	// RemoveAll a tree a live orphan is repopulating. Starting git as its own
-	// group leader makes the whole tree addressable in one signal.
-	startNetworkGitInOwnGroup(cmd)
-	cmd.Cancel = func() error { return terminateNetworkGitGroup(cmd) }
+	// RemoveAll a tree a live orphan is repopulating.
+	configureNetworkGitDeadline(cmd)
 	cmd.WaitDelay = networkGitWaitDelay
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// Auth classification runs first, and the deadline is the fallback.
-		// ClassifyAuthError gates on an *exec.ExitError with code 128, which a
-		// killed process (exit -1) can never satisfy, so a wedge cannot be
-		// mistaken for an auth failure no matter what partial output it left
-		// behind. Asking the deadline first would be the lossy order: a real
-		// rejection landing in the last milliseconds before the deadline lapses
-		// would be reported as a wedge, and the credential hint the user needs
-		// suppressed. So the timeout branch means what it should — the failure
-		// was not diagnosable and the clock had run out.
+		// ClassifyAuthError needs an *exec.ExitError with code 128 AND a
+		// recognized auth diagnostic in the output. A killed process usually
+		// exits -1, but a group SIGTERM can also race so that git observes its
+		// dead helper and die()s with 128 ("the remote end hung up") before its
+		// own signal lands — that exit code alone is not enough to misclassify,
+		// because "hung up" matches no auth trigger. So a wedge cannot be read
+		// as an auth failure, while the reverse order would be lossy: a real
+		// rejection landing in the last milliseconds before the deadline would
+		// be reported as a wedge and the credential hint the user needs
+		// suppressed.
 		if authErr := gitcred.ClassifyAuthError(remoteURL, inj, string(out), err); authErr != nil {
 			return "", authErr
 		}
 		if ctx.Err() != nil {
-			return "", fmt.Errorf("git %s: %w after %s: %s", strings.Join(args, " "), errNetworkGitTimeout, networkGitTimeout, strings.TrimSpace(string(out)))
+			return "", fmt.Errorf("git %s: %w after %s: %s", redactNetworkGitArgs(args), errNetworkGitTimeout, networkGitTimeout, gitcred.ScrubSecrets(strings.TrimSpace(string(out)), remoteURL))
 		}
-		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+		return "", fmt.Errorf("git %s: %s: %w", redactNetworkGitArgs(args), gitcred.ScrubSecrets(strings.TrimSpace(string(out)), remoteURL), err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -38,13 +38,25 @@ var (
 // instead of never. It is a var so tests can shrink it.
 var networkGitTimeout = 10 * time.Minute
 
-// networkGitWaitDelay caps how long a killed git's surviving children may keep
-// the output pipes open before they are SIGKILLed. This is not defensive
-// padding: a blackholed clone leaves git-remote-http holding the pipe, so
-// killing git alone leaves the call blocked in CombinedOutput and the deadline
-// buys nothing. It is a var so tests can shrink it; the real bound on a call is
-// networkGitTimeout + networkGitWaitDelay.
+// networkGitWaitDelay caps how long the call may stay blocked in CombinedOutput
+// after the deadline fires. This is not defensive padding: git's helpers
+// (git-remote-http, credential helpers) inherit the output pipes, so a read on
+// those pipes can outlive git itself and the deadline alone buys nothing.
+//
+// WaitDelay closes the parent's ends of those pipes; it does not signal anything
+// but the command's own process. Killing the descendants is
+// terminateNetworkGitGroup's job, and both are needed: the group kill stops the
+// writers, WaitDelay unblocks the reader if one slips through anyway. It is a
+// var so tests can shrink it; the real bound on a call is networkGitTimeout +
+// networkGitWaitDelay.
 var networkGitWaitDelay = 10 * time.Second
+
+// networkGitTerminateGrace is how long git's process group gets to exit on
+// SIGTERM before it is SIGKILLed. git removes a partially cloned directory when
+// it is interrupted, so asking politely first is what keeps a timed-out clone
+// from leaving debris in the repo cache; the escalation is what makes the bound
+// hold when it ignores us.
+const networkGitTerminateGrace = 2 * time.Second
 
 // errNetworkGitTimeout marks a network git call killed by networkGitTimeout.
 // It is a distinct sentinel because "the deadline fired" and "the remote said
@@ -357,22 +369,31 @@ func defaultRunNetworkGit(cityRoot, remoteURL, dir string, args ...string) (stri
 		cmd.Dir = dir
 	}
 	cmd.Env = append(gitutil.HermeticEnv(), inj.Env...)
-	// git spawns helpers (git-remote-http, credential helpers) that inherit the
-	// output pipes, so killing git alone can leave CombinedOutput waiting on a
-	// pipe a child still holds. WaitDelay caps that second wait and SIGKILLs
-	// whatever is left, which is the difference between a bounded call and a
-	// bound that only looks like one.
+	// The deadline has to reach git's descendants, not just git. exec's default
+	// cancel kills the command's own process, which leaves git-remote-http and
+	// index-pack alive — still writing into the cache directory this call is
+	// holding the write lock over. The next process to take that lock can then
+	// RemoveAll a tree a live orphan is repopulating. Starting git as its own
+	// group leader makes the whole tree addressable in one signal.
+	startNetworkGitInOwnGroup(cmd)
+	cmd.Cancel = func() error { return terminateNetworkGitGroup(cmd) }
 	cmd.WaitDelay = networkGitWaitDelay
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		// Check the deadline before classifying: a killed git produces little
-		// or no output, and auth classification reads output, so asking it
-		// first invites a confident wrong answer about why the call failed.
-		if ctx.Err() != nil {
-			return "", fmt.Errorf("git %s: %w after %s: %s", strings.Join(args, " "), errNetworkGitTimeout, networkGitTimeout, strings.TrimSpace(string(out)))
-		}
+		// Auth classification runs first, and the deadline is the fallback.
+		// ClassifyAuthError gates on an *exec.ExitError with code 128, which a
+		// killed process (exit -1) can never satisfy, so a wedge cannot be
+		// mistaken for an auth failure no matter what partial output it left
+		// behind. Asking the deadline first would be the lossy order: a real
+		// rejection landing in the last milliseconds before the deadline lapses
+		// would be reported as a wedge, and the credential hint the user needs
+		// suppressed. So the timeout branch means what it should — the failure
+		// was not diagnosable and the clock had run out.
 		if authErr := gitcred.ClassifyAuthError(remoteURL, inj, string(out), err); authErr != nil {
 			return "", authErr
+		}
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("git %s: %w after %s: %s", strings.Join(args, " "), errNetworkGitTimeout, networkGitTimeout, strings.TrimSpace(string(out)))
 		}
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}

--- a/internal/packman/network_git_group_unix_test.go
+++ b/internal/packman/network_git_group_unix_test.go
@@ -3,12 +3,10 @@
 package packman
 
 import (
-	"os"
-	"strconv"
-	"strings"
-	"syscall"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/processgroup/processgrouptest"
 )
 
 // TestDefaultRunNetworkGitKillsDescendants pins that the deadline reaches git's
@@ -22,9 +20,15 @@ import (
 // take that lock can RemoveAll a tree a live orphan is repopulating, which is
 // the same corruption the lock exists to prevent, arriving by a different door.
 //
-// Returning on time is therefore not sufficient. The tree has to be dead.
+// Returning on time is therefore not the property under test. The assertion is
+// that the writing stopped, measured directly: the shim's child appends to a
+// heartbeat file for as long as it lives, so a file that stops growing is the
+// descendant's death and a file that keeps growing is the leak. That is also
+// why this asserts on bytes rather than on the pid — a killed orphan is a
+// zombie until init reaps it, so pid liveness is ambiguous for exactly as long
+// as it takes to be misleading.
 func TestDefaultRunNetworkGitKillsDescendants(t *testing.T) {
-	remote, childPIDPath := wedgedGit(t)
+	wedged := wedgedGit(t)
 
 	restore := networkGitTimeout
 	networkGitTimeout = 300 * time.Millisecond
@@ -33,42 +37,15 @@ func TestDefaultRunNetworkGitKillsDescendants(t *testing.T) {
 	networkGitWaitDelay = time.Second
 	t.Cleanup(func() { networkGitWaitDelay = restoreWait })
 
-	if _, err := defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, t.TempDir()+"/dest"); err == nil {
+	if _, err := defaultRunNetworkGit("", wedged.URL, "", "clone", "--quiet", wedged.URL, t.TempDir()+"/dest"); err == nil {
 		t.Fatal("cloning a wedged remote succeeded, want a timeout error")
 	}
 
-	pid := readChildPID(t, childPIDPath)
-	// The group kill is delivered as the deadline fires, but reaping is not
-	// instant; poll briefly rather than assert on a single sample.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if err := syscall.Kill(pid, 0); err != nil {
-			return // ESRCH: the descendant is gone, which is the point.
-		}
-		if time.Now().After(deadline) {
-			// Do not leave a live orphan behind for the rest of the suite.
-			_ = syscall.Kill(pid, syscall.SIGKILL)
-			t.Fatalf("git's child (pid %d) survived the deadline: the bound kills git but orphans its helpers, which keep writing into the repo cache after the lock is released", pid)
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
-}
-
-func readChildPID(t *testing.T, path string) int {
-	t.Helper()
-	// The shim writes the pid just after backgrounding, so it may not have
-	// landed the instant the bound returns.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		raw, err := os.ReadFile(path)
-		if err == nil {
-			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw))); convErr == nil && pid > 0 {
-				return pid
-			}
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("git shim never recorded its child pid at %s: %v", path, err)
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
+	// Non-empty proves the child ran at all; without this the stability check
+	// below would pass vacuously against a shim that never started one.
+	size := processgrouptest.WaitForFileSize(t, wedged.HeartbeatPath)
+	// The child writes about once a second, so 1.5s of no growth cannot be a
+	// gap between its writes. AssertFileSizeStable fails with "kept growing
+	// after timeout cleanup" when the orphan survived, which is the leak.
+	processgrouptest.AssertFileSizeStable(t, wedged.HeartbeatPath, size, 1500*time.Millisecond)
 }

--- a/internal/packman/network_git_group_unix_test.go
+++ b/internal/packman/network_git_group_unix_test.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+package packman
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestDefaultRunNetworkGitKillsDescendants pins that the deadline reaches git's
+// children, not just git.
+//
+// The first version of this bound relied on cmd.WaitDelay, whose contract is to
+// close the parent's ends of the I/O pipes and kill the command's own process.
+// It does not signal descendants. So the call returned on time while
+// git-remote-http and index-pack stayed alive — still writing into the cache
+// directory whose write lock this call had just released. The next process to
+// take that lock can RemoveAll a tree a live orphan is repopulating, which is
+// the same corruption the lock exists to prevent, arriving by a different door.
+//
+// Returning on time is therefore not sufficient. The tree has to be dead.
+func TestDefaultRunNetworkGitKillsDescendants(t *testing.T) {
+	remote, childPIDPath := wedgedGit(t)
+
+	restore := networkGitTimeout
+	networkGitTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { networkGitTimeout = restore })
+	restoreWait := networkGitWaitDelay
+	networkGitWaitDelay = time.Second
+	t.Cleanup(func() { networkGitWaitDelay = restoreWait })
+
+	if _, err := defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, t.TempDir()+"/dest"); err == nil {
+		t.Fatal("cloning a wedged remote succeeded, want a timeout error")
+	}
+
+	pid := readChildPID(t, childPIDPath)
+	// The group kill is delivered as the deadline fires, but reaping is not
+	// instant; poll briefly rather than assert on a single sample.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return // ESRCH: the descendant is gone, which is the point.
+		}
+		if time.Now().After(deadline) {
+			// Do not leave a live orphan behind for the rest of the suite.
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+			t.Fatalf("git's child (pid %d) survived the deadline: the bound kills git but orphans its helpers, which keep writing into the repo cache after the lock is released", pid)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func readChildPID(t *testing.T, path string) int {
+	t.Helper()
+	// The shim writes the pid just after backgrounding, so it may not have
+	// landed the instant the bound returns.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("git shim never recorded its child pid at %s: %v", path, err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}

--- a/internal/packman/network_git_group_unix_test.go
+++ b/internal/packman/network_git_group_unix_test.go
@@ -41,11 +41,11 @@ func TestDefaultRunNetworkGitKillsDescendants(t *testing.T) {
 		t.Fatal("cloning a wedged remote succeeded, want a timeout error")
 	}
 
-	// Non-empty proves the child ran at all; without this the stability check
-	// below would pass vacuously against a shim that never started one.
 	size := processgrouptest.WaitForFileSize(t, wedged.HeartbeatPath)
-	// The child writes about once a second, so 1.5s of no growth cannot be a
-	// gap between its writes. AssertFileSizeStable fails with "kept growing
-	// after timeout cleanup" when the orphan survived, which is the leak.
-	processgrouptest.AssertFileSizeStable(t, wedged.HeartbeatPath, size, 1500*time.Millisecond)
+	// The window has to be a comfortable multiple of the shim's 50ms write
+	// cadence, because the failure mode of getting it wrong is silent: a live
+	// orphan that happens to be descheduled for one window reads as a dead one
+	// and the test goes green having stopped guarding. 300ms is 6x, and is what
+	// the other users of this helper pair with the same cadence.
+	processgrouptest.AssertFileSizeStable(t, wedged.HeartbeatPath, size, 300*time.Millisecond)
 }

--- a/internal/packman/network_git_timeout_test.go
+++ b/internal/packman/network_git_timeout_test.go
@@ -9,10 +9,25 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/processgroup/processgrouptest"
 )
 
-// wedgedGit puts a `git` on PATH that hangs the way a wedged remote does, and
-// returns a remote URL it will ignore.
+// wedgedRemote is what wedgedGit hands back: the remote URL the shim ignores,
+// plus the two artifacts its backgrounded child produces so a test can observe
+// the child's lifecycle without polling it.
+type wedgedRemote struct {
+	// URL is a syntactically valid remote the shim never actually contacts.
+	URL string
+	// PIDPath receives the backgrounded child's pid, for cleanup.
+	PIDPath string
+	// HeartbeatPath grows for as long as that child is alive. Its size is the
+	// direct measurement of the thing the bound has to stop: not "did the call
+	// return" but "did the work stop".
+	HeartbeatPath string
+}
+
+// wedgedGit puts a `git` on PATH that hangs the way a wedged remote does.
 //
 // A loopback listener that accepts and never answers is the more literal
 // reproduction, but it is not the more faithful one. What has to be exercised
@@ -23,10 +38,14 @@ import (
 // stderr, then waits — instead of hoping a real git happens to do it. It also
 // needs no port, no listener and no network, so it cannot flake on a busy host.
 //
+// The child appends to a heartbeat file rather than merely sleeping, so its
+// liveness is observable as a file that stops growing. That is what lets these
+// tests assert on the descendants with no polling loop of their own.
+//
 // exec.Command resolves the binary against the parent process PATH rather than
 // cmd.Env, so t.Setenv is enough to intercept even though defaultRunNetworkGit
 // hands the child a hermetic environment.
-func wedgedGit(t *testing.T) (remote, childPIDPath string) {
+func wedgedGit(t *testing.T) wedgedRemote {
 	t.Helper()
 	dir := t.TempDir()
 	// The shim runs with the hermetic environment defaultRunNetworkGit builds,
@@ -43,13 +62,23 @@ func wedgedGit(t *testing.T) (remote, childPIDPath string) {
 		}
 		t.Skipf("no sleep binary on %s: %v", runtime.GOOS, err)
 	}
-	childPIDPath = filepath.Join(dir, "child.pid")
-	script := "#!/bin/sh\n" + sleep + " 300 &\necho $! > " + childPIDPath + "\nwait\n"
+	w := wedgedRemote{
+		URL:           "http://packman.invalid/wedged.git",
+		PIDPath:       filepath.Join(dir, "child.pid"),
+		HeartbeatPath: filepath.Join(dir, "child.heartbeat"),
+	}
+	script := "#!/bin/sh\n" +
+		"{ while : ; do echo . >> " + w.HeartbeatPath + " ; " + sleep + " 1 ; done ; } &\n" +
+		"echo $! > " + w.PIDPath + "\n" +
+		"wait\n"
 	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
 		t.Fatalf("writing git shim: %v", err)
 	}
 	t.Setenv("PATH", dir)
-	return "http://packman.invalid/wedged.git", childPIDPath
+	// A test that fails before the bound kills the group must not leave the
+	// child running for the rest of the package.
+	t.Cleanup(func() { processgrouptest.KillFromPIDFile(t, w.PIDPath) })
+	return w
 }
 
 // TestDefaultRunNetworkGitIsBounded is the ga-r0epd regression test.
@@ -64,7 +93,7 @@ func wedgedGit(t *testing.T) (remote, childPIDPath string) {
 // The assertion is deliberately about the deadline, not the error text: what
 // matters is that the call RETURNS.
 func TestDefaultRunNetworkGitIsBounded(t *testing.T) {
-	remote, _ := wedgedGit(t)
+	remote := wedgedGit(t).URL
 
 	restore := networkGitTimeout
 	networkGitTimeout = 300 * time.Millisecond

--- a/internal/packman/network_git_timeout_test.go
+++ b/internal/packman/network_git_timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ import (
 // exec.Command resolves the binary against the parent process PATH rather than
 // cmd.Env, so t.Setenv is enough to intercept even though defaultRunNetworkGit
 // hands the child a hermetic environment.
-func wedgedGit(t *testing.T) string {
+func wedgedGit(t *testing.T) (remote, childPIDPath string) {
 	t.Helper()
 	dir := t.TempDir()
 	// The shim runs with the hermetic environment defaultRunNetworkGit builds,
@@ -34,14 +35,21 @@ func wedgedGit(t *testing.T) string {
 	// exits instantly — which looks exactly like a bound that fired early.
 	sleep, err := exec.LookPath("sleep")
 	if err != nil {
-		t.Skipf("no sleep binary to build a wedged git shim: %v", err)
+		// Skipping here would delete exactly the coverage this file exists for,
+		// silently. sleep is POSIX-required, so on the platforms we test it is
+		// a broken image, not an unsupported one.
+		if runtime.GOOS != "windows" {
+			t.Fatalf("no sleep binary to build a wedged git shim: %v", err)
+		}
+		t.Skipf("no sleep binary on %s: %v", runtime.GOOS, err)
 	}
-	script := "#!/bin/sh\n" + sleep + " 300 &\nwait\n"
+	childPIDPath = filepath.Join(dir, "child.pid")
+	script := "#!/bin/sh\n" + sleep + " 300 &\necho $! > " + childPIDPath + "\nwait\n"
 	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
 		t.Fatalf("writing git shim: %v", err)
 	}
 	t.Setenv("PATH", dir)
-	return "http://packman.invalid/wedged.git"
+	return "http://packman.invalid/wedged.git", childPIDPath
 }
 
 // TestDefaultRunNetworkGitIsBounded is the ga-r0epd regression test.
@@ -56,7 +64,7 @@ func wedgedGit(t *testing.T) string {
 // The assertion is deliberately about the deadline, not the error text: what
 // matters is that the call RETURNS.
 func TestDefaultRunNetworkGitIsBounded(t *testing.T) {
-	remote := wedgedGit(t)
+	remote, _ := wedgedGit(t)
 
 	restore := networkGitTimeout
 	networkGitTimeout = 300 * time.Millisecond
@@ -125,5 +133,12 @@ func TestDefaultRunNetworkGitRealFailuresAreNotTimeouts(t *testing.T) {
 	}
 	if errors.Is(err, errNetworkGitTimeout) {
 		t.Fatalf("err = %v, want a real git failure rather than a timeout classification", err)
+	}
+	// Asserting only "some error" would let this pass vacuously on an image
+	// with no git at all — where the bounded test supplies its own shim and
+	// this one would go green having executed no git at all. Naming git's own
+	// diagnosis is what keeps the control honest.
+	if !strings.Contains(err.Error(), "does not appear to be a git repository") {
+		t.Fatalf("err = %v, want git's own no-such-repository diagnosis", err)
 	}
 }

--- a/internal/packman/network_git_timeout_test.go
+++ b/internal/packman/network_git_timeout_test.go
@@ -2,44 +2,46 @@ package packman
 
 import (
 	"errors"
-	"fmt"
-	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
-// blackholeGitServer returns an http:// URL whose TCP listener accepts
-// connections and then never writes a byte. git connects, sends its request,
-// and waits forever — the same shape as a remote that is reachable but wedged,
-// which is what ga-r0epd is really about. Nothing leaves loopback.
-func blackholeGitServer(t *testing.T) string {
+// wedgedGit puts a `git` on PATH that hangs the way a wedged remote does, and
+// returns a remote URL it will ignore.
+//
+// A loopback listener that accepts and never answers is the more literal
+// reproduction, but it is not the more faithful one. What has to be exercised
+// is the shape that makes the bound hard: git spawns helpers (git-remote-http,
+// credential helpers) that inherit the output pipes, so killing git alone
+// leaves CombinedOutput blocked on a pipe a child still holds. This shim
+// reproduces that on purpose — it backgrounds a child that inherits stdout and
+// stderr, then waits — instead of hoping a real git happens to do it. It also
+// needs no port, no listener and no network, so it cannot flake on a busy host.
+//
+// exec.Command resolves the binary against the parent process PATH rather than
+// cmd.Env, so t.Setenv is enough to intercept even though defaultRunNetworkGit
+// hands the child a hermetic environment.
+func wedgedGit(t *testing.T) string {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	dir := t.TempDir()
+	// The shim runs with the hermetic environment defaultRunNetworkGit builds,
+	// whose PATH is not this machine's, so sleep is resolved here and embedded
+	// absolute. Left as a bare name it silently fails to start and the shim
+	// exits instantly — which looks exactly like a bound that fired early.
+	sleep, err := exec.LookPath("sleep")
 	if err != nil {
-		t.Fatalf("listen: %v", err)
+		t.Skipf("no sleep binary to build a wedged git shim: %v", err)
 	}
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			// Hold the connection open and answer nothing. Closing on
-			// listener shutdown is what releases git if the bound never fires.
-			go func() {
-				<-done
-				_ = conn.Close()
-			}()
-		}
-	}()
-	t.Cleanup(func() {
-		_ = ln.Close()
-		<-done
-	})
-	return fmt.Sprintf("http://%s/blackhole.git", ln.Addr().String())
+	script := "#!/bin/sh\n" + sleep + " 300 &\nwait\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing git shim: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	return "http://packman.invalid/wedged.git"
 }
 
 // TestDefaultRunNetworkGitIsBounded is the ga-r0epd regression test.
@@ -54,7 +56,7 @@ func blackholeGitServer(t *testing.T) string {
 // The assertion is deliberately about the deadline, not the error text: what
 // matters is that the call RETURNS.
 func TestDefaultRunNetworkGitIsBounded(t *testing.T) {
-	remote := blackholeGitServer(t)
+	remote := wedgedGit(t)
 
 	restore := networkGitTimeout
 	networkGitTimeout = 300 * time.Millisecond
@@ -78,7 +80,7 @@ func TestDefaultRunNetworkGitIsBounded(t *testing.T) {
 	case got := <-done:
 		elapsed := time.Since(start)
 		if got.err == nil {
-			t.Fatalf("cloning a blackholed remote succeeded after %s, want a timeout error", elapsed)
+			t.Fatalf("cloning a wedged remote succeeded after %s, want a timeout error", elapsed)
 		}
 		if !errors.Is(got.err, errNetworkGitTimeout) {
 			t.Fatalf("err = %v, want it to wrap errNetworkGitTimeout (elapsed %s)", got.err, elapsed)
@@ -105,26 +107,21 @@ func TestDefaultRunNetworkGitIsBounded(t *testing.T) {
 // deadline assertion while destroying the diagnosis of ordinary failures —
 // connection refused, no such repo, auth rejected. This pins that the new error
 // path is reached only when the deadline actually fires.
+//
+// The remote is a file:// URL for a path that does not exist, so real git fails
+// immediately with "does not appear to be a git repository" — a real failure
+// with no shim, no listener and no network, which is what keeps this control
+// honest.
 func TestDefaultRunNetworkGitRealFailuresAreNotTimeouts(t *testing.T) {
-	// Bind and immediately release, so the port is almost certainly closed:
-	// git fails fast with "connection refused" rather than hanging.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	addr := ln.Addr().String()
-	if err := ln.Close(); err != nil {
-		t.Fatalf("close listener: %v", err)
-	}
-	remote := fmt.Sprintf("http://%s/refused.git", addr)
+	remote := "file://" + filepath.Join(t.TempDir(), "nonexistent.git")
 
 	restore := networkGitTimeout
 	networkGitTimeout = 20 * time.Second
 	t.Cleanup(func() { networkGitTimeout = restore })
 
-	_, err = defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, t.TempDir()+"/dest")
+	_, err := defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, t.TempDir()+"/dest")
 	if err == nil {
-		t.Fatal("cloning a closed port succeeded, want a connection error")
+		t.Fatal("cloning a nonexistent repository succeeded, want a git failure")
 	}
 	if errors.Is(err, errNetworkGitTimeout) {
 		t.Fatalf("err = %v, want a real git failure rather than a timeout classification", err)

--- a/internal/packman/network_git_timeout_test.go
+++ b/internal/packman/network_git_timeout_test.go
@@ -67,8 +67,21 @@ func wedgedGit(t *testing.T) wedgedRemote {
 		PIDPath:       filepath.Join(dir, "child.pid"),
 		HeartbeatPath: filepath.Join(dir, "child.heartbeat"),
 	}
+	// The first heartbeat is written by the foreground shim, before the loop is
+	// backgrounded. Left to the child, it races the deadline: the tests shrink
+	// networkGitTimeout to a few hundred milliseconds, and on a loaded host a
+	// fork/exec can lose that race, so *correct* code would kill the group
+	// before any byte landed and the test would fail waiting for a file that is
+	// never coming. Writing it here removes the race without weakening the
+	// assertion — a shim whose child never starts exits immediately, which
+	// makes the clone succeed, which every caller already fails on.
+	//
+	// The 50ms cadence is the convention the other users of these helpers use
+	// (internal/orders, cmd/gc): it has to be well under the caller's stability
+	// window, or a live child idling between writes reads as a dead one.
 	script := "#!/bin/sh\n" +
-		"{ while : ; do echo . >> " + w.HeartbeatPath + " ; " + sleep + " 1 ; done ; } &\n" +
+		"echo . >> " + w.HeartbeatPath + "\n" +
+		"{ while : ; do echo . >> " + w.HeartbeatPath + " ; " + sleep + " 0.05 ; done ; } &\n" +
 		"echo $! > " + w.PIDPath + "\n" +
 		"wait\n"
 	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
@@ -79,6 +92,44 @@ func wedgedGit(t *testing.T) wedgedRemote {
 	// child running for the rest of the package.
 	t.Cleanup(func() { processgrouptest.KillFromPIDFile(t, w.PIDPath) })
 	return w
+}
+
+// TestDefaultRunNetworkGitErrorsCarryNoCredential pins that a credential
+// embedded in a source URL never reaches the error string.
+//
+// There are two independent routes for it to leak and both are live: git's argv
+// carries the remote verbatim, and git itself echoes the remote back in
+// transport failures. The callers' own wraps redact the URL they interpolate,
+// which is what makes this easy to miss — the outer label reads
+// "cloning ***@host/repo" while the inner string still holds the raw token.
+//
+// The shim stands in for git failing the way it does against a bad remote:
+// echoing the URL it was handed and exiting 128. That exercises the output
+// route, and passing the credentialed URL as an argument exercises the argv one.
+func TestDefaultRunNetworkGitErrorsCarryNoCredential(t *testing.T) {
+	const token = "s3cr3t-token-value"
+	remote := "https://gituser:" + token + "@packman.invalid/repo.git"
+
+	dir := t.TempDir()
+	// Echo the remote back the way git does, then fail as git does.
+	script := "#!/bin/sh\necho \"fatal: could not read from remote repository $*\" >&2\nexit 128\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing git shim: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	_, err := defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, filepath.Join(t.TempDir(), "dest"))
+	if err == nil {
+		t.Fatal("cloning from the failing shim succeeded, want an error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaks the credential: %v", err)
+	}
+	// The error still has to be usable: masking the token must not cost the
+	// operator the host and repo they need to act on.
+	if !strings.Contains(err.Error(), "packman.invalid/repo.git") {
+		t.Fatalf("err = %v, want the redacted remote to remain identifiable", err)
+	}
 }
 
 // TestDefaultRunNetworkGitIsBounded is the ga-r0epd regression test.
@@ -165,9 +216,17 @@ func TestDefaultRunNetworkGitRealFailuresAreNotTimeouts(t *testing.T) {
 	}
 	// Asserting only "some error" would let this pass vacuously on an image
 	// with no git at all — where the bounded test supplies its own shim and
-	// this one would go green having executed no git at all. Naming git's own
-	// diagnosis is what keeps the control honest.
-	if !strings.Contains(err.Error(), "does not appear to be a git repository") {
-		t.Fatalf("err = %v, want git's own no-such-repository diagnosis", err)
+	// this one would go green having executed no git. Exit 128 is what closes
+	// that hole: it proves a real git ran and exited on its own diagnosis. A
+	// missing git yields *exec.Error rather than *exec.ExitError, and a killed
+	// one exits -1, so neither can reach here.
+	//
+	// The exit code rather than git's message text, because that text is in
+	// git's translation catalogs and HermeticEnv passes LANG/LC_ALL through
+	// (it strips only git's own variables) — so asserting the English wording
+	// would fail loudly on a localized image for no good reason.
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 128 {
+		t.Fatalf("err = %v, want git's own failure as an *exec.ExitError with code 128", err)
 	}
 }

--- a/internal/packman/network_git_timeout_test.go
+++ b/internal/packman/network_git_timeout_test.go
@@ -1,0 +1,132 @@
+package packman
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// blackholeGitServer returns an http:// URL whose TCP listener accepts
+// connections and then never writes a byte. git connects, sends its request,
+// and waits forever — the same shape as a remote that is reachable but wedged,
+// which is what ga-r0epd is really about. Nothing leaves loopback.
+func blackholeGitServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open and answer nothing. Closing on
+			// listener shutdown is what releases git if the bound never fires.
+			go func() {
+				<-done
+				_ = conn.Close()
+			}()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		<-done
+	})
+	return fmt.Sprintf("http://%s/blackhole.git", ln.Addr().String())
+}
+
+// TestDefaultRunNetworkGitIsBounded is the ga-r0epd regression test.
+//
+// defaultRunNetworkGit runs inside WithRepoCacheWriteLock (EnsureRepoInCache),
+// so an unbounded network git does not merely hang its own caller — it holds
+// the machine-wide repo-cache lock for as long as the remote stays wedged, and
+// every other gc process on the host that touches pack state blocks behind it.
+// That is why `gc help` could hang forever and why `make test` and the pre-push
+// hook died on a Go test timeout instead of failing.
+//
+// The assertion is deliberately about the deadline, not the error text: what
+// matters is that the call RETURNS.
+func TestDefaultRunNetworkGitIsBounded(t *testing.T) {
+	remote := blackholeGitServer(t)
+
+	restore := networkGitTimeout
+	networkGitTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { networkGitTimeout = restore })
+	restoreWait := networkGitWaitDelay
+	networkGitWaitDelay = time.Second
+	t.Cleanup(func() { networkGitWaitDelay = restoreWait })
+
+	type result struct {
+		out string
+		err error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		out, err := defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, t.TempDir()+"/dest")
+		done <- result{out: out, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		elapsed := time.Since(start)
+		if got.err == nil {
+			t.Fatalf("cloning a blackholed remote succeeded after %s, want a timeout error", elapsed)
+		}
+		if !errors.Is(got.err, errNetworkGitTimeout) {
+			t.Fatalf("err = %v, want it to wrap errNetworkGitTimeout (elapsed %s)", got.err, elapsed)
+		}
+		// The message has to name the bound. An operator seeing this in a log
+		// needs to know a deadline fired rather than that the remote refused.
+		if !strings.Contains(got.err.Error(), networkGitTimeout.String()) {
+			t.Fatalf("err = %v, want the message to name the %s bound", got.err, networkGitTimeout)
+		}
+		// Returning eventually is not the same as respecting the deadline. The
+		// real bound is networkGitTimeout + networkGitWaitDelay (1.3s here);
+		// the slack is wide because this asserts "tracks the knobs", not
+		// scheduler precision.
+		if budget := 8 * time.Second; elapsed > budget {
+			t.Fatalf("returned after %s with a %s deadline and %s wait delay; the bound is not tracking its knobs", elapsed, networkGitTimeout, networkGitWaitDelay)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("defaultRunNetworkGit did not return: the network git call is unbounded (ga-r0epd)")
+	}
+}
+
+// TestDefaultRunNetworkGitRealFailuresAreNotTimeouts is the control for the
+// test above. A bound that reported every failure as a timeout would pass the
+// deadline assertion while destroying the diagnosis of ordinary failures —
+// connection refused, no such repo, auth rejected. This pins that the new error
+// path is reached only when the deadline actually fires.
+func TestDefaultRunNetworkGitRealFailuresAreNotTimeouts(t *testing.T) {
+	// Bind and immediately release, so the port is almost certainly closed:
+	// git fails fast with "connection refused" rather than hanging.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	remote := fmt.Sprintf("http://%s/refused.git", addr)
+
+	restore := networkGitTimeout
+	networkGitTimeout = 20 * time.Second
+	t.Cleanup(func() { networkGitTimeout = restore })
+
+	_, err = defaultRunNetworkGit("", remote, "", "clone", "--quiet", remote, t.TempDir()+"/dest")
+	if err == nil {
+		t.Fatal("cloning a closed port succeeded, want a connection error")
+	}
+	if errors.Is(err, errNetworkGitTimeout) {
+		t.Fatalf("err = %v, want a real git failure rather than a timeout classification", err)
+	}
+}

--- a/internal/packman/networkgit_group_unix.go
+++ b/internal/packman/networkgit_group_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package packman
+
+import (
+	"os/exec"
+
+	"github.com/gastownhall/gascity/internal/processgroup"
+)
+
+// startNetworkGitInOwnGroup makes cmd a process-group leader so the deadline can
+// reach git's helpers, which are the processes that actually hold the output
+// pipes and write into the repo cache.
+func startNetworkGitInOwnGroup(cmd *exec.Cmd) {
+	processgroup.StartCommandInNewGroup(cmd)
+}
+
+// terminateNetworkGitGroup signals git's whole process group, SIGTERM first so
+// git can remove its partial clone, then SIGKILL.
+func terminateNetworkGitGroup(cmd *exec.Cmd) error {
+	return processgroup.TerminateCommand(cmd, 0, networkGitTerminateGrace, processgroup.Options{})
+}

--- a/internal/packman/networkgit_group_unix.go
+++ b/internal/packman/networkgit_group_unix.go
@@ -8,15 +8,29 @@ import (
 	"github.com/gastownhall/gascity/internal/processgroup"
 )
 
-// startNetworkGitInOwnGroup makes cmd a process-group leader so the deadline can
-// reach git's helpers, which are the processes that actually hold the output
-// pipes and write into the repo cache.
-func startNetworkGitInOwnGroup(cmd *exec.Cmd) {
+// configureNetworkGitDeadline makes cmd a process-group leader and points its
+// cancel at the whole group, so the deadline reaches git's helpers — the
+// processes that hold the output pipes and write into the repo cache.
+//
+// SIGTERM goes first so git's own handler can remove the partial clone, then
+// SIGKILL once the grace expires. Debris left by a SIGKILL landing mid-removal
+// is not a leak: the next holder of the cache write lock RemoveAll's a checkout
+// carrying no completion marker.
+func configureNetworkGitDeadline(cmd *exec.Cmd) {
 	processgroup.StartCommandInNewGroup(cmd)
-}
-
-// terminateNetworkGitGroup signals git's whole process group, SIGTERM first so
-// git can remove its partial clone, then SIGKILL.
-func terminateNetworkGitGroup(cmd *exec.Cmd) error {
-	return processgroup.TerminateCommand(cmd, 0, networkGitTerminateGrace, processgroup.Options{})
+	cmd.Cancel = func() error {
+		// Pass the leader's pid as the known pgid rather than letting
+		// TerminateCommand look it up at cancel time. Setpgid(0,0) makes the
+		// group id equal the child pid, so this is the same number in the
+		// ordinary case — but a live Getpgid returns ESRCH once the leader has
+		// been reaped, and TerminateCommand would then return having signaled
+		// nothing, while surviving helpers keep the group alive. That is
+		// exactly the orphan-writer bug this file exists to fix, re-entering
+		// through a side door. A pid recorded up front still names the group.
+		knownPGID := 0
+		if cmd.Process != nil {
+			knownPGID = cmd.Process.Pid
+		}
+		return processgroup.TerminateCommand(cmd, knownPGID, networkGitTerminateGrace, processgroup.Options{})
+	}
 }

--- a/internal/packman/networkgit_group_windows.go
+++ b/internal/packman/networkgit_group_windows.go
@@ -4,16 +4,13 @@ package packman
 
 import "os/exec"
 
-// startNetworkGitInOwnGroup is a no-op on Windows, which has no process groups
-// in the POSIX sense. internal/processgroup is Unix-only for the same reason.
-func startNetworkGitInOwnGroup(*exec.Cmd) {}
-
-// terminateNetworkGitGroup kills git alone. Descendants are not reachable
-// without a job object, so on Windows the bound rests on WaitDelay closing the
-// pipes rather than on the writers being stopped.
-func terminateNetworkGitGroup(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
-		return nil
-	}
-	return cmd.Process.Kill()
-}
+// configureNetworkGitDeadline does nothing on Windows, which has no POSIX
+// process group — internal/processgroup has no Windows files at all.
+//
+// Leaving cmd.Cancel unset keeps exec's default, which kills git alone; the
+// bound then rests on WaitDelay closing the pipes rather than on the writers
+// being stopped. This is deliberately a no-op rather than a hand-rolled
+// cmd.Process.Kill, which would be byte-for-byte what exec already does and so
+// dead code claiming to be a fallback. Reaching descendants here needs a job
+// object in internal/processgroup, which is where that work belongs.
+func configureNetworkGitDeadline(*exec.Cmd) {}

--- a/internal/packman/networkgit_group_windows.go
+++ b/internal/packman/networkgit_group_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package packman
+
+import "os/exec"
+
+// startNetworkGitInOwnGroup is a no-op on Windows, which has no process groups
+// in the POSIX sense. internal/processgroup is Unix-only for the same reason.
+func startNetworkGitInOwnGroup(*exec.Cmd) {}
+
+// terminateNetworkGitGroup kills git alone. Descendants are not reachable
+// without a job object, so on Windows the bound rests on WaitDelay closing the
+// pipes rather than on the writers being stopped.
+func terminateNetworkGitGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/processgroup/processgrouptest/testproc.go
+++ b/internal/processgroup/processgrouptest/testproc.go
@@ -68,11 +68,21 @@ func WaitForFileSize(t *testing.T, path string) int64 {
 }
 
 // AssertFileSizeStable fails if path keeps growing during stableFor.
+//
+// stableFor must be a comfortable multiple of the writer's cadence. Too small a
+// multiple fails silently rather than loudly: a live writer descheduled for one
+// window looks exactly like a dead one, so the assertion passes and quietly
+// stops guarding whatever it was pointed at.
+//
+// The give-up deadline is derived from stableFor rather than fixed, because a
+// fixed one silently caps the usable window — with a 3s deadline, asking for 3s
+// of stability makes the pass check race the deadline check and a genuinely
+// dead writer fails.
 func AssertFileSizeStable(t *testing.T, path string, initialSize int64, stableFor time.Duration) {
 	t.Helper()
 	lastSize := initialSize
 	stableSince := time.Now()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(stableFor + 3*time.Second)
 	for {
 		time.Sleep(50 * time.Millisecond)
 		info, err := os.Stat(path)


### PR DESCRIPTION
## The failure

`gc help` could hang forever. `make test` and the pre-push hook died at the
`unit-cmd-gc` shard on a Go test timeout rather than failing with a diagnosis.
Everyone on the host was affected at once, which is the tell: this was never a
test bug.

`packman.defaultRunNetworkGit` ran `exec.Command` + `CombinedOutput()` with no
deadline, and `EnsureRepoInCache` calls it **while holding
`WithRepoCacheWriteLock`** — a machine-wide lock. A remote that accepts the
connection and then never answers therefore does not hang one caller; it holds
the lock forever and every other `gc` process on the machine that touches pack
state queues behind it.

Two independent things had to be true for this to bite, and both were:

1. the network git call was unbounded, and
2. five `cmd/gc` tests ran a real `gc init`, which clones `gascity-packs.git`.

This PR fixes both. Either alone leaves a hole: without (1) a wedged remote
still takes out anything that legitimately clones; without (2) the suite is
merely slow-and-bounded rather than hermetic.

## What this PR does not do

**It does not close ga-r0epd.** The guard test for the original symptom —
`gc help` blocking behind a held repo-cache lock — is still red, and correctly
so. This PR bounds the process that *holds* the lock. It does nothing for the
processes that *wait* on it: `internal/config/repo_cache_lock_unix.go:34` is a
plain blocking `syscall.Flock` with no `LOCK_NB` and no timeout, so a waiter is
still unbounded. Bounding the holder shrinks the window; only a try-lock closes
it. That is Phase 3 and is tracked on the bead.

## Commit 1 — bound the call

A 10-minute deadline on every network git invocation and a distinct
`errNetworkGitTimeout` sentinel.

## Commit 2 — take the network off the path

None of the five tests is about import installation: two assert doctor status
after init, one asserts events land in `events.jsonl`, two assert where
`city.toml` gets created. The clone was incidental cost — and it was the
dominant cost.

Measured with a `git` shim logging argv:

| | git invocations | network clones | wall clock |
| --- | --- | --- | --- |
| before | 12 | 1 | 81s |
| after | 0 | 0 | 2.5s |

Verified with a control, because "0 network calls" is indistinguishable from
"the shim never ran": removing the stub from one test brings all 12
invocations and the clone straight back.

`stubInitRemoteImports` is a named helper rather than five inline stubs, and
its doc says who must *not* use it — a test asserting on the install itself
would be asserting against a no-op.
`TestFinalizeInitReportsRemoteImportInstallFailure` still stubs
`ensureInitRemoteImportsInstalled` directly with the failure it means to
exercise, and remains the coverage for that path.

The four other `cmd/gc` test files that run a real `init` were checked and left
alone: they all call `configureIsolatedRuntimeEnv`, which sets
`GC_BOOTSTRAP=skip`, so no bootstrap packs and no remote imports. All seven of
those call sites finish in ≤2.1s against a cold per-test city root, which a
`gascity-packs` clone cannot do.

## Commit 3 — reproduce the wedge without a listener

The first reproduction was a loopback listener that accepts and never answers.
That is the more literal reproduction but not the more faithful one. What has
to be exercised is git's *shape*: it spawns `git-remote-http`, `index-pack` and
credential helpers that inherit the output pipes, so killing git alone leaves
`CombinedOutput` blocked on a pipe a child still holds. The replacement is a
`git` shim on PATH that backgrounds a child inheriting stdout and stderr, then
waits — that structure built on purpose rather than hoped for from a real git.
No port, no listener, no network, nothing to flake on a busy host.

It also adds no `net.Listen`, which is not incidental: the source-scope
stream-listener ratchet in `resourcecensus` takes **no** Medium exemption
(`validateBaseline` calls `census.Count`, not `census.SmallCount`), so a new
listener there can only be avoided, never owned.

(`exec.Command` resolves the binary against the parent process PATH rather than
`cmd.Env`, so `t.Setenv` intercepts even though the child gets a hermetic
environment. The shim resolves `sleep` to an absolute path for the same reason
— left bare it fails to start under the hermetic PATH and the shim exits
instantly, which looks exactly like a bound firing early.)

## Commit 4 — kill the descendants, not just git

Review caught that commits 1–3 made the call *return* on time without making
the work *stop*. `cmd.WaitDelay`'s contract is to close the parent's ends of
the I/O pipes and kill the command's own process; it does not signal
descendants. So git died and `git-remote-http` and `index-pack` lived on —
still writing into the cache directory whose write lock the call had just
released. The next process to take that lock can `RemoveAll` a tree a live
orphan is repopulating, which is the corruption the lock exists to prevent
arriving by a different door.

Measured on the commit-1 code: four `sleep 300` processes before the bounded
test, **six** after.

git now starts as its own process-group leader and `cmd.Cancel` terminates the
group — SIGTERM first, so git can remove its partial clone rather than leave
debris in the cache, then SIGKILL after `networkGitTerminateGrace`.
`internal/processgroup` already does exactly this; the Unix/Windows seam is two
small files because Windows has no POSIX process group and
`internal/processgroup` is Unix-only.

Killing the writers also makes the bound *tighter* than it was: the call now
returns as the deadline fires (0.33s in the test) instead of waiting out
`WaitDelay` on a pipe an orphan still held (1.3s). `WaitDelay` stays as the
backstop for a descendant that escapes the group, and its doc comment now says
what it actually does rather than claiming it kills the tree.

Same commit reorders the error path to classify auth failures **before**
checking the deadline. Commit 1 had it backwards, on the theory that a killed
git produces little output and `ClassifyAuthError` reads output. The reverse
order is safe in both directions and strictly better: `ClassifyAuthError` gates
on an `*exec.ExitError` with code 128 (`internal/gitcred/autherror.go:71-74`)
and a killed process exits -1, so a wedge can never be misread as an auth
failure no matter what partial output it left behind — while the old order
*would* report a real credential rejection landing in the last milliseconds
before the deadline as a wedge, suppressing the hint the user needs.

A `killedBySignal` predicate was tried first and rejected: git can exit
non-zero after catching SIGTERM, which would make a genuine timeout report as
an ordinary failure.

## Commit 5 — measure the leak as bytes, not as a poll loop

The descendant test first asserted the child's pid was gone, polling with
`time.Sleep`. The resource census rejected that: `fixed_sleep` is ratcheted,
its ledger invariant is that the totals cannot grow, and its owner note says
the remedy is to replace elapsed wall time with a lifecycle signal — so two new
sleep call sites are not something ownership can legalize.

Pid liveness was the wrong measurement anyway. A killed orphan is a zombie
until init reaps it, so `kill(pid, 0)` keeps succeeding for exactly as long as
it takes to be misleading — which is *why* the assertion needed a poll loop.

The shim's backgrounded child now appends to a heartbeat file, so its liveness
is observable as a file that grows, and the assertion states the harm directly:
not "did the call return" but "did the work stop".
`processgrouptest.WaitForFileSize` and `AssertFileSizeStable` already exist for
this shape and their sleeps are already in the baseline, so the new assertion
adds none. A `t.Cleanup` kills the child from its pidfile so a test failing
before the bound fires cannot leak it into the rest of the package.

Worth knowing for anyone else hitting this gate: `resourcecensus` enumerates via
`git ls-files` (`census.go:678`), so running it against new but **unstaged**
files reports a false green. Stage first, then check. That is how this drift
reached the pre-push hook instead of being caught locally.

## Mutation checks

Every mutant below was actually applied and run.

| mutant | result |
| --- | --- |
| revert to `exec.Command` (no context) | KILLED — hangs 15s+ |
| drop `cmd.WaitDelay` | KILLED — hangs 15s+ |
| delete the `ctx.Err()` branch | KILLED — wrong error class |
| remove the group start **and** `cmd.Cancel` (commit-1 behavior) | KILLED — "heartbeat file kept growing after timeout cleanup" |
| keep the group, but cancel only the leader | KILLED — same |

The last two were re-run after the commit-5 rewrite, against the new assertion.
Independently re-measured after the fix: four `sleep 300` processes before,
**four** after.

The bounded test's control uses a `file://` URL for a path that does not exist,
so it runs against real git with no shim, and pins that ordinary failures are
still diagnosed as themselves. It asserts git's own "does not appear to be a
git repository" text rather than merely "some error" — the weaker assertion
would pass vacuously on an image with no git at all, where the bounded test
supplies its own shim and the control would go green having executed no git.

For the same reason `wedgedGit` now *fails* rather than skips when there is no
`sleep` binary on a non-Windows host. Skipping would delete exactly the
coverage the file exists for, silently.

## Why init needs the network at all — filed, not fixed here

Instrumenting the bundled-source gate during init shows the actual mechanism:

```
source=".../gascity-packs/tree/main/gascity"
  isSource=true  pinned="sha:3b3b89f2..."  bundled=true   -> synthetic, no network
source=".../gascity-packs/tree/main/gascity/roles"
  isSource=false pinned="sha:f895c0ff..."  bundled=false  -> REAL CLONE
```

The nested source `gascity/roles` is not recognized as bundled, so it misses
the synthetic cache whose stated purpose is serving that content when the
network is unavailable. `gc init` therefore cannot work offline for that city
shape, and the bytes it goes to the network for are already embedded in the
binary. That half is confirmed and active.

A second problem in the same trace is **latent, not active**:
`BundledSourcePinnedVersion` falls through to `BundledPackImportVersion` and
returns a `gascity.git` commit for a `gascity-packs` source — different
repositories. Today that value is discarded on the non-bundled path (the
import's own declared version drives the checkout), so no city gets a wrong
tree. But the function answers confidently for a source it does not recognize,
which is the wrong shape for a fallthrough; it should error instead.

Both are filed as **ga-73eoo** (P1) with the evidence above. Fixing them would
remove the clone for real users too, not just under test, but it changes pack
resolution semantics and deserves its own review.

## Verification

- `go test ./internal/packman/ ./internal/processgroup/...` — ok
- `go test ./internal/testpolicy/resourcecensus/` — ok **with the new files
  staged**; the reproduction adds neither a listener nor a fixed sleep, so
  neither ratchet moves
- `go test ./cmd/gc/` — ok, 1175s, exit 0 (full package, no regressions)
- `go vet ./cmd/gc/ ./internal/packman/` — clean
- `gofmt -l` — clean
- committed and pushed with the git hooks **enabled**, which is the behavior
  this PR restores. The pre-push hook is what caught the `fixed_sleep` drift
  fixed in commit 5 — it rejected the push, and this is the state after the
  full `test-fast-parallel` run passes.

Refs: ga-r0epd (does not close), ga-73eoo, ga-vgdi3
