### PR TITLE
chore(github): remove csells from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,14 +19,3 @@
 # The rollout-gate registry is the only human gate on flag Expires extensions
 # and Category classification (an agent-authored repo); admin review is required.
 /internal/rollout/registry.go @gastownhall/gascity-admin
-
-# Specific docs/ content folders are owned by csells (auto-requests review on
-# matching PRs). Intentionally scoped to authored-content areas, excluding
-# /docs/reference and top-level docs files.
-/docs/diagrams/ @csells
-/docs/getting-started/ @csells
-/docs/guides/ @csells
-/docs/images/ @csells
-/docs/runbooks/ @csells
-/docs/troubleshooting/ @csells
-/docs/tutorials/ @csells


### PR DESCRIPTION
Removes the csells-owned `docs/` content-folder entries from `.github/CODEOWNERS`, so docs PRs no longer auto-request csells review via codeownership.

Intentionally left unchanged (separate mechanisms, flagged for follow-up if desired):
- `.github/workflows/docs-title-review.yml` — still requests csells review on PRs whose **title** starts with `docs:`
- `.github/blacksmith-allowlist.txt` and the CI runner allowlist in `ci.yml` — csells remains listed for Blacksmith runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)