### PR TITLE
fix(routing): never collapse a route that names a configured agent

### DIFF
--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -224,9 +224,19 @@ func RoutedToIdentity(agent *config.Agent) string {
 // a configured multi-session pool agent and N is a valid slot (>=1, and within
 // the agent's max when bounded) — the inverse of resolvePoolInstanceQualified.
 // Any other target (base names, non-pool agents, out-of-range or non-numeric
-// suffixes, unknown agents) is returned unchanged.
+// suffixes, unknown agents) is returned unchanged. A target that is itself a
+// configured agent's qualified name is likewise never collapsed.
 func NormalizePoolRouteTarget(cfg *config.City, target string) string {
 	if cfg == nil || target == "" {
+		return target
+	}
+	// Literal-before-slot precedence, mirroring ResolveAgent: a literal
+	// qualified match (step 2) wins over pool-instance synthesis (step 2b).
+	// A target that names a configured agent outright is a real routing
+	// destination, not a load-balancing hint, so it must never collapse into
+	// a same-prefixed pool base — e.g. an agent "myrig/polecat-4090" next to
+	// an unbounded pool "myrig/polecat" would otherwise lose its identity.
+	if _, ok := findAgentByQualified(cfg, target); ok {
 		return target
 	}
 	for i := range cfg.Agents {

--- a/internal/agentutil/resolve_test.go
+++ b/internal/agentutil/resolve_test.go
@@ -288,6 +288,27 @@ func TestNormalizePoolRouteTarget(t *testing.T) {
 	}
 }
 
+// A configured agent whose name happens to end in "-<digits>" must keep its
+// identity even when a same-prefixed unbounded pool exists: the literal agent
+// wins, mirroring ResolveAgent's literal-before-pool-instance precedence.
+func TestNormalizePoolRouteTargetConfiguredAgentWins(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			// Unbounded pool: any numeric suffix would otherwise collapse.
+			{Name: "polecat", Dir: "myrig", MaxActiveSessions: intPtr(-1)},
+			// A distinct configured agent that merely looks slot-suffixed.
+			{Name: "polecat-4090", Dir: "myrig"},
+		},
+	}
+	if got := NormalizePoolRouteTarget(cfg, "myrig/polecat-4090"); got != "myrig/polecat-4090" {
+		t.Errorf("configured agent collapsed: got %q, want %q", got, "myrig/polecat-4090")
+	}
+	// A genuine slot suffix (no agent of that name) still collapses.
+	if got := NormalizePoolRouteTarget(cfg, "myrig/polecat-3"); got != "myrig/polecat" {
+		t.Errorf("slot suffix did not collapse: got %q, want %q", got, "myrig/polecat")
+	}
+}
+
 func TestNormalizePoolRouteTargetNilConfig(t *testing.T) {
 	if got := NormalizePoolRouteTarget(nil, "myrig/polecat-2"); got != "myrig/polecat-2" {
 		t.Errorf("NormalizePoolRouteTarget(nil) = %q, want unchanged", got)


### PR DESCRIPTION
## Motivation

`agentutil.NormalizePoolRouteTarget` collapses a slot-suffixed pool target
(`myrig/polecat-2`) back to its base (`myrig/polecat`) so slot-suffixed slings
stay visible to the pool's `work_query`. That is correct — but it decides
purely by string shape: it walks the configured multi-session agents, and if
`target` is `<base>-<N>` with `N` a valid slot, it returns `<base>`. It never
asks whether `target` is itself a configured agent.

So an agent whose own name ends in `-<digits>` is silently rewritten whenever a
same-prefixed pool exists:

```toml
[[agents]]
name = "polecat"                    # pool
dir  = "myrig"
max_active_sessions = -1            # unbounded

[[agents]]
name = "polecat-4090"               # a distinct, deliberately named agent
dir  = "myrig"
```

`gc sling --to myrig/polecat-4090` stamps `gc.routed_to = "myrig/polecat"`. The
bead goes to the pool; the agent the operator named never sees it, and nothing
reports the rewrite. An unbounded pool makes this unconditional — the
`HasUnlimitedSessionCapacity` branch skips the max check, so *every* numeric
suffix is an "in-range slot". With a bounded pool it fires for any suffix
`1..max`. The blast radius is every routing write site: `cmd/gc/cmd_sling.go`,
`cmd/gc/pool_desired_state.go`, `cmd/gc/assigned_work_scope.go`,
`cmd/gc/demand_serve_predicate.go` (two sites).

Names ending in a number are ordinary (hardware/model/port suffixes:
`worker-4090`, `runner-8080`, `shard-2`), so this is reachable from plain
config with no pool intent at all.

`ResolveAgent` already has the right rule for exactly this ambiguity: a literal
qualified match (step 2) is tried *before* pool-instance synthesis (step 2b).
The normalizer is the inverse of `resolvePoolInstanceQualified` and must honour
the same precedence, otherwise read-side resolution and write-side
normalization disagree about what `myrig/polecat-4090` means.

## The change

`internal/agentutil/resolve.go`, before the collapse loop:

```go
	if _, ok := findAgentByQualified(cfg, target); ok {
		return target
	}
```

(plus a comment citing the `ResolveAgent` precedence it mirrors, and one
sentence added to the function's doc comment). Nothing else changes: a genuine
slot suffix names no configured agent, so `findAgentByQualified` misses and the
existing collapse runs untouched.

## Test

`internal/agentutil/resolve_test.go`,
`TestNormalizePoolRouteTargetConfiguredAgentWins`: a config with an unbounded
pool `myrig/polecat` and a distinct agent `myrig/polecat-4090` — the worst
case, since unbounded capacity makes every numeric suffix collapse today.

* `NormalizePoolRouteTarget(cfg, "myrig/polecat-4090")` must return
  `"myrig/polecat-4090"` — **fails before the fix** (returns `"myrig/polecat"`).
* `NormalizePoolRouteTarget(cfg, "myrig/polecat-3")` must still return
  `"myrig/polecat"` — the genuine-slot path is not regressed.

The existing `TestNormalizePoolRouteTarget` table (base names, out-of-range,
zero, non-numeric, singleton, non-pool, unknown, empty) is unchanged and still
passes.

```
go test ./internal/agentutil -count=1   # PASS
go vet ./internal/agentutil             # PASS
gofmt -l on both touched files          # clean
```

## Compatibility

Strictly narrowing: the only targets whose result changes are those that name a
configured agent — where the previous result pointed at a *different* agent than
the operator named. No config, schema, or docs change. No new field, no
migration. A city with no numerically-suffixed agent names sees identical
behavior on every input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
