### PR TITLE
Let pool workers discover template-assigned ready work

### DIFF
--- a/internal/config/workquery.go
+++ b/internal/config/workquery.go
@@ -571,6 +571,40 @@ func standardAssignedReadyWorkQueryScript(topo QueryTopology) string {
 		`done; `
 }
 
+// hasConfiguredPoolTemplate reports whether a is configured as a pool
+// template — the identity ready work can be assigned to before it is claimed
+// down to a specific instance. Gated on MinActiveSessions alone, not the
+// broader SupportsInstanceExpansion condition (session_capacity.go), which
+// also fires on a bare ScaleCheck override with no pool membership; that
+// wider condition would add this tier's script for agents that never
+// configure a template identity at all.
+func (a *Agent) hasConfiguredPoolTemplate() bool {
+	if a == nil {
+		return false
+	}
+	return a.MinActiveSessions != nil
+}
+
+// templateAssignedReadyTierScript adds a fallback read for ready work
+// assigned directly to a pool's shared template identity. A configured
+// ephemeral pool member ($GC_TEMPLATE set, $GC_SESSION_ORIGIN ephemeral)
+// queries the template identity only after every concrete identity above it
+// has come up empty, so ready work assigned to the template — not yet
+// claimed down to any specific instance — stays discoverable. Named/manual
+// sessions and non-pool agents never match the case guard, and a session
+// from a different pool never matches the exact-assignee read, so the tier
+// is a no-op for them.
+func templateAssignedReadyTierScript(a *Agent, topo QueryTopology) string {
+	if !a.hasConfiguredPoolTemplate() {
+		return ""
+	}
+	return `if [ -n "$GC_TEMPLATE" ]; then case "$GC_SESSION_ORIGIN" in ` +
+		`ephemeral|"") ` +
+		assignedReadyTierCommand("GC_TEMPLATE", topo) +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0 ;; ` +
+		`esac; fi; `
+}
+
 func legacyControlAssignedWorkQueryScript(topo QueryTopology) string {
 	return legacyControlAssignedInProgressWorkQueryScript(topo) +
 		legacyControlAssignedReadyWorkQueryScript(topo)
@@ -798,6 +832,7 @@ func buildWorkQuery(a *Agent, topo QueryTopology) string {
 	legacyTarget := legacyWorkflowControlQualifiedName(target)
 	if legacyTarget == "" {
 		script := standardAssignedWorkQueryScript(topo) +
+			templateAssignedReadyTierScript(a, topo) +
 			poolDemandOriginGateScript() +
 			poolDemandFirstRowFunctionScript(topo) +
 			`probe_pool_demand "$1"; ` +
@@ -857,7 +892,7 @@ func buildAssignedReadyQuery(a *Agent, topo QueryTopology) string {
 	if legacyWorkflowControlQualifiedName(target) != "" {
 		return shellquote.Join([]string{"sh", "-c", legacyControlAssignedReadyWorkQueryScript(topo) + `printf "[]"`})
 	}
-	return shellquote.Join([]string{"sh", "-c", standardAssignedReadyWorkQueryScript(topo) + `printf "[]"`})
+	return shellquote.Join([]string{"sh", "-c", standardAssignedReadyWorkQueryScript(topo) + templateAssignedReadyTierScript(a, topo) + `printf "[]"`})
 }
 
 // EffectiveRoutedPoolQuery returns the routed-pool-only command for prompt

--- a/internal/config/workquery_pool_template_ready_test.go
+++ b/internal/config/workquery_pool_template_ready_test.go
@@ -1,0 +1,286 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	poolTemplateReadyAssignee = "foundations/worker"
+	poolMemberReadyAssignee   = "foundations/worker-1"
+)
+
+// exactAssigneeReadyReader models the raw beads contract deliberately: a
+// --assignee read returns a row only when the requested spelling is byte-equal
+// to one of the configured answers. Pool membership is therefore exercised in
+// the generated Gas City query, not smuggled into the reader double.
+const exactAssigneeReadyReader = `#!/bin/sh
+set -eu
+case "$1" in
+  ready)
+    case " $* " in
+      *" --status in_progress "*) printf '[]'; exit 0 ;;
+    esac
+    assignee=""
+    for arg in "$@"; do
+      case "$arg" in
+        --assignee=*) assignee=${arg#--assignee=} ;;
+      esac
+    done
+    if [ -n "${READY_LOG:-}" ] && [ -n "$assignee" ]; then
+      printf '%s\n' "$assignee" >> "$READY_LOG"
+    fi
+    if [ -n "${PRIMARY_ASSIGNEE:-}" ] && [ "$assignee" = "$PRIMARY_ASSIGNEE" ]; then
+      printf '[{"id":"%s","status":"open","issue_type":"task","assignee":"%s"}]' "$PRIMARY_BEAD" "$PRIMARY_ASSIGNEE"
+    elif [ -n "${FALLBACK_ASSIGNEE:-}" ] && [ "$assignee" = "$FALLBACK_ASSIGNEE" ]; then
+      printf '[{"id":"%s","status":"open","issue_type":"task","assignee":"%s"}]' "$FALLBACK_BEAD" "$FALLBACK_ASSIGNEE"
+    else
+      printf '[]'
+    fi
+    ;;
+  *) printf '[]' ;;
+esac
+`
+
+type poolReadyQueryShape struct {
+	name  string
+	build func(*Agent, QueryTopology) string
+}
+
+func poolReadyQueryShapes() []poolReadyQueryShape {
+	return []poolReadyQueryShape{
+		{name: "work_query", build: (*Agent).EffectiveWorkQueryFor},
+		{name: "assigned_ready_query", build: (*Agent).EffectiveAssignedReadyQueryFor},
+	}
+}
+
+func poolReadyQueryTopologies() []struct {
+	name string
+	topo QueryTopology
+} {
+	return []struct {
+		name string
+		topo QueryTopology
+	}{
+		{
+			name: "single_store_bd_ready",
+			topo: QueryTopology{Beads: BeadsConfig{BDCompatibility: BeadsBDCompatibility105}},
+		},
+		{
+			name: "federated_gc_ready",
+			topo: QueryTopology{
+				Beads:          BeadsConfig{BDCompatibility: BeadsBDCompatibility105},
+				FederatedReady: true,
+			},
+		},
+	}
+}
+
+func configuredPoolTemplateAgent() *Agent {
+	return &Agent{
+		Name:              "worker",
+		Dir:               "foundations",
+		MinActiveSessions: ptrInt(0),
+		MaxActiveSessions: ptrInt(3),
+	}
+}
+
+func poolMemberReadyEnv(logPath string) map[string]string {
+	return map[string]string{
+		"GC_SESSION_ID":     "gc-session-worker-1",
+		"GC_SESSION_NAME":   poolMemberReadyAssignee,
+		"GC_ALIAS":          poolMemberReadyAssignee,
+		"GC_AGENT":          poolMemberReadyAssignee,
+		"GC_TEMPLATE":       poolTemplateReadyAssignee,
+		"GC_SESSION_ORIGIN": "ephemeral",
+		"READY_LOG":         logPath,
+		"PRIMARY_ASSIGNEE":  "no-concrete-match",
+		"PRIMARY_BEAD":      "ga-concrete-ready",
+		"FALLBACK_ASSIGNEE": poolTemplateReadyAssignee,
+		"FALLBACK_BEAD":     "ga-template-ready",
+	}
+}
+
+func runPoolReadyQuery(t *testing.T, agent *Agent, topo QueryTopology, build func(*Agent, QueryTopology) string, env map[string]string) generatedQueryResult {
+	t.Helper()
+	gcScript := fakeBDEmpty
+	bdScript := exactAssigneeReadyReader
+	if topo.FederatedReady {
+		gcScript = exactAssigneeReadyReader
+		bdScript = fakeBDEmpty
+	}
+	return runGeneratedQueryWithBD(t, build(agent, topo), env, gcScript, bdScript)
+}
+
+// TestPoolMemberDefaultQueriesDiscoverTemplateAssignedReadyWork is the RED
+// reproduction for ga-8vz95k. A configured pool member owns concrete runtime
+// identities, but ready work may be assigned to the shared template. Both
+// generated query surfaces must explicitly ask the exact reader for that
+// template after exhausting the concrete identities.
+func TestPoolMemberDefaultQueriesDiscoverTemplateAssignedReadyWork(t *testing.T) {
+	for _, topology := range poolReadyQueryTopologies() {
+		for _, shape := range poolReadyQueryShapes() {
+			t.Run(topology.name+"/"+shape.name, func(t *testing.T) {
+				logPath := filepath.Join(t.TempDir(), "ready-assignees")
+				res := runPoolReadyQuery(t, configuredPoolTemplateAgent(), topology.topo, shape.build, poolMemberReadyEnv(logPath))
+				if res.exit != 0 {
+					t.Fatalf("generated query exited %d: stderr=%q stdout=%q", res.exit, res.stderr, res.stdout)
+				}
+				if !strings.Contains(res.stdout, "ga-template-ready") {
+					t.Fatalf("generated query output = %q, want ready work assigned to pool template %q", res.stdout, poolTemplateReadyAssignee)
+				}
+
+				invocations, err := os.ReadFile(logPath)
+				if err != nil {
+					t.Fatalf("read exact-reader invocation log: %v", err)
+				}
+				lines := strings.Fields(string(invocations))
+				templateAt := -1
+				lastConcreteAt := -1
+				for i, assignee := range lines {
+					switch assignee {
+					case poolTemplateReadyAssignee:
+						templateAt = i
+					case "gc-session-worker-1", poolMemberReadyAssignee:
+						lastConcreteAt = i
+					}
+				}
+				if templateAt < 0 {
+					t.Fatalf("exact reader assignees = %v, want an explicit %q fallback; raw --assignee matching must remain exact", lines, poolTemplateReadyAssignee)
+				}
+				if templateAt <= lastConcreteAt {
+					t.Fatalf("exact reader assignees = %v, want every concrete identity before shared template %q", lines, poolTemplateReadyAssignee)
+				}
+			})
+		}
+	}
+}
+
+// TestPoolMemberConcreteReadyIdentityPrecedesTemplate protects the existing
+// identity order. Shared-template compatibility is a fallback for ready work,
+// never a replacement for the concrete owner candidates.
+func TestPoolMemberConcreteReadyIdentityPrecedesTemplate(t *testing.T) {
+	for _, topology := range poolReadyQueryTopologies() {
+		for _, shape := range poolReadyQueryShapes() {
+			t.Run(topology.name+"/"+shape.name, func(t *testing.T) {
+				logPath := filepath.Join(t.TempDir(), "ready-assignees")
+				env := poolMemberReadyEnv(logPath)
+				env["PRIMARY_ASSIGNEE"] = poolMemberReadyAssignee
+				env["PRIMARY_BEAD"] = "ga-concrete-ready"
+
+				res := runPoolReadyQuery(t, configuredPoolTemplateAgent(), topology.topo, shape.build, env)
+				if res.exit != 0 {
+					t.Fatalf("generated query exited %d: stderr=%q stdout=%q", res.exit, res.stderr, res.stdout)
+				}
+				if !strings.Contains(res.stdout, "ga-concrete-ready") || strings.Contains(res.stdout, "ga-template-ready") {
+					t.Fatalf("generated query output = %q, want concrete ready work before shared-template fallback", res.stdout)
+				}
+
+				invocations, err := os.ReadFile(logPath)
+				if err != nil {
+					t.Fatalf("read exact-reader invocation log: %v", err)
+				}
+				if strings.Contains(string(invocations), poolTemplateReadyAssignee+"\n") {
+					t.Fatalf("exact reader assignees = %q, shared template was queried before the concrete match returned", invocations)
+				}
+			})
+		}
+	}
+}
+
+// TestTemplateAssignedReadyFallbackRequiresConfiguredEphemeralPoolMembership
+// prevents suffix parsing or session-origin widening from turning a shared
+// queue into cross-session ownership. Each case offers work only for the
+// fallback assignee; the generated query must remain empty.
+func TestTemplateAssignedReadyFallbackRequiresConfiguredEphemeralPoolMembership(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    *Agent
+		override map[string]string
+	}{
+		{
+			name:  "ordinary_singleton",
+			agent: &Agent{Name: "auditor", Dir: "foundations", MaxActiveSessions: ptrInt(1)},
+			override: map[string]string{
+				"GC_TEMPLATE":       "foundations/auditor",
+				"FALLBACK_ASSIGNEE": "foundations/auditor",
+			},
+		},
+		{
+			name:  "numeric_suffix_lookalike",
+			agent: &Agent{Name: "worker-1", Dir: "foundations", MaxActiveSessions: ptrInt(1)},
+			override: map[string]string{
+				"GC_SESSION_NAME":   "foundations/worker-1",
+				"GC_ALIAS":          "foundations/worker-1",
+				"GC_AGENT":          "foundations/worker-1",
+				"GC_TEMPLATE":       "foundations/worker-1",
+				"FALLBACK_ASSIGNEE": "foundations/worker",
+			},
+		},
+		{
+			name:  "configured_named_session",
+			agent: configuredPoolTemplateAgent(),
+			override: map[string]string{
+				"GC_SESSION_ORIGIN": "named",
+			},
+		},
+		{
+			name:  "manual_session",
+			agent: configuredPoolTemplateAgent(),
+			override: map[string]string{
+				"GC_SESSION_ORIGIN": "manual",
+			},
+		},
+		{
+			name: "member_of_different_pool",
+			agent: &Agent{
+				Name:              "worker-a",
+				Dir:               "foundations",
+				MinActiveSessions: ptrInt(0),
+				MaxActiveSessions: ptrInt(3),
+			},
+			override: map[string]string{
+				"GC_TEMPLATE":       "foundations/worker-a",
+				"FALLBACK_ASSIGNEE": "foundations/worker-b",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, topology := range poolReadyQueryTopologies() {
+			for _, shape := range poolReadyQueryShapes() {
+				t.Run(tt.name+"/"+topology.name+"/"+shape.name, func(t *testing.T) {
+					env := poolMemberReadyEnv("")
+					for key, value := range tt.override {
+						env[key] = value
+					}
+					res := runPoolReadyQuery(t, tt.agent, topology.topo, shape.build, env)
+					if res.exit != 0 {
+						t.Fatalf("generated query exited %d: stderr=%q stdout=%q", res.exit, res.stderr, res.stdout)
+					}
+					if output := strings.TrimSpace(res.stdout); output != "" && output != "[]" {
+						t.Fatalf("generated query output = %q, want no shared-template ready fallback", res.stdout)
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestPoolMemberCustomWorkQueryRemainsVerbatim keeps configuration ownership
+// explicit: shared-template compatibility applies only to generated defaults.
+func TestPoolMemberCustomWorkQueryRemainsVerbatim(t *testing.T) {
+	const custom = `custom-ready --assignee="$GC_AGENT"`
+	agent := configuredPoolTemplateAgent()
+	agent.WorkQuery = custom
+
+	for _, topology := range poolReadyQueryTopologies() {
+		for _, shape := range poolReadyQueryShapes() {
+			if got := shape.build(agent, topology.topo); got != custom {
+				t.Errorf("%s/%s generated %q, want custom work_query returned verbatim", topology.name, shape.name, got)
+			}
+		}
+	}
+}

--- a/release-gates/ga-g716up-pool-template-ready-work-gate.md
+++ b/release-gates/ga-g716up-pool-template-ready-work-gate.md
@@ -1,0 +1,32 @@
+# Release gate: pool-template ready-work discovery
+
+- Deploy bead: `ga-g716up`
+- Build bead: `ga-8vz95k.1`
+- Review bead: `ga-zol62r`
+- Reviewed commit: `9c007d4aed3f612552a6a225153210b3682baca2`
+- Base: `origin/main@7e72e01ab00974f43ebc7695767e2290deda3662`
+- Deploy mode: remote (`origin` is GitHub and accepts a dry-run push)
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | `ga-zol62r` records `verdict: pass` on the exact reviewed commit, with no blocker, major, minor, or security findings. |
+| 2 | Acceptance criteria met | **PASS** | The generated default queries now fall back from concrete session identities to the configured pool-template assignee only for ephemeral pool members. The four diff-owned tests cover both single-store `bd ready` and federated `gc ready`, concrete-identity precedence, exact-assignee behavior, custom-query preservation, ordinary/named/manual sessions, numeric-suffix lookalikes, and membership in another pool. |
+| 3 | Tests pass | **PASS** | Full CI-equivalent local union: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true EXTRA_TEST_ENV='DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true' LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m GOFLAGS=-v LOCAL_TEST_LOG_DIR=/var/tmp/ga-g716up-full-gate make test-local-full-parallel`. Scope: `full-suite`. Result: 35/40 jobs green; 46,936 top-level PASS, 5 FAIL, 189 SKIP. All five failures are attributed below; no diff-owned test failed or skipped. All six `cmd-gc-process` jobs passed, satisfying the required process/Tutorial01 coverage for an `internal/**` change. The 189 skips are pre-existing OS-specific, live-provider, helper-process, or explicitly opt-in persistence tests; none is diff-owned. |
+| 3a | Pre-existing failures attributed | **PASS** | `TestBdFlagManifestCurrent` -> `ga-f0uceo`, clause 3(a): host `bd` flag-manifest skew in `internal/bdflags`, outside and unreachable from this work-query change. `TestGetKeyBinding_CapturesDefaultBinding` and `...WithArgs` -> `ga-afqddr`, clause 3(a): host tmux 3.7b filtered-default-keytable behavior, outside the changed package and mechanism. `TestE2E_SuspendResume_City` -> `ga-yc0e3a`, clause 3(b): the identical missing-`citysus.report` contention signature is documented across unrelated diffs and exact-base runs. `TestPersonalWorkFormulaCompileAndRun` -> `ga-lpfjhc`, exact gastownhall/beads#4566 dirty-table schema-migration signature during fixture `gc init`; raw result retained as **FAIL-WAIVED** under mayor standing authorization `ga-6bnc42`, and this occurrence was logged on `ga-lpfjhc`. Clauses 1, 2, and 4 pass for every attribution: none of the failing tests is diff-owned; each tracker predates this run and was opened during evaluation; no failing test file overlaps the diff. `inconclusive-guard`: not used. `added_test_load=no`: no census baseline or suite-target change. |
+| 3b | Policy and static lanes | **PASS** | `make test-ci-policy` PASS; clean-cache `make lint-affected LINT_CHANGED_REF=e736d74d0a84a129de47f9008c4560d3146c77ce LINT_CHANGED_SCOPE=tracked` PASS with 0 issues; `go vet ./...` PASS; `make fmt-check-changed` and `git diff --check origin/main...HEAD` PASS. An initial lint invocation using the shared analyzer cache was discarded because it returned stale absolute paths for already-deleted `/var/tmp` worktrees; the fresh on-disk cache rerun is the auditable result. |
+| 4 | No high-severity review findings open | **PASS** | Reviewer security/spec review reports no blocker, major, minor, or HIGH findings. |
+| 5 | Final branch is clean | **PASS** | `git status --short` was empty before the gate artifact was written; the candidate contains only its two reviewed commits and this gate file will be committed on the isolated deploy branch. Hooks path is `/home/jaword/projects/gascity/.githooks`. |
+| 6 | Branch diverges cleanly from main | **PASS** | After `git fetch origin main`, `git merge-tree --write-tree origin/main 9c007d4aed3f612552a6a225153210b3682baca2` exited 0 and produced tree `9290dac489163c6e7f97951c8d3a2965dd8b088f`. Pre-flight `gh api repos/gastownhall/gascity/commits/9c007d4aed3f612552a6a225153210b3682baca2/pulls` returned `[]`; the target has not already merged or closed. |
+| 7 | Single feature theme | **PASS** | Both commits touch one subsystem and one behavior: `internal/config` generation and tests for pool-template assigned ready-work discovery. |
+
+## Diff-owned test resolution
+
+- `TestPoolMemberDefaultQueriesDiscoverTemplateAssignedReadyWork`: PASS in `unit-core` and `integration-packages-core-3-of-4`, including all four topology/query-shape subtests.
+- `TestPoolMemberConcreteReadyIdentityPrecedesTemplate`: PASS in both full-suite jobs, including all four subtests.
+- `TestTemplateAssignedReadyFallbackRequiresConfiguredEphemeralPoolMembership`: PASS in both full-suite jobs, including all 20 boundary subtests.
+- `TestPoolMemberCustomWorkQueryRemainsVerbatim`: PASS in both full-suite jobs.
+- `waiver_ref`: `ga-6bnc42` applies only to the unrelated Beads #4566 fixture-bootstrap failure; no diff-owned test is waived.
+
+## Gate decision
+
+**PASS.** The reviewed feature is conflict-free against current main, its acceptance boundary is exercised in both supported ready-query topologies, every diff-owned test executed successfully, and the required process, policy, lint, formatting, and vet lanes are clean. The full-suite raw failures remain visible above and carry valid pre-existing attribution or the standing merge-authority waiver.


### PR DESCRIPTION
## What this changes

Pool workers can now discover ready work assigned to their shared template identity before that work has been claimed down to a concrete session. The fallback applies to both the single-store `bd ready` path and the federated `gc ready` path.

Concrete session identities still take precedence. The template fallback is enabled only for configured ephemeral pools, so ordinary agents, named or manual sessions, numeric-suffix lookalikes, and workers from another pool do not gain access to the work. Explicit custom work queries remain untouched.

## Review notes

- The behavior is gated by the existing `min_active_sessions` pool configuration; there is no new config field or migration.
- The generated shell reuses the existing exact-assignee reader and quotes `GC_TEMPLATE` the same way as the established identity tiers.
- The key review surface is ordering: concrete session ID/name/alias reads must finish before the shared-template fallback.

## Test plan

- [x] Run the documented full local CI union, including all six `cmd-gc` process shards.
- [x] Exercise both single-store and federated ready-query topologies.
- [x] Verify concrete-identity precedence and every non-pool boundary case.
- [x] Run CI policy, affected lint, formatting, and Go vet checks.
- [x] Release gate: [`release-gates/ga-g716up-pool-template-ready-work-gate.md`](release-gates/ga-g716up-pool-template-ready-work-gate.md)