### PR TITLE
chore(license): attribute copyright to Gas City Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Steve Yegge
+Copyright (c) 2026 Gas City Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Updates the copyright line in `LICENSE` from the single-author notice to a project-level one:

```
- Copyright (c) 2025 Steve Yegge
+ Copyright (c) 2026 Gas City Contributors
```

The license itself is unchanged — still MIT, permission and warranty text untouched. `README.md`'s `## License` section already just says "MIT", so no doc change is needed.

## Full diff vs. `main`

One file, one line: `LICENSE:3`. No code, config, docs, or generated artifacts are affected.

## Post-merge

Nothing to deploy. The push to `main` will trigger the usual `gc-edge-publish` rolling edge pre-release, which rebuilds the identical binary.

## Verification

Tests intentionally skipped at the author's request (LICENSE-only change; no Go/web/doc files touched, so pre-commit codegen/lint/vet did not run and pre-push `make test-fast-parallel` was bypassed with `--no-verify`).