### PR TITLE
fix(dolt): verify the remote tip after compaction pushes and stop stranding stale pending-push markers

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -115,8 +115,9 @@ whole city.
 
 If a city's remote is not (yet) credentialed, opt out of the fetch so
 compaction runs entirely from the local source of truth. The post-compaction
-remote push is deferred via a pending-push marker and resumes automatically on a
-later run once the fetch path is healthy:
+remote push is deferred via a pending-push marker and retried on later runs
+once the fetch path is healthy (see the next section for what happens when it
+never does):
 
 ```bash
 # Skip the fetch for every database this run.
@@ -136,6 +137,46 @@ remote sync for every database, including ones whose push would otherwise
 succeed. Do **not** set the global opt-out in the shared `mol-dog-compactor`
 order for the same reason; set the per-database env on the affected city
 instead.
+
+## When a deferred remote push does not resume
+
+A compaction push counts as done only after the compactor re-probes the
+remote-tracking ref (`remotes/<remote>/<branch>`) and finds it on the local tip.
+Dolt advances that ref only once the remote has accepted the push, so a
+`DOLT_PUSH` that exits 0 without moving it — for example when the managed
+sql-server's read timeout kills the proxied client mid-push — keeps the
+pending-push marker, logs both hashes, and fails the run instead of reporting
+`pushed`. `gc dolt sync` applies the same check to its own pushes.
+
+A pending-push marker is retried on every compaction run until it is older than
+`GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS` (default 48h). Past that age the
+compactor grants exactly one more automatic retry, so a push that died once to
+a transient failure still self-heals. If the marker survives that retry, every
+later run fails with `manual review required` and the operator is alerted
+(mail to `GC_DOLT_COMPACT_ALERT_TO`, default `mayor`, plus a
+`dolt.compact.quarantine` event). The mail follows the shared marker
+notification cadence: once on detection, then again only after
+`GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS` (default 24h) elapses, recorded in the
+marker's own `notify_count` / `last_notified_ts` fields. Whether the one
+automatic retry has already been spent lives in a `<db>.retry-state` sidecar
+next to the marker, because a failed retry rewrites the marker itself:
+
+```text
+<city>/.gc/runtime/packs/dolt/compact-pending-push/<db>              # the deferred push
+<city>/.gc/runtime/packs/dolt/compact-pending-push/<db>.retry-state  # one-automatic-retry bookkeeping
+```
+
+To recover, first fix the remote (credentials, reachability, or the server
+read timeout), then either:
+
+- delete the `<db>.retry-state` sidecar — the next compaction run gets another
+  automatic retry (and alerts again if that one fails too), or
+- push by hand with `gc dolt sync --force --db <db>` (compaction rewrites
+  history, so the push must be forced), verify the remote tip, and delete the
+  marker together with its sidecar.
+
+A pending-GC marker (`compact-pending-gc/<db>`) that also carries a remote push
+follows the same gate and the same `.retry-state` sidecar convention.
 
 ## Compacting a database that must never reach a remote
 

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -56,6 +56,12 @@
 # Remote push failures are recorded in compact-pending-push markers and do not
 # fail local compaction. Later runs retry those markers before threshold skips,
 # and unverified remote heads must become ancestry-verifiable before push.
+# A push is reported as pushed (and its marker cleared) only after the remote-
+# tracking ref is re-probed and matches the local tip; a zero exit whose tip did
+# not move keeps the marker and fails the run. A marker older than
+# GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS gets one final automatic retry and,
+# if that does not clear it, a single operator alert (see
+# ensure_remote_push_retry_fresh).
 # A database marked .no-sync (same marker the sync and pull commands honor) has
 # no remote phase at all: it is never fetched or pushed, never gets a
 # pending-push marker, and an existing one is cleared so it cannot block flatten.
@@ -84,8 +90,12 @@
 #                     discovery. Shared with the health command; the
 #                     default lives in runtime.sh.
 #   GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS
-#     (default: 172800) — maximum age for automatic pending remote-push retry.
-#                       Older markers require manual review before push.
+#     (default: 172800) — age past which a pending remote-push marker gets one
+#                       final automatic retry. If that retry does not clear
+#                       the marker the run fails and alerts the operator
+#                       (subject to GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS);
+#                       removing the marker or its .retry-state sidecar
+#                       grants another automatic retry.
 #   GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS
 #     (default: 86400) — once a quarantine, pending-push, or pending-gc
 #                       marker has mailed an alert for an unchanged reason,
@@ -1019,6 +1029,17 @@ remote_branch_head() {
     "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/$remote/$branch'"
 }
 
+# local_branch_head — tip of the local branch a push sends. Probed immediately
+# before the push so push_remote_after_compaction can verify afterwards that
+# the remote-tracking ref landed on exactly that commit.
+local_branch_head() {
+  db="$1"
+  branch="$2"
+  valid_branch_name "$branch" || return 1
+  query_single_cell "$db" "local branch HEAD probe failed" \
+    "SELECT hash FROM dolt_branches WHERE name = '$branch'"
+}
+
 commit_exists_in_local_log() {
   db="$1"
   hash="$2"
@@ -1855,13 +1876,90 @@ compact_marker_created_at_epoch() {
   parse_compact_timestamp "$created_at"
 }
 
+# Stale pending-push bookkeeping. A marker older than pending_push_max_age_secs
+# used to be refused forever ("manual review required"), so a push that died
+# once to a transient failure (e.g. the managed sql-server's read_timeout)
+# stayed stranded until a human noticed. The gate now grants ONE automatic
+# retry before it fails closed. That retry bookkeeping lives in a sidecar next
+# to the marker (<marker>.retry-state) rather than in the marker itself,
+# because a failed retry rewrites the marker (write_compact_marker preserves
+# only created_at) and would erase any in-marker field. The sidecar is bound
+# to the marker it describes through marker_created_at, so a marker that is
+# removed and later re-created starts over with a fresh retry;
+# clear_compact_marker drops the sidecar with the marker, and removing just
+# the sidecar grants another automatic retry. Alerting stays with the shared
+# marker_should_notify / record_marker_notify_state bookkeeping — this gate
+# only decides whether a retry is still owed.
+pending_push_retry_state_path() {
+  printf '%s/%s.retry-state\n' "$1" "$2"
+}
+
+pending_push_retry_state_value() {
+  _rs_state=$(pending_push_retry_state_path "$1" "$2")
+  [ -f "$_rs_state" ] && [ -r "$_rs_state" ] || return 1
+  awk -v prefix="$3=" 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1); exit }' "$_rs_state"
+}
+
+# pending_push_retry_state_current DIR DB
+#   True when the sidecar describes the marker currently on disk (same
+#   created_at). Anything else counts as no state at all.
+pending_push_retry_state_current() {
+  _rs_marker_created=$(compact_marker_value "$1" "$2" created_at || true)
+  _rs_state_created=$(pending_push_retry_state_value "$1" "$2" marker_created_at || true)
+  [ -n "$_rs_marker_created" ] && [ "$_rs_marker_created" = "$_rs_state_created" ]
+}
+
+pending_push_stale_retry_attempted() {
+  pending_push_retry_state_current "$1" "$2" || return 1
+  [ "$(pending_push_retry_state_value "$1" "$2" stale_retry_attempted || true)" = "1" ]
+}
+
+# record_pending_push_retry_state DIR DB
+#   Stamps the single automatic retry for the marker currently on disk. A
+#   write failure is a silent no-op — bookkeeping must never block compaction
+#   (worst case one extra retry, never a stranded push).
+record_pending_push_retry_state() {
+  dir="$1"
+  db="$2"
+
+  _rs_marker_created=$(compact_marker_value "$dir" "$db" created_at || true)
+  [ -n "$_rs_marker_created" ] || return 0
+
+  _rs_attempted_at=""
+  if pending_push_retry_state_current "$dir" "$db"; then
+    _rs_attempted_at=$(pending_push_retry_state_value "$dir" "$db" stale_retry_at || true)
+  fi
+  [ -n "$_rs_attempted_at" ] || _rs_attempted_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  _rs_old_umask=$(umask)
+  umask 077
+  _rs_tmp=$(mktemp "$dir/$db.retry-state.tmp.XXXXXX") || {
+    umask "$_rs_old_umask"
+    return 0
+  }
+  umask "$_rs_old_umask"
+  if ! {
+    printf 'db=%s\n' "$db"
+    printf 'marker_created_at=%s\n' "$_rs_marker_created"
+    printf 'stale_retry_attempted=%s\n' 1
+    printf 'stale_retry_at=%s\n' "$_rs_attempted_at"
+  } > "$_rs_tmp" 2>/dev/null; then
+    rm -f "$_rs_tmp"
+    return 0
+  fi
+  mv -f "$_rs_tmp" "$(pending_push_retry_state_path "$dir" "$db")" || rm -f "$_rs_tmp"
+  return 0
+}
+
 # ensure_remote_push_retry_fresh DIR DB MARKER_LABEL
-#   Gates an automatic remote-push retry on marker age: markers older than
-#   pending_push_max_age_secs fail the retry and alert. The alert event
-#   fires every cycle; the alert mail is gated by marker_should_notify so
-#   an unresolved stale marker pages on first detection and then again only
-#   after the renotify backstop elapses, instead of on every single cycle
-#   (previously: unconditional mail on every invocation past max-age).
+#   Age gate for a deferred remote push. Fresh markers retry every run. A
+#   marker past pending_push_max_age_secs gets exactly one automatic retry
+#   (return 0 once); when it is still present on the next run the gate fails
+#   closed with the manual-review message and alerts. The alert event fires
+#   every cycle; the alert mail is gated by marker_should_notify so a stranded
+#   marker pages on first detection and then again only after the renotify
+#   backstop elapses, instead of on every single cycle. Dry runs report the
+#   decision without consuming the retry, recording state, or alerting.
 ensure_remote_push_retry_fresh() {
   dir="$1"
   db="$2"
@@ -1878,28 +1976,48 @@ ensure_remote_push_retry_fresh() {
   if [ "$age_secs" -lt 0 ]; then
     age_secs=0
   fi
-  if [ "$age_secs" -gt "$pending_push_max_age_secs" ]; then
-    printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss — manual review required before remote push retry\n' \
-      "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" >&2
-    stale_reason="$marker_label marker is stale"
-    stale_marker_path=$(compact_marker_path "$dir" "$db")
-    stale_marker_type=$(basename "$dir")
-    stale_created_at=$(compact_marker_value "$dir" "$db" created_at || true)
-    emit_compact_quarantine_event "$db" "$stale_marker_type" "$stale_marker_path" "$stale_reason" "$stale_created_at"
-    if marker_should_notify "$dir" "$db" "$stale_reason" "$compact_renotify_backstop_secs"; then
-      stale_seen_count=$(compact_marker_value "$dir" "$db" seen_count || true)
-      case "$stale_seen_count" in ''|*[!0-9]*) stale_seen_count=0 ;; esac
-      if mail_compact_quarantine_alert "$db" "$stale_marker_type" "$stale_marker_path" "$stale_reason age=${age_secs}s seen=$((stale_seen_count + 1))" "$stale_created_at"; then
-        record_marker_notify_state "$dir" "$db" "$stale_reason" 1
-      else
-        record_marker_notify_state "$dir" "$db" "$stale_reason" 0
-      fi
-    else
-      record_marker_notify_state "$dir" "$db" "$stale_reason" 0
+  if [ "$age_secs" -le "$pending_push_max_age_secs" ]; then
+    return 0
+  fi
+
+  if ! pending_push_stale_retry_attempted "$dir" "$db"; then
+    if [ -n "$dry_run" ]; then
+      printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss — dry-run (would attempt one automatic remote push retry before manual review)\n' \
+        "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" >&2
+      return 0
     fi
+    printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss — attempting one automatic remote push retry before manual review\n' \
+      "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" >&2
+    record_pending_push_retry_state "$dir" "$db"
+    return 0
+  fi
+
+  stale_reason="$marker_label marker is stale"
+  stale_marker_path=$(compact_marker_path "$dir" "$db")
+  stale_marker_type=$(basename "$dir")
+  stale_created_at=$(compact_marker_value "$dir" "$db" created_at || true)
+  stale_state_path=$(pending_push_retry_state_path "$dir" "$db")
+  stale_retry_at=$(pending_push_retry_state_value "$dir" "$db" stale_retry_at || true)
+  printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss and the automatic retry at %s did not clear it — manual review required before remote push retry (remove %s to grant another automatic retry)\n' \
+    "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" "${stale_retry_at:-<unknown>}" "$stale_state_path" >&2
+  if [ -n "$dry_run" ]; then
     return 1
   fi
-  return 0
+  emit_compact_quarantine_event "$db" "$stale_marker_type" "$stale_marker_path" "$stale_reason" "$stale_created_at"
+  if marker_should_notify "$dir" "$db" "$stale_reason" "$compact_renotify_backstop_secs"; then
+    stale_seen_count=$(compact_marker_value "$dir" "$db" seen_count || true)
+    case "$stale_seen_count" in ''|*[!0-9]*) stale_seen_count=0 ;; esac
+    if mail_compact_quarantine_alert "$db" "$stale_marker_type" "$stale_marker_path" "$stale_reason age=${age_secs}s seen=$((stale_seen_count + 1))" "$stale_created_at"; then
+      record_marker_notify_state "$dir" "$db" "$stale_reason" 1
+    else
+      record_marker_notify_state "$dir" "$db" "$stale_reason" 0 "$quarantine_notify_error"
+    fi
+  else
+    printf 'compact: db=%s %s stale-marker alert already sent at %s — not re-alerting until the renotify backstop elapses\n' \
+      "$db" "$marker_label" "$(compact_marker_value "$dir" "$db" last_notified_ts || true)" >&2
+    record_marker_notify_state "$dir" "$db" "$stale_reason" 0
+  fi
+  return 1
 }
 
 recover_legacy_pending_push_contract() {
@@ -1971,7 +2089,7 @@ recover_legacy_pending_push_contract() {
 clear_compact_marker() {
   dir="$1"
   db="$2"
-  rm -f "$(compact_marker_path "$dir" "$db")"
+  rm -f "$(compact_marker_path "$dir" "$db")" "$(pending_push_retry_state_path "$dir" "$db")"
 }
 
 run_full_gc() {
@@ -2135,6 +2253,26 @@ push_remote_after_compaction() {
     fi
   fi
 
+  # Capture the tip about to be pushed so the post-push verification below
+  # compares against exactly that commit. With no local tip there is nothing
+  # to verify a push against, so defer rather than push blind.
+  if ! local_push_head=$(local_branch_head "$db" "$local_branch"); then
+    printf 'compact: db=%s remote=%s local branch=%s HEAD probe failed before push after local compaction\n' \
+      "$db" "$remote" "$local_branch" >&2
+    write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+      "flatten and full GC succeeded but local HEAD probe before push failed" "$local_branch" "$remote_branch" || return 1
+    return 0
+  fi
+  case "$local_push_head" in
+    ''|*[!A-Za-z0-9]*)
+      printf 'compact: db=%s remote=%s local branch=%s returned invalid HEAD=%s before push — fail\n' \
+        "$db" "$remote" "$local_branch" "${local_push_head:-<empty>}" >&2
+      write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+        "flatten and full GC succeeded but local HEAD before push was invalid" "$local_branch" "$remote_branch" || return 1
+      return 0
+      ;;
+  esac
+
   push_rc=0
   push_err_tmp=$(mktemp)
   push_remote_refspec "$db" "$remote" "$local_branch" "$remote_branch" >/dev/null 2>"$push_err_tmp" || push_rc=$?
@@ -2148,8 +2286,44 @@ push_remote_after_compaction() {
     return 0
   fi
   rm -f "$push_err_tmp"
+
+  # A zero exit is not proof the push landed. DOLT_PUSH advances the
+  # remotes/<remote>/<branch> tracking ref only once the remote has accepted
+  # the push, so re-probing it (no second fetch: the tracking ref is local
+  # state, and DOLT_FETCH carries the #2361 crash risk) separates a push that
+  # completed from one the proxied client abandoned with rc=0 — e.g. when the
+  # managed sql-server's read_timeout killed the connection mid-push. Such a
+  # push used to be reported as "pushed" with its marker cleared, leaving the
+  # remote silently diverged. Mismatch and probe failure both keep the push
+  # pending and fail the run so the caller's failure path surfaces it.
+  if ! pushed_remote_head=$(remote_branch_head "$db" "$remote" "$remote_branch"); then
+    printf 'compact: db=%s remote=%s HEAD probe failed after push rc=0 — push unverified, remote push stays pending\n' \
+      "$db" "$remote" >&2
+    write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+      "remote push reported success but remote HEAD probe after push failed" "$local_branch" "$remote_branch" || return 1
+    return 1
+  fi
+  if [ "$pushed_remote_head" != "$local_push_head" ]; then
+    printf 'compact: db=%s remote=%s push reported success rc=0 but remote HEAD=%s does not match local HEAD=%s — push did not land, remote push stays pending\n' \
+      "$db" "$remote" "${pushed_remote_head:-<empty>}" "$local_push_head" >&2
+    unmoved_remote_head="$pushed_remote_head"
+    unmoved_remote_head_verified=0
+    case "$unmoved_remote_head" in
+      *[!A-Za-z0-9]*)
+        unmoved_remote_head=""
+        ;;
+      *)
+        if [ "$unmoved_remote_head" = "$expected_remote_head" ]; then
+          unmoved_remote_head_verified="$expected_remote_head_verified"
+        fi
+        ;;
+    esac
+    write_pending_push_marker "$db" "$remote" "$unmoved_remote_head" "$unmoved_remote_head_verified" "$compacted_from_head" \
+      "remote push reported success but remote HEAD did not move" "$local_branch" "$remote_branch" || return 1
+    return 1
+  fi
   clear_compact_marker "${push_marker_dir:-$pending_push_dir}" "${push_marker_key:-$db}"
-  printf 'compact: db=%s remote=%s pushed compacted %s\n' "$db" "$remote" "$remote_branch"
+  printf 'compact: db=%s remote=%s pushed compacted %s remote_head=%s\n' "$db" "$remote" "$remote_branch" "$pushed_remote_head"
   return 0
 }
 

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -262,6 +262,52 @@ find_remote_sql() {
   printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
 }
 
+# branch_tip_sql <db> <query> / branch_tip_cli <db-dir> <query> — emit the
+# single hash cell of a tip probe (a missing branch yields an empty string).
+# The SQL twin goes through the live server; the CLI twin runs an offline
+# `dolt sql` inside the database directory because no server is up in CLI
+# mode. Both stay under the metadata ceiling: a tip probe is a local read.
+branch_tip_sql() {
+  bt_out=$(dolt_sql "USE \`$1\`; $2") || return 1
+  printf '%s\n' "$bt_out" | awk 'NR == 2 { gsub(/^"|"$/, ""); print; exit }'
+}
+
+branch_tip_cli() {
+  bt_out=$(cd "$1" && run_bounded 120 dolt sql --result-format csv -q "$2") || return 1
+  printf '%s\n' "$bt_out" | awk 'NR == 2 { gsub(/^"|"$/, ""); print; exit }'
+}
+
+# verify_pushed_tip <probe-fn> <probe-target> <db> <remote> <local> <remote-branch>
+#   After a push that exited 0, confirm remotes/<remote>/<remote-branch> now
+#   points at the local branch tip. Dolt advances that tracking ref only once
+#   the remote has accepted the push, so a zero exit whose tracking ref still
+#   lags is a push that never landed — seen in production when the proxied
+#   client outlived the managed sql-server's read_timeout and exited 0, which
+#   this command then reported as "pushed". Mismatch and probe failure both
+#   return 1 with an actionable ERROR: an unverifiable push is never reported
+#   as pushed.
+verify_pushed_tip() {
+  vp_probe="$1"
+  vp_target="$2"
+  vp_db="$3"
+  vp_remote="$4"
+  vp_local_branch="$5"
+  vp_remote_branch="$6"
+  vp_local=$("$vp_probe" "$vp_target" "SELECT hash FROM dolt_branches WHERE name = '$vp_local_branch'") || {
+    echo "  $vp_db: ERROR: push returned 0 but the local $vp_local_branch tip could not be probed — push unverified" >&2
+    return 1
+  }
+  vp_remote_tip=$("$vp_probe" "$vp_target" "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/$vp_remote/$vp_remote_branch'") || {
+    echo "  $vp_db: ERROR: push returned 0 but remotes/$vp_remote/$vp_remote_branch could not be probed — push unverified" >&2
+    return 1
+  }
+  if [ -z "$vp_local" ] || [ "$vp_local" != "$vp_remote_tip" ]; then
+    echo "  $vp_db: ERROR: push returned 0 but remote HEAD=${vp_remote_tip:-<none>} does not match local HEAD=${vp_local:-<none>} — push did not land (retry; if it persists, raise the server read timeout or push directly with dolt push)" >&2
+    return 1
+  fi
+  return 0
+}
+
 # resolve_refspec_sql <db> — emit two lines: local-branch and remote-branch.
 # Honors GC_DOLT_REFSPEC_<DB> first, then falls back to active_branch() over SQL,
 # then to 'main' if both fail.
@@ -493,8 +539,12 @@ sync_database_sql() {
   dolt_sql "$push_query" "$push_timeout" >/dev/null 2>"$push_err_tmp" || push_rc=$?
 
   if [ "$push_rc" -eq 0 ]; then
-    echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote_url)"
     rm -f "$push_err_tmp"
+    verify_pushed_tip branch_tip_sql "$name" "$name" "$remote_name" "$local_branch" "$remote_branch" || {
+      last_fail_reason="push reported success but the remote tip did not move"
+      return 1
+    }
+    echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote_url)"
     return 0
   fi
 
@@ -581,6 +631,10 @@ sync_database_cli() {
   fi
 
   if [ "$cli_rc" -eq 0 ]; then
+    verify_pushed_tip branch_tip_cli "$d" "$name" "$remote_name" "$local_branch" "$remote_branch" || {
+      last_fail_reason="push reported success but the remote tip did not move"
+      return 1
+    }
     echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote)"
     return 0
   fi

--- a/examples/bd/dolt/compact_notify_cadence_test.go
+++ b/examples/bd/dolt/compact_notify_cadence_test.go
@@ -14,6 +14,11 @@ import (
 // invocation (observed in production: 40 mails for one unchanged my_db
 // marker). The event still fires every cycle so automation keeps observing
 // each check; only the mail is gated.
+//
+// The strand gate spends one automatic retry before a stale marker is
+// considered stranded (see TestCompactScriptStalePendingPushMarkerGetsOneAutomaticRetry),
+// so the cycle that consumes that retry runs first here and the mail-cadence
+// window covers the two stranded cycles that follow it.
 func TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
@@ -22,6 +27,13 @@ func TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle(t *testing.T
 	}
 	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
 	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
+
+	// Spend the one automatic retry the strand gate owes a stale marker; it
+	// fails again, so the marker survives and every later cycle is stranded.
+	retryOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("the one automatic retry should defer like any failed push: %v\n%s", err, retryOut)
+	}
 	resetCompactGCLog(t, fixture)
 
 	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")

--- a/examples/bd/dolt/compact_push_verify_test.go
+++ b/examples/bd/dolt/compact_push_verify_test.go
@@ -1,0 +1,270 @@
+package dolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	compactPushMainCall    = "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"
+	compactRemoteMainProbe = "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/main'"
+)
+
+func compactPendingPushMarkerPath(fixture compactScriptFixture) string {
+	return filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+}
+
+// TestCompactScriptVerifiesRemoteTipAfterPush pins the success contract: a
+// push is reported as pushed only after the remote-tracking ref is re-probed
+// (after DOLT_PUSH, in the same run) and matches the local tip.
+func TestCompactScriptVerifiesRemoteTipAfterPush(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote=origin pushed compacted main remote_head=compactcommit") {
+		t.Fatalf("success line should carry the verified remote tip:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	pushAt := strings.Index(log, compactPushMainCall)
+	if pushAt < 0 {
+		t.Fatalf("dolt log missing push:\n%s", log)
+	}
+	if !strings.Contains(log[pushAt:], compactRemoteMainProbe) {
+		t.Fatalf("remote tip must be re-probed after the push:\n%s", log)
+	}
+	if !strings.Contains(log, "SELECT hash FROM dolt_branches WHERE name = 'main'") {
+		t.Fatalf("local tip must be probed for the post-push comparison:\n%s", log)
+	}
+	if _, err := os.Stat(compactPendingPushMarkerPath(fixture)); !os.IsNotExist(err) {
+		t.Fatalf("verified push must not leave a pending-push marker (stat err=%v)", err)
+	}
+}
+
+// TestCompactScriptKeepsPendingPushWhenPushReportsSuccessButRemoteTipDoesNotMove
+// reproduces the incident shape: DOLT_PUSH exits 0 but the remote-tracking ref
+// never advances (the proxied client was killed by the managed sql-server's
+// read_timeout and still exited 0). The old code cleared the marker and
+// printed "pushed" while the remote silently diverged. Now the marker is
+// written, both hashes are logged, and the run fails.
+func TestCompactScriptKeepsPendingPushWhenPushReportsSuccessButRemoteTipDoesNotMove(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_push_tip_unmoved", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("a push whose remote tip did not move must fail the run:\n%s", out)
+	}
+	if !strings.Contains(out, "push reported success rc=0 but remote HEAD=headcommit does not match local HEAD=compactcommit") {
+		t.Fatalf("output should log both hashes:\n%s", out)
+	}
+	if strings.Contains(out, "pushed compacted") {
+		t.Fatalf("unverified push must not be reported as pushed:\n%s", out)
+	}
+	if !strings.Contains(out, "1 database(s) failed compaction") {
+		t.Fatalf("caller failure path should run:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_GC"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("local compaction should still complete; missing %s:\n%s", want, log)
+		}
+	}
+	if got := strings.Count(log, compactPushMainCall); got != 1 {
+		t.Fatalf("push should be attempted exactly once, got %d:\n%s", got, log)
+	}
+	marker := compactPendingPushMarkerPath(fixture)
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "remote push reported success but remote HEAD did not move" {
+		t.Fatalf("marker reason = %q", reason)
+	}
+	assertCompactMarkerHasEvidence(t, marker,
+		"remote=origin",
+		"expected_remote_head=headcommit",
+		"expected_remote_head_verified=1",
+		"compacted_from_head=headcommit",
+		"local_branch=main",
+		"remote_branch=main",
+	)
+}
+
+// TestCompactScriptRetryKeepsPendingPushWhenRemoteTipDoesNotMove covers the
+// same shape on the pending-push retry path, then proves the kept marker still
+// drives a successful retry once the push really lands.
+func TestCompactScriptRetryKeepsPendingPushWhenRemoteTipDoesNotMove(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should defer the push: %v\n%s", err, firstOut)
+	}
+	marker := compactPendingPushMarkerPath(fixture)
+	createdAt := compactMarkerValue(t, marker, "created_at")
+
+	secondOut, err := fixture.run(t, "remote_push_tip_unmoved", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("retry whose remote tip did not move must fail the run:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "remote HEAD=headcommit does not match local HEAD=compactcommit") {
+		t.Fatalf("retry should log both hashes:\n%s", secondOut)
+	}
+	if got := compactMarkerValue(t, marker, "created_at"); got != createdAt {
+		t.Fatalf("unverified retry must preserve marker age: before=%s after=%s", createdAt, got)
+	}
+
+	thirdOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("retry should succeed once the push lands: %v\n%s", err, thirdOut)
+	}
+	if !strings.Contains(thirdOut, "pushed compacted main remote_head=compactcommit") {
+		t.Fatalf("landed retry should report the verified tip:\n%s", thirdOut)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("landed retry should clear marker (stat err=%v)", err)
+	}
+}
+
+// assertCompactStaleMarkerAlertedOnce is the stranded-pending-push twin of
+// assertCompactBeadsQuarantineAlert. The strand gate pages the operator exactly
+// once, but under the shared marker notification cadence (upstream #5624) the
+// dolt.compact.quarantine EVENT still fires on every cycle the marker is
+// stranded, so the event count is asserted separately from the mail count.
+func assertCompactStaleMarkerAlertedOnce(t *testing.T, fixture compactScriptFixture, recipient, markerPath, markerType, reason string, wantEvents int) {
+	t.Helper()
+	log := readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 1 {
+		t.Fatalf("a stranded pending-push marker should page the operator exactly once, got %d mail(s)\nlog:\n%s", len(mailLines), log)
+	}
+	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
+	if len(eventLines) != wantEvents {
+		t.Fatalf("stranded marker should emit one dolt.compact.quarantine event per cycle, want %d got %d\nlog:\n%s", wantEvents, len(eventLines), log)
+	}
+	for _, want := range []string{recipient, "beads", markerPath, markerType, reason, "--from controller"} {
+		if !strings.Contains(mailLines[0], want) {
+			t.Fatalf("mail alert line missing %q\nline:\n%s\nlog:\n%s", want, mailLines[0], log)
+		}
+	}
+	for _, want := range []string{"beads", markerPath, markerType, reason, "--actor controller"} {
+		if !strings.Contains(eventLines[0], want) {
+			t.Fatalf("event alert line missing %q\nline:\n%s\nlog:\n%s", want, eventLines[0], log)
+		}
+	}
+}
+
+// TestCompactScriptStalePendingPushMarkerGetsOneAutomaticRetry pins the
+// self-heal half of the strand gate: a marker past the age gate whose retry
+// lands is cleared together with its bookkeeping sidecar, and nobody is paged.
+func TestCompactScriptStalePendingPushMarkerGetsOneAutomaticRetry(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should defer the push: %v\n%s", err, firstOut)
+	}
+	marker := compactPendingPushMarkerPath(fixture)
+	replaceCompactMarkerCreatedAt(t, marker, "1970-01-01T00:00:00Z")
+	resetCompactGCLog(t, fixture)
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("stale marker should get one automatic retry and self-heal: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "attempting one automatic remote push retry") ||
+		!strings.Contains(secondOut, "pushed compacted main") {
+		t.Fatalf("retry should be granted and land:\n%s", secondOut)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("self-healed retry should clear marker (stat err=%v)", err)
+	}
+	if _, err := os.Stat(marker + ".retry-state"); !os.IsNotExist(err) {
+		t.Fatalf("self-healed retry should clear the retry-state sidecar (stat err=%v)", err)
+	}
+	if log := readCompactGCLog(t, fixture); len(compactGCLogLinesWithPrefix(log, "gc mail send ")) != 0 {
+		t.Fatalf("self-heal must not page the operator:\n%s", log)
+	}
+}
+
+// TestCompactScriptStalePendingPushEscalatesOnceThenResetsWhenSidecarRemoved
+// walks the full strand-gate lifecycle: failed automatic retry, exactly one
+// alert, silence, then the operator removes the sidecar and the gate grants one
+// more automatic retry, which lands and clears everything.
+func TestCompactScriptStalePendingPushEscalatesOnceThenResetsWhenSidecarRemoved(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should defer the push: %v\n%s", err, firstOut)
+	}
+	marker := compactPendingPushMarkerPath(fixture)
+	sidecar := marker + ".retry-state"
+	replaceCompactMarkerCreatedAt(t, marker, "1970-01-01T00:00:00Z")
+	resetCompactGCLog(t, fixture)
+
+	// Cycle 1 past the gate: the one automatic retry, which fails again.
+	out, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("automatic retry should defer on push failure: %v\n%s", err, out)
+	}
+	if got := compactMarkerValue(t, sidecar, "stale_retry_attempted"); got != "1" {
+		t.Fatalf("sidecar should record the consumed retry, got stale_retry_attempted=%q", got)
+	}
+	if got := compactMarkerValue(t, sidecar, "marker_created_at"); got != "1970-01-01T00:00:00Z" {
+		t.Fatalf("sidecar should be bound to the marker's created_at, got %q", got)
+	}
+
+	// Cycle 2: escalate exactly once.
+	out, err = fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stranded marker must fail the run:\n%s", out)
+	}
+	assertCompactStaleMarkerAlertedOnce(t, fixture, "mayor", marker, "compact-pending-push", "pending_push marker is stale", 1)
+	if got := compactMarkerValue(t, marker, "notify_count"); got != "1" {
+		t.Fatalf("marker should record the single escalation, got notify_count=%q", got)
+	}
+	if got := compactMarkerValue(t, marker, "last_notified_reason"); got != "pending_push marker is stale" {
+		t.Fatalf("marker should record the escalated reason, got %q", got)
+	}
+
+	// Cycle 3: silent.
+	out, err = fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stranded marker must keep failing the run:\n%s", out)
+	}
+	if !strings.Contains(out, "alert already sent") {
+		t.Fatalf("later cycle should explain it is not re-alerting:\n%s", out)
+	}
+	assertCompactStaleMarkerAlertedOnce(t, fixture, "mayor", marker, "compact-pending-push", "pending_push marker is stale", 2)
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if got := strings.Count(string(data), compactPushMainCall); got != 2 {
+		t.Fatalf("stranded marker must not be pushed again (want initial + one automatic retry = 2), got %d:\n%s", got, data)
+	}
+
+	// Operator removes the sidecar: the gate grants one more automatic retry.
+	if err := os.Remove(sidecar); err != nil {
+		t.Fatalf("remove sidecar: %v", err)
+	}
+	out, err = fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("removing the sidecar should grant another automatic retry: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "attempting one automatic remote push retry") ||
+		!strings.Contains(out, "pushed compacted main") {
+		t.Fatalf("reset retry should be granted and land:\n%s", out)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("landed retry should clear marker (stat err=%v)", err)
+	}
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Fatalf("landed retry should clear the sidecar (stat err=%v)", err)
+	}
+}

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -511,10 +511,35 @@ set_hash() {
   [ -n "$hash_state_file" ] || return 0
   printf '%%s\n' "$1" > "$hash_state_file"
 }
+# state_head reads the head state without the call-counting side effects some
+# modes attach to current_head, for the tip probes added around the push.
+state_head() {
+  if [ -n "$state_file" ] && [ -f "$state_file" ]; then
+    sed -n '1p' "$state_file"
+  else
+    printf 'headcommit\n'
+  fi
+}
+# The fake mirrors dolt's remote-tracking refs: a DOLT_PUSH that lands records
+# the pushed tip per remote/branch and the dolt_remote_branches probes answer
+# with it from then on. remote_push_tip_unmoved models the production incident
+# shape — DOLT_PUSH exits 0 but the tracking ref never advances.
+pushed_tip_file() {
+  printf '%%s.pushed.%%s.%%s\n' "$state_file" "$1" "$2"
+}
+record_push() {
+  [ -n "$state_file" ] || return 0
+  [ "$mode" = "remote_push_tip_unmoved" ] && return 0
+  state_head > "$(pushed_tip_file "$1" "$2")"
+}
+answer_pushed_tip() {
+  [ -n "$state_file" ] && [ -f "$(pushed_tip_file "$1" "$2")" ] || return 1
+  print_cell "$(sed -n '1p' "$(pushed_tip_file "$1" "$2")")"
+}
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin|backup_remote_reconcile|backup_remote_push_failure|backup_remote_filters_non_file_and_authoritative)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_push_tip_unmoved|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin|backup_remote_reconcile|backup_remote_push_failure|backup_remote_filters_non_file_and_authoritative)
         print_cell 1
         ;;
       *)
@@ -536,7 +561,7 @@ case "$query" in
     ;;
   *"SELECT COUNT(*) FROM dolt_remotes"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_push_tip_unmoved|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
         print_cell 1
         ;;
       multiple_remotes_with_origin|multiple_remotes_no_origin)
@@ -559,7 +584,7 @@ case "$query" in
     ;;
   *"SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_push_tip_unmoved|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
         print_cell origin
         ;;
       explicit_backup_remote)
@@ -619,6 +644,9 @@ case "$query" in
     exit 0
     ;;
   *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/main'"*)
+    if answer_pushed_tip origin main; then
+      exit 0
+    fi
     if [ "$mode" = "remote_advances_before_push" ] || [ "$mode" = "remote_writer_race_before_flatten" ]; then
       calls_file="$state_file.remote-head-calls"
       calls=0
@@ -644,15 +672,28 @@ case "$query" in
     exit 0
     ;;
   *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/gascity-3'"*)
+    if answer_pushed_tip origin gascity-3; then
+      exit 0
+    fi
     print_cell headcommit
     exit 0
     ;;
   *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/trunk'"*)
+    if answer_pushed_tip origin trunk; then
+      exit 0
+    fi
     print_cell headcommit
     exit 0
     ;;
   *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/backup/main'"*)
+    if answer_pushed_tip backup main; then
+      exit 0
+    fi
     print_cell headcommit
+    exit 0
+    ;;
+  *"SELECT hash FROM dolt_branches WHERE name = '"*)
+    print_cell "$(state_head)"
     exit 0
     ;;
   *"SELECT COUNT(*) FROM dolt_log WHERE commit_hash = 'remotecommit'"*)
@@ -1195,12 +1236,15 @@ case "$query" in
       printf 'push unavailable\n' >&2
       exit 53
     fi
+    record_push origin main
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3')"*)
+    record_push origin gascity-3
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3:trunk')"*)
+    record_push origin trunk
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'main:gascity-3')"*)
@@ -1208,6 +1252,7 @@ case "$query" in
       printf 'push unavailable\n' >&2
       exit 53
     fi
+    record_push origin gascity-3
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'backup', 'main')"*)
@@ -1215,6 +1260,7 @@ case "$query" in
       printf 'push unavailable\n' >&2
       exit 53
     fi
+    record_push backup main
     exit 0
     ;;
 esac
@@ -1974,7 +2020,12 @@ func TestCompactScriptRecordsPendingPushWhenRemotePushFails(t *testing.T) {
 	}
 }
 
-func TestCompactScriptBlocksStalePendingPushRetryBeforeForcePush(t *testing.T) {
+// TestCompactScriptBlocksStalePendingPushRetryAfterOneFailedAutomaticRetry pins
+// the strand gate: a marker past GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS gets
+// exactly one automatic retry (so a push that died once to a transient failure
+// self-heals), and only when that retry leaves the marker in place does the
+// gate fail closed with the manual-review message and stop force-pushing.
+func TestCompactScriptBlocksStalePendingPushRetryAfterOneFailedAutomaticRetry(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
 	if err != nil {
@@ -1983,27 +2034,43 @@ func TestCompactScriptBlocksStalePendingPushRetryBeforeForcePush(t *testing.T) {
 	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
 	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
 
-	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	if err == nil {
-		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", secondOut)
+	secondOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("stale marker must get one automatic retry, which defers like any failed push: %v\n%s", err, secondOut)
 	}
 	if !strings.Contains(secondOut, "pending_push marker is stale") ||
-		!strings.Contains(secondOut, "manual review required") {
-		t.Fatalf("retry missing stale-marker manual-review explanation:\n%s", secondOut)
+		!strings.Contains(secondOut, "attempting one automatic remote push retry") ||
+		strings.Contains(secondOut, "manual review required") {
+		t.Fatalf("first stale cycle should retry, not demand manual review:\n%s", secondOut)
+	}
+	if got := compactMarkerValue(t, pendingPush, "created_at"); got != "1970-01-01T00:00:00Z" {
+		t.Fatalf("failed automatic retry must preserve marker age, got created_at=%s", got)
+	}
+
+	thirdOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stale pending-push retry succeeded after its one automatic retry without manual review:\n%s", thirdOut)
+	}
+	if !strings.Contains(thirdOut, "pending_push marker is stale") ||
+		!strings.Contains(thirdOut, "manual review required") {
+		t.Fatalf("second stale cycle missing manual-review explanation:\n%s", thirdOut)
 	}
 	logData, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
 		t.Fatalf("read dolt log: %v", err)
 	}
-	if strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") != 1 {
-		t.Fatalf("stale pending-push retry must not attempt another force push:\n%s", logData)
+	if got := strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"); got != 2 {
+		t.Fatalf("stale marker should force-push exactly once more (initial + one automatic retry), got %d:\n%s", got, logData)
 	}
 	if _, err := os.Stat(pendingPush); err != nil {
 		t.Fatalf("stale retry should keep pending-push marker: %v", err)
 	}
 }
 
-func TestCompactScriptStalePendingPushMarkerAlertsDefaultMayorBeforeManualReview(t *testing.T) {
+// TestCompactScriptStalePendingPushMarkerAlertsDefaultMayorOnceAfterFailedAutomaticRetry
+// pins the escalation contract: no alert while the one automatic retry runs,
+// exactly one alert when the marker survives it, and silence on the cycle after.
+func TestCompactScriptStalePendingPushMarkerAlertsDefaultMayorOnceAfterFailedAutomaticRetry(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
 	if err != nil {
@@ -2013,17 +2080,38 @@ func TestCompactScriptStalePendingPushMarkerAlertsDefaultMayorBeforeManualReview
 	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
 	resetCompactGCLog(t, fixture)
 
-	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	secondOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("automatic retry of a stale marker should defer like any failed push: %v\n%s", err, secondOut)
+	}
+	if log := readCompactGCLog(t, fixture); len(compactGCLogLinesWithPrefix(log, "gc mail send ")) != 0 {
+		t.Fatalf("automatic retry must not page the operator:\n%s", log)
+	}
+
+	thirdOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
 	if err == nil {
-		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", secondOut)
+		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", thirdOut)
 	}
-	if !strings.Contains(secondOut, "pending_push marker is stale") ||
-		!strings.Contains(secondOut, "manual review required") {
-		t.Fatalf("retry missing stale-marker manual-review explanation:\n%s", secondOut)
+	if !strings.Contains(thirdOut, "pending_push marker is stale") ||
+		!strings.Contains(thirdOut, "manual review required") {
+		t.Fatalf("retry missing stale-marker manual-review explanation:\n%s", thirdOut)
 	}
-	assertCompactBeadsQuarantineAlert(t, fixture, "mayor", pendingPush, "compact-pending-push", "pending_push marker is stale")
+	assertCompactStaleMarkerAlertedOnce(t, fixture, "mayor", pendingPush, "compact-pending-push", "pending_push marker is stale", 1)
+
+	fourthOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stranded marker must keep failing the run until an operator acts:\n%s", fourthOut)
+	}
+	if !strings.Contains(fourthOut, "manual review required") ||
+		!strings.Contains(fourthOut, "alert already sent") {
+		t.Fatalf("later cycle should explain it is not re-alerting:\n%s", fourthOut)
+	}
+	assertCompactStaleMarkerAlertedOnce(t, fixture, "mayor", pendingPush, "compact-pending-push", "pending_push marker is stale", 2)
 }
 
+// TestCompactScriptDryRunReportsStalePendingPushMarker pins that --dry-run
+// previews the strand gate without consuming the one automatic retry, writing
+// bookkeeping, or paging the operator.
 func TestCompactScriptDryRunReportsStalePendingPushMarker(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
@@ -2031,9 +2119,35 @@ func TestCompactScriptDryRunReportsStalePendingPushMarker(t *testing.T) {
 		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
 	}
 	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	retryState := pendingPush + ".retry-state"
 	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
+	resetCompactGCLog(t, fixture)
 
 	dryRunOut, err := fixture.run(t, "remote_success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_DRY_RUN=1",
+	)
+	if err != nil {
+		t.Fatalf("dry run of a stale marker that still has its automatic retry should succeed: %v\n%s", err, dryRunOut)
+	}
+	if !strings.Contains(dryRunOut, "pending_push marker is stale") ||
+		!strings.Contains(dryRunOut, "would attempt one automatic remote push retry") ||
+		!strings.Contains(dryRunOut, "would retry remote push") {
+		t.Fatalf("dry-run should preview the one automatic retry:\n%s", dryRunOut)
+	}
+	if _, err := os.Stat(retryState); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not consume the automatic retry (stat err=%v)", err)
+	}
+
+	secondOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("automatic retry should defer on push failure: %v\n%s", err, secondOut)
+	}
+	if _, err := os.Stat(retryState); err != nil {
+		t.Fatalf("real run should record the consumed automatic retry: %v", err)
+	}
+
+	dryRunOut, err = fixture.run(t, "remote_success",
 		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
 		"GC_DOLT_COMPACT_DRY_RUN=1",
 	)
@@ -2045,14 +2159,21 @@ func TestCompactScriptDryRunReportsStalePendingPushMarker(t *testing.T) {
 		t.Fatalf("dry-run missing stale-marker manual-review explanation:\n%s", dryRunOut)
 	}
 	if strings.Contains(dryRunOut, "would retry remote push") {
-		t.Fatalf("dry-run should not claim it would retry a stale pending push:\n%s", dryRunOut)
+		t.Fatalf("dry-run should not claim it would retry a stranded pending push:\n%s", dryRunOut)
 	}
 	logData, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
 		t.Fatalf("read dolt log: %v", err)
 	}
-	if strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") != 1 {
-		t.Fatalf("dry-run stale pending-push retry must not attempt another force push:\n%s", logData)
+	if got := strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"); got != 2 {
+		t.Fatalf("dry runs must never force-push (want initial + one automatic retry = 2), got %d:\n%s", got, logData)
+	}
+	log := readCompactGCLog(t, fixture)
+	if mails := compactGCLogLinesWithPrefix(log, "gc mail send "); len(mails) != 0 {
+		t.Fatalf("dry-run must not page the operator, got %d mail(s):\n%s", len(mails), log)
+	}
+	if events := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine"); len(events) != 0 {
+		t.Fatalf("dry-run must not emit quarantine events, got %d:\n%s", len(events), log)
 	}
 }
 

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -14,6 +14,18 @@ import (
 
 const syncScript = "commands/sync/run.sh"
 
+// syncFakeDoltTipProbeArms answers the post-push tip verification probes
+// (commands/sync/run.sh verify_pushed_tip) with a matching local and
+// remote-tracking hash, modeling a push that landed. Spliced into every fake
+// whose push succeeds; the push-failure fakes never reach the probes.
+const syncFakeDoltTipProbeArms = `  *"SELECT hash FROM dolt_branches WHERE name = '"*)
+    printf 'hash\npushedtip\n'
+    ;;
+  *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/"*)
+    printf 'hash\npushedtip\n'
+    ;;
+`
+
 // syncFilteredEnv returns os.Environ() with every env var the sync script reads
 // stripped, so a test's GC_DOLT_* config is exactly what the test sets and never
 // what the developer/CI happens to export. GC_DOLT_SYNC_PUSH_TIMEOUT_SECS is in
@@ -101,7 +113,7 @@ case "$*" in
   *"dolt_log('remotes/origin/"*)
     printf 'n\n1\n'
     ;;
-esac
+` + syncFakeDoltTipProbeArms + `esac
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
@@ -131,7 +143,7 @@ case "$*" in
   *"SELECT active_branch()"*)
     printf 'active_branch()\n` + activeBranch + `\n'
     ;;
-esac
+` + syncFakeDoltTipProbeArms + `esac
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
@@ -161,7 +173,7 @@ case "$*" in
   *"SELECT active_branch()"*)
     printf 'active_branch()\n--force\n'
     ;;
-esac
+` + syncFakeDoltTipProbeArms + `esac
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
@@ -321,12 +333,54 @@ case "$*" in
     fi
     exit 0
     ;;
+` + syncFakeDoltTipProbeArms + `esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}
+
+// writeSyncFakeDoltPushTipUnmoved installs a fake dolt whose SQL-mode
+// DOLT_PUSH and CLI-mode `dolt push` both exit 0 without moving the
+// remote-tracking ref — the shape of a proxied push the managed sql-server
+// killed at read_timeout while the client still exited 0 (a production
+// incident that `gc dolt sync` and the compactor both reported as pushed).
+// The local tip probe answers newtip; the remote-tracking probe answers oldtip.
+func writeSyncFakeDoltPushTipUnmoved(t *testing.T, dir string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    ;;
+  *"CALL DOLT_FETCH("*)
+    :
+    ;;
+  *"..remotes/origin/"*)
+    printf 'n\n0\n'
+    ;;
+  *"dolt_log('remotes/origin/"*)
+    printf 'n\n1\n'
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    ;;
+  *"SELECT hash FROM dolt_branches WHERE name = '"*)
+    printf 'hash\nnewtip\n'
+    ;;
+  *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/"*)
+    printf 'hash\noldtip\n'
+    ;;
 esac
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake dolt: %v", err)
 	}
+	return logPath
 }
 
 // writeSyncFakeDoltPushEchoesArgs installs a fake dolt that, on the SQL-mode
@@ -1745,5 +1799,94 @@ func TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes(t *testing.T) {
 	}
 	if strings.Contains(output, "3/3 database(s) failed") {
 		t.Fatalf("summary must not read as if every database failed, got:\n%s", output)
+	}
+}
+
+// TestSyncSQLPushReportsSuccessButRemoteTipUnmoved verifies the SQL-mode push
+// re-probes the remote-tracking ref after a zero-exit DOLT_PUSH and refuses to
+// report "pushed" when it did not advance to the local tip: both hashes are
+// surfaced and the database fails instead of silently diverging.
+func TestSyncSQLPushReportsSuccessButRemoteTipUnmoved(t *testing.T) {
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltPushTipUnmoved(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	// runSync's extraEnv lands after its own GC_DOLT_PORT=1, and os/exec keeps
+	// the last value for a duplicated key, so this selects the SQL path
+	// (reachable server) without a second exec call site.
+	out, err := runSync(t, binDir, cityPath, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port)}, "--db", "app")
+	if err == nil {
+		t.Fatalf("a push whose remote tip did not move must fail, output:\n%s", out)
+	}
+	if !strings.Contains(out, "app: ERROR: push returned 0 but remote HEAD=oldtip does not match local HEAD=newtip") {
+		t.Fatalf("expected both hashes in the failure message, got:\n%s", out)
+	}
+	if strings.Contains(out, "app: pushed") {
+		t.Fatalf("unverified push must not be reported as pushed:\n%s", out)
+	}
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	pushAt := strings.Index(log, "CALL DOLT_PUSH('origin', 'main')")
+	if pushAt < 0 {
+		t.Fatalf("dolt log missing push:\n%s", log)
+	}
+	if !strings.Contains(log[pushAt:], "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/main'") {
+		t.Fatalf("remote tip must be re-probed after the push:\n%s", log)
+	}
+}
+
+// TestSyncCLIPushReportsSuccessButRemoteTipUnmoved is the CLI-mode twin: with
+// no server running the tip probes go through an offline `dolt sql` inside the
+// database directory, and a zero-exit `dolt push` that did not advance the
+// remote-tracking ref is reported as a failure, not as pushed.
+func TestSyncCLIPushReportsSuccessButRemoteTipUnmoved(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltPushTipUnmoved(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	out, err := runSync(t, binDir, cityPath, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a CLI push whose remote tip did not move must fail, output:\n%s", out)
+	}
+	if !strings.Contains(out, "app: ERROR: push returned 0 but remote HEAD=oldtip does not match local HEAD=newtip") {
+		t.Fatalf("expected both hashes in the failure message, got:\n%s", out)
+	}
+	if strings.Contains(out, "app: pushed") {
+		t.Fatalf("unverified push must not be reported as pushed:\n%s", out)
+	}
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	pushAt := strings.Index(log, "push origin main")
+	if pushAt < 0 {
+		t.Fatalf("dolt log missing CLI push:\n%s", log)
+	}
+	if !strings.Contains(log[pushAt:], "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/main'") {
+		t.Fatalf("remote tip must be re-probed after the CLI push:\n%s", log)
 	}
 }


### PR DESCRIPTION
## Summary

In a production 3-rig city, the compaction pack's proxied `DOLT_PUSH` after a flatten was killed by the managed sql-server's read timeout. The client exited 0, the pack printed `pushed compacted main` and cleared its pending-push marker, and the rig's remote silently diverged for six days. A pending-push marker that did get written later aged past the 48 h gate, after which every 2 h compaction cycle refused the retry ("manual review required") with no path back — no self-heal.

**Rebased onto `main` at `e74cd9263`.** Two upstream changes landed in this area since this branch was opened and are preserved rather than reverted:

- **#5624** (compact notification cadence) replaced `quarantine_should_notify` / `record_quarantine_notify_state` with the shared `marker_should_notify` (`compact/run.sh:1603`) / `record_marker_notify_state` (`:1638`) pair, and routed the stale-marker alert through it. That fixed the *mail-storm* half of this report — an unresolved stale marker no longer mails on every cycle. This PR keeps that path verbatim; it does **not** reintroduce a private dedup.
- **#5493** added `last_notify_error` and the stdout-preserving `mail_compact_quarantine_alert` contract. Also preserved.

What is still broken at `e74cd9263`, and what this PR fixes:

- `compact/run.sh:2140-2152` — `push_remote_refspec ... >/dev/null 2>"$push_err_tmp" || push_rc=$?`; on `push_rc=0` it calls `clear_compact_marker` (`:2151`) and prints `pushed` (`:2152`) with stdout discarded and no re-probe of the remote tip (`remote_branch_head`, `:1013`, is only used pre-push). The same shape exists in `sync/run.sh:495-496` (proxied) and `:583-584` (CLI).
- `compact/run.sh:1865-1905` `ensure_remote_push_retry_fresh` — past `pending_push_max_age_secs` (default 172800) it prints "manual review required" (`:1882`) and returns 1; both callers abort before any retry, so the marker is stranded permanently with no automatic way out. #5624 made that state quieter; it did not make it recoverable.
- `docs/troubleshooting/dolt-bloat-recovery.md:118` still says the deferred push "resumes automatically".

## Changes

**A. Post-push tip verification** — `compact/run.sh` `push_remote_after_compaction` (`:2121-2328`; new `local_branch_head` at `:1035`, pre-push local-tip probe at `:2256`, post-push verification at `:2290-2324`) and `sync/run.sh` `verify_pushed_tip` (`:280-309`, applied at `:543` SQL mode and `:634` CLI mode, with `branch_tip_sql` / `branch_tip_cli` probes at `:270` / `:275`).

Probe the local branch tip (`SELECT hash FROM dolt_branches WHERE name = '<branch>'`) right before the push; after an rc=0 push re-probe `remotes/<remote>/<branch>` with the existing `remote_branch_head` and only clear the marker / print `pushed compacted <branch> remote_head=<hash>` when they match. On mismatch (or a failed post-push probe) both hashes are logged, the pending-push marker is written or kept (`expected_remote_head` re-armed for the next retry) and the function returns 1 so the existing caller failure path runs (`N database(s) failed compaction`, non-zero exit). There is deliberately no second `DOLT_FETCH`: the tracking ref is local state that Dolt advances only once the remote accepted the push — checked against dolt 2.2.3, where it lags a local commit and moves on both CLI `dolt push` and `CALL DOLT_PUSH` — and a fetch would add #2361 crash exposure. `gc dolt sync` gets the same check on both push paths (CLI mode probes with an offline `dolt sql` inside the database directory) and feeds the #5621 failure summary a reason (`push reported success but the remote tip did not move`) so a tip mismatch is named in `sync: N/M database(s) failed`.

**B. Strand gate** — `ensure_remote_push_retry_fresh` (`:1963-2021`) with sidecar helpers (`:1879-1958`).

A marker past the age gate now gets exactly one automatic retry (`:1983`, recorded at `:1991`), so a push that died once to a transient failure self-heals. Only if it survives that retry does the gate fail closed with the unchanged "manual review required" wording (`:2001`) and escalate — through #5624's shared path: `emit_compact_quarantine_event` every cycle, and the mail gated by `marker_should_notify` against `compact_renotify_backstop_secs`, recorded with `record_marker_notify_state` in the marker's own `notify_count` / `last_notified_ts` / `last_notify_error` fields. So the alert cadence is exactly what #5624 defined for every other marker; this PR only adds the retry that precedes it.

Whether that one retry has been spent lives in a `<marker>.retry-state` sidecar (`stale_retry_attempted`, `stale_retry_at`) rather than in the marker, because a failed retry rewrites the marker (`write_compact_marker` preserves only `created_at`) and would erase an in-marker flag. The sidecar is bound to its marker through `marker_created_at`, is removed by `clear_compact_marker` (`:2089`), and deleting it alone grants another automatic retry. `--dry-run` previews the decision without consuming the retry, writing state, emitting an event, or alerting. The pending-GC marker path (`:2556` caller) shares the gate with the pending-push path (`:2648`).

**C. Docs** — `docs/troubleshooting/dolt-bloat-recovery.md`: corrected the "resumes automatically" sentence (`:118`) and added "When a deferred remote push does not resume" (`:141`) describing the verification, the one retry, the #5624 alert cadence, the sidecar path and both recovery options.

Not changed: `read_timeout` defaults, Go code, unrelated scripts.

## Tests

- New `examples/bd/dolt/compact_push_verify_test.go`: success path re-probes the tracking ref after `DOLT_PUSH`; an rc=0 push whose remote tip does not move keeps the marker (with evidence) and fails the run on both the initial and the retry path; a stale marker gets exactly one automatic retry (self-heal clears marker + sidecar, no mail); failed retry → one alert → silence within the renotify backstop → removing the sidecar grants another retry which lands.
- `dog_exec_scripts_test.go`: the fake `dolt` now models remote-tracking refs (records the pushed tip per remote/branch; new `remote_push_tip_unmoved` mode for the incident shape; `dolt_branches` local-tip arm). The three existing stale-marker tests were rewritten for the new contract (one retry, then #5624's alert cadence, side-effect-free dry run).
- `compact_notify_cadence_test.go` (from #5624): `TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle` now spends the one automatic retry before its two stranded cycles. Its assertions are unchanged — one mail, one event per stranded cycle, `seen=` context — because this PR does not alter the cadence it pins.
- `sync_test.go`: the success fakes answer the tip probes; new SQL-mode and CLI-mode "push returned 0 but the tip did not move" tests. Both run through #5621's `runSync` helper rather than their own `exec.Command`, so the untagged-subprocess ratchet in `internal/testpolicy/resourcecensus` is unchanged (`TestRepositoryLedgerMatchesCensusAndDocumentation` passes with no baseline edit).

Validation (local, go 1.26.6, rebased on `e74cd9263`):

- `go build ./...` — ok
- `go vet ./examples/bd/dolt/...` — ok
- `go test ./examples/bd/dolt/... -count=1` — ok
- `go test ./internal/testpolicy/resourcecensus/` (the checked test-resource ledger) — ok, no baseline change
- `sh -n` on both changed scripts — ok

## Follow-up (out of scope here)

The incident's root trigger has since been addressed upstream: `DefaultDoltReadTimeoutMillis` is now `120000` (`internal/config/config.go:1946`, was 15000), raised by the `ga-lfcx72` series with a matching sync shell fallback. This PR remains worth landing on top of that: a raised timeout shrinks the window for a killed proxied push but does not close it, and nothing else re-probes the remote tip or un-strands an aged marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161XB4BVDny4DK87CWXcCha
