### PR TITLE
Hoist a rig pack's formulas with its city-scoped agents

### DIFF
--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -125,9 +125,14 @@ type LoadOptions struct {
 	// discovery, shell completion — set this and degrade to "no pack state
 	// right now"; a load whose result the caller acts on must leave it false
 	// and wait, because a busy cache would otherwise read as an empty one.
-	RepoCacheNonBlocking    bool
-	deferRigPatches         bool
-	deferredRigPatches      *[]deferredRigPatches
+	RepoCacheNonBlocking bool
+	deferRigPatches      bool
+	deferredRigPatches   *[]deferredRigPatches
+	// hoistedCityFormulaDirs collects the formulas/ dirs of rig-scope packs
+	// that contributed a city-scoped agent or named session. Hoisting the
+	// agent without its formulas leaves it unable to resolve the formula it
+	// executes (gs-gd0z), so the dirs are promoted to the city layer too.
+	hoistedCityFormulaDirs  *[]string
 	allowLegacyOrderLayouts bool
 }
 
@@ -579,10 +584,14 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// deferred so they still run after city-level [[patches.agent]].
 	rigFormulaDirs := make(map[string][]string)
 	var deferredRigPatches []deferredRigPatches
+	// Formulas of rig-scope packs that contributed a city-scoped agent. They
+	// join the city layer so the hoisted agent can resolve them (gs-gd0z).
+	var hoistedCityFormulaDirs []string
 	if HasPackRigs(root.Rigs) {
 		rigPackOpts := opts
 		rigPackOpts.deferRigPatches = true
 		rigPackOpts.deferredRigPatches = &deferredRigPatches
+		rigPackOpts.hoistedCityFormulaDirs = &hoistedCityFormulaDirs
 		if err := expandPacks(root, fs, cityRoot, rigFormulaDirs, rigPackOpts); err != nil {
 			return nil, nil, fmt.Errorf("expanding packs: %w", err)
 		}
@@ -693,6 +702,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Always use FormulasDir() which defaults to "formulas" when
 	// [formulas] is not explicitly configured in city.toml.
 	cityLocalFormulas := citylayout.ResolveFormulasDir(cityRoot, root.FormulasDir())
+	cityTopoFormulas = appendUnique(cityTopoFormulas, hoistedCityFormulaDirs...)
 	root.FormulaLayers = ComputeFormulaLayers(
 		cityTopoFormulas, cityLocalFormulas, rigFormulaDirs, root.Rigs, cityRoot)
 

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -214,8 +214,9 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 
 			// Keep only rig-scoped and unscoped agents for rig expansion;
 			// hoist city-scoped ones to city scope instead of dropping them.
-			hoistedAgents = append(hoistedAgents, hoistCityScopedAgents(agents)...)
-			hoistedNamedSessions = append(hoistedNamedSessions, hoistCityScopedNamedSessions(namedSessions)...)
+			ha, hns := hoistCityScopeFromRigPack(agents, namedSessions, topoDirs, fs, opts)
+			hoistedAgents = append(hoistedAgents, ha...)
+			hoistedNamedSessions = append(hoistedNamedSessions, hns...)
 			agents = filterAgentsByScope(agents, false)
 			namedSessions = filterNamedSessionsByScope(namedSessions, false)
 
@@ -419,8 +420,9 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 
 				// Hoist city-scoped agents/sessions to city scope instead of
 				// dropping them at the rig-import boundary.
-				hoistedAgents = append(hoistedAgents, hoistCityScopedAgents(agents)...)
-				hoistedNamedSessions = append(hoistedNamedSessions, hoistCityScopedNamedSessions(namedSessions)...)
+				ha, hns := hoistCityScopeFromRigPack(agents, namedSessions, topoDirs, fs, opts)
+				hoistedAgents = append(hoistedAgents, ha...)
+				hoistedNamedSessions = append(hoistedNamedSessions, hns...)
 				agents = filterAgentsByScope(agents, false)
 				namedSessions = filterNamedSessionsByScope(namedSessions, false)
 
@@ -2664,6 +2666,37 @@ func hoistCityScopedNamedSessions(sessions []NamedSession) []NamedSession {
 		hoisted = append(hoisted, s)
 	}
 	return hoisted
+}
+
+// hoistCityScopeFromRigPack hoists the city-scoped agents and named sessions
+// of a pack reached through a rig include/import, and — when it hoisted
+// anything — promotes that pack's formulas/ dirs to the city formula layer.
+//
+// Hoisting an agent without its formulas leaves the agent registered at city
+// scope while the formula it executes stays in the rig layer, where the agent
+// never looks. That half-hoist stopped the deacon in gs-gd0z: moving a pack
+// import from city defaults to a single rig kept the deacon at city scope and
+// left mol-deacon-patrol behind, so every patrol cycle failed to pour.
+//
+// A pack with no city-scoped agents promotes nothing; only the hoist justifies
+// widening the formula layer.
+func hoistCityScopeFromRigPack(agents []Agent, namedSessions []NamedSession, topoDirs []string, fs fsys.FS, opts LoadOptions) ([]Agent, []NamedSession) {
+	hoistedAgents := hoistCityScopedAgents(agents)
+	hoistedSessions := hoistCityScopedNamedSessions(namedSessions)
+	if len(hoistedAgents) == 0 && len(hoistedSessions) == 0 {
+		return hoistedAgents, hoistedSessions
+	}
+	if opts.hoistedCityFormulaDirs == nil {
+		return hoistedAgents, hoistedSessions
+	}
+	for _, td := range topoDirs {
+		fd := filepath.Join(td, "formulas")
+		if _, err := fs.Stat(fd); err != nil {
+			continue
+		}
+		*opts.hoistedCityFormulaDirs = appendUnique(*opts.hoistedCityFormulaDirs, fd)
+	}
+	return hoistedAgents, hoistedSessions
 }
 
 // mergeHoistedCityAgents appends hoisted city-scoped agents to the city

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -5467,4 +5468,117 @@ func mustResolvedPackNames(t *testing.T, includes []string, imports map[string]I
 		t.Fatalf("resolvedPackNames: %v", err)
 	}
 	return names
+}
+
+// TestHoistedCityAgentSeesItsPackFormulas verifies that when a pack reached
+// only through a RIG import contributes a city-scoped agent, that pack's
+// formulas dir is hoisted to the city formula layer alongside the agent.
+//
+// Without this, the hoist is half-done: the agent registers at city scope but
+// the formula it executes stays in the rig layer, so the agent can never
+// resolve it. That is how gs-gd0z stopped the deacon — city.toml moved the
+// gastown import from city defaults to the celilo rig, the deacon hoisted to
+// city scope as designed, and mol-deacon-patrol did not follow it.
+func TestHoistedCityAgentSeesItsPackFormulas(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "town")
+	mustMkdirAll(t, cityDir, 0o755)
+	mustMkdirAll(t, packDir, 0o755)
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "onerig"
+path = "/tmp/onerig"
+
+[rigs.imports.town]
+source = "../town"
+`)
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "town"
+schema = 2
+
+[[agent]]
+name = "deacon"
+scope = "city"
+
+[[agent]]
+name = "witness"
+scope = "rig"
+`)
+	writeTestFile(t, packDir, "formulas/mol-deacon-patrol.toml", "formula = \"mol-deacon-patrol\"\n")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	var deacon *Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "deacon" {
+			deacon = &cfg.Agents[i]
+		}
+	}
+	if deacon == nil {
+		t.Fatalf("city-scoped deacon was not hoisted; agents: %v", agentNamesOf(cfg.Agents))
+	}
+	if deacon.Dir != "" {
+		t.Fatalf("hoisted deacon dir = %q, want \"\" (city scope)", deacon.Dir)
+	}
+
+	formulaDir := filepath.Join(packDir, "formulas")
+	if !slices.Contains(cfg.FormulaLayers.City, formulaDir) {
+		t.Fatalf("hoisted city agent cannot resolve its own pack formulas:\n  want %q in city layer\n  got  %v",
+			formulaDir, cfg.FormulaLayers.City)
+	}
+}
+
+// TestRigOnlyPackWithoutCityAgentsKeepsFormulasAtRigScope is the negative
+// half: a rig-imported pack with NO city-scoped agents must not leak its
+// formulas to the city layer. Only the hoist justifies the promotion.
+func TestRigOnlyPackWithoutCityAgentsKeepsFormulasAtRigScope(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "rigonly")
+	mustMkdirAll(t, cityDir, 0o755)
+	mustMkdirAll(t, packDir, 0o755)
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "onerig"
+path = "/tmp/onerig"
+
+[rigs.imports.rigonly]
+source = "../rigonly"
+`)
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "rigonly"
+schema = 2
+
+[[agent]]
+name = "witness"
+scope = "rig"
+`)
+	writeTestFile(t, packDir, "formulas/mol-witness-patrol.toml", "formula = \"mol-witness-patrol\"\n")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	formulaDir := filepath.Join(packDir, "formulas")
+	if slices.Contains(cfg.FormulaLayers.City, formulaDir) {
+		t.Fatalf("rig-only pack leaked formulas to city layer: %v", cfg.FormulaLayers.City)
+	}
+	if !slices.Contains(cfg.FormulaLayers.Rigs["onerig"], formulaDir) {
+		t.Fatalf("rig-imported pack formulas missing from rig layer: %v", cfg.FormulaLayers.Rigs["onerig"])
+	}
 }


### PR DESCRIPTION
## Summary

A pack reached only through a rig include or import can declare city-scoped agents. `expandPacks` hoists those agents and their named sessions up to city scope rather than dropping them (`hoistCityScopedAgents`, added for ga-hy0co). **The hoist stopped there:** the pack's `formulas/` dir went only into that rig's formula layer.

`ComputeFormulaLayers` builds a rig's layers as the city layers *plus* the rig's own, never the reverse. So a hoisted city-scoped agent can never resolve a formula from the pack it came from. The agent registers, and the formula it executes stays somewhere it does not look.

**What it broke, concretely.** In the `gc-scratch` city, a commit moved the gastown import out of `[defaults.rig.imports]` and onto one rig, to stop stamping an always-on witness onto every rig. That part worked. But `gastown.deacon` and `gastown.boot` hoisted to city scope as designed while `mol-deacon-patrol` stayed on the rig, so every patrol cycle failed to pour and the loop stopped rather than losing its wisp. The escalation path went with it: a warrant routes to the dog pool, the dog runs `mol-shutdown-dance`, and that formula was stranded the same way. The watchdog was disabled by the bug it would have been reporting.

`hoistCityScopeFromRigPack` now promotes the pack's `formulas/` dirs to the city formula layer when, and only when, that pack contributed a hoisted city-scoped agent or named session. A rig-only pack promotes nothing, so rig-scoped packs stay rig-scoped.

**Verified against a live city with no config change:** all four gastown formulas (`mol-deacon-patrol`, `mol-shutdown-dance`, `mol-refinery-patrol`, `mol-witness-patrol`) resolve at city scope, and `gc agent list` is byte-identical before and after at 80 entries, still exactly one witness. The fix widens formula visibility only.

## Testing

- [ ] `make check` — **not green, and not clean-red.** One package, `./scripts`, was killed at 901s against the 15m timeout. **Zero assertion failures** (`grep -c '^--- FAIL'` = 0). It is a timeout under load: the machine was at load average 127 on 10 cores from concurrent agent work. `go list -deps ./scripts/` returns no gascity package except `scripts` itself, so `internal/config` is not in its import graph and this change cannot reach it. The same package passed at 290s on the same tree earlier. Needs a re-run on a quiet box before merge, and I am not claiming the box otherwise.
- [x] `go build ./...` clean, `go vet ./internal/config/` clean
- [x] `go test ./internal/config/` — **ok, 53.5s, full package**
- [ ] `make check-docs` — n/a, no docs, navigation, or links changed
- [ ] `make test-integration` — n/a, this is config composition, not runtime, controller, or workflow behavior

## Checklist

- [x] Linked an issue — ga-kp9; city-store bead gs-gd0z records the symptom
- [x] Added or updated tests for behavior changes — one positive (`TestHoistedCityAgentSeesItsPackFormulas`) and one negative (`TestRigOnlyPackWithoutCityAgentsKeepsFormulasAtRigScope`), so the promotion is pinned in both directions
- [ ] Updated docs for user-facing changes — none; this restores intended behavior rather than changing it
- [x] Called out breaking changes or migration notes — none. Formula visibility widens for cities that already hoist an agent; the agent set is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EedCADsZczYgxLdtSqQnFc