### PR TITLE
fix(orders): share the doctor's cron parser and validate schedules at load

### DIFF
--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -173,9 +173,12 @@ Notes per trigger:
   waits `interval` since the last run. Drifts: a 3:02 run means the next is at
   3:07.
 - **`cron`** — a 5-field expression (minute, hour, day-of-month, month,
-  day-of-week) supporting `*`, integers, comma lists (`1,15`), and `*/N` steps.
-  Unlike cooldown it hits the same wall-clock times every day. Fires at most
-  once per minute.
+  day-of-week) supporting `*`, integers, comma lists (`1,15`), ranges (`9-17`),
+  and steps on either (`*/15`, `5-59/10`). A step counts from the start of its
+  range, so `*/2` on day-of-month means the 1st, 3rd, 5th. Every field is
+  bounds-checked at order discovery: an out-of-range or unparseable schedule is
+  a load error, not an order that quietly never fires. Unlike cooldown it hits
+  the same wall-clock times every day. Fires at most once per minute.
 - **`condition`** — the orchestrator runs `sh -c "<check>"` each tick, bounded by
   the order's `check_timeout` (a positive Go duration, default `10s`). This is
   separate from `timeout`, which bounds the dispatched formula/exec rather than

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -425,8 +424,8 @@ func expectedIntervalForOrder(order orders.Order, cronCache map[string]time.Dura
 
 func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, error) {
 	fields := strings.Fields(schedule)
-	if len(fields) != 5 {
-		return 0, fmt.Errorf("invalid cron schedule: want 5 fields, got %d", len(fields))
+	if len(fields) != orders.CronFieldCount {
+		return 0, fmt.Errorf("invalid cron schedule: want %d fields, got %d", orders.CronFieldCount, len(fields))
 	}
 
 	// Scan minute-by-minute from a fixed base so the result is deterministic
@@ -453,9 +452,9 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 		matches := make([]time.Time, 0, 16)
 		for i := 0; i < windowMinutes; i++ {
 			ts := base.Add(time.Duration(i) * time.Minute)
-			matched, err := cronScheduleMatchesAt(fields, ts)
+			matched, err := orders.CronScheduleMatchesAt(fields, ts)
 			if err != nil {
-				return 0, err
+				return 0, fmt.Errorf("invalid cron schedule: %w", err)
 			}
 			if matched {
 				matches = append(matches, ts)
@@ -495,105 +494,6 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 		return minGap, nil
 	}
 	return 0, fmt.Errorf("cron schedule %q has no firing minutes in a 366-day window", schedule)
-}
-
-func cronScheduleMatchesAt(fields []string, ts time.Time) (bool, error) {
-	specs := []struct {
-		name     string
-		field    string
-		value    int
-		min, max int
-	}{
-		{name: "minute", field: fields[0], value: ts.Minute(), min: 0, max: 59},
-		{name: "hour", field: fields[1], value: ts.Hour(), min: 0, max: 23},
-		{name: "day-of-month", field: fields[2], value: ts.Day(), min: 1, max: 31},
-		{name: "month", field: fields[3], value: int(ts.Month()), min: 1, max: 12},
-		{name: "day-of-week", field: fields[4], value: int(ts.Weekday()), min: 0, max: 6},
-	}
-	for _, spec := range specs {
-		matched, err := cronFieldMatchesForDoctor(spec.field, spec.value, spec.min, spec.max)
-		if err != nil {
-			return false, fmt.Errorf("invalid cron schedule: cannot parse %s field %q", spec.name, spec.field)
-		}
-		if !matched {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-func cronFieldMatchesForDoctor(field string, value, lowerBound, upperBound int) (bool, error) {
-	if strings.TrimSpace(field) == "" {
-		return false, fmt.Errorf("empty field")
-	}
-	for _, rawPart := range strings.Split(field, ",") {
-		part := strings.TrimSpace(rawPart)
-		matched, err := cronPartMatchesForDoctor(part, value, lowerBound, upperBound)
-		if err != nil {
-			return false, err
-		}
-		if matched {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func cronPartMatchesForDoctor(part string, value, lowerBound, upperBound int) (bool, error) {
-	if part == "" {
-		return false, fmt.Errorf("empty part")
-	}
-	rangePart, stepPart, hasStep := strings.Cut(part, "/")
-	step := 1
-	if hasStep {
-		parsed, err := strconv.Atoi(strings.TrimSpace(stepPart))
-		if err != nil || parsed <= 0 {
-			return false, fmt.Errorf("invalid step")
-		}
-		step = parsed
-	}
-
-	lo, hi, err := cronRangeForDoctor(strings.TrimSpace(rangePart), lowerBound, upperBound)
-	if err != nil {
-		return false, err
-	}
-	if value < lo || value > hi {
-		return false, nil
-	}
-	return (value-lo)%step == 0, nil
-}
-
-func cronRangeForDoctor(rangePart string, lowerBound, upperBound int) (int, int, error) {
-	switch {
-	case rangePart == "*":
-		return lowerBound, upperBound, nil
-	case strings.Contains(rangePart, "-"):
-		start, end, ok := strings.Cut(rangePart, "-")
-		if !ok {
-			return 0, 0, fmt.Errorf("invalid range")
-		}
-		lo, err := strconv.Atoi(strings.TrimSpace(start))
-		if err != nil {
-			return 0, 0, err
-		}
-		hi, err := strconv.Atoi(strings.TrimSpace(end))
-		if err != nil {
-			return 0, 0, err
-		}
-		if lo < lowerBound || hi > upperBound || lo > hi {
-			return 0, 0, fmt.Errorf("range out of bounds")
-		}
-		return lo, hi, nil
-	default:
-		value, err := strconv.Atoi(rangePart)
-		if err != nil {
-			return 0, 0, err
-		}
-		if value < lowerBound || value > upperBound {
-			return 0, 0, fmt.Errorf("value out of bounds")
-		}
-		return value, value, nil
-	}
 }
 
 // readEventTail reads the tail of the city event log through the check's

--- a/internal/orders/cron.go
+++ b/internal/orders/cron.go
@@ -1,0 +1,159 @@
+package orders
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CronFieldCount is the number of whitespace-separated fields a cron schedule
+// must have: minute, hour, day-of-month, month, day-of-week.
+const CronFieldCount = 5
+
+// cronFieldSpec names one cron field and the range its values may take.
+type cronFieldSpec struct {
+	name string
+	min  int
+	max  int
+}
+
+// cronFieldSpecs lists the five cron fields in schedule order. Every consumer
+// — the runtime trigger matcher, order validation at discovery, and the
+// doctor's order-firing check — reads schedules through this one table, so no
+// two of them can disagree about what a field accepts.
+var cronFieldSpecs = [CronFieldCount]cronFieldSpec{
+	{name: "minute", min: 0, max: 59},
+	{name: "hour", min: 0, max: 23},
+	{name: "day-of-month", min: 1, max: 31},
+	{name: "month", min: 1, max: 12},
+	{name: "day-of-week", min: 0, max: 6},
+}
+
+// cronFieldValuesAt returns t's five cron field values in schedule order.
+func cronFieldValuesAt(t time.Time) [CronFieldCount]int {
+	return [CronFieldCount]int{t.Minute(), t.Hour(), t.Day(), int(t.Month()), int(t.Weekday())}
+}
+
+// CronScheduleMatchesAt reports whether a 5-field cron schedule matches t's
+// wall-clock reading. It returns an error when any field is unparseable rather
+// than treating it as a non-match: a schedule nobody can parse is a broken
+// order, not an order that is merely not due.
+func CronScheduleMatchesAt(fields []string, t time.Time) (bool, error) {
+	if len(fields) != CronFieldCount {
+		return false, fmt.Errorf("want %d fields, got %d", CronFieldCount, len(fields))
+	}
+	values := cronFieldValuesAt(t)
+	for i, spec := range cronFieldSpecs {
+		matched, err := CronFieldMatches(fields[i], values[i], spec.min, spec.max)
+		if err != nil {
+			return false, fmt.Errorf("cannot parse %s field %q: %w", spec.name, fields[i], err)
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// ValidateCronSchedule checks that a schedule has the right field count and
+// that every field parses within its bounds. It reports the first problem it
+// finds and does not evaluate the schedule against any particular time.
+func ValidateCronSchedule(schedule string) error {
+	fields := strings.Fields(schedule)
+	if len(fields) != CronFieldCount {
+		return fmt.Errorf("want %d fields, got %d", CronFieldCount, len(fields))
+	}
+	for i, spec := range cronFieldSpecs {
+		// Parse errors do not depend on the value being matched, so any
+		// in-bounds value exercises the whole field.
+		if _, err := CronFieldMatches(fields[i], spec.min, spec.min, spec.max); err != nil {
+			return fmt.Errorf("cannot parse %s field %q: %w", spec.name, fields[i], err)
+		}
+	}
+	return nil
+}
+
+// CronFieldMatches reports whether one cron field matches value, where legal
+// values run from lowerBound to upperBound inclusive. Supported syntax per
+// comma-separated part: "*", an integer, a range "a-b", and either form with a
+// step suffix ("*/N", "a-b/N").
+//
+// Every part is parsed even after a match is found, so a malformed part fails
+// loudly instead of hiding behind an earlier one.
+func CronFieldMatches(field string, value, lowerBound, upperBound int) (bool, error) {
+	if strings.TrimSpace(field) == "" {
+		return false, fmt.Errorf("empty field")
+	}
+	matched := false
+	for _, rawPart := range strings.Split(field, ",") {
+		lo, hi, step, err := parseCronPart(strings.TrimSpace(rawPart), lowerBound, upperBound)
+		if err != nil {
+			return false, err
+		}
+		if value >= lo && value <= hi && (value-lo)%step == 0 {
+			matched = true
+		}
+	}
+	return matched, nil
+}
+
+// parseCronPart resolves one comma-separated part into the inclusive value
+// range it covers and its step. The step is anchored at the range's lower
+// bound — "*/2" on day-of-month means the 1st, 3rd, 5th, ... as standard cron
+// does, not the even days.
+func parseCronPart(part string, lowerBound, upperBound int) (lo, hi, step int, err error) {
+	if part == "" {
+		return 0, 0, 0, fmt.Errorf("empty part")
+	}
+	rangePart, stepPart, hasStep := strings.Cut(part, "/")
+	step = 1
+	if hasStep {
+		parsed, atoiErr := strconv.Atoi(strings.TrimSpace(stepPart))
+		if atoiErr != nil || parsed <= 0 {
+			return 0, 0, 0, fmt.Errorf("invalid step")
+		}
+		step = parsed
+	}
+	lo, hi, err = parseCronRange(strings.TrimSpace(rangePart), lowerBound, upperBound)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return lo, hi, step, nil
+}
+
+// parseCronRange resolves the pre-step portion of a part ("*", "a-b", or a
+// single integer) into an inclusive range, rejecting anything outside the
+// field's bounds.
+func parseCronRange(rangePart string, lowerBound, upperBound int) (int, int, error) {
+	switch {
+	case rangePart == "*":
+		return lowerBound, upperBound, nil
+	case strings.Contains(rangePart, "-"):
+		start, end, ok := strings.Cut(rangePart, "-")
+		if !ok {
+			return 0, 0, fmt.Errorf("invalid range")
+		}
+		lo, err := strconv.Atoi(strings.TrimSpace(start))
+		if err != nil {
+			return 0, 0, err
+		}
+		hi, err := strconv.Atoi(strings.TrimSpace(end))
+		if err != nil {
+			return 0, 0, err
+		}
+		if lo < lowerBound || hi > upperBound || lo > hi {
+			return 0, 0, fmt.Errorf("range out of bounds")
+		}
+		return lo, hi, nil
+	default:
+		value, err := strconv.Atoi(rangePart)
+		if err != nil {
+			return 0, 0, err
+		}
+		if value < lowerBound || value > upperBound {
+			return 0, 0, fmt.Errorf("value out of bounds")
+		}
+		return value, value, nil
+	}
+}

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -318,6 +318,12 @@ func Validate(a Order) error {
 		if a.Schedule == "" {
 			return fmt.Errorf("order %q: cron trigger requires schedule", a.Name)
 		}
+		// An unparseable schedule must fail loudly at discovery, the same way
+		// a bad tz does. The runtime matcher can only report such a field as
+		// "not matched", which yields an order that silently never fires.
+		if err := ValidateCronSchedule(a.Schedule); err != nil {
+			return fmt.Errorf("order %q: invalid schedule %q: %w", a.Name, a.Schedule, err)
+		}
 	case "condition":
 		if a.Check == "" {
 			return fmt.Errorf("order %q: condition trigger requires check command", a.Name)

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -198,6 +198,56 @@ func TestValidateCronMissingSchedule(t *testing.T) {
 	}
 }
 
+// TestValidateCronScheduleSyntax pins the full grammar the runtime matcher
+// accepts, so a schedule that validates is one that can actually fire.
+func TestValidateCronScheduleSyntax(t *testing.T) {
+	valid := []string{
+		"* * * * *",
+		"0 3 * * *",
+		"*/15 16-23 * * 1-5",
+		"5-59/10 * * * *",
+		"0 9-17 * * *",
+		"0 0 1,15 * *",
+		"0 0 * */3 *",
+		"59 23 31 12 6",
+	}
+	for _, schedule := range valid {
+		a := Order{Name: "cleanup", Formula: "mol-cleanup", Trigger: "cron", Schedule: schedule}
+		if err := Validate(a); err != nil {
+			t.Errorf("Validate(schedule %q): %v", schedule, err)
+		}
+	}
+}
+
+// TestValidateCronBadSchedule covers the #5709 failure mode: an unparseable
+// field used to yield an order that silently never fired. It must now be a
+// hard error at discovery, the way a bad tz already is.
+func TestValidateCronBadSchedule(t *testing.T) {
+	invalid := []string{
+		"0 3 * *",            // too few fields
+		"0 3 * * * *",        // too many fields
+		"60 3 * * *",         // minute above bound
+		"0 24 * * *",         // hour above bound
+		"0 0 0 * *",          // day-of-month below bound
+		"0 0 * 13 *",         // month above bound
+		"0 0 * * 7",          // day-of-week above bound
+		"0 16-24 * * *",      // range end above bound
+		"0 17-9 * * *",       // inverted range
+		"0 abc * * *",        // non-numeric
+		"*/0 * * * *",        // zero step
+		"*/ * * * *",         // missing step
+		"0 3 * * 1,",         // empty trailing part
+		"0-oops * * * *",     // malformed range
+		"0 3,notanumber * *", // wrong field count and garbage
+	}
+	for _, schedule := range invalid {
+		a := Order{Name: "cleanup", Formula: "mol-cleanup", Trigger: "cron", Schedule: schedule}
+		if err := Validate(a); err == nil {
+			t.Errorf("Validate(schedule %q) = nil, want an error", schedule)
+		}
+	}
+}
+
 func TestValidateCondition(t *testing.T) {
 	a := Order{Name: "check", Formula: "mol-check", Trigger: "condition", Check: "test -f /tmp/flag"}
 	if err := Validate(a); err != nil {

--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -183,12 +183,10 @@ const wallMinuteLayout = "2006-01-02 15:04"
 //     match a real instant; the catch-up scan detects the gap and fires the
 //     order once at the first real minute after the jump.
 func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
-	fields := strings.Fields(a.Schedule)
-	if len(fields) != 5 {
-		return TriggerResult{Due: false, Reason: fmt.Sprintf("bad cron schedule: want 5 fields, got %d", len(fields))}
+	if err := ValidateCronSchedule(a.Schedule); err != nil {
+		return TriggerResult{Due: false, Reason: fmt.Sprintf("bad cron schedule: %v", err)}
 	}
-
-	minute, hour, dom, month, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
+	fields := strings.Fields(a.Schedule)
 
 	loc, err := resolveOrderLocation(a, now)
 	if err != nil {
@@ -196,12 +194,11 @@ func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
 	}
 	now = now.In(loc)
 
+	// The schedule was validated above, so no parse error can reach here; a
+	// non-match is the safe reading if one ever did.
 	matchesAt := func(t time.Time) bool {
-		return cronFieldMatches(minute, t.Minute()) &&
-			cronFieldMatches(hour, t.Hour()) &&
-			cronFieldMatches(dom, t.Day()) &&
-			cronFieldMatches(month, int(t.Month())) &&
-			cronFieldMatches(dow, int(t.Weekday()))
+		matched, err := CronScheduleMatchesAt(fields, t)
+		return err == nil && matched
 	}
 	sameWallMinute := func(x, y time.Time) bool {
 		return x.Format(wallMinuteLayout) == y.Format(wallMinuteLayout)
@@ -281,29 +278,6 @@ func matchesInWallGap(matchesAt func(time.Time) bool, prev, t time.Time) bool {
 	}
 	for w, end := naive(prev).Add(time.Minute), naive(t); w.Before(end); w = w.Add(time.Minute) {
 		if matchesAt(w) {
-			return true
-		}
-	}
-	return false
-}
-
-// cronFieldMatches checks if a single cron field matches a value.
-// Supports: "*" (any), exact integer, or comma-separated values.
-func cronFieldMatches(field string, value int) bool {
-	if field == "*" {
-		return true
-	}
-	for _, part := range strings.Split(field, ",") {
-		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, "*/") {
-			step, err := strconv.Atoi(strings.TrimPrefix(part, "*/"))
-			if err == nil && step > 0 && value%step == 0 {
-				return true
-			}
-			continue
-		}
-		n, err := strconv.Atoi(part)
-		if err == nil && n == value {
 			return true
 		}
 	}

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -334,22 +334,134 @@ func TestCheckTriggerConditionKillsProcessGroupAfterWaitDelay(t *testing.T) {
 }
 
 func TestCronFieldMatches(t *testing.T) {
+	const (
+		minuteLo, minuteHi = 0, 59
+		hourLo, hourHi     = 0, 23
+		domLo, domHi       = 1, 31
+		monthLo, monthHi   = 1, 12
+	)
 	tests := []struct {
-		field string
-		value int
-		want  bool
+		name    string
+		field   string
+		value   int
+		lo, hi  int
+		want    bool
+		wantErr bool
 	}{
-		{"*", 5, true},
-		{"5", 5, true},
-		{"5", 3, false},
-		{"1,3,5", 3, true},
-		{"1,3,5", 2, false},
+		{name: "star", field: "*", value: 5, lo: minuteLo, hi: minuteHi, want: true},
+		{name: "exact hit", field: "5", value: 5, lo: minuteLo, hi: minuteHi, want: true},
+		{name: "exact miss", field: "5", value: 3, lo: minuteLo, hi: minuteHi, want: false},
+		{name: "list hit", field: "1,3,5", value: 3, lo: minuteLo, hi: minuteHi, want: true},
+		{name: "list miss", field: "1,3,5", value: 2, lo: minuteLo, hi: minuteHi, want: false},
+
+		// Ranges — the syntax the runtime matcher used to drop silently (#5709).
+		{name: "hour range low edge", field: "16-23", value: 16, lo: hourLo, hi: hourHi, want: true},
+		{name: "hour range high edge", field: "16-23", value: 23, lo: hourLo, hi: hourHi, want: true},
+		{name: "hour range below", field: "16-23", value: 15, lo: hourLo, hi: hourHi, want: false},
+		{name: "hour range above", field: "9-17", value: 18, lo: hourLo, hi: hourHi, want: false},
+		{name: "hour range inside", field: "9-17", value: 12, lo: hourLo, hi: hourHi, want: true},
+		{name: "range in list", field: "0,9-17", value: 9, lo: hourLo, hi: hourHi, want: true},
+
+		// Steps.
+		{name: "step hit", field: "*/15", value: 30, lo: minuteLo, hi: minuteHi, want: true},
+		{name: "step miss", field: "*/15", value: 31, lo: minuteLo, hi: minuteHi, want: false},
+		{name: "range step hit", field: "5-59/10", value: 25, lo: minuteLo, hi: minuteHi, want: true},
+		{name: "range step miss", field: "5-59/10", value: 30, lo: minuteLo, hi: minuteHi, want: false},
+		{name: "range step outside range", field: "5-59/10", value: 0, lo: minuteLo, hi: minuteHi, want: false},
+
+		// Step anchoring on 1-based fields: "*/N" steps from the field's lower
+		// bound, so day-of-month "*/2" means the 1st, 3rd, 5th — not the even
+		// days. This is standard cron, and differs from the pre-#5709 runtime
+		// matcher, which tested value%step == 0.
+		{name: "dom step from 1", field: "*/2", value: 1, lo: domLo, hi: domHi, want: true},
+		{name: "dom step skips 2", field: "*/2", value: 2, lo: domLo, hi: domHi, want: false},
+		{name: "dom step hits 3", field: "*/2", value: 3, lo: domLo, hi: domHi, want: true},
+		{name: "month step from 1", field: "*/3", value: 1, lo: monthLo, hi: monthHi, want: true},
+		{name: "month step skips 3", field: "*/3", value: 3, lo: monthLo, hi: monthHi, want: false},
+		{name: "month step hits 4", field: "*/3", value: 4, lo: monthLo, hi: monthHi, want: true},
+		{name: "minute step still from 0", field: "*/15", value: 0, lo: minuteLo, hi: minuteHi, want: true},
+
+		// Out-of-bounds and malformed fields are errors, not quiet non-matches.
+		{name: "value above bound", field: "60", value: 0, lo: minuteLo, hi: minuteHi, wantErr: true},
+		{name: "value below bound", field: "0", value: 1, lo: domLo, hi: domHi, wantErr: true},
+		{name: "range above bound", field: "20-24", value: 20, lo: hourLo, hi: hourHi, wantErr: true},
+		{name: "range inverted", field: "17-9", value: 12, lo: hourLo, hi: hourHi, wantErr: true},
+		{name: "non-numeric", field: "abc", value: 0, lo: minuteLo, hi: minuteHi, wantErr: true},
+		{name: "zero step", field: "*/0", value: 0, lo: minuteLo, hi: minuteHi, wantErr: true},
+		{name: "empty field", field: "", value: 0, lo: minuteLo, hi: minuteHi, wantErr: true},
+		// A bad part must not hide behind an earlier part that matched.
+		{name: "bad part after a match", field: "5,abc", value: 5, lo: minuteLo, hi: minuteHi, wantErr: true},
 	}
 	for _, tt := range tests {
-		got := cronFieldMatches(tt.field, tt.value)
-		if got != tt.want {
-			t.Errorf("cronFieldMatches(%q, %d) = %v, want %v", tt.field, tt.value, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CronFieldMatches(tt.field, tt.value, tt.lo, tt.hi)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("CronFieldMatches(%q, %d, %d, %d) = %v, want error", tt.field, tt.value, tt.lo, tt.hi, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CronFieldMatches(%q, %d, %d, %d) returned unexpected error: %v", tt.field, tt.value, tt.lo, tt.hi, err)
+			}
+			if got != tt.want {
+				t.Errorf("CronFieldMatches(%q, %d, %d, %d) = %v, want %v", tt.field, tt.value, tt.lo, tt.hi, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCronScheduleMatchesAtRanges pins the whole-schedule path for the report
+// in #5709: "*/15 16-23 * * 1-5" fired on no minute at all before the fix.
+func TestCronScheduleMatchesAtRanges(t *testing.T) {
+	const schedule = "*/15 16-23 * * 1-5"
+	tests := []struct {
+		name string
+		at   time.Time
+		want bool
+	}{
+		{name: "weekday in window on a step minute", at: time.Date(2026, 3, 4, 16, 30, 0, 0, time.UTC), want: true},
+		{name: "weekday in window off a step minute", at: time.Date(2026, 3, 4, 16, 31, 0, 0, time.UTC), want: false},
+		{name: "weekday outside the hour window", at: time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC), want: false},
+		{name: "weekend in window", at: time.Date(2026, 3, 7, 16, 30, 0, 0, time.UTC), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CronScheduleMatchesAt(strings.Fields(schedule), tt.at)
+			if err != nil {
+				t.Fatalf("CronScheduleMatchesAt(%q, %v) returned unexpected error: %v", schedule, tt.at, err)
+			}
+			if got != tt.want {
+				t.Errorf("CronScheduleMatchesAt(%q, %v) = %v, want %v", schedule, tt.at, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckCronRangeSchedule proves the reported schedule now reaches the
+// runtime trigger, not just the parser.
+func TestCheckCronRangeSchedule(t *testing.T) {
+	a := Order{Name: "digest", Formula: "mol-digest", Trigger: "cron", Schedule: "*/15 16-23 * * 1-5"}
+	never := func(string) (time.Time, error) { return time.Time{}, nil }
+
+	due := checkCron(a, time.Date(2026, 3, 4, 16, 30, 0, 0, time.UTC), never)
+	if !due.Due {
+		t.Errorf("Due = false for a matching minute, want true (reason %q)", due.Reason)
+	}
+}
+
+// TestCheckCronRejectsUnparseableSchedule pins the loud failure: a field the
+// matcher cannot read is reported as a bad schedule, not as "not matched".
+func TestCheckCronRejectsUnparseableSchedule(t *testing.T) {
+	a := Order{Name: "digest", Formula: "mol-digest", Trigger: "cron", Schedule: "0 25-30 * * *"}
+	never := func(string) (time.Time, error) { return time.Time{}, nil }
+
+	result := checkCron(a, time.Date(2026, 3, 4, 16, 30, 0, 0, time.UTC), never)
+	if result.Due {
+		t.Fatal("Due = true for an unparseable schedule, want false")
+	}
+	if !strings.Contains(result.Reason, "bad cron schedule") {
+		t.Errorf("Reason = %q, want it to name a bad cron schedule", result.Reason)
 	}
 }
 


### PR DESCRIPTION
Fixes #5709.

## The bug

`internal/orders/triggers.go` `cronFieldMatches` supported only `*`, integers,
comma lists, and `*/N`. It called `strconv.Atoi` on each part and dropped the
error (`if err == nil` with no `else`), so any field it could not parse — a
range like `16-23` above all — quietly failed to match and the order never
fired. No diagnostic, ever.

`internal/doctor/checks_order_firing.go` carried a second, richer parser
(`cronPartMatchesForDoctor` / `cronRangeForDoctor`) that supports `a-b` and
`a-b/N`, bounds-checks every field, and returns errors. It has a passing test
for `0 9-17 * * *`. Doctor was tested to accept syntax the runtime silently
dropped.

## The fix

**One parser.** The doctor's parsing moves into `internal/orders/cron.go`,
exported as `CronFieldMatches`, `CronScheduleMatchesAt`, and
`ValidateCronSchedule`. The runtime matcher and the doctor's firing check now
read schedules through the same code and the same field-bounds table
(`cronFieldSpecs`), so they cannot diverge again. The four doctor-local helpers
are deleted.

**Loud failure at load.** `Order.Validate()` now runs `ValidateCronSchedule`,
so an unparseable or out-of-bounds schedule is a hard error at order discovery
— the way an invalid `tz` already is. `checkCron` validates up front too and
reports `bad cron schedule: <why>` instead of `cron: schedule not matched`.

**Errors are not swallowed anywhere.** `CronFieldMatches` parses every
comma-separated part even after one matches, so `5,notanumber` is an error
rather than a match that hides a typo.

## Behavior changes

Three, all in the direction of standard cron. Worth release-note treatment:

1. **`*/N` step anchoring on 1-based fields.** The old runtime rule was
   `value % step == 0`; the rule now is `(value - lo) % step == 0`, where `lo`
   is the field's lower bound. Identical for minute and hour (`lo = 0`), but
   **different for day-of-month and month** (`lo = 1`): `*/2` in day-of-month
   now means the 1st, 3rd, 5th, … where it previously meant the 2nd, 4th, 6th,
   …. Standard cron uses the new semantics. Pinned by tests in
   `TestCronFieldMatches` ("dom step from 1", "month step from 1").

2. **Out-of-bounds fields are now rejected at load.** `70 * * * *`,
   `0 24 * * *`, `0 0 0 * *`, and `0 0 * * 7` used to load and simply never
   fire (or, for `0 0 0 * *`, never match). They are now load errors. Note
   `7` as a Sunday alias in day-of-week is **not** supported — the shared
   bounds are `0-6`, matching the doctor parser this lifts from. No cron order
   in this repo or in `gascity-packs` uses any of these forms.

3. **Ranges now work at runtime.** `16-23`, `9-17`, and `5-59/10` fire instead
   of never matching. This is the point of the change.

## Tests

- `internal/orders/triggers_test.go` — `TestCronFieldMatches` extended from 5
  cases to 31: ranges, ranges in lists, `*/15`, `5-59/10`, the DOM/month step
  anchoring, out-of-bounds rejection, and a malformed part behind a matching
  one. Plus `TestCronScheduleMatchesAtRanges`, `TestCheckCronRangeSchedule`
  (the reported `*/15 16-23 * * 1-5` now reaches the trigger), and
  `TestCheckCronRejectsUnparseableSchedule`.
- `internal/doctor/checks_order_firing_test.go` — unchanged. Its
  `0 9-17 * * *` case is the divergence regression guard and stays green
  through the refactor.
- `internal/orders/order_test.go` — `TestValidateCronScheduleSyntax` and
  `TestValidateCronBadSchedule` pin the accepted grammar and 15 rejected
  forms.

`docs/tutorials/07-orders.md` now documents ranges, step anchoring, and the
load-time bounds check.

## Design notes

Zero Framework Cognition: this is transport, not reasoning — the parser reads
a schedule and reports what it says, with no heuristic about what the author
"probably meant". Bitter Lesson alignment: one parser and a loud error at the
boundary, rather than two parsers whose disagreement is only discoverable by
an order that never runs.
