### PR TITLE
fix(pidutil,herdr): darwin-safe PID-1 probe and XDG skip-guard (fixes #5344)

### DIFF
--- a/internal/pidutil/cmdline_portable_test.go
+++ b/internal/pidutil/cmdline_portable_test.go
@@ -124,20 +124,23 @@ func TestAliveWithCmdline_NilMatchIsFalse(t *testing.T) {
 // safety here. An unreadable process must NOT be reported as matching: the
 // caller then assumes no poller is running and starts one. A duplicate poller is
 // recoverable; a silently absent one is not.
+//
+// PID 1 is the probe target rather than a stubbed ps on PATH: Cmdline reads
+// /proc directly on linux and kern.procargs2 directly on darwin for any live,
+// readable PID, so a ps stub never affected self's argv on either platform —
+// on darwin specifically, #5176 added the sysctl path, which made this
+// untestable there regardless of the stub. PID 1's argv, unlike this
+// process's own, is genuinely unreadable to an unprivileged caller on
+// darwin, which is the real permission boundary this test needs. Skip where
+// it IS readable (e.g. linux, where /proc/1/cmdline is typically
+// world-readable) rather than assert something false.
 func TestCmdline_FailsClosedWhenUnreadable(t *testing.T) {
-	if runtime.GOOS == "linux" {
-		t.Skip("on linux /proc answers directly, so the ps stub cannot make argv unreadable")
+	if _, err := Cmdline(1); err == nil {
+		t.Skip("PID 1 argv is readable in this environment; cannot exercise the fail-closed path this way")
 	}
 
-	binDir := t.TempDir()
-	// A ps that produces nothing, so the non-/proc path has no argv to offer.
-	if err := os.WriteFile(filepath.Join(binDir, "ps"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile(ps): %v", err)
-	}
-	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
-
-	if AliveWithCmdline(os.Getpid(), func([]string) bool { return true }) {
-		t.Fatal("AliveWithCmdline = true with no readable argv; must fail closed so the caller starts its poller")
+	if AliveWithCmdline(1, func([]string) bool { return true }) {
+		t.Fatal("AliveWithCmdline(1, ...) = true with unreadable argv; must fail closed so the caller starts its poller")
 	}
 }
 

--- a/internal/runtime/herdr/client_test.go
+++ b/internal/runtime/herdr/client_test.go
@@ -2,6 +2,7 @@ package herdr
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -18,8 +19,26 @@ import (
 // that sets XDG_CONFIG_HOME to the real user's config dir while redirecting
 // $HOME elsewhere (this fleet's agent sandboxes do exactly that) made the
 // old code compute a path no herdr process ever binds.
+//
+// Both tests below are Linux-only: os.UserConfigDir() on darwin ignores
+// XDG_CONFIG_HOME entirely and always resolves under
+// "$HOME/Library/Application Support" (see the Go stdlib implementation),
+// so asserting an XDG- or ".config"-rooted path is only valid on the
+// platforms os.UserConfigDir() treats as XDG-following (this repo's
+// non-Windows, non-Darwin default case). Whether herdr's own binary uses
+// pure-XDG resolution on macOS too is unverified here — the empirical
+// check above was run on Linux only — so the tests skip rather than assert
+// an unconfirmed cross-platform contract.
+
+func skipUnlessXDGPlatform(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skipf("os.UserConfigDir() does not follow XDG_CONFIG_HOME on %s; herdr's own resolution on this platform is unverified (see ga-nqlb8q)", runtime.GOOS)
+	}
+}
 
 func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
+	skipUnlessXDGPlatform(t)
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	t.Setenv("HOME", t.TempDir()) // deliberately different; must be ignored
@@ -36,6 +55,7 @@ func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
 }
 
 func TestSocketPathFallsBackToHomeConfigWhenXDGUnset(t *testing.T) {
+	skipUnlessXDGPlatform(t)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- `internal/pidutil`: `TestCmdline_FailsClosedWhenUnreadable` used a ps-stub-on-PATH technique that never actually exercised the fail-closed path on either platform still in use — `Cmdline` reads `/proc` directly on Linux and, since #5176, `kern.procargs2` directly on Darwin, both bypassing `ps` entirely for any live, readable PID. Replaces the stub with a dynamic probe against PID 1's own argv, which is genuinely unreadable to an unprivileged caller on Darwin (the real permission boundary under test) and typically readable on Linux, where the test now skips instead of asserting.
- `internal/runtime/herdr`: two new XDG socket-path tests unconditionally asserted a `.config`-rooted path; `os.UserConfigDir()` only honors `XDG_CONFIG_HOME` on Linux/Unix build tags and ignores it on Darwin. Skips the assertion on non-Linux platforms rather than assert an unverified cross-platform contract.
- Fixes #5344.

## Why this PR, now

Both fixes are Darwin-only-observable and test-file-only; there is no locally-executable RED to GREEN transition possible on Linux. Review (ga-ll4xto) requested changes because the Darwin-only assertion (`TestCmdline_FailsClosedWhenUnreadable`) self-skips in the Linux review environment, so no local run could supply the diff-owned evidence the fix actually works. Mayor ruling on that review: do not waive — open this PR instead, so the Mac CI lane (now executing `internal/pidutil` again after #5730 restored the macOS unit package list) supplies the real evidence.

**Note for whoever reads the Mac CI result:** `internal/pidutil` is also one of four pre-existing Mac failures already tracked separately (ga-bxlbi6/ga-uqdim3/ga-p1dis0). Read which test failed, not just the color — a `TestCmdline_FailsClosedWhenUnreadable` failure here would be diff-owned and real; a herdr/zcode/pathdurability failure is pre-existing and unrelated to this change.

## Testing

- [x] `gofmt -l internal/pidutil/cmdline_portable_test.go internal/runtime/herdr/client_test.go` — clean
- [x] `go vet ./internal/pidutil/... ./internal/runtime/herdr/...` — clean
- [x] `go test ./internal/runtime/herdr/... ./internal/pidutil/... -v` on Linux — 160 PASS, 2 SKIP (both platform-conditional; one is this diff's own Darwin-only assertion), 1 FAIL (`TestSessionEventsLive`, pre-existing/out-of-diff, reproduces identically against unmodified `origin/main`)
- [ ] Darwin verification — not possible from this Linux branch; this PR's Mac CI leg is the verification step (see above)

## Checklist

- [x] Linked an issue: fixes #5344
- [x] Added or updated tests for behavior changes (both commits are test-file-only)
- [ ] Updated docs for user-facing changes — n/a, no user-facing behavior change
- [x] Called out breaking changes or migration notes — none; test-only change

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4855 — touches one of the four process-introspection sites named there: it replaces the `runtime.GOOS == "linux"` skip whose stated rationale was "/proc answers directly" in internal/pidutil's argv unreadable-path test with a real PID 1 probe, which is exactly the skipped-coverage smell that issue describes. It does not consolidate the remaining direct /proc readers (bead_worktree_liveness, orphan_reap, dolt_cleanup_discovery) or settle the environ-identity design question, which are the main asks.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->