### PR TITLE
fix(dolt): defer proven same-count writer races during compact

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -2856,6 +2856,7 @@ flatten_database() {
     # unproven HEAD movement fails closed and falls through to quarantine.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ] && \
+       [ "${verify_counts_saw_gain:-0}" != "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" != "1" ] && \
        [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
        [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -1173,6 +1173,7 @@ verify_counts() {
   verify_counts_saw_row_decrease=0
   verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
+  verify_counts_same_count_drift_tables=""
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
@@ -1271,6 +1272,7 @@ verify_counts() {
         printf 'compact: db=%s table=%s value hash changed after flatten without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         verify_counts_saw_same_count_hash_drift=1
+        verify_counts_same_count_drift_tables="$verify_counts_same_count_drift_tables $t"
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten table value hash changed without row-count increase"
@@ -2288,6 +2290,7 @@ flatten_database() {
   verify_counts_saw_row_decrease=0
   verify_counts_saw_decrease_hash_drift=0
   verify_counts_saw_same_count_hash_drift=0
+  verify_counts_same_count_drift_tables=""
   verify_counts_saw_table_list_change=0
   verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
@@ -2765,12 +2768,15 @@ flatten_database() {
   if [ "$verify_counts_rc" -ne 0 ]; then
     integrity_reason="${verify_counts_failure_reason:-post-flatten integrity check failed}"
     integrity_guidance="${verify_counts_failure_guidance:-post-flatten integrity check failed; investigate before re-running}"
-    # The blocks below each downgrade a quarantine to a skip-and-retry defer for
-    # one benign concurrent-writer signature — gain+drift, row-count decrease, or
-    # same-count value-hash drift — but only when a concurrent writer is
-    # HEAD-proven (or, for gain+drift, proven additive-only via DOLT_DIFF). A
-    # signature mixed with any other failure category, table-list drift, a probe
-    # failure, or a stable HEAD still quarantines below unchanged.
+    # Downgrade quarantine -> defer for specific integrity-failure categories
+    # where a concurrent writer is proven, rather than assuming corruption.
+    # Three categories get their own proof-gated defer path below: gain+drift
+    # (HEAD-proven writer race, or an absorbed-writer race proven
+    # additive-only via diff), row-count decrease (HEAD-proven concurrent
+    # DELETE), and same-count hash drift (HEAD-proven writer race proven
+    # additive-only via diff — a concurrent UPDATE). Table-list drift, probe
+    # failure, or any case whose specific proof fails still quarantine below
+    # unchanged.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_gain:-0}" = "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
@@ -2839,23 +2845,24 @@ flatten_database() {
       return 0
     fi
     # Downgrade quarantine -> defer for concurrent-writer UPDATE. A concurrent
-    # UPDATE during the flatten window changes a committed table's value hash
-    # while leaving its row count unchanged — the net-zero-row-count churn that
-    # dominates the busiest db's workload (ephemeral wisp pour/burn and bead/mail
-    # row updates). The whole-database value-hash drift downgrade below already
-    # defers a same-content change when a concurrent writer is HEAD-proven, so the
-    # per-table check must not be stricter than the database-level check for the
-    # same phenomenon. Safe to defer when a writer is proven and no other anomaly
-    # (row gain+drift, row decrease, table-list change, or probe failure)
-    # prevents safe deferral.
+    # UPDATE during the flatten window changes row values without changing row
+    # counts, which verify_counts cannot distinguish from corruption by count
+    # alone. Prove it directly the same way the absorbed-writer gain+drift case
+    # does: diff the pre-flight snapshot HEAD against the flatten commit for
+    # each drifted table. Purely additive (no removed/modified rows) proves
+    # the flatten itself never touched the table, so the drift is the
+    # concurrent writer's; defer exactly as the other proven-writer-race paths
+    # above do. Any removed/modified row, a diff-probe failure, or an
+    # unproven HEAD movement fails closed and falls through to quarantine.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_same_count_hash_drift:-0}" = "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" != "1" ] && \
        [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
        [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
-       [ "${verify_counts_saw_probe_failure:-0}" != "1" ]; then
-      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — same-count table value hash drift is concurrent-writer UPDATE data, not corruption; deferring, will retry next run\n' \
-        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+       [ "${verify_counts_saw_probe_failure:-0}" != "1" ] && \
+       gain_drift_is_additive_only "$db" "$head" "$flatten_head" "$verify_counts_same_count_drift_tables"; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — same-count table value hash drift proven additive-only via DOLT_DIFF(%s..%s) for tables [%s] is concurrent-writer UPDATE, not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" "$head" "$flatten_head" "${verify_counts_same_count_drift_tables# }" >&2
       if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
         "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
         "$compacted_from_head" "$local_branch" "$remote_branch"; then

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -1060,7 +1060,7 @@ case "$query" in
     # same-count-hash-drift defer). A zero count means the flatten commit
     # itself never touched the table's rows.
     case "$mode" in
-      writer_race_same_count_hash_drift_only)
+      writer_race_same_count_hash_drift_only|same_count_hash_drift_with_writer_race)
         print_cell 0
         ;;
       writer_race_same_count_hash_drift_diff_fails)
@@ -5846,7 +5846,7 @@ func TestCompactScriptDefersWhenWriterCommitsCausingSameCountHashDrift(t *testin
 	if err != nil {
 		t.Fatalf("concurrent-UPDATE same-count defer must exit 0 (skip, not failure): %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "same-count table value hash drift is concurrent-writer UPDATE data, not corruption") {
+	if !strings.Contains(out, "same-count table value hash drift proven additive-only via DOLT_DIFF") {
 		t.Fatalf("output missing concurrent-UPDATE same-count defer message:\n%s", out)
 	}
 	if !strings.Contains(out, "deferring, will retry next run") {

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -761,7 +761,7 @@ case "$query" in
     # probe, which reports writercommit so HEAD has moved past the flatten's own
     # commit. verify_counts still sees compactcommit (gain+drift) because it does
     # not probe HEAD and the "$(current_head)" gates read the real state.
-    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "same_count_hash_drift_with_writer_race" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "same_count_hash_drift_with_writer_race" ] || [ "$mode" = "writer_race_same_count_hash_drift_only" ] || [ "$mode" = "writer_race_same_count_hash_drift_diff_fails" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.postverify-head-calls"
       calls=0
       if [ -f "$calls_file" ]; then
@@ -863,7 +863,7 @@ case "$query" in
       print_cell hash-beads-after-writer
       exit 0
     fi
-    if [ "$mode" = "same_row_count_writer" ] && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "same_row_count_writer" ] || [ "$mode" = "writer_race_same_count_hash_drift_only" ] || [ "$mode" = "writer_race_same_count_hash_drift_diff_fails" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -1083,6 +1083,26 @@ case "$query" in
       first_commit_table_diff_probe_failure)
         printf 'probe table diff unavailable\n' >&2
         exit 55
+        ;;
+      *)
+        printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
+        exit 64
+        ;;
+    esac
+    exit 0
+    ;;
+  *"DOLT_DIFF("*"'beads')"*)
+    # Content diff of table "beads" between the pre-flight snapshot HEAD and
+    # the flatten's own commit, used to prove same-count value-hash drift is
+    # a concurrent writer's UPDATE rather than corruption (gastownhall/gascity
+    # same-count-hash-drift defer). A zero count means the flatten commit
+    # itself never touched the table's rows.
+    case "$mode" in
+      writer_race_same_count_hash_drift_only)
+        print_cell 0
+        ;;
+      writer_race_same_count_hash_drift_diff_fails)
+        print_cell 1
         ;;
       *)
         printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
@@ -2516,6 +2536,64 @@ func TestCompactScriptDefersWhenDatabaseHashPreHeadProbeIsEmptyButPostProbeProve
 		t.Fatalf("defer message should report empty pre-probe HEAD and writer post-probe HEAD:\n%s", out)
 	}
 	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+// A concurrent UPDATE that lands during the post-flatten verify leaves the
+// row count unchanged but drifts the table's value hash — the same signal as
+// corruption. HEAD moving past the flatten's own commit proves a writer, and
+// diffing the pre-flight snapshot against the flatten commit shows the
+// flatten itself never touched the table's rows (zero non-added rows), so
+// the drift is entirely the writer's UPDATE. That combination downgrades the
+// same-count-hash-drift quarantine to a defer.
+func TestCompactScriptDefersProvenWriterRaceSameCountHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_same_count_hash_drift_only", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "table=beads value hash changed after flatten without row-count increase") {
+		t.Fatalf("output missing the same-count hash-drift signal that the gate downgrades:\n%s", out)
+	}
+	if !strings.Contains(out, "post_verify_HEAD=writercommit") {
+		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
+	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+// Same proven writer race (HEAD moves past the flatten commit) but the
+// preflight-to-flatten diff proof itself fails — the flatten commit shows a
+// removed/modified row for the drifted table, so the drift cannot be
+// attributed entirely to the writer. The defer downgrade must not apply and
+// the run quarantines exactly as an unproven same-count drift would.
+func TestCompactScriptQuarantinesSameCountDriftWhenDiffProofFails(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_same_count_hash_drift_diff_fails", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite a failed additive-only diff proof:\n%s", out)
+	}
+	if !strings.Contains(out, "table=beads value hash changed after flatten without row-count increase") {
+		t.Fatalf("output missing value-hash drift warning:\n%s", out)
+	}
+	logData, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("same-count value-hash drift with a failed diff proof must block full GC:\n%s", logData)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("failed diff proof should still write quarantine marker: %v", statErr)
+	}
+	assertCompactMarkerHasEvidence(t, marker,
+		"reason=post-flatten table value hash changed without row-count increase",
+		"integrity_table_drift=table=beads,before_rows=10,after_rows=10,before_hash=hash-beads-before,after_hash=hash-beads-after-writer,category=same_row_count_hash_drift",
+		"flatten_pre_reset_head=headcommit",
+		"flatten_head=compactcommit",
+		"flatten_post_verify_head=writercommit",
+		"decision=preserve_marker_manual_review_required",
+	)
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if _, statErr := os.Stat(pendingGC); !os.IsNotExist(statErr) {
+		t.Fatalf("failed diff proof must not write a pending-GC retry marker; stat=%v", statErr)
+	}
 }
 
 func TestCompactScriptRetriesPendingGCAfterWriterRaceDefer(t *testing.T) {

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -1024,6 +1024,55 @@ case "$query" in
     print_cell beads
     exit 0
     ;;
+  *"DOLT_DIFF("*"'__gc_read_only_probe')"*)
+    # Must stay ordered before the generic "SELECT COUNT(*) FROM"*"beads"*
+    # arm below: this query's text also contains "SELECT COUNT(*) FROM" and,
+    # once the table argument is 'beads' (see next arm), also "beads" — case
+    # is first-match-wins, so the DOLT_DIFF arms have to come first or the
+    # generic row-count arm silently swallows them.
+    # Content diff of the table the flatten first-committed. A table absent
+    # from the pre-flatten committed root reports every row as added.
+    case "$mode" in
+      first_commit_probe_table_db_hash_drift|absorbed_ws_plus_first_commit_drift)
+        print_cell 0
+        ;;
+      first_commit_table_nonadditive_diff)
+        print_cell 1
+        ;;
+      first_commit_table_diff_probe_failure)
+        printf 'probe table diff unavailable\n' >&2
+        exit 55
+        ;;
+      *)
+        printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
+        exit 64
+        ;;
+    esac
+    exit 0
+    ;;
+  *"DOLT_DIFF("*"'beads')"*)
+    # Same ordering requirement as the probe-table arm above: this query's
+    # text also matches "SELECT COUNT(*) FROM"*"beads"*, so it must be
+    # dispatched before that generic arm.
+    # Content diff of table "beads" between the pre-flight snapshot HEAD and
+    # the flatten's own commit, used to prove same-count value-hash drift is
+    # a concurrent writer's UPDATE rather than corruption (gastownhall/gascity
+    # same-count-hash-drift defer). A zero count means the flatten commit
+    # itself never touched the table's rows.
+    case "$mode" in
+      writer_race_same_count_hash_drift_only)
+        print_cell 0
+        ;;
+      writer_race_same_count_hash_drift_diff_fails)
+        print_cell 1
+        ;;
+      *)
+        printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
+        exit 64
+        ;;
+    esac
+    exit 0
+    ;;
   *"SELECT COUNT(*) FROM"*"blocked_issues"*)
     if [ "$db" = "blocked_issues" ]; then
       printf 'database not found: blocked_issues\n' >&2
@@ -1068,47 +1117,6 @@ case "$query" in
     else
       print_cell 10
     fi
-    exit 0
-    ;;
-  *"DOLT_DIFF("*"'__gc_read_only_probe')"*)
-    # Content diff of the table the flatten first-committed. A table absent
-    # from the pre-flatten committed root reports every row as added.
-    case "$mode" in
-      first_commit_probe_table_db_hash_drift|absorbed_ws_plus_first_commit_drift)
-        print_cell 0
-        ;;
-      first_commit_table_nonadditive_diff)
-        print_cell 1
-        ;;
-      first_commit_table_diff_probe_failure)
-        printf 'probe table diff unavailable\n' >&2
-        exit 55
-        ;;
-      *)
-        printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
-        exit 64
-        ;;
-    esac
-    exit 0
-    ;;
-  *"DOLT_DIFF("*"'beads')"*)
-    # Content diff of table "beads" between the pre-flight snapshot HEAD and
-    # the flatten's own commit, used to prove same-count value-hash drift is
-    # a concurrent writer's UPDATE rather than corruption (gastownhall/gascity
-    # same-count-hash-drift defer). A zero count means the flatten commit
-    # itself never touched the table's rows.
-    case "$mode" in
-      writer_race_same_count_hash_drift_only)
-        print_cell 0
-        ;;
-      writer_race_same_count_hash_drift_diff_fails)
-        print_cell 1
-        ;;
-      *)
-        printf 'unexpected DOLT_DIFF query: %%s\n' "$query" >&2
-        exit 64
-        ;;
-    esac
     exit 0
     ;;
   *"DOLT_DIFF_STAT"*)

--- a/release-gates/ga-i61ym3-dolt-compact-same-count-writer-race-gate.md
+++ b/release-gates/ga-i61ym3-dolt-compact-same-count-writer-race-gate.md
@@ -1,0 +1,101 @@
+# Release gate: Dolt compact same-count writer-race handling
+
+- Deploy bead: `ga-i61ym3`
+- Build bead: `ga-braayf`
+- Review bead: `ga-09gd0z`
+- Reviewed source: `164de8221d830458a1ab72a087cf9339c13bfaac`
+- Reviewed source branch: `builder/ga-vyrswz-samecount-rebase` (provenance only)
+- Deploy branch: `deploy/ga-i61ym3-gate`
+- Base checked at gate time: `origin/main@52b5f4045c8c3e779daaf814b1fde7573f3af752`
+- Gate result: **PASS with attributed pre-existing failures**
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-09gd0z` records `verdict: pass` for exact source `164de8221d830458a1ab72a087cf9339c13bfaac`. Deploy bead `ga-i61ym3`, created by `gascity/reviewer`, independently records a fresh rebase-resume review pass. |
+| 2 | Acceptance criteria met | **PASS** | The compact path distinguishes same-count value-hash drift, requires the existing additive-only `DOLT_DIFF` proof before treating it as a writer race, excludes any row gain from that path, defers on proof success, and preserves quarantine/manual review on proof failure. The complete affected package and all three diff-owned tests pass. |
+| 3 | Tests pass | **PASS with attributed failures** | `make test-local-full-parallel` completed 37/40 jobs PASS and 3/40 FAIL with 3 failing top-level tests and 0 observed SKIP. All three failures have trackers predating this run and are structurally unreachable from the two changed files. Independently, `go test -count=1 -v ./examples/bd/dolt/...` passed 289 PASS, 0 FAIL, 0 SKIP. Both PR REST smoke shards and all six `cmd/gc` process shards passed. |
+| 3b | Policy, build, and static checks | **PASS with attributed baseline failure** | `make test-ci-policy`, `make check-gomod-replace`, `make check-eventexport-isolation`, `make check-core-boundary`, `make check-docs`, `go build ./...`, `go vet ./...`, and `make test-native-doltlite-beads` passed. `make check-native-dependency-surface` preserved the known host-dependent old measurement failure (`270668536 > 270000000`), tracked before this run by `ga-iuznq2`; reviewed deploy bead `ga-qma9li` carries the isolated fix. This candidate cannot affect the `gc` binary graph. |
+| 4 | No unresolved HIGH review findings | **PASS** | Review bead `ga-09gd0z` records no style, security, specification, or high-severity finding. |
+| 5 | Final branch clean | **PASS** | Before this record was added, `git status --short --branch` showed only `## deploy/ga-i61ym3-gate`; `git diff --check origin/main...HEAD` passed. Final cleanliness is rechecked after the gate commit. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree --messages origin/main HEAD` returned tree `238cf7c5dca2174aa523f6f8f76b61f5f0f683c0` with no conflict messages. The source is 3 commits behind and 4 commits ahead of current `origin/main`. |
+| 7 | Single feature theme | **PASS** | The reviewed range changes only `examples/bd/dolt/commands/compact/run.sh` and `examples/bd/dolt/dog_exec_scripts_test.go`; all four commits implement or test same-count writer-race handling in Dolt compaction. |
+
+## Source and ancestry evidence
+
+The handoff SHA resolves as a commit and is the deploy branch's pre-gate `HEAD`:
+
+```text
+git rev-parse --verify --quiet '164de8221d830458a1ab72a087cf9339c13bfaac^{commit}'
+164de8221d830458a1ab72a087cf9339c13bfaac
+```
+
+The isolated branch was created directly from that SHA. Its reviewed range over
+merge base `157858d9ee8bd6ab85e4a0d2128f34dc2e166a7f` is exactly:
+
+```text
+3fd2e43963 test(dolt): red — cover same-count hash drift writer-race defer (ga-h0bj7x)
+22067fa6ce feat: green — defer same-count hash drift as proven writer-race UPDATE (refs ga-h0bj7x)
+70b0345f98 fix(dolt): restore missing gain-exclusion guard on same-count defer path (ga-loyfg8)
+164de8221d test(dolt): wire upstream's same-count writer-race test into the diff-proof mock (ga-h0bj7x)
+```
+
+## Acceptance and focused-test evidence
+
+- `TestCompactScriptDefersProvenWriterRaceSameCountHashDrift`: PASS.
+- `TestCompactScriptQuarantinesSameCountDriftWhenDiffProofFails`: PASS.
+- `TestCompactScriptDefersWhenWriterCommitsCausingSameCountHashDrift`: PASS.
+- Complete package command: `go test -count=1 -v ./examples/bd/dolt/...`.
+- Complete package result: 289 PASS, 0 FAIL, 0 SKIP.
+- Focused log: `/var/tmp/ga-i61ym3-focused.log`.
+
+The changed Go file is package-local test code. The production change is one
+shell script under the same package. Neither can be imported or executed by
+`internal/bdflags`, `internal/runtime/herdr`, or `test/integration`'s city
+suspend/resume scenario.
+
+## Full-sweep failure attribution
+
+- `test_cmd`: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=4 make test-local-full-parallel`
+- `test_cmd_scope`: full-suite, including the path-triggered integration lane.
+- `test_counts`: 37 PASS jobs, 3 FAIL jobs, 0 observed SKIP; 3 failing top-level tests.
+- `full_log`: `/var/tmp/ga-i61ym3-full.log`.
+- `shard_logs`: `/var/tmp/gc-local-tests.xHKZD3`.
+- `waiver_ref`: none; each failure is attributed under structural non-reachability with a predating tracker.
+
+| Raw failing test | Predating tracker | Disposition and proof |
+|---|---|---|
+| `TestBdFlagManifestCurrent` | `ga-f0uceo`, opened 2026-08-15 | Installed `bd` exposes flags absent from the checked-in manifest. The candidate does not touch `internal/bdflags`, the installed binary, or any manifest-generation path. |
+| `TestSessionEventsLive` | `ga-idsv6m`, opened 2026-08-29 15:03 UTC | Exact known herdr event-stream race (`getAgent evt-a: ok=false err=nil`). The candidate does not touch or reach `internal/runtime/herdr`. |
+| `TestE2E_SuspendResume_City` | `ga-yc0e3a`, opened 2026-08-18 | Exact known missing `citysus.report` timeout. The candidate does not touch city suspend/resume, session lifecycle, or the integration test. |
+
+`failure_attribution`: clause 3(a), structural mechanism/import reachability,
+plus no changed-path overlap. All trackers predate this gate run. No diff-owned
+test failed or skipped.
+
+## Policy and static evidence
+
+```text
+make test-ci-policy                      PASS
+make check-gomod-replace                 PASS
+make check-eventexport-isolation         PASS
+make check-core-boundary                 PASS
+make check-docs                          PASS
+go build ./...                           PASS
+go vet ./...                             PASS
+make test-native-doltlite-beads          PASS
+make check-native-dependency-surface     FAIL-ATTRIBUTED: 270668536 > 270000000 (ga-iuznq2; fix ga-qma9li)
+```
+
+The binary-size check's old measurement is host-path/cgo dependent. `ga-iuznq2`
+predates this run and records the same failure on unmodified main; its reviewed
+fix makes the build deterministic with `-trimpath` and `CGO_ENABLED=0`. This
+candidate changes no `cmd/gc` or dependency file and cannot change the measured
+binary.
+
+## Release disposition
+
+**Gate PASS.** Commit this record on `deploy/ga-i61ym3-gate`, push that isolated
+branch, open the PR, publish deploy clearance on its exact head, and route the
+merge request to mayor/mpr. The deployer does not merge.


### PR DESCRIPTION
## Summary

- treat same-count value-hash drift as a concurrent writer race only when the existing `DOLT_DIFF` proof shows additive-only changes
- fail closed to quarantine/manual review when that proof fails or any row gain is present
- extend the compact-script mock and regression coverage for both outcomes

Refs `ga-i61ym3`, `ga-h0bj7x`, and `ga-loyfg8`.

Deploy evidence: [`release-gates/ga-i61ym3-dolt-compact-same-count-writer-race-gate.md`](https://github.com/quad341/gascity/blob/deploy/ga-i61ym3-gate/release-gates/ga-i61ym3-dolt-compact-same-count-writer-race-gate.md)

## Testing

- [x] `go test -count=1 -v ./examples/bd/dolt/...` — 289 PASS, 0 FAIL, 0 SKIP
- [x] `make test-local-full-parallel` — 37/40 jobs PASS; three predating, structurally unrelated failures tracked as `ga-f0uceo`, `ga-idsv6m`, and `ga-yc0e3a`
- [x] `make test-ci-policy`
- [x] `make check-docs`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test-native-doltlite-beads`
- [x] pre-push `make test-fast-parallel` — all 10 jobs passed

`make check-native-dependency-surface` preserves the known host-dependent old measurement failure tracked by `ga-iuznq2`; reviewed deploy bead `ga-qma9li` carries its isolated fix. This PR changes no binary dependency path.

## Checklist

- [x] Linked the tracked work
- [x] Added regression coverage for the behavior change
- [x] No user-facing documentation change is required
- [x] No breaking change or migration is introduced

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3341 — hardens the dolt compact concurrent-writer handling described in that issue: same-count value-hash drift is deferred only when a DOLT_DIFF proof shows the flatten itself touched no rows, and fails closed to quarantine/manual review otherwise; it does not change the quarantine marker's alerting or auto-staleness, nor the backup path that fails while a database is quarantined

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->