### PR TITLE
fix(cmd/gc): converge every CLI by-id surface on the residency resolver's plan

### DIFF
--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/splittest"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/gastownhall/gascity/internal/storeref/storereftest"
 )
 
@@ -297,9 +300,112 @@ func TestBindingOwnerLeavesTheWorkResidualUnprobed(t *testing.T) {
 		t.Errorf("a city that relocates nothing reported a binding owner %p", owner.Store)
 	}
 
-	if _, err := (unprobedWorkResidual{}).Get("gc-1"); err == nil {
+	residual := newUnprobedWorkResidual()
+	got, err := residual.Get("gc-1")
+	if err == nil {
 		t.Error("the residual placeholder answered a Get; it must report the contract violation instead of a miss")
 	}
+	if !strings.Contains(err.Error(), "gc-1") {
+		t.Errorf("the residual's Get refusal reads %v, want the probed id named", err)
+	}
+	_ = got
+
+	// Get is the method the resolver reaches for, so it is the one with a
+	// bespoke message — but a leg role that called anything else must not get a
+	// nil-pointer panic, and must not get a clean empty answer either.
+	if _, err := residual.List(beads.ListQuery{}); !errors.Is(err, errWorkResidualProbed) {
+		t.Errorf("the residual answered List with err=%v, want the contract violation — an empty list here reads as absence", err)
+	}
+	if err := residual.Close("gc-1"); !errors.Is(err, errWorkResidualProbed) {
+		t.Errorf("the residual answered Close with err=%v, want the contract violation", err)
+	}
+	if _, err := residual.Create(beads.Bead{Title: "written through a placeholder"}); !errors.Is(err, errWorkResidualProbed) {
+		t.Errorf("the residual answered Create with err=%v, want the contract violation", err)
+	}
+}
+
+// TestConvoyResolutionStillRefusesAnIdTwoLedgersBothHold covers the rule the
+// binding short-circuit steps around, which until now nothing asserted anywhere
+// in the tree.
+//
+// The claim "dual residency is not ambiguity" only means something if ambiguity
+// is still refused when it is real. Two candidate stores holding the same id
+// with no binding in play is two ledgers disagreeing by accident, and the scan
+// must say so rather than resolve to whichever candidate it enumerated first —
+// the close that followed would write the loser.
+func TestConvoyResolutionStillRefusesAnIdTwoLedgersBothHold(t *testing.T) {
+	cityPath := t.TempDir()
+	seedCLIStorageRoutes(t, cityPath, &storageRoutes{stores: map[coordclass.Class]beads.Store{}})
+	cfg := &config.City{Rigs: []config.Rig{{Name: "alpha", Path: filepath.Join(cityPath, "rigs", "alpha")}}}
+
+	byDir := map[string]beads.Store{}
+	openStore := func(dir string) (beads.Store, error) {
+		if store, ok := byDir[dir]; ok {
+			return store, nil
+		}
+		store := splittest.NewWorkStore(t, "hq")
+		if _, err := store.Create(beads.Bead{Title: "a copy in " + dir, Type: "task"}); err != nil {
+			t.Fatalf("seeding the candidate at %s: %v", dir, err)
+		}
+		byDir[dir] = store
+		return store, nil
+	}
+
+	if len(convoyStoreCandidates(cfg, cityPath, "hq-1")) < 2 {
+		t.Fatalf("the fixture offers %d candidate store(s); a uniqueness refusal needs at least two", len(convoyStoreCandidates(cfg, cityPath, "hq-1")))
+	}
+	_, _, err := resolveOwningStoreDir("hq-1", cfg, cityPath, openStore)
+	if err == nil {
+		t.Fatal("an id two candidate stores both hold resolved cleanly; the scan's uniqueness rule is gone and the close would write whichever store enumerated last")
+	}
+	if !strings.Contains(err.Error(), "uniquely addressable") {
+		t.Errorf("the refusal reads %v, want the uniqueness contract named", err)
+	}
+}
+
+// TestBeadForOwnerDoesNotReReadAProbedLeg pins the reason Owner carries a bead
+// at all.
+//
+// A leg the resolver actually probed has already paid for the read, and the
+// answer it returns IS that read. Fetching it again is not merely wasteful: it
+// opens a window in which the second read disagrees with the one the resolver
+// made its ownership decision from.
+func TestBeadForOwnerDoesNotReReadAProbedLeg(t *testing.T) {
+	counted := &countingGetStore{Store: splittest.NewWorkStore(t, "hq")}
+	seeded, err := counted.Create(beads.Bead{Title: "the probed answer", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the counted store: %v", err)
+	}
+
+	got, err := beadForOwner(storeref.Owner{Store: counted, Bead: seeded, Read: true}, seeded.ID)
+	if err != nil {
+		t.Fatalf("reading a probed owner: %v", err)
+	}
+	if got.Title != "the probed answer" {
+		t.Errorf("a probed owner served %q, want the bead the resolver already read", got.Title)
+	}
+	if counted.gets != 0 {
+		t.Errorf("a probed owner cost %d further Get(s), want 0 — the leg's read is the caller's read", counted.gets)
+	}
+
+	if _, err := beadForOwner(storeref.Owner{Store: counted}, seeded.ID); err != nil {
+		t.Fatalf("reading an unprobed owner: %v", err)
+	}
+	if counted.gets != 1 {
+		t.Errorf("an unprobed owner cost %d Get(s), want exactly 1", counted.gets)
+	}
+}
+
+// countingGetStore counts the reads a caller makes of its own accord, so a test
+// can tell a served answer from a re-fetched one.
+type countingGetStore struct {
+	beads.Store
+	gets int
+}
+
+func (s *countingGetStore) Get(id string) (beads.Bead, error) {
+	s.gets++
+	return s.Store.Get(id)
 }
 
 // resetAutocloseFaultOnce lets a test observe the once-per-process warning more

--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -416,3 +416,86 @@ func resetAutocloseFaultOnce(t *testing.T) {
 	autocloseFaultOnce = sync.Once{}
 	t.Cleanup(func() { autocloseFaultOnce = sync.Once{} })
 }
+
+// TestByIDPlanUsesTheRegisteredControllerRoutes pins which routes the by-id
+// seam plans over.
+//
+// This resolver is not one-shot-only. A controller reaches it in-process —
+// order dispatch's emit store resolves a molecule root through
+// autocloseOwningStore, which lands in resolveOwningStoreDir — and a plan built
+// from the one-shot funnel inside a process that already opened its binding at
+// boot would open a SECOND handle on the same binding root: a duplicate
+// managed-Dolt server or a second sqlite writer. residencyTopologyForCity
+// exists to prevent exactly that, and this asserts the seam uses it.
+//
+// The funnel is seeded with an errStore rather than merely a different store,
+// so a plan that took the wrong routes FAILS rather than quietly answering from
+// the wrong handle. The second row is the one-shot fallback: with no
+// registration the funnel must still be what answers, or every genuine one-shot
+// command loses its binding leg.
+func TestByIDPlanUsesTheRegisteredControllerRoutes(t *testing.T) {
+	funnelFault := errors.New("the one-shot funnel opened a second handle")
+
+	tests := []struct {
+		name     string
+		register bool
+	}{
+		{name: "a registered controller's routes win over the funnel", register: true},
+		{name: "a one-shot command still falls through to the funnel", register: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+
+			var wantStore beads.Store
+			if tt.register {
+				// Seeded FIRST: registerResidencyRoutes drops the derived
+				// per-city binding memo, so the registration is what a later
+				// resolution re-reads.
+				seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(errStore{err: funnelFault}))
+				registered := splittest.NewWorkStore(t, "hq")
+				routes := messagingSplitRoutes(registered)
+				registerResidencyRoutes(cityPath, routes, func() beads.Store { return registered })
+				t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+				wantStore = registered
+			} else {
+				funnel := splittest.NewWorkStore(t, "hq")
+				seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(funnel))
+				wantStore = funnel
+			}
+
+			resident, err := wantStore.Create(beads.Bead{Title: "the binding's copy", Type: "task"})
+			if err != nil {
+				t.Fatalf("seeding the binding that should answer: %v", err)
+			}
+
+			owner, ok, err := cliByIDBindingOwner(cityPath, resident.ID)
+			if err != nil {
+				t.Fatalf("resolving %s: %v — a fault here is the funnel's binding answering, which means a second handle on the binding root", resident.ID, err)
+			}
+			if !ok {
+				t.Fatalf("no binding owned %s; the plan carried no binding leg at all", resident.ID)
+			}
+			if owner.Store != wantStore {
+				t.Errorf("the by-id plan resolved %s through %p, want %p", resident.ID, owner.Store, wantStore)
+			}
+
+			// The production caller, with a scan that fails the test if it runs:
+			// a binding hit must return before the directory scan, so the funnel
+			// is never reached by this arm either.
+			store, dir, err := resolveOwningStoreDir(resident.ID, nil, cityPath, func(storeDir string) (beads.Store, error) {
+				t.Errorf("the convoy scan opened %q for an id the binding owns", storeDir)
+				return nil, errors.New("the scan must not run for a binding hit")
+			})
+			if err != nil {
+				t.Fatalf("resolveOwningStoreDir(%s): %v", resident.ID, err)
+			}
+			if store != wantStore {
+				t.Errorf("the convoy resolver served %s from %p, want the binding %p", resident.ID, store, wantStore)
+			}
+			if dir != cityPath {
+				t.Errorf("the convoy resolver reported dir %q, want the city path %q", dir, cityPath)
+			}
+		})
+	}
+}

--- a/cmd/gc/by_id_binding_owner_test.go
+++ b/cmd/gc/by_id_binding_owner_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/storeref/storereftest"
+)
+
+// convoyCityConfig loads the city config the convoy resolver takes, so a test
+// can call resolveOwningStoreDir the way its production callers do.
+func convoyCityConfig(t *testing.T, cityPath string) *config.City {
+	t.Helper()
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading the city config at %s: %v", cityPath, err)
+	}
+	return cfg
+}
+
+// resolveThroughTheConvoyScan is the convoy arm's by-id resolution, as its
+// callers reach it.
+func resolveThroughTheConvoyScan(t *testing.T, cityPath, id string) (beads.Store, string) {
+	t.Helper()
+	store, dir, err := resolveOwningStoreDir(id, convoyCityConfig(t, cityPath), cityPath, func(storeDir string) (beads.Store, error) {
+		return openStoreAtForCity(storeDir, cityPath)
+	})
+	if err != nil {
+		t.Fatalf("resolving the store that owns %s: %v", id, err)
+	}
+	return store, dir
+}
+
+// TestConvoyResolutionServesTheBindingCopy adds the convoy arm to the
+// cross-plane binding-wins property.
+//
+// This is the arm the property was missing, and it is missing for a structural
+// reason rather than an oversight: the convoy resolver's work axis is a scan of
+// the city's DIRECTORIES, and a relocated class binding is not one of them. So
+// before the binding leg went in front, an infrastructure bead here was not
+// merely unrouted — it was answered, successfully, by the copy `gc storage
+// migrate` retained in the city store, and the close that followed wrote
+// through it.
+func TestConvoyResolutionServesTheBindingCopy(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	shadow, err := work.Create(beads.Bead{Title: "the retained work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	resident := classResidentWorkShapedBead(t, classStore, shadow.ID, "the class-binding copy")
+	control, err := work.Create(beads.Bead{Title: "a work bead the binding never held", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the control: %v", err)
+	}
+
+	storereftest.RunBindingWins(t,
+		storereftest.BindingWinsStores{
+			Binding:       classStore,
+			Work:          work,
+			DualID:        resident.ID,
+			BindingTitle:  "the class-binding copy",
+			WorkOnlyID:    control.ID,
+			WorkOnlyTitle: "a work bead the binding never held",
+		},
+		storereftest.BindingWinsSurface{
+			Name: "the gc convoy by-id resolver",
+			Get: func(t *testing.T, id string) beads.Bead {
+				t.Helper()
+				store, _ := resolveThroughTheConvoyScan(t, cityPath, id)
+				b, err := store.Get(id)
+				if err != nil {
+					t.Fatalf("reading %s from the resolved store: %v", id, err)
+				}
+				return b
+			},
+			Close: func(t *testing.T, id string) {
+				t.Helper()
+				store, _ := resolveThroughTheConvoyScan(t, cityPath, id)
+				if err := store.Close(id); err != nil {
+					t.Fatalf("closing %s through the resolved store: %v", id, err)
+				}
+			},
+		})
+}
+
+// TestConvoyResolutionReportsTheCityDirForABindingHit pins the store-ref
+// argument the resolver's doc makes.
+//
+// The directory this returns is mapped to a store-ref that scopes molecule-root
+// lookups. A relocated bead lived in the city store and carried the city's ref
+// before the migration moved it, and a binding is not a rig and has no ref of
+// its own — so reporting anything but the city path here would strand every
+// root recorded before the move.
+func TestConvoyResolutionReportsTheCityDirForABindingHit(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	resident := classResidentWorkShapedBead(t, classStore, "gc-relic1", "a relocated patrol root")
+
+	store, dir := resolveThroughTheConvoyScan(t, cityPath, resident.ID)
+	if store != classStore {
+		t.Errorf("the convoy resolver returned %p for %s, want the class binding %p", store, resident.ID, classStore)
+	}
+	if dir != cityPath {
+		t.Errorf("the convoy resolver reported dir %q for a binding hit, want the city path %q — the store-ref these beads carried before the migration is the city's", dir, cityPath)
+	}
+}
+
+// TestConvoyResolutionDoesNotRefuseDualResidenceAsAmbiguous is the deliberate
+// short-circuit, asserted.
+//
+// The scan REFUSES an id present in more than one candidate store, which is
+// right when two ledgers disagree by accident. Dual residency is not that: the
+// migration copies with ids preserved and deletes nothing, so a relocated bead
+// is supposed to exist twice and has a known winner. A resolver that reached
+// the uniqueness rule here would refuse every convoy command on exactly the
+// cities that finished migrating.
+func TestConvoyResolutionDoesNotRefuseDualResidenceAsAmbiguous(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	shadow, err := work.Create(beads.Bead{Title: "the retained work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	resident := classResidentWorkShapedBead(t, classStore, shadow.ID, "the class-binding copy")
+
+	store, _, err := resolveOwningStoreDir(resident.ID, convoyCityConfig(t, cityPath), cityPath, func(storeDir string) (beads.Store, error) {
+		return openStoreAtForCity(storeDir, cityPath)
+	})
+	if err != nil {
+		t.Fatalf("a dual-resident id resolved to %v; dual residency is the migration working, not two ledgers disagreeing", err)
+	}
+	if store != classStore {
+		t.Errorf("a dual-resident id resolved %p, want the class binding %p", store, classStore)
+	}
+}
+
+// TestConvoyResolutionUnchangedOnACityThatRelocatesNothing is the compatibility
+// row. A city with no [storage] binding plans no binding leg, so the scan runs
+// exactly as it did — including its uniqueness refusal, which the binding
+// short-circuit must not have disarmed for everyone.
+func TestConvoyResolutionUnchangedOnACityThatRelocatesNothing(t *testing.T) {
+	cityPath := oneShotCLICity(t, "")
+	refuseInfraMigrationSource(t)
+	captureCLIStorageStderr(t)
+	work := workStoreFor(t, cityPath)
+	bead, err := work.Create(beads.Bead{Title: "an ordinary work bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+
+	store, dir := resolveThroughTheConvoyScan(t, cityPath, bead.ID)
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("reading %s back: %v", bead.ID, err)
+	}
+	if got.Title != "an ordinary work bead" {
+		t.Errorf("the scan served %q, want the work copy", got.Title)
+	}
+	if dir != cityPath {
+		t.Errorf("the scan reported dir %q, want %q", dir, cityPath)
+	}
+
+	if _, _, err := resolveOwningStoreDir("gc-nothing-here", convoyCityConfig(t, cityPath), cityPath, func(storeDir string) (beads.Store, error) {
+		return openStoreAtForCity(storeDir, cityPath)
+	}); !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("an absent id resolved to %v, want beads.ErrNotFound — the scan's own miss shape", err)
+	}
+}
+
+// TestConvoyResolutionSurfacesABindingFaultRatherThanAbsence is the
+// classification the whole lane exists for, on this arm. A binding that cannot
+// answer must not degrade into a scan of the ledger that holds the stale copy:
+// that turns "I could not read the owner" into "the owner is the work store",
+// and the write that follows lands where nothing reads.
+func TestConvoyResolutionSurfacesABindingFaultRatherThanAbsence(t *testing.T) {
+	cityPath := t.TempDir()
+	boom := errors.New("binding unreachable")
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(errStore{err: boom}))
+
+	_, _, err := resolveOwningStoreDir("hq-1", nil, cityPath, func(string) (beads.Store, error) {
+		return splittest.NewWorkStore(t, "hq"), nil
+	})
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("an unreadable binding resolved to err=%v, want the read failure", err)
+	}
+}
+
+// TestAutocloseOwningStoreAnnouncesAFaultOnce pins the loud-skip.
+//
+// bd's on_close must not fail because a root could not be resolved, so this
+// path swallows every error and falls back to the cwd-rooted store. That is
+// right for absence and wrong for a fault, and the difference is invisible
+// unless it is said out loud — but only once, because bd closes beads in bursts
+// and a repeated line buries the log it wants to be seen in.
+func TestAutocloseOwningStoreAnnouncesAFaultOnce(t *testing.T) {
+	resetAutocloseFaultOnce(t)
+	cityPath, _ := foreignProviderCity(t)
+	sink := captureCLIStorageStderr(t)
+	failClassBindingReads(t, cityPath, errors.New("the class binding is having a bad day"))
+
+	for range 2 {
+		if store, _, ok := autocloseOwningStore("hq-1", cityPath); ok {
+			t.Fatalf("a failing binding resolved to %p; the fault must not be answered by the work ledger", store)
+		}
+	}
+
+	warnings := bytes.Count(sink.Bytes(), []byte("gc autoclose: resolving the store that owns"))
+	if warnings != 1 {
+		t.Errorf("the fault was announced %d times over two closes, want exactly 1: %s", warnings, sink.String())
+	}
+	if !bytes.Contains(sink.Bytes(), []byte("bad day")) {
+		t.Errorf("the announcement does not carry the store's own cause: %s", sink.String())
+	}
+}
+
+// TestAutocloseOwningStoreStaysQuietOnAbsence is the control for the test
+// above. Absence is the ordinary case — most closed beads are not molecule
+// members — and announcing it would make the warning meaningless.
+func TestAutocloseOwningStoreStaysQuietOnAbsence(t *testing.T) {
+	resetAutocloseFaultOnce(t)
+	cityPath, _ := foreignProviderCity(t)
+	sink := captureCLIStorageStderr(t)
+
+	if store, _, ok := autocloseOwningStore("hq-nothing-here", cityPath); ok {
+		t.Fatalf("an absent id resolved to %p", store)
+	}
+	if bytes.Contains(sink.Bytes(), []byte("gc autoclose:")) {
+		t.Errorf("absence was announced as a fault: %s", sink.String())
+	}
+}
+
+// TestBeadsShowFallbackServesTheBindingCopy is the read half on the `gc beads
+// show` arm: the same scan, taking the first hit rather than refusing a second
+// one, and the same retained copy standing in front of the live one.
+func TestBeadsShowFallbackServesTheBindingCopy(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	shadow, err := work.Create(beads.Bead{Title: "the retained work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	resident := classResidentWorkShapedBead(t, classStore, shadow.ID, "the class-binding copy")
+
+	var stdout, stderr bytes.Buffer
+	if code := doBeadsShowFallback(cityPath, resident.ID, "json", &stdout, &stderr); code != 0 {
+		t.Fatalf("gc beads show %s exited %d: %s", resident.ID, code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("the class-binding copy")) {
+		t.Errorf("gc beads show served %s, want the binding's copy — the work store's is frozen at migration time", stdout.String())
+	}
+}
+
+// TestBeadsShowFallbackScansForAnIdNoBindingHolds is the control: an id the
+// binding never held is still served by the scan, which is what makes this
+// about residence rather than about the binding winning everything.
+func TestBeadsShowFallbackScansForAnIdNoBindingHolds(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	work := workStoreFor(t, cityPath)
+	bead, err := work.Create(beads.Bead{Title: "a work bead the binding never held", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doBeadsShowFallback(cityPath, bead.ID, "json", &stdout, &stderr); code != 0 {
+		t.Fatalf("gc beads show %s exited %d: %s", bead.ID, code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("a work bead the binding never held")) {
+		t.Errorf("gc beads show served %s, want the work copy", stdout.String())
+	}
+}
+
+// TestBindingOwnerLeavesTheWorkResidualUnprobed is the sentinel's contract.
+//
+// cliByIDBindingOwner hands the plan a placeholder where the work leg goes,
+// because this arm's work axis is a directory scan the resolver must not run.
+// That is safe only while the residual is returned UNPROBED, so the placeholder
+// reports being read as an internal error — and a clean ok=false here is the
+// proof it was not.
+func TestBindingOwnerLeavesTheWorkResidualUnprobed(t *testing.T) {
+	cityPath := oneShotCLICity(t, "")
+	refuseInfraMigrationSource(t)
+	captureCLIStorageStderr(t)
+
+	owner, ok, err := cliByIDBindingOwner(cityPath, "gc-1")
+	if err != nil {
+		t.Fatalf("a city that relocates nothing resolved to err=%v; the residual must come back unprobed, not read", err)
+	}
+	if ok {
+		t.Errorf("a city that relocates nothing reported a binding owner %p", owner.Store)
+	}
+
+	if _, err := (unprobedWorkResidual{}).Get("gc-1"); err == nil {
+		t.Error("the residual placeholder answered a Get; it must report the contract violation instead of a miss")
+	}
+}
+
+// resetAutocloseFaultOnce lets a test observe the once-per-process warning more
+// than once per test binary, and leaves the gate closed again afterwards so an
+// unrelated test cannot inherit a spent one.
+func resetAutocloseFaultOnce(t *testing.T) {
+	t.Helper()
+	autocloseFaultOnce = sync.Once{}
+	t.Cleanup(func() { autocloseFaultOnce = sync.Once{} })
+}

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -1,0 +1,94 @@
+package main
+
+// The one-shot CLI's by-id residency seam.
+//
+// Every one-shot command that holds a bead id and a work store asks the same
+// question — "which store actually holds this bead?" — and before the residency
+// resolver each asked it in its own words. That is the split-store bug class
+// (#5125, #5127): the ordering, the identity gate, the namespace rule and the
+// failure classification are four clauses, and every restatement is a chance to
+// get one of them wrong.
+//
+// # The plane keeps its work axis; the resolver owns the binding legs
+//
+// The CLI's structural difference from internal/api is that its work axis is
+// often not a beads.Store at all: `gc bd`'s fall-through is a bd subprocess,
+// and the convoy surface's is a directory scan with a uniqueness contract of
+// its own. So this seam does not try to own the work half. It hands the plan a
+// work leg and reads back storeref's residual contract: the LAST
+// RoleWorkFallback leg is returned UNPROBED, which means "no binding answered —
+// run your own work axis". A caller whose work axis IS a store passes that
+// store and uses the answer directly; a caller whose work axis is a subprocess
+// or a scan passes a sentinel and treats it as the signal to fall through.
+//
+// That residual is also what keeps a single-store city byte-identical: its plan
+// has one leg, nothing is probed, and the caller gets back the exact store value
+// it passed in — so every optional-capability type assertion it already made
+// keeps holding, and it never pays for the funnel.
+
+import (
+	"errors"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// cliByIDOwner resolves id over the city's relocated class bindings and the
+// caller's own work leg, returning the row a winning binding probe already read.
+//
+// The plan is Plan(ByID) over a topology of {bindings: cliResidencyBindings,
+// work: the caller's leg} with NO rig legs. That absence is deliberate and is
+// the pre-resolver behavior preserved: none of these call sites ever read the
+// rig stores, and a caller that starts reading them here would silently change
+// which beads its command is about. storeref carries rigs as Shadows for the
+// surfaces that already hold them open (internal/api's by-id resolver); this one
+// passes none, and an empty Shadows list is what keeps the probe order the
+// [binding, work] the pre-seam list used.
+//
+// cfg is nil for the same reason the legacy route never loaded one: the only
+// thing a City would contribute here is the work and rig id prefixes, which
+// decide SHADOWING — and with no rig legs there is nothing to shadow.
+//
+// An error is a read that FAILED, never absence. Reading "the binding could not
+// answer" as "the bead is not there" is the root-loss shape this lane exists to
+// prevent. The one error that is not a fault is the one-shot funnel's standing
+// refusal: it is a verdict about a CITY's storage configuration and says nothing
+// about a bead, and a refused city still serves WORK from its work ledger. The
+// resolver applies that distinction from the leg's own role — a residence probe
+// for an id no relocated class could own tolerates the refusal, while the
+// authority leg for an id inside a reserved namespace surfaces it, because there
+// the refusal IS the answer.
+func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error) {
+	plan, err := cliByIDPlan(cityPath, id, work)
+	if err != nil {
+		return storeref.Owner{}, err
+	}
+	owner, err := storeref.ResolveOwnerRow(plan, id)
+	switch {
+	case err == nil:
+		return owner, nil
+	case errors.Is(err, beads.ErrNotFound):
+		// The second miss shape: every leg cleanly missed and the plan had no
+		// work residual to hand back. With no rig legs and no routed work axis
+		// this topology reaches it exactly one way — a city whose binding
+		// resolved back to the caller's own work store, which dedupeLegs folds
+		// into a single probed leg. Then "not found in the binding" and "not
+		// found in work" are the same sentence about the same store, and the
+		// work leg is the honest answer: the caller reads through it and its own
+		// Get produces its own error message, which is the pre-seam behavior.
+		return storeref.Owner{Store: work, Ref: storeref.WorkRef}, nil
+	default:
+		return storeref.Owner{}, err
+	}
+}
+
+// cliByIDPlan builds the leg list cliByIDOwner probes.
+//
+// Split out so the before/after order pin
+// (TestClassRoutedStoreForIDKeepsThePreSeamCandidateOrder) reads the plan this
+// seam actually executes rather than one assembled the same way beside it. A
+// pin over a parallel construction proves the topology constructor is right and
+// says nothing about whether the seam still uses it.
+func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, error) {
+	return storeref.Plan(storeref.ByID{ID: id}, cliResidencyTopology(cityPath, nil, work, nil))
+}

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -85,13 +85,22 @@ func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error)
 
 // cliByIDPlan builds the leg list cliByIDOwner probes.
 //
+// The bindings come from residencyTopologyForCity, so a plan built INSIDE a
+// running controller prefers the routes that controller registered at boot and
+// only a genuine one-shot command falls through to the funnel. That preference
+// is not a tidiness: this seam is reachable in-process — order dispatch reaches
+// it through the autoclose owner resolution — and resolving a controller's
+// bindings through the one-shot funnel would open a SECOND handle on the same
+// binding root, a duplicate managed-Dolt server or a second sqlite writer,
+// which is the reason residencyTopologyForCity exists and documents.
+//
 // Split out so the before/after order pin
 // (TestClassRoutedStoreForIDKeepsThePreSeamCandidateOrder) reads the plan this
 // seam actually executes rather than one assembled the same way beside it. A
 // pin over a parallel construction proves the topology constructor is right and
 // says nothing about whether the seam still uses it.
 func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, error) {
-	return storeref.Plan(storeref.ByID{ID: id}, cliResidencyTopology(cityPath, nil, work, nil))
+	return storeref.Plan(storeref.ByID{ID: id}, residencyTopologyForCity(cityPath, nil, work, nil))
 }
 
 // cliByIDBindingOwner answers the binding half of the by-id question for a

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -111,7 +111,7 @@ func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, 
 // row it already read; ok=false is "no binding answered, run your own scan",
 // and the caller then does exactly what it did before.
 func cliByIDBindingOwner(cityPath, id string) (storeref.Owner, bool, error) {
-	owner, err := cliByIDOwner(cityPath, id, unprobedWorkResidual{})
+	owner, err := cliByIDOwner(cityPath, id, newUnprobedWorkResidual())
 	if err != nil {
 		return storeref.Owner{}, false, err
 	}
@@ -139,9 +139,32 @@ func beadForOwner(owner storeref.Owner, id string) (beads.Bead, error) {
 // resolver that started probing the residual would otherwise turn "the caller
 // runs its own scan" into "the bead is absent", silently, on every convoy
 // command of every relocated city.
-type unprobedWorkResidual struct{ beads.Store }
+//
+// It refuses through a WHOLE beads.Store rather than an embedded nil one, for
+// the reason refusedClassStore already carries: a nil embedded interface makes
+// every method this file does not override a nil-pointer panic naming a line of
+// runtime.go, and the one method that must never be reached is exactly the one
+// least likely to be the first a future leg role calls. Get is overridden only
+// to name the id in the message; every other operation reports the same
+// violation.
+type unprobedWorkResidual struct{ refusedClassStore }
 
-// Get reports the contract violation described on the type.
+// errWorkResidualProbed is what every residual operation but Get reports.
+var errWorkResidualProbed = errors.New("internal: the by-id work residual was operated on; it is a placeholder for a work axis this surface runs itself")
+
+// newUnprobedWorkResidual builds the sentinel with its refusal armed.
+//
+// The zero value would embed a refusedClassStore with a nil error, and a
+// refusing store that returns nil is worse than one that panics: List would
+// answer "no beads" and the caller would read the residual as absence, which is
+// the exact confusion this type exists to prevent. Both construction sites go
+// through here so no zero value is ever in play.
+func newUnprobedWorkResidual() unprobedWorkResidual {
+	return unprobedWorkResidual{refusedClassStore{err: errWorkResidualProbed}}
+}
+
+// Get reports the contract violation described on the type, naming the id the
+// resolver reached for.
 func (unprobedWorkResidual) Get(id string) (beads.Bead, error) {
-	return beads.Bead{}, fmt.Errorf("internal: the by-id work residual was probed for %s; it is a placeholder for a work axis this surface runs itself", id)
+	return beads.Bead{}, fmt.Errorf("%w: probed for %s", errWorkResidualProbed, id)
 }

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -28,6 +28,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/storeref"
@@ -91,4 +92,56 @@ func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error)
 // says nothing about whether the seam still uses it.
 func cliByIDPlan(cityPath, id string, work beads.Store) (storeref.ResolvedPlan, error) {
 	return storeref.Plan(storeref.ByID{ID: id}, cliResidencyTopology(cityPath, nil, work, nil))
+}
+
+// cliByIDBindingOwner answers the binding half of the by-id question for a
+// surface whose work axis is not a beads.Store.
+//
+// `gc convoy`'s resolution is a directory scan with a uniqueness contract — it
+// probes every candidate and REFUSES an id present in more than one — and `gc
+// beads show`'s is the same scan taking the first hit. Neither is expressible
+// as a leg, and neither should be: the scan is what those commands are. What
+// they were missing is the leg in FRONT of it. A relocated class binding is not
+// one of the city's directories, so a directory scan cannot reach it at all,
+// and the id it cannot reach is answered instead by the retained pre-migration
+// copy sitting in the city store — successfully, with no error to notice.
+//
+// So the plan is resolved with a SENTINEL where the work leg goes and the
+// answer is read as a yes/no. ok=true is a binding that owns the id, with the
+// row it already read; ok=false is "no binding answered, run your own scan",
+// and the caller then does exactly what it did before.
+func cliByIDBindingOwner(cityPath, id string) (storeref.Owner, bool, error) {
+	owner, err := cliByIDOwner(cityPath, id, unprobedWorkResidual{})
+	if err != nil {
+		return storeref.Owner{}, false, err
+	}
+	if _, isResidual := owner.Store.(unprobedWorkResidual); isResidual {
+		return storeref.Owner{}, false, nil
+	}
+	return owner, true, nil
+}
+
+// beadForOwner returns the row the owner names, reading it only when the
+// resolver has not already. A probed leg's read IS the caller's read, and doing
+// it again doubles every by-id operation against a relocated city's binding.
+func beadForOwner(owner storeref.Owner, id string) (beads.Bead, error) {
+	if owner.Read {
+		return owner.Bead, nil
+	}
+	return owner.Store.Get(id)
+}
+
+// unprobedWorkResidual stands in for a work axis the resolver must not run.
+//
+// Plan(ByID) ends every plan in a work leg and hands the LAST one back
+// UNPROBED, which is the contract cliByIDBindingOwner rests on: this value is
+// returned, never read. Its Get therefore reports a bug rather than a miss — a
+// resolver that started probing the residual would otherwise turn "the caller
+// runs its own scan" into "the bead is absent", silently, on every convoy
+// command of every relocated city.
+type unprobedWorkResidual struct{ beads.Store }
+
+// Get reports the contract violation described on the type.
+func (unprobedWorkResidual) Get(id string) (beads.Bead, error) {
+	return beads.Bead{}, fmt.Errorf("internal: the by-id work residual was probed for %s; it is a placeholder for a work axis this surface runs itself", id)
 }

--- a/cmd/gc/by_id_store_route.go
+++ b/cmd/gc/by_id_store_route.go
@@ -11,116 +11,41 @@ package main
 // bead?" a second time is how this repo's split-store bug class reproduces
 // (#5125, #5127).
 //
-// # Candidate list and probe, never an unconditional route
-//
-// The list comes from storeref.ClassCandidates, the shared resolver: the class
-// store leads because it is the sole MINTER of the reserved namespace, but
-// minting is not holding. A reserved prefix is only an ADVISORY on work stores
-// (config.ReservedPrefixWarnings warns; config.ValidateRigs does not reject), so
-// a work store can legitimately hold an id inside the class namespace and a
-// resolver that routed unconditionally on the prefix would report those beads as
-// absent.
-//
-// # Why the residence fallback exists
-//
-// storeref.ClassCandidates gates on the class NAMESPACE (IDInNamespace) BEFORE
-// it builds a list, and `gc storage migrate` preserves ids
-// (infra_class_migrate.go). A bead the migration relocated therefore keeps its
-// HQ/rig-era prefix, sits outside the class namespace, and gets nil candidates
-// back — for exactly the ids that moved. The shared resolver's own doc says so.
-//
-// So a nil answer from the resolver is not "the work store owns this". It is
-// "the namespace rule cannot decide", and what decides is a RESIDENCE probe:
-// ask the class store about the id itself. That is the same probe
-// bdByIDClassDoor.resolve performs, for the same reason, and the fallback list
-// is the same [class, work] head the resolver would have returned — so the two
-// paths differ in what makes them fire, never in what they answer.
+// That one place is now cliByIDOwner (by_id_residency.go), the CLI's plan over
+// the residency resolver. What used to live here — a candidate list, a probe
+// loop and a hand-written classification of which read errors are absence — is
+// the resolver's ByID plan, its RoleResidenceProbe/PolicyRefusalTolerated leg
+// and its work residual. This file is what remains: the callers that want a
+// STORE rather than a row.
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // classRoutedStoreForID returns the store that actually holds id: the relocated
 // class binding when it answers for the bead, and work otherwise.
 //
 // work is the caller's own resolved scope store and is BOTH the residual answer
-// and the last candidate, so a city that relocates nothing — and an id no
+// and the last leg of the plan, so a city that relocates nothing — and an id no
 // relocated class holds — gets back the exact store value the caller passed in.
 // A single-store city therefore never changes behavior, and never pays for the
-// funnel: the identity gate returns before any probe.
+// funnel: its plan has one leg and the resolver returns it unprobed.
 //
-// An error is a read that FAILED, never absence. Reading "the binding could not
-// answer" as "the bead is not there" is the root-loss shape this whole lane
-// exists to prevent. The one error that is not a fault is the one-shot funnel's
-// standing refusal (isStandingStorageRefusal): it says this city's storage
-// configuration cannot be served, which is a fact about the city and none about
-// a particular bead — and a refused city still serves WORK from its work
-// ledger. So for a work-shaped id the refusal establishes nothing and the work
-// store still answers; for an id only the class binding could own it is the
-// answer, and surfaces.
+// An error is a read that FAILED, never absence. The resolver's own contract
+// carries that rule and the one exception to it — a refused city still serves
+// WORK, so the standing storage refusal is tolerated for an id no relocated
+// class could own and surfaces for one inside a reserved namespace. See
+// cliByIDOwner.
 //
-// NOT consulted: the rig work stores. They are a different SCOPE, not a
-// different class — a caller that never read them cannot start reading them
-// here without changing which beads its command is about. storeref.ClassRouting
-// carries them as Shadows for the call sites that already hold them open
-// (internal/api's by-id resolver); this one does not, and passing an empty
-// Shadows list is what keeps the candidate order identical to the pre-seam
-// [class, work].
+// The row a winning probe read is DISCARDED here. A caller that is about to
+// read the bead anyway should call cliByIDOwner directly and use Owner.Bead
+// rather than paying for the same read twice; this wrapper exists for the
+// callers that hand the store to something else (a formula cook, an attach)
+// instead of reading it themselves.
 func classRoutedStoreForID(cityPath, id string, work beads.Store) (beads.Store, error) {
-	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
-	if !relocated || class == nil || class == work {
-		return work, nil
+	owner, err := cliByIDOwner(cityPath, id, work)
+	if err != nil {
+		return nil, err
 	}
-	for _, candidate := range classRouteCandidates(id, class, work) {
-		if candidate == nil || candidate == work {
-			// The work leg is the caller's own store and the residual answer.
-			// Stop here rather than probing it, so the caller's own read
-			// produces its own error message byte-identically.
-			return work, nil
-		}
-		_, err := candidate.Get(id)
-		switch {
-		case err == nil:
-			return candidate, nil
-		case errors.Is(err, beads.ErrNotFound):
-		case isStandingStorageRefusal(err) && !bdIDIsClassReserved(id):
-		default:
-			return nil, fmt.Errorf("reading %q from the relocated class binding: %w", id, err)
-		}
-	}
-	return work, nil
-}
-
-// classRouteCandidates is the by-id probe list: the shared resolver's answer,
-// or the residence-probe list when the resolver declines because id sits
-// outside the class namespace.
-//
-// Both lists lead with the class store and fall back to work, which is the
-// order the pre-seam resolver used and the order storeref.ClassCandidates
-// documents. The fallback is not a second opinion about ownership — it is the
-// same list, reached for the ids the namespace gate cannot speak about.
-//
-// One binding answers for every reserved prefix, which is sound only because
-// the served split shape is storageSplitWhole (storageSplitShapeOf admits a
-// split only when all five infrastructure classes name the same binding). The
-// graph prefix is therefore representative rather than special: a sessions- or
-// orders-prefixed id takes the fallback list and is probed against the same
-// store the resolver would have named. If per-class fan-out is ever served,
-// this has to resolve per class.
-func classRouteCandidates(id string, class, work beads.Store) []beads.Store {
-	if prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph); ok {
-		if candidates := storeref.ClassCandidates(id, storeref.ClassRouting{
-			Prefix: prefix,
-			Class:  class,
-			Work:   work,
-		}); candidates != nil {
-			return candidates
-		}
-	}
-	return []beads.Store{class, work}
+	return owner.Store, nil
 }

--- a/cmd/gc/by_id_store_route_test.go
+++ b/cmd/gc/by_id_store_route_test.go
@@ -166,31 +166,118 @@ func TestClassRoutedStoreForIDResolvesAClassResidentID(t *testing.T) {
 	}
 }
 
-// TestClassRoutedStoreForIDTakesTheSharedResolversCandidateOrder pins that the
-// probe list for an in-namespace id is literally storeref.ClassCandidates'
-// answer, so the ORDER and the identity gate have exactly one owner. A local
-// list that happened to agree today would drift the moment the resolver grows a
-// leg.
-func TestClassRoutedStoreForIDTakesTheSharedResolversCandidateOrder(t *testing.T) {
-	_, work, class := byIDRouteCity(t)
+// TestClassRoutedStoreForIDKeepsThePreSeamCandidateOrder is the before/after
+// pin for the migration onto the residency resolver.
+//
+// This route used to build its own probe list (classRouteCandidates) and walk
+// it with its own error classification. Both now come from
+// storeref.Plan(ByID)/ResolveOwnerRow, and the claim that the swap changed
+// nothing is PROVEN here rather than asserted in a commit message:
+// legacyClassRouteCandidates carries the deleted list verbatim, and every row
+// asserts the plan's leg stores are that list, in that order.
+//
+// The four rows are the four shapes the old list had branches for — an
+// in-namespace id, a work-shaped id the namespace gate declined, a city that
+// relocates nothing, and a refused city — so a plan that agreed on the ordinary
+// case and diverged on a branch cannot pass.
+func TestClassRoutedStoreForIDKeepsThePreSeamCandidateOrder(t *testing.T) {
 	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
 	if !ok {
-		t.Fatal("no reserved graph prefix")
+		t.Fatal("no reserved graph prefix; there is no namespace for by-id routing to run on")
 	}
-	id := prefix + "-1"
-	want := storeref.ClassCandidates(id, storeref.ClassRouting{Prefix: prefix, Class: class, Work: work})
-	if len(want) == 0 {
-		t.Fatal("the shared resolver produced no candidates for an in-namespace id on a relocated city")
+	tests := []struct {
+		name  string
+		id    string
+		setup func(t *testing.T) (cityPath string, work beads.Store)
+	}{
+		{
+			name:  "in-namespace id on a relocated city",
+			id:    prefix + "-1",
+			setup: func(t *testing.T) (string, beads.Store) { p, w, _ := byIDRouteCity(t); return p, w },
+		},
+		{
+			name:  "work-shaped id the namespace gate declines",
+			id:    "hq-4177",
+			setup: func(t *testing.T) (string, beads.Store) { p, w, _ := byIDRouteCity(t); return p, w },
+		},
+		{
+			name: "city that relocates nothing",
+			id:   prefix + "-1",
+			setup: func(t *testing.T) (string, beads.Store) {
+				cityPath := t.TempDir()
+				resetCLIStorageRoutes(t)
+				seedCLIStorageRoutes(t, cityPath, nil)
+				return cityPath, splittest.NewWorkStore(t, "hq")
+			},
+		},
+		{
+			name: "refused city",
+			id:   "hq-4177",
+			setup: func(t *testing.T) (string, beads.Store) {
+				cityPath := t.TempDir()
+				resetCLIStorageRoutes(t)
+				entry := cliStorageRoutesEntryFor(filepath.Clean(cityPath))
+				entry.once.Do(func() {
+					entry.routes = refusingStorageRoutes("infra", errors.New("this city's storage cannot be served"))
+				})
+				return cityPath, splittest.NewWorkStore(t, "hq")
+			},
+		},
 	}
-	got := classRouteCandidates(id, class, work)
-	if len(got) != len(want) {
-		t.Fatalf("classRouteCandidates produced %d candidates, want the shared resolver's %d", len(got), len(want))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityPath, work := tt.setup(t)
+			class, _ := graphClassBinding(cliStorageRoutes(cityPath))
+			want := legacyClassRouteCandidates(tt.id, class, work)
+			got := planLegStoresForID(t, cityPath, tt.id, work)
+			if len(got) != len(want) {
+				t.Fatalf("the ByID plan has %d legs, the pre-seam list had %d candidates", len(got), len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("leg %d = %p, want the pre-seam candidate %p — the binding leads because it is the sole minter of the reserved namespace, and work follows as the residual", i, got[i], want[i])
+				}
+			}
+		})
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("candidate %d = %p, want %p — the class store leads because it is the sole minter of the namespace, and work follows as the fallback leg", i, got[i], want[i])
+}
+
+// legacyClassRouteCandidates is the deleted classRouteCandidates, carried here
+// verbatim (plus the identity gate its caller applied before reaching it) as the
+// reference implementation for the order pin above. Nothing in production calls
+// it; it exists so the migration's zero-change claim is checkable by a reader
+// who never saw the pre-seam file.
+func legacyClassRouteCandidates(id string, class, work beads.Store) []beads.Store {
+	if class == nil || class == work {
+		return []beads.Store{work}
+	}
+	if prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph); ok {
+		if candidates := storeref.ClassCandidates(id, storeref.ClassRouting{
+			Prefix: prefix,
+			Class:  class,
+			Work:   work,
+		}); candidates != nil {
+			return candidates
 		}
 	}
+	return []beads.Store{class, work}
+}
+
+// planLegStoresForID returns the stores the CLI's by-id plan probes, in plan
+// order. It reads cliByIDPlan — the seam's own builder — rather than assembling
+// a topology beside it, so a seam that stopped using the constructor fails the
+// pin instead of passing it.
+func planLegStoresForID(t *testing.T, cityPath, id string, work beads.Store) []beads.Store {
+	t.Helper()
+	plan, err := cliByIDPlan(cityPath, id, work)
+	if err != nil {
+		t.Fatalf("planning ByID{%q}: %v", id, err)
+	}
+	stores := make([]beads.Store, 0, len(plan.Legs))
+	for _, leg := range plan.Legs {
+		stores = append(stores, leg.Leg.Store)
+	}
+	return stores
 }
 
 // TestClassRoutedStoreForIDSurfacesAReadFailureRatherThanAbsence is the

--- a/cmd/gc/claim_class_route.go
+++ b/cmd/gc/claim_class_route.go
@@ -113,7 +113,7 @@ package main
 //
 // # A single-store city takes none of this
 //
-// hookClaimClassRouteForCity gates on graphClassBinding — store identity, the
+// hookClaimClassRouteForCity gates on cliSoleClassBinding — store identity, the
 // same question resolveClassStore asks — and returns nil for a city that
 // relocates nothing. classRoutedHookClaimOps then returns the ops value it was
 // handed, unwrapped, so every claim-time write is the exact call it is today.
@@ -255,12 +255,22 @@ func hookClaimBindingRefusedTheClaim(err error) bool {
 // The funnel is the same one cityQueryTopology already entered to decide whether
 // this invocation's work query federates at all, and it is memoized per city
 // (cli_storage_routes.go), so a hook that reaches here opens no second binding.
+//
+// It resolves the SOLE binding rather than the graph class's, for the reason
+// spelled out on cliSoleClassBinding: a claim escalates to this route for any
+// reserved-prefix id, so a city serving its classes from more than one store
+// would have sessions-class claims routed at the graph binding, which would
+// truthfully report the bead absent. That shape is refused upstream; asking for
+// the sole binding is what makes the refusal load-bearing here too.
 func hookClaimClassRouteForCity(cityPath string) (*hookClaimClassRoute, error) {
-	class, relocated := graphClassBinding(cliStorageRoutes(cityPath))
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving the claim-time class route: %w", err)
+	}
 	if !relocated {
 		return nil, nil
 	}
-	return newHookClaimClassRoute(class)
+	return newHookClaimClassRoute(binding.Store)
 }
 
 // knownResident reports whether an earlier probe in THIS invocation already

--- a/cmd/gc/cli_storage_routes.go
+++ b/cmd/gc/cli_storage_routes.go
@@ -188,11 +188,17 @@ func cliStorageRoutesEntryFor(cityPath string) *cliStorageRoutesEntry {
 // The memo is detached under the lock before anything is closed, so a second
 // call closes nothing and a call that races the first cannot hand out a closed
 // store: the next resolution starts from an empty memo and opens again.
+//
+// The DERIVED memo goes with it. cliResidencyBindings caches the class-to-store
+// grouping it read out of these routes, so leaving it behind would let the next
+// by-id resolution plan legs over stores this call just closed — the memo one
+// layer up outliving the one it was derived from.
 func closeCLIStorageRoutes() error {
 	cliStorageRoutesMu.Lock()
 	entries := cliStorageRoutesByCity
 	cliStorageRoutesByCity = nil
 	cliStorageRoutesMu.Unlock()
+	resetCLIResidencyBindings()
 
 	var errs []error
 	for _, entry := range entries {

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -740,17 +740,24 @@ func (d bdByIDClassDoor) bindingName() string {
 // stops holding, this door has to resolve per class — the graph store would
 // otherwise be asked for a sessions-class id it does not hold, and would
 // truthfully answer that it is absent.
+//
+// cliSoleClassBinding is how that condition is CHECKED rather than assumed: it
+// reports the city's relocated bindings grouped by store and refuses to name a
+// sole one when there is more than one. Asking the graph class specifically
+// (graphClassBinding) could not tell the two shapes apart.
 func openBdByIDClassFrontDoor(cityPath string) (bdByIDClassDoor, bool, error) {
-	routes := cliStorageRoutes(cityPath)
-	store, relocated := graphClassBinding(routes)
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		return bdByIDClassDoor{}, false, fmt.Errorf("resolving the class front door: %w", err)
+	}
 	if !relocated {
 		return bdByIDClassDoor{}, false, nil
 	}
-	graph, err := storebinding.NewBeadsGraphStore(store)
+	graph, err := storebinding.NewBeadsGraphStore(binding.Store)
 	if err != nil {
-		return bdByIDClassDoor{}, false, fmt.Errorf("projecting the class front door of binding %q: %w", routes.binding, err)
+		return bdByIDClassDoor{}, false, fmt.Errorf("projecting the class front door of binding %q: %w", binding.Name, err)
 	}
-	return bdByIDClassDoor{Graph: graph, Store: store, Binding: routes.binding}, true, nil
+	return bdByIDClassDoor{Graph: graph, Store: binding.Store, Binding: binding.Name}, true, nil
 }
 
 // resolve asks the open front door whether it owns id.

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -692,7 +692,13 @@ func (r bdByIDResolution) Owned() bool { return r.Reserved || r.Found }
 // reads one database rather than two, and a routed read cannot close a handle
 // another call site is still using.
 type bdByIDClassDoor struct {
-	Graph   storebinding.GraphStore
+	Graph storebinding.GraphStore
+	// Store is the same class binding Graph wraps, kept in its beads.Store shape
+	// so the work-record close gate — which is store-driven, not graph-driven —
+	// can evaluate the resolved class bead this door is about to write. It is a
+	// second view of the one handle the funnel owns, not a second handle: nothing
+	// here is released.
+	Store   beads.Store
 	Binding string
 }
 
@@ -744,7 +750,7 @@ func openBdByIDClassFrontDoor(cityPath string) (bdByIDClassDoor, bool, error) {
 	if err != nil {
 		return bdByIDClassDoor{}, false, fmt.Errorf("projecting the class front door of binding %q: %w", routes.binding, err)
 	}
-	return bdByIDClassDoor{Graph: graph, Binding: routes.binding}, true, nil
+	return bdByIDClassDoor{Graph: graph, Store: store, Binding: routes.binding}, true, nil
 }
 
 // resolve asks the open front door whether it owns id.
@@ -866,29 +872,44 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		return 0, false
 	}
 	if !served {
-		if !namesClassBead {
-			// No reserved prefix to lean on, so ownership is proven by
-			// RESIDENCE: this is an unserved mutation, and if the class binding
-			// holds any of its subjects the work store cannot answer for it.
-			resident, err := door.firstResident(mutationIDs)
-			if err != nil {
-				fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1, true
-			}
-			if resident == "" {
-				// Every subject is a work bead. bd is still their truth and the
-				// passthrough answers byte-identically — including doBd's own
-				// exact-ID collision guard, which this arm must not displace.
-				return 0, false
-			}
-			named = resident
-		}
-		// The invocation addresses a bead the class binding owns, in a spelling
-		// this surface does not serve. Forwarding it would run the command
-		// against the one ledger that cannot hold the bead.
-		return refuseClassOwnedTarget(door, bdByIDRefusedVerb(bdArgs), named, bdByIDUnservedFlag(bdArgs), stderr)
+		return refuseUnservedClassMutation(door, bdArgs, named, namesClassBead, mutationIDs, stderr)
 	}
+	return serveBdByIDResolved(door, op, bdArgs, rigName, cityPath, stdout, stderr)
+}
 
+// refuseUnservedClassMutation answers a by-ID invocation that addresses a bead
+// the class binding owns in a spelling this surface does not serve. Ownership
+// is proven from a reserved prefix (namesClassBead) or, failing that, from
+// RESIDENCE: an unserved mutation whose subjects the class binding actually
+// holds cannot be answered by the work store. Returning (0, false) means every
+// subject is an ordinary work bead — bd is still their truth and the caller's
+// passthrough answers byte-identically, including doBd's own exact-ID collision
+// guard, which this arm must not displace.
+func refuseUnservedClassMutation(door bdByIDClassDoor, bdArgs []string, named string, namesClassBead bool, mutationIDs []string, stderr io.Writer) (int, bool) {
+	if !namesClassBead {
+		resident, err := door.firstResident(mutationIDs)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1, true
+		}
+		if resident == "" {
+			return 0, false
+		}
+		named = resident
+	}
+	// The invocation addresses a bead the class binding owns, in a spelling
+	// this surface does not serve. Forwarding it would run the command against
+	// the one ledger that cannot hold the bead.
+	return refuseClassOwnedTarget(door, bdByIDRefusedVerb(bdArgs), named, bdByIDUnservedFlag(bdArgs), stderr)
+}
+
+// serveBdByIDResolved answers a served by-ID op from the class front door. It
+// resolves the id against the class binding, refuses the cases this surface
+// must not serve (a work-store id it does not own, a reserved-prefix id with no
+// row, an explicit --rig work scope), runs the ADR-0009 work-record close gate,
+// and dispatches the verb against the class graph. repoFallback is the git repo
+// the close gate falls back to when a closing bead carries no gc.work_dir.
+func serveBdByIDResolved(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, rigName, repoFallback string, stdout, stderr io.Writer) (int, bool) {
 	resolution, err := door.resolve(op.ID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -919,6 +940,9 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		// So neither is taken. See refuseRigScopedClassOwnedTarget.
 		return refuseRigScopedClassOwnedTarget(door, op.ID, rig, stderr)
 	}
+	if gateBdByIDClassClose(door, op, bdArgs, resolution, repoFallback, stderr) {
+		return 1, true
+	}
 	switch op.Verb {
 	case bdByIDShow:
 		return printBdByIDBead(resolution.Bead, op.JSON, door.bindingName(), stdout, stderr), true
@@ -943,6 +967,25 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 	// so the passthrough would run a verb this build recognized against the one
 	// ledger that cannot hold the bead.
 	return refuseClassOwnedTarget(door, string(op.Verb), op.ID, "", stderr)
+}
+
+// gateBdByIDClassClose runs the ADR-0009 work-record close gate against the
+// resolved class bead before the door serves a close or a closing update. The
+// class door writes the class copy, so — unlike the fall-through path in
+// cmd_bd.go — the prefix-store gate never saw these closes; this is where the
+// contract is enforced for them. It is a no-op for every non-closing op:
+// evaluateWorkRecordCloseGate consults workRecordCloseTargets, which reports
+// not-a-close for show/claim/release/dep/reopen and for updates that do not set
+// status closed. The resolved bead is handed in as the preFetched value so the
+// gate reuses it rather than re-reading the class store, and door.Store answers
+// any other id the argv might name. Returns true only when the close must be
+// blocked (enforcement on and the work record invalid).
+func gateBdByIDClassClose(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, resolution bdByIDResolution, repoFallback string, stderr io.Writer) bool {
+	if op.Verb != bdByIDClose && op.Verb != bdByIDUpdate {
+		return false
+	}
+	preFetched := map[string]beads.Bead{op.ID: resolution.Bead}
+	return evaluateWorkRecordCloseGate(bdArgs, door.Store, preFetched, repoFallback, workRecordEnforceEnabled(), stderr)
 }
 
 // refuseRigScopedClassOwnedTarget refuses a by-ID invocation that pins a rig

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
@@ -1430,6 +1431,167 @@ func TestBdCloseUnopenableBindingSurfacesNotAbsence(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "no issue found") {
 		t.Errorf("a failing read was reported as an absent bead: %q", stderr.String())
+	}
+}
+
+// TestBdCloseClassResidentEnforcesWorkRecordGate proves the class-door close
+// runs the ADR-0009 work-record gate against the class copy it is about to
+// write. A class-resident work step (a plain task bead, no gc.kind) that lacks a
+// typed gc.work_outcome must be BLOCKED under enforcement rather than retired
+// with no outcome — and the block must land BEFORE the write, so the class row
+// stays open. This is the codex major finding: the routed close returned before
+// the gate at cmd_bd.go:372 could run.
+func TestBdCloseClassResidentEnforcesWorkRecordGate(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	// Set enforcement AFTER foreignProviderCity: clearGCEnv wipes live GC_* keys.
+	t.Setenv(workRecordEnforceEnvVar, "1")
+	relic := classResidentWorkShapedBead(t, classStore, "gc-nooutcome1", "closed without a work outcome")
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", relic.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident close fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 1 {
+		t.Fatalf("close of an outcome-less work step exited %d, want 1 (blocked): %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work-record gate (enforced)") {
+		t.Errorf("the block does not carry the enforced-gate marker: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing "+beadmeta.WorkOutcomeMetadataKey) {
+		t.Errorf("the block does not name the missing outcome: %q", stderr.String())
+	}
+	after, err := classStore.Get(relic.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", relic.ID, err)
+	}
+	if after.Status == "closed" {
+		t.Errorf("the blocked close wrote to the class binding anyway; status=%q", after.Status)
+	}
+}
+
+// TestBdUpdateStatusClosedClassResidentEnforcesWorkRecordGate is the same gate
+// on the other close spelling — `gc bd update <id> --status closed`, the form
+// the worker formulas use to stamp metadata and close in one call. It must be
+// gated identically: an outcome-less update-close is blocked and does not write.
+func TestBdUpdateStatusClosedClassResidentEnforcesWorkRecordGate(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	t.Setenv(workRecordEnforceEnvVar, "1")
+	relic := classResidentWorkShapedBead(t, classStore, "gc-nooutcome2", "update-closed without an outcome")
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"update", relic.ID, "--status", "closed"}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident update-close fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 1 {
+		t.Fatalf("update --status closed on an outcome-less work step exited %d, want 1 (blocked): %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing "+beadmeta.WorkOutcomeMetadataKey) {
+		t.Errorf("the block does not name the missing outcome: %q", stderr.String())
+	}
+	after, err := classStore.Get(relic.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", relic.ID, err)
+	}
+	if after.Status == "closed" {
+		t.Errorf("the blocked update-close wrote to the class binding anyway; status=%q", after.Status)
+	}
+}
+
+// TestBdUpdateAtomicNoOpClassResidentPassesWorkRecordGate proves the gate does
+// not over-block: the documented worker close — stamp the typed outcome and
+// close in one atomic update — is ALLOWED under enforcement, and the class row
+// is retired with the outcome persisted. Validating the pre-update bead alone
+// would wrongly reject this, so the gate must project the submitted metadata.
+func TestBdUpdateAtomicNoOpClassResidentPassesWorkRecordGate(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	t.Setenv(workRecordEnforceEnvVar, "1")
+	relic := classResidentWorkShapedBead(t, classStore, "gc-outcome1", "closed with a no-op outcome")
+
+	args := []string{
+		"update", relic.ID,
+		"--set-metadata", beadmeta.WorkOutcomeMetadataKey + "=" + beadmeta.WorkOutcomeNoOp,
+		"--status", "closed",
+	}
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident atomic close fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("a compliant atomic close was blocked (exit %d): %s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "work-record gate") {
+		t.Errorf("a compliant close still tripped the gate: %q", stderr.String())
+	}
+	after, err := classStore.Get(relic.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", relic.ID, err)
+	}
+	if after.Status != "closed" {
+		t.Errorf("the compliant close did not retire the class row; status=%q", after.Status)
+	}
+	if got := after.Metadata[beadmeta.WorkOutcomeMetadataKey]; got != beadmeta.WorkOutcomeNoOp {
+		t.Errorf("the atomic close did not stamp the outcome; %s=%q", beadmeta.WorkOutcomeMetadataKey, got)
+	}
+}
+
+// TestBdCloseClassResidentWarnsOnlyByDefault keeps the migration default: with
+// enforcement OFF, an outcome-less close WARNS but still proceeds, so the open
+// work steps a migrated city already holds drain without breakage.
+func TestBdCloseClassResidentWarnsOnlyByDefault(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	// Enforcement deliberately unset (foreignProviderCity's clearGCEnv left it so).
+	relic := classResidentWorkShapedBead(t, classStore, "gc-warnonly1", "closed without an outcome, warn-only")
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", relic.ID}, &stdout, &stderr)
+	if !handled || code != 0 {
+		t.Fatalf("warn-only close = (%d, %t): %s", code, handled, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work-record gate (warn-only)") {
+		t.Errorf("the warn-only close did not warn: %q", stderr.String())
+	}
+	after, err := classStore.Get(relic.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", relic.ID, err)
+	}
+	if after.Status != "closed" {
+		t.Errorf("warn-only did not proceed with the close; status=%q", after.Status)
+	}
+}
+
+// TestBdUpdateUnservedWorkResidentFailsLoudOnClassProbeFault pins, deliberately,
+// the blast-radius minor: an ordinary WORK-bead unserved mutation fails loud
+// when the class-store residence probe faults with a NON-refusal read error,
+// rather than silently falling through to bd. It is the unserved-path mirror of
+// TestBdCloseUnopenableBindingSurfacesNotAbsence — a mid-query fault is a failure
+// to DECIDE ownership, and treating it as absence is the root-loss shape this
+// lane exists to prevent. A standing refusal is the one error treated as a miss;
+// a fault is not, so the command surfaces it instead of guessing the ledger.
+func TestBdUpdateUnservedWorkResidentFailsLoudOnClassProbeFault(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	resident, err := workStoreFor(t, cityPath).Create(beads.Bead{Title: "an ordinary work bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the work store: %v", err)
+	}
+	failure := errors.New("the class binding faulted mid-probe")
+	failClassBindingReads(t, cityPath, failure)
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"update", resident.ID, "--notes", "x"}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("a class-probe fault let an unserved work mutation fall through to the bd subprocess")
+	}
+	if code == 0 {
+		t.Errorf("a class-probe fault exited 0 with stdout %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), failure.Error()) {
+		t.Errorf("the failure does not carry the store's cause: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "no issue found") {
+		t.Errorf("a class-probe fault was reported as an absent bead: %q", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/storebinding"
 	"github.com/gastownhall/gascity/internal/storebinding/beadsworkspace"
 	sqlitebinding "github.com/gastownhall/gascity/internal/storebinding/sqlite"
+	"github.com/gastownhall/gascity/internal/storeref/storereftest"
 )
 
 // configRefEngineProviderID is the foreign provider the fixtures below serve
@@ -1313,6 +1314,12 @@ func TestBdCloseAlreadyClosedIsStoreContractNoOp(t *testing.T) {
 // migration's retained one. Draining the duplicate copies is still the sweep's
 // job — agreement is about which copy is authoritative, not about there being
 // one.
+//
+// The clauses live in storereftest so this test and the API's
+// TestBeadDualResidentAnswersFromTheBinding assert the SAME sentences. That is
+// the whole point: two surfaces can each pass their own pin and still disagree
+// about which copy of one id is real, and a shared property is the only thing
+// that catches it.
 func TestBdCloseDualResidentWritesServingCopy(t *testing.T) {
 	cityPath, classStore := foreignProviderCity(t)
 	work := workStoreFor(t, cityPath)
@@ -1321,38 +1328,67 @@ func TestBdCloseDualResidentWritesServingCopy(t *testing.T) {
 		t.Fatalf("seeding the work store: %v", err)
 	}
 	resident := classResidentWorkShapedBead(t, classStore, shadow.ID, "the class-binding copy")
-
-	var stdout, stderr bytes.Buffer
-	if code, handled := maybeRouteBdByID(cityPath, "", []string{"close", resident.ID}, &stdout, &stderr); !handled || code != 0 {
-		t.Fatalf("closing the dual-resident %s = (%d, %t): %s", resident.ID, code, handled, stderr.String())
-	}
-	classCopy, err := classStore.Get(resident.ID)
+	control, err := work.Create(beads.Bead{Title: "a work bead the binding never held", Type: "task"})
 	if err != nil {
-		t.Fatalf("re-reading the class copy: %v", err)
-	}
-	if classCopy.Status != "closed" {
-		t.Errorf("the class copy's status = %q, want closed", classCopy.Status)
-	}
-	workCopy, err := work.Get(shadow.ID)
-	if err != nil {
-		t.Fatalf("re-reading the work copy: %v", err)
-	}
-	if workCopy.Status == "closed" {
-		t.Errorf("the work copy was closed too; one id, one owner, one write")
+		t.Fatalf("seeding the control: %v", err)
 	}
 
-	// The read the same surface serves must agree with the write it just made.
-	stdout.Reset()
-	stderr.Reset()
-	if code, handled := maybeRouteBdByID(cityPath, "", []string{"show", resident.ID, "--json"}, &stdout, &stderr); !handled || code != 0 {
-		t.Fatalf("showing the dual-resident %s = (%d, %t): %s", resident.ID, code, handled, stderr.String())
-	}
-	var shown []beads.Bead
-	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
-		t.Fatalf("decoding the routed show %q: %v", stdout.String(), err)
-	}
-	if len(shown) != 1 || shown[0].Status != "closed" {
-		t.Errorf("the routed show reports %+v; the surface's read and its write disagree about which copy is authoritative", shown)
+	storereftest.RunBindingWins(t,
+		storereftest.BindingWinsStores{
+			Binding:       classStore,
+			Work:          work,
+			DualID:        resident.ID,
+			BindingTitle:  "the class-binding copy",
+			WorkOnlyID:    control.ID,
+			WorkOnlyTitle: "a work bead the binding never held",
+		},
+		storereftest.BindingWinsSurface{
+			Name: "the gc bd by-id class door",
+			Get:  showThroughTheClassDoor(cityPath, work),
+			Close: func(t *testing.T, id string) {
+				t.Helper()
+				var stdout, stderr bytes.Buffer
+				code, handled := maybeRouteBdByID(cityPath, "", []string{"close", id}, &stdout, &stderr)
+				if !handled || code != 0 {
+					t.Fatalf("closing %s = (%d, %t): %s", id, code, handled, stderr.String())
+				}
+			},
+		})
+}
+
+// showThroughTheClassDoor adapts `gc bd show --json` to the shared property's
+// Get.
+//
+// The door answers only for ids it resolves to a binding; for anything else it
+// returns handled=false and the real command falls through to a bd subprocess
+// pointed at the city's work ledger. A test cannot run that subprocess, so this
+// reads the work store the subprocess would have been given — which is what
+// makes the control clause an assertion about the DOOR rather than about bd: it
+// holds because the door DECLINED, and a door that started claiming ids no
+// binding holds would answer here from the binding and fail.
+func showThroughTheClassDoor(cityPath string, work beads.Store) func(*testing.T, string) beads.Bead {
+	return func(t *testing.T, id string) beads.Bead {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code, handled := maybeRouteBdByID(cityPath, "", []string{"show", id, "--json"}, &stdout, &stderr)
+		if !handled {
+			bead, err := work.Get(id)
+			if err != nil {
+				t.Fatalf("the door declined %s and the work ledger it falls through to cannot serve it either: %v", id, err)
+			}
+			return bead
+		}
+		if code != 0 {
+			t.Fatalf("the routed show of %s exited %d: %s", id, code, stderr.String())
+		}
+		var shown []beads.Bead
+		if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+			t.Fatalf("decoding the routed show %q: %v", stdout.String(), err)
+		}
+		if len(shown) != 1 {
+			t.Fatalf("the routed show of %s returned %d beads, want exactly one", id, len(shown))
+		}
+		return shown[0]
 	}
 }
 

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -769,11 +769,17 @@ func TestBdByIDSurfaceResolvesOneStoreNotAProviderPerOperation(t *testing.T) {
 			t.Errorf("%s calls %s %d time(s); the by-ID surface must resolve its store through the storage funnel alone", file, forbidden, counts[forbidden])
 		}
 	}
-	if counts["cliStorageRoutes"] != 1 {
-		t.Errorf("%s calls cliStorageRoutes %d time(s), want exactly 1: one store resolution per command", file, counts["cliStorageRoutes"])
+	if counts["cliSoleClassBinding"] != 1 {
+		t.Errorf("%s calls cliSoleClassBinding %d time(s), want exactly 1: one store resolution per command", file, counts["cliSoleClassBinding"])
 	}
-	if counts["graphClassBinding"] != 1 {
-		t.Errorf("%s calls graphClassBinding %d time(s), want exactly 1", file, counts["graphClassBinding"])
+	// The two calls cliSoleClassBinding replaced. Asking the graph class
+	// specifically cannot tell a whole split from a per-class fan-out, and
+	// re-entering the funnel beside the resolver is how the two answers get to
+	// disagree; both are now the resolver's job and neither belongs in this file.
+	for _, replaced := range []string{"cliStorageRoutes", "graphClassBinding"} {
+		if counts[replaced] != 0 {
+			t.Errorf("%s calls %s %d time(s); the by-ID surface resolves its binding through cliSoleClassBinding alone", file, replaced, counts[replaced])
+		}
 	}
 }
 

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -253,7 +253,34 @@ func renderBeadsShowFromAPI(cr api.CachedRead[beads.Bead], format string, stdout
 	return 0
 }
 
+// doBeadsShowFallback serves `gc beads show` from the stores directly when the
+// API is unreachable.
+//
+// The relocated class binding is asked first, through the shared residency
+// contract, because it is not one of the directories the scan below walks: on a
+// converged city an infrastructure bead would otherwise be shown from the copy
+// `gc storage migrate` retained in the city store, frozen at migration time and
+// reported as though it were current.
 func doBeadsShowFallback(cityPath, beadID, format string, stdout, stderr io.Writer) int {
+	owner, ownedByBinding, err := cliByIDBindingOwner(cityPath, beadID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc beads show: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if ownedByBinding {
+		b, err := beadForOwner(owner, beadID)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc beads show: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if format == "json" {
+			writeBeadJSON(b, stdout)
+		} else {
+			writeBeadDetail(b, stdout)
+		}
+		return 0
+	}
+
 	stores, code := openAllConvoyStoresAt(cityPath, stderr, "gc beads show")
 	if stores == nil {
 		return code

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"text/tabwriter"
 
 	"github.com/gastownhall/gascity/internal/api"
@@ -530,7 +531,36 @@ func resolveConvoyStore(convoyID string, cfg *config.City, cityPath string, open
 // contract. A candidate's not-found probe is skipped; any other error is
 // returned immediately. The returned directory maps back to the owning
 // candidate.
+//
+// # The binding leg comes first, and it short-circuits the uniqueness contract
+//
+// A relocated class binding is not one of the city's directories, so the scan
+// below cannot reach it. On a converged city that means an infrastructure bead
+// is answered by the copy `gc storage migrate` RETAINED in the city store —
+// frozen at migration time — and the caller then writes through it. So the
+// binding is resolved first, through the shared residency contract.
+//
+// A binding hit returns without consulting the ambiguity rule, deliberately.
+// Dual residency is not ambiguity: the migration copies with ids preserved and
+// deletes nothing, so a relocated bead is SUPPOSED to exist twice and there is
+// a known winner. Refusing it as ambiguous would break every convoy command on
+// exactly the cities that completed the migration.
+//
+// The directory reported for a binding hit is the CITY's, not the binding's,
+// and that is not a fudge. Callers map this directory to a store-ref
+// ("city:<name>" / "rig:<name>") that scopes molecule-root lookups. These beads
+// lived in the city store and carried the city's ref before the migration moved
+// them; a binding is not a rig and has no ref of its own, and inventing one
+// would strand every root recorded before the move.
 func resolveOwningStoreDir(beadID string, cfg *config.City, cityPath string, openStore func(string) (beads.Store, error)) (beads.Store, string, error) {
+	owner, ownedByBinding, err := cliByIDBindingOwner(cityPath, beadID)
+	if err != nil {
+		return nil, "", err
+	}
+	if ownedByBinding {
+		return owner.Store, cityPath, nil
+	}
+
 	candidates, err := openConvoyStores(cfg, cityPath, beadID, openStore)
 	if err != nil {
 		return nil, "", err
@@ -1796,6 +1826,10 @@ func doConvoyAutoclose(beadID string, stdout, stderr io.Writer) {
 // city config cannot be loaded or no candidate store holds the bead, so the
 // caller can fall back to cwd-rooted resolution. The store directory lets
 // molecule autoclose derive the matching store-ref label.
+//
+// A resolution that FAILED is still ok=false — the hooks cannot be made fatal
+// without wedging every close on a city with a sick store — but it is announced
+// first. See warnAutocloseResolutionFault.
 func autocloseOwningStore(beadID, cityPath string) (beads.Store, string, bool) {
 	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
@@ -1805,9 +1839,37 @@ func autocloseOwningStore(beadID, cityPath string) (beads.Store, string, bool) {
 		return openStoreAtForCity(storeDir, cityPath)
 	})
 	if err != nil {
+		if !errors.Is(err, beads.ErrNotFound) {
+			warnAutocloseResolutionFault(beadID, err)
+		}
 		return nil, "", false
 	}
 	return store, dir, true
+}
+
+// autocloseFaultOnce bounds warnAutocloseResolutionFault to one line per
+// process.
+var autocloseFaultOnce sync.Once
+
+// warnAutocloseResolutionFault announces a by-id resolution that failed rather
+// than missed, once per process.
+//
+// The autoclose hooks are best-effort by design: bd's on_close must not fail
+// because a molecule root could not be found, so every error here is swallowed
+// and the caller falls back to the cwd-rooted store. That is right for absence
+// and wrong for a fault. A binding that cannot be read, or an id the scan
+// refuses as ambiguous, makes the fallback close a root in a ledger that may
+// not hold it — the silent wrong-store write this lane exists to end — and it
+// cannot be made fatal without wedging closes on a city whose binding is sick.
+// So it is made LOUD instead.
+//
+// Once per process, because bd closes beads in bursts: a persistent fault would
+// otherwise print the same line on every close of a drain and bury the hook log
+// it is trying to be seen in.
+func warnAutocloseResolutionFault(beadID string, err error) {
+	autocloseFaultOnce.Do(func() {
+		fmt.Fprintf(cliStorageStderr, "gc autoclose: resolving the store that owns %s failed (%v); falling back to the cwd-rooted store, which may not hold it. Further occurrences this process are not repeated.\n", beadID, err) //nolint:errcheck // best-effort stderr
+	})
 }
 
 func convoyAutocloseStoreRoot(cwd string) string {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -700,17 +700,19 @@ func controlGraphRelocated(cityPath, storePath string) bool {
 // the standing refusal — so federating it would turn a city-level storage
 // misconfiguration into a hard scan error on EVERY rig dispatcher, and a scan
 // error is fatal to the drain loop, so all rig control dispatch would crash-loop
-// on a city that is otherwise still serving work. classRoutedStoreForID states
-// the governing rule for exactly this error: a standing refusal "is a fact about
-// the city and none about a particular bead — and a refused city still serves
-// WORK from its work ledger." A rig's own control beads are that case, so the
-// refusal establishes nothing about them and its own store still answers. The
+// on a city that is otherwise still serving work. cliByIDOwner states the
+// governing rule for exactly this error: the standing refusal "is a verdict
+// about a CITY's storage configuration and says nothing about a bead, and a
+// refused city still serves WORK from its work ledger." A rig's own control
+// beads are that case, so the refusal establishes nothing about them and its
+// own store still answers. The
 // beads the skipped leg would have carried belong to a graph plane that is down
 // by this build's own verdict, already reported by the boot gate, and equally
 // unreachable to the CITY dispatcher.
 //
-// The identity gate the sibling surfaces apply (relocatedGraphLegFrom, and
-// classRoutedStoreForID's `class == work`) is deliberately not restated here:
+// The identity gate the sibling surfaces apply (relocatedGraphLegFrom's
+// `binding == cityStore`, and storeref's own dedupeLegs, which folds a binding
+// that IS the caller's work store into one probed leg) is not restated here:
 // this arm runs only for a RIG scope, whose store is that rig's own bd/Dolt
 // handle and never the city's binding, and the scan-side caller holds no store
 // handle to compare against at all — it shells `bd` for its scope leg.

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -270,8 +270,9 @@ func cliResidencyBindings(cityPath string) ([]storeref.ClassBinding, error) {
 	return bindings, refused
 }
 
-// resetCLIResidencyBindings drops the memo. Wired into closeCLIStorageRoutes's
-// caller-visible lifecycle by the tests that need a second city in one process.
+// resetCLIResidencyBindings drops the memo wholesale. closeCLIStorageRoutes
+// calls it: this grouping is DERIVED from the routes that call closes, so it
+// cannot outlive them.
 func resetCLIResidencyBindings() {
 	cliResidencyBindingsMu.Lock()
 	cliResidencyBindingsByCity = nil

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -267,6 +267,17 @@ func cliResidencyBindings(cityPath string) ([]storeref.ClassBinding, error) {
 	if existing, raced := cliResidencyBindingsByCity[key]; raced {
 		return existing.bindings, existing.refused
 	}
+	// A nil map HERE is not the cold start the first section handles — that
+	// section made it non-nil before this goroutine ever left the lock. It means
+	// resetCLIResidencyBindings ran while this derivation was in flight, which
+	// happens on the shutdown path of a long-lived `gc start`. Storing anyway
+	// would do two wrong things at once: assign into a nil map, which panics the
+	// process during its own teardown, and re-populate a retired memo with
+	// bindings over stores closeCLIStorageRoutes has already closed. The answer
+	// is still correct for THIS caller, so it is returned unmemoized.
+	if cliResidencyBindingsByCity == nil {
+		return bindings, refused
+	}
 	cliResidencyBindingsByCity[key] = &cliResidencyBindingsEntry{bindings: bindings, refused: refused}
 	return bindings, refused
 }
@@ -363,14 +374,25 @@ func dropCLIResidencyBindings(key string) {
 // # Why a map keyed by beads.Store is safe HERE and is not in the resolver
 //
 // storeref.dedupeLegs cannot key a map on a store — beads.Store is an interface,
-// and an implementation whose dynamic type carries a slice is neither hashable
-// nor ==-able, so a caller's store panics it. This map is confined to the
-// CONSTRUCTORS: every value in it comes from routes.storeFor, which returns what
-// storage boot opened — a *SQLiteStore, a *BdStore, a *CachingStore or a
-// refusedClassStore, all pointer-typed and therefore reference-identified. Same
-// confinement for relocatedGraphLegFrom's `binding == cityStore`. A route that
-// ever yields a value-typed store makes both of these the resolver's bug, one
-// file over; reuse storeref's identity-based set at that point.
+// and an implementation whose dynamic type carries a slice, a map or a func is
+// neither hashable nor ==-able, so a caller's store panics it. This map is
+// confined to the CONSTRUCTORS: every value in it comes from routes.storeFor,
+// which returns what storage boot opened — *SQLiteStore, *BdStore and
+// *CachingStore, all pointer-typed and so reference-identified, plus
+// refusedClassStore, which is a value carrying one error field.
+//
+// That last one is comparable rather than reference-identified, and the
+// difference is visible: two refusedClassStore values built from the SAME error
+// compare equal, so a refused city's five classes group into one binding even
+// though storeFor handed back five separate values. That is the answer this
+// build wants — a refused city is refused as a whole, and cliSoleClassBinding
+// reports one binding for it rather than a five-way fan-out — but it is a
+// property of the type being comparable, not of the map being identity-keyed,
+// and a second value-typed route with a differing field would group differently
+// for the same reason. Same confinement for relocatedGraphLegFrom's
+// `binding == cityStore`. A route that ever yields a NON-comparable store makes
+// both of these the resolver's bug, one file over; reuse storeref's
+// identity-based set at that point.
 func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding, error) {
 	byStore := map[beads.Store][]coordclass.Class{}
 	var order []beads.Store

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -29,6 +29,7 @@ package main
 // the retired row, so the day verification ships this is a bit, not a redesign.
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -268,6 +269,70 @@ func cliResidencyBindings(cityPath string) ([]storeref.ClassBinding, error) {
 	}
 	cliResidencyBindingsByCity[key] = &cliResidencyBindingsEntry{bindings: bindings, refused: refused}
 	return bindings, refused
+}
+
+// cliRelocatedBinding is the one relocated class binding a city is served from.
+//
+// It carries the opened store rather than the storeref.ClassBinding it was
+// derived from, and that is the residency boundary rather than a convenience: a
+// caller handed the ClassBinding would read binding.Leg.Store, which is a
+// consumer picking a store out of a plan leg — the shape the boundary check
+// forbids, because a second consumer will pick a different one. The leg access
+// happens here, in the file that assembles legs, exactly once.
+//
+// Name is the operator-facing name of the configured [storage] binding, which is
+// not derivable from the ClassBinding: storeref carries a class REF
+// ("class:graph+sessions+…"), describing what the binding answers for and not
+// which configured binding it is. Operator text wants the latter.
+type cliRelocatedBinding struct {
+	Store   beads.Store
+	Classes []coordclass.Class
+	Name    string
+}
+
+// cliSoleClassBinding returns the single relocated class binding serving this
+// city, for the callers that answer EVERY reserved prefix from ONE store.
+//
+// # It turns a comment into a check
+//
+// The by-id front door and the claim route both used to ask
+// graphClassBinding — "which store serves the graph class" — and then answer
+// for sessions, convoy and mail ids out of that same store. That is correct
+// only because storageSplitShapeOf admits a split only when all five
+// infrastructure classes name the same binding and refuses a per-class fan-out
+// outright, and until now that argument lived entirely in a comment. Reading
+// the grouped bindings instead makes it a runtime condition: two bindings is a
+// fan-out neither caller can serve, and it says so rather than quietly picking
+// the graph one and letting a sessions-class read come back truthfully absent.
+//
+// # The refusal is carried, not returned
+//
+// A city configured for a binding it has not converged on still produces a
+// binding here — a refusedClassStore whose every operation returns the boot
+// gate's sentence — and cliResidencyBindings reports that refusal alongside it.
+// Both callers want the STORE in that case, exactly as they got it before: the
+// refusal reaches them through the reads they were going to make anyway, where
+// each already classifies it (bdByIDClassDoor.resolve, hookClaimClassRoute.holds).
+// Returning it here instead would collapse "this city cannot be served" into
+// "this city relocates nothing", which sends those reads back to the work
+// ledger the beads were migrated off — the exact stale-answer path the door was
+// built to close.
+func cliSoleClassBinding(cityPath string) (cliRelocatedBinding, bool, error) {
+	bindings, _ := cliResidencyBindings(cityPath)
+	switch len(bindings) {
+	case 0:
+		return cliRelocatedBinding{}, false, nil
+	case 1:
+		return cliRelocatedBinding{
+			Store:   bindings[0].Leg.Store,
+			Classes: bindings[0].Classes,
+			Name:    cliStorageRoutes(cityPath).binding,
+		}, true, nil
+	default:
+		return cliRelocatedBinding{}, false, fmt.Errorf(
+			"this city serves its coordination classes from %d separate bindings; %s",
+			len(bindings), storageSupportedTopologyStatement)
+	}
 }
 
 // resetCLIResidencyBindings drops the memo wholesale. closeCLIStorageRoutes

--- a/cmd/gc/sole_class_binding_test.go
+++ b/cmd/gc/sole_class_binding_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+// TestSoleClassBindingReportsTheWholeSplitAsOne is the shape this build serves:
+// five infrastructure classes, one store, one binding. The grouping is what
+// makes the by-id door's "every reserved prefix from one store" argument
+// checkable, so the count is the assertion.
+func TestSoleClassBindingReportsTheWholeSplitAsOne(t *testing.T) {
+	cityPath := t.TempDir()
+	infra := splittest.NewWorkStore(t, "hq")
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(infra))
+
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		t.Fatalf("resolving the sole binding: %v", err)
+	}
+	if !relocated {
+		t.Fatal("a converged split city reports no relocated binding")
+	}
+	if binding.Store != infra {
+		t.Errorf("the sole binding is %p, want the infra store %p", binding.Store, infra)
+	}
+	if binding.Name != "infra" {
+		t.Errorf("the sole binding is named %q, want the configured binding name", binding.Name)
+	}
+	if got, want := len(binding.Classes), len(infrastructureClasses()); got != want {
+		t.Errorf("the sole binding answers for %d classes, want all %d infrastructure classes — a door that serves every reserved prefix from it must own every one", got, want)
+	}
+}
+
+// TestSoleClassBindingRefusesAPerClassFanOut is the check that replaced a
+// comment.
+//
+// storageSplitShapeOf refuses a per-class fan-out upstream, so this arrangement
+// is unreachable through openStorageRoutes today. That is exactly why it is
+// worth pinning here: the by-id door and the claim route both answer for EVERY
+// reserved prefix out of the one store they resolve, and the day the upstream
+// refusal is relaxed they must stop rather than send a sessions-class read at
+// the graph binding and be told, truthfully, that the bead is absent.
+func TestSoleClassBindingRefusesAPerClassFanOut(t *testing.T) {
+	cityPath := t.TempDir()
+	routes := messagingSplitRoutes(splittest.NewWorkStore(t, "hq"))
+	routes.stores[coordclass.ClassGraph] = splittest.NewWorkStore(t, "gr")
+	seedCLIStorageRoutes(t, cityPath, routes)
+
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err == nil {
+		t.Fatalf("a two-binding city resolved to %p (relocated=%v); a fan-out has no sole binding to answer every prefix from", binding.Store, relocated)
+	}
+	if relocated {
+		t.Error("a refused fan-out reported relocated=true; a caller that ignored the error would open a door onto one of the two")
+	}
+	if !strings.Contains(err.Error(), storageSupportedTopologyStatement) {
+		t.Errorf("the refusal does not name the supported topology: %v", err)
+	}
+}
+
+// TestSoleClassBindingCarriesARefusedCityRatherThanHidingIt is the distinction
+// the whole residency lane turns on.
+//
+// A city configured for a binding it has not converged on is served by a store
+// whose every operation returns the boot gate's sentence. That city must still
+// report as RELOCATED: reading its refusal as "relocates nothing" would send
+// every infrastructure read back to the work ledger those beads were migrated
+// off, answered from the copy the migration retained, with no error to notice.
+func TestSoleClassBindingCarriesARefusedCityRatherThanHidingIt(t *testing.T) {
+	cityPath := t.TempDir()
+	refusal := errors.New("this city is configured for a binding it has not converged on")
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(refusedClassStore{err: refusal}))
+
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		t.Fatalf("a refused city resolved to err=%v; the refusal travels in the store, not in this return", err)
+	}
+	if !relocated {
+		t.Fatal("a refused city reports relocates-nothing; its reads would fall back to the ledger the migration moved them off")
+	}
+	if _, err := binding.Store.Get("hq-1"); !errors.Is(err, refusal) {
+		t.Errorf("reading the carried binding returned %v, want the standing refusal", err)
+	}
+}
+
+// TestSoleClassBindingIsAbsentOnACityThatRelocatesNothing is the compatibility
+// row: no binding, no error, and every caller's existing path stands unchanged.
+func TestSoleClassBindingIsAbsentOnACityThatRelocatesNothing(t *testing.T) {
+	cityPath := t.TempDir()
+	seedCLIStorageRoutes(t, cityPath, &storageRoutes{stores: map[coordclass.Class]beads.Store{}})
+
+	binding, relocated, err := cliSoleClassBinding(cityPath)
+	if err != nil {
+		t.Fatalf("a single-store city resolved to err=%v", err)
+	}
+	if relocated {
+		t.Errorf("a single-store city reported a binding %p", binding.Store)
+	}
+}

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -24,46 +24,38 @@ import (
 // proceeds — so existing open beads migrate without breakage. Set
 // GC_WORK_RECORD_ENFORCE to a truthy value to make violations block the close.
 //
-// # What the gate does NOT see: a close the by-ID class door served
+// # Two entry points run this gate: the bd fall-through and the class door
 //
 // doBd runs the by-ID class door (cmd_bd_by_id.go maybeRouteBdByID) BEFORE this
-// gate, and a routed close returns from doBd without reaching it. So on a city
-// that relocates a coordination class, `gc bd close <id>` and `gc bd update
-// <id> --status closed` are gated only when they fall through to the bd
-// subprocess. This is a coverage boundary, and it is recorded here rather than
-// closed because closing it would mean re-deriving the gate against a store
-// this file does not resolve.
+// gate. A close that falls through to the bd subprocess is gated here against
+// the PREFIX store (the caller's resolved work scope). A close the door SERVES —
+// because the city relocated a coordination class and the bead resides in the
+// class binding — never reaches this fall-through, so the door runs the same
+// evaluateWorkRecordCloseGate against the class bead it is about to write
+// (gateBdByIDClassClose), reusing the row it already resolved. Both spellings
+// the door serves — `gc bd close <id>` and `gc bd update <id> --status closed`
+// — are therefore gated wherever they land; the two entry points cover disjoint
+// stores, and neither trusts the other's read.
 //
-// It is narrower than it sounds, in three steps:
+// The DUAL-RESIDENT case is why the split matters rather than being a redundant
+// double-gate. `gc storage migrate` copies every non-work bead with its id
+// preserved and keeps the source (readInfraSnapshot / infra_class_migrate.go),
+// and coordclass.Classify routes ANY bead carrying gc.root_bead_id to ClassGraph
+// (isWorkflowMetadata) — including a plain task-typed molecule work step with no
+// gc.kind, which is exactly isWorkRecordGatedBead's population. On a migrated
+// city those steps exist in BOTH stores. The gate always validates the row the
+// close is about to write: the fall-through path validates the work store's
+// retained copy it is closing, and the door validates the class copy it is
+// closing. Neither validates the other store's stale row, because neither
+// writes it.
 //
-//   - This gate reads the PREFIX store (the caller's resolved work scope). A
-//     bead resident only in the class binding was never visible to it: the Get
-//     missed and the loop skipped the id. Routing those closes through the door
-//     removed nothing, because there was nothing to remove.
-//   - The canonical worker spelling was already outside. graph-worker.md renders
-//     `gc bd update <id> --set-metadata gc.outcome=pass --status closed`, and a
-//     served update on a class-owned bead has been answered by the door since
-//     that verb landed — well before close joined it.
-//   - What the door's close DOES take from the gate is the DUAL-RESIDENT case,
-//     and that population is real rather than hypothetical. `gc storage migrate`
-//     copies every non-work bead with its id preserved and keeps the source
-//     (readInfraSnapshot / infra_class_migrate.go), and coordclass.Classify
-//     routes ANY bead carrying gc.root_bead_id to ClassGraph
-//     (isWorkflowMetadata) — including a plain task-typed molecule work step
-//     with no gc.kind, which is exactly isWorkRecordGatedBead's population. On a
-//     migrated city those steps exist in both stores, and before the door served
-//     close, this gate evaluated them against the work store's RETAINED copy —
-//     the one frozen at migration time, not the one the close now writes. So the
-//     gate's pre-door verdict on a dual resident was already a verdict about a
-//     stale row.
-//
-// The drain path for that population is the sweep, not this gate. Both the CLI
-// door and the HTTP by-id lane now resolve a dual resident to the CLASS copy —
-// the door by its own residence probe, internal/api through the residency
-// resolver's ByID plan, which leads with the binding for exactly this reason —
-// so the two surfaces agree, and both write the row the controller reads. The
-// retained work copy stays reachable through raw bd against the work scope, and
-// it still has to be drained; that is the sweep's job, not this gate's.
+// Which copy a by-id close writes is the residency question, and both planes
+// now answer it the same way: the CLI door resolves a dual resident to the
+// CLASS copy through its own residence probe, and internal/api resolves it
+// through the residency resolver's ByID plan, which leads with the binding for
+// exactly this reason. The retained work copy stays reachable through raw bd
+// against the work scope, and it still has to be drained; that reconciliation
+// is the sweep's job, not this gate's.
 
 // workRecordEnforceEnvVar gates whether work-record violations block the close
 // (enforce) or are logged only (warn-only, the default).

--- a/internal/api/residency_by_id_test.go
+++ b/internal/api/residency_by_id_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/storeref"
+	"github.com/gastownhall/gascity/internal/storeref/storereftest"
 )
 
 // beadStoresForID renders the by-id PLAN as the ordered store list this
@@ -410,6 +411,12 @@ func TestBeadWriteLandsInClassStoreForWorkPrefixedResident(t *testing.T) {
 // The control is the id the binding does NOT hold: it must still answer from the
 // work store, which is what proves this is about residence and not about the
 // binding winning everything.
+//
+// The clauses themselves live in storereftest because they are only worth
+// anything if BOTH by-id surfaces satisfy them — this one and cmd/gc's class
+// door (TestBdCloseDualResidentWritesServingCopy). Two planes each passing their
+// own well-written pin while answering one id differently is precisely the bug,
+// so the property is written once and this test supplies the HTTP adapter.
 func TestBeadDualResidentAnswersFromTheBinding(t *testing.T) {
 	st, graph, city, _ := relocatedGraphRouteState(t)
 	st.cfg.Workspace.Prefix = "mc"
@@ -418,38 +425,32 @@ func TestBeadDualResidentAnswersFromTheBinding(t *testing.T) {
 	seedWithPinnedID(t, city, "mc-workonly1", "a work bead the binding never held")
 
 	s := New(st)
-	out, err := s.humaHandleBeadGet(context.Background(), &BeadGetInput{ID: id})
-	if err != nil {
-		t.Fatalf("GET bead %s: %v", id, err)
-	}
-	if out.Body.Title != "class-resident under a work prefix" {
-		t.Fatalf("GET served %q, want the binding's copy — the retained work copy is frozen at migration time", out.Body.Title)
-	}
-	if _, err := s.humaHandleBeadClose(context.Background(), &BeadCloseInput{ID: id}); err != nil {
-		t.Fatalf("close %s: %v", id, err)
-	}
-	classCopy, err := graph.Get(id)
-	if err != nil {
-		t.Fatalf("re-reading the class copy: %v", err)
-	}
-	if classCopy.Status != "closed" {
-		t.Errorf("the class copy's status = %q, want closed — the write must follow the read", classCopy.Status)
-	}
-	workCopy, err := city.Get(id)
-	if err != nil {
-		t.Fatalf("re-reading the work copy: %v", err)
-	}
-	if workCopy.Status == "closed" {
-		t.Errorf("the work copy was closed too; one id, one owner, one write")
-	}
-
-	control, err := s.humaHandleBeadGet(context.Background(), &BeadGetInput{ID: "mc-workonly1"})
-	if err != nil {
-		t.Fatalf("GET mc-workonly1: %v — a work bead the binding never held must still answer from work", err)
-	}
-	if control.Body.Title != "a work bead the binding never held" {
-		t.Fatalf("control GET served %q, want the work copy", control.Body.Title)
-	}
+	storereftest.RunBindingWins(t,
+		storereftest.BindingWinsStores{
+			Binding:       graph,
+			Work:          city,
+			DualID:        id,
+			BindingTitle:  "class-resident under a work prefix",
+			WorkOnlyID:    "mc-workonly1",
+			WorkOnlyTitle: "a work bead the binding never held",
+		},
+		storereftest.BindingWinsSurface{
+			Name: "the beads HTTP by-id surface",
+			Get: func(t *testing.T, id string) beads.Bead {
+				t.Helper()
+				out, err := s.humaHandleBeadGet(context.Background(), &BeadGetInput{ID: id})
+				if err != nil {
+					t.Fatalf("GET bead %s: %v", id, err)
+				}
+				return out.Body
+			},
+			Close: func(t *testing.T, id string) {
+				t.Helper()
+				if _, err := s.humaHandleBeadClose(context.Background(), &BeadCloseInput{ID: id}); err != nil {
+					t.Fatalf("POST bead %s close: %v", id, err)
+				}
+			},
+		})
 }
 
 // wholeSplitState builds the shape a relocated city actually serves: ONE

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -123,6 +123,15 @@ type ByID struct {
 // route byte-identical to the caller reading its own store. Any further legs
 // are read in order, so a multi-leg answer proves absence rather than handing
 // back a residual.
+//
+// DECLARING ONE IS A REVIEWED ACT. An implementation replaces this package's
+// by-id work rule with the plane's own, so a second one is a second answer to
+// the same question — the bug class the residency resolver exists to end,
+// wearing the resolver's API. A plane may declare at most one axis, every
+// declaration is named in scripts/residency-boundary-baseline.txt under the
+// c:WorkAxisRouter pattern, and the day a SECOND plane declares one the two
+// must land with a cross-plane router-agreement pin. The rule is stated in
+// full beside the pattern in scripts/residency-boundary-patterns.txt.
 type WorkAxisRouter interface {
 	// WorkLegsForID returns the work legs for id, or nil to leave the
 	// resolver's own [work, covering-shadows] rule in place.

--- a/internal/storeref/storereftest/binding_wins.go
+++ b/internal/storeref/storereftest/binding_wins.go
@@ -1,0 +1,175 @@
+// Package storereftest holds the cross-plane residency properties — the ones
+// that are only worth anything if EVERY by-id surface satisfies them.
+//
+// The residency resolver exists because planes disagreed about which store
+// holds a bead. A per-plane test cannot detect that: two surfaces can each pass
+// their own well-written pin and still answer differently, which is the bug. So
+// the property lives here once, as an executable definition, and each plane
+// supplies an adapter. A plane that drifts fails the shared clause with the
+// shared sentence, and a plane that is never wired in is visibly absent rather
+// than silently uncovered.
+//
+// This package is a TEST KIT that does not import the resolver: a kit built on
+// the thing under test would pass by construction. It takes two stores and two
+// closures and checks observable behavior.
+package storereftest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// BindingWinsStores is the dual-residency fixture: the two stores, the id both
+// of them hold, and the control id only work holds.
+//
+// # Why dual residency is the shape worth pinning
+//
+// `gc storage migrate` copies every non-work bead with its id PRESERVED and
+// never deletes the source, so after a migration a relocated bead exists twice:
+// the binding holds the row the controller and the class doors read and write,
+// and the work store holds a copy frozen at migration time. Both answer a Get
+// for the same id. A binding-blind surface therefore does not 404 and does not
+// error — it succeeds, against the stale copy, and a write that follows it
+// lands where nothing reads. Exit 0, no diagnostic. That silence is why this
+// has to be asserted rather than reasoned about.
+type BindingWinsStores struct {
+	// Binding is the relocated class store: the authoritative copy.
+	Binding beads.Store
+
+	// Work is the city work store holding the migration's retained copy.
+	Work beads.Store
+
+	// DualID is resident in BOTH stores under the same id, with a DIFFERENT
+	// title in each so a read can be attributed to one of them.
+	DualID string
+
+	// BindingTitle is the title of the binding's copy of DualID.
+	BindingTitle string
+
+	// WorkOnlyID is held by Work alone and by no binding — the control. Without
+	// it "the binding wins" and "residence decides" are the same test, and a
+	// surface that routed unconditionally on the prefix would pass.
+	WorkOnlyID string
+
+	// WorkOnlyTitle is the title of WorkOnlyID's only copy.
+	WorkOnlyTitle string
+}
+
+// BindingWinsSurface is one plane's by-id surface, reduced to the two verbs the
+// property is about.
+//
+// Get and Close take a *testing.T so an adapter can fail with its own plane's
+// diagnostic — an HTTP status, a CLI exit code and stderr — instead of
+// flattening every transport failure into one opaque error this package would
+// have to describe badly.
+type BindingWinsSurface struct {
+	// Name is the plane, for failure messages: "gc bd by-id door", "GET /beads".
+	Name string
+
+	// Get reads the bead the surface serves for id.
+	Get func(t *testing.T, id string) beads.Bead
+
+	// Close performs the surface's close of id.
+	Close func(t *testing.T, id string)
+}
+
+// RunBindingWins asserts the four clauses every by-id surface must satisfy on a
+// dual-resident city. Each is numbered in its failure message, so a plane that
+// breaks one is diagnosed by clause rather than by which adapter noticed.
+//
+//	(1) The READ serves the binding's copy, not the retained work copy.
+//	(2) The CLOSE writes the binding's copy, and the surface's own next read
+//	    sees it — the write follows the read, on the same surface.
+//	(3) The work copy is UNTOUCHED: one id, one owner, one write.
+//	(4) The control id the binding never held still answers from work, which is
+//	    what makes this residence rather than the binding winning everything.
+//
+// The fixture's own premise is checked first. A dual resident whose two copies
+// carry the same title, or which one of the stores does not actually hold,
+// makes every clause below vacuous — and a vacuously green cross-plane property
+// is worse than no property, because it is cited as proof of agreement.
+func RunBindingWins(t *testing.T, stores BindingWinsStores, surface BindingWinsSurface) {
+	t.Helper()
+	assertBindingWinsPremise(t, stores, surface)
+
+	got := surface.Get(t, stores.DualID)
+	if got.Title != stores.BindingTitle {
+		t.Errorf("%s clause 1: reading the dual-resident %s served %q, want the binding's copy %q — the work copy is the migration's retained one, frozen when it was copied, so serving it is not the old answer but a stale one",
+			surface.Name, stores.DualID, got.Title, stores.BindingTitle)
+	}
+
+	surface.Close(t, stores.DualID)
+
+	bindingCopy, err := stores.Binding.Get(stores.DualID)
+	if err != nil {
+		t.Fatalf("%s clause 2: re-reading the binding's copy of %s: %v", surface.Name, stores.DualID, err)
+	}
+	if bindingCopy.Status != "closed" {
+		t.Errorf("%s clause 2: the binding's copy of %s is %q after the close, want closed — a write that does not follow the read lands where nothing reads",
+			surface.Name, stores.DualID, bindingCopy.Status)
+	}
+
+	if served := surface.Get(t, stores.DualID); served.Status != "closed" {
+		t.Errorf("%s clause 2: after the close, the surface's own read of %s reports %q — the surface's read and its write disagree about which copy is authoritative, which is the divergence even a correct write cannot fix",
+			surface.Name, stores.DualID, served.Status)
+	}
+
+	workCopy, err := stores.Work.Get(stores.DualID)
+	if err != nil {
+		t.Fatalf("%s clause 3: re-reading the work copy of %s: %v", surface.Name, stores.DualID, err)
+	}
+	if workCopy.Status == "closed" {
+		t.Errorf("%s clause 3: the close reached the retained work copy of %s as well; one id, one owner, one write",
+			surface.Name, stores.DualID)
+	}
+
+	control := surface.Get(t, stores.WorkOnlyID)
+	if control.Title != stores.WorkOnlyTitle {
+		t.Errorf("%s clause 4: the control %s served %q, want the work copy %q — an id no binding holds must still answer from work, or this surface routes on the prefix rather than on residence",
+			surface.Name, stores.WorkOnlyID, control.Title, stores.WorkOnlyTitle)
+	}
+}
+
+// assertBindingWinsPremise fails the test when the fixture does not model dual
+// residency, so a clause can never pass for the wrong reason.
+func assertBindingWinsPremise(t *testing.T, stores BindingWinsStores, surface BindingWinsSurface) {
+	t.Helper()
+	switch {
+	case stores.Binding == nil || stores.Work == nil:
+		t.Fatalf("%s: the binding-wins fixture needs both stores", surface.Name)
+	case stores.DualID == "" || stores.WorkOnlyID == "":
+		t.Fatalf("%s: the binding-wins fixture needs both a dual-resident id and a work-only control", surface.Name)
+	case surface.Get == nil || surface.Close == nil:
+		t.Fatalf("%s: the binding-wins surface needs both a Get and a Close", surface.Name)
+	case stores.BindingTitle == stores.WorkOnlyTitle:
+		t.Fatalf("%s: the binding copy and the control carry the same title, so clauses 1 and 4 cannot be told apart", surface.Name)
+	}
+
+	bindingCopy, err := stores.Binding.Get(stores.DualID)
+	if err != nil {
+		t.Fatalf("%s: the binding does not hold %s (%v); without two copies there is no dual residency to resolve", surface.Name, stores.DualID, err)
+	}
+	if bindingCopy.Title != stores.BindingTitle {
+		t.Fatalf("%s: the binding's copy of %s is titled %q, not the declared %q", surface.Name, stores.DualID, bindingCopy.Title, stores.BindingTitle)
+	}
+	if bindingCopy.Status == "closed" {
+		t.Fatalf("%s: the binding's copy of %s is already closed, so clause 2 cannot observe the close", surface.Name, stores.DualID)
+	}
+
+	workCopy, err := stores.Work.Get(stores.DualID)
+	if err != nil {
+		t.Fatalf("%s: the work store does not hold %s (%v); a surface cannot answer from the wrong copy if there is only one", surface.Name, stores.DualID, err)
+	}
+	if workCopy.Title == stores.BindingTitle {
+		t.Fatalf("%s: both copies of %s are titled %q, so clause 1 cannot attribute a read to either store", surface.Name, stores.DualID, workCopy.Title)
+	}
+	if workCopy.Status == "closed" {
+		t.Fatalf("%s: the retained work copy of %s is already closed, so clause 3 cannot observe a stray write", surface.Name, stores.DualID)
+	}
+
+	if _, err := stores.Binding.Get(stores.WorkOnlyID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("%s: the binding answers for the control id %s (%v); the control must be an id no binding holds", surface.Name, stores.WorkOnlyID, err)
+	}
+}

--- a/scripts/check-residency-boundary.sh
+++ b/scripts/check-residency-boundary.sh
@@ -29,6 +29,12 @@
 #       (ResolveOwner/Union) is the only place leg order and per-leg error policy
 #       are applied; a literal list skips both, and so does a consumer that runs
 #       a plan's legs itself. Zero hits today, so the first one is a violation.
+#       WorkLegsForID is the same idea one level up: a plane that implements
+#       storeref.WorkAxisRouter tells the resolver to use the plane's leg order
+#       instead of its own, so a second implementation is a second answer to the
+#       same question. The rule governing that — one axis per plane, and a
+#       cross-plane agreement pin the day a second appears — is stated in
+#       scripts/residency-boundary-patterns.txt beside the row.
 #   (d) bespoke residence probes — IDInNamespace(, bdIDIsClassReserved(,
 #       ReservedClassPrefix(. The namespace gate is the resolver's, and a site
 #       that re-derives it is one `gc storage migrate` away from ga-axin6.
@@ -205,6 +211,18 @@ run_self_test() {
 	fixture "$tmp/rogue-baselined" $'cmd/gc/existing.go\ta\ta:BeadStores\t1\ncmd/gc/rogue.go\trogue\tc:storeref.EachLeg\t1\n'
 	printf 'package main\n\nfunc rogue(p storeref.ResolvedPlan) {\n\tstoreref.EachLeg(p, func(leg storeref.Leg, _ storeref.Role, _ storeref.ErrPolicy) {\n\t\t_, _ = leg.Store.Get("ga-1")\n\t})\n}\n' >"$tmp/rogue-baselined/cmd/gc/rogue.go"
 	expect 0 "a BASELINED storeref.EachLeg consumer must pass" "$tmp/rogue-baselined"
+
+	# THE SECOND WORK AXIS. A plane that implements storeref.WorkAxisRouter
+	# replaces the resolver's own by-id work rule with its own leg order. One
+	# such plane exists; a second written silently is two answers to one
+	# question, which is this guard's whole subject wearing the resolver's API.
+	fixture "$tmp/axis" $'cmd/gc/existing.go\ta\ta:BeadStores\t1\n'
+	printf 'package main\n\ntype rogueAxis struct{}\n\nfunc (rogueAxis) WorkLegsForID(id string) []storeref.Leg { return nil }\n' >"$tmp/axis/internal/api/axis.go"
+	expect 1 "a SECOND WorkAxisRouter implementation must fail" "$tmp/axis"
+
+	fixture "$tmp/axis-baselined" $'cmd/gc/existing.go\ta\ta:BeadStores\t1\ninternal/api/axis.go\tWorkLegsForID\tc:WorkAxisRouter\t1\n'
+	printf 'package main\n\ntype rogueAxis struct{}\n\nfunc (rogueAxis) WorkLegsForID(id string) []storeref.Leg { return nil }\n' >"$tmp/axis-baselined/internal/api/axis.go"
+	expect 0 "a BASELINED WorkAxisRouter must pass" "$tmp/axis-baselined"
 
 	return $rc
 }

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -29,12 +29,6 @@ cmd/gc/api_state.go	completionReconcileInputs	c:beads.Store-literal	1
 cmd/gc/bd_relocated_classes.go	relocatedBeadClasses	d:ReservedClassPrefix	1
 cmd/gc/build_desired_state.go	collectAssignedWorkBeadsWithStores	ast:returns-store-list	1
 cmd/gc/build_desired_state.go	collectOpenUnassignedRoutedWork	ast:returns-store-list	1
-cmd/gc/by_id_store_route.go	classRouteCandidates	ast:returns-store-list	1
-cmd/gc/by_id_store_route.go	classRouteCandidates	b:storeref.ClassCandidates	1
-cmd/gc/by_id_store_route.go	classRouteCandidates	c:beads.Store-literal	1
-cmd/gc/by_id_store_route.go	classRouteCandidates	d:ReservedClassPrefix	1
-cmd/gc/by_id_store_route.go	classRoutedStoreForID	b:graphClassBinding	1
-cmd/gc/by_id_store_route.go	classRoutedStoreForID	d:bdIDIsClassReserved	1
 cmd/gc/census_residency.go	censusLegCandidates	c:storeref.EachLeg	1
 cmd/gc/city_runtime.go	beadReconcileTick	a:rigBeadStores	1
 cmd/gc/city_runtime.go	buildStandaloneRigStores	ast:returns-store-list	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -44,7 +44,6 @@ cmd/gc/city_runtime.go	sweepOrphanedOrderTrackingAtBoot	c:beads.Store-literal	1
 cmd/gc/city_runtime.go	syncBeadsAndUpdateIndex	a:rigBeadStores	1
 cmd/gc/city_runtime.go	tick	a:rigBeadStores	4
 cmd/gc/claim_class_route.go	holds	d:bdIDIsClassReserved	1
-cmd/gc/claim_class_route.go	hookClaimClassRouteForCity	b:graphClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:graphClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:routes.storeFor	1
 cmd/gc/class_store.go	resolveClassStore	b:routes.storeFor	1
@@ -54,7 +53,6 @@ cmd/gc/class_store.go	workBeadStores	a:rigBeadStores	1
 cmd/gc/cmd_bd_by_id.go	bdByIDRefusedVerb	d:bdIDIsClassReserved	1
 cmd/gc/cmd_bd_by_id.go	bdFirstReservedClassID	d:bdIDIsClassReserved	1
 cmd/gc/cmd_bd_by_id.go	bdIDIsClassReserved	d:bdIDIsClassReserved	1
-cmd/gc/cmd_bd_by_id.go	openBdByIDClassFrontDoor	b:graphClassBinding	1
 cmd/gc/cmd_bd_by_id.go	resolve	d:bdIDIsClassReserved	1
 cmd/gc/cmd_beads.go	doBeadsListFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_beads.go	doBeadsShowFallback	a:openAllConvoyStoresAt	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -20,6 +20,12 @@
 # answers "which work store holds this id" in its own order, and the rule that
 # governs that — stated beside the pattern in residency-boundary-patterns.txt —
 # requires a cross-plane router-agreement pin to land with it.
+#
+# The two b:cliSoleClassBinding rows are the same kind of census one layer down:
+# the surfaces that answer every reserved prefix from ONE store, which is a
+# claim about the city's topology and not just a call. The accessor checks that
+# claim and refuses a fan-out, so a third row is not a correctness bug — it is a
+# new surface routing class-reserved ids, which is the thing worth seeing.
 cmd/gc/api_state.go	BeadStores	a:BeadStores	1
 cmd/gc/api_state.go	BeadStores	ast:returns-store-list	1
 cmd/gc/api_state.go	beadEventStoresLocked	ast:returns-store-list	1
@@ -44,6 +50,7 @@ cmd/gc/city_runtime.go	sweepOrphanedOrderTrackingAtBoot	c:beads.Store-literal	1
 cmd/gc/city_runtime.go	syncBeadsAndUpdateIndex	a:rigBeadStores	1
 cmd/gc/city_runtime.go	tick	a:rigBeadStores	4
 cmd/gc/claim_class_route.go	holds	d:bdIDIsClassReserved	1
+cmd/gc/claim_class_route.go	hookClaimClassRouteForCity	b:cliSoleClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:graphClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:routes.storeFor	1
 cmd/gc/class_store.go	resolveClassStore	b:routes.storeFor	1
@@ -53,6 +60,7 @@ cmd/gc/class_store.go	workBeadStores	a:rigBeadStores	1
 cmd/gc/cmd_bd_by_id.go	bdByIDRefusedVerb	d:bdIDIsClassReserved	1
 cmd/gc/cmd_bd_by_id.go	bdFirstReservedClassID	d:bdIDIsClassReserved	1
 cmd/gc/cmd_bd_by_id.go	bdIDIsClassReserved	d:bdIDIsClassReserved	1
+cmd/gc/cmd_bd_by_id.go	openBdByIDClassFrontDoor	b:cliSoleClassBinding	1
 cmd/gc/cmd_bd_by_id.go	resolve	d:bdIDIsClassReserved	1
 cmd/gc/cmd_beads.go	doBeadsListFallback	a:openAllConvoyStoresAt	1
 cmd/gc/cmd_beads.go	doBeadsShowFallback	a:openAllConvoyStoresAt	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -12,6 +12,14 @@
 # worth reviewing — internal/api/residency_by_id.go's three []storeref.Leg
 # returners are the WorkAxisRouter the resolver itself declares, and
 # c:storeref.EachLeg's two entries are the enumeration seam's only consumers.
+#
+# The single c:WorkAxisRouter row is the census of storeref.ByID.WorkAxis
+# implementations. It is deliberately HERE and not in the shell guard's
+# allowlist: the allowlist filters a file before counting, which would blind the
+# ratchet to exactly the growth worth seeing. A second row means a second plane
+# answers "which work store holds this id" in its own order, and the rule that
+# governs that — stated beside the pattern in residency-boundary-patterns.txt —
+# requires a cross-plane router-agreement pin to land with it.
 cmd/gc/api_state.go	BeadStores	a:BeadStores	1
 cmd/gc/api_state.go	BeadStores	ast:returns-store-list	1
 cmd/gc/api_state.go	beadEventStoresLocked	ast:returns-store-list	1
@@ -106,6 +114,7 @@ internal/api/huma_handlers_convoys.go	humaHandleConvoyGet	a:BeadStores	1
 internal/api/huma_handlers_convoys.go	humaHandleConvoyList	a:BeadStores	1
 internal/api/huma_handlers_convoys.go	humaHandleConvoyRemove	a:BeadStores	1
 internal/api/residency_by_id.go	WorkLegsForID	ast:returns-store-list	1
+internal/api/residency_by_id.go	WorkLegsForID	c:WorkAxisRouter	1
 internal/api/residency_by_id.go	configuredPrefixLegs	ast:returns-store-list	1
 internal/api/residency_by_id.go	resolveLegByConfiguredIDPrefix	d:IDInNamespace	1
 internal/api/residency_by_id.go	unroutedWorkLegs	a:BeadStores	1

--- a/scripts/residency-boundary-patterns.txt
+++ b/scripts/residency-boundary-patterns.txt
@@ -45,9 +45,25 @@ b:storeref.ClassCandidates	(^|[^A-Za-z0-9_])storeref\.ClassCandidates\(
 #     its own order with its own error handling, and pass both halves of the
 #     guard — which is the whole failure this file exists to prevent, wearing
 #     the resolver's name.
+#
+#     storeref.ByID.WorkAxis is the other sanctioned seam, and the same reasoning
+#     applies one level up: a plane that declares a work axis is telling the
+#     resolver "do not use your own rule here, use mine". THE RULE: a plane may
+#     declare at most one work axis, every declaration is named in the baseline,
+#     and the day a SECOND plane declares one the two must land with a
+#     cross-plane router-agreement pin — a shared-fixture test asserting both
+#     routers name the same owner leg sequence for configured-prefix ids, routed
+#     ids and unrouted ids, with any deliberate difference pinned as golden rows
+#     rather than settled in review prose. Today there is exactly one
+#     (internal/api's apiWorkAxis), so nothing stops a second from being written
+#     that diverges silently; this row is what makes writing it a reviewed act.
+#     The router's rows stay in the shrink-only baseline rather than moving to
+#     the script's allowlist: the allowlist filters a file BEFORE counting, and
+#     the router is the one file whose growth is most worth seeing.
 c:beads.Store-literal	\[\]beads\.Store\{
 c:plan-leg-store-access	\.Leg\.Store($|[^A-Za-z0-9_])
 c:storeref.EachLeg	(^|[^A-Za-z0-9_])storeref\.EachLeg\(
+c:WorkAxisRouter	(^|[^A-Za-z0-9_])WorkLegsForID\(
 # (d) bespoke residence probes. The namespace gate is the resolver's, and a site
 #     that re-derives it is one `gc storage migrate` away from ga-axin6.
 d:IDInNamespace	(^|[^A-Za-z0-9_])IDInNamespace\(

--- a/scripts/residency-boundary-patterns.txt
+++ b/scripts/residency-boundary-patterns.txt
@@ -26,7 +26,19 @@ a:openSourceWorkflowStores	(^|[^A-Za-z0-9_])openSourceWorkflowStores\(
 a:convoyStoreCandidates	(^|[^A-Za-z0-9_])convoyStoreCandidates\(
 # (b) direct binding-gate re-derivation. Asking "is this class relocated" a
 #     second time is how the split-store bug class reproduces (#5125, #5127).
+#
+#     cliSoleClassBinding is the SANCTIONED accessor for the callers that answer
+#     every reserved prefix out of one store, and it is ratcheted for the same
+#     reason storeref.EachLeg is: sanctioned is not free. Each call site is a
+#     surface asserting "this city serves all five infrastructure classes from
+#     one binding, and I am about to act on that" — the condition the accessor
+#     checks and refuses a fan-out for. Two are baselined today (the `gc bd`
+#     by-id front door and the claim-time class route). A third is a reviewed
+#     baseline change, because the review that matters is not whether the
+#     accessor was called correctly but whether that surface should be routing
+#     class-reserved ids at all.
 b:graphClassBinding	(^|[^A-Za-z0-9_])graphClassBinding\(
+b:cliSoleClassBinding	(^|[^A-Za-z0-9_])cliSoleClassBinding\(
 b:routes.storeFor	(^|[^A-Za-z0-9_])routes\.storeFor\(
 b:storeref.ClassCandidates	(^|[^A-Za-z0-9_])storeref\.ClassCandidates\(
 # (c) hand-rolled probe lists and plan disassembly. The executor

--- a/scripts/residency_boundary_test.go
+++ b/scripts/residency_boundary_test.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -433,6 +434,24 @@ func eleventh() map[string]beads.Store { return nil }
 		}
 	})
 
+	t.Run("a subpackage is not a hiding place", func(t *testing.T) {
+		writeResidencyFixture(t, root, "internal/api/dashboardbff/nested.go", `package dashboardbff
+
+import "github.com/gastownhall/gascity/internal/beads"
+
+func nested() []beads.Store { return nil }
+`)
+		defer func() {
+			if err := os.Remove(filepath.Join(root, "internal/api/dashboardbff/nested.go")); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+		}()
+		v := scan(t, base)
+		if len(v) == 0 || !strings.Contains(strings.Join(v, " "), "dashboardbff/nested.go") {
+			t.Fatalf("the AST guard accepted a store-list signature one directory down: %v", v)
+		}
+	})
+
 	t.Run("stale baseline forces a shrink", func(t *testing.T) {
 		if err := os.Remove(filepath.Join(root, "cmd/gc/eleventh.go")); err != nil {
 			t.Fatalf("remove: %v", err)
@@ -450,30 +469,49 @@ func eleventh() map[string]beads.Store { return nil }
 
 // scanStoreListSignatures counts, per file, the non-test functions whose
 // results include a raw []beads.Store or map[string]beads.Store.
+//
+// The walk RECURSES, because the grep half does (`find "${present[@]}" -type f
+// -name '*.go'`). A flat read here left every subpackage of a governed
+// directory — internal/api/dashboardbff, internal/api/genclient — outside this
+// half entirely: a store-list constructor added there was caught only if its
+// body also spelled the grep half's vocabulary, which a hand-rolled probe list
+// need not do. The halves are supposed to cover the same tree by different
+// means, not different trees.
 func scanStoreListSignatures(root string, dirs []string, allowlist map[string]bool) (map[string]int, error) {
 	found := map[string]int{}
 	fset := token.NewFileSet()
 	for _, dir := range dirs {
 		abs := filepath.Join(root, filepath.FromSlash(dir))
-		entries, err := os.ReadDir(abs)
-		if os.IsNotExist(err) {
+		if _, err := os.Stat(abs); os.IsNotExist(err) {
 			continue
 		}
-		if err != nil {
-			return nil, err
-		}
-		for _, entry := range entries {
-			name := entry.Name()
-			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-				continue
-			}
-			rel := dir + "/" + name
-			if allowlist[rel] {
-				continue
-			}
-			file, err := parser.ParseFile(fset, filepath.Join(abs, name), nil, parser.ParseComments)
+		walkErr := filepath.WalkDir(abs, func(path string, entry fs.DirEntry, err error) error {
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", rel, err)
+				return err
+			}
+			name := entry.Name()
+			if entry.IsDir() {
+				// node_modules and the built dashboard bundle hold no Go and
+				// are large enough that walking them is a real cost.
+				if path != abs && (name == "node_modules" || name == "dist") {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				return nil
+			}
+			relPath, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			rel := filepath.ToSlash(relPath)
+			if allowlist[rel] {
+				return nil
+			}
+			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				return fmt.Errorf("%s: %w", rel, err)
 			}
 			for _, decl := range file.Decls {
 				fn, ok := decl.(*ast.FuncDecl)
@@ -490,6 +528,10 @@ func scanStoreListSignatures(root string, dirs []string, allowlist map[string]bo
 					}
 				}
 			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, walkErr
 		}
 	}
 	return found, nil


### PR DESCRIPTION
**Segment 1 of 8 — split out of #5597 at the reviewer's request.** Base: `main`.

#5597 was 186 files and 18,100 changed lines, past the ceiling the review tooling
serves in one pass. It has been cut into eight stacked PRs, each a branch pointed
at a commit that was already in the series — no rebase, no commit rewriting, no
conflict resolution, so every commit here is byte-identical to the one that was
reviewed and CI-tested as part of #5597. Each segment builds, vets and passes the
residency boundary guard on its own.

| # | PR | lines | story |
|---|----|-------|-------|
| 1 | **this one** | 1,998 | CLI by-id reads converge on the resolver |
| 2 | #5641 | 3,408 | blind writers get class placement; the boot relic census |
| 3 | #5642 | 1,838 | the foreign-id provider contracts |
| 4 | #5643 | 2,221 | make the residency rows falsify; close guard evasions |
| 5 | #5644 | 2,479 | fence every provider; count closed relics |
| 6 | #5645 | 2,315 | retire the last hand-rolled probes |
| 7 | #5646 | 3,143 | pure code motion of the guard |
| 8 | #5597 | 4,180 | cutover: payload carry, binding verdicts, preflight |

**Read this one first.** It is where the bug class is stated, and every later
segment is an application of it.

---

## The bug class

A city that has split its beads across a work ledger and a relocated infra-class
**binding** has two places a given id can live. `gc storage migrate` preserves ids
and deletes nothing, so after a cutover the work ledger still holds a **frozen
copy** of every relocated bead — correct at cutover, never touched since.

Every read that walks the city's *directories* to find a bead therefore has a
second, wrong answer available to it. And the failure is silent, because *"the
binding could not answer"* and *"the bead is not there"* were the same outcome:
a miss fell through to the directory scan, the scan found the frozen twin, and
the command printed it with exit 0.

`internal/storeref` already owned the correct walk — `Plan(ByID)` and the binding
legs — from the earlier slices on `main`. What this segment does is stop the CLI
by-id surfaces from re-deriving it.

## What changed

**`classRoutedStoreForID` routes through the residency resolver** rather than its
own hand-rolled binding lookup, and the `gc bd` class front door resolves from the
resolver's grouped bindings instead of `graphClassBinding`'s parallel grouping.
Two code paths that answered "who owns this id" became one.

**`gc beads` and `gc convoy` ask the class binding before scanning the city's
directories.** That ordering is the fix: the binding is the authority for its
namespaces, so a directory scan is a fallback, not a peer.

**Binding-wins became one shared property both by-id surfaces run**
(`internal/storeref/storereftest/binding_wins.go`), so the CLI and the API cannot
drift on it — the same table drives both, and a surface that stops honouring the
binding fails in the shared row rather than in whichever plane happened to have a
test.

**Class-door closes are gated through ADR-0009**, and `maybeRouteBdByID` is split
so the routing decision and the close gate are separable.

**The guard grew a second half.** `scripts/check-residency-boundary.sh` was a grep
ratchet; its AST half now walks the same tree the grep half walks, and
`cliSoleClassBinding` call sites are ratcheted so a new blind reader has to be a
reviewed act rather than an unnoticed one. `093a55ed79` makes adding a second
by-id work axis explicitly reviewed for the same reason.

The last commit pins two rules an earlier mutation sweep found unguarded — both
were correct in production and simply had nothing asserting them.

## Verification

- `go build ./...`, `go vet ./...` clean at this head
- `./scripts/check-residency-boundary.sh` passes
- `go test ./internal/testutil/providerledger/` green (this head carries main's
  runtime-provider waiver renewal; every segment does)
- Full-suite results are inherited: these commits were tested as part of #5597,
  whose head was green across all 86 checks

Refs `ga-qdt5y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
