### PR TITLE
fix(prime): refuse a hook role prompt when the payload cwd proves a foreign identity

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -48,12 +48,18 @@ type primeHookInput struct {
 	Source        string `json:"source"`
 	SessionID     string `json:"session_id"`
 	HookEventName string `json:"hook_event_name"`
+	// Cwd is the working directory the provider reports for the session the
+	// hook is firing for. It is the only field in the payload that does not
+	// come from this process's (possibly foreign) environment, so it is what
+	// the identity guard checks the ambient GC_* identity against.
+	Cwd string `json:"cwd"`
 }
 
 type primeHookContext struct {
 	Source            string
 	HookEventName     string
 	ProviderSessionID string
+	Cwd               string
 }
 
 // newPrimeCmd creates the "gc prime [agent-name]" command.
@@ -255,6 +261,28 @@ func doPrimeWithHookFormatOpts(args []string, stdout, stderr io.Writer, hookMode
 	cityName := loadedCityName(cfg, cityPath)
 	if hookMode && strings.TrimSpace(agentName) == "" {
 		agentName = primeHookAgentFromWorkDir(cfg)
+	}
+
+	// Identity guard: the hook payload's cwd is the one field that does not
+	// come from this process's environment. If it proves the ambient GC_*
+	// identity belongs to a different rig's session, refuse to render a role
+	// prompt — a wrong prompt here sends every later gc/bd command in the
+	// session at the wrong ledger and the wrong mail identity.
+	if hookMode {
+		verdict, owner := classifyPrimeHookCwd(hookContext.Cwd, primeIdentityRootsFromEnv(cfg, cityPath, os.Getenv))
+		switch verdict {
+		case primeIdentityForeign:
+			refusal := primeIdentityMismatchPrompt(agentName, os.Getenv("GC_RIG"), hookContext.Cwd, owner)
+			// suppressPrompt is deliberately false: a managed session that
+			// already got its startup prompt still needs to see this.
+			// No hook context suffix and no afterDelivery callback: a refusal
+			// must not consume a pending handoff, which belongs to whichever
+			// session legitimately owns this identity.
+			writePrimePromptWithFormat(stdout, cityName, agentName, refusal, hookMode, hookFormat, false, "", nil)
+			return 0
+		case primeIdentityUnknown:
+			warnPrimeIdentityUnknown(stderr, agentName, hookContext.Cwd)
+		}
 	}
 
 	// Look up agent in config. First try qualified identity resolution
@@ -587,6 +615,9 @@ func readPrimeHookContext() primeHookContext {
 		}
 		if providerSessionID := strings.TrimSpace(input.SessionID); providerSessionID != "" {
 			ctx.ProviderSessionID = providerSessionID
+		}
+		if cwd := strings.TrimSpace(input.Cwd); cwd != "" {
+			ctx.Cwd = cwd
 		}
 	}
 	return ctx

--- a/cmd/gc/prime_identity_guard.go
+++ b/cmd/gc/prime_identity_guard.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// gc identity is 100% ambient environment: `gc prime --hook` renders a role
+// prompt for whatever GC_ALIAS/GC_AGENT/GC_TEMPLATE the process inherited, and
+// `gc mail`/`gc bd` follow GC_SESSION_ID/BEADS_DIR the same way. That is safe
+// only while the environment belongs to the session the hook is firing for.
+//
+// It does not always. Claude Code >= 2.1.x runs ONE per-user background daemon
+// (lock: $CLAUDE_CONFIG_DIR/daemon.lock, sockets: /tmp/cc-daemon-<uid>/<hash of
+// CLAUDE_CONFIG_DIR>/), and that daemon inherits the environment of whichever
+// session happened to spawn it. It then hosts background sessions for EVERY
+// other session on the box, so a background session opened by agent B can carry
+// agent A's GC_* environment while running in agent B's working directory. The
+// hook then renders A's role prompt inside B's session, and every subsequent gc
+// command in it acts as A — wrong ledger, wrong mail identity, wrong rig.
+//
+// Hook payloads carry the truth the environment lost: Claude Code delivers
+// `cwd` on stdin. When the reported cwd sits inside a DIFFERENT rig's tree than
+// the ambient identity claims, the environment is not this session's and the
+// prompt must not be rendered.
+//
+// The classifier is deliberately asymmetric. Refusal requires positive evidence
+// of a foreign owner (the cwd resolves inside another configured rig's root);
+// a cwd that simply matches nothing known is reported as unknown and only
+// warned about, because agents legitimately work in scratch dirs, source
+// checkouts, and mounts that no rig root covers. Refusing on absence of
+// evidence would break far more sessions than the leak it guards against.
+
+// primeIdentityVerdict is the result of comparing a hook-reported cwd against
+// the roots the ambient GC_* identity is entitled to.
+type primeIdentityVerdict string
+
+const (
+	// primeIdentityOK means the cwd belongs to this identity (or no cwd was
+	// reported, so there is nothing to contradict the environment).
+	primeIdentityOK primeIdentityVerdict = "ok"
+	// primeIdentityUnknown means the cwd matched no known root. Warn, render.
+	primeIdentityUnknown primeIdentityVerdict = "unknown"
+	// primeIdentityForeign means the cwd resolves inside another rig's tree.
+	// The ambient environment is another session's. Refuse.
+	primeIdentityForeign primeIdentityVerdict = "foreign"
+)
+
+// primeIdentityRoot is one directory the classifier can attribute to an owner.
+type primeIdentityRoot struct {
+	// Path is the directory, already normalised for comparison.
+	Path string
+	// Self is true when the root belongs to the ambient identity.
+	Self bool
+	// Label names the owner for the refusal message (rig name, or the env var
+	// the root came from).
+	Label string
+}
+
+// normalizeIdentityPath makes a path comparable: absolute, symlink-resolved,
+// cleaned. Symlink resolution is load-bearing, not cosmetic — gc agent homes
+// are routinely reached through a symlinked prefix (a city whose
+// .gc/worktrees lives on another volume resolves to a different real path than
+// the configured one), so a plain string compare marks healthy polecats
+// foreign. Paths that cannot be resolved (not yet created, permission denied)
+// fall back to the cleaned absolute form so the caller still gets a usable
+// comparison instead of an empty string.
+func normalizeIdentityPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		p = resolved
+	}
+	return filepath.Clean(p)
+}
+
+// identityPathWithin reports whether child is parent or sits underneath it.
+// Both arguments must already be normalised. The filepath.Rel form is used
+// rather than a string prefix so that "/a/bc" is not treated as inside "/a/b".
+func identityPathWithin(child, parent string) bool {
+	if child == "" || parent == "" {
+		return false
+	}
+	if child == parent {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// classifyPrimeHookCwd attributes a hook-reported cwd to an owner.
+//
+// Roots nest — every rig's polecat worktrees live under the city directory, so
+// the city root contains other rigs' trees. Matching therefore picks the
+// LONGEST matching root rather than the first, so the most specific owner wins
+// and a city-level self root cannot launder another rig's worktree into "ok".
+func classifyPrimeHookCwd(hookCwd string, roots []primeIdentityRoot) (primeIdentityVerdict, string) {
+	cwd := normalizeIdentityPath(hookCwd)
+	if cwd == "" {
+		// No cwd in the payload (older provider, or a non-Claude hook format):
+		// no evidence either way, so do not interfere.
+		return primeIdentityOK, ""
+	}
+	best := -1
+	for i, root := range roots {
+		if root.Path == "" || !identityPathWithin(cwd, root.Path) {
+			continue
+		}
+		if best < 0 || len(root.Path) > len(roots[best].Path) {
+			best = i
+		}
+	}
+	if best < 0 {
+		return primeIdentityUnknown, ""
+	}
+	if roots[best].Self {
+		return primeIdentityOK, roots[best].Label
+	}
+	return primeIdentityForeign, roots[best].Label
+}
+
+// primeIdentityRootsFromEnv builds the root table for the ambient identity.
+//
+// Self roots come from the session environment (the agent's own work dir, rig
+// root, bead scope) plus the configured path of the rig the environment names.
+// Foreign roots are every OTHER configured rig's repository path and that rig's
+// worktree tree under the city. getenv is injected so the table is testable
+// without mutating the process environment.
+func primeIdentityRootsFromEnv(cfg *config.City, cityPath string, getenv func(string) string) []primeIdentityRoot {
+	if getenv == nil {
+		return nil
+	}
+	selfRig := strings.TrimSpace(getenv("GC_RIG"))
+
+	var roots []primeIdentityRoot
+	addRoot := func(path string, self bool, label string) {
+		norm := normalizeIdentityPath(path)
+		if norm == "" {
+			return
+		}
+		for _, existing := range roots {
+			if existing.Path == norm {
+				return
+			}
+		}
+		roots = append(roots, primeIdentityRoot{Path: norm, Self: self, Label: label})
+	}
+
+	// The session's own declared working roots. GC_DIR is the agent home (a
+	// polecat's per-bead worktrees hang off it); GC_RIG_ROOT and
+	// GC_BEADS_SCOPE_ROOT are the rig repo as the session sees it.
+	for _, key := range []string{"GC_DIR", "GC_RIG_ROOT", "GC_BEADS_SCOPE_ROOT"} {
+		addRoot(getenv(key), true, key)
+	}
+
+	if cfg != nil {
+		for _, rig := range cfg.Rigs {
+			name := strings.TrimSpace(rig.Name)
+			isSelf := selfRig != "" && name == selfRig
+			label := name
+			if label == "" {
+				label = "unnamed rig"
+			}
+			addRoot(rig.Path, isSelf, label)
+			if cityPath != "" && name != "" {
+				// Pool/polecat worktrees: <city>/.gc/worktrees/<rig>/...
+				addRoot(filepath.Join(cityPath, ".gc", "worktrees", name), isSelf, label)
+			}
+		}
+	}
+
+	// The city directory itself is a legitimate place for city-scoped agents
+	// (mayor, deacon) to sit. It is added LAST and is the shortest match, so
+	// the longest-match rule keeps a foreign rig's worktree underneath it
+	// classified as foreign rather than swallowed by this entry.
+	for _, key := range []string{"GC_CITY", "GC_CITY_PATH"} {
+		addRoot(getenv(key), true, key)
+	}
+	addRoot(cityPath, true, "city")
+
+	return roots
+}
+
+// primeIdentityMismatchPrompt is the text rendered in place of a role prompt
+// when the hook cwd proves the ambient environment belongs to another session.
+// It is phrased as an instruction to the reading agent because that is the only
+// actor that can stop the damage: the process already holds the wrong
+// environment, and every gc command it runs will act on the wrong rig.
+func primeIdentityMismatchPrompt(envIdentity, envRig, hookCwd, foreignLabel string) string {
+	if envIdentity == "" {
+		envIdentity = "(unset)"
+	}
+	if envRig == "" {
+		envRig = "(unset)"
+	}
+	var b strings.Builder
+	b.WriteString("# ⛔ IDENTITY MISMATCH — NO ROLE PROMPT RENDERED\n\n")
+	b.WriteString("`gc prime --hook` refused to render a role prompt for this session.\n\n")
+	fmt.Fprintf(&b, "- Ambient environment claims: **%s** (rig `%s`)\n", envIdentity, envRig)
+	fmt.Fprintf(&b, "- This session is actually running in: `%s`\n", hookCwd)
+	fmt.Fprintf(&b, "- That directory belongs to: **%s**\n\n", foreignLabel)
+	b.WriteString("The GC_* environment in this process is another session's. This happens when a\n")
+	b.WriteString("background session is hosted by a shared per-user daemon that inherited a\n")
+	b.WriteString("different session's environment.\n\n")
+	b.WriteString("**Do not run `gc` or `bd` commands in this session.** They would read and write\n")
+	b.WriteString("the wrong rig's ledger and send mail under the wrong agent identity.\n\n")
+	b.WriteString("Report this to the operator, then stop.\n")
+	return b.String()
+}
+
+// warnPrimeIdentityUnknown notes a cwd that matched no known root. Diagnostic
+// only: it never suppresses the prompt.
+func warnPrimeIdentityUnknown(stderr io.Writer, envIdentity, hookCwd string) {
+	if stderr == nil || hookCwd == "" {
+		return
+	}
+	fmt.Fprintf(stderr, "gc prime: hook cwd %q is outside every known rig and city root for identity %q; rendering prompt anyway\n", hookCwd, envIdentity) //nolint:errcheck // best-effort stderr
+}

--- a/cmd/gc/prime_identity_guard_test.go
+++ b/cmd/gc/prime_identity_guard_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// mkdirs creates each directory under root and returns the root.
+func mkdirs(t *testing.T, root string, rel ...string) string {
+	t.Helper()
+	for _, r := range rel {
+		if err := os.MkdirAll(filepath.Join(root, r), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", r, err)
+		}
+	}
+	return root
+}
+
+func envFunc(pairs map[string]string) func(string) string {
+	return func(k string) string { return pairs[k] }
+}
+
+// TestClassifyPrimeHookCwd_ForeignRigRefuses is the regression for the
+// daemon identity leak: a session whose ambient environment says it is the
+// flinders project lead, but whose hook payload reports a cwd inside the
+// arnotts rig, must be classified foreign so no role prompt is rendered.
+func TestClassifyPrimeHookCwd_ForeignRigRefuses(t *testing.T) {
+	root := mkdirs(t, t.TempDir(), "flinders", "arnotts", "city")
+	cfg := &config.City{Rigs: []config.Rig{
+		{Name: "flinders", Path: filepath.Join(root, "flinders")},
+		{Name: "arnotts", Path: filepath.Join(root, "arnotts")},
+	}}
+	roots := primeIdentityRootsFromEnv(cfg, filepath.Join(root, "city"), envFunc(map[string]string{
+		"GC_RIG":      "flinders",
+		"GC_DIR":      filepath.Join(root, "flinders"),
+		"GC_RIG_ROOT": filepath.Join(root, "flinders"),
+	}))
+
+	verdict, owner := classifyPrimeHookCwd(filepath.Join(root, "arnotts"), roots)
+	if verdict != primeIdentityForeign {
+		t.Fatalf("cwd inside another rig: got verdict %q, want %q", verdict, primeIdentityForeign)
+	}
+	if owner != "arnotts" {
+		t.Errorf("owner: got %q, want %q", owner, "arnotts")
+	}
+}
+
+// TestClassifyPrimeHookCwd_OwnRigAndNestedWorktreeOK guards the common healthy
+// cases: the agent's own rig root, and a polecat's per-bead worktree nested
+// under its agent home. Neither may be flagged.
+func TestClassifyPrimeHookCwd_OwnRigAndNestedWorktreeOK(t *testing.T) {
+	root := mkdirs(t, t.TempDir(),
+		"gas-city",
+		"city/.gc/worktrees/gas-city/polecats/slit/worktrees/gci-cfki",
+		"other")
+	cityPath := filepath.Join(root, "city")
+	agentHome := filepath.Join(cityPath, ".gc", "worktrees", "gas-city", "polecats", "slit")
+	cfg := &config.City{Rigs: []config.Rig{
+		{Name: "gas-city", Path: filepath.Join(root, "gas-city")},
+		{Name: "other", Path: filepath.Join(root, "other")},
+	}}
+	roots := primeIdentityRootsFromEnv(cfg, cityPath, envFunc(map[string]string{
+		"GC_RIG":  "gas-city",
+		"GC_DIR":  agentHome,
+		"GC_CITY": cityPath,
+	}))
+
+	for _, cwd := range []string{
+		filepath.Join(root, "gas-city"),
+		agentHome,
+		filepath.Join(agentHome, "worktrees", "gci-cfki"),
+	} {
+		if verdict, _ := classifyPrimeHookCwd(cwd, roots); verdict != primeIdentityOK {
+			t.Errorf("cwd %s: got verdict %q, want %q", cwd, verdict, primeIdentityOK)
+		}
+	}
+}
+
+// TestClassifyPrimeHookCwd_CityRootDoesNotLaunderForeignWorktree is the
+// longest-match rule. Every rig's worktrees live under the city directory, and
+// city-scoped agents legitimately claim the city as a self root. Without
+// longest-match, that self root would swallow another rig's worktree and
+// silently pass the leak through.
+func TestClassifyPrimeHookCwd_CityRootDoesNotLaunderForeignWorktree(t *testing.T) {
+	root := mkdirs(t, t.TempDir(),
+		"city/.gc/worktrees/detmold/polecats/x",
+		"city/.gc/worktrees/gas-city/polecats/y",
+		"detmold", "gas-city")
+	cityPath := filepath.Join(root, "city")
+	cfg := &config.City{Rigs: []config.Rig{
+		{Name: "gas-city", Path: filepath.Join(root, "gas-city")},
+		{Name: "detmold", Path: filepath.Join(root, "detmold")},
+	}}
+	roots := primeIdentityRootsFromEnv(cfg, cityPath, envFunc(map[string]string{
+		"GC_RIG":  "gas-city",
+		"GC_CITY": cityPath,
+	}))
+
+	foreign := filepath.Join(cityPath, ".gc", "worktrees", "detmold", "polecats", "x")
+	verdict, owner := classifyPrimeHookCwd(foreign, roots)
+	if verdict != primeIdentityForeign {
+		t.Fatalf("foreign worktree under the city root: got %q, want %q", verdict, primeIdentityForeign)
+	}
+	if owner != "detmold" {
+		t.Errorf("owner: got %q, want %q", owner, "detmold")
+	}
+}
+
+// TestClassifyPrimeHookCwd_SymlinkedAgentHomeIsNotForeign is the false-positive
+// guard that matters most in practice: gc agent homes are commonly reached
+// through a symlinked prefix (a city whose worktrees live on another volume).
+// The configured path and the path the provider reports then differ as strings
+// while naming the same directory. A plain compare would mark every healthy
+// polecat foreign — worse than the bug being fixed.
+func TestClassifyPrimeHookCwd_SymlinkedAgentHomeIsNotForeign(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real-volume", "slit")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "city"), 0o755); err != nil {
+		t.Fatalf("MkdirAll city: %v", err)
+	}
+	link := filepath.Join(root, "city", "agent-home")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "gas-city", Path: filepath.Join(root, "city")}}}
+	// Environment names the agent home through the symlink...
+	roots := primeIdentityRootsFromEnv(cfg, filepath.Join(root, "city"), envFunc(map[string]string{
+		"GC_RIG": "gas-city",
+		"GC_DIR": link,
+	}))
+	// ...while the provider reports the resolved real path.
+	if verdict, _ := classifyPrimeHookCwd(realDir, roots); verdict != primeIdentityOK {
+		t.Errorf("symlinked agent home: got verdict %q, want %q", verdict, primeIdentityOK)
+	}
+}
+
+// TestClassifyPrimeHookCwd_NoEvidenceNeverRefuses pins the asymmetry: an empty
+// cwd (older provider, non-Claude hook format) is OK, and an unrecognized cwd
+// is unknown — never foreign. Refusal requires positive evidence of another
+// owner.
+func TestClassifyPrimeHookCwd_NoEvidenceNeverRefuses(t *testing.T) {
+	root := mkdirs(t, t.TempDir(), "gas-city", "city", "elsewhere")
+	cfg := &config.City{Rigs: []config.Rig{{Name: "gas-city", Path: filepath.Join(root, "gas-city")}}}
+	roots := primeIdentityRootsFromEnv(cfg, filepath.Join(root, "city"), envFunc(map[string]string{
+		"GC_RIG": "gas-city",
+		"GC_DIR": filepath.Join(root, "gas-city"),
+	}))
+
+	if verdict, _ := classifyPrimeHookCwd("", roots); verdict != primeIdentityOK {
+		t.Errorf("empty cwd: got %q, want %q", verdict, primeIdentityOK)
+	}
+	if verdict, _ := classifyPrimeHookCwd(filepath.Join(root, "elsewhere"), roots); verdict != primeIdentityUnknown {
+		t.Errorf("unrecognized cwd: got %q, want %q", verdict, primeIdentityUnknown)
+	}
+}
+
+// TestIdentityPathWithin_SiblingPrefixIsNotContained guards the containment
+// helper against the classic prefix bug: "/a/bc" must not count as inside
+// "/a/b".
+func TestIdentityPathWithin_SiblingPrefixIsNotContained(t *testing.T) {
+	if identityPathWithin("/a/bc", "/a/b") {
+		t.Error("/a/bc must not be treated as inside /a/b")
+	}
+	if !identityPathWithin("/a/b/c", "/a/b") {
+		t.Error("/a/b/c must be inside /a/b")
+	}
+	if !identityPathWithin("/a/b", "/a/b") {
+		t.Error("a path must be inside itself")
+	}
+}
+
+// TestPrimeIdentityMismatchPrompt_NamesBothSides checks the refusal actually
+// tells the reader what to do: which identity the environment claimed, where
+// the session really is, who owns it, and that gc/bd must not be run.
+func TestPrimeIdentityMismatchPrompt_NamesBothSides(t *testing.T) {
+	got := primeIdentityMismatchPrompt("flinders/oversight-rig.project-lead", "flinders", "/home/edward/the-arnotts-group", "arnotts")
+	for _, want := range []string{
+		"IDENTITY MISMATCH",
+		"flinders/oversight-rig.project-lead",
+		"/home/edward/the-arnotts-group",
+		"arnotts",
+		"Do not run",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("refusal prompt missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestWarnPrimeIdentityUnknown_QuietOnEmptyCwd keeps the diagnostic from
+// firing when there is nothing to report.
+func TestWarnPrimeIdentityUnknown_QuietOnEmptyCwd(t *testing.T) {
+	var buf bytes.Buffer
+	warnPrimeIdentityUnknown(&buf, "gas-city/gastown.slit", "")
+	if buf.Len() != 0 {
+		t.Errorf("expected no warning for empty cwd, got %q", buf.String())
+	}
+	warnPrimeIdentityUnknown(&buf, "gas-city/gastown.slit", "/somewhere")
+	if !strings.Contains(buf.String(), "/somewhere") {
+		t.Errorf("expected warning naming the cwd, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
Fixes #5682.

`gc` derives agent identity entirely from the ambient environment. That is safe
only while the environment belongs to the session the hook is firing for — and
it does not always. Claude Code >= 2.1.x runs **one** background daemon per
`CLAUDE_CONFIG_DIR`, that daemon inherits the environment of whichever session
happened to spawn it, and it then hosts background sessions for every other
session sharing that config dir. A background session opened by agent B can
therefore carry agent A's complete `GC_*` environment while running in B's
working directory. `gc prime --hook` renders A's role prompt into B's session,
and every later `gc`/`bd` command in it acts as A — wrong ledger, wrong mail
identity, wrong rig. The issue has a deterministic two-identity sandbox repro.

## What this does

Hook payloads carry the truth the environment lost: the provider delivers `cwd`
on stdin, and it is the **only** field in the payload that does not come from
this (possibly foreign) process's environment. `gc prime --hook` currently
ignores it. This parses `cwd`, attributes it to an owner, and refuses to render
a role prompt when it proves the ambient identity belongs to a different rig.

The refusal is rendered *in place of* the role prompt, so the session sees why
it got nothing and is told not to run `gc`/`bd` — the reading agent is the only
actor that can stop the damage, since the process already holds the wrong
environment.

## Four design decisions worth reviewing

**1. cwd-vs-env attribution.** Everything else in the payload — and everything
in `GC_ALIAS`/`GC_AGENT`/`GC_RIG` — is inherited, so it corroborates nothing.
`cwd` is reported by the provider for the session the hook is firing for, which
makes it the one independent signal available at prime time. The guard compares
it against the roots the ambient identity is entitled to.

**2. Refusal requires positive evidence.** The classifier is deliberately
asymmetric:

| cwd resolves… | verdict | behavior |
|---|---|---|
| inside another configured rig's tree | `foreign` | **refuse**, render the mismatch notice |
| inside a self root | `ok` | render normally |
| nowhere known | `unknown` | warn on stderr, **render normally** |
| absent from the payload | `ok` | render normally |

Agents legitimately work in scratch dirs, source checkouts and mounts no rig
root covers, and older providers (and non-Claude hook formats) send no `cwd` at
all. Refusing on *absence* of evidence would break far more sessions than the
leak it guards against, so absence is never grounds for refusal.

**3. Longest-match attribution.** Roots nest: every rig's polecat worktrees live
under the city dir (`<city>/.gc/worktrees/<rig>/…`), and city-scoped agents
(mayor, deacon) legitimately claim the city itself as a self root. Matching the
*first* root would let that city-level self root swallow another rig's worktree
and launder the leak into `ok`. The classifier picks the **longest** matching
root, so the most specific owner wins. `TestClassifyPrimeHookCwd_CityRootDoesNotLaunderForeignWorktree`
pins this.

**4. Symlink resolution is load-bearing, not cosmetic.** gc agent homes are
routinely reached through a symlinked prefix — on the box this was found on,
`/home/edward/gc/.gc/worktrees/gas-city/polecats/…` resolves to
`/srv/gc-data/gc-worktrees/…`. The configured path and the path the provider
reports then differ as strings while naming the same directory, so a plain
compare would mark **every** healthy polecat foreign — considerably worse than
the bug being fixed. Both sides go through `filepath.EvalSymlinks`, falling back
to the cleaned absolute form when a path cannot be resolved (not yet created,
permission denied). Containment uses `filepath.Rel` rather than a string prefix,
so `/a/bc` is not treated as inside `/a/b`.

## Scope limit, stated plainly

This is defence in depth, not a fix for the leak itself. It stops a leaked
session being handed the wrong *role prompt*. It does **not** stop a leaked
session that never fires `gc prime --hook` from running `gc bd`/`gc mail` under
the wrong identity. The natural next increment is on the mail path and belongs
with #4070 (`gc mail send --from` is unauthenticated) — the same trust problem,
not in this PR.

## Relationship to #5305

#5305 ("fix(prime,mail,nudge): gate hook injection on gc identity") touches the
same function but solves a **different vector**, and the two are complementary:

- #5305 returns early when `hookHasManagedIdentity()` is false — a hook carrying
  *no* gc identity, i.e. a human who opened a provider in a directory gc staged
  hook overlays into.
- The leak here carries a *complete and valid* managed identity that simply
  belongs to someone else, so `hookHasManagedIdentity()` returns **true** and
  #5305's gate does not fire.

#5305 was still open at the time of writing, so this is based on `main`. Its
`cmd_prime.go` hunk inserts at the top of `doPrimeWithHookFormatOpts` (right
after `readPrimeHookContext()`); this guard sits later in the same function,
after `loadCityConfig` and `resolveRigPaths`, which it needs in order to know
the configured rig roots. The hunks do not overlap — I test-applied #5305 on top
of this branch and it applies cleanly, with no symbol collisions between the two
test files. Happy to rebase if #5305 lands first.

Note for anyone tracking the earlier draft of this patch: it was written against
v1.4.0 (`a7297c51`) and predicted a rename rebase (`doPrimeWithHookFormat` →
`doPrimeWithHookFormatOpts`). `main` already carries **both** — the thin wrapper
and the `…Opts` implementation — so no rename rebase was needed; the guard went
into the implementation. The one real drift was
`writePrimePromptWithFormat` gaining a trailing `afterDelivery func()`
callback. The refusal path passes `nil` deliberately: a refusal must not consume
a pending handoff, which belongs to whichever session legitimately owns that
identity.

## Tests

Eight new tests in `cmd/gc/prime_identity_guard_test.go`, one per decision above
plus the false-positive guards:

- `TestClassifyPrimeHookCwd_ForeignRigRefuses` — the regression: env says rig A,
  cwd is inside rig B ⇒ `foreign`.
- `TestClassifyPrimeHookCwd_OwnRigAndNestedWorktreeOK` — own rig root and a
  polecat's per-bead worktree nested under its agent home are never flagged.
- `TestClassifyPrimeHookCwd_CityRootDoesNotLaunderForeignWorktree` — longest-match.
- `TestClassifyPrimeHookCwd_SymlinkedAgentHomeIsNotForeign` — the symlinked
  agent home false positive.
- `TestClassifyPrimeHookCwd_NoEvidenceNeverRefuses` — empty cwd ⇒ `ok`,
  unrecognized cwd ⇒ `unknown`, never `foreign`.
- `TestIdentityPathWithin_SiblingPrefixIsNotContained` — `/a/bc` ⊄ `/a/b`.
- `TestPrimeIdentityMismatchPrompt_NamesBothSides` — the refusal names both
  identities, the cwd, the owner, and the do-not-run instruction.
- `TestWarnPrimeIdentityUnknown_QuietOnEmptyCwd` — the diagnostic stays quiet
  when there is nothing to report.

## Gates

Run against `main` @ `8556a801c`:

- `go build ./cmd/gc/` — OK
- `go vet ./...` — clean
- `golangci-lint run cmd/gc/...` — **0 issues**
- `gofmt -l` on all three files — clean
- `go test ./cmd/gc/ -run 'TestClassifyPrimeHookCwd|TestIdentityPathWithin|TestPrimeIdentityMismatchPrompt|TestWarnPrimeIdentityUnknown'` — **8/8 PASS**
- `go test ./cmd/gc/ -run 'Prime|prime|Hook|hook'` — PASS, no existing prime/hook test regressed
- `.githooks/pre-commit` — green
- `make test-fast-parallel` — see below

**One pre-existing failure, not from this change.**
`make test-fast-parallel` reports `TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails`
failing in the `cmd/gc` shard:

```
--- FAIL: TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails (0.61s)
    cmd_stop_test.go:898: registry after managed-provider stop failure = [], want exact original entry
```

That is #5668 — deterministic on `main`, fix already open as #5667. I reproduced
it byte-identically in a **clean detached worktree at `8556a801c` with zero
changes applied**, so it is not caused by this PR, and no change here can clear
it. It lives in `cmd_stop_test.go` and is untouched by this diff. Every other
fast job passes, and `go test ./cmd/gc/` with only that one test skipped is
green on this branch.

Flagging it so a reviewer is not bounced by red CI: while #5668 stands,
`CI / required` is red for every PR against `main`.
