### PR TITLE
feat(cmd/gc): remind an agent whose stop-pending drain never took — and lead-fix the red main

### DIFF
--- a/cmd/gc/drain_reminder.go
+++ b/cmd/gc/drain_reminder.go
@@ -1,0 +1,401 @@
+package main
+
+// The drain reminder: a stop nobody was ever asked to make.
+//
+// A drain-acked session is moved to the durable stop-pending state and its
+// runtime is stopped asynchronously. When that stop does not take — the pane
+// survives the signal, the process reparents, the provider refuses — the row
+// stays `state=draining, state_reason=drain-ack-stop-pending` with a LIVE
+// runtime, and the controller re-queues the same stop on every tick, forever.
+// Nothing in that loop ever tells the AGENT anything. It cannot: the drain
+// signal is metadata, learned by polling, and the session this happens to is
+// the one sitting idle at its prompt not polling anything.
+//
+// So the loop has no exit but an operator killing the pane. This pass adds the
+// one thing missing from it: ask the agent. It runs off the same durable row
+// state the re-examination already reads, in the bounded shape the two nudge
+// backstops use (observe, remind, back off, give up), and it is purely
+// informational — it never stops anything.
+//
+// # It is anchored on the ROW, not on the drain tracker
+//
+// The in-memory drainTracker is the wrong anchor and an earlier revision of
+// this file proved it: a tracked drain is tracker-resident for about two
+// advances before the stop-pending handover clears it, the whole tracked phase
+// is bounded by defaultDrainTimeout, and a controller restart drops the tracker
+// entirely. The wedged rows — the ones that sit for days — have no tracker
+// entry at all. Everything here therefore keys off the session bead and the
+// durable stop-pending state, which are exactly what survives.
+//
+// # The reminder carries the identity because the pane's environment may not
+//
+// `gc runtime drain-ack` with no argument binds the acknowledgement through the
+// caller's own GC_SESSION_ID/GC_INSTANCE_TOKEN. An adopted pane whose
+// environment did not survive a restart therefore acks as nobody, which reads
+// downstream as no acknowledgement at all. The reminder text names the session
+// id so the agent runs the explicit-argument form, which resolves the target
+// from the store instead of from the pane.
+//
+// # Idleness comes from the runtime, not from a cache
+//
+// The quiet test reads the provider's activity signal directly (raw tmux window
+// activity on the tmux provider), never the observation cache: on an idle pane
+// that cache can read hours fresher than tmux does (ga-gg4mv), which would hold
+// the reminder forever on exactly the sessions it exists for. An unreadable
+// signal HOLDS rather than proceeds — the #312 rule that "we cannot tell" is
+// never "idle".
+//
+// Known bounded exposure: the k8s provider's GetLastActivity shells
+// `tmux display-message -p '#{session_activity}'` inside the pod, and
+// session-level activity does not advance on pane I/O for a detached session
+// (see Tmux.rawSessionActivity, which queries per-window activity for exactly
+// this reason). A busy k8s agent therefore reads as idle-since-attach and can
+// be nudged mid-turn. Every other provider is fail-closed. The exposure is
+// capped at drainReminderMaxAttempts informational nudges per drain and is
+// tracked as its own fix rather than papered over here.
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessions "github.com/gastownhall/gascity/internal/session"
+)
+
+// Pacing. There is no observe-first grace: the caller only reaches this pass
+// for a row that is ALREADY durably wedged — drain-acked, stop-pending, and
+// still alive after its stop was queued — so the first sight of one is already
+// late. After that it is one reminder per drainReminderInterval, capped at
+// drainReminderMaxAttempts so a session that will never answer costs a bounded
+// number of nudges rather than one per tick forever.
+const (
+	drainReminderInterval    = 10 * time.Minute
+	drainReminderGrace       = 2 * time.Minute
+	drainReminderMaxAttempts = 3
+)
+
+// Session-bead metadata keys. Persisted for the reason every sibling backstop
+// persists its pacing state: a controller restart must RESUME the state
+// machine, never replay it.
+const (
+	drainReminderCountKey = "drain_reminder_count"
+	// drainReminderFailedKey counts the attempts whose delivery FAILED. The
+	// spend is what bounds the loop and it is never unwound — a permanently
+	// input-dead pane must not re-send forever — but a spent attempt that never
+	// arrived is not a reminder anybody ignored, and the escalation's record has
+	// to be able to tell those apart.
+	drainReminderFailedKey = "drain_reminder_failed"
+	drainReminderAtKey     = "drain_reminder_at"
+	// drainReminderDrainKey scopes the budget to ONE drain of one incarnation.
+	// Binding to the instance token alone was not enough: a canceled drain
+	// leaves its markers on a session that goes back to work, and the next
+	// drain of that same incarnation would inherit a spent budget it never
+	// earned — skipping its reminders, or (on the enterprise line) authorizing
+	// an escalation for a drain nobody was ever asked about.
+	drainReminderDrainKey = "drain_reminder_drain"
+	// drainReminderHoldKey names why the most recent DUE evaluation did not
+	// remind. Written on transition only, so a session held for hours costs one
+	// write, not one per tick.
+	drainReminderHoldKey = "drain_reminder_hold"
+)
+
+// Hold reasons recorded in drainReminderHoldKey.
+const (
+	drainReminderHoldBusy       = "busy"
+	drainReminderHoldAttached   = "attached"
+	drainReminderHoldUnreadable = "activity_unreadable"
+	drainReminderHoldAckUnknown = "ack_unreadable"
+	drainReminderHoldExhausted  = "attempts_exhausted"
+)
+
+// drainReminderLabel prefixes this pass's journal lines so they are greppable
+// next to the sibling backstops' own labeled output.
+const drainReminderLabel = "drain-reminder"
+
+// drainReminderOutcome is what one row's reminder evaluation did.
+type drainReminderOutcome int
+
+const (
+	// drainReminderSkipped: nothing was owed (not this pass's row, not due, or
+	// already acknowledged). No write of any kind.
+	drainReminderSkipped drainReminderOutcome = iota
+	// drainReminderHeld: a reminder was due but the evidence said hold.
+	drainReminderHeld
+	// drainReminderDelivered: a reminder was reserved and delivered.
+	drainReminderDelivered
+	// drainReminderExhausted: the budget is spent and the row is still
+	// unacknowledged. On the enterprise line this is the escalation's cue.
+	drainReminderExhausted
+)
+
+// maybeRemindDrainingSession evaluates one durably stop-pending row whose
+// runtime is still alive and, when all the preconditions hold, delivers one
+// reminder nudge through the provider's hardened nudge path.
+//
+// The gates are ordered cheapest-first on purpose. This runs inside the
+// reconcile tick, so the overwhelmingly common answer — "not due" — must cost
+// one store read and zero provider round-trips; a tmux show-environment is a
+// subprocess, and paying two of them per wedged row per tick would put the
+// reconciler's throughput behind a wedged tmux server.
+func maybeRemindDrainingSession(
+	sp runtime.Provider,
+	store beads.Store,
+	info sessions.Info,
+	clk clock.Clock,
+	stdout io.Writer,
+) drainReminderOutcome {
+	if sp == nil || store == nil || clk == nil {
+		return drainReminderSkipped
+	}
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	name := strings.TrimSpace(info.SessionNameMetadata)
+	if name == "" || strings.TrimSpace(info.ID) == "" {
+		return drainReminderSkipped
+	}
+	// Only the wedge class. A row that is not durably stop-pending is either
+	// converging normally or belongs to a lane with its own convergence.
+	if !isDrainAckStopPendingInfo(info) {
+		return drainReminderSkipped
+	}
+	// Pool seats only. A named row's acknowledgement lane refuses it
+	// (named_row, policy_unsupported) and converges it through legacy timeout
+	// instead, so a reminder here would talk an agent into minting exactly the
+	// agent provenance that routes its row into a refusal class — making a
+	// named row's outcome WORSE than the behavior it has today.
+	if !isPoolManagedSessionInfo(info) {
+		return drainReminderSkipped
+	}
+
+	// One store read pays for both the pacing state and the drain identity.
+	bead, err := store.Get(info.ID)
+	if err != nil {
+		return drainReminderSkipped
+	}
+	drainID := drainReminderIdentity(bead)
+	if drainID == "" {
+		return drainReminderSkipped // no drain to scope a budget to
+	}
+	attempts, failed, last := drainReminderState(bead, drainID)
+
+	now := clk.Now()
+	exhausted := attempts >= drainReminderMaxAttempts
+	if !exhausted && attempts > 0 && now.Sub(last) < drainReminderInterval {
+		return drainReminderSkipped // waiting out the cadence — free, and the common case
+	}
+
+	// From here something will be written, so the acknowledgement pin runs
+	// first. A landed agent ack is the outcome this whole pass exists to
+	// produce; a reminder that clobbers one — by bumping a counter, by leaving a
+	// breadcrumb over it — converts a success into the refusal that wedges the
+	// row. An UNREADABLE source holds rather than proceeds: this guard stands in
+	// front of writes and a destructive-adjacent lane, so it fails closed.
+	source, sourceErr := sp.GetMeta(name, reconcilerDrainAckSourceKey)
+	if sourceErr != nil {
+		return drainReminderHeld // no breadcrumb: writing one is itself a write
+	}
+	if strings.TrimSpace(source) == drainAckSourceAgentValue {
+		return drainReminderSkipped
+	}
+
+	if exhausted {
+		// Budget spent. Say so once — the transition is the observable fact, and
+		// the caller decides whether anything escalates from here.
+		if noteDrainReminderHold(store, info, drainReminderHoldExhausted) {
+			fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+				"%s: drain reminders exhausted for %s after %s (still unacknowledged)\n",
+				drainReminderLabel, name, drainReminderSpendPhrase(attempts, failed))
+		}
+		return drainReminderExhausted
+	}
+
+	if !sp.IsRunning(name) {
+		return drainReminderSkipped // the stop took after all; the finalizer owns it
+	}
+	// A human at the pane is already handling this row; do not type into their
+	// session.
+	if sp.IsAttached(name) {
+		noteDrainReminderHold(store, info, drainReminderHoldAttached)
+		return drainReminderHeld
+	}
+	// Quiet check. An agent in the middle of a turn is answering its own drain;
+	// an unreadable signal is not evidence that it is not.
+	activity, activityErr := sp.GetLastActivity(name)
+	if activityErr != nil || activity.IsZero() {
+		noteDrainReminderHold(store, info, drainReminderHoldUnreadable)
+		return drainReminderHeld
+	}
+	if now.Sub(activity) < drainReminderGrace {
+		noteDrainReminderHold(store, info, drainReminderHoldBusy)
+		return drainReminderHeld
+	}
+
+	// Write ahead of the delivery, exactly as the sibling backstops do: a crash
+	// or a store failure between here and the nudge can cost one attempt, but it
+	// can never replay an unbounded stream of them.
+	if !writeDrainReminderMarker(store, info, drainID, attempts+1, failed, now, stdout) {
+		return drainReminderSkipped
+	}
+	if err := sp.Nudge(name, runtime.TextContent(drainReminderContent(info))); err != nil {
+		// The attempt is spent either way — the write-ahead above is what bounds
+		// this loop, and unwinding it would let a permanently input-dead pane
+		// re-send forever. Record instead that nothing ARRIVED, so the escalation
+		// that follows reports what actually happened rather than three
+		// conversations that never occurred.
+		//
+		// Limit worth knowing: a nil return is not proof of delivery. The seam
+		// adapter answers nil when it cannot attach, so some failures are
+		// invisible here and are counted as delivered. That is the best knowledge
+		// available at this boundary, and it errs toward the gentler journal line.
+		writeDrainReminderMarker(store, info, drainID, attempts+1, failed+1, now, stdout)
+		fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+			"%s: reminder %d/%d to %s was undeliverable: %v\n",
+			drainReminderLabel, attempts+1, drainReminderMaxAttempts, name, err)
+		return drainReminderSkipped
+	}
+	clearDrainReminderHold(store, info)
+	fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+		"%s: drain reminder %d/%d delivered to %s (stop-pending, unacked)\n",
+		drainReminderLabel, attempts+1, drainReminderMaxAttempts, name)
+	return drainReminderDelivered
+}
+
+// remindStopPendingDrain is the reconciler-facing entry point: it is called from
+// the stop-pending re-examination, on the arm that has just observed the runtime
+// still ALIVE after re-queueing its stop. That arm is the wedge, and it is the
+// only caller — the pass owns no scan of its own.
+func remindStopPendingDrain(sp runtime.Provider, store beads.Store, info sessions.Info, clk clock.Clock, stdout io.Writer) drainReminderOutcome {
+	if clk == nil {
+		clk = clock.Real{}
+	}
+	return maybeRemindDrainingSession(sp, store, info, clk, stdout)
+}
+
+// drainReminderIdentity names the ONE drain a budget belongs to: this
+// incarnation, this drain. Both halves are required — the token alone lets a
+// later drain inherit a canceled drain's spent budget, and drain_at alone would
+// carry across a re-wake.
+func drainReminderIdentity(bead beads.Bead) string {
+	token := strings.TrimSpace(bead.Metadata["instance_token"])
+	drainAt := strings.TrimSpace(bead.Metadata["drain_at"])
+	if token == "" || drainAt == "" {
+		return ""
+	}
+	return token + "/" + drainAt
+}
+
+// drainReminderContent is the reminder text. It names the session id twice on
+// purpose: once so a human reading the pane knows which row this is about, and
+// once inside the command so the agent runs the explicit-argument ack, which
+// binds the requester from the store rather than from a pane environment that
+// may not have survived adoption.
+func drainReminderContent(info sessions.Info) string {
+	id := strings.TrimSpace(info.ID)
+	return fmt.Sprintf(
+		"A drain of session %s (name %s) is pending and unacknowledged. "+
+			"Finish nothing new. Run: gc runtime drain-ack %s — then exit.",
+		id, strings.TrimSpace(info.SessionNameMetadata), id)
+}
+
+// drainReminderState reads the persisted pacing state, resetting it when the
+// markers belong to a different drain than the one in front of us. failed
+// counts the attempts whose delivery returned an error — spent, but never
+// received.
+func drainReminderState(bead beads.Bead, drainID string) (attempts, failed int, last time.Time) {
+	if strings.TrimSpace(bead.Metadata[drainReminderDrainKey]) != drainID {
+		return 0, 0, time.Time{}
+	}
+	return atoiOr0(bead.Metadata[drainReminderCountKey]),
+		atoiOr0(bead.Metadata[drainReminderFailedKey]),
+		parseRFC3339OrZero(bead.Metadata[drainReminderAtKey])
+}
+
+// drainRemindersSpent reports whether the budget for THIS drain is exhausted and
+// nothing more is worth waiting for. It is the durable question the enterprise
+// escalation asks of the markers this file writes.
+//
+// A delivered reminder earns a full interval to be answered. A budget in which
+// every attempt was UNDELIVERABLE earns none: waiting out an answer window for
+// messages that never arrived is waiting for nothing, and the pane that cannot
+// take input is precisely the one no further attempt will reach.
+func drainRemindersSpent(bead beads.Bead, now time.Time) bool {
+	drainID := drainReminderIdentity(bead)
+	if drainID == "" {
+		return false
+	}
+	attempts, failed, last := drainReminderState(bead, drainID)
+	if attempts < drainReminderMaxAttempts || last.IsZero() {
+		return false
+	}
+	if failed >= drainReminderMaxAttempts {
+		return true
+	}
+	return now.Sub(last) >= drainReminderInterval
+}
+
+// drainReminderSpendPhrase names what the budget was actually spent on, so a
+// journal line never claims a conversation that did not happen. It is the whole
+// point of tracking delivery separately from spend: the kill that follows is the
+// right outcome for an input-dead idle pane either way, but the record of why
+// has to be true.
+func drainReminderSpendPhrase(attempts, failed int) string {
+	switch {
+	case failed >= drainReminderMaxAttempts:
+		return fmt.Sprintf("%d undeliverable reminder attempts (input-dead pane)", failed)
+	case failed > 0:
+		return fmt.Sprintf("%d unanswered reminders (%d more undeliverable)", attempts-failed, failed)
+	default:
+		return fmt.Sprintf("%d unanswered reminders", attempts)
+	}
+}
+
+// drainReminderSpendPhraseFor is the bead-facing form for callers that hold the
+// row rather than the counts.
+func drainReminderSpendPhraseFor(bead beads.Bead) string {
+	attempts, failed, _ := drainReminderState(bead, drainReminderIdentity(bead))
+	return drainReminderSpendPhrase(attempts, failed)
+}
+
+func writeDrainReminderMarker(store beads.Store, info sessions.Info, drainID string, attempts, failed int, now time.Time, stdout io.Writer) bool {
+	err := store.SetMetadataBatch(info.ID, map[string]string{
+		drainReminderCountKey:  strconv.Itoa(attempts),
+		drainReminderFailedKey: strconv.Itoa(failed),
+		drainReminderAtKey:     now.UTC().Format(time.RFC3339),
+		drainReminderDrainKey:  drainID,
+	})
+	if err != nil {
+		fmt.Fprintf(stdout, "%s: marking %s failed: %v\n", drainReminderLabel, info.ID, err) //nolint:errcheck // best-effort
+		return false
+	}
+	return true
+}
+
+// noteDrainReminderHold records why this evaluation held, and reports whether
+// that was a TRANSITION. Steady-state holds are write-free, so a row parked on
+// the same reason for a day leaves one breadcrumb rather than a day of them.
+func noteDrainReminderHold(store beads.Store, info sessions.Info, reason string) bool {
+	bead, err := store.Get(info.ID)
+	if err == nil && strings.TrimSpace(bead.Metadata[drainReminderHoldKey]) == reason {
+		return false
+	}
+	if err := store.SetMetadataBatch(info.ID, map[string]string{drainReminderHoldKey: reason}); err != nil {
+		log.Printf("%s: recording hold %q for %s: %v", drainReminderLabel, reason, info.ID, err)
+		return false
+	}
+	return true
+}
+
+func clearDrainReminderHold(store beads.Store, info sessions.Info) {
+	bead, err := store.Get(info.ID)
+	if err != nil || strings.TrimSpace(bead.Metadata[drainReminderHoldKey]) == "" {
+		return
+	}
+	_ = store.SetMetadataBatch(info.ID, map[string]string{drainReminderHoldKey: ""})
+}

--- a/cmd/gc/drain_reminder.go
+++ b/cmd/gc/drain_reminder.go
@@ -45,14 +45,16 @@ package main
 // signal HOLDS rather than proceeds — the #312 rule that "we cannot tell" is
 // never "idle".
 //
-// Known bounded exposure: the k8s provider's GetLastActivity shells
+// Known bounded exposure: the k8s and ssh providers' GetLastActivity shell
 // `tmux display-message -p '#{session_activity}'` inside the pod, and
 // session-level activity does not advance on pane I/O for a detached session
 // (see Tmux.rawSessionActivity, which queries per-window activity for exactly
 // this reason). A busy k8s agent therefore reads as idle-since-attach and can
-// be nudged mid-turn. Every other provider is fail-closed. The exposure is
-// capped at drainReminderMaxAttempts informational nudges per drain and is
-// tracked as its own fix rather than papered over here.
+// be nudged mid-turn. The ssh provider has the same exposure for the same
+// reason (internal/runtime/ssh/provider.go reads #{session_activity} and
+// reports CanReportActivity: true). Every other provider is fail-closed. The
+// exposure is capped at drainReminderMaxAttempts informational nudges per drain
+// and is tracked as its own fix rather than papered over here.
 
 import (
 	"fmt"
@@ -110,7 +112,6 @@ const (
 	drainReminderHoldBusy       = "busy"
 	drainReminderHoldAttached   = "attached"
 	drainReminderHoldUnreadable = "activity_unreadable"
-	drainReminderHoldAckUnknown = "ack_unreadable"
 	drainReminderHoldExhausted  = "attempts_exhausted"
 )
 

--- a/cmd/gc/drain_reminder.go
+++ b/cmd/gc/drain_reminder.go
@@ -158,114 +158,34 @@ func maybeRemindDrainingSession(
 		stdout = io.Discard
 	}
 	name := strings.TrimSpace(info.SessionNameMetadata)
-	if name == "" || strings.TrimSpace(info.ID) == "" {
-		return drainReminderSkipped
-	}
-	// Only the wedge class. A row that is not durably stop-pending is either
-	// converging normally or belongs to a lane with its own convergence.
-	if !isDrainAckStopPendingInfo(info) {
-		return drainReminderSkipped
-	}
-	// Pool seats only. A named row's acknowledgement lane refuses it
-	// (named_row, policy_unsupported) and converges it through legacy timeout
-	// instead, so a reminder here would talk an agent into minting exactly the
-	// agent provenance that routes its row into a refusal class — making a
-	// named row's outcome WORSE than the behavior it has today.
-	if !isPoolManagedSessionInfo(info) {
+	if !drainReminderEligible(info, name) {
 		return drainReminderSkipped
 	}
 
-	// One store read pays for both the pacing state and the drain identity.
-	bead, err := store.Get(info.ID)
-	if err != nil {
+	// One store read pays for both the pacing state and the drain identity, and
+	// the free cadence wait — the overwhelmingly common answer — returns here
+	// before any provider round-trip.
+	due, ok := loadDrainReminderDue(store, info, clk)
+	if !ok {
 		return drainReminderSkipped
-	}
-	drainID := drainReminderIdentity(bead)
-	if drainID == "" {
-		return drainReminderSkipped // no drain to scope a budget to
-	}
-	attempts, failed, last := drainReminderState(bead, drainID)
-
-	now := clk.Now()
-	exhausted := attempts >= drainReminderMaxAttempts
-	if !exhausted && attempts > 0 && now.Sub(last) < drainReminderInterval {
-		return drainReminderSkipped // waiting out the cadence — free, and the common case
 	}
 
 	// From here something will be written, so the acknowledgement pin runs
-	// first. A landed agent ack is the outcome this whole pass exists to
-	// produce; a reminder that clobbers one — by bumping a counter, by leaving a
-	// breadcrumb over it — converts a success into the refusal that wedges the
-	// row. An UNREADABLE source holds rather than proceeds: this guard stands in
-	// front of writes and a destructive-adjacent lane, so it fails closed.
-	source, sourceErr := sp.GetMeta(name, reconcilerDrainAckSourceKey)
-	if sourceErr != nil {
-		return drainReminderHeld // no breadcrumb: writing one is itself a write
-	}
-	if strings.TrimSpace(source) == drainAckSourceAgentValue {
-		return drainReminderSkipped
+	// first: a reminder that clobbers a landed agent ack converts the success
+	// this pass exists to produce into the refusal that wedges the row.
+	if outcome, proceed := drainReminderAckPin(sp, name); !proceed {
+		return outcome
 	}
 
-	if exhausted {
-		// Budget spent. Say so once — the transition is the observable fact, and
-		// the caller decides whether anything escalates from here.
-		if noteDrainReminderHold(store, info, drainReminderHoldExhausted) {
-			fmt.Fprintf(stdout, //nolint:errcheck // best-effort
-				"%s: drain reminders exhausted for %s after %s (still unacknowledged)\n",
-				drainReminderLabel, name, drainReminderSpendPhrase(attempts, failed))
-		}
-		return drainReminderExhausted
+	if due.exhausted {
+		return announceDrainReminderExhausted(store, info, name, due, stdout)
 	}
 
-	if !sp.IsRunning(name) {
-		return drainReminderSkipped // the stop took after all; the finalizer owns it
-	}
-	// A human at the pane is already handling this row; do not type into their
-	// session.
-	if sp.IsAttached(name) {
-		noteDrainReminderHold(store, info, drainReminderHoldAttached)
-		return drainReminderHeld
-	}
-	// Quiet check. An agent in the middle of a turn is answering its own drain;
-	// an unreadable signal is not evidence that it is not.
-	activity, activityErr := sp.GetLastActivity(name)
-	if activityErr != nil || activity.IsZero() {
-		noteDrainReminderHold(store, info, drainReminderHoldUnreadable)
-		return drainReminderHeld
-	}
-	if now.Sub(activity) < drainReminderGrace {
-		noteDrainReminderHold(store, info, drainReminderHoldBusy)
-		return drainReminderHeld
+	if outcome, proceed := drainReminderQuietHold(sp, store, info, name, due.now); !proceed {
+		return outcome
 	}
 
-	// Write ahead of the delivery, exactly as the sibling backstops do: a crash
-	// or a store failure between here and the nudge can cost one attempt, but it
-	// can never replay an unbounded stream of them.
-	if !writeDrainReminderMarker(store, info, drainID, attempts+1, failed, now, stdout) {
-		return drainReminderSkipped
-	}
-	if err := sp.Nudge(name, runtime.TextContent(drainReminderContent(info))); err != nil {
-		// The attempt is spent either way — the write-ahead above is what bounds
-		// this loop, and unwinding it would let a permanently input-dead pane
-		// re-send forever. Record instead that nothing ARRIVED, so the escalation
-		// that follows reports what actually happened rather than three
-		// conversations that never occurred.
-		//
-		// Limit worth knowing: a nil return is not proof of delivery. The seam
-		// adapter answers nil when it cannot attach, so some failures are
-		// invisible here and are counted as delivered. That is the best knowledge
-		// available at this boundary, and it errs toward the gentler journal line.
-		writeDrainReminderMarker(store, info, drainID, attempts+1, failed+1, now, stdout)
-		fmt.Fprintf(stdout, //nolint:errcheck // best-effort
-			"%s: reminder %d/%d to %s was undeliverable: %v\n",
-			drainReminderLabel, attempts+1, drainReminderMaxAttempts, name, err)
-		return drainReminderSkipped
-	}
-	clearDrainReminderHold(store, info)
-	fmt.Fprintf(stdout, //nolint:errcheck // best-effort
-		"%s: drain reminder %d/%d delivered to %s (stop-pending, unacked)\n",
-		drainReminderLabel, attempts+1, drainReminderMaxAttempts, name)
-	return drainReminderDelivered
+	return deliverDrainReminder(sp, store, info, name, due, stdout)
 }
 
 // remindStopPendingDrain is the reconciler-facing entry point: it is called from
@@ -277,6 +197,145 @@ func remindStopPendingDrain(sp runtime.Provider, store beads.Store, info session
 		clk = clock.Real{}
 	}
 	return maybeRemindDrainingSession(sp, store, info, clk, stdout)
+}
+
+// drainReminderDue is the loaded pacing state for a row that has cleared the
+// cheap eligibility gates and is due for evaluation. now is sampled once so
+// every downstream gate reasons from the same instant.
+type drainReminderDue struct {
+	drainID   string
+	attempts  int
+	failed    int
+	last      time.Time
+	now       time.Time
+	exhausted bool
+}
+
+// drainReminderEligible reports whether info names a row this pass may ever
+// remind: it must carry an id, be durably drain-ack stop-pending (the wedge
+// class), and occupy a pool seat. A row that is not durably stop-pending is
+// converging on its own; a named row's acknowledgement lane refuses the agent
+// provenance a reminder would mint (named_row, policy_unsupported) and converges
+// through legacy timeout, so reminding one makes its outcome WORSE than today.
+func drainReminderEligible(info sessions.Info, name string) bool {
+	if name == "" || strings.TrimSpace(info.ID) == "" {
+		return false
+	}
+	if !isDrainAckStopPendingInfo(info) {
+		return false
+	}
+	return isPoolManagedSessionInfo(info)
+}
+
+// loadDrainReminderDue reads the one bead that carries both the drain identity
+// and the pacing markers, then applies the free cadence gate. ok is false when
+// nothing is owed yet: the row cannot be read, has no drain to scope a budget
+// to, or is still waiting out its interval — the common, zero-provider-cost case.
+func loadDrainReminderDue(store beads.Store, info sessions.Info, clk clock.Clock) (drainReminderDue, bool) {
+	bead, err := store.Get(info.ID)
+	if err != nil {
+		return drainReminderDue{}, false
+	}
+	drainID := drainReminderIdentity(bead)
+	if drainID == "" {
+		return drainReminderDue{}, false // no drain to scope a budget to
+	}
+	attempts, failed, last := drainReminderState(bead, drainID)
+	now := clk.Now()
+	exhausted := attempts >= drainReminderMaxAttempts
+	if !exhausted && attempts > 0 && now.Sub(last) < drainReminderInterval {
+		return drainReminderDue{}, false // waiting out the cadence — free, and the common case
+	}
+	return drainReminderDue{
+		drainID:   drainID,
+		attempts:  attempts,
+		failed:    failed,
+		last:      last,
+		now:       now,
+		exhausted: exhausted,
+	}, true
+}
+
+// drainReminderAckPin reads the acknowledgement source ahead of any write. It
+// stands in front of writes and a destructive-adjacent lane, so it fails closed:
+// proceed is false when an UNREADABLE source holds without a breadcrumb (writing
+// one is itself a write over a row whose state could not be read), and when a
+// landed agent ack — the outcome this whole pass exists to produce — must not be
+// clobbered.
+func drainReminderAckPin(sp runtime.Provider, name string) (drainReminderOutcome, bool) {
+	source, err := sp.GetMeta(name, reconcilerDrainAckSourceKey)
+	if err != nil {
+		return drainReminderHeld, false // no breadcrumb: writing one is itself a write
+	}
+	if strings.TrimSpace(source) == drainAckSourceAgentValue {
+		return drainReminderSkipped, false
+	}
+	return drainReminderSkipped, true
+}
+
+// announceDrainReminderExhausted records the spent-budget transition once — the
+// transition is the observable fact, and the caller decides whether anything
+// escalates from a drain that is still unacknowledged.
+func announceDrainReminderExhausted(store beads.Store, info sessions.Info, name string, due drainReminderDue, stdout io.Writer) drainReminderOutcome {
+	if noteDrainReminderHold(store, info, drainReminderHoldExhausted) {
+		fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+			"%s: drain reminders exhausted for %s after %s (still unacknowledged)\n",
+			drainReminderLabel, name, drainReminderSpendPhrase(due.attempts, due.failed))
+	}
+	return drainReminderExhausted
+}
+
+// drainReminderQuietHold runs the liveness and quiet gates that can still stop a
+// due reminder before delivery: the stop finally took, a human is at the pane,
+// or the activity signal is unreadable or too recent (an agent in the middle of
+// a turn is answering its own drain; an unreadable signal is not evidence it is
+// not). proceed is false when one of those holds, carrying the outcome to return.
+func drainReminderQuietHold(sp runtime.Provider, store beads.Store, info sessions.Info, name string, now time.Time) (drainReminderOutcome, bool) {
+	if !sp.IsRunning(name) {
+		return drainReminderSkipped, false // the stop took after all; the finalizer owns it
+	}
+	if sp.IsAttached(name) {
+		noteDrainReminderHold(store, info, drainReminderHoldAttached)
+		return drainReminderHeld, false
+	}
+	activity, err := sp.GetLastActivity(name)
+	if err != nil || activity.IsZero() {
+		noteDrainReminderHold(store, info, drainReminderHoldUnreadable)
+		return drainReminderHeld, false
+	}
+	if now.Sub(activity) < drainReminderGrace {
+		noteDrainReminderHold(store, info, drainReminderHoldBusy)
+		return drainReminderHeld, false
+	}
+	return drainReminderDelivered, true
+}
+
+// deliverDrainReminder writes the pacing marker ahead of the nudge, exactly as
+// the sibling backstops do: a crash between the two costs one attempt but can
+// never replay an unbounded stream. A nudge error still spends the attempt (the
+// write-ahead is what bounds the loop, and unwinding it would let a permanently
+// input-dead pane re-send forever) and records that nothing ARRIVED, so the
+// escalation reports what actually happened.
+func deliverDrainReminder(sp runtime.Provider, store beads.Store, info sessions.Info, name string, due drainReminderDue, stdout io.Writer) drainReminderOutcome {
+	if !writeDrainReminderMarker(store, info, due.drainID, due.attempts+1, due.failed, due.now, stdout) {
+		return drainReminderSkipped
+	}
+	if err := sp.Nudge(name, runtime.TextContent(drainReminderContent(info))); err != nil {
+		// A nil return is not proof of delivery: the seam adapter answers nil when
+		// it cannot attach, so some failures are invisible here and counted as
+		// delivered. That is the best knowledge available at this boundary, and it
+		// errs toward the gentler journal line.
+		writeDrainReminderMarker(store, info, due.drainID, due.attempts+1, due.failed+1, due.now, stdout)
+		fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+			"%s: reminder %d/%d to %s was undeliverable: %v\n",
+			drainReminderLabel, due.attempts+1, drainReminderMaxAttempts, name, err)
+		return drainReminderSkipped
+	}
+	clearDrainReminderHold(store, info)
+	fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+		"%s: drain reminder %d/%d delivered to %s (stop-pending, unacked)\n",
+		drainReminderLabel, due.attempts+1, drainReminderMaxAttempts, name)
+	return drainReminderDelivered
 }
 
 // drainReminderIdentity names the ONE drain a budget belongs to: this

--- a/cmd/gc/drain_reminder_test.go
+++ b/cmd/gc/drain_reminder_test.go
@@ -170,8 +170,8 @@ func (e *drainReminderEnv) beadSnapshot() map[string]string {
 	if err != nil {
 		e.t.Fatalf("read session bead: %v", err)
 	}
-	snapshot := make(map[string]string, 4)
-	for _, key := range []string{drainReminderCountKey, drainReminderAtKey, drainReminderDrainKey, drainReminderHoldKey} {
+	snapshot := make(map[string]string, 5)
+	for _, key := range []string{drainReminderCountKey, drainReminderFailedKey, drainReminderAtKey, drainReminderDrainKey, drainReminderHoldKey} {
 		snapshot[key] = got.Metadata[key]
 	}
 	return snapshot

--- a/cmd/gc/drain_reminder_test.go
+++ b/cmd/gc/drain_reminder_test.go
@@ -1,0 +1,601 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// blindAckSourceProvider fails exactly the acknowledgement-source read. It is
+// how the fail-closed pins distinguish "no ack" from "cannot tell".
+type blindAckSourceProvider struct {
+	*runtime.Fake
+}
+
+func (p *blindAckSourceProvider) GetMeta(name, key string) (string, error) {
+	if key == reconcilerDrainAckSourceKey {
+		return "", fmt.Errorf("session unavailable")
+	}
+	return p.Fake.GetMeta(name, key)
+}
+
+// nudgeFailingProvider is an input-dead pane: the session is alive and idle, but
+// nothing typed at it lands.
+type nudgeFailingProvider struct {
+	*runtime.Fake
+}
+
+func (p *nudgeFailingProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	_ = p.Fake.Nudge(name, content)
+	return fmt.Errorf("input fenced")
+}
+
+// drainReminderEnv is one durably wedged row: drain-acked, moved to
+// stop-pending, its stop queued — and the runtime still alive, idle, and
+// carrying no agent provenance. That is the class that sits for days. Each case
+// below removes exactly one entitlement.
+type drainReminderEnv struct {
+	t       *testing.T
+	sp      *runtime.Fake
+	store   beads.Store
+	clk     *clock.Fake
+	bead    beads.Bead
+	out     *bytes.Buffer
+	name    string
+	now     time.Time
+	drainAt string
+}
+
+func newDrainReminderEnv(t *testing.T) *drainReminderEnv {
+	t.Helper()
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	name := "gc-city-worker-1"
+	drainAt := now.Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+
+	if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+		t.Fatalf("start fake session: %v", err)
+	}
+	// The runtime carries reconciler-authored provenance and no agent ack — the
+	// state the stop-pending re-examination refuses to act on.
+	mustSetMeta(t, sp, name, reconcilerDrainAckSourceKey, reconcilerDrainAckSourceValue)
+	mustSetMeta(t, sp, name, "GC_DRAIN_ACK", "1")
+	sp.SetActivity(name, now.Add(-30*time.Minute))
+
+	bead, err := store.Create(beads.Bead{
+		Title: "session",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			"session_name":   name,
+			"template":       "worker",
+			"generation":     "3",
+			"state":          string(sessionpkg.StateDraining),
+			"state_reason":   sessionpkg.DrainAckStopPendingReason,
+			"drain_at":       drainAt,
+			"instance_token": "tok-a",
+			"pool_managed":   "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	return &drainReminderEnv{
+		t: t, sp: sp, store: store, clk: &clock.Fake{Time: now},
+		bead: bead, out: &bytes.Buffer{}, name: name, now: now, drainAt: drainAt,
+	}
+}
+
+func mustSetMeta(t *testing.T, sp *runtime.Fake, name, key, value string) {
+	t.Helper()
+	if err := sp.SetMeta(name, key, value); err != nil {
+		t.Fatalf("SetMeta %s: %v", key, err)
+	}
+}
+
+func (e *drainReminderEnv) info() sessionpkg.Info {
+	e.t.Helper()
+	got, err := e.store.Get(e.bead.ID)
+	if err != nil {
+		e.t.Fatalf("read session bead: %v", err)
+	}
+	return seedSessionInfo(got)
+}
+
+func (e *drainReminderEnv) remind() drainReminderOutcome {
+	e.t.Helper()
+	return maybeRemindDrainingSession(e.sp, e.store, e.info(), e.clk, e.out)
+}
+
+func (e *drainReminderEnv) remindWith(sp runtime.Provider) drainReminderOutcome {
+	e.t.Helper()
+	return maybeRemindDrainingSession(sp, e.store, e.info(), e.clk, e.out)
+}
+
+func (e *drainReminderEnv) setMeta(kvs map[string]string) {
+	e.t.Helper()
+	if err := e.store.SetMetadataBatch(e.bead.ID, kvs); err != nil {
+		e.t.Fatalf("set session metadata: %v", err)
+	}
+}
+
+func (e *drainReminderEnv) meta(key string) string {
+	e.t.Helper()
+	got, err := e.store.Get(e.bead.ID)
+	if err != nil {
+		e.t.Fatalf("read session bead: %v", err)
+	}
+	return strings.TrimSpace(got.Metadata[key])
+}
+
+func (e *drainReminderEnv) nudges() []runtime.Call {
+	var out []runtime.Call
+	for _, c := range e.sp.SnapshotCalls() {
+		if c.Method == "Nudge" && c.Name == e.name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// providerWrites returns the mutating provider calls, which is what the
+// agent-ack pin asserts the absence of.
+func (e *drainReminderEnv) providerWrites() []runtime.Call {
+	var out []runtime.Call
+	for _, c := range e.sp.SnapshotCalls() {
+		switch c.Method {
+		case "SetMeta", "RemoveMeta", "Nudge", "NudgeNow", "SendKeys", "Stop", "Interrupt":
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// beadSnapshot captures every reminder-owned key so the no-write pins can prove
+// nothing moved.
+func (e *drainReminderEnv) beadSnapshot() map[string]string {
+	e.t.Helper()
+	got, err := e.store.Get(e.bead.ID)
+	if err != nil {
+		e.t.Fatalf("read session bead: %v", err)
+	}
+	snapshot := make(map[string]string, 4)
+	for _, key := range []string{drainReminderCountKey, drainReminderAtKey, drainReminderDrainKey, drainReminderHoldKey} {
+		snapshot[key] = got.Metadata[key]
+	}
+	return snapshot
+}
+
+func (e *drainReminderEnv) assertBeadUnchanged(before map[string]string) {
+	e.t.Helper()
+	after := e.beadSnapshot()
+	for key, want := range before {
+		if after[key] != want {
+			e.t.Errorf("%s changed %q -> %q; this path must write nothing", key, want, after[key])
+		}
+	}
+}
+
+// The wedge, answered. A row whose stop did not take, still alive, still idle,
+// still unacknowledged, draws its first reminder on FIRST SIGHT — there is no
+// observe-first grace, because the caller only reaches here for a row that is
+// already late.
+func TestDrainReminderDeliversOnFirstSightOfAWedgedStopPendingRow(t *testing.T) {
+	e := newDrainReminderEnv(t)
+
+	if got := e.remind(); got != drainReminderDelivered {
+		t.Fatalf("outcome = %v, want delivered", got)
+	}
+	if n := len(e.nudges()); n != 1 {
+		t.Fatalf("nudge count = %d, want 1", n)
+	}
+	if got := e.meta(drainReminderCountKey); got != "1" {
+		t.Errorf("%s = %q, want 1", drainReminderCountKey, got)
+	}
+	if got, want := e.meta(drainReminderDrainKey), "tok-a/"+e.drainAt; got != want {
+		t.Errorf("%s = %q, want %q", drainReminderDrainKey, got, want)
+	}
+	if got := e.meta(drainReminderAtKey); got != e.now.UTC().Format(time.RFC3339) {
+		t.Errorf("%s = %q, want %q", drainReminderAtKey, got, e.now.UTC().Format(time.RFC3339))
+	}
+	if !strings.Contains(e.out.String(), "drain reminder 1/3 delivered to "+e.name) {
+		t.Errorf("journal line missing from %q", e.out.String())
+	}
+}
+
+// The stale-pane-environment survival contract: the no-argument ack binds the
+// requester from the pane's own environment, which an adopted pane may no
+// longer have. The reminder must name the id in the command it asks for.
+func TestDrainReminderContentNamesExplicitAckCommand(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	if got := e.remind(); got != drainReminderDelivered {
+		t.Fatalf("outcome = %v, want delivered", got)
+	}
+	msg := e.nudges()[0].Message
+	if want := "gc runtime drain-ack " + e.bead.ID; !strings.Contains(msg, want) {
+		t.Errorf("nudge %q does not contain %q", msg, want)
+	}
+	if !strings.Contains(msg, "A drain of session "+e.bead.ID) {
+		t.Errorf("nudge %q does not name the session id", msg)
+	}
+	if !strings.Contains(msg, "(name "+e.name+")") {
+		t.Errorf("nudge %q does not name the session name", msg)
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("nudge must be a single line, got %q", msg)
+	}
+}
+
+// Only the wedge class, and only pool seats. The named-row gate is the one the
+// design demanded: a named row's ack lane refuses agent provenance
+// (named_row / policy_unsupported), so talking its agent into minting some
+// would route it into a refusal class it does not sit in today.
+func TestDrainReminderGovernsOnlyWedgedPoolRows(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		patch map[string]string
+	}{
+		{"not draining", map[string]string{"state": "active", "state_reason": ""}},
+		{"draining for another reason", map[string]string{"state_reason": "pool-excess"}},
+		{"named row", map[string]string{"pool_managed": ""}},
+		{"no drain identity", map[string]string{"drain_at": ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newDrainReminderEnv(t)
+			e.setMeta(tc.patch)
+			before := e.beadSnapshot()
+
+			if got := e.remind(); got != drainReminderSkipped {
+				t.Fatalf("outcome = %v, want skipped", got)
+			}
+			if n := len(e.nudges()); n != 0 {
+				t.Errorf("nudge count = %d, want 0", n)
+			}
+			e.assertBeadUnchanged(before)
+		})
+	}
+}
+
+func TestDrainReminderHoldsWhileSessionIsBusy(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	e.sp.SetActivity(e.name, e.now.Add(-10*time.Second))
+
+	if got := e.remind(); got != drainReminderHeld {
+		t.Fatalf("outcome = %v, want held", got)
+	}
+	if n := len(e.nudges()); n != 0 {
+		t.Errorf("nudge count = %d, want 0", n)
+	}
+	if got := e.meta(drainReminderHoldKey); got != drainReminderHoldBusy {
+		t.Errorf("%s = %q, want %q", drainReminderHoldKey, got, drainReminderHoldBusy)
+	}
+	if got := e.meta(drainReminderCountKey); got != "" {
+		t.Errorf("%s = %q, want unset", drainReminderCountKey, got)
+	}
+}
+
+// A human at the pane is already on this row. Do not type into their session.
+func TestDrainReminderHoldsWhileAttached(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	e.sp.SetAttached(e.name, true)
+
+	if got := e.remind(); got != drainReminderHeld {
+		t.Fatalf("outcome = %v, want held", got)
+	}
+	if n := len(e.nudges()); n != 0 {
+		t.Errorf("nudge count = %d, want 0", n)
+	}
+	if got := e.meta(drainReminderHoldKey); got != drainReminderHoldAttached {
+		t.Errorf("%s = %q, want %q", drainReminderHoldKey, got, drainReminderHoldAttached)
+	}
+}
+
+// An unreadable activity signal is not evidence of idleness, and it must say so
+// under its own reason so an operator can tell the two holds apart.
+func TestDrainReminderHoldsWhenActivityUnreadable(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	e.sp.SetActivity(e.name, time.Time{})
+
+	if got := e.remind(); got != drainReminderHeld {
+		t.Fatalf("outcome = %v, want held", got)
+	}
+	if got := e.meta(drainReminderHoldKey); got != drainReminderHoldUnreadable {
+		t.Errorf("%s = %q, want %q", drainReminderHoldKey, got, drainReminderHoldUnreadable)
+	}
+}
+
+// Fail CLOSED on an unreadable acknowledgement. "Cannot tell" is not "no ack":
+// this guard stands in front of every write in the pass, so a transient
+// provider failure must hold, and must not leave a breadcrumb over a row whose
+// state it could not read.
+func TestDrainReminderHoldsAndWritesNothingWhenAckSourceUnreadable(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	before := e.beadSnapshot()
+
+	if got := e.remindWith(&blindAckSourceProvider{Fake: e.sp}); got != drainReminderHeld {
+		t.Fatalf("outcome = %v, want held", got)
+	}
+	if n := len(e.nudges()); n != 0 {
+		t.Errorf("nudge count = %d, want 0", n)
+	}
+	e.assertBeadUnchanged(before)
+}
+
+// The mutation pin. A landed agent acknowledgement is the outcome this pass
+// exists to produce; if the guard is removed the reminder writes over it.
+func TestDrainReminderWritesNothingOnceAgentAcked(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	mustSetMeta(t, e.sp, e.name, reconcilerDrainAckSourceKey, drainAckSourceAgentValue)
+	e.setMeta(map[string]string{
+		drainReminderCountKey: "1",
+		drainReminderAtKey:    e.now.Add(-30 * time.Minute).UTC().Format(time.RFC3339),
+		drainReminderDrainKey: "tok-a/" + e.drainAt,
+	})
+	before := e.beadSnapshot()
+	e.sp.Calls = nil
+
+	if got := e.remind(); got != drainReminderSkipped {
+		t.Fatalf("outcome = %v, want skipped", got)
+	}
+	if writes := e.providerWrites(); len(writes) != 0 {
+		t.Errorf("provider writes = %+v, want none", writes)
+	}
+	if got, _ := e.sp.GetMeta(e.name, reconcilerDrainAckSourceKey); got != drainAckSourceAgentValue {
+		t.Errorf("ack source = %q, want %q (clobbered)", got, drainAckSourceAgentValue)
+	}
+	e.assertBeadUnchanged(before)
+}
+
+// The hot-path pin. "Not due" is the overwhelmingly common answer on a
+// reconcile tick, and it must cost zero provider round-trips: a tmux
+// show-environment is a subprocess, and a wedged tmux server must not be able
+// to stall the reconciler through this pass.
+func TestDrainReminderPacingGateCostsNoProviderReads(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	if got := e.remind(); got != drainReminderDelivered {
+		t.Fatalf("first outcome = %v, want delivered", got)
+	}
+
+	e.clk.Time = e.now.Add(drainReminderInterval - time.Second)
+	e.sp.Calls = nil
+	if got := e.remind(); got != drainReminderSkipped {
+		t.Fatalf("second outcome = %v, want skipped", got)
+	}
+	if calls := e.sp.SnapshotCalls(); len(calls) != 0 {
+		t.Errorf("provider calls while not due = %+v, want none", calls)
+	}
+}
+
+func TestDrainReminderWaitsOutTheCadenceBetweenAttempts(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	if got := e.remind(); got != drainReminderDelivered {
+		t.Fatalf("first outcome = %v, want delivered", got)
+	}
+	e.clk.Time = e.now.Add(drainReminderInterval - time.Second)
+	if got := e.remind(); got != drainReminderSkipped {
+		t.Fatalf("second outcome = %v, want skipped", got)
+	}
+	e.clk.Time = e.now.Add(drainReminderInterval)
+	if got := e.remind(); got != drainReminderDelivered {
+		t.Fatalf("third outcome = %v, want delivered", got)
+	}
+	if n := len(e.nudges()); n != 2 {
+		t.Fatalf("nudge count = %d, want 2", n)
+	}
+	if got := e.meta(drainReminderCountKey); got != "2" {
+		t.Errorf("%s = %q, want 2", drainReminderCountKey, got)
+	}
+}
+
+// The budget belongs to ONE drain, not to an incarnation. A canceled drain
+// leaves its markers behind on a session that goes back to work; the next drain
+// of that same incarnation must start over rather than inherit a spent budget
+// it never earned.
+func TestDrainReminderBudgetIsScopedToOneDrain(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	e.setMeta(map[string]string{
+		drainReminderCountKey: strconv.Itoa(drainReminderMaxAttempts),
+		drainReminderAtKey:    e.now.Add(-time.Hour).UTC().Format(time.RFC3339),
+		drainReminderDrainKey: "tok-a/" + e.now.Add(-9*time.Hour).UTC().Format(time.RFC3339),
+	})
+
+	if got := e.remind(); got != drainReminderDelivered {
+		t.Fatalf("outcome = %v, want delivered (the spent budget belongs to an earlier drain)", got)
+	}
+	if got := e.meta(drainReminderCountKey); got != "1" {
+		t.Errorf("%s = %q, want 1", drainReminderCountKey, got)
+	}
+	if got, want := e.meta(drainReminderDrainKey), "tok-a/"+e.drainAt; got != want {
+		t.Errorf("%s = %q, want %q", drainReminderDrainKey, got, want)
+	}
+}
+
+// The cap is durable: the marker survives a controller restart, so the budget
+// resumes rather than replays, and exhaustion is announced exactly once.
+func TestDrainReminderAttemptCapIsDurableAndAnnouncedOnce(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	for i := 0; i < drainReminderMaxAttempts; i++ {
+		e.clk.Time = e.now.Add(time.Duration(i) * drainReminderInterval)
+		if got := e.remind(); got != drainReminderDelivered {
+			t.Fatalf("attempt %d outcome = %v, want delivered", i+1, got)
+		}
+	}
+	e.clk.Time = e.now.Add(4 * drainReminderInterval)
+	e.out.Reset()
+
+	if got := e.remind(); got != drainReminderExhausted {
+		t.Fatalf("outcome = %v, want exhausted", got)
+	}
+	if n := len(e.nudges()); n != drainReminderMaxAttempts {
+		t.Errorf("nudge count = %d, want %d (the cap must not replay)", n, drainReminderMaxAttempts)
+	}
+	if !strings.Contains(e.out.String(), "drain reminders exhausted for "+e.name) {
+		t.Errorf("exhaustion journal line missing from %q", e.out.String())
+	}
+	if got := e.meta(drainReminderHoldKey); got != drainReminderHoldExhausted {
+		t.Errorf("%s = %q, want %q", drainReminderHoldKey, got, drainReminderHoldExhausted)
+	}
+
+	e.out.Reset()
+	if got := e.remind(); got != drainReminderExhausted {
+		t.Fatalf("repeat outcome = %v, want exhausted", got)
+	}
+	if e.out.Len() != 0 {
+		t.Errorf("exhaustion re-announced: %q", e.out.String())
+	}
+}
+
+func TestDrainReminderSkipsWhenRuntimeIsGone(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	if err := e.sp.Stop(e.name); err != nil {
+		t.Fatalf("stop fake session: %v", err)
+	}
+
+	if got := e.remind(); got != drainReminderSkipped {
+		t.Fatalf("outcome = %v, want skipped", got)
+	}
+	if n := len(e.nudges()); n != 0 {
+		t.Errorf("nudge count = %d, want 0", n)
+	}
+}
+
+// drainRemindersSpent is the durable question the enterprise escalation asks of
+// the markers this file writes; pin it here, where the markers are produced.
+func TestDrainRemindersSpentReadsTheDurableBudget(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	for i := 0; i < drainReminderMaxAttempts; i++ {
+		e.clk.Time = e.now.Add(time.Duration(i) * drainReminderInterval)
+		if got := e.remind(); got != drainReminderDelivered {
+			t.Fatalf("attempt %d outcome = %v, want delivered", i+1, got)
+		}
+	}
+	bead, err := e.store.Get(e.bead.ID)
+	if err != nil {
+		t.Fatalf("read session bead: %v", err)
+	}
+	lastAt := e.now.Add(2 * drainReminderInterval)
+	if drainRemindersSpent(bead, lastAt.Add(drainReminderInterval-time.Second)) {
+		t.Error("budget reported spent before the last reminder had a full interval to be answered")
+	}
+	if !drainRemindersSpent(bead, lastAt.Add(drainReminderInterval)) {
+		t.Error("budget not reported spent after three delivered reminders and a full interval")
+	}
+	// A marker from a different drain does not satisfy it, however old.
+	bead.Metadata[drainReminderDrainKey] = "tok-a/" + e.now.Add(-9*time.Hour).UTC().Format(time.RFC3339)
+	if drainRemindersSpent(bead, lastAt.Add(24*time.Hour)) {
+		t.Error("an earlier drain's spent budget satisfied this drain's precondition")
+	}
+}
+
+// An attempt that never arrived is not a reminder anybody ignored. The spend is
+// never unwound — a permanently input-dead pane must not re-send forever — but
+// it is recorded separately, so the escalation that follows says what actually
+// happened instead of claiming three conversations that never occurred.
+func TestDrainReminderRecordsUndeliverableAttemptsSeparately(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	deaf := &nudgeFailingProvider{Fake: e.sp}
+
+	for i := 0; i < drainReminderMaxAttempts; i++ {
+		e.clk.Time = e.now.Add(time.Duration(i) * drainReminderInterval)
+		if got := e.remindWith(deaf); got != drainReminderSkipped {
+			t.Fatalf("attempt %d outcome = %v, want skipped (nothing was delivered)", i+1, got)
+		}
+	}
+
+	if got := e.meta(drainReminderCountKey); got != strconv.Itoa(drainReminderMaxAttempts) {
+		t.Errorf("%s = %q, want %d: the spend must not be unwound", drainReminderCountKey, got, drainReminderMaxAttempts)
+	}
+	if got := e.meta(drainReminderFailedKey); got != strconv.Itoa(drainReminderMaxAttempts) {
+		t.Errorf("%s = %q, want %d", drainReminderFailedKey, got, drainReminderMaxAttempts)
+	}
+	if !strings.Contains(e.out.String(), "was undeliverable") {
+		t.Errorf("undeliverable journal line missing from %q", e.out.String())
+	}
+
+	bead, err := e.store.Get(e.bead.ID)
+	if err != nil {
+		t.Fatalf("read session bead: %v", err)
+	}
+	// A budget nobody could receive earns no answer window: waiting one out for
+	// messages that never arrived is waiting for nothing.
+	if !drainRemindersSpent(bead, e.clk.Time) {
+		t.Error("an all-undeliverable budget is not reported spent")
+	}
+	want := fmt.Sprintf("%d undeliverable reminder attempts (input-dead pane)", drainReminderMaxAttempts)
+	if got := drainReminderSpendPhraseFor(bead); got != want {
+		t.Errorf("spend phrase = %q, want %q", got, want)
+	}
+}
+
+// The control for the pin above: a delivered budget reads as unanswered, and it
+// still earns its full answer window.
+func TestDrainReminderDeliveredBudgetReadsAsUnanswered(t *testing.T) {
+	e := newDrainReminderEnv(t)
+	for i := 0; i < drainReminderMaxAttempts; i++ {
+		e.clk.Time = e.now.Add(time.Duration(i) * drainReminderInterval)
+		if got := e.remind(); got != drainReminderDelivered {
+			t.Fatalf("attempt %d outcome = %v, want delivered", i+1, got)
+		}
+	}
+	bead, err := e.store.Get(e.bead.ID)
+	if err != nil {
+		t.Fatalf("read session bead: %v", err)
+	}
+	if got := e.meta(drainReminderFailedKey); got != "0" {
+		t.Errorf("%s = %q, want 0", drainReminderFailedKey, got)
+	}
+	if drainRemindersSpent(bead, e.clk.Time) {
+		t.Error("a delivered budget skipped its answer window")
+	}
+	want := fmt.Sprintf("%d unanswered reminders", drainReminderMaxAttempts)
+	if got := drainReminderSpendPhraseFor(bead); got != want {
+		t.Errorf("spend phrase = %q, want %q", got, want)
+	}
+}
+
+// The wiring pin. The stop-pending re-examination is the anchor, and the arm it
+// reminds from is the wedge itself: the stop was queued, the tick came back
+// round, and the runtime is still alive. A row whose runtime is gone takes the
+// finalize arm instead and is never nudged.
+func TestFinalizeDrainAckStopPendingRemindsTheLiveWedgeOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		alive      bool
+		wantNudges int
+	}{
+		{"runtime still alive", true, 1},
+		{"runtime gone", false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newDrainReminderEnv(t)
+			if !tc.alive {
+				if err := e.sp.Stop(e.name); err != nil {
+					t.Fatalf("stop fake session: %v", err)
+				}
+			}
+			e.setMeta(map[string]string{"work_dir": t.TempDir(), "provider": "claude"})
+			cfg := &config.City{Agents: []config.Agent{{Name: "worker", StartCommand: "true"}}}
+
+			finalizeDrainAckStopPendingSessions(
+				t.TempDir(), cfg, e.sp, beads.SessionStore{Store: e.store}, nil,
+				[]sessionpkg.Info{e.info()}, nil, newDrainTracker(), &asyncStartTracker{},
+				e.clk, nil, e.out,
+			)
+
+			if n := len(e.nudges()); n != tc.wantNudges {
+				t.Errorf("nudge count = %d, want %d", n, tc.wantNudges)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -778,7 +778,21 @@ func finalizeDrainAckStopPendingSessions(
 		// pool slot while the agent still runs.
 		processNames := drainAckStopPendingProcessNames(cfg, info)
 		obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, info.ID, processNames)
-		if err != nil || obs.Running || obs.Alive {
+		if err != nil {
+			// Observation unavailable, not "still alive". Re-queue the stop and
+			// say nothing to the agent: a reminder is a claim about the row's
+			// state, and this tick has none.
+			queueDrainAckAsyncStop(cityPath, store, sp, cfg, info.ID, name, info.InstanceToken, processNames, asyncStopTracker, stderr)
+			continue
+		}
+		if obs.Running || obs.Alive {
+			// The stop was already queued and the runtime is still here. This is
+			// the one drain state with no exit of its own: the loop re-queues the
+			// same stop every tick, nothing in it ever tells the AGENT anything,
+			// and the only thing that has ever cleared such a row is an operator
+			// killing the pane. Ask the agent to acknowledge and leave.
+			// See drain_reminder.go.
+			remindStopPendingDrain(sp, store, info, clk, stderr)
 			queueDrainAckAsyncStop(cityPath, store, sp, cfg, info.ID, name, info.InstanceToken, processNames, asyncStopTracker, stderr)
 			continue
 		}


### PR DESCRIPTION
## Summary

**Lead commit — main is red**: `go test ./cmd/gc` does not compile at the current tip; #5094 added two `filterAssignedWorkBeadsForPoolDemand` test call sites at the old signature. Fixed first, droppable independently.

**The feature (ga-b7213):** a drain request is metadata-only — an idle agent never polls, so it never learns; and when a queued stop keeps failing with the runtime alive, `finalizeDrainAckStopPendingSessions` re-queues the same stop forever. This series anchors a REMINDER on that exact live-runtime branch (which already pays for the liveness observation every tick): first sight delivers reminder #1 carrying the canonical explicit-arg ack command (`gc runtime drain-ack <session-id>` — survives stale pane env), then a 10-minute cadence, max 3, markers drain-scoped (`instance_token` + `drain_at`) and write-ahead persisted.

Honest delivery accounting: spend and delivery are separate facts — a delivered budget earns its full answer interval; an all-undeliverable budget (input-dead pane) earns none, and every journal line distinguishes "unanswered reminders" from "undeliverable reminder attempts (input-dead pane)", including the mixed case. The seam adapter's nil-on-attach-failure limit is documented at the call site.

Safety: the reminder writes nothing once the ack source is `agent` (mutation-pinned); idleness reads RAW tmux `session_activity`, not the observation cache; non-tmux providers fail closed (the k8s session-level activity limitation is documented as a bounded informational-nudge exposure).

## Review process

Designed, implemented, and adversarially reviewed in three waves: the first review confirmed 14 findings — including two criticals proving the original tracker-anchored design unreachable for its target population — which forced the durable-row re-anchor; the focused re-review of the rework confirmed one remaining minor (the delivery-accounting honesty above), fixed. 8 mutation-verified pins.

Refs: ga-b7213

🤖 Generated with [Claude Code](https://claude.com/claude-code)