### PR TITLE
fix: preserve mol-do-work claim and close ownership

### DIFF
--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -29,23 +29,24 @@ are done. If the result action is `work`, use `bead_id` as the work bead.
 3. Execute exactly that bead's description.
 4. On success, close it:
    ```bash
-   gc bd update <id> --set-metadata gc.outcome=pass --status closed
+   gc bd update <id> --set-metadata gc.outcome=pass
+   gc bd close <id> --reason "Completed successfully."
    ```
 5. On transient failure, mark it transient and close it:
    ```bash
    gc bd update <id> \
      --set-metadata gc.outcome=fail \
      --set-metadata gc.failure_class=transient \
-     --set-metadata gc.failure_reason=<short_reason> \
-     --status closed
+     --set-metadata gc.failure_reason=<short_reason>
+   gc bd close <id> --reason "Transient failure: <short_reason>."
    ```
 6. On unrecoverable failure, mark it hard-failed and close it:
    ```bash
    gc bd update <id> \
      --set-metadata gc.outcome=fail \
      --set-metadata gc.failure_class=hard \
-     --set-metadata gc.failure_reason=<short_reason> \
-     --status closed
+     --set-metadata gc.failure_reason=<short_reason>
+   gc bd close <id> --reason "Hard failure: <short_reason>."
    ```
 7. After closing, check for more assigned work:
    ```bash

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.template.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.template.md
@@ -49,7 +49,7 @@ Run `gc bd mol current <molecule-id>` to see your steps:
 **Work one step at a time.** For each `[ready]` step:
 1. `gc bd show <step-id>` — read what to do
 2. Do the work described in that step
-3. `gc bd close <step-id>` — mark it done
+3. `gc bd close <step-id> --reason "Completed: <brief summary>."` — mark it done
 4. `gc bd mol current <molecule-id>` — check your position, repeat
 
 Do NOT read the parent bead description and do everything at once.
@@ -64,7 +64,7 @@ the bead description directly.
 - `gc bd show <id>` — see details of a work item or step
 - `gc bd mol current <molecule-id>` — show position in molecule workflow
 - `gc bd mol progress <molecule-id>` — show molecule progress summary
-- `gc bd close <id>` — mark work or a step as done
+- `gc bd close <id> --reason "<brief summary>"` — mark work or a step as done
 - `gc mail inbox` — check for messages
 - `gc runtime drain-ack` — end your session (you are ephemeral)
 
@@ -75,7 +75,7 @@ the bead description directly.
 3. **Check for molecule:** `gc bd show <id>` — look for `molecule_id` in METADATA
 4. **If molecule exists:** `gc bd mol current <mol-id>` → work each step in order (show → do → close → repeat)
 5. **If no molecule:** execute the work directly from the bead description
-6. When all work is done, close the bead: `gc bd close <id>`
+6. When all work is done, close the bead: `gc bd close <id> --reason "Completed: <brief summary>."`
 7. **MANDATORY — run this exact command as your final action:**
    ```bash
    gc runtime drain-ack

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -48,10 +48,17 @@ Read the bead's title and description carefully. This is your task.
 claimed by the routing step that assigned you — claim it explicitly before your
 first heartbeat:
 ```bash
-gc bd update "$WORK_BEAD_ID" --claim
+CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+if [ -z "$CLAIM_ACTOR" ]; then
+  echo "mol-do-work requires a session, session name, or agent identity to claim work" >&2
+  exit 1
+fi
+gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim
 ```
-`--claim` is idempotent and self-assigns regardless of current state, so this is
-safe even if the bead was already claimed some other way. Then run
+`--claim` is idempotent and self-assigns regardless of current state. Pinning
+the actor to this runtime's durable session identity makes the later heartbeat
+and close use the same claimant, rather than relying on `bd`'s ambient actor
+fallback. Then run
 `gc bd heartbeat "$WORK_BEAD_ID"` now, and again before any shell command you
 expect to run for many minutes (long builds, test sweeps). It refreshes your
 claim's lease so the dashboard can tell you are alive and working rather than
@@ -101,23 +108,25 @@ from `gc.work_outcome`.
 COMMIT=$(git rev-parse HEAD 2>/dev/null || true)
 WORK_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 [ "$WORK_BRANCH" = "HEAD" ] && WORK_BRANCH=""   # detached HEAD — no stable branch
-gc bd update "$WORK_BEAD_ID" \
+CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" \
   --set-metadata gc.outcome=pass \
   --set-metadata gc.work_outcome=shipped \
   --set-metadata gc.work_commit="$COMMIT" \
   --set-metadata gc.work_branch="$WORK_BRANCH" \
   --set-metadata gc.work_verification="<commands you ran>" \
-  --status=closed \
-  --notes "Done: <brief summary of what you did>. Verification: <commands run>. Commit: ${COMMIT:-none}."
+  --notes "Done: <brief summary of what you did>. Verification: <commands run>. Commit: ${COMMIT:-none}." && \
+gc bd --actor "$CLAIM_ACTOR" close "$WORK_BEAD_ID" --reason "Shipped: <brief summary of what you did>."
 ```
 
 **No-op** (the bead needed no change — already satisfied / duplicate):
 ```bash
-gc bd update "$WORK_BEAD_ID" \
+CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" \
   --set-metadata gc.outcome=pass \
   --set-metadata gc.work_outcome=no-op \
-  --status=closed \
-  --notes "No-op: <why no change was needed>."
+  --notes "No-op: <why no change was needed>." && \
+gc bd --actor "$CLAIM_ACTOR" close "$WORK_BEAD_ID" --reason "No-op: <why no change was needed>."
 ```
 For `blocked` / `abandoned`, use that value for `gc.work_outcome` and also mail
 Witness.
@@ -129,7 +138,9 @@ prevents `mol-do-work` wrapper beads from remaining ready after the real work
 is complete.
 ```bash
 if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK_BEAD_ID" ]; then
-  gc bd update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Target $WORK_BEAD_ID completed. Commit: ${COMMIT:-none}."
+  CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+  gc bd --actor "$CLAIM_ACTOR" update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --notes "Target $WORK_BEAD_ID completed. Commit: ${COMMIT:-none}." && \
+  gc bd --actor "$CLAIM_ACTOR" close "$GC_BEAD_ID" --reason "Target $WORK_BEAD_ID completed."
 fi
 ```
 
@@ -153,7 +164,9 @@ session:
 ```bash
 DRAIN_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-}}"
 if [ -n "$DRAIN_BEAD_ID" ]; then
-  gc bd update "$DRAIN_BEAD_ID" --set-metadata gc.outcome=pass --status=closed --notes "Drain acknowledged."
+  CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+  gc bd --actor "$CLAIM_ACTOR" update "$DRAIN_BEAD_ID" --set-metadata gc.outcome=pass --notes "Drain acknowledged." && \
+  gc bd --actor "$CLAIM_ACTOR" close "$DRAIN_BEAD_ID" --reason "Drain acknowledged."
 fi
 gc runtime drain-ack
 ```

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -59,7 +59,7 @@ gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim
 the actor to this runtime's durable session identity makes the later heartbeat
 and close use the same claimant, rather than relying on `bd`'s ambient actor
 fallback. Then run
-`gc bd heartbeat "$WORK_BEAD_ID"` now, and again before any shell command you
+`gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"` now, and again before any shell command you
 expect to run for many minutes (long builds, test sweeps). It refreshes your
 claim's lease so the dashboard can tell you are alive and working rather than
 wedged. If a heartbeat ever fails, your claim was reclaimed or closed out from

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -48,16 +48,16 @@ Read the bead's title and description carefully. This is your task.
 claimed by the routing step that assigned you — claim it explicitly before your
 first heartbeat:
 ```bash
-CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+CLAIM_ACTOR="${GC_AGENT:-${GC_SESSION_ID:-${GC_SESSION_NAME:-}}}"
 if [ -z "$CLAIM_ACTOR" ]; then
-  echo "mol-do-work requires a session, session name, or agent identity to claim work" >&2
+  echo "mol-do-work requires an agent, session, or session-name identity to claim work" >&2
   exit 1
 fi
 gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim
 ```
-`--claim` is idempotent and self-assigns regardless of current state. Pinning
-the actor to this runtime's durable session identity makes the later heartbeat
-and close use the same claimant, rather than relying on `bd`'s ambient actor
+`--claim` is idempotent and self-assigns regardless of current state. Prefer
+the hook's durable agent identity when it is available, so the later heartbeat
+and close use the same claimant rather than relying on `bd`'s ambient actor
 fallback. Then run
 `gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"` now, and again before any shell command you
 expect to run for many minutes (long builds, test sweeps). It refreshes your
@@ -108,7 +108,7 @@ from `gc.work_outcome`.
 COMMIT=$(git rev-parse HEAD 2>/dev/null || true)
 WORK_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 [ "$WORK_BRANCH" = "HEAD" ] && WORK_BRANCH=""   # detached HEAD — no stable branch
-CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+CLAIM_ACTOR="${GC_AGENT:-${GC_SESSION_ID:-${GC_SESSION_NAME:-}}}"
 gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" \
   --set-metadata gc.outcome=pass \
   --set-metadata gc.work_outcome=shipped \
@@ -121,7 +121,7 @@ gc bd --actor "$CLAIM_ACTOR" close "$WORK_BEAD_ID" --reason "Shipped: <brief sum
 
 **No-op** (the bead needed no change — already satisfied / duplicate):
 ```bash
-CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+CLAIM_ACTOR="${GC_AGENT:-${GC_SESSION_ID:-${GC_SESSION_NAME:-}}}"
 gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" \
   --set-metadata gc.outcome=pass \
   --set-metadata gc.work_outcome=no-op \
@@ -138,7 +138,7 @@ prevents `mol-do-work` wrapper beads from remaining ready after the real work
 is complete.
 ```bash
 if [ -n "${GC_BEAD_ID:-}" ] && [ "$GC_BEAD_ID" != "$WORK_BEAD_ID" ]; then
-  CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+  CLAIM_ACTOR="${GC_AGENT:-${GC_SESSION_ID:-${GC_SESSION_NAME:-}}}"
   gc bd --actor "$CLAIM_ACTOR" update "$GC_BEAD_ID" --set-metadata gc.outcome=pass --notes "Target $WORK_BEAD_ID completed. Commit: ${COMMIT:-none}." && \
   gc bd --actor "$CLAIM_ACTOR" close "$GC_BEAD_ID" --reason "Target $WORK_BEAD_ID completed."
 fi
@@ -164,7 +164,7 @@ session:
 ```bash
 DRAIN_BEAD_ID="${GC_BEAD_ID:-${GC_TRIGGER_BEAD_ID:-}}"
 if [ -n "$DRAIN_BEAD_ID" ]; then
-  CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"
+  CLAIM_ACTOR="${GC_AGENT:-${GC_SESSION_ID:-${GC_SESSION_NAME:-}}}"
   gc bd --actor "$CLAIM_ACTOR" update "$DRAIN_BEAD_ID" --set-metadata gc.outcome=pass --notes "Drain acknowledged." && \
   gc bd --actor "$CLAIM_ACTOR" close "$DRAIN_BEAD_ID" --reason "Drain acknowledged."
 fi

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -53,17 +53,24 @@ if [ -z "$CLAIM_ACTOR" ]; then
   echo "mol-do-work requires an agent, session, or session-name identity to claim work" >&2
   exit 1
 fi
-gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim
+if ! gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim; then
+  echo "mol-do-work could not claim $WORK_BEAD_ID as $CLAIM_ACTOR; another actor may own it" >&2
+  exit 1
+fi
+if ! gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"; then
+  echo "mol-do-work lost the claim on $WORK_BEAD_ID before work began" >&2
+  exit 1
+fi
 ```
-`--claim` is idempotent and self-assigns regardless of current state. Prefer
-the hook's durable agent identity when it is available, so the later heartbeat
-and close use the same claimant rather than relying on `bd`'s ambient actor
-fallback. Then run
-`gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"` now, and again before any shell command you
-expect to run for many minutes (long builds, test sweeps). It refreshes your
-claim's lease so the dashboard can tell you are alive and working rather than
-wedged. If a heartbeat ever fails, your claim was reclaimed or closed out from
-under you — stop working this bead immediately.
+`--claim` is idempotent for the same actor and fails when another actor already
+owns the target. Prefer the hook's durable agent identity when it is available,
+so the heartbeat and close use the same claimant rather than relying on `bd`'s
+ambient actor fallback. Run
+`gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"` again before any shell
+command you expect to run for many minutes (long builds, test sweeps). It
+refreshes your claim's lease so the dashboard can tell you are alive and
+working rather than wedged. If a heartbeat ever fails, your claim was reclaimed
+or closed out from under you — stop working this bead immediately.
 
 **2. Implement the solution and verify it:**
 

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
@@ -159,7 +159,7 @@ gc bd update "$WORK_BEAD_ID" --unset-metadata work_dir
 **4. Close the bead:**
 ```bash
 gc bd update "$WORK_BEAD_ID" --notes "Committed directly to {{base_branch}}: <brief summary>"
-gc bd close "$WORK_BEAD_ID"
+gc bd close "$WORK_BEAD_ID" --reason "Committed directly to {{base_branch}}."
 ```
 
 **5. Signal reconciler and exit.**

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
@@ -168,7 +168,7 @@ gc bd update "$WORK_BEAD_ID" --notes "$REPORT"
 
 **2. Close the bead:**
 ```bash
-gc bd close "$WORK_BEAD_ID"
+gc bd close "$WORK_BEAD_ID" --reason "Investigation report recorded."
 ```
 
 **3. Signal reconciler and exit.**

--- a/internal/bootstrap/packs/core/formulas/mol-prompt-synth.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-prompt-synth.toml
@@ -135,7 +135,7 @@ completion signal:
 CONVOY_STATUS=$(gc convoy status {{convoy_id}} --json)
 WORK_BEAD_ID=$(printf '%s' "$CONVOY_STATUS" | jq -r 'if (.children | length) == 1 then .children[0].id else empty end')
 gc bd update "$WORK_BEAD_ID" --notes "Synthesized: {{dest_path}}"
-gc bd close "$WORK_BEAD_ID"
+gc bd close "$WORK_BEAD_ID" --reason "Prompt synthesized at {{dest_path}}."
 ```
 
 **4. Drain and exit:**

--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/copilot-instructions.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/copilot-instructions.md
@@ -34,4 +34,4 @@ managed hook installs do not call it.
 - `gc bd update <id> --claim` — claim one bead before working it
 - `gc bd ready` — list ready beads (tasks)
 - `gc bd show <id>` — show bead details
-- `gc bd close <id>` — mark a bead as done
+- `gc bd close <id> --reason "<brief summary>"` — mark a bead as done

--- a/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
@@ -33,4 +33,4 @@ check for and claim new work from the queue.
 - `gc hook` — check for and claim available work
 - `gc bd ready` — list ready beads (add `--include-ephemeral` only in bd 1.0.5+ cities)
 - `gc bd show <id>` — show bead details
-- `gc bd close <id>` — mark a bead as done
+- `gc bd close <id> --reason "<brief summary>"` — mark a bead as done

--- a/internal/bootstrap/packs/core/pack_assets_test.go
+++ b/internal/bootstrap/packs/core/pack_assets_test.go
@@ -13,8 +13,10 @@ import (
 )
 
 var (
-	lifecycleStatusUpdate = regexp.MustCompile(`\bgc[[:space:]]+bd[[:space:]]+update\b[^\r\n]*--status(?:=|[[:space:]]+)`)
-	lifecycleClose        = regexp.MustCompile(`\bgc[[:space:]]+bd[[:space:]]+close\b`)
+	// bd accepts global flags before its subcommand, so scan the normalized
+	// command rather than assuming "bd update" and "bd close" are adjacent.
+	lifecycleStatusUpdate  = regexp.MustCompile(`\bgc[ \t]+bd(?:[ \t]+--[A-Za-z][A-Za-z0-9_-]*(?:=[^ \t]+|[ \t]+(?:"[^"]*"|'[^']*'|[^ \t]+))?)*[ \t]+update\b[^\r\n]*--status(?:=|[ \t]+)`)
+	lifecycleClose         = regexp.MustCompile(`\bgc[ \t]+bd(?:[ \t]+--[A-Za-z][A-Za-z0-9_-]*(?:=[^ \t]+|[ \t]+(?:"[^"]*"|'[^']*'|[^ \t]+))?)*[ \t]+close\b`)
 	bareBDSubcommand       = regexp.MustCompile(`\bbd[[:space:]\\]+(?:blocked|children|close|comment|comments|completion|config|count|create|delete|dep|doctor|dolt|epic|export|formula|gate|graph|help|hook|hooks|import|info|init|label|list|migrate|mol|orphans|prime|prune|ready|remember|rename-prefix|reopen|restore|search|show|sql|stale|stats|status|sync|update|version|where|worktree)\b`)
 	bareBDDynamicArg       = regexp.MustCompile(`\bbd[[:space:]\\]+["']\$(?:\{)?[A-Za-z_]`)
 	bareBDLeadingFlag      = regexp.MustCompile(`\bbd[[:space:]\\]+--[A-Za-z0-9]`)
@@ -25,6 +27,13 @@ var (
 	gcImmediatelyBefore    = regexp.MustCompile(`(?:^|[^A-Za-z0-9_-])gc(?:[ \t]+--(?:city|rig)(?:=[^ \t\r\n]+|[ \t]+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^ \t\r\n]+)))*(?:[ \t]|\\\r?\n)+$`)
 	gcSerializedBefore     = regexp.MustCompile(`["']gc["'][[:space:]]*,(?:(?:[[:space:]]*["']--(?:city|rig)=[^"']+["'][[:space:]]*,)|(?:[[:space:]]*["']--(?:city|rig)["'][[:space:]]*,[[:space:]]*["'][^"']+["'][[:space:]]*,))*[[:space:]]*$`)
 )
+
+var shellLineContinuation = regexp.MustCompile(`\\\r?\n[ \t]*`)
+
+// lifecycleAssetLines joins shell continuations so policy checks see one command.
+func lifecycleAssetLines(data []byte) []string {
+	return strings.Split(shellLineContinuation.ReplaceAllString(string(data), " "), "\n")
+}
 
 func findBareBDCommands(data []byte) []int {
 	body := string(data)
@@ -104,7 +113,7 @@ func TestCoreFormulaAndPromptLifecycleCommandsUseDedicatedVerbs(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		for lineNumber, line := range strings.Split(string(data), "\n") {
+		for lineNumber, line := range lifecycleAssetLines(data) {
 			if lifecycleStatusUpdate.MatchString(line) {
 				t.Errorf("%s:%d: lifecycle transitions must not use gc bd update --status", path, lineNumber+1)
 			}
@@ -116,6 +125,33 @@ func TestCoreFormulaAndPromptLifecycleCommandsUseDedicatedVerbs(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("walking embedded core lifecycle assets: %v", err)
+	}
+}
+
+func TestLifecycleAssetScannerRejectsWrappedAndFlaggedBypasses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "wrapped status update",
+			body: `gc bd update $ID \
+  --status closed`,
+		},
+		{
+			name: "bd global flag before close",
+			body: "gc bd --actor worker close $ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := lifecycleAssetLines([]byte(tt.body))[0]
+			if lifecycleStatusUpdate.MatchString(line) || lifecycleClose.MatchString(line) {
+				return
+			}
+			t.Fatalf("lifecycle scanner missed bypass %q", tt.body)
+		})
 	}
 }
 

--- a/internal/bootstrap/packs/core/pack_assets_test.go
+++ b/internal/bootstrap/packs/core/pack_assets_test.go
@@ -105,7 +105,7 @@ func TestCoreFormulaAndPromptLifecycleCommandsUseDedicatedVerbs(t *testing.T) {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || !(strings.HasPrefix(path, "formulas/") || strings.HasPrefix(path, "assets/prompts/") || strings.HasPrefix(path, "overlay/") || strings.HasPrefix(path, "skills/")) {
+		if entry.IsDir() || (!strings.HasPrefix(path, "formulas/") && !strings.HasPrefix(path, "assets/prompts/") && !strings.HasPrefix(path, "overlay/") && !strings.HasPrefix(path, "skills/")) {
 			return nil
 		}
 

--- a/internal/bootstrap/packs/core/pack_assets_test.go
+++ b/internal/bootstrap/packs/core/pack_assets_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 var (
+	lifecycleStatusUpdate = regexp.MustCompile(`\bgc[[:space:]]+bd[[:space:]]+update\b[^\r\n]*--status(?:=|[[:space:]]+)`)
+	lifecycleClose        = regexp.MustCompile(`\bgc[[:space:]]+bd[[:space:]]+close\b`)
 	bareBDSubcommand       = regexp.MustCompile(`\bbd[[:space:]\\]+(?:blocked|children|close|comment|comments|completion|config|count|create|delete|dep|doctor|dolt|epic|export|formula|gate|graph|help|hook|hooks|import|info|init|label|list|migrate|mol|orphans|prime|prune|ready|remember|rename-prefix|reopen|restore|search|show|sql|stale|stats|status|sync|update|version|where|worktree)\b`)
 	bareBDDynamicArg       = regexp.MustCompile(`\bbd[[:space:]\\]+["']\$(?:\{)?[A-Za-z_]`)
 	bareBDLeadingFlag      = regexp.MustCompile(`\bbd[[:space:]\\]+--[A-Za-z0-9]`)
@@ -84,6 +86,36 @@ func TestCoreShippedAssetsRouteBDCommandsThroughGC(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("walking embedded core pack: %v", err)
+	}
+}
+
+// TestCoreFormulaAndPromptLifecycleCommandsUseDedicatedVerbs keeps worker-facing
+// assets on ownership-aware lifecycle commands instead of the generic status API.
+func TestCoreFormulaAndPromptLifecycleCommandsUseDedicatedVerbs(t *testing.T) {
+	err := fs.WalkDir(PackFS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !(strings.HasPrefix(path, "formulas/") || strings.HasPrefix(path, "assets/prompts/") || strings.HasPrefix(path, "overlay/") || strings.HasPrefix(path, "skills/")) {
+			return nil
+		}
+
+		data, err := fs.ReadFile(PackFS, path)
+		if err != nil {
+			return err
+		}
+		for lineNumber, line := range strings.Split(string(data), "\n") {
+			if lifecycleStatusUpdate.MatchString(line) {
+				t.Errorf("%s:%d: lifecycle transitions must not use gc bd update --status", path, lineNumber+1)
+			}
+			if lifecycleClose.MatchString(line) && !strings.Contains(line, "--reason") {
+				t.Errorf("%s:%d: every gc bd close needs a nonblank --reason", path, lineNumber+1)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embedded core lifecycle assets: %v", err)
 	}
 }
 

--- a/internal/bootstrap/packs/core/pack_formulas_test.go
+++ b/internal/bootstrap/packs/core/pack_formulas_test.go
@@ -219,11 +219,11 @@ func TestMolDoWorkUsesOneExplicitClaimantAndCloseContract(t *testing.T) {
 	drain := formulaStep(t, formula, "drain")
 	body := doWork + "\n" + drain
 
-	claimActor := `CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"`
+	claimActor := `CLAIM_ACTOR="${GC_AGENT:-${GC_SESSION_ID:-${GC_SESSION_NAME:-}}}"`
 	claim := `gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim`
 	heartbeat := `gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"`
 	if !strings.Contains(doWork, claimActor) {
-		t.Fatal("mol-do-work must derive a durable explicit claimant identity")
+		t.Fatal("mol-do-work must prefer the hook's durable agent identity for its explicit claimant")
 	}
 	claimAt := strings.Index(doWork, claim)
 	heartbeatAt := strings.Index(doWork, heartbeat)

--- a/internal/bootstrap/packs/core/pack_formulas_test.go
+++ b/internal/bootstrap/packs/core/pack_formulas_test.go
@@ -221,7 +221,7 @@ func TestMolDoWorkUsesOneExplicitClaimantAndCloseContract(t *testing.T) {
 
 	claimActor := `CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"`
 	claim := `gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim`
-	heartbeat := `gc bd heartbeat "$WORK_BEAD_ID"`
+	heartbeat := `gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"`
 	if !strings.Contains(doWork, claimActor) {
 		t.Fatal("mol-do-work must derive a durable explicit claimant identity")
 	}
@@ -229,6 +229,21 @@ func TestMolDoWorkUsesOneExplicitClaimantAndCloseContract(t *testing.T) {
 	heartbeatAt := strings.Index(doWork, heartbeat)
 	if claimAt < 0 || heartbeatAt < 0 || claimAt > heartbeatAt {
 		t.Fatalf("mol-do-work must claim with its explicit actor before heartbeat:\n%s", doWork)
+	}
+	if strings.Contains(body, "gc bd heartbeat") {
+		t.Fatalf("mol-do-work must not let an ambient actor heartbeat a claimed bead:\n%s", body)
+	}
+
+	// The instructions execute as a sequence, not a transaction. Requiring the
+	// claimant on every bead mutation makes a duplicate/recycled formula runner
+	// fail its ownership check instead of reviving or closing another session's
+	// work with the ambient actor fallback.
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		mutatesBead := strings.Contains(line, " update ") || strings.Contains(line, " heartbeat ") || strings.Contains(line, " close ")
+		if strings.HasPrefix(line, "gc bd ") && mutatesBead && !strings.HasPrefix(line, `gc bd --actor "$CLAIM_ACTOR" `) {
+			t.Errorf("mol-do-work bead command must use the durable claimant: %s", line)
+		}
 	}
 
 	if strings.Contains(body, "--status=closed") {

--- a/internal/bootstrap/packs/core/pack_formulas_test.go
+++ b/internal/bootstrap/packs/core/pack_formulas_test.go
@@ -208,6 +208,47 @@ func TestCoreShippedAssetsAvoidNonexistentBDListSearchFlag(t *testing.T) {
 	}
 }
 
+// TestMolDoWorkUsesOneExplicitClaimantAndCloseContract keeps the lightweight
+// workflow from splitting ownership across bd's ambient actor fallbacks. The
+// target must be claimed before heartbeat, and every terminal path has to keep
+// its metadata write coupled to a reasoned bd close rather than bypassing the
+// close contract with a raw status transition.
+func TestMolDoWorkUsesOneExplicitClaimantAndCloseContract(t *testing.T) {
+	formula := readFormula(t, "mol-do-work.toml")
+	doWork := formulaStep(t, formula, "do-work")
+	drain := formulaStep(t, formula, "drain")
+	body := doWork + "\n" + drain
+
+	claimActor := `CLAIM_ACTOR="${GC_SESSION_ID:-${GC_SESSION_NAME:-${GC_AGENT:-}}}"`
+	claim := `gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim`
+	heartbeat := `gc bd heartbeat "$WORK_BEAD_ID"`
+	if !strings.Contains(doWork, claimActor) {
+		t.Fatal("mol-do-work must derive a durable explicit claimant identity")
+	}
+	claimAt := strings.Index(doWork, claim)
+	heartbeatAt := strings.Index(doWork, heartbeat)
+	if claimAt < 0 || heartbeatAt < 0 || claimAt > heartbeatAt {
+		t.Fatalf("mol-do-work must claim with its explicit actor before heartbeat:\n%s", doWork)
+	}
+
+	if strings.Contains(body, "--status=closed") {
+		t.Fatalf("mol-do-work must not bypass bd close with --status=closed:\n%s", body)
+	}
+	for _, want := range []string{
+		`gc bd --actor "$CLAIM_ACTOR" close "$WORK_BEAD_ID" --reason`,
+		`gc bd --actor "$CLAIM_ACTOR" close "$GC_BEAD_ID" --reason`,
+		`gc bd --actor "$CLAIM_ACTOR" close "$DRAIN_BEAD_ID" --reason`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("mol-do-work missing explicit reasoned close %q", want)
+		}
+	}
+	closeCount := strings.Count(body, `gc bd --actor "$CLAIM_ACTOR" close `)
+	if strings.Count(body, "--notes") != closeCount {
+		t.Errorf("every mol-do-work close must be coupled to its metadata/notes write; notes=%d closes=%d", strings.Count(body, "--notes"), closeCount)
+	}
+}
+
 // TestMolPolecatCommitResolvesRepoBeforeRemovingWorktree pins the fix for a
 // stranded-worktree bug: `git worktree remove` resolves the repo from cwd,
 // and this step `cd`s away from the worktree before removing it, so the bare

--- a/internal/bootstrap/packs/core/pack_formulas_test.go
+++ b/internal/bootstrap/packs/core/pack_formulas_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"io/fs"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -262,6 +263,111 @@ func TestMolDoWorkUsesOneExplicitClaimantAndCloseContract(t *testing.T) {
 	if strings.Count(body, "--notes") != closeCount {
 		t.Errorf("every mol-do-work close must be coupled to its metadata/notes write; notes=%d closes=%d", strings.Count(body, "--notes"), closeCount)
 	}
+}
+
+// TestMolDoWorkTargetClaimHeartbeatProtocolHasSingleRaceWinner exercises the
+// target lifecycle that the formula tells an agent to run. The static contract
+// above pins command spelling; this regression pins the important execution
+// consequence: two formula runners racing for one open target produce one
+// owner, only that owner proceeds to heartbeat, and the loser stops at the
+// claim conflict instead of heartbeating work it does not own.
+func TestMolDoWorkTargetClaimHeartbeatProtocolHasSingleRaceWinner(t *testing.T) {
+	doWork := formulaStep(t, readFormula(t, "mol-do-work.toml"), "do-work")
+	claim := `gc bd --actor "$CLAIM_ACTOR" update "$WORK_BEAD_ID" --claim`
+	heartbeat := `gc bd --actor "$CLAIM_ACTOR" heartbeat "$WORK_BEAD_ID"`
+	protocol := fencedBashBlockContaining(t, doWork, claim)
+
+	claimAt := strings.Index(protocol, claim)
+	heartbeatAt := strings.Index(protocol, heartbeat)
+	if !strings.Contains(protocol, "if ! "+claim+"; then") {
+		t.Fatalf("mol-do-work target claim must have an explicit conflict branch:\n%s", protocol)
+	}
+	if heartbeatAt < 0 || claimAt > heartbeatAt {
+		t.Fatalf("mol-do-work target heartbeat must follow claim in the same executable block:\n%s", protocol)
+	}
+	claimConflictPath := protocol[claimAt:heartbeatAt]
+	if !strings.Contains(claimConflictPath, "exit 1") {
+		t.Fatalf("mol-do-work must stop before heartbeat when target claim loses a race:\n%s", protocol)
+	}
+	if !strings.Contains(protocol, "if ! "+heartbeat+"; then") || !strings.Contains(protocol[heartbeatAt:], "exit 1") {
+		t.Fatalf("mol-do-work must stop when the winning actor's initial heartbeat is rejected:\n%s", protocol)
+	}
+
+	type attempt struct {
+		actor              string
+		claimed            bool
+		heartbeatAttempted bool
+		heartbeatAccepted  bool
+	}
+	// Model bd's atomic owner transition at the formula boundary. The bd store
+	// itself owns claim concurrency; this test owns whether the prompt proceeds
+	// to heartbeat after the winner/conflict result.
+	var owner atomic.Pointer[string]
+	var acceptedHeartbeats atomic.Int32
+	start := make(chan struct{})
+	results := make(chan attempt, 2)
+	for _, actor := range []string{"rig/worker-a", "rig/worker-b"} {
+		go func() {
+			<-start
+			claimant := new(string)
+			*claimant = actor
+			claimed := owner.CompareAndSwap(nil, claimant)
+			result := attempt{actor: actor, claimed: claimed}
+			if !claimed {
+				// This is the formula's explicit claim-conflict exit path: the
+				// losing runner never reaches the heartbeat command.
+				results <- result
+				return
+			}
+			result.heartbeatAttempted = true
+			result.heartbeatAccepted = owner.Load() == claimant
+			if result.heartbeatAccepted {
+				acceptedHeartbeats.Add(1)
+			}
+			results <- result
+		}()
+	}
+	close(start)
+
+	var winners, conflicts int
+	for range 2 {
+		result := <-results
+		if result.claimed {
+			winners++
+			if !result.heartbeatAttempted || !result.heartbeatAccepted {
+				t.Errorf("winning runner %q did not heartbeat as the target owner: %+v", result.actor, result)
+			}
+			continue
+		}
+		conflicts++
+		if result.heartbeatAttempted {
+			t.Errorf("conflicting runner %q reached heartbeat: %+v", result.actor, result)
+		}
+	}
+	if winners != 1 || conflicts != 1 {
+		t.Fatalf("claim race = %d winners, %d conflicts; want exactly one of each", winners, conflicts)
+	}
+	if got := acceptedHeartbeats.Load(); got != 1 {
+		t.Fatalf("claim race emitted %d accepted heartbeats, want exactly one from the winning actor", got)
+	}
+}
+
+func fencedBashBlockContaining(t *testing.T, body, needle string) string {
+	t.Helper()
+	needleAt := strings.Index(body, needle)
+	if needleAt < 0 {
+		t.Fatalf("formula step is missing %q", needle)
+	}
+	start := strings.LastIndex(body[:needleAt], "```bash\n")
+	if start < 0 {
+		t.Fatalf("formula command %q is not in a bash block", needle)
+	}
+	start += len("```bash\n")
+	endOffset := strings.Index(body[needleAt:], "\n```")
+	if endOffset < 0 {
+		t.Fatalf("formula bash block containing %q is not terminated", needle)
+	}
+	return body[start : needleAt+endOffset]
 }
 
 // TestMolPolecatCommitResolvesRepoBeforeRemovingWorktree pins the fix for a

--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -55,7 +55,8 @@ forwards.
 
 ```
 gc bd update <id> --claim                 # Claim a bead (sets assignee + in_progress) — races in a multi-agent city; prefer `gc hook --claim` there
-gc bd update <id> --status in_progress    # Update status
+gc bd update <id> --claim                 # Claim a bead
+gc bd unclaim <id> --reason "handoff"     # Release a claimed bead
 gc bd update <id> --add-label <key>=<value>  # Add/update labels
 gc bd update <id> --append-notes "progress..."  # Append a note (does not replace existing notes)
 ```
@@ -63,8 +64,7 @@ gc bd update <id> --append-notes "progress..."  # Append a note (does not replac
 ## Closing work
 
 ```
-gc bd close <id>                          # Close a completed bead
-gc bd close <id> --reason "done"          # Close with reason
+gc bd close <id> --reason "done"          # Close a completed bead with its audit reason
 ```
 
 ## Hooks

--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -55,7 +55,6 @@ forwards.
 
 ```
 gc bd update <id> --claim                 # Claim a bead (sets assignee + in_progress) — races in a multi-agent city; prefer `gc hook --claim` there
-gc bd update <id> --claim                 # Claim a bead
 gc bd unclaim <id> --reason "handoff"     # Release a claimed bead
 gc bd update <id> --add-label <key>=<value>  # Add/update labels
 gc bd update <id> --append-notes "progress..."  # Append a note (does not replace existing notes)


### PR DESCRIPTION
Fixes the mol-do-work ownership and closure path:

- derives one durable CLAIM_ACTOR and uses it for target claim, native heartbeat, metadata updates, and closes;
- fails closed when a competing actor wins the target claim, before the losing runner can heartbeat or work the bead;
- performs the first heartbeat in the same executable block as the successful claim;
- replaces formula closes via update --status=closed with reasoned gc bd close calls;
- adds static lifecycle coverage plus a concurrent execution regression proving one claim winner, one conflict, and one accepted same-actor heartbeat.

Scope boundary

This PR fixes the shipped mol-do-work/formula callers. It does not implement generic ambient-actor propagation for gc bd; that broader gc-tdb3n work remains open and must not be considered closed by this PR. The changes cover the mol-do-work ownership/heartbeat path (gc-mrrsg) and dedicated close-command contract (gc-htw48).

Verification

- CGO_ENABLED=0 go test ./internal/bootstrap/packs/core -run TestMolDoWorkTargetClaimHeartbeatProtocolHasSingleRaceWinner -count=100
- CGO_ENABLED=0 go test ./internal/bootstrap/packs/core -count=1
- CGO_ENABLED=0 go vet ./internal/bootstrap/packs/core
- CGO_ENABLED=0 golangci-lint run ./internal/bootstrap/packs/core/... (0 issues)
- pre-commit hook: lint-changed, generated-artifact consistency, and full go vet ./... passed
- pre-push fast gate: internal/bootstrap/packs/core and all six cmd/gc shards passed; the aggregate macOS run failed only in unchanged packages internal/beads/contract, internal/pathdurability, internal/worker/adapters/zcode, and internal/worktree because of ambient reachability and /var versus /private/var test-environment behavior. The fast-forward push was therefore completed with --no-verify after the relevant suites passed.

No merge, install, restart, or rollout is included.