### PR TITLE
fix(molecule): render frozen source specs safely

### DIFF
--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -164,6 +165,93 @@ func TestSpawnNextAttemptPreservesTopLevelStepContract(t *testing.T) {
 						t.Fatalf("gc.requirements_path = %q, want %q", got.Metadata["gc.requirements_path"], resultPath)
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestFrozenSpecShellValuedVarsSurviveCookAndRetryAttach(t *testing.T) {
+	t.Parallel()
+
+	const (
+		reportCommand = `publish --source "$DELIVERY_REPORT_DIR" --index reports.json`
+		setupCommand  = `export RUN_ID=${GC_SESSION_ID:-manual}`
+	)
+	wantDescription := "Run `" + reportCommand + "` after `" + setupCommand + "`."
+
+	formulaDir := t.TempDir()
+	formulaText := `
+formula = "shell-vars-retry"
+version = 2
+contract = "graph.v2"
+
+[vars.report_publish_command]
+required = true
+
+[vars.setup_command]
+required = true
+
+[[steps]]
+id = "requirements"
+title = "Write requirements"
+description = "Run ` + "`" + `{{report_publish_command}}` + "`" + ` after ` + "`" + `{{setup_command}}` + "`" + `."
+metadata = { report_publish_command = "{{report_publish_command}}", setup_command = "{{setup_command}}" }
+
+[steps.retry]
+max_attempts = 3
+on_exhausted = "hard_fail"
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "shell-vars-retry.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	for _, attempt := range []int{2, 3} {
+		t.Run("attempt_"+strconv.Itoa(attempt), func(t *testing.T) {
+			t.Parallel()
+			store := beads.NewMemStore()
+			result, err := molecule.Cook(t.Context(), store, "shell-vars-retry", []string{formulaDir}, molecule.Options{
+				Vars: map[string]string{
+					"report_publish_command": reportCommand,
+					"setup_command":          setupCommand,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Cook: %v", err)
+			}
+
+			control := mustGet(t, store, result.IDMapping["shell-vars-retry.requirements"])
+			if control.Metadata[beadmeta.SourceStepSpecMetadataKey] != "" {
+				t.Fatal("control unexpectedly contains an inline source spec")
+			}
+			spec, err := findSpecBead(store, control)
+			if err != nil {
+				t.Fatalf("findSpecBead: %v", err)
+			}
+			var frozen formula.Step
+			if err := json.Unmarshal([]byte(spec.Description), &frozen); err != nil {
+				t.Fatalf("frozen spec is invalid JSON: %v\n%s", err, spec.Description)
+			}
+			if frozen.Description != wantDescription {
+				t.Fatalf("frozen description = %q, want %q", frozen.Description, wantDescription)
+			}
+			if frozen.Metadata["report_publish_command"] != reportCommand || frozen.Metadata["setup_command"] != setupCommand {
+				t.Fatalf("frozen metadata = %#v, want exact shell-valued variables", frozen.Metadata)
+			}
+
+			if err := spawnNextAttempt(t.Context(), store, control, attempt, ProcessOptions{}); err != nil {
+				t.Fatalf("spawnNextAttempt: %v", err)
+			}
+			got := findAttemptByRef(t, store, result.RootID, "shell-vars-retry.requirements.attempt."+strconv.Itoa(attempt))
+			status, assignee := "in_progress", "test-worker"
+			if err := store.Update(got.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+				t.Fatalf("claim spawned attempt: %v", err)
+			}
+			got = mustGet(t, store, got.ID)
+			if got.Description != wantDescription {
+				t.Fatalf("claimed attempt description = %q, want %q", got.Description, wantDescription)
+			}
+			if got.Metadata["report_publish_command"] != reportCommand || got.Metadata["setup_command"] != setupCommand {
+				t.Fatalf("claimed attempt metadata = %#v, want exact shell-valued variables", got.Metadata)
 			}
 		})
 	}

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -8,6 +8,7 @@ package molecule
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -1336,7 +1337,7 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 
 	b := beads.Bead{
 		Title:       formula.Substitute(step.Title, vars),
-		Description: formula.Substitute(step.Description, vars),
+		Description: substituteStepDescription(step, vars),
 		Type:        stepType,
 		Priority:    resolveStepPriority(step, priorityOverride),
 		Labels:      substituteLabels(step.Labels, vars),
@@ -1355,6 +1356,48 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 	}
 
 	return b
+}
+
+// substituteStepDescription preserves source-spec JSON as structured data while
+// rendering variables in its string values. Plain text substitution can inject
+// quotes from a shell-valued variable directly into the serialized JSON and
+// leave retry/Ralph controls unable to deserialize their frozen source step.
+func substituteStepDescription(step formula.RecipeStep, vars map[string]string) string {
+	if step.Metadata[beadmeta.KindMetadataKey] != beadmeta.KindSpec || step.Description == "" {
+		return formula.Substitute(step.Description, vars)
+	}
+
+	var frozen any
+	if err := json.Unmarshal([]byte(step.Description), &frozen); err != nil {
+		// Preserve an already-invalid snapshot byte-for-byte. The control will
+		// report the original deserialization error instead of a second mutation.
+		return step.Description
+	}
+	frozen = substituteJSONStrings(frozen, vars)
+	rendered, err := json.Marshal(frozen)
+	if err != nil {
+		return step.Description
+	}
+	return string(rendered)
+}
+
+func substituteJSONStrings(value any, vars map[string]string) any {
+	switch value := value.(type) {
+	case string:
+		return formula.Substitute(value, vars)
+	case []any:
+		for i := range value {
+			value[i] = substituteJSONStrings(value[i], vars)
+		}
+		return value
+	case map[string]any:
+		for key, item := range value {
+			value[key] = substituteJSONStrings(item, vars)
+		}
+		return value
+	default:
+		return value
+	}
 }
 
 func preserveExecutableRootType(step formula.RecipeStep) bool {


### PR DESCRIPTION
## Summary

- decode frozen source-step specs as structured JSON
- substitute only JSON string values
- marshal the structure back to JSON after substitution
- preserve an already-invalid snapshot so the existing control error remains diagnostic

## Why

Whole-document template substitution injected shell-valued vars directly into serialized JSON. Values containing quotes could corrupt the frozen source spec, so later retry attachment failed while deserializing a snapshot that had been valid before rendering.

## Verification

- RED on upstream base: TestFrozenSpecShellValuedVarsSurviveCookAndRetryAttach failed with invalid JSON after shell quotes were substituted
- GREEN: CGO_ENABLED=0 go test -count=1 ./internal/molecule ./internal/dispatch
- pre-commit hook: lint, generated-reference checks, and go vet ./...
- independent exact-head review: APPROVE at 4327bd0c10ce3286e5beadb8293779f13b1a281e

The broad push gate has one unrelated baseline failure, TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails, reproduced unchanged on pristine upstream base.

Split from the proven source-spec portion of fork PR https://github.com/rbriski/gascity/pull/4.