### PR TITLE
fix(bd): refuse an infra-shaped create on a split city

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   publish time: the registry byte-compares it with `[pack].name`, so it can
   only restate the name `pack.toml` already declares.
 
+- **`gc bd` now refuses a `--metadata` body it cannot validate before the
+  write, on `new` as well as `create` and `update`.** `gc bd` validates
+  rig-qualified metadata (`lease_owner`, `routed_to`) ahead of the write so a
+  create naming a rig this city does not configure is stopped before it mints a
+  stranded bead. That guard admitted `create` and `update` but not `new` — the
+  alias `bd` itself registers for `create` — so the same command spelled `gc bd
+  new` skipped validation entirely. It now normalizes the alias and applies the
+  identical check.
+
+  Upgrading: `gc bd new --metadata @file.json` now exits 1, on every city,
+  split or not. The `@file.json` spelling states its object in a file rather
+  than in argv, so `gc bd` cannot read the rig qualification before `bd`
+  resolves the file and mints from it — the one spelling where a refusal is the
+  only fail-closed answer. Pass the JSON inline (`--metadata '{"routed_to":
+  "rig/agent"}'`) instead. A malformed inline body is likewise refused by name
+  rather than forwarded. No in-repo caller uses the `@file.json` spelling.
+
 ### Fixed
 
 - **Mail archive and delete now expand whitespace-joined message IDs.** Each

--- a/cmd/gc/bd_relocated_classes.go
+++ b/cmd/gc/bd_relocated_classes.go
@@ -536,22 +536,25 @@ func bdRelocatedClassCreateAddMetadata(shape *beads.Bead, value string) {
 // pinned manifest says it takes one separately, so a title like `--title
 // --type` can never be read as the flag it spells.
 //
-// Two shapes are NOT stated in argv and are deliberately not guessed at:
+// The file-backed create forms are NOT stated in argv, so this function does not
+// see them; bdRelocatedClassCreateRefusal handles them before it reaches here:
 //
-//   - `create -f plan.md` and `create --graph <json>` take their beads from a
-//     file or a plan body. Parsing either would mean reimplementing bd's own
-//     parser here and drifting from it; classifying them by their absent argv
-//     would be a confident wrong answer.
-//   - A shorthand CLUSTER (`-qtmessage`) hides the type behind another
-//     shorthand. Decomposing one needs to know which letters take values, which
-//     bdflags pins per FLAG rather than per letter.
+//   - `create --graph <plan>` carries a JSON graph-apply plan. It is decoded in
+//     the beads.GraphApplyPlan shape bd itself consumes and classified with
+//     coordclass.ClassifyGraphPlan — no reparse of bd's format, no drift.
+//   - `create -f/--file <file>` carries bd's own multi-issue markdown. Reparsing
+//     that format here would drift from bd, so on a split city it fails closed
+//     rather than forward a payload this cannot classify.
 //
-// Both are documented limits rather than fail-closed refusals: a create whose
-// shape this cannot read is forwarded, exactly as it is today, and refusing
-// every bulk create on a split city would break the ordinary work mints the
-// work ledger exists for. The guard is a floor on stranded mints, not a proof
-// of their impossibility — the migration's containment check is what audits
-// beads already on disk.
+// One argv-shaped input remains a documented limit rather than a guessed one: a
+// shorthand CLUSTER (`-qtmessage`) hides the type behind another shorthand, and
+// decomposing one needs to know which letters take values — bdflags pins that
+// per FLAG, not per letter. (A `--metadata` value this cannot read as the inline
+// JSON object bd expects likewise contributes nothing to the shape rather than a
+// wrong guess.) The guard is a floor on stranded mints, not a proof of their
+// impossibility: the file-backed forms above close the two highest-value doors,
+// and the migration's containment check only REPORTS strays already on disk — it
+// detects them, it does not move them.
 func bdRelocatedClassCreateShape(manifest string, verbArgs []string) beads.Bead {
 	values := bdflags.ValueFlags(manifest)
 	var shape beads.Bead
@@ -588,6 +591,91 @@ func bdRelocatedClassCreateFlagValue(arg string) (name, value string, stated boo
 		return arg[:2], arg[2:], true
 	}
 	return arg, "", false
+}
+
+// fileCreateForm names a create form that states its beads in a FILE rather than
+// in argv, which bdRelocatedClassCreateShape cannot see.
+type fileCreateForm int
+
+const (
+	// fileCreateNone is an argv-shaped create (or a verb with no file form).
+	fileCreateNone fileCreateForm = iota
+	// fileCreateGraph is `create --graph <plan>`: a JSON graph-apply plan.
+	fileCreateGraph
+	// fileCreateBulk is `create -f/--file <file>`: bd's multi-issue markdown.
+	fileCreateBulk
+)
+
+// bdRelocatedClassCreateFileForm reports whether a create states its beads in a
+// file, and returns the file path when it does.
+//
+// It walks verbArgs with the same manifest-aware stepping bdRelocatedClassCreateShape
+// uses, so a value flag whose value happens to spell `--graph` or `-f` (a title
+// of `--graph`, say) is stepped over rather than misread as the flag it names.
+// The file flags are read by the same cobra spellings as the shape flags:
+// separated (`--graph plan`), inline (`--graph=plan`), and attached shorthand
+// (`-fplan`). A file flag with no value is reported with an empty path; bd
+// rejects it and mints nothing, so the caller's graph arm falls through safely.
+func bdRelocatedClassCreateFileForm(manifest string, verbArgs []string) (fileCreateForm, string) {
+	values := bdflags.ValueFlags(manifest)
+	for i := 0; i < len(verbArgs); i++ {
+		name, value, stated := bdRelocatedClassCreateFlagValue(verbArgs[i])
+		form := fileCreateFormForFlag(name)
+		switch {
+		// A flag names a file form only when the verb actually takes it as a
+		// value flag; `q` pins no --graph/--file, so its tokens are not one.
+		case form != fileCreateNone && values[name]:
+			if stated {
+				return form, value
+			}
+			if i+1 < len(verbArgs) {
+				return form, verbArgs[i+1]
+			}
+			return form, ""
+		case !stated && values[name]:
+			i++
+		}
+	}
+	return fileCreateNone, ""
+}
+
+// fileCreateFormForFlag maps a create flag to the file form it introduces, or
+// fileCreateNone for a flag that states its value in argv.
+func fileCreateFormForFlag(name string) fileCreateForm {
+	switch name {
+	case "--graph":
+		return fileCreateGraph
+	case "-f", "--file":
+		return fileCreateBulk
+	default:
+		return fileCreateNone
+	}
+}
+
+// bdRelocatedClassGraphPlanClass classifies the plan a `create --graph <path>`
+// would apply, reporting parsed=false when the plan file cannot be read or
+// decoded.
+//
+// The plan file is JSON in the beads.GraphApplyPlan shape bd consumes —
+// internal/beads.ApplyGraphPlanWithStorage marshals exactly this struct before
+// handing the path to bd — so decoding it here and classifying with
+// coordclass.ClassifyGraphPlan is the same decision the router and the migration
+// make, not a reparse of bd's format.
+//
+// parsed=false is not a swallowed error: bd applies the identical json.Unmarshal
+// and exits non-zero WITHOUT writing when it fails, so a plan unreadable here
+// cannot become a bead either. The caller forwards it to fail at bd rather than
+// refusing a create that would mint nothing.
+func bdRelocatedClassGraphPlanClass(path string) (class coordclass.Class, parsed bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return coordclass.ClassWork, false
+	}
+	var plan beads.GraphApplyPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return coordclass.ClassWork, false
+	}
+	return coordclass.ClassifyGraphPlan(&plan), true
 }
 
 // bdRelocatedClassCreateRefusal reports whether a `gc bd` invocation would mint
@@ -629,9 +717,37 @@ func bdRelocatedClassCreateRefusal(cfg *config.City, bdArgs []string) (string, b
 	if !mints {
 		return "", false
 	}
+	// The file-backed create forms carry their beads outside argv, so they are
+	// decided here before the argv-shape walk below — which would see no shape
+	// and forward — reaches them.
+	switch form, path := bdRelocatedClassCreateFileForm(manifest, verbArgs); form {
+	case fileCreateGraph:
+		// A --graph plan is JSON in the beads.GraphApplyPlan shape bd consumes,
+		// so it classifies without drift via coordclass.ClassifyGraphPlan. An
+		// unreadable or malformed plan is left to fall through to bd, which
+		// applies the identical parse and mints nothing when it fails, so there
+		// is nothing for this guard to strand.
+		if class, parsed := bdRelocatedClassGraphPlanClass(path); parsed {
+			return bdRelocatedClassMatch(verb, relocated, class)
+		}
+	case fileCreateBulk:
+		// A -f/--file payload is bd's own multi-issue markdown, whose per-issue
+		// type and labels can name a relocated class. Reparsing that format here
+		// would drift from bd, so on a split city it fails closed rather than
+		// forward a payload this guard cannot classify.
+		return bdRelocatedClassCreateFileRefusalText(verb, relocated), true
+	}
 	// A work-class shape matches nothing: relocatedBeadClasses never names the
 	// work class, which is the residual one and the one bd's ledger holds.
-	class := coordclass.Classify(bdRelocatedClassCreateShape(manifest, verbArgs))
+	return bdRelocatedClassMatch(verb, relocated, coordclass.Classify(bdRelocatedClassCreateShape(manifest, verbArgs)))
+}
+
+// bdRelocatedClassMatch returns the create refusal for a prospective bead CLASS
+// when this city serves that class from a storage binding, and ("", false) when
+// the class is the work class bd's ledger holds. It is the shared tail of every
+// create arm — argv-shaped and file-backed alike — so they cannot disagree about
+// what a relocated class is.
+func bdRelocatedClassMatch(verb string, relocated []beads.RelocatedClass, class coordclass.Class) (string, bool) {
 	for _, candidate := range relocated {
 		if candidate.Class == class.String() {
 			return bdRelocatedClassCreateRefusalText(verb, candidate), true
@@ -661,6 +777,38 @@ func bdRelocatedClassCreateRefusalText(verb string, class beads.RelocatedClass) 
 		"nothing would report that, because bd would have done exactly what it was asked. A bead minted under the work "+
 		"prefix cannot be moved into the class namespace afterwards, so this is refused before anything is written.%s",
 		verb, class.Class, class.Class, class.IDPrefix+"-", where, class.Class, mint)
+}
+
+// bdRelocatedClassCreateFileRefusalText renders the fail-closed refusal for a
+// `create -f/--file <file>` on a split city.
+//
+// Unlike a --graph plan — JSON in the shape bd consumes, classified without drift
+// — a -f/--file payload is bd's own multi-issue markdown, and classifying it
+// would mean reimplementing bd's parser and drifting from it. Its per-issue type
+// and labels CAN name a relocated class, so the guard cannot prove the file mints
+// no relocated bead, and a bead stranded under the work prefix cannot be moved
+// into a class namespace afterwards. It therefore refuses before any write and
+// names the doors that ARE classified: an inline create read from argv, or the
+// class-native mint command for each class this city relocates.
+func bdRelocatedClassCreateFileRefusalText(verb string, relocated []beads.RelocatedClass) string {
+	var served strings.Builder
+	for i, class := range relocated {
+		if i > 0 {
+			served.WriteString(", ")
+		}
+		served.WriteString(class.Class)
+		if mint := bdRelocatedClassMintPaths[class.Class]; mint != "" {
+			fmt.Fprintf(&served, " (%s)", mint)
+		}
+	}
+	return fmt.Sprintf("bd %s reads its beads from a file, and this city serves these classes from a separate storage "+
+		"binding: %s. bd writes the work ledger only, so any bead of those classes in that file would land where its "+
+		"class is never read, and a bead minted under the work prefix cannot be moved into the class namespace "+
+		"afterwards. This guard classifies a create from its argv and will not reparse bd's file format, so it cannot "+
+		"prove a file-backed create mints no relocated bead — it is refused before anything is written. Create work "+
+		"beads inline with `gc bd %s ...` (classified from argv), or mint an infra bead with the class-native command "+
+		"shown above.",
+		verb, served.String(), verb)
 }
 
 // relocatedClassLocation describes where a binding serves from, for the

--- a/cmd/gc/bd_relocated_classes.go
+++ b/cmd/gc/bd_relocated_classes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -508,11 +509,19 @@ func bdRelocatedClassCreateAddLabels(shape *beads.Bead, value string) {
 // a JSON number or boolean reads here exactly as it reads back off the wire.
 //
 // A body this cannot decode — malformed JSON, or the `@file.json` spelling
-// whose object is not in argv at all — contributes nothing, and that is not a
-// swallowed error: bd applies the identical parse and exits non-zero WITHOUT
-// writing when it fails, so a token unreadable here cannot become a bead
-// either. The `@file.json` case is a real limit and is documented on
-// bdRelocatedClassCreateShape with the other file-borne shapes.
+// whose object is not in argv at all — contributes nothing to the shape. Under
+// `gc bd` that is not a swallowed error, but the shield is a gc guard rather
+// than bd: bdRigQualifiedMetadataRefusal (cmd_bd.go) runs unconditionally ahead
+// of this one and refuses both spellings on every verb it admits — create, its
+// `new` alias, and update. `q`, the third mint verb here, has no --metadata
+// flag at all (bd q --help), so every mint verb that can carry one is refused
+// before this function is reached.
+//
+// Attributing that to bd instead would be wrong, because bd's own behavior
+// differs by spelling: it rejects a malformed inline body (identical parse,
+// exit non-zero, no write) but it RESOLVES `@file.json` — that spelling states
+// its object in a file, so a token unreadable here is one bd would read and
+// mint from.
 func bdRelocatedClassCreateAddMetadata(shape *beads.Bead, value string) {
 	var fields beads.StringMap
 	if err := json.Unmarshal([]byte(value), &fields); err != nil {
@@ -551,10 +560,21 @@ func bdRelocatedClassCreateAddMetadata(shape *beads.Bead, value string) {
 // decomposing one needs to know which letters take values — bdflags pins that
 // per FLAG, not per letter. (A `--metadata` value this cannot read as the inline
 // JSON object bd expects likewise contributes nothing to the shape rather than a
-// wrong guess.) The guard is a floor on stranded mints, not a proof of their
-// impossibility: the file-backed forms above close the two highest-value doors,
-// and the migration's containment check only REPORTS strays already on disk — it
-// detects them, it does not move them.
+// wrong guess.)
+//
+// Three MINT VERBS are outside the guard entirely, because
+// bdRelocatedClassCreateVerbs holds only create/new/q: `bd import` replays a
+// JSONL export with issue_type and labels carried verbatim, `bd batch` reads a
+// create grammar from stdin or a file, and `bd create-form` mints from a form.
+// Each can still land a relocated-class bead in the work ledger at exit 0. None
+// of them was ever guarded, so this is a limit of the floor rather than a
+// regression — but it is a limit, and `import` in particular is the natural
+// restore path, since JSONL is what `bd export` emits.
+//
+// The guard is a floor on stranded mints, not a proof of their impossibility:
+// the file-backed forms above close the two highest-value doors on the create
+// verbs it covers, and the migration's containment check only REPORTS strays
+// already on disk — it detects them, it does not move them.
 func bdRelocatedClassCreateShape(manifest string, verbArgs []string) beads.Bead {
 	values := bdflags.ValueFlags(manifest)
 	var shape beads.Bead
@@ -662,11 +682,35 @@ func fileCreateFormForFlag(name string) fileCreateForm {
 // coordclass.ClassifyGraphPlan is the same decision the router and the migration
 // make, not a reparse of bd's format.
 //
+// A RELATIVE path is resolved against scopeRoot, because that is the directory
+// bd will read it from: doBd runs the subprocess with cmd.Dir = target.ScopeRoot.
+// Reading it in the wrapper's own cwd instead resolved the same token against two
+// different roots, and the damaging direction is silent — the plan exists under
+// the scope root but not under cwd, this read fails, parsed=false forwards the
+// create, and bd finds the plan and mints the relocated-class bead. Two roots for
+// one path is also how a plan could be classified against a DIFFERENT file that
+// happens to sit at the same relative path under cwd.
+//
+// bd's own `-C/--directory` does not disturb this. Despite its help text
+// ("Change to this directory before running the command (like git -C)"), `-C`
+// selects the beads PROJECT bd opens — it is validated as such, with
+// `cannot use -C directory "...": no beads project found` — and is not the base
+// for a relative path argument. bd resolves `--graph <path>` against its process
+// cwd, and doBd pins that cwd with a single unconditional
+// `cmd.Dir = target.ScopeRoot` (cmd_bd.go), the same root threaded here, so this
+// read and bd's read name the same file with or without `-C`. Probed against bd
+// 1.1.0 in both directions: with the plan present in cwd only, bd parses it even
+// under `-C <other project>`; with the plan present under the `-C` directory
+// only, bd reports it missing.
+//
 // parsed=false is not a swallowed error: bd applies the identical json.Unmarshal
 // and exits non-zero WITHOUT writing when it fails, so a plan unreadable here
 // cannot become a bead either. The caller forwards it to fail at bd rather than
 // refusing a create that would mint nothing.
-func bdRelocatedClassGraphPlanClass(path string) (class coordclass.Class, parsed bool) {
+func bdRelocatedClassGraphPlanClass(scopeRoot, path string) (class coordclass.Class, parsed bool) {
+	if scopeRoot != "" && path != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(scopeRoot, path)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return coordclass.ClassWork, false
@@ -682,12 +726,15 @@ func bdRelocatedClassGraphPlanClass(path string) (class coordclass.Class, parsed
 // a bead of a class this city serves from a storage binding, and returns the
 // operator-facing refusal when it would.
 //
-// This is the write side of the same split the read guard above covers, and it
-// fails differently: a blind READ answers emptily and can be re-run once the
-// operator knows better, while a blind CREATE leaves a row in the wrong ledger
-// under the wrong prefix — a bead no later read finds, and no migration moves,
-// because renaming it into the class namespace afterwards is not something any
-// backend can do.
+// This is the write side of the same split the read guard above covers, over
+// the create verbs that state their beads in argv — not over every way bd can
+// mint: `import`, `batch` and `create-form` remain unguarded, as documented on
+// bdRelocatedClassCreateShape. Where it does fire it fails differently from the
+// read guard: a blind READ answers emptily and can be re-run once the operator
+// knows better, while a blind CREATE leaves a row in the wrong ledger under the
+// wrong prefix — a bead no later read finds, and no migration moves, because
+// renaming it into the class namespace afterwards is not something any backend
+// can do.
 //
 // It refuses rather than reroutes because rerouting is impossible on this seam:
 // only argv crosses to the bd subprocess, and the binding is opened in process.
@@ -700,11 +747,28 @@ func bdRelocatedClassGraphPlanClass(path string) (class coordclass.Class, parsed
 // is a type=chore bead, so any table written here would have to relearn the
 // boundary and would drift from it.
 //
-// An undecidable verb (a subcommand hidden behind an unrecognized root flag)
-// returns no refusal, unlike the read scan's fail-closed judgment of every
-// remaining token: there is nothing to fail closed ABOUT, because bd rejects
-// the unknown flag before creating anything, so no mint can occur either way.
-func bdRelocatedClassCreateRefusal(cfg *config.City, bdArgs []string) (string, bool) {
+// scopeRoot is the directory doBd will run bd in (target.ScopeRoot), and it is
+// threaded here for the file-backed arms: a relative `--graph` path names a file
+// relative to THAT root, not to the wrapper's cwd. An empty scopeRoot means no
+// root is known and relative paths resolve as the process sees them.
+//
+// An undecidable verb — a subcommand hidden behind a root flag that is in
+// NEITHER global manifest — returns no refusal, unlike the read scan's
+// fail-closed judgment of every remaining token. The premise is that a flag this
+// package does not know is one bd does not know either, so bd rejects it and
+// exits before creating anything. That premise holds only while the manifests in
+// internal/bdflags track bd's real persistent flags, and it did not hold once:
+// --profile was filed as a bool and --database, --server-url and --mem-profile
+// were in neither map, so four flags bd accepts and mints behind reached this arm
+// and switched the guard off. The manifests are pinned exactly — value and bool
+// sets compared separately by TestGlobalValueFlagsIsComplete and
+// TestGlobalBoolFlagsIsComplete — so restoring that premise is a build failure
+// away rather than a silent fail-open, and
+// TestBdCreateRefusesAnInfraShapedCreateBehindABdRootFlag pins the composition
+// from this end. Failing closed here instead is not the cheaper answer: with no
+// verb there is no dialect either, so judging the remaining tokens under the
+// create dialect would refuse `gc bd <unknown-flag> list --type message`, a READ.
+func bdRelocatedClassCreateRefusal(cfg *config.City, scopeRoot string, bdArgs []string) (string, bool) {
 	relocated := relocatedBeadClasses(cfg)
 	if len(relocated) == 0 {
 		return "", false
@@ -727,7 +791,7 @@ func bdRelocatedClassCreateRefusal(cfg *config.City, bdArgs []string) (string, b
 		// unreadable or malformed plan is left to fall through to bd, which
 		// applies the identical parse and mints nothing when it fails, so there
 		// is nothing for this guard to strand.
-		if class, parsed := bdRelocatedClassGraphPlanClass(path); parsed {
+		if class, parsed := bdRelocatedClassGraphPlanClass(scopeRoot, path); parsed {
 			return bdRelocatedClassMatch(verb, relocated, class)
 		}
 	case fileCreateBulk:

--- a/cmd/gc/bd_relocated_classes.go
+++ b/cmd/gc/bd_relocated_classes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/bdflags"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
 )
 
 // relocatedBeadClasses reports the coordination classes a city serves from
@@ -437,6 +439,228 @@ func bdRelocatedClassVerb(bdArgs []string) (verb string, verbArgs []string, ok b
 		return "", bdArgs[i+1:], false
 	}
 	return "", nil, false
+}
+
+// bdRelocatedClassCreateVerbs are the bd subcommands that MINT a bead from
+// argv, mapped to the bdflags manifest describing their flags.
+//
+// `create` is the ordinary one, `new` is the alias bd registers for it, and `q`
+// is quick capture — the same mint through a shorter dialect (-t/--type,
+// -l/--labels, -p/--priority, --parent). bdflags pins no manifest for `q`,
+// which costs nothing here: the flags that state a bead's CLASS are read by
+// name below, and the manifest is consulted only to step over OTHER flags'
+// values.
+var bdRelocatedClassCreateVerbs = map[string]string{
+	"create": "create",
+	"new":    "create",
+	"q":      "q",
+}
+
+// bdRelocatedClassMintPaths names the gc-native command that mints a bead of
+// each relocatable class into the binding the class is served from.
+//
+// A refusal that names no alternative leaves the operator holding a command
+// that does not work and no command that does, so this table is part of the
+// message rather than a nicety.
+// TestBdRelocatedClassCreateNamesAMintPathForEveryRelocatableClass pins it
+// against infraMigrationClasses and resolves every entry in the real command
+// tree, so neither a new class nor a renamed command can leave a refusal
+// pointing at nothing.
+var bdRelocatedClassMintPaths = map[string]string{
+	config.BeadClassGraph:     "gc sling",
+	config.BeadClassMessaging: "gc mail send",
+	config.BeadClassSessions:  "gc session new",
+	config.BeadClassOrders:    "gc order run",
+	config.BeadClassNudges:    "gc nudge",
+}
+
+// bdRelocatedClassCreateShapeFlags are the create-dialect flags that state a
+// prospective bead's CLASS, and how each lands on the bead the classifier
+// judges. Title, priority, description and assignee are absent because
+// classification does not read them — they are stepped over, not modeled.
+var bdRelocatedClassCreateShapeFlags = map[string]func(*beads.Bead, string){
+	"--type":     bdRelocatedClassCreateSetType,
+	"-t":         bdRelocatedClassCreateSetType,
+	"--labels":   bdRelocatedClassCreateAddLabels,
+	"-l":         bdRelocatedClassCreateAddLabels,
+	"--label":    bdRelocatedClassCreateAddLabels,
+	"--metadata": bdRelocatedClassCreateAddMetadata,
+}
+
+// bdRelocatedClassCreateSetType records a --type value on the prospective bead.
+func bdRelocatedClassCreateSetType(shape *beads.Bead, value string) {
+	shape.Type = strings.TrimSpace(value)
+}
+
+// bdRelocatedClassCreateAddLabels records a --labels value, which bd parses as
+// a comma-separated list (a cobra StringSlice), so `-l triage,gc:nudge` states
+// two labels and the second one decides the class.
+func bdRelocatedClassCreateAddLabels(shape *beads.Bead, value string) {
+	for _, label := range strings.Split(value, ",") {
+		if label = strings.TrimSpace(label); label != "" {
+			shape.Labels = append(shape.Labels, label)
+		}
+	}
+}
+
+// bdRelocatedClassCreateAddMetadata records a --metadata value, which bd parses
+// as a JSON object. It decodes through beads.StringMap so a value bd stores as
+// a JSON number or boolean reads here exactly as it reads back off the wire.
+//
+// A body this cannot decode — malformed JSON, or the `@file.json` spelling
+// whose object is not in argv at all — contributes nothing, and that is not a
+// swallowed error: bd applies the identical parse and exits non-zero WITHOUT
+// writing when it fails, so a token unreadable here cannot become a bead
+// either. The `@file.json` case is a real limit and is documented on
+// bdRelocatedClassCreateShape with the other file-borne shapes.
+func bdRelocatedClassCreateAddMetadata(shape *beads.Bead, value string) {
+	var fields beads.StringMap
+	if err := json.Unmarshal([]byte(value), &fields); err != nil {
+		return
+	}
+	if shape.Metadata == nil {
+		shape.Metadata = beads.StringMap{}
+	}
+	for key, text := range fields {
+		shape.Metadata[key] = text
+	}
+}
+
+// bdRelocatedClassCreateShape builds the bead a create WOULD mint, from the
+// only evidence this seam has: argv.
+//
+// It reads the three fields coordclass.Classify decides on — type, labels,
+// metadata — in every spelling cobra accepts for them: separated
+// (`--type message`), inline (`--type=message`), and attached shorthand
+// (`-tmessage`). Any other flag is stepped over, and its value with it when the
+// pinned manifest says it takes one separately, so a title like `--title
+// --type` can never be read as the flag it spells.
+//
+// Two shapes are NOT stated in argv and are deliberately not guessed at:
+//
+//   - `create -f plan.md` and `create --graph <json>` take their beads from a
+//     file or a plan body. Parsing either would mean reimplementing bd's own
+//     parser here and drifting from it; classifying them by their absent argv
+//     would be a confident wrong answer.
+//   - A shorthand CLUSTER (`-qtmessage`) hides the type behind another
+//     shorthand. Decomposing one needs to know which letters take values, which
+//     bdflags pins per FLAG rather than per letter.
+//
+// Both are documented limits rather than fail-closed refusals: a create whose
+// shape this cannot read is forwarded, exactly as it is today, and refusing
+// every bulk create on a split city would break the ordinary work mints the
+// work ledger exists for. The guard is a floor on stranded mints, not a proof
+// of their impossibility — the migration's containment check is what audits
+// beads already on disk.
+func bdRelocatedClassCreateShape(manifest string, verbArgs []string) beads.Bead {
+	values := bdflags.ValueFlags(manifest)
+	var shape beads.Bead
+	for i := 0; i < len(verbArgs); i++ {
+		name, value, stated := bdRelocatedClassCreateFlagValue(verbArgs[i])
+		apply, statesTheShape := bdRelocatedClassCreateShapeFlags[name]
+		switch {
+		case !statesTheShape:
+			if !stated && values[name] {
+				i++
+			}
+		case stated:
+			apply(&shape, value)
+		case i+1 < len(verbArgs):
+			i++
+			apply(&shape, verbArgs[i])
+		}
+	}
+	return shape
+}
+
+// bdRelocatedClassCreateFlagValue splits one argv token into the flag it names
+// and the value it states inside the same token, if any.
+//
+// cobra accepts a value flag two ways without a following token: `--type=x`
+// and the attached shorthand `-tx`. Reading only the first left `-tmessage`
+// classifying as an unnamed type, which is a create the guard would have
+// forwarded on a spelling bd itself accepts.
+func bdRelocatedClassCreateFlagValue(arg string) (name, value string, stated bool) {
+	if name, value, inline := strings.Cut(arg, "="); inline {
+		return name, value, true
+	}
+	if len(arg) > 2 && arg[0] == '-' && arg[1] != '-' {
+		return arg[:2], arg[2:], true
+	}
+	return arg, "", false
+}
+
+// bdRelocatedClassCreateRefusal reports whether a `gc bd` invocation would mint
+// a bead of a class this city serves from a storage binding, and returns the
+// operator-facing refusal when it would.
+//
+// This is the write side of the same split the read guard above covers, and it
+// fails differently: a blind READ answers emptily and can be re-run once the
+// operator knows better, while a blind CREATE leaves a row in the wrong ledger
+// under the wrong prefix — a bead no later read finds, and no migration moves,
+// because renaming it into the class namespace afterwards is not something any
+// backend can do.
+//
+// It refuses rather than reroutes because rerouting is impossible on this seam:
+// only argv crosses to the bd subprocess, and the binding is opened in process.
+// The gc-native commands in bdRelocatedClassMintPaths are the supported doors,
+// and the refusal names the one that fits.
+//
+// The classifier is coordclass.Classify — the production one the router and the
+// migration use — and not a lookalike label list. The split is not type-shaped:
+// an extmsg record is a type=task bead carrying a gc:extmsg-* label and a nudge
+// is a type=chore bead, so any table written here would have to relearn the
+// boundary and would drift from it.
+//
+// An undecidable verb (a subcommand hidden behind an unrecognized root flag)
+// returns no refusal, unlike the read scan's fail-closed judgment of every
+// remaining token: there is nothing to fail closed ABOUT, because bd rejects
+// the unknown flag before creating anything, so no mint can occur either way.
+func bdRelocatedClassCreateRefusal(cfg *config.City, bdArgs []string) (string, bool) {
+	relocated := relocatedBeadClasses(cfg)
+	if len(relocated) == 0 {
+		return "", false
+	}
+	verb, verbArgs, resolved := bdRelocatedClassVerb(bdArgs)
+	if !resolved {
+		return "", false
+	}
+	manifest, mints := bdRelocatedClassCreateVerbs[verb]
+	if !mints {
+		return "", false
+	}
+	// A work-class shape matches nothing: relocatedBeadClasses never names the
+	// work class, which is the residual one and the one bd's ledger holds.
+	class := coordclass.Classify(bdRelocatedClassCreateShape(manifest, verbArgs))
+	for _, candidate := range relocated {
+		if candidate.Class == class.String() {
+			return bdRelocatedClassCreateRefusalText(verb, candidate), true
+		}
+	}
+	return "", false
+}
+
+// bdRelocatedClassCreateRefusalText renders the refusal for one stranded mint:
+// what the create would make, where beads of that kind actually live, and the
+// command that mints one there.
+//
+// It is built here rather than in internal/beads because that package's
+// relocated-class messages are READ-shaped — they steer the reader to `gc bd
+// show` and the federated projections — and a create needs the opposite advice.
+func bdRelocatedClassCreateRefusalText(verb string, class beads.RelocatedClass) string {
+	where := strings.TrimSpace(class.Location)
+	if where == "" {
+		where = "another store"
+	}
+	mint := ""
+	if path := bdRelocatedClassMintPaths[class.Class]; path != "" {
+		mint = fmt.Sprintf(" Mint it with `%s`, which writes the binding that class is served from.", path)
+	}
+	return fmt.Sprintf("bd %s would mint a %s-class bead, and this city serves %s-class beads (id prefix %q) from %s. "+
+		"bd writes the work ledger and nothing else, so the bead would land where the %s subsystem never reads it — and "+
+		"nothing would report that, because bd would have done exactly what it was asked. A bead minted under the work "+
+		"prefix cannot be moved into the class namespace afterwards, so this is refused before anything is written.%s",
+		verb, class.Class, class.Class, class.IDPrefix+"-", where, class.Class, mint)
 }
 
 // relocatedClassLocation describes where a binding serves from, for the

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -1383,7 +1383,7 @@ func TestBdCreateRefusesInfraShapedCreateOnSplitCity(t *testing.T) {
 		"graph node by metadata":        {[]string{"create", "--metadata", `{"gc.root_bead_id":"gcg-abc123"}`, "x"}, []string{"graph-class", "gc sling"}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), tc.args)
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", tc.args)
 			if !refused {
 				t.Fatalf("`gc bd %s` was forwarded to bd on a split city; bd writes the work ledger only, so that mint is stranded", strings.Join(tc.args, " "))
 			}
@@ -1396,7 +1396,7 @@ func TestBdCreateRefusesInfraShapedCreateOnSplitCity(t *testing.T) {
 				"no storage section":  nil,
 				"every class on work": allWorkCityConfig(),
 			} {
-				if msg, refused := bdRelocatedClassCreateRefusal(cfg, tc.args); refused {
+				if msg, refused := bdRelocatedClassCreateRefusal(cfg, "", tc.args); refused {
 					t.Errorf("a city with %s relocates nothing, so this create is not stranded, but it was refused: %q", cityName, msg)
 				}
 			}
@@ -1427,7 +1427,7 @@ func TestBdCreateForwardsAWorkShapedCreateOnASplitCity(t *testing.T) {
 		"show is not a create verb":  {"show", "gcm-abc123"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args); refused {
+			if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", args); refused {
 				t.Fatalf("`gc bd %s` mints a work bead into the work ledger, which is where it belongs, but it was refused: %q", strings.Join(args, " "), msg)
 			}
 		})
@@ -1597,7 +1597,7 @@ func TestBdCreateClassifiesAGraphPlanCreateOnASplitCity(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			args := spell(writeGraphPlanFile(t, graphMarkedPlan()))
-			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args)
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", args)
 			if !refused {
 				t.Fatalf("`gc bd %s` forwards a graph-apply plan to bd on a split city, stranding a graph-class bead", strings.Join(args, " "))
 			}
@@ -1610,7 +1610,7 @@ func TestBdCreateClassifiesAGraphPlanCreateOnASplitCity(t *testing.T) {
 				"no storage section":  nil,
 				"every class on work": allWorkCityConfig(),
 			} {
-				if msg, refused := bdRelocatedClassCreateRefusal(cfg, args); refused {
+				if msg, refused := bdRelocatedClassCreateRefusal(cfg, "", args); refused {
 					t.Errorf("a city with %s relocates nothing, but the graph create was refused: %q", cityName, msg)
 				}
 			}
@@ -1624,7 +1624,7 @@ func TestBdCreateClassifiesAGraphPlanCreateOnASplitCity(t *testing.T) {
 // ledger where it belongs.
 func TestBdCreateForwardsAWorkOnlyGraphPlanOnASplitCity(t *testing.T) {
 	args := []string{"create", "--graph", writeGraphPlanFile(t, workOnlyPlan()), "--json"}
-	if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args); refused {
+	if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", args); refused {
 		t.Fatalf("a work-only graph plan belongs in the work ledger, but it was refused: %q", msg)
 	}
 }
@@ -1643,7 +1643,7 @@ func TestBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity(t *testing.T) {
 		"through the alias": {"new", "-f", "issues.md"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args)
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", args)
 			if !refused {
 				t.Fatalf("`gc bd %s` reads beads from a file this guard cannot classify, but it was forwarded on a split city", strings.Join(args, " "))
 			}
@@ -1658,7 +1658,7 @@ func TestBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity(t *testing.T) {
 				"no storage section":  nil,
 				"every class on work": allWorkCityConfig(),
 			} {
-				if msg, refused := bdRelocatedClassCreateRefusal(cfg, args); refused {
+				if msg, refused := bdRelocatedClassCreateRefusal(cfg, "", args); refused {
 					t.Errorf("a city with %s relocates nothing, so a file-backed create strands nothing, but it was refused: %q", cityName, msg)
 				}
 			}
@@ -1710,5 +1710,151 @@ func TestGcBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity(t *testing.T) 
 	if _, err := os.Stat(capture); err == nil {
 		data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
 		t.Fatalf("bd was invoked despite the fail-closed refusal: %q", data)
+	}
+}
+
+// TestBdCreateRefusesAnInfraShapedCreateBehindABdRootFlag pins the guard
+// against the flags that used to switch it off.
+//
+// bd accepts its root flags BEFORE the subcommand, and four of them consume the
+// next argument as a value (`--profile`, `--database`, `--server-url`,
+// `--mem-profile`). A global manifest that filed `--profile` as a bool and did
+// not know the other three left bdRelocatedClassVerb reading a flag's VALUE as
+// the verb (`--profile default create …` resolves to "default") or reporting the
+// argv undecidable — and both answers forward the create. bd accepts every one
+// of these flags and goes on to mint, so the disarmed guard was the only thing
+// between an ordinary invocation and a stranded bead.
+func TestBdCreateRefusesAnInfraShapedCreateBehindABdRootFlag(t *testing.T) {
+	for name, prefix := range map[string][]string{
+		"--profile":              {"--profile", "default"},
+		"--profile inline":       {"--profile=default"},
+		"--database":             {"--database", "beads_other"},
+		"--server-url":           {"--server-url", "http://127.0.0.1:8080"},
+		"--mem-profile":          {"--mem-profile", "/tmp/heap.out"},
+		"--no-color":             {"--no-color"},
+		"--cpu-profile":          {"--cpu-profile"},
+		"stacked with the known": {"--json", "--mem-profile", "/tmp/heap.out", "-C", "/d"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			args := append(append([]string{}, prefix...), "create", "--type", "message", "hello")
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", args)
+			if !refused {
+				t.Fatalf("`gc bd %s` reached bd unguarded on a split city; the root flag disarmed the create guard", strings.Join(args, " "))
+			}
+			if !strings.Contains(msg, "messaging-class") || !strings.Contains(msg, "gc mail send") {
+				t.Errorf("refusal does not name the class and its mint path; msg=%q", msg)
+			}
+			// The same prefix in front of a work-shaped create must still pass
+			// through: completing the manifest resolves the verb, it does not
+			// turn a root flag into a refusal of its own.
+			work := append(append([]string{}, prefix...), "create", "--type", "task", "hello")
+			if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), "", work); refused {
+				t.Errorf("`gc bd %s` mints a work bead into the work ledger, but it was refused: %q", strings.Join(work, " "), msg)
+			}
+		})
+	}
+}
+
+// TestBdCreateClassifiesARelativeGraphPlanAgainstTheScopeRoot pins the root a
+// `--graph` path is resolved against.
+//
+// doBd runs the bd subprocess with cmd.Dir = target.ScopeRoot, so bd reads a
+// relative plan path from THERE while this guard reads it in the wrapper's own
+// cwd. When those differ, the guard's read fails, the plan classifies as
+// nothing, and the create is forwarded — after which bd finds the plan and mints
+// the relocated-class bead the guard exists to stop.
+func TestBdCreateClassifiesARelativeGraphPlanAgainstTheScopeRoot(t *testing.T) {
+	scopeRoot := t.TempDir()
+	data, err := json.Marshal(graphMarkedPlan())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scopeRoot, "plan.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Stand somewhere the plan is NOT, which is the whole point: an operator or
+	// agent naming a scope-root-relative path from a subdirectory.
+	t.Chdir(t.TempDir())
+
+	msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), scopeRoot, []string{"create", "--graph", "plan.json"})
+	if !refused {
+		t.Fatalf("a scope-root-relative graph plan was forwarded to bd, which reads it from the scope root and mints it; msg=%q", msg)
+	}
+	if !strings.Contains(msg, "graph-class") || !strings.Contains(msg, "gc sling") {
+		t.Errorf("refusal does not name the class and its mint path; msg=%q", msg)
+	}
+
+	// An absolute path is already unambiguous and must not be re-rooted.
+	absolute := []string{"create", "--graph", writeGraphPlanFile(t, graphMarkedPlan())}
+	if _, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), scopeRoot, absolute); !refused {
+		t.Error("an absolute graph plan path was re-rooted against the scope root and lost")
+	}
+
+	// The class still decides: a work-only plan at the same relative path is
+	// forwarded, so resolving the path did not turn `--graph` into a refusal.
+	workData, err := json.Marshal(workOnlyPlan())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scopeRoot, "work.json"), workData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), scopeRoot, []string{"create", "--graph", "work.json"}); refused {
+		t.Errorf("a work-only graph plan belongs in the work ledger, but it was refused: %q", msg)
+	}
+}
+
+// TestGcBdCreateRefusesARelativeGraphPlanFromAnotherDirectory drives the
+// scope-root resolution through the real command: `gc bd` invoked from outside
+// the store root, naming the plan the way bd itself will read it, still exits
+// non-zero without spawning bd.
+//
+// The second invocation pins the same refusal behind bd's own `-C/--directory`.
+// bd's help text reads like a cwd change ("like git -C"), but `-C` selects the
+// beads PROJECT bd opens, not the base for a relative path argument, so the
+// scope root remains the only root either side resolves against. That is the
+// claim the guard's doc comment makes, and without this row it rests on observed
+// bd behavior with nothing in the build behind it.
+func TestGcBdCreateRefusesARelativeGraphPlanFromAnotherDirectory(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	scopeRoot := os.Getenv("GC_CITY_PATH")
+	data, err := json.Marshal(graphMarkedPlan())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scopeRoot, "plan.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"create", "--graph", "plan.json"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0 on a stranded graph mint named relative to the scope root; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "graph-class") {
+		t.Errorf("refusal is missing the class; stderr=%q", stderr.String())
+	}
+	if _, err := os.Stat(capture); err == nil {
+		body, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked despite the refusal: %q", body)
+	}
+
+	// A `-C` directory that is neither the cwd nor the scope root, and that no
+	// rig claims: resolveRigForDir finds no match and leaves the scope root
+	// unchanged, so the guard reads the same plan and refuses the same way. The
+	// refusal fires before bd is invoked, so no subprocess runs and no mint is
+	// possible regardless of how bd would have read the path.
+	otherDir := t.TempDir()
+	stdout.Reset()
+	stderr.Reset()
+	if code := doBd([]string{"create", "-C", otherDir, "--graph", "plan.json"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0 on the same stranded graph mint behind `-C`; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "graph-class") {
+		t.Errorf("refusal behind `-C` is missing the class; stderr=%q", stderr.String())
+	}
+	if _, err := os.Stat(capture); err == nil {
+		body, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked despite the refusal behind `-C`: %q", body)
 	}
 }

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1336,5 +1337,204 @@ func TestGcBdSQLIsUnchangedOnASingleStoreCity(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "gcg-abc123") {
 		t.Fatalf("bd received %q, want the unmodified query", data)
+	}
+}
+
+// TestBdCreateRefusesInfraShapedCreateOnSplitCity is the stranded mint, caught
+// from the only evidence the passthrough has: the shape argv states.
+//
+// `gc bd create` hands its arguments to bd, and bd writes one ledger — the work
+// one. On a city that serves a coordination class from a storage binding, a
+// create whose shape belongs to that class lands the bead in the ledger the
+// class is no longer read from, and nothing reports it, because bd did exactly
+// what it was asked and exited 0. Placement is impossible on this seam (only
+// argv crosses it), so the create is refused at the boundary instead.
+//
+// Every row asserts the same three facts an operator needs to act: the class,
+// where its beads actually live, and the gc-native command that mints one
+// correctly. Each row also runs against a city that relocates nothing, where
+// the identical argv must pass through untouched — the single-store
+// compatibility claim, checked per row rather than once.
+func TestBdCreateRefusesInfraShapedCreateOnSplitCity(t *testing.T) {
+	messaging := []string{"messaging-class", `"gcm-"`, `"infra" storage binding`, "gc mail send"}
+	for name, tc := range map[string]struct {
+		args []string
+		want []string
+	}{
+		"mail by type":            {[]string{"create", "--type", "message", "hello"}, messaging},
+		"mail by type shorthand":  {[]string{"create", "-t", "message", "hello"}, messaging},
+		"mail by inline type":     {[]string{"create", "--type=message", "hello"}, messaging},
+		"mail by attached type":   {[]string{"create", "-tmessage", "hello"}, messaging},
+		"mail behind a root flag": {[]string{"--json", "create", "--type", "message", "hello"}, messaging},
+		"mail through the alias":  {[]string{"new", "--type", "message", "hello"}, messaging},
+		// The title is not the shape. A bead titled "message" is a work bead.
+		"mail type beside a title flag": {[]string{"create", "--title", "ship it", "--type", "message"}, messaging},
+		// The reason the classifier has to be the runtime one: an extmsg record
+		// is a type=task bead, indistinguishable from work by type alone.
+		"extmsg by label":               {[]string{"create", "--type", "task", "--labels", "gc:extmsg-binding", "x"}, messaging},
+		"extmsg in a label list":        {[]string{"create", "-l", "triage,gc:extmsg-delivery", "x"}, messaging},
+		"session by type":               {[]string{"create", "--type", "session", "x"}, []string{"sessions-class", `"gcs-"`, "gc session new"}},
+		"session by label":              {[]string{"create", "--label", "gc:session", "x"}, []string{"sessions-class", "gc session new"}},
+		"session through quick capture": {[]string{"q", "-t", "session", "x"}, []string{"sessions-class", "gc session new"}},
+		"nudge by label":                {[]string{"create", "--type", "chore", "-l", "gc:nudge", "x"}, []string{"nudges-class", `"gcn-"`, "gc nudge"}},
+		"order tracking by label":       {[]string{"create", "--type", "task", "-l", "order-tracking", "x"}, []string{"orders-class", `"gco-"`, "gc order run"}},
+		"wisp by metadata":              {[]string{"create", "--metadata", `{"gc.kind":"wisp"}`, "x"}, []string{"graph-class", `"gcg-"`, "gc sling"}},
+		"graph node by metadata":        {[]string{"create", "--metadata", `{"gc.root_bead_id":"gcg-abc123"}`, "x"}, []string{"graph-class", "gc sling"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), tc.args)
+			if !refused {
+				t.Fatalf("`gc bd %s` was forwarded to bd on a split city; bd writes the work ledger only, so that mint is stranded", strings.Join(tc.args, " "))
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(msg, want) {
+					t.Errorf("refusal is missing %q; msg=%q", want, msg)
+				}
+			}
+			for cityName, cfg := range map[string]*config.City{
+				"no storage section":  nil,
+				"every class on work": allWorkCityConfig(),
+			} {
+				if msg, refused := bdRelocatedClassCreateRefusal(cfg, tc.args); refused {
+					t.Errorf("a city with %s relocates nothing, so this create is not stranded, but it was refused: %q", cityName, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestBdCreateForwardsAWorkShapedCreateOnASplitCity is the false-positive proof.
+//
+// A split city still mints work beads through this passthrough — that is what
+// the work ledger is for — so the guard must fire on the SHAPE and on nothing
+// else. A title that reads like a class, a label that is merely near one, and
+// an id-valued flag naming a relocated bead are all left alone here: the last
+// belongs to the by-id ownership door in cmd_bd_by_id.go, which names the bead
+// rather than the class, and a second refusal on this seam would shadow it with
+// a vaguer message while adding no coverage.
+func TestBdCreateForwardsAWorkShapedCreateOnASplitCity(t *testing.T) {
+	for name, args := range map[string][]string{
+		"bare create":                {"create", "plain work"},
+		"explicit task":              {"create", "-t", "task", "plain work"},
+		"task with labels":           {"create", "--type", "task", "--labels", "triage,p1", "x"},
+		"title that reads as a type": {"create", "--title", "message", "-t", "task"},
+		"label near but not a class": {"create", "-l", "gc:nudged", "x"},
+		"epic":                       {"create", "--type", "epic", "roll up"},
+		"convoy":                     {"create", "--type", "convoy", "batch"},
+		"id-valued flag":             {"create", "--type", "task", "--parent", "gcg-abc123", "x"},
+		"not a create verb":          {"list", "--type", "message", "--json"},
+		"show is not a create verb":  {"show", "gcm-abc123"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args); refused {
+				t.Fatalf("`gc bd %s` mints a work bead into the work ledger, which is where it belongs, but it was refused: %q", strings.Join(args, " "), msg)
+			}
+		})
+	}
+}
+
+// TestGcBdCreateRefusesAnInfraShapedCreateOnASplitCity drives the refusal
+// through the real command: the exit code is non-zero and bd is never spawned,
+// so nothing is written anywhere.
+func TestGcBdCreateRefusesAnInfraShapedCreateOnASplitCity(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"create", "--type", "message", "hello"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0 on a stranded mint; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"messaging-class", `"infra" storage binding`, "gc mail send"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("refusal is missing %q; stderr=%q", want, stderr.String())
+		}
+	}
+	if _, err := os.Stat(capture); err == nil {
+		data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked despite the refusal: %q", data)
+	}
+}
+
+// TestGcBdCreateRefusalIsNotLiftedByTheReadOverride pins the one thing the
+// existing escape hatch must not reach.
+//
+// GC_BD_ALLOW_RELOCATED_CLASS_READ exists because the READ scan classifies
+// text, and text is not always decidable — an operator holding a false positive
+// needs a way to run the query anyway. A refused create is not that: it is a
+// WRITE that would leave a row in the wrong ledger, where no later read can
+// find it and no migration will move it. Honoring the read knob here would turn
+// an escape hatch into a data-loss switch.
+func TestGcBdCreateRefusalIsNotLiftedByTheReadOverride(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	t.Setenv(bdRelocatedClassOverrideEnvVar, "1")
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"create", "--type", "message", "hello"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("the read override let a stranded mint through; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(capture); err == nil {
+		data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked with the read override set: %q", data)
+	}
+}
+
+// TestGcBdCreateIsUnchangedOnASingleStoreCity is the compatibility proof end to
+// end: the exact invocation a split city refuses reaches bd verbatim, and
+// succeeds, on a city that relocates nothing.
+func TestGcBdCreateIsUnchangedOnASingleStoreCity(t *testing.T) {
+	for name, tc := range map[string]struct {
+		storage string
+		args    []string
+	}{
+		"infra shape, no split": {"", []string{"create", "--type", "message", "hello"}},
+		"work shape, split":     {bdSQLRefusalSplitStorage, []string{"create", "--type", "task", "hello"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			capture := bdSQLRefusalCity(t, tc.storage)
+			t.Setenv("BD_STUB_STDOUT", `{"id":"demo-1"}`)
+
+			var stdout, stderr bytes.Buffer
+			if code := doBd(tc.args, &stdout, &stderr); code != 0 {
+				t.Fatalf("doBd = %d; stderr=%q", code, stderr.String())
+			}
+			data, err := os.ReadFile(capture)
+			if err != nil {
+				t.Fatalf("bd was not invoked: %v", err)
+			}
+			if !strings.Contains(string(data), strings.Join(tc.args, " ")) {
+				t.Fatalf("bd received %q, want the create forwarded verbatim", data)
+			}
+		})
+	}
+}
+
+// TestBdRelocatedClassCreateNamesAMintPathForEveryRelocatableClass is the
+// anti-drift pin on the one part of the refusal an operator acts on.
+//
+// A refusal that names no alternative leaves the operator with a command that
+// does not work and no command that does, and the failure mode of a hand-kept
+// table is that a class grows without one. So the table is checked against the
+// same class list the migration uses, and each command it names is resolved in
+// the real cobra tree rather than trusted as a string.
+func TestBdRelocatedClassCreateNamesAMintPathForEveryRelocatableClass(t *testing.T) {
+	root := newRootCmdWithOptions(io.Discard, io.Discard, rootCommandOptions{})
+	for _, class := range infraMigrationClasses {
+		path, named := bdRelocatedClassMintPaths[string(class)]
+		if !named {
+			t.Errorf("class %q can be relocated but the refusal names no gc-native command that mints one", class)
+			continue
+		}
+		words := strings.Fields(path)
+		if len(words) < 2 || words[0] != "gc" {
+			t.Errorf("class %q names mint path %q, which is not a `gc ...` command", class, path)
+			continue
+		}
+		cmd, _, err := root.Find(words[1:])
+		if err != nil {
+			t.Errorf("class %q names mint path %q, which does not resolve: %v", class, path, err)
+			continue
+		}
+		if cmd.Name() != words[len(words)-1] {
+			t.Errorf("class %q names mint path %q, which resolved to `gc %s` instead", class, path, cmd.CommandPath())
+		}
 	}
 }

--- a/cmd/gc/bd_relocated_classes_test.go
+++ b/cmd/gc/bd_relocated_classes_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -1536,5 +1537,178 @@ func TestBdRelocatedClassCreateNamesAMintPathForEveryRelocatableClass(t *testing
 		if cmd.Name() != words[len(words)-1] {
 			t.Errorf("class %q names mint path %q, which resolved to `gc %s` instead", class, path, cmd.CommandPath())
 		}
+	}
+}
+
+// writeGraphPlanFile marshals a plan to the exact JSON wire shape bd's
+// `create --graph <file>` consumes — internal/beads.ApplyGraphPlanWithStorage
+// json.Marshals this same struct before handing the path to bd — and returns the
+// file path. Building it from the struct rather than a string literal is what
+// makes the test's plan and bd's plan provably the same format.
+func writeGraphPlanFile(t *testing.T, plan beads.GraphApplyPlan) string {
+	t.Helper()
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshaling graph plan: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "plan.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("writing graph plan: %v", err)
+	}
+	return path
+}
+
+// graphMarkedPlan is a minimal plan whose root node carries a graph marker
+// (gc.root_bead_id), so coordclass.ClassifyGraphPlan routes the whole plan to
+// ClassGraph — the shape a formula pour applies through `create --graph`.
+func graphMarkedPlan() beads.GraphApplyPlan {
+	return beads.GraphApplyPlan{Nodes: []beads.GraphApplyNode{{
+		Key:      "root",
+		Title:    "workflow root",
+		Type:     "task",
+		Metadata: map[string]string{"gc.root_bead_id": "gcg-abc123"},
+	}}}
+}
+
+// workOnlyPlan is a plan of plain work nodes with no graph markers, so
+// ClassifyGraphPlan falls to its root node and classifies ClassWork: a graph
+// create that belongs in the work ledger even on a split city.
+func workOnlyPlan() beads.GraphApplyPlan {
+	return beads.GraphApplyPlan{Nodes: []beads.GraphApplyNode{{
+		Key:   "root",
+		Title: "plain work",
+		Type:  "task",
+	}}}
+}
+
+// TestBdCreateClassifiesAGraphPlanCreateOnASplitCity is the graph-door fix. A
+// `create --graph <plan>` carries its beads inside a file the argv-shape walk
+// never sees, so before this the highest-value infra shape — a graph-apply plan
+// — classified as work and forwarded, stranding a graph-class bead in the work
+// ledger. The plan is JSON in the beads.GraphApplyPlan shape bd consumes, so it
+// is classified with the production coordclass.ClassifyGraphPlan and refused
+// when it names a relocated class, across every spelling of the flag.
+func TestBdCreateClassifiesAGraphPlanCreateOnASplitCity(t *testing.T) {
+	for name, spell := range map[string]func(path string) []string{
+		"separated":   func(p string) []string { return []string{"create", "--graph", p, "--json"} },
+		"inline":      func(p string) []string { return []string{"create", "--graph=" + p} },
+		"alias":       func(p string) []string { return []string{"new", "--graph", p} },
+		"after title": func(p string) []string { return []string{"create", "--title", "roll up", "--graph", p} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			args := spell(writeGraphPlanFile(t, graphMarkedPlan()))
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args)
+			if !refused {
+				t.Fatalf("`gc bd %s` forwards a graph-apply plan to bd on a split city, stranding a graph-class bead", strings.Join(args, " "))
+			}
+			for _, want := range []string{"graph-class", `"gcg-"`, "gc sling"} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("refusal is missing %q; msg=%q", want, msg)
+				}
+			}
+			for cityName, cfg := range map[string]*config.City{
+				"no storage section":  nil,
+				"every class on work": allWorkCityConfig(),
+			} {
+				if msg, refused := bdRelocatedClassCreateRefusal(cfg, args); refused {
+					t.Errorf("a city with %s relocates nothing, but the graph create was refused: %q", cityName, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestBdCreateForwardsAWorkOnlyGraphPlanOnASplitCity is the graph-door
+// false-positive proof: the guard fires on the plan's CLASS, not on the mere
+// presence of `--graph`, so a plan of plain work nodes still mints into the work
+// ledger where it belongs.
+func TestBdCreateForwardsAWorkOnlyGraphPlanOnASplitCity(t *testing.T) {
+	args := []string{"create", "--graph", writeGraphPlanFile(t, workOnlyPlan()), "--json"}
+	if msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args); refused {
+		t.Fatalf("a work-only graph plan belongs in the work ledger, but it was refused: %q", msg)
+	}
+}
+
+// TestBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity pins the -f/--file
+// decision. bd's multi-issue markdown states per-issue type and labels that CAN
+// name a relocated class, and reparsing that format here would drift from bd, so
+// on a split city these create forms fail closed rather than forward a payload
+// the guard cannot classify. A city that relocates nothing forwards them.
+func TestBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity(t *testing.T) {
+	for name, args := range map[string][]string{
+		"-f separated":      {"create", "-f", "issues.md", "x"},
+		"--file separated":  {"create", "--file", "issues.md"},
+		"--file inline":     {"create", "--file=issues.md"},
+		"-f attached":       {"create", "-fissues.md"},
+		"through the alias": {"new", "-f", "issues.md"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			msg, refused := bdRelocatedClassCreateRefusal(splitCityConfig(), args)
+			if !refused {
+				t.Fatalf("`gc bd %s` reads beads from a file this guard cannot classify, but it was forwarded on a split city", strings.Join(args, " "))
+			}
+			// The message must explain the file-backed limit and leave the
+			// operator a classified door, not just say no.
+			for _, want := range []string{"file", "gc sling", "gc mail send"} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("fail-closed refusal is missing %q; msg=%q", want, msg)
+				}
+			}
+			for cityName, cfg := range map[string]*config.City{
+				"no storage section":  nil,
+				"every class on work": allWorkCityConfig(),
+			} {
+				if msg, refused := bdRelocatedClassCreateRefusal(cfg, args); refused {
+					t.Errorf("a city with %s relocates nothing, so a file-backed create strands nothing, but it was refused: %q", cityName, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestGcBdCreateRefusesAGraphPlanCreateOnASplitCity drives the graph-door fix
+// through the real command: a graph-apply plan on a split city exits non-zero
+// and bd is never spawned, so nothing is written anywhere.
+func TestGcBdCreateRefusesAGraphPlanCreateOnASplitCity(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	planPath := writeGraphPlanFile(t, graphMarkedPlan())
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"create", "--graph", planPath, "--json"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0 on a stranded graph mint; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"graph-class", "gc sling"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("refusal is missing %q; stderr=%q", want, stderr.String())
+		}
+	}
+	if _, err := os.Stat(capture); err == nil {
+		data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked despite the refusal: %q", data)
+	}
+}
+
+// TestGcBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity drives the
+// -f/--file decision through the real command: even a work-only markdown file is
+// refused on a split city — the guard classifies from argv and will not reparse
+// bd's file format, so it cannot prove the file mints no relocated bead — and bd
+// is never spawned.
+func TestGcBdCreateFailsClosedOnAFileBackedBulkCreateOnASplitCity(t *testing.T) {
+	capture := bdSQLRefusalCity(t, bdSQLRefusalSplitStorage)
+	mdPath := filepath.Join(t.TempDir(), "issues.md")
+	if err := os.WriteFile(mdPath, []byte("## plain work\nType: task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"create", "-f", mdPath}, &stdout, &stderr); code == 0 {
+		t.Fatalf("doBd exited 0 on a file-backed create; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "file") {
+		t.Errorf("fail-closed refusal does not explain the file-backed limit; stderr=%q", stderr.String())
+	}
+	if _, err := os.Stat(capture); err == nil {
+		data, _ := os.ReadFile(capture) //nolint:errcheck // diagnostic only
+		t.Fatalf("bd was invoked despite the fail-closed refusal: %q", data)
 	}
 }

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -221,6 +221,17 @@ func rewriteBdHeartbeatArgs(bdArgs []string) ([]string, error) {
 // preflight cannot interpret exactly are refused before bd can mutate state.
 func bdRigQualifiedMetadataRefusal(cfg *config.City, bdArgs []string) (string, bool) {
 	verb, args := bdflags.SplitGlobalFlags(bdArgs)
+	// bd registers `new` as an alias for `create` (bd create --help: "Aliases:
+	// create, new"), so the alias has to reach the same admission check AND the
+	// same flag manifest. Normalizing here covers both, because those are the
+	// only two things verb is read for. The gate alone would not: bdflags keys
+	// its manifests under the canonical verb only and performs no alias
+	// normalization, so ValueFlags("new") is nil, and an empty manifest steps
+	// over no value — the failure mode globalValueFlags' doc comment calls
+	// load-bearing.
+	if verb == "new" {
+		verb = "create"
+	}
 	if verb != "create" && verb != "update" {
 		return "", false
 	}
@@ -383,7 +394,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// prospective bead's CLASS and never an addressed id, so a create that names
 	// a relocated bead in --parent still reaches the ownership refusal, which
 	// names that bead. When both are true the mint is what has to be stopped.
-	if msg, stranded := bdRelocatedClassCreateRefusal(cfg, bdArgs); stranded {
+	if msg, stranded := bdRelocatedClassCreateRefusal(cfg, target.ScopeRoot, bdArgs); stranded {
 		fmt.Fprintf(stderr, "gc bd: %s\n", msg) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -365,6 +365,28 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		// refused travels with the result they are about to trust.
 		fmt.Fprintf(stderr, "gc bd: %s is set; running anyway: %s\n", bdRelocatedClassOverrideEnvVar, msg) //nolint:errcheck // best-effort stderr
 	}
+	// The same split, on the write side. `gc bd create` is a passthrough too, and
+	// bd writes the work ledger only, so a create whose SHAPE belongs to a
+	// relocated class strands the bead in a ledger that class is never read from
+	// — silently, because bd did what it was asked and exited 0. Placement is
+	// impossible here (only argv crosses to the subprocess), so the create is
+	// refused before anything is written and the refusal names the gc-native
+	// command that mints it correctly.
+	//
+	// The read override above deliberately does not reach this arm: it exists
+	// because the read scan classifies ambiguous TEXT and a refused read can be
+	// re-run, while a stranded mint leaves a row under the wrong prefix that no
+	// later read finds and no migration moves.
+	//
+	// It runs before the by-id door rather than after because the two answer
+	// different questions and cannot shadow each other: this arm reads the
+	// prospective bead's CLASS and never an addressed id, so a create that names
+	// a relocated bead in --parent still reaches the ownership refusal, which
+	// names that bead. When both are true the mint is what has to be stopped.
+	if msg, stranded := bdRelocatedClassCreateRefusal(cfg, bdArgs); stranded {
+		fmt.Fprintf(stderr, "gc bd: %s\n", msg) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	// A by-ID operation whose subject a relocated class owns is answered in
 	// process, from the binding that class is served from, and never handed to
 	// the subprocess — which opens the work workspace and cannot see the bead.

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1508,6 +1508,7 @@ printf '{"id":"scratch-1","metadata":{"written":true}}\n' > "$SCRATCH_BEAD"
 		{"whole metadata object", "update", []string{"--metadata", `{"gc.routed_to":"ghostrig/polecat-01"}`}, "ghostrig/polecat-01"},
 		{"inline metadata object", "update", []string{`--metadata={"gc.routed_to":"ghostrig/polecat-01"}`}, "ghostrig/polecat-01"},
 		{"create route target", "create", []string{"--metadata", `{"gc.routed_to":"ghostrig/polecat-01"}`}, "ghostrig/polecat-01"},
+		{"new alias route target", "new", []string{"--metadata", `{"gc.routed_to":"ghostrig/polecat-01"}`}, "ghostrig/polecat-01"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := os.WriteFile(scratchBead, []byte(original), 0o600); err != nil {
@@ -1564,22 +1565,30 @@ printf 'called' > "$BD_CAPTURE"
 
 	for _, tc := range []struct {
 		name string
+		verb string
 		args []string
 		want string
 	}{
-		{"metadata file", []string{"--metadata", "@metadata.json"}, "@file input"},
-		{"malformed metadata", []string{"--metadata", "{not-json}"}, "malformed --metadata"},
-		{"non-string guarded metadata", []string{"--metadata", `{"gc.routed_to":true}`}, "non-string gc.routed_to"},
-		{"malformed set metadata", []string{"--set-metadata", "gc.routed_to"}, "malformed --set-metadata"},
-		{"missing metadata", []string{"--metadata"}, "without a value"},
-		{"missing set metadata", []string{"--set-metadata"}, "without a value"},
+		{"metadata file", "update", []string{"--metadata", "@metadata.json"}, "@file input"},
+		{"malformed metadata", "update", []string{"--metadata", "{not-json}"}, "malformed --metadata"},
+		{"non-string guarded metadata", "update", []string{"--metadata", `{"gc.routed_to":true}`}, "non-string gc.routed_to"},
+		{"malformed set metadata", "update", []string{"--set-metadata", "gc.routed_to"}, "malformed --set-metadata"},
+		{"missing metadata", "update", []string{"--metadata"}, "without a value"},
+		{"missing set metadata", "update", []string{"--set-metadata"}, "without a value"},
+		{"new alias metadata file", "new", []string{"--metadata", "@metadata.json"}, "@file input"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := os.Remove(capture); err != nil && !os.IsNotExist(err) {
 				t.Fatal(err)
 			}
 			var stdout, stderr bytes.Buffer
-			args := append([]string{"--city", cityDir, "update", "scratch-1"}, tc.args...)
+			args := []string{"--city", cityDir, tc.verb}
+			if tc.verb == "update" {
+				args = append(args, "scratch-1")
+			} else {
+				args = append(args, "scratch")
+			}
+			args = append(args, tc.args...)
 			if got := doBd(args, &stdout, &stderr); got == 0 {
 				t.Fatalf("doBd() = 0, want refusal; stdout=%q stderr=%q", stdout.String(), stderr.String())
 			}

--- a/internal/bdflags/bdargs_test.go
+++ b/internal/bdflags/bdargs_test.go
@@ -45,15 +45,23 @@ func TestSplitGlobalFlagsSkipsGlobalFlagValues(t *testing.T) {
 // bypass below: SplitGlobalFlags would read that flag's value as the verb, and
 // every guard keyed off the verb stops firing — with no test failing.
 //
-// Sourced from `bd --help` (bd 1.1.0). bd declares exactly four persistent
-// flags that consume the next argument; -C and --directory are the two spellings
-// of one of them. Every other persistent flag (--global, --ignore-schema-skew,
-// --json, --profile, -q/--quiet, --readonly, --sandbox, -v/--verbose, -h/--help,
-// -V/--version) is boolean and consumes nothing.
+// Filing a value flag as a BOOL is the same bypass wearing a different hat: the
+// flag is skipped without its value, and the value is read as the verb. That is
+// how `--profile` sat in the bool table while bd declared it `--profile string`,
+// so `bd --profile <name> create …` resolved the verb to <name> and every
+// create-side guard went quiet. Both directions are pinned here and in
+// TestGlobalBoolFlagsIsComplete, which is why the two sets are compared exactly
+// rather than merged.
+//
+// Sourced from `bd --help` (bd 1.1.0). bd declares eight persistent flags that
+// consume the next argument — --actor, --database, --db, -C/--directory
+// (two spellings of one flag), --dolt-auto-commit, --mem-profile, --profile,
+// --server-url. Every other persistent flag is boolean and consumes nothing.
 func TestGlobalValueFlagsIsComplete(t *testing.T) {
 	want := map[string]bool{
-		"--actor": true, "--db": true, "-C": true, "--directory": true,
-		"--dolt-auto-commit": true,
+		"--actor": true, "--database": true, "--db": true, "-C": true,
+		"--directory": true, "--dolt-auto-commit": true, "--mem-profile": true,
+		"--profile": true, "--server-url": true,
 	}
 	if got := GlobalValueFlags(); !reflect.DeepEqual(got, want) {
 		t.Errorf("GlobalValueFlags() = %v, want %v; re-check `bd --help` persistent flags", got, want)
@@ -69,9 +77,10 @@ func TestGlobalValueFlagsIsComplete(t *testing.T) {
 // Sourced from `bd --help` (bd 1.1.0), the same pass as the value-flag table.
 func TestGlobalBoolFlagsIsComplete(t *testing.T) {
 	want := map[string]bool{
-		"--global": true, "--ignore-schema-skew": true, "--json": true,
-		"--profile": true, "-q": true, "--quiet": true, "--readonly": true,
-		"--sandbox": true, "-v": true, "--verbose": true, "-h": true, "--help": true,
+		"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true,
+		"--json": true, "--no-color": true, "-q": true, "--quiet": true,
+		"--readonly": true, "--sandbox": true, "-v": true, "--verbose": true,
+		"-h": true, "--help": true, "-V": true, "--version": true,
 	}
 	if got := GlobalBoolFlags(); !reflect.DeepEqual(got, want) {
 		t.Errorf("GlobalBoolFlags() = %v, want %v; re-check `bd --help` persistent flags", got, want)

--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -15,16 +15,28 @@ import (
 
 // globalValueFlags are accepted by every bd subcommand and consume the next
 // argument as their value.
+//
+// Completeness is load-bearing, not cosmetic. A caller locating the verb reads
+// the VALUE of an omitted flag as the subcommand — `--profile default create`
+// resolves to "default" — and every guard keyed off the verb then stops firing
+// on an ordinary invocation, with no test failing. Which side of the split a
+// flag lands on matters as much as its presence: a value flag filed as a bool
+// is exactly that bypass. The two are pinned separately by
+// TestGlobalValueFlagsIsComplete and TestGlobalBoolFlagsIsComplete so a
+// misfiled flag fails the build rather than silently disarming a guard.
 var globalValueFlags = map[string]bool{
-	"--actor": true, "--db": true, "-C": true, "--directory": true,
-	"--dolt-auto-commit": true,
+	"--actor": true, "--database": true, "--db": true, "-C": true,
+	"--directory": true, "--dolt-auto-commit": true, "--mem-profile": true,
+	"--profile": true, "--server-url": true,
 }
 
 // globalBoolFlags are accepted by every bd subcommand and take no value.
+// See globalValueFlags for why the split between the two is load-bearing.
 var globalBoolFlags = map[string]bool{
-	"--global": true, "--ignore-schema-skew": true, "--json": true,
-	"--profile": true, "-q": true, "--quiet": true, "--readonly": true,
-	"--sandbox": true, "-v": true, "--verbose": true, "-h": true, "--help": true,
+	"--cpu-profile": true, "--global": true, "--ignore-schema-skew": true,
+	"--json": true, "--no-color": true, "-q": true, "--quiet": true,
+	"--readonly": true, "--sandbox": true, "-v": true, "--verbose": true,
+	"-h": true, "--help": true, "-V": true, "--version": true,
 }
 
 // valueFlagsBySub holds each subcommand's value-consuming flags (beyond the


### PR DESCRIPTION
## Summary

`gc bd create` is a subprocess passthrough, and `bd` writes one ledger: the work
one. On a city that serves a coordination class from a storage binding, a create
whose **shape** belongs to that class — `--type message`, a `gc:session` /
`gc:nudge` / `order-tracking` label, a `gc:extmsg-*` label on a `type=task` row —
landed the bead in the ledger that class is no longer read from, and nothing
reported it, because `bd` did exactly what it was asked and exited 0.

The bead is stranded: it carries the work prefix, so no class-routed read finds
it and no migration moves it, and renaming it into the class namespace afterwards
is not something any backend can do.

Placement is impossible on this seam — only argv crosses to the subprocess — so
the create is **refused before anything is written**, naming the class, the
binding its beads are served from, and the gc-native command that mints one
there. The prospective shape is built from argv (type, labels, metadata, in every
spelling cobra accepts for them) and classified with `coordclass.Classify`, the
production classifier the router and the migration already use: the split is not
type-shaped, so a lookalike table written here would have to relearn the boundary
and would drift from it.

The read override (`GC_BD_ALLOW_RELOCATED_CLASS_READ`) deliberately does **not**
reach this arm. It exists because the read scan classifies ambiguous text and a
refused read can be re-run; a stranded mint cannot be undone. A city that
relocates nothing gets nil relocated classes and a byte-identical passthrough,
which is the same single-store compatibility claim the read guard makes.

Two create channels state their shape outside argv and are documented limits
rather than fail-closed refusals: `create -f plan.md` / `--graph <json>` (the
beads come from a file or plan body) and shorthand clusters like `-qtmessage`.
Refusing those would break the ordinary work mints the work ledger exists for.

Follow-on to #5597 (epic `ga-qdt5y`). Closes `ga-7bb42`.

## Testing

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/gc/ -timeout 40m` — ok 716.6s, exit 0 (full package; the only
      package touched). The default 10m timeout panics on this package.
- [x] **Mutation proof, forced both ways, different tests dying each way.**
      Forcing every create to classify as infrastructure kills both controls — all
      ten rows of `TestBdCreateForwardsAWorkShapedCreateOnASplitCity` and
      `TestGcBdCreateIsUnchangedOnASingleStoreCity/work_shape,_split`. Dropping
      label-derived classification (type only) kills a *different* set: exactly
      the five label rows, including the `gc:extmsg-*`-labeled `type=task`
      create, with both controls still green.
- [x] `gofmt` clean; pre-commit hook active and ran on the staged change
      (`lint-changed: ./cmd/gc  0 issues`)

### One design premise corrected during implementation

The design prescribed the argv `create --type message -t hello`. In the pinned
`bd` module, `create` registers `StringP("type", "t", ...)` and `--title` has **no
shorthand** — so `-t hello` means `type=hello`, i.e. that exact argv is a
work-class create that must pass through. As written it would have been a
false-positive test. The row is spelled `create --type message "hello"` instead,
with the shorthand-cluster case covered explicitly as a documented limit.

## Checklist

- [x] Linked an issue — `ga-7bb42`, under epic `ga-qdt5y`
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes — the refusal text itself names the
      class, the binding, and the gc-native command that mints there
- [x] Called out breaking changes or migration notes — a create that previously
      stranded a bead now fails loudly. That is the point: the alternative is an
      unrecoverable write. Single-store cities are byte-identical.
