### PR TITLE
fix(dolt): scope ENOSPC restart guard to current process

### DIFF
--- a/cmd/gc/dolt_start_address_in_use_retry_window_test.go
+++ b/cmd/gc/dolt_start_address_in_use_retry_window_test.go
@@ -627,6 +627,46 @@ func TestStartManagedDoltProcessWithOptions_HappyPathReturnsReadyOnFirstAttempt(
 	}
 }
 
+func TestStartManagedDoltProcessPersistsPreLaunchBoundary(t *testing.T) {
+	const port = 17790
+	launchBoundary := time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)
+	originalNow := managedDoltNowFn
+	managedDoltNowFn = func() time.Time { return launchBoundary }
+	t.Cleanup(func() { managedDoltNowFn = originalNow })
+
+	var observedBoundary bool
+	cityPath := installStartManagedDoltLoopStubs(t, startManagedDoltLoopStubs{
+		startFn: func(cityPath, _, _ string, _ *os.File) (managedDoltStartedProcess, error) {
+			observedBoundary = true
+			return managedDoltStartedProcess{CityPath: cityPath, PID: 4242}, nil
+		},
+		waitReadyFn: func(_, _, _, _ string, _ int, _ time.Duration, _ bool) (managedDoltWaitReadyReport, error) {
+			return managedDoltWaitReadyReport{Ready: true, PIDAlive: true}, nil
+		},
+		logSuffixFn:     func(_ string, _ int64) (string, error) { return "", nil },
+		portAvailableFn: func(_ string, _ int) bool { return true },
+		retryWindow:     0,
+	})
+
+	if _, err := startManagedDoltProcessWithOptions(cityPath, "0.0.0.0", strconv.Itoa(port), "root", "warning", -1, time.Second, false); err != nil {
+		t.Fatalf("start managed Dolt: %v", err)
+	}
+	if !observedBoundary {
+		t.Fatal("managed Dolt launch stub was not called")
+	}
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolve runtime layout: %v", err)
+	}
+	state, err := readDoltRuntimeStateFile(layout.StateFile)
+	if err != nil {
+		t.Fatalf("read provider state: %v", err)
+	}
+	if state.StartedAt != launchBoundary.Format(time.RFC3339) {
+		t.Fatalf("provider started_at = %q, want pre-launch boundary %q", state.StartedAt, launchBoundary.Format(time.RFC3339))
+	}
+}
+
 // TestStartManagedDoltProcessWithOptions_RetryWindowZeroBumpsImmediately
 // pins the legacy fall-back-immediately behavior: retryWindow=0 means the
 // wait helper at line 246 is gated out (`retryWindow > 0` is false), so

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -105,6 +105,7 @@ var (
 	managedDoltStartSQLServerFn = startManagedDoltSQLServer
 	managedDoltWaitForReadyFn   = waitForManagedDoltReady
 	managedDoltLogSuffixFn      = managedDoltLogSuffix
+	managedDoltNowFn            = time.Now
 )
 
 // init is the re-entry point for the dolt-managed-test watchdog. The watchdog
@@ -219,6 +220,10 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 			return report, fmt.Errorf("open log file: %w", err)
 		}
 
+		// Capture the durable classification boundary before launching. The
+		// provider state is written after PID acquisition, but this timestamp
+		// must remain valid when an immediately-failing child is already dead.
+		launchStartedAt := managedDoltNowFn().UTC().Format(time.RFC3339)
 		started, err := managedDoltStartSQLServerFn(cityPath, layout.ConfigFile, layout.LogFile, logFile)
 		if err != nil {
 			_ = logFile.Close()
@@ -241,7 +246,7 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 			PID:       started.PID,
 			Port:      currentPort,
 			DataDir:   layout.DataDir,
-			StartedAt: time.Now().UTC().Format(time.RFC3339),
+			StartedAt: launchStartedAt,
 		}); err != nil {
 			terminateManagedDoltStartedProcess(started)
 			_ = os.Remove(layout.PIDFile)

--- a/examples/bd/assets/scripts/dolt-enospc.sh
+++ b/examples/bd/assets/scripts/dolt-enospc.sh
@@ -3,8 +3,9 @@
 # Dolt restart/recovery guard shared by the managed lifecycle commands.
 #
 # The guard has two independent inputs:
-#   1. ENOSPC evidence must belong to the current Dolt process. A match before
-#      that process's start time is stale and does not block recovery.
+#   1. ENOSPC evidence must belong to the current Dolt launch. A match before
+#      that launch's durable start boundary is stale and does not block
+#      recovery, even after the managed process has exited.
 #   2. The filesystem holding the live databases must have at least twice the
 #      allocated size of the largest database available. Dolt conjoin writes a
 #      replacement before deleting its inputs, so less headroom can reproduce
@@ -44,17 +45,40 @@ dolt_epoch_from_ps_lstart() (
     LC_ALL=C date -j -f '%a %b %e %T %Y' "$_dolt_raw" +%s 2>/dev/null
 )
 
-dolt_current_process_start_epoch() (
+dolt_provider_state_field() (
+    [ -n "${STATE_FILE:-}" ] && [ -r "$STATE_FILE" ] || return 1
+    _dolt_field="$1"
+    sed -n 's/.*"'"$_dolt_field"'"[[:space:]]*:[[:space:]]*"\{0,1\}\([^",}]*\)"\{0,1\}.*/\1/p' "$STATE_FILE" \
+        | head -1
+)
+
+dolt_current_launch_start_epoch() (
     [ -n "${PID_FILE:-}" ] && [ -r "$PID_FILE" ] || return 1
     IFS= read -r _dolt_pid < "$PID_FILE" || return 1
     case "$_dolt_pid" in
         ''|*[!0-9]*) return 1 ;;
     esac
-    kill -0 "$_dolt_pid" 2>/dev/null || return 1
-    _dolt_started=$(LC_ALL=C ps -p "$_dolt_pid" -o lstart= 2>/dev/null \
-        | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    [ -n "$_dolt_started" ] || return 1
-    dolt_epoch_from_ps_lstart "$_dolt_started"
+
+    # Prefer the kernel-backed boundary while the process is alive. Recovery
+    # normally runs after death, so fall back to provider state below.
+    if kill -0 "$_dolt_pid" 2>/dev/null; then
+        _dolt_started=$(LC_ALL=C ps -p "$_dolt_pid" -o lstart= 2>/dev/null \
+            | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [ -n "$_dolt_started" ]; then
+            dolt_epoch_from_ps_lstart "$_dolt_started" && return 0
+        fi
+    fi
+
+    # dolt-provider-state.json is written with a pre-launch timestamp and
+    # survives process death. Require its PID and running marker to match the
+    # retained PID file so a stopped/prior launch cannot become the boundary.
+    _dolt_state_pid=$(dolt_provider_state_field pid) || return 1
+    _dolt_state_running=$(dolt_provider_state_field running) || return 1
+    _dolt_state_started=$(dolt_provider_state_field started_at) || return 1
+    [ "$_dolt_state_pid" = "$_dolt_pid" ] || return 1
+    [ "$_dolt_state_running" = "true" ] || return 1
+    [ -n "$_dolt_state_started" ] || return 1
+    dolt_epoch_from_rfc3339 "$_dolt_state_started"
 )
 
 dolt_available_kib() (
@@ -122,8 +146,8 @@ dolt_enospc_log_guard_reason() (
     ')
     [ -n "$_dolt_matches" ] || return 1
 
-    _dolt_start_epoch=$(dolt_current_process_start_epoch) || {
-        printf 'cannot determine current Dolt process start time while ENOSPC exists in the last 1000 log lines\n'
+    _dolt_start_epoch=$(dolt_current_launch_start_epoch) || {
+        printf 'cannot determine managed Dolt launch boundary while ENOSPC exists in the last 1000 log lines\n'
         return 0
     }
 
@@ -140,7 +164,7 @@ dolt_enospc_log_guard_reason() (
             return 0
         }
         if [ "$_dolt_match_epoch" -ge "$_dolt_start_epoch" ]; then
-            printf 'ENOSPC after current Dolt process start: timestamp=%s tail_line=%s\n' \
+            printf 'ENOSPC at or after managed Dolt launch: timestamp=%s tail_line=%s\n' \
                 "$_dolt_timestamp" "$_dolt_line_number"
             return 0
         fi

--- a/examples/bd/assets/scripts/dolt-enospc.sh
+++ b/examples/bd/assets/scripts/dolt-enospc.sh
@@ -1,22 +1,168 @@
 #!/bin/sh
 
-# recovery_should_skip_due_to_enospc returns 0 (true) when the recent Dolt
-# server log shows disk-exhaustion (ENOSPC) signatures.
+# Dolt restart/recovery guard shared by the managed lifecycle commands.
 #
-# Restarting Dolt under ENOSPC does not free disk space, and the recovery cycle
-# itself amplifies the failure: every restart triggers a fresh conjoin that can
-# drop another partial nbs_table_* file in the backup remote, accelerating the
-# disk-full feedback loop. See gastownhall/gascity#2158.
+# The guard has two independent inputs:
+#   1. ENOSPC evidence must belong to the current Dolt process. A match before
+#      that process's start time is stale and does not block recovery.
+#   2. The filesystem holding the live databases must have at least twice the
+#      allocated size of the largest database available. Dolt conjoin writes a
+#      replacement before deleting its inputs, so less headroom can reproduce
+#      the disk-full cascade even when the log has no ENOSPC match yet.
 #
-# Returns 1 (false) when no ENOSPC signature is found in the recent log tail, or
-# when LOG_FILE is unset or unreadable.
-recovery_should_skip_due_to_enospc() {
+# Callers inspect DOLT_ENOSPC_GUARD_REASON after a true (0) return from
+# recovery_should_skip_due_to_enospc. --force remains the caller-owned,
+# explicit operator override.
+
+# shellcheck disable=SC2034 # Read by the scripts that source this helper.
+DOLT_ENOSPC_GUARD_REASON=""
+
+dolt_epoch_from_rfc3339() (
+    _dolt_raw="$1"
+
+    # GNU date accepts RFC3339 directly. Strip fractional seconds first so the
+    # same normalized value can fall through to BSD date on macOS.
+    _dolt_normalized=$(printf '%s\n' "$_dolt_raw" \
+        | sed -E 's/\.[0-9]+(Z|[+-][0-9][0-9]:?[0-9][0-9])$/\1/')
+    if LC_ALL=C date -d "$_dolt_normalized" +%s >/dev/null 2>&1; then
+        LC_ALL=C date -d "$_dolt_normalized" +%s
+        return 0
+    fi
+
+    _dolt_normalized=$(printf '%s\n' "$_dolt_normalized" \
+        | sed -E 's/Z$/+0000/; s/([+-][0-9][0-9]):([0-9][0-9])$/\1\2/')
+    LC_ALL=C date -j -f '%Y-%m-%dT%H:%M:%S%z' "$_dolt_normalized" +%s 2>/dev/null
+)
+
+dolt_epoch_from_ps_lstart() (
+    _dolt_raw="$1"
+
+    if LC_ALL=C date -d "$_dolt_raw" +%s >/dev/null 2>&1; then
+        LC_ALL=C date -d "$_dolt_raw" +%s
+        return 0
+    fi
+    LC_ALL=C date -j -f '%a %b %e %T %Y' "$_dolt_raw" +%s 2>/dev/null
+)
+
+dolt_current_process_start_epoch() (
+    [ -n "${PID_FILE:-}" ] && [ -r "$PID_FILE" ] || return 1
+    IFS= read -r _dolt_pid < "$PID_FILE" || return 1
+    case "$_dolt_pid" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    kill -0 "$_dolt_pid" 2>/dev/null || return 1
+    _dolt_started=$(LC_ALL=C ps -p "$_dolt_pid" -o lstart= 2>/dev/null \
+        | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ -n "$_dolt_started" ] || return 1
+    dolt_epoch_from_ps_lstart "$_dolt_started"
+)
+
+dolt_available_kib() (
+    df -Pk "$1" 2>/dev/null \
+        | awk 'NR > 1 { available = $4 } END { if (available ~ /^[0-9]+$/) print available }'
+)
+
+dolt_largest_database_kib() (
+    _dolt_data_dir="$1"
+    _dolt_largest=0
+
+    for _dolt_database in "$_dolt_data_dir"/*; do
+        [ -d "$_dolt_database" ] || continue
+        _dolt_size=$(du -sk "$_dolt_database" 2>/dev/null | awk 'NR == 1 { print $1 }') || return 1
+        case "$_dolt_size" in
+            ''|*[!0-9]*) return 1 ;;
+        esac
+        if [ "$_dolt_size" -gt "$_dolt_largest" ]; then
+            _dolt_largest="$_dolt_size"
+        fi
+    done
+    printf '%s\n' "$_dolt_largest"
+)
+
+dolt_disk_headroom_guard_reason() (
+    # No database directory means there is no existing store to conjoin.
+    [ -n "${DATA_DIR:-}" ] && [ -d "$DATA_DIR" ] || return 1
+    _dolt_largest=$(dolt_largest_database_kib "$DATA_DIR") || {
+        printf 'cannot measure Dolt database sizes under %s\n' "$DATA_DIR"
+        return 0
+    }
+    _dolt_available=$(dolt_available_kib "$DATA_DIR") || true
+    case "$_dolt_available" in
+        ''|*[!0-9]*)
+            printf 'cannot determine free disk headroom for %s\n' "$DATA_DIR"
+            return 0
+            ;;
+    esac
+    _dolt_required=$((_dolt_largest * 2))
+    if [ "$_dolt_available" -lt "$_dolt_required" ]; then
+        printf 'insufficient Dolt disk headroom: available=%s KiB required=%s KiB (2x largest database=%s KiB) under %s\n' \
+            "$_dolt_available" "$_dolt_required" "$_dolt_largest" "$DATA_DIR"
+        return 0
+    fi
+    return 1
+)
+
+dolt_enospc_log_guard_reason() (
     [ -n "${LOG_FILE:-}" ] && [ -r "$LOG_FILE" ] || return 1
-    # Scan the recent log tail rather than the whole file; an old transient
-    # ENOSPC error from a since-resolved disk-pressure event should not block
-    # recovery indefinitely.
-    tail -n 1000 "$LOG_FILE" 2>/dev/null \
-        | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
-        || return 1
-    return 0
+    _dolt_matches=$(tail -n 1000 "$LOG_FILE" 2>/dev/null | awk '
+        {
+            if (match($0, /time="[^"]*"/)) {
+                context_timestamp = substr($0, RSTART + 6, RLENGTH - 7)
+            } else if ($0 ~ /time=/) {
+                context_timestamp = "__INVALID__"
+            }
+            if ($0 ~ /no space left on device|copy_file_range:.*no space|ENOSPC/) {
+                timestamp = context_timestamp
+                if ($0 ~ /time=/ && !match($0, /time="[^"]*"/)) {
+                    timestamp = "__INVALID__"
+                }
+                printf "%d|%s\n", NR, timestamp
+            }
+        }
+    ')
+    [ -n "$_dolt_matches" ] || return 1
+
+    _dolt_start_epoch=$(dolt_current_process_start_epoch) || {
+        printf 'cannot determine current Dolt process start time while ENOSPC exists in the last 1000 log lines\n'
+        return 0
+    }
+
+    while IFS='|' read -r _dolt_line_number _dolt_timestamp; do
+        case "$_dolt_timestamp" in
+            ''|__INVALID__)
+                printf 'cannot parse ENOSPC log timestamp at tail line %s; refusing recovery fail-closed\n' "$_dolt_line_number"
+                return 0
+                ;;
+        esac
+        _dolt_match_epoch=$(dolt_epoch_from_rfc3339 "$_dolt_timestamp") || {
+            printf 'cannot parse ENOSPC log timestamp %s at tail line %s; refusing recovery fail-closed\n' \
+                "$_dolt_timestamp" "$_dolt_line_number"
+            return 0
+        }
+        if [ "$_dolt_match_epoch" -ge "$_dolt_start_epoch" ]; then
+            printf 'ENOSPC after current Dolt process start: timestamp=%s tail_line=%s\n' \
+                "$_dolt_timestamp" "$_dolt_line_number"
+            return 0
+        fi
+    done <<DOLT_ENOSPC_MATCHES
+$_dolt_matches
+DOLT_ENOSPC_MATCHES
+    return 1
+)
+
+# recovery_should_skip_due_to_enospc returns 0 (true) when recovery is unsafe.
+# It returns 1 only when both the log classification and disk-headroom check are
+# safe. Each blocking path sets a precise diagnostic for the caller.
+recovery_should_skip_due_to_enospc() {
+    # shellcheck disable=SC2034 # Read by the scripts that source this helper.
+    DOLT_ENOSPC_GUARD_REASON=""
+    _dolt_guard_reason=$(dolt_disk_headroom_guard_reason) && {
+        DOLT_ENOSPC_GUARD_REASON="$_dolt_guard_reason"
+        return 0
+    }
+    _dolt_guard_reason=$(dolt_enospc_log_guard_reason) && {
+        DOLT_ENOSPC_GUARD_REASON="$_dolt_guard_reason"
+        return 0
+    }
+    return 1
 }

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -3053,12 +3053,11 @@ if [ -r "$enospc_helper" ]; then
 else
     # Some focused shell harnesses execute gc-beads-bd's prelude as a single
     # temporary file without sibling assets. Keep the production helper as the
-    # canonical copy, but preserve the same detector behavior for those harnesses.
+    # canonical copy and fail closed when it is unavailable; silently retaining
+    # an older duplicate detector here would let harness and production safety
+    # semantics drift apart.
     recovery_should_skip_due_to_enospc() {
-        [ -n "${LOG_FILE:-}" ] && [ -r "$LOG_FILE" ] || return 1
-        tail -n 1000 "$LOG_FILE" 2>/dev/null \
-            | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
-            || return 1
+        DOLT_ENOSPC_GUARD_REASON="dolt ENOSPC guard helper unavailable: $enospc_helper"
         return 0
     }
 fi
@@ -3078,8 +3077,8 @@ op_recover() {
     # Require manual intervention (free disk space) before recovery
     # resumes. See gastownhall/gascity#2158.
     if recovery_should_skip_due_to_enospc; then
-        echo "skipping dolt recovery: recent dolt log shows ENOSPC — manual intervention required" >&2
-        echo "  free disk space, then re-run health checks" >&2
+        echo "skipping dolt recovery: ${DOLT_ENOSPC_GUARD_REASON:-ENOSPC recovery guard failed closed}" >&2
+        echo "  resolve the reported guard condition, then re-run health checks" >&2
         die "dolt recovery skipped: ENOSPC detected"
     fi
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -728,7 +728,21 @@ wait_for_bd_runtime_schema() {
 
 # save_state writes the private provider runtime state atomically (no jq dependency).
 save_state() {
-    local pid="$1" running="$2" gc_bin
+    local pid="$1" running="$2" started_at="${3:-}" gc_bin
+    if [ -z "$started_at" ]; then
+        # A refresh of the same live managed process must not move its launch
+        # boundary forward; recovery may need it after the process has died.
+        local prior_pid prior_running prior_started_at
+        prior_pid=$(load_state_field pid)
+        prior_running=$(load_state_field running)
+        prior_started_at=$(load_state_field started_at)
+        if [ "$running" = "true" ] && [ "$prior_running" = "true" ] && \
+            [ "$prior_pid" = "$pid" ] && [ -n "$prior_started_at" ]; then
+            started_at="$prior_started_at"
+        else
+            started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        fi
+    fi
     gc_bin=$(resolve_gc_helper_bin)
     if [ -n "$gc_bin" ]; then
         "$gc_bin" dolt-state write-provider \
@@ -736,7 +750,8 @@ save_state() {
             --pid "$pid" \
             --running "$running" \
             --port "$DOLT_PORT" \
-            --data-dir "$DATA_DIR" || die "failed to write provider state via gc helper $gc_bin"
+            --data-dir "$DATA_DIR" \
+            --started-at "$started_at" || die "failed to write provider state via gc helper $gc_bin"
         return 0
     fi
     mkdir -p "$(dirname "$STATE_FILE")"
@@ -744,7 +759,7 @@ save_state() {
     tmp=$(mktemp "$STATE_FILE.tmp.XXXXXX")
     printf '{"running":%s,"pid":%s,"port":%s,"data_dir":"%s","started_at":"%s"}\n' \
         "$running" "$pid" "$DOLT_PORT" "$DATA_DIR" \
-        "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "$tmp"
+        "$started_at" > "$tmp"
     mv "$tmp" "$STATE_FILE"
 }
 
@@ -2389,6 +2404,11 @@ op_start() {
             log_offset=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
         fi
 
+        # Capture the boundary before launch so even an immediate ENOSPC crash
+        # is classified as belonging to this attempt after its PID is dead.
+        local launch_started_at
+        launch_started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
         # Start dolt sql-server with config file. Close the startup lock fd in
         # the child so the flock is released when this starter exits.
         nohup sh -c 'exec 9>&-; exec dolt sql-server --config "$1"' sh "$CONFIG_FILE" >> "$LOG_FILE" 2>&1 &
@@ -2398,7 +2418,7 @@ op_start() {
         echo "$server_pid" > "$PID_FILE"
 
         # Save state.
-        save_state "$server_pid" true
+        save_state "$server_pid" true "$launch_started_at"
 
         # Wait for server: combined PID alive + TCP reachable + query-ready check.
         # 60 iterations × 500ms = 30s max. Large data dirs with many databases

--- a/examples/bd/dolt/commands/restart/run.sh
+++ b/examples/bd/dolt/commands/restart/run.sh
@@ -53,6 +53,7 @@ CITY_RUNTIME_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}"
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_RUNTIME_DIR/packs/dolt}"
 DATA_DIR="${GC_DOLT_DATA_DIR:-$GC_CITY_PATH/.beads/dolt}"
 LOG_FILE="${GC_DOLT_LOG_FILE:-$PACK_STATE_DIR/dolt.log}"
+STATE_FILE="${GC_DOLT_STATE_FILE:-$PACK_STATE_DIR/dolt-provider-state.json}"
 PID_FILE="${GC_DOLT_PID_FILE:-$PACK_STATE_DIR/dolt.pid}"
 BD_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$GC_BEADS_BD_SCRIPT")" && pwd)"
 if [ ! -f "$BD_SCRIPT_DIR/dolt-enospc.sh" ]; then

--- a/examples/bd/dolt/commands/restart/run.sh
+++ b/examples/bd/dolt/commands/restart/run.sh
@@ -51,7 +51,9 @@ esac
 
 CITY_RUNTIME_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}"
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_RUNTIME_DIR/packs/dolt}"
+DATA_DIR="${GC_DOLT_DATA_DIR:-$GC_CITY_PATH/.beads/dolt}"
 LOG_FILE="${GC_DOLT_LOG_FILE:-$PACK_STATE_DIR/dolt.log}"
+PID_FILE="${GC_DOLT_PID_FILE:-$PACK_STATE_DIR/dolt.pid}"
 BD_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$GC_BEADS_BD_SCRIPT")" && pwd)"
 if [ ! -f "$BD_SCRIPT_DIR/dolt-enospc.sh" ]; then
   # GC_BEADS_BD_SCRIPT may be the stable city shim; the helper ships next
@@ -62,12 +64,13 @@ fi
 . "$BD_SCRIPT_DIR/dolt-enospc.sh"
 
 if recovery_should_skip_due_to_enospc; then
+  guard_reason="${DOLT_ENOSPC_GUARD_REASON:-ENOSPC recovery guard failed closed}"
   if [ "$force_restart" != "true" ]; then
-    echo "gc dolt restart: recent Dolt log shows ENOSPC; refusing restart because it can amplify recovery writes" >&2
-    echo "  free disk space, then run gc dolt restart --force only if a restart is still required" >&2
+    echo "gc dolt restart: refusing restart: $guard_reason" >&2
+    echo "  resolve the reported guard condition, then retry; use --force only as an explicit operator override" >&2
     exit 1
   fi
-  echo "gc dolt restart: --force set; restarting despite recent ENOSPC evidence" >&2
+  echo "gc dolt restart: --force set; restarting despite guard: $guard_reason" >&2
 fi
 
 # Stop. Exit 2 from gc-beads-bd stop means "nothing was running" — a

--- a/examples/bd/dolt/restart_test.go
+++ b/examples/bd/dolt/restart_test.go
@@ -82,6 +82,22 @@ func writeRestartLog(t *testing.T, cityPath, body string) {
 	}
 }
 
+func writeDeadDoltLaunchState(t *testing.T, cityPath, startedAt string) {
+	t.Helper()
+	const deadPID = 2147483647
+	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.WriteFile(filepath.Join(stateDir, "dolt.pid"), []byte(strconv.Itoa(deadPID)+"\n"), 0o644); err != nil {
+		t.Fatalf("write dead dolt pid: %v", err)
+	}
+	state := fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":3307,"data_dir":%q,"started_at":%q}`+"\n",
+		deadPID, filepath.Join(cityPath, ".beads", "dolt"), startedAt,
+	)
+	if err := os.WriteFile(filepath.Join(stateDir, "dolt-provider-state.json"), []byte(state), 0o644); err != nil {
+		t.Fatalf("write dead dolt provider state: %v", err)
+	}
+}
+
 func runRestart(t *testing.T, cityPath, root string, port int) ([]byte, error) {
 	t.Helper()
 	return runRestartWithEnv(t, cityPath, root, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port)})
@@ -95,7 +111,7 @@ func runRestartWithEnv(t *testing.T, cityPath, root string, extraEnv []string, a
 		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
 		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
 		"GC_CITY_RUNTIME_DIR", "GC_PACK_STATE_DIR", "GC_DOLT_LOG_FILE",
-		"GC_BEADS_BD_SCRIPT",
+		"GC_DOLT_STATE_FILE", "GC_DOLT_PID_FILE", "GC_BEADS_BD_SCRIPT",
 	),
 		"PATH="+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
@@ -249,6 +265,73 @@ func TestRestartAllowsStaleENOSPCBeforeCurrentProcessStart(t *testing.T) {
 	}
 }
 
+func TestRestartAllowsStaleENOSPCBeforeDeadProcessLaunch(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeDeadDoltLaunchState(t, cityPath, "2026-09-01T00:00:00Z")
+	writeRestartLog(t, cityPath, "time=\"2026-08-31T23:59:59Z\" level=error msg=\"ENOSPC\"\n")
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err != nil {
+		t.Fatalf("gc dolt restart blocked stale ENOSPC after the managed process died: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	if got := strings.Join(strings.Fields(string(data)), " "); got != "stop start" {
+		t.Fatalf("expected stale ENOSPC to allow stop then start for dead PID, got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartRefusesCurrentENOSPCAfterDeadProcessLaunch(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeDeadDoltLaunchState(t, cityPath, "2026-09-01T00:00:00Z")
+	writeRestartLog(t, cityPath, "time=\"2026-09-01T00:00:00Z\" level=error msg=\"ENOSPC\"\n")
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err == nil {
+		t.Fatalf("gc dolt restart ignored ENOSPC from the dead process's launch interval:\n%s", out)
+	}
+	if !strings.Contains(string(out), "ENOSPC at or after managed Dolt launch") {
+		t.Fatalf("restart did not explain current-launch ENOSPC refusal; output:\n%s", out)
+	}
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("restart invoked gc-beads-bd despite dead-PID ENOSPC refusal; ops log:\n%s\noutput:\n%s", data, out)
+	}
+}
+
+func TestRestartRefusesUnparseableENOSPCWithDeadProcess(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeDeadDoltLaunchState(t, cityPath, "2026-09-01T00:00:00Z")
+	writeRestartLog(t, cityPath, "time=\"not-a-timestamp\" level=error msg=\"ENOSPC\"\n")
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err == nil {
+		t.Fatalf("gc dolt restart allowed unparseable ENOSPC after the managed process died:\n%s", out)
+	}
+	if !strings.Contains(string(out), "cannot parse ENOSPC log timestamp") {
+		t.Fatalf("restart did not fail closed on dead-PID unparseable ENOSPC; output:\n%s", out)
+	}
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("restart invoked gc-beads-bd after dead-PID timestamp failure; ops log:\n%s\noutput:\n%s", data, out)
+	}
+}
+
 func TestRestartRefusesFreshENOSPCUnlessForced(t *testing.T) {
 	root := repoRoot(t)
 	port, cleanup := startReachableTCPListener(t)
@@ -264,7 +347,7 @@ func TestRestartRefusesFreshENOSPCUnlessForced(t *testing.T) {
 	if err == nil {
 		t.Fatalf("gc dolt restart unexpectedly ignored ENOSPC after the current process start:\n%s", out)
 	}
-	if !strings.Contains(string(out), "ENOSPC after current Dolt process start") {
+	if !strings.Contains(string(out), "ENOSPC at or after managed Dolt launch") {
 		t.Fatalf("restart did not explain ENOSPC refusal; output:\n%s", out)
 	}
 	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {

--- a/examples/bd/dolt/restart_test.go
+++ b/examples/bd/dolt/restart_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 const restartScript = "commands/restart/run.sh"
@@ -14,7 +16,7 @@ const restartScript = "commands/restart/run.sh"
 // writeFakeBeadsBDForRestart writes a stub gc-beads-bd that records each
 // invocation's first argument and exits with the code specified for that
 // op. ops that aren't in opExitCodes exit 0.
-func writeFakeBeadsBDForRestart(t *testing.T, cityPath string, opExitCodes map[string]int) string {
+func writeFakeBeadsBDForRestart(t *testing.T, cityPath, root string, opExitCodes map[string]int) string {
 	t.Helper()
 	scriptDir := filepath.Join(cityPath, ".gc", "scripts")
 	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
@@ -34,19 +36,50 @@ esac
 	if err := os.WriteFile(filepath.Join(scriptDir, "gc-beads-bd.sh"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake bd script: %v", err)
 	}
-	enospcHelper := `#!/bin/sh
-recovery_should_skip_due_to_enospc() {
-  [ -n "${LOG_FILE:-}" ] && [ -r "$LOG_FILE" ] || return 1
-  tail -n 1000 "$LOG_FILE" 2>/dev/null \
-    | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
-    || return 1
-  return 0
-}
-`
-	if err := os.WriteFile(filepath.Join(scriptDir, "dolt-enospc.sh"), []byte(enospcHelper), 0o644); err != nil {
+	enospcHelper, err := os.ReadFile(filepath.Join(root, "..", "assets", "scripts", "dolt-enospc.sh"))
+	if err != nil {
+		t.Fatalf("read production enospc helper: %v", err)
+	}
+	// Keep disk-capacity injection at the smallest owning seam. The production
+	// helper still owns all classification logic; only df's observed value is
+	// replaced for the insufficient-headroom branch.
+	enospcHelper = append(enospcHelper, []byte(`
+if [ -n "${GC_TEST_DOLT_AVAILABLE_KIB:-}" ]; then
+  dolt_available_kib() {
+    printf '%s\n' "$GC_TEST_DOLT_AVAILABLE_KIB"
+  }
+fi
+`)...)
+	if err := os.WriteFile(filepath.Join(scriptDir, "dolt-enospc.sh"), enospcHelper, 0o644); err != nil {
 		t.Fatalf("write fake enospc helper: %v", err)
 	}
+
+	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake dolt state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "dolt.pid"), []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatalf("write fake dolt pid: %v", err)
+	}
+	databaseDir := filepath.Join(cityPath, ".beads", "dolt", "hq")
+	if err := os.MkdirAll(databaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake dolt database: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(databaseDir, "seed"), []byte("allocated database block\n"), 0o644); err != nil {
+		t.Fatalf("write fake dolt database: %v", err)
+	}
 	return logPath
+}
+
+func writeRestartLog(t *testing.T, cityPath, body string) {
+	t.Helper()
+	logPath := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir dolt log dir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write dolt log: %v", err)
+	}
 }
 
 func runRestart(t *testing.T, cityPath, root string, port int) ([]byte, error) {
@@ -80,7 +113,7 @@ func TestRestartCallsStopThenStart_HappyPath(t *testing.T) {
 	defer cleanup()
 
 	cityPath := t.TempDir()
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
 
 	out, err := runRestart(t, cityPath, root, port)
 	if err != nil {
@@ -105,7 +138,7 @@ func TestRestartCallsStartWhenStopReportsNothingRunning(t *testing.T) {
 	cityPath := t.TempDir()
 	// op_stop exits 2 when no managed dolt PID is found. restart must
 	// treat that as success and still invoke start.
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 2, "start": 0})
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 2, "start": 0})
 
 	out, err := runRestart(t, cityPath, root, port)
 	if err != nil {
@@ -125,7 +158,7 @@ func TestRestartCallsStartWhenStopReportsNothingRunning(t *testing.T) {
 func TestRestartDoesNotRequirePortWhenStopReportsNothingRunning(t *testing.T) {
 	root := repoRoot(t)
 	cityPath := t.TempDir()
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 2, "start": 0})
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 2, "start": 0})
 
 	out, err := runRestartWithEnv(t, cityPath, root, nil)
 	if err != nil {
@@ -151,7 +184,7 @@ func TestRestartAbortsAndDoesNotStartWhenStopFails(t *testing.T) {
 	// op_stop exit code 1 is the genuine-failure path (e.g., couldn't kill
 	// the managed PID). restart must abort without calling start so the
 	// operator can investigate.
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 1, "start": 0})
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 1, "start": 0})
 
 	out, err := runRestart(t, cityPath, root, port)
 	if err == nil {
@@ -173,7 +206,7 @@ func TestRestartPropagatesStartFailureWithDiagnostic(t *testing.T) {
 	defer cleanup()
 
 	cityPath := t.TempDir()
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 1})
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 1})
 
 	out, err := runRestart(t, cityPath, root, port)
 	if err == nil {
@@ -193,26 +226,45 @@ func TestRestartPropagatesStartFailureWithDiagnostic(t *testing.T) {
 	}
 }
 
-func TestRestartRefusesRecentENOSPCUnlessForced(t *testing.T) {
+func TestRestartAllowsStaleENOSPCBeforeCurrentProcessStart(t *testing.T) {
 	root := repoRoot(t)
 	port, cleanup := startReachableTCPListener(t)
 	defer cleanup()
 
 	cityPath := t.TempDir()
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
-	logPath := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt.log")
-	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
-		t.Fatalf("mkdir dolt log dir: %v", err)
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeRestartLog(t, cityPath, "time=\"2000-01-01T00:00:00Z\" level=warning msg=\"conjoin failed\"\n"+
+		"fatal error: write .beads/dolt/hq/.dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv: no space left on device: error writing to database journal file\n")
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err != nil {
+		t.Fatalf("gc dolt restart blocked a stale ENOSPC from before the current process start: %v\n%s", err, out)
 	}
-	if err := os.WriteFile(logPath, []byte("fatal: no space left on device\n"), 0o644); err != nil {
-		t.Fatalf("write dolt log: %v", err)
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
 	}
+	if got := strings.Join(strings.Fields(string(data)), " "); got != "stop start" {
+		t.Fatalf("expected stale ENOSPC to allow stop then start, got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartRefusesFreshENOSPCUnlessForced(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	freshTimestamp := time.Now().UTC().Format(time.RFC3339)
+	writeRestartLog(t, cityPath, fmt.Sprintf("time=\"%s\" level=warning msg=\"conjoin failed\"\n", freshTimestamp)+
+		"fatal error: write .beads/dolt/hq/.dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv: no space left on device: error writing to database journal file\n")
 
 	out, err := runRestart(t, cityPath, root, port)
 	if err == nil {
-		t.Fatalf("gc dolt restart unexpectedly ignored recent ENOSPC:\n%s", out)
+		t.Fatalf("gc dolt restart unexpectedly ignored ENOSPC after the current process start:\n%s", out)
 	}
-	if !strings.Contains(string(out), "recent Dolt log shows ENOSPC") {
+	if !strings.Contains(string(out), "ENOSPC after current Dolt process start") {
 		t.Fatalf("restart did not explain ENOSPC refusal; output:\n%s", out)
 	}
 	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
@@ -233,6 +285,89 @@ func TestRestartRefusesRecentENOSPCUnlessForced(t *testing.T) {
 	}
 }
 
+func TestRestartAllowsNoENOSPCWithSufficientDiskHeadroom(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeRestartLog(t, cityPath, "time=\"2000-01-01T00:00:00Z\" level=warning msg=\"ordinary warning\"\n")
+
+	out, err := runRestartWithEnv(t, cityPath, root, []string{
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_TEST_DOLT_AVAILABLE_KIB=1048576",
+	})
+	if err != nil {
+		t.Fatalf("gc dolt restart blocked with no ENOSPC and sufficient disk headroom: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	if got := strings.Join(strings.Fields(string(data)), " "); got != "stop start" {
+		t.Fatalf("expected sufficient headroom to allow stop then start, got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartRefusesInsufficientDiskHeadroomUnlessForced(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeRestartLog(t, cityPath, "time=\"2000-01-01T00:00:00Z\" level=warning msg=\"ordinary warning\"\n")
+	extraEnv := []string{
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_TEST_DOLT_AVAILABLE_KIB=0",
+	}
+
+	out, err := runRestartWithEnv(t, cityPath, root, extraEnv)
+	if err == nil {
+		t.Fatalf("gc dolt restart unexpectedly ignored insufficient disk headroom:\n%s", out)
+	}
+	if !strings.Contains(string(out), "insufficient Dolt disk headroom") {
+		t.Fatalf("restart did not explain the headroom refusal; output:\n%s", out)
+	}
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("restart invoked gc-beads-bd despite insufficient headroom; ops log:\n%s\noutput:\n%s", data, out)
+	}
+
+	out, err = runRestartWithEnv(t, cityPath, root, extraEnv, "--force")
+	if err != nil {
+		t.Fatalf("gc dolt restart --force failed despite fake stop/start success: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	if got := strings.Join(strings.Fields(string(data)), " "); got != "stop start" {
+		t.Fatalf("expected --force to remain an explicit headroom override, got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartRefusesUnparseableFreshENOSPCWithDiagnostic(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
+	writeRestartLog(t, cityPath, "time=\"not-a-timestamp\" level=error msg=\"ENOSPC\"\n")
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err == nil {
+		t.Fatalf("gc dolt restart unexpectedly allowed an unparseable ENOSPC line:\n%s", out)
+	}
+	if !strings.Contains(string(out), "cannot parse ENOSPC log timestamp") {
+		t.Fatalf("restart did not diagnose the unparseable ENOSPC timestamp; output:\n%s", out)
+	}
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("restart invoked gc-beads-bd after fail-closed timestamp parsing; ops log:\n%s\noutput:\n%s", data, out)
+	}
+}
+
 // TestRestartTreatsLoopbackAndWildcardHostsAsLocalManaged pins the P0.5
 // host-classification contract: the managed-server bind default is
 // 127.0.0.1, and 0.0.0.0 remains the explicit wildcard opt-out — both must
@@ -248,7 +383,7 @@ func TestRestartTreatsLoopbackAndWildcardHostsAsLocalManaged(t *testing.T) {
 			defer cleanup()
 
 			cityPath := t.TempDir()
-			bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+			bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
 
 			out, err := runRestartWithEnv(t, cityPath, root, []string{
 				fmt.Sprintf("GC_DOLT_PORT=%d", port),
@@ -276,7 +411,7 @@ func TestRestartRejectsRemoteHostWithDiagnostic(t *testing.T) {
 	defer cleanup()
 
 	cityPath := t.TempDir()
-	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, root, map[string]int{"stop": 0, "start": 0})
 
 	out, err := runRestartWithEnv(t, cityPath, root, []string{
 		fmt.Sprintf("GC_DOLT_PORT=%d", port),


### PR DESCRIPTION
## Summary

- scope the restart ENOSPC log guard to the current managed Dolt process start time
- keep fresh or unparseable ENOSPC evidence fail-closed with an explicit reason
- separately require free disk headroom of at least twice the largest database
- preserve `--force` as the explicit operator override

## Reproduction

Addresses the false restart block reported in #468. On the affected 1.4.1 installation, the last 1000 Dolt log lines still contained three journal ENOSPC entries from Aug 26/27 (tail positions 459, 595, and 711), while the healthy current process had started Aug 30 and had no ENOSPC event. The line-only guard therefore rejected an ordinary restart based on stale history.

The helper now derives the live managed PID start epoch, associates raw panic continuation lines with their preceding structured log timestamp, ignores evidence older than that epoch, and rejects fresh or timestamp-unparseable evidence. Disk capacity is evaluated independently using `df -Pk` and the largest direct database size.

## Tests

- PASS: `go test -count=1 ./examples/bd/dolt -run ^TestRestart`
- PASS: restart matrix repeated with `-count=10`
- PASS: `sh -n` for all changed shell scripts
- PASS: `shellcheck examples/bd/assets/scripts/dolt-enospc.sh`
- PASS: `go vet ./examples/bd/dolt`
- PASS: repository pre-commit checks, including generated-file checks and `go vet ./...`
- NOTE: `make test-fast-parallel` reached the existing 20-minute aggregate timeout in `examples/bd/dolt`; unrelated backup/doctor/health/compact tests failed or remained active. The focused restart suite above is green, including the production helper copied into fixtures. Remaining parallel shards were stopped after the suite had a terminal failure result.

No local install, pin update, Dolt restart, or supervisor lifecycle action was performed.