### PR TITLE
fix(nudge): deliver queued nudges to continuously busy sessions

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1415,9 +1415,6 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store, sessStore beads.S
 	if err != nil || !matches {
 		return false, err
 	}
-	if !pollerSessionIdleEnough(target, sp, quiescence, obs) {
-		return false, nil
-	}
 	items, err := claimDueQueuedNudgesForTarget(target.cityPath, target, time.Now())
 	if err != nil || len(items) == 0 {
 		return false, err

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -2544,6 +2544,66 @@ func TestTryDeliverQueuedNudgesByPollerDeliversAndAcks(t *testing.T) {
 	}
 }
 
+func TestTryDeliverQueuedNudgesByPollerDeliversBusySession(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "stop and re-read the plan", now)); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "codex", WorkDir: dir, Provider: "codex", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{WorkDir: dir}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	busySince := time.Now()
+	fake.Activity = map[string]time.Time{info.SessionName: busySince}
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		sessionID:   info.ID,
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: info.SessionName,
+	}
+	obs := worker.LiveObservation{Running: true, LastActivity: &busySince}
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, store, fake, time.Hour, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if !delivered {
+		t.Fatal("delivered = false, want true for a running busy target")
+	}
+
+	var nudgeCalls []runtime.Call
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" {
+			nudgeCalls = append(nudgeCalls, call)
+		}
+	}
+	if len(nudgeCalls) != 1 {
+		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
+	}
+	if !strings.Contains(nudgeCalls[0].Message, "stop and re-read the plan") {
+		t.Fatalf("nudge message = %q, want original reminder", nudgeCalls[0].Message)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 0/0/0", len(pending), len(inFlight), len(dead))
+	}
+}
+
 func TestTryDeliverQueuedNudgesByPollerDeliversActivitylessTimedOnlySession(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()


### PR DESCRIPTION
## What changes

This removes the outer early return in `tryDeliverQueuedNudgesByPoller` that kept the queue from reaching either the claim or the existing provider delivery path while a session stayed continuously busy.

With the change, the native poller hands the entry to the existing `NudgeDeliveryDefault`: the provider waits a bounded time for an idle boundary and then falls back to the cooperative path. This path does not invoke `Interrupt` logic. Fence checks, release/retry and ack are unchanged.

This is a behavioural complement to #5317 and an alternative to #5363: that PR adds observability for skipped entries but never delivers them.

## Verification

- A new test with `LastActivity=time.Now()` and `quiescence=time.Hour` asserts delivery, a single provider `Nudge`, and empty pending/in-flight/dead after ack.
- The control run against the original code fails: `delivered=false`.
- The targeted set for busy, idle, activityless and stale-generation sessions passes:
  `CGO_ENABLED=0 go test ./cmd/gc -run 'TestTryDeliverQueuedNudgesByPoller(DeliversAndAcks|DeliversBusySession|DeliversActivitylessTimedOnlySession|SkipsStaleSessionGeneration)$' -count=1`

A fence mismatch deliberately stays terminal: an old message is not carried over into a new generation automatically.
