### PR TITLE
fix(compact): admit a dropped dolt_ignore'd table as explained root drift

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1073,6 +1073,12 @@ preflight_counts() {
   tables_tmp=$(mktemp)
   : > "$out"
   preflight_excluded_tables=""
+  # Reset unconditionally, not inside the dolt_ignore branch below: compaction
+  # walks every database in one shell process, so a database with no
+  # dolt_ignore patterns would otherwise inherit the previous database's list.
+  # db_root_drift_within_verified_tables reads this to admit drift, so a stale
+  # value would admit it for the wrong database.
+  preflight_dolt_ignored_tables=""
   if ! user_tables "$db" > "$tables_tmp"; then
     rm -f "$tables_tmp"
     return 1
@@ -1088,7 +1094,6 @@ preflight_counts() {
   dolt_ignore_patterns "$db" > "$ignored_patterns_tmp" || true
   if [ -s "$ignored_patterns_tmp" ]; then
     filtered_committed_tmp=$(mktemp)
-    preflight_dolt_ignored_tables=""
     while IFS= read -r ct; do
       [ -n "$ct" ] || continue
       ct_matched=0
@@ -1353,6 +1358,20 @@ verify_counts() {
 #    rewritten, so a first commit only introduced rows, and an
 #    already-committed table keeps every row it held at <from> intact at <to>.
 #
+#    One shape inside category 2 cannot satisfy that proof, and must not be
+#    asked to: a dolt_ignore'd table that a force-healed store inlined into the
+#    committed root. -Am cannot stage a dolt_ignore'd table, so the flatten's
+#    DOLT_RESET('--soft', root) un-tracks it and the flatten commit DROPS it.
+#    The diff is a deletion by construction, on every flatten of an affected
+#    database, for as long as the table stays inlined -- so it never self-heals
+#    and deferring starves GC exactly as a quarantine does. It is admitted on
+#    preflight's own positive identification (preflight_dolt_ignored_tables)
+#    rather than on a content diff. The rows are not lost: they remain in the
+#    working set, which DOLT_GC keeps reachable, and that is already the steady
+#    state for every database whose ignored tables were never force-inlined.
+#    What the flatten drops is the table's presence in the committed root --
+#    which is the same thing a flatten does to all history by design.
+#
 # Any other table (system tables such as dolt_schemas), a first-committed
 # table whose diff is not added-only or whose diff probe fails, an empty
 # DOLT_DIFF_STAT, or a DIFF_STAT probe failure fails closed. Exports the full
@@ -1364,6 +1383,7 @@ db_root_drift_within_verified_tables() {
   preflight_file="$4"
   db_root_drift_proven_tables=""
   db_root_drift_first_committed_tables=""
+  db_root_drift_dropped_ignored_tables=""
   db_root_drift_stat_tables=""
   [ -n "$from" ] && [ -n "$to" ] || return 1
   stat_tmp=$(mktemp)
@@ -1387,6 +1407,7 @@ db_root_drift_within_verified_tables() {
   fi
   drift_verified_tables=""
   drift_first_committed_tables=""
+  drift_dropped_ignored_tables=""
   drift_unproven_tables=""
   for drift_t in $drift_tables; do
     db_root_drift_stat_tables="$db_root_drift_stat_tables $drift_t"
@@ -1400,11 +1421,23 @@ db_root_drift_within_verified_tables() {
     fi
     case " $preflight_excluded_tables " in
       *" $drift_t "*)
-        if diff_is_additive_only "$db" "$from" "$to" "$drift_t"; then
-          drift_first_committed_tables="$drift_first_committed_tables $drift_t"
-        else
-          drift_unproven_tables="$drift_unproven_tables $drift_t (first-commit diff not added-only or diff probe failed)"
-        fi
+        case " $preflight_dolt_ignored_tables " in
+          *" $drift_t "*)
+            # Category 2, drop direction. -Am cannot stage a dolt_ignore'd
+            # table, so the flatten's DOLT_RESET('--soft') un-tracks it and the
+            # flatten commit DROPS it. The diff is a deletion by construction,
+            # so diff_is_additive_only can never admit it -- see the comment on
+            # this function for why that is not evidence of corruption.
+            drift_dropped_ignored_tables="$drift_dropped_ignored_tables $drift_t"
+            ;;
+          *)
+            if diff_is_additive_only "$db" "$from" "$to" "$drift_t"; then
+              drift_first_committed_tables="$drift_first_committed_tables $drift_t"
+            else
+              drift_unproven_tables="$drift_unproven_tables $drift_t (first-commit diff not added-only or diff probe failed)"
+            fi
+            ;;
+        esac
         ;;
       *)
         drift_unproven_tables="$drift_unproven_tables $drift_t (outside verified set)"
@@ -1419,6 +1452,7 @@ db_root_drift_within_verified_tables() {
   fi
   db_root_drift_proven_tables=${drift_verified_tables# }
   db_root_drift_first_committed_tables=${drift_first_committed_tables# }
+  db_root_drift_dropped_ignored_tables=${drift_dropped_ignored_tables# }
   return 0
 }
 
@@ -2998,8 +3032,8 @@ flatten_database() {
       # belongs to one of those categories; defer exactly as the proven
       # writer-race paths do. Anything else stays quarantined.
       if db_root_drift_within_verified_tables "$db" "$head" "$flatten_head" "$preflight_tmp"; then
-        printf 'compact: db=%s committed-root drift confined to verified table(s) [%s] and first-committed unversioned table(s) [%s] via DOLT_DIFF_STAT(%s..%s) with per-table verification passed — absorbed working-set state committed by the flatten, not corruption; deferring, will retry next run\n' \
-          "$db" "${db_root_drift_proven_tables:-}" "${db_root_drift_first_committed_tables:-}" "$head" "$flatten_head" >&2
+        printf 'compact: db=%s committed-root drift confined to verified table(s) [%s], first-committed unversioned table(s) [%s] and dropped dolt_ignore'"'"'d table(s) [%s] via DOLT_DIFF_STAT(%s..%s) with per-table verification passed — absorbed working-set state committed by the flatten, not corruption; deferring, will retry next run\n' \
+          "$db" "${db_root_drift_proven_tables:-}" "${db_root_drift_first_committed_tables:-}" "${db_root_drift_dropped_ignored_tables:-}" "$head" "$flatten_head" >&2
         if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
           "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
           "$compacted_from_head" "$local_branch" "$remote_branch"; then

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -788,7 +788,7 @@ case "$query" in
     ;;
   *"DOLT_HASHOF_DB"*)
     case "$mode" in
-      absorbed_ws_db_hash_drift|absorbed_ws_db_hash_drift_system_table|first_commit_probe_table_db_hash_drift|first_commit_table_nonadditive_diff|first_commit_table_diff_probe_failure|absorbed_ws_plus_first_commit_drift)
+      absorbed_ws_db_hash_drift|absorbed_ws_db_hash_drift_system_table|first_commit_probe_table_db_hash_drift|first_commit_table_nonadditive_diff|first_commit_table_diff_probe_failure|absorbed_ws_plus_first_commit_drift|dropped_ignored_table_db_hash_drift)
         # Standing uncommitted working-set state absorbed by the flatten's -Am:
         # the committed root legitimately differs across the flatten while HEAD
         # never moves and every per-table working-set hash stays stable. The
@@ -896,7 +896,7 @@ case "$query" in
     # dolt#11131 heal but is still dolt_ignore'd — the fix must detect this and
     # exclude wisps from flatten verification (#3541).
     case "$mode" in
-      ignored_committed_table_drift)
+      ignored_committed_table_drift|dropped_ignored_table_db_hash_drift)
         print_cell wisps
         ;;
       *)
@@ -965,7 +965,7 @@ case "$query" in
     # was inlined into HEAD by DOLT_ADD('--force',...)+commit, so SHOW TABLES
     # AS OF HEAD returns it — unlike the normal ignored_table_drift case where
     # wisps is absent from every commit root. Both queries return wisps here.
-    if [ "$mode" = "ignored_committed_table_drift" ]; then
+    if [ "$mode" = "ignored_committed_table_drift" ] || [ "$mode" = "dropped_ignored_table_db_hash_drift" ]; then
       print_cells beads wisps
       exit 0
     fi
@@ -1023,6 +1023,15 @@ case "$query" in
       exit 0
     fi
     print_cell beads
+    exit 0
+    ;;
+  *"DOLT_DIFF("*"'wisps')"*)
+    # Same ordering requirement as the probe-table arm below: this query's
+    # text also matches the generic "SELECT COUNT(*) FROM" arm, so it must be
+    # dispatched first.
+    # The flatten commit DROPS a dolt_ignore'd table, so its content diff
+    # reports deletions: never added-only, by construction.
+    print_cell 1
     exit 0
     ;;
   *"DOLT_DIFF("*"'__gc_read_only_probe')"*)
@@ -1127,6 +1136,10 @@ case "$query" in
     fi
     if [ "$mode" = "absorbed_ws_db_hash_drift_system_table" ]; then
       print_cell dolt_schemas
+      exit 0
+    fi
+    if [ "$mode" = "dropped_ignored_table_db_hash_drift" ]; then
+      print_cell wisps
       exit 0
     fi
     case "$mode" in
@@ -2896,6 +2909,49 @@ func TestCompactScriptStillQuarantinesDbHashDriftBeyondVerifiedTables(t *testing
 	}
 	if strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("unexplained db root drift must block full GC:\n%s", string(data))
+	}
+}
+
+// Production incident (hq 2026-08-03, sysadmin 2026-08-04): a store force-healed
+// per #3541/dolt#11131 has dolt_ignore'd tables inlined into the committed root
+// via DOLT_ADD('--force')+commit. preflight_counts correctly drops them from
+// per-table verification, but DOLT_HASHOF_DB('HEAD') still counts them -- and
+// the flatten's DOLT_RESET('--soft', root) un-tracks them while -Am cannot
+// re-stage a dolt_ignore'd table, so the flatten commit DROPS them. The
+// committed root drifts with a stable HEAD, every verified table stays
+// byte-identical, and DOLT_DIFF_STAT names a table whose diff is a deletion --
+// so #5049's added-only proof can never admit it and the database hard-
+// quarantines, blocking compaction and GC indefinitely.
+//
+// The drop is by construction rather than evidence of loss: the rows stay in
+// the working set, which DOLT_GC keeps reachable. Admit it on preflight's own
+// positive identification and take the existing defer path. That converges --
+// the defer leaves the flatten HEAD in place, and that HEAD no longer carries
+// the table, so the next run sees an ordinary never-committed table.
+func TestCompactScriptDefersDroppedDoltIgnoredTableDbHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "dropped_ignored_table_db_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("dropped dolt_ignore'd table drift must defer, not fail: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dropped dolt_ignore'd table(s) [wisps]") ||
+		!strings.Contains(out, "deferring, will retry next run") {
+		t.Fatalf("output missing dropped dolt_ignore'd table defer message:\n%s", out)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
+		t.Fatalf("dropped dolt_ignore'd table drift must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
+		t.Fatalf("dropped dolt_ignore'd table defer should record pending-GC retry marker, got reason %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read fake dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_HASHOF_TABLE('wisps')") {
+		t.Fatalf("dolt_ignore'd committed table must not be hash-verified:\n%s", string(data))
 	}
 }
 


### PR DESCRIPTION
## Summary

A store force-healed per #3541 / dolt#11131 has `dolt_ignore`'d tables inlined into the committed root. On its next threshold-crossing flatten it **hard-quarantines** and stops compacting and GC'ing — indefinitely, until an operator clears the marker by hand.

Two production stores hit this (hq 2026-08-03, sysadmin 2026-08-04), both on quiet stores with no writer anywhere near the flatten window:

```
compact: db=... post-flatten value hash changed without row-count increase — quarantine and investigate before GC
```

This is the same *family* #5049 fixed, with the opposite sign, and #5049's proof cannot reach it.

## Root cause

`preflight_counts` correctly drops `dolt_ignore`'d committed tables from per-table verification (category 2 in its comment). But `db_value_hash()` is `DOLT_HASHOF_DB('HEAD')` — pinned to the committed root, which **still counts them**.

The flatten's `DOLT_RESET('--soft', root)` un-tracks them, and `-Am` cannot re-stage a `dolt_ignore`'d table, so the flatten commit **drops** them. The committed root moves while every verified table stays byte-identical.

`db_root_drift_within_verified_tables` then sees a drift table that is in `preflight_excluded_tables`, and asks `diff_is_additive_only`. The diff is a **deletion**, so the answer is no, and it falls to:

```
committed-root drift includes unproven table(s): wisps (first-commit diff not added-only or diff probe failed) — quarantine
```

Verified on the live stores at the time: neither flatten commit contained any of those tables, while both current HEADs did.

## Fix

Inside the existing `preflight_excluded_tables` case, check `preflight_dolt_ignored_tables` **first**. A table preflight positively identified as `dolt_ignore`'d-and-committed is admitted on that identification rather than on a content diff.

**Added-only is left exactly as it is for the rest of category 2.** It is the right proof for a first-committed table, and this PR does not weaken it. It is simply not a proof this shape can ever satisfy: the drop is what the flatten does by construction, on every run, for as long as the table stays inlined.

### The claim to scrutinise

This admits a drift where rows committed at `<from>` are absent from the committed root at `<to>`. That is a real relaxation and it deserves the hard look, so let me put the argument plainly rather than bury it:

- The rows are **not lost**. They remain in the working set, which `DOLT_GC` keeps reachable.
- That is **already the steady state** for every database whose ignored tables were never force-inlined — those tables live only in the working set and always have. The force-heal is what made this database temporarily different; the flatten returns it to the norm.
- What the flatten drops is the table's *presence in the committed root* — which is what a history flatten does to all history by design.

If you would rather this be gated on something stronger (an explicit row-count probe against the working-set copy, say), I am happy to add it — but I did not want to invent a proof obligation the surrounding code does not impose on the same tables anywhere else.

### It takes the existing defer path, and that converges

The admitted drift routes into the **existing** defer, not to full GC. That matters, and it is the one place I revised our internal fix rather than porting it: our production patch proceeded straight to GC on the reasoning that a structural drift repeats every run, so deferring would starve GC exactly as a quarantine does.

Against this code that reasoning does not hold. `preserve_head_after_writer_race_defer` leaves the **flatten HEAD** in place and `write_pending_gc_marker` schedules the retry — and that HEAD no longer carries the table. The next run therefore sees an ordinary never-committed table and completes normally. One extra cycle, no starvation, no new branch, and no quarantine auto-clear (per the #3584 revert).

### One latent bug this makes load-bearing

`preflight_dolt_ignored_tables` was reset *inside* the `if [ -s "$ignored_patterns_tmp" ]` branch. Compaction walks every database in one shell process, so a database with **no** `dolt_ignore` patterns inherited the previous database's list. Harmless before — nothing read it across databases — but this change reads it to admit drift, so a stale value would admit drift for the wrong database. Reset hoisted to the top of `preflight_counts`, with a comment saying why it must stay there.

## Tests

New fake-dolt scenario `dropped_ignored_table_db_hash_drift`: `wisps` is `dolt_ignore`'d **and** present in `SHOW TABLES AS OF HEAD` (force-inlined), the committed-root hash drifts across the flatten, `DOLT_DIFF_STAT` names `wisps`, and its `DOLT_DIFF` reports a deletion — never added-only, modelled explicitly so the scenario stays faithful even if the proof order changes.

`TestCompactScriptDefersDroppedDoltIgnoredTableDbHashDrift` asserts the defer message names the dropped table, no quarantine marker is written, the pending-GC retry marker is recorded, and `wisps` is still never hash-verified.

**On `main` this test reproduces the production incident verbatim**, which is the evidence I would most want a reviewer to check:

```
compact: db=beads excluding dolt_ignored committed table(s) from flatten verification
         (force-inlined into HEAD but -Am cannot stage them): wisps
compact: db=beads committed-root drift includes unproven table(s):
         wisps (first-commit diff not added-only or diff probe failed) — quarantine
compact: db=beads value hash changed without row-count increase
         before=hash-root-before after=hash-root-after-absorb — quarantine and investigate before GC
compact: 1 database(s) failed compaction
```

Verification, all on a linux/amd64 runner:

- `go test ./examples/bd/dolt/ -run TestCompactScript` — ok, all compact-script scenarios pass.
- `go vet ./examples/bd/dolt/` — clean.
- `bash -n` on `run.sh` — clean. `shellcheck -S warning` — three findings, all pre-existing on `main` (SC1083 line 525, SC2254 line 1084, SC2034 line 2217); **zero new**.
- Full-package `go test ./examples/bd/dolt/` fails one test, `TestSQLScriptConnectedBranchExportsPassword` — it fails **identically on clean `main` on the same runner** (`no dolt server running and no databases found`). Pre-existing and unrelated; I checked rather than assumed.

## Related

- **#5049** (merged) fixed the first-commit direction of this same category and is what `diff_is_additive_only` came from. This is the drop direction, which that proof structurally cannot admit.
- **#2348 / #3341** describe concurrent-writer false positives in this gate. This is **not** one of those: there is no race. It reproduces on every flatten of an affected database and never self-heals, which is exactly why quarantining is the wrong response.
- **#2740** — a store stuck in this state stops GC'ing entirely, which is one way a Dolt store grows unbounded.
