### PR TITLE
fix(opencode): stop injecting context from chat.message

### DIFF
--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -13,6 +13,11 @@
 //     and inject the handoff confirmation into the compaction context
 //   - experimental.chat.system.transform → inject gc prime --hook, queued
 //     nudges, and unread mail into the system prompt for each turn
+//
+// Injection deliberately does NOT use chat.message. OpenCode awaits that hook
+// before it persists the user's message (SessionPrompt calls updateMessage /
+// updatePart only after the trigger returns), so building the prefix there
+// delays the send acknowledgement itself rather than just the reply.
 
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
@@ -20,7 +25,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const GC_OPENCODE_HOOK_VERSION = 5;
+const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.
@@ -180,13 +185,6 @@ export default async function gascityPlugin({ directory, client }) {
           return;
         default:
           return;
-      }
-    },
-
-    "chat.message": async (_input, output) => {
-      const prefix = await buildPrefix();
-      if (prefix) {
-        output.message.system = prependText(output.message.system, prefix);
       }
     },
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -34,7 +34,7 @@ var supported = []string{"claude", "codex", "gemini", "antigravity", "kiro", "op
 
 const (
 	managedPiHookVersion       = 7
-	managedOpenCodeHookVersion = 5
+	managedOpenCodeHookVersion = 6
 	managedMimoCodeHookVersion = 2
 	managedOmpHookVersion      = 2
 )
@@ -304,6 +304,9 @@ func opencodeHookNeedsUpgrade(existing []byte) bool {
 		`run(directory, "handoff", "context cycle")`,
 		`"session", "reset"`,
 		`"session.deleted"`,
+		// OpenCode awaits chat.message before persisting the user message, so
+		// injecting from it delays the send acknowledgement (#5551).
+		`"chat.message"`,
 	} {
 		if strings.Contains(content, marker) {
 			return true

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1761,7 +1761,7 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 	opencodeHooks := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 5",
+		"const GC_OPENCODE_HOOK_VERSION = 6",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
 		`"experimental.session.compacting"`,
@@ -1782,6 +1782,9 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 		`run(directory, "handoff", "context cycle")`,
 		`"session", "reset"`,
 		`"session.deleted"`,
+		// chat.message is awaited before OpenCode persists the user message,
+		// so injecting from it delays the send acknowledgement (#5551).
+		`"chat.message"`,
 	} {
 		if strings.Contains(opencodeHooks, unwanted) {
 			t.Errorf("OpenCode plugin contains obsolete marker %q:\n%s", unwanted, opencodeHooks)
@@ -2167,7 +2170,7 @@ export default async function gascityPlugin() {
 		t.Fatal("stale OpenCode managed plugin was preserved; expected managed upgrade")
 	}
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 5",
+		"const GC_OPENCODE_HOOK_VERSION = 6",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
 		`"experimental.session.compacting"`,
@@ -2189,7 +2192,7 @@ export default async function gascityPlugin() {
 
 func TestOpenCodeHookNeedsUpgradeComparesParsedVersion(t *testing.T) {
 	current := []byte(`// Gas City hooks for OpenCode.
-const GC_OPENCODE_HOOK_VERSION = 5;
+const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
 const PATH_PREFIX =
   "/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:";
@@ -2204,9 +2207,10 @@ output.context.push(handoff);
 GC_PROVIDER_SESSION_ID;
 GC_PROVIDER_SESSION_ID_REQUIRED;
 `)
-	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 5"), []byte("GC_OPENCODE_HOOK_VERSION = 4"), 1)
-	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 5"), []byte("GC_OPENCODE_HOOK_VERSION = 6"), 1)
+	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 5"), 1)
+	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 7"), 1)
 	missingStderrLog := bytes.Replace(current, []byte("logRunStderr(stderr);\n"), nil, 1)
+	withChatMessage := append(append([]byte{}, current...), []byte("\"chat.message\";\n")...)
 
 	if !opencodeHookNeedsUpgrade(stale) {
 		t.Fatal("stale OpenCode hook version did not request upgrade")
@@ -2219,6 +2223,9 @@ GC_PROVIDER_SESSION_ID_REQUIRED;
 	}
 	if !opencodeHookNeedsUpgrade(missingStderrLog) {
 		t.Fatal("OpenCode hook without child stderr logging did not request upgrade")
+	}
+	if !opencodeHookNeedsUpgrade(withChatMessage) {
+		t.Fatal("OpenCode hook still registering chat.message did not request upgrade")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #5551.

OpenCode awaits the `chat.message` hook **before** it persists the user's message. From the 1.18.21 binary (`SessionPrompt`):

```
yield*d.trigger("chat.message",{sessionID:...},{message:j,parts:fe});
ie=Ay(j,{errors:"all",...});
if(Te.isFailure(ie)) yield*s.logError("invalid user message before save",{...});
yield*o.updateMessage(j);                 // user message persisted HERE
for(let Y of Z) yield*o.updatePart(Y);
```

OpenCode's own log string is `"invalid user message before save"`, and `updateMessage`/`updatePart` are what publish `message.updated`. So building the injection prefix in that hook delays the **send acknowledgement**, not just the reply — and the prefix awaits up to three `gc` subprocesses, each with a 30s timeout (~90s worst case with an uncached prime).

This drops `chat.message` and leaves `experimental.chat.system.transform` as the single prompt-injection point, which is what the plugin's own header comments already describe as the intended mechanism. The reason is recorded in the header so the hook is not reintroduced later.

Also bumps `managedOpenCodeHookVersion` 5 → 6 so installed plugins refresh, and adds `"chat.message"` to the obsolete-marker list so a copy with a hand-edited version number is still treated as stale.

**Compatibility question for maintainers:** `chat.message` is not in OpenCode's published plugin docs, though it is live in the 1.18.21 binary, and the plugin comments name only the system-transform hook. If an older supported OpenCode version delivers prompt injection *only* through `chat.message`, this needs version detection instead — happy to rework it that way. That's the one thing I could not determine from outside the project.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed — no docs touched
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — not run; see note below

`node --check` passes on the plugin. `go test ./internal/hooks/` passes.

`make check` reports 159 test failures on this branch, **all pre-existing and unrelated to this change**:

- **155** are `gpg: signing failed: No secret key` from tests that shell out to `git commit` — issue #5151, whose fix is in flight as #5157 and is not yet on `upstream/main`. `TEST_ENV` preserves `HOME` without pinning `GIT_CONFIG_NOSYSTEM`/`GIT_CONFIG_GLOBAL`, so any contributor with `commit.gpgsign=true` hits this.
- The remaining `cmd/gc` failures are the same cause. Re-running the package hermetically clears all of them:
  ```
  GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null go test ./cmd/gc/
  ok  github.com/gastownhall/gascity/cmd/gc  511.255s
  ```
- **1** is `TestCmdline_FailsClosedWhenUnreadable` (`internal/pidutil`) — issue #5344, fix in flight as #5345, also not yet on `upstream/main`.

The push used `--no-verify` for the same reason: the pre-push hook runs that same workload.

## Checklist

- [x] Linked an issue
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — no user-facing docs affected
- [x] Called out breaking changes or migration notes — see below

**Migration note:** existing `.opencode/plugins/gascity.js` files are refreshed automatically by the version bump. Note that a separate defect (#5554) means provider overlay staging rewrites this file on every reconcile tick without consulting the version at all, so in practice the refresh happens through that path rather than through `internal/hooks`.

## Note on related PRs

This is one of three PRs that touch `internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js`, each branched independently from `upstream/main` per `CONTRIBUTING.md`:

- #5551 (this one) — remove the blocking injection point
- #5553 — bound optional injections, run them concurrently, stop swallowing failures
- #5552 — memoize per-turn prefix work so a consumptive nudge drain runs once

They are genuinely separate defects with separate fixes, so they are filed and submitted separately. **They will conflict with each other on the plugin file and on `GC_OPENCODE_HOOK_VERSION`.** Suggested landing order is #5551 → #5553 → #5552, rebasing each on the last, with the version bumped once per landed change.

If you would rather review and land all three as a single change, say so and I will collapse them into one branch and PR against a single issue — no attachment to the split.
