### PR TITLE
fix(orders): report a condition-false exit as 'not met', not 'check command failed'

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -358,6 +358,10 @@ func checkCondition(a Order, opts TriggerOptions) TriggerResult {
 			}
 			return TriggerResult{Due: false, Reason: reason}
 		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return TriggerResult{Due: false, Reason: fmt.Sprintf("condition: not met (exit %d)", exitErr.ExitCode())}
+		}
 		return TriggerResult{Due: false, Reason: fmt.Sprintf("check command failed: %v", err)}
 	}
 	return TriggerResult{Due: true, Reason: "condition: check passed (exit 0)"}

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -264,6 +264,10 @@ func TestCheckTriggerConditionFails(t *testing.T) {
 	if result.Due {
 		t.Errorf("Due = true, want false (exit non-zero)")
 	}
+	const wantReason = "condition: not met (exit 1)"
+	if result.Reason != wantReason {
+		t.Errorf("Reason = %q, want %q", result.Reason, wantReason)
+	}
 }
 
 func TestCheckTriggerConditionKillsProcessGroupOnTimeout(t *testing.T) {


### PR DESCRIPTION
## Problem

`checkCondition` treats every non-zero exit from an order's condition command as a failure: the trigger result reads `check command failed: exit status 1`. But for condition commands, a non-zero exit is the *normal* way to say "condition not met" — that's the whole contract of exit-code semantics (`test`, `grep -q`, bespoke probes). Every healthy not-yet-due order was being labeled a failure, which pollutes trigger telemetry and makes real check-command breakage (command not found, permission denied, timeout) indistinguishable from an ordinary quiet tick.

## Fix

Distinguish the two cases with `errors.As` on `*exec.ExitError`:

- clean non-zero exit → `condition: not met (exit N)` — a healthy, quiet result;
- anything else (spawn failure, I/O error, etc.) → still `check command failed: %v`.

## Testing

`TestCheckTriggerConditionFails` now pins the exact reason string (`condition: not met (exit 1)`), so a regression back to the failure label breaks the suite. Full `internal/orders` suite green.

## Provenance

Authored by `gascity/gasburger.tuft` (pool worker) on bead `ga-198`; the session was killed mid-push by the reconciler claim-kill loop (ga-re7) and the commit was salvaged by the gascity witness, then merged to the boomfartville fork's develop by the refinery (orders tests green, gasburger-green advanced) — hence the `witness: salvage` commit title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
