### PR TITLE
fix(import): validate composed config after install, not just at doctor time (#5382)

### DIFF
--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -734,10 +734,13 @@ func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 	// Nothing rolls back: the packs are in the cache and packs.lock is
 	// written by the time this runs, and the load error may predate this
 	// command. Say so, or a non-zero exit reads as "nothing was installed"
-	// and the operator re-runs instead of fixing the config.
+	// and the operator re-runs instead of fixing the config. No count here:
+	// the success line's len(lock.Packs) is the lock closure by source, not
+	// a count of import bindings, and it is 0 for a local-path-only city
+	// whose config is nonetheless on disk.
 	if cfgErr := validateComposedConfigAfterInstall(cityPath); cfgErr != nil {
-		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr)                                          //nolint:errcheck
-		fmt.Fprintf(stderr, "%d remote import(s) and packs.lock are on disk; fix the config, then re-run `gc doctor` to confirm.\n", len(lock.Packs)) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr)                        //nolint:errcheck
+		fmt.Fprintln(stderr, "The installed packs and packs.lock are on disk; fix the config, then re-run `gc doctor` to confirm.") //nolint:errcheck
 		return 1
 	}
 

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -731,8 +731,13 @@ func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 	// expanded-config-load check applies. Validate here so install fails
 	// closed on the same errors doctor would later catch, instead of
 	// succeeding while every subsequent config reload aborts. See #5382.
+	// Nothing rolls back: the packs are in the cache and packs.lock is
+	// written by the time this runs, and the load error may predate this
+	// command. Say so, or a non-zero exit reads as "nothing was installed"
+	// and the operator re-runs instead of fixing the config.
 	if cfgErr := validateComposedConfigAfterInstall(cityPath); cfgErr != nil {
-		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr) //nolint:errcheck
+		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr)                                          //nolint:errcheck
+		fmt.Fprintf(stderr, "%d remote import(s) and packs.lock are on disk; fix the config, then re-run `gc doctor` to confirm.\n", len(lock.Packs)) //nolint:errcheck
 		return 1
 	}
 

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -739,8 +739,8 @@ func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 	// a count of import bindings, and it is 0 for a local-path-only city
 	// whose config is nonetheless on disk.
 	if cfgErr := validateComposedConfigAfterInstall(cityPath); cfgErr != nil {
-		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr)                        //nolint:errcheck
-		fmt.Fprintln(stderr, "The installed packs and packs.lock are on disk; fix the config, then re-run `gc doctor` to confirm.") //nolint:errcheck
+		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr)                                                                  //nolint:errcheck
+		fmt.Fprintln(stderr, "This is not rolled back: packs.lock is written and any fetched packs remain in the cache. Fix the config, then re-run `gc doctor` to confirm.") //nolint:errcheck
 		return 1
 	}
 

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -34,6 +34,18 @@ var (
 	resolveImportVersion    = packman.ResolveVersion
 	defaultImportConstraint = packman.DefaultConstraint
 	resolveImportHeadCommit = defaultImportHeadCommit
+
+	// validateComposedConfigAfterInstall loads the composed city config after
+	// install, so `gc import install` fails on the same load errors gc
+	// doctor's expanded-config-load check would report, instead of reporting
+	// success on a config the loader will refuse to load on a later reload.
+	// A var so command tests that stub syncImports/installLockedImports
+	// (and so have no real cache content on disk for the loader to expand)
+	// can stub this too. See #5382.
+	validateComposedConfigAfterInstall = func(cityPath string) error {
+		_, err := loadCityConfig(cityPath, io.Discard)
+		return err
+	}
 )
 
 // resolveImportVersion and resolveImportHeadCommit carry a leading cityRoot so
@@ -712,6 +724,18 @@ func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 		printCredentialHint(stderr, err)
 		return 1
 	}
+
+	// Installing the locked imports can still leave the city with a composed
+	// config the loader will refuse: install resolves and fetches packs, but
+	// never runs the same expansion/validation `gc doctor`'s
+	// expanded-config-load check applies. Validate here so install fails
+	// closed on the same errors doctor would later catch, instead of
+	// succeeding while every subsequent config reload aborts. See #5382.
+	if cfgErr := validateComposedConfigAfterInstall(cityPath); cfgErr != nil {
+		fmt.Fprintf(stderr, "gc import install: composed config failed to load after install: %v\n", cfgErr) //nolint:errcheck
+		return 1
+	}
+
 	fmt.Fprintf(stdout, "Installed %d remote import(s)\n", len(lock.Packs)) //nolint:errcheck
 	return 0
 }

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -1119,6 +1119,9 @@ trigger = "manual"
 		"gc import install: composed config failed to load after install",
 		"unsupported PackV1 order path",
 		"packs/ops/orders/nightly/order.toml",
+		// The install is not rolled back, so the failure must say what is
+		// already on disk rather than reading as "nothing was installed".
+		"packs.lock are on disk",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr = %q, want substring %q", stderr.String(), want)

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -1121,7 +1121,7 @@ trigger = "manual"
 		"packs/ops/orders/nightly/order.toml",
 		// The install is not rolled back, so the failure must say what is
 		// already on disk rather than reading as "nothing was installed".
-		"packs.lock are on disk",
+		"packs.lock is written",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr = %q, want substring %q", stderr.String(), want)

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -812,10 +812,16 @@ version = "^1.4"
 
 	prevSync := syncImports
 	prevInstall := installLockedImports
+	prevValidate := validateComposedConfigAfterInstall
 	t.Cleanup(func() {
 		syncImports = prevSync
 		installLockedImports = prevInstall
+		validateComposedConfigAfterInstall = prevValidate
 	})
+	// The fetch and lockfile calls below are stubbed, so no pack content is
+	// actually cached on disk; skip the post-install config load, which is
+	// covered on its own in TestDoImportInstallRejectsUnloadableComposedConfig.
+	validateComposedConfigAfterInstall = func(_ string) error { return nil }
 	syncImports = func(cityRoot string, imports map[string]config.Import, mode packman.InstallMode) (*packman.Lockfile, error) {
 		if cityRoot != dir {
 			t.Fatalf("cityRoot = %q, want %q", cityRoot, dir)
@@ -940,10 +946,16 @@ version = "^1.0"
 
 	prevSync := syncImports
 	prevInstall := installLockedImports
+	prevValidate := validateComposedConfigAfterInstall
 	t.Cleanup(func() {
 		syncImports = prevSync
 		installLockedImports = prevInstall
+		validateComposedConfigAfterInstall = prevValidate
 	})
+	// The fetch and lockfile calls below are stubbed, so no pack content is
+	// actually cached on disk; skip the post-install config load, which is
+	// covered on its own in TestDoImportInstallRejectsUnloadableComposedConfig.
+	validateComposedConfigAfterInstall = func(_ string) error { return nil }
 	syncImports = func(_ string, _ map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
 		return &packman.Lockfile{
 			Schema: packman.LockfileSchema,
@@ -988,10 +1000,16 @@ version = "^1.4"
 
 	prevSync := syncImports
 	prevInstall := installLockedImports
+	prevValidate := validateComposedConfigAfterInstall
 	t.Cleanup(func() {
 		syncImports = prevSync
 		installLockedImports = prevInstall
+		validateComposedConfigAfterInstall = prevValidate
 	})
+	// The fetch and lockfile calls below are stubbed, so no pack content is
+	// actually cached on disk; skip the post-install config load, which is
+	// covered on its own in TestDoImportInstallRejectsUnloadableComposedConfig.
+	validateComposedConfigAfterInstall = func(_ string) error { return nil }
 
 	syncImports = func(cityRoot string, imports map[string]config.Import, mode packman.InstallMode) (*packman.Lockfile, error) {
 		if cityRoot != dir {
@@ -1055,6 +1073,59 @@ func TestDoImportInstallWithNoImportsSucceeds(t *testing.T) {
 	}
 	if len(lock.Packs) != 0 {
 		t.Fatalf("len(Packs) = %d, want 0", len(lock.Packs))
+	}
+}
+
+// TestDoImportInstallRejectsUnloadableComposedConfig mirrors the fixture in
+// TestExpandedConfigLoadCheckReportsImportedPackLegacyOrderPath
+// (doctor_v2_checks_test.go): a locally-sourced pack whose order lives at
+// the legacy PackV1 path. `gc doctor`'s expanded-config-load check already
+// refuses to load this composed config; `gc import install` must now refuse
+// it too instead of reporting success (#5382). The import here is a local
+// path source, so syncImports/installLockedImports run for real -- no
+// network fetch is needed to reproduce the gap.
+func TestDoImportInstallRejectsUnloadableComposedConfig(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, `
+[workspace]
+name = "order-city"
+`)
+	writePackToml(t, dir, `
+[pack]
+name = "order-city"
+schema = 2
+
+[imports.ops]
+source = "./packs/ops"
+`)
+	writeDoctorFile(t, dir, "packs/ops/pack.toml", `
+[pack]
+name = "ops"
+schema = 2
+`)
+	writeDoctorFile(t, dir, "packs/ops/orders/nightly/order.toml", `
+[order]
+formula = "nightly"
+trigger = "manual"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doImportInstall(dir, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout = %s", code, stdout.String())
+	}
+	for _, want := range []string{
+		"gc import install: composed config failed to load after install",
+		"unsupported PackV1 order path",
+		"packs/ops/orders/nightly/order.toml",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want substring %q", stderr.String(), want)
+		}
+	}
+	if strings.Contains(stdout.String(), "Installed") {
+		t.Fatalf("stdout = %q, install should not have reported success", stdout.String())
 	}
 }
 


### PR DESCRIPTION
Fixes #5382 (part 1 of 2).

`gc import install` could succeed on a composed config that the loader would later refuse outright — the install-time path didn't run the same validation `gc doctor` already catches, so the failure only surfaced later, disconnected from the actual install action that caused it.

**Fix:** `gc import install` now validates the composed config after installing, catching the same class of error `gc doctor` already catches, at the point where it's actionable.

**Scope note:** deliberately scoped to just this — part 2 of the original issue (a reload-visibility gap) is a separate design question, not touched here.

**Testing:** `go build`/`gofmt -l` clean, targeted `go test` green.

---

Generated with [Claude Code](https://claude.com/claude-code)