### PR TITLE
fix: gate pool starts on live work queries

### DIFF
--- a/cmd/gc/pool_start_preflight.go
+++ b/cmd/gc/pool_start_preflight.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/telemetry"
+)
+
+const (
+	poolStartPreflightBypassed = "work_query_preflight_bypassed"
+	poolStartPreflightWork     = "work_query_preflight_work"
+	poolStartPreflightEmpty    = "work_query_preflight_empty"
+	poolStartPreflightFailed   = "work_query_preflight_failed"
+)
+
+type poolStartPreflightResult struct {
+	AllowStart bool
+	Outcome    string
+	Err        error
+	Started    time.Time
+	Finished   time.Time
+}
+
+// runPoolStartWorkQueryPreflight is the last zero-cost gate before an on-demand
+// pool candidate mutates its wake metadata and reaches runtime.Provider.Start.
+// It deliberately excludes configured pool floors: min_active_sessions is an
+// operator request for resident capacity, not inferred work demand. Named,
+// manual, and other non-pool sessions likewise retain their existing lifecycle.
+//
+// Query failures fail closed. Starting a paid model session from an incomplete
+// read would make storage failure indistinguishable from useful demand.
+func runPoolStartWorkQueryPreflight(
+	ctx context.Context,
+	candidate startCandidate,
+	cfg *config.City,
+	cityPath, cityName string,
+	store beads.Store,
+	now time.Time,
+	runner ScaleCheckRunner,
+	stderr io.Writer,
+) poolStartPreflightResult {
+	result := poolStartPreflightResult{AllowStart: true, Outcome: poolStartPreflightBypassed}
+	if strings.TrimSpace(cityPath) == "" || cfg == nil ||
+		!isPoolManagedSessionInfo(candidate.info) || isNamedSessionInfo(candidate.info) || candidate.tp.ManualSession {
+		return result
+	}
+
+	agentCfg := findAgentByTemplate(cfg, candidate.logicalTemplate(cfg))
+	if agentCfg == nil || isNonModelStartCandidate(candidate, agentCfg) ||
+		!agentCfg.SupportsGenericEphemeralSessions() ||
+		isConfiguredPoolFloorSession(candidate.info, candidate.logicalTemplate(cfg), cfg, store) {
+		return result
+	}
+	// A restarting pool worker must re-adopt work already assigned to its
+	// concrete session identity. The configured work_query remains the demand
+	// gate for cold/unassigned capacity, but it may intentionally expose only
+	// Ready-visible work and therefore omit an in-progress claim.
+	identifiers := sessionAssignmentIdentifiersForConfigInfo(candidate.info, cfg)
+	if hasAssigned, err := sessionHasOpenAssignedWorkInStoreByIdentifiers(store, identifiers); err == nil && hasAssigned {
+		return result
+	}
+	if runner == nil {
+		runner = shellScaleCheck
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	if cityName == "" {
+		cityName = config.EffectiveCityName(cfg, cityPath)
+	}
+
+	queryEnv, err := controllerWorkQueryEnv(cityPath, cfg, agentCfg)
+	if err != nil {
+		return finishPoolStartWorkQueryPreflight(ctx, result, candidate, cityPath, "", poolStartPreflightFailed, err, stderr)
+	}
+	runtimeInfo := candidate.info
+	runtimeInfo.SessionName = candidate.name()
+	identityEnv := sessionpkg.RuntimeEnvWithSessionContext(
+		runtimeInfo,
+		sessionpkg.DefaultGeneration,
+		sessionpkg.DefaultContinuationEpoch,
+		runtimeInfo.InstanceToken,
+	)
+	for key, value := range identityEnv {
+		queryEnv[key] = value
+	}
+	// A pool instance's persisted template is authoritative. Repairable legacy
+	// rows may omit it, so fall back to the configured template rather than
+	// letting a stale inherited GC_TEMPLATE select another pool.
+	if strings.TrimSpace(queryEnv["GC_TEMPLATE"]) == "" {
+		queryEnv["GC_TEMPLATE"] = agentCfg.QualifiedName()
+	}
+
+	command := strings.TrimSpace(agentCfg.EffectiveWorkQueryFor(config.QueryTopology{Beads: cfg.Beads}))
+	command = expandAgentCommandTemplate(cityPath, cityName, agentCfg, cfg.Rigs, "work_query", command, stderr)
+	if command == "" {
+		return result
+	}
+
+	result.Started = time.Now()
+	out, err := runner(command, agentCommandDir(cityPath, agentCfg, cfg.Rigs), queryEnv)
+	if err != nil {
+		return finishPoolStartWorkQueryPreflight(ctx, result, candidate, cityPath, command, poolStartPreflightFailed, err, stderr)
+	}
+	normalized := normalizeWorkQueryOutput(strings.TrimSpace(out))
+	normalized = filterUnreadyHookCandidates(normalized, now)
+	if !workQueryHasReadyWork(normalized) {
+		return finishPoolStartWorkQueryPreflight(ctx, result, candidate, cityPath, command, poolStartPreflightEmpty, nil, stderr)
+	}
+	result.AllowStart = true
+	result.Outcome = poolStartPreflightWork
+	result.Finished = time.Now()
+	telemetry.RecordPoolStartPreflight(ctx, candidate.logicalTemplate(cfg), result.Outcome, result.Finished.Sub(result.Started), nil)
+	return result
+}
+
+func isNonModelStartCandidate(candidate startCandidate, agentCfg *config.Agent) bool {
+	if strings.EqualFold(strings.TrimSpace(agentCfg.PromptMode), "none") {
+		return true
+	}
+	return candidate.tp.ResolvedProvider != nil &&
+		strings.EqualFold(strings.TrimSpace(candidate.tp.ResolvedProvider.PromptMode), "none")
+}
+
+// isConfiguredPoolFloorSession reports whether info is one of the
+// deterministic min_active_sessions residents. A failed lookup does not bypass
+// the preflight: an unverified slot is safer to query than to start on a failed
+// read.
+func isConfiguredPoolFloorSession(info sessionpkg.Info, template string, cfg *config.City, store beads.Store) bool {
+	infos, err := loadOpenSessionInfos(store)
+	if err != nil {
+		return false
+	}
+	byID := make(map[string]sessionpkg.Info, len(infos))
+	for _, candidate := range infos {
+		byID[candidate.ID] = candidate
+	}
+	return isMinFloorExemptIdleSession(byID, cfg, template, info.ID)
+}
+
+func finishPoolStartWorkQueryPreflight(
+	ctx context.Context,
+	result poolStartPreflightResult,
+	candidate startCandidate,
+	cityPath string,
+	command string,
+	outcome string,
+	err error,
+	stderr io.Writer,
+) poolStartPreflightResult {
+	result.AllowStart = false
+	result.Outcome = outcome
+	result.Err = err
+	if result.Started.IsZero() {
+		result.Started = time.Now()
+	}
+	result.Finished = time.Now()
+	template := candidate.tp.TemplateName
+	if template == "" {
+		template = strings.TrimSpace(candidate.info.Template)
+	}
+	telemetry.RecordPoolStartPreflight(ctx, template, outcome, result.Finished.Sub(result.Started), err)
+	if err != nil {
+		emitCityWorkQueryFailure(cityPath, stderr, candidate.info.ID, template, command, err)
+		fmt.Fprintf(stderr, "session reconciler: work_query preflight for %s failed closed: %v\n", candidate.name(), err) //nolint:errcheck
+	}
+	return result
+}

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -912,8 +912,12 @@ func TestCoreWorkerPromptsUseHookClaimProtocol(t *testing.T) {
 				t.Fatalf("ReadFile(%s): %v", rel, err)
 			}
 			text := string(data)
-			if !strings.Contains(text, "gc hook --claim --drain-ack --json") {
+			claimAt := strings.Index(text, "gc hook --claim --drain-ack --json")
+			if claimAt < 0 {
 				t.Fatalf("%s missing drain-aware hook claim startup protocol", rel)
+			}
+			if primeAt := strings.Index(text, "gc prime"); primeAt >= 0 && primeAt < claimAt {
+				t.Fatalf("%s runs gc prime before the zero-cost hook claim", rel)
 			}
 			if !strings.Contains(text, "gc hook --claim --json") {
 				t.Fatalf("%s missing hook claim polling protocol", rel)

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -313,6 +313,11 @@ type startExecutionOptions struct {
 	// deferred under storeQueryPartial today.
 	deferSessionClosesOnBoot bool
 	readyAssignedFlags       []bool
+	// poolWorkQueryRunner executes the controller-side zero-cost preflight for
+	// on-demand pool starts. Nil selects the production shell runner. Tests
+	// inject a deterministic runner so the coordination contract can assert that
+	// an empty query never reaches runtime.Provider.Start.
+	poolWorkQueryRunner ScaleCheckRunner
 }
 
 type startExecutionOption func(*startExecutionOptions)
@@ -411,6 +416,12 @@ func withDeferSessionClosesOnBoot() startExecutionOption {
 func withReadyAssignedFlags(readyAssignedFlags []bool) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.readyAssignedFlags = readyAssignedFlags
+	}
+}
+
+func withPoolStartWorkQueryRunner(runner ScaleCheckRunner) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.poolWorkQueryRunner = runner
 	}
 }
 
@@ -2757,6 +2768,14 @@ func executePlannedStartsTraced(
 				}
 				if !allDependenciesAliveForTemplateWithClock(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store, clk) {
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
+					continue
+				}
+				preflight := runPoolStartWorkQueryPreflight(
+					ctx, candidate, cfg, cityPath, cityName, store, clk.Now(),
+					startOpts.poolWorkQueryRunner, stderr,
+				)
+				if !preflight.AllowStart {
+					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), preflight.Outcome, preflight.Started, preflight.Finished, preflight.Err)
 					continue
 				}
 				var release func()

--- a/cmd/gc/session_workquery_preflight_test.go
+++ b/cmd/gc/session_workquery_preflight_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session/sessiontest"
+)
+
+func TestExecutePlannedStarts_WorkQueryPreflight(t *testing.T) {
+	t.Run("empty ready result skips every on-demand pool role before pre-wake", func(t *testing.T) {
+		t.Setenv("GC_BEADS", "file")
+		store := beads.NewMemStore()
+		clk := &clock.Fake{Time: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)}
+		cfg := &config.City{
+			Workspace: config.Workspace{Name: "preflight-city"},
+			Agents:    []config.Agent{{Name: "builder"}, {Name: "reviewer"}},
+		}
+		builder, builderTP := preflightPoolCandidate(t, store, "builder", "builder-1")
+		reviewer, reviewerTP := preflightPoolCandidate(t, store, "reviewer", "reviewer-1")
+		sp := runtime.NewFake()
+		queried := map[string]bool{}
+
+		got := executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{builder, reviewer},
+			cfg,
+			map[string]TemplateParams{"builder-1": builderTP, "reviewer-1": reviewerTP},
+			sp,
+			store,
+			"preflight-city",
+			t.TempDir(),
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			ioDiscard{},
+			nil,
+			withPoolStartWorkQueryRunner(func(_ string, _ string, env map[string]string) (string, error) {
+				queried[env["GC_TEMPLATE"]] = true
+				if env["GC_SESSION_ID"] == "" || env["GC_SESSION_NAME"] == "" ||
+					env["GC_ALIAS"] == "" || env["GC_AGENT"] == "" {
+					t.Fatalf("preflight identity env is incomplete: %#v", env)
+				}
+				return "[]", nil
+			}),
+		)
+		if got != 0 {
+			t.Fatalf("woken = %d, want 0", got)
+		}
+		if !queried["builder"] || !queried["reviewer"] {
+			t.Fatalf("queried templates = %#v, want both pool roles", queried)
+		}
+		if starts := countProviderStarts(sp); starts != 0 {
+			t.Fatalf("provider Start calls = %d, want 0", starts)
+		}
+		for _, candidate := range []startCandidate{builder, reviewer} {
+			updated, err := store.Get(candidate.info.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := updated.Metadata["last_woke_at"]; got != "" {
+				t.Fatalf("%s last_woke_at = %q, want unchanged empty before preflight passes", candidate.logicalTemplate(cfg), got)
+			}
+		}
+	})
+
+	t.Run("ready work starts the pool session", func(t *testing.T) {
+		t.Setenv("GC_BEADS", "file")
+		store := beads.NewMemStore()
+		clk := &clock.Fake{Time: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)}
+		cfg := &config.City{Workspace: config.Workspace{Name: "preflight-city"}, Agents: []config.Agent{{Name: "builder"}}}
+		candidate, tp := preflightPoolCandidate(t, store, "builder", "builder-1")
+		sp := runtime.NewFake()
+
+		got := executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{candidate},
+			cfg,
+			map[string]TemplateParams{"builder-1": tp},
+			sp,
+			store,
+			"preflight-city",
+			t.TempDir(),
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			ioDiscard{},
+			nil,
+			withPoolStartWorkQueryRunner(func(_ string, _ string, env map[string]string) (string, error) {
+				if got := env["GC_SESSION_ID"]; got != candidate.info.ID {
+					t.Fatalf("GC_SESSION_ID = %q, want %q", got, candidate.info.ID)
+				}
+				if got := env["GC_SESSION_NAME"]; got != candidate.name() {
+					t.Fatalf("GC_SESSION_NAME = %q, want %q", got, candidate.name())
+				}
+				if got := env["GC_ALIAS"]; got != "builder-1" {
+					t.Fatalf("GC_ALIAS = %q, want builder-1", got)
+				}
+				if got := env["GC_AGENT"]; got != "builder-1" {
+					t.Fatalf("GC_AGENT = %q, want builder-1", got)
+				}
+				if got := env["GC_TEMPLATE"]; got != "builder" {
+					t.Fatalf("GC_TEMPLATE = %q, want builder", got)
+				}
+				return `[{"id":"work-1"}]`, nil
+			}),
+		)
+		if got != 1 {
+			t.Fatalf("woken = %d, want 1", got)
+		}
+		if starts := countProviderStarts(sp); starts != 1 {
+			t.Fatalf("provider Start calls = %d, want 1", starts)
+		}
+	})
+
+	t.Run("existing assignment bypasses a cold-demand query", func(t *testing.T) {
+		t.Setenv("GC_BEADS", "file")
+		store := beads.NewMemStore()
+		clk := &clock.Fake{Time: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)}
+		cfg := &config.City{Workspace: config.Workspace{Name: "preflight-city"}, Agents: []config.Agent{{Name: "builder"}}}
+		candidate, tp := preflightPoolCandidate(t, store, "builder", "builder-1")
+		status := "in_progress"
+		if _, err := store.Create(beads.Bead{ID: "work-1", Title: "claimed work", Type: "task", Status: status, Assignee: candidate.info.ID}); err != nil {
+			t.Fatal(err)
+		}
+		sp := runtime.NewFake()
+		runs := 0
+
+		got := executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{candidate},
+			cfg,
+			map[string]TemplateParams{"builder-1": tp},
+			sp,
+			store,
+			"preflight-city",
+			t.TempDir(),
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			ioDiscard{},
+			nil,
+			withPoolStartWorkQueryRunner(func(string, string, map[string]string) (string, error) {
+				runs++
+				return "[]", nil
+			}),
+		)
+		if runs != 0 {
+			t.Fatalf("preflight runner calls = %d, want 0 for an already assigned session", runs)
+		}
+		if got != 1 || countProviderStarts(sp) != 1 {
+			t.Fatalf("woken = %d, provider starts = %d; want 1, 1", got, countProviderStarts(sp))
+		}
+	})
+
+	t.Run("query error fails closed and logs its outcome", func(t *testing.T) {
+		t.Setenv("GC_BEADS", "file")
+		store := beads.NewMemStore()
+		clk := &clock.Fake{Time: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)}
+		cfg := &config.City{Workspace: config.Workspace{Name: "preflight-city"}, Agents: []config.Agent{{Name: "builder"}}}
+		candidate, tp := preflightPoolCandidate(t, store, "builder", "builder-1")
+		sp := runtime.NewFake()
+		var stderr bytes.Buffer
+
+		got := executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{candidate},
+			cfg,
+			map[string]TemplateParams{"builder-1": tp},
+			sp,
+			store,
+			"preflight-city",
+			t.TempDir(),
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			&stderr,
+			nil,
+			withPoolStartWorkQueryRunner(func(string, string, map[string]string) (string, error) {
+				return "", errors.New("store unavailable")
+			}),
+		)
+		if got != 0 {
+			t.Fatalf("woken = %d, want 0", got)
+		}
+		if starts := countProviderStarts(sp); starts != 0 {
+			t.Fatalf("provider Start calls = %d, want 0", starts)
+		}
+		if got := stderr.String(); !bytes.Contains([]byte(got), []byte("work_query_preflight_failed")) {
+			t.Fatalf("stderr = %q, want observable work_query_preflight_failed outcome", got)
+		}
+	})
+
+	t.Run("configured floor named and non-model sessions bypass the preflight", func(t *testing.T) {
+		t.Setenv("GC_BEADS", "file")
+		store := beads.NewMemStore()
+		clk := &clock.Fake{Time: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)}
+		minActive := 1
+		cfg := &config.City{
+			Workspace: config.Workspace{Name: "preflight-city"},
+			Agents: []config.Agent{
+				{Name: "floor", MinActiveSessions: &minActive},
+				{Name: "persistent"},
+				{Name: "daemon"},
+			},
+		}
+		floor, floorTP := preflightPoolCandidate(t, store, "floor", "floor-1")
+		elastic, elasticTP := preflightPoolCandidate(t, store, "floor", "floor-2")
+		persistent, persistentTP := preflightPoolCandidate(t, store, "persistent", "persistent-1")
+		daemon, daemonTP := preflightPoolCandidate(t, store, "daemon", "daemon-1")
+		daemonTP.ResolvedProvider = &config.ResolvedProvider{PromptMode: "none"}
+		daemon.tp = daemonTP
+		persistent.info.ConfiguredNamedSession = true
+		if err := store.SetMetadata(persistent.info.ID, "configured_named_session", "true"); err != nil {
+			t.Fatal(err)
+		}
+		sp := runtime.NewFake()
+		runs := 0
+
+		got := executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{floor, elastic, persistent, daemon},
+			cfg,
+			map[string]TemplateParams{"floor-1": floorTP, "floor-2": elasticTP, "persistent-1": persistentTP, "daemon-1": daemonTP},
+			sp,
+			store,
+			"preflight-city",
+			t.TempDir(),
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			ioDiscard{},
+			nil,
+			withPoolStartWorkQueryRunner(func(string, string, map[string]string) (string, error) {
+				runs++
+				return "[]", nil
+			}),
+		)
+		if runs != 1 {
+			t.Fatalf("preflight runner calls = %d, want 1 for the elastic pool session only", runs)
+		}
+		if got != 3 {
+			t.Fatalf("woken = %d, want 3", got)
+		}
+		if starts := countProviderStarts(sp); starts != 3 {
+			t.Fatalf("provider Start calls = %d, want 3", starts)
+		}
+	})
+}
+
+func preflightPoolCandidate(t *testing.T, store beads.Store, template, name string) (startCandidate, TemplateParams) {
+	t.Helper()
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-" + name,
+		Title:  template,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + name},
+		Metadata: map[string]string{
+			"template":     template,
+			"agent_name":   name,
+			"alias":        name,
+			"session_name": name,
+			"state":        "start-pending",
+			"pool_managed": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp := TemplateParams{
+		Command:      "agent",
+		SessionName:  name,
+		TemplateName: template,
+		Alias:        name,
+		Env: map[string]string{
+			"GC_AGENT":    name,
+			"GC_ALIAS":    name,
+			"GC_TEMPLATE": template,
+		},
+	}
+	return startCandidate{info: sessiontest.SeedBead(t, session), tp: tp}, tp
+}
+
+func countProviderStarts(sp *runtime.Fake) int {
+	count := 0
+	for _, call := range sp.Calls {
+		if call.Method == "Start" {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -56,11 +56,12 @@ type recorderInstruments struct {
 	bdTotal              metric.Int64Counter
 	slingTotal           metric.Int64Counter
 
-	// Counters — Phase 2 (4)
-	poolSpawnTotal  metric.Int64Counter
-	poolRemoveTotal metric.Int64Counter
-	mailOpsTotal    metric.Int64Counter
-	drainTotal      metric.Int64Counter
+	// Counters — Phase 2 (5)
+	poolSpawnTotal          metric.Int64Counter
+	poolRemoveTotal         metric.Int64Counter
+	poolStartPreflightTotal metric.Int64Counter
+	mailOpsTotal            metric.Int64Counter
+	drainTotal              metric.Int64Counter
 
 	// Gauges (1)
 	beadStoreHealthy metric.Int64Gauge
@@ -146,6 +147,9 @@ func initInstruments() {
 		)
 		inst.poolRemoveTotal, _ = m.Int64Counter("gc.pool.removes.total",
 			metric.WithDescription("Total pool member instance removals"),
+		)
+		inst.poolStartPreflightTotal, _ = m.Int64Counter("gc.pool.start_preflights.total",
+			metric.WithDescription("Pool starts admitted or suppressed by work_query preflight"),
 		)
 		inst.mailOpsTotal, _ = m.Int64Counter("gc.mail.operations.total",
 			metric.WithDescription("Total mail operations"),
@@ -616,6 +620,26 @@ func RecordPoolCheck(ctx context.Context, agent string, durationMs float64, desi
 		otellog.Float64("duration_ms", durationMs),
 		otellog.Int("desired", desired),
 		otellog.String("status", status),
+		errKV(err),
+	)
+}
+
+// RecordPoolStartPreflight records the final zero-cost work_query decision made
+// before an on-demand pool session reaches its model runtime. The template
+// label is stable across numbered pool instances; outcome distinguishes useful
+// work from empty and failed reads.
+func RecordPoolStartPreflight(ctx context.Context, template, outcome string, duration time.Duration, err error) {
+	initInstruments()
+	inst.poolStartPreflightTotal.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("template", template),
+			attribute.String("outcome", outcome),
+		),
+	)
+	emit(ctx, "pool.start_preflight", severity(err),
+		otellog.String("template", template),
+		otellog.String("outcome", outcome),
+		otellog.Float64("duration_ms", float64(duration.Milliseconds())),
 		errKV(err),
 	)
 }


### PR DESCRIPTION
Addresses the zero-cost pool-start gate in #5508.

## Summary
- run the configured `work_query` immediately before an on-demand pool candidate reaches `runtime.Provider.Start`
- suppress model starts on empty or failed queries without mutating pre-wake metadata
- preserve configured floors, named/manual sessions, non-model workers, and sessions re-adopting assigned work
- add structured preflight telemetry and enforce hook-claim-before-prime prompt ordering

## Validation
- all six `cmd/gc` pre-push shards passed
- focused and neighboring lifecycle tests passed, including 3x boundary runs
- `internal/telemetry` and resource census passed
- changed-file formatting, lint, and repository pre-commit `go vet ./...` passed

The broader pre-push `unit-core` job remains red on unrelated host-sensitive tests (Darwin `/var` path normalization, XDG/Home, pid/signal behavior, and the ZCode adapter shell harness); none of those packages are changed here.