### PR TITLE
fix(wisp): preserve split-store routing in preclaim bridge

### DIFF
--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -215,11 +215,11 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 		Limit:     10,
 	})
 	if err == nil {
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
-	return resolveMoleculeRootViaRoutedBridge(store, assignees)
+	return resolveMoleculeRootViaRoutedBridge(workStore, graphStore, assignees)
 }
 
 // resolveMoleculeRootViaRoutedBridge finds the molecule root reachable from a
@@ -236,9 +236,9 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 // later identity still gets a chance.
 //
 // Returns nil when no routed bridge bead is found for any identity.
-func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *beads.Bead {
+func resolveMoleculeRootViaRoutedBridge(workStore, graphStore beads.Store, assignees []string) *beads.Bead {
 	for _, identity := range assignees {
-		results, err := store.List(beads.ListQuery{
+		results, err := workStore.List(beads.ListQuery{
 			Status:   "open",
 			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: identity},
 			TierMode: beads.TierBoth,
@@ -247,7 +247,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 		if err != nil {
 			continue
 		}
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
@@ -257,7 +257,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 // firstMoleculeRootFrom returns the molecule root reachable via molecule_id
 // from the first candidate bead that carries one. Returns nil when no
 // candidate carries a resolvable molecule_id.
-func firstMoleculeRootFrom(store beads.Store, candidates []beads.Bead) *beads.Bead {
+func firstMoleculeRootFrom(graphStore beads.Store, candidates []beads.Bead) *beads.Bead {
 	for i := range candidates {
 		rootID := strings.TrimSpace(candidates[i].Metadata[beadmeta.MoleculeIDMetadataKey])
 		if rootID == "" {

--- a/cmd/gc/wisp_step_inject_prewake_test.go
+++ b/cmd/gc/wisp_step_inject_prewake_test.go
@@ -39,18 +39,20 @@ func mustCreateOpen(t *testing.T, store *beads.MemStore, b beads.Bead) beads.Bea
 // bead plainly, closes it, and the molecule leaks with every step untouched
 // (created_at == updated_at).
 func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
-	store := beads.NewMemStore()
+	workStore := beads.NewMemStore()
+	graphStore := beads.NewMemStoreFrom(100, nil, nil)
 
 	// Molecule root: attached formulas deliberately leave it unrouted and
-	// unassigned (sling_core.go:585-594).
-	root := mustCreateOpen(t, store, beads.Bead{
+	// unassigned (sling_core.go:585-594). Keep graph data in a disjoint store
+	// so a same-store fixture cannot hide an inverted bridge lookup.
+	root := mustCreateOpen(t, graphStore, beads.Bead{
 		Title: "mol-deployer-gate",
 		Type:  "molecule",
 	})
 
 	// Step children: open, unassigned, no labels — invisible to every
 	// work_query by design.
-	step := mustCreateOpen(t, store, beads.Bead{
+	step := mustCreateOpen(t, graphStore, beads.Bead{
 		Title:       "Step 1: verify the gate",
 		Description: "Run the deployer gate checks",
 		Type:        "step",
@@ -59,21 +61,21 @@ func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
 
 	// Source work bead in its REAL post-sling, pre-claim state: routed, carrying
 	// molecule_id, but still open and unassigned.
-	source := mustCreateOpen(t, store, beads.Bead{
+	source := mustCreateOpen(t, workStore, beads.Bead{
 		Title:       "needs-deploy: ship the reviewed branch",
 		Description: "Deploy the reviewed work",
 		Type:        "task",
 	})
-	if err := store.SetMetadata(source.ID, beadmeta.MoleculeIDMetadataKey, root.ID); err != nil {
+	if err := workStore.SetMetadata(source.ID, beadmeta.MoleculeIDMetadataKey, root.ID); err != nil {
 		t.Fatalf("SetMetadata(molecule_id): %v", err)
 	}
-	if err := store.SetMetadata(source.ID, beadmeta.RoutedToMetadataKey, "beads/deployer"); err != nil {
+	if err := workStore.SetMetadata(source.ID, beadmeta.RoutedToMetadataKey, "beads/deployer"); err != nil {
 		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
 	}
 
 	// This is the wake: gc nudge --inject calls wispStepInjectionContent, which
 	// resolves against the agent's identities.
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(workStore, graphStore, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,13 +101,14 @@ func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
 // mechanism: the bridge requires post-claim state to deliver a pre-claim
 // instruction.
 func TestResolveActiveWispStep_PostClaimBridgeResolves(t *testing.T) {
-	store := beads.NewMemStore()
+	workStore := beads.NewMemStore()
+	graphStore := beads.NewMemStoreFrom(100, nil, nil)
 
-	root := mustCreateOpen(t, store, beads.Bead{
+	root := mustCreateOpen(t, graphStore, beads.Bead{
 		Title: "mol-deployer-gate",
 		Type:  "molecule",
 	})
-	step := mustCreateOpen(t, store, beads.Bead{
+	step := mustCreateOpen(t, graphStore, beads.Bead{
 		Title:       "Step 1: verify the gate",
 		Description: "Run the deployer gate checks",
 		Type:        "step",
@@ -113,17 +116,17 @@ func TestResolveActiveWispStep_PostClaimBridgeResolves(t *testing.T) {
 	})
 
 	// Same bead, but claimed: in_progress + assigned.
-	source := mustCreateInProgress(t, store, beads.Bead{
+	source := mustCreateInProgress(t, workStore, beads.Bead{
 		Title:       "needs-deploy: ship the reviewed branch",
 		Description: "Deploy the reviewed work",
 		Type:        "task",
 		Assignee:    "deployer-gm-wisp-sl677d",
 	})
-	if err := store.SetMetadata(source.ID, beadmeta.MoleculeIDMetadataKey, root.ID); err != nil {
+	if err := workStore.SetMetadata(source.ID, beadmeta.MoleculeIDMetadataKey, root.ID); err != nil {
 		t.Fatalf("SetMetadata(molecule_id): %v", err)
 	}
 
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(workStore, graphStore, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## What this fixes

Current `main` does not compile after the preclaim molecule bridge was merged across the work/graph store split. The new bridge refers to an out-of-scope `store`, resolves roots through an out-of-scope `graphStore`, and its new tests still call the older two-argument resolver.

This keeps the class boundary explicit:

- list claimed or routed source beads through `workStore`;
- resolve their `molecule_id` roots through `graphStore`; and
- pass both stores through the routed-preclaim fallback.

The two prewake regressions now use disjoint stores and disjoint ID ranges, so a future store inversion cannot be hidden by a same-store fixture.

## Reproduction

Exact upstream `eec4a2fb625279ac62f29ff4f6a554168bc77b1a` fails an isolated build with:

```text
cmd/gc/wisp_step_inject.go:218:36: undefined: store
cmd/gc/wisp_step_inject.go:222:44: undefined: store
cmd/gc/wisp_step_inject.go:266:16: undefined: graphStore
```

## Validation

- focused wisp resolver and prewake tests
- `go test ./cmd/gc -count=1`
- `go vet ./cmd/gc`
- `go build -buildvcs=false -o /dev/null ./cmd/gc`
- repository pre-push fast gate (all 10 jobs)

All pass with this change.
