### PR TITLE
fix(sling): refuse to route a blocked bead, and name the blockers

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -819,6 +819,11 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, stderr
 			printMissingBeadError(stderr, missingBeadErr, missingBeadForceApplies(opts))
 			return 1
 		}
+		var blockedErr *sling.BlockedError
+		if errors.As(err, &blockedErr) {
+			printBlockedError(stderr, blockedErr)
+			return 1
+		}
 		fmt.Fprintln(stderr, err) //nolint:errcheck
 		return 1
 	}
@@ -891,6 +896,11 @@ func doSlingBatchWithJSON(opts slingOpts, deps slingDeps, querier BeadChildQueri
 		var missingBeadErr *sling.MissingBeadError
 		if errors.As(err, &missingBeadErr) {
 			printMissingBeadError(stderr, missingBeadErr, missingBeadForceApplies(opts))
+			return 1
+		}
+		var blockedErr *sling.BlockedError
+		if errors.As(err, &blockedErr) {
+			printBlockedError(stderr, blockedErr)
 			return 1
 		}
 		// In batch mode, per-child FailReasons have already been rendered
@@ -1038,6 +1048,16 @@ func printMissingBeadError(stderr io.Writer, err *sling.MissingBeadError, allowF
 		return
 	}
 	fmt.Fprintln(stderr, "  verify the bead ID; --force does not bypass missing source validation for formula-backed routes") //nolint:errcheck
+}
+
+// printBlockedError renders a refused sling plus one line per blocker, so the
+// operator sees which beads to close instead of having to go find them. The
+// error string itself stays single-line for log and errors.As use.
+func printBlockedError(stderr io.Writer, err *sling.BlockedError) {
+	fmt.Fprintln(stderr, err) //nolint:errcheck
+	for _, b := range err.Blockers {
+		fmt.Fprintf(stderr, "  blocked by %s\n", b) //nolint:errcheck
+	}
 }
 
 func missingBeadForceApplies(opts sling.SlingOpts) bool {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2054,6 +2054,38 @@ func TestPrintMissingBeadErrorFormulaBackedDoesNotSuggestForce(t *testing.T) {
 	}
 }
 
+// A refused blocked sling must name every blocker on its own line, with the
+// blocker's status and title. Handing the operator "check the dependencies"
+// and nothing else is what turned a one-line dependency fix into a four-hour
+// stall in the original incident.
+func TestPrintBlockedErrorListsEveryBlocker(t *testing.T) {
+	var stderr bytes.Buffer
+	printBlockedError(&stderr, &sling.BlockedError{
+		BeadID: "FE-work1",
+		Target: "frontend/worker",
+		Blockers: []sling.Blocker{
+			{ID: "FE-dep1", Status: "open", Title: "invert the dependency edge"},
+			{ID: "FE-dep2", Status: "in_progress", Title: "land the parser fix"},
+			{ID: "FE-ghost"},
+		},
+	})
+
+	got := stderr.String()
+	for _, want := range []string{
+		"REFUSED",
+		"FE-work1",
+		"frontend/worker",
+		"--force",
+		"blocked by FE-dep1 (open) invert the dependency edge",
+		"blocked by FE-dep2 (in_progress) land the parser fix",
+		"blocked by FE-ghost (not found in store)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stderr = %q, missing %q", got, want)
+		}
+	}
+}
+
 func TestCmdSlingDryRunRefusesMissingBead(t *testing.T) {
 	setupCmdSlingBeadExistsFixture(t)
 

--- a/internal/sling/readiness.go
+++ b/internal/sling/readiness.go
@@ -1,0 +1,113 @@
+package sling
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// BlockerLister resolves a bead's direct dependency edges and the status of
+// the beads on the far end of them. beads.Store satisfies it.
+type BlockerLister interface {
+	DepLister
+	Get(id string) (beads.Bead, error)
+}
+
+// Blocker is one unclosed dependency holding a bead out of the ready set.
+type Blocker struct {
+	ID     string
+	Status string // empty when the dependency target is missing from the store
+	Title  string
+}
+
+// String renders one blocker for operator-facing output.
+func (b Blocker) String() string {
+	status := b.Status
+	if status == "" {
+		status = "not found in store"
+	}
+	if b.Title == "" {
+		return fmt.Sprintf("%s (%s)", b.ID, status)
+	}
+	return fmt.Sprintf("%s (%s) %s", b.ID, status, b.Title)
+}
+
+// BlockedError reports that the routed bead is held out of the ready set by
+// open dependencies. Routing such a bead writes gc.routed_to and reports
+// success, yet still strands the work: the supervisor counts pool demand with
+// a ready query, a blocked bead is never ready, and so no session can ever
+// spawn to claim it. Refusing is better than a dry no-op that prints a convoy
+// id, because the latter starts a clock the operator thinks is running.
+type BlockedError struct {
+	BeadID   string
+	Target   string
+	Blockers []Blocker
+}
+
+// Error returns the refusal diagnostic. Callers that can render multiple lines
+// should also print Blockers, which carries the status and title of each one.
+func (e *BlockedError) Error() string {
+	return fmt.Sprintf(
+		"REFUSED: %s is blocked by %s — routing it to %s cannot result in a claim, "+
+			"because pool demand is counted with a ready query and a blocked bead is "+
+			"never ready; close the blockers or re-run with --force",
+		e.BeadID, strings.Join(BlockerIDs(e.Blockers), ", "), e.Target)
+}
+
+// BlockedWarning renders the non-fatal form of BlockedError, used where a dry
+// run downgrades the refusal to a warning. It stays in the conditional: a dry
+// run routes nothing, so claiming the bead "was routed" would be exactly the
+// kind of misleading output this check exists to remove.
+func BlockedWarning(beadID, target string, blockers []Blocker) string {
+	return fmt.Sprintf(
+		"warning: %s is blocked by %s — routing it to %s would not result in a "+
+			"claim until they close",
+		beadID, strings.Join(BlockerIDs(blockers), ", "), target)
+}
+
+// BlockerIDs returns just the bead IDs, in the order the blockers were found.
+func BlockerIDs(blockers []Blocker) []string {
+	ids := make([]string, 0, len(blockers))
+	for _, b := range blockers {
+		ids = append(ids, b.ID)
+	}
+	return ids
+}
+
+// OpenBlockers returns the unclosed blocking dependencies of beadID — the
+// edges that keep it out of Ready().
+//
+// It mirrors the store's own readiness rule rather than reimplementing one: a
+// dependency whose type is ready-blocking (beads.IsReadyBlockingDependencyType)
+// and whose target is not closed blocks the bead. That keeps the answer aligned
+// with what a pool's ready query will actually see. A dependency target missing
+// from the store counts as blocking, because Ready() resolves its status to the
+// empty string, which is likewise not "closed".
+//
+// Duplicate edges to the same target are reported once.
+func OpenBlockers(beadID string, bl BlockerLister) ([]Blocker, error) {
+	deps, err := bl.DepList(beadID, "down")
+	if err != nil {
+		return nil, fmt.Errorf("reading dependencies of %s: %w", beadID, err)
+	}
+	var blockers []Blocker
+	seen := make(map[string]bool, len(deps))
+	for _, d := range deps {
+		if !beads.IsReadyBlockingDependencyType(d.Type) || seen[d.DependsOnID] {
+			continue
+		}
+		seen[d.DependsOnID] = true
+		target, getErr := bl.Get(d.DependsOnID)
+		switch {
+		case errors.Is(getErr, beads.ErrNotFound):
+			blockers = append(blockers, Blocker{ID: d.DependsOnID})
+		case getErr != nil:
+			return nil, fmt.Errorf("reading dependency %s of %s: %w", d.DependsOnID, beadID, getErr)
+		case target.Status != "closed":
+			blockers = append(blockers, Blocker{ID: target.ID, Status: target.Status, Title: target.Title})
+		}
+	}
+	return blockers, nil
+}

--- a/internal/sling/readiness_test.go
+++ b/internal/sling/readiness_test.go
@@ -1,0 +1,291 @@
+package sling
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// testBlockedBead is the bead under test in this file: the one being routed,
+// whose readiness the sling has to resolve before it will route.
+const testBlockedBead = "BL-42"
+
+// blockedStore seeds a store holding testBlockedBead plus the given dependency
+// edges. Statuses are keyed by bead ID so a test can close a blocker by seeding
+// it closed, exactly as the store's own Ready() cross-references status.
+func blockedStore(deps []beads.Dep, statuses map[string]string) *beads.MemStore {
+	seed := []beads.Bead{{ID: testBlockedBead, Title: testBlockedBead, Type: "task", Status: "open", Metadata: map[string]string{}}}
+	for id, status := range statuses {
+		seed = append(seed, beads.Bead{
+			ID: id, Title: "blocker " + id, Type: "task", Status: status, Metadata: map[string]string{},
+		})
+	}
+	return beads.NewMemStoreFrom(0, seed, deps)
+}
+
+func TestOpenBlockersReportsOnlyUnclosedReadyBlockingDeps(t *testing.T) {
+	store := blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-open", Type: "blocks"},
+		{IssueID: "BL-42", DependsOnID: "BL-waits", Type: "waits-for"},
+		{IssueID: "BL-42", DependsOnID: "BL-done", Type: "blocks"},
+		{IssueID: "BL-42", DependsOnID: "BL-related", Type: "relates-to"},
+		{IssueID: "BL-42", DependsOnID: "BL-tracked", Type: "tracks"},
+	}, map[string]string{
+		"BL-open":    "open",
+		"BL-waits":   "in_progress",
+		"BL-done":    "closed",
+		"BL-related": "open",
+		"BL-tracked": "open",
+	})
+
+	blockers, err := OpenBlockers("BL-42", store)
+	if err != nil {
+		t.Fatalf("OpenBlockers error: %v", err)
+	}
+	got := BlockerIDs(blockers)
+	want := []string{"BL-open", "BL-waits"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("OpenBlockers = %v, want %v (closed and informational edges must not block)", got, want)
+	}
+	if blockers[1].Status != "in_progress" {
+		t.Errorf("blocker status = %q, want in_progress", blockers[1].Status)
+	}
+}
+
+// A dep edge pointing at a bead that is not in the store still blocks: Ready()
+// resolves its status to the empty string, which is not "closed". This is the
+// inverted/dangling-edge shape that made the original incident undiagnosable.
+func TestOpenBlockersTreatsMissingDependencyAsBlocking(t *testing.T) {
+	store := blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-ghost", Type: "blocks"},
+	}, nil)
+
+	blockers, err := OpenBlockers("BL-42", store)
+	if err != nil {
+		t.Fatalf("OpenBlockers error: %v", err)
+	}
+	if len(blockers) != 1 || blockers[0].ID != "BL-ghost" {
+		t.Fatalf("OpenBlockers = %v, want [BL-ghost]", BlockerIDs(blockers))
+	}
+	if !strings.Contains(blockers[0].String(), "not found in store") {
+		t.Errorf("Blocker.String() = %q, want it to say the target is missing", blockers[0].String())
+	}
+}
+
+func TestOpenBlockersReportsDuplicateEdgesOnce(t *testing.T) {
+	store := blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-open", Type: "blocks"},
+		{IssueID: "BL-42", DependsOnID: "BL-open", Type: "waits-for"},
+	}, map[string]string{"BL-open": "open"})
+
+	blockers, err := OpenBlockers("BL-42", store)
+	if err != nil {
+		t.Fatalf("OpenBlockers error: %v", err)
+	}
+	if len(blockers) != 1 {
+		t.Fatalf("OpenBlockers = %v, want a single entry for BL-open", BlockerIDs(blockers))
+	}
+}
+
+// TestDoSlingRefusesBlockedBead is the regression test for the reported bug:
+// gc sling wrote gc.routed_to and printed a success line (convoy id, "Slung
+// ... ->", controller poke) for a bead that no ready query could ever surface,
+// so the operator waited on a dispatch that could not result in a claim.
+func TestDoSlingRefusesBlockedBead(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "gastown.polecat", Dir: "flinders", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-blocker", Type: "blocks"},
+	}, map[string]string{"BL-blocker": "open"})
+
+	_, err := DoSling(testOpts(a, "BL-42"), deps, nil)
+	if err == nil {
+		t.Fatal("DoSling error = nil, want a refusal: the bead is blocked and can never be claimed")
+	}
+	var blockedErr *BlockedError
+	if !errors.As(err, &blockedErr) {
+		t.Fatalf("DoSling error = %T (%v), want *BlockedError", err, err)
+	}
+	if blockedErr.BeadID != "BL-42" {
+		t.Errorf("BlockedError.BeadID = %q, want BL-42", blockedErr.BeadID)
+	}
+	if got := BlockerIDs(blockedErr.Blockers); len(got) != 1 || got[0] != "BL-blocker" {
+		t.Errorf("BlockedError.Blockers = %v, want [BL-blocker]", got)
+	}
+	msg := err.Error()
+	for _, want := range []string{"REFUSED", "BL-42", "BL-blocker", a.QualifiedName(), "--force"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+	// The refusal must land before routing, so no route is written and no
+	// controller poke starts a clock the operator thinks is running.
+	if len(runner.calls) != 0 {
+		t.Errorf("runner calls = %v, want none: the sling must refuse before routing", runner.calls)
+	}
+	bead, getErr := deps.Store.Get("BL-42")
+	if getErr != nil {
+		t.Fatalf("Get(BL-42) error: %v", getErr)
+	}
+	if routed := bead.Metadata["gc.routed_to"]; routed != "" {
+		t.Errorf("gc.routed_to = %q, want empty: a refused sling must not route", routed)
+	}
+}
+
+func TestDoSlingRoutesReadyBead(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	// Same graph shape as the refusal test, except the blocker is closed.
+	deps.Store = blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-blocker", Type: "blocks"},
+	}, map[string]string{"BL-blocker": "closed"})
+
+	result, err := DoSling(testOpts(a, "BL-42"), deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling error: %v", err)
+	}
+	if result.BeadID != "BL-42" {
+		t.Errorf("BeadID = %q, want BL-42", result.BeadID)
+	}
+	if len(result.BeadWarnings) != 0 {
+		t.Errorf("BeadWarnings = %v, want none for a ready bead", result.BeadWarnings)
+	}
+}
+
+// --force is the escape hatch the refusal points operators at: it routes the
+// blocked bead instead of refusing. It is also documented to suppress warnings
+// and to dispatch even when the bead does not resolve in the local store, so
+// it must not pay for the readiness lookup at all.
+func TestDoSlingForceRoutesBlockedBead(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	store := &depCountingStore{MemStore: blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-blocker", Type: "blocks"},
+	}, map[string]string{"BL-blocker": "open"})}
+	deps.Store = store
+
+	opts := testOpts(a, "BL-42")
+	opts.Force = true
+	result, err := DoSling(opts, deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling --force error: %v", err)
+	}
+	if result.BeadID != "BL-42" {
+		t.Errorf("BeadID = %q, want BL-42", result.BeadID)
+	}
+	if store.depListCalls != 0 {
+		t.Errorf("DepList calls under --force = %d, want 0", store.depListCalls)
+	}
+}
+
+// depCountingStore counts DepList calls so a test can assert that a code path
+// does not pay for the readiness lookup.
+type depCountingStore struct {
+	*beads.MemStore
+	depListCalls int
+}
+
+func (s *depCountingStore) DepList(id, direction string) ([]beads.Dep, error) {
+	s.depListCalls++
+	return s.MemStore.DepList(id, direction)
+}
+
+func TestDoSlingDryRunWarnsBlockedBeadWithoutFailing(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = blockedStore([]beads.Dep{
+		{IssueID: "BL-42", DependsOnID: "BL-blocker", Type: "blocks"},
+	}, map[string]string{"BL-blocker": "open"})
+
+	opts := testOpts(a, "BL-42")
+	opts.DryRun = true
+	result, err := DoSling(opts, deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling --dry-run error: %v", err)
+	}
+	if !result.DryRun {
+		t.Fatal("result.DryRun = false, want true")
+	}
+	joined := strings.Join(result.BeadWarnings, "\n")
+	if !strings.Contains(joined, "BL-blocker") || !strings.Contains(joined, "would not result in a claim") {
+		t.Errorf("dry-run warnings %q must name the blockers and stay conditional", joined)
+	}
+}
+
+// The readiness check only makes sense where an existing bead is what gets
+// routed. Inline text and formula slings mint new beads/molecules that cannot
+// carry blockers; --on routes the workflow root rather than the source bead,
+// so the source bead's blockers do not decide the root's readiness; and
+// --force both suppresses warnings and tolerates a bead that does not resolve
+// locally. --dry-run stays in scope and downgrades to a warning.
+func TestShouldCheckBlockedScope(t *testing.T) {
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	base := func() SlingOpts { return testOpts(a, "BL-42") }
+
+	tests := []struct {
+		name string
+		opts SlingOpts
+		want bool
+	}{
+		{"plain bead", base(), true},
+		{"dry run", func() SlingOpts { o := base(); o.DryRun = true; return o }(), true},
+		{"force", func() SlingOpts { o := base(); o.Force = true; return o }(), false},
+		{"formula", func() SlingOpts { o := base(); o.IsFormula = true; return o }(), false},
+		{"on formula", func() SlingOpts { o := base(); o.OnFormula = "mol-do-work"; return o }(), false},
+		{"inline text", func() SlingOpts { o := base(); o.InlineText = true; return o }(), false},
+		{"no bead", func() SlingOpts { o := base(); o.BeadOrFormula = ""; return o }(), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldCheckBlocked(tc.opts); got != tc.want {
+				t.Errorf("shouldCheckBlocked(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// A store fault while resolving blockers is not proof that the bead is
+// blocked. The sling must warn and proceed rather than refuse legitimate work.
+func TestCheckBlockedWarnsAndProceedsOnStoreFault(t *testing.T) {
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	deps := SlingDeps{Store: failingDepStore{}}
+	var result SlingResult
+
+	if err := checkBlocked(testOpts(a, "BL-42"), deps, a, &result); err != nil {
+		t.Fatalf("checkBlocked error = %v, want nil: a store fault must not refuse the sling", err)
+	}
+	joined := strings.Join(result.BeadWarnings, "\n")
+	if !strings.Contains(joined, "could not verify") || !strings.Contains(joined, "BL-42") {
+		t.Errorf("warnings = %q, want an unverified-readiness warning naming BL-42", joined)
+	}
+}
+
+// failingDepStore is a beads.Store whose DepList always fails, standing in for
+// a store fault during the readiness check.
+type failingDepStore struct {
+	beads.Store
+}
+
+func (failingDepStore) DepList(string, string) ([]beads.Dep, error) {
+	return nil, errors.New("store unreachable")
+}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -116,6 +116,17 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 		}
 	}
 
+	// Readiness check: routing a bead that open dependencies hold out of the
+	// ready set writes gc.routed_to and reports success, but no session can
+	// ever spawn for it — pool demand is counted with a ready query. Refuse
+	// before routing rather than print a success line for a dispatch that
+	// cannot possibly result in a claim.
+	if shouldCheckBlocked(opts) {
+		if err := checkBlocked(opts, deps, a, &result); err != nil {
+			return result, err
+		}
+	}
+
 	// Pre-flight idempotency check.
 	if shouldCheckBeadState(opts) {
 		check := CheckBeadStateWithOptions(querier, opts.BeadOrFormula, a, deps, BeadCheckOptions{
@@ -201,6 +212,51 @@ func shouldCheckDepCycle(opts SlingOpts) bool {
 
 func shouldGuardCrossRig(opts SlingOpts) bool {
 	return !opts.IsFormula && !opts.Force && !opts.DryRun
+}
+
+// shouldCheckBlocked reports whether the routed target is an existing bead
+// whose readiness can be resolved from the bead graph.
+//
+// It mirrors shouldCheckDepCycle's scope, for the same reasons: inline text
+// mints a brand-new bead and formula slings mint molecules, neither of which
+// can carry blockers; --on routes the workflow root rather than the source
+// bead, so the source bead's blockers do not decide the root's readiness; and
+// --force is documented to suppress warnings and to dispatch even when the
+// bead does not resolve in the local store, which is precisely the state this
+// check cannot read. --force therefore stays the escape hatch the refusal
+// points operators at, and costs no extra store round-trip.
+//
+// --dry-run stays in scope. It downgrades to a warning inside checkBlocked
+// rather than being skipped, because a preview that preserves the misleading
+// output is exactly what this check exists to remove.
+func shouldCheckBlocked(opts SlingOpts) bool {
+	return !opts.IsFormula && opts.OnFormula == "" && !opts.InlineText && !opts.Force && opts.BeadOrFormula != ""
+}
+
+// checkBlocked resolves the routed bead's open blockers and decides whether to
+// refuse the sling or warn and proceed. A dry run must not fail, so it warns
+// with the blockers named instead. A store fault while resolving them is not
+// proof of anything — it warns and proceeds rather than refusing legitimate
+// work.
+func checkBlocked(opts SlingOpts, deps SlingDeps, a config.Agent, result *SlingResult) error {
+	blockers, err := OpenBlockers(opts.BeadOrFormula, deps.Store)
+	if err != nil {
+		result.BeadWarnings = append(result.BeadWarnings, fmt.Sprintf(
+			"warning: could not verify that %s is ready to be claimed: %v", opts.BeadOrFormula, err))
+		return nil
+	}
+	if len(blockers) == 0 {
+		return nil
+	}
+	target := a.QualifiedName()
+	if opts.DryRun {
+		result.BeadWarnings = append(result.BeadWarnings, BlockedWarning(opts.BeadOrFormula, target, blockers))
+		for _, b := range blockers {
+			result.BeadWarnings = append(result.BeadWarnings, "  blocked by "+b.String())
+		}
+		return nil
+	}
+	return &BlockedError{BeadID: opts.BeadOrFormula, Target: target, Blockers: blockers}
 }
 
 func shouldCheckBeadState(opts SlingOpts) bool {


### PR DESCRIPTION
## What this changes

`gc sling` refuses to route a bead that open dependencies hold out of the ready set, and names the blockers.

Today it writes `gc.routed_to` and reports success for such a bead. Pool demand is counted with a **ready** query, so a blocked bead is invisible as demand and no session can ever spawn to claim it. Every line of the output reads like success:

```
$ gc sling flinders/gastown.polecat fph-aijq --nudge
Auto-convoy fph-9cnr
Slung fph-aijq -> flinders/gastown.polecat
No running sessions for "flinders/gastown.polecat" - poked controller for wake
```

Nothing says the bead cannot be picked up. A dry no-op that prints a convoy id is worse than an error, because it starts a clock the operator thinks is running. In the reported incident a P1 sat undispatched for ~4h and was escalated across rigs as a rig-specific pool defect; it was neither. The underlying cause was an inverted dependency edge, and this output is what made it undiagnosable.

After this change:

```
$ gc sling frontend/worker FE-5jz
REFUSED: FE-5jz is blocked by FE-1d7, FE-87a — routing it to frontend/worker cannot
result in a claim, because pool demand is counted with a ready query and a blocked
bead is never ready; close the blockers or re-run with --force
  blocked by FE-1d7 (in_progress) blocker three
  blocked by FE-87a (open) blocker two
$ echo $?
1
```

The refusal lands in `preflight`, **before** any routing metadata is written, so a refused sling leaves no half-applied state and fires no controller poke.

## Review notes

- `OpenBlockers` (`internal/sling/readiness.go`) mirrors the store's own readiness rule rather than reimplementing one: it reuses `beads.IsReadyBlockingDependencyType`, so an edge counts exactly when the ready query would count it. A dependency target missing from the store blocks, for the same reason `Ready()` blocks on it — its status resolves to neither `"closed"` nor anything else. That is the dangling/inverted-edge shape from the incident.
- Scope mirrors the sibling `shouldCheckDepCycle`: formula slings and inline text mint new beads that cannot carry blockers, and `--on` routes the workflow root rather than the source bead.
- `--force` is excluded entirely. It is documented to *suppress warnings* and to dispatch even when the bead does not resolve in the local store — precisely the state this check cannot read — so it stays the escape hatch the refusal points at and adds no store round-trip to the force path.
- `--dry-run` stays in scope but downgrades to a warning that keeps the conditional voice ("would not result in a claim"), since a preview that hides the blockers preserves exactly the misleading output this removes.
- A store fault while resolving blockers warns and proceeds. An unreadable graph is not proof the bead is blocked, and refusing legitimate work is the worse failure.
- No config, API, schema, or migration surface changes. `make docs` regeneration produced no diff.

### Relationship to #4665

[#4665](https://github.com/gastownhall/gascity/pull/4665) adds a *post*-routing probe of the target's `work_query`. The two are complementary and do not conflict logically, though both touch `internal/sling`:

|  | #4665 | this PR |
|---|---|---|
| When | after routing | before routing |
| Detects | bead invisible to the target's `work_query` (labels, holds, pack overrides) | bead held out of the ready set by open dependencies |
| On failure | routing already written | nothing written |
| Diagnostic | "check labels/metadata/holds against the query X runs" | names each blocker with id, status, title |

If #4665 lands first I am happy to rebase; the mechanisms are independent and the blocker list is the diagnostic payload the source report actually asked for.

## Test plan

- [x] `make test-fast-parallel` — all eight jobs pass
- [x] `go test -count=1 ./internal/sling/...`
- [x] `go test -count=1 ./cmd/gc/... -run 'Sling'`
- [x] `go build ./...`, `go vet ./...`
- [x] `golangci-lint run ./internal/sling/... ./cmd/gc/...` — 0 issues
- [x] `.githooks/pre-commit` active and green (lint-changed, docs regen, vet, fast suite)

New coverage: `internal/sling/readiness_test.go` (blocking-type filtering, missing dependency, duplicate edges, refusal + no-route-written, ready bead unaffected, `--force` skips the lookup entirely, `--dry-run` warns, scope table, store-fault fail-open) and `TestPrintBlockedErrorListsEveryBlocker` in `cmd/gc/cmd_sling_test.go`.

### Verified end-to-end against a real `bd` store

Built binary, sandbox city, real `bd` backend — not just fakes:

| Case | Before (v1.4.0) | After |
|---|---|---|
| blocked bead | `Slung FE-wss → frontend/worker`, exit 0 | `REFUSED …` + blocker lines, exit 1 |
| refusal side effects | — | no `gc.routed_to` written |
| `--dry-run` on blocked | preview only | warning + blocker lines, exit 0 |
| `--force` on blocked | routes | routes, exit 0 |
| blockers closed | routes | routes, exit 0 |
| unblocked bead | routes | routes, no new warning |

Also confirmed live that auto-convoy `sling-<id>` wrappers use `tracks` edges, which are correctly **not** treated as blocking — no false positives on that path.

Source report: gas-city bead `gci-1de`. The report's second, smaller item (the spurious `agent "…" not found in config` message on the wake path) is tracked separately and is not in this PR.
