### PR TITLE
fix(dolt): name failed databases in sync summary

### DIFF
--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -651,11 +651,9 @@ if [ -d "$data_dir" ]; then
   done
 fi
 
-# D2: the loop above uses a sticky aggregate exit_code with no record of which
-# database(s) failed or why, which reads to a caller/agent as if ALL databases
-# failed even when only one did. Name the actual failures explicitly, as the
-# last line emitted (it must survive tailForOrderFailureEvent's truncation
-# window in cmd/gc/order_dispatch.go when this runs under an order).
+# Positioned as the last line of output: an OrderFailed event built from this
+# script's output (tailForOrderFailureEvent, cmd/gc/order_dispatch.go) keeps
+# only a bounded tail, so this summary must survive that truncation window.
 if [ "$exit_code" -ne 0 ]; then
   echo "sync: $fail_count/$total_count database(s) failed: $failed_summary" >&2
 fi

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -351,11 +351,13 @@ sync_database_sql() {
   name="$1"
   if ! valid_database_name "$name"; then
     echo "  $name: ERROR: invalid database name" >&2
+    last_fail_reason="invalid database name"
     return 1
   fi
 
   remote_pair=$(find_remote_sql "$name") || {
     echo "  $name: ERROR: failed to query remotes" >&2
+    last_fail_reason="failed to query remotes"
     return 1
   }
   if [ -z "$remote_pair" ]; then
@@ -366,10 +368,11 @@ sync_database_sql() {
   remote_url=${remote_pair#*|}
   if ! valid_remote_name "$remote_name"; then
     echo "  $name: ERROR: invalid remote name: $remote_name" >&2
+    last_fail_reason="invalid remote name: $remote_name"
     return 1
   fi
 
-  refspec_pair=$(resolve_refspec_sql "$name") || return 1
+  refspec_pair=$(resolve_refspec_sql "$name") || { last_fail_reason="refspec resolution failed"; return 1; }
   local_branch=$(printf '%s\n' "$refspec_pair" | sed -n '1p')
   remote_branch=$(printf '%s\n' "$refspec_pair" | sed -n '2p')
 
@@ -386,6 +389,7 @@ sync_database_sql() {
     remote_tracking="remotes/$remote_name/$remote_branch"
     fetch_err_tmp=$(mktemp) || {
       echo "  $name: ERROR: cannot create temp file for fetch diagnostics" >&2
+      last_fail_reason="cannot create temp file for fetch diagnostics"
       return 1
     }
     fetch_rc=0
@@ -401,6 +405,7 @@ sync_database_sql() {
     elif [ "$fetch_rc" -eq 124 ]; then
       rm -f "$fetch_err_tmp"
       echo "  $name: fetch timed out after ${fetch_timeout}s — skipped (NOT pushed)" >&2
+      last_fail_reason="fetch timed out after ${fetch_timeout}s"
       return 1
     elif [ "$fetch_rc" -ne 0 ]; then
       echo "  $name: fetch failed (exit $fetch_rc) — skipped (NOT pushed)" >&2
@@ -410,6 +415,7 @@ sync_database_sql() {
         done < "$fetch_err_tmp"
       fi
       rm -f "$fetch_err_tmp"
+      last_fail_reason="fetch failed (exit $fetch_rc)"
       return 1
     else
       rm -f "$fetch_err_tmp"
@@ -455,6 +461,7 @@ sync_database_sql() {
       diverged*)  echo "  $name: $ff_status — manual reconcile" >&2 ;;
       *)          echo "  $name: skipped [$ff_status]" ;;
     esac
+    last_fail_reason="$ff_status"
     return "$ff_rc"
   fi
 
@@ -477,6 +484,7 @@ sync_database_sql() {
   # on rather than killing the run.
   push_err_tmp=$(mktemp) || {
     echo "  $name: ERROR: cannot create temp file for push diagnostics" >&2
+    last_fail_reason="cannot create temp file for push diagnostics"
     return 1
   }
   # Route push under push_timeout (not dolt_sql's 120s metadata ceiling) and
@@ -498,8 +506,10 @@ sync_database_sql() {
     # "cannot run bounded command" marker, so the stderr replay below
     # disambiguates the two at zero extra mechanism.
     echo "  $name: TIMEOUT after ${push_timeout}s — push manually or increase timeout (GC_DOLT_SYNC_PUSH_TIMEOUT_SECS)" >&2
+    last_fail_reason="TIMEOUT after ${push_timeout}s"
   else
     echo "  $name: ERROR: push failed (exit $push_rc)" >&2
+    last_fail_reason="push failed (exit $push_rc)"
   fi
 
   # Replay the captured dolt stderr, prefixed with the db name for scannable
@@ -540,10 +550,11 @@ sync_database_cli() {
   fi
   if ! valid_remote_name "$remote_name"; then
     echo "  $name: ERROR: invalid remote name: $remote_name" >&2
+    last_fail_reason="invalid remote name: $remote_name"
     return 1
   fi
 
-  refspec_pair=$(resolve_refspec_cli "$d" "$name") || return 1
+  refspec_pair=$(resolve_refspec_cli "$d" "$name") || { last_fail_reason="refspec resolution failed"; return 1; }
   local_branch=$(printf '%s\n' "$refspec_pair" | sed -n '1p')
   remote_branch=$(printf '%s\n' "$refspec_pair" | sed -n '2p')
 
@@ -575,6 +586,7 @@ sync_database_cli() {
   fi
 
   echo "  $name: ERROR: push failed (exit $cli_rc)" >&2
+  last_fail_reason="push failed (exit $cli_rc)"
   return 1
 }
 
@@ -607,6 +619,9 @@ fi
 
 # Sync each database.
 exit_code=0
+fail_count=0
+total_count=0
+failed_summary=""
 server_running=false
 is_running && server_running=true
 if [ -d "$data_dir" ]; then
@@ -620,12 +635,29 @@ if [ -d "$data_dir" ]; then
       continue
     fi
 
+    total_count=$((total_count + 1))
+    last_fail_reason=""
+    call_rc=0
     if [ "$server_running" = true ]; then
-      sync_database_sql "$name" || exit_code=1
+      sync_database_sql "$name" || call_rc=$?
     else
-      sync_database_cli "$d" "$name" || exit_code=1
+      sync_database_cli "$d" "$name" || call_rc=$?
+    fi
+    if [ "$call_rc" -ne 0 ]; then
+      exit_code=1
+      fail_count=$((fail_count + 1))
+      failed_summary="$failed_summary$name (${last_fail_reason:-unknown error}); "
     fi
   done
+fi
+
+# D2: the loop above uses a sticky aggregate exit_code with no record of which
+# database(s) failed or why, which reads to a caller/agent as if ALL databases
+# failed even when only one did. Name the actual failures explicitly, as the
+# last line emitted (it must survive tailForOrderFailureEvent's truncation
+# window in cmd/gc/order_dispatch.go when this runs under an order).
+if [ "$exit_code" -ne 0 ]; then
+  echo "sync: $fail_count/$total_count database(s) failed: $failed_summary" >&2
 fi
 
 exit $exit_code

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -31,6 +31,34 @@ func syncFilteredEnv() []string {
 	)
 }
 
+// runSync runs the sync script's CLI-mode path against a fake dolt CLI
+// already installed in binDir for the city rooted at cityPath, with extraEnv
+// appended after the standard CLI-mode env (GC_DOLT_PORT=1 so the script
+// cannot reach a SQL server and falls back to the dolt CLI), and returns
+// combined output plus the command's error so callers that must assert the
+// sync itself failed (as opposed to merely producing unexpected output) can
+// do so.
+func runSync(t *testing.T, binDir, cityPath string, extraEnv []string, args ...string) (string, error) {
+	t.Helper()
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+	dataDir := filepath.Join(cityPath, "data")
+
+	cmd := exec.Command("sh", append([]string{script}, args...)...)
+	cmd.Env = append(syncFilteredEnv(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 func startReachableTCPListener(t *testing.T) (int, func()) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -1607,9 +1635,6 @@ func TestSyncRejectsTripleZeroPushTimeout(t *testing.T) {
 // TestSyncCLIPushReportsExitCode verifies the CLI-mode plain push surfaces the
 // underlying exit code instead of a generic message (R4).
 func TestSyncCLIPushReportsExitCode(t *testing.T) {
-	root := repoRoot(t)
-	script := filepath.Join(root, syncScript)
-
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "data")
 	dbDir := filepath.Join(dataDir, "app")
@@ -1625,21 +1650,11 @@ func TestSyncCLIPushReportsExitCode(t *testing.T) {
 	writeSyncFakeDoltCLIPushFails(t, binDir, 3)
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
-	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(syncFilteredEnv(),
-		"PATH="+binDir+":"+os.Getenv("PATH"),
-		"GC_CITY_PATH="+cityPath,
-		"GC_PACK_DIR="+root,
-		"GC_DOLT_DATA_DIR="+dataDir,
-		"GC_DOLT_PORT=1",
-		"GC_DOLT_USER=root",
-		"GC_DOLT_PASSWORD=",
-	)
-	out, err := cmd.CombinedOutput()
+	out, err := runSync(t, binDir, cityPath, nil, "--db", "app")
 	if err == nil {
 		t.Fatalf("expected CLI push failure, output:\n%s", out)
 	}
-	if !strings.Contains(string(out), "ERROR: push failed (exit 3)") {
+	if !strings.Contains(out, "ERROR: push failed (exit 3)") {
 		t.Fatalf("expected CLI exit-code-3 failure message, got:\n%s", out)
 	}
 }
@@ -1693,9 +1708,6 @@ func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
 // failed". The final line must name the failing database and reason, and
 // must not claim every database failed.
 func TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes(t *testing.T) {
-	root := repoRoot(t)
-	script := filepath.Join(root, syncScript)
-
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "data")
 	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
@@ -1713,21 +1725,10 @@ func TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes(t *testing.T) {
 	writeSyncFakeDoltCLIPushFailsForDB(t, binDir, "bad", 1)
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
-	cmd := exec.Command("sh", script)
-	cmd.Env = append(syncFilteredEnv(),
-		"PATH="+binDir+":"+os.Getenv("PATH"),
-		"GC_CITY_PATH="+cityPath,
-		"GC_PACK_DIR="+root,
-		"GC_DOLT_DATA_DIR="+dataDir,
-		"GC_DOLT_PORT=1",
-		"GC_DOLT_USER=root",
-		"GC_DOLT_PASSWORD=",
-	)
-	out, err := cmd.CombinedOutput()
+	output, err := runSync(t, binDir, cityPath, nil)
 	if err == nil {
-		t.Fatalf("expected non-zero exit when one of three databases fails to push, output:\n%s", out)
+		t.Fatalf("expected non-zero exit when one of three databases fails to push, output:\n%s", output)
 	}
-	output := string(out)
 
 	if !strings.Contains(output, "good1: pushed") || !strings.Contains(output, "good2: pushed") {
 		t.Fatalf("expected both healthy databases to still push, got:\n%s", output)

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -275,6 +275,32 @@ exit 0
 	}
 }
 
+// writeSyncFakeDoltCLIPushFailsForDB installs a fake dolt for CLI-mode tests
+// that fails `dolt push` only for the named database and succeeds for every
+// other one. CLI mode runs `dolt push` with cwd set to the per-database
+// directory (`cd "$d" && dolt push ...`), so the failing db is selected by
+// $PWD's basename rather than by argv.
+func writeSyncFakeDoltCLIPushFailsForDB(t *testing.T, dir, badDB string, exitCode int) {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"push "*)
+    if [ "$(basename "$PWD")" = "` + badDB + `" ]; then
+      printf 'remote rejected push\n' >&2
+      exit ` + strconv.Itoa(exitCode) + `
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}
+
 // writeSyncFakeDoltPushEchoesArgs installs a fake dolt that, on the SQL-mode
 // DOLT_PUSH call, reports whether DOLT_CLI_PASSWORD was delivered via the
 // environment and echoes its own full argv to stderr (mimicking a dolt that
@@ -1656,5 +1682,67 @@ func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "ERROR: push failed (exit 5)") {
 		t.Fatalf("expected CLI --force exit-code-5 failure message, got:\n%s", out)
+	}
+}
+
+// TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes covers the sync command's
+// exit-code/output contract when only one database among several fails to
+// push: the sticky aggregate `exit_code` used to carry no record of which
+// database(s) failed or why, so a caller (or an OrderFailed event built from
+// this output) could misread "some databases failed" as "every database
+// failed". The final line must name the failing database and reason, and
+// must not claim every database failed.
+func TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	for _, name := range []string{"good1", "bad", "good2"} {
+		dbDir := filepath.Join(dataDir, name)
+		if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir db %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+			t.Fatalf("write remotes for %s: %v", name, err)
+		}
+	}
+
+	binDir := t.TempDir()
+	writeSyncFakeDoltCLIPushFailsForDB(t, binDir, "bad", 1)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script)
+	cmd.Env = append(syncFilteredEnv(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit when one of three databases fails to push, output:\n%s", out)
+	}
+	output := string(out)
+
+	if !strings.Contains(output, "good1: pushed") || !strings.Contains(output, "good2: pushed") {
+		t.Fatalf("expected both healthy databases to still push, got:\n%s", output)
+	}
+	if !strings.Contains(output, "bad: ERROR: push failed") {
+		t.Fatalf("expected the failing database's own error line, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "sync: 1/3 database(s) failed") {
+		t.Fatalf("expected a summary line naming exactly 1/3 failures, got:\n%s", output)
+	}
+	if !strings.Contains(output, "bad (push failed (exit 1))") {
+		t.Fatalf("expected the summary to name the failing database and reason, got:\n%s", output)
+	}
+	if strings.Contains(output, "3/3 database(s) failed") {
+		t.Fatalf("summary must not read as if every database failed, got:\n%s", output)
 	}
 }

--- a/release-gates/ga-g514cl-dolt-sync-failure-summary-gate.md
+++ b/release-gates/ga-g514cl-dolt-sync-failure-summary-gate.md
@@ -1,0 +1,47 @@
+# Release gate: Dolt sync failure summary
+
+- Deploy bead: `ga-g514cl`
+- Build bead: `ga-0uzqsf`
+- Review bead: `ga-01v8g7`
+- Reviewed source: `2e35396a6d82d9f9a5e0101e41420ff79c48c719`
+- Base: `origin/main@145cc2be9b2be3b16aedfd64fe884820a27c6d3e`
+- Deploy mode: `remote`
+- Overall result: **PASS**
+- Additional manifest criteria: none; `docs/PROJECT_MANIFEST.md` is absent at the reviewed source.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | The deploy bead contains a fresh `gascity/reviewer` verdict of PASS for the exact rewritten commit `2e35396a6d82d9f9a5e0101e41420ff79c48c719`. The reviewer verified that the rewrite changed commit messages only, preserved both tree objects, fixed the accepted bead citations, and re-ran build, vet, and package tests. |
+| 2 | Acceptance criteria met | **PASS** | D1 is already present: `03549ad968` is an ancestor of the reviewed source, so failed Order Events retain the bounded, redacted output tail. D2 is supplied here: the sync command records each failed database and emits `sync: N/M database(s) failed: name (reason)` as its last stderr line. The full-scope verbose run records `TestSyncCLIPushReportsExitCode` PASS and `TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes` PASS. |
+| 3 | Tests pass | **PASS** | `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 GOFLAGS=-v make test-local-full-parallel`; `test_cmd_scope: full-suite`. Rootless Podman 5.8.4 was reachable and `docker.io/dolthub/dolt-sql-server:2.2.0` was cached before the run. Result: 31/40 jobs PASS, 9/40 jobs raw FAIL, 0 skipped jobs; 45,540 top-level test executions PASS, 10 raw FAIL, 187 SKIP. Every raw failure is attributed below to a predating tracker. `diff_tests_executed: TestSyncCLIPushReportsExitCode PASS; TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes PASS`. |
+| 3a | Pre-existing failures may be attributed | **PASS** | All failing test files are outside the two changed paths. The failing test sources contain no reference to `commands/sync/run.sh`; the fixture failures occur in `bd init` before any sync order runs. Exact trackers, mechanism proofs, and raw dispositions are recorded below and appended to the trackers. |
+| 3b | Policy/lint lane | **PASS** | PASS: `go build ./...`, `go vet ./...`, `make test-ci-policy`, `make check-gomod-replace`, `make check-eventexport-isolation`, `make check-core-boundary`, `make check-docs`, `make test-native-doltlite-beads`, and changed-scope `make fmt-check-changed`. Raw `make lint-affected` FAIL is attributed to `ga-u8z8j6`: an isolated-cache rerun widened to the full repository because a newer workflow is absent from this reviewed head, then found only three vendored `node_modules/flatted` findings. Raw `make check-native-dependency-surface` FAIL at 270,285,336 bytes is attributed to `ga-5flk3r`; current `origin/main` independently fails the same 270,000,000-byte ceiling at 270,267,744 bytes. |
+| 4 | No unresolved high-severity review findings | **PASS** | Fresh reviewer verdict says “No blockers found.” Unresolved HIGH findings: 0. |
+| 5 | Final branch clean | **PASS** | `git status --short` was empty at the reviewed source before this gate artifact was added. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree origin/main 2e35396a6d82d9f9a5e0101e41420ff79c48c719` exited 0 and produced tree `8321ea2c29a1a103b55b5560f71fe47ef685d7cc`. No self-rebase was needed. Preflight found no PR carrying the reviewed commit. |
+| 7 | Single feature theme | **PASS** | Three commits modify only `examples/bd/dolt/commands/sync/run.sh` and `examples/bd/dolt/sync_test.go`: one operator-facing failure-summary behavior and its tests/refactor. |
+
+## Full-suite failure attribution
+
+All four attribution clauses pass for each entry: the test is not diff-owned; the cited tracker predates this run and covers the exact signature; the failing path does not execute the changed sync command; and neither changed path overlaps the failing test package.
+
+| Raw failing test(s) | Tracker | Proof and disposition |
+|---|---|---|
+| `TestProviderLiveClaudeKindPath` | `ga-fh1flg` | Clause 3(a), exact `agent_pane_busy` / startup-delivery signature in `internal/runtime/herdr`; `waiver_ref: mayor-2026-08-20-herdr-pane-standing`. |
+| `TestBdFlagManifestCurrent` | `ga-f0uceo` | Clause 3(a), installed `bd` exposes flags absent from the source manifest; candidate cannot change the installed binary or `internal/bdflags`. |
+| `TestGetKeyBinding_CapturesDefaultBinding`, `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `ga-afqddr` | Clause 3(a), host tmux 3.7b returns the tracked empty filtered default-binding result. |
+| `TestPersonalWorkFormulaCompileAndRun`, `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries`, `TestAdoptPRFormulaRetriesTransientReviewerStep`, `TestGCLiveContract_BeadsAndEvents` | `ga-lpfjhc` | Exact `gastownhall/beads#4566` dirty-table schema-migration signatures during fixture `bd init`; raw FAIL preserved as FAIL-WAIVED under standing authorization `ga-6bnc42`. |
+| `TestCleanInstallTutorialPath` | `ga-z08s5l` | Clause 3(a), tracked Dolt TCP read timeout followed by database-existence `invalid connection` during fixture bootstrap. The same shard passed in the immediately preceding full-scope run. |
+| `TestE2E_SuspendResume_City` | `ga-yc0e3a` | Clause 3(a), tracked timeout waiting for `citysus.report`; the sync command is not executed by suspend/resume. |
+
+The immediately preceding non-verbose run used the same full scope and recorded 35/40 jobs PASS and five raw failing jobs. It additionally observed the tracked `TestSessionReconcilerTraceGH1654WorkRequestedStartCandidates` async-start timeout (`ga-hgjlhi`); all six `cmd/gc` process shards passed in the authoritative verbose rerun.
+
+## Skip justification
+
+The 187 top-level skips are pre-existing platform, live-infrastructure, opt-in, helper-process, or environment gates spread across unrelated packages. Neither diff-owned test skipped; both executed and passed by name. No skip waiver is needed for the candidate.
+
+## Ancestry and scope
+
+`assert_deploy_ancestry_scope origin/main 2e35396a6d82d9f9a5e0101e41420ff79c48c719 ga-g514cl ga-0uzqsf ga-01v8g7` exited 0. The rewritten commits now cite accepted bead `ga-0uzqsf`, and the deploy range introduces no `.claude/**` path.


### PR DESCRIPTION
## What this changes

`gc dolt sync` now ends a partially failed run with a concise summary that names each database that failed and why. Healthy databases still sync, while operators and failed Order Events can distinguish a one-database failure from a total outage without searching supervisor logs.

For example, a run where one of three pushes fails ends with `sync: 1/3 database(s) failed: bad (push failed (exit 1));`.

## Review notes

- Failure aggregation is keyed to each database sync call's return code; the reason string is diagnostic data, not the success signal.
- The summary is written last so it remains inside the bounded output tail captured for a failed Order Event.
- Successful runs keep their existing output. Remote selection, divergence handling, and push behavior are unchanged.

## Test plan

- [x] Run the full local CI-equivalent suite with the rootless container runtime enabled; confirm both modified sync tests execute and pass by name.
- [x] Verify a three-database fixture continues both healthy pushes, returns non-zero, and names only the failed database and reason in the final summary.
- [x] Run build, vet, CI policy, module-boundary, documentation, native-DoltLite, and changed-format checks.
- [x] Release gate: [`release-gates/ga-g514cl-dolt-sync-failure-summary-gate.md`](release-gates/ga-g514cl-dolt-sync-failure-summary-gate.md)