### PR TITLE
fix(formula): preserve inherited vars in prompt references

### DIFF
--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -369,6 +369,13 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 	}
 	setFormulaCompilerConstraints(merged, compilerConstraints)
 
+	// Oversized description_file references are first created while each
+	// formula is parsed, before parent variables are inherited. Clone the
+	// composed steps so cached parent formulas remain immutable, then render
+	// every retained reference from the full effective variable contract.
+	merged.Steps = refreshDescriptionFileReferences(merged.Steps, merged.Vars)
+	merged.Template = refreshDescriptionFileReferences(merged.Template, merged.Vars)
+
 	if err := merged.Validate(); err != nil {
 		return nil, err
 	}
@@ -816,14 +823,17 @@ func (p *Parser) resolveDescriptionFiles(steps []*Step, baseDir string, strict b
 				}
 			} else {
 				if len(data) > descriptionFileInlineMaxBytes {
-					step.Description = descriptionFileReferenceDescription(step.DescriptionFile, path, len(data), vars)
-					// Record the resolved path out-of-band so a later
-					// substitution pass over Description (expansion
-					// templates, loop bodies) can recognize this stub and
-					// leave its embedded path untouched (gastownhall/gascity#4860).
+					step.descriptionFileReference = &descriptionFileReference{
+						rawPath:      step.DescriptionFile,
+						resolvedPath: path,
+						size:         len(data),
+					}
+					step.Description = step.descriptionFileReference.render(vars)
+					// Preserve the path token during subsequent expansion substitution.
 					step.DescriptionFileResolvedPath = path
 				} else {
 					step.Description = string(data)
+					step.descriptionFileReference = nil
 					step.DescriptionFileResolvedPath = ""
 				}
 				step.DescriptionFile = "" // consumed; don't serialize
@@ -839,6 +849,55 @@ func (p *Parser) resolveDescriptionFiles(steps []*Step, baseDir string, strict b
 		}
 	}
 	return nil
+}
+
+type descriptionFileReference struct {
+	rawPath      string
+	resolvedPath string
+	size         int
+}
+
+func (r *descriptionFileReference) render(vars map[string]*VarDef) string {
+	return descriptionFileReferenceDescription(r.rawPath, r.resolvedPath, r.size, vars)
+}
+
+func refreshDescriptionFileReferences(steps []*Step, vars map[string]*VarDef) []*Step {
+	if !hasDescriptionFileReferences(steps) {
+		return steps
+	}
+	cloned := cloneStepsRecursive(steps)
+	refreshDescriptionFileReferencesInPlace(cloned, vars)
+	return cloned
+}
+
+func hasDescriptionFileReferences(steps []*Step) bool {
+	for _, step := range steps {
+		if step == nil {
+			continue
+		}
+		if step.descriptionFileReference != nil || hasDescriptionFileReferences(step.Children) {
+			return true
+		}
+		if step.Loop != nil && hasDescriptionFileReferences(step.Loop.Body) {
+			return true
+		}
+	}
+	return false
+}
+
+func refreshDescriptionFileReferencesInPlace(steps []*Step, vars map[string]*VarDef) {
+	for _, step := range steps {
+		if step == nil {
+			continue
+		}
+		if step.descriptionFileReference != nil {
+			step.Description = step.descriptionFileReference.render(vars)
+		}
+		refreshDescriptionFileReferencesInPlace(step.Children, vars)
+		if step.Loop != nil {
+			refreshDescriptionFileReferencesInPlace(step.Loop.Body, vars)
+		}
+	}
 }
 
 func (p *Parser) readDescriptionFile(rawPath, baseDir string) ([]byte, string, error) {

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1,6 +1,7 @@
 package formula
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -513,6 +514,87 @@ description_file = "operator.md"
 	}
 	if strings.Contains(step.Description, "large prompt body\nlarge prompt body\n") {
 		t.Fatalf("Description unexpectedly inlined oversized prompt:\n%s", step.Description)
+	}
+}
+
+func TestCompileInheritedVarsInOversizedDescriptionFileReference(t *testing.T) {
+	enableV2ForTest(t)
+
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "requirements.md")
+	largePrompt := strings.Repeat("requirements prompt body\n", descriptionFileInlineMaxBytes/24+128)
+	if len([]byte(largePrompt)) <= descriptionFileInlineMaxBytes {
+		t.Fatalf("test prompt length = %d, want > %d", len([]byte(largePrompt)), descriptionFileInlineMaxBytes)
+	}
+	if err := os.WriteFile(promptPath, []byte(largePrompt), 0o644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "base.toml"), []byte(`
+formula = "base"
+version = 2
+contract = "graph.v2"
+type = "workflow"
+
+[vars.requirements_path]
+description = "Requirements artifact path"
+required = true
+
+[[steps]]
+id = "requirements"
+title = "Requirements"
+description = "base prompt"
+`), 0o644); err != nil {
+		t.Fatalf("write base formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "child.toml"), []byte(`
+formula = "child"
+version = 2
+contract = "graph.v2"
+type = "workflow"
+extends = ["base"]
+
+[vars.interaction_mode]
+description = "Interaction mode"
+required = true
+
+[[steps]]
+id = "requirements"
+title = "Requirements"
+description_file = "requirements.md"
+`), 0o644); err != nil {
+		t.Fatalf("write child formula: %v", err)
+	}
+
+	vars := map[string]string{
+		"interaction_mode":  "autonomous",
+		"requirements_path": "artifacts/delivery/requirements.md",
+	}
+	recipe, err := Compile(context.Background(), "child", []string{dir}, vars)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	step := recipe.StepByID("child.requirements")
+	if step == nil {
+		t.Fatal("compiled recipe missing child.requirements")
+	}
+	rendered := Substitute(step.Description, vars)
+	for _, want := range []string{
+		"External Prompt Required",
+		promptPath,
+		`interaction_mode="autonomous"`,
+		`requirements_path="artifacts/delivery/requirements.md"`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("Description missing %q:\n%s", want, rendered)
+		}
+	}
+	for _, name := range []string{"interaction_mode", "requirements_path"} {
+		if got := strings.Count(rendered, name+"="); got != 1 {
+			t.Fatalf("Description contains %s assignment %d times, want once:\n%s", name, got, rendered)
+		}
+	}
+	if strings.Index(rendered, "interaction_mode=") > strings.Index(rendered, "requirements_path=") {
+		t.Fatalf("Formula variables are not sorted:\n%s", rendered)
 	}
 }
 

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -239,6 +239,12 @@ type Step struct {
 	// If both Description and DescriptionFile are set, DescriptionFile wins.
 	DescriptionFile string `json:"description_file,omitempty" toml:"description_file,omitempty"`
 
+	// descriptionFileReference retains the source of an oversized prompt after
+	// DescriptionFile is consumed. Resolve uses it to regenerate the compact
+	// reference after inherited variables have been composed. It is internal
+	// compiler state and must never be serialized into recipes or bead metadata.
+	descriptionFileReference *descriptionFileReference
+
 	// Notes are additional notes for the issue (supports substitution).
 	Notes string `json:"notes,omitempty"`
 


### PR DESCRIPTION
## Summary

- retain the source behind oversized description_file reference stubs
- regenerate those stubs after parent and child vars are fully composed
- clone before refresh so cached parent formulas remain immutable

## Why

Oversized description files are replaced with a compact reference during compilation. That reference was rendered before inherited vars were merged, so child formulas could emit a stale requirements path even though normal template fields saw the composed values.

## Verification

- RED on upstream base 8556a801c: the inherited requirements_path assertion failed
- GREEN: CGO_ENABLED=0 go test -count=1 ./internal/formula ./internal/dispatch
- pre-commit hook: lint, generated-reference checks, and go vet ./...
- independent exact-head review: APPROVE at ca3a9cbde2fa5bad314d8ea515da393e77ec09f2

The broad push gate has one unrelated baseline failure, TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails, reproduced unchanged on pristine upstream base.

Ported as the smallest proven slice from fork PR https://github.com/rbriski/gascity/pull/2.