### PR TITLE
fix(dispatch): class-binding candidates are authoritative for rig-rooted control rows

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4736,9 +4736,29 @@ func normalizeDemandStoreRef(storeRef string) string {
 // through the city candidate and rig-owned rows only through their named rig.
 // Legacy rows without a canonical ref remain visible through every independent
 // store so same-ID beads in genuinely separate stores are not collapsed.
+//
+// A class-binding candidate is a special case of "authoritative", not an
+// exception to it. The duplicate-view risk this filter exists for is legacy
+// unscoped file-store mode, where two DIFFERENT store handles alias the same
+// physical file; a relocated class binding is never that — it is a distinct
+// physical store `gc storage migrate` moves rows INTO, and `gc storage status`
+// proves it converged. So a row the binding physically serves is never also
+// visible through a second candidate to defer to, city- or rig-logical alike:
+// on the runtime plane Narrow (internal/storeref/relevance.go) drops every
+// leg but the binding once a plan touches one, so it is the only leg that will
+// ever offer the row; on the reconcile plane the binding still holds the row
+// no legacy rig/city store does post-migration. Gating it on rootRig the way a
+// legacy-store candidate is gated would silently drop every rig-logical row a
+// migration relocated into the binding — the row is real, open, routed, and
+// permanently invisible to demand and route repair. e7e7427 already mapped the
+// binding's OWN ref onto city scope for this same reason; this closes the
+// matching gap for rows the binding serves under a still-rig-logical root.
 func rootStoreRefMatchesCandidate(rootStoreRef, candidateStoreRef string) bool {
 	rootRig, rootScoped := storeref.ScopeRigContext(rootStoreRef)
 	if !rootScoped {
+		return true
+	}
+	if storeref.IsClassRef(candidateStoreRef) {
 		return true
 	}
 	candidateRig, candidateScoped := storeref.ScopeRigContext(candidateStoreRef)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5185,15 +5185,19 @@ func configuredControlDispatcherRouteForScope(cfg *config.City, rigContext strin
 
 func controlDispatcherRigContextForStoreRef(storeRef string) string {
 	storeRef = strings.TrimSpace(storeRef)
-	if storeRef == "" || storeRef == "city" || strings.HasPrefix(storeRef, "city:") {
+	if storeRef == "" || storeRef == "city" {
 		return ""
 	}
+	if rigContext, ok := storeref.ScopeRigContext(storeRef); ok {
+		return rigContext
+	}
+	// Keep accepting the pre-canonical bare rig label used by older census
+	// snapshots while canonical refs are interpreted by storeref above.
 	return strings.TrimPrefix(storeRef, "rig:")
 }
 
 func controlDispatcherStoreRefLabel(storeRef string) string {
-	storeRef = strings.TrimSpace(storeRef)
-	if storeRef == "" || storeRef == "city" || strings.HasPrefix(storeRef, "city:") {
+	if controlDispatcherRigContextForStoreRef(storeRef) == "" {
 		return "the city store"
 	}
 	return fmt.Sprintf("rig store %q", controlDispatcherRigContextForStoreRef(storeRef))

--- a/cmd/gc/build_desired_state_gmnos_test.go
+++ b/cmd/gc/build_desired_state_gmnos_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestControlDispatcherRigContextForStoreRefUsesCanonicalScope(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "legacy city", ref: "", want: ""},
+		{name: "city alias", ref: "city", want: ""},
+		{name: "city", ref: "city:test-city", want: ""},
+		{name: "relocated class", ref: "class:gmnos", want: ""},
+		{name: "rig", ref: "rig:fixture", want: "fixture"},
+		{name: "legacy bare rig", ref: "fixture", want: "fixture"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := controlDispatcherRigContextForStoreRef(tc.ref); got != tc.want {
+				t.Fatalf("controlDispatcherRigContextForStoreRef(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildDesiredStateClassControlWorkWakesExactlyOneCityDispatcher(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	classStore := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, classStore)
+
+	control, err := classStore.Create(beads.Bead{
+		Title:  "Finalize graph workflow",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindWorkflowFinalize,
+			beadmeta.RoutedToMetadataKey:     "core.control-dispatcher",
+			beadmeta.RootStoreRefMetadataKey: "class:gmnos",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create class control: %v", err)
+	}
+
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              config.ControlDispatcherAgentName,
+			BindingName:       "core",
+			StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: &maxActive,
+		}},
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), cityStore,
+		nil, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	stored, err := classStore.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get class control: %v", err)
+	}
+	if got := stored.Metadata[beadmeta.RoutedToMetadataKey]; got != "core.control-dispatcher" {
+		t.Fatalf("class control route = %q, want canonical city route preserved", got)
+	}
+	if got := result.ScaleCheckCounts["core.control-dispatcher"]; got != 1 {
+		t.Fatalf("city dispatcher demand = %d, want exactly one", got)
+	}
+	if got := result.ScaleCheckCounts["fixture/core.control-dispatcher"]; got != 0 {
+		t.Fatalf("rig dispatcher demand = %d, want zero for class-resident control work", got)
+	}
+	if len(result.State) != 1 {
+		t.Fatalf("desired state = %v, want exactly one ephemeral city dispatcher", mapKeys(result.State))
+	}
+	for _, desired := range result.State {
+		if desired.TemplateName != "core.control-dispatcher" {
+			t.Fatalf("desired dispatcher template = %q, want core.control-dispatcher", desired.TemplateName)
+		}
+	}
+}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -12303,6 +12303,87 @@ func TestBuildDesiredState_RepairsRigRoutedCityControlWork(t *testing.T) {
 	}
 }
 
+// TestBuildDesiredState_RepairsClassBoundRigRoutedControlWork covers the
+// converged graph->infra-class binding topology `gc storage status` proves
+// live: a P0 retry control bead physically resides in the graph-class binding
+// (relocated there by `gc storage migrate`), but still carries its
+// pre-migration LOGICAL gc.root_store_ref ("rig:fixture") and a stale rig
+// route. On the runtime plane, storeref.Narrow drops every leg but the class
+// binding once the plan touches one (internal/storeref/relevance.go), so the
+// binding candidate is the ONLY leg that can ever see this row — there is no
+// separate "rig:fixture" leg behind it to catch what the binding candidate
+// declines. rootStoreRefMatchesCandidate must therefore treat the class
+// candidate as authoritative for a rig-rooted row it physically serves, or the
+// row is dropped from collectOpenUnassignedRoutedWork entirely: never repaired
+// by repairControlDispatcherRoutesForStoreScope and never counted by
+// openControlDispatcherDemand (e7e7427 already maps class bindings to CITY
+// control scope; this closes the gap that mapping left for rig-logical rows).
+func TestBuildDesiredState_RepairsClassBoundRigRoutedControlWork(t *testing.T) {
+	cityPath := t.TempDir()
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return work })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+
+	control, err := binding.Create(beads.Bead{
+		Title:  "Transcribe order retry",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindWorkflowFinalize,
+			beadmeta.RoutedToMetadataKey:     "fixture/core.control-dispatcher",
+			beadmeta.RootStoreRefMetadataKey: "rig:fixture",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+
+	rigStore := beads.NewMemStore()
+	maxActive := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "fixture", Path: t.TempDir()}},
+		Agents: []config.Agent{
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &maxActive,
+			},
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				Dir:               "fixture",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MaxActiveSessions: &maxActive,
+			},
+		},
+	}
+
+	// binding is handed as the leading (sessions-class) store, exactly what
+	// buildDesiredState hands the census on a converged split (D6).
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), binding,
+		map[string]beads.Store{"fixture": rigStore}, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	stored, err := binding.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get control: %v", err)
+	}
+	if got := stored.Metadata[beadmeta.RoutedToMetadataKey]; got != "core.control-dispatcher" {
+		t.Fatalf("stored gc.routed_to = %q, want repaired city route core.control-dispatcher", got)
+	}
+	if got := result.ScaleCheckCounts["core.control-dispatcher"]; got != 1 {
+		t.Fatalf("city dispatcher demand = %d, want 1", got)
+	}
+	if got := result.ScaleCheckCounts["fixture/core.control-dispatcher"]; got != 0 {
+		t.Fatalf("rig dispatcher demand = %d, want 0 for a class-bound control row", got)
+	}
+}
+
 func TestBuildDesiredState_DoesNotWakeRigDispatcherWhenCityRouteRepairFails(t *testing.T) {
 	cityPath := t.TempDir()
 	cityBase := beads.NewMemStore()

--- a/cmd/gc/census_residency_test.go
+++ b/cmd/gc/census_residency_test.go
@@ -173,10 +173,22 @@ func TestBindingRefNormalizesOntoTheCityScope(t *testing.T) {
 	if !rootStoreRefMatchesCandidate("city:test-city", ref) {
 		t.Error("a city-scope root_store_ref no longer matches the binding candidate; every binding-resident routed row just left the demand scan")
 	}
-	// Control: a RIG-scoped root must still not match the binding, or the
-	// normalization has flattened the scope comparison into a tautology.
-	if rootStoreRefMatchesCandidate("rig:alpha", ref) {
-		t.Error("a rig-scoped root_store_ref matched the binding candidate")
+	// A class binding is a genuinely distinct physical store, not a duplicate
+	// view of a rig or city work store — `gc storage migrate` relocates rows
+	// INTO it, it never aliases a rig's own file. So it is authoritative for a
+	// RIG-scoped root too: on the runtime plane it is the only leg Narrow
+	// leaves once a plan touches a binding (no rig leg survives to defer to),
+	// and on the reconcile plane the binding still holds the row no rig store
+	// does post-migration. Rejecting it here is exactly the duplicate-view
+	// rejection this filter is FOR — the binding is never a duplicate view.
+	if !rootStoreRefMatchesCandidate("rig:alpha", ref) {
+		t.Error("a rig-scoped root_store_ref did not match the binding candidate; a migrated rig-rooted control row would be permanently invisible to demand and route repair")
+	}
+	// Control: two independent LEGACY (non-class) candidates still gate on
+	// rig identity, or the class-binding carve-out has flattened the whole
+	// comparison into a tautology.
+	if rootStoreRefMatchesCandidate("rig:alpha", "rig:bravo") {
+		t.Error("a rig-scoped root_store_ref matched an unrelated rig candidate")
 	}
 }
 


### PR DESCRIPTION
# fix(dispatch): class-binding candidates are authoritative for rig-rooted control rows

Fixes #5587

**Note:** `56a8e8ff4` depends on `controlDispatcherRigContextForStoreRef` already resolving class refs to city scope, which was introduced by an earlier unedited commit, `e7e7427a5` ("fix(dispatch): resolve class store refs as city control scope"), that had not yet reached `origin/main`. This branch/PR therefore includes both commits, unedited, so the new regression test in `56a8e8ff4` actually passes against current main. Confirmed RED without `e7e7427a5` (repaired route stayed `fixture/core.control-dispatcher` instead of `core.control-dispatcher`) and GREEN with both commits.


Base: `main`
Commit: `56a8e8ff4789d8a9c2e11177edfff6e78a25c628`

## Summary

`collectOpenUnassignedRoutedWork`'s duplicate-view filter,
`rootStoreRefMatchesCandidate`, rejected a `class:*` candidate for any row
whose `gc.root_store_ref` was rig-scoped. On the runtime plane a plan that
touches a binding narrows to the binding as its ONLY leg
(`storeref.Narrow`), so a rig-logical control row a migration relocated
into the binding had no other leg to be read through and was silently
dropped before route repair or demand ever saw it — city dispatcher trace
`pending=false` forever, dependent workflow steps never ready.

## Fix

- `rootStoreRefMatchesCandidate` now treats any `storeref.IsClassRef`
  candidate as authoritative for a scoped `rootStoreRef`, regardless of rig
  identity. A class binding is a distinct physical store (`gc storage
  migrate` relocates rows *into* it), never a duplicate view of a rig/city
  file store, so the legacy-unscoped collapsing risk this filter guards
  against does not apply to it. No rig names in the fix — the carve-out is
  purely `IsClassRef`.
- `e7e7427a5` already made `controlDispatcherRigContextForStoreRef` treat a
  `class:*` candidate ref as city scope for repair's own routing decision;
  this closes the matching gap one level upstream, in the read that decides
  whether the row is collected at all.

## Test plan

`cmd/gc` — new:
- `TestBuildDesiredState_RepairsClassBoundRigRoutedControlWork`: RED
  pre-fix (route never touched — row dropped in collection, not repair),
  GREEN post-fix. End-to-end through repair and demand.
- `TestBindingRefNormalizesOntoTheCityScope`
  (`census_residency_test.go`): pinned control assertion
  `rootStoreRefMatchesCandidate("rig:alpha", classRef)` flipped from
  `false` to `true` (the exact case this bug reports); new control case
  `rig:alpha` vs `rig:bravo` (both non-class) proves the rig-identity gate
  still applies between two ordinary legacy candidates.

`go test ./cmd/gc/... ./internal/storeref/...`, `go vet ./cmd/gc/...
./internal/storeref/...`, `go build ./cmd/gc` all clean. Full-package
`./cmd/gc/...` run confirmed pre-existing unrelated failures only
(`TestClassifyProductMetrics*`, nil-map panic, reproduced identically on
unmodified base — not introduced by this change).

## Compatibility

Only two callers of `rootStoreRefMatchesCandidate` exist total (the
production site plus its own unit test); downstream consumers of
`collectOpenUnassignedRoutedWork`'s output already handle a `class:*`-scoped
storeRef correctly and are untouched.

## Stack

Independent of `fix/one-shot-pool-independent-steps` (`e356ea793`) and
`fix/scoped-one-shot-lifecycle` (`9ac41cad1`) — different subsystem, no
overlapping files, observed in the same estate. Targets `main` directly.
