### PR TITLE
fix(controller): let pool demand see work resident in a relocated class binding

### DIFF
--- a/cmd/gc/assigned_work_residency.go
+++ b/cmd/gc/assigned_work_residency.go
@@ -132,6 +132,34 @@ func assignedWorkClaimRefs(cityPath string, cfg *config.City, leading beads.Stor
 	return out
 }
 
+// assignedWorkRelocatedClaimRefs is assignedWorkClaimRefs for the callers that
+// may only widen where a class was actually RELOCATED: it answers empty for a
+// single-store city.
+//
+// The wake filter can take the unconditional set because it matches a session's
+// own exact assignee identity, so a wider ref set still admits only that
+// session's own claims. Pool demand matches a routed TEMPLATE, so the same set
+// would make city-store work resume a rig-scoped pool session on a city that
+// relocates nothing — the reachability rule
+// TestBuildDesiredState_RigPoolIgnoresAssignedWorkInUnreachableStore pins, and
+// the reason this is a second function rather than a second caller of the first.
+//
+// On a city that DOES relocate, the collapse inside ClaimRefs is what makes the
+// answer right on both planes: a leading arm that is itself the binding reports
+// the single ref its census records, and a distinct binding reports its own.
+func assignedWorkRelocatedClaimRefs(cityPath string, cfg *config.City, leading beads.Store) []string {
+	topology := residencyTopologyForCity(cityPath, cfg, censusWorkLeg(cityPath, leading), nil)
+	if topology.IsSingleStore() {
+		return nil
+	}
+	refs := topology.ClaimRefs()
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, string(ref))
+	}
+	return out
+}
+
 // assignedWorkScanComplete turns a partial pass into an error for the gates that
 // answer "does this session still hold work?".
 //

--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -120,11 +120,58 @@ func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agen
 	return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
 }
 
+// assignedWorkIndexReachableFromAgentOnClaimRefs extends the rig-equality test
+// with the refs a claim can be RECORDED under whatever the holder's rig scope:
+// the leading work arm plus every relocated class binding (assignedWorkClaimRefs).
+//
+// This is the demand-side twin of the widening filterAssignedWorkBeadsForSessionWake
+// already applies (ga-whzrt). The two filters answer one question from opposite
+// ends — "is this holder still working?" and "does this work still need a
+// worker?" — so a ref the wake side accepts and the demand side rejects is a city
+// that drains a slot and then refuses to refill it.
+//
+// Relocating a coordination class is what made that reachable. The equality test
+// is against the agent's configured RIG, so once graph-resident work carries a
+// "class:*" ref no rig name can equal, in-progress demand for a rig-scoped pool
+// agent became structurally invisible. It stayed hidden because scale_check
+// supplies demand independently while the work is still ready; only once the
+// work is CLAIMED is the resume tier the sole remaining source, which is why the
+// symptom is a session that dies holding a claim and is never replaced.
+//
+// claimRefs must come from assignedWorkRelocatedClaimRefs, which answers empty
+// for a city that relocates nothing: the widening covers relocated class
+// bindings only, never another rig's ref, so rig isolation and every
+// single-store city are exactly what they were.
+func assignedWorkIndexReachableFromAgentOnClaimRefs(
+	cityPath string,
+	cfg *config.City,
+	agentCfg *config.Agent,
+	storeRefs []string,
+	index int,
+	claimRefs []string,
+) bool {
+	if assignedWorkIndexReachableFromAgent(cityPath, cfg, agentCfg, storeRefs, index) {
+		return true
+	}
+	if index < 0 || index >= len(storeRefs) {
+		return false
+	}
+	for _, ref := range claimRefs {
+		if storeRefs[index] == ref {
+			return true
+		}
+	}
+	return false
+}
+
 // filterAssignedWorkBeadsForPoolDemand resolves work through the routed
 // backing template because pool scale decisions are per agent template.
+// leading is the store this arm was handed; it resolves the claim refs, and is
+// a property of the CITY so it is read once rather than per bead.
 func filterAssignedWorkBeadsForPoolDemand(
 	cfg *config.City,
 	cityPath string,
+	leading beads.Store,
 	sessionInfos []sessionpkg.Info,
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStoreRefs []string,
@@ -135,6 +182,7 @@ func filterAssignedWorkBeadsForPoolDemand(
 	if cfg == nil {
 		return assignedWorkBeads
 	}
+	claimRefs := assignedWorkRelocatedClaimRefs(cityPath, cfg, leading)
 	assigneeToSessionBeadID := make(map[string]string)
 	sessionBeadTemplate := make(map[string]string)
 	for _, sb := range sessionInfos {
@@ -171,7 +219,7 @@ func filterAssignedWorkBeadsForPoolDemand(
 		if agentCfg == nil {
 			continue
 		}
-		if assignedWorkIndexReachableFromAgent(cityPath, cfg, agentCfg, assignedWorkStoreRefs, i) {
+		if assignedWorkIndexReachableFromAgentOnClaimRefs(cityPath, cfg, agentCfg, assignedWorkStoreRefs, i, claimRefs) {
 			filtered = append(filtered, wb)
 		}
 	}

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -158,7 +158,7 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsDirectAssigneeAfterTemplateFal
 		Metadata: map[string]string{},
 	}}
 
-	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", sessionInfosFromBeads(sessions), work, []string{""})
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, sessionInfosFromBeads(sessions), work, []string{""})
 
 	if len(got) != 1 || got[0].ID != "direct-assigned" {
 		t.Fatalf("filtered work = %#v, want direct-assigned work preserved through template fallback", got)
@@ -181,7 +181,7 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsLegacyWorkflowRunTarget(t *tes
 		},
 	}}
 
-	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, nil, work, []string{""})
 
 	if len(got) != 1 || got[0].ID != "legacy-workflow-root" {
 		t.Fatalf("filtered work = %#v, want legacy workflow root preserved through run_target fallback", got)
@@ -217,7 +217,7 @@ func TestFilterAssignedWorkBeadsForPoolDemandKeepsPersistedBoundRoute(t *testing
 		},
 	}}
 
-	got := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionInfosFromBeads(sessions), work, []string{"gascity-packs"})
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, nil, sessionInfosFromBeads(sessions), work, []string{"gascity-packs"})
 
 	if len(got) != 1 || got[0].ID != "gp-qx0o" {
 		t.Fatalf("filtered work = %#v, want persisted bound route preserved", got)
@@ -241,7 +241,7 @@ func TestFilterAssignedWorkBeadsForPoolDemandNormalizesInstanceSuffixedRouteTarg
 		},
 	}}
 
-	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, nil, work, []string{""})
 
 	if len(got) != 1 || got[0].ID != "instance-routed" {
 		t.Fatalf("filtered work = %#v, want instance-suffixed route target normalized to the base template and kept", got)
@@ -265,7 +265,7 @@ func TestFilterAssignedWorkBeadsForPoolDemandLeavesUnmatchedInstanceSuffixAlone(
 		},
 	}}
 
-	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, nil, work, []string{""})
 
 	if len(got) != 0 {
 		t.Fatalf("filtered work = %#v, want out-of-range instance suffix left unmatched and dropped", got)
@@ -297,7 +297,7 @@ func TestFilterAssignedWorkBeadsForPoolDemandDropsDirectAssigneeFromUnreachableS
 		Metadata: map[string]string{},
 	}}
 
-	got := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionInfosFromBeads(sessions), work, []string{"riga"})
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, nil, sessionInfosFromBeads(sessions), work, []string{"riga"})
 
 	if len(got) != 0 {
 		t.Fatalf("filtered work = %#v, want unreachable rig-store direct assignment dropped", got)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -859,7 +859,7 @@ func buildDesiredStateWithSessionBeads(
 		if len(scaleCheckPartialTemplates) > 0 {
 			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed for %s, retaining affected sessions\n", strings.Join(sortedBoolMapKeys(scaleCheckPartialTemplates), ",")) //nolint:errcheck
 		}
-		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, store, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
 		bp.assignedWorkBeads = poolWorkBeads
 		bp.poolScaleCheckPartialTemplates = poolScaleCheckPartialTemplates
 		bp.providerHealthSnapshot = loadProviderHealthSnapshot(cityPath)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -936,6 +936,22 @@ func buildDesiredStateWithSessionBeads(
 	// Raw gc.routed_to metadata is intentionally NOT treated as direct named
 	// demand here. The controller only uses assignment/readiness state; routed
 	// metadata is consumed by the agent-side gc hook path.
+	//
+	// namedClaimRefs widens the reachability test below the same way the pool
+	// demand tier is widened at :862 and the wake filter already is: a claim
+	// recorded under a relocated "class:*" binding ref matches no rig name, so a
+	// rig-scoped named session that dies holding one is otherwise never resumed
+	// even though the wake side still retains the holder (ga-whzrt, one tier
+	// over). It is a city-level property, so resolve it once — and only when
+	// there is both work to match and a named spec to match it — mirroring the
+	// pool filter's guards so an idle city does no topology work.
+	// assignedWorkRelocatedClaimRefs answers nil on a single-store city (nothing
+	// relocated) and degrades a nil store to nil refs, so this never widens the
+	// rig gate where the base rig-equality test is all that is correct.
+	var namedClaimRefs []string
+	if len(assignedWorkBeads) > 0 && len(namedSpecs) > 0 {
+		namedClaimRefs = assignedWorkRelocatedClaimRefs(cityPath, cfg, store)
+	}
 	for identity, spec := range namedSpecs {
 		for i, wb := range assignedWorkBeads {
 			// in_progress work is always actionable; open work is direct named
@@ -972,7 +988,7 @@ func buildDesiredStateWithSessionBeads(
 			// configured named session's own bare identity, so this bare match
 			// is trustworthy unconditionally — no per-template-shape guard
 			// needed here anymore (ga-p0u752).
-			if !assignedWorkIndexReachableFromAgent(cityPath, cfg, spec.Agent, assignedWorkStoreRefs, i) {
+			if !assignedWorkIndexReachableFromAgentOnClaimRefs(cityPath, cfg, spec.Agent, assignedWorkStoreRefs, i, namedClaimRefs) {
 				continue
 			}
 			fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2499,7 +2499,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	poolDesired := result.PoolDesiredCounts
 	if poolDesired == nil {
 		phaseStart = time.Now()
-		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, store, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesired = retainScaleCheckPartialPoolDesired(
 			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
@@ -3344,7 +3344,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 	filteredRows := filterReconcileRowsByName(updated, reconcileNames)
 	filteredSnap := newSessionBeadSnapshotFromReconcileRows(filteredRows)
 	openInfos := filterSessionInfosByName(updated, reconcileNames)
-	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, openInfos, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
+	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, cr.cityBeadStore(), openInfos, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
 	poolDesired := retainScaleCheckPartialPoolDesired(
 		filteredCfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(
@@ -3594,7 +3594,7 @@ func (cr *CityRuntime) loadDemandSnapshot(
 		if sessionBeads != nil {
 			openSessionInfos = sessionBeads.OpenInfos()
 		}
-		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, cr.cityBeadStore(), openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 		result.PoolDesiredCounts = retainScaleCheckPartialPoolDesired(
 			cr.cfg,
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1018,7 +1018,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	dt := newDrainTracker()
 	openInfos := sessionBeads.OpenInfos()
-	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, oneShotStore, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	poolDesired := retainScaleCheckPartialPoolDesired(
 		cfg,
 		PoolDesiredCounts(ComputePoolDesiredStates(

--- a/cmd/gc/named_session_demand_class_binding_test.go
+++ b/cmd/gc/named_session_demand_class_binding_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// The demand-tier twin of pool_demand_class_binding_test.go, one tier over.
+//
+// filterAssignedWorkBeadsForPoolDemand learned to see a claim recorded under a
+// relocated "class:*" binding (ga-whzrt); the named-session direct-demand match
+// at build_desired_state.go:975 did not. The two answer the same question —
+// "does this work still need a worker?" — for the two session shapes a city
+// runs, so a ref pool demand accepts and named demand rejects is the same
+// "drains a slot then refuses to refill it" asymmetry, reproduced for a
+// rig-scoped [[named_session]] that dies holding a class-routed graph claim.
+//
+// namedWorkReady is exported verbatim as DesiredStateResult.NamedSessionDemand
+// (build_desired_state.go:1084), so these tests drive the whole builder and read
+// that map — the tightest end-to-end pin on the :975 site.
+
+// namedSessionClassBindingIdentity is the rig-scoped named session under test.
+// Rig scope is load-bearing: a rig-scoped agent is NOT cross-store-eligible, so
+// its claim must pass the rig-equality gate that a "class:*" ref can never
+// satisfy — exactly the reachability the widening restores.
+const namedSessionClassBindingIdentity = "riga/patrol"
+
+// namedSessionClassBindingCfg is a two-rig city with a rig-scoped, on_demand
+// [[named_session]]. on_demand is what makes assigned work the sole materialize
+// signal, so the store-ref reachability check is the only thing standing between
+// the claim and demand.
+func namedSessionClassBindingCfg(t *testing.T, cityPath string) *config.City {
+	t.Helper()
+	for _, rig := range []string{"riga", "rigb"} {
+		if err := os.MkdirAll(filepath.Join(cityPath, rig), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "riga", Path: filepath.Join(cityPath, "riga")},
+			{Name: "rigb", Path: filepath.Join(cityPath, "rigb")},
+		},
+		Agents: []config.Agent{{
+			Name:         "patrol",
+			Dir:          "riga",
+			StartCommand: "true",
+			WorkQuery:    "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "patrol",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+}
+
+// seedNamedSessionClaim records an in_progress claim held by the named session's
+// runtime identity — the tmux-safe "riga--patrol" form live cities record, which
+// namedSessionAssigneeMatchesSpec accepts (ga-e70d2). in_progress bypasses the
+// readiness gate so only the store-ref reachability check is under test.
+func seedNamedSessionClaim(t *testing.T, store beads.Store) {
+	t.Helper()
+	runtimeName := agent.SanitizeQualifiedNameForSession(namedSessionClassBindingIdentity)
+	b, err := store.Create(beads.Bead{
+		Title:    "graph step claimed by a rig-scoped named session",
+		Type:     "task",
+		Status:   "open",
+		Assignee: runtimeName,
+		Metadata: map[string]string{"gc.routed_to": namedSessionClassBindingIdentity},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(b.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The finding. On a split city a rig-scoped named session's in_progress claim is
+// resident under the relocated class binding ("class:gmnos"), a ref no rig name
+// equals. Before the widening the demand tier could not see it, so a session
+// that died holding it was never resumed — even though the wake filter still
+// retained the holder. NamedSessionDemand must be true.
+func TestBuildDesiredState_NamedSessionResumesClassRelocatedClaim(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := namedSessionClassBindingCfg(t, cityPath)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	seedNamedSessionClaim(t, binding)
+
+	cityStore := beads.NewMemStore()
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": beads.NewMemStore(), "rigb": beads.NewMemStore()}, nil, nil, io.Discard,
+	)
+
+	if !dsResult.NamedSessionDemand[namedSessionClassBindingIdentity] {
+		t.Fatalf("named session %q holds an in_progress claim resident under the relocated class binding "+
+			"but generated no demand (NamedSessionDemand=%v).\n"+
+			"build_desired_state.go:975 gated named demand on pure rig-equality, so a \"class:*\" ref no rig "+
+			"name can equal made the claim unreachable — the pool tier's ga-whzrt bug, one tier over.",
+			namedSessionClassBindingIdentity, dsResult.NamedSessionDemand)
+	}
+}
+
+// Gate-not-vacuous control. On the SAME split city a claim resident in rigb's
+// store must still be dropped for the riga-scoped named session: the widening
+// covers the relocated class binding only, never another rig's ref. A different
+// outcome from the row above is what proves this is not a blanket "accept every
+// ref". Holds before and after the fix.
+func TestBuildDesiredState_NamedSessionDropsForeignRigClaimOnASplitCity(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := namedSessionClassBindingCfg(t, cityPath)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+
+	rigbStore := beads.NewMemStore()
+	seedNamedSessionClaim(t, rigbStore) // riga's named session, claim resident in RIGB's store
+
+	cityStore := beads.NewMemStore()
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": beads.NewMemStore(), "rigb": rigbStore}, nil, nil, io.Discard,
+	)
+
+	if dsResult.NamedSessionDemand[namedSessionClassBindingIdentity] {
+		t.Fatalf("a claim resident in rigb's store woke the riga-scoped named session %q "+
+			"(NamedSessionDemand=%v); the widening covers the relocated class binding only, never another "+
+			"rig's ref — the gate must not be vacuous", namedSessionClassBindingIdentity, dsResult.NamedSessionDemand)
+	}
+}
+
+// Single-store control, the load-bearing half. A city that relocates nothing has
+// its work under the empty ref, and accepting that for a rig-scoped agent would
+// make the rig gate vacuous — the demand-tier twin of the regression
+// TestBuildDesiredState_RigPoolIgnoresAssignedWorkInUnreachableStore forbids.
+// assignedWorkRelocatedClaimRefs answering nil on a single-store city is what
+// keeps it dropped. Holds before and after the fix.
+func TestBuildDesiredState_NamedSessionDropsCityWorkOnASingleStoreCity(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := namedSessionClassBindingCfg(t, cityPath)
+	seedNoRoutes(t, cityPath)
+
+	cityStore := beads.NewMemStore()
+	seedNamedSessionClaim(t, cityStore) // resident in the city work store, ref ""
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": beads.NewMemStore(), "rigb": beads.NewMemStore()}, nil, nil, io.Discard,
+	)
+
+	if dsResult.NamedSessionDemand[namedSessionClassBindingIdentity] {
+		t.Fatalf("city-store work woke the rig-scoped named session %q on a single-store city "+
+			"(NamedSessionDemand=%v). assignedWorkRelocatedClaimRefs must answer nil where nothing was "+
+			"relocated, or the rig gate goes vacuous — the demand-tier twin of "+
+			"TestPoolDemandFilterUnchangedOnASingleStoreCity.", namedSessionClassBindingIdentity, dsResult.NamedSessionDemand)
+	}
+}

--- a/cmd/gc/pool_demand_class_binding_test.go
+++ b/cmd/gc/pool_demand_class_binding_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// The demand-derivation twin of the ga-whzrt rows.
+//
+// filterAssignedWorkBeadsForSessionWake learned to accept a claim recorded on a
+// relocated class binding; filterAssignedWorkBeadsForPoolDemand never did. The
+// two answer the same question from opposite ends — "is this holder still
+// working?" and "does this work still need a worker?" — so a ref one accepts and
+// the other rejects is a city that will not regenerate a worker for work it can
+// plainly see.
+//
+// That gap is not reachable on a single-store city, which is why it survived:
+// the demand filter's equality test is against the agent's configured RIG, and
+// before the graph class was relocated a rig-scoped agent's molecule work sat in
+// a leg whose ref was that rig. Relocating the class moved every graph-resident
+// step bead to a "class:*" ref that no rig name can equal, so demand for a
+// rig-scoped pool agent's in-progress work became structurally unreachable.
+//
+// The failure only SHOWS when a session dies holding a claim: while the work is
+// still ready, scale_check supplies demand independently. Once it is claimed,
+// the resume tier is the only source left, and it is reading a ref that never
+// matches.
+
+func rigScopedPoolDemandFixture(t *testing.T) (*config.City, string, []sessionpkg.Info) {
+	t.Helper()
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "riga", Path: filepath.Join(cityPath, "riga")},
+			{Name: "rigb", Path: filepath.Join(cityPath, "rigb")},
+		},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "riga"},
+			{Name: "worker", Dir: "rigb"},
+		},
+	}
+	sessions := []beads.Bead{{
+		ID:     "gcs-1",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":     "riga/worker",
+			"session_name": "test-city--worker-1",
+			"state":        "asleep",
+			"pool_managed": "true",
+		},
+	}}
+	return cfg, cityPath, sessionInfosFromBeads(sessions)
+}
+
+// routedPoolWorkBead is the one shape every row here needs: an in-progress claim
+// held by the fixture's asleep pool session and routed to its rig-scoped
+// template. The rows differ only in which store-ref the census hands the filter,
+// so the bead itself is constant.
+func routedPoolWorkBead() beads.Bead {
+	return beads.Bead{
+		ID:       "gcg-1",
+		Status:   "in_progress",
+		Assignee: "test-city--worker-1",
+		Metadata: map[string]string{beadmeta.RoutedToMetadataKey: "riga/worker"},
+	}
+}
+
+// The production row: the census labels the relocated binding leg with its own
+// "class:*" ref, the work is routed to a rig-scoped pool template, and the
+// holder is asleep. Pool demand must still see the bead — it is the only thing
+// that can mint a replacement worker for an in-progress claim.
+func TestPoolDemandFilterKeepsABindingRefClaimOnTheReconcilerPlane(t *testing.T) {
+	cfg, cityPath, infos := rigScopedPoolDemandFixture(t)
+	work := beads.NewMemStore()
+	binding := beads.NewMemStore()
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return work })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+
+	candidates, err := censusStoreCandidates(cityPath, cfg, binding, nil, nil, censusRefBare)
+	if err != nil {
+		t.Fatalf("censusStoreCandidates: %v", err)
+	}
+	bindingRef := candidates[len(candidates)-1].ref
+	if bindingRef == "" {
+		t.Fatalf("the census labeled the binding leg %q; this row is about the DISTINCT label", bindingRef)
+	}
+	workBeads := []beads.Bead{routedPoolWorkBead()}
+
+	kept := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, binding, infos, workBeads, []string{bindingRef})
+
+	if len(kept) != 1 || kept[0].ID != "gcg-1" {
+		t.Fatalf("filtered work = %#v, want the binding-resident claim kept under %q — the census emits that ref and pool demand must read it", kept, bindingRef)
+	}
+}
+
+// The leading-arm spelling of the same claim: on the reconciler's plane the
+// binding IS the store the arm was handed, so the row carries "".
+func TestPoolDemandFilterKeepsAClaimOnTheClassBindingArm(t *testing.T) {
+	cfg, cityPath, infos := rigScopedPoolDemandFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	workBeads := []beads.Bead{routedPoolWorkBead()}
+
+	kept := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, binding, infos, workBeads, []string{""})
+
+	if len(kept) != 1 || kept[0].ID != "gcg-1" {
+		t.Fatalf("filtered work = %#v, want the claim on the leading binding arm kept", kept)
+	}
+}
+
+// Control: work sitting in ANOTHER RIG's store, routed to riga's template. The
+// widening covers the relocated class binding only, so a genuine cross-rig
+// mismatch must still be dropped. A different outcome from the rows above is
+// what proves this is not a blanket "accept every ref".
+func TestPoolDemandFilterStillDropsWorkResidentInAnotherRigsStore(t *testing.T) {
+	cfg, cityPath, infos := rigScopedPoolDemandFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	workBeads := []beads.Bead{routedPoolWorkBead()}
+
+	kept := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, binding, infos, workBeads, []string{"rigb"})
+
+	if len(kept) != 0 {
+		t.Fatalf("filtered work = %#v, want work resident in rigb's store dropped for a riga-scoped agent", kept)
+	}
+}
+
+// Control: the single-store city relocates nothing, so the binding ref set
+// collapses to the work ref and behavior is exactly what it was.
+func TestPoolDemandFilterUnchangedOnASingleStoreCity(t *testing.T) {
+	cfg, cityPath, infos := rigScopedPoolDemandFixture(t)
+	seedNoRoutes(t, cityPath)
+	workBeads := []beads.Bead{routedPoolWorkBead()}
+
+	kept := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, beads.NewMemStore(), infos, workBeads, []string{"riga"})
+	if len(kept) != 1 {
+		t.Fatalf("filtered work = %#v, want a rig-resident bead kept for its own rig's agent", kept)
+	}
+
+	dropped := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, beads.NewMemStore(), infos, workBeads, []string{"rigb"})
+	if len(dropped) != 0 {
+		t.Fatalf("filtered work = %#v, want a foreign-rig bead still dropped on a single-store city", dropped)
+	}
+}

--- a/cmd/gc/pool_demand_class_binding_test.go
+++ b/cmd/gc/pool_demand_class_binding_test.go
@@ -149,4 +149,47 @@ func TestPoolDemandFilterUnchangedOnASingleStoreCity(t *testing.T) {
 	if len(dropped) != 0 {
 		t.Fatalf("filtered work = %#v, want a foreign-rig bead still dropped on a single-store city", dropped)
 	}
+
+	// The load-bearing half of this control. On a single-store city EVERY bead
+	// lives under the work ref, so accepting "" for a rig-scoped agent would make
+	// the rig gate vacuous — the exact regression
+	// TestBuildDesiredState_RigPoolIgnoresAssignedWorkInUnreachableStore forbids.
+	// assignedWorkRelocatedClaimRefs answering nil is what keeps it rejected.
+	cityResident := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, beads.NewMemStore(), infos, workBeads, []string{""})
+	if len(cityResident) != 0 {
+		t.Fatalf("filtered work = %#v, want city-store work still dropped for a rig-scoped agent on a single-store city", cityResident)
+	}
+}
+
+// The intentional behavior change, stated out loud: on a SPLIT city a rig-scoped
+// pool agent does accept the work ref.
+//
+// This is not the gate going vacuous. On a split city "" names one specific leg
+// among several, and the sibling control above proves rigb's leg is still
+// rejected; on a single-store city "" names every leg, which is why the widening
+// is gated off there entirely. The bead still has to be routed to this agent's
+// template, and the resume tier downstream still requires the assignee to
+// resolve to an open session bead, so widening the ref set does not widen
+// ownership.
+//
+// It also has to be this way for the two filters to agree.
+// filterAssignedWorkBeadsForSessionWake takes the work ref unconditionally
+// (assignedWorkClaimRefs), so excluding it here would recreate in miniature the
+// very asymmetry this change exists to remove: wake retains the holder, demand
+// refuses to replace it.
+func TestPoolDemandFilterAcceptsTheWorkRefOnASplitCity(t *testing.T) {
+	cfg, cityPath, infos := rigScopedPoolDemandFixture(t)
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+	workBeads := []beads.Bead{routedPoolWorkBead()}
+
+	kept := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, beads.NewMemStore(), infos, workBeads, []string{""})
+	if len(kept) != 1 {
+		t.Fatalf("filtered work = %#v, want city-work-store work kept for the rig agent it is routed to on a split city", kept)
+	}
+
+	stillDropped := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, beads.NewMemStore(), infos, workBeads, []string{"rigb"})
+	if len(stillDropped) != 0 {
+		t.Fatalf("filtered work = %#v, want rigb's leg still rejected — accepting the work ref must not make the rig gate vacuous", stillDropped)
+	}
 }


### PR DESCRIPTION
## The defect

`filterAssignedWorkBeadsForPoolDemand` decided reachability with a single equality test against the agent's configured **rig**:

```go
return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
```

Once a city relocates its coordination classes, graph-resident work carries the binding's own `class:*` ref. No rig name can ever equal that, so **every in-progress claim on a molecule step is structurally invisible to pool demand** — not racy, not intermittent, unreachable by construction.

## Why it is a half-fix being completed

`filterAssignedWorkBeadsForSessionWake` got exactly this widening in ga-whzrt. The demand half never did. The two filters answer one question from opposite ends — *"is this holder still working?"* and *"does this work still need a worker?"* — so a ref the wake side accepts and the demand side rejects is a city that drains a slot and then refuses to refill it.

The stalled molecule never recovers because the resume tier is the only demand source once work is claimed: while the step is still `open`, `scale_check` supplies demand on an independent path and hides the hole entirely.

## Why it stayed latent

Observed on a live split city: graph beads have carried assignees for over a month at 1–9/day, but **none was ever assigned to a `-pool` session** until the assignee spelling moved from `rig/agent.name-N` to the `rig--agent__name-N-pool` session-name form. That spelling is what makes a bead resolve to a pool *template* and enter this arm at all. The relocation created the hole; the routing change started feeding it.

## The widening is narrower than the wake filter's

Deliberately. The wake filter matches a session's own exact assignee identity, so an unconditional claim-ref set still admits only that session's own claims. Pool demand matches a routed **template**, so the same set would let city-store work resume a rig-scoped pool session on a city that relocates nothing.

`assignedWorkRelocatedClaimRefs` answers empty for a single-store city (`Topology.IsSingleStore()`), so rig isolation and every unsplit city are byte-identical. `TestBuildDesiredState_RigPoolIgnoresAssignedWorkInUnreachableStore` is the control and passes unchanged.

## Tests

Four new rows in `cmd/gc/pool_demand_class_binding_test.go`, mirroring the wake filter's:

| Test | Asserts |
| --- | --- |
| `...KeepsABindingRefClaimOnTheReconcilerPlane` | production row: census-emitted `class:*` ref is kept |
| `...KeepsAClaimOnTheClassBindingArm` | mid-rollout row: leading-arm `""` spelling is kept |
| `...StillDropsWorkResidentInAnotherRigsStore` | **control** — another rig's ref is still dropped |
| `...UnchangedOnASingleStoreCity` | **control** — no widening without a relocation |

Two of the four fail without the fix (the `class:*` ref is dropped); all four pass with it.

## Verification

- `go test ./cmd/gc/ -count=1 -timeout 40m` → `ok 696.957s`
- `lint-changed ./cmd/gc` → 0 issues
- `go vet ./...` clean; docs/schema regeneration clean

Refs ga-pe2lf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5453 — touches the same pool_desired demand path: it widens the in-progress-claim residency filter so a claim recorded on a relocated class binding is no longer dropped, which lets a pool that drained while holding a claim be refilled; it does not make standing open gc.routed_to demand visible, so the zero-sessions-with-no-in-progress-work case described in that issue is unchanged
- Related to #5587 — touches the same class of defect that issue describes — a rig-identity equality gate that can never match a `class:*` ref after a class is relocated, so the row is silently dropped before demand derivation sees it — but on a different gate: this changes the pool-demand residency filter (`assignedWorkIndexReachableFromAgent` / `filterAssignedWorkBeadsForPoolDemand`) for in-progress claims, and leaves the control-row collection gate (`rootStoreRefMatchesCandidate` / `collectOpenUnassignedRoutedWork`) exactly as it was, so nothing here addresses that filed defect

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->