### PR TITLE
fix(events): activeScanStart falls back to a full scan on a reversed-seq log (#5650)

### DIFF
--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -159,14 +159,25 @@ func seqLineAt(f *os.File, off int64) (seq uint64, start int64, ok bool) {
 // it only after each line has been unmarshalled -- the dominant cost of the
 // supervisor's per-tick order-trigger check (gcy-ocb5).
 //
-// Returns 0 (full scan) whenever the boundary cannot be established, so a log
-// that violates the ordering invariant degrades in speed, never in correctness.
+// Returns 0 (full scan) whenever the boundary cannot be established, or
+// whenever the file's own head and tail contradict the non-decreasing-seq
+// assumption sort.Search depends on, so a log that violates the ordering
+// invariant this way degrades in speed rather than silently dropping events.
+// That check is necessarily partial: it catches a reversed tail (e.g. a stale
+// post-rotation writer appending seq below the file's head) but, like any
+// sub-linear check, cannot see an out-of-order run that both starts and ends
+// within the seq range the head and tail already imply.
 func activeScanStart(f *os.File, size int64, afterSeq uint64) int64 {
 	if afterSeq == 0 || size <= 0 {
 		return 0
 	}
 	// Nothing to skip when the log's first line is already above the cursor.
-	if first, _, ok := seqLineAt(f, 0); !ok || first > afterSeq {
+	first, _, ok := seqLineAt(f, 0)
+	if !ok || first > afterSeq {
+		return 0
+	}
+	tailSeq, err := readLatestSeqFromTail(f, size)
+	if err != nil || tailSeq < first {
 		return 0
 	}
 	i := sort.Search(int(size), func(i int) bool {
@@ -175,6 +186,11 @@ func activeScanStart(f *os.File, size int64, afterSeq uint64) int64 {
 	})
 	seq, start, ok := seqLineAt(f, int64(i))
 	if !ok || seq <= afterSeq {
+		if tailSeq > afterSeq {
+			// The file's actual last record contradicts "nothing left to
+			// see"; the search converged on a stale or corrupted region.
+			return 0
+		}
 		// Cursor is at or beyond the newest event: skip the file entirely.
 		return size
 	}

--- a/internal/events/reader_afterseq_seek_test.go
+++ b/internal/events/reader_afterseq_seek_test.go
@@ -151,6 +151,99 @@ func TestReadFilteredAfterSeqEquivalence(t *testing.T) {
 	}
 }
 
+// writeRawSeqLog writes one JSON line per entry in seqs, in order, with no
+// requirement that seqs be increasing. Models a log corrupted by a stale
+// post-rotation writer or a torn write, where seq no longer tracks byte
+// offset.
+func writeRawSeqLog(t *testing.T, seqs []uint64) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var sb strings.Builder
+	for _, seq := range seqs {
+		fmt.Fprintf(&sb, `{"seq":%d,"type":"a","ts":"2026-08-25T00:00:00Z","actor":"t","subject":"s%d"}`+"\n", seq, seq)
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+// TestActiveScanStartNonMonotonicReversal pins the fix for gastownhall/gascity#5650:
+// a log whose tail seq sits below its head seq (the shape a stale
+// post-rotation file descriptor produces, per the issue's reachability
+// analysis) must not let activeScanStart's sort.Search fast path silently
+// convince ReadFiltered to skip records that are still owed to the caller.
+// activeScanStart must fall back to a full scan (offset 0) rather than trust
+// a boundary computed against a non-monotone predicate.
+func TestActiveScanStartNonMonotonicReversal(t *testing.T) {
+	seqs := []uint64{10, 11, 12, 1, 2, 3}
+	path := writeRawSeqLog(t, seqs)
+
+	for _, tc := range []struct {
+		after uint64
+		want  []uint64
+	}{
+		{after: 10, want: []uint64{11, 12}},
+		{after: 11, want: []uint64{12}},
+	} {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		st, err := f.Stat()
+		if err != nil {
+			f.Close() //nolint:errcheck // test cleanup
+			t.Fatalf("stat: %v", err)
+		}
+		if got := activeScanStart(f, st.Size(), tc.after); got != 0 {
+			t.Errorf("after=%d: activeScanStart = %d, want 0 (full scan fallback on reversed tail)", tc.after, got)
+		}
+		f.Close() //nolint:errcheck // test cleanup
+
+		got, err := ReadFiltered(path, Filter{AfterSeq: tc.after})
+		if err != nil {
+			t.Fatalf("after=%d: ReadFiltered: %v", tc.after, err)
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("after=%d: got %d events, want %d (%v)", tc.after, len(got), len(tc.want), tc.want)
+		}
+		for i, w := range tc.want {
+			if got[i].Seq != w {
+				t.Errorf("after=%d: event %d seq=%d, want %d", tc.after, i, got[i].Seq, w)
+			}
+		}
+	}
+}
+
+// TestActiveScanStartInteriorSpikeResidualGap documents a known, accepted gap
+// left open by the gastownhall/gascity#5650 hardening: activeScanStart's
+// head/tail consistency check (see TestActiveScanStartNonMonotonicReversal)
+// can only detect non-monotonicity that is visible at the file's endpoints.
+// A single out-of-order record whose value falls strictly between the head
+// and tail seq -- an interior spike -- is information-theoretically
+// indistinguishable, from just the head and tail, from a healthy log whose
+// cursor happens to have caught up to the tail (activeScanStartTest already
+// pins that a caught-up cursor must still return size, not 0). Detecting an
+// interior spike would require scanning the file, which is exactly the cost
+// the optimization exists to avoid. This test pins the current, documented
+// behavior rather than asserting a fix that cannot exist at this cost.
+func TestActiveScanStartInteriorSpikeResidualGap(t *testing.T) {
+	path := writeRawSeqLog(t, []uint64{1, 2, 3, 100, 4, 5, 6})
+
+	got, err := ReadFiltered(path, Filter{AfterSeq: 6})
+	if err != nil {
+		t.Fatalf("ReadFiltered: %v", err)
+	}
+	// The correct answer per the issue's repro is [100]; the head/tail check
+	// cannot see it (head=1, tail=6 look perfectly healthy), so the fast path
+	// still skips the file. Recorded here so a future, stronger fix has a
+	// test to flip rather than a silent regression to catch.
+	if len(got) != 0 {
+		t.Fatalf("got %d events %v, want 0 (documenting the residual gap -- if this now finds [100], update this test to assert the fix and delete this comment)", len(got), got)
+	}
+}
+
 // TestReadFilteredAfterSeqMalformedLines pins that the seek path degrades to a
 // correct result when the log contains unparseable lines, which the scanner has
 // always tolerated by skipping.

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -390,7 +390,11 @@ func (r *FileRecorder) writeRecordLocked(e *Event) error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 	data = append(data, '\n')
-	if _, err := r.file.Write(data); err != nil {
+	written, err := r.file.Write(data)
+	if written != len(data) {
+		return errors.Join(err, io.ErrShortWrite)
+	}
+	if err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	r.recordCount++

--- a/internal/events/recorder_shortwrite_unix_test.go
+++ b/internal/events/recorder_shortwrite_unix_test.go
@@ -1,0 +1,47 @@
+//go:build unix
+
+package events
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestFileRecorderWriteRecordLockedDetectsShortWrite pins that
+// writeRecordLocked surfaces a partial write instead of silently treating it
+// as success, matching writeBatch's existing short-write handling. Uses
+// RLIMIT_FSIZE to force a real short write from the OS rather than mocking
+// r.file, which is a concrete *os.File.
+func TestFileRecorderWriteRecordLockedDetectsShortWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	recorder, err := NewFileRecorder(path, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = recorder.Close() })
+
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &rlim); err != nil {
+		t.Skipf("getrlimit RLIMIT_FSIZE unsupported: %v", err)
+	}
+	old := rlim
+	t.Cleanup(func() { _ = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &old) })
+
+	// The log is empty (NewFileRecorder performs no header write), so a
+	// five-byte cap guarantees the marshaled event -- far larger than five
+	// bytes -- gets truncated by the kernel mid-write.
+	rlim.Cur = 5
+	if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &rlim); err != nil {
+		t.Skipf("setrlimit RLIMIT_FSIZE unsupported: %v", err)
+	}
+
+	e := Event{Type: BeadCreated, Actor: "t", Subject: strings.Repeat("x", 200)}
+	err = recorder.writeRecordLocked(&e)
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("writeRecordLocked error = %v, want io.ErrShortWrite", err)
+	}
+}


### PR DESCRIPTION
Fixes the reachable half of #5650, and corrects the false claim in `activeScanStart`'s own doc comment that the issue leads with.

**Scope, stated up front: this fixes two of the four cases in the issue and deliberately leaves the other two, with a test pinning them.**

| repro from the issue | before | after |
|---|---|---|
| `[10 11 12 1 2 3]` `after=10`, `after=11` | drops events | **fixed** — full scan |
| `[1 2 3 100 4 5 6]` `after=4`, `after=6` | drops events | still drops — see below |

## What changed

`activeScanStart` drives `sort.Search`, which is only meaningful on a monotone predicate. It now refuses the fast path when the file's own head and tail contradict the non-decreasing-seq assumption — `tailSeq < first` means a reversed log, so it returns 0 and the caller does a full scan. There is a second guard on the way out: if the search converges on "nothing left to see" while the file's actual last record is above the cursor, that contradiction also forces a full scan.

That covers the shape your own reachability analysis identified — a stale post-rotation writer appending seq below the file's head.

## What it does not cover, and why I am not claiming otherwise

An out-of-order run that both starts and ends *within* the range head and tail already imply is invisible to any sub-linear check: in `[1 2 3 100 4 5 6]` the head is 1 and the tail is 6, which looks perfectly healthy. Catching that requires giving up the sub-linear property the optimization exists for, which is a different change with a performance argument attached, so I did not fold it in here.

Rather than leave that implicit, it is pinned: `TestActiveScanStartInteriorSpikeResidualGap` runs the issue's own `[1 2 3 100 4 5 6]` / `after=6` repro, asserts the current (wrong) empty result, and says in the failure message that a future stronger fix should flip the assertion rather than delete the test. So the gap is a documented, tested boundary rather than a silent one — and if someone closes it, the test tells them exactly what to do.

The doc comment on `activeScanStart` is updated to match: the old "degrades in speed, never in correctness" line — the false claim the issue opens with — is replaced by an accurate statement of what the check catches and what it cannot.

## Also here: the `writeRecordLocked` short-write asymmetry

You flagged this in your review of #5614 — `writeBatch` checks for a short write and `writeRecordLocked` does not — and called it "plausibly one source of the corruption being repaired here." Agreed, and it is the same package and the same failure class, so it is in this commit rather than a third PR: `writeRecordLocked` now compares the byte count and returns `errors.Join(err, io.ErrShortWrite)` on a partial write instead of dropping it. `TestFileRecorderWriteRecordLockedDetectsShortWrite` covers it.

If you would rather see that split out, say so and I will separate it.

## Tests

- `TestActiveScanStartNonMonotonicReversal` — the fixed class, from the issue's repro
- `TestActiveScanStartInteriorSpikeResidualGap` — the residual class, pinned
- `TestFileRecorderWriteRecordLockedDetectsShortWrite` — the short-write guard

`go vet ./...` clean whole-repo (untagged), `go test ./internal/events/...` passes, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>