### PR TITLE
fix(dispatch): fail closed on unscoped terminal controls

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -458,6 +458,13 @@ func quarantineControlFailureBead(store beads.Store, beadID string, cause error)
 		failureReason = "malformed_control_graph"
 	}
 	reason := controlQuarantineReason(cause, failureReason)
+	control, err := store.Get(beadID)
+	if err != nil {
+		return fmt.Errorf("loading control before quarantine: %w", err)
+	}
+	if _, err := dispatch.SkipBlockedWorkflowDependents(store, control); err != nil {
+		return fmt.Errorf("skipping downstream before quarantine: %w", err)
+	}
 	status := "closed"
 	if err := store.Update(beadID, beads.UpdateOpts{
 		Status: &status,

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2372,6 +2372,51 @@ func TestQuarantineControlFailureBeadClosesWithDiagnostics(t *testing.T) {
 	}
 }
 
+func TestQuarantineControlFailureBeadSkipsUnscopedDownstream(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWorkflow},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	control, err := store.Create(beads.Bead{
+		Title: "control",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:       beadmeta.KindRetry,
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	downstream, err := store.Create(beads.Bead{
+		Title: "plan",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey: root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create downstream: %v", err)
+	}
+	if err := store.DepAdd(downstream.ID, control.ID, "blocks"); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+
+	if err := quarantineControlFailureBead(store, control.ID, fmt.Errorf("%w: invalid spec", dispatch.ErrControlGraphMalformed)); err != nil {
+		t.Fatalf("quarantineControlFailureBead: %v", err)
+	}
+
+	got, err := store.Get(downstream.ID)
+	if err != nil {
+		t.Fatalf("get downstream: %v", err)
+	}
+	if got.Status != "closed" || got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomeSkipped {
+		t.Fatalf("downstream = status %q outcome %q, want closed/skipped", got.Status, got.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+}
+
 func TestQuarantineControlFailureBeadTruncatesReasonAtUTF8Boundary(t *testing.T) {
 	store := beads.NewMemStore()
 	control, err := store.Create(beads.Bead{

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -31,6 +31,9 @@ const (
 	// attemptHardFail closes the control as a terminal hard failure regardless
 	// of attempts remaining (only the retry classifier produces this).
 	attemptHardFail
+	// attemptCanceled closes the control as a terminal non-failure without
+	// scheduling another attempt.
+	attemptCanceled
 	// attemptContinue spawns the next attempt when attempts remain, or disposes
 	// of the exhausted control via the strategy when max_attempts is reached.
 	attemptContinue
@@ -96,10 +99,18 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 				beadmeta.FailedAttemptMetadataKey: strconv.Itoa(iterationNum),
 			}
 			clearControllerSpawnErrorMetadata(closeMetadata)
+			control, err := store.Get(beadID)
+			if err != nil {
+				return ControlResult{}, fmt.Errorf("%s: loading exhausted control: %w", beadID, err)
+			}
+			skipped, err := SkipBlockedWorkflowDependents(store, control)
+			if err != nil {
+				return ControlResult{}, fmt.Errorf("%s: skipping downstream after exhaustion: %w", beadID, err)
+			}
 			if err := updateMetadataAndClose(store, beadID, closeMetadata); err != nil {
 				return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", beadID, err)
 			}
-			return ControlResult{Processed: true, Action: "fail"}, nil
+			return ControlResult{Processed: true, Action: "fail", Skipped: skipped}, nil
 		},
 	}
 	return processAttemptControl(store, bead, opts, strategy)
@@ -177,6 +188,10 @@ func processAttemptControl(store beads.Store, bead beads.Bead, opts ProcessOptio
 			beadmeta.FinalDispositionMetadataKey: beadmeta.DispositionHardFail,
 		}
 		clearControllerSpawnErrorMetadata(closeMetadata)
+		skipped, err := SkipBlockedWorkflowDependents(store, bead)
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: skipping downstream after hard failure: %w", bead.ID, err)
+		}
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing hard-failed: %w", bead.ID, err)
 		}
@@ -184,7 +199,22 @@ func processAttemptControl(store beads.Store, bead beads.Bead, opts ProcessOptio
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
 		}
-		return ControlResult{Processed: true, Action: "hard-fail", Skipped: scopeResult.Skipped}, nil
+		return ControlResult{Processed: true, Action: "hard-fail", Skipped: skipped + scopeResult.Skipped}, nil
+
+	case attemptCanceled:
+		closeMetadata := map[string]string{
+			beadmeta.AttemptLogMetadataKey: attemptLog,
+			beadmeta.OutcomeMetadataKey:    beadmeta.OutcomeCanceled,
+		}
+		clearControllerSpawnErrorMetadata(closeMetadata)
+		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: closing canceled: %w", bead.ID, err)
+		}
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
+		}
+		return ControlResult{Processed: true, Action: "canceled", Skipped: scopeResult.Skipped}, nil
 
 	case attemptContinue:
 		if attemptNum >= maxAttempts {
@@ -252,8 +282,7 @@ func ensurePendingAttemptConverges(store beads.Store, bead, attempt beads.Bead, 
 }
 
 // evaluateRetryAttempt classifies a closed retry attempt via its worker-result
-// postconditions. classifyRetryAttempt only emits pass/hard/transient, so the
-// default branch is defensive.
+// postconditions. The default branch is defensive against classifier drift.
 func evaluateRetryAttempt(store beads.Store, bead, attempt beads.Bead, _ int, opts ProcessOptions) (attemptEvaluation, error) {
 	result, err := classifyRetryAttemptWithPostconditions(store, attempt, opts)
 	if err != nil {
@@ -265,6 +294,8 @@ func evaluateRetryAttempt(store beads.Store, bead, attempt beads.Bead, _ int, op
 		eval.disposition = attemptPass
 	case "hard":
 		eval.disposition = attemptHardFail
+	case "canceled":
+		eval.disposition = attemptCanceled
 	case "transient":
 		eval.disposition = attemptContinue
 	default:
@@ -386,8 +417,18 @@ func markControllerSpawnError(store beads.Store, beadID string, err error, opts 
 	metadata[beadmeta.ControllerErrorClassMetadataKey] = beadmeta.FailureClassHard
 	metadata[beadmeta.ControllerRetryableMetadataKey] = ""
 	metadata[beadmeta.FinalDispositionMetadataKey] = beadmeta.DispositionControllerError
+	// Preserve the diagnostic even if fail-closed propagation encounters a
+	// store error. The control remains open in that case, but the next observer
+	// can see why it is blocked instead of losing the originating failure.
 	if writeErr := store.SetMetadataBatch(beadID, metadata); writeErr != nil {
 		opts.tracef("controller-spawn-error bead=%s recording hard failure metadata failed err=%v", beadID, writeErr)
+	}
+	if control, getErr := store.Get(beadID); getErr != nil {
+		opts.tracef("controller-spawn-error bead=%s loading control for downstream skip failed err=%v", beadID, getErr)
+		return false
+	} else if _, skipErr := SkipBlockedWorkflowDependents(store, control); skipErr != nil {
+		opts.tracef("controller-spawn-error bead=%s skipping downstream failed err=%v", beadID, skipErr)
+		return false
 	}
 	if closeErr := setOutcomeAndClose(store, beadID, beadmeta.OutcomeFail); closeErr != nil {
 		opts.tracef("controller-spawn-error bead=%s closing failed bead failed err=%v", beadID, closeErr)
@@ -626,10 +667,111 @@ func handleRetryExhaustion(store beads.Store, beadID string, attemptNum int, rea
 		beadmeta.FinalDispositionMetadataKey: beadmeta.DispositionHardFail,
 	}
 	clearControllerSpawnErrorMetadata(closeMetadata)
+	control, err := store.Get(beadID)
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: loading exhausted control: %w", beadID, err)
+	}
+	skipped, err := SkipBlockedWorkflowDependents(store, control)
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: skipping downstream after exhaustion: %w", beadID, err)
+	}
 	if err := updateMetadataAndClose(store, beadID, closeMetadata); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", beadID, err)
 	}
-	return ControlResult{Processed: true, Action: "fail"}, nil
+	return ControlResult{Processed: true, Action: "fail", Skipped: skipped}, nil
+}
+
+// SkipBlockedWorkflowDependents fail-closes every open blocking-dependent
+// reachable from an unscoped terminal control before that control is closed.
+// Ordinary work is skipped, downstream scopes are aborted through their scope
+// convergence path, and structural controls remain runnable. Keeping the failed
+// control open until this finishes prevents status-only readiness from briefly
+// exposing downstream work. Scoped controls use abortScope instead.
+//
+// The operation is intentionally ordered for stores without atomic Tx support:
+// a partial failure may leave some dependents skipped, but it leaves the
+// control open and therefore cannot release the remainder.
+func SkipBlockedWorkflowDependents(store beads.Store, control beads.Bead) (int, error) {
+	if strings.TrimSpace(control.Metadata[beadmeta.ScopeRefMetadataKey]) != "" {
+		return 0, nil
+	}
+	rootID := strings.TrimSpace(control.Metadata[beadmeta.RootBeadIDMetadataKey])
+	if rootID == "" {
+		return 0, nil
+	}
+
+	seen := map[string]bool{control.ID: true}
+	queue := []string{control.ID}
+	pending := make(map[string]beads.Bead)
+	finalizers := make(map[string]beads.Bead)
+	scopes := make(map[string]beads.Bead)
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		deps, err := store.DepList(current, "up")
+		if err != nil {
+			return 0, fmt.Errorf("listing dependents of %s: %w", current, err)
+		}
+		for _, dep := range deps {
+			if dep.Type != "blocks" || seen[dep.IssueID] {
+				continue
+			}
+			dependent, err := store.Get(dep.IssueID)
+			if err != nil {
+				return 0, fmt.Errorf("loading dependent %s: %w", dep.IssueID, err)
+			}
+			if dependent.ID == rootID || strings.TrimSpace(dependent.Metadata[beadmeta.RootBeadIDMetadataKey]) != rootID {
+				continue
+			}
+			seen[dependent.ID] = true
+			queue = append(queue, dependent.ID)
+			if dependent.Status != "closed" {
+				kind := strings.TrimSpace(dependent.Metadata[beadmeta.KindMetadataKey])
+				scopeRef := strings.TrimSpace(dependent.Metadata[beadmeta.ScopeRefMetadataKey])
+				switch {
+				case kind == beadmeta.KindWorkflowFinalize:
+					finalizers[dependent.ID] = dependent
+				case scopeRef != "":
+					scopes[scopeRef] = dependent
+				case kind == beadmeta.KindScopeCheck, kind == beadmeta.KindDrain, kind == beadmeta.KindFanout, kind == beadmeta.KindScope:
+					// Structural nodes own graph convergence. Leave them runnable
+					// once the failed dependency closes instead of labeling them as
+					// ordinary skipped work.
+				default:
+					pending[dependent.ID] = dependent
+				}
+			}
+		}
+	}
+
+	skipped := 0
+	for _, scopeRef := range sortedPendingIDs(scopes) {
+		body, err := resolveScopeBodyOnce(store, rootID, scopeRef)
+		if err != nil {
+			return skipped, fmt.Errorf("resolving downstream scope %s: %w", scopeRef, err)
+		}
+		snapshot, err := loadScopeSnapshotWithBody(store, rootID, scopeRef, body)
+		if err != nil {
+			return skipped, fmt.Errorf("loading downstream scope %s: %w", scopeRef, err)
+		}
+		n, err := abortScope(store, snapshot, ProcessOptions{}, control.ID)
+		skipped += n
+		if err != nil {
+			return skipped, fmt.Errorf("aborting downstream scope %s: %w", scopeRef, err)
+		}
+	}
+
+	// Keep workflow finalizers runnable so they can close the root and clean up
+	// sidecars/artifacts. A direct edge to the failed control lets outcome
+	// aggregation observe the terminal failure after intermediate work is
+	// skipped.
+	for _, finalizerID := range sortedPendingIDs(finalizers) {
+		if err := ensureBlockingDependency(store, finalizerID, control.ID); err != nil {
+			return skipped, fmt.Errorf("linking finalizer %s to failed control %s: %w", finalizerID, control.ID, err)
+		}
+	}
+	n, err := skipScopeMembers(store, sortedPendingIDs(pending))
+	return skipped + n, err
 }
 
 // spawnNextAttempt deserializes the frozen step spec, builds an attempt recipe,

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -487,6 +487,377 @@ func TestProcessRetryControlHardFail(t *testing.T) {
 	}
 }
 
+func TestProcessRetryControlHardFailSkipsUnscopedDownstream(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "requirements",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.requirements",
+			"gc.step_id":          "requirements",
+			"gc.max_attempts":     "1",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"requirements","title":"Requirements","type":"task","retry":{"max_attempts":1}}`,
+		},
+	})
+	attempt := mustCreate(t, store, beads.Bead{
+		Title: "requirements attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id":   root.ID,
+			"gc.step_ref":       "mol-test.requirements.attempt.1",
+			"gc.attempt":        "1",
+			"gc.outcome":        "fail",
+			"gc.failure_class":  "hard",
+			"gc.failure_reason": "invalid_spec",
+		},
+	})
+	downstream := mustCreate(t, store, beads.Bead{
+		Title: "plan",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.plan",
+		},
+	})
+	finalizer := mustCreate(t, store, beads.Bead{
+		Title: "finalize",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.workflow-finalize",
+		},
+	})
+	mustClose(t, store, attempt.ID)
+	mustDep(t, store, control.ID, attempt.ID, "blocks")
+	mustDep(t, store, downstream.ID, control.ID, "blocks")
+	mustDep(t, store, finalizer.ID, downstream.ID, "blocks")
+	mustDep(t, store, root.ID, finalizer.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if result.Action != "hard-fail" || result.Skipped != 1 {
+		t.Fatalf("result = %+v, want hard-fail with one skipped downstream bead", result)
+	}
+	gotDownstream := mustGet(t, store, downstream.ID)
+	if gotDownstream.Status != "closed" || gotDownstream.Metadata["gc.outcome"] != "skipped" {
+		t.Fatalf("downstream = status %q outcome %q, want closed/skipped", gotDownstream.Status, gotDownstream.Metadata["gc.outcome"])
+	}
+	if mustReadyContains(t, store, downstream.ID) {
+		t.Fatal("ordinary downstream work is ready after hard failure")
+	}
+	if !mustReadyContains(t, store, finalizer.ID) {
+		t.Fatal("workflow finalizer is not ready after downstream skip")
+	}
+
+	finalizeResult, err := ProcessControl(store, mustGet(t, store, finalizer.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if finalizeResult.Action != "workflow-fail" {
+		t.Fatalf("finalize result = %+v, want workflow-fail", finalizeResult)
+	}
+	gotRoot := mustGet(t, store, root.ID)
+	if gotRoot.Status != "closed" || gotRoot.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("root = status %q outcome %q, want closed/fail", gotRoot.Status, gotRoot.Metadata["gc.outcome"])
+	}
+	gotFinalizer := mustGet(t, store, finalizer.ID)
+	if gotFinalizer.Status != "closed" || gotFinalizer.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("finalizer = status %q outcome %q, want closed/pass", gotFinalizer.Status, gotFinalizer.Metadata["gc.outcome"])
+	}
+}
+
+func TestProcessRetryControlHardFailAbortsDownstreamScope(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+	}})
+	control := mustCreate(t, store, beads.Bead{Title: "requirements", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:           beadmeta.KindRetry,
+		beadmeta.RootBeadIDMetadataKey:     root.ID,
+		beadmeta.StepRefMetadataKey:        "mol-test.requirements",
+		beadmeta.StepIDMetadataKey:         "requirements",
+		beadmeta.MaxAttemptsMetadataKey:    "1",
+		beadmeta.OnExhaustedMetadataKey:    "hard_fail",
+		beadmeta.SourceStepSpecMetadataKey: `{"id":"requirements","title":"Requirements","type":"task","retry":{"max_attempts":1}}`,
+	}})
+	attempt := mustCreate(t, store, beads.Bead{Title: "requirements attempt 1", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey:    root.ID,
+		beadmeta.StepRefMetadataKey:       "mol-test.requirements.attempt.1",
+		beadmeta.AttemptMetadataKey:       "1",
+		beadmeta.OutcomeMetadataKey:       beadmeta.OutcomeFail,
+		beadmeta.FailureClassMetadataKey:  beadmeta.FailureClassHard,
+		beadmeta.FailureReasonMetadataKey: "invalid_spec",
+	}})
+	body := mustCreate(t, store, beads.Bead{Title: "scoped work", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:       beadmeta.KindScope,
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.ScopeRefMetadataKey:   "mol-test.scoped-work",
+		beadmeta.ScopeRoleMetadataKey:  beadmeta.ScopeRoleBody,
+	}})
+	member := mustCreate(t, store, beads.Bead{Title: "scope member", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.ScopeRefMetadataKey:   "mol-test.scoped-work",
+		beadmeta.ScopeRoleMetadataKey:  beadmeta.ScopeRoleMember,
+	}})
+	drain := mustCreate(t, store, beads.Bead{Title: "scope drain", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:       beadmeta.KindDrain,
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.ScopeRefMetadataKey:   "mol-test.scoped-work",
+		beadmeta.ScopeRoleMetadataKey:  beadmeta.ScopeRoleMember,
+	}})
+	finalizer := mustCreate(t, store, beads.Bead{Title: "finalize", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:       beadmeta.KindWorkflowFinalize,
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+	}})
+	mustClose(t, store, attempt.ID)
+	mustDep(t, store, control.ID, attempt.ID, "blocks")
+	mustDep(t, store, member.ID, control.ID, "blocks")
+	mustDep(t, store, drain.ID, member.ID, "blocks")
+	mustDep(t, store, body.ID, drain.ID, "blocks")
+	mustDep(t, store, finalizer.ID, body.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if result.Action != "hard-fail" {
+		t.Fatalf("result = %+v, want hard-fail", result)
+	}
+	gotBody := mustGet(t, store, body.ID)
+	if gotBody.Status != "closed" || gotBody.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomeFail {
+		t.Fatalf("scope body = status %q outcome %q, want closed/fail", gotBody.Status, gotBody.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+	for _, id := range []string{member.ID, drain.ID} {
+		got := mustGet(t, store, id)
+		if got.Status != "closed" || got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomeSkipped {
+			t.Fatalf("scope member %s = status %q outcome %q, want closed/skipped", id, got.Status, got.Metadata[beadmeta.OutcomeMetadataKey])
+		}
+	}
+	if mustReadyContains(t, store, body.ID) {
+		t.Fatal("scope body became ready instead of being failed by scope abort")
+	}
+	if !mustReadyContains(t, store, finalizer.ID) {
+		t.Fatal("workflow finalizer is not ready after downstream scope abort")
+	}
+}
+
+func TestProcessRetryControlHardFailSkipsDownstreamRetryControl(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+	}})
+	upstream := mustCreate(t, store, beads.Bead{Title: "requirements", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:           beadmeta.KindRetry,
+		beadmeta.RootBeadIDMetadataKey:     root.ID,
+		beadmeta.StepRefMetadataKey:        "mol-test.requirements",
+		beadmeta.MaxAttemptsMetadataKey:    "1",
+		beadmeta.OnExhaustedMetadataKey:    "hard_fail",
+		beadmeta.SourceStepSpecMetadataKey: `{"id":"requirements","title":"Requirements","type":"task","retry":{"max_attempts":1}}`,
+	}})
+	upstreamAttempt := mustCreate(t, store, beads.Bead{Title: "requirements attempt 1", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey:    root.ID,
+		beadmeta.StepRefMetadataKey:       "mol-test.requirements.attempt.1",
+		beadmeta.AttemptMetadataKey:       "1",
+		beadmeta.OutcomeMetadataKey:       beadmeta.OutcomeFail,
+		beadmeta.FailureClassMetadataKey:  beadmeta.FailureClassHard,
+		beadmeta.FailureReasonMetadataKey: "invalid_spec",
+	}})
+	downstream := mustCreate(t, store, beads.Bead{Title: "implementation", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:           beadmeta.KindRetry,
+		beadmeta.RootBeadIDMetadataKey:     root.ID,
+		beadmeta.StepRefMetadataKey:        "mol-test.implementation",
+		beadmeta.MaxAttemptsMetadataKey:    "3",
+		beadmeta.OnExhaustedMetadataKey:    "hard_fail",
+		beadmeta.SourceStepSpecMetadataKey: `{"id":"implementation","title":"Implementation","type":"task","retry":{"max_attempts":3}}`,
+	}})
+	downstreamAttempt := mustCreate(t, store, beads.Bead{Title: "implementation attempt 1", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.StepRefMetadataKey:    "mol-test.implementation.attempt.1",
+		beadmeta.AttemptMetadataKey:    "1",
+	}})
+	mustClose(t, store, upstreamAttempt.ID)
+	mustDep(t, store, upstream.ID, upstreamAttempt.ID, "blocks")
+	mustDep(t, store, downstream.ID, upstream.ID, "blocks")
+	mustDep(t, store, downstream.ID, downstreamAttempt.ID, "blocks")
+	mustDep(t, store, downstreamAttempt.ID, upstream.ID, "blocks")
+
+	if _, err := processRetryControl(store, mustGet(t, store, upstream.ID), ProcessOptions{}); err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	for _, id := range []string{downstream.ID, downstreamAttempt.ID} {
+		got := mustGet(t, store, id)
+		if got.Status != "closed" || got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomeSkipped {
+			t.Fatalf("downstream retry bead %s = status %q outcome %q, want closed/skipped", id, got.Status, got.Metadata[beadmeta.OutcomeMetadataKey])
+		}
+	}
+	all, err := beads.DirectMembers(store, root.ID)
+	if err != nil {
+		t.Fatalf("list workflow members: %v", err)
+	}
+	for _, bead := range all {
+		if bead.Metadata[beadmeta.StepRefMetadataKey] == "mol-test.implementation.attempt.2" {
+			t.Fatalf("downstream retry spawned attempt 2 after upstream hard failure: %s", bead.ID)
+		}
+	}
+}
+
+func TestProcessRetryControlSkippedAttemptDoesNotRetry(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+	}})
+	control := mustCreate(t, store, beads.Bead{Title: "implementation", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:           beadmeta.KindRetry,
+		beadmeta.RootBeadIDMetadataKey:     root.ID,
+		beadmeta.StepRefMetadataKey:        "mol-test.implementation",
+		beadmeta.MaxAttemptsMetadataKey:    "3",
+		beadmeta.OnExhaustedMetadataKey:    "hard_fail",
+		beadmeta.SourceStepSpecMetadataKey: `{"id":"implementation","title":"Implementation","type":"task","retry":{"max_attempts":3}}`,
+	}})
+	attempt := mustCreate(t, store, beads.Bead{Title: "implementation attempt 1", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+		beadmeta.StepRefMetadataKey:    "mol-test.implementation.attempt.1",
+		beadmeta.AttemptMetadataKey:    "1",
+		beadmeta.OutcomeMetadataKey:    beadmeta.OutcomeSkipped,
+	}})
+	mustClose(t, store, attempt.ID)
+	mustDep(t, store, control.ID, attempt.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if result.Action != "canceled" {
+		t.Fatalf("result = %+v, want canceled", result)
+	}
+	after := mustGet(t, store, control.ID)
+	if after.Status != "closed" || after.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomeCanceled {
+		t.Fatalf("control = status %q outcome %q, want closed/canceled", after.Status, after.Metadata[beadmeta.OutcomeMetadataKey])
+	}
+	all, err := beads.DirectMembers(store, root.ID)
+	if err != nil {
+		t.Fatalf("list workflow members: %v", err)
+	}
+	for _, bead := range all {
+		if bead.Metadata[beadmeta.StepRefMetadataKey] == "mol-test.implementation.attempt.2" {
+			t.Fatalf("skipped attempt spawned retry attempt 2: %s", bead.ID)
+		}
+	}
+}
+
+func TestProcessRetryControlSkipFailureLeavesControlBlockingRemainingWork(t *testing.T) {
+	t.Parallel()
+	base := beads.NewMemStore()
+
+	root := mustCreate(t, base, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, base, beads.Bead{
+		Title: "requirements",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.requirements",
+			"gc.step_id":          "requirements",
+			"gc.max_attempts":     "1",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"requirements","title":"Requirements","type":"task","retry":{"max_attempts":1}}`,
+		},
+	})
+	attempt := mustCreate(t, base, beads.Bead{
+		Title: "requirements attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id":   root.ID,
+			"gc.step_ref":       "mol-test.requirements.attempt.1",
+			"gc.attempt":        "1",
+			"gc.outcome":        "fail",
+			"gc.failure_class":  "hard",
+			"gc.failure_reason": "invalid_spec",
+		},
+	})
+	first := mustCreate(t, base, beads.Bead{
+		Title:    "first downstream",
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	remaining := mustCreate(t, base, beads.Bead{
+		Title:    "remaining downstream",
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	mustClose(t, base, attempt.ID)
+	mustDep(t, base, control.ID, attempt.ID, "blocks")
+	mustDep(t, base, first.ID, control.ID, "blocks")
+	mustDep(t, base, remaining.ID, control.ID, "blocks")
+
+	store := &failCloseForBeadStore{
+		Store:  base,
+		beadID: remaining.ID,
+		err:    errors.New("injected downstream close failure"),
+	}
+	if _, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{}); err == nil {
+		t.Fatal("processRetryControl unexpectedly succeeded")
+	}
+
+	gotControl := mustGet(t, store, control.ID)
+	if gotControl.Status == "closed" {
+		t.Fatal("control closed after a partial downstream skip failure")
+	}
+	gotFirst := mustGet(t, store, first.ID)
+	if gotFirst.Status != "closed" || gotFirst.Metadata["gc.outcome"] != "skipped" {
+		t.Fatalf("first downstream = status %q outcome %q, want closed/skipped", gotFirst.Status, gotFirst.Metadata["gc.outcome"])
+	}
+	gotRemaining := mustGet(t, store, remaining.ID)
+	if gotRemaining.Status != "open" {
+		t.Fatalf("remaining downstream status = %q, want open", gotRemaining.Status)
+	}
+	if mustReadyContains(t, store, remaining.ID) {
+		t.Fatal("remaining downstream became ready while failed control stayed open")
+	}
+}
+
+func TestMarkControllerSpawnErrorPreservesDiagnosticsWhenDownstreamSkipFails(t *testing.T) {
+	t.Parallel()
+	base := beads.NewMemStore()
+	root := mustCreate(t, base, beads.Bead{Title: "workflow", Metadata: map[string]string{
+		beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+	}})
+	control := mustCreate(t, base, beads.Bead{Title: "control", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:       beadmeta.KindRetry,
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+	}})
+	downstream := mustCreate(t, base, beads.Bead{Title: "downstream", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey: root.ID,
+	}})
+	mustDep(t, base, downstream.ID, control.ID, "blocks")
+	store := &failCloseForBeadStore{Store: base, beadID: downstream.ID, err: errors.New("injected close failure")}
+
+	if retryable := markControllerSpawnError(store, control.ID, errors.New("invalid frozen spec"), ProcessOptions{}); retryable {
+		t.Fatal("hard controller error marked retryable")
+	}
+	after := mustGet(t, store, control.ID)
+	if after.Status == "closed" {
+		t.Fatal("control closed despite downstream skip failure")
+	}
+	if after.Metadata[beadmeta.ControllerErrorMetadataKey] != "invalid frozen spec" {
+		t.Fatalf("controller error = %q, want preserved root cause", after.Metadata[beadmeta.ControllerErrorMetadataKey])
+	}
+	if after.Metadata[beadmeta.FinalDispositionMetadataKey] != beadmeta.DispositionControllerError {
+		t.Fatalf("final disposition = %q, want controller_error", after.Metadata[beadmeta.FinalDispositionMetadataKey])
+	}
+}
+
 func TestProcessRetryControlTransientRetry(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
@@ -2987,6 +3358,27 @@ func mustDep(t *testing.T, store beads.Store, from, to, depType string) { //noli
 type listFailStore struct {
 	beads.Store
 	err error
+}
+
+type failCloseForBeadStore struct {
+	beads.Store
+	beadID string
+	err    error
+}
+
+func (s *failCloseForBeadStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	closed := 0
+	for _, id := range ids {
+		if id == s.beadID {
+			return closed, s.err
+		}
+		n, err := s.Store.CloseAll([]string{id}, metadata)
+		closed += n
+		if err != nil {
+			return closed, err
+		}
+	}
+	return closed, nil
 }
 
 func (s *listFailStore) List(beads.ListQuery) ([]beads.Bead, error) {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -354,9 +354,11 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 		default:
 			return retryEvalResult{Outcome: "transient", Reason: "unknown_failure_class"}
 		}
-	case beadmeta.OutcomeCanceled:
-		// A canceled attempt subject (its run was canceled via the API) is a
-		// terminal non-failure: do not schedule another attempt.
+	case beadmeta.OutcomeCanceled, beadmeta.OutcomeSkipped:
+		// A canceled or skipped attempt subject is a terminal non-failure: do
+		// not schedule another attempt. Skipped normally closes its logical
+		// control too; accepting it here keeps a partially observed graph from
+		// resurrecting downstream work.
 		return retryEvalResult{Outcome: "canceled"}
 	case "":
 		return retryEvalResult{Outcome: "transient", Reason: "missing_outcome"}

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -338,6 +338,18 @@ func TestClassifyRetryAttemptCanceledIsTerminalNonRetry(t *testing.T) {
 	}
 }
 
+func TestClassifyRetryAttemptSkippedIsTerminalNonRetry(t *testing.T) {
+	t.Parallel()
+
+	got := classifyRetryAttempt(beads.Bead{
+		Metadata: map[string]string{beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped},
+	})
+	want := retryEvalResult{Outcome: "canceled"}
+	if got != want {
+		t.Fatalf("classifyRetryAttempt(skipped) = %+v, want %+v", got, want)
+	}
+}
+
 // TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome pins strict validation
 // of the typed close that reproduces gc-e2xqk.
 func TestClassifyRetryAttemptConsumesTypedCoordinatorOutcome(t *testing.T) {


### PR DESCRIPTION
## Summary

- skip ordinary downstream work before closing an unscoped terminal control
- abort downstream scopes through the existing scope convergence path
- leave only true convergence controls runnable
- keep workflow finalizers runnable with an idempotent direct failure edge
- preserve controller-error diagnostics when propagation fails
- treat an observed skipped retry attempt as terminal so it cannot spawn another attempt

## Why

Closing an unscoped hard-failed or quarantined control could make status-only downstream work ready. A first implementation skipped every dependent, but that bypassed scope semantics; a broad control exemption then exposed a fail-open where a downstream retry control could reactivate and spawn attempt 2. This version distinguishes ordinary work, scopes, convergence controls, work-driving controls, and finalizers.

## Verification

- RED on upstream base: downstream work remained open instead of closed skipped
- RED scope regression: the scope body closed skipped instead of fail
- RED retry-chain regression: a downstream retry control remained open and could reactivate
- GREEN: CGO_ENABLED=0 go test -count=1 ./internal/dispatch
- GREEN: focused convoy, control, and quarantine tests in ./cmd/gc
- pre-commit hook: lint, generated-reference checks, and go vet ./...
- independent exact-head review: APPROVE at cb256f2155f83288453e222263dc019e373e2e71

The broad push gate has one unrelated baseline failure, TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails, reproduced unchanged on pristine upstream base.

Split from the proven terminal-control portion of fork PR https://github.com/rbriski/gascity/pull/4.