### PR TITLE
fix(ci): a failed integration-test discovery is not an empty shard

### DIFF
--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -177,7 +177,21 @@ validate_modulo_shard() {
 }
 
 list_integration_tests() {
-  run_go_test -tags integration -list '^Test' "$pkg" | grep '^Test'
+  # Discovery is a network-and-compile step: module downloads happen inside
+  # the -list invocation, so a transient failure here must not masquerade as
+  # an empty test set — that is exactly how a runner hiccup turned into
+  # "no tests selected for shard rest-full-N-of-16" on whichever matrix jobs
+  # the hiccup hit. Capture with the status intact and retry once for the
+  # transient class; a second failure aborts the shard with the real reason.
+  local out
+  if ! out="$(run_go_test -tags integration -list '^Test' "$pkg")"; then
+    echo "listing integration tests failed; retrying once" >&2
+    if ! out="$(run_go_test -tags integration -list '^Test' "$pkg")"; then
+      echo "listing integration tests failed twice; refusing to shard an unknown test set" >&2
+      return 1
+    fi
+  fi
+  printf '%s\n' "$out" | grep '^Test' || true
 }
 
 validate_selected_tests() {
@@ -310,9 +324,15 @@ run_rest_full_shard_modulo() {
     excluded+="${excluded_name}"$'\n'
   done
 
+  # Command substitution rather than process substitution: a process
+  # substitution's exit status is invisible to the parent even under
+  # `set -e`, so a failed discovery would silently yield an empty list and
+  # fail the shard with the wrong diagnosis.
+  local listed
+  listed="$(list_integration_tests)"
   while IFS= read -r test_name; do
-    all_tests+=("$test_name")
-  done < <(list_integration_tests)
+    [[ -n "$test_name" ]] && all_tests+=("$test_name")
+  done <<< "$listed"
 
   for test_name in "${all_tests[@]}"; do
     if ! printf '%s' "$excluded" | grep -Fxq -- "$test_name"; then


### PR DESCRIPTION
## Summary

The rest-full/rest-smoke shard runner discovers its test set with `go test -tags integration -list` behind a process substitution, whose exit status is invisible to the parent even under `set -euo pipefail`. Module downloads happen inside that `-list` invocation, so a transient runner hiccup failed discovery silently, yielded an empty list, and surfaced as `no tests selected for shard rest-full-N-of-16` on whichever matrix jobs the hiccup hit — the wandering integration-shard reds on main (rest-full-2 at 08:43Z, packages-core-3 at 09:07Z, rest-full-5+6 at 01:03Z; runs 32949218048 / 32951335349 / 33009528457).

With #5676 fixing the deterministic cmd/gc red, these discovery flakes are the remaining cause of main-red.

Capture the discovery with its status intact, retry once for the transient class, and abort with the real reason on a second failure. The empty-shard guard in `run_pkg_tests_modulo` stays: with discovery status now propagated it again means what it says.

## Testing

Falsified with a shimmed `go` binary:
- fail-once → `listing integration tests failed; retrying once` → shard selects and runs (10 tests on rest-full-5-of-16)
- fail-always → `refusing to shard an unknown test set`, script exit 1 (not the misleading empty-shard message)
- unshimmed control → `Running shard rest-full-5-of-16 against ./test/integration (10 tests)`
- `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)