### PR TITLE
P0 fix(cmd/gc): finish the two-store rename in the molecule_id bridge — main does not build

### DIFF
--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -215,11 +215,11 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 		Limit:     10,
 	})
 	if err == nil {
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
-	return resolveMoleculeRootViaRoutedBridge(store, assignees)
+	return resolveMoleculeRootViaRoutedBridge(workStore, graphStore, assignees)
 }
 
 // resolveMoleculeRootViaRoutedBridge finds the molecule root reachable from a
@@ -236,9 +236,13 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 // later identity still gets a chance.
 //
 // Returns nil when no routed bridge bead is found for any identity.
-func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *beads.Bead {
+//
+// Crosses the same class boundary as resolveMoleculeRootViaBridge: the routed
+// source bead carrying gc.routed_to is work class, the root it names is
+// ClassGraph.
+func resolveMoleculeRootViaRoutedBridge(workStore, graphStore beads.Store, assignees []string) *beads.Bead {
 	for _, identity := range assignees {
-		results, err := store.List(beads.ListQuery{
+		results, err := workStore.List(beads.ListQuery{
 			Status:   "open",
 			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: identity},
 			TierMode: beads.TierBoth,
@@ -247,7 +251,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 		if err != nil {
 			continue
 		}
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
@@ -256,8 +260,9 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 
 // firstMoleculeRootFrom returns the molecule root reachable via molecule_id
 // from the first candidate bead that carries one. Returns nil when no
-// candidate carries a resolvable molecule_id.
-func firstMoleculeRootFrom(store beads.Store, candidates []beads.Bead) *beads.Bead {
+// candidate carries a resolvable molecule_id. The candidates are work-class
+// beads; the root they name is ClassGraph, so the Get goes to the graph store.
+func firstMoleculeRootFrom(graphStore beads.Store, candidates []beads.Bead) *beads.Bead {
 	for i := range candidates {
 		rootID := strings.TrimSpace(candidates[i].Metadata[beadmeta.MoleculeIDMetadataKey])
 		if rootID == "" {

--- a/cmd/gc/wisp_step_inject_prewake_test.go
+++ b/cmd/gc/wisp_step_inject_prewake_test.go
@@ -73,7 +73,7 @@ func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
 
 	// This is the wake: gc nudge --inject calls wispStepInjectionContent, which
 	// resolves against the agent's identities.
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(store, store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestResolveActiveWispStep_PostClaimBridgeResolves(t *testing.T) {
 		t.Fatalf("SetMetadata(molecule_id): %v", err)
 	}
 
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(store, store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Fixes `ga-ujov66`. **`cmd/gc` does not build on `main` right now.**

```
$ go build ./cmd/gc     # origin/main
exit 1
cmd/gc/wisp_step_inject.go:218:36: undefined: store
cmd/gc/wisp_step_inject.go:222:44: undefined: store
cmd/gc/wisp_step_inject.go:266:16: undefined: graphStore
```

`go build` hides two more, because it does not compile test files. The CI shard job builds the test binary and sees all five — the other two are `wisp_step_inject_prewake_test.go:76` and `:126` calling `resolveActiveWispStep` with one store.

## What happened

A **semantic merge conflict**, and it is worth reading because no standard gate can catch this class.

- #5488 (`3b44512c8f`, 08-27) introduced two-store signatures: `resolveMoleculeRootViaBridge(workStore, graphStore, …)`.
- #5297's branch was cut 13 days earlier, when those functions were single-store. Its new code referencing a bare `store` compiled honestly on the branch — 96 checks, 0 failing, all twelve `cmd/gc` shards green.
- Squash-merging it onto a main that already contained #5488 produced **zero textual conflicts** — the hunks do not overlap — and a file with #5488's two-store signatures wrapped around #5297's single-store bodies. That combination had never been compiled anywhere until it was on main.

`mergeable=MERGEABLE` and a green rollup are both computed against a base that no longer exists at merge time.

**We merged #5297, so this break is ours, not the contributor's.**

## The fix

Finishes the rename by restoring the pre-extraction semantics. `29b3687cf4` extracted an inline loop into `firstMoleculeRootFrom` and carried the `graphStore.Get` line verbatim while naming the parameter `store` — that extraction is the whole bug.

The class boundary decides each call site: **a `List` of candidate source beads is work class; a `Get` of the molecule root is `ClassGraph`.**

| call site | store |
|---|---|
| `resolveMoleculeRootViaBridge` — candidate List | `workStore` (already correct) |
| `resolveMoleculeRootViaRoutedBridge` — candidate List | `workStore` (needed both; had one) |
| root `Get`, both paths | `graphStore` |
| `firstMoleculeRootFrom` | uses its store for nothing but the root Get → it *is* the graphStore |

This is not cosmetic. `cliGraphStore` → `resolveGraphStore` → `resolveClassStore(…, BeadClassGraph, …)` is class-routed: identical to the work store at the default backend, a **different** store under a `[beads.classes.graph]` relocation. Listing work beads from `graphStore` would silently return nothing on exactly those cities.

`(store, store)` in the prewake test is correct *for that test* — it builds root, step and source in one `MemStore`, so it is not a class-split case.

## Verification

```
go build ./cmd/gc                                    exit 0
go vet   ./cmd/gc                                    exit 0
go test  ./cmd/gc -run 'ResolveActiveWispStep|Prewake|WispStep'   ok
go test  ./cmd/gc  (whole package)                   ok  284.857s
```

`TestResolveActiveWispStepSpansTheClassBoundary` is the one that matters — it uses disjoint-ID-space MemStores specifically so a wrong-store `Get` collides instead of silently succeeding. Swap either store and it fails.

## Not in scope

Seven PRs currently failing `cmd/gc process / shard N of 12` are **unrelated** — their runs all predate this break and their logs contain no build errors. Six fail one deterministic assertion already fixed on main by `d7fe115836` (#5676) and are showing stale red; a plain CI re-run should clear them. #5567 is a different failure again.
