### PR TITLE
Fix Dolt compact notification cadence

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -85,6 +85,15 @@
 #   GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS
 #     (default: 172800) — maximum age for automatic pending remote-push retry.
 #                       Older markers require manual review before push.
+#   GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS
+#     (default: 86400) — once a quarantine, pending-push, or pending-gc
+#                       marker has mailed an alert for an unchanged reason,
+#                       suppress repeat mail until this many seconds have
+#                       elapsed since the last notification, then send
+#                       exactly one more. Set to 0 to restore
+#                       notify-once-per-reason-forever (the marker never
+#                       re-mails on its own once a given reason has been
+#                       reported, even if left unresolved indefinitely).
 #   GC_DOLT_COMPACT_REMOTE               (optional) — remote to fetch/push.
 #                                         Defaults to origin when present;
 #                                         ambiguous multi-remote stores fail.
@@ -303,6 +312,7 @@ threshold_commits="${GC_DOLT_COMPACT_THRESHOLD_COMMITS:-2000}"
 call_timeout="${GC_DOLT_COMPACT_CALL_TIMEOUT_SECS:-1800}"
 push_timeout="${GC_DOLT_COMPACT_PUSH_TIMEOUT_SECS:-120}"
 pending_push_max_age_secs="${GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS:-172800}"
+compact_renotify_backstop_secs="${GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS:-86400}"
 compact_remote="${GC_DOLT_COMPACT_REMOTE:-}"
 dry_run="${GC_DOLT_COMPACT_DRY_RUN:-}"
 only_dbs="${GC_DOLT_COMPACT_ONLY_DBS:-}"
@@ -379,6 +389,14 @@ case "$pending_push_max_age_secs" in
   ''|*[!0-9]*)
     printf 'compact: invalid GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS=%s (must be a non-negative integer)\n' \
       "$pending_push_max_age_secs" >&2
+    exit 2
+    ;;
+esac
+
+case "$compact_renotify_backstop_secs" in
+  ''|*[!0-9]*)
+    printf 'compact: invalid GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS=%s (must be a non-negative integer)\n' \
+      "$compact_renotify_backstop_secs" >&2
     exit 2
     ;;
 esac
@@ -1485,10 +1503,14 @@ write_compact_marker() {
   fi
   if [ "$dir" = "$quarantine_dir" ]; then
     emit_compact_quarantine_event "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at"
-    if mail_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at"; then
-      record_quarantine_notify_state "$db" "$reason" 1
+    if marker_should_notify "$quarantine_dir" "$db" "$reason" "$compact_renotify_backstop_secs"; then
+      if mail_compact_quarantine_alert "$db" "compact-quarantine" "$marker_path" "$reason" "$created_at"; then
+        record_marker_notify_state "$quarantine_dir" "$db" "$reason" 1
+      else
+        record_marker_notify_state "$quarantine_dir" "$db" "$reason" 0
+      fi
     else
-      record_quarantine_notify_state "$db" "$reason" 0
+      record_marker_notify_state "$quarantine_dir" "$db" "$reason" 0
     fi
   fi
   return 0
@@ -1517,91 +1539,111 @@ mail_compact_quarantine_alert() {
   return 1
 }
 
-send_compact_quarantine_alert() {
-  emit_compact_quarantine_event "$@"
-  mail_compact_quarantine_alert "$@"
+# marker_should_notify DIR DB REASON BACKSTOP_SECS
+#   Fail-open dedup+backstop check: EMIT (return 0) unless DIR/DB's marker
+#   last_notified_reason already matches REASON exactly AND fewer than
+#   BACKSTOP_SECS have elapsed since last_notified_ts. A missing/unreadable
+#   marker, a marker never notified before, a changed reason, or a
+#   missing/unparseable last_notified_ts all emit — this must never wrongly
+#   suppress a real alert. BACKSTOP_SECS<=0 disables the backstop re-notify
+#   (dedup holds forever once a reason has been notified, matching the
+#   original notify-once-per-distinct-state contract). Shared by quarantine,
+#   pending-push, and pending-gc markers — they carry the same
+#   seen_count/notify_count/last_notified_ts/last_notified_reason shape.
+#   Mirrors the notify-once-per-distinct-state marker shape in
+#   gc-management's packs/maintainer-pr-review/scripts/hold-notice-lib.sh,
+#   extended with a time backstop so an unresolved condition cannot go
+#   silent forever.
+marker_should_notify() {
+  _mn_dir="$1"
+  _mn_db="$2"
+  _mn_reason="$3"
+  _mn_backstop_secs="$4"
+
+  _mn_marker=$(compact_marker_path "$_mn_dir" "$_mn_db")
+  [ -f "$_mn_marker" ] && [ -r "$_mn_marker" ] || return 0
+
+  _mn_prev_reason=$(compact_marker_value "$_mn_dir" "$_mn_db" last_notified_reason || true)
+  [ -n "$_mn_prev_reason" ] || return 0
+  [ "$_mn_prev_reason" = "$_mn_reason" ] || return 0
+
+  [ "$_mn_backstop_secs" -gt 0 ] 2>/dev/null || return 1
+
+  _mn_last_ts=$(compact_marker_value "$_mn_dir" "$_mn_db" last_notified_ts || true)
+  _mn_last_epoch=$(parse_compact_timestamp "$_mn_last_ts" || true)
+  [ -n "$_mn_last_epoch" ] || return 0
+
+  _mn_now_epoch=$(date -u +%s)
+  _mn_age=$(( _mn_now_epoch - _mn_last_epoch ))
+  [ "$_mn_age" -lt 0 ] && _mn_age=0
+  [ "$_mn_age" -ge "$_mn_backstop_secs" ] && return 0
+  return 1
 }
 
-# quarantine_should_notify DB REASON
-#   Fail-open dedup check: EMIT (return 0) unless the quarantine marker's
-#   last_notified_reason already matches REASON, meaning a mail already went
-#   out for this exact quarantine state. A missing marker, missing field, or
-#   unreadable marker always emits — this must never wrongly suppress a real
-#   alert. Mirrors the notify-once-per-distinct-state marker shape in
-#   gc-management's packs/maintainer-pr-review/scripts/hold-notice-lib.sh.
-quarantine_should_notify() {
-  db="$1"
-  reason="$2"
-  _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
-  [ -f "$_qn_marker" ] && [ -r "$_qn_marker" ] || return 0
-  _qn_prev_reason=$(compact_marker_value "$quarantine_dir" "$db" last_notified_reason || true)
-  [ -n "$_qn_prev_reason" ] || return 0
-  [ "$_qn_prev_reason" = "$reason" ] && return 1
-  return 0
-}
-
-# record_quarantine_notify_state DB REASON EMITTED
+# record_marker_notify_state DIR DB REASON EMITTED
 #   Patches only the notify-bookkeeping fields (seen_count, notify_count,
-#   last_notified_ts, last_notified_reason) onto DB's existing quarantine
-#   marker, preserving every other field byte-for-byte. EMITTED=1 bumps
+#   last_notified_ts, last_notified_reason) onto DB's existing marker in
+#   DIR, preserving every other field byte-for-byte. EMITTED=1 bumps
 #   notify_count and stamps last_notified_ts/last_notified_reason; EMITTED=0
 #   only bumps seen_count. A missing marker or write failure is a silent
 #   no-op — bookkeeping must never block or fail compaction.
-record_quarantine_notify_state() {
-  db="$1"
-  reason="$2"
-  _qn_emitted="$3"
+record_marker_notify_state() {
+  _mn_dir="$1"
+  _mn_db="$2"
+  _mn_reason="$3"
+  _mn_emitted="$4"
 
-  _qn_marker=$(compact_marker_path "$quarantine_dir" "$db")
-  [ -f "$_qn_marker" ] && [ -r "$_qn_marker" ] || return 0
+  _mn_marker=$(compact_marker_path "$_mn_dir" "$_mn_db")
+  [ -f "$_mn_marker" ] && [ -r "$_mn_marker" ] || return 0
 
-  _qn_seen_count=$(compact_marker_value "$quarantine_dir" "$db" seen_count || true)
-  case "$_qn_seen_count" in ''|*[!0-9]*) _qn_seen_count=0 ;; esac
-  _qn_seen_count=$((_qn_seen_count + 1))
+  _mn_seen_count=$(compact_marker_value "$_mn_dir" "$_mn_db" seen_count || true)
+  case "$_mn_seen_count" in ''|*[!0-9]*) _mn_seen_count=0 ;; esac
+  _mn_seen_count=$((_mn_seen_count + 1))
 
-  _qn_notify_count=$(compact_marker_value "$quarantine_dir" "$db" notify_count || true)
-  case "$_qn_notify_count" in ''|*[!0-9]*) _qn_notify_count=0 ;; esac
-  _qn_last_ts=$(compact_marker_value "$quarantine_dir" "$db" last_notified_ts || true)
-  _qn_last_reason=$(compact_marker_value "$quarantine_dir" "$db" last_notified_reason || true)
-  if [ "$_qn_emitted" = "1" ]; then
-    _qn_notify_count=$((_qn_notify_count + 1))
-    _qn_last_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    _qn_last_reason="$reason"
+  _mn_notify_count=$(compact_marker_value "$_mn_dir" "$_mn_db" notify_count || true)
+  case "$_mn_notify_count" in ''|*[!0-9]*) _mn_notify_count=0 ;; esac
+  _mn_last_ts=$(compact_marker_value "$_mn_dir" "$_mn_db" last_notified_ts || true)
+  _mn_last_reason=$(compact_marker_value "$_mn_dir" "$_mn_db" last_notified_reason || true)
+  if [ "$_mn_emitted" = "1" ]; then
+    _mn_notify_count=$((_mn_notify_count + 1))
+    _mn_last_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    _mn_last_reason="$_mn_reason"
   fi
 
-  _qn_old_umask=$(umask)
+  _mn_old_umask=$(umask)
   umask 077
-  _qn_tmp=$(mktemp "$quarantine_dir/$db.tmp.XXXXXX") || {
-    umask "$_qn_old_umask"
+  _mn_tmp=$(mktemp "$_mn_dir/$_mn_db.tmp.XXXXXX") || {
+    umask "$_mn_old_umask"
     return 0
   }
-  umask "$_qn_old_umask"
-  if ! awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_qn_marker" > "$_qn_tmp" 2>/dev/null; then
-    rm -f "$_qn_tmp"
+  umask "$_mn_old_umask"
+  if ! awk '!/^(seen_count|notify_count|last_notified_ts|last_notified_reason)=/' "$_mn_marker" > "$_mn_tmp" 2>/dev/null; then
+    rm -f "$_mn_tmp"
     return 0
   fi
   if ! {
-    printf 'seen_count=%s\n' "$_qn_seen_count"
-    printf 'notify_count=%s\n' "$_qn_notify_count"
-    printf 'last_notified_ts=%s\n' "$_qn_last_ts"
-    printf 'last_notified_reason=%s\n' "$_qn_last_reason"
-  } >> "$_qn_tmp" 2>/dev/null; then
-    rm -f "$_qn_tmp"
+    printf 'seen_count=%s\n' "$_mn_seen_count"
+    printf 'notify_count=%s\n' "$_mn_notify_count"
+    printf 'last_notified_ts=%s\n' "$_mn_last_ts"
+    printf 'last_notified_reason=%s\n' "$_mn_last_reason"
+  } >> "$_mn_tmp" 2>/dev/null; then
+    rm -f "$_mn_tmp"
     return 0
   fi
-  if ! grep -q '^db=' "$_qn_tmp" 2>/dev/null; then
-    rm -f "$_qn_tmp"
+  if ! grep -q '^db=' "$_mn_tmp" 2>/dev/null; then
+    rm -f "$_mn_tmp"
     return 0
   fi
-  mv -f "$_qn_tmp" "$_qn_marker" || rm -f "$_qn_tmp"
+  mv -f "$_mn_tmp" "$_mn_marker" || rm -f "$_mn_tmp"
   return 0
 }
 
 # report_existing_quarantine DB
 #   Diagnostic + alert path for a compact/bare-gc invocation that hit an
 #   already-quarantined database. The event still fires every cycle; the
-#   mail is gated by quarantine_should_notify so a stable quarantine reason
-#   pages once instead of on every subsequent run.
+#   mail is gated by marker_should_notify so a stable quarantine reason
+#   pages on discovery and then again only after the renotify backstop
+#   elapses, instead of once ever or on every single cycle.
 report_existing_quarantine() {
   db="$1"
   quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
@@ -1612,12 +1654,14 @@ report_existing_quarantine() {
   emit_compact_quarantine_event "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"
 
   quarantine_alert_emitted=0
-  if quarantine_should_notify "$db" "${quarantine_reason:-<unknown>}"; then
-    if mail_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}"; then
+  if marker_should_notify "$quarantine_dir" "$db" "${quarantine_reason:-<unknown>}" "$compact_renotify_backstop_secs"; then
+    quarantine_seen_count=$(compact_marker_value "$quarantine_dir" "$db" seen_count || true)
+    case "$quarantine_seen_count" in ''|*[!0-9]*) quarantine_seen_count=0 ;; esac
+    if mail_compact_quarantine_alert "$db" "compact-quarantine" "$quarantine_marker" "${quarantine_reason:-<unknown>} seen=$((quarantine_seen_count + 1))" "${quarantine_created_at:-<unknown>}"; then
       quarantine_alert_emitted=1
     fi
   fi
-  record_quarantine_notify_state "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted"
+  record_marker_notify_state "$quarantine_dir" "$db" "${quarantine_reason:-<unknown>}" "$quarantine_alert_emitted"
 }
 
 ensure_compact_marker_writable() {
@@ -1755,20 +1799,36 @@ write_quarantine_marker() {
     "$@"
 }
 
-compact_marker_created_at_epoch() {
-  dir="$1"
-  db="$2"
-  created_at=$(compact_marker_value "$dir" "$db" created_at || true)
-  [ -n "$created_at" ] || return 1
-  case "$created_at" in
+# parse_compact_timestamp TIMESTAMP
+#   Parses a UTC "%Y-%m-%dT%H:%M:%SZ" marker timestamp field to epoch
+#   seconds, trying GNU date then BSD date. Empty or non-timestamp-charset
+#   input fails without invoking date.
+parse_compact_timestamp() {
+  _pt_ts="$1"
+  [ -n "$_pt_ts" ] || return 1
+  case "$_pt_ts" in
     *[!0-9TZ:.-]*)
       return 1
       ;;
   esac
-  date -u -d "$created_at" +%s 2>/dev/null ||
-    date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$created_at" +%s 2>/dev/null
+  date -u -d "$_pt_ts" +%s 2>/dev/null ||
+    date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$_pt_ts" +%s 2>/dev/null
 }
 
+compact_marker_created_at_epoch() {
+  dir="$1"
+  db="$2"
+  created_at=$(compact_marker_value "$dir" "$db" created_at || true)
+  parse_compact_timestamp "$created_at"
+}
+
+# ensure_remote_push_retry_fresh DIR DB MARKER_LABEL
+#   Gates an automatic remote-push retry on marker age: markers older than
+#   pending_push_max_age_secs fail the retry and alert. The alert event
+#   fires every cycle; the alert mail is gated by marker_should_notify so
+#   an unresolved stale marker pages on first detection and then again only
+#   after the renotify backstop elapses, instead of on every single cycle
+#   (previously: unconditional mail on every invocation past max-age).
 ensure_remote_push_retry_fresh() {
   dir="$1"
   db="$2"
@@ -1788,7 +1848,22 @@ ensure_remote_push_retry_fresh() {
   if [ "$age_secs" -gt "$pending_push_max_age_secs" ]; then
     printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss — manual review required before remote push retry\n' \
       "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" >&2
-    send_compact_quarantine_alert "$db" "$(basename "$dir")" "$(compact_marker_path "$dir" "$db")" "$marker_label marker is stale" "$(compact_marker_value "$dir" "$db" created_at || true)" || true
+    stale_reason="$marker_label marker is stale"
+    stale_marker_path=$(compact_marker_path "$dir" "$db")
+    stale_marker_type=$(basename "$dir")
+    stale_created_at=$(compact_marker_value "$dir" "$db" created_at || true)
+    emit_compact_quarantine_event "$db" "$stale_marker_type" "$stale_marker_path" "$stale_reason" "$stale_created_at"
+    if marker_should_notify "$dir" "$db" "$stale_reason" "$compact_renotify_backstop_secs"; then
+      stale_seen_count=$(compact_marker_value "$dir" "$db" seen_count || true)
+      case "$stale_seen_count" in ''|*[!0-9]*) stale_seen_count=0 ;; esac
+      if mail_compact_quarantine_alert "$db" "$stale_marker_type" "$stale_marker_path" "$stale_reason age=${age_secs}s seen=$((stale_seen_count + 1))" "$stale_created_at"; then
+        record_marker_notify_state "$dir" "$db" "$stale_reason" 1
+      else
+        record_marker_notify_state "$dir" "$db" "$stale_reason" 0
+      fi
+    else
+      record_marker_notify_state "$dir" "$db" "$stale_reason" 0
+    fi
     return 1
   fi
   return 0

--- a/examples/bd/dolt/compact_notify_cadence_test.go
+++ b/examples/bd/dolt/compact_notify_cadence_test.go
@@ -1,0 +1,103 @@
+package dolt_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle pins the
+// "too loud" half of ga-0fdnyn: a stale pending-push marker that stays
+// unresolved across repeated compact cycles must not page the operator on
+// every single cycle. Previously ensure_remote_push_retry_fresh had no
+// dedup at all, so an unresolved marker sent one identical mail per compact
+// invocation (observed in production: 40 mails for one unchanged my_db
+// marker). The event still fires every cycle so automation keeps observing
+// each check; only the mail is gated.
+func TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
+	resetCompactGCLog(t, fixture)
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", secondOut)
+	}
+	thirdOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", thirdOut)
+	}
+
+	log := readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 1 {
+		t.Fatalf("two stale-pending-push retry cycles over an unresolved marker should send exactly one operator mail, got %d\nlog:\n%s", len(mailLines), log)
+	}
+	if !strings.Contains(mailLines[0], "seen=") {
+		t.Fatalf("stale-marker alert should carry dynamic context (e.g. seen count) so operators can gauge how long it has persisted\nline:\n%s\nlog:\n%s", mailLines[0], log)
+	}
+	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
+	if len(eventLines) != 2 {
+		t.Fatalf("each stale-pending-push retry cycle should still emit an event even when the mail is suppressed, got %d\nlog:\n%s", len(eventLines), log)
+	}
+}
+
+// TestCompactScriptQuarantineRenotifiesAfterBackstopElapses pins the "too
+// quiet" half of ga-0fdnyn: an unresolved quarantine with an UNCHANGED
+// reason must still page again once the renotify backstop elapses.
+// Previously quarantine_should_notify deduped on exact reason match with no
+// time backstop, so a real, still-unresolved integrity failure was reported
+// exactly once and then silently ignored forever (observed in production:
+// gascity marker seen_count=26, notify_count=1). This must not regress
+// TestCompactScriptQuarantineReasonChangeReMails (a changed reason still
+// re-mails immediately, independent of the backstop) or
+// TestCompactScriptExistingQuarantineMarkerAlertsOnceAcrossRepeatedCycles
+// (an unchanged reason within the backstop window still dedups).
+func TestCompactScriptQuarantineRenotifiesAfterBackstopElapses(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact succeeded despite row-count decrease:\n%s", firstOut)
+	}
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("second compact succeeded despite quarantine:\n%s", secondOut)
+	}
+
+	log := readCompactGCLog(t, fixture)
+	if mailLines := compactGCLogLinesWithPrefix(log, "gc mail send "); len(mailLines) != 1 {
+		t.Fatalf("dedup should be established after two cycles, want 1 mail, got %d\nlog:\n%s", len(mailLines), log)
+	}
+
+	// Force the backstop to have elapsed by backdating the marker's own
+	// notify bookkeeping, matching the file's existing convention of aging
+	// marker fields directly rather than faking the clock.
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	replaceCompactMarkerField(t, marker, "last_notified_ts", "2000-01-01T00:00:00Z")
+
+	thirdOut, err := fixture.run(t, "below_threshold")
+	if err == nil {
+		t.Fatalf("third compact succeeded despite quarantine:\n%s", thirdOut)
+	}
+
+	log = readCompactGCLog(t, fixture)
+	mailLines := compactGCLogLinesWithPrefix(log, "gc mail send ")
+	if len(mailLines) != 2 {
+		t.Fatalf("quarantine must re-notify once the renotify backstop elapses, want 2 mails, got %d\nlog:\n%s", len(mailLines), log)
+	}
+	if !strings.Contains(mailLines[1], "reason=post-flatten row count decreased") {
+		t.Fatalf("backstop re-notify should still carry the original, unchanged reason\nline:\n%s\nlog:\n%s", mailLines[1], log)
+	}
+	if !strings.Contains(mailLines[1], "seen=") {
+		t.Fatalf("repeat notification should carry dynamic context (e.g. seen count) distinguishing it from the first alert\nline:\n%s\nlog:\n%s", mailLines[1], log)
+	}
+	eventLines := compactGCLogLinesWithPrefix(log, "gc event emit dolt.compact.quarantine")
+	if len(eventLines) != 3 {
+		t.Fatalf("each compact cycle should still emit a dolt.compact.quarantine event even when the mail is suppressed, got %d\nlog:\n%s", len(eventLines), log)
+	}
+}

--- a/release-gates/ga-6dgrtc-dolt-compact-notification-cadence-gate.md
+++ b/release-gates/ga-6dgrtc-dolt-compact-notification-cadence-gate.md
@@ -1,0 +1,64 @@
+# Release gate: Dolt compact notification cadence
+
+- Deploy bead: `ga-6dgrtc`
+- Build bead: `ga-0fdnyn`
+- Reviewed source: `b764a390f99c519c11b5fdc53119ec39d4c6113d`
+- Base evaluated: `origin/main@7e72e01ab00974f43ebc7695767e2290deda3662`
+- Deploy mode: `remote`
+- Result: **PASS**
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `gascity/reviewer` recorded a full PASS pinned to the exact reviewed source SHA. |
+| 2 | Acceptance criteria met | **PASS** | Unchanged quarantine reasons now re-notify only after the configurable backstop, changed reasons still notify immediately, and stale pending-push/pending-GC alerts share the same marker-state deduplication. Alert reasons include `seen` and `age` context. Both new tests and all nine named regression tests passed in the full-suite output. |
+| 3 | Tests pass | **PASS with attributed failures and one authorized waiver** | The documented 40-job CI-equivalent union completed 34 job PASS / 6 job FAIL. Test-level results were **46,675 PASS / 6 FAIL / 188 SKIP**. Both diff-owned tests passed twice. All six raw failures are preserved and resolved below; none is diff-owned. |
+| 3a | Pre-existing failures attributable | **PASS** | Five failures have predating trackers plus exact-base/cross-PR or structural mechanism evidence and no path overlap. The sixth is the exact Beads #4566 signature covered by the mayor's standing authorization `ga-6bnc42`; it remains **FAIL-WAIVED** and was logged on `ga-lpfjhc` as required. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy`, `go vet ./...`, `make lint-affected LINT_BASE=origin/main`, `git diff --check origin/main...HEAD`, `gofmt -l` on the added test, and `bash -n` on the changed script all passed. The affected-lint target reported no lintable changed production package; full-repo vet covered the Go change. |
+| 4 | No high-severity review findings open | **PASS** | Reviewer reported no blocking or HIGH finding; only a non-blocking warning that open PR #5493 will require textual reconciliation if it lands later. |
+| 5 | Final branch clean | **PASS** | The reviewed source worktree was clean at `b764a390f99c519c11b5fdc53119ec39d4c6113d` before adding this gate artifact. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree origin/main b764a390f99c519c11b5fdc53119ec39d4c6113d` returned 0 and produced tree `1c5dc185ab169075710bc30dfd3f96496b3d39b2`; no self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | Two commits change one subsystem: compact marker notification cadence in `examples/bd/dolt`, plus its package-local regression tests. |
+
+## Acceptance evidence
+
+The full-suite integration package log records PASS for:
+
+- `TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle`
+- `TestCompactScriptQuarantineRenotifiesAfterBackstopElapses`
+- `TestCompactScriptQuarantineReasonChangeReMails`
+- `TestCompactScriptExistingQuarantineMarkerAlertsOnceAcrossRepeatedCycles`
+- `TestCompactScriptQuarantineMailFailureIsRetriedNextCycle`
+- `TestCompactScriptUnreadableQuarantineMarkerIsNotClobbered`
+- `TestCompactScriptQuarantineAlertRecipientCanBeOverridden`
+- `TestCompactScriptSkipsRemotePhaseForNoSyncDatabase`
+- `TestCompactScriptClearsPendingPushMarkerWhenDatabaseBecomesNoSync`
+- `TestCompactScriptDryRunPreservesPendingPushMarkerForNoSyncDatabase`
+- `TestCompactScriptPendingPushMarkerBlocksFlattenEvenWhenFresh`
+
+## Test evidence
+
+```text
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true EXTRA_TEST_ENV='DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true' LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m GOFLAGS=-v LOCAL_TEST_LOG_DIR=/var/tmp/ga-6dgrtc-full-gate make test-local-full-parallel
+test_cmd_scope: full-suite
+test_jobs: 34 PASS, 6 FAIL
+test_counts: 46675 PASS, 6 FAIL, 188 SKIP
+diff_tests_executed: TestCompactScriptStalePendingPushMarkerDoesNotRemailEveryCycle PASS (unit + integration); TestCompactScriptQuarantineRenotifiesAfterBackstopElapses PASS (unit + integration)
+waiver_ref: ga-6bnc42 — mayor standing authorization dated 2026-08-18, exact gastownhall/beads#4566 signature only
+```
+
+The rootless Podman socket was live and `dolthub/dolt-sql-server:1.32.4` was pulled and inspected before the run. The 188 skips are pre-existing suite-controlled opt-ins and platform/privilege exclusions; none belongs to the diff. They include live provider/Kubernetes tests, persistence tests requiring an opt-in installed Beads build, Darwin/root-only cases, and test helpers. The count matches the immediately preceding full-suite gate run on an unrelated candidate.
+
+This diff adds two tests, so `added_test_load=yes`. No failure used the inconclusive attribution path: each has structural, exact-base, or cross-PR proof, except the one signature explicitly covered by a pre-existing merge-authority waiver.
+
+### Raw failures and disposition
+
+| Raw failing test | Disposition |
+|---|---|
+| `TestBdFlagManifestCurrent` | Attributed to `ga-f0uceo`, created 2026-08-15. Clause 3(a): the installed `bd --help` surface and `internal/bdflags` manifest are unreachable from this compact-script diff; the identical signature has exact-base and many unrelated-candidate reproductions. No path overlap. |
+| `TestGetKeyBinding_CapturesDefaultBinding` | Attributed to `ga-afqddr`, created 2026-08-15. Clause 3(a): host tmux 3.7b returns an empty filtered default key table; this compact-script diff cannot alter `internal/runtime/tmux` or host tmux. No path overlap. |
+| `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | Attributed to `ga-afqddr`, same proof and no path overlap. |
+| `TestAdoptPRFormulaRetriesTransientReviewerStep` | **FAIL-WAIVED**, not rewritten green. Tracker `ga-lpfjhc`; exact signature: pending schema migrations alter pre-existing dirty table `dependencies` (gastownhall/beads#4566). The failure occurs during fixture `gc init`, before the formula path; the compact command is not invoked by store bootstrap. Authorized by `ga-6bnc42`, and this occurrence was appended to `ga-lpfjhc` before gate completion. |
+| `TestE2E_SuspendResume_City` | Attributed to `ga-yc0e3a`, created 2026-08-18. Clause 3(d)/cross-run proof: exact base previously failed with the same missing `citysus.report` timeout, and unrelated candidates reproduce it. This test does not invoke the compact command; no path overlap. |
+| `TestCleanInstallTutorialPath` | Attributed to `ga-2ywyyf`, created before this run. Clause 3(b): the exact unexpected pre-existing `.beads` store signature occurred on unrelated reviewed candidates, including the immediately preceding gate. The current failure occurs at `gc rig add`, before compact notification code can execute; no path overlap. |
+
+Full raw logs are retained in `/var/tmp/ga-6dgrtc-full-gate` on the gate host.


### PR DESCRIPTION
## What this changes

Dolt compaction alerts now notify on meaningful state transitions and on a configurable long backstop, instead of applying opposite policies to different marker types. An unchanged stale pending-push or pending-GC marker no longer mails on every compact cycle, while an unresolved quarantine no longer goes silent forever after its first notification.

Repeated notifications include the marker's sighting count and age so operators can tell how long the condition has persisted. The backstop defaults to 24 hours and can be changed with `GC_DOLT_COMPACT_RENOTIFY_BACKSTOP_SECS`.

The change does not clear protective markers or suppress their first alert. A changed reason still notifies immediately, and failed mail delivery remains retryable on the next cycle.

## Review notes

- The quarantine, pending-push, and pending-GC paths now share marker notification-state bookkeeping.
- Marker-state writes remain atomic, and invalid backstop configuration fails through the existing numeric-validation path.
- Open PR #5493 changes nearby quarantine notification functions for delivery-error visibility. The behaviors are complementary, but whichever lands second will likely need a small textual reconciliation.

## Test plan

- [x] Run the documented 40-job `make test-local-full-parallel` union and confirm both new cadence tests plus the existing compact notification/no-sync regression suite execute and pass.
- [x] Run `make test-ci-policy`, `go vet ./...`, affected lint, formatting, shell syntax, and diff checks.
- [x] Release gate: [`release-gates/ga-6dgrtc-dolt-compact-notification-cadence-gate.md`](release-gates/ga-6dgrtc-dolt-compact-notification-cadence-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2348 — touches the same compact quarantine path: an unresolved quarantine or stale pending-push marker now re-alerts on a configurable backstop (default 24h) with sighting count and age instead of going quiet after the first mail, which shortens how long a quarantined rig can sit unnoticed; it does not change the concurrent-write row-count race that creates the false quarantine, and does not add gc doctor surfacing
- Related to #3341 — touches the same dolt compact quarantine-marker path and changes its alert cadence so an unresolved quarantine keeps re-alerting on a configurable backstop instead of going quiet after the first mail; it does not address the write-race that causes the quarantine, does not clear markers or restore GC, and leaves the backup-while-quarantined behavior unchanged

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->