### PR TITLE
fix(api): retry provider bearer once after 401

### DIFF
--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -733,6 +733,12 @@ func (rt *registryProviderReauthRoundTripper) RoundTrip(req *http.Request) (*htt
 		if ctxErr := req.Context().Err(); ctxErr != nil {
 			return nil, fmt.Errorf("refreshing registry credential after 401: %w", ctxErr)
 		}
+		if errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("refreshing registry credential after 401: %w", context.Canceled)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("refreshing registry credential after 401: %w", context.DeadlineExceeded)
+		}
 		return nil, errors.New("refreshing registry credential after 401: credential refresh failed")
 	}
 	token = strings.TrimSpace(token)

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -722,7 +722,8 @@ func (rt *registryProviderReauthRoundTripper) RoundTrip(req *http.Request) (*htt
 	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized || rt.refresh == nil {
 		return resp, err
 	}
-	if !registryHasBearerAuthorization(req.Header.Get("Authorization")) ||
+	if !isRegistryRetrySafeMethod(req.Method) ||
+		!registryHasBearerAuthorization(req.Header.Get("Authorization")) ||
 		(req.Body != nil && req.Body != http.NoBody && req.GetBody == nil) {
 		return resp, nil
 	}
@@ -752,7 +753,7 @@ func (rt *registryProviderReauthRoundTripper) RoundTrip(req *http.Request) (*htt
 		retry.Body, err = req.GetBody()
 		if err != nil {
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("replaying registry request after credential refresh: %w", err)
+			return nil, errors.New("replaying registry request after credential refresh: request body recreation failed")
 		}
 	}
 	retry.Header.Set("Authorization", "Bearer "+token)
@@ -763,6 +764,15 @@ func (rt *registryProviderReauthRoundTripper) RoundTrip(req *http.Request) (*htt
 func registryHasBearerAuthorization(value string) bool {
 	fields := strings.Fields(value)
 	return len(fields) == 2 && strings.EqualFold(fields[0], "Bearer") && fields[1] != ""
+}
+
+func isRegistryRetrySafeMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
 }
 
 func (a registryPublishAuth) hasCredentials() bool {

--- a/cmd/gc/cmd_registry.go
+++ b/cmd/gc/cmd_registry.go
@@ -730,7 +730,10 @@ func (rt *registryProviderReauthRoundTripper) RoundTrip(req *http.Request) (*htt
 	token, err := rt.refresh(req.Context(), true)
 	if err != nil {
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("refreshing registry credential after 401: %w", err)
+		if ctxErr := req.Context().Err(); ctxErr != nil {
+			return nil, fmt.Errorf("refreshing registry credential after 401: %w", ctxErr)
+		}
+		return nil, errors.New("refreshing registry credential after 401: credential refresh failed")
 	}
 	token = strings.TrimSpace(token)
 	if token == "" {

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -806,7 +806,7 @@ func TestRegistryGasworksCredentialOriginAllowsOnlyCanonicalProductionOrigin(t *
 	}
 }
 
-func TestDoRegistryPublishProviderRefreshesOnceAfter401(t *testing.T) {
+func TestDoRegistryPublishProviderDoesNotRefreshAfter401(t *testing.T) {
 	_, packDir := setupRegistryPublishRepo(t)
 	clearRegistryEnv(t)
 	const baseURL = defaultRegistryPublishURL
@@ -832,32 +832,14 @@ func TestDoRegistryPublishProviderRefreshesOnceAfter401(t *testing.T) {
 	requests := 0
 	registryPublishHTTPClient = &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		requests++
-		if requests == 1 {
-			if got := r.Header.Get("Authorization"); got != "Bearer sts-initial" {
-				t.Fatalf("first Authorization = %q", got)
-			}
-			return &http.Response{
-				StatusCode: http.StatusUnauthorized,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"unauthorized","message":"expired"}}`)),
-				Request:    r,
-			}, nil
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer sts-refreshed" {
-			t.Fatalf("retry Authorization = %q", got)
+		if got := r.Header.Get("Authorization"); got != "Bearer sts-initial" {
+			t.Fatalf("Authorization = %q", got)
 		}
 		return &http.Response{
-			StatusCode: http.StatusOK,
+			StatusCode: http.StatusUnauthorized,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body: io.NopCloser(strings.NewReader(`{
-				"publishRequest": {
-					"id": "prq_refreshed",
-					"status": "pending_review",
-					"requestedName": "gastownhall/demo-pack",
-					"requestedVersion": "0.2.0"
-				}
-			}`)),
-			Request: r,
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"unauthorized","message":"expired"}}`)),
+			Request:    r,
 		}, nil
 	})}
 
@@ -866,17 +848,14 @@ func TestDoRegistryPublishProviderRefreshesOnceAfter401(t *testing.T) {
 		RegistryURL: baseURL,
 		Validate:    true,
 	}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("doRegistryPublish = %d, stderr=%q", code, stderr.String())
+	if code == 0 {
+		t.Fatalf("doRegistryPublish succeeded, stdout=%q", stdout.String())
 	}
-	if requests != 2 {
-		t.Fatalf("publish requests = %d, want 2", requests)
+	if requests != 1 {
+		t.Fatalf("publish requests = %d, want 1", requests)
 	}
-	if len(forceRefresh) != 2 || forceRefresh[0] || !forceRefresh[1] {
-		t.Fatalf("force refresh calls = %v, want [false true]", forceRefresh)
-	}
-	if !strings.Contains(stdout.String(), "prq_refreshed") {
-		t.Fatalf("stdout = %q", stdout.String())
+	if len(forceRefresh) != 1 || forceRefresh[0] {
+		t.Fatalf("force refresh calls = %v, want [false]", forceRefresh)
 	}
 }
 
@@ -909,7 +888,7 @@ func TestRegistryProviderReauthRoundTripperRetriesOnlyEligible401(t *testing.T) 
 				return "refreshed", nil
 			},
 		}
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/api/me", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -956,9 +935,9 @@ func TestRegistryProviderReauthRoundTripperRetriesOnlyEligible401(t *testing.T) 
 			var req *http.Request
 			var err error
 			if tc.replayable {
-				req, err = http.NewRequestWithContext(t.Context(), http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+				req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/api/me", bytes.NewReader([]byte("payload")))
 			} else {
-				req, err = http.NewRequestWithContext(t.Context(), http.MethodPost, "https://registry.example/api/publish-requests", io.NopCloser(strings.NewReader("payload")))
+				req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/api/me", io.NopCloser(strings.NewReader("payload")))
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -973,6 +952,95 @@ func TestRegistryProviderReauthRoundTripperRetriesOnlyEligible401(t *testing.T) 
 				t.Fatalf("requests=%d refreshes=%d, want 1/0", requests, refreshes)
 			}
 		})
+	}
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method+" 401 is not replayed", func(t *testing.T) {
+			requests := 0
+			refreshes := 0
+			rt := &registryProviderReauthRoundTripper{
+				base: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+					requests++
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(`{}`)),
+						Request:    r,
+					}, nil
+				}),
+				refresh: func(context.Context, bool) (string, error) {
+					refreshes++
+					return "refreshed", nil
+				},
+			}
+			req, err := http.NewRequestWithContext(t.Context(), method, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer initial")
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusUnauthorized || requests != 1 || refreshes != 0 {
+				t.Fatalf("status=%d requests=%d refreshes=%d, want 401/1/0", resp.StatusCode, requests, refreshes)
+			}
+		})
+	}
+}
+
+type registryCloseTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *registryCloseTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestRegistryProviderReauthRoundTripperSanitizesBodyRecreationFailure(t *testing.T) {
+	const secretMarker = "registry-body-recreation-super-secret"
+
+	firstBody := &registryCloseTrackingBody{Reader: strings.NewReader("rejected")}
+	baseCalls, refreshes := 0, 0
+	rt := &registryProviderReauthRoundTripper{
+		base: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			baseCalls++
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       firstBody,
+				Request:    r,
+			}, nil
+		}),
+		refresh: func(context.Context, bool) (string, error) {
+			refreshes++
+			return "fresh", nil
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/api/me", strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, errors.New("body recreation failed: " + secretMarker)
+	}
+	req.Header.Set("Authorization", "Bearer stale")
+
+	resp, err := rt.RoundTrip(req)
+	if resp != nil || err == nil {
+		t.Fatalf("response=%v error=%v, want nil response and sanitized body recreation failure", resp, err)
+	}
+	if got, want := err.Error(), "replaying registry request after credential refresh: request body recreation failed"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	if strings.Contains(err.Error(), secretMarker) {
+		t.Fatalf("body recreation error leaked request material: %q", err)
+	}
+	if baseCalls != 1 || refreshes != 1 || !firstBody.closed {
+		t.Fatalf("calls=%d refreshes=%d body closed=%v, want 1, 1, true", baseCalls, refreshes, firstBody.closed)
 	}
 }
 
@@ -1024,7 +1092,7 @@ func TestRegistryProviderReauthRoundTripperRefreshHonorsCancellation(t *testing.
 					return "", errors.New("credential helper failed: bearer=super-secret helper stderr")
 				},
 			}
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://registry.example/api/me", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1068,7 +1136,7 @@ func TestRegistryProviderReauthRoundTripperRefreshPreservesHelperContext(t *test
 					return "", fmt.Errorf("credential helper stderr bearer=super-secret: %w", tt.want)
 				},
 			}
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://registry.example/api/me", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1102,7 +1170,7 @@ func TestRegistryProviderReauthRoundTripperRefreshFailureIsSecretSafe(t *testing
 			return "", errors.New("credential helper failed: bearer=super-secret helper stderr")
 		},
 	}
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/api/me", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -976,10 +976,76 @@ func TestRegistryProviderReauthRoundTripperRetriesOnlyEligible401(t *testing.T) 
 }
 
 func TestRegistryProviderReauthRoundTripperRefreshHonorsCancellation(t *testing.T) {
-	requests := 0
+	tests := []struct {
+		name                string
+		newContext          func(*testing.T) (context.Context, context.CancelFunc)
+		cancelBeforeRefresh bool
+		want                error
+	}{
+		{
+			name: "canceled",
+			newContext: func(t *testing.T) (context.Context, context.CancelFunc) {
+				return context.WithCancel(t.Context())
+			},
+			cancelBeforeRefresh: true,
+			want:                context.Canceled,
+		},
+		{
+			name: "deadline exceeded",
+			newContext: func(t *testing.T) (context.Context, context.CancelFunc) {
+				return context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := tt.newContext(t)
+			defer cancel()
+			requests := 0
+			rt := &registryProviderReauthRoundTripper{
+				base: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+					requests++
+					if tt.cancelBeforeRefresh {
+						cancel()
+					}
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(`{}`)),
+						Request:    r,
+					}, nil
+				}),
+				refresh: func(_ context.Context, force bool) (string, error) {
+					if !force {
+						t.Fatal("401 refresh was not forced")
+					}
+					return "", errors.New("credential helper failed: bearer=super-secret helper stderr")
+				},
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer initial")
+
+			resp, err := rt.RoundTrip(req)
+			if resp != nil || !errors.Is(err, tt.want) {
+				t.Fatalf("response=%v error=%v, want nil response and %v", resp, err, tt.want)
+			}
+			if strings.Contains(err.Error(), "super-secret") || strings.Contains(err.Error(), "stderr") {
+				t.Fatalf("refresh error leaked credential-helper output: %q", err)
+			}
+			if requests != 1 {
+				t.Fatalf("requests = %d, want no replay after cancellation", requests)
+			}
+		})
+	}
+}
+
+func TestRegistryProviderReauthRoundTripperRefreshFailureIsSecretSafe(t *testing.T) {
 	rt := &registryProviderReauthRoundTripper{
 		base: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			requests++
 			return &http.Response{
 				StatusCode: http.StatusUnauthorized,
 				Header:     make(http.Header),
@@ -987,30 +1053,25 @@ func TestRegistryProviderReauthRoundTripperRefreshHonorsCancellation(t *testing.
 				Request:    r,
 			}, nil
 		}),
-		refresh: func(ctx context.Context, force bool) (string, error) {
-			if !force {
-				t.Fatal("401 refresh was not forced")
-			}
-			return "", ctx.Err()
+		refresh: func(context.Context, bool) (string, error) {
+			return "", errors.New("credential helper failed: bearer=super-secret helper stderr")
 		},
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Authorization", "Bearer initial")
-	cancel()
 
 	resp, err := rt.RoundTrip(req)
-	if resp != nil {
-		t.Fatalf("response = %v, want nil after refresh cancellation", resp)
+	if resp != nil || err == nil {
+		t.Fatalf("response=%v error=%v, want nil response and refresh error", resp, err)
 	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("err = %v, want context.Canceled", err)
+	if got, want := err.Error(), "refreshing registry credential after 401: credential refresh failed"; got != want {
+		t.Fatalf("refresh error = %q, want %q", got, want)
 	}
-	if requests != 1 {
-		t.Fatalf("requests = %d, want no replay after cancellation", requests)
+	if strings.Contains(err.Error(), "super-secret") || strings.Contains(err.Error(), "stderr") {
+		t.Fatalf("refresh error leaked credential-helper output: %q", err)
 	}
 }
 

--- a/cmd/gc/cmd_registry_test.go
+++ b/cmd/gc/cmd_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1038,6 +1039,50 @@ func TestRegistryProviderReauthRoundTripperRefreshHonorsCancellation(t *testing.
 			}
 			if requests != 1 {
 				t.Fatalf("requests = %d, want no replay after cancellation", requests)
+			}
+		})
+	}
+}
+
+func TestRegistryProviderReauthRoundTripperRefreshPreservesHelperContext(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		want error
+	}{
+		{name: "canceled", want: context.Canceled},
+		{name: "deadline exceeded", want: context.DeadlineExceeded},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			rt := &registryProviderReauthRoundTripper{
+				base: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+					requests++
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(`{}`)),
+						Request:    r,
+					}, nil
+				}),
+				refresh: func(context.Context, bool) (string, error) {
+					return "", fmt.Errorf("credential helper stderr bearer=super-secret: %w", tt.want)
+				},
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://registry.example/api/publish-requests", bytes.NewReader([]byte("payload")))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer initial")
+
+			resp, err := rt.RoundTrip(req)
+			if resp != nil || !errors.Is(err, tt.want) {
+				t.Fatalf("response=%v error=%v, want nil response and %v", resp, err, tt.want)
+			}
+			if strings.Contains(err.Error(), "super-secret") || strings.Contains(err.Error(), "stderr") {
+				t.Fatalf("refresh error leaked credential-helper output: %q", err)
+			}
+			if requests != 1 {
+				t.Fatalf("requests = %d, want no replay after helper cancellation", requests)
 			}
 		})
 	}

--- a/cmd/gc/remote_client.go
+++ b/cmd/gc/remote_client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -38,12 +39,15 @@ func remoteClientOptions(target *remoteTarget) (api.RemoteOptions, error) {
 			opts.Token = cs.Token
 			// Force-mint on a 401 so a token rejected before its expiry (edge key
 			// rotation / early revocation) recovers without a fresh gc invocation.
-			opts.RefreshToken = cs.Refresh
+			opts.RefreshToken = func(ctx context.Context) (string, error) {
+				return cs.RefreshContext(ctx)
+			}
 		}
 	}
 	if target.Token != "" {
 		tok := target.Token
 		opts.Token = func() (string, error) { return tok, nil }
+		opts.RefreshToken = nil
 	}
 	return opts, nil
 }

--- a/cmd/gc/remote_client_test.go
+++ b/cmd/gc/remote_client_test.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -88,10 +93,30 @@ func TestResolveReadTarget_Remote(t *testing.T) {
 func TestCmdBeadsList_RemoteRoutesToServerNoFallback(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 
+	statePath := filepath.Join(t.TempDir(), "credential-state")
+	scriptPath := filepath.Join(t.TempDir(), "credential-helper.sh")
+	script := "#!/bin/sh\n" +
+		"if [ -e \"$1\" ]; then\n" +
+		"  printf '%s\\n' '{\"token\":\"fresh\",\"expiration_timestamp\":\"2030-01-01T00:00:00Z\"}'\n" +
+		"else\n" +
+		"  : > \"$1\"\n" +
+		"  printf '%s\\n' '{\"token\":\"stale\",\"expiration_timestamp\":\"2030-01-01T00:00:00Z\"}'\n" +
+		"fi\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	command := fmt.Sprintf("%s %s", strconv.Quote(scriptPath), strconv.Quote(statePath))
+
 	var gotPath, gotReq string
+	var auth []string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotReq = r.Header.Get("X-GC-Request")
+		auth = append(auth, r.Header.Get("Authorization"))
+		if len(auth) == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{}`))
@@ -99,7 +124,7 @@ func TestCmdBeadsList_RemoteRoutesToServerNoFallback(t *testing.T) {
 	defer srv.Close()
 
 	var out, errb bytes.Buffer
-	if code := doContextAdd(clientcontext.Context{Name: "prod", URL: srv.URL, City: "mc", InsecureSkipVerify: true}, &out, &errb); code != 0 {
+	if code := doContextAdd(clientcontext.Context{Name: "prod", URL: srv.URL, City: "mc", InsecureSkipVerify: true, CredentialCommand: command}, &out, &errb); code != 0 {
 		t.Fatalf("seed context: %q", errb.String())
 	}
 	setProdContextFlag(t)
@@ -121,6 +146,9 @@ func TestCmdBeadsList_RemoteRoutesToServerNoFallback(t *testing.T) {
 	}
 	if gotReq != "true" {
 		t.Errorf("X-GC-Request = %q, want true", gotReq)
+	}
+	if got, want := auth, []string{"Bearer stale", "Bearer fresh"}; !slices.Equal(got, want) {
+		t.Fatalf("Authorization sequence = %v, want %v", got, want)
 	}
 }
 

--- a/cmd/gc/remote_client_test.go
+++ b/cmd/gc/remote_client_test.go
@@ -48,6 +48,22 @@ func TestBuildRemoteClient_CredentialCommandWired(t *testing.T) {
 	}
 }
 
+func TestRemoteClientOptionsStaticTokenDoesNotWireRefresh(t *testing.T) {
+	opts, err := remoteClientOptions(&remoteTarget{
+		BaseURL: "https://box:9443", CityName: "mc", Token: "static",
+		Ctx: &clientcontext.Context{Name: "c", URL: "https://box:9443", City: "mc", CredentialCommand: "echo x"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Token == nil {
+		t.Fatal("static token was not wired")
+	}
+	if opts.RefreshToken != nil {
+		t.Fatal("static token must not gain a refresh source")
+	}
+}
+
 func TestResolveReadTarget_Remote(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
 	var out, errb bytes.Buffer

--- a/internal/api/client_remote.go
+++ b/internal/api/client_remote.go
@@ -130,11 +130,11 @@ func NewRemoteCityScopedClient(baseURL, cityName string, opts RemoteOptions) (*C
 // NewRemoteEventsClient builds a genclient for the events feed against a remote
 // city. It is backed by the NO-TIMEOUT stream HTTP client — a --follow SSE
 // stream must not be cut by the bounded REST timeout — and carries the same auth
-// as the REST client: the X-GC-Request CSRF header, an Authorization bearer from
-// opts.Token, and a 401 re-mint via opts.RefreshToken (wrapped into the stream
-// transport by newRemoteHTTPClients). It is the events path's authenticated
-// client for a --context/--city-url remote target. No X-GC-City-Write grant: the
-// events feed is read-only.
+// as the REST client: the X-GC-Request CSRF header and an Authorization bearer
+// from opts.Token. A 401 on the stream is deliberately not retried, because
+// reconnecting an SSE request can duplicate event delivery. It is the events
+// path's authenticated client for a --context/--city-url remote target. No
+// X-GC-City-Write grant: the events feed is read-only.
 func NewRemoteEventsClient(baseURL string, opts RemoteOptions) (*genclient.ClientWithResponses, error) {
 	_, stream, err := newRemoteHTTPClients(opts)
 	if err != nil {
@@ -320,6 +320,9 @@ func (rt *reauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	tok = strings.TrimSpace(tok)
 	if rerr != nil {
 		_ = resp.Body.Close()
+		if ctxErr := req.Context().Err(); ctxErr != nil {
+			return nil, fmt.Errorf("refreshing bearer after 401: %w", ctxErr)
+		}
 		// Refresh sources may execute credential helpers whose errors include
 		// stderr. Keep helper diagnostics out of this public transport error.
 		return nil, fmt.Errorf("refreshing bearer after 401: credential refresh failed")
@@ -349,6 +352,20 @@ func hasBearerAuthorization(value string) bool {
 }
 
 func isSSERequest(req *http.Request) bool {
+	// The generated StreamEvents request intentionally has no Accept header.
+	// Keep its exact route non-replayable even when a 401 arrives before a
+	// server can establish the SSE response.
+	if req.Method == http.MethodGet && req.URL != nil {
+		const prefix = "/v0/city/"
+		const suffix = "/events/stream"
+		path := req.URL.Path
+		if strings.HasPrefix(path, prefix) && strings.HasSuffix(path, suffix) {
+			cityName := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+			if cityName != "" && !strings.Contains(cityName, "/") {
+				return true
+			}
+		}
+	}
 	for _, value := range req.Header.Values("Accept") {
 		for _, mediaType := range strings.Split(value, ",") {
 			if strings.EqualFold(strings.TrimSpace(strings.SplitN(mediaType, ";", 2)[0]), "text/event-stream") {

--- a/internal/api/client_remote.go
+++ b/internal/api/client_remote.go
@@ -320,7 +320,9 @@ func (rt *reauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	tok = strings.TrimSpace(tok)
 	if rerr != nil {
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("refreshing bearer after 401: %w", rerr)
+		// Refresh sources may execute credential helpers whose errors include
+		// stderr. Keep helper diagnostics out of this public transport error.
+		return nil, fmt.Errorf("refreshing bearer after 401: credential refresh failed")
 	}
 	if tok == "" {
 		_ = resp.Body.Close()

--- a/internal/api/client_remote.go
+++ b/internal/api/client_remote.go
@@ -39,6 +39,11 @@ const (
 // a grant rather than a bearer).
 type TokenSource func() (string, error)
 
+// TokenRefreshSource force-mints a fresh transport bearer after the peer
+// rejects the currently presented bearer. The request context bounds the
+// refresh operation. A nil source disables automatic refresh and retry.
+type TokenRefreshSource func(context.Context) (string, error)
+
 // GrantBinding is the request binding a city-write grant is bound to. The
 // transport computes it from the FINAL outgoing request and hands it to a
 // GrantSource, which mints a grant covering exactly this method/path/query/body.
@@ -65,11 +70,10 @@ type RemoteOptions struct {
 	// (consumed by an edge/proxy; the controller ignores Authorization).
 	Token TokenSource
 	// RefreshToken, when non-nil, force-mints a fresh bearer (bypassing any
-	// expiry cache). The transport calls it once on a 401 and retries the request
-	// with the new bearer, so an edge that rejects a still-unexpired token (key
-	// rotation, early revocation) recovers without a fresh gc invocation. Only
-	// applied to requests that carry no single-use X-GC-City-Write grant.
-	RefreshToken TokenSource
+	// expiry cache). The transport calls it once on a 401 and retries only a
+	// bearer-authenticated, replayable non-SSE request without a single-use
+	// city-write grant.
+	RefreshToken TokenRefreshSource
 	// Grant, when non-nil, mints an X-GC-City-Write grant for each mutating
 	// request (a direct hardened self-host). Reads never carry a grant.
 	Grant GrantSource
@@ -290,46 +294,67 @@ func newRemoteHTTPClients(opts RemoteOptions) (rest, stream *http.Client, err er
 	return rest, stream, nil
 }
 
-// reauthRoundTripper retries a request ONCE on a 401 after force-minting a fresh
-// bearer, so an edge that rejects a still-unexpired token (key rotation, early
-// revocation) recovers transparently. It deliberately does NOT retry a request
-// carrying an X-GC-City-Write grant: that grant is single-use and bound to the
-// exact bytes, and the request editors (which mint it) do not re-run at the
-// transport layer — a fresh grant needs a fresh gc invocation. A body without
-// GetBody (non-replayable) is also left alone.
+// reauthRoundTripper retries one bearer-authenticated, replayable non-SSE
+// request after a 401 by force-minting a fresh bearer. It calls the underlying
+// transport directly for the retry, so a second 401 is returned without another
+// refresh. Redirect follow-ups and requests with single-use city-write grants
+// are deliberately never retried.
 type reauthRoundTripper struct {
 	base    http.RoundTripper
-	refresh TokenSource
+	refresh TokenRefreshSource
 }
 
 func (rt *reauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.base.RoundTrip(req)
-	if err != nil || resp.StatusCode != http.StatusUnauthorized || rt.refresh == nil {
+	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized || rt.refresh == nil {
 		return resp, err
 	}
-	if req.Header.Get("X-GC-City-Write") != "" {
-		return resp, err // single-use grant; cannot re-mint here
+	if !hasBearerAuthorization(req.Header.Get("Authorization")) ||
+		req.Header.Get("X-GC-City-Write") != "" ||
+		isSSERequest(req) ||
+		req.Response != nil ||
+		(req.Body != nil && req.Body != http.NoBody && req.GetBody == nil) {
+		return resp, nil
 	}
-	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
-		return resp, err // non-replayable body
+	tok, rerr := rt.refresh(req.Context())
+	tok = strings.TrimSpace(tok)
+	if rerr != nil {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("refreshing bearer after 401: %w", rerr)
 	}
-	tok, rerr := rt.refresh()
-	if rerr != nil || strings.TrimSpace(tok) == "" {
-		return resp, err // keep the original 401
+	if tok == "" {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("refreshing bearer after 401: credential source returned an empty token")
 	}
 	retry := req.Clone(req.Context())
 	if req.GetBody != nil {
 		body, gerr := req.GetBody()
 		if gerr != nil {
-			return resp, err // cannot replay; keep the original 401 (untouched)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("replaying request after bearer refresh: %w", gerr)
 		}
 		retry.Body = body
 	}
 	retry.Header.Set("Authorization", "Bearer "+tok)
-	// Committed to the retry: drain + close the first response, then re-send.
-	_, _ = io.Copy(io.Discard, resp.Body)
+	// Committed to the retry: close the first response before re-sending.
 	_ = resp.Body.Close()
 	return rt.base.RoundTrip(retry)
+}
+
+func hasBearerAuthorization(value string) bool {
+	value = strings.TrimSpace(value)
+	return strings.HasPrefix(value, "Bearer ") && strings.TrimSpace(strings.TrimPrefix(value, "Bearer ")) != ""
+}
+
+func isSSERequest(req *http.Request) bool {
+	for _, value := range req.Header.Values("Accept") {
+		for _, mediaType := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(strings.SplitN(mediaType, ";", 2)[0]), "text/event-stream") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // remoteTLSConfig builds the client TLS config from the options: a custom CA

--- a/internal/api/client_remote.go
+++ b/internal/api/client_remote.go
@@ -72,8 +72,8 @@ type RemoteOptions struct {
 	Token TokenSource
 	// RefreshToken, when non-nil, force-mints a fresh bearer (bypassing any
 	// expiry cache). The transport calls it once on a 401 and retries only a
-	// bearer-authenticated, replayable non-SSE request without a single-use
-	// city-write grant.
+	// bearer-authenticated, safe, replayable non-SSE request without a
+	// single-use city-write grant.
 	RefreshToken TokenRefreshSource
 	// Grant, when non-nil, mints an X-GC-City-Write grant for each mutating
 	// request (a direct hardened self-host). Reads never carry a grant.
@@ -145,6 +145,8 @@ func NewRemoteEventsClient(baseURL string, opts RemoteOptions) (*genclient.Clien
 		genclient.WithHTTPClient(stream),
 		genclient.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
 			req.Header.Set("X-GC-Request", "true")
+			// This client is used exclusively for generated SSE operations.
+			req.Header.Set("Accept", "text/event-stream")
 			return nil
 		}),
 	}
@@ -295,11 +297,11 @@ func newRemoteHTTPClients(opts RemoteOptions) (rest, stream *http.Client, err er
 	return rest, stream, nil
 }
 
-// reauthRoundTripper retries one bearer-authenticated, replayable non-SSE
+// reauthRoundTripper retries one bearer-authenticated, safe, replayable non-SSE
 // request after a 401 by force-minting a fresh bearer. It calls the underlying
 // transport directly for the retry, so a second 401 is returned without another
-// refresh. Redirect follow-ups and requests with single-use city-write grants
-// are deliberately never retried.
+// refresh. Unsafe requests, redirect follow-ups, and requests with single-use
+// city-write grants are deliberately never retried.
 type reauthRoundTripper struct {
 	base    http.RoundTripper
 	refresh TokenRefreshSource
@@ -310,7 +312,8 @@ func (rt *reauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized || rt.refresh == nil {
 		return resp, err
 	}
-	if !hasBearerAuthorization(req.Header.Get("Authorization")) ||
+	if !isRetrySafeMethod(req.Method) ||
+		!hasBearerAuthorization(req.Header.Get("Authorization")) ||
 		req.Header.Get("X-GC-City-Write") != "" ||
 		isSSERequest(req) ||
 		req.Response != nil ||
@@ -358,13 +361,16 @@ func hasBearerAuthorization(value string) bool {
 	return strings.HasPrefix(value, "Bearer ") && strings.TrimSpace(strings.TrimPrefix(value, "Bearer ")) != ""
 }
 
-func isSSERequest(req *http.Request) bool {
-	// Generated SSE requests intentionally have no Accept header. Keep only
-	// their exact route shapes non-replayable; generic "stream" paths remain
-	// eligible for the normal safe-REST retry policy.
-	if req.Method == http.MethodGet && req.URL != nil && isGeneratedSSEPath(req.URL.EscapedPath()) {
+func isRetrySafeMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
 		return true
+	default:
+		return false
 	}
+}
+
+func isSSERequest(req *http.Request) bool {
 	for _, value := range req.Header.Values("Accept") {
 		for _, mediaType := range strings.Split(value, ",") {
 			if strings.EqualFold(strings.TrimSpace(strings.SplitN(mediaType, ";", 2)[0]), "text/event-stream") {
@@ -373,37 +379,6 @@ func isSSERequest(req *http.Request) bool {
 		}
 	}
 	return false
-}
-
-func isGeneratedSSEPath(path string) bool {
-	segments := strings.Split(path, "/")
-	nonEmpty := func(indexes ...int) bool {
-		for _, index := range indexes {
-			if segments[index] == "" {
-				return false
-			}
-		}
-		return true
-	}
-
-	switch len(segments) {
-	case 4: // /v0/events/stream
-		return segments[0] == "" && segments[1] == "v0" && segments[2] == "events" && segments[3] == "stream"
-	case 6: // /v0/city/{city}/events/stream
-		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
-			nonEmpty(3) && segments[4] == "events" && segments[5] == "stream"
-	case 7: // /v0/city/{city}/session/{id}/stream
-		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
-			nonEmpty(3, 5) && segments[4] == "session" && segments[6] == "stream"
-	case 8: // /v0/city/{city}/agent/{base}/output/stream
-		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
-			nonEmpty(3, 5) && segments[4] == "agent" && segments[6] == "output" && segments[7] == "stream"
-	case 9: // /v0/city/{city}/agent/{dir}/{base}/output/stream
-		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
-			nonEmpty(3, 5, 6) && segments[4] == "agent" && segments[7] == "output" && segments[8] == "stream"
-	default:
-		return false
-	}
 }
 
 // remoteTLSConfig builds the client TLS config from the options: a custom CA

--- a/internal/api/client_remote.go
+++ b/internal/api/client_remote.go
@@ -346,7 +346,7 @@ func (rt *reauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		body, gerr := req.GetBody()
 		if gerr != nil {
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("replaying request after bearer refresh: %w", gerr)
+			return nil, errors.New("replaying request after bearer refresh: request body recreation failed")
 		}
 		retry.Body = body
 	}

--- a/internal/api/client_remote.go
+++ b/internal/api/client_remote.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -323,6 +324,12 @@ func (rt *reauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		if ctxErr := req.Context().Err(); ctxErr != nil {
 			return nil, fmt.Errorf("refreshing bearer after 401: %w", ctxErr)
 		}
+		if errors.Is(rerr, context.Canceled) {
+			return nil, fmt.Errorf("refreshing bearer after 401: %w", context.Canceled)
+		}
+		if errors.Is(rerr, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("refreshing bearer after 401: %w", context.DeadlineExceeded)
+		}
 		// Refresh sources may execute credential helpers whose errors include
 		// stderr. Keep helper diagnostics out of this public transport error.
 		return nil, fmt.Errorf("refreshing bearer after 401: credential refresh failed")
@@ -352,19 +359,11 @@ func hasBearerAuthorization(value string) bool {
 }
 
 func isSSERequest(req *http.Request) bool {
-	// The generated StreamEvents request intentionally has no Accept header.
-	// Keep its exact route non-replayable even when a 401 arrives before a
-	// server can establish the SSE response.
-	if req.Method == http.MethodGet && req.URL != nil {
-		const prefix = "/v0/city/"
-		const suffix = "/events/stream"
-		path := req.URL.Path
-		if strings.HasPrefix(path, prefix) && strings.HasSuffix(path, suffix) {
-			cityName := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
-			if cityName != "" && !strings.Contains(cityName, "/") {
-				return true
-			}
-		}
+	// Generated SSE requests intentionally have no Accept header. Keep only
+	// their exact route shapes non-replayable; generic "stream" paths remain
+	// eligible for the normal safe-REST retry policy.
+	if req.Method == http.MethodGet && req.URL != nil && isGeneratedSSEPath(req.URL.EscapedPath()) {
+		return true
 	}
 	for _, value := range req.Header.Values("Accept") {
 		for _, mediaType := range strings.Split(value, ",") {
@@ -374,6 +373,37 @@ func isSSERequest(req *http.Request) bool {
 		}
 	}
 	return false
+}
+
+func isGeneratedSSEPath(path string) bool {
+	segments := strings.Split(path, "/")
+	nonEmpty := func(indexes ...int) bool {
+		for _, index := range indexes {
+			if segments[index] == "" {
+				return false
+			}
+		}
+		return true
+	}
+
+	switch len(segments) {
+	case 4: // /v0/events/stream
+		return segments[0] == "" && segments[1] == "v0" && segments[2] == "events" && segments[3] == "stream"
+	case 6: // /v0/city/{city}/events/stream
+		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
+			nonEmpty(3) && segments[4] == "events" && segments[5] == "stream"
+	case 7: // /v0/city/{city}/session/{id}/stream
+		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
+			nonEmpty(3, 5) && segments[4] == "session" && segments[6] == "stream"
+	case 8: // /v0/city/{city}/agent/{base}/output/stream
+		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
+			nonEmpty(3, 5) && segments[4] == "agent" && segments[6] == "output" && segments[7] == "stream"
+	case 9: // /v0/city/{city}/agent/{dir}/{base}/output/stream
+		return segments[0] == "" && segments[1] == "v0" && segments[2] == "city" &&
+			nonEmpty(3, 5, 6) && segments[4] == "agent" && segments[7] == "output" && segments[8] == "stream"
+	default:
+		return false
+	}
 }
 
 // remoteTLSConfig builds the client TLS config from the options: a custom CA

--- a/internal/api/client_remote_test.go
+++ b/internal/api/client_remote_test.go
@@ -783,6 +783,8 @@ func TestReauthRoundTripperRejectsEmptyRefreshedCredential(t *testing.T) {
 }
 
 func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
+	const secretMarker = "body-recreation-super-secret"
+
 	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
 	baseCalls, refreshes := 0, 0
 	rt := &reauthRoundTripper{
@@ -796,11 +798,14 @@ func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("body recreation failed") }
+	req.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("body recreation failed: " + secretMarker) }
 	req.Header.Set("Authorization", "Bearer stale")
 	resp, err := rt.RoundTrip(req)
-	if resp != nil || err == nil || !strings.Contains(err.Error(), "body recreation failed") {
-		t.Fatalf("response=%v error=%v, want body recreation failure", resp, err)
+	if resp != nil || err == nil || err.Error() != "replaying request after bearer refresh: request body recreation failed" {
+		t.Fatalf("response=%v error=%v, want sanitized body recreation failure", resp, err)
+	}
+	if strings.Contains(err.Error(), secretMarker) {
+		t.Fatalf("body recreation error leaked request material: %q", err)
 	}
 	if baseCalls != 1 || refreshes != 1 || !firstBody.closed {
 		t.Fatalf("calls=%d refreshes=%d body closed=%v, want 1, 1, true", baseCalls, refreshes, firstBody.closed)

--- a/internal/api/client_remote_test.go
+++ b/internal/api/client_remote_test.go
@@ -455,13 +455,55 @@ func TestReauthRoundTripper_SkipsGrantedRequest(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
 	})
 	rt := &reauthRoundTripper{base: base, refresh: func(context.Context) (string, error) { return "fresh", nil }}
-	req, _ := http.NewRequest("POST", "https://example/y", nil)
+	// Use a safe method so this test exercises the grant exclusion itself rather
+	// than the unsafe-method exclusion.
+	req, _ := http.NewRequest(http.MethodGet, "https://example/y", nil)
+	req.Header.Set("Authorization", "Bearer stale")
 	req.Header.Set("X-GC-City-Write", "grant")
 	if _, err := rt.RoundTrip(req); err != nil {
 		t.Fatal(err)
 	}
 	if calls != 1 {
 		t.Fatalf("calls = %d, want 1 (granted request must not retry)", calls)
+	}
+}
+
+func TestReauthRoundTripperSkipsUnsafeReplayableRequests(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			calls, refreshes := 0, 0
+			rt := &reauthRoundTripper{
+				base: rtFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body:       io.NopCloser(strings.NewReader("rejected")),
+						Header:     http.Header{},
+					}, nil
+				}),
+				refresh: func(context.Context) (string, error) {
+					refreshes++
+					return "fresh", nil
+				},
+			}
+			req, err := http.NewRequest(method, "https://example.test/status", strings.NewReader("replayable body"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if req.GetBody == nil {
+				t.Fatal("test request must be replayable")
+			}
+			req.Header.Set("Authorization", "Bearer stale")
+
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusUnauthorized || calls != 1 || refreshes != 0 {
+				t.Fatalf("status=%d calls=%d refreshes=%d, want 401, 1, 0", resp.StatusCode, calls, refreshes)
+			}
+		})
 	}
 }
 
@@ -507,7 +549,7 @@ func TestReauthRoundTripperSkipsIneligible401(t *testing.T) {
 			name: "non replayable body",
 			request: func(t *testing.T) *http.Request {
 				t.Helper()
-				req, err := http.NewRequest(http.MethodPost, "https://example.test/status", io.NopCloser(strings.NewReader("stream")))
+				req, err := http.NewRequest(http.MethodGet, "https://example.test/status", io.NopCloser(strings.NewReader("stream")))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -750,7 +792,7 @@ func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
 		}),
 		refresh: func(context.Context) (string, error) { refreshes++; return "fresh", nil },
 	}
-	req, err := http.NewRequest(http.MethodPost, "https://example.test/status", strings.NewReader("body"))
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/status", strings.NewReader("body"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -766,8 +808,7 @@ func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
 }
 
 // TestNewRemoteEventsClientDoesNotRetrySSE401 proves every generated SSE request
-// is never replayed after a 401. These generated requests do not set
-// Accept: text/event-stream, so each real wire path must remain non-replayable.
+// sends its required Accept header and is never replayed after a 401.
 func TestNewRemoteEventsClientDoesNotRetrySSE401(t *testing.T) {
 	tests := []struct {
 		name string
@@ -849,8 +890,8 @@ func TestNewRemoteEventsClientDoesNotRetrySSE401(t *testing.T) {
 			if gotPath != tt.path {
 				t.Fatalf("request path = %q, want %q", gotPath, tt.path)
 			}
-			if gotAccept != "" {
-				t.Fatalf("generated stream Accept = %q, want none", gotAccept)
+			if gotAccept != "text/event-stream" {
+				t.Fatalf("generated stream Accept = %q, want text/event-stream", gotAccept)
 			}
 			if gotAuth != "Bearer stale" {
 				t.Fatalf("Authorization = %q, want Bearer stale", gotAuth)

--- a/internal/api/client_remote_test.go
+++ b/internal/api/client_remote_test.go
@@ -408,6 +408,7 @@ func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r)
 func TestReauthRoundTripper_RetriesOn401(t *testing.T) {
 	var calls int
 	var sawAuth []string
+	firstBody := &closeTrackingBody{Reader: strings.NewReader("x")}
 	base := rtFunc(func(req *http.Request) (*http.Response, error) {
 		calls++
 		sawAuth = append(sawAuth, req.Header.Get("Authorization"))
@@ -415,9 +416,13 @@ func TestReauthRoundTripper_RetriesOn401(t *testing.T) {
 		if calls == 1 {
 			code = http.StatusUnauthorized
 		}
-		return &http.Response{StatusCode: code, Body: io.NopCloser(strings.NewReader("x")), Header: http.Header{}}, nil
+		body := io.NopCloser(strings.NewReader("x"))
+		if calls == 1 {
+			body = firstBody
+		}
+		return &http.Response{StatusCode: code, Body: body, Header: http.Header{}}, nil
 	})
-	rt := &reauthRoundTripper{base: base, refresh: func() (string, error) { return "fresh", nil }}
+	rt := &reauthRoundTripper{base: base, refresh: func(context.Context) (string, error) { return "fresh", nil }}
 	req, _ := http.NewRequest("GET", "https://example/y", nil)
 	req.Header.Set("Authorization", "Bearer stale")
 	resp, err := rt.RoundTrip(req)
@@ -433,6 +438,9 @@ func TestReauthRoundTripper_RetriesOn401(t *testing.T) {
 	if sawAuth[0] != "Bearer stale" || sawAuth[1] != "Bearer fresh" {
 		t.Fatalf("auth seq = %v, want [Bearer stale, Bearer fresh]", sawAuth)
 	}
+	if !firstBody.closed {
+		t.Fatal("first 401 response body was not closed before retry")
+	}
 }
 
 // TestReauthRoundTripper_SkipsGrantedRequest proves a request carrying a
@@ -444,7 +452,7 @@ func TestReauthRoundTripper_SkipsGrantedRequest(t *testing.T) {
 		calls++
 		return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
 	})
-	rt := &reauthRoundTripper{base: base, refresh: func() (string, error) { return "fresh", nil }}
+	rt := &reauthRoundTripper{base: base, refresh: func(context.Context) (string, error) { return "fresh", nil }}
 	req, _ := http.NewRequest("POST", "https://example/y", nil)
 	req.Header.Set("X-GC-City-Write", "grant")
 	if _, err := rt.RoundTrip(req); err != nil {
@@ -452,6 +460,156 @@ func TestReauthRoundTripper_SkipsGrantedRequest(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("calls = %d, want 1 (granted request must not retry)", calls)
+	}
+}
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestReauthRoundTripperSkipsIneligible401(t *testing.T) {
+	tests := []struct {
+		name    string
+		request func(t *testing.T) *http.Request
+	}{
+		{
+			name: "forbidden",
+			request: func(t *testing.T) *http.Request {
+				t.Helper()
+				req, err := http.NewRequest(http.MethodGet, "https://example.test/status", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Authorization", "Bearer current")
+				return req
+			},
+		},
+		{
+			name: "no bearer",
+			request: func(t *testing.T) *http.Request {
+				t.Helper()
+				req, err := http.NewRequest(http.MethodGet, "https://example.test/status", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return req
+			},
+		},
+		{
+			name: "non replayable body",
+			request: func(t *testing.T) *http.Request {
+				t.Helper()
+				req, err := http.NewRequest(http.MethodPost, "https://example.test/status", io.NopCloser(strings.NewReader("stream")))
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Authorization", "Bearer current")
+				return req
+			},
+		},
+		{
+			name: "SSE",
+			request: func(t *testing.T) *http.Request {
+				t.Helper()
+				req, err := http.NewRequest(http.MethodGet, "https://example.test/events", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Authorization", "Bearer current")
+				req.Header.Set("Accept", "text/event-stream")
+				return req
+			},
+		},
+		{
+			name: "redirect follow up",
+			request: func(t *testing.T) *http.Request {
+				t.Helper()
+				req, err := http.NewRequest(http.MethodGet, "https://example.test/status", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Authorization", "Bearer current")
+				req.Response = &http.Response{StatusCode: http.StatusFound}
+				return req
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls, refreshCalls := 0, 0
+			status := http.StatusUnauthorized
+			if tt.name == "forbidden" {
+				status = http.StatusForbidden
+			}
+			rt := &reauthRoundTripper{
+				base: rtFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader("rejected")), Header: http.Header{}}, nil
+				}),
+				refresh: func(context.Context) (string, error) { refreshCalls++; return "fresh", nil },
+			}
+			resp, err := rt.RoundTrip(tt.request(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != status || calls != 1 || refreshCalls != 0 {
+				t.Fatalf("status=%d calls=%d refresh=%d, want %d, 1, 0", resp.StatusCode, calls, refreshCalls, status)
+			}
+		})
+	}
+}
+
+func TestReauthRoundTripperStopsAfterSecond401(t *testing.T) {
+	calls, refreshCalls := 0, 0
+	rt := &reauthRoundTripper{
+		base: rtFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(strings.NewReader("rejected")), Header: http.Header{}}, nil
+		}),
+		refresh: func(context.Context) (string, error) { refreshCalls++; return "fresh", nil },
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer stale")
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized || calls != 2 || refreshCalls != 1 {
+		t.Fatalf("status=%d calls=%d refresh=%d, want 401, 2, 1", resp.StatusCode, calls, refreshCalls)
+	}
+}
+
+func TestReauthRoundTripperRefreshFailureClosesResponseAndPropagatesContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
+	rt := &reauthRoundTripper{
+		base: rtFunc(func(*http.Request) (*http.Response, error) {
+			cancel()
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody, Header: http.Header{}}, nil
+		}),
+		refresh: func(ctx context.Context) (string, error) { return "", ctx.Err() },
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer stale")
+	resp, err := rt.RoundTrip(req)
+	if !errors.Is(err, context.Canceled) || resp != nil {
+		t.Fatalf("response=%v error=%v, want nil response and context cancellation", resp, err)
+	}
+	if !firstBody.closed {
+		t.Fatal("first 401 response body was not closed")
 	}
 }
 

--- a/internal/api/client_remote_test.go
+++ b/internal/api/client_remote_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/api/genclient"
 	"github.com/gastownhall/gascity/internal/citywriteauth"
@@ -618,6 +619,64 @@ func TestReauthRoundTripperRefreshFailureIsSecretSafe(t *testing.T) {
 	}
 }
 
+func TestReauthRoundTripperRefreshFailurePreservesRequestContext(t *testing.T) {
+	tests := []struct {
+		name                string
+		newContext          func(*testing.T) (context.Context, context.CancelFunc)
+		cancelBeforeRefresh bool
+		want                error
+	}{
+		{
+			name: "canceled",
+			newContext: func(t *testing.T) (context.Context, context.CancelFunc) {
+				return context.WithCancel(t.Context())
+			},
+			cancelBeforeRefresh: true,
+			want:                context.Canceled,
+		},
+		{
+			name: "deadline exceeded",
+			newContext: func(t *testing.T) (context.Context, context.CancelFunc) {
+				return context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := tt.newContext(t)
+			defer cancel()
+			firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
+			rt := &reauthRoundTripper{
+				base: rtFunc(func(*http.Request) (*http.Response, error) {
+					if tt.cancelBeforeRefresh {
+						cancel()
+					}
+					return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody, Header: http.Header{}}, nil
+				}),
+				refresh: func(context.Context) (string, error) {
+					return "", errors.New("credential helper failed: bearer=super-secret helper stderr")
+				},
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test/status", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer stale")
+			resp, err := rt.RoundTrip(req)
+			if resp != nil || !errors.Is(err, tt.want) {
+				t.Fatalf("response=%v error=%v, want nil response and %v", resp, err, tt.want)
+			}
+			if strings.Contains(err.Error(), "super-secret") || strings.Contains(err.Error(), "stderr") {
+				t.Fatalf("refresh error leaked credential-helper output: %q", err)
+			}
+			if !firstBody.closed {
+				t.Fatal("first 401 response body was not closed")
+			}
+		})
+	}
+}
+
 func TestReauthRoundTripperRejectsEmptyRefreshedCredential(t *testing.T) {
 	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
 	refreshes := 0
@@ -666,32 +725,56 @@ func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
 	}
 }
 
-// TestNewRemoteEventsClientAttachesAuth proves the events client (used by
-// `gc events --context`) carries the X-GC-Request CSRF header and an
-// Authorization bearer from opts.Token — so the events feed authenticates to a
-// remote edge like the REST client does.
-func TestNewRemoteEventsClientAttachesAuth(t *testing.T) {
-	var gotAuth, gotCSRF string
+// TestNewRemoteEventsClientDoesNotRetrySSE401 proves the actual generated
+// StreamEvents request is never replayed after a 401. The generated request
+// does not set Accept: text/event-stream, so this covers its real wire shape.
+func TestNewRemoteEventsClientDoesNotRetrySSE401(t *testing.T) {
+	var gotAuth, gotCSRF, gotPath, gotAccept string
+	requests, refreshes := 0, 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
 		gotAuth = r.Header.Get("Authorization")
 		gotCSRF = r.Header.Get("X-GC-Request")
-		w.WriteHeader(http.StatusOK)
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
 	gen, err := NewRemoteEventsClient(srv.URL, RemoteOptions{
-		Token: func() (string, error) { return "tok", nil },
+		Token: func() (string, error) { return "stale", nil },
+		RefreshToken: func(context.Context) (string, error) {
+			refreshes++
+			return "fresh", nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewRemoteEventsClient: %v", err)
 	}
-	if _, err := gen.StreamEvents(context.Background(), "mc", &genclient.StreamEventsParams{}); err != nil {
+	resp, err := gen.StreamEvents(context.Background(), "mc", &genclient.StreamEventsParams{})
+	if err != nil {
 		t.Fatalf("StreamEvents: %v", err)
 	}
-	if gotAuth != "Bearer tok" {
-		t.Fatalf("Authorization = %q, want Bearer tok", gotAuth)
+	if resp == nil {
+		t.Fatal("StreamEvents returned a nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("StreamEvents status = %d, want 401", resp.StatusCode)
+	}
+	if gotPath != "/v0/city/mc/events/stream" {
+		t.Fatalf("request path = %q, want generated stream path", gotPath)
+	}
+	if gotAccept != "" {
+		t.Fatalf("generated StreamEvents Accept = %q, want none", gotAccept)
+	}
+	if gotAuth != "Bearer stale" {
+		t.Fatalf("Authorization = %q, want Bearer stale", gotAuth)
 	}
 	if gotCSRF != "true" {
 		t.Fatalf("X-GC-Request = %q, want true", gotCSRF)
+	}
+	if requests != 1 || refreshes != 0 {
+		t.Fatalf("requests=%d refreshes=%d, want 1, 0", requests, refreshes)
 	}
 }

--- a/internal/api/client_remote_test.go
+++ b/internal/api/client_remote_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -677,6 +678,45 @@ func TestReauthRoundTripperRefreshFailurePreservesRequestContext(t *testing.T) {
 	}
 }
 
+func TestReauthRoundTripperRefreshFailurePreservesHelperContext(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		want error
+	}{
+		{name: "canceled", want: context.Canceled},
+		{name: "deadline exceeded", want: context.DeadlineExceeded},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
+			requests := 0
+			rt := &reauthRoundTripper{
+				base: rtFunc(func(*http.Request) (*http.Response, error) {
+					requests++
+					return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody, Header: http.Header{}}, nil
+				}),
+				refresh: func(context.Context) (string, error) {
+					return "", fmt.Errorf("credential helper stderr bearer=super-secret: %w", tt.want)
+				},
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test/status", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer stale")
+			resp, err := rt.RoundTrip(req)
+			if resp != nil || !errors.Is(err, tt.want) {
+				t.Fatalf("response=%v error=%v, want nil response and %v", resp, err, tt.want)
+			}
+			if strings.Contains(err.Error(), "super-secret") || strings.Contains(err.Error(), "stderr") {
+				t.Fatalf("refresh error leaked credential-helper output: %q", err)
+			}
+			if requests != 1 || !firstBody.closed {
+				t.Fatalf("requests=%d body closed=%v, want 1, true", requests, firstBody.closed)
+			}
+		})
+	}
+}
+
 func TestReauthRoundTripperRejectsEmptyRefreshedCredential(t *testing.T) {
 	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
 	refreshes := 0
@@ -725,56 +765,102 @@ func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
 	}
 }
 
-// TestNewRemoteEventsClientDoesNotRetrySSE401 proves the actual generated
-// StreamEvents request is never replayed after a 401. The generated request
-// does not set Accept: text/event-stream, so this covers its real wire shape.
+// TestNewRemoteEventsClientDoesNotRetrySSE401 proves every generated SSE request
+// is never replayed after a 401. These generated requests do not set
+// Accept: text/event-stream, so each real wire path must remain non-replayable.
 func TestNewRemoteEventsClientDoesNotRetrySSE401(t *testing.T) {
-	var gotAuth, gotCSRF, gotPath, gotAccept string
-	requests, refreshes := 0, 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		gotAuth = r.Header.Get("Authorization")
-		gotCSRF = r.Header.Get("X-GC-Request")
-		gotPath = r.URL.Path
-		gotAccept = r.Header.Get("Accept")
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	gen, err := NewRemoteEventsClient(srv.URL, RemoteOptions{
-		Token: func() (string, error) { return "stale", nil },
-		RefreshToken: func(context.Context) (string, error) {
-			refreshes++
-			return "fresh", nil
+	tests := []struct {
+		name string
+		path string
+		call func(context.Context, *genclient.ClientWithResponses) (*http.Response, error)
+	}{
+		{
+			name: "city events",
+			path: "/v0/city/mc/events/stream",
+			call: func(ctx context.Context, gen *genclient.ClientWithResponses) (*http.Response, error) {
+				return gen.StreamEvents(ctx, "mc", &genclient.StreamEventsParams{})
+			},
 		},
-	})
-	if err != nil {
-		t.Fatalf("NewRemoteEventsClient: %v", err)
+		{
+			name: "agent output",
+			path: "/v0/city/mc/agent/base/output/stream",
+			call: func(ctx context.Context, gen *genclient.ClientWithResponses) (*http.Response, error) {
+				return gen.StreamAgentOutput(ctx, "mc", "base")
+			},
+		},
+		{
+			name: "qualified agent output",
+			path: "/v0/city/mc/agent/dir/base/output/stream",
+			call: func(ctx context.Context, gen *genclient.ClientWithResponses) (*http.Response, error) {
+				return gen.StreamAgentOutputQualified(ctx, "mc", "dir", "base")
+			},
+		},
+		{
+			name: "session",
+			path: "/v0/city/mc/session/session/stream",
+			call: func(ctx context.Context, gen *genclient.ClientWithResponses) (*http.Response, error) {
+				return gen.StreamSession(ctx, "mc", "session", &genclient.StreamSessionParams{})
+			},
+		},
+		{
+			name: "supervisor events",
+			path: "/v0/events/stream",
+			call: func(ctx context.Context, gen *genclient.ClientWithResponses) (*http.Response, error) {
+				return gen.StreamSupervisorEvents(ctx, &genclient.StreamSupervisorEventsParams{})
+			},
+		},
 	}
-	resp, err := gen.StreamEvents(context.Background(), "mc", &genclient.StreamEventsParams{})
-	if err != nil {
-		t.Fatalf("StreamEvents: %v", err)
-	}
-	if resp == nil {
-		t.Fatal("StreamEvents returned a nil response")
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("StreamEvents status = %d, want 401", resp.StatusCode)
-	}
-	if gotPath != "/v0/city/mc/events/stream" {
-		t.Fatalf("request path = %q, want generated stream path", gotPath)
-	}
-	if gotAccept != "" {
-		t.Fatalf("generated StreamEvents Accept = %q, want none", gotAccept)
-	}
-	if gotAuth != "Bearer stale" {
-		t.Fatalf("Authorization = %q, want Bearer stale", gotAuth)
-	}
-	if gotCSRF != "true" {
-		t.Fatalf("X-GC-Request = %q, want true", gotCSRF)
-	}
-	if requests != 1 || refreshes != 0 {
-		t.Fatalf("requests=%d refreshes=%d, want 1, 0", requests, refreshes)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotAuth, gotCSRF, gotPath, gotAccept string
+			requests, refreshes := 0, 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				gotAuth = r.Header.Get("Authorization")
+				gotCSRF = r.Header.Get("X-GC-Request")
+				gotPath = r.URL.Path
+				gotAccept = r.Header.Get("Accept")
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer srv.Close()
+
+			gen, err := NewRemoteEventsClient(srv.URL, RemoteOptions{
+				Token: func() (string, error) { return "stale", nil },
+				RefreshToken: func(context.Context) (string, error) {
+					refreshes++
+					return "fresh", nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRemoteEventsClient: %v", err)
+			}
+			resp, err := tt.call(context.Background(), gen)
+			if err != nil {
+				t.Fatalf("stream request: %v", err)
+			}
+			if resp == nil {
+				t.Fatal("stream request returned a nil response")
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("stream status = %d, want 401", resp.StatusCode)
+			}
+			if gotPath != tt.path {
+				t.Fatalf("request path = %q, want %q", gotPath, tt.path)
+			}
+			if gotAccept != "" {
+				t.Fatalf("generated stream Accept = %q, want none", gotAccept)
+			}
+			if gotAuth != "Bearer stale" {
+				t.Fatalf("Authorization = %q, want Bearer stale", gotAuth)
+			}
+			if gotCSRF != "true" {
+				t.Fatalf("X-GC-Request = %q, want true", gotCSRF)
+			}
+			if requests != 1 || refreshes != 0 {
+				t.Fatalf("requests=%d refreshes=%d, want 1, 0", requests, refreshes)
+			}
+		})
 	}
 }

--- a/internal/api/client_remote_test.go
+++ b/internal/api/client_remote_test.go
@@ -588,28 +588,81 @@ func TestReauthRoundTripperStopsAfterSecond401(t *testing.T) {
 	}
 }
 
-func TestReauthRoundTripperRefreshFailureClosesResponseAndPropagatesContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func TestReauthRoundTripperRefreshFailureIsSecretSafe(t *testing.T) {
 	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
 	rt := &reauthRoundTripper{
 		base: rtFunc(func(*http.Request) (*http.Response, error) {
-			cancel()
 			return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody, Header: http.Header{}}, nil
 		}),
-		refresh: func(ctx context.Context) (string, error) { return "", ctx.Err() },
+		refresh: func(context.Context) (string, error) {
+			return "", errors.New("credential helper failed: bearer=super-secret helper stderr")
+		},
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test/status", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/status", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Authorization", "Bearer stale")
 	resp, err := rt.RoundTrip(req)
-	if !errors.Is(err, context.Canceled) || resp != nil {
-		t.Fatalf("response=%v error=%v, want nil response and context cancellation", resp, err)
+	if resp != nil || err == nil {
+		t.Fatalf("response=%v error=%v, want nil response and refresh error", resp, err)
+	}
+	if got, want := err.Error(), "refreshing bearer after 401: credential refresh failed"; got != want {
+		t.Fatalf("refresh error = %q, want %q", got, want)
+	}
+	if strings.Contains(err.Error(), "super-secret") || strings.Contains(err.Error(), "stderr") {
+		t.Fatalf("refresh error leaked credential-helper output: %q", err)
 	}
 	if !firstBody.closed {
 		t.Fatal("first 401 response body was not closed")
+	}
+}
+
+func TestReauthRoundTripperRejectsEmptyRefreshedCredential(t *testing.T) {
+	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
+	refreshes := 0
+	rt := &reauthRoundTripper{
+		base: rtFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody, Header: http.Header{}}, nil
+		}),
+		refresh: func(context.Context) (string, error) { refreshes++; return "  ", nil },
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.test/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer stale")
+	resp, err := rt.RoundTrip(req)
+	if resp != nil || err == nil || err.Error() != "refreshing bearer after 401: credential source returned an empty token" {
+		t.Fatalf("response=%v error=%v, want empty refreshed credential error", resp, err)
+	}
+	if refreshes != 1 || !firstBody.closed {
+		t.Fatalf("refreshes=%d body closed=%v, want 1, true", refreshes, firstBody.closed)
+	}
+}
+
+func TestReauthRoundTripperReturnsBodyRecreationFailure(t *testing.T) {
+	firstBody := &closeTrackingBody{Reader: strings.NewReader("rejected")}
+	baseCalls, refreshes := 0, 0
+	rt := &reauthRoundTripper{
+		base: rtFunc(func(*http.Request) (*http.Response, error) {
+			baseCalls++
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody, Header: http.Header{}}, nil
+		}),
+		refresh: func(context.Context) (string, error) { refreshes++; return "fresh", nil },
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/status", strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("body recreation failed") }
+	req.Header.Set("Authorization", "Bearer stale")
+	resp, err := rt.RoundTrip(req)
+	if resp != nil || err == nil || !strings.Contains(err.Error(), "body recreation failed") {
+		t.Fatalf("response=%v error=%v, want body recreation failure", resp, err)
+	}
+	if baseCalls != 1 || refreshes != 1 || !firstBody.closed {
+		t.Fatalf("calls=%d refreshes=%d body closed=%v, want 1, 1, true", baseCalls, refreshes, firstBody.closed)
 	}
 }
 

--- a/internal/clientauth/clientauth.go
+++ b/internal/clientauth/clientauth.go
@@ -126,25 +126,34 @@ func (s *CredentialSource) Token() (string, error) {
 	if s.token != "" && s.now().Add(expirySkew).Before(s.expiresAt) {
 		return s.token, nil
 	}
-	return s.mintLocked()
+	return s.mintLocked(context.Background())
 }
 
 // Refresh mints a fresh token regardless of cache state. Use it to re-invoke the
 // credential command after a 401 (the server rejected the presented token).
 func (s *CredentialSource) Refresh() (string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.mintLocked()
+	return s.RefreshContext(context.Background())
 }
 
-func (s *CredentialSource) mintLocked() (string, error) {
+// RefreshContext mints a fresh token regardless of cache state and bounds the
+// credential command by ctx as well as the source's helper timeout.
+func (s *CredentialSource) RefreshContext(ctx context.Context) (string, error) {
+	if ctx == nil {
+		return "", errors.New("clientauth: credential context is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mintLocked(ctx)
+}
+
+func (s *CredentialSource) mintLocked(ctx context.Context) (string, error) {
 	info := ExecInfo{
 		Version: Version,
 		Spec:    ExecSpec{ServerURL: s.serverURL, City: s.city, Interactive: s.interactive},
 	}
 	// Bound the exec so a hung helper is canceled instead of blocking the caller
 	// (and every remote request behind this lock) indefinitely.
-	ctx, cancel := context.WithTimeout(context.Background(), s.helperTimeout)
+	ctx, cancel := context.WithTimeout(ctx, s.helperTimeout)
 	defer cancel()
 	res, err := s.runner(ctx, s.command, info)
 	if err != nil {

--- a/internal/clientauth/clientauth.go
+++ b/internal/clientauth/clientauth.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -86,7 +85,7 @@ type CredentialSource struct {
 	now    func() time.Time
 	runner runFunc
 
-	mu        sync.Mutex
+	gate      chan struct{}
 	token     string
 	expiresAt time.Time
 }
@@ -106,6 +105,8 @@ func NewCredentialSource(command, serverURL, city string, interactive bool) (*Cr
 	if interactive {
 		timeout = interactiveCredentialHelperTimeout
 	}
+	gate := make(chan struct{}, 1)
+	gate <- struct{}{}
 	return &CredentialSource{
 		command:       command,
 		serverURL:     serverURL,
@@ -114,6 +115,7 @@ func NewCredentialSource(command, serverURL, city string, interactive bool) (*Cr
 		helperTimeout: timeout,
 		now:           time.Now,
 		runner:        runCredentialCommand,
+		gate:          gate,
 	}, nil
 }
 
@@ -121,8 +123,8 @@ func NewCredentialSource(command, serverURL, city string, interactive bool) (*Cr
 // otherwise mints a fresh one. Call it before every request and every SSE
 // (re)connect.
 func (s *CredentialSource) Token() (string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.lock()
+	defer s.unlock()
 	if s.token != "" && s.now().Add(expirySkew).Before(s.expiresAt) {
 		return s.token, nil
 	}
@@ -132,7 +134,9 @@ func (s *CredentialSource) Token() (string, error) {
 // Refresh mints a fresh token regardless of cache state. Use it to re-invoke the
 // credential command after a 401 (the server rejected the presented token).
 func (s *CredentialSource) Refresh() (string, error) {
-	return s.RefreshContext(context.Background())
+	s.lock()
+	defer s.unlock()
+	return s.mintLocked(context.Background())
 }
 
 // RefreshContext mints a fresh token regardless of cache state and bounds the
@@ -141,9 +145,35 @@ func (s *CredentialSource) RefreshContext(ctx context.Context) (string, error) {
 	if ctx == nil {
 		return "", errors.New("clientauth: credential context is nil")
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	if err := s.lockContext(ctx); err != nil {
+		return "", err
+	}
+	defer s.unlock()
 	return s.mintLocked(ctx)
+}
+
+func (s *CredentialSource) lock() {
+	<-s.gate
+}
+
+func (s *CredentialSource) lockContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.gate:
+		if err := ctx.Err(); err != nil {
+			s.unlock()
+			return err
+		}
+		return nil
+	}
+}
+
+func (s *CredentialSource) unlock() {
+	s.gate <- struct{}{}
 }
 
 func (s *CredentialSource) mintLocked(ctx context.Context) (string, error) {

--- a/internal/clientauth/clientauth_test.go
+++ b/internal/clientauth/clientauth_test.go
@@ -2,6 +2,7 @@ package clientauth
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -209,6 +210,23 @@ func TestCredentialSource_BoundsHelperContext(t *testing.T) {
 	}
 	if tokErr == nil {
 		t.Error("Token = nil error, want the canceled-helper error")
+	}
+}
+
+func TestCredentialSource_RefreshContextPropagatesCancellation(t *testing.T) {
+	s, err := NewCredentialSource("cred-helper", "https://box:9443", "mc", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runner = func(ctx context.Context, _ string, _ ExecInfo) (ExecResult, error) {
+		<-ctx.Done()
+		return ExecResult{}, ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = s.RefreshContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RefreshContext error = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/clientauth/clientauth_test.go
+++ b/internal/clientauth/clientauth_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
@@ -227,6 +229,91 @@ func TestCredentialSource_RefreshContextPropagatesCancellation(t *testing.T) {
 	_, err = s.RefreshContext(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("RefreshContext error = %v, want context.Canceled", err)
+	}
+}
+
+func TestCredentialSource_RefreshContextCancelsWhileWaitingForMint(t *testing.T) {
+	s, err := NewCredentialSource("cred-helper", "https://box:9443", "mc", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runnerStarted := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	result := ExecResult{
+		Token:               "token",
+		ExpirationTimestamp: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}
+	calls := 0
+	s.runner = func(context.Context, string, ExecInfo) (ExecResult, error) {
+		calls++
+		if calls == 1 {
+			close(runnerStarted)
+			<-release
+		}
+		return result, nil
+	}
+
+	released := false
+	firstFinished := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+		if !firstFinished {
+			select {
+			case err := <-firstDone:
+				if err != nil {
+					t.Errorf("first RefreshContext: %v", err)
+				}
+			case <-time.After(testutil.GoroutineRaceTimeout):
+				t.Error("first RefreshContext did not finish after release")
+			}
+		}
+	}()
+
+	go func() {
+		_, err := s.RefreshContext(context.Background())
+		firstDone <- err
+	}()
+	select {
+	case <-runnerStarted:
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		t.Fatal("first RefreshContext did not start the credential helper")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := s.RefreshContext(ctx)
+		secondDone <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-secondDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiting RefreshContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		t.Fatal("RefreshContext did not honor cancellation while waiting for the mint lock")
+	}
+	if calls != 1 {
+		t.Fatalf("credential helper calls = %d, want 1 while the first mint remains blocked", calls)
+	}
+
+	close(release)
+	released = true
+	select {
+	case err := <-firstDone:
+		firstFinished = true
+		if err != nil {
+			t.Fatalf("first RefreshContext: %v", err)
+		}
+	case <-time.After(testutil.GoroutineRaceTimeout):
+		t.Fatal("first RefreshContext did not finish after release")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Force-refresh provider-backed bearer credentials and retry one eligible request after a 401.
- Keep static tokens, SSE, redirects, non-replayable requests, 403 responses, and single-use grants out of the retry path.
- Propagate request cancellation to the credential command and close replaced 401 response bodies.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] Focused API/clientauth/CLI tests
- [x] Commit lint, generated-code, and vet hooks
- [x] Required pre-push fast suite

## Checklist

- [x] Linked an issue, or explained why one is not needed: implements bead `ga-0xdql0.5`.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes: not needed; this is transport behavior.
- [x] Called out breaking changes or migration notes: none.