### PR TITLE
test(reconciler): cover max-session-age slot-free on the production Info path

### DIFF
--- a/cmd/gc/session_classifier_info_equiv_test.go
+++ b/cmd/gc/session_classifier_info_equiv_test.go
@@ -215,6 +215,21 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 				"pool_slot":    "2",
 			},
 		},
+		// asleep+sleep_reason=max-session-age is freeable (isPoolSessionSlotFreeable*):
+		// covers the Info-form production path (isPoolSessionSlotFreeableInfo), which
+		// previously had no equivalence-oracle coverage for this reason.
+		"asleep-max-session-age-freeable": {
+			ID:     "ga-maxage",
+			Type:   session.BeadType,
+			Title:  "maxage",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":     "worker",
+				"state":        "asleep",
+				"sleep_reason": string(session.SleepReasonMaxSessionAge),
+				"pool_slot":    "2",
+			},
+		},
 		"asleep-wait-hold-not-freeable": {
 			ID:     "ga-wait",
 			Type:   session.BeadType,

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2480,6 +2480,63 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_AsleepMaxSessionAgePoolBeadFreesSlot mirrors
+// TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot for
+// sleep_reason=max-session-age: a session forced to stop by the max-session-age
+// timer must free its pool slot through the same live-query close gate,
+// instead of wedging the slot until an operator intervenes.
+func TestReconcileSessionBeads_AsleepMaxSessionAgePoolBeadFreesSlot(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", false) // NOT running
+	session := env.createSessionBead("worker", "worker")
+	// Simulate the post-max-session-age-stop state: asleep +
+	// sleep_reason=max-session-age + pool-managed, but the runtime has
+	// exited and no work is assigned.
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "asleep",
+		"sleep_reason":         string(sessionpkg.SleepReasonMaxSessionAge),
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		nil,
+		nil, // rigStores
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed — asleep-max-session-age pool beads must free their slot via the live-query close gate", got.Status)
+	}
+}
+
 // capturingRecorder is an in-memory events.Recorder used in tests that
 // need to assert which events were emitted.
 type capturingRecorder struct {

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -47,11 +47,12 @@ func poolSessionIsLiveInfo(i sessionpkg.Info) bool {
 }
 
 // isPoolSessionSlotFreeable reports whether a session's bead is in a terminal
-// state where the pool slot it occupies can be freed — either explicitly
-// drained, asleep from a normal idle transition, or asleep after max-session-age
-// expiry. Sessions parked via
-// `gc session wait` (sleep_reason=wait-hold), held by context-churn
-// quarantine, or otherwise signaling "don't touch me" keep their slot.
+// state where the pool slot it occupies can be freed: explicitly drained, or
+// asleep with sleep_reason one of idle, idle-timeout, city-stop,
+// failed-create, runtime-missing, provider-terminal-error, or
+// max-session-age. Sessions parked via `gc session wait` (sleep_reason=wait-hold),
+// held by context-churn quarantine, or otherwise signaling "don't touch me"
+// keep their slot.
 //
 // Distinct from `isDrainedSessionBead` because drain-ack can land pool
 // workers in state=asleep+sleep_reason=idle when the pre-close ownership


### PR DESCRIPTION
#5523 fixed pool slots wedging when a session is stopped by the max-session-age timer. The regression test that shipped with it exercises `isPoolSessionSlotFreeable`, which takes a bead. Production never calls that function. The reconciler calls `isPoolSessionSlotFreeableInfo`, which takes a `session.Info`, at `cmd/gc/session_reconciler.go:3841`. The shipped test would have stayed green if the fix had reached only one of the two classifiers.

This adds the missing coverage:

- a `max-session-age` fixture in the classifier equivalence oracle (`cmd/gc/session_classifier_info_equiv_test.go`), the one shape the fixture set had no entry for;
- `TestReconcileSessionBeads_AsleepMaxSessionAgePoolBeadFreesSlot`, mirroring the existing idle-path test, driving a real reconciler tick and asserting the slot frees;
- a correction to the `isPoolSessionSlotFreeable` doc comment, which named three of the seven allowlisted sleep reasons.

Mutation check: removing `max-session-age` from the Info classifier alone fails the new reconciler test with `status = "open"`; removing it from the bead classifier alone leaves the test passing. The new test pins the path production takes.

No production behavior changes.

## Test plan

- `go test ./cmd/gc/ -run 'TestReconcileSessionBeads_AsleepMaxSessionAgePoolBeadFreesSlot|TestSessionClassifierInfoEquivalence|TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot' -count=1` passes.
- Both mutation cases above were run and produced the stated results.
