### PR TITLE
fix(graphroute): make the pool continuation group a formula opt-in

### DIFF
--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -26,11 +26,6 @@ const (
 	GraphExecutionRigContextMetaKey = beadmeta.ExecutionRigContextMetadataKey
 )
 
-// poolWorkflowContinuationGroup is the continuation group value stamped on
-// pool-routed graph.v2 steps so preassignHookContinuationGroup keeps all steps
-// of a molecule on the same pool slot (fixes #2978).
-const poolWorkflowContinuationGroup = "pool-workflow"
-
 // AgentResolver resolves an agent name to a config.Agent.
 type AgentResolver interface {
 	ResolveAgent(cfg *config.City, name, rigContext string) (config.Agent, bool)
@@ -189,11 +184,19 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 	}
 	step.Metadata[beadmeta.RoutedToMetadataKey] = binding.QualifiedName
 	if binding.MetadataOnly {
-		// Pool-routed step: stamp continuation group so preassignHookContinuationGroup
-		// pre-assigns all molecule steps to the claiming slot, preventing scatter
-		// across pool slots (fixes #2978).
-		step.Metadata[beadmeta.ContinuationGroupMetadataKey] = poolWorkflowContinuationGroup
-		step.Metadata[beadmeta.SessionAffinityMetadataKey] = "require"
+		// Pool-routed step: the pool decides which slot runs it. Whether the
+		// molecule's steps must share one slot is the formula's call, declared as
+		// a continuation group; preassignHookContinuationGroup then pins the
+		// siblings to whichever slot claims first (#2978). Stamping a group here
+		// instead would apply that judgment to every pool-routed molecule whether
+		// its formula asked for it or not — a routing decision Go is not entitled
+		// to make. Affinity tracks the group so a re-decorated step never keeps a
+		// requirement its current binding no longer declares.
+		if strings.TrimSpace(step.Metadata[beadmeta.ContinuationGroupMetadataKey]) != "" {
+			step.Metadata[beadmeta.SessionAffinityMetadataKey] = "require"
+		} else {
+			delete(step.Metadata, beadmeta.SessionAffinityMetadataKey)
+		}
 		step.Assignee = ""
 		return
 	}

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -1117,27 +1117,57 @@ func TestApplyGraphControlRouteBinding_ClearsStaleFallbackMetadata(t *testing.T)
 	}
 }
 
-func TestApplyGraphRouteBinding_PoolRouted_StampsContinuationGroup(t *testing.T) {
-	step := &formula.RecipeStep{
-		Metadata: map[string]string{},
+// Pinning a molecule's steps to one pool slot is the formula's decision, so
+// routing only honors a continuation group the formula already declared. It
+// must never manufacture one: a blanket group made every pool-routed molecule
+// single-slot, and on multi-agent formulas it pinned steps to a slot whose
+// template could not run them.
+func TestApplyGraphRouteBinding_PoolRouted_ContinuationGroupIsFormulaOptIn(t *testing.T) {
+	tests := []struct {
+		name       string
+		metadata   map[string]string
+		wantGroup  string
+		wantAffini string
+	}{
+		{
+			name:     "no declared group leaves the step unpinned",
+			metadata: map[string]string{},
+		},
+		{
+			name:       "declared group requires slot affinity",
+			metadata:   map[string]string{"gc.continuation_group": "review-chain"},
+			wantGroup:  "review-chain",
+			wantAffini: "require",
+		},
+		{
+			name: "re-decoration drops affinity when the group is gone",
+			metadata: map[string]string{
+				"gc.session_affinity": "require",
+			},
+		},
 	}
-	binding := GraphRouteBinding{
-		QualifiedName: "gascity/polecat",
-		MetadataOnly:  true,
-	}
-	ApplyGraphRouteBinding(step, binding)
 
-	if got := step.Metadata["gc.continuation_group"]; got != "pool-workflow" {
-		t.Errorf("gc.continuation_group = %q, want pool-workflow", got)
-	}
-	if got := step.Metadata["gc.session_affinity"]; got != "require" {
-		t.Errorf("gc.session_affinity = %q, want require", got)
-	}
-	if got := step.Metadata["gc.routed_to"]; got != "gascity/polecat" {
-		t.Errorf("gc.routed_to = %q, want gascity/polecat", got)
-	}
-	if step.Assignee != "" {
-		t.Errorf("Assignee = %q, want empty (pool slots claim at runtime)", step.Assignee)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &formula.RecipeStep{Metadata: tt.metadata}
+			ApplyGraphRouteBinding(step, GraphRouteBinding{
+				QualifiedName: "gascity/polecat",
+				MetadataOnly:  true,
+			})
+
+			if got := step.Metadata["gc.continuation_group"]; got != tt.wantGroup {
+				t.Errorf("gc.continuation_group = %q, want %q", got, tt.wantGroup)
+			}
+			if got := step.Metadata["gc.session_affinity"]; got != tt.wantAffini {
+				t.Errorf("gc.session_affinity = %q, want %q", got, tt.wantAffini)
+			}
+			if got := step.Metadata["gc.routed_to"]; got != "gascity/polecat" {
+				t.Errorf("gc.routed_to = %q, want gascity/polecat", got)
+			}
+			if step.Assignee != "" {
+				t.Errorf("Assignee = %q, want empty (pool slots claim at runtime)", step.Assignee)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

`ApplyGraphRouteBinding` stamped `gc.continuation_group="pool-workflow"` plus `gc.session_affinity="require"` on **every** pool-routed step (added in #3405, `40ae2d69e8`). That is a routing-layer decision imposed on molecules whose formula never asked for one.

The pin binds all of a molecule's steps to whichever slot claims the first sibling. For a formula that routes steps to *different* agent templates — `mol-adopt-pr-v2` puts `apply-fixes` on a worker slot and `quality-scorecard` on a reviewer slot — successors get assigned to a slot that cannot run them, and the molecule stalls with ready work nobody claims.

Whether a molecule's steps must share one slot is the **formula's** call, and formulas already declare it: `mol-scoped-work` stamps the group and the affinity in its own TOML, and formula compilation preserves the key. So this requires the declaration instead of inventing one:

- group declared → `gc.session_affinity=require` (unchanged behavior for opt-in formulas)
- no group → affinity is **deleted**, not stamped

Affinity now *tracks* the group, including on re-decoration, so a step never keeps a requirement its current binding no longer declares. A step with no declared group stays unassigned and is claimed off the ordinary unassigned tier by any slot matching its route — the path that works today.

The now-unused `poolWorkflowContinuationGroup = "pool-workflow"` const is deleted.

## Why now

Live in maintainer-city: 25 open + 3 in_progress graph beads carried the blanket pin across **13 distinct slot labels**, and 7 molecules were stalled at a ready, pinned-to-nobody frontier step. Root `…228624` is the cross-template case in the wild — children pinned to both `gascity--gc__implementation-reviewer-4-pool` and `gascity--gc__run-operator-4-pool` under one blanket group.

## Note for reviewers

`release-gates/ga-39tsop-pool-step-slot-affinity-gate.md` records the old blanket-stamp behavior. It is left as-is: a historical record of what shipped, not a spec this change violates.

## Tests

`go test ./internal/graphroute/` PASS · `go vet ./...` clean · full pre-commit hook (lint-changed 0 issues, genspec/genschema) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2978 — narrows the blanket pool continuation-group pin that was added for that issue so it applies only to formulas that declare the group themselves, which unblocks multi-agent molecules whose steps were pinned to a slot that could not run them; it is not a fix for the filed report — pool-routed molecules with no declared group are left unpinned, so the cross-slot scatter described there can still occur for them
- Related to #5583 — removes the blanket continuation-group/session-affinity stamp in ApplyGraphRouteBinding so a pool-routed step is only pinned when its formula declares a group — which covers the repro in that issue, where no group is declared; it does not add the lifecycle awareness that issue proposes, so a one_shot pool running a formula that does declare a group can still pin a successor step to a session that has already exited

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->