### PR TITLE
Deflake semantic gc stop tests without weakening timeout ownership

### DIFF
--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -362,7 +362,7 @@ func TestCmdStopForceEscalatesInProgressControllerStop(t *testing.T) {
 	var normalStdout, normalStderr lockedBuffer
 	normalDone := make(chan int, 1)
 	go func() {
-		normalDone <- cmdStop([]string{dir}, &normalStdout, &normalStderr, 10*time.Second, false)
+		normalDone <- cmdStop([]string{dir}, &normalStdout, &normalStderr, 0, false)
 	}()
 
 	interrupted := sp.waitForInterrupts(t, 1)
@@ -373,7 +373,7 @@ func TestCmdStopForceEscalatesInProgressControllerStop(t *testing.T) {
 	var forceStdout, forceStderr lockedBuffer
 	forceDone := make(chan int, 1)
 	go func() {
-		forceDone <- cmdStop([]string{dir}, &forceStdout, &forceStderr, 10*time.Second, true)
+		forceDone <- cmdStop([]string{dir}, &forceStdout, &forceStderr, 0, true)
 	}()
 
 	stopped := sp.waitForStops(t, 1)
@@ -834,7 +834,24 @@ func TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails(t *testin
 	})
 
 	var stdout, stderr lockedBuffer
-	code := cmdStop([]string{cityDir}, &stdout, &stderr, 5*time.Second, false)
+	// Input 0 selects production's normal config-derived timeout path instead
+	// of an arbitrary test override; completion is observed via the package
+	// hang detector below rather than via this input, so a scheduler-starved
+	// run reports a hang budget failure instead of racing a tight deadline.
+	codeCh := make(chan int, 1)
+	go func() {
+		codeCh <- cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
+	}()
+
+	var code int
+	awaitCond(t, func() bool {
+		select {
+		case code = <-codeCh:
+			return true
+		default:
+			return false
+		}
+	}, "cmdStop to finish for invalid-config shutdown failure")
 	if code != 1 {
 		t.Fatalf("cmdStop() = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}

--- a/release-gates/ga-imv1fb-cmd-stop-test-deflake-gate.md
+++ b/release-gates/ga-imv1fb-cmd-stop-test-deflake-gate.md
@@ -1,0 +1,89 @@
+# Release gate: semantic `cmdStop` test deflake
+
+- Deploy bead: `ga-imv1fb`
+- Build bead: `ga-4zsjqm`
+- Review bead: `ga-lqkf81`
+- Reviewed source: `16302822b2db29c899af3a8240596f539076c9e2`
+- Base: `origin/main@145cc2be9b2be3b16aedfd64fe884820a27c6d3e`
+- Deploy mode: remote
+- Push remote: `origin`
+- Gate result: **PASS**
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Closed review bead `ga-lqkf81` records `verdict: pass` for the exact reviewed source. |
+| 2 | Acceptance criteria met | **PASS** | Both semantics-only tests now avoid arbitrary positive outer timeout inputs; force escalation retains interrupt/stop/exit assertions, and the shutdown-error test observes asynchronous completion through the existing hang detector while retaining the same error/output assertions. Dedicated timeout-owner tests, the justified city-runtime latency test, and the package `hangBudget` are untouched. Builder evidence records 20/20 loaded-host runs. |
+| 3 | Tests pass | **PASS with attributed failures** | Fresh full-scope run completed 36/40 jobs PASS and 4/40 FAIL with 4 failing functions and 0 observed SKIP. Both diff-owned tests were selected in green full-suite shards and independently passed by name. Every raw failure has a tracker predating this run, is outside `cmd/gc/cmd_stop_test.go`, and cannot be caused by this test-only diff. |
+| 3b | Policy/lint lane | **PASS with attributed baseline failure** | Policy, docs, build, vet, native-DoltLite, changed formatting, and affected lint pass. The tracked native binary-size baseline remains above its ceiling (`270281232 > 270000000`, `ga-5flk3r`); a test-only diff cannot change the `gc` binary dependency graph. |
+| 4 | No unresolved HIGH review findings | **PASS** | Review bead records no HIGH, security, or spec finding. Its comment-precision observation is explicitly non-blocking and does not affect behavior or assertions. |
+| 5 | Final branch clean | **PASS** | The exact reviewed source was clean before this gate record; `git diff --check origin/main...HEAD` passed. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree --messages origin/main HEAD` returned no conflicts and tree `9776599711ddf4ed5789a211b610b40319623d73`. Source is 8 commits behind and 1 ahead of main. |
+| 7 | Single feature theme | **PASS** | One commit modifies one test file to deflake two related semantics-only `cmdStop` cases while preserving timeout ownership. |
+
+The mandatory deploy-source ancestry audit passes:
+
+```text
+assert_deploy_ancestry_scope origin/main 16302822b2db29c899af3a8240596f539076c9e2 ga-imv1fb ga-4zsjqm ga-lqkf81
+ANCESTRY_SCOPE=PASS
+```
+
+## Acceptance evidence
+
+- `TestCmdStopForceEscalatesInProgressControllerStop` passes `0` to both
+  `cmdStop` invocations while retaining the existing interrupt, force-stop,
+  completion, and exit-code assertions.
+- `TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails` invokes
+  `cmdStop(..., 0, false)` asynchronously and bounds observation with the
+  existing package helper; the shutdown-error and false-success assertions are
+  unchanged.
+- The reviewed diff has only two hunks in `cmd/gc/cmd_stop_test.go`; it does not
+  touch either dedicated wall-clock timeout owner, the city-runtime latency
+  assertion, the separate held force-delegation recurrence, or `hangBudget`.
+- Builder and reviewer evidence records 20/20 clean loaded-host package runs.
+
+## Test evidence
+
+- `test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 make test-local-full-parallel`
+- `test_cmd_scope: full-suite`
+- `test_counts: 36 PASS jobs, 4 FAIL jobs, 0 observed SKIP jobs`
+- `failing_test_functions: 4`
+- `full_log: /var/tmp/ga-imv1fb-full-suite-20260825.log`
+- `shard_logs: /var/tmp/gc-local-tests.QRMWtI`
+- `diff_tests_executed: TestCmdStopForceEscalatesInProgressControllerStop PASS in cmd-gc-process-1-of-6 and integration-packages-cmd-gc-3-of-6; TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails PASS in cmd-gc-process-3-of-6 and integration-packages-cmd-gc-5-of-6`
+- `named_check: go test -count=1 -v ./cmd/gc/... -run '^(TestCmdStopForceEscalatesInProgressControllerStop|TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails)$' — 2 PASS, 0 FAIL, 0 SKIP`
+- `waiver_ref: none`
+
+| Raw failing test(s) | Tracker | Attribution evidence |
+|---|---|---|
+| `TestBdFlagManifestCurrent` | `ga-f0uceo` | Installed-`bd` flag-manifest drift. Candidate changes only a separate test file and cannot reach `internal/bdflags`. |
+| `TestGetKeyBinding_CapturesDefaultBinding`, `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `ga-afqddr` | Exact host-tmux empty-default-binding class. Candidate changes only `cmd/gc/cmd_stop_test.go` and cannot reach `internal/runtime/tmux`. |
+| `TestCleanInstallTutorialPath` | `ga-2ywyyf` | Exact fresh-temp-rig pre-existing `.beads` store signature. Tracker predates this run; the candidate changes no production code or suite target and cannot affect the integration fixture's isolated filesystem. |
+
+`failure_attribution`: each failure satisfies clause 3(a), structural mechanism,
+and has no path overlap. This diff changes test code only, adds no test target,
+and does not alter resource-census baselines.
+
+## Policy and static evidence
+
+```text
+make test-ci-policy                                      PASS
+make check-gomod-replace                                 PASS
+make check-eventexport-isolation                         PASS
+make check-core-boundary                                 PASS
+make check-docs                                          PASS
+go build ./...                                           PASS
+go vet ./...                                             PASS
+make test-native-doltlite-beads                          PASS
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=HEAD^ make fmt-check-changed  PASS
+LINT_CHANGED_REF=HEAD^ make lint-affected                PASS (0 issues)
+make check-native-dependency-surface                     FAIL-ATTRIBUTED: 270281232 > 270000000 (`ga-5flk3r`)
+```
+
+## Release disposition
+
+**Gate PASS.** Cut isolated branch `deploy/ga-imv1fb-gate` from the exact
+reviewed source, commit this checklist, push the isolated branch, open the PR,
+publish exact-head deploy clearance, and route the merge-request to the merge
+authority. The deployer does not merge.


### PR DESCRIPTION
## What this changes

Two semantics-focused `gc stop` tests no longer inject arbitrary positive wall-clock limits into `cmdStop`. The force-escalation case uses the default input while preserving its interrupt, forced-stop, and exit-code assertions. The invalid-city-config case runs the stop operation asynchronously and observes completion through the package's existing hang detector, so a real hang remains bounded without turning the observation budget into product behavior.

This keeps explicit timeout ownership in the dedicated timeout tests and makes the semantic cases resilient to loaded-host scheduling delays.

## Review notes

- This is test-only; `gc stop` runtime behavior and user-visible output are unchanged.
- Dedicated wall-clock timeout tests, the justified city-runtime latency assertion, and the shared test hang budget are untouched.
- In the invalid-config error path, zero removes the arbitrary outer test override; the path may return before the normal config-derived timeout is consulted. The assertion remains about shutdown-error propagation, not the default timeout value.

## Test plan

- [x] Run both modified tests repeatedly with result caching disabled and confirm their semantic assertions pass.
- [x] Run the full `cmd/gc` process shards and the repository-wide local CI-equivalent suite.
- [x] Run policy, docs, build, vet, native-DoltLite, formatting, and affected-lint checks.
- [x] Release gate: [`release-gates/ga-imv1fb-cmd-stop-test-deflake-gate.md`](release-gates/ga-imv1fb-cmd-stop-test-deflake-gate.md)