### PR TITLE
fix(bd): disclose which store gc bd list/ready/search/show answered from (#5170)

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -289,6 +289,26 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		}
 		return doBdReleaseIfCurrent(cityPath, cfg, target, id, expectedAssignee, stdout, stderr)
 	}
+
+	// Disclose which store answers a read-only passthrough, so a zero-row
+	// result is distinguishable from a true empty (gastownhall/gascity#5170).
+	// resolveBdScopeTarget's priority chain (explicit --rig > explicit --city
+	// > bead-prefix detect > -C/--directory > GC_RIG env > cwd > city)
+	// silently picks a store on every one of those paths but the GC_RIG-
+	// mismatch warning above; the common cwd-auto-detect case reached bd with
+	// no diagnostic at all. Placed after the by-ID and release-if-current
+	// arms above (rather than immediately after resolveBdScopeTarget) so it
+	// names the store that actually serves the request: a class-owned `show`
+	// on a split city is answered in process from the class's own binding by
+	// maybeRouteBdByID, not from target, and disclosing target there would be
+	// wrong for that one read. This is stderr-only and additive — bd's own
+	// stdout (human or --json) is untouched, and it never changes the exit
+	// code, matching the disclosure style #5162/#5167 established for the
+	// sibling relocated-class invariant.
+	if verb, _, ok := bdRelocatedClassVerb(bdArgs); ok && bdScopeDisclosureVerbs[verb] {
+		fmt.Fprintf(stderr, "gc bd: answering from the %s store\n", scopeLabel(target)) //nolint:errcheck // best-effort stderr
+	}
+
 	if provider := rawBeadsProviderForScope(target.ScopeRoot, cityPath); !providerUsesBdStoreContract(provider) {
 		fmt.Fprintf(stderr, "gc bd: only supported for bd-backed beads providers (resolved %q for %s)\n", provider, target.ScopeRoot) //nolint:errcheck // best-effort stderr
 		if hint := bdProviderMismatchHint(target.ScopeRoot, provider); hint != "" {
@@ -777,6 +797,19 @@ func resolveBdScopeTarget(cfg *config.City, cityPath, rigName string, args []str
 		fmt.Fprintf(stderr, "gc bd: warning: GC_RIG=%q does not name a bound rig in this city; ignoring it and answering from the %s store instead (the same value via --rig would exit 1)\n", gcRigDiscarded, scopeLabel(target)) //nolint:errcheck // best-effort stderr
 	}
 	return target, nil
+}
+
+// bdScopeDisclosureVerbs are the bd read-only passthrough verbs whose
+// resolved store gets announced on stderr (gastownhall/gascity#5170). Scoped
+// to reads: a write verb's effect is directly observable (the record it
+// touched can be re-read), while a read verb's silence is exactly what makes
+// an empty answer indistinguishable from "no matches in the store that was
+// asked."
+var bdScopeDisclosureVerbs = map[string]bool{
+	"list":   true,
+	"ready":  true,
+	"search": true,
+	"show":   true,
 }
 
 // scopeLabel renders a store target for operator-facing diagnostics, e.g.

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -809,10 +809,19 @@ esac
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("BD_EXPORT_AUTO", "true")
 
-	for _, args := range [][]string{
-		{"show", "gc-1", "--json"},
-		{"update", "gc-1", "--claim", "--json"},
+	for _, tc := range []struct {
+		args       []string
+		wantStderr string // "" means stderr must be empty
+	}{
+		// show is a read-only passthrough verb, so it now carries the
+		// gastownhall/gascity#5170 scope-disclosure line (see
+		// TestGcBdDisclosesAnsweringStore); this test's own concern —
+		// BD_EXPORT_AUTO is suppressed and no auto-export error reaches the
+		// operator — is unaffected by that one additive line.
+		{args: []string{"show", "gc-1", "--json"}, wantStderr: "gc bd: answering from the city store\n"},
+		{args: []string{"update", "gc-1", "--claim", "--json"}, wantStderr: ""},
 	} {
+		args := tc.args
 		var stdout, stderr bytes.Buffer
 		if got := doBd(args, &stdout, &stderr); got != 0 {
 			t.Fatalf("doBd(%v) = %d, want 0; stdout=%q stderr=%q", args, got, stdout.String(), stderr.String())
@@ -820,8 +829,8 @@ esac
 		if strings.TrimSpace(stdout.String()) == "" {
 			t.Fatalf("doBd(%v) produced empty stdout", args)
 		}
-		if stderr.String() != "" {
-			t.Fatalf("doBd(%v) stderr = %q, want empty", args, stderr.String())
+		if stderr.String() != tc.wantStderr {
+			t.Fatalf("doBd(%v) stderr = %q, want %q", args, stderr.String(), tc.wantStderr)
 		}
 	}
 }
@@ -2853,6 +2862,107 @@ func TestGcBdPassthroughResolvesBdBinary(t *testing.T) {
 		}
 		if want := "partial beads storage binding"; !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr = %q, want it to name the %q", stderr.String(), want)
+		}
+	})
+}
+
+// newBdScopeDisclosureTestCity stages a city with one dolt-backed rig
+// ("frontend") and a stub bd on PATH that answers "[]" to anything, for
+// TestGcBdDisclosesAnsweringStore. No [storage] split is configured, so
+// maybeRouteBdByID never intercepts a read here — this is the ordinary
+// single-store shape the issue's repro used.
+func newBdScopeDisclosureTestCity(t *testing.T) {
+	t.Helper()
+	disableManagedDoltRecoveryForTest(t)
+
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	t.Cleanup(func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	})
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"backend":"doltlite"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte("#!/bin/sh\necho '[]'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY_PATH", cityDir)
+}
+
+// TestGcBdDisclosesAnsweringStore pins gastownhall/gascity#5170:
+// resolveBdScopeTarget's priority chain (explicit --rig > explicit --city >
+// bead-prefix detect > -C/--directory > GC_RIG env > cwd > city) silently
+// picked a store on every path but the GC_RIG-mismatch warning, so a
+// byte-identical `gc bd list`/`ready`/`search`/`show` invocation could answer
+// "[]"/exit 0 from either of two different stores with no diagnostic
+// distinguishing "this store has no matches" from "a different store
+// answered." doBd now emits one stderr line via scopeLabel naming the store
+// that served the read, for the read-only passthrough verbs only.
+func TestGcBdDisclosesAnsweringStore(t *testing.T) {
+	t.Run("cwd auto-detect discloses the city store", func(t *testing.T) {
+		newBdScopeDisclosureTestCity(t)
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"list"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(list) = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "gc bd: answering from the city store") {
+			t.Fatalf("stderr = %q, want scope disclosure naming the city store", stderr.String())
+		}
+	})
+
+	for _, verb := range []string{"list", "ready", "search", "show"} {
+		t.Run("explicit --rig discloses the rig store for "+verb, func(t *testing.T) {
+			newBdScopeDisclosureTestCity(t)
+
+			args := []string{"--rig", "frontend", verb}
+			switch verb {
+			case "search":
+				args = append(args, "x")
+			case "show":
+				args = append(args, "fe-1")
+			}
+			var stdout, stderr bytes.Buffer
+			if got := doBd(args, &stdout, &stderr); got != 0 {
+				t.Fatalf("doBd(%v) = %d, want 0; stdout=%q stderr=%q", args, got, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), `gc bd: answering from the rig "frontend" store`) {
+				t.Fatalf("stderr = %q, want scope disclosure naming rig %q", stderr.String(), "frontend")
+			}
+		})
+	}
+
+	t.Run("write verbs stay silent", func(t *testing.T) {
+		newBdScopeDisclosureTestCity(t)
+
+		var stdout, stderr bytes.Buffer
+		if got := doBd([]string{"--rig", "frontend", "create", "--json", "x", "-t", "task"}, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(create) = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+		}
+		if strings.Contains(stderr.String(), "answering from") {
+			t.Fatalf("stderr = %q, want no scope disclosure for a write verb; stderr=%q", stderr.String(), stderr.String())
 		}
 	})
 }

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -6777,6 +6777,10 @@ case "$1" in
     printf '[{"id":"ga-loop","status":"open","metadata":{"recovered":"true"}}]\n'
     ;;
   show)
+    # gc writes diagnostics to stderr on a read (scope disclosure, doctor
+    # warnings). The prune loop must not fold them into the JSON it parses,
+    # or every bead reads as "unknown" and nothing is ever pruned.
+    printf 'gc bd: answering from the city store\n' >&2
     case "$2" in
       ga-closed)
         printf '[{"id":"ga-closed","status":"closed","title":"Closed bead"}]\n'

--- a/internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
@@ -76,9 +76,13 @@ done <<< "$RESET_IDS"
 TRACKED_IDS=$(echo "$COUNTS" | jq -r 'keys[]' 2>/dev/null) || true
 while IFS= read -r tid; do
     [ -z "$tid" ] && continue
-    if BEAD_OUTPUT=$(gc bd show "$tid" --json 2>&1); then
+    # stdout only: gc writes diagnostics to stderr (scope disclosure, doctor
+    # warnings), and merging them into the JSON makes every jq parse fail and
+    # every bead read as "unknown", so nothing is ever pruned. The error path
+    # re-reads with stderr merged, since that is where the not-found text is.
+    if BEAD_OUTPUT=$(gc bd show "$tid" --json 2>/dev/null); then
         BEAD_STATUS=$(echo "$BEAD_OUTPUT" | jq -r 'if type == "array" then (.[0].status // "deleted") elif type == "object" and ((.error // "") | test("not found|no issue found"; "i")) then "deleted" else "unknown" end' 2>/dev/null || echo "unknown")
-    elif echo "$BEAD_OUTPUT" | grep -qiE 'not found|no issue found'; then
+    elif BEAD_OUTPUT=$(gc bd show "$tid" --json 2>&1 || true); echo "$BEAD_OUTPUT" | grep -qiE 'not found|no issue found'; then
         BEAD_STATUS="deleted"
     else
         BEAD_STATUS="unknown"


### PR DESCRIPTION
Fixes #5170.

`gc bd list`/`ready`/`search`/`show` silently answered from one store selected by cwd, with no indication to the caller which store that was — in a multi-store setup, an answer could look complete while actually reflecting only one store's contents, with no signal that anything was scoped at all.

**Fix:** these commands now disclose which store answered the query.

**Testing:** `go build`/`gofmt -l` clean, `TestGcBdDisclosesAnsweringStore` (6 subtests) plus the full surrounding `cmd_bd_test.go` suite pass.

---

Generated with [Claude Code](https://claude.com/claude-code)