### PR TITLE
fix(suspend): route runtime state through supervisor

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1814,23 +1814,26 @@ func (cs *controllerState) ResumeAgent(name string) error {
 	})
 }
 
-// SuspendRig writes suspended=true on the rig in city.toml.
+// SuspendRig records a runtime-only suspension override and pokes the
+// reconciler. Runtime suspension does not recompose authored config: the
+// mutation did not change it, and treating the poke as a config write creates
+// an unrelated config generation and reload barrier.
 func (cs *controllerState) SuspendRig(name string) error {
-	return cs.mutateAndPoke(func() error {
+	return cs.mutateRuntimeStateAndPoke(func() error {
 		return cs.editor.SuspendRig(name)
 	})
 }
 
-// ResumeRig clears suspended on the rig in city.toml.
+// ResumeRig records a runtime-only resume override and pokes the reconciler.
 func (cs *controllerState) ResumeRig(name string) error {
-	return cs.mutateAndPoke(func() error {
+	return cs.mutateRuntimeStateAndPoke(func() error {
 		return cs.editor.ResumeRig(name)
 	})
 }
 
-// SuspendCity sets workspace.suspended = true.
+// SuspendCity records a runtime-only city suspension override.
 func (cs *controllerState) SuspendCity() error {
-	if err := cs.mutateAndPoke(func() error {
+	if err := cs.mutateRuntimeStateAndPoke(func() error {
 		return cs.editor.SuspendCity()
 	}); err != nil {
 		return err
@@ -1841,9 +1844,9 @@ func (cs *controllerState) SuspendCity() error {
 	return nil
 }
 
-// ResumeCity sets workspace.suspended = false.
+// ResumeCity records a runtime-only city resume override.
 func (cs *controllerState) ResumeCity() error {
-	if err := cs.mutateAndPoke(func() error {
+	if err := cs.mutateRuntimeStateAndPoke(func() error {
 		return cs.editor.ResumeCity()
 	}); err != nil {
 		return err
@@ -2868,6 +2871,20 @@ func (cs *controllerState) mutateAndPoke(mutate func() error) error {
 	cs.markConfigMutationPending(revision)
 	if cs.configDirty != nil {
 		cs.configDirty.Store(true)
+	}
+	cs.Poke()
+	return nil
+}
+
+// mutateRuntimeStateAndPoke applies a mutation whose durable source of truth
+// lives under .gc/runtime rather than in authored city configuration. The
+// Editor method owns the shared per-city mutation lock. There is deliberately
+// no config reload and no configDirty transition here: the existing composed
+// snapshot (including imported-pack entries) remains authoritative while the
+// poke asks the reconciler to re-read runtime state.
+func (cs *controllerState) mutateRuntimeStateAndPoke(mutate func() error) error {
+	if err := mutate(); err != nil {
+		return err
 	}
 	cs.Poke()
 	return nil

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -3169,10 +3169,11 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 	// instead of spawning managed Dolt. Other rows are unaffected.
 	t.Setenv("GC_BEADS", "file")
 	cases := []struct {
-		name    string
-		initial func(*config.City)
-		mutate  func(*controllerState) error
-		verify  func(t *testing.T, cfg *config.City, cityDir string)
+		name        string
+		initial     func(*config.City)
+		mutate      func(*controllerState) error
+		verify      func(t *testing.T, cfg *config.City, cityDir string)
+		runtimeOnly bool
 	}{
 		{
 			name: "suspend agent",
@@ -3202,7 +3203,8 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 			},
 		},
 		{
-			name: "suspend rig",
+			name:        "suspend rig",
+			runtimeOnly: true,
 			mutate: func(cs *controllerState) error {
 				return cs.SuspendRig("rig1")
 			},
@@ -3221,7 +3223,8 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 			},
 		},
 		{
-			name: "resume rig",
+			name:        "resume rig",
+			runtimeOnly: true,
 			initial: func(cfg *config.City) {
 				cfg.Rigs[0].SuspendedOnStart = true
 			},
@@ -3245,7 +3248,8 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 			},
 		},
 		{
-			name: "suspend city",
+			name:        "suspend city",
+			runtimeOnly: true,
 			mutate: func(cs *controllerState) error {
 				return cs.SuspendCity()
 			},
@@ -3264,7 +3268,8 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 			},
 		},
 		{
-			name: "resume city",
+			name:        "resume city",
+			runtimeOnly: true,
 			initial: func(cfg *config.City) {
 				cfg.Workspace.SuspendedOnStart = true
 			},
@@ -3561,8 +3566,11 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 			default:
 				t.Fatal("expected controller mutation to poke reconciler")
 			}
-			if cs.configDirty == nil || !cs.configDirty.Load() {
-				t.Fatal("expected controller mutation to mark config dirty")
+			if cs.configDirty == nil {
+				t.Fatal("controller mutation harness has no config dirty flag")
+			}
+			if got, want := cs.configDirty.Load(), !tc.runtimeOnly; got != want {
+				t.Fatalf("config dirty = %v, want %v (runtimeOnly=%v)", got, want, tc.runtimeOnly)
 			}
 
 			got, err := config.Load(fsys.OSFS{}, tomlPath)

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -957,7 +957,7 @@ func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	cityPath := ctx.CityPath
-	if c := apiClient(cityPath); c != nil {
+	if c, _ := supervisorFallthroughAPIClient(cityPath); c != nil {
 		err := c.SuspendRig(rigName)
 		if err == nil {
 			fmt.Fprintf(stdout, "Suspended rig '%s'\n", rigName) //nolint:errcheck // best-effort stdout
@@ -1071,7 +1071,7 @@ func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	cityPath := ctx.CityPath
-	if c := apiClient(cityPath); c != nil {
+	if c, _ := supervisorFallthroughAPIClient(cityPath); c != nil {
 		err := c.ResumeRig(rigName)
 		if err == nil {
 			fmt.Fprintf(stdout, "Resumed rig '%s'\n", rigName) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -75,7 +75,11 @@ func cmdSuspend(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc suspend: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if c := apiClient(cityPath); c != nil {
+	// A supervisor-managed city has a live controller socket but normally no
+	// standalone [api] port. Route through the supervisor API in that common
+	// case so the mutation also pokes reconciliation immediately; a direct file
+	// fallback cannot provide that wake-up handshake.
+	if c, _ := supervisorFallthroughAPIClient(cityPath); c != nil {
 		err := c.SuspendCity()
 		if err == nil {
 			return writeCitySuspensionSuccess(stdout, stderr, cityPath, true, jsonOut)
@@ -96,7 +100,9 @@ func cmdResume(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc resume: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if c := apiClient(cityPath); c != nil {
+	// See cmdSuspend: supervisor routing couples the durable runtime-state write
+	// with an immediate reconciler poke.
+	if c, _ := supervisorFallthroughAPIClient(cityPath); c != nil {
 		err := c.ResumeCity()
 		if err == nil {
 			return writeCitySuspensionSuccess(stdout, stderr, cityPath, false, jsonOut)

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -145,7 +145,7 @@ func doSuspendCity(fs fsys.FS, cityPath string, suspend bool, jsonOut bool, stdo
 		return 1
 	}
 
-	rec := openCityRecorder(stderr)
+	rec := openCityRecorderAt(cityPath, stderr)
 	if suspend {
 		rec.Record(events.Event{
 			Type:  events.CitySuspended,

--- a/cmd/gc/cmd_suspend_test.go
+++ b/cmd/gc/cmd_suspend_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
@@ -73,6 +75,100 @@ func TestSuspendResume(t *testing.T) {
 	}
 	if v, ok := suspensionstate.ExplicitCity(st); !ok || v {
 		t.Errorf("runtime state should record explicit resume after doSuspendCity(false); got (%v, %v)", v, ok)
+	}
+}
+
+// TestDoSuspendCityExplicitPathDoesNotMutateAmbientCity pins the fallback
+// isolation contract: the explicit cityPath owns the runtime state, event,
+// and generated provider shim even when the process context resolves to a
+// different city. The working directory is nested beneath the ambient city;
+// GC_CITY_PATH makes that production discovery result explicit because test
+// binaries intentionally refuse unpinned upward city discovery.
+func TestDoSuspendCityExplicitPathDoesNotMutateAmbientCity(t *testing.T) {
+	clearGCEnv(t)
+
+	root := t.TempDir()
+	gcHome := filepath.Join(root, "gc-home")
+	ambientCity := filepath.Join(root, "ambient-city")
+	ambientWorkDir := filepath.Join(ambientCity, "nested", "worktree")
+	explicitCity := filepath.Join(root, "explicit-city")
+	for _, dir := range []string{gcHome, ambientWorkDir, explicitCity} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeMinimalCityToml(t, ambientCity)
+	writeMinimalCityToml(t, explicitCity)
+	ambientEventPath := filepath.Join(ambientCity, ".gc", "events.jsonl")
+	ambientShimPath := filepath.Join(ambientCity, ".gc", "scripts", "gc-beads-bd.sh")
+	ambientEventSentinel := []byte("{\"seq\":1,\"type\":\"test.ambient-sentinel\",\"ts\":\"2026-08-27T00:00:00Z\"}\n")
+	ambientShimSentinel := []byte("#!/bin/sh\n# ambient sentinel\nexit 99\n")
+	for _, dir := range []string{filepath.Dir(ambientEventPath), filepath.Dir(ambientShimPath)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir ambient runtime dir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(ambientEventPath, ambientEventSentinel, 0o644); err != nil {
+		t.Fatalf("write ambient event sentinel: %v", err)
+	}
+	if err := os.WriteFile(ambientShimPath, ambientShimSentinel, 0o755); err != nil {
+		t.Fatalf("write ambient shim sentinel: %v", err)
+	}
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("GC_CITY_PATH", ambientCity)
+	t.Setenv("GC_CEILING_DIRECTORIES", root)
+	setCwd(t, ambientWorkDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSuspendCity(fsys.OSFS{}, explicitCity, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("suspend code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	st, err := suspensionstate.Load(fsys.OSFS{}, explicitCity)
+	if err != nil {
+		t.Fatalf("load explicit suspension state: %v", err)
+	}
+	if !suspensionstate.IsCitySuspended(st) {
+		t.Fatal("explicit city did not receive suspended runtime state")
+	}
+
+	explicitEvents := filepath.Join(explicitCity, ".gc", "events.jsonl")
+	recorded, err := events.ReadFiltered(explicitEvents, events.Filter{Type: events.CitySuspended})
+	if err != nil {
+		t.Fatalf("read explicit city events: %v", err)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("explicit city suspended events = %d, want 1", len(recorded))
+	}
+
+	explicitShim := filepath.Join(explicitCity, ".gc", "scripts", "gc-beads-bd.sh")
+	shimData, err := os.ReadFile(explicitShim)
+	if err != nil {
+		t.Fatalf("read explicit city provider shim: %v", err)
+	}
+	wantTarget, err := bundledGcBeadsBdScriptTarget()
+	if err != nil {
+		t.Fatalf("resolve expected provider shim target: %v", err)
+	}
+	if !strings.Contains(string(shimData), wantTarget) {
+		t.Fatalf("explicit city provider shim does not target isolated cache %q:\n%s", wantTarget, shimData)
+	}
+
+	for path, want := range map[string][]byte{
+		ambientEventPath: ambientEventSentinel,
+		ambientShimPath:  ambientShimSentinel,
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read ambient sentinel %s: %v", path, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("ambient city artifact %s was mutated:\n got: %q\nwant: %q", path, got, want)
+		}
+	}
+	ambientState := filepath.Join(ambientCity, ".gc", "runtime", "suspension-state.json")
+	if _, err := os.Stat(ambientState); !os.IsNotExist(err) {
+		t.Fatalf("ambient suspension state exists or cannot be safely classified: %v", err)
 	}
 }
 

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -711,6 +711,9 @@ func (e *Editor) ResumeRig(name string) error {
 // in .gc/runtime/suspension-state.json. The legacy `[workspace] suspended`
 // field in city.toml is no longer touched.
 func (e *Editor) SuspendCity() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	cityPath := filepath.Dir(e.tomlPath)
 	t := true
 	return suspensionstate.SetCitySuspended(e.fs, cityPath, &t)
@@ -720,6 +723,9 @@ func (e *Editor) SuspendCity() error {
 // state file. The explicit-resume override sticks across city restarts
 // even when [workspace] declares suspended_on_start = true.
 func (e *Editor) ResumeCity() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	cityPath := filepath.Dir(e.tomlPath)
 	f := false
 	return suspensionstate.SetCitySuspended(e.fs, cityPath, &f)

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -579,6 +579,8 @@ func waitForReport(t *testing.T, cityDir, agentName string, timeout time.Duratio
 		time.Sleep(500 * time.Millisecond)
 	}
 
+	logE2EReportTimeoutDiagnostics(t, cityDir, agentName)
+
 	// Timeout: show what we have.
 	data, err := os.ReadFile(reportPath)
 	if err != nil {
@@ -590,6 +592,33 @@ func waitForReport(t *testing.T, cityDir, agentName string, timeout time.Duratio
 	}
 	t.Fatalf("timed out waiting for report from %s (STATUS=complete not found):\n%s", agentName, string(data))
 	return nil // unreachable
+}
+
+func logE2EReportTimeoutDiagnostics(t *testing.T, cityDir, agentName string) {
+	t.Helper()
+	env := commandEnvForDir(cityDir, false)
+	if gcHome := parseEnvList(env)["GC_HOME"]; gcHome != "" {
+		if data, err := os.ReadFile(filepath.Join(gcHome, "supervisor.log")); err == nil {
+			t.Logf("report timeout for %s: isolated supervisor log:\n%s", agentName, string(data))
+		} else {
+			t.Logf("report timeout for %s: read isolated supervisor log: %v", agentName, err)
+		}
+	}
+	if out, err := runGCWithEnv(env, "", "supervisor", "status"); err != nil {
+		t.Logf("report timeout for %s: supervisor status failed: %v\n%s", agentName, err, out)
+	} else {
+		t.Logf("report timeout for %s: supervisor status:\n%s", agentName, out)
+	}
+	if out, err := runGCWithEnv(env, cityDir, "status", "--json"); err != nil {
+		t.Logf("report timeout for %s: city status failed: %v\n%s", agentName, err, out)
+	} else {
+		t.Logf("report timeout for %s: city status:\n%s", agentName, out)
+	}
+	if out, err := runGCWithEnv(env, cityDir, "config", "show", "--json"); err != nil {
+		t.Logf("report timeout for %s: composed config failed: %v\n%s", agentName, err, out)
+	} else {
+		t.Logf("report timeout for %s: composed config:\n%s", agentName, out)
+	}
 }
 
 // waitForPoolMemberReports resolves a pool template's live members and returns


### PR DESCRIPTION
## Summary

- route city and rig runtime suspension through the supervisor client when a managed city has no standalone API port
- keep runtime-only suspension changes out of authored-config reload and dirty-generation handling
- serialize city suspension-state writes with the existing editor lock
- add failure-only E2E diagnostics for supervisor, city status, and composed config

## Root cause

A supervisor-managed city normally has a live controller socket but no standalone API port. The suspend and resume commands used the general API router, which intentionally returned no client in that shape, then fell back to a direct runtime-state write. That fallback could not poke reconciliation. The controller path also treated the runtime-only write as authored configuration, creating an unrelated config generation and reload barrier.

## Testing

- [ ] `make check`
- [ ] `make check-docs` (not applicable; no docs changed)
- [x] `make test-integration` equivalent focused lifecycle coverage: `go test -tags=integration ./test/integration -run TestE2E_SuspendResume_\(Agent\|City\)$ -count=1 -timeout=180s`
- [x] `go test ./cmd/gc ./internal/configedit`
- [x] `go vet ./cmd/gc ./internal/configedit`
- [x] reproduced the prior city lifecycle failure before the fix; repeated real tmux city and agent-to-city lifecycle cohorts pass after the fix

## Checklist

- [x] No issue is required: this fixes a reproduced regression in supervisor-managed suspend/resume routing and includes regression coverage.
- [x] Added or updated tests for behavior changes.
- [x] No user-facing documentation change is required; command semantics are unchanged.
- [x] No breaking changes or migration steps.
