### PR TITLE
perf(scripts): screen the residency grep census with each pattern's required literal

### DIFF
--- a/scripts/residency_grep_rule_test.go
+++ b/scripts/residency_grep_rule_test.go
@@ -2,10 +2,12 @@ package scripts_test
 
 import (
 	"bufio"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"regexp/syntax"
 	"strings"
 	"testing"
 )
@@ -24,11 +26,45 @@ import (
 type residencyPattern struct {
 	name  string
 	regex *regexp.Regexp
+
+	// core is a literal string every line this pattern can match MUST contain,
+	// derived from the parsed pattern. strings.Contains(line, core) is
+	// therefore a sound screen in front of the regex: it can only skip lines
+	// the regex would have missed anyway.
+	core string
+
+	// witness is a synthesized line the pattern matches. It is the load-time
+	// proof that core was derived from a REQUIRED position, and it is what the
+	// equivalence control builds its on-disk fixture out of — so a vocabulary
+	// row added to the pattern file is exercised by that control on the day it
+	// lands, with no second hand-kept list.
+	witness string
 }
+
+// residencyPrefilter selects whether the census screens each line with a
+// pattern's required literal before running that pattern's regex.
+//
+// It is a parameter rather than a constant because the prefilter's entire
+// contract is that it changes NOTHING: the equivalence control runs the same
+// census both ways over the same on-disk tree and refuses a single differing
+// row. "It got faster" is not evidence that it still counts the same sites,
+// and a guard that has quietly stopped biting is worse than a slow one.
+type residencyPrefilter bool
+
+const (
+	residencyPrefilterOn  residencyPrefilter = true
+	residencyPrefilterOff residencyPrefilter = false
+)
 
 // loadResidencyPatterns reads the forbidden vocabulary from the file the shell
 // guard reads. One source of truth: two hand-kept copies of "what is forbidden"
 // would be this guard's own bug class, one level up.
+//
+// It also derives each row's prefilter core and self-checks the derivation. A
+// derivation that cannot be made fails the whole suite here rather than
+// degrading to an unscreened scan: the census is the product, the prefilter is
+// only its cost, and a guard is allowed to be slow but never allowed to be
+// quietly narrower than its own pattern file.
 func loadResidencyPatterns(t *testing.T, dir string) []residencyPattern {
 	t.Helper()
 	f, err := os.Open(filepath.Join(dir, "residency-boundary-patterns.txt"))
@@ -52,13 +88,198 @@ func loadResidencyPatterns(t *testing.T, dir string) []residencyPattern {
 		if err != nil {
 			t.Fatalf("pattern %q: %v", name, err)
 		}
-		out = append(out, residencyPattern{name: name, regex: re})
+		parsed, err := syntax.Parse(expr, syntax.Perl)
+		if err != nil {
+			t.Fatalf("pattern %q: parsing for the prefilter core: %v", name, err)
+		}
+		core, err := residencyPatternCore(parsed)
+		if err != nil {
+			t.Fatalf("pattern %q: %v", name, err)
+		}
+		witness, err := residencyPatternWitness(parsed)
+		if err != nil {
+			t.Fatalf("pattern %q: %v", name, err)
+		}
+		if strings.ContainsAny(witness, "\n\r") {
+			t.Fatalf("pattern %q: the synthesized witness %q spans lines, and this census is line-oriented; neither the self-check below nor the equivalence fixture can carry it", name, witness)
+		}
+		if !re.MatchString(witness) {
+			t.Fatalf("pattern %q: the synthesized witness %q does not match its own pattern; the witness generator does not understand this row, so nothing it certifies about the core %q can be trusted", name, witness, core)
+		}
+		if !strings.Contains(witness, core) {
+			t.Fatalf("pattern %q: the derived core %q is absent from %q, a line the pattern matches; the prefilter would drop a real enumeration site", name, core, witness)
+		}
+		out = append(out, residencyPattern{name: name, regex: re, core: core, witness: witness})
 	}
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("reading the pattern file: %v", err)
 	}
 	if len(out) == 0 {
 		t.Fatal("the pattern file declares no pattern; the guard is evaluating nothing")
+	}
+	return out
+}
+
+// residencyPatternCore derives, from a parsed vocabulary pattern, a literal
+// string every line that pattern can match must contain.
+//
+// It reads the PARSE TREE rather than editing the pattern text, because the
+// property the prefilter needs is not "the longest run of ordinary characters"
+// but "a literal the match cannot avoid", and the two part company on the rows
+// this file already carries. Strip the metacharacters from
+// `cliSoleClassBinding(Store)?\(` textually and the answer is
+// `cliSoleClassBindingStore(` — a core no call of the un-suffixed accessor
+// contains, so the census would stop counting exactly the sites that row exists
+// to count, and stop silently. That is this guard's own bug class one level up:
+// a rule that still runs, still passes, and no longer sees anything.
+//
+// Only literals on the unconditional path are eligible — a concatenation's own,
+// and those of the groups it captures unconditionally. Everything under an
+// alternation or a quantifier is skipped: for an alternation or an optional
+// group that is required, since a match need not go through it; for a `+` it is
+// merely conservative. Conservative is the safe direction — a screen weaker than
+// it could be still counts every site, while one stronger than the pattern
+// justifies stops counting, and stops silently. The longest eligible literal is
+// simply the strongest of the sound choices.
+func residencyPatternCore(re *syntax.Regexp) (string, error) {
+	best := ""
+	var walk func(*syntax.Regexp)
+	walk = func(r *syntax.Regexp) {
+		switch r.Op {
+		case syntax.OpLiteral:
+			// A case-folded literal is not a substring requirement for the
+			// case-sensitive strings.Contains the scan uses, and Go parses
+			// (?i)abc as the literal "ABC" — using those runes verbatim would
+			// screen out every real line.
+			if r.Flags&syntax.FoldCase != 0 {
+				return
+			}
+			if lit := string(r.Rune); len(lit) > len(best) {
+				best = lit
+			}
+		case syntax.OpConcat, syntax.OpCapture:
+			for _, sub := range r.Sub {
+				walk(sub)
+			}
+		}
+	}
+	walk(re)
+	if best == "" {
+		return "", fmt.Errorf("no required literal could be derived from %q, so the prefilter has no sound screen for it; give the row a literal core or teach residencyPatternCore this shape — do not scan without one", re.String())
+	}
+	return best, nil
+}
+
+// residencyPatternWitness synthesizes one line the pattern matches, taking the
+// shortest route through every choice the pattern offers.
+//
+// It has two jobs. At load time it is the self-check: a core absent from a line
+// its own pattern matches was not derived from a required position, and the
+// suite fails rather than censusing the tree through a screen nobody checked.
+// In the controls it is the equivalence fixture, so the vocabulary file stays
+// the single source of truth for what the equivalence row exercises.
+//
+// An operator it does not understand is an error, never a best guess: a bogus
+// witness would let both jobs report a success they did not earn.
+func residencyPatternWitness(re *syntax.Regexp) (string, error) {
+	switch re.Op {
+	case syntax.OpLiteral:
+		// A folded literal's runes are the folding orbit's representatives
+		// ((?i)abc parses as "ABC"), so emitting them verbatim would not be a
+		// witness. residencyPatternCore refuses folded literals for the same
+		// reason; there are none in the pattern file and there is no honest
+		// way to invent one here.
+		if re.Flags&syntax.FoldCase != 0 {
+			return "", fmt.Errorf("case-folded literal %q has no verbatim witness", string(re.Rune))
+		}
+		return string(re.Rune), nil
+	case syntax.OpEmptyMatch, syntax.OpBeginLine, syntax.OpEndLine, syntax.OpBeginText, syntax.OpEndText, syntax.OpWordBoundary:
+		return "", nil
+	case syntax.OpQuest, syntax.OpStar:
+		return "", nil
+	case syntax.OpCapture, syntax.OpPlus:
+		return residencyPatternWitness(re.Sub[0])
+	case syntax.OpRepeat:
+		sub, err := residencyPatternWitness(re.Sub[0])
+		if err != nil {
+			return "", err
+		}
+		return strings.Repeat(sub, re.Min), nil
+	case syntax.OpConcat:
+		var b strings.Builder
+		for _, part := range re.Sub {
+			w, err := residencyPatternWitness(part)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(w)
+		}
+		return b.String(), nil
+	case syntax.OpAlternate:
+		for _, branch := range re.Sub {
+			if w, err := residencyPatternWitness(branch); err == nil {
+				return w, nil
+			}
+		}
+		return "", fmt.Errorf("no branch of %q has a witness", re.String())
+	case syntax.OpCharClass:
+		// The first PRINTABLE ASCII rune in the class. A negated identifier
+		// class such as [^A-Za-z0-9_] begins at NUL, and a NUL in a fixture
+		// line would be a witness no source file could carry.
+		for i := 0; i+1 < len(re.Rune); i += 2 {
+			for r := re.Rune[i]; r <= re.Rune[i+1] && r < 0x7f; r++ {
+				if r >= 0x20 {
+					return string(r), nil
+				}
+			}
+		}
+		return "", fmt.Errorf("class %q holds no printable ASCII rune", re.String())
+	case syntax.OpAnyChar, syntax.OpAnyCharNotNL:
+		return "x", nil
+	}
+	return "", fmt.Errorf("unsupported operator %v in %q", re.Op, re.String())
+}
+
+// The equivalence control's fixture: one file, one function, one line per
+// vocabulary row.
+const (
+	residencyWitnessFixturePath = "cmd/gc/witness_census.go"
+	residencyWitnessFixtureFunc = "everyPattern"
+)
+
+// residencyWitnessFixture renders a fixture file carrying every pattern's own
+// synthesized witness, one per line.
+//
+// The body is deliberately not compilable Go. This census is textual by design
+// (see the enclosingFuncRe comment below), and deriving the fixture from the
+// pattern file rather than hand-writing call sites is what keeps the
+// equivalence control exhaustive as the vocabulary grows: a row nobody wrote a
+// fixture for would make that control vacuous for exactly the row most likely
+// to be mis-derived — the newest one.
+func residencyWitnessFixture(patterns []residencyPattern) string {
+	var b strings.Builder
+	b.WriteString("package main\n\nfunc " + residencyWitnessFixtureFunc + "() {\n")
+	for _, p := range patterns {
+		b.WriteString("\t" + p.witness + "\n")
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// residencyCensusDiff reports every key whose count differs between two
+// censuses of the same tree, naming each side so the failure says which scan
+// lost the row.
+func residencyCensusDiff(a, b map[string]int, aLabel, bLabel string) []string {
+	var out []string
+	for _, key := range sortedKeys(a) {
+		if a[key] != b[key] {
+			out = append(out, fmt.Sprintf("%s: %d with %s, %d with %s", strings.ReplaceAll(key, "\t", " "), a[key], aLabel, b[key], bLabel))
+		}
+	}
+	for _, key := range sortedKeys(b) {
+		if _, ok := a[key]; !ok {
+			out = append(out, fmt.Sprintf("%s: absent with %s, %d with %s", strings.ReplaceAll(key, "\t", " "), aLabel, b[key], bLabel))
+		}
 	}
 	return out
 }
@@ -91,7 +312,12 @@ const residencyFileScope = "(file-scope)"
 // the same file, and the count is level. Family (a) — the bulk of the baseline
 // — is consumption-shaped, so the signature-level AST half cannot see that swap
 // either. The residual, stated honestly, is a swap within one function.
-func scanResidencyGrepSites(root string, dirs []string, allowlist map[string]bool, patterns []residencyPattern) (map[string]int, error) {
+//
+// prefilter screens each line with that pattern's required literal before
+// running its regex, which is what keeps a full-tree census off the seconds
+// scale. Off is not a production mode: it exists so the equivalence control can
+// scan one tree both ways and prove the screen is invisible.
+func scanResidencyGrepSites(root string, dirs []string, allowlist map[string]bool, patterns []residencyPattern, prefilter residencyPrefilter) (map[string]int, error) {
 	found := map[string]int{}
 	for _, dir := range dirs {
 		abs := filepath.Join(root, filepath.FromSlash(dir))
@@ -135,6 +361,13 @@ func scanResidencyGrepSites(root string, dirs []string, allowlist map[string]boo
 					continue
 				}
 				for _, p := range patterns {
+					// p.core is a literal every line this pattern can match
+					// must contain, so a line without it is a line the regex
+					// would have rejected. The census-equivalence control is
+					// what turns that argument into evidence.
+					if prefilter == residencyPrefilterOn && !strings.Contains(line, p.core) {
+						continue
+					}
 					if p.regex.MatchString(line) {
 						found[rel+"\t"+fn+"\t"+p.name]++
 					}
@@ -154,7 +387,7 @@ func scanResidencyGrepSites(root string, dirs []string, allowlist map[string]boo
 func TestResidencyBoundaryGrepRatchet(t *testing.T) {
 	root := repoRoot(t)
 	patterns := loadResidencyPatterns(t, residencyScriptsDir(t))
-	found, err := scanResidencyGrepSites(root, residencyScanDirs, residencyAllowlist, patterns)
+	found, err := scanResidencyGrepSites(root, residencyScanDirs, residencyAllowlist, patterns, residencyPrefilterOn)
 	if err != nil {
 		t.Fatalf("scanning: %v", err)
 	}
@@ -179,11 +412,19 @@ func TestResidencyBoundaryGrepControls(t *testing.T) {
 	base := map[string]int{"cmd/gc/pinned.go\ta\ta:BeadStores": 1}
 	scan := func(t *testing.T, baseline map[string]int) []string {
 		t.Helper()
-		found, err := scanResidencyGrepSites(root, residencyScanDirs, nil, patterns)
+		found, err := scanResidencyGrepSites(root, residencyScanDirs, nil, patterns, residencyPrefilterOn)
 		if err != nil {
 			t.Fatalf("scan: %v", err)
 		}
 		return ratchetViolations(found, baseline)
+	}
+	census := func(t *testing.T, tree string, with []residencyPattern, prefilter residencyPrefilter) map[string]int {
+		t.Helper()
+		found, err := scanResidencyGrepSites(tree, residencyScanDirs, nil, with, prefilter)
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		return found
 	}
 
 	t.Run("baselined site passes", func(t *testing.T) {
@@ -242,7 +483,7 @@ func TestResidencyBoundaryGrepControls(t *testing.T) {
 		// tree, so it can have no baseline row to be pinned by.
 		writeResidencyFixture(t, wrapped, "cmd/gc/cmd_bd_topology.go",
 			"package main\n\nfunc workAxis() { _ = BeadStores() }\n")
-		found, err := scanResidencyGrepSites(wrapped, residencyScanDirs, residencyAllowlist, patterns)
+		found, err := scanResidencyGrepSites(wrapped, residencyScanDirs, residencyAllowlist, patterns, residencyPrefilterOn)
 		if err != nil {
 			t.Fatalf("scan: %v", err)
 		}
@@ -285,4 +526,167 @@ func TestResidencyBoundaryGrepControls(t *testing.T) {
 			t.Fatalf("the violation must name both the new function and the retired one: %v", v)
 		}
 	})
+
+	// The prefilter must never be able to switch itself off quietly. An empty
+	// core screens every line IN, so a census that lost its screens would stay
+	// perfectly correct — which is precisely why no other row in this file can
+	// see it, and why residencyPatternCore returns an error rather than "".
+	t.Run("every vocabulary row carries a screen", func(t *testing.T) {
+		for _, p := range patterns {
+			if p.core == "" {
+				t.Errorf("pattern %q has an empty prefilter core: it screens nothing, so the prefilter is off for that row and the equivalence row below cannot tell", p.name)
+			}
+		}
+	})
+
+	// The prefilter's whole contract, on a real on-disk tree: it is a COST
+	// change, not a census change. Scan the same tree both ways and refuse a
+	// single differing row.
+	//
+	// The fixture carries one line per vocabulary row, so the row is not
+	// vacuous for the pattern most likely to be mis-derived — the newest one —
+	// and the reachability check below is what says so out loud: an
+	// equivalence that held because both scans found nothing would be the
+	// vacuous green this contract exists to prevent.
+	t.Run("the census is identical with the prefilter off", func(t *testing.T) {
+		tree := t.TempDir()
+		writeResidencyFixture(t, tree, residencyWitnessFixturePath, residencyWitnessFixture(patterns))
+		off := census(t, tree, patterns, residencyPrefilterOff)
+		for _, p := range patterns {
+			if off[residencyWitnessFixturePath+"\t"+residencyWitnessFixtureFunc+"\t"+p.name] == 0 {
+				t.Fatalf("pattern %q was never censused in the witness fixture, so the equivalence row proves nothing about it; its synthesized witness %q does not survive being written as a fixture line", p.name, p.witness)
+			}
+		}
+		on := census(t, tree, patterns, residencyPrefilterOn)
+		if diff := residencyCensusDiff(off, on, "the prefilter off", "the prefilter on"); len(diff) != 0 {
+			t.Fatalf("the prefilter changed the census, so it is not a prefilter but a second, narrower rule: %s", strings.Join(diff, "; "))
+		}
+	})
+
+	// The control of the control. The equivalence row above is evidence only if
+	// it can fail, and the failure it exists to catch is a core NARROWER than
+	// its pattern — the screen skipping a line the regex would have counted.
+	// Narrow every core and the row must bite; if it does not, it is decoration
+	// and the derivation is unguarded.
+	t.Run("the equivalence row bites an over-narrow core", func(t *testing.T) {
+		tree := t.TempDir()
+		writeResidencyFixture(t, tree, residencyWitnessFixturePath, residencyWitnessFixture(patterns))
+		off := census(t, tree, patterns, residencyPrefilterOff)
+		on := census(t, tree, residencyNarrowedCores(patterns), residencyPrefilterOn)
+		if diff := residencyCensusDiff(off, on, "the prefilter off", "over-narrow cores"); len(diff) == 0 {
+			t.Fatal("an over-narrow core changed no census row: the equivalence row cannot see a prefilter that drops sites, so it certifies nothing about the real derivation")
+		}
+	})
+
+	// And the other half of that argument: the OFF side has to actually be off.
+	// If it quietly screened too, the equivalence row would be comparing a
+	// screened census with a screened census — green, and vacuous. Hand the off
+	// scan a core no line can contain and it must count the sites anyway.
+	t.Run("the prefilter-off census ignores the core", func(t *testing.T) {
+		tree := t.TempDir()
+		writeResidencyFixture(t, tree, residencyWitnessFixturePath, residencyWitnessFixture(patterns))
+		plain := census(t, tree, patterns, residencyPrefilterOff)
+		narrowed := census(t, tree, residencyNarrowedCores(patterns), residencyPrefilterOff)
+		if diff := residencyCensusDiff(plain, narrowed, "the derived cores", "over-narrow cores"); len(diff) != 0 {
+			t.Fatalf("the prefilter-off census consulted the core, so it is not an unscreened baseline to compare against: %s", strings.Join(diff, "; "))
+		}
+	})
+}
+
+// residencyOverNarrowSuffix turns a derived core into one that is narrower than
+// its own pattern. A NUL byte appears in no Go source line, so appending it
+// makes every screen reject lines its regex would have matched — which is the
+// exact failure mode the equivalence row has to be able to see.
+const residencyOverNarrowSuffix = "\x00"
+
+// residencyNarrowedCores copies patterns with every screen sabotaged past what
+// its pattern requires. It is how both halves of the equivalence argument are
+// falsified: on the ON side a narrowed core must change the census, and on the
+// OFF side it must not.
+func residencyNarrowedCores(patterns []residencyPattern) []residencyPattern {
+	out := make([]residencyPattern, len(patterns))
+	copy(out, patterns)
+	for i := range out {
+		out[i].core += residencyOverNarrowSuffix
+	}
+	return out
+}
+
+// TestResidencyPatternCoreIsARequiredLiteral pins the derivation on the shapes
+// where "the longest run of ordinary characters" and "a literal the match
+// cannot avoid" part company.
+//
+// This is the census-equivalence row's unit twin, and it is deliberately built
+// from synthetic patterns rather than the vocabulary file: the shapes below
+// must stay guarded on the day someone retires the row that happens to carry
+// one today.
+func TestResidencyPatternCoreIsARequiredLiteral(t *testing.T) {
+	for _, row := range []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			// The shape a text-level derivation gets wrong. Strip the
+			// metacharacters from the real b:cliSoleClassBinding row and the
+			// answer is cliSoleClassBindingStore(, which the accessor's own
+			// call sites do not contain.
+			name: "an optional group is not required",
+			expr: `(^|[^A-Za-z0-9_])probeBinding(Store)?\(`,
+			want: "probeBinding",
+		},
+		{
+			name: "a boundary wrapper contributes nothing",
+			expr: `(^|[^A-Za-z0-9_])probeBinding\(`,
+			want: "probeBinding(",
+		},
+		{
+			name: "the longest alternation branch is not required",
+			expr: `(alpha|betaLongerBranch)probe\(`,
+			want: "probe(",
+		},
+		{
+			name: "a repeated group is not required",
+			expr: `probeStores(All)*\(`,
+			want: "probeStores",
+		},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			parsed, err := syntax.Parse(row.expr, syntax.Perl)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", row.expr, err)
+			}
+			got, err := residencyPatternCore(parsed)
+			if err != nil {
+				t.Fatalf("deriving a core for %s: %v", row.expr, err)
+			}
+			if got != row.want {
+				t.Fatalf("core(%s) = %q, want %q — a core wider than the pattern requires silently narrows the census", row.expr, got, row.want)
+			}
+		})
+	}
+
+	// The two shapes with no sound screen at all. Both must ERROR rather than
+	// hand back "", because "" screens every line in: the scan would keep
+	// passing, the census would keep looking right, and the guard would have
+	// silently reverted to the slow rule it was supposed to be equivalent to —
+	// or, worse, a future caller would read "" as "no screen needed".
+	//
+	// A case-folded literal is the subtler one: Go parses (?i)abc as the
+	// literal "ABC", so taking its runes verbatim would screen out every real
+	// line instead of none.
+	for _, row := range []struct{ name, expr string }{
+		{"a case-folded pattern has no sound core", `(?i)probeStores`},
+		{"a pattern with no literal has no core", `[a-z]+`},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			parsed, err := syntax.Parse(row.expr, syntax.Perl)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", row.expr, err)
+			}
+			if got, err := residencyPatternCore(parsed); err == nil {
+				t.Fatalf("%s was handed the screen %q instead of an error; an unsound screen must fail the suite, never disable itself", row.expr, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The Go half of the residency boundary guard ran all 25 vocabulary regexes against
every line of every file under the scan dirs: **11.04s** of the `./scripts` wall
clock, and growing with both the tree and the pattern file. A guard that slow is a
guard people start skipping, so the cost is a correctness risk and not just an
annoyance.

Each pattern now carries a `core` — a literal string every line it can match MUST
contain — and the scanner does `strings.Contains(line, core)` before the regex.
The core is derived mechanically by walking the `regexp/syntax` parse tree and
keeping only literals on the unconditional path (concat children and
unconditional captures), skipping alternations and quantifiers entirely and
refusing case-folded literals.

**Deriving from the parse tree rather than from the pattern text is the whole
point.** Text-level metacharacter stripping turns

```
(^|[^A-Za-z0-9_])cliSoleClassBinding(Store)?\(
```

into the core `cliSoleClassBindingStore(`, which no bare `cliSoleClassBinding(`
call site contains — the guard would have gone on reporting a green census while
silently counting fewer sites than the pattern file asks for.

A screen that is too narrow fails silently, so the derivation cannot be allowed to
fail quietly either. `residencyPatternCore` returns an **error** rather than an
empty string when it can find no required literal, and `loadResidencyPatterns`
`t.Fatalf`s on it — an unscreenable row stops the suite instead of scanning
unscreened.

Soundness is proved by **census equivalence**, not by argument. The suite
synthesizes a minimal matching witness line per pattern from the same parse tree,
writes them to a real on-disk fixture tree, asserts every pattern is actually
censused there, then scans the tree with the prefilter off and on and fails on any
single-row diff. Because the fixture body is generated from the pattern file, a
vocabulary row added later joins that control the day it lands, with no second
hand-kept list to forget.

**`TestResidencyBoundaryGrepRatchet`: 11.04s → 0.40s (~28x).**

Follow-on to #5597 (epic `ga-qdt5y`). Closes `ga-laswd`. Test-only; no production
code changes.

## Testing

- [x] `gofmt -l scripts/` — no output
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./scripts/` — ok 84.4s (whole package: the shell/Go halves-agree
      test and all four residency rules)
- [x] `go test ./scripts/ -run 'TestResidencyBoundaryGrep|TestResidencyPatternCore' -v`
      — 3 top-level PASS, 17 sub-row PASS, ok 0.46s
- [x] Pre-commit hook ran on the staged change: `lint-changed ./scripts` — 0
      issues; docs/schema regeneration produced no diff
- [x] **Mutation proof — each a real on-disk edit, reverted after.** An AST/grep
      guard cannot be falsified with an in-memory overlay, so none of these used
      one:
      - *core derived text-level instead* (the sabotage above): the load-time
        self-check died on `the derived core "cliSoleClassBindingStore(" is absent
        from "cliSoleClassBinding("`; with that check neutered so the row could be
        observed independently, the equivalence row died naming
        `cmd/gc/witness_census.go everyPattern b:cliSoleClassBinding: 1 with the
        prefilter off, 0 with it on`, and 3 of 4 derivation unit rows died.
      - *prefilter never applied*: ONLY `the equivalence row bites an over-narrow
        core` died, and the ratchet's wall time went back to 10.681s.
      - *prefilter always applied, ignoring the off mode*: ONLY `the prefilter-off
        census ignores the core` died, naming all 25 patterns. That row exists
        because an off side that quietly screened would make the equivalence row
        compare screened against screened — green and vacuous.
      - *derivation returns `""` instead of an error*: both `a case-folded pattern
        has no sound core` and `a pattern with no literal has no core` died.
      - *witness set to the core itself*: the load-time `MatchString(witness)`
        check died, proving the witness check is not circular.

      Different tests die each way. All seven pre-existing control rows pass
      before and after, and **the baseline does not move**.

## Checklist

- [x] Linked an issue — `ga-laswd`, under epic `ga-qdt5y`
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes — none; this is guard machinery
- [x] Called out breaking changes or migration notes — none. The census verdict is
      proved identical row-for-row; only the time it takes changed.
