### PR TITLE
fix(orders): isolate event triggers and persist cursor progress

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -558,6 +558,15 @@ type orderDispatchCandidate struct {
 	conditionResult *orders.TriggerResult
 }
 
+type pendingEventCursorCheckpoint struct {
+	order     orders.Order
+	scoped    string
+	front     *orders.Store
+	cursor    uint64
+	lastRunFn orders.LastRunFunc
+	opts      orders.TriggerOptions
+}
+
 // prefetchConditionResults runs every candidate condition check concurrently,
 // bounded by orderConditionCheckConcurrency.
 //
@@ -643,6 +652,10 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	}()
 	trackingIndex := newOrderDispatchTrackingIndex(m.stderr)
 	budgetSpent := 0
+	var pendingCursorCheckpoints []pendingEventCursorCheckpoint
+	defer func() {
+		m.flushEventCursorCheckpoints(ctx, now, pendingCursorCheckpoints)
+	}()
 
 	total := len(m.aa)
 	if total == 0 {
@@ -769,12 +782,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			return last, err
 		}
 		cursorFn := orders.CursorAcross(orderFrontDoorsForStores(storesForGate))
+		var eventCursor uint64
 		if a.Trigger == "event" {
 			cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
 			if err != nil {
 				logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
 				continue
 			}
+			eventCursor = cursor
 			cursorFn = func(string) uint64 {
 				return cursor
 			}
@@ -809,7 +824,16 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if cand.conditionResult != nil {
 			result = *cand.conditionResult
 		} else {
-			result = orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
+			var triggerErr error
+			result, triggerErr = checkOrderTriggerBounded(ctx, a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
+			if triggerErr != nil {
+				logDispatchError(m.stderr, "gc: order dispatch: evaluating trigger for %s: %v", a.ScopedName(), triggerErr)
+				continue
+			}
+		}
+		if result.Err != nil {
+			logDispatchError(m.stderr, "gc: order dispatch: evaluating trigger for %s: %v", a.ScopedName(), result.Err)
+			continue
 		}
 		if lastRunErr != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
@@ -835,6 +859,12 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			// (ga-ocypq2). Raise the order's check_timeout to fix.
 			if a.Trigger == "condition" && strings.Contains(result.Reason, orders.ConditionCheckTimedOutMarker) {
 				logDispatchError(m.stderr, "gc: order dispatch: %s %s — raise check_timeout if the check needs a slow store read", a.ScopedName(), result.Reason)
+			}
+			if a.Trigger == "event" && result.Cursor > eventCursor {
+				pendingCursorCheckpoints = append(pendingCursorCheckpoints, pendingEventCursorCheckpoint{
+					order: a, scoped: scoped, front: m.orderFrontDoorFor(store), cursor: result.Cursor,
+					lastRunFn: lastRunFn, opts: triggerOpts,
+				})
 			}
 			continue
 		}
@@ -916,6 +946,42 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
 		if spendDispatchBudget(idx) {
 			return
+		}
+	}
+}
+
+func (m *memoryOrderDispatcher) flushEventCursorCheckpoints(ctx context.Context, now time.Time, pending []pendingEventCursorCheckpoint) {
+	type createdCheckpoint struct {
+		pendingEventCursorCheckpoint
+		run orders.OrderRun
+	}
+	created := make([]createdCheckpoint, 0, len(pending))
+	for _, checkpoint := range pending {
+		run, err := checkpoint.front.CreateCursorCheckpoint(checkpoint.scoped, orders.EventCursor(checkpoint.cursor), "event trigger cursor advanced past controller bookkeeping events")
+		if err != nil {
+			logDispatchError(m.stderr, "gc: order dispatch: advancing event cursor for %s: %v", checkpoint.scoped, err)
+			continue
+		}
+		created = append(created, createdCheckpoint{pendingEventCursorCheckpoint: checkpoint, run: run})
+	}
+
+	// Create every checkpoint before re-reading the event log. Otherwise one
+	// event order can checkpoint before a peer creates its tracking bead, and
+	// the two orders generate cursor beads for each other forever.
+	for _, checkpoint := range created {
+		if checkpoint.order.On != events.BeadCreated && checkpoint.order.On != events.BeadClosed {
+			continue
+		}
+		post, postErr := checkOrderTriggerBounded(ctx, checkpoint.order, now, checkpoint.lastRunFn, m.ep, func(string) uint64 { return checkpoint.cursor }, checkpoint.opts)
+		switch {
+		case postErr != nil:
+			logDispatchError(m.stderr, "gc: order dispatch: verifying advanced event cursor for %s: %v", checkpoint.scoped, postErr)
+		case post.Err != nil:
+			logDispatchError(m.stderr, "gc: order dispatch: verifying advanced event cursor for %s: %v", checkpoint.scoped, post.Err)
+		case !post.Due && post.Cursor > checkpoint.cursor:
+			if err := checkpoint.front.AdvanceCursor(checkpoint.run.ID, checkpoint.scoped, orders.EventCursor(checkpoint.cursor), orders.EventCursor(post.Cursor)); err != nil {
+				logDispatchError(m.stderr, "gc: order dispatch: covering cursor bookkeeping event for %s: %v", checkpoint.scoped, err)
+			}
 		}
 	}
 }
@@ -2624,6 +2690,28 @@ func isOrderWispDescendantDepType(depType string) bool {
 // the rest of the sweep proceeds. Package-level var so it is tunable and
 // overridable in tests.
 var orderGateTimeout = 8 * time.Second
+
+// orderTriggerTimeout bounds event-provider reads, whose interface does not
+// accept a context, so one stalled order cannot starve peer dispatches.
+var orderTriggerTimeout = 8 * time.Second
+
+func checkOrderTriggerBounded(ctx context.Context, a orders.Order, now time.Time, lastRunFn orders.LastRunFunc, ep events.Provider, cursorFn orders.CursorFunc, opts orders.TriggerOptions) (orders.TriggerResult, error) {
+	if a.Trigger != "event" {
+		return orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, opts), nil
+	}
+	resultCh := make(chan orders.TriggerResult, 1)
+	go func() { resultCh <- orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, opts) }()
+	timer := time.NewTimer(orderTriggerTimeout)
+	defer timer.Stop()
+	select {
+	case result := <-resultCh:
+		return result, nil
+	case <-timer.C:
+		return orders.TriggerResult{}, fmt.Errorf("trigger evaluation timed out after %s", orderTriggerTimeout)
+	case <-ctx.Done():
+		return orders.TriggerResult{}, fmt.Errorf("trigger evaluation aborted: %w", ctx.Err())
+	}
+}
 
 // orderGateBackoffDuration is the suppression window set after a gate timeout,
 // anchored to the actual wall clock at the moment the timeout fires (not the

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -69,6 +70,27 @@ type eventCursorUpdateFailStore struct {
 
 type latestSeqFailProvider struct {
 	events.Provider
+}
+
+type blockingListEventProvider struct {
+	*events.Fake
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingListEventProvider() *blockingListEventProvider {
+	return &blockingListEventProvider{
+		Fake:    events.NewFake(),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *blockingListEventProvider) List(filter events.Filter) ([]events.Event, error) {
+	p.once.Do(func() { close(p.started) })
+	<-p.release
+	return p.Fake.List(filter)
 }
 
 type triggerEvaluationFailStore struct {
@@ -1672,6 +1694,240 @@ func TestOrderDispatchMultiple(t *testing.T) {
 	if trackingCount != 1 {
 		t.Errorf("expected 1 tracking bead for order-a, got %d", trackingCount)
 	}
+}
+
+func TestOrderDispatchBlockedEventTriggerDoesNotStarveCooldownPeer(t *testing.T) {
+	provider := newBlockingListEventProvider()
+	defer close(provider.release)
+	provider.Record(events.Event{Type: events.BeadCreated})
+
+	store := beads.NewMemStore()
+	var executions []string
+	ad := buildOrderDispatcherFromListExec([]orders.Order{
+		{Name: "blocked-event", Trigger: "event", On: events.BeadCreated, Exec: "true"},
+		{Name: "cooldown-peer", Trigger: "cooldown", Interval: "1m", Exec: "true"},
+	}, store, provider, func(_ context.Context, command, _ string, _ []string) ([]byte, error) {
+		executions = append(executions, command)
+		return nil, nil
+	}, events.Discard)
+	if ad == nil {
+		t.Fatal("expected dispatcher")
+	}
+	m := ad.(*memoryOrderDispatcher)
+	originalTimeout := orderTriggerTimeout
+	orderTriggerTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { orderTriggerTimeout = originalTimeout })
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	select {
+	case <-provider.started:
+	default:
+		t.Fatal("event trigger List was not evaluated")
+	}
+	m.drain(context.Background())
+
+	if len(executions) != 1 || executions[0] != "true" {
+		t.Fatalf("executions = %v, want cooldown peer to run despite blocked event trigger", executions)
+	}
+}
+
+func TestCheckOrderTriggerBoundedDoesNotCapConditionTimeout(t *testing.T) {
+	originalTimeout := orderTriggerTimeout
+	orderTriggerTimeout = time.Millisecond
+	t.Cleanup(func() { orderTriggerTimeout = originalTimeout })
+
+	a := orders.Order{
+		Name:         "slow-condition",
+		Trigger:      "condition",
+		Check:        "sleep 0.05",
+		CheckTimeout: "1s",
+	}
+	result, err := checkOrderTriggerBounded(
+		context.Background(),
+		a,
+		time.Now(),
+		func(string) (time.Time, error) { return time.Time{}, nil },
+		nil,
+		nil,
+		orders.TriggerOptions{ConditionTimeout: a.CheckTimeoutOrDefault()},
+	)
+	if err != nil {
+		t.Fatalf("checkOrderTriggerBounded() error = %v; event-read isolation must not cap condition check_timeout", err)
+	}
+	if !result.Due {
+		t.Fatalf("Due = false, want true; reason: %s", result.Reason)
+	}
+}
+
+func TestOrderDispatchEventTrackingOnlyPageAdvancesDurableCursor(t *testing.T) {
+	provider := events.NewFake()
+	provider.Record(events.Event{
+		Type:    events.BeadCreated,
+		Payload: mustMarshalOrderDispatchLabels(t, []string{labelOrderTracking}),
+	})
+	store := beads.NewMemStore()
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name: "event-order", Trigger: "event", On: events.BeadCreated, Exec: "true",
+	}}, store, provider, successfulExec, events.Discard)
+	if ad == nil {
+		t.Fatal("expected dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	runs := trackingBeads(t, store, "order-run:event-order")
+	if len(runs) != 1 {
+		t.Fatalf("cursor advance runs = %d, want 1", len(runs))
+	}
+	if !slicesContain(runs[0].Labels, "order:event-order") || !slicesContain(runs[0].Labels, "seq:1") {
+		t.Fatalf("cursor advance labels = %v, want order:event-order and seq:1", runs[0].Labels)
+	}
+	if runs[0].Status != "closed" {
+		t.Errorf("cursor advance status = %q, want closed", runs[0].Status)
+	}
+}
+
+func TestOrderDispatchEventCursorAdvanceDoesNotSelfRegenerate(t *testing.T) {
+	provider := events.NewFake()
+	backing := beads.NewMemStore()
+	store := beads.NewCachingStoreForTest(backing, func(eventType, _ string, payload json.RawMessage) {
+		provider.Record(events.Event{Type: eventType, Payload: payload})
+	})
+	provider.Record(events.Event{
+		Type:    events.BeadCreated,
+		Payload: mustMarshalOrderDispatchLabels(t, []string{labelOrderTracking}),
+	})
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name: "event-order", Trigger: "event", On: events.BeadCreated, Exec: "true",
+	}}, store, provider, successfulExec, events.Discard)
+	if ad == nil {
+		t.Fatal("expected dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	runs := trackingBeads(t, store, "order-run:event-order")
+	if len(runs) != 1 {
+		t.Fatalf("cursor advance runs after two ticks = %d, want 1; the cursor bead must cover its own bead.created event", len(runs))
+	}
+}
+
+func TestOrderDispatchPeerEventCursorCheckpointsDoNotRegenerate(t *testing.T) {
+	provider := events.NewFake()
+	backing := beads.NewMemStore()
+	store := beads.NewCachingStoreForTest(backing, func(eventType, _ string, payload json.RawMessage) {
+		provider.Record(events.Event{Type: eventType, Payload: payload})
+	})
+	provider.Record(events.Event{
+		Type:    events.BeadCreated,
+		Payload: mustMarshalOrderDispatchLabels(t, []string{labelOrderTracking}),
+	})
+	ad := buildOrderDispatcherFromListExec([]orders.Order{
+		{Name: "event-order-a", Trigger: "event", On: events.BeadCreated, Exec: "true"},
+		{Name: "event-order-b", Trigger: "event", On: events.BeadCreated, Exec: "true"},
+	}, store, provider, successfulExec, events.Discard)
+	if ad == nil {
+		t.Fatal("expected dispatcher")
+	}
+
+	for range 3 {
+		ad.dispatch(context.Background(), t.TempDir(), time.Now())
+		ad.drain(context.Background())
+	}
+
+	for _, name := range []string{"event-order-a", "event-order-b"} {
+		runs := trackingBeads(t, store, "order-run:"+name)
+		if len(runs) != 1 {
+			t.Fatalf("%s cursor advance runs after three ticks = %d, want 1; peer cursor beads must be covered in the same tick", name, len(runs))
+		}
+	}
+}
+
+func TestOrderDispatchEventCursorAdvancePreservesConcurrentRealEvent(t *testing.T) {
+	provider := events.NewFake()
+	backing := beads.NewMemStore()
+	injected := false
+	store := beads.NewCachingStoreForTest(backing, func(eventType, _ string, payload json.RawMessage) {
+		if eventType == events.BeadCreated && !injected {
+			var created struct {
+				Labels []string `json:"labels"`
+			}
+			if err := json.Unmarshal(payload, &created); err == nil && slicesContain(created.Labels, labelOrderTracking) {
+				injected = true
+				provider.Record(events.Event{Type: events.BeadCreated})
+			}
+		}
+		provider.Record(events.Event{Type: eventType, Payload: payload})
+	})
+	provider.Record(events.Event{
+		Type:    events.BeadCreated,
+		Payload: mustMarshalOrderDispatchLabels(t, []string{labelOrderTracking}),
+	})
+	executions := 0
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name: "event-order", Trigger: "event", On: events.BeadCreated, Exec: "true",
+	}}, store, provider, func(context.Context, string, string, []string) ([]byte, error) {
+		executions++
+		return nil, nil
+	}, events.Discard)
+	if ad == nil {
+		t.Fatal("expected dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	if executions != 1 {
+		t.Fatalf("executions = %d, want 1; a real event interleaved with cursor persistence must remain dispatchable", executions)
+	}
+}
+
+func TestOrderDispatchTrackingOnlyBeadUpdatedAdvancesWithoutRecursiveCursorRun(t *testing.T) {
+	provider := events.NewFake()
+	provider.Record(events.Event{
+		Type:    events.BeadUpdated,
+		Payload: mustMarshalOrderDispatchLabels(t, []string{labelOrderTracking}),
+	})
+	backing := beads.NewMemStore()
+	store := beads.NewCachingStoreForTest(backing, func(eventType, _ string, payload json.RawMessage) {
+		provider.Record(events.Event{Type: eventType, Payload: payload})
+	})
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name: "update-order", Trigger: "event", On: events.BeadUpdated, Exec: "true",
+	}}, store, provider, successfulExec, events.Discard)
+	if ad == nil {
+		t.Fatal("expected dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	runs := trackingBeads(t, store, "order-run:update-order")
+	if len(runs) != 1 {
+		t.Fatalf("cursor advance runs after two ticks = %d, want 1", len(runs))
+	}
+	if !slicesContain(runs[0].Labels, "seq:1") {
+		t.Fatalf("cursor labels = %v, want seq:1", runs[0].Labels)
+	}
+}
+
+func mustMarshalOrderDispatchLabels(t *testing.T, labels []string) []byte {
+	t.Helper()
+	data, err := json.Marshal(struct {
+		Labels []string `json:"labels"`
+	}{Labels: labels})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
 }
 
 func TestOrderDispatchRespectsMaxDispatchesPerTick(t *testing.T) {

--- a/internal/orders/store.go
+++ b/internal/orders/store.go
@@ -326,6 +326,21 @@ func (s *Store) SetCursor(runID, scoped string, cursor EventCursor) error {
 	return nil
 }
 
+// AdvanceCursor replaces a run's existing sequence label while preserving the
+// order label. Cursor checkpoints use it when their own bookkeeping events
+// move the durable cursor beyond the sequence stored at creation time.
+func (s *Store) AdvanceCursor(runID, scoped string, from, to EventCursor) error {
+	labels := []string{
+		labelOrderTitlePrefix + scoped,
+		fmt.Sprintf("%s%d", labelSeqPrefix, uint64(to)),
+	}
+	remove := []string{fmt.Sprintf("%s%d", labelSeqPrefix, uint64(from))}
+	if err := s.store.Update(runID, beads.UpdateOpts{Labels: labels, RemoveLabels: remove}); err != nil {
+		return fmt.Errorf("advancing order run cursor on %q: %w", runID, err)
+	}
+	return nil
+}
+
 // CloseRun closes a tracking bead, stamping close_reason so validation.on-close
 // cities accept it. Replaces the defer-Close / immediate-close sites in
 // cmd_order.go.
@@ -376,6 +391,25 @@ func (s *Store) CreateRunClosed(scoped string, outcome RunOutcome, cursor *Event
 	}
 	if err := s.CloseRun(created.ID, closeReason); err != nil {
 		return run, err
+	}
+	return run, nil
+}
+
+// CreateCursorCheckpoint records a consumed event cursor without a separate
+// update, avoiding recursive bead.updated event triggers.
+func (s *Store) CreateCursorCheckpoint(scoped string, cursor EventCursor, closeReason string) (OrderRun, error) {
+	labels := append(baseLabels(scoped, RunOutcomeNone), labelOrderTitlePrefix+scoped, fmt.Sprintf("%s%d", labelSeqPrefix, uint64(cursor)))
+	var metadata map[string]string
+	if closeReason != "" {
+		metadata = map[string]string{"close_reason": closeReason}
+	}
+	created, err := s.store.Create(beads.Bead{Title: trackingTitle(scoped), Labels: labels, Metadata: metadata, NoHistory: true})
+	if err != nil {
+		return OrderRun{}, fmt.Errorf("creating cursor checkpoint for %q: %w", scoped, err)
+	}
+	run := OrderRun{ID: created.ID, Scoped: scoped, CreatedAt: created.CreatedAt, Cursor: cursor}
+	if err := s.store.Close(created.ID); err != nil {
+		return run, fmt.Errorf("closing cursor checkpoint %q: %w", created.ID, err)
 	}
 	return run, nil
 }

--- a/internal/orders/store_test.go
+++ b/internal/orders/store_test.go
@@ -115,6 +115,26 @@ func TestSetCursorLabelPair(t *testing.T) {
 	}
 }
 
+func TestAdvanceCursorReplacesSequenceLabel(t *testing.T) {
+	st, rec := recordingOrdersStore()
+	seeded, err := st.store.Create(beads.Bead{Title: "order:rig/agent", Labels: []string{"order:rig/agent", "seq:7"}})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rec.Reset()
+
+	if err := st.AdvanceCursor(seeded.ID, "rig/agent", EventCursor(7), EventCursor(11)); err != nil {
+		t.Fatalf("AdvanceCursor: %v", err)
+	}
+	call := rec.CallsForOp("Update")[0].Opts
+	if want := []string{"order:rig/agent", "seq:11"}; !reflect.DeepEqual(call.Labels, want) {
+		t.Errorf("cursor labels = %v, want %v", call.Labels, want)
+	}
+	if want := []string{"seq:7"}; !reflect.DeepEqual(call.RemoveLabels, want) {
+		t.Errorf("removed labels = %v, want %v", call.RemoveLabels, want)
+	}
+}
+
 // TestCloseRunStampsReasonThenCloses proves CloseRun stamps close_reason then
 // closes — matching cmd_order.go's SetMetadata(close_reason)+Close.
 func TestCloseRunStampsReasonThenCloses(t *testing.T) {
@@ -199,6 +219,37 @@ func TestCreateRunClosedWithCursor(t *testing.T) {
 	}
 	if got := updates[1].Opts.Labels; !reflect.DeepEqual(got, []string{"exec"}) {
 		t.Errorf("outcome labels = %v, want [exec]", got)
+	}
+}
+
+func TestCreateCursorCheckpointDoesNotEmitUpdate(t *testing.T) {
+	st, rec := recordingOrdersStore()
+
+	run, err := st.CreateCursorCheckpoint("rig/agent", EventCursor(9), "tracking-only event page consumed")
+	if err != nil {
+		t.Fatalf("CreateCursorCheckpoint: %v", err)
+	}
+	if run.Open || run.Cursor != EventCursor(9) {
+		t.Fatalf("run = %+v, want closed cursor 9", run)
+	}
+
+	ops := make([]string, 0)
+	for _, c := range rec.Calls() {
+		ops = append(ops, c.Op)
+	}
+	if want := []string{"Create", "Close"}; !reflect.DeepEqual(ops, want) {
+		t.Fatalf("ops = %v, want %v; a cursor checkpoint must not emit bead.updated", ops, want)
+	}
+	create := rec.CallsForOp("Create")[0].Bead
+	wantLabels := []string{"order-run:rig/agent", "order-tracking", "order:rig/agent", "seq:9"}
+	if !reflect.DeepEqual(create.Labels, wantLabels) {
+		t.Errorf("labels = %v, want %v", create.Labels, wantLabels)
+	}
+	if create.Metadata["close_reason"] != "tracking-only event page consumed" {
+		t.Errorf("close_reason = %q", create.Metadata["close_reason"])
+	}
+	if !create.NoHistory {
+		t.Error("NoHistory = false, want true")
 	}
 }
 

--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -24,7 +24,13 @@ type TriggerResult struct {
 	Reason string
 	// LastRun is the last execution time (zero if never run).
 	LastRun time.Time
+	// Cursor is the highest event sequence inspected while evaluating an event trigger.
+	Cursor uint64
+	// Err records a trigger-read failure for the dispatcher to surface.
+	Err error
 }
+
+const eventTriggerScanLimit = 128
 
 // LastRunFunc returns the last run time for a named order.
 // Returns zero time and nil error if never run.
@@ -382,12 +388,17 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 	matched, err := ep.List(events.Filter{
 		Type:     a.On,
 		AfterSeq: cursor,
+		Limit:    eventTriggerScanLimit,
 	})
 	if err != nil {
-		return TriggerResult{Due: false, Reason: fmt.Sprintf("event: read error: %v", err)}
+		return TriggerResult{Due: false, Reason: fmt.Sprintf("event: read error: %v", err), Err: err}
 	}
 	var count int
+	var lastSeq uint64
 	for _, e := range matched {
+		if e.Seq > lastSeq {
+			lastSeq = e.Seq
+		}
 		// Exclude the dispatcher's own order-tracking bookkeeping beads so an event
 		// order never self-fires on lifecycle events emitted by those beads (#3720).
 		if !payloadHasLabel(e.Payload, labelOrderTracking) {
@@ -395,9 +406,9 @@ func checkEvent(a Order, ep events.Provider, cursorFn CursorFunc) TriggerResult 
 		}
 	}
 	if count == 0 {
-		return TriggerResult{Due: false, Reason: "event: no matching events"}
+		return TriggerResult{Due: false, Reason: "event: no matching events", Cursor: lastSeq}
 	}
-	return TriggerResult{Due: true, Reason: fmt.Sprintf("event: %d %s event(s)", count, a.On)}
+	return TriggerResult{Due: true, Reason: fmt.Sprintf("event: %d %s event(s)", count, a.On), Cursor: lastSeq}
 }
 
 // payloadHasLabel reports whether a JSON bead payload contains the given label.

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -387,6 +387,37 @@ func TestCheckTriggerEventDue(t *testing.T) {
 	}
 }
 
+type limitCapturingEventProvider struct {
+	events.Provider
+	filter events.Filter
+}
+
+func (p *limitCapturingEventProvider) List(filter events.Filter) ([]events.Event, error) {
+	p.filter = filter
+	return p.Provider.List(filter)
+}
+
+func TestCheckTriggerEventBoundsBacklogScan(t *testing.T) {
+	entries := make([]events.Event, eventTriggerScanLimit+1)
+	for i := range entries {
+		entries[i] = events.Event{Type: "bead.created"}
+	}
+	p := &limitCapturingEventProvider{Provider: newEventsProvider(t, entries)}
+	a := Order{Name: "notify", Trigger: "event", On: "bead.created"}
+
+	result := CheckTrigger(a, time.Time{}, neverRan, p, nil)
+
+	if !result.Due {
+		t.Fatalf("Due = false, want true; reason: %s", result.Reason)
+	}
+	if got, want := p.filter.Limit, eventTriggerScanLimit; got != want {
+		t.Errorf("event filter limit = %d, want %d", got, want)
+	}
+	if result.Cursor != eventTriggerScanLimit {
+		t.Errorf("cursor = %d, want %d", result.Cursor, eventTriggerScanLimit)
+	}
+}
+
 func TestCheckTriggerEventWithCursor(t *testing.T) {
 	ep := newEventsProvider(t, []events.Event{
 		{Type: "bead.closed"},


### PR DESCRIPTION
## Summary

- bound event-provider reads so one stalled event order cannot starve peer orders
- classify controller bookkeeping events without losing the durable page cursor
- persist tracking-only cursor checkpoints without recursive update events
- create all peer checkpoints before postchecking the final event-log head
- replace stale seq labels when a checkpoint advances

## Why

A tracking-only page could return not due without advancing durable state, causing the controller to rescan the same page forever. Persisting that cursor naively can create self-generated event churn; doing it per order also makes peer event orders generate checkpoints for each other forever.

## Verification

- RED on upstream base: the new cursor contract was absent; disabling checkpoint persistence made TestOrderDispatchEventTrackingOnlyPageAdvancesDurableCursor fail with 0 runs, want 1
- RED before the peer repair: TestOrderDispatchPeerEventCursorCheckpointsDoNotRegenerate produced 3 runs per order after 3 ticks
- GREEN: CGO_ENABLED=0 go test -count=1 ./internal/orders
- GREEN: focused order and event-trigger tests in ./cmd/gc
- pre-commit hook: lint, generated-reference checks, and go vet ./...
- independent exact-head review: APPROVE at 1027b735b13ec6a2e9a750fb8249d3ea574d500d

The broad push gate has one unrelated baseline failure, TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails, reproduced unchanged on pristine upstream base.

Ported from fork PR https://github.com/rbriski/gascity/pull/3.