### PR TITLE
fix(opencode): register hooks only in gc-managed sessions

### DIFF
--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -27,7 +27,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const GC_OPENCODE_HOOK_VERSION = 7;
+const GC_OPENCODE_HOOK_VERSION = 8;
 const GC_BIN = process.env.GC_BIN || "gc";
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.
@@ -175,11 +175,6 @@ async function mirrorTranscript(directory, client, sessionID) {
 
 export default async function gascityPlugin({ directory, client }) {
   if (!managedSessionIdentityPresent()) {
-    // One line so an operator can tell "plugin inactive" from "plugin
-    // missing", then stay silent: this OpenCode instance is not gc-managed.
-    console.warn(
-      "gascity opencode plugin: no Gas City session identity in the environment; hooks disabled for this OpenCode instance",
-    );
     return {};
   }
   let cachedPrime = null;

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -13,6 +13,13 @@
 //     and inject the handoff confirmation into the compaction context
 //   - experimental.chat.system.transform → inject gc prime --hook, queued
 //     nudges, and unread mail into the system prompt for each turn
+//
+// OpenCode auto-discovers this file for EVERY OpenCode launch in the work
+// dir, including a developer's personal session started by hand. The plugin
+// therefore registers hooks only when gc's session identity is present in
+// the environment; otherwise every lifecycle call it would make is
+// guaranteed to fail (gc's session-facing commands require that identity)
+// and the failures surface as warnings in a session Gas City does not own.
 
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
@@ -20,7 +27,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const GC_OPENCODE_HOOK_VERSION = 6;
+const GC_OPENCODE_HOOK_VERSION = 7;
 const GC_BIN = process.env.GC_BIN || "gc";
 // GC_BIN is the explicit override. The fallback order matches Pi hooks so
 // sibling providers resolve the same installed gc before developer-local bins.
@@ -113,6 +120,22 @@ function sessionIDFromEvent(event) {
   );
 }
 
+// Mirrors gc's own hookHasManagedIdentity (cmd/gc/cmd_prime.go): the session
+// lifecycle seeds GC_SESSION_ID, GC_SESSION_NAME and GC_ALIAS into every
+// managed session's environment, and GC_AGENT/GC_TEMPLATE come from templated
+// starts. A process with none of these was not started by gc, so gc handoff
+// would exit 1 ("not in session context") and the injection commands would
+// return nothing.
+function managedSessionIdentityPresent() {
+  return [
+    "GC_SESSION_ID",
+    "GC_SESSION_NAME",
+    "GC_ALIAS",
+    "GC_AGENT",
+    "GC_TEMPLATE",
+  ].some((key) => String(process.env[key] || "").trim() !== "");
+}
+
 function providerSessionEnv(sessionID) {
   sessionID = String(sessionID || "");
   const env = { GC_PROVIDER_SESSION_ID_REQUIRED: "opencode" };
@@ -151,6 +174,14 @@ async function mirrorTranscript(directory, client, sessionID) {
 }
 
 export default async function gascityPlugin({ directory, client }) {
+  if (!managedSessionIdentityPresent()) {
+    // One line so an operator can tell "plugin inactive" from "plugin
+    // missing", then stay silent: this OpenCode instance is not gc-managed.
+    console.warn(
+      "gascity opencode plugin: no Gas City session identity in the environment; hooks disabled for this OpenCode instance",
+    );
+    return {};
+  }
   let cachedPrime = null;
 
   async function readPrime(force = false, extraEnv = {}) {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -34,7 +34,7 @@ var supported = []string{"claude", "codex", "gemini", "antigravity", "kiro", "op
 
 const (
 	managedPiHookVersion       = 7
-	managedOpenCodeHookVersion = 7
+	managedOpenCodeHookVersion = 8
 	managedMimoCodeHookVersion = 2
 	managedOmpHookVersion      = 2
 )

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -34,7 +34,7 @@ var supported = []string{"claude", "codex", "gemini", "antigravity", "kiro", "op
 
 const (
 	managedPiHookVersion       = 7
-	managedOpenCodeHookVersion = 6
+	managedOpenCodeHookVersion = 7
 	managedMimoCodeHookVersion = 2
 	managedOmpHookVersion      = 2
 )
@@ -299,7 +299,11 @@ func opencodeHookNeedsUpgrade(existing []byte) bool {
 		!strings.Contains(content, "GC_PROVIDER_SESSION_ID") ||
 		!strings.Contains(content, "GC_PROVIDER_SESSION_ID_REQUIRED") ||
 		// The child's stdin must be closed or gc blocks on it (#5562).
-		!strings.Contains(content, "pending.child.stdin?.end();") {
+		!strings.Contains(content, "pending.child.stdin?.end();") ||
+		// OpenCode loads the workdir plugin for human-launched sessions
+		// too; without the identity guard the plugin runs gc lifecycle
+		// commands in sessions gc does not manage.
+		!strings.Contains(content, "managedSessionIdentityPresent()") {
 		return true
 	}
 	for _, marker := range []string{

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1761,7 +1761,7 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 	opencodeHooks := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 7",
+		"const GC_OPENCODE_HOOK_VERSION = 8",
 		"managedSessionIdentityPresent()",
 		"pending.child.stdin?.end();",
 		`process.env.GC_BIN || "gc"`,
@@ -2169,7 +2169,7 @@ export default async function gascityPlugin() {
 		t.Fatal("stale OpenCode managed plugin was preserved; expected managed upgrade")
 	}
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 7",
+		"const GC_OPENCODE_HOOK_VERSION = 8",
 		"managedSessionIdentityPresent()",
 		"pending.child.stdin?.end();",
 		`process.env.GC_BIN || "gc"`,
@@ -2191,9 +2191,29 @@ export default async function gascityPlugin() {
 	}
 }
 
+func TestInstallOpenCodeHookUpgradesVersion7(t *testing.T) {
+	fs := fsys.NewFake()
+	const dst = "/work/.opencode/plugins/gascity.js"
+	if err := Install(fs, "/city", "/work", []string{"opencode"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	current := fs.Files[dst]
+	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 8"), []byte("GC_OPENCODE_HOOK_VERSION = 7"), 1)
+	fs.Files[dst] = stale
+	if err := Install(fs, "/city", "/work", []string{"opencode"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !bytes.Equal(fs.Files[dst], current) || opencodeHookVersion(string(fs.Files[dst])) != 8 {
+		t.Fatal("version 7 OpenCode plugin was not upgraded to current version 8 bytes")
+	}
+	if !bytes.Equal(fs.Files[dst+".bak"], stale) {
+		t.Fatal("version 7 OpenCode plugin backup does not match original bytes")
+	}
+}
+
 func TestOpenCodeHookNeedsUpgradeComparesParsedVersion(t *testing.T) {
 	current := []byte(`// Gas City hooks for OpenCode.
-const GC_OPENCODE_HOOK_VERSION = 7;
+const GC_OPENCODE_HOOK_VERSION = 8;
 const GC_BIN = process.env.GC_BIN || "gc";
 const PATH_PREFIX =
   "/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:";
@@ -2211,8 +2231,8 @@ GC_PROVIDER_SESSION_ID_REQUIRED;
 pending.child.stdin?.end();
 managedSessionIdentityPresent();
 `)
-	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 7"), []byte("GC_OPENCODE_HOOK_VERSION = 6"), 1)
-	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 7"), []byte("GC_OPENCODE_HOOK_VERSION = 8"), 1)
+	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 8"), []byte("GC_OPENCODE_HOOK_VERSION = 7"), 1)
+	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 8"), []byte("GC_OPENCODE_HOOK_VERSION = 9"), 1)
 	missingStderrLog := bytes.Replace(current, []byte("logRunStderr(stderr);\n"), nil, 1)
 	openStdin := bytes.Replace(current, []byte("pending.child.stdin?.end();\n"), nil, 1)
 	unguarded := bytes.ReplaceAll(current, []byte("managedSessionIdentityPresent"), []byte("somethingElse"))

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1761,7 +1761,8 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 	opencodeHooks := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 6",
+		"const GC_OPENCODE_HOOK_VERSION = 7",
+		"managedSessionIdentityPresent()",
 		"pending.child.stdin?.end();",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
@@ -2168,7 +2169,8 @@ export default async function gascityPlugin() {
 		t.Fatal("stale OpenCode managed plugin was preserved; expected managed upgrade")
 	}
 	for _, want := range []string{
-		"const GC_OPENCODE_HOOK_VERSION = 6",
+		"const GC_OPENCODE_HOOK_VERSION = 7",
+		"managedSessionIdentityPresent()",
 		"pending.child.stdin?.end();",
 		`process.env.GC_BIN || "gc"`,
 		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
@@ -2191,7 +2193,7 @@ export default async function gascityPlugin() {
 
 func TestOpenCodeHookNeedsUpgradeComparesParsedVersion(t *testing.T) {
 	current := []byte(`// Gas City hooks for OpenCode.
-const GC_OPENCODE_HOOK_VERSION = 6;
+const GC_OPENCODE_HOOK_VERSION = 7;
 const GC_BIN = process.env.GC_BIN || "gc";
 const PATH_PREFIX =
   "/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:";
@@ -2199,6 +2201,7 @@ function logRunFailure(args, directory, err) {}
 function logRunStderr(stderr) {}
 async function runWithWarning(directory, ...args) {}
 function providerSessionEnv(sessionID) {}
+function managedSessionIdentityPresent() {}
 "experimental.session.compacting";
 logRunStderr(stderr);
 runWithWarning(directory, "handoff", "--auto", "context cycle");
@@ -2206,11 +2209,13 @@ output.context.push(handoff);
 GC_PROVIDER_SESSION_ID;
 GC_PROVIDER_SESSION_ID_REQUIRED;
 pending.child.stdin?.end();
+managedSessionIdentityPresent();
 `)
-	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 5"), 1)
-	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 6"), []byte("GC_OPENCODE_HOOK_VERSION = 7"), 1)
+	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 7"), []byte("GC_OPENCODE_HOOK_VERSION = 6"), 1)
+	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 7"), []byte("GC_OPENCODE_HOOK_VERSION = 8"), 1)
 	missingStderrLog := bytes.Replace(current, []byte("logRunStderr(stderr);\n"), nil, 1)
 	openStdin := bytes.Replace(current, []byte("pending.child.stdin?.end();\n"), nil, 1)
+	unguarded := bytes.ReplaceAll(current, []byte("managedSessionIdentityPresent"), []byte("somethingElse"))
 
 	if !opencodeHookNeedsUpgrade(stale) {
 		t.Fatal("stale OpenCode hook version did not request upgrade")
@@ -2226,6 +2231,9 @@ pending.child.stdin?.end();
 	}
 	if !opencodeHookNeedsUpgrade(openStdin) {
 		t.Fatal("OpenCode hook leaving child stdin open did not request upgrade")
+	}
+	if !opencodeHookNeedsUpgrade(unguarded) {
+		t.Fatal("OpenCode hook without the unmanaged-session guard did not request upgrade")
 	}
 }
 

--- a/internal/hooks/opencode_plugin.test.mjs
+++ b/internal/hooks/opencode_plugin.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
+import test from "node:test";
+
+// Unmanaged factory calls must remain silent no-ops, even when repeatedly loaded.
+test("OpenCode factory is silent without identity and registers managed hooks", async () => {
+  const source = await readFile(new URL(
+    "../bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js",
+    import.meta.url,
+  ), "utf8");
+  const savedEnv = process.env;
+  const savedStdout = process.stdout.write;
+  const savedStderr = process.stderr.write;
+  const savedCommands = {};
+  const calls = [];
+  const stdout = [];
+  const stderr = [];
+  try {
+    for (const name of ["exec", "execSync", "execFile", "execFileSync", "spawn", "spawnSync", "fork"]) {
+      savedCommands[name] = childProcess[name];
+      childProcess[name] = (...args) => {
+        calls.push({ name, args });
+        throw new Error("unexpected subprocess call");
+      };
+    }
+    syncBuiltinESMExports();
+    process.env = {};
+    const { default: factory } = await import(
+      `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+    );
+    process.stdout.write = (chunk) => { stdout.push(String(chunk)); return true; };
+    process.stderr.write = (chunk) => { stderr.push(String(chunk)); return true; };
+    const identityKeys = ["GC_SESSION_ID", "GC_SESSION_NAME", "GC_ALIAS", "GC_AGENT", "GC_TEMPLATE"];
+    for (const env of [{}, Object.fromEntries(identityKeys.map((key) => [key, ""])), Object.fromEntries(identityKeys.map((key) => [key, " \t\n"]))]) {
+      process.env = env;
+      for (let i = 0; i < 3; i++) {
+        assert.deepEqual(await factory({ directory: "/unused", client: {} }), {});
+      }
+    }
+    assert.deepEqual(calls, [], "unmanaged factories must not launch subprocesses");
+    assert.deepEqual(stdout, [], "unmanaged factories must not write stdout");
+    assert.deepEqual(stderr, [], "unmanaged factories must not write stderr");
+
+    for (const key of identityKeys) {
+      process.env = { [key]: "managed-test-session" };
+      const hooks = await factory({ directory: "/unused", client: {} });
+      assert.deepEqual(Object.keys(hooks).sort(), [
+        "chat.message", "event", "experimental.chat.system.transform", "experimental.session.compacting",
+      ]);
+      for (const hook of Object.values(hooks)) assert.equal(typeof hook, "function");
+    }
+  } finally {
+    process.env = savedEnv;
+    process.stdout.write = savedStdout;
+    process.stderr.write = savedStderr;
+    Object.assign(childProcess, savedCommands);
+    syncBuiltinESMExports();
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #5787.

Gas City installs its OpenCode plugin into `{workDir}/.opencode/plugins/gascity.js`. OpenCode discovers that plugin for manual launches too, but those sessions do not belong to Gas City.

Previously, the plugin registered hooks unconditionally. Unmanaged sessions invoked `gc handoff --auto "context cycle"` during compaction and spawned `gc prime --hook`, `gc nudge drain --inject`, and `gc mail check --inject` during prompt processing. The handoff failed without session identity; the injection commands were already guarded on the CLI side but still spawned unnecessary subprocesses.

The plugin now checks the same identity variables as the CLI before registering hooks:

- `GC_SESSION_ID`
- `GC_SESSION_NAME`
- `GC_ALIAS`
- `GC_AGENT`
- `GC_TEMPLATE`

If all are missing, empty, or whitespace-only, it silently returns `{}`. No hooks, subprocesses, or startup warnings. A manual launch in a city directory is normal, not an error. Managed sessions retain their existing hooks.

The first revision logged a warning before returning. The follow-up removes it because it reported normal usage as a problem and could print repeatedly during initialization. The regression test exercises repeated factory calls rather than assuming one initialization per visible session.

The managed plugin version is now 8, up from 6 at the base of this PR. Version 7 copies from the first revision also upgrade. The installer still requires the identity-guard marker and preserves user-authored plugins.

## Testing

Passed on the updated PR branch:

- `node --test internal/hooks/opencode_plugin.test.mjs`: repeated missing, empty, and whitespace-only identities return no hooks, write no stdout/stderr, and spawn no subprocesses; each supported identity variable preserves the managed hook set.
- `go test -count=1 ./internal/hooks ./internal/bootstrap/packs/core`: includes version-7-to-8 upgrade and backup preservation coverage.
- `go test -count=1 ./examples/gastown -run "PreCompact|Hook"`
- Focused installer and version regression tests repeated with `-count=10`.
- `go vet ./internal/hooks ./internal/bootstrap/packs/core ./examples/gastown`
- Pre-commit checks, including lint, generated-document checks, and repository-wide `go vet ./...`.

The new tests failed before the implementation change and passed afterward. Go checks used the macOS ICU include/linker flags and isolated Git configuration where needed.

The full test suite was not rerun. The pre-push suite was bypassed per the local Mac workflow because of known Git-signing and herdr failures; pre-commit checks ran normally.

## Scope

This PR changes whether hooks register, not how managed-session injection works. It does not include the separate chat-message or per-turn injection changes from the integration branch. Overlapping plugin changes may require reconciling the version and installer markers when merged.