### PR TITLE
fix(gc): serve `gc bd dep tree` in process for class-owned beads

### DIFF
--- a/cmd/gc/bd_relocated_classes.go
+++ b/cmd/gc/bd_relocated_classes.go
@@ -112,10 +112,11 @@ func bdRelocatedClassOverrideEnabled() bool {
 // gcg- row. The value named an id but the VERB is a PROJECTION over a class
 // this ledger cannot see, and a projection that cannot see a class must fail
 // loudly rather than answer with the empty set. That is the whole of ga-iaj7k's
-// Invariant 0, and it is what makes `list` COHERENT with `dep tree`, which
-// already refuses a relocated id — two projections over the same data with
-// opposite failure semantics is worse than either one alone, because an
-// operator who learned the loud one trusts the quiet one.
+// Invariant 0, and it is what makes `list` COHERENT with `dep tree` — which
+// answers a relocated id from the store that holds it, rather than emptily from
+// the one that does not. Two projections over the same data with opposite
+// failure semantics is worse than either one alone, because an operator who
+// learned the loud one trusts the quiet one.
 //
 // `search` is the same projection over the same flag: bd registers
 // --metadata-field for it too, and it answers no-match with `[]` and exit 0.
@@ -134,13 +135,15 @@ func bdRelocatedClassOverrideEnabled() bool {
 // The other verbs are unguarded because they are no longer blind, not because
 // they were ever safe:
 //
-//   - `show`, `update` (including `--claim`), `release-if-current` and
-//     `dep list` are answered IN PROCESS from the binding their class is served
-//     from — cmd_bd_by_id.go, wired into doBd immediately after this scan — so
-//     they never reach the subprocess for a class-owned bead.
-//   - `dep tree` is not served in process, and on a class-owned id that same
-//     surface REFUSES it (exit 1, naming the bead and the binding) rather than
-//     forwarding it.
+//   - `show`, `update` (including `--claim`), `release-if-current`, `dep list`
+//     and `dep tree` are answered IN PROCESS from the binding their class is
+//     served from — cmd_bd_by_id.go, wired into doBd immediately after this
+//     scan — so they never reach the subprocess for a class-owned bead.
+//   - Spellings of those verbs the in-process arm does not implement — `dep tree
+//     --show-all-paths`, `--status`, `--format`, `--direction=both` — are
+//     REFUSED there (exit 1, naming the bead and the binding) rather than
+//     forwarded, because serving them by dropping the flag would answer a
+//     different question than the one asked.
 //   - Every other bd subcommand that ADDRESSES a reserved-prefix id — in a
 //     positional or an id-valued flag — is refused there too, by ownership
 //     rather than by servability.

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -546,28 +546,31 @@ func TestGcBdListRefusesAGraphClassProjectionOnASplitCity(t *testing.T) {
 // TestGcBdProjectionsAgreeOnAClassTheyCannotSee is the coherence assertion, and
 // it is the reason this fix is not just "one more guarded verb".
 //
-// `gc bd dep tree <gcg id>` and `gc bd list --metadata-field <k>=<gcg id>` are
-// two projections over the same data, asked through the same command, on the
-// same city. Before this change they disagreed about what happens when the class
-// cannot be seen: dep tree refused with exit 1 while list answered `[]` with exit
-// 0. Two failure semantics for one fact is worse than either one alone, because
-// an operator who learned the loud one trusts the quiet one.
+// `gc bd list` and `gc bd search`, both carrying `--metadata-field
+// <k>=<gcg id>`, are two projections over the same data, asked through the same
+// command, on the same city. The failure this pins is disagreement about what
+// happens when the class cannot be seen — one refusing with exit 1 while the
+// other answers `[]` with exit 0. Two failure semantics for one fact is worse
+// than either one alone, because an operator who learned the loud one trusts the
+// quiet one.
 //
 // The assertion is the correspondence, not the wording: BOTH exit non-zero,
 // BOTH name the id namespace that cannot be seen AND the binding it is served
 // from, and NEITHER reaches the ledger that cannot answer. Those three are what
 // an operator needs and what a script can rely on.
 //
-// The two messages are deliberately not compared verbatim, because they are
-// produced by different arms answering different questions and the difference
-// is real: `dep tree` is refused by the by-id door, which knows the exact bead
-// and reports OWNERSHIP of it, while `list` is refused by the dialect guard,
-// which knows only that the query names the namespace and reports that. Pinning
-// identical wording would force one arm to say something it does not know.
+// This pin used to pair `list` against `gc bd dep tree <gcg id>`, whose refusal
+// was the loud arm the quiet one had to be squared with. ga-pxppl squared it the
+// other way: dep tree is now ANSWERED in process from the binding the class is
+// served from, so it is no longer a projection that cannot see the class and has
+// no place in this correspondence. `search` takes its row because it is blind for
+// the same reason `list` is and shares its scan. The coherence claim that spans
+// both outcomes — answer from the owning store, or refuse; never a quiet `[]` —
+// is conformanceProjectionCoherence (I14).
 func TestGcBdProjectionsAgreeOnAClassTheyCannotSee(t *testing.T) {
 	for name, args := range map[string][]string{
-		"dep tree": {"dep", "tree", "gcg-abc123"},
-		"list":     bdListGraphProjection,
+		"list":   bdListGraphProjection,
+		"search": {"search", "--metadata-field", "gc.root_bead_id=gcg-abc123", "--json"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
@@ -1142,13 +1145,19 @@ func TestBdRelocatedClassGuardCoversEveryFrontierSurface(t *testing.T) {
 // routing anywhere on the path, so following the advice ran the blind read the
 // refusal had just prevented.
 //
-// `dep tree` is still not served in process — this surface implements no tree
-// walk — but servability is no longer what decides where it goes. On a
-// class-owned id it is refused before the subprocess, because bd would answer
-// from the one ledger that cannot hold the bead; on a work id it is forwarded
-// verbatim, because that ledger is exactly the right answerer. Both halves are
-// asserted together: either alone is satisfied by a surface that stopped
-// discriminating.
+// Servability is not what decides where `dep tree` goes, and ga-pxppl is why
+// that distinction had to survive the verb becoming servable. On a class-owned
+// id the walk is now answered in process from the class binding, because bd
+// would answer from the one ledger that cannot hold the bead; on a work id it is
+// still forwarded verbatim, because that ledger is exactly the right answerer.
+// Both halves are asserted together: either alone is satisfied by a surface that
+// stopped discriminating.
+//
+// The class-owned leg's binding is empty, so the routed answer is a genuine
+// absence reported in bd's own shape — the same claim
+// TestGcBdShowNeverReachesBdForAClassOwnedIDOnASplitCity makes for `show`. That
+// the walk itself is correct is pinned separately, against a populated binding,
+// by TestBdByIDServesDepTreeFromTheClassBinding.
 func TestGcBdDepTreeSplitsOnOwnershipNotOnServability(t *testing.T) {
 	t.Run("work id is forwarded verbatim", func(t *testing.T) {
 		args := []string{"dep", "tree", "demo-abc123"}
@@ -1169,7 +1178,7 @@ func TestGcBdDepTreeSplitsOnOwnershipNotOnServability(t *testing.T) {
 		}
 	})
 
-	t.Run("class-owned id is refused", func(t *testing.T) {
+	t.Run("class-owned id is answered in process", func(t *testing.T) {
 		args := []string{"dep", "tree", "gcg-abc123"}
 		capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
 		resetCLIStorageRoutes(t)
@@ -1177,13 +1186,13 @@ func TestGcBdDepTreeSplitsOnOwnershipNotOnServability(t *testing.T) {
 
 		var stdout, stderr bytes.Buffer
 		if code := doBd(args, &stdout, &stderr); code == 0 {
-			t.Fatalf("doBd(%v) exited 0 for a class-owned id; stdout=%q", args, stdout.String())
+			t.Fatalf("doBd(%v) exited 0 for a class-owned id the binding does not hold; stdout=%q", args, stdout.String())
 		}
 		if data, err := os.ReadFile(capture); err == nil && strings.Contains(string(data), strings.Join(args, " ")) {
 			t.Fatalf("the class-owned dep tree was forwarded to bd: %q", data)
 		}
-		if !strings.Contains(stderr.String(), "gc bd dep tree") {
-			t.Errorf("the refusal does not name the command the operator ran; stderr=%q", stderr.String())
+		if !strings.Contains(stderr.String(), "gcg-abc123") {
+			t.Errorf("the answer does not name the bead; stderr=%q", stderr.String())
 		}
 	})
 }

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -75,7 +75,7 @@ package main
 //     resolve.
 //
 // Served here: show, update (fields and metadata, including --claim), close,
-// reopen, release-if-current, and dep list. `gc bd heartbeat` is not — it
+// reopen, release-if-current, dep list, and dep tree. `gc bd heartbeat` is not — it
 // forwards to bd's native owner-only lease-refresh verb (commit 80aad8c), a
 // literal spelling parseBdByIDOp does not recognize, and it is no longer
 // rewritten to a metadata update the way it once was. On a city that relocates
@@ -194,6 +194,21 @@ const (
 	// every closed blocker, and on a split city it is the operation whose
 	// subprocess never returned.
 	bdByIDDepList bdByIDVerb = "dep-list"
+	// bdByIDDepTree is `gc bd dep tree <id> [--direction=up|down] [--reverse]
+	// [--max-depth=N] [--json]`, the recursive form of the same read.
+	//
+	// It is the one federated read that resolves a whole relocated molecule, and
+	// every status summary asks for exactly that: pr_review.py's
+	// city_dep_subtree walks a root plus its descendants in one call, because
+	// the selector projections (`list`, `ready`, `sql`) cannot see the class at
+	// all. While this was unserved, the ownership gate refused it on every
+	// class-owned root — correctly, since bd would have answered from the ledger
+	// that does not hold the bead — and the pr-review label poller failed on
+	// every tick for every labeled PR (ga-pxppl).
+	//
+	// Serving it asks nothing new of the store: the walk is DepList to a level
+	// and Get for each related bead, which is what dep list already does once.
+	bdByIDDepTree bdByIDVerb = "dep-tree"
 	// bdByIDUpdate is `gc bd update <id>` carrying field and metadata writes.
 	//
 	// It is here because it is the step-completion write the core pack makes on
@@ -231,8 +246,11 @@ type bdByIDOp struct {
 	Assignee string
 	// Direction and DepType carry `dep list`'s two selectors. Direction is
 	// always populated for that verb; an empty DepType means every edge type.
+	// Direction is populated for `dep tree` too, which takes the same axis.
 	Direction string
 	DepType   string
+	// MaxDepth is `dep tree`'s safety limit, always populated for that verb.
+	MaxDepth int
 	// Update carries the field and metadata writes of the update verb, already
 	// translated into the object model's own shape.
 	Update beads.UpdateOpts
@@ -269,10 +287,16 @@ func parseBdByIDOp(bdArgs []string) (bdByIDOp, bool) {
 		}
 		return bdByIDOp{Verb: bdByIDRelease, ID: id, Assignee: assignee}, true
 	case "dep":
-		if len(bdArgs) < 2 || bdArgs[1] != "list" {
+		if len(bdArgs) < 2 {
 			return bdByIDOp{}, false
 		}
-		return parseBdDepListArgs(bdArgs[2:])
+		switch bdArgs[1] {
+		case "list":
+			return parseBdDepListArgs(bdArgs[2:])
+		case "tree":
+			return parseBdDepTreeArgs(bdArgs[2:])
+		}
+		return bdByIDOp{}, false
 	}
 	return bdByIDOp{}, false
 }
@@ -529,6 +553,86 @@ func parseBdDepListArgs(args []string) (bdByIDOp, bool) {
 	}
 	if op.ID == "" {
 		return bdByIDOp{}, false
+	}
+	if op.Direction != bdByIDDepDirectionUp && op.Direction != bdByIDDepDirectionDown {
+		return bdByIDOp{}, false
+	}
+	return op, true
+}
+
+// bdByIDDepTreeDefaultMaxDepth is bd's own default tree depth (dep.go registers
+// --max-depth with it), carried here so an unflagged walk cuts in the same place
+// on both arms.
+const bdByIDDepTreeDefaultMaxDepth = 50
+
+// parseBdDepTreeArgs parses the tail of `gc bd dep tree`.
+//
+// It serves the flags whose meaning this walk implements — --direction, its
+// deprecated --reverse spelling, --max-depth (with bd's -d short form) and
+// --json — and rejects the rest rather than accepting them as no-ops.
+// --show-all-paths, --status and --format all change what bd prints, so
+// answering them with the plain walk would report a different question as
+// executed; unrecognized here means the ownership gate refuses them loudly on a
+// class-owned id, which is the honest answer until they are implemented.
+//
+// --direction=both is rejected for the same reason and not because it is hard:
+// bd merges two walks for it, and this arm walks one.
+func parseBdDepTreeArgs(args []string) (bdByIDOp, bool) {
+	op := bdByIDOp{Verb: bdByIDDepTree, MaxDepth: bdByIDDepTreeDefaultMaxDepth}
+	reverse := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		name, inline, hasInline := strings.Cut(arg, "=")
+		switch name {
+		case "--json":
+			if hasInline {
+				return bdByIDOp{}, false
+			}
+			op.JSON = true
+			continue
+		case "--reverse":
+			if hasInline {
+				return bdByIDOp{}, false
+			}
+			reverse = true
+			continue
+		case "--direction", "--max-depth", "-d":
+			if !hasInline {
+				if i+1 >= len(args) {
+					return bdByIDOp{}, false
+				}
+				i++
+				inline = args[i]
+			}
+			if name == "--direction" {
+				op.Direction = inline
+				continue
+			}
+			depth, err := strconv.Atoi(strings.TrimSpace(inline))
+			if err != nil || depth < 1 {
+				return bdByIDOp{}, false
+			}
+			op.MaxDepth = depth
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			return bdByIDOp{}, false
+		}
+		if op.ID != "" || arg == "" {
+			return bdByIDOp{}, false
+		}
+		op.ID = arg
+	}
+	if op.ID == "" {
+		return bdByIDOp{}, false
+	}
+	// bd's own precedence: an explicit --direction wins, and bare --reverse is
+	// the deprecated spelling of --direction=up.
+	if op.Direction == "" {
+		op.Direction = bdByIDDepDirectionDown
+		if reverse {
+			op.Direction = bdByIDDepDirectionUp
+		}
 	}
 	if op.Direction != bdByIDDepDirectionUp && op.Direction != bdByIDDepDirectionDown {
 		return bdByIDOp{}, false
@@ -824,6 +928,8 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		return doBdByIDReleaseIfCurrent(resolution.Graph, op.ID, op.Assignee, stdout, stderr), true
 	case bdByIDDepList:
 		return doBdByIDDepList(resolution.Graph, op, stdout, stderr), true
+	case bdByIDDepTree:
+		return doBdByIDDepTree(resolution.Graph, resolution.Bead, op, stdout, stderr), true
 	case bdByIDUpdate:
 		return doBdByIDUpdate(resolution.Graph, op, door.bindingName(), stdout, stderr), true
 	case bdByIDClose:
@@ -1245,6 +1351,126 @@ func doBdByIDDepList(graph storebinding.GraphStore, op bdByIDOp, stdout, stderr 
 	}
 	return 0
 }
+
+// bdByIDTreeRow is one node of `bd dep tree --json`: the bead, plus where the
+// walk found it. bd emits a FLAT array in pre-order rather than a nested tree —
+// TreeNode has no children field — and the consumers read it that way, so the
+// shape is kept rather than improved on.
+//
+// TreeParentID is the edge the walk arrived by and is a different fact from the
+// bead's own `parent`, which the embedded record still carries under that name.
+type bdByIDTreeRow struct {
+	beads.Bead
+	Depth          int    `json:"depth"`
+	TreeParentID   string `json:"parent_id"`
+	EdgeFromParent string `json:"edge_from_parent,omitempty"`
+	// Truncated marks a node whose children were cut by --max-depth. bd's own
+	// walker declares the field and never sets it, which reports a silently
+	// shortened subtree as complete; this arm answers it, because a summary that
+	// reads a cut tree as the whole molecule is the wrong-answer class this
+	// surface exists to close.
+	Truncated bool `json:"truncated"`
+	// External marks an edge whose other end is not resident in this class
+	// store, exactly as dep list reports it. Such a node is named but not
+	// walked: crossing to the work store here would be a federated cross-store
+	// read, and dropping the edge would misreport a declared reference.
+	External bool `json:"external,omitempty"`
+}
+
+// doBdByIDDepTree answers the recursive dependency read from the owning class
+// store, walking the same contract dep list reads once.
+//
+// The walk reproduces bd's own semantics deliberately, because the two arms
+// answer the same command and a consumer cannot tell which one served it:
+// pre-order with the root at depth 0, one visit per bead however many paths
+// reach it, `relates-to` edges excluded as loose knowledge-graph links rather
+// than structure, and --max-depth cutting at depth >= max.
+func doBdByIDDepTree(graph storebinding.GraphStore, root beads.Bead, op bdByIDOp, stdout, stderr io.Writer) int {
+	visited := map[string]bool{}
+	rows := []bdByIDTreeRow{}
+
+	// Recursion depth is bounded by op.MaxDepth, which the parser floors at 1.
+	var walk func(bead beads.Bead, depth int, parentID, edge string) error
+	walk = func(bead beads.Bead, depth int, parentID, edge string) error {
+		row := bdByIDTreeRow{Bead: bead, Depth: depth, TreeParentID: parentID, EdgeFromParent: edge}
+		visited[bead.ID] = true
+		deps, err := graph.DepList(bead.ID, op.Direction)
+		if err != nil {
+			return fmt.Errorf("listing %s dependencies of %s: %w", op.Direction, bead.ID, err)
+		}
+		children := make([]beads.Dep, 0, len(deps))
+		for _, dep := range deps {
+			if dep.Type == bdByIDDepTreeLooseEdge {
+				continue
+			}
+			children = append(children, dep)
+		}
+		row.Truncated = len(children) > 0 && depth+1 >= op.MaxDepth
+		rows = append(rows, row)
+		if row.Truncated {
+			return nil
+		}
+		for _, dep := range children {
+			related := dep.DependsOnID
+			if op.Direction == bdByIDDepDirectionUp {
+				related = dep.IssueID
+			}
+			if visited[related] {
+				continue
+			}
+			child, err := graph.Get(related)
+			switch {
+			case err == nil:
+				if err := walk(child, depth+1, bead.ID, dep.Type); err != nil {
+					return err
+				}
+			case errors.Is(err, beads.ErrNotFound):
+				visited[related] = true
+				rows = append(rows, bdByIDTreeRow{
+					Bead:           beads.Bead{ID: related},
+					Depth:          depth + 1,
+					TreeParentID:   bead.ID,
+					EdgeFromParent: dep.Type,
+					External:       true,
+				})
+			default:
+				return fmt.Errorf("reading %s: %w", related, err)
+			}
+		}
+		return nil
+	}
+
+	if err := walk(root, 0, "", ""); err != nil {
+		fmt.Fprintf(stderr, "gc bd dep tree: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if op.JSON {
+		out, err := json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "gc bd dep tree: rendering %s: %v\n", op.ID, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintln(stdout, string(out)) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	fmt.Fprintf(stderr, "gc bd dep tree: served in process from the class binding\n") //nolint:errcheck // best-effort stderr
+	for _, row := range rows {
+		title := row.Title
+		switch {
+		case row.External:
+			title = "(not resident in this class binding)"
+		case row.Truncated:
+			title += " (children cut by --max-depth)"
+		}
+		fmt.Fprintf(stdout, "%s%s\t%s\t%s\n", strings.Repeat("  ", row.Depth), row.ID, row.Status, title) //nolint:errcheck // best-effort stdout
+	}
+	return 0
+}
+
+// bdByIDDepTreeLooseEdge is the one edge kind bd's tree walker skips: a
+// knowledge-graph link rather than structure, so following it would pull an
+// unrelated bead into a molecule's subtree.
+const bdByIDDepTreeLooseEdge = "relates-to"
 
 // printBdByIDBead renders a routed bead.
 //

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -250,6 +250,125 @@ func TestBdByIDServesClaimReleaseAndDepListFromTheClassBinding(t *testing.T) {
 	}
 }
 
+// bdByIDTreeWireRow is the tree row as a CONSUMER reads it, declared here rather
+// than borrowed from the production type on purpose: what the pack scripts and
+// pr_review.py parse is the JSON, and a test that decodes into the emitter's own
+// struct would follow a field rename straight past them.
+type bdByIDTreeWireRow struct {
+	ID       string `json:"id"`
+	Status   string `json:"status"`
+	Depth    int    `json:"depth"`
+	Parent   string `json:"parent_id"`
+	Edge     string `json:"edge_from_parent"`
+	External bool   `json:"external"`
+}
+
+func routedDepTree(t *testing.T, cityPath string, args ...string) []bdByIDTreeWireRow {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", append([]string{"dep", "tree"}, args...), &stdout, &stderr)
+	if !handled {
+		t.Fatalf("dep tree %v fell through to the bd subprocess", args)
+	}
+	if code != 0 {
+		t.Fatalf("dep tree %v = %d: %s", args, code, stderr.String())
+	}
+	var rows []bdByIDTreeWireRow
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("decoding the routed dep tree %q: %v", stdout.String(), err)
+	}
+	return rows
+}
+
+// TestBdByIDServesDepTreeFromTheClassBinding is the recursive read, and it is
+// here because a molecule's whole subtree is what every status summary asks for.
+//
+// `dep list` was already served and `dep tree` was not, so the one federated
+// read that resolves a relocated root — pr_review.py's city_dep_subtree, which
+// the pr-review label poller runs on every labeled PR — was refused on every
+// tick. The tree walk is composed from the SAME contract the single-level read
+// uses: DepList to a level, Get for each related bead. Nothing new is asked of
+// the store, which is why serving it needs no contract change.
+//
+// The fixture is the shape a molecule actually has, and every leg of it is a
+// case the walk gets wrong if it is written as a naive recursion:
+//
+//   - a two-level subtree, so pre-order depth and parent_id are observable;
+//   - a `relates-to` edge, which bd's own walker excludes from the tree (it is a
+//     loose knowledge-graph link, not structure) and which would otherwise drag
+//     an unrelated bead into a molecule summary;
+//   - an edge out of the class store, reported as external and NOT recursed,
+//     the same boundary `dep list` draws;
+//   - a cycle, which without a visited set is an infinite walk rather than a
+//     wrong answer.
+func TestBdByIDServesDepTreeFromTheClassBinding(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	root := mustCreateClassBead(t, classStore, beads.Bead{Title: "molecule root", Type: "task"})
+	step := mustCreateClassBead(t, classStore, beads.Bead{Title: "step", Type: "task"})
+	leaf := mustCreateClassBead(t, classStore, beads.Bead{Title: "leaf", Type: "task"})
+	aside := mustCreateClassBead(t, classStore, beads.Bead{Title: "loosely related", Type: "task"})
+	external := reservedClassID(t, "notresident")
+
+	for _, edge := range []struct{ from, to, kind string }{
+		{root.ID, step.ID, "blocks"},
+		{step.ID, leaf.ID, "parent-child"},
+		{root.ID, aside.ID, "relates-to"},
+		{leaf.ID, external, "blocks"},
+		{leaf.ID, root.ID, "blocks"}, // the cycle
+	} {
+		if err := classStore.DepAdd(edge.from, edge.to, edge.kind); err != nil {
+			t.Fatalf("adding %s -%s-> %s: %v", edge.from, edge.kind, edge.to, err)
+		}
+	}
+
+	rows := routedDepTree(t, cityPath, root.ID, "--json")
+	got := make([]string, 0, len(rows))
+	for _, row := range rows {
+		got = append(got, row.ID)
+	}
+	want := []string{root.ID, step.ID, leaf.ID, external}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("the routed dep tree walked %v, want the pre-order subtree %v (relates-to excluded, the cycle visited once)", got, want)
+	}
+	for i, want := range []bdByIDTreeWireRow{
+		{ID: root.ID, Depth: 0},
+		{ID: step.ID, Depth: 1, Parent: root.ID, Edge: "blocks"},
+		{ID: leaf.ID, Depth: 2, Parent: step.ID, Edge: "parent-child"},
+		{ID: external, Depth: 3, Parent: leaf.ID, Edge: "blocks", External: true},
+	} {
+		if rows[i].Depth != want.Depth || rows[i].Parent != want.Parent || rows[i].Edge != want.Edge {
+			t.Errorf("row %d = %+v, want depth=%d parent=%q edge=%q", i, rows[i], want.Depth, want.Parent, want.Edge)
+		}
+		if rows[i].External != want.External {
+			t.Errorf("row %d external = %t, want %t; an edge out of this class binding is a declared reference, not a resident bead", i, rows[i].External, want.External)
+		}
+	}
+	if rows[0].Status != root.Status {
+		t.Errorf("the root row carries status %q, want %q; the summary reads status off these rows", rows[0].Status, root.Status)
+	}
+
+	// --max-depth is bd's own safety limit and it CUTS: depth >= max stops, so
+	// the deepest row a `--max-depth 2` walk emits is depth 1.
+	shallow := routedDepTree(t, cityPath, root.ID, "--max-depth", "2", "--json")
+	if len(shallow) != 2 || shallow[1].ID != step.ID {
+		t.Errorf("--max-depth 2 walked %+v, want the root and its one child", shallow)
+	}
+
+	// --direction=up is the same walk over the reverse edges, and it must not
+	// silently answer the down question.
+	up := routedDepTree(t, cityPath, leaf.ID, "--direction=up", "--json")
+	upIDs := make([]string, 0, len(up))
+	for _, row := range up {
+		upIDs = append(upIDs, row.ID)
+	}
+	if strings.Join(upIDs, ",") != strings.Join([]string{leaf.ID, step.ID, root.ID}, ",") {
+		t.Errorf("--direction=up from the leaf walked %v, want the chain of beads that depend on it", upIDs)
+	}
+	if len(up) > 1 && up[1].Edge != "parent-child" {
+		t.Errorf("the reverse walk reported edge %q from the leaf's dependent, want the edge that relates them", up[1].Edge)
+	}
+}
+
 // TestBdByIDReservedPrefixAbsenceIsNotAFallThrough pins the rule that makes the
 // routing safe: a reserved-prefix id is minted by the class store and nowhere
 // else, so its absence there is genuine absence. Falling through would print a
@@ -692,14 +811,15 @@ func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *te
 		enter bool
 	}{
 		"work list":                  {[]string{"list", "--status", "open"}, false},
-		"work dep tree":              {[]string{"dep", "tree", "gc-123"}, false},
 		"quoted id in a value":       {[]string{"list", "--metadata-field", "workflow_id=" + reserved}, false},
 		"ambiguous mutation scan":    {[]string{"delete", "gc-123", "--bogus", "v"}, false},
 		"mutation with no id":        {[]string{"delete", "--from-file", "ids.txt"}, false},
 		"class mutation":             {[]string{"update", reserved, "--status", "closed"}, true},
 		"class close":                {[]string{"close", reserved}, true},
 		"class id in an id flag":     {[]string{"list", "--parent", reserved}, true},
+		"unserved dep tree spelling": {[]string{"dep", "tree", "--show-all-paths", "gc-123"}, false},
 		"served read on a work id":   {[]string{"show", "gc-123"}, true},
+		"served dep tree":            {[]string{"dep", "tree", "gc-123"}, true},
 		"served write on a work id":  {[]string{"update", "gc-123", "--status", "closed"}, true},
 		"served close on a work id":  {[]string{"close", "gc-123"}, true},
 		"served reopen on a work id": {[]string{"reopen", "gc-123"}, true},
@@ -728,6 +848,7 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		bdByIDClaim:   true,
 		bdByIDRelease: true,
 		bdByIDDepList: true,
+		bdByIDDepTree: true,
 		bdByIDUpdate:  true,
 		bdByIDClose:   true,
 		bdByIDReopen:  true,
@@ -739,6 +860,10 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		{"dep", "list", "gcg-1"},
 		{"dep", "list", "gcg-1", "-t", "blocks"},
 		{"dep", "list", "gcg-1", "--direction=up"},
+		{"dep", "tree", "gcg-1"},
+		{"dep", "tree", "gcg-1", "--json"},
+		{"dep", "tree", "gcg-1", "--reverse"},
+		{"dep", "tree", "gcg-1", "--direction=up", "--max-depth", "3"},
 		{"update", "gcg-1", "--status", "closed"},
 		{"update", "gcg-1", "--set-metadata", "gc.outcome=pass", "--status=closed"},
 		{"close", "gcg-1"},
@@ -762,9 +887,21 @@ func TestBdByIDSurfaceServesAClosedVerbSet(t *testing.T) {
 		{"show", "--id", "gcg-1"},
 		{"update", "gcg-1"},
 		{"update", "gcg-1", "--notes", "hello"},
-		{"dep", "tree", "gcg-1"},
 		{"dep", "list"},
 		{"dep", "list", "gcg-1", "--direction=sideways"},
+		// dep tree spellings this walk does not implement. Serving them by
+		// dropping the flag would answer a different question than the one asked:
+		// --show-all-paths asks for every path to a bead the walk visits once,
+		// --status and --format reshape the result, and --direction=both merges
+		// two walks. Each stays unserved so it meets the ownership refusal.
+		{"dep", "tree"},
+		{"dep", "tree", "gcg-1", "gcg-2"},
+		{"dep", "tree", "gcg-1", "--show-all-paths"},
+		{"dep", "tree", "gcg-1", "--status", "open"},
+		{"dep", "tree", "gcg-1", "--format", "dot"},
+		{"dep", "tree", "gcg-1", "--direction=both"},
+		{"dep", "tree", "gcg-1", "--direction=sideways"},
+		{"dep", "tree", "gcg-1", "--max-depth", "0"},
 		{"close"},
 		{"close", "gcg-1", "gcg-2"},
 		{"close", "gcg-1", "--reason", "done"},
@@ -807,7 +944,10 @@ func TestBdByIDRefusesUnservedSpellingsOfAClassOwnedBead(t *testing.T) {
 		{"show", bead.ID, "--include-dependents"},
 		{"show", bead.ID, "--as-of", "2026-01-01"},
 		{"show", "--id", bead.ID},
-		{"dep", "tree", bead.ID},
+		{"dep", "tree", bead.ID, "--show-all-paths"},
+		{"dep", "tree", bead.ID, "--status", "open"},
+		{"dep", "tree", bead.ID, "--format", "dot"},
+		{"dep", "tree", bead.ID, "--direction=both"},
 		{"delete", bead.ID},
 		{"update", bead.ID, "--notes", "a note"},
 		{"close", bead.ID, "--reason", "done"},
@@ -1397,13 +1537,20 @@ func TestBdMutationAmbiguousScanNeverEntersFunnel(t *testing.T) {
 }
 
 // TestBdSelectorVerbsNeverEnterFunnel is the other half of the widened gate,
-// and the line it draws: a MUTATION addressing ids enters, a read or a selector
-// never does.
+// and the line it draws: a MUTATION addressing ids enters, a selector or a read
+// this surface does not serve never does.
 //
 // A selector quotes ids rather than addressing them — `--metadata-field
 // workflow_id=<id>` selects rows by a field they carry — so there is no subject
 // whose residence could decide anything, and these are the hot per-tick
 // invocations that must keep paying nothing.
+//
+// A SERVED read is not in this list and never was: `show` addresses its subject
+// and has to probe residence to find a class-resident row, which is why
+// TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead expects
+// it to enter. `dep tree` moved into that company under ga-pxppl, so what stands
+// here for it is the spelling the in-process walk does NOT implement — still a
+// read, still free.
 func TestBdSelectorVerbsNeverEnterFunnel(t *testing.T) {
 	cityPath, classStore := foreignProviderCity(t)
 	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "an orphaned patrol root")
@@ -1413,7 +1560,7 @@ func TestBdSelectorVerbsNeverEnterFunnel(t *testing.T) {
 		{"list", "--label", relic.ID},
 		{"list", "--status", "open"},
 		{"search", relic.ID},
-		{"dep", "tree", relic.ID},
+		{"dep", "tree", relic.ID, "--show-all-paths"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			resetCLIStorageRoutes(t)

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -2258,17 +2258,25 @@ func assertFederationServesWholeLeg(t *testing.T, surface, legName string, legID
 // The bug is win-mc-forge's measurement row #2, and it survived the by-id lane
 // because it does not look like a by-id read. On a converged split city:
 //
-//	gc bd dep tree <gcg root>                          → exit 1, refused
+//	gc bd dep tree <gcg root>                          → diverted from the blind ledger
 //	gc bd list --metadata-field gc.root_bead_id=<root> → 0 rows, exit 0
 //
-// Two projections, the same molecule, the same command, opposite failure
-// semantics. `dep tree` names the bead in an id POSITION so the by-id door
-// decides ownership and refuses; --metadata-field is not id-valued, so that door
+// Two projections, the same molecule, the same command, opposite semantics.
+// `dep tree` names the bead in an id POSITION so the by-id door decides
+// ownership and takes it; --metadata-field is not id-valued, so that door
 // correctly declines (a QUOTED id decides nothing about ownership — see
 // cmd_bd_by_id.go) and the passthrough asks the one ledger that holds no gcg-
 // row, which answers `[]` and exits 0. The value named an id; the VERB is a
 // projection. Invariant 0 of ga-iaj7k: a projection that cannot see a class must
 // fail LOUDLY, and `[]` is forbidden.
+//
+// What the by-id door DOES with `dep tree` changed under ga-pxppl — it used to
+// refuse, and now it walks the molecule from the binding the class is served
+// from — and that does not weaken this invariant, it strengthens it. The claim
+// was never "both refuse". It is that neither answers `[]` from a ledger that
+// cannot hold the bead: on a split city all three argvs divert away from that
+// ledger, `dep tree` to an ANSWER and `list`/`ready` to a REFUSAL that names the
+// federated reader.
 //
 // The asymmetry is what makes it urgent rather than merely wrong. An operator
 // who has learned that this CLI refuses what it cannot see reads the empty array
@@ -2280,9 +2288,10 @@ func assertFederationServesWholeLeg(t *testing.T, surface, legName string, legID
 // of (config, argv): bdSQLRelocatedClassRefusal for `list` and
 // bdArgsNameClassOwnedBead for every other verb. So the coherence claim is
 // checkable exactly where it is decided, and the row runs on both topologies
-// without opening a binding. The end-to-end proof through the real command —
-// real doBd, real refusals, a bd stub that answers `[]` and exits 0 — is
-// TestGcBdProjectionsAgreeOnAClassTheyCannotSee.
+// without opening a binding. The end-to-end proofs through the real command —
+// real doBd, a bd stub that answers `[]` and exits 0 — are
+// TestGcBdProjectionsAgreeOnAClassTheyCannotSee for the refusing verbs and
+// TestGcBdDepTreeSplitsOnOwnershipNotOnServability for the answering one.
 //
 // # The single-store row is the byte-identity claim
 //
@@ -2352,19 +2361,20 @@ func conformanceProjectionCoherence(t *testing.T, e splitEnv) {
 	readyArgs := []string{"ready", "--metadata-field", selector, "--json"}
 	depTreeArgs := []string{"dep", "tree", root.ID}
 
-	// `dep tree` must stay UNSERVED in process, or the arm being compared here is
-	// not the refusal arm and the coherence claim is about something else.
-	if _, served := parseBdByIDOp(depTreeArgs); served {
-		t.Fatalf("`gc bd dep tree` is now served in process; I14 compares the REFUSAL arms, so re-point this row at the served answer")
+	// The by-id door must still be able to ANSWER this argv, or the row below is
+	// asserting that dep tree is diverted somewhere that cannot serve it — which
+	// is the refusal this invariant used to compare, not the answer it now does.
+	if _, served := parseBdByIDOp(depTreeArgs); !served {
+		t.Fatalf("`gc bd dep tree %s` is no longer served in process; I14 pins that it is diverted from the blind ledger TO AN ANSWER, so a diversion into a refusal has moved the dead end rather than removed it (ga-pxppl)", root.ID)
 	}
 
 	msg, listRefused := bdSQLRelocatedClassRefusal(e.cfg, listArgs)
 	_, readyRefused := bdSQLRelocatedClassRefusal(e.cfg, readyArgs)
-	_, depTreeRefused := bdArgsNameClassOwnedBead(depTreeArgs)
+	_, depTreeRouted := bdArgsNameClassOwnedBead(depTreeArgs)
 
-	if listRefused != depTreeRefused {
-		t.Fatalf("`gc bd list --metadata-field %s` refused = %v but `gc bd dep tree %s` refused = %v on the same molecule; two projections over the same data must not disagree about what happens when a class cannot be seen",
-			selector, listRefused, root.ID, depTreeRefused)
+	if listRefused != depTreeRouted {
+		t.Fatalf("`gc bd list --metadata-field %s` refused = %v but `gc bd dep tree %s` was diverted from the work ledger = %v on the same molecule; two projections over the same data must not disagree about whether that ledger can answer for the class",
+			selector, listRefused, root.ID, depTreeRouted)
 	}
 	if readyRefused != listRefused {
 		t.Fatalf("`gc bd ready --metadata-field %s` refused = %v but `gc bd list` with the same selector refused = %v; the two verbs take the same predicate and answer no-match the same way, so guarding one moves the silent empty rather than removing it",


### PR DESCRIPTION
On a split-store city the graph class is bound to its own store, and any argv naming a class-owned bead is diverted away from the work store before it reaches the `bd` subprocess. `show`, `update`, `close`, `reopen`, `release-if-current` and `dep list` were already answered in process from the class binding. `dep tree` was diverted into a *refusal* instead — making it the one federated read that could not resolve a graph bead post-split-store.

That is load-bearing downstream: `pr_review.py::city_dep_subtree` uses `gc bd dep tree` precisely *because* it is the read that resolves graph beads on a split city. With it refusing, `pr-review-label-poll` failed on every 5-minute tick, stalling review on every PR carrying `status/needs-review-auto`.

## What this does

Serves `dep tree` for a class-owned id by recursing the already-served `DepList` from the class binding. The `GraphStore` contract is unchanged — `DepList` + `Get` are all the walk needs.

`bd`s own semantics are replicated, because a consumer cannot tell which arm answered:

- flat pre-order rows, root at depth 0
- one global `visited` set
- `depth >= maxDepth` stops; default `maxDepth` 50
- `relates-to` edges excluded
- `--json`, `--reverse`, `--direction`, `--max-depth`/`-d` all served

One deliberate divergence: `Truncated` is answered **truthfully**. `bd` declares the field and never sets it.

## What this deliberately does NOT do

Spellings the walk does not implement — `--show-all-paths`, `--status`, `--format`, `--direction=both` — stay unserved and meet the ownership refusal rather than being served with the flag dropped. Serving them by dropping the flag would answer a different question than the one asked: `--show-all-paths` asks for every path to a bead the walk visits once, `--status`/`--format` reshape the result, and `--direction=both` merges two walks.

`dep tree` is also **not** forwarded to the work store. That store does not hold the bead; the refusal protects against a confident wrong answer.

## Test pins

Six existing pins move, each because the behavior genuinely changed rather than to accommodate the diff — every one carries a rewritten comment explaining why the expectation moved. Notably `conformanceProjectionCoherence` (I14) had already anticipated this exact change and carried an instruction to re-point when it landed: the claim it pins was never "both refuse", it is that neither answers `[]` from a ledger that cannot hold the bead — `dep tree` now diverts to an ANSWER while `list`/`ready` divert to a REFUSAL.

New coverage: `TestBdByIDServesDepTreeFromTheClassBinding`, mutation-verified three ways (disable recursion / stop excluding `relates-to` / drop the cycle guard — all three kill it).

## Verification

- `gofmt` clean, `go vet ./cmd/gc/` clean
- targeted set: 28 pass, 0 fail, 0 skip
- full `make test-fast-parallel` green (all 6 `cmd/gc` shards + core) via the pre-push hook

Fixes ga-pxppl

🤖 Generated with [Claude Code](https://claude.com/claude-code)