### PR TITLE
fix(runtime/herdr): resolve session sockets with herdr's XDG precedence on every platform

### DIFF
--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -675,24 +675,41 @@ func (c *client) ensurePlacement(ctx context.Context, wsLabel, tabLabel, cwd str
 // confirmed empirically (`XDG_CONFIG_HOME=X herdr --help` prints
 // "Config: X/herdr/config.toml" regardless of $HOME; with XDG_CONFIG_HOME
 // unset it falls back to "$HOME/.config/herdr/…") to be standard XDG Base
-// Directory precedence, i.e. exactly os.UserConfigDir() on this platform. A
-// plain os.UserHomeDir()+".config" join (the prior implementation) silently
-// ignores XDG_CONFIG_HOME, so it diverges from herdr's own resolution in any
-// environment that sets XDG_CONFIG_HOME while pointing $HOME elsewhere —
-// this fleet's agent sandboxes do exactly that. The result: this client
-// dials a socket no herdr process ever binds, so serverAlive() reads false
-// against a perfectly healthy server ("did not become ready"), and every
-// retry launches a redundant herdr server contending for the same pane
-// ("agent_pane_busy") — ga-nqlb8q.
+// Directory precedence on EVERY platform, macOS included (herdr 0.8.2 on
+// darwin prints "Config: ~/.config/herdr/config.toml" and honors
+// XDG_CONFIG_HOME the same way). That rules out os.UserConfigDir(), which
+// only implements XDG precedence under the unix build tag minus darwin: on
+// darwin it ignores XDG_CONFIG_HOME entirely and answers
+// "$HOME/Library/Application Support" — a directory herdr never uses. It
+// also rules out a plain os.UserHomeDir()+".config" join (the pre-#5459
+// implementation), which silently ignores XDG_CONFIG_HOME on all platforms.
+// Either divergence makes this client dial a socket no herdr process ever
+// binds, so serverAlive() reads false against a perfectly healthy server
+// ("did not become ready"), and every retry launches a redundant herdr
+// server contending for the same pane ("agent_pane_busy") — ga-nqlb8q.
+// herdrConfigRoot below is the one resolution that matches herdr everywhere.
 func (c *client) socketPath() string {
 	if c.sockPath != "" {
 		return c.sockPath
 	}
-	configDir, _ := os.UserConfigDir()
+	configDir := herdrConfigRoot()
 	if c.session == "" || c.session == "default" {
 		return filepath.Join(configDir, "herdr", "herdr.sock")
 	}
 	return filepath.Join(configDir, "herdr", "sessions", c.session, "herdr.sock")
+}
+
+// herdrConfigRoot resolves the base config directory the herdr binary roots
+// its config, state, and session sockets in: $XDG_CONFIG_HOME when set, else
+// $HOME/.config. herdr applies this XDG Base Directory precedence on every
+// platform, so gc must too — see the socketPath comment for why neither
+// os.UserConfigDir() nor a bare $HOME join can substitute.
+func herdrConfigRoot() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return xdg
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config")
 }
 
 // serverAlive reports whether the session-server is actually accepting

--- a/internal/runtime/herdr/client_test.go
+++ b/internal/runtime/herdr/client_test.go
@@ -13,11 +13,16 @@ import (
 // Verified empirically against the herdr binary itself: `XDG_CONFIG_HOME=X
 // herdr --help` prints "Config: X/herdr/config.toml" regardless of $HOME,
 // and with XDG_CONFIG_HOME unset it falls back to "$HOME/.config/herdr/…" —
-// standard XDG Base Directory precedence, which os.UserConfigDir()
-// implements and the old os.UserHomeDir()+".config" join did not: a sandbox
-// that sets XDG_CONFIG_HOME to the real user's config dir while redirecting
-// $HOME elsewhere (this fleet's agent sandboxes do exactly that) made the
-// old code compute a path no herdr process ever binds.
+// standard XDG Base Directory precedence, on every platform herdr ships for
+// (macOS included; darwin herdr 0.8.2 behaves identically). Neither stdlib
+// shortcut implements that contract everywhere: os.UserConfigDir() ignores
+// XDG_CONFIG_HOME on darwin and answers "$HOME/Library/Application Support",
+// and the old os.UserHomeDir()+".config" join ignored XDG_CONFIG_HOME on all
+// platforms — a sandbox that sets XDG_CONFIG_HOME to the real user's config
+// dir while redirecting $HOME elsewhere (this fleet's agent sandboxes do
+// exactly that) made the old code compute a path no herdr process ever
+// binds. These tests pin the herdr-matching resolution on every platform,
+// so they must not be skipped per-OS.
 
 func TestSocketPathHonorsXDGConfigHomeOverHome(t *testing.T) {
 	xdg := t.TempDir()

--- a/internal/runtime/herdr/staleserver_test.go
+++ b/internal/runtime/herdr/staleserver_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // shortHome points socketPath()'s config-dir resolution at a short, isolated
-// temp dir via $XDG_CONFIG_HOME — the env var os.UserConfigDir() consults
+// temp dir via $XDG_CONFIG_HOME — the env var herdrConfigRoot() consults
 // before $HOME (see socketPath's doc comment) — so these tests never touch
 // the real user's ~/.config/herdr/sessions/. The default t.TempDir()
 // (/var/folders/… on macOS) blows past the 104-byte unix-socket sun_path


### PR DESCRIPTION
## Summary

- `internal/runtime/herdr`: `socketPath()` resolved the herdr config root with `os.UserConfigDir()` (#5459). On Linux that is exactly XDG Base Directory precedence, but on darwin it ignores `XDG_CONFIG_HOME` entirely **and** answers `$HOME/Library/Application Support` — a directory the herdr binary never uses. herdr applies XDG precedence on every platform it ships for (verified against herdr 0.8.2 on macOS: `herdr --help` prints `Config: ~/.config/herdr/config.toml`, and `XDG_CONFIG_HOME=X herdr --help` prints `Config: X/herdr/config.toml`). So on macOS gc polled a socket no herdr process ever binds: `serverAlive()` read false against a healthy server, every start timed out with "did not become ready", and the provider was unusable.
- Replace it with an explicit resolution matching herdr everywhere: `$XDG_CONFIG_HOME` when set, else `$HOME/.config` (`herdrConfigRoot()`). On Linux this is behavior-identical to `os.UserConfigDir()`, so the ga-nqlb8q agent-sandbox fix from #5459 is fully preserved; on darwin it repairs the provider.
- The `TestSocketPath*` tests added with #5459 already pin this exact contract and are the RED on darwin — no test logic changes, only comment updates so they describe the cross-platform contract accurately. This also supersedes the herdr half of #5746, which proposed skipping those assertions on non-Linux as "an unverified cross-platform contract": the contract is now verified against the darwin binary, so the implementation is fixed instead of the tests narrowed.
- Fixes #5770.

## Testing

- [x] `gofmt -l internal/runtime/herdr/` — clean
- [x] `go vet ./internal/runtime/herdr/` — clean
- [x] macOS 15 / Apple Silicon, live herdr 0.8.2: `TestSocketPathHonorsXDGConfigHomeOverHome`, `TestSocketPathFallsBackToHomeConfigWhenXDGUnset`, `TestActivityLive`, `TestStaleSocket*`, and the full `TestHerdrConformance` suite all PASS with this change; before it, both socket-path tests fail and every live test times out with "did not become ready".
- [x] Remaining package failures on macOS are pre-existing and unrelated: `TestSessionEventsLive` (#5746 reports it failing identically against unmodified `origin/main` on Linux) and `TestProviderLiveClaudeKindPath` (fails identically at pre-#4966 refs on this machine; herdr reports `agent_not_ready` launching the claude kind).
- [x] Linux behavior is unchanged by construction (`os.UserConfigDir()` ≡ `$XDG_CONFIG_HOME`-else-`$HOME/.config` there).

## Checklist

- [x] Linked an issue: fixes #5770
- [x] Added or updated tests for behavior changes — the #5459 socket-path tests already encode the contract; they go RED on darwin without this fix and GREEN with it
- [ ] Updated docs for user-facing changes — n/a, behavior fix only
- [x] Called out breaking changes or migration notes — none
