### PR TITLE
fix(events): a wide --since window now truncates instead of failing with nothing

### DIFF
--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -564,10 +564,9 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 		return 1
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
 	if scope.isSupervisor() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 		items, err := fetchSupervisorEvents(ctx, client, typeFilter, sinceFlag)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
@@ -576,6 +575,13 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 		items = filterSupervisorEvents(items, typeFilter, payloadMatch)
 		return printJSONLines(items, stdout, stderr)
 	}
+
+	// The city list drains a --since window across as many pages as it takes.
+	// The walk stays bounded in aggregate -- an unbounded walk would trade a
+	// fast failure for a hang -- but running out of budget now truncates the
+	// window and says so, instead of discarding every page already fetched.
+	ctx, cancel := context.WithTimeout(context.Background(), cityEventsWalkBudget)
+	defer cancel()
 
 	items, err := fetchCityEvents(ctx, client, scope.cityName, typeFilter, sinceFlag, stderr)
 	if err != nil {
@@ -1039,6 +1045,40 @@ func probeCityEventsReachable(ctx context.Context, client *genclient.ClientWithR
 // strictly below the page's oldest seq (#4194).
 const cityEventsPageLimit = int64(500)
 
+// The city event list is drained under two separate budgets, because a
+// --since window is walked across however many pages it takes (#4385) and the
+// two failures they catch are not the same failure:
+//
+//   - cityEventsPageTimeout bounds ONE page request. It catches a server that
+//     has stopped answering.
+//   - cityEventsWalkBudget bounds the WHOLE walk. It is the ceiling on how
+//     long `gc events --since ...` may run, so that a wide window degrades
+//     instead of hanging.
+//
+// A single budget cannot do both jobs. Charging the whole walk to one
+// per-request deadline is what made a wide window fail on its size rather
+// than on server health -- and fail having discarded every page it had
+// already fetched. Hitting the walk budget is therefore a truncation, not an
+// error: fetchCityEvents returns the pages it has and labels them.
+//
+// Both are vars so tests can exercise the walk without real-time waits.
+var (
+	cityEventsPageTimeout = 30 * time.Second
+	cityEventsWalkBudget  = 30 * time.Second
+)
+
+// fetchCityEventsPage issues a single page request under its own deadline, so
+// that a multi-page walk is bounded per request rather than in aggregate.
+func fetchCityEventsPage(ctx context.Context, client *genclient.ClientWithResponses, cityName string, params *genclient.GetV0CityByCityNameEventsParams) (*genclient.GetV0CityByCityNameEventsResponse, error) {
+	pageCtx, cancel := context.WithTimeout(ctx, cityEventsPageTimeout)
+	defer cancel()
+	resp, err := client.GetV0CityByCityNameEventsWithResponse(pageCtx, cityName, params)
+	if err != nil {
+		return nil, &eventsAPITransportError{err: err}
+	}
+	return resp, nil
+}
+
 // fetchCityEvents fetches city events matching the type/since filter and
 // returns them chronologically (ascending seq). The endpoint is a keyset,
 // seq-DESC (newest first) paginated list; a truncated page carries a
@@ -1070,9 +1110,17 @@ func fetchCityEvents(ctx context.Context, client *genclient.ClientWithResponses,
 		if cursor != "" {
 			params.Cursor = &cursor
 		}
-		resp, err := client.GetV0CityByCityNameEventsWithResponse(ctx, cityName, params)
+		resp, err := fetchCityEventsPage(ctx, client, cityName, params)
 		if err != nil {
-			return nil, &eventsAPITransportError{err: err}
+			// Out of walk budget mid-drain. Every page already fetched is
+			// good data, and throwing it away is strictly worse than a short
+			// window the caller can see is short -- so report the truncation
+			// the same way the single-page cap below does, and return.
+			if paginate && len(all) > 0 && ctx.Err() != nil {
+				fmt.Fprintf(warn, "gc events: showing the newest %d events in the window; the walk ran out of time before reaching the older end. Use a narrower --since to fetch a full window.\n", len(all)) //nolint:errcheck
+				break
+			}
+			return nil, err
 		}
 		if err := eventsListError(resp.StatusCode(), resp.Body); err != nil {
 			return nil, err

--- a/cmd/gc/cmd_events_test.go
+++ b/cmd/gc/cmd_events_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1635,6 +1636,169 @@ func TestFetchCityEventsPaginatesSinceWindow(t *testing.T) {
 	// A drained window is complete, so no truncation notice.
 	if warn.Len() != 0 {
 		t.Fatalf("unexpected truncation notice for a fully drained window: %q", warn.String())
+	}
+}
+
+// delayedHandler wraps a route so each page request costs a fixed amount of
+// wall time, letting the budget tests below distinguish "per page" from
+// "per walk" without depending on real network latency.
+func delayedHandler(delay time.Duration, next func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			return
+		}
+		next(w, r)
+	}
+}
+
+// TestFetchCityEventsPageBudgetDoesNotAccumulateAcrossWalk pins the fix for the
+// deadline that #4385 left behind: draining a --since window across pages made
+// the walk unbounded in page count, but the budget stayed the single fixed one
+// written for the one-page world. The result was a command that failed on
+// window SIZE rather than on server health -- deterministically, and discarding
+// every page it had already fetched.
+//
+// The walk here costs more wall time in aggregate than one page budget, while
+// each individual page fits comfortably inside it. It must drain in full.
+func TestFetchCityEventsPageBudgetDoesNotAccumulateAcrossWalk(t *testing.T) {
+	const (
+		total     = 2000 // 4 keyset pages of 500
+		pageDelay = 150 * time.Millisecond
+		budget    = 400 * time.Millisecond // > pageDelay, < 4*pageDelay
+	)
+	restore := cityEventsPageTimeout
+	cityEventsPageTimeout = budget
+	t.Cleanup(func() { cityEventsPageTimeout = restore })
+
+	allDesc := make([]cliWireEvent, 0, total)
+	for seq := total; seq >= 1; seq-- {
+		allDesc = append(allDesc, cliWireEvent{
+			Actor: "gc", Seq: int64(seq), Type: "e.t",
+			Ts: time.Unix(1700000000+int64(seq), 0).UTC(),
+		})
+	}
+	server := newEventsTestServer(t, testEventRoutes{
+		cityEvents: delayedHandler(pageDelay, pagedCityEventsHandler(t, allDesc, 500)),
+	})
+	defer server.Close()
+
+	client, err := genclient.NewClientWithResponses(server.URL)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	var warn bytes.Buffer
+	start := time.Now()
+	got, err := fetchCityEvents(context.Background(), client, "mc-city", "", "24h", &warn)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("fetchCityEvents: %v (a multi-page walk must not share one budget)", err)
+	}
+	if len(got) != total {
+		t.Fatalf("got %d events, want %d (full window drained across pages)", len(got), total)
+	}
+	// The point of the test: the walk outlived a single page budget. If this
+	// does not hold the timings above no longer exercise the regression.
+	if elapsed <= budget {
+		t.Fatalf("walk took %v, expected > one page budget (%v); test no longer pins the bug", elapsed, budget)
+	}
+}
+
+// TestFetchCityEventsPageBudgetBoundsASinglePage is the other half of the
+// contract: moving the deadline onto each page must not remove it. A page that
+// cannot be served inside the budget still fails, and still surfaces as a
+// deadline rather than as an empty success.
+func TestFetchCityEventsPageBudgetBoundsASinglePage(t *testing.T) {
+	const (
+		pageDelay = 800 * time.Millisecond
+		budget    = 100 * time.Millisecond
+	)
+	restore := cityEventsPageTimeout
+	cityEventsPageTimeout = budget
+	t.Cleanup(func() { cityEventsPageTimeout = restore })
+
+	allDesc := []cliWireEvent{{
+		Actor: "gc", Seq: 1, Type: "e.t",
+		Ts: time.Unix(1700000001, 0).UTC(),
+	}}
+	server := newEventsTestServer(t, testEventRoutes{
+		cityEvents: delayedHandler(pageDelay, pagedCityEventsHandler(t, allDesc, 500)),
+	})
+	defer server.Close()
+
+	client, err := genclient.NewClientWithResponses(server.URL)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	var warn bytes.Buffer
+	got, err := fetchCityEvents(context.Background(), client, "mc-city", "", "24h", &warn)
+	if err == nil {
+		t.Fatalf("expected a deadline error for a page slower than the budget, got %d events", len(got))
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want it to unwrap to context.DeadlineExceeded", err)
+	}
+}
+
+// TestFetchCityEventsWalkBudgetTruncatesInsteadOfDiscarding pins the other
+// half of the reported failure. Before this fix a --since walk that ran out of
+// budget returned an error and *nothing at all* -- roughly fifty pages of
+// already-fetched events were thrown away on the way out. A short window the
+// caller can see is short beats thirty seconds of work returning zero rows.
+func TestFetchCityEventsWalkBudgetTruncatesInsteadOfDiscarding(t *testing.T) {
+	const (
+		total     = 2000
+		pageSize  = 250 // 8 pages: the budget must land mid-walk, not at a seam
+		pageDelay = 120 * time.Millisecond
+		walk      = 300 * time.Millisecond // enough for ~2 pages, not 8
+	)
+	restore := cityEventsPageTimeout
+	cityEventsPageTimeout = 5 * time.Second // page budget must not be what bites
+	t.Cleanup(func() { cityEventsPageTimeout = restore })
+
+	allDesc := make([]cliWireEvent, 0, total)
+	for seq := total; seq >= 1; seq-- {
+		allDesc = append(allDesc, cliWireEvent{
+			Actor: "gc", Seq: int64(seq), Type: "e.t",
+			Ts: time.Unix(1700000000+int64(seq), 0).UTC(),
+		})
+	}
+	server := newEventsTestServer(t, testEventRoutes{
+		cityEvents: delayedHandler(pageDelay, pagedCityEventsHandler(t, allDesc, pageSize)),
+	})
+	defer server.Close()
+
+	client, err := genclient.NewClientWithResponses(server.URL)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), walk)
+	defer cancel()
+
+	var warn bytes.Buffer
+	got, err := fetchCityEvents(ctx, client, "mc-city", "", "24h", &warn)
+	if err != nil {
+		t.Fatalf("a budget-exhausted walk must return its pages, not an error: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("got 0 events; the fetched pages were discarded again")
+	}
+	if len(got) >= total {
+		t.Fatalf("got %d of %d events; the walk was expected to be cut short", len(got), total)
+	}
+	// The caller must be able to tell the window is incomplete.
+	if !strings.Contains(warn.String(), "ran out of time") {
+		t.Fatalf("truncated window carried no notice; warn = %q", warn.String())
+	}
+	// What comes back is the NEWEST end of the window, contiguous and ascending.
+	for i := 1; i < len(got); i++ {
+		if got[i].Seq != got[i-1].Seq+1 {
+			t.Fatalf("gap at %d: seq %d then %d", i, got[i-1].Seq, got[i].Seq)
+		}
+	}
+	if got[len(got)-1].Seq != int64(total) {
+		t.Fatalf("last seq = %d, want %d (newest end retained)", got[len(got)-1].Seq, total)
 	}
 }
 


### PR DESCRIPTION
On this city, `gc events --since=40h` exits 1 after ~32 seconds and prints nothing — after having already fetched roughly 52 pages and thrown all of them away. `doEvents` wraps the city-events call in a single 30-second `context.WithTimeout`, but `fetchCityEvents` walks *every* page of a `--since` window under that one context, so a budget sized for a single request is charged to an unbounded multi-page walk. #4385 introduced that walk — pagination is enabled solely by `--since` — and the budget was never revisited for it.

This splits the budget in two: a per-page timeout that bounds one request to a server that has stopped answering, and a whole-walk budget that bounds total runtime. Exhausting the walk budget is now a truncation rather than an error — the pages already fetched are returned newest-end-first and contiguous, with the same style of notice the single-page cap in that same function already prints. Running out of budget on the *first* page still fails, since there is nothing to show. On this city the same command now exits 0 with 31,500 events.

Not #1487 — that was intermittent, load-triggered, and self-recovering. This is deterministic and scales with the query window; a fix for one is not a fix for the other.

## The shape that shipped, and the one that did not

Rejected first attempt: move the deadline onto each page and let the walk run unbounded, on the reasoning that the walk is finite by construction. It is finite — but `--since=40h` then ran past five minutes without finishing. That trades a fast failure for a hang. Caught by running the patched binary against the live city instead of trusting the argument.

Shipped: two budgets, because they catch two different failures.
- `cityEventsPageTimeout` (30s) bounds one page request — a server that stopped answering.
- `cityEventsWalkBudget` (30s) bounds the whole walk — the ceiling on runtime.

## Measured on this live city

| window | stock `gc` 1.4.0 | patched |
|---|---|---|
| `--since=40h` | exit 1, 32s, **0 events** | exit 0, 36s, **31,500 events** + notice |
| `--since=2h` | exit 0, 25.5s | exit 0, 23s, 10,243 events, no notice |

## Tests

Three added. Two are true red-to-green witnesses, verified red by reverting the behavior with the tests in place:
- `TestFetchCityEventsPageBudgetBoundsASinglePage`
- `TestFetchCityEventsWalkBudgetTruncatesInsteadOfDiscarding`

The third, `TestFetchCityEventsPageBudgetDoesNotAccumulateAcrossWalk`, passes on unfixed code too — it's a forward guard against re-introducing an accumulating budget, not evidence of the bug.

`go vet ./...` clean whole-repo (untagged), `go test ./cmd/gc/ -run 'Events|Event'` passes, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>