### PR TITLE
fix(session): safely handle partial and empty tmux scans

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -699,7 +699,11 @@ func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) err
 	}
 	found, err := scanner.FindRuntimesBySessionID(sessionID)
 	if err != nil {
-		log.Printf("session: scanning for orphaned runtimes for %s (failing closed): %v", sessionID, err)
+		// A partial process-table scan cannot distinguish a live tracked tmux
+		// session from an escaped orphan. Do not kill any partial result: a
+		// false-positive kill loses assigned work. Refuse this start and let the
+		// reconciler retry after a complete observation instead.
+		return fmt.Errorf("scan orphaned runtimes for %s: %w", sessionID, err)
 	}
 	cityPath := pathutil.NormalizePathForCompare(strings.TrimSpace(m.cityPath))
 	var termErrs []error

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -698,7 +698,7 @@ func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) err
 		return nil
 	}
 	found, err := scanner.FindRuntimesBySessionID(sessionID)
-	if err != nil {
+	if err != nil && !(len(found) == 0 && runtime.IsSessionGone(err)) {
 		// A partial process-table scan cannot distinguish a live tracked tmux
 		// session from an escaped orphan. Do not kill any partial result: a
 		// false-positive kill loses assigned work. Refuse this start and let the

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -511,17 +511,15 @@ func TestCreateKillsUntrackedOrphanFromSameCityBeforeStartWithNormalizedPath(t *
 }
 
 // TestCreateRefusesStartWhenOrphanNotConfirmedDead pins the fail-closed
-// contract: when an untracked same-session orphan cannot be confirmed dead
-// (TerminateRuntime errors — e.g. it survived SIGKILL), Create must refuse to
-// start a replacement rather than race the survivor for the same work bead. A
-// concurrent scan error is logged and treated as fail-closed, so the orphan the
-// scan did surface is still targeted. No Start is attempted.
+// contract: when the process-table scan is incomplete, Create must refuse to
+// start a replacement rather than race a survivor for the same work bead. Its
+// partial result cannot prove an untracked runtime is orphaned, so no runtime
+// is terminated. No Start is attempted.
 func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &orphanScanProvider{
 		Fake:         runtime.NewFake(),
 		findErr:      errors.New("partial scan failed"),
-		terminateErr: errors.New("terminate failed"),
 		results: []runtime.LiveRuntime{{
 			PID:       1234,
 			IsTracked: false,
@@ -541,11 +539,8 @@ func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 			t.Fatalf("Start was attempted despite unconfirmed orphan; events = %v", sp.events)
 		}
 	}
-	want := []string{"find:", "terminate:"}
-	for i, prefix := range want {
-		if i >= len(sp.events) || !strings.HasPrefix(sp.events[i], prefix) {
-			t.Fatalf("events = %v, want prefixes %v", sp.events, want)
-		}
+	if got := sp.events; len(got) != 1 || !strings.HasPrefix(got[0], "find:") {
+		t.Fatalf("events = %v, want only a process-table scan", got)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -544,6 +544,30 @@ func TestCreateRefusesStartWhenOrphanNotConfirmedDead(t *testing.T) {
 	}
 }
 
+// TestCreateStartsWhenNoTmuxServerExists covers a fresh City: tmux reports
+// its authoritative empty state as "no tmux server running". That is not a
+// partial observation and must not prevent the first session from starting.
+func TestCreateStartsWhenNoTmuxServerExists(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{
+		Fake:    runtime.NewFake(),
+		findErr: errors.New("tmux server unreachable: no tmux server running"),
+	}
+	mgr := NewManagerWithOptions(store, sp)
+
+	info, err := mgr.CreateSession(context.Background(), CreateOptions{Template: "helper", Title: "my chat", Command: "claude", WorkDir: "/tmp", Provider: "claude", Env: nil, Resume: ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !sp.IsRunning(info.SessionName) {
+		t.Fatalf("runtime session %q not running after fresh-city create", info.SessionName)
+	}
+	want := []string{"find:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+}
+
 // acpOrphanScanProvider augments orphanScanProvider with ACP route bookkeeping
 // so a resume that reserves an ACP route before the pre-start orphan gate can
 // be observed unwinding that reservation when the gate refuses. RouteACP and


### PR DESCRIPTION
## Summary

This is the complete session-start safety fix. It contains both required behaviors:

1. If runtime discovery is partial and includes possible same-session process roots, do not terminate or replace them; defer the start rather than risking assigned work.
2. If a fresh City has no tmux server and discovery is authoritatively empty, allow the first session to start.

Together these prevent false-positive kills without deadlocking fresh City startup.

## Fork dogfood

Merged into `allenday/gascity` as #1 and #2; this upstream PR intentionally combines them as one coherent change.

## Validation

- `go test ./internal/session -run "^(TestCreateStartsWhenNoTmuxServerExists|TestCreateRefusesStartWhenOrphanNotConfirmedDead)$"`
- `git diff --check`