### PR TITLE
test(reconciler): pin every freeable sleep reason in the classifier oracle

### DIFF
--- a/cmd/gc/session_classifier_info_equiv_test.go
+++ b/cmd/gc/session_classifier_info_equiv_test.go
@@ -230,6 +230,61 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 				"pool_slot":    "2",
 			},
 		},
+		// The remaining freeable sleep reasons. Each arm of the
+		// isPoolSessionSlotFreeable allowlist needs its own fixture: the oracle
+		// compares the bead form against the Info form per fixture, so a reason
+		// with no fixture lets the two classifiers drift apart on that reason
+		// alone. failed-create appears here in its asleep+sleep_reason spelling,
+		// which is distinct from the "failed-create" fixture below (state=
+		// failed-create) and reaches a different arm.
+		"asleep-city-stop-freeable": {
+			ID:     "ga-citystop",
+			Type:   session.BeadType,
+			Title:  "citystop",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":     "worker",
+				"state":        "asleep",
+				"sleep_reason": string(session.SleepReasonCityStop),
+				"pool_slot":    "2",
+			},
+		},
+		"asleep-failed-create-freeable": {
+			ID:     "ga-failedasleep",
+			Type:   session.BeadType,
+			Title:  "failedasleep",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":     "worker",
+				"state":        "asleep",
+				"sleep_reason": string(session.SleepReasonFailedCreate),
+				"pool_slot":    "2",
+			},
+		},
+		"asleep-runtime-missing-freeable": {
+			ID:     "ga-runtimemissing",
+			Type:   session.BeadType,
+			Title:  "runtimemissing",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":     "worker",
+				"state":        "asleep",
+				"sleep_reason": string(session.SleepReasonRuntimeMissing),
+				"pool_slot":    "2",
+			},
+		},
+		"asleep-provider-terminal-error-freeable": {
+			ID:     "ga-providerterm",
+			Type:   session.BeadType,
+			Title:  "providerterm",
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"template":     "worker",
+				"state":        "asleep",
+				"sleep_reason": string(session.SleepReasonProviderTerminalError),
+				"pool_slot":    "2",
+			},
+		},
 		"asleep-wait-hold-not-freeable": {
 			ID:     "ga-wait",
 			Type:   session.BeadType,


### PR DESCRIPTION
Follow-up to #5769, taking up quad341's suggestion there.

`TestSessionClassifierInfoEquivalence` compares each session classifier's bead form against its `Info` form once per fixture in `beadsByShape`. That means a sleep reason with no fixture is not covered at all: `isPoolSessionSlotFreeable` and `isPoolSessionSlotFreeableInfo` can drift apart on that one reason and the suite stays green.

The allowlist has seven arms. Four had no fixture:

- `city-stop`
- `runtime-missing`
- `provider-terminal-error`
- `failed-create` in its `asleep` + `sleep_reason` spelling. The existing `failed-create` fixture sets `state=failed-create`, which fails the `state=asleep` gate and never reaches the sleep-reason switch, so it pins a different arm.

The first three are the ones quad341 named. The fourth turned up while checking the rest.

`idle`, `idle-timeout` and `max-session-age` were already covered and are unchanged.

## Verification

Mutation, one arm at a time. Deleting a single reason from the `isPoolSessionSlotFreeableInfo` switch and running `TestSessionClassifierInfoEquivalence`:

| removed arm | before this change | after |
| --- | --- | --- |
| `city-stop` | pass | FAIL |
| `failed-create` | pass | FAIL |
| `runtime-missing` | pass | FAIL |
| `provider-terminal-error` | pass | FAIL |
| `max-session-age` | FAIL | FAIL |

Four arms could be deleted from the production classifier with the suite still green. Now none can.

`TestIsPoolSessionSlotFreeable_Matrix` already pins the expected policy for all seven reasons on the bead form; this closes the equivalence side.

No production code changes.
