### PR TITLE
test(rigidem): pin the rig-create idem record to the work class

### DIFF
--- a/internal/api/rigidem_class_pin_test.go
+++ b/internal/api/rigidem_class_pin_test.go
@@ -51,8 +51,17 @@ func (t *idemCreateRecorderTx) Create(b beads.Bead) (beads.Bead, error) {
 // grows an arm that claims it, the write becomes a stranded one: the record
 // lands in the work ledger while the class's own readers look at the relocated
 // binding, and the rig-create idempotency axis silently stops converging on a
-// split city. Nothing else in the tree would notice, which is why the hazard
-// gets a pin instead of a seam.
+// split city. The one thing that would notice is confirmInfraConvergence
+// (cmd/gc/infra_class_migrate.go), which re-checks containment on every boot
+// of a converged split city and refuses to serve while naming the stranded
+// ids — but only after the writes are already stranded, and not at all on a
+// city that converged before its copy manifest was recorded, where
+// stranded-write detection is off. Failing at build time instead is why the
+// hazard gets a pin rather than a seam.
+//
+// The pin's scope is createIdemRecord's create-time literal: the post-create
+// SetMetadataBatch writers are trusted to stay within gc.idem.*, a namespace
+// no classifier arm keys on.
 func TestRigIdemRecordsStayWorkClass(t *testing.T) {
 	rec := &idemCreateRecorder{Store: beads.NewMemStore()}
 	if _, err := createIdemRecord(rec, "c1", "req-classpin1", "digestval", "7", "web", idemStateInFlight); err != nil {

--- a/internal/api/rigidem_class_pin_test.go
+++ b/internal/api/rigidem_class_pin_test.go
@@ -72,7 +72,8 @@ func TestRigIdemRecordsStayWorkClass(t *testing.T) {
 	if class := coordclass.Classify(got); class != coordclass.ClassWork {
 		t.Fatalf("coordclass.Classify(idem record) = %s, want %s.\n"+
 			"Remedy: if coordclass grows a %q arm, rigidem's writes must take placement "+
-			"(storeref.ResolvePlacement) in the same change — otherwise createIdemRecord "+
+			"through Server.createStoreForBead (internal/api/residency_create.go), which plans "+
+			"and then resolves, in the same change — otherwise createIdemRecord "+
 			"keeps writing the record into the work ledger that no longer serves its class.",
 			class, coordclass.ClassWork, idemLabel)
 	}

--- a/internal/api/rigidem_class_pin_test.go
+++ b/internal/api/rigidem_class_pin_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// idemCreateRecorder wraps a store and records every bead handed to Create
+// inside a transaction. Classifying the recorded value pins the write site
+// itself rather than a hand-copied duplicate of its literal, so a change to the
+// shape createIdemRecord writes is carried into the assertion instead of
+// drifting away from it.
+type idemCreateRecorder struct {
+	beads.Store
+	created []beads.Bead
+}
+
+// Tx runs the wrapped store's transaction with a Tx that records creates.
+func (r *idemCreateRecorder) Tx(commitMsg string, fn func(beads.Tx) error) error {
+	return r.Store.Tx(commitMsg, func(tx beads.Tx) error {
+		return fn(&idemCreateRecorderTx{Tx: tx, rec: r})
+	})
+}
+
+// idemCreateRecorderTx is the recording half of idemCreateRecorder.
+type idemCreateRecorderTx struct {
+	beads.Tx
+	rec *idemCreateRecorder
+}
+
+// Create records the bead as the caller wrote it, then performs the real
+// create. The pre-store value is the one that matters: it is what a class
+// router would classify to choose a destination, before the store fills in ID,
+// status and timestamps.
+func (t *idemCreateRecorderTx) Create(b beads.Bead) (beads.Bead, error) {
+	t.rec.created = append(t.rec.created, b)
+	return t.Tx.Create(b)
+}
+
+// TestRigIdemRecordsStayWorkClass pins the durable rig-create idempotency
+// record to the work class.
+//
+// createIdemRecord writes straight to the store it is handed — there is no
+// placement hop on the path — and that is only correct while the record
+// classifies as work, which today it does by falling through every arm of
+// coordclass.Classify: "gc-idem" is not a class marker. The day coordclass
+// grows an arm that claims it, the write becomes a stranded one: the record
+// lands in the work ledger while the class's own readers look at the relocated
+// binding, and the rig-create idempotency axis silently stops converging on a
+// split city. Nothing else in the tree would notice, which is why the hazard
+// gets a pin instead of a seam.
+func TestRigIdemRecordsStayWorkClass(t *testing.T) {
+	rec := &idemCreateRecorder{Store: beads.NewMemStore()}
+	if _, err := createIdemRecord(rec, "c1", "req-classpin1", "digestval", "7", "web", idemStateInFlight); err != nil {
+		t.Fatalf("createIdemRecord: %v", err)
+	}
+
+	// Non-vacuity: a pin that classifies nothing, or classifies the wrong
+	// bead, passes for free. Both guards fail loudly instead.
+	if len(rec.created) != 1 {
+		t.Fatalf("createIdemRecord created %d beads, want exactly 1: there is nothing for this pin to classify", len(rec.created))
+	}
+	got := rec.created[0]
+	if !slices.Contains(got.Labels, idemLabel) {
+		t.Fatalf("recorded bead labels = %v, want the %q marker: this is not the idem record, so the class assertion below would prove nothing", got.Labels, idemLabel)
+	}
+
+	if class := coordclass.Classify(got); class != coordclass.ClassWork {
+		t.Fatalf("coordclass.Classify(idem record) = %s, want %s.\n"+
+			"Remedy: if coordclass grows a %q arm, rigidem's writes must take placement "+
+			"(storeref.ResolvePlacement) in the same change — otherwise createIdemRecord "+
+			"keeps writing the record into the work ledger that no longer serves its class.",
+			class, coordclass.ClassWork, idemLabel)
+	}
+
+	// Control: the classifier must still be able to answer something other
+	// than work for this bead. Without it, a Classify gutted to always-work —
+	// the mutation that would make the pin above meaningless — would read as a
+	// pass.
+	infra := got
+	infra.Labels = append(slices.Clone(got.Labels), session.LabelSession)
+	if class := coordclass.Classify(infra); class == coordclass.ClassWork {
+		t.Fatalf("control: coordclass.Classify(idem record + %q) = %s, want any infrastructure class: "+
+			"the classifier reports work for everything, so the pin above is vacuous",
+			session.LabelSession, class)
+	}
+}


### PR DESCRIPTION
## Summary

`createIdemRecord` writes the durable `(city, request_id)` record straight to the
store it is handed — there is no placement hop on that path — and that is only
correct while the record classifies as **work**. Today it does, but only by
falling through every arm of `coordclass.Classify`: `gc-idem` is not a class
marker.

Nothing states that dependency. An arm added later would silently convert every
idem write into a stranded one on a split city: the record lands in the work
ledger while the class's own readers follow the relocated binding, and the
rig-create idempotency axis stops converging. The only thing that would notice is
`confirmInfraConvergence` (`cmd/gc/infra_class_migrate.go`), which re-checks
containment on every boot of a converged split city and refuses to serve while
naming the stranded ids — after the writes are already stranded, and not at all
on a city that converged before its copy manifest was recorded.

Failing at build time instead is why this gets a pin rather than a seam — the
fix, if it ever fires, is to route the write through `Server.createStoreForBead`
(`internal/api/residency_create.go`), which plans and then resolves placement,
and the pin says so. The
test classifies the bead `createIdemRecord` **actually hands to `tx.Create`**,
captured through a recording store, rather than a hand-copied literal, so a change
to the written shape is carried into the assertion instead of drifting away from
it.

Follow-on to #5597 (epic `ga-qdt5y`). Closes `ga-yx7h7`. Test-only; **no
production behavior changes.**

## Testing

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (also re-run by the pre-commit hook with
      `-mod=readonly`)
- [x] `go test ./internal/api/` — ok 92.1s (full package; the only package touched)
- [x] `go test ./internal/coordclass/` — ok 0.13s (proves no toy-arm residue from
      the mutation proof)
- [x] `go test ./internal/api/ -run TestRigIdem -v` — 22/22 PASS including the new
      `TestRigIdemRecordsStayWorkClass`; the pre-existing
      `TestRigIdemRecordClosedAtCreateNeverReady` (nearest neighbour) unchanged
      and green
- [x] `gofmt -l` on both touched and mutated files — empty
- [x] Pre-commit hook active and ran on the staged change:
      `lint-changed: ./internal/api  0 issues`
- [x] **Mutation proof, three ways, each killing a different assertion:**
      - add a toy `coordclass` arm matching the `gc-idem` label → **the pin dies
        naming the remedy**: `coordclass.Classify(idem record) = orders, want work.
        Remedy: if coordclass grows a "gc-idem" arm, rigidem's writes must take
        placement through Server.createStoreForBead
        (internal/api/residency_create.go), which plans and then resolves, in the
        same change …`. The toy arm was reverted completely; `git diff` shows no
        `coordclass` change.
      - gut `classifyFields` to always-work → **the control dies instead**: *"the
        classifier reports work for everything, so the pin above is vacuous"*.
      - drop the recorder's capture → **the non-vacuity guard dies**: *"created 0
        beads … nothing for this pin to classify"*.
- [x] The residency boundary guard cannot move: both halves skip `*_test.go`
      (`scripts/check-residency-boundary.sh:269`, `scripts/residency_boundary_test.go:160`,
      `internal/api/residency_create_guard_test.go:51`), and
      no pattern in `scripts/residency-boundary-patterns.txt` matches
      `coordclass.Classify(`. Baseline untouched.

## Checklist

- [x] Linked an issue — `ga-yx7h7`, under epic `ga-qdt5y`
- [x] Added or updated tests for behavior changes — the change *is* the test
- [x] Updated docs for user-facing changes — none
- [x] Called out breaking changes or migration notes — none; test-only



