### PR TITLE
fix(graphroute): source pool continuation-group opt-in from the immutable binding (follow-up to #5622)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1106,6 +1106,12 @@ func decorateDynamicFragmentRecipe(fragment *formula.FragmentRecipe, source bead
 		if err != nil {
 			return err
 		}
+		// Capture the formula-declared continuation group from the authored
+		// (freshly-cloned) step metadata so the pool opt-in is sourced immutably
+		// through the binding, matching DecorateGraphWorkflowRecipeWithDefaultBinding.
+		// The leaf now clears any group the binding does not carry, so omitting
+		// this on the dynamic-fragment path would drop every declared group.
+		binding.ContinuationGroup = strings.TrimSpace(step.Metadata[beadmeta.ContinuationGroupMetadataKey])
 		if graphroute.IsControlDispatcherKind(step.Metadata[beadmeta.KindMetadataKey]) {
 			controlRigContext := graphRouteBindingRigContext(binding)
 			if storeScoped {

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -52,6 +52,14 @@ type GraphRouteBinding struct {
 	DirectSessionID string
 	RigContext      string
 	MetadataOnly    bool
+	// ContinuationGroup is the formula-declared continuation group for a
+	// pool-routed (MetadataOnly) step, captured from the authored recipe
+	// metadata at decoration time. It is the immutable source of the pool
+	// opt-in: ApplyGraphRouteBinding pins the step to a slot only when this is
+	// non-empty, and never consults the step's own (mutable, re-decoratable)
+	// metadata for the decision. Empty means the formula did not opt in, and a
+	// re-decorated step's stale group is cleared rather than preserved.
+	ContinuationGroup string
 }
 
 type graphStepTarget struct {
@@ -186,16 +194,27 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 	if binding.MetadataOnly {
 		// Pool-routed step: the pool decides which slot runs it. Whether the
 		// molecule's steps must share one slot is the formula's call, declared as
-		// a continuation group; preassignHookContinuationGroup then pins the
-		// siblings to whichever slot claims first (#2978). Stamping a group here
-		// instead would apply that judgment to every pool-routed molecule whether
-		// its formula asked for it or not — a routing decision Go is not entitled
-		// to make. Affinity tracks the group so a re-decorated step never keeps a
-		// requirement its current binding no longer declares.
-		if strings.TrimSpace(step.Metadata[beadmeta.ContinuationGroupMetadataKey]) != "" {
+		// a continuation group and captured into the binding from the authored
+		// recipe at decoration time; preassignHookContinuationGroup then pins the
+		// siblings to whichever slot claims first (#2978). Stamping a group Go
+		// manufactured would apply that judgment to every pool-routed molecule
+		// whether its formula asked for it or not — a routing decision Go is not
+		// entitled to make.
+		//
+		// The opt-in reads binding.ContinuationGroup (the immutable source),
+		// never the step's own mutable metadata, so a re-decorated step can never
+		// re-affirm a stale group its current binding no longer declares. When the
+		// formula opted in, stamp the group + affinity; otherwise clear the group
+		// and affinity together (the pinned pair, per
+		// beadmeta.SessionAffinityMetadataKeys) so no stale group survives to
+		// mis-vacuum later pool claims.
+		if group := strings.TrimSpace(binding.ContinuationGroup); group != "" {
+			step.Metadata[beadmeta.ContinuationGroupMetadataKey] = group
 			step.Metadata[beadmeta.SessionAffinityMetadataKey] = "require"
 		} else {
-			delete(step.Metadata, beadmeta.SessionAffinityMetadataKey)
+			for _, key := range beadmeta.SessionAffinityMetadataKeys {
+				delete(step.Metadata, key)
+			}
 		}
 		step.Assignee = ""
 		return
@@ -597,6 +616,12 @@ func DecorateGraphWorkflowRecipeWithDefaultBinding(recipe *formula.Recipe, route
 		if err != nil {
 			return err
 		}
+		// Capture the formula-declared continuation group from the authored
+		// (freshly-cloned) step metadata so the pool opt-in is sourced immutably
+		// through the binding rather than re-read from metadata a later
+		// decoration may have mutated (the finding [1] re-decoration concern).
+		// binding is a per-step value copy, so this never pollutes the route cache.
+		binding.ContinuationGroup = strings.TrimSpace(step.Metadata[beadmeta.ContinuationGroupMetadataKey])
 		if IsControlDispatcherKind(step.Metadata[beadmeta.KindMetadataKey]) {
 			AssignGraphStepRoute(step, binding, &controlRoute)
 			continue

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -1118,41 +1118,62 @@ func TestApplyGraphControlRouteBinding_ClearsStaleFallbackMetadata(t *testing.T)
 }
 
 // Pinning a molecule's steps to one pool slot is the formula's decision, so
-// routing only honors a continuation group the formula already declared. It
-// must never manufacture one: a blanket group made every pool-routed molecule
-// single-slot, and on multi-agent formulas it pinned steps to a slot whose
-// template could not run them.
+// routing only honors a continuation group the formula already declared,
+// threaded through the binding as the immutable source of truth. It must never
+// manufacture one: a blanket group made every pool-routed molecule single-slot,
+// and on multi-agent formulas it pinned steps to a slot whose template could
+// not run them. The opt-in is read from binding.ContinuationGroup, never from
+// the step's own (mutable, possibly re-decorated) metadata.
 func TestApplyGraphRouteBinding_PoolRouted_ContinuationGroupIsFormulaOptIn(t *testing.T) {
 	tests := []struct {
-		name       string
-		metadata   map[string]string
-		wantGroup  string
-		wantAffini string
+		name         string
+		stepMetadata map[string]string
+		bindingGroup string
+		wantGroup    string
+		wantAffini   string
 	}{
 		{
-			name:     "no declared group leaves the step unpinned",
-			metadata: map[string]string{},
+			name:         "no declared group leaves the step unpinned",
+			stepMetadata: map[string]string{},
 		},
 		{
-			name:       "declared group requires slot affinity",
-			metadata:   map[string]string{"gc.continuation_group": "review-chain"},
-			wantGroup:  "review-chain",
-			wantAffini: "require",
+			name:         "declared group requires slot affinity",
+			bindingGroup: "review-chain",
+			wantGroup:    "review-chain",
+			wantAffini:   "require",
 		},
 		{
 			name: "re-decoration drops affinity when the group is gone",
-			metadata: map[string]string{
+			stepMetadata: map[string]string{
 				"gc.session_affinity": "require",
+			},
+		},
+		{
+			// Reachability proof for the finding [1] concern: the opt-in reads
+			// the immutable binding, never the mutable step metadata. A step that
+			// arrives carrying a stale group its current binding did not declare
+			// is cleared (group + affinity together), so
+			// preassignHookContinuationGroup cannot vacuum later pool claims onto
+			// the stale group.
+			name: "stale group from a prior decoration is cleared, not preserved",
+			stepMetadata: map[string]string{
+				"gc.continuation_group": "pool-workflow",
+				"gc.session_affinity":   "require",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			step := &formula.RecipeStep{Metadata: tt.metadata}
+			metadata := tt.stepMetadata
+			if metadata == nil {
+				metadata = map[string]string{}
+			}
+			step := &formula.RecipeStep{Metadata: metadata}
 			ApplyGraphRouteBinding(step, GraphRouteBinding{
-				QualifiedName: "gascity/polecat",
-				MetadataOnly:  true,
+				QualifiedName:     "gascity/polecat",
+				MetadataOnly:      true,
+				ContinuationGroup: tt.bindingGroup,
 			})
 
 			if got := step.Metadata["gc.continuation_group"]; got != tt.wantGroup {
@@ -1168,6 +1189,61 @@ func TestApplyGraphRouteBinding_PoolRouted_ContinuationGroupIsFormulaOptIn(t *te
 				t.Errorf("Assignee = %q, want empty (pool slots claim at runtime)", step.Assignee)
 			}
 		})
+	}
+}
+
+// TestDecorateGraphWorkflowRecipe_PoolContinuationGroupOptIn locks the opt-in
+// contract end-to-end through DecorateGraphWorkflowRecipe (the clone → resolve →
+// stamp path a real molecule takes), not just at the leaf. A formula-declared
+// group must survive decoration onto the stamped pool step with slot affinity;
+// a pool step the formula did not opt in must end unpinned. Together with the
+// leaf-level "stale group is cleared" case, this closes the finding [1]
+// re-decoration concern: the group that reaches a step is exactly the one its
+// formula declared, sourced immutably through the binding.
+func TestDecorateGraphWorkflowRecipe_PoolContinuationGroupOptIn(t *testing.T) {
+	cfg := &config.City{Agents: []config.Agent{
+		{Name: "polecat", MaxActiveSessions: intPtr(2)}, // pool → MetadataOnly binding
+		{Name: "control-dispatcher", MaxActiveSessions: intPtr(1)},
+	}}
+	recipe := &formula.Recipe{
+		Name: "wf-optin",
+		Steps: []formula.RecipeStep{
+			{ID: "wf-optin", IsRoot: true, Metadata: map[string]string{
+				beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+				beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+			}},
+			{ID: "wf-optin.pinned", Metadata: map[string]string{
+				beadmeta.RunTargetMetadataKey:         "polecat",
+				beadmeta.ContinuationGroupMetadataKey: "review-chain",
+			}},
+			{ID: "wf-optin.free", Metadata: map[string]string{
+				beadmeta.RunTargetMetadataKey: "polecat",
+			}},
+		},
+	}
+
+	err := DecorateGraphWorkflowRecipe(
+		recipe, nil, "", "city", "test-city", "city:test",
+		"polecat", "", nil, "test-city", cfg, Deps{Resolver: testAgentResolver{}},
+	)
+	if err != nil {
+		t.Fatalf("DecorateGraphWorkflowRecipe: %v", err)
+	}
+
+	pinned := recipe.Steps[1]
+	if got := pinned.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "review-chain" {
+		t.Errorf("pinned gc.continuation_group = %q, want review-chain (formula opt-in survives decoration)", got)
+	}
+	if got := pinned.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "require" {
+		t.Errorf("pinned gc.session_affinity = %q, want require", got)
+	}
+
+	free := recipe.Steps[2]
+	if got := free.Metadata[beadmeta.ContinuationGroupMetadataKey]; got != "" {
+		t.Errorf("free gc.continuation_group = %q, want empty (formula did not opt in)", got)
+	}
+	if got := free.Metadata[beadmeta.SessionAffinityMetadataKey]; got != "" {
+		t.Errorf("free gc.session_affinity = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Maintainer follow-up to #5622

- **Original PR:** https://github.com/gastownhall/gascity/pull/5622
- **Title:** fix(graphroute): make the pool continuation group a formula opt-in
- **State:** MERGED
- **Configured base:** `main` (original GitHub base `main` — no base mismatch)

#5622 was merged at the contributor head while the maintainer adoption review
was still in flight. The review's final iteration produced one maintainer fixup
that resolved a **major** correctness finding, and that fixup is **not** part of
the merged commit. This follow-up carries only that maintainer fix forward onto
`main`; all contributor commits from #5622 are already merged.

### What this carries

**`fix(graphroute): source pool continuation-group opt-in from the immutable binding`**

The pool-routed (`MetadataOnly`) branch of `ApplyGraphRouteBinding` sourced the
continuation-group opt-in from *mutable* step metadata and preserved whatever
group was already present. A stale `gc.continuation_group` surviving a
re-decoration could therefore re-affirm slot affinity on a group the current
formula never declared, and `preassignHookContinuationGroup` would then vacuum
later pool claims onto the wrong session — the exact failure class #5622 set out
to fix.

The fix threads the formula-declared group through a new **immutable**
`GraphRouteBinding.ContinuationGroup` field, captured from the freshly-cloned
authored recipe metadata in both decorate loops
(`DecorateGraphWorkflowRecipeWithDefaultBinding` and
`decorateDynamicFragmentRecipe`). The leaf now sources the opt-in from that
binding value, never the step's own metadata: it stamps the group + affinity
only when the formula opted in, and otherwise clears the group and affinity
together (the pinned pair) so no stale group can survive. A decorate-level test
locks the declared-survives / undeclared-stays-unpinned contract, and a
leaf-level test proves a stale group from a prior decoration is cleared rather
than preserved.

### Scope

Cherry-picked cleanly onto current `main`. 3 files changed, +133 / −26:
`cmd/gc/cmd_convoy_dispatch.go`, `internal/graphroute/graphroute.go`,
`internal/graphroute/graphroute_test.go`.

---
_Maintainer follow-up carrying the reviewed fix from `/adopt-pr` review of #5622. Original contributor commits preserved on `main` via #5622._
