### PR TITLE
fix(reconciler): orphan release retains work the same tick's wake arm will serve

### DIFF
--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -294,7 +294,7 @@ func TestOrphanReleaseSparesALiveHoldersBindingResidentClaim(t *testing.T) {
 	infos := sessionInfosFromBeads([]beads.Bead{sess})
 	released := releaseOrphanedPoolAssignments(
 		work, beads.SessionStore{Store: work}, cfg, cityPath, infos,
-		[]beads.Bead{claim}, []beads.Store{work}, []string{""}, nil,
+		[]beads.Bead{claim}, []beads.Store{work}, []string{""}, nil, nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %v — a LIVE holder's claim was taken back on a leg the release path now reads; that is claim loss, not a strand", released)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2531,7 +2531,12 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
 	assignedWorkStores := result.AssignedWorkStores
 	phaseStart := time.Now()
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores)
+	// Compute the wake-candidate set BEFORE the orphan release, from the same
+	// snapshot the release reads: the release arm must not reopen work the wake
+	// arm of this very tick is about to act on (the release-first ordering plus
+	// snapshot staleness otherwise produces the wake/release/retire treadmill).
+	preWakeCandidates, _ := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, store, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores, protectedWakeWorkIDs(preWakeCandidates))
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
 		"released_count": len(released),
 	})

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2535,8 +2535,8 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// snapshot the release reads: the release arm must not reopen work the wake
 	// arm of this very tick is about to act on (the release-first ordering plus
 	// snapshot staleness otherwise produces the wake/release/retire treadmill).
-	preWakeCandidates, _ := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, store, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores, protectedWakeWorkIDs(preWakeCandidates))
+	preWakeCandidates, preWakeCandidateRefs := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, store, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores, protectedWakeWorkKeys(preWakeCandidates, preWakeCandidateRefs))
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
 		"released_count": len(released),
 	})

--- a/cmd/gc/city_runtime_release_callsite_test.go
+++ b/cmd/gc/city_runtime_release_callsite_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestBeadReconcileTick_OrphanReleaseCallSite_RetainsLiveAndWakeProtectedWork
+// is the production-call-site control for the rebased orphan-release stack
+// (precondition 3.0): it drives the REAL tick — beadReconcileTick — through
+// the snapshot-staleness window and asserts both cures hold AT THE CALL SITE,
+// so a lost or mis-merged hunk at city_runtime.go's release call turns this
+// red rather than leaving a green suite over regressed production code.
+//
+// Two work beads, one per cure:
+//
+//   - W1 (sessionStore cure, upstream 512b79c67 / ga-g3pf0): assigned to a
+//     session whose bead lives ONLY in the relocated sessions-class store.
+//     Its liveness is invisible to the work store; only the call site passing
+//     the typed session store keeps it from being released every tick.
+//     LEG D reachable-red: repoint the call site's sessionStore argument at
+//     the work store and W1 is falsely released — this test MUST fail.
+//
+//   - W2 (protectedWakeWork cure, local ce42c9c7c / gc-ft31x): assigned to
+//     the bare template identity with no session bead anywhere (the
+//     replacement bead is not yet in the pre-tick snapshot), while an open
+//     session of that template makes it reachable to the SAME tick's wake
+//     arm. Only the pre-release wake-candidate exemption retains it.
+//     LEG E reachable-red: drop protectedWakeWorkIDs(preWakeCandidates) from
+//     the call site (pass nil) and W2 is reopened — this test MUST fail.
+//
+// Coverage denominator, stated per the receipt rule: this control covers the
+// beadReconcileTick call site (city_runtime.go). The one-shot path's separate
+// call site in cmd_start.go is NOT covered by this test.
+func TestBeadReconcileTick_OrphanReleaseCallSite_RetainsLiveAndWakeProtectedWork(t *testing.T) {
+	workStore := beads.NewMemStore()
+	sessionStore := beads.NewMemStore() // relocated [beads.classes.sessions] binding
+
+	inProgress := "in_progress"
+
+	// W1: assignee live ONLY in the relocated sessions store.
+	w1, err := workStore.Create(beads.Bead{
+		Title:    "w1 routed work, assignee live in relocated sessions store",
+		Assignee: "worker-w1-live",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create w1: %v", err)
+	}
+	if err := workStore.Update(w1.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("w1 in_progress: %v", err)
+	}
+	if _, err := sessionStore.Create(beads.Bead{
+		Title:  "live session for w1, resident in the sessions class only",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name": "worker-w1-live",
+			"template":     "worker",
+			"agent_name":   "worker",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatalf("create w1 session bead: %v", err)
+	}
+
+	// W2: bare-template assignee, no session bead anywhere (staleness window),
+	// wake-reachable via the open worker session in the snapshot below.
+	w2, err := workStore.Create(beads.Bead{
+		Title:    "w2 routed work in the snapshot-staleness window",
+		Assignee: "worker",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create w2: %v", err)
+	}
+	if err := workStore.Update(w2.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("w2 in_progress: %v", err)
+	}
+
+	// Snapshot: one open worker session whose own identities match neither
+	// assignee — it exists to make W2 wake-reachable through the template key,
+	// exactly the "wake arm is about to serve this" half of the treadmill.
+	snapshotSession := beads.Bead{
+		ID:     "sc-snap-worker",
+		Title:  "open worker session in the pre-tick snapshot",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"template":     "worker",
+			"agent_name":   "worker",
+			"state":        "active",
+		},
+	}
+
+	cfg := &config.City{Agents: []config.Agent{{
+		Name:              "worker",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(2),
+	}}}
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "callsite-control-city",
+		cfg:                 cfg,
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: workStore,
+		storageRoutes: &storageRoutes{stores: map[coordclass.Class]beads.Store{
+			coordclass.ClassSessions: sessionStore,
+		}},
+		sessionDrains: newDrainTracker(),
+		rec:           events.Discard,
+		stdout:        io.Discard,
+		stderr:        io.Discard,
+	}
+
+	result := DesiredStateResult{
+		State:                 map[string]TemplateParams{},
+		AssignedWorkBeads:     []beads.Bead{callsiteControlGet(t, workStore, w1.ID), callsiteControlGet(t, workStore, w2.ID)},
+		AssignedWorkStores:    []beads.Store{workStore, workStore},
+		AssignedWorkStoreRefs: []string{"", ""},
+	}
+
+	cr.beadReconcileTick(context.Background(), result, newSessionBeadSnapshot([]beads.Bead{snapshotSession}), nil, false)
+
+	for _, tc := range []struct {
+		id, assignee, cure string
+	}{
+		{w1.ID, "worker-w1-live", "sessionStore (liveness read must hit the relocated sessions class, not the work store)"},
+		{w2.ID, "worker", "protectedWakeWork (release arm must not reopen work this tick's wake arm serves)"},
+	} {
+		got := callsiteControlGet(t, workStore, tc.id)
+		if got.Assignee != tc.assignee || got.Status != inProgress {
+			t.Errorf("%s was released at the production call site: assignee=%q status=%q, want assignee=%q status=%q — lost cure: %s",
+				tc.id, got.Assignee, got.Status, tc.assignee, inProgress, tc.cure)
+		}
+	}
+}
+
+func callsiteControlGet(t *testing.T, store beads.Store, id string) beads.Bead {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return b
+}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1026,7 +1026,10 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
 	)
 
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores); len(released) > 0 {
+	// Same protection as the daemon tick: wake candidates computed before the
+	// release, so the one-shot path cannot reopen work this run is about to wake.
+	preWakeCandidates, _ := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, oneShotStore, sessionBeads.OpenInfos(), dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores, protectedWakeWorkIDs(preWakeCandidates)); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1028,8 +1028,8 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	// Same protection as the daemon tick: wake candidates computed before the
 	// release, so the one-shot path cannot reopen work this run is about to wake.
-	preWakeCandidates, _ := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, oneShotStore, sessionBeads.OpenInfos(), dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores, protectedWakeWorkIDs(preWakeCandidates)); len(released) > 0 {
+	preWakeCandidates, preWakeCandidateRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, oneShotStore, sessionBeads.OpenInfos(), dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores, protectedWakeWorkKeys(preWakeCandidates, preWakeCandidateRefs)); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/cmd_start_release_callsite_test.go
+++ b/cmd/gc/cmd_start_release_callsite_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestStartStandalone_OrphanReleaseCallSite_RetainsLiveAndWakeProtectedWork is
+// the production-call-site control for the ONE-SHOT release call in
+// doStartStandalone (cmd_start.go) — the second of the two sites, and per the
+// acceptance review the more important one: it is the path that runs when the
+// controller STARTS (a bounce IS a controller start), and it has no follow-up
+// patrol tick to repair a wrong release.
+//
+// Same two-leg discrimination as the daemon-site control
+// (city_runtime_release_callsite_test.go):
+//
+//   - W1 (sessionStore cure): assigned to a running rig-scoped session whose
+//     bead lives ONLY in the relocated sessions-class binding. LEG D
+//     reachable-red: repoint the call site's sessionStore argument at the
+//     work store and W1 is falsely released.
+//   - W2 (protectedWakeWork cure): bare-template assignee with no session
+//     bead of its own, wake-reachable via a running same-template session.
+//     LEG E reachable-red: drop the preWakeCandidates hunk and W2 is
+//     reopened.
+func TestStartStandalone_OrphanReleaseCallSite_RetainsLiveAndWakeProtectedWork(t *testing.T) {
+	cityPath := t.TempDir()
+	clearInheritedBeadsEnv(t)
+	t.Chdir(t.TempDir())
+
+	for _, rig := range []string{"rigA", "rigB"} {
+		if err := os.MkdirAll(filepath.Join(cityPath, rig), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rig, err)
+		}
+	}
+	cityTOML := `[workspace]
+name = "oneshot-callsite-city"
+provider = "shell"
+
+[providers.shell]
+command = "echo"
+
+[beads]
+provider = "file"
+
+[storage.classes]
+work = "work"
+graph = "infra"
+sessions = "infra"
+messaging = "infra"
+orders = "infra"
+nudges = "infra"
+
+[storage.bindings.infra]
+provider = "sqlite-beads"
+path = ".gc/session-class-store"
+
+[[agent]]
+name = "worker"
+scope = "city"
+max_active_sessions = 2
+
+[[agent]]
+name = "rigworker"
+dir = "rigA"
+max_active_sessions = 2
+
+[[rigs]]
+name = "rigA"
+path = "rigA"
+prefix = "ra"
+
+[[rigs]]
+name = "rigB"
+path = "rigB"
+prefix = "rb"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityPath); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, root := range []string{cityPath, filepath.Join(cityPath, "rigA"), filepath.Join(cityPath, "rigB")} {
+		if err := ensurePersistedScopeLocalFileStore(root); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%q): %v", root, err)
+		}
+	}
+
+	rigBStore, err := openScopeLocalFileStore(filepath.Join(cityPath, "rigB"))
+	if err != nil {
+		t.Fatalf("open rigB store: %v", err)
+	}
+	inProgress := "in_progress"
+	seedWorkIn := func(store beads.Store, title, assignee, routedTo string) beads.Bead {
+		t.Helper()
+		wb, err := store.Create(beads.Bead{
+			Title:    title,
+			Assignee: assignee,
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: routedTo},
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", title, err)
+		}
+		if err := store.Update(wb.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+			t.Fatalf("%s in_progress: %v", title, err)
+		}
+		return wb
+	}
+	// W1 lives in rigB's store while its assignee is rigA's session: the
+	// cross-rig claim keeps snapshot-ownership and wake-reachability ref
+	// mismatched, so retention falls to the sessionStore liveness probe —
+	// the argument Leg D mutates.
+	w1 := seedWorkIn(rigBStore, "w1: assignee live only in the relocated sessions binding", "rigworker-w1-live", "rigA/rigworker")
+	w2 := seedWorkIn(rigBStore, "w2: staleness-window bare-template assignee", "worker", "worker")
+	// Keeps the worker-1 session bead owning open work so no sweep closes it
+	// before the release arm needs it for W2's wake reachability.
+	seedWorkIn(rigBStore, "w3: anchors the worker-1 session through sweeps", "worker-1", "worker")
+	// Canary: a genuinely orphaned bead. If the release arm runs at all, this
+	// one MUST be released; it staying assigned means the fixture never
+	// reached the release gates and every retention above is vacuous.
+	w0 := seedWorkIn(rigBStore, "w0 canary: dead assignee, releasable", "ghost-nobody", "worker")
+
+	// Sessions-class beads live ONLY in the relocated binding.
+	sessStore, relocated := cliStorageRoutes(cityPath).storeFor(coordclass.ClassSessions)
+	if !relocated || sessStore == nil {
+		t.Fatalf("sessions class did not relocate to the sqlite binding; storeFor(sessions) relocated=%v", relocated)
+	}
+	seedSession := func(sessionName, template, agentLabel string) {
+		t.Helper()
+		if _, err := sessStore.Create(beads.Bead{
+			Title:  "session " + sessionName,
+			Type:   sessionBeadType,
+			Status: "open",
+			Labels: []string{sessionBeadLabel, "agent:" + agentLabel},
+			Metadata: map[string]string{
+				"session_name": sessionName,
+				"template":     template,
+				"agent_name":   agentLabel,
+				"state":        "active",
+			},
+		}); err != nil {
+			t.Fatalf("create session bead %s: %v", sessionName, err)
+		}
+	}
+	seedSession("rigworker-w1-live", "rigA/rigworker", "rigworker")
+	seedSession("worker-1", "worker", "worker")
+
+	// The provider reports both sessions RUNNING so reconciliation does not
+	// kill their beads before the release arm reads them.
+	fake := runtime.NewFake()
+	for _, name := range []string{"rigworker-w1-live", "worker-1"} {
+		if err := fake.Start(context.Background(), name, runtime.Config{}); err != nil {
+			t.Fatalf("fake start %s: %v", name, err)
+		}
+	}
+	oldBuild := buildSessionProviderByName
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+	buildSessionProviderByName = func(_ *config.City, _ string, _ config.SessionConfig, _, _ string) (runtime.Provider, error) {
+		return fake, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doStartStandalone([]string{cityPath}, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("doStartStandalone exit = %d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+
+	// Reachability canary: the release arm must have actually run and released w0.
+	if got, err := rigBStore.Get(w0.ID); err != nil {
+		t.Fatalf("get canary: %v", err)
+	} else if got.Assignee == "ghost-nobody" {
+		t.Fatalf("canary w0 still assigned — the release arm never gated this fixture; retention assertions are vacuous\nstderr:\n%s", stderr.String())
+	}
+
+	// Bead IDs collide across independent stores (both minted "gc-1"), so each
+	// row carries its own store — the same store-scoped-key lesson
+	// readyAssignedFlagsForBeads documents.
+	for _, tc := range []struct {
+		store              beads.Store
+		id, assignee, cure string
+	}{
+		{rigBStore, w1.ID, "rigworker-w1-live", "sessionStore (one-shot liveness read must hit the relocated sessions class, not the work store)"},
+		{rigBStore, w2.ID, "worker", "protectedWakeWork (one-shot release must not reopen work this run's wake arm serves)"},
+	} {
+		got, err := tc.store.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", tc.id, err)
+		}
+		if got.Assignee != tc.assignee || got.Status != inProgress {
+			t.Errorf("%s was released at the one-shot call site: assignee=%q status=%q, want assignee=%q status=%q — lost cure: %s\nstderr:\n%s",
+				tc.id, got.Assignee, got.Status, tc.assignee, inProgress, tc.cure, stderr.String())
+		}
+	}
+}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -666,6 +666,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			StoreQueryPartial:  true,
 		},
 		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %d work bead(s) from a partial snapshot, want none", len(released))
@@ -690,6 +691,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			SessionQueryPartial: true,
 		},
 		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %d work bead(s) from a partial session snapshot, want none", len(released))
@@ -712,6 +714,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			AssignedWorkBeads:  []beads.Bead{work},
 			AssignedWorkStores: []beads.Store{store},
 		},
+		nil,
 		nil,
 	)
 	if len(released) != 1 {

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -187,7 +187,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveAssigneeStaysAssigned(t *testin
 		"",
 		sessionInfosFromBeads([]beads.Bead{live}),
 		[]beads.Bead{work},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("live assignee must not be released, got %v", released)
@@ -242,7 +242,7 @@ func TestReleaseOrphanedPoolAssignments_NilSessionsStoreFallsBackToWorkStore(t *
 		"",
 		nil, // empty snapshot: the two snapshot gates miss, so the live re-read decides
 		[]beads.Bead{work},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("a live assignee was released with a nil sessions store, got %v; "+

--- a/cmd/gc/execution_stalled_convergence_test.go
+++ b/cmd/gc/execution_stalled_convergence_test.go
@@ -178,7 +178,7 @@ func TestExecutionStalledDrainConvergesToAReclaimableRow(t *testing.T) {
 		t.Fatalf("re-reading the claim: %v", err)
 	}
 	released := releaseOrphanedPoolAssignments(h.env.store, beads.SessionStore{Store: h.env.store}, h.env.cfg, "", nil,
-		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil)
+		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil, nil)
 	if len(released) != 1 || released[0].ID != h.work.ID {
 		t.Fatalf("released = %+v, want the stalled claim reopened", released)
 	}
@@ -308,7 +308,7 @@ func TestExecutionStalledDrainDoesNotStrandAMidDrainWake(t *testing.T) {
 		t.Fatalf("re-reading the claim: %v", err)
 	}
 	released := releaseOrphanedPoolAssignments(h.env.store, beads.SessionStore{Store: h.env.store}, h.env.cfg, "", nil,
-		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil)
+		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil, nil)
 	if len(released) != 1 {
 		t.Fatalf("released = %+v, want the claim released once its holder is gone", released)
 	}

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -142,6 +142,7 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	openSessionInfos []session.Info,
 	result DesiredStateResult,
 	rigStores map[string]beads.Store,
+	protectedWakeWork map[string]struct{},
 ) []releasedPoolAssignment {
 	// Partial input snapshots can make active work look orphaned for this
 	// tick only: missing work affects drain decisions, and missing sessions
@@ -149,7 +150,29 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	if result.snapshotQueryPartial() {
 		return nil
 	}
-	return releaseOrphanedPoolAssignments(store, sessionStore, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores)
+	return releaseOrphanedPoolAssignments(store, sessionStore, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores, protectedWakeWork)
+}
+
+// protectedWakeWorkIDs indexes the wake-candidate slice by bead ID for the
+// release arm's retain check. The release pass runs BEFORE the wake arm inside
+// one reconcile tick, over the same pre-tick session snapshot; work the wake
+// arm is about to act on must not be judged orphaned by the arm that ran first
+// (retain rather than reap). Without this, a release in the snapshot-staleness
+// window also removes the work from the tick's wake demand, the session
+// reconciler then retires the now-workless slot it just created, and the
+// reopened work re-creates demand next tick — a wake/release/retire treadmill
+// (observed live 12x on one identity).
+func protectedWakeWorkIDs(wakeCandidates []beads.Bead) map[string]struct{} {
+	if len(wakeCandidates) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(wakeCandidates))
+	for _, wb := range wakeCandidates {
+		if id := strings.TrimSpace(wb.ID); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
 }
 
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
@@ -176,6 +199,7 @@ func releaseOrphanedPoolAssignments(
 	assignedWorkStores []beads.Store,
 	assignedWorkStoreRefs []string,
 	rigStores map[string]beads.Store,
+	protectedWakeWork map[string]struct{},
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
@@ -226,6 +250,15 @@ func releaseOrphanedPoolAssignments(
 	var released []releasedPoolAssignment
 	for i, wb := range assignedWorkBeads {
 		if wb.Status != "open" && wb.Status != "in_progress" {
+			continue
+		}
+		// Retain work the same tick's wake arm is about to act on: the release
+		// pass runs first over a pre-tick snapshot in which a replacement
+		// session bead may not exist yet, and releasing here both drops a live
+		// claim and starves the wake demand that would have protected the slot.
+		// Uncertainty about session materialization is not permission to reopen
+		// work (retain rather than reap, gc-ft31x).
+		if _, ok := protectedWakeWork[wb.ID]; ok {
 			continue
 		}
 		assignee := strings.TrimSpace(wb.Assignee)

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -142,7 +142,7 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	openSessionInfos []session.Info,
 	result DesiredStateResult,
 	rigStores map[string]beads.Store,
-	protectedWakeWork map[string]struct{},
+	protectedWakeWork map[storeScopedBeadKey]struct{},
 ) []releasedPoolAssignment {
 	// Partial input snapshots can make active work look orphaned for this
 	// tick only: missing work affects drain decisions, and missing sessions
@@ -153,26 +153,41 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	return releaseOrphanedPoolAssignments(store, sessionStore, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores, protectedWakeWork)
 }
 
-// protectedWakeWorkIDs indexes the wake-candidate slice by bead ID for the
-// release arm's retain check. The release pass runs BEFORE the wake arm inside
-// one reconcile tick, over the same pre-tick session snapshot; work the wake
-// arm is about to act on must not be judged orphaned by the arm that ran first
-// (retain rather than reap). Without this, a release in the snapshot-staleness
-// window also removes the work from the tick's wake demand, the session
-// reconciler then retires the now-workless slot it just created, and the
-// reopened work re-creates demand next tick — a wake/release/retire treadmill
-// (observed live 12x on one identity).
-func protectedWakeWorkIDs(wakeCandidates []beads.Bead) map[string]struct{} {
+// protectedWakeWorkKeys indexes the wake-candidate slice by store ref + bead ID
+// for the release arm's retain check. The release pass runs BEFORE the wake arm
+// inside one reconcile tick, over the same pre-tick session snapshot; work the
+// wake arm is about to act on must not be judged orphaned by the arm that ran
+// first (retain rather than reap). Without this, a release in the
+// snapshot-staleness window also removes the work from the tick's wake demand,
+// the session reconciler then retires the now-workless slot it just created,
+// and the reopened work re-creates demand next tick — a wake/release/retire
+// treadmill (observed live 12x on one identity).
+//
+// AssignedWorkBeads can carry the same bead ID from independent city and rig
+// stores (storeScopedBeadKey), so a plain-ID key would let a wake candidate in
+// one store shield a genuinely orphaned same-ID bead in another.
+// wakeCandidateStoreRefs is the second return of
+// filterAssignedWorkBeadsForSessionWake and is index-aligned with
+// wakeCandidates; an empty refs slice means the caller had no refs either, and
+// both sides then key under "".
+func protectedWakeWorkKeys(wakeCandidates []beads.Bead, wakeCandidateStoreRefs []string) map[storeScopedBeadKey]struct{} {
 	if len(wakeCandidates) == 0 {
 		return nil
 	}
-	ids := make(map[string]struct{}, len(wakeCandidates))
-	for _, wb := range wakeCandidates {
-		if id := strings.TrimSpace(wb.ID); id != "" {
-			ids[id] = struct{}{}
+	scoped := len(wakeCandidateStoreRefs) == len(wakeCandidates)
+	keys := make(map[storeScopedBeadKey]struct{}, len(wakeCandidates))
+	for i, wb := range wakeCandidates {
+		id := strings.TrimSpace(wb.ID)
+		if id == "" {
+			continue
 		}
+		ref := ""
+		if scoped {
+			ref = wakeCandidateStoreRefs[i]
+		}
+		keys[storeScopedBeadKey{StoreRef: ref, ID: id}] = struct{}{}
 	}
-	return ids
+	return keys
 }
 
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
@@ -199,7 +214,7 @@ func releaseOrphanedPoolAssignments(
 	assignedWorkStores []beads.Store,
 	assignedWorkStoreRefs []string,
 	rigStores map[string]beads.Store,
-	protectedWakeWork map[string]struct{},
+	protectedWakeWork map[storeScopedBeadKey]struct{},
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
@@ -252,13 +267,17 @@ func releaseOrphanedPoolAssignments(
 		if wb.Status != "open" && wb.Status != "in_progress" {
 			continue
 		}
+		workStoreRef := ""
+		if storeRefAware {
+			workStoreRef = assignedWorkStoreRefs[i]
+		}
 		// Retain work the same tick's wake arm is about to act on: the release
 		// pass runs first over a pre-tick snapshot in which a replacement
 		// session bead may not exist yet, and releasing here both drops a live
 		// claim and starves the wake demand that would have protected the slot.
 		// Uncertainty about session materialization is not permission to reopen
 		// work (retain rather than reap, gc-ft31x).
-		if _, ok := protectedWakeWork[wb.ID]; ok {
+		if _, ok := protectedWakeWork[storeScopedBeadKey{StoreRef: workStoreRef, ID: wb.ID}]; ok {
 			continue
 		}
 		assignee := strings.TrimSpace(wb.Assignee)
@@ -282,10 +301,6 @@ func releaseOrphanedPoolAssignments(
 				continue
 			}
 		} else {
-			workStoreRef := ""
-			if storeRefAware {
-				workStoreRef = assignedWorkStoreRefs[i]
-			}
 			if openSessionOwnsWork(legacyOpenIdentifiers, openIdentifiers, assignee, workStoreRef, storeRefAware) {
 				continue
 			}

--- a/cmd/gc/pool_session_name_orphan_release_fanout_test.go
+++ b/cmd/gc/pool_session_name_orphan_release_fanout_test.go
@@ -73,6 +73,7 @@ func countOrphanReleaseLiveSessionLists(t *testing.T, workBeadCount int) int {
 		stores,
 		storeRefs,
 		nil,
+		nil,
 	)
 	return store.liveSessionLists
 }
@@ -201,6 +202,7 @@ func TestReleaseOrphanedPoolAssignments_OwnerStoreMemoDoesNotCollapseDistinctSto
 				tc.work,
 				tc.store,
 				tc.refs,
+				nil,
 				nil,
 			)
 

--- a/cmd/gc/pool_session_name_protected_wake_test.go
+++ b/cmd/gc/pool_session_name_protected_wake_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// seedProtectedWakeWork creates an in_progress pool-routed work bead whose
+// assignee has NO open session bead — the exact snapshot-staleness shape in
+// which the release arm historically reopened work the same tick's wake arm
+// was about to serve (release runs first over the shared pre-tick snapshot;
+// the reopened work is then filtered out of wake demand, the reconciler
+// retires the now-workless slot, and the reopened work re-creates demand next
+// tick — the wake/release/retire treadmill).
+func seedProtectedWakeWork(t *testing.T) (*beads.MemStore, beads.Bead) {
+	t.Helper()
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "routed work",
+		Assignee: "worker-mc-gone",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set in_progress: %v", err)
+	}
+	work, _ = store.Get(work.ID)
+	return store, work
+}
+
+// A work bead in the protected wake set must be RETAINED even though its
+// assignee has no open session bead: the wake arm of this very tick is about
+// to act on it, and uncertainty about session materialization is not
+// permission to reopen work.
+func TestReleaseOrphanedPoolAssignments_RetainsProtectedWakeWork(t *testing.T) {
+	store, work := seedProtectedWakeWork(t)
+
+	released := releaseOrphanedPoolAssignments(
+		store, beads.SessionStore{Store: store}, testPoolReleaseConfig(), "", nil,
+		[]beads.Bead{work}, []beads.Store{store}, nil, nil,
+		map[string]struct{}{work.ID: {}},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released %v — protected wake work was reopened; the release arm ran ahead of the wake arm it must yield to", released)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-read work: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-mc-gone" {
+		t.Fatalf("work mutated despite protection: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+// The empty protected set preserves existing behavior exactly: the same bead
+// with no protection is released (the genuine dead-assignee recovery this
+// sweep exists for must keep working).
+func TestReleaseOrphanedPoolAssignments_EmptyProtectedSetStillReleases(t *testing.T) {
+	store, work := seedProtectedWakeWork(t)
+
+	released := releaseOrphanedPoolAssignments(
+		store, beads.SessionStore{Store: store}, testPoolReleaseConfig(), "", nil,
+		[]beads.Bead{work}, []beads.Store{store}, nil, nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want exactly the dead-assignee bead %s", released, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-read work: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("unprotected dead-assignee work not reopened: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+// Protection is keyed on the work bead's ID alone, independent of identity
+// spelling or store residency: an alias-assigned bead in a rig owner store is
+// retained the same way (the guard must not depend on the alias/store-ref
+// liveness fixes that already exist — it protects precisely the case they
+// cannot see).
+func TestReleaseOrphanedPoolAssignments_ProtectsAliasAssignedRigWork(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	ownerStore := beads.NewMemStore()
+	work, err := ownerStore.Create(beads.Bead{
+		Title:    "rig routed work",
+		Assignee: "r-dog/gastown.furiosa",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := ownerStore.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set in_progress: %v", err)
+	}
+	work, _ = ownerStore.Get(work.ID)
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore, beads.SessionStore{Store: cityStore}, testPoolReleaseConfig(), "", nil,
+		[]beads.Bead{work}, []beads.Store{ownerStore}, nil, nil,
+		map[string]struct{}{work.ID: {}},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released %v — alias-assigned rig-store work was reopened despite wake protection", released)
+	}
+	got, err := ownerStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-read work: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "r-dog/gastown.furiosa" {
+		t.Fatalf("work mutated despite protection: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}

--- a/cmd/gc/pool_session_name_protected_wake_test.go
+++ b/cmd/gc/pool_session_name_protected_wake_test.go
@@ -43,7 +43,7 @@ func TestReleaseOrphanedPoolAssignments_RetainsProtectedWakeWork(t *testing.T) {
 	released := releaseOrphanedPoolAssignments(
 		store, beads.SessionStore{Store: store}, testPoolReleaseConfig(), "", nil,
 		[]beads.Bead{work}, []beads.Store{store}, nil, nil,
-		map[string]struct{}{work.ID: {}},
+		map[storeScopedBeadKey]struct{}{{ID: work.ID}: {}},
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %v — protected wake work was reopened; the release arm ran ahead of the wake arm it must yield to", released)
@@ -105,7 +105,7 @@ func TestReleaseOrphanedPoolAssignments_ProtectsAliasAssignedRigWork(t *testing.
 	released := releaseOrphanedPoolAssignments(
 		cityStore, beads.SessionStore{Store: cityStore}, testPoolReleaseConfig(), "", nil,
 		[]beads.Bead{work}, []beads.Store{ownerStore}, nil, nil,
-		map[string]struct{}{work.ID: {}},
+		map[storeScopedBeadKey]struct{}{{ID: work.ID}: {}},
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %v — alias-assigned rig-store work was reopened despite wake protection", released)
@@ -116,5 +116,71 @@ func TestReleaseOrphanedPoolAssignments_ProtectsAliasAssignedRigWork(t *testing.
 	}
 	if got.Status != "in_progress" || got.Assignee != "r-dog/gastown.furiosa" {
 		t.Fatalf("work mutated despite protection: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+// Protection is store-scoped: a wake candidate in one store must not shield a
+// genuinely orphaned bead that happens to share its ID in another store.
+// AssignedWorkBeads carries colliding IDs across independent city and rig
+// stores by design (storeScopedBeadKey), so keying the protected set on the
+// bead ID alone strands the same-ID row in every other store forever — the
+// retain check sits ahead of the liveness probes, so nothing downstream can
+// undo it.
+func TestReleaseOrphanedPoolAssignments_ProtectionDoesNotCrossStoreIDCollision(t *testing.T) {
+	inProgress := "in_progress"
+	seed := func(store beads.Store, title, assignee string) beads.Bead {
+		t.Helper()
+		wb, err := store.Create(beads.Bead{
+			Title:    title,
+			Assignee: assignee,
+			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "worker"},
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", title, err)
+		}
+		if err := store.Update(wb.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+			t.Fatalf("set %s in_progress: %v", title, err)
+		}
+		wb, err = store.Get(wb.ID)
+		if err != nil {
+			t.Fatalf("re-read %s: %v", title, err)
+		}
+		return wb
+	}
+
+	// Two independent stores each mint their own "gc-1": storeA holds the wake
+	// candidate under ref "", storeB holds a genuinely orphaned bead of the
+	// same ID under ref "rig:b".
+	storeA := beads.NewMemStore()
+	storeB := beads.NewMemStore()
+	aWork := seed(storeA, "storeA wake candidate", "worker-a-waking")
+	bWork := seed(storeB, "storeB orphan sharing storeA's bead ID", "worker-mc-gone")
+	if aWork.ID != bWork.ID {
+		t.Fatalf("fixture needs colliding IDs across stores, got %q and %q", aWork.ID, bWork.ID)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		storeA, beads.SessionStore{Store: storeA}, testPoolReleaseConfig(), "", nil,
+		[]beads.Bead{aWork, bWork}, []beads.Store{storeA, storeB}, []string{"", "rig:b"}, nil,
+		protectedWakeWorkKeys([]beads.Bead{aWork}, []string{""}),
+	)
+	if len(released) != 1 || released[0].ID != bWork.ID {
+		t.Fatalf("released = %v, want exactly storeB's %s — storeA's wake candidate shielded a same-ID bead in another store", released, bWork.ID)
+	}
+
+	gotB, err := storeB.Get(bWork.ID)
+	if err != nil {
+		t.Fatalf("re-read storeB work: %v", err)
+	}
+	if gotB.Status != "open" || gotB.Assignee != "" {
+		t.Fatalf("storeB orphan not reopened: status=%q assignee=%q", gotB.Status, gotB.Assignee)
+	}
+
+	gotA, err := storeA.Get(aWork.ID)
+	if err != nil {
+		t.Fatalf("re-read storeA work: %v", err)
+	}
+	if gotA.Status != inProgress || gotA.Assignee != "worker-a-waking" {
+		t.Fatalf("storeA wake candidate lost its protection: status=%q assignee=%q", gotA.Status, gotA.Assignee)
 	}
 }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -2286,6 +2286,7 @@ func releaseProbeAssignments(store *conditionalReleaseProbeStore, work beads.Bea
 		[]beads.Store{store},
 		nil,
 		nil,
+		nil,
 	)
 }
 
@@ -2488,7 +2489,7 @@ func releaseOrphanedPoolAssignmentsFromBeads(
 	}
 	// Single-store fixtures: the session class resolves to the work store, which
 	// is what a city without a [storage.classes] sessions binding does.
-	return releaseOrphanedPoolAssignments(store, beads.SessionStore{Store: store}, cfg, cityPath, infos, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores)
+	return releaseOrphanedPoolAssignments(store, beads.SessionStore{Store: store}, cfg, cityPath, infos, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores, nil)
 }
 
 // gcSweepSessionBeadsFromBeads projects raw session beads to session.Info and
@@ -2590,6 +2591,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveModernPoolSessionWhenLiveListMi
 		nil, // open-session snapshot also misses the live session
 		[]beads.Bead{work},
 		[]beads.Store{store},
+		nil,
 		nil,
 		nil,
 	)

--- a/cmd/gc/pool_session_release_owner_store_test.go
+++ b/cmd/gc/pool_session_release_owner_store_test.go
@@ -86,6 +86,7 @@ func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromWorkOwnerStore(t *testin
 		[]beads.Store{ownerStore},
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -135,6 +136,7 @@ func TestReleaseOrphanedPoolAssignmentsReleasesWhenNoStoreHoldsTheSession(t *tes
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{ownerStore},
+		nil,
 		nil,
 		nil,
 	)

--- a/cmd/gc/pool_session_release_session_store_test.go
+++ b/cmd/gc/pool_session_release_session_store_test.go
@@ -85,6 +85,7 @@ func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromSessionStore(t *testing.
 		[]beads.Store{workStore},
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -121,6 +122,7 @@ func TestReleaseOrphanedPoolAssignmentsStillReleasesWhenSessionStoreSaysDead(t *
 		[]beads.Store{workStore},
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 1 || released[0].ID != work.ID {
@@ -155,6 +157,7 @@ func TestReleaseOrphanedPoolAssignmentsFallsBackToWorkStoreForLiveness(t *testin
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{single},
+		nil,
 		nil,
 		nil,
 	)

--- a/cmd/gc/pool_slot_unaliased_test.go
+++ b/cmd/gc/pool_slot_unaliased_test.go
@@ -320,6 +320,7 @@ func TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim(t *testing.T) {
 		[]beads.Store{store},
 		nil,
 		nil,
+		nil,
 	)
 	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s] — a stale slot-form assignee names no live session once pool beads are unaliased", released, work.ID)

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -336,6 +336,7 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 		sessionInfosFromBeads([]beads.Bead{sess}),
 		got, stores, refs,
 		e.rigStores,
+		nil,
 	)
 	wantReleased := []string{dead.ID, hqDead.ID}
 	releasedIDs := make(map[string]bool, len(released))


### PR DESCRIPTION
## Problem

Inside one reconcile tick, the orphan-release arm runs BEFORE the wake filter, over a shared pre-tick session snapshot (`beadReconcileTick` in city_runtime.go; same order in the `cmd_start` one-shot path). When an assignee's replacement session bead is not yet in that snapshot, the release arm reopens the work — which also removes it from the tick's wake demand — so the session reconciler retires the now-workless slot (`poolFreeable && !hasAssignedWork`), and the reopened work re-creates demand next tick.

The result is a wake/release/retire treadmill. Observed live: 12 consecutive cycles against one identity, session bead lifetime 74s each, close_reason `pool slot retired by reconciler`.

## Why the existing guards don't cover this

Two adjacent cures are already on main and this patch complements both:

- The sessionStore class fix (512b79c67) cures the *wrong-store* liveness read (an empty-success List reading as "assignee dead").
- `releaseOrphanedPoolAssignmentsWhenSnapshotsComplete` skips release when the snapshot query is **partial**.

This window is different: the snapshot is **complete but stale** — the query succeeded fully; the successor session simply did not exist yet at query time. The completeness guard passes, and the release proceeds against work the same tick's wake arm was about to serve.

## Fix (retain rather than reap)

Compute the wake-candidate set before the release, from the same snapshot, and pass its bead IDs to the release loop as a protected set: the release arm retains protected work. An empty/nil set preserves existing behavior exactly. Applied at both call sites — the daemon tick and the one-shot start path (the bounce path, where no follow-up tick exists to repair a wrong release).

Production delta is 47 lines across three files; the rest is tests.

## Testing

- `pool_session_name_protected_wake_test.go` — the retain-vs-release decision matrix.
- `city_runtime_release_callsite_test.go` and `cmd_start_release_callsite_test.go` — call-site controls that drive the REAL production paths through the snapshot-staleness window and assert the cure holds where it executes, at both sites.
- Full `./cmd/gc` suite green on top of current main (4460d7de2).
- Running in production on our deployment since 2026-08-18: the 12x treadmill has not recurred (retire-event lifetime analysis since deploy shows only normal demand-scale-down closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)