### PR TITLE
perf(events): seek past the cursor instead of rescanning the active log

### DIFF
--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -100,6 +100,87 @@ func ReadAll(path string) ([]Event, error) {
 	return ReadFiltered(path, Filter{})
 }
 
+// seqProbeBufSize bounds the read-ahead used when probing a byte offset for the
+// line that begins there. Events average ~1.4 KB on a live log; 64 KB
+// comfortably spans one line plus the partial line a probe may land inside.
+const seqProbeBufSize = 64 * 1024
+
+// seqLineAt probes byte offset off and returns the seq of the next parseable
+// line, along with that line's start offset.
+//
+// Contract, which the binary search in activeScanStart depends on: for off > 0
+// the line containing off is treated as a partial line and DISCARDED, so the
+// result is the first parseable line beginning strictly after off. Only off == 0
+// reads the line starting at off itself. Probing a known line start therefore
+// returns the FOLLOWING line, not the line at that offset.
+//
+// start is always a true line boundary. Unparseable lines are skipped, matching
+// the scanner's long-standing tolerance for malformed rows. ok is false when EOF
+// is reached without finding a parseable line.
+func seqLineAt(f *os.File, off int64) (seq uint64, start int64, ok bool) {
+	if _, err := f.Seek(off, io.SeekStart); err != nil {
+		return 0, 0, false
+	}
+	r := bufio.NewReaderSize(f, seqProbeBufSize)
+	pos := off
+	if off > 0 {
+		partial, err := r.ReadBytes('\n')
+		if err != nil {
+			return 0, 0, false
+		}
+		pos += int64(len(partial))
+	}
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			var probe struct {
+				Seq uint64 `json:"seq"`
+			}
+			if json.Unmarshal(bytes.TrimRight(line, "\r\n"), &probe) == nil && probe.Seq > 0 {
+				return probe.Seq, pos, true
+			}
+			pos += int64(len(line))
+		}
+		if err != nil {
+			return 0, 0, false
+		}
+	}
+}
+
+// activeScanStart returns the byte offset in the active log at which a scan can
+// begin without missing any event Filter.AfterSeq can match.
+//
+// The active log is append-only with strictly increasing seq (FileRecorder
+// assigns e.Seq = r.seq++ under its mutex), so every line at or below the
+// cursor sorts before every line above it and can be skipped wholesale. This is
+// the seq-window skip archiveOverlapsFilter already applies to .gz archives,
+// extended to the active file. Without it a cursored read re-parses the entire
+// log on every call and AfterSeq saves nothing, because matchesFilter applies
+// it only after each line has been unmarshalled -- the dominant cost of the
+// supervisor's per-tick order-trigger check (gcy-ocb5).
+//
+// Returns 0 (full scan) whenever the boundary cannot be established, so a log
+// that violates the ordering invariant degrades in speed, never in correctness.
+func activeScanStart(f *os.File, size int64, afterSeq uint64) int64 {
+	if afterSeq == 0 || size <= 0 {
+		return 0
+	}
+	// Nothing to skip when the log's first line is already above the cursor.
+	if first, _, ok := seqLineAt(f, 0); !ok || first > afterSeq {
+		return 0
+	}
+	i := sort.Search(int(size), func(i int) bool {
+		seq, _, ok := seqLineAt(f, int64(i))
+		return !ok || seq > afterSeq
+	})
+	seq, start, ok := seqLineAt(f, int64(i))
+	if !ok || seq <= afterSeq {
+		// Cursor is at or beyond the newest event: skip the file entirely.
+		return size
+	}
+	return start
+}
+
 // ReadFiltered reads events from path and sibling archives, returning
 // only those matching all non-zero fields in filter. Archives whose
 // seq window is fully excluded by the filter's AfterSeq predicate are
@@ -166,6 +247,17 @@ func readFilteredTracked(path string, filter Filter) ([]Event, map[eventSeqWindo
 		return result, listed, fmt.Errorf("reading events: %w", err)
 	}
 	defer f.Close() //nolint:errcheck // read-only file
+
+	// Skip the prefix of the active log the cursor already covers. seqLineAt
+	// leaves the descriptor wherever its last probe ended, so seek explicitly
+	// even when the scan starts at 0 (the uncursored case).
+	scanFrom := int64(0)
+	if st, statErr := f.Stat(); statErr == nil {
+		scanFrom = activeScanStart(f, st.Size(), filter.AfterSeq)
+	}
+	if _, err := f.Seek(scanFrom, io.SeekStart); err != nil {
+		return result, listed, fmt.Errorf("seeking events: %w", err)
+	}
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // handle lines up to 1MB

--- a/internal/events/reader_afterseq_seek_test.go
+++ b/internal/events/reader_afterseq_seek_test.go
@@ -1,0 +1,169 @@
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSeqLog writes a monotonic append-only log of n events and returns its path.
+// Every other event is type "b" so filters have something to discriminate on.
+func writeSeqLog(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		typ := "a"
+		if i%2 == 0 {
+			typ = "b"
+		}
+		fmt.Fprintf(&sb, `{"seq":%d,"type":%q,"ts":"2026-08-25T00:00:00Z","actor":"t","subject":"s%d"}`+"\n", i, typ, i)
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+// TestActiveScanStart pins the seq->offset boundary search on the active log.
+// The append-only log has strictly increasing seq, so every line at or below
+// AfterSeq can be skipped wholesale; activeScanStart must land exactly on the
+// first line above the cursor and never before it (which would be slow) or
+// after it (which would silently drop events).
+func TestActiveScanStart(t *testing.T) {
+	const n = 500
+	path := writeSeqLog(t, n)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	size := st.Size()
+
+	// AfterSeq=0 means "no cursor": start at byte 0.
+	if got := activeScanStart(f, size, 0); got != 0 {
+		t.Fatalf("activeScanStart(afterSeq=0) = %d, want 0", got)
+	}
+	// A cursor below the first seq cannot skip anything.
+	if got := activeScanStart(f, size, 0); got != 0 {
+		t.Fatalf("activeScanStart(below first) = %d, want 0", got)
+	}
+	// A cursor at or beyond the last seq skips the whole file.
+	if got := activeScanStart(f, size, n); got != size {
+		t.Fatalf("activeScanStart(afterSeq=%d) = %d, want size %d", n, got, size)
+	}
+	if got := activeScanStart(f, size, n+1000); got != size {
+		t.Fatalf("activeScanStart(beyond last) = %d, want size %d", n+1000, size)
+	}
+	// Interior cursors must land exactly on the start of the first line whose
+	// seq exceeds the cursor. Read the line AT the offset directly: seqLineAt
+	// treats a nonzero offset as mid-line and would report the following line.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	for _, cursor := range []uint64{1, 2, 7, 128, 499} {
+		off := activeScanStart(f, size, cursor)
+		if off <= 0 || off >= size {
+			t.Fatalf("cursor=%d: offset %d out of range (size %d)", cursor, off, size)
+		}
+		if off > 0 && raw[off-1] != '\n' {
+			t.Fatalf("cursor=%d: offset %d is not a line start", cursor, off)
+		}
+		line, _, _ := bytes.Cut(raw[off:], []byte("\n"))
+		var probe struct {
+			Seq uint64 `json:"seq"`
+		}
+		if err := json.Unmarshal(line, &probe); err != nil {
+			t.Fatalf("cursor=%d: line at %d not parseable: %v", cursor, off, err)
+		}
+		if probe.Seq != cursor+1 {
+			t.Fatalf("cursor=%d: line at offset %d has seq %d, want %d", cursor, off, probe.Seq, cursor+1)
+		}
+	}
+}
+
+// TestReadFilteredAfterSeqEquivalence is the safety net for the optimization:
+// for every cursor, the seek path must return exactly what a full scan returns.
+func TestReadFilteredAfterSeqEquivalence(t *testing.T) {
+	const n = 300
+	path := writeSeqLog(t, n)
+
+	all, err := ReadFiltered(path, Filter{})
+	if err != nil {
+		t.Fatalf("ReadFiltered(all): %v", err)
+	}
+	if len(all) != n {
+		t.Fatalf("baseline read %d events, want %d", len(all), n)
+	}
+
+	for cursor := uint64(0); cursor <= n+1; cursor++ {
+		for _, typ := range []string{"", "a", "b"} {
+			got, err := ReadFiltered(path, Filter{AfterSeq: cursor, Type: typ})
+			if err != nil {
+				t.Fatalf("cursor=%d type=%q: %v", cursor, typ, err)
+			}
+			var want []Event
+			for _, e := range all {
+				if e.Seq > cursor && (typ == "" || e.Type == typ) {
+					want = append(want, e)
+				}
+			}
+			if len(got) != len(want) {
+				t.Fatalf("cursor=%d type=%q: got %d events, want %d", cursor, typ, len(got), len(want))
+			}
+			for i := range got {
+				if got[i].Seq != want[i].Seq {
+					t.Fatalf("cursor=%d type=%q: event %d seq=%d, want %d", cursor, typ, i, got[i].Seq, want[i].Seq)
+				}
+			}
+		}
+	}
+}
+
+// TestReadFilteredAfterSeqMalformedLines pins that the seek path degrades to a
+// correct result when the log contains unparseable lines, which the scanner has
+// always tolerated by skipping.
+func TestReadFilteredAfterSeqMalformedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	body := `{"seq":1,"type":"a"}
+not json at all
+{"seq":2,"type":"a"}
+{"seq":3,"type":"a"}
+{truncated
+{"seq":4,"type":"a"}
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for cursor, wantSeqs := range map[uint64][]uint64{
+		0: {1, 2, 3, 4},
+		1: {2, 3, 4},
+		2: {3, 4},
+		3: {4},
+		4: nil,
+	} {
+		got, err := ReadFiltered(path, Filter{AfterSeq: cursor})
+		if err != nil {
+			t.Fatalf("cursor=%d: %v", cursor, err)
+		}
+		if len(got) != len(wantSeqs) {
+			t.Fatalf("cursor=%d: got %d events, want %d", cursor, len(got), len(wantSeqs))
+		}
+		for i, s := range wantSeqs {
+			if got[i].Seq != s {
+				t.Fatalf("cursor=%d: event %d seq=%d, want %d", cursor, i, got[i].Seq, s)
+			}
+		}
+	}
+}

--- a/internal/events/reader_afterseq_seek_test.go
+++ b/internal/events/reader_afterseq_seek_test.go
@@ -10,19 +10,29 @@ import (
 	"testing"
 )
 
-// writeSeqLog writes a monotonic append-only log of n events and returns its path.
-// Every other event is type "b" so filters have something to discriminate on.
+// writeSeqLog writes a monotonic append-only log of n events, seq 1..n, and
+// returns its path. Every other event is type "b" so filters have something to
+// discriminate on.
 func writeSeqLog(t *testing.T, n int) string {
+	t.Helper()
+	return writeSeqLogFrom(t, 1, n)
+}
+
+// writeSeqLogFrom writes n events whose seq starts at first. A log whose lowest
+// seq sits well above zero models the ordinary post-rotation active file, which
+// a stale cursor can point below.
+func writeSeqLogFrom(t *testing.T, first uint64, n int) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
 	var sb strings.Builder
-	for i := 1; i <= n; i++ {
+	for i := 0; i < n; i++ {
+		seq := first + uint64(i)
 		typ := "a"
-		if i%2 == 0 {
+		if seq%2 == 0 {
 			typ = "b"
 		}
-		fmt.Fprintf(&sb, `{"seq":%d,"type":%q,"ts":"2026-08-25T00:00:00Z","actor":"t","subject":"s%d"}`+"\n", i, typ, i)
+		fmt.Fprintf(&sb, `{"seq":%d,"type":%q,"ts":"2026-08-25T00:00:00Z","actor":"t","subject":"s%d"}`+"\n", seq, typ, seq)
 	}
 	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
 		t.Fatalf("write log: %v", err)
@@ -42,7 +52,7 @@ func TestActiveScanStart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck // read-only file
 	st, err := f.Stat()
 	if err != nil {
 		t.Fatalf("stat: %v", err)
@@ -53,9 +63,20 @@ func TestActiveScanStart(t *testing.T) {
 	if got := activeScanStart(f, size, 0); got != 0 {
 		t.Fatalf("activeScanStart(afterSeq=0) = %d, want 0", got)
 	}
-	// A cursor below the first seq cannot skip anything.
-	if got := activeScanStart(f, size, 0); got != 0 {
-		t.Fatalf("activeScanStart(below first) = %d, want 0", got)
+	// A cursor below the log's first seq cannot skip anything: after a rotation
+	// the active file starts high and a stale cursor sits below every line in it.
+	rotated := writeSeqLogFrom(t, 5000, 100)
+	f2, err := os.Open(rotated)
+	if err != nil {
+		t.Fatalf("open rotated: %v", err)
+	}
+	defer f2.Close() //nolint:errcheck // read-only file
+	st2, err := f2.Stat()
+	if err != nil {
+		t.Fatalf("stat rotated: %v", err)
+	}
+	if got := activeScanStart(f2, st2.Size(), 100); got != 0 {
+		t.Fatalf("activeScanStart(below first seq) = %d, want 0", got)
 	}
 	// A cursor at or beyond the last seq skips the whole file.
 	if got := activeScanStart(f, size, n); got != size {


### PR DESCRIPTION
## Summary

`readFilteredTracked` reads the **active** `events.jsonl` from byte 0 and `json.Unmarshal`s every line, then discards non-matching events in `matchesFilter`. Because `AfterSeq` is applied only *after* the unmarshal, a cursored read does no less work than an uncursored one — it re-parses the entire log on every call.

The supervisor pays this on every patrol tick. `dispatchOrders` → `memoryOrderDispatcher.dispatch` → `CheckTriggerWithOptions` → `checkEvent` calls `List{Type: "bead.closed", AfterSeq: cursor}` to serve a single event-triggered order. A live 30s CPU profile of the supervisor attributed **53% of all process CPU** to this one read path (`syscall.read` 35.9%, `bufio.Scanner.Scan` 34.5%, `json.Unmarshal` 18.6%) against a 121 MB / 87,831-line log.

Because the log grows monotonically, so does per-tick cost. This presents as supervisor CPU that climbs over *days* with no change in workload.

## Root cause

`internal/events/reader.go`, the active-file branch of `readFilteredTracked`:

```go
scanner := bufio.NewScanner(f)
for scanner.Scan() {
    var e Event
    if err := json.Unmarshal(scanner.Bytes(), &e); err != nil { continue }
    if !matchesFilter(e, filter) { continue }   // <- AfterSeq applied HERE, after the decode
```

The `.gz` archive branch immediately above it already has a seq-window skip — `archiveOverlapsFilter` prunes an archive whose `LastSeq <= AfterSeq` without gunzipping it. **The active file simply never got the same treatment.** This PR restores that symmetry rather than introducing a new mechanism.

## Fix

`activeScanStart` binary-searches the byte offset of the first line whose `seq > AfterSeq` and starts the scan there (~27 probes on a 121 MB log). `seqLineAt` probes an offset and returns the seq of the next parseable line plus that line's true start offset; for `off > 0` it discards the partial line it landed inside, which is the contract the search depends on.

Soundness: the active log is append-only with strictly increasing seq — `FileRecorder` assigns `e.Seq = r.seq++` under its mutex — so every line at or below the cursor sorts before every line above it and can be skipped wholesale.

Correctness is preserved by construction, three ways:
- the offset is only ever used as a *scan start*; `matchesFilter` still runs on every line actually read, so the result set is unchanged;
- if the boundary cannot be established (unparseable head, seek error, ordering invariant violated) `activeScanStart` returns 0 and degrades to the previous full scan — a log that breaks the invariant loses speed, never correctness;
- add-only. No existing line is deleted or modified apart from the one `f.Seek` that positions the scanner.

No persistent or shared state is deleted or mutated; this changes only where a read starts.

## Tests

`internal/events/reader_afterseq_seek_test.go` (new):
- `TestActiveScanStart` — boundary cases: zero cursor, cursor below the first seq, cursor at and beyond the last seq, and interior cursors landing *exactly* on the first qualifying line start.
- `TestReadFilteredAfterSeqEquivalence` — asserts the seek path returns results identical to a full scan for **every** cursor `0..n+1` across three filters. This is the load-bearing test: the fix is a pure optimization, so the property that matters is that it changes nothing observable.
- `TestReadFilteredAfterSeqMalformedLines` — the scanner's long-standing tolerance for malformed rows survives probing.

`go test ./internal/events/` and `go vet ./internal/events/` pass on this branch, rebased onto `main` at 3e686dace. On unpatched `main` the test file does not build (`undefined: activeScanStart`) — worth stating plainly: because this is a performance fix with identical semantics, no *correctness* test can fail on `main`. The behavioural evidence is the measurements below.

## Validation

Measured against a real 121 MB / 87,831-line production log, **match counts identical** in every case:

| cursor position | before | after | |
|---|---|---|---|
| 50 events behind head (steady state) | 1565.7 ms | 1.9 ms | **842x** |
| 5000 events behind (catch-up) | 1118.3 ms | 142.2 ms | 7.9x |

Deployed to a live city, before → after:

| | before | after |
|---|---|---|
| dispatch duration, mean | 3953 ms | 1345 ms (−66%) |
| dispatch duration, p90 | 6973 ms | 1983 ms (−72%) |
| dispatch duration, max | 15675 ms | 2396 ms (−85%) |
| supervisor steady state | ~52.4% of a core | ~8–10% of a core |

A live CPU profile after the change shows `dispatchOrders` down 76%, with `ReadFiltered` / `CheckTriggerWithOptions` / `json.Unmarshal` **absent from the profile** rather than merely reduced. A 2.68 h post-deploy watch showed no regrowth, with dispatch *rate* and *duration* both flat — i.e. the win is not an artifact of the city going quiet.

## Related

- **#5445** (open) fixes the mirror-image defect one branch over: `streamArchive` takes the `Filter` as `_`, so a cursor landing *inside* an archive's seq window decodes the whole archive. That is the archive branch; this is the active branch. The two are complementary and, as far as I can see, do not conflict — together they close the `AfterSeq` path end to end. Happy to rebase on top of it if you would rather land them in order.
- **#5191** (open) reports the same read path from the zero-cursor angle. This PR does not address that: `AfterSeq == 0` means "no cursor", `activeScanStart` returns 0, and the full scan is correct and unchanged. The semantics question that issue raises about what a zero cursor *should* mean for `checkEvent` is untouched here.
- **#4418 / #4856** bounded the same shape for `gc status` via `Filter.MaxScanBytes`. That bound is a *cap*; this is a *seek* — it can skip the prefix exactly because the cursor makes it provably irrelevant, so no events are dropped.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2604 — reduces one component of the order-dispatch phase that issue measures — the per-tick full rescan of the active events log in the event-trigger check, with dispatch duration on a live city going from ~3.9s mean to ~1.3s — but does not change the synchronous-on-tick-path dispatch design, the fork-per-operation bd store, or the per-rig order fan-out identified there as root causes

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->