### PR TITLE
feat(push-ownership-guard): accept undeclared single in-progress match as branch-bead successor

### DIFF
--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -134,6 +134,68 @@ _pog_branch_id_bead_inactive() {
     [[ "$st" != "in_progress" && "$st" != "open" && -n "$st" ]]
 }
 
+# _pog_ownership_violation <json>: pure predicate over an already-fetched
+# `bd show <id> --json` payload (parsed here, not re-read). Prints nothing
+# and returns 0 when the bead reads as currently owned by this session;
+# otherwise prints a short, undecorated reason and returns 1. Checks, in
+# order: status open/in_progress, assignee among this session's live
+# identities, gc.routed_to unset-or-matching, no hold:mayor/hold:external
+# label. Shared by assert_bead_still_claimed (the public push gate, which
+# wraps the reason into its own BLOCKED/--no-verify message below) and
+# _pog_resolve_bead_id's undeclared-single-match tier (ga-0ywrmy.1, which
+# discards the reason and uses only the pass/fail to decide whether an
+# undeclared in-progress bead may stand in for a closed branch-derived one).
+#
+# NOTE: never name a local here 'status' — it is a zsh special parameter
+# (linked to $?, alongside $pipestatus) and this file is sourced into the
+# deployer's ambient zsh shell (ga-xi7wi6); binding a local named 'status'
+# there is a read-only-variable error, not a shadow.
+_pog_ownership_violation() {
+    local json="$1"
+    local bead_status assignee routed_to labels
+    bead_status="$(jq -r '.[0].status // empty' <<<"$json")"
+    assignee="$(jq -r '.[0].assignee // empty' <<<"$json")"
+    routed_to="$(jq -r '.[0].metadata."gc.routed_to" // empty' <<<"$json")"
+    labels="$(jq -r '.[0].labels[]? // empty' <<<"$json")"
+
+    if [[ "$bead_status" != "in_progress" && "$bead_status" != "open" ]]; then
+        printf "status is '%s', not in_progress/open; the claim behind this push is stale" "$bead_status"
+        return 1
+    fi
+
+    local -a _pog_identities=()
+    local _pog_ident
+    for _pog_ident in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}" "${GC_TEMPLATE:-}"; do
+        [[ -n "$_pog_ident" ]] && _pog_identities+=("$_pog_ident")
+    done
+    if [[ ${#_pog_identities[@]} -gt 0 ]]; then
+        local _pog_owned=0
+        for _pog_ident in "${_pog_identities[@]}"; do
+            if [[ -n "$assignee" && "$assignee" == "$_pog_ident" ]]; then _pog_owned=1; break; fi
+        done
+        if [[ $_pog_owned -eq 0 ]]; then
+            printf "assignee is '%s', not any current-session identity (%s); it was reassigned since this push began" "$assignee" "${_pog_identities[*]}"
+            return 1
+        fi
+    fi
+
+    if [[ -n "${GC_TEMPLATE:-}" && -n "$routed_to" && "$routed_to" != "$GC_TEMPLATE" ]]; then
+        printf "gc.routed_to is '%s', not this session's config identity (%s); it was rerouted since this push began" "$routed_to" "$GC_TEMPLATE"
+        return 1
+    fi
+
+    if grep -qx 'hold:mayor' <<<"$labels"; then
+        printf 'is held (hold:mayor); a mayor ruling is pending'
+        return 1
+    fi
+    if grep -qx 'hold:external' <<<"$labels"; then
+        printf 'is held (hold:external)'
+        return 1
+    fi
+
+    return 0
+}
+
 # _pog_resolve_bead_id: prints the bead id this push should be checked
 # against; prints nothing if none can be resolved. Resolution order:
 #   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* —
@@ -292,6 +354,49 @@ _pog_resolve_bead_id() {
         return
     fi
 
+    # UNDECLARED SINGLE MATCH (ga-0ywrmy.1): reached only once the declared-
+    # successor check above found nothing. Requires the SAME freshness gate
+    # (branch-derived bead confirmed inactive) plus one more condition: this
+    # session's in-progress list (already fetched above, not re-queried) has
+    # EXACTLY one entry -- no declared link required, cardinality alone is
+    # the safety bound, mirroring path 2's own single-match discipline. The
+    # sole candidate still has to pass a fresh live-ownership check below; an
+    # unrelated bead that happens to be this session's only other
+    # in-progress claim but reads back not-owned (closed, reassigned, held,
+    # ...) on its own fresh bd show must still not validate this push -- this
+    # tier only ever widens *resolution*, never *verification*.
+    #
+    # Cheap conditions (branch_id present, exactly one candidate already sitting
+    # in ${list_json} from the assignee-fallback fetch above, that candidate
+    # isn't literally branch_id) are checked FIRST, purely from data already in
+    # hand -- no I/O. _pog_branch_id_bead_inactive is deliberately the LAST
+    # link in this && chain, short-circuited so it only runs (and only pays for
+    # its own bd show + retries) once every cheap prerequisite already holds.
+    # The ordinary push -- branch_id resolves, no reuse in play at all -- must
+    # cost exactly the one bd show that assert_bead_still_claimed's own final
+    # check already makes; putting the I/O check first would double that cost
+    # on every push through this guard, not just the rare reuse case (caught
+    # by test_retry_exhausted_still_blocks's exact-call-count assertion).
+    if [[ -n "$branch_id" ]]; then
+        local undeclared_count
+        undeclared_count="$(jq -r 'length' <<<"${list_json:-[]}" 2>/dev/null || echo 0)"
+        if [[ "$undeclared_count" == "1" ]]; then
+            local undeclared_id
+            undeclared_id="$(jq -r '.[0].id // empty' <<<"${list_json:-[]}" 2>/dev/null || true)"
+            if [[ -n "$undeclared_id" && "$undeclared_id" != "$branch_id" ]] && _pog_branch_id_bead_inactive "$branch_id"; then
+                local undeclared_json
+                if undeclared_json="$(_pog_read_with_retry bd show "$undeclared_id" --json)" \
+                    && [[ -n "$undeclared_json" ]] \
+                    && jq -e '.' <<<"$undeclared_json" >/dev/null 2>&1 \
+                    && _pog_ownership_violation "$undeclared_json" >/dev/null 2>&1; then
+                    echo "push-ownership-guard: NOTE branch $branch was reused after $branch_id closed; this session has exactly one other in-progress bead ($undeclared_id) with no declared continuation link, using it as the undeclared single match" >&2
+                    printf '%s' "$undeclared_id"
+                    return
+                fi
+            fi
+        fi
+    fi
+
     if [[ -n "$branch_id" && -n "$assignee_id" && "$branch_id" != "$assignee_id" ]]; then
         echo "push-ownership-guard: WARNING branch name resolves to $branch_id but this session's in-progress assignment is $assignee_id; using $branch_id (branch name wins)" >&2
     fi
@@ -335,69 +440,10 @@ assert_bead_still_claimed() {
         return 1
     fi
 
-    # NOTE: never name this local 'status' — it is a zsh special parameter
-    # (linked to $?, alongside $pipestatus) and this function is sourced
-    # into the deployer's ambient zsh shell (ga-xi7wi6); binding a local
-    # named 'status' there is a read-only-variable error, not a shadow.
-    local bead_status assignee routed_to labels
-    bead_status="$(jq -r '.[0].status // empty' <<<"$json")"
-    assignee="$(jq -r '.[0].assignee // empty' <<<"$json")"
-    routed_to="$(jq -r '.[0].metadata."gc.routed_to" // empty' <<<"$json")"
-    labels="$(jq -r '.[0].labels[]? // empty' <<<"$json")"
-
-    if [[ "$bead_status" != "in_progress" && "$bead_status" != "open" ]]; then
-        echo "push-ownership-guard: BLOCKED — $id status is '$bead_status', not in_progress/open; the claim behind this push is stale. Bypass with: git push --no-verify" >&2
+    local reason
+    if ! reason="$(_pog_ownership_violation "$json")"; then
+        echo "push-ownership-guard: BLOCKED — $id $reason. Bypass with: git push --no-verify" >&2
         return 1
     fi
-
-    # A session-run claim sets bead.assignee from the first non-empty of
-    # GC_SESSION_NAME, GC_SESSION_ID, GC_ALIAS, GC_AGENT (see
-    # cmd/gc/cmd_hook.go's firstNonEmptyHookValue). Accept ANY of this
-    # session's live identities — GC_AGENT alone falsely blocks a push whose
-    # bead is legitimately assigned to the session name/id. Fail-closed
-    # semantics preserved: with identities present, an assignee matching none
-    # (including empty) still blocks.
-    #
-    # GC_TEMPLATE is also a valid match (ga-kzl21p): it's the bare pool
-    # identity (e.g. "gascity/builder"), stamped by the SDK at session start
-    # for every session shape regardless of which specific pool instance is
-    # running (e.g. "gascity/builder-1") — see internal/session/lifecycle.go.
-    # Work routed to the whole pool, rather than claimed by one instance, can
-    # carry that bare identity as assignee. Without this, a session whose
-    # GC_SESSION_NAME/GC_SESSION_ID/GC_ALIAS/GC_AGENT are all instance-shaped
-    # could never match a pool-level assignee, and completed, gate-verified
-    # work became unpushable with no reassignment and no bypass. This is the
-    # same trust boundary the routed_to check below already applies to
-    # GC_TEMPLATE — extended here to cover assignee too.
-    local -a _pog_identities=()
-    local _pog_ident
-    for _pog_ident in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}" "${GC_TEMPLATE:-}"; do
-        [[ -n "$_pog_ident" ]] && _pog_identities+=("$_pog_ident")
-    done
-    if [[ ${#_pog_identities[@]} -gt 0 ]]; then
-        local _pog_owned=0
-        for _pog_ident in "${_pog_identities[@]}"; do
-            if [[ -n "$assignee" && "$assignee" == "$_pog_ident" ]]; then _pog_owned=1; break; fi
-        done
-        if [[ $_pog_owned -eq 0 ]]; then
-            echo "push-ownership-guard: BLOCKED — $id assignee is '$assignee', not any current-session identity (${_pog_identities[*]}); it was reassigned since this push began. Bypass with: git push --no-verify" >&2
-            return 1
-        fi
-    fi
-
-    if [[ -n "${GC_TEMPLATE:-}" && -n "$routed_to" && "$routed_to" != "$GC_TEMPLATE" ]]; then
-        echo "push-ownership-guard: BLOCKED — $id gc.routed_to is '$routed_to', not this session's config identity ($GC_TEMPLATE); it was rerouted since this push began. Bypass with: git push --no-verify" >&2
-        return 1
-    fi
-
-    if grep -qx 'hold:mayor' <<<"$labels"; then
-        echo "push-ownership-guard: BLOCKED — $id is held (hold:mayor); a mayor ruling is pending. Bypass with: git push --no-verify" >&2
-        return 1
-    fi
-    if grep -qx 'hold:external' <<<"$labels"; then
-        echo "push-ownership-guard: BLOCKED — $id is held (hold:external). Bypass with: git push --no-verify" >&2
-        return 1
-    fi
-
     return 0
 }

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -721,18 +721,142 @@ FAKE
 # metadata.branch/build_bead tying it to THIS branch or to the closed
 # branch-derived bead must never be silently substituted -- the guard must
 # keep blocking on the real (closed) branch-derived bead instead.
+#
+# Needs an id-aware fake (unlike the pre-ga-0ywrmy.1 version of this test,
+# which used the single-canned-response write_show_json helper): that fake
+# answers ANY bd show call with the SAME "ga-oldbld closed" payload
+# regardless of id, which can no longer distinguish "the undeclared-match
+# tier fetched ga-unrel8d fresh and correctly rejected it" from "the tier
+# never looked at ga-unrel8d at all" -- both produce the exact same
+# observable rc/output. This fixture instead gives ga-unrel8d its own
+# genuinely distinguishable (and genuinely not-owned) response, and asserts
+# on show-ids.log that it was actually queried.
 test_bead_id_branch_reused_does_not_pick_unrelated_inprogress_bead_as_successor() {
-    local repo fbd out rc
+    local repo fbd out rc show_ids
     repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
     fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
-    write_fake_bd "$fbd"
-    printf '[{"id":"ga-unrel8d","metadata":{}}]' > "$fbd/fake-bd-state/list-json"
-    write_show_json "$fbd" "ga-oldbld" "closed" "agent-x" "tmpl-x" "[]"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-unrel8d) printf '[{"id":"ga-unrel8d","status":"in_progress","assignee":"someone-else","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-unrel8d","metadata":{}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
     out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
-    if [[ $rc -ne 0 ]] && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
-        record_pass "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor (rc=$rc, unrelated concurrent bead correctly ignored, blocks on the real closed bead)"
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -ne 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" && grep -qx "ga-unrel8d" <<<"$show_ids" \
+        && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor (rc=$rc, unrelated candidate ga-unrel8d checked fresh and rejected on its own assignee mismatch, still blocks on the real closed ga-oldbld)"
     else
-        record_fail "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor" "expected non-zero rc mentioning status+--no-verify (an unrelated in-progress bead under the same assignee must never be silently substituted), got rc=$rc, output: $out"
+        record_fail "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor" "expected non-zero rc mentioning status+--no-verify with BOTH ga-oldbld and ga-unrel8d fresh-checked (an unrelated in-progress bead must be verified, not blindly trusted or blindly ignored, and still not substituted once its own read shows a different assignee), got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# The undeclared-single-match tier (ga-0ywrmy.1): once the branch-derived
+# bead is confirmed inactive and NO in-progress bead declares itself its
+# successor via metadata, a session holding exactly one OTHER in-progress
+# bead -- with no declared link at all -- may still use it, but only if that
+# candidate independently passes the same live-ownership checks
+# assert_bead_still_claimed itself applies (status, assignee, routed_to,
+# hold). This is deliberately narrower than "any live claim wins": cardinality
+# (exactly one) is the resolution-time safety bound, and the fresh ownership
+# read is the verification-time safety bound -- see the sibling test above,
+# which pins the identical shape (single in-progress candidate, no declared
+# link) failing when that second bound doesn't hold.
+test_bead_id_branch_reused_accepts_undeclared_single_inprogress_match_when_branch_bead_closed() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-undecl) printf '[{"id":"ga-undecl","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-undecl","metadata":{}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -eq 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" && grep -qx "ga-undecl" <<<"$show_ids" \
+        && grep -qi "undeclared single match" <<<"$out"; then
+        record_pass "resolve/branch-reused-accepts-undeclared-single-inprogress-match-when-branch-bead-closed (rc=0, checked ga-oldbld (found closed) then verified+used the undeclared live candidate ga-undecl with no declared link at all)"
+    else
+        record_fail "resolve/branch-reused-accepts-undeclared-single-inprogress-match-when-branch-bead-closed" "expected rc=0 with bd show called against both ga-oldbld and ga-undecl and a NOTE naming the undeclared-single-match path, got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# Cardinality safety, mirrored for the undeclared-match tier: with TWO
+# in-progress beads and no declared link on either, "exactly one" fails and
+# the undeclared-match tier must not activate at all -- even though the
+# branch-derived bead is confirmed closed, there is no positive signal for
+# which (if either) in-progress bead continues it. Falls through to the
+# pre-existing block-on-branch_id behavior. Only ga-oldbld gets a configured
+# show-json response here -- if the tier ever mistakenly fired against
+# ambiguous cardinality, the resulting bd show on an unconfigured candidate
+# id would exit 1 and surface as a different failure shape than this test
+# asserts on, an incidental second guard on top of the explicit
+# show-ids.log negative assertion below.
+test_bead_id_branch_reused_undeclared_match_does_not_activate_with_multiple_inprogress() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-cand01","metadata":{}},{"id":"ga-cand02","metadata":{}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -ne 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" \
+        && ! grep -qx "ga-cand01" <<<"$show_ids" && ! grep -qx "ga-cand02" <<<"$show_ids" \
+        && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "resolve/branch-reused-undeclared-match-does-not-activate-with-multiple-inprogress (rc=$rc, 2+ undeclared in-progress beads leaves the tier inactive, blocks on the real closed ga-oldbld, neither candidate ever queried)"
+    else
+        record_fail "resolve/branch-reused-undeclared-match-does-not-activate-with-multiple-inprogress" "expected non-zero rc mentioning status+--no-verify with neither candidate ever bd-show'd (2+ undeclared in-progress beads is not a positive single-match signal), got rc=$rc show_ids=[$show_ids], output: $out"
     fi
     rm -rf "$repo" "$fbd"
 }
@@ -1141,6 +1265,8 @@ run_all() {
     test_bead_id_branch_reused_successor_match_via_branch_metadata_alone
     test_bead_id_branch_reused_successor_match_via_build_bead_metadata_alone
     test_bead_id_branch_reused_does_not_pick_unrelated_inprogress_bead_as_successor
+    test_bead_id_branch_reused_accepts_undeclared_single_inprogress_match_when_branch_bead_closed
+    test_bead_id_branch_reused_undeclared_match_does_not_activate_with_multiple_inprogress
     test_bead_id_branch_reused_does_not_override_when_branch_bead_still_active
     test_bead_id_deploy_gate_branch_prefers_live_assignee
     test_bead_id_deploy_gate_branch_allows_when_no_live_assignee


### PR DESCRIPTION
## Summary
- Extends `_pog_resolve_bead_id` (push-ownership-guard.sh) with a third tier: when a branch-derived bead is confirmed closed/inactive and no bead declares itself its successor via metadata, a session holding exactly one *other* in-progress bead (no declared link required) may use it as an undeclared successor — but only after that candidate independently passes the same live-ownership predicate `assert_bead_still_claimed` already applies (status, assignee identity, `gc.routed_to`, hold labels).
- Extracts that predicate out of `assert_bead_still_claimed` into a shared `_pog_ownership_violation` helper so the new tier and the public push gate share one definition of "owned," verified byte-for-byte message-preserving against the prior inline checks.
- Reuses the in-progress list already fetched for Tier 1 (no second `bd list` call). The new tier's own I/O (`_pog_branch_id_bead_inactive`) is ordered last in its condition chain, gated behind the cheap already-in-hand cardinality check, so an ordinary no-reuse push still costs exactly one `bd show`, not two.

## Motivation
Implements `ga-0ywrmy.1` (architecture: `ga-0ywrmy`). Closes the recurring "pr-audit rotates the live bead hourly while the branch name stays pinned to the closed originating bead" false-block pattern, without reopening the cardinality risk the existing tests guard against — 2+ undeclared in-progress beads leaves the tier inactive.

## Review note
Per the bead's own architecture notes: *"Treat with commensurate review scrutiny; consider asking for a second review pass given the safety-critical, fleet-wide blast radius, before this merges."* This script is sourced into every fleet push (Layer A pre-push hook, Layer B `attempt_bounded_self_rebase` — no bypass by design). Flagging for reviewer to judge whether a second pass (e.g. `gascity/qwen-reviewer`) is warranted before merge.

## Test plan
- [x] `bash scripts/test-push-ownership-guard.sh` — 40/40 pass (rewrote 1 test to use an id-aware fake `bd`, added 2 new tests: acceptance of a genuinely-owned undeclared single match, non-activation with 2+ undeclared in-progress beads)
- [x] `shellcheck scripts/push-ownership-guard.sh scripts/test-push-ownership-guard.sh` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Pre-push fast gate (`./scripts/test-local-parallel fast`) — all 10 jobs passed