### PR TITLE
fix(dispatch): split gc.attempt into separate iteration and retry counters

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -810,6 +810,18 @@ func qualifyAttemptTargetWithSourceRoute(target, sourceRoute string, cfg *config
 	return target
 }
 
+// setIterationMetadata records gc.iteration, or removes it when the step has no
+// iteration to speak of. A plain retry outside any loop is the second case, and
+// leaving a stale key there would name a directory that belongs to some other
+// molecule's loop.
+func setIterationMetadata(meta map[string]string, iteration string) {
+	if iteration == "" {
+		delete(meta, beadmeta.IterationMetadataKey)
+		return
+	}
+	meta[beadmeta.IterationMetadataKey] = iteration
+}
+
 // buildAttemptRecipe constructs a minimal formula.Recipe for one attempt
 // from the frozen step spec.
 func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) *formula.Recipe {
@@ -830,6 +842,17 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 		attemptPrefix = fmt.Sprintf("%s.iteration.%d", stepRef, attemptNum)
 	} else {
 		attemptPrefix = fmt.Sprintf("%s.attempt.%d", stepRef, attemptNum)
+	}
+
+	// Which loop iteration this sub-DAG belongs to, tracked separately from
+	// gc.attempt. A ralph step's attempts ARE its iterations, so it defines the
+	// value; every other step inherits it from its control, which is the only
+	// way a retry nested inside a ralph body learns which iteration it is
+	// retrying within. Derived from the live control chain and never from the
+	// frozen spec, so a stale copy in step.Metadata cannot survive.
+	iteration := strings.TrimSpace(control.Metadata[beadmeta.IterationMetadataKey])
+	if step.Ralph != nil {
+		iteration = strconv.Itoa(attemptNum)
 	}
 
 	// Root step for the attempt sub-DAG.
@@ -855,6 +878,7 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	// (buildNestedControlSeed) — both are covered by findLatestAttempt's
 	// identity set.
 	rootMeta[beadmeta.ControlForMetadataKey] = control.ID
+	setIterationMetadata(rootMeta, iteration)
 	if step.OnComplete != nil {
 		rootMeta[beadmeta.OutputJSONRequiredMetadataKey] = "true"
 	}
@@ -907,8 +931,12 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 
 		for _, child := range step.Children {
 			childID := attemptPrefix + "." + child.ID
+			childAttempt := strconv.Itoa(attemptNum)
+			if step.Ralph != nil {
+				childAttempt = formula.RalphBodyChildAttempt(child, attemptNum)
+			}
 			childMeta := map[string]string{
-				beadmeta.AttemptMetadataKey:     strconv.Itoa(attemptNum),
+				beadmeta.AttemptMetadataKey:     childAttempt,
 				beadmeta.StepRefMetadataKey:     childID,
 				beadmeta.StepIDMetadataKey:      child.ID,
 				beadmeta.ScopeRefMetadataKey:    attemptPrefix,
@@ -920,6 +948,27 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 			for k, v := range child.Metadata {
 				if _, exists := childMeta[k]; !exists {
 					childMeta[k] = v
+				}
+			}
+			// Written after the copy loop for the same reason gc.control_for is
+			// on the root: the iteration comes from the live control chain, so a
+			// value carried in a frozen spec must not shadow it.
+			setIterationMetadata(childMeta, iteration)
+			// Same S38 rewrite namespaceRalphBodySteps applies at compile time,
+			// extended to the shape it missed. A frozen ralph body arrives
+			// already retry-expanded, so a nested control's attempt root carries
+			// gc.control_for as the BARE child id — identical in every outer
+			// iteration. Left bare, each iteration's control matches all its
+			// siblings' attempt roots through the shared gc.step_id identity
+			// member, and only max(gc.attempt) told them apart. That tiebreak
+			// was the iteration index being stamped as an attempt number, so it
+			// disappears with the counter split; the ref has to carry the
+			// distinction it was always supposed to carry. buildNestedControlSeed
+			// already yields this form for nested ralphs, whose synthetic control
+			// is keyed by the namespaced child ref.
+			if step.Ralph != nil {
+				if cf := strings.TrimSpace(child.Metadata[beadmeta.ControlForMetadataKey]); cf != "" {
+					childMeta[beadmeta.ControlForMetadataKey] = attemptPrefix + "." + cf
 				}
 			}
 			if child.OnComplete != nil {
@@ -1626,32 +1675,44 @@ func latestAttemptFromDependencies(store beads.Store, control beads.Bead) (beads
 // candidate carries a matching stamp (in-flight molecules minted before S38),
 // it falls back to the deprecated ref-string cascade.
 func latestAttemptFromCandidates(control beads.Bead, candidates []beads.Bead) beads.Bead {
-	identity := controlIdentitySet(control)
+	precise, bare := controlIdentitySets(control)
 
-	var latest beads.Bead
-	latestAttempt := 0
+	var preciseLatest, bareLatest beads.Bead
+	preciseAttempt, bareAttempt := 0, 0
 	for _, b := range candidates {
 		if isFailedPartialMolecule(b) {
 			continue
 		}
-		// Skip beads that are control infrastructure, not actual work. On the
-		// primary path only this control's own attempt roots carry its identity,
-		// so no scope-unless-ralph skip is needed (see legacy fallback).
+		// Skip beads that are control infrastructure, not actual work. This runs
+		// before the precision ranking below so a scope-check carrying the same
+		// namespaced ref cannot pose as the precise match and starve a real
+		// attempt root of its fallback.
 		if latestAttemptCandidateIsControlInfrastructure(b.Metadata[beadmeta.KindMetadataKey]) {
 			continue
 		}
 		cf := strings.TrimSpace(b.Metadata[beadmeta.ControlForMetadataKey])
-		if cf == "" || !identity[cf] {
+		if cf == "" {
 			continue
 		}
 		attemptNum, _ := strconv.Atoi(b.Metadata[beadmeta.AttemptMetadataKey])
-		if attemptNum > latestAttempt {
-			latestAttempt = attemptNum
-			latest = b
+		switch {
+		case precise[cf]:
+			if attemptNum > preciseAttempt {
+				preciseAttempt = attemptNum
+				preciseLatest = b
+			}
+		case bare[cf]:
+			if attemptNum > bareAttempt {
+				bareAttempt = attemptNum
+				bareLatest = b
+			}
 		}
 	}
-	if latest.ID != "" {
-		return latest
+	if preciseLatest.ID != "" {
+		return preciseLatest
+	}
+	if bareLatest.ID != "" {
+		return bareLatest
 	}
 	return latestAttemptFromCandidatesLegacyRefSurgery(control, candidates)
 }
@@ -1661,18 +1722,38 @@ func latestAttemptFromCandidates(control beads.Bead, candidates []beads.Bead) be
 // gc.control_for stamp equal to any member points at this control (bead-ID
 // stamps come from runtime top-level mints; step-ref/step-id stamps come from
 // compile-time and nested seeds — see S38).
-func controlIdentitySet(control beads.Bead) map[string]bool {
-	identity := make(map[string]bool, 3)
+// controlIdentitySets splits the values an attempt root may carry in
+// gc.control_for by how precisely each one names THIS control.
+//
+// The store bead ID and the namespaced gc.step_ref belong to exactly one
+// control. The bare gc.step_id does not: every outer ralph iteration mints an
+// inner control with the same step id, so a bare stamp names all of them at
+// once. Attempt roots minted before the namespaced stamp existed carry only the
+// bare form, which is why it is still matched — but it has to rank below a
+// precise match, because a molecule that spans a deploy holds both shapes and
+// the older siblings are the ones with the bare stamp.
+//
+// max(gc.attempt) used to paper over the ambiguity: body children were stamped
+// with their outer iteration index, so a later iteration always outscored an
+// earlier one. Splitting the iteration and attempt counters removes that
+// accident — a current iteration's first attempt is now 1, which loses to a
+// stale sibling's 3 — so the precedence has to be stated rather than inferred
+// from a number that no longer means what it did (S38, ga-v7pu5).
+func controlIdentitySets(control beads.Bead) (precise, bare map[string]bool) {
+	precise = make(map[string]bool, 2)
 	for _, v := range []string{
 		control.ID,
 		control.Metadata[beadmeta.StepRefMetadataKey],
-		control.Metadata[beadmeta.StepIDMetadataKey],
 	} {
 		if v = strings.TrimSpace(v); v != "" {
-			identity[v] = true
+			precise[v] = true
 		}
 	}
-	return identity
+	bare = make(map[string]bool, 1)
+	if v := strings.TrimSpace(control.Metadata[beadmeta.StepIDMetadataKey]); v != "" && !precise[v] {
+		bare[v] = true
+	}
+	return precise, bare
 }
 
 // legacyAttemptLineageHits counts attempt-lineage recoveries served by the

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -822,6 +822,50 @@ func setIterationMetadata(meta map[string]string, iteration string) {
 	meta[beadmeta.IterationMetadataKey] = iteration
 }
 
+// attemptIteration returns which loop iteration an attempt's sub-DAG belongs to,
+// tracked separately from gc.attempt. A ralph step's attempts ARE its
+// iterations, so it defines the value; every other step inherits it from its
+// control, which is the only way a retry nested inside a ralph body learns which
+// iteration it is retrying within. Derived from the live control chain and never
+// from the frozen spec, so a stale copy in step.Metadata cannot survive.
+func attemptIteration(step *formula.Step, control beads.Bead, attemptNum int) string {
+	if step.Ralph != nil {
+		return strconv.Itoa(attemptNum)
+	}
+	return strings.TrimSpace(control.Metadata[beadmeta.IterationMetadataKey])
+}
+
+// applyRalphBodyChildControls rewrites the counters and lineage a ralph body
+// child must take from the live control chain instead of its frozen spec. The
+// iteration is inherited so a retry nested in the body knows which iteration it
+// is retrying within; setIterationMetadata clears it for a non-loop child. A
+// ralph body child additionally resets its retry counter to the child's own
+// spec attempt each iteration (RalphBodyChildAttempt), so an iteration-N child
+// is not born exhausted, and namespaces a bare gc.control_for under this attempt
+// so sibling attempt roots stop colliding on a shared gc.step_id across
+// iterations.
+func applyRalphBodyChildControls(childMeta map[string]string, step, child *formula.Step, attemptNum int, iteration, attemptPrefix string) {
+	setIterationMetadata(childMeta, iteration)
+	if step.Ralph == nil {
+		return
+	}
+	childMeta[beadmeta.AttemptMetadataKey] = formula.RalphBodyChildAttempt(child, attemptNum)
+	// Same S38 rewrite namespaceRalphBodySteps applies at compile time, extended
+	// to the shape it missed. A frozen ralph body arrives already retry-expanded,
+	// so a nested control's attempt root carries gc.control_for as the BARE child
+	// id — identical in every outer iteration. Left bare, each iteration's
+	// control matches all its siblings' attempt roots through the shared
+	// gc.step_id identity member, and only max(gc.attempt) told them apart. That
+	// tiebreak was the iteration index being stamped as an attempt number, so it
+	// disappears with the counter split; the ref has to carry the distinction it
+	// was always supposed to carry. buildNestedControlSeed already yields this
+	// form for nested ralphs, whose synthetic control is keyed by the namespaced
+	// child ref.
+	if cf := strings.TrimSpace(child.Metadata[beadmeta.ControlForMetadataKey]); cf != "" {
+		childMeta[beadmeta.ControlForMetadataKey] = attemptPrefix + "." + cf
+	}
+}
+
 // buildAttemptRecipe constructs a minimal formula.Recipe for one attempt
 // from the frozen step spec.
 func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) *formula.Recipe {
@@ -844,16 +888,7 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 		attemptPrefix = fmt.Sprintf("%s.attempt.%d", stepRef, attemptNum)
 	}
 
-	// Which loop iteration this sub-DAG belongs to, tracked separately from
-	// gc.attempt. A ralph step's attempts ARE its iterations, so it defines the
-	// value; every other step inherits it from its control, which is the only
-	// way a retry nested inside a ralph body learns which iteration it is
-	// retrying within. Derived from the live control chain and never from the
-	// frozen spec, so a stale copy in step.Metadata cannot survive.
-	iteration := strings.TrimSpace(control.Metadata[beadmeta.IterationMetadataKey])
-	if step.Ralph != nil {
-		iteration = strconv.Itoa(attemptNum)
-	}
+	iteration := attemptIteration(step, control, attemptNum)
 
 	// Root step for the attempt sub-DAG.
 	// For ralph iterations with children, the root is a scope bead.
@@ -931,12 +966,8 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 
 		for _, child := range step.Children {
 			childID := attemptPrefix + "." + child.ID
-			childAttempt := strconv.Itoa(attemptNum)
-			if step.Ralph != nil {
-				childAttempt = formula.RalphBodyChildAttempt(child, attemptNum)
-			}
 			childMeta := map[string]string{
-				beadmeta.AttemptMetadataKey:     childAttempt,
+				beadmeta.AttemptMetadataKey:     strconv.Itoa(attemptNum),
 				beadmeta.StepRefMetadataKey:     childID,
 				beadmeta.StepIDMetadataKey:      child.ID,
 				beadmeta.ScopeRefMetadataKey:    attemptPrefix,
@@ -950,27 +981,11 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 					childMeta[k] = v
 				}
 			}
-			// Written after the copy loop for the same reason gc.control_for is
-			// on the root: the iteration comes from the live control chain, so a
-			// value carried in a frozen spec must not shadow it.
-			setIterationMetadata(childMeta, iteration)
-			// Same S38 rewrite namespaceRalphBodySteps applies at compile time,
-			// extended to the shape it missed. A frozen ralph body arrives
-			// already retry-expanded, so a nested control's attempt root carries
-			// gc.control_for as the BARE child id — identical in every outer
-			// iteration. Left bare, each iteration's control matches all its
-			// siblings' attempt roots through the shared gc.step_id identity
-			// member, and only max(gc.attempt) told them apart. That tiebreak
-			// was the iteration index being stamped as an attempt number, so it
-			// disappears with the counter split; the ref has to carry the
-			// distinction it was always supposed to carry. buildNestedControlSeed
-			// already yields this form for nested ralphs, whose synthetic control
-			// is keyed by the namespaced child ref.
-			if step.Ralph != nil {
-				if cf := strings.TrimSpace(child.Metadata[beadmeta.ControlForMetadataKey]); cf != "" {
-					childMeta[beadmeta.ControlForMetadataKey] = attemptPrefix + "." + cf
-				}
-			}
+			// Rewrite the counters and lineage a ralph body child must take from
+			// the live control chain rather than its frozen spec. Applied after
+			// the copy loop, for the same reason gc.control_for is on the root: a
+			// value carried in a frozen spec must not shadow them.
+			applyRalphBodyChildControls(childMeta, step, child, attemptNum, iteration, attemptPrefix)
 			if child.OnComplete != nil {
 				childMeta[beadmeta.OutputJSONRequiredMetadataKey] = "true"
 			}

--- a/internal/dispatch/control_attempt_iteration_test.go
+++ b/internal/dispatch/control_attempt_iteration_test.go
@@ -1,0 +1,321 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+// gc.attempt answers "which attempt of THIS step is this". A ralph iteration
+// root is a step whose attempts are iterations, so attempt == iteration there.
+// Its body children are DIFFERENT steps: each owns a retry counter that starts
+// at 1 and is bounded by that child's own gc.max_attempts. Stamping the outer
+// iteration onto a child conflates the two counters, and the conflation is not
+// cosmetic — processRetryEval reads gc.attempt off the child and computes
+// nextAttempt = attempt + 1, so a child first run in iteration N is born at
+// attempt N against max_attempts 3. By iteration 3 it is exhausted before it
+// runs and hard-fails with zero retries taken. Live census of the
+// maintainer-city graph store found 81 of 382 retry-kind beads (21%) born at or
+// past their own max, including 40 at attempt 4 and 10 at attempt 5 against a
+// max of 3 — values a counter that starts at 1 can never reach (ga-v7pu5).
+//
+// The iteration index is still worth recording; it just needs its own key.
+// gc.iteration has existed in beadmeta since the runs view started reading it
+// (internal/runproj/detail_nodeshape.go) but nothing ever wrote it.
+func TestBuildAttemptRecipeKeepsChildRetryCountersIndependentOfIteration(t *testing.T) {
+	t.Parallel()
+
+	// The frozen spec shape observed live: by the time a ralph step is frozen,
+	// its children have already been through ApplyRetries, so the child list
+	// holds the retry control, its spec, and its first attempt bead — and that
+	// attempt bead carries the gc.attempt=1 expandRetry stamped on it.
+	newStep := func() *formula.Step {
+		return &formula.Step{
+			ID:    "review-loop",
+			Title: "Review loop",
+			Type:  "task",
+			Ralph: &formula.RalphSpec{
+				MaxAttempts: 5,
+				Check:       &formula.RalphCheckSpec{Mode: "exec", Path: "check.sh"},
+			},
+			Children: []*formula.Step{
+				{
+					ID:    "scorecard",
+					Title: "Scorecard",
+					Type:  "task",
+					Retry: &formula.RetrySpec{MaxAttempts: 3, OnExhausted: "hard_fail"},
+				},
+				{
+					ID:    "scorecard.attempt.1",
+					Title: "Scorecard",
+					Type:  "task",
+					Metadata: map[string]string{
+						"gc.attempt":     "1",
+						"gc.control_for": "scorecard",
+					},
+				},
+				{ID: "publish", Title: "Publish", Type: "task"},
+			},
+		}
+	}
+
+	control := beads.Bead{
+		ID: "gc-1",
+		Metadata: map[string]string{
+			"gc.step_id":  "review-loop",
+			"gc.step_ref": "mol-test.review-loop",
+		},
+	}
+
+	recipe := buildAttemptRecipe(newStep(), control, 3)
+
+	stepByID := func(t *testing.T, id string) *formula.RecipeStep {
+		t.Helper()
+		step := recipe.StepByID(id)
+		if step == nil {
+			ids := make([]string, 0, len(recipe.Steps))
+			for _, s := range recipe.Steps {
+				ids = append(ids, s.ID)
+			}
+			t.Fatalf("missing step %q; recipe has %v", id, ids)
+		}
+		return step
+	}
+
+	t.Run("retry control starts its own counter at 1", func(t *testing.T) {
+		// This is the bead processRetryEval reads. Born at the iteration index,
+		// it spends the child's retry budget on iterations it never used.
+		got := stepByID(t, "mol-test.review-loop.iteration.3.scorecard")
+		if attempt := got.Metadata["gc.attempt"]; attempt != "1" {
+			t.Errorf("retry control gc.attempt = %q, want 1 (its own counter, not the iteration)", attempt)
+		}
+		if kind := got.Metadata["gc.kind"]; kind != "retry" {
+			t.Fatalf("control gc.kind = %q, want retry — the fixture is not exercising a retry control", kind)
+		}
+		if maximum := got.Metadata["gc.max_attempts"]; maximum != "3" {
+			t.Errorf("retry control gc.max_attempts = %q, want 3", maximum)
+		}
+	})
+
+	t.Run("first attempt bead keeps the attempt its spec carries", func(t *testing.T) {
+		got := stepByID(t, "mol-test.review-loop.iteration.3.scorecard.attempt.1")
+		if attempt := got.Metadata["gc.attempt"]; attempt != "1" {
+			t.Errorf("gc.attempt = %q, want 1 — the ref says attempt.1, so the metadata must agree", attempt)
+		}
+	})
+
+	t.Run("plain children keep the existing iteration stamp", func(t *testing.T) {
+		// A child with no retry control has no counter of its own, so nothing
+		// reads its gc.attempt. TestBuildAttemptRecipeRalphWithChildren pins the
+		// current value; this change must not disturb it.
+		got := stepByID(t, "mol-test.review-loop.iteration.3.publish")
+		if attempt := got.Metadata["gc.attempt"]; attempt != "3" {
+			t.Errorf("plain child gc.attempt = %q, want 3", attempt)
+		}
+	})
+
+	t.Run("every step records the iteration under its own key", func(t *testing.T) {
+		for _, id := range []string{
+			"mol-test.review-loop.iteration.3",
+			"mol-test.review-loop.iteration.3.scorecard",
+			"mol-test.review-loop.iteration.3.scorecard.attempt.1",
+			"mol-test.review-loop.iteration.3.publish",
+		} {
+			if iteration := stepByID(t, id).Metadata["gc.iteration"]; iteration != "3" {
+				t.Errorf("%s: gc.iteration = %q, want 3", id, iteration)
+			}
+		}
+	})
+
+	t.Run("retry children point at THIS iteration's control", func(t *testing.T) {
+		// S38 gave nested ralph controls a namespaced gc.control_for so an
+		// iteration resolves only its own attempt roots. Nested RETRY controls
+		// never got it: their attempt roots come from the frozen spec, whose
+		// gc.control_for is the bare child id, and the copy loop below passes it
+		// through unchanged. Live molecules show every iteration's attempt.1
+		// carrying the identical bare "review-pipeline.quality-scorecard", so
+		// all of them match every iteration's control through the shared
+		// gc.step_id identity member. Only max(gc.attempt) kept them apart —
+		// which worked solely because the iteration index was being stamped
+		// there, the very conflation this file removes.
+		got := stepByID(t, "mol-test.review-loop.iteration.3.scorecard.attempt.1")
+		want := "mol-test.review-loop.iteration.3.scorecard"
+		if cf := got.Metadata["gc.control_for"]; cf != want {
+			t.Errorf("gc.control_for = %q, want %q (this iteration's control, not the bare step id)", cf, want)
+		}
+	})
+
+	t.Run("iteration root still counts iterations in gc.attempt", func(t *testing.T) {
+		// The root IS the ralph subject, and processRalphControl reads gc.attempt
+		// off it. Its attempts genuinely are iterations, so this must not move.
+		got := stepByID(t, "mol-test.review-loop.iteration.3")
+		if attempt := got.Metadata["gc.attempt"]; attempt != "3" {
+			t.Errorf("iteration root gc.attempt = %q, want 3", attempt)
+		}
+	})
+}
+
+// TestBuildAttemptRecipeRetryAttemptsStillCarryTheAttemptNumber guards the
+// non-ralph half. A plain retry's sub-DAG really is attempt N, so its root and
+// any children it owns must keep counting attempts — the fix above is scoped to
+// ralph iterations and must not leak into this path.
+func TestBuildAttemptRecipeRetryAttemptsStillCarryTheAttemptNumber(t *testing.T) {
+	t.Parallel()
+
+	step := &formula.Step{
+		ID:    "finalize",
+		Title: "Finalize",
+		Type:  "task",
+		Retry: &formula.RetrySpec{MaxAttempts: 3},
+		Children: []*formula.Step{
+			{ID: "inner", Title: "Inner", Type: "task"},
+		},
+	}
+	control := beads.Bead{
+		ID: "gc-2",
+		Metadata: map[string]string{
+			"gc.step_id":  "finalize",
+			"gc.step_ref": "mol-test.finalize",
+		},
+	}
+
+	recipe := buildAttemptRecipe(step, control, 2)
+
+	root := recipe.StepByID("mol-test.finalize.attempt.2")
+	if root == nil {
+		t.Fatal("missing attempt root")
+	}
+	if attempt := root.Metadata["gc.attempt"]; attempt != "2" {
+		t.Errorf("attempt root gc.attempt = %q, want 2", attempt)
+	}
+	if iteration, ok := root.Metadata["gc.iteration"]; ok {
+		t.Errorf("attempt root carries gc.iteration = %q; a plain retry has no iteration", iteration)
+	}
+
+	inner := recipe.StepByID("mol-test.finalize.attempt.2.inner")
+	if inner == nil {
+		t.Fatal("missing inner child")
+	}
+	if attempt := inner.Metadata["gc.attempt"]; attempt != "2" {
+		t.Errorf("inner child gc.attempt = %q, want 2 — it is part of attempt 2", attempt)
+	}
+}
+
+// TestBuildAttemptRecipeInheritsIterationForNestedRetryAttempts covers the path
+// that actually writes the review artifacts. A retry nested inside a ralph body
+// spawns through the NON-ralph branch — step.Ralph is nil for the child — so it
+// cannot derive the iteration from attemptNum. It has to carry the iteration
+// forward from its control, or every retried step inside an iteration loses the
+// only stable name for the directory its siblings wrote to (ga-la0py).
+func TestBuildAttemptRecipeInheritsIterationForNestedRetryAttempts(t *testing.T) {
+	t.Parallel()
+
+	step := &formula.Step{
+		ID:    "scorecard",
+		Title: "Scorecard",
+		Type:  "task",
+		Retry: &formula.RetrySpec{MaxAttempts: 3},
+	}
+	// The control is the retry control bead minted as a child of iteration 2,
+	// so it carries that iteration.
+	control := beads.Bead{
+		ID: "gc-3",
+		Metadata: map[string]string{
+			"gc.step_id":   "scorecard",
+			"gc.step_ref":  "mol-test.review-loop.iteration.2.scorecard",
+			"gc.iteration": "2",
+		},
+	}
+
+	recipe := buildAttemptRecipe(step, control, 2)
+
+	root := recipe.StepByID("mol-test.review-loop.iteration.2.scorecard.attempt.2")
+	if root == nil {
+		ids := make([]string, 0, len(recipe.Steps))
+		for _, s := range recipe.Steps {
+			ids = append(ids, s.ID)
+		}
+		t.Fatalf("missing attempt root; recipe has %v", ids)
+	}
+	if iteration := root.Metadata["gc.iteration"]; iteration != "2" {
+		t.Errorf("gc.iteration = %q, want 2 — inherited from the control, not from attemptNum", iteration)
+	}
+	// The two counters have genuinely diverged here: this is retry attempt 2 of
+	// a step inside iteration 2. Only coincidence makes them equal; the point is
+	// that each is now readable on its own.
+	if attempt := root.Metadata["gc.attempt"]; attempt != "2" {
+		t.Errorf("gc.attempt = %q, want 2", attempt)
+	}
+}
+
+// TestLatestAttemptPrefersPreciseControlIdentityOverBareStepID is the read-side
+// half of the counter split. A control's identity set has three members, and
+// they are not equally specific: the bead ID and the namespaced gc.step_ref name
+// exactly one control, while the bare gc.step_id names the same inner control in
+// EVERY outer iteration. Attempt roots minted before the namespaced stamp
+// existed carry only the bare form, so a molecule that spans a deploy holds both
+// shapes at once.
+//
+// Until now max(gc.attempt) hid the ambiguity, because a body child was stamped
+// with its outer iteration index and later iterations therefore always scored
+// higher. Once each child counts its own attempts from 1, the older sibling's
+// stale index outranks the current iteration's first attempt and the control
+// resolves a closed attempt from an iteration it has nothing to do with.
+// Precision has to be ranked explicitly rather than inferred from a number that
+// no longer means what it used to (S38, ga-v7pu5).
+func TestLatestAttemptPrefersPreciseControlIdentityOverBareStepID(t *testing.T) {
+	t.Parallel()
+
+	control := beads.Bead{
+		ID: "gc-ctl-iter5",
+		Metadata: map[string]string{
+			"gc.kind":     "retry",
+			"gc.step_ref": "mol.review-loop.iteration.5.scorecard",
+			"gc.step_id":  "scorecard",
+		},
+	}
+
+	candidates := []beads.Bead{
+		// Minted before the deploy, in earlier iterations of this same loop:
+		// bare stamp, and carrying the outer iteration index as its attempt.
+		{ID: "old-iter2", Metadata: map[string]string{
+			"gc.control_for": "scorecard",
+			"gc.attempt":     "2",
+		}},
+		{ID: "old-iter3", Metadata: map[string]string{
+			"gc.control_for": "scorecard",
+			"gc.attempt":     "3",
+		}},
+		// This iteration's own first attempt, minted after the split.
+		{ID: "new-iter5", Metadata: map[string]string{
+			"gc.control_for": "mol.review-loop.iteration.5.scorecard",
+			"gc.attempt":     "1",
+		}},
+	}
+
+	if got := latestAttemptFromCandidates(control, candidates); got.ID != "new-iter5" {
+		t.Errorf("resolved %q, want new-iter5 — a precise stamp outranks a bare one regardless of gc.attempt", got.ID)
+	}
+
+	t.Run("bare stamps still resolve when nothing precise exists", func(t *testing.T) {
+		// A molecule minted entirely before the namespaced stamp has only bare
+		// candidates. Those must keep resolving exactly as they do today.
+		if got := latestAttemptFromCandidates(control, candidates[:2]); got.ID != "old-iter3" {
+			t.Errorf("resolved %q, want old-iter3 — bare candidates still select max(gc.attempt)", got.ID)
+		}
+	})
+
+	t.Run("infrastructure is filtered before precision is judged", func(t *testing.T) {
+		// A scope-check carries the precise ref too. It must not count as the
+		// precise match and starve the real attempt root of its bare fallback.
+		withCheck := append([]beads.Bead{{ID: "chk", Metadata: map[string]string{
+			"gc.control_for": "mol.review-loop.iteration.5.scorecard",
+			"gc.attempt":     "9",
+			"gc.kind":        "scope-check",
+		}}}, candidates[:2]...)
+		if got := latestAttemptFromCandidates(control, withCheck); got.ID != "old-iter3" {
+			t.Errorf("resolved %q, want old-iter3 — a scope-check is not an attempt root", got.ID)
+		}
+	})
+}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -512,7 +512,7 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 	// Create the subject first so scope_ref remapping is stable for nested attempts.
 	subjectMeta := cloneMetadata(prevSubject.Metadata)
 	clearRetryEphemera(subjectMeta)
-	subjectMeta[beadmeta.AttemptMetadataKey] = strconv.Itoa(nextAttempt)
+	stampRalphRetryIteration(subjectMeta, prevSubject, nextAttempt)
 	subjectMeta[beadmeta.RetryFromMetadataKey] = prevSubject.ID
 	subjectMeta[beadmeta.LogicalBeadIDMetadataKey] = logicalID
 	subjectMeta[beadmeta.StepRefMetadataKey] = rewriteRetryStepRef(prevSubject.Metadata, prevSubject.Ref, oldScopeRef, newScopeRef, oldAttempt, nextAttempt)
@@ -547,7 +547,7 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 		}
 		meta := cloneMetadata(old.Metadata)
 		clearRetryEphemera(meta)
-		meta[beadmeta.AttemptMetadataKey] = strconv.Itoa(nextAttempt)
+		stampRalphRetryIteration(meta, old, nextAttempt)
 		meta[beadmeta.RetryFromMetadataKey] = old.ID
 		if currentScopeRef := strings.TrimSpace(meta[beadmeta.ScopeRefMetadataKey]); currentScopeRef != "" {
 			meta[beadmeta.ScopeRefMetadataKey] = rewriteRetryScopeRef(currentScopeRef, oldScopeRef, newScopeRef, prevSubject.ID)
@@ -581,7 +581,7 @@ func appendRalphRetryLegacy(store beads.Store, logicalID string, prevSubject, pr
 
 	checkMeta := cloneMetadata(prevCheck.Metadata)
 	clearRetryEphemera(checkMeta)
-	checkMeta[beadmeta.AttemptMetadataKey] = strconv.Itoa(nextAttempt)
+	stampRalphRetryIteration(checkMeta, prevCheck, nextAttempt)
 	checkMeta[beadmeta.RetryFromMetadataKey] = prevCheck.ID
 	checkMeta[beadmeta.TerminalMetadataKey] = ""
 	checkMeta[beadmeta.LogicalBeadIDMetadataKey] = logicalID
@@ -730,7 +730,7 @@ func appendRalphRetryViaGraphApply(store beads.Store, applier beads.GraphApplySt
 func buildRalphRetryGraphNode(old beads.Bead, logicalID, oldScopeRef, newScopeRef string, oldAttempt, nextAttempt int, attemptIDs map[string]bool, cfg *config.City) beads.GraphApplyNode {
 	meta := cloneMetadata(old.Metadata)
 	clearRetryEphemera(meta)
-	meta[beadmeta.AttemptMetadataKey] = strconv.Itoa(nextAttempt)
+	stampRalphRetryIteration(meta, old, nextAttempt)
 	meta[beadmeta.RetryFromMetadataKey] = old.ID
 	if currentScopeRef := strings.TrimSpace(meta[beadmeta.ScopeRefMetadataKey]); currentScopeRef != "" {
 		meta[beadmeta.ScopeRefMetadataKey] = rewriteRetryScopeRef(currentScopeRef, oldScopeRef, newScopeRef, old.ID)
@@ -786,6 +786,76 @@ func buildRalphRetryGraphNode(old beads.Bead, logicalID, oldScopeRef, newScopeRe
 		MetadataRefs:      metadataRefs,
 		ParentKey:         parentKey,
 		ParentID:          parentID,
+	}
+}
+
+// stampRalphRetryIteration advances the iteration/attempt counters on a bead
+// cloned to form the next Ralph outer iteration, reproducing the contract the
+// mint paths establish (internal/formula/ralph.go and
+// dispatch.buildAttemptRecipe). gc.iteration is the outer loop counter and
+// always advances to nextAttempt. gc.attempt advances too on a loop-level bead
+// (the scope/subject or the check — the beads that ARE the loop), but a nested
+// body member instead resets to its own local step counter (see
+// ralphRetryMemberAttempt) so a retry nested in the body is not born exhausted.
+//
+// Loop-level vs member is read from the bead: a body member lives inside the
+// scope and carries gc.scope_ref, while the scope subject, the simple-ralph
+// iteration bead, and the check do not. Callers pass the ORIGINAL bead so the
+// classification is not affected by rewrites already applied to the clone's meta.
+func stampRalphRetryIteration(meta map[string]string, old beads.Bead, nextAttempt int) {
+	meta[beadmeta.IterationMetadataKey] = strconv.Itoa(nextAttempt)
+	if strings.TrimSpace(old.Metadata[beadmeta.ScopeRefMetadataKey]) == "" {
+		meta[beadmeta.AttemptMetadataKey] = strconv.Itoa(nextAttempt)
+		return
+	}
+	meta[beadmeta.AttemptMetadataKey] = ralphRetryMemberAttempt(old, nextAttempt)
+}
+
+// ralphRetryMemberAttempt derives the gc.attempt a cloned Ralph body member
+// carries in the next outer iteration, matching the runtime mint
+// (dispatch.buildAttemptRecipe -> formula.RalphBodyChildAttempt): a retry or
+// nested-ralph control resets its own counter to 1; an already-materialized
+// attempt.N run keeps the attempt its ref names; every other (plain) member
+// inherits the outer iteration index. Classification is structural because at
+// iteration 1 every member's gc.attempt reads "1" and cannot be told apart by
+// value alone. (A nested ralph SCOPE member is not produced by any current
+// formula and is treated as a plain child here; if one is ever introduced it
+// would want the "1" reset like its control, tracked with the retry/ralph case.)
+func ralphRetryMemberAttempt(old beads.Bead, nextAttempt int) string {
+	switch strings.TrimSpace(old.Metadata[beadmeta.KindMetadataKey]) {
+	case beadmeta.KindRetry, beadmeta.KindRalph:
+		return "1"
+	}
+	if own := strings.TrimSpace(old.Metadata[beadmeta.AttemptMetadataKey]); own != "" && ralphRetryMemberIsFrozenAttempt(old) {
+		return own
+	}
+	return strconv.Itoa(nextAttempt)
+}
+
+// ralphRetryMemberIsFrozenAttempt reports whether a Ralph body member is an
+// already-materialized retry attempt run — its ref carries a ".attempt.<n>"
+// segment — as opposed to a retry control or a plain member. Such a bead owns
+// its attempt number and must keep it across an outer iteration rather than
+// inherit the iteration index.
+func ralphRetryMemberIsFrozenAttempt(old beads.Bead) bool {
+	return refHasAttemptSegment(old.Metadata[beadmeta.StepRefMetadataKey]) || refHasAttemptSegment(old.Ref)
+}
+
+// refHasAttemptSegment reports whether ref contains a ".attempt.<digits>"
+// segment. The trailing digit requirement rejects a step literally named
+// "attempt" (whose ref would end at ".attempt" with no counter).
+func refHasAttemptSegment(ref string) bool {
+	const marker = ".attempt."
+	for {
+		idx := strings.Index(ref, marker)
+		if idx < 0 {
+			return false
+		}
+		rest := ref[idx+len(marker):]
+		if len(rest) > 0 && rest[0] >= '0' && rest[0] <= '9' {
+			return true
+		}
+		ref = rest
 	}
 }
 

--- a/internal/dispatch/ralph_retry_iteration_test.go
+++ b/internal/dispatch/ralph_retry_iteration_test.go
@@ -1,0 +1,200 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// A Ralph loop advances an outer iteration by CLONING the prior iteration's
+// beads (appendRalphRetryLegacy / buildRalphRetryGraphNode), not by re-minting
+// them from the frozen spec. The clone therefore has to reproduce the same
+// iteration/attempt contract the mint paths establish (internal/formula/ralph.go
+// + dispatch.buildAttemptRecipe):
+//
+//   - gc.iteration is the outer loop counter and advances to the NEW iteration on
+//     EVERY cloned bead — the scope/subject, the check, and every nested member.
+//   - gc.attempt is the loop counter only on the loop-level beads (scope/subject
+//     and check); a nested body member's gc.attempt follows its own local step
+//     semantics (RalphBodyChildAttempt): a retry/ralph control resets to 1, an
+//     already-materialized attempt.N bead keeps the attempt its ref carries, and a
+//     plain child inherits the iteration index.
+//
+// Before the fix both clone paths blanket-stamped gc.attempt=nextAttempt onto
+// subject/members/check and never wrote gc.iteration, so a retried iteration N+1
+// carried gc.iteration=N (stale) and every nested retry counter was overwritten
+// with the outer iteration number. These tests pin the contract on both paths.
+
+// ralphIterationOneBead is a compact description of one iteration-1 bead used to
+// seed the clone-path tests. The step_ref strings are the logical namespaced
+// refs the producers emit; the store assigns opaque bead IDs on top.
+type ralphIterationOneBead struct {
+	title    string
+	kind     string
+	stepID   string
+	stepRef  string
+	scopeRef string
+	attempt  string
+}
+
+func (b ralphIterationOneBead) metadata(rootID string) map[string]string {
+	meta := map[string]string{
+		beadmeta.StepIDMetadataKey:      b.stepID,
+		beadmeta.RalphStepIDMetadataKey: "review-loop",
+		beadmeta.AttemptMetadataKey:     b.attempt,
+		beadmeta.IterationMetadataKey:   "1",
+		beadmeta.StepRefMetadataKey:     b.stepRef,
+		beadmeta.RootBeadIDMetadataKey:  rootID,
+	}
+	if b.kind != "" {
+		meta[beadmeta.KindMetadataKey] = b.kind
+	}
+	if b.scopeRef != "" {
+		meta[beadmeta.ScopeRefMetadataKey] = b.scopeRef
+		meta[beadmeta.ScopeRoleMetadataKey] = beadmeta.ScopeRoleMember
+	}
+	return meta
+}
+
+// The five iteration-1 beads a nested Ralph body produces: a scope subject, a
+// retry-controlled member and its first attempt run, a plain member, and the
+// ralph check. Refs mirror internal/formula/ralph.go's namespacing.
+var (
+	ralphIterOneSubject = ralphIterationOneBead{
+		title: "review-loop.iteration.1", kind: beadmeta.KindScope,
+		stepID: "review-loop", stepRef: "review-loop.iteration.1", attempt: "1",
+	}
+	ralphIterOneRetryControl = ralphIterationOneBead{
+		title: "review-loop.iteration.1.scorecard", kind: beadmeta.KindRetry,
+		stepID: "scorecard", stepRef: "review-loop.iteration.1.scorecard",
+		scopeRef: "review-loop.iteration.1", attempt: "1",
+	}
+	ralphIterOneAttemptRun = ralphIterationOneBead{
+		title:  "review-loop.iteration.1.scorecard.attempt.1",
+		stepID: "scorecard", stepRef: "review-loop.iteration.1.scorecard.attempt.1",
+		scopeRef: "review-loop.iteration.1", attempt: "1",
+	}
+	ralphIterOnePlainMember = ralphIterationOneBead{
+		title:  "review-loop.iteration.1.publish",
+		stepID: "publish", stepRef: "review-loop.iteration.1.publish",
+		scopeRef: "review-loop.iteration.1", attempt: "1",
+	}
+	ralphIterOneCheck = ralphIterationOneBead{
+		title: "review-loop.check.1", kind: beadmeta.KindCheck,
+		stepID: "review-loop", stepRef: "review-loop.check.1", attempt: "1",
+	}
+)
+
+// clonedRalphIteration is the outer iteration every cloned bead must advance to:
+// these tests seed iteration-1 beads and clone them forward one outer iteration.
+const clonedRalphIteration = "2"
+
+// assertClonedCounters pins the two counters a cloned bead must carry. Every
+// clone advances gc.iteration to the new outer iteration (clonedRalphIteration);
+// gc.attempt follows local step semantics and so varies per bead.
+func assertClonedCounters(t *testing.T, label string, meta map[string]string, wantAttempt string) {
+	t.Helper()
+	if got := meta[beadmeta.IterationMetadataKey]; got != clonedRalphIteration {
+		t.Errorf("%s: gc.iteration = %q, want %q", label, got, clonedRalphIteration)
+	}
+	if got := meta[beadmeta.AttemptMetadataKey]; got != wantAttempt {
+		t.Errorf("%s: gc.attempt = %q, want %q", label, got, wantAttempt)
+	}
+}
+
+func TestAppendRalphRetryLegacyAdvancesIterationAndResetsNestedCounters(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review-loop",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindRalph,
+			beadmeta.StepIDMetadataKey:     "review-loop",
+			beadmeta.RootBeadIDMetadataKey: workflow.ID,
+		},
+	})
+
+	newBead := func(desc ralphIterationOneBead) beads.Bead {
+		meta := desc.metadata(workflow.ID)
+		if desc.kind == beadmeta.KindScope || desc.kind == beadmeta.KindCheck {
+			meta[beadmeta.LogicalBeadIDMetadataKey] = logical.ID
+		}
+		return mustCreateWorkflowBead(t, store, beads.Bead{Title: desc.title, Type: "task", Metadata: meta})
+	}
+
+	subject := newBead(ralphIterOneSubject)
+	retryControl := newBead(ralphIterOneRetryControl)
+	attemptRun := newBead(ralphIterOneAttemptRun)
+	plainMember := newBead(ralphIterOnePlainMember)
+	check := newBead(ralphIterOneCheck)
+
+	attemptSet := map[string]beads.Bead{
+		subject.ID:      subject,
+		retryControl.ID: retryControl,
+		attemptRun.ID:   attemptRun,
+		plainMember.ID:  plainMember,
+	}
+
+	mapping, err := appendRalphRetryLegacy(store, logical.ID, subject, check, attemptSet,
+		1, 2, "review-loop.iteration.1", "review-loop.iteration.2", nil)
+	if err != nil {
+		t.Fatalf("appendRalphRetryLegacy: %v", err)
+	}
+
+	cloneMeta := func(oldID string) map[string]string {
+		newID := mapping[oldID]
+		if newID == "" {
+			t.Fatalf("no clone mapped for %s", oldID)
+		}
+		return mustGetBead(t, store, newID).Metadata
+	}
+
+	// Loop-level beads advance both counters to the new outer iteration.
+	assertClonedCounters(t, "scope/subject", cloneMeta(subject.ID), "2")
+	assertClonedCounters(t, "check", cloneMeta(check.ID), "2")
+	// Nested members advance gc.iteration but derive gc.attempt locally.
+	assertClonedCounters(t, "retry control", cloneMeta(retryControl.ID), "1")
+	assertClonedCounters(t, "attempt.1 run", cloneMeta(attemptRun.ID), "1")
+	assertClonedCounters(t, "plain member", cloneMeta(plainMember.ID), "2")
+}
+
+func TestBuildRalphRetryGraphNodeAdvancesIterationAndResetsNestedCounters(t *testing.T) {
+	t.Parallel()
+
+	// buildRalphRetryGraphNode is a pure function: it maps one iteration-1 bead to
+	// the GraphApplyNode for its iteration-2 clone with no store involved.
+	oldBead := func(desc ralphIterationOneBead) beads.Bead {
+		return beads.Bead{ID: desc.stepRef, Ref: desc.stepRef, Metadata: desc.metadata("workflow")}
+	}
+	subject := oldBead(ralphIterOneSubject)
+	retryControl := oldBead(ralphIterOneRetryControl)
+	attemptRun := oldBead(ralphIterOneAttemptRun)
+	plainMember := oldBead(ralphIterOnePlainMember)
+	check := oldBead(ralphIterOneCheck)
+
+	attemptIDs := map[string]bool{
+		subject.ID:      true,
+		retryControl.ID: true,
+		attemptRun.ID:   true,
+		plainMember.ID:  true,
+		check.ID:        true,
+	}
+	node := func(old beads.Bead) map[string]string {
+		return buildRalphRetryGraphNode(old, "logical",
+			"review-loop.iteration.1", "review-loop.iteration.2", 1, 2, attemptIDs, nil).Metadata
+	}
+
+	assertClonedCounters(t, "scope/subject", node(subject), "2")
+	assertClonedCounters(t, "check", node(check), "2")
+	assertClonedCounters(t, "retry control", node(retryControl), "1")
+	assertClonedCounters(t, "attempt.1 run", node(attemptRun), "1")
+	assertClonedCounters(t, "plain member", node(plainMember), "2")
+}

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -434,10 +434,37 @@ func requiredArtifactTemplates(metadata map[string]string) []string {
 	return result
 }
 
+// requiredArtifactWorkDir reads the worktree recorded on a bead, canonical key
+// first and legacy second. beadmeta documents that contract for this key family
+// and internal/beads/contract implements it for the sibling keys; the artifact
+// gate predates both and read only the legacy spelling, so a bead carrying just
+// gc.work_dir resolved to nothing and its attempts stayed transient forever.
+func requiredArtifactWorkDir(meta map[string]string) string {
+	if v := strings.TrimSpace(meta[beadmeta.WorkDirMetadataKey]); v != "" {
+		return v
+	}
+	return strings.TrimSpace(meta[beadmeta.LegacyWorkDirMetadataKey])
+}
+
+// resolveRequiredArtifactPath expands a gc.required_artifact template against
+// the attempt subject. This is the only place the template vocabulary is
+// defined, so it is also where that vocabulary is documented:
+//
+//	{worktree}          the resolved worktree root (also the implicit base for
+//	                    a relative template)
+//	{root} / {root_id}  the workflow root bead ID
+//	{attempt}           gc.attempt — this step's own retry counter
+//	{iteration}         gc.iteration — the loop iteration the step ran in
+//
+// {attempt} and {iteration} are NOT interchangeable. A directory shared by the
+// steps of one loop iteration is named by {iteration}; only {attempt} advances
+// when a single step retries. Any token left unexpanded fails the template
+// loudly rather than resolving to a partial path.
 func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath string) (string, string, string, error) {
 	rootID := strings.TrimSpace(subject.Metadata[beadmeta.RootBeadIDMetadataKey])
 	attempt := strings.TrimSpace(subject.Metadata[beadmeta.AttemptMetadataKey])
-	worktree := strings.TrimSpace(subject.Metadata["work_dir"])
+	iteration := strings.TrimSpace(subject.Metadata[beadmeta.IterationMetadataKey])
+	worktree := requiredArtifactWorkDir(subject.Metadata)
 
 	if worktree == "" {
 		resolvedWorktree, reason, err := resolveRequiredArtifactWorktree(store, rootID)
@@ -458,6 +485,17 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 	path = strings.ReplaceAll(path, "{root}", rootID)
 	path = strings.ReplaceAll(path, "{root_id}", rootID)
 	path = strings.ReplaceAll(path, "{attempt}", attempt)
+	// {iteration} names the loop iteration a whole sub-DAG ran in, which is the
+	// directory a set of sibling steps share. {attempt} names one step's own
+	// retry counter, which only the step that retried advances — so a template
+	// built from it sends a retried reader to a directory its siblings never
+	// wrote. Substituted only when the bead actually carries the value: an empty
+	// replacement would produce a silently wrong path segment and the gate would
+	// then blame the step for the resolver's gap, where falling through to the
+	// unresolved-template check below names the real fault (ga-la0py).
+	if iteration != "" {
+		path = strings.ReplaceAll(path, "{iteration}", iteration)
+	}
 	if strings.Contains(path, "{") || strings.Contains(path, "}") {
 		return "", "", "unresolved_required_artifact_template", nil
 	}
@@ -534,7 +572,7 @@ func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, 
 	// bead of a cross-store root (gc.root_store_ref pointing at another rig)
 	// is not resolvable through this store, and dereferencing it used to fail
 	// passing attempts with missing_required_artifact_context.
-	if worktree := strings.TrimSpace(root.Metadata["work_dir"]); worktree != "" {
+	if worktree := requiredArtifactWorkDir(root.Metadata); worktree != "" {
 		return worktree, "", nil
 	}
 	sourceID := strings.TrimSpace(root.Metadata[beadmeta.SourceBeadIDMetadataKey])
@@ -551,7 +589,7 @@ func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, 
 	if err != nil {
 		return "", "", fmt.Errorf("loading required artifact source bead %s: %w", sourceID, markTransientControllerBoundaryError(err))
 	}
-	worktree := strings.TrimSpace(source.Metadata["work_dir"])
+	worktree := requiredArtifactWorkDir(source.Metadata)
 	if worktree == "" {
 		return "", "missing_required_artifact_context", nil
 	}

--- a/internal/dispatch/retry_artifact_iteration_test.go
+++ b/internal/dispatch/retry_artifact_iteration_test.go
@@ -1,0 +1,198 @@
+package dispatch
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// The required-artifact gate resolves {attempt} from the subject's own
+// gc.attempt — the same key ga-v7pu5 showed is carrying the ralph iteration
+// index rather than the step's retry counter. That makes the gate structurally
+// incapable of catching the artifact-directory mismatch: it computes the same
+// wrong directory the failing step computed, agrees with it, and passes.
+//
+// Worse, the gate is live rather than inert. A census of the maintainer-city
+// graph store found 471 of 542 beads carrying a required-artifact template do
+// resolve a worktree (434 through the workflow root's work_dir). So a gate
+// pointed at a directory nobody wrote turns passing attempts into burned
+// retries.
+//
+// {iteration} gives the template a key that means what the reviewers' shared
+// output directory actually is: the loop iteration all of them ran in, not the
+// per-step retry counter that only one of them advanced (ga-la0py).
+func TestResolveRequiredArtifactPathResolvesIterationSeparatelyFromAttempt(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	worktree := t.TempDir()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"work_dir": worktree,
+		},
+	})
+
+	// The shape that breaks today: quality-scorecard is on retry attempt 3 of
+	// itself, inside review-loop iteration 2. Its sibling reviewers never
+	// retried, so they wrote attempt-2/ and the scorecard must read from there.
+	subject := beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":      "pass",
+			"gc.root_bead_id": root.ID,
+			"gc.attempt":      "3",
+			"gc.iteration":    "2",
+		},
+	}
+
+	got, _, reason, err := resolveRequiredArtifactPath(store, subject,
+		".gc/reviews/{root}/attempt-{iteration}/synthesis.md")
+	if err != nil {
+		t.Fatalf("resolveRequiredArtifactPath error = %v, want nil", err)
+	}
+	if reason != "" {
+		t.Fatalf("resolveRequiredArtifactPath reason = %q, want none", reason)
+	}
+	want := filepath.Join(worktree, ".gc/reviews", root.ID, "attempt-2", "synthesis.md")
+	if got != want {
+		t.Errorf("resolved %q, want %q — {iteration} must read gc.iteration, not gc.attempt", got, want)
+	}
+
+	t.Run("{attempt} still resolves the step's own retry counter", func(t *testing.T) {
+		// The two placeholders must genuinely diverge; a template that asks for
+		// the retry attempt still gets it.
+		got, _, reason, err := resolveRequiredArtifactPath(store, subject,
+			".gc/reviews/{root}/attempt-{attempt}/synthesis.md")
+		if err != nil || reason != "" {
+			t.Fatalf("resolveRequiredArtifactPath = (%v, %q), want success", err, reason)
+		}
+		want := filepath.Join(worktree, ".gc/reviews", root.ID, "attempt-3", "synthesis.md")
+		if got != want {
+			t.Errorf("resolved %q, want %q", got, want)
+		}
+	})
+}
+
+// A missing gc.iteration must fail loudly. Substituting empty would yield
+// "attempt-/", a path nobody writes, and the gate would report
+// missing_required_artifact — blaming the step for the resolver's own gap. The
+// existing unresolved-template check is the correct loud failure, so the
+// substitution has to be skipped rather than applied as empty.
+func TestResolveRequiredArtifactPathRefusesToGuessAMissingIteration(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	worktree := t.TempDir()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"work_dir": worktree,
+		},
+	})
+
+	_, _, reason, err := resolveRequiredArtifactPath(store, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":      "pass",
+			"gc.root_bead_id": root.ID,
+			"gc.attempt":      "3",
+		},
+	}, ".gc/reviews/{root}/attempt-{iteration}/synthesis.md")
+	if err != nil {
+		t.Fatalf("resolveRequiredArtifactPath error = %v, want nil", err)
+	}
+	if reason != "unresolved_required_artifact_template" {
+		t.Errorf("reason = %q, want unresolved_required_artifact_template — an absent iteration must not silently become an empty path segment", reason)
+	}
+}
+
+// The worktree lookup reads the bare legacy "work_dir" and never the canonical
+// gc.work_dir. beadmeta documents the read contract for this family as
+// canonical-then-legacy, and internal/beads/contract implements exactly that
+// for its siblings; this site predates it. Roots that carry only the canonical
+// key resolve to nothing and their attempts go transient forever.
+func TestResolveRequiredArtifactWorktreePrefersCanonicalWorkDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subject's own canonical key", func(t *testing.T) {
+		store := beads.NewMemStore()
+		worktree := t.TempDir()
+		root := mustCreateWorkflowBead(t, store, beads.Bead{
+			Title:    "workflow",
+			Type:     "task",
+			Metadata: map[string]string{"work_dir": t.TempDir()},
+		})
+		got, _, reason, err := resolveRequiredArtifactPath(store, beads.Bead{
+			Metadata: map[string]string{
+				"gc.root_bead_id": root.ID,
+				"gc.work_dir":     worktree,
+			},
+		}, "synthesis.md")
+		if err != nil || reason != "" {
+			t.Fatalf("resolveRequiredArtifactPath = (%v, %q), want success", err, reason)
+		}
+		if want := filepath.Join(worktree, "synthesis.md"); got != want {
+			t.Errorf("resolved %q, want %q — the subject's canonical gc.work_dir must win", got, want)
+		}
+	})
+
+	t.Run("root's canonical key", func(t *testing.T) {
+		store := beads.NewMemStore()
+		worktree := t.TempDir()
+		root := mustCreateWorkflowBead(t, store, beads.Bead{
+			Title:    "workflow",
+			Type:     "task",
+			Metadata: map[string]string{"gc.work_dir": worktree},
+		})
+		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID)
+		if err != nil || reason != "" {
+			t.Fatalf("resolveRequiredArtifactWorktree = (%v, %q), want success", err, reason)
+		}
+		if got != worktree {
+			t.Errorf("resolved %q, want %q", got, worktree)
+		}
+	})
+
+	t.Run("source bead's canonical key", func(t *testing.T) {
+		store := beads.NewMemStore()
+		worktree := t.TempDir()
+		source := mustCreateWorkflowBead(t, store, beads.Bead{
+			Title:    "source",
+			Type:     "convoy",
+			Metadata: map[string]string{"gc.work_dir": worktree},
+		})
+		root := mustCreateWorkflowBead(t, store, beads.Bead{
+			Title:    "workflow",
+			Type:     "task",
+			Metadata: map[string]string{"gc.source_bead_id": source.ID},
+		})
+		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID)
+		if err != nil || reason != "" {
+			t.Fatalf("resolveRequiredArtifactWorktree = (%v, %q), want success", err, reason)
+		}
+		if got != worktree {
+			t.Errorf("resolved %q, want %q", got, worktree)
+		}
+	})
+
+	t.Run("legacy key still wins when canonical is absent", func(t *testing.T) {
+		// The overwhelming majority of live beads carry only the legacy key;
+		// adding the canonical read must not disturb them.
+		store := beads.NewMemStore()
+		worktree := t.TempDir()
+		root := mustCreateWorkflowBead(t, store, beads.Bead{
+			Title:    "workflow",
+			Type:     "task",
+			Metadata: map[string]string{"work_dir": worktree},
+		})
+		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID)
+		if err != nil || reason != "" {
+			t.Fatalf("resolveRequiredArtifactWorktree = (%v, %q), want success", err, reason)
+		}
+		if got != worktree {
+			t.Errorf("resolved %q, want %q", got, worktree)
+		}
+	})
+}

--- a/internal/formula/ralph.go
+++ b/internal/formula/ralph.go
@@ -99,6 +99,7 @@ func expandRalph(step *Step) ([]*Step, error) {
 	// formula syntax, so they intentionally retain legacy ralph naming.
 	iteration.Metadata = withMetadata(iteration.Metadata, map[string]string{
 		beadmeta.AttemptMetadataKey:     strconv.Itoa(attempt),
+		beadmeta.IterationMetadataKey:   strconv.Itoa(attempt),
 		beadmeta.StepIDMetadataKey:      step.ID,
 		beadmeta.RalphStepIDMetadataKey: step.ID,
 		beadmeta.StepRefMetadataKey:     iterationID,
@@ -145,6 +146,7 @@ func expandNestedRalph(step, control, specStep *Step, iterationID string, attemp
 		beadmeta.StepIDMetadataKey:      step.ID,
 		beadmeta.RalphStepIDMetadataKey: step.ID,
 		beadmeta.AttemptMetadataKey:     strconv.Itoa(attempt),
+		beadmeta.IterationMetadataKey:   strconv.Itoa(attempt),
 		beadmeta.StepRefMetadataKey:     iterationID,
 		// gc.control_for on the scope root only (body children hang off it via
 		// gc.scope_ref and are not attempt roots — they must not be stamped).
@@ -159,6 +161,36 @@ func expandNestedRalph(step, control, specStep *Step, iterationID string, attemp
 	out := []*Step{control, specStep, iteration}
 	out = append(out, flattenedBody...)
 	return out, nil
+}
+
+// RalphBodyChildAttempt answers which attempt of ITSELF a ralph body child is
+// on, which is not the iteration index it sits inside. A body child is a step in
+// its own right, and when it carries a retry control that control's counter
+// starts at 1 and is bounded by the child's own gc.max_attempts. Stamping the
+// outer iteration here makes processRetryEval read N off a child that has run
+// once and spawn attempt N+1, so a step first reached in iteration 3 is born
+// exhausted and hard-fails having never retried. A census of the maintainer-city
+// graph store found 81 of 382 retry beads (21%) at or past their own max,
+// including 10 at attempt 5 against a max of 3 — a value no counter that starts
+// at 1 can reach (ga-v7pu5).
+//
+// Children whose spec already carries an attempt keep it: retry expansion has
+// run by the time a ralph body is namespaced or frozen, so a first attempt bead
+// arrives stamped 1 and its own ref says attempt.1. Fresh nested controls start
+// at 1. Everything else is a plain body step with no counter of its own, where
+// inheriting the iteration is both harmless and long-standing.
+//
+// Both the compile-time expansion (namespaceRalphBodySteps) and the runtime
+// re-spawn (dispatch.buildAttemptRecipe) route through here so iteration 1 and
+// iterations 2+ cannot disagree about what a child's attempt number means.
+func RalphBodyChildAttempt(child *Step, iterationNum int) string {
+	if spec := strings.TrimSpace(child.Metadata[beadmeta.AttemptMetadataKey]); spec != "" {
+		return spec
+	}
+	if child.Retry != nil || child.Ralph != nil {
+		return "1"
+	}
+	return strconv.Itoa(iterationNum)
 }
 
 func collectRalphBodyStepIDs(steps []*Step) map[string]bool {
@@ -206,7 +238,8 @@ func namespaceRalphBodySteps(steps []*Step, iterationID string, owner *Step, att
 				beadmeta.ScopeRoleMetadataKey:   metadataDefault(node.Metadata, beadmeta.ScopeRoleMetadataKey, beadmeta.ScopeRoleMember),
 				beadmeta.StepIDMetadataKey:      childStepID,
 				beadmeta.RalphStepIDMetadataKey: owner.ID,
-				beadmeta.AttemptMetadataKey:     strconv.Itoa(attempt),
+				beadmeta.AttemptMetadataKey:     RalphBodyChildAttempt(node, attempt),
+				beadmeta.IterationMetadataKey:   strconv.Itoa(attempt),
 				beadmeta.StepRefMetadataKey:     clone.ID,
 			}
 			// A nested control's attempt/iteration root carries gc.control_for as

--- a/internal/formula/ralph_iteration_test.go
+++ b/internal/formula/ralph_iteration_test.go
@@ -1,0 +1,132 @@
+package formula
+
+import "testing"
+
+// Iteration 1 is minted here by ApplyRalph; iterations 2+ are minted at runtime
+// by dispatch.buildAttemptRecipe from the frozen spec. Those are two code paths
+// producing beads that downstream consumers — the retry evaluator, the runs
+// view, and the artifact-path resolver — read identically. Every defect in this
+// family is the two paths disagreeing, so the contract worth pinning is that
+// iteration 1 already carries what iterations 2+ carry.
+func TestApplyRalph_IterationOneStampsIterationAndPreservesChildAttempts(t *testing.T) {
+	// The real pipeline order: retries expand on the children first, so ralph
+	// receives a body that already contains a retry control, its spec, and its
+	// first attempt bead.
+	expandedChildren, err := ApplyRetries([]*Step{
+		{
+			ID:    "scorecard",
+			Title: "Scorecard",
+			Retry: &RetrySpec{MaxAttempts: 3, OnExhausted: "hard_fail"},
+		},
+		{
+			ID:    "publish",
+			Title: "Publish",
+			Needs: []string{"scorecard"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRetries: %v", err)
+	}
+
+	got, err := ApplyRalph([]*Step{
+		{
+			ID:    "review-loop",
+			Title: "Review loop",
+			Type:  "task",
+			Ralph: &RalphSpec{
+				MaxAttempts: 3,
+				Check:       &RalphCheckSpec{Mode: "exec", Path: "check.sh"},
+			},
+			Children: expandedChildren,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRalph: %v", err)
+	}
+
+	byID := make(map[string]*Step, len(got))
+	for _, step := range got {
+		byID[step.ID] = step
+	}
+	mustGet := func(t *testing.T, id string) *Step {
+		t.Helper()
+		step, ok := byID[id]
+		if !ok {
+			ids := make([]string, 0, len(got))
+			for _, s := range got {
+				ids = append(ids, s.ID)
+			}
+			t.Fatalf("missing step %q; got %v", id, ids)
+		}
+		return step
+	}
+
+	t.Run("iteration scope and body children record the iteration", func(t *testing.T) {
+		for _, id := range []string{
+			"review-loop.iteration.1",
+			"review-loop.iteration.1.scorecard",
+			"review-loop.iteration.1.scorecard.attempt.1",
+			"review-loop.iteration.1.publish",
+		} {
+			if iteration := mustGet(t, id).Metadata["gc.iteration"]; iteration != "1" {
+				t.Errorf("%s: gc.iteration = %q, want 1", id, iteration)
+			}
+		}
+	})
+
+	t.Run("retry control keeps its own counter", func(t *testing.T) {
+		// Trivially true while iteration 1 is the only compile-time iteration,
+		// since both counters read 1 — but it is the same rule the runtime path
+		// applies at iteration 3, and the two must not drift apart.
+		control := mustGet(t, "review-loop.iteration.1.scorecard")
+		if kind := control.Metadata["gc.kind"]; kind != "retry" {
+			t.Fatalf("gc.kind = %q, want retry — the fixture is not exercising a retry control", kind)
+		}
+		if attempt := control.Metadata["gc.attempt"]; attempt != "1" {
+			t.Errorf("retry control gc.attempt = %q, want 1", attempt)
+		}
+		if attempt := mustGet(t, "review-loop.iteration.1.scorecard.attempt.1").Metadata["gc.attempt"]; attempt != "1" {
+			t.Errorf("first attempt gc.attempt = %q, want 1", attempt)
+		}
+	})
+}
+
+// TestRalphBodyChildAttempt pins the shared rule directly, at the iteration
+// numbers the compile-time path can never reach. dispatch.buildAttemptRecipe
+// calls this for every ralph body child on iterations 2+, which is where the
+// two counters actually diverge.
+func TestRalphBodyChildAttempt(t *testing.T) {
+	tests := []struct {
+		name  string
+		child *Step
+		want  string
+	}{
+		{
+			name:  "retry control starts its own counter",
+			child: &Step{ID: "scorecard", Retry: &RetrySpec{MaxAttempts: 3}},
+			want:  "1",
+		},
+		{
+			name:  "nested ralph control starts its own counter",
+			child: &Step{ID: "inner", Ralph: &RalphSpec{MaxAttempts: 3}},
+			want:  "1",
+		},
+		{
+			name:  "expanded attempt keeps the attempt its spec carries",
+			child: &Step{ID: "scorecard.attempt.1", Metadata: map[string]string{"gc.attempt": "1"}},
+			want:  "1",
+		},
+		{
+			name:  "plain body step inherits the iteration",
+			child: &Step{ID: "publish"},
+			want:  "4",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RalphBodyChildAttempt(tc.child, 4); got != tc.want {
+				t.Errorf("RalphBodyChildAttempt(%s, 4) = %q, want %q", tc.child.ID, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes `ga-v7pu5` and `ga-la0py`.

## The defect

`gc.attempt` is one metadata key serving **two independent counters**: the ralph *iteration* index and a step's own *retry attempt* index. The ralph expansion overwrites the second with the first.

That is not cosmetic. `processRetryEval` reads `gc.attempt` off a child and computes `nextAttempt = attempt + 1`, so a child first run in iteration N is **born at attempt N** against its own `max_attempts`. By iteration 3 it is exhausted before it runs and hard-fails having never retried.

Census of the maintainer-city graph store:

- **81 of 382** retry-kind beads (21%) born at or past their own max — 40 at attempt 4 and 10 at attempt 5 against a max of 3, values a counter starting at 1 can never reach
- **177 beads** whose `gc.step_ref` literally ends in `.attempt.1` while `gc.attempt` claims 2–5
- All **2086** ralph-iteration beads storewide came from the recipe path (`buildAttemptRecipe`); zero carry `gc.retry_from`, so the clone path has never run here

## Commit 1 — split the counters

`gc.iteration` has existed in `beadmeta` since the runs view started reading it (`internal/runproj/detail_nodeshape.go:33`) but **nothing ever wrote it**. It does now.

`RalphBodyChildAttempt` decides what a body child's attempt number means: a child whose spec already carries one keeps it, a child owning a retry/ralph control starts at 1, and a plain body step still inherits the iteration. Both the compile-time expansion and the runtime re-spawn route through it, so iteration 1 and iterations 2+ cannot disagree.

**This also had to complete S38.** `controlIdentitySet` included the control's *bare* `gc.step_id`, which names the same inner control in **every** outer iteration. Only `max(gc.attempt)` kept them apart — and that ordering existed *only because* the iteration index was being stamped as the attempt number. Splitting the counters removes that accidental tiebreaker, so identity is now ranked explicitly: precise (`bead ID`, `gc.step_ref`) outranks bare (`gc.step_id`), with the infrastructure filter applied *before* the ranking so a scope-check can't starve a real attempt root of its fallback.

## Commit 2 — give the artifact gate an `{iteration}` placeholder

The gate resolved `{attempt}` from the same conflated key, making it **structurally incapable** of catching the mismatch: it computed the same wrong directory the failing step computed, agreed with it, and passed.

The gate is **live, not inert** — 471 of 542 template-carrying beads (87%) do resolve a worktree, and the "root not resolvable in this store" bucket is **zero**. A gate pointed at a directory nobody wrote turns passing attempts into burned retries.

Also fixes the worktree read: three sites read only the legacy `work_dir`, never canonical `gc.work_dir`. `beadmeta` documents this family's contract as canonical-then-legacy and `internal/beads/contract` implements exactly that for the siblings; this site predates both.

A **missing** `gc.iteration` deliberately fails loud via the existing `unresolved_required_artifact_template` check. Substituting empty would build `attempt-/` and the gate would then report `missing_required_artifact` — blaming the step for the resolver's own gap.

## Deploy order — this does NOT ship alone

**`gastownhall/workflows#35` must merge first.** The adopt-pr gate scripts join sibling beads on `gc.attempt`, and `apply-fixes` declares `steps.children.retry max_attempts = 3`. After the split its beads carry their own retry counter, `load_verdict` matches nothing, returns `"iterate"`, and the ralph loop **never approves** — an infinite review loop. That PR is a strict no-op against today's binary, so it can and should land first.

Then: deploy this binary. *Then* switch `attempt-{attempt}` → `attempt-{iteration}` in `formulas/expansion-review-pr.toml` — never before, or an older binary leaves `{iteration}` unresolved and sends every attempt transient forever.

## Tests

TDD throughout; every assertion was seen RED first. New: `internal/dispatch/control_attempt_iteration_test.go`, `internal/dispatch/retry_artifact_iteration_test.go`, `internal/formula/ralph_iteration_test.go`.

`go build ./...`, `go vet` clean; `internal/{dispatch,formula,molecule,runproj}` green; pre-commit lint 0 issues.

> **Note on CI:** `TestCatalogMatchesProductionWiringAndDocumentation` is red repo-wide today — the `ga-80po0c.3` provider waivers expired 2026-08-26. Proven pre-existing against a pristine base with a clean `git status`. Fixed separately in `fix/renew-runtime-provider-waivers`.

## Known dormant twin

`appendRalphRetry` has the same conflation and would carry a stale `gc.iteration` through `cloneMetadata`. Proven dormant (zero `gc.kind=check` and zero `gc.retry_from` beads storewide), so it is filed as `ga-4dt92` (P3) rather than expanded into a verified commit as untestable speculative work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)