### PR TITLE
fix(cmd/gc): restore wisp bridge store wiring

### DIFF
--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -215,11 +215,11 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 		Limit:     10,
 	})
 	if err == nil {
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
-	return resolveMoleculeRootViaRoutedBridge(store, assignees)
+	return resolveMoleculeRootViaRoutedBridge(workStore, graphStore, assignees)
 }
 
 // resolveMoleculeRootViaRoutedBridge finds the molecule root reachable from a
@@ -236,9 +236,9 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 // later identity still gets a chance.
 //
 // Returns nil when no routed bridge bead is found for any identity.
-func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *beads.Bead {
+func resolveMoleculeRootViaRoutedBridge(workStore, graphStore beads.Store, assignees []string) *beads.Bead {
 	for _, identity := range assignees {
-		results, err := store.List(beads.ListQuery{
+		results, err := workStore.List(beads.ListQuery{
 			Status:   "open",
 			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: identity},
 			TierMode: beads.TierBoth,
@@ -247,7 +247,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 		if err != nil {
 			continue
 		}
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
@@ -257,7 +257,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 // firstMoleculeRootFrom returns the molecule root reachable via molecule_id
 // from the first candidate bead that carries one. Returns nil when no
 // candidate carries a resolvable molecule_id.
-func firstMoleculeRootFrom(store beads.Store, candidates []beads.Bead) *beads.Bead {
+func firstMoleculeRootFrom(graphStore beads.Store, candidates []beads.Bead) *beads.Bead {
 	for i := range candidates {
 		rootID := strings.TrimSpace(candidates[i].Metadata[beadmeta.MoleculeIDMetadataKey])
 		if rootID == "" {

--- a/cmd/gc/wisp_step_inject_prewake_test.go
+++ b/cmd/gc/wisp_step_inject_prewake_test.go
@@ -73,7 +73,7 @@ func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
 
 	// This is the wake: gc nudge --inject calls wispStepInjectionContent, which
 	// resolves against the agent's identities.
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(store, store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestResolveActiveWispStep_PostClaimBridgeResolves(t *testing.T) {
 		t.Fatalf("SetMetadata(molecule_id): %v", err)
 	}
 
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(store, store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Restores the work-store and graph-store parameters accidentally left undefined in the attached-molecule bridge helpers on current official `upstream/main`.
- This is a focused compile repair for the upstream CI failure at `eec4a2fb`.
- It is intentionally separate from #5719 and the four pre-existing feature drafts.
- No separate issue: the defect was discovered while validating those upstream PRs.

## Testing

- [ ] `make check` — authoritative exact-head CI is running; no failures are currently reported.
- [x] `make check-docs` not applicable (no docs/navigation/link changes).
- [ ] `make test-integration` — exact-head integration jobs are running.
- [x] Change is limited to restoring the missing bridge arguments.

## Checklist

- [x] Explained why a separate issue is not needed.
- [x] Existing compiler/integration coverage exercises the repaired call sites.
- [x] No user-facing documentation changes.
- [x] No breaking changes or migration required.

Do not merge until all exact-head required checks complete successfully.