### PR TITLE
fix(beads): stop forcing unbounded bd list for issues-tier reads

### DIFF
--- a/cmd/gc/cmd_bd_store_bridge_test.go
+++ b/cmd/gc/cmd_bd_store_bridge_test.go
@@ -370,10 +370,9 @@ func TestBdStoreBridgeListCommandForwardsFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(args): %v", err)
 	}
-	// BdStore may need to merge and filter policy tiers client-side, so it
-	// requests all server-side candidates and applies the requested limit after
-	// parsing.
-	for _, want := range []string{"list", "--json", "--status=open", "--assignee=mayor", "--type=message", "--include-infra", "--include-gates", "--limit", "0"} {
+	// TierIssues + a single assignee has no Go-side-only residual filter, so
+	// BdStore pushes the caller's real limit straight to bd list (gc-i4j3y).
+	for _, want := range []string{"list", "--json", "--status=open", "--assignee=mayor", "--type=message", "--include-infra", "--include-gates", "--limit", "7"} {
 		if !strings.Contains(string(argsText), want) {
 			t.Fatalf("list args missing %q: %s", want, string(argsText))
 		}

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3306,7 +3306,7 @@ func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		call := name + " " + strings.Join(args, " ")
 		switch call {
-		case "bd list --json --label=parent-projection --include-infra --include-gates --limit 0":
+		case "bd list --json --label=parent-projection --include-infra --include-gates --limit 50":
 			return []byte(`[
 				{
 					"id":"ga-child",

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -2730,7 +2730,12 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 }
 
 func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssignees bool) bool {
-	if query.TierMode == TierIssues || query.TierMode == TierWisps {
+	// TierWisps always merges two independently-fetched legs (this bd-list
+	// leg plus the ephemeral leg in listWispsTier) and needs full candidates
+	// from both to union/dedupe/sort/limit correctly; TierIssues is the only
+	// tier reaching this function that reads a single, self-contained result
+	// set, so only it is eligible for a bd-side limit below.
+	if query.TierMode == TierWisps {
 		return true
 	}
 	if serverQuery.Sort == SortCreatedAsc || clientFilteredAssignees {
@@ -2744,6 +2749,12 @@ func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssig
 	// bd-side limit would cut rows before that filter runs — fetch unbounded
 	// and let applyListQuery filter then limit.
 	if serverQuery.SeekAfter != nil {
+		return true
+	}
+	// IDs is a Go-side-only residual filter (see ListQuery.Matches): bd list
+	// has no --id flag, so a bd-side limit could truncate before the
+	// matching IDs are even fetched.
+	if len(serverQuery.IDs) > 0 {
 		return true
 	}
 	return false

--- a/internal/beads/bdstore_storage_conformance_test.go
+++ b/internal/beads/bdstore_storage_conformance_test.go
@@ -331,10 +331,13 @@ func TestBdStoreListStorageTierConformance(t *testing.T) {
 			wantIDs: []string{"bd-history", "bd-no-history"},
 		},
 		{
-			name:                  "issues tier applies limit after client storage filtering",
-			query:                 beads.ListQuery{Label: "scope", Limit: 1},
-			wantIDs:               []string{"bd-history"},
-			wantUnlimitedPrelimit: true,
+			// gc-i4j3y: issues-tier bd list never returns ephemeral rows (no
+			// --include-templates), so the Go-side matchesTier filter is a
+			// no-op backstop here — a bounded caller Limit is safe to push
+			// down to bd list directly instead of forcing --limit 0.
+			name:    "issues tier applies limit after client storage filtering",
+			query:   beads.ListQuery{Label: "scope", Limit: 1},
+			wantIDs: []string{"bd-history"},
 		},
 		{
 			name:                  "wisps tier keeps no-history and ephemeral rows",

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2985,7 +2985,7 @@ func TestBdStoreListInfersParentFromParentChildDependency(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=real-world-app-contract --include-infra --include-gates --limit 0`: {
+		`bd list --json --label=real-world-app-contract --include-infra --include-gates --limit 50`: {
 			out: []byte(`[
 				{
 					"id":"bd-child",
@@ -3016,6 +3016,94 @@ func TestBdStoreListInfersParentFromParentChildDependency(t *testing.T) {
 	}
 	if got[0].ParentID != "bd-parent" {
 		t.Fatalf("ParentID = %q, want bd-parent", got[0].ParentID)
+	}
+}
+
+// TestBdStoreListPushesCallerLimitForIssuesTierDefaultSort pins the gc-i4j3y
+// fix: an issues-tier query with default ordering and none of the residual
+// Go-side filters must forward the caller's real Limit to bd list instead of
+// forcing an unbounded --limit 0 scan.
+func TestBdStoreListPushesCallerLimitForIssuesTierDefaultSort(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --label=bounded-caller --include-infra --include-gates --limit 7`: {
+			out: []byte(`[{"id":"bd-a","title":"a","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["bounded-caller"]}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{Label: "bounded-caller", Limit: 7})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "bd-a" {
+		t.Fatalf("got = %+v, want single bd-a", got)
+	}
+}
+
+// TestBdStoreListForcesUnboundedForIDs pins that ListQuery.IDs — a Go-side-
+// only residual filter bd list has no flag for — still forces --limit 0 so a
+// bd-side limit can never truncate before the ID match runs.
+func TestBdStoreListForcesUnboundedForIDs(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --label=bounded-caller --include-infra --include-gates --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-a","title":"a","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["bounded-caller"]},
+				{"id":"bd-b","title":"b","status":"open","issue_type":"task","created_at":"2026-05-02T00:00:00Z","labels":["bounded-caller"]}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{Label: "bounded-caller", Limit: 1, IDs: []string{"bd-b"}})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "bd-b" {
+		t.Fatalf("got = %+v, want single bd-b matched Go-side after unbounded fetch", got)
+	}
+}
+
+// TestBdStoreListPushesCallerLimitForSortCreatedDesc pins that a bare
+// SortCreatedDesc issues-tier query (no SeekAfter/Metadata/etc.) pushes the
+// caller's real Limit to bd list. Only paginated (SeekAfter-bearing) reads
+// need the unbounded fetch — see TestSeekGatesForceClientSideLimit, which
+// pins the same baseline at the gate-function level.
+func TestBdStoreListPushesCallerLimitForSortCreatedDesc(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --label=bounded-caller --include-infra --include-gates --limit 3`: {
+			out: []byte(`[{"id":"bd-a","title":"a","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["bounded-caller"]}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.List(beads.ListQuery{Label: "bounded-caller", Limit: 3, Sort: beads.SortCreatedDesc})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+// TestBdStoreListForcesUnboundedForSortCreatedAsc is the SortCreatedAsc twin
+// of TestBdStoreListForcesUnboundedForSortCreatedDesc, confirming the
+// pre-existing guard still holds under the relaxed TierIssues condition.
+func TestBdStoreListForcesUnboundedForSortCreatedAsc(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --label=bounded-caller --include-infra --include-gates --limit 0`: {
+			out: []byte(`[{"id":"bd-a","title":"a","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["bounded-caller"]}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.List(beads.ListQuery{Label: "bounded-caller", Limit: 1, Sort: beads.SortCreatedAsc})
+	if err != nil {
+		t.Fatalf("List: %v", err)
 	}
 }
 
@@ -3856,7 +3944,7 @@ func TestBdStoreListByLabel(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=order-run:digest --include-infra --include-gates --limit 0`: {
+		`bd list --json --label=order-run:digest --include-infra --include-gates --limit 5`: {
 			out: []byte(`[{"id":"bd-aaa","title":"digest wisp","status":"open","issue_type":"task","created_at":"2026-02-27T10:00:00Z","labels":["order-run:digest"]}]`),
 		},
 	})
@@ -3909,7 +3997,7 @@ func TestBdStoreListByLabelEmpty(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=order-run:none --include-infra --include-gates --limit 0`: {out: []byte(`[]`)},
+		`bd list --json --label=order-run:none --include-infra --include-gates --limit 1`: {out: []byte(`[]`)},
 	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.ListByLabel("order-run:none", 1)


### PR DESCRIPTION
## What

`bdListRequiresClientLimit` forced `--limit 0` for every issues-tier read, even
when the caller's own `Limit` was safe to push straight through to `bd list`.
Every such query fetched the whole table and discarded the tail in Go.

The force now applies only to the shapes that actually need it. A caller's limit
passes through when all of these hold: default or created-desc sort, no
`CreatedBefore`/`UpdatedBefore`, no metadata filter, no seek pagination, no ID
list, and at most one assignee. None of those calls carry a Go-side residual
filter that could drop rows before a bd-side limit truncates them: the underlying
list never returns ephemeral rows, and the issues-tier filter is a no-op against
what it does return.

## What is deliberately unchanged

The wisps tier keeps the unconditional force. Its list leg reads with
`--include-templates`, which returns ordinary issues that the Go-side tier filter
(`Ephemeral || NoHistory`) then discards, so a server-side limit there would
silently under-fetch. Bounding it needs a paged loop, because the list command
has no compound seek flag. `internal/config/workquery.go:92` carries the same
open-ended shape for the same reason. Both surfaces are one decision and are
tracked together in #5789.

## Test plan

- New table cases in `internal/beads/bdstore_test.go` cover each pass-through
  condition and each condition that still forces the unbounded read.
- Full suites pass: `internal/beads`, `internal/orders`, `internal/molecule`,
  `internal/mail/beadmail`, `internal/nudgequeue`, `internal/api`,
  `examples/gastown`, and all of `cmd/gc`.
- `go vet ./...` and lint on the changed files are clean.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2655 — bounds one source of the unbounded active-bead list scans described there: gc's bd-list wrapper no longer forces `--limit 0` on every issues-tier read, so a caller's own limit is pushed down to bd instead of the whole table being fetched and trimmed in Go. It does not add the indexed active-read path that issue proposes, and the wisps-tier list leg plus the open-ended work-query read stay unbounded (tracked separately).
- Related to #3253 — removes the unconditional unbounded `bd list --limit 0` on issues-tier reads, so the bounded first-page molecule query in the beads(all=true) path can push its caller limit down to a bd-backed store instead of having it overridden; the formulas/feed path is untouched — its closed-history metadata query still forces the full scan — as are seeked cursor pages and the wisps tier
- Related to #4246 — removes the forced unbounded `bd list --limit 0` for issues-tier reads whose caller already supplies a safe limit, trimming part of the BdStore scan cost described there; it does not add the change-detection, caching, batching, or backoff that issue asks for, and the ephemeral/wisps legs and supervisor `--all` scans it measures are deliberately left unchanged

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->