### PR TITLE
fix(reconciler): break the orphaned-seat work deadlock (ga-jrnou)

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -280,6 +280,86 @@ func releaseOrphanedPoolAssignments(
 	return released
 }
 
+// releaseConfirmedOrphanSessionWork releases the pool-routed work still held by
+// a session the reconciler has confirmed orphaned, so the close guard that
+// refuses to close a seat holding work stops being a permanent block.
+//
+// This is the tie-break for the deadlock in ga-jrnou. An orphaned seat holding
+// work is unreachable by every other lane: the close guard refuses while the
+// work is assigned, the wake path is blocked because an orphaned base state
+// raises BlockerMissingConfig, and releaseOrphanedPoolAssignments skips the work
+// because the seat's session bead is still open — liveOpenSessionAssignmentExists
+// tests bead status, not runtime liveness. Each lane defers to the others and
+// the seat wedges indefinitely.
+//
+// The caller MUST have confirmed the runtime is observably dead. This function
+// deliberately takes no liveness argument and performs no liveness probe: the
+// orphan-close site is the only caller precisely because it has already failed
+// closed on an unreadable liveness observation. Releasing work from a seat that
+// is actually alive is data loss, not recovery (ga-g3pf0).
+//
+// Every per-bead gate from releaseOrphanedPoolAssignments applies unchanged,
+// including the live re-read in liveWorkAssignmentStillReleasable — the tick
+// snapshot names candidates but never by itself justifies a release.
+func releaseConfirmedOrphanSessionWork(
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	assignedWorkBeads []beads.Bead,
+	info session.Info,
+) []releasedPoolAssignment {
+	if cfg == nil || store == nil || len(assignedWorkBeads) == 0 {
+		return nil
+	}
+	identifiers := make(map[string]struct{}, 5)
+	for _, id := range sessionAssignmentIdentifiersForConfigInfo(info, cfg) {
+		if id = strings.TrimSpace(id); id != "" {
+			identifiers[id] = struct{}{}
+		}
+	}
+	if len(identifiers) == 0 {
+		return nil
+	}
+
+	var released []releasedPoolAssignment
+	for i, wb := range assignedWorkBeads {
+		if wb.Status != "open" && wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if _, ok := identifiers[assignee]; !ok {
+			continue
+		}
+		template := routedToOrLegacyWorkflowTarget(wb)
+		if template == "" {
+			continue
+		}
+		agentCfg := findAgentByTemplate(cfg, template)
+		if agentCfg == nil || !agentCfg.SupportsGenericEphemeralSessions() {
+			continue
+		}
+		ownerStore := storeForPoolAssignment(cfg, store, rigStores, wb)
+		if ownerStore == nil {
+			continue
+		}
+		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, wb.Status, assignee) {
+			continue
+		}
+		allowsRelease, clearDetached := detachedProbeAllowsOrphanRelease(wb)
+		if !allowsRelease {
+			continue
+		}
+		if !releaseOrphanedPoolAssignment(ownerStore, wb, clearDetached) {
+			continue
+		}
+		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
+	}
+	return released
+}
+
 // assignedWorkOwnerStore resolves the store that owns the assigned work bead at
 // index i: the index-aligned snapshot store when the caller supplied one (the
 // store-aware form), otherwise the routed/prefix fallback. A nil result means

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1876,13 +1876,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						continue
 					}
-					if trace != nil {
-						trace.RecordDecision(TraceSiteReconcilerCloseFailedCreate, TraceReasonCode(sessionpkg.StateFailedCreate), TraceOutcomeClosed, template, name, nil)
-					}
 					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
+						if trace != nil {
+							trace.RecordDecision(TraceSiteReconcilerCloseFailedCreate, TraceReasonCode(sessionpkg.StateFailedCreate), TraceOutcomeSkipped, template, name, traceRecordPayload{
+								"store_query_partial":          storeQueryPartial,
+								"defer_session_closes_on_boot": reconcileOpts.deferSessionClosesOnBoot,
+							})
+						}
 						continue
 					}
-					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], string(sessionpkg.StateFailedCreate), clk.Now().UTC(), stderr, false) {
+					closedFailedCreate := closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], string(sessionpkg.StateFailedCreate), clk.Now().UTC(), stderr, false)
+					if closedFailedCreate {
 						// Reflect the in-memory close on the snapshot: the cross-session
 						// min-floor scan (below) reads Info.Closed off infoByID, so a
 						// session closed this tick must not still count as open in its
@@ -1892,6 +1896,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// the Step-6d front-door cutover. Guarded by
 						// TestReconcileSessionBeads_MinFloorCountReflectsMidTickClose.
 						tick.markClosed(id)
+					}
+					if trace != nil {
+						outcome := TraceOutcomeClosed
+						if !closedFailedCreate {
+							// Same refusal as the orphan close below: the guard keeps a
+							// bead that still holds open assigned work, so "closed" would
+							// be a lie for as long as the seat stays wedged (ga-jrnou).
+							outcome = TraceOutcomeNoChange
+						}
+						trace.RecordDecision(TraceSiteReconcilerCloseFailedCreate, TraceReasonCode(sessionpkg.StateFailedCreate), outcome, template, name, nil)
 					}
 					continue
 				}
@@ -2185,13 +2199,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						continue
 					}
-					if trace != nil {
-						trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), TraceOutcomeClosed, template, name, nil)
-					}
 					if storeQueryPartial || reconcileOpts.deferSessionClosesOnBoot {
+						if trace != nil {
+							trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), TraceOutcomeSkipped, template, name, traceRecordPayload{
+								"store_query_partial":          storeQueryPartial,
+								"defer_session_closes_on_boot": reconcileOpts.deferSessionClosesOnBoot,
+							})
+						}
 						continue
 					}
-					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr, false) {
+					closed := closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr, false)
+					if closed {
 						// Keep the snapshot's Info.Closed in step with the in-memory
 						// close so the cross-session min-floor scan does not count this
 						// orphan. Store-only close (closeBead/closeFailedCreateBead stamp
@@ -2202,6 +2220,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// pre-close Info. Guarded by
 						// TestReconcileSessionBeads_MinFloorCountReflectsMidTickCloseOrphan.
 						tick.markClosed(id)
+					}
+					if trace != nil {
+						outcome := TraceOutcomeClosed
+						if !closed {
+							// The reachable-store guard refused — the seat still holds
+							// open assigned work. Reporting "closed" for a bead that is
+							// still open sends `gc trace` investigations the wrong way
+							// for as long as the seat stays wedged (ga-jrnou).
+							outcome = TraceOutcomeNoChange
+						}
+						trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), outcome, template, name, nil)
 					}
 				}
 				continue

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2209,6 +2209,22 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						continue
 					}
 					closed := closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr, false)
+					if !closed && reason == "orphaned" {
+						// The guard refused because the seat still holds work. Nothing
+						// else can resolve that: the wake path is blocked on the orphaned
+						// base state and releaseOrphanedPoolAssignments skips work whose
+						// seat's session bead is still open. This site has already
+						// confirmed the runtime is observably dead (livenessErr == nil
+						// above, and this is the not-running branch), so it owns the
+						// tie-break — release, then close (ga-jrnou).
+						//
+						// Restricted to "orphaned": a "suspended" seat is configured and
+						// merely scaled down, so its work stays put for its return.
+						if released := releaseConfirmedOrphanSessionWork(cfg, store, rigStores, assignedWorkBeads, infoByID[id]); len(released) > 0 {
+							emitDeadAssigneeReopenedEvents(rec, assignedWorkBeads, released, clk.Now().UTC())
+							closed = closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr, false)
+						}
+					}
 					if closed {
 						// Keep the snapshot's Info.Closed in step with the in-memory
 						// close so the cross-session min-floor scan does not count this

--- a/cmd/gc/session_reconciler_close_orphan_trace_test.go
+++ b/cmd/gc/session_reconciler_close_orphan_trace_test.go
@@ -6,28 +6,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
-// TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned pins the
-// close-orphan site's outcome to what actually happened.
-//
-// closeSessionBeadIfReachableStoreUnassigned refuses to close a session bead
-// that still holds open assigned work (session_work_guard.go). That refusal is
-// deliberate — but the decision record was emitted BEFORE the close was
-// attempted and hard-coded TraceOutcomeClosed, so a seat that never closed was
-// reported as "closed" on every tick. `gc trace` is the documented tool for
-// diagnosing a stuck reconciler (engdocs/contributors/reconciler-debugging.md);
-// a site that reports success for a close it did not perform sends that
-// investigation the wrong way for as long as the seat stays wedged.
-//
-// Scenario: an orphan seat (not desired, not running, liveness observable) that
-// still has an open work bead assigned to it. The close is refused, so the
-// record must not claim "closed".
-func TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned(t *testing.T) {
+// closeOrphanEnv is the shared fixture for the orphan-close tests: one pool
+// agent, one session bead, and one open work bead routed to that pool and
+// assigned to the seat.
+type closeOrphanEnv struct {
+	cityDir string
+	cfg     *config.City
+	store   beads.Store
+	sp      *runtime.Fake
+	tracer  *SessionReconcilerTracer
+	session beads.Bead
+	work    beads.Bead
+}
+
+func newCloseOrphanEnv(t *testing.T) *closeOrphanEnv {
+	t.Helper()
 	cityDir := t.TempDir()
 	writeCityTOML(t, cityDir, "trace-town", "mayor")
 
@@ -45,8 +46,16 @@ func TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned(t *test
 	}
 
 	store := beads.NewMemStore()
+	// Type + label matter: the reconciler's liveness probe resolves a seat
+	// through session.ResolveSessionRecordByExactID, which only recognizes a
+	// bead as a session record when it is typed (or labeled and untyped). An
+	// untyped bead still reconciles — newSessionBeadSnapshot builds Info
+	// directly — but every liveness observation on it reads not-running, which
+	// silently turns a live seat into a confirmed orphan.
 	sessionBead, err := store.Create(beads.Bead{
-		Title: "polecat",
+		Title:  "polecat",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
 			"session_name":       "polecat-1",
 			"template":           "repo/polecat",
@@ -60,19 +69,17 @@ func TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned(t *test
 		t.Fatalf("Create session bead: %v", err)
 	}
 
-	// The work that makes the close guard refuse. Without this the orphan closes
-	// normally and the assertion below would be vacuous.
-	if _, err := store.Create(beads.Bead{
+	work, err := store.Create(beads.Bead{
 		Title:    "assigned work",
 		Status:   "open",
 		Assignee: "polecat-1",
-	}); err != nil {
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: "repo/polecat",
+		},
+	})
+	if err != nil {
 		t.Fatalf("Create work bead: %v", err)
 	}
-
-	// Never started: the seat is not running, and the fake provider can still
-	// observe that (no liveness error), so the reconciler reaches the close.
-	sp := runtime.NewFake()
 
 	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)
 	if !tracer.Enabled() {
@@ -92,62 +99,173 @@ func TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned(t *test
 		t.Fatalf("upsert arm: %v", err)
 	}
 
+	return &closeOrphanEnv{
+		cityDir: cityDir,
+		cfg:     cfg,
+		store:   store,
+		sp:      runtime.NewFake(),
+		tracer:  tracer,
+		session: sessionBead,
+		work:    work,
+	}
+}
+
+// tick runs one reconcile pass with the given desired state.
+func (e *closeOrphanEnv) tick(t *testing.T, desired map[string]TemplateParams) []SessionReconcilerTraceRecord {
+	t.Helper()
+	armNow := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	cr := &CityRuntime{
-		cityPath:            cityDir,
+		cityPath:            e.cityDir,
 		cityName:            "trace-town",
-		cfg:                 cfg,
-		sp:                  sp,
-		trace:               tracer,
-		standaloneCityStore: store,
+		cfg:                 e.cfg,
+		sp:                  e.sp,
+		trace:               e.tracer,
+		standaloneCityStore: e.store,
 		sessionDrains:       newDrainTracker(),
 		rec:                 events.NewFake(),
 		stdout:              io.Discard,
 		stderr:              io.Discard,
 	}
-
-	sessionBeads := newSessionBeadSnapshot([]beads.Bead{sessionBead})
-	cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "controller_tick", armNow, cfg)
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{e.session})
+	cycle := e.tracer.BeginCycle(TraceTickTriggerPatrol, "controller_tick", armNow, e.cfg)
 	if cycle == nil {
 		t.Fatal("BeginCycle returned nil")
 	}
 	cycle.configRevision = "rev-close-orphan-1"
-	cycle.syncArms(armNow, cfg)
+	cycle.syncArms(armNow, e.cfg)
 
-	// Empty desired state: the seat is an orphan this tick.
-	cr.beadReconcileTick(context.Background(), DesiredStateResult{State: map[string]TemplateParams{}}, sessionBeads, cycle, false)
+	if desired == nil {
+		desired = map[string]TemplateParams{}
+	}
+	cr.beadReconcileTick(context.Background(), DesiredStateResult{
+		State:             desired,
+		AssignedWorkBeads: []beads.Bead{e.work},
+	}, sessionBeads, cycle, false)
 	if err := cycle.End(TraceCompletionCompleted, traceRecordPayload{"phase": "tick"}); err != nil {
 		t.Fatalf("cycle.End: %v", err)
 	}
-	if err := tracer.Close(); err != nil {
+	if err := e.tracer.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-
-	// Control: the close must actually have been refused. If the guard let it
-	// through, this scenario proves nothing about the outcome code.
-	got, err := store.Get(sessionBead.ID)
-	if err != nil {
-		t.Fatalf("store.Get(%s): %v", sessionBead.ID, err)
-	}
-	if got.Status == "closed" {
-		t.Fatalf("session bead status = closed, want still open — the close guard must refuse while open work is assigned, otherwise this test cannot exercise the refusal outcome")
-	}
-
-	records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{TraceID: cycle.traceID})
+	records, err := ReadTraceRecords(traceCityRuntimeDir(e.cityDir), TraceFilter{TraceID: cycle.traceID})
 	if err != nil {
 		t.Fatalf("ReadTraceRecords: %v", err)
 	}
+	return records
+}
+
+func (e *closeOrphanEnv) get(t *testing.T, id string) beads.Bead {
+	t.Helper()
+	got, err := e.store.Get(id)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", id, err)
+	}
+	return got
+}
+
+// TestSessionReconcilerOrphanCloseReleasesHeldWorkThenCloses pins the repair for
+// the three-way deadlock in ga-jrnou.
+//
+// A confirmed-orphaned seat that still holds open assigned work could not be
+// resolved by any lane: the close guard refuses while work is assigned
+// (session_work_guard.go), the wake path is blocked because an orphaned base
+// state raises BlockerMissingConfig, and releaseOrphanedPoolAssignments skips
+// the work because the seat's session bead is still open
+// (liveOpenSessionAssignmentExists tests bead status, not runtime liveness).
+// Each lane correctly deferred to the others and the seat wedged indefinitely —
+// 86 hours, in the maintainer-city case that surfaced it.
+//
+// The orphan close is the one site that has already confirmed the runtime is
+// observably dead, so it owns the tie-break: release the held work, then close.
+func TestSessionReconcilerOrphanCloseReleasesHeldWorkThenCloses(t *testing.T) {
+	env := newCloseOrphanEnv(t)
+
+	// Empty desired state and a never-started provider: the seat is a confirmed
+	// orphan this tick.
+	env.tick(t, nil)
+
+	work := env.get(t, env.work.ID)
+	if work.Assignee != "" {
+		t.Fatalf("work assignee = %q, want empty — a confirmed-orphaned seat must not keep holding work", work.Assignee)
+	}
+	if work.Status != "open" {
+		t.Fatalf("work status = %q, want open — released work must return to open so pool demand can re-route it", work.Status)
+	}
+
+	session := env.get(t, env.session.ID)
+	if session.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed — once the held work is released the close guard no longer refuses, so the orphan must close in the same tick", session.Status)
+	}
+}
+
+// TestSessionReconcilerOrphanCloseRecordsClosedOnlyWhenClosed keeps the close
+// sites honest about what they did. Both close sites recorded their decision
+// BEFORE attempting the close and hard-coded TraceOutcomeClosed, so a seat that
+// never closed was still reported "closed" every tick. gc trace is the
+// documented entry point for a stuck reconciler
+// (engdocs/contributors/reconciler-debugging.md), so that misreport actively
+// misdirected the investigation for as long as the seat stayed wedged.
+//
+// Here the close DOES happen (the release above unblocks it), so the record
+// must say closed — and it must say so because the bead closed, not because the
+// site was reached.
+func TestSessionReconcilerOrphanCloseRecordsClosedOnlyWhenClosed(t *testing.T) {
+	env := newCloseOrphanEnv(t)
+	records := env.tick(t, nil)
+
+	session := env.get(t, env.session.ID)
 	var sawCloseOrphan bool
 	for _, rec := range records {
 		if rec.SiteCode != TraceSiteReconcilerCloseOrphan {
 			continue
 		}
 		sawCloseOrphan = true
-		if rec.OutcomeCode == TraceOutcomeClosed {
-			t.Fatalf("close_orphan outcome_code = %q, but session bead %s is still %q — the decision must report the close that actually happened, not one that was only attempted",
-				rec.OutcomeCode, sessionBead.ID, got.Status)
+		wantClosed := session.Status == "closed"
+		gotClosed := rec.OutcomeCode == TraceOutcomeClosed
+		if wantClosed != gotClosed {
+			t.Fatalf("close_orphan outcome_code = %q but session bead %s is %q — the decision must report the close that actually happened, not one that was only attempted",
+				rec.OutcomeCode, env.session.ID, session.Status)
 		}
 	}
 	if !sawCloseOrphan {
 		t.Fatalf("no %s decision record found in %d records — the orphan close path must be reached for this test to have teeth", TraceSiteReconcilerCloseOrphan, len(records))
+	}
+}
+
+// TestSessionReconcilerOrphanCloseLeavesLiveSeatWorkAlone is the control for
+// the release above, and the one that matters: releasing work from a seat that
+// is actually alive is data loss, not recovery. The releaser this repair reuses
+// carries that scar already (ga-g3pf0, where a session store serving zero
+// session beads read as "every assignee is dead" and released live work every
+// tick).
+//
+// Here the seat is running in the provider but absent from the desired state.
+// That is the DRAIN path, not the orphan close — the runtime is observably
+// alive, so nothing may touch its work.
+func TestSessionReconcilerOrphanCloseLeavesLiveSeatWorkAlone(t *testing.T) {
+	env := newCloseOrphanEnv(t)
+	if err := env.sp.Start(context.Background(), "polecat-1", runtime.Config{}); err != nil {
+		t.Fatalf("seed provider session: %v", err)
+	}
+
+	records := env.tick(t, nil)
+
+	// Assert the mechanism, not just the outcome: the release only exists
+	// inside the orphan close, so the control has teeth exactly as long as a
+	// live seat never reaches that site.
+	for _, rec := range records {
+		if rec.SiteCode == TraceSiteReconcilerCloseOrphan {
+			t.Fatalf("live seat reached %s (reason %q) — a running runtime must never be treated as an orphan", rec.SiteCode, rec.ReasonCode)
+		}
+	}
+
+	work := env.get(t, env.work.ID)
+	if work.Assignee != "polecat-1" {
+		t.Fatalf("work assignee = %q, want polecat-1 — a seat whose runtime is observably ALIVE must keep its work; releasing it is data loss, not recovery", work.Assignee)
+	}
+
+	session := env.get(t, env.session.ID)
+	if session.Status == "closed" {
+		t.Fatalf("session bead closed, want still open — a live runtime takes the drain path, never the orphan close")
 	}
 }

--- a/cmd/gc/session_reconciler_close_orphan_trace_test.go
+++ b/cmd/gc/session_reconciler_close_orphan_trace_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned pins the
+// close-orphan site's outcome to what actually happened.
+//
+// closeSessionBeadIfReachableStoreUnassigned refuses to close a session bead
+// that still holds open assigned work (session_work_guard.go). That refusal is
+// deliberate — but the decision record was emitted BEFORE the close was
+// attempted and hard-coded TraceOutcomeClosed, so a seat that never closed was
+// reported as "closed" on every tick. `gc trace` is the documented tool for
+// diagnosing a stuck reconciler (engdocs/contributors/reconciler-debugging.md);
+// a site that reports success for a close it did not perform sends that
+// investigation the wrong way for as long as the seat stays wedged.
+//
+// Scenario: an orphan seat (not desired, not running, liveness observable) that
+// still has an open work bead assigned to it. The close is refused, so the
+// record must not claim "closed".
+func TestSessionReconcilerTraceCloseOrphanRecordsRefusalWhenWorkAssigned(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityTOML(t, cityDir, "trace-town", "mayor")
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "trace-town"},
+		Session:   config.SessionConfig{Provider: "fake"},
+		Agents: []config.Agent{
+			{
+				Name:              "polecat",
+				Dir:               "repo",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(1),
+			},
+		},
+	}
+
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title: "polecat",
+		Metadata: map[string]string{
+			"session_name":       "polecat-1",
+			"template":           "repo/polecat",
+			"agent_name":         "polecat",
+			"state":              "asleep",
+			"generation":         "1",
+			"continuation_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+
+	// The work that makes the close guard refuse. Without this the orphan closes
+	// normally and the assertion below would be vacuous.
+	if _, err := store.Create(beads.Bead{
+		Title:    "assigned work",
+		Status:   "open",
+		Assignee: "polecat-1",
+	}); err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+
+	// Never started: the seat is not running, and the fake provider can still
+	// observe that (no liveness error), so the reconciler reaches the close.
+	sp := runtime.NewFake()
+
+	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)
+	if !tracer.Enabled() {
+		t.Fatal("tracer should be enabled")
+	}
+	armNow := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	if _, err := tracer.armStore.upsertArm(TraceArm{
+		ScopeType:      TraceArmScopeTemplate,
+		ScopeValue:     "repo/polecat",
+		Source:         TraceArmSourceManual,
+		Level:          TraceModeDetail,
+		ArmedAt:        armNow,
+		ExpiresAt:      armNow.Add(15 * time.Minute),
+		LastExtendedAt: armNow,
+		UpdatedAt:      armNow,
+	}); err != nil {
+		t.Fatalf("upsert arm: %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityPath:            cityDir,
+		cityName:            "trace-town",
+		cfg:                 cfg,
+		sp:                  sp,
+		trace:               tracer,
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.NewFake(),
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{sessionBead})
+	cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "controller_tick", armNow, cfg)
+	if cycle == nil {
+		t.Fatal("BeginCycle returned nil")
+	}
+	cycle.configRevision = "rev-close-orphan-1"
+	cycle.syncArms(armNow, cfg)
+
+	// Empty desired state: the seat is an orphan this tick.
+	cr.beadReconcileTick(context.Background(), DesiredStateResult{State: map[string]TemplateParams{}}, sessionBeads, cycle, false)
+	if err := cycle.End(TraceCompletionCompleted, traceRecordPayload{"phase": "tick"}); err != nil {
+		t.Fatalf("cycle.End: %v", err)
+	}
+	if err := tracer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Control: the close must actually have been refused. If the guard let it
+	// through, this scenario proves nothing about the outcome code.
+	got, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", sessionBead.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("session bead status = closed, want still open — the close guard must refuse while open work is assigned, otherwise this test cannot exercise the refusal outcome")
+	}
+
+	records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{TraceID: cycle.traceID})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	var sawCloseOrphan bool
+	for _, rec := range records {
+		if rec.SiteCode != TraceSiteReconcilerCloseOrphan {
+			continue
+		}
+		sawCloseOrphan = true
+		if rec.OutcomeCode == TraceOutcomeClosed {
+			t.Fatalf("close_orphan outcome_code = %q, but session bead %s is still %q — the decision must report the close that actually happened, not one that was only attempted",
+				rec.OutcomeCode, sessionBead.ID, got.Status)
+		}
+	}
+	if !sawCloseOrphan {
+		t.Fatalf("no %s decision record found in %d records — the orphan close path must be reached for this test to have teeth", TraceSiteReconcilerCloseOrphan, len(records))
+	}
+}


### PR DESCRIPTION
## Problem

An orphaned seat that still holds open assigned work was unreachable by every recovery lane, and each lane was individually correct to defer:

- **close_orphan** refuses while the seat holds work (`session_work_guard.go:126`).
- **wake / `projectDesiredState`** refuses because an orphaned base state raises `BlockerMissingConfig` → `DesiredStateBlocked`.
- **`releaseOrphanedPoolAssignments`** skips the work because `liveOpenSessionAssignmentExists` (`pool_session_name.go:619`) tests **bead status**, not runtime liveness — and the seat's session bead is still open.

`closeBead` is itself what runs the orphaned-work release cascade, so the close guard blocks its own release path. Observed wedged for 86 hours in maintainer-city.

## Fix

The orphan close is the one site that has **already confirmed the runtime is observably dead**, so it owns the tie-break: release the held work, then close. Restricted to `reason == "orphaned"` — a `suspended` seat is configured and merely scaled down, so its work stays put for its return.

`releaseConfirmedOrphanSessionWork` deliberately takes no liveness argument and performs no liveness probe; the caller must have confirmed death. That is the `ga-g3pf0` scar, where a session store serving zero session beads read as "every assignee is dead" and released live work every tick.

## Trace honesty

Both close sites recorded their decision **before** attempting the close and hard-coded `TraceOutcomeClosed`, so a seat that never closed was still reported "closed" every tick. `gc trace` is the documented entry point for a stuck reconciler (`engdocs/contributors/reconciler-debugging.md`), so that misreport actively misdirected the investigation for as long as the seat stayed wedged. Both sites now report the close that actually happened.

## Tests

Three tests, one per behaviour:

- `...ReleasesHeldWorkThenCloses` — pins the repair.
- `...RecordsClosedOnlyWhenClosed` — pins the trace honesty.
- `...LeavesLiveSeatWorkAlone` — the control that matters. Releasing work from a live seat is data loss, not recovery. It asserts the **mechanism**, not just the outcome: a running runtime must never reach the `close_orphan` site at all.

The control also documents a fixture trap worth knowing: a session bead needs `Type`/`Labels` set, because `session.ResolveSessionRecordByExactID` only recognises a typed (or labelled-and-untyped) bead as a session record. An untyped bead still reconciles, but every liveness observation on it reads not-running — silently turning a live seat into a confirmed orphan.

## Verification

- All three tests pass.
- **Mutation check:** replacing the release call with `nil` makes the release test fail (`work assignee = "polecat-1", want empty`) while the control still passes — so the wiring is load-bearing and the control is not vacuous.
- `go vet ./cmd/gc/ ./internal/session/` clean.
- `go test ./cmd/gc/ -run 'Reconcil|Orphan|Pool|SessionBead|Drain|Trace'` → ok, 60.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3566 — adds a confirmed-dead-orphan release path alongside releaseOrphanedPoolAssignments that reuses the same liveness predicates (the detached probe and the live re-read) instead of a holder-renewed lease, so it is a new release site the lease work in that issue would need to subsume rather than a step toward it. It does not touch the live-holder release race or the gate-2 named-session asymmetry that issue still tracks.
- Related to #4387 — covers one narrow lane of the abandoned-work problem: when the reconciler has confirmed an orphaned seat's runtime is dead, it now releases the pool-routed work that seat still held — clearing the assignee and returning the bead to open — instead of leaving it assigned to a corpse; it does not add the general sweep described in that issue (no lease/TTL/heartbeat, no reclaim for still-configured crashed sessions, and no re-dispatch cooldown, attempt limits, or mayor escalation)
- Related to #4448 — addresses one route by which a session bead whose runtime is confirmed dead can stay open indefinitely and keep consuming a pool slot — the reconciler's orphan-reap guard deferring while the seat still holds assigned work; it does not cover the post-drain-ack unreaped-shell case described here, and does not change how open_count is computed

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->