### PR TITLE
fix(doctor): recover panics in Check.Fix and pin the Wait contract

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -431,6 +431,12 @@ func doDoctor(fix, verbose, jsonOut bool, checkTimeout time.Duration, stdout, st
 		return 1
 	}
 
+	// Deliberately no d.Wait() here: gc doctor's whole point in bounding a check
+	// is that a wedged one cannot stall the command, and waiting on an abandoned
+	// goroutine would restore exactly that hang. Nothing this function owns
+	// outlives the process, and ctx holds no handle a late writer can corrupt --
+	// an abandoned check writes only to its own private buffer. A future caller
+	// that reuses a Doctor in-process must call Wait before releasing ctx.
 	d := &doctor.Doctor{CheckTimeout: checkTimeout}
 	ctx := &doctor.CheckContext{CityPath: cityPath, Verbose: verbose}
 	cfg, cfgErr := loadCityConfig(cityPath, stderr)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -58,6 +58,11 @@ func (d *Doctor) Register(c Check) {
 // Wait blocks until every timed execution started by prior Run or RunCollect
 // calls has finished. Callers that release resources used by checks must call
 // Wait after the run returns and before releasing those resources.
+//
+// A Doctor serves one run at a time: Wait must not be called concurrently with
+// Run or RunCollect on another goroutine. Concurrent use would let a run's
+// inFlight.Add race a Wait that has already observed a zero counter, so Wait
+// could return while a timed execution still owns caller resources.
 func (d *Doctor) Wait() {
 	d.inFlight.Wait()
 }
@@ -198,6 +203,18 @@ func runCheckRecoveringPanic(c Check, ctx *CheckContext) (result *CheckResult) {
 	return c.Run(ctx)
 }
 
+// runFixRecoveringPanic converts a panic in a check's Fix into an error. Fix
+// runs pack-authored remediation, so a panic there must fail the one check
+// rather than take down the whole doctor process.
+func runFixRecoveringPanic(c Check, ctx *CheckContext) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("fix for %s panicked: %v", c.Name(), recovered)
+		}
+	}()
+	return c.Fix(ctx)
+}
+
 // fixAndVerify remediates a failing, fixable check and re-runs it to confirm,
 // bounding both the fix and the verifying re-run under the per-check timeout.
 // It returns the result to report (res mutated in place on fix failure, or the
@@ -242,7 +259,7 @@ func (d *Doctor) fixAndVerify(c Check, ctx *CheckContext, res *CheckResult) (*Ch
 // otherwise Fix's own error (or nil) is returned.
 func (d *Doctor) boundedFix(c Check, ctx *CheckContext) error {
 	if d.CheckTimeout <= 0 {
-		return c.Fix(ctx)
+		return runFixRecoveringPanic(c, ctx)
 	}
 	var buf bytes.Buffer
 	fixCtx := *ctx
@@ -251,7 +268,7 @@ func (d *Doctor) boundedFix(c Check, ctx *CheckContext) error {
 	d.inFlight.Add(1)
 	go func() {
 		defer d.inFlight.Done()
-		done <- c.Fix(&fixCtx)
+		done <- runFixRecoveringPanic(c, &fixCtx)
 	}()
 	select {
 	case err := <-done:

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -35,7 +36,8 @@ type Report struct {
 
 // Doctor runs registered health checks and reports results.
 type Doctor struct {
-	checks []Check
+	checks   []Check
+	inFlight sync.WaitGroup
 	// CheckTimeout bounds each individual check's Run, its --fix remediation,
 	// and the post-fix verification re-run. Zero (the default) preserves the
 	// historical unbounded behavior. When one of those exceeds the bound it is
@@ -43,13 +45,21 @@ type Doctor struct {
 	// data plane, or a fix script blocked on I/O) cannot stall the entire
 	// doctor run and hide every check registered after it. A timed-out Run is
 	// reported as a timed-out advisory error; a timed-out fix is reported as an
-	// unconfirmed remediation.
+	// unconfirmed remediation. Call Wait before releasing resources that a
+	// timed execution may still be using.
 	CheckTimeout time.Duration
 }
 
 // Register adds a check to the doctor's check list.
 func (d *Doctor) Register(c Check) {
 	d.checks = append(d.checks, c)
+}
+
+// Wait blocks until every timed execution started by prior Run or RunCollect
+// calls has finished. Callers that release resources used by checks must call
+// Wait after the run returns and before releasing those resources.
+func (d *Doctor) Wait() {
+	d.inFlight.Wait()
 }
 
 // Run executes all registered checks, streaming results to w as each
@@ -146,13 +156,17 @@ func (r *Report) tally(result *CheckResult) {
 // can never interleave writes with — or race against — the rest of the run.
 func (d *Doctor) boundedRun(c Check, ctx *CheckContext) *CheckResult {
 	if d.CheckTimeout <= 0 {
-		return c.Run(ctx)
+		return runCheckRecoveringPanic(c, ctx)
 	}
 	var buf bytes.Buffer
 	checkCtx := *ctx
 	checkCtx.Output = &buf
 	done := make(chan *CheckResult, 1)
-	go func() { done <- c.Run(&checkCtx) }()
+	d.inFlight.Add(1)
+	go func() {
+		defer d.inFlight.Done()
+		done <- runCheckRecoveringPanic(c, &checkCtx)
+	}()
 	select {
 	case result := <-done:
 		if buf.Len() > 0 && ctx.Output != nil {
@@ -168,6 +182,20 @@ func (d *Doctor) boundedRun(c Check, ctx *CheckContext) *CheckResult {
 			Message:  fmt.Sprintf("timed out after %s and was abandoned (outcome unknown); re-run alone or raise --check-timeout", d.CheckTimeout),
 		}
 	}
+}
+
+func runCheckRecoveringPanic(c Check, ctx *CheckContext) (result *CheckResult) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = &CheckResult{
+				Name:     c.Name(),
+				Status:   StatusError,
+				Severity: SeverityBlocking,
+				Message:  fmt.Sprintf("panic: %v", recovered),
+			}
+		}
+	}()
+	return c.Run(ctx)
 }
 
 // fixAndVerify remediates a failing, fixable check and re-runs it to confirm,
@@ -220,7 +248,11 @@ func (d *Doctor) boundedFix(c Check, ctx *CheckContext) error {
 	fixCtx := *ctx
 	fixCtx.Output = &buf
 	done := make(chan error, 1)
-	go func() { done <- c.Fix(&fixCtx) }()
+	d.inFlight.Add(1)
+	go func() {
+		defer d.inFlight.Done()
+		done <- c.Fix(&fixCtx)
+	}()
 	select {
 	case err := <-done:
 		if buf.Len() > 0 && ctx.Output != nil {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -636,6 +636,43 @@ func TestRunCheckTimeoutFlushesCompletedCheckOutput(t *testing.T) {
 	}
 }
 
+func TestRunCheckPanicBecomesReportedError(t *testing.T) {
+	for _, timeout := range []time.Duration{0, time.Second} {
+		t.Run(timeout.String(), func(t *testing.T) {
+			d := &Doctor{CheckTimeout: timeout}
+			d.Register(&panickingCheck{name: "panicking"})
+
+			report := d.RunCollect(&CheckContext{}, false)
+
+			if len(report.Results) != 1 {
+				t.Fatalf("Results = %d, want 1", len(report.Results))
+			}
+			result := report.Results[0]
+			if result.Name != "panicking" || result.Status != StatusError || result.Severity != SeverityBlocking {
+				t.Fatalf("panic result = %+v, want named blocking error", result)
+			}
+			if !strings.Contains(result.Message, "panic: check exploded") {
+				t.Fatalf("panic message = %q, want recovered panic detail", result.Message)
+			}
+			if report.Failed != 1 || report.BlockingFailed != 1 {
+				t.Fatalf("report = %+v, want one blocking failure", report)
+			}
+		})
+	}
+}
+
+type panickingCheck struct {
+	name string
+}
+
+func (c *panickingCheck) Name() string { return c.name }
+func (c *panickingCheck) Run(_ *CheckContext) *CheckResult {
+	panic("check exploded")
+}
+func (c *panickingCheck) CanFix() bool              { return false }
+func (c *panickingCheck) Fix(_ *CheckContext) error { return nil }
+func (c *panickingCheck) WarmupEligible() bool      { return false }
+
 // outputWritingCheck writes to ctx.Output during Run, like checks that
 // surface fix-time diagnostics.
 type outputWritingCheck struct{ mockCheck }
@@ -825,6 +862,43 @@ func TestRunCheckTimeoutIsolatesLateOutputAndSkipsRenderExtras(t *testing.T) {
 	if check.renderExtrasCalled.Load() {
 		t.Fatalf("RenderExtras was invoked for a timed-out check; it must be skipped")
 	}
+}
+
+func TestDoctorWaitKeepsTimedOutCheckOwnedUntilCompletion(t *testing.T) {
+	d := &Doctor{CheckTimeout: 25 * time.Millisecond}
+	check := &lateWritingCheck{
+		name:      "owned-after-timeout",
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+		wroteLate: make(chan struct{}),
+	}
+	d.Register(check)
+
+	runDone := make(chan *Report, 1)
+	go func() { runDone <- d.RunCollect(&CheckContext{}, false) }()
+	<-check.started
+	report := <-runDone
+	if len(report.Results) != 1 || !report.Results[0].TimedOut {
+		t.Fatalf("Results = %+v, want one timed-out result", report.Results)
+	}
+
+	waitStarted := make(chan struct{})
+	waitDone := make(chan struct{})
+	go func() {
+		close(waitStarted)
+		d.Wait()
+		close(waitDone)
+	}()
+	<-waitStarted
+	select {
+	case <-waitDone:
+		t.Fatal("Wait returned while the timed-out check was still running")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(check.release)
+	<-check.wroteLate
+	<-waitDone
 }
 
 // lateWritingCheck blocks inside Run until released, then writes to

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1008,3 +1008,48 @@ func (c *lateWritingOnFixCheck) Fix(ctx *CheckContext) error {
 	return nil
 }
 func (c *lateWritingOnFixCheck) WarmupEligible() bool { return false }
+
+// panickingFixCheck fails its Run and panics inside Fix, modeling a
+// pack-authored remediation that blows up mid-run.
+type panickingFixCheck struct{}
+
+func (panickingFixCheck) Name() string { return "panicking-fix" }
+func (panickingFixCheck) CanFix() bool { return true }
+func (panickingFixCheck) Fix(*CheckContext) error {
+	panic("fix exploded")
+}
+
+func (panickingFixCheck) Run(*CheckContext) *CheckResult {
+	return &CheckResult{
+		Name:     "panicking-fix",
+		Status:   StatusError,
+		Severity: SeverityBlocking,
+		Message:  "needs fixing",
+	}
+}
+
+// A panicking Fix must fail its own check, not crash the doctor process. Run
+// once unbounded and once timed, because boundedFix takes a different path for
+// each and only one of them was recovered before.
+func TestPanickingFixDoesNotCrashTheRun(t *testing.T) {
+	for _, timeout := range []time.Duration{0, time.Minute} {
+		d := &Doctor{CheckTimeout: timeout}
+		d.Register(panickingFixCheck{})
+		report := d.RunCollect(&CheckContext{}, true)
+		d.Wait()
+		if len(report.Results) != 1 {
+			t.Fatalf("CheckTimeout=%s: Results = %+v, want one result", timeout, report.Results)
+		}
+		if report.Results[0].Status != StatusError {
+			t.Errorf("CheckTimeout=%s: Status = %v, want StatusError", timeout, report.Results[0].Status)
+		}
+		if !report.Results[0].FixAttempted {
+			t.Errorf("CheckTimeout=%s: FixAttempted = false, want the panicking fix recorded as attempted", timeout)
+		}
+		if !strings.Contains(report.Results[0].FixError, "panicked") {
+			t.Errorf("CheckTimeout=%s: FixError = %q, want it to report the panic", timeout, report.Results[0].FixError)
+		}
+	}
+}
+
+func (panickingFixCheck) WarmupEligible() bool { return false }


### PR DESCRIPTION
## What

A panicking `Check.Fix` took down the whole `gc doctor --fix` process, on both
the unbounded and the timed path. Only `Check.Run` was recovered. `Fix` runs
pack-authored remediation, so it is the likelier of the two to blow up, and one
bad pack should fail one check rather than the command.

Both call sites now route through `runFixRecoveringPanic`, which reports the
panic as that check's `FixError` and leaves the rest of the run intact.

## The Wait contract

`Wait` always relied on a one-run-at-a-time contract that was never written down.
A concurrent `Run` could `Add` after `Wait` had already observed a zero counter,
so `Wait` could return while a timed execution still owned caller resources. The
doc comment now states it.

`doDoctor` deliberately does not call `Wait`: an abandoned check writes only to
its own private buffer, and blocking on it would restore the hang the per-check
timeout exists to prevent. That reasoning is recorded at the call site so the
next reader does not add the `Wait` back.

## Test plan

- `TestPanickingFixDoesNotCrashTheRun` drives a check whose `Fix` panics, once
  with no timeout and once with a timeout, covering both branches. It asserts the
  run completes, the check reports an error status, the fix is marked attempted,
  and the panic text reaches `FixError`.
- `internal/doctor` and `cmd/gc` suites pass; `go vet` and lint are clean.
