### PR TITLE
fix(core): claim WORK_BEAD_ID before heartbeating it in mol-do-work

### DIFF
--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -44,11 +44,19 @@ gc bd show "$WORK_BEAD_ID"
 
 Read the bead's title and description carefully. This is your task.
 
-**Signal liveness:** run `gc bd heartbeat "$WORK_BEAD_ID"` now, and again before any
-shell command you expect to run for many minutes (long builds, test sweeps).
-It refreshes your claim's lease so the dashboard can tell you are alive and
-working rather than wedged. If a heartbeat ever fails, your claim was reclaimed
-or closed out from under you — stop working this bead immediately.
+**Claim it and signal liveness:** the input-convoy child derived above is not
+claimed by the routing step that assigned you — claim it explicitly before your
+first heartbeat:
+```bash
+gc bd update "$WORK_BEAD_ID" --claim
+```
+`--claim` is idempotent and self-assigns regardless of current state, so this is
+safe even if the bead was already claimed some other way. Then run
+`gc bd heartbeat "$WORK_BEAD_ID"` now, and again before any shell command you
+expect to run for many minutes (long builds, test sweeps). It refreshes your
+claim's lease so the dashboard can tell you are alive and working rather than
+wedged. If a heartbeat ever fails, your claim was reclaimed or closed out from
+under you — stop working this bead immediately.
 
 **2. Implement the solution and verify it:**
 


### PR DESCRIPTION
## Bug

`gc sling <pool-target> <existing-bead-id>` wraps the routed bead as the sole child of a synthetic input convoy. The `do-work` step's own routing claims the workflow STEP bead, but never claims that convoy child (`WORK_BEAD_ID`) itself. The step then instructs the agent to heartbeat `WORK_BEAD_ID` directly, which fails 100% of the time — `bd heartbeat` only refreshes an existing `in_progress` lease held by the calling actor, it does not auto-claim.

Confirmed 100% reproduction across three independent dispatches on a downstream city before this fix (all failing identically at the first `gc bd heartbeat` call with `"issue not claimable: <id> status open"`).

## Fix

Add an explicit `gc bd update "$WORK_BEAD_ID" --claim` immediately before the heartbeat in `mol-do-work.toml`'s `do-work` step. `--claim` is idempotent and self-assigns regardless of current state, so this is safe whether or not something else already holds/matches the lease.

## Verification

Root-caused via a controlled probe reproducing the exact error on a disposable bead, and via `bd history` showing affected beads only ever transitioned `open -> closed` (auto-closed as a blocked outcome), never `in_progress` — confirming the claim step was genuinely missing, not a flaky race.