### PR TITLE
fix(graphroute): resolve one-shot lifecycle for rig-scoped route targets

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -17,7 +17,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -1232,9 +1231,8 @@ func graphFallbackBindingForBead(source beads.Bead, store beads.Store, cityName,
 		return graphRouteBinding{}, fmt.Errorf("unknown formulas v2 fallback target %q on %s", routedTo, source.ID)
 	}
 
-	binding := graphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
-	if agentCfg.SupportsInstanceExpansion() {
-		binding.MetadataOnly = true
+	binding := graphroute.GraphRouteBindingForAgent(agentCfg)
+	if binding.MetadataOnly {
 		return binding, nil
 	}
 	if source.Assignee != "" {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1769,6 +1769,117 @@ func TestDecorateDynamicFragmentRecipePreservesPoolFallbackAndScopeMetadata(t *t
 	}
 }
 
+func TestDecorateDynamicFragmentRecipeOneShotPoolFallbackLeavesStepsIndependent(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Daemon:    config.DaemonConfig{FormulaV2: boolPtr(true)},
+		Agents: []config.Agent{
+			{
+				Name:              "worker",
+				Lifecycle:         config.AgentLifecycleOneShot,
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+		},
+	}
+	config.InjectImplicitAgents(cfg)
+	addTestControlDispatcherAgents(cfg, "")
+
+	source := beads.Bead{
+		ID: "gc-source",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: "worker",
+		},
+	}
+	fragment := &formula.FragmentRecipe{
+		Name: "expansion",
+		Steps: []formula.RecipeStep{{
+			ID:    "expansion.work",
+			Title: "Work independently",
+			Metadata: map[string]string{
+				beadmeta.ContinuationGroupMetadataKey: "stale-group",
+				beadmeta.SessionAffinityMetadataKey:   "require",
+			},
+		}},
+	}
+
+	if err := decorateDynamicFragmentRecipe(fragment, source, store, cfg.Workspace.Name, "", cfg); err != nil {
+		t.Fatalf("decorateDynamicFragmentRecipe: %v", err)
+	}
+
+	work := fragment.Steps[0]
+	if got := work.Metadata[beadmeta.RoutedToMetadataKey]; got != "worker" {
+		t.Fatalf("gc.routed_to = %q, want worker", got)
+	}
+	if got := work.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "" {
+		t.Errorf("gc.continuation_group = %q, want unset for one-shot fragment step", got)
+	}
+	if got := work.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "" {
+		t.Errorf("gc.session_affinity = %q, want unset for one-shot fragment step", got)
+	}
+	if work.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty so any fresh pool slot can claim the step", work.Assignee)
+	}
+}
+
+func TestDecorateDynamicFragmentRecipePerStepOneShotPoolTargetLeavesStepIndependent(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Daemon:    config.DaemonConfig{FormulaV2: boolPtr(true)},
+		Agents: []config.Agent{
+			{
+				Name:              "coordinator",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+			{
+				Name:              "worker",
+				Lifecycle:         config.AgentLifecycleOneShot,
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+		},
+	}
+	config.InjectImplicitAgents(cfg)
+	addTestControlDispatcherAgents(cfg, "")
+
+	source := beads.Bead{
+		ID: "gc-source",
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: "coordinator",
+		},
+	}
+	fragment := &formula.FragmentRecipe{
+		Name: "expansion",
+		Steps: []formula.RecipeStep{{
+			ID:    "expansion.work",
+			Title: "Work independently",
+			Metadata: map[string]string{
+				beadmeta.RunTargetMetadataKey:         "worker",
+				beadmeta.ContinuationGroupMetadataKey: "stale-group",
+				beadmeta.SessionAffinityMetadataKey:   "require",
+			},
+		}},
+	}
+
+	if err := decorateDynamicFragmentRecipe(fragment, source, store, cfg.Workspace.Name, "", cfg); err != nil {
+		t.Fatalf("decorateDynamicFragmentRecipe: %v", err)
+	}
+
+	work := fragment.Steps[0]
+	if got := work.Metadata[beadmeta.RoutedToMetadataKey]; got != "worker" {
+		t.Fatalf("gc.routed_to = %q, want worker", got)
+	}
+	if got := work.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "" {
+		t.Errorf("gc.continuation_group = %q, want unset for per-step one-shot fragment route", got)
+	}
+	if got := work.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "" {
+		t.Errorf("gc.session_affinity = %q, want unset for per-step one-shot fragment route", got)
+	}
+}
+
 func TestDecorateDynamicFragmentRecipeControlRouteUsesOwningStoreScope(t *testing.T) {
 	store := beads.NewMemStore()
 	cfg := &config.City{

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1449,9 +1449,8 @@ func resolveGraphStepBindingWithVars(stepID string, stepByID map[string]*formula
 	if !ok {
 		return graphRouteBinding{}, fmt.Errorf("step %s: unknown formulas v2 target %q", stepID, target.value)
 	}
-	binding := graphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
-	if agentCfg.SupportsInstanceExpansion() {
-		binding.MetadataOnly = true
+	binding := graphroute.GraphRouteBindingForAgent(agentCfg)
+	if binding.MetadataOnly {
 		cache[stepID] = binding
 		return binding, nil
 	}

--- a/engdocs/design/agent-pools.md
+++ b/engdocs/design/agent-pools.md
@@ -168,6 +168,27 @@ Gastown's themed name pools ("Toast", "Furiosa") are cosmetic and can
 be added later via the `theme` field in PoolConfig. For now, numeric
 suffixes are simple, predictable, and debuggable.
 
+### Graph workflow continuity
+
+Graph steps routed to a pool remain unassigned until a concrete session
+claims them. The agent lifecycle determines whether the router also requests
+cross-step session continuity:
+
+- The default long-lived lifecycle stamps the automatic
+  `gc.continuation_group=pool-workflow` and `gc.session_affinity=require`
+  pair. Claiming one executable step pre-assigns its workflow siblings to the
+  same persistent session, preserving its worktree and conversation context.
+- `lifecycle = "one_shot"` is an independent-step route. Each executable step
+  stays routed to the configured pool but carries no automatic continuation
+  group or required session affinity, so a fresh session may claim the next
+  ready step after the prior bounded invocation exits.
+
+A formula sent through a one-shot pool must therefore persist every input a
+later step needs in the work artifact or bead graph rather than relying on a
+surviving process or conversation. Explicit graph mechanisms that request a
+shared execution context, such as shared single-lane drains, remain separate
+formula contracts rather than an inference from ordinary pool routing.
+
 ## Upscaling
 
 The simple case. The reconciler evaluates `check`, computes

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -60,6 +60,12 @@ type GraphRouteBinding struct {
 	// metadata for the decision. Empty means the formula did not opt in, and a
 	// re-decorated step's stale group is cleared rather than preserved.
 	ContinuationGroup string
+	// IndependentSteps keeps a metadata-only route claimable by any fresh
+	// pool session instead of pinning the workflow to the first claiming
+	// session, overriding any formula-declared ContinuationGroup. One-shot
+	// agent lifecycles use this because their runtime exits after each
+	// bounded invocation and cannot own cross-step continuation.
+	IndependentSteps bool
 }
 
 type graphStepTarget struct {
@@ -203,12 +209,19 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 		//
 		// The opt-in reads binding.ContinuationGroup (the immutable source),
 		// never the step's own mutable metadata, so a re-decorated step can never
-		// re-affirm a stale group its current binding no longer declares. When the
-		// formula opted in, stamp the group + affinity; otherwise clear the group
-		// and affinity together (the pinned pair, per
-		// beadmeta.SessionAffinityMetadataKeys) so no stale group survives to
-		// mis-vacuum later pool claims.
-		if group := strings.TrimSpace(binding.ContinuationGroup); group != "" {
+		// re-affirm a stale group its current binding no longer declares. A
+		// one-shot agent's IndependentSteps overrides any declared group: its
+		// runtime exits after each bounded invocation and cannot own cross-step
+		// continuation, so it is never eligible for pinning regardless of what
+		// the formula asked for. Otherwise, when the formula opted in, stamp the
+		// group + affinity; when neither applies, clear the group and affinity
+		// together (the pinned pair, per beadmeta.SessionAffinityMetadataKeys) so
+		// no stale group survives to mis-vacuum later pool claims.
+		group := ""
+		if !binding.IndependentSteps {
+			group = strings.TrimSpace(binding.ContinuationGroup)
+		}
+		if group != "" {
 			step.Metadata[beadmeta.ContinuationGroupMetadataKey] = group
 			step.Metadata[beadmeta.SessionAffinityMetadataKey] = "require"
 		} else {
@@ -226,6 +239,19 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 		step.Metadata[beadmeta.SessionNameMetadataKey] = binding.SessionName
 	}
 	step.Assignee = binding.SessionName
+}
+
+// GraphRouteBindingForAgent derives the config-backed routing behavior for an
+// agent. Pool routes stay metadata-only; one-shot pools additionally make each
+// graph step an independent claim because no runtime survives to carry session
+// affinity into the next step.
+func GraphRouteBindingForAgent(agentCfg config.Agent) GraphRouteBinding {
+	binding := GraphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
+	if agentCfg.SupportsInstanceExpansion() {
+		binding.MetadataOnly = true
+		binding.IndependentSteps = agentCfg.Lifecycle == config.AgentLifecycleOneShot
+	}
+	return binding
 }
 
 // ApplyGraphControlRouteBinding routes control steps to the store-scoped
@@ -453,9 +479,8 @@ func ResolveGraphStepBindingWithVars(stepID string, stepByID map[string]*formula
 	if !ok {
 		return GraphRouteBinding{}, fmt.Errorf("step %s: unknown formulas v2 target %q", stepID, target.value)
 	}
-	binding := GraphRouteBinding{QualifiedName: agentutil.RoutedToIdentity(&agentCfg)}
-	if agentCfg.SupportsInstanceExpansion() {
-		binding.MetadataOnly = true
+	binding := GraphRouteBindingForAgent(agentCfg)
+	if binding.MetadataOnly {
 		cache[stepID] = binding
 		return binding, nil
 	}
@@ -661,29 +686,38 @@ func ApplyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string,
 	// Resolve agent if not provided (order dispatch path).
 	if a == nil {
 		rigContext := GraphRouteRigContext(routedTo)
-		baseName := routedTo
-		if i := strings.LastIndex(routedTo, "/"); i >= 0 {
-			baseName = routedTo[i+1:]
-		}
 		if deps.Resolver == nil {
 			return nil
 		}
-		resolved, ok := deps.Resolver.ResolveAgent(cfg, baseName, rigContext)
+		// Pass the full qualified routedTo (not a rig-prefix-stripped bare
+		// name) as the resolver's name argument. Stripping the rig prefix
+		// here and relying on the resolver to reconstruct it from rigContext
+		// alone loses information for resolvers that match only on the
+		// qualified identity, causing rig-scoped one-shot targets to fail
+		// resolution and fall through the `!ok` early-return below without
+		// ever stamping gc.routed_to or clearing stale session-affinity
+		// metadata. Passing routedTo preserves existing behavior for bare
+		// (unscoped) names, since routedTo == baseName in that case.
+		resolved, ok := deps.Resolver.ResolveAgent(cfg, routedTo, rigContext)
 		if !ok {
 			return nil
 		}
 		a = &resolved
 	}
 
-	var sessionName string
-	if !a.SupportsInstanceExpansion() {
-		sessionName = agentutil.LookupSessionName(store, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-		if sessionName == "" {
+	defaultRoute := GraphRouteBindingForAgent(*a)
+	// routedTo is the caller's already-normalized persisted identity. Preserve
+	// it rather than recomputing in case the caller resolved a compatibility
+	// spelling that agentutil intentionally keeps stable on the wire.
+	defaultRoute.QualifiedName = routedTo
+	if !defaultRoute.MetadataOnly {
+		defaultRoute.SessionName = agentutil.LookupSessionName(store, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
+		if defaultRoute.SessionName == "" {
 			return fmt.Errorf("could not resolve session name for %q", a.QualifiedName())
 		}
 	}
 	routeVars := GraphWorkflowRouteVars(recipe, vars)
-	return DecorateGraphWorkflowRecipe(recipe, routeVars, sourceBeadID, scopeKind, scopeRef, storeRef, routedTo, sessionName, store, cityName, cfg, deps)
+	return DecorateGraphWorkflowRecipeWithDefaultBinding(recipe, routeVars, sourceBeadID, scopeKind, scopeRef, storeRef, defaultRoute, store, cityName, cfg, deps)
 }
 
 // stampLegacyRecipeRouting mirrors the graph.v2 path in ApplyGraphRouteBinding:

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -1247,6 +1247,116 @@ func TestDecorateGraphWorkflowRecipe_PoolContinuationGroupOptIn(t *testing.T) {
 	}
 }
 
+func TestApplyGraphRouting_OneShotPoolLeavesExecutableStepsIndependent(t *testing.T) {
+	zero := 0
+	two := 2
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "worker",
+				Lifecycle:         config.AgentLifecycleOneShot,
+				MinActiveSessions: &zero,
+				MaxActiveSessions: &two,
+			},
+			{Name: "control-dispatcher"},
+		},
+	}
+	recipe := &formula.Recipe{
+		Name: "demo",
+		Steps: []formula.RecipeStep{
+			{
+				ID:     "demo.root",
+				IsRoot: true,
+				Metadata: map[string]string{
+					beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+					beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+				},
+			},
+			{
+				ID:    "demo.work",
+				Title: "Work independently",
+				Metadata: map[string]string{
+					beadmeta.ContinuationGroupMetadataKey: "stale-group",
+					beadmeta.SessionAffinityMetadataKey:   "require",
+				},
+			},
+		},
+	}
+
+	if err := ApplyGraphRouting(recipe, &cfg.Agents[0], "worker", nil, "", "", "", "", beads.NewMemStore(), cfg.Workspace.Name, cfg, Deps{Resolver: testAgentResolver{}}); err != nil {
+		t.Fatalf("ApplyGraphRouting: %v", err)
+	}
+
+	work := recipe.Steps[1]
+	if got := work.Metadata[beadmeta.RoutedToMetadataKey]; got != "worker" {
+		t.Fatalf("gc.routed_to = %q, want worker", got)
+	}
+	if got := work.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "" {
+		t.Errorf("gc.continuation_group = %q, want unset for independent one-shot step", got)
+	}
+	if got := work.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "" {
+		t.Errorf("gc.session_affinity = %q, want unset for independent one-shot step", got)
+	}
+	if work.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty so any fresh pool slot can claim the step", work.Assignee)
+	}
+}
+
+func TestDecorateGraphWorkflowRecipe_PerStepOneShotPoolTargetLeavesStepIndependent(t *testing.T) {
+	zero := 0
+	two := 2
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "worker",
+				Lifecycle:         config.AgentLifecycleOneShot,
+				MinActiveSessions: &zero,
+				MaxActiveSessions: &two,
+			},
+			{Name: "control-dispatcher"},
+		},
+	}
+	recipe := &formula.Recipe{
+		Name: "demo",
+		Steps: []formula.RecipeStep{
+			{
+				ID:     "demo.root",
+				IsRoot: true,
+				Metadata: map[string]string{
+					beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+					beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+				},
+			},
+			{
+				ID:    "demo.work",
+				Title: "Work independently",
+				Metadata: map[string]string{
+					beadmeta.RunTargetMetadataKey:         "worker",
+					beadmeta.ContinuationGroupMetadataKey: "stale-group",
+					beadmeta.SessionAffinityMetadataKey:   "require",
+				},
+			},
+		},
+	}
+
+	if err := DecorateGraphWorkflowRecipeWithDefaultBinding(recipe, nil, "", "", "", "", GraphRouteBinding{}, beads.NewMemStore(), cfg.Workspace.Name, cfg, Deps{Resolver: testAgentResolver{}}); err != nil {
+		t.Fatalf("DecorateGraphWorkflowRecipeWithDefaultBinding: %v", err)
+	}
+
+	work := recipe.Steps[1]
+	if got := work.Metadata[beadmeta.RoutedToMetadataKey]; got != "worker" {
+		t.Fatalf("gc.routed_to = %q, want worker", got)
+	}
+	if got := work.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "" {
+		t.Errorf("gc.continuation_group = %q, want unset for per-step one-shot route", got)
+	}
+	if got := work.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "" {
+		t.Errorf("gc.session_affinity = %q, want unset for per-step one-shot route", got)
+	}
+}
+
 func TestApplyGraphRouteBinding_SingleSession_NoAffinityKeys(t *testing.T) {
 	step := &formula.RecipeStep{
 		Metadata: map[string]string{},

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -1357,6 +1357,95 @@ func TestDecorateGraphWorkflowRecipe_PerStepOneShotPoolTargetLeavesStepIndepende
 	}
 }
 
+// qualifiedOnlyAgentResolver models a resolver that only matches an agent
+// by its full qualified identity (dir/name), never by bare Name alone. It
+// ignores the rigContext argument entirely, unlike testAgentResolver which
+// matches on bare Name regardless of rig. This isolates the order-dispatch
+// a == nil branch's bare-name stripping in ApplyGraphRouting: that branch
+// calls deps.Resolver.ResolveAgent(cfg, baseName, rigContext) with baseName
+// already stripped of its rig prefix, so a resolver that requires the
+// qualified string to appear in the name argument itself (rather than being
+// reconstructed from name+rigContext) cannot find the agent.
+type qualifiedOnlyAgentResolver struct{}
+
+func (qualifiedOnlyAgentResolver) ResolveAgent(cfg *config.City, name, _ string) (config.Agent, bool) {
+	for _, a := range cfg.Agents {
+		if a.QualifiedName() == name {
+			return a, true
+		}
+	}
+	return config.Agent{}, false
+}
+
+func TestApplyGraphRouting_OrderDispatchNilAgent_RigScopedOneShot_IndependentSteps(t *testing.T) {
+	zero := 0
+	two := 2
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "rig1"}},
+		Agents: []config.Agent{
+			{
+				Name:              "oneshot",
+				Dir:               "rig1",
+				Lifecycle:         config.AgentLifecycleOneShot,
+				MinActiveSessions: &zero,
+				MaxActiveSessions: &two,
+			},
+			{Name: "control-dispatcher"},
+			{Name: "control-dispatcher", Dir: "rig1"},
+		},
+	}
+	newRecipe := func() *formula.Recipe {
+		return &formula.Recipe{
+			Name: "demo",
+			Steps: []formula.RecipeStep{
+				{
+					ID:     "demo.root",
+					IsRoot: true,
+					Metadata: map[string]string{
+						beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+						beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+					},
+				},
+				{
+					ID:    "demo.work",
+					Title: "Work independently",
+					Metadata: map[string]string{
+						beadmeta.ContinuationGroupMetadataKey: "stale-group",
+						beadmeta.SessionAffinityMetadataKey:   "require",
+					},
+				},
+			},
+		}
+	}
+	assertIndependent := func(t *testing.T, recipe *formula.Recipe) {
+		t.Helper()
+		work := recipe.Steps[1]
+		if got := work.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "" {
+			t.Errorf("gc.continuation_group = %q, want unset for independent rig-scoped one-shot step", got)
+		}
+		if got := work.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "" {
+			t.Errorf("gc.session_affinity = %q, want unset for independent rig-scoped one-shot step", got)
+		}
+	}
+
+	t.Run("testAgentResolver (matches bare name too)", func(t *testing.T) {
+		recipe := newRecipe()
+		if err := ApplyGraphRouting(recipe, nil, "rig1/oneshot", nil, "", "", "", "", beads.NewMemStore(), cfg.Workspace.Name, cfg, Deps{Resolver: testAgentResolver{}}); err != nil {
+			t.Fatalf("ApplyGraphRouting: %v", err)
+		}
+		assertIndependent(t, recipe)
+	})
+
+	t.Run("qualifiedOnlyAgentResolver (rig-scoped only)", func(t *testing.T) {
+		recipe := newRecipe()
+		if err := ApplyGraphRouting(recipe, nil, "rig1/oneshot", nil, "", "", "", "", beads.NewMemStore(), cfg.Workspace.Name, cfg, Deps{Resolver: qualifiedOnlyAgentResolver{}}); err != nil {
+			t.Fatalf("ApplyGraphRouting: %v", err)
+		}
+		assertIndependent(t, recipe)
+	})
+}
+
 func TestApplyGraphRouteBinding_SingleSession_NoAffinityKeys(t *testing.T) {
 	step := &formula.RecipeStep{
 		Metadata: map[string]string{},


### PR DESCRIPTION
# fix(graphroute): resolve one-shot lifecycle for rig-scoped route targets

Fixes #5585

**Note:** GitHub does not allow a PR opened via a fork to use another fork branch as its base unless that branch also exists in the base repo. This PR is opened with base `main` instead of stacking directly on #5584 as originally planned; it genuinely depends on #5584 (fix/one-shot-pool-independent-steps) and its diff will include that PR's commit until #5584 merges. Please review/merge #5584 first.


Base: `fix/one-shot-pool-independent-steps` (`e356ea793`) — **stacked PR**
Branch: `fix/scoped-one-shot-lifecycle`
Commit: `9ac41cad15bd7ff095f7371cd1cb862d8301b0c0`

## Summary

Follow-up to `e356ea793`, which taught `ApplyGraphRouting` to skip
continuation-group/session-affinity stamping for `one_shot` pools. That fix
only takes effect if the agent resolves with the right `Lifecycle` in the
first place. In the order-dispatch (`a == nil`) branch, `ApplyGraphRouting`
stripped the rig prefix off `routedTo` into a bare `baseName` before calling
`deps.Resolver.ResolveAgent(cfg, baseName, rigContext)`, relying on the
resolver to reconstruct the rig-scoped identity from `baseName` +
`rigContext` alone. A resolver matching only on the fully qualified agent
identity fails to resolve rig-scoped `one_shot` targets like
`rig1/oneshot`, so the step falls through the `!ok` early return: no
`gc.routed_to` stamp, and stale `gc.session_affinity=require` /
continuation-group metadata is left in place, parking the step on an
exited one-shot session. Observed in production on
`fable-nomad/claude-sonnet-one-shot` and `…/claude-opus-one-shot`.

## Fix

- Pass the full qualified `routedTo` to `deps.Resolver.ResolveAgent`
  instead of the rig-prefix-stripped `baseName`.
- Bare (unscoped) targets are unaffected: `routedTo == baseName` in that
  case, so behavior is unchanged.
- No change to `e356ea793`'s `IndependentSteps` stamping logic itself —
  this only fixes resolution so that logic actually sees the right
  `Lifecycle`.

## Test plan

`internal/graphroute` — new:
- `TestApplyGraphRouting_OrderDispatchNilAgent_RigScopedOneShot_IndependentSteps`
  - subtest `testAgentResolver (matches bare name too)`: passes pre-fix too
    (double-matches on bare `Name` regardless of rig; doesn't expose the
    bug).
  - subtest `qualifiedOnlyAgentResolver (rig-scoped only)`: RED pre-fix
    (resolver matches only `QualifiedName()`), GREEN post-fix. This is the
    case that isolates the bug.

`go test ./internal/graphroute/...` passes, including all `e356ea793` /
`71de83f27` tests (e.g.
`TestApplyGraphRouting_OneShotPoolLeavesExecutableStepsIndependent`,
`TestDecorateGraphWorkflowRecipe_PerStepOneShotPoolTargetLeavesStepIndependent`).
`go vet ./internal/graphroute` clean. `go build ./cmd/gc` clean.

## Compatibility

Bare (unscoped) targets and persistent pools: unchanged — this PR only
touches how the agent is *resolved*, not the stamping decision itself.

## Stack

Targets `fix/one-shot-pool-independent-steps` (`e356ea793`), not main —
merge order matters since this fix only matters given that PR's gating.
