### PR TITLE
fix(dolt): require local remote for compact auto-selection

### DIFF
--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -889,14 +889,9 @@ remote_exists() {
     "SELECT COUNT(*) FROM dolt_remotes WHERE name = '$remote'"
 }
 
-single_remote_name() {
-  db="$1"
-  query_single_cell "$db" "remote probe failed" \
-    "SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"
-}
-
 # list_remotes emits one "name<TAB>url" line per configured remote, sorted by
-# name. The only current consumer is backup_remotes' scheme filter.
+# name. Consumed by select_remote's locality scan and backup_remotes' scheme
+# filter.
 list_remotes() {
   db="$1"
   out_tmp=$(mktemp)
@@ -944,18 +939,31 @@ select_remote() {
     printf '\n'
     return 0
   fi
-  if [ "$count" -eq 1 ]; then
-    single_remote_name "$db"
-    return $?
-  fi
 
-  origin_exists=$(remote_exists "$db" "origin") || return 1
-  if [ "$origin_exists" = "1" ]; then
-    printf 'origin\n'
+  remotes_tmp=$(mktemp)
+  if ! list_remotes "$db" > "$remotes_tmp"; then
+    rm -f "$remotes_tmp"
+    return 1
+  fi
+  local_pick=""
+  while read -r name url; do
+    [ -n "$name" ] || continue
+    case "$url" in
+      file://*)
+        local_pick="$name"
+        break
+        ;;
+    esac
+  done < "$remotes_tmp"
+  rm -f "$remotes_tmp"
+
+  if [ -n "$local_pick" ]; then
+    printf '%s\n' "$local_pick"
     return 0
   fi
-  printf 'compact: db=%s multiple remotes found without origin; set GC_DOLT_COMPACT_REMOTE — fail\n' \
-    "$db" >&2
+
+  printf 'compact: db=%s no local (file://) remote found among %s configured remotes; set GC_DOLT_COMPACT_REMOTE to override — fail\n' \
+    "$db" "$count" >&2
   return 1
 }
 

--- a/examples/bd/dolt/compact_backup_remotes_test.go
+++ b/examples/bd/dolt/compact_backup_remotes_test.go
@@ -14,7 +14,7 @@ import (
 func TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 
-	out, err := fixture.run(t, "backup_remote_reconcile", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	out, err := fixture.run(t, "backup_remote_reconcile", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500", "GC_DOLT_COMPACT_REMOTE=origin")
 	if err != nil {
 		t.Fatalf("compact should succeed with a reconcilable file:// backup remote: %v\n%s", err, out)
 	}
@@ -50,7 +50,7 @@ func TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin(t *testing.T) {
 func TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 
-	out, err := fixture.run(t, "backup_remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	out, err := fixture.run(t, "backup_remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500", "GC_DOLT_COMPACT_REMOTE=origin")
 	if err != nil {
 		t.Fatalf("a failed backup push must not fail the overall compact run: %v\n%s", err, out)
 	}
@@ -87,7 +87,7 @@ func TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush(t *testing.T) {
 func TestCompactScriptExcludesNonFileRemotesAndAuthoritativeFromBackupReconciliation(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 
-	out, err := fixture.run(t, "backup_remote_filters_non_file_and_authoritative", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	out, err := fixture.run(t, "backup_remote_filters_non_file_and_authoritative", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500", "GC_DOLT_COMPACT_REMOTE=origin")
 	if err != nil {
 		t.Fatalf("compact should succeed with a mixed-scheme remote set: %v\n%s", err, out)
 	}

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -514,7 +514,7 @@ set_hash() {
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin|backup_remote_reconcile|backup_remote_push_failure|backup_remote_filters_non_file_and_authoritative)
+      backup_remote_reconcile|backup_remote_push_failure|backup_remote_filters_non_file_and_authoritative)
         print_cell 1
         ;;
       *)
@@ -539,8 +539,11 @@ case "$query" in
       remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
         print_cell 1
         ;;
-      multiple_remotes_with_origin|multiple_remotes_no_origin)
+      multiple_remotes_with_origin|multiple_remotes_no_origin|multiple_remotes_local_beats_origin)
         print_cell 2
+        ;;
+      remote_sole_non_local)
+        print_cell 1
         ;;
       explicit_backup_remote)
         print_cell 1
@@ -557,22 +560,23 @@ case "$query" in
     esac
     exit 0
     ;;
-  *"SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"*)
-    case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
-        print_cell origin
-        ;;
-      explicit_backup_remote)
-        print_cell backup
-        ;;
-      *)
-        print_cell ""
-        ;;
-    esac
-    exit 0
-    ;;
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     case "$mode" in
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
+        print_remote_rows origin "file:///data/beads"
+        ;;
+      remote_sole_non_local)
+        print_remote_rows origin "https://example.test/beads"
+        ;;
+      multiple_remotes_with_origin)
+        print_remote_rows mirror "https://mirror.test/beads" origin "file:///data/beads"
+        ;;
+      multiple_remotes_no_origin)
+        print_remote_rows mirror "https://mirror.test/beads" hosted "https://hosted.test/beads"
+        ;;
+      multiple_remotes_local_beats_origin)
+        print_remote_rows backup "file:///data/backup/beads" origin "https://example.test/beads"
+        ;;
       backup_remote_reconcile|backup_remote_push_failure)
         print_remote_rows origin "https://example.test/beads" backup "file:///data/backup/beads"
         ;;
@@ -1470,8 +1474,8 @@ func TestCompactScriptFailsWhenMultipleRemotesLackOrigin(t *testing.T) {
 	if err == nil {
 		t.Fatalf("compact succeeded despite ambiguous remotes:\n%s", out)
 	}
-	if !strings.Contains(out, "multiple remotes found without origin") {
-		t.Fatalf("output missing ambiguous remote failure:\n%s", out)
+	if !strings.Contains(out, "no local (file://) remote found") {
+		t.Fatalf("output missing no-local-remote failure:\n%s", out)
 	}
 	data, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
@@ -1481,6 +1485,59 @@ func TestCompactScriptFailsWhenMultipleRemotesLackOrigin(t *testing.T) {
 		if strings.Contains(string(data), forbidden) {
 			t.Fatalf("ambiguous remotes must block compaction before %s:\n%s", forbidden, data)
 		}
+	}
+}
+
+// TestCompactScriptFailsWhenSoleRemoteIsNonLocal asserts that compact never
+// auto-selects the one and only configured remote unless it is a local
+// file:// path — a lone hosted "origin" must not silently become the compact
+// target without an explicit GC_DOLT_COMPACT_REMOTE override.
+func TestCompactScriptFailsWhenSoleRemoteIsNonLocal(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_sole_non_local", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite a sole non-local remote:\n%s", out)
+	}
+	if !strings.Contains(out, "no local (file://) remote found") {
+		t.Fatalf("output missing no-local-remote failure:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	for _, forbidden := range []string{"DOLT_FETCH", "DOLT_RESET", "DOLT_PUSH"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("a sole non-local remote must never be auto-selected or pushed to before %s:\n%s", forbidden, data)
+		}
+	}
+}
+
+// TestCompactScriptPrefersLocalRemoteOverNonLocalOrigin asserts that
+// select_remote's locality policy beats name-based preference: when "origin"
+// is configured but is not a local file:// remote, and another candidate is
+// local, compact selects and pushes to the local candidate instead of origin.
+func TestCompactScriptPrefersLocalRemoteOverNonLocalOrigin(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "multiple_remotes_local_beats_origin", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact failed with a local remote available among multiple remotes: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote=backup") {
+		t.Fatalf("output missing local remote selection:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "DOLT_FETCH('backup')") {
+		t.Fatalf("compact did not fetch the local remote:\n%s", log)
+	}
+	if !strings.Contains(log, "DOLT_PUSH('--force', '--set-upstream', 'backup', 'main')") {
+		t.Fatalf("compact did not push the local remote:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_FETCH('origin')") || strings.Contains(log, "'origin', 'main'") {
+		t.Fatalf("compact must never select the non-local origin remote when a local candidate exists:\n%s", log)
 	}
 }
 

--- a/release-gates/ga-dw2u8w-compact-local-remote-selection-gate.md
+++ b/release-gates/ga-dw2u8w-compact-local-remote-selection-gate.md
@@ -1,0 +1,78 @@
+# Release Gate: Compact Local Remote Selection
+
+- Deploy bead: `ga-dw2u8w`
+- Build bead: `ga-cr66lk`
+- Review bead: `ga-s40eru`
+- Reviewed commit: `5d06034de2cb7dc5bc5f8af59b97912eee287e91`
+- Base: `origin/main@7cf9c8b3fb0bb03dac7cc89683a5f1883a641c6c`
+- Deploy mode: remote
+- Deploy branch: `deploy/ga-dw2u8w-gate`
+- Verdict: **PASS**
+
+The reviewed change removes count- and name-based automatic remote selection
+from the Dolt compact command. An explicit operator override remains
+authoritative; without one, compact selects only the first name-sorted
+`file://` remote and refuses when no local remote exists.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-s40eru` records `REVIEW VERDICT: PASS` on exact commit `5d06034de2cb7dc5bc5f8af59b97912eee287e91`. |
+| 2 | Acceptance criteria met | PASS | `select_remote` now implements override -> first sorted local `file://` remote -> refusal. Tests cover a sole non-local remote and a non-local `origin` alongside a local candidate. The deliberately broader multi-local/backup-eligibility policy remains tracked separately by open P1 `ga-ubowno`. |
+| 3 | Tests pass | PASS | The canonical isolated 40-job run had 38 jobs exit 0 and two non-diff-owned failures attributed below. All seven added/modified behavioral tests passed by exact name. Policy, build, vet, lint, format, docs, and native-DoltLite gates passed. |
+| 4 | No high-severity review findings open | PASS | Review records no findings; security, spec, scope, and consistency checks all passed. |
+| 5 | Final branch is clean | PASS | The detached candidate worktree was clean before this checklist was written. Hooks are active at `/home/jaword/projects/gascity/.githooks`. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first. Candidate is exactly 2 commits ahead and 0 behind current `origin/main`; `git merge-tree --write-tree origin/main 5d06034de2cb7dc5bc5f8af59b97912eee287e91` exited 0 with tree `5231172b689f45c05f21472033c46c2674960078`; `git diff --check` passed. No PR already carries the reviewed SHA. |
+| 7 | Single feature theme | PASS | Three files, +99/-34, all confined to compact remote selection and its test fixture/coverage under `examples/bd/dolt`. |
+
+## Criterion 3 evidence
+
+The first full-suite invocation was invalid harness evidence: the caller-supplied
+log directory did not yet exist, so all jobs failed before test execution. It was
+discarded. The canonical rerun created the dedicated directory first and used:
+
+`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=2 LOCAL_TEST_LOG_DIR=/var/tmp/gc-deploy-ga-dw2u8w-eval-logs make test-local-full-parallel`
+
+`test_counts`:
+
+- Full-suite wrapper jobs: 38 PASS, 2 FAIL, 0 SKIP.
+- Diff-owned behavioral tests: 7 PASS, 0 FAIL, 0 SKIP.
+
+`diff_tests_executed`:
+
+- `TestCompactScriptFailsWhenSoleRemoteIsNonLocal`: PASS
+- `TestCompactScriptPrefersLocalRemoteOverNonLocalOrigin`: PASS
+- `TestCompactScriptFailsWhenMultipleRemotesLackOrigin`: PASS
+- `TestCompactScriptPrefersOriginWhenMultipleRemotesExist`: PASS
+- `TestCompactScriptReconcilesFileBackupRemoteAlongsideOrigin`: PASS
+- `TestCompactScriptIsolatesBackupPushFailureFromPrimaryPush`: PASS
+- `TestCompactScriptExcludesNonFileRemotesAndAuthoritativeFromBackupReconciliation`: PASS
+
+`failure_attribution`:
+
+- `TestSessionEventsLive` -> `ga-vkhfnj` | mechanism proof: the candidate changes only a shell script and Go tests in `examples/bd/dolt`; none is compiled into or invoked by `internal/runtime/herdr`. The tracker predates this run, covers the exact `getAgent evt-a: ok=false err=<nil>` signature, the failing test is not diff-owned, and there is no path overlap.
+- `TestBdFlagManifestCurrent` -> `ga-he29xi` | mechanism proof: installed-CLI flag discovery in `internal/bdflags` cannot execute the compact shell script or its package tests. The PR-audit tracker predates this run and covers the exact manifest drift; the failing test is not diff-owned and there is no path overlap.
+
+The diff adds two tests inside an already-covered package, but the attribution
+protocol's inconclusive guard is not reached: direct mechanism proof settles both
+failures before that branch.
+
+Additional required gates:
+
+- `go test -json -count=1 ./examples/bd/dolt/...` with exact-name filtering — all seven names above PASS; package command exited 0.
+- `make test-ci-policy check-gomod-replace check-native-dependency-surface check-eventexport-isolation check-core-boundary test-native-doltlite-beads check-docs` — PASS.
+- `go build ./...` — PASS.
+- `make vet` — PASS.
+- `GOLANGCI_LINT_CACHE=<fresh on-disk cache> make lint` — PASS, 0 issues.
+- `make fmt-check` — PASS.
+- `shellcheck -S warning examples/bd/dolt/commands/compact/run.sh` — three inherited warnings (`SC1083`, `SC2254`, `SC2034`), identical to `origin/main`; no diff-introduced warning.
+
+`waiver_ref`: none.
+
+`ci_lane_run`: n/a — no CI configuration changed.
+
+## Disposition
+
+Proceed from exact reviewed SHA `5d06034de2cb7dc5bc5f8af59b97912eee287e91`
+on isolated branch `deploy/ga-dw2u8w-gate`. Publish the deploy-clearance status
+on the gated head and route the pull request to mayor/mpr; the deployer does not
+merge.

--- a/release-gates/ga-dw2u8w-compact-local-remote-selection-gate.md
+++ b/release-gates/ga-dw2u8w-compact-local-remote-selection-gate.md
@@ -4,7 +4,7 @@
 - Build bead: `ga-cr66lk`
 - Review bead: `ga-s40eru`
 - Reviewed commit: `5d06034de2cb7dc5bc5f8af59b97912eee287e91`
-- Base: `origin/main@7cf9c8b3fb0bb03dac7cc89683a5f1883a641c6c`
+- Base: `origin/main@c7a92b25ebb100ccfd0f3a31cf2e865a5d7bfb1c`
 - Deploy mode: remote
 - Deploy branch: `deploy/ga-dw2u8w-gate`
 - Verdict: **PASS**
@@ -21,7 +21,7 @@ authoritative; without one, compact selects only the first name-sorted
 | 3 | Tests pass | PASS | The canonical isolated 40-job run had 38 jobs exit 0 and two non-diff-owned failures attributed below. All seven added/modified behavioral tests passed by exact name. Policy, build, vet, lint, format, docs, and native-DoltLite gates passed. |
 | 4 | No high-severity review findings open | PASS | Review records no findings; security, spec, scope, and consistency checks all passed. |
 | 5 | Final branch is clean | PASS | The detached candidate worktree was clean before this checklist was written. Hooks are active at `/home/jaword/projects/gascity/.githooks`. |
-| 6 | Branch diverges cleanly from main | PASS | Evaluated first. Candidate is exactly 2 commits ahead and 0 behind current `origin/main`; `git merge-tree --write-tree origin/main 5d06034de2cb7dc5bc5f8af59b97912eee287e91` exited 0 with tree `5231172b689f45c05f21472033c46c2674960078`; `git diff --check` passed. No PR already carries the reviewed SHA. |
+| 6 | Branch diverges cleanly from main | PASS | Evaluated first and refreshed before PR creation. Candidate is 2 commits ahead and 1 behind current `origin/main`; `git merge-tree --write-tree origin/main 5d06034de2cb7dc5bc5f8af59b97912eee287e91` exited 0 with tree `7f03ff3f4d0663ad6cb5b19a878d7e5aa2270832`; `git diff --check` passed. The new base commit changes only opencode/hooks files, with no overlap. No PR already carries the reviewed SHA. |
 | 7 | Single feature theme | PASS | Three files, +99/-34, all confined to compact remote selection and its test fixture/coverage under `examples/bd/dolt`. |
 
 ## Criterion 3 evidence


### PR DESCRIPTION
## Summary

- require compact auto-selection to choose only local `file://` remotes
- preserve `GC_DOLT_COMPACT_REMOTE` as the explicit override
- cover sole-nonlocal and nonlocal-origin/local-backup cases

## Test plan

- canonical 40-job local suite: 38 passed; 2 known non-diff-owned failures attributed to `ga-he29xi` and `ga-vkhfnj`
- exact changed behavior tests: 7/7 passed
- CI policy, build, vet, lint, format, docs, and native DoltLite gates passed

Beads: content `ga-dw2u8w`, build `ga-cr66lk`, review `ga-s40eru`.

Release evidence: `release-gates/ga-dw2u8w-compact-local-remote-selection-gate.md`.