### PR TITLE
fix(lint): recognize nested bd subcommands

### DIFF
--- a/internal/bdflags/bdflags.go
+++ b/internal/bdflags/bdflags.go
@@ -29,8 +29,9 @@ var globalBoolFlags = map[string]bool{
 
 // valueFlagsBySub holds each subcommand's value-consuming flags (beyond the
 // global set), keyed by subcommand: a single word ("update") or, for
-// compound bd subcommands, "parent child" ("mol pour"). The key set here
-// defines every subcommand this package knows about — see Known/Subcommands.
+// compound bd subcommands, all command words joined by spaces ("mol pour" or
+// "mol wisp gc"). The key set here defines every subcommand this package knows
+// about — see Known/Subcommands.
 var valueFlagsBySub = map[string]map[string]bool{
 	"create": {
 		"--acceptance": true, "--append-notes": true, "-a": true, "--assignee": true,
@@ -104,6 +105,12 @@ var valueFlagsBySub = map[string]map[string]bool{
 	"mol wisp": {
 		"--var": true,
 	},
+	// bd v1.1.0 exposes gc as a command below "mol wisp". Keep these flags
+	// pinned even though discovery can read them from `bd mol wisp gc --help`:
+	// discovery deliberately falls back to this table when bd is unavailable.
+	"mol wisp gc": {
+		"--age": true, "--exclude-type": true,
+	},
 	"mol burn": {},
 	"gate check": {
 		"-l": true, "--limit": true, "-t": true, "--type": true,
@@ -162,6 +169,9 @@ var boolFlagsBySub = map[string]map[string]bool{
 	},
 	"mol wisp": {
 		"--dry-run": true, "--root-only": true,
+	},
+	"mol wisp gc": {
+		"--all": true, "--closed": true, "--dry-run": true, "-f": true, "--force": true,
 	},
 	"mol burn": {
 		"--dry-run": true, "--force": true,

--- a/internal/bdflags/bdflags_test.go
+++ b/internal/bdflags/bdflags_test.go
@@ -90,7 +90,7 @@ func TestSubcommandsListsAllKnownKeys(t *testing.T) {
 	want := []string{
 		"close", "create", "delete", "dep add", "dep list", "dep remove",
 		"gate check", "gate list", "list", "mol burn", "mol current",
-		"mol pour", "mol wisp", "ready", "reopen", "show", "update",
+		"mol pour", "mol wisp", "mol wisp gc", "ready", "reopen", "show", "update",
 	}
 	got := Subcommands()
 	sort.Strings(got)
@@ -237,6 +237,16 @@ func TestCompoundSubcommandFlagSets(t *testing.T) {
 	if ValueFlags("gate check") == nil {
 		t.Fatal(`ValueFlags("gate check") = nil, want non-nil`)
 	}
+	for _, flag := range []string{"--age", "--exclude-type"} {
+		if !ValueFlags("mol wisp gc")[flag] {
+			t.Errorf(`ValueFlags("mol wisp gc")[%q] = false, want true`, flag)
+		}
+	}
+	for _, flag := range []string{"--all", "--closed", "--dry-run", "-f", "--force"} {
+		if !BoolFlags("mol wisp gc")[flag] {
+			t.Errorf(`BoolFlags("mol wisp gc")[%q] = false, want true`, flag)
+		}
+	}
 }
 
 func TestScanUnknownFlagsCleanInvocationsProduceNoFindings(t *testing.T) {
@@ -253,6 +263,8 @@ func TestScanUnknownFlagsCleanInvocationsProduceNoFindings(t *testing.T) {
 		"gc bd ready --label=pool:worker --unassigned --limit=1 --json",
 		`gc bd create "..." -t task`,
 		"gc bd dep add <tests-id> <auth-id>   # tests need auth first",
+		"gc bd mol wisp gc --age 24h --dry-run",
+		"bd mol wisp gc --closed --force --exclude-type agent,rig",
 		"`gc bd list --status=open`",
 		"`gc bd list --status=in_progress`",
 		"`gc bd ready --unassigned`",
@@ -300,6 +312,19 @@ func TestScanUnknownFlagsDetectsTypoInCompoundSubcommand(t *testing.T) {
 	}
 	if findings[0].Flag != "--asignee" {
 		t.Errorf("Flag = %q, want %q", findings[0].Flag, "--asignee")
+	}
+}
+
+func TestScanUnknownFlagsUsesLongestNestedSubcommand(t *testing.T) {
+	findings := ScanUnknownFlags([]byte("gc bd mol wisp gc --age 24h --dry-rnu"))
+	if len(findings) != 1 {
+		t.Fatalf("ScanUnknownFlags() = %v, want exactly 1 finding", findings)
+	}
+	if findings[0].Subcommand != "mol wisp gc" {
+		t.Errorf("Subcommand = %q, want %q", findings[0].Subcommand, "mol wisp gc")
+	}
+	if findings[0].Flag != "--dry-rnu" {
+		t.Errorf("Flag = %q, want %q", findings[0].Flag, "--dry-rnu")
 	}
 }
 

--- a/internal/bdflags/scan.go
+++ b/internal/bdflags/scan.go
@@ -244,20 +244,28 @@ func bdSubcommandStart(tokens []string, i int) (start int, viaGC bool) {
 	}
 }
 
-// matchSubcommand returns the longest known subcommand key starting at
-// token index i, preferring the two-token compound form (e.g. "mol pour")
-// over the single-token form (e.g. "update").
+// matchSubcommand returns the longest known subcommand key starting at token
+// index i. Keys may be nested to any depth (for example "mol wisp gc"), so
+// matching is derived from the manifest rather than capped at two tokens.
 func matchSubcommand(tokens []string, i int) (key string, consumed int, ok bool) {
 	if i >= len(tokens) {
 		return "", 0, false
 	}
-	if i+1 < len(tokens) {
-		if two := tokens[i] + " " + tokens[i+1]; Known(two) {
-			return two, 2, true
+	for _, candidate := range Subcommands() {
+		parts := strings.Fields(candidate)
+		if len(parts) <= consumed || i+len(parts) > len(tokens) {
+			continue
+		}
+		matches := true
+		for offset, part := range parts {
+			if tokens[i+offset] != part {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			key, consumed, ok = candidate, len(parts), true
 		}
 	}
-	if Known(tokens[i]) {
-		return tokens[i], 1, true
-	}
-	return "", 0, false
+	return key, consumed, ok
 }


### PR DESCRIPTION
## What this changes

`gc lint` now recognizes manifest subcommands at arbitrary nesting depth and
models `bd mol wisp gc` as its own command. The static fallback table includes
the value and boolean flags exposed by `bd v1.1.0`; live help discovery still
augments that table when `bd` is available.

## Why

The scanner previously capped compound commands at two tokens. For a valid
invocation such as `gc bd mol wisp gc --age 24h --dry-run`, it selected the
parent `mol wisp` manifest, treated `gc` as positional data, and incorrectly
reported `--age` as unknown. The current `gastown` pack contains this command,
so an exact current Gas City build could not lint the current pack cleanly.

Matching is now derived from the manifest and selects the longest exact
command prefix. This preserves typo detection: `--dry-rnu` is still reported
against `mol wisp gc`.

Related to #5221. This intentionally does not close that broader issue because
its separate hidden `create --label` case remains out of scope.

## Verification

- `go test ./internal/bdflags -count=1`
- `go test -tags=integration ./internal/bdflags -count=1`
- `go test -race ./internal/bdflags -count=1`
- `go test ./cmd/gc -run TestLint -count=1`
- `go test ./cmd/gc -count=1`
- `go vet ./internal/bdflags ./cmd/gc`
- `./scripts/check-generated-docs-drift.sh`
- built `bin/gc` and ran it against the deployment configuration: before this
  patch, two `bd-unknown-flag` errors at the current pack's wisp-GC lines;
  after this patch, zero errors and `passed: true`.
