### PR TITLE
ci: skip image rebuild dispatch in forks

### DIFF
--- a/.github/workflows/notify-image-build.yaml
+++ b/.github/workflows/notify-image-build.yaml
@@ -27,6 +27,10 @@ permissions: {}
 
 jobs:
   notify:
+    # Forks intentionally lack the canonical cross-repository dispatch token.
+    # Skip there instead of turning every upstream fast-forward red; the exact
+    # repository guard keeps a missing/invalid canonical secret fail-visible.
+    if: github.repository == 'gastownhall/gascity'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger runtime image rebuild

--- a/scripts/ci_critical_path_test.go
+++ b/scripts/ci_critical_path_test.go
@@ -1286,3 +1286,18 @@ func readCriticalPathWorkflow(t *testing.T, name string) ciCriticalPathWorkflow 
 	}
 	return wf
 }
+
+// Fork main branches receive every upstream fast-forward, but they do not and
+// should not carry the canonical repository's cross-repository dispatch token.
+// Keep that expected fork run green while preserving a hard failure if the
+// canonical publisher loses its secret or dispatch permission.
+func TestNotifyImageRebuildsRunsOnlyInCanonicalRepository(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "notify-image-build.yaml")
+	notify, ok := wf.Jobs["notify"]
+	if !ok {
+		t.Fatal("notify-image-build workflow has no notify job")
+	}
+	if got, want := notify.If, "github.repository == 'gastownhall/gascity'"; got != want {
+		t.Fatalf("notify job if = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Summary:
- run the cross-repository image rebuild dispatch only in gastownhall/gascity
- let fork fast-forward runs skip cleanly without the canonical dispatch token
- keep missing or invalid canonical credentials fail-visible

Why:
Forks intentionally do not carry GASCITY_HOSTED_TOKEN. Their Notify Image Rebuilds jobs currently fail immediately before any build or dispatch occurs.

Tests:
- go test -count=1 ./scripts
- repository pre-commit hook
- repository full fast push gate (all 10 jobs passed)