### PR TITLE
fix(cmd/gc): finish the two-store migration #5297 half-applied — main does not compile

### DIFF
--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -215,11 +215,11 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 		Limit:     10,
 	})
 	if err == nil {
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
-	return resolveMoleculeRootViaRoutedBridge(store, assignees)
+	return resolveMoleculeRootViaRoutedBridge(workStore, graphStore, assignees)
 }
 
 // resolveMoleculeRootViaRoutedBridge finds the molecule root reachable from a
@@ -236,9 +236,9 @@ func resolveMoleculeRootViaBridge(workStore, graphStore beads.Store, assignees [
 // later identity still gets a chance.
 //
 // Returns nil when no routed bridge bead is found for any identity.
-func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *beads.Bead {
+func resolveMoleculeRootViaRoutedBridge(workStore, graphStore beads.Store, assignees []string) *beads.Bead {
 	for _, identity := range assignees {
-		results, err := store.List(beads.ListQuery{
+		results, err := workStore.List(beads.ListQuery{
 			Status:   "open",
 			Metadata: map[string]string{beadmeta.RoutedToMetadataKey: identity},
 			TierMode: beads.TierBoth,
@@ -247,7 +247,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 		if err != nil {
 			continue
 		}
-		if root := firstMoleculeRootFrom(store, results); root != nil {
+		if root := firstMoleculeRootFrom(graphStore, results); root != nil {
 			return root
 		}
 	}
@@ -257,7 +257,7 @@ func resolveMoleculeRootViaRoutedBridge(store beads.Store, assignees []string) *
 // firstMoleculeRootFrom returns the molecule root reachable via molecule_id
 // from the first candidate bead that carries one. Returns nil when no
 // candidate carries a resolvable molecule_id.
-func firstMoleculeRootFrom(store beads.Store, candidates []beads.Bead) *beads.Bead {
+func firstMoleculeRootFrom(graphStore beads.Store, candidates []beads.Bead) *beads.Bead {
 	for i := range candidates {
 		rootID := strings.TrimSpace(candidates[i].Metadata[beadmeta.MoleculeIDMetadataKey])
 		if rootID == "" {

--- a/cmd/gc/wisp_step_inject_prewake_test.go
+++ b/cmd/gc/wisp_step_inject_prewake_test.go
@@ -73,7 +73,7 @@ func TestResolveActiveWispStep_PreClaimBridgeMisses(t *testing.T) {
 
 	// This is the wake: gc nudge --inject calls wispStepInjectionContent, which
 	// resolves against the agent's identities.
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(store, store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestResolveActiveWispStep_PostClaimBridgeResolves(t *testing.T) {
 		t.Fatalf("SetMetadata(molecule_id): %v", err)
 	}
 
-	got, err := resolveActiveWispStep(store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
+	got, err := resolveActiveWispStep(store, store, []string{"beads/deployer", "deployer-gm-wisp-sl677d"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
**Main is red**: `go build ./cmd/gc` fails at tip `eec4a2fb62` (`wisp_step_inject.go`: `undefined: store`, `undefined: graphStore`, stale test call sites) — a semantic collision between #5488's two-store split and #5297's merge. Every PR's CI is failing and every adopt-pr review returns review-failed; the merge pipeline is down until this lands.

The fix completes the migration coherently: routed-work listings on `workStore`, molecule-root resolution via `firstMoleculeRootFrom(graphStore, …)`, prewake tests pass the same MemStore for both roles (the existing convention in `wisp_step_inject_test.go`).

Verified: `go build`/`go vet ./cmd/gc` clean; the wisp/prewake/pre-claim test families pass.

This is the second half-applied-migration build break in two days (#5094 missed test call sites; this one broke the production file). Both entered through merges whose CI predates the colliding merge — a merge-queue rebase-and-retest gap worth its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)