### PR TITLE
fix(ci): make native dependency size guard deterministic

### DIFF
--- a/release-gates/ga-qma9li-native-dependency-surface-determinism-gate.md
+++ b/release-gates/ga-qma9li-native-dependency-surface-determinism-gate.md
@@ -1,0 +1,102 @@
+# Release gate: deterministic native dependency surface measurement
+
+- Deploy bead: `ga-qma9li`
+- Build bead: `ga-iuznq2`
+- Review bead: `ga-n8apor`
+- Reviewed source: `09139999930b1c2aa7d47df288d1f2e26f28b4eb`
+- Reviewed source branch: `builder/ga-iuznq2` (provenance only)
+- Deploy branch: `deploy/ga-qma9li-gate`
+- Base checked at gate time: `origin/main@52b5f4045c8c3e779daaf814b1fde7573f3af752`
+- Gate result: **PASS**
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Closed review bead `ga-n8apor` records `verdict: pass` for exact source `09139999930b1c2aa7d47df288d1f2e26f28b4eb`, with no uncovered criterion. |
+| 2 | Acceptance criteria met | **PASS** | The measurement build now uses `CGO_ENABLED=0 go build -trimpath` while remaining unstripped for the downstream symbol and literal scans. The default byte ceiling is re-baselined from 270,000,000 to 180,000,000 beside dated measurement, variance, growth-rate, and future re-baseline evidence. Two consecutive exact guard runs were byte-identical at 172,098,893 bytes. |
+| 3 | Tests pass | **PASS** | The path-relevant required CI coverage is green: the `Preflight / static checks` commands pass, including the exact native-surface guard twice; `Preflight / acceptance A` passes via `make test-acceptance`; and the broader fast baseline passes all 10 jobs. No test file changes in this one-file shell diff, so there is no diff-owned test to enumerate or waive. |
+| 4 | No unresolved HIGH review findings | **PASS** | Review bead `ga-n8apor` records no style, security, specification, or high-severity finding. |
+| 5 | Final branch clean | **PASS** | Before this record was added, `git status --short --branch` showed only `## deploy/ga-qma9li-gate`; `git diff --check origin/main...HEAD` passed. Final cleanliness is rechecked after the gate commit. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree --messages origin/main HEAD` returned tree `897f0a2b7201af728ab4e29b762f16cc16d829b8` with no conflict messages. The source is 2 commits behind and 1 commit ahead of current `origin/main`. |
+| 7 | Single feature theme | **PASS** | One reviewed commit changes only `scripts/check-native-dependency-surface.sh`, making its byte measurement cross-host deterministic and re-baselining the same guard from evidence. |
+
+## Source and acceptance evidence
+
+The recorded source resolves exactly and is the deploy branch's pre-gate
+`HEAD`:
+
+```text
+git rev-parse --verify --quiet '09139999930b1c2aa7d47df288d1f2e26f28b4eb^{commit}'
+09139999930b1c2aa7d47df288d1f2e26f28b4eb
+```
+
+The isolated branch was created directly from that SHA. The source has one
+commit over merge base `8940ee38c24c8c587293e0f456b42ae76bb298b1`:
+
+```text
+0913999993 fix(ci): make native-dependency-surface build deterministic, re-baseline cap
+```
+
+The exact guard was run twice in sequence after `bash -n` and `shellcheck`:
+
+```text
+native dependency guard: modules=727 aws=25 azure=9 dolthub=15 googleapi=1 binary_bytes=172098893
+native dependency guard: modules=727 aws=25 azure=9 dolthub=15 googleapi=1 binary_bytes=172098893
+```
+
+Both runs preserved every module-count tripwire and produced the same binary
+size. The 180,000,000-byte ceiling leaves 7,901,107 bytes of measured headroom,
+while remaining 90,000,000 bytes tighter than the old host-dependent ceiling.
+
+## Test and static evidence
+
+- `test_cmd`: `make check-native-dependency-surface` twice.
+- `test_cmd_scope`: focused, exact required policy check changed by this diff.
+- `test_counts`: 2 PASS runs, 0 FAIL, byte-identical; no test SKIP applies.
+- `determinism_log`: `/var/tmp/ga-qma9li-determinism.log`.
+- `fast_cmd`: `LOCAL_TEST_JOBS=15 make test-fast-parallel`.
+- `fast_result`: 10 PASS jobs, 0 FAIL jobs.
+- `fast_log`: `/var/tmp/ga-qma9li-fast.log`.
+- `acceptance_cmd`: `make test-acceptance`.
+- `acceptance_result`: PASS for the Tier-A command-level PR gate.
+- `static_acceptance_log`: `/var/tmp/ga-qma9li-static-acceptance.log`.
+- `diff_tests_executed`: none; the diff changes no test file and no existing test wraps this script.
+- `waiver_ref`: none.
+- `uncovered_criteria`: none.
+
+```text
+bash -n scripts/check-native-dependency-surface.sh   PASS
+shellcheck scripts/check-native-dependency-surface.sh PASS
+make test-ci-policy                                 PASS
+make check-gomod-replace                            PASS
+make check-eventexport-isolation                    PASS
+make check-core-boundary                            PASS
+make test-native-doltlite-beads                     PASS
+make check-docs                                     PASS
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make fmt-check-changed PASS
+LINT_CHANGED_REF=origin/main make lint-affected     PASS (0 issues)
+go build ./...                                      PASS
+go vet ./...                                        PASS
+make test-acceptance                                PASS
+```
+
+## PR #5489 conflict guard
+
+PR #5489 is still open at gate time. Its current head
+`9ef8c29b969e573eaa390dde18a64e3348c903c6` contains cited commit
+`3c4090e81a`, and its copy of `scripts/check-native-dependency-surface.sh`
+still uses the host-dependent plain `go build` plus a 285,000,000-byte default.
+If #5489 lands after this deploy, it will silently replace the deterministic
+180,000,000-byte re-baseline with that older behavior.
+
+The deploy PR body must flag this conflict explicitly. Mayor/mpr must preserve
+this PR's deterministic build and 180,000,000-byte ceiling when resolving or
+sequencing #5489.
+
+## Release disposition
+
+**Gate PASS.** Commit this record on `deploy/ga-qma9li-gate`, push that isolated
+branch, open the PR with the mandatory #5489 conflict warning, publish deploy
+clearance on its exact head, and route the merge request to mayor/mpr. The
+deployer does not merge.

--- a/scripts/check-native-dependency-surface.sh
+++ b/scripts/check-native-dependency-surface.sh
@@ -2,7 +2,16 @@
 set -euo pipefail
 
 max_modules="${GC_NATIVE_DEP_MAX_MODULES:-727}"
-max_binary_bytes="${GC_NATIVE_DEP_MAX_BINARY_BYTES:-270000000}"
+# max_binary_bytes re-baselined 2026-08-29 (ga-iuznq2). The build below now
+# adds -trimpath and CGO_ENABLED=0, which removes cross-host path-embedding
+# and native C-object (dolthub/gozstd, ICU) variance that previously made
+# this cap non-deterministic between machines. Measured 172,098,757 bytes on
+# this host, corroborating an independent 172,098,813 measured elsewhere
+# (within 56 bytes -- residual build-id/timestamp noise). First-party code
+# grows the binary ~90KB/day, so 180,000,000 gives ~88 days of headroom.
+# Re-baseline with fresh measurement + growth-rate evidence, not an
+# arbitrary bump, when this next fails.
+max_binary_bytes="${GC_NATIVE_DEP_MAX_BINARY_BYTES:-180000000}"
 max_aws_modules="${GC_NATIVE_DEP_MAX_AWS_MODULES:-25}"
 max_azure_modules="${GC_NATIVE_DEP_MAX_AZURE_MODULES:-9}"
 max_dolthub_modules="${GC_NATIVE_DEP_MAX_DOLTHUB_MODULES:-15}"
@@ -51,7 +60,7 @@ fi
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT INT TERM HUP
-go build -o "$tmpdir/gc" ./cmd/gc
+CGO_ENABLED=0 go build -trimpath -o "$tmpdir/gc" ./cmd/gc
 
 go tool nm "$tmpdir/gc" > "$tmpdir/gc.nm"
 for forbidden_symbol in \


### PR DESCRIPTION
## Summary

- build the native-dependency measurement binary with `CGO_ENABLED=0` and `-trimpath`, removing host C-toolchain and embedded-path variance
- keep the binary unstripped so the existing symbol and forbidden-literal scans remain effective
- re-baseline the byte ceiling from 270,000,000 to 180,000,000 with dated measurement and growth-rate evidence

Refs `ga-qma9li` and `ga-iuznq2`.

Deploy evidence: [`release-gates/ga-qma9li-native-dependency-surface-determinism-gate.md`](https://github.com/quad341/gascity/blob/deploy/ga-qma9li-gate/release-gates/ga-qma9li-native-dependency-surface-determinism-gate.md)

## ⚠️ Merge-order conflict with PR #5489

PR #5489 currently still contains commit `3c4090e81a` (`chore(ci): raise the native-surface byte tripwire to 285MB`). Its current head keeps the old host-dependent plain `go build` and changes this same ceiling to `285000000`.

**If #5489 lands after this PR, it will silently undo this deterministic measurement and replace the evidence-based `180000000` re-baseline with `285000000`.** Whoever merges or rebases either PR must preserve this PR's `CGO_ENABLED=0 go build -trimpath` invocation and 180,000,000-byte ceiling. Please do not allow #5489 to clobber them during conflict resolution or later sequencing.

## Testing

- [x] `make check-native-dependency-surface` twice — both PASS, byte-identical at 172,098,893 bytes; module counts 727/25/9/15/1
- [x] `bash -n scripts/check-native-dependency-surface.sh`
- [x] `shellcheck scripts/check-native-dependency-surface.sh`
- [x] `make test-fast-parallel` — all 10 jobs passed
- [x] `make test-acceptance` — Tier-A PR gate passed
- [x] `make test-ci-policy`
- [x] `make test-native-doltlite-beads`
- [x] `make check-docs`
- [x] changed formatting and affected lint — 0 issues
- [x] `go build ./...`
- [x] `go vet ./...`

## Checklist

- [x] Linked the tracked work
- [x] The existing native-surface guard is the direct regression proof; no test file changes are needed
- [x] No user-facing documentation change is required
- [x] The #5489 merge-order conflict is explicitly called out above
- [x] No breaking change or migration is introduced
