### PR TITLE
fix: allow pool aliases in push ownership guard

### DIFF
--- a/release-gates/ga-yaqkq6-push-ownership-guard-pool-identity-gate.md
+++ b/release-gates/ga-yaqkq6-push-ownership-guard-pool-identity-gate.md
@@ -1,0 +1,44 @@
+# Release gate: pool identity in push ownership guard
+
+- Deploy bead: `ga-yaqkq6`
+- Reviewed source: `356b611b21462839364d72f9f5c03e27ff4f02c9`
+- Gated head after bounded self-rebase: `f176cbff84a1ab31317c7af9b2bf26429bf122d8`
+- Base: `origin/main@e736d74d0a84a129de47f9008c4560d3146c77ce`
+- Deploy mode: `remote`; push remote: `origin`
+- Overall verdict: **PASS**
+
+| # | Criterion | Verdict | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-qdljcu` records `REVIEW VERDICT: PASS` for the reviewed source and independently verifies build, vet, shell syntax, shellcheck, the regression suite, and the trust-boundary change. |
+| 2 | Acceptance criteria met | **PASS** | `scripts/push-ownership-guard.sh` now accepts `GC_TEMPLATE` as a valid assignee identity. The regression `allow/assignee-is-bare-pool-template` passes when the pool identity is `tmpl-x` and all instance-shaped identity values differ. The fail-closed reassignment case also passes. |
+| 3 | Tests pass | **PASS with attributed raw failures** | The documented union, `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true make test-local-full-parallel`, completed **33 PASS / 7 FAIL / 0 SKIP jobs**. All seven red jobs are retained and attributed below under criterion 3a. The first invocation executed no tests and returned infrastructure admission code 75 after the shared two-slot gate stayed full for 600 seconds; the permitted pre-test retry acquired a slot and produced the recorded union result. `go build ./...`, `go vet ./...`, `shellcheck` on both changed scripts, `bash -n` on both changed scripts, and `git diff --check` all pass. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy` passes: 5 runner-policy tests, 15 CI-coverage tests, `go test ./scripts/cipolicy`, and the focused static-scope contracts are green. |
+| 4 | No high-severity review findings open | **PASS** | Review bead `ga-qdljcu` records PASS with zero findings; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty after all gate commands and before this checklist was created. |
+| 6 | Branch diverges cleanly from main | **PASS** | The reviewed source was stale but `git merge-tree --write-tree` was clean. The canonical bounded helper rebased and force-with-lease pushed `356b611b21462839364d72f9f5c03e27ff4f02c9 -> f176cbff84a1ab31317c7af9b2bf26429bf122d8` with rc 0. Local and remote heads match, and current `origin/main` is an ancestor of the gated head. |
+| 7 | Single feature theme | **PASS** | The final diff is limited to `scripts/push-ownership-guard.sh` and its dedicated shell regression suite: one push-ownership identity-normalization theme. |
+
+## Criterion 3 evidence
+
+Test environment:
+
+- Rootless Podman socket is live at `unix:///run/user/1000/podman/podman.sock`.
+- Cached images include repository-pinned `dolthub/dolt:2.1.7` and testcontainers image `dolthub/dolt-sql-server:1.32.4`.
+- `TESTCONTAINERS_RYUK_DISABLED=true` was set before the union.
+
+Diff-owned tests:
+
+- `scripts/test-push-ownership-guard.sh`: **36 PASS / 0 FAIL / 0 SKIP**.
+- `allow/assignee-is-bare-pool-template`: **PASS** by name.
+- The existing Go `scripts` package wrapper also passed in the union.
+- `diff_tests_executed`: all 36 named cases in the modified shell suite PASS; no diff-owned test skipped.
+- `waiver_ref`: `MAYOR-2026-08-19-ga-yaqkq6-full-disposition` is recorded on the bead, but the current result is independently adjudicated under the live three-outcome criterion-3 policy.
+
+Raw failures and attribution:
+
+- `TestBdFlagManifestCurrent` in `integration-packages-core-1-of-4` -> `ga-gqxh5s`. Clause 3(a), mechanism: the installed `bd --help` exposes flags absent from `internal/bdflags`; the candidate changes only push-guard shell files and cannot alter either the installed binary or the Go manifest. Tracker created 2026-07-28, before this run.
+- `TestProviderLiveClaudeKindPath` in `unit-core` and `integration-packages-core-3-of-4` -> `ga-fh1flg`. Clause 3(a), mechanism: both occurrences have the tracked `agent_pane_busy` / startup-delivery timeout signature. No failing herdr package path imports or invokes the changed push-guard scripts. Tracker created 2026-08-18, before this run; standing disposition `mayor-2026-08-20-herdr-pane-standing` also covers the exact signature.
+- `TestGetKeyBinding_CapturesDefaultBinding` and `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr`. Clause 3(a), mechanism: host tmux 3.7b returns an empty filtered default key table (`next-window` / `choose-tree` missing). The candidate cannot reach `internal/runtime/tmux`. Tracker created 2026-08-15 and explicitly names both tests.
+- `TestAdoptPRFormulaCompileAndRun` and `TestPersonalWorkFormulaCompileAndRun` -> `ga-lpfjhc`. Clause 3(a), mechanism: both fail during fixture `gc init`, before formula execution, with the exact gastownhall/beads#4566 `pending schema migrations alter pre-existing dirty tables` signature. Push-guard shell code cannot alter Dolt schema migration or store bootstrap. Tracker created 2026-08-15; standing authorization is recorded on `ga-6bnc42`.
+
+For every attributed failure: the failing test file is not diff-owned; the cited tracker predates the run and covers the exact test or condition; `git grep` found no push-guard reference in `internal/bdflags/**`, `internal/runtime/herdr/**`, `internal/runtime/tmux/**`, or `test/integration/**`; and none of those paths overlaps the two changed files. The diff changes no resource census, Makefile, workflow, or test target.

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -18,9 +18,10 @@
 # assignment), re-reads its live state from bd, and returns non-zero
 # (blocking the push) unless the bead is still open/in_progress, still
 # assigned to one of this session's identities (any of GC_SESSION_NAME,
-# GC_SESSION_ID, GC_ALIAS, GC_AGENT — mirroring the claim path), still
-# routed to this session's config identity, and not held by the mayor or an
-# external actor.
+# GC_SESSION_ID, GC_ALIAS, GC_AGENT — mirroring the claim path — or
+# GC_TEMPLATE, for work routed to the whole pool rather than claimed by one
+# instance; see ga-kzl21p), still routed to this session's config identity,
+# and not held by the mayor or an external actor.
 #
 # TWO CALL SITES (defense in depth — see ga-fip9ps.1 bead notes):
 #   Layer A — .githooks/pre-push calls this unconditionally for every
@@ -323,9 +324,21 @@ assert_bead_still_claimed() {
     # bead is legitimately assigned to the session name/id. Fail-closed
     # semantics preserved: with identities present, an assignee matching none
     # (including empty) still blocks.
+    #
+    # GC_TEMPLATE is also a valid match (ga-kzl21p): it's the bare pool
+    # identity (e.g. "gascity/builder"), stamped by the SDK at session start
+    # for every session shape regardless of which specific pool instance is
+    # running (e.g. "gascity/builder-1") — see internal/session/lifecycle.go.
+    # Work routed to the whole pool, rather than claimed by one instance, can
+    # carry that bare identity as assignee. Without this, a session whose
+    # GC_SESSION_NAME/GC_SESSION_ID/GC_ALIAS/GC_AGENT are all instance-shaped
+    # could never match a pool-level assignee, and completed, gate-verified
+    # work became unpushable with no reassignment and no bypass. This is the
+    # same trust boundary the routed_to check below already applies to
+    # GC_TEMPLATE — extended here to cover assignee too.
     local -a _pog_identities=()
     local _pog_ident
-    for _pog_ident in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}"; do
+    for _pog_ident in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}" "${GC_TEMPLATE:-}"; do
         [[ -n "$_pog_ident" ]] && _pog_identities+=("$_pog_ident")
     done
     if [[ ${#_pog_identities[@]} -gt 0 ]]; then

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -330,6 +330,33 @@ test_allow_when_assignee_is_session_name() {
     rm -rf "$repo" "$fbd"
 }
 
+# Regression (ga-kzl21p): a session running as pool instance "<agent>-N" has
+# GC_TEMPLATE set to the bare pool identity "<agent>" (stamped by the SDK at
+# session start regardless of which instance is running — see
+# internal/session/lifecycle.go), but work routed to the whole pool can carry
+# that same bare "<agent>" string as bead.assignee (not any instance-suffixed
+# form). GC_TEMPLATE was missing from the identity-set match, so a session
+# whose GC_AGENT/GC_SESSION_ID/GC_SESSION_NAME are all instance-specific could
+# never match a pool-level assignee — completed, gate-verified work became
+# unpushable with no reassignment and no bypass. Concrete instance: TEMPLATE=
+# gascity/builder, TARGET=gascity/builder-1, assignee=gascity/builder.
+test_allow_when_assignee_is_bare_pool_template() {
+    local repo fbd out rc
+    repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    write_fake_bd "$fbd"
+    # assignee is the bare pool template ("tmpl-x"), matching GC_TEMPLATE —
+    # not GC_AGENT/GC_SESSION_ID/GC_SESSION_NAME, which are all instance-shaped.
+    write_show_json "$fbd" "ga-abc123.1" "in_progress" "tmpl-x" "tmpl-x" "[]"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 5 "sess-id-x" "sess-name-x" 2>&1)"; rc=$?
+    if [[ $rc -eq 0 ]]; then
+        record_pass "allow/assignee-is-bare-pool-template (rc=0, GC_AGENT/SESSION_ID/SESSION_NAME all differ)"
+    else
+        record_fail "allow/assignee-is-bare-pool-template" "expected rc=0, got rc=$rc, output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
 test_block_on_routed_to_changed() {
     local repo fbd out rc
     repo="$(new_repo_with_branch "builder/ga-abc123.1-my-feature")"
@@ -1035,6 +1062,7 @@ run_all() {
     test_block_on_reassigned
     test_allow_when_assignee_is_session_id
     test_allow_when_assignee_is_session_name
+    test_allow_when_assignee_is_bare_pool_template
     test_block_on_routed_to_changed
     test_block_on_hold_mayor
     test_block_on_hold_external


### PR DESCRIPTION
## What this changes

Pool-backed agents can now push work assigned to the pool's bare template identity. Previously, the ownership guard compared only instance-shaped session identities and rejected legitimate pushes from pool instances.

The guard now includes the SDK-stamped `GC_TEMPLATE` identity while preserving its existing fail-closed behavior.

## Review notes

- The change is limited to the local pre-push ownership guard and its shell regression suite.
- It does not introduce a broader identity-normalization API or change bead assignment semantics.
- Missing or unrelated identity data remains a hard rejection.

## Test plan

- [x] Run `bash scripts/test-push-ownership-guard.sh` and verify all 36 cases pass, including the bare pool-template assignment case.
- [x] Run `make test-ci-policy`.
- [x] Run `go build ./...`, `go vet ./...`, ShellCheck, and shell syntax checks.
- [x] Run the documented full local test union; tracked, structurally unrelated host/tool failures are recorded in the release gate.
- [x] Release gate: [`release-gates/ga-yaqkq6-push-ownership-guard-pool-identity-gate.md`](release-gates/ga-yaqkq6-push-ownership-guard-pool-identity-gate.md)