### PR TITLE
fix(pool): reuse a freeable-asleep one_shot session instead of blocking its own name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatch, so shell variables containing multiple IDs no longer look like one
   already-handled message.
 
+- **A `lifecycle=one_shot` pool session that exits normally no longer blocks
+  its own runtime name forever.** The session's bounded-work exit lands its
+  bead in `state=asleep` via the generic heal path, same as any other dead
+  session, but `reusablePoolSessionInfo` excluded every asleep session from
+  reuse on the assumption that "the reconciler closes orphaned asleep
+  beads" — no such closing exists. The bead stayed open holding the
+  identity's `session_name`, and the next tick's fresh create failed closed
+  on that same name ("pool session name unavailable ... session name
+  already exists") until an operator ran `gc session close` by hand. The
+  asleep exclusion is now scoped: a `one_shot` session whose sleep reason is
+  already in the freeable allow-list (idle, idle-timeout, city-stop,
+  failed-create, runtime-missing, provider-terminal-error) is reused
+  through the ordinary wake path instead. Persistent (non-`one_shot`) pools
+  are unaffected — a genuine crash still gets a fresh identity.
+
 - **`gc import add` of a local in-git pack now locks to HEAD, not the repo's
   latest tag.** Per `gc import add --help`, a local path inside a git
   worktree is documented to be "locked to the current commit," but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,19 +131,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatch, so shell variables containing multiple IDs no longer look like one
   already-handled message.
 
-- **A `lifecycle=one_shot` pool session that exits normally no longer blocks
-  its own runtime name forever.** The session's bounded-work exit lands its
-  bead in `state=asleep` via the generic heal path, same as any other dead
-  session, but `reusablePoolSessionInfo` excluded every asleep session from
-  reuse on the assumption that "the reconciler closes orphaned asleep
-  beads" — no such closing exists. The bead stayed open holding the
-  identity's `session_name`, and the next tick's fresh create failed closed
-  on that same name ("pool session name unavailable ... session name
-  already exists") until an operator ran `gc session close` by hand. The
-  asleep exclusion is now scoped: a `one_shot` session whose sleep reason is
-  already in the freeable allow-list (idle, idle-timeout, city-stop,
-  failed-create, runtime-missing, provider-terminal-error) is reused
-  through the ordinary wake path instead. Persistent (non-`one_shot`) pools
+- **A `lifecycle=one_shot` pool session that exits into a freeable sleep
+  reason no longer blocks its own runtime name forever.** The session's
+  bounded-work exit lands its bead in `state=asleep` via the generic heal
+  path, same as any other dead session, but `reusablePoolSessionInfo`
+  excluded every asleep session from reuse on the assumption that "the
+  reconciler closes orphaned asleep beads" — no such closing exists. The
+  bead stayed open holding the identity's `session_name`, and the next
+  tick's fresh create failed closed on that same name ("pool session name
+  unavailable ... session name already exists") until an operator ran
+  `gc session close` by hand. The asleep exclusion is now scoped: a
+  `one_shot` session whose sleep reason is already in the freeable
+  allow-list (idle, idle-timeout, city-stop, failed-create, runtime-missing,
+  provider-terminal-error, max-session-age) is reused through the ordinary
+  wake path instead. A `one_shot` exit that still holds an open or
+  in-progress assigned work bead under any of its identities is not treated
+  as a clean exit — it falls through to fresh-identity creation rather than
+  being reused, so the unfinished step is claimed properly instead of being
+  pinned `in_progress` on a dead name. Persistent (non-`one_shot`) pools
   are unaffected — a genuine crash still gets a fresh identity.
 
 - **`gc import add` of a local in-git pack now locks to HEAD, not the repo's

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4910,6 +4910,41 @@ func sessionBeadHasAssignedWorkInfo(workBeads []beads.Bead, info session.Info) b
 	return false
 }
 
+// sessionBeadHasAssignedWorkByAnyIdentityInfo is the broader sibling of
+// sessionBeadHasAssignedWorkInfo: it matches an open/in-progress work bead's
+// Assignee against every current identity of the session (ID,
+// SessionNameMetadata, ConfiguredNamedIdentity, Alias, AliasHistory — see
+// session.AssigneeIdentities), not just the narrower ID/SessionNameMetadata/
+// ConfiguredNamedIdentity trio sessionBeadHasAssignedWorkInfo pins. Work
+// claimed by an agent is commonly assigned under its actor alias (GC_ALIAS /
+// BEADS_ACTOR, see session.AssigneeIdentifier), which the narrower check
+// does not consider, so it can miss live assigned work entirely.
+//
+// It exists as a separate function (not a change to the pinned
+// sessionBeadHasAssignedWorkInfo) so its wider match is opt-in for callers
+// that need it — currently only the one_shot asleep-freeable wake-reuse
+// guard in reusablePoolSessionInfo, where under-detecting assigned work lets
+// the ordinary wake path "reuse" an identity that still holds an unfinished
+// step, orphaning it a tick later with the step pinned in_progress forever.
+func sessionBeadHasAssignedWorkByAnyIdentityInfo(workBeads []beads.Bead, info session.Info) bool {
+	identities := make(map[string]bool, 5)
+	for _, id := range sessionBeadAssigneeIdentitiesInfo(info) {
+		if id = strings.TrimSpace(id); id != "" {
+			identities[id] = true
+		}
+	}
+	for _, wb := range workBeads {
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
+			continue
+		}
+		if identities[assignee] {
+			return true
+		}
+	}
+	return false
+}
+
 // poolRequestResumesAssignedWorkInfo proves that a concrete resume request is
 // still backed by its exact actionable work bead and that the bead is assigned
 // through any current or historical identity of the preferred session.

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -4381,9 +4381,12 @@ func selectOrPlanPoolSessionBead(
 		info, err := normalizeNonExpandingPoolSessionInfoForSelection(bp, cfgAgent, canonical)
 		return info, slot, nil, err
 	}
-	// Reuse an existing active/creating session bead. Skip drained, closed,
-	// and asleep — asleep ephemerals are not restarted; a fresh session is
-	// created instead. The reconciler closes orphaned asleep beads.
+	// Reuse an existing active/creating session bead. Skip drained and
+	// closed. Asleep is skipped too, with one carve-out: a
+	// lifecycle=one_shot session whose sleep reason is freeable and which
+	// holds no assigned work is reused through the wake path — see
+	// reusablePoolSessionInfo. Nothing in the reconciler closes orphaned
+	// asleep beads; an earlier version of this comment claimed it did.
 	for _, candidate := range reusablePoolSessionInfosForRequest(bp, cfgAgent, template, request, decisionTime, used) {
 		if desiredName := strings.TrimSpace(candidate.SessionNameMetadata); desiredName != "" {
 			slot := claimDesiredPoolSlotInfo(bp.city, cfgAgent, candidate, usedSlots)

--- a/cmd/gc/build_desired_state_pool_info.go
+++ b/cmd/gc/build_desired_state_pool_info.go
@@ -225,6 +225,21 @@ func reusablePoolSessionInfo(bp *agentBuildParams, cfgAgent *config.Agent, templ
 		if cfgAgent.Lifecycle != config.AgentLifecycleOneShot || !isPoolSessionSlotFreeableInfo(info) {
 			return false
 		}
+		// A one_shot exit that still holds an open/in-progress assigned work
+		// bead under any of its identities is not a clean exit: the bounded
+		// unit of work never finished, so waking/reusing it here hands the
+		// step no real execution turn — the reused session drains and lands
+		// orphaned ~45-55s later, and the step stays pinned in_progress on
+		// the dead name with retry control never re-attempting it. Fall
+		// through to fresh-identity creation instead (the pre-6f1ee854b
+		// behavior for this case), which claims the step properly. Uses the
+		// wider by-any-identity match (including actor alias) because
+		// claimed work is commonly assigned under GC_ALIAS/BEADS_ACTOR, not
+		// necessarily the raw SessionNameMetadata the narrower
+		// sessionBeadHasAssignedWorkInfo check below matches.
+		if sessionBeadHasAssignedWorkByAnyIdentityInfo(bp.assignedWorkBeads, info) {
+			return false
+		}
 	}
 	if isManualSessionInfoForAgent(info, cfgAgent) {
 		return false

--- a/cmd/gc/build_desired_state_pool_info.go
+++ b/cmd/gc/build_desired_state_pool_info.go
@@ -209,7 +209,22 @@ func reusablePoolSessionInfo(bp *agentBuildParams, cfgAgent *config.Agent, templ
 		return false
 	}
 	if info.MetadataState == "asleep" {
-		return false
+		// A one_shot pool's own exit is expected completion, not a crash to
+		// avoid resuming: nothing closes its bead (the reconciler does not
+		// actually implement the "closes orphaned asleep beads" behavior this
+		// file's callers assume), so blanket-excluding every asleep session
+		// leaves it open forever holding the identity's runtime session_name
+		// — the next tick's fresh create then fails closed on that same name
+		// (derivePoolSessionName -> errPoolSessionNameUnavailable) until an
+		// operator manually closes it. A freeable-asleep (idle/idle-timeout/
+		// etc — see isPoolSessionSlotFreeableInfo) one_shot exit carries no
+		// deliberate hold, so it is reused instead: the ordinary wake path
+		// retires the exit and remints the identity in place. Persistent
+		// pools keep today's behavior (a genuine crash gets a fresh identity
+		// rather than resuming a possibly-corrupt conversation).
+		if cfgAgent.Lifecycle != config.AgentLifecycleOneShot || !isPoolSessionSlotFreeableInfo(info) {
+			return false
+		}
 	}
 	if isManualSessionInfoForAgent(info, cfgAgent) {
 		return false

--- a/cmd/gc/build_desired_state_pool_info.go
+++ b/cmd/gc/build_desired_state_pool_info.go
@@ -217,11 +217,13 @@ func reusablePoolSessionInfo(bp *agentBuildParams, cfgAgent *config.Agent, templ
 		// — the next tick's fresh create then fails closed on that same name
 		// (derivePoolSessionName -> errPoolSessionNameUnavailable) until an
 		// operator manually closes it. A freeable-asleep (idle/idle-timeout/
-		// etc — see isPoolSessionSlotFreeableInfo) one_shot exit carries no
-		// deliberate hold, so it is reused instead: the ordinary wake path
-		// retires the exit and remints the identity in place. Persistent
-		// pools keep today's behavior (a genuine crash gets a fresh identity
-		// rather than resuming a possibly-corrupt conversation).
+		// city-stop/failed-create/runtime-missing/provider-terminal-error/
+		// max-session-age — see isPoolSessionSlotFreeableInfo) one_shot exit
+		// carries no deliberate hold, so it is reused instead: the ordinary
+		// wake path retires the exit and remints the identity in place.
+		// Persistent pools keep today's behavior (a genuine crash gets a
+		// fresh identity rather than resuming a possibly-corrupt
+		// conversation).
 		if cfgAgent.Lifecycle != config.AgentLifecycleOneShot || !isPoolSessionSlotFreeableInfo(info) {
 			return false
 		}

--- a/cmd/gc/session_reconciler_pool_replacement_test.go
+++ b/cmd/gc/session_reconciler_pool_replacement_test.go
@@ -351,6 +351,62 @@ func TestReusablePoolSessionInfo_OneShotAsleepFreeableIsReusable(t *testing.T) {
 	}
 }
 
+// TestReusablePoolSessionInfo_OneShotAsleepFreeableWithOpenAssignedWorkNotReusable
+// is the regression guard for the wake-reuse-orphans-work outage: a one_shot
+// pool session lands asleep with a freeable reason (idle, ...) per the
+// carve-out above, but the identity still has an open/in-progress assigned
+// work bead attached from before the exit (the step never finished). The
+// ordinary wake path (reusablePoolSessionInfo -> true) "reuses" the identity
+// without giving the step a real execution turn: the reconciler logs
+// `session lifecycle: op=start ... outcome=success`, then the reused session
+// drains and lands `orphaned` ~45-55s later with no work done, and the step
+// stays in_progress pinned to the now-dead name — retry control never
+// re-attempts it because the step still looks claimed.
+//
+// A one_shot exit that still holds assigned work is not a clean exit: it must
+// fall through to fresh-identity creation (the pre-6f1ee854b behavior for
+// this case) instead of being reused. This mirrors the assigned-work
+// visibility the caller already provides via bp.assignedWorkBeads (the same
+// slice sessionBeadHasAssignedWorkInfo checks a few lines below the asleep
+// carve-out), not a bypass around it.
+func TestReusablePoolSessionInfo_OneShotAsleepFreeableWithOpenAssignedWorkNotReusable(t *testing.T) {
+	t.Parallel()
+
+	cfgAgent := &config.Agent{Name: "claude-sonnet-one-shot", Dir: "fable-nomad", Lifecycle: config.AgentLifecycleOneShot}
+	template := "fable-nomad/claude-sonnet-one-shot"
+
+	asleepFreeableWithWork := session.Info{
+		ID:                  "session-asleep-freeable-with-work",
+		Template:            template,
+		SessionNameMetadata: "fable-nomad--claude-sonnet-one-shot-2-pool",
+		Alias:               "fable-nomad/claude-sonnet-one-shot-2",
+		PoolManaged:         true,
+		PoolSlot:            "2",
+		MetadataState:       "asleep",
+		SleepReason:         "idle",
+	}
+
+	bp := &agentBuildParams{
+		assignedWorkBeads: []beads.Bead{
+			{
+				// Claimed work is assigned under the session's actor identity
+				// (Alias — GC_ALIAS/BEADS_ACTOR, per session.AssigneeIdentifier),
+				// not necessarily the raw runtime SessionNameMetadata.
+				ID:       "work-in-progress",
+				Status:   "in_progress",
+				Assignee: asleepFreeableWithWork.Alias,
+			},
+		},
+	}
+
+	if got := reusablePoolSessionInfo(bp, cfgAgent, template, asleepFreeableWithWork, nil); got {
+		t.Fatalf("reusablePoolSessionInfo(one_shot, asleep, sleep_reason=idle, open assigned work) = true; "+
+			"want false — an asleep one_shot exit that still holds in-progress assigned work must fall "+
+			"through to fresh-identity creation, not be wake-reused (session %s)",
+			asleepFreeableWithWork.ID)
+	}
+}
+
 func createRoutedReadyBeadForReplacement(t *testing.T, store beads.Store, template, title string) beads.Bead {
 	t.Helper()
 	b, err := store.Create(beads.Bead{

--- a/cmd/gc/session_reconciler_pool_replacement_test.go
+++ b/cmd/gc/session_reconciler_pool_replacement_test.go
@@ -289,6 +289,68 @@ func TestReusablePoolSessionInfo_DrainAckStopPendingNotReusable(t *testing.T) {
 	}
 }
 
+// TestReusablePoolSessionInfo_OneShotAsleepFreeableIsReusable is the
+// regression guard for the recurring one-shot pool-name-holder outage
+// (EDGE-RECEIPT-asleep-holder): a one_shot pool session that finishes its
+// bounded unit of work exits, and the generic heal path lands it in
+// state=asleep with a freeable reason (idle, idle-timeout, ...) — not a
+// crash, not a deliberate hold. Nothing in the reconciler closes that bead
+// (the "reconciler closes orphaned asleep beads" comment on the caller is
+// aspirational, not implemented), so it sits open forever holding the
+// identity's runtime session_name. Because this function excluded EVERY
+// asleep session from reuse, selectOrPlanPoolSessionBead fell through to a
+// fresh create, which collided with the very name this bead still holds:
+// derivePoolSessionName -> errPoolSessionNameUnavailable, and buildDesiredState
+// refuses to mint ("pool session name unavailable ... session name already
+// exists") on every tick until an operator runs `gc session close` by hand.
+//
+// A one_shot pool's own freeable-asleep exit must be reusable so the ordinary
+// wake path (the same one that already handles this fine for other pool
+// states, per the "Woke session" / outcome=success log lines) retires the
+// exit and remints the identity — matching the reuse this function already
+// grants a closed/swept slot with the pool markers intact.
+func TestReusablePoolSessionInfo_OneShotAsleepFreeableIsReusable(t *testing.T) {
+	t.Parallel()
+
+	bp := &agentBuildParams{}
+	cfgAgent := &config.Agent{Name: "claude-sonnet-one-shot", Dir: "fable-nomad", Lifecycle: config.AgentLifecycleOneShot}
+	template := "fable-nomad/claude-sonnet-one-shot"
+
+	asleepFreeable := session.Info{
+		ID:                  "session-asleep-freeable",
+		Template:            template,
+		SessionNameMetadata: "fable-nomad--claude-sonnet-one-shot-1-pool",
+		PoolManaged:         true,
+		PoolSlot:            "1",
+		MetadataState:       "asleep",
+		SleepReason:         "idle",
+	}
+	if got := reusablePoolSessionInfo(bp, cfgAgent, template, asleepFreeable, nil); !got {
+		t.Fatalf("reusablePoolSessionInfo(one_shot, asleep, sleep_reason=idle) = false; "+
+			"want true — a freeable-asleep one_shot exit must be reusable or it blocks its own "+
+			"identity name forever (session %s)", asleepFreeable.ID)
+	}
+
+	// Control: a deliberately held asleep one_shot session (e.g. quarantine)
+	// must stay excluded — freeable-only, not asleep-blanket.
+	asleepHeld := asleepFreeable
+	asleepHeld.ID = "session-asleep-quarantine"
+	asleepHeld.SleepReason = "quarantine"
+	if got := reusablePoolSessionInfo(bp, cfgAgent, template, asleepHeld, nil); got {
+		t.Fatalf("reusablePoolSessionInfo(one_shot, asleep, sleep_reason=quarantine) = true; "+
+			"want false — a deliberately held sleep must still block reuse")
+	}
+
+	// Control: a persistent (non-one_shot) pool keeps today's behavior — an
+	// asleep session is never reused, even when freeable, so a genuine crash
+	// gets a fresh identity instead of resuming a possibly-corrupt conversation.
+	persistentAgent := &config.Agent{Name: "claude-sonnet-one-shot", Dir: "fable-nomad"}
+	if got := reusablePoolSessionInfo(bp, persistentAgent, template, asleepFreeable, nil); got {
+		t.Fatalf("reusablePoolSessionInfo(persistent, asleep, sleep_reason=idle) = true; "+
+			"want false — the freeable-asleep reuse carve-out is scoped to lifecycle=one_shot")
+	}
+}
+
 func createRoutedReadyBeadForReplacement(t *testing.T, store beads.Store, template, title string) beads.Bead {
 	t.Helper()
 	b, err := store.Create(beads.Bead{

--- a/cmd/gc/session_reconciler_pool_replacement_test.go
+++ b/cmd/gc/session_reconciler_pool_replacement_test.go
@@ -337,7 +337,7 @@ func TestReusablePoolSessionInfo_OneShotAsleepFreeableIsReusable(t *testing.T) {
 	asleepHeld.ID = "session-asleep-quarantine"
 	asleepHeld.SleepReason = "quarantine"
 	if got := reusablePoolSessionInfo(bp, cfgAgent, template, asleepHeld, nil); got {
-		t.Fatalf("reusablePoolSessionInfo(one_shot, asleep, sleep_reason=quarantine) = true; "+
+		t.Fatalf("reusablePoolSessionInfo(one_shot, asleep, sleep_reason=quarantine) = true; " +
 			"want false — a deliberately held sleep must still block reuse")
 	}
 
@@ -346,7 +346,7 @@ func TestReusablePoolSessionInfo_OneShotAsleepFreeableIsReusable(t *testing.T) {
 	// gets a fresh identity instead of resuming a possibly-corrupt conversation.
 	persistentAgent := &config.Agent{Name: "claude-sonnet-one-shot", Dir: "fable-nomad"}
 	if got := reusablePoolSessionInfo(bp, persistentAgent, template, asleepFreeable, nil); got {
-		t.Fatalf("reusablePoolSessionInfo(persistent, asleep, sleep_reason=idle) = true; "+
+		t.Fatalf("reusablePoolSessionInfo(persistent, asleep, sleep_reason=idle) = true; " +
 			"want false — the freeable-asleep reuse carve-out is scoped to lifecycle=one_shot")
 	}
 }


### PR DESCRIPTION
## Summary

A `lifecycle=one_shot` pool session's normal exit (bounded work done) lands
its bead in `state=asleep` via the generic heal path, same as any other dead
session. `reusablePoolSessionInfo` excluded EVERY asleep session from reuse,
on the caller's assumption (`build_desired_state.go:3917-3918`) that "the
reconciler closes orphaned asleep beads" — no such closing exists anywhere
in the reconciler. The bead stays open forever holding the identity's
runtime `session_name`; the next tick's fresh create then fails closed on
that same name (`derivePoolSessionName` -> `errPoolSessionNameUnavailable`,
"pool session name unavailable ... session name already exists"), and
`buildDesiredState` refuses to mint on every subsequent tick until an
operator runs `gc session close` by hand.

Fixes #5593.

### Fix

- `reusablePoolSessionInfo` now scopes the asleep exclusion: it still
  excludes every asleep session **unless** `cfgAgent.Lifecycle ==
  config.AgentLifecycleOneShot` **and** `isPoolSessionSlotFreeableInfo(info)`
  (the existing allow-list: idle, idle-timeout, city-stop, failed-create,
  runtime-missing, provider-terminal-error — i.e. no deliberate hold such as
  quarantine, rate-limit, or wait-hold).
- This routes the freeable exit through the already-tested wake path (the
  same one that already logs `Woke session ... outcome=success` for other
  pool states) instead of leaving the reconciler to fall through to a
  create that collides on the same name. Persistent (non-one_shot) pools
  are unaffected — a genuine crash still gets a fresh identity rather than
  resuming a possibly-corrupt conversation.

### Compatibility

Single `if` inside one reuse predicate (`reusablePoolSessionInfo`); the
carve-out only widens reuse for `lifecycle=one_shot` + freeable-asleep,
which previously always fell through to a colliding create. No behavior
change for persistent pools or non-freeable sleep reasons.

### Stack

Related: PR #5584 (one-shot routing), #5586 (scoped lifecycle). Upstreamed
standalone from `fix/scoped-one-shot-lifecycle` (commit `6f1ee854b`) as
`fix/one-shot-asleep-pool-reuse`, targeting `main` directly, since this
fix is independent of the rest of that branch.

## Testing

- [x] `make check` — ran the underlying gates directly rather than via
      `make`: `go build ./cmd/gc`, `go vet ./cmd/gc`, and the targeted
      regression subset (CGO env for icu4c). All clean; the full
      `go test ./cmd/gc/...` was still running in the background at
      PR-open time and its result will be appended as a comment. See
      Test plan below.
- [ ] `make check-docs` — not applicable, no docs/navigation/links changed.
- [ ] `make test-integration` — not run; change is scoped to one reconciler
      predicate in `cmd/gc`, covered by the unit/regression suite below.

### Test plan

`cmd/gc` — new:
- `TestReusablePoolSessionInfo_OneShotAsleepFreeableIsReusable`: RED
  pre-fix (`reusablePoolSessionInfo(... asleep, sleep_reason=idle) = false;
  want true`), GREEN post-fix. Two controls in the same test: a
  deliberately-held sleep reason (`quarantine`) on a one_shot agent stays
  excluded, and a non-one_shot (persistent) agent stays excluded even when
  freeable — confirming the carve-out is scoped, not a blanket asleep-allow.

Validated on a fresh `fix/one-shot-asleep-pool-reuse` branch cut from
`origin/main`, with `6f1ee854b` cherry-picked cleanly (no conflicts):

- `go build ./cmd/gc` — clean.
- `go vet ./cmd/gc` — clean.
- `go test ./cmd/gc/ -run 'TestReusablePoolSessionInfo|TestPoolSessionCreate|TestPoolSessionName|TestSelectOrCreateDependencyPoolSessionBead|TestReconcileSessionBeads_DrainAck' -v`
  — all pass, including `TestReusablePoolSessionInfo_DrainAckStopPendingNotReusable`
  (draining still excluded) and the `TestPoolSessionCreate_*` name-holder
  suite (legacy holder, swept slot, foreign reservation, failed-create
  holder, degraded-store — all unaffected).
- `go test ./cmd/gc/...` (full package) — still running in the
  background at PR-open time (long-running, ~7min); result will be
  appended as a PR comment once it finishes.

## Checklist

- [x] Linked an issue: #5593
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — no user-facing docs surface
      for this reconciler predicate; a `CHANGELOG.md` entry is included.
- [x] Called out breaking changes or migration notes — none; see
      Compatibility above.
