### PR TITLE
fix(scale): prevent pool duplicate beside live named session

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -508,9 +508,11 @@ func buildDesiredStateWithSessionBeadsAt(
 			continue
 		}
 		namedSessionMode := ""
+		namedIdentity := ""
 		for j := range cfg.NamedSessions {
 			if cfg.NamedSessions[j].TemplateQualifiedName() == cfg.Agents[i].QualifiedName() {
 				namedSessionMode = cfg.NamedSessions[j].ModeOrDefault()
+				namedIdentity = cfg.NamedSessions[j].QualifiedName()
 				break
 			}
 		}
@@ -584,6 +586,17 @@ func buildDesiredStateWithSessionBeadsAt(
 			// work below; defaultNamedScaleTargets only preserves partial-query
 			// retention for configured named-session beads.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+			// A live on-demand named session already claims its routed work. Do not
+			// create a second pool slot beside that resident; retain the existing
+			// pool-demand path when the named session is asleep.
+			residentLive := false
+			if namedSessionMode != "always" && namedIdentity != "" {
+				if spec, ok := findNamedSessionSpec(cfg, cityName, namedIdentity); ok {
+					if info, has := findCanonicalNamedSessionInfo(bp.sessionBeads, spec); has && poolSessionIsLiveInfo(info) {
+						residentLive = true
+					}
+				}
+			}
 			if store != nil && !hasCustomScaleCheck {
 				ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
 				// mode='always': named session is unconditionally desired by the named
@@ -592,7 +605,7 @@ func buildDesiredStateWithSessionBeadsAt(
 				// singleton (namedWorkReady covers only direct Assignee beads, not
 				// gc.routed_to). Leave defaultNamedScaleTargets unchanged for both modes
 				// (partial-query retention).
-				if namedSessionMode != "always" {
+				if namedSessionMode != "always" && !residentLive {
 					defaultScaleTargets = append(defaultScaleTargets, ownTarget)
 					namedOnDemandTemplates[template] = true
 				}
@@ -612,7 +625,7 @@ func buildDesiredStateWithSessionBeadsAt(
 				// mirrors these probes only for partial-query retention bookkeeping.
 				if !storeScopedControlDispatcher && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 					cityTarget := defaultScaleCheckTarget{template: template, store: store, storeKey: "city"}
-					if namedSessionMode != "always" {
+					if namedSessionMode != "always" && !residentLive {
 						defaultScaleTargets = append(defaultScaleTargets, cityTarget)
 					}
 					defaultNamedScaleTargets = append(defaultNamedScaleTargets, cityTarget)

--- a/cmd/gc/build_desired_state_crew_dup_test.go
+++ b/cmd/gc/build_desired_state_crew_dup_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// TestBuildDesiredState_RoutedToLiveNamedSession_NoPoolDuplicate ensures routed
+// work does not create a pool slot alongside an already-live on-demand named
+// session. The resident session can claim the routed work itself; when it is
+// asleep, the existing scale-from-zero coverage retains the wake path.
+func TestBuildDesiredState_RoutedToLiveNamedSession_NoPoolDuplicate(t *testing.T) {
+	cfg, cityStore, rigStores, identity := newNoScaleCheckNamedBackingCity(t)
+
+	if _, err := cityStore.Create(beads.Bead{
+		ID:       "bead-city-1",
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": identity},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	liveNamed := beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Status: "open",
+		Metadata: map[string]string{
+			"configured_named_session":  "true",
+			"configured_named_identity": identity,
+			"configured_named_mode":     "on_demand",
+		},
+	}
+	snap := newSessionBeadSnapshot([]beads.Bead{liveNamed})
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, snap, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[identity]; got != 0 {
+		t.Fatalf("routed-to-LIVE-named-session registered pool demand = %d, want 0", got)
+	}
+	for key, tp := range result.State {
+		if tp.TemplateName == identity && tp.Alias != "" && tp.Alias != identity {
+			t.Fatalf("spawned pool duplicate %q beside the live named session %q", key, identity)
+		}
+	}
+}


### PR DESCRIPTION
## TL;DR

Prevent routed work from creating an ephemeral pool slot beside an already-live on-demand named session.

## Trigger

A routed, unassigned bead targeted at an on-demand named-session backing template was counted as generic pool demand even while that named session was live. This could materialize an additional pool slot for work the resident can claim itself.

## Behavior

- Given a live canonical on-demand named session and routed work for its backing template, when desired state is built, then generic pool demand is suppressed.
- Given the same named session is asleep, when routed work arrives, then the existing pool-demand path remains available to wake it.
- Given an always-on named session, when routed work arrives, then its existing behavior is unchanged.

## Safety

The guard applies only to a verified live canonical named session. It does not alter custom scale checks, direct assignee demand, or the sleeping-session wake path.

## Related work

- Supersedes the stale-head implementation in #4578; this successor is rebased on current `main` and retains the focused regression coverage.

## Scope

- `cmd/gc/build_desired_state.go`
- `cmd/gc/build_desired_state_crew_dup_test.go`

## Verification

- `go test -count=1 ./cmd/gc -run "^(TestBuildDesiredState_RoutedToLiveNamedSession_NoPoolDuplicate|TestBuildDesiredState_WarmNamedBackingRigPoolSeesCityStoreRoutedDemand|TestScaleFromZeroNamed)"`
- `go build ./...`
- `go vet ./...`