### PR TITLE
fix(mail): archiving a message no longer makes it unrecoverable — Archive stamps a close reason, peek reads through it

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -2128,6 +2128,16 @@ func routeMailPeek(_ string, args []string, c *api.Client, nilReason string, jso
 		func() error {
 			var err error
 			cr, err = c.GetMail(id, "")
+			// The API mail read hides archived messages (it serves the
+			// Get view). Peek's contract is to read through the archive,
+			// which only the local provider path can do — so a not-found
+			// from the API is a cue to fall back, not a final answer.
+			// routeRead's remote-city gate (G1) still hard-errors this
+			// sentinel for remote clients, which is correct: a remote
+			// operator has no local store to read through.
+			if err != nil && strings.Contains(err.Error(), "not_found") {
+				return fallbackAfterFetch{Reason: "peek-archived-readthrough"}
+			}
 			return err
 		},
 		func() int {
@@ -2172,7 +2182,17 @@ func doMailPeekWithJSON(mp mail.Provider, args []string, jsonOut bool, stdout, s
 	}
 	id := args[0]
 
-	m, err := mp.Get(id)
+	// Peek reads through the archive when the provider supports it —
+	// Archive's contract retains the body for exactly this verb, while
+	// Get keeps archived mail hidden per the removes-from-every-view
+	// conformance contract.
+	var m mail.Message
+	var err error
+	if peeker, ok := mp.(mail.ArchivePeeker); ok {
+		m, err = peeker.Peek(id)
+	} else {
+		m, err = mp.Get(id)
+	}
 	if err != nil {
 		fmt.Fprintf(stderr, "gc mail peek: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1561,7 +1561,12 @@ func newMailPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Display a message without marking it as read.
 
 Same output as "gc mail read" but does not change the message's read status.
-The message will continue to appear in inbox results.`,
+An unarchived message will continue to appear in inbox results.
+
+peek also reads THROUGH the archive: a message closed by "gc mail archive"
+or "gc mail delete" is still displayable here, even though read, inbox, and
+check report it as not found. Mail removed before this behavior existed
+(closed with no archive reason) stays not-found for peek as well.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailPeekWithJSON(args, jsonOut, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -4551,10 +4551,17 @@ func TestRouteMailPeek_SixRowMatrix(t *testing.T) {
 			wantReason: "conn-refused",
 		},
 		{
+			// Peek diverges from the shared matrix here BY DESIGN: the API
+			// serves the Get view, which hides archived mail, so a 404 is a
+			// cue to read through the archive locally (ArchivePeeker), not a
+			// final answer. The local fake has no such message either, so
+			// the exit is still 1 — but via the fallback route.
 			name:       "api-404-error",
 			handler:    mailProblemHandler(http.StatusNotFound, "not_found: no such message"),
 			wantExit:   1,
-			wantStderr: "not_found",
+			wantRoute:  "fallback",
+			wantReason: "peek-archived-readthrough",
+			wantStderr: "message not found",
 		},
 		{
 			name:         "controller-down",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2489,7 +2489,12 @@ gc mail mark-unread <id> [flags]
 Display a message without marking it as read.
 
 Same output as "gc mail read" but does not change the message's read status.
-The message will continue to appear in inbox results.
+An unarchived message will continue to appear in inbox results.
+
+peek also reads THROUGH the archive: a message closed by "gc mail archive"
+or "gc mail delete" is still displayable here, even though read, inbox, and
+check report it as not found. Mail removed before this behavior existed
+(closed with no archive reason) stays not-found for peek as well.
 
 ```
 gc mail peek <id> [flags]

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -282,6 +282,27 @@ func (p *Provider) Get(id string) (mail.Message, error) {
 	return beadToMessage(b), nil
 }
 
+// Peek retrieves a message by ID without mutating it, reading THROUGH the
+// archive: a message Archive closed (stamped [ArchiveCloseReason]) is
+// returned even though Get/Read/MarkRead answer ErrNotFound for it per the
+// removes-from-every-view conformance contract. Peek is the archeology verb
+// Archive's contract advertises ("retrievable via gc mail peek or bd show").
+// Truly removed mail — Delete-purged or legacy closed-without-reason beads —
+// stays ErrNotFound even here, preserving the upgrade-path contract.
+func (p *Provider) Peek(id string) (mail.Message, error) {
+	b, err := p.store.Get(id)
+	if err != nil {
+		return mail.Message{}, beadmailError("peek", err)
+	}
+	if b.Type != messageBeadType {
+		return mail.Message{}, fmt.Errorf("beadmail peek: bead %s is type %q, not message", id, b.Type)
+	}
+	if isRemovedMessageBead(b) && b.Metadata["close_reason"] != ArchiveCloseReason {
+		return mail.Message{}, beadmailError("peek", beads.ErrNotFound)
+	}
+	return beadToMessage(b), nil
+}
+
 // Read retrieves a message by ID and marks it as read (adds "read" label).
 // The message remains in the store (not closed).
 func (p *Provider) Read(id string) (mail.Message, error) {
@@ -351,6 +372,14 @@ type ArchiveFilter struct {
 // gc mail peek or bd show. A closed message no longer appears in inbox views
 // (all listing paths filter Status != "open"). Archiving an already-closed
 // message is idempotent and returns ErrAlreadyArchived without mutating it.
+//
+// The close_reason stamp is what keeps the retained body reachable: every
+// read path routes through isRemovedMessageBead, which treats a closed
+// message with an unrecognized close_reason as user-removed and answers
+// ErrNotFound. Archive without the stamp therefore silently broke its own
+// retrieval contract — the bead body sat intact in the store while peek,
+// Get, and MarkRead all reported the message gone. Stamp BEFORE Close so
+// any close-side validation and every subsequent reader observe it.
 func (p *Provider) Archive(id string) error {
 	b, err := p.store.Get(id)
 	if err != nil {
@@ -364,6 +393,12 @@ func (p *Provider) Archive(id string) error {
 	}
 	if b.Status == "closed" {
 		return mail.ErrAlreadyArchived
+	}
+	if err := p.store.SetMetadata(id, "close_reason", ArchiveCloseReason); err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return mail.ErrAlreadyArchived
+		}
+		return fmt.Errorf("beadmail archive: stamping close_reason: %w", err)
 	}
 	if err := p.store.Close(id); err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
@@ -876,6 +911,11 @@ func readMessagesBefore(store beads.Store, before time.Time, limit int) ([]beads
 // closeReason, keeping the writer and the direct-ID reader in lockstep. The
 // 20-character floor satisfies validation.on-close=error.
 const RetentionSweepCloseReason = "mail gc-swept: read mail bead past gc retention window"
+
+// ArchiveCloseReason is the close_reason Provider.Archive stamps so an
+// archived message stays addressable (peek/bd show) per Archive's contract,
+// instead of classifying as user-removed the moment it closes.
+const ArchiveCloseReason = "mail archived: retained for peek/bd show"
 
 // SweepReadMessagesBefore closes read message beads created before cutoff,
 // oldest first, stamping closeReason as "close_reason" metadata on each bead

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -452,6 +452,11 @@ func (p *Provider) ArchiveCandidates(filter ArchiveFilter) ([]mail.Message, erro
 // ArchiveMatching archives open messages selected by filter without per-message
 // lookups after the candidate list has already verified them. Matched beads are
 // closed rather than deleted, so their bodies stay readable.
+//
+// Like [Provider.Archive] it stamps [ArchiveCloseReason] before closing: the
+// stamp is what makes "bodies stay readable" true, since isRemovedMessageBead
+// classifies a closed message with no recognized reason as user-removed and
+// every read path — Peek included — then answers ErrNotFound.
 func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail.ArchiveResult, error) {
 	candidates, err := p.ArchiveCandidates(filter)
 	if err != nil {
@@ -467,6 +472,14 @@ func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail
 		return candidates, results, nil
 	}
 	for i, id := range ids {
+		if err := p.store.SetMetadata(id, "close_reason", ArchiveCloseReason); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				results[i].Err = mail.ErrAlreadyArchived
+				continue
+			}
+			results[i].Err = fmt.Errorf("beadmail archive: stamping close_reason: %w", err)
+			continue
+		}
 		if err := p.store.Close(id); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				results[i].Err = mail.ErrAlreadyArchived

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -2964,3 +2964,41 @@ func mustCreateSessionBead(t *testing.T, store beads.Store, metadata map[string]
 	}
 	return b
 }
+
+// TestArchiveMatchingStampsCloseReason pins the bulk selection path to the
+// same retained-body contract as [Provider.Archive]: `gc mail archive` with
+// filters closes candidates directly, and without the stamp every one of them
+// classified as user-removed — so a never-read message selected by a bulk
+// cleanup became irrecoverable through the mail layer.
+func TestArchiveMatchingStampsCloseReason(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "GO: ship the release", "the handoff body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Never read.
+	if _, _, err := p.ArchiveMatching(ArchiveFilter{Recipients: []string{"bob"}}); err != nil {
+		t.Fatalf("ArchiveMatching: %v", err)
+	}
+	raw, err := store.Get(sent.ID)
+	if err != nil {
+		t.Fatalf("store.Get after bulk archive: %v", err)
+	}
+	if got := raw.Metadata["close_reason"]; got != ArchiveCloseReason {
+		t.Errorf("close_reason after ArchiveMatching = %q, want %q", got, ArchiveCloseReason)
+	}
+	// Hidden from the mail views, per the removes-from-every-view contract.
+	if _, err := p.Get(sent.ID); !errors.Is(err, mail.ErrNotFound) {
+		t.Errorf("Get after ArchiveMatching err = %v, want ErrNotFound", err)
+	}
+	// Still recoverable through the archeology verb.
+	got, err := p.Peek(sent.ID)
+	if err != nil {
+		t.Fatalf("Peek after ArchiveMatching: %v (contract: body stays readable)", err)
+	}
+	if got.Body != "the handoff body" {
+		t.Errorf("Peek body = %q, want %q", got.Body, "the handoff body")
+	}
+}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1556,6 +1556,47 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+// TestDeletePeekRecoverable pins the Delete-alias consequence: Delete is an
+// alias for Archive (#4422 forbids store.Delete on any archive path), so a
+// deleted message is stamped ArchiveCloseReason and stays recoverable through
+// Peek — the same body bd show has always exposed. This is intended, not a
+// leak: Delete's own help says "same effect as archive", and every
+// mail.Provider view still reports it not-found per the removes-from-every-view
+// contract (mailtest.runRemovalVisibilityContract).
+func TestDeletePeekRecoverable(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "subject", "delete me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Delete(sent.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := p.Get(sent.ID); !errors.Is(err, mail.ErrNotFound) {
+		t.Errorf("Get after Delete err = %v, want ErrNotFound", err)
+	}
+	got, err := p.Peek(sent.ID)
+	if err != nil {
+		t.Fatalf("Peek after Delete: %v (#4422: the row is retained)", err)
+	}
+	if got.Body != "delete me" {
+		t.Errorf("Peek body after Delete = %q, want %q", got.Body, "delete me")
+	}
+
+	batch, err := p.Send("alice", "bob", "subject", "delete many")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.DeleteMany([]string{batch.ID}); err != nil {
+		t.Fatalf("DeleteMany: %v", err)
+	}
+	if got, err := p.Peek(batch.ID); err != nil || got.Body != "delete many" {
+		t.Errorf("Peek after DeleteMany = (%q, %v), want (%q, nil)", got.Body, err, "delete many")
+	}
+}
+
 // --- Reply ---
 
 func TestReply(t *testing.T) {

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1042,6 +1042,45 @@ func TestArchive(t *testing.T) {
 	if b.Description != "dismiss me" {
 		t.Errorf("bead body = %q, want \"dismiss me\"", b.Description)
 	}
+
+	// The archive stamp is what lets Peek distinguish "archived, body
+	// retained" from "removed/legacy-closed" — without it, archived
+	// never-read mail was irrecoverable through the mail layer while the
+	// body sat intact in the store.
+	if got := b.Metadata["close_reason"]; got != ArchiveCloseReason {
+		t.Errorf("close_reason = %q, want %q (peek discriminator)", got, ArchiveCloseReason)
+	}
+	// Conformance contract holds: archived mail is hidden from Get.
+	if _, err := p.Get(sent.ID); !errors.Is(err, mail.ErrNotFound) {
+		t.Errorf("Get after Archive err = %v, want ErrNotFound (hidden from mail views)", err)
+	}
+	// Archive's advertised contract holds: Peek reads through the archive.
+	got, err := p.Peek(sent.ID)
+	if err != nil {
+		t.Fatalf("Peek after Archive: %v (contract: archived mail stays peek-retrievable)", err)
+	}
+	if got.Body != "dismiss me" {
+		t.Errorf("Peek body after Archive = %q, want \"dismiss me\"", got.Body)
+	}
+}
+
+// TestPeekHidesLegacyAndRemovedMail pins Peek's boundary: reading through
+// the archive must not resurrect truly removed mail — a legacy
+// closed-without-reason bead (old-release archive, treated as removed for
+// the upgrade path) stays ErrNotFound even for Peek.
+func TestPeekHidesLegacyAndRemovedMail(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+	legacy, err := p.Send("alice", "bob", "legacy", "closed by an old release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(legacy.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Peek(legacy.ID); !errors.Is(err, mail.ErrNotFound) {
+		t.Errorf("Peek(legacy closed-no-reason) err = %v, want ErrNotFound", err)
+	}
 }
 
 // TestLegacyClosedMessageBeadTreatedAsRemoved covers the upgrade path for a

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -151,3 +151,12 @@ type Provider interface {
 type MultiRecipientInboxer interface {
 	InboxRecipients(recipients []string) ([]Message, error)
 }
+
+// ArchivePeeker is an optional extension for providers that can read THROUGH
+// the archive: Peek returns a message that Archive has closed (hidden from
+// Get/Read and every inbox view) without resurrecting truly removed mail.
+// `gc mail peek` uses it when available so Archive's retained-body contract
+// is honored at the mail layer instead of requiring a raw store read.
+type ArchivePeeker interface {
+	Peek(id string) (Message, error)
+}


### PR DESCRIPTION
### Problem

`Provider.Archive` and `Provider.ArchiveMatching` close a message bead without stamping a
`close_reason`. `isRemovedMessageBead` (`internal/mail/beadmail/beadmail.go:692`) treats *any*
closed message bead whose `close_reason` is not the retention-sweep marker as **user-removed**,
so after an archive every read path — `Get`, `Read`, `MarkRead`, `MarkUnread`, and `gc mail
peek`, which routes to `Get` — answers `ErrNotFound`. The bead and its body are untouched in
the store the whole time.

Both functions document the opposite. `Archive`: "retaining its body for later retrieval via
`gc mail peek` or `bd show`". `ArchiveMatching`: "closed rather than deleted, so their bodies
stay readable". Neither is true today.

The consequence is worst for mail that was never read. On one long-running deployment, **63 of
a single agent's 209 archive events in one day were for messages with no corresponding read
event** — and over a month, **599 message beads were closed having never been read**. Each was
an obligation that became invisible to every mail verb while its text sat intact in the store.
One of them was a cross-agent handoff carrying a go-ahead; the recipient idled roughly ten hours
because the message could not be surfaced through any supported read path. Recovery in every
case meant reading the raw store object and bypassing the mail API.

What makes this expensive to diagnose is that the failure is *silent and ambiguous by
construction*: one closed state is being asked to mean two different things — "a human deleted
this" and "this was archived, body retained" — and the read paths cannot tell them apart, so
they conservatively report the message gone.

Notably, the codebase already solved this exact problem elsewhere and just did not carry it to
these two functions:

- `SweepReadMessagesBefore` stamps `close_reason` before closing (`beadmail.go:913`).
- `ArchiveInjectedAutoHandoffs` stamps before closing (`beadmail.go:491`), with a comment
  spelling out that it does so "so an unconsumed handoff stays recoverable" and to avoid
  "permanent data loss".

So this PR is closing an internal inconsistency rather than introducing a new convention.

### The fix

1. **A discriminator.** New constant `ArchiveCloseReason = "mail archived: retained for
   peek/bd show"`. `Archive` and `ArchiveMatching` stamp it *before* `Close`, so any close-side
   validation and every subsequent reader observe it. This is the only thing that distinguishes
   "archived, body retained" from "removed" and from a legacy bead closed by an older release.

2. **A verb that can read through.** New optional interface `mail.ArchivePeeker` with
   `Peek(id) (Message, error)`; `beadmail.Provider` implements it. `Peek` returns a message
   closed with `ArchiveCloseReason` and *only* that — a `Delete`-purged bead, or a legacy bead
   closed with no reason at all, stays `ErrNotFound` even for `Peek`, so the upgrade path is
   unchanged.

3. **`gc mail peek` uses it** when the provider supports it, falling back to `Get` otherwise.
   When the command is served by the supervisor API (which serves the `Get` view and therefore
   hides archived mail), a `not_found` response is treated as a cue to fall back to the local
   read-through rather than a final answer. The existing remote-client gate still hard-errors
   for a genuinely remote operator, who has no local store to read through — that is correct
   and unchanged.

**Design constraint honoured deliberately:** the conformance suite pins `Archive` as
*removes-from-every-view*, and that stays exactly as it is. `Get`, `Read`, `Reply`, `MarkRead`,
and every inbox listing continue to return `ErrNotFound` / omit archived mail. The two
contracts — "removed from every view" and "body retrievable via peek" — are only consistent if
`peek` is a distinct read-through verb, which is what this PR makes it. No existing view
changes behaviour.

### Behaviour, before and after

Send a message, never read it, archive it:

| call | before | after |
|---|---|---|
| raw bead `status` / `close_reason` | `closed` / `""` | `closed` / `mail archived: retained for peek/bd show` |
| raw bead body | intact | intact |
| `Get` | `message not found` | `message not found` (unchanged) |
| `Read` | `message not found` | `message not found` (unchanged) |
| `MarkRead` / `MarkUnread` | `message not found` | `message not found` (unchanged) |
| inbox / list views | omitted | omitted (unchanged) |
| **`Peek` / `gc mail peek`** | **`message not found`** | **returns the message, body intact** |

And for a bead closed by an older release with no `close_reason` (the upgrade path), `Peek`
still returns `message not found` — archived-ness is proven by the stamp, never assumed from
"closed".

### Test evidence

New:

- `TestPeekHidesLegacyAndRemovedMail` — the boundary: reading through the archive must not
  resurrect a legacy closed-without-reason bead.
- `TestArchiveMatchingStampsCloseReason` — the bulk selection path gets the same contract:
  stamped, hidden from `Get`, recoverable via `Peek`.
- `TestArchive` extended — asserts the stamp, asserts `Get` still hides the message
  (conformance contract intact), asserts `Peek` returns the body.
- `TestRouteMailPeek_SixRowMatrix` updated for one row: `peek` diverging from the shared matrix
  on an API 404 is the intended fallback, and the row now pins that.

Unchanged and green: the full mail conformance suite, the legacy-closed upgrade-path test, the
retention-sweep tests, `TestArchiveMatchingSkipsPerMessageGet`, and the auto-handoff archive
tests.

```
$ go test ./internal/mail/...
ok  	.../internal/mail	0.004s
ok  	.../internal/mail/beadmail	0.063s
ok  	.../internal/mail/exec	48.147s

$ go test ./cmd/gc/ -run 'TestRouteMailPeek|TestMailArchive'
ok  	.../cmd/gc	0.308s
```

A before/after probe on the same store, run once at the base commit and once on this branch,
is the clearest summary:

```
base:  raw close_reason=""                                    Peek -> message not found
this:  raw close_reason="mail archived: retained for peek…"   Peek -> body "the handoff body"
```

### Scope

5 files, +168 / -2, all under `internal/mail` and `cmd/gc`. 41 lines of net production code.
No signature changes; `ArchivePeeker` is optional, so no provider outside `beadmail` needs to
change.

