### PR TITLE
fix(repo): gitignore agent seat/ homes and exclude them from doc-tree coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ internal/api/dashboardspa/web/frontend/.playwright/
 .agents/migration/
 .gc/
 
+# Seat home (IDENTITY, diary, laurels) — agent-local runtime memory, never committed.
+/seat/
+
 # Dolt database files (added by bd init)
 .dolt/
 *.db

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -39,7 +39,7 @@ var docTreeDirs = []string{"contrib", "docs", "engdocs", "release-gates", "specs
 // docTreeIgnored lists directories that contain markdown but are not
 // documentation trees (e.g., embedded prompt templates, test fixtures,
 // gitignored scratch space for local work).
-var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "scripts", "test", "tmp", "worktrees"}
+var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "scripts", "seat", "test", "tmp", "worktrees"}
 
 // beadScratchPrefixes are the bead-id prefixes agents name their top-level
 // scratch directories after. An explicit list, not a shape match: a doc tree


### PR DESCRIPTION
## Problem

Gas City agents keep a per-seat home directory (`seat/` — identity, diary, laurels; agent-local runtime memory) inside their worktrees. When such a worktree doubles as a merge/test workspace, the markdown inside `seat/` trips `TestDocDirCoverage` in `test/docsync`, which walks top-level directories for documentation trees — and nothing stopped a stray `git add -A` from committing a seat home outright.

## Fix

Belt and suspenders:

- `.gitignore`: add `/seat/` with a comment explaining what it is, so seat homes can never be committed;
- `test/docsync`: add `"seat"` to `docTreeIgnored`, so the coverage walk skips it even when the directory exists untracked in the worktree under test.

## Testing

`TestDocDirCoverage` green in a worktree containing a populated `seat/`; full `test/docsync` suite green.

## Provenance

Authored by `gascity/gasburger.whisker` (pool worker) on bead `ga-dvl`; the session was killed mid-work by the reconciler claim-kill loop (ga-re7) and the committed-but-unpushed fix was salvaged by the gascity witness, then merged to the boomfartville fork's develop by the refinery (gasburger-green advanced) — hence the `witness: salvage` commit title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
