### PR TITLE
fix(residency): give the blind write paths class placement and census the binding's relics

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1706,6 +1706,18 @@ func (cs *controllerState) OrdersBeadStore() beads.OrdersStore {
 	return beads.OrdersStore{Store: resolveOrderStore(cs.storageRoutes, cs.cityBeadStore, cs.cfg, cs.cityPath, cs.eventProv)}
 }
 
+// ClassBindingHasLegacyResidents replays the boot census for one binding store.
+//
+// The store values the class accessors above hand out are the routes' own
+// stores — resolveClassStore returns routes.storeFor unwrapped — so the census
+// map the boot keyed by store answers directly here. A store this city never
+// censused, the work store included, keeps its probe.
+func (cs *controllerState) ClassBindingHasLegacyResidents(store beads.Store) bool {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return cs.storageRoutes.hasLegacyResidents(store)
+}
+
 // CityBeadsDiagnostic returns the city-level bead store selection diagnostic.
 func (cs *controllerState) CityBeadsDiagnostic() *beads.BeadsDiagnostic {
 	cs.mu.RLock()

--- a/cmd/gc/class_store_agreement_test.go
+++ b/cmd/gc/class_store_agreement_test.go
@@ -1,0 +1,153 @@
+package main
+
+// The legacy front door and the placement plan must name the same store.
+//
+// resolveClassStore is what every class-scoped write in cmd/gc still goes
+// through, and storeref.Plan(Class{…}) is what the resolver answers the same
+// question with. They are separate code reading the same routes, and a class
+// they disagree about is a class whose writes land in one store while every
+// resolver-built reader looks in the other — a bead that exists and cannot be
+// found, with no error anywhere to say so.
+//
+// This is an agreement pin, not a behavior test: neither side is asserted
+// against a literal store here, only against each other, so the day one of them
+// gains a class the other does not, this fails rather than the fleet.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// configClasses is every class name resolveClassStore can be asked about.
+func configClasses() []string {
+	return []string{
+		config.BeadClassWork,
+		config.BeadClassGraph,
+		config.BeadClassMessaging,
+		config.BeadClassSessions,
+		config.BeadClassOrders,
+		config.BeadClassNudges,
+	}
+}
+
+func TestResolveClassStoreAgreesWithThePlacementPlan(t *testing.T) {
+	binding := beads.NewMemStore()
+	graphOnly := beads.NewMemStore()
+	sessionsOnly := beads.NewMemStore()
+
+	wholeSplit := map[coordclass.Class]beads.Store{}
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			wholeSplit[class] = binding
+		}
+	}
+
+	tests := []struct {
+		name   string
+		routes *storageRoutes
+	}{
+		{"single-store city", nil},
+		{"whole split", &storageRoutes{stores: wholeSplit, binding: "infra"}},
+		{
+			// Not a shape this build serves (storageSupportedTopologyStatement),
+			// but both sides accept it as data and a disagreement here is the
+			// same disagreement.
+			name: "per-class split",
+			routes: &storageRoutes{stores: map[coordclass.Class]beads.Store{
+				coordclass.ClassGraph:    graphOnly,
+				coordclass.ClassSessions: sessionsOnly,
+			}, binding: "infra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			work := beads.NewMemStore()
+			bindings, refused := residencyBindingsFromRoutes(tt.routes)
+			topo := assembleResidencyTopology(nil, work, nil, bindings, refused)
+
+			for _, class := range configClasses() {
+				got := resolveClassStore(tt.routes, work, nil, "", class, nil)
+				plan, err := storeref.Plan(storeref.Class{C: coordclassFor(class)}, topo)
+				if err != nil {
+					t.Fatalf("planning placement for %q: %v", class, err)
+				}
+				if plan.Mode != storeref.ModeSingleOwner || len(plan.Legs) != 1 {
+					t.Fatalf("placement plan for %q is %s, want one single-owner leg", class, plan)
+				}
+				if want := plan.Legs[0].Leg.Store; got != want {
+					t.Errorf("%q: the front door writes to %p, the plan reads %p (%s) — a bead written through one is invisible to the other",
+						class, got, want, plan.Legs[0].Leg.Ref)
+				}
+			}
+		})
+	}
+}
+
+// An unrecognized class name is the residual, on both sides: coordclassFor maps
+// it to work rather than guessing, so the front door leaves it on the work
+// ledger and the plan names the same leg. The control that matters is that it
+// is NOT silently routed at whatever binding happens to be open.
+func TestAnUnknownClassNameStaysOnTheWorkLedger(t *testing.T) {
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	stores := map[coordclass.Class]beads.Store{}
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			stores[class] = binding
+		}
+	}
+	routes := &storageRoutes{stores: stores, binding: "infra"}
+
+	got := resolveClassStore(routes, work, nil, "", "a-class-this-build-does-not-know", nil)
+	if got == binding {
+		t.Fatal("an unknown class name routed at the binding; a name this build cannot interpret must never be relocated")
+	}
+	if got != work {
+		t.Fatalf("unknown class resolved to %p, want the work store %p", got, work)
+	}
+}
+
+// A refused city refuses its classes on both sides. The front door hands back a
+// store that answers the refusal, and the plan errors with it; what neither may
+// do is answer the work ledger, which is the degraded answer that looks like
+// success while reading the store the class was moved off.
+func TestRefusedCityNeverPlacesAClassOnTheWorkLedger(t *testing.T) {
+	work := beads.NewMemStore()
+	routes := refusingStorageRoutes("infra", errors.New("storage: this build cannot serve the configured split"))
+	bindings, refused := residencyBindingsFromRoutes(routes)
+	topo := assembleResidencyTopology(nil, work, nil, bindings, refused)
+
+	for _, class := range configClasses() {
+		got := resolveClassStore(routes, work, nil, "", class, nil)
+		_, err := storeref.Plan(storeref.Class{C: coordclassFor(class)}, topo)
+
+		if class == config.BeadClassWork {
+			// Work is untouched by a refusal: a refused city still serves its
+			// work beads from its work ledger.
+			if got != work {
+				t.Errorf("work resolved to %p on a refused city, want the work store", got)
+			}
+			if err != nil {
+				t.Errorf("planning work placement on a refused city: %v", err)
+			}
+			continue
+		}
+		if got == work {
+			t.Errorf("%q resolved to the work ledger on a refused city; the refusal exists to stop exactly that read", class)
+		}
+		if _, readErr := got.Get("gcg-probe"); !storeref.IsStandingRefusal(readErr) {
+			t.Errorf("%q resolved to a store whose read fails with %v rather than the standing refusal; a not-found is what an empty serving store says too", class, readErr)
+		}
+		if err == nil {
+			t.Errorf("planning %q placement on a refused city returned no error", class)
+		} else if !storeref.IsStandingRefusal(err) {
+			t.Errorf("planning %q placement failed with %v, want the standing storage refusal", class, err)
+		}
+	}
+}

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -832,10 +832,11 @@ func bdByIDMutationSubjects(bdArgs []string) []string {
 }
 
 // bdIDIsClassReserved reports whether id carries a reserved class id prefix.
-// Those prefixes are minted only by the relocated class stores, so such an id
+// Those namespaces belong to the relocated class stores — whether the store's
+// own sequence minted the id or a subsystem inside it did — so such an id
 // existing anywhere else is not a thing bd can answer for.
 func bdIDIsClassReserved(id string) bool {
-	for _, prefix := range config.ReservedClassPrefixes() {
+	for _, prefix := range config.AllReservedClassPrefixes() {
 		if prefix != "" && strings.HasPrefix(id, prefix+"-") {
 			return true
 		}

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -403,7 +403,7 @@ func TestBdByIDReservedPrefixAbsenceIsNotAFallThrough(t *testing.T) {
 func TestBdByIDRoutesAWorkShapedIDResidentInTheClassBinding(t *testing.T) {
 	cityPath, classStore := foreignProviderCity(t)
 	migrated := beads.Bead{ID: "demo-premigration", Title: "carried across by the migration", Type: "task", Description: "work-shaped id, class-resident row"}
-	created, err := classStore.Create(migrated)
+	created, err := migrationSeed(classStore, migrated)
 	if err != nil {
 		t.Fatalf("seeding a work-shaped id in the class binding: %v", err)
 	}
@@ -1058,19 +1058,24 @@ func reservedClassID(t *testing.T, suffix string) string {
 // The tests below cover the write-orphaned class resident: a bead whose id
 // carries a WORK prefix but whose only row lives in the class binding.
 //
-// It is the population the class store MINTS rather than the one the migration
-// carried across — a class-store Create with no id mints from the binding
-// workspace's own prefix, which on a converged city is a work prefix — and it
-// is write-unreachable without a residence lane: reads reach it (the door
-// probes the class leg for every id) while writes route by prefix at a ledger
-// that never held the row.
+// A converged city holds this population two ways — the migration carried the
+// pre-split rows across with their ids PRESERVED, and a class-store Create with
+// no id mints from the binding workspace's own prefix, which on such a city is
+// still a work prefix. Either way it is write-unreachable without a residence
+// lane: reads reach it (the door probes the class leg for every id) while writes
+// route by prefix at a ledger that never held the row.
 
 // classResidentWorkShapedBead seeds a bead with an explicit WORK-shaped id into
 // the class binding only, and proves the id carries no reserved prefix so the
 // test exercises the residence probe rather than the prefix rule.
+//
+// It seeds through the foreign-id create because that is the only way a pinned
+// foreign id enters a binding — the ordinary create fences them out, which is
+// what stops a live subsystem from writing one there by accident. Pinning the id
+// rather than taking a minted one is what lets the tests name it.
 func classResidentWorkShapedBead(t *testing.T, classStore beads.Store, id, title string) beads.Bead {
 	t.Helper()
-	created, err := classStore.Create(beads.Bead{ID: id, Title: title, Type: "task"})
+	created, err := migrationSeed(classStore, beads.Bead{ID: id, Title: title, Type: "task"})
 	if err != nil {
 		t.Fatalf("seeding %s in the class binding: %v", id, err)
 	}
@@ -1078,6 +1083,17 @@ func classResidentWorkShapedBead(t *testing.T, classStore beads.Store, id, title
 		t.Fatalf("the fixture id %q carries a reserved class prefix; it cannot exercise the residence probe", created.ID)
 	}
 	return created
+}
+
+// migrationSeed writes a bead into a binding the way `gc storage migrate` does:
+// through the store's foreign-id create, which keeps a preserved id that the
+// ordinary create fences out.
+func migrationSeed(store beads.Store, b beads.Bead) (beads.Bead, error) {
+	creator, ok := store.(beads.ForeignIDCreator)
+	if !ok {
+		return beads.Bead{}, fmt.Errorf("%T cannot create with a foreign id, so it cannot hold a bead the migration carried across", store)
+	}
+	return creator.CreateWithForeignID(b)
 }
 
 // workStoreFor opens the city's own work ledger — the store the bd subprocess

--- a/cmd/gc/cmd_storage.go
+++ b/cmd/gc/cmd_storage.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/storebinding"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 const (
@@ -474,6 +475,7 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 		fmt.Fprintf(stdout, "converged: no\nblocking invariant: boot never migrates; run `%s`\n", storageMigrationCommand) //nolint:errcheck // best-effort stdout
 		return 1
 	}
+	reportBindingRelics(target, logPrefix, stdout, stderr)
 
 	proven, recorded, err := readInfraCopyManifest(target)
 	if err != nil {
@@ -501,6 +503,35 @@ func doStorageStatus(request storageOperatorRequest, stdout, stderr io.Writer) i
 		return 1
 	}
 	return 0
+}
+
+// reportBindingRelics prints how many beads the binding still holds under ids
+// no reader can route to it from — the rows the cutover carried across under
+// their original work-shaped ids.
+//
+// That count is the residence probe's retirement condition. While it is
+// non-zero every work-shaped by-id read in the city pays one extra store read
+// to find beads that are reachable no other way, and it falls only as those
+// beads close. An operator draining a migrated city has nothing else to watch.
+//
+// It never changes the exit code. A relic is the migration working as designed,
+// so a status command that failed over one would report every city that ever
+// migrated as broken. A binding that cannot be read is reported and skipped for
+// the same reason: the layout facts above it stand on their own.
+func reportBindingRelics(target infraBindingTarget, logPrefix string, stdout, stderr io.Writer) {
+	binding, err := openInfraDestination(target)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: counting open relics: opening the binding: %v\n", logPrefix, err) //nolint:errcheck // best-effort stderr
+		return
+	}
+	defer closeBeadStoreHandle(binding) //nolint:errcheck // best-effort close
+
+	relics, err := storeref.OpenLegacyResidents(binding, config.AllReservedClassPrefixes())
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", logPrefix, err) //nolint:errcheck // best-effort stderr
+		return
+	}
+	fmt.Fprintf(stdout, "open relics: %d (carried across under their original ids; the residence probe retires when the last one closes)\n", len(relics)) //nolint:errcheck // best-effort stdout
 }
 
 // cityMigrationGuardDirectory returns the city .gc directory the migration

--- a/cmd/gc/relic_census_boot_test.go
+++ b/cmd/gc/relic_census_boot_test.go
@@ -1,0 +1,263 @@
+package main
+
+// The boot census, and the probe it is allowed to retire.
+//
+// C4 made the mint bit an observation and left the relic bit pessimistically
+// true, so nothing retired. This is the commit where a plan shape actually
+// changes, and these rows are the live pair the change is worth: a clean
+// binding stops probing, and a binding holding one migrated bead does not.
+//
+// Both rows run against a REAL sqlite binding opened by openStorageRoutes,
+// because the claim is about what a converged city's boot observes, and a
+// hand-built topology could assert the bits without ever proving the boot sets
+// them.
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// openSplitBindingRoutes opens the routes a converged whole-split city boots
+// with, against a real sqlite binding on disk.
+func openSplitBindingRoutes(t *testing.T) *storageRoutes {
+	t.Helper()
+	root := t.TempDir()
+	cfg := infraSplitConfig(filepath.Join(root, "store"))
+	plan, err := resolveCityStoragePlan(root, cfg)
+	if err != nil {
+		t.Fatalf("resolving the storage plan for a converged split city: %v", err)
+	}
+	routes, err := openStorageRoutes(plan, mustResolveInfraTarget(t, root, cfg))
+	if err != nil {
+		t.Fatalf("openStorageRoutes: %v", err)
+	}
+	t.Cleanup(func() { _ = routes.close() })
+	return routes
+}
+
+// soleBinding is the one binding a whole-split city relocates every class onto.
+func soleBinding(t *testing.T, routes *storageRoutes) storeref.ClassBinding {
+	t.Helper()
+	bindings, err := residencyBindingsFromRoutes(routes)
+	if err != nil {
+		t.Fatalf("building bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("got %d bindings, want the one this build serves", len(bindings))
+	}
+	return bindings[0]
+}
+
+// bindingLegRead reports whether a by-id plan for id would read the binding.
+func bindingLegRead(t *testing.T, routes *storageRoutes, id string) bool {
+	t.Helper()
+	topo := assembleResidencyTopology(nil, beads.NewMemStore(), nil, mustBindings(t, routes), nil)
+	plan, err := storeref.Plan(storeref.ByID{ID: id}, topo)
+	if err != nil {
+		t.Fatalf("planning a by-id read of %q: %v", id, err)
+	}
+	ref := storeref.ClassRef(infrastructureClasses())
+	for _, leg := range plan.Legs {
+		if leg.Leg.Ref == ref {
+			return true
+		}
+	}
+	return false
+}
+
+func mustBindings(t *testing.T, routes *storageRoutes) []storeref.ClassBinding {
+	t.Helper()
+	bindings, err := residencyBindingsFromRoutes(routes)
+	if err != nil {
+		t.Fatalf("building bindings: %v", err)
+	}
+	return bindings
+}
+
+func TestBootCensusRetiresTheProbeOnACleanBinding(t *testing.T) {
+	routes := openSplitBindingRoutes(t)
+	censusBindingRelics(routes)
+
+	binding := soleBinding(t, routes)
+	if !binding.MintsReserved {
+		t.Fatal("the binding does not mint inside its own namespaces, so this row is not testing retirement at all — the relic bit is dead weight while the mint bit is off")
+	}
+	if binding.HasLegacyResidents {
+		t.Error("a freshly opened binding reported legacy residents; nothing has ever been written to it")
+	}
+	if bindingLegRead(t, routes, "ga-1") {
+		t.Error("a work-shaped by-id read still probes the binding of a city that has never held a migrated bead; the probe is the per-read cost this census exists to remove")
+	}
+}
+
+// The ga-axin6 pin, at the topology level: one bead the migration carried
+// across is enough to keep every work-shaped read probing, because that bead
+// is reachable no other way.
+func TestBootCensusKeepsTheProbeForAMigratedBead(t *testing.T) {
+	routes := openSplitBindingRoutes(t)
+	store, ok := routes.storeFor(coordclass.ClassGraph)
+	if !ok {
+		t.Fatal("the split city relocated no graph store")
+	}
+	creator, ok := store.(beads.ForeignIDCreator)
+	if !ok {
+		t.Fatalf("%T cannot create with a foreign id, so it cannot hold a bead the migration carried across", store)
+	}
+	if _, err := creator.CreateWithForeignID(beads.Bead{ID: "ga-relic", Title: "carried across", Type: "task"}); err != nil {
+		t.Fatalf("seeding the relic the way `gc storage migrate` does: %v", err)
+	}
+	censusBindingRelics(routes)
+
+	if !soleBinding(t, routes).HasLegacyResidents {
+		t.Fatal("the census missed a bead sitting open in the binding under a work-shaped id")
+	}
+	if !bindingLegRead(t, routes, "ga-relic") {
+		t.Error("the plan for the relic's own id never reads the binding it lives in; the bead is unreachable")
+	}
+}
+
+// The ordering guard. C5 landing before C4's pessimistic default, or a plane
+// building bindings from routes the boot never censused, must not retire
+// anything: an unasked question is not a clean answer.
+func TestUncensusedRoutesKeepTheirProbe(t *testing.T) {
+	routes := openSplitBindingRoutes(t)
+
+	if !soleBinding(t, routes).HasLegacyResidents {
+		t.Error("routes that were never censused reported a clean binding")
+	}
+	if !bindingLegRead(t, routes, "ga-1") {
+		t.Error("an uncensused city retired its probe")
+	}
+}
+
+// convergedEmptyInfraCity is convergedInfraCity's clean twin: a city that cut
+// over while its work store held no infrastructure at all, so the binding it
+// boots on holds no relic.
+//
+// That is the only shape whose probe may retire, and it is the shape mc reaches
+// on the day its last carried-across bead closes.
+func convergedEmptyInfraCity(t *testing.T) (string, *config.City) {
+	t.Helper()
+	cityPath := t.TempDir()
+	stubInfraMigrationSource(t)
+	cfg := infraSplitConfig(filepath.Join(cityPath, ".gc", "store"))
+
+	var log bytes.Buffer
+	if got := migrateInfraClasses(t, cityPath, cfg, &log); got.Outcome != infraMigrationConverged {
+		t.Fatalf("cutover outcome = %v, want converged; log: %s", got.Outcome, log.String())
+	}
+	return cityPath, cfg
+}
+
+// The census's call site, through the real boot gate.
+//
+// The rows above call censusBindingRelics directly. That proves the census
+// works and proves nothing about whether the boot ever takes it — with the call
+// deleted from storageBootGate they would all still pass, and every city would
+// quietly go back to probing forever. This row boots a converged city the way
+// `gc start` does and asserts the routes it hands back already carry the clean
+// verdict.
+func TestBootGateTakesTheCensus(t *testing.T) {
+	cityPath, cfg := convergedEmptyInfraCity(t)
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("booting a converged city: %v (stderr: %s)", err, stderr.String())
+	}
+	t.Cleanup(func() { _ = routes.close() })
+
+	binding := soleBinding(t, routes)
+	if !binding.MintsReserved {
+		t.Fatal("the booted binding does not mint inside its own namespaces, so the relic bit decides nothing here and this row tests no retirement")
+	}
+	if binding.HasLegacyResidents {
+		t.Error("the boot gate handed back a binding still marked as holding relics; the census the gate exists to take was never taken")
+	}
+	if bindingLegRead(t, routes, "ga-1") {
+		t.Error("every work-shaped read of a converged, relic-free city still probes the binding")
+	}
+}
+
+// The same gate, on the city shape that actually shipped: one bead carried
+// across under its original work id. The boot must observe it and keep probing.
+func TestBootGateKeepsTheProbeForACityThatMigratedWork(t *testing.T) {
+	cityPath, cfg, source, _ := convergedInfraCity(t)
+	carried := infraStoreFingerprint(t, source)
+	if len(carried) == 0 {
+		t.Fatal("the converged fixture migrated nothing, so this row cannot distinguish an observed relic from the pessimistic default")
+	}
+
+	var stderr bytes.Buffer
+	routes, err := storageBootGate(cityPath, cfg, "gc start", nil, &stderr)
+	if err != nil {
+		t.Fatalf("booting a converged city: %v (stderr: %s)", err, stderr.String())
+	}
+	t.Cleanup(func() { _ = routes.close() })
+
+	if !soleBinding(t, routes).HasLegacyResidents {
+		t.Fatalf("the boot retired the probe on a binding holding %v", carried)
+	}
+	if !bindingLegRead(t, routes, carried[0]) {
+		t.Errorf("the plan for %s never reads the binding it was carried into; the bead is unreachable", carried[0])
+	}
+}
+
+// The operator's view of the same count.
+//
+// The probe retires on its own, silently, on the day the last relic closes.
+// Without a number an operator can watch, a city that has been paying the probe
+// for weeks looks exactly like one that retired it, and there is nothing to
+// point at when asking why every read costs two.
+func TestStorageStatusCountsTheOpenRelics(t *testing.T) {
+	cityPath, cfg, source, _ := convergedInfraCity(t)
+	carried := infraStoreFingerprint(t, source)
+	if len(carried) != 1 {
+		t.Fatalf("the converged fixture carried %d beads across, want exactly 1 so the printed count is unambiguous", len(carried))
+	}
+	stubInfraControllerPing(t, 0)
+
+	var stdout, stderr bytes.Buffer
+	code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr)
+	got := stdout.String()
+	if code != 0 {
+		t.Fatalf("status exited %d on a converged city; a carried-across bead is the migration working, not a fault (stdout: %s, stderr: %s)", code, got, stderr.String())
+	}
+	if !strings.Contains(got, "open relics: 1") {
+		t.Errorf("status does not count the open relics:\n%s", got)
+	}
+	if !strings.Contains(got, "probe") {
+		t.Errorf("status names a relic count but not what it blocks, so an operator cannot tell why it matters:\n%s", got)
+	}
+}
+
+// The other end of the drain: a city that cut over clean prints zero, so the
+// operator watching the count fall sees it land.
+func TestStorageStatusReportsNoRelicsOnACleanCutover(t *testing.T) {
+	cityPath, cfg := convergedEmptyInfraCity(t)
+	stubInfraControllerPing(t, 0)
+
+	var stdout, stderr bytes.Buffer
+	if code := doStorageStatus(storageOperatorRequest{CityPath: cityPath, Cfg: cfg}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status exited %d on a clean converged city (stdout: %s, stderr: %s)", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "open relics: 0") {
+		t.Errorf("status does not report the retired probe:\n%s", got)
+	}
+}
+
+// A city that relocates nothing has no binding to census, and the census must
+// not care.
+func TestCensusOfIdentityRoutesIsANoOp(t *testing.T) {
+	censusBindingRelics(nil)
+	if bindings := mustBindings(t, nil); len(bindings) != 0 {
+		t.Errorf("nil routes produced %d bindings", len(bindings))
+	}
+}

--- a/cmd/gc/residency_namespace_test.go
+++ b/cmd/gc/residency_namespace_test.go
@@ -40,6 +40,7 @@ func TestCLIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
 			bindings, _ := residencyBindingsFor(
 				[]beads.Store{tt.store},
 				map[beads.Store][]coordclass.Class{tt.store: {coordclass.ClassGraph}},
+				nil,
 			)
 			if len(bindings) != 1 {
 				t.Fatalf("got %d bindings, want 1", len(bindings))
@@ -48,7 +49,7 @@ func TestCLIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
 				t.Errorf("MintsReserved = %v, want %v", bindings[0].MintsReserved, tt.mints)
 			}
 			if !bindings[0].HasLegacyResidents {
-				t.Error("HasLegacyResidents = false, but nothing in this build censuses the binding's residents; the probe would retire over every id the migration preserved")
+				t.Error("HasLegacyResidents = false for a caller that supplied no census; an unasked question is not a clean answer, and the probe would retire over every id the migration preserved")
 			}
 		})
 	}

--- a/cmd/gc/residency_namespace_test.go
+++ b/cmd/gc/residency_namespace_test.go
@@ -1,0 +1,42 @@
+package main
+
+// The namespaces a binding declares, on the CLI plane, and the front door that
+// decides an id is not bd's to answer for.
+//
+// Both read the reserved set, and both were reading only the prefixes each
+// class MINTS under. The nudges store additionally holds the nudge queue's
+// "gcnq-…" records, whose ids come from a content hash of the nudge they carry
+// rather than from the store's sequence. Unlisted, such an id is planned as an
+// ordinary work id: `gc bd show gcnq-…` goes to bd, which does not have it.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+func TestReservedPrefixesForDeclaresHeldNamespaces(t *testing.T) {
+	got := map[string]bool{}
+	for _, p := range reservedPrefixesFor([]coordclass.Class{coordclass.ClassNudges}) {
+		got[p] = true
+	}
+	for _, want := range config.ReservedClassPrefixesFor(config.BeadClassNudges) {
+		if !got[want] {
+			t.Errorf("the nudges binding does not declare %q; an id in that namespace resolves past the binding", want)
+		}
+	}
+}
+
+func TestBdByIDFrontDoorClaimsHeldNamespaces(t *testing.T) {
+	for _, prefix := range config.AllReservedClassPrefixes() {
+		id := prefix + "-abc"
+		if !bdIDIsClassReserved(id) {
+			t.Errorf("bdIDIsClassReserved(%q) = false; the by-id front door hands a class id to bd, which cannot answer for it", id)
+		}
+	}
+	// The control: a work id must stay bd's to answer.
+	if bdIDIsClassReserved("ga-abc") {
+		t.Error("bdIDIsClassReserved claimed a work id; the front door would divert every ordinary read")
+	}
+}

--- a/cmd/gc/residency_namespace_test.go
+++ b/cmd/gc/residency_namespace_test.go
@@ -12,9 +12,60 @@ package main
 import (
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 )
+
+// The retirement condition's two halves, as the CLI plane reports them. Same
+// rule as the API plane's, asserted separately because the two constructors are
+// separate code and a plane that disagreed with the other about whether a probe
+// may retire would resolve the same id to two different stores.
+func TestCLIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
+	graphPrefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("graph has no reserved mint prefix")
+	}
+	tests := []struct {
+		name  string
+		store beads.Store
+		mints bool
+	}{
+		{"store declaring the binding's namespace", newPrefixDeclaringStore(graphPrefix), true},
+		{"store minting work ids", newPrefixDeclaringStore("ga"), false},
+		{"store declaring nothing", beads.NewMemStore(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bindings, _ := residencyBindingsFor(
+				[]beads.Store{tt.store},
+				map[beads.Store][]coordclass.Class{tt.store: {coordclass.ClassGraph}},
+			)
+			if len(bindings) != 1 {
+				t.Fatalf("got %d bindings, want 1", len(bindings))
+			}
+			if bindings[0].MintsReserved != tt.mints {
+				t.Errorf("MintsReserved = %v, want %v", bindings[0].MintsReserved, tt.mints)
+			}
+			if !bindings[0].HasLegacyResidents {
+				t.Error("HasLegacyResidents = false, but nothing in this build censuses the binding's residents; the probe would retire over every id the migration preserved")
+			}
+		})
+	}
+}
+
+// prefixDeclaringStore names the namespace it mints into, which beads.MemStore
+// does not.
+type prefixDeclaringStore struct {
+	beads.Store
+	prefix string
+}
+
+func newPrefixDeclaringStore(prefix string) beads.Store {
+	return prefixDeclaringStore{Store: beads.NewMemStore(), prefix: prefix}
+}
+
+func (s prefixDeclaringStore) IDPrefix() string { return s.prefix }
 
 func TestReservedPrefixesForDeclaresHeldNamespaces(t *testing.T) {
 	got := map[string]bool{}

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -23,10 +23,11 @@ package main
 // A constructor takes the opened work and rig stores it is handed and the
 // routes this process already resolved. It does not decide which rigs are
 // serving — a suspended rig is simply absent from the map it is given — and it
-// does not decide whether a binding mints truthfully: nothing in this build
-// verifies a binding's mint prefix, so MintsReserved stays false everywhere
-// here and the residence probe stays in every plan. The corpus already carries
-// the retired row, so the day verification ships this is a bit, not a redesign.
+// does not decide whether a binding mints truthfully: it asks the store, which
+// declares the namespace it mints into. The residence probe nonetheless stays
+// in every plan, because retirement also needs a binding known to hold no
+// relics and nothing here censuses residents. The corpus already carries the
+// retired row, so the day the census ships this is a bit, not a redesign.
 
 import (
 	"fmt"
@@ -78,9 +79,9 @@ func cliResidencyTopology(cityPath string, cfg *config.City, work beads.Store, r
 // (buildSuspendedRigPathsForCity, threaded through the census arms) rather than
 // being re-derived here: the constructor is told, it does not decide.
 //
-// MintsReserved stays false for the same reason it does everywhere else —
-// nothing in this build verifies a binding's mint prefix — so the residence
-// probe stays in every plan.
+// The residence probe stays in every plan for the same reason it does
+// everywhere else: the mint bit is observed, but nothing censuses a binding's
+// relics, so the retirement condition's other half is never satisfied.
 func (cr *CityRuntime) residencyTopology(servingRigs map[string]beads.Store) storeref.Topology {
 	bindings, refused := residencyBindingsFromRoutes(cr.storageRoutes)
 	return assembleResidencyTopology(cr.cfg, cr.cityBeadStore(), servingRigs, bindings, refused)
@@ -419,13 +420,18 @@ func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordcl
 	bindings := make([]storeref.ClassBinding, 0, len(order))
 	for _, store := range order {
 		classes := byStore[store]
+		prefixes := reservedPrefixesFor(classes)
 		bindings = append(bindings, storeref.ClassBinding{
 			Classes:  classes,
-			Prefixes: reservedPrefixesFor(classes),
+			Prefixes: prefixes,
 			Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: store},
-			// MintsReserved and HasLegacyResidents stay false: nothing in this
-			// build verifies a binding's mint prefix or censuses its relics, so
-			// the residence probe stays in every plan.
+			// The mint bit is observed from the store's own declaration; the
+			// relic bit is pessimistic because nothing here censuses residents.
+			// The probe therefore still stays in every plan — see the
+			// ClassBinding docs for why the optimistic pairing is the one shape
+			// that must never ship.
+			MintsReserved:      storeref.MintsInsideNamespace(store, prefixes),
+			HasLegacyResidents: true,
 		})
 		if refusing, ok := store.(storeref.RefusingStore); ok && refused == nil {
 			refused = refusing.StorageRefusal()

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -410,12 +410,16 @@ func residencyBindingsFromRoutes(routes *storageRoutes) ([]storeref.ClassBinding
 		}
 		byStore[store] = append(byStore[store], class)
 	}
-	return residencyBindingsFor(order, byStore)
+	return residencyBindingsFor(order, byStore, routes.hasLegacyResidents)
 }
 
 // residencyBindingsFor turns a store->classes grouping into bindings, and
 // reports the standing refusal when any binding is a refusing store.
-func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordclass.Class) ([]storeref.ClassBinding, error) {
+//
+// relics answers the boot census's question for a binding store. A nil one is
+// the pessimistic answer for every store, which is what a caller holding no
+// censused routes is entitled to claim.
+func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordclass.Class, relics func(beads.Store) bool) ([]storeref.ClassBinding, error) {
 	var refused error
 	bindings := make([]storeref.ClassBinding, 0, len(order))
 	for _, store := range order {
@@ -425,13 +429,13 @@ func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordcl
 			Classes:  classes,
 			Prefixes: prefixes,
 			Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: store},
-			// The mint bit is observed from the store's own declaration; the
-			// relic bit is pessimistic because nothing here censuses residents.
-			// The probe therefore still stays in every plan — see the
-			// ClassBinding docs for why the optimistic pairing is the one shape
-			// that must never ship.
+			// Both bits are observations now: the mint bit from the store's own
+			// declaration, the relic bit from the boot census. Neither is ever
+			// optimistic by default — a store that declares no namespace does
+			// not mint truthfully, and a binding no census reached still has
+			// relics as far as this build knows.
 			MintsReserved:      storeref.MintsInsideNamespace(store, prefixes),
-			HasLegacyResidents: true,
+			HasLegacyResidents: hasLegacyResidentsOr(relics, store),
 		})
 		if refusing, ok := store.(storeref.RefusingStore); ok && refused == nil {
 			refused = refusing.StorageRefusal()
@@ -442,6 +446,15 @@ func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordcl
 	}
 	sort.SliceStable(bindings, func(i, j int) bool { return bindings[i].Leg.Ref < bindings[j].Leg.Ref })
 	return bindings, refused
+}
+
+// hasLegacyResidentsOr applies the census verdict, or the pessimistic default
+// when there is no census to ask.
+func hasLegacyResidentsOr(relics func(beads.Store) bool, store beads.Store) bool {
+	if relics == nil {
+		return true
+	}
+	return relics(store)
 }
 
 // infrastructureClasses is the class set a whole split relocates: every

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -451,13 +451,15 @@ func infrastructureClasses() []coordclass.Class {
 	return classes
 }
 
-// reservedPrefixesFor returns the reserved id prefixes a class set mints.
+// reservedPrefixesFor returns the reserved id namespaces a class set holds —
+// the prefix each class mints under plus any its store holds without minting,
+// such as the nudge queue's. A namespace the binding does not declare is one
+// the resolver gives it no authority over, so an id carrying it falls through
+// to the work ledger that never had it.
 func reservedPrefixesFor(classes []coordclass.Class) []string {
 	prefixes := make([]string, 0, len(classes))
 	for _, class := range classes {
-		if prefix, ok := config.ReservedClassPrefix(class.String()); ok {
-			prefixes = append(prefixes, prefix)
-		}
+		prefixes = append(prefixes, config.ReservedClassPrefixesFor(class.String())...)
 	}
 	return prefixes
 }

--- a/cmd/gc/residency_topology_test.go
+++ b/cmd/gc/residency_topology_test.go
@@ -215,10 +215,10 @@ func TestTopologyConstructorsServeOnlyTheWholeSplit(t *testing.T) {
 		t.Fatalf("the binding carries %d classes, want all five", len(bindings[0].Classes))
 	}
 	if bindings[0].MintsReserved {
-		t.Fatal("MintsReserved is set, but nothing in this build verifies a binding's mint prefix — the residence probe must stay in every plan")
+		t.Fatal("MintsReserved is set for a store that declares no mint prefix; the bit is an OBSERVATION and a store that names nothing has verified nothing")
 	}
-	if bindings[0].HasLegacyResidents {
-		t.Fatal("HasLegacyResidents is set, but nothing in this build censuses relics")
+	if !bindings[0].HasLegacyResidents {
+		t.Fatal("HasLegacyResidents is clear, but nothing in this build censuses relics — the probe would retire over every id the migration preserved")
 	}
 }
 

--- a/cmd/gc/residency_topology_test.go
+++ b/cmd/gc/residency_topology_test.go
@@ -218,7 +218,7 @@ func TestTopologyConstructorsServeOnlyTheWholeSplit(t *testing.T) {
 		t.Fatal("MintsReserved is set for a store that declares no mint prefix; the bit is an OBSERVATION and a store that names nothing has verified nothing")
 	}
 	if !bindings[0].HasLegacyResidents {
-		t.Fatal("HasLegacyResidents is clear, but nothing in this build censuses relics — the probe would retire over every id the migration preserved")
+		t.Fatal("HasLegacyResidents is clear on routes the boot never censused; an unasked question is not a clean answer, and the probe would retire over every id the migration preserved")
 	}
 }
 

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/storebinding"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // storageSupportedTopologyStatement is the one sentence describing what this
@@ -94,6 +95,61 @@ type storageRoutes struct {
 	// its CachingStore stays the only emitter on that side — see
 	// class_store_emit.go for why the two must not both emit.
 	emitCityPath string
+	// relics records, per binding store, whether the boot-time census found an
+	// open bead outside the namespaces that binding declares.
+	//
+	// ABSENT MEANS UNKNOWN, and unknown means "assume relics" — see
+	// hasLegacyResidents. A process that never censused, or a binding whose
+	// mint bit is off so the answer would not matter, must not read as clean.
+	//
+	// Keying a map on beads.Store is safe here for the same confined reason
+	// residencyBindingsFromRoutes gives: every key comes from this struct's own
+	// stores map, which holds what storage boot opened.
+	relics map[beads.Store]bool
+}
+
+// hasLegacyResidents reports the boot census's verdict for a binding store.
+//
+// The default is the pessimistic one on every path that could skip the census:
+// a nil receiver, an uncensused process, and a store the census never reached
+// all answer true. Retirement is the claim that needs evidence.
+func (r *storageRoutes) hasLegacyResidents(store beads.Store) bool {
+	if r == nil {
+		return true
+	}
+	verdict, censused := r.relics[store]
+	if !censused {
+		return true
+	}
+	return verdict
+}
+
+// censusBindingRelics takes the once-per-process live read that turns
+// ClassBinding.HasLegacyResidents from a pessimistic default into an
+// observation.
+//
+// It runs only for a binding whose mint bit already verified, which is both a
+// cost bound and a statement of what the answer is for: probe retirement needs
+// BOTH halves, so a binding that does not mint truthfully pays nothing to learn
+// an answer that cannot change its plans.
+func censusBindingRelics(routes *storageRoutes) {
+	if routes == nil {
+		return
+	}
+	// Built with the pessimistic default still in force — the census reads the
+	// bindings' stores and prefixes, never their relic bits — so this is not
+	// circular. A refusal here is carried by the bindings themselves; the
+	// census's own error handling is what makes a refused binding keep its
+	// probe.
+	bindings, _ := residencyBindingsFromRoutes(routes)
+	relics := make(map[beads.Store]bool, len(bindings))
+	for _, binding := range bindings {
+		if !binding.MintsReserved {
+			continue
+		}
+		relics[binding.Leg.Store] = storeref.HasOpenLegacyResidents(binding) // residency:allow — indexes a census result by the binding it was taken from; resolves nothing
+	}
+	routes.relics = relics
 }
 
 // storeFor returns the store serving a class and whether these routes relocate
@@ -291,6 +347,11 @@ func storageBootGate(cityPath string, cfg *config.City, logPrefix string, rec ev
 	if err := recordServedBinding(plan, cityPath, storage, target); err != nil {
 		return nil, errors.Join(fmt.Errorf("%s: %w", logPrefix, err), routes.close())
 	}
+	// One read, here, because this is the single funnel both planes pass
+	// through — the controller's boot and the one-shot CLI's memoized routes.
+	// Taking it anywhere downstream would put a store read inside a per-tick
+	// topology constructor.
+	censusBindingRelics(routes)
 	return routes, nil
 }
 

--- a/internal/api/dashport_support.go
+++ b/internal/api/dashport_support.go
@@ -265,6 +265,11 @@ func (s *seededState) OrdersBeadStore() beads.OrdersStore {
 	return beads.OrdersStore{Store: s.cityStore}
 }
 
+// ClassBindingHasLegacyResidents answers true for everything: a seeded city
+// relocates no class, so it contributes no binding and nothing consults this —
+// and a state that censused nothing has cleared nothing.
+func (s *seededState) ClassBindingHasLegacyResidents(beads.Store) bool { return true }
+
 func (s *seededState) Orders() []orders.Order    { return nil }
 func (s *seededState) OrdersAll() []orders.Order { return nil }
 func (s *seededState) Poke()                     {}

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -46,6 +46,10 @@ type fakeState struct {
 	sessionsBeadStore beads.Store // relocated sessions store; nil falls back to cityBeadStore (default backend)
 	graphBeadStore    beads.Store // relocated graph store; nil falls back to cityBeadStore (default backend)
 	ordersBeadStore   beads.Store // relocated orders store; nil falls back to cityBeadStore (default backend)
+	// bindingRelics is the boot census a test wants replayed. Absent means
+	// uncensused, which means "assume relics" — see
+	// ClassBindingHasLegacyResidents.
+	bindingRelics     map[beads.Store]bool
 	cityBeadsDiag     *beads.BeadsDiagnostic
 	cityMailProv      mail.Provider // city-level mail provider (all mail is city-scoped)
 	eventProv         events.Provider
@@ -162,6 +166,17 @@ func (f *fakeState) OrdersBeadStore() beads.OrdersStore {
 		return beads.OrdersStore{Store: f.ordersBeadStore}
 	}
 	return beads.OrdersStore{Store: f.cityBeadStore}
+}
+
+// ClassBindingHasLegacyResidents replays whatever census a test recorded in
+// bindingRelics. A store with no entry — the default for every test that never
+// thought about relics — keeps its probe, matching an uncensused controller.
+func (f *fakeState) ClassBindingHasLegacyResidents(store beads.Store) bool {
+	verdict, censused := f.bindingRelics[store]
+	if !censused {
+		return true
+	}
+	return verdict
 }
 
 func (f *fakeState) CityBeadsDiagnostic() *beads.BeadsDiagnostic {

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -709,25 +709,28 @@ func (s *Server) humaHandleBeadCreate(ctx context.Context, input *BeadCreateInpu
 	// released on any error, so every fallible step lives in the closure.
 	b, err := withIdempotency(s.idem, "/v0/beads", input.IdempotencyKey, input.Body,
 		func() (beads.Bead, error) {
-			store := s.findStore(input.Body.Rig)
-			if store == nil {
-				return beads.Bead{}, apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
-			}
-			assignee, err := s.normalizeRawBeadAssignee(ctx, input.Body.Assignee)
-			if err != nil {
-				return beads.Bead{}, apierr.InvalidRequest.Msg(err.Error())
-			}
-			created, err := store.Create(beads.Bead{
+			candidate := beads.Bead{
 				Title:       input.Body.Title,
 				Type:        input.Body.Type,
 				Priority:    input.Body.Priority,
-				Assignee:    assignee,
 				Description: input.Body.Description,
 				Labels:      input.Body.Labels,
 				ParentID:    input.Body.Parent,
 				Metadata:    input.Body.Metadata,
 				DeferUntil:  input.Body.DeferUntil,
-			})
+			}
+			// The store follows from the bead, not from the request: an
+			// infrastructure-class body belongs in this city's class binding
+			// wherever the caller posted it from.
+			store, err := s.createStoreForBead(candidate, input.Body.Rig)
+			if err != nil {
+				return beads.Bead{}, err
+			}
+			candidate.Assignee, err = s.normalizeRawBeadAssignee(ctx, input.Body.Assignee)
+			if err != nil {
+				return beads.Bead{}, apierr.InvalidRequest.Msg(err.Error())
+			}
+			created, err := store.Create(candidate)
 			if err != nil {
 				return beads.Bead{}, apierr.Internal.Msg(err.Error())
 			}

--- a/internal/api/relic_census_state_test.go
+++ b/internal/api/relic_census_state_test.go
@@ -1,0 +1,118 @@
+package api
+
+// The relic verdict, on the API plane.
+//
+// The API holds no storageRoutes and opens no binding of its own, so it cannot
+// take the census — but it plans by-id reads against the same bindings the CLI
+// does, and a plane that kept probing after the other retired would resolve the
+// same id to two different stores. The verdict therefore crosses the State
+// surface, and until it arrives the answer stays pessimistic.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// relocatedGraphState wires a distinct graph store onto a fake State, which is
+// the smallest shape residencyTopology reads as one binding.
+func relocatedGraphState(t *testing.T, graph beads.Store) *fakeState {
+	t.Helper()
+	st := newFakeState(t)
+	st.cityBeadStore = beads.NewMemStore()
+	st.graphBeadStore = graph
+	st.stores = nil
+	st.cfg.Rigs = nil
+	return st
+}
+
+// mintingGraphStore is a binding that declares the graph namespace it mints
+// into, so the mint half of the retirement condition is satisfied and the relic
+// half is the only thing left deciding.
+func mintingGraphStore(t *testing.T) beads.Store {
+	t.Helper()
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("graph has no reserved mint prefix")
+	}
+	return newPrefixDeclaringStore(prefix)
+}
+
+// soleAPIBinding is the one binding a relocated city's API plane observes.
+func soleAPIBinding(t *testing.T, st *fakeState) storeref.ClassBinding {
+	t.Helper()
+	topo := New(st).residencyTopology()
+	if len(topo.Bindings) != 1 {
+		t.Fatalf("got %d bindings, want the one this state relocates", len(topo.Bindings))
+	}
+	return topo.Bindings[0]
+}
+
+// apiBindingLegRead reports whether a by-id plan for id would read the binding.
+func apiBindingLegRead(t *testing.T, st *fakeState, id string) bool {
+	t.Helper()
+	topo := New(st).residencyTopology()
+	plan, err := storeref.Plan(storeref.ByID{ID: id}, topo)
+	if err != nil {
+		t.Fatalf("planning a by-id read of %q: %v", id, err)
+	}
+	for _, leg := range plan.Legs {
+		for _, binding := range topo.Bindings {
+			if leg.Leg.Ref == binding.Leg.Ref {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// A State that reports the boot census found nothing retires the probe here
+// too. This is the whole point of plumbing the verdict across: the CLI plane
+// retired on the same city, and the two planes must agree.
+func TestAPIRetiresTheProbeWhenTheStateReportsACleanBinding(t *testing.T) {
+	graph := mintingGraphStore(t)
+	st := relocatedGraphState(t, graph)
+	st.bindingRelics = map[beads.Store]bool{graph: false}
+
+	binding := soleAPIBinding(t, st)
+	if !binding.MintsReserved {
+		t.Fatal("the binding does not mint inside its own namespaces, so the relic bit decides nothing and this row tests no retirement")
+	}
+	if binding.HasLegacyResidents {
+		t.Error("the API kept the relic bit set over a State that reported a clean census")
+	}
+	if apiBindingLegRead(t, st, "ga-1") {
+		t.Error("a work-shaped by-id read still probes a binding the census cleared; the two planes now disagree about where that id lives")
+	}
+}
+
+// The other direction, and the one that must survive every refactor: a binding
+// the census found a carried-across bead in keeps probing.
+func TestAPIKeepsTheProbeWhenTheStateReportsRelics(t *testing.T) {
+	graph := mintingGraphStore(t)
+	st := relocatedGraphState(t, graph)
+	st.bindingRelics = map[beads.Store]bool{graph: true}
+
+	if !soleAPIBinding(t, st).HasLegacyResidents {
+		t.Error("the API cleared the relic bit over a State that reported relics")
+	}
+	if !apiBindingLegRead(t, st, "ga-1") {
+		t.Error("a work-shaped by-id read skips a binding holding beads reachable no other way")
+	}
+}
+
+// The default, for every State that has no census to report — a seeded dashport
+// city, an API built without a runtime, a controller whose routes never booted.
+// An unasked question is not a clean answer.
+func TestAPIKeepsTheProbeForAnUncensusedState(t *testing.T) {
+	st := relocatedGraphState(t, mintingGraphStore(t))
+
+	if !soleAPIBinding(t, st).HasLegacyResidents {
+		t.Error("a State that censused nothing reported a clean binding")
+	}
+	if !apiBindingLegRead(t, st, "ga-1") {
+		t.Error("an uncensused plane retired its probe")
+	}
+}

--- a/internal/api/residency_create.go
+++ b/internal/api/residency_create.go
@@ -1,0 +1,87 @@
+package api
+
+// Where a created bead goes.
+//
+// Every other residency seam on this plane answers "where does this bead
+// LIVE" — a probe with an id in hand and a store that either holds it or does
+// not. Create is the one question the topology alone can answer and no probe
+// can: the bead does not exist yet, so there is nothing to look for, and the
+// only thing that decides the store is the class the body describes.
+//
+// That is why this file executes a ModeSingleOwner plan rather than reusing
+// resolveBeadOwner. A placement plan names the owner; a by-id plan names a
+// probe ORDER whose leading leg is not a placement.
+
+import (
+	"github.com/gastownhall/gascity/internal/api/apierr"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// errRigRequired is the pre-existing refusal for a rig-less create on a city
+// with no single obvious store. Held as one value so the placement seam cannot
+// drift from the message clients already match on.
+func errRigRequired() error {
+	return apierr.InvalidRequest.Msg("rig is required when multiple rigs are configured")
+}
+
+// createStoreForBead picks the store a POST /v0/beads body is created in.
+//
+// The rule has two halves and the second is what keeps this change safe. On a
+// city with no class binding — the shipped default — the answer is exactly
+// findStore(rig), byte for byte, and the resolver is never consulted: a
+// placement plan over a topology whose work leg is nil has no leg at all, and
+// turning today's "rig is required" into a planning error would break a working
+// create. On a converged city an infrastructure-class body is placed at the
+// binding, because the work ledger it would otherwise land in is the store the
+// city moved that class off; a bead minted there carries the work ledger's id
+// prefix and cannot be relocated afterwards by copying it.
+//
+// An infrastructure class combined with an explicit rig is refused rather than
+// resolved. A binding is city-keyed — there is one per city and no per-rig
+// binding to route to — so the request names something that does not exist, and
+// both silent answers are lies: honoring the rig re-creates the stranded write,
+// ignoring it returns a bead that is not where the caller was told to look.
+func (s *Server) createStoreForBead(b beads.Bead, rig string) (beads.Store, error) {
+	class := coordclass.Classify(b)
+	if !class.IsInfrastructure() {
+		return s.storeOrRigRequired(rig)
+	}
+	topo := s.residencyTopology()
+	if len(topo.Bindings) == 0 && topo.Refused == nil {
+		return s.storeOrRigRequired(rig)
+	}
+	// A standing refusal with no binding to attach it to still has to reach
+	// Plan: it means this build cannot serve the class's store, and falling
+	// through to the work ledger is the one answer that is never right.
+	plan, err := storeref.Plan(storeref.Class{C: class}, topo)
+	if err != nil {
+		// A standing refusal reaches here as an error, and refusing the create
+		// is the point: this build must not serve the binding that owns the
+		// class, and writing to the work ledger instead is precisely the
+		// stranded write the refusal exists to prevent.
+		return nil, apierr.InvalidRequest.Msg(err.Error())
+	}
+	if !plan.TouchesBinding() {
+		return s.storeOrRigRequired(rig)
+	}
+	if rig != "" {
+		return nil, apierr.InvalidRequest.Msg("rig must be empty for a " + class.String() + " bead: this city serves that class from a city-scoped store, not from any rig")
+	}
+	owner, err := storeref.ResolvePlacement(plan)
+	if err != nil {
+		return nil, apierr.Internal.Msg(err.Error())
+	}
+	return owner.Store, nil
+}
+
+// storeOrRigRequired is findStore with its nil case spelled as the refusal
+// callers already receive.
+func (s *Server) storeOrRigRequired(rig string) (beads.Store, error) {
+	store := s.findStore(rig)
+	if store == nil {
+		return nil, errRigRequired()
+	}
+	return store, nil
+}

--- a/internal/api/residency_create_guard_test.go
+++ b/internal/api/residency_create_guard_test.go
@@ -1,0 +1,88 @@
+package api
+
+// The create seam has to stay the only door.
+//
+// createStoreForBead is a routing rule, and a routing rule that one call site
+// obeys is not a rule — the next handler that mints a raw bead through
+// findStore reopens exactly the hole this lane closed, silently, on converged
+// cities only. The shared residency-boundary ratchet cannot express this: its
+// rows are line regexes over a vocabulary of store access, and "this create
+// took placement" is a property of the bead's CLASS, which no line contains.
+// So the enforcement is local, named, and allowlisted with reasons.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// rawBeadLiteral matches a composite literal carrying at least one field. The
+// negated class is what excludes `beads.Bead{}` zero values, which this package
+// returns from every error path and which create nothing; without it the guard
+// would flag half the package and be turned off.
+var rawBeadLiteral = regexp.MustCompile(`beads\.Bead\{([^}]|$)`)
+
+var storeCreateCall = regexp.MustCompile(`\.Create\(`)
+
+// rawBeadCreateRequired is the file the guard exists for. Pinning it keeps a
+// detector regression honest: a change that stopped matching composite literals
+// would otherwise leave this test passing over an empty set.
+const rawBeadCreateRequired = "huma_handlers_beads.go"
+
+// rawBeadCreateExemptions are the non-test files that mint a raw bead outside
+// the placement seam, each with the reason it is safe to.
+var rawBeadCreateExemptions = map[string]string{
+	"huma_handlers_convoys.go": "a convoy bead is ClassWork by construction and must be co-resident with the members it tracks; " +
+		"placing it by class would separate a convoy from its own rows",
+	"rigidem.go": "a gc-idem record is ClassWork and is written through, and read back only through, the rig store that " +
+		"owns the request being deduplicated (see TestIdemRecordsAreWorkClass)",
+}
+
+func TestRawBeadCreatesTakeThePlacementSeam(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	found := map[string]bool{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		text := string(src)
+		if !rawBeadLiteral.MatchString(text) || !storeCreateCall.MatchString(text) {
+			continue
+		}
+		found[name] = true
+		if reason, exempt := rawBeadCreateExemptions[name]; exempt {
+			t.Logf("%s is exempt: %s", name, reason)
+			continue
+		}
+		if !strings.Contains(text, "createStoreForBead(") {
+			t.Errorf("%s builds a raw beads.Bead and calls Create without going through createStoreForBead.\n"+
+				"A create picks its store from the bead's class, not from the request's rig: on a converged city "+
+				"findStore sends an infrastructure-class bead to the work ledger the city moved that class off, "+
+				"minting it under the wrong id prefix. Route it through createStoreForBead, or add %q to "+
+				"rawBeadCreateExemptions with the reason it is work-class by construction.", name, name)
+		}
+	}
+
+	if !found[rawBeadCreateRequired] {
+		t.Errorf("the detector no longer matches %s, the create door this guard exists for; "+
+			"it is now scanning an empty set and would pass over any new unrouted create", rawBeadCreateRequired)
+	}
+
+	// An exemption that no longer names a real create site is worse than no
+	// exemption: it silently blesses whatever file later takes the name.
+	for name := range rawBeadCreateExemptions {
+		if !found[name] {
+			t.Errorf("exemption %q no longer builds a raw beads.Bead and calls Create; drop the entry", name)
+		}
+	}
+}

--- a/internal/api/residency_create_test.go
+++ b/internal/api/residency_create_test.go
@@ -1,0 +1,297 @@
+package api
+
+// Where POST /v0/beads puts the bead it creates.
+//
+// The by-id door of this surface has taken residency through the resolver since
+// the ga-axin6 lane; the CREATE door never did. It picked its store with
+// findStore(rig) — "the rig you named, else the city work ledger" — and then
+// created whatever it was handed there, including a bead whose class a
+// converged city moved off that ledger. That is not a read miss you can retry:
+// it is a bead minted into the wrong store, in the work ledger's own id
+// namespace, which `gc storage status` counts as a stranded write and which
+// every later class-routed read looks for in the binding and does not find.
+//
+// The rows below are the two halves of the placement rule. A relocated class
+// goes to the binding, whatever rig-less body asked for it; a city with nothing
+// relocated chooses exactly the store it chose before, for every shape, because
+// a placement plan over an unsplit topology names the work store and the
+// resolver is the identity there.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+// createBody is the POST /v0/beads request body, spelled as a struct so a
+// field rename in BeadCreateInput.Body is a compile error here rather than a
+// silently-ignored JSON key.
+type createBody struct {
+	Rig      string            `json:"rig,omitempty"`
+	Title    string            `json:"title"`
+	Type     string            `json:"type,omitempty"`
+	Labels   []string          `json:"labels,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// bead returns the bead the classifier sees for this body — the same fields
+// coordclass.Classify reads — so a row can state its intended class and have
+// the test verify it rather than assert it in a comment.
+func (b createBody) bead() beads.Bead {
+	return beads.Bead{Title: b.Title, Type: b.Type, Labels: b.Labels, Metadata: b.Metadata}
+}
+
+// infraCreateBodies is one create body per infrastructure class, each shaped
+// the way the class's real beads are shaped. Every entry's class is asserted
+// against coordclass.Classify before it is used, so a classifier change breaks
+// the fixture instead of quietly turning a row into a work-class no-op.
+func infraCreateBodies() map[coordclass.Class]createBody {
+	return map[coordclass.Class]createBody{
+		coordclass.ClassGraph:     {Title: "a wisp", Type: "task", Labels: []string{"gc:wisp"}},
+		coordclass.ClassMessaging: {Title: "mail", Type: "message"},
+		coordclass.ClassSessions:  {Title: "a session", Type: "session"},
+		coordclass.ClassOrders:    {Title: "an order run", Type: "task", Labels: []string{"order-tracking"}},
+		coordclass.ClassNudges:    {Title: "a nudge", Type: "task", Labels: []string{"gc:nudge"}},
+	}
+}
+
+// newWholeSplitCreateState is a converged city as this plane observes one: an
+// HQ work store, a rig work store, and ONE binding serving every relocated
+// class. The four class accessors point at the same store because this build
+// serves the whole split or none of it, which is also what lets
+// completeObservedClasses round the binding up to the messaging class the API
+// has no accessor for.
+func newWholeSplitCreateState(t *testing.T) (*fakeState, beads.Store) {
+	t.Helper()
+	fs := newFakeState(t)
+	fs.cityBeadStore = splittest.NewWorkStore(t, "hq")
+	fs.stores["myrig"] = splittest.NewWorkStore(t, "ra")
+	binding := splittest.NewClassStore(t, config.BeadClassGraph)
+	fs.graphBeadStore = binding
+	fs.sessionsBeadStore = binding
+	fs.ordersBeadStore = binding
+	fs.nudgesBeadStore = binding
+	return fs, binding
+}
+
+// newUnsplitCreateState is the same city with nothing relocated: every class
+// accessor falls back to the city store, so the topology carries no binding.
+func newUnsplitCreateState(t *testing.T) *fakeState {
+	t.Helper()
+	fs := newFakeState(t)
+	fs.cityBeadStore = splittest.NewWorkStore(t, "hq")
+	fs.stores["myrig"] = splittest.NewWorkStore(t, "ra")
+	return fs
+}
+
+// postBead issues POST /v0/beads and returns the raw recorder, so a row can
+// assert on a refusal status as easily as on a created bead.
+//
+// The handler is a parameter rather than a per-call newTestCityHandler because
+// every call to that helper builds a fresh SupervisorMux, and therefore a fresh
+// per-city Server with its own idempotency cache — two posts through two
+// handlers can never replay each other.
+func postBead(t *testing.T, h http.Handler, fs *fakeState, body createBody, idemKey string) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal create body: %v", err)
+	}
+	req := newPostRequest(cityURL(fs, "/beads"), bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	if idemKey != "" {
+		req.Header.Set("Idempotency-Key", idemKey)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// createBead posts and decodes, failing on any non-201.
+func createBead(t *testing.T, h http.Handler, fs *fakeState, body createBody, idemKey string) beads.Bead {
+	t.Helper()
+	rec := postBead(t, h, fs, body, idemKey)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /beads %+v status = %d, want 201 (body=%q)", body, rec.Code, rec.Body.String())
+	}
+	var created beads.Bead
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response %q: %v", rec.Body.String(), err)
+	}
+	if created.ID == "" {
+		t.Fatalf("create response %q carries no bead id", rec.Body.String())
+	}
+	return created
+}
+
+func storeHolds(t *testing.T, store beads.Store, id string) bool {
+	t.Helper()
+	_, err := store.Get(id)
+	return err == nil
+}
+
+// storeCount is the bead count of a leg, used by the refusal rows to prove the
+// refused create wrote nothing anywhere.
+func storeCount(t *testing.T, store beads.Store) int {
+	t.Helper()
+	list, err := store.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	return len(list)
+}
+
+// TestBeadCreateRoutesEveryInfraClassToTheBinding is the defect. Red on the
+// pre-fix tree for all five classes, e.g.:
+//
+//	--- FAIL: .../graph
+//	    created bead hq-1 is not in the class binding; a graph create on a
+//	    converged city belongs there
+//	    created bead hq-1 landed in the CITY WORK LEDGER — a stranded write in
+//	    the store this city moved graph off
+//
+// The id is the tell: hq-1 is the work ledger's own prefix, so the bead is not
+// merely in the wrong store, it carries an id minted from the wrong namespace
+// and cannot be relocated by copying it.
+func TestBeadCreateRoutesEveryInfraClassToTheBinding(t *testing.T) {
+	for class, body := range infraCreateBodies() {
+		t.Run(class.String(), func(t *testing.T) {
+			if got := coordclass.Classify(body.bead()); got != class {
+				t.Fatalf("fixture body %+v classifies as %s, want %s", body, got, class)
+			}
+			fs, binding := newWholeSplitCreateState(t)
+
+			created := createBead(t, newTestCityHandler(t, fs), fs, body, "")
+
+			if !storeHolds(t, binding, created.ID) {
+				t.Errorf("created bead %s is not in the class binding; a %s create on a converged city belongs there", created.ID, class)
+			}
+			if storeHolds(t, fs.cityBeadStore, created.ID) {
+				t.Errorf("created bead %s landed in the CITY WORK LEDGER — a stranded write in the store this city moved %s off", created.ID, class)
+			}
+		})
+	}
+}
+
+// TestBeadCreateKeepsWorkClassOnTheWorkLedger is the other half: relocating a
+// class must not relocate the work beads that share the city. A fix that routed
+// every create at the binding would pass the row above and destroy this one.
+func TestBeadCreateKeepsWorkClassOnTheWorkLedger(t *testing.T) {
+	fs, binding := newWholeSplitCreateState(t)
+	body := createBody{Title: "ordinary work", Type: "task"}
+	if got := coordclass.Classify(body.bead()); got != coordclass.ClassWork {
+		t.Fatalf("fixture body classifies as %s, want work", got)
+	}
+
+	created := createBead(t, newTestCityHandler(t, fs), fs, body, "")
+
+	if !storeHolds(t, fs.cityBeadStore, created.ID) {
+		t.Errorf("work-class bead %s is not in the city work ledger", created.ID)
+	}
+	if storeHolds(t, binding, created.ID) {
+		t.Errorf("work-class bead %s landed in the class binding; only relocated classes are placed there", created.ID)
+	}
+}
+
+// TestBeadCreateOnAnUnsplitCityIsUnchanged pins the identity case: with nothing
+// relocated the placement plan names the work store, so every shape — infra or
+// not, rig-named or not — chooses exactly the store findStore chose before.
+func TestBeadCreateOnAnUnsplitCityIsUnchanged(t *testing.T) {
+	bodies := infraCreateBodies()
+	bodies[coordclass.ClassWork] = createBody{Title: "ordinary work", Type: "task"}
+	for class, body := range bodies {
+		t.Run(class.String(), func(t *testing.T) {
+			fs := newUnsplitCreateState(t)
+			h := newTestCityHandler(t, fs)
+			created := createBead(t, h, fs, body, "")
+			if !storeHolds(t, fs.cityBeadStore, created.ID) {
+				t.Errorf("bead %s is not in the city work ledger; an unsplit city has no binding and must be byte-identical", created.ID)
+			}
+
+			rigged := body
+			rigged.Rig = "myrig"
+			riggedBead := createBead(t, h, fs, rigged, "")
+			if !storeHolds(t, fs.stores["myrig"], riggedBead.ID) {
+				t.Errorf("bead %s is not in the named rig's store; an explicit rig still chooses the rig on an unsplit city", riggedBead.ID)
+			}
+		})
+	}
+}
+
+// TestBeadCreateRefusesAnInfraClassWithAnExplicitRig states the one refusal the
+// seam adds.
+//
+// A class binding is CITY-keyed: there is one per city and no per-rig binding to
+// route to. So a caller asking for a relocated class in a named rig has asked
+// for something that does not exist, and both silent answers are wrong —
+// honoring the rig re-creates the stranded write, ignoring it returns a bead
+// that is not where the caller was told it would be.
+func TestBeadCreateRefusesAnInfraClassWithAnExplicitRig(t *testing.T) {
+	for class, body := range infraCreateBodies() {
+		t.Run(class.String(), func(t *testing.T) {
+			fs, binding := newWholeSplitCreateState(t)
+			body.Rig = "myrig"
+
+			rec := postBead(t, newTestCityHandler(t, fs), fs, body, "")
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+			}
+			if n := storeCount(t, binding); n != 0 {
+				t.Errorf("the refused create still wrote %d bead(s) to the binding", n)
+			}
+			if n := storeCount(t, fs.stores["myrig"]); n != 0 {
+				t.Errorf("the refused create still wrote %d bead(s) to the rig store", n)
+			}
+		})
+	}
+}
+
+// TestBeadCreateIdempotencyReplayHoldsAcrossPlacement pins that the seam lives
+// INSIDE the idempotency closure. A replay must return the first bead and must
+// not create a second one — and it must do so for a placed create, where the
+// store the record was written through is not the store findStore names.
+func TestBeadCreateIdempotencyReplayHoldsAcrossPlacement(t *testing.T) {
+	fs, binding := newWholeSplitCreateState(t)
+	body := infraCreateBodies()[coordclass.ClassGraph]
+	h := newTestCityHandler(t, fs)
+
+	first := createBead(t, h, fs, body, "key-1")
+	replay := createBead(t, h, fs, body, "key-1")
+
+	if first.ID != replay.ID {
+		t.Fatalf("replay returned %s, want the first bead %s", replay.ID, first.ID)
+	}
+	if n := storeCount(t, binding); n != 1 {
+		t.Fatalf("the binding holds %d bead(s) after an idempotent replay, want 1", n)
+	}
+}
+
+// TestIdemRecordsAreWorkClass freezes the fragility the S5 audit found at
+// rigidem.go:351: the durable rig-create idempotency record is a "task" bead
+// carrying gc-idem labels, and it is work class only because coordclass has no
+// arm for that family. It is created through the rig's own store, deliberately,
+// so if an arm is ever added this row fails first — before the record starts
+// being minted into a binding that no lookup on that path reads.
+func TestIdemRecordsAreWorkClass(t *testing.T) {
+	record := beads.Bead{
+		Type:   "task",
+		Title:  "idem: rig-create req-1",
+		Labels: []string{idemLabel, idemLabelRigCreate},
+		Metadata: beads.StringMap{
+			metaIdemKind:      idemKindRigCreate,
+			metaIdemCity:      "test-city",
+			metaIdemRequestID: "req-1",
+		},
+	}
+	if got := coordclass.Classify(record); got != coordclass.ClassWork {
+		t.Fatalf("a gc-idem record classifies as %s, want work — createIdemRecord writes it through the rig store, and every lookup on that path reads only there", got)
+	}
+}

--- a/internal/api/residency_namespace_test.go
+++ b/internal/api/residency_namespace_test.go
@@ -19,6 +19,66 @@ import (
 	"github.com/gastownhall/gascity/internal/coordclass"
 )
 
+// The two halves of the residence-probe retirement condition, as this plane
+// reports them.
+//
+// The mint bit is observed rather than assumed: a store that names the
+// namespace it mints into, and names one the binding claims, has verified the
+// only thing the retirement premise needs about future beads. A store that
+// names nothing has verified nothing.
+//
+// The relic bit is the other half and is pessimistic on purpose. Nothing in
+// this build censuses a binding's residents, so "not known to hold relics" is
+// all a constructor can honestly say, and that is not the claim that retires a
+// probe. The two must land together: an observed mint bit over an optimistic
+// relic bit would retire the probe on every converged city at boot, over
+// exactly the ids `gc storage migrate` preserved.
+func TestAPIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
+	graphPrefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatal("graph has no reserved mint prefix")
+	}
+	tests := []struct {
+		name  string
+		store beads.Store
+		mints bool
+	}{
+		{"store declaring the binding's namespace", newPrefixDeclaringStore(graphPrefix), true},
+		{"store minting work ids", newPrefixDeclaringStore("ga"), false},
+		{"store declaring nothing", beads.NewMemStore(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bindings, _ := apiResidencyBindings(
+				[]beads.Store{tt.store},
+				map[beads.Store][]coordclass.Class{tt.store: {coordclass.ClassGraph}},
+			)
+			if len(bindings) != 1 {
+				t.Fatalf("got %d bindings, want 1", len(bindings))
+			}
+			if bindings[0].MintsReserved != tt.mints {
+				t.Errorf("MintsReserved = %v, want %v", bindings[0].MintsReserved, tt.mints)
+			}
+			if !bindings[0].HasLegacyResidents {
+				t.Error("HasLegacyResidents = false, but nothing in this build censuses the binding's residents; the probe would retire over every id the migration preserved")
+			}
+		})
+	}
+}
+
+// prefixDeclaringStore names the namespace it mints into, which beads.MemStore
+// does not.
+type prefixDeclaringStore struct {
+	beads.Store
+	prefix string
+}
+
+func newPrefixDeclaringStore(prefix string) beads.Store {
+	return prefixDeclaringStore{Store: beads.NewMemStore(), prefix: prefix}
+}
+
+func (s prefixDeclaringStore) IDPrefix() string { return s.prefix }
+
 func TestAPIBindingDeclaresEveryHeldNamespace(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/api/residency_namespace_test.go
+++ b/internal/api/residency_namespace_test.go
@@ -1,0 +1,68 @@
+package api
+
+// The namespaces a binding declares, on the API plane.
+//
+// A binding's Prefixes list is what the resolver reads to decide it has
+// AUTHORITY over an id rather than merely a guess worth probing. Building that
+// list from the class's MINT prefix alone understates it: the nudges store also
+// holds the nudge queue's own "gcnq-…" records, which a subsystem mints from a
+// content hash rather than from the store's sequence. An unlisted namespace is
+// not a weaker claim, it is no claim — the id falls through to the work ledger,
+// which answers it emptily and confidently, and on a city whose probe has been
+// retired there is not even a binding leg left to catch it.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+func TestAPIBindingDeclaresEveryHeldNamespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		observed []coordclass.Class
+		want     []string
+	}{
+		{
+			// A binding serving only the nudges class still holds the queue's
+			// namespace, because the queue lives in the nudges store.
+			name:     "nudges alone",
+			observed: []coordclass.Class{coordclass.ClassNudges},
+			want:     config.ReservedClassPrefixesFor(config.BeadClassNudges),
+		},
+		{
+			// Observing every observable class is the whole-split shape:
+			// completeObservedClasses rounds it up to all five infrastructure
+			// classes, so the binding must declare the full reserved union.
+			name:     "whole split",
+			observed: observableInfraClasses(),
+			want:     config.AllReservedClassPrefixes(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			bindings, refused := apiResidencyBindings(
+				[]beads.Store{store},
+				map[beads.Store][]coordclass.Class{store: tt.observed},
+			)
+			if refused != nil {
+				t.Fatalf("unexpected refusal: %v", refused)
+			}
+			if len(bindings) != 1 {
+				t.Fatalf("got %d bindings, want 1", len(bindings))
+			}
+			got := map[string]bool{}
+			for _, p := range bindings[0].Prefixes {
+				got[p] = true
+			}
+			for _, want := range tt.want {
+				if !got[want] {
+					t.Errorf("binding declares %v, missing %q: an id in that namespace resolves past the binding to the work ledger", bindings[0].Prefixes, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/residency_namespace_test.go
+++ b/internal/api/residency_namespace_test.go
@@ -27,10 +27,9 @@ import (
 // only thing the retirement premise needs about future beads. A store that
 // names nothing has verified nothing.
 //
-// The relic bit is the other half and is pessimistic on purpose. Nothing in
-// this build censuses a binding's residents, so "not known to hold relics" is
-// all a constructor can honestly say, and that is not the claim that retires a
-// probe. The two must land together: an observed mint bit over an optimistic
+// The relic bit is the other half, and this row supplies no census — so it
+// pins the default. "Not asked" is not "not known to hold relics", and neither
+// is the claim that retires a probe. An observed mint bit over an optimistic
 // relic bit would retire the probe on every converged city at boot, over
 // exactly the ids `gc storage migrate` preserved.
 func TestAPIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
@@ -52,6 +51,7 @@ func TestAPIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
 			bindings, _ := apiResidencyBindings(
 				[]beads.Store{tt.store},
 				map[beads.Store][]coordclass.Class{tt.store: {coordclass.ClassGraph}},
+				nil,
 			)
 			if len(bindings) != 1 {
 				t.Fatalf("got %d bindings, want 1", len(bindings))
@@ -60,7 +60,7 @@ func TestAPIBindingReportsBothHalvesOfTheRetirementCondition(t *testing.T) {
 				t.Errorf("MintsReserved = %v, want %v", bindings[0].MintsReserved, tt.mints)
 			}
 			if !bindings[0].HasLegacyResidents {
-				t.Error("HasLegacyResidents = false, but nothing in this build censuses the binding's residents; the probe would retire over every id the migration preserved")
+				t.Error("HasLegacyResidents = false for a caller that supplied no census; an unasked question is not a clean answer, and the probe would retire over every id the migration preserved")
 			}
 		})
 	}
@@ -107,6 +107,7 @@ func TestAPIBindingDeclaresEveryHeldNamespace(t *testing.T) {
 			bindings, refused := apiResidencyBindings(
 				[]beads.Store{store},
 				map[beads.Store][]coordclass.Class{store: tt.observed},
+				nil,
 			)
 			if refused != nil {
 				t.Fatalf("unexpected refusal: %v", refused)

--- a/internal/api/residency_topology.go
+++ b/internal/api/residency_topology.go
@@ -27,8 +27,8 @@ import (
 //
 // A class accessor that returns the city store, or nil, relocates nothing and
 // contributes no binding — the identity gate that keeps a single-store city
-// byte-identical. MintsReserved stays false: nothing in this build verifies a
-// binding's mint prefix, so every plan keeps its residence probe.
+// byte-identical. Every plan still keeps its residence probe: the mint bit is
+// observed, but the relic bit is pessimistic until a census can say otherwise.
 func (s *Server) residencyTopology() storeref.Topology {
 	cfg := s.state.Config()
 	city := s.state.CityBeadStore()
@@ -157,6 +157,13 @@ func apiResidencyBindings(order []beads.Store, byStore map[beads.Store][]coordcl
 			Classes:  classes,
 			Prefixes: prefixes,
 			Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: store},
+			// The mint bit is observed from the store's own declaration; the
+			// relic bit is pessimistic because nothing here censuses residents.
+			// The probe therefore still stays in every plan — see the
+			// ClassBinding docs for why the optimistic pairing is the one shape
+			// that must never ship.
+			MintsReserved:      storeref.MintsInsideNamespace(store, prefixes),
+			HasLegacyResidents: true,
 		})
 		if refusing, ok := store.(storeref.RefusingStore); ok && refused == nil {
 			refused = refusing.StorageRefusal()

--- a/internal/api/residency_topology.go
+++ b/internal/api/residency_topology.go
@@ -27,8 +27,9 @@ import (
 //
 // A class accessor that returns the city store, or nil, relocates nothing and
 // contributes no binding — the identity gate that keeps a single-store city
-// byte-identical. Every plan still keeps its residence probe: the mint bit is
-// observed, but the relic bit is pessimistic until a census can say otherwise.
+// byte-identical. A plan's residence probe retires only when both halves say
+// so: the mint bit observed from the store, the relic bit carried across the
+// State surface from the boot that censused the binding.
 func (s *Server) residencyTopology() storeref.Topology {
 	cfg := s.state.Config()
 	city := s.state.CityBeadStore()
@@ -49,7 +50,7 @@ func (s *Server) residencyTopology() storeref.Topology {
 	topo := storeref.Topology{
 		Work: storeref.Leg{Ref: storeref.WorkRef, Store: city, Prefix: strings.TrimSpace(config.EffectiveHQPrefix(cfg))},
 	}
-	topo.Bindings, topo.Refused = apiResidencyBindings(order, byStore)
+	topo.Bindings, topo.Refused = apiResidencyBindings(order, byStore, s.state.ClassBindingHasLegacyResidents)
 
 	if cfg != nil {
 		for _, rig := range cfg.Rigs {
@@ -137,7 +138,11 @@ func containsClass(classes []coordclass.Class, want coordclass.Class) bool {
 }
 
 // apiResidencyBindings groups the relocated classes by the store serving them.
-func apiResidencyBindings(order []beads.Store, byStore map[beads.Store][]coordclass.Class) ([]storeref.ClassBinding, error) {
+//
+// relics is the boot census's verdict, read across the State surface. A nil one
+// is the pessimistic answer for every store: a caller with no census to offer
+// has not cleared anything.
+func apiResidencyBindings(order []beads.Store, byStore map[beads.Store][]coordclass.Class, relics func(beads.Store) bool) ([]storeref.ClassBinding, error) {
 	if len(order) == 0 {
 		return nil, nil
 	}
@@ -157,17 +162,26 @@ func apiResidencyBindings(order []beads.Store, byStore map[beads.Store][]coordcl
 			Classes:  classes,
 			Prefixes: prefixes,
 			Leg:      storeref.Leg{Ref: storeref.ClassRef(classes), Store: store},
-			// The mint bit is observed from the store's own declaration; the
-			// relic bit is pessimistic because nothing here censuses residents.
-			// The probe therefore still stays in every plan — see the
+			// Both bits are observations: the mint bit from the store's own
+			// declaration, the relic bit from the boot that opened this binding
+			// and counted. Neither is ever optimistic by default — see the
 			// ClassBinding docs for why the optimistic pairing is the one shape
 			// that must never ship.
 			MintsReserved:      storeref.MintsInsideNamespace(store, prefixes),
-			HasLegacyResidents: true,
+			HasLegacyResidents: apiHasLegacyResidents(relics, store),
 		})
 		if refusing, ok := store.(storeref.RefusingStore); ok && refused == nil {
 			refused = refusing.StorageRefusal()
 		}
 	}
 	return bindings, refused
+}
+
+// apiHasLegacyResidents applies the census verdict, or the pessimistic default
+// when there is no census to ask.
+func apiHasLegacyResidents(relics func(beads.Store) bool, store beads.Store) bool {
+	if relics == nil {
+		return true
+	}
+	return relics(store)
 }

--- a/internal/api/residency_topology.go
+++ b/internal/api/residency_topology.go
@@ -145,11 +145,13 @@ func apiResidencyBindings(order []beads.Store, byStore map[beads.Store][]coordcl
 	bindings := make([]storeref.ClassBinding, 0, len(order))
 	for _, store := range order {
 		classes := completeObservedClasses(byStore[store])
+		// Every namespace the store HOLDS, not only the one each class mints
+		// under: a namespace the binding does not declare is one the resolver
+		// gives it no authority over, and the id falls through to the work
+		// ledger that never had it.
 		prefixes := make([]string, 0, len(classes))
 		for _, class := range classes {
-			if prefix, ok := config.ReservedClassPrefix(class.String()); ok {
-				prefixes = append(prefixes, prefix)
-			}
+			prefixes = append(prefixes, config.ReservedClassPrefixesFor(class.String())...)
 		}
 		bindings = append(bindings, storeref.ClassBinding{
 			Classes:  classes,

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -171,6 +171,21 @@ type State interface {
 	// call site; its embedded .Store is nil when no store is available.
 	OrdersBeadStore() beads.OrdersStore
 
+	// ClassBindingHasLegacyResidents reports whether store — one of the
+	// per-class stores above — still holds an open bead under an id outside the
+	// namespaces its classes declare: a row `gc storage migrate` carried across
+	// under its original work-shaped id, reachable only by probing the binding.
+	//
+	// The API never opens a binding and cannot take that census itself, so the
+	// verdict crosses this surface from the boot that did. It exists because
+	// both planes plan by-id reads against the same bindings, and a plane that
+	// kept probing after the other retired would resolve one id to two stores.
+	//
+	// TRUE is the answer for every store this State cannot speak for —
+	// unknown included. An unread binding has said nothing about its residents,
+	// and "nothing" is not the claim that retires a probe.
+	ClassBindingHasLegacyResidents(store beads.Store) bool
+
 	// Orders returns the current active set of scanned orders.
 	// Returns nil if orders are not configured.
 	Orders() []orders.Order

--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -39,6 +39,7 @@ const (
 // SQLiteStoreOptions configures the SQLite bead store.
 type SQLiteStoreOptions struct {
 	prefix                  string
+	reservedPrefixes        []string
 	retentionPeriod         time.Duration
 	retentionSweepInterval  time.Duration
 	disableRetentionSweeper bool
@@ -80,6 +81,33 @@ func WithSQLiteStoreIDPrefix(prefix string) SQLiteStoreOption {
 	return func(o *SQLiteStoreOptions) {
 		if strings.TrimSpace(prefix) != "" {
 			o.prefix = normalizeIDPrefix(prefix)
+		}
+	}
+}
+
+// WithSQLiteStoreReservedIDPrefixes fences the store to the id namespaces it
+// serves: a caller-PINNED id outside all of them is refused by Create.
+//
+// Minting already keeps generated ids inside the store's own namespace, but an
+// explicit id is honored verbatim, so without this a caller can write a bead
+// into a class binding under an id the binding does not claim. Such a bead is
+// unreachable by every id-shaped lookup and contradicts the binding's own
+// namespace declaration, which is what lets the residency resolver eventually
+// stop probing.
+//
+// More than one prefix, because a binding holds more than it mints — the nudge
+// queue's records live in the nudges store under their own namespace. An empty
+// set leaves the store unfenced, which is the shipped default everywhere the
+// store is not a class binding.
+//
+// CreateWithForeignID deliberately bypasses the fence: carrying a preserved
+// foreign id across is the store-migration copy path's entire job.
+func WithSQLiteStoreReservedIDPrefixes(prefixes ...string) SQLiteStoreOption {
+	return func(o *SQLiteStoreOptions) {
+		for _, p := range prefixes {
+			if p = normalizeIDPrefix(p); p != "" {
+				o.reservedPrefixes = append(o.reservedPrefixes, p)
+			}
 		}
 	}
 }
@@ -153,6 +181,7 @@ type SQLiteStore struct {
 	readDB                     *sql.DB // read pool (MaxOpenConns=8)
 	path                       string
 	prefix                     string
+	reservedPrefixes           []string // when non-empty, the namespaces a pinned id must carry
 	retentionPeriod            time.Duration
 	retentionSweepInterval     time.Duration
 	disableRetentionSweeper    bool
@@ -247,6 +276,7 @@ func OpenSQLiteStore(dir string, opts ...SQLiteStoreOption) (Store, error) {
 		db:                      db,
 		path:                    dbPath,
 		prefix:                  cfg.prefix,
+		reservedPrefixes:        cfg.reservedPrefixes,
 		retentionPeriod:         cfg.retentionPeriod,
 		retentionSweepInterval:  cfg.retentionSweepInterval,
 		disableRetentionSweeper: cfg.disableRetentionSweeper,
@@ -551,15 +581,28 @@ func (s *SQLiteStore) CreateWithForeignID(b Bead) (Bead, error) {
 	if strings.TrimSpace(b.ID) == "" {
 		return Bead{}, fmt.Errorf("creating bead with foreign id: empty id")
 	}
-	return s.Create(b)
+	return s.create(b, true)
 }
 
 // Create persists a new bead, minting a prefixed sequential id when the
 // caller did not pin one; an explicit id is honored verbatim with a hard
-// duplicate-id error.
+// duplicate-id error, provided it carries one of the store's reserved
+// namespaces when the store is fenced (WithSQLiteStoreReservedIDPrefixes).
 func (s *SQLiteStore) Create(b Bead) (Bead, error) {
+	return s.create(b, false)
+}
+
+// create is the shared body. allowForeign is the CreateWithForeignID
+// exemption: the store-migration copy path carries preserved ids across, and
+// refusing them there would leave the beads nowhere at all.
+func (s *SQLiteStore) create(b Bead, allowForeign bool) (Bead, error) {
 	if err := s.ensureOpen(); err != nil {
 		return Bead{}, err
+	}
+	if !allowForeign {
+		if err := s.checkPinnedIDNamespace(b.ID); err != nil {
+			return Bead{}, err
+		}
 	}
 	var stored Bead
 	autoID := b.ID == ""
@@ -603,6 +646,25 @@ func (s *SQLiteStore) Create(b Bead) (Bead, error) {
 		return Bead{}, err
 	}
 	return cloneBead(stored), nil
+}
+
+// checkPinnedIDNamespace enforces the fence. An empty id is a mint request and
+// an unfenced store claims no namespace, so both pass untouched.
+func (s *SQLiteStore) checkPinnedIDNamespace(id string) error {
+	if len(s.reservedPrefixes) == 0 {
+		return nil
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	lowered := strings.ToLower(id)
+	for _, prefix := range s.reservedPrefixes {
+		if strings.HasPrefix(lowered, prefix+"-") {
+			return nil
+		}
+	}
+	return fmt.Errorf("sqlite create: id %q is outside this store's namespaces (%s): a pinned id must carry one of them, or use the foreign-id create the store migration uses", id, strings.Join(s.reservedPrefixes, ", "))
 }
 
 func (s *SQLiteStore) normalizeCreate(b Bead) Bead {

--- a/internal/beads/sqlite_store_id_fence_test.go
+++ b/internal/beads/sqlite_store_id_fence_test.go
@@ -1,0 +1,106 @@
+package beads
+
+// The pinned-id fence.
+//
+// A class binding claims a namespace, and the residency resolver is allowed to
+// retire its residence probe once that claim is true — once every bead in the
+// binding can be recognized from its id alone. Minting takes care of the ids
+// the store generates. It says nothing about the ids a CALLER pins: Create
+// honors an explicit id verbatim, so without a fence any caller can write a
+// "ga-…" bead into the graph binding and the claim quietly stops holding. The
+// bead is then invisible to every id-shaped lookup and lives in a store that
+// says it does not hold such things.
+//
+// The fence is a namespace check, not an equality check: a binding holds more
+// than it mints (the nudge queue's "gcnq-" records inside the nudges store), so
+// the store is opened with the namespace SET it serves rather than with its
+// mint prefix alone.
+//
+// CreateWithForeignID is the deliberate exception and stays open. It is the
+// store-migration copy path, whose entire job is to carry a preserved foreign
+// id across — and the beads it writes are exactly the relics
+// ClassBinding.HasLegacyResidents exists to keep the probe alive for.
+
+import (
+	"strings"
+	"testing"
+)
+
+func openFencedStore(t *testing.T, prefixes ...string) *SQLiteStore {
+	t.Helper()
+	opened, err := OpenSQLiteStore(t.TempDir(),
+		WithSQLiteStoreIDPrefix("gcn"),
+		WithSQLiteStoreReservedIDPrefixes(prefixes...),
+	)
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	store, ok := opened.(*SQLiteStore)
+	if !ok {
+		t.Fatalf("OpenSQLiteStore returned %T, want *SQLiteStore", opened)
+	}
+	t.Cleanup(func() { _ = store.CloseStore() })
+	return store
+}
+
+func TestFenceRefusesAPinnedForeignID(t *testing.T) {
+	store := openFencedStore(t, "gcn", "gcnq")
+	_, err := store.Create(Bead{ID: "ga-42", Title: "a work id pinned into the nudges binding"})
+	if err == nil {
+		t.Fatal("Create accepted a foreign pinned id; the binding's namespace claim is now false and the bead is unreachable by id")
+	}
+	if !strings.Contains(err.Error(), "ga-42") || !strings.Contains(err.Error(), "gcn") {
+		t.Errorf("refusal %q names neither the id nor the namespaces it must carry", err)
+	}
+}
+
+func TestFenceAcceptsEveryNamespaceTheBindingHolds(t *testing.T) {
+	store := openFencedStore(t, "gcn", "gcnq")
+	// The mint prefix, and the namespace the store holds without minting.
+	for _, id := range []string{"gcn-7", "gcnq-abc-q"} {
+		created, err := store.Create(Bead{ID: id, Title: "held"})
+		if err != nil {
+			t.Fatalf("Create(%q): %v", id, err)
+		}
+		if created.ID != id {
+			t.Errorf("Create(%q) returned id %q; a pinned id inside the namespace must be honored verbatim", id, created.ID)
+		}
+	}
+}
+
+// The control that keeps the fence from being a blanket refusal of pinned ids:
+// an unfenced store is the shipped default and must behave exactly as before.
+func TestAnUnfencedStoreStillHonorsAnyPinnedID(t *testing.T) {
+	store := openFencedStore(t)
+	created, err := store.Create(Bead{ID: "ga-42", Title: "no fence configured"})
+	if err != nil {
+		t.Fatalf("an unfenced store refused a pinned id: %v", err)
+	}
+	if created.ID != "ga-42" {
+		t.Errorf("got id %q, want ga-42", created.ID)
+	}
+}
+
+// The other control: minting is untouched. The fence only ever inspects an id
+// the caller supplied.
+func TestFenceLeavesMintingAlone(t *testing.T) {
+	store := openFencedStore(t, "gcn", "gcnq")
+	created, err := store.Create(Bead{Title: "minted"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !strings.HasPrefix(created.ID, "gcn-") {
+		t.Errorf("minted id %q does not carry the store's own prefix", created.ID)
+	}
+}
+
+func TestForeignIDCreateStaysOpenForTheMigrationCopy(t *testing.T) {
+	store := openFencedStore(t, "gcn", "gcnq")
+	created, err := store.CreateWithForeignID(Bead{ID: "ga-42", Title: "a relic carried across by gc storage migrate"})
+	if err != nil {
+		t.Fatalf("CreateWithForeignID refused a preserved id: %v — the migration copy path cannot do its job", err)
+	}
+	if created.ID != "ga-42" {
+		t.Errorf("got id %q, want the preserved ga-42", created.ID)
+	}
+}

--- a/internal/config/reserved_prefixes.go
+++ b/internal/config/reserved_prefixes.go
@@ -21,12 +21,65 @@ var reservedClassPrefixes = map[string]string{
 	BeadClassNudges:    "gcn",
 }
 
-// ReservedClassPrefix returns the reserved id-prefix for a SQLite-relocated
-// coordination class (e.g. BeadClassOrders -> "gco"), and whether the class has
+// reservedAuxiliaryPrefixes maps a class to the prefixes its store holds beads
+// under but does NOT mint from — a subsystem inside the class binding that
+// mints its own ids.
+//
+// The nudge queue is the one such subsystem: it derives a queue record's id
+// from the nudge it carries (storebinding's nudgeQueueIDPrefix, a content hash
+// rather than a sequence) so that redelivering the same nudge is idempotent
+// without a lookup. Those records live in the nudges binding and are nudges-class
+// beads in every sense that matters to routing; they are simply not minted by
+// the store's own sequence, which is the only thing ReservedClassPrefix
+// describes.
+//
+// A prefix here is reserved exactly as strongly as a mint prefix: a rig
+// configured with it collides with real ids, and an id carrying it belongs to
+// the class binding and nowhere else.
+var reservedAuxiliaryPrefixes = map[string][]string{
+	BeadClassNudges: {"gcnq"},
+}
+
+// ReservedClassPrefix returns the id-prefix a SQLite-relocated coordination
+// class MINTS under (e.g. BeadClassOrders -> "gco"), and whether the class has
 // one. Classes without a reserved prefix (e.g. BeadClassWork) return ("", false).
+//
+// This is the store's IDPrefix, not the class's namespace union: a caller
+// deciding whether an id belongs to the class wants ReservedClassPrefixesFor,
+// which also covers the prefixes the class holds without minting.
 func ReservedClassPrefix(class string) (string, bool) {
 	p, ok := reservedClassPrefixes[class]
 	return p, ok
+}
+
+// ReservedClassPrefixesFor returns every reserved id-prefix belonging to a
+// class — the one it mints under first, then any auxiliary namespaces its
+// store holds. Classes with no reserved prefix return nil.
+//
+// Mint-first ordering is load-bearing for callers that take the head as "the"
+// prefix, and it is what lets a binding's namespace list be built by
+// concatenation without a second lookup.
+func ReservedClassPrefixesFor(class string) []string {
+	mint, ok := reservedClassPrefixes[class]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, 1+len(reservedAuxiliaryPrefixes[class]))
+	out = append(out, mint)
+	out = append(out, reservedAuxiliaryPrefixes[class]...)
+	return out
+}
+
+// AllReservedClassPrefixes returns every reserved id-prefix across all classes,
+// sorted. It is the namespace union an id is tested against when the class it
+// might belong to is not known in advance.
+func AllReservedClassPrefixes() []string {
+	out := make([]string, 0, len(reservedClassPrefixes)+len(reservedAuxiliaryPrefixes))
+	for class := range reservedClassPrefixes {
+		out = append(out, ReservedClassPrefixesFor(class)...)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // ReservedClassPrefixes returns a copy of the class -> reserved-prefix map.
@@ -45,7 +98,7 @@ func IsReservedClassPrefix(p string) bool {
 	if p == "" {
 		return false
 	}
-	for _, reserved := range reservedClassPrefixes {
+	for _, reserved := range AllReservedClassPrefixes() {
 		if strings.ToLower(reserved) == p {
 			return true
 		}
@@ -56,10 +109,5 @@ func IsReservedClassPrefix(p string) bool {
 // reservedClassPrefixListText returns the reserved class id-prefixes as a
 // sorted, comma-separated string for use in validation error messages.
 func reservedClassPrefixListText() string {
-	prefixes := make([]string, 0, len(reservedClassPrefixes))
-	for _, p := range reservedClassPrefixes {
-		prefixes = append(prefixes, p)
-	}
-	sort.Strings(prefixes)
-	return strings.Join(prefixes, ", ")
+	return strings.Join(AllReservedClassPrefixes(), ", ")
 }

--- a/internal/config/reserved_prefixes_test.go
+++ b/internal/config/reserved_prefixes_test.go
@@ -1,0 +1,127 @@
+package config
+
+// The reserved id namespaces, and the auxiliary one the registry did not know
+// about.
+//
+// A class mints under one prefix, but a class STORE can hold beads under more
+// than one: the nudge queue mints its own records as "gcnq-…" inside the nudges
+// binding (internal/storebinding/beads_nudge_queue.go's nudgeQueueIDPrefix).
+// That prefix was never registered, so every consumer that asks "is this id
+// class-reserved" — the rig/HQ prefix validator, the `gc bd` by-id front door,
+// the residency topology's binding namespaces — answered no for a queue id.
+//
+// The consequences are asymmetric and both bad. A rig could be configured with
+// prefix "gcnq" and collide with the queue's own ids, and a by-id read of a
+// queue bead falls through to the work ledger, which answers it emptily and
+// confidently. Registration is what makes the union match the reality.
+
+import (
+	"testing"
+)
+
+func TestNudgeQueuePrefixIsReserved(t *testing.T) {
+	if !IsReservedClassPrefix("gcnq") {
+		t.Error("gcnq is not reserved; a rig could be configured with that prefix and collide with the nudge queue's own bead ids")
+	}
+	// Case-insensitive, matching ValidateRigs' prefix handling.
+	if !IsReservedClassPrefix("  GCNQ ") {
+		t.Error("gcnq is not reserved case-insensitively; the rig validator lowercases before comparing")
+	}
+}
+
+// The auxiliary prefix must not displace the one the class MINTS under. A
+// binding's store is opened with ReservedClassPrefix as its IDPrefix, so a
+// change there is a change to every id the class creates from then on.
+func TestReservedClassPrefixStillNamesTheMintPrefix(t *testing.T) {
+	got, ok := ReservedClassPrefix(BeadClassNudges)
+	if !ok {
+		t.Fatal("nudges has no reserved mint prefix")
+	}
+	if got != "gcn" {
+		t.Fatalf("nudges mints under %q, want gcn — this is the store's IDPrefix, not the namespace union", got)
+	}
+}
+
+func TestReservedClassPrefixesForCoversAuxiliaryNamespaces(t *testing.T) {
+	tests := []struct {
+		class string
+		want  []string
+	}{
+		{BeadClassNudges, []string{"gcn", "gcnq"}},
+		{BeadClassGraph, []string{"gcg"}},
+		{BeadClassWork, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.class, func(t *testing.T) {
+			got := ReservedClassPrefixesFor(tt.class)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ReservedClassPrefixesFor(%q) = %v, want %v", tt.class, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("ReservedClassPrefixesFor(%q) = %v, want %v (mint prefix first)", tt.class, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// Every prefix the registry knows must be reserved, and the union must be the
+// concatenation of the per-class unions. Stated as a property rather than a
+// literal list so registering a sixth class cannot leave one accessor behind.
+func TestReservedPrefixUnionAgreesWithPerClassUnions(t *testing.T) {
+	union := map[string]bool{}
+	for _, p := range AllReservedClassPrefixes() {
+		if !IsReservedClassPrefix(p) {
+			t.Errorf("AllReservedClassPrefixes returned %q, which IsReservedClassPrefix denies", p)
+		}
+		union[p] = true
+	}
+	for class := range reservedClassPrefixes {
+		for _, p := range ReservedClassPrefixesFor(class) {
+			if !union[p] {
+				t.Errorf("class %q reserves %q, which is missing from AllReservedClassPrefixes", class, p)
+			}
+		}
+	}
+}
+
+// The validator's message names what it refuses. An operator told "gcnq is
+// reserved" and then shown a list without gcnq in it has been told the rule and
+// shown a contradiction.
+func TestReservedPrefixListTextNamesEveryReservedPrefix(t *testing.T) {
+	text := reservedClassPrefixListText()
+	for _, p := range AllReservedClassPrefixes() {
+		if !containsWord(text, p) {
+			t.Errorf("the validator's reserved-prefix list %q omits %q, which it refuses", text, p)
+		}
+	}
+}
+
+func containsWord(text, word string) bool {
+	for _, field := range splitCommaSpace(text) {
+		if field == word {
+			return true
+		}
+	}
+	return false
+}
+
+func splitCommaSpace(text string) []string {
+	var out []string
+	cur := ""
+	for _, r := range text {
+		if r == ',' || r == ' ' {
+			if cur != "" {
+				out = append(out, cur)
+				cur = ""
+			}
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/internal/storebinding/sqlite/beads_engine.go
+++ b/internal/storebinding/sqlite/beads_engine.go
@@ -35,6 +35,30 @@ func (p *beadsProvider) BindingLocation(spec storebinding.BindingSpec) (string, 
 	return p.path, nil
 }
 
+// engineReservedPrefixes returns the id namespaces a binding serving classes
+// may hold, for the pinned-id fence. Nil leaves the store unfenced.
+//
+// A class with no reserved namespace makes the whole binding unfenceable: work
+// beads carry whatever prefix an operator configured for the rig or HQ, which
+// is not knowable here, so a binding that serves work claims nothing and every
+// pinned id has to be let through. Fencing it to the infrastructure prefixes
+// would refuse the work beads it exists to hold.
+func engineReservedPrefixes(classes storebinding.ClassSet) []string {
+	served := classes.Classes()
+	if len(served) == 0 {
+		return nil
+	}
+	prefixes := make([]string, 0, len(served))
+	for _, class := range served {
+		held := config.ReservedClassPrefixesFor(class.String())
+		if len(held) == 0 {
+			return nil
+		}
+		prefixes = append(prefixes, held...)
+	}
+	return prefixes
+}
+
 // storeCloser adapts a bead store's own close to io.Closer.
 //
 // beads.Store already has a Close method with a different meaning — closing one
@@ -71,7 +95,10 @@ func (p *beadsProvider) OpenEngine(spec storebinding.BindingSpec, classes storeb
 	if !ok || prefix == "" {
 		return nil, nil, fmt.Errorf("%w: no reserved id prefix is registered for the %q class", ErrInvalidBeadsBinding, config.BeadClassGraph)
 	}
-	store, err := beads.OpenSQLiteStore(filepath.Dir(p.path), beads.WithSQLiteStoreIDPrefix(prefix))
+	store, err := beads.OpenSQLiteStore(filepath.Dir(p.path),
+		beads.WithSQLiteStoreIDPrefix(prefix),
+		beads.WithSQLiteStoreReservedIDPrefixes(engineReservedPrefixes(classes)...),
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening the SQLite Beads engine of binding %q at %s: %w", p.spec.Name, p.path, err)
 	}

--- a/internal/storebinding/sqlite/beads_engine_namespace_test.go
+++ b/internal/storebinding/sqlite/beads_engine_namespace_test.go
@@ -1,0 +1,65 @@
+package sqlite
+
+// The namespaces an opened engine is fenced to.
+//
+// A class binding claims id namespaces, and the fence is what keeps that claim
+// true against a caller-pinned id (beads.WithSQLiteStoreReservedIDPrefixes).
+// The set has to be derived from the classes the binding was ASSIGNED, not from
+// the class this provider happens to name its file after: a whole split serves
+// all five infrastructure classes from one ledger and legitimately holds every
+// one of their namespaces.
+//
+// The work class is the case that decides the shape of the rule. Work beads
+// carry the rig or HQ prefix an operator configured, which is not a reserved
+// namespace and not knowable here, so a binding that serves work claims no
+// namespace at all and must be left unfenced. Fencing it to the infrastructure
+// prefixes would refuse every work bead the binding exists to hold.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storebinding"
+)
+
+func classSet(t *testing.T, classes ...coordclass.Class) storebinding.ClassSet {
+	t.Helper()
+	set, err := storebinding.NewClassSet(classes...)
+	if err != nil {
+		t.Fatalf("NewClassSet(%v): %v", classes, err)
+	}
+	return set
+}
+
+func TestEngineFenceCoversEveryAssignedClass(t *testing.T) {
+	got := engineReservedPrefixes(classSet(t, coordclass.ClassGraph, coordclass.ClassNudges))
+	want := append(
+		config.ReservedClassPrefixesFor(config.BeadClassGraph),
+		config.ReservedClassPrefixesFor(config.BeadClassNudges)...,
+	)
+	if len(got) != len(want) {
+		t.Fatalf("engineReservedPrefixes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("engineReservedPrefixes = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestEngineServingWorkIsLeftUnfenced(t *testing.T) {
+	if got := engineReservedPrefixes(classSet(t, coordclass.ClassWork, coordclass.ClassGraph)); got != nil {
+		t.Errorf("engineReservedPrefixes = %v, want nil: work beads carry the operator's configured rig prefix, so fencing this binding would refuse them", got)
+	}
+	// The control: drop work and the same set is fenced.
+	if got := engineReservedPrefixes(classSet(t, coordclass.ClassGraph)); got == nil {
+		t.Error("an infrastructure-only binding was left unfenced")
+	}
+}
+
+func TestEngineFenceIsEmptyForNoClasses(t *testing.T) {
+	if got := engineReservedPrefixes(storebinding.ClassSet{}); got != nil {
+		t.Errorf("engineReservedPrefixes = %v, want nil", got)
+	}
+}

--- a/internal/storeref/mint_test.go
+++ b/internal/storeref/mint_test.go
@@ -1,0 +1,62 @@
+package storeref
+
+// Whether a binding mints truthfully.
+//
+// ClassBinding.MintsReserved is half of the residence-probe retirement
+// condition, and its doc has always demanded a VERIFIED check rather than a
+// constructor's optimism. The verification available is the store's own
+// declaration: a store that implements HasIDPrefix names the namespace it mints
+// into, and the binding names the namespaces it claims. When the first is one
+// of the second, a bead this binding creates from now on is recognizable from
+// its id alone — which is exactly what the retirement premise needs.
+//
+// It is only ever half. A store that mints truthfully today can still hold
+// relics migrated in under a foreign id, which is why HasLegacyResidents is the
+// other half and why nothing retires until a census says so.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestMintsInsideNamespaceMatchesADeclaredPrefix(t *testing.T) {
+	store := newPrefixedStore("gcg")
+	if !MintsInsideNamespace(store, []string{"gcg", "gcm", "gcs", "gco", "gcn", "gcnq"}) {
+		t.Error("a store minting gcg- into a binding that claims gcg is not recognized as minting truthfully")
+	}
+}
+
+func TestMintsInsideNamespaceRejectsAnUnclaimedPrefix(t *testing.T) {
+	// The shape the field exists to exclude: the binding claims the graph
+	// namespace but its store mints work ids, so a new bead's id says nothing
+	// about where it lives.
+	store := newPrefixedStore("ga")
+	if MintsInsideNamespace(store, []string{"gcg"}) {
+		t.Error("a store minting ga- was called truthful for a gcg binding")
+	}
+}
+
+// The control that keeps the check from defaulting to optimism: a store that
+// declares nothing has verified nothing.
+func TestMintsInsideNamespaceRejectsAStoreThatDeclaresNothing(t *testing.T) {
+	if MintsInsideNamespace(beads.NewMemStore(), []string{"gcg"}) {
+		t.Error("a store with no IDPrefix() was called truthful; nothing about it was verified")
+	}
+	if MintsInsideNamespace(newPrefixedStore(""), []string{"gcg"}) {
+		t.Error("a store declaring an empty prefix was called truthful")
+	}
+	if MintsInsideNamespace(nil, []string{"gcg"}) {
+		t.Error("a nil store was called truthful")
+	}
+}
+
+func TestMintsInsideNamespaceRejectsABindingThatClaimsNothing(t *testing.T) {
+	if MintsInsideNamespace(newPrefixedStore("gcg"), nil) {
+		t.Error("a binding claiming no namespace cannot have a store minting inside it")
+	}
+}
+
+// newPrefixedStore is newPrefixed as a beads.Store, so a row can pass the nil
+// interface the "declares nothing" control needs.
+func newPrefixedStore(prefix string) beads.Store { return newPrefixed(prefix) }

--- a/internal/storeref/placement_test.go
+++ b/internal/storeref/placement_test.go
@@ -1,0 +1,100 @@
+package storeref
+
+// The single-owner executor.
+//
+// ModeSingleOwner is the placement contract's mode — "this class is created
+// HERE, there is nothing to probe" — and until now it had no executor. Plan
+// produced it for every Class intent and no caller could run it: ResolveOwner
+// refuses a non-FirstOwner plan and Union refuses a non-Union one, so the only
+// way to act on a placement plan was to reach into its legs, which is exactly
+// what plan.go's mode doc warns against and what the residency-boundary guard's
+// plan-leg-store-access row forbids at every consumer.
+//
+// These rows are the executor's contract: it names the one store, and it
+// refuses the two plan shapes it is not for. The refusals are the load-bearing
+// half — running a FirstOwner plan through a placement executor would silently
+// place a bead in the leg that merely LEADS the probe order.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+func TestResolvePlacementNamesTheBinding(t *testing.T) {
+	f := newT1()
+	plan := mustPlan(t, Class{C: coordclass.ClassGraph}, f.topo)
+
+	leg, err := ResolvePlacement(plan)
+	if err != nil {
+		t.Fatalf("ResolvePlacement(%s): %v", plan, err)
+	}
+	want := f.legStore(ClassRef(infraClasses))
+	if want == nil {
+		t.Fatalf("fixture %s has no whole-split binding to name", f.name)
+	}
+	if leg.Store != beads.Store(want) {
+		t.Fatalf("placement store = %s, want the class binding %s", storeNameOf(leg.Store), want.name)
+	}
+	if !IsClassRef(string(leg.Ref)) {
+		t.Fatalf("placement leg ref = %q, want a class binding ref", leg.Ref)
+	}
+}
+
+func TestResolvePlacementNamesTheWorkStoreWhenNothingIsRelocated(t *testing.T) {
+	f := newT0()
+	plan := mustPlan(t, Class{C: coordclass.ClassGraph}, f.topo)
+
+	leg, err := ResolvePlacement(plan)
+	if err != nil {
+		t.Fatalf("ResolvePlacement(%s): %v", plan, err)
+	}
+	if leg.Store != beads.Store(f.work) {
+		t.Fatalf("placement store = %s, want the work store %s", storeNameOf(leg.Store), f.work.name)
+	}
+	if leg.Ref != WorkRef {
+		t.Fatalf("placement leg ref = %q, want the work ref", leg.Ref)
+	}
+}
+
+// A refused city must not place an infrastructure-class bead at all. The
+// refusal is the whole point: the binding is the owner, this build must not
+// serve it, and writing to the work ledger instead is the stranded write the
+// refusal exists to prevent.
+func TestResolvePlacementCarriesTheStandingRefusal(t *testing.T) {
+	if _, err := Plan(Class{C: coordclass.ClassGraph}, newT3().topo); err == nil {
+		t.Fatal("planning a placement on a REFUSED city succeeded; a refused binding has no placement to hand out")
+	}
+}
+
+func TestResolvePlacementRejectsAFirstOwnerPlan(t *testing.T) {
+	f := newT1()
+	plan := mustPlan(t, ByID{ID: workShapedID}, f.topo)
+	if _, err := ResolvePlacement(plan); err == nil {
+		t.Fatal("ResolvePlacement accepted a FirstOwner plan; its leading leg merely leads a PROBE order and is not a placement")
+	}
+}
+
+func TestResolvePlacementRejectsAUnionPlan(t *testing.T) {
+	f := newT2()
+	plan := mustPlan(t, RoutedWork{}, f.topo)
+	if _, err := ResolvePlacement(plan); err == nil {
+		t.Fatal("ResolvePlacement accepted a Union plan; the mode decides the executor")
+	}
+}
+
+// The other two executors must refuse a placement plan for the same reason.
+// Without this row a Class plan could be run through ResolveOwner, which
+// PROBES its leg and reports absence as a miss — turning "create it here" into
+// "there is nothing here".
+func TestTheOtherExecutorsRejectAPlacementPlan(t *testing.T) {
+	f := newT1()
+	plan := mustPlan(t, Class{C: coordclass.ClassGraph}, f.topo)
+	if _, _, err := ResolveOwner(plan, workShapedID); err == nil {
+		t.Error("ResolveOwner accepted a SingleOwner plan")
+	}
+	if _, err := Union(plan, beadID, listOpenLeg); err == nil {
+		t.Error("Union accepted a SingleOwner plan")
+	}
+}

--- a/internal/storeref/relic_census.go
+++ b/internal/storeref/relic_census.go
@@ -1,0 +1,89 @@
+package storeref
+
+// The relic census: does this binding still hold a bead that only a probe can
+// find?
+//
+// A class migration copies rows across with their ORIGINAL ids
+// (beads.ForeignIDCreator), so a converged city's binding holds a population of
+// work-shaped ids no reader can locate from the id alone. That population is
+// the whole reason ClassBinding.HasLegacyResidents exists, and it is a
+// LIVE-STATE question, not a config or manifest one: the migration manifest
+// records what was copied, not what is still open, and relics close over the
+// following weeks. A recorded number would be stale the day after it was
+// written — "no status files — query live state".
+//
+// So the answer is one read of the binding, taken once per process, and it is
+// deliberately allowed to be wrong in exactly one direction. Reporting relics
+// that have since closed keeps a probe one process longer. Reporting clean when
+// the read failed retires the probe over beads that are still there.
+//
+// The once-per-process part rests on one premise: no relic ARRIVES while the
+// process runs. That holds because the only thing that creates one is `gc
+// storage migrate`, which refuses to run against a city with a live controller
+// (cmd/gc/infra_class_migrate.go, guarded by
+// TestEnsureInfraClassMigratedRefusesWhileAnotherControllerIsLive). If that
+// refusal is ever relaxed, this verdict has to be recomputed on migrate rather
+// than taken once at boot.
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// OpenLegacyResidents returns the ids of the OPEN beads store holds whose
+// namespace none of prefixes claims — the relics a class migration carried
+// across under their original ids.
+//
+// Closed beads are excluded because the retirement blocker is a bead that can
+// still be READ BY ID; counting a city's whole history would pin the probe
+// forever. Both tiers are read, because a wisp carried across is as unfindable
+// as an issue.
+//
+// The ids come back sorted so an operator report and a boot verdict describe
+// the same binding the same way twice.
+func OpenLegacyResidents(store beads.Store, prefixes []string) ([]string, error) {
+	if store == nil {
+		return nil, fmt.Errorf("relic census: no binding store to read")
+	}
+	rows, err := store.List(beads.ListQuery{TierMode: beads.FederatedReadTier, AllowScan: true})
+	if err != nil {
+		return nil, fmt.Errorf("relic census: listing the binding: %w", err)
+	}
+	var relics []string
+	for _, b := range rows {
+		if idInAnyNamespace(b.ID, prefixes) {
+			continue
+		}
+		relics = append(relics, b.ID)
+	}
+	sort.Strings(relics)
+	return relics, nil
+}
+
+// HasOpenLegacyResidents is the boot-time verdict form of the census: the value
+// ClassBinding.HasLegacyResidents is allowed to be set from.
+//
+// A census that failed answers TRUE. An unread binding has said nothing about
+// its residents, and "nothing" is not the claim that retires a probe — the
+// refused city, whose store answers every read with the standing storage
+// refusal, takes this branch too.
+func HasOpenLegacyResidents(b ClassBinding) bool {
+	relics, err := OpenLegacyResidents(b.Leg.Store, b.Prefixes)
+	if err != nil {
+		return true
+	}
+	return len(relics) > 0
+}
+
+// idInAnyNamespace reports whether any prefix claims id's namespace. It is the
+// one rule the census and ClassBinding.coversID both read ids by.
+func idInAnyNamespace(id string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if IDInNamespace(id, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storeref/relic_census_test.go
+++ b/internal/storeref/relic_census_test.go
@@ -1,0 +1,188 @@
+package storeref
+
+// The relic census, and the direction it is allowed to be wrong in.
+//
+// HasLegacyResidents is the half of the retirement condition that a
+// point-in-time read answers, so every row here is really about one question:
+// when the census cannot see clearly, which way does it fall? True keeps the
+// probe and costs one Get per out-of-namespace by-id read. False retires the
+// probe and strands every bead the migration carried across under its original
+// id — the ga-axin6 shape. The error rows are therefore not edge cases; they
+// are the point.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
+)
+
+// censusStore is a binding store whose List can be made to fail, so the
+// fail-safe direction is testable rather than asserted.
+type censusStore struct {
+	*beads.MemStore
+	listErr error
+}
+
+func newCensusStore() *censusStore {
+	mem := beads.NewMemStore()
+	mem.HonorExplicitIDs = true
+	return &censusStore{MemStore: mem}
+}
+
+func (s *censusStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.MemStore.List(q)
+}
+
+func (s *censusStore) seedBead(t *testing.T, id string) {
+	t.Helper()
+	if _, err := s.Create(beads.Bead{ID: id, Title: id, Type: "task"}); err != nil {
+		t.Fatalf("seeding %q: %v", id, err)
+	}
+}
+
+func censusBinding(store beads.Store) ClassBinding {
+	return ClassBinding{
+		Classes:  infraClasses,
+		Prefixes: infraPrefixes,
+		Leg:      Leg{Ref: ClassRef(infraClasses), Store: store},
+	}
+}
+
+func TestOpenLegacyResidentsFindsAMigratedID(t *testing.T) {
+	store := newCensusStore()
+	store.seedBead(t, "gcg-1")
+	store.seedBead(t, "ga-relic")
+
+	relics, err := OpenLegacyResidents(store, infraPrefixes)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if len(relics) != 1 || relics[0] != "ga-relic" {
+		t.Fatalf("census reported %v, want just the work-shaped id the migration carried across", relics)
+	}
+	if !HasOpenLegacyResidents(censusBinding(store)) {
+		t.Error("a binding holding an open relic reported none; its probe would retire and the relic would be unreadable")
+	}
+}
+
+func TestOpenLegacyResidentsIgnoresEveryNamespaceTheBindingHolds(t *testing.T) {
+	// Both halves of "holds": the prefix each class mints under, and the
+	// auxiliary the nudge queue pins. A census that knew only the mint
+	// prefixes would count every queued nudge as a relic and keep the probe
+	// alive forever on a perfectly clean city.
+	store := newCensusStore()
+	for _, id := range []string{"gcg-1", "gcm-2", "gcs-3", "gco-4", "gcn-5", "gcnq-6"} {
+		store.seedBead(t, id)
+	}
+
+	relics, err := OpenLegacyResidents(store, infraPrefixes)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if len(relics) != 0 {
+		t.Fatalf("census reported %v as relics; every one of those namespaces is one this binding declares", relics)
+	}
+	if HasOpenLegacyResidents(censusBinding(store)) {
+		t.Error("a binding holding only its own ids reported relics")
+	}
+}
+
+func TestOpenLegacyResidentsIgnoresAClosedRelic(t *testing.T) {
+	// The retirement blocker is a relic that can still be READ BY ID, and the
+	// operational story is watching that population drain as the beads close.
+	// Counting closed rows would pin the probe to a city's whole history.
+	store := newCensusStore()
+	store.seedBead(t, "ga-done")
+	if err := store.Close("ga-done"); err != nil {
+		t.Fatalf("closing the relic: %v", err)
+	}
+
+	relics, err := OpenLegacyResidents(store, infraPrefixes)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if len(relics) != 0 {
+		t.Fatalf("census reported %v; a closed relic is not a retirement blocker", relics)
+	}
+}
+
+func TestOpenLegacyResidentsReportsAnEmptyBindingClean(t *testing.T) {
+	if HasOpenLegacyResidents(censusBinding(newCensusStore())) {
+		t.Error("an empty binding reported relics; nothing is what a fresh born-split city holds")
+	}
+}
+
+// The fail-safe control. An unreadable binding has told us nothing, and
+// "nothing" must not read as "clean".
+func TestUnreadableBindingKeepsItsProbe(t *testing.T) {
+	store := newCensusStore()
+	store.listErr = errors.New("binding unreachable")
+
+	if _, err := OpenLegacyResidents(store, infraPrefixes); err == nil {
+		t.Fatal("a failing List produced no census error; the caller cannot tell a clean binding from an unread one")
+	}
+	if !HasOpenLegacyResidents(censusBinding(store)) {
+		t.Error("an unreadable binding was reported clean; a census that cannot read must not retire a probe")
+	}
+}
+
+// The refused city takes the same branch, and it matters that it does: its
+// binding store answers every read with the standing refusal, which is the
+// least informative answer there is.
+func TestRefusedBindingKeepsItsProbe(t *testing.T) {
+	store := newCensusStore()
+	store.listErr = newRefusal()
+
+	if !HasOpenLegacyResidents(censusBinding(store)) {
+		t.Error("a refused city's binding was reported clean")
+	}
+}
+
+func TestCensusWithoutAStoreKeepsItsProbe(t *testing.T) {
+	if _, err := OpenLegacyResidents(nil, infraPrefixes); err == nil {
+		t.Fatal("censusing a nil store succeeded")
+	}
+	if !HasOpenLegacyResidents(ClassBinding{Classes: infraClasses, Prefixes: infraPrefixes}) {
+		t.Error("a binding with no store was reported clean")
+	}
+}
+
+// A binding that claims no namespace holds nothing it can recognize, so every
+// resident is a relic. That is the honest answer and it pairs with the mint
+// bit's own control: such a binding never mints truthfully either, so its
+// probe was never retiring anyway.
+func TestBindingClaimingNoNamespaceCountsEveryResident(t *testing.T) {
+	store := newCensusStore()
+	store.seedBead(t, "gcg-1")
+
+	relics, err := OpenLegacyResidents(store, nil)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if len(relics) != 1 {
+		t.Fatalf("census reported %v, want the one resident no declared namespace covers", relics)
+	}
+}
+
+// The census reads the binding and nothing else. A topology's work ledger is
+// full of work-shaped ids by definition, and reading it would report every
+// city on earth as relic-bound.
+func TestCensusReadsOnlyTheBinding(t *testing.T) {
+	binding := newCensusStore()
+	binding.seedBead(t, "gcg-1")
+	work := newCensusStore()
+	work.seedBead(t, "ga-1")
+
+	if HasOpenLegacyResidents(ClassBinding{
+		Classes:  []coordclass.Class{coordclass.ClassGraph},
+		Prefixes: []string{"gcg"},
+		Leg:      Leg{Ref: ClassRef([]coordclass.Class{coordclass.ClassGraph}), Store: binding},
+	}) {
+		t.Error("the census reported relics for a clean binding; it must read the binding leg alone")
+	}
+}

--- a/internal/storeref/residency_conformance_test.go
+++ b/internal/storeref/residency_conformance_test.go
@@ -26,6 +26,12 @@ const (
 	graphNamespacedID = "gcg-abc" // minted by the binding: inside the reserved namespace
 	workShapedID      = "ga-xyz"  // the migrate-preserved id: outside every namespace
 	rigShapedID       = "ra-7"    // inside a rig's CONFIGURED prefix: the shadow row
+	// queueNamespacedID is a nudge-queue record: inside a namespace the nudges
+	// binding HOLDS but does not mint. Its rows must match graphNamespacedID's
+	// wherever a binding carries the namespace, because "who minted it" is not a
+	// question the resolver asks — and must match the work-shaped rows on T5,
+	// where no binding carries it.
+	queueNamespacedID = "gcnq-abc-q"
 )
 
 // corpusRouter is the routed work axis the ",routed" rows plan over: the shape
@@ -49,6 +55,7 @@ func corpusIntents() []struct {
 		{"ByID(" + graphNamespacedID + ")", ByID{ID: graphNamespacedID}},
 		{"ByID(" + workShapedID + ")", ByID{ID: workShapedID}},
 		{"ByID(" + rigShapedID + ")", ByID{ID: rigShapedID}},
+		{"ByID(" + queueNamespacedID + ")", ByID{ID: queueNamespacedID}},
 		{"ByID(" + workShapedID + ",routed)", ByID{ID: workShapedID, WorkAxis: corpusRouter()}},
 		{"ByID(" + graphNamespacedID + ",routed)", ByID{ID: graphNamespacedID, WorkAxis: corpusRouter()}},
 		{"RoutedWork", RoutedWork{}},
@@ -224,6 +231,23 @@ var residencyCorpus = map[string]string{
 	"Class(work) x T6r":                    `SingleOwner: ""[Authority,Fatal]`,
 	"Class(graph) x T6r":                   `SingleOwner: class:gmnos[Authority,Fatal]`,
 	"Class(sessions) x T6r":                `SingleOwner: class:gmnos[Authority,Fatal]`,
+
+	// ---- The held-not-minted namespace, kept together because the claim is a
+	// comparison rather than a shape. Wherever a binding carries "gcnq" these
+	// rows are character-for-character the gcg-abc rows above: the resolver
+	// grants authority over a namespace the binding HOLDS, and never asks which
+	// sequence minted the id. On T5, where the two bindings carry only "gcg" and
+	// "gcs", they are the ga-xyz rows instead — an unheld namespace is not a
+	// half-claim, it is no claim, and the id gets the same probe order any
+	// unrecognized id gets.
+	"ByID(gcnq-abc-q) x T0":  `FirstOwner: ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T1":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T2":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T3":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T4":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T5":  `FirstOwner: class:g[ResidenceProbe,RefusalTolerated] > class:s[ResidenceProbe,RefusalTolerated] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T6":  `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
+	"ByID(gcnq-abc-q) x T6r": `FirstOwner: class:gmnos[Authority,Fatal] > ""[WorkFallback,Fatal]`,
 }
 
 // runtimeCorpusIntents is the intent axis of the RUNTIME-PLANE corpus: the

--- a/internal/storeref/residency_fixtures_test.go
+++ b/internal/storeref/residency_fixtures_test.go
@@ -29,12 +29,18 @@ const (
 )
 
 // infraClasses is the class set a whole-split binding carries, and
-// infraPrefixes the reserved id prefixes those classes mint. They are stated
-// here rather than read from internal/config because storeref is a leaf: a
-// caller supplies the prefixes, so the corpus supplies them too.
+// infraPrefixes the reserved id namespaces it holds beads under. They are
+// stated here rather than read from internal/config because storeref is a leaf:
+// a caller supplies the prefixes, so the corpus supplies them too.
+//
+// "gcnq" is in the list and is not a fifth-class mint prefix: it is the nudge
+// queue's own namespace inside the nudges binding, minted by a subsystem rather
+// than by the store's sequence. The resolver draws no distinction — a namespace
+// a binding holds is a namespace it has authority over — and that is the
+// property these rows pin.
 var (
 	infraClasses  = []coordclass.Class{coordclass.ClassGraph, coordclass.ClassMessaging, coordclass.ClassSessions, coordclass.ClassOrders, coordclass.ClassNudges}
-	infraPrefixes = []string{"gcg", "gcm", "gcs", "gco", "gcn"}
+	infraPrefixes = []string{"gcg", "gcm", "gcs", "gco", "gcn", "gcnq"}
 )
 
 // errRefused stands in for the standing storage refusal a refused city's boot

--- a/internal/storeref/resolve.go
+++ b/internal/storeref/resolve.go
@@ -625,6 +625,35 @@ func ResolveOwnerRow(p ResolvedPlan, id string) (Owner, error) {
 	return Owner{}, beads.ErrNotFound
 }
 
+// ResolvePlacement is the ModeSingleOwner executor: the one store a
+// class-pure operation — above all a CREATE — acts on.
+//
+// It performs no I/O, because placement is not a search. A by-id plan asks
+// "where does this bead live" and probes until something answers; a placement
+// plan asks "where does this class BELONG", and the topology already knows.
+// That difference is why the modes need separate executors rather than one
+// leg-walking loop: running a FirstOwner plan through this function would
+// return the leg that merely LEADS a probe order and place the bead there, and
+// running a placement plan through ResolveOwner would probe the owner and
+// report a not-yet-created bead's absence as a miss.
+//
+// A refused city never reaches here for a relocated class — Plan returns the
+// standing refusal as an error, which is what keeps an infrastructure-class
+// create off the work ledger the class was moved away from.
+func ResolvePlacement(p ResolvedPlan) (Leg, error) {
+	if p.Mode != ModeSingleOwner {
+		return Leg{}, fmt.Errorf("storeref: ResolvePlacement needs a %s plan, got %s", ModeSingleOwner, p.Mode)
+	}
+	if len(p.Legs) != 1 {
+		return Leg{}, fmt.Errorf("storeref: a %s plan names exactly one store, got %d (%s)", ModeSingleOwner, len(p.Legs), p)
+	}
+	owner := p.Legs[0].Leg
+	if owner.Store == nil {
+		return Leg{}, fmt.Errorf("storeref: %s plan leg %s has no store", ModeSingleOwner, legName(owner.Ref))
+	}
+	return owner, nil
+}
+
 // LegError names a leg whose read failed and was tolerated as a partial
 // degradation.
 type LegError struct {

--- a/internal/storeref/storeref.go
+++ b/internal/storeref/storeref.go
@@ -82,6 +82,33 @@ type HasIDPrefix interface {
 	IDPrefix() string
 }
 
+// MintsInsideNamespace reports whether store declares a mint prefix that is one
+// of prefixes — the boot-time check a topology constructor sets
+// ClassBinding.MintsReserved from.
+//
+// It is a comparison of declarations, not a read: the store names the namespace
+// it mints into and the binding names the namespaces it claims, and when they
+// agree a bead this binding creates from now on is recognizable from its id
+// alone. A store that declares nothing has verified nothing and reports false,
+// which is the conservative answer — a false mint bit only keeps the residence
+// probe, while a wrong true one retires it over beads it cannot recognize.
+func MintsInsideNamespace(store beads.Store, prefixes []string) bool {
+	declaring, ok := store.(HasIDPrefix)
+	if !ok {
+		return false
+	}
+	minted := strings.TrimSpace(declaring.IDPrefix())
+	if minted == "" {
+		return false
+	}
+	for _, prefix := range prefixes {
+		if strings.TrimSpace(prefix) == minted {
+			return true
+		}
+	}
+	return false
+}
+
 // PrefixOwner returns the store whose IDPrefix() owns id's namespace
 // (strings.HasPrefix(id, prefix+"-")), or nil when none claims it. It routes
 // purely on the static id prefix and never reads a store. Mirrors

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -92,9 +92,10 @@ type ClassBinding struct {
 	// carries all five infrastructure classes on one binding.
 	Classes []coordclass.Class
 
-	// Prefixes are the reserved id prefixes those classes mint (the caller
-	// supplies them from config.ReservedClassPrefix; storeref stays free of
-	// internal/config).
+	// Prefixes are the reserved id namespaces those classes HOLD — the prefix
+	// each mints under plus any its store holds without minting, such as the
+	// nudge queue's. The caller supplies them from
+	// config.ReservedClassPrefixesFor; storeref stays free of internal/config.
 	Prefixes []string
 
 	// Leg is the opened binding store.
@@ -105,16 +106,23 @@ type ClassBinding struct {
 	// condition: when a binding mints truthfully, a new bead's residence is
 	// decidable from its id alone.
 	//
-	// A constructor may only set this from a VERIFIED boot-time check. This
-	// build has no such check, so every constructor here leaves it false and
-	// the probe stays — the flip row is pre-written in the corpus so the day
-	// verification ships is a topology-bit change, not a redesign.
+	// A constructor may only set this from a VERIFIED boot-time check. The
+	// check is MintsInsideNamespace: the store declares the namespace it mints
+	// into, the binding declares the namespaces it claims, and a store that
+	// declares nothing reports false. A false bit only keeps the residence
+	// probe; a wrong true one retires it over beads it cannot recognize.
 	MintsReserved bool
 
 	// HasLegacyResidents reports whether the binding is known to still hold
 	// OPEN beads minted outside the reserved namespace — the relics `gc storage
 	// migrate` produced by preserving ids. The residence probe retires only
 	// when the binding both mints truthfully AND holds no such relic.
+	//
+	// Constructors set this TRUE until a census can say otherwise: "not known
+	// to hold relics" and "known to hold none" are different claims, and only
+	// the second may retire the probe. Defaulting false while the mint bit is
+	// observed would retire the probe on any converged city the moment it
+	// booted, stranding every id the migration preserved.
 	HasLegacyResidents bool
 }
 

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -216,14 +216,7 @@ func (t Topology) orderedRigs() []Leg {
 
 // coversID reports whether any of the binding's reserved prefixes claims id's
 // namespace.
-func (b ClassBinding) coversID(id string) bool {
-	for _, p := range b.Prefixes {
-		if IDInNamespace(id, p) {
-			return true
-		}
-	}
-	return false
-}
+func (b ClassBinding) coversID(id string) bool { return idInAnyNamespace(id, b.Prefixes) }
 
 // probeRetired reports whether the residence probe may be dropped for this
 // binding: it mints truthfully AND holds no open legacy resident. Both halves


### PR DESCRIPTION
**Segment 2 of 8 — split out of #5597 at the reviewer's request.** Base: segment 1.
See segment 1 for the bug class and the full segment table; it is the one to read
first. Every commit here is byte-identical to the one reviewed in #5597.

Segment 1 fixed the by-id **readers**. This one fixes the **writers**, and then
makes the resolver's own retirement bit an observed fact rather than a promise.

## The blind writers

Four surfaces placed beads without asking the class seam where they belonged.
A bead minted into the wrong store on a split city is worse than a bad read: the
read is wrong once, the write is wrong forever.

- **`gc handoff`** wrote handoff mail into whichever store the command happened to
  hold, not the messaging-class store (S5 C1).
- **The PR repair workflow** cooked its molecule without class placement, so a
  repair run on a split city scattered its step beads (S5 C2).
- **The API bead-create door** had no placement at all — `POST /beads` minted into
  the work ledger regardless of the id's namespace (S5 C3).
- **The nudge queue's id namespace was not registered as class-reserved**, so
  nothing downstream could even tell that those ids belonged to a class (S5 C4a).

## C4a shipped neither of them honestly, and C4b is why this segment does not end there

Registering the namespace made the *table* right and left two things wrong: a
binding would still accept a **pinned foreign id** — an id outside its own
reserved namespaces, written in with an explicit id — and the resolver's
`MintsReserved` bit was inferred rather than observed. `03a0efe91f` fences the
first and observes the second.

That pair is why the cut lands here rather than after C4a: C4a's own follow-up
commit says *"C4a shipped neither of them honestly."* Splitting between them would
hand a reviewer a half-finished mechanism.

## The relic census retires the residence probe

`storeref` carried a per-read **residence probe**: before trusting a binding, ask
it whether it holds ids outside its namespaces. Correct, and paid on every read.

`939ebafcdb` replaces it with a **boot-time census**: `gc storage boot` walks the
binding once, records whether it holds preserved ids, and the resolver reads that
durable fact instead of re-deriving it. `HasLegacyResidents` stops being a guess.

`169fb83090` then retires `graphClassBinding` — the last parallel grouping of
bindings — in favour of the resolver's own, and `29a28fe9fc` closes the review
council's findings on the slice.

## Disclosure: this census is open-only, and segment 5 falsifies that

The census as landed here counts **open** relics. That is wrong — a binding whose
relics have all been closed still holds preserved ids, and the retirement verdict
must say so. `8f9eeee96b`, in **segment 5**, widens it to count closed relics too.

A defect introduced in one segment and fixed three segments later is inherent to
splitting a linear series without rewriting it, and it is stated here rather than
left to be discovered. The alternative — reordering commits so the fix precedes
the defect — would mean rewriting 47 commits across hub files touched by nine of
them, discarding the CI and review history that makes these segments cheap to
trust.

## Disclosure: the pinned-id fence spans four segments

`03a0efe91f` fences the sqlite engine. Segment 3 states the fence as a **provider
contract**; segment 5 applies it to the second provider and the test kit; segment
8 pins it at every workspace open. Each stage is complete in itself — the sqlite
engine is genuinely fenced when this segment lands — but a reviewer looking for
"is the fence everywhere yet" will not find the answer until segment 5.

## Verification

- `go build ./...`, `go vet ./...` clean at this head
- `./scripts/check-residency-boundary.sh` passes
- `go test ./internal/testutil/providerledger/` green
- Full-suite results inherited from #5597's green head

Refs `ga-qdt5y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
