### PR TITLE
fix(nudge): truthful mail-reminder lifecycle — retire on source-of-truth state, judge per-sender, report real outcomes

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1330,8 +1330,13 @@ func sendMailNotifyWithWorker(target nudgeTarget, store beads.Store, sp runtime.
 			}
 		}
 	}
+	// Stamp the sender on the queued item so the mail-state supersession gate
+	// can retire this reminder the moment the recipient has no unread mail
+	// from that sender — exact truth instead of the inbox-empty proxy.
+	mailOpts := queuedNudgeOptionsFromTarget(target)
+	mailOpts.Reference = &nudgeReference{Kind: "mail-sender", ID: sender}
 	if !obs.Running && canRequestManagedNudgeWake(target, store) {
-		item := newQueuedNudgeWithOptions(target.agentKey(), msg, "mail", now, queuedNudgeOptionsFromTarget(target))
+		item := newQueuedNudgeWithOptions(target.agentKey(), msg, "mail", now, mailOpts)
 		if err := enqueueManagedNudgeThenWake(target, store, item); err != nil {
 			return err
 		}
@@ -1342,7 +1347,7 @@ func sendMailNotifyWithWorker(target nudgeTarget, store beads.Store, sp runtime.
 		}
 		return nil
 	}
-	if err := enqueueQueuedNudge(target.cityPath, newQueuedNudgeWithOptions(target.agentKey(), msg, "mail", now, queuedNudgeOptionsFromTarget(target))); err != nil {
+	if err := enqueueQueuedNudge(target.cityPath, newQueuedNudgeWithOptions(target.agentKey(), msg, "mail", now, mailOpts)); err != nil {
 		return err
 	}
 	if obs.Running {
@@ -1826,29 +1831,52 @@ func blockedQueuedNudgeReason(sessFront *session.Store, item queuedNudge) (strin
 	}
 }
 
-// mailReminderUnreadCount reports the recipient's current unread mail count
-// for the mail-state supersession gate below. It is a package var so tests can
-// pin the mailbox state without a live mail store. The production reader mirrors
-// `gc mail check <agent>`: the same message-store class resolution and the same
-// recipient identity the notify path enqueued the reminder under.
-var mailReminderUnreadCount = func(target nudgeTarget, store beads.Store) (int, error) {
+// mailReminderUnreadSenders reports the recipient's current unread mail keyed
+// by sender, for the mail-state supersession gate below. It is a package var so
+// tests can pin the mailbox state without a live mail store. The production
+// reader mirrors `gc mail check <agent>`: the same message-store class
+// resolution and the same recipient identity the notify path enqueued the
+// reminder under.
+var mailReminderUnreadSenders = func(target nudgeTarget, store beads.Store) (map[string]int, error) {
 	msgStore := resolveMailMessagesStore(cliStorageRoutes(target.cityPath), store, target.cfg, target.cityPath, nil)
 	mp := newMailProviderWithSessionStore(msgStore, cliSessionStore(store, target.cfg, target.cityPath))
 	msgs, err := mp.Inbox(target.agentKey())
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return len(msgs), nil
+	senders := make(map[string]int, len(msgs))
+	for _, m := range msgs {
+		senders[m.From]++
+	}
+	return senders, nil
+}
+
+// mailReminderSender recovers the sender a "You have mail" reminder is about:
+// the enqueue-stamped mail-sender reference when present, else parsed from
+// gc's own notify format for items enqueued before the stamp existed. Empty
+// means the sender is unrecoverable and only a fully empty inbox can prove the
+// reminder extinct.
+func mailReminderSender(item queuedNudge) string {
+	if item.Reference != nil && item.Reference.Kind == "mail-sender" {
+		return strings.TrimSpace(item.Reference.ID)
+	}
+	if rest, ok := strings.CutPrefix(item.Message, "You have mail from "); ok {
+		return strings.TrimSpace(rest)
+	}
+	return ""
 }
 
 // splitSatisfiedMailReminders separates source:mail reminders whose purpose is
-// extinct — the recipient has NO unread mail, so "You have mail" is a stale
-// echo — from still-live items (dip-lvsq3c). The mail store is the truth for a
-// mail reminder; delivery confirmation is a transport proxy that fails exactly
-// on busy sessions, which is what let the same reminder re-inject at every
-// safe boundary. A read error or any unread mail keeps EVERY item deliverable
-// (fail-closed toward delivery: a live reminder must never be dropped on a
-// store hiccup).
+// extinct from still-live items (dip-lvsq3c). The mail store is the truth for
+// a mail reminder; delivery confirmation is a transport proxy that fails
+// exactly on busy sessions, which is what let the same reminder re-inject at
+// every safe boundary. The check is PER SENDER, not inbox-empty: "You have
+// mail from X" is extinct exactly when the recipient has no unread mail from
+// X — one unrelated unread message must not keep every stale reminder alive
+// (the dip-kiflqd 17:57Z specimen: two read+archived mails re-reminded because
+// a third, unrelated mail was legitimately unread). A read error keeps EVERY
+// item deliverable (fail-closed toward delivery: a live reminder must never be
+// dropped on a store hiccup).
 func splitSatisfiedMailReminders(target nudgeTarget, store beads.Store, items []queuedNudge) (deliverable, satisfied []queuedNudge) {
 	hasMail := false
 	for _, item := range items {
@@ -1860,12 +1888,22 @@ func splitSatisfiedMailReminders(target nudgeTarget, store beads.Store, items []
 	if !hasMail {
 		return items, nil
 	}
-	unread, err := mailReminderUnreadCount(target, store)
-	if err != nil || unread > 0 {
+	senders, err := mailReminderUnreadSenders(target, store)
+	if err != nil {
 		return items, nil
 	}
 	for _, item := range items {
-		if item.Source == "mail" {
+		if item.Source != "mail" {
+			deliverable = append(deliverable, item)
+			continue
+		}
+		sender := mailReminderSender(item)
+		extinct := senders[sender] == 0
+		if sender == "" {
+			// Unrecoverable sender: only the pre-stamp criterion applies.
+			extinct = len(senders) == 0
+		}
+		if extinct {
 			satisfied = append(satisfied, item)
 			continue
 		}

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -848,6 +848,21 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 		return 1
 	}
 	if queueManagedWake {
+		// Send-time loud-fail guard (sc-875uie): shouldQueueManagedNudgeWake chose to
+		// queue purely on !obs.Running, which cannot tell a resumable (asleep) session
+		// from one that has DRAINED. A drained session is not a wake conflict, so
+		// WakeSession accepts the wake and returns success — but the reconciler spawns
+		// a fresh worker instead of resuming it, so nothing ever consumes the queued
+		// nudge; it lingers until its retired fence stops matching and gc nudge status
+		// reads 0/0/0, having handed the sender a false "queued" success. Detect that
+		// silent-strand case here and fail undeliverable BEFORE enqueuing. (Terminal
+		// and gone targets are NOT diverted here — WakeSession already rejects them and
+		// the enqueue→rollback path dead-letters them loudly.) A probe error
+		// (transient/store) is non-fatal: fall through to the existing enqueue+wake
+		// path rather than block a legitimate nudge.
+		if reason, wouldStrand, probeErr := nudgeManagedWakeStrands(target, store); probeErr == nil && wouldStrand {
+			return writeUndeliverableSessionNudgeResult(target, mode, reason, jsonOutput, stdout, stderr)
+		}
 		return queueManagedSessionNudgeWake(target, store, message, mode, jsonOutput, stdout, stderr)
 	}
 	// A wait-idle nudge to a RUNNING-but-busy target must not block the caller in
@@ -968,6 +983,20 @@ func queueManagedSessionNudgeWake(target nudgeTarget, store beads.Store, message
 		fmt.Fprintf(stderr, "gc session nudge: warning: poke failed: %v\n", err) //nolint:errcheck
 	}
 	return writeQueuedSessionNudgeResult(target, mode, jsonOutput, "", stdout, stderr)
+}
+
+// nudgeManagedWakeStrands reports whether queuing a managed nudge-wake for the
+// target would silently strand it (a drained/stopped session WakeSession accepts
+// but never resumes), via the session front door's read-only ManagedWakeWouldStrand
+// probe. When the front door is unbacked or the target carries no session id it
+// cannot classify, so it reports wouldStrand=false to preserve the pre-existing
+// enqueue behavior.
+func nudgeManagedWakeStrands(target nudgeTarget, store beads.Store) (string, bool, error) {
+	front := cliSessionFrontDoor(store, target.cfg, target.cityPath)
+	if !front.Backed() || target.sessionID == "" {
+		return "", false, nil
+	}
+	return front.ManagedWakeWouldStrand(target.sessionID, time.Now().UTC())
 }
 
 func enqueueManagedNudgeThenWake(target nudgeTarget, store beads.Store, item queuedNudge) error {
@@ -1214,6 +1243,34 @@ func queuedNudgeDowngradeNote(target nudgeTarget, undelivered worker.NudgeUndeli
 	}
 }
 
+// writeUndeliverableSessionNudgeResult reports a nudge that was NOT queued
+// because the target session would silently strand a managed wake (drained/
+// stopped — see nudgeManagedWakeStrands). It is the loud-fail counterpart to
+// writeQueuedSessionNudgeResult: the command exits non-zero and, in JSON mode,
+// emits queued=false / outcome="undeliverable" with the reason, so a caller
+// (human or script) gets a real failure signal instead of a false "queued"
+// success that later evaporates (sc-875uie).
+func writeUndeliverableSessionNudgeResult(target nudgeTarget, mode nudgeDeliveryMode, reason string, jsonOutput bool, stdout, stderr io.Writer) int {
+	if jsonOutput {
+		if code := writeCLIJSONLineOrExit(stdout, stderr, "gc session nudge", sessionNudgeJSON{
+			SchemaVersion: "1",
+			OK:            false,
+			Target:        target.agentKey(),
+			SessionID:     target.sessionID,
+			SessionName:   target.sessionName,
+			Delivery:      string(mode),
+			Queued:        false,
+			Outcome:       "undeliverable",
+			Reason:        reason,
+		}); code != 0 {
+			return code
+		}
+		return 1
+	}
+	fmt.Fprintf(stderr, "gc session nudge: undeliverable — target session %s is %s and will not be resumed; nudge not queued\n", target.agentKey(), reason) //nolint:errcheck
+	return 1
+}
+
 func sendMailNotify(target nudgeTarget, sender string) error {
 	store, err := openNudgeBeadStoreErr(target.cityPath)
 	if err != nil {
@@ -1261,6 +1318,14 @@ func sendMailNotifyWithWorker(target nudgeTarget, store beads.Store, sp runtime.
 					sessFront = sessionFrontDoor(sessStore)
 				}
 				stampLastNudgeDeliveredAt(sessFront, target.sessionID, time.Now())
+				return nil
+			}
+			if nudgeErr == nil && result.Undelivered == worker.NudgeUndeliveredNoIdleBoundary {
+				// Live but busy past the idle window: the mail-check hook
+				// announces unread mail at the session's next prompt boundary,
+				// so enqueueing here would deliver the same mail through two
+				// channels (dip-lq1utb). The downgrade reason is upstream's
+				// vocabulary for exactly this state.
 				return nil
 			}
 		}
@@ -2086,6 +2151,11 @@ type nudgeMaintenanceStore struct {
 	opened   bool
 	store    beads.NudgesStore
 	front    *nudgequeue.Store
+
+	// sessProbe is the session-lifecycle probe the stranded-nudge sweep uses,
+	// built once (sessProbeBuilt) over the same store handle frontForState opened.
+	sessProbe      managedWakeUnreachableProbe
+	sessProbeBuilt bool
 }
 
 // frontForState returns the front-door handle to use for the maintenance passes
@@ -2113,6 +2183,41 @@ func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 		}
 	}
 	return m.store
+}
+
+// managedWakeUnreachableProbe reports whether the target session of a queued nudge
+// has reached a terminal/stranding lifecycle state and can therefore no longer
+// consume it. It is session.Store.ManagedWakeUnreachable as a method value; a nil
+// probe (no backed session front door) disables the stranded-nudge sweep.
+type managedWakeUnreachableProbe func(sessionID string, now time.Time) (string, bool, error)
+
+// strandProbe returns the session-lifecycle probe pruneStrandedQueuedNudges uses,
+// built lazily over the same underlying store handle frontForState opened (so the
+// idle/empty-queue tick never opens a store or loads config just to build it). It
+// returns nil — disabling the sweep for this pass — when the store was never
+// opened or the session front door is not backed. The one-shot session store is
+// routed through cliSessionFrontDoor so a [beads.classes.sessions] relocation is
+// honored the same way the running controller honors it.
+func (m *nudgeMaintenanceStore) strandProbe() managedWakeUnreachableProbe {
+	if m.sessProbeBuilt {
+		return m.sessProbe
+	}
+	m.sessProbeBuilt = true
+	if !m.opened || m.store.Store == nil {
+		return nil
+	}
+	// cfg drives only [beads.classes.sessions] relocation routing and is nil-safe at
+	// the single-store backend (resolveClassStore ignores it). Load it so a relocated
+	// session store is honored the same way the controller honors it, but fall back
+	// to nil rather than disable the sweep when config is unreadable (e.g. a bare
+	// test city) — the sweep is far too valuable to silently skip over a config read.
+	cfg, _ := loadCityConfig(m.cityPath, io.Discard)
+	front := cliSessionFrontDoor(m.store.Store, cfg, m.cityPath)
+	if front == nil || !front.Backed() {
+		return nil
+	}
+	m.sessProbe = front.ManagedWakeUnreachable
+	return m.sessProbe
 }
 
 // close releases the store this frame opened (if any). It never touches a
@@ -2151,6 +2256,9 @@ func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(que
 			return err
 		}
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
+			return err
+		}
+		if err := pruneStrandedQueuedNudges(state, front, maint.strandProbe(), now, deadline); err != nil {
 			return err
 		}
 		pending := state.Pending[:0]
@@ -2193,6 +2301,9 @@ func listQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge,
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
 			return err
 		}
+		if err := pruneStrandedQueuedNudges(state, front, maint.strandProbe(), now, deadline); err != nil {
+			return err
+		}
 		for _, item := range state.Pending {
 			if item.Agent == agentName {
 				pending = append(pending, item)
@@ -2229,6 +2340,9 @@ func listQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Tim
 			return err
 		}
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
+			return err
+		}
+		if err := pruneStrandedQueuedNudges(state, front, maint.strandProbe(), now, deadline); err != nil {
 			return err
 		}
 		for _, item := range state.Pending {
@@ -2730,6 +2844,68 @@ func pruneExpiredQueuedNudgesWithClock(state *nudgeQueueState, front *nudgequeue
 		filtered = append(filtered, item)
 	}
 	state.Pending = filtered
+	sortQueuedNudges(state)
+	return nil
+}
+
+// pruneStrandedQueuedNudges dead-letters queued nudges whose TARGET SESSION has
+// terminated (closed / closing / archived-without-continuity) or stranded
+// (drained / stopped) and will therefore never consume them — the drain-time-race
+// half of the sc-875uie loud-fail guard. The send-time guard (half a,
+// nudgeManagedWakeStrands) blocks a NEW managed wake to an already-drained target;
+// this sweep covers the RACE the send-time guard cannot: a nudge queued to a live
+// or asleep session that THEN terminates before consuming it. Left unswept the
+// orphan lingers in Pending/InFlight until its retired session fence stops matching,
+// at which point `gc nudge status` reads 0/0/0 with zero trace and the sender never
+// learns delivery failed (the measured bug). Moving it to Dead surfaces it in
+// status and leaves a durable terminal bead.
+//
+// It is deliberately session-keyed: an item with no target SessionID (an
+// agent-broadcast nudge bound to no specific session) is left untouched — this fix
+// targets the measured session-directed evaporation only. A probe error (a
+// transient session-store read) KEEPS the item (fail-closed) rather than
+// dead-letter a possibly-live target. A nil probe or front (idle/empty queue never
+// opened the store) makes the whole pass a no-op.
+func pruneStrandedQueuedNudges(state *nudgeQueueState, front *nudgequeue.Store, probe managedWakeUnreachableProbe, now, deadline time.Time) error {
+	if probe == nil || front == nil {
+		return nil
+	}
+	var stranded []queuedNudge
+	sweep := func(items []queuedNudge) []queuedNudge {
+		kept := items[:0]
+		for i, item := range items {
+			if time.Now().After(deadline) {
+				kept = append(kept, items[i:]...)
+				break
+			}
+			if strings.TrimSpace(item.SessionID) == "" {
+				kept = append(kept, item)
+				continue
+			}
+			reason, unreachable, err := probe(item.SessionID, now)
+			if err != nil || !unreachable {
+				kept = append(kept, item)
+				continue
+			}
+			item.DeadAt = now.UTC()
+			item.ClaimedAt = time.Time{}
+			item.LeaseUntil = time.Time{}
+			if strings.TrimSpace(item.LastError) == "" {
+				item.LastError = "session " + reason
+			}
+			stranded = append(stranded, item)
+		}
+		return kept
+	}
+	state.Pending = sweep(state.Pending)
+	state.InFlight = sweep(state.InFlight)
+	for _, item := range stranded {
+		// Best-effort: mark the backing bead terminal even if the write fails, so a
+		// store hiccup cannot trap the item back in Pending/InFlight (mirrors the
+		// expired-prune contract). pruneDeadQueuedNudges repairs any missed terminal.
+		_ = front.Terminalize(item, "failed", item.LastError, "", now)
+	}
+	state.Dead = append(state.Dead, stranded...)
 	sortQueuedNudges(state)
 	return nil
 }

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessiontmux "github.com/gastownhall/gascity/internal/runtime/tmux"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/gastownhall/gascity/internal/worker"
@@ -41,6 +42,23 @@ const (
 	defaultQueuedNudgeRetryDelay    = 15 * time.Second
 	defaultQueuedNudgeMaxAttempts   = 5
 	defaultQueuedNudgeDeadRetention = 1 * time.Hour
+
+	// queuedNudgeUnconfirmedSubmitCeiling bounds how many submit Enters may
+	// reach the runtime for ONE reminder before the queue presumes the
+	// injection landed (sc-lx6q5t).
+	//
+	// A tmux submit that cannot be confirmed (the agent's busy indicator was
+	// never observed within budget) is ambiguous: either the message is
+	// sitting drafted-but-unsubmitted in the pane, or — the measured common
+	// case on a busy session — it landed and the busy window was simply
+	// missed. Treating that ambiguity as a plain failure spends the full
+	// defaultQueuedNudgeMaxAttempts budget, so one reminder re-injects 3-5
+	// times into a session that already has it. One retry covers the genuinely
+	// drafted case; after a SECOND Enter has reached the runtime the balance
+	// of evidence is that the agent has the reminder, and another echo is
+	// strictly worse than none. Confirmable failures (nothing reached the
+	// runtime) are unaffected and keep the full attempt budget.
+	queuedNudgeUnconfirmedSubmitCeiling = 2
 
 	// nudgeEnqueueMaintenanceBudget bounds the wall-clock time the foreground
 	// `gc sling --nudge` enqueue path spends on best-effort nudge-queue
@@ -124,6 +142,11 @@ type nudgeTarget struct {
 	sessionID         string
 	continuationEpoch string
 	sessionName       string
+	// subjectBeadID is the bead this nudge is ABOUT (gc session nudge
+	// --about), not the bead identifying the target. It is what lets a
+	// deferred reminder retire when its subject closes; empty for the
+	// ordinary "just wake this agent" nudge.
+	subjectBeadID string
 }
 
 type nudgeStatusJSON struct {
@@ -540,6 +563,16 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 			fmt.Fprintf(stderr, "gc nudge drain: withdrawing blocked nudges: %v\n", err) //nolint:errcheck
 		}
 	}
+	// Mail-state supersession gate (dip-lvsq3c): at this prompt boundary the
+	// hook's own mail-check injection already reflects CURRENT unread state, so
+	// a "You have mail" reminder for an emptied inbox is a stale echo — retire
+	// it instead of injecting it.
+	items, satisfied := splitSatisfiedMailReminders(target, deliveryStore.Store, items)
+	if len(satisfied) > 0 {
+		if err := terminalizeSatisfiedMailReminders(target.cityPath, satisfied); err != nil {
+			fmt.Fprintf(stderr, "gc nudge drain: retiring read-mail reminders: %v\n", err) //nolint:errcheck
+		}
+	}
 	if len(items) == 0 {
 		if inject {
 			return 0
@@ -588,10 +621,16 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 }
 
 func queuedNudgeOptionsFromTarget(target nudgeTarget) queuedNudgeOptions {
-	return queuedNudgeOptions{
+	opts := queuedNudgeOptions{
 		SessionID:         target.sessionID,
 		ContinuationEpoch: target.continuationEpoch,
 	}
+	// Carry the subject bead onto the queued item so the delivery pass can
+	// retire the reminder once that bead closes.
+	if id := strings.TrimSpace(target.subjectBeadID); id != "" {
+		opts.Reference = &nudgeReference{Kind: "bead", ID: id}
+	}
+	return opts
 }
 
 // configureNudgePollRuntime bounds the long-lived nudge-poll sidecar's memory
@@ -1457,6 +1496,22 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store, sessStore beads.S
 			bookkeepErr = errors.Join(bookkeepErr, fmt.Errorf("withdrawing blocked nudges: %w", termErr))
 		}
 	}
+	// Mail-state supersession gate (dip-lvsq3c): a "You have mail" reminder
+	// whose recipient has no unread mail must retire, not re-inject.
+	items, satisfied := splitSatisfiedMailReminders(target, deliveryStore, items)
+	if len(satisfied) > 0 {
+		if termErr := terminalizeSatisfiedMailReminders(target.cityPath, satisfied); termErr != nil {
+			bookkeepErr = errors.Join(bookkeepErr, fmt.Errorf("retiring read-mail reminders: %w", termErr))
+		}
+	}
+	// Subject-state supersession gate (sc-lx6q5t): a cascade/route reminder
+	// about a bead that has since closed must retire, not re-inject.
+	items, extinct := splitPurposeExtinctSessionReminders(deliveryStore, items)
+	if len(extinct) > 0 {
+		if termErr := terminalizePurposeExtinctSessionReminders(target.cityPath, extinct); termErr != nil {
+			bookkeepErr = errors.Join(bookkeepErr, fmt.Errorf("retiring reminders about closed beads: %w", termErr))
+		}
+	}
 	if len(items) == 0 {
 		return false, bookkeepErr
 	}
@@ -1485,8 +1540,20 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store, sessStore beads.S
 			}
 			return false, bookkeepErr
 		}
-		if recErr := recordQueuedNudgeFailureWithStore(target.cityPath, beads.NudgesStore{Store: deliveryStore}, queuedNudgeIDs(items), err, time.Now()); recErr != nil {
-			return false, errors.Join(bookkeepErr, recErr)
+		// An unconfirmed submit already handed the keystrokes to the runtime.
+		// Retry the first one; once a second Enter has reached the session,
+		// retire the item as accepted-for-injection instead of echoing it into
+		// a session that most likely already has it.
+		retry, presumed := splitUnconfirmedSubmitNudges(err, items)
+		if len(presumed) > 0 {
+			if ackErr := ackQueuedNudgesWithOutcome(target.cityPath, queuedNudgeIDs(presumed), "accepted_for_injection", "two submits reached the runtime; boundary injection presumed", "unconfirmed-submit-ceiling"); ackErr != nil {
+				bookkeepErr = errors.Join(bookkeepErr, fmt.Errorf("retiring unconfirmed-submit nudges: %w", ackErr))
+			}
+		}
+		if len(retry) > 0 {
+			if recErr := recordQueuedNudgeFailureWithStore(target.cityPath, beads.NudgesStore{Store: deliveryStore}, queuedNudgeIDs(retry), err, time.Now()); recErr != nil {
+				return false, errors.Join(bookkeepErr, recErr)
+			}
 		}
 		return false, bookkeepErr
 	}
@@ -1692,6 +1759,155 @@ func blockedQueuedNudgeReason(sessFront *session.Store, item queuedNudge) (strin
 	default:
 		return "wait-not-ready", true, nil
 	}
+}
+
+// mailReminderUnreadCount reports the recipient's current unread mail count
+// for the mail-state supersession gate below. It is a package var so tests can
+// pin the mailbox state without a live mail store. The production reader mirrors
+// `gc mail check <agent>`: the same message-store class resolution and the same
+// recipient identity the notify path enqueued the reminder under.
+var mailReminderUnreadCount = func(target nudgeTarget, store beads.Store) (int, error) {
+	msgStore := resolveMailMessagesStore(cliStorageRoutes(target.cityPath), store, target.cfg, target.cityPath, nil)
+	mp := newMailProviderWithSessionStore(msgStore, cliSessionStore(store, target.cfg, target.cityPath))
+	msgs, err := mp.Inbox(target.agentKey())
+	if err != nil {
+		return 0, err
+	}
+	return len(msgs), nil
+}
+
+// splitSatisfiedMailReminders separates source:mail reminders whose purpose is
+// extinct — the recipient has NO unread mail, so "You have mail" is a stale
+// echo — from still-live items (dip-lvsq3c). The mail store is the truth for a
+// mail reminder; delivery confirmation is a transport proxy that fails exactly
+// on busy sessions, which is what let the same reminder re-inject at every
+// safe boundary. A read error or any unread mail keeps EVERY item deliverable
+// (fail-closed toward delivery: a live reminder must never be dropped on a
+// store hiccup).
+func splitSatisfiedMailReminders(target nudgeTarget, store beads.Store, items []queuedNudge) (deliverable, satisfied []queuedNudge) {
+	hasMail := false
+	for _, item := range items {
+		if item.Source == "mail" {
+			hasMail = true
+			break
+		}
+	}
+	if !hasMail {
+		return items, nil
+	}
+	unread, err := mailReminderUnreadCount(target, store)
+	if err != nil || unread > 0 {
+		return items, nil
+	}
+	for _, item := range items {
+		if item.Source == "mail" {
+			satisfied = append(satisfied, item)
+			continue
+		}
+		deliverable = append(deliverable, item)
+	}
+	return deliverable, satisfied
+}
+
+// terminalizeSatisfiedMailReminders retires purpose-extinct mail reminders as
+// superseded: consumed by the recipient reading their mail, not failed.
+func terminalizeSatisfiedMailReminders(cityPath string, items []queuedNudge) error {
+	if len(items) == 0 {
+		return nil
+	}
+	return ackQueuedNudgesWithOutcome(cityPath, queuedNudgeIDs(items), "superseded", "mail already read (recipient inbox empty)", "mail-state-satisfied")
+}
+
+// splitPurposeExtinctSessionReminders separates source:session reminders whose
+// subject bead has CLOSED from still-live items (sc-lx6q5t). The cascade and
+// route orders enqueue a reminder ABOUT a bead ("blocker X closed — your
+// dependent Y may be unblocked", "check for assigned work"); once that bead is
+// closed the reminder has nothing left to say, and injecting it at the next
+// boundary costs the agent a turn to discover there is no work. The bead store
+// is the truth for those reminders, exactly as the mail store is for "You have
+// mail".
+//
+// Only items carrying a bead Reference are classified; everything else — no
+// reference, a non-bead reference, another source — is returned untouched. An
+// unreadable reference (missing bead, store hiccup, a bead owned by a store
+// this poller cannot see) keeps the item deliverable: fail-closed toward
+// delivery, since a live reminder must never be dropped on a read failure.
+func splitPurposeExtinctSessionReminders(store beads.Store, items []queuedNudge) (deliverable, extinct []queuedNudge) {
+	if store == nil {
+		return items, nil
+	}
+	referenced := false
+	for _, item := range items {
+		if queuedNudgeSubjectBeadID(item) != "" {
+			referenced = true
+			break
+		}
+	}
+	if !referenced {
+		return items, nil
+	}
+	for _, item := range items {
+		if queuedNudgeSubjectBeadClosed(store, item) {
+			extinct = append(extinct, item)
+			continue
+		}
+		deliverable = append(deliverable, item)
+	}
+	return deliverable, extinct
+}
+
+// queuedNudgeSubjectBeadID returns the bead a session-sourced reminder is
+// about, or "" when the item carries no usable bead reference.
+func queuedNudgeSubjectBeadID(item queuedNudge) string {
+	if item.Source != "session" || item.Reference == nil || item.Reference.Kind != "bead" {
+		return ""
+	}
+	return strings.TrimSpace(item.Reference.ID)
+}
+
+// queuedNudgeSubjectBeadClosed reports whether a session reminder's subject
+// bead is closed. Any read failure reports false so the item stays deliverable.
+func queuedNudgeSubjectBeadClosed(store beads.Store, item queuedNudge) bool {
+	id := queuedNudgeSubjectBeadID(item)
+	if id == "" {
+		return false
+	}
+	subject, err := store.Get(id)
+	if err != nil {
+		return false
+	}
+	return subject.Status == "closed"
+}
+
+// terminalizePurposeExtinctSessionReminders retires reminders about closed
+// beads as superseded: consumed by the subject reaching its terminal state,
+// not failed.
+func terminalizePurposeExtinctSessionReminders(cityPath string, items []queuedNudge) error {
+	if len(items) == 0 {
+		return nil
+	}
+	return ackQueuedNudgesWithOutcome(cityPath, queuedNudgeIDs(items), "superseded", "referenced bead closed — reminder purpose extinct", "subject-bead-closed")
+}
+
+// splitUnconfirmedSubmitNudges partitions the items of a FAILED delivery into
+// the ones that still deserve a retry and the ones whose submit has now reached
+// the runtime twice (queuedNudgeUnconfirmedSubmitCeiling) and must be presumed
+// injected. A confirmable failure — anything that is not the unconfirmed-submit
+// sentinel — returns every item for retry, preserving today's behavior exactly.
+func splitUnconfirmedSubmitNudges(cause error, items []queuedNudge) (retry, presumed []queuedNudge) {
+	if !errors.Is(cause, sessiontmux.ErrNudgeSubmitUnconfirmed) {
+		return items, nil
+	}
+	for _, item := range items {
+		// Attempts counts submits already recorded, so Attempts+1 is the
+		// submit that just reached the runtime.
+		if item.Attempts+1 >= queuedNudgeUnconfirmedSubmitCeiling {
+			presumed = append(presumed, item)
+			continue
+		}
+		retry = append(retry, item)
+	}
+	return retry, presumed
 }
 
 func terminalizeBlockedQueuedNudges(cityPath string, blocked map[string][]queuedNudge) error {
@@ -2214,14 +2430,22 @@ func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, 
 		now := time.Now()
 		front := maint.frontForState(state)
 		deadline := noMaintenanceDeadline()
+		// Maintenance and shadow-bead bookkeeping are BEST-EFFORT here: the
+		// flock'd state.json is the storage authority and the bead is a shadow
+		// (see internal/nudgequeue/store.go). Before this change, a failure in
+		// the shadow store (bead-store contention on a loaded rig) aborted the
+		// whole transaction, so an already-INJECTED reminder was never removed
+		// from Pending — its claim lease lapsed and the hook re-injected the
+		// same items at every prompt boundary until the store freed up. The
+		// observability shadow must never block the delivery authority.
 		if err := recoverExpiredInFlightNudges(state, front, now, deadline); err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "gc nudge ack: warning: recover pass (best-effort): %v\n", err) //nolint:errcheck
 		}
 		if err := pruneExpiredQueuedNudges(state, front, now, deadline); err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "gc nudge ack: warning: expired prune (best-effort): %v\n", err) //nolint:errcheck
 		}
 		if err := pruneDeadQueuedNudges(state, front, now, deadline); err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "gc nudge ack: warning: dead prune (best-effort): %v\n", err) //nolint:errcheck
 		}
 		var terminal []queuedNudge
 		filtered := state.Pending[:0]
@@ -2245,9 +2469,12 @@ func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, 
 		for _, item := range terminal {
 			// terminal items come from a non-empty Pending/InFlight, so the
 			// store is already open; ensureOpen is idempotent and just returns
-			// the cached handle here.
+			// the cached handle here. Shadow-bead terminalization is
+			// best-effort: the item is already removed from the authority
+			// above, and resurrecting it (by aborting this transaction) turns
+			// one delayed shadow write into an endless duplicate delivery.
 			if err := markQueuedNudgeTerminal(maint.ensureOpen(), item, outcome, reason, commitBoundary, now); err != nil {
-				return err
+				fmt.Fprintf(os.Stderr, "gc nudge ack: warning: shadow terminalize %s (best-effort): %v\n", item.ID, err) //nolint:errcheck
 			}
 		}
 		return nil

--- a/cmd/gc/cmd_nudge_strand_sweep_test.go
+++ b/cmd/gc/cmd_nudge_strand_sweep_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/worker"
+)
+
+// TestPruneStrandedQueuedNudgesDrainTimeRaceIsDeadLettered pins half (a2) of the
+// sc-875uie loud-fail guard end to end: a managed nudge queued to a live/asleep
+// session that THEN drains before consuming it is dead-lettered by the maintenance
+// sweep and becomes VISIBLE in `gc nudge status` (Dead: 1), instead of lingering in
+// Pending until its retired fence stops matching and status reads 0/0/0 with zero
+// trace. The send-time guard (half a) cannot catch this race — the target was
+// perfectly resumable when the nudge was queued; only a later observation over the
+// now-terminal session lifecycle can. The same observation while the target is
+// still asleep must NOT sweep the nudge (no false positive on a resumable target).
+func TestPruneStrandedQueuedNudgesDrainTimeRaceIsDeadLettered(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "claude", WorkDir: dir, Provider: "claude", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Asleep (suspended) — a genuinely resumable target. A managed wake queued here
+	// is legitimate: the session would consume it on resume. This is the pre-race
+	// state; the drain happens AFTER the nudge is already queued.
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	prevManaged := nudgeCityUsesManagedReconciler
+	prevPoke := nudgePokeController
+	prevObserve := nudgeObserveTarget
+	pokes := 0
+	nudgeCityUsesManagedReconciler = func(cityPath string) bool { return cityPath == dir }
+	nudgePokeController = func(string) error {
+		pokes++
+		return nil
+	}
+	nudgeObserveTarget = func(nudgeTarget, beads.Store, runtime.Provider) (worker.LiveObservation, error) {
+		return worker.LiveObservation{Running: false}, nil
+	}
+	t.Cleanup(func() {
+		nudgeCityUsesManagedReconciler = prevManaged
+		nudgePokeController = prevPoke
+		nudgeObserveTarget = prevObserve
+	})
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		cfg:         &config.City{Agents: []config.Agent{{Name: "worker", Provider: "claude"}}},
+		sessionID:   info.ID,
+		sessionName: info.SessionName,
+		identity:    "worker",
+		agent:       config.Agent{Name: "worker", Provider: "claude"},
+	}
+
+	// Queue the managed wake to the asleep session — the normal, successful path.
+	var stdout, stderr bytes.Buffer
+	if code := deliverSessionNudgeWithWorker(target, store, fake, "resume: mayor ruling", nudgeDeliveryImmediate, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("deliverSessionNudgeWithWorker = %d (%q), want 0 (queued to a resumable session)", code, stderr.String())
+	}
+	if pokes != 1 {
+		t.Fatalf("pokes = %d, want 1 (managed wake enqueued + controller poked)", pokes)
+	}
+
+	// Observation #1, target still ASLEEP: the sweep runs but must NOT touch a
+	// resumable target — the nudge stays Pending.
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget (asleep): %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("asleep pending/inFlight/dead = %d/%d/%d, want 1/0/0 (no false sweep of a resumable target)", len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].SessionID != info.ID {
+		t.Fatalf("queued nudge SessionID = %q, want %q (item must carry its target session for the sweep to classify it)", pending[0].SessionID, info.ID)
+	}
+
+	// The race: the target DRAINS after the nudge was queued. A drained session
+	// projects to BaseStateDrained — the reconciler spawns a fresh worker rather
+	// than resuming it, so nothing will ever consume the queued wake.
+	if err := store.SetMetadata(info.ID, "state", "drained"); err != nil {
+		t.Fatalf("SetMetadata(state=drained): %v", err)
+	}
+
+	// Observation #2, target now DRAINED: the sweep dead-letters the orphan. This
+	// is the fix — status now shows a real Dead trace instead of 0/0/0.
+	pending, inFlight, dead, err = listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget (drained): %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 1 {
+		t.Fatalf("drained pending/inFlight/dead = %d/%d/%d, want 0/0/1 (queued-then-drained nudge dead-lettered, not evaporated)", len(pending), len(inFlight), len(dead))
+	}
+	if !strings.Contains(dead[0].LastError, "drained") {
+		t.Fatalf("dead LastError = %q, want it to name the terminal session state (drained)", dead[0].LastError)
+	}
+	if dead[0].DeadAt.IsZero() {
+		t.Fatalf("dead nudge DeadAt is zero, want it stamped at sweep time")
+	}
+
+	// Idempotent: a subsequent observation does not re-sweep or duplicate the Dead
+	// entry — the item is already terminal.
+	pending, inFlight, dead, err = listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget (re-observe): %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 1 {
+		t.Fatalf("re-observe pending/inFlight/dead = %d/%d/%d, want 0/0/1 (sweep is idempotent)", len(pending), len(inFlight), len(dead))
+	}
+}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -1779,14 +1779,17 @@ func TestSendMailNotifyWithWorkerManagedQueueFailureDoesNotWake(t *testing.T) {
 	}
 }
 
-// TestSendMailNotifyQueuesIndependentRemindersForEachMail is a regression
-// guard for the deferred-reminder race in gc-ub7: every `gc mail send --notify`
-// to a non-live recipient must queue its own reminder, even when an earlier
-// mail reminder for the same recipient is still pending (unread). The
-// queued-nudge layer must not collapse distinct mail arrivals — neither by ID
-// dedup nor by supersession — so the recipient learns about each mail rather
-// than only the first that crossed the no-unread -> has-unread boundary.
-func TestSendMailNotifyQueuesIndependentRemindersForEachMail(t *testing.T) {
+// TestSendMailNotifyCollapsesSameSenderKeepsSendersIndependent pins the
+// sender-stamped reminder shape (dip-kiflqd, revising gc-ub7's per-mail pin):
+// a second PENDING "You have mail from X" is byte-identical to the first and
+// delivering both is exactly the echo class the mail-state gate exists to
+// kill, so same-sender pending reminders collapse to the newest via reference
+// supersession — while reminders for DIFFERENT senders stay independent.
+// gc-ub7's underlying race stays covered without per-mail pending items:
+// supersession touches only pending/in-flight entries, so a reminder that
+// already delivered (or terminalized any other way) never blocks the next
+// mail's fresh reminder from queueing.
+func TestSendMailNotifyCollapsesSameSenderKeepsSendersIndependent(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
 	store := openNudgeBeadStore(dir)
@@ -1824,14 +1827,32 @@ func TestSendMailNotifyQueuesIndependentRemindersForEachMail(t *testing.T) {
 			t.Fatalf("sendMailNotifyWithWorker(call %d): %v", i+1, err)
 		}
 	}
+	// A third mail from a DIFFERENT sender queues its own reminder.
+	if err := sendMailNotifyWithWorker(target, store, fake, "mayor"); err != nil {
+		t.Fatalf("sendMailNotifyWithWorker(other sender): %v", err)
+	}
 
 	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
 	if err != nil {
 		t.Fatalf("listQueuedNudgesForTarget: %v", err)
 	}
 	if len(pending) != 2 {
-		t.Fatalf("pending reminders = %d, want 2 (the second mail must not be deduped against the still-unread first); pending=%#v inFlight=%#v dead=%#v", len(pending), pending, inFlight, dead)
+		t.Fatalf("pending reminders = %d, want 2 (same-sender pair collapsed to the newest + the other sender's own reminder); pending=%#v inFlight=%#v dead=%#v", len(pending), pending, inFlight, dead)
 	}
+	senders := map[string]int{}
+	for _, item := range pending {
+		if item.Reference == nil || item.Reference.Kind != "mail-sender" {
+			t.Fatalf("pending item %q lacks the mail-sender reference stamp: %#v", item.ID, item.Reference)
+		}
+		senders[item.Reference.ID]++
+	}
+	if senders["human"] != 1 || senders["mayor"] != 1 {
+		t.Fatalf("pending senders = %v, want exactly one reminder per sender", senders)
+	}
+	if len(dead) != 1 || dead[0].LastError != "superseded" {
+		t.Fatalf("dead = %#v, want exactly the older same-sender reminder retired as superseded", dead)
+	}
+	_ = inFlight
 }
 
 // TestSendMailNotifyWithWorkerLiveBusySessionDoesNotDoubleDeliver is a
@@ -2634,9 +2655,9 @@ func TestTryDeliverQueuedNudgesByPollerTerminalizesReadMailReminders(t *testing.
 	idleSince := time.Now().Add(-10 * time.Second)
 	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
 
-	prevUnread := mailReminderUnreadCount
-	t.Cleanup(func() { mailReminderUnreadCount = prevUnread })
-	mailReminderUnreadCount = func(nudgeTarget, beads.Store) (int, error) { return 0, nil }
+	prevUnread := mailReminderUnreadSenders
+	t.Cleanup(func() { mailReminderUnreadSenders = prevUnread })
+	mailReminderUnreadSenders = func(nudgeTarget, beads.Store) (map[string]int, error) { return nil, nil }
 
 	target := nudgeTarget{
 		cityPath:    dir,
@@ -2673,6 +2694,57 @@ func TestTryDeliverQueuedNudgesByPollerTerminalizesReadMailReminders(t *testing.
 	}
 }
 
+// TestSplitSatisfiedMailRemindersIsPerSender is the falsifier for the
+// dip-kiflqd 17:57Z specimen: reminders for two read+archived mails re-fired
+// because ONE unrelated mail was legitimately unread — the inbox-empty proxy
+// kept every stale reminder alive on any busy inbox. The gate must judge each
+// reminder against ITS sender's unread state: stale senders retire, the
+// unread sender's reminder stays deliverable, and a reference-stamped item is
+// judged by its stamp even when the message text disagrees.
+func TestSplitSatisfiedMailRemindersIsPerSender(t *testing.T) {
+	prevUnread := mailReminderUnreadSenders
+	t.Cleanup(func() { mailReminderUnreadSenders = prevUnread })
+	mailReminderUnreadSenders = func(nudgeTarget, beads.Store) (map[string]int, error) {
+		return map[string]int{"reviewer-c": 1}, nil
+	}
+	now := time.Now()
+	staleA := newQueuedNudgeWithOptions("pl", "You have mail from reviewer-a", "mail", now, queuedNudgeOptions{})
+	staleB := newQueuedNudgeWithOptions("pl", "You have mail from reviewer-b", "mail", now, queuedNudgeOptions{})
+	liveC := newQueuedNudgeWithOptions("pl", "You have mail from reviewer-c", "mail", now, queuedNudgeOptions{})
+	// Reference stamp wins over message text: stamped sender is unread even
+	// though the text names a stale sender.
+	stampedLive := newQueuedNudgeWithOptions("pl", "You have mail from reviewer-a", "mail", now, queuedNudgeOptions{
+		Reference: &nudgeReference{Kind: "mail-sender", ID: "reviewer-c"},
+	})
+	other := newQueuedNudgeWithOptions("pl", "review the deploy logs", "session", now, queuedNudgeOptions{})
+
+	deliverable, satisfied := splitSatisfiedMailReminders(nudgeTarget{}, nil, []queuedNudge{staleA, staleB, liveC, stampedLive, other})
+	if len(satisfied) != 2 {
+		t.Fatalf("satisfied = %d items, want exactly the two stale-sender reminders", len(satisfied))
+	}
+	for _, item := range satisfied {
+		if item.ID != staleA.ID && item.ID != staleB.ID {
+			t.Fatalf("retired %q (%s), want only the stale-sender reminders", item.Message, item.ID)
+		}
+	}
+	if len(deliverable) != 3 {
+		t.Fatalf("deliverable = %d items, want live sender + stamped item + non-mail item", len(deliverable))
+	}
+
+	// Legacy shape with an unrecoverable sender: retires only on a fully
+	// empty inbox, exactly the pre-stamp behavior.
+	legacy := newQueuedNudgeWithOptions("pl", "mail arrived", "mail", now, queuedNudgeOptions{})
+	deliverable, satisfied = splitSatisfiedMailReminders(nudgeTarget{}, nil, []queuedNudge{legacy})
+	if len(deliverable) != 1 || len(satisfied) != 0 {
+		t.Fatalf("unrecoverable sender with unread mail present: deliverable=%d satisfied=%d, want 1/0", len(deliverable), len(satisfied))
+	}
+	mailReminderUnreadSenders = func(nudgeTarget, beads.Store) (map[string]int, error) { return nil, nil }
+	deliverable, satisfied = splitSatisfiedMailReminders(nudgeTarget{}, nil, []queuedNudge{legacy})
+	if len(deliverable) != 0 || len(satisfied) != 1 {
+		t.Fatalf("unrecoverable sender with empty inbox: deliverable=%d satisfied=%d, want 0/1", len(deliverable), len(satisfied))
+	}
+}
+
 // TestTryDeliverQueuedNudgesByPollerKeepsUnreadMailReminders pins the other
 // half of the mail-state gate: while the recipient still HAS unread mail, the
 // reminder is live and must deliver normally.
@@ -2697,9 +2769,11 @@ func TestTryDeliverQueuedNudgesByPollerKeepsUnreadMailReminders(t *testing.T) {
 	idleSince := time.Now().Add(-10 * time.Second)
 	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
 
-	prevUnread := mailReminderUnreadCount
-	t.Cleanup(func() { mailReminderUnreadCount = prevUnread })
-	mailReminderUnreadCount = func(nudgeTarget, beads.Store) (int, error) { return 2, nil }
+	prevUnread := mailReminderUnreadSenders
+	t.Cleanup(func() { mailReminderUnreadSenders = prevUnread })
+	mailReminderUnreadSenders = func(nudgeTarget, beads.Store) (map[string]int, error) {
+		return map[string]int{"human": 2}, nil
+	}
 
 	target := nudgeTarget{
 		cityPath:    dir,

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -857,6 +857,107 @@ func TestDeliverSessionNudgeWithWorkerManagedWakeFailureRollsBackQueuedNudge(t *
 	}
 }
 
+// TestDeliverSessionNudgeWithWorkerManagedDrainedTargetIsUndeliverable pins the
+// sc-875uie send-time guard end to end: a managed nudge to a DRAINED session is
+// reported undeliverable synchronously and NOT enqueued, so the sender gets a real
+// failure signal instead of the false "queued" success that used to evaporate
+// (gc nudge status 0/0/0, zero trace). Contrast the closing-session case above,
+// which WakeSession rejects and the enqueue→rollback path dead-letters (dead==1);
+// a drained session is not a wake conflict, so absent the guard the wake would
+// silently "succeed" and strand the nudge.
+func TestDeliverSessionNudgeWithWorkerManagedDrainedTargetIsUndeliverable(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "claude", WorkDir: dir, Provider: "claude", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+	// A drained pool worker: state=drained projects to BaseStateDrained, which is
+	// NOT a wake conflict — WakeSession would accept a wake and report success. That
+	// is the exact silent-strand the send-time guard intercepts.
+	if err := store.SetMetadata(info.ID, "state", "drained"); err != nil {
+		t.Fatalf("SetMetadata(state): %v", err)
+	}
+
+	prevManaged := nudgeCityUsesManagedReconciler
+	prevPoke := nudgePokeController
+	prevObserve := nudgeObserveTarget
+	pokes := 0
+	nudgeCityUsesManagedReconciler = func(cityPath string) bool { return cityPath == dir }
+	nudgePokeController = func(string) error {
+		pokes++
+		return nil
+	}
+	nudgeObserveTarget = func(nudgeTarget, beads.Store, runtime.Provider) (worker.LiveObservation, error) {
+		return worker.LiveObservation{Running: false}, nil
+	}
+	t.Cleanup(func() {
+		nudgeCityUsesManagedReconciler = prevManaged
+		nudgePokeController = prevPoke
+		nudgeObserveTarget = prevObserve
+	})
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		cfg:         &config.City{Agents: []config.Agent{{Name: "worker", Provider: "claude"}}},
+		sessionID:   info.ID,
+		sessionName: info.SessionName,
+		identity:    "worker",
+		agent:       config.Agent{Name: "worker", Provider: "claude"},
+	}
+
+	// Text mode: undeliverable → exit 1, message on stderr, and NOTHING enqueued.
+	var stdout, stderr bytes.Buffer
+	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryImmediate, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("deliverSessionNudgeWithWorker = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "undeliverable") || !strings.Contains(stderr.String(), "drained") {
+		t.Fatalf("stderr = %q, want undeliverable/drained", stderr.String())
+	}
+	if pokes != 0 {
+		t.Fatalf("pokes = %d, want 0 (guard fires before the enqueue/poke)", pokes)
+	}
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 0/0/0 (nothing enqueued — no evaporation and no dead-letter)", len(pending), len(inFlight), len(dead))
+	}
+	// The read-only probe must not have stamped a wake request on the session.
+	updated, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got := updated.Metadata["wake_request"]; got != "" {
+		t.Fatalf("wake_request = %q, want empty (probe is read-only)", got)
+	}
+
+	// JSON mode: a structured failure signal — ok=false, queued=false,
+	// outcome="undeliverable", with the state carried in reason.
+	var jstdout, jstderr bytes.Buffer
+	jcode := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryImmediate, true, &jstdout, &jstderr)
+	if jcode != 1 {
+		t.Fatalf("deliverSessionNudgeWithWorker(json) = %d, want 1", jcode)
+	}
+	for _, want := range []string{`"ok":false`, `"queued":false`, `"outcome":"undeliverable"`, `"reason":"drained"`} {
+		if !strings.Contains(jstdout.String(), want) {
+			t.Fatalf("json stdout = %q, want substring %q", jstdout.String(), want)
+		}
+	}
+}
+
 func TestDeliverSessionNudgeWithWorkerManagedWaitNudgeWithdrawFailureKeepsQueuedNudge(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
@@ -1730,6 +1831,48 @@ func TestSendMailNotifyQueuesIndependentRemindersForEachMail(t *testing.T) {
 	}
 	if len(pending) != 2 {
 		t.Fatalf("pending reminders = %d, want 2 (the second mail must not be deduped against the still-unread first); pending=%#v inFlight=%#v dead=%#v", len(pending), pending, inFlight, dead)
+	}
+}
+
+// TestSendMailNotifyWithWorkerLiveBusySessionDoesNotDoubleDeliver is a
+// regression guard for the dual-delivery defect (dip-lq1utb): a live session
+// that stays busy past the WaitIdle window already learns about unread mail at
+// its next prompt boundary via the mail-check hook, so the notify path must
+// NOT also enqueue a queued-nudge reminder — that delivers the same mail
+// through two channels to every session that is actually doing work.
+func TestSendMailNotifyWithWorkerLiveBusySessionDoesNotDoubleDeliver(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "mayor", Title: "Mayor", Command: "claude", WorkDir: dir, Provider: "claude", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{WorkDir: dir}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Recipient stays live but busy: the idle wait times out internally.
+	fake.WaitForIdleErrors[info.SessionName] = context.DeadlineExceeded
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		cfg:         &config.City{Agents: []config.Agent{{Name: "mayor", Provider: "claude"}}},
+		sessionID:   info.ID,
+		sessionName: info.SessionName,
+		identity:    "mayor",
+		agent:       config.Agent{Name: "mayor", Provider: "claude"},
+	}
+
+	if err := sendMailNotifyWithWorker(target, store, fake, "human"); err != nil {
+		t.Fatalf("sendMailNotifyWithWorker: %v", err)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("queued nudges after live-busy timeout = pending %d inFlight %d dead %d, want none (boundary delivery is already guaranteed); pending=%#v", len(pending), len(inFlight), len(dead), pending)
 	}
 }
 

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessiontmux "github.com/gastownhall/gascity/internal/runtime/tmux"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/worker"
 )
@@ -2462,6 +2463,119 @@ func TestCmdNudgeStatusSurfacesDispatchSkips(t *testing.T) {
 	}
 }
 
+// TestTryDeliverQueuedNudgesByPollerTerminalizesReadMailReminders is the
+// falsifier for the mail-nudge echo storm (dip-lvsq3c): a source:mail
+// reminder whose recipient has NO unread mail is purpose-extinct — the mail
+// store is the truth, tmux delivery confirmation is a proxy that fails
+// exactly on busy sessions. The poller must terminalize it as superseded
+// WITHOUT a delivery attempt, across any number of boundaries, instead of
+// re-injecting "You have mail" until the 24h expiry.
+func TestTryDeliverQueuedNudgesByPollerTerminalizesReadMailReminders(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+	if err := enqueueQueuedNudge(dir, newQueuedNudgeWithOptions("worker", "You have mail from human", "mail", now, queuedNudgeOptions{})); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "codex", WorkDir: dir, Provider: "codex", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{WorkDir: dir}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+
+	prevUnread := mailReminderUnreadCount
+	t.Cleanup(func() { mailReminderUnreadCount = prevUnread })
+	mailReminderUnreadCount = func(nudgeTarget, beads.Store) (int, error) { return 0, nil }
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		sessionID:   info.ID,
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: info.SessionName,
+	}
+	obs := worker.LiveObservation{Running: true, LastActivity: &idleSince}
+
+	// Three boundaries: no delivery may happen on any of them.
+	for i := 0; i < 3; i++ {
+		delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs)
+		if err != nil {
+			t.Fatalf("tryDeliverQueuedNudgesByPoller(pass %d): %v", i+1, err)
+		}
+		if delivered {
+			t.Fatalf("pass %d delivered a purpose-extinct mail reminder", i+1)
+		}
+	}
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" || call.Method == "NudgeNow" {
+			t.Fatalf("calls = %#v, want zero injections for a read-mail reminder", fake.Calls)
+		}
+	}
+	// "superseded" retires the item to a terminal bead close — it must leave
+	// every queue list (Dead is only for dead-lettered failures).
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending=%d inFlight=%d dead=%d, want the reminder fully retired as superseded", len(pending), len(inFlight), len(dead))
+	}
+}
+
+// TestTryDeliverQueuedNudgesByPollerKeepsUnreadMailReminders pins the other
+// half of the mail-state gate: while the recipient still HAS unread mail, the
+// reminder is live and must deliver normally.
+func TestTryDeliverQueuedNudgesByPollerKeepsUnreadMailReminders(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+	if err := enqueueQueuedNudge(dir, newQueuedNudgeWithOptions("worker", "You have mail from human", "mail", now, queuedNudgeOptions{})); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "codex", WorkDir: dir, Provider: "codex", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{WorkDir: dir}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+
+	prevUnread := mailReminderUnreadCount
+	t.Cleanup(func() { mailReminderUnreadCount = prevUnread })
+	mailReminderUnreadCount = func(nudgeTarget, beads.Store) (int, error) { return 2, nil }
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		sessionID:   info.ID,
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: info.SessionName,
+	}
+	obs := worker.LiveObservation{Running: true, LastActivity: &idleSince}
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if !delivered {
+		t.Fatal("delivered = false, want true while mail is unread")
+	}
+}
+
 func TestTryDeliverQueuedNudgesByPollerDeliversAndAcks(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
@@ -4226,7 +4340,7 @@ start_command = "echo"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdSessionNudge([]string{"sess-worker", "check", "deploy"}, nudgeDeliveryQueue, true, &stdout, &stderr)
+	code := cmdSessionNudge([]string{"sess-worker", "check", "deploy"}, nudgeDeliveryQueue, "", true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdSessionNudge = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -5161,4 +5275,379 @@ func TestResolveNudgePollInterval(t *testing.T) {
 			t.Fatalf("resolveNudgePollInterval = %v, want default %v", got, defaultNudgePollInterval)
 		}
 	})
+}
+
+// unconfirmedSubmitNudgeProvider reproduces the tmux "submit Enter delivered
+// but busy state never observed" outcome: the keystrokes reached the runtime,
+// but the provider cannot confirm the agent consumed them.
+type unconfirmedSubmitNudgeProvider struct {
+	*runtime.Fake
+}
+
+func (p *unconfirmedSubmitNudgeProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	_ = p.Fake.Nudge(name, content)
+	return fmt.Errorf("%w: session %q", sessiontmux.ErrNudgeSubmitUnconfirmed, name)
+}
+
+// plainFailureNudgeProvider fails delivery with an ordinary (confirmable)
+// error: nothing reached the runtime, so the item keeps the full 5-attempt
+// budget.
+type plainFailureNudgeProvider struct {
+	*runtime.Fake
+}
+
+func (p *plainFailureNudgeProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	_ = p.Fake.Nudge(name, content)
+	return fmt.Errorf("paste buffer write failed for %q", name)
+}
+
+// startNudgePollTargetSession is the shared harness for the poller delivery
+// tests below: it starts a fake session, marks it idle, and returns the
+// target/observation pair tryDeliverQueuedNudgesByPoller expects.
+func startNudgePollTargetSession(t *testing.T, dir string, store beads.NudgesStore, sp runtime.Provider) (nudgeTarget, worker.LiveObservation) {
+	t.Helper()
+	mgr := newSessionManagerWithConfig(dir, store, sp, nil)
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "codex", WorkDir: dir, Provider: "codex", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{WorkDir: dir}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	switch fake := sp.(type) {
+	case *runtime.Fake:
+		fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+	case *unconfirmedSubmitNudgeProvider:
+		fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+	case *plainFailureNudgeProvider:
+		fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+	default:
+		t.Fatalf("unsupported provider %T", sp)
+	}
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		sessionID:   info.ID,
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: info.SessionName,
+	}
+	return target, worker.LiveObservation{Running: true, LastActivity: &idleSince}
+}
+
+// makeQueuedNudgesDueNow drags every pending item's retry delay into the past
+// so the next delivery pass claims it without a real 15s sleep.
+func makeQueuedNudgesDueNow(t *testing.T, dir string) {
+	t.Helper()
+	if err := withNudgeQueueState(dir, func(state *nudgeQueueState) error {
+		for i := range state.Pending {
+			state.Pending[i].DeliverAfter = time.Now().Add(-time.Minute).UTC()
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("withNudgeQueueState: %v", err)
+	}
+}
+
+func countNudgeInjections(calls []runtime.Call) int {
+	n := 0
+	for _, call := range calls {
+		if call.Method == "Nudge" || call.Method == "NudgeNow" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestTryDeliverQueuedNudgesByPollerRetriesFirstUnconfirmedSubmit pins the
+// forgiving half of the could-not-confirm cap: the FIRST unconfirmed submit
+// may genuinely have left the message drafted-but-unsubmitted, so it records
+// as an ordinary failure and earns one retry.
+func TestTryDeliverQueuedNudgesByPollerRetriesFirstUnconfirmedSubmit(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "review the deploy logs", time.Now().Add(-time.Minute))); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	store := openNudgeBeadStore(dir)
+	fake := &unconfirmedSubmitNudgeProvider{Fake: runtime.NewFake()}
+	target, obs := startNudgePollTargetSession(t, dir, store, fake)
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if delivered {
+		t.Fatal("delivered = true, want false for an unconfirmed submit")
+	}
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 1/0/0 (one retry allowed)", len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].Attempts != 1 {
+		t.Fatalf("Attempts = %d, want 1", pending[0].Attempts)
+	}
+}
+
+// TestTryDeliverQueuedNudgesByPollerTerminalizesSecondUnconfirmedSubmit is the
+// falsifier for the re-injection storm (sc-lx6q5t): once TWO submit Enters have
+// reached the runtime for one reminder, the overwhelmingly likely truth is that
+// both landed in a busy session. The item must retire as accepted-for-injection
+// instead of burning the remaining attempts on more echoes.
+func TestTryDeliverQueuedNudgesByPollerTerminalizesSecondUnconfirmedSubmit(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "review the deploy logs", time.Now().Add(-time.Minute))); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	store := openNudgeBeadStore(dir)
+	fake := &unconfirmedSubmitNudgeProvider{Fake: runtime.NewFake()}
+	target, obs := startNudgePollTargetSession(t, dir, store, fake)
+
+	for i := 0; i < 4; i++ {
+		if _, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs); err != nil {
+			t.Fatalf("tryDeliverQueuedNudgesByPoller(pass %d): %v", i+1, err)
+		}
+		makeQueuedNudgesDueNow(t, dir)
+	}
+
+	if got := countNudgeInjections(fake.Calls); got != queuedNudgeUnconfirmedSubmitCeiling {
+		t.Fatalf("submit attempts = %d, want %d", got, queuedNudgeUnconfirmedSubmitCeiling)
+	}
+	// "accepted_for_injection" retires the item to a terminal bead close, so it
+	// leaves every queue bucket (Dead is only for dead-lettered failures).
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want the reminder fully retired", len(pending), len(inFlight), len(dead))
+	}
+}
+
+// TestTryDeliverQueuedNudgesByPollerKeepsFullBudgetForConfirmableFailures pins
+// the untouched half: an ordinary delivery error never reached the agent, so it
+// keeps the full defaultQueuedNudgeMaxAttempts budget.
+func TestTryDeliverQueuedNudgesByPollerKeepsFullBudgetForConfirmableFailures(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "review the deploy logs", time.Now().Add(-time.Minute))); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	store := openNudgeBeadStore(dir)
+	fake := &plainFailureNudgeProvider{Fake: runtime.NewFake()}
+	target, obs := startNudgePollTargetSession(t, dir, store, fake)
+
+	for i := 0; i < 3; i++ {
+		if _, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs); err != nil {
+			t.Fatalf("tryDeliverQueuedNudgesByPoller(pass %d): %v", i+1, err)
+		}
+		makeQueuedNudgesDueNow(t, dir)
+	}
+
+	if got := countNudgeInjections(fake.Calls); got != 3 {
+		t.Fatalf("submit attempts = %d, want 3 (confirmable failures keep retrying)", got)
+	}
+	pending, _, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 || len(dead) != 0 {
+		t.Fatalf("pending/dead = %d/%d, want 1/0 below the %d-attempt cap", len(pending), len(dead), defaultQueuedNudgeMaxAttempts)
+	}
+	if pending[0].Attempts != 3 {
+		t.Fatalf("Attempts = %d, want 3", pending[0].Attempts)
+	}
+}
+
+func TestSplitUnconfirmedSubmitNudges(t *testing.T) {
+	unconfirmed := fmt.Errorf("%w: session %q", sessiontmux.ErrNudgeSubmitUnconfirmed, "sess")
+	items := []queuedNudge{
+		{ID: "fresh", Attempts: 0},
+		{ID: "second", Attempts: 1},
+		{ID: "later", Attempts: 3},
+	}
+
+	retry, presumed := splitUnconfirmedSubmitNudges(unconfirmed, items)
+	if len(retry) != 1 || retry[0].ID != "fresh" {
+		t.Fatalf("retry = %+v, want only the first-attempt item", retry)
+	}
+	if len(presumed) != 2 || presumed[0].ID != "second" || presumed[1].ID != "later" {
+		t.Fatalf("presumed = %+v, want the items whose submit already reached the runtime", presumed)
+	}
+
+	retry, presumed = splitUnconfirmedSubmitNudges(errors.New("paste failed"), items)
+	if len(retry) != len(items) || len(presumed) != 0 {
+		t.Fatalf("retry/presumed = %d/%d, want every item retried for a confirmable failure", len(retry), len(presumed))
+	}
+}
+
+// TestTryDeliverQueuedNudgesByPollerRetiresReminderForClosedBead is the
+// falsifier for purpose-extinct session reminders: a cascade/route reminder
+// about a bead that has since CLOSED has nothing left to say, so it must retire
+// as superseded without ever being injected.
+func TestTryDeliverQueuedNudgesByPollerRetiresReminderForClosedBead(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	subject, err := store.Create(beads.Bead{Title: "blocked work", Type: "task"})
+	if err != nil {
+		t.Fatalf("create subject bead: %v", err)
+	}
+	if err := store.Close(subject.ID); err != nil {
+		t.Fatalf("close subject bead: %v", err)
+	}
+	item := newQueuedNudgeWithOptions("worker", "blocker closed — "+subject.ID+" may be unblocked", "session", time.Now().Add(-time.Minute), queuedNudgeOptions{
+		Reference: &nudgeReference{Kind: "bead", ID: subject.ID},
+	})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	fake := runtime.NewFake()
+	target, obs := startNudgePollTargetSession(t, dir, store, fake)
+
+	for i := 0; i < 3; i++ {
+		delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs)
+		if err != nil {
+			t.Fatalf("tryDeliverQueuedNudgesByPoller(pass %d): %v", i+1, err)
+		}
+		if delivered {
+			t.Fatalf("pass %d delivered a reminder about a closed bead", i+1)
+		}
+	}
+	if got := countNudgeInjections(fake.Calls); got != 0 {
+		t.Fatalf("injections = %d, want 0 for a purpose-extinct reminder", got)
+	}
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want the reminder fully retired as superseded", len(pending), len(inFlight), len(dead))
+	}
+}
+
+// TestTryDeliverQueuedNudgesByPollerDeliversReminderForOpenBead pins the live
+// half of the gate: while the referenced bead is open the reminder still has a
+// purpose and must deliver normally.
+func TestTryDeliverQueuedNudgesByPollerDeliversReminderForOpenBead(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	subject, err := store.Create(beads.Bead{Title: "blocked work", Type: "task"})
+	if err != nil {
+		t.Fatalf("create subject bead: %v", err)
+	}
+	item := newQueuedNudgeWithOptions("worker", "check "+subject.ID, "session", time.Now().Add(-time.Minute), queuedNudgeOptions{
+		Reference: &nudgeReference{Kind: "bead", ID: subject.ID},
+	})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	fake := runtime.NewFake()
+	target, obs := startNudgePollTargetSession(t, dir, store, fake)
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if !delivered {
+		t.Fatal("delivered = false, want true while the referenced bead is open")
+	}
+}
+
+// TestTryDeliverQueuedNudgesByPollerDeliversWhenReferenceUnreadable pins the
+// fail-closed-toward-delivery rule: an unreadable reference (missing bead,
+// store hiccup, a bead owned by another store) must never drop a live reminder.
+func TestTryDeliverQueuedNudgesByPollerDeliversWhenReferenceUnreadable(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	item := newQueuedNudgeWithOptions("worker", "check gc-does-not-exist", "session", time.Now().Add(-time.Minute), queuedNudgeOptions{
+		Reference: &nudgeReference{Kind: "bead", ID: "gc-does-not-exist"},
+	})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	target, obs := startNudgePollTargetSession(t, dir, store, fake)
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if !delivered {
+		t.Fatal("delivered = false, want true when the reference cannot be resolved")
+	}
+}
+
+// TestCmdSessionNudgeAboutStampsBeadReference proves the mint site: the
+// cascade/route orders name the subject bead on the CLI, and that id must
+// survive onto the queued item as a bead Reference — without it the
+// purpose-extinct gate above can never fire in production.
+func TestCmdSessionNudgeAboutStampsBeadReference(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "myrig")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+dir = "myrig"
+provider = "codex"
+start_command = "echo"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sess-worker",
+			"agent_name":   "myrig/worker",
+			"template":     "myrig/worker",
+			"provider":     "codex",
+			"work_dir":     rigDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNudge([]string{"sess-worker", "check", "gc-42"}, nudgeDeliveryQueue, "gc-42", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionNudge = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	pending, _, _, err := listQueuedNudges(cityDir, sessionBead.ID, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending = %d, want 1", len(pending))
+	}
+	if pending[0].Reference == nil {
+		t.Fatal("Reference = nil, want the --about bead stamped on the queued item")
+	}
+	if pending[0].Reference.Kind != "bead" || pending[0].Reference.ID != "gc-42" {
+		t.Fatalf("Reference = %+v, want {bead gc-42}", *pending[0].Reference)
+	}
 }

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2670,6 +2670,7 @@ type sessionNudgeJSON struct {
 	Delivery      string `json:"delivery"`
 	Queued        bool   `json:"queued"`
 	Outcome       string `json:"outcome"`
+	Reason        string `json:"reason,omitempty"`
 }
 
 // cmdSessionNudge is the CLI entry point for "gc session nudge". The about

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2511,6 +2511,7 @@ func sessionKillRuntimeAlreadyInactive(info session.Info, sp runtime.Provider) b
 // newSessionNudgeCmd creates the "gc session nudge <id-or-alias> <message>" command.
 func newSessionNudgeCmd(stdout, stderr io.Writer) *cobra.Command {
 	var delivery string
+	var about string
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "nudge <id-or-alias> <message...>",
@@ -2521,7 +2522,11 @@ The message is delivered as text content to the session's input. This is
 equivalent to typing the message into the session's terminal.
 
 Accepts a session ID or session alias. Multi-word messages are
-joined automatically.`,
+joined automatically.
+
+Pass --about <bead-id> when the nudge is about a specific bead. A nudge
+that has to be queued (the session is busy or asleep) is retired instead
+of delivered if that bead closes before the next safe boundary.`,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			mode, err := parseNudgeDeliveryMode(delivery)
@@ -2529,7 +2534,7 @@ joined automatically.`,
 				fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
-			if cmdSessionNudge(args, mode, jsonOutput, stdout, stderr) != 0 {
+			if cmdSessionNudge(args, mode, about, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -2537,6 +2542,7 @@ joined automatically.`,
 		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().StringVar(&delivery, "delivery", string(nudgeDeliveryWaitIdle), "delivery mode: immediate, wait-idle, or queue")
+	cmd.Flags().StringVar(&about, "about", "", "bead this nudge is about; a queued nudge retires if the bead closes first")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
 	return cmd
 }
@@ -2666,8 +2672,10 @@ type sessionNudgeJSON struct {
 	Outcome       string `json:"outcome"`
 }
 
-// cmdSessionNudge is the CLI entry point for "gc session nudge".
-func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, jsonOutput bool, stdout, stderr io.Writer) int {
+// cmdSessionNudge is the CLI entry point for "gc session nudge". The about
+// argument names the bead the nudge is about (--about); it is stamped on the
+// queued item so a deferred reminder retires when its subject bead closes.
+func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, about string, jsonOutput bool, stdout, stderr io.Writer) int {
 	target := args[0]
 	message := strings.Join(args[1:], " ")
 
@@ -2676,6 +2684,7 @@ func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, jsonOutput bool,
 		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	targetInfo.subjectBeadID = strings.TrimSpace(about)
 	return deliverSessionNudge(targetInfo, message, delivery, jsonOutput, stdout, stderr)
 }
 

--- a/cmd/gc/session_model_phase0_cli_surface_spec_test.go
+++ b/cmd/gc/session_model_phase0_cli_surface_spec_test.go
@@ -69,7 +69,7 @@ func TestPhase0CLISessionTargetingSurfaces_RejectTemplateFactoryTargets(t *testi
 		{
 			name: "gc session nudge",
 			run: func(stdout, stderr *bytes.Buffer) int {
-				return cmdSessionNudge([]string{"template:worker", "hello"}, nudgeDeliveryImmediate, false, stdout, stderr)
+				return cmdSessionNudge([]string{"template:worker", "hello"}, nudgeDeliveryImmediate, "", false, stdout, stderr)
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestPhase0CLISessionTargetingSurfaces_BareConfigNameDoesNotMaterializeOrdin
 		{
 			name: "gc session nudge",
 			run: func(stdout, stderr *bytes.Buffer) int {
-				return cmdSessionNudge([]string{"worker", "hello"}, nudgeDeliveryImmediate, false, stdout, stderr)
+				return cmdSessionNudge([]string{"worker", "hello"}, nudgeDeliveryImmediate, "", false, stdout, stderr)
 			},
 		},
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4133,12 +4133,17 @@ equivalent to typing the message into the session's terminal.
 Accepts a session ID or session alias. Multi-word messages are
 joined automatically.
 
+Pass --about &lt;bead-id&gt; when the nudge is about a specific bead. A nudge
+that has to be queued (the session is busy or asleep) is retired instead
+of delivered if that bead closes before the next safe boundary.
+
 ```
 gc session nudge <id-or-alias> <message...> [flags]
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--about` | string |  | bead this nudge is about; a queued nudge retires if the bead closes first |
 | `--delivery` | string | `wait-idle` | delivery mode: immediate, wait-idle, or queue |
 | `--json` | bool |  | JSON output |
 

--- a/internal/bootstrap/packs/core/assets/scripts/cascade-nudge-on-blocker-close.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/cascade-nudge-on-blocker-close.sh
@@ -127,7 +127,11 @@ while IFS= read -r blocker; do
         fi
         set_rig_args "$dep_id"
         msg="blocker $blocker closed — your dependent $dep_id may be unblocked"
-        if gc session nudge ${RIG_ARG1:+"$RIG_ARG1" "$RIG_ARG2"} "$assignee" "$msg" >/dev/null 2>&1; then
+        # --about names the DEPENDENT bead (the subject of the reminder, not
+        # the blocker that triggered it). A nudge queued against a busy
+        # assignee retires instead of interrupting them if that dependent
+        # closes before their next safe boundary.
+        if gc session nudge --about "$dep_id" ${RIG_ARG1:+"$RIG_ARG1" "$RIG_ARG2"} "$assignee" "$msg" >/dev/null 2>&1; then
             STATE="$(echo "$STATE" | jq --arg k "$key" --arg now "$NOW" '.[$k] = $now')"
             NUDGED=$((NUDGED + 1))
         fi

--- a/internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh
@@ -61,15 +61,21 @@ duration_to_seconds() {
 # pool's active members by template and nudge each; a target with no members
 # (a single-session agent, or an explicit slot name) is nudged directly.
 # Returns 0 if at least one nudge succeeded, non-zero otherwise.
+#
+# --about names the routed bead as the nudge's subject. A busy worker's nudge
+# is queued until its next safe boundary; if the routed bead closes in the
+# meantime the reminder is purpose-extinct and retires instead of interrupting
+# the worker to look for work that is already done.
 nudge_routed_target() {
     _target="$1"
+    _bead="$2"
     _members="$(gc session list --json --state active --template "$_target" 2>/dev/null \
         | jq -r '(.sessions // [])[] | .name // .id' 2>/dev/null)" || _members=""
     if [ -n "$_members" ]; then
         _any=1
         while IFS= read -r _m; do
             [ -n "$_m" ] || continue
-            if gc session nudge "$_m" "$NUDGE_MESSAGE" >/dev/null 2>&1; then
+            if gc session nudge --about "$_bead" "$_m" "$NUDGE_MESSAGE" >/dev/null 2>&1; then
                 _any=0
             fi
         done <<MEMBERS
@@ -77,7 +83,7 @@ $_members
 MEMBERS
         return "$_any"
     fi
-    gc session nudge "$_target" "$NUDGE_MESSAGE" >/dev/null 2>&1
+    gc session nudge --about "$_bead" "$_target" "$NUDGE_MESSAGE" >/dev/null 2>&1
 }
 
 # Pull recent bead.updated events. Best-effort: a read failure (API down)
@@ -115,7 +121,7 @@ while IFS="$(printf '\t')" read -r bead_id routed_to; do
         STATE="$(echo "$STATE" | jq --arg k "$key" --arg now "$NOW" '.[$k] = $now')"
         continue
     fi
-    if nudge_routed_target "$routed_to"; then
+    if nudge_routed_target "$routed_to" "$bead_id"; then
         STATE="$(echo "$STATE" | jq --arg k "$key" --arg now "$NOW" '.[$k] = $now')"
         NUDGED=$((NUDGED + 1))
     fi

--- a/internal/bootstrap/packs/core/pack_orders_test.go
+++ b/internal/bootstrap/packs/core/pack_orders_test.go
@@ -138,6 +138,28 @@ func TestNudgeOnRouteResolvesPoolMembers(t *testing.T) {
 	}
 }
 
+// TestNudgeScriptsNameTheSubjectBead guards the purpose-extinct retirement
+// path (sc-lx6q5t): both nudge orders talk to a possibly-busy worker, so their
+// nudges are routinely QUEUED until the next safe boundary. Without --about the
+// queued item carries no bead reference, and the delivery pass cannot tell that
+// the reminder's subject has closed — so it interrupts the worker to look for
+// work that is already done. The route script must name the routed bead, and
+// the cascade script the DEPENDENT bead (its subject), not the blocker.
+func TestNudgeScriptsNameTheSubjectBead(t *testing.T) {
+	for _, tc := range []struct{ script, want string }{
+		{"assets/scripts/nudge-on-route.sh", `--about "$_bead"`},
+		{"assets/scripts/cascade-nudge-on-blocker-close.sh", `--about "$dep_id"`},
+	} {
+		data, err := fs.ReadFile(PackFS, tc.script)
+		if err != nil {
+			t.Fatalf("reading %s: %v", tc.script, err)
+		}
+		if !strings.Contains(string(data), tc.want) {
+			t.Errorf("%s must name the nudge's subject bead; missing %q", tc.script, tc.want)
+		}
+	}
+}
+
 // TestNotifyOnHumanGateCreationOrder pins the notify-on-human-gate-creation
 // order's event contract: it wakes on bead.created — the event synthesized for
 // any newly-appeared bead — and runs the notify-on-human-gate-creation script.

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -3695,6 +3695,26 @@ func paneContainsBusyIndicator(lines []string) bool {
 			return true
 		}
 	}
+	// Narrow panes defeat the per-line match two ways (observed live on a
+	// 45-col pane, dip rig 2026-08-09): the spinner's parenthetical wraps
+	// across a line break — "(4m 28s" / "· ↓ 11.5k tokens)" — so no single
+	// line matches claudeBusySpinnerRe; and the status footer ellipsizes
+	// "esc to interrupt" down to "esc …". A busy session then reads idle,
+	// every confirmed-submit reports ErrNudgeSubmitUnconfirmed, and the
+	// queued nudge re-delivers forever. Re-run the spinner match over the
+	// joined capture so a wrapped parenthetical is seen whole, and accept
+	// the ellipsized footer fragment ("· esc …"/"• esc …") that only the
+	// busy footer produces.
+	joined := strings.Join(lines, " ")
+	if claudeBusySpinnerRe.MatchString(joined) ||
+		strings.Contains(joined, "esc to interrupt") {
+		return true
+	}
+	for _, sep := range []string{"· esc …", "· esc…", "• esc …", "• esc…"} {
+		if strings.Contains(joined, sep) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/session/wait_store.go
+++ b/internal/session/wait_store.go
@@ -612,3 +612,95 @@ func (s *Store) wakeSessionFromBead(sessionBead beads.Bead, now time.Time) ([]st
 	}
 	return nudgeIDs, nil
 }
+
+// ManagedWakeWouldStrand reports, via a read-only lifecycle projection (it never
+// mutates the session, unlike WakeSession), whether enqueuing a managed nudge-wake
+// for session id would SILENTLY STRAND it: WakeSession would accept the wake with
+// no error, yet the reconciler never brings the session back to running to consume
+// the queued nudge, so the item lingers until its retired fence stops matching and
+// `gc nudge status` reads 0/0/0 while the sender was handed a false "queued"
+// success (the measured sc-875uie bug).
+//
+// This is deliberately NARROW — the completed/stopped states drained and stopped:
+//   - drained: the session finished its drain; the reconciler spawns a FRESH
+//     worker rather than resuming it, so a queued wake is never consumed. This is
+//     exactly the measured case (a nudge queued to a worker as it drained).
+//   - stopped: stopped outside normal sleep semantics — same "won't be resumed to
+//     consume" property.
+//
+// It intentionally does NOT cover the terminal (closed / closing /
+// archived-without-continuity) or gone (missing bead) cases: WakeSession already
+// rejects those with a WakeConflictError / ErrNotFound, so the existing
+// enqueue→wake→rollback path dead-letters them loudly (code 1 + a DEAD trace).
+// Scoping the send-time guard to only the states WakeSession misses keeps this fix
+// off the core session-wake semantics and preserves that established behavior.
+//
+// state is a short diagnostic label ("drained"/"stopped") the caller surfaces as
+// its failure signal. A store lookup error other than not-found is returned bare
+// so the caller can fall back to the existing path rather than misclassify.
+func (s *Store) ManagedWakeWouldStrand(id string, now time.Time) (state string, wouldStrand bool, err error) {
+	b, err := s.store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return "", false, nil // gone → WakeSession errors → existing rollback path handles it
+		}
+		return "", false, err
+	}
+	if !IsSessionBeadOrRepairable(b) {
+		return "", false, nil
+	}
+	RepairEmptyType(s.store.Store, &b)
+	lcInput := LifecycleInputFromMetadata(b.Status, b.Metadata)
+	lcInput.Now = now
+	switch base := ProjectLifecycle(lcInput).BaseState; base {
+	case BaseStateDrained, BaseStateStopped:
+		return string(base), true, nil
+	}
+	return "", false, nil
+}
+
+// ManagedWakeUnreachable reports, via a read-only lifecycle projection (it never
+// mutates the session), whether a nudge ALREADY QUEUED for session id can no longer
+// be consumed because the target session has reached a terminal or stranding
+// lifecycle state. It is the maintenance-time superset of ManagedWakeWouldStrand:
+// the send-time strand probe deliberately covers only the drained/stopped states
+// WakeSession would silently accept, leaving the terminal states to WakeSession's
+// own enqueue-time rejection. The drain-time dead-letter sweep, by contrast, runs
+// AFTER the raced session has often progressed all the way to closed (the
+// reconciler closes a drained pool worker), so it must treat BOTH the terminal
+// wake-conflict states (closed / closing / archived-without-continuity) AND the
+// stranding states (drained / stopped) as unreachable. Archived-WITH-continuity and
+// every live/resumable state (asleep, suspended, active, start-pending) return
+// unreachable=false — those genuinely still consume a queued nudge, so sweeping
+// them would drop a live delivery.
+//
+// A missing session bead (ErrNotFound) returns unreachable=false: at sweep time a
+// freshly-queued nudge can momentarily race ahead of a slow session read, so
+// treating a transient not-found as terminal would drop a legitimate nudge; a
+// genuinely retention-swept bead is caught by the fence-mismatch dead-letter path
+// on the next delivery attempt instead. Any other store error is returned bare so
+// the caller keeps the item rather than misclassify a live target as unreachable.
+func (s *Store) ManagedWakeUnreachable(id string, now time.Time) (state string, unreachable bool, err error) {
+	b, err := s.store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if !IsSessionBeadOrRepairable(b) {
+		return "", false, nil
+	}
+	RepairEmptyType(s.store.Store, &b)
+	lcInput := LifecycleInputFromMetadata(b.Status, b.Metadata)
+	lcInput.Now = now
+	view := ProjectLifecycle(lcInput)
+	if st, conflict := lifecycleWakeConflictState(view); conflict {
+		return st, true, nil
+	}
+	switch view.BaseState {
+	case BaseStateDrained, BaseStateStopped:
+		return string(view.BaseState), true, nil
+	}
+	return "", false, nil
+}

--- a/internal/session/wait_store_managed_wake_strand_test.go
+++ b/internal/session/wait_store_managed_wake_strand_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestManagedWakeWouldStrand_FlagsDrainedAndStoppedOnly pins the send-time
+// loud-fail classification behind the sc-875uie guard. Only the completed/stopped
+// states silently strand a managed nudge-wake (WakeSession accepts them with no
+// conflict, yet the reconciler never resumes them). Live/resumable states keep
+// the queue-a-wake behavior, and terminal/gone states are deliberately left to
+// WakeSession's own conflict/not-found rejection (the enqueue→rollback→dead-letter
+// path), so they must report wouldStrand=false here.
+func TestManagedWakeWouldStrand_FlagsDrainedAndStoppedOnly(t *testing.T) {
+	cases := []struct {
+		name            string
+		seedID          string // "" => do not seed the store (probe a missing id)
+		status          string
+		meta            map[string]string
+		probeID         string
+		wantWouldStrand bool
+		wantState       string // asserted only when wantWouldStrand is true
+	}{
+		{
+			name:            "drained-via-sleep-reason strands (the measured sc-875uie case)",
+			seedID:          "s-drained-sr",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep", "sleep_reason": "drained"},
+			probeID:         "s-drained-sr",
+			wantWouldStrand: true,
+			wantState:       "drained",
+		},
+		{
+			name:            "drained-via-state strands",
+			seedID:          "s-drained",
+			status:          "open",
+			meta:            map[string]string{"state": "drained"},
+			probeID:         "s-drained",
+			wantWouldStrand: true,
+			wantState:       "drained",
+		},
+		{
+			name:            "stopped strands",
+			seedID:          "s-stopped",
+			status:          "open",
+			meta:            map[string]string{"state": "stopped"},
+			probeID:         "s-stopped",
+			wantWouldStrand: true,
+			wantState:       "stopped",
+		},
+		{
+			name:            "asleep does not strand (resumable — keep queuing)",
+			seedID:          "s-asleep",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep"},
+			probeID:         "s-asleep",
+			wantWouldStrand: false,
+		},
+		{
+			name:            "active does not strand",
+			seedID:          "s-active",
+			status:          "open",
+			meta:            map[string]string{"state": "active"},
+			probeID:         "s-active",
+			wantWouldStrand: false,
+		},
+		{
+			name:            "closed is left to WakeSession's conflict rejection",
+			seedID:          "s-closed",
+			status:          "closed",
+			meta:            map[string]string{"state": "closed"},
+			probeID:         "s-closed",
+			wantWouldStrand: false,
+		},
+		{
+			name:            "missing bead is left to WakeSession's not-found rejection",
+			probeID:         "s-missing",
+			wantWouldStrand: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seeds []beads.Bead
+			if tc.seedID != "" {
+				seeds = append(seeds, sessionBeadFixture(tc.seedID, tc.status, tc.meta))
+			}
+			s, _ := recordingWaitStore(t, seeds...)
+			state, wouldStrand, err := s.ManagedWakeWouldStrand(tc.probeID, waitStoreNow)
+			if err != nil {
+				t.Fatalf("ManagedWakeWouldStrand(%q): unexpected error %v", tc.probeID, err)
+			}
+			if wouldStrand != tc.wantWouldStrand {
+				t.Fatalf("ManagedWakeWouldStrand(%q) wouldStrand = %v, want %v (state=%q)", tc.probeID, wouldStrand, tc.wantWouldStrand, state)
+			}
+			if tc.wantWouldStrand && state != tc.wantState {
+				t.Fatalf("ManagedWakeWouldStrand(%q) state = %q, want %q", tc.probeID, state, tc.wantState)
+			}
+		})
+	}
+}
+
+// TestManagedWakeWouldStrand_IsReadOnly asserts the probe never mutates the
+// session — unlike WakeSession, which stamps wake metadata via SetMetadataBatch.
+// Probing a drained session must emit zero writes.
+func TestManagedWakeWouldStrand_IsReadOnly(t *testing.T) {
+	s, rec := recordingWaitStore(t, sessionBeadFixture("s-drained", "open", map[string]string{"state": "asleep", "sleep_reason": "drained"}))
+	if _, _, err := s.ManagedWakeWouldStrand("s-drained", waitStoreNow); err != nil {
+		t.Fatalf("ManagedWakeWouldStrand: %v", err)
+	}
+	if writes := rec.CallsForOp("SetMetadataBatch"); len(writes) != 0 {
+		t.Fatalf("ManagedWakeWouldStrand emitted %d SetMetadataBatch writes, want 0 (must be read-only)", len(writes))
+	}
+}

--- a/internal/session/wait_store_managed_wake_unreachable_test.go
+++ b/internal/session/wait_store_managed_wake_unreachable_test.go
@@ -1,0 +1,124 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestManagedWakeUnreachable_FlagsTerminalAndStranding pins the drain-time
+// dead-letter classification behind the sc-875uie sweep. Unlike the send-time
+// ManagedWakeWouldStrand probe (drained/stopped only), the maintenance-time sweep
+// runs after the raced session has often already reached closed, so it must flag
+// BOTH the terminal wake-conflict states (closed / archived-without-continuity) AND
+// the stranding states (drained / stopped) as unreachable — while still leaving a
+// genuinely resumable session (asleep / active / archived-with-continuity) alone so
+// a queued nudge it will still consume is never dropped.
+func TestManagedWakeUnreachable_FlagsTerminalAndStranding(t *testing.T) {
+	cases := []struct {
+		name            string
+		seedID          string // "" => do not seed the store (probe a missing id)
+		status          string
+		meta            map[string]string
+		probeID         string
+		wantUnreachable bool
+		wantState       string // asserted only when wantUnreachable is true
+	}{
+		{
+			name:            "closed is unreachable (the drained pool worker the reconciler closed)",
+			seedID:          "s-closed",
+			status:          "closed",
+			meta:            map[string]string{"state": "closed"},
+			probeID:         "s-closed",
+			wantUnreachable: true,
+			wantState:       "closed",
+		},
+		{
+			name:            "drained is unreachable (the measured sc-875uie race)",
+			seedID:          "s-drained",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep", "sleep_reason": "drained"},
+			probeID:         "s-drained",
+			wantUnreachable: true,
+			wantState:       "drained",
+		},
+		{
+			name:            "stopped is unreachable",
+			seedID:          "s-stopped",
+			status:          "open",
+			meta:            map[string]string{"state": "stopped"},
+			probeID:         "s-stopped",
+			wantUnreachable: true,
+			wantState:       "stopped",
+		},
+		{
+			name:            "archived-without-continuity is unreachable",
+			seedID:          "s-arch-no",
+			status:          "open",
+			meta:            map[string]string{"state": "archived", "continuity_eligible": "false"},
+			probeID:         "s-arch-no",
+			wantUnreachable: true,
+			wantState:       "archived",
+		},
+		{
+			name:            "archived-with-continuity stays reachable (still resumable)",
+			seedID:          "s-arch-yes",
+			status:          "open",
+			meta:            map[string]string{"state": "archived", "continuity_eligible": "true"},
+			probeID:         "s-arch-yes",
+			wantUnreachable: false,
+		},
+		{
+			name:            "asleep stays reachable (a queued nudge is still consumed on wake)",
+			seedID:          "s-asleep",
+			status:          "open",
+			meta:            map[string]string{"state": "asleep"},
+			probeID:         "s-asleep",
+			wantUnreachable: false,
+		},
+		{
+			name:            "active stays reachable",
+			seedID:          "s-active",
+			status:          "open",
+			meta:            map[string]string{"state": "active"},
+			probeID:         "s-active",
+			wantUnreachable: false,
+		},
+		{
+			name:            "missing bead is not swept (transient-race safe; left to the fence-mismatch path)",
+			probeID:         "s-missing",
+			wantUnreachable: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seeds []beads.Bead
+			if tc.seedID != "" {
+				seeds = append(seeds, sessionBeadFixture(tc.seedID, tc.status, tc.meta))
+			}
+			s, _ := recordingWaitStore(t, seeds...)
+			state, unreachable, err := s.ManagedWakeUnreachable(tc.probeID, waitStoreNow)
+			if err != nil {
+				t.Fatalf("ManagedWakeUnreachable(%q): unexpected error %v", tc.probeID, err)
+			}
+			if unreachable != tc.wantUnreachable {
+				t.Fatalf("ManagedWakeUnreachable(%q) unreachable = %v, want %v (state=%q)", tc.probeID, unreachable, tc.wantUnreachable, state)
+			}
+			if tc.wantUnreachable && state != tc.wantState {
+				t.Fatalf("ManagedWakeUnreachable(%q) state = %q, want %q", tc.probeID, state, tc.wantState)
+			}
+		})
+	}
+}
+
+// TestManagedWakeUnreachable_IsReadOnly asserts the sweep probe never mutates the
+// session it classifies — probing a terminal session must emit zero writes.
+func TestManagedWakeUnreachable_IsReadOnly(t *testing.T) {
+	s, rec := recordingWaitStore(t, sessionBeadFixture("s-closed", "closed", map[string]string{"state": "closed"}))
+	if _, _, err := s.ManagedWakeUnreachable("s-closed", waitStoreNow); err != nil {
+		t.Fatalf("ManagedWakeUnreachable: %v", err)
+	}
+	if writes := rec.CallsForOp("SetMetadataBatch"); len(writes) != 0 {
+		t.Fatalf("ManagedWakeUnreachable emitted %d SetMetadataBatch writes, want 0 (must be read-only)", len(writes))
+	}
+}

--- a/internal/worker/handle_test.go
+++ b/internal/worker/handle_test.go
@@ -1624,6 +1624,9 @@ func TestRuntimeHandleNudgeWaitIdleHonorsCallerContext(t *testing.T) {
 	if result.Delivered {
 		t.Fatal("Nudge(wait_idle) Delivered = true, want false after context cancellation")
 	}
+	if result.Undelivered != "" {
+		t.Fatalf("Nudge(wait_idle) Undelivered = %q, want empty after context cancellation (no downgrade note for a caller-canceled wait)", result.Undelivered)
+	}
 	for _, call := range sp.Calls {
 		if call.Method == "Nudge" || call.Method == "NudgeNow" {
 			t.Fatalf("calls = %#v, want no delivery after context cancellation", sp.Calls)
@@ -1658,6 +1661,9 @@ func TestRuntimeHandleNudgeWaitIdleInternalTimeoutReturnsUndeliveredWithoutError
 	if result.Delivered {
 		t.Fatal("Nudge(wait_idle) Delivered = true, want false after internal timeout")
 	}
+	if result.Undelivered != NudgeUndeliveredNoIdleBoundary {
+		t.Fatalf("Nudge(wait_idle) Undelivered = %q, want %q: a live session that stays busy past the idle window is a named downgrade, not a delivery failure", result.Undelivered, NudgeUndeliveredNoIdleBoundary)
+	}
 	for _, call := range sp.Calls {
 		if call.Method == "Nudge" || call.Method == "NudgeNow" {
 			t.Fatalf("calls = %#v, want no delivery after internal timeout", sp.Calls)
@@ -1689,6 +1695,9 @@ func TestRuntimeHandleNudgeWaitIdleUnsupportedProviderReturnsUndelivered(t *test
 	}
 	if result.Delivered {
 		t.Fatal("Nudge(wait_idle) Delivered = true, want false for unsupported provider")
+	}
+	if result.Undelivered != NudgeUndeliveredProviderUnsupported {
+		t.Fatalf("Nudge(wait_idle) Undelivered = %q, want %q for unsupported provider", result.Undelivered, NudgeUndeliveredProviderUnsupported)
 	}
 	for _, call := range sp.Calls {
 		if call.Method == "WaitForIdle" || call.Method == "Nudge" || call.Method == "NudgeNow" {

--- a/internal/worker/runtime_handle.go
+++ b/internal/worker/runtime_handle.go
@@ -418,6 +418,13 @@ func (h *RuntimeHandle) nudgeWaitIdle(ctx context.Context, req NudgeRequest) (Nu
 		if errors.Is(err, context.Canceled) {
 			return NudgeResult{Delivered: false}, err
 		}
+		if errors.Is(err, runtime.ErrInteractionUnsupported) {
+			// The waiter itself cannot do idle-waits on this runtime: that is the
+			// permanent provider property, not a busy session — a caller must not
+			// read it as "delivered at the next boundary" (there is no boundary
+			// channel to deliver on).
+			return NudgeResult{Delivered: false, Undelivered: NudgeUndeliveredProviderUnsupported}, nil
+		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return NudgeResult{Delivered: false}, ctxErr


### PR DESCRIPTION
## Problem

The mail-reminder (nudge) lifecycle lies in three related ways:

1. **Reminders retire on transport evidence, not state.** A reminder is considered delivered when the send path reports success, even when the receiving session never observed the mail — so a nudge can retire while its message sits unread, and the reminder machinery believes its job is done.
2. **Send/queue outcomes are not truthful at the session boundary.** A send into a dead or unreachable session runtime reports the same success shape as a real delivery; stranded wakes are indistinguishable from received ones.
3. **Supersession judges by inbox-empty, not per-sender.** A reminder is dropped as "superseded" whenever the inbox drains, even if the drain was another sender's traffic — one busy correspondent silently cancels every other sender's pending reminders.

The composite failure: a session misses a nudge, the reminder that existed to cover exactly that case has already retired itself, and no signal remains that anything was lost.

## Fix (three commits, one behavior)

- `fix(nudge): retire reminders on source-of-truth state, not transport` — retirement keys off the receiving session's observed state rather than the send path's return.
- `fix(nudge): make send and queue outcomes truthful at the session boundary` — dead/unreachable runtimes produce distinguishable outcomes; stranded and unreachable wakes are covered by new tests.
- `fix(nudge): mail-reminder supersession judges each reminder by ITS sender, not inbox-empty` — supersession is scoped per-sender, so one correspondent's traffic cannot cancel another's reminder.

## Testing

- ~1,700 lines changed, the bulk new tests: strand/unreachable wake controls in `internal/session`, truthful-outcome coverage in `internal/worker`, per-sender supersession matrix.
- Full `./cmd/gc` (272s), `./internal/session/...`, and `./internal/worker/...` suites green on top of current main (4460d7de2).
- Running in production on our deployment since 2026-08-23; the lost-nudge class it cures was observed live (a coordinator missing its wake reminder because a different sender's mail drained the inbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)