### PR TITLE
fix(storeref): refuse the by-id read a migrated-then-refused city would answer from the frozen twin

### DIFF
--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -373,6 +373,21 @@ func TestBindingOwnerRefusedCityWithKnownRelicsRefuses(t *testing.T) {
 	if !storeref.IsStandingRefusal(err) {
 		t.Errorf("the refusal came back as %v, want the standing storage refusal that names the remedy", err)
 	}
+	// The refusal's own sentence is the boot gate's, and a city takes the
+	// identical one for an infrastructure-class id it simply cannot serve. What
+	// makes this denial actionable is the reason behind it and the move that
+	// clears it, and neither is in that sentence.
+	if !errors.Is(err, storeref.ErrProvenRelicRefusal) {
+		t.Errorf("the denial reads %q and carries nothing that tells it apart from the refusal an in-namespace id takes; the operator goes looking for a missing bead", err)
+	}
+	if !strings.Contains(err.Error(), "gc doctor") {
+		t.Errorf("the denial reads %q with no route back to a served city", err)
+	}
+	// One line, because every caller prints this as `gc <cmd>: %v` and a second
+	// line arrives without the command prefix that says which surface refused.
+	if strings.Contains(err.Error(), "\n") {
+		t.Errorf("the denial is multi-line (%q); callers print it as `gc <cmd>: %%v`, so everything after the newline loses the command that refused", err)
+	}
 }
 
 // TestBindingOwnerRefusedCityWithoutMemoStillDeclines is the control, and it

--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -339,10 +339,12 @@ func TestBindingOwnerLeavesTheWorkResidualUnprobed(t *testing.T) {
 
 // refusedRelicTopology is a city whose boot could not serve its configured
 // split: every infrastructure class resolves to a refusing store and the
-// standing refusal rides on the topology. proven says whether a durable census
-// has PROVED that binding holds ids outside its reserved namespaces — the one
-// fact about a refused binding that is readable without reading the binding,
-// because it is a city file rather than a store.
+// standing refusal rides on the topology. proven says whether a census has
+// PROVED that binding holds ids outside its reserved namespaces.
+//
+// It is assembled by hand rather than resolved from a city, so these two rows
+// stay about the RESOLVER's verdict alone. Where the proof comes from is
+// by_id_relic_proof_test.go's subject.
 func refusedRelicTopology(proven bool) storeref.Topology {
 	refusal := standingStorageRefusal{err: errors.New("storage refused: this city has not converged on its configured [storage] binding; run `gc storage migrate`")}
 	classes := infrastructureClasses()
@@ -351,7 +353,7 @@ func refusedRelicTopology(proven bool) storeref.Topology {
 		Prefixes: storeref.ReservedPrefixesFor(classes),
 		Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: refusedClassStore{err: refusal}},
 		// A refused store declares no mint namespace, so the pessimistic bit
-		// stands whatever the memo says.
+		// stands whatever the proof says.
 		HasLegacyResidents:   true,
 		KnownLegacyResidents: proven,
 	}}, refusal)
@@ -390,17 +392,17 @@ func TestBindingOwnerRefusedCityWithKnownRelicsRefuses(t *testing.T) {
 	}
 }
 
-// TestBindingOwnerRefusedCityWithoutMemoStillDeclines is the control, and it
+// TestBindingOwnerRefusedCityWithoutProofStillDeclines is the control, and it
 // must pass on both sides of the fix.
 //
-// The memo is TRUE-only: a ref absent from it means "not known", never "known
-// clean". So absence must not deny anything — a city that was never migrated,
-// or whose note was lost, keeps today's behavior, and work is still served from
-// the ledger work never left.
-func TestBindingOwnerRefusedCityWithoutMemoStillDeclines(t *testing.T) {
+// The proof is TRUE-only: a binding it says nothing about is "not known", never
+// "known clean". So absence must not deny anything — a city that was never
+// migrated, or whose binding could not be read, keeps today's behavior, and
+// work is still served from the ledger work never left.
+func TestBindingOwnerRefusedCityWithoutProofStillDeclines(t *testing.T) {
 	owner, ok, err := byIDBindingOwnerForTopology(refusedRelicTopology(false), "gc-1")
 	if err != nil {
-		t.Fatalf("a refused city with no relic evidence resolved to err=%v; the memo's absence is not evidence, and denying here takes work-bead reads away from every unconverged city", err)
+		t.Fatalf("a refused city with no relic evidence resolved to err=%v; absence of proof is not evidence, and denying here takes work-bead reads away from every unconverged city", err)
 	}
 	if ok {
 		t.Errorf("a refusing binding reported ownership of gc-1 (%p)", owner.Store)

--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -280,26 +280,39 @@ func TestBeadsShowFallbackScansForAnIdNoBindingHolds(t *testing.T) {
 	}
 }
 
-// TestBindingOwnerLeavesTheWorkResidualUnprobed is the sentinel's contract.
+// TestBindingOwnerLeavesTheWorkResidualUnprobed is the delegation pin: this
+// arm's work axis is a directory scan the resolver must not run, and
+// storeref.ResolveBindingOwner is what guarantees it does not.
 //
-// cliByIDBindingOwner hands the plan a placeholder where the work leg goes,
-// because this arm's work axis is a directory scan the resolver must not run.
-// That is safe only while the residual is returned UNPROBED, so the placeholder
-// reports being read as an internal error — and a clean ok=false here is the
-// proof it was not.
+// The measurement is a COUNT rather than a sentinel's refusal, because the
+// dangerous case is not a work store that errors — it is one that answers. The
+// city store still holds the copy `gc storage migrate` retained, so a work leg
+// that got probed here would report a real, stale bead as a binding owner and
+// the caller's fall-through would never run. Zero Gets is the only shape that
+// rules that out.
 func TestBindingOwnerLeavesTheWorkResidualUnprobed(t *testing.T) {
-	cityPath := oneShotCLICity(t, "")
-	refuseInfraMigrationSource(t)
-	captureCLIStorageStderr(t)
-
-	owner, ok, err := cliByIDBindingOwner(cityPath, "gc-1")
+	cityPath, _ := foreignProviderCity(t)
+	counted := &countingGetStore{Store: splittest.NewWorkStore(t, "hq")}
+	held, err := counted.Create(beads.Bead{Title: "a bead only the work axis holds", Type: "task"})
 	if err != nil {
-		t.Fatalf("a city that relocates nothing resolved to err=%v; the residual must come back unprobed, not read", err)
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	counted.gets = 0
+
+	owner, ok, err := byIDBindingOwnerForTopology(cliResidencyTopology(cityPath, nil, counted, nil), held.ID)
+	if err != nil {
+		t.Fatalf("an id no binding holds resolved to err=%v; a clean miss is ok=false, not a failure", err)
 	}
 	if ok {
-		t.Errorf("a city that relocates nothing reported a binding owner %p", owner.Store)
+		t.Errorf("the work axis's own copy of %s came back as a binding owner (%p); the caller would never run its scan", held.ID, owner.Store)
+	}
+	if counted.gets != 0 {
+		t.Errorf("the work leg was probed %d time(s), want 0 — the retained pre-migration copy lives there, so a probe answers with a stale bead rather than a miss", counted.gets)
 	}
 
+	// The placeholder both call sites hand the plan is defense in depth for the
+	// same guarantee: if the executor ever does reach the work leg, it must be a
+	// loud error rather than a plausible answer.
 	residual := newUnprobedWorkResidual()
 	got, err := residual.Get("gc-1")
 	if err == nil {

--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -337,6 +337,61 @@ func TestBindingOwnerLeavesTheWorkResidualUnprobed(t *testing.T) {
 	}
 }
 
+// refusedRelicTopology is a city whose boot could not serve its configured
+// split: every infrastructure class resolves to a refusing store and the
+// standing refusal rides on the topology. proven says whether a durable census
+// has PROVED that binding holds ids outside its reserved namespaces — the one
+// fact about a refused binding that is readable without reading the binding,
+// because it is a city file rather than a store.
+func refusedRelicTopology(proven bool) storeref.Topology {
+	refusal := standingStorageRefusal{err: errors.New("storage refused: this city has not converged on its configured [storage] binding; run `gc storage migrate`")}
+	classes := infrastructureClasses()
+	return assembleResidencyTopology(nil, newUnprobedWorkResidual(), nil, []storeref.ClassBinding{{
+		Classes:  classes,
+		Prefixes: storeref.ReservedPrefixesFor(classes),
+		Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: refusedClassStore{err: refusal}},
+		// A refused store declares no mint namespace, so the pessimistic bit
+		// stands whatever the memo says.
+		HasLegacyResidents:   true,
+		KnownLegacyResidents: proven,
+	}}, refusal)
+}
+
+// TestBindingOwnerRefusedCityWithKnownRelicsRefuses is the ga-q8ick bug.
+//
+// A refused city still serves WORK, so the resolver tolerates the refusal on a
+// residence probe and the surface falls through to its own scan. That is right
+// until the binding is PROVEN to hold work-prefixed relics: `gc storage migrate`
+// preserved those ids and deleted nothing, so the scan finds the retained
+// pre-migration copy in the city work store, serves it, and the close that
+// follows writes it. Exit 0, no diagnostic.
+func TestBindingOwnerRefusedCityWithKnownRelicsRefuses(t *testing.T) {
+	_, ok, err := byIDBindingOwnerForTopology(refusedRelicTopology(true), "gc-1")
+	if err == nil {
+		t.Fatalf("a refused city proven to hold work-prefixed relics resolved to ok=%v with no error; the caller's scan then serves the copy the migration left in the work store", ok)
+	}
+	if !storeref.IsStandingRefusal(err) {
+		t.Errorf("the refusal came back as %v, want the standing storage refusal that names the remedy", err)
+	}
+}
+
+// TestBindingOwnerRefusedCityWithoutMemoStillDeclines is the control, and it
+// must pass on both sides of the fix.
+//
+// The memo is TRUE-only: a ref absent from it means "not known", never "known
+// clean". So absence must not deny anything — a city that was never migrated,
+// or whose note was lost, keeps today's behavior, and work is still served from
+// the ledger work never left.
+func TestBindingOwnerRefusedCityWithoutMemoStillDeclines(t *testing.T) {
+	owner, ok, err := byIDBindingOwnerForTopology(refusedRelicTopology(false), "gc-1")
+	if err != nil {
+		t.Fatalf("a refused city with no relic evidence resolved to err=%v; the memo's absence is not evidence, and denying here takes work-bead reads away from every unconverged city", err)
+	}
+	if ok {
+		t.Errorf("a refusing binding reported ownership of gc-1 (%p)", owner.Store)
+	}
+}
+
 // TestConvoyResolutionStillRefusesAnIdTwoLedgersBothHold covers the rule the
 // binding short-circuit steps around, which until now nothing asserted anywhere
 // in the tree.

--- a/cmd/gc/by_id_relic_proof.go
+++ b/cmd/gc/by_id_relic_proof.go
@@ -1,0 +1,192 @@
+package main
+
+// The by-id door's relic proof: computed, never recorded.
+//
+// A city whose boot REFUSED still serves WORK from its work ledger, so the
+// residency resolver tolerates the standing storage refusal on a residence
+// probe and the surface falls through to its own axis. The sentence that
+// justifies that is "this leg was only ever a probe for an id no relocated
+// class could own", and there is exactly one shape of city it is false for: one
+// whose binding still holds ids `gc storage migrate` carried across under their
+// original work-shaped names. There, falling through does not land on "no
+// answer" — it lands on the frozen pre-migration copy the migration left in the
+// work store, which answers confidently and wrongly, and the close that follows
+// writes it. That is ga-q8ick.
+//
+// # Why the proof is taken here rather than read off disk
+//
+// The obvious place to keep this verdict is a note under the city's own .gc,
+// written by whichever process last managed to read the binding. It is the
+// wrong place twice over. It is a status file, which this codebase does not
+// keep (AGENTS.md: no status files — query live state), and it goes stale in
+// the DENYING direction: relics close over the weeks after a migration, so a
+// note written in March denies reads in June for a binding that has been clean
+// since April.
+//
+// The premise the note was there to work around turns out to be false anyway.
+// "Refused" is a verdict about SERVING the binding — a convergence check, a
+// served-binding note, a discipline the boot gate enforces — and almost none of
+// those verdicts say the binding cannot be READ. So the census that decides
+// this runs right here, against a handle opened for the read and closed after
+// it, and its answer is about the binding as it is now.
+//
+// # What it costs, and who pays
+//
+// Only a refused city reaches any of it. residencyTopologyForCity has already
+// answered by the time the gate below is consulted, and a served city's
+// Topology.Refused is nil, so it resolves no plan, opens no engine and takes no
+// read — TestServedCityPaysNothingForTheRelicProof counts the plan resolutions
+// and requires zero. A refused city pays one engine open and one full list of
+// the binding, once per process per city, on the by-id path only. That city is
+// already in the incident state its own boot gate reported.
+//
+// # The absent case is the tolerant one
+//
+// Every way of not reaching an answer — a config that will not load, a plan
+// that will not resolve, a provider that opens no engine, an open that fails —
+// is proof-ABSENT, and proof-absent falls through exactly as today. The bit
+// only ever denies, so its unknown must be false: a binding nobody could read
+// has proved nothing, and denying on it would take work-bead reads away from
+// every city whose binding is merely unreachable.
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// byIDResidencyTopology is the topology the by-id door plans over: the city's
+// own residency topology, plus — on a REFUSED city only — the proof that the
+// binding it cannot serve still holds ids the migration preserved.
+//
+// The refused city is re-derived rather than patched. A ClassBinding's two
+// relic bits have an implication between them that storeref.BuildBindings
+// enforces, and reaching into the assembled topology to raise one of them by
+// hand is how a plane ends up spelling a state no city can be in. Handing the
+// proof back through residencyBindingsFromRoutesWithProof means both bits and
+// the ref they are keyed by come from the one derivation.
+func byIDResidencyTopology(cityPath string, cfg *config.City, work beads.Store, rigs map[string]beads.Store) storeref.Topology {
+	topo := residencyTopologyForCity(cityPath, cfg, work, rigs)
+	if topo.Refused == nil || len(topo.Bindings) == 0 || cityPath == "" {
+		return topo
+	}
+	proven := provenRelicRefsForCity(cityPath)
+	if len(proven) == 0 {
+		return topo
+	}
+	bindings, refused := residencyBindingsFromRoutesWithProof(
+		residencyRoutesForCity(cityPath),
+		func(ref storeref.StoreRef) bool { return proven[ref] },
+	)
+	return assembleResidencyTopology(cfg, work, rigs, bindings, refused)
+}
+
+// provenRelicRefsForCity opens the binding this city is configured for, censuses
+// it, and returns the binding refs the census PROVED hold ids outside the
+// namespaces they declare.
+//
+// It is called only for a city whose boot refused, which is also what makes
+// opening the binding here safe: the refusal is why nothing else in this
+// process holds it open. A served city's binding is already open on the funnel,
+// and a second handle on a binding root — a duplicate managed-Dolt server, a
+// second sqlite writer — is the bug the residency constructors exist to avoid.
+//
+// The handle is closed before the verdict is returned. Nothing downstream reads
+// through it: what travels is a set of refs.
+//
+// An empty result is "nothing proved", which every failure path also produces
+// and which the caller reads as no evidence.
+func provenRelicRefsForCity(cityPath string) map[storeref.StoreRef]bool {
+	key := filepath.Clean(cityPath)
+	provenRelicRefsMu.Lock()
+	if provenRelicRefsByCity == nil {
+		provenRelicRefsByCity = make(map[string]map[storeref.StoreRef]bool, 1)
+	}
+	cached, ok := provenRelicRefsByCity[key]
+	provenRelicRefsMu.Unlock()
+	if ok {
+		return cached
+	}
+
+	proven := censusRefusedCityBinding(cityPath)
+
+	provenRelicRefsMu.Lock()
+	defer provenRelicRefsMu.Unlock()
+	if provenRelicRefsByCity == nil {
+		// resetProvenRelicRefs ran while this census was in flight. The answer
+		// is still right for this caller, so it is returned unmemoized rather
+		// than assigned into a nil map.
+		return proven
+	}
+	provenRelicRefsByCity[key] = proven
+	return proven
+}
+
+// censusRefusedCityBinding is the read itself: resolve this city's storage
+// plan, open the binding it names, and ask each derived binding whether it
+// still holds a relic.
+//
+// Every early return is the same answer — no proof — and they are deliberately
+// silent. A refused city has already had its refusal printed once by the
+// one-shot gate, and the reasons a binding cannot be reopened here are the
+// reasons it was refused in the first place; reporting them again would put a
+// second copy of the same sentence on every by-id read of an unconverged city.
+func censusRefusedCityBinding(cityPath string) map[storeref.StoreRef]bool {
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil || cfg == nil || cfg.Storage == nil {
+		return nil
+	}
+	shape, binding := storageSplitShapeOf(cfg.EffectiveStorage())
+	if shape != storageSplitWhole {
+		// The only arrangement this build serves is also the only one a
+		// migration can have produced, so it is the only one whose binding can
+		// hold a preserved id.
+		return nil
+	}
+	plan, err := resolveCityStoragePlan(cityPath, cfg)
+	if err != nil {
+		return nil
+	}
+	routes, err := openStorageRoutes(plan, infraBindingTarget{Binding: binding})
+	if err != nil {
+		// "Cannot open the binding" — the one refusal that really does say the
+		// binding is unreadable. No proof, and the read falls through.
+		return nil
+	}
+	defer routes.close() //nolint:errcheck // a close failure cannot unsay what the census already read
+
+	bindings, _ := residencyBindingsFromRoutes(routes)
+	proven := make(map[storeref.StoreRef]bool, len(bindings))
+	for _, b := range bindings {
+		if storeref.ProvenLegacyResidents(b) { // residency:allow — censuses the binding this proof is about; resolves nothing
+			proven[b.Leg.Ref] = true
+		}
+	}
+	return proven
+}
+
+var (
+	provenRelicRefsMu     sync.Mutex
+	provenRelicRefsByCity map[string]map[storeref.StoreRef]bool
+)
+
+// resetProvenRelicRefs drops the memo wholesale, alongside the routes and the
+// binding grouping derived from them. The verdict is about a binding this
+// process opened and closed, so it cannot outlive the funnel that decided the
+// city was refused in the first place.
+func resetProvenRelicRefs() {
+	provenRelicRefsMu.Lock()
+	provenRelicRefsByCity = nil
+	provenRelicRefsMu.Unlock()
+}
+
+// dropProvenRelicRefs drops one city's memoized verdict.
+func dropProvenRelicRefs(key string) {
+	provenRelicRefsMu.Lock()
+	delete(provenRelicRefsByCity, key)
+	provenRelicRefsMu.Unlock()
+}

--- a/cmd/gc/by_id_relic_proof.go
+++ b/cmd/gc/by_id_relic_proof.go
@@ -48,6 +48,19 @@ package main
 // only ever denies, so its unknown must be false: a binding nobody could read
 // has proved nothing, and denying on it would take work-bead reads away from
 // every city whose binding is merely unreachable.
+//
+// # It opens only a binding that ALREADY EXISTS on disk
+//
+// beads.OpenSQLiteStore creates the database when it is absent, so an opener
+// used as a probe answers its own question: it would report "no relics" about a
+// binding it just created. The never-migrated city — a [storage] split
+// configured and never cut over — is the most common refused city there is, and
+// on it an ordinary by-id read would leave an empty binding root behind that a
+// later boot reads as a genesis root. A workspace-backed provider would start a
+// managed engine for the same read. So existence is checked BEFORE the open,
+// through the same two helpers the migration's own no-open probe uses
+// (infraBindingRootEnumerable, infraPathExists), and a binding that is not
+// already there is proof-absent.
 
 import (
 	"path/filepath"
@@ -147,6 +160,9 @@ func censusRefusedCityBinding(cityPath string) map[storeref.StoreRef]bool {
 		// hold a preserved id.
 		return nil
 	}
+	if !refusedBindingIsAlreadyOnDisk(cityPath, cfg) {
+		return nil
+	}
 	plan, err := resolveCityStoragePlan(cityPath, cfg)
 	if err != nil {
 		return nil
@@ -167,6 +183,83 @@ func censusRefusedCityBinding(cityPath string) map[storeref.StoreRef]bool {
 		}
 	}
 	return proven
+}
+
+// refusedBindingIsAlreadyOnDisk reports whether this city's configured binding
+// exists, WITHOUT opening it.
+//
+// It is the precondition on the census above, and it is a correctness gate
+// rather than an optimization. The engine opener creates the database when it is
+// absent, so a census that skipped this would report "no relics" about a
+// binding it had just brought into existence — and would leave that binding
+// behind. infraBindingHoldsNothing already states the rule for the migration's
+// own probe: a probe that creates the database it is asked about is answering
+// its own question. Both checks are the migration's, reused rather than
+// re-spelled, so the two probes cannot disagree about what "the binding is
+// there" means.
+//
+// The root is checked as well as the database, and for this gate that is
+// belt-and-braces rather than a second condition: every way the root check can
+// fail — absent, not a directory, not enumerable by this process — also makes
+// the database stat below answer absent or error, and both decline. It is kept
+// so this precondition reads the same as infraBindingHoldsNothing's, which is
+// the migration's own no-open probe and the place the rule is argued. The
+// DATABASE check is the one carrying the weight here, and it is the one a
+// mutation kills: a binding root that exists and holds no database is a city
+// that has not cut over, and only that check can tell it from one whose binding
+// is clean.
+//
+// A binding served by a provider this build resolves no target for takes the
+// second branch. resolveInfraBindingTarget answers only for the built-in bead
+// engine, and for anything else this file cannot know which file under a root
+// is the database — so the PROVIDER is asked where it serves from, and that
+// location has to exist. Declining is always safe here: the bit only ever
+// denies.
+func refusedBindingIsAlreadyOnDisk(cityPath string, cfg *config.City) bool {
+	target, configured, err := resolveInfraBindingTarget(cityPath, cfg)
+	if err != nil {
+		return false
+	}
+	if !configured {
+		return foreignBindingLocationExists(cityPath, cfg)
+	}
+	if err := infraBindingRootEnumerable(target.Root); err != nil {
+		return false
+	}
+	present, err := infraPathExists(target.Database)
+	return err == nil && present
+}
+
+// foreignBindingLocationExists is the same question for a binding served by a
+// provider whose layout this build does not own: does the location the PROVIDER
+// reports it serves from already exist?
+//
+// It asks the provider rather than guessing, because only the provider knows —
+// the built-in engine reports a database FILE, another may report a directory,
+// and a third may report something that is not a path at all. All three answer
+// this correctly: a location that is not an existing path is not a binding this
+// process may bring into existence, so it is proof-absent, and the read falls
+// through. A remote or opaque location fails the same way, which is the safe
+// direction.
+func foreignBindingLocationExists(cityPath string, cfg *config.City) bool {
+	if cfg == nil {
+		return false
+	}
+	storage := cfg.EffectiveStorage()
+	shape, binding := storageSplitShapeOf(storage)
+	if shape != storageSplitWhole {
+		return false
+	}
+	plan, err := resolveCityStoragePlan(cityPath, cfg)
+	if err != nil {
+		return false
+	}
+	location, err := servedBindingLocation(plan, binding, storage.Bindings[binding])
+	if err != nil || location == "" {
+		return false
+	}
+	present, err := infraPathExists(location)
+	return err == nil && present
 }
 
 var (

--- a/cmd/gc/by_id_relic_proof.go
+++ b/cmd/gc/by_id_relic_proof.go
@@ -37,8 +37,31 @@ package main
 // Topology.Refused is nil, so it resolves no plan, opens no engine and takes no
 // read — TestServedCityPaysNothingForTheRelicProof counts the plan resolutions
 // and requires zero. A refused city pays one engine open and one full list of
-// the binding, once per process per city, on the by-id path only. That city is
-// already in the incident state its own boot gate reported.
+// the binding, on the by-id path only. That city is already in the incident
+// state its own boot gate reported.
+//
+// The memo below makes that ONE read per city for the callers this door
+// actually has: one-shot cobra commands that resolve by-id sequentially. It is
+// not a single-flight — provenRelicRefsForCity releases the memo lock across
+// the census — so two concurrent by-id callers on the same refused city would
+// each take the read, and each would open its own handle on the binding root.
+// That is the second-handle hazard named below, and what rules it out today is
+// the absence of such a caller, not the memo. A parallel by-id caller has to
+// bring a single-flight (or a sync.Once entry) with it: ga-nzxob.
+//
+// # Who the denial reaches
+//
+// The proof is keyed by BINDING ref, not by id, so what turns Fatal is the
+// whole binding's residence probe: every non-reserved by-id read on this city's
+// CLI fallback path denies, including a fresh post-migration work bead and a
+// rig-shadowed id that can have no frozen twin at all. That breadth is
+// deliberate rather than incidental. The census reads OPEN beads only, so it
+// cannot enumerate the closed relics a per-id rule would have to consult, and a
+// per-id rule would therefore deny LESS than the evidence supports. The corpus
+// pins it — residency_conformance_test.go's T3k rows make ByID(ga-xyz) and
+// ByID(ra-7) Fatal too, not just the reserved-prefix ones. The operator cost is
+// that one proven open relic takes the by-id door away for the city, not only
+// for the ids the migration preserved.
 //
 // # The absent case is the tolerant one
 //
@@ -248,6 +271,12 @@ func foreignBindingLocationExists(cityPath string, cfg *config.City) bool {
 	storage := cfg.EffectiveStorage()
 	shape, binding := storageSplitShapeOf(storage)
 	if shape != storageSplitWhole {
+		// Deliberately re-derived, not a second independent precondition: the
+		// one caller today reaches here having already established this on the
+		// same cfg (censusRefusedCityBinding). It is kept because it is what
+		// makes `binding` safe to read below — storageSplitShapeOf names no
+		// binding for any other shape — so the helper stays correct for a
+		// caller it may later acquire.
 		return false
 	}
 	plan, err := resolveCityStoragePlan(cityPath, cfg)

--- a/cmd/gc/by_id_relic_proof_test.go
+++ b/cmd/gc/by_id_relic_proof_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/storebinding"
 	"github.com/gastownhall/gascity/internal/storeref"
@@ -211,6 +213,123 @@ func refsOf(proven map[storeref.StoreRef]bool) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// controllerDownForBeadsShow answers the `gc beads show` API seam "no
+// controller", which is the only state in which the command reaches the store
+// funnel at all.
+//
+// The seam is stubbed rather than left alone because apiClient() probes for a
+// live controller and loads config: unstubbed, the row would pass or fail on
+// whether something happened to be listening for the fixture's city, and on a
+// machine where one was it would never run the fallback it exists to pin.
+func controllerDownForBeadsShow(t *testing.T) {
+	t.Helper()
+	prev := beadsShowAPIClient
+	beadsShowAPIClient = func(string) (*api.Client, string) { return nil, "no controller for this fixture city" }
+	t.Cleanup(func() { beadsShowAPIClient = prev })
+}
+
+// TestBeadsShowRefusesTheRelicItWouldOtherwiseServeFrozen drives the denial at
+// the surface ga-q8ick was reported on.
+//
+// TestRefusedCityDeniesTheRelicItsLiveCensusProves pins the same fixture one
+// frame below, at cliByIDBindingOwner, and that is not the same claim. The bead
+// exists because `gc beads show` answered with a stale pre-migration row, exit
+// 0, no diagnostic — so what has to be pinned is the COMMAND's exit and the
+// COMMAND's output, not the error value a helper hands it. Between the two sits
+// doBeadsShowFallback's classification, and the failure that reopens ga-q8ick is
+// a change there that reads every error as "no binding answered, run your own
+// scan": the denial disappears, the scan finds the copy the migration retained
+// in the work ledger, and the command reports it as current.
+//
+// The frozen copy is therefore seeded for real. Without it the row could pass
+// against a fall-through that simply found nothing, which is a different exit
+// code for a different reason and says nothing about serving stale rows.
+func TestBeadsShowRefusesTheRelicItWouldOtherwiseServeFrozen(t *testing.T) {
+	const frozenTitle = "the copy the migration left in the work ledger"
+
+	cityPath, classStore := foreignProviderCity(t)
+	frozen, err := workStoreFor(t, cityPath).Create(beads.Bead{Title: frozenTitle, Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store's retained copy: %v", err)
+	}
+	relic := classResidentWorkShapedBead(t, classStore, frozen.ID, "the row the binding holds now")
+
+	controllerDownForBeadsShow(t)
+	refuseTheseCities(t, theRefusalARefusedCityCarries(), cityPath)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdBeadsShow(relic.ID, "json", &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("gc beads show %s exited 0 on a refused city whose binding is proven to hold relics; stdout = %s", relic.ID, stdout.String())
+	}
+	if strings.Contains(stdout.String(), frozenTitle) {
+		t.Fatalf("gc beads show served the pre-migration copy from the work ledger: %s — this is the ga-q8ick symptom, a row frozen at migration time reported as current", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gc beads show:") {
+		t.Errorf("the denial reached stderr as %q without naming the command that refused; an operator reading this cannot tell which surface gave up", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gc doctor") {
+		t.Errorf("gc beads show printed %q with no route back to a served city", stderr.String())
+	}
+	// One printed line, because the caller's format string is
+	// `gc beads show: %v\n`: a second line in the error value arrives without
+	// that prefix and the operator cannot tell which surface it came from.
+	if got := strings.Count(strings.TrimRight(stderr.String(), "\n"), "\n"); got != 0 {
+		t.Errorf("the denial printed %d extra line(s): %q — everything after the first loses the `gc beads show:` prefix", got, stderr.String())
+	}
+
+	// The control, and the reason this row is about the PROOF rather than about
+	// the refusal: the same city, the same refusal, the same id, with the
+	// evidence taken out of reach. A refused city still serves work, so the
+	// command must fall through to its scan and answer — from the retained copy,
+	// which is the behavior every unconverged city depends on. If this arm ever
+	// fails, the pin above has degenerated into "a refused city refuses
+	// everything" and would hold against code that dropped the census entirely.
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: the proof cannot be taken out of reach, so the control arm below cannot run")
+	}
+	sealTheBindingRoot(t, cityPath)
+	dropCLIResidencyBindings(filepath.Clean(cityPath))
+
+	var unprovenOut, unprovenErr bytes.Buffer
+	if code := cmdBeadsShow(relic.ID, "json", &unprovenOut, &unprovenErr); code != 0 {
+		t.Fatalf("gc beads show %s exited %d on the same refusal with nothing proved: %s — absence of evidence is not evidence, and refusing here takes work-bead reads away from every unconverged city", relic.ID, code, unprovenErr.String())
+	}
+	if !strings.Contains(unprovenOut.String(), frozenTitle) {
+		t.Errorf("the unproven arm served %q, want the work ledger's copy; if the scan cannot reach it then the arm above proved nothing about a stale answer being suppressed", unprovenOut.String())
+	}
+}
+
+// TestBeadsShowServesAConvergedCityThroughTheSameEntryPoint is the healthy
+// control for the row above, taken at the same entry point rather than at the
+// fallback it calls.
+//
+// TestBeadsShowFallbackServesTheBindingCopy already pins this property one frame
+// down. What it cannot pin is that `gc beads show` still REACHES that frame: a
+// guard added to cmdBeadsShow or routeBeadsShow that refused a city whose
+// storage looked unusual would leave that row green and break every converged
+// city's reads. Exit 0 here, from the binding's copy, is what keeps the denial
+// above a statement about proven relics instead of about this funnel.
+func TestBeadsShowServesAConvergedCityThroughTheSameEntryPoint(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	shadow, err := workStoreFor(t, cityPath).Create(beads.Bead{Title: "the retained work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	relocated := classResidentWorkShapedBead(t, classStore, shadow.ID, "the class-binding copy")
+	recensusAfterSeedingARelic(t, cityPath)
+
+	controllerDownForBeadsShow(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdBeadsShow(relocated.ID, "json", &stdout, &stderr); code != 0 {
+		t.Fatalf("gc beads show %s exited %d on a served city: %s", relocated.ID, code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "the class-binding copy") {
+		t.Errorf("gc beads show served %s, want the binding's copy — the work store's is frozen at migration time", stdout.String())
+	}
 }
 
 // sealTheBindingRoot makes this city's configured binding unopenable, and only

--- a/cmd/gc/by_id_relic_proof_test.go
+++ b/cmd/gc/by_id_relic_proof_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/storebinding"
 	"github.com/gastownhall/gascity/internal/storeref"
 )
@@ -351,4 +353,69 @@ func sealTheBindingRoot(t *testing.T, cityPath string) {
 		t.Fatalf("sealing %s: %v", root, err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(root, info.Mode().Perm()) })
+}
+
+// TestTheRelicProofNeverCreatesTheBindingItIsAskedAbout is the hazard a probe
+// that OPENS its subject always has.
+//
+// beads.OpenSQLiteStore creates the database when it is absent — that is why
+// infraBindingHoldsNothing checks infraPathExists before it opens, and says so
+// in as many words: "a probe that creates the database it is asked about would
+// be answering its own question". The most common refused city is the
+// NEVER-MIGRATED one, whose binding database does not exist at all, and on that
+// city an ordinary by-id read reaches this proof. Creating a binding root as
+// the side effect of a READ is the one thing this path must not do — on the
+// built-in engine it leaves an empty database that a later boot reads as a
+// genesis root, and on a workspace-backed provider it would start a managed
+// engine.
+func TestTheRelicProofNeverCreatesTheBindingItIsAskedAbout(t *testing.T) {
+	bindingRoot := filepath.Join(t.TempDir(), "never-migrated")
+	cityPath := oneShotCLICity(t, bindingRoot)
+	captureCLIStorageStderr(t)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading the fixture city: %v", err)
+	}
+	target, configured, err := resolveInfraBindingTarget(cityPath, cfg)
+	if err != nil || !configured {
+		t.Fatalf("the fixture city resolved no infra binding target (configured=%v): %v — the row cannot be about a binding that was never named", configured, err)
+	}
+	if _, err := os.Stat(target.Database); !os.IsNotExist(err) {
+		t.Fatalf("the fixture's binding database %s already exists (%v); a never-migrated city is the whole subject of this row", target.Database, err)
+	}
+
+	refuseTheseCities(t, theRefusalARefusedCityCarries(), cityPath)
+
+	owner, ok, err := cliByIDBindingOwner(cityPath, "gc-1")
+	if err != nil {
+		t.Fatalf("a refused city whose binding does not exist resolved to err=%v; nothing can be proved about a binding that was never written, and denying here takes work-bead reads away from every city that has not cut over yet", err)
+	}
+	if ok {
+		t.Errorf("a binding that does not exist reported ownership of gc-1 (%p)", owner.Store)
+	}
+
+	if _, err := os.Stat(target.Database); !os.IsNotExist(err) {
+		t.Errorf("the relic proof CREATED the binding database %s as the side effect of a by-id read (stat err = %v); the next boot then finds a genesis root on a city that never cut over", target.Database, err)
+	}
+	if _, err := os.Stat(bindingRoot); !os.IsNotExist(err) {
+		t.Errorf("the relic proof CREATED the binding root %s as the side effect of a by-id read (stat err = %v)", bindingRoot, err)
+	}
+
+	// Second arm: the root is THERE and the database is not. A binding volume
+	// mounted but never written looks exactly like this, and so does a genesis
+	// root that was created and then rolled back. The root check above cannot
+	// see the difference — it passes — so this is the arm that makes the
+	// DATABASE check load-bearing rather than decorative.
+	if err := os.MkdirAll(bindingRoot, 0o755); err != nil {
+		t.Fatalf("creating the empty binding root: %v", err)
+	}
+	dropCLIResidencyBindings(filepath.Clean(cityPath))
+
+	if _, ok, err := cliByIDBindingOwner(cityPath, "gc-1"); err != nil || ok {
+		t.Fatalf("a refused city whose binding root exists but holds no database resolved to ok=%v err=%v, want a clean fall-through", ok, err)
+	}
+	if _, err := os.Stat(target.Database); !os.IsNotExist(err) {
+		t.Errorf("the relic proof CREATED the binding database %s inside an existing but empty root (stat err = %v); an empty root is a city that has not cut over, not one with a clean binding", target.Database, err)
+	}
 }

--- a/cmd/gc/by_id_relic_proof_test.go
+++ b/cmd/gc/by_id_relic_proof_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -157,6 +158,59 @@ func TestServedCityPaysNothingForTheRelicProof(t *testing.T) {
 	if *resolutions != 0 {
 		t.Errorf("a served city resolved %d storage plan(s) on the by-id path; the relic proof is for a REFUSED city, and a served one must not pay an engine open per command", *resolutions)
 	}
+}
+
+// TestTheProofAndTheRefusedFunnelSpellTheBindingRefTheSameWay holds the two
+// ends of the fix together.
+//
+// The rows above each assemble one end. The proof keys its verdict by the ref
+// of the binding IT built — over an opened sqlite engine, from the classes the
+// storage plan assigns it. The refused by-id path looks a ref up in that
+// verdict using the ref of the binding the REFUSED funnel built — over five
+// refusedClassStore values grouped by equality, from the classes
+// refusingStorageRoutes decided to route. Those are two constructions on two
+// different days of a city's life, and nothing states that they spell the ref
+// the same way.
+//
+// They do, because both go through residencyBindingsFromRoutes and so through
+// storeref.ClassRef over the same infrastructure class set. If either side ever
+// narrowed to the classes its own routes happened to name, the lookup would
+// miss and the denial would vanish: no error, ok=false, the caller's scan serves
+// the pre-migration copy the migration left in the work ledger — exactly the
+// ga-q8ick symptom, restored silently. The denial row above would catch that,
+// but only by its absence, and a row that fails for "the denial went missing"
+// says nothing about WHY. This one names the reason.
+func TestTheProofAndTheRefusedFunnelSpellTheBindingRefTheSameWay(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "carried across by the migration")
+
+	refuseTheseCities(t, theRefusalARefusedCityCarries(), cityPath)
+
+	proven := provenRelicRefsForCity(cityPath)
+	if len(proven) != 1 {
+		t.Fatalf("the live census proved %d ref(s) for a city whose binding holds %s; with nothing proved the agreement below would be vacuous", len(proven), relic.ID)
+	}
+
+	refusedBindings, refused := cliResidencyBindings(cityPath)
+	if refused == nil {
+		t.Fatal("the fixture city is not refused; the funnel side of the agreement is the REFUSED one")
+	}
+	if len(refusedBindings) != 1 {
+		t.Fatalf("the refused funnel grouped %d binding(s), want one", len(refusedBindings))
+	}
+	if !proven[refusedBindings[0].Leg.Ref] {
+		t.Errorf("the census proved %v and the refused funnel asks about %q; the two spell the same physical binding differently, so the lookup misses and the denial silently disappears", refsOf(proven), refusedBindings[0].Leg.Ref)
+	}
+}
+
+// refsOf renders a proof verdict for a failure message.
+func refsOf(proven map[storeref.StoreRef]bool) []string {
+	out := make([]string, 0, len(proven))
+	for ref := range proven {
+		out = append(out, string(ref))
+	}
+	sort.Strings(out)
+	return out
 }
 
 // sealTheBindingRoot makes this city's configured binding unopenable, and only

--- a/cmd/gc/by_id_relic_proof_test.go
+++ b/cmd/gc/by_id_relic_proof_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/storebinding"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// refuseTheseCities installs the same standing storage refusal for several
+// cities at once, without standing up a binding for any of them.
+//
+// The funnel cannot be seeded twice through resetCLIStorageRoutes: it closes
+// the whole memo first, so a second call would drop the first city's routes. A
+// row that needs a city and its control refused at the same moment resets once
+// and seeds both.
+func refuseTheseCities(t *testing.T, refusal error, cityPaths ...string) {
+	t.Helper()
+	resetCLIStorageRoutes(t)
+	for _, cityPath := range cityPaths {
+		entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+		entry.once.Do(func() { entry.routes = refusingStorageRoutes("infra", refusal) })
+		dropDerivedResidencyMemo(t, cityPath)
+	}
+}
+
+// theRefusalARefusedCityCarries is the boot gate's own sentence. The denial
+// rows below share it with their controls, so what changes the outcome is the
+// proof rather than the wording of the refusal.
+func theRefusalARefusedCityCarries() error {
+	return errors.New("storage refused: this city has not converged on its configured [storage] binding; run `gc storage migrate`")
+}
+
+// countStoragePlanResolutions wraps the registry constructor so a row can prove
+// the relic proof was NOT taken. Every path into the proof resolves a storage
+// plan, and a plan resolution constructs exactly one registry.
+func countStoragePlanResolutions(t *testing.T) *int {
+	t.Helper()
+	var n int
+	prev := newStorageRegistryForPlan
+	newStorageRegistryForPlan = func() (*storebinding.ProviderRegistry, error) {
+		n++
+		return prev()
+	}
+	t.Cleanup(func() { newStorageRegistryForPlan = prev })
+	return &n
+}
+
+// TestRefusedCityDeniesTheRelicItsLiveCensusProves is the ga-q8ick fix with the
+// proof computed where it is used.
+//
+// A refused city still serves WORK, so the resolver tolerates the standing
+// refusal on a residence probe and the surface falls through to its own scan.
+// That is right until the binding is proven to hold work-prefixed relics: `gc
+// storage migrate` preserved those ids and deleted nothing, so the scan finds
+// the retained pre-migration copy in the city work store, serves it, and the
+// close that follows writes it. Exit 0, no diagnostic.
+//
+// Nothing on disk records the proof. The binding IS readable — the boot gate
+// refused to SERVE it, which is a different claim — so the census that decides
+// this is taken here, against a handle opened for the read and closed after it.
+func TestRefusedCityDeniesTheRelicItsLiveCensusProves(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "carried across by the migration")
+
+	// The control city is refused identically and its binding holds nothing,
+	// which is what makes the denial below attributable to the PROOF rather
+	// than to the refusal.
+	control, _ := foreignProviderCity(t)
+	refuseTheseCities(t, theRefusalARefusedCityCarries(), cityPath, control)
+
+	_, ok, err := cliByIDBindingOwner(cityPath, relic.ID)
+	if err == nil {
+		t.Fatalf("a refused city whose binding holds %s resolved to ok=%v with no error; the caller falls through to its scan and serves the copy the migration retained in the work store", relic.ID, ok)
+	}
+	if !storeref.IsStandingRefusal(err) {
+		t.Errorf("the denial came back as %v, want the standing storage refusal", err)
+	}
+	if !errors.Is(err, storeref.ErrProvenRelicRefusal) {
+		t.Errorf("the denial reads %q and carries nothing that tells it apart from the refusal an in-namespace id takes", err)
+	}
+	if !strings.Contains(err.Error(), "gc doctor") {
+		t.Errorf("the denial reads %q with no route back to a served city", err)
+	}
+	if strings.Contains(err.Error(), "\n") {
+		t.Errorf("the denial is multi-line (%q); callers print it as `gc <cmd>: %%v`, so everything after the newline loses the command that refused", err)
+	}
+
+	if _, ok, err := cliByIDBindingOwner(control, relic.ID); err != nil || ok {
+		t.Errorf("the same refusal over a city whose binding holds no relic resolved to ok=%v err=%v, want a clean fall-through; a census that found nothing proves nothing, and denying there takes work-bead reads away from every unconverged city", ok, err)
+	}
+}
+
+// TestRefusedCityThatCannotOpenItsBindingFallsThrough is the proof's absent
+// case, and it is deliberately the tolerant one.
+//
+// A city whose binding cannot be OPENED has said nothing about what that
+// binding holds, and this bit only ever denies: an unknown must never assert
+// it. So the read falls through exactly as it does today, and the operator
+// keeps the work-bead reads a refused city depends on.
+//
+// The relic is seeded first so the row cannot pass by finding an empty binding.
+// What is pinned is that an unreadable binding counts as no evidence even when
+// the evidence is really there.
+func TestRefusedCityThatCannotOpenItsBindingFallsThrough(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a mode-0 directory is still readable, so the binding cannot be made unopenable this way")
+	}
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "carried across by the migration")
+
+	refuseTheseCities(t, theRefusalARefusedCityCarries(), cityPath)
+	sealTheBindingRoot(t, cityPath)
+
+	owner, ok, err := cliByIDBindingOwner(cityPath, relic.ID)
+	if err != nil {
+		t.Fatalf("a refused city whose binding could not be opened resolved %s to err=%v; a census that could not run is not proof, and denying on it takes work-bead reads away from every city whose binding is merely unreachable", relic.ID, err)
+	}
+	if ok {
+		t.Errorf("a refusing binding reported ownership of %s (%p)", relic.ID, owner.Store)
+	}
+}
+
+// TestServedCityPaysNothingForTheRelicProof is the healthy control, and it is
+// the cost bound as well as the behavior one.
+//
+// The proof exists for a city whose boot REFUSED. A served city's bindings were
+// censused live when the funnel opened them, so a second read could prove
+// nothing the first did not — and taking one would put an engine open on the
+// by-id path of every converged city. Zero plan resolutions is the only shape
+// that rules that out.
+func TestServedCityPaysNothingForTheRelicProof(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	relic := classResidentWorkShapedBead(t, classStore, "gc-relic1", "carried across by the migration")
+	binding := recensusAfterSeedingARelic(t, cityPath)
+	if _, err := workStoreFor(t, cityPath).Create(beads.Bead{Title: "the copy the migration left in the work ledger", Type: "task"}); err != nil {
+		t.Fatalf("seeding the work store's retained copy: %v", err)
+	}
+
+	resolutions := countStoragePlanResolutions(t)
+
+	owner, ok, err := cliByIDBindingOwner(cityPath, relic.ID)
+	if err != nil {
+		t.Fatalf("a served city resolved %s to err=%v", relic.ID, err)
+	}
+	if !ok {
+		t.Fatalf("a served city's binding did not answer for %s; the caller falls through to the work ledger's frozen copy", relic.ID)
+	}
+	if owner.Store != binding {
+		t.Errorf("the owner is %p, want the class binding %p", owner.Store, binding)
+	}
+	if *resolutions != 0 {
+		t.Errorf("a served city resolved %d storage plan(s) on the by-id path; the relic proof is for a REFUSED city, and a served one must not pay an engine open per command", *resolutions)
+	}
+}
+
+// sealTheBindingRoot makes this city's configured binding unopenable, and only
+// for the length of the test.
+//
+// The fixture's provider is this build's own sqlite engine behind a
+// configuration reference, so removing the directory's permissions is what
+// "cannot open the binding" means for it. The bead already inside stays there,
+// which is the point: the proof is absent because the census could not RUN, not
+// because there was nothing to find.
+func sealTheBindingRoot(t *testing.T, cityPath string) {
+	t.Helper()
+	root := filepath.Join(cityPath, ".gc", "engine-infra")
+	info, err := os.Stat(root)
+	if err != nil {
+		t.Fatalf("the fixture's binding root is not at %s: %v", root, err)
+	}
+	if err := os.Chmod(root, 0o000); err != nil {
+		t.Fatalf("sealing %s: %v", root, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, info.Mode().Perm()) })
+}

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -83,7 +83,7 @@ func byIDOwnerForTopology(topo storeref.Topology, id string, work beads.Store) (
 	if err != nil {
 		return storeref.Owner{}, err
 	}
-	owner, err := storeref.ResolveOwnerRow(plan, id)
+	owner, err := withProvenRelicRemedy(storeref.ResolveOwnerRow(plan, id))
 	switch {
 	case err == nil:
 		return owner, nil
@@ -167,7 +167,31 @@ func byIDBindingOwnerForTopology(topo storeref.Topology, id string) (storeref.Ow
 	if err != nil {
 		return storeref.Owner{}, false, err
 	}
-	return storeref.ResolveBindingOwner(plan, id)
+	owner, ok, err := storeref.ResolveBindingOwner(plan, id)
+	owner, err = withProvenRelicRemedy(owner, err)
+	return owner, ok, err
+}
+
+// withProvenRelicRemedy names the operator's next move on the one denial that
+// is otherwise unactionable.
+//
+// storeref decides that a refused binding proven to hold migration-preserved
+// ids may not be skipped, and says why — but it does not know what clears the
+// condition, because that is a fact about this plane's boot gate rather than
+// about a plan. The refusal's own text is the boot gate's, identical to the one
+// a city sees for an infrastructure-class id it simply cannot serve, so an
+// operator reading it looks for a missing bead. What they need is that
+// converging the split is what makes the id resolve from the binding again.
+//
+// The remedy is a SECOND SENTENCE on one line, not a second line. Every caller
+// prints this value as `gc <cmd>: %v`, so an embedded newline drops the command
+// prefix off everything after it and the operator cannot tell which surface
+// refused.
+func withProvenRelicRemedy(owner storeref.Owner, err error) (storeref.Owner, error) {
+	if err == nil || !errors.Is(err, storeref.ErrProvenRelicRefusal) {
+		return owner, err
+	}
+	return owner, fmt.Errorf("%w. Converge the configured [storage] split and this id resolves from the binding again; `gc doctor` reports what is outstanding", err)
 }
 
 // beadForOwner returns the row the owner names, reading it only when the

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -53,13 +53,19 @@ import (
 //
 // An error is a read that FAILED, never absence. Reading "the binding could not
 // answer" as "the bead is not there" is the root-loss shape this lane exists to
-// prevent. The one error that is not a fault is the one-shot funnel's standing
-// refusal: it is a verdict about a CITY's storage configuration and says nothing
-// about a bead, and a refused city still serves WORK from its work ledger. The
-// resolver applies that distinction from the leg's own role — a residence probe
-// for an id no relocated class could own tolerates the refusal, while the
-// authority leg for an id inside a reserved namespace surfaces it, because there
-// the refusal IS the answer.
+// prevent. The one error that is not always a fault is the one-shot funnel's
+// standing refusal: it is a verdict about a CITY's storage configuration and
+// says nothing about a bead, and a refused city still serves WORK from its work
+// ledger. The resolver applies that distinction from the leg's own role — the
+// authority leg for an id inside a reserved namespace surfaces the refusal,
+// because there the refusal IS the answer, while a residence probe for an id no
+// relocated class could own tolerates it.
+//
+// That toleration is conditional, and the condition is a relic census proving
+// the binding holds ids the migration preserved. Then the probe's miss is not
+// harmless — the work store's frozen pre-migration copy is what the caller
+// falls through to — so the refusal is surfaced there too, wrapped by
+// withProvenRelicRemedy with the move that clears it.
 func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error) {
 	return byIDOwnerForTopology(residencyTopologyForCity(cityPath, nil, work, nil), id, work)
 }

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -19,7 +19,8 @@ package main
 // RoleWorkFallback leg is returned UNPROBED, which means "no binding answered —
 // run your own work axis". A caller whose work axis IS a store passes that
 // store and uses the answer directly; a caller whose work axis is a subprocess
-// or a scan passes a sentinel and treats it as the signal to fall through.
+// or a scan asks only the binding half, through storeref.ResolveBindingOwner,
+// and reads its ok=false as the signal to fall through.
 //
 // That residual is also what keeps a single-store city byte-identical: its plan
 // has one leg, nothing is probed, and the caller gets back the exact store value
@@ -144,34 +145,29 @@ func byIDPlanForTopology(topo storeref.Topology, id string) (storeref.ResolvedPl
 // and the id it cannot reach is answered instead by the retained pre-migration
 // copy sitting in the city store — successfully, with no error to notice.
 //
-// So the plan is resolved with a SENTINEL where the work leg goes and the
-// answer is read as a yes/no. ok=true is a binding that owns the id, with the
-// row it already read; ok=false is "no binding answered, run your own scan",
-// and the caller then does exactly what it did before.
+// So the plan is executed by storeref.ResolveBindingOwner, the executor that
+// walks the binding legs and stops at the work axis. ok=true is a binding that
+// owns the id, with the row it already read; ok=false is "no binding answered,
+// run your own scan", and the caller then does exactly what it did before.
 func cliByIDBindingOwner(cityPath, id string) (storeref.Owner, bool, error) {
-	residual := newUnprobedWorkResidual()
-	return byIDBindingOwnerForTopology(residencyTopologyForCity(cityPath, nil, residual, nil), id)
+	return byIDBindingOwnerForTopology(residencyTopologyForCity(cityPath, nil, newUnprobedWorkResidual(), nil), id)
 }
 
 // byIDBindingOwnerForTopology is cliByIDBindingOwner over a topology the caller
 // already holds.
 //
-// That topology's WORK leg must be an unprobedWorkResidual, because ok=false is
-// read off the returned store's type: a topology assembled with a real work
-// store answers ok=true for every id that store holds, which turns "run your own
-// scan" into "the work ledger owns it" — the stale answer this whole seam
-// closes. The residual handed to byIDOwnerForTopology below is a fresh value
-// rather than the caller's, which is sound because the assertion is on the TYPE;
-// both reach the reader as the same "no binding answered".
+// The work leg is still supplied — Plan(ByID) ends every plan in one, and a
+// topology without it is not a topology — but the executor never reads it, so
+// what goes there only has to be a beads.Store. Both call sites pass the
+// unprobedWorkResidual sentinel, which turns a resolver that started probing
+// the work leg into a loud error here rather than a silent "the work ledger
+// owns it" on every convoy command of every relocated city.
 func byIDBindingOwnerForTopology(topo storeref.Topology, id string) (storeref.Owner, bool, error) {
-	owner, err := byIDOwnerForTopology(topo, id, newUnprobedWorkResidual())
+	plan, err := byIDPlanForTopology(topo, id)
 	if err != nil {
 		return storeref.Owner{}, false, err
 	}
-	if _, isResidual := owner.Store.(unprobedWorkResidual); isResidual {
-		return storeref.Owner{}, false, nil
-	}
-	return owner, true, nil
+	return storeref.ResolveBindingOwner(plan, id)
 }
 
 // beadForOwner returns the row the owner names, reading it only when the
@@ -186,12 +182,13 @@ func beadForOwner(owner storeref.Owner, id string) (beads.Bead, error) {
 
 // unprobedWorkResidual stands in for a work axis the resolver must not run.
 //
-// Plan(ByID) ends every plan in a work leg and hands the LAST one back
-// UNPROBED, which is the contract cliByIDBindingOwner rests on: this value is
-// returned, never read. Its Get therefore reports a bug rather than a miss — a
-// resolver that started probing the residual would otherwise turn "the caller
-// runs its own scan" into "the bead is absent", silently, on every convoy
-// command of every relocated city.
+// Plan(ByID) ends every plan in a work leg, so a surface that owns its own work
+// axis still has to put something there. storeref.ResolveBindingOwner
+// guarantees the leg is never read; this value makes a broken guarantee visible
+// instead of plausible. Its Get reports a bug rather than a miss, because a
+// resolver that started probing here would otherwise turn "the caller runs its
+// own scan" into "the work ledger owns it" — silently, on every convoy command
+// of every relocated city.
 //
 // It refuses through a WHOLE beads.Store rather than an embedded nil one, for
 // the reason refusedClassStore already carries: a nil embedded interface makes

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -60,7 +60,25 @@ import (
 // authority leg for an id inside a reserved namespace surfaces it, because there
 // the refusal IS the answer.
 func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error) {
-	plan, err := cliByIDPlan(cityPath, id, work)
+	return byIDOwnerForTopology(residencyTopologyForCity(cityPath, nil, work, nil), id, work)
+}
+
+// byIDOwnerForTopology is cliByIDOwner over a topology the caller already holds.
+//
+// The split is at the topology line because that is the only thing the one-shot
+// funnel contributes: everything below it — the ByID plan, the residual
+// contract, the two miss shapes — is the same question asked of whatever legs
+// are in play. A caller that captured its topology at construction gets the
+// resolver's rules without re-entering the funnel per bead, which is what makes
+// its probe handle and its write handle the same store by construction rather
+// than by coincidence.
+//
+// work is passed again rather than read back off the topology: it is the value
+// the not-found fallback below must return, and reaching into topo.Work.Store
+// for it would be this file picking a store out of a leg — the residency
+// boundary's one forbidden move, and pointless when the caller already has it.
+func byIDOwnerForTopology(topo storeref.Topology, id string, work beads.Store) (storeref.Owner, error) {
+	plan, err := byIDPlanForTopology(topo, id)
 	if err != nil {
 		return storeref.Owner{}, err
 	}
@@ -99,8 +117,19 @@ func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error)
 // seam actually executes rather than one assembled the same way beside it. A
 // pin over a parallel construction proves the topology constructor is right and
 // says nothing about whether the seam still uses it.
+//
+// It stays a composition of the two calls cliByIDOwner makes, not a third
+// spelling of them: the same residencyTopologyForCity and the same
+// byIDPlanForTopology, so the pin cannot drift from the executed path without
+// one of those two changing under both.
 func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, error) {
-	return storeref.Plan(storeref.ByID{ID: id}, residencyTopologyForCity(cityPath, nil, work, nil))
+	return byIDPlanForTopology(residencyTopologyForCity(cityPath, nil, work, nil), id)
+}
+
+// byIDPlanForTopology is the ByID plan itself, the one line both the cityPath
+// and the captured-topology forms go through.
+func byIDPlanForTopology(topo storeref.Topology, id string) (storeref.ResolvedPlan, error) {
+	return storeref.Plan(storeref.ByID{ID: id}, topo)
 }
 
 // cliByIDBindingOwner answers the binding half of the by-id question for a
@@ -120,7 +149,22 @@ func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, 
 // row it already read; ok=false is "no binding answered, run your own scan",
 // and the caller then does exactly what it did before.
 func cliByIDBindingOwner(cityPath, id string) (storeref.Owner, bool, error) {
-	owner, err := cliByIDOwner(cityPath, id, newUnprobedWorkResidual())
+	residual := newUnprobedWorkResidual()
+	return byIDBindingOwnerForTopology(residencyTopologyForCity(cityPath, nil, residual, nil), id)
+}
+
+// byIDBindingOwnerForTopology is cliByIDBindingOwner over a topology the caller
+// already holds.
+//
+// That topology's WORK leg must be an unprobedWorkResidual, because ok=false is
+// read off the returned store's type: a topology assembled with a real work
+// store answers ok=true for every id that store holds, which turns "run your own
+// scan" into "the work ledger owns it" — the stale answer this whole seam
+// closes. The residual handed to byIDOwnerForTopology below is a fresh value
+// rather than the caller's, which is sound because the assertion is on the TYPE;
+// both reach the reader as the same "no binding answered".
+func byIDBindingOwnerForTopology(topo storeref.Topology, id string) (storeref.Owner, bool, error) {
+	owner, err := byIDOwnerForTopology(topo, id, newUnprobedWorkResidual())
 	if err != nil {
 		return storeref.Owner{}, false, err
 	}

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -67,7 +67,7 @@ import (
 // falls through to — so the refusal is surfaced there too, wrapped by
 // withProvenRelicRemedy with the move that clears it.
 func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error) {
-	return byIDOwnerForTopology(residencyTopologyForCity(cityPath, nil, work, nil), id, work)
+	return byIDOwnerForTopology(byIDResidencyTopology(cityPath, nil, work, nil), id, work)
 }
 
 // byIDOwnerForTopology is cliByIDOwner over a topology the caller already holds.
@@ -130,7 +130,7 @@ func byIDOwnerForTopology(topo storeref.Topology, id string, work beads.Store) (
 // byIDPlanForTopology, so the pin cannot drift from the executed path without
 // one of those two changing under both.
 func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, error) {
-	return byIDPlanForTopology(residencyTopologyForCity(cityPath, nil, work, nil), id)
+	return byIDPlanForTopology(byIDResidencyTopology(cityPath, nil, work, nil), id)
 }
 
 // byIDPlanForTopology is the ByID plan itself, the one line both the cityPath
@@ -156,7 +156,7 @@ func byIDPlanForTopology(topo storeref.Topology, id string) (storeref.ResolvedPl
 // owns the id, with the row it already read; ok=false is "no binding answered,
 // run your own scan", and the caller then does exactly what it did before.
 func cliByIDBindingOwner(cityPath, id string) (storeref.Owner, bool, error) {
-	return byIDBindingOwnerForTopology(residencyTopologyForCity(cityPath, nil, newUnprobedWorkResidual(), nil), id)
+	return byIDBindingOwnerForTopology(byIDResidencyTopology(cityPath, nil, newUnprobedWorkResidual(), nil), id)
 }
 
 // byIDBindingOwnerForTopology is cliByIDBindingOwner over a topology the caller

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -410,7 +410,7 @@ func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding
 		}
 		byStore[store] = append(byStore[store], class)
 	}
-	return residencyBindingsFor(order, byStore, routes.hasLegacyResidents)
+	return residencyBindingsFor(order, byStore, routes.hasLegacyResidents, nil)
 }
 
 // residencyBindingsFor turns a store->classes grouping into bindings, and
@@ -424,8 +424,12 @@ func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding
 // relics answers the boot census's question for a binding store. A nil one is
 // the pessimistic answer for every store, which is what a caller holding no
 // censused routes is entitled to claim.
-func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordclass.Class, relics func(beads.Store) bool) ([]storeref.ClassBinding, error) {
-	return storeref.BuildBindings(order, byStore, storeref.BindingOptions{Relics: relics})
+//
+// known answers the proof question for a binding ref, and its nil is the
+// OPPOSITE default: no proof is no evidence, and this bit only ever denies.
+// Nothing supplies it yet; the by-id door's live proof is what will.
+func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordclass.Class, relics func(beads.Store) bool, known func(storeref.StoreRef) bool) ([]storeref.ClassBinding, error) {
+	return storeref.BuildBindings(order, byStore, storeref.BindingOptions{Relics: relics, KnownRelics: known})
 }
 
 // infrastructureClasses is the class set a whole split relocates: every

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -108,6 +108,27 @@ func residencyTopologyForCity(cityPath string, cfg *config.City, work beads.Stor
 	return cliResidencyTopology(cityPath, cfg, work, rigs)
 }
 
+// residencyRoutesForCity returns the routes THIS process answers residency from
+// for cityPath: a running controller's registered ones, else the one-shot
+// funnel's.
+//
+// It is the routes half of the branch above, split out for the by-id door's
+// relic proof, which re-derives the bindings over a topology it already
+// resolved. That re-derivation must read the SAME routes the first one did.
+// Calling the funnel unconditionally would resolve it for a city a controller
+// registered, which is a second handle on the binding root — a duplicate
+// managed-Dolt server or a second sqlite writer, and the reason the
+// registration exists at all. The proof's own gate happens to exclude that case
+// today (a refused city aborts controller construction, so registered routes
+// are never refusing), but a branch that is correct only because of an
+// invariant three files away is one edit from being wrong.
+func residencyRoutesForCity(cityPath string) *storageRoutes {
+	if entry, ok := registeredResidencyEntry(cityPath); ok {
+		return entry.routes
+	}
+	return cliStorageRoutes(cityPath)
+}
+
 // registeredCityWorkStore returns the CITY WORK store the runtime serving
 // cityPath opened at boot, or nil when no runtime here serves that city.
 //
@@ -354,6 +375,7 @@ func resetCLIResidencyBindings() {
 	cliResidencyBindingsMu.Lock()
 	cliResidencyBindingsByCity = nil
 	cliResidencyBindingsMu.Unlock()
+	resetProvenRelicRefs()
 }
 
 // dropCLIResidencyBindings drops one city's memoized funnel answer.
@@ -361,6 +383,7 @@ func dropCLIResidencyBindings(key string) {
 	cliResidencyBindingsMu.Lock()
 	delete(cliResidencyBindingsByCity, key)
 	cliResidencyBindingsMu.Unlock()
+	dropProvenRelicRefs(key)
 }
 
 // residencyBindingsFromRoutes groups the relocated classes by the STORE that
@@ -395,6 +418,26 @@ func dropCLIResidencyBindings(key string) {
 // both of these the resolver's bug, one file over; reuse storeref's
 // identity-based set at that point.
 func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding, error) {
+	return residencyBindingsFromRoutesWithProof(routes, nil)
+}
+
+// residencyBindingsFromRoutesWithProof is the grouping plus a relic PROOF the
+// caller took, for the one plane that has one: the by-id door on a refused
+// city (by_id_relic_proof.go).
+//
+// The proof cannot come from these routes, and that is why it is a parameter.
+// A refused city's every infrastructure class resolves to a refusedClassStore,
+// so routes.hasLegacyResidents answers the pessimistic default and the live
+// boot census never ran — there was no store for it to read. The by-id door
+// opens the configured binding itself and censuses it, then hands the verdict
+// back in here so the binding it applies to is derived exactly once, by this
+// function, for both the proof side and the plan side. Spelling the ref twice
+// is the failure d94358b5aa was written against: the two would agree today and
+// the lookup would miss silently the day either narrowed its class set.
+//
+// A nil proof is the honest "no evidence", which is what every other caller
+// has. It is also the safe one: this bit only ever DENIES a read.
+func residencyBindingsFromRoutesWithProof(routes *storageRoutes, known func(storeref.StoreRef) bool) ([]storeref.ClassBinding, error) {
 	byStore := map[beads.Store][]coordclass.Class{}
 	var order []beads.Store
 	for _, class := range coordclass.Classes() {
@@ -410,7 +453,7 @@ func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding
 		}
 		byStore[store] = append(byStore[store], class)
 	}
-	return residencyBindingsFor(order, byStore, routes.hasLegacyResidents, nil)
+	return residencyBindingsFor(order, byStore, routes.hasLegacyResidents, known)
 }
 
 // residencyBindingsFor turns a store->classes grouping into bindings, and
@@ -427,7 +470,6 @@ func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding
 //
 // known answers the proof question for a binding ref, and its nil is the
 // OPPOSITE default: no proof is no evidence, and this bit only ever denies.
-// Nothing supplies it yet; the by-id door's live proof is what will.
 func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordclass.Class, relics func(beads.Store) bool, known func(storeref.StoreRef) bool) ([]storeref.ClassBinding, error) {
 	return storeref.BuildBindings(order, byStore, storeref.BindingOptions{Relics: relics, KnownRelics: known})
 }

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -52,6 +52,14 @@ func (s refusedClassStore) StorageRefusal() error { return s.err }
 // (storeref.StandingRefusal). The resolver keys its one tolerated non-fault on
 // it: a refused city still serves WORK from its work ledger, so a residence
 // probe for an id no relocated class could own may skip the refusing leg.
+//
+// That carve-out is CONDITIONAL, and storeref.ClassBinding.KnownLegacyResidents
+// is the condition that withdraws it. A binding proven to hold ids outside its
+// reserved namespaces has falsified the sentence above — the migration
+// preserved those ids, so a work-shaped id can be resident there — and
+// ClassBinding.probeRefusalPolicy raises the probe back to PolicyFatal for it.
+// New code written against this marker must not assume the tolerance is
+// unconditional.
 func (standingStorageRefusal) StandingStorageRefusal() {}
 
 // cliResidencyTopology builds the one-shot CLI's topology.

--- a/internal/storeref/bindings.go
+++ b/internal/storeref/bindings.go
@@ -41,6 +41,18 @@ type BindingOptions struct {
 	// "known to hold none" may retire a probe.
 	Relics func(beads.Store) bool
 
+	// KnownRelics answers the same question from a DURABLE record, keyed by the
+	// binding's ref rather than by its store: has a census ever proven this
+	// binding holds a bead outside its reserved namespaces?
+	//
+	// It is separate from Relics because it survives a boot that cannot read
+	// the binding at all — the refused city, where the live census has no store
+	// to ask and every answer falls back to the pessimistic default. A ref the
+	// record does not name is "not known", so nil means "no record to ask" and
+	// the answer is false for every binding: this bit is evidence, and its
+	// absence must never be read as proof.
+	KnownRelics func(StoreRef) bool
+
 	// CompleteClasses rounds an observed class set up to include classes the
 	// calling plane cannot see a store for.
 	//
@@ -74,17 +86,23 @@ func BuildBindings(order []beads.Store, byStore map[beads.Store][]coordclass.Cla
 			classes = opts.CompleteClasses(classes)
 		}
 		prefixes := ReservedPrefixesFor(classes)
+		ref := ClassRef(classes)
+		known := knownLegacyResidents(opts.KnownRelics, ref)
 		bindings = append(bindings, ClassBinding{
 			Classes:  classes,
 			Prefixes: prefixes,
-			Leg:      Leg{Ref: ClassRef(classes), Store: store},
+			Leg:      Leg{Ref: ref, Store: store},
 			// Both bits are observations, and neither is ever optimistic by
 			// default: the mint bit comes from the store's own declaration, so
 			// a store that declares nothing reports false, and the relic bit
 			// comes from a census that was actually run, so a binding no census
 			// reached still has relics as far as this build knows.
-			MintsReserved:      MintsInsideNamespace(store, prefixes),
-			HasLegacyResidents: hasLegacyResidents(opts.Relics, store),
+			MintsReserved: MintsInsideNamespace(store, prefixes),
+			// Proof implies the pessimistic bit, so the two cannot disagree —
+			// a live census that answered "clean" on a binding a durable record
+			// says is dirty is a census that could not read it.
+			HasLegacyResidents:   known || hasLegacyResidents(opts.Relics, store),
+			KnownLegacyResidents: known,
 		})
 		if refusing, ok := store.(RefusingStore); ok && refused == nil {
 			refused = refusing.StorageRefusal()
@@ -116,4 +134,15 @@ func hasLegacyResidents(relics func(beads.Store) bool, store beads.Store) bool {
 		return true
 	}
 	return relics(store)
+}
+
+// knownLegacyResidents applies the durable record, or false when there is none
+// to ask. The default is the opposite of hasLegacyResidents's for the same
+// reason it is safe: this bit only ever DENIES an answer, so an unknown must
+// never assert it.
+func knownLegacyResidents(known func(StoreRef) bool, ref StoreRef) bool {
+	if known == nil {
+		return false
+	}
+	return known(ref)
 }

--- a/internal/storeref/bindings.go
+++ b/internal/storeref/bindings.go
@@ -41,16 +41,20 @@ type BindingOptions struct {
 	// "known to hold none" may retire a probe.
 	Relics func(beads.Store) bool
 
-	// KnownRelics answers the same question from a DURABLE record, keyed by the
-	// binding's ref rather than by its store: has a census ever proven this
-	// binding holds a bead outside its reserved namespaces?
+	// KnownRelics answers the same question from a census the CALLING PLANE
+	// ran, keyed by the binding's ref rather than by its store: did that census
+	// prove this binding holds a bead outside its reserved namespaces?
 	//
 	// It is separate from Relics because it survives a boot that cannot read
 	// the binding at all — the refused city, where the live census has no store
-	// to ask and every answer falls back to the pessimistic default. A ref the
-	// record does not name is "not known", so nil means "no record to ask" and
-	// the answer is false for every binding: this bit is evidence, and its
-	// absence must never be read as proof.
+	// to ask and every answer falls back to the pessimistic default. The plane
+	// supplies a verdict it took itself, at the time it asks, against a handle
+	// it opened for the read; this is deliberately NOT a durable record, which
+	// would go stale in the DENYING direction as relics close over the weeks
+	// after a migration (cmd/gc/by_id_relic_proof.go argues that at length). A
+	// ref the census does not name is "not known", so nil means "no census to
+	// ask" and the answer is false for every binding: this bit is evidence, and
+	// its absence must never be read as proof.
 	KnownRelics func(StoreRef) bool
 
 	// CompleteClasses rounds an observed class set up to include classes the

--- a/internal/storeref/bindings_test.go
+++ b/internal/storeref/bindings_test.go
@@ -87,6 +87,61 @@ func TestBuildBindingsObservesAMintingStore(t *testing.T) {
 	}
 }
 
+// TestBuildBindingsRaisesThePessimisticBitOnProof pins the one clause that
+// makes the two relic bits impossible to disagree.
+//
+// A durable record naming this binding is PROOF of what the pessimistic bit only
+// guesses at, so a live census that answered "clean" against it is a census that
+// could not read the store — never grounds to lower the bit. Without the raise,
+// a build whose Relics predicate answers clean (the ga-dx4ho namespace predicate
+// is the one on the way) would produce MintsReserved+clean and retire the probe
+// on a binding proven to hold relics, and probeRefusalPolicy would never be
+// consulted at all.
+func TestBuildBindingsRaisesThePessimisticBitOnProof(t *testing.T) {
+	graph, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("graph has no reserved mint prefix")
+	}
+	store := bindingTestMinter{Store: beads.NewMemStore(), prefix: graph}
+	bindings, _ := BuildBindings(
+		[]beads.Store{store},
+		map[beads.Store][]coordclass.Class{store: {coordclass.ClassGraph}},
+		BindingOptions{
+			Relics:      func(beads.Store) bool { return false },
+			KnownRelics: func(StoreRef) bool { return true },
+		},
+	)
+	if len(bindings) != 1 {
+		t.Fatalf("got %d bindings, want 1", len(bindings))
+	}
+	if !bindings[0].HasLegacyResidents {
+		t.Error("a binding a durable record PROVES holds relics reports HasLegacyResidents = false; the proof did not raise the pessimistic bit, so a clean live census can still retire its probe")
+	}
+	if bindings[0].probeRetired() {
+		t.Error("the residence probe retired on a binding proven to hold relics; every id the migration preserved there becomes unreachable")
+	}
+}
+
+// TestProbeRetirementIgnoresNeitherRelicBit is the same invariant enforced where
+// it is READ, for a ClassBinding that never went through BuildBindings.
+//
+// The builder's raise keeps the FIELD honest; this keeps the DECISION safe.
+// storeref exports ClassBinding, so a plane assembling one by hand — the CLI
+// already does, for its refused-city topology — can spell the contradictory
+// state the builder cannot produce, and the failure would be silent: a retired
+// probe answers "no such bead" for exactly the ids the proof is about.
+func TestProbeRetirementIgnoresNeitherRelicBit(t *testing.T) {
+	if (ClassBinding{MintsReserved: true, KnownLegacyResidents: true}).probeRetired() {
+		t.Error("a hand-built binding with proof but no pessimistic bit retired its probe; proof must retire nothing")
+	}
+	if (ClassBinding{MintsReserved: true, HasLegacyResidents: true}).probeRetired() {
+		t.Error("a binding carrying the pessimistic bit retired its probe")
+	}
+	if !(ClassBinding{MintsReserved: true}).probeRetired() {
+		t.Error("a mint-truthful binding with neither relic bit did not retire; the two checks above are unfalsifiable")
+	}
+}
+
 // TestBuildBindingsOrdersByRefRegardlessOfInput covers the difference the two
 // copies had drifted into: the CLI plane sorted, the API plane returned map
 // order fixed by whatever sequence its accessors happened to be listed in.

--- a/internal/storeref/plan.go
+++ b/internal/storeref/plan.go
@@ -93,6 +93,22 @@ const (
 	RoleFederationTail
 )
 
+// ownedByCallersWorkAxis reports whether a by-id plan carries this leg on
+// behalf of the CALLER's work axis rather than as part of the resolver's
+// binding half. Both roles are produced only by the by-id planner, so the
+// question is meaningless on any other plan shape and no other plan shape
+// spells either role.
+//
+// ResolveBindingOwner is the reader: it answers about bindings and hands the
+// work axis back untouched. "Untouched" has to mean every leg of that axis, not
+// just the residual — the residual is followed by the shadows of any rig whose
+// configured prefix covers the id, and dedupeLegs can remove the residual
+// outright when the binding resolved back to the work store, leaving shadows
+// with nothing in front of them.
+func (r Role) ownedByCallersWorkAxis() bool {
+	return r == RoleWorkFallback || r == RoleShadow
+}
+
 // String renders the role as it appears in a corpus row.
 func (r Role) String() string {
 	switch r {

--- a/internal/storeref/relic_census.go
+++ b/internal/storeref/relic_census.go
@@ -77,6 +77,30 @@ func HasOpenLegacyResidents(b ClassBinding) bool {
 	return len(relics) > 0
 }
 
+// ProvenLegacyResidents is the PROOF form of the census: the value
+// ClassBinding.KnownLegacyResidents is allowed to be set from.
+//
+// It is HasOpenLegacyResidents with the default inverted, and the inversion is
+// the whole reason there are two. That one decides whether to KEEP a residence
+// probe, so a census that failed answers true — an unread binding has cleared
+// nothing. This one decides whether to DENY a read, so a census that failed
+// answers false: a binding nobody could read has PROVED nothing, and denying on
+// it would take work-bead reads away from every city whose binding is merely
+// unreachable.
+//
+// So the only true answer here is a read that completed and found a resident.
+// It is also the one line to change when the census stops excluding closed
+// beads: swap OpenLegacyResidents for the closed-inclusive form and every
+// caller inherits it, because nobody outside this file names the census
+// directly.
+func ProvenLegacyResidents(b ClassBinding) bool {
+	relics, err := OpenLegacyResidents(b.Leg.Store, b.Prefixes)
+	if err != nil {
+		return false
+	}
+	return len(relics) > 0
+}
+
 // idInAnyNamespace reports whether any prefix claims id's namespace. It is the
 // one rule the census and ClassBinding.coversID both read ids by.
 func idInAnyNamespace(id string, prefixes []string) bool {

--- a/internal/storeref/relic_census_test.go
+++ b/internal/storeref/relic_census_test.go
@@ -131,6 +131,47 @@ func TestUnreadableBindingKeepsItsProbe(t *testing.T) {
 	}
 }
 
+// TestProvenLegacyResidentsFallsTheOTHERWay is the whole reason there are two
+// verdict forms over one census.
+//
+// HasOpenLegacyResidents decides whether to KEEP a probe, so an unreadable
+// binding answers TRUE: nothing has been cleared. ProvenLegacyResidents decides
+// whether to DENY a by-id read on a refused city, so the same binding must
+// answer FALSE: a census that could not run has proved nothing, and denying on
+// it takes work-bead reads away from every city whose binding is merely
+// unreachable. Sharing one default would make one of those two wrong, silently,
+// and in the direction that is hardest to notice from the outside.
+func TestProvenLegacyResidentsFallsTheOTHERWay(t *testing.T) {
+	unreadable := newCensusStore()
+	unreadable.listErr = errors.New("binding unreachable")
+	if ProvenLegacyResidents(censusBinding(unreadable)) {
+		t.Error("an unreadable binding came back PROVEN to hold relics; a census that could not run proves nothing, and this bit only ever denies a read")
+	}
+
+	refused := newCensusStore()
+	refused.listErr = newRefusal()
+	if ProvenLegacyResidents(censusBinding(refused)) {
+		t.Error("a refusing binding came back PROVEN to hold relics")
+	}
+
+	if ProvenLegacyResidents(ClassBinding{Classes: infraClasses, Prefixes: infraPrefixes}) {
+		t.Error("a binding with no store came back PROVEN to hold relics")
+	}
+
+	if ProvenLegacyResidents(censusBinding(newCensusStore())) {
+		t.Error("an empty binding came back PROVEN to hold relics; the three rows above would then be unfalsifiable")
+	}
+
+	// And the one true answer: a read that completed and found a resident.
+	// Without it the rows above pass against a predicate that is simply always
+	// false, which denies nothing and fixes nothing.
+	held := newCensusStore()
+	held.seedBead(t, "ga-relic")
+	if !ProvenLegacyResidents(censusBinding(held)) {
+		t.Error("a binding whose census read a work-shaped relic came back unproven; nothing would ever deny the frozen copy")
+	}
+}
+
 // The refused city takes the same branch, and it matters that it does: its
 // binding store answers every read with the standing refusal, which is the
 // least informative answer there is.

--- a/internal/storeref/residency_conformance_test.go
+++ b/internal/storeref/residency_conformance_test.go
@@ -152,6 +152,29 @@ var residencyCorpus = map[string]string{
 	"Class(graph) x T3":                   "error: storage refused: run `gc storage migrate`",
 	"Class(sessions) x T3":                "error: storage refused: run `gc storage migrate`",
 
+	// ---- T3k: T3 whose binding a durable census PROVED holds ids outside its
+	// reserved namespaces. Every row is character-for-character T3's except the
+	// three residence probes, which become Fatal. The carve-out above rests on
+	// "this leg was only ever a probe for an id no relocated class could own",
+	// and that sentence is known to be false here: the migration preserved ids,
+	// so a work-shaped id CAN be resident in this binding, and the retained
+	// pre-migration copy is sitting in the work store ready to answer for it.
+	"ByID(gcg-abc) x T3k":                  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(ga-xyz) x T3k":                   `FirstOwner: class:gmnos[ResidenceProbe,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(ra-7) x T3k":                     `FirstOwner: class:gmnos[ResidenceProbe,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(ga-xyz,routed) x T3k":            `FirstOwner: class:gmnos[ResidenceProbe,Fatal] > ""[WorkFallback,Fatal] > rig:routed[Shadow,Fatal]`,
+	"ByID(gcg-abc,routed) x T3k":           `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"RoutedWork x T3k":                     "error: storage refused: run `gc storage migrate`",
+	"AssignedWork(sweep) x T3k":            "error: storage refused: run `gc storage migrate`",
+	"AssignedWork(claim-escalation) x T3k": "error: storage refused: run `gc storage migrate`",
+	"Session x T3k":                        "error: storage refused: run `gc storage migrate`",
+	"Census(all) x T3k":                    "error: storage refused: run `gc storage migrate`",
+	"Census(work) x T3k":                   `Union(first-leg-wins): ""[Authority,Fatal]`,
+	"Census(graph) x T3k":                  "error: storage refused: run `gc storage migrate`",
+	"Class(work) x T3k":                    `SingleOwner: ""[Authority,Fatal]`,
+	"Class(graph) x T3k":                   "error: storage refused: run `gc storage migrate`",
+	"Class(sessions) x T3k":                "error: storage refused: run `gc storage migrate`",
+
 	// ---- T4: T2 with the bravo rig suspended. The constructor is TOLD which
 	// rigs to include; the resolver never re-invents an excluded leg.
 	"ByID(gcg-abc) x T4":                  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
@@ -244,6 +267,7 @@ var residencyCorpus = map[string]string{
 	"ByID(gcnq-abc-q) x T1":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
 	"ByID(gcnq-abc-q) x T2":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
 	"ByID(gcnq-abc-q) x T3":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T3k": `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
 	"ByID(gcnq-abc-q) x T4":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
 	"ByID(gcnq-abc-q) x T5":  `FirstOwner: class:g[ResidenceProbe,RefusalTolerated] > class:s[ResidenceProbe,RefusalTolerated] > ""[WorkFallback,Fatal]`,
 	"ByID(gcnq-abc-q) x T6":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
@@ -320,6 +344,15 @@ var residencyRuntimeCorpus = map[string]string{
 	"Session@runtime x T3":                        "error: storage refused: run `gc storage migrate`",
 	"Census(all)@runtime x T3":                    "error: storage refused: run `gc storage migrate`",
 	"ByID(ga-xyz)@runtime x T3":                   `FirstOwner: class:gmnos[ResidenceProbe,RefusalTolerated]`,
+
+	// T3k narrows identically — narrowing keeps a leg's role and policy, so the
+	// Fatal probe stays Fatal here too.
+	"RoutedWork@runtime x T3k":                     "error: storage refused: run `gc storage migrate`",
+	"AssignedWork(sweep)@runtime x T3k":            "error: storage refused: run `gc storage migrate`",
+	"AssignedWork(claim-escalation)@runtime x T3k": "error: storage refused: run `gc storage migrate`",
+	"Session@runtime x T3k":                        "error: storage refused: run `gc storage migrate`",
+	"Census(all)@runtime x T3k":                    "error: storage refused: run `gc storage migrate`",
+	"ByID(ga-xyz)@runtime x T3k":                   `FirstOwner: class:gmnos[ResidenceProbe,Fatal]`,
 
 	"RoutedWork@runtime x T4":                     `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,
 	"AssignedWork(sweep)@runtime x T4":            `Union(first-leg-wins): class:gmnos[FederationTail,Fatal]`,

--- a/internal/storeref/residency_fixtures_test.go
+++ b/internal/storeref/residency_fixtures_test.go
@@ -155,6 +155,15 @@ func (f topoFixture) resetGets() {
 	}
 }
 
+// bindingSpec is one binding of a corpus topology.
+//
+// mints and relics are not independent, and the corpus may not spell a pair
+// production cannot produce. A census only ever runs against a binding whose
+// mint bit verified (cmd/gc's censusBindingRelics), so a binding with mints
+// false was never asked, and BuildBindings leaves it on the pessimistic default:
+// relics TRUE. mints=false with relics=false is therefore unreachable, and a
+// fixture carrying it silently exempts itself from any rule keyed on the
+// pessimistic bit. TestCorpusBindingsAreProductionReachable is the guard.
 type bindingSpec struct {
 	classes  []coordclass.Class
 	prefixes []string
@@ -206,8 +215,11 @@ func buildTopology(name string, rigs map[string]string, specs []bindingSpec, ref
 	return f
 }
 
+// wholeSplit is a binding carrying all five infrastructure classes, unverified:
+// no mint declaration, and therefore never censused, so the pessimistic relic
+// bit stands. A fixture that verifies the mint bit lowers relics explicitly.
 func wholeSplit() bindingSpec {
-	return bindingSpec{classes: infraClasses, prefixes: infraPrefixes}
+	return bindingSpec{classes: infraClasses, prefixes: infraPrefixes, relics: true}
 }
 
 func newT0() topoFixture { return buildTopology("T0", nil, nil, nil) }
@@ -232,7 +244,6 @@ func newT3Known() topoFixture {
 	refusal := newRefusal()
 	spec := wholeSplit()
 	spec.refusing = true
-	spec.relics = true
 	spec.known = true
 	return buildTopology("T3k", nil, []bindingSpec{spec}, refusal)
 }
@@ -249,26 +260,50 @@ func newT4() topoFixture {
 // skip-until row rots, and the tripwire this replaces lived in two files.
 func newT5() topoFixture {
 	return buildTopology("T5", nil, []bindingSpec{
-		{classes: []coordclass.Class{coordclass.ClassGraph}, prefixes: []string{"gcg"}},
-		{classes: []coordclass.Class{coordclass.ClassSessions}, prefixes: []string{"gcs"}},
+		{classes: []coordclass.Class{coordclass.ClassGraph}, prefixes: []string{"gcg"}, relics: true},
+		{classes: []coordclass.Class{coordclass.ClassSessions}, prefixes: []string{"gcs"}, relics: true},
 	}, nil)
 }
 
+// newT6 is the retirement shape: a binding that mints truthfully AND was
+// censused clean, which is the only way the pessimistic bit comes down.
 func newT6() topoFixture {
 	spec := wholeSplit()
 	spec.mints = true
+	spec.relics = false
 	return buildTopology("T6", nil, []bindingSpec{spec}, nil)
 }
 
 func newT6Relics() topoFixture {
 	spec := wholeSplit()
 	spec.mints = true
-	spec.relics = true
 	return buildTopology("T6r", nil, []bindingSpec{spec}, nil)
 }
 
 func allTopologies() []topoFixture {
 	return []topoFixture{newT0(), newT1(), newT2(), newT3(), newT3Known(), newT4(), newT5(), newT6(), newT6Relics()}
+}
+
+// TestCorpusBindingsAreProductionReachable keeps the corpus from asserting about
+// states no city can be in.
+//
+// A fixture in an impossible state is worse than a missing fixture: it looks
+// like coverage. The refused topology carried mints=false with relics=false for
+// exactly this reason, and it made a rule keyed on the pessimistic bit
+// indistinguishable from a rule keyed on the proof — the two collapse only on a
+// binding where the pessimistic bit is false, which a refused binding's never
+// is. Both bits are then checked here rather than in each row.
+func TestCorpusBindingsAreProductionReachable(t *testing.T) {
+	for _, f := range allTopologies() {
+		for _, b := range f.topo.Bindings {
+			if !b.MintsReserved && !b.HasLegacyResidents {
+				t.Errorf("%s binding %s: mints=false with HasLegacyResidents=false; a binding that does not mint truthfully is never censused, so production leaves the pessimistic bit standing", f.name, b.Leg.Ref)
+			}
+			if b.KnownLegacyResidents && !b.HasLegacyResidents {
+				t.Errorf("%s binding %s: proven to hold relics yet pessimistically clean; BuildBindings raises the bit on proof and no city reports this pair", f.name, b.Leg.Ref)
+			}
+		}
+	}
 }
 
 // planString renders a row: the plan, or "error: <msg>" when the intent cannot

--- a/internal/storeref/residency_fixtures_test.go
+++ b/internal/storeref/residency_fixtures_test.go
@@ -18,6 +18,7 @@ import (
 //	T1  whole split: one binding carrying all five infrastructure classes
 //	T2  T1 plus two rigs
 //	T3  standing refusal (the deleted-[storage] trap)
+//	T3k T3 whose binding is PROVEN to have held work-prefixed relics
 //	T4  T2 with one rig suspended — the constructor excluded it
 //	T5  per-class split: graph and sessions on two DIFFERENT bindings
 //	T6  T1 with a mint-truthful binding (the section-5 retirement shape)
@@ -159,6 +160,7 @@ type bindingSpec struct {
 	prefixes []string
 	mints    bool
 	relics   bool
+	known    bool
 	refusing bool
 }
 
@@ -193,11 +195,12 @@ func buildTopology(name string, rigs map[string]string, specs []bindingSpec, ref
 		}
 		f.bindings[ref] = s
 		f.topo.Bindings = append(f.topo.Bindings, ClassBinding{
-			Classes:            append([]coordclass.Class(nil), spec.classes...),
-			Prefixes:           append([]string(nil), spec.prefixes...),
-			Leg:                Leg{Ref: ref, Store: s},
-			MintsReserved:      spec.mints,
-			HasLegacyResidents: spec.relics,
+			Classes:              append([]coordclass.Class(nil), spec.classes...),
+			Prefixes:             append([]string(nil), spec.prefixes...),
+			Leg:                  Leg{Ref: ref, Store: s},
+			MintsReserved:        spec.mints,
+			HasLegacyResidents:   spec.relics,
+			KnownLegacyResidents: spec.known,
 		})
 	}
 	return f
@@ -219,6 +222,19 @@ func newT3() topoFixture {
 	spec := wholeSplit()
 	spec.refusing = true
 	return buildTopology("T3", nil, []bindingSpec{spec}, refusal)
+}
+
+// newT3Known is T3 whose binding a durable census PROVED holds ids outside its
+// reserved namespaces. The refusal is the same; what changes is that the
+// tolerated-refusal rationale — "this leg was only ever a residence probe for an
+// id no relocated class could own" — is known to be false here.
+func newT3Known() topoFixture {
+	refusal := newRefusal()
+	spec := wholeSplit()
+	spec.refusing = true
+	spec.relics = true
+	spec.known = true
+	return buildTopology("T3k", nil, []bindingSpec{spec}, refusal)
 }
 
 // newT4 is T2 with the bravo rig suspended. The constructor is TOLD which rigs
@@ -252,7 +268,7 @@ func newT6Relics() topoFixture {
 }
 
 func allTopologies() []topoFixture {
-	return []topoFixture{newT0(), newT1(), newT2(), newT3(), newT4(), newT5(), newT6(), newT6Relics()}
+	return []topoFixture{newT0(), newT1(), newT2(), newT3(), newT3Known(), newT4(), newT5(), newT6(), newT6Relics()}
 }
 
 // planString renders a row: the plan, or "error: <msg>" when the intent cannot

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -661,7 +661,15 @@ var ErrProvenRelicRefusal = errors.New("a relic census proved this binding holds
 // axis instead of handing the work leg back unprobed.
 func resolveByID(p ResolvedPlan, id string, bindingOnly bool) (Owner, bool, error) {
 	if p.Mode != ModeFirstOwner {
-		return Owner{}, false, fmt.Errorf("storeref: ResolveOwner needs a %s plan, got %s", ModeFirstOwner, p.Mode)
+		// Named for the executor the caller actually called. This is the one
+		// message in the package a shared body can get wrong that way, and a
+		// caller sent to ResolveOwner's contract when it broke
+		// ResolveBindingOwner's reads a doc about a work leg it does not have.
+		executor := "ResolveOwner"
+		if bindingOnly {
+			executor = "ResolveBindingOwner"
+		}
+		return Owner{}, false, fmt.Errorf("storeref: %s needs a %s plan, got %s", executor, ModeFirstOwner, p.Mode)
 	}
 	id = strings.TrimSpace(id)
 	if p.ID != "" && p.ID != id {

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -641,6 +641,21 @@ func ResolveBindingOwner(p ResolvedPlan, id string) (Owner, bool, error) {
 	return resolveByID(p, id, true)
 }
 
+// ErrProvenRelicRefusal explains a by-id denial that a refused city's binding
+// would otherwise have been forgiven for.
+//
+// A standing storage refusal is normally tolerated on a residence probe — a
+// refused city still serves WORK — and the two cases are then indistinguishable
+// in the text: the operator sees the boot gate's own sentence and goes looking
+// for a bead. What actually happened is that a census proved this binding holds
+// ids the migration preserved, which withdrew the carve-out and denied a read
+// that would otherwise have been served from the frozen copy.
+//
+// It is a sentinel as well as a sentence because the remedy is the CALLER's to
+// phrase: this package knows the reason, and not what a plane has to do to make
+// the condition go away. cmd/gc's by-id seam matches on it and appends its own.
+var ErrProvenRelicRefusal = errors.New("a relic census proved this binding holds ids outside its reserved namespaces, so its standing storage refusal is a denial rather than a leg to skip")
+
 // resolveByID is the leg walk both ModeFirstOwner executors share. found
 // reports whether an owner was pinned; bindingOnly stops the walk at the work
 // axis instead of handing the work leg back unprobed.
@@ -672,6 +687,21 @@ func resolveByID(p ResolvedPlan, id string, bindingOnly bool) (Owner, bool, erro
 			// A refused city still serves WORK, and this leg was only ever a
 			// residence probe for an id no relocated class could own.
 			continue
+		case leg.Role == RoleResidenceProbe && leg.OnError == PolicyFatal && IsStandingRefusal(err):
+			// The same refusal on a probe the planner made Fatal: the carve-out
+			// above was withdrawn because this binding is PROVEN to hold ids
+			// outside its reserved namespaces. Say so, or the operator reads a
+			// sentence identical to an in-namespace refusal and looks for a
+			// missing bead rather than for the evidence that denied it.
+			//
+			// The policy is part of the key, not just the role. planByID is the
+			// only producer of a Fatal residence probe today, so keying on the
+			// role alone happens to select the same legs — but the sentence this
+			// arm attaches is a claim about the EVIDENCE, and the evidence is
+			// what set the policy. A second planner that emitted a tolerated
+			// residence probe reaching here would otherwise be told a census
+			// proved something nobody censused (ga-e3dvx).
+			return Owner{Ref: leg.Leg.Ref}, false, fmt.Errorf("reading %q from %s: %w: %w", id, legName(leg.Leg.Ref), err, ErrProvenRelicRefusal)
 		default:
 			return Owner{Ref: leg.Leg.Ref}, false, fmt.Errorf("reading %q from %s: %w", id, legName(leg.Leg.Ref), err)
 		}

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -25,7 +25,11 @@ package storeref
 //     [binding as a residence probe, work, shadows]. `gc storage migrate`
 //     preserves ids, so a relocated bead keeps its work-era prefix; nil from
 //     the namespace gate means "cannot decide", never "work owns it"
-//     (ga-axin6/#5245, #5132). Retired per ClassBinding.MintsReserved.
+//     (ga-axin6/#5245, #5132). Retired per ClassBinding.MintsReserved. The
+//     probe tolerates a standing refusal, because a refused city still serves
+//     work — unless the binding is PROVEN to hold such relics, where skipping
+//     it falls back to the migration's frozen copy rather than to nothing
+//     (ga-q8ick).
 //
 //   ByID, single-store city
 //     [work], returned unprobed. The identity fast-path: a city that relocates
@@ -271,7 +275,7 @@ func planByID(in ByID, t Topology) (ResolvedPlan, error) {
 			if b.probeRetired() {
 				continue
 			}
-			plan.Legs = append(plan.Legs, PlanLeg{Leg: b.Leg, Role: RoleResidenceProbe, OnError: PolicyRefusalTolerated})
+			plan.Legs = append(plan.Legs, PlanLeg{Leg: b.Leg, Role: RoleResidenceProbe, OnError: b.probeRefusalPolicy()})
 		}
 		// Outside every reserved namespace a plane with its own by-id router
 		// owns the work axis, and its answer REPLACES the probed tail below

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -691,25 +691,27 @@ func resolveByID(p ResolvedPlan, id string, bindingOnly bool) (Owner, bool, erro
 			return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref, Bead: b, Read: true}, true, nil
 		case errors.Is(err, beads.ErrNotFound):
 			continue
+		case leg.Role == RoleResidenceProbe && leg.OnError == PolicyFatal && IsStandingRefusal(err):
+			// A residence probe the planner made Fatal: the carve-out below was
+			// withdrawn because this binding is PROVEN to hold ids outside its
+			// reserved namespaces. Say so, or the operator reads a sentence
+			// identical to an in-namespace refusal and looks for a missing bead
+			// rather than for the evidence that denied it.
+			//
+			// The POLICY is the key here, not the role, and this arm is ordered
+			// first so that stays true. planByID is the only producer of a Fatal
+			// residence probe today, so keying on the role alone selects the
+			// same legs — but the sentence this arm attaches is a claim about
+			// the EVIDENCE, and the evidence is what set the policy. Below the
+			// tolerated arm the role key would have been load-bearing for
+			// nothing and unfalsifiable besides; above it, dropping the policy
+			// clause claims every tolerated residence probe and the no-evidence
+			// controls die (ga-e3dvx).
+			return Owner{Ref: leg.Leg.Ref}, false, fmt.Errorf("reading %q from %s: %w: %w", id, legName(leg.Leg.Ref), err, ErrProvenRelicRefusal)
 		case leg.OnError == PolicyRefusalTolerated && IsStandingRefusal(err):
 			// A refused city still serves WORK, and this leg was only ever a
 			// residence probe for an id no relocated class could own.
 			continue
-		case leg.Role == RoleResidenceProbe && leg.OnError == PolicyFatal && IsStandingRefusal(err):
-			// The same refusal on a probe the planner made Fatal: the carve-out
-			// above was withdrawn because this binding is PROVEN to hold ids
-			// outside its reserved namespaces. Say so, or the operator reads a
-			// sentence identical to an in-namespace refusal and looks for a
-			// missing bead rather than for the evidence that denied it.
-			//
-			// The policy is part of the key, not just the role. planByID is the
-			// only producer of a Fatal residence probe today, so keying on the
-			// role alone happens to select the same legs — but the sentence this
-			// arm attaches is a claim about the EVIDENCE, and the evidence is
-			// what set the policy. A second planner that emitted a tolerated
-			// residence probe reaching here would otherwise be told a census
-			// proved something nobody censused (ga-e3dvx).
-			return Owner{Ref: leg.Leg.Ref}, false, fmt.Errorf("reading %q from %s: %w: %w", id, legName(leg.Leg.Ref), err, ErrProvenRelicRefusal)
 		default:
 			return Owner{Ref: leg.Leg.Ref}, false, fmt.Errorf("reading %q from %s: %w", id, legName(leg.Leg.Ref), err)
 		}

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -626,10 +626,13 @@ func ResolveOwnerRow(p ResolvedPlan, id string) (Owner, error) {
 // authoritative owner — succeeding, against the wrong store, with no
 // diagnostic. TestResolveBindingOwnerNeverProbesTheWorkLeg pins the zero.
 //
-// The walk stops at the work axis rather than at the plan's last leg, so legs
-// ordered BELOW work — a rig whose configured prefix shadows the id — are left
-// to the caller too. Declining is always safe; claiming an id a caller's own
-// axis owns is not.
+// The walk stops at the FIRST leg of that axis rather than at the plan's last
+// leg, so legs ordered below it — a rig whose configured prefix shadows the id
+// — are left to the caller too. Declining is always safe; claiming an id a
+// caller's own axis owns is not. The stop reads the leg's role rather than its
+// position, because the residual is not always there to stop at: dedupeLegs
+// removes it on a city whose binding resolved back to the work store, and the
+// shadows behind it stay.
 //
 // A read fault is still an error rather than a decline: a binding that could
 // not answer has said nothing about the id, and turning that into "no binding
@@ -653,13 +656,11 @@ func resolveByID(p ResolvedPlan, id string, bindingOnly bool) (Owner, bool, erro
 		return Owner{}, false, errors.New("storeref: plan has no legs")
 	}
 	for i, leg := range p.Legs {
-		if leg.Role == RoleWorkFallback {
-			if bindingOnly {
-				return Owner{}, false, nil
-			}
-			if i == len(p.Legs)-1 {
-				return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref}, true, nil
-			}
+		if bindingOnly && leg.Role.ownedByCallersWorkAxis() {
+			return Owner{}, false, nil
+		}
+		if leg.Role == RoleWorkFallback && i == len(p.Legs)-1 {
+			return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref}, true, nil
 		}
 		b, err := leg.Leg.Store.Get(id)
 		switch {

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -594,24 +594,73 @@ type Owner struct {
 // binding — the hot path, and exactly the funnel cost the identity fast-path
 // exists to avoid.
 func ResolveOwnerRow(p ResolvedPlan, id string) (Owner, error) {
+	owner, found, err := resolveByID(p, id, false)
+	switch {
+	case err != nil:
+		return owner, err
+	case !found:
+		return Owner{}, beads.ErrNotFound
+	default:
+		return owner, nil
+	}
+}
+
+// ResolveBindingOwner is the ModeFirstOwner executor for a caller that owns its
+// own work axis: it answers only the BINDING half of the by-id question.
+//
+// `gc convoy`'s member scan and the `gc bd` class door reach a work store that
+// is not a beads.Store — a directory of files, a subprocess they shell out to —
+// so they cannot let the resolver walk the work leg on their behalf. What they
+// need is the one thing they cannot compute themselves: whether a relocated
+// class binding owns this id. `ok` false means "no binding answered; run your
+// own axis", and it is returned WITHOUT touching the work leg the plan carries
+// for everyone else.
+//
+// That untouched work leg is the whole point. `gc storage migrate` preserved
+// ids and deleted nothing, so the work store still holds a frozen copy of every
+// relocated bead. Probing it here would hand a caller its own stale copy as an
+// authoritative owner — succeeding, against the wrong store, with no
+// diagnostic. TestResolveBindingOwnerNeverProbesTheWorkLeg pins the zero.
+//
+// The walk stops at the work axis rather than at the plan's last leg, so legs
+// ordered BELOW work — a rig whose configured prefix shadows the id — are left
+// to the caller too. Declining is always safe; claiming an id a caller's own
+// axis owns is not.
+//
+// A read fault is still an error rather than a decline: a binding that could
+// not answer has said nothing about the id, and turning that into "no binding
+// owns it" sends the caller straight at the frozen copy.
+func ResolveBindingOwner(p ResolvedPlan, id string) (Owner, bool, error) {
+	return resolveByID(p, id, true)
+}
+
+// resolveByID is the leg walk both ModeFirstOwner executors share. found
+// reports whether an owner was pinned; bindingOnly stops the walk at the work
+// axis instead of handing the work leg back unprobed.
+func resolveByID(p ResolvedPlan, id string, bindingOnly bool) (Owner, bool, error) {
 	if p.Mode != ModeFirstOwner {
-		return Owner{}, fmt.Errorf("storeref: ResolveOwner needs a %s plan, got %s", ModeFirstOwner, p.Mode)
+		return Owner{}, false, fmt.Errorf("storeref: ResolveOwner needs a %s plan, got %s", ModeFirstOwner, p.Mode)
 	}
 	id = strings.TrimSpace(id)
 	if p.ID != "" && p.ID != id {
-		return Owner{}, fmt.Errorf("storeref: plan was resolved for %q, executed for %q — a by-id plan is id-specific", p.ID, id)
+		return Owner{}, false, fmt.Errorf("storeref: plan was resolved for %q, executed for %q — a by-id plan is id-specific", p.ID, id)
 	}
 	if len(p.Legs) == 0 {
-		return Owner{}, errors.New("storeref: plan has no legs")
+		return Owner{}, false, errors.New("storeref: plan has no legs")
 	}
 	for i, leg := range p.Legs {
-		if leg.Role == RoleWorkFallback && i == len(p.Legs)-1 {
-			return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref}, nil
+		if leg.Role == RoleWorkFallback {
+			if bindingOnly {
+				return Owner{}, false, nil
+			}
+			if i == len(p.Legs)-1 {
+				return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref}, true, nil
+			}
 		}
 		b, err := leg.Leg.Store.Get(id)
 		switch {
 		case err == nil:
-			return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref, Bead: b, Read: true}, nil
+			return Owner{Store: leg.Leg.Store, Ref: leg.Leg.Ref, Bead: b, Read: true}, true, nil
 		case errors.Is(err, beads.ErrNotFound):
 			continue
 		case leg.OnError == PolicyRefusalTolerated && IsStandingRefusal(err):
@@ -619,10 +668,10 @@ func ResolveOwnerRow(p ResolvedPlan, id string) (Owner, error) {
 			// residence probe for an id no relocated class could own.
 			continue
 		default:
-			return Owner{Ref: leg.Leg.Ref}, fmt.Errorf("reading %q from %s: %w", id, legName(leg.Leg.Ref), err)
+			return Owner{Ref: leg.Leg.Ref}, false, fmt.Errorf("reading %q from %s: %w", id, legName(leg.Leg.Ref), err)
 		}
 	}
-	return Owner{}, beads.ErrNotFound
+	return Owner{}, false, nil
 }
 
 // ResolvePlacement is the ModeSingleOwner executor: the one store a

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -612,13 +612,21 @@ func ResolveOwnerRow(p ResolvedPlan, id string) (Owner, error) {
 // ResolveBindingOwner is the ModeFirstOwner executor for a caller that owns its
 // own work axis: it answers only the BINDING half of the by-id question.
 //
-// `gc convoy`'s member scan and the `gc bd` class door reach a work store that
-// is not a beads.Store — a directory of files, a subprocess they shell out to —
-// so they cannot let the resolver walk the work leg on their behalf. What they
-// need is the one thing they cannot compute themselves: whether a relocated
-// class binding owns this id. `ok` false means "no binding answered; run your
-// own axis", and it is returned WITHOUT touching the work leg the plan carries
-// for everyone else.
+// `gc convoy`'s member scan and `gc beads show`'s store fallback reach a work
+// store that is not a beads.Store — a directory of files, a subprocess they
+// shell out to — so they cannot let the resolver walk the work leg on their
+// behalf. What they need is the one thing they cannot compute themselves:
+// whether a relocated class binding owns this id. `ok` false means "no binding
+// answered; run your own axis", and it is returned WITHOUT touching the work
+// leg the plan carries for everyone else.
+//
+// The `gc bd` class door is a caller of that SHAPE which this seam does not yet
+// serve, and naming it here would misreport the tree. It reaches its binding
+// through cmd/gc's plain bindings memo and hand-rolls the tolerated-refusal
+// carve-out over its own graph handle (cmd/gc/cmd_bd_by_id.go,
+// cmd/gc/claim_class_route.go), so it never sees the proven-relic bit and still
+// answers — and closes — a refused city's by-id read from the frozen
+// pre-migration copy. Converting it is deferred, not done: ga-3htcm.
 //
 // That untouched work leg is the whole point. `gc storage migrate` preserved
 // ids and deleted nothing, so the work store still holds a frozen copy of every

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -245,6 +245,80 @@ func TestResidenceProbeRetirementFlip(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// The binding-only executor. A surface whose work axis is not a beads.Store —
+// `gc convoy`'s directory scan, `gc bd`'s subprocess fall-through — asks only
+// the binding half of the by-id question and runs its own axis for the rest.
+
+// TestResolveBindingOwnerNeverProbesTheWorkLeg is the executor's whole contract:
+// the work leg is in the plan (it has to be — the plan is the same one every
+// by-id surface gets) and is never READ. A caller whose work axis is a scan
+// would otherwise be told its own retained pre-migration copy is the owner.
+func TestResolveBindingOwnerNeverProbesTheWorkLeg(t *testing.T) {
+	f := newT1()
+	f.work.seed(t, workShapedID) // the copy `gc storage migrate` retained
+	plan := mustPlan(t, ByID{ID: workShapedID}, f.topo)
+	f.resetGets()
+
+	owner, ok, err := ResolveBindingOwner(plan, workShapedID)
+	if err != nil {
+		t.Fatalf("a clean binding miss produced an error: %v", err)
+	}
+	if ok {
+		t.Fatalf("the work store's copy of %s came back as a binding owner (%s); ok=false is what tells the caller to run its own axis", workShapedID, storeNameOf(owner.Store))
+	}
+	if *f.work.gets != 0 {
+		t.Fatalf("the work leg was probed %d time(s), want 0 — this executor answers about the BINDING and must never run an axis the caller owns", *f.work.gets)
+	}
+}
+
+// TestResolveBindingOwnerReturnsTheBindingRow is the other half: a binding that
+// DOES hold the id answers with the row it already read, so the caller does not
+// pay for the same read twice — and does not open a window in which the second
+// read disagrees with the one ownership was decided from.
+func TestResolveBindingOwnerReturnsTheBindingRow(t *testing.T) {
+	f := newT1()
+	f.legStore(ClassRef(infraClasses)).seed(t, workShapedID)
+	plan := mustPlan(t, ByID{ID: workShapedID}, f.topo)
+
+	owner, ok, err := ResolveBindingOwner(plan, workShapedID)
+	if err != nil {
+		t.Fatalf("ResolveBindingOwner: %v", err)
+	}
+	if !ok {
+		t.Fatalf("a binding-resident id resolved to ok=false; the caller would fall through to a work axis that holds a stale copy or nothing at all")
+	}
+	if owner.Ref != ClassRef(infraClasses) {
+		t.Fatalf("pinned %q (%s), want the binding", owner.Ref, storeNameOf(owner.Store))
+	}
+	if !owner.Read || owner.Bead.ID != workShapedID {
+		t.Fatalf("the winning probe's row was dropped (Read=%v, bead %q); the leg's read IS the caller's read", owner.Read, owner.Bead.ID)
+	}
+}
+
+// TestResolveBindingOwnerSurfacesAReadFault keeps the fail-loud classification
+// on this executor too: a binding that could not answer has said nothing about
+// the id, and reporting that as "no binding owns it" sends the caller's own
+// scan at the ledger holding the frozen copy.
+func TestResolveBindingOwnerSurfacesAReadFault(t *testing.T) {
+	f := newT1()
+	boom := errors.New("binding unreachable")
+	f.legStore(ClassRef(infraClasses)).getErr = boom
+	plan := mustPlan(t, ByID{ID: workShapedID}, f.topo)
+
+	if _, ok, err := ResolveBindingOwner(plan, workShapedID); !errors.Is(err, boom) {
+		t.Fatalf("an unreadable binding resolved to (ok=%v, err=%v), want the read failure", ok, err)
+	}
+}
+
+func TestResolveBindingOwnerRejectsAUnionPlan(t *testing.T) {
+	f := newT1()
+	plan := mustPlan(t, RoutedWork{}, f.topo)
+	if _, _, err := ResolveBindingOwner(plan, workShapedID); err == nil {
+		t.Fatal("ResolveBindingOwner accepted a Union plan; the mode decides the executor")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Executor guards.
 
 func TestResolveOwnerRejectsAMismatchedID(t *testing.T) {

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -322,6 +322,39 @@ func TestResolveBindingOwnerNeverProbesTheWorkLeg(t *testing.T) {
 	}
 }
 
+// TestProvenRelicRefusalSaysWhyItRefused pins the sentence apart from the
+// verdict.
+//
+// The two refusal outcomes are decided by evidence the operator cannot see and
+// reported in text they cannot tell apart: a tolerated probe and a denied one
+// both end in the boot gate's own sentence, so a denial reads as "your bead is
+// missing on a broken city" rather than "a census proved this binding holds the
+// id and the copy you would have been served is frozen". The sentinel is what
+// lets the plane that OWNS the proof name where it is written down.
+func TestProvenRelicRefusalSaysWhyItRefused(t *testing.T) {
+	proven := mustPlan(t, ByID{ID: workShapedID}, newT3Known().topo)
+	_, _, err := ResolveBindingOwner(proven, workShapedID)
+	if err == nil {
+		t.Fatal("a proven-relic refused city resolved cleanly")
+	}
+	if !errors.Is(err, ErrProvenRelicRefusal) {
+		t.Errorf("the denial reads %v, and carries nothing that distinguishes it from the refusal an in-namespace id takes", err)
+	}
+	if !IsStandingRefusal(err) {
+		t.Errorf("the denial stopped reading as a standing storage refusal (%v); callers classify on that", err)
+	}
+
+	// The control the sentinel needs: a leg that genuinely could not be READ is
+	// a fault, not this denial, and attaching the relic sentence to it would
+	// send an operator at a note that has nothing to do with the failure.
+	f := newT1()
+	f.legStore(ClassRef(infraClasses)).getErr = errors.New("binding unreachable")
+	faulted := mustPlan(t, ByID{ID: workShapedID}, f.topo)
+	if _, _, err := ResolveBindingOwner(faulted, workShapedID); errors.Is(err, ErrProvenRelicRefusal) {
+		t.Errorf("an ordinary read fault came back as a proven-relic denial: %v", err)
+	}
+}
+
 // TestResolveBindingOwnerLeavesEveryLegBelowWorkAlone carries that zero to the
 // legs the work leg stands in front of.
 //

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -234,7 +234,7 @@ func TestBindingOwnerSurfacesTheRefusalOnAProvenRelicBinding(t *testing.T) {
 		t.Fatalf("a proven-relic refused city resolved to ok=%v with no error; the caller's own scan then serves the copy the migration left behind", ok)
 	}
 
-	// Control: no proof, no denial. An absent memo is not evidence, and work
+	// Control: no proof, no denial. Absence of evidence is not evidence, and work
 	// never left the work ledger.
 	tolerated := mustPlan(t, ByID{ID: workShapedID}, newT3().topo)
 	owner, ok, err := ResolveBindingOwner(tolerated, workShapedID)

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -462,11 +462,23 @@ func TestResolveBindingOwnerSurfacesAReadFault(t *testing.T) {
 	}
 }
 
+// TestResolveBindingOwnerRejectsAUnionPlan also pins WHICH executor the
+// refusal names.
+//
+// The guard is shared by both ModeFirstOwner executors, so it is the one
+// sentence in this package that can name a function the caller did not call.
+// The message is a caller's only pointer back to the contract it broke, and
+// sending someone reading ResolveBindingOwner's fall-through semantics to
+// ResolveOwner's doc is a wrong answer delivered with total confidence.
 func TestResolveBindingOwnerRejectsAUnionPlan(t *testing.T) {
 	f := newT1()
 	plan := mustPlan(t, RoutedWork{}, f.topo)
-	if _, _, err := ResolveBindingOwner(plan, workShapedID); err == nil {
+	_, _, err := ResolveBindingOwner(plan, workShapedID)
+	if err == nil {
 		t.Fatal("ResolveBindingOwner accepted a Union plan; the mode decides the executor")
+	}
+	if !strings.Contains(err.Error(), "ResolveBindingOwner") {
+		t.Errorf("the refusal reads %q and names an executor this caller never called", err)
 	}
 }
 
@@ -481,11 +493,19 @@ func TestResolveOwnerRejectsAMismatchedID(t *testing.T) {
 	}
 }
 
+// TestResolveOwnerRejectsAUnionPlan is the other half of the naming pin: the
+// shared guard must still name THIS executor for the caller that walks the
+// whole plan, or a fix that stopped hard-coding one name has just hard-coded
+// the other.
 func TestResolveOwnerRejectsAUnionPlan(t *testing.T) {
 	f := newT1()
 	plan := mustPlan(t, RoutedWork{}, f.topo)
-	if _, _, err := ResolveOwner(plan, workShapedID); err == nil {
+	_, _, err := ResolveOwner(plan, workShapedID)
+	if err == nil {
 		t.Fatal("ResolveOwner accepted a Union plan; the mode decides the executor")
+	}
+	if !strings.Contains(err.Error(), "ResolveOwner") || strings.Contains(err.Error(), "ResolveBindingOwner") {
+		t.Errorf("the refusal reads %q, want the whole-plan executor named", err)
 	}
 }
 

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -322,6 +322,74 @@ func TestResolveBindingOwnerNeverProbesTheWorkLeg(t *testing.T) {
 	}
 }
 
+// TestResolveBindingOwnerLeavesEveryLegBelowWorkAlone carries that zero to the
+// legs the work leg stands in front of.
+//
+// The work leg is not the last leg of a by-id plan on a city with rigs: a rig
+// whose CONFIGURED prefix also covers the id follows it as a shadow. Those legs
+// belong to the caller's axis for the same reason the work leg does — a surface
+// that scans a directory for its city scans its rigs the same way — so a walk
+// that merely declined the work leg and kept going would answer with a rig
+// store, succeeding against a store this executor promised not to touch.
+//
+// Both production callers pass rigs=nil, so nothing reached this shape and the
+// contract sentence was pinning itself.
+func TestResolveBindingOwnerLeavesEveryLegBelowWorkAlone(t *testing.T) {
+	f := newT2()
+	alpha := f.rigs["alpha"]
+	alpha.seed(t, rigShapedID)
+	plan := mustPlan(t, ByID{ID: rigShapedID}, f.topo)
+	f.resetGets()
+
+	owner, ok, err := ResolveBindingOwner(plan, rigShapedID)
+	if err != nil {
+		t.Fatalf("a clean binding miss produced an error: %v", err)
+	}
+	if ok {
+		t.Fatalf("a leg below the work axis (%s) came back as the binding owner of %s; ok=false is what hands the id to the caller's own scan", storeNameOf(owner.Store), rigShapedID)
+	}
+	if *alpha.gets != 0 {
+		t.Fatalf("the rig shadow leg was probed %d time(s), want 0", *alpha.gets)
+	}
+	if got := *f.legStore(ClassRef(infraClasses)).gets; got != 1 {
+		t.Fatalf("the binding was probed %d time(s), want 1 — the walk has to reach the work axis for a stop there to mean anything", got)
+	}
+}
+
+// TestResolveBindingOwnerStopsAtAShadowTheDedupeExposed is that stop with the
+// work leg itself gone.
+//
+// dedupeLegs drops a repeat of a store the plan already carries, and on a city
+// whose binding resolved back to the work store — the shape that function's own
+// doc names — the work leg is the repeat. What survives is a plan whose
+// caller-owned legs wear RoleShadow and nothing else, so a stop keyed on
+// RoleWorkFallback alone walks straight past them and probes a rig.
+func TestResolveBindingOwnerStopsAtAShadowTheDedupeExposed(t *testing.T) {
+	f := newT2()
+	f.topo.Bindings[0].Leg.Store = f.work // the binding IS the work ledger
+	alpha := f.rigs["alpha"]
+	alpha.seed(t, rigShapedID)
+
+	plan := mustPlan(t, ByID{ID: rigShapedID}, f.topo)
+	for _, leg := range plan.Legs {
+		if leg.Role == RoleWorkFallback {
+			t.Fatalf("plan %s still carries a work-fallback leg; the dedupe this row is about did not happen", plan)
+		}
+	}
+	f.resetGets()
+
+	owner, ok, err := ResolveBindingOwner(plan, rigShapedID)
+	if err != nil {
+		t.Fatalf("a clean binding miss produced an error: %v", err)
+	}
+	if ok {
+		t.Fatalf("%s answered as the binding owner of %s on a plan whose work leg the dedupe removed", storeNameOf(owner.Store), rigShapedID)
+	}
+	if *alpha.gets != 0 {
+		t.Fatalf("the rig shadow leg was probed %d time(s), want 0", *alpha.gets)
+	}
+}
+
 // TestResolveBindingOwnerReturnsTheBindingRow is the other half: a binding that
 // DOES hold the id answers with the row it already read, so the caller does not
 // pay for the same read twice — and does not open a window in which the second

--- a/internal/storeref/resolve_test.go
+++ b/internal/storeref/resolve_test.go
@@ -195,6 +195,57 @@ func TestStandingRefusalIsToleratedOnlyOutsideTheReservedNamespace(t *testing.T)
 	}
 }
 
+// TestStandingRefusalSurfacesOnAProvenRelicBinding is the other side of that
+// carve-out, and it is a bug fix rather than a symmetry.
+//
+// Tolerating the refusal is justified by one sentence — "this leg was only ever
+// a residence probe for an id no relocated class could own" — and a durable
+// census that PROVED this binding holds ids outside its reserved namespaces has
+// falsified it. `gc storage migrate` preserved those ids and deleted nothing, so
+// the work store still holds a copy of every one of them. Skipping the refusing
+// binding here does not fall back to "no answer": it falls back to the frozen
+// pre-migration copy, successfully, and the write that follows lands on it.
+//
+// So the probe becomes Fatal and the refusal reaches the caller, naming the
+// remedy. This deliberately denies work-shaped by-id reads on a refused city
+// that is proven to hold relics: that city is already in an incident state its
+// boot gate reported, and a loud denial during an incident beats a confident
+// wrong-copy write.
+func TestStandingRefusalSurfacesOnAProvenRelicBinding(t *testing.T) {
+	f := newT3Known()
+	plan := mustPlan(t, ByID{ID: workShapedID}, f.topo)
+
+	_, ref, err := ResolveOwner(plan, workShapedID)
+	if err == nil {
+		t.Fatalf("a refused city whose binding is proven to hold relics answered %q for a work-shaped id; the retained pre-migration copy lives there", ref)
+	}
+	if !errors.Is(err, f.topo.Refused) {
+		t.Fatalf("the surfaced error is not the refusal that names the remedy: %v", err)
+	}
+}
+
+// TestBindingOwnerSurfacesTheRefusalOnAProvenRelicBinding carries the same
+// verdict to the executor the scan-backed surfaces use. This is the one that
+// matters in production: ok=false there is not a miss, it is permission to run a
+// directory scan that CAN reach the frozen copy.
+func TestBindingOwnerSurfacesTheRefusalOnAProvenRelicBinding(t *testing.T) {
+	proven := mustPlan(t, ByID{ID: workShapedID}, newT3Known().topo)
+	if _, ok, err := ResolveBindingOwner(proven, workShapedID); err == nil {
+		t.Fatalf("a proven-relic refused city resolved to ok=%v with no error; the caller's own scan then serves the copy the migration left behind", ok)
+	}
+
+	// Control: no proof, no denial. An absent memo is not evidence, and work
+	// never left the work ledger.
+	tolerated := mustPlan(t, ByID{ID: workShapedID}, newT3().topo)
+	owner, ok, err := ResolveBindingOwner(tolerated, workShapedID)
+	if err != nil {
+		t.Fatalf("a refused city with no relic evidence resolved to err=%v, want a clean decline: %s", err, storeNameOf(owner.Store))
+	}
+	if ok {
+		t.Errorf("a refusing binding reported ownership of %s (%s)", workShapedID, storeNameOf(owner.Store))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // §6 T5 — the identity fast-path. A single-store city pays nothing for a seam
 // it cannot use (the ga-4qdfn short-circuit, as a resolver property).

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -124,6 +124,24 @@ type ClassBinding struct {
 	// observed would retire the probe on any converged city the moment it
 	// booted, stranding every id the migration preserved.
 	HasLegacyResidents bool
+
+	// KnownLegacyResidents reports whether a census has PROVEN this binding
+	// holds such a relic. It is the same subject as HasLegacyResidents and the
+	// opposite kind of claim: that field is a pessimistic default that a census
+	// may lower, this one is evidence that only a census may raise. A
+	// constructor with nothing to cite leaves it false.
+	//
+	// The distinction is worth a second bool because the two are read for
+	// opposite purposes. HasLegacyResidents decides whether to KEEP a probe, so
+	// its unknown must be true; this one decides whether to DENY an answer, so
+	// its unknown must be false. Collapsing them would either retire probes on
+	// unknown or deny reads on unknown, and both are the failure this package
+	// exists to prevent, in one direction or the other.
+	//
+	// True here always implies HasLegacyResidents — every constructor derives
+	// the pessimistic bit from the same or a weaker source — so "proven relics
+	// on a retired probe" is not a state a caller has to reason about.
+	KnownLegacyResidents bool
 }
 
 // Topology is the store arrangement of one city.
@@ -223,6 +241,23 @@ func (b ClassBinding) coversID(id string) bool { return idInAnyNamespace(id, b.P
 // are required — a point-in-time "zero relics" on a binding that still mints
 // work-shaped ids re-strands the very next create.
 func (b ClassBinding) probeRetired() bool { return b.MintsReserved && !b.HasLegacyResidents }
+
+// probeRefusalPolicy is the error policy a residence probe over this binding
+// carries.
+//
+// The tolerated-refusal carve-out rests on one sentence — a refused city still
+// serves WORK, so a probe for an id no relocated class could own may skip the
+// refusing leg — and a binding PROVEN to hold ids outside its reserved
+// namespaces has falsified it. Skipping it there does not fall back to "no
+// answer": the migration preserved those ids and deleted nothing, so it falls
+// back to the frozen pre-migration copy in the work store, which answers
+// confidently and wrongly.
+func (b ClassBinding) probeRefusalPolicy() ErrPolicy {
+	if b.KnownLegacyResidents {
+		return PolicyFatal
+	}
+	return PolicyRefusalTolerated
+}
 
 // RefusingStore is the optional interface a store implements to declare that it
 // is a standing storage refusal rather than a servable binding. A topology

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -138,9 +138,11 @@ type ClassBinding struct {
 	// unknown or deny reads on unknown, and both are the failure this package
 	// exists to prevent, in one direction or the other.
 	//
-	// True here always implies HasLegacyResidents — every constructor derives
-	// the pessimistic bit from the same or a weaker source — so "proven relics
-	// on a retired probe" is not a state a caller has to reason about.
+	// True here always implies HasLegacyResidents, so "proven relics on a
+	// retired probe" is not a state a caller has to reason about. BuildBindings
+	// makes that true of the FIELD by raising the pessimistic bit on proof, and
+	// probeRetired makes it true of the DECISION for a binding assembled by
+	// hand — the two are pinned separately, in bindings_test.go.
 	KnownLegacyResidents bool
 }
 
@@ -240,7 +242,22 @@ func (b ClassBinding) coversID(id string) bool { return idInAnyNamespace(id, b.P
 // binding: it mints truthfully AND holds no open legacy resident. Both halves
 // are required — a point-in-time "zero relics" on a binding that still mints
 // work-shaped ids re-strands the very next create.
-func (b ClassBinding) probeRetired() bool { return b.MintsReserved && !b.HasLegacyResidents }
+func (b ClassBinding) probeRetired() bool { return b.MintsReserved && !b.holdsLegacyResidents() }
+
+// holdsLegacyResidents is the relic question read as ONE answer: the pessimistic
+// bit, or the proof that outranks it.
+//
+// BuildBindings already raises HasLegacyResidents on proof, so for a binding it
+// built the two clauses agree and this reads the same field twice. It is here
+// for the bindings it did not build. ClassBinding is exported and planes
+// assemble one by hand — cmd/gc's refused-city topology does — so the
+// contradictory shape (proven, yet pessimistically clean) is spellable, and it
+// would be silent: a retired probe answers "no such bead" for precisely the ids
+// the proof is about. Enforcing the implication where the decision is made costs
+// one clause and cannot be bypassed by a constructor.
+func (b ClassBinding) holdsLegacyResidents() bool {
+	return b.HasLegacyResidents || b.KnownLegacyResidents
+}
 
 // probeRefusalPolicy is the error policy a residence probe over this binding
 // carries.

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -198,7 +198,7 @@ cmd/gc/ready_federation.go	readyRigLegStores	ast:returns-store-list	1
 cmd/gc/residency_topology.go	cliSoleClassBinding	ast:plan-leg-store-chain	1
 cmd/gc/residency_topology.go	cliSoleClassBinding	b:cliSoleClassBinding	1
 cmd/gc/residency_topology.go	cliSoleClassBinding	c:plan-leg-store-access	1
-cmd/gc/residency_topology.go	residencyBindingsFromRoutes	b:routes.storeFor	1
+cmd/gc/residency_topology.go	residencyBindingsFromRoutesWithProof	b:routes.storeFor	1
 internal/api/dashport_support.go	BeadStores	a:BeadStores	1
 internal/api/dashport_support.go	BeadStores	ast:returns-store-list	1
 internal/api/handler_agents.go	findActiveBeadForAssigneesWithFreshness	a:BeadStores	1


### PR DESCRIPTION
`gc beads show <id>` on a city that migrated its infrastructure classes and then stopped being able to serve the binding exits **0** with the pre-migration copy. `gc storage migrate` preserves ids and deletes nothing, so the work ledger still holds a frozen twin of every relocated bead; the residency resolver tolerates the city's standing storage refusal on a residence probe — a refused city still serves WORK — and the surface falls through to its own directory scan, which finds that twin and reports it as current. No error, no diagnostic, and the close that follows writes it. That is ga-q8ick.

This branch withdraws the toleration for exactly one shape of city: one whose binding is **proven** to still hold ids outside the namespaces it declares.

## What changed since the last review

The previously-approved version fed the proof from a durable note under the city's own `.gc/` (`.gc/storage-relic-census.json`, produced by s8). **That status file is gone**, and the design changed with it: the proof is now **computed live at by-id time**, on a refused city only.

Two reasons the note was the wrong shape. It is a status file, which this codebase does not keep (`AGENTS.md`: *no status files — query live state*), and it goes stale in the **denying** direction — relics close over the weeks after a migration, so a note written in March denies reads in June for a binding that has been clean since April.

The premise it existed to work around is false anyway. **"Refused" is a verdict about SERVING a binding**, not about reading one: a convergence check, a served-binding note, a discipline the boot gate enforces. Almost none of those say the binding is unreadable. So the census runs against a handle opened for the read and closed after it, and its answer is about the binding as it is now.

- `storeref.ProvenLegacyResidents` is `HasOpenLegacyResidents` **with the default inverted**, and the inversion is why there are two. That one decides whether to KEEP a probe, so an unreadable binding answers `true`. This one decides whether to DENY a read, so the same binding answers `false`: a census that could not run has proved nothing.
- `byIDResidencyTopology` gates the whole thing on `Topology.Refused`. A served city's bindings were censused live when the funnel opened them, so a second read could prove nothing the first did not — and taking one would put an engine open on the by-id path of every converged city.
- The refused city is **re-derived** through `residencyBindingsFromRoutesWithProof` rather than patched in place, so both relic bits and the ref they are keyed by come from the one derivation.
- Every way of not reaching an answer — a config that will not load, a plan that will not resolve, a provider that opens no engine, an **open that fails** — is proof-absent and falls through exactly as today.

### Can the proof re-derive over a controller's registered routes?

No — and it is now structural rather than incidental. A refused city aborts controller construction (`city_runtime.go`: `storageBootGate` error ⇒ `return nil, err`), so registered routes are never refusing and the `Topology.Refused != nil` gate provably excludes them. Relying on an invariant three files away is still one edit from being wrong, so the re-derivation goes through `residencyRoutesForCity`, which returns a running controller's registered routes when there are any and only otherwise the one-shot funnel. Resolving the funnel for a city a controller registered is a second handle on the binding root — a duplicate managed-Dolt server or a second sqlite writer — and that is the reason the registration exists at all.

## Known residual (ga-q8ick follow-up)

The census this gates on is **main's open-only** one (`storeref.OpenLegacyResidents`). s5's closed-inclusive census is being re-cut in parallel and is not on this base, so **a binding whose only relics are CLOSED still reads as unproven and its frozen twin is still served**. Closing that is a one-line swap, deliberately structured as one: `ProvenLegacyResidents` is the only caller that names the census, and its doc comment says so.

## Commits

Rebased onto `origin/main` @ `fc7a23a292`. All eleven of the previous head's contributor commits are carried with `-x`; the SHAs are new. s8's own commits are dropped — they are in the `fc7a23a292` squash.

| | commit | carried from |
|---|---|---|
| 1 | `7131d9d4fa` refactor(gc): split the by-id residency seam at the topology line | `cfa2b5634a` |
| 2 | `a428a9fc5f` refactor(storeref): give binding-only by-id resolution its own executor | `5563f05baf` |
| 3 | `bbaeede0f9` fix(storeref): refuse a refused city's by-id read when its binding is proven to hold relics | `5bafebae1a` |
| 4 | `49c794b381` test(storeref): pin the relic-bit implication and make the corpus reachable | `fad9f80099` |
| 5 | `b49b8caf42` fix(storeref): stop binding-only resolution at every leg of the caller's axis | `eede08964d` |
| 6 | `6d59a6f44c` fix(storeref): say why a proven-relic by-id denial refused, and pin the note | `02ff37960b` |
| 7 | `329229ba3a` docs(residency): correct the refusal-tolerance comments and name the executor | `fab32855b9` |
| 8 | `f9b875a2eb` fix(gc): prove a refused city's relics at by-id time instead of from a note | `8afc3608fe` + the baseline row rename |
| 9 | `39e12a773c` test(gc): compose the relic denial from the census that produced the proof | `36753e4f0a` |
| 10 | `d56af32ca0` test(beads): pin the relic denial at the `gc beads show` surface itself | `7df2f95c67` |
| 11 | `0b022a3618` fix(gc): never let the relic proof create the binding it is asked about | `4a2dea5ad4` |
| 12 | `f37b86a520` fix(residency): rename the baseline row #5597 renamed the function under | *new — base-owned, droppable; see below* |

**`e23cc60ea9`'s rename is now needed, and is folded into commit 8.** On the old base the guard **allowlisted `cmd/gc/residency_topology.go` wholesale**, so the file carried no baseline row and that commit was a no-op. s4 #5643 (`7746bbe5ab`) closed that evasion and pinned the file's hits as rows, so on `main` the row exists and commit 8's `residencyBindingsFromRoutes` → `residencyBindingsFromRoutesWithProof` rename moves it. Regenerated by the baseline header's documented three-emitter splice (`--emit-baseline`, `RESIDENCY_BASELINE_EMIT=1 go test ./scripts -run TestResidencyResolverBoundary`, `… -run TestResidencyASTExpressionRatchet`, concatenated and `LC_ALL=C sort`ed, header kept). **114 rows before, 114 after** — a rename, not growth. The header prose names neither renamed function, and the "six rows, six hits" block is still six.

## Review reconciliations applied

- **ga-e3dvx** — the denial arm keys on `leg.OnError == PolicyFatal`, not only on `Role`. It is also **ordered above** the tolerated arm, because below it the policy clause was unreachable and the key would have been unfalsifiable. It is load-bearing now (see mutations).
- **The remedy is one line.** Callers print `gc <cmd>: %v`, so the original's embedded `\n` dropped the command prefix off the half that named the remedy. `withProvenRelicRemedy` (renamed from `withRelicNoteRemedy`, which named a note that no longer exists) appends the remedy as a **second sentence** on one line, and both the value and the printed output are pinned.
- **`TestBeadsShowRefusesTheRelicItWouldOtherwiseServeFrozen`** and **`TestRefusedCityDeniesTheRelicIts…`** are kept, re-pointed at the live proof. The frozen twin is seeded for real; the proof is computed, never written.
- Doc comments on every exported symbol.

## RED → GREEN

Written red first, against commit 7:

```
=== RUN   TestRefusedCityDeniesTheRelicItsLiveCensusProves
    by_id_relic_proof_test.go:79: a refused city whose binding holds gc-relic1
    resolved to ok=false with no error; the caller falls through to its scan and
    serves the copy the migration retained in the work store
--- FAIL: TestRefusedCityDeniesTheRelicItsLiveCensusProves (0.06s)
--- PASS: TestRefusedCityThatCannotOpenItsBindingFallsThrough (0.03s)
--- PASS: TestServedCityPaysNothingForTheRelicProof (0.10s)
```

That is the ga-q8ick symptom verbatim. The other two are controls that must hold across the change. After commit 8:

```
--- PASS: TestRefusedCityDeniesTheRelicItsLiveCensusProves (0.06s)
--- PASS: TestRefusedCityThatCannotOpenItsBindingFallsThrough (0.02s)
--- PASS: TestServedCityPaysNothingForTheRelicProof (0.12s)
```

## Mutation probes

| mutation | dies |
|---|---|
| drop `leg.OnError == PolicyFatal` from `resolveByID`'s denial arm | `TestStandingRefusalIsToleratedOnlyOutsideTheReservedNamespace`, `TestBindingOwnerSurfacesTheRefusalOnAProvenRelicBinding`, `TestBindingOwnerRefusedCityWithoutProofStillDeclines`, and both new controls |
| `probeRefusalPolicy` forced to `PolicyRefusalTolerated` | `TestRefusedCityDeniesTheRelicItsLiveCensusProves` |
| drop the denial arm entirely | `TestRefusedCityDeniesTheRelicItsLiveCensusProves` (loses the sentinel and the remedy) |
| `ProvenLegacyResidents` returns `true` on a census error | `TestProvenLegacyResidentsFallsTheOTHERWay` — the CLI rows cannot reach it, because a binding that cannot be *opened* never gets as far as a `List` |
| the proof keys on a narrowed ref (`ClassRef(b.Classes[:1])`) | `TestTheProofAndTheRefusedFunnelSpellTheBindingRefTheSameWay` **and** the denial row — but only the first names the reason |
| `doBeadsShowFallback` reads every error as fall-through | `TestBeadsShowRefusesTheRelicItWouldOtherwiseServeFrozen` **only** — the frame below stays green, which is why that row exists |

## Gates

| command | exit |
|---|---|
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `gofmt -l cmd internal scripts` | 0 (nothing printed) |
| `golangci-lint run ./cmd/gc/... ./internal/storeref/... ./internal/storebinding/...` | 0 — `0 issues.` |
| `./scripts/check-residency-boundary.sh` | 0 |
| `go test ./internal/storeref/... ./internal/storebinding/... -count=1` | 0 |
| `go test ./cmd/gc -run 'ByID\|Residency\|Relic\|BeadsShow\|Refused' -count=1 -v` | 0 — **82** `--- PASS`, 0 `--- FAIL` |
| `make check-docs` | 0 |
| `make test-fast-parallel` | 0 |

Refs ga-q8ick.

---

## Review follow-up: the proof must not create the binding it is asked about

`4a2dea5ad4`. `beads.OpenSQLiteStore` **creates** the database when it is absent, so opening the binding as a probe made it answer its own question — on a binding that was not there it would create one, census it, find nothing, and report clean. The city this happens to is the **never-migrated** one (a `[storage]` split configured and never cut over), which is the most common refused city there is, and on it an ordinary by-id read reached this path. The damage is what it leaves behind: an empty binding root that a later boot reads as a genesis root on a city that never cut over, and on a workspace-backed provider a managed engine started for a *read*.

`infraBindingHoldsNothing` already argues the rule for the migration's own no-open probe — *"a probe that creates the database it is asked about would be answering its own question"* — so existence is now checked **before** the open, through the same two helpers (`infraBindingRootEnumerable`, `infraPathExists`) rather than a second spelling of them. A binding that is not already on disk is proof-absent and falls through exactly as an unreadable one does.

`resolveInfraBindingTarget` answers only for the built-in bead engine, so a binding served by any other provider takes a second branch: the **provider** is asked where it serves from (`servedBindingLocation`) and that location has to exist. A location that is remote, opaque or simply absent is proof-absent — the safe direction.

**RED, both arms.** Against `7df2f95c67`:

```
--- FAIL: TestTheRelicProofNeverCreatesTheBindingItIsAskedAbout
    the relic proof CREATED the binding database
    .../never-migrated/graph/beads.sqlite as the side effect of a by-id read
    (stat err = <nil>); the next boot then finds a genesis root on a city that
    never cut over
    the relic proof CREATED the binding root .../never-migrated as the side
    effect of a by-id read (stat err = <nil>)
```

The second arm — **root present and empty, database absent** (a binding volume mounted but never written, or a genesis root rolled back) — is what makes the *database* check load-bearing, because the root check passes there. GREEN after the fix, with `TestRefusedCityDeniesTheRelicItsLiveCensusProves` (database present ⇒ still denies) and the other four controls unchanged.

**Mutation.** Dropping the database-exists check kills the second arm on the created file. The root check is deliberately **not** independently falsifiable and the doc comment says so: every way it can fail also makes the database stat answer absent-or-error, and both decline. It is kept so this precondition reads the same as the migration probe's, which is where the rule is argued — not because it is a second condition.

Gates re-run at `4a2dea5ad4`, all exit 0: `go build ./...`, `go vet ./...`, `gofmt -l cmd internal scripts` (nothing printed), `golangci-lint` (`0 issues.`), `./scripts/check-residency-boundary.sh`, `go test ./internal/storeref/... ./internal/storebinding/... -count=1`, targeted `cmd/gc` run **83** `--- PASS` / 0 FAIL, `make check-docs`, `make test-fast-parallel` ("All fast jobs passed").


---

## Rebase onto `main`

`f37b86a520`. Retargeted from `residency/storeref-series` to `main` now that s8 #5597 has merged as the squash `fc7a23a292` and s4 #5643 as `7746bbe5ab`. Branched from `origin/main` and cherry-picked **only this PR's eleven** commits with `-x`; s8's twelve are dropped, because they are in that squash — and the squash also carries fix commits (`0165a56fd1`, `21fa4eb892`) that were never on the `f79429f461` head this branch was originally cut from.

**No textual conflicts.** All eleven applied clean. `cmd/gc/cmd_bd_by_id.go` did not conflict: s8's squash moved the relocated-class reads into the new `cmd/gc/bd_relocated_classes.go`, and this PR's by-id seam is confined to `cmd/gc/by_id_residency.go`. The one reconciliation the rebase did need is the residency boundary baseline, described under **Commits** — the rename that was a no-op on the old base and is load-bearing on this one.

**The design is carried unchanged.** Re-verified on the rebased tree, not assumed: `ResolveBindingOwner` is `resolveByID(p, id, true)` and stops at the caller's work axis **by role** (`ownedByCallersWorkAxis` = `RoleWorkFallback || RoleShadow`); `holdsLegacyResidents` is `HasLegacyResidents || KnownLegacyResidents`, so the known bit only ever **denies**, and `BuildBindings` raises the pessimistic bit on proof; `probeRefusalPolicy` returns `PolicyFatal` keyed on `KnownLegacyResidents`, and `resolveByID`'s denial arm keys on `leg.OnError == PolicyFatal` **ordered above** the tolerated arm; `ProvenLegacyResidents` returns **false** on a census error, failing the other way from `HasOpenLegacyResidents`; the live proof is computed on a refused city only (`topo.Refused == nil` ⇒ return), memoized per process and dropped with the residency memo, and gated by `refusedBindingIsAlreadyOnDisk` before any open; the T3k corpus rows are intact.

**The closed-inclusive swap did NOT happen — deliberately.** Checked on `main` rather than assumed: `internal/storeref` exports only the open-only census (`OpenLegacyResidents` / `HasOpenLegacyResidents`, with `TestOpenLegacyResidentsIgnoresAClosedRelic` pinning the exclusion). There is no `LegacyResidents` / `HasLegacyResidents` census function — s5's closed-inclusive verdict is still not on `main`. So the open-only gate stands and **the "Known residual" section above is still accurate and is kept**. The swap remains the one line its doc comment advertises.

### Base-owned red, disclosed

`./scripts/check-residency-boundary.sh` **exits 1 on `origin/main` @ `fc7a23a292` itself**, before this branch touches anything. Proven on an untouched export of `origin/main` (`git archive origin/main` into a scratch dir, run there):

```
RESIDENCY-BOUNDARY: cmd/gc/infra_class_migrate.go infraBindingIDPrefix d:ReservedClassPrefix: 1 sites, baseline 0 — a NEW store-enumeration site.
RESIDENCY-BOUNDARY: cmd/gc/infra_class_migrate.go openInfraDestination d:ReservedClassPrefix: 0 sites, baseline 1 — the baseline must SHRINK …
```

That is **ga-kkcby**, and a one-row fix PR for `main` is in flight. It is not caused by this change and is not this branch's to own — but the baseline is one file with one ratchet, and the documented regeneration emits current reality, so it cannot be regenerated around while re-keying this branch's own row. It is therefore carried as commit 12, **last and alone**, and it **drops out as an empty rebase step** once the main fix merges: both sides re-key the row identically. Nothing else in the branch depends on it.

### Mutation probes re-run on the rebased tree

| mutation | dies |
|---|---|
| drop `leg.OnError == PolicyFatal` from `resolveByID`'s denial arm | `TestStandingRefusalIsToleratedOnlyOutsideTheReservedNamespace`, `TestBindingOwnerSurfacesTheRefusalOnAProvenRelicBinding`, `TestBindingOwnerRefusedCityWithoutProofStillDeclines`, `TestRefusedCityDeniesTheRelicItsLiveCensusProves`, `TestRefusedCityThatCannotOpenItsBindingFallsThrough`, `TestBeadsShowRefusesTheRelicItWouldOtherwiseServeFrozen`, `TestTheRelicProofNeverCreatesTheBindingItIsAskedAbout` — **and two rows this base adds**: `TestClassRoutedStoreForIDKeepsWorkOnARefusedCity`, `TestControllerResidencyTopologyCarriesTheStandingRefusal` |
| drop the `refusedBindingIsAlreadyOnDisk` existence gate | `TestTheRelicProofNeverCreatesTheBindingItIsAskedAbout` **only**, on all three of its arms (database created; root created; database created inside an existing empty root) |

Both restored; the tree is byte-clean after each.

### Gates at `f37b86a520`

| command | exit |
|---|---|
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `gofmt -l cmd internal scripts` | 0 (nothing printed) |
| `golangci-lint run ./cmd/gc/... ./internal/storeref/... ./internal/storebinding/...` | 0 — `0 issues.` |
| `./scripts/check-residency-boundary.sh` | 0 |
| `go test ./scripts -count=1` (the guard's AST half) | 0 |
| `go test ./internal/storeref/... ./internal/storebinding/... -count=1` | 0 |
| `go test ./cmd/gc -run 'ByID\|Residency\|Relic\|BeadsShow\|Refused' -count=1 -v` | 0 — **86** `--- PASS`, 0 `--- FAIL`, 0 skipped (82 → 83 → 86; this base adds rows). All seven `by_id_relic_proof_test.go` rows present and passing. |
| `make check-docs` | 0 |
| `make test-fast-parallel` | 0 — "All fast jobs passed" |

Refs ga-q8ick, ga-kkcby.
