### PR TITLE
fix(reconciler): free max-age pool slots after runtime exit

### DIFF
--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -48,7 +48,8 @@ func poolSessionIsLiveInfo(i sessionpkg.Info) bool {
 
 // isPoolSessionSlotFreeable reports whether a session's bead is in a terminal
 // state where the pool slot it occupies can be freed — either explicitly
-// drained, or asleep from a normal idle transition. Sessions parked via
+// drained, asleep from a normal idle transition, or asleep after max-session-age
+// expiry. Sessions parked via
 // `gc session wait` (sleep_reason=wait-hold), held by context-churn
 // quarantine, or otherwise signaling "don't touch me" keep their slot.
 //
@@ -78,7 +79,8 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	switch reason {
 	case string(sessionpkg.SleepReasonIdle), string(sessionpkg.SleepReasonIdleTimeout),
 		string(sessionpkg.SleepReasonCityStop), string(sessionpkg.SleepReasonFailedCreate),
-		string(sessionpkg.SleepReasonRuntimeMissing), string(sessionpkg.SleepReasonProviderTerminalError):
+		string(sessionpkg.SleepReasonRuntimeMissing), string(sessionpkg.SleepReasonProviderTerminalError),
+		string(sessionpkg.SleepReasonMaxSessionAge):
 		return true
 	}
 	return false
@@ -96,7 +98,8 @@ func isPoolSessionSlotFreeableInfo(i sessionpkg.Info) bool {
 	switch reason {
 	case string(sessionpkg.SleepReasonIdle), string(sessionpkg.SleepReasonIdleTimeout),
 		string(sessionpkg.SleepReasonCityStop), string(sessionpkg.SleepReasonFailedCreate),
-		string(sessionpkg.SleepReasonRuntimeMissing), string(sessionpkg.SleepReasonProviderTerminalError):
+		string(sessionpkg.SleepReasonRuntimeMissing), string(sessionpkg.SleepReasonProviderTerminalError),
+		string(sessionpkg.SleepReasonMaxSessionAge):
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -58,6 +58,7 @@ func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 		{"asleep+failed-create", map[string]string{"state": "asleep", "sleep_reason": "failed-create"}, true},
 		{"asleep+runtime-missing", map[string]string{"state": "asleep", "sleep_reason": string(sessionpkg.SleepReasonRuntimeMissing)}, true},
 		{"asleep+provider-terminal-error", map[string]string{"state": "asleep", "sleep_reason": string(sessionpkg.SleepReasonProviderTerminalError)}, true},
+		{"asleep+max-session-age", map[string]string{"state": "asleep", "sleep_reason": string(sessionpkg.SleepReasonMaxSessionAge)}, true},
 		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},
 		{"asleep+missing-reason", map[string]string{"state": "asleep"}, false},
 		{"asleep+wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},


### PR DESCRIPTION
Fixes #5522.

# Fix pool slot retention after max-session-age sleep

## Problem

`DecideMaxSessionAge` records `sleep_reason=max-session-age` when the age
ladder stops a session (`internal/session/lifecycle_timers.go:129-159`). Once
the runtime is gone, pool cleanup is gated by
`isPoolSessionSlotFreeableInfo` (`cmd/gc/session_reconciler.go:3774`). The
freeable allowlist omitted this explicit terminal reason in both its raw-bead
and typed-`session.Info` twins (`cmd/gc/session_state_helpers.go:71-105`), so
the asleep bead kept its slot/name and blocked replacement.

## Fix

Add `sessionpkg.SleepReasonMaxSessionAge` to both existing allowlists. The
change preserves the deny-by-default behavior for empty, missing, unknown,
wait-hold, and context-churn reasons. No reconciler, provider, runtime, or
storage behavior is changed outside the existing freeable-state decision.

## Regression coverage

`TestIsPoolSessionSlotFreeable_Matrix` now asserts that
`state=asleep,sleep_reason=max-session-age` is freeable while the existing
negative cases remain protected (`cmd/gc/session_state_helpers_test.go:46-80`).

Verification performed:

```text
# RED before the production change:
CGO_ENABLED=0 go test ./cmd/gc -run '^TestIsPoolSessionSlotFreeable_Matrix$' -count=1
isPoolSessionSlotFreeable(map[sleep_reason:max-session-age state:asleep]) = false, want true

# GREEN after the production change:
gofmt -w cmd/gc/session_state_helpers.go cmd/gc/session_state_helpers_test.go
CGO_ENABLED=0 go test ./cmd/gc -run 'Test(IsPoolSessionSlotFreeable_Matrix|PoolSessionIsLiveInfo_Matrix)$' -count=1
ok  github.com/gastownhall/gascity/cmd/gc  1.514s

CGO_ENABLED=0 go test ./cmd/gc -run '^TestSessionClassifierInfoEquivalence$' -count=1
ok  github.com/gastownhall/gascity/cmd/gc  1.578s

git diff --check
```

The full `CGO_ENABLED=0 go test ./cmd/gc -count=1` run was started, but after
more than six minutes with no output it was interrupted; no package failure
was reported before interruption. The focused regression and liveness tests
are the completed verification.

## Risk

The allowlist remains explicit and narrow. Only a pool-managed session whose
runtime is already absent and whose store state carries the exact max-age
reason becomes eligible for the existing ownership check and close path.
