### PR TITLE
fix(doctor): see the per-bead worktrees at <rig>/worktrees/

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -348,6 +348,10 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 				continue
 			}
 			register(doctor.NewRigPathCheck(rig))
+			// Per-bead worktrees live at <rig>/worktrees/, not under
+			// $CITY/.gc/worktrees/, so none of the city-scoped worktree
+			// checks above can see them.
+			register(doctor.NewRigWorktreesCheck(rig, doctorCfg))
 			register(doctor.NewRigGitCheck(rig))
 			register(doctor.NewRigRootBranchCheck(rig))
 			register(doctor.NewRigBDSplitStoreCheck(cityPath, rig))

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -350,8 +350,8 @@ DoctorConfig holds settings for the gc doctor surface.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `worktree_rig_warn_size` | string |  | `10GB` | WorktreeRigWarnSize is the per-rig warning threshold for the total disk footprint under .gc/worktrees/&lt;rig&gt;/. Reported by the worktree-disk-size check. Go-style human size string ("10GB", "500MB"). Empty or unparseable falls back to the default (10 GB). |
-| `worktree_rig_error_size` | string |  | `50GB` | WorktreeRigErrorSize is the per-rig error threshold. When any rig exceeds this, the worktree-disk-size check reports an error rather than a warning. Empty or unparseable falls back to the default (50 GB). |
+| `worktree_rig_warn_size` | string |  | `10GB` | WorktreeRigWarnSize is the per-rig warning threshold for a worktree population's total disk footprint. Reported by the worktree-disk-size check for .gc/worktrees/&lt;rig&gt;/, and by the rig:&lt;rig&gt;:worktrees check for the per-bead worktrees at &lt;rig&gt;/worktrees/. Go-style human size string ("10GB", "500MB"). Empty or unparseable falls back to the default (10 GB). |
+| `worktree_rig_error_size` | string |  | `50GB` | WorktreeRigErrorSize is the per-rig error threshold. When a rig worktree population exceeds this, the reporting check errors rather than warns. Empty or unparseable falls back to the default (50 GB). |
 | `nested_worktree_prune` | boolean |  | `false` | NestedWorktreePrune escalates the nested-worktree-prune check from warning to error severity when safely-prunable nested worktrees are present, so CI / scripted doctor runs fail until the operator runs `gc doctor --fix`. Actual removal still requires --fix; this flag does not auto-prune. Safety is enforced by mechanical checks (no uncommitted changes, no unpushed commits, no stashes) — never by role identity. |
 | `check` | []LocalDoctorCheck |  |  | Checks holds city-local inline doctor checks declared via [[doctor.check]] in city.toml. |
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1418,12 +1418,12 @@
       "properties": {
         "worktree_rig_warn_size": {
           "type": "string",
-          "description": "WorktreeRigWarnSize is the per-rig warning threshold for the total\ndisk footprint under .gc/worktrees/\u003crig\u003e/. Reported by the\nworktree-disk-size check. Go-style human size string (\"10GB\", \"500MB\").\nEmpty or unparseable falls back to the default (10 GB).",
+          "description": "WorktreeRigWarnSize is the per-rig warning threshold for a\nworktree population's total disk footprint. Reported by the\nworktree-disk-size check for .gc/worktrees/\u003crig\u003e/, and by the\nrig:\u003crig\u003e:worktrees check for the per-bead worktrees at\n\u003crig\u003e/worktrees/. Go-style human size string (\"10GB\", \"500MB\").\nEmpty or unparseable falls back to the default (10 GB).",
           "default": "10GB"
         },
         "worktree_rig_error_size": {
           "type": "string",
-          "description": "WorktreeRigErrorSize is the per-rig error threshold. When any rig\nexceeds this, the worktree-disk-size check reports an error rather\nthan a warning. Empty or unparseable falls back to the default\n(50 GB).",
+          "description": "WorktreeRigErrorSize is the per-rig error threshold. When a rig\nworktree population exceeds this, the reporting check errors\nrather than warns. Empty or unparseable falls back to the default\n(50 GB).",
           "default": "50GB"
         },
         "nested_worktree_prune": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1418,12 +1418,12 @@
       "properties": {
         "worktree_rig_warn_size": {
           "type": "string",
-          "description": "WorktreeRigWarnSize is the per-rig warning threshold for the total\ndisk footprint under .gc/worktrees/\u003crig\u003e/. Reported by the\nworktree-disk-size check. Go-style human size string (\"10GB\", \"500MB\").\nEmpty or unparseable falls back to the default (10 GB).",
+          "description": "WorktreeRigWarnSize is the per-rig warning threshold for a\nworktree population's total disk footprint. Reported by the\nworktree-disk-size check for .gc/worktrees/\u003crig\u003e/, and by the\nrig:\u003crig\u003e:worktrees check for the per-bead worktrees at\n\u003crig\u003e/worktrees/. Go-style human size string (\"10GB\", \"500MB\").\nEmpty or unparseable falls back to the default (10 GB).",
           "default": "10GB"
         },
         "worktree_rig_error_size": {
           "type": "string",
-          "description": "WorktreeRigErrorSize is the per-rig error threshold. When any rig\nexceeds this, the worktree-disk-size check reports an error rather\nthan a warning. Empty or unparseable falls back to the default\n(50 GB).",
+          "description": "WorktreeRigErrorSize is the per-rig error threshold. When a rig\nworktree population exceeds this, the reporting check errors\nrather than warns. Empty or unparseable falls back to the default\n(50 GB).",
           "default": "50GB"
         },
         "nested_worktree_prune": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2322,15 +2322,17 @@ type LocalDoctorCheck struct {
 // (broken-worktree pointers, missing files) remain hardcoded since they
 // cannot be operator-tuned in any meaningful sense.
 type DoctorConfig struct {
-	// WorktreeRigWarnSize is the per-rig warning threshold for the total
-	// disk footprint under .gc/worktrees/<rig>/. Reported by the
-	// worktree-disk-size check. Go-style human size string ("10GB", "500MB").
+	// WorktreeRigWarnSize is the per-rig warning threshold for a
+	// worktree population's total disk footprint. Reported by the
+	// worktree-disk-size check for .gc/worktrees/<rig>/, and by the
+	// rig:<rig>:worktrees check for the per-bead worktrees at
+	// <rig>/worktrees/. Go-style human size string ("10GB", "500MB").
 	// Empty or unparseable falls back to the default (10 GB).
 	WorktreeRigWarnSize string `toml:"worktree_rig_warn_size,omitempty" jsonschema:"default=10GB"`
 
-	// WorktreeRigErrorSize is the per-rig error threshold. When any rig
-	// exceeds this, the worktree-disk-size check reports an error rather
-	// than a warning. Empty or unparseable falls back to the default
+	// WorktreeRigErrorSize is the per-rig error threshold. When a rig
+	// worktree population exceeds this, the reporting check errors
+	// rather than warns. Empty or unparseable falls back to the default
 	// (50 GB).
 	WorktreeRigErrorSize string `toml:"worktree_rig_error_size,omitempty" jsonschema:"default=50GB"`
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1613,7 +1613,9 @@ type WorktreeCheck struct {
 // Name returns the check identifier.
 func (c *WorktreeCheck) Name() string { return "worktrees" }
 
-// Run walks .gc/worktrees/ and verifies each .git pointer.
+// Run walks .gc/worktrees/ and verifies each .git pointer. Per-bead
+// worktrees at <rig>/worktrees/ are a separate population and are
+// covered by RigWorktreesCheck.
 func (c *WorktreeCheck) Run(ctx *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	c.broken = nil
@@ -1623,7 +1625,11 @@ func (c *WorktreeCheck) Run(ctx *CheckContext) *CheckResult {
 	if err != nil {
 		if os.IsNotExist(err) {
 			r.Status = StatusOK
-			r.Message = "no worktrees directory"
+			// Name the directory. The bare "no worktrees directory"
+			// read as a claim about every worktree on the box, and was
+			// reported green against a rig whose own worktrees/ held
+			// tens of gigabytes. Sibling checks already say ".gc/".
+			r.Message = "no .gc/worktrees directory"
 			return r
 		}
 		r.Status = StatusError
@@ -1655,7 +1661,7 @@ func (c *WorktreeCheck) Run(ctx *CheckContext) *CheckResult {
 	if len(c.broken) == 0 {
 		r.Status = StatusOK
 		if total == 0 {
-			r.Message = "no worktrees"
+			r.Message = "no agent worktrees under .gc/worktrees"
 		} else {
 			r.Message = fmt.Sprintf("all %d worktree(s) valid", total)
 		}

--- a/internal/doctor/checks_rig_worktrees.go
+++ b/internal/doctor/checks_rig_worktrees.go
@@ -1,0 +1,138 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// RigWorktreesCheck reports the per-bead worktree population that
+// formulas create at <rig>/worktrees/<bead-id>/.
+//
+// This is a different population from the one WorktreeDiskSizeCheck,
+// NestedWorktreePruneCheck and WorktreeCheck inspect: those three are
+// scoped to $CITY/.gc/worktrees/ (agent home worktrees and anything
+// nested inside them). A rig whose worktrees/ directory holds tens of
+// gigabytes of per-bead trees was therefore invisible to every worktree
+// check doctor had, and the board came back green over it.
+//
+// Observation only. Removal is owned by the worktree-prune order, which
+// already carries the safety criterion (clean tree, no unpushed work,
+// `git worktree remove` without --force as the gate, in-flight detached
+// heads left alone); duplicating that here would give doctor --fix a
+// second, weaker opinion about when a worktree is disposable.
+type RigWorktreesCheck struct {
+	rig config.Rig
+	cfg config.DoctorConfig
+	// measureDir is injectable so tests can avoid shelling out to du.
+	// Production uses duDirBytes from checks.go.
+	measureDir func(string) (int64, bool, error)
+}
+
+// NewRigWorktreesCheck creates the per-rig worktree population check.
+// The cfg is read for thresholds at Run time, so reload-time changes
+// propagate naturally, and the thresholds are deliberately the same
+// [doctor].worktree_rig_* pair the city-scoped size check uses: the
+// question ("is a worktree population eating this disk?") is the same
+// one, and a second knob would be a second thing to keep in sync.
+func NewRigWorktreesCheck(rig config.Rig, cfg config.DoctorConfig) *RigWorktreesCheck {
+	measure := func(path string) (int64, bool, error) {
+		n, ok, err := duDirBytes(path)
+		if err != nil {
+			return n, ok, fmt.Errorf("measure rig worktree dir %q: %w", path, err)
+		}
+		return n, ok, nil
+	}
+	return &RigWorktreesCheck{rig: rig, cfg: cfg, measureDir: measure}
+}
+
+// Name returns the check identifier.
+func (c *RigWorktreesCheck) Name() string { return "rig:" + c.rig.Name + ":worktrees" }
+
+// Run counts the per-bead worktrees under <rig>/worktrees/ and measures
+// their aggregate footprint.
+func (c *RigWorktreesCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	root := filepath.Join(c.rig.Path, "worktrees")
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			r.Status = StatusOK
+			r.Message = fmt.Sprintf("no %s directory", root)
+			return r
+		}
+		// Unreadable is not the same as absent. Saying "none" here is
+		// the exact failure this check exists to correct, so surface it.
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("reading %s: %v", root, err)
+		r.FixHint = "check filesystem permissions on <rig>/worktrees/"
+		return r
+	}
+
+	var count int
+	for _, e := range entries {
+		if e.IsDir() {
+			count++
+		}
+	}
+	if count == 0 {
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("no per-bead worktrees under %s", root)
+		return r
+	}
+
+	measure := c.measureDir
+	if measure == nil {
+		measure = duDirBytes
+	}
+	// One measurement of the root, not one per worktree: a rig can hold
+	// dozens, and this check runs on every doctor invocation.
+	bytes, exists, err := measure(root)
+	if err != nil {
+		// "We can't tell" must not look like "we're fine". Matches
+		// WorktreeDiskSizeCheck's policy of escalating on measurement
+		// failure — the count alone is still worth reporting.
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("%d per-bead worktree(s) under %s, size unmeasurable", count, root)
+		r.Details = []string{err.Error()}
+		r.FixHint = "check filesystem permissions on <rig>/worktrees/"
+		return r
+	}
+	if !exists {
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("no %s directory", root)
+		return r
+	}
+
+	warn := c.cfg.WorktreeRigWarnBytes()
+	errBytes := c.cfg.WorktreeRigErrorBytes()
+	pruneHint := "worktrees are reclaimed by the worktree-prune order; run `gc order run worktree-prune` or inspect with `git -C " + c.rig.Path + " worktree list`"
+
+	switch {
+	case bytes >= errBytes:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("%d per-bead worktree(s) in %s using %s (exceeds %s error threshold)",
+			count, root, humanSize(bytes), humanSize(errBytes))
+		r.FixHint = pruneHint
+	case bytes >= warn:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("%d per-bead worktree(s) in %s using %s (exceeds %s warn threshold)",
+			count, root, humanSize(bytes), humanSize(warn))
+		r.FixHint = pruneHint
+	default:
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("%d per-bead worktree(s) in %s using %s (under %s warn)",
+			count, root, humanSize(bytes), humanSize(warn))
+	}
+	return r
+}
+
+// CanFix returns false — see the type comment: removal belongs to the
+// worktree-prune order, which owns the safety criterion.
+func (c *RigWorktreesCheck) CanFix() bool { return false }
+
+// Fix is a no-op; see CanFix.
+func (c *RigWorktreesCheck) Fix(_ *CheckContext) error { return nil }

--- a/internal/doctor/checks_rig_worktrees_test.go
+++ b/internal/doctor/checks_rig_worktrees_test.go
@@ -1,0 +1,224 @@
+package doctor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// newRigWorktreesCheckWithMeasure builds the check with an injected
+// measurement so tests never shell out to du.
+func newRigWorktreesCheckWithMeasure(t *testing.T, rigPath string, cfg config.DoctorConfig, measure func(string) (int64, bool, error)) *RigWorktreesCheck {
+	t.Helper()
+	c := NewRigWorktreesCheck(config.Rig{Name: "testrig", Path: rigPath}, cfg)
+	c.measureDir = measure
+	return c
+}
+
+// fixedSize returns a measurement stub reporting n bytes for an
+// existing directory.
+func fixedSize(n int64) func(string) (int64, bool, error) {
+	return func(string) (int64, bool, error) { return n, true, nil }
+}
+
+// makeWorktreeDirs creates <rigPath>/worktrees/<name> for each name and
+// returns the rig path.
+func makeWorktreeDirs(t *testing.T, names ...string) string {
+	t.Helper()
+	rigPath := t.TempDir()
+	for _, n := range names {
+		if err := os.MkdirAll(filepath.Join(rigPath, "worktrees", n), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", n, err)
+		}
+	}
+	return rigPath
+}
+
+func TestRigWorktreesCheck_Name(t *testing.T) {
+	c := NewRigWorktreesCheck(config.Rig{Name: "eunice", Path: "/tmp/x"}, config.DoctorConfig{})
+	if got, want := c.Name(), "rig:eunice:worktrees"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+// The regression this check exists for: a rig holding a large per-bead
+// worktree population must be reported, not reported as absent. Before
+// this check, every worktree check was scoped to $CITY/.gc/worktrees and
+// the board came back green over tens of gigabytes.
+func TestRigWorktreesCheck_PopulatedOverErrorThreshold_ReportsCountAndSize(t *testing.T) {
+	rigPath := makeWorktreeDirs(t, "tlp-aaa", "tlp-bbb", "tlp-ccc")
+	cfg := config.DoctorConfig{WorktreeRigWarnSize: "10GB", WorktreeRigErrorSize: "50GB"}
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, cfg, fixedSize(60*1024*1024*1024))
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusError {
+		t.Fatalf("status = %d (%s), want StatusError", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "3 per-bead worktree(s)") {
+		t.Errorf("message = %q, want the worktree count", r.Message)
+	}
+	if !strings.Contains(r.Message, "60.0 GB") {
+		t.Errorf("message = %q, want the aggregate size", r.Message)
+	}
+	if strings.Contains(r.Message, "no worktrees") {
+		t.Errorf("message = %q, must not claim absence over a populated directory", r.Message)
+	}
+	if r.FixHint == "" {
+		t.Error("FixHint empty; want a pointer at the prune order")
+	}
+}
+
+func TestRigWorktreesCheck_OverWarnUnderError_Warns(t *testing.T) {
+	rigPath := makeWorktreeDirs(t, "tlp-aaa")
+	cfg := config.DoctorConfig{WorktreeRigWarnSize: "10GB", WorktreeRigErrorSize: "50GB"}
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, cfg, fixedSize(20*1024*1024*1024))
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "warn threshold") {
+		t.Errorf("message = %q, want the warn threshold named", r.Message)
+	}
+}
+
+func TestRigWorktreesCheck_UnderThresholds_OKButStillReportsCount(t *testing.T) {
+	rigPath := makeWorktreeDirs(t, "tlp-aaa", "tlp-bbb")
+	cfg := config.DoctorConfig{WorktreeRigWarnSize: "10GB", WorktreeRigErrorSize: "50GB"}
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, cfg, fixedSize(1024*1024*1024))
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK", r.Status, r.Message)
+	}
+	// An OK status must still be honest about what is there — the
+	// original bug was a green line that implied nothing existed.
+	if !strings.Contains(r.Message, "2 per-bead worktree(s)") {
+		t.Errorf("message = %q, want the count even when under threshold", r.Message)
+	}
+	if r.FixHint != "" {
+		t.Errorf("FixHint = %q, want empty for OK result", r.FixHint)
+	}
+}
+
+func TestRigWorktreesCheck_NoWorktreesDir_OKAndNamesThePath(t *testing.T) {
+	rigPath := t.TempDir()
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, config.DoctorConfig{}, fixedSize(0))
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK", r.Status, r.Message)
+	}
+	// Naming the path is the point: "no worktrees directory" unqualified
+	// is what made the old message a false claim.
+	if !strings.Contains(r.Message, filepath.Join(rigPath, "worktrees")) {
+		t.Errorf("message = %q, want the absent path named", r.Message)
+	}
+}
+
+func TestRigWorktreesCheck_EmptyWorktreesDir_OK(t *testing.T) {
+	rigPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rigPath, "worktrees"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, config.DoctorConfig{}, fixedSize(0))
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no per-bead worktrees") {
+		t.Errorf("message = %q, want empty-directory wording", r.Message)
+	}
+}
+
+func TestRigWorktreesCheck_FilesAreNotCountedAsWorktrees(t *testing.T) {
+	rigPath := makeWorktreeDirs(t, "tlp-aaa")
+	if err := os.WriteFile(filepath.Join(rigPath, "worktrees", "README"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, config.DoctorConfig{}, fixedSize(1))
+
+	r := c.Run(&CheckContext{})
+
+	if !strings.Contains(r.Message, "1 per-bead worktree(s)") {
+		t.Errorf("message = %q, want only the directory counted", r.Message)
+	}
+}
+
+// "We can't tell" must not read as "we're fine" — the same policy
+// WorktreeDiskSizeCheck applies to measurement failure.
+func TestRigWorktreesCheck_MeasureFails_WarnsAndKeepsTheCount(t *testing.T) {
+	rigPath := makeWorktreeDirs(t, "tlp-aaa", "tlp-bbb")
+	c := newRigWorktreesCheckWithMeasure(t, rigPath, config.DoctorConfig{}, func(string) (int64, bool, error) {
+		return 0, false, errors.New("du exploded")
+	})
+
+	r := c.Run(&CheckContext{})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d (%s), want StatusWarning", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "2 per-bead worktree(s)") {
+		t.Errorf("message = %q, want the count preserved when size is unknown", r.Message)
+	}
+	if len(r.Details) == 0 || !strings.Contains(strings.Join(r.Details, " "), "du exploded") {
+		t.Errorf("Details = %v, want the underlying measurement error", r.Details)
+	}
+}
+
+// Removal belongs to the worktree-prune order, which owns the safety
+// criterion. doctor --fix must not grow a second, weaker opinion.
+func TestRigWorktreesCheck_IsObservationOnly(t *testing.T) {
+	c := NewRigWorktreesCheck(config.Rig{Name: "r", Path: t.TempDir()}, config.DoctorConfig{})
+	if c.CanFix() {
+		t.Error("CanFix() = true, want false — removal is the prune order's job")
+	}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Errorf("Fix() = %v, want nil no-op", err)
+	}
+	if c.WarmupEligible() {
+		t.Error("WarmupEligible() = true, want false")
+	}
+}
+
+// The city-scoped check's message was a positive false claim: it said
+// "no worktrees directory" on a box whose rig worktrees/ held 28 GB.
+func TestWorktreeCheck_AbsentCityDirMessageNamesGcWorktrees(t *testing.T) {
+	c := &WorktreeCheck{}
+
+	r := c.Run(&CheckContext{CityPath: t.TempDir()})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, ".gc/worktrees") {
+		t.Errorf("message = %q, want the .gc/worktrees scope named", r.Message)
+	}
+}
+
+func TestWorktreeCheck_EmptyCityDirMessageNamesGcWorktrees(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "worktrees"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	c := &WorktreeCheck{}
+
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, ".gc/worktrees") {
+		t.Errorf("message = %q, want the .gc/worktrees scope named", r.Message)
+	}
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -170,6 +170,10 @@ func (c *RigPathCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *RigWorktreesCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *SkillCollisionCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## Summary

All three worktree checks resolve their root against the city: `WorktreeCheck` (`internal/doctor/checks.go`), `WorktreeDiskSizeCheck` and `NestedWorktreePruneCheck` (`internal/doctor/checks_semantic.go`) all walk `$CITY/.gc/worktrees/`. But core's own formulas create a second population at the **rig** root — `mol-polecat-commit.toml:72` and `mol-scoped-work.toml:101` both do `WORKTREE_PATH=$(pwd)/worktrees/"$WORK_BEAD_ID"` — and no check has ever looked there. On the affected city doctor printed

```
OK worktrees             - no worktrees directory
OK worktree-disk-size    - no .gc/worktrees directory
OK nested-worktree-prune - no .gc/worktrees directory
```

against a rig whose `worktrees/` held 28 GB across 82 trees. The first line is the worst of the three: unqualified, it reads as a claim about every worktree on the box, and it was false. `git worktree prune` doesn't help either — git considers all of them live, so it reaps nothing.

Adds `RigWorktreesCheck` (`rig:<rig>:worktrees`), registered in `cmd_doctor.go`'s existing per-rig loop next to `NewRigPathCheck` so it inherits the suspended-rig and empty-path skips. It counts the directory entries under `<rig.Path>/worktrees/` and measures the root **once** through the injectable `measureDir` (production `duDirBytes`) rather than once per worktree — a rig can hold dozens and this runs on every doctor invocation. Thresholds are the existing `[doctor].worktree_rig_warn_size` / `worktree_rig_error_size` pair: the question ("is a worktree population eating this disk?") is the same one the city-scoped size check asks, and a second knob would be a second thing to keep in sync. An OK result still prints the count and size, because a green line that implies nothing is there is the bug being fixed. Unreadable directory and failed measurement both warn rather than pass — "we can't tell" must not look like "we're fine", the same policy `WorktreeDiskSizeCheck` applies.

**Observation only**: `CanFix()` is false, `Fix()` is a no-op. Per-worktree classification (closed-bead, detached HEAD, clean/dirty) and removal are deliberately excluded — that logic already lives in the prune order that owns the safety criterion (clean tree, no unpushed work, `git worktree remove` without `--force` as the gate, in-flight detached heads left alone), and giving `doctor --fix` a second, weaker opinion about worktree disposability would create two sources of truth.

Also qualifies the two vague `WorktreeCheck` messages: `"no worktrees directory"` → `"no .gc/worktrees directory"` and `"no worktrees"` → `"no agent worktrees under .gc/worktrees"`, matching what the other two checks already say.

Purely additive to the check set plus those two strings. No existing check changes scope, status or thresholds, so a city with no rig `worktrees/` directory gains one `OK rig:<rig>:worktrees - no <path> directory` line and nothing else moves. `internal/config/config.go` doc comments now name both consuming checks, which propagates through `go run ./cmd/genschema` into `docs/reference/config.md` and `city-schema.{json,txt}`.

Tracking bead: `ga-1zx4k`. No linked issue — self-contained bug fix.

## Testing

- New `internal/doctor/checks_rig_worktrees_test.go`, 10 cases with `measureDir` injected so nothing shells out to `du`: count + size at error / warn / under-threshold, absent and empty directories, stray files not counted as worktrees, measurement failure warning while preserving the count, observation-only, and the check name.
- Confirmed RED: the two `WorktreeCheck` message assertions fail against the pre-change strings (`message = "no worktrees directory", want the .gc/worktrees scope named`).
- `go test ./internal/doctor/ ./internal/config/ ./cmd/gc/ ./test/docsync` all green; `go vet ./internal/doctor/ ./cmd/gc/` clean; `gofmt -l` empty.
- `make check-docs` green after regenerating with `go run ./cmd/genschema`.
- `make check`: green (`fmt-check lint vet check-release-dist-ignore check-routed-test-rows check-split-topology-rows check-residency-boundary test`, exit 0).
- `make test-integration` not run — no runtime, controller or workflow behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
