### PR TITLE
fix(dolt): fence full GC after final writer check

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -3027,6 +3027,28 @@ flatten_database() {
     printf 'compact: db=%s row-count increase passed value-hash verification — full GC allowed\n' \
       "$db"
   fi
+
+  # The post-db-hash HEAD probe closes the hash query itself, but a writer can
+  # still commit in the small gap before DOLT_GC starts. Full GC rewrites the
+  # store and must not start against a state that changed after every
+  # flatten/verification proof passed. Take one final HEAD fence immediately
+  # before GC: a move past the flatten commit is an ordinary writer, so retain
+  # the compacted data and defer the reclamation for a quiet retry instead of
+  # racing the writer or manufacturing a later quarantine signal.
+  final_verify_head=$(head_commit "$db" || true)
+  if [ -n "$flatten_head" ] && [ -n "$final_verify_head" ] && [ "$final_verify_head" != "$flatten_head" ]; then
+    printf 'compact: db=%s writer race detected during flatten verification (snapshot_HEAD=%s flatten_HEAD=%s final_verify_HEAD=%s) — deferring full GC until the next quiet run\n' \
+      "$db" "$head" "$flatten_head" "$final_verify_head" >&2
+    if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+      "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+      "$compacted_from_head" "$local_branch" "$remote_branch"; then
+      rm -f "$preflight_tmp"
+      return 1
+    fi
+    rm -f "$preflight_tmp"
+    return 0
+  fi
+
   rm -f "$preflight_tmp"
 
   after_count=$(commit_count "$db" || true)

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -3028,13 +3028,13 @@ flatten_database() {
       "$db"
   fi
 
-  # The post-db-hash HEAD probe closes the hash query itself, but a writer can
-  # still commit in the small gap before DOLT_GC starts. Full GC rewrites the
-  # store and must not start against a state that changed after every
-  # flatten/verification proof passed. Take one final HEAD fence immediately
-  # before GC: a move past the flatten commit is an ordinary writer, so retain
-  # the compacted data and defer the reclamation for a quiet retry instead of
-  # racing the writer or manufacturing a later quarantine signal.
+  # Treat HEAD movement after the database-hash probes as a final signal that
+  # this is not a quiet compaction window. Deferring here avoids starting an
+  # expensive full GC while a writer is already known to be active. This probe
+  # is intentionally not described as quiescence: a writer can still commit
+  # after it. Concurrent-GC correctness comes from Dolt's online-GC safepoint
+  # controller; this check only detects the residual window we can observe and
+  # leaves reclamation for a quieter retry.
   final_verify_head=$(head_commit "$db" || true)
   if [ -n "$flatten_head" ] && [ -n "$final_verify_head" ] && [ "$final_verify_head" != "$flatten_head" ]; then
     printf 'compact: db=%s writer race detected during flatten verification (snapshot_HEAD=%s flatten_HEAD=%s final_verify_HEAD=%s) — deferring full GC until the next quiet run\n' \

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -761,7 +761,7 @@ case "$query" in
     # probe, which reports writercommit so HEAD has moved past the flatten's own
     # commit. verify_counts still sees compactcommit (gain+drift) because it does
     # not probe HEAD and the "$(current_head)" gates read the real state.
-    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "same_count_hash_drift_with_writer_race" ] || [ "$mode" = "writer_race_same_count_hash_drift_only" ] || [ "$mode" = "writer_race_same_count_hash_drift_diff_fails" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "row_count_decreases_with_writer_race" ] || [ "$mode" = "same_count_hash_drift_with_writer_race" ] || [ "$mode" = "writer_race_same_count_hash_drift_only" ] || [ "$mode" = "writer_race_same_count_hash_drift_diff_fails" ] || [ "$mode" = "writer_race_after_db_hash" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.postverify-head-calls"
       calls=0
       if [ -f "$calls_file" ]; then
@@ -769,7 +769,11 @@ case "$query" in
       fi
       calls=$((calls + 1))
       printf '%%s\n' "$calls" > "$calls_file"
-      if [ "$calls" -ge 2 ]; then
+      if [ "$mode" = "writer_race_after_db_hash" ] && [ "$calls" -ge 5 ]; then
+        print_cell writercommit
+        exit 0
+      fi
+      if [ "$mode" != "writer_race_after_db_hash" ] && [ "$calls" -ge 2 ]; then
         print_cell writercommit
         exit 0
       fi
@@ -2450,7 +2454,7 @@ func assertCompactWriterRaceDeferred(t *testing.T, fixture compactScriptFixture,
 		t.Fatalf("writer-race defer must exit 0 (skip, not failure): %v\n%s", err, out)
 	}
 	if !strings.Contains(out, "writer race detected during flatten") ||
-		!strings.Contains(out, "deferring, will retry next run") {
+		!strings.Contains(out, "deferring full GC until the next quiet run") {
 		t.Fatalf("output missing writer-race defer message:\n%s", out)
 	}
 	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
@@ -2529,6 +2533,19 @@ func TestCompactScriptDefersWhenWriterCommitsDuringDatabaseHash(t *testing.T) {
 	}
 	if !strings.Contains(out, "post_db_hash_HEAD=writercommit") {
 		t.Fatalf("defer message should report HEAD moving across the database hash probe:\n%s", out)
+	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+// A writer can commit after the database-hash probes have both completed but
+// immediately before full GC. The final HEAD fence must defer that run so GC
+// never starts from a state that changed after flatten verification.
+func TestCompactScriptDefersWhenWriterCommitsAfterDatabaseHashBeforeGC(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_after_db_hash", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "writer race detected during flatten verification") ||
+		!strings.Contains(out, "final_verify_HEAD=writercommit") {
+		t.Fatalf("output missing final verification writer-race fence:\n%s", out)
 	}
 	assertCompactWriterRaceDeferred(t, fixture, out, err)
 }

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -2448,13 +2448,13 @@ func TestCompactScriptQuarantinesMixedSignalsDespiteWriterRace(t *testing.T) {
 // writer-race defer: the gain+drift quarantine is downgraded to a skip, so the
 // run exits 0, logs the defer message, writes NO quarantine marker, and does not
 // run DOLT_GC (GC is left for the next run after the writer settles).
-func assertCompactWriterRaceDeferred(t *testing.T, fixture compactScriptFixture, out string, err error) {
+func assertCompactWriterRaceDeferred(t *testing.T, fixture compactScriptFixture, out string, err error, expectedDeferMessage string) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("writer-race defer must exit 0 (skip, not failure): %v\n%s", err, out)
 	}
 	if !strings.Contains(out, "writer race detected during flatten") ||
-		!strings.Contains(out, "deferring full GC until the next quiet run") {
+		!strings.Contains(out, expectedDeferMessage) {
 		t.Fatalf("output missing writer-race defer message:\n%s", out)
 	}
 	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
@@ -2490,7 +2490,7 @@ func TestCompactScriptDefersWhenWriterCommitsBeforeFlatten(t *testing.T) {
 	if !strings.Contains(out, "pre_reset_HEAD=writercommit") {
 		t.Fatalf("defer message should report the pre-reset writer HEAD:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring, will retry next run")
 }
 
 // A writer that commits during/after the post-flatten verify moves HEAD past
@@ -2506,7 +2506,7 @@ func TestCompactScriptDefersWhenWriterCommitsDuringVerify(t *testing.T) {
 	if !strings.Contains(out, "post_verify_HEAD=writercommit") {
 		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring, will retry next run")
 }
 
 // The whole-database value hash also drifts when a concurrent writer adds rows.
@@ -2522,7 +2522,7 @@ func TestCompactScriptDefersWhenWriterCommitsCausingDatabaseHashDrift(t *testing
 	if !strings.Contains(out, "post_verify_HEAD=writercommit") {
 		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring, will retry next run")
 }
 
 func TestCompactScriptDefersWhenWriterCommitsDuringDatabaseHash(t *testing.T) {
@@ -2534,7 +2534,7 @@ func TestCompactScriptDefersWhenWriterCommitsDuringDatabaseHash(t *testing.T) {
 	if !strings.Contains(out, "post_db_hash_HEAD=writercommit") {
 		t.Fatalf("defer message should report HEAD moving across the database hash probe:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring, will retry next run")
 }
 
 // A writer can commit after the database-hash probes have both completed but
@@ -2547,7 +2547,7 @@ func TestCompactScriptDefersWhenWriterCommitsAfterDatabaseHashBeforeGC(t *testin
 		!strings.Contains(out, "final_verify_HEAD=writercommit") {
 		t.Fatalf("output missing final verification writer-race fence:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring full GC until the next quiet run")
 }
 
 func TestCompactScriptDefersWhenDatabaseHashPreHeadProbeIsEmptyButPostProbeProvesWriter(t *testing.T) {
@@ -2560,7 +2560,7 @@ func TestCompactScriptDefersWhenDatabaseHashPreHeadProbeIsEmptyButPostProbeProve
 		!strings.Contains(out, "post_db_hash_HEAD=writercommit") {
 		t.Fatalf("defer message should report empty pre-probe HEAD and writer post-probe HEAD:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring, will retry next run")
 }
 
 // A concurrent UPDATE that lands during the post-flatten verify leaves the
@@ -2579,7 +2579,7 @@ func TestCompactScriptDefersProvenWriterRaceSameCountHashDrift(t *testing.T) {
 	if !strings.Contains(out, "post_verify_HEAD=writercommit") {
 		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
 	}
-	assertCompactWriterRaceDeferred(t, fixture, out, err)
+	assertCompactWriterRaceDeferred(t, fixture, out, err, "deferring, will retry next run")
 }
 
 // Same proven writer race (HEAD moves past the flatten commit) but the
@@ -2632,7 +2632,7 @@ func TestCompactScriptRetriesPendingGCAfterWriterRaceDefer(t *testing.T) {
 	}
 
 	firstOut, err := fixture.run(t, "writer_race_during_verify", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	assertCompactWriterRaceDeferred(t, fixture, firstOut, err)
+	assertCompactWriterRaceDeferred(t, fixture, firstOut, err, "deferring, will retry next run")
 	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
 	if compactedFrom := compactMarkerValue(t, pendingGC, "compacted_from_head"); compactedFrom != "headcommit" {
 		t.Fatalf("pending-GC marker should preserve compaction source HEAD, got %q", compactedFrom)
@@ -2668,7 +2668,7 @@ func TestCompactScriptRetriesRemotePendingGCAfterBeforeFlattenWriterRace(t *test
 	fixture := newCompactScriptFixture(t)
 
 	firstOut, err := fixture.run(t, "remote_writer_race_before_flatten", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	assertCompactWriterRaceDeferred(t, fixture, firstOut, err)
+	assertCompactWriterRaceDeferred(t, fixture, firstOut, err, "deferring, will retry next run")
 	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
 	marker, err := os.ReadFile(pendingGC)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Detect HEAD movement after the database-hash probes as a final signal that the compaction window is not quiet.
- Preserve the flattened data, write the pending-GC retry marker, and defer full GC when that observable movement is found.
- Keep the claim precise: this probe is not quiescence and a writer may still commit after it. Concurrent-GC correctness is provided by Dolt online-GC safepoints, not by this shell probe.

## Correctness boundary
Both managed cities run Dolt 2.2.2 with the default session-aware safepoint controller. In that exact release, DOLT_GC is implemented as online GC: the session-aware controller visits active-session roots and waits at the pre-finalize safepoint; the legacy controller instead closes competing connections before finalization.

Primary-source evidence:
- https://github.com/dolthub/dolt/blob/v2.2.2/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
- https://github.com/dolthub/dolt/blob/v2.2.2/integration-tests/go-sql-server-driver/concurrent_gc_test.go

The upstream test exercises concurrent writers with both ordinary and --full GC under both safepoint implementations. This PR therefore reduces interference during a known-active write window; it does not manufacture an external write lock and does not claim to close an unobservable post-probe interval.

## Validation
Exact head: 74e642345692dceaba26a5de35209c21d2728ae8

- Linux Go 1.26.7: go test ./examples/bd/dolt -count=1 — PASS (83.153s).
- bash -n examples/bd/dolt/commands/compact/run.sh — PASS.
- git diff --check — PASS.
- Previous exact implementation head 942354f49b72 passed the focused writer-race regression and full examples/bd/dolt suite; the new commit changes comments only.

## Manual release gate
Code-only PR. Do not remove compact-quarantine/hq, run live compact/GC, restart Dolt, or deploy as part of review. Marker recovery remains separately gated on fresh backup proof and a controlled live canary.