### PR TITLE
test: close two local-only test gaps (docsync scratch roots, label-order cache path)

### DIFF
--- a/internal/beads/caching_store_setequal_internal_test.go
+++ b/internal/beads/caching_store_setequal_internal_test.go
@@ -1,6 +1,9 @@
 package beads
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // Reordered label/needs/dependency sets must NOT read as a change: the Dolt gcg
 // rig store does not guarantee a stable element order across scans, so an
@@ -46,6 +49,26 @@ func TestBeadChangedIgnoresSetOrder(t *testing.T) {
 	}
 	if !depsChanged(base.Dependencies, depChanged.Dependencies) {
 		t.Error("depsChanged = false when a dependency target changed; want true")
+	}
+}
+
+func TestCacheEventConflictsCurrentIgnoresLabelOrder(t *testing.T) {
+	current := Bead{
+		ID:     "gcg-wisp-x",
+		Title:  "t",
+		Status: "open",
+		Type:   "task",
+		Labels: []string{"a", "b", "c"},
+	}
+	patch := current
+	patch.Labels = []string{"c", "a", "b"}
+
+	fields := map[string]json.RawMessage{
+		"labels": json.RawMessage(`["c","a","b"]`),
+	}
+
+	if cacheEventConflictsCurrent(current, patch, fields) {
+		t.Fatal("cacheEventConflictsCurrent = true for a pure label reorder; want false")
 	}
 }
 

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -41,6 +41,21 @@ var docTreeDirs = []string{"contrib", "docs", "engdocs", "release-gates", "specs
 // gitignored scratch space for local work).
 var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "scripts", "test", "tmp", "worktrees"}
 
+// beadScratchPrefixes are the bead-id prefixes agents name their top-level
+// scratch directories after. An explicit list, not a shape match: a doc tree
+// may legitimately be hyphenated (release-gates), and silently exempting one
+// would defeat the coverage this file exists to enforce.
+var beadScratchPrefixes = []string{"ga-", "gcg-", "mc-"}
+
+func isBeadScratchRoot(name string) bool {
+	for _, p := range beadScratchPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // isNestedWorktreeRoot reports whether path is the root of a linked git
 // worktree checked out inside this tree. Linked worktrees have a .git FILE
 // (a "gitdir: ..." pointer) rather than a .git directory, so this catches
@@ -819,7 +834,7 @@ func TestDocDirCoverage(t *testing.T) {
 			continue
 		}
 		name := e.Name()
-		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "ga-") || name == "vendor" || name == "node_modules" {
+		if strings.HasPrefix(name, ".") || isBeadScratchRoot(name) || name == "vendor" || name == "node_modules" {
 			continue
 		}
 		if known[name] {


### PR DESCRIPTION
Two small test-only changes that were sitting in a local working tree and are not upstream.

**`test/docsync`: skip bead-named scratch roots.** `TestDocDirCoverage` walks
top-level directories and fails on any it does not recognise. Agents routinely
leave bead-id-named scratch directories (`ga-…`, `gcg-…`, `mc-…`) at the repo
root, which turns a clean local checkout red for a reason that has nothing to do
with docs. The exemption is an explicit prefix list rather than a shape match on
purpose: a doc tree may legitimately be hyphenated (`release-gates`), and a
shape matcher would silently exempt it from the coverage this file exists to
enforce.

**`internal/beads`: pin the label-order path of `cacheEventConflictsCurrent`.**
The set-compare fix for labels is already on `main` (`caching_store_events.go`
uses `stringSetEqual`), but nothing fails if the comparison goes back to being
order-sensitive. A pure reorder must not read as a conflict — when it does, the
cache reconciler re-absorbs every bead whose labels came back in a different
order.

Verified: `go test ./internal/beads/ -run TestCacheEventConflictsCurrentIgnoresLabelOrder`
and the full `make test-fast-parallel` fast suite (via the pre-push hook) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)