### PR TITLE
fix(execgrace): run TestMonitorOutputResetsIdle on a virtual clock

### DIFF
--- a/internal/execgrace/execgrace_test.go
+++ b/internal/execgrace/execgrace_test.go
@@ -55,6 +55,7 @@ func TestMonitorIdleTimeout(t *testing.T) {
 // deadline with no actual stall, producing a spurious ErrIdle. The bubble
 // removes that dependence on real elapsed time and OS scheduling entirely.
 func TestMonitorOutputResetsIdle(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		m := NewMonitor(context.Background(), 200*time.Millisecond, 0)
 		defer m.Stop()

--- a/internal/execgrace/execgrace_test.go
+++ b/internal/execgrace/execgrace_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -47,34 +48,41 @@ func TestMonitorIdleTimeout(t *testing.T) {
 // TestMonitorOutputResetsIdle proves output keeps the context alive past the
 // idle window (the slow-but-healthy case the fixed deadline killed), and that
 // silence afterwards still cancels.
+//
+// Runs inside a synctest bubble so the write cadence and idle window advance
+// on a virtual clock: under a loaded machine (e.g. the full `make test`
+// suite), real goroutine scheduling delays could push a write past the idle
+// deadline with no actual stall, producing a spurious ErrIdle. The bubble
+// removes that dependence on real elapsed time and OS scheduling entirely.
 func TestMonitorOutputResetsIdle(t *testing.T) {
-	t.Parallel()
-	m := NewMonitor(context.Background(), 200*time.Millisecond, 0)
-	defer m.Stop()
-	w := m.Writer(io.Discard)
+	synctest.Test(t, func(t *testing.T) {
+		m := NewMonitor(context.Background(), 200*time.Millisecond, 0)
+		defer m.Stop()
+		w := m.Writer(io.Discard)
 
-	// Write every 50ms for 3x the idle window.
-	deadline := time.Now().Add(600 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		if _, err := w.Write([]byte("progress\n")); err != nil {
-			t.Fatalf("write: %v", err)
+		// Write every 50ms for 3x the idle window.
+		deadline := time.Now().Add(600 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			if _, err := w.Write([]byte("progress\n")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			select {
+			case <-m.Context().Done():
+				t.Fatalf("context canceled while output was flowing: %v", context.Cause(m.Context()))
+			case <-time.After(50 * time.Millisecond):
+			}
 		}
+
+		// Now go silent; the idle window must fire.
 		select {
 		case <-m.Context().Done():
-			t.Fatalf("context canceled while output was flowing: %v", context.Cause(m.Context()))
-		case <-time.After(50 * time.Millisecond):
+			if cause := context.Cause(m.Context()); !errors.Is(cause, ErrIdle) {
+				t.Fatalf("cause = %v, want ErrIdle", cause)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("idle timeout never fired after output stopped")
 		}
-	}
-
-	// Now go silent; the idle window must fire.
-	select {
-	case <-m.Context().Done():
-		if cause := context.Cause(m.Context()); !errors.Is(cause, ErrIdle) {
-			t.Fatalf("cause = %v, want ErrIdle", cause)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("idle timeout never fired after output stopped")
-	}
+	})
 }
 
 // TestMonitorCeiling proves the runaway backstop: continuous output does not


### PR DESCRIPTION
`TestMonitorOutputResetsIdle` paced writes against a real 200ms idle window with a 50ms write cadence. Under load, a stall in the writer goroutine's own real-time scheduling could exceed the idle window with no actual output stall, so the monitor cancelled and the test failed with a spurious `ErrIdle`. It surfaced during full-suite runs, where the scheduler is contended.

The fix moves the test into a `testing/synctest` bubble. Virtual time only advances once every goroutine is durably blocked, so a slow scheduler can no longer let apparent silence elapse between writes. The assertions are unchanged: output past the idle window keeps the context alive, and silence afterwards still cancels with `ErrIdle`.

`t.Parallel()` stays on the outer test. Only the bubble's inner `*testing.T` forbids it, and the rest of the package is parallel.

No production code changes.

## Test plan

- `go test -race -count=5 ./internal/execgrace/` passes; the bubbled test is deterministic across runs.
- `go vet ./internal/execgrace/` and `make build` clean.
- Guard suites green: `go test ./internal/testpolicy/resourcecensus/ ./scripts/cipolicy/ ./internal/testenv/`, baseline pinned to `origin/main` at `8940ee38c`.
- Reviewed the monitor for anything that would not participate in a bubble. It uses `time.Now`, `time.Since` and `time.AfterFunc` (`internal/execgrace/execgrace.go:130,132,190`), with atomics, context cancellation and an uncontended mutex otherwise, and the test writes only to `io.Discard`. Nothing there can prevent durable blocking.

One coverage boundary worth naming: the activity refresh is synchronous today (`execgrace.go:208`). If it ever became asynchronous, this test would pass under virtual time while starving under real load. The original timing-based test was not a reliable load regression test either, so this is not a regression in coverage, but it is the assumption the deterministic version rests on.
