### PR TITLE
docs(pack-spec): document [runtimes.<name>] pack manifest tables

### DIFF
--- a/docs/reference/exec-session-provider.md
+++ b/docs/reference/exec-session-provider.md
@@ -47,7 +47,9 @@ Rules:
   errors — no silent shadowing. Identical re-declarations of the same
   pack reached through a diamond import graph dedupe.
 - The `pack-runtimes` doctor check verifies each declared executable is
-  installed and answers the `protocol` handshake.
+  installed and that its RPP handshake works. An executable with no
+  `protocol` op is the version-0 floor and passes; a present-but-broken
+  handshake fails.
 - Config reload enforces the same registration rules, and rebuilds the
   session provider when the declaration behind the selected name changes
   (the executable binding is fixed at provider construction).

--- a/docs/reference/exec-session-provider.md
+++ b/docs/reference/exec-session-provider.md
@@ -53,8 +53,10 @@ Rules:
 - Config reload enforces the same registration rules, and rebuilds the
   session provider when the declaration behind the selected name changes
   (the executable binding is fixed at provider construction).
-- `gc runtime check <name>` resolves the declared name and runs the
-  full conformance suite against the pack's executable.
+- `gc runtime check <name>` and `gc runtime conformance <name>` both
+  resolve the declared name and run against the pack's executable:
+  `check` is the smoke test, `conformance` the full requirement-coded
+  suite.
 
 ## Calling Convention
 

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -496,7 +496,8 @@ declared name and run against that pack's executable: `check` is the smoke
 test (handshake, lifecycle round-trip, declared capabilities, optional
 probes), and `conformance` is the full requirement-coded RPP suite. A
 `pack-runtimes` doctor check verifies each declared executable is installed
-and answers the `protocol` handshake.
+and that its RPP handshake works. An executable with no `protocol` op is the
+documented version-0 floor and passes; a present-but-broken handshake fails.
 
 ### 1.2.9. Formula Directory
 

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -85,6 +85,7 @@ A pack may contain the following abstract content:
 | Named sessions | `[[named_session]]` in `pack.toml` | current |
 | Services | `[[service]]` in `pack.toml` | current |
 | Providers | `[providers.<name>]` in `pack.toml` | current |
+| Runtimes | `[runtimes.<name>]` in `pack.toml` | current |
 | Formulas | `formulas/` | preferred |
 | Orders | `orders/<name>.toml` | preferred |
 | Skills | `skills/` | preferred |
@@ -181,6 +182,7 @@ Conceptually, the file may contain these tables:
 | `[[named_session]]` | Pack-provided named sessions. | current |
 | `[[service]]` | Pack-provided services. | current |
 | `[providers.<name>]` | Pack-provided provider presets. | current |
+| `[runtimes.<name>]` | Pack-shipped runtime provider executables. | current |
 | `[[patches.agent]]` | Pack-level agent patches. | current |
 | `[global]` | Pack-wide live session commands. | current |
 | `[[pricing]]` | Pack-provided pricing estimates. | current |
@@ -455,7 +457,43 @@ the effective city wins.
 
 Provider fields are the same provider fields accepted in `city.toml`.
 
-### 1.2.8. Formula Directory
+### 1.2.8. `[runtimes.<name>]`
+
+The `[runtimes]` table declares pack-shipped runtime provider executables. Each
+`[runtimes.<name>]` entry binds a selection name to a Runtime Provider Protocol
+(RPP) executable:
+
+```toml
+[runtimes.cloudflare]
+command = "gc-runtime-cloudflare"   # pack-relative if it contains a path
+                                     # separator, else resolved on PATH
+protocol = 0
+```
+
+| Field | Meaning | Status |
+|---|---|---|
+| `command` | Required. The runtime executable: a path relative to the pack directory (anything containing a path separator), or a bare name resolved on PATH at session start. | required |
+| `protocol` | The RPP version the executable speaks. `0` is the only version today; any other value fails composition. | current |
+
+`<name>` must not contain `:`, `/`, or whitespace, since `:` is reserved for
+prefix-form selection names (`exec:...`) and `/` and whitespace keep selection
+names shell- and TOML-friendly.
+
+City composition registers declared runtimes into a city-wide selection
+registry (`City.Runtimes`), including runtimes declared by rig-imported packs.
+Consumers select a runtime by name the same way they select a builtin
+provider — `city.toml` `[session].provider`, or an agent/template `session`
+field — for example `provider = "cloudflare"` for the entry above. Name
+collisions with builtin runtimes or other packs are composition errors; only
+identical re-declarations of the same pack reached through a diamond import
+graph dedupe.
+
+`gc runtime check <name>` resolves a declared name and runs the RPP
+conformance suite against the pack's executable. A `pack-runtimes` doctor
+check verifies each declared executable is installed and answers the
+`protocol` handshake.
+
+### 1.2.9. Formula Directory
 
 A pack's formula directory is the well-known `formulas/` directory at the pack
 root. The only formula directory the pack loader collects is `formulas/`.
@@ -466,7 +504,7 @@ directories are collected before higher-priority pack directories.
 > **Compatibility:** Older material may mention `[formulas].dir`. That field is
 > invalid in `pack.toml`; new packs should put formulas under `formulas/`.
 
-### 1.2.9. `[[patches.agent]]`
+### 1.2.10. `[[patches.agent]]`
 
 Agent patches modify an existing agent by identity.
 
@@ -499,7 +537,7 @@ The specified append fields are:
 Pack-level patch paths in `prompt_template`, `session_setup_script`, and
 `overlay_dir` resolve relative to the patching pack directory.
 
-### 1.2.10. Doctor Directory
+### 1.2.11. Doctor Directory
 
 Pack doctor checks are authored under `doctor/`. Each immediate child directory
 under `doctor/` defines one check when it contains a runnable check script.
@@ -530,7 +568,7 @@ metadata:
 > **Compatibility:** Legacy `pack.toml` `[[doctor]]` entries remain loader
 > compatibility for existing packs. New packs should use `doctor/<name>/`.
 
-### 1.2.11. Command Directory
+### 1.2.12. Command Directory
 
 Pack commands are authored under `commands/`. Each directory containing `run.sh`
 defines one command leaf. Nested directories imply nested command words.
@@ -558,7 +596,7 @@ An optional `command.toml` may override the default command words or script:
 > **Compatibility:** Legacy `pack.toml` `[[commands]]` entries remain loader
 > compatibility for existing packs. New packs should use `commands/<path>/`.
 
-### 1.2.12. `[global]`
+### 1.2.13. `[global]`
 
 The `[global]` table declares pack-wide live session commands.
 
@@ -575,7 +613,7 @@ When `[global].session_live` is loaded, `{{.ConfigDir}}` is resolved to the
 concrete pack directory. Other template variables remain for per-agent
 expansion.
 
-### 1.2.13. `[[pricing]]`
+### 1.2.14. `[[pricing]]`
 
 Each `[[pricing]]` table declares an estimated model-pricing entry for one
 provider/model pair.
@@ -608,7 +646,7 @@ Pack pricing entries are lower priority than city-level `[[pricing]]` entries
 and higher priority than the built-in default pricing table. Pricing entries
 are estimates for decision support, not invoice reconciliation.
 
-### 1.2.14. Authoring Summary
+### 1.2.15. Authoring Summary
 
 New packs should use these authoring constructs:
 
@@ -629,6 +667,7 @@ New packs should use these authoring constructs:
 | `[[named_session]]` | Pack named sessions. |
 | `[[service]]` | Pack services. |
 | `[providers.<name>]` | Pack provider presets. |
+| `[runtimes.<name>]` | Pack-shipped runtime provider executables. |
 | `[[patches.agent]]` | Pack-level agent patches. |
 | `[global]` | Pack-wide live session commands. |
 | `[[pricing]]` | Pack pricing estimates. |

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -465,14 +465,13 @@ The `[runtimes]` table declares pack-shipped runtime provider executables. Each
 
 ```toml
 [runtimes.cloudflare]
-command = "gc-runtime-cloudflare"   # pack-relative if it contains a path
-                                     # separator, else resolved on PATH
+command = "gc-runtime-cloudflare"   # bare name, resolved on PATH
 protocol = 0
 ```
 
 | Field | Meaning | Status |
 |---|---|---|
-| `command` | Required. The runtime executable: a path relative to the pack directory (anything containing a path separator), or a bare name resolved on PATH at session start. | required |
+| `command` | Required. The runtime executable. A bare name (no path separator) is resolved on PATH at session start. A relative path (any other value containing a separator) is anchored at the declaring pack directory during load. An absolute path is used as written. | required |
 | `protocol` | The RPP version the executable speaks. `0` is the only version today; any other value fails composition. | current |
 
 `<name>` must not contain `:`, `/`, or whitespace, since `:` is reserved for
@@ -484,14 +483,19 @@ registry (`City.Runtimes`), including runtimes declared by rig-imported packs.
 Consumers select a runtime by name the same way they select a builtin
 provider — `city.toml` `[session].provider`, or an agent/template `session`
 field — for example `provider = "cloudflare"` for the entry above. Name
-collisions with builtin runtimes or other packs are composition errors; only
-identical re-declarations of the same pack reached through a diamond import
-graph dedupe.
+collisions with builtin runtimes or other packs are composition errors. The
+only re-declaration that dedupes is the same pack *directory* reached twice
+through a diamond import graph with the same command and protocol; two
+distinct pack directories collide even when their pack name, command, and
+protocol all coincide, so a runtime's provenance is never silently
+re-attributed.
 
-`gc runtime check <name>` resolves a declared name and runs the RPP
-conformance suite against the pack's executable. A `pack-runtimes` doctor
-check verifies each declared executable is installed and answers the
-`protocol` handshake.
+`gc runtime check <name>` and `gc runtime conformance <name>` both accept a
+declared name and run against that pack's executable: `check` is the smoke
+test (handshake, lifecycle round-trip, declared capabilities, optional
+probes), and `conformance` is the full requirement-coded RPP suite. A
+`pack-runtimes` doctor check verifies each declared executable is installed
+and answers the `protocol` handshake.
 
 ### 1.2.9. Formula Directory
 

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -480,9 +480,10 @@ names shell- and TOML-friendly.
 
 City composition registers declared runtimes into a city-wide selection
 registry (`City.Runtimes`), including runtimes declared by rig-imported packs.
-Consumers select a runtime by name the same way they select a builtin
-provider — `city.toml` `[session].provider`, or an agent/template `session`
-field — for example `provider = "cloudflare"` for the entry above. Name
+Selection is city-wide: set `city.toml` `[session].provider` to the declared
+name (`provider = "cloudflare"` for the entry above), or override it for one
+invocation with `GC_SESSION`. An agent's `session` field does not select a
+runtime; it names a session transport (`acp`, `tmux`, or omitted). Name
 collisions with builtin runtimes or other packs are composition errors. The
 only re-declaration that dedupes is the same pack *directory* reached twice
 through a diamond import graph with the same command and protocol; two


### PR DESCRIPTION
Follow-up to the offer in #5606: `docs/reference/specs/pack-spec.md` documented `[providers.<name>]` but never `[runtimes.<name>]`, which lived only in the generated pack schema and `internal/config`.

Adds §1.2.8 `[runtimes.<name>]` (fields `command`/`protocol`, name rules, city composition + collision semantics, `gc runtime check` / `pack-runtimes` doctor) and the matching rows in the content table, section list, and authoring summary. Derived from `docs/reference/schema/pack-schema.json` (PackRuntimeEntry), `internal/config/pack_runtimes.go`, `internal/runtime/REQUIREMENTS.md` (RUNTIME-SEL-011/012), and the existing `exec-session-provider.md` prose; no fields documented beyond what the schema defines.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoMPoPbV2gsgSEguHovjhC