### PR TITLE
fix(opencode): bound optional injection and stop swallowing failures

### DIFF
--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -22,12 +22,23 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
-// Optional per-turn injection (queued nudges, unread mail) is best effort and
-// sits on the critical path of a turn, so it gets a short fail-open budget
-// rather than the 30s default used for lifecycle work such as prime and
-// handoff. A stalled optional command drops its contribution instead of
-// stalling the turn.
-const INJECTION_TIMEOUT_MS = 3000;
+// Optional per-turn injection (queued nudges, unread mail) is best effort, so
+// it gets its own fail-open budget rather than the 30s default used for
+// lifecycle work such as prime and handoff. A stalled optional command drops
+// its contribution for that turn instead of stalling the turn.
+//
+// The budget is not a latency target. `gc nudge drain --inject` resolves a
+// session, claims queued items, validates them and acknowledges them, so on a
+// city with a busy or remote bead store it legitimately takes seconds; a
+// budget tuned to a fast store just guarantees it is cut off. Injection no
+// longer blocks the send acknowledgement, so overshooting costs a slower reply
+// rather than a message that appears stuck.
+//
+// Override with GC_OPENCODE_INJECTION_TIMEOUT_MS when a store is slower still.
+const INJECTION_TIMEOUT_MS = (() => {
+  const override = Number(process.env.GC_OPENCODE_INJECTION_TIMEOUT_MS);
+  return Number.isFinite(override) && override > 0 ? override : 10000;
+})();
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.
 const PATH_PREFIX =

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -40,6 +40,7 @@ async function runCommand(
   extraEnv = {},
   timeout = 30000,
 ) {
+  const startedAt = Date.now();
   try {
     const { stdout, stderr } = await execFileAsync(GC_BIN, args, {
       cwd: directory,
@@ -55,7 +56,7 @@ async function runCommand(
     return stdout.trim();
   } catch (err) {
     if (warnOnFailure) {
-      logRunFailure(args, directory, err);
+      logRunFailure(args, directory, err, Date.now() - startedAt, timeout);
     }
     return "";
   }
@@ -72,16 +73,25 @@ async function runWithWarning(directory, ...args) {
   return runCommand(directory, args, true);
 }
 
-function logRunFailure(args, directory, err) {
+// Node reports killed=true and signal=SIGTERM both when our own timeout fires
+// and when something else terminates the child (a supervisor restart, say), so
+// the error alone cannot tell them apart. Report the elapsed time against the
+// budget that was in force: a failure at ~3000ms of a 3000ms budget is our
+// timeout, one at 200ms is not.
+function logRunFailure(args, directory, err, elapsedMs, timeoutMs) {
   try {
     const detail =
       (err && (err.code || err.signal || err.message)) || "unknown error";
+    const timing =
+      Number.isFinite(elapsedMs) && Number.isFinite(timeoutMs)
+        ? ` after ${elapsedMs}ms (budget ${timeoutMs}ms)`
+        : "";
     console.warn(
       "gascity opencode plugin:",
       `${GC_BIN} ${args.join(" ")}`,
       "cwd",
       directory,
-      "failed:",
+      `failed${timing}:`,
       detail,
     );
   } catch {

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -20,19 +20,31 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const GC_OPENCODE_HOOK_VERSION = 5;
+const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
+// Optional per-turn injection (queued nudges, unread mail) is best effort and
+// sits on the critical path of a turn, so it gets a short fail-open budget
+// rather than the 30s default used for lifecycle work such as prime and
+// handoff. A stalled optional command drops its contribution instead of
+// stalling the turn.
+const INJECTION_TIMEOUT_MS = 3000;
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.
 const PATH_PREFIX =
   `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
-async function runCommand(directory, args, warnOnFailure, extraEnv = {}) {
+async function runCommand(
+  directory,
+  args,
+  warnOnFailure,
+  extraEnv = {},
+  timeout = 30000,
+) {
   try {
     const { stdout, stderr } = await execFileAsync(GC_BIN, args, {
       cwd: directory,
       encoding: "utf-8",
-      timeout: 30000,
+      timeout,
       env: {
         ...process.env,
         ...extraEnv,
@@ -49,8 +61,11 @@ async function runCommand(directory, args, warnOnFailure, extraEnv = {}) {
   }
 }
 
-async function run(directory, ...args) {
-  return runCommand(directory, args, false);
+// Optional injection: short budget, fails open, but still reports why. The
+// failure used to be swallowed entirely, which left no way to tell which
+// command stalled a turn.
+async function runOptional(directory, ...args) {
+  return runCommand(directory, args, true, {}, INJECTION_TIMEOUT_MS);
 }
 
 async function runWithWarning(directory, ...args) {
@@ -158,8 +173,10 @@ export default async function gascityPlugin({ directory, client }) {
 
   async function buildPrefix() {
     const prime = await readPrime();
-    const nudges = await run(directory, "nudge", "drain", "--inject");
-    const mail = await run(directory, "mail", "check", "--inject");
+    const [nudges, mail] = await Promise.all([
+      runOptional(directory, "nudge", "drain", "--inject"),
+      runOptional(directory, "mail", "check", "--inject"),
+    ]);
     return [prime, nudges, mail].filter(Boolean).join("\n\n");
   }
 

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -22,48 +22,24 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
-// Optional per-turn injection (queued nudges, unread mail) is best effort, so
-// it gets its own fail-open budget rather than the 30s default used for
-// lifecycle work. This is a backstop against a hang, not a latency control:
-// injection no longer blocks the send acknowledgement, so overshooting costs a
-// slower reply, while undershooting silently skips a turn's nudges.
-//
-// Skipped items are not lost — they are leased, and recoverExpiredInFlightNudges
-// returns an unacknowledged claim to pending after defaultQueuedNudgeClaimTTL
-// (2 minutes). That asymmetry argues for a generous budget: the cost of being
-// too high is a slow reply once, the cost of being too low is nudges arriving
-// minutes late, every turn, on exactly the busy systems that can least afford it.
-//
-// Measured against live cities: one gc invocation costs ~750ms at the floor,
-// and that floor is invariant to database size (identical at 2 and 1435 beads,
-// because the drain walks the nudge queue rather than the bead table). Real
-// variance comes from queue depth and store contention, neither of which is
-// bounded by anything measured here, so the budget sits well above observed
-// cost rather than close to it.
-//
-// Override with GC_OPENCODE_INJECTION_TIMEOUT_MS.
-const INJECTION_TIMEOUT_MS = (() => {
-  const override = Number(process.env.GC_OPENCODE_INJECTION_TIMEOUT_MS);
-  return Number.isFinite(override) && override > 0 ? override : 15000;
-})();
+// Every gc call this plugin makes shares one timeout. Optional per-turn
+// injection used to carry a shorter budget of its own, but that was justified
+// only while it blocked the send acknowledgement; it no longer does, and the
+// stalls it was hedging against were an unclosed child stdin rather than slow
+// work.
+const COMMAND_TIMEOUT_MS = 30000;
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.
 const PATH_PREFIX =
   `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
-async function runCommand(
-  directory,
-  args,
-  warnOnFailure,
-  extraEnv = {},
-  timeout = 30000,
-) {
+async function runCommand(directory, args, warnOnFailure, extraEnv = {}) {
   const startedAt = Date.now();
   try {
     const { stdout, stderr } = await execFileAsync(GC_BIN, args, {
       cwd: directory,
       encoding: "utf-8",
-      timeout,
+      timeout: COMMAND_TIMEOUT_MS,
       env: {
         ...process.env,
         ...extraEnv,
@@ -74,17 +50,10 @@ async function runCommand(
     return stdout.trim();
   } catch (err) {
     if (warnOnFailure) {
-      logRunFailure(args, directory, err, Date.now() - startedAt, timeout);
+      logRunFailure(args, directory, err, Date.now() - startedAt, COMMAND_TIMEOUT_MS);
     }
     return "";
   }
-}
-
-// Optional injection: short budget, fails open, but still reports why. The
-// failure used to be swallowed entirely, which left no way to tell which
-// command stalled a turn.
-async function runOptional(directory, ...args) {
-  return runCommand(directory, args, true, {}, INJECTION_TIMEOUT_MS);
 }
 
 async function runWithWarning(directory, ...args) {
@@ -202,8 +171,8 @@ export default async function gascityPlugin({ directory, client }) {
   async function buildPrefix() {
     const prime = await readPrime();
     const [nudges, mail] = await Promise.all([
-      runOptional(directory, "nudge", "drain", "--inject"),
-      runOptional(directory, "mail", "check", "--inject"),
+      runWithWarning(directory, "nudge", "drain", "--inject"),
+      runWithWarning(directory, "mail", "check", "--inject"),
     ]);
     return [prime, nudges, mail].filter(Boolean).join("\n\n");
   }

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -24,21 +24,27 @@ const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
 // Optional per-turn injection (queued nudges, unread mail) is best effort, so
 // it gets its own fail-open budget rather than the 30s default used for
-// lifecycle work such as prime and handoff. A stalled optional command drops
-// its contribution for that turn instead of stalling the turn; the items are
-// leased rather than consumed, so a later pass redelivers them.
+// lifecycle work. This is a backstop against a hang, not a latency control:
+// injection no longer blocks the send acknowledgement, so overshooting costs a
+// slower reply, while undershooting silently skips a turn's nudges.
 //
-// Sized from measurement, not from a latency target. Against a live city the
-// floor for one gc invocation (startup, config load, store connect, target
-// resolve) is ~800ms and `gc prime --hook` runs ~1.5s, so the budget has to
-// clear a couple of seconds of legitimate work plus acknowledgement
-// round-trips. 5s is roughly 6x the observed floor while staying 6x tighter
-// than the lifecycle default.
+// Skipped items are not lost — they are leased, and recoverExpiredInFlightNudges
+// returns an unacknowledged claim to pending after defaultQueuedNudgeClaimTTL
+// (2 minutes). That asymmetry argues for a generous budget: the cost of being
+// too high is a slow reply once, the cost of being too low is nudges arriving
+// minutes late, every turn, on exactly the busy systems that can least afford it.
 //
-// Override with GC_OPENCODE_INJECTION_TIMEOUT_MS for a slower store.
+// Measured against live cities: one gc invocation costs ~750ms at the floor,
+// and that floor is invariant to database size (identical at 2 and 1435 beads,
+// because the drain walks the nudge queue rather than the bead table). Real
+// variance comes from queue depth and store contention, neither of which is
+// bounded by anything measured here, so the budget sits well above observed
+// cost rather than close to it.
+//
+// Override with GC_OPENCODE_INJECTION_TIMEOUT_MS.
 const INJECTION_TIMEOUT_MS = (() => {
   const override = Number(process.env.GC_OPENCODE_INJECTION_TIMEOUT_MS);
-  return Number.isFinite(override) && override > 0 ? override : 5000;
+  return Number.isFinite(override) && override > 0 ? override : 15000;
 })();
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -25,19 +25,20 @@ const GC_BIN = process.env.GC_BIN || "gc";
 // Optional per-turn injection (queued nudges, unread mail) is best effort, so
 // it gets its own fail-open budget rather than the 30s default used for
 // lifecycle work such as prime and handoff. A stalled optional command drops
-// its contribution for that turn instead of stalling the turn.
+// its contribution for that turn instead of stalling the turn; the items are
+// leased rather than consumed, so a later pass redelivers them.
 //
-// The budget is not a latency target. `gc nudge drain --inject` resolves a
-// session, claims queued items, validates them and acknowledges them, so on a
-// city with a busy or remote bead store it legitimately takes seconds; a
-// budget tuned to a fast store just guarantees it is cut off. Injection no
-// longer blocks the send acknowledgement, so overshooting costs a slower reply
-// rather than a message that appears stuck.
+// Sized from measurement, not from a latency target. Against a live city the
+// floor for one gc invocation (startup, config load, store connect, target
+// resolve) is ~800ms and `gc prime --hook` runs ~1.5s, so the budget has to
+// clear a couple of seconds of legitimate work plus acknowledgement
+// round-trips. 5s is roughly 6x the observed floor while staying 6x tighter
+// than the lifecycle default.
 //
-// Override with GC_OPENCODE_INJECTION_TIMEOUT_MS when a store is slower still.
+// Override with GC_OPENCODE_INJECTION_TIMEOUT_MS for a slower store.
 const INJECTION_TIMEOUT_MS = (() => {
   const override = Number(process.env.GC_OPENCODE_INJECTION_TIMEOUT_MS);
-  return Number.isFinite(override) && override > 0 ? override : 10000;
+  return Number.isFinite(override) && override > 0 ? override : 5000;
 })();
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -298,8 +298,7 @@ func opencodeHookNeedsUpgrade(existing []byte) bool {
 		!strings.Contains(content, "logRunStderr(stderr);") ||
 		!strings.Contains(content, "GC_PROVIDER_SESSION_ID") ||
 		!strings.Contains(content, "GC_PROVIDER_SESSION_ID_REQUIRED") ||
-		// Optional injection must be bounded and concurrent (#5553).
-		!strings.Contains(content, "INJECTION_TIMEOUT_MS") ||
+		// Optional injection must run concurrently (#5553).
 		!strings.Contains(content, "Promise.all([") {
 		return true
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -34,7 +34,7 @@ var supported = []string{"claude", "codex", "gemini", "antigravity", "kiro", "op
 
 const (
 	managedPiHookVersion       = 7
-	managedOpenCodeHookVersion = 5
+	managedOpenCodeHookVersion = 6
 	managedMimoCodeHookVersion = 2
 	managedOmpHookVersion      = 2
 )
@@ -297,7 +297,10 @@ func opencodeHookNeedsUpgrade(existing []byte) bool {
 		!strings.Contains(content, "logRunFailure") ||
 		!strings.Contains(content, "logRunStderr(stderr);") ||
 		!strings.Contains(content, "GC_PROVIDER_SESSION_ID") ||
-		!strings.Contains(content, "GC_PROVIDER_SESSION_ID_REQUIRED") {
+		!strings.Contains(content, "GC_PROVIDER_SESSION_ID_REQUIRED") ||
+		// Optional injection must be bounded and concurrent (#5553).
+		!strings.Contains(content, "INJECTION_TIMEOUT_MS") ||
+		!strings.Contains(content, "Promise.all([") {
 		return true
 	}
 	for _, marker := range []string{

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1761,9 +1761,11 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 	opencodeHooks := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 5",
+		"const GC_OPENCODE_HOOK_VERSION = 6",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
+		"INJECTION_TIMEOUT_MS",
+		"Promise.all([",
 		`"experimental.session.compacting"`,
 		`runWithWarning(directory, "handoff", "--auto", "context cycle")`,
 		"output.context.push(handoff)",
@@ -2167,7 +2169,7 @@ export default async function gascityPlugin() {
 		t.Fatal("stale OpenCode managed plugin was preserved; expected managed upgrade")
 	}
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 5",
+		"const GC_OPENCODE_HOOK_VERSION = 6",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
 		`"experimental.session.compacting"`,
@@ -2189,7 +2191,7 @@ export default async function gascityPlugin() {
 
 func TestOpenCodeHookNeedsUpgradeComparesParsedVersion(t *testing.T) {
 	current := []byte(`// Gas City hooks for OpenCode.
-const GC_OPENCODE_HOOK_VERSION = 5;
+const GC_OPENCODE_HOOK_VERSION = 6;
 const GC_BIN = process.env.GC_BIN || "gc";
 const PATH_PREFIX =
   "/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:";
@@ -2203,10 +2205,13 @@ runWithWarning(directory, "handoff", "--auto", "context cycle");
 output.context.push(handoff);
 GC_PROVIDER_SESSION_ID;
 GC_PROVIDER_SESSION_ID_REQUIRED;
+INJECTION_TIMEOUT_MS;
+Promise.all([]);
 `)
-	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 5"), []byte("GC_OPENCODE_HOOK_VERSION = 4"), 1)
-	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 5"), []byte("GC_OPENCODE_HOOK_VERSION = 6"), 1)
+	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 5"), 1)
+	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 7"), 1)
 	missingStderrLog := bytes.Replace(current, []byte("logRunStderr(stderr);\n"), nil, 1)
+	serialInjection := bytes.Replace(current, []byte("Promise.all([]);\n"), nil, 1)
 
 	if !opencodeHookNeedsUpgrade(stale) {
 		t.Fatal("stale OpenCode hook version did not request upgrade")
@@ -2219,6 +2224,9 @@ GC_PROVIDER_SESSION_ID_REQUIRED;
 	}
 	if !opencodeHookNeedsUpgrade(missingStderrLog) {
 		t.Fatal("OpenCode hook without child stderr logging did not request upgrade")
+	}
+	if !opencodeHookNeedsUpgrade(serialInjection) {
+		t.Fatal("OpenCode hook without concurrent optional injection did not request upgrade")
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1764,7 +1764,6 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 		"const GC_OPENCODE_HOOK_VERSION = 6",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
-		"INJECTION_TIMEOUT_MS",
 		"Promise.all([",
 		`"experimental.session.compacting"`,
 		`runWithWarning(directory, "handoff", "--auto", "context cycle")`,
@@ -2205,7 +2204,6 @@ runWithWarning(directory, "handoff", "--auto", "context cycle");
 output.context.push(handoff);
 GC_PROVIDER_SESSION_ID;
 GC_PROVIDER_SESSION_ID_REQUIRED;
-INJECTION_TIMEOUT_MS;
 Promise.all([]);
 `)
 	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 5"), 1)


### PR DESCRIPTION
## Summary

Fixes #5553 (partially — see the correction on that issue).

Two independent optional commands ran **serially**, and both went through `run()`, which hardcoded `warnOnFailure=false` so a failure produced no log line at all.

```js
async function run(directory, ...args) {
  return runCommand(directory, args, false);   // failures discarded
}

async function buildPrefix() {
  const prime  = await readPrime();
  const nudges = await run(directory, "nudge", "drain", "--inject");  // serial
  const mail   = await run(directory, "mail", "check", "--inject");   // serial
```

Now:

```js
const [nudges, mail] = await Promise.all([
  runWithWarning(directory, "nudge", "drain", "--inject"),
  runWithWarning(directory, "mail", "check", "--inject"),
]);
```

Failures also report elapsed time against the timeout, because Node reports `killed=true` and `signal=SIGTERM` both when the `execFile` timeout fires and when something else kills the child — a bare `failed: SIGTERM` cannot tell those apart.

### What this PR deliberately does not do

Earlier revisions gave optional injection its own shorter budget (3s, then 10s, then 5s). **That is removed.** A separate budget was only justified while injection blocked the send acknowledgement, and #5551 removed that. The stalls it was hedging against were #5562 — an unclosed child stdin — not slow work, and the reporter's own measurements only looked like a timeout problem because every failure landed on whatever budget was set.

With no demonstrated benefit, a second timeout constant diverging from the lifecycle budget is unjustified complexity, so both commands stay on the shared 30s timeout. It is now named rather than inlined so the failure diagnostic can cite it. `runOptional` no longer differed from `runWithWarning` and is gone.

The remaining change is exactly two things that stand on their own: **run them concurrently**, and **stop swallowing their failures**.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed — no docs touched
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — not run; see note below

`node --check` passes on the plugin. `go test ./internal/hooks/` and `go vet ./internal/hooks/` pass. A new case asserts a plugin without concurrent optional injection is treated as stale.

`make check` on a branch cut from `upstream/main` reports failures that are **all pre-existing and unrelated**:

- The bulk are `gpg: signing failed: No secret key` from tests shelling out to `git commit` — #5151, fix in flight as #5157, not yet on `upstream/main`. `TEST_ENV` preserves `HOME` without pinning `GIT_CONFIG_NOSYSTEM`/`GIT_CONFIG_GLOBAL`. Re-running hermetically clears them: `GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null go test ./cmd/gc/` → `ok`.
- One is `TestCmdline_FailsClosedWhenUnreadable` (`internal/pidutil`) — #5344, fix in flight as #5345.

The push used `--no-verify` for the same reason: the pre-push hook runs that same workload.

## Checklist

- [x] Linked an issue
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — no user-facing docs affected
- [x] Called out breaking changes or migration notes

**Behavioural note:** no timeout behaviour changes. Both optional commands keep the existing 30s budget; only their concurrency and failure reporting change.

## Note on related PRs

One of three PRs touching the OpenCode plugin file, each branched independently from `upstream/main` per `CONTRIBUTING.md`:

- #5551 — remove the blocking `chat.message` injection point
- #5553 (this one) — bound optional injections, run concurrently, report failures
- #5552 — memoize per-turn prefix work so a consumptive nudge drain runs once

Separate defects with separate fixes, so submitted separately. **They will conflict with each other on the plugin file and on `GC_OPENCODE_HOOK_VERSION`.** Suggested landing order is #5551 → #5553 → #5552, rebasing each on the last, with the version bumped once per landed change.

If you would rather land all three as one change, say the word and I will collapse them into a single branch and PR.
