### PR TITLE
fix(githubmonitor): defer summary states to pending checks

### DIFF
--- a/internal/githubmonitor/monitor.go
+++ b/internal/githubmonitor/monitor.go
@@ -202,14 +202,17 @@ func classifyPullRequest(pr PullRequest, failed, pending []string) (state, failu
 		return StateConflicted, FailureKindMergeConflict, true
 	case "BEHIND":
 		return StateBehind, FailureKindBehindBase, true
-	case "UNSTABLE":
-		return StateFailed, FailureKindChecksFailed, true
-	case "BLOCKED":
-		return StateBlocked, FailureKindBlocked, true
 	}
 
 	if len(pending) > 0 {
 		return StatePending, "", false
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
+	case "UNSTABLE":
+		return StateFailed, FailureKindChecksFailed, true
+	case "BLOCKED":
+		return StateBlocked, FailureKindBlocked, true
 	}
 	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
 	case "", "UNKNOWN":

--- a/internal/githubmonitor/monitor.go
+++ b/internal/githubmonitor/monitor.go
@@ -197,7 +197,8 @@ func classifyPullRequest(pr PullRequest, failed, pending []string) (state, failu
 		return StateFailed, FailureKindChecksFailed, true
 	}
 
-	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
+	mergeState := strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus))
+	switch mergeState {
 	case "DIRTY":
 		return StateConflicted, FailureKindMergeConflict, true
 	case "BEHIND":
@@ -208,13 +209,11 @@ func classifyPullRequest(pr PullRequest, failed, pending []string) (state, failu
 		return StatePending, "", false
 	}
 
-	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
+	switch mergeState {
 	case "UNSTABLE":
 		return StateFailed, FailureKindChecksFailed, true
 	case "BLOCKED":
 		return StateBlocked, FailureKindBlocked, true
-	}
-	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
 	case "", "UNKNOWN":
 		return StateUnknown, "", false
 	default:

--- a/internal/githubmonitor/monitor_test.go
+++ b/internal/githubmonitor/monitor_test.go
@@ -198,6 +198,13 @@ func TestEvaluatePullRequestsPrefersConcreteCheckEvidence(t *testing.T) {
 			wantKind:   FailureKindBlocked,
 			wantAction: true,
 		},
+		{
+			name:       "unstable without checks remains actionable",
+			mergeState: "UNSTABLE",
+			wantState:  StateFailed,
+			wantKind:   FailureKindChecksFailed,
+			wantAction: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/githubmonitor/monitor_test.go
+++ b/internal/githubmonitor/monitor_test.go
@@ -134,6 +134,91 @@ func TestEvaluatePullRequestsCleanWithPendingChecksIsNotRepairActionable(t *test
 	}
 }
 
+func TestEvaluatePullRequestsPrefersConcreteCheckEvidence(t *testing.T) {
+	monitor := config.GitHubPRMonitor{
+		Name:         "main",
+		Owner:        "org",
+		Repo:         "repo",
+		BaseBranches: []string{"main"},
+		Rig:          "repo",
+		RepairRoute:  "repo/polecat",
+	}
+
+	tests := []struct {
+		name       string
+		mergeState string
+		checks     []Check
+		wantState  string
+		wantKind   string
+		wantAction bool
+	}{
+		{
+			name:       "blocked queued is pending",
+			mergeState: "BLOCKED",
+			checks:     []Check{{Name: "ci", Status: "QUEUED"}},
+			wantState:  StatePending,
+		},
+		{
+			name:       "unstable in progress is pending",
+			mergeState: "UNSTABLE",
+			checks:     []Check{{Name: "ci", Status: "IN_PROGRESS"}},
+			wantState:  StatePending,
+		},
+		{
+			name:       "failed check takes precedence over pending check",
+			mergeState: "UNSTABLE",
+			checks: []Check{
+				{Name: "failed", Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "pending", Status: "QUEUED"},
+			},
+			wantState:  StateFailed,
+			wantKind:   FailureKindChecksFailed,
+			wantAction: true,
+		},
+		{
+			name:       "dirty takes precedence over pending check",
+			mergeState: "DIRTY",
+			checks:     []Check{{Name: "ci", Status: "QUEUED"}},
+			wantState:  StateConflicted,
+			wantKind:   FailureKindMergeConflict,
+			wantAction: true,
+		},
+		{
+			name:       "behind takes precedence over pending check",
+			mergeState: "BEHIND",
+			checks:     []Check{{Name: "ci", Status: "QUEUED"}},
+			wantState:  StateBehind,
+			wantKind:   FailureKindBehindBase,
+			wantAction: true,
+		},
+		{
+			name:       "blocked without checks remains actionable",
+			mergeState: "BLOCKED",
+			wantState:  StateBlocked,
+			wantKind:   FailureKindBlocked,
+			wantAction: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			results := EvaluatePullRequests(monitor, []PullRequest{{
+				Number:           1,
+				BaseRefName:      "main",
+				MergeStateStatus: tc.mergeState,
+				Checks:           tc.checks,
+			}})
+			if len(results) != 1 {
+				t.Fatalf("len(results) = %d, want 1", len(results))
+			}
+			got := results[0]
+			if got.State != tc.wantState || got.FailureKind != tc.wantKind || got.Actionable != tc.wantAction {
+				t.Fatalf("result = %#v, want state=%q failure_kind=%q actionable=%t", got, tc.wantState, tc.wantKind, tc.wantAction)
+			}
+		})
+	}
+}
+
 func TestGraphQLDecodePullRequests(t *testing.T) {
 	body := strings.NewReader(`{
 		"data": {


### PR DESCRIPTION
## Summary

- Recreates the pending-check classifier fix from #5395 on current official `upstream/main`.
- Gives queued or in-progress check evidence precedence over GitHub summary-only `BLOCKED` / `UNSTABLE` states.
- Preserves failed-check and `DIRTY` / `BEHIND` handling.
- No separate issue: this replaces the mistakenly closed #5395.

## Testing

- [ ] `make check` — currently blocked by the current upstream compile regression repaired separately in #5720; this PR remains draft until rebased after that merge.
- [x] `make check-docs` not applicable (no docs/navigation/link changes).
- [x] `make test-integration` not applicable (GitHub monitor classification only).
- [x] Added regression coverage for queued/in-progress checks, failed-plus-pending, `DIRTY`/`BEHIND` precedence, and summary-only `BLOCKED`.

## Checklist

- [x] Linked predecessor PR #5395 and explained why no separate issue is needed.
- [x] Added or updated tests for behavior changes.
- [x] No user-facing documentation changes.
- [x] No breaking changes or migration required.

This stays draft until #5720 is merged, the branch is rebased onto the resulting official `main`, and all exact-head checks are green.