### PR TITLE
fix(hook): hide assigned and foreign-routed work consistently

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -442,43 +442,49 @@ func cmdHookWithOptions(args []string, opts hookCommandOptions, stdout, stderr i
 		emitQueryFailure(command, err)
 		return out, err
 	}
+	// The stale-session fence already ran before agent resolution above; this
+	// sessionID feeds only the claim/visibility assignee identity.
+	sessionID := strings.TrimSpace(overrides["GC_SESSION_ID"])
+	sessionName := strings.TrimSpace(sessionForQuery)
+	alias := strings.TrimSpace(overrides["GC_ALIAS"])
+	// Write the alias/agent form that read paths query through GC_AGENT.
+	// Session forms remain fallbacks for unaliased workers.
+	assignee := firstNonEmptyHookValue(alias, agentForQuery, resolvedAgentName, sessionName, sessionID)
+	// IdentityCandidates governs ADOPTION of already-owned in_progress/open
+	// work (hookClaimExistingAssignment, claimFirstReadyHookAssignment, and
+	// the display path's hookCandidateVisible own-work check); it must be
+	// scoped to this session's OWN runtime identity, never the bare pool
+	// template. A suffixed pool worker resolves config via the GC_TEMPLATE
+	// fallback, so resolvedAgentName == a.QualifiedName() is the bare
+	// template, which is ALSO the [[named_session]] holder's identity —
+	// including it let a suffixed worker adopt the holder's in_progress bead
+	// (ga-80pen8). The bare template stays in RouteTargets, which governs
+	// FRESH claims of UNASSIGNED routed work. The canonical slot / named
+	// holder keep it via `alias` (GC_ALIAS == qualified bare name); only
+	// suffixed workers drop it.
+	identityCandidates := hookClaimIdentityCandidates(
+		assignee,
+		sessionID,
+		sessionName,
+		alias,
+		agentForQuery,
+	)
+	routeTargets := hookClaimRouteTargets(hookClaimPrimaryRouteTarget(&a), resolvedAgentName, strings.TrimSpace(overrides["GC_TEMPLATE"]))
 	if opts.Claim {
-		// The stale-session fence already ran before agent resolution above; this
-		// sessionID feeds only the claim assignee identity.
-		sessionID := strings.TrimSpace(overrides["GC_SESSION_ID"])
-		sessionName := strings.TrimSpace(sessionForQuery)
-		alias := strings.TrimSpace(overrides["GC_ALIAS"])
-		// Write the alias/agent form that read paths query through GC_AGENT.
-		// Session forms remain fallbacks for unaliased workers.
-		assignee := firstNonEmptyHookValue(alias, agentForQuery, resolvedAgentName, sessionName, sessionID)
 		claimOpts := hookClaimOptions{
-			Assignee: assignee,
-			// IdentityCandidates governs ADOPTION of already-owned in_progress/open
-			// work (hookClaimExistingAssignment and
-			// claimFirstReadyHookAssignment); it must be scoped to this session's
-			// OWN runtime identity, never the bare pool template. A
-			// suffixed pool worker resolves config via the GC_TEMPLATE fallback, so
-			// resolvedAgentName == a.QualifiedName() is the bare template, which is
-			// ALSO the [[named_session]] holder's identity — including it let a
-			// suffixed worker adopt the holder's in_progress bead (ga-80pen8). The
-			// bare template stays in RouteTargets, which governs FRESH claims of
-			// UNASSIGNED routed work. The canonical slot / named holder keep it via
-			// `alias` (GC_ALIAS == qualified bare name); only suffixed workers drop it.
-			IdentityCandidates: hookClaimIdentityCandidates(
-				assignee,
-				sessionID,
-				sessionName,
-				alias,
-				agentForQuery,
-			),
-			RouteTargets: hookClaimRouteTargets(hookClaimPrimaryRouteTarget(&a), resolvedAgentName, strings.TrimSpace(overrides["GC_TEMPLATE"])),
-			Env:          queryEnv,
-			DrainAck:     opts.DrainAck,
-			JSON:         opts.JSON,
+			Assignee:           assignee,
+			IdentityCandidates: identityCandidates,
+			RouteTargets:       routeTargets,
+			Env:                queryEnv,
+			DrainAck:           opts.DrainAck,
+			JSON:               opts.JSON,
 		}
 		return claimHookWork(cityPath, workQuery, workDir, queryEnv, stores, claimOpts, emitQueryFailure, stdout, stderr)
 	}
-	return doHook(workQuery, workDir, false, runner, stdout, stderr)
+	return doHook(workQuery, workDir, false, runner, stdout, stderr, hookVisibility{
+		Identities:   identityCandidates,
+		RouteTargets: routeTargets,
+	})
 }
 
 // hookClaimSessionVerdict classifies a runtime session's fitness to claim routed
@@ -908,11 +914,25 @@ func workQueryEnvForDir(env []string, dir string) []string {
 	return append(out, "PWD="+dir)
 }
 
+// hookVisibility scopes which already-returned work_query candidates doHook
+// shows the caller. Identities match a candidate's OWN assignee
+// (already-claimed work); RouteTargets match an UNASSIGNED candidate's
+// gc.routed_to (freshly routed work). These are kept as two separate lists,
+// not merged into one, because they are not interchangeable - see the
+// IdentityCandidates/RouteTargets split in cmdHookWithOptions (ga-80pen8): a
+// suffixed pool worker's own session identity must never act as a route
+// target for fresh unassigned claims. The zero value disables filtering
+// entirely, matching pre-ga-1xaqgo.2 behavior byte-for-byte.
+type hookVisibility struct {
+	Identities   []string
+	RouteTargets []string
+}
+
 // doHook is the pure logic for gc hook. Runs the work query and outputs
 // results based on mode. Without inject: prints normalized ready-only output,
 // returns 0 if work exists, 1 if empty. With inject: skips the work query and
 // returns 0.
-func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, stderr io.Writer) int {
+func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, stderr io.Writer, visibility hookVisibility) int {
 	if inject {
 		return 0
 	}
@@ -929,6 +949,7 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 	trimmed := strings.TrimSpace(output)
 	normalized := normalizeWorkQueryOutput(trimmed)
 	normalized = filterUnreadyHookCandidates(normalized, time.Now())
+	normalized = filterForeignHookCandidates(normalized, visibility)
 	hasWork := workQueryHasReadyWork(normalized)
 
 	// Non-inject mode: print normalized, ready-only output. Return 0 only when work exists.
@@ -1013,6 +1034,76 @@ func filterUnreadyHookCandidates(output string, now time.Time) string {
 		return output
 	}
 	return string(reencoded)
+}
+
+// filterForeignHookCandidates drops work_query candidates that belong to a
+// different agent or are routed to a different agent/rig, mirroring the
+// assignee/route eligibility the claim path already enforces
+// (hookCandidateVisible). Plain "gc hook" has no claim step to reject
+// foreign work at, so under native-store schema skew (gc.routed_to's own
+// store-side predicate silently no-ops - ga-lmy6yj) it would otherwise
+// display another agent's in-flight or routed work as if it were this
+// session's own (ga-1xaqgo.2). Fails open at every decode step -
+// unparseable output, non-array output, non-object items, and items that
+// fail to decode as a beads.Bead all pass through unchanged - and is a
+// no-op entirely when visibility carries no identity/route context, since a
+// filter that can silently empty an agent's queue is a worse outage than
+// the over-serving it replaces.
+func filterForeignHookCandidates(output string, visibility hookVisibility) string {
+	if output == "" {
+		return output
+	}
+	if len(visibility.Identities) == 0 && len(visibility.RouteTargets) == 0 {
+		return output
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		return output
+	}
+	arr, ok := decoded.([]any)
+	if !ok {
+		return output
+	}
+	filtered := make([]any, 0, len(arr))
+	for _, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		candidate, ok := decodeHookCandidateBead(obj)
+		if !ok {
+			filtered = append(filtered, obj)
+			continue
+		}
+		if !hookCandidateVisible(candidate, visibility.Identities, visibility.RouteTargets) {
+			continue
+		}
+		filtered = append(filtered, obj)
+	}
+	reencoded, err := json.Marshal(filtered)
+	if err != nil {
+		return output
+	}
+	return string(reencoded)
+}
+
+// decodeHookCandidateBead best-effort decodes a raw work_query candidate
+// into a beads.Bead so filterForeignHookCandidates can reuse the same
+// assignee/route predicates as gc hook --claim. Roundtrips through JSON
+// rather than a field-by-field map read because beads.Bead.Metadata
+// (StringMap) already carries the bd-CLI type-coercion tolerance that this
+// decode should inherit unchanged.
+func decodeHookCandidateBead(obj map[string]any) (beads.Bead, bool) {
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		return beads.Bead{}, false
+	}
+	var candidate beads.Bead
+	if err := json.Unmarshal(raw, &candidate); err != nil {
+		return beads.Bead{}, false
+	}
+	return candidate, true
 }
 
 func isFutureDeferredHookCandidate(item map[string]any, now time.Time) bool {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
@@ -1999,6 +2000,22 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 	return false
 }
 
+// hookRouteIdentitiesEqual reports whether two route/identity strings refer
+// to the same qualified agent, tolerating the tmux-safe session-name
+// encoding (/ -> --, . -> __) alongside the canonical slash-qualified form.
+// gc.routed_to is always written in canonical form, but comparison
+// candidates built from a runtime session name (sessionForQuery) are
+// dash-encoded, so the two spellings must compare equal. This is the single
+// route-spelling matcher shared by the claim path (hookClaimMatchesRoute)
+// and the display path (hookCandidateVisible) per ga-1xaqgo.2 - do not fork
+// a second one.
+func hookRouteIdentitiesEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return agent.UnsanitizeQualifiedNameFromSession(a) == agent.UnsanitizeQualifiedNameFromSession(b)
+}
+
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {
 	if len(routeTargets) == 0 {
 		return false
@@ -2011,14 +2028,34 @@ func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {
 		if target == "" {
 			continue
 		}
-		if routedTo == target {
+		if hookRouteIdentitiesEqual(routedTo, target) {
 			return true
 		}
-		if routedTo == "" && kind == beadmeta.KindWorkflow && runTarget == target {
+		if routedTo == "" && kind == beadmeta.KindWorkflow && hookRouteIdentitiesEqual(runTarget, target) {
 			return true
 		}
 	}
 	return false
+}
+
+// hookCandidateVisible reports whether a work_query candidate should be
+// shown to this identity at all. An already-assigned candidate is visible
+// only when the assignee is one of this session's own identities. An
+// unassigned candidate is visible when it carries no route at all (legacy
+// and unrouted work is always claimable - the fail-open default the legacy
+// workflow-target path depends on) or when its route matches one of
+// routeTargets. This is deliberately more permissive than the claim path's
+// eligibility check, which additionally requires a positive route match
+// even for unrouted work; that stricter rule is correct for claiming but
+// would wrongly hide legitimately unrouted display candidates (ga-1xaqgo.2).
+func hookCandidateVisible(candidate beads.Bead, identities, routeTargets []string) bool {
+	if assignee := strings.TrimSpace(candidate.Assignee); assignee != "" {
+		return hookClaimHasIdentity(assignee, identities)
+	}
+	if hookClaimRoute(candidate) == "" {
+		return true
+	}
+	return hookClaimMatchesRoute(candidate, routeTargets)
 }
 
 func hookClaimRoute(candidate beads.Bead) string {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -314,7 +314,7 @@ work_query = "printf '[{\"id\":\"ga-pool1\",\"status\":\"open\",\"title\":\"work
 func TestHookNoWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "", nil }
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 1 {
 		t.Errorf("doHook(no work) = %d, want 1", code)
 	}
@@ -326,7 +326,7 @@ func TestHookNoWork(t *testing.T) {
 func TestHookHasWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "hw-1  open  Fix the bug\n", nil }
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Errorf("doHook(has work) = %d, want 0", code)
 	}
@@ -1294,7 +1294,7 @@ func TestDoHookClaimPreassignsContinuationGroupSiblings(t *testing.T) {
 func TestHookCommandError(t *testing.T) {
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 1 {
 		t.Errorf("doHook(error) = %d, want 1", code)
 	}
@@ -1308,7 +1308,7 @@ func TestHookCommandErrorPrintsPartialOutput(t *testing.T) {
 		return "[]\n", fmt.Errorf("timed out after 15s with partial stdout")
 	}
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 1 {
 		t.Errorf("doHook(error with output) = %d, want 1", code)
 	}
@@ -1340,7 +1340,7 @@ func TestShellWorkQueryWithEnvTimeoutReportsPartialOutput(t *testing.T) {
 func TestHookInjectNoWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "", nil }
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Errorf("doHook(inject, no work) = %d, want 0", code)
 	}
@@ -1354,7 +1354,7 @@ func TestHookNoReadyMessagePrintsButExitsOne(t *testing.T) {
 		return "✨ No ready work found (all issues have blocking dependencies)\n", nil
 	}
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 1 {
 		t.Errorf("doHook(no-ready-message) = %d, want 1", code)
 	}
@@ -1368,7 +1368,7 @@ func TestHookInjectSuppressesNoReadyMessage(t *testing.T) {
 		return "✨ No ready work found (all issues have blocking dependencies)\n", nil
 	}
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Errorf("doHook(inject, no-ready-message) = %d, want 0", code)
 	}
@@ -1380,7 +1380,7 @@ func TestHookInjectSuppressesNoReadyMessage(t *testing.T) {
 func TestHookInjectIsNonIntrusiveWithWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "hw-1  open  Fix the bug\n", nil }
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Errorf("doHook(inject, work) = %d, want 0", code)
 	}
@@ -1396,7 +1396,7 @@ func TestHookInjectDoesNotRunWorkQuery(t *testing.T) {
 		return "hw-1  open  Fix the bug\n", nil
 	}
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Errorf("doHook(inject, work) = %d, want 0", code)
 	}
@@ -2191,7 +2191,7 @@ func TestHookInjectAlwaysExitsZero(t *testing.T) {
 	// Even on command failure, inject mode exits 0.
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Errorf("doHook(inject, error) = %d, want 0", code)
 	}
@@ -2206,7 +2206,7 @@ func TestHookPassesWorkQuery(t *testing.T) {
 		return "item-1\n", nil
 	}
 	var stdout, stderr bytes.Buffer
-	doHook("bd ready --assignee=mayor", "/tmp/work", false, runner, &stdout, &stderr)
+	doHook("bd ready --assignee=mayor", "/tmp/work", false, runner, &stdout, &stderr, hookVisibility{})
 	if receivedCmd != "bd ready --assignee=mayor" {
 		t.Errorf("runner command = %q, want %q", receivedCmd, "bd ready --assignee=mayor")
 	}
@@ -2856,7 +2856,7 @@ func TestDoHookNormalizesSingleObjectOutputToArray(t *testing.T) {
 		return `{"id":"bd-1","title":"Work"}`, nil
 	}
 
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// --- hookRouteIdentitiesEqual ----------------------------------------------
+
+func TestHookRouteIdentitiesEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical canonical", "gascity/builder", "gascity/builder", true},
+		{"canonical vs dash-encoded", "gascity/builder", "gascity--builder", true},
+		{"canonical vs dot-encoded", "gastown.mayor", "gastown__mayor", true},
+		{"both dash-encoded, same identity", "gascity--builder", "gascity--builder", true},
+		{"different rigs", "rig-a/planner", "rig-b/planner", false},
+		{"different agents, same rig", "gascity/builder", "gascity/reviewer", false},
+		{"empty vs non-empty", "", "gascity/builder", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hookRouteIdentitiesEqual(tc.a, tc.b); got != tc.want {
+				t.Errorf("hookRouteIdentitiesEqual(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			if got := hookRouteIdentitiesEqual(tc.b, tc.a); got != tc.want {
+				t.Errorf("hookRouteIdentitiesEqual(%q, %q) = %v, want %v (reversed)", tc.b, tc.a, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHookClaimMatchesRouteToleratesSessionNameEncoding proves the claim
+// path's own predicate now shares hookRouteIdentitiesEqual, satisfying
+// ga-1xaqgo.2's "display and claim paths share one route-spelling matcher"
+// criterion directly against the function gc hook --claim calls.
+func TestHookClaimMatchesRouteToleratesSessionNameEncoding(t *testing.T) {
+	candidate := beads.Bead{
+		ID:       "rt-1",
+		Status:   "open",
+		Metadata: beads.StringMap{"gc.routed_to": "gascity/builder"},
+	}
+	if !hookClaimMatchesRoute(candidate, []string{"gascity--builder"}) {
+		t.Fatal("dash-encoded route target must match canonical gc.routed_to")
+	}
+	if hookClaimMatchesRoute(candidate, []string{"gascity--reviewer"}) {
+		t.Fatal("a genuinely different agent must not match")
+	}
+}
+
+// --- hookCandidateVisible ---------------------------------------------------
+
+func TestHookCandidateVisible(t *testing.T) {
+	cases := []struct {
+		name         string
+		assignee     string
+		routedTo     string
+		identities   []string
+		routeTargets []string
+		want         bool
+	}{
+		{
+			name:       "assigned to me",
+			assignee:   "gascity/builder",
+			identities: []string{"gascity/builder"},
+			want:       true,
+		},
+		{
+			name:       "assigned to someone else",
+			assignee:   "reviewer-gm-wisp-b6tr3z",
+			identities: []string{"gascity/builder"},
+			want:       false,
+		},
+		{
+			name:     "assigned to someone else, no identity context at all",
+			assignee: "reviewer-gm-wisp-b6tr3z",
+			want:     false,
+		},
+		{
+			name: "unassigned and unrouted is always visible",
+			want: true,
+		},
+		{
+			name:         "unassigned, routed to me",
+			routedTo:     "gascity/builder",
+			routeTargets: []string{"gascity/builder"},
+			want:         true,
+		},
+		{
+			name:         "unassigned, routed to me in session-name encoding",
+			routedTo:     "gascity/builder",
+			routeTargets: []string{"gascity--builder"},
+			want:         true,
+		},
+		{
+			name:         "unassigned, routed to a different agent",
+			routedTo:     "gascity/reviewer",
+			routeTargets: []string{"gascity/builder"},
+			want:         false,
+		},
+		{
+			name:         "unassigned, routed to a different rig",
+			routedTo:     "otherrig/builder",
+			routeTargets: []string{"gascity/builder"},
+			want:         false,
+		},
+		{
+			name:     "unassigned, routed, but no route context at all",
+			routedTo: "gascity/reviewer",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := beads.Bead{ID: "vis-1", Status: "open", Assignee: tc.assignee}
+			if tc.routedTo != "" {
+				candidate.Metadata = beads.StringMap{"gc.routed_to": tc.routedTo}
+			}
+			if got := hookCandidateVisible(candidate, tc.identities, tc.routeTargets); got != tc.want {
+				t.Errorf("hookCandidateVisible(assignee=%q, routedTo=%q, identities=%v, routeTargets=%v) = %v, want %v",
+					tc.assignee, tc.routedTo, tc.identities, tc.routeTargets, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHookCandidateVisibleWorkflowRunTargetFallback(t *testing.T) {
+	candidate := beads.Bead{
+		ID:     "wf-1",
+		Status: "open",
+		Metadata: beads.StringMap{
+			"gc.kind":       "workflow",
+			"gc.run_target": "gascity/builder",
+		},
+	}
+	if !hookCandidateVisible(candidate, nil, []string{"gascity/builder"}) {
+		t.Fatal("unrouted workflow candidate must fall back to gc.run_target, matching hookClaimMatchesRoute")
+	}
+	if hookCandidateVisible(candidate, nil, []string{"gascity/reviewer"}) {
+		t.Fatal("workflow run_target for a different agent must not be visible")
+	}
+}
+
+// --- filterForeignHookCandidates --------------------------------------------
+
+func TestFilterForeignHookCandidatesFailsOpen(t *testing.T) {
+	visibility := hookVisibility{Identities: []string{"gascity/builder"}, RouteTargets: []string{"gascity/builder"}}
+
+	t.Run("empty output unchanged", func(t *testing.T) {
+		if got := filterForeignHookCandidates("", visibility); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("no visibility configured, output unchanged", func(t *testing.T) {
+		raw := `[{"id":"x","status":"open","assignee":"someone-else"}]`
+		if got := filterForeignHookCandidates(raw, hookVisibility{}); got != raw {
+			t.Errorf("got %q, want unchanged %q", got, raw)
+		}
+	})
+
+	t.Run("non-JSON output unchanged", func(t *testing.T) {
+		raw := "hw-1  open  Fix the bug\n"
+		if got := filterForeignHookCandidates(raw, visibility); got != raw {
+			t.Errorf("got %q, want unchanged %q", got, raw)
+		}
+	})
+
+	t.Run("non-array JSON unchanged", func(t *testing.T) {
+		raw := `{"id":"x"}`
+		if got := filterForeignHookCandidates(raw, visibility); got != raw {
+			t.Errorf("got %q, want unchanged %q", got, raw)
+		}
+	})
+
+	t.Run("non-object array item is kept", func(t *testing.T) {
+		raw := `["not-an-object"]`
+		var got []any
+		if err := json.Unmarshal([]byte(filterForeignHookCandidates(raw, visibility)), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d items, want 1 kept", len(got))
+		}
+	})
+
+	t.Run("item that fails to decode as a Bead is kept", func(t *testing.T) {
+		raw := `[{"id":12345,"status":"open","assignee":"someone-else"}]`
+		var got []any
+		if err := json.Unmarshal([]byte(filterForeignHookCandidates(raw, visibility)), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d items, want 1 kept (fail-open on decode error)", len(got))
+		}
+	})
+}
+
+func TestFilterForeignHookCandidatesDropsForeignKeepsOwnAndUnrouted(t *testing.T) {
+	candidates := []beads.Bead{
+		{ID: "ga-2a46gb", Status: "open", Assignee: "gascity/builder"},
+		{ID: "ga-77refr", Status: "in_progress", Assignee: "reviewer-gm-wisp-b6tr3z"},
+		{ID: "ga-20zoji", Status: "open"},
+		{ID: "ga-5hdwl6", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "gascity/reviewer"}},
+		{ID: "ga-drlztz", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "otherrig/builder"}},
+		{ID: "ga-same-route", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "gascity--builder"}},
+	}
+	raw, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	visibility := hookVisibility{
+		Identities:   []string{"gascity/builder"},
+		RouteTargets: []string{"gascity/builder"},
+	}
+	got := filterForeignHookCandidates(string(raw), visibility)
+
+	var kept []beads.Bead
+	if err := json.Unmarshal([]byte(got), &kept); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	var ids []string
+	for _, b := range kept {
+		ids = append(ids, b.ID)
+	}
+	want := []string{"ga-2a46gb", "ga-20zoji", "ga-same-route"}
+	if len(ids) != len(want) {
+		t.Fatalf("kept ids = %v, want %v", ids, want)
+	}
+	for i, id := range want {
+		if ids[i] != id {
+			t.Errorf("kept[%d] = %q, want %q (full: %v)", i, ids[i], id, ids)
+		}
+	}
+}
+
+// --- doHook integration -----------------------------------------------------
+
+func TestDoHookVisibilityIgnoredWhenEmpty(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return `[{"id":"hw-1","status":"open","assignee":"someone-else"}]`, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, hookVisibility{})
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0 (zero-value visibility must not filter); stderr=%s", code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("hw-1")) {
+		t.Errorf("stdout = %q, want to contain hw-1 (unfiltered)", stdout.String())
+	}
+}
+
+func TestDoHookDropsForeignAssigneeUnderVisibility(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return `[{"id":"ga-77refr","status":"in_progress","assignee":"reviewer-gm-wisp-b6tr3z"}]`, nil
+	}
+	var stdout, stderr bytes.Buffer
+	visibility := hookVisibility{Identities: []string{"gascity/builder"}, RouteTargets: []string{"gascity/builder"}}
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, visibility)
+	if code != 1 {
+		t.Fatalf("doHook() = %d, want 1 (foreign assignee filtered to no-work); stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("ga-77refr")) {
+		t.Errorf("stdout = %q, must not contain the foreign-assigned candidate", stdout.String())
+	}
+}
+
+func TestDoHookKeepsUnroutedUnassignedWorkUnderVisibility(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return `[{"id":"ga-20zoji","status":"open"}]`, nil
+	}
+	var stdout, stderr bytes.Buffer
+	visibility := hookVisibility{Identities: []string{"gascity/builder"}, RouteTargets: []string{"gascity/builder"}}
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, visibility)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0 (legacy unrouted work must stay visible); stderr=%s", code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("ga-20zoji")) {
+		t.Errorf("stdout = %q, want to contain the unrouted candidate", stdout.String())
+	}
+}
+
+// TestDoHookGa1xaqgoRegression mirrors the ga-1xaqgo.2 / ga-lmy6yj bug
+// report's repro shape: a plain "gc hook" call under native-store schema
+// skew (where the store's own gc.routed_to predicate silently no-ops) must
+// show only this agent's own and legitimately unrouted work.
+func TestDoHookGa1xaqgoRegression(t *testing.T) {
+	candidates := []beads.Bead{
+		{ID: "ga-2a46gb", Status: "open", Assignee: "gascity/builder"},
+		{ID: "ga-77refr", Status: "in_progress", Assignee: "reviewer-gm-wisp-b6tr3z"},
+		{ID: "ga-20zoji", Status: "open"},
+		{ID: "ga-5hdwl6", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "gascity/reviewer"}},
+		{ID: "ga-drlztz", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "otherrig/builder"}},
+	}
+	raw, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	runner := func(string, string) (string, error) { return string(raw), nil }
+	var stdout, stderr bytes.Buffer
+	visibility := hookVisibility{Identities: []string{"gascity/builder"}, RouteTargets: []string{"gascity/builder"}}
+	code := doHook("bd ready", "", false, runner, &stdout, &stderr, visibility)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, wantID := range []string{"ga-2a46gb", "ga-20zoji"} {
+		if !bytes.Contains([]byte(out), []byte(wantID)) {
+			t.Errorf("stdout missing own/unrouted candidate %q: %s", wantID, out)
+		}
+	}
+	for _, foreignID := range []string{"ga-77refr", "ga-5hdwl6", "ga-drlztz"} {
+		if bytes.Contains([]byte(out), []byte(foreignID)) {
+			t.Errorf("stdout leaked foreign candidate %q: %s", foreignID, out)
+		}
+	}
+}

--- a/cmd/gc/hook_defer_blocked_test.go
+++ b/cmd/gc/hook_defer_blocked_test.go
@@ -16,7 +16,7 @@ func TestDoHookFiltersDeferredBeads(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -38,7 +38,7 @@ func TestDoHookFiltersDepBlockedBeads(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -60,7 +60,7 @@ func TestDoHookFiltersIsBlockedBeads(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -82,7 +82,7 @@ func TestDoHookFiltersStatusBlockedBeads(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -101,7 +101,7 @@ func TestDoHookKeepsAbsentIsBlocked(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -120,7 +120,7 @@ func TestDoHookKeepsPastDeferredAndClosedBlockers(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr, hookVisibility{})
 	if code != 0 {
 		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}

--- a/release-gates/ga-oeb47p-gc-hook-visibility-gate.md
+++ b/release-gates/ga-oeb47p-gc-hook-visibility-gate.md
@@ -1,0 +1,90 @@
+# Release Gate: consistent `gc hook` visibility
+
+- Deploy bead: `ga-oeb47p`
+- Review bead: `ga-dooipb`
+- Build bead: `ga-1xaqgo.2`
+- Reviewed source: `a4e9c3b40602c4787feaf23c5c29abe82fda4cca`
+- Base evaluated: `origin/main@2cd07e018bf3680d24b037b509e6a4bad5e623ba`
+- Deploy mode: remote
+- Overall verdict: **PASS WITH ATTRIBUTED FAILURES**
+
+The already-merged preflight found no pull request carrying the reviewed
+source. Criterion 6 passed first, and the source ancestry passed the deploy
+scope guard for `ga-oeb47p`, `ga-dooipb`, `ga-0t1lfm`, and `ga-1xaqgo.2`.
+The full CI union reported six red jobs, but every failure is non-diff-owned,
+predates this run under an exact tracker, has no path overlap with the diff,
+and has a direct mechanism or coverage proof below. The required lint command
+also hit a tracked full-fallback path leak rather than a finding in this diff.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Review bead `ga-dooipb` is closed with a PASS verdict pinned to exact source `a4e9c3b40602c4787feaf23c5c29abe82fda4cca`. |
+| 2 | Acceptance criteria met | PASS | Plain `gc hook` now applies the same assignee and route visibility facts as the claim path. Assigned work is visible only to a matching identity; foreign agent/rig routes are dropped; unassigned/unrouted legacy work remains visible; canonical slash and double-dash route spellings share one matcher. The implementation reuses `hookClaimHasIdentity` and `hookRouteIdentitiesEqual` across display and claim paths. All ten added top-level tests and 22 subtests pass. |
+| 3 | Tests pass | PASS WITH ATTRIBUTED FAILURES | Documented CI union `make EXTRA_TEST_ENV="DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true" test-local-full-parallel`, at the fleet's two-job cap: **34 PASS jobs, 6 FAIL jobs, 0 SKIP jobs**. All six red jobs are attributed below. Focused diff-owned run: **32 PASS events, 0 FAIL, 0 SKIP** across ten top-level tests and 22 subtests. `waiver_ref: none`. Summary log: `/var/tmp/ga-oeb47p-test-local-full.log`; job logs: `/var/tmp/gc-local-tests.S9nil6`. |
+| 3b | Policy/lint lane | PASS WITH ATTRIBUTED FAILURE | `make test-ci-policy`: PASS. `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make fmt-check-changed`: PASS. `go build ./...`: PASS. `go vet ./...`: PASS. `git diff --check`: PASS. `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected`: red only after the source's absence of base-only `.github/workflows/pr-evidence-watchdog.yml` forced a full-repository fallback that traversed stale `/var/tmp/ga-*-gate` worktrees and dashboard `node_modules`; all 623 findings are outside the five-file diff. Exact predating tracker: `ga-u8z8j6`. |
+| 4 | No high-severity review findings open | PASS | Reviewer recorded no security, style, or specification blocker and no unresolved HIGH finding. |
+| 5 | Final branch is clean | PASS | Exact reviewed source was checked out detached; `git status --porcelain=v1` was empty before this checklist was written. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main a4e9c3b40602c4787feaf23c5c29abe82fda4cca` exited 0 and produced tree `a6481e443285e8fffcec20e562ec5e9fed6c06ef`; branch counts were 2 behind / 1 ahead. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | One commit changes five `cmd/gc` hook files for a single behavior: keep plain hook display visibility consistent with hook claim eligibility. |
+
+## Diff-owned test execution
+
+Command:
+
+```text
+GC_FAST_UNIT=0 go test -json -count=1 ./cmd/gc -run '^(TestHookRouteIdentitiesEqual|TestHookClaimMatchesRouteToleratesSessionNameEncoding|TestHookCandidateVisible|TestHookCandidateVisibleWorkflowRunTargetFallback|TestFilterForeignHookCandidatesFailsOpen|TestFilterForeignHookCandidatesDropsForeignKeepsOwnAndUnrouted|TestDoHookVisibilityIgnoredWhenEmpty|TestDoHookDropsForeignAssigneeUnderVisibility|TestDoHookKeepsUnroutedUnassignedWorkUnderVisibility|TestDoHookGa1xaqgoRegression)$'
+```
+
+Results: **32 PASS events, 0 FAIL, 0 SKIP**.
+
+- `TestHookRouteIdentitiesEqual` — PASS (7 subtests).
+- `TestHookClaimMatchesRouteToleratesSessionNameEncoding` — PASS.
+- `TestHookCandidateVisible` — PASS (9 subtests).
+- `TestHookCandidateVisibleWorkflowRunTargetFallback` — PASS.
+- `TestFilterForeignHookCandidatesFailsOpen` — PASS (6 subtests).
+- `TestFilterForeignHookCandidatesDropsForeignKeepsOwnAndUnrouted` — PASS.
+- `TestDoHookVisibilityIgnoredWhenEmpty` — PASS.
+- `TestDoHookDropsForeignAssigneeUnderVisibility` — PASS.
+- `TestDoHookKeepsUnroutedUnassignedWorkUnderVisibility` — PASS.
+- `TestDoHookGa1xaqgoRegression` — PASS.
+
+`diff_tests_executed`: every added test and subtest above executed and passed;
+no diff-owned test skipped. The modified pre-existing hook tests also ran in
+the full `cmd/gc` shards.
+
+## Failure attribution
+
+- `TestSendReloadControlRequestNoChange` -> `ga-movzgb` | clause 3(c),
+  coverage: a focused run passed, and its coverage profile reports 0.0% for
+  every changed hook function (`cmdHookWithOptions`, `workQueryEnvForDir`,
+  `doHook`, `filterForeignHookCandidates`, `decodeHookCandidateBead`,
+  `hookRouteIdentitiesEqual`, `hookClaimMatchesRoute`, and
+  `hookCandidateVisible`). Profile: `/var/tmp/ga-oeb47p-reload.cover`.
+- `TestBdFlagManifestCurrent` -> `ga-f0uceo` | clause 3(a), mechanism: the
+  test compares the installed `bd` binary with `internal/bdflags`; neither is
+  changed or reachable from the hook display/claim diff.
+- `TestGetKeyBinding_CapturesDefaultBinding` and
+  `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr` | clause
+  3(a), mechanism: the host tmux 3.7b default key table is independent of the
+  `cmd/gc` hook filter.
+- `TestE2E_SuspendResume_City` -> `ga-yc0e3a` | clause 3(a), mechanism: the
+  test invokes city suspend/resume and session kill, never `gc hook`; the
+  tracked missing-`citysus.report` signature therefore cannot execute the
+  changed path.
+- `TestGCLiveContract_BeadsAndEvents` -> `ga-lpfjhc` (standing condition
+  `ga-6bnc42`) | clause 3(a), mechanism: fixture initialization failed with
+  the exact `gastownhall/beads#4566` dirty-table migration signature before
+  any hook command or hook filter could execute.
+- `lint-affected` full-fallback path leak -> `ga-u8z8j6` | mechanism: all 623
+  findings name stale `/var/tmp` worktrees or dashboard `node_modules`; none
+  names a changed file.
+
+Every tracker above predates its cited run. Every failing test file/package is
+path-disjoint from the five changed hook files. The coverage proof resolves
+the only same-package failure.
+
+## Release decision
+
+The change is ready for an isolated deploy branch and pull request. The
+attributed failures remain visible here; no failure was silently converted to
+green and no waiver was self-granted.


### PR DESCRIPTION
## What this changes

Plain `gc hook` now filters its displayed work with the same identity and route rules used by `gc hook --claim`. Agents no longer see beads already assigned to another identity or routed to another agent or rig, closing a path that could wake an agent for work it could not legitimately claim.

Valid unassigned, unrouted work remains visible. Canonical route names and supported slash/double-dash session aliases resolve through one shared matcher, so display and claim behavior cannot drift independently.

## Review notes

- The visibility filter is shared by the display and claim paths; there is no second assignee or route-policy implementation.
- Malformed fallback output remains fail-open rather than disappearing silently, preserving the existing diagnostic behavior.
- Claim semantics are unchanged; this aligns the plain display path with them.

## Test plan

- [x] Ten focused hook regression tests and 22 subtests pass with no skips.
- [x] The pre-push fast suite passes all 10 jobs.
- [x] Required policy, formatting, build, vet, and diff checks pass.
- [x] Release gate and attributed full-suite evidence: [`release-gates/ga-oeb47p-gc-hook-visibility-gate.md`](release-gates/ga-oeb47p-gc-hook-visibility-gate.md)
