### PR TITLE
fix(beads): stop the cache re-absorbing its own reconcile emissions (ga-yoix1)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -48,6 +48,11 @@ import (
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
+// cacheReconcileActor is the event actor the controller stamps on bead events
+// emitted by a CachingStore's reconciliation pass, distinguishing the cache's
+// own snapshots from foreign writes delivered by a bd hook.
+const cacheReconcileActor = "cache-reconcile"
+
 // controllerState implements api.State, api.StateMutator, and
 // api.ConfigWriteSerializer.
 // Protected by an RWMutex for hot-reload: readers take RLock,
@@ -287,7 +292,7 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 		if recorder != nil {
 			recorder.Record(events.Event{
 				Type:             eventType,
-				Actor:            "cache-reconcile",
+				Actor:            cacheReconcileActor,
 				Subject:          beadID,
 				RunID:            runID,
 				SessionID:        sessionID,
@@ -753,12 +758,23 @@ func (cs *controllerState) applyBeadEventToStores(evt events.Event) {
 	}
 	cs.mu.RUnlock()
 
+	// A cache-reconcile event carries a CachingStore's own post-absorb snapshot,
+	// dependencies included, rather than a bd hook patch. Saying so keeps the
+	// cache from reading its own emission as a coverage-unknown payload and
+	// discarding the dependency and is_blocked state it just installed, which
+	// fences the row out of the next reconcile pass and re-emits forever
+	// (ga-yoix1).
+	snapshot := evt.Actor == cacheReconcileActor
 	for _, store := range stores {
 		if cached, ok := store.(*beads.CachingStore); ok {
-			cached.ApplyEvent(evt.Type, evt.Payload)
+			if snapshot {
+				cached.ApplyEventSnapshot(evt.Type, evt.Payload)
+			} else {
+				cached.ApplyEvent(evt.Type, evt.Payload)
+			}
 		}
 	}
-	if evt.Actor != "cache-reconcile" {
+	if !snapshot {
 		cs.Poke()
 	}
 	if evt.Type == events.BeadClosed && evt.Subject != "" && len(stores) > 0 {

--- a/cmd/gc/api_state_cache_reconcile_snapshot_test.go
+++ b/cmd/gc/api_state_cache_reconcile_snapshot_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// TestApplyBeadEventRoutesCacheReconcileEventsAsSnapshots pins the controller
+// half of the cache-reconcile flood fix (ga-yoix1).
+//
+// The reconcile emitter marshals a whole absorbed bead, but Dependencies and
+// Needs are omitempty, so a bead with no dependencies produces a payload that
+// looks exactly like a bd on_update patch. Fed back through the plain ApplyEvent
+// path, the cache treats dependency coverage as unknown and clears the
+// is_blocked verdict reconciliation just installed — the divergence that makes
+// every later pass re-emit. Routing on the actor is what tells the cache the
+// payload is its own snapshot.
+func TestApplyBeadEventRoutesCacheReconcileEventsAsSnapshots(t *testing.T) {
+	backing := beads.NewMemStore()
+	unblocked := false
+	created, err := backing.Create(beads.Bead{Title: "backlog issue", IsBlocked: &unblocked})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cached := beads.NewCachingStoreForTest(backing, nil)
+	if err := cached.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	payload, err := json.Marshal(created)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if raw := string(payload); strings.Contains(raw, `"dependencies"`) {
+		t.Fatalf("payload %s carries a dependencies key; the omitempty premise no longer holds", raw)
+	}
+
+	cs := &controllerState{
+		beadStores: map[string]beads.Store{"alpha": cached},
+		pokeCh:     make(chan struct{}, 1),
+	}
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadUpdated,
+		Actor:   cacheReconcileActor,
+		Subject: created.ID,
+		Payload: payload,
+	})
+
+	got, err := cached.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.IsBlocked == nil {
+		t.Fatalf("re-absorbing a cache-reconcile snapshot nilled %s's is_blocked verdict", created.ID)
+	}
+}

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -18,6 +18,33 @@ import (
 // with the full bead JSON payload. This keeps the cache fresh without
 // waiting for reconciliation.
 func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
+	c.applyEvent(eventType, payload, false)
+}
+
+// ApplyEventSnapshot applies an event whose payload is a complete bead snapshot
+// with authoritative dependency coverage, rather than a bd hook patch.
+//
+// A CachingStore emits exactly such a snapshot after reconciliation absorbs a
+// row: notifyChange marshals the whole absorbed bead, dependencies included.
+// Bead.Dependencies and Bead.Needs are omitempty, so a bead with no
+// dependencies marshals with neither key, leaving that snapshot indistinguishable
+// on the wire from a bd on_update payload — which legitimately omits
+// dependencies after a removal and must be treated as coverage-unknown.
+//
+// Guessing wrong in that direction is not a lost optimization, it is a loop: the
+// coverage-unknown path drops the dep set, clears the is_blocked verdict
+// reconciliation just installed, clears depsComplete store-wide, and stamps a
+// mutation sequence that fences the row out of the next pass' absorb. The
+// cleared verdict is therefore never repaired, every later pass sees cached nil
+// against fresh &false, calls that a change, and emits again — thousands of
+// events per minute against a completely idle backing store (ga-yoix1).
+//
+// Callers that know the payload's provenance use this entry point to say so.
+func (c *CachingStore) ApplyEventSnapshot(eventType string, payload json.RawMessage) {
+	c.applyEvent(eventType, payload, true)
+}
+
+func (c *CachingStore) applyEvent(eventType string, payload json.RawMessage, depsAuthoritative bool) {
 	if len(payload) == 0 {
 		return
 	}
@@ -226,7 +253,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 				seqMode:    seqKeep,
 				clearDirty: true,
 			})
-			c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
+			c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking || depsAuthoritative)
 		}
 		c.updateStatsLocked()
 		mutated = true
@@ -247,7 +274,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			})
 			mutated = true
 		}
-		if depsMutated := c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking); depsMutated && !mutated {
+		if depsMutated := c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking || depsAuthoritative); depsMutated && !mutated {
 			c.noteMutationLocked(b.ID)
 			mutated = true
 		}
@@ -268,7 +295,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			seqMode:    seqKeep,
 			clearDirty: true,
 		})
-		c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
+		c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking || depsAuthoritative)
 		mutated = true
 		if c.clearDependentReadyProjectionsLocked(b.ID) {
 			mutated = true

--- a/internal/beads/caching_store_reconcile_flood_internal_test.go
+++ b/internal/beads/caching_store_reconcile_flood_internal_test.go
@@ -1,0 +1,137 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// floodLoopHarness wires a cache to the controller's real event topology: every
+// reconcile emission is recorded on the bus and then fed back into ApplyEvent on
+// the emitting store (cmd/gc/api_state.go startBeadEventWatcher ->
+// applyBeadEventToStores). Delivery is deferred to after the pass because the
+// bus is asynchronous; applying inline would deadlock on the reconcile lock and
+// would not match production ordering anyway.
+type floodLoopHarness struct {
+	cache   *CachingStore
+	pending []cacheFloodEvent
+	emitted []string
+}
+
+type cacheFloodEvent struct {
+	eventType string
+	payload   json.RawMessage
+}
+
+func newFloodLoopHarness(t *testing.T, backing Store) *floodLoopHarness {
+	t.Helper()
+	h := &floodLoopHarness{}
+	h.cache = NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		h.emitted = append(h.emitted, eventType+":"+beadID)
+		h.pending = append(h.pending, cacheFloodEvent{eventType: eventType, payload: payload})
+	})
+	if err := h.cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	return h
+}
+
+// pass runs one reconcile cycle and then delivers everything it emitted back to
+// the cache, the way the controller's watcher does.
+func (h *floodLoopHarness) pass() {
+	h.cache.runReconciliation()
+	pending := h.pending
+	h.pending = nil
+	for _, evt := range pending {
+		// The controller routes cache-reconcile-actored events through the
+		// snapshot entry point; every emission here is one of those.
+		h.cache.ApplyEventSnapshot(evt.eventType, evt.payload)
+	}
+}
+
+// TestReconcileEmissionFedBackDoesNotSustainFloodLoop pins the fix for the
+// cache-reconcile event flood (a rig emitting bead.updated for every open bead,
+// every pass, forever — 2k+ events/minute against an unchanging backing store).
+//
+// The loop is closed by the cache re-absorbing its own reconcile emission:
+//
+//  1. Reconcile absorbs a row with an explicit dependency snapshot and an
+//     is_blocked verdict, then emits bead.updated carrying that full snapshot.
+//  2. Bead.Dependencies and Bead.Needs are `omitempty`, so a bead with no
+//     dependencies marshals with neither key. The payload is now
+//     indistinguishable from a bd on_update hook patch, which legitimately omits
+//     dependencies after a removal.
+//  3. ApplyEvent therefore treats dependency coverage as unknown: it drops the
+//     cached dep set, clears the is_blocked verdict, clears depsComplete
+//     store-wide, and reports a mutation.
+//  4. The mutation stamps a sequence number, which fences the row out of the
+//     next pass' absorb, so the cleared verdict is never repaired.
+//  5. The pass after that absorbs again, sees cached is_blocked nil against a
+//     fresh &false, calls that a change, and emits — returning to step 1.
+//
+// A dependency-free bead that nothing is writing to must go quiet.
+func TestReconcileEmissionFedBackDoesNotSustainFloodLoop(t *testing.T) {
+	mem := NewMemStore()
+	unblocked := false
+	subject, err := mem.Create(Bead{Title: "backlog issue", IsBlocked: &unblocked})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	h := newFloodLoopHarness(t, mem)
+	h.pass()
+	h.emitted = nil
+
+	// Seed exactly one real divergence, the way any external writer would. Every
+	// emission after the pass that reports it is the cache talking to itself.
+	edited := "backlog issue (edited)"
+	if err := mem.Update(subject.ID, UpdateOpts{Title: &edited}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	h.pass()
+	seeded := len(h.emitted)
+	if seeded == 0 {
+		t.Fatalf("reconcile did not report the seeded title change; harness is not exercising the emit path")
+	}
+	h.emitted = nil
+
+	for i := 0; i < 5; i++ {
+		h.pass()
+	}
+	if len(h.emitted) != 0 {
+		t.Fatalf("reconcile kept emitting for an unchanging bead after the seeded change settled: %v", h.emitted)
+	}
+}
+
+// TestReconcileEmissionFedBackPreservesReadyVerdict isolates the state damage
+// behind the loop above. Re-absorbing the cache's own snapshot must not nil out
+// the is_blocked verdict reconcile just installed, and must not clear the
+// store-wide depsComplete latch, which silently downgrades the reconcile
+// dependency comparison for every other bead in the rig.
+func TestReconcileEmissionFedBackPreservesReadyVerdict(t *testing.T) {
+	mem := NewMemStore()
+	unblocked := false
+	subject, err := mem.Create(Bead{Title: "backlog issue", IsBlocked: &unblocked})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	h := newFloodLoopHarness(t, mem)
+	h.pass()
+
+	h.cache.mu.RLock()
+	cached, ok := h.cache.beads[subject.ID]
+	depsComplete := h.cache.depsComplete
+	h.cache.mu.RUnlock()
+
+	if !ok {
+		t.Fatalf("bead %s dropped from cache", subject.ID)
+	}
+	if cached.IsBlocked == nil {
+		t.Fatalf("re-absorbing the cache's own reconcile snapshot nilled %s's is_blocked verdict", subject.ID)
+	}
+	if !depsComplete {
+		t.Fatalf("re-absorbing the cache's own reconcile snapshot cleared the store-wide depsComplete latch")
+	}
+}


### PR DESCRIPTION
## The loop

The controller feeds every bead event on the bus back into `ApplyEvent` on the emitting `CachingStore` (`startBeadEventWatcher` -> `applyBeadEventToStores`). A reconcile emission is that store's own post-absorb snapshot -- but `Bead.Dependencies` and `Bead.Needs` are `omitempty`, so a bead with **no dependencies** marshals with neither key. On the wire that snapshot is indistinguishable from a bd `on_update` patch, which legitimately omits dependencies after a removal and must be treated as coverage-unknown.

So `ApplyEvent` guesses coverage-unknown, and that guess is not a lost optimization -- it is a latch:

1. `updateEventDepsLocked` drops the cached dep set, clears the `is_blocked` verdict reconciliation just installed, and clears `depsComplete` **store-wide**.
2. It reports a mutation, which stamps a sequence number.
3. That sequence fences the row out of the next pass' absorb (`mergeSkipFenced`), so the cleared verdict is never repaired.
4. Every later pass compares cached `is_blocked` nil against fresh `&false`, calls that a change, and emits again -> back to 1.

## Production signature

On maintainer-city this was **98% of the event bus**: 11937 of ~12600 events in a 20 MB tail, 2353 distinct beads each emitted repeatedly with a **byte-identical** payload, sustained above 2000 events/minute against a completely idle backing store (~3.4M events/day, matching the ~70 MB-gz-per-75-min log rotation).

Per-rig churn was bimodal -- 100% or 0%, never in between -- which is the tell: `depsComplete` is a store-wide latch, so a single bead's wipe degrades the dependency comparison for the entire rig, and any rig with no initial diff stays clean forever.

## The fix

Add `CachingStore.ApplyEventSnapshot` for payloads that carry authoritative dependency coverage, and route `cache-reconcile`-actored events through it. The controller already excludes this actor from `cs.Poke()` three lines below; this extends the same distinction to the absorb.

This is the sibling leg of `ga-fnmb5`, which fixed `clearDependentReadyProjectionsLocked` (the *dependent's* projection) but not the `clearReadyProjectionLocked` inside the dependency wipe (the bead's *own*).

Not a blanket actor skip: reconcile events still reach the cache and still update fields, so `TestControllerStateAppliesCacheReconcileBeadEventsToStores` is unchanged, and `admitReadyRoutedWorkEvent` / `admitSessionStartEvent` / the `BeadClosed` arm still run.

## Tests

- `TestReconcileEmissionFedBackDoesNotSustainFloodLoop` reproduces the ring end-to-end against the controller's real topology (emit during the pass, deliver after, as the async bus does). Before the fix: five passes, five emissions, one unchanging dependency-free bead.
- `TestReconcileEmissionFedBackPreservesReadyVerdict` isolates the state damage (`is_blocked` nilled, `depsComplete` cleared).
- `TestApplyBeadEventRoutesCacheReconcileEventsAsSnapshots` pins the controller-side routing, and asserts the `omitempty` premise still holds so the test cannot go vacuous if the wire shape changes.

Both halves are **mutation-checked**: reverting either one reproduces the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)