### PR TITLE
fix(backstop): escalate instead of skipping when an agent has no nudge configured

### DIFF
--- a/cmd/gc/execution_backstop.go
+++ b/cmd/gc/execution_backstop.go
@@ -301,10 +301,15 @@ func (p poolExecutionBackstop) exhausted(store beads.Store, s *beads.Bead, stdou
 	}, "execution-claim-nudge", stdout) {
 		return
 	}
-	p.emitStepStalled(s, beadID, atoiOr0(s.Metadata[executionClaimNudgeCountKey]))
+	// Report the attempts actually DELIVERED, not the cap. An agent with no
+	// configured nudge escalates at 0/3 having never been contacted, and an
+	// operator reading "after 3 attempts" there would go looking for three
+	// nudges that were never sent.
+	attempts := atoiOr0(s.Metadata[executionClaimNudgeCountKey])
+	p.emitStepStalled(s, beadID, attempts)
 	fmt.Fprintf(stdout, //nolint:errcheck // best-effort
-		"execution-claim-nudge: %s still holds %s unexecuted after %d attempts; draining (%s)\n",
-		sessName, beadID, idleClaimNudgeMaxAttempts, executionStalledDrainReason)
+		"execution-claim-nudge: %s still holds %s unexecuted after %d/%d nudge attempts; draining (%s)\n",
+		sessName, beadID, attempts, idleClaimNudgeMaxAttempts, executionStalledDrainReason)
 	if p.requestDrain == nil || sessName == "" {
 		return
 	}

--- a/cmd/gc/execution_backstop_test.go
+++ b/cmd/gc/execution_backstop_test.go
@@ -302,3 +302,64 @@ func TestExecutionStepStalledStaysOffTheExportAllowlist(t *testing.T) {
 		t.Fatal("execution.step_stalled is on the redacted-export allowlist; that is an egress-surface change and needs its own review")
 	}
 }
+
+// TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured is the
+// production row this backstop was missing. `agent.Nudge` is optional, and in a
+// real city every workflow pool template leaves it unset — maintainer-city had
+// it on 18 of 260 agents and on none of its four pool roles. The shared engine
+// skipped empty content with a bare `continue`, so the state machine parked on
+// its observe marker forever: it never reserved an attempt, never reached the
+// attempt cap, and so never ran the drain that is the ONLY thing that releases
+// the claim. A seat holding an in-progress bead still satisfies poolDesired, so
+// no replacement spawns and the whole pool starves behind it. Observed: 20 of 21
+// live markers frozen at count=0, the oldest claim held 3.5 days.
+//
+// With nothing to deliver there is nothing to wait for — the bounded attempts
+// exist to give the agent a chance to ANSWER a nudge. The grace window still
+// applies, and then it escalates.
+func TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.cfg.Agents[0].Nudge = "" // the maintainer-city pool templates, verbatim
+	f.idleFor(t, 10*time.Minute)
+
+	f.tick(t) // first sighting: start the grace clock, escalate nothing yet
+	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != f.work.ID {
+		t.Fatalf("observed work marker = %q, want %q", got, f.work.ID)
+	}
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests inside the grace window = %v, want none", f.drained)
+	}
+
+	f.now = f.now.Add(idleClaimNudgeGrace + time.Second)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t)
+
+	if got := f.nudgeCount(); got != 0 {
+		t.Fatalf("delivered nudges with no configured nudge = %d, want 0", got)
+	}
+	if len(f.drained) != 1 || f.drained[0] != f.sessName {
+		t.Fatalf("drain requests = %v, want exactly one for %s; stdout=%s", f.drained, f.sessName, f.stdout.String())
+	}
+	if f.sessionMeta(t, executionClaimNudgeStalledKey) == "" {
+		t.Fatal("escalation was not latched; a later tick would drain the session all over again")
+	}
+
+	// Latched: however many ticks follow, exactly one drain and one event.
+	for i := 0; i < 3; i++ {
+		f.now = f.now.Add(idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+	if len(f.drained) != 1 {
+		t.Fatalf("drain requests after further ticks = %v, want exactly one", f.drained)
+	}
+	stalled := 0
+	for _, e := range f.rec.Events {
+		if e.Type == events.ExecutionStepStalled {
+			stalled++
+		}
+	}
+	if stalled != 1 {
+		t.Fatalf("execution.step_stalled events = %d, want exactly 1", stalled)
+	}
+}

--- a/cmd/gc/nudge_backstop.go
+++ b/cmd/gc/nudge_backstop.go
@@ -178,10 +178,6 @@ func runNudgeBackstop(
 			pred.exhausted(store, s, stdout)
 			continue
 		case backstopActionNudge:
-			content := pred.content(*s)
-			if content == "" {
-				continue
-			}
 			switch pred.revalidate(target) {
 			case backstopResolutionHold:
 				continue
@@ -189,8 +185,24 @@ func runNudgeBackstop(
 				pred.clear(store, s, stdout)
 				continue
 			case backstopResolutionOutstanding:
-				// Reserve below.
+				// Deliver below.
 			default:
+				continue
+			}
+			content := pred.content(*s)
+			if content == "" {
+				// Nothing is deliverable for this session. `agent.Nudge` is
+				// optional and pool templates routinely leave it unset, so this
+				// is the common case, not the exotic one. Skipping silently
+				// parks the state machine on its observe marker forever: no
+				// attempt is ever reserved, the cap is never reached, and the
+				// predicate's terminal action never runs — which for the
+				// execution backstop is the drain that is the only thing that
+				// releases the claim. The bounded attempts exist to give the
+				// agent a chance to ANSWER a nudge; with no nudge to send there
+				// is nothing to wait for, so go straight to the terminal action
+				// after the same grace window.
+				pred.exhausted(store, s, stdout)
 				continue
 			}
 			// Write ahead of the external delivery. If the process crashes


### PR DESCRIPTION
## The defect

`runNudgeBackstop` (`cmd/gc/nudge_backstop.go`) skipped delivery whenever the
predicate resolved empty nudge content:

```go
content := pred.content(*s)
if content == "" {
    continue        // silent, every tick, forever
}
```

`content` for the execution backstop is `claimNudgeFor()`, which returns the
agent template's `agent.Nudge`. **That field is optional**, and pool templates
routinely leave it unset — so this is the common case, not the exotic one.

The consequence is not "no nudge is sent". It is that the state machine
**parks on its observe marker permanently**: it writes
`execution_claim_nudge_at` with `count=0`, then bails at the same line on
every subsequent tick. No attempt is ever reserved, the attempt cap is never
reached, and `pred.exhausted()` never runs.

For `poolExecutionBackstop`, `exhausted()` is the **only** caller of
`requestDrain` — the drain is the convergence step, not a notification.
Nothing else releases the claim: the session is alive so no crash lane touches
it, and the bead is `in_progress` so no claim probe wants it. Meanwhile a seat
holding an in-progress claim still satisfies `poolDesired`, so no replacement
spawns and the rest of the pool starves behind it. There is no log line on
this path, so it is invisible.

## Evidence from a live city

- 18 of 260 resolved agents had a `nudge` configured; **none of the four
  workflow pool roles did**.
- 25 live `execution_claim_nudge_work` markers, 20 of them frozen at
  `count=0`, spanning nine days. Oldest claim held **3.5 days**.
- `execution_claim_nudge_stalled` was non-empty on **exactly one bead in the
  store's entire history** — the single affected template that *does* carry a
  nudge. It reached `count=3` and drained correctly. That is the control: the
  engine, the pacing, the latch and the drain all work. The only thing that
  was broken was reaching them.

## The fix

Empty content falls through to the terminal action instead of skipping. The
bounded attempts exist to give an agent a chance to *answer* a nudge; with no
nudge to send there is nothing to wait for, so escalate after the same grace
window.

`revalidate` moved **ahead** of the content check so an escalation can never
fire on a claim that completed under the snapshot — the ordering matters more
now that the empty-content branch has a side effect.

Safe for the sibling predicate: `poolClaimBackstop.exhausted` is a no-op, so
the pool-claim backstop's behaviour is unchanged.

The exhaustion log line now reports the attempts actually **delivered**
(`0/3`) rather than hardcoding the cap. An operator reading "after 3 attempts"
on a session that was never contacted would go looking for three nudges that
do not exist.

## Test

`TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured` — the
fixture previously always configured a nudge, which is precisely why this case
was never exercised. The row asserts: nothing inside the grace window; then
zero nudges delivered, exactly one drain, and a latched stall marker; and
after three further ticks still exactly one drain and one
`execution.step_stalled` event.

Verified red first: it failed at the drain assertion with empty stdout before
the change.

## Generalisable shape

An unset optional config field silently disabled a P0 convergence mechanism —
no warning, no log line, no `gc doctor` check. Worth a follow-up sweep for
other optional fields that gate terminal actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3554 — addresses the stuck-claim half of that symptom: a pool session holding an unexecuted claim whose agent template has no nudge configured now escalates and releases the claim after the grace window instead of parking on its observe marker forever, so the seat stops starving the pool; it does not add the per-step auto-advance through the work formula that the filed issue asks for

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->