### PR TITLE
feat(core): detect and escalate silently-dead workflow runs

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -6723,6 +6723,7 @@ func writeCityRuntimeSoftReloadConfig(t *testing.T, tomlPath, shutdownTimeout st
 	skippedOrders := []string{
 		"beads-health",
 		"cross-rig-deps",
+		"dead-run-detect",
 		"gate-sweep",
 		"jsonl-export",
 		"reaper",

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -2110,7 +2110,7 @@ func TestSupervisorCreatesControllerSocketForManagedCity(t *testing.T) {
 name = "test-city"
 
 [orders]
-skip = ["beads-health", "cross-rig-deps", "gate-sweep", "jsonl-export", "reaper", "order-tracking-sweep", "orphan-sweep", "prune-branches", "spawn-storm-detect", "wisp-compact"]
+skip = ["beads-health", "cross-rig-deps", "dead-run-detect", "gate-sweep", "jsonl-export", "reaper", "order-tracking-sweep", "orphan-sweep", "prune-branches", "spawn-storm-detect", "wisp-compact"]
 
 [session]
 provider = "fake"

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -2161,7 +2161,7 @@ func TestTryReloadConfig_IncludesBuiltinPackOrders(t *testing.T) {
 	}
 
 	// Core pack housekeeping orders (explicit core include).
-	for _, want := range []string{"gate-sweep", "wisp-compact"} {
+	for _, want := range []string{"gate-sweep", "wisp-compact", "dead-run-detect"} {
 		if !names[want] {
 			t.Errorf("missing core order %q; got %v", want, names)
 		}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -667,6 +667,20 @@ func TestNoMaintenanceBuiltinPack(t *testing.T) {
 	}
 }
 
+// TestCorePackShipsDeadRunDetectOrder pins that the dead-run-detect order and
+// the script it execs ship in the bundled core pack, so every city that imports
+// core gets the silently-dead-run escalation without per-city configuration.
+func TestCorePackShipsDeadRunDetectOrder(t *testing.T) {
+	order := readBundledPackFileForTest(t, "core", "orders/dead-run-detect.toml")
+	if !strings.Contains(order, `exec = "$PACK_DIR/assets/scripts/dead-run-detect.sh"`) {
+		t.Errorf("dead-run-detect order does not exec its bundled script:\n%s", order)
+	}
+	script := readBundledPackFileForTest(t, "core", "assets/scripts/dead-run-detect.sh")
+	if first := strings.SplitN(script, "\n", 2)[0]; first != "#!/usr/bin/env bash" {
+		t.Errorf("dead-run-detect.sh first line = %q, want bash shebang", first)
+	}
+}
+
 func TestEnsureBuiltinRuntimeAssetsHydratesCacheAndShim(t *testing.T) {
 	clearGCEnv(t) // fresh GC_HOME → hydration starts from a cold cache
 	city := t.TempDir()

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -11472,3 +11472,412 @@ exit 0
 		t.Fatalf("cross-rig-deps summary missing or wrong (subshell counter regression?)\nwant substring: %q\ngot output:\n%s\nbd log:\n%s", want, out, logData)
 	}
 }
+
+// deadRunDetectFixture is the fake city a dead-run-detect test runs against:
+// the session rows `gc session list --json` reports for the "project" rig and
+// the in_progress / open beads `gc bd list --rig project` returns. HQ reports
+// no sessions and no beads. Mail delivery is driven by DEAD_RUN_TEST_MAIL_FAIL
+// (comma-separated recipients whose send fails) and the session list by
+// DEAD_RUN_TEST_SESSION_LIST_EXIT (non-empty = that exit code).
+type deadRunDetectFixture struct {
+	sessions     string // JSON array of session rows for the "project" rig
+	inProgress   string // JSON array of beads for the "project" rig
+	open         string // JSON array of beads for the "project" rig
+	hqInProgress string // JSON array of beads for HQ (bare gc bd list); "[]" when empty
+	hqOpen       string // JSON array of beads for HQ; "[]" when empty
+}
+
+func writeDeadRunDetectGCStub(t *testing.T, path string, fx deadRunDetectFixture) {
+	t.Helper()
+	hqInProgress, hqOpen := fx.hqInProgress, fx.hqOpen
+	if hqInProgress == "" {
+		hqInProgress = "[]"
+	}
+	if hqOpen == "" {
+		hqOpen = "[]"
+	}
+	writeExecutable(t, path, `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+rig=""
+if [ "$1" = "--rig" ]; then
+  rig="$2"
+  shift 2
+fi
+case "$1" in
+  rig)
+    printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+    exit 0
+    ;;
+  session)
+    if [ -n "${DEAD_RUN_TEST_SESSION_LIST_EXIT:-}" ]; then
+      exit "$DEAD_RUN_TEST_SESSION_LIST_EXIT"
+    fi
+    if [ "$rig" = "project" ]; then
+      cat <<'JSON'
+{"sessions":`+fx.sessions+`,"summary":{},"filters":{},"schema_version":"1"}
+JSON
+    else
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+    fi
+    exit 0
+    ;;
+  bd)
+    case "$2" in
+      list)
+        case "$*" in
+          *"--rig project"*"--status=in_progress"*)
+            cat <<'JSON'
+`+fx.inProgress+`
+JSON
+            ;;
+          *"--rig project"*"--status=open"*)
+            cat <<'JSON'
+`+fx.open+`
+JSON
+            ;;
+          *"--status=in_progress"*)
+            cat <<'JSON'
+`+hqInProgress+`
+JSON
+            ;;
+          *)
+            cat <<'JSON'
+`+hqOpen+`
+JSON
+            ;;
+        esac
+        exit 0
+        ;;
+      update)
+        exit 0
+        ;;
+    esac
+    exit 1
+    ;;
+  mail)
+    case ",${DEAD_RUN_TEST_MAIL_FAIL:-}," in
+      *",$3,"*) exit 1 ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 1
+`)
+}
+
+// runDeadRunDetect runs the script against fx with extra env and returns its
+// combined output, the gc call log, and the exit error.
+func runDeadRunDetect(t *testing.T, fx deadRunDetectFixture, extra map[string]string) (string, string, error) {
+	t.Helper()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	writeDeadRunDetectGCStub(t, filepath.Join(binDir, "gc"), fx)
+	env := map[string]string{
+		"GC_CITY":     t.TempDir(),
+		"GC_CALL_LOG": gcLog,
+		"PATH":        binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	for k, v := range extra {
+		env[k] = v
+	}
+	out, err := runScriptResult(t, coreScriptPath("dead-run-detect.sh"), env)
+	logData, readErr := os.ReadFile(gcLog)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("ReadFile(gc log): %v", readErr)
+	}
+	return string(out), string(logData), err
+}
+
+const deadRunDriver = "gc__run-operator-mc-dead"
+
+// deadRunRootJSON is an in_progress graph.v2 workflow root driven by
+// deadRunDriver: it is the assignee and is stamped as gc.session_name the way
+// stampRunRootFromStep does.
+func deadRunRootJSON(at, extraMeta string) string {
+	return fmt.Sprintf(`{"id":"ga-root","title":"Build widget","status":"in_progress","assignee":%q,"created_at":%q,"updated_at":%q,"metadata":{"gc.kind":"workflow","gc.formula_contract":"graph.v2","gc.session_name":%q,"gc.input_convoy_id":"ga-convoy","gc.formula_name":"build-basic","gc.routed_to":"gascity/gc.run-operator"%s}}`,
+		deadRunDriver, at, at, deadRunDriver, extraMeta)
+}
+
+// deadRunStepJSON is a step bead under ga-root. An empty assignee is emitted
+// as a missing field for the first id and as "" for the second, matching both
+// shapes bd produces for an unclaimed bead.
+func deadRunStepJSON(id, status, assignee, at string) string {
+	assigneeField := ""
+	if assignee != "" || strings.HasSuffix(id, "2") {
+		assigneeField = fmt.Sprintf(`"assignee":%q,`, assignee)
+	}
+	return fmt.Sprintf(`{"id":%q,"status":%q,%s"created_at":%q,"updated_at":%q,"metadata":{"gc.root_bead_id":"ga-root"}}`,
+		id, status, assigneeField, at, at)
+}
+
+func deadRunTimestamp(ago time.Duration) string {
+	return time.Now().UTC().Add(-ago).Format(time.RFC3339)
+}
+
+func TestDeadRunDetectEscalatesDeadRootWithRecoveryRecipe(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		// The driver is present only as a CLOSED row: closed rows must not
+		// count as live.
+		sessions:   `[{"id":"mc-closed","session_name":"` + deadRunDriver + `","closed":true},{"id":"mc-other","session_name":"project__worker-gc-live","template":"project/worker","closed":false}]`,
+		inProgress: `[` + deadRunRootJSON(old, "") + `,{"id":"ga-plain","status":"in_progress","assignee":"project__worker-gc-live","created_at":"` + old + `","updated_at":"` + old + `"}]`,
+		open:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `,` + deadRunStepJSON("ga-step2", "open", "", old) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dead-run-detect: escalated=1 already-escalated=0 cleared=0") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	if got := strings.Count(log, "mail send "); got != 1 {
+		t.Fatalf("mail send count = %d, want 1\n%s", got, log)
+	}
+	for _, want := range []string{
+		"mail send mayor -s DEAD_RUN: workflow root ga-root has no live driving session -m ",
+		"driving it (gascity/gc.run-operator, " + deadRunDriver + ")",
+		"silent for 3h0m (threshold: 2h)",
+		"2 open, unclaimed step bead(s): ga-step1 ga-step2",
+		"formula: build-basic; input convoy: ga-convoy",
+		"gc sling gascity/gc.run-operator ga-convoy --on build-from-convoy --force --var requirements_path=<requirements.md> --var plan_path=<plan.md> --var decomposition_path=<decomposition.json>",
+		`gc bd close ga-root ga-step1 ga-step2 --reason "dead workflow run superseded by re-entry"`,
+		" --notify\n",
+		"bd update ga-root --rig project --set-metadata gc.dead_run_escalated_at=",
+	} {
+		if !strings.Contains(log, want) {
+			t.Errorf("gc log missing %q:\n%s", want, log)
+		}
+	}
+	// The marker is the only mutation: no close, no reset, and the plain
+	// in_progress task is never touched. The recovery recipe in the mail body
+	// mentions `gc bd close`, so match logged INVOCATIONS (line prefixes), not
+	// substrings.
+	for _, line := range nonEmptyLogLines(log) {
+		for _, forbidden := range []string{"bd close", "bd delete", "bd release-if-current", "bd update ga-plain", "bd update ga-step"} {
+			if strings.HasPrefix(line, forbidden) {
+				t.Errorf("gc log contains forbidden mutation %q: %s", forbidden, line)
+			}
+		}
+	}
+}
+
+func TestDeadRunDetectSkipsRootWithLiveDriver(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		sessions:   `[{"id":"mc-live","session_name":"` + deadRunDriver + `","state":"active","closed":false}]`,
+		inProgress: `[` + deadRunRootJSON(old, "") + `]`,
+		open:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if strings.Contains(log, "mail send") || strings.Contains(log, "bd update") {
+		t.Fatalf("live-driver root must not be escalated or marked:\n%s", log)
+	}
+}
+
+// TestDeadRunDetectAcceptsLiveTemplateShortFormAsDriver pins the conservative
+// identity matching: a root whose recorded driver is the bare agent name
+// (gc.run-operator) is alive when any non-closed session of that template
+// (gascity/gc.run-operator) exists, mirroring the rig-stripped forms
+// orphan-sweep accepts. Without this, every named-agent root would alert the
+// moment its session was recycled under a new session_name.
+func TestDeadRunDetectAcceptsLiveTemplateShortFormAsDriver(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		sessions:   `[{"id":"mc-new","session_name":"gc__run-operator-mc-new","template":"gascity/gc.run-operator","closed":false}]`,
+		inProgress: `[{"id":"ga-root","status":"in_progress","assignee":"gc.run-operator","created_at":"` + old + `","updated_at":"` + old + `","metadata":{"gc.formula_contract":"graph.v2"}}]`,
+		open:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if strings.Contains(log, "mail send") || strings.Contains(log, "bd update") {
+		t.Fatalf("root driven by a live template must not be escalated:\n%s", log)
+	}
+}
+
+func TestDeadRunDetectDedupsMarkedRootAndClearsMarkerOnRecovery(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	marked := deadRunRootJSON(old, `,"gc.dead_run_escalated_at":"2026-01-01T00:00:00Z"`)
+	steps := `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`
+
+	// Still dead, already marked: no second mail, no marker rewrite.
+	out, log, err := runDeadRunDetect(t, deadRunDetectFixture{
+		sessions:   `[]`,
+		inProgress: `[` + marked + `]`,
+		open:       steps,
+	}, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "escalated=0 already-escalated=1 cleared=0") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	if strings.Contains(log, "mail send") || strings.Contains(log, "bd update") {
+		t.Fatalf("marked root must be deduped, not re-mailed or re-marked:\n%s", log)
+	}
+
+	// Driver back: the marker is cleared so a recurrence re-alerts.
+	out, log, err = runDeadRunDetect(t, deadRunDetectFixture{
+		sessions:   `[{"id":"mc-live","session_name":"` + deadRunDriver + `","closed":false}]`,
+		inProgress: `[` + marked + `]`,
+		open:       steps,
+	}, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "escalated=0 already-escalated=0 cleared=1") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	if !strings.Contains(log, "bd update ga-root --rig project --unset-metadata gc.dead_run_escalated_at") {
+		t.Fatalf("marker was not cleared:\n%s", log)
+	}
+	if strings.Contains(log, "mail send") {
+		t.Fatalf("recovered root must not be mailed:\n%s", log)
+	}
+}
+
+func TestDeadRunDetectHonorsSilenceThreshold(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	recent := deadRunTimestamp(10 * time.Minute)
+	fx := deadRunDetectFixture{
+		sessions:   `[]`,
+		inProgress: `[` + deadRunRootJSON(old, "") + `]`,
+		// The step was touched 10 minutes ago: the run is silent, but not
+		// past the default 2h threshold.
+		open: `[` + deadRunStepJSON("ga-step1", "open", "", recent) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if strings.Contains(log, "mail send") || strings.Contains(log, "bd update") {
+		t.Fatalf("run inside the silence threshold must not be escalated:\n%s", log)
+	}
+
+	out, log, err = runDeadRunDetect(t, fx, map[string]string{"GC_DEAD_RUN_THRESHOLD": "5m"})
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(log, "mail send mayor") || !strings.Contains(log, "--set-metadata gc.dead_run_escalated_at=") {
+		t.Fatalf("lowered threshold must escalate:\n%s", log)
+	}
+	if !strings.Contains(log, "(threshold: 5m)") {
+		t.Fatalf("mail must name the configured threshold:\n%s", log)
+	}
+}
+
+func TestDeadRunDetectSkipsRunWithStepHeldByLiveSession(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		sessions:   `[{"id":"mc-w","session_name":"project__worker-gc-live","closed":false}]`,
+		inProgress: `[` + deadRunRootJSON(old, "") + `,` + deadRunStepJSON("ga-step2", "in_progress", "project__worker-gc-live", old) + `]`,
+		open:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if strings.Contains(log, "mail send") || strings.Contains(log, "bd update") {
+		t.Fatalf("run with a step held by a live session is not dead:\n%s", log)
+	}
+}
+
+func TestDeadRunDetectFallsBackToEscalationRecipientAndFailsLoud(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		sessions:   `[]`,
+		inProgress: `[` + deadRunRootJSON(old, "") + `]`,
+		open:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`,
+	}
+
+	// No mayor to deliver to: the fallback address gets the mail and the
+	// root is marked.
+	out, log, err := runDeadRunDetect(t, fx, map[string]string{"DEAD_RUN_TEST_MAIL_FAIL": "mayor"})
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(log, "mail send mayor") || !strings.Contains(log, "mail send human") {
+		t.Fatalf("expected mayor attempt then human fallback:\n%s", log)
+	}
+	if !strings.Contains(log, "--set-metadata gc.dead_run_escalated_at=") {
+		t.Fatalf("delivered fallback must mark the root:\n%s", log)
+	}
+
+	// Nothing deliverable: loud-fail — non-zero exit, stderr, and NO marker so
+	// the next sweep retries.
+	out, log, err = runDeadRunDetect(t, fx, map[string]string{"DEAD_RUN_TEST_MAIL_FAIL": "mayor,human"})
+	if err == nil {
+		t.Fatalf("dead-run-detect.sh must exit non-zero when no escalation was delivered; output:\n%s", out)
+	}
+	if !strings.Contains(out, "FAILED to escalate dead workflow run ga-root") || !strings.Contains(out, "will retry next sweep") {
+		t.Fatalf("expected loud-fail message; output:\n%s", out)
+	}
+	if strings.Contains(log, "bd update") {
+		t.Fatalf("undelivered escalation must not be marked:\n%s", log)
+	}
+}
+
+func TestDeadRunDetectSkipsSweepWhenSessionListFails(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		sessions:   `[]`,
+		inProgress: `[` + deadRunRootJSON(old, "") + `]`,
+		open:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, map[string]string{"DEAD_RUN_TEST_SESSION_LIST_EXIT": "1"})
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh must skip (exit 0) on an unverifiable session list: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "liveness unverifiable, skipping sweep") {
+		t.Fatalf("expected skip notice; output:\n%s", out)
+	}
+	if strings.Contains(log, "mail send") || strings.Contains(log, "bd update") || strings.Contains(log, "bd list") {
+		t.Fatalf("unverifiable liveness must stop the sweep before any bead read or write:\n%s", log)
+	}
+}
+
+// TestDeadRunDetectHandlesHQScopedRoot pins the HQ scope: a root that lives in
+// the city store (listed by a bare `gc bd list`, no --rig) must be evaluated
+// and marked without a --rig argument. The scope is an empty TSV field, which a
+// tab-IFS `read` strips when it LEADS the line — so the script must emit the
+// id first, or every HQ-scoped root is silently skipped.
+func TestDeadRunDetectHandlesHQScopedRoot(t *testing.T) {
+	old := deadRunTimestamp(3 * time.Hour)
+	fx := deadRunDetectFixture{
+		sessions:     `[]`,
+		inProgress:   `[]`,
+		open:         `[]`,
+		hqInProgress: `[` + deadRunRootJSON(old, "") + `]`,
+		hqOpen:       `[` + deadRunStepJSON("ga-step1", "open", "", old) + `]`,
+	}
+
+	out, log, err := runDeadRunDetect(t, fx, nil)
+	if err != nil {
+		t.Fatalf("dead-run-detect.sh failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dead-run-detect: escalated=1 already-escalated=0 cleared=0") {
+		t.Fatalf("HQ-scoped dead root was not escalated; output:\n%s", out)
+	}
+	if !strings.Contains(log, "mail send mayor -s DEAD_RUN: workflow root ga-root has no live driving session") {
+		t.Fatalf("gc log missing HQ escalation mail:\n%s", log)
+	}
+	if !strings.Contains(log, "Scope: hq;") {
+		t.Fatalf("mail must report the hq scope:\n%s", log)
+	}
+	if !strings.Contains(log, "bd update ga-root --set-metadata gc.dead_run_escalated_at=") {
+		t.Fatalf("HQ marker write must not carry --rig:\n%s", log)
+	}
+	if strings.Contains(log, "bd update ga-root --rig") {
+		t.Fatalf("HQ marker write carried a --rig argument:\n%s", log)
+	}
+}

--- a/internal/bootstrap/packs/core/README.md
+++ b/internal/bootstrap/packs/core/README.md
@@ -18,6 +18,7 @@ none requires per-city configuration.
 | `cross-rig-deps` | cooldown 5m | Convert satisfied cross-rig `blocks` deps to `related` |
 | `order-tracking-sweep` | cooldown | Close stale order-tracking beads and prune expired tracking history |
 | `spawn-storm-detect` | cooldown | Detect beads repeatedly bouncing back to pool |
+| `dead-run-detect` | cooldown 30m | Mail the mayor once when an in_progress workflow root's driving session is gone |
 | `prune-branches` | cooldown | Clean stale `gc/*` branches from all rigs |
 | `wisp-compact` | cooldown | TTL-based cleanup of expired ephemeral beads (wisps) |
 | **`nudge-on-route`** | **event `bead.updated`** | **Nudge the target session when a bead is routed to it** |
@@ -111,6 +112,71 @@ Entries older than the retention window are pruned on each run.
 | -------- | ------- | ------- |
 | `GC_CASCADE_NUDGE_LOOKBACK` | `5m` | Event lookback window |
 | `GC_CASCADE_NUDGE_RETENTION` | `1h` | Dedup-entry retention (Ns/Nm/Nh) |
+
+## `dead-run-detect`
+
+**Why.** A formulas-v2 (graph.v2) run is driven by the session that claimed
+its workflow root. When that session dies between steps — after a
+decomposition step closed and before the drain was routed — the root stays
+`in_progress`, the step beads stay open and unclaimed, and the run reports as
+active indefinitely with no signal to anyone. Nothing else catches that shape:
+`reaper.sh`'s stale-root close needs an empty assignee, >24h of silence and
+no descendant in a live status (`open` is live, so open step beads make the
+root permanently ineligible — and it closes silently anyway);
+`orphan-sweep.sh` resets `in_progress` beads whose assignee is unknown, and a
+configured agent name counts as known with no session running; the
+dashboard's run staleness (`internal/runproj/enrich.go`) is display-only; the
+pool-slot backstops (`cmd/gc/execution_backstop.go`, `cmd/gc/idle_nudge.go`)
+never look at workflow roots. This order ships the missing detector.
+
+**Predicate.** Every sweep collects the live session identities from
+`gc session list --json` for HQ and every non-HQ rig (the liveness source
+`orphan-sweep.sh` uses; a failed list in any scope skips the whole sweep so a
+partial picture never produces a false verdict), enumerates `in_progress` and
+`open` beads per scope, and selects workflow roots: `status == in_progress`
+and `gc.kind == workflow` or `gc.formula_contract == graph.v2`
+(`sourceworkflow.IsWorkflowRoot`) and `gc.root_bead_id` empty or self. A
+root's driver is read from the fields the run projection reads
+(`internal/runproj/detail_sessionlink.go`): `session_name` /
+`gc.session_name` / `gc.sessionName` / `session_id` / `gc.session_id` /
+`gc.sessionId`, then the assignee, then `gc.routed_to`; the reconciler
+back-fills `gc.session_name` onto the root from its worked steps
+(`cmd/gc/build_desired_state.go` `stampRunRootFromStep`). A root is escalated
+when none of those identities matches a live session (exact
+id/session_name/alias/agent_name/name/template, or the rig-stripped and
+pool-slot-stripped forms `orphan-sweep.sh` accepts), it has at least one
+open step with an empty assignee (`gc.root_bead_id == root`), no
+`in_progress` step is held by a live session, and no step bead has been
+created or updated for longer than `GC_DEAD_RUN_THRESHOLD`. A root with no
+recorded driver at all is left alone as unverifiable.
+
+**Escalation.** One `gc mail send --notify` to `GC_DEAD_RUN_RECIPIENT`
+(default `mayor`), falling back to `GC_ESCALATION_RECIPIENT` (default
+`human`) when the primary address is undeliverable. The body names the root,
+its driver, the silence age, the unclaimed step ids, and the recovery recipe
+validated in production: re-enter with `gc sling <target> <convoy> --on
+build-from-convoy --force` (build-from-convoy adopts the existing
+implementation convoy and takes `requirements_path` / `plan_path` /
+`decomposition_path` vars), then close the dead root and all of its step beads
+in ONE `gc bd close` invocation (per-bead close loops time out). Undeliverable
+sends surface loudly, are not marked, and exit non-zero so the controller logs
+them (loud-fail, gastownhall/gascity#4543).
+
+**Idempotence / dedup.** The marker `gc.dead_run_escalated_at=<ISO timestamp>`
+is written on the root only after a delivered send; a marked root is never
+re-mailed. The marker is removed when the condition clears (driver alive
+again, steps claimed, run progressed), so a recurrence re-alerts. The marker is
+the only mutation the order ever makes: it never closes, resets, or reassigns
+work beads.
+
+**Configuration** (all optional, via `[order.env]` or the controller env):
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `GC_DEAD_RUN_THRESHOLD` | `2h` | Silence (no step created/updated) required before escalating |
+| `GC_DEAD_RUN_RECIPIENT` | `mayor` | Primary escalation address |
+| `GC_ESCALATION_RECIPIENT` | `human` | Fallback address when the primary is undeliverable |
+| `GC_DEAD_RUN_REENTRY_FORMULA` | `build-from-convoy` | Re-entry formula named in the recovery recipe |
 
 ## Dependencies
 

--- a/internal/bootstrap/packs/core/assets/scripts/dead-run-detect.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/dead-run-detect.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# dead-run-detect — escalate in-flight workflow runs whose driving session died.
+#
+# A formulas-v2 (graph.v2) run is driven by the session that claimed its
+# workflow root (the run-operator). When that session dies between steps —
+# after a decomposition step closed and before the drain was routed — nothing
+# in the city notices: the root stays in_progress, the step beads stay open and
+# unclaimed, and the run reports as active indefinitely. Every existing sweep
+# misses this shape:
+#   - reaper.sh's stale-root close needs an EMPTY assignee, >24h of silence and
+#     NO descendant in a live status ('open' is live), so open step beads make
+#     the root permanently ineligible — and that path closes silently anyway.
+#   - orphan-sweep.sh resets in_progress beads whose assignee is unknown; a
+#     root assigned to a CONFIGURED agent name counts as known even when no
+#     session for it is running.
+#   - the dashboard's run staleness (internal/runproj/enrich.go) is display-only.
+#   - the execution / idle-claim backstops (cmd/gc/execution_backstop.go,
+#     cmd/gc/idle_nudge.go) act on pool-slot trigger beads, not workflow roots.
+#
+# Runs as a cooldown sweep. Each run:
+#   1. Collects the live session identities from `gc session list --json` for
+#      HQ and every non-HQ rig (the liveness source orphan-sweep.sh uses). If
+#      any scope's session list fails, liveness is unverifiable and the whole
+#      sweep is skipped — never alert on a partial picture.
+#   2. Enumerates in_progress and open beads per scope via `gc bd list`.
+#   3. Selects workflow ROOTS: status in_progress AND
+#      (metadata gc.kind == "workflow" OR gc.formula_contract == "graph.v2")
+#      AND gc.root_bead_id empty or self (sourceworkflow.IsWorkflowRoot).
+#   4. Resolves each root's DRIVING SESSION from the fields the run projection
+#      reads (internal/runproj/detail_sessionlink.go): metadata session_name /
+#      gc.session_name / gc.sessionName / session_id / gc.session_id /
+#      gc.sessionId, then the assignee, then gc.routed_to. The reconciler
+#      back-fills gc.session_name onto the root from its worked steps
+#      (cmd/gc/build_desired_state.go stampRunRootFromStep).
+#   5. A root is DEAD when none of those identities matches a live session
+#      (exact id / session_name / alias / agent_name / name / template, or the
+#      rig-stripped and pool-slot-stripped forms orphan-sweep.sh accepts), it
+#      has at least one open UNCLAIMED step (gc.root_bead_id == root, status
+#      open, empty assignee), no in_progress step held by a live session, and
+#      the run has been silent — no step bead created or updated — for longer
+#      than GC_DEAD_RUN_THRESHOLD.
+#   6. Escalates ONCE per root by mail to GC_DEAD_RUN_RECIPIENT (default
+#      mayor), falling back to GC_ESCALATION_RECIPIENT (default human) when the
+#      primary address is undeliverable. The mail carries the recovery recipe.
+#
+# Dedup marker: metadata gc.dead_run_escalated_at=<ISO timestamp> on the root,
+# written only after a delivered send. A marked root is never re-mailed; the
+# marker is removed when the condition clears (driver alive again, steps
+# claimed, or the run progressed), so a recurrence re-alerts. Nothing else on
+# any work bead is mutated — no closes, no resets, no assignee changes.
+#
+# Loud-fail (gastownhall/gascity#4543): an undeliverable escalation surfaces on
+# stderr, is NOT marked, and the script exits non-zero so the controller logs
+# it; the next sweep retries.
+#
+# Runs as an exec order (no LLM, no agent, no wisp).
+set -euo pipefail
+
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "dead-run-detect"
+
+# jq is a hard dependency: it decodes the session list and every bead record.
+# Without it nothing could be evaluated. Fail loud.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "dead-run-detect: jq is required but not found in PATH" >&2
+    exit 1
+fi
+
+# A root must have been silent (no step bead created or updated) at least this
+# long, with its driver gone, before it is escalated. Debounces the window in
+# which a session is being replaced or a step is between hand-offs.
+THRESHOLD="${GC_DEAD_RUN_THRESHOLD:-2h}"
+# Primary escalation address. The mayor coordinates runs, so it is the address
+# that can act on the recovery recipe.
+RECIPIENT="${GC_DEAD_RUN_RECIPIENT:-mayor}"
+# Fallback when the primary address is undeliverable (a city with no mayor).
+# escalate.sh and the human-gate notify orders use the same default.
+FALLBACK_RECIPIENT="${GC_ESCALATION_RECIPIENT:-human}"
+# Re-entry formula named in the recovery recipe.
+REENTRY_FORMULA="${GC_DEAD_RUN_REENTRY_FORMULA:-build-from-convoy}"
+# Dedup marker written on the root after a delivered escalation.
+MARKER_KEY="gc.dead_run_escalated_at"
+
+# Convert a simple Go-style duration (Ns/Nm/Nh/Nd) to whole seconds.
+duration_to_seconds() {
+    case "$1" in
+        *d) echo $(( ${1%d} * 86400 )) ;;
+        *h) echo $(( ${1%h} * 3600 )) ;;
+        *m) echo $(( ${1%m} * 60 )) ;;
+        *s) echo "${1%s}" ;;
+        *)  echo "$1" ;;
+    esac
+}
+
+THRESHOLD_S="$(duration_to_seconds "$THRESHOLD")"
+NOW_EPOCH="$(date -u +%s)"
+NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+WORK_DIR="$(mktemp -d)" || exit 0
+trap 'rm -rf "$WORK_DIR"' EXIT
+SESSIONS_FILE="$WORK_DIR/sessions.jsonl"
+BEADS_FILE="$WORK_DIR/beads.jsonl"
+SCOPES_FILE="$WORK_DIR/scopes"
+: > "$SESSIONS_FILE"
+: > "$BEADS_FILE"
+
+# Scopes to sweep: HQ (empty scope, bare gc) plus every non-HQ rig. `gc bd
+# list` and `gc session list` without --rig are HQ-scoped from the city cwd,
+# so per-rig beads and sessions are invisible to a bare query — walk each rig
+# explicitly. The HQ entry is excluded (gc rig list reports the city root as an
+# hq=true pseudo-rig that `gc --rig <cityName>` cannot resolve), matching the
+# sibling scripts' cross-rig convention.
+printf '\n' > "$SCOPES_FILE"
+RIGS_JSON="$(gc rig list --json 2>/dev/null || true)"
+if [ -n "$RIGS_JSON" ]; then
+    printf '%s' "$RIGS_JSON" \
+        | jq -r '(.rigs // [])[] | select(.hq != true) | .name' 2>/dev/null \
+        >> "$SCOPES_FILE" || true
+fi
+RIG_COUNT=$(( $(grep -c . "$SCOPES_FILE" || true) ))
+
+# Step 1: live session identities across every scope. A session-list failure
+# in ANY scope makes liveness unverifiable city-wide (a root's driver may live
+# in a scope other than the root's), so the sweep stops before it can produce
+# a false "dead" verdict. Skipping is silent-by-design like orphan-sweep's
+# `|| exit 0`; nothing is mutated on this path.
+while IFS= read -r scope; do
+    if [ -n "$scope" ]; then
+        gc --rig "$scope" session list --json >"$WORK_DIR/sessions.raw" 2>/dev/null || {
+            echo "dead-run-detect: session list failed for rig $scope; liveness unverifiable, skipping sweep" >&2
+            exit 0
+        }
+    else
+        gc session list --json >"$WORK_DIR/sessions.raw" 2>/dev/null || {
+            echo "dead-run-detect: HQ session list failed; liveness unverifiable, skipping sweep" >&2
+            exit 0
+        }
+    fi
+    cat "$WORK_DIR/sessions.raw" >> "$SESSIONS_FILE"
+done < "$SCOPES_FILE"
+
+# Every identity a non-closed session row exposes, plus the rig-stripped short
+# form of each, as one JSON array. The JSON shape is
+# {"sessions":[...], "summary":..., "filters":..., "schema_version":...} with
+# snake_case fields; PascalCase is accepted as forward-compatible hardening so
+# a casing change cannot empty the live set and turn every run "dead"
+# (orphan-sweep.sh carries the same guard).
+LIVE_JSON="$(jq -c -s '
+    def pick($snake; $pascal):
+      if has($snake) and .[$snake] != null then .[$snake]
+      elif has($pascal) and .[$pascal] != null then .[$pascal]
+      else null end;
+    [ .[] | .sessions[]?
+      | select(
+          (pick("closed"; "Closed") // false) == false
+          and (((pick("state"; "State") // "") | tostring | ascii_downcase) != "closed")
+        )
+      | pick("id"; "ID"), pick("session_name"; "SessionName"), pick("alias"; "Alias"),
+        pick("agent_name"; "AgentName"), pick("template"; "Template"), pick("name"; "Name")
+    ]
+    | map(select(. != null and . != "") | tostring)
+    | map(., (split("/") | last))
+    | unique
+' "$SESSIONS_FILE" 2>/dev/null)" || exit 0
+[ -n "$LIVE_JSON" ] || LIVE_JSON='[]'
+
+# Step 2: in_progress and open beads per scope, annotated with their scope so
+# a root's marker write can be routed back to the store that owns it. A scope
+# is staged and committed only when BOTH lists succeed and parse; a scope with
+# a failed list is dropped whole (its roots are simply not evaluated this
+# sweep), so a root can never be judged against a partial view of its steps.
+# Nothing is mutated for beads that were not seen.
+list_beads() {
+    local scope="$1"
+    local status="$2"
+    if [ -n "$scope" ]; then
+        gc bd list --rig "$scope" --status="$status" --json --limit=0 2>/dev/null
+    else
+        gc bd list --status="$status" --json --limit=0 2>/dev/null
+    fi
+}
+
+SCOPE_STAGE="$WORK_DIR/scope.jsonl"
+while IFS= read -r scope; do
+    : > "$SCOPE_STAGE"
+    for status in in_progress open; do
+        LISTED="$(list_beads "$scope" "$status")" || {
+            echo "dead-run-detect: gc bd list --status=$status failed for scope '${scope:-hq}'; skipping scope" >&2
+            continue 2
+        }
+        [ -n "$LISTED" ] || continue
+        printf '%s' "$LISTED" \
+            | jq -c --arg scope "$scope" '(if type == "array" then . else [] end)[] | {scope: $scope, bead: .}' \
+            >> "$SCOPE_STAGE" 2>/dev/null || {
+            echo "dead-run-detect: unparseable gc bd list output for scope '${scope:-hq}'; skipping scope" >&2
+            continue 2
+        }
+    done
+    cat "$SCOPE_STAGE" >> "$BEADS_FILE"
+done < "$SCOPES_FILE"
+
+[ -s "$BEADS_FILE" ] || exit 0
+
+# Step 3: workflow roots. Mirrors sourceworkflow.IsWorkflowRoot (gc.kind ==
+# workflow OR gc.formula_contract == graph.v2) plus the reaper's root test
+# (gc.root_bead_id empty or self), so graph.v2-only roots are not missed.
+ROOTS="$(jq -r '
+    select(.bead.status == "in_progress")
+    | .bead as $b
+    | ($b.metadata // {}) as $m
+    | select(
+        (($m["gc.kind"] // "") | tostring | ascii_downcase) == "workflow"
+        or (($m["gc.formula_contract"] // "") | tostring | ascii_downcase) == "graph.v2"
+      )
+    | select((($m["gc.root_bead_id"] // "") | tostring) as $r | $r == "" or $r == $b.id)
+    | [$b.id, .scope] | @tsv
+' "$BEADS_FILE" 2>/dev/null)" || exit 0
+[ -n "$ROOTS" ] || exit 0
+
+# Step 4: per-root verdict. One jq pass over the collected beads yields the
+# driver identities, which of them are live, the unclaimed open steps, the
+# in_progress steps held by live sessions, the last step activity, and the
+# marker. Timestamps are parsed in jq (portable across GNU and BSD date);
+# fractional seconds are dropped and numeric UTC offsets folded in.
+root_verdict() {
+    local scope="$1"
+    local id="$2"
+    jq -c -s --arg scope "$scope" --arg id "$id" --arg marker "$MARKER_KEY" \
+        --argjson live "$LIVE_JSON" --argjson now "$NOW_EPOCH" '
+        def short: if type == "string" and contains("/") then (split("/") | last) else . end;
+        def slotbase: if type == "string" then sub("-[0-9]+$"; "") else . end;
+        def islive($ids):
+          (tostring) as $s
+          | any($ids[]; . == $s or . == ($s | short) or . == ($s | slotbase) or . == ($s | short | slotbase));
+        def epoch:
+          if . == null or . == "" then null else
+            (tostring | sub("\\.[0-9]+"; "")) as $s
+            | if ($s | endswith("Z")) then (try ($s | fromdateiso8601) catch null)
+              else ($s | capture("^(?<base>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})(?<sign>[+-])(?<hh>[0-9]{2}):(?<mm>[0-9]{2})$") // null) as $c
+                | if $c == null then null
+                  else (try (($c.base + "Z") | fromdateiso8601) catch null) as $b
+                    | if $b == null then null
+                      else $b - (if $c.sign == "+" then 1 else -1 end) * ((($c.hh | tonumber) * 3600) + (($c.mm | tonumber) * 60))
+                      end
+                  end
+              end
+          end;
+        (map(select(.scope == $scope and .bead.id == $id)) | first | .bead) as $root
+        | ($root.metadata // {}) as $rm
+        | (map(.bead) | map(select(.id != $id and (((.metadata // {})["gc.root_bead_id"] // "") | tostring) == $id))) as $desc
+        | ($desc | map(select(.status == "open" and ((.assignee // "") == ""))) | map(.id)) as $unclaimed
+        | ($desc | map(select(.status == "in_progress" and ((.assignee // "") != "") and ((.assignee) | islive($live)))) | map(.id)) as $claimed_live
+        | ([ $rm.session_name, $rm["gc.session_name"], $rm["gc.sessionName"],
+             $rm.session_id, $rm["gc.session_id"], $rm["gc.sessionId"],
+             $root.assignee, $rm["gc.routed_to"] ]
+           | map(select(. != null and . != "") | tostring) | unique) as $drivers
+        | ($drivers | map(select(islive($live)))) as $alive
+        | ([ $root.created_at ] + ($desc | map(.updated_at // .created_at)) | map(epoch) | map(select(. != null)) | max) as $last
+        | {
+            unclaimed: $unclaimed,
+            claimed_live: $claimed_live,
+            drivers: $drivers,
+            alive: $alive,
+            silence: (if $last == null then null else ($now - $last) end),
+            marker: (($rm[$marker] // "") | tostring),
+            title: ($root.title // ""),
+            formula: (($rm["gc.formula_name"] // $rm["gc.formula"] // "") | tostring),
+            convoy: (($rm["gc.input_convoy_id"] // "") | tostring),
+            routed_to: (($rm["gc.routed_to"] // "") | tostring)
+          }
+    ' "$BEADS_FILE" 2>/dev/null
+}
+
+verdict_field() {
+    printf '%s' "$1" | jq -r "$2" 2>/dev/null
+}
+
+ESCALATED=0
+DEDUPED=0
+CLEARED=0
+FAILED=0
+# The id comes first: the HQ scope is an empty field, and `read` with a tab
+# IFS strips a LEADING empty field (tab is IFS whitespace), which would shift
+# the id into $scope and silently skip every HQ-scoped root.
+while IFS="$(printf '\t')" read -r root_id scope; do
+    [ -n "$root_id" ] || continue
+
+    RIG_ARG1=""
+    RIG_ARG2=""
+    if [ -n "$scope" ]; then
+        RIG_ARG1="--rig"
+        RIG_ARG2="$scope"
+    fi
+
+    VERDICT="$(root_verdict "$scope" "$root_id")" || continue
+    [ -n "$VERDICT" ] && [ "$VERDICT" != "null" ] || continue
+
+    DRIVER_COUNT="$(verdict_field "$VERDICT" '.drivers | length')"
+    ALIVE_COUNT="$(verdict_field "$VERDICT" '.alive | length')"
+    UNCLAIMED_COUNT="$(verdict_field "$VERDICT" '.unclaimed | length')"
+    CLAIMED_LIVE_COUNT="$(verdict_field "$VERDICT" '.claimed_live | length')"
+    SILENCE="$(verdict_field "$VERDICT" '.silence // empty')"
+    MARKER="$(verdict_field "$VERDICT" '.marker')"
+
+    # Dead = a driver is recorded and none of its identities is live, the run
+    # has an open unclaimed step, no step is being worked by a live session,
+    # and the silence exceeds the threshold. A root with NO recorded driver at
+    # all is unverifiable and left alone rather than guessed at.
+    DEAD=0
+    if [ "${DRIVER_COUNT:-0}" -gt 0 ] && [ "${ALIVE_COUNT:-0}" -eq 0 ] \
+        && [ "${UNCLAIMED_COUNT:-0}" -gt 0 ] && [ "${CLAIMED_LIVE_COUNT:-0}" -eq 0 ] \
+        && [ -n "$SILENCE" ] && [ "$SILENCE" -ge "$THRESHOLD_S" ]; then
+        DEAD=1
+    fi
+
+    if [ "$DEAD" -eq 0 ]; then
+        # Condition absent or cleared. Drop a stale marker so a recurrence on
+        # this root re-alerts; a root that was never marked is untouched.
+        if [ -n "$MARKER" ]; then
+            if gc bd update "$root_id" ${RIG_ARG1:+"$RIG_ARG1" "$RIG_ARG2"} --unset-metadata "$MARKER_KEY" >/dev/null 2>&1; then
+                CLEARED=$((CLEARED + 1))
+            else
+                echo "dead-run-detect: failed to clear $MARKER_KEY on $root_id (will retry next sweep)" >&2
+            fi
+        fi
+        continue
+    fi
+
+    if [ -n "$MARKER" ]; then
+        # Already escalated for this occurrence; never re-mail every cycle.
+        DEDUPED=$((DEDUPED + 1))
+        continue
+    fi
+
+    TITLE="$(verdict_field "$VERDICT" '.title')"
+    DRIVERS="$(verdict_field "$VERDICT" '.drivers | join(", ")')"
+    UNCLAIMED_IDS="$(verdict_field "$VERDICT" '.unclaimed | join(" ")')"
+    FORMULA="$(verdict_field "$VERDICT" '.formula')"
+    CONVOY="$(verdict_field "$VERDICT" '.convoy')"
+    ROUTED_TO="$(verdict_field "$VERDICT" '.routed_to')"
+    age_h=$(( SILENCE / 3600 ))
+    age_m=$(( (SILENCE % 3600) / 60 ))
+
+    SUBJECT="DEAD_RUN: workflow root $root_id has no live driving session"
+    BODY="Workflow root $root_id${TITLE:+ ($TITLE)} is in_progress but the session driving it ($DRIVERS) is not in gc session list (HQ + $RIG_COUNT rig(s)), and the run has been silent for ${age_h}h${age_m}m (threshold: $THRESHOLD).
+It has $UNCLAIMED_COUNT open, unclaimed step bead(s): $UNCLAIMED_IDS
+Scope: ${scope:-hq}${FORMULA:+; formula: $FORMULA}${CONVOY:+; input convoy: $CONVOY}${ROUTED_TO:+; routed to: $ROUTED_TO}
+
+No sweep will recover this on its own: the reaper skips roots with open descendants, orphan-sweep only resets beads whose assignee is unknown, and the dashboard staleness flag is display-only.
+
+Recovery recipe (validated in production):
+1. Re-enter the build with the latest re-entry formula. $REENTRY_FORMULA adopts the existing implementation convoy; --force replaces the dead workflow's source attachment; pass the artifact-path vars the formula requires (requirements_path, plan_path, decomposition_path):
+   gc sling ${ROUTED_TO:-gc.run-operator} ${CONVOY:-<convoy-id>} --on $REENTRY_FORMULA --force --var requirements_path=<requirements.md> --var plan_path=<plan.md> --var decomposition_path=<decomposition.json>
+2. Then close the dead root and its step beads in ONE gc bd close invocation (per-bead close loops time out):
+   gc bd close $root_id $UNCLAIMED_IDS --reason \"dead workflow run superseded by re-entry\"
+
+Inspect: gc bd show $root_id --json
+This alert is sent once per root (marker $MARKER_KEY) and re-fires only if the condition clears and recurs."
+
+    # Loud-fail: mark the root only on a delivered send, so an undeliverable
+    # escalation surfaces and retries next sweep. The fallback address covers a
+    # city with no mayor session to address.
+    if gc mail send "$RECIPIENT" -s "$SUBJECT" -m "$BODY" --notify >/dev/null 2>&1 \
+        || { [ "$FALLBACK_RECIPIENT" != "$RECIPIENT" ] && gc mail send "$FALLBACK_RECIPIENT" -s "$SUBJECT" -m "$BODY" --notify >/dev/null 2>&1; }; then
+        if ! gc bd update "$root_id" ${RIG_ARG1:+"$RIG_ARG1" "$RIG_ARG2"} --set-metadata "$MARKER_KEY=$NOW_ISO" >/dev/null 2>&1; then
+            echo "dead-run-detect: escalated $root_id but failed to write $MARKER_KEY; it may re-escalate next sweep" >&2
+        fi
+        ESCALATED=$((ESCALATED + 1))
+    else
+        echo "dead-run-detect: FAILED to escalate dead workflow run $root_id to '$RECIPIENT' (will retry next sweep)" >&2
+        FAILED=$((FAILED + 1))
+    fi
+done <<<"$ROOTS"
+
+if [ "$ESCALATED" -gt 0 ] || [ "$DEDUPED" -gt 0 ] || [ "$CLEARED" -gt 0 ]; then
+    echo "dead-run-detect: escalated=$ESCALATED already-escalated=$DEDUPED cleared=$CLEARED"
+fi
+
+# Loud-fail: delivered escalations are already marked, so a non-zero exit now
+# surfaces the per-root failure lines above to the controller log without
+# losing them. exit 0 would swallow the failures (#4543).
+if [ "$FAILED" -gt 0 ]; then
+    echo "dead-run-detect: $FAILED dead workflow run(s) failed to escalate (see above; will retry next sweep)" >&2
+    exit 1
+fi

--- a/internal/bootstrap/packs/core/orders/dead-run-detect.toml
+++ b/internal/bootstrap/packs/core/orders/dead-run-detect.toml
@@ -1,0 +1,35 @@
+# dead-run-detect escalates an in-flight formulas-v2 workflow run whose
+# driving session is gone. When the run-operator session that claimed a
+# workflow root dies between steps — after a decomposition step closed and
+# before the drain was routed — the root stays in_progress, its step beads
+# stay open and unclaimed, and the run reports as active indefinitely with
+# zero signal to anyone. No existing sweep catches that shape: reaper.sh's
+# stale-root close needs an empty assignee and no open descendants (open
+# step beads make the root permanently ineligible, and it closes silently
+# anyway), orphan-sweep.sh only resets beads whose assignee is unknown (a
+# configured agent name counts as known with no session running), the
+# dashboard's run staleness is display-only, and the pool-slot backstops
+# never look at workflow roots.
+#
+# It is a cooldown sweep (mechanical: list sessions, list beads, compare
+# timestamps, send mail — no LLM judgment), mirroring spawn-storm-detect.
+# Each run collects the live session identities from `gc session list`
+# across HQ and every rig, selects in_progress workflow roots
+# (gc.kind=workflow or gc.formula_contract=graph.v2), resolves the session
+# each root records as its driver (gc.session_name / gc.session_id /
+# assignee / gc.routed_to), and when that session is absent AND the root
+# has an open, unclaimed step AND the run has been silent past
+# GC_DEAD_RUN_THRESHOLD (default 2h), mails the mayor ONCE with the
+# recovery recipe. Dedup rides a gc.dead_run_escalated_at metadata marker
+# on the root, cleared when the condition clears so a recurrence re-alerts.
+# It never closes, resets, or reassigns work beads. See
+# assets/scripts/dead-run-detect.sh.
+#
+# Undeliverable escalations surface loudly and are NOT marked, so the next
+# sweep retries them (loud-fail, gastownhall/gascity#4543).
+[order]
+description = "Escalate in_progress workflow roots whose driving session is gone"
+trigger = "cooldown"
+interval = "30m"
+timeout = "120s"
+exec = "$PACK_DIR/assets/scripts/dead-run-detect.sh"

--- a/internal/bootstrap/packs/core/pack_assets_test.go
+++ b/internal/bootstrap/packs/core/pack_assets_test.go
@@ -124,10 +124,12 @@ func TestFindBareBDCommands(t *testing.T) {
 func TestCoreMaintenanceExecAssets(t *testing.T) {
 	required := []string{
 		"assets/scripts/_bd_trace.sh",
+		"assets/scripts/dead-run-detect.sh",
 		"assets/scripts/dolt-target.sh",
 		"assets/scripts/escalate.sh",
 		"assets/scripts/jsonl-export.sh",
 		"assets/scripts/reaper.sh",
+		"orders/dead-run-detect.toml",
 		"orders/jsonl-export.toml",
 		"orders/reaper.toml",
 	}

--- a/internal/bootstrap/packs/core/pack_orders_test.go
+++ b/internal/bootstrap/packs/core/pack_orders_test.go
@@ -331,3 +331,87 @@ func TestRenudgeStaleHumanGatesScriptContract(t *testing.T) {
 		t.Error("renudge-stale-human-gates.sh must exit non-zero when a re-nudge failed, or the loud-fail message is never logged (#4543)")
 	}
 }
+
+// TestDeadRunDetectOrder pins the dead-run detector's contract: it is a
+// cooldown-triggered exec order running the dead-run-detect script, the
+// escalation counterpart to spawn-storm-detect for runs whose driving session
+// died between steps.
+func TestDeadRunDetectOrder(t *testing.T) {
+	assertCooldownExecOrder(t, "dead-run-detect.toml", "dead-run-detect.sh")
+}
+
+// TestDeadRunDetectScriptContract guards the load-bearing behaviors of the
+// dead-run detector. Its failures are best-effort and swallowed at runtime, so
+// the contract is pinned here:
+//
+//   - Liveness comes from `gc session list --json` (the source orphan-sweep
+//     uses), swept across HQ and every non-HQ rig (`.hq != true`), never from
+//     config: a configured agent name is exactly what orphan-sweep already
+//     accepts as "known" with no session running.
+//   - Roots are selected by sourceworkflow.IsWorkflowRoot's discriminator —
+//     gc.kind == workflow OR gc.formula_contract == graph.v2 — plus the
+//     gc.root_bead_id self/empty test, so graph.v2-only roots are not missed.
+//   - The driver is read from gc.session_name (back-filled onto the root by
+//     stampRunRootFromStep) with the runproj session-link fallbacks and
+//     gc.routed_to; steps are matched by gc.root_bead_id.
+//   - The silence threshold is configurable (GC_DEAD_RUN_THRESHOLD).
+//   - Dedup is a metadata marker on the root (gc.dead_run_escalated_at), set
+//     with --set-metadata only after a delivered send and cleared with
+//     --unset-metadata when the condition clears, so a recurrence re-alerts.
+//   - The mail rides `gc mail send --notify` and carries the recovery recipe
+//     (`gc sling ... --force`, build-from-convoy, batch `gc bd close`).
+//   - Loud-fail: the send is conditional, an undeliverable one surfaces to
+//     stderr, and the script exits non-zero when any send failed (#4543).
+//   - The marker is the ONLY mutation: no close, delete, reset, or reopen.
+func TestDeadRunDetectScriptContract(t *testing.T) {
+	data, err := fs.ReadFile(PackFS, "assets/scripts/dead-run-detect.sh")
+	if err != nil {
+		t.Fatalf("reading dead-run-detect.sh: %v", err)
+	}
+	body := string(data)
+
+	for _, want := range []string{
+		"gc session list --json",              // liveness source (HQ + rigs)
+		".hq != true",                         // exclude HQ pseudo-rig from rig enumeration
+		`.bead.status == "in_progress"`,       // roots are in_progress
+		`"gc.kind"`,                           // root discriminator (legacy)
+		`"gc.formula_contract"`,               // root discriminator (graph.v2)
+		`"graph.v2"`,                          // ...
+		`"gc.root_bead_id"`,                   // root self-test + step ownership
+		`"gc.session_name"`,                   // driving session field
+		`"gc.routed_to"`,                      // last-resort driver identity
+		"GC_DEAD_RUN_THRESHOLD",               // configurable silence threshold
+		"gc.dead_run_escalated_at",            // dedup marker
+		"--set-metadata",                      // marker write
+		"--unset-metadata",                    // marker clear on recurrence
+		"if gc mail send",                     // conditional send (loud-fail)
+		"--notify",                            // mail + nudge primitive
+		"GC_ESCALATION_RECIPIENT",             // fallback address
+		"gc sling",                            // recovery recipe: re-entry
+		"--force",                             // ...replaces the dead workflow
+		"build-from-convoy",                   // ...default re-entry formula
+		"requirements_path",                   // ...required vars
+		"gc bd close $root_id $UNCLAIMED_IDS", // ...one batch close
+		"will retry next sweep",               // loud-fail message
+		`"$FAILED" -gt 0`,                     // loud-fail exit
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dead-run-detect.sh missing load-bearing element %q", want)
+		}
+	}
+
+	// The marker must be the only mutation. Any of these would turn a detector
+	// into a destructive sweep.
+	for _, forbidden := range []string{
+		"release-if-current",
+		"gc bd delete",
+		"gc bd reopen",
+		"--status=closed",
+		"--status closed",
+		`gc bd close "`,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("dead-run-detect.sh must never mutate work beads beyond the marker; found %q", forbidden)
+		}
+	}
+}

--- a/test/acceptance/worker_inference/worker_inference_test.go
+++ b/test/acceptance/worker_inference/worker_inference_test.go
@@ -59,6 +59,7 @@ const (
 var inferenceDisabledOrders = []string{
 	"beads-health",
 	"cross-rig-deps",
+	"dead-run-detect",
 	"dolt-health",
 	"dolt-remotes-patrol",
 	"gate-sweep",


### PR DESCRIPTION
## Summary

In a production 3-rig city, the run-operator session driving a `build-basic` (graph.v2) workflow died between the decomposition step closing and the drain being routed. The workflow root stayed `in_progress`, its step beads stayed `open` and unclaimed, the convoy items stayed unrouted, and the run kept reporting as active — for two days, with zero signal to anyone. Recovery was manual once a human noticed.

This PR adds a `dead-run-detect` core-pack exec order (cooldown, 30m) that detects exactly that shape and mails the mayor **once per root** with the recovery recipe that worked. It never closes, resets, or reassigns work beads; its only write is a dedup marker on the root.

**Rebased onto `main` at `e74cd9263`** (clean rebase, no conflicts). All references below were re-verified at that commit.

## Why nothing existing catches it (verified at main `e74cd9263`)

- `internal/bootstrap/packs/core/assets/scripts/reaper.sh` — the stale-root close (`workflow_root_candidates_cte`, :542-632; `workflow_root_closeable_select`, :649-660) requires `COALESCE(assignee, '') = ''` (:554), >24h since the root was created/updated, and no descendant whose status is in `WORKFLOW_ROOT_LIVE_STATUSES` (:66) — which includes `'open'` (`roots_with_live_descendants`, :612-618). Open step beads therefore make a dead root permanently ineligible, and that path closes silently anyway.
- `orphan-sweep.sh` — resets `in_progress` beads by assignee only (:367-396, via `gc bd release-if-current` in `reset_orphan_if_current`, :288). `is_known_agent` (:311) accepts a configured agent template name from config alone (`agent_exists`, :175, over the `gc config show` scrape at :123), so a root assigned to a configured run-operator is "known" even with no session running. #5841 made this sweep *more* conservative about live pool seats; it still has no notion of a workflow root whose driver died.
- `internal/runproj/enrich.go` — `staleLatchAfterMs` (:25, 24h) and `staleRunSilenceMs` (:36, 72h) only demote/flag lanes in the dashboard projection (:109-119); nothing acts on the flag.
- `cmd/gc/execution_backstop.go` (`poolExecutionBackstop` / `nudgeStalledPoolExecution`, :85) and `cmd/gc/idle_nudge.go` (`nudgeStalledPoolClaims`, :80) are scoped to a pool slot's own trigger bead, not to workflow roots.
- `gc doctor`'s session-liveness checks (#5940) report dead/zombie sessions, but nothing connects a dead session to the workflow root it was driving, and doctor is not on a schedule.

## What the order does

Files: `internal/bootstrap/packs/core/orders/dead-run-detect.toml` (trigger `cooldown`, interval `30m`, timeout `120s`) and `assets/scripts/dead-run-detect.sh`, modeled on `spawn-storm-detect` (city discovery, `gc bd list`, `gc mail send`, `_bd_trace.sh`, loud-fail per #4543).

Each sweep:

1. **Liveness** — `gc session list --json` for HQ and every non-HQ rig (`gc rig list --json`, `.hq != true`): the same source and row fields `orphan-sweep.sh` uses (:129-172; row shape `sessionListJSONRow`, `cmd/gc/cmd_session.go:1086`). Every non-closed row contributes its id / session_name / alias / agent_name / name / template plus the rig-stripped short form of each. If any scope's session list fails, the sweep is skipped — liveness is unverifiable, and nothing is mutated on that path.
2. **Beads** — `gc bd list --status=in_progress|open --json --limit=0` per scope; a scope is used only when both lists succeed and parse, so a root is never judged against a partial view of its steps.
3. **Roots** — `status == in_progress` AND (`gc.kind == workflow` OR `gc.formula_contract == graph.v2`), i.e. `sourceworkflow.IsWorkflowRoot` (`internal/sourceworkflow/sourceworkflow.go:74`), AND `gc.root_bead_id` empty or self (the reaper's own root test).
4. **Driver** — the fields the run projection reads (`internal/runproj/detail_sessionlink.go:154-190`): `session_name` / `gc.session_name` / `gc.sessionName` / `session_id` / `gc.session_id` / `gc.sessionId`, then the `assignee`, then `gc.routed_to`. The reconciler back-fills `gc.session_name` onto the root from its worked steps (`cmd/gc/build_desired_state.go:5001` `stampRunSessionIdentity` -> `:5071` `stampRunRootFromStep`). Matching is exact, or via the rig-stripped / trailing-`-N` slot-stripped forms `orphan-sweep.sh` accepts, evaluated against live sessions rather than config. This is deliberately conservative: a live session of the same template counts as alive. A root with no recorded driver at all is skipped as unverifiable.
5. **Dead** iff: no driver identity is live AND at least one descendant (`gc.root_bead_id == root`) has `status == open` with an empty assignee AND no `in_progress` descendant is held by a live session AND the run has been silent for >= `GC_DEAD_RUN_THRESHOLD` (default `2h`), where silence = now - max(root `created_at`, descendants' `updated_at`/`created_at`). The root's own `updated_at` is excluded on purpose so the marker write below cannot feed back into the clock.
6. **Escalation** — one `gc mail send --notify` to `GC_DEAD_RUN_RECIPIENT` (default `mayor`), falling back to `GC_ESCALATION_RECIPIENT` (default `human`) when the primary is undeliverable (a city with no mayor). Loud-fail (#4543): an undeliverable send surfaces on stderr, is not marked, and the script exits non-zero so the controller logs it; the next sweep retries.

**Dedup** — after a delivered send: `gc bd update <root> [--rig <rig>] --set-metadata gc.dead_run_escalated_at=<ISO>`. A marked root is never re-mailed. When the condition clears (driver alive again, steps claimed, run progressed) the marker is removed with `--unset-metadata`, so a recurrence re-alerts. That marker is the only mutation the order makes. Side effect worth knowing: the marker write bumps the root's `updated_at`; the reaper's stale-root path reads that column, but the two never overlap (this alert requires open descendants, which the reaper excludes).

**Knobs** (controller env or `[order.env]`): `GC_DEAD_RUN_THRESHOLD` (`2h`), `GC_DEAD_RUN_RECIPIENT` (`mayor`), `GC_ESCALATION_RECIPIENT` (`human`), `GC_DEAD_RUN_REENTRY_FORMULA` (`build-from-convoy`).

## The mail

Subject `DEAD_RUN: workflow root <id> has no live driving session`. Body: root and title, the driver identities checked, silence age and threshold, the unclaimed step ids, scope / formula / input convoy / routed_to, a note on why no sweep will fix it, and the recovery recipe validated in production:

1. `gc sling <gc.routed_to or gc.run-operator> <gc.input_convoy_id> --on build-from-convoy --force --var requirements_path=<...> --var plan_path=<...> --var decomposition_path=<...>` — `build-from-convoy` adopts the existing implementation convoy; `--force` replaces the dead workflow's source attachment; the three path vars are the ones the formula required in production.
2. `gc bd close <root> <step...> --reason "dead workflow run superseded by re-entry"` — all ids in **one** invocation; per-bead close loops time out.

Also updated: the core pack `README.md` (orders table + a `dead-run-detect` section documenting predicate, dedup, and knobs).

## Tests

- `internal/bootstrap/packs/core/pack_orders_test.go`: `TestDeadRunDetectOrder` (cooldown-exec contract, script embedded) and `TestDeadRunDetectScriptContract` (load-bearing elements: liveness source, root discriminator, driver field, threshold knob, marker set/unset, conditional `gc mail send --notify`, recipe, loud-fail exit; plus forbidden mutations). `pack_assets_test.go` lists the new order and script as required assets; the existing `TestCoreShippedAssetsRouteBDCommandsThroughGC` covers the script's `bd` routing.
- `cmd/gc/embed_builtin_packs_test.go`: `TestCorePackShipsDeadRunDetectOrder` (bundled pack carries the order and script). `controller_test.go` `TestTryReloadConfig_IncludesBuiltinPackOrders` now expects `dead-run-detect` to be scanned. The housekeeping skip lists in `city_runtime_test.go`, `cmd_supervisor_city_test.go`, and `test/acceptance/worker_inference/worker_inference_test.go` include it, matching the sibling orders.
- `examples/gastown/maintenance_scripts_test.go`: 8 shell-level scenario tests run the real script against a stub `gc` — escalation with the full recipe and marker write (a closed row for the driver must not count as live); live driver; live template short form; dedup of a marked root and marker clear on recovery; silence threshold with `GC_DEAD_RUN_THRESHOLD` override; step held by a live session; fallback recipient and loud-fail with no marker; session-list failure skips the sweep before any bead read/write.

Validation on the rebased branch (`e74cd9263` + this commit, go 1.26.6):

- `go build ./...` — ok
- `go vet ./cmd/gc/ ./internal/bootstrap/packs/core/... ./examples/gastown/ ./test/acceptance/worker_inference/` — ok
- `go test ./internal/bootstrap/packs/core/...` — PASS
- `go test -run 'TestCorePackShipsDeadRunDetectOrder|TestNoMaintenanceBuiltinPack|TestTryReloadConfig_IncludesBuiltinPackOrders' ./cmd/gc/` — PASS, all three ran
- `go test ./examples/gastown/` — PASS (153s), including all 9 `TestDeadRunDetect*` cases
- `go test ./internal/testpolicy/resourcecensus/` (the checked test-resource ledger) — PASS
- `go test ./...` — see the note below on this machine's pre-existing failures, which are unchanged from plain `origin/main`.

No shellcheck target exists in the Makefile or CI; `bash -n` passes on the script. `make check-docs` was not run because nothing under `docs/` changed (the core README lives under `internal/`).

## Follow-up (out of scope here)

`internal/dispatch/runtime.go:218` `closeOrphanedControl` gates control beads on the root being missing, canceled, or settled, but mints retry controls with no check that the root's driving session is alive — so a dead driver's control lane keeps retrying under a run nobody is driving. That deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161XB4BVDny4DK87CWXcCha
