### PR TITLE
Fix bounded order feed reads and partial-result status fixtures

### DIFF
--- a/internal/api/handler_beads_partial_test.go
+++ b/internal/api/handler_beads_partial_test.go
@@ -77,13 +77,13 @@ func newPartialListState(t *testing.T, listErr, readyErr error) *fakeState {
 
 	// Add a second rig "bad" whose store fails.
 	bad := beads.NewMemStore()
-	_, _ = bad.Create(beads.Bead{Type: "task", Title: "would-be-lost", Status: "active"})
+	_, _ = bad.Create(beads.Bead{Type: "task", Title: "would-be-lost", Status: "open"})
 	wrapped := &failingBeadStore{Store: bad, listErr: listErr, readyErr: readyErr}
 	fs.stores["bad"] = wrapped
 	fs.cfg.Rigs = append(fs.cfg.Rigs, config.Rig{Name: "bad", Path: t.TempDir()})
 
 	// Seed "myrig" with a real bead so the good-rig path has something.
-	_, _ = fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "ok-rig-task", Status: "active"})
+	_, _ = fs.stores["myrig"].Create(beads.Bead{Type: "task", Title: "ok-rig-task", Status: "open"})
 	return fs
 }
 

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -625,7 +625,7 @@ func (s *Server) humaHandleOrdersFeed(_ context.Context, input *OrdersFeedInput)
 	if err != nil {
 		return nil, apierr.Internal.Msg("workflow feed failed")
 	}
-	orderRuns, err := buildOrderRunFeedItems(s.state, scopeKind, scopeRef)
+	orderRuns, err := buildOrderRunFeedItems(s.state, scopeKind, scopeRef, limit)
 	if err != nil {
 		return nil, apierr.Internal.Msg("order feed failed")
 	}

--- a/internal/api/orders_class_store_test.go
+++ b/internal/api/orders_class_store_test.go
@@ -94,7 +94,7 @@ func TestOrderFeedListsTrackingBeadsFromTheOrdersBinding(t *testing.T) {
 
 	tracking := seedOrdersTrackingBead(t, binding, "dolt-health")
 
-	result, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()))
+	result, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()), 0)
 	if err != nil {
 		t.Fatalf("buildOrderRunFeedItems: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestOrderFeedCountsAStoreServingBothClassesOnce(t *testing.T) {
 
 	tracking := seedOrdersTrackingBead(t, city, "dolt-health")
 
-	result, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()))
+	result, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()), 0)
 	if err != nil {
 		t.Fatalf("buildOrderRunFeedItems: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestOrderHistoryStoreRefsAllResolveToTheSameStore(t *testing.T) {
 	_, listRef := orderHistoryListStoreRef(t, h, st, "nightly-review")
 	_, detailBody := orderHistoryDetail(t, h, st, tracking.ID, "")
 
-	feed, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()))
+	feed, err := buildOrderRunFeedItems(st, beadmeta.ScopeKindCity, workflowCityScopeRef(st.CityName()), 0)
 	if err != nil {
 		t.Fatalf("buildOrderRunFeedItems: %v", err)
 	}

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -335,7 +335,7 @@ func listActiveWorkflowProjectionBeads(store beads.Store) ([]beads.Bead, error) 
 	return active, nil
 }
 
-func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef string) (orderRunFeedResult, error) {
+func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef string, limit int) (orderRunFeedResult, error) {
 	// The feed lists order-tracking beads, which are orders class and live in
 	// the orders binding on a split city. workflowStores leads with the GRAPH
 	// binding (its own callers scan workflow roots), so on a city that relocates
@@ -359,7 +359,7 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 			continue
 		}
 		front := orders.NewStore(beads.OrdersStore{Store: info.store})
-		runs, err := front.ListTracking(0)
+		runs, err := front.ListTracking(limit)
 		if err != nil {
 			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
 				requestedScopeErr = err
@@ -372,13 +372,18 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 			continue
 		}
 
+		// Scoped to this store's front: LatestOpenRun is a per-store lookup, so
+		// a cache keyed only by run.Scoped must not be reused across stores.
+		// Runs sharing a scoped name within this store's result (repeat runs of
+		// the same order) cost one backing lookup instead of one per run.
+		latestOpenCache := make(map[string]latestOpenRunLookup, len(runs))
 		for _, run := range runs {
 			scopeKind, scopeRef := orderTrackingScope(run.Scoped, cityScopeRef)
 			if !includeAllForCity && (scopeKind != requestedScopeKind || scopeRef != requestedScopeRef) {
 				continue
 			}
 
-			updatedAt := orderTrackingUpdatedAt(front, run)
+			updatedAt := orderTrackingUpdatedAt(front, run, latestOpenCache)
 			orderDef, ok := orderByScopedName[run.Scoped]
 			title := orderTrackingTitle(run.Scoped, orderDef, ok)
 			target := orderTrackingTarget(orderDef, ok, run)
@@ -413,18 +418,31 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 	}, nil
 }
 
-func orderTrackingUpdatedAt(front *orders.Store, run orders.OrderRun) time.Time {
+// latestOpenRunLookup caches one front.LatestOpenRun result so repeat runs of
+// the same scoped order pay one backing lookup, not one per run.
+type latestOpenRunLookup struct {
+	run   orders.OrderRun
+	found bool
+	err   error
+}
+
+func orderTrackingUpdatedAt(front *orders.Store, run orders.OrderRun, cache map[string]latestOpenRunLookup) time.Time {
 	updatedAt := run.CreatedAt
-	latest, found, err := front.LatestOpenRun(run.Scoped)
-	if err != nil && !found {
-		orderFeedLogf("api: order feed update lookup failed for %s bead %s: %v", run.Scoped, run.ID, err)
+	lookup, cached := cache[run.Scoped]
+	if !cached {
+		latest, found, err := front.LatestOpenRun(run.Scoped)
+		lookup = latestOpenRunLookup{run: latest, found: found, err: err}
+		cache[run.Scoped] = lookup
+	}
+	if lookup.err != nil && !lookup.found {
+		orderFeedLogf("api: order feed update lookup failed for %s bead %s: %v", run.Scoped, run.ID, lookup.err)
 		return updatedAt
 	}
-	if err != nil {
-		orderFeedLogf("api: order feed update lookup partially failed for %s bead %s: %v", run.Scoped, run.ID, err)
+	if lookup.err != nil {
+		orderFeedLogf("api: order feed update lookup partially failed for %s bead %s: %v", run.Scoped, run.ID, lookup.err)
 	}
-	if found && latest.CreatedAt.After(updatedAt) {
-		updatedAt = latest.CreatedAt
+	if lookup.found && lookup.run.CreatedAt.After(updatedAt) {
+		updatedAt = lookup.run.CreatedAt
 	}
 	return updatedAt
 }

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -359,7 +359,7 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 			continue
 		}
 		front := orders.NewStore(beads.OrdersStore{Store: info.store})
-		runs, err := front.ListTracking()
+		runs, err := front.ListTracking(0)
 		if err != nil {
 			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
 				requestedScopeErr = err

--- a/internal/api/orders_feed_test.go
+++ b/internal/api/orders_feed_test.go
@@ -167,7 +167,7 @@ func TestBuildOrderRunFeedItemsUsesAllOrdersForDisabledExecMetadata(t *testing.T
 		t.Fatalf("create tracking bead: %v", err)
 	}
 
-	got, err := buildOrderRunFeedItems(state, "city", "test-city")
+	got, err := buildOrderRunFeedItems(state, "city", "test-city", 0)
 	if err != nil {
 		t.Fatalf("buildOrderRunFeedItems: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestOrderTrackingUpdatedAtLogsLookupFailure(t *testing.T) {
 	}
 	defer func() { orderFeedLogf = origLogf }()
 
-	got := orderTrackingUpdatedAt(front, run)
+	got := orderTrackingUpdatedAt(front, run, make(map[string]latestOpenRunLookup))
 	if !got.Equal(run.CreatedAt) {
 		t.Fatalf("updatedAt = %s, want %s", got, run.CreatedAt)
 	}

--- a/internal/orders/store.go
+++ b/internal/orders/store.go
@@ -420,12 +420,15 @@ func (s *Store) RecentRuns(scoped string, limit int) ([]OrderRun, error) {
 // decoded into OrderRun values. It is the typed face of the /v0/orders/feed read
 // it replaces: it confines the order-tracking List and the tracking-bead decode
 // the feed previously performed inline. Beads with no order-run label (which
-// RunFromTrackingBead rejects) are skipped. The query is byte-identical to the
-// feed's prior raw scan — order-tracking label, created-desc, both tiers, and no
-// IncludeClosed so only in-flight/open tracking beads surface. Decoded rows and
-// any list error are returned together (the RecentRuns pattern) so callers keep
-// the feed's err-branch semantics.
-func (s *Store) ListTracking() ([]OrderRun, error) {
+// RunFromTrackingBead rejects) are skipped. Decoded rows and any list error are
+// returned together (the RecentRuns pattern) so callers keep the feed's
+// err-branch semantics.
+//
+// RED stub (ga-h8q2aj): limit is accepted so callers and tests can compile
+// against the bounded signature, but is not yet pushed to the backing, and the
+// query still omits IncludeClosed -- GREEN wires both into the ListQuery
+// (Limit, IncludeClosed, AllowBackingCreatedLimit), mirroring RecentRuns.
+func (s *Store) ListTracking(_ int) ([]OrderRun, error) {
 	if s.store.Store == nil {
 		return nil, nil
 	}

--- a/internal/orders/store.go
+++ b/internal/orders/store.go
@@ -424,18 +424,23 @@ func (s *Store) RecentRuns(scoped string, limit int) ([]OrderRun, error) {
 // returned together (the RecentRuns pattern) so callers keep the feed's
 // err-branch semantics.
 //
-// RED stub (ga-h8q2aj): limit is accepted so callers and tests can compile
-// against the bounded signature, but is not yet pushed to the backing, and the
-// query still omits IncludeClosed -- GREEN wires both into the ListQuery
-// (Limit, IncludeClosed, AllowBackingCreatedLimit), mirroring RecentRuns.
-func (s *Store) ListTracking(_ int) ([]OrderRun, error) {
+// limit is pushed to the backing (AllowBackingCreatedLimit) rather than
+// applied client-side, matching RecentRuns's ga-klv fix: slicing after an
+// unbounded fetch still pays the full scan cost on a city with a large
+// retained tracking-bead corpus. IncludeClosed is always true -- unlike
+// LatestOpenRun's deliberate open-only narrowing, the feed lists completed
+// runs alongside in-flight ones. A non-positive limit means unlimited.
+func (s *Store) ListTracking(limit int) ([]OrderRun, error) {
 	if s.store.Store == nil {
 		return nil, nil
 	}
 	list, err := s.store.List(beads.ListQuery{
-		Label:    labelOrderTracking,
-		Sort:     beads.SortCreatedDesc,
-		TierMode: beads.TierBoth,
+		Label:                    labelOrderTracking,
+		Limit:                    limit,
+		IncludeClosed:            true,
+		Sort:                     beads.SortCreatedDesc,
+		TierMode:                 beads.TierBoth,
+		AllowBackingCreatedLimit: true,
 	})
 	runs := make([]OrderRun, 0, len(list))
 	for _, b := range list {

--- a/internal/orders/store_reads_bounded_test.go
+++ b/internal/orders/store_reads_bounded_test.go
@@ -77,3 +77,49 @@ func TestRecentRunsUnlimitedStaysUnlimited(t *testing.T) {
 		}
 	}
 }
+
+// TestListTrackingPushesLimitToBacking guards the same class of read cost as
+// TestRecentRunsPushesLimitToBacking: the /v0/orders/feed read must bound the
+// backing scan instead of fetching every retained tracking bead and slicing
+// client-side.
+func TestListTrackingPushesLimitToBacking(t *testing.T) {
+	spy := &listSpyStore{Store: beads.NewMemStore()}
+	store := NewStore(beads.OrdersStore{Store: spy})
+
+	if _, err := store.ListTracking(20); err != nil {
+		t.Fatalf("ListTracking(): %v", err)
+	}
+	if len(spy.queries) == 0 {
+		t.Fatal("ListTracking issued no list query")
+	}
+	for i, q := range spy.queries {
+		if q.Limit != 20 {
+			t.Fatalf("query %d: Limit = %d, want 20 (the caller's bound must be threaded through)", i, q.Limit)
+		}
+		if !q.IncludeClosed {
+			t.Fatalf("query %d: IncludeClosed = false, want true; the feed lists completed runs too", i)
+		}
+		if !q.AllowBackingCreatedLimit {
+			t.Fatalf("query %d: AllowBackingCreatedLimit = false, want true; the bound must reach the backing", i)
+		}
+	}
+}
+
+// TestListTrackingUnlimitedStaysUnlimited keeps the explicit opt-out working,
+// matching RecentRuns's limit<=0-means-unlimited convention.
+func TestListTrackingUnlimitedStaysUnlimited(t *testing.T) {
+	spy := &listSpyStore{Store: beads.NewMemStore()}
+	store := NewStore(beads.OrdersStore{Store: spy})
+
+	if _, err := store.ListTracking(0); err != nil {
+		t.Fatalf("ListTracking(): %v", err)
+	}
+	if len(spy.queries) == 0 {
+		t.Fatal("ListTracking issued no list query")
+	}
+	for i, q := range spy.queries {
+		if q.Limit != 0 {
+			t.Fatalf("query %d: Limit = %d, want 0 (unlimited opt-out)", i, q.Limit)
+		}
+	}
+}

--- a/internal/orders/store_test.go
+++ b/internal/orders/store_test.go
@@ -383,7 +383,7 @@ func TestListTrackingDecodesTrackingBeadsNewestFirst(t *testing.T) {
 	mem := beads.NewMemStoreFrom(3, []beads.Bead{older, newer, unlabeled}, nil)
 	front := NewStore(beads.OrdersStore{Store: mem})
 
-	runs, err := front.ListTracking()
+	runs, err := front.ListTracking(0)
 	if err != nil {
 		t.Fatalf("ListTracking: %v", err)
 	}
@@ -394,9 +394,43 @@ func TestListTrackingDecodesTrackingBeadsNewestFirst(t *testing.T) {
 		t.Fatalf("order = [%s %s], want [rig/b rig/a] (newest first)", runs[0].Scoped, runs[1].Scoped)
 	}
 
-	got, err := NewStore(beads.OrdersStore{}).ListTracking()
+	got, err := NewStore(beads.OrdersStore{}).ListTracking(0)
 	if err != nil || got != nil {
 		t.Fatalf("nil-store ListTracking = (%v, %v), want (nil, nil)", got, err)
+	}
+}
+
+// TestListTrackingIncludesClosedRuns proves the IncludeClosed omission is a
+// bug, not a deliberate narrowing like LatestOpenRun's (pinned above by
+// TestLatestOpenRunIgnoresClosedRuns): the /v0/orders/feed lists completed
+// runs alongside in-flight ones, so a closed tracking bead must still decode
+// and return, newest first alongside open ones.
+func TestListTrackingIncludesClosedRuns(t *testing.T) {
+	now := time.Now()
+	open := beads.Bead{
+		ID:        "gc-1",
+		Status:    "open",
+		CreatedAt: now.Add(-time.Hour),
+		Labels:    []string{"order-tracking", "order-run:rig/a"},
+	}
+	closed := beads.Bead{
+		ID:        "gc-2",
+		Status:    "closed",
+		CreatedAt: now,
+		Labels:    []string{"order-tracking", "order-run:rig/b"},
+	}
+	mem := beads.NewMemStoreFrom(2, []beads.Bead{open, closed}, nil)
+	front := NewStore(beads.OrdersStore{Store: mem})
+
+	runs, err := front.ListTracking(0)
+	if err != nil {
+		t.Fatalf("ListTracking: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("runs = %d, want 2 (closed tracking beads must still surface)", len(runs))
+	}
+	if runs[0].Scoped != "rig/b" || runs[1].Scoped != "rig/a" {
+		t.Fatalf("order = [%s %s], want [rig/b rig/a] (newest first)", runs[0].Scoped, runs[1].Scoped)
 	}
 }
 

--- a/internal/storebinding/storebinding.go
+++ b/internal/storebinding/storebinding.go
@@ -315,7 +315,7 @@ type OrdersStore interface {
 	RunDetail(string) (orders.RunDetail, error)
 	RecentRuns(string, int) ([]orders.OrderRun, error)
 	RecentRunsAll(int) ([]orders.OrderRun, error)
-	ListTracking() ([]orders.OrderRun, error)
+	ListTracking(int) ([]orders.OrderRun, error)
 	LatestOpenRun(string) (orders.OrderRun, bool, error)
 	OpenRuns() ([]orders.OrderRun, error)
 	StaleOpenRuns(time.Time) ([]orders.OrderRun, error)

--- a/release-gates/ga-xe7biz-orders-feed-partial-results-gate.md
+++ b/release-gates/ga-xe7biz-orders-feed-partial-results-gate.md
@@ -1,0 +1,81 @@
+# Release gate: orders-feed and partial-result status correctness
+
+- Deploy bead: `ga-xe7biz`
+- Build bead: `ga-h8q2aj`
+- Review bead: `ga-7wjddi`
+- Reviewed commit: `5f11f2c076c6863df7fc21c75cd030236af3b0da`
+- Base: `origin/main@09bae7ad1706aced67a72775d2b1d11549002cd0`
+- Merge base: `09bae7ad1706aced67a72775d2b1d11549002cd0`
+- Deploy mode: remote
+- Gate verdict: **PASS**
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | **PASS** | `ga-7wjddi` is closed with a PASS verdict pinned to the exact reviewed commit; the independent review records no style, security, or specification finding. |
+| 2 | Acceptance criteria met | **PASS** | Partial-result fixtures now use canonical `open` status; `ListTracking(limit)` includes closed runs while pushing a created-desc limit to the backing store; the feed threads its normalized limit and memoizes `LatestOpenRun` per scoped order and per store. `LatestOpenRun` remains open-only. No wire, event, OpenAPI, or generated-client shape changed. |
+| 3 | Tests pass | **PASS** | Fifteen focused acceptance/regression tests passed. The required 40-job union completed 35 PASS / 5 FAIL / 0 SKIP; every failure is independently attributed below to a pre-run tracker with direct base/mechanism evidence, and no candidate-owned failure remains. Policy, lint, vet, formatting, docs, boundary, native DoltLite, dashboard, TypeScript, and preview-smoke lanes passed. |
+| 4 | No unresolved HIGH findings | **PASS** | The reviewer found no security or HIGH-severity issue. The feed continues using typed `beads.ListQuery` values and keeps the cache inside each store iteration, preventing cross-store result reuse. A repository-wide affected lint completed with 0 issues. |
+| 5 | Final branch clean | **PASS** | `git status --short` was empty after the full union, static gates, dashboard generation/build, and live preview smoke, before this gate record was written. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree origin/main 5f11f2c076c6863df7fc21c75cd030236af3b0da` returned rc 0 and tree `97e157e1b6d2f01c34d68d4823129de27d804efc`. The candidate is a direct two-commit child of current `origin/main`. |
+| 7 | Single feature theme | **PASS** | All nine changed files implement one behavior: stop relying on MemStore's former forced-open status while preserving complete, bounded orders-feed and partial-result behavior. |
+
+## Acceptance evidence
+
+- `internal/api/handler_beads_partial_test.go` uses canonical `Status: "open"` for both seeded rows.
+- `internal/orders/store.go` exposes `ListTracking(limit int)` with `IncludeClosed: true`, caller `Limit`, and `AllowBackingCreatedLimit: true`; its comment distinguishes this from the deliberately open-only `LatestOpenRun` contract.
+- `internal/api/huma_handlers_orders.go` passes the normalized request limit into `buildOrderRunFeedItems` instead of fetching an unbounded corpus and slicing afterward.
+- `internal/api/orders_feed.go` scopes `latestOpenCache` inside each store iteration and keys it by scoped order name, preserving store isolation while eliminating repeated lookups.
+- `internal/storebinding/storebinding.go` updates the typed `OrdersStore` interface consistently.
+- The diff contains no OpenAPI JSON, generated client, dashboard, wire type, route registration, or event-payload change.
+
+## Test evidence
+
+- Focused named acceptance/regression command over `./internal/api/... ./internal/orders/...` — **15 PASS, 0 FAIL, 0 SKIP**.
+- `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GO_TEST_TIMEOUT=30m make test-local-full-parallel` — **35/40 jobs PASS, 5/40 jobs FAIL, 0 tests SKIP**. Logs: `/var/tmp/gc-local-tests.U5aDQ4`.
+- `make test-ci-policy` — PASS.
+- `make check-gomod-replace` — PASS.
+- `make check-eventexport-isolation` — PASS.
+- `make check-core-boundary` — PASS.
+- `make test-native-doltlite-beads` — PASS.
+- `GOLANGCI_LINT_CACHE=<isolated-on-disk-cache> LINT_CHANGED_REF=origin/main make lint-affected` — PASS, 0 issues.
+- `make fmt-check-changed` — PASS.
+- `make check-docs` — PASS.
+- `go vet ./...` — PASS.
+- `make dashboard-ci` — PASS: dashboard build, shared/frontend/test/e2e TypeScript checks, dashboard Go tests, and generated-client projection all completed successfully.
+- Dashboard preview smoke — PASS: the built frontend served valid HTML from `http://127.0.0.1:4175/` before the preview process was stopped.
+- `make check-native-dependency-surface` — raw FAIL: candidate binary 270,246,136 bytes exceeds the 270,000,000-byte ceiling. Exact current base `origin/main@09bae7ad17` measured 270,291,592 bytes, 45,456 bytes larger than the candidate, and the diff adds no dependency. Tracked as `ga-5flk3r`; this occurrence is attributed rather than rewritten green.
+
+`test_cmd_scope`: full-suite.
+
+`diff_tests_executed`:
+
+- `TestListTrackingIncludesClosedRuns` — PASS.
+- `TestLatestOpenRunIgnoresClosedRuns` — PASS.
+- `TestListTrackingPushesLimitToBacking` — PASS.
+- `TestListTrackingUnlimitedStaysUnlimited` — PASS.
+- `TestHandleOrdersFeedIncludesRigStoreTrackingBeads` — PASS.
+- `TestBeadListSurfacesStoreErrorsAsPartial` — PASS.
+- `TestBeadListPreservesPartialResultRows` — PASS.
+- `TestBeadListReturns503OnTotalOutage` — PASS.
+- `TestBeadListReturns503OnEmptyPartialTotalOutage` — PASS.
+- `TestBeadReadyPreservesPartialResultRows` — PASS.
+- `TestBeadReadySurfacesStoreErrorsAsPartial` — PASS.
+- `TestBeadReadyReturns503OnEmptyPartialTotalOutage` — PASS.
+
+`policy_lane`: `make test-ci-policy` — PASS.
+
+`waiver_ref`: none; all raw failures are attributed under criterion 3a, not waived.
+
+`added_test_load`: no. Tests were added to already-covered package targets; the diff adds no suite target and changes no resource-census baseline.
+
+## Full-union failure attribution
+
+- `TestBdFlagManifestCurrent` -> `ga-f0uceo`. The installed-`bd` manifest skew predates this run and is independent of the candidate's API/orders/storebinding paths. The candidate cannot change the installed CLI or `internal/bdflags` manifest.
+- `TestGetKeyBinding_CapturesDefaultBinding` and `TestGetKeyBinding_CapturesDefaultBindingWithArgs` -> `ga-afqddr` / `ga-k3fxvj`. Both exact empty-default-keytable signatures predate the run and arise from host tmux 3.7b behavior. The candidate does not touch or reach `internal/runtime/tmux`.
+- `TestGraphWorkflowSuccessPath` -> `ga-lpfjhc`. It failed during `gc init` with the exact `gastownhall/beads#4566` pending-dirty-schema signature, before any workflow or orders-feed behavior executed. The candidate cannot alter schema migration or fixture store bootstrap.
+- `TestE2E_SuspendResume_City` -> `ga-yc0e3a`. The tracker contains exact-base reproduction of the same missing `citysus.report` timeout. This test exercises city suspend/resume, session kill, and report production; it never invokes the changed orders-feed/ListTracking path.
+
+All five failing tests are outside diff-owned test files, every tracker predates
+this run, and none of the failing execution paths reaches a changed function.
+The candidate adds no test target or declared resource load. Criterion 3
+therefore passes with the raw failures preserved and attributed.


### PR DESCRIPTION
## What this changes

Order-history and order-feed reads now include closed tracking runs when building history, while the latest-open-run lookup remains explicitly open-only. Bounded feed requests push their limits into the backing store, avoiding an unbounded tracking scan before normalization.

The API partial-result fixtures now use the canonical `open` status, so degraded multi-store responses exercise the same status vocabulary as production data.

## Review notes

- `ListTracking(limit)` opts into closed rows and forwards a bounded limit to the store.
- Latest-open-run selection remains open-only and feed caching stays scoped to each store and run.
- No endpoint, OpenAPI, event payload, or dashboard wire shape changes.

## Test plan

- [x] Focused API and orders-store coverage for bounded reads, closed-run history, open-run selection, and partial-result behavior.
- [x] Repository pre-push fast suite.
- [x] Static policy checks, `go vet ./...`, dashboard CI, and local dashboard preview smoke.
- [x] Release gate: [`release-gates/ga-xe7biz-orders-feed-partial-results-gate.md`](release-gates/ga-xe7biz-orders-feed-partial-results-gate.md)