### PR TITLE
fix(events): fail a short single-record write instead of counting it as written

### DIFF
--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -385,15 +385,31 @@ func (r *FileRecorder) writeRecordLocked(e *Event) error {
 	if e.Ts.IsZero() {
 		e.Ts = time.Now()
 	}
+	if err := encodeAndWriteRecord(r.file, e); err != nil {
+		return err
+	}
+	r.recordCount++
+	return nil
+}
+
+// encodeAndWriteRecord marshals e as one JSONL line and writes it to w,
+// treating a short write as an error rather than a success.
+//
+// The guard matters because a partial line is indistinguishable from a
+// torn write to every downstream reader: the recorder would otherwise
+// count the record as written and continue appending after the fragment,
+// which is the corrupted-tail shape that startup truncation has to repair.
+// Sharing writeBatch keeps the single-record and batch paths honest about
+// short writes in the same way, from one implementation.
+func encodeAndWriteRecord(w io.Writer, e *Event) error {
 	data, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
 	data = append(data, '\n')
-	if _, err := r.file.Write(data); err != nil {
+	if err := writeBatch(w, data); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
-	r.recordCount++
 	return nil
 }
 

--- a/internal/events/recorder_batch_test.go
+++ b/internal/events/recorder_batch_test.go
@@ -111,6 +111,35 @@ func TestWriteBatchDetectsShortWriteInOneCall(t *testing.T) {
 	}
 }
 
+func TestEncodeAndWriteRecordDetectsShortWrite(t *testing.T) {
+	writer := &shortBatchWriter{}
+	err := encodeAndWriteRecord(writer, &Event{Type: ExecutionStepDefined})
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("encodeAndWriteRecord error = %v, want io.ErrShortWrite", err)
+	}
+	if writer.calls != 1 {
+		t.Fatalf("write calls = %d, want one", writer.calls)
+	}
+}
+
+func TestEncodeAndWriteRecordWritesOneCompleteLine(t *testing.T) {
+	var buf bytes.Buffer
+	if err := encodeAndWriteRecord(&buf, &Event{Type: ExecutionStepDefined, Seq: 7}); err != nil {
+		t.Fatalf("encodeAndWriteRecord: %v", err)
+	}
+	line := buf.String()
+	if !strings.HasSuffix(line, "\n") {
+		t.Fatalf("line = %q, want a trailing newline", line)
+	}
+	var got Event
+	if err := json.Unmarshal([]byte(strings.TrimSuffix(line, "\n")), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", line, err)
+	}
+	if got.Seq != 7 {
+		t.Fatalf("Seq = %d, want 7", got.Seq)
+	}
+}
+
 type shortBatchWriter struct {
 	calls int
 }


### PR DESCRIPTION
`internal/events/recorder.go` has two write paths and only one checks its byte count. `writeBatch` returns `io.ErrShortWrite` when it writes fewer bytes than it was given. `writeRecordLocked` — the single-record path behind `Record()` and the rotation anchor write — discarded the count and kept only the error, so a short write that returned a nil error committed a partial line, incremented `recordCount`, and left the already-bumped `seq` in place. The recorder treated it as a complete record and appended everything after it behind the fragment.

Nothing detected that and nothing reported it. A partial line is indistinguishable from a torn write to every downstream reader, which is the corrupted-tail shape the recorder's startup truncation has to repair — so this and #5614 compose: truncation removes the damage, this stops the single-record path from producing it silently.

**Credit:** @sjarmak spotted this asymmetry while reviewing #5614 and noted it was "plausibly one source of the corruption being repaired here." That is exactly what it looks like from here.

**Fix:** route the single-record write through `writeBatch` so both paths get the guard from one implementation rather than two copies of the same check. The marshal-and-write step moves into `encodeAndWriteRecord`, which takes an `io.Writer` — `FileRecorder.file` is a concrete `*os.File`, so there was previously no way to inject a short writer and cover this path at all. The new test reuses the `shortBatchWriter` helper already in the package.

**Testing:** full `./internal/events` package green; `gofmt` and `golangci-lint --new-from-rev=origin/main --whole-files` clean; pre-commit hook passed in full. Red-green confirmed — with the guard reverted the new test fails with `error = <nil>, want io.ErrShortWrite`.

Does not conflict with #5614; verified by test merge, either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>