### PR TITLE
fix(session): surface two setup-timeout config footguns as validation warnings (#5279)

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -186,6 +186,9 @@ func isNonFatalLoadConfigWarning(warning string) bool {
 	if config.IsDisabledNamedSessionWarning(warning) {
 		return true
 	}
+	if config.IsSessionSetupTimeoutAdvisory(warning) {
+		return true
+	}
 	if config.IsAlwaysFreshWakeModeWarning(warning) {
 		return true
 	}

--- a/cmd/gc/setup_timeout_advisory_test.go
+++ b/cmd/gc/setup_timeout_advisory_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -50,5 +51,33 @@ func TestSessionSetupTimeoutAdvisoriesAreNonFatalAndEmitted(t *testing.T) {
 				t.Error("a setup-timeout advisory must reach the operator, not be swallowed")
 			}
 		})
+	}
+}
+
+// TestUnparseableDurationIsNotMistakenForAnAdvisory pins the classifier
+// against the one input that can forge an advisory: the unparseable-duration
+// warning quotes the operator's raw value verbatim, so a value containing an
+// advisory sentence would be recognized as advisory and lose its strict-fatal
+// handling if the match were not anchored.
+func TestUnparseableDurationIsNotMistakenForAnAdvisory(t *testing.T) {
+	forged := "setup_timeout now bounds idle/silence time between output, not total setup runtime"
+	warnings := config.ValidateDurations(&config.City{
+		Session: config.SessionConfig{SetupTimeout: forged, StartupTimeout: "60s"},
+	}, "city.toml")
+
+	var parseWarning string
+	for _, w := range warnings {
+		if strings.Contains(w, "is not a valid duration") {
+			parseWarning = w
+		}
+	}
+	if parseWarning == "" {
+		t.Fatalf("warnings = %v, want an unparseable-duration warning", warnings)
+	}
+	if config.IsSessionSetupTimeoutAdvisory(parseWarning) {
+		t.Fatalf("an unparseable duration was classified as an advisory: %q", parseWarning)
+	}
+	if fatal, _ := splitStrictConfigWarnings([]string{parseWarning}); len(fatal) != 1 {
+		t.Errorf("strict split: fatal=%v, want the unparseable duration to stay fatal", fatal)
 	}
 }

--- a/cmd/gc/setup_timeout_advisory_test.go
+++ b/cmd/gc/setup_timeout_advisory_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestSessionSetupTimeoutAdvisoriesAreNonFatalAndEmitted pins both downstream
+// re-classifiers of the setup-timeout advisories introduced for
+// gastownhall/gascity#5279. Strict mode is on by default for `gc start`, so a
+// warning that is not recognized as advisory turns a city that starts today
+// into one that exits 1 — and the setup_max_timeout advisory fires on every
+// config that sets the field, including a correct one. The agent emit path
+// must also surface them, or the advisory the PR exists to deliver is dropped
+// before it reaches the operator.
+//
+// The warning text is derived from config.ValidateDurations rather than
+// hardcoded so this test cannot pass against a string the validator no longer
+// emits.
+func TestSessionSetupTimeoutAdvisoriesAreNonFatalAndEmitted(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		session config.SessionConfig
+	}{
+		{
+			name:    "setup_timeout at or above startup_timeout",
+			session: config.SessionConfig{SetupTimeout: "90s", StartupTimeout: "60s"},
+		},
+		{
+			name:    "setup_max_timeout reinterprets setup_timeout",
+			session: config.SessionConfig{SetupMaxTimeout: "5m"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := config.ValidateDurations(&config.City{Session: tc.session}, "city.toml")
+			if len(warnings) != 1 {
+				t.Fatalf("warnings = %v, want exactly the setup-timeout advisory", warnings)
+			}
+			w := warnings[0]
+			if !config.IsSessionSetupTimeoutAdvisory(w) {
+				t.Fatalf("advisory not recognized by its own classifier: %q", w)
+			}
+
+			fatal, nonFatal := splitStrictConfigWarnings([]string{w})
+			if len(fatal) != 0 || len(nonFatal) != 1 {
+				t.Errorf("strict split: fatal=%v nonFatal=%v, want the advisory non-fatal", fatal, nonFatal)
+			}
+			if !shouldEmitLoadCityConfigWarning(w) {
+				t.Error("a setup-timeout advisory must reach the operator, not be swallowed")
+			}
+		})
+	}
+}

--- a/cmd/gc/strict_warnings.go
+++ b/cmd/gc/strict_warnings.go
@@ -21,5 +21,6 @@ func strictWarningIsNonFatal(warning string) bool {
 		config.IsLegacyWorkspaceFieldWarning(warning) ||
 		config.IsIdleSleepMaskedByIdleTimeoutWarning(warning) ||
 		config.IsAlwaysFreshWakeModeWarning(warning) ||
-		config.IsRetiredKeyWarning(warning)
+		config.IsRetiredKeyWarning(warning) ||
+		config.IsSessionSetupTimeoutAdvisory(warning)
 }

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -2,8 +2,26 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
+
+const (
+	setupTimeoutMaskedByStartupWarningFragment   = "setup_timeout can never fire because startup_timeout bounds the whole session Start() call first"
+	setupTimeoutBecomesIdleBudgetWarningFragment = "setup_timeout now bounds idle/silence time between output, not total setup runtime"
+)
+
+// IsSessionSetupTimeoutAdvisory reports whether warning is one of the
+// [session] setup-timeout advisories. They describe how the timeout knobs
+// reinterpret each other rather than a config the loader cannot honor: the
+// setup_max_timeout advisory fires on every config that sets the field,
+// including a deliberately correct one. Callers that promote warnings to
+// errors must keep these advisory, or setting a documented field would stop a
+// city from starting.
+func IsSessionSetupTimeoutAdvisory(warning string) bool {
+	return strings.Contains(warning, setupTimeoutMaskedByStartupWarningFragment) ||
+		strings.Contains(warning, setupTimeoutBecomesIdleBudgetWarningFragment)
+}
 
 // ValidateDurations checks all duration string fields in the config and returns
 // warnings for any values that cannot be parsed by time.ParseDuration. This
@@ -88,8 +106,8 @@ func ValidateDurations(cfg *City, source string) []string {
 	// conflicting default is still caught (gastownhall/gascity#5279).
 	if setupDur, startupDur := cfg.Session.SetupTimeoutDuration(), cfg.Session.StartupTimeoutDuration(); setupDur >= startupDur {
 		warnings = append(warnings, fmt.Sprintf(
-			"%s: [session] setup_timeout (%s) >= startup_timeout (%s): setup_timeout can never fire because startup_timeout bounds the whole session Start() call first",
-			source, setupDur, startupDur))
+			"%s: [session] setup_timeout (%s) >= startup_timeout (%s): %s",
+			source, setupDur, startupDur, setupTimeoutMaskedByStartupWarningFragment))
 	}
 
 	// setup_max_timeout > 0 silently reinterprets setup_timeout from a
@@ -98,8 +116,8 @@ func ValidateDurations(cfg *City, source string) []string {
 	// is being tuned (gastownhall/gascity#5279).
 	if maxDur := cfg.Session.SetupMaxTimeoutDuration(); maxDur > 0 {
 		warnings = append(warnings, fmt.Sprintf(
-			"%s: [session] setup_max_timeout (%s) is set: setup_timeout now bounds idle/silence time between output, not total setup runtime",
-			source, maxDur))
+			"%s: [session] setup_max_timeout (%s) is set: %s",
+			source, maxDur, setupTimeoutBecomesIdleBudgetWarningFragment))
 	}
 
 	// Daemon config durations.

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -18,9 +18,14 @@ const (
 // including a deliberately correct one. Callers that promote warnings to
 // errors must keep these advisory, or setting a documented field would stop a
 // city from starting.
+// The fragments are matched as a suffix rather than anywhere in the string:
+// the unparseable-duration warnings in this file quote the operator's raw
+// value verbatim and then append the parse error, so a value that happens to
+// contain an advisory sentence must not be mistaken for the advisory itself
+// and downgraded out of strict-fatal handling.
 func IsSessionSetupTimeoutAdvisory(warning string) bool {
-	return strings.Contains(warning, setupTimeoutMaskedByStartupWarningFragment) ||
-		strings.Contains(warning, setupTimeoutBecomesIdleBudgetWarningFragment)
+	return strings.HasSuffix(warning, setupTimeoutMaskedByStartupWarningFragment) ||
+		strings.HasSuffix(warning, setupTimeoutBecomesIdleBudgetWarningFragment)
 }
 
 // ValidateDurations checks all duration string fields in the config and returns

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -81,6 +81,27 @@ func ValidateDurations(cfg *City, source string) []string {
 	check("[session]", "progress_stall_timeout", cfg.Session.ProgressStallTimeout)
 	check("[session]", "claim_holder_stall_timeout", cfg.Session.ClaimHolderStallTimeout)
 
+	// Cross-field: startup_timeout wraps the whole Start() call (pre_start and
+	// setup included), so a setup_timeout that is >= startup_timeout can never
+	// actually fire — startup_timeout kills Start() first. Compared as
+	// effective (defaulted) durations so an unset field that inherits a
+	// conflicting default is still caught (gastownhall/gascity#5279).
+	if setupDur, startupDur := cfg.Session.SetupTimeoutDuration(), cfg.Session.StartupTimeoutDuration(); setupDur >= startupDur {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: [session] setup_timeout (%s) >= startup_timeout (%s): setup_timeout can never fire because startup_timeout bounds the whole session Start() call first",
+			source, setupDur, startupDur))
+	}
+
+	// setup_max_timeout > 0 silently reinterprets setup_timeout from a
+	// total-runtime budget into an idle/silence budget (see runSetupCommand in
+	// internal/runtime/tmux/adapter.go) — easy to miss when only setup_timeout
+	// is being tuned (gastownhall/gascity#5279).
+	if maxDur := cfg.Session.SetupMaxTimeoutDuration(); maxDur > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: [session] setup_max_timeout (%s) is set: setup_timeout now bounds idle/silence time between output, not total setup runtime",
+			source, maxDur))
+	}
+
 	// Daemon config durations.
 	check("[daemon]", "patrol_interval", cfg.Daemon.PatrolInterval)
 	check("[daemon]", "restart_window", cfg.Daemon.RestartWindow)

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -444,6 +444,92 @@ func TestValidateDurationsIncludesSource(t *testing.T) {
 	}
 }
 
+func TestValidateDurationsSetupTimeoutExceedsStartupTimeout(t *testing.T) {
+	cfg := &City{
+		Session: SessionConfig{
+			SetupTimeout:   "90s",
+			StartupTimeout: "60s",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "setup_timeout") || !strings.Contains(warnings[0], "startup_timeout") {
+		t.Errorf("warning should mention both fields: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "can never fire") {
+		t.Errorf("warning should explain the footgun: %s", warnings[0])
+	}
+}
+
+func TestValidateDurationsSetupTimeoutEqualsStartupTimeout(t *testing.T) {
+	// Equal values are also a footgun: startup_timeout's context deadline
+	// fires at (or before, given scheduling jitter) the same instant as
+	// setup_timeout, so setup_timeout still never gets to act on its own.
+	cfg := &City{
+		Session: SessionConfig{
+			SetupTimeout:   "60s",
+			StartupTimeout: "60s",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func TestValidateDurationsSetupTimeoutExceedsDefaultStartupTimeout(t *testing.T) {
+	// startup_timeout left unset still defaults to 60s at runtime, so an
+	// explicit setup_timeout above that default must still warn.
+	cfg := &City{
+		Session: SessionConfig{
+			SetupTimeout: "90s",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "startup_timeout") {
+		t.Errorf("warning should mention startup_timeout: %s", warnings[0])
+	}
+}
+
+func TestValidateDurationsSetupMaxTimeoutChangesSetupTimeoutMeaning(t *testing.T) {
+	cfg := &City{
+		Session: SessionConfig{
+			SetupTimeout:    "10s",
+			SetupMaxTimeout: "10m",
+			StartupTimeout:  "60s",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "setup_max_timeout") {
+		t.Errorf("warning should mention setup_max_timeout: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "idle/silence") {
+		t.Errorf("warning should explain the meaning shift: %s", warnings[0])
+	}
+}
+
+func TestValidateDurationsSaneSessionSetupConfigNoWarnings(t *testing.T) {
+	cfg := &City{
+		Session: SessionConfig{
+			SetupTimeout:    "10s",
+			SetupMaxTimeout: "",
+			StartupTimeout:  "60s",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for sane session setup config, got: %v", warnings)
+	}
+}
+
 func TestValidateDurationsBadChatSessionsGracePeriod(t *testing.T) {
 	cfg := &City{
 		ChatSessions: ChatSessionsConfig{GracePeriod: "bogus"},


### PR DESCRIPTION
Fixes #5279.

Two silent config footguns around session setup timeouts:

1. `setup_timeout` silently means something different once `setup_max_timeout` is also set — easy to misread as still-authoritative when it isn't.
2. `setup_timeout >= startup_timeout` is a silent no-op — the config validates but the intended timeout never actually takes effect.

**Fix:** both now surface as validation warnings instead of failing silently.

**Scope note:** deliberately scoped down from 3 footguns to these 2. The third (a reload provider-rebuild gap) is a separate, deeper follow-up — not touched here.

**Testing:** `go build`/`gofmt -l` clean, targeted `go test` green.

---

Generated with [Claude Code](https://claude.com/claude-code)