### PR TITLE
fix(dolt): admit the concurrent-UPDATE writer race in the compact preservation proof

### DIFF
--- a/examples/bd/dolt/assets/scripts/compact-gain-drift-proof.sh
+++ b/examples/bd/dolt/assets/scripts/compact-gain-drift-proof.sh
@@ -1,20 +1,21 @@
 #!/bin/sh
-# compact-gain-drift-proof.sh — Option A row-preservation proof for the
-# post-flatten gain+drift case (gastownhall/gascity#2846).
+# compact-gain-drift-proof.sh — Option A row-preservation proof for post-flatten
+# table value-hash drift (gastownhall/gascity#2846, widened for #3341).
 #
-# When verify_counts sees a table gain rows AND its value hash drift, the
-# safety property at stake ("pre-flight rows remain reachable") cannot be
-# inferred from HEAD movement alone: a concurrent writer whose commit is
-# ABSORBED into the flatten commit moves no HEAD, so the HEAD-proven gate
-# misses it and a benign race is hard-quarantined — which then blocks all
-# future GC of a busy DB (the memory-exhaustion failure the code calls out).
+# When verify_counts sees a table's value hash drift, the safety property at
+# stake ("pre-flight rows remain reachable") cannot be inferred from HEAD
+# movement alone: a concurrent writer whose commit is ABSORBED into the flatten
+# commit moves no HEAD, so the HEAD-proven gate misses it and a benign race is
+# hard-quarantined — which then blocks all future GC of a busy DB (the
+# memory-exhaustion failure the code calls out).
 #
-# This proves preservation DIRECTLY: for each gained+drifted table, diff the
-# pre-flight snapshot HEAD against the flatten commit. If the only change is
-# `added` rows (no `removed`/`modified`), every pre-flight row survived and the
-# gain is concurrent-writer data — defer, exactly as the HEAD-proven path does.
-# It is strictly more rigorous than the HEAD proxy: it proves reachability
-# instead of inferring it. Any removed/modified row, or any probe failure,
+# This proves preservation DIRECTLY: for each drifted table, diff the pre-flight
+# snapshot HEAD against the flatten commit. `added` rows are a concurrent
+# INSERT and `modified` rows a concurrent UPDATE; neither can drop a pre-flight
+# row, so a diff carrying no `removed` row proves every pre-flight row survived
+# and the drift is concurrent-writer data — defer, exactly as the HEAD-proven
+# path does. It is strictly more rigorous than the HEAD proxy: it proves
+# reachability instead of inferring it. Any removed row, or any probe failure,
 # fails closed and falls through to quarantine.
 #
 # Depends on `query_single_cell` and `valid_table_name` from run.sh.
@@ -23,9 +24,11 @@
 # Returns 0 iff the table's <from>..<to> content diff contains only `added`
 # rows. Returns non-zero (fail closed) if either commit endpoint is missing,
 # the table name is missing or invalid, the diff probe fails or returns a
-# non-numeric result, or the table shows removed/modified rows. Shared by the
-# gain+drift preservation proof and the committed-root drift proof's
-# first-committed table case (run.sh db_root_drift_within_verified_tables).
+# non-numeric result, or the table shows removed/modified rows. Used by the
+# committed-root drift proof's first-committed table case (run.sh
+# db_root_drift_within_verified_tables), where the table exists in no
+# pre-flatten commit root and so must be wholly new to be provable — a
+# strictly stronger claim than the row-preservation proof below.
 diff_is_additive_only() {
   _da_db="$1"
   _da_from="$2"
@@ -49,21 +52,55 @@ diff_is_additive_only() {
   esac
 }
 
-# gain_drift_is_additive_only <db> <from_head> <to_head> <space-separated tables>
-# Returns 0 iff every listed table's <from>..<to> content diff contains only
-# `added` rows. Returns non-zero (fail closed) if the table list is empty or
-# any table fails diff_is_additive_only.
-gain_drift_is_additive_only() {
-  _gd_db="$1"
-  _gd_from="$2"
-  _gd_to="$3"
-  _gd_tables="$4"
-  _gd_seen=0
-  for _gd_t in $_gd_tables; do
-    _gd_seen=1
-    diff_is_additive_only "$_gd_db" "$_gd_from" "$_gd_to" "$_gd_t" || return 1
+# diff_has_no_removed_rows <db> <from_head> <to_head> <table>
+# Returns 0 iff the table's <from>..<to> content diff contains no `removed`
+# rows. Returns non-zero (fail closed) if either commit endpoint is missing,
+# the table name is missing or invalid, the diff probe fails or returns a
+# non-numeric result, or the table shows removed rows.
+#
+# This is the preservation claim itself rather than a proxy for it, and it
+# subsumes the additive-only case: `added` rows are a concurrent INSERT and
+# `modified` rows a concurrent UPDATE — an UPDATE rewrites a row's non-key
+# values but keeps the row reachable, so only a `removed` row is loss. A
+# concurrent DELETE does show as `removed` here and correctly fails this proof;
+# it is carried by the row-decrease writer-race branch in run.sh instead.
+diff_has_no_removed_rows() {
+  _dr_db="$1"
+  _dr_from="$2"
+  _dr_to="$3"
+  _dr_t="$4"
+  # Without both commit endpoints there is nothing to diff against — fail closed.
+  [ -n "$_dr_from" ] && [ -n "$_dr_to" ] && [ -n "$_dr_t" ] || return 1
+  valid_table_name "$_dr_t" || return 1
+  # Count rows dropped between the two commits. Zero means every row present at
+  # <from> is still reachable at <to>, whatever else changed.
+  if ! _dr_removed=$(query_single_cell "$_dr_db" \
+    "preservation diff probe failed for table=$_dr_t" \
+    "SELECT COUNT(*) FROM DOLT_DIFF('$_dr_from', '$_dr_to', '$_dr_t') WHERE diff_type = 'removed'"); then
+    return 1
+  fi
+  case "$_dr_removed" in
+    0) return 0 ;;             # no row dropped — this table's <from> rows preserved
+    ''|*[!0-9]*) return 1 ;;   # empty/non-numeric probe result — fail closed
+    *) return 1 ;;             # one or more removed rows — not preservable
+  esac
+}
+
+# drift_preserves_preflight_rows <db> <from_head> <to_head> <space-separated tables>
+# Returns 0 iff every listed table's <from>..<to> content diff drops no row.
+# Returns non-zero (fail closed) if the table list is empty or any table fails
+# diff_has_no_removed_rows.
+drift_preserves_preflight_rows() {
+  _dp_db="$1"
+  _dp_from="$2"
+  _dp_to="$3"
+  _dp_tables="$4"
+  _dp_seen=0
+  for _dp_t in $_dp_tables; do
+    _dp_seen=1
+    diff_has_no_removed_rows "$_dp_db" "$_dp_from" "$_dp_to" "$_dp_t" || return 1
   done
   # An empty table list is not a proof of preservation.
-  [ "$_gd_seen" = "1" ] || return 1
+  [ "$_dp_seen" = "1" ] || return 1
   return 0
 }

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1172,6 +1172,7 @@ verify_counts() {
   verify_counts_saw_row_decrease=0
   verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
+  verify_counts_same_count_drift_tables=""
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
@@ -1270,6 +1271,7 @@ verify_counts() {
         printf 'compact: db=%s table=%s value hash changed after flatten without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         verify_counts_saw_same_count_hash_drift=1
+        verify_counts_same_count_drift_tables="$verify_counts_same_count_drift_tables $t"
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten table value hash changed without row-count increase"
@@ -2257,6 +2259,7 @@ flatten_database() {
   verify_counts_saw_row_decrease=0
   verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
+  verify_counts_same_count_drift_tables=""
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
@@ -2736,8 +2739,9 @@ flatten_database() {
     integrity_guidance="${verify_counts_failure_guidance:-post-flatten integrity check failed; investigate before re-running}"
     # Downgrade quarantine -> defer ONLY for the ambiguous gain+drift case when
     # a concurrent writer is proven. Every other integrity failure (row-count
-    # decrease, same-count hash drift, table-list drift, probe failure) and the
-    # gain+drift case with a stable HEAD still quarantine below unchanged.
+    # decrease, same-count hash drift, table-list drift, probe failure) falls
+    # through: to the direct preservation proof immediately below where drift is
+    # the only category, and to the quarantine otherwise.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_gain:-0}" = "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
@@ -2756,24 +2760,35 @@ flatten_database() {
       rm -f "$preflight_tmp"
       return 0
     fi
-    # Option A (#2846): HEAD movement is only a proxy for "pre-flight rows
-    # remain reachable". When gain+drift is the only failure category but no
-    # concurrent writer was HEAD-proven — the absorbed-writer race, where the
-    # writer's commit was folded into the flatten and left no HEAD fingerprint
-    # — prove preservation directly by diffing the pre-flight snapshot HEAD
-    # against the flatten commit for each gained+drifted table. Purely additive
-    # (no removed/modified rows) proves every pre-flight row survived; defer
-    # exactly as the HEAD-proven path above does. Any removed/modified row, or
-    # a diff-probe failure, fails closed and falls through to the quarantine.
-    if [ "${verify_counts_saw_gain:-0}" = "1" ] && \
-       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
+    # Option A (#2846, widened for #3341): HEAD movement is only a proxy for
+    # "pre-flight rows remain reachable". When table value-hash drift is the
+    # only failure category — with a row gain (concurrent INSERT), without one
+    # (concurrent in-place UPDATE), or a mix of both across tables — prove
+    # preservation directly by diffing the pre-flight snapshot HEAD against the
+    # flatten commit for each drifted table. A diff that drops no row proves
+    # every pre-flight row survived; defer exactly as the HEAD-proven path
+    # above does. Any removed row, or a diff-probe failure, fails closed and
+    # falls through to the quarantine.
+    #
+    # This needs no HEAD proof because it proves reachability instead of
+    # inferring it, so it also carries the absorbed-writer race, where the
+    # writer's commit was folded into the flatten and left no HEAD fingerprint.
+    # Same-count hash drift stays disqualifying for the two HEAD-proxy branches
+    # around it — those infer preservation and have no direct evidence — but an
+    # in-place UPDATE is the dominant write shape on a busy issues table, so
+    # refusing it here made a HEAD-proven writer race quarantine anyway and left
+    # the check unsatisfiable on a live store (#3341). A concurrent DELETE shows
+    # as a removed row, fails this proof, and is carried by the row-decrease
+    # writer-race branch below.
+    verify_counts_drift_proof_tables="${verify_counts_gain_drift_tables}${verify_counts_same_count_drift_tables}"
+    if { [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] || \
+         [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ]; } && \
        [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
-       [ "${verify_counts_saw_same_count_hash_drift:-0}" != "1" ] && \
        [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
        [ "${verify_counts_saw_probe_failure:-0}" != "1" ] && \
-       gain_drift_is_additive_only "$db" "$head" "$flatten_head" "$verify_counts_gain_drift_tables"; then
-      printf 'compact: db=%s gain+drift proven additive-only via DOLT_DIFF(%s..%s) for tables [%s] — pre-flight rows preserved (absorbed-writer race), not corruption; deferring, will retry next run\n' \
-        "$db" "$head" "$flatten_head" "${verify_counts_gain_drift_tables# }" >&2
+       drift_preserves_preflight_rows "$db" "$head" "$flatten_head" "$verify_counts_drift_proof_tables"; then
+      printf 'compact: db=%s value-hash drift proven row-preserving via DOLT_DIFF(%s..%s) for tables [%s] — pre-flight rows preserved (concurrent writer), not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "$flatten_head" "${verify_counts_drift_proof_tables# }" >&2
       if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
         "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
         "${compacted_from_head:-}" "$local_branch" "$remote_branch"; then

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -856,7 +856,7 @@ case "$query" in
       print_cell hash-beads-after-writer
       exit 0
     fi
-    if [ "$mode" = "same_row_count_writer" ] && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "same_row_count_writer" ] || [ "$mode" = "same_row_count_update_race" ] || [ "$mode" = "preservation_diff_probe_failure" ] || [ "$mode" = "mixed_update_and_insert_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -864,7 +864,7 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_HASHOF_TABLE('notes')"*)
-    if { [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "same_count_hash_drift_then_probe_failure" ] || [ "$mode" = "probe_failure_then_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "mixed_update_and_insert_race" ] || [ "$mode" = "same_count_hash_drift_then_probe_failure" ] || [ "$mode" = "probe_failure_then_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-notes-after-writer
       exit 0
     fi
@@ -1002,7 +1002,7 @@ case "$query" in
       print_cell blocked_issues
       exit 0
     fi
-    if [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; then
+    if [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "mixed_update_and_insert_race" ]; then
       print_cells beads notes
       exit 0
     fi
@@ -1015,6 +1015,35 @@ case "$query" in
       exit 0
     fi
     print_cell beads
+    exit 0
+    ;;
+  *"DOLT_DIFF("*"'beads')"*|*"DOLT_DIFF("*"'notes')"*)
+    # Post-flatten preservation proof (drift_preserves_preflight_rows): count of
+    # rows DROPPED between the stable pre-flight HEAD and the flatten commit for
+    # a drifted table that is in the verified set. Zero proves every pre-flight
+    # row survived whatever the concurrent writer did to it. This arm must stay
+    # ABOVE the row-count arms below — the proof is a SELECT COUNT(*) naming the
+    # same table, so they would otherwise answer it with a row count.
+    case "$mode" in
+      same_row_count_update_race|mixed_update_and_insert_race)
+        # Concurrent in-place UPDATE (and, in the mixed mode, a concurrent
+        # INSERT alongside it): rows change value, none are dropped.
+        print_cell 0
+        ;;
+      same_table_replacement_with_row_gain|mixed_row_count_gain_and_same_count_hash_drift|writer_race_with_mixed_same_count_hash_drift|same_row_count_writer|row_count_and_hash_diverges)
+        # A pre-flight row is gone at the flatten commit — preservation is
+        # unprovable however HEAD moved, so these stay quarantined.
+        print_cell 1
+        ;;
+      preservation_diff_probe_failure)
+        printf 'preservation diff unavailable\n' >&2
+        exit 56
+        ;;
+      *)
+        printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
+        exit 64
+        ;;
+    esac
     exit 0
     ;;
   *"SELECT COUNT(*) FROM"*"blocked_issues"*)
@@ -1054,7 +1083,7 @@ case "$query" in
       printf 'row count exploded after flatten\n' >&2
       exit 47
     fi
-    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$calls" -gt 1 ]; then
+    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "remote_writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "mixed_update_and_insert_race" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 11
     elif { [ "$mode" = "row_count_decreases" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "row_count_decreases_with_hash_change" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 9
@@ -2644,6 +2673,101 @@ func TestCompactScriptStillQuarantinesGainAndHashDriftWithStableHead(t *testing.
 	}
 	if strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("stable-HEAD gain+drift must block full GC:\n%s", string(data))
+	}
+}
+
+// assertCompactPreservationDeferred encodes the shared expectations for a defer
+// carried by the direct preservation proof rather than by HEAD movement: the
+// run exits 0, names the proof in its defer message, writes NO quarantine
+// marker, records the pending-GC retry marker, and leaves GC for the next run.
+func assertCompactPreservationDeferred(t *testing.T, fixture compactScriptFixture, out string, err error, tables string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("preservation defer must exit 0 (skip, not failure): %v\n%s", err, out)
+	}
+	want := "value-hash drift proven row-preserving via DOLT_DIFF(headcommit..compactcommit) for tables [" + tables + "]"
+	if !strings.Contains(out, want) || !strings.Contains(out, "deferring, will retry next run") {
+		t.Fatalf("output missing preservation defer message %q:\n%s", want, out)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
+		t.Fatalf("preservation defer must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
+		t.Fatalf("preservation defer should record pending-GC retry marker, got reason %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("preservation defer must skip GC this run:\n%s", string(data))
+	}
+}
+
+// Production incident (hq since 2026-07-29, dip since 2026-08-04, #3341): the
+// post-flatten row_count / table_value_hash probes read the LIVE working set of
+// a continuously-written DB, so an in-place UPDATE landing inside the flatten
+// window drifts a table's value hash with no row-count change. That is the
+// dominant write shape on a busy issues table (bd update, heartbeats, status
+// and metadata writes), and same-count drift disqualified every branch of the
+// writer-race ladder — so the DB re-quarantined roughly every two hours and all
+// future GC of it stayed blocked. The verification was unsatisfiable by
+// construction: a flatten of a 320k-row table takes far longer than the gap
+// between writes.
+//
+// An UPDATE rewrites a row's values but keeps the row reachable, so the direct
+// DOLT_DIFF proof drops no row and preservation holds. Defer, do not quarantine.
+func TestCompactScriptDefersSameCountHashDriftProvenRowPreserving(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "same_row_count_update_race", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "table=beads value hash changed after flatten without row-count increase") {
+		t.Fatalf("output missing the same-count drift signal that the proof clears:\n%s", out)
+	}
+	if strings.Contains(out, "writer race detected") {
+		t.Fatalf("stable HEAD must not be misclassified as a HEAD-proven writer race:\n%s", out)
+	}
+	assertCompactPreservationDeferred(t, fixture, out, err, "beads")
+}
+
+// A concurrent INSERT and a concurrent UPDATE landing in the same flatten window
+// produce gain+drift on one table and same-count drift on another. Both tables
+// must be proven — the union of the two drift lists is what the proof runs over.
+func TestCompactScriptDefersMixedGainAndSameCountDriftProvenRowPreserving(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "mixed_update_and_insert_race", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "table=beads gained rows during flatten") ||
+		!strings.Contains(out, "table=notes value hash changed after flatten without row-count increase") {
+		t.Fatalf("output missing the mixed gain+drift and same-count drift signals:\n%s", out)
+	}
+	assertCompactPreservationDeferred(t, fixture, out, err, "beads notes")
+}
+
+// The proof is the only evidence on this branch — there is no HEAD proxy behind
+// it — so a diff probe that cannot answer must fail closed and quarantine.
+func TestCompactScriptQuarantinesSameCountHashDriftWhenPreservationProbeFails(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "preservation_diff_probe_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("an unanswerable preservation proof must stay a blocking failure:\n%s", out)
+	}
+	if strings.Contains(out, "proven row-preserving") {
+		t.Fatalf("a failed diff probe must not report a proof:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten INTEGRITY check failed") {
+		t.Fatalf("unproven same-count drift should escalate as an integrity failure:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed without row-count increase" {
+		t.Fatalf("unproven same-count drift must quarantine with the same-count reason, got %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("unproven same-count drift must block full GC:\n%s", string(data))
 	}
 }
 

--- a/test/dolt/compact_gain_drift_proof_test.sh
+++ b/test/dolt/compact_gain_drift_proof_test.sh
@@ -1,11 +1,21 @@
 #!/bin/sh
-# Unit test for gain_drift_is_additive_only (Option A preservation proof, #2846).
+# Unit test for the compact preservation proofs (Option A, #2846; widened for
+# the concurrent-UPDATE case, #3341).
 # Lib under test: examples/bd/dolt/assets/scripts/compact-gain-drift-proof.sh
 #
 # Stubs the run.sh-provided dependencies (query_single_cell, valid_table_name)
-# so the additive-only classification is exercised without a live Dolt server.
-# The full flatten path needs a concurrent-writer race that cannot be reproduced
+# so the classification is exercised without a live Dolt server. The full
+# flatten path needs a concurrent-writer race that cannot be reproduced
 # deterministically in a unit test (see #2846); this covers the decision logic.
+#
+# Two proofs live in the lib and they are deliberately different strengths:
+#   * diff_is_additive_only      — added rows ONLY. Used for a table that
+#     exists in no pre-flatten commit root, which must be wholly new.
+#   * diff_has_no_removed_rows / drift_preserves_preflight_rows — no row
+#     dropped. Used for the post-flatten drift proof, where a `modified` row is
+#     a concurrent in-place UPDATE and keeps the row reachable.
+# The stub models both DOLT_DIFF predicates separately so the gap between them
+# (a modified-only diff) is pinned rather than assumed.
 set -u
 
 HERE=$(unset CDPATH; cd -- "$(dirname "$0")" && pwd)
@@ -14,7 +24,9 @@ LIB="$HERE/../../examples/bd/dolt/assets/scripts/compact-gain-drift-proof.sh"
 
 # --- stubs for run.sh-provided helpers --------------------------------------
 # query_single_cell <db> <msg> <query>: extract the table from the DOLT_DIFF
-# query and echo the canned non-added count stub_count_<table> (default 0).
+# query and echo the canned count for whichever diff_type predicate was asked
+# for — stub_nonadded_<table> for `<> 'added'`, stub_removed_<table> for
+# `= 'removed'` (both default 0).
 # STUB_FAIL_TABLE forces a probe failure; STUB_EMPTY_TABLE forces an empty result.
 query_single_cell() {
   _t=$(printf '%s\n' "$3" | sed -n "s/.*DOLT_DIFF('[^']*', *'[^']*', *'\([^']*\)').*/\1/p")
@@ -25,10 +37,25 @@ query_single_cell() {
     printf ''
     return 0
   fi
-  case "$_t" in
-    issues) printf '%s' "${stub_count_issues:-0}" ;;
-    mail) printf '%s' "${stub_count_mail:-0}" ;;
-    *) printf '0' ;;
+  case "$3" in
+    *"diff_type = 'removed'"*)
+      case "$_t" in
+        issues) printf '%s' "${stub_removed_issues:-0}" ;;
+        mail) printf '%s' "${stub_removed_mail:-0}" ;;
+        *) printf '0' ;;
+      esac
+      ;;
+    *"diff_type <> 'added'"*)
+      case "$_t" in
+        issues) printf '%s' "${stub_nonadded_issues:-0}" ;;
+        mail) printf '%s' "${stub_nonadded_mail:-0}" ;;
+        *) printf '0' ;;
+      esac
+      ;;
+    *)
+      printf 'stub: unexpected diff predicate: %s\n' "$3" >&2
+      return 1
+      ;;
   esac
   return 0
 }
@@ -49,48 +76,78 @@ ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
 no() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
 reset() {
   unset STUB_FAIL_TABLE STUB_EMPTY_TABLE STUB_INVALID_TABLE \
-    stub_count_issues stub_count_mail 2>/dev/null || true
+    stub_nonadded_issues stub_nonadded_mail \
+    stub_removed_issues stub_removed_mail 2>/dev/null || true
 }
 
-# 1. single table, purely additive -> preserved (defer)
-reset; stub_count_issues=0
-if gain_drift_is_additive_only db H1 H2 "issues"; then ok "additive-only single table -> defer"; else no "additive-only single table -> defer"; fi
+# --- drift_preserves_preflight_rows (post-flatten drift proof) ---------------
 
-# 2. single table with removed/modified rows -> not preservable (quarantine)
-reset; stub_count_issues=2
-if gain_drift_is_additive_only db H1 H2 "issues"; then no "removed/modified -> quarantine"; else ok "removed/modified -> quarantine"; fi
+# 1. single table, nothing dropped -> preserved (defer)
+reset; stub_removed_issues=0
+if drift_preserves_preflight_rows db H1 H2 "issues"; then ok "no removed rows single table -> defer"; else no "no removed rows single table -> defer"; fi
 
-# 3. two tables, both additive -> preserved
-reset; stub_count_issues=0; stub_count_mail=0
-if gain_drift_is_additive_only db H1 H2 "issues mail"; then ok "two additive tables -> defer"; else no "two additive tables -> defer"; fi
+# 2. single table with a dropped row -> not preservable (quarantine)
+reset; stub_removed_issues=2
+if drift_preserves_preflight_rows db H1 H2 "issues"; then no "removed rows -> quarantine"; else ok "removed rows -> quarantine"; fi
 
-# 4. two tables, one not additive -> not preservable
-reset; stub_count_issues=0; stub_count_mail=5
-if gain_drift_is_additive_only db H1 H2 "issues mail"; then no "mixed tables -> quarantine"; else ok "mixed tables -> quarantine"; fi
+# 3. THE #3341 CASE: concurrent in-place UPDATE — rows modified, none dropped.
+# The additive-only proof refuses it; the preservation proof admits it. This is
+# the whole point of the widening, so pin both verdicts on the same diff.
+reset; stub_nonadded_issues=7; stub_removed_issues=0
+if drift_preserves_preflight_rows db H1 H2 "issues"; then ok "modified-only (concurrent UPDATE) -> defer"; else no "modified-only (concurrent UPDATE) -> defer"; fi
+if diff_is_additive_only db H1 H2 "issues"; then no "modified-only still fails the additive-only proof"; else ok "modified-only still fails the additive-only proof"; fi
 
-# 5. diff probe failure on a table -> fail closed
-reset; stub_count_issues=0; STUB_FAIL_TABLE=mail
-if gain_drift_is_additive_only db H1 H2 "issues mail"; then no "probe failure -> quarantine"; else ok "probe failure -> quarantine"; fi
+# 4. two tables, neither drops a row -> preserved
+reset; stub_removed_issues=0; stub_removed_mail=0
+if drift_preserves_preflight_rows db H1 H2 "issues mail"; then ok "two preserving tables -> defer"; else no "two preserving tables -> defer"; fi
 
-# 6. empty / non-numeric probe result -> fail closed
+# 5. two tables, one drops a row -> not preservable
+reset; stub_removed_issues=0; stub_removed_mail=5
+if drift_preserves_preflight_rows db H1 H2 "issues mail"; then no "mixed tables -> quarantine"; else ok "mixed tables -> quarantine"; fi
+
+# 6. diff probe failure on a table -> fail closed
+reset; stub_removed_issues=0; STUB_FAIL_TABLE=mail
+if drift_preserves_preflight_rows db H1 H2 "issues mail"; then no "probe failure -> quarantine"; else ok "probe failure -> quarantine"; fi
+
+# 7. empty / non-numeric probe result -> fail closed
 reset; STUB_EMPTY_TABLE=issues
-if gain_drift_is_additive_only db H1 H2 "issues"; then no "empty probe result -> quarantine"; else ok "empty probe result -> quarantine"; fi
+if drift_preserves_preflight_rows db H1 H2 "issues"; then no "empty probe result -> quarantine"; else ok "empty probe result -> quarantine"; fi
 
-# 7. empty table list -> not a proof
+# 8. empty table list -> not a proof
 reset
-if gain_drift_is_additive_only db H1 H2 ""; then no "empty table list -> quarantine"; else ok "empty table list -> quarantine"; fi
+if drift_preserves_preflight_rows db H1 H2 ""; then no "empty table list -> quarantine"; else ok "empty table list -> quarantine"; fi
 
-# 8. missing from-head -> fail closed
-reset; stub_count_issues=0
-if gain_drift_is_additive_only db "" H2 "issues"; then no "missing from-head -> quarantine"; else ok "missing from-head -> quarantine"; fi
+# 9. missing from-head -> fail closed
+reset; stub_removed_issues=0
+if drift_preserves_preflight_rows db "" H2 "issues"; then no "missing from-head -> quarantine"; else ok "missing from-head -> quarantine"; fi
 
-# 9. missing to-head -> fail closed
-reset; stub_count_issues=0
-if gain_drift_is_additive_only db H1 "" "issues"; then no "missing to-head -> quarantine"; else ok "missing to-head -> quarantine"; fi
+# 10. missing to-head -> fail closed
+reset; stub_removed_issues=0
+if drift_preserves_preflight_rows db H1 "" "issues"; then no "missing to-head -> quarantine"; else ok "missing to-head -> quarantine"; fi
 
-# 10. invalid table name -> fail closed
-reset; stub_count_issues=0; STUB_INVALID_TABLE=issues
-if gain_drift_is_additive_only db H1 H2 "issues"; then no "invalid table name -> quarantine"; else ok "invalid table name -> quarantine"; fi
+# 11. invalid table name -> fail closed
+reset; stub_removed_issues=0; STUB_INVALID_TABLE=issues
+if drift_preserves_preflight_rows db H1 H2 "issues"; then no "invalid table name -> quarantine"; else ok "invalid table name -> quarantine"; fi
+
+# --- diff_is_additive_only (first-committed table proof) ---------------------
+# Still used by run.sh db_root_drift_within_verified_tables, where a table
+# absent from the pre-flatten commit root must be wholly new to be provable.
+
+# 12. purely additive -> proven
+reset; stub_nonadded_issues=0
+if diff_is_additive_only db H1 H2 "issues"; then ok "additive-only -> proven"; else no "additive-only -> proven"; fi
+
+# 13. any non-added row -> fail closed
+reset; stub_nonadded_issues=1
+if diff_is_additive_only db H1 H2 "issues"; then no "non-added rows -> fail closed"; else ok "non-added rows -> fail closed"; fi
+
+# 14. probe failure -> fail closed
+reset; STUB_FAIL_TABLE=issues
+if diff_is_additive_only db H1 H2 "issues"; then no "additive probe failure -> fail closed"; else ok "additive probe failure -> fail closed"; fi
+
+# 15. invalid table name -> fail closed
+reset; stub_nonadded_issues=0; STUB_INVALID_TABLE=issues
+if diff_is_additive_only db H1 H2 "issues"; then no "additive invalid table name -> fail closed"; else ok "additive invalid table name -> fail closed"; fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Problem

The post-flatten integrity check compares a pre-flight snapshot against the
LIVE working set — `row_count` is `SELECT COUNT(*) FROM tbl` and
`table_value_hash` is `SELECT DOLT_HASHOF_TABLE(tbl)`, both unpinned, while
`db_value_hash` one function below IS pinned to `HEAD` and carries a comment
naming this exact hazard. On a continuously-written DB an in-place UPDATE
landing in the flatten window drifts a table's value hash with no row-count
change, which verify_counts categorises as `same_row_count_hash_drift`.

All three writer-race defer branches required
`verify_counts_saw_same_count_hash_drift != 1`, so that category disqualified
every one of them: the ladder covered concurrent INSERT (gain) and concurrent
DELETE (decrease) but had no branch for concurrent UPDATE — the dominant write
shape on a busy issues table (bd update, heartbeats, status/metadata writes).
A HEAD-proven writer race still hard-quarantined, and the marker blocks all
future GC of the database, so the store cannot shrink.

Production: hq re-quarantined roughly every two hours (seen_count 113, since
2026-07-29) and dip likewise (35, since 2026-08-04), 1:1 with mol-dog-compactor
exit-1. Read-only probe of a live store, 90s apart, no writes from the prober:
the working set moved (events 320522 -> 320560, issues 27629 -> 27632) while
the same revision pinned at the commit was byte-identical across both reads. A
flatten of a 320k-row table takes far longer than 90s, so the verification is
unsatisfiable by construction on a live store.

## Fix

Generalise the existing Option A (#2846) proof instead of adding a fourth
heuristic. Option A already proves the real safety property directly — "every
pre-flight row remains reachable at the flatten commit" — by diffing the
pre-flight snapshot HEAD against the flatten commit.

1. `drift_preserves_preflight_rows` (was `gain_drift_is_additive_only`) now
   asks for no `removed` rows rather than added-only. `added` rows are a
   concurrent INSERT and `modified` rows a concurrent UPDATE; neither can drop
   a pre-flight row, so only a removal is loss. This is the preservation claim
   itself and it subsumes the previous additive-only case.
2. `same_row_count_hash_drift` no longer disqualifies THAT branch, and the
   branch no longer requires a row gain, so a drift-only failure reaches the
   proof whether the writer INSERTed, UPDATEd, or both. The proof runs over the
   union of the gain-drift and same-count-drift table lists, so a mixed shape
   must prove every drifted table.
3. `same_row_count_hash_drift` stays disqualifying for the two HEAD-proxy
   branches around it — those infer preservation from HEAD movement and have no
   direct evidence.
4. `diff_is_additive_only` is unchanged and still used by the committed-root
   drift proof's first-committed table case, where a table absent from every
   pre-flatten commit root must be wholly new to be provable.

Concurrent DELETE still shows as `removed`, still fails this proof, and still
falls through to the existing row-decrease + writer-race branch. Everything
unproven — a removed row, a diff-probe failure, table-list drift, a probe
failure — fails closed exactly as before.

Tradeoff, stated explicitly for review: additive-only proved every pre-flight
row was byte-identical at the flatten commit; no-removed proves every
pre-flight row is still reachable. The flatten is a soft reset plus
`DOLT_COMMIT -Am`, which re-commits the live working set and cannot rewrite
cell values, so a `modified` row can only be a writer's own write — the same
reasoning that already justifies admitting `added`. The stronger claim is what
made the check unsatisfiable on a live store.

## Verification

- TDD: the two new defer tests were falsified first — they fail against
  unmodified canonical scripts (both quarantine) and pass with the fix, so they
  are load-bearing rather than tautological.
- New fake-dolt scenarios/tests: same-count drift proven row-preserving ->
  defer (the hq/dip production shape); mixed gain+drift and same-count drift ->
  defer over the union of both table lists; preservation probe failure ->
  quarantine (this branch has no HEAD proxy behind it, so it must fail closed).
- The fake-dolt DOLT_DIFF arm for verified tables is placed above the row-count
  arms: the proof is a `SELECT COUNT(*)` naming the same table, so those arms
  would otherwise answer it with a row count.
- Existing fail-closed pins unchanged and still green, now exercising the real
  proof path rather than an unhandled-query error:
  `TestCompactScriptQuarantinesSameRowCountWriterBeforeFullGC`,
  `TestCompactScriptStillQuarantinesGainAndHashDriftWithStableHead`,
  `TestCompactScriptQuarantinesMixedSignalsDespiteWriterRace`,
  `TestCompactScriptQuarantinesMixedRowGainAndSameCountHashDriftBeforeFullGC`,
  row-decrease and dolt_schemas system-table drift.
- `go test ./examples/bd/dolt/` green (full package); `go vet ./examples/bd/dolt/...`
  clean; `go test ./internal/builtinpacks/...` green.
- `test/dolt/compact_gain_drift_proof_test.sh` rewritten to model the two
  DOLT_DIFF predicates separately, so the gap between the proofs (a
  modified-only diff: refused by additive-only, admitted by preservation) is
  pinned rather than assumed. 16/16 pass.

## Not done

- Quarantine markers are not cleared — that carries the `clear_decision`
  evidence bar and is an operator call (and the #3584 revert stands).
- Optional follow-up, orthogonal to this fix: pin `row_count` and
  `table_value_hash` to the revision under verification so the two probes at
  least agree with each other, removing the intra-loop race at source. Drift
  against the pre-flight snapshot would remain, so the proof is still required.
- `test/dolt/*.sh` are still not CI-wired (tracked upstream in ga-7yrto); the
  Go fake-dolt tests are the CI-enforced proof of this change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016j4o3961MTbXkBq5jP35Ah


---
Re-verified against current `origin/main` (87ece235f) before opening: clean cherry-pick, and `go test ./examples/bd/dolt -count=1` passes (128s) on the rebased head. Fixes #3341.
