### PR TITLE
Proposal: CI throughput toward the 10K changes/day horizon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,10 @@ These decisions are final. Do not revisit them.
 - **`engdocs/contributors/release-gate-criteria-conventions.md`** — What the
   "Tests pass" criterion in a `release-gates/*.md` file must cite. Apply this
   before signing off that criterion on any deploy gate.
+- **`specs/adr/`** — Short-form architectural decision records. Add one only
+  when a decision is hard to reverse, surprising without context, and a real
+  trade-off. `CONTEXT.md` at the repo root is the shared glossary for terms
+  outside the six-primitive model; challenge new vocabulary against it.
 
 ## Key design principles
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,70 @@
+# Gas City
+
+Shared language for the Gas City platform. The six primitives (Agent, Bead,
+Formula, Rig, Pack, Event) are defined normatively in
+`docs/getting-started/how-gas-city-works.md`; this glossary covers terms that
+crystallized outside that model.
+
+## Change admission and verification
+
+**Logical change**:
+One independently attributable behavior change, selectively reversible or
+repairable subject to its dependency closure.
+_Avoid_: commit, PR, diff (a logical change need not map one-to-one to any of
+them)
+
+**Parent outcome**:
+The user-visible result requested by the originating Bead or formula run;
+reported beside logical-change throughput so decomposition cannot manufacture
+apparent value.
+
+**Measured resource**:
+A constrained resource on owned infrastructure whose sustainable service curve
+is established by controlled saturation testing.
+
+**Modeled resource**:
+A constrained resource that cannot be saturation-tested (the forge, human
+work); its capacity is claimed only through a registered capacity model.
+
+**Capacity model**:
+A registered claim about a modeled resource's sustainable capacity, naming its
+evidence basis, the largest canary that validated it, and an extrapolation
+factor capped relative to that canary.
+
+**Bounds ledger**:
+The checked TOML file holding every registered bound, budget, assumption, and
+ratchet; a bound is registered for a run only when the commit recording it
+predates that run.
+_Avoid_: "registered" without a ledger entry
+
+**Ratchet**:
+A bound anchored to a measured baseline that must not regress and is
+re-derived at each sustained doubling of accepted-change volume, rather than a
+fixed horizon value.
+
+**Admission latency**:
+Ready-to-canonical latency over the merge-group and batch build population —
+the runs that actually admit code. Distinct from the developer-facing PR
+feedback SLO in `TESTING.md`.
+
+**Full-suite-equivalent (FSE)**:
+The unit of verification compute: one full-union suite priced at the SHA
+pinned in the bounds ledger. Re-priced only at explicit re-baselining entries.
+
+**Intervention**:
+A counted, forge-attributable manual action on the admission path (rerun,
+dequeue, manual rebase, forced merge). The unit of the human-work budget.
+_Avoid_: human minutes (no collection mechanism; minutes come only from
+sampled time studies)
+
+**Base-advance rerun**:
+A rerun of an identical patch (same `git patch-id`) against a new base SHA.
+Classified mechanically, never by judgment.
+
+**Flake**:
+An identical patch and base that fails and then passes under the registered
+rerun criterion.
+
+**External value anchor**:
+An output metric produced outside the beads/formula loop (user-facing issues
+closed, shipped release-notes entries) that scheduled automation cannot mint.

--- a/specs/adr/0001-measured-vs-modeled-resources.md
+++ b/specs/adr/0001-measured-vs-modeled-resources.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+---
+
+# Measured vs. modeled resources, with bounds in a checked ledger
+
+The CI-throughput program (`specs/proposals/0001-increasing-ci-throughput.md`)
+needs capacity claims about resources it can never saturation-test: GitHub's
+publication path and human work. Pretending to measure them created a
+contradiction (Phase 0 demanded saturation curves that Phase 7 rightly forbade
+generating against github.com). We split constrained resources into
+**measured** (owned infrastructure — runners, caches, queues, the beads
+ledger, the event bus — with real saturation curves) and **modeled** (forge,
+humans — a registered capacity model with a named validating canary and an
+extrapolation cap of 20× that canary). Every registered bound lives in the
+checked ledger `specs/proposals/0001-bounds.toml`, guarded by a docsync test;
+a bound counts as registered for a run only when its commit predates that run,
+so git history is the audit trail. Because the 10,000/day figure is
+directional, bounds are ratchets anchored to measured baselines, re-derived at
+each sustained volume doubling — not fixed horizon values.
+
+Considered and rejected: a fake-forge simulator presented as measurement
+(relaunders the contradiction); absolute horizon bounds (start red at 500× the
+current volume and teach people to ignore them); human-minutes budgets (no
+collection mechanism exists — interventions are counted from forge audit
+records instead, converted to minutes only by sampled time study).

--- a/specs/proposals/0001-bounds.toml
+++ b/specs/proposals/0001-bounds.toml
@@ -1,0 +1,78 @@
+# Registered bounds for the CI-throughput program
+# (specs/proposals/0001-increasing-ci-throughput.md).
+#
+# A bound is "registered" for a phase run only when the commit recording it
+# predates that run's SHA; this file's git history is the audit trail.
+# Guarded by TestThroughputBoundsLedger in test/docsync. Rationale for the
+# measured/modeled split and this ledger: specs/adr/0001-measured-vs-modeled-resources.md.
+#
+# The 10,000/day figure is directional: bounds below are ratchets anchored to
+# measured baselines, not fixed horizon values. "phase0" / "phase3-pilot"
+# means the baseline is registered by that phase's measurement and the ratchet
+# holds from there.
+
+[meta]
+owner = "csells"
+registered = 2026-08-23
+proposal = "0001-increasing-ci-throughput.md"
+rederive = "re-derive every ratchet at each sustained doubling of accepted-change volume"
+
+[workload]
+burst_basis = "measured arrival distribution 2026-07-21..2026-08-21: peak hour 24x the trailing-month hourly average (19 vs 0.8 changes/hr), peak day 2.9x the daily average; re-registered from measurement at each volume doubling"
+
+[workload.shape_mix]
+hot_repo = 0.55
+fleet = 0.20
+shared_core = 0.15
+cross_repo = 0.10
+
+[publication]
+compression_min_changes_per_pr = 10
+forge_headroom = 0.30
+basis = "GitHub recommendation of 1 merged PR/min and 6 pushes/min per repository (docs: repository-limits); 6.94/(1-0.30) = 9.9, rounded up"
+
+[compute]
+fse_pin_sha = "4460d7de282063dd861a8d17fa9559858a538046"
+floor_fse_per_change = 0.2
+ratchet = "Phase 0 registers the measured baseline; never regress above it; target -25% per quarter until the floor"
+current_estimate_fse = 0.57
+estimate_basis = "84 of 300 recent main commits (28%) touch shared paths and force full-union runs; filtered runs estimated at ~0.4 FSE; replaced by the Phase 0 measurement"
+
+[human]
+unit = "interventions per accepted change (rerun, dequeue, manual rebase, forced merge; counted from forge audit records)"
+bound = "Phase 0 registers the measured baseline; the per-change rate must not rise as volume grows; alert at 2x baseline"
+minutes_conversion = "quarterly sampled time study with stated error; minutes are never self-reported continuously"
+current_observation = "0 rerun-clicks in the last 100 completed workflow runs, sampled 2026-08-23"
+
+[queue]
+admission_slo = "ready-to-canonical p95/p99 over the merge-group and batch build population"
+bound = "Phase 3's merge-queue pilot registers the measured baseline; never regress above it"
+drain_max = "2x burst duration after any registered burst"
+creation_to_ready = "hard p95 ratchet (from Phase 0 baseline) for dependency-free changes only; reported distribution with drift alerting for changes with dependencies"
+amplification_max_phase3 = 2.0
+amplification_max_stress = 1.5
+
+[safety]
+miss_rate_reviewed_max = 0.001
+miss_rate_auto_admitted_max = 0.0001
+audit_fraction_min = 0.05
+confidence = 0.95
+min_audited_runs = 3000
+observation_window_days = 14
+exposure_restatement = "expected escapes per day = bound x accepted volume; recomputed and re-accepted at each sustained volume doubling"
+
+[flakes]
+per_job_flake_assumed_max = 0.003
+classification = "a failure is a flake when the identical patch-id and base pass on one rerun; a rerun of an identical patch-id on a new base is a base-advance rerun"
+quarantine = "any test flaking 3 times in 7 days is quarantined with an owner and expiry"
+replaced_by = "Phase 0 measurement of the real per-job flake rate"
+
+[model]
+extrapolation_cap = 20
+forge_canary = "1 merged PR/min sustained for 60 minutes, run at Phase 4 entry; the capacity model may claim at most extrapolation_cap x its largest validating canary"
+
+[value_anchor]
+metrics = [
+  "user-facing GitHub issues closed per week",
+  "shipped release-notes entries per week",
+]

--- a/specs/proposals/0001-bounds.toml
+++ b/specs/proposals/0001-bounds.toml
@@ -30,6 +30,15 @@ cross_repo = 0.10
 compression_min_changes_per_pr = 10
 forge_headroom = 0.30
 basis = "GitHub recommendation of 1 merged PR/min and 6 pushes/min per repository (docs: repository-limits); 6.94/(1-0.30) = 9.9, rounded up"
+batch_merge_structure = "single-change publications may squash; a multi-change batch publishes as a merge commit carrying one rebased commit per logical change in dependency order; batches are never squashed"
+batch_overlap = "changes touching the same hunks share a batch only when dependency-related; a dependency-closed subgraph reverts as a unit or not at all"
+
+[admission]
+coverage_min_at_500_per_day = 0.5
+coverage_min_at_2000_per_day = 0.9
+coverage_min_at_10000_per_day = 0.99
+exception_rate_max = 0.005
+human_touch_budget = "daily budget of routine reviews + exceptions + interventions, registered from Phase 0 measured team capacity; sustained volume growth is gated on staying inside it"
 
 [compute]
 fse_pin_sha = "4460d7de282063dd861a8d17fa9559858a538046"

--- a/specs/proposals/0001-increasing-ci-throughput
+++ b/specs/proposals/0001-increasing-ci-throughput
@@ -1,0 +1,665 @@
+# Proposal: Increating CI Throughput to 10K Changes/Day
+
+TODO: update the pipeline to include directing the agents up front to make small, targeted changes to reduce their blast radius and therefore reduce the required tests to validate and... profit!
+
+TODO: bias towards multiple components in a monorepo, multiple repos, multiple services, etc. that are smallest and can be hardened independently with a smaller blast radius then "the entire system" with the tests filtered as appropriate.
+
+## From CI Queueing to Incremental, Reusable Verification
+
+**Gas City Engineering White Paper — Discussion Draft**  
+**August 21, 2026**
+
+> **Central objective:** Build an engineering system that can absorb **10,000 agent-generated logical changes per day**, while keeping the canonical branch trustworthy and avoiding proportional growth in CI compute or human review.
+
+> **Core thesis:** _Agents make changes. The system establishes facts. Policy decides what ships. Humans govern policy and handle exceptions._
+
+---
+
+## Executive Summary
+
+Gas City and Gas Town are already encountering a constraint that will become existential in an agent-heavy software factory: **code can now be produced faster than it can be admitted safely into the canonical branch**. The visible symptoms are familiar. A pull request becomes green; another pull request merges; `main` moves; the first PR must be rebased or restaged; expensive checks run again. Meanwhile, the arrival rate of new changes exceeds the throughput of CI. The result is a queue whose cost grows faster than the useful work it is protecting.
+
+This paper treats the target of **10,000 agentic changes per day** as the design requirement, not a distant aspiration. Ten thousand logical changes per 24 hours is about **417 per hour, 6.94 per minute, or one every 8.6 seconds on average**. Bursty working periods will be materially higher. If a complete verification cycle takes `T` minutes and each logical change requires a fresh full run, the steady-state concurrency required merely to keep up is approximately `6.94 × T`. A 20-minute full cycle implies about 139 concurrent full validations; a 30-minute cycle implies about 208 — before failures, retries, flakes, rebases, or queue churn.
+
+There are two coupled problems:
+
+1. **Moving-main invalidation.** Correctness is usually attached to a PR/commit SHA. When the base SHA changes, CI treats prior evidence as stale even when nothing relevant to that evidence changed.
+2. **Verification throughput.** Even with a perfect merge queue, the system can still demand more tests, builds, static analysis, and integration work than available compute can execute.
+
+Current systems attack important pieces. GitHub Merge Queue and Zuul speculatively test future integration states. Bors, Prow/Tide, Gas Town's Refinery design, Mergify, Aviator, and Graphite batch changes to amortize CI. Mergify, Trunk, and Aviator add scope- or target-aware parallel lanes. Bazel/Blaze, Buck2, Pants, and Nx use dependency graphs and content-addressed caches to avoid recomputing work whose inputs have not changed. Google's Rosie and TAP infrastructure showed how sharding, transitive affected-test selection, union testing, and anomaly-oriented review can drive thousands of automated source changes per day.
+
+The recommended near-term OSS experiment for Gas City is:
+
+**GitHub + Zuul (or an enhanced Gas Town Refinery) + Pants + Buildbarn/bazel-remote**, while keeping current GitHub Actions/Blacksmith execution where convenient. The queue layer establishes the future source states that need validation. Pants supplies fine-grained affectedness and precise process caching. Buildbarn (or bazel-remote for cache-only) shares results across workers. Refinery remains strategically interesting as the Gas Town-native coordinator, especially if it adopts Zuul-style speculative gating and scope-aware lanes.
+
+But that stack still leaves a deeper gap. Merge queues know **which source state** must be tested. Build systems know **which computations** can be reused. They do not provide a general mechanism for deciding whether an arbitrary correctness claim remains valid after the source graph changes.
+
+> **Don't re-establish a fact unless something that fact depends on has changed.**
+
+This paper proposes the missing abstraction as an **open verification graph**: a content-addressed graph in which each evidence node states a proposition, identifies the exact inputs and verifier that established it, and depends on content or other evidence nodes. A change to `main` invalidates only the downstream evidence whose actual dependencies changed. Everything else remains valid and reusable across PRs, agents, integration states, and CI workers.
+
+The strategic claim is therefore not “make CI faster.” It is:
+
+> **At 10,000 agentic changes per day, verification must become incremental, compositional, and reusable.**
+
+---
+
+## 1. The Design Requirement: 10,000 Agentic Changes per Day
+
+A **logical change** in this paper is one independently attributable proposed modification to source or configuration. It may be generated by a human, one coding agent, a swarm, a codemod, a dependency bot, or an automated optimizer. It does **not** have to map one-to-one to a GitHub pull request.
+
+That distinction matters. GitHub currently recommends no more than **one merged pull request per minute per repository** and six pushes per minute per repository. At 10,000 logical changes per day, one-change-per-PR would average almost seven merged PRs per minute continuously — roughly seven times GitHub's recommended per-repository merge rate. [4]
+
+Therefore a 10,000-change system eventually needs to distinguish:
+
+- **Logical changes:** independently generated, attributable, verifiable, revertible units.
+- **Integration transactions:** groups or sequences validated together.
+- **Publication transactions:** the smaller number of Git pushes/PR merges used to materialize accepted logical changes.
+
+The 10,000/day target also changes the economics of CI. Faster runners help only linearly. If generation scales by 10× while every change still triggers a complete validation universe, the organization simply purchases 10× more verification capacity — and still pays again every time `main` moves. That is not a scalable architecture.
+
+The desired system should instead make **marginal verification cost proportional to the new uncertainty introduced by a change**, not proportional to the size of the repository or the existence of a new commit SHA.
+
+## 2. The Immediate Problem at Gas City and Gas Town
+
+### 2.1 The moving-main loop
+
+The maintainer workflow is currently vulnerable to a destructive loop:
+
+```text
+PR B passes against main@100
+        ↓
+PR A merges → main@101
+        ↓
+B is now stale
+        ↓
+rebase/restage B
+        ↓
+rerun CI
+        ↓
+PR C merges → main@102
+        ↓
+repeat
+```
+
+This work is not merely annoying. It is **proof churn**: a previously established body of evidence is discarded because its base revision identifier changed, even when the facts being established had no dependency on the preceding change.
+
+GitHub's own documentation describes merge queues as a solution to the ordering problem: `merge_group` branches include the current base plus changes ahead in the queue. [3] Gas City's current CI workflow listens to `push` on `main` and `pull_request`, but not `merge_group`; it already contains substantial optimization machinery, including path-sensitive suite selection, a conservative `shared` barrier, affected-package linting, runner selection, caching, and sharding. [1]
+
+That matters: this is **not** a case where the team simply forgot to parallelize CI. Gas City is already applying the normal bag of tricks.
+
+### 2.2 Verification throughput
+
+The second problem appears when the rate of ready changes exceeds the rate at which the verification system can establish that they are safe. Even a fully automated rebase/retest loop can saturate. If each queued change requires another expensive integration state, the queue may continue growing while every available runner is busy.
+
+This is the more fundamental bottleneck in an agentic system. Models make code generation cheaper; the admission system does not become cheaper automatically.
+
+### 2.3 Gas Town Refinery already points toward batching
+
+Gas Town's architecture assigns the Refinery agent responsibility for merge processing and verification. The current architecture document specifies a **Bors-style batch-then-bisect** strategy: stack multiple merge requests on `main`, test the tip once, fast-forward the whole batch if green, and binary-bisect a failing batch. [2]
+
+That is a legitimate and important optimization. It converts `N` successful changes from `N` complete CI validations into approximately one validation per batch. The current architecture document also shows that this work is phased: parallel gates are listed as in progress, with batch-then-bisect and pre-verification following. [2]
+
+Batching reduces work, but it does not by itself answer what happens when changes are independent, when only one verifier's inputs changed, or when evidence from a failed speculative branch is still valid for another candidate.
+
+## 3. The Underlying Queueing Failure
+
+Traditional PR CI largely uses the commit SHA as an invalidation boundary:
+
+```text
+new SHA → new CI run → re-establish everything
+```
+
+That is conservative and simple, but extremely coarse. In a high-change-rate repository, each merge changes the base SHA and can invalidate many in-flight results. Prow/Tide documents this behavior explicitly: whenever a PR merges, existing test results for other PRs become stale and retesting is required. [20]
+
+The ideal invalidation question is not:
+
+> “Did the commit SHA change?”
+
+It is:
+
+> “Did any input to this particular verifier change?”
+
+For example:
+
+```text
+Evidence: unit tests for internal/mail
+Depends on:
+  internal/mail/**
+  transitive Go dependencies
+  relevant fixtures
+  go.mod / go.sum where applicable
+  Go toolchain digest
+  test command + flags
+  verifier implementation version
+
+A dashboard-only PR merges.
+None of those inputs changed.
+Therefore: the evidence is still valid.
+```
+
+This shift — from revision invalidation to dependency invalidation — is the key to making verification cost grow sublinearly with change volume.
+
+## 4. What Google Learned: Rosie, TAP, and Blaze
+
+Google encountered a related scaling problem long before LLM coding agents. Its large-scale-change infrastructure had to generate, test, review, and submit huge numbers of mechanically produced changes against a constantly evolving monorepo.
+
+### 4.1 Rosie: shard the logical change
+
+Google's Software Engineering at Google describes Rosie as the platform that splits a large master change into independently testable/reviewable/submittable shards. It can test, mail, review, and submit thousands of changes per day. [5]
+
+The important lesson is not that Rosie is a merge queue. It is that Google stopped treating a giant source transformation as one human-sized review transaction. The system creates many small, independently admissible units and manages them as cattle rather than pets.
+
+### 4.2 TAP: test affected transitive closure, then exploit union economics
+
+For each shard, Google's Large-Scale Change pipeline runs the transitive closure of tests that may be affected. When too many shards affect too many tests, TAP can group them: run the **union** of affected tests for the whole set, then use failures to determine which individual shards need narrower retesting. The Google SWE book notes that once a union is already large, adding additional similar changes can be nearly free. [5]
+
+Google also describes a “TAP train”: sample tests for candidate changes, combine the passing changes into an uber-change, run the union of affected tests, then isolate nonflaky failures back to individual changes. [5]
+
+That is directly relevant to the 10,000/day target: **share verification across changes instead of forcing every change to buy an isolated universe.**
+
+### 4.3 Review only anomalies when the change class permits it
+
+Rosie also attacks human-review throughput. Global approvers use pattern-based tooling to automatically approve expected changes and manually inspect the anomalous subset. [5] This is a precursor to the broader agentic thesis: humans define and govern the acceptance regime; routine instances flow automatically; unusual cases escalate.
+
+### 4.4 Blaze/Bazel: make computation reusable by exact inputs
+
+A terminology correction is useful here: **Blaze is Google's internal build system lineage; Bazel is its open-source relative. Meta/Facebook's analogous system is Buck/Buck2.** [7][10]
+
+Blaze/Bazel's critical contribution is precise, reproducible action identity. Bazel breaks work into actions with declared inputs, output names, command line, and environment. Its remote cache maps action hashes to results and stores artifacts in a content-addressable store. If the same action with the same inputs has already succeeded, the output can be reused instead of recomputed. [8]
+
+Google's distributed build documentation describes the internal stack around Blaze, including ObjFS for cached build outputs and Forge for remote execution. [9]
+
+The conceptual breakthrough is simple:
+
+> **A change to the repository should invalidate only the computations whose inputs changed.**
+
+### 4.5 Steve Yegge's connection: Grok as code-intelligence substrate
+
+Public sources most directly document Steve Yegge as the leader of Google's Grok project, a language-neutral code-intelligence platform. Steve's own writing describes Grok as powering automated refactoring infrastructure and explicitly calls out Rosie as a tool used to automate large migrations. [6]
+
+For this proposal, Grok's lesson is as important as Rosie's: **high-scale automation needs an explicit machine-readable graph of code relationships**, not just file diffs and shell scripts.
+
+## 5. Current Proprietary Solution Space
+
+No current commercial product appears to deliver the complete end state proposed here, but several have already converged on important components.
+
+| Product            | What it solves              | Key mechanism                                                                                                                              | What remains                                                                                 |
+| ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| GitHub Merge Queue | Moving-main ordering        | `merge_group` future-state validation, up to 100 concurrent builds                                                                         | Does not combine merge-group builds; CI work still scales with validation states [3]         |
+| Mergify            | Queue throughput + CI cost  | Speculative checks, scope-aware parallel queues, batching, automatic splitting/bisection; batch lineage can inherit check results          | Reuse is queue/batch-lineage-oriented, not a general proof graph [11][12]                    |
+| Trunk Merge Queue  | Independent-lane throughput | Impacted-target dynamic queues; predictive cumulative testing; pending failure depth reuses downstream evidence against flaky predecessors | Reuse is structural/queue-specific rather than arbitrary verifier dependency reuse [13][14]  |
+| Aviator MergeQueue | High-volume monorepo queues | Affected targets, parallel queues, configurable batching, bisection                                                                        | Does not generalize result validity beyond queue/target logic [15][16]                       |
+| Graphite           | Stack-heavy teams           | Stack-aware speculative parallel CI, fast-forward reuse, batching                                                                          | Strong stack optimization; not a generic affectedness/evidence system [17]                   |
+| Develocity         | Test throughput             | Predictive test selection, build cache, test distribution; avoids re-running tests that already passed for identical inputs                | Probabilistic and primarily test/build-tool focused; not an integration admission graph [18] |
+
+The trend is clear. Commercial merge-queue vendors are moving from FIFO queues toward **dependency-aware DAG scheduling**, because simple serial queues cannot keep up when CI duration exceeds change arrival intervals. Commercial test platforms are separately moving toward **input-aware test reuse**. The seam between those two categories is where the proposed verification graph lives.
+
+## 6. Current Open-Source Solution Space
+
+### 6.1 Zuul: the strongest OSS speculative integration scheduler
+
+Zuul's dependent pipeline manager is purpose-built for gating. It tests each change exactly as it is expected to appear in the repository, but starts downstream speculative states in parallel. If an earlier change fails, downstream results that included it are discarded and rerun without it. [19]
+
+**What it accomplishes:** eliminates the human rebase/retest serialization loop while preserving future-main correctness.
+
+**What it does not accomplish:** it does not know that some downstream evidence may still be valid after an upstream candidate is removed. It reasons at integration-state granularity.
+
+### 6.2 Prow/Tide: mature batching with a documented invalidation ceiling
+
+Tide automatically batches and retests PRs and ensures they are validated against the current base. It explicitly advises maintainers not to force PR authors to keep rebasing manually. But its own maintainer documentation states that any merge makes other in-pool test results stale. [20]
+
+That is a crisp illustration of the gap: Tide automates the churn; it does not eliminate the churn.
+
+### 6.3 Bors: simple, proven gated batching
+
+The current Rust `rust-lang/bors` project is an actively used, MIT/Apache-2.0 merge queue implementation. Rust also uses rollups to combine multiple low-risk changes into one expensive CI cycle, a pragmatic response to multi-hour CI. [21]
+
+Bors is a strong model for “test exactly what will land” and for batching. It is intentionally not a general incremental verification engine.
+
+### 6.4 Gas Town Refinery: strategically aligned, not yet the whole answer
+
+Refinery's planned batch-then-bisect algorithm is conceptually Bors-like and directly attacks successful-case CI amplification. [2] Because Refinery already lives inside an agent-native orchestration system, it is a plausible long-term home for merge scheduling in Gas City/Gas Town.
+
+The natural extensions would be:
+
+1. Zuul-style speculative future-state windows.
+2. Mergify/Trunk-style scope-aware independent lanes.
+3. An affectedness interface supplied by Pants/Bazel/Buck2 or a repository-specific graph.
+4. A shared action/evidence cache.
+5. Eventually, verification-graph-aware invalidation instead of batch/commit invalidation.
+
+### 6.5 Pants: probably the lowest-friction OSS experiment for Gas City's Go-heavy repo
+
+Pants provides fine-grained invalidation, sandboxed/hermetic process execution, exact input-based caching, remote caching/execution via REAPI, and Git-aware changed-target operation. Its Go support includes per-package test-result caching and `--changed-since`, although Go support remains labeled beta. [22][23][24]
+
+For Gas City, that tradeoff is attractive: Pants can test the **incremental-verification hypothesis** without first converting the repository to Bazel.
+
+### 6.6 Bazel: the mature gold standard, with real migration cost
+
+Bazel is the strongest existing OSS demonstration of deterministic dependency graphs + content-addressed action caching + remote execution. [8] If Gas City were already a Bazel shop, it would be the obvious foundation. Adopting it primarily to fix CI is a much larger migration.
+
+`bazel-diff` and `target-determinator` can add affected-target analysis between revisions for Bazel-based repositories, making the relationship to merge scheduling even stronger.
+
+### 6.7 Buck2: important validation of the model
+
+Meta's Buck2 uses a single incremental dependency graph, hermetic rules, remote execution compatible with the Bazel Remote Execution API, and integration with virtual filesystems. Meta reports millions of internal builds per day. [10]
+
+Buck2 is evidence that the “incremental graph + remote cache/execution” pattern is not Google-specific. It is also a possible technical option, but less obvious than Pants for a low-risk Gas City pilot.
+
+### 6.8 Buildbarn / bazel-remote: shared compute memory
+
+Buildbarn is an Apache-2.0 implementation of the Remote Execution API, providing distributed content-addressed storage, action cache, scheduling, and remote execution. [25] For a lighter cache-only experiment, `bazel-remote` is an established REAPI-compatible cache.
+
+This layer is important because a verifier result that is reusable only on one runner is not useful at 10,000 changes/day. **The cache must be organizational, not local.**
+
+### 6.9 Nx: a parallel example from the JS/TS ecosystem
+
+Nx's `affected` command computes the minimal project set affected by Git changes using its project graph, and its task cache keys work from declared inputs. Nx now documents a self-hosted remote-cache API. [26][27]
+
+Nx is not the likely foundation for Gas City's Go code, but it validates the same architectural shape: affectedness first, then task-level cache reuse.
+
+## 7. Recommended OSS Reference Stack
+
+The fastest way to test the thesis is **not** to build the missing system first. Assemble the best existing pieces and measure what remains.
+
+```text
+                         GitHub
+                            │
+                            ▼
+                Integration / merge scheduler
+                Zuul  OR  Gas Town Refinery
+                            │
+                  future integration states
+                            │
+                            ▼
+               Affectedness + task graph
+                  Pants (pilot) / Bazel
+                            │
+                 exact process/action keys
+                            │
+                 ┌──────────┴──────────┐
+                 ▼                     ▼
+            cache hit              cache miss
+                 │                     │
+                 │             current runners /
+                 │             remote execution
+                 │                     │
+                 └──────────┬──────────┘
+                            ▼
+               Buildbarn / bazel-remote
+                     shared REAPI cache
+                            │
+                            ▼
+                    admission decision
+                            │
+                            ▼
+                          main
+```
+
+### Layer 1 — keep GitHub as source of record
+
+Do not replace Git or GitHub to solve this problem. Keep branches, review UI, permissions, status reporting, and canonical source history there. At 10,000 logical changes/day, batch logical changes into fewer publication transactions rather than assuming each logical change must consume a separate PR merge.
+
+### Layer 2 — eliminate human merge serialization
+
+**Reference implementation:** Zuul.
+
+**Strategic Gas Town path:** evolve Refinery toward the same semantics.
+
+The scheduler should construct and validate the future states changes will actually enter, and should allow independent scopes to advance concurrently.
+
+### Layer 3 — stop running obviously unaffected work
+
+Pilot Pants against the Go repository. Use it initially in shadow mode: ask Pants which tests/processes are affected, but continue running the existing full required checks as an audit. Compare Pants's predicted invalidation set to actual failures.
+
+If Pants's Go limitations prove material, evaluate a Bazel/Buck2 migration separately rather than contaminating the merge-queue experiment.
+
+### Layer 4 — share exact work across every runner
+
+Deploy `bazel-remote` first if a simple cache is sufficient; move to Buildbarn if remote execution or scalable CAS/action-cache topology becomes valuable.
+
+The objective is that identical verifier actions across PRs, agents, speculative states, and developer machines converge on a single cached result.
+
+### Layer 5 — preserve existing Actions/Blacksmith investment
+
+The experiment need not replace the current GitHub Actions pipeline. Current jobs can call Pants or other affectedness tooling, consume the remote cache, and report normal checks. Replace execution infrastructure only if measurement shows it is still a bottleneck.
+
+## 8. What This Stack Should Do for Julian and Steve
+
+For the moving-main problem:
+
+```text
+Before:
+B green on main@100
+A merges
+B's entire proof is stale
+rebase + rerun
+
+With merge scheduling:
+B is already tested against predicted main+A
+A merges
+B can continue without human intervention
+```
+
+For verification saturation:
+
+```text
+Before:
+new integration state
+→ run all required jobs
+
+With affectedness + exact action cache:
+new integration state
+→ compute affected task graph
+→ reuse tasks with identical inputs
+→ execute only cache misses
+```
+
+This should remove a large fraction of CTO/architect babysitting and make queue throughput depend more on **actual conflicts and changed dependencies** than on raw PR count.
+
+It still does not deliver the complete 10,000/day thesis, because the reuse boundary is mostly **process execution**. That is why the experiment is valuable: it tells us whether process-level caching is already sufficient or whether a more general evidence layer is required.
+
+## 9. The Experiment: Prove or Kill the Thesis
+
+The right test is not “does the demo feel faster?” It is a controlled measurement of proof churn and marginal verification cost.
+
+### 9.1 Instrument the current baseline
+
+Record, for every required check and every ready PR/change:
+
+- arrival time and ready-to-merge time;
+- base SHA when each check started;
+- reason a check/re-run was triggered;
+- changed files and current Gas City scope classification;
+- job identity/version and execution environment;
+- wall time and compute time;
+- pass/fail/flake classification;
+- cache hit/miss where available;
+- whether prior success was discarded solely because the base advanced;
+- human actions required to rebase, rerun, dequeue, or unblock;
+- final merge order and broken-main/revert outcomes.
+
+From those data, compute:
+
+**Proof churn ratio** = verification work repeated after a base advance / total verification work.
+
+**Marginal verification cost** = new verification compute consumed / merged logical change.
+
+**Queue amplification** = CI validations executed / logical changes merged.
+
+**Human serialization cost** = maintainer interventions / logical changes merged.
+
+### 9.2 Experiment A — scheduling only
+
+Run Zuul (or a Refinery implementation of equivalent semantics) in shadow mode on the live queue. Compare the future-state DAG it would have constructed with the actual sequence of rebases/retests.
+
+Then gate a low-risk subset through it.
+
+**Question:** How much of the pain disappears purely by removing human serialization?
+
+### 9.3 Experiment B — affectedness only
+
+Introduce Pants or an equivalent dependency engine in audit mode. For each CI run, record which packages/tests/actions it says can be skipped. Continue full verification in parallel so false non-invalidations are detectable.
+
+**Question:** What fraction of Gas City's current CI work is actually invalidated by an average change?
+
+### 9.4 Experiment C — shared action cache
+
+Connect the dependency engine to bazel-remote or Buildbarn. Run the same candidate stream across multiple workers and measure cache hits, bytes transferred, and compute avoided.
+
+**Question:** How much work is identical across different PRs and integration states once action identity is precise?
+
+### 9.5 Experiment D — combined stack
+
+Run the speculative merge DAG and affectedness/cache layer together. This is the real test: when an upstream candidate lands or fails, how much downstream verification survives?
+
+Suggested success metrics for the pilot should be agreed before running it. Reasonable starting targets to debate with the community are:
+
+| Metric                                                        |                                         Suggested pilot target |
+| ------------------------------------------------------------- | -------------------------------------------------------------: |
+| Manual rebase/retest interventions for queue-managed changes  |                                                 Reduce by ≥90% |
+| Verification compute repeated solely because base moved       |                                                 Reduce by ≥70% |
+| p95 ready-to-merged latency                                   |                          Approach ≤2 full CI cycles under load |
+| Cache/evidence reuse for unrelated or lightly related changes |                                          ≥70% of eligible work |
+| False non-invalidation in audited runs                        |                                                              0 |
+| Broken-main / revert rate                                     |                                         No worse than baseline |
+| Scheduler throughput                                          | Sustain ≥7 logical changes/minute in simulation; burst ≥20/min |
+
+The exact percentages are hypotheses, not promises. The non-negotiable safety target is **zero known false reuse** during the audit phase.
+
+### 9.6 Experiment E — 10,000/day control-plane stress test
+
+Do not create 10,000 real GitHub PRs. Feed 10,000 logical candidate events through the scheduler and verification planner using a distribution derived from real Gas City changes. Include realistic overlap, failures, flakes, shared-core changes, and bursts.
+
+The test should answer:
+
+- Does the queue remain bounded at a sustained average of ~6.94 logical changes/minute?
+- What percentage of verification nodes are newly executed vs reused?
+- How often does one failed upstream candidate destroy downstream work?
+- Can independent scopes proceed without waiting?
+- What publication batch size is needed to remain within GitHub's operational recommendations?
+- How many human escalations would 10,000 changes create under current policy?
+
+If the OSS stack keeps up economically and safely, stop. We have solved the problem with existing technology.
+
+If the queue still falls behind because useful verification results cannot survive changes to unrelated state, the missing abstraction has been isolated.
+
+## 10. The Missing Layer: An Open Verification Graph
+
+### 10.1 The one-line thesis
+
+> **Don't re-establish a fact unless something that fact depends on has changed.**
+
+An open verification graph generalizes the idea behind Bazel's action cache from **computations** to **claims about software**.
+
+### 10.2 Evidence is a first-class object
+
+A verifier should produce an immutable evidence record resembling:
+
+```text
+Evidence
+  proposition:  "internal/mail unit tests pass"
+  subject:      candidate tree / target digest
+  verifier:     mail-tests@<version-digest>
+  inputs:
+    - source/target digests
+    - transitive dependency digests
+    - fixture/config digests
+    - toolchain/environment digest
+    - command/flags
+  result:       PASS
+  outputs:      optional artifacts/logs
+  signature:    verifier identity
+```
+
+The evidence identifier is content-derived. Two independent candidates that require the same proposition over the same effective inputs should reference the same evidence node.
+
+### 10.3 The graph performs exact invalidation
+
+```text
+main advances
+     │
+     ▼
+Which content nodes changed?
+     │
+     ▼
+Traverse dependent evidence nodes
+     │
+ ┌───┴─────────────┐
+ │                 │
+still valid      invalid
+ │                 │
+reuse            recompute
+```
+
+This is conservative by construction: undeclared dependencies are a correctness bug. Early implementations should over-invalidate rather than risk false reuse. Hermetic verifier execution and dependency capture are therefore foundational.
+
+### 10.4 It goes beyond tests and builds
+
+Evidence nodes can represent:
+
+- compilation success;
+- unit/integration/e2e test outcomes;
+- lint/static-analysis results;
+- API/ABI compatibility;
+- schema migration properties;
+- dependency/license/security policy;
+- generated-code consistency;
+- benchmark bounds;
+- deterministic review rules;
+- canary/post-submit health;
+- even LLM reviewer opinions, provided they are treated as probabilistic/advisory evidence rather than hard truth.
+
+This is the distinction between an action cache and a verification graph.
+
+### 10.5 It deduplicates in-flight verification too
+
+If 37 candidates simultaneously require the same uncached fact, the scheduler should launch it once and attach all 37 consumers to that future. At 10,000/day, this can matter as much as caching completed work.
+
+### 10.6 It makes admission policy compositional
+
+A change class can declare the evidence required to ship:
+
+```text
+mechanical_refactor:
+  requires:
+    - affected compilation passes
+    - affected unit tests pass
+    - public API unchanged
+    - formatter/lint pass
+    - integration policy satisfied
+```
+
+Policy does not ask whether “CI is green.” It asks whether the required propositions are currently established for the candidate's exact integration state.
+
+SLSA's Verification Summary Attestation and the in-toto attestation framework are promising existing schemas for authenticated evidence, while OPA is a plausible policy engine with versioned policy bundles and auditable decision logs. [28][29][30] None of them supplies the invalidation/planning graph itself.
+
+## 11. Why the Open Verification Graph Could Matter Beyond Gas City
+
+The industry is converging on agents that can create more software changes than human-centric CI/CD was designed to absorb. The immediate response has been “more agents” on the generation side and “more runners” on the verification side. That scales cost, not architecture.
+
+An open verification graph could provide:
+
+1. **Sublinear verification cost.** The cost of one more change approaches the cost of the facts it actually invalidates.
+2. **Cross-agent reuse.** Thousands of agents share already-established truths rather than independently rediscovering them.
+3. **Cross-queue reuse.** Evidence can survive failed speculative parents when its real inputs are unaffected.
+4. **Vendor-neutral CI memory.** Evidence is not trapped in GitHub Actions, Buildkite, Jenkins, or one merge-queue vendor.
+5. **Auditable autonomous admission.** A policy decision can enumerate exactly which evidence justified publication.
+6. **A path from PR review to policy governance.** Humans can progressively automate well-understood change classes while escalating anomalies.
+7. **A common substrate for OSS.** Any verifier can publish evidence if it follows the schema and dependency rules.
+
+The sharpest formulation is:
+
+> **Merge queues cache ordering. Build systems cache computation. What is missing is a cache of verified truths.**
+
+If that statement is wrong — if Zuul/Refinery + Pants/Bazel + REAPI caching already makes 10,000/day practical — we should happily discover that through measurement and avoid building another subsystem.
+
+If it is right, then the verification graph is not “another CI product.” It is a potential **admission substrate for autonomous software factories**.
+
+## 12. Proposed Next Steps for Gas City and the OSS Community
+
+### Immediate
+
+1. Instrument Gas City's current pipeline to measure proof churn, queue amplification, and human serialization.
+2. Enable or prototype future-state merge scheduling (`merge_group`, Zuul, or Refinery-equivalent) rather than requiring every PR to chase `main`.
+3. Pilot Pants affectedness/caching on a representative Go slice in audit mode.
+4. Stand up a shared REAPI cache (bazel-remote first; Buildbarn if warranted).
+5. Replay historical/live change streams through the combined scheduler in shadow mode.
+
+### Then decide based on evidence
+
+If existing OSS keeps the queue bounded and compute affordable, adopt it and stop.
+
+If the remaining dominant cost is repeated verification whose actual dependencies are unchanged, prototype the **smallest possible verification graph** by wrapping existing CI jobs as coarse evidence nodes. Do not begin by inventing new test runners or a new forge. Refine the graph only where coarse invalidation is demonstrably expensive.
+
+### Questions for Julian, Steve, and the community
+
+- Which Gas City checks are genuinely hermetic today?
+- Which checks have undeclared dependencies that would make result reuse unsafe?
+- How much CI is repeated because `main` changed versus because relevant source actually changed?
+- Does Refinery want to own speculative integration scheduling, or should it consume an external scheduler such as Zuul?
+- Is Pants sufficiently accurate/mature for Gas City's Go dependency graph, or is Bazel/Buck2 worth the migration cost?
+- Which change classes could eventually be admitted by policy without per-change human review?
+- What is the right open schema for evidence identity and dependencies?
+- Can SLSA/in-toto be extended rather than inventing another attestation format?
+- How should probabilistic evidence (LLM review, predictive test selection) compose with deterministic evidence?
+- What is the minimum viable implementation that proves evidence survival across a moving `main`?
+
+## Conclusion
+
+Gas City's current pain is an early signal of a general transition. When coding agents can produce changes faster than a human team can integrate them, the bottleneck moves downstream: from **writing code** to **establishing that code is safe to admit**.
+
+The first step is not a new forge. It is to use the best existing integration and build-system ideas together: speculative merge scheduling, dependency-aware affectedness, batching, precise content-addressed caching, and shared execution. Google has demonstrated many of these principles independently at enormous scale through Rosie/TAP and Blaze; modern products and OSS systems have brought much of that machinery outside Google.
+
+But 10,000 autonomous changes per day pushes one step further. A commit SHA is too coarse a unit of invalidation, and a CI run is too coarse a unit of knowledge.
+
+The engineering target should be:
+
+> **A software factory in which each new change pays only for the uncertainty it creates.**
+
+That is the purpose of the proposed open verification graph. The next move is to measure whether we need it.
+
+---
+
+## References
+
+1. [Gas City repository: .github/workflows/ci.yml](https://github.com/gastownhall/gascity/blob/main/.github/workflows/ci.yml)
+
+2. [Gas Town Architecture: Merge Queue — Batch-then-Bisect](https://github.com/gastownhall/gastown/blob/main/docs/design/architecture.md)
+
+3. [GitHub Docs: Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+
+4. [GitHub Docs: Repository limits](https://docs.github.com/en/repositories/creating-and-managing-repositories/repository-limits)
+
+5. [Software Engineering at Google, Chapter 22: Large-Scale Changes](https://abseil.io/resources/swe-book/html/ch22.html)
+
+6. [Steve Yegge: Dear Google Cloud — discussion of Grok and Rosie](https://yegge.ai/essays/dear-google-cloud-your-deprecation-policy-is-killing-you/)
+
+7. [Bazel FAQ: internal Blaze lineage and scale](https://bazel.build/about/faq)
+
+8. [Bazel Docs: Remote Caching](https://bazel.build/remote/caching)
+
+9. [Bazel docs: Distributed builds (ObjFS and Forge)](https://bazel.build/basics/distributed-builds)
+
+10. [Meta Engineering: Build faster with Buck2](https://engineering.fb.com/2023/04/06/open-source/buck2-open-source-large-scale-build-system/)
+
+11. [Mergify Docs: Queue Modes](https://docs.mergify.com/merge-queue/queue-modes/)
+
+12. [Mergify Docs: Merge Queue Batches](https://docs.mergify.com/merge-queue/batches/)
+
+13. [Trunk Docs: Parallel Queues](https://docs.trunk.io/merge-queue/optimizations/parallel-queues)
+
+14. [Trunk Docs: Pending Failure Depth](https://docs.trunk.io/merge-queue/optimizations/pending-failure-depth)
+
+15. [Aviator Docs: Affected Targets](https://docs.aviator.co/mergequeue/concepts/affected-targets)
+
+16. [Aviator Docs: Batching](https://docs.aviator.co/mergequeue/concepts/batching)
+
+17. [Graphite Docs: Merge Queue Optimizations](https://graphite.com/docs/merge-queue-optimizations)
+
+18. [Develocity Docs: Predictive Test Selection](https://docs.gradle.com/develocity/predictive-test-selection)
+
+19. [Zuul Docs: Project Gating](https://zuul-ci.org/docs/zuul/latest/gating.html)
+
+20. [Prow Docs: Tide](https://docs.prow.k8s.io/docs/components/core/tide/)
+
+21. [rust-lang/bors](https://github.com/rust-lang/bors)
+
+22. [Pants Docs: How does Pants work?](https://www.pantsbuild.org/stable/docs/introduction/how-does-pants-work)
+
+23. [Pants Docs: Go overview](https://www.pantsbuild.org/dev/docs/go)
+
+24. [Pants Docs: Remote caching & execution](https://www.pantsbuild.org/dev/docs/using-pants/remote-caching-and-execution)
+
+25. [Buildbarn: distributed cache and remote execution](https://github.com/buildbarn)
+
+26. [Nx Docs: Run Only Tasks Affected by a PR](https://nx.dev/docs/features/ci-features/affected)
+
+27. [Nx Docs: Self-hosted remote cache](https://nx.dev/docs/kb/self-hosted-caching)
+
+28. [SLSA v1.2: Verification Summary Attestation](https://slsa.dev/spec/v1.2/verification_summary)
+
+29. [in-toto: software supply-chain attestations](https://in-toto.io/docs/what-is-in-toto/)
+
+30. [Open Policy Agent: policy management and decision logs](https://www.openpolicyagent.org/docs/management-introduction)

--- a/specs/proposals/0001-increasing-ci-throughput
+++ b/specs/proposals/0001-increasing-ci-throughput
@@ -3,9 +3,16 @@
 **Gas City Engineering White Paper — Discussion Draft**  
 **August 21, 2026**
 
-> **Objective:** Build an engineering system that can safely admit **10,000
-> agent-generated logical changes per day** without proportional growth in CI
-> compute or maintainer attention.
+> **Objective:** Design toward **10,000 agent-generated logical changes per
+> day** without verification compute growing as change volume multiplied by a
+> fresh full CI run, or routine maintainer attention growing with each change.
+> The number is a directional design horizon and stress case, not a traffic
+> forecast or universal release gate.
+
+> **Thesis:** Admission should scale with the uncertainty a change introduces,
+> not the number of changes produced. Durable work identity, integration,
+> proof selection, and publication must remain separate so the system can
+> batch, reuse, and recover without losing safety or accountability.
 
 > **Operating principle:** _Agents make changes. The system establishes facts.
 > Policy decides what ships. Humans govern policy and handle exceptions._
@@ -24,11 +31,19 @@ work it protects.
 Ten thousand logical changes per day is about **417 per hour, 6.94 per minute,
 or one every 8.6 seconds**. If every change buys a fresh full CI run, even a
 five-minute verification cycle requires roughly 35 concurrent validations to
-keep up. A 20-minute cycle requires about 139, before failures, flakes, retries,
-or queue churn.
+keep up. A 20-minute cycle requires about 139. Those are zero-headroom floors,
+before failures, flakes, retries, bursts, or queue churn; they are not safe
+capacity targets.
 
-Runner capacity alone will not solve this. Gas City must attack the problem at
-three points:
+The 10,000/day horizon is directional, not a hard operating requirement or a
+forecast of the current factory's traffic. It forces the design to confront
+four future shapes: one repository receiving most of the volume, work spread
+across a fleet, bursts against a shared core, and coordinated changes spanning
+repositories or services.
+
+Runner capacity can keep up with a raw arrival rate, but capacity alone would
+buy a fresh proof for every change and violate the objective. Gas City must
+attack the problem at three points:
 
 1. **Shape smaller changes.** Direct agents to make the smallest coherent
    change with the narrowest dependency and test blast radius. Split unrelated
@@ -54,41 +69,53 @@ measure the real queue, exercise GitHub's merge queue on `merge_group` states,
 and harden the existing affectedness model. Pilot Pants, Bazel, Zuul, Refinery,
 or a shared REAPI cache only where measurements expose a gap they can close.
 
-If that system safely keeps the queue bounded at 10,000 logical changes per
-day, stop. This proposal does not design a general-purpose verification graph,
-a new forge, or a new build system.
+If the experiments establish credible headroom toward that horizon within the
+registered safety and cost bounds, stop. This proposal does not design a
+general-purpose verification graph, a new forge, or a new build system.
 
-## 1. Define the target precisely
+## 1. Define the design horizon precisely
 
-A **logical change** is one independently attributable and revertible behavior
-change. It may come from a human, one coding agent, a swarm, a codemod, a
-dependency bot, or an optimizer. It does not have to map one-to-one to a commit
-or pull request, but the system must retain its identity after batching.
+A **logical change** is one independently attributable behavior change that can
+be selectively reversed or repaired subject to its dependency closure. It may
+come from a human, one coding agent, a swarm, a codemod, a dependency bot, or an
+optimizer. It does not have to map one-to-one to a commit or pull request, but
+the system must retain its identity after batching.
 
-Three units matter:
+Four units matter:
 
 | Unit | Meaning |
 | --- | --- |
-| Logical change | The independently attributable and revertible unit of intent |
+| Parent outcome | The user-visible result requested by the originating Bead or formula run |
+| Logical change | A publishable Bead, or dependency-closed Bead subgraph, that carries one attributable behavior change |
 | Integration candidate | One or more logical changes assembled into a source state for verification |
 | Publication transaction | The Git push or PR merge that makes accepted changes canonical |
 
-The throughput target counts **accepted logical changes**, not generated diffs.
+The throughput metric counts **accepted logical changes**, not generated diffs.
 Splitting one edit into ten commits does not create ten units of value. A useful
 logical change has a stable identity, an owner, an intended outcome, dependency
 relationships, verification results, and a path to individual rollback or
-forward repair.
+forward repair. Report completed parent outcomes beside logical-change
+throughput so decomposition cannot manufacture apparent value.
+
+Beads already provides the durable work identity. The originating Bead or
+formula-run root identifies the parent outcome; a designated publishable Bead
+or dependency-closed Bead subgraph identifies each logical change. The
+publication record maps those IDs to their source commits or patch, declared
+dependencies, proofs, candidate and batch membership, and final canonical SHA.
+No new work ledger is required.
 
 GitHub currently recommends no more than one merged PR per minute and six
-pushes per minute per repository. Ten thousand one-change PRs would require
-almost seven merges per minute continuously. Staying near the recommended merge
-rate requires publication transactions to carry at least seven logical changes
-on average, and more during working-hour bursts. [1]
+pushes per minute per repository. A repository receiving the entire target
+would need 6.94 logical changes per merged PR to stay near the first limit, or
+1.16 logical changes per push to stay near the second. This proposal uses
+reviewed PR publication as the primary pressure model. [1]
 
-This makes batching part of the design requirement rather than a later
-optimization. The batch is a transport unit. It must not erase the identity,
-dependency order, audit trail, or revertibility of the logical changes inside
-it.
+This makes batching a design requirement for a sufficiently hot repository,
+not for every fleet topology. GitHub Merge Queue grouping is publication
+scheduling: it does not create pre-PR logical batches or combine the underlying
+builds. A Gas City batch is a transport unit and must not erase the identity,
+dependency order, audit trail, or selective repair path of the logical changes
+inside it.
 
 ### 1.1 The workload model
 
@@ -101,13 +128,25 @@ test and capacity model must include:
 - conflicts and explicit dependencies between concurrent changes;
 - test, review, and integration failure rates;
 - flakes and infrastructure failures;
-- single-repository, cross-repository, and cross-service changes; and
-- publication batch size and failure-contamination rate.
+- single-repository, cross-repository, and cross-service changes;
+- publication batch size and failure-contamination rate;
+- offered load and sustainable service capacity for each constrained resource;
+  and
+- queue depth, oldest-ready age, tail latency, and post-burst drain time.
 
-The first model should come from recent Gas City history. Synthetic cases then
-stress the tails: a burst against one shared package, many independent component
-changes, a cache outage, a failing change at the front of the queue, and a
-coordinated change spanning Gas City, T3 Code, and the beads backend.
+Recent Gas City history should calibrate change shape, proof cost, failure rate,
+and human work. It does not set the target volume. Synthetic cases then exercise
+the four future workload shapes and stress the tails: a burst against one shared
+package, many independent component changes, a cache outage, a failing change
+at the front of the queue, and a coordinated change spanning Gas City, T3 Code,
+and the beads backend.
+
+For every constrained resource—the forge and its API, candidate construction,
+queues, runners, caches, publication, and human exception handling—offered load
+must remain below measured sustainable service capacity with positive headroom.
+Phase 0 establishes those service curves through baseline telemetry and
+controlled saturation tests. The capacity, tail-latency, compute, and
+human-work limits are then fixed before the combined load test.
 
 ## 2. Start from Gas City's current system
 
@@ -194,12 +233,15 @@ A directory, repository, or service is not independently hardenable merely
 because it has a name. It needs an explicit contract, a known dependency edge,
 and a focused proof that protects the boundary.
 
-Gas City should derive an initial component map from the path groups and test
-owners already present in CI. Tighten those boundaries where measurement shows
-that unrelated changes still force a full union. When two components can be
-changed, tested, deployed, and reverted independently, the scheduler can place
-them in parallel lanes. When a change crosses the contract between them, it
-becomes one coordinated integration candidate.
+Gas City's current path groups and test owners should seed component names and
+the proof inventory, not define dependency truth. Authoritative package and
+build graphs plus explicit contracts define dependency edges; `shared` remains
+the fail-closed answer when the graph cannot prove a narrower scope. Tighten
+those boundaries where measurement shows that unrelated changes still force a
+full union. When two components can be changed, tested, deployed, and repaired
+independently, the scheduler can place them in parallel lanes. When a change
+crosses the contract between them, it becomes one coordinated integration
+candidate.
 
 This model works at every scale:
 
@@ -230,17 +272,22 @@ limits do not combine the underlying `merge_group` builds. [5]
 
 That makes GitHub's queue the first scheduler to test. The pilot should:
 
-1. add `merge_group` handling to the reusable CI workflow;
-2. make changed-file and base-SHA logic work for both PR and merge-group events;
-3. report the same stable `CI / required` check on predicted integration states;
-4. run first on a test branch or bounded class of changes; and
-5. compare interventions, duplicate work, and time-to-merge against the current
+1. inventory the live required contexts and ruleset that govern admission;
+2. add `merge_group` handling to every required workflow, including CodeQL;
+3. make changed-file and base-SHA logic work for both PR and merge-group events;
+4. report the same stable `CI / required` check on predicted integration states;
+5. migrate the ruleset through a canary with an operator rollback path; and
+6. compare interventions, duplicate work, and time-to-merge against the current
    flow.
 
 If GitHub's queue keeps the admission queue bounded, use it. Bring in Zuul or
 extend Gas Town's Refinery only if measurements show that GitHub's state-level
 rebuilds, queue policy, batching, or cross-repository coordination are the
 remaining bottleneck. [10]
+
+This pilot can prove whether predicted integration states reduce rebase churn.
+It cannot prove logical batching, cross-repository atomicity, or incremental
+proof reuse; those are separate experiments.
 
 ### 4.1 Batch logical changes without losing them
 
@@ -251,7 +298,8 @@ publication transactions. A practical batcher should:
 - group changes with low overlap or an intentional dependency relationship;
 - build and test the combined tip or required union once where safe;
 - publish the whole batch when it passes; and
-- split or bisect a failing batch until the bad logical change is isolated.
+- split or bisect a failing batch until the minimal failing subset is isolated,
+  without violating dependency closure.
 
 Gas Town's Refinery design already describes Bors-style batch-then-bisect
 behavior. That is a plausible strategic home for Gas City-aware batching once
@@ -267,12 +315,14 @@ Ten thousand changes per day cannot require ten thousand human approvals. For a
 bounded change class with trustworthy deterministic proofs, policy should admit
 the routine cases and send exceptions to a person.
 
-Start with one narrow class whose risks and required proofs are well understood.
-A trusted classifier uses provenance, the diff, the dependency closure, and
-verification results. A new scope, failed proof, unexplained generated output,
-policy change, or unexpectedly broad blast radius escalates. Humans review the
-versioned admission policy, audit samples, and handle those exceptions. Go
-executes that policy; it does not contain the judgment itself.
+Start with one narrow class whose risks and required proofs are well understood,
+after affectedness and merge behavior have passed their own audits. A versioned,
+declarative policy names the admissible scope, provenance, dependency closure,
+and required proofs. The controller evaluates those predicates mechanically; it
+does not infer whether a change is safe. Missing or ambiguous evidence, a new
+scope, failed proof, unexplained generated output, policy change, or unexpectedly
+broad blast radius fails closed into human review. Humans govern the policy,
+audit samples, and handle exceptions.
 
 Expand automated admission one audited change class at a time. Track its
 escalation rate, escaped-defect rate, rollback rate, and human minutes per
@@ -296,15 +346,21 @@ larger invalidation sets even when the scheduler is perfect.
 
 ### 5.1 Improve the current planner before importing another one
 
-Use the existing path filters and `shared` fallback as the first affectedness
-model. Instrument which gates they select and compare that selection with
-full-union audit runs. Replace a coarse rule only when dependency or contract
-data can prove a narrower one.
+Use the existing path filters, package dependency graph, and `shared`
+fail-closed fallback as the first affectedness model. Instrument which gates
+they select and compare that selection with full-union audit runs. Replace a
+coarse rule only when dependency or contract data can prove a narrower one.
 
 Pants is a candidate for a shadow pilot because it offers Git-aware changed
 targets, per-package Go test caching, and REAPI-compatible remote caching. Its
 Go backend remains beta and has unsupported edges, so it is an experiment, not
 the default architecture. [7][8]
+
+Before the pilot, register the acceptable miss-rate bound, confidence target,
+sample size, workload strata, and delayed observation window. Exercise seeded
+hidden-dependency cases and retain random full-union runs after rollout so drift
+stays visible. Any missed failure broadens the rule and removes it from
+admission until it passes again.
 
 The pilot should answer concrete questions:
 
@@ -337,11 +393,13 @@ interesting if distributed CAS, scheduling, or remote execution is needed.
 Neither helps until Pants, Bazel, or another client emits trustworthy action
 keys. [11][12]
 
-A shared cache is part of the admission trust boundary. Untrusted pull requests
-must not be able to poison results later consumed by protected runs. Writes need
-an authenticated producer identity and a repository/toolchain namespace;
-untrusted work should be isolated or read-only. Cache failure must cause
-recomputation, never false success.
+A shared cache is part of the admission trust boundary. Authenticating a
+producer does not authorize its results for every consumer. Reuse and in-flight
+coalescing must be bound to a trust domain, workflow and policy revision,
+platform and environment, and the exact action inputs. Protected candidates
+must never consume results produced in an untrusted pull-request domain.
+Untrusted work should be isolated or read-only. A miss, corrupt entry, or cache
+failure causes recomputation, never false success.
 
 Do not reuse time-sensitive or environment-sensitive checks as though they were
 pure functions. Security scans, live-service tests, benchmarks, and probabilistic
@@ -350,14 +408,23 @@ reviews need explicit freshness and environment policy. When in doubt, run them.
 ## 6. Measure before choosing the final stack
 
 The experiment is a funnel. Each phase must isolate one source of throughput
-loss and has a stop condition.
+loss and has a stop condition. A control enters admission only after its own
+safety gate passes. Phase 0 supplies the baseline used to set capacity, tail
+latency, compute, human-work, and safety limits; those limits are registered
+before the combined test rather than chosen after seeing its results.
 
-### Phase 0: establish the baseline
+### Phase 0: establish identity and the baseline
+
+Define the Beads projection for parent outcomes and logical changes, then carry
+those IDs through candidates, proofs, batches, and publication transactions.
+Use controlled load to find each constrained resource's sustainable service
+curve rather than extrapolating from an underloaded production sample.
 
 For every required check and ready logical change, record:
 
 - creation, ready, queue-entry, verification, and publication times;
-- logical change, integration candidate, and publication transaction IDs;
+- parent outcome, logical change, integration candidate, batch, and publication
+  transaction IDs;
 - base SHA and reason each run or rerun was triggered;
 - changed components and predicted proof set;
 - suite mode (`filtered` or `full`) and actual jobs executed;
@@ -365,7 +432,9 @@ For every required check and ready logical change, record:
 - cache hits, misses, and bytes transferred;
 - pass, failure, flake, and infrastructure-failure classification;
 - prior successes discarded solely because the base advanced;
-- human actions required to rebase, rerun, dequeue, or unblock; and
+- human actions and minutes required to rebase, rerun, dequeue, or unblock;
+- queue depth, oldest-ready age, and post-burst drain time;
+- offered load and sustainable service rate at each constrained resource; and
 - merge order, rollback, and broken-`main` outcomes.
 
 Compute:
@@ -373,12 +442,15 @@ Compute:
 | Metric | Definition |
 | --- | --- |
 | Admission throughput | Accepted logical changes / day |
+| Outcome throughput | Completed parent outcomes / day |
 | Publication compression | Accepted logical changes / publication transactions |
 | Proof churn ratio | Verification compute repeated after a base advance / total verification compute |
 | Invalidation surface | Proof nodes selected / proof nodes available |
-| Marginal verification cost | New verification compute / accepted logical change |
+| Verification cost | Full-suite-equivalent compute / accepted logical change and completed parent outcome |
 | Queue amplification | Integration states validated / accepted logical changes |
-| Human serialization cost | Maintainer interventions / accepted logical changes |
+| Queue health | Queue depth, oldest-ready age, p95/p99 ready-to-canonical latency, and drain time |
+| Capacity headroom | Sustainable service capacity minus offered load at each constrained resource |
+| Human serialization cost | Maintainer interventions and minutes / accepted logical change |
 
 The timing work should extend the existing `ga-80po0c.4` telemetry rather than
 create a parallel measurement system. [3][4]
@@ -392,35 +464,47 @@ rollback size with the baseline.
 **Stop condition:** keep the guidance only if changes become narrower without
 increasing escaped defects, partial fixes, or human decomposition work.
 
-### Phase 2: bounded automated admission
+### Phase 2: affectedness shadow and audit
 
-Choose one routine change class with stable, deterministic proof requirements.
-Run its admission policy in shadow mode while humans continue reviewing it, then
-compare classifications, exceptions, escaped defects, and review effort.
+Shadow the current planner, then any Pants or repository-specific alternative,
+against full-union runs. Include seeded hidden-dependency cases and retain
+random full validation after rollout. Report the registered miss-rate bound,
+confidence, sample size, workload strata, and delayed observation window.
 
-**Stop condition:** automate only if the trusted classifier and proof set cover
-the class cleanly. Ambiguous scope or a high exception rate means the class is
-not ready.
+**Safety gate:** a missed failure fails the pilot, broadens the rule, and keeps
+it out of admission until the revised rule passes. A zero-observation result is
+reported with its actual confidence and coverage, not as proof of impossibility.
 
 ### Phase 3: merge scheduling
 
 Run GitHub Merge Queue on a bounded stream. Measure base-advance reruns, queue
-latency, duplicate compute, and manual intervention.
+latency, duplicate compute, and manual intervention. Exercise every required
+workflow, the live ruleset, the canary, and operator rollback.
 
 **Stop condition:** if moving-main churn becomes negligible, do not add Zuul or
 build equivalent scheduling machinery in Refinery.
 
-### Phase 4: affectedness audit
+### Phase 4: logical batching
 
-Shadow the current planner, then any Pants or repository-specific alternative,
-against full-union runs. Randomly retain full validation after the audit period
-so drift remains detectable.
+Replay and canary batches in the hot-repository workload. Measure publication
+compression, combined-proof reuse, failure contamination, split cost, and time
+to isolate the minimal failing dependency-closed subset.
 
-**Safety gate:** zero observed false non-invalidations, plus enough audited and
-randomly sampled full runs to report the confidence and workload coverage
-honestly. A missed failure fails the pilot and broadens the rule.
+**Stop condition:** keep batching only where it reduces publication or proof
+pressure without losing identity, dependency order, or failure containment.
 
-### Phase 5: shared cache
+### Phase 5: bounded automated admission
+
+Choose one routine change class with stable, deterministic proof requirements.
+Run its versioned declarative policy in shadow mode while humans continue
+reviewing it, then compare decisions, exceptions, escaped defects, and review
+effort.
+
+**Stop condition:** automate only if every admission decision is explained by
+explicit predicates and proofs. Missing or ambiguous evidence must fail closed;
+a high exception rate means the class is not ready.
+
+### Phase 6: shared cache
 
 Connect the selected client to a shared cache in an isolated trust domain.
 Measure hit rate, transfer cost, compute avoided, poisoning resistance, and
@@ -429,25 +513,37 @@ behavior during cache loss.
 **Stop condition:** keep the remote cache only if avoided compute and latency
 outweigh transfer, storage, operations, and security cost.
 
-### Phase 6: combined load test
+### Phase 7: combined load test
 
-Replay a representative stream plus synthetic worst cases through the complete
-planner and scheduler. Do not create 10,000 real GitHub PRs.
+Replay representative history plus synthetic versions of the four future
+workload shapes through the complete planner and scheduler. Model large-volume
+capacity offline and use smaller real GitHub canaries for forge behavior; do
+not create 10,000 real pull requests.
 
-The system passes when it:
+The directional 10,000/day scenario succeeds when it:
 
-- sustains at least 6.94 accepted logical changes per minute on average and the
-  agreed burst profile without an unbounded queue;
-- groups enough logical changes to remain near GitHub's publication guidance;
+- sustains an average 6.94 accepted logical changes per minute and the
+  registered burst profile with positive headroom at every constrained
+  resource;
+- keeps queue depth, oldest-ready age, p95/p99 ready-to-canonical latency, and
+  post-burst drain time within their registered bounds;
+- achieves the required publication compression in the hot-repository shape;
 - keeps p95 protected feedback within the `TESTING.md` target;
+- stays within the registered full-suite-equivalent compute budget per accepted
+  logical change and completed parent outcome;
+- stays within the registered maintainer-intervention and human-minute budgets;
+- meets the registered affectedness and admission safety bounds at their stated
+  confidence and workload coverage;
 - shows no worse broken-`main` or rollback rate than the baseline;
 - survives scheduler restart, cache loss, and a failing shared-core change;
 - keeps unrelated component lanes moving during localized failures; and
 - reports every logical change, proof result, batch membership, and publication
   outcome without silent loss.
 
-Percent-reduction targets for churn, cost, and intervention should be set after
-Phase 0. The safety and bounded-queue outcomes are not negotiable.
+This scenario is evidence about the architecture's future headroom, not a claim
+that today's workload needs 10,000 changes or that every deployment must clear
+that volume before it can ship. The safety, truthfulness, and bounded-queue
+outcomes remain requirements at every operating scale.
 
 ## 7. The practical architecture
 
@@ -456,75 +552,80 @@ agent formula / prompt
   shapes the smallest coherent logical change
                      │
                      ▼
-logical change stream
-  identity + dependencies + affectedness declaration
+Beads work graph
+  parent outcome + logical change IDs + dependency closure
                      │
                      ▼
-trusted integration planner
-  computes actual component/dependency blast radius
+candidate builder / batcher
+  preserves source, dependency, proof, and publication mappings
                      │
           ┌──────────┴──────────┐
           ▼                     ▼
- independent lanes       shared/cross-repo lane
+ component-local lanes    shared/cross-repo lane
+          │                     │
+          ▼                     ▼
+ per-repo Merge Queue     per-repo queues + cross-repo
+ predicted states         coordination when required
           │                     │
           └──────────┬──────────┘
-                     ▼
-future integration states / batches
-  GitHub Merge Queue first; Refinery or Zuul if justified
                      │
                      ▼
 affected proof planner
-  current Gas City graph first; Pants/Bazel pilot if justified
+  path filters + package graph + contracts + fail-closed fallback
                      │
           ┌──────────┴──────────┐
           ▼                     ▼
-      cache hit             cache miss
+ trusted cache hit      isolated miss / recompute
+ exact inputs + trust domain + workflow/policy revision
           │                     │
           └──────────┬──────────┘
                      ▼
              CI / required
                      │
                      ▼
-             admission policy
-  publishes routine cases; escalates exceptions
+      declarative admission policy
+  admits proved cases; fails closed on missing evidence
                      │
                      ▼
 publication transaction
-  preserves each logical change's identity and rollback path
+  canonical SHA ↔ logical change IDs and dependency closure
 ```
 
-GitHub remains the source of record. GitHub Actions and Blacksmith remain the
+GitHub remains the source of record for code and canonical publication. Beads
+remains the source of record for work identity and dependencies; the
+publication mapping connects the two. GitHub Actions and Blacksmith remain the
 execution layer until a measured bottleneck justifies replacing them. Gas City
 prompts shape the work; trusted CI code computes affectedness and establishes
 the facts used for admission.
 
 ## 8. Immediate next steps
 
-1. Extend the existing timing telemetry to measure logical changes,
-   publication transactions, proof churn, invalidation surface, and maintainer
-   intervention.
+1. Define the Beads projection for parent outcomes and logical changes, then
+   extend existing telemetry through candidates, proofs, batches, and canonical
+   publication.
 2. Add small-change and blast-radius guidance to the development formulas used
    by Gas City agents.
-3. Turn the existing CI path groups and test owners into an explicit initial
-   component/dependency map, retaining `shared` as the fail-closed fallback.
-4. Add and test `merge_group` support on a bounded branch or change class.
-5. Replay historical changes through the component planner and merge scheduler
-   before either controls admission.
-6. Define one bounded change class for audited policy-based admission, with
-   explicit required proofs and escalation triggers.
-7. Pilot batching with stable logical-change identities and batch-then-bisect
-   failure isolation.
-8. Run a Pants shadow pilot only if the current affectedness model remains a
+3. Build the initial component and dependency model from authoritative package
+   and build graphs plus explicit contracts; run affectedness in shadow mode
+   with `shared` as the fail-closed fallback.
+4. Inventory required contexts and add `merge_group` support to every required
+   workflow, then canary the ruleset migration with an operator rollback path.
+5. Pilot dependency-aware batching in the hot-repository shape, preserving
+   logical identity and isolating minimal failing subsets.
+6. Define one bounded change class for declarative admission and run its policy
+   in shadow mode with explicit proofs and fail-closed escalation.
+7. Run a Pants shadow pilot only if the audited affectedness model remains a
    material source of excess work.
-9. Add a shared action-cache pilot only after a client can produce safe,
-   reproducible keys and the cache trust boundary is defined.
-10. Run the 10,000/day load test, publish the measurements, and choose the
-   smallest stack that keeps the queue bounded.
+8. Add a shared action-cache pilot only after a selected client can produce
+   exact keys and authorization between trust domains is defined.
+9. Run the combined directional 10,000/day scenario, publish the measurements,
+   and choose the smallest stack that keeps queues bounded with positive
+   headroom.
 
 ## Conclusion
 
-Gas City gets to 10,000 changes per day by controlling the entire admission
-path, beginning with the shape of the change itself.
+Gas City designs toward the 10,000/day horizon by controlling the entire
+admission path, beginning with the shape of the change itself.
 
 Agents should produce the smallest independently useful changes. Component
 boundaries should let unrelated work proceed and harden independently. The
@@ -532,13 +633,14 @@ merge scheduler should test future states and publish groups of logical changes
 without making every PR chase `main`. CI should run the smallest truthful proof
 set and reuse exact work behind a clear trust boundary.
 
-The target is straightforward:
+The thesis is straightforward:
 
-> **Each new change pays only for the uncertainty it creates, and the queue
-> stays bounded while 10,000 useful changes become canonical every day.**
+> **Each new change pays only for the uncertainty it creates. Work identity,
+> integration, proof, and publication stay separate so queues and human effort
+> remain bounded as volume grows.**
 
 Measure each layer, add machinery only where the measurements require it, and
-stop when the target is met.
+use the 10,000/day scenario to expose where the design runs out of headroom.
 
 ---
 

--- a/specs/proposals/0001-increasing-ci-throughput
+++ b/specs/proposals/0001-increasing-ci-throughput
@@ -1,665 +1,569 @@
-# Proposal: Increating CI Throughput to 10K Changes/Day
-
-TODO: update the pipeline to include directing the agents up front to make small, targeted changes to reduce their blast radius and therefore reduce the required tests to validate and... profit!
-
-TODO: bias towards multiple components in a monorepo, multiple repos, multiple services, etc. that are smallest and can be hardened independently with a smaller blast radius then "the entire system" with the tests filtered as appropriate.
-
-## From CI Queueing to Incremental, Reusable Verification
+# Proposal: Getting Gas City to 10K Changes/Day
 
 **Gas City Engineering White Paper — Discussion Draft**  
 **August 21, 2026**
 
-> **Central objective:** Build an engineering system that can absorb **10,000 agent-generated logical changes per day**, while keeping the canonical branch trustworthy and avoiding proportional growth in CI compute or human review.
+> **Objective:** Build an engineering system that can safely admit **10,000
+> agent-generated logical changes per day** without proportional growth in CI
+> compute or maintainer attention.
 
-> **Core thesis:** _Agents make changes. The system establishes facts. Policy decides what ships. Humans govern policy and handle exceptions._
-
----
-
-## Executive Summary
-
-Gas City and Gas Town are already encountering a constraint that will become existential in an agent-heavy software factory: **code can now be produced faster than it can be admitted safely into the canonical branch**. The visible symptoms are familiar. A pull request becomes green; another pull request merges; `main` moves; the first PR must be rebased or restaged; expensive checks run again. Meanwhile, the arrival rate of new changes exceeds the throughput of CI. The result is a queue whose cost grows faster than the useful work it is protecting.
-
-This paper treats the target of **10,000 agentic changes per day** as the design requirement, not a distant aspiration. Ten thousand logical changes per 24 hours is about **417 per hour, 6.94 per minute, or one every 8.6 seconds on average**. Bursty working periods will be materially higher. If a complete verification cycle takes `T` minutes and each logical change requires a fresh full run, the steady-state concurrency required merely to keep up is approximately `6.94 × T`. A 20-minute full cycle implies about 139 concurrent full validations; a 30-minute cycle implies about 208 — before failures, retries, flakes, rebases, or queue churn.
-
-There are two coupled problems:
-
-1. **Moving-main invalidation.** Correctness is usually attached to a PR/commit SHA. When the base SHA changes, CI treats prior evidence as stale even when nothing relevant to that evidence changed.
-2. **Verification throughput.** Even with a perfect merge queue, the system can still demand more tests, builds, static analysis, and integration work than available compute can execute.
-
-Current systems attack important pieces. GitHub Merge Queue and Zuul speculatively test future integration states. Bors, Prow/Tide, Gas Town's Refinery design, Mergify, Aviator, and Graphite batch changes to amortize CI. Mergify, Trunk, and Aviator add scope- or target-aware parallel lanes. Bazel/Blaze, Buck2, Pants, and Nx use dependency graphs and content-addressed caches to avoid recomputing work whose inputs have not changed. Google's Rosie and TAP infrastructure showed how sharding, transitive affected-test selection, union testing, and anomaly-oriented review can drive thousands of automated source changes per day.
-
-The recommended near-term OSS experiment for Gas City is:
-
-**GitHub + Zuul (or an enhanced Gas Town Refinery) + Pants + Buildbarn/bazel-remote**, while keeping current GitHub Actions/Blacksmith execution where convenient. The queue layer establishes the future source states that need validation. Pants supplies fine-grained affectedness and precise process caching. Buildbarn (or bazel-remote for cache-only) shares results across workers. Refinery remains strategically interesting as the Gas Town-native coordinator, especially if it adopts Zuul-style speculative gating and scope-aware lanes.
-
-But that stack still leaves a deeper gap. Merge queues know **which source state** must be tested. Build systems know **which computations** can be reused. They do not provide a general mechanism for deciding whether an arbitrary correctness claim remains valid after the source graph changes.
-
-> **Don't re-establish a fact unless something that fact depends on has changed.**
-
-This paper proposes the missing abstraction as an **open verification graph**: a content-addressed graph in which each evidence node states a proposition, identifies the exact inputs and verifier that established it, and depends on content or other evidence nodes. A change to `main` invalidates only the downstream evidence whose actual dependencies changed. Everything else remains valid and reusable across PRs, agents, integration states, and CI workers.
-
-The strategic claim is therefore not “make CI faster.” It is:
-
-> **At 10,000 agentic changes per day, verification must become incremental, compositional, and reusable.**
+> **Operating principle:** _Agents make changes. The system establishes facts.
+> Policy decides what ships. Humans govern policy and handle exceptions._
 
 ---
 
-## 1. The Design Requirement: 10,000 Agentic Changes per Day
+## Executive summary
 
-A **logical change** in this paper is one independently attributable proposed modification to source or configuration. It may be generated by a human, one coding agent, a swarm, a codemod, a dependency bot, or an automated optimizer. It does **not** have to map one-to-one to a GitHub pull request.
+Gas City is approaching a constraint that will become existential for every
+agent-heavy software factory: code can be produced faster than it can be
+admitted safely into the canonical branch. A pull request becomes green,
+another change lands, `main` moves, and work that was already proved safe is
+run again. As the arrival rate rises, the CI queue grows faster than the useful
+work it protects.
 
-That distinction matters. GitHub currently recommends no more than **one merged pull request per minute per repository** and six pushes per minute per repository. At 10,000 logical changes per day, one-change-per-PR would average almost seven merged PRs per minute continuously — roughly seven times GitHub's recommended per-repository merge rate. [4]
+Ten thousand logical changes per day is about **417 per hour, 6.94 per minute,
+or one every 8.6 seconds**. If every change buys a fresh full CI run, even a
+five-minute verification cycle requires roughly 35 concurrent validations to
+keep up. A 20-minute cycle requires about 139, before failures, flakes, retries,
+or queue churn.
 
-Therefore a 10,000-change system eventually needs to distinguish:
+Runner capacity alone will not solve this. Gas City must attack the problem at
+three points:
 
-- **Logical changes:** independently generated, attributable, verifiable, revertible units.
-- **Integration transactions:** groups or sequences validated together.
-- **Publication transactions:** the smaller number of Git pushes/PR merges used to materialize accepted logical changes.
+1. **Shape smaller changes.** Direct agents to make the smallest coherent
+   change with the narrowest dependency and test blast radius. Split unrelated
+   work before it reaches CI. Prefer independently hardened components, whether
+   they live in one repository, several repositories, or separate services.
+2. **Integrate without chasing `main`.** Speculatively test future integration
+   states, batch compatible logical changes into fewer publication
+   transactions, and isolate failures without serial maintainer intervention.
+3. **Verify only what changed.** Compute affectedness from trusted dependency
+   information, run the smallest truthful proof set, and reuse an exact result
+   only when every input to that verifier is unchanged.
 
-The 10,000/day target also changes the economics of CI. Faster runners help only linearly. If generation scales by 10× while every change still triggers a complete validation universe, the organization simply purchases 10× more verification capacity — and still pays again every time `main` moves. That is not a scalable architecture.
+The order matters. A perfectly incremental CI system still wastes work when an
+agent mixes five concerns into one change. A disciplined stream of small
+changes still stalls when each one waits for `main` and consumes a separate PR
+merge. Gas City needs all three controls.
 
-The desired system should instead make **marginal verification cost proportional to the new uncertainty introduced by a change**, not proportional to the size of the repository or the existence of a new commit SHA.
+The practical path starts with what the repository already has: the current
+GitHub Actions/Blacksmith pipeline, path-sensitive suite selection, conservative
+full-suite barriers, affected-package static analysis, timing data, sharding,
+and the `CI / required` summary. Add change-shaping guidance to agent prompts,
+measure the real queue, exercise GitHub's merge queue on `merge_group` states,
+and harden the existing affectedness model. Pilot Pants, Bazel, Zuul, Refinery,
+or a shared REAPI cache only where measurements expose a gap they can close.
 
-## 2. The Immediate Problem at Gas City and Gas Town
+If that system safely keeps the queue bounded at 10,000 logical changes per
+day, stop. This proposal does not design a general-purpose verification graph,
+a new forge, or a new build system.
 
-### 2.1 The moving-main loop
+## 1. Define the target precisely
 
-The maintainer workflow is currently vulnerable to a destructive loop:
+A **logical change** is one independently attributable and revertible behavior
+change. It may come from a human, one coding agent, a swarm, a codemod, a
+dependency bot, or an optimizer. It does not have to map one-to-one to a commit
+or pull request, but the system must retain its identity after batching.
+
+Three units matter:
+
+| Unit | Meaning |
+| --- | --- |
+| Logical change | The independently attributable and revertible unit of intent |
+| Integration candidate | One or more logical changes assembled into a source state for verification |
+| Publication transaction | The Git push or PR merge that makes accepted changes canonical |
+
+The throughput target counts **accepted logical changes**, not generated diffs.
+Splitting one edit into ten commits does not create ten units of value. A useful
+logical change has a stable identity, an owner, an intended outcome, dependency
+relationships, verification results, and a path to individual rollback or
+forward repair.
+
+GitHub currently recommends no more than one merged PR per minute and six
+pushes per minute per repository. Ten thousand one-change PRs would require
+almost seven merges per minute continuously. Staying near the recommended merge
+rate requires publication transactions to carry at least seven logical changes
+on average, and more during working-hour bursts. [1]
+
+This makes batching part of the design requirement rather than a later
+optimization. The batch is a transport unit. It must not erase the identity,
+dependency order, audit trail, or revertibility of the logical changes inside
+it.
+
+### 1.1 The workload model
+
+The number 10,000 is meaningless without the shape of those changes. The load
+test and capacity model must include:
+
+- logical changes per minute, including burst periods;
+- changed components and the size of their transitive dependency closures;
+- shared-core changes versus component-local changes;
+- conflicts and explicit dependencies between concurrent changes;
+- test, review, and integration failure rates;
+- flakes and infrastructure failures;
+- single-repository, cross-repository, and cross-service changes; and
+- publication batch size and failure-contamination rate.
+
+The first model should come from recent Gas City history. Synthetic cases then
+stress the tails: a burst against one shared package, many independent component
+changes, a cache outage, a failing change at the front of the queue, and a
+coordinated change spanning Gas City, T3 Code, and the beads backend.
+
+## 2. Start from Gas City's current system
+
+Gas City is not starting with a serial, full-repository CI script. The current
+workflow already has:
+
+- path-sensitive jobs for mail, beads, packs, worker, provider, and integration
+  coverage;
+- a conservative `shared` barrier that forces the union of gated suites for
+  cross-cutting paths;
+- changed-package lint and formatting checks where the scope can be proved;
+- explicit full-repository fallbacks where it cannot;
+- sharded unit, process, and integration runners;
+- Blacksmith runner selection and dependency caches; and
+- a stable `CI / required` summary suitable for branch protection. [2]
+
+The normative target in [`TESTING.md`](../../TESTING.md) is p95 protected PR
+feedback under five minutes, including queueing. The current testing-efficiency
+program has demonstrated one exact-`main` run at 4m59s, but the repository does
+not yet have authoritative workflow telemetry proving that result at p95. The
+timing planner is still measurement infrastructure rather than the authority
+that selects the required graph. [3][4]
+
+The current workflow does not listen for GitHub's `merge_group` event. That
+means it cannot yet provide required checks for GitHub Merge Queue's predicted
+future states. [2][5]
+
+These facts change the near-term plan. The first job is to instrument and
+finish the current system, not replace it. Any new scheduler, dependency engine,
+or cache must beat that baseline on admission throughput, compute, or human
+intervention while preserving its safety properties.
+
+## 3. Shape changes before they enter CI
+
+The cheapest verification is the work a well-shaped change never invalidates.
+Gas City's formulas and agent prompts should ask for a narrow change before an
+agent edits code. This is behavioral guidance supplied by the pack, not judgment
+hardcoded into Go.
+
+A useful default instruction is:
 
 ```text
-PR B passes against main@100
+Before editing:
+- identify the smallest coherent behavior change that satisfies the assignment;
+- identify the component that owns it and the interfaces it can affect;
+- keep cleanup, refactoring, generated updates, and unrelated fixes separate;
+- avoid shared-core changes when a component-local change is truthful;
+- split work that can be verified and reverted independently.
+
+Before handoff:
+- list the logical change IDs and their dependencies;
+- name the changed components and public contracts;
+- name the smallest tests that own the changed behavior;
+- call out any shared or cross-repository blast radius.
+```
+
+This declaration helps reviewers and the planner, but it is not trusted input
+to admission. CI computes affectedness from the source tree, dependency data,
+and checked policy. If the agent claims a component-local change but the diff
+touches a shared dependency, the shared dependency wins.
+
+### 3.1 Optimize blast radius, not line count
+
+A five-line change to `go.mod`, shared configuration, or a central interface may
+invalidate more work than a 500-line component-local implementation. Change
+shaping should minimize the **effective invalidation surface**: the set of
+components, contracts, and proofs that can be affected.
+
+That gives the system a measurable feedback loop. For each logical change,
+record:
+
+- files and components touched;
+- direct and transitive dependents;
+- required proof set;
+- whether the work could have been split into independent changes; and
+- whether a shared-core edit was necessary.
+
+The goal is not to punish broad changes. Some changes are inherently broad.
+The goal is to stop creating broad changes accidentally.
+
+### 3.2 Make component boundaries earn their independence
+
+A directory, repository, or service is not independently hardenable merely
+because it has a name. It needs an explicit contract, a known dependency edge,
+and a focused proof that protects the boundary.
+
+Gas City should derive an initial component map from the path groups and test
+owners already present in CI. Tighten those boundaries where measurement shows
+that unrelated changes still force a full union. When two components can be
+changed, tested, deployed, and reverted independently, the scheduler can place
+them in parallel lanes. When a change crosses the contract between them, it
+becomes one coordinated integration candidate.
+
+This model works at every scale:
+
+```text
+package → component → repository → service
+```
+
+The affectedness planner follows real dependencies across those boundaries. It
+does not assume that a repository boundary makes two changes independent.
+
+## 4. Integrate without serializing on `main`
+
+The moving-main loop is proof churn:
+
+```text
+B passes against main@100
         ↓
-PR A merges → main@101
+A merges → main@101
         ↓
-B is now stale
-        ↓
-rebase/restage B
-        ↓
-rerun CI
-        ↓
-PR C merges → main@102
-        ↓
-repeat
+B is restaged and proved again
 ```
 
-This work is not merely annoying. It is **proof churn**: a previously established body of evidence is discarded because its base revision identifier changed, even when the facts being established had no dependency on the preceding change.
+GitHub Merge Queue already constructs temporary `merge_group` branches from the
+current base plus changes ahead in the queue. It can dispatch up to 100
+concurrent builds, and it automatically reconstructs downstream states when an
+earlier change fails. Its merge limits can group publication, although those
+limits do not combine the underlying `merge_group` builds. [5]
 
-GitHub's own documentation describes merge queues as a solution to the ordering problem: `merge_group` branches include the current base plus changes ahead in the queue. [3] Gas City's current CI workflow listens to `push` on `main` and `pull_request`, but not `merge_group`; it already contains substantial optimization machinery, including path-sensitive suite selection, a conservative `shared` barrier, affected-package linting, runner selection, caching, and sharding. [1]
+That makes GitHub's queue the first scheduler to test. The pilot should:
 
-That matters: this is **not** a case where the team simply forgot to parallelize CI. Gas City is already applying the normal bag of tricks.
+1. add `merge_group` handling to the reusable CI workflow;
+2. make changed-file and base-SHA logic work for both PR and merge-group events;
+3. report the same stable `CI / required` check on predicted integration states;
+4. run first on a test branch or bounded class of changes; and
+5. compare interventions, duplicate work, and time-to-merge against the current
+   flow.
 
-### 2.2 Verification throughput
+If GitHub's queue keeps the admission queue bounded, use it. Bring in Zuul or
+extend Gas Town's Refinery only if measurements show that GitHub's state-level
+rebuilds, queue policy, batching, or cross-repository coordination are the
+remaining bottleneck. [10]
 
-The second problem appears when the rate of ready changes exceeds the rate at which the verification system can establish that they are safe. Even a fully automated rebase/retest loop can saturate. If each queued change requires another expensive integration state, the queue may continue growing while every available runner is busy.
+### 4.1 Batch logical changes without losing them
 
-This is the more fundamental bottleneck in an agentic system. Models make code generation cheaper; the admission system does not become cheaper automatically.
+Batching is how 10,000 logical changes fit through a much smaller number of
+publication transactions. A practical batcher should:
 
-### 2.3 Gas Town Refinery already points toward batching
+- retain the identity and dependency order of every logical change;
+- group changes with low overlap or an intentional dependency relationship;
+- build and test the combined tip or required union once where safe;
+- publish the whole batch when it passes; and
+- split or bisect a failing batch until the bad logical change is isolated.
 
-Gas Town's architecture assigns the Refinery agent responsibility for merge processing and verification. The current architecture document specifies a **Bors-style batch-then-bisect** strategy: stack multiple merge requests on `main`, test the tip once, fast-forward the whole batch if green, and binary-bisect a failing batch. [2]
+Gas Town's Refinery design already describes Bors-style batch-then-bisect
+behavior. That is a plausible strategic home for Gas City-aware batching once
+the simpler queue pilot establishes what GitHub does and does not solve. [6]
 
-That is a legitimate and important optimization. It converts `N` successful changes from `N` complete CI validations into approximately one validation per batch. The current architecture document also shows that this work is phased: parallel gates are listed as in progress, with batch-then-bisect and pre-verification following. [2]
+Independent component lanes matter as much as batch size. A failure in one
+component should not block unrelated changes elsewhere. Shared-core changes
+enter the broader lane whose dependents they invalidate.
 
-Batching reduces work, but it does not by itself answer what happens when changes are independent, when only one verifier's inputs changed, or when evidence from a failed speculative branch is still valid for another candidate.
+### 4.2 Keep humans off routine happy paths
 
-## 3. The Underlying Queueing Failure
+Ten thousand changes per day cannot require ten thousand human approvals. For a
+bounded change class with trustworthy deterministic proofs, policy should admit
+the routine cases and send exceptions to a person.
 
-Traditional PR CI largely uses the commit SHA as an invalidation boundary:
+Start with one narrow class whose risks and required proofs are well understood.
+A trusted classifier uses provenance, the diff, the dependency closure, and
+verification results. A new scope, failed proof, unexplained generated output,
+policy change, or unexpectedly broad blast radius escalates. Humans review the
+versioned admission policy, audit samples, and handle those exceptions. Go
+executes that policy; it does not contain the judgment itself.
+
+Expand automated admission one audited change class at a time. Track its
+escalation rate, escaped-defect rate, rollback rate, and human minutes per
+accepted change.
+
+## 5. Run the smallest truthful proof set
+
+The planner's question is:
+
+> Did any input to this verifier change?
+
+For a deterministic package test, those inputs may include source files,
+transitive Go dependencies, fixtures, generated files, module metadata, the Go
+toolchain, environment, command, and flags. If the planner cannot account for
+an input, it must over-invalidate.
+
+This is an extension of Gas City's current policy: one risk, one smallest owning
+proof. Narrow production boundaries and focused test ownership make affectedness
+more precise. Coarse integration tests and hidden environment dependencies force
+larger invalidation sets even when the scheduler is perfect.
+
+### 5.1 Improve the current planner before importing another one
+
+Use the existing path filters and `shared` fallback as the first affectedness
+model. Instrument which gates they select and compare that selection with
+full-union audit runs. Replace a coarse rule only when dependency or contract
+data can prove a narrower one.
+
+Pants is a candidate for a shadow pilot because it offers Git-aware changed
+targets, per-package Go test caching, and REAPI-compatible remote caching. Its
+Go backend remains beta and has unsupported edges, so it is an experiment, not
+the default architecture. [7][8]
+
+The pilot should answer concrete questions:
+
+- Can it model Gas City's generated files, embedded resources, native
+  dependencies, process-backed tests, and custom integration shards?
+- Does it select a materially smaller proof set than the current planner?
+- Does that reduction survive full-union audit runs with no observed missed
+  failures?
+- Is the setup and maintenance cost lower than improving the current scripts?
+
+Evaluate Bazel or Buck2 only if the measurements justify a build-system
+migration. Do not adopt one merely because its dependency model is elegant. [9]
+
+### 5.2 Reuse exact work, with a trust boundary
+
+Cache in layers:
+
+1. Keep runner images, toolchains, module downloads, browser binaries, and other
+   setup inputs warm.
+2. Preserve Go build/test and static-analysis caches under exact tool and input
+   keys.
+3. Add a shared action cache only after the client can identify hermetic actions
+   precisely enough for cross-runner reuse.
+
+Coalesce in-flight misses too. When several candidates request the same exact
+action key, run it once and attach every waiting candidate to that result.
+
+`bazel-remote` is a reasonable cache-only REAPI pilot. Buildbarn becomes
+interesting if distributed CAS, scheduling, or remote execution is needed.
+Neither helps until Pants, Bazel, or another client emits trustworthy action
+keys. [11][12]
+
+A shared cache is part of the admission trust boundary. Untrusted pull requests
+must not be able to poison results later consumed by protected runs. Writes need
+an authenticated producer identity and a repository/toolchain namespace;
+untrusted work should be isolated or read-only. Cache failure must cause
+recomputation, never false success.
+
+Do not reuse time-sensitive or environment-sensitive checks as though they were
+pure functions. Security scans, live-service tests, benchmarks, and probabilistic
+reviews need explicit freshness and environment policy. When in doubt, run them.
+
+## 6. Measure before choosing the final stack
+
+The experiment is a funnel. Each phase must isolate one source of throughput
+loss and has a stop condition.
+
+### Phase 0: establish the baseline
+
+For every required check and ready logical change, record:
+
+- creation, ready, queue-entry, verification, and publication times;
+- logical change, integration candidate, and publication transaction IDs;
+- base SHA and reason each run or rerun was triggered;
+- changed components and predicted proof set;
+- suite mode (`filtered` or `full`) and actual jobs executed;
+- wall time, compute time, queue time, and setup time;
+- cache hits, misses, and bytes transferred;
+- pass, failure, flake, and infrastructure-failure classification;
+- prior successes discarded solely because the base advanced;
+- human actions required to rebase, rerun, dequeue, or unblock; and
+- merge order, rollback, and broken-`main` outcomes.
+
+Compute:
+
+| Metric | Definition |
+| --- | --- |
+| Admission throughput | Accepted logical changes / day |
+| Publication compression | Accepted logical changes / publication transactions |
+| Proof churn ratio | Verification compute repeated after a base advance / total verification compute |
+| Invalidation surface | Proof nodes selected / proof nodes available |
+| Marginal verification cost | New verification compute / accepted logical change |
+| Queue amplification | Integration states validated / accepted logical changes |
+| Human serialization cost | Maintainer interventions / accepted logical changes |
+
+The timing work should extend the existing `ga-80po0c.4` telemetry rather than
+create a parallel measurement system. [3][4]
+
+### Phase 1: change shaping
+
+Add the small-change guidance to the Gas City development formulas used by
+agents. Compare invalidation surface, cross-component edits, proof-set size, and
+rollback size with the baseline.
+
+**Stop condition:** keep the guidance only if changes become narrower without
+increasing escaped defects, partial fixes, or human decomposition work.
+
+### Phase 2: bounded automated admission
+
+Choose one routine change class with stable, deterministic proof requirements.
+Run its admission policy in shadow mode while humans continue reviewing it, then
+compare classifications, exceptions, escaped defects, and review effort.
+
+**Stop condition:** automate only if the trusted classifier and proof set cover
+the class cleanly. Ambiguous scope or a high exception rate means the class is
+not ready.
+
+### Phase 3: merge scheduling
+
+Run GitHub Merge Queue on a bounded stream. Measure base-advance reruns, queue
+latency, duplicate compute, and manual intervention.
+
+**Stop condition:** if moving-main churn becomes negligible, do not add Zuul or
+build equivalent scheduling machinery in Refinery.
+
+### Phase 4: affectedness audit
+
+Shadow the current planner, then any Pants or repository-specific alternative,
+against full-union runs. Randomly retain full validation after the audit period
+so drift remains detectable.
+
+**Safety gate:** zero observed false non-invalidations, plus enough audited and
+randomly sampled full runs to report the confidence and workload coverage
+honestly. A missed failure fails the pilot and broadens the rule.
+
+### Phase 5: shared cache
+
+Connect the selected client to a shared cache in an isolated trust domain.
+Measure hit rate, transfer cost, compute avoided, poisoning resistance, and
+behavior during cache loss.
+
+**Stop condition:** keep the remote cache only if avoided compute and latency
+outweigh transfer, storage, operations, and security cost.
+
+### Phase 6: combined load test
+
+Replay a representative stream plus synthetic worst cases through the complete
+planner and scheduler. Do not create 10,000 real GitHub PRs.
+
+The system passes when it:
+
+- sustains at least 6.94 accepted logical changes per minute on average and the
+  agreed burst profile without an unbounded queue;
+- groups enough logical changes to remain near GitHub's publication guidance;
+- keeps p95 protected feedback within the `TESTING.md` target;
+- shows no worse broken-`main` or rollback rate than the baseline;
+- survives scheduler restart, cache loss, and a failing shared-core change;
+- keeps unrelated component lanes moving during localized failures; and
+- reports every logical change, proof result, batch membership, and publication
+  outcome without silent loss.
+
+Percent-reduction targets for churn, cost, and intervention should be set after
+Phase 0. The safety and bounded-queue outcomes are not negotiable.
+
+## 7. The practical architecture
 
 ```text
-new SHA → new CI run → re-establish everything
+agent formula / prompt
+  shapes the smallest coherent logical change
+                     │
+                     ▼
+logical change stream
+  identity + dependencies + affectedness declaration
+                     │
+                     ▼
+trusted integration planner
+  computes actual component/dependency blast radius
+                     │
+          ┌──────────┴──────────┐
+          ▼                     ▼
+ independent lanes       shared/cross-repo lane
+          │                     │
+          └──────────┬──────────┘
+                     ▼
+future integration states / batches
+  GitHub Merge Queue first; Refinery or Zuul if justified
+                     │
+                     ▼
+affected proof planner
+  current Gas City graph first; Pants/Bazel pilot if justified
+                     │
+          ┌──────────┴──────────┐
+          ▼                     ▼
+      cache hit             cache miss
+          │                     │
+          └──────────┬──────────┘
+                     ▼
+             CI / required
+                     │
+                     ▼
+             admission policy
+  publishes routine cases; escalates exceptions
+                     │
+                     ▼
+publication transaction
+  preserves each logical change's identity and rollback path
 ```
 
-That is conservative and simple, but extremely coarse. In a high-change-rate repository, each merge changes the base SHA and can invalidate many in-flight results. Prow/Tide documents this behavior explicitly: whenever a PR merges, existing test results for other PRs become stale and retesting is required. [20]
-
-The ideal invalidation question is not:
-
-> “Did the commit SHA change?”
-
-It is:
-
-> “Did any input to this particular verifier change?”
-
-For example:
-
-```text
-Evidence: unit tests for internal/mail
-Depends on:
-  internal/mail/**
-  transitive Go dependencies
-  relevant fixtures
-  go.mod / go.sum where applicable
-  Go toolchain digest
-  test command + flags
-  verifier implementation version
-
-A dashboard-only PR merges.
-None of those inputs changed.
-Therefore: the evidence is still valid.
-```
-
-This shift — from revision invalidation to dependency invalidation — is the key to making verification cost grow sublinearly with change volume.
-
-## 4. What Google Learned: Rosie, TAP, and Blaze
-
-Google encountered a related scaling problem long before LLM coding agents. Its large-scale-change infrastructure had to generate, test, review, and submit huge numbers of mechanically produced changes against a constantly evolving monorepo.
-
-### 4.1 Rosie: shard the logical change
-
-Google's Software Engineering at Google describes Rosie as the platform that splits a large master change into independently testable/reviewable/submittable shards. It can test, mail, review, and submit thousands of changes per day. [5]
-
-The important lesson is not that Rosie is a merge queue. It is that Google stopped treating a giant source transformation as one human-sized review transaction. The system creates many small, independently admissible units and manages them as cattle rather than pets.
-
-### 4.2 TAP: test affected transitive closure, then exploit union economics
-
-For each shard, Google's Large-Scale Change pipeline runs the transitive closure of tests that may be affected. When too many shards affect too many tests, TAP can group them: run the **union** of affected tests for the whole set, then use failures to determine which individual shards need narrower retesting. The Google SWE book notes that once a union is already large, adding additional similar changes can be nearly free. [5]
-
-Google also describes a “TAP train”: sample tests for candidate changes, combine the passing changes into an uber-change, run the union of affected tests, then isolate nonflaky failures back to individual changes. [5]
-
-That is directly relevant to the 10,000/day target: **share verification across changes instead of forcing every change to buy an isolated universe.**
-
-### 4.3 Review only anomalies when the change class permits it
-
-Rosie also attacks human-review throughput. Global approvers use pattern-based tooling to automatically approve expected changes and manually inspect the anomalous subset. [5] This is a precursor to the broader agentic thesis: humans define and govern the acceptance regime; routine instances flow automatically; unusual cases escalate.
-
-### 4.4 Blaze/Bazel: make computation reusable by exact inputs
-
-A terminology correction is useful here: **Blaze is Google's internal build system lineage; Bazel is its open-source relative. Meta/Facebook's analogous system is Buck/Buck2.** [7][10]
-
-Blaze/Bazel's critical contribution is precise, reproducible action identity. Bazel breaks work into actions with declared inputs, output names, command line, and environment. Its remote cache maps action hashes to results and stores artifacts in a content-addressable store. If the same action with the same inputs has already succeeded, the output can be reused instead of recomputed. [8]
-
-Google's distributed build documentation describes the internal stack around Blaze, including ObjFS for cached build outputs and Forge for remote execution. [9]
-
-The conceptual breakthrough is simple:
-
-> **A change to the repository should invalidate only the computations whose inputs changed.**
-
-### 4.5 Steve Yegge's connection: Grok as code-intelligence substrate
-
-Public sources most directly document Steve Yegge as the leader of Google's Grok project, a language-neutral code-intelligence platform. Steve's own writing describes Grok as powering automated refactoring infrastructure and explicitly calls out Rosie as a tool used to automate large migrations. [6]
-
-For this proposal, Grok's lesson is as important as Rosie's: **high-scale automation needs an explicit machine-readable graph of code relationships**, not just file diffs and shell scripts.
-
-## 5. Current Proprietary Solution Space
-
-No current commercial product appears to deliver the complete end state proposed here, but several have already converged on important components.
-
-| Product            | What it solves              | Key mechanism                                                                                                                              | What remains                                                                                 |
-| ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| GitHub Merge Queue | Moving-main ordering        | `merge_group` future-state validation, up to 100 concurrent builds                                                                         | Does not combine merge-group builds; CI work still scales with validation states [3]         |
-| Mergify            | Queue throughput + CI cost  | Speculative checks, scope-aware parallel queues, batching, automatic splitting/bisection; batch lineage can inherit check results          | Reuse is queue/batch-lineage-oriented, not a general proof graph [11][12]                    |
-| Trunk Merge Queue  | Independent-lane throughput | Impacted-target dynamic queues; predictive cumulative testing; pending failure depth reuses downstream evidence against flaky predecessors | Reuse is structural/queue-specific rather than arbitrary verifier dependency reuse [13][14]  |
-| Aviator MergeQueue | High-volume monorepo queues | Affected targets, parallel queues, configurable batching, bisection                                                                        | Does not generalize result validity beyond queue/target logic [15][16]                       |
-| Graphite           | Stack-heavy teams           | Stack-aware speculative parallel CI, fast-forward reuse, batching                                                                          | Strong stack optimization; not a generic affectedness/evidence system [17]                   |
-| Develocity         | Test throughput             | Predictive test selection, build cache, test distribution; avoids re-running tests that already passed for identical inputs                | Probabilistic and primarily test/build-tool focused; not an integration admission graph [18] |
-
-The trend is clear. Commercial merge-queue vendors are moving from FIFO queues toward **dependency-aware DAG scheduling**, because simple serial queues cannot keep up when CI duration exceeds change arrival intervals. Commercial test platforms are separately moving toward **input-aware test reuse**. The seam between those two categories is where the proposed verification graph lives.
-
-## 6. Current Open-Source Solution Space
-
-### 6.1 Zuul: the strongest OSS speculative integration scheduler
-
-Zuul's dependent pipeline manager is purpose-built for gating. It tests each change exactly as it is expected to appear in the repository, but starts downstream speculative states in parallel. If an earlier change fails, downstream results that included it are discarded and rerun without it. [19]
-
-**What it accomplishes:** eliminates the human rebase/retest serialization loop while preserving future-main correctness.
-
-**What it does not accomplish:** it does not know that some downstream evidence may still be valid after an upstream candidate is removed. It reasons at integration-state granularity.
-
-### 6.2 Prow/Tide: mature batching with a documented invalidation ceiling
-
-Tide automatically batches and retests PRs and ensures they are validated against the current base. It explicitly advises maintainers not to force PR authors to keep rebasing manually. But its own maintainer documentation states that any merge makes other in-pool test results stale. [20]
-
-That is a crisp illustration of the gap: Tide automates the churn; it does not eliminate the churn.
-
-### 6.3 Bors: simple, proven gated batching
-
-The current Rust `rust-lang/bors` project is an actively used, MIT/Apache-2.0 merge queue implementation. Rust also uses rollups to combine multiple low-risk changes into one expensive CI cycle, a pragmatic response to multi-hour CI. [21]
-
-Bors is a strong model for “test exactly what will land” and for batching. It is intentionally not a general incremental verification engine.
-
-### 6.4 Gas Town Refinery: strategically aligned, not yet the whole answer
-
-Refinery's planned batch-then-bisect algorithm is conceptually Bors-like and directly attacks successful-case CI amplification. [2] Because Refinery already lives inside an agent-native orchestration system, it is a plausible long-term home for merge scheduling in Gas City/Gas Town.
-
-The natural extensions would be:
-
-1. Zuul-style speculative future-state windows.
-2. Mergify/Trunk-style scope-aware independent lanes.
-3. An affectedness interface supplied by Pants/Bazel/Buck2 or a repository-specific graph.
-4. A shared action/evidence cache.
-5. Eventually, verification-graph-aware invalidation instead of batch/commit invalidation.
-
-### 6.5 Pants: probably the lowest-friction OSS experiment for Gas City's Go-heavy repo
-
-Pants provides fine-grained invalidation, sandboxed/hermetic process execution, exact input-based caching, remote caching/execution via REAPI, and Git-aware changed-target operation. Its Go support includes per-package test-result caching and `--changed-since`, although Go support remains labeled beta. [22][23][24]
-
-For Gas City, that tradeoff is attractive: Pants can test the **incremental-verification hypothesis** without first converting the repository to Bazel.
-
-### 6.6 Bazel: the mature gold standard, with real migration cost
-
-Bazel is the strongest existing OSS demonstration of deterministic dependency graphs + content-addressed action caching + remote execution. [8] If Gas City were already a Bazel shop, it would be the obvious foundation. Adopting it primarily to fix CI is a much larger migration.
-
-`bazel-diff` and `target-determinator` can add affected-target analysis between revisions for Bazel-based repositories, making the relationship to merge scheduling even stronger.
-
-### 6.7 Buck2: important validation of the model
-
-Meta's Buck2 uses a single incremental dependency graph, hermetic rules, remote execution compatible with the Bazel Remote Execution API, and integration with virtual filesystems. Meta reports millions of internal builds per day. [10]
-
-Buck2 is evidence that the “incremental graph + remote cache/execution” pattern is not Google-specific. It is also a possible technical option, but less obvious than Pants for a low-risk Gas City pilot.
-
-### 6.8 Buildbarn / bazel-remote: shared compute memory
-
-Buildbarn is an Apache-2.0 implementation of the Remote Execution API, providing distributed content-addressed storage, action cache, scheduling, and remote execution. [25] For a lighter cache-only experiment, `bazel-remote` is an established REAPI-compatible cache.
-
-This layer is important because a verifier result that is reusable only on one runner is not useful at 10,000 changes/day. **The cache must be organizational, not local.**
-
-### 6.9 Nx: a parallel example from the JS/TS ecosystem
-
-Nx's `affected` command computes the minimal project set affected by Git changes using its project graph, and its task cache keys work from declared inputs. Nx now documents a self-hosted remote-cache API. [26][27]
-
-Nx is not the likely foundation for Gas City's Go code, but it validates the same architectural shape: affectedness first, then task-level cache reuse.
-
-## 7. Recommended OSS Reference Stack
-
-The fastest way to test the thesis is **not** to build the missing system first. Assemble the best existing pieces and measure what remains.
-
-```text
-                         GitHub
-                            │
-                            ▼
-                Integration / merge scheduler
-                Zuul  OR  Gas Town Refinery
-                            │
-                  future integration states
-                            │
-                            ▼
-               Affectedness + task graph
-                  Pants (pilot) / Bazel
-                            │
-                 exact process/action keys
-                            │
-                 ┌──────────┴──────────┐
-                 ▼                     ▼
-            cache hit              cache miss
-                 │                     │
-                 │             current runners /
-                 │             remote execution
-                 │                     │
-                 └──────────┬──────────┘
-                            ▼
-               Buildbarn / bazel-remote
-                     shared REAPI cache
-                            │
-                            ▼
-                    admission decision
-                            │
-                            ▼
-                          main
-```
-
-### Layer 1 — keep GitHub as source of record
-
-Do not replace Git or GitHub to solve this problem. Keep branches, review UI, permissions, status reporting, and canonical source history there. At 10,000 logical changes/day, batch logical changes into fewer publication transactions rather than assuming each logical change must consume a separate PR merge.
-
-### Layer 2 — eliminate human merge serialization
-
-**Reference implementation:** Zuul.
-
-**Strategic Gas Town path:** evolve Refinery toward the same semantics.
-
-The scheduler should construct and validate the future states changes will actually enter, and should allow independent scopes to advance concurrently.
-
-### Layer 3 — stop running obviously unaffected work
-
-Pilot Pants against the Go repository. Use it initially in shadow mode: ask Pants which tests/processes are affected, but continue running the existing full required checks as an audit. Compare Pants's predicted invalidation set to actual failures.
-
-If Pants's Go limitations prove material, evaluate a Bazel/Buck2 migration separately rather than contaminating the merge-queue experiment.
-
-### Layer 4 — share exact work across every runner
-
-Deploy `bazel-remote` first if a simple cache is sufficient; move to Buildbarn if remote execution or scalable CAS/action-cache topology becomes valuable.
-
-The objective is that identical verifier actions across PRs, agents, speculative states, and developer machines converge on a single cached result.
-
-### Layer 5 — preserve existing Actions/Blacksmith investment
-
-The experiment need not replace the current GitHub Actions pipeline. Current jobs can call Pants or other affectedness tooling, consume the remote cache, and report normal checks. Replace execution infrastructure only if measurement shows it is still a bottleneck.
-
-## 8. What This Stack Should Do for Julian and Steve
-
-For the moving-main problem:
-
-```text
-Before:
-B green on main@100
-A merges
-B's entire proof is stale
-rebase + rerun
-
-With merge scheduling:
-B is already tested against predicted main+A
-A merges
-B can continue without human intervention
-```
-
-For verification saturation:
-
-```text
-Before:
-new integration state
-→ run all required jobs
-
-With affectedness + exact action cache:
-new integration state
-→ compute affected task graph
-→ reuse tasks with identical inputs
-→ execute only cache misses
-```
-
-This should remove a large fraction of CTO/architect babysitting and make queue throughput depend more on **actual conflicts and changed dependencies** than on raw PR count.
-
-It still does not deliver the complete 10,000/day thesis, because the reuse boundary is mostly **process execution**. That is why the experiment is valuable: it tells us whether process-level caching is already sufficient or whether a more general evidence layer is required.
-
-## 9. The Experiment: Prove or Kill the Thesis
-
-The right test is not “does the demo feel faster?” It is a controlled measurement of proof churn and marginal verification cost.
-
-### 9.1 Instrument the current baseline
-
-Record, for every required check and every ready PR/change:
-
-- arrival time and ready-to-merge time;
-- base SHA when each check started;
-- reason a check/re-run was triggered;
-- changed files and current Gas City scope classification;
-- job identity/version and execution environment;
-- wall time and compute time;
-- pass/fail/flake classification;
-- cache hit/miss where available;
-- whether prior success was discarded solely because the base advanced;
-- human actions required to rebase, rerun, dequeue, or unblock;
-- final merge order and broken-main/revert outcomes.
-
-From those data, compute:
-
-**Proof churn ratio** = verification work repeated after a base advance / total verification work.
-
-**Marginal verification cost** = new verification compute consumed / merged logical change.
-
-**Queue amplification** = CI validations executed / logical changes merged.
-
-**Human serialization cost** = maintainer interventions / logical changes merged.
-
-### 9.2 Experiment A — scheduling only
-
-Run Zuul (or a Refinery implementation of equivalent semantics) in shadow mode on the live queue. Compare the future-state DAG it would have constructed with the actual sequence of rebases/retests.
-
-Then gate a low-risk subset through it.
-
-**Question:** How much of the pain disappears purely by removing human serialization?
-
-### 9.3 Experiment B — affectedness only
-
-Introduce Pants or an equivalent dependency engine in audit mode. For each CI run, record which packages/tests/actions it says can be skipped. Continue full verification in parallel so false non-invalidations are detectable.
-
-**Question:** What fraction of Gas City's current CI work is actually invalidated by an average change?
-
-### 9.4 Experiment C — shared action cache
-
-Connect the dependency engine to bazel-remote or Buildbarn. Run the same candidate stream across multiple workers and measure cache hits, bytes transferred, and compute avoided.
-
-**Question:** How much work is identical across different PRs and integration states once action identity is precise?
-
-### 9.5 Experiment D — combined stack
-
-Run the speculative merge DAG and affectedness/cache layer together. This is the real test: when an upstream candidate lands or fails, how much downstream verification survives?
-
-Suggested success metrics for the pilot should be agreed before running it. Reasonable starting targets to debate with the community are:
-
-| Metric                                                        |                                         Suggested pilot target |
-| ------------------------------------------------------------- | -------------------------------------------------------------: |
-| Manual rebase/retest interventions for queue-managed changes  |                                                 Reduce by ≥90% |
-| Verification compute repeated solely because base moved       |                                                 Reduce by ≥70% |
-| p95 ready-to-merged latency                                   |                          Approach ≤2 full CI cycles under load |
-| Cache/evidence reuse for unrelated or lightly related changes |                                          ≥70% of eligible work |
-| False non-invalidation in audited runs                        |                                                              0 |
-| Broken-main / revert rate                                     |                                         No worse than baseline |
-| Scheduler throughput                                          | Sustain ≥7 logical changes/minute in simulation; burst ≥20/min |
-
-The exact percentages are hypotheses, not promises. The non-negotiable safety target is **zero known false reuse** during the audit phase.
-
-### 9.6 Experiment E — 10,000/day control-plane stress test
-
-Do not create 10,000 real GitHub PRs. Feed 10,000 logical candidate events through the scheduler and verification planner using a distribution derived from real Gas City changes. Include realistic overlap, failures, flakes, shared-core changes, and bursts.
-
-The test should answer:
-
-- Does the queue remain bounded at a sustained average of ~6.94 logical changes/minute?
-- What percentage of verification nodes are newly executed vs reused?
-- How often does one failed upstream candidate destroy downstream work?
-- Can independent scopes proceed without waiting?
-- What publication batch size is needed to remain within GitHub's operational recommendations?
-- How many human escalations would 10,000 changes create under current policy?
-
-If the OSS stack keeps up economically and safely, stop. We have solved the problem with existing technology.
-
-If the queue still falls behind because useful verification results cannot survive changes to unrelated state, the missing abstraction has been isolated.
-
-## 10. The Missing Layer: An Open Verification Graph
-
-### 10.1 The one-line thesis
-
-> **Don't re-establish a fact unless something that fact depends on has changed.**
-
-An open verification graph generalizes the idea behind Bazel's action cache from **computations** to **claims about software**.
-
-### 10.2 Evidence is a first-class object
-
-A verifier should produce an immutable evidence record resembling:
-
-```text
-Evidence
-  proposition:  "internal/mail unit tests pass"
-  subject:      candidate tree / target digest
-  verifier:     mail-tests@<version-digest>
-  inputs:
-    - source/target digests
-    - transitive dependency digests
-    - fixture/config digests
-    - toolchain/environment digest
-    - command/flags
-  result:       PASS
-  outputs:      optional artifacts/logs
-  signature:    verifier identity
-```
-
-The evidence identifier is content-derived. Two independent candidates that require the same proposition over the same effective inputs should reference the same evidence node.
-
-### 10.3 The graph performs exact invalidation
-
-```text
-main advances
-     │
-     ▼
-Which content nodes changed?
-     │
-     ▼
-Traverse dependent evidence nodes
-     │
- ┌───┴─────────────┐
- │                 │
-still valid      invalid
- │                 │
-reuse            recompute
-```
-
-This is conservative by construction: undeclared dependencies are a correctness bug. Early implementations should over-invalidate rather than risk false reuse. Hermetic verifier execution and dependency capture are therefore foundational.
-
-### 10.4 It goes beyond tests and builds
-
-Evidence nodes can represent:
-
-- compilation success;
-- unit/integration/e2e test outcomes;
-- lint/static-analysis results;
-- API/ABI compatibility;
-- schema migration properties;
-- dependency/license/security policy;
-- generated-code consistency;
-- benchmark bounds;
-- deterministic review rules;
-- canary/post-submit health;
-- even LLM reviewer opinions, provided they are treated as probabilistic/advisory evidence rather than hard truth.
-
-This is the distinction between an action cache and a verification graph.
-
-### 10.5 It deduplicates in-flight verification too
-
-If 37 candidates simultaneously require the same uncached fact, the scheduler should launch it once and attach all 37 consumers to that future. At 10,000/day, this can matter as much as caching completed work.
-
-### 10.6 It makes admission policy compositional
-
-A change class can declare the evidence required to ship:
-
-```text
-mechanical_refactor:
-  requires:
-    - affected compilation passes
-    - affected unit tests pass
-    - public API unchanged
-    - formatter/lint pass
-    - integration policy satisfied
-```
-
-Policy does not ask whether “CI is green.” It asks whether the required propositions are currently established for the candidate's exact integration state.
-
-SLSA's Verification Summary Attestation and the in-toto attestation framework are promising existing schemas for authenticated evidence, while OPA is a plausible policy engine with versioned policy bundles and auditable decision logs. [28][29][30] None of them supplies the invalidation/planning graph itself.
-
-## 11. Why the Open Verification Graph Could Matter Beyond Gas City
-
-The industry is converging on agents that can create more software changes than human-centric CI/CD was designed to absorb. The immediate response has been “more agents” on the generation side and “more runners” on the verification side. That scales cost, not architecture.
-
-An open verification graph could provide:
-
-1. **Sublinear verification cost.** The cost of one more change approaches the cost of the facts it actually invalidates.
-2. **Cross-agent reuse.** Thousands of agents share already-established truths rather than independently rediscovering them.
-3. **Cross-queue reuse.** Evidence can survive failed speculative parents when its real inputs are unaffected.
-4. **Vendor-neutral CI memory.** Evidence is not trapped in GitHub Actions, Buildkite, Jenkins, or one merge-queue vendor.
-5. **Auditable autonomous admission.** A policy decision can enumerate exactly which evidence justified publication.
-6. **A path from PR review to policy governance.** Humans can progressively automate well-understood change classes while escalating anomalies.
-7. **A common substrate for OSS.** Any verifier can publish evidence if it follows the schema and dependency rules.
-
-The sharpest formulation is:
-
-> **Merge queues cache ordering. Build systems cache computation. What is missing is a cache of verified truths.**
-
-If that statement is wrong — if Zuul/Refinery + Pants/Bazel + REAPI caching already makes 10,000/day practical — we should happily discover that through measurement and avoid building another subsystem.
-
-If it is right, then the verification graph is not “another CI product.” It is a potential **admission substrate for autonomous software factories**.
-
-## 12. Proposed Next Steps for Gas City and the OSS Community
-
-### Immediate
-
-1. Instrument Gas City's current pipeline to measure proof churn, queue amplification, and human serialization.
-2. Enable or prototype future-state merge scheduling (`merge_group`, Zuul, or Refinery-equivalent) rather than requiring every PR to chase `main`.
-3. Pilot Pants affectedness/caching on a representative Go slice in audit mode.
-4. Stand up a shared REAPI cache (bazel-remote first; Buildbarn if warranted).
-5. Replay historical/live change streams through the combined scheduler in shadow mode.
-
-### Then decide based on evidence
-
-If existing OSS keeps the queue bounded and compute affordable, adopt it and stop.
-
-If the remaining dominant cost is repeated verification whose actual dependencies are unchanged, prototype the **smallest possible verification graph** by wrapping existing CI jobs as coarse evidence nodes. Do not begin by inventing new test runners or a new forge. Refine the graph only where coarse invalidation is demonstrably expensive.
-
-### Questions for Julian, Steve, and the community
-
-- Which Gas City checks are genuinely hermetic today?
-- Which checks have undeclared dependencies that would make result reuse unsafe?
-- How much CI is repeated because `main` changed versus because relevant source actually changed?
-- Does Refinery want to own speculative integration scheduling, or should it consume an external scheduler such as Zuul?
-- Is Pants sufficiently accurate/mature for Gas City's Go dependency graph, or is Bazel/Buck2 worth the migration cost?
-- Which change classes could eventually be admitted by policy without per-change human review?
-- What is the right open schema for evidence identity and dependencies?
-- Can SLSA/in-toto be extended rather than inventing another attestation format?
-- How should probabilistic evidence (LLM review, predictive test selection) compose with deterministic evidence?
-- What is the minimum viable implementation that proves evidence survival across a moving `main`?
+GitHub remains the source of record. GitHub Actions and Blacksmith remain the
+execution layer until a measured bottleneck justifies replacing them. Gas City
+prompts shape the work; trusted CI code computes affectedness and establishes
+the facts used for admission.
+
+## 8. Immediate next steps
+
+1. Extend the existing timing telemetry to measure logical changes,
+   publication transactions, proof churn, invalidation surface, and maintainer
+   intervention.
+2. Add small-change and blast-radius guidance to the development formulas used
+   by Gas City agents.
+3. Turn the existing CI path groups and test owners into an explicit initial
+   component/dependency map, retaining `shared` as the fail-closed fallback.
+4. Add and test `merge_group` support on a bounded branch or change class.
+5. Replay historical changes through the component planner and merge scheduler
+   before either controls admission.
+6. Define one bounded change class for audited policy-based admission, with
+   explicit required proofs and escalation triggers.
+7. Pilot batching with stable logical-change identities and batch-then-bisect
+   failure isolation.
+8. Run a Pants shadow pilot only if the current affectedness model remains a
+   material source of excess work.
+9. Add a shared action-cache pilot only after a client can produce safe,
+   reproducible keys and the cache trust boundary is defined.
+10. Run the 10,000/day load test, publish the measurements, and choose the
+   smallest stack that keeps the queue bounded.
 
 ## Conclusion
 
-Gas City's current pain is an early signal of a general transition. When coding agents can produce changes faster than a human team can integrate them, the bottleneck moves downstream: from **writing code** to **establishing that code is safe to admit**.
+Gas City gets to 10,000 changes per day by controlling the entire admission
+path, beginning with the shape of the change itself.
 
-The first step is not a new forge. It is to use the best existing integration and build-system ideas together: speculative merge scheduling, dependency-aware affectedness, batching, precise content-addressed caching, and shared execution. Google has demonstrated many of these principles independently at enormous scale through Rosie/TAP and Blaze; modern products and OSS systems have brought much of that machinery outside Google.
+Agents should produce the smallest independently useful changes. Component
+boundaries should let unrelated work proceed and harden independently. The
+merge scheduler should test future states and publish groups of logical changes
+without making every PR chase `main`. CI should run the smallest truthful proof
+set and reuse exact work behind a clear trust boundary.
 
-But 10,000 autonomous changes per day pushes one step further. A commit SHA is too coarse a unit of invalidation, and a CI run is too coarse a unit of knowledge.
+The target is straightforward:
 
-The engineering target should be:
+> **Each new change pays only for the uncertainty it creates, and the queue
+> stays bounded while 10,000 useful changes become canonical every day.**
 
-> **A software factory in which each new change pays only for the uncertainty it creates.**
-
-That is the purpose of the proposed open verification graph. The next move is to measure whether we need it.
+Measure each layer, add machinery only where the measurements require it, and
+stop when the target is met.
 
 ---
 
 ## References
 
-1. [Gas City repository: .github/workflows/ci.yml](https://github.com/gastownhall/gascity/blob/main/.github/workflows/ci.yml)
+1. [GitHub Docs: Repository limits](https://docs.github.com/en/repositories/creating-and-managing-repositories/repository-limits)
 
-2. [Gas Town Architecture: Merge Queue — Batch-then-Bisect](https://github.com/gastownhall/gastown/blob/main/docs/design/architecture.md)
+2. [Gas City repository: `.github/workflows/ci.yml`](https://github.com/gastownhall/gascity/blob/main/.github/workflows/ci.yml)
 
-3. [GitHub Docs: Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+3. [Gas City testing policy](../../TESTING.md)
 
-4. [GitHub Docs: Repository limits](https://docs.github.com/en/repositories/creating-and-managing-repositories/repository-limits)
+4. [Gas City testing-efficiency operating corpus](../../engdocs/contributors/testing-efficiency-workflow-corpus.md)
 
-5. [Software Engineering at Google, Chapter 22: Large-Scale Changes](https://abseil.io/resources/swe-book/html/ch22.html)
+5. [GitHub Docs: Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
 
-6. [Steve Yegge: Dear Google Cloud — discussion of Grok and Rosie](https://yegge.ai/essays/dear-google-cloud-your-deprecation-policy-is-killing-you/)
+6. [Gas Town Architecture: Merge Queue — Batch-then-Bisect](https://github.com/gastownhall/gastown/blob/main/docs/design/architecture.md)
 
-7. [Bazel FAQ: internal Blaze lineage and scale](https://bazel.build/about/faq)
+7. [Pants Docs: Go overview](https://www.pantsbuild.org/stable/docs/go)
 
-8. [Bazel Docs: Remote Caching](https://bazel.build/remote/caching)
+8. [Pants Docs: Remote caching and execution](https://www.pantsbuild.org/stable/docs/using-pants/remote-caching-and-execution)
 
-9. [Bazel docs: Distributed builds (ObjFS and Forge)](https://bazel.build/basics/distributed-builds)
+9. [Bazel Docs: Remote caching](https://bazel.build/remote/caching)
 
-10. [Meta Engineering: Build faster with Buck2](https://engineering.fb.com/2023/04/06/open-source/buck2-open-source-large-scale-build-system/)
+10. [Zuul Docs: Project gating](https://zuul-ci.org/docs/zuul/latest/gating.html)
 
-11. [Mergify Docs: Queue Modes](https://docs.mergify.com/merge-queue/queue-modes/)
+11. [`bazel-remote`: REAPI-compatible remote cache](https://github.com/buchgr/bazel-remote)
 
-12. [Mergify Docs: Merge Queue Batches](https://docs.mergify.com/merge-queue/batches/)
-
-13. [Trunk Docs: Parallel Queues](https://docs.trunk.io/merge-queue/optimizations/parallel-queues)
-
-14. [Trunk Docs: Pending Failure Depth](https://docs.trunk.io/merge-queue/optimizations/pending-failure-depth)
-
-15. [Aviator Docs: Affected Targets](https://docs.aviator.co/mergequeue/concepts/affected-targets)
-
-16. [Aviator Docs: Batching](https://docs.aviator.co/mergequeue/concepts/batching)
-
-17. [Graphite Docs: Merge Queue Optimizations](https://graphite.com/docs/merge-queue-optimizations)
-
-18. [Develocity Docs: Predictive Test Selection](https://docs.gradle.com/develocity/predictive-test-selection)
-
-19. [Zuul Docs: Project Gating](https://zuul-ci.org/docs/zuul/latest/gating.html)
-
-20. [Prow Docs: Tide](https://docs.prow.k8s.io/docs/components/core/tide/)
-
-21. [rust-lang/bors](https://github.com/rust-lang/bors)
-
-22. [Pants Docs: How does Pants work?](https://www.pantsbuild.org/stable/docs/introduction/how-does-pants-work)
-
-23. [Pants Docs: Go overview](https://www.pantsbuild.org/dev/docs/go)
-
-24. [Pants Docs: Remote caching & execution](https://www.pantsbuild.org/dev/docs/using-pants/remote-caching-and-execution)
-
-25. [Buildbarn: distributed cache and remote execution](https://github.com/buildbarn)
-
-26. [Nx Docs: Run Only Tasks Affected by a PR](https://nx.dev/docs/features/ci-features/affected)
-
-27. [Nx Docs: Self-hosted remote cache](https://nx.dev/docs/kb/self-hosted-caching)
-
-28. [SLSA v1.2: Verification Summary Attestation](https://slsa.dev/spec/v1.2/verification_summary)
-
-29. [in-toto: software supply-chain attestations](https://in-toto.io/docs/what-is-in-toto/)
-
-30. [Open Policy Agent: policy management and decision logs](https://www.openpolicyagent.org/docs/management-introduction)
+12. [Buildbarn: distributed cache and remote execution](https://github.com/buildbarn)

--- a/specs/proposals/0001-increasing-ci-throughput.md
+++ b/specs/proposals/0001-increasing-ci-throughput.md
@@ -328,6 +328,25 @@ Independent component lanes matter as much as batch size. A failure in one
 component should not block unrelated changes elsewhere. Shared-core changes
 enter the broader lane whose dependents they invalidate.
 
+The publication commit structure is part of the identity contract, and it is
+registered rather than assumed. A single-change publication may squash: one
+logical change, one canonical commit, identity trivially preserved. A
+multi-change batch publishes as a merge commit whose first-parent chain
+carries one rebased commit per logical change in dependency order, so every
+logical change ID maps to exactly one canonical SHA and `git revert` of one
+mid-batch commit is the default repair path. Batches are never squashed:
+squashing collapses the batch to a single commit and degrades selective
+repair to patch reconstruction. The repository ruleset already permits both
+merge methods, so this is publication policy, not new forge machinery.
+
+Selective revert also has an honest limit, and the batcher enforces it
+rather than papering over it: changes that touch the same hunks share a
+batch only when they are dependency-related, and a dependency-closed
+subgraph reverts as a unit or not at all. Where a clean revert is impossible,
+forward repair from the recorded patch is the fallback, and the publication
+record states which repair path each logical change actually has instead of
+promising one it does not.
+
 ### 4.2 Keep humans off routine happy paths
 
 Ten thousand changes per day cannot require ten thousand human approvals. For a
@@ -344,8 +363,39 @@ broad blast radius fails closed into human review. Humans govern the policy,
 audit samples, and handle exceptions.
 
 Expand automated admission one audited change class at a time. Track its
-escalation rate, escaped-defect rate, rollback rate, and human minutes per
+escalation rate, escaped-defect rate, rollback rate, and human touches per
 accepted change.
+
+The arithmetic makes admission coverage the load-bearing number, so the
+design states it instead of implying it. At the registered compression
+target, the directional horizon is roughly 1,000 publication transactions
+per day; if each crossed a human reviewer at even five to fifteen minutes,
+routine review alone would cost 80 to 250 person-hours per day. Routine
+review therefore cannot scale with volume, and the plan must say how fast it
+retires.
+
+Define **admission coverage** as the fraction of accepted logical changes
+admitted by declarative policy without a routine human review. Human work is
+then two streams — the reviewed publications of the uncovered fraction, and
+the exceptions escalated from automated lanes — and both draw down one
+finite, registered daily human-touch budget (routine reviews plus exceptions
+plus interventions), ratcheted from the measured capacity of the actual
+team. That budget is what forces coverage upward: the registered milestones
+require coverage of at least 0.5 before sustained volume passes 500 changes
+per day, 0.9 before 2,000, and 0.99 before the 10,000/day shape, with the
+exception rate under its registered bound and the stricter auto-admission
+miss bound holding throughout. Volume growth that would breach the touch
+budget waits for coverage, not the reverse.
+
+Coverage expands class by class. Inventory change classes by provenance,
+scope, and proof determinism; order them by volume share times proof
+stability, so the classes that buy the most coverage graduate first —
+dependency bumps, generated-file refreshes, and codemod output are the
+plausible front of that queue, and judgment-heavy shared-core work is the
+back. Reviewed lanes are not required to carry the compression target:
+small human-reviewed publications and heavily batched automated lanes
+coexist, because the forge limit binds the publication stream as a whole,
+not each lane — batching optimizes the lanes humans no longer read.
 
 ## 5. Run the smallest truthful proof set
 
@@ -553,7 +603,7 @@ effort.
 
 **Stop condition:** automate only if every admission decision is explained by
 explicit predicates and proofs. Missing or ambiguous evidence must fail closed;
-a high exception rate means the class is not ready.
+an exception rate above the registered bound means the class is not ready.
 
 ### Phase 6: shared cache
 

--- a/specs/proposals/0001-increasing-ci-throughput.md
+++ b/specs/proposals/0001-increasing-ci-throughput.md
@@ -111,7 +111,10 @@ would need 6.94 logical changes per merged PR to stay near the first limit, or
 reviewed PR publication as the primary pressure model. [1]
 
 This makes batching a design requirement for a sufficiently hot repository,
-not for every fleet topology. GitHub Merge Queue grouping is publication
+not for every fleet topology. The registered compression target is at least
+ten logical changes per publication transaction in the hot-repository shape —
+the 6.94 floor plus thirty percent forge headroom
+([`0001-bounds.toml`](0001-bounds.toml)). GitHub Merge Queue grouping is publication
 scheduling: it does not create pre-PR logical batches or combine the underlying
 builds. A Gas City batch is a transport unit and must not erase the identity,
 dependency order, audit trail, or selective repair path of the logical changes
@@ -135,18 +138,34 @@ test and capacity model must include:
 - queue depth, oldest-ready age, tail latency, and post-burst drain time.
 
 Recent Gas City history should calibrate change shape, proof cost, failure rate,
-and human work. It does not set the target volume. Synthetic cases then exercise
-the four future workload shapes and stress the tails: a burst against one shared
-package, many independent component changes, a cache outage, a failing change
-at the front of the queue, and a coordinated change spanning Gas City, T3 Code,
-and the beads backend.
+and human work. It does not set the target volume. The burst profile and
+workload-shape mix are registered values: the initial registration uses the
+measured arrival distribution and a 55/20/15/10
+hot-repository/fleet/shared-core/cross-repository mix. Synthetic cases then
+exercise the four future workload shapes and stress the tails: a burst against
+one shared package, many independent component changes, a cache outage, a
+failing change at the front of the queue, and a coordinated change spanning
+Gas City, T3 Code, and the beads backend.
 
-For every constrained resource—the forge and its API, candidate construction,
-queues, runners, caches, publication, and human exception handling—offered load
-must remain below measured sustainable service capacity with positive headroom.
-Phase 0 establishes those service curves through baseline telemetry and
-controlled saturation tests. The capacity, tail-latency, compute, and
-human-work limits are then fixed before the combined load test.
+Constrained resources split into two classes. **Measured resources** are owned
+infrastructure — candidate construction, queues, runners, caches, the beads
+work ledger, and the event bus — whose sustainable service curves Phase 0
+establishes through baseline telemetry and controlled saturation tests.
+**Modeled resources** cannot be saturation-tested — the forge and its API,
+publication, routine review, and human exception handling — so each carries a
+registered capacity model naming its evidence basis, the largest canary that
+validated it, and an extrapolation factor capped at twenty times that canary.
+For every resource, offered load must remain below measured or model-predicted
+sustainable capacity with positive headroom.
+
+Every registered bound, budget, assumption, and ratchet lives in the checked
+ledger [`specs/proposals/0001-bounds.toml`](0001-bounds.toml). A bound is
+registered for a phase run only when the commit recording it predates that
+run; the ledger's git history is the audit trail, and a guard test in
+`test/docsync` keeps the ledger and this document in sync. Because the
+10,000/day figure is directional, bounds are ratchets anchored to measured
+baselines — re-derived at each sustained doubling of accepted-change volume —
+rather than fixed horizon values.
 
 ## 2. Start from Gas City's current system
 
@@ -357,7 +376,11 @@ Go backend remains beta and has unsupported edges, so it is an experiment, not
 the default architecture. [7][8]
 
 Before the pilot, register the acceptable miss-rate bound, confidence target,
-sample size, workload strata, and delayed observation window. Exercise seeded
+sample size, workload strata, and delayed observation window. The miss-rate
+bound is two-tier: one bound for human-reviewed lanes and a stricter bound
+plus an ongoing random full-union audit fraction for auto-admitted classes.
+Every bound is restated at exposure — expected escapes per day at current
+volume — and re-accepted at each sustained volume doubling. Exercise seeded
 hidden-dependency cases and retain random full-union runs after rollout so drift
 stays visible. Any missed failure broadens the rule and removes it from
 admission until it passes again.
@@ -412,27 +435,39 @@ loss and has a stop condition. A control enters admission only after its own
 safety gate passes. Phase 0 supplies the baseline used to set capacity, tail
 latency, compute, human-work, and safety limits; those limits are registered
 before the combined test rather than chosen after seeing its results.
+Registered means committed to the bounds ledger
+([`0001-bounds.toml`](0001-bounds.toml)): a bound counts for a run only when
+its commit predates that run, and a guard test keeps the ledger and this
+document in sync. Most bounds are ratchets — a baseline measured by the named
+phase, a no-regression rule, and re-derivation at each sustained doubling of
+accepted-change volume.
 
 ### Phase 0: establish identity and the baseline
 
 Define the Beads projection for parent outcomes and logical changes, then carry
 those IDs through candidates, proofs, batches, and publication transactions.
-Use controlled load to find each constrained resource's sustainable service
-curve rather than extrapolating from an underloaded production sample.
+Use controlled load to find each measured resource's sustainable service
+curve rather than extrapolating from an underloaded production sample; a
+modeled resource is validated instead by the largest canary its owner permits,
+and its capacity model records that canary and the extrapolation factor.
 
 For every required check and ready logical change, record:
 
 - creation, ready, queue-entry, verification, and publication times;
 - parent outcome, logical change, integration candidate, batch, and publication
   transaction IDs;
-- base SHA and reason each run or rerun was triggered;
+- base SHA and patch identity for each run, so rerun causes classify
+  mechanically: an identical patch on a new base is a base-advance rerun, and
+  an identical patch and base that now passes is a flake;
 - changed components and predicted proof set;
 - suite mode (`filtered` or `full`) and actual jobs executed;
 - wall time, compute time, queue time, and setup time;
 - cache hits, misses, and bytes transferred;
 - pass, failure, flake, and infrastructure-failure classification;
 - prior successes discarded solely because the base advanced;
-- human actions and minutes required to rebase, rerun, dequeue, or unblock;
+- human interventions (rerun, dequeue, manual rebase, forced merge) counted
+  from forge audit records, with a quarterly sampled time study converting
+  counts to minutes;
 - queue depth, oldest-ready age, and post-burst drain time;
 - offered load and sustainable service rate at each constrained resource; and
 - merge order, rollback, and broken-`main` outcomes.
@@ -446,14 +481,21 @@ Compute:
 | Publication compression | Accepted logical changes / publication transactions |
 | Proof churn ratio | Verification compute repeated after a base advance / total verification compute |
 | Invalidation surface | Proof nodes selected / proof nodes available |
-| Verification cost | Full-suite-equivalent compute / accepted logical change and completed parent outcome |
+| Verification cost | Full-suite-equivalent (FSE) compute / accepted logical change and completed parent outcome; one FSE is the full-union suite priced at the SHA pinned in the bounds ledger |
 | Queue amplification | Integration states validated / accepted logical changes |
 | Queue health | Queue depth, oldest-ready age, p95/p99 ready-to-canonical latency, and drain time |
 | Capacity headroom | Sustainable service capacity minus offered load at each constrained resource |
-| Human serialization cost | Maintainer interventions and minutes / accepted logical change |
+| Human serialization cost | Maintainer interventions / accepted logical change; minutes come only from the sampled time study |
+| Backlog latency | Creation-to-ready distribution; the hard bound applies to dependency-free changes only |
+| External value anchor | User-facing issues closed and shipped release-notes entries per week, reported beside throughput |
 
 The timing work should extend the existing `ga-80po0c.4` telemetry rather than
 create a parallel measurement system. [3][4]
+
+Phase 0 also registers the flake policy: a per-job flake-rate assumption held
+only until measurement replaces it, the mechanical classification rule above,
+and a quarantine rule for repeat offenders. No queue or batching phase begins
+before that policy is registered.
 
 ### Phase 1: change shaping
 
@@ -479,7 +521,10 @@ reported with its actual confidence and coverage, not as proof of impossibility.
 
 Run GitHub Merge Queue on a bounded stream. Measure base-advance reruns, queue
 latency, duplicate compute, and manual intervention. Exercise every required
-workflow, the live ruleset, the canary, and operator rollback.
+workflow, the live ruleset, the canary, and operator rollback. The phase runs
+under the registered queue-amplification bound, and its measured
+ready-to-canonical latency and post-burst drain become the baselines the
+admission-latency ratchet holds thereafter.
 
 **Stop condition:** if moving-main churn becomes negligible, do not add Zuul or
 build equivalent scheduling machinery in Refinery.
@@ -488,7 +533,13 @@ build equivalent scheduling machinery in Refinery.
 
 Replay and canary batches in the hot-repository workload. Measure publication
 compression, combined-proof reuse, failure contamination, split cost, and time
-to isolate the minimal failing dependency-closed subset.
+to isolate the minimal failing dependency-closed subset. Bisection uses the
+registered flake policy: a failure is attributed only when it reproduces under
+the rerun criterion, which is also what makes the minimal failing subset
+well-defined. The failure-contamination bound is registered before the phase
+begins, and the first deliberate forge canary — one merged pull request per
+minute sustained for sixty minutes — runs at this phase's entry to validate
+the forge capacity model.
 
 **Stop condition:** keep batching only where it reduces publication or proof
 pressure without losing identity, dependency order, or failure containment.
@@ -520,30 +571,54 @@ workload shapes through the complete planner and scheduler. Model large-volume
 capacity offline and use smaller real GitHub canaries for forge behavior; do
 not create 10,000 real pull requests.
 
-The directional 10,000/day scenario succeeds when it:
+Each success criterion is labeled by how it is established. **Measured**
+criteria run on the real system or its canary. **Modeled** criteria are
+predictions of the registered capacity model, valid only within its
+extrapolation cap of the largest validating canary. **Imported** criteria are
+earlier phases' evidence restated at target-volume exposure; Phase 7 adds no
+proof of its own for them.
 
-- sustains an average 6.94 accepted logical changes per minute and the
-  registered burst profile with positive headroom at every constrained
-  resource;
-- keeps queue depth, oldest-ready age, p95/p99 ready-to-canonical latency, and
-  post-burst drain time within their registered bounds;
-- achieves the required publication compression in the hot-repository shape;
-- keeps p95 protected feedback within the `TESTING.md` target;
-- stays within the registered full-suite-equivalent compute budget per accepted
-  logical change and completed parent outcome;
-- stays within the registered maintainer-intervention and human-minute budgets;
-- meets the registered affectedness and admission safety bounds at their stated
-  confidence and workload coverage;
-- shows no worse broken-`main` or rollback rate than the baseline;
-- survives scheduler restart, cache loss, and a failing shared-core change;
-- keeps unrelated component lanes moving during localized failures; and
-- reports every logical change, proof result, batch membership, and publication
-  outcome without silent loss.
+The directional 10,000/day scenario succeeds when:
+
+**Measured, on the real system and canaries:**
+
+- p95 protected PR feedback stays within the `TESTING.md` target, and the
+  admission-latency SLO — ready-to-canonical p95/p99 over merge-group and
+  batch builds — stays within its ratcheted bounds (two SLOs over two distinct
+  run populations);
+- the canary survives scheduler restart, cache loss, and a failing shared-core
+  change within the registered recovery bounds;
+- unrelated component lanes keep accepting changes during localized failures;
+  and
+- every logical change, proof result, batch membership, and publication
+  outcome reconciles dual-entry: the count published per the Beads publication
+  mapping equals the count derived independently from forge history.
+
+**Modeled, by the registered capacity model within its extrapolation cap:**
+
+- sustained 6.94 accepted logical changes per minute and the registered burst
+  profile with positive headroom at every resource, measured or modeled;
+- queue depth, oldest-ready age, ready-to-canonical tails, and post-burst
+  drain within their registered bounds;
+- the registered publication-compression target in the hot-repository shape,
+  with the failure-contamination bound holding alongside it; and
+- the FSE compute ratchet and the intervention ratchet, with per-change rates
+  taken from canary measurement and scaled by the model.
+
+**Imported, restated at exposure:**
+
+- the Phase 2 and Phase 5 affectedness and admission bounds at their stated
+  confidence and workload coverage, with expected escapes per day recomputed
+  at target volume and re-accepted; and
+- a broken-`main` and rollback rate no worse than baseline on the canary, with
+  the model's failure assumptions calibrated from the baseline rather than fit
+  to the result.
 
 This scenario is evidence about the architecture's future headroom, not a claim
 that today's workload needs 10,000 changes or that every deployment must clear
 that volume before it can ship. The safety, truthfulness, and bounded-queue
-outcomes remain requirements at every operating scale.
+outcomes remain requirements at every operating scale, and the modeled
+criteria are claims about the model, disclosed as such.
 
 ## 7. The practical architecture
 
@@ -603,22 +678,27 @@ the facts used for admission.
 1. Define the Beads projection for parent outcomes and logical changes, then
    extend existing telemetry through candidates, proofs, batches, and canonical
    publication.
-2. Add small-change and blast-radius guidance to the development formulas used
+2. Keep the bounds ledger ([`0001-bounds.toml`](0001-bounds.toml)) current:
+   the initial burst basis, shape mix, compression target, ratchets, safety,
+   flake, and model values are registered; re-derive them at each sustained
+   volume doubling and keep the guard test green.
+3. Add small-change and blast-radius guidance to the development formulas used
    by Gas City agents.
-3. Build the initial component and dependency model from authoritative package
+4. Build the initial component and dependency model from authoritative package
    and build graphs plus explicit contracts; run affectedness in shadow mode
    with `shared` as the fail-closed fallback.
-4. Inventory required contexts and add `merge_group` support to every required
+5. Inventory required contexts and add `merge_group` support to every required
    workflow, then canary the ruleset migration with an operator rollback path.
-5. Pilot dependency-aware batching in the hot-repository shape, preserving
+6. Pilot dependency-aware batching in the hot-repository shape, preserving
    logical identity and isolating minimal failing subsets.
-6. Define one bounded change class for declarative admission and run its policy
+7. Define one bounded change class for declarative admission and run its policy
    in shadow mode with explicit proofs and fail-closed escalation.
-7. Run a Pants shadow pilot only if the audited affectedness model remains a
+8. Run a Pants shadow pilot only if the audited affectedness model remains a
    material source of excess work.
-8. Add a shared action-cache pilot only after a selected client can produce
+9. Add a shared action-cache pilot only after a selected client can produce
    exact keys and authorization between trust domains is defined.
-9. Run the combined directional 10,000/day scenario, publish the measurements,
+10. Run the combined directional 10,000/day scenario with each criterion
+    labeled measured, modeled, or imported, publish the measurements,
    and choose the smallest stack that keeps queues bounded with positive
    headroom.
 

--- a/test/docsync/throughput_bounds_test.go
+++ b/test/docsync/throughput_bounds_test.go
@@ -1,0 +1,174 @@
+package docsync
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// throughputBounds mirrors specs/proposals/0001-bounds.toml, the checked
+// ledger of registered bounds for the CI-throughput program. A bound the
+// proposal calls "registered" counts only if it lives here; this test keeps
+// the ledger and the proposal in sync (see ADR 0001).
+type throughputBounds struct {
+	Meta struct {
+		Owner    string `toml:"owner"`
+		Proposal string `toml:"proposal"`
+		Rederive string `toml:"rederive"`
+	} `toml:"meta"`
+	Workload struct {
+		ShapeMix   map[string]float64 `toml:"shape_mix"`
+		BurstBasis string             `toml:"burst_basis"`
+	} `toml:"workload"`
+	Publication struct {
+		CompressionMinChangesPerPR int     `toml:"compression_min_changes_per_pr"`
+		ForgeHeadroom              float64 `toml:"forge_headroom"`
+		Basis                      string  `toml:"basis"`
+	} `toml:"publication"`
+	Compute struct {
+		FSEPinSHA          string  `toml:"fse_pin_sha"`
+		FloorFSEPerChange  float64 `toml:"floor_fse_per_change"`
+		Ratchet            string  `toml:"ratchet"`
+		EstimateBasis      string  `toml:"estimate_basis"`
+		CurrentEstimateFSE float64 `toml:"current_estimate_fse"`
+	} `toml:"compute"`
+	Human struct {
+		Unit               string `toml:"unit"`
+		Bound              string `toml:"bound"`
+		MinutesConversion  string `toml:"minutes_conversion"`
+		CurrentObservation string `toml:"current_observation"`
+	} `toml:"human"`
+	Queue struct {
+		AdmissionSLO           string  `toml:"admission_slo"`
+		Bound                  string  `toml:"bound"`
+		DrainMax               string  `toml:"drain_max"`
+		CreationToReady        string  `toml:"creation_to_ready"`
+		AmplificationMaxPhase3 float64 `toml:"amplification_max_phase3"`
+		AmplificationMaxStress float64 `toml:"amplification_max_stress"`
+	} `toml:"queue"`
+	Safety struct {
+		MissRateReviewedMax     float64 `toml:"miss_rate_reviewed_max"`
+		MissRateAutoAdmittedMax float64 `toml:"miss_rate_auto_admitted_max"`
+		AuditFractionMin        float64 `toml:"audit_fraction_min"`
+		Confidence              float64 `toml:"confidence"`
+		MinAuditedRuns          int     `toml:"min_audited_runs"`
+		ObservationWindowDays   int     `toml:"observation_window_days"`
+		ExposureRestatement     string  `toml:"exposure_restatement"`
+	} `toml:"safety"`
+	Flakes struct {
+		PerJobFlakeAssumedMax float64 `toml:"per_job_flake_assumed_max"`
+		Classification        string  `toml:"classification"`
+		Quarantine            string  `toml:"quarantine"`
+		ReplacedBy            string  `toml:"replaced_by"`
+	} `toml:"flakes"`
+	Model struct {
+		ExtrapolationCap float64 `toml:"extrapolation_cap"`
+		ForgeCanary      string  `toml:"forge_canary"`
+	} `toml:"model"`
+	ValueAnchor struct {
+		Metrics []string `toml:"metrics"`
+	} `toml:"value_anchor"`
+}
+
+var shaRE = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// TestThroughputBoundsLedger verifies the bounds ledger exists, parses, holds
+// every section the proposal's "registered" language depends on, and that the
+// proposal and ledger reference each other.
+func TestThroughputBoundsLedger(t *testing.T) {
+	root := repoRoot()
+	ledgerPath := filepath.Join(root, "specs", "proposals", "0001-bounds.toml")
+
+	var b throughputBounds
+	if _, err := toml.DecodeFile(ledgerPath, &b); err != nil {
+		t.Fatalf("decoding bounds ledger %s: %v", ledgerPath, err)
+	}
+
+	if b.Meta.Owner == "" {
+		t.Error("meta.owner is empty")
+	}
+	if b.Meta.Rederive == "" {
+		t.Error("meta.rederive is empty: ratchets must name their re-derivation rule")
+	}
+	proposalPath := filepath.Join(root, "specs", "proposals", b.Meta.Proposal)
+	proposal, err := os.ReadFile(proposalPath)
+	if err != nil {
+		t.Fatalf("meta.proposal %q does not resolve: %v", b.Meta.Proposal, err)
+	}
+	if !strings.Contains(string(proposal), "0001-bounds.toml") {
+		t.Error("proposal never references the bounds ledger; \"registered\" has no registry")
+	}
+
+	var mixSum float64
+	for _, v := range b.Workload.ShapeMix {
+		mixSum += v
+	}
+	if len(b.Workload.ShapeMix) < 4 || mixSum < 0.999 || mixSum > 1.001 {
+		t.Errorf("workload.shape_mix must cover the four shapes and sum to 1.0, got %v (sum %.3f)", b.Workload.ShapeMix, mixSum)
+	}
+	if b.Workload.BurstBasis == "" {
+		t.Error("workload.burst_basis is empty: the burst profile must name its measurement basis")
+	}
+
+	if b.Publication.CompressionMinChangesPerPR < 7 {
+		t.Errorf("publication.compression_min_changes_per_pr = %d: below the 6.94 zero-headroom floor", b.Publication.CompressionMinChangesPerPR)
+	}
+	if b.Publication.ForgeHeadroom <= 0 || b.Publication.ForgeHeadroom >= 1 {
+		t.Errorf("publication.forge_headroom = %v: must be a fraction in (0,1)", b.Publication.ForgeHeadroom)
+	}
+
+	if !shaRE.MatchString(b.Compute.FSEPinSHA) {
+		t.Errorf("compute.fse_pin_sha %q is not a full commit SHA: the FSE yardstick must be pinned", b.Compute.FSEPinSHA)
+	}
+	if b.Compute.FloorFSEPerChange <= 0 || b.Compute.FloorFSEPerChange >= 1 {
+		t.Errorf("compute.floor_fse_per_change = %v: must be in (0,1)", b.Compute.FloorFSEPerChange)
+	}
+	if b.Compute.Ratchet == "" || b.Human.Bound == "" || b.Queue.Bound == "" {
+		t.Error("compute.ratchet, human.bound, and queue.bound must each state their ratchet rule")
+	}
+
+	if b.Queue.AmplificationMaxPhase3 < b.Queue.AmplificationMaxStress {
+		t.Errorf("queue amplification bounds inverted: phase3 %v < stress %v", b.Queue.AmplificationMaxPhase3, b.Queue.AmplificationMaxStress)
+	}
+	if b.Queue.AmplificationMaxStress < 1 {
+		t.Errorf("queue.amplification_max_stress = %v: below 1 is unsatisfiable (every change needs one state)", b.Queue.AmplificationMaxStress)
+	}
+
+	if b.Safety.MissRateAutoAdmittedMax >= b.Safety.MissRateReviewedMax {
+		t.Errorf("safety: auto-admitted bound %v must be stricter than reviewed bound %v", b.Safety.MissRateAutoAdmittedMax, b.Safety.MissRateReviewedMax)
+	}
+	for name, v := range map[string]float64{
+		"miss_rate_reviewed_max":      b.Safety.MissRateReviewedMax,
+		"miss_rate_auto_admitted_max": b.Safety.MissRateAutoAdmittedMax,
+		"audit_fraction_min":          b.Safety.AuditFractionMin,
+	} {
+		if v <= 0 || v >= 1 {
+			t.Errorf("safety.%s = %v: must be a rate in (0,1)", name, v)
+		}
+	}
+	if b.Safety.MinAuditedRuns <= 0 || b.Safety.ObservationWindowDays <= 0 {
+		t.Error("safety sample size and observation window must be positive")
+	}
+	if b.Safety.ExposureRestatement == "" {
+		t.Error("safety.exposure_restatement is empty: bounds must be restated at exposure")
+	}
+
+	if b.Flakes.PerJobFlakeAssumedMax <= 0 || b.Flakes.Classification == "" || b.Flakes.Quarantine == "" {
+		t.Error("flakes: assumption, mechanical classification rule, and quarantine rule are all required")
+	}
+
+	if b.Model.ExtrapolationCap < 1 {
+		t.Errorf("model.extrapolation_cap = %v: must be >= 1", b.Model.ExtrapolationCap)
+	}
+	if b.Model.ForgeCanary == "" {
+		t.Error("model.forge_canary is empty: modeled resources need a named validating canary")
+	}
+
+	if len(b.ValueAnchor.Metrics) == 0 {
+		t.Error("value_anchor.metrics is empty: the metric suite needs at least one externally-anchored signal")
+	}
+}

--- a/test/docsync/throughput_bounds_test.go
+++ b/test/docsync/throughput_bounds_test.go
@@ -28,7 +28,16 @@ type throughputBounds struct {
 		CompressionMinChangesPerPR int     `toml:"compression_min_changes_per_pr"`
 		ForgeHeadroom              float64 `toml:"forge_headroom"`
 		Basis                      string  `toml:"basis"`
+		BatchMergeStructure        string  `toml:"batch_merge_structure"`
+		BatchOverlap               string  `toml:"batch_overlap"`
 	} `toml:"publication"`
+	Admission struct {
+		CoverageMinAt500PerDay   float64 `toml:"coverage_min_at_500_per_day"`
+		CoverageMinAt2000PerDay  float64 `toml:"coverage_min_at_2000_per_day"`
+		CoverageMinAt10000PerDay float64 `toml:"coverage_min_at_10000_per_day"`
+		ExceptionRateMax         float64 `toml:"exception_rate_max"`
+		HumanTouchBudget         string  `toml:"human_touch_budget"`
+	} `toml:"admission"`
 	Compute struct {
 		FSEPinSHA          string  `toml:"fse_pin_sha"`
 		FloorFSEPerChange  float64 `toml:"floor_fse_per_change"`
@@ -119,6 +128,29 @@ func TestThroughputBoundsLedger(t *testing.T) {
 	}
 	if b.Publication.ForgeHeadroom <= 0 || b.Publication.ForgeHeadroom >= 1 {
 		t.Errorf("publication.forge_headroom = %v: must be a fraction in (0,1)", b.Publication.ForgeHeadroom)
+	}
+	if b.Publication.BatchMergeStructure == "" || b.Publication.BatchOverlap == "" {
+		t.Error("publication.batch_merge_structure and batch_overlap are required: the identity model depends on the publication commit structure")
+	}
+
+	milestones := []float64{
+		b.Admission.CoverageMinAt500PerDay,
+		b.Admission.CoverageMinAt2000PerDay,
+		b.Admission.CoverageMinAt10000PerDay,
+	}
+	for i, m := range milestones {
+		if m <= 0 || m > 1 {
+			t.Errorf("admission coverage milestone %d = %v: must be in (0,1]", i, m)
+		}
+		if i > 0 && m < milestones[i-1] {
+			t.Errorf("admission coverage milestones must be non-decreasing, got %v", milestones)
+		}
+	}
+	if b.Admission.ExceptionRateMax <= 0 || b.Admission.ExceptionRateMax >= 1 {
+		t.Errorf("admission.exception_rate_max = %v: must be a rate in (0,1)", b.Admission.ExceptionRateMax)
+	}
+	if b.Admission.HumanTouchBudget == "" {
+		t.Error("admission.human_touch_budget is empty: the coverage milestones must name the budget that forces them")
 	}
 
 	if !shaRE.MatchString(b.Compute.FSEPinSHA) {


### PR DESCRIPTION
## What this is

A discussion-draft engineering proposal (`specs/proposals/0001-increasing-ci-throughput.md`) for scaling change admission — how agent-generated work gets verified and merged — toward a directional stress case of 10,000 logical changes/day, without verification compute growing as volume × fresh-full-CI-run or maintainer attention growing per change. The 10K figure is a design horizon, not a traffic forecast: the operating mode is *optimize now, ratchet continuously from measured baselines*.

The core thesis: **admission should scale with the uncertainty a change introduces, not the number of changes produced.** Agents make changes; the system establishes facts; policy decides what ships; humans govern policy and handle exceptions.

## What's in the diff

- **The proposal itself** — change shaping, GitHub Merge Queue on predicted states, identity-preserving logical batching, affectedness-based proof selection, trust-bounded caching, bounded automated admission, and a phased experiment funnel (Phase 0–7) with stop conditions.
- **`specs/proposals/0001-bounds.toml`** — a checked ledger holding every value the proposal calls "registered": burst basis, workload-shape mix, compression target, compute/human ratchets, two-tier miss-rate bounds, flake policy, amplification caps, model extrapolation cap, admission-coverage milestones. A bound counts for a phase run only if its commit predates that run — the ledger's git history is the audit trail.
- **`test/docsync/throughput_bounds_test.go`** — guard test keeping the ledger and proposal in sync (required sections, rates in range, milestones non-decreasing, pinned FSE yardstick SHA, cross-references intact).
- **`CONTEXT.md` + `specs/adr/0001-measured-vs-modeled-resources.md`** — glossary for the new vocabulary (logical change, ratchet, FSE, intervention, admission latency…) and the ADR recording the measured-vs-modeled resource split. `AGENTS.md` gains a pointer to both conventions.

## How it was hardened

The draft went through a multi-verifier adversarial review (claims checked against ci.yml, TESTING.md, live branch-protection state, and every cited external source — GitHub merge-queue/limits docs, Pants, Gas Town's Refinery design, bazel-remote, Buildbarn, Zuul; 23/24 factual claims verified, zero contradicted). The review's confirmed defects drove the current text:

- **Measured vs modeled resources** — resolves a genuine method contradiction: Phase 0 demanded saturation curves for the forge and humans that Phase 7 rightly forbids generating against github.com. Owned infrastructure gets real saturation curves; the forge and human work get registered capacity models with a named validating canary and a 20× extrapolation cap.
- **Pre-registered, test-guarded bounds** — every stop condition now points at a committed number instead of a blank ("negligible", "high").
- **Batch publication structure** — multi-change batches publish as merge commits with one rebased commit per logical change, so per-change `git revert` is real; batches are never squashed; the honest limits of selective revert are stated rather than papered over.
- **Admission coverage model** — the human-review arithmetic is stated (≈1,000 publications/day at the compression target), and volume growth is gated on a registered daily human-touch budget with coverage milestones (≥0.5/0.9/0.99 before sustained 500/2,000/10K per day).
- **Honest Phase 7** — every success criterion is labeled measured / modeled / imported, so the combined load test can't launder simulation results as operational proof.

## Where reviewer judgment is most wanted

1. **Batch publication via merge commits** (§4.1) — registered as the proposal's position because it's the only structure that makes per-change revert executable; squash remains for single-change publications. Sanity-check this against how you want `main`'s history to read.
2. **The coverage milestones and touch budget** (§4.2, `[admission]` in the ledger) — the numbers are defensible-first-guesses meant to be re-derived at each volume doubling; the *shape* (volume waits for coverage) is the part to weigh in on.
3. **The declarative admission engine vs the Primitive Test** (§4.2) — predicates in versioned config, mechanically evaluated by the controller. An explicit ruling on transport-vs-cognition per `engdocs/contributors/primitive-test.md` is deliberately left open for maintainers.

## Notes

- Current CI facts in §2 were verified against the live repo (no `merge_group` triggers today; `CI / required` is already a required context; the 4m59s exact-`main` run was a full-union run; the timing planner is measurement infrastructure, not yet authority).
- Two darwin-only runtime/test fixes discovered while validating this branch locally (zcode temp-root canonicalization, herdr XDG socket-path) were deliberately kept **out** of this PR and are parked on `csells/darwin-runtime-fixes` for a separate PR.