### PR TITLE
fix(ci): macOS test portability — green the Mac lane

### DIFF
--- a/internal/pathdurability/durability_test.go
+++ b/internal/pathdurability/durability_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -272,7 +273,17 @@ func TestClassifyFailsOpen(t *testing.T) {
 
 // TestClassifyOnRealFilesystem exercises the real syscall probes rather than the
 // fake mount table, so a bug in the platform file cannot hide behind the double.
+//
+// Only Linux has those probes: probe_linux.go is `//go:build linux` and
+// probe_other.go covers `!linux` by answering errUnsupported, which is what
+// makes Classify fail open to Unknown on every other platform. The GOOS check
+// below mirrors exactly that build constraint. It deliberately does not skip on
+// a probe *error*, which on Linux is a real regression this test must still
+// catch — the platform coverage is the only thing being waived here.
 func TestClassifyOnRealFilesystem(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("no real durability probe on %s; Classify is contractually Unknown there", runtime.GOOS)
+	}
 	cityRoot := t.TempDir()
 
 	t.Run("same device as the city root", func(t *testing.T) {

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -9,12 +9,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/pathutil"
 	zcodeadapter "github.com/gastownhall/gascity/internal/worker/adapters/zcode"
 )
 
@@ -298,7 +300,11 @@ func (s *session) sendRaw(text string) {
 func (s *session) signal(sig syscall.Signal) {
 	s.t.Helper()
 	if err := syscall.Kill(-s.cmd.Process.Pid, sig); err != nil {
-		s.t.Fatalf("signal %v: %v", sig, err)
+		// An adapter that already died leaves a zombie process group, and
+		// signaling one reports EPERM on macOS rather than ESRCH — which reads
+		// as a permissions problem and hides the real story. Print what the
+		// adapter said before it went, which is where the cause actually is.
+		s.t.Fatalf("signal %v: %v\nadapter output so far:\n%s", sig, err, s.output())
 	}
 }
 
@@ -645,10 +651,23 @@ func TestDrainKeepsPartialTrailingLine(t *testing.T) {
 	time.Sleep(2500 * time.Millisecond)
 	s.sendRaw("\n")
 	time.Sleep(2500 * time.Millisecond)
+	// Surviving the drain is the assertion that must hold on every platform: an
+	// unbound $more here killed the adapter under `set -u` on bash 3.2, which
+	// is exactly the regression this test's own shape provokes.
 	if _, code := s.closeAndWait(); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
 
+	// *Keeping* the fragment, by contrast, is a bash 4.0 behavior: only there
+	// does a timed-out `read -t` save the partial line into the variable. bash
+	// 3.2 — what `#!/usr/bin/env bash` resolves to on stock macOS — consumes
+	// the fragment off the fd and discards it before the script regains
+	// control, so no adapter change can recover it. Gated by GOOS rather than
+	// by probing the shell because probing costs a subprocess, and the source
+	// resource ledger (test/test-resources.toml) ratchets those down, not up.
+	if runtime.GOOS == "darwin" {
+		return
+	}
 	joined := strings.Join(h.prompts(), "|")
 	if !strings.Contains(joined, "trailing line without a newline") {
 		t.Fatalf("partial trailing line was dropped; prompts = %q", h.prompts())
@@ -1017,7 +1036,12 @@ func TestExportMirrorAccumulatesTurns(t *testing.T) {
 	if export.Info.ID != "sess_mirror" {
 		t.Fatalf("info.id = %q, want sess_mirror", export.Info.ID)
 	}
-	if export.Info.Directory != h.workDir {
+	// The adapter reports the shell's $PWD, which bash derives from getcwd()
+	// because the harness hands it an env with no PWD to inherit — so it is the
+	// physical path. h.workDir is whatever t.TempDir() handed out, which on
+	// macOS is the /var symlink to the same directory. Same directory, two
+	// spellings: compare by path identity, not by string.
+	if !pathutil.SamePath(export.Info.Directory, h.workDir) {
 		t.Fatalf("info.directory = %q, want %q", export.Info.Directory, h.workDir)
 	}
 	if len(export.Messages) != 2 {

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -581,7 +581,21 @@ while :; do
     # Enter, so a 1s idle window closes the paste without splitting it. A
     # timed-out read still assigns whatever partial line arrived, so take it
     # before breaking — otherwise the tail of the last line is silently lost.
+    #
+    # Saving partial input on timeout is a bash 4.0 feature; bash 3.2 (still
+    # /bin/bash on stock macOS) returns from a timed-out read without touching
+    # the variable at all, having already consumed and discarded the fragment.
+    # Clearing it before every read is what makes the loop correct on both:
+    # bash >= 4 overwrites it with the fragment, bash 3.2 leaves the empty
+    # value and the branch below simply does not fire. Without this, $more is
+    # *unbound* on the first timed-out drain and `set -u` kills the whole
+    # adapter mid-prompt — on macOS that is every pane, on the first prompt.
+    # The 3.2 fragment itself is unrecoverable at this layer (the shell ate it
+    # before the script ran), so there it is dropped rather than misplaced;
+    # gc's own nudge always terminates its last line, so only a human pausing
+    # mid-line for longer than the drain window can hit it.
     while :; do
+        more=
         IFS= read -r -t "$DRAIN_TIMEOUT" more
         drain_rc=$?
         if (( drain_rc == 0 )); then

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -445,9 +445,21 @@ func TestEnsureManagedWorktreePersistsAndVerifiesProvenance(t *testing.T) {
 	if rep.Provenance == nil {
 		t.Fatal("Ensure report has nil provenance")
 	}
+	// Provenance.Path is contractually the *canonical* spec path:
+	// plannedProvenance runs it through canonicalPathAllowMissing so that
+	// identity comparison is not defeated by symlinks, exactly as
+	// canonicalCommonDir does for RepoIdentity. So the expectation has to be
+	// canonicalized by the same helper rather than compared to the raw temp
+	// path — on macOS t.TempDir() hands back the /var spelling of a directory
+	// whose canonical form is /private/var, and a raw compare reads that
+	// contract-honoring value as a mismatch.
+	wantPath, err := canonicalPathAllowMissing(wt)
+	if err != nil {
+		t.Fatalf("canonicalPathAllowMissing(%q): %v", wt, err)
+	}
 	if rep.Provenance.BeadID != spec.BeadID ||
 		rep.Provenance.StoreRef != spec.StoreRef ||
-		rep.Provenance.Path != wt ||
+		rep.Provenance.Path != wantPath ||
 		rep.Provenance.Branch != spec.Branch ||
 		rep.Provenance.BaseRef != base ||
 		rep.Provenance.BaseSHA == "" ||


### PR DESCRIPTION
Greens the Mac lane. `Mac / make test` has been failing on every PR with a
byte-identical set of 17 failures (run
[33333799933](https://github.com/gastownhall/gascity/actions/runs/33333799933),
job `Mac / make test`) — the failures are pre-existing on `main` and unrelated
to whatever PR they surface under.

15 of the 17 are fixed here. The other 2 are the `internal/runtime/herdr`
socket-path pair, already fixed by **#5771** — see *Dependency* below.

## Root causes

Three unrelated portability bugs, one per package.

### 1. `internal/worker/adapters/zcode` — 12 failures — **production bug**

The adapter script's prompt-drain loop read `$more` without ever initializing
it:

```bash
while :; do
    IFS= read -r -t "$DRAIN_TIMEOUT" more
    drain_rc=$?
    ...
    if [[ -n "$more" ]]; then line+=$'\n'"$more"; fi   # line 593
```

bash **4.0+** saves partial input into the variable when `read -t` times out,
so `$more` always existed and the omission was invisible on Linux. bash **3.2**
returns from a timed-out read without touching the variable at all. Under the
script's `set -u` that unbound expansion kills the shell — `zcode-repl: line
593: more: unbound variable`, exit 1.

macOS still ships bash 3.2 as `/bin/bash`, so `#!/usr/bin/env bash` resolves to
it there and the adapter **died on the first prompt of every pane**. That is a
dead pane, not a degraded one — precisely the failure mode the loop's
deliberate `set -uo pipefail` *without* `-e` exists to prevent.

This is fixed in production code, not accommodated in the test. The repo's
stated shell floor is bash 3.2 (`scripts/lib/harness-reap.sh`,
`scripts/push-gate-lock-lib.sh:130`, the core pack's
`cascade-nudge-on-blocker-close.sh`), and this adapter is shipped to run in a
user's pane on whatever bash that host provides. Clearing `more` before each
read is correct on both shells: bash >= 4 overwrites it with the fragment,
bash 3.2 leaves it empty and the append does not fire.

Nine of the twelve failures are direct consequences of that exit. Two more are
separate:

- **`TestExportMirrorAccumulatesTurns`** compared the adapter's reported
  directory to `t.TempDir()` by string. The adapter reports bash's `$PWD`,
  which is `getcwd()`-derived (the harness passes no `PWD` to inherit) and
  therefore physical, while macOS hands out the `/var` spelling of the same
  directory. Same directory, two spellings — now compared with
  `pathutil.SamePath`, the repo's existing helper for exactly this (it already
  collapses the darwin `/private` aliases).
- **`TestInterruptMidTurnContinuesTheLoop`** failed at `syscall.Kill` with
  `signal interrupt: operation not permitted`. This is downstream, not a
  separate bug: the adapter was already dead, and signalling a zombie process
  group reports EPERM on macOS rather than ESRCH. See *Verification* for how
  this was pinned. `session.signal` now prints the adapter's output when a kill
  fails, so a dead adapter stops masquerading as a permissions error.

### 2. `internal/pathdurability` — 2 entries / 1 test — skip-gated, justified

`TestClassifyOnRealFilesystem` asserts `Classify` returns `CityDevice` for a
path on the city root's device. That verdict requires a working `deviceID`, and
`deviceID` only exists on Linux: `probe_linux.go` is `//go:build linux` and
`probe_other.go` covers `!linux` by answering `errUnsupported`. On macOS the
test was asserting *against* the package's own documented fail-open contract —
`Classify` is supposed to answer `Unknown` where no probe exists — so it failed
for being right.

**This is the one test in this PR I could not fix, only gate.** The capability
genuinely does not exist on darwin; nothing short of writing a
`probe_darwin.go` would change that, which is a feature, not a CI fix. The skip
mirrors the build constraint exactly and gates on `GOOS`, **not** on a probe
error — a `deviceID` failure on Linux is a real regression and must still fail
the test rather than skip it.

### 3. `internal/worktree` — 1 failure — test-side

`Provenance.Path` is contractually the *canonical* spec path:
`plannedProvenance` runs it through `canonicalPathAllowMissing` so worktree
identity survives symlinked paths, the same treatment `canonicalCommonDir`
gives `RepoIdentity`. The test compared it to the raw `t.TempDir()` path, which
is only equal when the temp root contains no symlinks. On macOS it never does.

Canonicalizing the expectation with the same helper the production path uses
keeps the assertion strict — a `Path` that skipped canonicalization still fails
— rather than loosening it to a same-location compare.

## Verification

No macOS runner was available, so each fix was reproduced on Linux by
reconstructing the macOS condition, **with a control that fails differently**.
Mac CI on this PR is the end-to-end verifier.

**bash 3.2.** Built GNU bash 3.2.0 from source and put it first on `PATH` so
the adapter's shebang resolves to it.

- Semantics pinned directly, with bash 5.2 as the control:
  `{ printf 'a\npartial'; sleep 3; } | bash script` →
  bash 5.2: `rc=142 more=[partial]`; bash 3.2: `rc=1 more=[<UNBOUND>]`.
  A follow-up probe confirms bash 3.2 *discards* the fragment (a later read
  never sees it), so it is unrecoverable above the shell.
- **Control:** unpatched script under bash 3.2 on Linux reproduces **10 of the
  12** macOS failures, including `TestInterruptMidTurnContinuesTheLoop` — which
  on Linux surfaces as `only 0/2 turns completed` instead of EPERM, confirming
  the signal error is a macOS-specific *symptom* of the same dead adapter and
  not an independent capability gap.
- Patched script: whole package green under bash 3.2 **and** bash 5.2.

**Symlinked TMPDIR** (reconstructs `/var` → `/private/var`). Pointing `TMPDIR`
at a symlink reproduces `TestEnsureManagedWorktreePersistsAndVerifiesProvenance`
at the identical line with the identical message shape and `Path:` resolved
through the link; the fix clears it.

**`TestDrainKeepsPartialTrailingLine`** provokes exactly the regression this PR
fixes, so it keeps its survival assertion on every platform and gates only the
bash-4-only half. Verified across all three points of the matrix:

| | bash 5.2 | bash 3.2 |
|---|---|---|
| `GOOS=linux` (reality on Linux) | full assertion runs, **pass** | fragment assertion fails — artificial rig only, never a real configuration |
| darwin branch active (reality on Mac) | — | **whole package passes**, survival assertion enforced |

The bash-3.2 row of the middle cell is the useful one: `prompts = ["first
line"]` with **exit code 0**. The adapter completed the drain cleanly instead
of dying — the fix working — and only the fragment is absent, which is the
shell's doing.

**`pathdurability` skip** verified by inverting the condition, which skips as
intended.

### Why GOOS and not a shell probe

The first cut of this PR probed the shell's actual `read -t` behavior instead
of branching on GOOS — strictly more accurate, since a Mac with Homebrew bash 5
would then still run the assertion. It costs one `exec.Command`, and
`test/test-resources.toml` caught it:

```
Small resource census grew: scope=untagged resource=subprocess calls=423 (baseline 422)
```

That ledger's invariant is `untagged subprocess call/file totals cannot grow;
reductions must lower this baseline`, and raising it is an explicit policy
change requiring council review. Spending a ratchet increment — and a council
review — to buy accuracy on a configuration (macOS + Homebrew bash) where the
skip is merely conservative is a bad trade, and well outside this PR's remit.
GOOS it is. The Mac lane's own log confirms the runner resolves
`#!/usr/bin/env bash` to 3.2.

### Gates

- `go test -count=1 -race` green for all three packages, individually and
  combined.
- Also green under the symlinked-TMPDIR rig, and — for `zcode` — under bash 3.2
  and symlinked TMPDIR simultaneously (both macOS conditions at once).
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `shellcheck -s bash` on `zcode-repl`: no new findings vs. the pre-change
  baseline. `bash -n` clean under both 3.2 and 5.2.
- `GOOS=darwin GOARCH=arm64 go vet` on all three packages, since the darwin
  branches cannot be executed here.
- `.githooks/pre-commit` active and run for every commit; `.githooks/pre-push`
  (full `make test-fast-parallel`) green for the branch — including
  `TestRepositoryLedgerMatchesCensusAndDocumentation`.

## Dependency

The remaining 2 of the 17 — `TestSocketPathHonorsXDGConfigHomeOverHome` and
`TestSocketPathFallsBackToHomeConfigWhenXDGUnset` in `internal/runtime/herdr`
(`Library/Application Support` vs `.config`) — are **deliberately not touched
here**. They are fixed by **#5771**, which replaces `os.UserConfigDir()` with a
`herdrConfigRoot()` that applies XDG precedence on every platform. **The Mac
lane needs both this PR and #5771 to go fully green**; expect those two to stay
red here until #5771 lands.

## Risk

`zcode-repl` is the only production change and it is one line plus comments,
strictly widening the set of shells the adapter survives on — no behavior
change on bash >= 4, which is every Linux host in the fleet. The other two
changes are test-only.
