### PR TITLE
fix(stop): roll back the pending unregister on the uncapped stop path too

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -84,7 +84,19 @@ func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.
 			return cmdStopJSONSequence(args, stdout, stderr, force, jsonOut, true, unregisterTx)
 		})
 	} else {
-		outcome = cmdStopJSONSequence(args, stdout, stderr, force, jsonOut, false, nil)
+		// The uncapped path holds the same pending-unregister transaction as
+		// the capped one: a stop that fails after removing the registration —
+		// a managed provider that refuses to shut down, an invalid config the
+		// body cannot recover — must hand the entry back rather than leave a
+		// live city unregistered. This mirrors the capped arm's accept/rollback
+		// exactly; the deferred success message is part of the same contract.
+		unregisterTx := newSupervisorUnregisterTransaction()
+		outcome = cmdStopJSONSequence(args, stdout, stderr, force, jsonOut, false, unregisterTx)
+		if outcome.code == 0 {
+			unregisterTx.commit()
+		} else {
+			writeSupervisorUnregisterRollback(stderr, "gc stop", "stop failed after unregistering city", unregisterTx.rollback())
+		}
 	}
 	if outcome.code != 0 {
 		return outcome.code


### PR DESCRIPTION
## Summary

#4999 made the supervisor unregister a pending transaction so a stop that fails after removing the registration hands the entry back — but only the wall-clock-capped dispatch got the transaction. The uncapped path (the default: `gc stop` with no `--timeout`) still passed `nil`, so the unregister committed immediately and a managed provider that refused to shut down left a live city unregistered with nothing to restore.

#4999's own `TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails` asserts the restore on exactly this path, and has failed deterministically on every main push since the merge (e.g. run 32970139971 — both `Preflight / unit cover (cmd/gc 1 of 6)` and `cmd/gc process / shard 1 of 12` fail on this one test). **This is the current deterministic main-red.**

The fix gives the uncapped dispatch the same transaction and mirrors the capped arm's accept/rollback verbatim: commit on success, restore-and-report on failure. The deferred success-message ordering matches the capped path by design.

## Testing

- `go test ./cmd/gc -run 'TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails' -count=1` — fails on main, passes here
- `go test ./cmd/gc -run 'TestCmdStop|TestSupervisorUnregister|TestCmdUnregister' -count=1` — 27/27 PASS
- `go test ./cmd/gc -run 'TestCmdStop|TestSupervisorUnregister' -race -count=3` — ok
- `go build` / `go vet` / `gofmt` clean

The earlier same-day red main runs (08:43Z, 09:07Z) failed different integration jobs and are judged separately once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)