### PR TITLE
fix(cmd/gc): stop unasked-for work from queueing on the repo-cache lock

### DIFF
--- a/cmd/gc/city_arg_resolve_test.go
+++ b/cmd/gc/city_arg_resolve_test.go
@@ -880,7 +880,7 @@ func TestResolveContextFromDirRefusesAmbientWalkUpInTestBinary(t *testing.T) {
 	}
 	t.Chdir(nested)
 
-	ctx, err := resolveContextFromDir()
+	ctx, err := resolveContextFromDir(contextResolutionMode{})
 	if err == nil {
 		t.Fatalf("resolveContextFromDir() = %+v, nil; want an error refusing the ambient walk-up to %q in a test binary", ctx, ambient)
 	}
@@ -909,7 +909,7 @@ func TestIsCityDiscoveryNotFoundRecognizesTestBinaryGuardRefusal(t *testing.T) {
 	}
 	t.Chdir(nested)
 
-	_, err := resolveContextFromDir()
+	_, err := resolveContextFromDir(contextResolutionMode{})
 	if err == nil {
 		t.Fatal("resolveContextFromDir() = nil error; want the test-binary ambient-walk refusal")
 	}

--- a/cmd/gc/city_context.go
+++ b/cmd/gc/city_context.go
@@ -68,11 +68,11 @@ func resolveCityPathFromCwd() (string, bool) {
 	return cityPath, true
 }
 
-func rigFromGCDirOrCwd(cityPath string) string {
+func rigFromGCDirOrCwd(cityPath string, mode contextResolutionMode) string {
 	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" {
-		if rigName := rigFromCwdDir(cityPath, gcDir); rigName != "" {
+		if rigName := rigFromCwdDir(cityPath, gcDir, mode); rigName != "" {
 			return rigName
 		}
 	}
-	return rigFromCwd(cityPath)
+	return rigFromCwd(cityPath, mode)
 }

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -81,11 +81,23 @@ func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (
 // briefly reflect stale builtin-pack content after an upgrade until a normal
 // gc command refreshes the generated packs.
 func loadCityConfigWithoutBuiltinPackRefreshFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (*config.City, error) {
-	cfg, prov, err := config.LoadWithIncludesOptions(fs, tomlPath, skipRevisionSnapshot)
+	return loadPrematerializedCityConfig(fs, tomlPath, skipRevisionSnapshot, resolveLoadCityConfigWarningWriter(warningWriter...))
+}
+
+func loadCityConfigWithoutBuiltinPackRefresh(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
+	return loadCityConfigWithoutBuiltinPackRefreshFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), warningWriter...)
+}
+
+// loadPrematerializedCityConfig is the shared body of the loaders that take
+// builtin packs as they already are on disk. It differs from loadCityConfigFS
+// only in skipping the refresh; opts is what separates a blocking load from an
+// advisory one.
+func loadPrematerializedCityConfig(fs fsys.FS, tomlPath string, opts config.LoadOptions, warnings io.Writer) (*config.City, error) {
+	cfg, prov, err := config.LoadWithIncludesOptions(fs, tomlPath, opts)
 	if err != nil {
 		return nil, err
 	}
-	emitLoadCityConfigWarnings(resolveLoadCityConfigWarningWriter(warningWriter...), prov)
+	emitLoadCityConfigWarnings(warnings, prov)
 	if err := validatePackRuntimeRegistrations(cfg); err != nil {
 		return nil, err
 	}
@@ -93,8 +105,30 @@ func loadCityConfigWithoutBuiltinPackRefreshFS(fs fsys.FS, tomlPath string, warn
 	return cfg, nil
 }
 
-func loadCityConfigWithoutBuiltinPackRefresh(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
-	return loadCityConfigWithoutBuiltinPackRefreshFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), warningWriter...)
+// advisoryLoad is the load option set for a config load nobody asked for.
+//
+// RepoCacheNonBlocking is the load-bearing half: the repo-cache lock is held
+// for the whole of a cache write, which includes its network clone, so a
+// blocking load turns one `gc import install` into a hang for every other gc
+// process on the machine. An advisory load reports config.ErrRepoCacheBusy
+// instead and its caller degrades to "no pack state right now".
+var advisoryLoad = config.LoadOptions{SkipRevisionSnapshot: true, RepoCacheNonBlocking: true}
+
+// loadCityConfigAdvisory loads city config for callers that would rather have
+// no answer than a slow one: eager pack-command discovery and shell
+// completion, both of which run on input the user has not submitted yet. It
+// takes builtin packs as they already are on disk like the completion loader
+// it replaces, and additionally never waits on the repo cache.
+//
+// Nothing an advisory load has to say belongs on the user's terminal — it is
+// reporting on a command they did not type — so both the provenance warnings
+// and the default logger's output are discarded here rather than at each call
+// site.
+func loadCityConfigAdvisory(cityPath string) (cfg *config.City, err error) {
+	quietDefaultLogger(func() {
+		cfg, err = loadPrematerializedCityConfig(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), advisoryLoad, io.Discard)
+	})
+	return cfg, err
 }
 
 var loadCityConfigDefaultWarningWriter = func() io.Writer {

--- a/cmd/gc/cmd_pack_commands.go
+++ b/cmd/gc/cmd_pack_commands.go
@@ -66,11 +66,15 @@ func registerPackCommands(root *cobra.Command, args []string, stdout, stderr io.
 	if isCredentialHelperInvocation(args) {
 		return
 	}
-	cityPath, err := resolveCity()
+	// Eager discovery runs on every gc invocation, whatever the user typed, so
+	// it resolves advisorily: it must not wait on another process's repo-cache
+	// clone. When it degrades, the command the user actually typed still
+	// resolves through the blocking lazy paths below.
+	cityPath, err := resolveCityForDiscovery()
 	if err != nil {
 		return
 	}
-	cfg, err := quietLoadCityConfig(cityPath)
+	cfg, err := loadCityConfigAdvisory(cityPath)
 	if err != nil {
 		return
 	}

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -130,7 +130,7 @@ func rigNameCandidates(toComplete string) []string {
 		if err != nil {
 			return
 		}
-		cfg, err := loadCityConfigWithoutBuiltinPackRefreshFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), io.Discard)
+		cfg, err := loadCityConfigAdvisory(cityPath)
 		if err != nil {
 			return
 		}
@@ -179,14 +179,25 @@ func resolveCityForCompletionContext(honorRigFlag bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if ctx, ok := lookupRigFromCwd(cwd); ok {
+	ctx, ok, err := lookupRigFromCwd(cwd, completionResolutionMode)
+	if err != nil {
+		return "", err
+	}
+	if ok {
 		return ctx.CityPath, nil
 	}
 	return findCity(cwd)
 }
 
+// completionResolutionMode marks every completion-time resolution advisory,
+// matching the loadCityConfigAdvisory loads above. Completion runs on a
+// keystroke against input the user has not submitted yet, so it already
+// tolerates stale pack state; waiting on another process's repo-cache clone
+// would hang the user's shell instead.
+var completionResolutionMode = contextResolutionMode{advisory: true}
+
 func resolveRigForCompletion(nameOrPath string) (resolvedContext, error) {
-	matches, _, err := registeredRigBindingsByName(nameOrPath, false)
+	matches, _, err := registeredRigBindingsByName(nameOrPath, false, completionResolutionMode)
 	if err != nil {
 		return resolvedContext{}, err
 	}
@@ -198,7 +209,7 @@ func resolveRigForCompletion(nameOrPath string) (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, err
 	}
-	matches, _, err = registeredRigBindingsByPath(abs, false)
+	matches, _, err = registeredRigBindingsByPath(abs, false, completionResolutionMode)
 	if err != nil {
 		return resolvedContext{}, err
 	}
@@ -215,7 +226,7 @@ func loadOrdersForCompletion() []orders.Order {
 		if err != nil {
 			return
 		}
-		cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
+		cfg, err := loadCityConfigAdvisory(cityPath)
 		if err != nil {
 			return
 		}
@@ -242,7 +253,7 @@ func loadSessionsForCompletion() []session.Info {
 		if err != nil {
 			return
 		}
-		cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
+		cfg, err := loadCityConfigAdvisory(cityPath)
 		if err != nil {
 			return
 		}

--- a/cmd/gc/load_city_config_snapshot_test.go
+++ b/cmd/gc/load_city_config_snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 // TestCityConfigLoadersDeclineTheRevisionSnapshot pins a file-level invariant:
@@ -52,7 +53,10 @@ import (
 func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
 	const guarded = "cmd_agent.go"
 	const capturingCall = "config.LoadWithIncludes("
-	const optionsLiteral = "config.LoadOptions{"
+	// optionsType, not "config.LoadOptions{": a zero value declared without a
+	// literal (`var opts config.LoadOptions`) captures the snapshot just as
+	// surely, and matching on the brace would not see it.
+	const optionsType = "config.LoadOptions"
 	const option = "SkipRevisionSnapshot: true"
 	// sharedBodyParam is the parameter the shared loader body forwards. It is
 	// safe only because every call that supplies it is checked below.
@@ -88,13 +92,24 @@ func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
 	declining := map[string]bool{sharedBodyParam: true}
 	optionsFound := 0
 	for i, line := range lines {
-		if !strings.Contains(line, optionsLiteral) {
+		trimmed := strings.TrimSpace(line)
+		if !strings.Contains(line, optionsType) {
+			continue
+		}
+		// A comment naming the type declares nothing.
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		// The shared body's signature declares the parameter itself. It is
+		// checked indirectly instead: every call that supplies it is required
+		// below to pass one of the values verified here.
+		if strings.HasPrefix(trimmed, "func ") {
 			continue
 		}
 		optionsFound++
 		if !strings.Contains(line, option) {
 			t.Errorf("%s:%d declares options that capture the revision snapshot: %s",
-				guarded, i+1, strings.TrimSpace(line))
+				guarded, i+1, trimmed)
 			continue
 		}
 		if name, ok := declaredVarName(line); ok {
@@ -102,7 +117,7 @@ func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
 		}
 	}
 	if optionsFound == 0 {
-		t.Fatalf("no %s literal in %s; this guard is no longer watching anything", optionsLiteral, guarded)
+		t.Fatalf("no %s declaration in %s; this guard is no longer watching anything", optionsType, guarded)
 	}
 
 	// Second half: every load call must be handed one of those values. Without
@@ -120,7 +135,7 @@ func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
 			continue
 		}
 		callsFound++
-		if !containsAnyKey(line, declining) {
+		if !hasIdentifierIn(line, declining) {
 			t.Errorf("%s:%d loads config without passing one of this file's named declining options values %s: %s",
 				guarded, i+1, sortedKeys(declining), trimmed)
 		}
@@ -153,11 +168,44 @@ func containsAny(line string, needles []string) bool {
 	return false
 }
 
-func containsAnyKey(line string, needles map[string]bool) bool {
-	for n := range needles {
-		if strings.Contains(line, n) {
+// hasIdentifierIn reports whether the line uses any of the named values as a
+// whole identifier.
+//
+// Whole identifier, not substring: a substring test for the parameter name
+// "opts" also accepts "sneakyopts", so declaring `var sneakyopts
+// config.LoadOptions` and passing it would satisfy this half of the guard
+// while capturing the snapshot — which is precisely the evasion the two halves
+// exist to close.
+func hasIdentifierIn(line string, names map[string]bool) bool {
+	for _, ident := range identifiers(line) {
+		if names[ident] {
 			return true
 		}
 	}
 	return false
+}
+
+// identifiers splits a source line into its Go identifier tokens. It does not
+// distinguish identifiers from keywords or from the digits of a numeric
+// literal; the guard only ever looks up names it declared itself, so the extra
+// tokens cannot produce a false match.
+func identifiers(line string) []string {
+	var out []string
+	start := -1
+	for i, r := range line {
+		if r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			out = append(out, line[start:i])
+			start = -1
+		}
+	}
+	if start >= 0 {
+		out = append(out, line[start:])
+	}
+	return out
 }

--- a/cmd/gc/load_city_config_snapshot_test.go
+++ b/cmd/gc/load_city_config_snapshot_test.go
@@ -29,6 +29,19 @@ import (
 // runtime.Caller-derived directory rather than the process working directory,
 // and match with substring needles.
 //
+// The loaders no longer each spell the option out at their own call site: they
+// share a body that takes the options as a parameter, since which options to
+// pass is what separates a blocking load from an advisory one. So the guard
+// checks the two halves that together still forbid a default-options load —
+// every config.LoadOptions value this file declares declines the snapshot, and
+// every load call is handed one of those values rather than something else.
+//
+// That second half deliberately requires a *named* value: an inline
+// config.LoadOptions{SkipRevisionSnapshot: true} at a call site would be
+// correct today but leaves the reasoning above attached to nothing, and the
+// next option added beside it has no comment to inherit. Declare a var with a
+// rationale and pass that.
+//
 // Scope is deliberately narrow. Only cmd_agent.go's loaders are known to discard
 // the Provenance; roughly a dozen other call sites elsewhere in the tree do the
 // same thing and are out of scope for this change and this guard.
@@ -39,8 +52,14 @@ import (
 func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
 	const guarded = "cmd_agent.go"
 	const capturingCall = "config.LoadWithIncludes("
-	const decliningCall = "config.LoadWithIncludesOptions("
-	const option = "skipRevisionSnapshot"
+	const optionsLiteral = "config.LoadOptions{"
+	const option = "SkipRevisionSnapshot: true"
+	// sharedBodyParam is the parameter the shared loader body forwards. It is
+	// safe only because every call that supplies it is checked below.
+	const sharedBodyParam = "opts"
+
+	// Calls that must be handed a declining options value.
+	loadCalls := []string{"config.LoadWithIncludesOptions(", "loadPrematerializedCityConfig("}
 
 	_, currentFile, _, ok := runtime.Caller(0)
 	if !ok {
@@ -52,28 +71,93 @@ func TestCityConfigLoadersDeclineTheRevisionSnapshot(t *testing.T) {
 	}
 	text := string(src)
 
-	// capturingCall ends in '(' so it does not also match decliningCall, whose
-	// next character is 'O'.
+	// capturingCall ends in '(' so it does not also match
+	// config.LoadWithIncludesOptions(, whose next character is 'O'.
 	if strings.Contains(text, capturingCall) {
-		t.Errorf("%s calls %s — that form always captures the revision snapshot; use %s..., %s)",
-			guarded, capturingCall, decliningCall, option)
+		t.Errorf("%s calls %s — that form always captures the revision snapshot; use %sOptions(..., <declining options>)",
+			guarded, capturingCall, capturingCall)
 	}
 
 	// Scan line by line rather than with a bracket-matching regex: a pattern
 	// like `\([^)]*\)` truncates at the first ')', so a future call containing a
 	// nested call expression would fail spuriously with a misleading message.
-	found := 0
-	for i, line := range strings.Split(text, "\n") {
-		if !strings.Contains(line, decliningCall) {
+	lines := strings.Split(text, "\n")
+
+	// First half: every options value this file declares must decline the
+	// snapshot, and record its name so the call scan below can recognize it.
+	declining := map[string]bool{sharedBodyParam: true}
+	optionsFound := 0
+	for i, line := range lines {
+		if !strings.Contains(line, optionsLiteral) {
 			continue
 		}
-		found++
+		optionsFound++
 		if !strings.Contains(line, option) {
-			t.Errorf("%s:%d does not decline the revision snapshot: %s",
+			t.Errorf("%s:%d declares options that capture the revision snapshot: %s",
 				guarded, i+1, strings.TrimSpace(line))
+			continue
+		}
+		if name, ok := declaredVarName(line); ok {
+			declining[name] = true
 		}
 	}
-	if found == 0 {
-		t.Fatalf("no %s call in %s; this guard is no longer watching anything", decliningCall, guarded)
+	if optionsFound == 0 {
+		t.Fatalf("no %s literal in %s; this guard is no longer watching anything", optionsLiteral, guarded)
 	}
+
+	// Second half: every load call must be handed one of those values. Without
+	// this, the first half could pass while a loader was quietly switched to a
+	// default config.LoadOptions{} declared elsewhere.
+	callsFound := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// The shared body's own signature names the parameter; it is a
+		// declaration, not a call.
+		if strings.HasPrefix(trimmed, "func ") {
+			continue
+		}
+		if !containsAny(line, loadCalls) {
+			continue
+		}
+		callsFound++
+		if !containsAnyKey(line, declining) {
+			t.Errorf("%s:%d loads config without passing one of this file's named declining options values %s: %s",
+				guarded, i+1, sortedKeys(declining), trimmed)
+		}
+	}
+	if callsFound == 0 {
+		t.Fatalf("no config load call in %s; this guard is no longer watching anything", guarded)
+	}
+}
+
+// declaredVarName returns the identifier bound by a `var NAME = ...` line.
+func declaredVarName(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	rest, ok := strings.CutPrefix(trimmed, "var ")
+	if !ok {
+		return "", false
+	}
+	name, _, ok := strings.Cut(rest, " ")
+	if !ok || name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func containsAny(line string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(line, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAnyKey(line string, needles map[string]bool) bool {
+	for n := range needles {
+		if strings.Contains(line, n) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -669,6 +670,13 @@ func resolveContextAllowRemoteMode(mode contextResolutionMode) (resolvedContext,
 	if err == nil {
 		return ctx, nil
 	}
+	// A busy repo cache means local discovery could not look, not that it
+	// looked and found nothing. Falling through would answer with a remote
+	// sticky default because a clone happened to be running in another
+	// terminal — a different city for the same cwd, decided by timing.
+	if errors.Is(err, config.ErrRepoCacheBusy) {
+		return resolvedContext{}, err
+	}
 	// Step 4: no local city discoverable — fall back to the sticky default
 	// context, if any (subordinate to local discovery, per Decision 4).
 	if target, ok, derr := resolveStickyDefaultTarget(); derr != nil {
@@ -999,14 +1007,9 @@ func localCityRigBindings(cityPath string, mode contextResolutionMode) ([]regist
 }
 
 func siteBoundRigBindings(city supervisor.CityEntry, cfg *config.City, siteBinding *config.SiteBinding) []registeredRigBinding {
-	siteRigPaths := make(map[string]string, len(siteBinding.Rigs))
-	for _, rig := range siteBinding.Rigs {
-		name := strings.TrimSpace(rig.Name)
-		path := strings.TrimSpace(rig.Path)
-		if name == "" || path == "" {
-			continue
-		}
-		siteRigPaths[name] = path
+	candidates := make(map[string]rigCandidate, len(siteBinding.Rigs))
+	for _, candidate := range siteRigCandidates(city, siteBinding) {
+		candidates[candidate.Name] = candidate
 	}
 
 	var bindings []registeredRigBinding
@@ -1014,18 +1017,43 @@ func siteBoundRigBindings(city supervisor.CityEntry, cfg *config.City, siteBindi
 		if strings.TrimSpace(rig.Name) == "" {
 			continue
 		}
-		sitePath := strings.TrimSpace(siteRigPaths[rig.Name])
-		if sitePath == "" {
+		candidate, ok := candidates[rig.Name]
+		if !ok {
 			continue
 		}
-		rig.Path = sitePath
+		rig.Path = candidate.Path
 		bindings = append(bindings, registeredRigBinding{
 			City: city,
 			Rig:  rig,
-			Path: resolveStoreScopeRoot(city.Path, sitePath),
+			Path: candidate.ScopeRoot,
 		})
 	}
 	return bindings
+}
+
+// siteRigCandidates enumerates the machine-local rig bindings a city's
+// .gc/site.toml declares.
+//
+// This is the single derivation both siteBoundRigBindings and the pre-filter
+// in registeredRigBindings run, which is what makes the pre-filter's superset
+// property structural rather than a claim two functions have to keep agreeing
+// on independently.
+func siteRigCandidates(city supervisor.CityEntry, siteBinding *config.SiteBinding) []rigCandidate {
+	candidates := make([]rigCandidate, 0, len(siteBinding.Rigs))
+	for _, rig := range siteBinding.Rigs {
+		name := strings.TrimSpace(rig.Name)
+		path := strings.TrimSpace(rig.Path)
+		if name == "" || path == "" {
+			continue
+		}
+		candidates = append(candidates, rigCandidate{
+			City:      city,
+			Name:      name,
+			Path:      path,
+			ScopeRoot: resolveStoreScopeRoot(city.Path, path),
+		})
+	}
+	return candidates
 }
 
 // resolveRigPathToContext resolves an explicit path argument to a registered
@@ -1108,14 +1136,36 @@ type registeredRigBinding struct {
 	Path string
 }
 
+// rigCandidate is the part of a registered rig binding that a city's
+// .gc/site.toml alone determines — everything siteRigCandidates can produce
+// without loading city.toml.
+//
+// Match predicates take this rather than a whole registeredRigBinding so the
+// compiler forbids a predicate from reading a field the pre-filter cannot
+// populate. That failure would be silent: the pre-filter would stop admitting
+// a city the real scan would have matched, and the scan would just return
+// fewer bindings.
+type rigCandidate struct {
+	City      supervisor.CityEntry
+	Name      string // rig name as recorded in site.toml
+	Path      string // machine-local rig path as recorded in site.toml
+	ScopeRoot string // resolveStoreScopeRoot(City.Path, Path)
+}
+
+// candidate projects a fully resolved binding back onto the fields the
+// pre-filter can see, so both sides hand the predicate the same shape.
+func (b registeredRigBinding) candidate() rigCandidate {
+	return rigCandidate{City: b.City, Name: b.Rig.Name, Path: b.Rig.Path, ScopeRoot: b.Path}
+}
+
 func registeredRigBindingsByName(name string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
 	matches, stale, err, _ = registeredRigBindingsByNameWithDeferredLoadError(name, failOnLoadError, mode)
 	return matches, stale, err
 }
 
 func registeredRigBindingsByNameWithDeferredLoadError(name string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
-	return registeredRigBindings(failOnLoadError, mode, func(binding registeredRigBinding) bool {
-		return binding.Rig.Name == name
+	return registeredRigBindings(failOnLoadError, mode, func(c rigCandidate) bool {
+		return c.Name == name
 	})
 }
 
@@ -1126,9 +1176,8 @@ func registeredRigBindingsByPath(dir string, failOnLoadError bool, mode contextR
 
 func registeredRigBindingsByPathWithDeferredLoadError(dir string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
 	dir = normalizePathForCompare(dir)
-	matches, stale, err, deferredLoadErr = registeredRigBindings(failOnLoadError, mode, func(binding registeredRigBinding) bool {
-		rigPath := normalizePathForCompare(binding.Path)
-		return pathWithinScope(dir, rigPath)
+	matches, stale, err, deferredLoadErr = registeredRigBindings(failOnLoadError, mode, func(c rigCandidate) bool {
+		return pathWithinScope(dir, normalizePathForCompare(c.ScopeRoot))
 	})
 	if err != nil {
 		return nil, stale, err, nil
@@ -1164,7 +1213,7 @@ func emitStaleRegisteredCityWarnings(w io.Writer, stale []staleRegisteredCity) {
 	}
 }
 
-func registeredRigBindings(failOnLoadError bool, mode contextResolutionMode, match func(registeredRigBinding) bool) (_ []registeredRigBinding, stale []staleRegisteredCity, _ error, deferredLoadErr error) {
+func registeredRigBindings(failOnLoadError bool, mode contextResolutionMode, match func(rigCandidate) bool) (_ []registeredRigBinding, stale []staleRegisteredCity, _ error, deferredLoadErr error) {
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
 	cities, err := reg.List()
 	if err != nil {
@@ -1174,15 +1223,41 @@ func registeredRigBindings(failOnLoadError bool, mode contextResolutionMode, mat
 	var loadErrors []string
 	for _, c := range cities {
 		siteBinding, siteErr := config.LoadSiteBinding(fsys.OSFS{}, c.Path)
-		// An advisory scan skips the config load for cities that cannot
-		// contribute an answer. site.toml names a superset of the rigs
-		// siteBoundRigBindings keeps — it records where a rig lives, not
-		// whether city.toml still declares it — so a city with no candidate
-		// here has none after pruning either. Cities that do have a candidate
-		// are loaded and pruned exactly as an authoritative scan would, which
-		// is what keeps advisory resolution from ever selecting a city an
-		// authoritative resolution would have rejected.
-		if mode.advisory && siteErr == nil && !siteBindingHasCandidate(c, siteBinding, match) {
+		// A match-only scan skips the config load for cities that cannot
+		// contribute a match.
+		//
+		// This is what keeps the fail-closed behavior above from turning one
+		// clone into a machine-wide outage. Every registered city's load is a
+		// chance to hit a busy repo cache, and a busy cache now aborts the whole
+		// scan — so without this, `gc import install` in any one city would
+		// break rig resolution in all of them. Filtering first narrows that
+		// exposure to the cities that could actually answer the question.
+		//
+		// site.toml names a superset of the rigs siteBoundRigBindings keeps —
+		// it records where a rig lives, not whether city.toml still declares
+		// it — so a city with no candidate here has none after pruning either.
+		// Cities that do have one are loaded and pruned exactly as before.
+		//
+		// The condition deliberately does not mention mode. It once read
+		// `mode.advisory && ...`, which left the two modes disagreeing about a
+		// city that cannot match but can still fail to load: the unfiltered
+		// scan collected that load error, and one load error fails any scan
+		// that also matched something (below). Same registry, same rig, a
+		// different answer depending on who asked — which is what the advisory
+		// contract forbids, and eager discovery captures the city it picks into
+		// pack-command closures the user later runs. With mode out of the
+		// condition the two traversals are identical by construction.
+		//
+		// failOnLoadError is a different request: report everything wrong with
+		// the registry, not just what matched. A caller asking for that is
+		// asking about the cities this filter would skip — a vanished city.toml
+		// or an unloadable include is exactly the diagnostic they came for — so
+		// it turns the filter off and pays the full scan for it.
+		//
+		// A malformed site.toml also disables the filter for that city: it is
+		// not evidence of anything, so the city is loaded and its error
+		// reported below.
+		if !failOnLoadError && siteErr == nil && !siteBindingHasCandidate(c, siteBinding, match) {
 			continue
 		}
 		cfg, err := loadRegisteredCityConfig(c.Path, mode)
@@ -1208,7 +1283,7 @@ func registeredRigBindings(failOnLoadError bool, mode contextResolutionMode, mat
 			continue
 		}
 		for _, binding := range siteBoundRigBindings(c, cfg, siteBinding) {
-			if match(binding) {
+			if match(binding.candidate()) {
 				matched = append(matched, binding)
 			}
 		}
@@ -1226,22 +1301,11 @@ func registeredRigBindings(failOnLoadError bool, mode contextResolutionMode, mat
 // city's .gc/site.toml could satisfy match. It is a pre-filter, not an answer:
 // site.toml records where a rig lives, not whether city.toml still declares it,
 // so a candidate here is only a reason to load the config and check properly.
-func siteBindingHasCandidate(city supervisor.CityEntry, siteBinding *config.SiteBinding, match func(registeredRigBinding) bool) bool {
-	for _, rig := range siteBinding.Rigs {
-		name := strings.TrimSpace(rig.Name)
-		path := strings.TrimSpace(rig.Path)
-		if name == "" || path == "" {
-			continue
-		}
-		if match(registeredRigBinding{
-			City: city,
-			Rig:  config.Rig{Name: name, Path: path},
-			Path: resolveStoreScopeRoot(city.Path, path),
-		}) {
-			return true
-		}
-	}
-	return false
+//
+// It runs match over exactly the candidates siteBoundRigBindings prunes from,
+// so "no candidate here" implies "no binding after pruning" by construction.
+func siteBindingHasCandidate(city supervisor.CityEntry, siteBinding *config.SiteBinding, match func(rigCandidate) bool) bool {
+	return slices.ContainsFunc(siteRigCandidates(city, siteBinding), match)
 }
 
 // loadRegisteredCityConfig loads one registered city's config for a rig-binding

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -525,6 +525,31 @@ func cliSessionName(cityPath, cityName, agentName, sessionTemplate string) strin
 	return sessionName(store, cityName, agentName, sessionTemplate)
 }
 
+// contextResolutionMode distinguishes the two kinds of caller the resolution
+// chain serves. The zero value is the authoritative one, so every caller that
+// does not opt in keeps waiting for whatever it needs.
+type contextResolutionMode struct {
+	// advisory marks a resolution nobody asked for: eager pack-command
+	// discovery and shell completion, which run on every gc invocation
+	// whatever the user typed. Such a caller would rather have no answer than
+	// wait out another process's network clone, so an advisory resolution
+	// never blocks on the machine-wide repo-cache lock, skips the rig
+	// decoration its caller discards anyway, and stays off the terminal.
+	//
+	// It does not trade accuracy for speed. An advisory resolution either
+	// names the same city an authoritative one would, or fails: whatever it
+	// declines to wait for it reports as an error rather than resolving
+	// around. Eager discovery captures the city it picks into the
+	// pack-command closures the user later runs, so a cheaper-but-different
+	// answer would end up executing pack code against the wrong city.
+	advisory bool
+}
+
+// authoritativeResolution is the mode for anything the user actually typed: it
+// waits for whatever it needs. Named rather than spelled as a bare
+// contextResolutionMode{} so the choice reads as deliberate at the call site.
+var authoritativeResolution contextResolutionMode
+
 // resolvedContext holds the result of city+rig resolution.
 type resolvedContext struct {
 	CityPath string        // absolute path to city root (empty when Remote is set)
@@ -589,7 +614,11 @@ func resolveCommandCity(args []string) (string, error) {
 // local store. Remote-capable READ commands call resolveContextAllowRemote
 // directly and route through the remote transport (resolveReadRoute).
 func resolveContext() (resolvedContext, error) {
-	ctx, err := resolveContextAllowRemote()
+	return resolveContextMode(authoritativeResolution)
+}
+
+func resolveContextMode(mode contextResolutionMode) (resolvedContext, error) {
+	ctx, err := resolveContextAllowRemoteMode(mode)
 	if err != nil {
 		return resolvedContext{}, err
 	}
@@ -599,11 +628,30 @@ func resolveContext() (resolvedContext, error) {
 	return ctx, nil
 }
 
+// resolveCityForDiscovery returns the city root for a resolution nobody asked
+// for — eager pack-command discovery, shell completion. It is resolveCity that
+// refuses to wait on the machine-wide repo-cache lock: a single `gc import
+// install` holds that lock for the whole of its network clone, and blocking
+// discovery would make every unrelated gc command on the host hang for the
+// duration. Callers get "no city right now" and degrade; anything the user
+// actually typed still resolves through resolveCity and waits.
+func resolveCityForDiscovery() (string, error) {
+	ctx, err := resolveContextMode(contextResolutionMode{advisory: true})
+	if err != nil {
+		return "", err
+	}
+	return ctx.CityPath, nil
+}
+
 // resolveContextAllowRemote is the raw priority-chain resolver. It returns a
 // remote target (resolvedContext.Remote) when one is selected, WITHOUT the
 // capability gate — so only a remote-aware caller that routes through the remote
 // transport should use it. Every other caller uses resolveContext, which gates.
 func resolveContextAllowRemote() (resolvedContext, error) {
+	return resolveContextAllowRemoteMode(authoritativeResolution)
+}
+
+func resolveContextAllowRemoteMode(mode contextResolutionMode) (resolvedContext, error) {
 	// Step 0: explicit remote target. A conflict (remote+local or remote+remote)
 	// surfaces here regardless.
 	if target, handled, err := resolveRemoteTarget(); err != nil {
@@ -611,13 +659,13 @@ func resolveContextAllowRemote() (resolvedContext, error) {
 	} else if handled {
 		return resolvedContext{Remote: target}, nil
 	}
-	if ctx, handled, err := resolveContextFromFlags(); handled {
+	if ctx, handled, err := resolveContextFromFlags(mode); handled {
 		return ctx, err
 	}
-	if ctx, handled, err := resolveContextFromCityEnv(); handled {
+	if ctx, handled, err := resolveContextFromCityEnv(mode); handled {
 		return ctx, err
 	}
-	ctx, err := resolveContextFromDir()
+	ctx, err := resolveContextFromDir(mode)
 	if err == nil {
 		return ctx, nil
 	}
@@ -641,7 +689,7 @@ func resolveContextAllowRemote() (resolvedContext, error) {
 // resolveContextFromFlags resolves context from the explicit --city and --rig
 // flags (priority steps 1-3). handled is false with a nil error when neither
 // flag is set, so the caller falls through to env/cwd resolution.
-func resolveContextFromFlags() (resolvedContext, bool, error) {
+func resolveContextFromFlags(mode contextResolutionMode) (resolvedContext, bool, error) {
 	city := cityFlag
 	rig := rigFlag
 	switch {
@@ -656,9 +704,9 @@ func resolveContextFromFlags() (resolvedContext, bool, error) {
 		if err != nil {
 			return resolvedContext{}, true, err
 		}
-		return resolvedContext{CityPath: cp, RigName: rigFromCwd(cp)}, true, nil
+		return resolvedContext{CityPath: cp, RigName: rigFromCwd(cp, mode)}, true, nil
 	case rig != "": // Step 3: --rig only
-		ctx, err := resolveRigToContext(rig)
+		ctx, err := resolveRigToContext(rig, mode)
 		return ctx, true, err
 	default:
 		return resolvedContext{}, false, nil
@@ -668,16 +716,16 @@ func resolveContextFromFlags() (resolvedContext, bool, error) {
 // resolveContextFromCityEnv resolves context from the explicit city env
 // (GC_CITY / GC_CITY_PATH / GC_CITY_ROOT) and GC_RIG (priority steps 4-6).
 // handled is false with a nil error when neither resolves.
-func resolveContextFromCityEnv() (resolvedContext, bool, error) {
+func resolveContextFromCityEnv(mode contextResolutionMode) (resolvedContext, bool, error) {
 	gcRig := os.Getenv("GC_RIG")
 	gcCity, ok := resolveExplicitCityPathEnv()
 	switch {
 	case ok && gcRig != "": // Step 4: explicit city env + GC_RIG
 		return resolvedContext{CityPath: gcCity, RigName: gcRig}, true, nil
 	case ok: // Step 5: explicit city env only
-		return resolvedContext{CityPath: gcCity, RigName: rigFromGCDirOrCwd(gcCity)}, true, nil
+		return resolvedContext{CityPath: gcCity, RigName: rigFromGCDirOrCwd(gcCity, mode)}, true, nil
 	case gcRig != "": // Step 6: GC_RIG only
-		ctx, err := resolveRigToContext(gcRig)
+		ctx, err := resolveRigToContext(gcRig, mode)
 		return ctx, true, err
 	default:
 		return resolvedContext{}, false, nil
@@ -688,7 +736,7 @@ func resolveContextFromCityEnv() (resolvedContext, bool, error) {
 // steps 7-11): a GC_DIR rig binding, a GC_DIR-derived city, a cwd rig binding,
 // and finally a walk up from cwd for city.toml. This is the terminal stage, so
 // it always returns a result or an error.
-func resolveContextFromDir() (resolvedContext, error) {
+func resolveContextFromDir(mode contextResolutionMode) (resolvedContext, error) {
 	// Step 7: Registered rig binding lookup using GC_DIR. Must run before
 	// the GC_DIR walkup (step 8) so that a rig dir with a leftover ".gc/"
 	// runtime artifact does not get mistaken for a legacy city via
@@ -706,14 +754,18 @@ func resolveContextFromDir() (resolvedContext, error) {
 	// rig lookup) covers it.
 	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" &&
 		citylayout.HasRuntimeRoot(gcDir) && !citylayout.HasCityConfig(gcDir) {
-		if ctx, ok := lookupRigFromCwd(gcDir); ok {
+		ctx, ok, err := lookupRigFromCwd(gcDir, mode)
+		if err != nil {
+			return resolvedContext{}, err
+		}
+		if ok {
 			return ctx, nil
 		}
 	}
 
 	// Step 8: GC_DIR-derived city path.
 	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
-		rn := rigFromCwdDir(gcDirCity, strings.TrimSpace(os.Getenv("GC_DIR")))
+		rn := rigFromCwdDir(gcDirCity, strings.TrimSpace(os.Getenv("GC_DIR")), mode)
 		return resolvedContext{CityPath: gcDirCity, RigName: rn}, nil
 	}
 
@@ -722,7 +774,11 @@ func resolveContextFromDir() (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, err
 	}
-	if ctx, ok := lookupRigFromCwd(cwd); ok {
+	ctx, ok, err := lookupRigFromCwd(cwd, mode)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	if ok {
 		return ctx, nil
 	}
 
@@ -737,7 +793,7 @@ func resolveContextFromDir() (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, err
 	}
-	return resolvedContext{CityPath: cityPath, RigName: rigFromCwdDir(cityPath, cwd)}, nil
+	return resolvedContext{CityPath: cityPath, RigName: rigFromCwdDir(cityPath, cwd, mode)}, nil
 }
 
 // resolveCity returns the city root path. Thin wrapper over resolveContext
@@ -765,7 +821,7 @@ func resolveContextFromPath(path string) (resolvedContext, error) {
 	if citylayout.HasCityConfig(abs) {
 		return resolvedContext{
 			CityPath: abs,
-			RigName:  rigFromCwdDir(abs, abs),
+			RigName:  rigFromCwdDir(abs, abs, authoritativeResolution),
 		}, nil
 	}
 	ctx, ok, err := resolveRigPathToContext(abs)
@@ -781,7 +837,7 @@ func resolveContextFromPath(path string) (resolvedContext, error) {
 	}
 	return resolvedContext{
 		CityPath: cityPath,
-		RigName:  rigFromCwdDir(cityPath, abs),
+		RigName:  rigFromCwdDir(cityPath, abs, authoritativeResolution),
 	}, nil
 }
 
@@ -798,12 +854,12 @@ func validateCityPath(p string) (string, error) {
 // registered cities and their machine-local .gc/site.toml rig bindings. This
 // is an explicit rig-resolution path, so stale-sibling warnings are emitted
 // to os.Stderr (deduped across the two registry scans below).
-func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
+func resolveRigToContext(nameOrPath string, mode contextResolutionMode) (resolvedContext, error) {
 	var allStale []staleRegisteredCity
 	defer func() { emitStaleRegisteredCityWarnings(os.Stderr, allStale) }()
 
 	var deferredRegisteredLoadErr error
-	matches, stale, err, loadErr := registeredRigBindingsByNameWithDeferredLoadError(nameOrPath, false)
+	matches, stale, err, loadErr := registeredRigBindingsByNameWithDeferredLoadError(nameOrPath, false, mode)
 	allStale = append(allStale, stale...)
 	if err != nil {
 		return resolvedContext{}, err
@@ -817,7 +873,7 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, fmt.Errorf("rig %q: %w", nameOrPath, err)
 	}
-	matches, stale, err, loadErr = registeredRigBindingsByPathWithDeferredLoadError(abs, false)
+	matches, stale, err, loadErr = registeredRigBindingsByPathWithDeferredLoadError(abs, false, mode)
 	allStale = append(allStale, stale...)
 	if err != nil {
 		return resolvedContext{}, err
@@ -835,7 +891,7 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	// the resolved city for a site-bound rig of this name. Site binding is
 	// required: legacy city.toml-only paths remain rejected so the existing
 	// legacy_city_toml_path_is_not_registered_binding test continues to pass.
-	if ctx, ok, err := lookupRigFromLocalCity(nameOrPath); err != nil {
+	if ctx, ok, err := lookupRigFromLocalCity(nameOrPath, mode); err != nil {
 		return resolvedContext{}, err
 	} else if ok {
 		return ctx, nil
@@ -886,7 +942,7 @@ func isCityDiscoveryNotFound(err error) bool {
 // .gc/site.toml, matching the registered resolver's binding semantics.
 // Legacy city.toml-only paths are still rejected so this fallback preserves
 // the invariant pinned by legacy_city_toml_path_is_not_registered_binding.
-func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool, error) {
+func lookupRigFromLocalCity(nameOrPath string, mode contextResolutionMode) (resolvedContext, bool, error) {
 	cityPath, err := resolveLocalCityForRigFallback()
 	if err != nil {
 		return resolvedContext{}, false, err
@@ -894,7 +950,7 @@ func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool, error) {
 	if cityPath == "" {
 		return resolvedContext{}, false, nil
 	}
-	bindings, err := localCityRigBindings(cityPath)
+	bindings, err := localCityRigBindings(cityPath, mode)
 	if err != nil {
 		return resolvedContext{}, false, err
 	}
@@ -926,8 +982,8 @@ func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool, error) {
 	return resolvedContext{}, false, nil
 }
 
-func localCityRigBindings(cityPath string) ([]registeredRigBinding, error) {
-	cfg, err := loadCityConfig(cityPath, io.Discard)
+func localCityRigBindings(cityPath string, mode contextResolutionMode) ([]registeredRigBinding, error) {
+	cfg, err := loadRegisteredCityConfig(cityPath, mode)
 	if err != nil {
 		if _, ok := missingRootCityTOML(err, cityPath); ok {
 			return nil, nil
@@ -976,7 +1032,7 @@ func siteBoundRigBindings(city supervisor.CityEntry, cfg *config.City, siteBindi
 // rig context. Stale-sibling warnings are emitted to os.Stderr because the
 // caller is explicitly depending on the registry.
 func resolveRigPathToContext(dir string) (resolvedContext, bool, error) {
-	matches, stale, err := registeredRigBindingsByPath(dir, true)
+	matches, stale, err := registeredRigBindingsByPath(dir, true, authoritativeResolution)
 	emitStaleRegisteredCityWarnings(os.Stderr, stale)
 	if err != nil {
 		return resolvedContext{}, false, err
@@ -995,25 +1051,46 @@ func resolveRigPathToContext(dir string) (resolvedContext, bool, error) {
 // Ambiguous bindings deliberately fall through to the city walk-up fallback.
 // This is an opportunistic probe (failOnLoadError=false): stale-sibling
 // warnings are intentionally dropped so unrelated commands stay quiet.
-func lookupRigFromCwd(cwd string) (resolvedContext, bool) {
-	matches, _, err := registeredRigBindingsByPath(cwd, false)
-	if err != nil || len(matches) != 1 {
-		return resolvedContext{}, false
+// lookupRigFromCwd maps cwd onto the single registered rig that contains it.
+//
+// A scan error normally means "no answer from the registry", and the caller
+// falls back to walking up from cwd. A busy repo cache is different: the
+// registry might well have named a city, and falling back could settle on a
+// different one just because an unrelated clone was running. That case is
+// returned as an error so the caller fails closed instead.
+func lookupRigFromCwd(cwd string, mode contextResolutionMode) (resolvedContext, bool, error) {
+	matches, _, err := registeredRigBindingsByPath(cwd, false, mode)
+	if err != nil {
+		if errors.Is(err, config.ErrRepoCacheBusy) {
+			return resolvedContext{}, false, err
+		}
+		return resolvedContext{}, false, nil
 	}
-	return resolvedContext{CityPath: matches[0].City.Path, RigName: matches[0].Rig.Name}, true
+	if len(matches) != 1 {
+		return resolvedContext{}, false, nil
+	}
+	return resolvedContext{CityPath: matches[0].City.Path, RigName: matches[0].Rig.Name}, true, nil
 }
 
 // rigFromCwd attempts to derive a rig name from cwd when the city is known.
-func rigFromCwd(cityPath string) string {
+func rigFromCwd(cityPath string, mode contextResolutionMode) string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
 	}
-	return rigFromCwdDir(cityPath, cwd)
+	return rigFromCwdDir(cityPath, cwd, mode)
 }
 
 // rigFromCwdDir matches cwd against registered rigs in a city's config.
-func rigFromCwdDir(cityPath, cwd string) string {
+//
+// This is pure decoration: it loads the whole city config to produce a rig
+// name, and an advisory resolution's caller only wants the city path. Skipping
+// it there is what keeps discovery off the repo-cache lock entirely, rather
+// than merely making its acquisition non-blocking.
+func rigFromCwdDir(cityPath, cwd string, mode contextResolutionMode) string {
+	if mode.advisory {
+		return ""
+	}
 	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {
 		return ""
@@ -1031,25 +1108,25 @@ type registeredRigBinding struct {
 	Path string
 }
 
-func registeredRigBindingsByName(name string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
-	matches, stale, err, _ = registeredRigBindingsByNameWithDeferredLoadError(name, failOnLoadError)
+func registeredRigBindingsByName(name string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
+	matches, stale, err, _ = registeredRigBindingsByNameWithDeferredLoadError(name, failOnLoadError, mode)
 	return matches, stale, err
 }
 
-func registeredRigBindingsByNameWithDeferredLoadError(name string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
-	return registeredRigBindings(failOnLoadError, func(binding registeredRigBinding) bool {
+func registeredRigBindingsByNameWithDeferredLoadError(name string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
+	return registeredRigBindings(failOnLoadError, mode, func(binding registeredRigBinding) bool {
 		return binding.Rig.Name == name
 	})
 }
 
-func registeredRigBindingsByPath(dir string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
-	matches, stale, err, _ = registeredRigBindingsByPathWithDeferredLoadError(dir, failOnLoadError)
+func registeredRigBindingsByPath(dir string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
+	matches, stale, err, _ = registeredRigBindingsByPathWithDeferredLoadError(dir, failOnLoadError, mode)
 	return matches, stale, err
 }
 
-func registeredRigBindingsByPathWithDeferredLoadError(dir string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
+func registeredRigBindingsByPathWithDeferredLoadError(dir string, failOnLoadError bool, mode contextResolutionMode) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
 	dir = normalizePathForCompare(dir)
-	matches, stale, err, deferredLoadErr = registeredRigBindings(failOnLoadError, func(binding registeredRigBinding) bool {
+	matches, stale, err, deferredLoadErr = registeredRigBindings(failOnLoadError, mode, func(binding registeredRigBinding) bool {
 		rigPath := normalizePathForCompare(binding.Path)
 		return pathWithinScope(dir, rigPath)
 	})
@@ -1087,7 +1164,7 @@ func emitStaleRegisteredCityWarnings(w io.Writer, stale []staleRegisteredCity) {
 	}
 }
 
-func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding) bool) (_ []registeredRigBinding, stale []staleRegisteredCity, _ error, deferredLoadErr error) {
+func registeredRigBindings(failOnLoadError bool, mode contextResolutionMode, match func(registeredRigBinding) bool) (_ []registeredRigBinding, stale []staleRegisteredCity, _ error, deferredLoadErr error) {
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
 	cities, err := reg.List()
 	if err != nil {
@@ -1096,8 +1173,26 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 	var matched []registeredRigBinding
 	var loadErrors []string
 	for _, c := range cities {
-		cfg, err := loadCityConfig(c.Path, io.Discard)
+		siteBinding, siteErr := config.LoadSiteBinding(fsys.OSFS{}, c.Path)
+		// An advisory scan skips the config load for cities that cannot
+		// contribute an answer. site.toml names a superset of the rigs
+		// siteBoundRigBindings keeps — it records where a rig lives, not
+		// whether city.toml still declares it — so a city with no candidate
+		// here has none after pruning either. Cities that do have a candidate
+		// are loaded and pruned exactly as an authoritative scan would, which
+		// is what keeps advisory resolution from ever selecting a city an
+		// authoritative resolution would have rejected.
+		if mode.advisory && siteErr == nil && !siteBindingHasCandidate(c, siteBinding, match) {
+			continue
+		}
+		cfg, err := loadRegisteredCityConfig(c.Path, mode)
 		if err != nil {
+			// A busy repo cache is the one failure an advisory scan must not
+			// absorb: quietly skipping the city would let resolution settle on
+			// a different one purely because a clone happened to be running.
+			if errors.Is(err, config.ErrRepoCacheBusy) {
+				return nil, stale, fmt.Errorf("loading registered city rig bindings: %s: %w", registeredCityLabel(c), err), nil
+			}
 			// Tolerate stale registry entries whose city.toml has been
 			// deleted out from under the registry, but keep missing includes
 			// or other config dependencies as load errors.
@@ -1108,9 +1203,8 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 			loadErrors = append(loadErrors, registeredCityLoadError(c, err))
 			continue
 		}
-		siteBinding, err := config.LoadSiteBinding(fsys.OSFS{}, c.Path)
-		if err != nil {
-			loadErrors = append(loadErrors, registeredCityLoadError(c, err))
+		if siteErr != nil {
+			loadErrors = append(loadErrors, registeredCityLoadError(c, siteErr))
 			continue
 		}
 		for _, binding := range siteBoundRigBindings(c, cfg, siteBinding) {
@@ -1126,6 +1220,39 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 		return matched, stale, nil, fmt.Errorf("loading registered city rig bindings: %s", strings.Join(loadErrors, "; "))
 	}
 	return matched, stale, nil, nil
+}
+
+// siteBindingHasCandidate reports whether any machine-local binding in the
+// city's .gc/site.toml could satisfy match. It is a pre-filter, not an answer:
+// site.toml records where a rig lives, not whether city.toml still declares it,
+// so a candidate here is only a reason to load the config and check properly.
+func siteBindingHasCandidate(city supervisor.CityEntry, siteBinding *config.SiteBinding, match func(registeredRigBinding) bool) bool {
+	for _, rig := range siteBinding.Rigs {
+		name := strings.TrimSpace(rig.Name)
+		path := strings.TrimSpace(rig.Path)
+		if name == "" || path == "" {
+			continue
+		}
+		if match(registeredRigBinding{
+			City: city,
+			Rig:  config.Rig{Name: name, Path: path},
+			Path: resolveStoreScopeRoot(city.Path, path),
+		}) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadRegisteredCityConfig loads one registered city's config for a rig-binding
+// scan. An advisory scan refuses to wait on the repo-cache lock, and takes
+// builtin packs as they already are on disk — the same staleness window shell
+// completion has always accepted.
+func loadRegisteredCityConfig(cityPath string, mode contextResolutionMode) (*config.City, error) {
+	if mode.advisory {
+		return loadCityConfigAdvisory(cityPath)
+	}
+	return loadCityConfig(cityPath, io.Discard)
 }
 
 func registeredCityLoadError(city supervisor.CityEntry, err error) string {

--- a/cmd/gc/pack_command_discovery_lock_test.go
+++ b/cmd/gc/pack_command_discovery_lock_test.go
@@ -180,23 +180,18 @@ func TestCompletionCandidatesDoNotWaitOnHeldRepoCacheLock(t *testing.T) {
 // `gc <cmd> --rig <TAB>` resolves the rig before it can list anything, which
 // reaches the registry scan rather than the city load the other completion
 // paths take.
+//
+// It asserts the busy error rather than only the timing. Returning promptly is
+// half the contract; the other half is refusing to answer, and a resolution
+// that swallowed the busy error would return promptly too — from whichever
+// city it could still reach.
 func TestCompletionRigFlagResolutionDoesNotWaitOnHeldRepoCacheLock(t *testing.T) {
 	cityPath, cacheRoot := setupDiscoveryLockCity(t)
 	registerRigInSiteBinding(t, cityPath, "hauler")
 	rigFlag = "hauler"
 	holdExclusiveRepoCacheLock(t, cacheRoot)
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		resolveCityForCompletion() //nolint:errcheck // only the timing matters
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("completion rig-flag resolution blocked on a held repo-cache lock")
-	}
+	assertFailsClosedPromptly(t, "completion rig-flag resolution", resolveCityForCompletion)
 }
 
 // Running gc from inside a rig directory is the ordinary way to use it, and it
@@ -209,16 +204,31 @@ func TestCwdRigDiscoveryDoesNotWaitOnHeldRepoCacheLock(t *testing.T) {
 	t.Chdir(rigDir)
 	holdExclusiveRepoCacheLock(t, cacheRoot)
 
-	done := make(chan struct{})
+	assertFailsClosedPromptly(t, "cwd rig discovery", resolveCityForDiscovery)
+}
+
+// assertFailsClosedPromptly runs resolve off the test goroutine — the point is
+// that it might block — and requires it to both return quickly and report the
+// busy cache rather than an answer it reached by skipping the busy city.
+func assertFailsClosedPromptly(t *testing.T, what string, resolve func() (string, error)) {
+	t.Helper()
+	type result struct {
+		city string
+		err  error
+	}
+	done := make(chan result, 1)
 	go func() {
-		defer close(done)
-		resolveCityForDiscovery() //nolint:errcheck // only the timing matters
+		city, err := resolve()
+		done <- result{city, err}
 	}()
 
 	select {
-	case <-done:
+	case got := <-done:
+		if !errors.Is(got.err, config.ErrRepoCacheBusy) {
+			t.Fatalf("%s: err = %v, want config.ErrRepoCacheBusy (city %q)", what, got.err, got.city)
+		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("cwd rig discovery blocked on a held repo-cache lock")
+		t.Fatalf("%s blocked on a held repo-cache lock", what)
 	}
 }
 
@@ -290,6 +300,113 @@ func TestAdvisoryRigLookupPrunesSiteOnlyBindingsLikeAuthoritative(t *testing.T) 
 				}
 			})
 		}
+	}
+}
+
+// The sticky default is the tier below local discovery, so a local discovery
+// that could not look is the one case where falling through changes the answer
+// rather than supplying a missing one: the same cwd resolves to a remote city
+// while another terminal happens to be cloning, and to the local one a moment
+// later.
+func TestBusyRepoCacheDoesNotFallThroughToTheStickyDefault(t *testing.T) {
+	cityPath, cacheRoot := setupDiscoveryLockCity(t)
+	rigDir := registerRigInSiteBinding(t, cityPath, "hauler")
+	declareRigInCityTOML(t, cityPath, "hauler")
+	t.Setenv("GC_CITY", "")
+	t.Chdir(rigDir)
+	writeStickyDefaultContext(t)
+
+	// The control: without contention this resolves locally, so the assertion
+	// below is about the busy cache and not about an unreachable sticky tier.
+	if ctx, err := resolveContextAllowRemoteMode(authoritativeResolution); err != nil || ctx.Remote != nil {
+		t.Fatalf("uncontended resolve = %+v, err %v; want the local city", ctx, err)
+	}
+
+	release := holdExclusiveRepoCacheLock(t, cacheRoot)
+	defer release()
+
+	ctx, err := resolveContextAllowRemoteMode(completionResolutionMode)
+	if !errors.Is(err, config.ErrRepoCacheBusy) {
+		t.Fatalf("err = %v, want config.ErrRepoCacheBusy (resolved %+v)", err, ctx)
+	}
+	if ctx.Remote != nil {
+		t.Fatalf("busy local discovery fell through to remote %+v", ctx.Remote)
+	}
+}
+
+// writeStickyDefaultContext registers a remote context and makes it the sticky
+// default, so a local resolution that gives up has somewhere else to land.
+func writeStickyDefaultContext(t *testing.T) {
+	t.Helper()
+	body := "default = \"prod\"\n\n[[context]]\nname = \"prod\"\nurl = \"https://box.internal:9443\"\ncity = \"example-city\"\n"
+	if err := os.WriteFile(DefaultPath(), []byte(body), 0o600); err != nil {
+		t.Fatalf("writing contexts.toml: %v", err)
+	}
+}
+
+// Whether a registered city that cannot contribute a match still affects the
+// scan is settled by failOnLoadError alone. It must never depend on the
+// resolution mode: eager discovery captures the city it picks into the
+// pack-command closures the user later runs, so an advisory answer that
+// differs from the authoritative one is a wrong city, not a stale one.
+//
+// The unmatchable city is broken rather than merely irrelevant because that is
+// the only way its presence is observable at all: a healthy city that cannot
+// match contributes nothing to any scan. Broken, it makes the two axes visible
+// — a match-only scan skips it before loading, and a scan asked to report load
+// errors loads it and fails — and this asserts both modes agree on which.
+func TestRigLookupTreatsUnmatchableBrokenCityTheSameInBothModes(t *testing.T) {
+	cityPath, _ := setupDiscoveryLockCity(t)
+	registerRigInSiteBinding(t, cityPath, "hauler")
+	declareRigInCityTOML(t, cityPath, "hauler")
+	registerUnloadableCity(t, filepath.Join(filepath.Dir(cityPath), "broken"))
+
+	for _, scan := range []struct {
+		name            string
+		failOnLoadError bool
+		wantMatches     int
+		wantErr         bool
+	}{
+		// Match-only: the broken city cannot match, so it is skipped unread.
+		{name: "match-only", failOnLoadError: false, wantMatches: 1},
+		// Diagnostics requested: the broken city is exactly what was asked
+		// about, so it is loaded and its failure is the answer.
+		{name: "report-load-errors", failOnLoadError: true, wantErr: true},
+	} {
+		for _, mode := range []struct {
+			name string
+			mode contextResolutionMode
+		}{
+			{"advisory", completionResolutionMode},
+			{"authoritative", authoritativeResolution},
+		} {
+			t.Run(scan.name+"/"+mode.name, func(t *testing.T) {
+				matches, _, err := registeredRigBindingsByName("hauler", scan.failOnLoadError, mode.mode)
+				if gotErr := err != nil; gotErr != scan.wantErr {
+					t.Fatalf("rig lookup err = %v, want error: %v", err, scan.wantErr)
+				}
+				if len(matches) != scan.wantMatches {
+					t.Fatalf("rig %q resolved to %d bindings, want %d", "hauler", len(matches), scan.wantMatches)
+				}
+			})
+		}
+	}
+}
+
+// registerUnloadableCity registers a city whose city.toml is present but
+// unparseable, and which binds no rigs at all. Present-but-broken matters:
+// a missing city.toml is reported as a stale registry entry instead, which the
+// scan tolerates.
+func registerUnloadableCity(t *testing.T, cityPath string) {
+	t.Helper()
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace\nname = \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "discovery-lock-broken"); err != nil {
+		t.Fatalf("registering broken city: %v", err)
 	}
 }
 

--- a/cmd/gc/pack_command_discovery_lock_test.go
+++ b/cmd/gc/pack_command_discovery_lock_test.go
@@ -1,0 +1,338 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/builtinpacks"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/supervisor"
+	"github.com/spf13/cobra"
+)
+
+// setupDiscoveryLockCity builds a city that imports a bundled pack under a
+// private, cold GC_HOME, and returns the city path plus its repo-cache root.
+// Resolving that import hydrates the pack's synthetic repo cache under the
+// repo-cache write lock, which is what puts an ordinary config load in
+// contention with a concurrent `gc import install`.
+//
+// The cache is deliberately left cold: a hydrated cache short-circuits ahead
+// of the lock (ValidateSyntheticRepoFast), so warming the fixture would make
+// every assertion below vacuous.
+func setupDiscoveryLockCity(t *testing.T) (cityPath, cacheRoot string) {
+	t.Helper()
+	source, ok := builtinpacks.Source("core")
+	if !ok {
+		t.Fatal("no bundled source for the core pack")
+	}
+	config.ResetRemoteCacheValidationCache()
+	t.Cleanup(config.ResetRemoteCacheValidationCache)
+
+	base := t.TempDir()
+	// GC_HOME deliberately sits outside HOME: supervisor.Registry panics on any
+	// test write under $HOME/.gc, and this fixture registers a city.
+	gcHome := filepath.Join(base, "gchome")
+	t.Setenv("HOME", filepath.Join(base, "home"))
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath = filepath.Join(base, "city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityTOML := fmt.Sprintf("[workspace]\nname = \"discovery-lock\"\n\n[imports.core]\nsource = %q\n", source)
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Test binaries refuse the ambient upward city walk, so name the city
+	// explicitly instead of relying on cwd.
+	t.Setenv("GC_CITY", cityPath)
+	t.Setenv("GC_DIR", "")
+	t.Setenv("GC_RIG", "")
+	// These are package globals, not env: a value left behind by another test
+	// would divert resolution before it ever reaches the lock, and no assertion
+	// below would notice.
+	restoreFlag(t, &cityFlag)
+	restoreFlag(t, &rigFlag)
+
+	cacheRoot = filepath.Join(gcHome, "cache", "repos")
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return cityPath, cacheRoot
+}
+
+func restoreFlag(t *testing.T, flag *string) {
+	t.Helper()
+	prev := *flag
+	*flag = ""
+	t.Cleanup(func() { *flag = prev })
+}
+
+// holdExclusiveRepoCacheLock takes the repo-cache lock the way a `gc import
+// install` holds it for the whole of its network clone. The returned release
+// is idempotent; tests that leave a goroutine blocked on the lock must call it
+// and then join, since a goroutine woken during t.TempDir's cleanup races the
+// directory removal.
+func holdExclusiveRepoCacheLock(t *testing.T, cacheRoot string) (release func()) {
+	t.Helper()
+	lockFile, err := os.OpenFile(filepath.Join(cacheRoot, ".packman-cache.lock"), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open repo cache lock: %v", err)
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		lockFile.Close() //nolint:errcheck
+		t.Fatalf("flock: %v", err)
+	}
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+			lockFile.Close()                                   //nolint:errcheck
+		})
+	}
+	t.Cleanup(release)
+	return release
+}
+
+// The control, and the reason this file exists: a blocking city load really
+// does queue behind a held repo-cache lock. Eager pack-command discovery runs
+// on every gc invocation, so before ga-r0epd one `gc import install` clone
+// stalled every other gc command on the machine for its whole duration.
+//
+// It loads through loadCityConfigWithoutBuiltinPackRefresh, the blocking twin
+// of loadCityConfigAdvisory: the two differ in exactly the one bit under test.
+// A loader that refreshes builtin packs would instead block in the
+// always-required builtin-ensure step, which every city reaches whatever its
+// city.toml declares — so it would stay green even if the fixture stopped
+// importing anything, and the assertions below would go quietly vacuous.
+func TestBlockingCityLoadWaitsOnHeldRepoCacheLock(t *testing.T) {
+	cityPath, cacheRoot := setupDiscoveryLockCity(t)
+	release := holdExclusiveRepoCacheLock(t, cacheRoot)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard) //nolint:errcheck // only the timing matters
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("blocking city load returned while the repo-cache lock was held; " +
+			"the fixture no longer reaches the lock, so the advisory assertions in this file prove nothing")
+	case <-time.After(500 * time.Millisecond):
+	}
+	// Join before the tempdir cleanup: the woken load writes into the city.
+	release()
+	<-done
+}
+
+func TestRegisterPackCommandsDoesNotWaitOnHeldRepoCacheLock(t *testing.T) {
+	_, cacheRoot := setupDiscoveryLockCity(t)
+	holdExclusiveRepoCacheLock(t, cacheRoot)
+
+	root := &cobra.Command{Use: "gc"}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		registerPackCommands(root, nil, io.Discard, io.Discard)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("eager pack-command discovery blocked on a held repo-cache lock")
+	}
+}
+
+// Completion runs on a <TAB> keystroke, so a blocking load there stalls the
+// user's shell rather than a command they submitted.
+func TestCompletionCandidatesDoNotWaitOnHeldRepoCacheLock(t *testing.T) {
+	_, cacheRoot := setupDiscoveryLockCity(t)
+	holdExclusiveRepoCacheLock(t, cacheRoot)
+
+	// loadSessionsForCompletion is deliberately absent: it opens the city store
+	// first, and the store open loads config blockingly and readies builtin
+	// packs, which is a second way into the same lock that this change does not
+	// address. Tracked separately rather than left looking covered.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rigNameCandidates("")
+		loadOrdersForCompletion()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("completion candidates blocked on a held repo-cache lock")
+	}
+}
+
+// `gc <cmd> --rig <TAB>` resolves the rig before it can list anything, which
+// reaches the registry scan rather than the city load the other completion
+// paths take.
+func TestCompletionRigFlagResolutionDoesNotWaitOnHeldRepoCacheLock(t *testing.T) {
+	cityPath, cacheRoot := setupDiscoveryLockCity(t)
+	registerRigInSiteBinding(t, cityPath, "hauler")
+	rigFlag = "hauler"
+	holdExclusiveRepoCacheLock(t, cacheRoot)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		resolveCityForCompletion() //nolint:errcheck // only the timing matters
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("completion rig-flag resolution blocked on a held repo-cache lock")
+	}
+}
+
+// Running gc from inside a rig directory is the ordinary way to use it, and it
+// resolves through the registered-binding lookup rather than GC_CITY. That
+// step carries its own resolution mode, so it needs its own guard.
+func TestCwdRigDiscoveryDoesNotWaitOnHeldRepoCacheLock(t *testing.T) {
+	cityPath, cacheRoot := setupDiscoveryLockCity(t)
+	rigDir := registerRigInSiteBinding(t, cityPath, "hauler")
+	t.Setenv("GC_CITY", "")
+	t.Chdir(rigDir)
+	holdExclusiveRepoCacheLock(t, cacheRoot)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		resolveCityForDiscovery() //nolint:errcheck // only the timing matters
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cwd rig discovery blocked on a held repo-cache lock")
+	}
+}
+
+// Refusing to wait is only half of it. An advisory scan must also refuse to
+// answer from whatever it could reach without waiting: silently skipping the
+// busy city would let resolution settle on a different one, and eager
+// discovery captures the city it picks into the pack-command closures the user
+// later runs.
+func TestAdvisoryRigLookupFailsClosedOnBusyRepoCache(t *testing.T) {
+	cityPath, cacheRoot := setupDiscoveryLockCity(t)
+	registerRigInSiteBinding(t, cityPath, "hauler")
+	holdExclusiveRepoCacheLock(t, cacheRoot)
+
+	type result struct {
+		matches []registeredRigBinding
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		matches, _, err := registeredRigBindingsByName("hauler", false, completionResolutionMode)
+		done <- result{matches, err}
+	}()
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, config.ErrRepoCacheBusy) {
+			t.Fatalf("advisory rig lookup err = %v, want config.ErrRepoCacheBusy", got.err)
+		}
+		if len(got.matches) != 0 {
+			t.Fatalf("advisory rig lookup returned %d matches alongside a busy cache, want none", len(got.matches))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("advisory rig lookup blocked on a held repo-cache lock")
+	}
+}
+
+// An advisory scan reads .gc/site.toml to decide which cities are worth
+// loading, but site.toml records only where a rig lives — not whether the city
+// still declares it. Answering from site.toml alone would resurrect a rig that
+// an authoritative resolution prunes, and hand eager discovery a city the user
+// is not in.
+func TestAdvisoryRigLookupPrunesSiteOnlyBindingsLikeAuthoritative(t *testing.T) {
+	cityPath, _ := setupDiscoveryLockCity(t)
+	registerRigInSiteBinding(t, cityPath, "hauler")
+	registerRigInSiteBinding(t, cityPath, "ghost")
+	declareRigInCityTOML(t, cityPath, "hauler")
+
+	for _, tc := range []struct {
+		rig  string
+		want int
+	}{
+		{rig: "hauler", want: 1}, // declared and bound: the control
+		{rig: "ghost", want: 0},  // bound but no longer declared
+	} {
+		for _, mode := range []struct {
+			name string
+			mode contextResolutionMode
+		}{
+			{"advisory", completionResolutionMode},
+			{"authoritative", authoritativeResolution},
+		} {
+			t.Run(tc.rig+"/"+mode.name, func(t *testing.T) {
+				matches, _, err := registeredRigBindingsByName(tc.rig, false, mode.mode)
+				if err != nil {
+					t.Fatalf("rig lookup: %v", err)
+				}
+				if len(matches) != tc.want {
+					t.Fatalf("rig %q resolved to %d bindings, want %d", tc.rig, len(matches), tc.want)
+				}
+			})
+		}
+	}
+}
+
+// registerRigInSiteBinding registers cityPath with the supervisor so the
+// registry scan visits it, and binds one rig name to a machine-local path in
+// .gc/site.toml. It returns the rig directory.
+func registerRigInSiteBinding(t *testing.T, cityPath, rigName string) string {
+	t.Helper()
+	// Registering the same path under the same name twice is idempotent, so
+	// callers may bind more than one rig.
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "discovery-lock"); err != nil {
+		t.Fatalf("registering city: %v", err)
+	}
+	rigPath := filepath.Join(cityPath, "rigs", rigName)
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sitePath := config.SiteBindingPath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(sitePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(sitePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+	if _, err := fmt.Fprintf(f, "[[rig]]\nname = %q\npath = %q\n\n", rigName, rigPath); err != nil {
+		t.Fatal(err)
+	}
+	return rigPath
+}
+
+// declareRigInCityTOML adds the [[rigs]] declaration that turns a machine-local
+// site binding into a rig the city actually has. The path here is the legacy
+// one the site binding overrides; only the name decides whether the rig exists.
+func declareRigInCityTOML(t *testing.T, cityPath, rigName string) {
+	t.Helper()
+	f, err := os.OpenFile(filepath.Join(cityPath, "city.toml"), os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+	if _, err := fmt.Fprintf(f, "\n[[rigs]]\nname = %q\npath = %q\n", rigName, filepath.Join(cityPath, "rigs", rigName)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/gc/productmetrics_controls_process_testhook_test.go
+++ b/cmd/gc/productmetrics_controls_process_testhook_test.go
@@ -135,7 +135,20 @@ func runProductMetricsTaggedControlFlow(t *testing.T, binary, workingDir, home s
 	if _, err := os.Stat(productUsageRoot); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("non-TTY metrics on created product state: %v", err)
 	}
-	ordinaryWorkingDir := filepath.Join(t.TempDir(), privacySentinel)
+	// Ordinary help must run from inside a real city, because a city is what
+	// makes it load pack state at all. Without one, findCity's walk-up decides
+	// what this subtest exercises: on a host with a stray /tmp/city.toml it
+	// resolves that and takes the repo-cache lock, and on a clean host it
+	// resolves nothing and never locks — the same test asserting two different
+	// things. configureProductMetricsTrustedProcessTempRoot pins TMPDIR to /tmp
+	// deliberately (product metrics reject a user-owned writable ancestor), so
+	// this fixture cannot move off the shared root; it has to out-rank it. A
+	// city.toml one level up is nearer than /tmp, so the walk-up stops here.
+	ordinaryCityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ordinaryCityDir, "city.toml"), []byte("[workspace]\nname = \"ordinary-help\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ordinaryWorkingDir := filepath.Join(ordinaryCityDir, privacySentinel)
 	if err := os.MkdirAll(ordinaryWorkingDir, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1389,7 +1389,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 	t.Run("rig_not_registered_anywhere", func(t *testing.T) {
 		t.Setenv("GC_HOME", t.TempDir())
 
-		_, err := resolveRigToContext("nonexistent-rig")
+		_, err := resolveRigToContext("nonexistent-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should fail for unregistered rig")
 		}
@@ -1410,7 +1410,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 
 		registerRigBindingForResolution(t, gcHome, cityPath, "ctx-city", "ctx-rig", rigDir)
 
-		ctx, err := resolveRigToContext("ctx-rig")
+		ctx, err := resolveRigToContext("ctx-rig", contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext error: %v", err)
 		}
@@ -1437,7 +1437,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 		registerCityForRigResolution(t, gcHome, badCity, "bad-city")
 
-		_, err := resolveRigToContext("ctx-rig")
+		_, err := resolveRigToContext("ctx-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should fail when any registered city binding cannot load")
 		}
@@ -1461,7 +1461,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 
 		registerRigBindingForResolution(t, gcHome, cityPath, "path-city", "path-rig", rigDir)
 
-		ctx, err := resolveRigToContext(rigDir)
+		ctx, err := resolveRigToContext(rigDir, contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext error: %v", err)
 		}
@@ -1492,7 +1492,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 		registerCityForRigResolution(t, gcHome, cityPath, "legacy-city")
 
-		_, err := resolveRigToContext("legacy-rig")
+		_, err := resolveRigToContext("legacy-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should not treat legacy city.toml paths as registered bindings")
 		}
@@ -1526,7 +1526,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		writeRigAnywhereCityToml(t, cityPath, toml)
 		setCwd(t, cityPath)
 
-		ctx, err := resolveRigToContext("local-rig")
+		ctx, err := resolveRigToContext("local-rig", contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1560,7 +1560,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		writeRigAnywhereCityToml(t, cityPath, toml)
 		setCwd(t, cityPath)
 
-		ctx, err := resolveRigToContext("local-load-error-rig")
+		ctx, err := resolveRigToContext("local-load-error-rig", contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1595,7 +1595,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		writeRigAnywhereCityToml(t, cityPath, toml)
 		setCwd(t, cityPath)
 
-		ctx, err := resolveRigToContext(nestedDir)
+		ctx, err := resolveRigToContext(nestedDir, contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1629,7 +1629,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		writeRigAnywhereCityToml(t, cityPath, toml)
 		setCwd(t, cityPath)
 
-		_, err := resolveRigToContext("missing-rig")
+		_, err := resolveRigToContext("missing-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should preserve registered load errors when local fallback misses")
 		}
@@ -1660,7 +1660,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, t.TempDir())
 		cityFlag = cityPath
 
-		ctx, err := resolveRigToContext(nestedDir)
+		ctx, err := resolveRigToContext(nestedDir, contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1689,7 +1689,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, t.TempDir())
 		cityFlag = cityPath
 
-		ctx, err := resolveRigToContext(targetDir)
+		ctx, err := resolveRigToContext(targetDir, contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1717,7 +1717,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, cityPath)
 		cityFlag = cityPath
 
-		ctx, err := resolveRigToContext(filepath.Join("rigs", "relative-rig", "child"))
+		ctx, err := resolveRigToContext(filepath.Join("rigs", "relative-rig", "child"), contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1745,7 +1745,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, t.TempDir())
 		cityFlag = cityPath
 
-		_, err := resolveRigToContext("stale-rig")
+		_, err := resolveRigToContext("stale-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should reject site-only rig bindings not declared in city.toml")
 		}
@@ -1766,7 +1766,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, t.TempDir())
 		cityFlag = cityPath
 
-		_, err := resolveRigToContext("broken")
+		_, err := resolveRigToContext("broken", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should surface malformed local site binding")
 		}
@@ -1790,7 +1790,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, t.TempDir())
 		cityFlag = cityPath
 
-		ctx, err := resolveRigToContext("local-flag-rig")
+		ctx, err := resolveRigToContext("local-flag-rig", contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1809,7 +1809,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		setCwd(t, t.TempDir())
 		cityFlag = filepath.Join(t.TempDir(), "not-a-city")
 
-		_, err := resolveRigToContext("missing-rig")
+		_, err := resolveRigToContext("missing-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should surface explicit local city errors")
 		}
@@ -1839,7 +1839,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		t.Setenv("GC_CITY_ROOT", "")
 		t.Setenv("GC_DIR", "")
 
-		ctx, err := resolveRigToContext("local-env-rig")
+		ctx, err := resolveRigToContext("local-env-rig", contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1870,7 +1870,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		t.Setenv("GC_CITY_ROOT", "")
 		t.Setenv("GC_DIR", nestedDir)
 
-		ctx, err := resolveRigToContext("local-gc-dir-rig")
+		ctx, err := resolveRigToContext("local-gc-dir-rig", contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("resolveRigToContext: %v", err)
 		}
@@ -1905,7 +1905,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 		setCwd(t, cityPath)
 
-		_, err := resolveRigToContext("local-legacy-rig")
+		_, err := resolveRigToContext("local-legacy-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("resolveRigToContext should reject a legacy city.toml even via the local-city fallback")
 		}
@@ -2043,7 +2043,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		// data; callers decide whether to emit a user-facing warning. This
 		// asserts the diagnostic is available without coupling the test to
 		// a particular stderr routing scheme.
-		_, stale, err := registeredRigBindingsByPath(rigDir, true)
+		_, stale, err := registeredRigBindingsByPath(rigDir, true, contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("registeredRigBindingsByPath error: %v", err)
 		}
@@ -2105,7 +2105,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 		assertSameTestPath(t, ctx.CityPath, goodCity)
 
-		_, stale, err := registeredRigBindingsByPath(rigDir, true)
+		_, stale, err := registeredRigBindingsByPath(rigDir, true, contextResolutionMode{})
 		if err != nil {
 			t.Fatalf("registeredRigBindingsByPath error: %v", err)
 		}
@@ -2143,7 +2143,7 @@ name = "missing-include-broken"
 		}
 		registerCityForRigResolution(t, gcHome, brokenCity, "missing-include-broken")
 
-		_, stale, err := registeredRigBindingsByPath(rigDir, true)
+		_, stale, err := registeredRigBindingsByPath(rigDir, true, contextResolutionMode{})
 		if err == nil {
 			t.Fatal("registeredRigBindingsByPath should fail closed on missing include")
 		}
@@ -2197,7 +2197,7 @@ includes = ["packs/legacy"]
 		}
 		registerCityForRigResolution(t, gcHome, brokenCity, "legacy-order-broken")
 
-		_, stale, err := registeredRigBindingsByPath(rigDir, true)
+		_, stale, err := registeredRigBindingsByPath(rigDir, true, contextResolutionMode{})
 		if err == nil {
 			t.Fatal("registeredRigBindingsByPath should fail closed on legacy order layout")
 		}
@@ -2247,7 +2247,7 @@ includes = ["packs/legacy"]
 		}
 		registerCityForRigResolution(t, gcHome, badCity, "path-stale-error-bad")
 
-		_, stale, err := registeredRigBindingsByPath(rigDir, true)
+		_, stale, err := registeredRigBindingsByPath(rigDir, true, contextResolutionMode{})
 		if err == nil {
 			t.Fatal("registeredRigBindingsByPath should fail closed on the malformed site binding")
 		}
@@ -2306,7 +2306,7 @@ includes = ["packs/legacy"]
 		registerCityForRigResolution(t, gcHome, city1, "city1")
 		registerCityForRigResolution(t, gcHome, city2, "city2")
 
-		_, err := resolveRigToContext("ambig-rig")
+		_, err := resolveRigToContext("ambig-rig", contextResolutionMode{})
 		if err == nil {
 			t.Fatal("should fail for ambiguous rig")
 		}
@@ -2337,7 +2337,10 @@ func TestRigAnywhere_LookupRigFromCwd(t *testing.T) {
 
 		registerRigBindingForResolution(t, gcHome, cityPath, "lookup-city", "lookup-rig", rigDir)
 
-		ctx, ok := lookupRigFromCwd(rigDir)
+		ctx, ok, err := lookupRigFromCwd(rigDir, contextResolutionMode{})
+		if err != nil {
+			t.Fatalf("lookupRigFromCwd: %v", err)
+		}
 		if !ok {
 			t.Fatal("expected match")
 		}
@@ -2360,7 +2363,10 @@ func TestRigAnywhere_LookupRigFromCwd(t *testing.T) {
 
 		registerRigBindingForResolution(t, gcHome, cityPath, "sub-city", "sub-rig", rigDir)
 
-		ctx, ok := lookupRigFromCwd(subDir)
+		ctx, ok, err := lookupRigFromCwd(subDir, contextResolutionMode{})
+		if err != nil {
+			t.Fatalf("lookupRigFromCwd: %v", err)
+		}
 		if !ok {
 			t.Fatal("expected match for subdirectory")
 		}
@@ -2372,7 +2378,7 @@ func TestRigAnywhere_LookupRigFromCwd(t *testing.T) {
 	t.Run("no_match", func(t *testing.T) {
 		t.Setenv("GC_HOME", t.TempDir())
 
-		_, ok := lookupRigFromCwd("/completely/unrelated/path")
+		_, ok, _ := lookupRigFromCwd("/completely/unrelated/path", contextResolutionMode{})
 		if ok {
 			t.Error("expected no match for unrelated path")
 		}
@@ -2394,7 +2400,7 @@ func TestRigAnywhere_LookupRigFromCwd(t *testing.T) {
 		registerCityForRigResolution(t, gcHome, cityA, "ambig-cwd-a")
 		registerCityForRigResolution(t, gcHome, cityB, "ambig-cwd-b")
 
-		_, ok := lookupRigFromCwd(rigDir)
+		_, ok, _ := lookupRigFromCwd(rigDir, contextResolutionMode{})
 		if ok {
 			t.Error("expected false for ambiguous rig binding")
 		}
@@ -2417,7 +2423,7 @@ func TestRigAnywhere_LookupRigFromCwd(t *testing.T) {
 		}
 		registerCityForRigResolution(t, gcHome, badCity, "lookup-bad")
 
-		_, ok := lookupRigFromCwd(rigDir)
+		_, ok, _ := lookupRigFromCwd(rigDir, contextResolutionMode{})
 		if ok {
 			t.Fatal("lookupRigFromCwd should not choose a match when another registered city cannot load")
 		}
@@ -2438,7 +2444,7 @@ func TestRigAnywhere_RigFromCwdDir(t *testing.T) {
 		toml := "[workspace]\nname = \"cwd-match\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"matchrig\"\npath = \"" + rigDir + "\"\n"
 		writeRigAnywhereCityToml(t, cityPath, toml)
 
-		got := rigFromCwdDir(cityPath, rigDir)
+		got := rigFromCwdDir(cityPath, rigDir, contextResolutionMode{})
 		if got != "matchrig" {
 			t.Errorf("rigFromCwdDir = %q, want %q", got, "matchrig")
 		}
@@ -2454,7 +2460,7 @@ func TestRigAnywhere_RigFromCwdDir(t *testing.T) {
 		toml := "[workspace]\nname = \"cwd-sub\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"subrig\"\npath = \"" + rigDir + "\"\n"
 		writeRigAnywhereCityToml(t, cityPath, toml)
 
-		got := rigFromCwdDir(cityPath, subDir)
+		got := rigFromCwdDir(cityPath, subDir, contextResolutionMode{})
 		if got != "subrig" {
 			t.Errorf("rigFromCwdDir = %q, want %q", got, "subrig")
 		}
@@ -2462,7 +2468,7 @@ func TestRigAnywhere_RigFromCwdDir(t *testing.T) {
 
 	t.Run("no_match_returns_empty", func(t *testing.T) {
 		cityPath := setupCity(t, "cwd-nomatch")
-		got := rigFromCwdDir(cityPath, "/unrelated/path")
+		got := rigFromCwdDir(cityPath, "/unrelated/path", contextResolutionMode{})
 		if got != "" {
 			t.Errorf("rigFromCwdDir = %q, want empty", got)
 		}
@@ -2479,7 +2485,7 @@ func TestRigAnywhere_RigFromCwdDir(t *testing.T) {
 		toml := "[workspace]\nname = \"cwd-rel\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"relrig\"\npath = \"rigs/relrig\"\n"
 		writeRigAnywhereCityToml(t, cityPath, toml)
 
-		got := rigFromCwdDir(cityPath, rigDir)
+		got := rigFromCwdDir(cityPath, rigDir, contextResolutionMode{})
 		if got != "relrig" {
 			t.Errorf("rigFromCwdDir with relative path = %q, want %q", got, "relrig")
 		}
@@ -2491,7 +2497,7 @@ func TestRigAnywhere_RigFromCwdDir(t *testing.T) {
 		toml := "[workspace]\nname = \"cwd-symlink\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"aliasrig\"\npath = \"" + rigDir + "\"\n"
 		writeRigAnywhereCityToml(t, cityPath, toml)
 
-		got := rigFromCwdDir(cityPath, filepath.Join(aliasRigDir, "src"))
+		got := rigFromCwdDir(cityPath, filepath.Join(aliasRigDir, "src"), contextResolutionMode{})
 		if got != "aliasrig" {
 			t.Errorf("rigFromCwdDir via symlink alias = %q, want %q", got, "aliasrig")
 		}

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -21,7 +21,7 @@ func TestResolveLockedRemoteImportAcceptsBundledSyntheticCache(t *testing.T) {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
-	got, ok, err := resolveLockedRemoteImport(source, cityDir)
+	got, ok, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err != nil {
 		t.Fatalf("resolveLockedRemoteImport: %v", err)
 	}
@@ -53,7 +53,7 @@ name = "tampered"
 schema = 1
 `)
 
-	_, ok, err := resolveLockedRemoteImport(source, cityDir)
+	_, ok, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err != nil {
 		t.Fatalf("fast-path resolution must not reject content drift: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestResolveLockedRemoteImportFastPathToleratesBundledSyntheticExtraFile(t *
 	}
 	writeTestFile(t, cacheDir, "internal/bootstrap/packs/core/agents/injected/prompt.md", "extra file")
 
-	_, ok, err := resolveLockedRemoteImport(source, cityDir)
+	_, ok, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err != nil {
 		t.Fatalf("fast-path resolution must not reject extra files: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestResolveInstalledRemoteImportAcceptsBundledSyntheticCache(t *testing.T) 
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
-	got, err := resolveInstalledRemoteImport(source, "", cityDir)
+	got, err := resolveInstalledRemoteImport(source, "", cityDir, false)
 	if err != nil {
 		t.Fatalf("resolveInstalledRemoteImport: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestResolveImportPackRefAcceptsPublicGastownSyntheticCache(t *testing.T) {
 		t.Fatalf("materialize synthetic repo: %v", err)
 	}
 
-	got, err := resolveImportPackRef(source, "", cityDir, cityDir)
+	got, err := resolveImportPackRef(source, "", cityDir, cityDir, false)
 	if err != nil {
 		t.Fatalf("resolveImportPackRef: %v", err)
 	}
@@ -225,7 +225,7 @@ fetched = "2026-01-01T00:00:00Z"
 	// went to fetchRemoteInclude (which would fail with "not cached at ...").
 	refWithGitRef := source + "#main"
 
-	got, err := resolvePackRef(refWithGitRef, cityDir, cityDir)
+	got, err := resolvePackRef(refWithGitRef, cityDir, cityDir, false)
 	if err != nil {
 		t.Fatalf("resolvePackRef(%q): %v", refWithGitRef, err)
 	}
@@ -247,7 +247,7 @@ commit = "abc123def456abc123def456abc123def456abc123de"
 content_hash = "sha256:deadbeef"
 `)
 
-	_, _, err := resolveLockedRemoteImport(source, cityDir)
+	_, _, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err == nil {
 		t.Fatal("expected invalid marker error")
 	}
@@ -269,7 +269,7 @@ commit = %q
 content_hash = "sha256:deadbeef"
 `, source, commit))
 
-	_, _, err := resolveLockedRemoteImport(source, cityDir)
+	_, _, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err == nil {
 		t.Fatal("expected non-bundled synthetic cache to be rejected")
 	}
@@ -308,7 +308,7 @@ content_hash = "sha256:deadbeef"
 		}
 	}
 
-	_, ok, err := resolveLockedRemoteImport(source, cityDir)
+	_, ok, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err != nil {
 		t.Fatalf("resolveLockedRemoteImport: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestValidateInstalledRemoteCacheRequiresGitForNonCanonicalBundledPin(t *tes
 	writeBundledImportLock(t, cityDir, source, commit)
 	cacheDir := bundledRepoCacheDir(home, source, commit)
 
-	_, _, err := resolveLockedRemoteImport(source, cityDir)
+	_, _, err := resolveLockedRemoteImport(source, cityDir, false)
 	if err == nil {
 		t.Fatal("expected non-canonical bundled pin without cache to fail")
 	}
@@ -480,7 +480,7 @@ func TestResolveInstalledRemoteImportBundledFallbackWithoutLock(t *testing.T) {
 	source := bundledPackSource()
 	commit := strings.TrimPrefix(BundledSourcePinnedVersion(source), "sha:")
 
-	got, err := resolveInstalledRemoteImport(source, "", cityDir)
+	got, err := resolveInstalledRemoteImport(source, "", cityDir, false)
 	if err != nil {
 		t.Fatalf("resolveInstalledRemoteImport without lock: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestResolveInstalledRemoteImportBundledFallbackWithoutLock(t *testing.T) {
 func TestResolveInstalledRemoteImportNonBundledStillRequiresLock(t *testing.T) {
 	_, cityDir := setupBundledImportTest(t)
 
-	_, err := resolveInstalledRemoteImport("https://github.com/example/other.git", "", cityDir)
+	_, err := resolveInstalledRemoteImport("https://github.com/example/other.git", "", cityDir, false)
 	if err == nil || !strings.Contains(err.Error(), "missing packs.lock") {
 		t.Fatalf("err = %v, want missing packs.lock error", err)
 	}
@@ -525,7 +525,7 @@ func TestResolveInstalledRemoteImportLockedBundledSelfHealsWhenCacheAbsent(t *te
 		t.Fatalf("precondition: cache dir should be absent, stat err = %v", err)
 	}
 
-	got, err := resolveInstalledRemoteImport(source, "", cityDir)
+	got, err := resolveInstalledRemoteImport(source, "", cityDir, false)
 	if err != nil {
 		t.Fatalf("resolveInstalledRemoteImport locked+absent bundled cache: %v", err)
 	}
@@ -546,13 +546,13 @@ func TestResolveInstalledRemoteImportRejectsDeclaredNonCanonicalPinWithoutLock(t
 	_, cityDir := setupBundledImportTest(t)
 	source := bundledPackSource()
 
-	_, err := resolveInstalledRemoteImport(source, "sha:0123456789abcdef0123456789abcdef01234567", cityDir)
+	_, err := resolveInstalledRemoteImport(source, "sha:0123456789abcdef0123456789abcdef01234567", cityDir, false)
 	if err == nil || !strings.Contains(err.Error(), "missing packs.lock") {
 		t.Fatalf("err = %v, want missing packs.lock error for declared non-canonical pin", err)
 	}
 
 	// The canonical declared pin (and an empty declaration) still falls back.
-	if _, err := resolveInstalledRemoteImport(source, BundledSourcePinnedVersion(source), cityDir); err != nil {
+	if _, err := resolveInstalledRemoteImport(source, BundledSourcePinnedVersion(source), cityDir, false); err != nil {
 		t.Fatalf("canonical declared pin should fall back to embedded content: %v", err)
 	}
 }
@@ -595,20 +595,20 @@ func TestSupersededBundledPinErrorsRecommendDoctorFix(t *testing.T) {
 	t.Run("locked but not cached", func(t *testing.T) {
 		_, cityDir := setupBundledImportTest(t)
 		writeBundledImportLock(t, cityDir, source, strings.TrimPrefix(superseded, "sha:"))
-		_, err := resolveInstalledRemoteImport(source, superseded, cityDir)
+		_, err := resolveInstalledRemoteImport(source, superseded, cityDir, false)
 		assertDoctorFirstRemediation(t, err)
 	})
 
 	t.Run("missing packs.lock", func(t *testing.T) {
 		_, cityDir := setupBundledImportTest(t)
-		_, err := resolveInstalledRemoteImport(source, superseded, cityDir)
+		_, err := resolveInstalledRemoteImport(source, superseded, cityDir, false)
 		assertDoctorFirstRemediation(t, err)
 	})
 
 	t.Run("missing packs.lock entry", func(t *testing.T) {
 		_, cityDir := setupBundledImportTest(t)
 		writeBundledImportLock(t, cityDir, "https://github.com/example/other.git", "0123456789abcdef0123456789abcdef01234567")
-		_, err := resolveInstalledRemoteImport(source, superseded, cityDir)
+		_, err := resolveInstalledRemoteImport(source, superseded, cityDir, false)
 		assertDoctorFirstRemediation(t, err)
 	})
 
@@ -616,7 +616,7 @@ func TestSupersededBundledPinErrorsRecommendDoctorFix(t *testing.T) {
 	// plain install remediation — the doctor re-pin would not honor it.
 	t.Run("non-superseded pin stays plain", func(t *testing.T) {
 		_, cityDir := setupBundledImportTest(t)
-		_, err := resolveInstalledRemoteImport(source, "sha:0123456789abcdef0123456789abcdef01234567", cityDir)
+		_, err := resolveInstalledRemoteImport(source, "sha:0123456789abcdef0123456789abcdef01234567", cityDir, false)
 		if err == nil || !strings.Contains(err.Error(), `run "gc import install"`) {
 			t.Fatalf("err = %v, want the plain gc import install remediation", err)
 		}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -114,7 +114,17 @@ type LoadOptions struct {
 	// load time. That only matters to a caller holding a Provenance across a
 	// window in which the config may change, which is exactly the long-running
 	// case that should leave this false.
-	SkipRevisionSnapshot    bool
+	SkipRevisionSnapshot bool
+	// RepoCacheNonBlocking makes every repo-cache lock this load takes fail
+	// fast with ErrRepoCacheBusy instead of waiting for the holder.
+	//
+	// The repo-cache lock is machine-wide and a writer holds it for as long as
+	// its git clone takes, so a blocking load can stall for minutes on work
+	// that has nothing to do with the caller. Advisory loads — command
+	// discovery, shell completion — set this and degrade to "no pack state
+	// right now"; a load whose result the caller acts on must leave it false
+	// and wait, because a busy cache would otherwise read as an empty one.
+	RepoCacheNonBlocking    bool
 	deferRigPatches         bool
 	deferredRigPatches      *[]deferredRigPatches
 	allowLegacyOrderLayouts bool
@@ -397,7 +407,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	for _, inc := range includes {
 		var fragPath string
 		if isRemoteInclude(inc) || isGitHubTreeURL(inc) {
-			resolved, err := resolvePackRef(inc, cityRoot, cityRoot)
+			resolved, err := resolvePackRef(inc, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 			if err != nil {
 				return nil, nil, fmt.Errorf("resolving include %q: %w", inc, err)
 			}
@@ -462,7 +472,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	resolveNamedPacks(root, cityRoot)
 	rootIncludes = root.Workspace.LegacyIncludes()
 
-	existingPacks := resolvedConfigPackNames(root, fs, cityRoot)
+	existingPacks := resolvedConfigPackNames(root, fs, cityRoot, opts.RepoCacheNonBlocking)
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
 		if name != "" && existingPacks[name] {
@@ -545,7 +555,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 	// Track city pack agents in provenance.
 	for _, ref := range root.Workspace.LegacyIncludes() {
-		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 		topoPath := filepath.Join(topoDir, packFile)
 		for _, a := range root.Agents {
 			if a.Dir == "" {
@@ -1715,7 +1725,7 @@ func LoadPackGraphDirsForDoctor(fs fsys.FS, cityTomlPath string) ([]string, erro
 }
 
 func loadImportPackGraphDirsForDoctor(fs fsys.FS, imp Import, declDir, cityRoot string, cache *packLoadCache) ([]string, error) {
-	impDir, err := resolveImportPackRef(imp.Source, imp.Version, declDir, cityRoot)
+	impDir, err := resolveImportPackRef(imp.Source, imp.Version, declDir, cityRoot, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1831,7 +1841,7 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 // [imports] according to each import's transitive setting so builtin system-pack
 // injection can be skipped when a user pack already brings the same pack into
 // the city closure.
-func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
+func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string, nonBlocking bool) map[string]bool {
 	names := make(map[string]bool, len(includes)+len(imports))
 	seenShallowDirs := make(map[string]bool)
 	expandedDirs := make(map[string]bool)
@@ -1887,7 +1897,7 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 	}
 
 	visitInclude = func(ref, declDir string, transitive bool) {
-		dir, err := resolvePackRef(ref, declDir, cityRoot)
+		dir, err := resolvePackRef(ref, declDir, cityRoot, nonBlocking)
 		if err != nil {
 			return
 		}
@@ -1895,7 +1905,7 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 	}
 
 	visitImport = func(ref, declDir string, transitive bool) {
-		dir, err := resolveImportPackRef(ref, "", declDir, cityRoot)
+		dir, err := resolveImportPackRef(ref, "", declDir, cityRoot, nonBlocking)
 		if err != nil {
 			return
 		}
@@ -1927,13 +1937,13 @@ func (c *City) PackDirByName(name string) string {
 // The gc binary uses it after composition to verify that required builtin
 // packs (core, and bd for bd-provider cities) are explicitly included.
 func ReachablePackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[string]bool {
-	return resolvedConfigPackNames(cfg, sysFS, cityRoot)
+	return resolvedConfigPackNames(cfg, sysFS, cityRoot, false)
 }
 
 // resolvedConfigPackNames collects all pack names reachable from the city,
 // rig, and default-rig pack graphs before builtin extra includes are injected.
-func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[string]bool {
-	names := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot)
+func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string, nonBlocking bool) map[string]bool {
+	names := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot, nonBlocking)
 	add := func(more map[string]bool) {
 		for name := range more {
 			names[name] = true
@@ -1941,11 +1951,11 @@ func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[stri
 	}
 
 	for _, rig := range cfg.Rigs {
-		add(resolvedPackNames(rig.Includes, rig.Imports, sysFS, cityRoot))
+		add(resolvedPackNames(rig.Includes, rig.Imports, sysFS, cityRoot, nonBlocking))
 	}
 
-	add(resolvedPackNames(cfg.Workspace.LegacyDefaultRigIncludes(), nil, sysFS, cityRoot))
-	add(resolvedPackNames(nil, cfg.DefaultRigImports, sysFS, cityRoot))
+	add(resolvedPackNames(cfg.Workspace.LegacyDefaultRigIncludes(), nil, sysFS, cityRoot, nonBlocking))
+	add(resolvedPackNames(nil, cfg.DefaultRigImports, sysFS, cityRoot, nonBlocking))
 
 	return names
 }

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -472,7 +473,10 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	resolveNamedPacks(root, cityRoot)
 	rootIncludes = root.Workspace.LegacyIncludes()
 
-	existingPacks := resolvedConfigPackNames(root, fs, cityRoot, opts.RepoCacheNonBlocking)
+	existingPacks, err := resolvedConfigPackNames(root, fs, cityRoot, opts.RepoCacheNonBlocking)
+	if err != nil {
+		return nil, nil, err
+	}
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
 		if name != "" && existingPacks[name] {
@@ -553,7 +557,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	if len(root.LoadWarnings) > 0 {
 		prov.Warnings = appendUnique(prov.Warnings, root.LoadWarnings...)
 	}
-	// Track city pack agents in provenance.
+	// Track city pack agents in provenance. The resolve error is discarded
+	// deliberately: this only builds an attribution string for a diagnostic,
+	// and an unresolvable ref yields a useless path rather than a wrong config.
+	// Anything that would change what composes has already been resolved and
+	// hard-failed upstream by then.
 	for _, ref := range root.Workspace.LegacyIncludes() {
 		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 		topoPath := filepath.Join(topoDir, packFile)
@@ -1841,10 +1849,17 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 // [imports] according to each import's transitive setting so builtin system-pack
 // injection can be skipped when a user pack already brings the same pack into
 // the city closure.
-func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string, nonBlocking bool) map[string]bool {
+// A ref that fails to resolve is skipped, since an unresolvable pack brings
+// nothing into the closure. ErrRepoCacheBusy is the exception: there the pack
+// may well be in the closure and the walk simply could not look. Returning a
+// short set would inject a builtin the city already has, so it is reported
+// instead — this set decides what gets injected, and a busy cache must never
+// quietly change that.
+func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string, nonBlocking bool) (map[string]bool, error) {
 	names := make(map[string]bool, len(includes)+len(imports))
 	seenShallowDirs := make(map[string]bool)
 	expandedDirs := make(map[string]bool)
+	var busyErr error
 
 	var visitDir func(dir string, transitive bool)
 	var visitInclude func(ref, declDir string, transitive bool)
@@ -1896,9 +1911,16 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		}
 	}
 
+	noteResolveErr := func(err error) {
+		if busyErr == nil && errors.Is(err, ErrRepoCacheBusy) {
+			busyErr = err
+		}
+	}
+
 	visitInclude = func(ref, declDir string, transitive bool) {
 		dir, err := resolvePackRef(ref, declDir, cityRoot, nonBlocking)
 		if err != nil {
+			noteResolveErr(err)
 			return
 		}
 		visitDir(dir, transitive)
@@ -1907,6 +1929,7 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 	visitImport = func(ref, declDir string, transitive bool) {
 		dir, err := resolveImportPackRef(ref, "", declDir, cityRoot, nonBlocking)
 		if err != nil {
+			noteResolveErr(err)
 			return
 		}
 		visitDir(dir, transitive)
@@ -1918,7 +1941,10 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 	for _, imp := range imports {
 		visitImport(imp.Source, cityRoot, imp.ImportIsTransitive())
 	}
-	return names
+	if busyErr != nil {
+		return nil, busyErr
+	}
+	return names, nil
 }
 
 // PackDirByName returns the composed pack directory whose pack.toml
@@ -1936,28 +1962,46 @@ func (c *City) PackDirByName(name string) string {
 // explicit includes, imports, rig pack graphs, and default-rig pack graphs.
 // The gc binary uses it after composition to verify that required builtin
 // packs (core, and bd for bd-provider cities) are explicitly included.
+// A blocking walk waits out any contention, so the error can only be a busy
+// cache and only a non-blocking caller can see one.
 func ReachablePackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[string]bool {
-	return resolvedConfigPackNames(cfg, sysFS, cityRoot, false)
+	names, _ := resolvedConfigPackNames(cfg, sysFS, cityRoot, false)
+	return names
 }
 
 // resolvedConfigPackNames collects all pack names reachable from the city,
 // rig, and default-rig pack graphs before builtin extra includes are injected.
-func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string, nonBlocking bool) map[string]bool {
-	names := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot, nonBlocking)
-	add := func(more map[string]bool) {
+// It returns ErrRepoCacheBusy if any graph could not be walked because another
+// process held the repo-cache lock.
+func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string, nonBlocking bool) (map[string]bool, error) {
+	names, err := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot, nonBlocking)
+	if err != nil {
+		return nil, err
+	}
+	add := func(more map[string]bool, err error) error {
+		if err != nil {
+			return err
+		}
 		for name := range more {
 			names[name] = true
 		}
+		return nil
 	}
 
 	for _, rig := range cfg.Rigs {
-		add(resolvedPackNames(rig.Includes, rig.Imports, sysFS, cityRoot, nonBlocking))
+		if err := add(resolvedPackNames(rig.Includes, rig.Imports, sysFS, cityRoot, nonBlocking)); err != nil {
+			return nil, err
+		}
 	}
 
-	add(resolvedPackNames(cfg.Workspace.LegacyDefaultRigIncludes(), nil, sysFS, cityRoot, nonBlocking))
-	add(resolvedPackNames(nil, cfg.DefaultRigImports, sysFS, cityRoot, nonBlocking))
+	if err := add(resolvedPackNames(cfg.Workspace.LegacyDefaultRigIncludes(), nil, sysFS, cityRoot, nonBlocking)); err != nil {
+		return nil, err
+	}
+	if err := add(resolvedPackNames(nil, cfg.DefaultRigImports, sysFS, cityRoot, nonBlocking)); err != nil {
+		return nil, err
+	}
 
-	return names
+	return names, nil
 }
 
 // readPackNameFromDir reads [pack].name from pack.toml in the given directory.

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -1374,7 +1374,7 @@ schema = 2
 
 	names := resolvedPackNames(nil, map[string]Import{
 		"gastown": {Source: source, Version: "^1.2"},
-	}, fsys.OSFS{}, cityDir)
+	}, fsys.OSFS{}, cityDir, false)
 
 	for _, name := range []string{"gastown", "maintenance"} {
 		if !names[name] {

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -1372,9 +1372,9 @@ name = "maintenance"
 schema = 2
 `)
 
-	names := resolvedPackNames(nil, map[string]Import{
+	names := mustResolvedPackNames(t, nil, map[string]Import{
 		"gastown": {Source: source, Version: "^1.2"},
-	}, fsys.OSFS{}, cityDir, false)
+	}, fsys.OSFS{}, cityDir)
 
 	for _, name := range []string{"gastown", "maintenance"} {
 		if !names[name] {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -145,7 +145,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 		var rigImportPackDirs []string
 		var rigGlobals []ResolvedPackGlobal
 		for _, ref := range topoRefs {
-			topoDir, err := resolvePackRef(ref, cityRoot, cityRoot)
+			topoDir, err := resolvePackRef(ref, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 			if err != nil {
 				return fmt.Errorf("rig %q pack %q: %w", rig.Name, ref, err)
 			}
@@ -271,7 +271,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					continue
 				}
 
-				impDir, err := resolveImportPackRef(imp.Source, imp.Version, cityRoot, cityRoot)
+				impDir, err := resolveImportPackRef(imp.Source, imp.Version, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 				if err != nil {
 					return fmt.Errorf("rig %q import %q: %w", rig.Name, bindingName, err)
 				}
@@ -589,7 +589,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 	cache := &packLoadCache{results: make(map[string]*packLoadResult)}
 
 	for _, ref := range topos {
-		topoDir, err := resolvePackRef(ref, cityRoot, cityRoot)
+		topoDir, err := resolvePackRef(ref, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 		if err != nil {
 			// Pack directory may have been removed upstream (e.g. renamed/deleted
 			// in the remote repo). Skip gracefully so the rest of the city loads.
@@ -716,7 +716,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 			// Unlike V1 includes (which skip gracefully for missing remote
 			// subpaths), V2 imports are always fatal on missing source.
 			// A typo in [imports.X].source should not be silently ignored.
-			impDir, err := resolveImportPackRef(imp.Source, imp.Version, cityRoot, cityRoot)
+			impDir, err := resolveImportPackRef(imp.Source, imp.Version, cityRoot, cityRoot, opts.RepoCacheNonBlocking)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("city import %q: %w", bindingName, err)
 			}
@@ -977,10 +977,10 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 // declaredVersion is the import's declared version constraint; it gates the
 // no-lock bundled fallback so a declared non-canonical pin never silently
 // composes the binary's embedded content.
-func resolveImportPackRef(ref, declaredVersion, declDir, cityRoot string) (string, error) {
+func resolveImportPackRef(ref, declaredVersion, declDir, cityRoot string, nonBlocking bool) (string, error) {
 	if isGitHubTreeURL(ref) {
 		_, subpath, _ := parseGitHubTreeURL(ref)
-		cacheDir, err := resolveInstalledRemoteImport(ref, declaredVersion, cityRoot)
+		cacheDir, err := resolveInstalledRemoteImport(ref, declaredVersion, cityRoot, nonBlocking)
 		if err != nil {
 			return "", err
 		}
@@ -991,7 +991,7 @@ func resolveImportPackRef(ref, declaredVersion, declDir, cityRoot string) (strin
 	}
 	if isRemoteInclude(ref) {
 		_, subpath, _ := parseRemoteInclude(ref)
-		cacheDir, err := resolveInstalledRemoteImport(ref, declaredVersion, cityRoot)
+		cacheDir, err := resolveInstalledRemoteImport(ref, declaredVersion, cityRoot, nonBlocking)
 		if err != nil {
 			return "", err
 		}
@@ -1000,7 +1000,7 @@ func resolveImportPackRef(ref, declaredVersion, declDir, cityRoot string) (strin
 		}
 		return cacheDir, nil
 	}
-	return resolvePackRef(ref, declDir, cityRoot)
+	return resolvePackRef(ref, declDir, cityRoot, nonBlocking)
 }
 
 // ComputeFormulaLayers builds the FormulaLayers from the resolved formula
@@ -1209,7 +1209,7 @@ func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName s
 	var topoDirs []string
 	var requirements []PackRequirement
 	var globals []ResolvedPackGlobal
-	err := withRepoCacheReadLockForPath(topoDir, func() error {
+	err := withRepoCacheReadLockForPath(topoDir, opts.RepoCacheNonBlocking, func() error {
 		var loadErr error
 		agents, namedSessions, providers, upstreams, services, topoDirs, requirements, globals, loadErr = loadPackWithCacheOptionsLocked(
 			fs, topoPath, topoDir, cityRoot, rigName, seen, cache, opts)
@@ -1291,7 +1291,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	includedUpstreams := make(map[string]UpstreamSpec)
 
 	for _, inc := range tc.Pack.Includes {
-		incTopoDir, err := resolvePackRef(inc, topoDir, cityRoot)
+		incTopoDir, err := resolvePackRef(inc, topoDir, cityRoot, opts.RepoCacheNonBlocking)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("include %q: %w", inc, err)
 		}
@@ -1349,7 +1349,7 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		// remote sources, and a bundled source at its canonical pin
 		// self-heals from the binary's embedded content when the lock is
 		// absent or lacks the entry — matching city- and rig-scope imports.
-		impDir, err := resolveImportPackRef(imp.Source, imp.Version, topoDir, cityRoot)
+		impDir, err := resolveImportPackRef(imp.Source, imp.Version, topoDir, cityRoot, opts.RepoCacheNonBlocking)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("import %q: %w", bindingName, err)
 		}
@@ -3055,7 +3055,7 @@ func resolveNamedPacks(cfg *City, cityRoot string) {
 // defines a rig-scoped agent with the given name. Returns false on error
 // (fail-open: caller should add the default polecat).
 func PackDefinesAgent(fs fsys.FS, packRef, cityRoot, agentName string) bool {
-	topoDir, err := resolvePackRef(packRef, cityRoot, cityRoot)
+	topoDir, err := resolvePackRef(packRef, cityRoot, cityRoot, false)
 	if err != nil {
 		return false
 	}
@@ -3123,7 +3123,7 @@ func PackSummary(cfg *City, fs fsys.FS, cityRoot string) map[string]string {
 
 // packSummaryOne builds a summary string for a single pack reference.
 func packSummaryOne(fs fsys.FS, ref, cityRoot string) string {
-	topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+	topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, false)
 	topoPath := filepath.Join(topoDir, packFile)
 	data, err := fs.ReadFile(topoPath)
 	if err != nil {

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -96,7 +97,7 @@ func parseGitHubTreeURL(s string) (source, subpath, ref string) {
 
 // resolvePackRef resolves a pack reference to a local directory.
 // Handles local paths, GitHub tree URLs, and git source//sub#ref URLs.
-func resolvePackRef(ref, declDir, cityRoot string) (string, error) {
+func resolvePackRef(ref, declDir, cityRoot string, nonBlocking bool) (string, error) {
 	if isGitHubTreeURL(ref) || isRemoteInclude(ref) {
 		// parseRemoteInclude handles GitHub tree/blob URLs too
 		// (remotesource.Parse short-circuits to ParseGitHubTreeOrBlob),
@@ -121,7 +122,7 @@ func resolvePackRef(ref, declDir, cityRoot string) (string, error) {
 			lockKeys = append(lockKeys, source)
 		}
 		for _, key := range lockKeys {
-			if cacheDir, ok, err := resolveLockedRemoteImport(key, cityRoot); err != nil {
+			if cacheDir, ok, err := resolveLockedRemoteImport(key, cityRoot, nonBlocking); err != nil {
 				return "", err
 			} else if ok {
 				if subpath != "" {
@@ -150,7 +151,7 @@ type remoteImportLockEntry struct {
 	Commit string `toml:"commit"`
 }
 
-func resolveLockedRemoteImport(source, cityRoot string) (string, bool, error) {
+func resolveLockedRemoteImport(source, cityRoot string, nonBlocking bool) (string, bool, error) {
 	lockPath := filepath.Join(cityRoot, "packs.lock")
 	data, err := os.ReadFile(lockPath)
 	if err != nil {
@@ -174,7 +175,7 @@ func resolveLockedRemoteImport(source, cityRoot string) (string, bool, error) {
 		return "", false, err
 	}
 	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, entry.Commit))
-	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, entry.Commit); err != nil {
+	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, entry.Commit, nonBlocking); err != nil {
 		return "", false, err
 	}
 	return cacheDir, true, nil
@@ -284,7 +285,7 @@ func IsBundledSourceAtCanonicalPin(source, commit string) bool {
 // be installed for real, exactly like any other remote import. This
 // fallback keeps cities composable before the first "gc import install"
 // writes the lock.
-func resolveBundledSourceWithoutLock(source, declaredVersion string) (string, bool, error) {
+func resolveBundledSourceWithoutLock(source, declaredVersion string, nonBlocking bool) (string, bool, error) {
 	if !builtinpacks.IsSource(source) {
 		return "", false, nil
 	}
@@ -305,23 +306,26 @@ func resolveBundledSourceWithoutLock(source, declaredVersion string) (string, bo
 	if builtinpacks.ValidateSyntheticRepoFast(cacheDir, repository, commit) == nil {
 		return cacheDir, true, nil
 	}
-	if _, err := WithRepoCacheWriteLock(cacheRoot, func() (string, error) {
+	if _, err := repoCacheWriteLock(nonBlocking)(cacheRoot, func() (string, error) {
 		if builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil {
 			return cacheDir, nil
 		}
 		return cacheDir, builtinpacks.MaterializeSyntheticRepo(cacheDir, repository, commit)
 	}); err != nil {
+		if errors.Is(err, ErrRepoCacheBusy) {
+			return "", true, err
+		}
 		return "", true, fmt.Errorf("hydrating synthetic repo cache: %w", err)
 	}
 	return cacheDir, true, nil
 }
 
-func resolveInstalledRemoteImport(source, declaredVersion, cityRoot string) (string, error) {
+func resolveInstalledRemoteImport(source, declaredVersion, cityRoot string, nonBlocking bool) (string, error) {
 	lockPath := filepath.Join(cityRoot, "packs.lock")
 	data, err := os.ReadFile(lockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if cacheDir, ok, err := resolveBundledSourceWithoutLock(source, declaredVersion); ok {
+			if cacheDir, ok, err := resolveBundledSourceWithoutLock(source, declaredVersion, nonBlocking); ok {
 				if err != nil {
 					return "", fmt.Errorf("resolving remote import %s without lock: %w", source, err)
 				}
@@ -338,7 +342,7 @@ func resolveInstalledRemoteImport(source, declaredVersion, cityRoot string) (str
 	}
 	entry, ok := lock.Packs[source]
 	if !ok || entry.Commit == "" {
-		if cacheDir, ok, err := resolveBundledSourceWithoutLock(source, declaredVersion); ok {
+		if cacheDir, ok, err := resolveBundledSourceWithoutLock(source, declaredVersion, nonBlocking); ok {
 			if err != nil {
 				return "", fmt.Errorf("resolving remote import %s without lock entry: %w", source, err)
 			}
@@ -352,7 +356,7 @@ func resolveInstalledRemoteImport(source, declaredVersion, cityRoot string) (str
 		return "", err
 	}
 	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, entry.Commit))
-	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, entry.Commit); err != nil {
+	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, entry.Commit, nonBlocking); err != nil {
 		return "", err
 	}
 	return cacheDir, nil
@@ -397,7 +401,7 @@ func remoteCacheFingerprint(cacheDir string) string {
 // validateInstalledRemoteCacheLocked validates the remote cache under the
 // repo-cache read lock, memoizing the success so a warm, unchanged cache skips
 // both the flock and the git execs on subsequent loads.
-func validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit string) error {
+func validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit string, nonBlocking bool) error {
 	key := cacheDir + "\x00" + commit
 	fp := remoteCacheFingerprint(cacheDir)
 	if v, ok := remoteCacheValidationCache.Load(key); ok {
@@ -405,9 +409,18 @@ func validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit stri
 			return nil
 		}
 	}
-	if err := WithRepoCacheReadLock(cacheRoot, func() error {
+	readLock := WithRepoCacheReadLock
+	if nonBlocking {
+		readLock = TryWithRepoCacheReadLock
+	}
+	if err := readLock(cacheRoot, func() error {
 		return validateInstalledRemoteCache(source, cacheDir, commit)
 	}); err != nil {
+		// A busy cache is not a verdict on this cache's contents, so it must
+		// not trigger the absent-cache rebuild below.
+		if errors.Is(err, ErrRepoCacheBusy) {
+			return err
+		}
 		// A locked bundled source pinned at its canonical commit is served from
 		// the running binary's embedded content. A freshly installed/upgraded
 		// binary resolves a new content-hash cache dir (RepoCacheKey folds the
@@ -417,7 +430,7 @@ func validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit stri
 		// case so a present-but-invalid cache (content drift, tampering, bad
 		// marker) still fails loudly per its security contract. The read lock
 		// above is already released here, so taking the write lock is safe.
-		if rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit) {
+		if rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit, nonBlocking) {
 			remoteCacheValidationCache.Store(key, remoteCacheValidationEntry{fingerprint: remoteCacheFingerprint(cacheDir)})
 			return nil
 		}
@@ -435,7 +448,7 @@ func validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit stri
 // reports success only if the rebuilt cache validates. It deliberately leaves
 // a present-but-invalid cache untouched, so content-drift / tampering /
 // bad-marker rejection in validateInstalledRemoteCache keeps failing loudly.
-func rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit string) bool {
+func rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit string, nonBlocking bool) bool {
 	if !IsBundledSourceAtCanonicalPin(source, commit) {
 		return false
 	}
@@ -447,7 +460,7 @@ func rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit string)
 	if !ok {
 		return false
 	}
-	if _, err := WithRepoCacheWriteLock(cacheRoot, func() (string, error) {
+	if _, err := repoCacheWriteLock(nonBlocking)(cacheRoot, func() (string, error) {
 		// Re-check under the lock: another writer may have materialized it.
 		if builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil {
 			return cacheDir, nil

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -306,7 +306,7 @@ func resolveBundledSourceWithoutLock(source, declaredVersion string, nonBlocking
 	if builtinpacks.ValidateSyntheticRepoFast(cacheDir, repository, commit) == nil {
 		return cacheDir, true, nil
 	}
-	if _, err := repoCacheWriteLock(nonBlocking)(cacheRoot, func() (string, error) {
+	if _, err := withRepoCacheWriteLock(cacheRoot, nonBlocking, func() (string, error) {
 		if builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil {
 			return cacheDir, nil
 		}
@@ -460,7 +460,7 @@ func rematerializeAbsentBundledCache(source, cacheRoot, cacheDir, commit string,
 	if !ok {
 		return false
 	}
-	if _, err := repoCacheWriteLock(nonBlocking)(cacheRoot, func() (string, error) {
+	if _, err := withRepoCacheWriteLock(cacheRoot, nonBlocking, func() (string, error) {
 		// Re-check under the lock: another writer may have materialized it.
 		if builtinpacks.ValidateSyntheticRepo(cacheDir, repository, commit) == nil {
 			return cacheDir, nil

--- a/internal/config/pack_include_nonblocking_test.go
+++ b/internal/config/pack_include_nonblocking_test.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// lockRepoCacheRoot takes mode on an existing cache root's lock file and
+// releases it when the test ends. Unlike holdRepoCacheLock it locks a root the
+// caller already owns, so a fixture's real cache root can be contended.
+func lockRepoCacheRoot(t *testing.T, root string, mode int) {
+	t.Helper()
+	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	t.Cleanup(func() { lockFile.Close() }) //nolint:errcheck
+	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+		t.Fatalf("Flock(%d): %v", mode, err)
+	}
+	t.Cleanup(func() { syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }) //nolint:errcheck
+}
+
+// The non-blocking flag has to reach the lock, not just the signature: an
+// unused parameter compiles fine and silently leaves every advisory load
+// waiting behind whoever is cloning.
+func TestResolvePackRefNonBlockingRefusesBusyCache(t *testing.T) {
+	const ref = "https://github.com/example/packs/tree/main/gastown"
+	cityDir, cacheDir := setupLockedPackRefTest(t, ref)
+	lockRepoCacheRoot(t, filepath.Dir(cacheDir), syscall.LOCK_EX)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := resolvePackRef(ref, cityDir, cityDir, true)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrRepoCacheBusy) {
+			t.Fatalf("err = %v, want ErrRepoCacheBusy", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-blocking resolvePackRef waited on a held repo-cache lock")
+	}
+}
+
+// The control: blocking stays blocking. Without this, dropping the flag and
+// making every caller non-blocking would pass the test above while breaking
+// installers, prune and bootstrap, which must see the cache's real contents.
+func TestResolvePackRefBlockingWaitsOnBusyCache(t *testing.T) {
+	const ref = "https://github.com/example/packs/tree/main/gastown"
+	cityDir, cacheDir := setupLockedPackRefTest(t, ref)
+	lockRepoCacheRoot(t, filepath.Dir(cacheDir), syscall.LOCK_EX)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := resolvePackRef(ref, cityDir, cityDir, false)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("blocking resolvePackRef returned %v while the cache lock was held", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+	// The goroutine unblocks when t.Cleanup releases the flock.
+}

--- a/internal/config/pack_include_nonblocking_test.go
+++ b/internal/config/pack_include_nonblocking_test.go
@@ -6,25 +6,39 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 )
 
-// lockRepoCacheRoot takes mode on an existing cache root's lock file and
-// releases it when the test ends. Unlike holdRepoCacheLock it locks a root the
-// caller already owns, so a fixture's real cache root can be contended.
-func lockRepoCacheRoot(t *testing.T, root string, mode int) {
+// lockRepoCacheRoot takes mode on an existing cache root's lock file. Unlike
+// holdRepoCacheLock it locks a root the caller already owns, so a fixture's
+// real cache root can be contended.
+//
+// The returned release is idempotent, so a test that has to release early —
+// any test that parks a goroutine on the lock and must join it before
+// returning — can call it and still let the t.Cleanup backstop cover the
+// paths that don't.
+func lockRepoCacheRoot(t *testing.T, root string, mode int) (release func()) {
 	t.Helper()
 	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		t.Fatalf("open lock file: %v", err)
 	}
-	t.Cleanup(func() { lockFile.Close() }) //nolint:errcheck
 	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+		lockFile.Close() //nolint:errcheck
 		t.Fatalf("Flock(%d): %v", mode, err)
 	}
-	t.Cleanup(func() { syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }) //nolint:errcheck
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+			lockFile.Close()                                   //nolint:errcheck
+		})
+	}
+	t.Cleanup(release)
+	return release
 }
 
 // The non-blocking flag has to reach the lock, not just the signature: an
@@ -57,7 +71,7 @@ func TestResolvePackRefNonBlockingRefusesBusyCache(t *testing.T) {
 func TestResolvePackRefBlockingWaitsOnBusyCache(t *testing.T) {
 	const ref = "https://github.com/example/packs/tree/main/gastown"
 	cityDir, cacheDir := setupLockedPackRefTest(t, ref)
-	lockRepoCacheRoot(t, filepath.Dir(cacheDir), syscall.LOCK_EX)
+	release := lockRepoCacheRoot(t, filepath.Dir(cacheDir), syscall.LOCK_EX)
 
 	done := make(chan error, 1)
 	go func() {
@@ -70,5 +84,13 @@ func TestResolvePackRefBlockingWaitsOnBusyCache(t *testing.T) {
 		t.Fatalf("blocking resolvePackRef returned %v while the cache lock was held", err)
 	case <-time.After(500 * time.Millisecond):
 	}
-	// The goroutine unblocks when t.Cleanup releases the flock.
+
+	// Release and join here rather than leaving the goroutine parked for
+	// t.Cleanup. Cleanups run LIFO, so the flock release would fire first and
+	// wake the goroutine into the rest of this test's teardown: it goes on to
+	// read runRepoCacheGit, which setupLockedPackRefTest's own cleanup is
+	// restoring, and to walk a t.TempDir that is being removed. That is a real
+	// ~7% failure under -race, not a theoretical one.
+	release()
+	<-done
 }

--- a/internal/config/pack_include_test.go
+++ b/internal/config/pack_include_test.go
@@ -286,7 +286,7 @@ func TestValidateInstalledRemoteCacheLockedMemoizesSuccess(t *testing.T) {
 	t.Cleanup(func() { runRepoCacheGit = orig })
 
 	const source = "git@github.com:example/pack"
-	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit); err != nil {
+	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit, false); err != nil {
 		t.Fatalf("first validate: %v", err)
 	}
 	first := calls
@@ -294,7 +294,7 @@ func TestValidateInstalledRemoteCacheLockedMemoizesSuccess(t *testing.T) {
 		t.Fatal("first validation should run git (rev-parse + status)")
 	}
 
-	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit); err != nil {
+	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit, false); err != nil {
 		t.Fatalf("second validate: %v", err)
 	}
 	if calls != first {
@@ -309,7 +309,7 @@ func TestValidateInstalledRemoteCacheLockedMemoizesSuccess(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cacheDir, ".git", "index.lock"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit); err != nil {
+	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit, false); err != nil {
 		t.Fatalf("post-.git-touch validate: %v", err)
 	}
 	if calls != first {
@@ -328,7 +328,7 @@ func TestValidateInstalledRemoteCacheLockedMemoizesSuccess(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cacheDir, ".git", "index"), []byte("idx2-longer"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit); err != nil {
+	if err := validateInstalledRemoteCacheLocked(source, cacheRoot, cacheDir, commit, false); err != nil {
 		t.Fatalf("third validate: %v", err)
 	}
 	if calls == first {
@@ -336,10 +336,16 @@ func TestValidateInstalledRemoteCacheLockedMemoizesSuccess(t *testing.T) {
 	}
 }
 
+// lockedPackRefCommit is the stubbed HEAD every setupLockedPackRefTest city
+// pins. Its value is arbitrary; only that the lock file, the cache key and the
+// stubbed rev-parse all agree on it matters.
+const lockedPackRefCommit = "abcdef1234567890abcdef1234567890abcdef12"
+
 // setupLockedPackRefTest fabricates a city with a packs.lock entry for ref and
 // a valid installed repo cache for it under a temp HOME, with git stubbed out.
-func setupLockedPackRefTest(t *testing.T, ref, commit string) (cityDir, cacheDir string) {
+func setupLockedPackRefTest(t *testing.T, ref string) (cityDir, cacheDir string) {
 	t.Helper()
+	const commit = lockedPackRefCommit
 	ResetRemoteCacheValidationCache()
 	t.Cleanup(ResetRemoteCacheValidationCache)
 
@@ -377,10 +383,9 @@ fetched = "2026-06-06T00:00:00Z"
 
 func TestResolvePackRefUsesLockedImportForGitHubTreeURL(t *testing.T) {
 	const ref = "https://github.com/example/packs/tree/main/gastown"
-	const commit = "abcdef1234567890abcdef1234567890abcdef12"
-	cityDir, cacheDir := setupLockedPackRefTest(t, ref, commit)
+	cityDir, cacheDir := setupLockedPackRefTest(t, ref)
 
-	got, err := resolvePackRef(ref, cityDir, cityDir)
+	got, err := resolvePackRef(ref, cityDir, cityDir, false)
 	if err != nil {
 		t.Fatalf("resolvePackRef: %v", err)
 	}
@@ -392,10 +397,9 @@ func TestResolvePackRefUsesLockedImportForGitHubTreeURL(t *testing.T) {
 
 func TestResolvePackRefUsesLockedImportForRefRemoteInclude(t *testing.T) {
 	const ref = "git@github.com:example/packs//gastown#main"
-	const commit = "abcdef1234567890abcdef1234567890abcdef12"
-	cityDir, cacheDir := setupLockedPackRefTest(t, ref, commit)
+	cityDir, cacheDir := setupLockedPackRefTest(t, ref)
 
-	got, err := resolvePackRef(ref, cityDir, cityDir)
+	got, err := resolvePackRef(ref, cityDir, cityDir, false)
 	if err != nil {
 		t.Fatalf("resolvePackRef: %v", err)
 	}
@@ -414,7 +418,7 @@ func TestResolvePackRefFallsBackToIncludeCacheWhenUnlocked(t *testing.T) {
 	mustMkdirAll(t, cityDir, 0o755)
 
 	const ref = "https://github.com/example/packs/tree/main/gastown"
-	_, err := resolvePackRef(ref, cityDir, cityDir)
+	_, err := resolvePackRef(ref, cityDir, cityDir, false)
 	if err == nil {
 		t.Fatal("expected uncached include error for unlocked remote ref")
 	}
@@ -456,7 +460,7 @@ func TestResolveBundledSourceWithoutLockHitsFastPathOnPreMaterializedCache(t *te
 		t.Fatalf("MaterializeSyntheticRepo: %v", err)
 	}
 
-	got, ok, err := resolveBundledSourceWithoutLock(source, "")
+	got, ok, err := resolveBundledSourceWithoutLock(source, "", false)
 	if err != nil {
 		t.Fatalf("resolveBundledSourceWithoutLock: %v", err)
 	}

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3460,9 +3460,9 @@ source = "../shared"
 transitive = false
 `)
 
-	names := resolvedPackNames([]string{"packs/wrapper"}, map[string]Import{
+	names := mustResolvedPackNames(t, []string{"packs/wrapper"}, map[string]Import{
 		"shared": {Source: "packs/shared"},
-	}, fsys.OSFS{}, dir, false)
+	}, fsys.OSFS{}, dir)
 
 	if !names["maintenance"] {
 		t.Fatalf("maintenance missing after mixed shallow/deep visits: names=%v", names)
@@ -3487,9 +3487,9 @@ source = "../maintenance"
 `)
 
 	transitiveFalse := false
-	names := resolvedPackNames(nil, map[string]Import{
+	names := mustResolvedPackNames(t, nil, map[string]Import{
 		"shared": {Source: "packs/shared", Transitive: &transitiveFalse},
-	}, fsys.OSFS{}, dir, false)
+	}, fsys.OSFS{}, dir)
 
 	if !names["shared"] {
 		t.Fatalf("shared missing from non-transitive visit: names=%v", names)
@@ -3525,7 +3525,7 @@ source = "../middle"
 transitive = false
 `)
 
-	names := resolvedPackNames([]string{"packs/root"}, nil, fsys.OSFS{}, dir, false)
+	names := mustResolvedPackNames(t, []string{"packs/root"}, nil, fsys.OSFS{}, dir)
 	if !names["middle"] {
 		t.Fatalf("middle pack was not recorded: names=%v", names)
 	}
@@ -3572,7 +3572,7 @@ source = "../middle"
 		{"packs/shallow", "packs/deep"},
 		{"packs/deep", "packs/shallow"},
 	} {
-		names := resolvedPackNames(includes, nil, fsys.OSFS{}, dir, false)
+		names := mustResolvedPackNames(t, includes, nil, fsys.OSFS{}, dir)
 		if !names["maintenance"] {
 			t.Fatalf("includes %v did not resolve transitive maintenance after shallow visit: names=%v", includes, names)
 		}
@@ -3591,10 +3591,10 @@ schema = 2
 
 		transitiveFalse := false
 		countingFS := newReadCountingFS()
-		names := resolvedPackNames(nil, map[string]Import{
+		names := mustResolvedPackNames(t, nil, map[string]Import{
 			"shared_a": {Source: "packs/shared", Transitive: &transitiveFalse},
 			"shared_b": {Source: "packs/shared", Transitive: &transitiveFalse},
-		}, countingFS, dir, false)
+		}, countingFS, dir)
 
 		if !names["shared"] {
 			t.Fatalf("shared missing from repeated shallow imports: names=%v", names)
@@ -3641,7 +3641,7 @@ source = "../right"
 `)
 
 		countingFS := newReadCountingFS()
-		names := resolvedPackNames([]string{"packs/root"}, nil, countingFS, dir, false)
+		names := mustResolvedPackNames(t, []string{"packs/root"}, nil, countingFS, dir)
 
 		for _, name := range []string{"root", "left", "right", "shared"} {
 			if !names[name] {
@@ -5452,4 +5452,19 @@ source = "../roles"
 	if !found {
 		t.Fatalf("warnings = %#v, want one containing %q", loaded.Warnings, wantSubstring)
 	}
+}
+
+// mustResolvedPackNames is resolvedPackNames for the blocking callers above.
+// They wait out contention, so the only error class they can hit is a new one
+// the walk grows later. Asserting that here keeps such an error from being
+// silently discarded and turning those assertions into claims about a
+// half-walked graph. The non-blocking mode has its own tests, which care about
+// the error rather than the names.
+func mustResolvedPackNames(t *testing.T, includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
+	t.Helper()
+	names, err := resolvedPackNames(includes, imports, sysFS, cityRoot, false)
+	if err != nil {
+		t.Fatalf("resolvedPackNames: %v", err)
+	}
+	return names
 }

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3462,7 +3462,7 @@ transitive = false
 
 	names := resolvedPackNames([]string{"packs/wrapper"}, map[string]Import{
 		"shared": {Source: "packs/shared"},
-	}, fsys.OSFS{}, dir)
+	}, fsys.OSFS{}, dir, false)
 
 	if !names["maintenance"] {
 		t.Fatalf("maintenance missing after mixed shallow/deep visits: names=%v", names)
@@ -3489,7 +3489,7 @@ source = "../maintenance"
 	transitiveFalse := false
 	names := resolvedPackNames(nil, map[string]Import{
 		"shared": {Source: "packs/shared", Transitive: &transitiveFalse},
-	}, fsys.OSFS{}, dir)
+	}, fsys.OSFS{}, dir, false)
 
 	if !names["shared"] {
 		t.Fatalf("shared missing from non-transitive visit: names=%v", names)
@@ -3525,7 +3525,7 @@ source = "../middle"
 transitive = false
 `)
 
-	names := resolvedPackNames([]string{"packs/root"}, nil, fsys.OSFS{}, dir)
+	names := resolvedPackNames([]string{"packs/root"}, nil, fsys.OSFS{}, dir, false)
 	if !names["middle"] {
 		t.Fatalf("middle pack was not recorded: names=%v", names)
 	}
@@ -3572,7 +3572,7 @@ source = "../middle"
 		{"packs/shallow", "packs/deep"},
 		{"packs/deep", "packs/shallow"},
 	} {
-		names := resolvedPackNames(includes, nil, fsys.OSFS{}, dir)
+		names := resolvedPackNames(includes, nil, fsys.OSFS{}, dir, false)
 		if !names["maintenance"] {
 			t.Fatalf("includes %v did not resolve transitive maintenance after shallow visit: names=%v", includes, names)
 		}
@@ -3594,7 +3594,7 @@ schema = 2
 		names := resolvedPackNames(nil, map[string]Import{
 			"shared_a": {Source: "packs/shared", Transitive: &transitiveFalse},
 			"shared_b": {Source: "packs/shared", Transitive: &transitiveFalse},
-		}, countingFS, dir)
+		}, countingFS, dir, false)
 
 		if !names["shared"] {
 			t.Fatalf("shared missing from repeated shallow imports: names=%v", names)
@@ -3641,7 +3641,7 @@ source = "../right"
 `)
 
 		countingFS := newReadCountingFS()
-		names := resolvedPackNames([]string{"packs/root"}, nil, countingFS, dir)
+		names := resolvedPackNames([]string{"packs/root"}, nil, countingFS, dir, false)
 
 		for _, name := range []string{"root", "left", "right", "shared"} {
 			if !names[name] {

--- a/internal/config/repo_cache_lock.go
+++ b/internal/config/repo_cache_lock.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,16 +9,42 @@ import (
 
 const repoCacheLockName = ".packman-cache.lock"
 
+// ErrRepoCacheBusy reports that another process holds a conflicting repo-cache
+// lock. Only the Try* helpers return it; the blocking helpers wait instead.
+var ErrRepoCacheBusy = errors.New("repo cache is busy")
+
+// repoCacheLockOptions selects which repo-cache lock an acquisition takes and
+// how it behaves under contention.
+type repoCacheLockOptions struct {
+	mode        int
+	createRoot  bool
+	nonBlocking bool
+}
+
 // WithRepoCacheReadLock runs fn while holding the shared repo-cache lock if
 // the cache root exists. It does not create cache files or directories.
 func WithRepoCacheReadLock(root string, fn func() error) error {
-	return withRepoCacheLock(root, repoCacheLockShared, false, fn)
+	return withRepoCacheLock(root, repoCacheLockOptions{mode: repoCacheLockShared}, fn)
+}
+
+// TryWithRepoCacheReadLock runs fn while holding the shared repo-cache lock,
+// returning ErrRepoCacheBusy immediately instead of waiting when another
+// process holds the lock exclusively.
+//
+// Use this only where a missed result is acceptable and a stall is not, such
+// as command discovery or shell completion: a single cache write holds the
+// exclusive lock for as long as its network clone takes, and every blocking
+// reader on the machine queues behind it. Callers whose answer must be
+// correct — installers, prune, bootstrap, skills materialization — keep using
+// WithRepoCacheReadLock and wait.
+func TryWithRepoCacheReadLock(root string, fn func() error) error {
+	return withRepoCacheLock(root, repoCacheLockOptions{mode: repoCacheLockShared, nonBlocking: true}, fn)
 }
 
 // WithRepoCacheWriteLock runs fn while holding the exclusive repo-cache lock.
 func WithRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
 	var result string
-	err := withRepoCacheLock(root, repoCacheLockExclusive, true, func() error {
+	err := withRepoCacheLock(root, repoCacheLockOptions{mode: repoCacheLockExclusive, createRoot: true}, func() error {
 		var fnErr error
 		result, fnErr = fn()
 		return fnErr

--- a/internal/config/repo_cache_lock.go
+++ b/internal/config/repo_cache_lock.go
@@ -43,8 +43,33 @@ func TryWithRepoCacheReadLock(root string, fn func() error) error {
 
 // WithRepoCacheWriteLock runs fn while holding the exclusive repo-cache lock.
 func WithRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
+	return writeLock(root, false, fn)
+}
+
+// TryWithRepoCacheWriteLock is WithRepoCacheWriteLock for advisory callers: it
+// returns ErrRepoCacheBusy immediately rather than waiting for a writer that
+// may be doing a network clone. Cache repair reached from an advisory load is
+// better skipped than waited on; the next authoritative command repairs it.
+func TryWithRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
+	return writeLock(root, true, fn)
+}
+
+// repoCacheWriteLock picks the exclusive-lock helper matching a load's
+// blocking policy, so call sites read the same either way.
+func repoCacheWriteLock(nonBlocking bool) func(string, func() (string, error)) (string, error) {
+	if nonBlocking {
+		return TryWithRepoCacheWriteLock
+	}
+	return WithRepoCacheWriteLock
+}
+
+func writeLock(root string, nonBlocking bool, fn func() (string, error)) (string, error) {
 	var result string
-	err := withRepoCacheLock(root, repoCacheLockOptions{mode: repoCacheLockExclusive, createRoot: true}, func() error {
+	err := withRepoCacheLock(root, repoCacheLockOptions{
+		mode:        repoCacheLockExclusive,
+		createRoot:  true,
+		nonBlocking: nonBlocking,
+	}, func() error {
 		var fnErr error
 		result, fnErr = fn()
 		return fnErr
@@ -52,10 +77,13 @@ func WithRepoCacheWriteLock(root string, fn func() (string, error)) (string, err
 	return result, err
 }
 
-func withRepoCacheReadLockForPath(path string, fn func() error) error {
+func withRepoCacheReadLockForPath(path string, nonBlocking bool, fn func() error) error {
 	root, ok := repoCacheRootForPath(path)
 	if !ok {
 		return fn()
+	}
+	if nonBlocking {
+		return TryWithRepoCacheReadLock(root, fn)
 	}
 	return WithRepoCacheReadLock(root, fn)
 }

--- a/internal/config/repo_cache_lock.go
+++ b/internal/config/repo_cache_lock.go
@@ -10,7 +10,7 @@ import (
 const repoCacheLockName = ".packman-cache.lock"
 
 // ErrRepoCacheBusy reports that another process holds a conflicting repo-cache
-// lock. Only the Try* helpers return it; the blocking helpers wait instead.
+// lock. Only a non-blocking acquisition returns it; the rest wait instead.
 var ErrRepoCacheBusy = errors.New("repo cache is busy")
 
 // repoCacheLockOptions selects which repo-cache lock an acquisition takes and
@@ -41,29 +41,19 @@ func TryWithRepoCacheReadLock(root string, fn func() error) error {
 	return withRepoCacheLock(root, repoCacheLockOptions{mode: repoCacheLockShared, nonBlocking: true}, fn)
 }
 
-// WithRepoCacheWriteLock runs fn while holding the exclusive repo-cache lock.
+// WithRepoCacheWriteLock runs fn while holding the exclusive repo-cache lock,
+// waiting for whoever holds it. Callers whose answer must be correct —
+// installers, prune, bootstrap — want this.
 func WithRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
-	return writeLock(root, false, fn)
+	return withRepoCacheWriteLock(root, false, fn)
 }
 
-// TryWithRepoCacheWriteLock is WithRepoCacheWriteLock for advisory callers: it
-// returns ErrRepoCacheBusy immediately rather than waiting for a writer that
-// may be doing a network clone. Cache repair reached from an advisory load is
-// better skipped than waited on; the next authoritative command repairs it.
-func TryWithRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
-	return writeLock(root, true, fn)
-}
-
-// repoCacheWriteLock picks the exclusive-lock helper matching a load's
-// blocking policy, so call sites read the same either way.
-func repoCacheWriteLock(nonBlocking bool) func(string, func() (string, error)) (string, error) {
-	if nonBlocking {
-		return TryWithRepoCacheWriteLock
-	}
-	return WithRepoCacheWriteLock
-}
-
-func writeLock(root string, nonBlocking bool, fn func() (string, error)) (string, error) {
+// withRepoCacheWriteLock runs fn under the exclusive repo-cache lock. With
+// nonBlocking it returns ErrRepoCacheBusy immediately rather than waiting for
+// a writer that may be doing a network clone: cache repair reached from an
+// advisory load is better skipped than waited on, and the next authoritative
+// command repairs it.
+func withRepoCacheWriteLock(root string, nonBlocking bool, fn func() (string, error)) (string, error) {
 	var result string
 	err := withRepoCacheLock(root, repoCacheLockOptions{
 		mode:        repoCacheLockExclusive,

--- a/internal/config/repo_cache_lock_nonblocking_test.go
+++ b/internal/config/repo_cache_lock_nonblocking_test.go
@@ -1,0 +1,128 @@
+//go:build !windows
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// holdRepoCacheLock takes mode on the cache root's lock file and releases it
+// when the test ends. It returns the root so callers can pass it straight to
+// the helper under test.
+func holdRepoCacheLock(t *testing.T, mode int) string {
+	t.Helper()
+	root := t.TempDir()
+	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	t.Cleanup(func() { lockFile.Close() }) //nolint:errcheck
+	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+		t.Fatalf("Flock(%d): %v", mode, err)
+	}
+	t.Cleanup(func() { syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }) //nolint:errcheck
+	return root
+}
+
+func TestTryWithRepoCacheReadLockReportsBusyWithoutWaiting(t *testing.T) {
+	root := holdRepoCacheLock(t, syscall.LOCK_EX)
+
+	called := false
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- TryWithRepoCacheReadLock(root, func() error {
+			called = true
+			return nil
+		})
+	}()
+
+	// A blocking acquisition never returns while the exclusive lock is held,
+	// so this select is what fails the test if LOCK_NB is ever dropped.
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("TryWithRepoCacheReadLock blocked on a held exclusive lock")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("returned after %v, want an immediate refusal", elapsed)
+	}
+	if !errors.Is(err, ErrRepoCacheBusy) {
+		t.Fatalf("err = %v, want ErrRepoCacheBusy", err)
+	}
+	if called {
+		t.Fatal("callback ran while the exclusive lock was held")
+	}
+}
+
+func TestTryWithRepoCacheReadLockRunsWhenLockIsFree(t *testing.T) {
+	root := t.TempDir()
+	called := false
+	if err := TryWithRepoCacheReadLock(root, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("TryWithRepoCacheReadLock: %v", err)
+	}
+	if !called {
+		t.Fatal("callback did not run with the lock free")
+	}
+}
+
+// A shared holder must not lock out a shared try-acquisition. This is the
+// control that distinguishes a correct LOCK_SH|LOCK_NB from a LOCK_EX|LOCK_NB
+// that would refuse every concurrent reader and quietly disable pack
+// discovery whenever any other gc process is reading the cache.
+func TestTryWithRepoCacheReadLockSharesWithOtherReaders(t *testing.T) {
+	root := holdRepoCacheLock(t, syscall.LOCK_SH)
+
+	called := false
+	if err := TryWithRepoCacheReadLock(root, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("TryWithRepoCacheReadLock: %v", err)
+	}
+	if !called {
+		t.Fatal("callback did not run alongside another shared reader")
+	}
+}
+
+// Missing root means there is no cache to contend for, so the callback runs
+// and no lock file is created — matching WithRepoCacheReadLock.
+func TestTryWithRepoCacheReadLockDoesNotCreateMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	called := false
+	if err := TryWithRepoCacheReadLock(root, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("TryWithRepoCacheReadLock: %v", err)
+	}
+	if !called {
+		t.Fatal("callback did not run for a missing cache root")
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("root stat err = %v, want not exist", err)
+	}
+}
+
+// The callback's own error must reach the caller unchanged, so a busy cache
+// stays distinguishable from work that ran and failed.
+func TestTryWithRepoCacheReadLockPropagatesCallbackError(t *testing.T) {
+	root := t.TempDir()
+	sentinel := errors.New("callback failed")
+	err := TryWithRepoCacheReadLock(root, func() error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the callback error", err)
+	}
+	if errors.Is(err, ErrRepoCacheBusy) {
+		t.Fatal("callback error was reported as a busy cache")
+	}
+}

--- a/internal/config/repo_cache_lock_unix.go
+++ b/internal/config/repo_cache_lock_unix.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -13,7 +14,8 @@ const (
 	repoCacheLockExclusive = syscall.LOCK_EX
 )
 
-func withRepoCacheLock(root string, mode int, createRoot bool, fn func() error) error {
+func withRepoCacheLock(root string, opts repoCacheLockOptions, fn func() error) error {
+	createRoot := opts.createRoot
 	if createRoot {
 		if err := os.MkdirAll(root, 0o755); err != nil {
 			return fmt.Errorf("creating repo cache root: %w", err)
@@ -31,7 +33,16 @@ func withRepoCacheLock(root string, mode int, createRoot bool, fn func() error) 
 		return fmt.Errorf("opening repo cache lock file: %w", err)
 	}
 	defer lockFile.Close() //nolint:errcheck
+	mode := opts.mode
+	if opts.nonBlocking {
+		mode |= syscall.LOCK_NB
+	}
 	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+		// LOCK_NB reports contention as EWOULDBLOCK. Everything else is a
+		// real failure and must not be mistaken for a busy cache.
+		if opts.nonBlocking && errors.Is(err, syscall.EWOULDBLOCK) {
+			return ErrRepoCacheBusy
+		}
 		return fmt.Errorf("locking repo cache: %w", err)
 	}
 	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck

--- a/internal/config/repo_cache_lock_windows.go
+++ b/internal/config/repo_cache_lock_windows.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,8 @@ const (
 	repoCacheLockExclusive = 1
 )
 
-func withRepoCacheLock(root string, mode int, createRoot bool, fn func() error) error {
+func withRepoCacheLock(root string, opts repoCacheLockOptions, fn func() error) error {
+	createRoot := opts.createRoot
 	if createRoot {
 		if err := os.MkdirAll(root, 0o755); err != nil {
 			return fmt.Errorf("creating repo cache root: %w", err)
@@ -34,11 +36,20 @@ func withRepoCacheLock(root string, mode int, createRoot bool, fn func() error) 
 	defer lockFile.Close() //nolint:errcheck
 
 	var flags uint32
-	if mode == repoCacheLockExclusive {
+	if opts.mode == repoCacheLockExclusive {
 		flags = windows.LOCKFILE_EXCLUSIVE_LOCK
+	}
+	if opts.nonBlocking {
+		flags |= windows.LOCKFILE_FAIL_IMMEDIATELY
 	}
 	var overlapped windows.Overlapped
 	if err := windows.LockFileEx(windows.Handle(lockFile.Fd()), flags, 0, 1, 0, &overlapped); err != nil {
+		// LOCKFILE_FAIL_IMMEDIATELY reports contention as ERROR_LOCK_VIOLATION.
+		// Everything else is a real failure and must not be mistaken for a
+		// busy cache.
+		if opts.nonBlocking && errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return ErrRepoCacheBusy
+		}
 		return fmt.Errorf("locking repo cache: %w", err)
 	}
 	defer windows.UnlockFileEx(windows.Handle(lockFile.Fd()), 0, 1, 0, &overlapped) //nolint:errcheck

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -53,14 +53,14 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	rigs := cfg.Rigs
 	for _, r := range rigs {
 		for _, ref := range r.Includes {
-			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, false)
 			writeRevisionDirHash(h, prov, "pack:"+r.Name+":"+ref, fs, topoDir)
 		}
 	}
 
 	// Hash city-level pack directory contents.
 	for _, ref := range cfg.Workspace.LegacyIncludes() {
-		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, false)
 		writeRevisionDirHash(h, prov, "city-pack:"+ref, fs, topoDir)
 	}
 
@@ -129,12 +129,12 @@ func (p *Provenance) captureRevisionSnapshot(fs fsys.FS, cfg *City, cityRoot str
 
 	for _, r := range cfg.Rigs {
 		for _, ref := range r.Includes {
-			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, false)
 			recordDir("pack:"+r.Name+":"+ref, topoDir)
 		}
 	}
 	for _, ref := range cfg.Workspace.LegacyIncludes() {
-		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot, false)
 		recordDir("city-pack:"+ref, topoDir)
 	}
 	if tracksPackV2Imports(cfg) {
@@ -321,7 +321,7 @@ func revisionPackDir(ref, declDir, cityRoot string) (string, bool) {
 	if strings.TrimSpace(ref) == "" {
 		return "", false
 	}
-	dir, err := resolvePackRef(ref, declDir, cityRoot)
+	dir, err := resolvePackRef(ref, declDir, cityRoot, false)
 	if err != nil || strings.TrimSpace(dir) == "" {
 		return "", false
 	}


### PR DESCRIPTION
## Problem

Eager pack-command discovery and shell completion run on **every** `gc`
invocation, and both load city config blockingly. A single `gc import install`
holds the exclusive repo-cache lock for the whole of its network clone — so one
clone in one terminal stalled every other `gc` command on the machine for its
entire duration.

Fixes ga-r0epd.

## What changed

**Don't wait for work nobody asked for.** Discovery and completion take the
repo-cache lock non-blockingly. `TryWithRepoCacheReadLock` and the non-blocking
write path return `config.ErrRepoCacheBusy` immediately instead of queueing.
Callers whose answer must be correct — installers, prune, bootstrap, skills
materialization — keep blocking and wait.

**Refusing to wait is only half the contract.** The other half is refusing to
*answer*. A path that swallows the busy error also returns promptly — from
whichever city it could still reach — and that is worse than a stall, because
`registerPackCommands` captures the chosen city into the pack-command `RunE`
closures the user later executes. A wrong advisory answer is a wrong city, not
merely stale data. So every advisory path propagates `ErrRepoCacheBusy` rather
than degrading to a partial result.

## Review-council findings, and their fixes

The council found three places where the advisory paths still answered from
whatever they could reach without waiting. All three are fixed in `acda6fae5e`.

**1. Busy local discovery fell through to the sticky remote default.**
`resolveContextAllowRemoteMode` treated "could not look" the same as "looked and
found nothing," so the same cwd resolved to a remote city while another terminal
happened to be cloning, and to the local one a moment later. It now returns the
busy error instead of descending a tier.
Guarded by `TestBusyRepoCacheDoesNotFallThroughToTheStickyDefault`, which
asserts an uncontended control resolves locally first — otherwise the assertion
would be about an unreachable sticky tier rather than about the busy cache.

**2. `resolvedPackNames` returned a short set on a busy cache.** That set decides
which builtin packs get *injected*, so a half-walked closure silently injects a
pack the city already has. It now reports `ErrRepoCacheBusy`; unresolvable refs
for any other reason are still skipped, since they bring nothing into the
closure either way.

**3. The `site.toml` pre-filter was gated on the resolution mode.** Skipping a
city also skips its *load error*, and one load error fails any scan that also
matched something. The `mode.advisory &&` form therefore left advisory returning
city A while authoritative errored and fell through to the cwd walk-up — a
different city, decided by who asked. The condition now mentions no mode at all:
it is gated on `!failOnLoadError`, which is a different question (report
everything wrong with the registry vs. match only). Parity then holds for every
`(failOnLoadError, mode)` pair **by construction**, with no premise about which
call sites pair which values.

`TestRigLookupTreatsUnmatchableBrokenCityTheSameInBothModes` covers the full 2×2.
Reinstating `mode.advisory` produces two distinct failures —
`match-only/authoritative` errors on the broken city, `report-load-errors/advisory`
silently skips it — which is exactly the parity break.

### Structural follow-through

`siteRigCandidates` is now the single derivation both the pre-filter and
`siteBoundRigBindings` run, so the filter's superset property is structural
rather than two functions agreeing by hand. Match predicates take a
`rigCandidate` — the fields `site.toml` alone determines — so the compiler
forbids a predicate from reading a field the pre-filter cannot populate. That
failure mode would otherwise be silent: the pre-filter would quietly stop
admitting a city the real scan would have matched, and the scan would just
return fewer bindings.

The four repo-cache write-lock spellings collapse to two:
`WithRepoCacheWriteLock` (blocking, exported) and `withRepoCacheWriteLock(root,
nonBlocking, fn)`.

## Testing

`TestBlockingCityLoadWaitsOnHeldRepoCacheLock` is the control this whole file
rests on: it proves a blocking load really does queue behind a held lock, and it
loads through `loadCityConfigWithoutBuiltinPackRefresh` — the blocking twin of
the advisory loader, differing in exactly the one bit under test. A loader that
refreshed builtin packs would block in the always-required builtin-ensure step
instead, staying green even if the fixture stopped importing anything, and every
assertion in the file would go quietly vacuous.

The fixture's repo cache is deliberately left cold, since a hydrated cache
short-circuits ahead of the lock.

- `make test-fast-parallel` — green, all 10 shards
- `go vet ./...` — clean
- resource census — clean
- Each behaviour change mutation-proved: reinstating `mode.advisory`, deleting
  the `lookupRigFromCwd` busy propagation, and deleting the sticky-default guard
  each produce a distinct, predicted failure.

## Follow-ups filed

- **ga-q66yd** (P3) — `nonBlocking bool` reads as a positional boolean at the
  call sites; worth a named option, but not worth widening an
  upstream-rebase-sensitive diff here.
- `loadSessionsForCompletion` is deliberately *not* covered: it opens the city
  store first, and the store open loads config blockingly and readies builtin
  packs. That is a second route into the same lock, tracked separately rather
  than left looking covered.
