### PR TITLE
fix(reaper): expired-nudge cleanup now closes rig-scoped shadows too (#5285)

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/reaper.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/reaper.sh
@@ -400,6 +400,35 @@ EOF
     printf '%s\n' "$refs"
 }
 
+# rig_name_for_db looks up the rig name bound to a non-city database, using
+# the same RIG_STORE_REFS_BY_DB map discover_rig_store_refs populates from
+# city.toml/site.toml [[rigs]] bindings. Prints the rig name and returns 0 on
+# a match; returns 1 with no output when $db has no rig binding (e.g. it is
+# neither the city store nor a discovered rig store).
+rig_name_for_db() {
+    local db="$1"
+    local entry
+    local entry_db
+    local store_ref
+
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        entry_db="${entry%%|*}"
+        store_ref="${entry#*|}"
+        [ "$entry_db" = "$db" ] || continue
+        case "$store_ref" in
+            rig:*)
+                printf '%s\n' "${store_ref#rig:}"
+                return 0
+                ;;
+        esac
+    done <<EOF
+$RIG_STORE_REFS_BY_DB
+EOF
+
+    return 1
+}
+
 workflow_root_store_ref_local_condition() {
     local db="$1"
     local alias="$2"
@@ -728,6 +757,36 @@ close_city_issue() {
     )
 }
 
+# close_rig_issue mirrors close_city_issue but closes an issue in a
+# rig-scoped bead store instead of the city store, via the --city+--rig flag
+# combination (see cmd/gc/cmd_bd.go resolveBdScopeTarget/extractBdScopeFlags).
+# Needed because sling-delivered nudge shadows are enqueued into the sling
+# target's rig store (cmd/gc/cmd_sling.go deliverSlingNudge), not the city
+# store, so the reaper's TTL sweep (Step 4) must be able to close them there
+# too (gastownhall/gascity#5285).
+close_rig_issue() {
+    local issue_id="$1"
+    local reason="$2"
+    local rig_name="$3"
+    # See close_city_issue above for why the reaper closes bare unless the
+    # caller explicitly requests --force.
+    local force="${4:-}"
+
+    if [ ! -d "$CITY_BEADS_DIR" ]; then
+        printf 'city bead store %s is unavailable' "$CITY_BEADS_DIR"
+        return 1
+    fi
+
+    (
+        cd "$CITY_ABS"
+        if [ -n "$force" ]; then
+            gc bd --city "$CITY_ABS" --rig "$rig_name" close "$issue_id" --force --reason "$reason"
+        else
+            gc bd --city "$CITY_ABS" --rig "$rig_name" close "$issue_id" --reason "$reason"
+        fi
+    )
+}
+
 run_sql_change() {
     local db="$1"
     local label="$2"
@@ -1023,10 +1082,7 @@ while IFS= read -r DB; do
             fi
             SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
             TOTAL_EXPIRED_ISSUES_SKIPPED=$((TOTAL_EXPIRED_ISSUES_SKIPPED + SKIPPED_COUNT))
-        elif [ "$DB" != "$CITY_DB" ]; then
-            SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
-            TOTAL_EXPIRED_ISSUES_SKIPPED=$((TOTAL_EXPIRED_ISSUES_SKIPPED + SKIPPED_COUNT))
-        else
+        elif [ "$DB" = "$CITY_DB" ]; then
             while IFS= read -r issue_id; do
                 [ -z "$issue_id" ] && continue
                 if CLOSE_OUTPUT=$(close_city_issue "$issue_id" "ttl:expired by reaper" 2>&1); then
@@ -1037,6 +1093,29 @@ while IFS= read -r DB; do
                     record_anomaly "$DB" "closing expired nudge bead $issue_id failed for $DB: $(sanitize_output "$CLOSE_OUTPUT")"
                 fi
             done <<< "$EXPIRED_IDS"
+        elif EXPIRED_RIG_NAME=$(rig_name_for_db "$DB"); then
+            # $DB is a rig-scoped store bound via a [[rigs]] entry in
+            # city.toml/site.toml (see discover_rig_store_refs). Nudge
+            # shadows created by a sling land here — deliverSlingNudge
+            # enqueues into the sling target's rig store, not the city
+            # store — so close them via gc bd --rig instead of only
+            # counting them as skipped (gastownhall/gascity#5285).
+            while IFS= read -r issue_id; do
+                [ -z "$issue_id" ] && continue
+                if CLOSE_OUTPUT=$(close_rig_issue "$issue_id" "ttl:expired by reaper" "$EXPIRED_RIG_NAME" 2>&1); then
+                    DB_EXPIRED_ISSUES_CLOSED=$((DB_EXPIRED_ISSUES_CLOSED + 1))
+                    TOTAL_EXPIRED_ISSUES_CLOSED=$((TOTAL_EXPIRED_ISSUES_CLOSED + 1))
+                    DB_MUTATIONS=$((DB_MUTATIONS + 1))
+                else
+                    record_anomaly "$DB" "closing expired nudge bead $issue_id failed for $DB (rig:$EXPIRED_RIG_NAME): $(sanitize_output "$CLOSE_OUTPUT")"
+                fi
+            done <<< "$EXPIRED_IDS"
+        else
+            # $DB is neither the city store nor a discovered rig store (e.g.
+            # an unbound or undiscoverable scope) — no scoped close path
+            # exists, so fall back to the prior skip+anomaly behavior.
+            SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+            TOTAL_EXPIRED_ISSUES_SKIPPED=$((TOTAL_EXPIRED_ISSUES_SKIPPED + SKIPPED_COUNT))
         fi
     fi
 

--- a/test/reaper_expired_rig_nudge_test.sh
+++ b/test/reaper_expired_rig_nudge_test.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Test: reaper Step 4 expired-nudge close path — rig-store routing
+# (gastownhall/gascity#5285: "Expired rig-scoped nudge shadows evade the
+# native reaper").
+#
+# Before the fix, Step 4 only ever closed expired nudge beads in the city
+# store; a non-city $DB always fell into the skip+anomaly-count path even
+# when it was a legitimate rig store the reaper already knew about via
+# discover_rig_store_refs. The fix adds an elif that resolves $DB to a rig
+# name (rig_name_for_db) and closes through gc bd --city --rig instead.
+#
+# Acceptance criteria:
+#   1. DB == CITY_DB                        → close_city_issue called, no rig/skip
+#   2. DB != CITY_DB, rig binding found      → close_rig_issue called with that
+#                                              rig name; no skip, no city close
+#   3. DB != CITY_DB, no rig binding found   → falls back to skip+anomaly-count
+#                                              (unchanged prior behavior), no
+#                                              close call of either kind
+#   4. CITY_DB unset entirely                → skip+anomaly-count (unchanged),
+#                                              no close call of either kind
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAPER="$SCRIPT_DIR/../internal/bootstrap/packs/core/assets/scripts/reaper.sh"
+FAILED=0
+
+pass() { printf '\033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '\033[31mFAIL\033[0m %s\n' "$1"; FAILED=1; }
+
+if [ ! -f "$REAPER" ]; then
+    printf 'ERROR: reaper.sh not found at %s\n' "$REAPER" >&2
+    exit 1
+fi
+
+# Extract the Step 4 block verbatim from reaper.sh (it lives inside the
+# indented per-DB `while` loop, not at column 0, so — unlike the Step 6
+# tests — it's captured by comment markers rather than if/fi depth-counting).
+STEP4=$(awk '
+  /# Step 5:/{f=0}
+  f{print}
+  /# Step 4:/{f=1}
+' "$REAPER")
+
+if [ -z "$STEP4" ]; then
+    printf 'ERROR: could not extract Step 4 block from %s\n' "$REAPER" >&2
+    exit 1
+fi
+
+# run_step4_scenario <db> <city_db> <rig_lookup_result|"none">
+#
+#   rig_lookup_result  the rig name rig_name_for_db should report finding for
+#                       $db, or "none" to simulate no binding (rc=1).
+#
+# Returns: <city_close_called>|<rig_close_called>|<rig_name_used>|<skipped_total>|<anomaly_called>
+run_step4_scenario() {
+    local db="$1"
+    local city_db="$2"
+    local rig_lookup="$3"
+    local tmpdir city_flag rig_flag rig_name_file skipped_file anomaly_flag step4_file run_script
+
+    tmpdir=$(mktemp -d)
+    city_flag="$tmpdir/city_close_called"
+    rig_flag="$tmpdir/rig_close_called"
+    rig_name_file="$tmpdir/rig_name_used"
+    skipped_file="$tmpdir/skipped_total"
+    anomaly_flag="$tmpdir/anomaly_called"
+    step4_file="$tmpdir/step4.sh"
+    run_script="$tmpdir/run.sh"
+
+    printf '%s\n' "$STEP4" > "$step4_file"
+
+    local rig_lookup_body
+    if [ "$rig_lookup" = "none" ]; then
+        rig_lookup_body='return 1'
+    else
+        rig_lookup_body="printf '%s\n' '$rig_lookup'; return 0"
+    fi
+
+    cat > "$run_script" << RUNEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+get_sql_rows() {
+    local db="\$1" label="\$2"
+    case "\$label" in
+        "expired nudge bead with parse anomaly") SQL_ROWS_RESULT='' ;;
+        "expired nudge bead") SQL_ROWS_RESULT='nudge-123' ;;
+        *) SQL_ROWS_RESULT='' ;;
+    esac
+}
+record_anomaly() { touch '$anomaly_flag'; }
+sanitize_output() { printf '%s' "\$1"; }
+close_city_issue() { touch '$city_flag'; return 0; }
+close_rig_issue() {
+    touch '$rig_flag'
+    printf '%s\n' "\$3" > '$rig_name_file'
+    return 0
+}
+rig_name_for_db() { $rig_lookup_body; }
+export -f get_sql_rows record_anomaly sanitize_output close_city_issue close_rig_issue rig_name_for_db
+
+DB='$db'
+CITY_DB='$city_db'
+CITY='/tmp/unused-city'
+CITY_DB_ANOMALY_RECORDED=0
+DRY_RUN=''
+TOTAL_WOULD_EXPIRE=0
+TOTAL_EXPIRED_ISSUES_SKIPPED=0
+TOTAL_EXPIRED_ISSUES_CLOSED=0
+DB_EXPIRED_ISSUES_CLOSED=0
+DB_MUTATIONS=0
+
+. '$step4_file'
+
+printf '%s\n' "\$TOTAL_EXPIRED_ISSUES_SKIPPED" > '$skipped_file'
+RUNEOF
+
+    local rc=0
+    bash "$run_script" 2>/dev/null || rc=$?
+
+    local city_result rig_result rig_name_val skipped_val anomaly_result
+    city_result=$([ -f "$city_flag" ] && echo yes || echo no)
+    rig_result=$([ -f "$rig_flag" ] && echo yes || echo no)
+    rig_name_val=$(cat "$rig_name_file" 2>/dev/null || echo "")
+    skipped_val=$(cat "$skipped_file" 2>/dev/null || echo "?")
+    anomaly_result=$([ -f "$anomaly_flag" ] && echo yes || echo no)
+    rm -rf "$tmpdir"
+    printf '%s|%s|%s|%s|%s|%s\n' "$city_result" "$rig_result" "$rig_name_val" "$skipped_val" "$anomaly_result" "$rc"
+}
+
+# ── T1: DB == CITY_DB → close_city_issue called ───────────────────────────
+result=$(run_step4_scenario "city_db" "city_db" "none")
+city_called=$(printf '%s' "$result" | cut -d'|' -f1)
+rig_called=$(printf '%s' "$result" | cut -d'|' -f2)
+skipped=$(printf '%s' "$result" | cut -d'|' -f4)
+if [ "$city_called" = "yes" ] && [ "$rig_called" = "no" ] && [ "$skipped" = "0" ]; then
+    pass "T1: DB == CITY_DB → close_city_issue called, no rig close, no skip"
+else
+    fail "T1: DB == CITY_DB → expected city=yes rig=no skipped=0; got $result"
+fi
+
+# ── T2: DB != CITY_DB, rig binding found → close_rig_issue called ────────
+result=$(run_step4_scenario "rig_alpha_db" "city_db" "alpha")
+city_called=$(printf '%s' "$result" | cut -d'|' -f1)
+rig_called=$(printf '%s' "$result" | cut -d'|' -f2)
+rig_name=$(printf '%s' "$result" | cut -d'|' -f3)
+skipped=$(printf '%s' "$result" | cut -d'|' -f4)
+if [ "$city_called" = "no" ] && [ "$rig_called" = "yes" ] && [ "$rig_name" = "alpha" ] && [ "$skipped" = "0" ]; then
+    pass "T2: DB != CITY_DB, rig found → close_rig_issue called with rig=alpha, no skip"
+else
+    fail "T2: DB != CITY_DB, rig found → expected city=no rig=yes rig_name=alpha skipped=0; got $result"
+fi
+
+# ── T3: DB != CITY_DB, no rig binding → skip+anomaly (unchanged fallback) ─
+result=$(run_step4_scenario "unbound_db" "city_db" "none")
+city_called=$(printf '%s' "$result" | cut -d'|' -f1)
+rig_called=$(printf '%s' "$result" | cut -d'|' -f2)
+skipped=$(printf '%s' "$result" | cut -d'|' -f4)
+if [ "$city_called" = "no" ] && [ "$rig_called" = "no" ] && [ "$skipped" = "1" ]; then
+    pass "T3: DB != CITY_DB, no rig binding → falls back to skip, no close call"
+else
+    fail "T3: DB != CITY_DB, no rig binding → expected city=no rig=no skipped=1; got $result"
+fi
+
+# ── T4: CITY_DB unset entirely → skip+anomaly (unchanged) ────────────────
+result=$(run_step4_scenario "some_db" "" "alpha")
+city_called=$(printf '%s' "$result" | cut -d'|' -f1)
+rig_called=$(printf '%s' "$result" | cut -d'|' -f2)
+skipped=$(printf '%s' "$result" | cut -d'|' -f4)
+anomaly=$(printf '%s' "$result" | cut -d'|' -f5)
+if [ "$city_called" = "no" ] && [ "$rig_called" = "no" ] && [ "$skipped" = "1" ] && [ "$anomaly" = "yes" ]; then
+    pass "T4: CITY_DB unset → skip+anomaly, no close call even when a rig binding exists"
+else
+    fail "T4: CITY_DB unset → expected city=no rig=no skipped=1 anomaly=yes; got $result"
+fi
+
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/test/reaper_rig_name_for_db_test.sh
+++ b/test/reaper_rig_name_for_db_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Test: reaper rig_name_for_db() — the RIG_STORE_REFS_BY_DB lookup added for
+# gastownhall/gascity#5285 (expired rig-scoped nudge shadows evade the
+# reaper). This function is what lets Step 4 tell a rig-scoped bead store
+# apart from an unbound/undiscoverable one.
+#
+# Acceptance criteria:
+#   1. No entries at all              → not found (rc=1, no output)
+#   2. One entry, matching db         → found, prints the rig name
+#   3. One entry, non-matching db     → not found (rc=1, no output)
+#   4. Multiple entries, second matches → found, prints the right rig name
+#   5. Entry present but not "rig:"-prefixed → not found (defensive: only
+#      rig: store refs are ever appended today, but the lookup must not
+#      misinterpret a future non-rig store_ref as a rig name)
+#   6. db is a literal substring of another entry's db → not found for the
+#      substring (exact match only, no accidental prefix match)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAPER="$SCRIPT_DIR/../internal/bootstrap/packs/core/assets/scripts/reaper.sh"
+FAILED=0
+
+pass() { printf '\033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '\033[31mFAIL\033[0m %s\n' "$1"; FAILED=1; }
+
+if [ ! -f "$REAPER" ]; then
+    printf 'ERROR: reaper.sh not found at %s\n' "$REAPER" >&2
+    exit 1
+fi
+
+# Extract the rig_name_for_db function body verbatim from reaper.sh so the
+# test exercises the real implementation rather than a re-typed copy.
+FUNC=$(awk '
+  /^rig_name_for_db\(\)/{found=1}
+  found{print}
+  found && /^}$/{exit}
+' "$REAPER")
+
+if [ -z "$FUNC" ]; then
+    printf 'ERROR: could not extract rig_name_for_db() from %s\n' "$REAPER" >&2
+    exit 1
+fi
+
+# run_lookup <RIG_STORE_REFS_BY_DB> <db>
+# Returns: <rc>|<output>
+run_lookup() {
+    local refs="$1"
+    local db="$2"
+    local tmpdir run_script rc out
+    tmpdir=$(mktemp -d)
+    run_script="$tmpdir/run.sh"
+
+    {
+        printf '%s\n' "$FUNC"
+        printf 'RIG_STORE_REFS_BY_DB=%q\n' "$refs"
+        printf 'rig_name_for_db %q\n' "$db"
+    } > "$run_script"
+
+    rc=0
+    out=$(bash "$run_script" 2>/dev/null) || rc=$?
+    rm -rf "$tmpdir"
+    printf '%s|%s\n' "$rc" "$out"
+}
+
+# ── T1: no entries → not found ────────────────────────────────────────────
+result=$(run_lookup "" "rig_alpha_db")
+rc=$(printf '%s' "$result" | cut -d'|' -f1)
+out=$(printf '%s' "$result" | cut -d'|' -f2-)
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+    pass "T1: empty map → not found"
+else
+    fail "T1: empty map → expected rc!=0 and empty output; got rc=$rc out=$out"
+fi
+
+# ── T2: one entry, matching db → found ────────────────────────────────────
+result=$(run_lookup $'rig_alpha_db|rig:alpha\n' "rig_alpha_db")
+rc=$(printf '%s' "$result" | cut -d'|' -f1)
+out=$(printf '%s' "$result" | cut -d'|' -f2-)
+if [ "$rc" -eq 0 ] && [ "$out" = "alpha" ]; then
+    pass "T2: single matching entry → found, prints rig name"
+else
+    fail "T2: single matching entry → expected rc=0 out=alpha; got rc=$rc out=$out"
+fi
+
+# ── T3: one entry, non-matching db → not found ────────────────────────────
+result=$(run_lookup $'rig_alpha_db|rig:alpha\n' "rig_other_db")
+rc=$(printf '%s' "$result" | cut -d'|' -f1)
+out=$(printf '%s' "$result" | cut -d'|' -f2-)
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+    pass "T3: no matching entry → not found"
+else
+    fail "T3: no matching entry → expected rc!=0 and empty output; got rc=$rc out=$out"
+fi
+
+# ── T4: multiple entries, second matches → found, correct rig name ───────
+result=$(run_lookup $'rig_alpha_db|rig:alpha\nrig_beta_db|rig:beta\n' "rig_beta_db")
+rc=$(printf '%s' "$result" | cut -d'|' -f1)
+out=$(printf '%s' "$result" | cut -d'|' -f2-)
+if [ "$rc" -eq 0 ] && [ "$out" = "beta" ]; then
+    pass "T4: multiple entries, second matches → found, prints beta"
+else
+    fail "T4: multiple entries, second matches → expected rc=0 out=beta; got rc=$rc out=$out"
+fi
+
+# ── T5: matching entry but store_ref is not rig:-prefixed → not found ────
+result=$(run_lookup $'city_db|city:main\n' "city_db")
+rc=$(printf '%s' "$result" | cut -d'|' -f1)
+out=$(printf '%s' "$result" | cut -d'|' -f2-)
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+    pass "T5: non-rig: store_ref → not found (defensive)"
+else
+    fail "T5: non-rig: store_ref → expected rc!=0 and empty output; got rc=$rc out=$out"
+fi
+
+# ── T6: db is a substring of another entry's db → exact match only ───────
+result=$(run_lookup $'rig_alpha_db_extended|rig:alpha\n' "rig_alpha_db")
+rc=$(printf '%s' "$result" | cut -d'|' -f1)
+out=$(printf '%s' "$result" | cut -d'|' -f2-)
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+    pass "T6: substring db does not accidentally match → not found"
+else
+    fail "T6: substring db does not accidentally match → expected rc!=0 and empty output; got rc=$rc out=$out"
+fi
+
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Fixes #5285.

The reaper's expired-nudge cleanup only ever closed city-store nudge shadows; rig-scoped ones were silently skipped, forever — they just accumulated with no path to closure.

**Fix:** resolves the rig binding and closes rig-scoped shadows via `gc bd --city --rig`, matching how city-store shadows were already handled.

**Testing:** `go build`/`gofmt -l` clean, targeted `go test` green. Includes new shell-level test coverage for this path — worth noting this script's existing test harness is informal/manual, not CI-wired, so this coverage isn't yet exercised automatically.

---

Generated with [Claude Code](https://claude.com/claude-code)