### PR TITLE
fix(dolt): probe the alternate managed-Dolt port during recovery instead of discarding it

### DIFF
--- a/cmd/gc/dolt_recover_managed.go
+++ b/cmd/gc/dolt_recover_managed.go
@@ -110,7 +110,11 @@ func recoverManagedDoltProcessWithOps(cityPath, host, port, user, logLevel strin
 	}
 
 	if recoverManagedDoltObservedRebindPossible(cityPath, port) {
-		if ready := observeExistingManagedDoltForRecovery(cityPath, host, port, user, recoverManagedDoltExistingObserveTimeout(timeout), &report); ready && recoverManagedDoltShouldReuseExisting(report.Port, port) {
+		observePort := port
+		if alternatePort := recoverManagedDoltObservedPort(cityPath, port); alternatePort != "" {
+			observePort = alternatePort
+		}
+		if ready := observeExistingManagedDoltForRecovery(cityPath, host, observePort, user, recoverManagedDoltExistingObserveTimeout(timeout), &report); ready && recoverManagedDoltShouldReuseExisting(report.Port, port) {
 			report.Ready = true
 			report.Healthy = true
 			if err := ops.publish(cityPath); err != nil {
@@ -255,16 +259,28 @@ func recoverManagedDoltObservedRebindPossible(cityPath, requestedPort string) bo
 	if requestedPort == "" {
 		return true
 	}
+	return recoverManagedDoltObservedPort(cityPath, requestedPort) != ""
+}
+
+// recoverManagedDoltObservedPort returns a live-state port different from the
+// requested port. Provider state can lag a scope watchdog rebind, so probing
+// only the requested port would miss the healthy managed server and start a
+// second recovery against stale endpoint state.
+func recoverManagedDoltObservedPort(cityPath, requestedPort string) string {
+	requestedPort = strings.TrimSpace(requestedPort)
+	if requestedPort == "" {
+		return ""
+	}
 	for _, path := range []string{providerManagedDoltStatePath(cityPath), managedDoltStatePath(cityPath)} {
 		state, err := readDoltRuntimeStateFile(path)
 		if err != nil || !state.Running || state.PID <= 0 || state.Port <= 0 {
 			continue
 		}
 		if strconv.Itoa(state.Port) != requestedPort {
-			return true
+			return strconv.Itoa(state.Port)
 		}
 	}
-	return false
+	return ""
 }
 
 func recoverManagedDoltRepairRuntimeStateForHealthyPort(cityPath, requestedPort string) error {

--- a/cmd/gc/dolt_recover_managed_test.go
+++ b/cmd/gc/dolt_recover_managed_test.go
@@ -432,6 +432,28 @@ func TestRecoverManagedDoltObservedRebindPossible(t *testing.T) {
 	})
 }
 
+func TestRecoverManagedDoltObservedPortUsesAlternatePublishedState(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath), doltRuntimeState{
+		Running: true,
+		PID:     1234,
+		Port:    36267,
+	}); err != nil {
+		t.Fatalf("write provider state: %v", err)
+	}
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running: true,
+		PID:     5678,
+		Port:    36266,
+	}); err != nil {
+		t.Fatalf("write published state: %v", err)
+	}
+
+	if got := recoverManagedDoltObservedPort(cityPath, "36267"); got != "36266" {
+		t.Fatalf("recoverManagedDoltObservedPort() = %q, want alternate published port 36266", got)
+	}
+}
+
 func setupRecoveryTestCity(t *testing.T) string {
 	t.Helper()
 	cityPath := t.TempDir()


### PR DESCRIPTION
## What

`recoverManagedDoltObservedRebindPossible` already treats disagreement between
the provider runtime state and the published managed-Dolt state as evidence
that the managed server may have rebound to a different port. But it throws
that information away — it returns a bare `bool`, and
`recoverManagedDoltProcess` then hands the **requested** port straight to
`observeExistingManagedDoltForRecovery`.

So in exactly the case the predicate was written to detect, recovery probes the
port it already has reason to believe is stale, fails to observe the healthy
server on the alternate state port, and proceeds to stop/start against stale
endpoint state.

This extracts the alternate port instead of discarding it, and probes that.

## Changes

- `cmd/gc/dolt_recover_managed.go`: new `recoverManagedDoltObservedPort`
  returns the first live-state port that differs from the requested port
  (provider state, then published state);
  `recoverManagedDoltObservedRebindPossible` becomes a thin wrapper over it, so
  the detection rule is unchanged and stays in one place.
- `cmd/gc/dolt_recover_managed.go`: the existing-server observation uses that
  alternate port when there is one, and the requested port otherwise.
- `cmd/gc/dolt_recover_managed_test.go`: regression test — provider state on
  36267, published state on 36266, requested 36267 ⇒ probe 36266.

Port allocation, process-ownership checks, readiness, the requested-vs-observed
reuse check (`recoverManagedDoltShouldReuseExisting`), and live runtime state
are all untouched. The only behavioural change is *which state-derived port is
handed to the existing-server observation*.

## Verification

Rebased onto `origin/main` `16bfb855b`; cherry-pick applied clean.

```
CGO_CPPFLAGS=-I$(brew --prefix icu4c)/include \
CGO_LDFLAGS=-L$(brew --prefix icu4c)/lib \
  go build ./cmd/gc                                  OK
  go test ./cmd/gc -run TestRecoverManagedDolt -count=1   ok  2.995s
  go test ./cmd/gc -run Dolt -count=1                     ok  69.429s
  go vet ./cmd/gc                                    clean
  git diff --check                                   clean
```

(On macOS a bare `go build` fails without the ICU CGO flags the Makefile sets;
that is a toolchain requirement, not a build break.)

## Honest scoping — does this fix #5536?

**No, and I want to be plain about that.** #5536 is a supervisor holding a
bead-store handle whose circuit breaker is pinned to a stale port; that breaker
is keyed once at store-open time in the beads dependency and nothing in gc
re-keys it, and `reload` does not rebuild the store because the managed-Dolt
runtime port is not part of `storeMetadataSignature`. This patch does not touch
any of that.

What it does fix is a real, separate latent defect in the *recovery* path,
which is adjacent: the supervisor reaches `gc dolt-state recover-managed`
indirectly through the beads provider script's `recover` op
(`examples/bd/assets/scripts/gc-beads-bd.sh`), so a recovery that probes the
stale port during a rebind window is one more way the system can converge on
the wrong endpoint. I filed it as `Refs`, not `Fixes`, deliberately.

## Is this us swimming against the river?

Mostly no, with one caveat I would rather state than hide.

Not against the river: this is a two-line behavioural change inside a function
whose stated purpose is already "detect a possible rebind." It makes the code
use the fact it just computed. It adds no new concept, no new config, no new
state file, and it collapses two near-identical state-file walks into one
helper. If a maintainer had written the predicate to return `(string, bool)`
originally, this is what it would have looked like.

The caveat: the *issue* it came out of probably wants a different fix — either
putting the managed-Dolt runtime port into the reload store signature, or
teaching the store breaker to re-resolve its endpoint after repeated probe
failures. Those are design calls I did not want to make unilaterally in
someone else's supervisor-reload semantics. If maintainers would rather have
one of those and consider this patch noise next to it, close it and I will not
argue — the issue is the contribution that matters here, and this is a small
piece of hardening I had in hand.

Refs #5536.
