### PR TITLE
fix(session): defer orphan cleanup after partial scan

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -699,7 +699,11 @@ func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) err
 	}
 	found, err := scanner.FindRuntimesBySessionID(sessionID)
 	if err != nil {
-		log.Printf("session: scanning for orphaned runtimes for %s (failing closed): %v", sessionID, err)
+		// A partial process-table scan cannot distinguish a live tracked tmux
+		// session from an escaped orphan. Do not kill any partial result: a
+		// false-positive kill loses assigned work. Refuse this start and let the
+		// reconciler retry after a complete observation instead.
+		return fmt.Errorf("scan orphaned runtimes for %s: %w", sessionID, err)
 	}
 	cityPath := pathutil.NormalizePathForCompare(strings.TrimSpace(m.cityPath))
 	var termErrs []error

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -511,17 +511,15 @@ func TestCreateKillsUntrackedOrphanFromSameCityBeforeStartWithNormalizedPath(t *
 }
 
 // TestCreateRefusesStartWhenOrphanNotConfirmedDead pins the fail-closed
-// contract: when an untracked same-session orphan cannot be confirmed dead
-// (TerminateRuntime errors — e.g. it survived SIGKILL), Create must refuse to
-// start a replacement rather than race the survivor for the same work bead. A
-// concurrent scan error is logged and treated as fail-closed, so the orphan the
-// scan did surface is still targeted. No Start is attempted.
+// contract: when the process-table scan is incomplete, Create must refuse to
+// start a replacement rather than race a survivor for the same work bead. Its
+// partial result cannot prove an untracked runtime is orphaned, so no runtime
+// is terminated. No Start is attempted.
 func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &orphanScanProvider{
 		Fake:         runtime.NewFake(),
 		findErr:      errors.New("partial scan failed"),
-		terminateErr: errors.New("terminate failed"),
 		results: []runtime.LiveRuntime{{
 			PID:       1234,
 			IsTracked: false,
@@ -541,11 +539,8 @@ func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 			t.Fatalf("Start was attempted despite unconfirmed orphan; events = %v", sp.events)
 		}
 	}
-	want := []string{"find:", "terminate:"}
-	for i, prefix := range want {
-		if i >= len(sp.events) || !strings.HasPrefix(sp.events[i], prefix) {
-			t.Fatalf("events = %v, want prefixes %v", sp.events, want)
-		}
+	if got := sp.events; len(got) != 1 || !strings.HasPrefix(got[0], "find:") {
+		t.Fatalf("events = %v, want only a process-table scan", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

When the tmux process-table scan is incomplete, do not terminate a partial result and do not start a replacement. Return a retryable pre-start error instead. A complete scan keeps the existing confirmed-orphan cleanup behavior.

## Regression

`TestCreateRefusesStartWhenOrphanNotConfirmedDead` now proves a partial scan does not terminate an untracked partial result or start a replacement.

## Validation

- `go test ./internal/session -run "^TestCreateRefusesStartWhenOrphanNotConfirmedDead$"`
- `go test ./internal/session` has an unrelated current failure in `TestSubmitInterruptNowRestoresPiSessionWhenTranscriptResetFails`.

Refs allenday/gascity#1.