### PR TITLE
fix(stop): rollback unregister on default-path failure

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -84,7 +84,13 @@ func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.
 			return cmdStopJSONSequence(args, stdout, stderr, force, jsonOut, true, unregisterTx)
 		})
 	} else {
-		outcome = cmdStopJSONSequence(args, stdout, stderr, force, jsonOut, false, nil)
+		unregisterTx := newSupervisorUnregisterTransaction()
+		outcome = cmdStopJSONSequence(args, stdout, stderr, force, jsonOut, false, unregisterTx)
+		if outcome.code == 0 {
+			unregisterTx.commit()
+		} else {
+			writeSupervisorUnregisterRollback(stderr, "gc stop", "stop failed after unregistering city", unregisterTx.rollback())
+		}
 	}
 	if outcome.code != 0 {
 		return outcome.code


### PR DESCRIPTION
## Summary

- keep the supervisor unregister transaction pending on the normal config-derived `gc stop` path
- commit the unregister only after the complete stop sequence succeeds
- restore the original registration when post-unregister shutdown fails

## Root cause

#4999 introduced a compensating unregister transaction, but `cmdStopJSON` only supplied it when an explicit nonzero `--timeout` was provided. With the normal zero/config-derived timeout, `unregisterCityFromSupervisorWithOptions` created and committed its own transaction before the managed bead-store shutdown ran.

If that shutdown then failed, `gc stop` returned nonzero but the registration was already permanently removed. The regression test added with #4999 exposed this deterministically on current `main`.

This patch keeps the same transaction pending for the normal path and settles it from the final stop outcome. The explicit timeout path and missing-city permanent-cleanup exception are unchanged.

## Validation

- `go test -count=1 ./cmd/gc -run '^TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails$'`
- `go test -count=10 ./cmd/gc -run '^TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails$'`
- adjacent invalid-config, JSON, timeout, and `TestSupervisorUnregisterTransaction.*` suite
- `go test -race -count=1 ./cmd/gc -run '^(TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails|TestCmdStopWallClockTimeoutBoundsSupervisorManagedInvalidConfigStop|TestSupervisorUnregisterTransaction.*)$'`
- `go test -count=1 ./cmd/gc -run '^(TestCmdStop|TestSupervisorUnregisterTransaction)'`
- `go vet ./cmd/gc`
- `.githooks/pre-commit`
