### PR TITLE
Say so when a configured idle_timeout cannot be enforced

### DIFF
--- a/cmd/gc/idle_tracker.go
+++ b/cmd/gc/idle_tracker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"sync"
 	"time"
 
@@ -54,6 +55,7 @@ type memoryIdleTracker struct {
 	timeouts                   map[string]time.Duration // session name → idle timeout
 	templateTimeouts           map[string]time.Duration // agent template → idle timeout
 	templateFallbackExemptions map[string]bool          // session name → skip template fallback
+	reportedUnenforceable      map[string]bool          // session name → already warned that idle_timeout cannot fire
 }
 
 // newIdleTracker creates an idle tracker. Returns nil if disabled.
@@ -109,9 +111,50 @@ func (m *memoryIdleTracker) checkIdle(sessionName, template string, sp runtime.P
 	if !ok || timeout <= 0 {
 		return false
 	}
+	// A provider that cannot report activity makes idle_timeout inert, and
+	// silently: GetLastActivity returns the zero time with a NIL error, which is
+	// indistinguishable here from "active just now". checkIdle then returns
+	// false on every tick forever, DecideIdleTimeout is never entered, and the
+	// consecutive-defer backstop it feeds can never fire either. A session that
+	// stops mid-bead becomes immortal and keeps its claim (ga-7ye, root cause of
+	// ga-0nf: six workers held beads for 3-5 hours with idle_timeout=5m set).
+	//
+	// The capability is declared honestly by every provider and was consulted by
+	// nothing. Consult it here, and say so once per session — a configured
+	// timeout that cannot fire is an operator-visible misconfiguration, not a
+	// detail to swallow.
+	if sp != nil && !sp.Capabilities().CanReportActivity {
+		m.reportUnenforceable(sessionName, "provider cannot report activity", timeout)
+		return false
+	}
 	lastActivity, err := workerSessionTargetLastActivityWithConfig("", nil, sp, nil, sessionName)
-	if err != nil || lastActivity.IsZero() {
+	if err != nil {
+		m.reportUnenforceable(sessionName, "last-activity lookup failed: "+err.Error(), timeout)
+		return false
+	}
+	if lastActivity.IsZero() {
+		m.reportUnenforceable(sessionName, "provider reported no activity timestamp", timeout)
 		return false
 	}
 	return now.Sub(lastActivity) > timeout
+}
+
+// reportUnenforceable logs, once per session, that a configured idle_timeout
+// cannot be evaluated. Once rather than per tick: the reconciler runs this on
+// every session every cycle, so an unconditional log would bury the fleet in
+// the same line and get filtered out, which is how it stayed invisible.
+func (m *memoryIdleTracker) reportUnenforceable(sessionName, why string, timeout time.Duration) {
+	m.mu.Lock()
+	if m.reportedUnenforceable == nil {
+		m.reportedUnenforceable = make(map[string]bool)
+	}
+	already := m.reportedUnenforceable[sessionName]
+	m.reportedUnenforceable[sessionName] = true
+	m.mu.Unlock()
+	if already {
+		return
+	}
+	log.Printf("idle_timeout=%s configured for session %q but cannot be enforced: %s. "+
+		"The session will never be idle-stopped, and a session that stops mid-bead will hold its claim indefinitely. See ga-7ye.",
+		timeout, sessionName, why)
 }

--- a/cmd/gc/idle_tracker_unenforceable_test.go
+++ b/cmd/gc/idle_tracker_unenforceable_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// noActivityProvider mirrors the herdr provider's real contract: it declares
+// CanReportActivity false and returns the ZERO time with a NIL error. The nil
+// error is the important half — it is what made this indistinguishable from
+// "active just now" and kept the failure silent (ga-7ye).
+type noActivityProvider struct{ runtime.Provider }
+
+func (noActivityProvider) Capabilities() runtime.ProviderCapabilities {
+	return runtime.ProviderCapabilities{CanReportActivity: false}
+}
+
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() { log.SetOutput(prevOut); log.SetFlags(prevFlags) }()
+	fn()
+	return buf.String()
+}
+
+// TestCheckIdleReportsUnenforceableTimeout is the gate for ga-7ye. celilo ran
+// provider="herdr" with idle_timeout="5m" for months; herdr cannot report
+// activity, so checkIdle returned false on every tick, DecideIdleTimeout was
+// never entered, and six workers held in_progress beads for 3-5 hours. Across
+// 1,208,783 trace records on that city the idle ladder had produced no decision
+// of any kind. The setting was accepted, stored, and inert, with no diagnostic.
+func TestCheckIdleReportsUnenforceableTimeout(t *testing.T) {
+	tr := newIdleTracker()
+	tr.setTimeout("worker-1", 5*time.Minute)
+
+	var idle bool
+	out := captureLog(t, func() {
+		idle = tr.checkIdle("worker-1", "tmpl", noActivityProvider{}, time.Now())
+	})
+
+	if idle {
+		t.Fatal("a session whose activity cannot be measured must not be reported idle")
+	}
+	if !strings.Contains(out, "cannot be enforced") {
+		t.Fatalf("silent inert idle_timeout: no diagnostic logged.\ngot: %q", out)
+	}
+	for _, want := range []string{"worker-1", "5m0s", "ga-7ye"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diagnostic must name %q so an operator can act on it; got: %q", want, out)
+		}
+	}
+}
+
+// The reconciler calls checkIdle for every session every cycle. An
+// unconditional log would emit the same line thousands of times an hour and be
+// filtered out as noise, which is the failure mode this is meant to escape.
+func TestCheckIdleReportsUnenforceableOncePerSession(t *testing.T) {
+	tr := newIdleTracker()
+	tr.setTimeout("worker-1", time.Minute)
+
+	out := captureLog(t, func() {
+		for i := 0; i < 50; i++ {
+			tr.checkIdle("worker-1", "tmpl", noActivityProvider{}, time.Now())
+		}
+	})
+
+	if got := strings.Count(out, "cannot be enforced"); got != 1 {
+		t.Fatalf("logged %d times across 50 ticks, want exactly 1", got)
+	}
+}
+
+// The CAPABILITY diagnostic must not fire on a provider that reports activity,
+// or every healthy city gets the line and learns to ignore it.
+//
+// Scoped to the capability branch on purpose. The later "no activity timestamp"
+// branch is not reachable from here: the lookup resolves a worker handle rather
+// than querying the provider by bare session name, so a standalone Fake never
+// gets asked. That branch is exercised in the herdr-shaped case above, where the
+// capability gate short-circuits before it. Asserting on the generic text would
+// make this test pass for the wrong reason.
+func TestCheckIdleStaysQuietWhenProviderCanReportActivity(t *testing.T) {
+	tr := newIdleTracker()
+	tr.setTimeout("worker-1", time.Minute)
+
+	// runtime.Fake declares CanReportActivity true and answers with a real
+	// timestamp, which is what a healthy provider looks like.
+	fake := runtime.NewFake()
+	fake.Activity = map[string]time.Time{"worker-1": time.Now()}
+
+	out := captureLog(t, func() {
+		tr.checkIdle("worker-1", "tmpl", fake, time.Now())
+	})
+
+	if strings.Contains(out, "provider cannot report activity") {
+		t.Fatalf("capability diagnostic fired on a provider that reports activity; got: %q", out)
+	}
+}
+
+// No timeout configured is not a misconfiguration, so it must stay silent.
+func TestCheckIdleStaysQuietWithNoTimeoutConfigured(t *testing.T) {
+	tr := newIdleTracker()
+	out := captureLog(t, func() {
+		tr.checkIdle("worker-1", "tmpl", noActivityProvider{}, time.Now())
+	})
+	if out != "" {
+		t.Fatalf("no idle_timeout configured means nothing to warn about; got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

A city ran `provider = "herdr"` with `idle_timeout = "5m"` patched onto its worker pool. **The timeout never fired once.** Six workers stopped mid-bead and held their `in_progress` claims for three to five hours while the queue read as busy. Nothing reported a problem.

The chain, end to end:

1. `internal/runtime/herdr/provider.go:826` — `GetLastActivity` returns the **zero time and a nil error**. Its `Capabilities()` honestly declares `CanReportActivity: false`.
2. `cmd/gc/idle_tracker.go` — `checkIdle` treated a zero timestamp as indistinguishable from "active just now" and returned `false`, every tick, forever.
3. `cmd/gc/session_reconciler.go:3266` sets `TimerFacts.Triggered` from `checkIdle`, and `DecideIdleTimeout` short-circuits on `!Triggered`. The ladder was never entered.
4. The consecutive same-bead defer backstop (`DecideAssignedWorkExhausted`, default limit 3) is correctly implemented and correctly wired at `session_reconciler.go:3323`. It can only fire on a defer. With no trigger there is never a defer, so it is **unreachable** on any such provider.

**Measured on the affected city:** across **1,208,783** trace records, `gc trace reasons` returns no `idle_timeout`, no `deferred_busy`, no `deferred_min_floor`, and no `assigned_work_exhausted`. The idle ladder has never produced a decision of any kind.

The reason it was silent: `CanReportActivity` is declared by every provider (`fake`/`k8s`/`t3bridge` true, `herdr` false) and **consulted by nothing in the idle path** — grep across `idle_tracker.go`, `session_reconciler.go` and `lifecycle_timers.go` returned zero hits. An operator writing `idle_timeout = "5m"` got no error, no warning, no trace record. Accepted, stored, inert.

## What this changes

`checkIdle` consults the capability, and distinguishes the three ways it can fail to measure — provider cannot report, lookup errored, timestamp absent — logging **once per session** rather than per tick. The reconciler calls this for every session every cycle; an unconditional line would be filtered out as noise, which is how this stayed invisible.

## What this deliberately does not change

It makes the misconfiguration loud. It does **not** make `idle_timeout` work on `herdr`. That needs a non-provider activity source (session log, bead `gc.claimed_at`, event bus) and is a design decision, recorded rather than taken here.

## Testing

- [x] `go test ./cmd/gc/ -run TestCheckIdle` — 4 pass, 0 fail. Covers the herdr shape, once-per-session suppression, a healthy provider staying quiet, and no-timeout-configured staying quiet.
- [x] **Rule 7.6** — reverting the fix turns them red (`TestCheckIdleReportsUnenforceableTimeout` fails); restoring returns them green. Checked, not assumed.
- [x] `go vet ./cmd/gc/` clean, `go build ./cmd/gc/` clean
- [ ] `make check` — **not run.** The host is at load 37 on 10 cores from concurrent agent work, and a full-suite run there produces timeout-shaped failures that describe the machine rather than the change. Needs a re-run on a quiet box before merge, and I am not claiming it.
- [ ] `make check-docs` — n/a, no docs changed
- [ ] `make test-integration` — n/a, no runtime, controller, or workflow behavior changed; this only adds a diagnostic on an existing decision path

## Checklist

- [x] Linked an issue — `ga-7ye`, root cause of `ga-0nf`
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — none; this reports an existing misconfiguration rather than changing behavior
- [x] Called out breaking changes or migration notes — none. Cities on a provider that reports activity are unaffected. Cities on one that does not gain a startup-time log line naming the agent, the setting and the reason; the timeout was already not firing for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EedCADsZczYgxLdtSqQnFc