### PR TITLE
fix(dispatch): resolve class store refs as city control scope

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5185,15 +5185,19 @@ func configuredControlDispatcherRouteForScope(cfg *config.City, rigContext strin
 
 func controlDispatcherRigContextForStoreRef(storeRef string) string {
 	storeRef = strings.TrimSpace(storeRef)
-	if storeRef == "" || storeRef == "city" || strings.HasPrefix(storeRef, "city:") {
+	if storeRef == "" || storeRef == "city" {
 		return ""
 	}
+	if rigContext, ok := storeref.ScopeRigContext(storeRef); ok {
+		return rigContext
+	}
+	// Keep accepting the pre-canonical bare rig label used by older census
+	// snapshots while canonical refs are interpreted by storeref above.
 	return strings.TrimPrefix(storeRef, "rig:")
 }
 
 func controlDispatcherStoreRefLabel(storeRef string) string {
-	storeRef = strings.TrimSpace(storeRef)
-	if storeRef == "" || storeRef == "city" || strings.HasPrefix(storeRef, "city:") {
+	if controlDispatcherRigContextForStoreRef(storeRef) == "" {
 		return "the city store"
 	}
 	return fmt.Sprintf("rig store %q", controlDispatcherRigContextForStoreRef(storeRef))

--- a/cmd/gc/build_desired_state_gmnos_test.go
+++ b/cmd/gc/build_desired_state_gmnos_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestControlDispatcherRigContextForStoreRefUsesCanonicalScope(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "legacy city", ref: "", want: ""},
+		{name: "city alias", ref: "city", want: ""},
+		{name: "city", ref: "city:test-city", want: ""},
+		{name: "relocated class", ref: "class:gmnos", want: ""},
+		{name: "rig", ref: "rig:fixture", want: "fixture"},
+		{name: "legacy bare rig", ref: "fixture", want: "fixture"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := controlDispatcherRigContextForStoreRef(tc.ref); got != tc.want {
+				t.Fatalf("controlDispatcherRigContextForStoreRef(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildDesiredStateClassControlWorkWakesExactlyOneCityDispatcher(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	classStore := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, classStore)
+
+	control, err := classStore.Create(beads.Bead{
+		Title:  "Finalize graph workflow",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindWorkflowFinalize,
+			beadmeta.RoutedToMetadataKey:     "core.control-dispatcher",
+			beadmeta.RootStoreRefMetadataKey: "class:gmnos",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create class control: %v", err)
+	}
+
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: &maxActive,
+		}},
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), cityStore,
+		nil, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	stored, err := classStore.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get class control: %v", err)
+	}
+	if got := stored.Metadata[beadmeta.RoutedToMetadataKey]; got != "core.control-dispatcher" {
+		t.Fatalf("class control route = %q, want canonical city route preserved", got)
+	}
+	if got := result.ScaleCheckCounts["core.control-dispatcher"]; got != 1 {
+		t.Fatalf("city dispatcher demand = %d, want exactly one", got)
+	}
+	if got := result.ScaleCheckCounts["fixture/core.control-dispatcher"]; got != 0 {
+		t.Fatalf("rig dispatcher demand = %d, want zero for class-resident control work", got)
+	}
+	if len(result.State) != 1 {
+		t.Fatalf("desired state = %v, want exactly one ephemeral city dispatcher", mapKeys(result.State))
+	}
+	for _, desired := range result.State {
+		if desired.TemplateName != "core.control-dispatcher" {
+			t.Fatalf("desired dispatcher template = %q, want core.control-dispatcher", desired.TemplateName)
+		}
+	}
+}


### PR DESCRIPTION
# fix(dispatch): resolve class store refs as city control scope

## Summary

Use the canonical `storeref.ScopeRigContext` contract when desired-state route
repair selects a control dispatcher. Relocated class bindings such as
`class:gmnos` are city scope, while canonical `rig:<name>` refs remain rig
scope; legacy bare rig labels remain compatible.

## Mechanism

The old `controlDispatcherRigContextForStoreRef` in
`cmd/gc/build_desired_state.go:5186-5197` treated every non-city value as a rig
by stripping only the `rig:` prefix. That turned `class:gmnos` into a phantom
rig context and caused `desiredRoute` (`:5088-5105`) to suppress valid city
dispatcher demand when no such rig dispatcher was configured.

The candidate delegates canonical refs to `storeref.ScopeRigContext`, whose
contract at `internal/storeref/storeref.go:39-67` explicitly maps class
bindings to city scope. The diagnostic label uses the same resolver. Existing
legacy bare-rig compatibility is retained intentionally.

## Changes

- `cmd/gc/build_desired_state.go`: canonical scope resolution and consistent
  city/rig diagnostic labeling.
- `cmd/gc/build_desired_state_gmnos_test.go`: RED-first direct scope table and
  full desired-state regression. It proves `class:gmnos` preserves its route,
  produces exactly one city dispatcher demand/desired session, produces no rig
  demand, and that both canonical `rig:fixture` and legacy bare `fixture`
  remain rig-scoped.

No production config, formulas, stores, sessions, or binaries were touched.

## Validation

Environment: macOS Darwin arm64; Homebrew ICU `icu4c@78`.

```sh
CGO_ENABLED=1 \
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c@78/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c@78/lib' \
go test ./cmd/gc \
  -run 'TestControlDispatcherRigContextForStoreRefUsesCanonicalScope|TestBuildDesiredStateClassControlWorkWakesExactlyOneCityDispatcher' \
  -count=1 -v
```

Result: PASS (`cmd/gc`, 1.813s), including the legacy bare-rig subtest.

```sh
CGO_ENABLED=1 \
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c@78/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c@78/lib' \
go test ./cmd/gc -run 'Test(BuildDesiredState_(OpenBlockedControlDispatcherWorkRetainsDemand|RepairsCityRoutedRigControlWork|RepairsAliasedRigControlWorkOnlyOnce|RepairsRigRoutedCityControlWork|DoesNotWakeRigDispatcherWhenCityRouteRepairFails)|RepairControlDispatcherRoutes|OpenControlDispatcherDemandHonorsBareLegacyRoute|SourceWorkflowStoresScanTheLedgerThatHoldsWorkflowRoots|SourceWorkflowStoresStayOnTheScopeStoreWithNoRelocation)' -count=1 -v
```

Result: PASS (`cmd/gc`, 1.980s). The source-workflow test emits its existing
`native_store_unavailable` preflight warning for a deliberately incomplete temp
store, then passes.

```sh
CGO_ENABLED=1 \
CGO_CPPFLAGS='-I/opt/homebrew/opt/icu4c@78/include' \
CGO_LDFLAGS='-L/opt/homebrew/opt/icu4c@78/lib' \
go test ./internal/storeref ./internal/dispatch ./internal/sourceworkflow -count=1
```

Result: PASS (`storeref` 0.889s, `dispatch` 4.884s, `sourceworkflow` 2.376s).

Linux validation: `haus-gpu` WSL2, Bash 5.2, Go 1.26.6 from the official
archive (SHA-256 prefix supplied with the receipt: `708eff...`). `make build`,
`make check-residency-boundary`, and `make check` each exited 0; lint reported
0 issues; the focused and regression test commands exited 0.

`gofmt` is clean and `git diff --check` is clean. `make build` passed (exit 0),
with only the informational note that no stable macOS signing identity was
available. `make check` reached `golangci-lint` (`0 issues`) and the vet/check
stages, then failed with exit 2 in
`./scripts/check-residency-boundary.sh --self-test`:

```text
declare: -A: invalid option
cmd: unbound variable
make: *** [check-residency-boundary] Error 1
```

This is an unrelated baseline portability defect in the residency-boundary
shell self-test on this macOS host, not a failure introduced by this candidate;
no workaround was applied. A package-wide `go test ./cmd/gc -count=1` was started in the scratch
worktree but interrupted after approximately 222 seconds per operator stop
instruction; it is not claimed as a full-suite result. `make check-docs` was
not run because no docs or generated schemas are changed.

## Blast radius and non-goals

Blast radius is limited to control-dispatcher scope selection during desired
state construction. Canonical city refs and class refs now share the city
dispatcher lookup; canonical and legacy rig refs continue to select rig
dispatchers. Durable route writes, store enumeration, session lifecycle, and
formula compilation are unchanged.

Out of scope:

- Convoy source cleanup: its graph/class binding bridge is already covered by
  existing tests.
- Formula/`gc.routed_to` drift cleanup: its raw store scan is a separate path;
  no isolated class-binding failure justified expanding this patch.
- New defaults, config changes, diagnostics policy, or changes to legacy census
  vocabulary.

## Review notes

- B1/B2/B3: no hardcoded roles or new semantic heuristics; the change reuses an
  existing canonical resolver.
- B7/B8/B14/B20/B27: test is colocated unit-level coverage, uses `t.TempDir`,
  hand-written in-memory stores, reads the route back, and adds no sleeps or
  ambient environment mutation.
- B10/B23: scope is the single misclassifying helper plus its missing class
  integration test; canonical resolver siblings were audited, and separate
  convoy/formula paths remain explicit non-goals.
- B12/B16/B17/B21/B24/B28/B29/B30/B34/B35/B36: no store-write, lifecycle,
  reload, environment, package-state, safety-predicate, pack-qualification, or
  sweep behavior was changed.

## Publication gate

Issue: [#5547](https://github.com/gastownhall/gascity/issues/5547) (filed first).

The issue-first publication gate is satisfied; retain this reference when
opening the pull request:

```sh
awk '/^Issue: #/ && /[<>]/ { found=1 } END { exit found }' PR-gmnos-control-dispatcher-scope.md
```

## Verification provenance

- Baseline `HEAD` before applying the candidate and `origin/main`:
  `ca54c7264ff139b3502064daa430bdb719992d81`
- Base commit: merge PR #5534, `2026-08-23T10:59:02-07:00`
- SHA-256 `cmd/gc/build_desired_state.go`:
  `a1b0c9b84fda797cbf1c4f880749a92a17032808f81de7adcc311408d4afafc3`
- SHA-256 `cmd/gc/build_desired_state_gmnos_test.go`:
  `8a0b2bf06c000cbc0c38ea77d61ee9996a49a13e9b9b8dd8007ab005b09b165c`
- SHA-256 `ISSUE-gmnos-control-dispatcher-scope.md` at final-packet intake:
  `029c70169cfe855c8f36cde26161d0313a480c3d39b80df92082df6e94242b81`
- SHA-256 `ISSUE-gmnos-control-dispatcher-scope.md` after the final packet edit:
  `e56eef8f82cbe11b03eac79b80b837f84452fa198b4fda075e64cc3bdb016395`
