### PR TITLE
fix(cli): federate the relocated class binding into the CLI read fan-outs and workflow sweeps

### DIFF
--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -499,3 +499,134 @@ func TestByIDPlanUsesTheRegisteredControllerRoutes(t *testing.T) {
 		})
 	}
 }
+
+// bindingHitCity builds the fixture the binding short-circuit runs on: a city
+// whose infrastructure classes are served by one store, plus a rig, plus a
+// per-directory store opener the caller controls.
+//
+// The binding is a work-PREFIXED store on purpose. A binding that minted
+// reserved ids would retire the residence probe, and then a work-shaped id
+// would never reach the binding leg at all — which is the fixture testing
+// itself rather than the resolver.
+func bindingHitCity(t *testing.T) (cityPath, rigPath string, cfg *config.City, binding beads.Store) {
+	t.Helper()
+	cityPath = t.TempDir()
+	binding = splittest.NewWorkStore(t, "hq")
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
+	rigPath = filepath.Join(cityPath, "rigs", "alpha")
+	cfg = &config.City{Rigs: []config.Rig{{Name: "alpha", Path: rigPath}}}
+	return cityPath, rigPath, cfg, binding
+}
+
+// storesByDir is an openStore that hands each directory the store the test
+// prepared for it, and an empty one for any directory it did not name.
+func storesByDir(t *testing.T, byDir map[string]beads.Store) func(string) (beads.Store, error) {
+	t.Helper()
+	return func(dir string) (beads.Store, error) {
+		if store, ok := byDir[dir]; ok {
+			return store, nil
+		}
+		return splittest.NewWorkStore(t, "hq"), nil
+	}
+}
+
+// TestResolveOwningStoreDirRefusesBindingRigCollision is the ga-qnagn
+// regression.
+//
+// The binding leg short-circuits the scan, and with it the scan's uniqueness
+// refusal. That is right for the city's own retained copy — dual residency is
+// the migration working — but it is not right for a RIG, which is never a
+// migration target and so has no retained copy to be excused. A rig holding the
+// same id is two ledgers disagreeing by accident, exactly what the uniqueness
+// contract exists for, and answering it silently from the binding means the
+// close that follows writes one copy while the other stays open forever.
+func TestResolveOwningStoreDirRefusesBindingRigCollision(t *testing.T) {
+	cityPath, rigPath, cfg, binding := bindingHitCity(t)
+	resident, err := binding.Create(beads.Bead{Title: "the binding's copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the binding: %v", err)
+	}
+	rig := splittest.NewWorkStore(t, "hq")
+	collision, err := rig.Create(beads.Bead{Title: "a rig copy under the same id", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the rig: %v", err)
+	}
+	if collision.ID != resident.ID {
+		t.Fatalf("the fixture minted %s and %s; a collision needs one id", resident.ID, collision.ID)
+	}
+
+	_, _, err = resolveOwningStoreDir(resident.ID, cfg, cityPath, storesByDir(t, map[string]beads.Store{rigPath: rig}))
+	if err == nil {
+		t.Fatal("a binding/rig collision resolved cleanly; the caller would close one copy and leave the other open")
+	}
+	if !strings.Contains(err.Error(), "exists in multiple stores") {
+		t.Errorf("the refusal reads %v, want the scan's own uniqueness wording", err)
+	}
+	if !strings.Contains(err.Error(), rigPath) {
+		t.Errorf("the refusal %v does not name the rig store that collides", err)
+	}
+}
+
+// TestResolveOwningStoreDirBindingWinsOverRetainedCityCopy is the control for
+// the test above, and the reason its probe skips the city store.
+//
+// The city store is where the migration RETAINED its copies, so it holds the
+// same id by design on every converged city. A probe that counted it would
+// refuse every convoy command on exactly the cities that finished migrating —
+// the failure PR1's short-circuit was added to prevent.
+func TestResolveOwningStoreDirBindingWinsOverRetainedCityCopy(t *testing.T) {
+	cityPath, _, cfg, binding := bindingHitCity(t)
+	resident, err := binding.Create(beads.Bead{Title: "the binding's copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the binding: %v", err)
+	}
+	city := splittest.NewWorkStore(t, "hq")
+	retained, err := city.Create(beads.Bead{Title: "the copy the migration retained", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained city copy: %v", err)
+	}
+	if retained.ID != resident.ID {
+		t.Fatalf("the fixture minted %s and %s; dual residency needs one id", resident.ID, retained.ID)
+	}
+
+	store, dir, err := resolveOwningStoreDir(resident.ID, cfg, cityPath, storesByDir(t, map[string]beads.Store{cityPath: city}))
+	if err != nil {
+		t.Fatalf("a dual-resident id resolved to %v; the retained city copy is the migration working, not a collision", err)
+	}
+	if store != binding {
+		t.Errorf("the resolver returned %p, want the binding %p", store, binding)
+	}
+	if dir != cityPath {
+		t.Errorf("the resolver reported dir %q, want the city path %q", dir, cityPath)
+	}
+}
+
+// TestResolveOwningStoreDirSkipsTheRigProbeForAReservedID pins the probe's
+// other bound.
+//
+// A class-reserved prefix is minted by the binding and by nothing else, so a
+// rig cannot hold one legitimately and there is no collision to find. Probing
+// anyway would add a full rig walk to every reserved-id resolution — including
+// bd's on-close hook, which runs in bursts — to learn nothing.
+func TestResolveOwningStoreDirSkipsTheRigProbeForAReservedID(t *testing.T) {
+	cityPath, rigPath, cfg, binding := bindingHitCity(t)
+	reserved, err := migrationSeed(binding, beads.Bead{ID: "gcg-1", Title: "a graph-class bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the reserved-prefix bead: %v", err)
+	}
+	if !bdIDIsClassReserved(reserved.ID) {
+		t.Fatalf("the fixture id %q carries no reserved class prefix", reserved.ID)
+	}
+	rig := splittest.NewWorkStore(t, "hq")
+	if _, err := migrationSeed(rig, beads.Bead{ID: reserved.ID, Title: "a rig copy the probe must not consult", Type: "task"}); err != nil {
+		t.Fatalf("seeding the rig: %v", err)
+	}
+
+	store, _, err := resolveOwningStoreDir(reserved.ID, cfg, cityPath, storesByDir(t, map[string]beads.Store{rigPath: rig}))
+	if err != nil {
+		t.Fatalf("a reserved-prefix id resolved to %v; no rig can own one, so there is nothing to refuse", err)
+	}
+	if store != binding {
+		t.Errorf("the resolver returned %p, want the binding %p", store, binding)
+	}
+}

--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -480,15 +480,26 @@ func TestByIDPlanUsesTheRegisteredControllerRoutes(t *testing.T) {
 				t.Errorf("the by-id plan resolved %s through %p, want %p", resident.ID, owner.Store, wantStore)
 			}
 
-			// The production caller, with a scan that fails the test if it runs:
-			// a binding hit must return before the directory scan, so the funnel
-			// is never reached by this arm either.
+			// The production caller. The scan's opener DOES run on a binding
+			// hit now — refuseBindingRigCollision probes the scan's candidates
+			// so a rig holding the same id is refused rather than silently
+			// losing to the binding — so what this pins is narrower than "the
+			// scan never runs": the probe stays inside the directories the scan
+			// would have walked, and the binding is still what answers. The
+			// binding is not one of those directories, so no probe of it can be
+			// planned and the funnel's errStore is never reached.
+			var probed []string
 			store, dir, err := resolveOwningStoreDir(resident.ID, nil, cityPath, func(storeDir string) (beads.Store, error) {
-				t.Errorf("the convoy scan opened %q for an id the binding owns", storeDir)
-				return nil, errors.New("the scan must not run for a binding hit")
+				probed = append(probed, storeDir)
+				return splittest.NewWorkStore(t, "hq"), nil
 			})
 			if err != nil {
 				t.Fatalf("resolveOwningStoreDir(%s): %v", resident.ID, err)
+			}
+			for _, storeDir := range probed {
+				if !samePath(storeDir, cityPath) {
+					t.Errorf("the collision probe opened %q; this city configures no rigs, so its own directory is the only candidate", storeDir)
+				}
 			}
 			if store != wantStore {
 				t.Errorf("the convoy resolver served %s from %p, want the binding %p", resident.ID, store, wantStore)

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -152,22 +152,22 @@ func foreignProviderCity(t *testing.T) (cityPath string, classStore beads.Store)
 	return cityPath, store
 }
 
-// cliSoleClassBindingStore resolves the city's sole relocated class binding as
-// a STORE, for fixtures that seed both sides of a migration and have no error
-// channel of their own.
+// soleClassBindingStore resolves the city's sole relocated class binding as a
+// STORE, for the fixtures that seed both sides of a migration.
 //
-// The fan-out — the only error cliSoleClassBinding returns — is a topology this
+// A fan-out — the only error cliSoleClassBinding returns — is a topology this
 // build refuses to serve, so a fixture that met one has not built the city it
 // meant to build and says so here rather than seeding half of it.
-func cliSoleClassBindingStore(cityPath string) (beads.Store, bool) {
+func soleClassBindingStore(t *testing.T, cityPath string) beads.Store {
+	t.Helper()
 	binding, relocated, err := cliSoleClassBinding(cityPath)
 	if err != nil {
-		return refusedClassStore{err: standingStorageRefusal{err: err}}, true
+		t.Fatalf("resolving the city's class binding: %v", err)
 	}
 	if !relocated {
-		return nil, false
+		t.Fatal("the fixture city resolved no class binding; it is not split")
 	}
-	return binding.Store, true
+	return binding.Store
 }
 
 // recensusAfterSeedingARelic reopens the funnel so the binding's relic census
@@ -194,21 +194,18 @@ func recensusAfterSeedingARelic(t *testing.T, cityPath string) beads.Store {
 	if err := closeCLIStorageRoutes(); err != nil {
 		t.Fatalf("closing the funnel so the binding is censused again: %v", err)
 	}
-	store, relocated := cliSoleClassBindingStore(cityPath)
-	if !relocated {
-		t.Fatal("the reopened funnel resolved no class binding; the fixture's city stopped being split across the reopen")
-	}
-	return store
+	return soleClassBindingStore(t, cityPath)
 }
 
-// dropDerivedResidencyMemo drops one city's memoized binding grouping, for the
-// fixtures that swap a route's store out from under it.
+// dropDerivedResidencyMemo invalidates the grouping derived from these routes.
 //
-// The grouping is DERIVED from the routes, and nothing recomputes it when a
-// test reaches into routes.stores directly. Without this a fault-injecting row
-// holds a store captured before the swap and passes against a healthy one,
-// which is the failure mode a fault-injection row exists to rule out. Dropped
-// again on cleanup so the swap does not outlive the test that made it.
+// Swapping routes.stores in place is invisible to cliResidencyBindings, which
+// caches the class-to-store grouping it read out of those routes: anything that
+// already resolved the grouping keeps handing out the stores that were there
+// BEFORE the swap. A test that routed one command before installing its failing
+// store would then exercise a healthy store while asserting on a fault path,
+// and pass for the wrong reason. Dropping the memo here makes that ordering bug
+// unwritable rather than merely currently absent.
 func dropDerivedResidencyMemo(t *testing.T, cityPath string) {
 	t.Helper()
 	dropCLIResidencyBindings(filepath.Clean(cityPath))
@@ -740,6 +737,7 @@ func failClassBindingReads(t *testing.T, cityPath string, cause error) {
 		restore[class] = previous
 		routes.stores[class] = store
 	}
+	dropDerivedResidencyMemo(t, cityPath)
 	t.Cleanup(func() {
 		for class, previous := range restore {
 			routes.stores[class] = previous
@@ -1885,6 +1883,7 @@ func stubClassBindingStore(t *testing.T, cityPath string, store beads.Store) {
 		restore[class] = previous
 		routes.stores[class] = store
 	}
+	dropDerivedResidencyMemo(t, cityPath)
 	t.Cleanup(func() {
 		for class, previous := range restore {
 			routes.stores[class] = previous

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -152,6 +152,69 @@ func foreignProviderCity(t *testing.T) (cityPath string, classStore beads.Store)
 	return cityPath, store
 }
 
+// cliSoleClassBindingStore resolves the city's sole relocated class binding as
+// a STORE, for fixtures that seed both sides of a migration and have no error
+// channel of their own.
+//
+// The fan-out — the only error cliSoleClassBinding returns — is a topology this
+// build refuses to serve, so a fixture that met one has not built the city it
+// meant to build and says so here rather than seeding half of it.
+func cliSoleClassBindingStore(cityPath string) (beads.Store, bool) {
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		return refusedClassStore{err: standingStorageRefusal{err: err}}, true
+	}
+	if !relocated {
+		return nil, false
+	}
+	return binding.Store, true
+}
+
+// recensusAfterSeedingARelic reopens the funnel so the binding's relic census
+// runs again, and returns the class store on the far side of it.
+//
+// The census runs when the funnel OPENS a binding, and a fixture that plants a
+// work-shaped id afterwards has produced a verdict that was true when it was
+// taken and is false by the time the row asserts on it. The residence probe
+// retires on that stale verdict — MintsReserved && !HasLegacyResidents — and the
+// row then reads the retained work copy while claiming to test that the binding
+// wins.
+//
+// Reopening is not a workaround for the ordering: it IS what production does.
+// Relics are what `gc storage migrate` leaves behind, so every process that
+// meets them starts after they exist, censuses once at boot, and sees them. A
+// one-shot `gc` invocation against a migrated city is exactly this.
+//
+// The returned store is a NEW handle — the engine is a real sqlite database
+// under .gc/, so the seeded relic is still there, but the pointer the fixture
+// handed back before the reopen is closed and no longer the one the door
+// resolves. Rows that compare store identity must use this one.
+func recensusAfterSeedingARelic(t *testing.T, cityPath string) beads.Store {
+	t.Helper()
+	if err := closeCLIStorageRoutes(); err != nil {
+		t.Fatalf("closing the funnel so the binding is censused again: %v", err)
+	}
+	store, relocated := cliSoleClassBindingStore(cityPath)
+	if !relocated {
+		t.Fatal("the reopened funnel resolved no class binding; the fixture's city stopped being split across the reopen")
+	}
+	return store
+}
+
+// dropDerivedResidencyMemo drops one city's memoized binding grouping, for the
+// fixtures that swap a route's store out from under it.
+//
+// The grouping is DERIVED from the routes, and nothing recomputes it when a
+// test reaches into routes.stores directly. Without this a fault-injecting row
+// holds a store captured before the swap and passes against a healthy one,
+// which is the failure mode a fault-injection row exists to rule out. Dropped
+// again on cleanup so the swap does not outlive the test that made it.
+func dropDerivedResidencyMemo(t *testing.T, cityPath string) {
+	t.Helper()
+	dropCLIResidencyBindings(filepath.Clean(cityPath))
+	t.Cleanup(func() { dropCLIResidencyBindings(filepath.Clean(cityPath)) })
+}
+
 // mustCreateClassBead creates a bead in the class binding and proves it carries
 // a reserved class prefix, which is what makes it unanswerable by any other
 // store.

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -313,9 +313,11 @@ func doBeadsShowFallback(cityPath, beadID, format string, stdout, stderr io.Writ
 // default UX.
 //
 // The merge is mergeConvoyViewRows, so a relocated class binding's rows
-// supersede the frozen copies the migration retained in the city store. Rows
-// from two scanned stores that happen to share an id are two different beads
-// and both survive.
+// supersede the frozen copies the migration retained in the city store — asked
+// of the binding by id rather than read off these filtered results, because a
+// filter the caller chose must not decide which store owns a bead. Rows from two
+// scanned stores that happen to share an id are two different beads and both
+// survive.
 func collectBeadsAcrossStores(stores []convoyStoreView, filters beadFilters) ([]beads.Bead, error) {
 	q := beads.ListQuery{
 		Label:         filters.label,
@@ -331,7 +333,7 @@ func collectBeadsAcrossStores(stores []convoyStoreView, filters beadFilters) ([]
 		}
 		rows[i] = list
 	}
-	return mergeConvoyViewRows(stores, rows, func(b beads.Bead) string { return b.ID }), nil
+	return mergeConvoyViewRows(stores, rows, func(b beads.Bead) string { return b.ID })
 }
 
 // sortBeadsForList orders beads by ID so output is stable across store

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -181,6 +181,7 @@ func doBeadsListFallback(cityPath, format string, filters beadFilters, stdout, s
 	if stores == nil {
 		return code
 	}
+	stores = convoyStoreViewsForRead(cityPath, stores, stderr, "gc beads list")
 	all, err := collectBeadsAcrossStores(stores, filters)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc beads list: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -310,6 +311,11 @@ func doBeadsShowFallback(cityPath, beadID, format string, stdout, stderr io.Writ
 // for sorting. --all maps to IncludeClosed (matching `bd list --all`); the
 // CLI always opts into AllowScan because an unfiltered list is a valid
 // default UX.
+//
+// The merge is mergeConvoyViewRows, so a relocated class binding's rows
+// supersede the frozen copies the migration retained in the city store. Rows
+// from two scanned stores that happen to share an id are two different beads
+// and both survive.
 func collectBeadsAcrossStores(stores []convoyStoreView, filters beadFilters) ([]beads.Bead, error) {
 	q := beads.ListQuery{
 		Label:         filters.label,
@@ -317,15 +323,15 @@ func collectBeadsAcrossStores(stores []convoyStoreView, filters beadFilters) ([]
 		IncludeClosed: filters.all,
 		AllowScan:     true,
 	}
-	all := make([]beads.Bead, 0)
-	for _, candidate := range stores {
+	rows := make([][]beads.Bead, len(stores))
+	for i, candidate := range stores {
 		list, err := candidate.store.List(q)
 		if err != nil {
 			return nil, err
 		}
-		all = append(all, list...)
+		rows[i] = list
 	}
-	return all, nil
+	return mergeConvoyViewRows(stores, rows, func(b beads.Bead) string { return b.ID }), nil
 }
 
 // sortBeadsForList orders beads by ID so output is stable across store

--- a/cmd/gc/cmd_beads_test.go
+++ b/cmd/gc/cmd_beads_test.go
@@ -779,11 +779,7 @@ func TestBeadsListFallbackReadsTheRelocatedBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding the retained copy in the work store: %v", err)
 	}
-	binding, relocated := cliSoleClassBindingStore(cityPath)
-	if !relocated {
-		t.Fatal("the fixture city resolved no class binding; it is not split")
-	}
-	classResidentWorkShapedBead(t, binding, frozen.ID, "the binding's live row")
+	classResidentWorkShapedBead(t, soleClassBindingStore(t, cityPath), frozen.ID, "the binding's live row")
 	classStore := recensusAfterSeedingARelic(t, cityPath)
 	mustCreateClassBead(t, classStore, beads.Bead{Title: "minted in the binding after the migration", Type: "task"})
 	if _, err := work.Create(beads.Bead{Title: "a work bead the binding never held", Type: "task"}); err != nil {

--- a/cmd/gc/cmd_beads_test.go
+++ b/cmd/gc/cmd_beads_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 func TestDoBeadsHealth_FileProvider(t *testing.T) {
@@ -758,5 +760,88 @@ func TestRun_BeadsShowRejectsExtraArgs(t *testing.T) {
 	}
 	if !strings.Contains(errb.String(), "accepts at most 1 arg") {
 		t.Fatalf("stderr = %q, want an at-most-1-arg error", errb.String())
+	}
+}
+
+// TestBeadsListFallbackReadsTheRelocatedBinding is the ga-efyq4 regression on
+// the beads-list arm.
+//
+// The fan-out enumerates the city's DIRECTORIES, and a relocated class binding
+// is not one of them. On a migrated city that makes the list doubly wrong: the
+// binding's live rows are absent, and the copies `gc storage migrate` retained
+// in the work ledger — frozen at cutover, never mutated again — are printed in
+// their place. The reader cannot tell the two apart, because the migration
+// preserves ids and only the titles here differ.
+func TestBeadsListFallbackReadsTheRelocatedBinding(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	frozen, err := work.Create(beads.Bead{Title: "the retained frozen copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained copy in the work store: %v", err)
+	}
+	binding, relocated := cliSoleClassBindingStore(cityPath)
+	if !relocated {
+		t.Fatal("the fixture city resolved no class binding; it is not split")
+	}
+	classResidentWorkShapedBead(t, binding, frozen.ID, "the binding's live row")
+	classStore := recensusAfterSeedingARelic(t, cityPath)
+	mustCreateClassBead(t, classStore, beads.Bead{Title: "minted in the binding after the migration", Type: "task"})
+	if _, err := work.Create(beads.Bead{Title: "a work bead the binding never held", Type: "task"}); err != nil {
+		t.Fatalf("seeding the work-only control: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doBeadsListFallback(cityPath, "", beadFilters{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc beads list exited %d: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	if got := strings.Count(out, "the binding's live row"); got != 1 {
+		t.Errorf("the binding's row appears %d times, want exactly 1:\n%s", got, out)
+	}
+	if strings.Contains(out, "the retained frozen copy") {
+		t.Errorf("the list printed the frozen work copy of %s; the binding is the truth for reads:\n%s", frozen.ID, out)
+	}
+	if !strings.Contains(out, "a work bead the binding never held") {
+		t.Errorf("a work-only bead vanished from the list; the merge dropped rows the binding never claimed:\n%s", out)
+	}
+	// The discriminator between the two ways this can be broken. A bead the
+	// binding minted after the migration has no retained copy anywhere, so it
+	// survives a merge that picks the wrong winner and disappears only when the
+	// binding is not read at all.
+	if !strings.Contains(out, "minted in the binding after the migration") {
+		t.Errorf("a bead that exists only in the binding is missing; the fan-out never read it:\n%s", out)
+	}
+}
+
+// TestBeadsListFallbackWarnsEveryRunOnARefusedBinding pins the list surface's
+// half of the refusal policy.
+//
+// A list is a read, and a refused city still serves work from its work ledger,
+// so failing the whole command would take `gc beads list` away from every city
+// whose storage config is mid-repair. The rows the binding holds are missing
+// from that output, though, and a listing that silently omits them is the
+// stale-answer failure this lane exists to close — so the omission is said out
+// loud EVERY run. Not once per process: each `gc beads list` is a fresh answer
+// and has to carry its own caveat.
+func TestBeadsListFallbackWarnsEveryRunOnARefusedBinding(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	if _, err := work.Create(beads.Bead{Title: "a work bead the binding never held", Type: "task"}); err != nil {
+		t.Fatalf("seeding the work-only control: %v", err)
+	}
+	failClassBindingReads(t, cityPath, errors.New("the class binding is having a bad day"))
+
+	for run := 1; run <= 2; run++ {
+		var stdout, stderr bytes.Buffer
+		if code := doBeadsListFallback(cityPath, "", beadFilters{}, &stdout, &stderr); code != 0 {
+			t.Fatalf("run %d: a refused binding failed the whole list (exit %d); a refused city still serves work: %s", run, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "a work bead the binding never held") {
+			t.Errorf("run %d: the work ledger's own rows went missing:\n%s", run, stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "bad day") {
+			t.Errorf("run %d: the refusal was not announced with its own cause: %q", run, stderr.String())
+		}
 	}
 }

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -697,6 +697,9 @@ func resolveOwningStoreDir(beadID string, cfg *config.City, cityPath string, ope
 		return nil, "", err
 	}
 	if ownedByBinding {
+		if err := refuseBindingRigCollision(beadID, cfg, cityPath, openStore); err != nil {
+			return nil, "", err
+		}
 		return owner.Store, cityPath, nil
 	}
 
@@ -728,6 +731,51 @@ func resolveOwningStoreDir(beadID string, cfg *config.City, cityPath string, ope
 		return nil, "", beads.ErrNotFound
 	}
 	return foundStore, foundDir, nil
+}
+
+// refuseBindingRigCollision restores the uniqueness contract to the one case
+// the binding short-circuit takes it away from without meaning to.
+//
+// A binding hit returns before the scan runs, and the scan is where "this id
+// exists in more than one store" is refused. Skipping it is right for the CITY
+// store, whose copy of a relocated id is the migration working as designed, and
+// wrong for a RIG: a rig is never a migration target, so it has no retained copy
+// to be excused, and one holding the same id is two ledgers disagreeing by
+// accident. Answering that silently from the binding means whichever caller
+// follows — a close, a land, a convoy walk — acts on one copy while the other
+// stays open forever, which is the failure the contract was written for.
+//
+// So the probe is the rigs and only the rigs, and only for an id no reserved
+// class prefix claims. A reserved prefix is minted by the binding and by nothing
+// else, so a rig cannot hold one legitimately and the walk would cost every
+// reserved-id resolution — bd's on-close hook among them, and it closes in
+// bursts — to learn nothing.
+//
+// Read faults are refusals, not skips. This runs in front of callers that
+// MUTATE, and a rig that cannot answer has not established the id is uniquely
+// addressable; the error policy is the scan's own, one function down, for the
+// same probe.
+func refuseBindingRigCollision(beadID string, cfg *config.City, cityPath string, openStore func(string) (beads.Store, error)) error {
+	if bdIDIsClassReserved(beadID) {
+		return nil
+	}
+	candidates, err := openConvoyStores(cfg, cityPath, beadID, openStore)
+	if err != nil {
+		return err
+	}
+	for _, candidate := range candidates {
+		if candidate.store == nil || samePath(candidate.path, cityPath) {
+			continue
+		}
+		if _, err := candidate.store.Get(beadID); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("bead %s exists in multiple stores (%s and %s); resolution requires a uniquely addressable bead id", beadID, convoyBindingViewPath, candidate.path)
+	}
+	return nil
 }
 
 func openAllConvoyStores(stderr io.Writer, cmdName string) ([]convoyStoreView, int) {

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -529,8 +529,8 @@ func (v convoyStoreView) isClassBinding() bool {
 // the view's own path. The binding is not a directory at all — it is where the
 // city's infrastructure classes were relocated to — and its rows belong to the
 // city scope, which is the answer three separate questions need: which store ref
-// a workflow root implies when it carries none, which directory a source-workflow
-// lock is taken in, and whether two matched views are one scope or two.
+// a workflow root implies when it carries none, which scope a source-workflow
+// lock is keyed on, and whether two matched views are one scope or two.
 func (v convoyStoreView) scopePath(cityPath string) string {
 	if v.isClassBinding() {
 		return cityPath
@@ -617,8 +617,41 @@ func convoyStoreViewsForRead(cityPath string, views []convoyStoreView, stderr io
 	return merged
 }
 
-// mergeConvoyViewRows folds one row set per view into one, dropping the rows a
-// class binding supersedes.
+// convoyBindingOwnedIDs asks the class binding which of these ids it HOLDS.
+//
+// This is deliberately not "which of these ids did the binding return for the
+// caller's query". Those are different questions, and answering the second one
+// is how a migrated city ends up serving frozen rows: `gc convoy list` asks
+// every store for its OPEN convoys, so the moment the city closes a relocated
+// convoy in the binding — the normal end of every migrated workflow, not an edge
+// case — the binding stops answering for that id, the retained copy stops
+// looking superseded, and a convoy the city finished prints open forever.
+//
+// So the ownership probe carries only the ids it is asking about and
+// IncludeClosed, and no filter of the caller's reaches it. It is one round trip:
+// ListQuery.IDs is the IN-list form of a batch of Gets and counts as a filter,
+// so it needs no AllowScan and costs one query rather than one per row.
+//
+// A probe that FAILS is an error, never an empty answer. Reading a fault as "the
+// binding holds none of these" would serve every frozen twin as live data and
+// say nothing about why.
+func convoyBindingOwnedIDs(binding beads.Store, ids []string) (map[string]bool, error) {
+	owned := make(map[string]bool, len(ids))
+	if binding == nil || len(ids) == 0 {
+		return owned, nil
+	}
+	held, err := binding.List(beads.ListQuery{IDs: ids, IncludeClosed: true})
+	if err != nil {
+		return nil, fmt.Errorf("asking %s which ids it holds: %w", convoyBindingViewPath, err)
+	}
+	for _, b := range held {
+		owned[b.ID] = true
+	}
+	return owned, nil
+}
+
+// mergeConvoyViewRows folds one row set per view into one, dropping the frozen
+// copies a class binding supersedes.
 //
 // Ids are unique only WITHIN a store, so this is not an id dedupe: a city and a
 // rig that each mint "gc-1" hold two different beads and both belong in the
@@ -626,26 +659,46 @@ func convoyStoreViewsForRead(cityPath string, views []convoyStoreView, stderr io
 // copies a class into the binding with ids preserved and deletes nothing — so
 // the migration source's copy is a frozen duplicate of a row the binding now
 // owns. That pair, and only that pair, collapses, with the binding winning.
-func mergeConvoyViewRows[T any](views []convoyStoreView, rows [][]T, idOf func(T) string) []T {
-	superseded := make(map[string]bool)
+//
+// Which is why the supersede question is asked of the BINDING and only about the
+// migration source's ids, rather than read off the two row sets. A rig's id is
+// never put to the binding at all, so the role scoping is structural; and the
+// answer does not depend on whether the binding's own row happened to survive
+// the caller's filter, so a relocated bead the city has since closed still
+// supersedes its twin.
+func mergeConvoyViewRows[T any](views []convoyStoreView, rows [][]T, idOf func(T) string) ([]T, error) {
+	var binding beads.Store
 	for i, view := range views {
-		if view.role != convoyViewClassBinding {
+		if view.role == convoyViewClassBinding && len(rows) > i {
+			binding = view.store
+		}
+	}
+	var candidates []string
+	for i, view := range views {
+		if view.role != convoyViewMigrationSource || len(rows) <= i {
 			continue
 		}
 		for _, row := range rows[i] {
-			superseded[idOf(row)] = true
+			candidates = append(candidates, idOf(row))
 		}
+	}
+	owned, err := convoyBindingOwnedIDs(binding, candidates)
+	if err != nil {
+		return nil, err
 	}
 	merged := make([]T, 0)
 	for i, view := range views {
+		if len(rows) <= i {
+			continue
+		}
 		for _, row := range rows[i] {
-			if view.role == convoyViewMigrationSource && superseded[idOf(row)] {
+			if view.role == convoyViewMigrationSource && owned[idOf(row)] {
 				continue
 			}
 			merged = append(merged, row)
 		}
 	}
-	return merged
+	return merged, nil
 }
 
 func openConvoyStores(cfg *config.City, cityPath, beadID string, openStore func(string) (beads.Store, error)) ([]convoyStoreView, error) {
@@ -903,7 +956,10 @@ func collectOpenConvoys(stores []convoyStoreView) ([]convoyWithStore, error) {
 			rows[i] = append(rows[i], convoyWithStore{store: candidate.store, bead: b})
 		}
 	}
-	convoys := mergeConvoyViewRows(stores, rows, func(c convoyWithStore) string { return c.bead.ID })
+	convoys, err := mergeConvoyViewRows(stores, rows, func(c convoyWithStore) string { return c.bead.ID })
+	if err != nil {
+		return nil, err
+	}
 	sort.SliceStable(convoys, func(i, j int) bool {
 		if convoys[i].bead.ID == convoys[j].bead.ID {
 			return convoys[i].bead.Title < convoys[j].bead.Title

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -581,6 +581,18 @@ func convoyStoreViewsWithBinding(cityPath string, views []convoyStoreView) ([]co
 		// second leg — it is the one that is there. Adding it would duplicate
 		// every row against itself. This is relocatedGraphLegFrom's identity
 		// gate, applied to a list of views.
+		//
+		// Both operands are pointer-typed HERE, which is what keeps the `==`
+		// away from the non-comparable dynamic type that panics an interface
+		// compare: the scan side is whatever opener openConvoyStores was handed,
+		// and both production openers end in a pointer store — openStoreAtForCity
+		// through wrapStoreWithBeadPolicies, openControlStoreAtForCity through
+		// that or the *beads.BdStore control factory — while the binding side is
+		// constructor-opened and its one value-typed route, refusedClassStore,
+		// already returned above. relocatedGraphLegFrom carries the same
+		// argument, but its own doc says production no longer calls it, so the
+		// operand set is named here rather than only by reference to a function
+		// documented as dead.
 		if view.store == binding {
 			return views, nil
 		}
@@ -616,6 +628,13 @@ func convoyStoreViewsWithBinding(cityPath string, views []convoyStoreView) ([]co
 // refusal stands they are no longer superseded and print as live rows in place
 // of the ones that are missing. A convoy the city closed in the binding lists
 // open again for exactly as long as the binding cannot be read.
+//
+// "Only READ" is the whole precondition, so the caller set is named rather than
+// assumed: `gc beads list`, `gc convoy list`, and `gc convoy stranded`, none of
+// which write. A caller that mutates takes convoyStoreViewsWithBinding directly
+// and refuses — doConvoyCheckFallback does, and federateSweepViews does it for
+// the sweeps — because the frozen rows this tolerates printing are rows a
+// mutation would act on.
 func convoyStoreViewsForRead(cityPath string, views []convoyStoreView, stderr io.Writer, cmdName string) []convoyStoreView {
 	merged, err := convoyStoreViewsWithBinding(cityPath, views)
 	if err != nil {
@@ -849,10 +868,14 @@ func resolveOwningStoreDir(beadID string, cfg *config.City, cityPath string, ope
 // reserved-id resolution — bd's on-close hook among them, and it closes in
 // bursts — to learn nothing.
 //
-// Read faults are refusals, not skips. This runs in front of callers that
-// MUTATE, and a rig that cannot answer has not established the id is uniquely
-// addressable; the error policy is the scan's own, one function down, for the
-// same probe.
+// Read faults are refusals, not skips. This fronts resolveOwningStoreDir, whose
+// callers are the mutations reached through resolveConvoyStore — `gc convoy
+// target`/`add`/`close`/`land` — and autocloseOwningStore, which absorbs the
+// refusal into its own ok=false, but ALSO the pure read `gc convoy status`. It
+// refuses there too: a rig that cannot answer has not established the id is
+// uniquely addressable, and a read served from one of two disagreeing ledgers is
+// the same wrong answer whether or not a write follows it. The error policy is
+// the scan's own, one function down, for the same probe.
 func refuseBindingRigCollision(beadID string, cfg *config.City, cityPath string, openStore func(string) (beads.Store, error)) error {
 	if bdIDIsClassReserved(beadID) {
 		return nil
@@ -876,16 +899,7 @@ func refuseBindingRigCollision(beadID string, cfg *config.City, cityPath string,
 	return nil
 }
 
-func openAllConvoyStores(stderr io.Writer, cmdName string) ([]convoyStoreView, int) {
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
-	}
-	return openAllConvoyStoresAt(cityPath, stderr, cmdName)
-}
-
-// openAllConvoyStoresAt is openAllConvoyStores with a pre-resolved cityPath,
+// openAllConvoyStoresAt opens every convoy store for a pre-resolved cityPath,
 // used by routed callers that already resolved the city before dispatching
 // to the fallback path.
 func openAllConvoyStoresAt(cityPath string, stderr io.Writer, cmdName string) ([]convoyStoreView, int) {
@@ -1681,12 +1695,25 @@ func routeConvoyCheck(cityPath string, _ *api.Client, nilReason string, jsonOut 
 }
 
 // doConvoyCheckFallback is the direct-bd path for "gc convoy check".
+//
+// It federates through convoyStoreViewsWithBinding rather than through
+// convoyStoreViewsForRead, because this command CLOSES convoys. A refusal hands
+// back the views unchanged, which leaves the city's retained pre-migration
+// copies unsuperseded and walks them as live rows — and their children were
+// frozen at cutover, so a convoy the city is still working reads as complete.
+// Degrading here would auto-close it and report that as success while the
+// binding's open row went untouched, so the check refuses instead: a mutation
+// on a view this build could not prove is worse than no mutation.
 func doConvoyCheckFallback(cityPath string, jsonOut bool, stdout, stderr io.Writer) int {
 	stores, code := openAllConvoyStoresAt(cityPath, stderr, "gc convoy check")
 	if stores == nil {
 		return code
 	}
-	stores = convoyStoreViewsForRead(cityPath, stores, stderr, "gc convoy check")
+	stores, err := convoyStoreViewsWithBinding(cityPath, stores)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc convoy check: the city's relocated class binding is unreadable, so this refuses rather than auto-close convoys from the retained pre-migration copies it cannot supersede: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	rec := openCityRecorderAt(cityPath, stderr)
 	return doConvoyCheckAcrossStoresJSON(stores, rec, jsonOut, stdout, stderr)
 }
@@ -1836,10 +1863,28 @@ func cmdConvoyStranded(stdout, stderr io.Writer) int {
 }
 
 func cmdConvoyStrandedJSON(jsonOut bool, stdout, stderr io.Writer) int {
-	stores, code := openAllConvoyStores(stderr, "gc convoy stranded")
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc convoy stranded: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return doConvoyStrandedFallback(cityPath, jsonOut, stdout, stderr)
+}
+
+// doConvoyStrandedFallback is the direct-bd path for "gc convoy stranded".
+//
+// This is a pure read, so it takes the tolerant helper its list sibling takes.
+// It needs the helper at all because an unfederated stranded query is wrong in
+// both directions at once on a migrated city: a retained copy still carries the
+// assignees and open children it had at cutover and reports work that is not
+// stranded, while a convoy living in the binding is never walked and genuinely
+// stranded work stays invisible.
+func doConvoyStrandedFallback(cityPath string, jsonOut bool, stdout, stderr io.Writer) int {
+	stores, code := openAllConvoyStoresAt(cityPath, stderr, "gc convoy stranded")
 	if stores == nil {
 		return code
 	}
+	stores = convoyStoreViewsForRead(cityPath, stores, stderr, "gc convoy stranded")
 	return doConvoyStrandedAcrossStoresJSON(stores, jsonOut, stdout, stderr)
 }
 

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -609,13 +609,34 @@ func convoyStoreViewsWithBinding(cityPath string, views []convoyStoreView) ([]co
 // missing from that output, though, so the omission is announced — every run,
 // not once per process, because each invocation is a fresh answer and has to
 // carry its own caveat.
+//
+// The caveat says both halves, because on a converged city the omission is not
+// the whole hazard. The migration RETAINED a frozen copy of every row it moved,
+// and it is the binding's answer that supersedes those copies — so while the
+// refusal stands they are no longer superseded and print as live rows in place
+// of the ones that are missing. A convoy the city closed in the binding lists
+// open again for exactly as long as the binding cannot be read.
 func convoyStoreViewsForRead(cityPath string, views []convoyStoreView, stderr io.Writer, cmdName string) []convoyStoreView {
 	merged, err := convoyStoreViewsWithBinding(cityPath, views)
 	if err != nil {
-		fmt.Fprintf(stderr, "%s: the city's relocated class binding is unreadable, so any beads it holds are missing from this output: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: the city's relocated class binding is unreadable, so any beads it holds are missing from this output and retained pre-migration copies of them may appear in their place as stale open rows: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 	}
 	return merged
 }
+
+// convoyOwnershipProbeBatch bounds how many ids one ownership probe puts on the
+// wire, because an unbounded IN-list is a query no sqlite binding can run.
+//
+// The IDs filter compiles to one bound variable per id (`b.id IN (?,...,?)` in
+// sqliteListSQL, with no chunking of its own) and modernc sqlite refuses any
+// statement carrying more than 32766 of them. The candidate set is every
+// migration-source row matching the caller's query and `gc beads list` runs
+// unbounded, so on a converged city with a long history the probe would carry
+// the whole work ledger and come back "too many SQL variables" — failing the
+// read outright on exactly the large migrated cities the federation exists for.
+// Batching under the cap keeps the probe O(candidates/batch) round trips rather
+// than the one-per-row it replaced.
+const convoyOwnershipProbeBatch = 30000
 
 // convoyBindingOwnedIDs asks the class binding which of these ids it HOLDS.
 //
@@ -628,9 +649,9 @@ func convoyStoreViewsForRead(cityPath string, views []convoyStoreView, stderr io
 // looking superseded, and a convoy the city finished prints open forever.
 //
 // So the ownership probe carries only the ids it is asking about and
-// IncludeClosed, and no filter of the caller's reaches it. It is one round trip:
-// ListQuery.IDs is the IN-list form of a batch of Gets and counts as a filter,
-// so it needs no AllowScan and costs one query rather than one per row.
+// IncludeClosed, and no filter of the caller's reaches it. ListQuery.IDs is the
+// IN-list form of a batch of Gets and counts as a filter, so it needs no
+// AllowScan and costs one query per batch rather than one per row.
 //
 // A probe that FAILS is an error, never an empty answer. Reading a fault as "the
 // binding holds none of these" would serve every frozen twin as live data and
@@ -640,12 +661,15 @@ func convoyBindingOwnedIDs(binding beads.Store, ids []string) (map[string]bool, 
 	if binding == nil || len(ids) == 0 {
 		return owned, nil
 	}
-	held, err := binding.List(beads.ListQuery{IDs: ids, IncludeClosed: true})
-	if err != nil {
-		return nil, fmt.Errorf("asking %s which ids it holds: %w", convoyBindingViewPath, err)
-	}
-	for _, b := range held {
-		owned[b.ID] = true
+	for start := 0; start < len(ids); start += convoyOwnershipProbeBatch {
+		batch := ids[start:min(start+convoyOwnershipProbeBatch, len(ids))]
+		held, err := binding.List(beads.ListQuery{IDs: batch, IncludeClosed: true})
+		if err != nil {
+			return nil, fmt.Errorf("asking %s which ids it holds: %w", convoyBindingViewPath, err)
+		}
+		for _, b := range held {
+			owned[b.ID] = true
+		}
 	}
 	return owned, nil
 }

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -517,6 +517,27 @@ const (
 // working directory has to check the view's role first.
 const convoyBindingViewPath = "city (class binding)"
 
+// isClassBinding reports whether this view is the city's relocated class
+// binding rather than one of the directories the scan enumerated.
+func (v convoyStoreView) isClassBinding() bool {
+	return v.role == convoyViewClassBinding
+}
+
+// scopePath is the directory whose SCOPE owns the view's rows.
+//
+// Every view but the class binding is itself a scope root, so this is usually
+// the view's own path. The binding is not a directory at all — it is where the
+// city's infrastructure classes were relocated to — and its rows belong to the
+// city scope, which is the answer three separate questions need: which store ref
+// a workflow root implies when it carries none, which directory a source-workflow
+// lock is taken in, and whether two matched views are one scope or two.
+func (v convoyStoreView) scopePath(cityPath string) string {
+	if v.isClassBinding() {
+		return cityPath
+	}
+	return v.path
+}
+
 // convoyStoreViewsWithBinding federates a directory scan's views with the
 // city's relocated class binding, and reports a refusal rather than deciding
 // what to do about it.

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -422,6 +422,7 @@ func doConvoyListFallback(cityPath string, jsonOut bool, stdout, stderr io.Write
 	if stores == nil {
 		return code
 	}
+	stores = convoyStoreViewsForRead(cityPath, stores, stderr, "gc convoy list")
 	return doConvoyListAcrossStores(stores, jsonOut, stdout, stderr)
 }
 
@@ -486,6 +487,144 @@ func convoyStoreCandidatesWithProvider(cfg *config.City, cityPath, beadID string
 type convoyStoreView struct {
 	path  string
 	store beads.Store
+	role  convoyViewRole
+}
+
+// convoyViewRole says how a view's rows relate to the other views' rows. It is
+// the only thing a fan-out merge needs to know about where a store came from.
+type convoyViewRole int
+
+const (
+	// convoyViewOrdinary is a store the directory scan enumerated. Its ids are
+	// its own: a city and a rig that each mint "gc-1" hold two different beads,
+	// and a merge that collapsed them would delete one from the output.
+	convoyViewOrdinary convoyViewRole = iota
+	// convoyViewClassBinding is the city's relocated class binding — the store
+	// `gc storage migrate` moved the infrastructure classes INTO, and the one
+	// the city has gone on mutating since.
+	convoyViewClassBinding
+	// convoyViewMigrationSource is the city store the migration copied OUT of.
+	// The copies it retained are frozen at cutover and share their ids with the
+	// binding's live rows, so they are the one duplicate a merge can safely
+	// collapse.
+	convoyViewMigrationSource
+)
+
+// convoyBindingViewPath is what the class binding is called in fan-out output.
+//
+// It is deliberately not a directory. No `bd` invocation can be rooted there
+// and no lock can be taken on it, so a caller that treats a view's path as a
+// working directory has to check the view's role first.
+const convoyBindingViewPath = "city (class binding)"
+
+// convoyStoreViewsWithBinding federates a directory scan's views with the
+// city's relocated class binding, and reports a refusal rather than deciding
+// what to do about it.
+//
+// The scan enumerates DIRECTORIES, and a relocated binding is not one of them.
+// On a converged city that makes every fan-out read the copies `gc storage
+// migrate` retained — frozen at cutover, never mutated since — while the rows
+// the city actually works are invisible. Appending the binding as one more view
+// is what closes that, and marking the city's view as the migration source is
+// what lets the merge collapse the resulting duplicate.
+//
+// A REFUSED binding comes back as an error with the views unchanged, because
+// the two kinds of caller need opposite things from it. A read can print what
+// it has and say what is missing; a destructive sweep cannot, because reaching
+// only some of the rows it was asked to delete is worse than deleting nothing.
+// Deciding that here would force one of them to be wrong.
+//
+// Both shapes of refusal arrive as an error and neither arrives as "this city
+// relocates nothing". A city configured for a binding it has not converged on
+// resolves to a refusedClassStore carrying the boot gate's sentence; a city
+// serving its classes from more than one binding is a topology this build
+// refuses outright, and that is a STANDING verdict about the city rather than a
+// fault this read ran into, so it is marked as one. Reporting either as
+// unrelocated would send the fan-out to the directory scan alone — the retained
+// pre-migration copies, printed as live rows — which is the confidently stale
+// answer this federation exists to close.
+func convoyStoreViewsWithBinding(cityPath string, views []convoyStoreView) ([]convoyStoreView, error) {
+	relocated, isRelocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		return views, standingStorageRefusal{err: err}
+	}
+	binding := relocated.Store
+	if !isRelocated || binding == nil {
+		return views, nil
+	}
+	if refusal, refused := binding.(refusedClassStore); refused {
+		return views, refusal.err
+	}
+	for _, view := range views {
+		// The scan already opened this exact store, so the binding is not a
+		// second leg — it is the one that is there. Adding it would duplicate
+		// every row against itself. This is relocatedGraphLegFrom's identity
+		// gate, applied to a list of views.
+		if view.store == binding {
+			return views, nil
+		}
+	}
+
+	merged := make([]convoyStoreView, 0, len(views)+1)
+	for _, view := range views {
+		if samePath(view.path, cityPath) {
+			view.role = convoyViewMigrationSource
+		}
+		merged = append(merged, view)
+	}
+	return append(merged, convoyStoreView{
+		path:  convoyBindingViewPath,
+		store: binding,
+		role:  convoyViewClassBinding,
+	}), nil
+}
+
+// convoyStoreViewsForRead is convoyStoreViewsWithBinding for the surfaces that
+// only READ, which continue past a refusal and say so.
+//
+// A refused city still serves work from its work ledger, so failing the whole
+// listing would take `gc beads list` and `gc convoy list` away from every city
+// whose storage configuration is mid-repair. The rows the binding holds are
+// missing from that output, though, so the omission is announced — every run,
+// not once per process, because each invocation is a fresh answer and has to
+// carry its own caveat.
+func convoyStoreViewsForRead(cityPath string, views []convoyStoreView, stderr io.Writer, cmdName string) []convoyStoreView {
+	merged, err := convoyStoreViewsWithBinding(cityPath, views)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: the city's relocated class binding is unreadable, so any beads it holds are missing from this output: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+	}
+	return merged
+}
+
+// mergeConvoyViewRows folds one row set per view into one, dropping the rows a
+// class binding supersedes.
+//
+// Ids are unique only WITHIN a store, so this is not an id dedupe: a city and a
+// rig that each mint "gc-1" hold two different beads and both belong in the
+// output. The one place an id means the same bead twice is the migration, which
+// copies a class into the binding with ids preserved and deletes nothing — so
+// the migration source's copy is a frozen duplicate of a row the binding now
+// owns. That pair, and only that pair, collapses, with the binding winning.
+func mergeConvoyViewRows[T any](views []convoyStoreView, rows [][]T, idOf func(T) string) []T {
+	superseded := make(map[string]bool)
+	for i, view := range views {
+		if view.role != convoyViewClassBinding {
+			continue
+		}
+		for _, row := range rows[i] {
+			superseded[idOf(row)] = true
+		}
+	}
+	merged := make([]T, 0)
+	for i, view := range views {
+		for _, row := range rows[i] {
+			if view.role == convoyViewMigrationSource && superseded[idOf(row)] {
+				continue
+			}
+			merged = append(merged, row)
+		}
+	}
+	return merged
 }
 
 func openConvoyStores(cfg *config.City, cityPath, beadID string, openStore func(string) (beads.Store, error)) ([]convoyStoreView, error) {
@@ -501,7 +640,7 @@ func openConvoyStores(cfg *config.City, cityPath, beadID string, openStore func(
 			}
 			continue
 		}
-		stores = append(stores, convoyStoreView{path: dir, store: store})
+		stores = append(stores, convoyStoreView{path: dir, store: store, role: convoyViewOrdinary})
 	}
 	if len(stores) > 0 {
 		return stores, nil
@@ -685,16 +824,17 @@ type convoyStatusResultJSON struct {
 }
 
 func collectOpenConvoys(stores []convoyStoreView) ([]convoyWithStore, error) {
-	convoys := make([]convoyWithStore, 0)
-	for _, candidate := range stores {
+	rows := make([][]convoyWithStore, len(stores))
+	for i, candidate := range stores {
 		all, err := candidate.store.List(beads.ListQuery{Type: "convoy"})
 		if err != nil {
 			return nil, err
 		}
 		for _, b := range all {
-			convoys = append(convoys, convoyWithStore{store: candidate.store, bead: b})
+			rows[i] = append(rows[i], convoyWithStore{store: candidate.store, bead: b})
 		}
 	}
+	convoys := mergeConvoyViewRows(stores, rows, func(c convoyWithStore) string { return c.bead.ID })
 	sort.SliceStable(convoys, func(i, j int) bool {
 		if convoys[i].bead.ID == convoys[j].bead.ID {
 			return convoys[i].bead.Title < convoys[j].bead.Title
@@ -1397,6 +1537,7 @@ func doConvoyCheckFallback(cityPath string, jsonOut bool, stdout, stderr io.Writ
 	if stores == nil {
 		return code
 	}
+	stores = convoyStoreViewsForRead(cityPath, stores, stderr, "gc convoy check")
 	rec := openCityRecorderAt(cityPath, stderr)
 	return doConvoyCheckAcrossStoresJSON(stores, rec, jsonOut, stdout, stderr)
 }

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -977,10 +977,39 @@ func graphBindingResidentScope(cityPath string, cfg *config.City, beadID string)
 	return cityStore, cityPath, nil
 }
 
+// findUniqueBeadAcrossStoresView resolves the store view holding beadID, and
+// the row itself, refusing an id that more than one store answers.
+//
+// The binding leg runs in front of the scan for the reason resolveOwningStoreDir
+// states: a relocated class binding is not one of the city's directories, so a
+// directory scan answers a relocated id from the frozen copy the migration
+// retained. That matters more here than for a read — the view this returns is
+// the one delete-source and reopen-source WRITE the source bead's metadata
+// through, and clearing workflow_id on the frozen twin leaves the live row still
+// pointing at a workflow that no longer exists.
+//
+// A binding hit skips the uniqueness rule for the city's own retained copy,
+// which is dual residency working as designed, and still refuses a rig holding
+// the same id, which never is.
 func findUniqueBeadAcrossStoresView(cityPath, beadID string) (convoyStoreView, beads.Bead, error) {
 	cfg, err := loadCityConfig(cityPath, os.Stderr)
 	if err != nil {
 		return convoyStoreView{}, beads.Bead{}, fmt.Errorf("loading city config for bead %q: %w", beadID, err)
+	}
+	owner, ownedByBinding, err := cliByIDBindingOwner(cityPath, beadID)
+	if err != nil {
+		return convoyStoreView{}, beads.Bead{}, err
+	}
+	if ownedByBinding {
+		openStore := func(dir string) (beads.Store, error) { return openStoreAtForCity(dir, cityPath) }
+		if err := refuseBindingRigCollision(beadID, cfg, cityPath, openStore); err != nil {
+			return convoyStoreView{}, beads.Bead{}, err
+		}
+		bead, err := beadForOwner(owner, beadID)
+		if err != nil {
+			return convoyStoreView{}, beads.Bead{}, fmt.Errorf("getting bead %q from %s: %w", beadID, convoyBindingViewPath, err)
+		}
+		return convoyStoreView{path: convoyBindingViewPath, store: owner.Store, role: convoyViewClassBinding}, bead, nil
 	}
 	stores, skips, err := openSourceWorkflowStores(cfg, cityPath, beadID)
 	if err != nil {
@@ -1371,7 +1400,47 @@ type workflowStoreMatch struct {
 	beads  []beads.Bead
 	label  string
 	path   string
+	role   convoyViewRole
 	runner beads.CommandRunner
+}
+
+// refuseSweepPastAnUnreadableBinding federates a sweep's store views with the
+// city's relocated class binding, and turns a refused binding into a hard error.
+//
+// This is the one policy difference between a sweep and a read fan-out. A read
+// prints what it reached and names what it could not; a destructive one-shot has
+// no such output — "I could not see the binding's tree" and "the binding's tree
+// is gone" leave the operator believing the same thing, and only one of them is
+// true. So the sweep stops before it touches anything.
+func refuseSweepPastAnUnreadableBinding(cityPath string, views []convoyStoreView, cmdName string) ([]convoyStoreView, error) {
+	merged, err := convoyStoreViewsWithBinding(cityPath, views)
+	if err != nil {
+		return nil, fmt.Errorf("%s: the city's relocated class binding is unreadable, so this would sweep only some of the workflow: %w", cmdName, err)
+	}
+	return merged, nil
+}
+
+// workflowDeleteStoreLabelForView names a store view in sweep output. The class
+// binding has no directory to fall back on, so it is named for what it is.
+func workflowDeleteStoreLabelForView(cfg *config.City, cityPath string, view convoyStoreView) string {
+	if view.isClassBinding() {
+		return convoyBindingViewPath
+	}
+	return workflowDeleteStoreLabel(cfg, cityPath, view.path)
+}
+
+// workflowDeleteRunnerForView returns the `bd` runner for a view's scope, and
+// nil for the class binding.
+//
+// bd runs IN a directory. The binding is a database the city was rebound to, not
+// a directory, so there is nothing to root an invocation at; its beads are
+// deleted through the store handle instead — the same route delete-source has
+// always taken for every store.
+func workflowDeleteRunnerForView(cfg *config.City, cityPath string, view convoyStoreView) beads.CommandRunner {
+	if view.isClassBinding() {
+		return nil
+	}
+	return workflowDeleteRunnerForPath(cfg, cityPath, view.path)
 }
 
 func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stderr io.Writer) int {
@@ -1396,6 +1465,15 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	// The scan enumerates directories, and a relocated binding is not one. Every
+	// row it holds is the row the city is actually running; the copies retained
+	// in the work ledger are frozen twins of the same ids. Both are swept — the
+	// operator is erasing the workflow, not choosing between its copies.
+	stores, err = refuseSweepPastAnUnreadableBinding(cityPath, stores, "gc workflow delete")
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	for _, info := range stores {
 		found := findWorkflowBeads(info.store, workflowID)
 		if len(found) == 0 {
@@ -1404,9 +1482,10 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		matches = append(matches, workflowStoreMatch{
 			store:  info.store,
 			beads:  found,
-			label:  workflowDeleteStoreLabel(cfg, cityPath, info.path),
+			label:  workflowDeleteStoreLabelForView(cfg, cityPath, info),
 			path:   info.path,
-			runner: workflowDeleteRunnerForPath(cfg, cityPath, info.path),
+			role:   info.role,
+			runner: workflowDeleteRunnerForView(cfg, cityPath, info),
 		})
 	}
 
@@ -1477,10 +1556,21 @@ func workflowDeleteRunnerForPath(cfg *config.City, cityPath, scopePath string) b
 func deleteWorkflowMatches(matches []workflowStoreMatch) (int, error) {
 	deleted := 0
 	for _, m := range matches {
+		ids := workflowBeadIDs(m.beads)
+		if m.role == convoyViewClassBinding {
+			// No directory, so no bd invocation. The store handle is the whole
+			// access path to a relocated class, and it is the same one
+			// delete-source deletes every match through.
+			n, errs := deleteWorkflowBeads(m.store, ids)
+			deleted += n
+			if len(errs) > 0 {
+				return deleted, fmt.Errorf("%s: %w", m.label, errors.Join(errs...))
+			}
+			continue
+		}
 		if m.runner == nil {
 			return deleted, fmt.Errorf("%s: delete runner missing", m.label)
 		}
-		ids := workflowBeadIDs(m.beads)
 		args := append([]string{"delete"}, ids...)
 		args = append(args, "--cascade", "--force")
 		if _, err := m.runner(m.path, "bd", args...); err != nil {
@@ -1492,12 +1582,37 @@ func deleteWorkflowMatches(matches []workflowStoreMatch) (int, error) {
 }
 
 type sourceWorkflowStoreMatch struct {
-	label  string
-	store  beads.Store
-	roots  []beads.Bead
-	beads  []beads.Bead
-	path   string
-	runner beads.CommandRunner
+	label string
+	store beads.Store
+	roots []beads.Bead
+	beads []beads.Bead
+	path  string
+	// scopePath is the directory whose scope owns these rows. It differs from
+	// path only for the class binding, whose rows are the city's — which is what
+	// keeps a converged city's two matched views from reading as two stores.
+	scopePath string
+	runner    beads.CommandRunner
+}
+
+// distinctSourceWorkflowScopes counts the SCOPES a match set spans.
+//
+// The multi-store guard exists because a live root in a rig and a live root in
+// the city are two different workflows, and delete-source cannot pick one. A
+// converged city's binding is not that case: it and the city's work ledger are
+// one scope holding one workflow in two copies, deliberately, and refusing there
+// would take delete-source away from every city that has migrated.
+func distinctSourceWorkflowScopes(matches []sourceWorkflowStoreMatch) []string {
+	scopes := make([]string, 0, len(matches))
+	for _, match := range matches {
+		scope := match.scopePath
+		if strings.TrimSpace(scope) == "" {
+			scope = match.path
+		}
+		if !slices.ContainsFunc(scopes, func(existing string) bool { return samePath(existing, scope) }) {
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes
 }
 
 type sourceWorkflowStoreSelector struct {
@@ -1542,7 +1657,7 @@ func resolveSourceWorkflowTarget(cfg *config.City, cityPath, sourceBeadID string
 				return resolvedSourceWorkflowTarget{}, fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
 			}
 		default:
-			return resolvedSourceWorkflowTarget{}, fmt.Errorf("getting bead %q from %s: %w", sourceBeadID, workflowDeleteStoreLabel(cfg, cityPath, view.path), err)
+			return resolvedSourceWorkflowTarget{}, fmt.Errorf("getting bead %q from %s: %w", sourceBeadID, workflowDeleteStoreLabelForView(cfg, cityPath, view), err)
 		}
 		return target, nil
 	}
@@ -1555,7 +1670,7 @@ func resolveSourceWorkflowTarget(cfg *config.City, cityPath, sourceBeadID string
 	}
 	target.storeView = view
 	target.sourceBead = bead
-	target.storeRef = workflowStoreRefForDir(view.path, cityPath, loadedCityName(cfg, cityPath), cfg)
+	target.storeRef = workflowStoreRefForDir(view.scopePath(cityPath), cityPath, loadedCityName(cfg, cityPath), cfg)
 	return target, nil
 }
 
@@ -1662,7 +1777,12 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
 		return 1
 	}
-	lockScope := target.storeView.path
+	// The lock is taken in a directory, so it follows the view's SCOPE. A
+	// relocated class binding has no directory of its own and its rows are the
+	// city's, so it locks the city — which is also what keeps a binding-resolved
+	// target and a city-resolved one from running concurrently over the same
+	// workflow.
+	lockScope := target.storeView.scopePath(cityPath)
 	if strings.TrimSpace(lockScope) == "" {
 		lockScope = cityPath
 	}
@@ -1682,7 +1802,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			// rather than silently declaring success.
 			fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips(skips)) //nolint:errcheck
 		}
-		if target.storeRef == "" && len(matches) > 1 {
+		if target.storeRef == "" && len(distinctSourceWorkflowScopes(matches)) > 1 {
 			return fmt.Errorf(
 				"source workflow %s has live roots in multiple stores (%s); rerun with --rig <name> or --store-ref <city:name|rig:name>",
 				sourceBeadID,
@@ -1809,7 +1929,7 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 	}
 	ctx, cancel := sourceWorkflowCommandContext()
 	defer cancel()
-	runErr := sourceworkflow.WithLock(ctx, cityPath, target.storeView.path, sourceBeadID, func() error {
+	runErr := sourceworkflow.WithLock(ctx, cityPath, target.storeView.scopePath(cityPath), sourceBeadID, func() error {
 		target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, true)
 		if err != nil {
 			return err
@@ -2028,6 +2148,14 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 	if err != nil {
 		return nil, skips, err
 	}
+	// A relocated class binding is not one of the directories the scan
+	// enumerated, and on a converged city it is where the live workflow graph
+	// actually is. Sweeping without it would delete the frozen retained copy and
+	// leave the running one.
+	stores, err = refuseSweepPastAnUnreadableBinding(cityPath, stores, "gc workflow delete-source")
+	if err != nil {
+		return nil, skips, err
+	}
 	return collectSourceWorkflowMatchesFromStores(cfg, cityPath, sourceBeadID, sourceStoreRef, stores, skips)
 }
 
@@ -2069,7 +2197,7 @@ func ensureSelectedSourceStorePresent(cfg *config.City, cityPath, cityName, sour
 	}
 	present := slices.ContainsFunc(stores, func(info convoyStoreView) bool {
 		return info.store != nil &&
-			sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(info.path, cityPath, cityName, cfg)) == selectedRef
+			sourceworkflow.NormalizeSourceStoreRef(workflowStoreRefForDir(info.scopePath(cityPath), cityPath, cityName, cfg)) == selectedRef
 	})
 	if present {
 		return nil
@@ -2115,7 +2243,7 @@ func (c *sourceWorkflowMatchCollector) collect(currentSourceID, currentSourceSto
 		if err != nil {
 			return err
 		}
-		rootStoreRef := workflowStoreRefForDir(info.path, c.cityPath, c.cityName, c.cfg)
+		rootStoreRef := workflowStoreRefForDir(info.scopePath(c.cityPath), c.cityPath, c.cityName, c.cfg)
 		for _, child := range children {
 			if err := c.collect(child.ID, rootStoreRef); err != nil {
 				return err
@@ -2138,11 +2266,15 @@ func (c *sourceWorkflowMatchCollector) scanStore(index int, info convoyStoreView
 	if _, failed := c.failedStores[index]; failed {
 		return nil, nil
 	}
-	rootStoreRef := workflowStoreRefForDir(info.path, c.cityPath, c.cityName, c.cfg)
-	// Downward delete-source walks key by root store plus source identity. The
-	// upward finalize walk in internal/dispatch only needs source store plus
-	// bead ID because each hop has one parent.
-	visitKey := rootStoreRef + "\x00" + currentSourceStoreRef + "\x00" + currentSourceID
+	rootStoreRef := workflowStoreRefForDir(info.scopePath(c.cityPath), c.cityPath, c.cityName, c.cfg)
+	// Downward delete-source walks key by the store actually being read plus the
+	// source identity. The upward finalize walk in internal/dispatch only needs
+	// source store plus bead ID because each hop has one parent.
+	//
+	// The key is the VIEW, not its store ref: a converged city's binding and its
+	// work ledger share one scope and therefore one ref, so keying on the ref
+	// would mark the pair visited after the first and leave the second unswept.
+	visitKey := info.path + "\x00" + currentSourceStoreRef + "\x00" + currentSourceID
 	if _, ok := c.visited[visitKey]; ok {
 		return nil, nil
 	}
@@ -2180,12 +2312,13 @@ func (c *sourceWorkflowMatchCollector) mergeRootMatches(info convoyStoreView, ro
 		beadSet = append(beadSet, workflowBeads...)
 	}
 	mergeSourceWorkflowMatch(c.matchesByLabel, sourceWorkflowStoreMatch{
-		label:  workflowDeleteStoreLabel(c.cfg, c.cityPath, info.path),
-		store:  info.store,
-		roots:  roots,
-		beads:  uniqueBeads(beadSet),
-		path:   info.path,
-		runner: workflowDeleteRunnerForPath(c.cfg, c.cityPath, info.path),
+		label:     workflowDeleteStoreLabelForView(c.cfg, c.cityPath, info),
+		store:     info.store,
+		roots:     roots,
+		beads:     uniqueBeads(beadSet),
+		path:      info.path,
+		scopePath: info.scopePath(c.cityPath),
+		runner:    workflowDeleteRunnerForView(c.cfg, c.cityPath, info),
 	})
 	return nil
 }
@@ -2195,14 +2328,14 @@ func (c *sourceWorkflowMatchCollector) mergeRootMatches(info convoyStoreView, ro
 // when the failed store is the strict selected source store (so the caller
 // aborts). Otherwise it returns nil so the walk tolerates the failure.
 func (c *sourceWorkflowMatchCollector) recordScanFailure(index int, info convoyStoreView, currentSourceStoreRef, operation string, scanErr error) error {
-	wrapped := fmt.Errorf("%s in %s: %w", operation, workflowDeleteStoreLabel(c.cfg, c.cityPath, info.path), scanErr)
+	wrapped := fmt.Errorf("%s in %s: %w", operation, workflowDeleteStoreLabelForView(c.cfg, c.cityPath, info), scanErr)
 	if c.firstScanErr == nil {
 		c.firstScanErr = wrapped
 	}
 	c.failedStores[index] = struct{}{}
 	c.skips = append(c.skips, sourceWorkflowStoreSkip{path: info.path, err: wrapped})
 
-	rootStoreRef := workflowStoreRefForDir(info.path, c.cityPath, c.cityName, c.cfg)
+	rootStoreRef := workflowStoreRefForDir(info.scopePath(c.cityPath), c.cityPath, c.cityName, c.cfg)
 	selectedStore := strings.TrimSpace(currentSourceStoreRef) != "" &&
 		sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(currentSourceStoreRef)
 	if selectedStore {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1404,18 +1404,38 @@ type workflowStoreMatch struct {
 	runner beads.CommandRunner
 }
 
-// refuseSweepPastAnUnreadableBinding federates a sweep's store views with the
-// city's relocated class binding, and turns a refused binding into a hard error.
+// refusePartialSweep is the single refusal every destructive arm speaks when a
+// store it was told to sweep could not answer.
 //
 // This is the one policy difference between a sweep and a read fan-out. A read
 // prints what it reached and names what it could not; a destructive one-shot has
 // no such output — "I could not see the binding's tree" and "the binding's tree
 // is gone" leave the operator believing the same thing, and only one of them is
-// true. So the sweep stops before it touches anything.
-func refuseSweepPastAnUnreadableBinding(cityPath string, views []convoyStoreView, cmdName string) ([]convoyStoreView, error) {
+// true.
+//
+// It is one function because the ways a store stops answering do not look alike
+// and have to be treated alike. A standing refusal arrives at federation time; a
+// dropped connection arrives mid-scan and shows up as zero rows, which is what
+// an empty store contributes; a lock contended mid-close arrives after the other
+// views have already been swept. Each of those was, at some point, handled
+// somewhere else and differently, and every one of them ends in a store that
+// COULD NOT ANSWER being treated as a store with NOTHING TO SAY — the partial
+// sweep reported as success. Routing all three here is what keeps the three
+// callers from drifting apart again.
+// It carries no command name: every caller already prefixes what it prints with
+// its own, and the source-workflow arms surface this through a returned error
+// that the command prefixes on the way out.
+func refusePartialSweep(operation, storeLabel string, cause error) error {
+	return fmt.Errorf("%s %s failed, so part of the workflow is left untouched: %w", operation, storeLabel, cause)
+}
+
+// federateSweepViews federates a sweep's store views with the city's relocated
+// class binding, and turns a binding this build must not serve into a refusal
+// rather than a store the sweep quietly does without.
+func federateSweepViews(cityPath string, views []convoyStoreView) ([]convoyStoreView, error) {
 	merged, err := convoyStoreViewsWithBinding(cityPath, views)
 	if err != nil {
-		return nil, fmt.Errorf("%s: the city's relocated class binding is unreadable, so this would sweep only some of the workflow: %w", cmdName, err)
+		return nil, refusePartialSweep("resolving", convoyBindingViewPath, err)
 	}
 	return merged, nil
 }
@@ -1469,20 +1489,25 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 	// row it holds is the row the city is actually running; the copies retained
 	// in the work ledger are frozen twins of the same ids. Both are swept — the
 	// operator is erasing the workflow, not choosing between its copies.
-	stores, err = refuseSweepPastAnUnreadableBinding(cityPath, stores, "gc workflow delete")
+	stores, err = federateSweepViews(cityPath, stores)
 	if err != nil {
-		fmt.Fprintf(stderr, "%v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	for _, info := range stores {
-		found := findWorkflowBeads(info.store, workflowID)
+		label := workflowDeleteStoreLabelForView(cfg, cityPath, info)
+		found, err := findWorkflowBeads(info.store, workflowID)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc workflow delete: %v\n", refusePartialSweep("scanning", label, err)) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		if len(found) == 0 {
 			continue
 		}
 		matches = append(matches, workflowStoreMatch{
 			store:  info.store,
 			beads:  found,
-			label:  workflowDeleteStoreLabelForView(cfg, cityPath, info),
+			label:  label,
 			path:   info.path,
 			role:   info.role,
 			runner: workflowDeleteRunnerForView(cfg, cityPath, info),
@@ -1521,29 +1546,100 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 	if deleteBeads {
 		deleted, err := deleteWorkflowMatches(matches)
 		if err != nil {
-			fmt.Fprintf(stderr, "  batch delete: %v\n", err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		fmt.Fprintf(stdout, "Deleted %d beads\n", deleted) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 
-	closed := closeWorkflowMatches(matches)
+	closed, err := closeWorkflowMatches(matches)
+	if err != nil {
+		fmt.Fprintf(stdout, "Closed %d open beads\n", closed) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err)  //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	fmt.Fprintf(stdout, "Closed %d open beads\n", closed) //nolint:errcheck // best-effort stdout
 	return 0
 }
 
-func closeWorkflowMatches(matches []workflowStoreMatch) int {
-	closed := 0
+// sweepOrder is the match order a MUTATION runs in: the class binding first,
+// then everything else in the order the views were collected.
+//
+// The binding is appended last by the federation, which is the right order to
+// PRINT (it reads as one more store after the city's own) and the wrong order to
+// write in. On a converged city the binding holds the tree the city is running
+// and the work ledger holds the frozen twins the migration retained, so a sweep
+// that writes the ledger first and then faults has stopped the copy nobody was
+// watching and left the live tree running. Writing the binding first inverts
+// both outcomes: a fault before it touches anything sweeps nothing, and a fault
+// after it means the workflow really did stop and a cosmetic twin is left open.
+func sweepOrder(matches []workflowStoreMatch) []workflowStoreMatch {
+	ordered := make([]workflowStoreMatch, 0, len(matches))
 	for _, m := range matches {
+		if m.role == convoyViewClassBinding {
+			ordered = append(ordered, m)
+		}
+	}
+	for _, m := range matches {
+		if m.role != convoyViewClassBinding {
+			ordered = append(ordered, m)
+		}
+	}
+	return ordered
+}
+
+// closeWorkflowMatches closes every matched bead in every matched store, and
+// reports the first store that would not finish.
+//
+// The close IS the destructive act of the default mode, and its error used to be
+// discarded — so `gc workflow delete` on a converged city could close the
+// retained frozen copies, no-op on the live tree because the binding refused
+// every write, print the count it managed and exit 0. Delete mode fails loud and
+// delete-source verifies what it closed; the default mode of the same command
+// now does both.
+func closeWorkflowMatches(matches []workflowStoreMatch) (int, error) {
+	closed := 0
+	for _, m := range sweepOrder(matches) {
 		ids := workflowBeadIDs(m.beads)
-		n, _ := m.store.CloseAll(ids, map[string]string{
+		n, err := m.store.CloseAll(ids, map[string]string{
 			beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped,
 			"close_reason":              sourceworkflow.WorkflowSkippedCloseReason,
 		})
 		closed += n
+		if err != nil {
+			return closed, refusePartialSweep("closing beads in", m.label, err)
+		}
 	}
-	return closed
+	if err := verifyWorkflowMatchesClosed(matches); err != nil {
+		return closed, err
+	}
+	return closed, nil
+}
+
+// verifyWorkflowMatchesClosed re-reads every bead the sweep closed and refuses
+// if any is still open.
+//
+// A store that accepts a close and does not apply it reports the same success as
+// one that did, which is countOpenMatchedBeads' reason on the delete-source arm.
+// A bead that has since been DELETED is gone, which is what the sweep wanted.
+func verifyWorkflowMatchesClosed(matches []workflowStoreMatch) error {
+	for _, m := range matches {
+		for _, b := range m.beads {
+			current, err := m.store.Get(b.ID)
+			if err != nil {
+				if errors.Is(err, beads.ErrNotFound) {
+					continue
+				}
+				return refusePartialSweep("re-reading beads in", m.label, err)
+			}
+			if current.Status != "closed" {
+				return refusePartialSweep("closing beads in", m.label,
+					fmt.Errorf("bead %s is still %s after the sweep", b.ID, current.Status))
+			}
+		}
+	}
+	return nil
 }
 
 func workflowDeleteRunnerForPath(cfg *config.City, cityPath, scopePath string) beads.CommandRunner {
@@ -1553,9 +1649,13 @@ func workflowDeleteRunnerForPath(cfg *config.City, cityPath, scopePath string) b
 	return bdCommandRunnerForRig(cityPath, cfg, scopePath)
 }
 
+// deleteWorkflowMatches erases every matched bead in every matched store.
+//
+// The binding is deleted through the store handle rather than a `bd` invocation
+// and is swept first, for sweepOrder's reason.
 func deleteWorkflowMatches(matches []workflowStoreMatch) (int, error) {
 	deleted := 0
-	for _, m := range matches {
+	for _, m := range sweepOrder(matches) {
 		ids := workflowBeadIDs(m.beads)
 		if m.role == convoyViewClassBinding {
 			// No directory, so no bd invocation. The store handle is the whole
@@ -1564,17 +1664,17 @@ func deleteWorkflowMatches(matches []workflowStoreMatch) (int, error) {
 			n, errs := deleteWorkflowBeads(m.store, ids)
 			deleted += n
 			if len(errs) > 0 {
-				return deleted, fmt.Errorf("%s: %w", m.label, errors.Join(errs...))
+				return deleted, refusePartialSweep("deleting beads in", m.label, errors.Join(errs...))
 			}
 			continue
 		}
 		if m.runner == nil {
-			return deleted, fmt.Errorf("%s: delete runner missing", m.label)
+			return deleted, refusePartialSweep("deleting beads in", m.label, errors.New("delete runner missing"))
 		}
 		args := append([]string{"delete"}, ids...)
 		args = append(args, "--cascade", "--force")
 		if _, err := m.runner(m.path, "bd", args...); err != nil {
-			return deleted, fmt.Errorf("%s: %w", m.label, err)
+			return deleted, refusePartialSweep("deleting beads in", m.label, err)
 		}
 		deleted += len(ids)
 	}
@@ -1591,7 +1691,6 @@ type sourceWorkflowStoreMatch struct {
 	// path only for the class binding, whose rows are the city's — which is what
 	// keeps a converged city's two matched views from reading as two stores.
 	scopePath string
-	runner    beads.CommandRunner
 }
 
 // distinctSourceWorkflowScopes counts the SCOPES a match set spans.
@@ -1777,11 +1876,13 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
 		return 1
 	}
-	// The lock is taken in a directory, so it follows the view's SCOPE. A
-	// relocated class binding has no directory of its own and its rows are the
-	// city's, so it locks the city — which is also what keeps a binding-resolved
-	// target and a city-resolved one from running concurrently over the same
-	// workflow.
+	// The lock follows the view's SCOPE, not the view. Every lock file lives
+	// under the city's runtime dir and the scope is only HASHED into its name,
+	// which is what makes getting this wrong quiet: the binding's own view path
+	// is a perfectly valid scope, it just hashes to a different file, so a
+	// binding-resolved run and a city-resolved run over the same workflow would
+	// each take a lock and neither would see the other. A relocated class
+	// binding's rows are the city's, so it locks the city.
 	lockScope := target.storeView.scopePath(cityPath)
 	if strings.TrimSpace(lockScope) == "" {
 		lockScope = cityPath
@@ -1929,6 +2030,8 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 	}
 	ctx, cancel := sourceWorkflowCommandContext()
 	defer cancel()
+	// The scope, not the view — see cmdWorkflowDeleteSource. Reopen and delete
+	// have to key on the same thing or they do not exclude each other.
 	runErr := sourceworkflow.WithLock(ctx, cityPath, target.storeView.scopePath(cityPath), sourceBeadID, func() error {
 		target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, true)
 		if err != nil {
@@ -2152,7 +2255,7 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 	// enumerated, and on a converged city it is where the live workflow graph
 	// actually is. Sweeping without it would delete the frozen retained copy and
 	// leave the running one.
-	stores, err = refuseSweepPastAnUnreadableBinding(cityPath, stores, "gc workflow delete-source")
+	stores, err = federateSweepViews(cityPath, stores)
 	if err != nil {
 		return nil, skips, err
 	}
@@ -2318,23 +2421,35 @@ func (c *sourceWorkflowMatchCollector) mergeRootMatches(info convoyStoreView, ro
 		beads:     uniqueBeads(beadSet),
 		path:      info.path,
 		scopePath: info.scopePath(c.cityPath),
-		runner:    workflowDeleteRunnerForView(c.cfg, c.cityPath, info),
 	})
 	return nil
 }
 
 // recordScanFailure records a store whose scan failed: it remembers the first
-// error, marks the store failed and skipped, and returns the wrapped error only
-// when the failed store is the strict selected source store (so the caller
-// aborts). Otherwise it returns nil so the walk tolerates the failure.
+// error, marks the store failed and skipped, and returns the wrapped error when
+// the walk must abort rather than tolerate the failure.
+//
+// Tolerance exists so one sick rig cannot take down a walk that spans several,
+// and it is bounded by two stores that are never optional. The SELECTED source
+// store is the one the caller named. The class BINDING is the city's own store
+// after relocation, and the selected-store test cannot speak for it: a binding's
+// rows carry the CITY's ref, so a leg carrying a rig's ref — or carrying none,
+// which is what an orphaned source bead produces — puts the binding outside the
+// strict set on exactly the sweeps that still have to reach it. Tolerating it
+// there closes the frozen twins the migration retained, leaves the live tree
+// running, and prints result=cleaned.
 func (c *sourceWorkflowMatchCollector) recordScanFailure(index int, info convoyStoreView, currentSourceStoreRef, operation string, scanErr error) error {
-	wrapped := fmt.Errorf("%s in %s: %w", operation, workflowDeleteStoreLabelForView(c.cfg, c.cityPath, info), scanErr)
+	label := workflowDeleteStoreLabelForView(c.cfg, c.cityPath, info)
+	wrapped := fmt.Errorf("%s in %s: %w", operation, label, scanErr)
 	if c.firstScanErr == nil {
 		c.firstScanErr = wrapped
 	}
 	c.failedStores[index] = struct{}{}
 	c.skips = append(c.skips, sourceWorkflowStoreSkip{path: info.path, err: wrapped})
 
+	if info.isClassBinding() {
+		return refusePartialSweep(operation+" in", label, scanErr)
+	}
 	rootStoreRef := workflowStoreRefForDir(info.scopePath(c.cityPath), c.cityPath, c.cityName, c.cfg)
 	selectedStore := strings.TrimSpace(currentSourceStoreRef) != "" &&
 		sourceworkflow.NormalizeSourceStoreRef(rootStoreRef) == sourceworkflow.NormalizeSourceStoreRef(currentSourceStoreRef)
@@ -2599,7 +2714,15 @@ func uniqueBeads(bb []beads.Bead) []beads.Bead {
 	return out
 }
 
-func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
+// findWorkflowBeads returns every bead of a workflow that this store holds.
+//
+// A read that FAILS is returned, never folded into the empty result. The
+// difference is invisible in the return value alone — a store that lost its
+// connection and a store that holds none of this workflow both contribute no
+// beads — and a sweep planned off the second reading of the first is the
+// partial sweep that reports success. A not-found root is genuinely absent and
+// stays a skip.
+func findWorkflowBeads(store beads.Store, workflowID string) ([]beads.Bead, error) {
 	result := make([]beads.Bead, 0, 4)
 	seen := make(map[string]struct{}, 4)
 	rootIDs := make([]string, 0, 2)
@@ -2634,20 +2757,25 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 		rootIDs = append(rootIDs, root.ID)
 		addBead(root)
 	}
-	if root, err := store.Get(workflowID); err == nil {
+	switch root, err := store.Get(workflowID); {
+	case err == nil:
 		addRoot(root)
+	case !errors.Is(err, beads.ErrNotFound):
+		return nil, fmt.Errorf("getting workflow root %s: %w", workflowID, err)
 	}
 	// Query on gc.workflow_id only; the predicate is applied in-memory via
 	// addRoot so we pick up graph.v2-only roots alongside legacy roots.
-	if roots, err := store.List(beads.ListQuery{
+	roots, err := store.List(beads.ListQuery{
 		Metadata: map[string]string{
 			beadmeta.WorkflowIDMetadataKey: workflowID,
 		},
 		IncludeClosed: true,
-	}); err == nil {
-		for _, root := range roots {
-			addRoot(root)
-		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing roots of workflow %s: %w", workflowID, err)
+	}
+	for _, root := range roots {
+		addRoot(root)
 	}
 	for _, rootID := range rootIDs {
 		all, err := store.List(beads.ListQuery{
@@ -2655,13 +2783,13 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 			IncludeClosed: true,
 		})
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("listing descendants of workflow %s: %w", rootID, err)
 		}
 		for _, b := range all {
 			addBead(b)
 		}
 	}
-	return result
+	return result, nil
 }
 
 func findWorkflowBeadsFromRoot(store beads.Store, root beads.Bead) ([]beads.Bead, error) {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1948,6 +1948,12 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		closed := 0
 		deleted := 0
 		incomplete := false
+		// Must attempt every match before verifying — do not short-circuit on the
+		// first fault. Unlike cmdWorkflowDelete (abort-on-first-error, which needs
+		// binding-first sweepOrder), this arm tolerates all matches, then gates the
+		// metadata clear on completeness. An early break/return would clear
+		// workflow_id while a live tree is still open, orphaning the source; if that
+		// ever becomes necessary, impose binding-first ordering here too.
 		for _, match := range matches {
 			matchClosed, matchDeleted, matchIncomplete := applySourceWorkflowMatchCleanup(match, deleteBeads, stderr)
 			closed += matchClosed
@@ -2541,7 +2547,7 @@ func countOpenMatchedBeads(matches []sourceWorkflowStoreMatch) (int, error) {
 				if errors.Is(err, beads.ErrNotFound) {
 					continue
 				}
-				return 0, err
+				return 0, refusePartialSweep("re-reading beads in", match.label, err)
 			}
 			if current.Status != "closed" {
 				open++

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -7582,21 +7582,42 @@ func (s *faultingClassStore) IDPrefix() string {
 // resolving rather than on one that resolves and cannot answer.
 func installFaultingClassBinding(t *testing.T, cityPath string, readErr, writeErr error) {
 	t.Helper()
+	installWrappedClassBinding(t, cityPath, func(previous beads.Store) beads.Store {
+		return &faultingClassStore{Store: previous, readErr: readErr, writeErr: writeErr}
+	})
+}
+
+// installWrappedClassBinding swaps this city's class stores for wrap's store and
+// restates the census verdict for it, so the binding still derives as relocated
+// and relic-bearing.
+//
+// Both halves, for installCountedClassBindingWrapped's reason: the verdict is
+// keyed by store identity and the swap installs a store the census never saw.
+// Without the restatement the derivation would re-probe through a store that is
+// now failing, and the row would be asserting on a binding that stopped
+// resolving rather than on one that resolves and cannot answer.
+//
+// wrap is called exactly once, on the first relocated class store, and the store
+// it returns fronts every class — the fixtures here relocate one class, and a
+// wrapper installed for some of them would leave the row asserting on whichever
+// leg the command happened to take.
+func installWrappedClassBinding(t *testing.T, cityPath string, wrap func(beads.Store) beads.Store) {
+	t.Helper()
 	routes := cliStorageRoutes(cityPath)
 	if routes == nil {
-		t.Fatal("the city resolved no routes to fault")
+		t.Fatal("the city resolved no routes to wrap")
 	}
-	var installed *faultingClassStore
+	var installed beads.Store
 	restore := make(map[coordclass.Class]beads.Store, len(routes.stores))
 	for class, previous := range routes.stores {
 		restore[class] = previous
 		if installed == nil {
-			installed = &faultingClassStore{Store: previous, readErr: readErr, writeErr: writeErr}
+			installed = wrap(previous)
 		}
 		routes.stores[class] = installed
 	}
 	if installed == nil {
-		t.Fatal("the city relocated no class store to fault")
+		t.Fatal("the city relocated no class store to wrap")
 	}
 	previousRelics := routes.relics
 	routes.relics = map[beads.Store]bool{installed: true}
@@ -7610,10 +7631,10 @@ func installFaultingClassBinding(t *testing.T, cityPath string, readErr, writeEr
 
 	bindings, err := cliResidencyBindings(cityPath)
 	if err != nil {
-		t.Fatalf("re-deriving the bindings the sweep will use: %v", err)
+		t.Fatalf("re-deriving the bindings this row will use: %v", err)
 	}
-	if len(bindings) != 1 || bindings[0].Leg.Store != beads.Store(installed) {
-		t.Fatalf("the sweep's binding resolves to %d bindings not fronted by the faulting store; this row would exercise a healthy one", len(bindings))
+	if len(bindings) != 1 || bindings[0].Leg.Store != installed {
+		t.Fatalf("the binding resolves to %d bindings not fronted by the installed store; this row would exercise a healthy one", len(bindings))
 	}
 }
 
@@ -7756,8 +7777,10 @@ func TestWorkflowDeleteSourceRefusesWhenTheBindingFaultsOnARigLeg(t *testing.T) 
 // deleted nothing, or deleted through the wrong store, and the command would
 // still have printed a count and exited 0.
 //
-// The row also pins the order. The binding is erased FIRST, so a fault partway
-// through leaves the frozen twins behind rather than the live tree.
+// The row does NOT pin sweepOrder's ordering: with every store healthy the sweep
+// reaches all of them whichever way round it goes, so this row passes against
+// the identity order too. The order is falsified by the refusal row below, where
+// the binding's fault is what the retained copies have to be spared by.
 func TestDeleteWorkflowMatchesErasesTheBindingThroughItsStoreHandle(t *testing.T) {
 	binding := beads.NewMemStore()
 	live, err := binding.Create(beads.Bead{Title: "the binding's live root", Type: "task"})
@@ -7812,6 +7835,11 @@ func TestDeleteWorkflowMatchesErasesTheBindingThroughItsStoreHandle(t *testing.T
 // TestDeleteWorkflowMatchesRefusesABindingThatWillNotDelete pins the fault half
 // of the same arm: the binding's store handle is the only access path to it, so
 // a delete it rejects has to stop the sweep before the frozen twins go.
+//
+// This is also the row that falsifies sweepOrder on the delete arm. The binding
+// is listed second, as the federation appends it, and its delete fails — so the
+// retained copy survives only if the sweep put the binding first. Neutered to
+// the identity order, the `bd delete` guard on the retained view fires.
 func TestDeleteWorkflowMatchesRefusesABindingThatWillNotDelete(t *testing.T) {
 	binding := beads.NewMemStore()
 	live, err := binding.Create(beads.Bead{Title: "the binding's live root", Type: "task"})
@@ -7852,6 +7880,186 @@ func TestDeleteWorkflowMatchesRefusesABindingThatWillNotDelete(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), convoyBindingViewPath) {
 		t.Errorf("the refusal does not name the store that failed: %v", err)
+	}
+}
+
+// unhonouredCloseStore reports a close count it did not apply, which is the one
+// store shape the verification pass exists for.
+//
+// A store that accepts CloseAll and leaves the rows open returns exactly what a
+// store that honoured it returns — same count, nil error — so the sweep cannot
+// tell them apart from the write's own answer. effect is what the close ACTUALLY
+// does to the rows; nil means nothing at all. getErr faults the re-read instead,
+// which is the other way the verification can fail to get an answer.
+type unhonouredCloseStore struct {
+	beads.Store
+	effect func(ids []string)
+	getErr error
+}
+
+func (s *unhonouredCloseStore) CloseAll(ids []string, _ map[string]string) (int, error) {
+	if s.effect != nil {
+		s.effect(ids)
+	}
+	return len(ids), nil
+}
+
+func (s *unhonouredCloseStore) Get(id string) (beads.Bead, error) {
+	if s.getErr != nil {
+		return beads.Bead{}, s.getErr
+	}
+	return s.Store.Get(id)
+}
+
+// TestCloseWorkflowMatchesVerifiesTheRowsItWasToldItClosed pins every arm of the
+// re-read that follows the default mode's close.
+//
+// The close IS the destructive act of `gc workflow delete`, and its only report
+// is a count the store chooses. A store that accepts the write and does not
+// apply it — a stale view, a rejected transaction retried into a no-op, a
+// binding fronting a class it can no longer write — returns the identical count
+// and nil error as one that honoured it, so the command would print "Closed 2
+// open beads" over a workflow that is still running. The re-read is the only
+// thing that can tell those apart, and without a store that lies there is
+// nothing in the suite it can be told apart FROM.
+func TestCloseWorkflowMatchesVerifiesTheRowsItWasToldItClosed(t *testing.T) {
+	readFailed := errors.New("the store went away after the write")
+	tests := []struct {
+		name    string
+		effect  func(store beads.Store) func(ids []string)
+		getErr  error
+		wantErr string
+	}{
+		{
+			name: "a close the store did not apply is refused",
+			// The rows stay exactly as they were: open, and reported closed.
+			wantErr: "is still open after the sweep",
+		},
+		{
+			name: "a close the store honoured is accepted",
+			effect: func(store beads.Store) func([]string) {
+				return func(ids []string) {
+					for _, id := range ids {
+						if err := store.Close(id); err != nil {
+							panic(err)
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "a row the store deleted instead counts as swept",
+			// Gone is what the sweep wanted; --delete reaches this shape, and
+			// so does a store that erases on close.
+			effect: func(store beads.Store) func([]string) {
+				return func(ids []string) {
+					for _, id := range ids {
+						if err := store.Delete(id); err != nil {
+							panic(err)
+						}
+					}
+				}
+			},
+		},
+		{
+			name:    "a re-read that faults is refused rather than assumed clean",
+			getErr:  readFailed,
+			wantErr: readFailed.Error(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			backing := beads.NewMemStore()
+			row, err := backing.Create(beads.Bead{Title: "a matched workflow bead", Type: "task"})
+			if err != nil {
+				t.Fatalf("seeding the matched bead: %v", err)
+			}
+			store := &unhonouredCloseStore{Store: backing, getErr: tc.getErr}
+			if tc.effect != nil {
+				store.effect = tc.effect(backing)
+			}
+
+			closed, err := closeWorkflowMatches([]workflowStoreMatch{{
+				store: store,
+				beads: []beads.Bead{row},
+				label: "city",
+				path:  "/city",
+				role:  convoyViewMigrationSource,
+			}})
+			if closed != 1 {
+				t.Errorf("closed = %d, want the 1 the store reported; the count is what the command prints either way", closed)
+			}
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("closeWorkflowMatches refused a sweep the store honoured: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("closeWorkflowMatches returned nil; the command would print %d closed over rows it did not close", closed)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("the refusal is %v, want it to name %q", err, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), "city") {
+				t.Errorf("the refusal does not name the store that failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestCloseWorkflowMatchesClosesTheBindingBeforeTheRetainedCopies pins
+// sweepOrder on the CLOSE arm, which is the arm `gc workflow delete` takes by
+// default.
+//
+// sweepOrder's promise is stated for mutations generally, not for --delete
+// alone: a fault before the binding is touched sweeps nothing, and a fault after
+// it means the workflow really did stop. The close arm needs that at least as
+// much as the delete arm does, because closing the frozen twins while the live
+// tree keeps running is the partial sweep that LOOKS finished — the retained
+// copies are what a reader sees.
+//
+// So the binding is listed second here, as the federation appends it, and the
+// retained view faults. Swept binding-first, the live tree is closed before the
+// fault; swept in the order given, the fault lands first and the binding is
+// never reached.
+func TestCloseWorkflowMatchesClosesTheBindingBeforeTheRetainedCopies(t *testing.T) {
+	binding := beads.NewMemStore()
+	live, err := binding.Create(beads.Bead{Title: "the binding's live root", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the binding's root: %v", err)
+	}
+	retained := beads.NewMemStore()
+	frozen, err := retained.Create(beads.Bead{Title: "the retained frozen root", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained root: %v", err)
+	}
+
+	_, err = closeWorkflowMatches([]workflowStoreMatch{
+		{
+			store: &faultingClassStore{Store: retained, writeErr: errors.New("database is locked mid-close")},
+			beads: []beads.Bead{frozen},
+			label: "city",
+			path:  "/city",
+			role:  convoyViewMigrationSource,
+		},
+		{
+			store: binding,
+			beads: []beads.Bead{live},
+			label: convoyBindingViewPath,
+			path:  convoyBindingViewPath,
+			role:  convoyViewClassBinding,
+		},
+	})
+	if err == nil {
+		t.Fatal("closeWorkflowMatches returned nil after the retained view refused every close")
+	}
+	current, err := binding.Get(live.ID)
+	if err != nil {
+		t.Fatalf("reading the binding's root back: %v", err)
+	}
+	if current.Status != "closed" {
+		t.Errorf("the binding's live root is still %s; the sweep faulted on the retained copies before it reached the tree the city is running", current.Status)
 	}
 }
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/dispatch"
@@ -7743,5 +7744,341 @@ func TestWorkflowDeleteSourceRefusesWhenTheBindingFaultsOnARigLeg(t *testing.T) 
 	}
 	if strings.TrimSpace(source.Metadata["workflow_id"]) == "" {
 		t.Errorf("the source bead's workflow_id was cleared, which tells the next sling the workflow is gone")
+	}
+}
+
+// TestDeleteWorkflowMatchesErasesTheBindingThroughItsStoreHandle covers the arm
+// `gc workflow delete --delete` takes on a converged city.
+//
+// A relocated class binding has no directory, so the `bd delete` invocation every
+// other view is erased through has nowhere to run. The binding is erased through
+// its store handle instead, and that branch had no test at all: it could have
+// deleted nothing, or deleted through the wrong store, and the command would
+// still have printed a count and exited 0.
+//
+// The row also pins the order. The binding is erased FIRST, so a fault partway
+// through leaves the frozen twins behind rather than the live tree.
+func TestDeleteWorkflowMatchesErasesTheBindingThroughItsStoreHandle(t *testing.T) {
+	binding := beads.NewMemStore()
+	live, err := binding.Create(beads.Bead{Title: "the binding's live root", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the binding's root: %v", err)
+	}
+	retained := beads.NewMemStore()
+	frozen, err := retained.Create(beads.Bead{Title: "the retained frozen root", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained root: %v", err)
+	}
+
+	var bdInvokedFor []string
+	deleted, err := deleteWorkflowMatches([]workflowStoreMatch{
+		{
+			store: retained,
+			beads: []beads.Bead{frozen},
+			label: "city",
+			path:  "/city",
+			role:  convoyViewMigrationSource,
+			runner: func(string, string, ...string) ([]byte, error) {
+				bdInvokedFor = append(bdInvokedFor, "city")
+				return nil, nil
+			},
+		},
+		{
+			store: binding,
+			beads: []beads.Bead{live},
+			label: convoyBindingViewPath,
+			path:  convoyBindingViewPath,
+			role:  convoyViewClassBinding,
+			runner: func(string, string, ...string) ([]byte, error) {
+				t.Error("the binding was erased through a bd invocation; it has no directory to run one in")
+				return nil, nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("deleteWorkflowMatches: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("deleted = %d, want 2 (one row in each store)", deleted)
+	}
+	if _, err := binding.Get(live.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("the binding's live root is still there after --delete: %v", err)
+	}
+	if want := []string{"city"}; !slices.Equal(bdInvokedFor, want) {
+		t.Errorf("bd was invoked for %v, want %v", bdInvokedFor, want)
+	}
+}
+
+// TestDeleteWorkflowMatchesRefusesABindingThatWillNotDelete pins the fault half
+// of the same arm: the binding's store handle is the only access path to it, so
+// a delete it rejects has to stop the sweep before the frozen twins go.
+func TestDeleteWorkflowMatchesRefusesABindingThatWillNotDelete(t *testing.T) {
+	binding := beads.NewMemStore()
+	live, err := binding.Create(beads.Bead{Title: "the binding's live root", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the binding's root: %v", err)
+	}
+	retained := beads.NewMemStore()
+	frozen, err := retained.Create(beads.Bead{Title: "the retained frozen root", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained root: %v", err)
+	}
+	// An id the binding does not hold: the per-bead delete reports it, which is
+	// the shape a binding that cannot answer for its rows produces.
+	live.ID = "gc-does-not-exist"
+
+	_, err = deleteWorkflowMatches([]workflowStoreMatch{
+		{
+			store: retained,
+			beads: []beads.Bead{frozen},
+			label: "city",
+			path:  "/city",
+			role:  convoyViewMigrationSource,
+			runner: func(string, string, ...string) ([]byte, error) {
+				t.Error("the sweep erased the retained copy after the binding refused; that is the partial sweep")
+				return nil, nil
+			},
+		},
+		{
+			store: binding,
+			beads: []beads.Bead{live},
+			label: convoyBindingViewPath,
+			path:  convoyBindingViewPath,
+			role:  convoyViewClassBinding,
+		},
+	})
+	if err == nil {
+		t.Fatal("deleteWorkflowMatches returned nil after the binding could not delete its rows")
+	}
+	if !strings.Contains(err.Error(), convoyBindingViewPath) {
+		t.Errorf("the refusal does not name the store that failed: %v", err)
+	}
+}
+
+// TestWorkflowDeleteWithDeleteBeadsErasesTheRelocatedTree is the end-to-end half:
+// `gc workflow delete --delete --force` on a converged city, which no test
+// reached at all.
+//
+// The city view is erased through a `bd delete` this fixture's foreign-provider
+// city cannot serve, so the command reports that store as a failure. That is
+// what makes the row worth having: the binding is swept FIRST, so its live tree
+// is gone before the failing store is ever touched.
+func TestWorkflowDeleteWithDeleteBeadsErasesTheRelocatedTree(t *testing.T) {
+	_, rootID, bindingOnlyID, _, binding := relocatedWorkflowCity(t)
+
+	var stdout, stderr bytes.Buffer
+	cmdWorkflowDelete(rootID, true, true, &stdout, &stderr)
+	if !strings.Contains(stdout.String(), convoyBindingViewPath) {
+		t.Fatalf("the sweep never named the class binding:\n%s%s", stdout.String(), stderr.String())
+	}
+	for _, id := range []string{rootID, bindingOnlyID} {
+		if _, err := binding.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Errorf("the binding still holds %s after --delete: %v", id, err)
+		}
+	}
+}
+
+// TestFindUniqueBeadAcrossStoresViewRefusesABindingRigCollision pins the
+// uniqueness refusal on the SOURCE-workflow resolver's binding leg.
+//
+// The refusal itself is pinned for the convoy resolver, but this resolver is the
+// one delete-source and reopen-source WRITE through: it returns the view whose
+// store the source bead's workflow_id is cleared in. Resolving a rig collision
+// silently from the binding here clears the metadata on one ledger's row and
+// leaves the other still pointing at a workflow that no longer exists.
+func TestFindUniqueBeadAcrossStoresViewRefusesABindingRigCollision(t *testing.T) {
+	cityPath, rootID, _, _, _ := relocatedWorkflowCity(t)
+	rigHoldingID(t, cityPath, rootID, "a rig row minted under the same id", "task")
+
+	view, _, err := findUniqueBeadAcrossStoresView(cityPath, rootID)
+	if err == nil {
+		t.Fatalf("a binding/rig collision resolved to %s; the write that follows lands on one ledger and not the other", view.path)
+	}
+	if !strings.Contains(err.Error(), "exists in multiple stores") {
+		t.Errorf("the refusal reads %v, want the uniqueness wording", err)
+	}
+}
+
+// TestFindUniqueBeadAcrossStoresViewKeepsTheBindingOverTheRetainedCopy is the
+// control for the test above, and the reason the collision probe skips the city
+// store: the city is where the migration RETAINED its copies, so it holds the
+// same id on every converged city. A probe that counted it would refuse every
+// source-workflow command on exactly the cities that finished migrating.
+func TestFindUniqueBeadAcrossStoresViewKeepsTheBindingOverTheRetainedCopy(t *testing.T) {
+	cityPath, rootID, _, _, _ := relocatedWorkflowCity(t)
+
+	view, bead, err := findUniqueBeadAcrossStoresView(cityPath, rootID)
+	if err != nil {
+		t.Fatalf("a dual-resident id resolved to %v; the retained city copy is the migration working, not a collision", err)
+	}
+	if view.role != convoyViewClassBinding {
+		t.Errorf("the resolver returned the %v view at %s, want the class binding", view.role, view.path)
+	}
+	if bead.Title != "the binding's live workflow" {
+		t.Errorf("the resolver answered with %q, want the binding's live row", bead.Title)
+	}
+}
+
+// orphanedSourceRoots points the fixture city's relocated roots at a source
+// bead id no store holds, which is the only shape that reaches the multi-store
+// guard: with the source bead gone there is no store to resolve a selector
+// from, so delete-source runs unscoped and has to decide from the matches alone.
+func orphanedSourceRoots(t *testing.T, rootID string, stores ...beads.Store) string {
+	t.Helper()
+	const orphaned = "spent-source-1"
+	for _, store := range stores {
+		if err := store.SetMetadata(rootID, beadmeta.SourceBeadIDMetadataKey, orphaned); err != nil {
+			t.Fatalf("stamping the root's source bead id: %v", err)
+		}
+	}
+	return orphaned
+}
+
+// TestWorkflowDeleteSourceSweepsAConvergedCityAsOneScope pins the difference
+// between "matched two STORES" and "matched two SCOPES".
+//
+// The multi-store guard refuses when it cannot tell which workflow the operator
+// means. A converged city is never that case: the binding and the city's work
+// ledger hold one workflow in two copies, deliberately, and the binding's rows
+// are the city's. Counting matches instead of scopes takes delete-source away
+// from every city that has migrated — and it does so only on the unscoped path,
+// which is exactly the path an operator lands on once the source bead is gone.
+func TestWorkflowDeleteSourceSweepsAConvergedCityAsOneScope(t *testing.T) {
+	_, rootID, bindingOnlyID, work, binding := relocatedWorkflowCity(t)
+	orphaned := orphanedSourceRoots(t, rootID, work, binding)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(orphaned, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d on one scope in two copies: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=cleaned") {
+		t.Errorf("delete-source did not report a clean sweep:\n%s", stdout.String())
+	}
+	for _, id := range []string{rootID, bindingOnlyID} {
+		swept, err := binding.Get(id)
+		if err != nil {
+			t.Fatalf("reading %s back from the binding: %v", id, err)
+		}
+		if swept.Status != "closed" {
+			t.Errorf("the binding's %s is %q after delete-source, want closed", id, swept.Status)
+		}
+	}
+}
+
+// TestWorkflowDeleteSourceRefusesRootsInTwoScopes is the control for the test
+// above: the guard it relaxes for the binding still has to fire for a rig, which
+// is never a migration target and so is a genuinely different workflow.
+func TestWorkflowDeleteSourceRefusesRootsInTwoScopes(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+	orphaned := orphanedSourceRoots(t, rootID, work, binding)
+
+	const rigRootID = "rig-root-1"
+	rig := rigHoldingID(t, cityPath, rigRootID, "the rig's own live workflow", "task")
+	if err := rig.SetMetadataBatch(rigRootID, map[string]string{
+		beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+		beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+		beadmeta.SourceBeadIDMetadataKey:    orphaned,
+	}); err != nil {
+		t.Fatalf("making the rig's row a workflow root: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(orphaned, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 1 {
+		t.Fatalf("gc workflow delete-source exited %d across two scopes, want 1: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "live roots in multiple stores") {
+		t.Errorf("the refusal does not say which ambiguity it hit:\n%s", stderr.String())
+	}
+	live, err := binding.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the binding: %v", rootID, err)
+	}
+	if live.Status == "closed" {
+		t.Errorf("the refusal still closed the city's workflow; the operator was never asked which one they meant")
+	}
+}
+
+// sourceWorkflowLockFiles lists the lock files the source-workflow lock has
+// created under a city. Every scope's lock lives in this one directory and is
+// named for a hash of the scope, so the set of files IS the set of scopes that
+// have been locked.
+func sourceWorkflowLockFiles(t *testing.T, cityPath string) []string {
+	t.Helper()
+	dir := filepath.Join(citylayout.RuntimeDataDir(cityPath), "sling-source-locks")
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("listing the source-workflow lock dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	slices.Sort(names)
+	return names
+}
+
+// takeSourceWorkflowLock takes and releases the lock for one scope, so the test
+// learns which file that scope hashes to without reimplementing the hash.
+func takeSourceWorkflowLock(t *testing.T, cityPath, scope, sourceBeadID string) {
+	t.Helper()
+	if err := sourceworkflow.WithLock(context.Background(), cityPath, scope, sourceBeadID, func() error { return nil }); err != nil {
+		t.Fatalf("taking the source-workflow lock on scope %q: %v", scope, err)
+	}
+}
+
+// TestWorkflowDeleteSourceLocksTheCityScopeForABindingTarget pins WHICH scope a
+// binding-resolved delete-source excludes on.
+//
+// The scope is hashed into a lock filename, so the binding's own view path is a
+// valid scope that simply hashes somewhere else. Locking it fails nothing and
+// prints nothing: a binding-resolved run and a city-resolved run over the same
+// workflow each take a lock, neither sees the other, and the mutual exclusion
+// the lock exists for is gone with no symptom until two of them interleave.
+//
+// So the assertion is on the lock file itself. The command's lock must be the
+// one the CITY scope hashes to, and the binding's view path must hash to a
+// different file — which is what makes the first half mean anything.
+func TestWorkflowDeleteSourceLocksTheCityScopeForABindingTarget(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+
+	source, err := binding.Create(beads.Bead{Title: "the source bead, relocated with its class", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("seeding the source bead in the binding: %v", err)
+	}
+	if err := binding.SetMetadata(source.ID, "workflow_id", rootID); err != nil {
+		t.Fatalf("stamping the source bead's workflow_id: %v", err)
+	}
+	for _, store := range []beads.Store{work, binding} {
+		if err := store.SetMetadata(rootID, beadmeta.SourceBeadIDMetadataKey, source.ID); err != nil {
+			t.Fatalf("stamping the root's source bead id: %v", err)
+		}
+	}
+	view, _, err := findUniqueBeadAcrossStoresView(cityPath, source.ID)
+	if err != nil {
+		t.Fatalf("resolving the source bead: %v", err)
+	}
+	if view.role != convoyViewClassBinding {
+		t.Fatalf("the source bead resolved to the %v view at %s; this test only says anything about a binding target", view.role, view.path)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	locked := sourceWorkflowLockFiles(t, cityPath)
+	if len(locked) != 1 {
+		t.Fatalf("the command left %d lock files (%v), want exactly the one it took", len(locked), locked)
+	}
+
+	takeSourceWorkflowLock(t, cityPath, cityPath, source.ID)
+	if after := sourceWorkflowLockFiles(t, cityPath); !slices.Equal(after, locked) {
+		t.Errorf("the city scope hashes to %v but the command locked %v; a city-resolved run would not exclude this one", after, locked)
+	}
+	takeSourceWorkflowLock(t, cityPath, convoyBindingViewPath, source.ID)
+	if after := sourceWorkflowLockFiles(t, cityPath); len(after) != 2 {
+		t.Errorf("the binding's view path hashes to the same file as the city scope (%v), so this test cannot tell them apart", after)
 	}
 }

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -7258,10 +7258,7 @@ func relocatedWorkflowCity(t *testing.T) (cityPath, rootID, bindingOnlyID string
 		t.Fatalf("seeding the retained workflow step in the work store: %v", err)
 	}
 
-	binding, relocated := cliSoleClassBindingStore(cityPath)
-	if !relocated {
-		t.Fatal("the fixture city resolved no class binding; it is not split")
-	}
+	binding = soleClassBindingStore(t, cityPath)
 	carried := rootShape
 	carried.ID = root.ID
 	carried.Title = "the binding's live workflow"
@@ -7486,10 +7483,7 @@ func TestWorkflowReopenSourceSeesTheRelocatedRoot(t *testing.T) {
 		t.Fatalf("the seeded source bead is %q, want closed", seeded.Status)
 	}
 
-	binding, relocated := cliSoleClassBindingStore(cityPath)
-	if !relocated {
-		t.Fatal("the fixture city resolved no class binding; it is not split")
-	}
+	binding := soleClassBindingStore(t, cityPath)
 	root, err := binding.Create(beads.Bead{
 		Title:  "the binding's live workflow",
 		Type:   "task",
@@ -7722,10 +7716,7 @@ func TestWorkflowDeleteReportsAFailedCloseInTheBinding(t *testing.T) {
 // which leg the walk is on.
 func TestWorkflowDeleteSourceRefusesWhenTheBindingFaultsOnARigLeg(t *testing.T) {
 	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
-	binding, relocated := cliSoleClassBindingStore(cityPath)
-	if !relocated {
-		t.Fatal("the fixture city resolved no class binding")
-	}
+	binding := soleClassBindingStore(t, cityPath)
 	const sourceID = "rig-src-1"
 	rig := rigHoldingID(t, cityPath, sourceID, "the rig's source bead", "task")
 	for _, store := range []beads.Store{work, binding} {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -7883,28 +7883,28 @@ func TestDeleteWorkflowMatchesRefusesABindingThatWillNotDelete(t *testing.T) {
 	}
 }
 
-// unhonouredCloseStore reports a close count it did not apply, which is the one
+// unhonoredCloseStore reports a close count it did not apply, which is the one
 // store shape the verification pass exists for.
 //
 // A store that accepts CloseAll and leaves the rows open returns exactly what a
-// store that honoured it returns — same count, nil error — so the sweep cannot
+// store that honored it returns — same count, nil error — so the sweep cannot
 // tell them apart from the write's own answer. effect is what the close ACTUALLY
 // does to the rows; nil means nothing at all. getErr faults the re-read instead,
 // which is the other way the verification can fail to get an answer.
-type unhonouredCloseStore struct {
+type unhonoredCloseStore struct {
 	beads.Store
 	effect func(ids []string)
 	getErr error
 }
 
-func (s *unhonouredCloseStore) CloseAll(ids []string, _ map[string]string) (int, error) {
+func (s *unhonoredCloseStore) CloseAll(ids []string, _ map[string]string) (int, error) {
 	if s.effect != nil {
 		s.effect(ids)
 	}
 	return len(ids), nil
 }
 
-func (s *unhonouredCloseStore) Get(id string) (beads.Bead, error) {
+func (s *unhonoredCloseStore) Get(id string) (beads.Bead, error) {
 	if s.getErr != nil {
 		return beads.Bead{}, s.getErr
 	}
@@ -7918,7 +7918,7 @@ func (s *unhonouredCloseStore) Get(id string) (beads.Bead, error) {
 // is a count the store chooses. A store that accepts the write and does not
 // apply it — a stale view, a rejected transaction retried into a no-op, a
 // binding fronting a class it can no longer write — returns the identical count
-// and nil error as one that honoured it, so the command would print "Closed 2
+// and nil error as one that honored it, so the command would print "Closed 2
 // open beads" over a workflow that is still running. The re-read is the only
 // thing that can tell those apart, and without a store that lies there is
 // nothing in the suite it can be told apart FROM.
@@ -7936,7 +7936,7 @@ func TestCloseWorkflowMatchesVerifiesTheRowsItWasToldItClosed(t *testing.T) {
 			wantErr: "is still open after the sweep",
 		},
 		{
-			name: "a close the store honoured is accepted",
+			name: "a close the store honored is accepted",
 			effect: func(store beads.Store) func([]string) {
 				return func(ids []string) {
 					for _, id := range ids {
@@ -7974,7 +7974,7 @@ func TestCloseWorkflowMatchesVerifiesTheRowsItWasToldItClosed(t *testing.T) {
 			if err != nil {
 				t.Fatalf("seeding the matched bead: %v", err)
 			}
-			store := &unhonouredCloseStore{Store: backing, getErr: tc.getErr}
+			store := &unhonoredCloseStore{Store: backing, getErr: tc.getErr}
 			if tc.effect != nil {
 				store.effect = tc.effect(backing)
 			}
@@ -7991,7 +7991,7 @@ func TestCloseWorkflowMatchesVerifiesTheRowsItWasToldItClosed(t *testing.T) {
 			}
 			if tc.wantErr == "" {
 				if err != nil {
-					t.Fatalf("closeWorkflowMatches refused a sweep the store honoured: %v", err)
+					t.Fatalf("closeWorkflowMatches refused a sweep the store honored: %v", err)
 				}
 				return
 			}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -7213,3 +7213,303 @@ func TestRunControlDispatcherRejectsCrossScopeDrain(t *testing.T) {
 		t.Fatalf("error = %v, want both the root and dispatch scopes named", err)
 	}
 }
+
+// relocatedWorkflowCity builds the shape `gc storage migrate` leaves behind for
+// a workflow tree: control beads copied into the class binding with their ids
+// preserved, and the copies the migration retained still sitting in the work
+// ledger.
+//
+// The two rows differ in the one way that makes a wrong sweep visible. The
+// binding carries a step minted AFTER the cutover, so a sweep that never opened
+// the binding cannot reach it at all; the work ledger's copy shares its ids with
+// the binding's, so a sweep that folded duplicates away would leave it open.
+// Both belong to the operator's "erase this workflow", which is why these arms
+// take the union rather than the merge the read fan-outs take.
+func relocatedWorkflowCity(t *testing.T) (cityPath, rootID, bindingOnlyID string, work, binding beads.Store) {
+	t.Helper()
+	cityPath, _ = foreignProviderCity(t)
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+	work = workStoreFor(t, cityPath)
+
+	rootShape := beads.Bead{
+		Title:  "the retained frozen workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+		},
+	}
+	root, err := work.Create(rootShape)
+	if err != nil {
+		t.Fatalf("seeding the retained workflow root in the work store: %v", err)
+	}
+	step, err := work.Create(beads.Bead{
+		Title:    "the retained frozen step",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("seeding the retained workflow step in the work store: %v", err)
+	}
+
+	binding, relocated := cliSoleClassBindingStore(cityPath)
+	if !relocated {
+		t.Fatal("the fixture city resolved no class binding; it is not split")
+	}
+	carried := rootShape
+	carried.ID = root.ID
+	carried.Title = "the binding's live workflow"
+	if _, err := migrationSeed(binding, carried); err != nil {
+		t.Fatalf("carrying the workflow root across to the class binding: %v", err)
+	}
+	if _, err := migrationSeed(binding, beads.Bead{
+		ID:       step.ID,
+		Title:    "the binding's live step",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	}); err != nil {
+		t.Fatalf("carrying the workflow step across to the class binding: %v", err)
+	}
+	binding = recensusAfterSeedingARelic(t, cityPath)
+
+	later, err := binding.Create(beads.Bead{
+		Title:    "minted in the binding after the migration",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("seeding the binding's post-migration step: %v", err)
+	}
+	return cityPath, root.ID, later.ID, work, binding
+}
+
+// TestWorkflowDeleteSweepsTheRelocatedTreeAndTheRetainedCopy is the ga-gqc9e
+// regression on `gc workflow delete`.
+//
+// The command enumerates the city's and rigs' DIRECTORIES, and a relocated class
+// binding is not one of them. On a converged city that leaves the sweep working
+// entirely on the copies the migration retained: it closes the frozen twin,
+// reports the count and exits 0, while the tree the city is actually running
+// stays live in the binding. An operator who ran delete to stop a workflow has
+// been told it stopped.
+func TestWorkflowDeleteSweepsTheRelocatedTreeAndTheRetainedCopy(t *testing.T) {
+	_, rootID, bindingOnlyID, work, binding := relocatedWorkflowCity(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDelete(rootID, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), convoyBindingViewPath) {
+		t.Errorf("the sweep never named the class binding, so the tree the city works was not in it:\n%s", stdout.String())
+	}
+	for _, id := range []string{rootID, bindingOnlyID} {
+		swept, err := binding.Get(id)
+		if err != nil {
+			t.Fatalf("reading %s back from the binding: %v", id, err)
+		}
+		if swept.Status != "closed" {
+			t.Errorf("the binding's %s is %q after the sweep, want closed", id, swept.Status)
+		}
+	}
+	retained, err := work.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", rootID, err)
+	}
+	if retained.Status != "closed" {
+		t.Errorf("the retained work copy is %q after the sweep, want closed; delete erases the workflow everywhere, and a frozen twin left open is the copy an operator later finds still listed", retained.Status)
+	}
+}
+
+// TestWorkflowDeleteRefusesToSweepPastAnUnreadableBinding pins the arm that
+// separates a sweep from a read.
+//
+// `gc beads list` prints what it can reach and says what it could not. A
+// destructive one-shot cannot: "I could not see the binding's tree" and "the
+// binding's tree is gone" produce the same exit code and the same operator
+// belief, and only one of them is true. So the refusal stops the sweep before it
+// touches anything.
+func TestWorkflowDeleteRefusesToSweepPastAnUnreadableBinding(t *testing.T) {
+	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
+	failClassBindingReads(t, cityPath, errors.New("the class binding is having a bad day"))
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDelete(rootID, true, false, &stdout, &stderr); code != 1 {
+		t.Fatalf("gc workflow delete exited %d, want 1: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "bad day") {
+		t.Errorf("the refusal does not carry the binding's cause: %q", stderr.String())
+	}
+	retained, err := work.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", rootID, err)
+	}
+	if retained.Status == "closed" {
+		t.Errorf("the sweep closed the copy it could reach and then stopped; a partial sweep is exactly what refusing is for")
+	}
+}
+
+// TestWorkflowDeleteSourceSweepsTheRelocatedRoots is the same regression on the
+// arm operators actually reach for: delete-source names the SOURCE bead and lets
+// gc find the workflow it spawned.
+//
+// The roots here carry no gc.source_store_ref, which is the legacy shape
+// WorkflowMatchesSource resolves against the store the root physically lives in.
+// That makes the row a pin on more than the extra view: the binding is the city's
+// own store after relocation, so its rows have to answer to the CITY's store ref.
+// A binding view that reported a ref of its own would match no legacy root at
+// all, and would also read as a second store to the multi-store guard — which
+// would refuse every converged city instead of sweeping it.
+func TestWorkflowDeleteSourceSweepsTheRelocatedRoots(t *testing.T) {
+	cityPath, rootID, bindingOnlyID, work, binding := relocatedWorkflowCity(t)
+
+	source, err := work.Create(beads.Bead{Title: "the source bead", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("seeding the source bead: %v", err)
+	}
+	if err := work.SetMetadata(source.ID, "workflow_id", rootID); err != nil {
+		t.Fatalf("stamping the source bead's workflow_id: %v", err)
+	}
+	for _, store := range []beads.Store{work, binding} {
+		if err := store.SetMetadata(rootID, beadmeta.SourceBeadIDMetadataKey, source.ID); err != nil {
+			t.Fatalf("stamping the root's source bead id: %v", err)
+		}
+	}
+	_ = cityPath
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=cleaned") {
+		t.Errorf("delete-source did not report a clean sweep:\n%s", stdout.String())
+	}
+	for _, id := range []string{rootID, bindingOnlyID} {
+		swept, err := binding.Get(id)
+		if err != nil {
+			t.Fatalf("reading %s back from the binding: %v", id, err)
+		}
+		if swept.Status != "closed" {
+			t.Errorf("the binding's %s is %q after delete-source, want closed", id, swept.Status)
+		}
+	}
+	retained, err := work.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", rootID, err)
+	}
+	if retained.Status != "closed" {
+		t.Errorf("the retained work copy is %q after delete-source, want closed", retained.Status)
+	}
+	cleared, err := work.Get(source.ID)
+	if err != nil {
+		t.Fatalf("reading the source bead back: %v", err)
+	}
+	if got := strings.TrimSpace(cleared.Metadata["workflow_id"]); got != "" {
+		t.Errorf("the source bead's workflow_id = %q, want empty", got)
+	}
+}
+
+// TestWorkflowDeleteSourceRefusesToSweepPastAnUnreadableBinding is the
+// delete-source half of the refusal. It runs a different collector from
+// `gc workflow delete`, so the policy has to be stated in both.
+//
+// The selector is explicit on purpose. Without one, delete-source resolves the
+// source bead by id first, and that resolution leads with the same binding —
+// so an unreadable binding aborts the command before the sweep is ever planned,
+// and the exit code proves nothing about the sweep. Naming the store skips the
+// by-id leg and puts the collector's own refusal on the only path to failure.
+func TestWorkflowDeleteSourceRefusesToSweepPastAnUnreadableBinding(t *testing.T) {
+	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
+	source, err := work.Create(beads.Bead{Title: "the source bead", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("seeding the source bead: %v", err)
+	}
+	if err := work.SetMetadata(rootID, beadmeta.SourceBeadIDMetadataKey, source.ID); err != nil {
+		t.Fatalf("stamping the root's source bead id: %v", err)
+	}
+	failClassBindingReads(t, cityPath, errors.New("the class binding is having a bad day"))
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{storeRef: "city"}, true, false, &stdout, &stderr); code != 1 {
+		t.Fatalf("gc workflow delete-source exited %d, want 1: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "bad day") {
+		t.Errorf("the refusal does not carry the binding's cause: %q", stderr.String())
+	}
+	retained, err := work.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", rootID, err)
+	}
+	if retained.Status == "closed" {
+		t.Errorf("delete-source swept the copy it could reach past an unreadable binding")
+	}
+}
+
+// TestWorkflowReopenSourceSeesTheRelocatedRoot is the gating half of ga-gqc9e.
+//
+// reopen-source refuses to re-open a source bead whose workflow is still live,
+// and it decides that from the roots the same candidate walk finds. On a
+// converged city the live root is in the binding, so the walk finds nothing,
+// the guard passes, and the bead is re-slung underneath a workflow that never
+// stopped — two runs of the same work against the same branch.
+func TestWorkflowReopenSourceSeesTheRelocatedRoot(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	work := workStoreFor(t, cityPath)
+	source, err := work.Create(beads.Bead{Title: "the source bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the source bead: %v", err)
+	}
+	// Create normalizes a new bead to open, so the closed state this test's
+	// mutation assertion rests on has to be a transition. Assert it landed —
+	// a source bead that was never closed makes "still closed" vacuous.
+	if _, err := work.CloseAll([]string{source.ID}, nil); err != nil {
+		t.Fatalf("closing the source bead: %v", err)
+	}
+	if seeded, err := work.Get(source.ID); err != nil {
+		t.Fatalf("reading the seeded source bead: %v", err)
+	} else if seeded.Status != "closed" {
+		t.Fatalf("the seeded source bead is %q, want closed", seeded.Status)
+	}
+
+	binding, relocated := cliSoleClassBindingStore(cityPath)
+	if !relocated {
+		t.Fatal("the fixture city resolved no class binding; it is not split")
+	}
+	root, err := binding.Create(beads.Bead{
+		Title:  "the binding's live workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+			beadmeta.SourceBeadIDMetadataKey:    source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("seeding the binding's live workflow root: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 3 {
+		t.Fatalf("gc workflow reopen-source exited %d, want 3 (conflict): %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), root.ID) {
+		t.Errorf("the conflict does not name the binding's live root %s: %q", root.ID, stderr.String())
+	}
+	unchanged, err := work.Get(source.ID)
+	if err != nil {
+		t.Fatalf("reading the source bead back: %v", err)
+	}
+	if unchanged.Status != "closed" {
+		t.Errorf("the source bead is %q, want closed; reopen-source ran past a live workflow it could not see", unchanged.Status)
+	}
+}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -28,6 +29,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 func TestDrainItemRecipeVarsIncludesRuntimeMetadata(t *testing.T) {
@@ -840,7 +842,10 @@ func TestFindWorkflowBeadsIncludesClosedDescendants(t *testing.T) {
 		t.Fatalf("Create(child): %v", err)
 	}
 
-	found := findWorkflowBeads(store, root.ID)
+	found, err := findWorkflowBeads(store, root.ID)
+	if err != nil {
+		t.Fatalf("findWorkflowBeads(...): %v", err)
+	}
 	ids := make([]string, 0, len(found))
 	for _, bead := range found {
 		ids = append(ids, bead.ID)
@@ -879,7 +884,10 @@ func TestFindWorkflowBeadsResolvesLogicalWorkflowID(t *testing.T) {
 		t.Fatalf("Create(child): %v", err)
 	}
 
-	found := findWorkflowBeads(store, "wf-delete-logical")
+	found, err := findWorkflowBeads(store, "wf-delete-logical")
+	if err != nil {
+		t.Fatalf("findWorkflowBeads(logical): %v", err)
+	}
 	ids := make([]string, 0, len(found))
 	for _, bead := range found {
 		ids = append(ids, bead.ID)
@@ -6651,28 +6659,21 @@ func TestApplySourceWorkflowMatchCleanupDeletesOnlyCollectedWorkflowBeads(t *tes
 		t.Fatalf("DepAdd(outside->second): %v", err)
 	}
 
-	runnerCalled := false
-	runner := func(_ string, _ string, _ ...string) ([]byte, error) {
-		runnerCalled = true
-		return []byte("ok"), nil
-	}
-
+	// The match carries no bd runner, which is the point: delete-source deletes
+	// exactly the ids it collected, in process. A `bd delete --cascade` would
+	// walk the dependency edges out of the workflow and take `outside` with it.
 	var stderr bytes.Buffer
 	closed, deleted, incomplete := applySourceWorkflowMatchCleanup(sourceWorkflowStoreMatch{
-		label:  "rig:gascity",
-		store:  store,
-		beads:  []beads.Bead{first, second},
-		path:   "/repo",
-		runner: runner,
+		label: "rig:gascity",
+		store: store,
+		beads: []beads.Bead{first, second},
+		path:  "/repo",
 	}, true, &stderr)
 	if incomplete {
 		t.Fatalf("cleanup incomplete; stderr=%s", stderr.String())
 	}
 	if closed != 2 || deleted != 2 {
 		t.Fatalf("closed/deleted = %d/%d, want 2/2", closed, deleted)
-	}
-	if runnerCalled {
-		t.Fatal("cleanup used bd cascade runner; want explicit in-process deletion of collected IDs")
 	}
 	for _, id := range []string{first.ID, second.ID} {
 		if _, err := store.Get(id); err == nil {
@@ -7326,15 +7327,20 @@ func TestWorkflowDeleteSweepsTheRelocatedTreeAndTheRetainedCopy(t *testing.T) {
 	}
 }
 
-// TestWorkflowDeleteRefusesToSweepPastAnUnreadableBinding pins the arm that
-// separates a sweep from a read.
+// TestWorkflowDeleteRefusesToSweepPastABindingThatStandsRefused pins the arm
+// that separates a sweep from a read.
 //
 // `gc beads list` prints what it can reach and says what it could not. A
 // destructive one-shot cannot: "I could not see the binding's tree" and "the
 // binding's tree is gone" produce the same exit code and the same operator
 // belief, and only one of them is true. So the refusal stops the sweep before it
 // touches anything.
-func TestWorkflowDeleteRefusesToSweepPastAnUnreadableBinding(t *testing.T) {
+//
+// The fault here is a STANDING refusal — a verdict about storage config that
+// arrives at federation time, before a row is read. A binding that resolves and
+// then fails mid-read is a different arrival with the same consequence, and it
+// is pinned separately by the ...FaultsMidRead rows below.
+func TestWorkflowDeleteRefusesToSweepPastABindingThatStandsRefused(t *testing.T) {
 	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
 	failClassBindingReads(t, cityPath, errors.New("the class binding is having a bad day"))
 
@@ -7366,7 +7372,7 @@ func TestWorkflowDeleteRefusesToSweepPastAnUnreadableBinding(t *testing.T) {
 // all, and would also read as a second store to the multi-store guard — which
 // would refuse every converged city instead of sweeping it.
 func TestWorkflowDeleteSourceSweepsTheRelocatedRoots(t *testing.T) {
-	cityPath, rootID, bindingOnlyID, work, binding := relocatedWorkflowCity(t)
+	_, rootID, bindingOnlyID, work, binding := relocatedWorkflowCity(t)
 
 	source, err := work.Create(beads.Bead{Title: "the source bead", Type: "task", Status: "in_progress"})
 	if err != nil {
@@ -7380,7 +7386,6 @@ func TestWorkflowDeleteSourceSweepsTheRelocatedRoots(t *testing.T) {
 			t.Fatalf("stamping the root's source bead id: %v", err)
 		}
 	}
-	_ = cityPath
 
 	var stdout, stderr bytes.Buffer
 	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
@@ -7414,8 +7419,8 @@ func TestWorkflowDeleteSourceSweepsTheRelocatedRoots(t *testing.T) {
 	}
 }
 
-// TestWorkflowDeleteSourceRefusesToSweepPastAnUnreadableBinding is the
-// delete-source half of the refusal. It runs a different collector from
+// TestWorkflowDeleteSourceRefusesToSweepPastABindingThatStandsRefused is the
+// delete-source half of the standing refusal. It runs a different collector from
 // `gc workflow delete`, so the policy has to be stated in both.
 //
 // The selector is explicit on purpose. Without one, delete-source resolves the
@@ -7423,7 +7428,7 @@ func TestWorkflowDeleteSourceSweepsTheRelocatedRoots(t *testing.T) {
 // so an unreadable binding aborts the command before the sweep is ever planned,
 // and the exit code proves nothing about the sweep. Naming the store skips the
 // by-id leg and puts the collector's own refusal on the only path to failure.
-func TestWorkflowDeleteSourceRefusesToSweepPastAnUnreadableBinding(t *testing.T) {
+func TestWorkflowDeleteSourceRefusesToSweepPastABindingThatStandsRefused(t *testing.T) {
 	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
 	source, err := work.Create(beads.Bead{Title: "the source bead", Type: "task", Status: "in_progress"})
 	if err != nil {
@@ -7511,5 +7516,232 @@ func TestWorkflowReopenSourceSeesTheRelocatedRoot(t *testing.T) {
 	}
 	if unchanged.Status != "closed" {
 		t.Errorf("the source bead is %q, want closed; reopen-source ran past a live workflow it could not see", unchanged.Status)
+	}
+}
+
+// faultingClassStore wraps a city's real class binding and makes chosen
+// operations fail at RUNTIME, without the binding becoming a standing refusal.
+//
+// That distinction is the whole point of the rows below. refusedClassStore is a
+// verdict about the city's storage configuration, taken before any work starts,
+// and it is the one shape the sweep's federation guard was written to intercept.
+// A binding that resolves normally and then drops its connection mid-sweep — a
+// sqlite I/O error, a dolt server going away, a permission change — announces
+// nothing: it contributes no rows, which is indistinguishable from holding none,
+// and a sweep that reads that silence as "nothing here" reports a completed
+// erase over a live tree.
+//
+// Pointer-typed because the binding grouping keys a map on store identity, and
+// IDPrefix is delegated explicitly for the reason countingClassStore delegates
+// it: beads.Store does not carry it, so embedding the interface alone would hide
+// the leaf's declaration and the binding's mint bit would read false.
+type faultingClassStore struct {
+	beads.Store
+	readErr  error
+	writeErr error
+}
+
+func (s *faultingClassStore) Get(id string) (beads.Bead, error) {
+	if s.readErr != nil {
+		return beads.Bead{}, s.readErr
+	}
+	return s.Store.Get(id)
+}
+
+func (s *faultingClassStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if s.readErr != nil {
+		return nil, s.readErr
+	}
+	return s.Store.List(q)
+}
+
+func (s *faultingClassStore) CloseAll(ids []string, meta map[string]string) (int, error) {
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	return s.Store.CloseAll(ids, meta)
+}
+
+func (s *faultingClassStore) IDPrefix() string {
+	declaring, ok := s.Store.(storeref.HasIDPrefix)
+	if !ok {
+		return ""
+	}
+	return declaring.IDPrefix()
+}
+
+// installFaultingClassBinding swaps this city's class stores for one that faults
+// on the given operations, and restates the census verdict for the store it
+// installed so the binding still derives as relocated and relic-bearing.
+//
+// Both halves, for installCountedClassBindingWrapped's reason: the verdict is
+// keyed by store identity and the swap installs a store the census never saw.
+// Without the restatement the derivation would re-probe through a store that is
+// now failing, and the row would be asserting on a binding that stopped
+// resolving rather than on one that resolves and cannot answer.
+func installFaultingClassBinding(t *testing.T, cityPath string, readErr, writeErr error) {
+	t.Helper()
+	routes := cliStorageRoutes(cityPath)
+	if routes == nil {
+		t.Fatal("the city resolved no routes to fault")
+	}
+	var installed *faultingClassStore
+	restore := make(map[coordclass.Class]beads.Store, len(routes.stores))
+	for class, previous := range routes.stores {
+		restore[class] = previous
+		if installed == nil {
+			installed = &faultingClassStore{Store: previous, readErr: readErr, writeErr: writeErr}
+		}
+		routes.stores[class] = installed
+	}
+	if installed == nil {
+		t.Fatal("the city relocated no class store to fault")
+	}
+	previousRelics := routes.relics
+	routes.relics = map[beads.Store]bool{installed: true}
+	dropDerivedResidencyMemo(t, cityPath)
+	t.Cleanup(func() {
+		routes.relics = previousRelics
+		for class, previous := range restore {
+			routes.stores[class] = previous
+		}
+	})
+
+	bindings, err := cliResidencyBindings(cityPath)
+	if err != nil {
+		t.Fatalf("re-deriving the bindings the sweep will use: %v", err)
+	}
+	if len(bindings) != 1 || bindings[0].Leg.Store != beads.Store(installed) {
+		t.Fatalf("the sweep's binding resolves to %d bindings not fronted by the faulting store; this row would exercise a healthy one", len(bindings))
+	}
+}
+
+// TestWorkflowDeleteRefusesToSweepPastABindingThatFaultsMidRead is the ga-gqc9e
+// regression on the fault a standing refusal does not cover.
+//
+// A binding that resolves as relocated and then FAILS its reads contributes zero
+// rows to the sweep. Zero rows is what an empty store contributes, so the sweep
+// drops it, closes the retained frozen copies it could reach, prints a count and
+// exits 0 — never naming the binding whose live tree it did not touch. That is
+// the partial sweep reported as success, arrived at without any refusal for the
+// federation guard to intercept.
+func TestWorkflowDeleteRefusesToSweepPastABindingThatFaultsMidRead(t *testing.T) {
+	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
+	installFaultingClassBinding(t, cityPath, errors.New("connection reset mid-sweep"), nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDelete(rootID, true, false, &stdout, &stderr); code != 1 {
+		t.Fatalf("gc workflow delete exited %d, want 1: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "connection reset mid-sweep") {
+		t.Errorf("the refusal does not carry the fault that caused it: %q", stderr.String())
+	}
+	retained, err := work.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", rootID, err)
+	}
+	if retained.Status == "closed" {
+		t.Errorf("the sweep closed the copies it could reach and reported success over an unread binding")
+	}
+}
+
+// TestWorkflowDeleteReportsAFailedCloseInTheBinding is the ga-gqc9e regression on
+// the default mode's WRITE half.
+//
+// `gc workflow delete` without --delete closes; that close is the destructive
+// act, and its error was dropped on the floor. Ordinary views are swept before
+// the binding, so a binding whose writes fail loses nothing of its own and takes
+// the retained copies with it: the frozen twins close, the live tree stays open,
+// and the command prints the count of what it managed and exits 0. Delete mode
+// and delete-source both fail loud here; the default mode of the same command
+// must too.
+func TestWorkflowDeleteReportsAFailedCloseInTheBinding(t *testing.T) {
+	cityPath, rootID, bindingOnlyID, _, binding := relocatedWorkflowCity(t)
+	installFaultingClassBinding(t, cityPath, nil, errors.New("database is locked mid-close"))
+
+	var stdout, stderr bytes.Buffer
+	code := cmdWorkflowDelete(rootID, true, false, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("gc workflow delete exited 0 after the binding refused every close: %s%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "database is locked mid-close") {
+		t.Errorf("the failure does not carry the store's cause: %q", stderr.String())
+	}
+	for _, id := range []string{rootID, bindingOnlyID} {
+		live, err := binding.Get(id)
+		if err != nil {
+			t.Fatalf("reading %s back from the binding: %v", id, err)
+		}
+		if live.Status == "closed" {
+			t.Fatalf("the fixture's binding closed %s after all; this row cannot distinguish a reported failure from a real sweep", id)
+		}
+	}
+}
+
+// TestWorkflowDeleteSourceRefusesWhenTheBindingFaultsOnARigLeg is the ga-gqc9e
+// regression on the gap the selected-store rule leaves open.
+//
+// The source-workflow collector tolerates a per-store scan failure so one sick
+// rig cannot take the whole walk down, and it makes an exception only for the
+// store the walk was told to work in. The class binding is never that store on a
+// rig-selected sweep: the binding's rows are the city's and carry the CITY's
+// ref, so `--rig frontend` puts it permanently outside the strict set. The sweep
+// then warns, closes the retained frozen copy it could reach, prints
+// result=cleaned and exits 0 while the tree the city is running stays live in
+// the store it could not read.
+//
+// The topology here is the ordinary one, not a contrivance: the source bead
+// lives in a rig, the workflow's control beads live in the city's coordination
+// class, and relocation moved that class into the binding. So the leg that
+// carries the rig's ref is the same leg that has to reach the binding.
+//
+// A binding is not a rig whose absence merely degrades coverage — on a converged
+// city it IS the city's store. Whether it can answer is not a question about
+// which leg the walk is on.
+func TestWorkflowDeleteSourceRefusesWhenTheBindingFaultsOnARigLeg(t *testing.T) {
+	cityPath, rootID, _, work, _ := relocatedWorkflowCity(t)
+	binding, relocated := cliSoleClassBindingStore(cityPath)
+	if !relocated {
+		t.Fatal("the fixture city resolved no class binding")
+	}
+	const sourceID = "rig-src-1"
+	rig := rigHoldingID(t, cityPath, sourceID, "the rig's source bead", "task")
+	for _, store := range []beads.Store{work, binding} {
+		if err := store.SetMetadataBatch(rootID, map[string]string{
+			beadmeta.SourceBeadIDMetadataKey:   sourceID,
+			beadmeta.SourceStoreRefMetadataKey: "rig:frontend",
+		}); err != nil {
+			t.Fatalf("stamping the root's source identity: %v", err)
+		}
+	}
+	if err := rig.SetMetadata(sourceID, "workflow_id", rootID); err != nil {
+		t.Fatalf("stamping the rig source bead's workflow_id: %v", err)
+	}
+	installFaultingClassBinding(t, cityPath, errors.New("connection reset mid-sweep"), nil)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdWorkflowDeleteSource(sourceID, sourceWorkflowStoreSelector{storeRef: "rig:frontend"}, true, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("gc workflow delete-source exited %d, want 1: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "connection reset mid-sweep") {
+		t.Errorf("the refusal does not carry the fault that caused it: %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "result=cleaned") {
+		t.Errorf("delete-source reported a clean sweep over a binding it could not read:\n%s", stdout.String())
+	}
+	retained, err := work.Get(rootID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", rootID, err)
+	}
+	if retained.Status == "closed" {
+		t.Errorf("delete-source closed the copies it could reach and reported success over an unread binding")
+	}
+	source, err := rig.Get(sourceID)
+	if err != nil {
+		t.Fatalf("reading the rig's source bead back: %v", err)
+	}
+	if strings.TrimSpace(source.Metadata["workflow_id"]) == "" {
+		t.Errorf("the source bead's workflow_id was cleared, which tells the next sling the workflow is gone")
 	}
 }

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
 )
 
@@ -2478,5 +2479,101 @@ func TestRouteConvoyStatus_RemoteWorkflowConvoyNoLocalFallback(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "route=api reason=error") {
 		t.Errorf("expected route=api reason=error for a remote workflow-convoy:\n%s", stderr.String())
+	}
+}
+
+// relocatedConvoyCity builds the shape `gc storage migrate` leaves behind for a
+// convoy: one id, two rows, and a binding that is the live one.
+//
+// The work ledger keeps the copy the migration RETAINED — frozen at cutover,
+// still carrying the open child it had then — and the binding holds the row the
+// city has gone on mutating, whose children are finished. Every read surface has
+// to prefer the second, and the two differ in exactly the way that makes a wrong
+// choice visible: the frozen copy still gates, the live one is ready to close.
+func relocatedConvoyCity(t *testing.T) (cityPath, convoyID string, work, binding beads.Store) {
+	t.Helper()
+	cityPath, _ = foreignProviderCity(t)
+	work = workStoreFor(t, cityPath)
+
+	frozen, err := work.Create(beads.Bead{Title: "the retained frozen convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("seeding the retained convoy in the work store: %v", err)
+	}
+	if _, err := work.Create(beads.Bead{Title: "still open in the frozen copy", ParentID: frozen.ID}); err != nil {
+		t.Fatalf("seeding the frozen copy's open child: %v", err)
+	}
+
+	binding, relocated := cliSoleClassBindingStore(cityPath)
+	if !relocated {
+		t.Fatal("the fixture city resolved no class binding; it is not split")
+	}
+	if _, err := migrationSeed(binding, beads.Bead{ID: frozen.ID, Title: "the binding's live convoy", Type: "convoy"}); err != nil {
+		t.Fatalf("carrying %s across to the class binding: %v", frozen.ID, err)
+	}
+	binding = recensusAfterSeedingARelic(t, cityPath)
+
+	done, err := binding.Create(beads.Bead{Title: "finished in the binding", ParentID: frozen.ID})
+	if err != nil {
+		t.Fatalf("seeding the binding copy's child: %v", err)
+	}
+	if err := binding.Close(done.ID); err != nil {
+		t.Fatalf("closing the binding copy's child: %v", err)
+	}
+	return cityPath, frozen.ID, work, binding
+}
+
+// TestConvoyCheckReadsTheBindingRow is the ga-efyq4 regression on the arm that
+// MUTATES.
+//
+// `gc convoy check` closes convoys whose children are all done, and it decides
+// that from whichever row its directory scan happened to find. On a migrated
+// city that is the retained copy, whose children were frozen mid-flight at
+// cutover — so the convoy the city actually finished never auto-closes, and the
+// gate it feeds never opens.
+func TestConvoyCheckReadsTheBindingRow(t *testing.T) {
+	cityPath, convoyID, work, binding := relocatedConvoyCity(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := doConvoyCheckFallback(cityPath, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc convoy check exited %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Auto-closed convoy "+convoyID) {
+		t.Errorf("the finished convoy did not auto-close; check read the frozen copy's open child:\n%s", stdout.String())
+	}
+
+	closed, err := binding.Get(convoyID)
+	if err != nil {
+		t.Fatalf("reading %s back from the binding: %v", convoyID, err)
+	}
+	if !convoycore.IsTerminalStatus(closed.Status) {
+		t.Errorf("the binding's convoy is %q after the check, want a terminal status", closed.Status)
+	}
+	retained, err := work.Get(convoyID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", convoyID, err)
+	}
+	if convoycore.IsTerminalStatus(retained.Status) {
+		t.Errorf("the check closed the retained work copy too; the frozen copy still has an open child and is not the row this decides from")
+	}
+}
+
+// TestConvoyListReadsTheBindingRow is the ga-efyq4 regression on the plain list.
+//
+// One convoy must print once, as the binding has it. Printing the frozen copy
+// instead reports progress that stopped at cutover; printing both reports two
+// convoys where the city has one.
+func TestConvoyListReadsTheBindingRow(t *testing.T) {
+	cityPath, _, _, _ := relocatedConvoyCity(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := doConvoyListFallback(cityPath, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc convoy list exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if got := strings.Count(out, "the binding's live convoy"); got != 1 {
+		t.Errorf("the binding's convoy appears %d times, want exactly 1:\n%s", got, out)
+	}
+	if strings.Contains(out, "the retained frozen convoy") {
+		t.Errorf("the list printed the frozen work copy; the binding is the truth for reads:\n%s", out)
 	}
 }

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // --- gc convoy create ---
@@ -2740,5 +2741,207 @@ func TestBeadsListFilteredByStatusDropsTheFrozenCopy(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "the retained frozen copy") {
 		t.Errorf("a bead the city CLOSED in the binding is listed open from its frozen twin:\n%s", stdout.String())
+	}
+}
+
+// idsFaultingClassStore answers an ordinary listing and faults on the OWNERSHIP
+// probe, which is the one thing a healthy-binding fixture cannot reach.
+//
+// The probe is the only read that carries ListQuery.IDs, so keying the fault on
+// a non-empty IDs list separates it from the caller's own query without a flag
+// the production path could never set. A binding that fails BOTH — the shape
+// installFaultingClassBinding produces — never reaches the merge at all, because
+// its empty row set makes the probe moot; this one contributes rows and then
+// cannot say which of them it owns.
+//
+// IDPrefix is delegated explicitly for countingClassStore's reason: beads.Store
+// does not carry it, so embedding the interface alone would hide the wrapped
+// store's declaration.
+type idsFaultingClassStore struct {
+	beads.Store
+	err    error
+	probes int
+}
+
+func (s *idsFaultingClassStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if len(q.IDs) > 0 {
+		s.probes++
+		return nil, s.err
+	}
+	return s.Store.List(q)
+}
+
+func (s *idsFaultingClassStore) IDPrefix() string {
+	declaring, ok := s.Store.(storeref.HasIDPrefix)
+	if !ok {
+		return ""
+	}
+	return declaring.IDPrefix()
+}
+
+// TestBeadsListRefusesWhenTheOwnershipProbeFaults pins the FAULT arm of the
+// ownership probe, which no healthy-binding row can reach.
+//
+// Every other relocated-city read fixture serves a binding that answers both
+// questions, so the probe's error path is never taken and a merge that read a
+// probe fault as "the binding holds none of these" would produce byte-identical
+// output. That misreading is the whole hazard: an empty owned set supersedes
+// nothing, so every frozen copy the migration retained is served as a live row —
+// silently, with the command exiting 0 and the fault named nowhere.
+//
+// The binding here resolves, answers the caller's query, and fails only when
+// asked which ids it holds. The listing must stop and say why rather than print
+// the frozen twin.
+func TestBeadsListRefusesWhenTheOwnershipProbeFaults(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	frozen, err := work.Create(beads.Bead{Title: "the retained frozen copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained copy in the work store: %v", err)
+	}
+	if _, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the binding's live row"); classStore == nil {
+		t.Fatal("seeding the binding's row returned no class store")
+	}
+	var probe *idsFaultingClassStore
+	installWrappedClassBinding(t, cityPath, func(previous beads.Store) beads.Store {
+		probe = &idsFaultingClassStore{Store: previous, err: errors.New("the id index is corrupt")}
+		return probe
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doBeadsListFallback(cityPath, "", beadFilters{}, &stdout, &stderr)
+	if probe.probes == 0 {
+		t.Fatal("the ownership probe never ran, so this row asserts on a path it did not take")
+	}
+	if code != 1 {
+		t.Fatalf("gc beads list exited %d after the ownership probe faulted, want 1:\n%s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "the id index is corrupt") {
+		t.Errorf("the refusal does not name the fault that caused it: %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "the retained frozen copy") {
+		t.Errorf("the frozen copy was served as a live row after the probe that supersedes it faulted:\n%s", stdout.String())
+	}
+}
+
+// sqliteMaxBoundVariables is the ceiling modernc sqlite enforces on one
+// statement's bound variables, which is what an unchunked ownership probe hits.
+const sqliteMaxBoundVariables = 32766
+
+// varCappedIDStore answers an ownership probe the way a sqlite binding does,
+// including the bound-variable ceiling, and records the batch sizes it was asked
+// for.
+//
+// The recording is what makes the chunking observable: a batched probe and an
+// unbatched one over a small population return the same answer, so a row taking
+// only the answer would pass identically against either. The cap is what makes
+// the fault reachable at all — sqliteListSQL emits one placeholder per id, so
+// the ceiling is a property of the query the probe builds, not of the data.
+type varCappedIDStore struct {
+	beads.Store
+	held    map[string]bool
+	batches []int
+}
+
+func (s *varCappedIDStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.batches = append(s.batches, len(q.IDs))
+	if len(q.IDs) > sqliteMaxBoundVariables {
+		return nil, fmt.Errorf("SQL logic error: too many SQL variables (%d)", len(q.IDs))
+	}
+	held := make([]beads.Bead, 0, len(q.IDs))
+	for _, id := range q.IDs {
+		if s.held[id] {
+			held = append(held, beads.Bead{ID: id})
+		}
+	}
+	return held, nil
+}
+
+// TestConvoyBindingOwnedIDsBatchesPastTheSQLVariableCap pins the scale arm of
+// the ownership probe.
+//
+// The probe puts one SQL placeholder per candidate id on the wire, and the
+// candidates are every migration-source row matching the caller's query — with
+// `gc beads list` running unbounded, that is the whole work ledger's history on
+// a converged city. Past the driver's ceiling the statement does not run at all,
+// so the probe fails, the merge fails and the listing exits 1: the large
+// migrated cities the federation exists for are exactly the ones that lose the
+// read.
+//
+// Two things are asserted, because either alone is passable by wrong code. The
+// batched answer must equal the answer one query would have given if the driver
+// allowed one, and no batch may reach the ceiling — and the control below proves
+// the ceiling IS reachable from this population, so a probe that stopped
+// chunking fails here rather than passing quietly.
+func TestConvoyBindingOwnedIDsBatchesPastTheSQLVariableCap(t *testing.T) {
+	const population = 100000
+	ids := make([]string, population)
+	held := make(map[string]bool, population/7+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("gc-%d", i)
+		if i%7 == 0 {
+			held[ids[i]] = true
+		}
+	}
+	binding := &varCappedIDStore{held: held}
+
+	// Control: the population really does exceed what one statement can carry,
+	// so a probe that sent it whole would fail rather than merely run slowly.
+	if _, err := binding.List(beads.ListQuery{IDs: ids, IncludeClosed: true}); err == nil {
+		t.Fatal("the fixture answered every id in one query; this row cannot tell a chunked probe from an unchunked one")
+	}
+	binding.batches = nil
+
+	owned, err := convoyBindingOwnedIDs(binding, ids)
+	if err != nil {
+		t.Fatalf("convoyBindingOwnedIDs over %d candidates: %v", population, err)
+	}
+	if len(owned) != len(held) {
+		t.Fatalf("the probe reported %d owned ids, want %d; the batches do not union to the whole answer", len(owned), len(held))
+	}
+	for id := range held {
+		if !owned[id] {
+			t.Fatalf("%s is held by the binding but missing from the batched answer", id)
+		}
+	}
+	if len(binding.batches) < 2 {
+		t.Fatalf("the probe issued %d queries for %d candidates; it did not batch", len(binding.batches), population)
+	}
+	carried := 0
+	for _, size := range binding.batches {
+		if size > sqliteMaxBoundVariables {
+			t.Fatalf("a batch carried %d ids, past the %d the driver allows", size, sqliteMaxBoundVariables)
+		}
+		carried += size
+	}
+	if carried != population {
+		t.Errorf("the batches carried %d ids in total, want %d; the probe skipped candidates", carried, population)
+	}
+}
+
+// TestConvoyBindingOwnedIDsKeepsOneQueryUnderTheCap is the other side of the
+// same boundary: batching must not turn the ordinary case into a fan of queries.
+//
+// The probe is an IN-list rather than one Get per row precisely because a
+// per-row fan-out is what a converged city cannot afford on every listing, so a
+// population that fits stays a single round trip.
+func TestConvoyBindingOwnedIDsKeepsOneQueryUnderTheCap(t *testing.T) {
+	ids := make([]string, 500)
+	held := make(map[string]bool, len(ids))
+	for i := range ids {
+		ids[i] = fmt.Sprintf("gc-%d", i)
+		held[ids[i]] = true
+	}
+	binding := &varCappedIDStore{held: held}
+
+	owned, err := convoyBindingOwnedIDs(binding, ids)
+	if err != nil {
+		t.Fatalf("convoyBindingOwnedIDs: %v", err)
+	}
+	if len(owned) != len(ids) {
+		t.Errorf("the probe reported %d owned ids, want %d", len(owned), len(ids))
+	}
+	if len(binding.batches) != 1 {
+		t.Errorf("the probe issued %d queries for %d candidates, want 1", len(binding.batches), len(ids))
 	}
 }

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -2504,10 +2504,7 @@ func relocatedConvoyCity(t *testing.T) (cityPath, convoyID string, work, binding
 		t.Fatalf("seeding the frozen copy's open child: %v", err)
 	}
 
-	binding, relocated := cliSoleClassBindingStore(cityPath)
-	if !relocated {
-		t.Fatal("the fixture city resolved no class binding; it is not split")
-	}
+	binding = soleClassBindingStore(t, cityPath)
 	if _, err := migrationSeed(binding, beads.Bead{ID: frozen.ID, Title: "the binding's live convoy", Type: "convoy"}); err != nil {
 		t.Fatalf("carrying %s across to the class binding: %v", frozen.ID, err)
 	}
@@ -2693,9 +2690,8 @@ func TestBeadsListKeepsARigBeadThatCollidesWithABindingID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding the retained copy in the work store: %v", err)
 	}
-	if _, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the binding's live row"); classStore == nil {
-		t.Fatal("seeding the binding's row returned no class store")
-	}
+	classResidentWorkShapedBead(t, soleClassBindingStore(t, cityPath), frozen.ID, "the binding's live row")
+	recensusAfterSeedingARelic(t, cityPath)
 	rigHoldingID(t, cityPath, frozen.ID, "the rig's own row", "task")
 
 	var stdout, stderr bytes.Buffer
@@ -2730,7 +2726,8 @@ func TestBeadsListFilteredByStatusDropsTheFrozenCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding the retained copy in the work store: %v", err)
 	}
-	_, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the binding's live row")
+	classResidentWorkShapedBead(t, soleClassBindingStore(t, cityPath), frozen.ID, "the binding's live row")
+	classStore := recensusAfterSeedingARelic(t, cityPath)
 	if err := classStore.Close(frozen.ID); err != nil {
 		t.Fatalf("closing the binding's row: %v", err)
 	}
@@ -2799,9 +2796,8 @@ func TestBeadsListRefusesWhenTheOwnershipProbeFaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding the retained copy in the work store: %v", err)
 	}
-	if _, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the binding's live row"); classStore == nil {
-		t.Fatal("seeding the binding's row returned no class store")
-	}
+	classResidentWorkShapedBead(t, soleClassBindingStore(t, cityPath), frozen.ID, "the binding's live row")
+	recensusAfterSeedingARelic(t, cityPath)
 	var probe *idsFaultingClassStore
 	installWrappedClassBinding(t, cityPath, func(previous beads.Store) beads.Store {
 		probe = &idsFaultingClassStore{Store: previous, err: errors.New("the id index is corrupt")}

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -2605,6 +2605,115 @@ func TestConvoyListDropsTheFrozenCopyOfAConvoyTheBindingClosed(t *testing.T) {
 	}
 }
 
+// convoyCityWhoseFrozenCopyLooksFinished is relocatedConvoyCity with the two
+// copies' children swapped, which is the arrangement an auto-close can act on.
+//
+// relocatedConvoyCity freezes the retained copy mid-flight, so a check that read
+// the wrong row simply declines to close and the damage is a convoy that never
+// finishes. The opposite pairing is the one that MUTATES: the retained copy was
+// cut over at a moment its children were all closed, and the binding has gone on
+// to open more. A check reading the frozen copy finds a convoy that looks
+// complete and closes it, while the work the binding is still tracking stays
+// open under a convoy the city now calls done.
+func convoyCityWhoseFrozenCopyLooksFinished(t *testing.T) (cityPath, convoyID string, work, binding beads.Store) {
+	t.Helper()
+	cityPath, _ = foreignProviderCity(t)
+	work = workStoreFor(t, cityPath)
+
+	frozen, err := work.Create(beads.Bead{Title: "the retained frozen convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("seeding the retained convoy in the work store: %v", err)
+	}
+	settled, err := work.Create(beads.Bead{Title: "finished in the frozen copy", ParentID: frozen.ID})
+	if err != nil {
+		t.Fatalf("seeding the frozen copy's child: %v", err)
+	}
+	if err := work.Close(settled.ID); err != nil {
+		t.Fatalf("closing the frozen copy's child: %v", err)
+	}
+
+	binding = soleClassBindingStore(t, cityPath)
+	if _, err := migrationSeed(binding, beads.Bead{ID: frozen.ID, Title: "the binding's live convoy", Type: "convoy"}); err != nil {
+		t.Fatalf("carrying %s across to the class binding: %v", frozen.ID, err)
+	}
+	binding = recensusAfterSeedingARelic(t, cityPath)
+
+	if _, err := binding.Create(beads.Bead{Title: "still open in the binding", ParentID: frozen.ID}); err != nil {
+		t.Fatalf("seeding the binding copy's open child: %v", err)
+	}
+	return cityPath, frozen.ID, work, binding
+}
+
+// TestConvoyCheckRefusesRatherThanAutoclosingThroughARefusedBinding is the
+// mutating arm's half of the refusal policy.
+//
+// A refused binding degrades a READ: the listing prints what it reached and says
+// what it could not. `gc convoy check` is not a read — it closes convoys — and
+// on a refusal the federation hands back the views unchanged, so the retained
+// pre-migration copies stop being superseded and are walked as live rows. Their
+// children were frozen at cutover, so a convoy the city is still working looks
+// complete, and the check closes it and reports that as success while the
+// binding's open row is never touched. A mutation on a view this build could not
+// prove is worse than no mutation, so this one refuses.
+func TestConvoyCheckRefusesRatherThanAutoclosingThroughARefusedBinding(t *testing.T) {
+	cityPath, convoyID, work, _ := convoyCityWhoseFrozenCopyLooksFinished(t)
+	failClassBindingReads(t, cityPath, errors.New("the class binding is having a bad day"))
+
+	var stdout, stderr bytes.Buffer
+	if code := doConvoyCheckFallback(cityPath, false, &stdout, &stderr); code == 0 {
+		t.Fatalf("gc convoy check exited 0 with an unreadable binding; it auto-closed from rows it could not prove:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "bad day") {
+		t.Errorf("the refusal does not carry its own cause: %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Auto-closed") {
+		t.Errorf("the check reported an auto-close it must not have made:\n%s", stdout.String())
+	}
+
+	retained, err := work.Get(convoyID)
+	if err != nil {
+		t.Fatalf("reading %s back from the work store: %v", convoyID, err)
+	}
+	if convoycore.IsTerminalStatus(retained.Status) {
+		t.Errorf("the check closed the retained pre-migration copy of %s from a view it could not read; the binding's row is the one this decides from", convoyID)
+	}
+}
+
+// TestConvoyStrandedReadsTheBindingRow is the ga-efyq4 regression on the "is my
+// work stuck?" query.
+//
+// `gc convoy stranded` walks open convoys for open, unassigned children, and on
+// a migrated city the directory scan reaches only the copies the migration
+// retained. That is wrong in both directions at once: a frozen copy still
+// carries the assignees and open children it had at cutover, so it reports work
+// that is not stranded, while a convoy the binding minted afterwards is never
+// looked at, so genuinely stranded work is invisible. Both halves are asserted
+// here because federating only the merge would fix the first and leave the
+// second.
+func TestConvoyStrandedReadsTheBindingRow(t *testing.T) {
+	cityPath, _, _, binding := relocatedConvoyCity(t)
+
+	adrift, err := binding.Create(beads.Bead{Title: "the binding's own convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("seeding a convoy the binding minted after the migration: %v", err)
+	}
+	if _, err := binding.Create(beads.Bead{Title: "nobody is on this", ParentID: adrift.ID}); err != nil {
+		t.Fatalf("seeding the stranded child: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doConvoyStrandedFallback(cityPath, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc convoy stranded exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "still open in the frozen copy") {
+		t.Errorf("the retained pre-migration copy was reported as stranded work; its children stopped at cutover and the binding's row supersedes it:\n%s", out)
+	}
+	if !strings.Contains(out, "nobody is on this") {
+		t.Errorf("work stranded in the binding is invisible; the fan-out never read it:\n%s", out)
+	}
+}
+
 // rigHoldingID registers a rig on cityPath and plants a bead in it under a
 // pinned id, so a fixture can put a rig row and a binding row in collision.
 //

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -2577,3 +2577,168 @@ func TestConvoyListReadsTheBindingRow(t *testing.T) {
 		t.Errorf("the list printed the frozen work copy; the binding is the truth for reads:\n%s", out)
 	}
 }
+
+// TestConvoyListDropsTheFrozenCopyOfAConvoyTheBindingClosed is the ga-efyq4
+// regression on the state a migrated city ENDS in.
+//
+// Every relocated workflow eventually finishes, and finishing it closes the
+// binding's row. From that moment the binding's open-only query returns nothing
+// for the id, so a supersede set derived from the query's ROWS forgets the
+// binding owns it — and the retained copy, frozen open at cutover and never
+// touched since, is served as the live convoy. The convoy reports open forever,
+// which is the incident this bead exists to close, arrived at through the normal
+// end of the workflow rather than through any edge case.
+func TestConvoyListDropsTheFrozenCopyOfAConvoyTheBindingClosed(t *testing.T) {
+	cityPath, convoyID, _, binding := relocatedConvoyCity(t)
+	if err := binding.Close(convoyID); err != nil {
+		t.Fatalf("closing the binding's convoy: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doConvoyListFallback(cityPath, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc convoy list exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "the retained frozen convoy") {
+		t.Errorf("a convoy the city CLOSED in the binding is listed open from its frozen twin:\n%s", out)
+	}
+	if strings.Contains(out, convoyID) {
+		t.Errorf("%s is still listed after the binding closed it:\n%s", convoyID, out)
+	}
+}
+
+// rigHoldingID registers a rig on cityPath and plants a bead in it under a
+// pinned id, so a fixture can put a rig row and a binding row in collision.
+//
+// Ids are unique only within a store. A rig mints from its own sequence and
+// nothing keeps that sequence disjoint from the ids a relocated binding holds,
+// so "gc-1" in a rig and "gc-1" in the binding are two different beads that both
+// belong in a fan-out's output. Without a rig in the fixtures, every relocated
+// city under test has exactly one non-binding store and a merge that collapsed
+// on id alone would look correct.
+//
+// The pinned id goes in through the file store's explicit-id mode, which is off
+// by default so that ordinary creates cannot mint a collision by accident. The
+// returned handle is the fixture's own; the CLI opens the same JSON afresh.
+func rigHoldingID(t *testing.T, cityPath, id, title, beadType string) beads.Store {
+	t.Helper()
+	const rigName = "frontend"
+	rigDir := filepath.Join(cityPath, "rigs", rigName)
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("creating the directory of rig %s: %v", rigName, err)
+	}
+	cityTOML := filepath.Join(cityPath, "city.toml")
+	body, err := os.ReadFile(cityTOML)
+	if err != nil {
+		t.Fatalf("reading city.toml to register rig %s: %v", rigName, err)
+	}
+	body = append(body, []byte(fmt.Sprintf("\n[[rigs]]\nname = %q\npath = %q\n", rigName, rigDir))...)
+	if err := os.WriteFile(cityTOML, body, 0o644); err != nil {
+		t.Fatalf("registering rig %s in city.toml: %v", rigName, err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("giving rig %s its own file store: %v", rigName, err)
+	}
+	store, err := openScopeLocalFileStore(rigDir)
+	if err != nil {
+		t.Fatalf("opening the store of rig %s: %v", rigName, err)
+	}
+	store.HonorExplicitIDs = true
+	if _, err := store.Create(beads.Bead{ID: id, Title: title, Type: beadType}); err != nil {
+		t.Fatalf("planting %s in rig %s: %v", id, rigName, err)
+	}
+	return store
+}
+
+// TestConvoyListKeepsARigConvoyThatCollidesWithABindingID pins the SCOPE of the
+// supersede rule: it collapses the migration's duplicate and nothing else.
+//
+// The migration is the one place an id means the same bead twice, because it
+// copies with ids preserved and deletes nothing. Two stores the directory scan
+// enumerated are not that: a rig's "gc-1" and the binding's "gc-1" are separate
+// beads, and a merge that dropped either because the binding "owns" the id would
+// delete a live rig convoy from the listing.
+//
+// This is also the row that makes the supersede pin bite. Without a colliding
+// rig, dropping every id the binding owns and dropping only the migration
+// source's produce identical output, so the role scoping is unfalsifiable.
+func TestConvoyListKeepsARigConvoyThatCollidesWithABindingID(t *testing.T) {
+	cityPath, convoyID, _, _ := relocatedConvoyCity(t)
+	rigHoldingID(t, cityPath, convoyID, "the rig's own convoy", "convoy")
+
+	var stdout, stderr bytes.Buffer
+	if code := doConvoyListFallback(cityPath, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc convoy list exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "the rig's own convoy") {
+		t.Errorf("the rig's convoy was dropped as if the binding superseded it; it is a different bead that merely shares an id:\n%s", out)
+	}
+	if !strings.Contains(out, "the binding's live convoy") {
+		t.Errorf("the binding's convoy is missing from the listing:\n%s", out)
+	}
+	if strings.Contains(out, "the retained frozen convoy") {
+		t.Errorf("the frozen work copy is still listed; the binding supersedes it:\n%s", out)
+	}
+}
+
+// TestBeadsListKeepsARigBeadThatCollidesWithABindingID is the same scope pin on
+// the arm the caller filters, where the ownership probe runs against ids drawn
+// from a query result rather than a whole-store listing.
+func TestBeadsListKeepsARigBeadThatCollidesWithABindingID(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	frozen, err := work.Create(beads.Bead{Title: "the retained frozen copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained copy in the work store: %v", err)
+	}
+	if _, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the binding's live row"); classStore == nil {
+		t.Fatal("seeding the binding's row returned no class store")
+	}
+	rigHoldingID(t, cityPath, frozen.ID, "the rig's own row", "task")
+
+	var stdout, stderr bytes.Buffer
+	if code := doBeadsListFallback(cityPath, "", beadFilters{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc beads list exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "the rig's own row") {
+		t.Errorf("the rig's bead was dropped as if the binding superseded it:\n%s", out)
+	}
+	if !strings.Contains(out, "the binding's live row") {
+		t.Errorf("the binding's bead is missing from the listing:\n%s", out)
+	}
+	if strings.Contains(out, "the retained frozen copy") {
+		t.Errorf("the frozen work copy is still listed; the binding supersedes it:\n%s", out)
+	}
+}
+
+// TestBeadsListFilteredByStatusDropsTheFrozenCopy is the same regression on the
+// arm that lets the CALLER choose the filter.
+//
+// `gc beads list --status open` asks every store for its open rows. The binding
+// answers with the ones that are open THERE; the frozen twin of a row the
+// binding has since closed is open in the work ledger, and a supersede set built
+// from the binding's answer to the caller's filter cannot see that it is a twin.
+// Whether the binding owns an id and whether the binding has a row matching this
+// filter are two different questions, and only the first one decides a merge.
+func TestBeadsListFilteredByStatusDropsTheFrozenCopy(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	frozen, err := work.Create(beads.Bead{Title: "the retained frozen copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained copy in the work store: %v", err)
+	}
+	_, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the binding's live row")
+	if err := classStore.Close(frozen.ID); err != nil {
+		t.Fatalf("closing the binding's row: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doBeadsListFallback(cityPath, "", beadFilters{status: "open"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc beads list --status open exited %d: %s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "the retained frozen copy") {
+		t.Errorf("a bead the city CLOSED in the binding is listed open from its frozen twin:\n%s", stdout.String())
+	}
+}

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -21,10 +21,10 @@
 # governs that — stated beside the pattern in residency-boundary-patterns.txt —
 # requires a cross-plane router-agreement pin to land with it.
 #
-# The two b:cliSoleClassBinding rows are the same kind of census one layer down:
-# the surfaces that answer every reserved prefix from ONE store, which is a
-# claim about the city's topology and not just a call. The accessor checks that
-# claim and refuses a fan-out, so a third row is not a correctness bug — it is a
+# The three b:cliSoleClassBinding rows are the same kind of census one layer
+# down: the surfaces that answer every reserved prefix from ONE store, which is
+# a claim about the city's topology and not just a call. The accessor checks that
+# claim and refuses a fan-out, so a fourth row is not a correctness bug — it is a
 # new surface routing class-reserved ids, which is the thing worth seeing.
 cmd/gc/api_state.go	BeadStores	a:BeadStores	1
 cmd/gc/api_state.go	BeadStores	ast:returns-store-list	1
@@ -67,6 +67,7 @@ cmd/gc/cmd_bd_by_id.go	resolve	d:bdIDIsClassReserved	1
 cmd/gc/cmd_beads.go	doBeadsListFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_beads.go	doBeadsShowFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	convoyStoreCandidates	a:convoyStoreCandidates	1
+cmd/gc/cmd_convoy.go	convoyStoreViewsWithBinding	b:cliSoleClassBinding	1
 cmd/gc/cmd_convoy.go	doConvoyCheckFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	doConvoyListFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	openAllConvoyStores	a:openAllConvoyStoresAt	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -81,7 +81,7 @@ cmd/gc/cmd_convoy.go	convoyStoreCandidates	a:convoyStoreCandidates	1
 cmd/gc/cmd_convoy.go	convoyStoreViewsWithBinding	b:cliSoleClassBinding	1
 cmd/gc/cmd_convoy.go	doConvoyCheckFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	doConvoyListFallback	a:openAllConvoyStoresAt	1
-cmd/gc/cmd_convoy.go	openAllConvoyStores	a:openAllConvoyStoresAt	1
+cmd/gc/cmd_convoy.go	doConvoyStrandedFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	openAllConvoyStoresAt	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	openAllConvoyStoresAt	a:openConvoyStores	1
 cmd/gc/cmd_convoy.go	openConvoyStores	a:convoyStoreCandidates	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -26,6 +26,17 @@
 # a claim about the city's topology and not just a call. The accessor checks that
 # claim and refuses a fan-out, so a fourth row is not a correctness bug — it is a
 # new surface routing class-reserved ids, which is the thing worth seeing.
+#
+# cmd/gc/cmd_convoy.go's refuseBindingRigCollision holds two rows and is one
+# site, deliberately. The binding short-circuit in resolveOwningStoreDir returns
+# before the scan runs, and the scan is where "this id exists in more than one
+# store" is refused — correct to skip for the city's own retained copy, wrong to
+# skip for a rig, which is never a migration target. Restoring the refusal for
+# that one case needs the candidate list (a:openConvoyStores) and needs to know
+# which ids no rig can hold (d:bdIDIsClassReserved). Both are the enumeration
+# and the namespace gate this guard exists to count, and both are pinned here
+# rather than annotated because the review that matters is whether the
+# short-circuit should be probing at all, not whether it called correctly.
 cmd/gc/api_state.go	BeadStores	a:BeadStores	1
 cmd/gc/api_state.go	BeadStores	ast:returns-store-list	1
 cmd/gc/api_state.go	beadEventStoresLocked	ast:returns-store-list	1
@@ -75,6 +86,8 @@ cmd/gc/cmd_convoy.go	openAllConvoyStoresAt	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_convoy.go	openAllConvoyStoresAt	a:openConvoyStores	1
 cmd/gc/cmd_convoy.go	openConvoyStores	a:convoyStoreCandidates	1
 cmd/gc/cmd_convoy.go	openConvoyStores	a:openConvoyStores	1
+cmd/gc/cmd_convoy.go	refuseBindingRigCollision	a:openConvoyStores	1
+cmd/gc/cmd_convoy.go	refuseBindingRigCollision	d:bdIDIsClassReserved	1
 cmd/gc/cmd_convoy.go	resolveOwningStoreDir	a:openConvoyStores	1
 cmd/gc/cmd_convoy_dispatch.go	cmdWorkflowDelete	a:openConvoyStores	1
 cmd/gc/cmd_convoy_dispatch.go	collectSourceWorkflowMatches	a:openSourceWorkflowStores	1

--- a/scripts/residency-boundary-patterns.txt
+++ b/scripts/residency-boundary-patterns.txt
@@ -35,8 +35,10 @@ a:convoyStoreCandidates	(^|[^A-Za-z0-9_])convoyStoreCandidates\(
 #     checks and refuses a fan-out for. Three are baselined today: the `gc bd`
 #     by-id front door, the claim-time class route, and the CLI fan-out
 #     federation (convoyStoreViewsWithBinding, which is the one place `gc beads
-#     list`, `gc convoy list`, `gc convoy check` and the workflow-delete sweep
-#     all get the binding from). A fourth is a reviewed baseline change, because
+#     list`, `gc convoy list`, `gc convoy stranded`, `gc convoy check` and the
+#     workflow-delete sweep all get the binding from — the reads through the
+#     tolerant wrapper, the check and the sweep through their own refusals).
+#     A fourth is a reviewed baseline change, because
 #     the review that matters is not whether the accessor was called correctly
 #     but whether that surface should be routing class-reserved ids at all.
 b:graphClassBinding	(^|[^A-Za-z0-9_])graphClassBinding\(

--- a/scripts/residency-boundary-patterns.txt
+++ b/scripts/residency-boundary-patterns.txt
@@ -32,11 +32,13 @@ a:convoyStoreCandidates	(^|[^A-Za-z0-9_])convoyStoreCandidates\(
 #     reason storeref.EachLeg is: sanctioned is not free. Each call site is a
 #     surface asserting "this city serves all five infrastructure classes from
 #     one binding, and I am about to act on that" — the condition the accessor
-#     checks and refuses a fan-out for. Two are baselined today (the `gc bd`
-#     by-id front door and the claim-time class route). A third is a reviewed
-#     baseline change, because the review that matters is not whether the
-#     accessor was called correctly but whether that surface should be routing
-#     class-reserved ids at all.
+#     checks and refuses a fan-out for. Three are baselined today: the `gc bd`
+#     by-id front door, the claim-time class route, and the CLI fan-out
+#     federation (convoyStoreViewsWithBinding, which is the one place `gc beads
+#     list`, `gc convoy list`, `gc convoy check` and the workflow-delete sweep
+#     all get the binding from). A fourth is a reviewed baseline change, because
+#     the review that matters is not whether the accessor was called correctly
+#     but whether that surface should be routing class-reserved ids at all.
 b:graphClassBinding	(^|[^A-Za-z0-9_])graphClassBinding\(
 b:cliSoleClassBinding	(^|[^A-Za-z0-9_])cliSoleClassBinding\(
 b:routes.storeFor	(^|[^A-Za-z0-9_])routes\.storeFor\(


### PR DESCRIPTION
Stacked on #5626 (which stacks on #5597). **Base: `residency/pr1-storeref-byid`** — GitHub retargets as each parent merges.

On a converged city, `gc beads list`, `gc convoy list`, `gc convoy check`,
`gc workflow delete`, `delete-source` and `reopen-source` all enumerate the
city's and rigs' **directories**. A relocated class binding is not one of them.
So every one of those commands worked on the copies `gc storage migrate`
retained — frozen at cutover, never touched since — and reported success.

## The three shapes of the same bug

**Reads print the frozen twin as live.** The rows the city has gone on mutating
are invisible and the retained copies are printed in their place, under the same
ids. `gc convoy check` is the one that bites: it decides whether a convoy is
finished from whichever end it can see.

**Destructive sweeps report a partial as a success.** `gc workflow delete` closes
the frozen twin, reports the count, exits 0 — and the tree the city is actually
running stays live in the binding. An operator who ran `delete` to stop a
workflow has been told it stopped. `reopen-source` is worse: it decides *"is this
source's workflow still live"* from the same blind walk, finds nothing, and
re-slings the bead underneath a workflow that never stopped.

**A store that could not answer was read as a store with nothing to say.** Three
separate holes fed this. `findWorkflowBeads` swallowed every `Get`/`List` error
and returned whatever it had collected. `closeWorkflowMatches` dropped
`CloseAll`'s error on the floor and reported the count it *got back* as the count
it *closed*. `recordScanFailure` aborted only for the **selected** store, and the
binding's `rootStoreRef` is the city's — so a `--rig` selector, or a recursion leg
carrying a rig ref, demoted a faulting binding to a warning.

## What changed

All three refusal paths now route through `refusePartialSweep`, the choke point
the standing refusal already used, so the callers cannot drift apart on policy:
one message shape, one exit code, the store named every time. A standing refusal
is a verdict about storage config that arrives at federation time; a read that
faults arrives mid-scan and had no interception at all. The federation guard's
name and doc said *"unreadable"* while covering only the first — which is exactly
why the second went unnoticed.

**Read fan-outs warn and continue; destructive one-shots hard-error.** That is
the one deliberate policy difference. A read prints what it reached and names
what it could not. A destructive one-shot has no such output, and *"I could not
see the binding's tree"* and *"the binding's tree is gone"* leave the operator
believing the same thing.

**Ask the binding which ids it OWNS, not which it MATCHED.** The supersede set
was read off the binding's rows *for the caller's query*, which makes the answer
depend on a filter the caller chose: `gc convoy list` asks every store for its
**open** convoys, so the moment the city closes a relocated convoy in the binding,
the binding stops answering for that id, the retained copy stops looking
superseded, and the frozen twin prints as live. That is not an edge case — a
closed relocated bead is the steady state a migrated city converges to.
`convoyBindingOwnedIDs` now carries only the migration source's ids and
`IncludeClosed`, so no filter of the caller's reaches it, and the role scoping
becomes structural rather than incidental: a rig's id is never put to the binding
at all, so two stores that merely mint the same id both survive.

**Five things had to move with the extra view**, each of which would otherwise
have turned the fix into its own silent partial: `scopePath` (the binding has no
directory and its rows are the *city's*); the collector's visit key moves from
the store **ref** to the **view** (binding and work ledger share one ref, so
ref-keying marked the pair visited after the first and left the second unswept);
the multi-store guard counts distinct **scopes**, not labels (labels would refuse
`delete-source` on every migrated city); the `bd` runner is nil for the binding
and its beads are deleted through the store handle (`bd` runs *in* a directory,
and there is none here); and `findUniqueBeadAcrossStoresView` leads with the
binding leg, because that view is the one `delete-source`/`reopen-source`
**write** the source bead's metadata through — clearing `workflow_id` on the
frozen twin leaves the live row pointing at a workflow that no longer exists.

**The cross-store id refusal is restored on a binding hit.**
`resolveOwningStoreDir` short-circuited to the binding and returned before the
directory scan — and the scan is where *"this id exists in more than one store"*
is refused. Skipping it for the city's own store is correct (the retained copy is
a frozen twin, not a second bead); a **rig** is different, since it is never a
migration target, so the same id in a rig is a genuinely different bead and
picking a winner silently is the `ga-axin6` shape.

**The source-workflow lock keys on the view's SCOPE, not its display path.**
`lockIdentity` hashes the ref into a filename, so `"city (class binding)"` is a
valid key that simply is not the city's — mutual exclusion was weakened silently
rather than failing.

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test ./cmd/gc/ -timeout 40m` green (the default 10m timeout **panics** this
  package)
- **Mutation-proved with disjoint kills.** Dropping the binding view from the
  walk while keeping the refusal kills the three sweep/gate rows and leaves both
  refusal rows green; making the refusal warn-and-continue kills only the two
  refusal rows.
- The final commit exists because **five behaviours the CLI already relied on
  survived every mutation** — a pin that stays green when you break the thing it
  names is documentation, not a test. Each new row was written by first breaking
  the production code and watching the intended test die. The `--delete` arm on a
  converged city had **no coverage at all**; the supersede rule's scope needed a
  rig in the fixtures (every relocated fixture had exactly one non-binding store,
  so "drop every id the binding owns" and "drop only the migration source's"
  produced identical output); `distinctSourceWorkflowScopes` was unreachable
  except through an **orphaned** source bead; and the lock-scope pin asserts on
  the lock **files** under the city's runtime dir, which is what distinguishes a
  correct key from a valid but different one.

Refs `ga-gqc9e`.

---

## Council round 2 — the arms the first pass could not falsify

A three-lens fable council reviewed the branch and returned changes-required.
Production behavior was judged correct throughout; what it found were coverage
holes, one reproduced scale cliff, and two mis-mapped evidence claims. All are
closed in `382d5576fc`.

**The probe did not scale past 32766 ids.** It put one SQL placeholder per
candidate on the wire, and the candidates are every migration-source row matching
the caller's query. `gc beads list` runs unbounded, so a converged city with a
long history sent its whole work ledger in one IN-list and modernc sqlite refused
the statement past 32766 bound variables — reproduced against a real sqlite
binding: 32766 ok, 40000 and 100000 `SQL logic error: too many SQL variables`.
The read failed *loud*, so no wrong answer was served, but it failed on exactly
the large migrated cities this federation exists for. The probe now chunks under
the cap, keeping it O(candidates/batch) round trips rather than the one-per-row
it replaced.

**Three arms were unfalsifiable and are now pinned.** Each was confirmed
unfalsifiable by mutating production and watching the **full** `./cmd/gc/` suite
stay green.

- *The probe's fault path.* Every relocated-city read fixture served a binding
  that answers both the caller's query and the ownership probe, so a merge that
  read a probe fault as *"the binding holds none of these"* produced
  byte-identical output — and that misreading serves every frozen copy the
  migration retained as a live row. The new row faults only on a query carrying
  `IDs`.
- *`verifyWorkflowMatchesClosed`.* No fixture held a store that reports a close
  count it did not honour, so the whole verification pass and all four of its
  branches were unexercised — deleting the function outright left the suite
  green. The lying store is what the pass can now be told apart from.
- *`sweepOrder` on the CLOSE arm.* Closing the frozen twins while the live tree
  keeps running is the partial sweep that *looks* finished, so the close arm
  needs the binding-first guarantee at least as much as `--delete` does.

**Two evidence corrections.** The delete arm's ordering evidence was mapped to
the wrong row — with every store healthy the sweep reaches all of them whichever
way round it goes, so the order is falsified by the *refusal* row, not the
erasure row. The comments now say so. And the read caveat understated its own
hazard: a standing refusal does not merely omit the binding's rows — the
binding's answer is what **supersedes** the retained pre-migration copies, so
those copies print in their place as stale open rows for as long as the refusal
stands.

Filed as follow-ups rather than fixed here: `ga-4kivg` (P1, `delete-source` with
an explicit selector clears `workflow_id` on the wrong copy) and the
`openConvoyStores` silent-drop and delete-source sweep-order nits, both
pre-existing at the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
