### PR TITLE
feat(beads): answer the relic census with one store-level predicate

### DIFF
--- a/cmd/gc/class_store_emit.go
+++ b/cmd/gc/class_store_emit.go
@@ -538,6 +538,39 @@ func (s *emittingClassStore) AtomicConditionalCloserHandle() (beads.AtomicCondit
 	return s, true
 }
 
+// HasResidentOutside forwards the relic census to the backing capability. It
+// exists because TestEmittingClassStoreKeepsEveryEngineCapability holds this
+// wrapper to every engine method, and a wrapper that carries the method must
+// still be unable to answer for a backing that cannot: a store with no census
+// gets beads.ErrNamespaceCensusUnsupported, never (false, nil). A false clean
+// here would retire the binding's by-id probe over every relic sitting in it.
+//
+// Discovery does not reach this method — NamespaceCensusHandle below answers
+// first — so this is the spelling for a caller holding the wrapper that asks
+// directly.
+func (s *emittingClassStore) HasResidentOutside(prefixes []string) (bool, error) {
+	census, ok := beads.NamespaceCensusFor(s.Store)
+	if !ok {
+		return false, fmt.Errorf("censusing the id namespaces of the emitting class store over %T: %w", s.Store, beads.ErrNamespaceCensusUnsupported)
+	}
+	return census.HasResidentOutside(prefixes)
+}
+
+// NamespaceCensusHandle keeps beads.NamespaceCensusFor honest over this
+// wrapper, exactly as AtomicConditionalCloserHandle does above and for the same
+// reason: the reflective capability guard forces HasResidentOutside to EXIST
+// for every engine, so a bare type assertion would advertise a census over a
+// backing — a mem store, the native Dolt engine — that has none. The census
+// contract makes that a hard gate rather than a rollout seam, because a store
+// that answers the question inexactly strands every bead it failed to see.
+//
+// It hands back the backing's census rather than the wrapper: the wrapper adds
+// emission, a census reads and mutates nothing, so there is nothing here for
+// the answer to pass back through.
+func (s *emittingClassStore) NamespaceCensusHandle() (beads.NamespaceCensus, bool) {
+	return beads.NamespaceCensusFor(s.Store)
+}
+
 func (s *emittingClassStore) DeleteIfMatch(id string, revision int64) error {
 	writer, ok := beads.ConditionalWriterFor(s.Store)
 	if !ok {

--- a/cmd/gc/class_store_emit_test.go
+++ b/cmd/gc/class_store_emit_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -22,6 +23,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // The three gates this seam has to hold, and the control that keeps the second
@@ -593,6 +595,91 @@ func TestEmittingClassStoreKeepsEveryEngineCapability(t *testing.T) {
 			t.Errorf("the emitting class store drops %v from %s; every one is a capability assertion that stops matching", missing, engine)
 		}
 	}
+}
+
+// The relic census is the one capability where carrying the method is WORSE
+// than dropping it, so TestEmittingClassStoreKeepsEveryEngineCapability forcing
+// HasResidentOutside to exist needs this row underneath it.
+//
+// Dropping the method costs a scan that returns the same verdict. Carrying it
+// as a plain forward makes a bare assertion succeed over a backing that has no
+// census — the mem store here, the native Dolt engine in production — and the
+// caller then retires the binding's by-id probe on an answer nobody computed,
+// stranding every bead the class migration carried across under its original
+// id. Both halves are pinned: discovery must refuse a backing that cannot
+// answer, and it must find one that can and agree with the scan.
+func TestTheEmittingClassStoreOnlyAdvertisesACensusItCanAnswer(t *testing.T) {
+	const graphPrefix = "gcg"
+
+	t.Run("a backing with no census is not advertised as one", func(t *testing.T) {
+		cityPath := t.TempDir()
+		wrapped := splitClassRoutes(beads.NewMemStore()).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
+
+		direct, carried := wrapped.(beads.NamespaceCensus)
+		if !carried {
+			t.Fatal("the wrapper does not carry HasResidentOutside at all; this row models the hazard of carrying it and has nothing to say")
+		}
+		if census, ok := beads.NamespaceCensusFor(wrapped); ok {
+			t.Fatalf("a wrapper over a backing with no census was discovered as one (%T); the boot verdict would take its word and retire the binding's probe", census)
+		}
+		got, err := direct.HasResidentOutside([]string{graphPrefix})
+		if !errors.Is(err, beads.ErrNamespaceCensusUnsupported) {
+			t.Fatalf("asking the wrapper directly returned (%v, %v), want beads.ErrNamespaceCensusUnsupported: a structural method with nothing behind it must not answer a verdict", got, err)
+		}
+		if got {
+			t.Error("the refusal came back with a TRUE verdict; a store that cannot answer answers nothing")
+		}
+	})
+
+	t.Run("a sqlite backing is reached and agrees with the scan", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			seed []string
+			want bool
+		}{
+			{name: "binding holding a relic", seed: []string{"gcg-1", "ga-relic"}, want: true},
+			{name: "clean binding", seed: []string{"gcg-1", "gcg-2"}, want: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cityPath := t.TempDir()
+				leaf, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix(graphPrefix))
+				if err != nil {
+					t.Fatalf("opening the leaf store: %v", err)
+				}
+				t.Cleanup(func() { _ = closeBeadStoreHandle(leaf) })
+				for _, id := range tc.seed {
+					if _, err := leaf.Create(beads.Bead{ID: id, Title: id, Type: "task"}); err != nil {
+						t.Fatalf("seeding %q: %v", id, err)
+					}
+				}
+
+				wrapped := splitClassRoutes(leaf).withCLIEmission(cityPath).stores[coordclass.ClassGraph]
+				census, ok := beads.NamespaceCensusFor(wrapped)
+				if !ok {
+					t.Fatalf("the wrapper hid the sqlite leaf's census; every one-shot command on this city goes back to scanning the whole binding")
+				}
+				predicate, err := census.HasResidentOutside([]string{graphPrefix})
+				if err != nil {
+					t.Fatalf("predicate: %v", err)
+				}
+
+				relics, err := storeref.LegacyResidents(leaf, []string{graphPrefix})
+				if err != nil {
+					t.Fatalf("scan: %v", err)
+				}
+				scanned := len(relics) > 0
+				if scanned != tc.want {
+					t.Fatalf("the scan answered %v, want %v (relics %v); the fixture does not model what it claims to", scanned, tc.want, relics)
+				}
+				if predicate != scanned {
+					t.Fatalf("the census through the wrapper answered %v and the scan answered %v (relics %v)", predicate, scanned, relics)
+				}
+				if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 0 {
+					t.Errorf("censusing the binding appended %d bead event(s); a verdict reads and mutates nothing: %s", len(got), eventSummary(got))
+				}
+			})
+		}
+	})
 }
 
 // TestEmittingClassStoreCarriesAnEdgePayloadAndEmitsForIt covers the wrapper's

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -172,9 +172,10 @@ type State interface {
 	OrdersBeadStore() beads.OrdersStore
 
 	// ClassBindingHasLegacyResidents reports whether store — one of the
-	// per-class stores above — still holds an open bead under an id outside the
-	// namespaces its classes declare: a row `gc storage migrate` carried across
-	// under its original work-shaped id, reachable only by probing the binding.
+	// per-class stores above — still holds a bead, open or closed, under an id
+	// outside the namespaces its classes declare: a row `gc storage migrate`
+	// carried across under its original work-shaped id, reachable only by
+	// probing the binding.
 	//
 	// The API never opens a binding and cannot take that census itself, so the
 	// verdict crosses this surface from the boot that did. It exists because

--- a/internal/beads/doltlite_namespace_census.go
+++ b/internal/beads/doltlite_namespace_census.go
@@ -1,0 +1,51 @@
+//go:build gascity_native_beads
+
+package beads
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+var _ NamespaceCensus = (*DoltliteReadStore)(nil)
+
+// HasResidentOutside reports whether the store holds any bead whose id none of
+// prefixes claims. It satisfies NamespaceCensus.
+//
+// Both storage tables are asked, because both are places a carried-across row
+// can sit and TierBoth applies no discriminator to either — the tier and
+// storage-flag predicates List layers on for the narrower modes are the ones
+// TierBoth deliberately omits. Neither the cross-table dedupe nor the
+// storage-flag classification changes the answer: a row that exists in either
+// table is a resident whichever tier it is classified into, and a wisp shadowed
+// by its durable twin shares that twin's id.
+//
+// The wisps table is optional — snapshots written before the upstream wisps
+// migration have none — so its absence is a table with no rows in it, not a
+// failed read.
+func (s *DoltliteReadStore) HasResidentOutside(prefixes []string) (bool, error) {
+	where, args := namespaceExclusionSQL("COALESCE(i.id, '')", prefixes)
+	for _, tables := range doltliteTableSetsForMode(TierBoth) {
+		if tables.wisps && !s.tableExists(tables.issues) {
+			continue
+		}
+		query := "SELECT 1 FROM " + tables.issues + " i"
+		if where != "" {
+			query += " WHERE " + where
+		}
+		query += " LIMIT 1"
+
+		var found int
+		switch err := s.db.QueryRowContext(context.Background(), query, args...).Scan(&found); {
+		case errors.Is(err, sql.ErrNoRows):
+			continue
+		case err != nil:
+			return false, fmt.Errorf("censusing the id namespaces of doltlite table %s: %w", tables.issues, err)
+		default:
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/beads/doltlite_namespace_census_test.go
+++ b/internal/beads/doltlite_namespace_census_test.go
@@ -1,0 +1,155 @@
+//go:build gascity_native_beads
+
+package beads
+
+// The DoltLite half of the namespace census, held to the same bar the
+// hydration-free Count is: whatever the predicate says, listing the store and
+// applying the rule by hand must say the same thing.
+
+import (
+	"strings"
+	"testing"
+)
+
+func doltliteResidentOutsideByScan(t *testing.T, store *DoltliteReadStore, prefixes []string) bool {
+	t.Helper()
+	rows, err := store.List(ListQuery{TierMode: FederatedReadTier, AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, row := range rows {
+		inside := false
+		for _, prefix := range prefixes {
+			prefix = strings.TrimSpace(prefix)
+			if prefix == "" {
+				continue
+			}
+			if row.ID == prefix || strings.HasPrefix(row.ID, prefix+"-") {
+				inside = true
+				break
+			}
+		}
+		if !inside {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDoltliteHasResidentOutside(t *testing.T) {
+	classPrefixes := []string{"gcg", "gcnq"}
+
+	for _, tc := range []struct {
+		name     string
+		issues   []testDoltliteIssue
+		wisps    []testDoltliteIssue
+		prefixes []string
+		want     bool
+		why      string
+	}{
+		{
+			name:     "a work-shaped id the migration carried across is a resident outside",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own"}, {ID: "ga-relic", Title: "carried across"}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "ga-relic carries no namespace this binding declares",
+		},
+		{
+			name:     "every declared namespace is inside",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own"}, {ID: "gcnq-2", Title: "own"}},
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "a binding holding only its own ids is the converged city the probe retires for",
+		},
+		{
+			// The load-bearing row (ga-qdt5y.19): a closed relic is still read,
+			// reopened and claimed by id.
+			name:     "a closed relic is still a resident",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own"}, {ID: "ga-done", Title: "drained", Status: "closed"}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "closing a relic drains it; it does not make it findable by prefix",
+		},
+		{
+			name:     "a closed bead inside a declared namespace is ordinary retired infrastructure",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own", Status: "closed"}},
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "it is findable by prefix whether it is open or closed",
+		},
+		{
+			name:     "an empty binding holds nothing outside",
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "nothing is what a fresh born-split city holds",
+		},
+		{
+			// The wisps table is a second place a carried-across row can sit, and
+			// a predicate that read one table would miss it.
+			name:     "a relic in the wisps table counts",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own"}},
+			wisps:    []testDoltliteIssue{{ID: "ga-wisp", Title: "carried across", Ephemeral: true}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "a wisp carried across is as unfindable as an issue",
+		},
+		{
+			name:     "a durable no-history wisp relic counts",
+			wisps:    []testDoltliteIssue{{ID: "ga-durable", Title: "carried across", NoHistory: true}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "the storage flag decides the tier, not whether the row exists",
+		},
+		{
+			name:     "a lookalike prefix is not the namespace",
+			issues:   []testDoltliteIssue{{ID: "gcgx-1", Title: "neighbour"}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "gcgx is its own namespace; only gcg and gcg-... are inside gcg",
+		},
+		{
+			name:     "the bare prefix is inside its own namespace",
+			issues:   []testDoltliteIssue{{ID: "gcg", Title: "own"}},
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "IDInNamespace admits the bare prefix, and the predicate must agree",
+		},
+		{
+			name:     "a binding claiming no namespace counts every resident",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own"}},
+			prefixes: nil,
+			want:     true,
+			why:      "nothing is declared, so nothing is inside",
+		},
+		{
+			name:     "a blank prefix claims nothing",
+			issues:   []testDoltliteIssue{{ID: "gcg-1", Title: "own"}},
+			prefixes: []string{"  "},
+			want:     true,
+			why:      "an empty namespace is not a wildcard",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newDoltliteStoreWithRows(t, tc.issues, tc.wisps)
+
+			got, err := store.HasResidentOutside(tc.prefixes)
+			if err != nil {
+				t.Fatalf("HasResidentOutside: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("HasResidentOutside(%v) = %v, want %v: %s", tc.prefixes, got, tc.want, tc.why)
+			}
+			if scanned := doltliteResidentOutsideByScan(t, store, tc.prefixes); scanned != got {
+				t.Fatalf("the predicate answered %v and listing the store answered %v; one of the two is narrowing the census", got, scanned)
+			}
+		})
+	}
+}
+
+// The capability is what a caller type-asserts for, so the assertion has to land.
+func TestDoltliteReadStoreIsANamespaceCensus(t *testing.T) {
+	var store Store = newDoltliteStoreWithRows(t, nil, nil)
+	if _, ok := store.(NamespaceCensus); !ok {
+		t.Fatalf("%T does not satisfy beads.NamespaceCensus", store)
+	}
+}

--- a/internal/beads/namespace_census.go
+++ b/internal/beads/namespace_census.go
@@ -1,0 +1,174 @@
+package beads
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// NamespaceCensus is an optional Store capability: answering, in one query,
+// whether the store holds ANY bead whose id falls outside a set of namespaces.
+//
+// This is a VERDICT, not a filter. The caller does not want the rows — it wants
+// to know whether a by-id probe over this store can be retired — so the question
+// is deliberately not a ListQuery field. A ListQuery field would oblige every
+// backend to honor the superset-plus-ApplyListQuery contract for a question
+// that has one shape and one caller, and would let a backend that ignored it
+// answer with a superset. There is no safe superset of a verdict.
+//
+// A prefix claims a namespace under the same rule the caller reads ids by
+// (storeref.IDInNamespace): id == prefix, or id begins with prefix + "-". The
+// prefix is trimmed of surrounding whitespace first, and an empty prefix claims
+// nothing — it is not a wildcard. An implementation whose rule differs from that
+// one silently disagrees with its caller about what a namespace is, so a
+// prefix-match written as LIKE prefix || '%' is wrong twice over: it swallows
+// the neighboring gcgx namespace, and it reads % and _ inside a prefix as
+// wildcards.
+//
+// Implementations MUST count CLOSED beads and BOTH tiers. Closing a bead does
+// not make it findable by prefix: it is still shown, reopened, claimed and
+// written by id, and the class migration that carried it across never deletes
+// the work store's pre-migration copy. A predicate that skipped closed rows
+// would report clean the moment the last relic closed, retiring the probe and
+// sending that id back to a frozen copy that reads OPEN forever (ga-qdt5y.19).
+// Because nothing deletes such a bead, the closed-inclusive answer is also
+// MONOTONE, which is what makes it safe to take once per process.
+//
+// Answering FALSE strands every bead the implementation failed to see, so a
+// store that cannot answer the question exactly must not implement this at all.
+// Callers discover it through NamespaceCensusFor — never a bare type assertion,
+// see there — and fall back to listing the store and applying the rule
+// themselves, which is always available and merely slower.
+type NamespaceCensus interface {
+	HasResidentOutside(prefixes []string) (bool, error)
+}
+
+var _ NamespaceCensus = (*SQLiteStore)(nil)
+
+// ErrNamespaceCensusUnsupported reports a census asked of a store that cannot
+// answer it. It is what a wrapper carrying HasResidentOutside structurally
+// returns when its backing has no census: the one answer that is neither a
+// verdict nor a lie, and the caller reads it the same way it reads any other
+// failed census — keep the probe.
+var ErrNamespaceCensusUnsupported = errors.New("namespace census unsupported")
+
+// NamespaceCensusHandleProvider lets a wrapper expose the census capability of
+// its backing without claiming it when that backing cannot answer.
+//
+// A wrapper needs this precisely when something else forces it to carry
+// HasResidentOutside structurally — cmd/gc's emitting class store is held to
+// every engine method by TestEmittingClassStoreKeepsEveryEngineCapability — so
+// the method's presence stops being evidence that an answer exists behind it.
+type NamespaceCensusHandleProvider interface {
+	NamespaceCensusHandle() (NamespaceCensus, bool)
+}
+
+// NamespaceCensusFor returns store's census capability when one is really
+// there. Callers MUST discover the capability through this rather than
+// asserting NamespaceCensus directly.
+//
+// The provider is consulted BEFORE the plain assertion, which is the opposite
+// of GraphApplyFor's order and the same as AtomicConditionalCloserFor's, for
+// the same reason as there: a wrapper that carries the method structurally
+// satisfies the plain assertion too, so an assertion-first lookup would return
+// the wrapper's method and never reach the handle that knows whether the
+// backing can honor it. Discovery here is a hard capability gate — answering
+// FALSE strands every bead the answer failed to see — so the honest "no" has
+// to win.
+//
+// Unlike AtomicConditionalCloserFor this does NOT follow
+// ConditionalWritesResolveTarget. That seam is declared for one capability and
+// says so (internal/beads/class_store.go: "the one optional capability where
+// forgetting the unwrap would not fail loudly but silently resolve
+// unset→legacy (fatal under require). All other optional capabilities keep the
+// assert-on-.Store convention"), and the asymmetry that earns it does not exist
+// here: a conditional writer that goes undiscovered collapses to a legacy
+// write, while a census that goes undiscovered falls back to the scan, which
+// returns the same verdict a little slower. Borrowing the follow would let a
+// wrapper's read-shaping decisions be stepped around by a question about the
+// wrapper's contents, to buy nothing but speed.
+func NamespaceCensusFor(store Store) (NamespaceCensus, bool) {
+	if store == nil {
+		return nil, false
+	}
+	if provider, ok := store.(NamespaceCensusHandleProvider); ok {
+		return provider.NamespaceCensusHandle()
+	}
+	census, ok := store.(NamespaceCensus)
+	return census, ok
+}
+
+// namespaceExclusionSQL builds the WHERE fragment matching rows whose id
+// expression falls outside every prefix, together with its bind arguments. It
+// returns an empty fragment when no prefix is usable, which matches every row:
+// a store that declares no namespace recognizes nothing, so all of it is
+// outside.
+//
+// The prefixes are compile-time reserved-class constants at every call site
+// today, and they are still bound as parameters. A literal here would be a
+// standing invitation for the next caller to pass something it read from disk.
+//
+// substr/length rather than LIKE: LIKE would treat % and _ inside a prefix as
+// wildcards. Both callers execute this on SQLite — the DoltLite read store
+// included, which opens the pure-Go sqlite driver — and there length() counts
+// in the same units substr() indexes in, so the comparison stays exact whatever
+// the prefix encodes. That pairing is engine-specific rather than universal: on
+// a MySQL-executed engine LENGTH() is bytes while SUBSTR() indexes characters,
+// so a third caller running this against the native Dolt engine has to spell it
+// CHAR_LENGTH() (mc-wuwe). Every prefix bound today is an ASCII reserved-class
+// constant, where the two agree either way.
+func namespaceExclusionSQL(idExpr string, prefixes []string) (string, []any) {
+	var (
+		clauses []string
+		args    []any
+	)
+	for _, prefix := range prefixes {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			continue
+		}
+		clauses = append(clauses, "("+idExpr+" = ? OR substr("+idExpr+", 1, length(?)) = ?)")
+		args = append(args, prefix, prefix+"-", prefix+"-")
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return "NOT (" + strings.Join(clauses, " OR ") + ")", args
+}
+
+// HasResidentOutside reports whether the store holds any bead whose id none of
+// prefixes claims. It satisfies NamespaceCensus.
+//
+// One statement over the beads table, reading the id column and stopping at the
+// first match. The table holds both tiers and every status with no discriminator
+// applied, so counting all of them is the absence of a filter rather than the
+// presence of one — there is no closed-status clause here to accidentally delete.
+//
+// A NOT-prefix predicate cannot seek, so this is still a scan; what it stops
+// being is a hydration. The listing path it replaces decodes every row's
+// bead_json into a Bead and builds a slice of the whole history before the
+// caller looks at the first id, and on a binding that does hold a relic the
+// LIMIT ends the read at the first one.
+func (s *SQLiteStore) HasResidentOutside(prefixes []string) (bool, error) {
+	if err := s.ensureOpen(); err != nil {
+		return false, err
+	}
+	query := "SELECT 1 FROM beads"
+	where, args := namespaceExclusionSQL("COALESCE(id, '')", prefixes)
+	if where != "" {
+		query += " WHERE " + where
+	}
+	query += " LIMIT 1"
+
+	var found int
+	switch err := s.readDB.QueryRowContext(context.Background(), query, args...).Scan(&found); {
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("censusing the id namespaces of the sqlite bead store at %s: %w", s.path, err)
+	default:
+		return true, nil
+	}
+}

--- a/internal/beads/namespace_census.go
+++ b/internal/beads/namespace_census.go
@@ -106,6 +106,13 @@ func NamespaceCensusFor(store Store) (NamespaceCensus, bool) {
 // a store that declares no namespace recognizes nothing, so all of it is
 // outside.
 //
+// idExpr must not evaluate to SQL NULL; wrap a nullable column in COALESCE
+// with an empty-string default. Under NOT (...), a NULL comparison yields
+// NULL rather than true, so the row drops out of the WHERE entirely — and a
+// row with a NULL id is outside every namespace, so silently losing it
+// answers clean over a resident, the one direction this verdict must never
+// get wrong.
+//
 // The prefixes are compile-time reserved-class constants at every call site
 // today, and they are still bound as parameters. A literal here would be a
 // standing invitation for the next caller to pass something it read from disk.

--- a/internal/beads/namespace_census_test.go
+++ b/internal/beads/namespace_census_test.go
@@ -1,0 +1,298 @@
+package beads
+
+// The namespace census predicate, and the one row that decides whether it is
+// sound.
+//
+// HasResidentOutside answers a verdict the caller uses to retire a by-id probe,
+// so an answer of FALSE strands every bead it failed to see. The rows below are
+// mostly about what "see" has to mean: every tier, every status, and a namespace
+// rule that matches storeref.IDInNamespace byte for byte rather than
+// approximately.
+
+import (
+	"testing"
+)
+
+func seedCensusRow(t *testing.T, store *SQLiteStore, b Bead) {
+	t.Helper()
+	if b.Title == "" {
+		b.Title = b.ID
+	}
+	if b.Type == "" {
+		b.Type = "task"
+	}
+	if _, err := store.Create(b); err != nil {
+		t.Fatalf("seeding %q: %v", b.ID, err)
+	}
+}
+
+func openCensusStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	opened, err := OpenSQLiteStore(t.TempDir(), WithSQLiteStoreIDPrefix("gcg"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	store, ok := opened.(*SQLiteStore)
+	if !ok {
+		t.Fatalf("OpenSQLiteStore returned %T, want *SQLiteStore", opened)
+	}
+	t.Cleanup(func() { _ = store.CloseStore() })
+	return store
+}
+
+func TestSQLiteHasResidentOutside(t *testing.T) {
+	classPrefixes := []string{"gcg", "gcnq"}
+
+	for _, tc := range []struct {
+		name     string
+		seed     []Bead
+		close    []string
+		prefixes []string
+		want     bool
+		why      string
+	}{
+		{
+			name:     "a work-shaped id the migration carried across is a resident outside",
+			seed:     []Bead{{ID: "gcg-1"}, {ID: "ga-relic"}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "ga-relic carries no namespace this binding declares, so only a probe can find it",
+		},
+		{
+			name:     "every declared namespace is inside",
+			seed:     []Bead{{ID: "gcg-1"}, {ID: "gcnq-2"}},
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "a binding holding only its own ids is exactly the converged city the probe retires for",
+		},
+		{
+			// The load-bearing row (ga-qdt5y.19). A closed relic is still read,
+			// reopened and claimed by id, and `gc storage migrate` never deletes
+			// the work store's pre-migration copy — so a predicate that skipped
+			// closed rows would certify this store clean and send that id back to
+			// a frozen copy that reads OPEN forever.
+			name:     "a closed relic is still a resident",
+			seed:     []Bead{{ID: "gcg-1"}, {ID: "ga-done"}},
+			close:    []string{"ga-done"},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "closing a relic drains it; it does not make it findable by prefix",
+		},
+		{
+			// The must-be-silent counterpart: widening past closed rows must widen
+			// only the CLOSED half. The namespace still decides what counts, or
+			// every city that ever closed an infrastructure bead keeps its probe.
+			name:     "a closed bead inside a declared namespace is ordinary retired infrastructure",
+			seed:     []Bead{{ID: "gcg-1"}},
+			close:    []string{"gcg-1"},
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "it is findable by prefix whether it is open or closed",
+		},
+		{
+			name:     "an empty binding holds nothing outside",
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "nothing is what a fresh born-split city holds",
+		},
+		{
+			// A wisp carried across is as unfindable as an issue, and it lives in
+			// the wisp tier. A predicate that read one tier would miss it.
+			name:     "a wisp-tier relic counts",
+			seed:     []Bead{{ID: "gcg-1"}, {ID: "ga-wisp", Ephemeral: true}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "the census reads both tiers or it is not a census",
+		},
+		{
+			// The rule is `id == prefix || strings.HasPrefix(id, prefix+"-")`. A
+			// predicate written as LIKE 'gcg%' would swallow gcgx-1 — a different
+			// namespace entirely — and retire the probe over it.
+			name:     "a lookalike prefix is not the namespace",
+			seed:     []Bead{{ID: "gcgx-1"}},
+			prefixes: classPrefixes,
+			want:     true,
+			why:      "gcgx is its own namespace; only gcg and gcg-... are inside gcg",
+		},
+		{
+			name:     "the bare prefix is inside its own namespace",
+			seed:     []Bead{{ID: "gcg"}},
+			prefixes: classPrefixes,
+			want:     false,
+			why:      "IDInNamespace admits the bare prefix, and the predicate must agree",
+		},
+		{
+			// A binding that claims no namespace recognizes nothing, so every
+			// resident is a relic. That is the honest answer, and it pairs with
+			// the mint bit: such a binding never mints truthfully either.
+			name:     "a binding claiming no namespace counts every resident",
+			seed:     []Bead{{ID: "gcg-1"}},
+			prefixes: nil,
+			want:     true,
+			why:      "nothing is declared, so nothing is inside",
+		},
+		{
+			name:     "a binding claiming no namespace over an empty store is still clean",
+			prefixes: nil,
+			want:     false,
+			why:      "there is no row to be outside anything",
+		},
+		{
+			// Blank prefixes are dropped rather than treated as a namespace that
+			// claims everything; IDInNamespace says an empty prefix claims nothing.
+			name:     "a blank prefix claims nothing",
+			seed:     []Bead{{ID: "gcg-1"}},
+			prefixes: []string{"  "},
+			want:     true,
+			why:      "an empty namespace is not a wildcard",
+		},
+		{
+			name:     "surrounding whitespace does not change a namespace",
+			seed:     []Bead{{ID: "gcg-1"}},
+			prefixes: []string{" gcg "},
+			want:     false,
+			why:      "IDInNamespace trims the prefix before it compares, and so must the predicate",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openCensusStore(t)
+			for _, b := range tc.seed {
+				seedCensusRow(t, store, b)
+			}
+			for _, id := range tc.close {
+				if err := store.Close(id); err != nil {
+					t.Fatalf("closing %q: %v", id, err)
+				}
+			}
+
+			got, err := store.HasResidentOutside(tc.prefixes)
+			if err != nil {
+				t.Fatalf("HasResidentOutside: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("HasResidentOutside(%v) = %v, want %v: %s", tc.prefixes, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// The capability is what a caller type-asserts for, so the assertion has to
+// land. A store that answers the question but does not satisfy the interface is
+// invisible to every caller, and nothing else in the tree would fail.
+func TestSQLiteStoreIsANamespaceCensus(t *testing.T) {
+	var store Store = openCensusStore(t)
+	if _, ok := store.(NamespaceCensus); !ok {
+		t.Fatalf("%T does not satisfy beads.NamespaceCensus; the census would silently fall back to the full scan on every city", store)
+	}
+}
+
+// censusHandleStore models a decorator that carries HasResidentOutside
+// structurally — cmd/gc's emitting class store is held to every engine method
+// by a reflective guard, so it has no choice — while knowing perfectly well
+// whether its backing can answer.
+//
+// Its structural method deliberately answers a WRONG verdict, because that is
+// the failure being pinned: a discovery that takes it has retired a probe over
+// beads nobody looked for.
+type censusHandleStore struct {
+	Store
+	capable       bool
+	handleCalls   int
+	structCalls   int
+	handedBack    NamespaceCensus
+	structVerdict bool
+}
+
+func (s *censusHandleStore) HasResidentOutside([]string) (bool, error) {
+	s.structCalls++
+	return s.structVerdict, nil
+}
+
+func (s *censusHandleStore) NamespaceCensusHandle() (NamespaceCensus, bool) {
+	s.handleCalls++
+	if !s.capable {
+		return nil, false
+	}
+	return s.handedBack, true
+}
+
+// censusAnswer is a bare census with no store behind it, so a test can tell the
+// handed-back capability apart from the wrapper's own method by its answer.
+type censusAnswer struct {
+	verdict bool
+	calls   int
+}
+
+func (c *censusAnswer) HasResidentOutside([]string) (bool, error) {
+	c.calls++
+	return c.verdict, nil
+}
+
+// The handle is consulted BEFORE the plain assertion, which is the whole reason
+// this helper exists rather than a bare `store.(NamespaceCensus)`. A wrapper
+// forced to carry the method satisfies the assertion whatever it wraps, so an
+// assertion-first lookup would take the method's word and never ask the handle.
+//
+// Both directions are pinned here: a wrapper whose backing cannot answer must
+// be reported as having NO census even though the method is right there, and
+// one whose backing can must hand back the BACKING's census rather than its own
+// method. Only the first is the data-integrity case, but a helper that answered
+// "no" to everything would pass it alone.
+func TestNamespaceCensusForConsultsTheHandleBeforeTheMethod(t *testing.T) {
+	t.Run("incapable backing is not advertised", func(t *testing.T) {
+		wrapper := &censusHandleStore{Store: NewMemStore()}
+		census, ok := NamespaceCensusFor(wrapper)
+		if ok {
+			t.Fatalf("a wrapper over a backing with no census was advertised as one (%T); the caller retires its probe on the wrapper's own verdict", census)
+		}
+		if wrapper.handleCalls != 1 {
+			t.Errorf("the handle was asked %d times, want exactly 1", wrapper.handleCalls)
+		}
+		if wrapper.structCalls != 0 {
+			t.Errorf("the wrapper's own HasResidentOutside was called %d times during discovery; discovery must not take a verdict", wrapper.structCalls)
+		}
+	})
+
+	t.Run("capable backing hands back the backing", func(t *testing.T) {
+		backing := &censusAnswer{verdict: true}
+		wrapper := &censusHandleStore{Store: NewMemStore(), capable: true, handedBack: backing}
+		census, ok := NamespaceCensusFor(wrapper)
+		if !ok {
+			t.Fatal("a wrapper whose backing answers the census was reported as having none; every city would scan its whole binding")
+		}
+		got, err := census.HasResidentOutside([]string{"gcg"})
+		if err != nil {
+			t.Fatalf("HasResidentOutside: %v", err)
+		}
+		if !got {
+			t.Error("the discovered census answered the wrapper's own verdict, not the backing's")
+		}
+		if backing.calls != 1 {
+			t.Errorf("the backing census was asked %d times, want exactly 1", backing.calls)
+		}
+		if wrapper.structCalls != 0 {
+			t.Errorf("the wrapper's own HasResidentOutside was called %d times, want 0", wrapper.structCalls)
+		}
+	})
+}
+
+// A store that simply implements the capability, with no handle, still resolves
+// — that is every production engine, and a helper that only understood handles
+// would send all of them down the scan.
+func TestNamespaceCensusForResolvesAPlainImplementation(t *testing.T) {
+	var store Store = openCensusStore(t)
+	if _, ok := NamespaceCensusFor(store); !ok {
+		t.Fatalf("%T implements the census but was not discovered through NamespaceCensusFor", store)
+	}
+}
+
+// Nil and census-less stores are the fallback's entry condition, and the
+// fallback is the safe path — it must stay reachable.
+func TestNamespaceCensusForReportsNoCensus(t *testing.T) {
+	if _, ok := NamespaceCensusFor(nil); ok {
+		t.Error("a nil store was reported as answering the census")
+	}
+	if _, ok := NamespaceCensusFor(NewMemStore()); ok {
+		t.Error("the mem store was reported as answering the census; it has no such query and the caller must scan it")
+	}
+}

--- a/internal/storeref/relic_census.go
+++ b/internal/storeref/relic_census.go
@@ -97,11 +97,57 @@ func legacyResidents(store beads.Store, prefixes []string, includeClosed bool) (
 // refused city, whose store answers every read with the standing storage
 // refusal, takes this branch too.
 func HasLegacyResidents(b ClassBinding) bool {
-	relics, err := LegacyResidents(b.Leg.Store, b.Prefixes)
+	has, err := legacyResidentVerdict(b.Leg.Store, b.Prefixes)
 	if err != nil {
 		return true
 	}
-	return len(relics) > 0
+	return has
+}
+
+// legacyResidentVerdict answers the verdict from the store itself when the store
+// can answer it, and by listing the store when it cannot.
+//
+// The verdict is a yes-or-no question over the binding's whole history, and the
+// listing form pays for the history twice: once to hydrate every row, once to
+// throw all but the id away. A store that can answer it in one statement is
+// asked directly, and it is asked instead of the scan rather than as well as it
+// — running both would make the fast path a pure cost.
+//
+// The fallback is not a legacy path. A binding served by the native Dolt engine
+// reaches its rows through the beads library and holds no SQL of its own, so it
+// cannot implement the capability and lists exactly as before.
+//
+// Discovery goes through beads.NamespaceCensusFor rather than a bare assertion
+// on beads.NamespaceCensus, because the binding this runs against is not always
+// a bare engine: cmd/gc's emitting class store is held to every engine method
+// by TestEmittingClassStoreKeepsEveryEngineCapability, so it carries
+// HasResidentOutside whatever it wraps, and a bare assertion would take that
+// method's word for a native-Dolt-served binding and lose the scan the binding
+// depends on.
+//
+// The drain report (OpenLegacyResidents) deliberately does not come through
+// here: it needs the ids themselves, and a verdict cannot name them.
+func legacyResidentVerdict(store beads.Store, prefixes []string) (bool, error) {
+	if store == nil {
+		return false, fmt.Errorf("relic census: no binding store to read")
+	}
+	if census, ok := beads.NamespaceCensusFor(store); ok {
+		has, err := census.HasResidentOutside(prefixes)
+		if err != nil {
+			// Not a reason to fall back to the scan: a store whose own read
+			// failed will not serve a listing of itself either, so the fallback
+			// would only pay the cost twice on the way to the same answer. The
+			// caller reads an error as "keep the probe", which is the honest
+			// verdict for a binding that said nothing.
+			return false, fmt.Errorf("relic census: asking the binding for a resident outside its namespaces: %w", err)
+		}
+		return has, nil
+	}
+	relics, err := LegacyResidents(store, prefixes)
+	if err != nil {
+		return false, err
+	}
+	return len(relics) > 0, nil
 }
 
 // ProvenLegacyResidents is the PROOF form of the census: the value

--- a/internal/storeref/relic_census_bench_test.go
+++ b/internal/storeref/relic_census_bench_test.go
@@ -1,0 +1,107 @@
+package storeref
+
+// What the census costs, and on which population.
+//
+// The census reads the binding's WHOLE history, not its working set — closed
+// rows included — and the verdict is load-bearing on `gc bd`'s by-id path, the
+// busiest one-shot route in the CLI. A one-shot process pays this before it
+// answers anything.
+//
+// The benchmark seeds a clean binding, because clean is the case that cannot be
+// memoized away: only the TRUE verdict is monotone and safe to cache, so a city
+// that has never held a relic keeps paying on every invocation. The number here
+// is what that city pays.
+//
+// A store that can answer the verdict itself takes beads.NamespaceCensus, so
+// these measure the predicate. BenchmarkRelicCensusScanFallback_10k measures the
+// listing form the same population takes on a store without the capability,
+// which is both what this replaced and what a native-Dolt binding still pays.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// benchmarkCensusStore seeds a clean binding store: rows minted under the
+// binding's own prefix, one in closedFraction of them closed.
+func benchmarkCensusStore(b *testing.B, rows int, closedFraction int) beads.Store {
+	b.Helper()
+	store, err := beads.OpenSQLiteStore(b.TempDir(), beads.WithSQLiteStoreIDPrefix("gcg"))
+	if err != nil {
+		b.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	for i := range rows {
+		bead, err := store.Create(beads.Bead{Title: fmt.Sprintf("graph node %d", i), Type: "task"})
+		if err != nil {
+			b.Fatalf("seeding row %d: %v", i, err)
+		}
+		if closedFraction > 0 && i%closedFraction == 0 {
+			if err := store.Close(bead.ID); err != nil {
+				b.Fatalf("closing row %d: %v", i, err)
+			}
+		}
+	}
+	return store
+}
+
+func benchmarkRelicCensus(b *testing.B, rows int, closedFraction int) {
+	b.Helper()
+	store := benchmarkCensusStore(b, rows, closedFraction)
+	binding := ClassBinding{Prefixes: []string{"gcg"}, Leg: Leg{Ref: "graph", Store: store}}
+	b.ResetTimer()
+	for b.Loop() {
+		if HasLegacyResidents(binding) {
+			b.Fatal("seeded binding reports relics; the fixture mints under its own prefix")
+		}
+	}
+}
+
+// The closed population is the one ga-qdt5y.19 added to the scan by widening the
+// verdict from OPEN residents to ALL of them, so the fixture is mostly closed.
+func BenchmarkRelicCensusCleanBinding_1k(b *testing.B)  { benchmarkRelicCensus(b, 1000, 2) }
+func BenchmarkRelicCensusCleanBinding_10k(b *testing.B) { benchmarkRelicCensus(b, 10000, 2) }
+
+// The listing cost on the same clean 10k population: what a binding whose store
+// cannot answer the verdict itself still pays, and what every binding paid
+// before the capability existed.
+func BenchmarkRelicCensusScanFallback_10k(b *testing.B) {
+	store := benchmarkCensusStore(b, 10000, 2)
+	b.ResetTimer()
+	for b.Loop() {
+		relics, err := LegacyResidents(store, []string{"gcg"})
+		if err != nil {
+			b.Fatalf("LegacyResidents: %v", err)
+		}
+		if len(relics) > 0 {
+			b.Fatal("seeded binding reports relics; the fixture mints under its own prefix")
+		}
+	}
+}
+
+// The open-only cost, for comparison: what the census charged before the
+// verdict was widened.
+func BenchmarkRelicCensusOpenOnly_10k(b *testing.B) {
+	store, err := beads.OpenSQLiteStore(b.TempDir(), beads.WithSQLiteStoreIDPrefix("gcg"))
+	if err != nil {
+		b.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	for i := range 10000 {
+		bead, err := store.Create(beads.Bead{Title: fmt.Sprintf("graph node %d", i), Type: "task"})
+		if err != nil {
+			b.Fatalf("seeding row %d: %v", i, err)
+		}
+		if i%2 == 0 {
+			if err := store.Close(bead.ID); err != nil {
+				b.Fatalf("closing row %d: %v", i, err)
+			}
+		}
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := OpenLegacyResidents(store, []string{"gcg"}); err != nil {
+			b.Fatalf("OpenLegacyResidents: %v", err)
+		}
+	}
+}

--- a/internal/storeref/relic_census_bench_test.go
+++ b/internal/storeref/relic_census_bench_test.go
@@ -59,7 +59,7 @@ func benchmarkRelicCensus(b *testing.B, rows int, closedFraction int) {
 }
 
 // The closed population is the one ga-qdt5y.19 added to the scan by widening the
-// verdict from OPEN residents to ALL of them, so the fixture is mostly closed.
+// verdict from OPEN residents to ALL of them, so the fixture is half closed.
 func BenchmarkRelicCensusCleanBinding_1k(b *testing.B)  { benchmarkRelicCensus(b, 1000, 2) }
 func BenchmarkRelicCensusCleanBinding_10k(b *testing.B) { benchmarkRelicCensus(b, 10000, 2) }
 

--- a/internal/storeref/relic_census_test.go
+++ b/internal/storeref/relic_census_test.go
@@ -12,6 +12,7 @@ package storeref
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -271,6 +272,206 @@ func TestBindingClaimingNoNamespaceCountsEveryResident(t *testing.T) {
 	}
 }
 
+// censusCapabilityStore is a binding store that can answer the verdict itself,
+// instrumented so a test can tell WHICH path produced an answer rather than
+// inferring it from the answer's value.
+type censusCapabilityStore struct {
+	*beads.MemStore
+	outside      bool
+	censusErr    error
+	censusCalls  int
+	listCalls    int
+	prefixesSeen []string
+}
+
+func newCensusCapabilityStore() *censusCapabilityStore {
+	mem := beads.NewMemStore()
+	mem.HonorExplicitIDs = true
+	return &censusCapabilityStore{MemStore: mem}
+}
+
+func (s *censusCapabilityStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return s.MemStore.List(q)
+}
+
+func (s *censusCapabilityStore) HasResidentOutside(prefixes []string) (bool, error) {
+	s.censusCalls++
+	s.prefixesSeen = append([]string(nil), prefixes...)
+	if s.censusErr != nil {
+		return false, s.censusErr
+	}
+	return s.outside, nil
+}
+
+func (s *censusCapabilityStore) seedBead(t *testing.T, id string) {
+	t.Helper()
+	if _, err := s.Create(beads.Bead{ID: id, Title: id, Type: "task"}); err != nil {
+		t.Fatalf("seeding %q: %v", id, err)
+	}
+}
+
+// The verdict takes the store's own answer when the store has one, and it must
+// be the store's answer rather than a scan that happens to agree.
+//
+// The fixture is deliberately contradictory — an EMPTY store that reports a
+// resident outside — because that is the only way to prove which path spoke.
+// The zero List calls are the other half: the whole point of the capability is
+// that a clean born-split city stops hydrating its entire binding history on
+// every one-shot process, and only the TRUE verdict is memoized, so that city
+// pays this on every invocation forever.
+func TestLegacyResidentsVerdictUsesTheCensusCapability(t *testing.T) {
+	store := newCensusCapabilityStore()
+	store.outside = true
+
+	if !HasLegacyResidents(censusBinding(store)) {
+		t.Fatal("the verdict ignored the store's own census; an empty store scanned clean and the capability's answer was discarded")
+	}
+	if store.censusCalls != 1 {
+		t.Errorf("the store's census was asked %d times, want exactly 1", store.censusCalls)
+	}
+	if store.listCalls != 0 {
+		t.Errorf("the verdict issued %d List calls on a store that answers the question directly; the scan is what this replaces", store.listCalls)
+	}
+	if !slices.Equal(store.prefixesSeen, infraPrefixes) {
+		t.Fatalf("the store was handed %v, want the binding's declared namespaces %v", store.prefixesSeen, infraPrefixes)
+	}
+}
+
+// The clean answer has to come from the capability too, or the fallback would
+// mask a predicate that never answers false.
+func TestLegacyResidentsVerdictTakesTheCensusCapabilitysCleanAnswer(t *testing.T) {
+	store := newCensusCapabilityStore()
+	store.seedBead(t, "ga-relic")
+
+	if HasLegacyResidents(censusBinding(store)) {
+		t.Fatal("the verdict scanned past the store's own clean answer; the capability is the verdict, not a hint")
+	}
+	if store.listCalls != 0 {
+		t.Errorf("the verdict issued %d List calls; a store that answered must not be scanned as well", store.listCalls)
+	}
+}
+
+// Most stores cannot answer the question — a class binding served by the native
+// Dolt engine reaches its rows through beadslib.Storage and has no SQL of its
+// own — so the scan is not a legacy path, it is the general one.
+func TestLegacyResidentsVerdictFallsBackToTheScan(t *testing.T) {
+	store := newCensusStore()
+	if _, ok := beads.Store(store).(beads.NamespaceCensus); ok {
+		t.Fatal("the fallback fixture answers the census itself; this row proves nothing")
+	}
+	store.seedBead(t, "ga-relic")
+
+	if !HasLegacyResidents(censusBinding(store)) {
+		t.Error("a store with no census capability was reported clean while holding a relic; the scan must still run for it")
+	}
+}
+
+// A capability that failed is an unread binding, and the fail-safe direction is
+// the same one a failed scan takes: keep the probe. Falling back to the scan
+// here would be worse than useless — it would double the cost of a store that
+// is already failing, and a store whose SQL cannot run will not serve a List
+// either.
+func TestACensusCapabilityErrorKeepsItsProbe(t *testing.T) {
+	store := newCensusCapabilityStore()
+	store.censusErr = errors.New("binding unreachable")
+
+	if !HasLegacyResidents(censusBinding(store)) {
+		t.Error("a binding whose census failed was reported clean; a census that cannot read must not retire a probe")
+	}
+}
+
+// The drain report is a LIST of ids, not a verdict, so it cannot be served by a
+// predicate that only answers yes or no. This row keeps a natural-looking tidy-up
+// — routing both census entry points through the fast path — from silently
+// emptying `gc storage status`'s count.
+func TestTheDrainReportIgnoresTheCensusCapability(t *testing.T) {
+	store := newCensusCapabilityStore()
+	store.seedBead(t, "ga-relic")
+
+	relics, err := OpenLegacyResidents(store, infraPrefixes)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if len(relics) != 1 || relics[0] != "ga-relic" {
+		t.Fatalf("the drain report returned %v, want the ids themselves; an operator watches these fall", relics)
+	}
+	if store.censusCalls != 0 {
+		t.Errorf("the drain report asked the store for a verdict %d times; a verdict cannot name the ids", store.censusCalls)
+	}
+}
+
+// The equivalence row: the predicate and the scan are two implementations of one
+// question, and a disagreement silently narrows the census on exactly the cities
+// that have relics.
+//
+// Both run against the SAME seeded store, so this is not two fixtures that
+// happen to agree — it is one population read two ways. The predicate is asked
+// directly rather than through HasLegacyResidents, because a verdict that had
+// quietly stopped routing through the capability would otherwise compare the
+// scan with itself and agree forever; the verdict is then checked against the
+// same answer, which is what pins the routing.
+func TestTheCensusPredicateAndTheScanAgree(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		seed     []beads.Bead
+		close    []string
+		prefixes []string
+	}{
+		{name: "clean binding", seed: []beads.Bead{{ID: "gcg-1"}, {ID: "gcnq-2"}}, prefixes: infraPrefixes},
+		{name: "open relic", seed: []beads.Bead{{ID: "gcg-1"}, {ID: "ga-relic"}}, prefixes: infraPrefixes},
+		{name: "closed relic only", seed: []beads.Bead{{ID: "gcg-1"}, {ID: "ga-done"}}, close: []string{"ga-done"}, prefixes: infraPrefixes},
+		{name: "closed in-namespace only", seed: []beads.Bead{{ID: "gcg-1"}}, close: []string{"gcg-1"}, prefixes: infraPrefixes},
+		{name: "wisp relic", seed: []beads.Bead{{ID: "gcg-1"}, {ID: "ga-wisp", Ephemeral: true}}, prefixes: infraPrefixes},
+		{name: "lookalike prefix", seed: []beads.Bead{{ID: "gcgx-1"}}, prefixes: infraPrefixes},
+		{name: "bare prefix id", seed: []beads.Bead{{ID: "gcg"}}, prefixes: infraPrefixes},
+		{name: "empty binding", prefixes: infraPrefixes},
+		{name: "binding claiming no namespace", seed: []beads.Bead{{ID: "gcg-1"}}, prefixes: nil},
+		{name: "blank namespace", seed: []beads.Bead{{ID: "gcg-1"}}, prefixes: []string{" "}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("gcg"))
+			if err != nil {
+				t.Fatalf("OpenSQLiteStore: %v", err)
+			}
+			census, ok := store.(beads.NamespaceCensus)
+			if !ok {
+				t.Fatalf("%T cannot answer the census itself; this row would compare the scan with itself", store)
+			}
+			for _, b := range tc.seed {
+				b.Title = b.ID
+				b.Type = "task"
+				if _, err := store.Create(b); err != nil {
+					t.Fatalf("seeding %q: %v", b.ID, err)
+				}
+			}
+			for _, id := range tc.close {
+				if err := store.Close(id); err != nil {
+					t.Fatalf("closing %q: %v", id, err)
+				}
+			}
+
+			relics, err := LegacyResidents(store, tc.prefixes)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			scanned := len(relics) > 0
+			predicate, err := census.HasResidentOutside(tc.prefixes)
+			if err != nil {
+				t.Fatalf("predicate: %v", err)
+			}
+			if predicate != scanned {
+				t.Fatalf("the predicate answered %v and the scan answered %v (relics %v); one of the two is narrowing the census", predicate, scanned, relics)
+			}
+
+			binding := ClassBinding{Classes: infraClasses, Prefixes: tc.prefixes, Leg: Leg{Ref: ClassRef(infraClasses), Store: store}}
+			if got := HasLegacyResidents(binding); got != scanned {
+				t.Fatalf("the boot verdict answered %v while both the predicate and the scan answered %v", got, scanned)
+			}
+		})
+	}
+}
+
 // The census reads the binding and nothing else. A topology's work ledger is
 // full of work-shaped ids by definition, and reading it would report every
 // city on earth as relic-bound.
@@ -286,5 +487,107 @@ func TestCensusReadsOnlyTheBinding(t *testing.T) {
 		Leg:      Leg{Ref: ClassRef([]coordclass.Class{coordclass.ClassGraph}), Store: binding},
 	}) {
 		t.Error("the census reported relics for a clean binding; it must read the binding leg alone")
+	}
+}
+
+// censusWrapperStore is the shape of a production decorator over a binding —
+// cmd/gc's emitting class store — reproduced here so the verdict's DISCOVERY is
+// testable in this package.
+//
+// It carries HasResidentOutside structurally because a reflective guard over
+// there forces it to, and it declares beads.NamespaceCensusHandleProvider
+// because carrying the method is not the same as being able to answer. The two
+// counters are what let a row say WHICH of the three paths ran: the backing's
+// census, the wrapper's own method, or the scan.
+type censusWrapperStore struct {
+	beads.Store
+	directCalls int
+	handleCalls int
+}
+
+func (s *censusWrapperStore) HasResidentOutside(prefixes []string) (bool, error) {
+	s.directCalls++
+	census, ok := beads.NamespaceCensusFor(s.Store)
+	if !ok {
+		return false, beads.ErrNamespaceCensusUnsupported
+	}
+	return census.HasResidentOutside(prefixes)
+}
+
+func (s *censusWrapperStore) NamespaceCensusHandle() (beads.NamespaceCensus, bool) {
+	s.handleCalls++
+	return beads.NamespaceCensusFor(s.Store)
+}
+
+// A wrapped binding whose backing CAN answer still reaches the predicate. The
+// wrapper is not a wall: losing the capability here would put every one-shot
+// command on a converged city back on the full scan, which is the cost this
+// whole capability exists to remove.
+func TestTheVerdictReachesThePredicateThroughAWrapper(t *testing.T) {
+	backing := newCensusCapabilityStore()
+	backing.outside = true
+	wrapper := &censusWrapperStore{Store: backing}
+
+	if !HasLegacyResidents(censusBinding(wrapper)) {
+		t.Fatal("the verdict discarded the wrapped backing's census; an empty store scanned clean and the capability's answer was thrown away")
+	}
+	if backing.censusCalls != 1 {
+		t.Errorf("the backing's census was asked %d times, want exactly 1", backing.censusCalls)
+	}
+	if backing.listCalls != 0 {
+		t.Errorf("the verdict issued %d List calls through a wrapper whose backing answers directly", backing.listCalls)
+	}
+	if wrapper.handleCalls != 1 {
+		t.Errorf("the wrapper's census handle was consulted %d times, want exactly 1; discovery went somewhere else", wrapper.handleCalls)
+	}
+}
+
+// The row that makes the seam worth having: a wrapped binding whose backing
+// CANNOT answer must fall back to the scan and reach the same verdict the scan
+// reaches unwrapped.
+//
+// This is the native-Dolt-served binding. Its wrapper carries
+// HasResidentOutside all the same, so a bare `store.(beads.NamespaceCensus)`
+// would match, the scan would never run, and the binding's whole population
+// would be answered for by a method with nothing behind it. Both directions run
+// against one fixture read three ways — wrapped verdict, unwrapped verdict,
+// scan — because a fallback that answered TRUE unconditionally would pass the
+// relic row and strand nothing only by luck.
+func TestTheVerdictScansThroughAWrapperWhoseBackingCannotAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed []string
+		want bool
+	}{
+		{name: "binding holding a relic", seed: []string{"gcg-1", "ga-relic"}, want: true},
+		{name: "clean binding", seed: []string{"gcg-1", "gcnq-2"}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backing := newCensusStore()
+			for _, id := range tc.seed {
+				backing.seedBead(t, id)
+			}
+			if _, ok := beads.Store(backing).(beads.NamespaceCensus); ok {
+				t.Fatal("the fixture backing answers the census itself; this row proves nothing")
+			}
+			wrapper := &censusWrapperStore{Store: backing}
+			if _, ok := beads.Store(wrapper).(beads.NamespaceCensus); !ok {
+				t.Fatal("the wrapper fixture does not carry HasResidentOutside, so it does not model the wrapper the guard forces; this row proves nothing")
+			}
+
+			relics, err := LegacyResidents(backing, infraPrefixes)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if scanned := len(relics) > 0; scanned != tc.want {
+				t.Fatalf("the unwrapped scan answered %v, want %v (relics %v)", scanned, tc.want, relics)
+			}
+			if got := HasLegacyResidents(censusBinding(wrapper)); got != tc.want {
+				t.Fatalf("the verdict over the wrapped binding answered %v, want the scan's %v", got, tc.want)
+			}
+			if wrapper.directCalls != 0 {
+				t.Errorf("the wrapper's own HasResidentOutside answered for a backing that has no census (%d call(s)); the scan is the only thing that can speak for this binding", wrapper.directCalls)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

The boot census asks a binding one question — *"does any bead in here carry an id
none of your namespaces claims?"* — and answered it by listing the binding's whole
history, hydrating every row's `bead_json` into a `Bead` so it could read the id
and throw the rest away. Only the TRUE verdict is safe to remember, because only
TRUE is monotone, so **the city that has never held a relic is exactly the city
that re-pays that scan on every one-shot process, forever** — in front of `gc bd`'s
by-id door, the busiest one-shot route in the CLI.

`beads.NamespaceCensus` is an optional `Store` capability that answers it
directly, implemented on the SQLite and DoltLite stores as one statement over the
id column with `LIMIT 1`. It is a capability rather than a `ListQuery` field on
purpose: the question is a **verdict**, and `ListQuery` fields carry a
superset-plus-`ApplyListQuery` contract every backend would then have to honour —
there is no safe superset of a verdict. `storeref`'s verdict path discovers it and
otherwise lists exactly as before, which is what a binding served by the native
Dolt engine still does. The drain report (`OpenLegacyResidents`) keeps returning
the ids themselves unconditionally, because a verdict cannot name them.

The predicate is spelled `substr`/`length` rather than `LIKE prefix || '%'`:
`LIKE` would swallow the neighbouring `gcgx` namespace and would read `%` and `_`
inside a prefix as wildcards. The prefixes are compile-time reserved-class
constants at every call site and are still bound as parameters.

Follow-on to the residency storeref split stack (`ga-j4p3y`), under epic
`ga-qdt5y`. Closes `ga-dx4ho` — which specifies exactly this work ("add the
namespace predicate to `beads.ListQuery` (or a dedicated store capability
interface), implement it on the sqlite and Dolt stores, and have
`storeref.LegacyResidents` use it … for the verdict form (`HasLegacyResidents`)
while `OpenLegacyResidents` keeps returning the full id list the operator drain
report prints") and names the closed-relic row as its own acceptance test.

### Discovery is gated, not asserted

`TestEmittingClassStoreKeepsEveryEngineCapability` holds `cmd/gc`'s emitting class
store to every method either engine declares, so the wrapper has to carry
`HasResidentOutside` whatever it wraps. **Carrying it as a plain forward is worse
than dropping it**: the wrapper would then satisfy a bare
`store.(beads.NamespaceCensus)` over *any* backing — including a mem store or a
native-Dolt backing that cannot answer at all — and the honest-looking
`(false, nil)` **retires the residence probe over beads that are still there.**
That is the one direction this verdict is never allowed to be wrong in.

The same hazard is already solved in the same file, for atomic closes, with a
comment that describes this situation almost word for word: *"a bare type
assertion would advertise the capability even over a backing … that cannot honor
it — and that discovery is contractually a hard capability gate, not a rollout
seam."* So this follows `AtomicConditionalCloserFor` rather than inventing a
shape:

1. `internal/beads` gains `NamespaceCensusHandleProvider`, `NamespaceCensusFor`,
   and `ErrNamespaceCensusUnsupported`. The handle is consulted **before** the
   plain assertion — the opposite of `GraphApplyFor` — because the method-set
   guard forces the wrapper to carry the method, so assertion-first would take
   the method's word and never reach the handle.
2. `legacyResidentVerdict` discovers via `NamespaceCensusFor`, so the scan
   fallback still reaches a wrapped store whose backing cannot answer.
3. The wrapper implements both. Its handle returns the **backing's** census, and
   its structural `HasResidentOutside` returns `ErrNamespaceCensusUnsupported` —
   never `(false, nil)` — so it cannot lie to a caller holding it directly.

It deliberately does **not** follow `ConditionalWritesResolveTarget`.
`internal/beads/class_store.go:76-81` scopes that seam to the one capability
where forgetting the unwrap fails silently rather than loudly; an undiscovered
census merely scans and returns the same verdict.

**Scope correction, kept from the original review:** the stranding is *latent on
this branch, not live.* The boot census runs on the leaf stores before
`withCLIEmission` wraps them (`cmd/gc/storage_boot.go` `censusBindingRelics` vs
`cmd/gc/cli_storage_routes.go:158`), and `HasLegacyResidents` has one caller. The
mechanism is real — nothing stops the next caller from handing a wrapped binding
to the verdict — but no live data-integrity bug was observed, and the record
should say so.

## What changed since the previous head (`4c02f3d8f5`)

**Base retargeted onto `main`, and that is the load-bearing change.** The old
head sat on `residency/storeref-series` (#5597). This one is `main` at
`c6bb2aa30d` plus exactly one commit — and `c6bb2aa30d` is PR A of the split
stack, **#5644, merged 2026-09-08 02:10Z**, which is what carried the
**closed-inclusive** verdict onto `main`.

The predicate's contract requires counting CLOSED rows
(`internal/beads/namespace_census.go`: *"Implementations MUST count CLOSED beads
and BOTH tiers"*), and that only agrees with a `storeref` verdict that is itself
closed-inclusive. On `main` before #5644 the verdict was open-only
(`HasOpenLegacyResidents`), so landing this ahead of it would have answered TRUE
where the scan it replaces answered FALSE — silently changing the boot verdict
out of order, or failing the `closed relic only` equivalence row. On this base
the verdict is `storeref.LegacyResidents` / `HasLegacyResidents`
(`IncludeClosed: true`) and the two agree by construction. Every open-only
spelling in the verdict path is gone; `OpenLegacyResidents` survives only as
`gc storage status`'s drain gauge, which is deliberate and has its own pins
(`TestOpenLegacyResidentsIgnoresAClosedRelic`,
`TestTheDrainReportIgnoresTheCensusCapability`,
`TestClosingTheLastRelicDrainsTheCountAndKeepsTheProbe`).

Four consequences of the retarget, all in this branch's favour:

- The `internal/storeref/relic_census_bench_test.go` hunk that used to depend on
  s6's `1b070b2d33` is now a plain file add. No s6/s7/s8 dependency remains, and
  no unmerged branch is in the base: this is `origin/main` and one commit.
- The segment applies verbatim. Cherry-picked onto `main` with **no conflicts**
  — `internal/storeref/relic_census.go` and `relic_census_test.go` auto-merged
  around the one thing #5644's own review added after this branch was cut,
  `ProvenLegacyResidents`, and not one line of this segment's production or test
  logic changed.
- `ProvenLegacyResidents` (base-owned, from #5644, read by
  `cmd/gc/by_id_relic_proof.go`) deliberately **does not** come through the new
  fast path, and this PR leaves it on the listing. It reads the OPEN-only census
  while the predicate is closed-inclusive by contract, so routing it here would
  silently widen what a by-id read is allowed to DENY on. Its own doc already
  advertises that swap as a separate, deliberate change ("swap
  `OpenLegacyResidents` for `LegacyResidents` and every caller inherits it"); it
  is not this PR's to make.
- The bench numbers were **re-measured on this base** rather than carried over.

**Squashed to one commit (`mc-xzso`).** The old head's `feat` half alone ships a
bare `store.(beads.NamespaceCensus)` at the verdict site *plus* a wrapper the
method-set guard forces to carry the method — a latent false-clean that only the
`fix` half closes. The two must never be bisectable apart, so they are now one
commit, together with the third head commit (the `api.State` doc fix below).

**`api.State` doc reconciled with the widened verdict.**
`ClassBindingHasLegacyResidents` still documented "still holds an **open** bead",
the opposite of what the value means after #5644. It now reads "a bead, open or
closed", matching the wording `storageRoutes.relics` and
`ClassBinding.HasLegacyResidents` already carry. Doc-only; no wire, schema or
handler change (`make dashboard-ci` green, spec unchanged).

**One review nit closed (`mc-wuwe`), doc-only.** The helper's comment claimed
`length()` counts in the units `substr()` indexes in "whatever the prefix
encodes". That is true on SQLite — which is what *both* implementations execute
on, the DoltLite read store included, since it opens the pure-Go sqlite driver —
but not universally: on a MySQL-executed engine `LENGTH()` is bytes while
`SUBSTR()` indexes characters. The comment now says which engine it is exact on
and what a third caller on the native Dolt engine would have to spell instead.

`mc-9m9s` (typed-nil store) needs no change and is not a hazard on this path:
`(*SQLiteStore).ensureOpen` returns `ErrStoreClosed` for a nil receiver, the
verdict turns that into an error, and `HasLegacyResidents` reads an error as
"keep the probe" — the predicate path is *safer* here than the scan it replaces.

### Measured (re-run on this base — `main` + this commit — `-benchtime 20x`)

| benchmark (10k rows, same seeded fixture) | ns/op |
| --- | --- |
| `BenchmarkRelicCensusCleanBinding_10k` (predicate) | **1.97 ms** |
| `BenchmarkRelicCensusScanFallback_10k` (what this replaced) | 89.35 ms |
| `BenchmarkRelicCensusOpenOnly_10k` | 49.89 ms |
| `BenchmarkRelicCensusCleanBinding_1k` (predicate) | 0.43 ms |

~45x on the clean-binding case — the case that cannot be memoized away, since
only the TRUE verdict is monotone.

The predicate is still O(rows): a NOT-prefix predicate cannot seek an index, and
the code comment says so in as many words. What it stops being is a **hydration**.

## Testing

RED first, then GREEN. Each mutation below was forced, observed, and reverted;
the failing sets are **disjoint**, so each pins a different property rather than
all three re-testing the answer. Mutation 1 was **re-run on this base** after the
rebase onto `main`; 2 and 3 were taken on the previous base over a segment whose
production and test logic is byte-identical to this one.

**1. Closed-inclusive — the property the retarget exists for.**
Adding `status <> 'closed'` to both predicates (SQLite and DoltLite):

| test | result |
| --- | --- |
| `TestSQLiteHasResidentOutside/a_closed_relic_is_still_a_resident` | **FAIL** |
| `TestDoltliteHasResidentOutside/a_closed_relic_is_still_a_resident` | **FAIL** |
| `TestTheCensusPredicateAndTheScanAgree/closed_relic_only` | **FAIL** |
| `cmd/gc TestBootCensusKeepsTheProbeForAClosedRelic` | **FAIL** |
| `cmd/gc TestClosingTheLastRelicDrainsTheCountAndKeepsTheProbe` | **FAIL** |
| `TestSQLiteHasResidentOutside` — other 11 rows | PASS |
| `TestDoltliteHasResidentOutside` — other 10 rows | PASS |
| `TestTheCensusPredicateAndTheScanAgree` — other 9 rows | PASS |
| `cmd/gc TestBootCensusKeepsTheProbeForAMigratedBead` | PASS |
| `cmd/gc TestBootCensusRetiresTheProbeOnACleanBinding` | PASS |

The `cmd/gc` rows are the end-to-end half: those boot gates run against real
SQLite bindings, so with this change they now reach the **predicate**, and the
closed-relic verdict is pinned through the whole boot path rather than only at
the store.

**2. The answer, independent of which rows it counts.** Forcing the predicate
always-false additionally killed `TestBootCensusKeepsTheProbeForAMigratedBead`
and six equivalence rows (`open relic`, `closed relic only`, `wisp relic`,
`lookalike prefix`, `binding claiming no namespace`, `blank namespace`), while
`clean binding`, `closed in-namespace only`, `bare prefix id` and `empty binding`
correctly survived.

**3. The routing, independent of the answer.** Reverting the verdict's discovery
to a bare `store.(beads.NamespaceCensus)` killed
`TestTheVerdictReachesThePredicateThroughAWrapper` and
`TestTheVerdictScansThroughAWrapperWhoseBackingCannotAnswer` (both rows) and
**nothing else**, with `internal/beads` green as a control. Making the verdict
skip discovery entirely — always scan — killed a *different* set:
`TestLegacyResidentsVerdictUsesTheCensusCapability`,
`TestLegacyResidentsVerdictTakesTheCensusCapabilitysCleanAnswer`,
`TestACensusCapabilityErrorKeepsItsProbe` and
`TestTheVerdictReachesThePredicateThroughAWrapper`, and nothing else. Both
directions pin the capability gate rather than the verdict.

### Gates

| command | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `CGO_ENABLED=0 go vet -tags gascity_native_beads ./internal/beads/` | 0 |
| `gofmt -l cmd internal` | 0, no output |
| `golangci-lint run ./internal/storeref/... ./internal/beads/... ./cmd/gc/...` | 0, `0 issues` |
| `./scripts/check-residency-boundary.sh` | 0 (baseline needed no growth; the segment adds no `residency:allow`) |
| `go test ./internal/storeref/... ./internal/beads/... -count=1` | 0 |
| `go test ./cmd/gc -run 'Relic\|Census\|Residency\|Storage' -count=1` | 0 |
| `make test-native-doltlite-beads` | 0, verified **non-vacuous**: `TestDoltliteHasResidentOutside` (11 subtests, incl. the closed-relic row and two wisp rows) and `TestDoltliteReadStoreIsANamespaceCensus` all PASS under `-v` |
| `make check-docs` | 0 |
| `make dashboard-ci` | 0 — run because `internal/api/state.go` is touched; no generated artifact moved |
| `make test-fast-parallel` | 0 (first invocation returned 75 without running anything — the local `push-gate` slot cap timed out waiting on two other suites on this host; re-run once a slot freed) |

## Checklist

- [x] Linked an issue — `ga-dx4ho`, under epic `ga-qdt5y`, stack `ga-j4p3y`
- [x] Added or updated tests for behavior changes — including an explicit
      predicate-vs-scan equivalence suite, so the fast path cannot answer
      differently from the listing form it replaces
- [x] Updated docs for user-facing changes — none; this is a boot-path
      optimisation with an unchanged verdict. The one doc edit is the `api.State`
      interface comment, corrected to the semantics #5644 already shipped.
- [x] Called out breaking changes or migration notes — none. `NamespaceCensus` is
      **optional**: a store that does not implement it lists exactly as before.

Known follow-ups, filed and not blocking: `ga-j1stb` (`splittest` forwards
`GraphApplyHandle`/`ConditionalWriterHandle` but not `NamespaceCensusHandle`, so
kit leaves scan while production predicates — a fidelity gap the equivalence
suite already pins the answer for) and `ga-55w1j` (the DoltLite pre-wisps-migration
skip has no test row; it mirrors `List`'s skip and fails conservatively).
