### PR TITLE
fix(dashboardbff): unwrap the response writer before the Flusher check on run-detail stream

### DIFF
--- a/internal/api/dashboardbff/rundetail_stream.go
+++ b/internal/api/dashboardbff/rundetail_stream.go
@@ -103,8 +103,8 @@ func (p *Plane) handleRunDetailStream(w http.ResponseWriter, r *http.Request) {
 	}
 	runID := r.PathValue("runId")
 
-	flusher, ok := w.(http.Flusher)
-	if !ok {
+	flusher := findFlusher(w)
+	if flusher == nil {
 		// A ResponseWriter that cannot flush cannot stream; fail closed so the
 		// SPA falls back to the GET + nudge path rather than hanging on a stream
 		// that never delivers a frame.
@@ -256,4 +256,25 @@ func frameSeq(detail runproj.FormulaRunDetail) int64 {
 		return detail.SnapshotEventSeq.Seq
 	}
 	return 0
+}
+
+// findFlusher unwraps w to find one that supports http.Flusher. Middleware
+// wrappers commonly embed the http.ResponseWriter interface (not the
+// concrete writer), which promotes only the interface's own methods
+// (Header/Write/WriteHeader) -- not Flush -- so a bare type assertion on the
+// wrapper can fail even though the underlying writer supports it.
+func findFlusher(w http.ResponseWriter) http.Flusher {
+	type unwrapper interface {
+		Unwrap() http.ResponseWriter
+	}
+	for {
+		if f, ok := w.(http.Flusher); ok {
+			return f
+		}
+		if u, ok := w.(unwrapper); ok {
+			w = u.Unwrap()
+			continue
+		}
+		return nil
+	}
 }

--- a/internal/api/dashboardbff/rundetail_stream_test.go
+++ b/internal/api/dashboardbff/rundetail_stream_test.go
@@ -490,6 +490,79 @@ func TestRunDetailStreamUnsupportedRun422(t *testing.T) {
 // window and 404 after it expires, before any stream body — covered by
 // TestRunDetailStreamUnknownRunWarmingGrace in rundetail_grace_test.go.
 
+// unwrapOnlyWriter wraps an http.ResponseWriter but promotes only Unwrap, not
+// Flush — mirroring the production logging middleware's responseWriter, which
+// embeds the http.ResponseWriter interface, so Flush is never promoted even
+// though the underlying writer (here, an httptest.ResponseRecorder)
+// implements it. frameWritten closes once, after the first Write, so a test
+// can safely inspect the underlying recorder from another goroutine without
+// racing the handler's writes.
+type unwrapOnlyWriter struct {
+	http.ResponseWriter
+	once         sync.Once
+	frameWritten chan struct{}
+}
+
+func (u *unwrapOnlyWriter) Unwrap() http.ResponseWriter { return u.ResponseWriter }
+
+func (u *unwrapOnlyWriter) Write(b []byte) (int, error) {
+	n, err := u.ResponseWriter.Write(b)
+	u.once.Do(func() { close(u.frameWritten) })
+	return n, err
+}
+
+// TestRunDetailStreamFlusherUnwrapsWrappedWriter is the regression guard for
+// the wrapped-ResponseWriter path: every other test in this file hands the
+// handler an httptest.ResponseRecorder directly, which natively implements
+// http.Flusher, so none of them exercise the case that actually breaks in
+// production — a middleware wrapper exposing only Unwrap. This must reach a
+// real 200 SSE response rather than the 500 "streaming unsupported" a bare
+// w.(http.Flusher) assertion produces against such a wrapper.
+func TestRunDetailStreamFlusherUnwrapsWrappedWriter(t *testing.T) {
+	dir := t.TempDir()
+	writeEventLog(t, filepath.Join(dir, ".gc", "events.jsonl"), runDetailRootEvent())
+	p := New(Deps{Resolver: fakeResolver{paths: map[string]string{"alpha": dir}}})
+	p.Start(t.Context())
+	defer p.Stop()
+
+	rec := httptest.NewRecorder()
+	wrapped := &unwrapOnlyWriter{ResponseWriter: rec, frameWritten: make(chan struct{})}
+	if _, ok := any(wrapped).(http.Flusher); ok {
+		t.Fatal("unwrapOnlyWriter must not itself satisfy http.Flusher — that would defeat the point of this test")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/api/city/alpha/runs/run1/detail/stream", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		p.Handler().ServeHTTP(wrapped, req)
+		close(done)
+	}()
+
+	select {
+	case <-wrapped.frameWritten:
+	case <-time.After(hangBudget):
+		t.Fatal("no frame written through the wrapped writer before deadline (likely regressed to the 500 streaming-unsupported path)")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(hangBudget):
+		t.Fatal("handler did not return after context cancel")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "streaming unsupported") {
+		t.Fatalf("got the flusher-unsupported error even though the wrapped writer supports Flush via Unwrap: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "event: detail") {
+		t.Fatalf("no detail frame in body: %q", rec.Body.String())
+	}
+}
+
 // TestRunDetailStreamHeartbeat proves a heartbeat comment frame is emitted after
 // the (shortened) heartbeat interval when no data change fires.
 func TestRunDetailStreamHeartbeat(t *testing.T) {


### PR DESCRIPTION
## Summary

The dashboard BFF's run-detail SSE route (`GET /api/city/{city}/runs/{runId}/detail/stream`) always failed with `500 {"error":"streaming unsupported"}` — unconditionally, in ~50µs, even for a nonexistent run id, so the handler was bailing before it ever resolved anything.

Root cause: the logging middleware wraps every `ResponseWriter` in a struct that embeds the `http.ResponseWriter` interface (not the concrete writer), so `Flush` is never promoted to the wrapper. A bare `w.(http.Flusher)` type assertion on that wrapper fails even though the real underlying writer supports it fine — the `/v0` SSE routes on the same server already handle this correctly via `sse.go`'s `findFlusher`, walking `Unwrap()` until it finds one. This route just wasn't doing that.

## Fix

- Added `findFlusher`, mirroring the existing `/v0` pattern: walks `Unwrap()` until it finds a writer that implements `http.Flusher`, or returns `nil` if none do.
- Swapped the bare type assertion for `findFlusher(w)`.
- Added a regression test (`TestRunDetailStreamFlusherUnwrapsWrappedWriter`) that wraps `httptest.ResponseRecorder` in a writer exposing only `Unwrap` (not `Flush` directly) — matching the shape the production middleware actually produces. Every existing test in this file hands the handler a recorder directly, which natively implements `Flusher` and never exercised this path.

Fixes #5675.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l` empty
- [x] `go test ./internal/api/dashboardbff/... -run TestRunDetailStream` — all pass, including the new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>