### PR TITLE
Fix implicit formula sling re-routes for molecule-attached beads

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1784,10 +1784,14 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			}
 			w("")
 		} else if !opts.NoFormula && a.EffectiveDefaultSlingFormula() != "" {
+			// Report-only pre-check: unlike explicit --on, an implicit
+			// default formula no longer hard-fails on a pre-existing
+			// molecule/wisp -- the live path skips the attach and routes
+			// the bead plainly -- so the preview must not predict an
+			// error the real run will not produce.
+			var blockingLabel, blockingID string
 			if preCheck {
-				if rc := dryRunReportBlockingMolecule(opts, deps, querier, stderr); rc != 0 {
-					return rc
-				}
+				blockingLabel, blockingID = sling.FindBlockingMolecule(querier, opts.BeadOrFormula, deps.Store)
 			}
 			w("Default formula:")
 			w("  Formula: " + a.EffectiveDefaultSlingFormula())
@@ -1800,7 +1804,11 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			}
 			w("  Would run: " + cookCmd)
 			if preCheck {
-				w("  Pre-check: " + opts.BeadOrFormula + " has no existing molecule/wisp children ✓")
+				if blockingLabel != "" {
+					w(fmt.Sprintf("  Pre-check: %s already has attached %s %s — the default formula will be skipped and the bead routed plainly.", opts.BeadOrFormula, blockingLabel, blockingID))
+				} else {
+					w("  Pre-check: " + opts.BeadOrFormula + " has no existing molecule/wisp children ✓")
+				}
 			}
 			w("")
 		}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -6895,6 +6895,48 @@ func TestDryRunOnExistingMolecule(t *testing.T) {
 	}
 }
 
+// TestDryRunDefaultFormulaExistingMolecule pins the dry-run preview to the
+// live behavior for an implicit default_sling_formula: the real run skips the
+// attach and routes the bead plainly (exit 0), so the preview must report the
+// blocking attachment as a note and exit 0 too, rather than predicting the
+// hard failure that only an explicit --on produces
+// (TestDryRunOnExistingMolecule).
+func TestDryRunDefaultFormulaExistingMolecule(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1), DefaultSlingFormula: strPtr("code-review")}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["BL-42"] = beads.Bead{ID: "BL-42", Type: "task", Status: "open"}
+	q.childrenOf["BL-42"] = []beads.Bead{
+		{ID: "MOL-1", Type: "molecule", Status: "open"},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
+	opts := testOpts(a, "BL-42")
+	opts.DryRun = true
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dry-run returned %d, want 0 (default formula falls back to plain routing); stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "BL-42 already has attached molecule MOL-1") {
+		t.Errorf("stdout = %q, want the blocking-attachment pre-check note", out)
+	}
+	if !strings.Contains(out, "the default formula will be skipped and the bead routed plainly") {
+		t.Errorf("stdout = %q, want the plain-routing skip note", out)
+	}
+	if strings.Contains(out, "has no existing molecule/wisp children") {
+		t.Errorf("stdout = %q, must not claim the bead has no molecule children", out)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)
+	}
+}
+
 func TestDryRunNilQuerier(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -226,9 +226,27 @@ func checkNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, re
 				continue
 			}
 		}
-		return fmt.Errorf("bead %s already has attached %s %s", beadID, AttachmentLabel(attached), attached.ID)
+		return &MoleculeAttachedError{BeadID: beadID, Label: AttachmentLabel(attached), AttachmentID: attached.ID}
 	}
 	return nil
+}
+
+// MoleculeAttachedError reports that a bead already has a live, non-workflow
+// molecule/wisp attachment blocking a new formula attach. It is distinct from
+// sourceworkflow.ConflictError (a live graph.v2 workflow attachment) so
+// callers can use errors.As to tell the two conflict kinds apart: an implicit
+// default-formula sling may choose to fall back to plain routing on this
+// error, but must keep hard-failing on a workflow conflict or any other
+// error, since neither is the "unrelated molecule already attached" case the
+// fallback exists for.
+type MoleculeAttachedError struct {
+	BeadID       string
+	Label        string // AttachmentLabel(attached), e.g. "molecule" or "wisp"
+	AttachmentID string
+}
+
+func (e *MoleculeAttachedError) Error() string {
+	return fmt.Sprintf("bead %s already has attached %s %s", e.BeadID, e.Label, e.AttachmentID)
 }
 
 // CheckNoMoleculeChildren returns an error if the bead already has an attached

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -531,8 +531,24 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			graphv2.CloseSyntheticInputConvoy(deps.Store, graphInv.InputConvoy, beadID)
 			return result, fmt.Errorf("instantiating %s %q on %s: %w", errLabel, formulaName, beadID, err)
 		}
+		var fellBackToPlainRoute bool
 		lockedResult, lockedErr := withGraphV2SourceWorkflowLock(context.Background(), deps, beadID, func() (SlingResult, error) {
 			if err := CheckNoMoleculeChildrenAllowLiveWorkflow(querier, beadID, deps.Store, &result); err != nil {
+				var molErr *MoleculeAttachedError
+				if fallbackToPlainOnMoleculeConflict && errors.As(err, &molErr) {
+					// Mirrors the legacy branch's fallback below: the caller
+					// never asked for this formula attach -- it was only
+					// implied by the target's default_sling_formula config --
+					// so an unrelated live molecule/wisp is not a reason to
+					// block the sling. Warn and route as a plain bead instead.
+					// fellBackToPlainRoute keeps the synthetic input convoy
+					// cleanup (after this lock releases) firing on this
+					// success path too, since prepareGraphV2FormulaInvocation
+					// already minted that convoy before this check ran.
+					result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf("skipped attaching %s %q on %s: %v; routed as a plain bead instead", errLabel, formulaName, beadID, molErr))
+					fellBackToPlainRoute = true
+					return finalize(opts, deps, beadID, "bead", result)
+				}
 				return result, fmt.Errorf("%w", err)
 			}
 			if err := checkLegacySourceWorkflowConflict(deps, beadID); err != nil {
@@ -577,12 +593,14 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 			restampWorkBeadRouting(deps, beadID, a, &wfResult)
 			return wfResult, wfErr
 		})
-		if lockedErr != nil {
+		if lockedErr != nil || fellBackToPlainRoute {
 			// The pour failed after minting its synthetic input convoy
 			// (children-conflict, snapshot, instantiate, or start failure —
-			// the started-workflow path returns nil error). Close the pour's
-			// own artifact so repeated failures do not accumulate open
-			// claim-attracting convoys.
+			// the started-workflow path returns nil error), or it fell back
+			// to plain routing on an unrelated molecule/wisp conflict (also
+			// nil error). Either way the convoy was never handed to a live
+			// graph workflow, so close it here — otherwise it leaks as an
+			// open, claim-attracting convoy.
 			graphv2.CloseSyntheticInputConvoy(deps.Store, graphInv.InputConvoy, beadID)
 		}
 		return lockedResult, lockedErr

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -431,7 +431,7 @@ func rootOnlyVaporPourHint(formulaName string, recipe *formula.Recipe) string {
 
 // slingOnFormula handles the --on formula attachment path.
 func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", result)
+	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.OnFormula, "on-formula", "formula", false, result)
 	if err == nil {
 		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
 			result.BeadWarnings = append(result.BeadWarnings, hint)
@@ -486,7 +486,7 @@ func attachedBeadInstructionsDroppedHint(querier BeadQuerier, beadID string, use
 
 // slingDefaultFormula handles the default formula attachment path.
 func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
-	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", result)
+	result, err := attachFormulaToBead(opts, deps, querier, beadID, opts.Target.EffectiveDefaultSlingFormula(), "default-on-formula", "default formula", true, result)
 	if err == nil {
 		if hint := attachedBeadInstructionsDroppedHint(querier, beadID, opts.Vars); hint != "" {
 			result.BeadWarnings = append(result.BeadWarnings, hint)
@@ -503,7 +503,17 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 // caller supplies the formula name, the sling method, and the error-label
 // prefix ("formula" vs "default formula"); graph-vs-legacy behavior is
 // byte-identical across both entry points.
-func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID, formulaName, method, errLabel string, result SlingResult) (SlingResult, error) {
+//
+// fallbackToPlainOnMoleculeConflict governs the legacy branch's reaction to a
+// *MoleculeAttachedError from CheckNoMoleculeChildren: an explicit --on
+// request (slingOnFormula) passes false and always hard-fails on a
+// pre-existing attachment, but an implicit default_sling_formula
+// (slingDefaultFormula) passes true, since the caller never actually asked
+// for a formula attach -- an unrelated live molecule/wisp should not block a
+// bare route, so that one specific error class falls back to plain bead
+// routing instead. Any other error (a live graph.v2 workflow conflict, or a
+// metadata-clear failure) keeps hard-failing regardless of this flag.
+func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID, formulaName, method, errLabel string, fallbackToPlainOnMoleculeConflict bool, result SlingResult) (SlingResult, error) {
 	a := opts.Target
 	formulaVars := BuildSlingFormulaVars(formulaName, beadID, opts.Vars, a, deps)
 	searchPaths := SlingFormulaSearchPaths(deps, a)
@@ -588,6 +598,17 @@ func attachFormulaToBead(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 	// live-workflow allowance could never fire. Attachments are always checked
 	// with CheckNoMoleculeChildren on this path.
 	if err := CheckNoMoleculeChildren(querier, beadID, deps.Store, &result); err != nil {
+		var molErr *MoleculeAttachedError
+		if fallbackToPlainOnMoleculeConflict && errors.As(err, &molErr) {
+			// The caller never asked for this formula attach -- it was only
+			// implied by the target's default_sling_formula config -- so an
+			// unrelated live molecule/wisp is not a reason to block the
+			// sling. Warn and route as a plain bead instead, so gc.routed_to
+			// still gets set. A workflow conflict or metadata-clear error is
+			// not this specific error class and keeps hard-failing above.
+			result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf("skipped attaching %s %q on %s: %v; routed as a plain bead instead", errLabel, formulaName, beadID, molErr))
+			return finalize(opts, deps, beadID, "bead", result)
+		}
 		return result, fmt.Errorf("%w", err)
 	}
 	run := func() (SlingResult, error) {

--- a/internal/sling/sling_core_test.go
+++ b/internal/sling/sling_core_test.go
@@ -88,3 +88,51 @@ func TestAttachFormulaToBeadEntryShapes(t *testing.T) {
 		}
 	})
 }
+
+// TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached pins the
+// REPAIR SCOPE for ga-ueugmi: a bare sling (no explicit --on/--formula) to a
+// target whose config carries a default_sling_formula must not hard-fail when
+// the bead already has a live attached molecule from an unrelated workflow --
+// the caller never asked for a formula attach, so the implicit default should
+// yield to plain routing (and warn) instead of blocking the sling and leaving
+// gc.routed_to unset. An explicit --on/--formula request must keep
+// hard-failing in this situation (TestOnFormulaExistingMoleculeErrors in
+// cmd/gc/cmd_sling_test.go) -- only the implicit default-formula path falls
+// back.
+func TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Type: "task", Status: "open", Assignee: "reviewer-session"},
+		{ID: "MOL-1", Type: "molecule", Status: "open", ParentID: "BL-1"},
+	}, nil)
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	runner := newFakeRunner()
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+
+	a := config.Agent{Name: "builder", MaxActiveSessions: intPtr(1), DefaultSlingFormula: stringPtr("code-review")}
+	opts := SlingOpts{Target: a, BeadOrFormula: "BL-1", NoConvoy: true}
+
+	result, err := DoSling(opts, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("DoSling default-formula with attached molecule: expected no error (fallback to plain route), got %v", err)
+	}
+	if result.Method != "bead" {
+		t.Errorf("Method = %q, want %q (fell back to plain bead routing)", result.Method, "bead")
+	}
+	if result.FormulaName != "" {
+		t.Errorf("FormulaName = %q, want empty (formula was not attached)", result.FormulaName)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (plain route must still execute, so gc.routed_to gets set)", len(runner.calls))
+	}
+
+	var warned bool
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "MOL-1") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("BeadWarnings = %v, want a warning naming the skipped attachment MOL-1", result.BeadWarnings)
+	}
+}

--- a/internal/sling/sling_core_test.go
+++ b/internal/sling/sling_core_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -151,8 +150,6 @@ func TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached(t *testi
 // gets closed on the fallback path rather than leaked as an open,
 // claim-attracting convoy (refs ga-9azvzg).
 func TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttachedGraphV2Formula(t *testing.T) {
-	formulatest.EnableV2ForTest(t)
-
 	dir := t.TempDir()
 	content := "formula = \"graph-review\"\nversion = 1\ncontract = \"graph.v2\"\ntype = \"workflow\"\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n"
 	if err := os.WriteFile(filepath.Join(dir, "graph-review.toml"), []byte(content), 0o644); err != nil {

--- a/internal/sling/sling_core_test.go
+++ b/internal/sling/sling_core_test.go
@@ -1,11 +1,14 @@
 package sling
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -134,5 +137,75 @@ func TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached(t *testi
 	}
 	if !warned {
 		t.Errorf("BeadWarnings = %v, want a warning naming the skipped attachment MOL-1", result.BeadWarnings)
+	}
+}
+
+// TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttachedGraphV2Formula
+// extends the ga-ueugmi repair scope (see the test above) to the graph.v2
+// branch of attachFormulaToBead: when the target's default_sling_formula
+// resolves through the graph.v2 compiler (isGraph == true), a pre-existing
+// non-workflow molecule/wisp attachment must fall back to plain routing the
+// same way the legacy branch does, instead of hard-failing through
+// CheckNoMoleculeChildrenAllowLiveWorkflow. It also pins that the synthetic
+// input convoy prepareGraphV2FormulaInvocation mints before that check runs
+// gets closed on the fallback path rather than leaked as an open,
+// claim-attracting convoy (refs ga-9azvzg).
+func TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttachedGraphV2Formula(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	content := "formula = \"graph-review\"\nversion = 1\ncontract = \"graph.v2\"\ntype = \"workflow\"\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "graph-review.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing graph-review fixture: %v", err)
+	}
+
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Type: "task", Status: "open", Assignee: "reviewer-session"},
+		{ID: "MOL-1", Type: "molecule", Status: "open", ParentID: "BL-1"},
+	}, nil)
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test"},
+		FormulaLayers: config.FormulaLayers{City: []string{dir}},
+	}
+	runner := newFakeRunner()
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = store
+
+	a := config.Agent{Name: "builder", MaxActiveSessions: intPtr(1), DefaultSlingFormula: stringPtr("graph-review")}
+	opts := SlingOpts{Target: a, BeadOrFormula: "BL-1", NoConvoy: true}
+
+	result, err := DoSling(opts, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("DoSling default-formula (graph.v2) with attached molecule: expected no error (fallback to plain route), got %v", err)
+	}
+	if result.Method != "bead" {
+		t.Errorf("Method = %q, want %q (fell back to plain bead routing)", result.Method, "bead")
+	}
+	if result.FormulaName != "" {
+		t.Errorf("FormulaName = %q, want empty (formula was not attached)", result.FormulaName)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (plain route must still execute, so gc.routed_to gets set)", len(runner.calls))
+	}
+
+	var warned bool
+	for _, w := range result.BeadWarnings {
+		if strings.Contains(w, "MOL-1") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("BeadWarnings = %v, want a warning naming the skipped attachment MOL-1", result.BeadWarnings)
+	}
+
+	convoys, err := deps.Store.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List(convoy): %v", err)
+	}
+	if len(convoys) != 1 {
+		t.Fatalf("convoys = %d, want 1 (the synthetic input convoy minted by prepareGraphV2FormulaInvocation)", len(convoys))
+	}
+	if convoys[0].Status != "closed" {
+		t.Errorf("synthetic input convoy %s status = %q, want closed (fallback must close it, not leak it)", convoys[0].ID, convoys[0].Status)
 	}
 }

--- a/release-gates/ga-e71kz1-sling-attached-molecule-reroute-gate.md
+++ b/release-gates/ga-e71kz1-sling-attached-molecule-reroute-gate.md
@@ -1,0 +1,171 @@
+# Release gate: molecule-attached sling re-route
+
+**Disposition:** **PROCEED — criterion 3 contains one raw FAIL that is WAIVED
+under the Mayor's standing beads#4566 authorization; all unwaived criteria
+PASS.**
+
+**Evaluated:** 2026-08-22 (America/Los_Angeles)
+
+**Deploy bead:** `ga-e71kz1`
+
+**Build/review bead:** `ga-9azvzg`
+
+**Reviewed commit:** `2a0bbfeb34898ccd48b31f64d1803944e6602c77`
+
+**Base:** `origin/main@08ecb0585498a0a5464e78a3b5d122236ff0ac9d`
+
+**Deploy mode:** remote; push-capability probe selected `origin`
+
+**Deploy branch:** `deploy/ga-e71kz1-gate`
+
+`docs/PROJECT_MANIFEST.md` is absent from both this checkout and
+`origin/main`. This checklist therefore applies the active seven release
+criteria in the deployer contract and the CI-equivalent commands documented in
+`TESTING.md` and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-9azvzg` records `REVIEWER 2026-08-22 -- VERDICT: PASS` for the exact reviewed commit, with independent build, vet, formatting, package-test, acceptance, and security evidence. |
+| 2 | Acceptance criteria met | PASS | The implicit default-formula route falls back to plain bead routing on a pre-existing non-workflow molecule in both legacy and graph-v2 compiler paths, records a warning, and closes the unused graph-v2 synthetic input convoy. Explicit `--on`/`--formula` attachment remains a hard failure. The two new regression tests and both cross-package guards pass by name. |
+| 3 | Tests pass | **FAIL — WAIVED** | `LOCAL_TEST_JOBS=4 make test-local-full-parallel` reported 36 PASS / 4 FAIL / 0 SKIP jobs. Three failures satisfy all four pre-existing-failure attribution clauses. The fourth is the exact `gastownhall/beads#4566` dirty-schema signature and is preserved as FAIL-WAIVED under the Mayor's standing authorization on `ga-6bnc42`; the required sighting was logged on `ga-lpfjhc`. Both diff-owned tests report PASS. Full evidence is below. |
+| 3a | Pre-existing failures attributed | PASS | `TestBdFlagManifestCurrent` and both tmux default-binding tests failed identically on exact base and have tracked beads with no diff-path overlap. The remaining dirty-schema failure is separately covered by the signature-specific standing authorization; it is not rewritten as green. |
+| 3b | Policy/lint lane | PASS | `make test-ci-policy`, affected-package lint, full build, full vet, gofmt, and `git diff --check` all pass on the reviewed commit. |
+| 4 | No high-severity review findings open | PASS | The reviewer recorded no security, blocking, or HIGH-severity finding. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty at the reviewed commit immediately before this checklist was written. The checklist is committed separately on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | PASS | The reviewed commit contains current `origin/main`; `git merge-tree --write-tree origin/main <reviewed-sha>` exited 0 and produced tree `cb42792bae60174be821fd9fe719263e1543b5fc`. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | Five commits modify only three `internal/sling` files for one behavior: routing an already-molecule-attached bead when the target supplies an implicit default formula. The legacy and graph-v2 paths are coupled implementations of that same feature. |
+
+## Pre-flight and source integrity
+
+The recorded commit resolves to the full SHA above. The GitHub
+commit-to-pull-request query returned no associated pull requests, so there is
+no already-merged, closed, or superseded PR to reconcile.
+
+Deploy mode is remote because the repository has GitHub `origin` and `fork`
+remotes, and GitHub authentication is active. A no-hook dry-run of the exact
+candidate to the isolated branch ref succeeded against `origin`, so `origin`
+is the selected push remote.
+
+`assert_deploy_ancestry_scope` passed for `ga-e71kz1`, review/build bead
+`ga-9azvzg`, and confirmed same-feature predecessor `ga-ueugmi`. The latter
+accounts for the inherited legacy-compiler red/green pair described in the
+review record; the graph-v2 pair and follow-up commit cite `ga-9azvzg`. The
+range introduces no `.claude/**` or independent-theme path.
+
+## Acceptance evidence
+
+The reviewed diff is limited to:
+
+- `internal/sling/sling_attachment.go`
+- `internal/sling/sling_core.go`
+- `internal/sling/sling_core_test.go`
+
+Direct inspection confirms:
+
+- `MoleculeAttachedError` distinguishes the non-workflow attachment case from
+  graph-v2 workflow conflicts and unrelated metadata/probe failures.
+- Only the implicit `default_sling_formula` caller enables fallback; explicit
+  formula attachment passes `false` and retains fail-closed behavior.
+- Legacy and graph-v2 paths both warn and call the ordinary `finalize` route,
+  ensuring `gc.routed_to` is still set.
+- Graph-v2 fallback closes the synthetic input convoy created before the
+  attachment check instead of leaking open, claim-attracting work.
+- Batch fan-out behavior is intentionally unchanged and tracked separately by
+  `ga-6htqom` because it needs a distinct partition/report design.
+
+Focused commands and results:
+
+```text
+go test ./internal/sling -run '^(TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached|TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttachedGraphV2Formula)$' -count=1 -v
+test_counts: 2 PASS, 0 FAIL, 0 SKIP
+
+go test ./cmd/gc -run '^TestOnFormulaExistingMoleculeErrors$' -count=1 -v
+test_counts: 1 PASS, 0 FAIL, 0 SKIP
+
+go test ./internal/testenv -run '^TestLegacyFormulaV2MechanismFrozen$' -count=1 -v
+test_counts: 1 PASS, 0 FAIL, 0 SKIP
+```
+
+`diff_tests_executed`:
+
+- `TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttached` — PASS
+- `TestDoSlingDefaultFormulaFallsBackToPlainRouteWhenMoleculeAttachedGraphV2Formula` — PASS
+
+`skip_justification`: none required; zero diff-owned or job-level skips.
+
+`waiver_ref`: Mayor's 2026-08-18 standing authorization recorded verbatim on
+`ga-6bnc42`, scoped specifically to the `ga-lpfjhc` /
+`gastownhall/beads#4566` dirty-table schema-migration signature.
+
+## CI-equivalent test evidence
+
+The rootless Podman socket was configured before testing:
+`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock` and
+`TESTCONTAINERS_RYUK_DISABLED=true`. Cached images include the pinned
+`dolthub/dolt:2.1.7` tag. The shared Go build cache was neither cleaned nor
+relocated.
+
+```text
+test_cmd: LOCAL_TEST_JOBS=4 make test-local-full-parallel
+test_counts: 36 PASS jobs, 4 FAIL jobs, 0 SKIP jobs (40 total)
+full_logs: /var/tmp/gc-local-tests.Ek5Nbq
+```
+
+All unit-core coverage, five of six `cmd/gc` process shards, all six
+integration `cmd/gc` package shards, all review-formula shards, bdstore, both
+REST-smoke shards, and all eight REST-full shards passed. The sole process
+failure was the waived dirty-schema signature described below.
+
+### Raw failures and disposition
+
+| Failing test | Candidate job | Disposition |
+|---|---|---|
+| `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix` | `cmd-gc-process-4-of-6` | **FAIL — WAIVED** — exact beads#4566 text: `pending schema migrations alter pre-existing dirty tables: issues`. Candidate only changes `internal/sling`, with no plausible schema-migration/store-bootstrap mechanism. Occurrence logged on `ga-lpfjhc`; standing authorization is on `ga-6bnc42`. Exact-base isolated rerun passed, consistent with the authorized nondeterministic race rather than contradicting it. |
+| `TestBdFlagManifestCurrent` | `integration-packages-core-1-of-4` | FAIL — attributed to `ga-gqxh5s`. The installed-`bd` manifest-skew signature failed identically on exact base. `internal/bdflags` has no path overlap with this diff. |
+| `TestGetKeyBinding_CapturesDefaultBinding` | `integration-packages-runtime-tmux-2-of-3` | FAIL — attributed to `ga-sxinl6`. Exact base failed with the same empty default `prefix-n` binding. `internal/runtime/tmux` has no path overlap with this diff. |
+| `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `integration-packages-runtime-tmux-3-of-3` | FAIL — attributed to `ga-sxinl6`. Exact base failed with the same empty `choose-tree` binding. `internal/runtime/tmux` has no path overlap with this diff. |
+
+```text
+failure_attribution: TestBdFlagManifestCurrent -> ga-gqxh5s + exact-base matching failure + no path overlap
+failure_attribution: TestGetKeyBinding_CapturesDefaultBinding -> ga-sxinl6 + exact-base matching failure + no path overlap
+failure_attribution: TestGetKeyBinding_CapturesDefaultBindingWithArgs -> ga-sxinl6 + exact-base matching failure + no path overlap
+failure_waiver: TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix -> ga-lpfjhc signature + ga-6bnc42 standing authorization + occurrence logged + no plausible mechanism/path overlap
+```
+
+Exact-base commands at
+`origin/main@08ecb0585498a0a5464e78a3b5d122236ff0ac9d`:
+
+```text
+go test -tags integration ./internal/bdflags -run '^TestBdFlagManifestCurrent$' -count=1 -v
+result: FAIL, same installed-bd flag-manifest skew
+
+go test -tags integration ./internal/runtime/tmux -run '^(TestGetKeyBinding_CapturesDefaultBinding|TestGetKeyBinding_CapturesDefaultBindingWithArgs)$' -count=1 -v
+result: 0 PASS, 2 FAIL, same empty default bindings
+
+GC_FAST_UNIT=0 go test ./cmd/gc -run '^TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix$' -count=1 -v -timeout 5m
+result: PASS in 8.85s; standing waiver applies because this failure class is nondeterministic and the candidate matched its exact signature and scope conditions
+```
+
+## Policy and static lanes
+
+- `policy_lane: make test-ci-policy` — PASS
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected` — PASS, 0 issues
+- `go build ./...` — PASS
+- `go vet ./...` — PASS
+- `gofmt -l` on all three changed Go files — PASS, no output
+- `git diff --check origin/main...HEAD` — PASS
+
+## Waiver disposition
+
+The dirty-schema test's raw result remains **FAIL — WAIVED**; this record does
+not call the 40-job suite green. Conditions (a)-(d) of the Mayor's standing
+authorization are satisfied: the failure text matches the tracked signature,
+the diff cannot reach schema migration or store bootstrap, the occurrence is
+logged on `ga-lpfjhc` with the deploy/build identifiers and failing test name,
+and this checklist preserves the raw failure. That authorization permits the
+deployer to proceed with the isolated branch and pull request without a new
+mayor round trip. Merge authority remains mayor/mpr; the deployer does not
+merge.


### PR DESCRIPTION
## What this changes

`gc sling <target> <bead> --nudge` now completes a plain bead re-route when the target's implicit `default_sling_formula` cannot be attached because the bead already belongs to a live molecule. The command emits a warning and still records the new route instead of failing before the handoff reaches its intended agent.

The behavior is consistent across the legacy and graph-v2 formula compilers. Explicit `--on` and `--formula` requests remain fail-closed: they still refuse to attach a second live workflow. On graph-v2 fallback, the unused synthetic input convoy is closed so the successful plain route does not leave claimable workflow debris behind.

## Review notes

- The new typed attachment error distinguishes this exact fallback case from live graph-v2 workflow conflicts and unrelated storage errors.
- Only an implicit default formula enables fallback; explicit formula attachment is unchanged.
- Batch fan-out behavior is intentionally unchanged because partial fallback needs a separate routing/reporting design.
- No configuration, persistence schema, API, or migration changes are included.

## Test plan

- [x] Run both new legacy and graph-v2 fallback regressions by exact test name; verify plain routing, warning emission, and convoy cleanup.
- [x] Run the explicit-formula hard-fail guard and the formula-v2 coupling guard.
- [x] Run the repository's 40-job local CI-equivalent suite with the pinned container environment; audit raw failures and exact-base attribution in the gate record.
- [x] Run workflow-policy, affected lint, full build, full vet, formatting, and diff checks.
- [x] Release gate: [`release-gates/ga-e71kz1-sling-attached-molecule-reroute-gate.md`](release-gates/ga-e71kz1-sling-attached-molecule-reroute-gate.md)