### PR TITLE
RFC: city-qualified cross-city mail addressing ([mail.crosscity])

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1042,6 +1042,20 @@ func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, sessS
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
 		return "human", nil
 	}
+	roster := mailCityRosterFor(cfg, cityPath)
+	switch kind, addr := roster.ResolveCityAddress(identifier); kind {
+	case mail.CityAddressForeign:
+		// A peer city's address is canonical as written; its identity can
+		// only be checked by that city, so the session store is never
+		// consulted.
+		return addr, nil
+	case mail.CityAddressLocal:
+		// <local city>/<addr> and <addr> are one mailbox.
+		identifier = addr
+		if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
+			return "human", nil
+		}
+	}
 	if sessStore != nil {
 		sessionID, err := session.ResolveSessionIDByExactID(sessStore, identifier)
 		if err == nil {
@@ -1059,7 +1073,14 @@ func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, sessS
 	if normalizeNamedSessionTarget(identifier) == controllerMailIdentity {
 		return "", session.ErrSessionNotFound
 	}
-	return resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, identifier, cache)
+	resolved, err := resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, identifier, cache)
+	if err != nil {
+		// A slash-form recipient whose first segment names neither a rig nor
+		// a roster city refuses as unknown-city, so a stale roster is never
+		// spelled "session not found".
+		return "", mail.WrapUnresolvedRecipient(err, identifier, roster, mailCityLocalScopes(cfg))
+	}
+	return resolved, nil
 }
 
 func configuredMailboxAddress(identifier string) (string, bool) {
@@ -1220,9 +1241,31 @@ func resolveMailTargetsWithConfig(cityPath string, cfg *config.City, sessStore b
 }
 
 func resolveMailTargetsWithConfigCached(cityPath string, cfg *config.City, sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
+	roster := mailCityRosterFor(cfg, cityPath)
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
-		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, nil
+		return resolvedMailTarget{display: "human", recipients: roster.ExpandLocalRecipients([]string{"human"})}, nil
 	}
+	switch kind, addr := roster.ResolveCityAddress(identifier); kind {
+	case mail.CityAddressForeign:
+		// Reads are open-world: a peer city's mailbox is readable with no
+		// session lookup, exactly as an unresolved bare recipient is today.
+		return resolvedMailTarget{display: addr, recipients: []string{addr}}, nil
+	case mail.CityAddressLocal:
+		identifier = addr
+		if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
+			return resolvedMailTarget{display: "human", recipients: roster.ExpandLocalRecipients([]string{"human"})}, nil
+		}
+	}
+	target, err := resolveLocalMailTargetsWithConfigCached(cityPath, cfg, sessStore, identifier, cache)
+	if err != nil {
+		return target, mail.WrapUnresolvedRecipient(err, identifier, roster, mailCityLocalScopes(cfg))
+	}
+	// Delivery addressed to <local city>/<addr> is a read on <addr>'s inbox.
+	target.recipients = roster.ExpandLocalRecipients(target.recipients)
+	return target, nil
+}
+
+func resolveLocalMailTargetsWithConfigCached(cityPath string, cfg *config.City, sessStore beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
 	if sessStore != nil && cfg != nil {
 		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, sessStore, identifier)
 		if err == nil {
@@ -1476,7 +1519,14 @@ a non-running recipient. Unread mail alone does not request a wake.
 Use --from to override the sender identity.
 Use --to as an alternative to the positional <to> argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
-Use --all to broadcast to all live sessions (excluding sender and "human").`,
+Use --all to broadcast to all live sessions (excluding sender and "human").
+
+When [mail.crosscity] is configured, a recipient may be city-qualified:
+<city>/<address>, split on the first "/". This city's own name strips to the
+local form (<city>/mayor and mayor are one mailbox); a listed peer city's
+address is stored canonical as written, with no local session lookup, and the
+sender is stored city-qualified so a plain reply resolves back. --notify does
+not cross cities: the recipient's wake belongs to its own city's mail sweep.`,
 		Example: `  gc mail send mayor "Build is green"
   gc mail send mayor -s "Build is green"
   gc mail send myrig/witness -s "Need investigation" -m "Attach logs from the last failed run"
@@ -1764,6 +1814,7 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 	// recipient + listLiveSessionMailboxes) shares one broad scan instead of
 	// issuing one per call site (ga-q6ct Layer 3).
 	idCache := &mailIdentitySessionCache{}
+	roster := mailCityRosterFor(cfg, cityPath)
 	if store != nil {
 		validRecipients, err = listLiveSessionMailboxesCached(sessStore, idCache)
 		if err != nil {
@@ -1784,10 +1835,24 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 			sender = defaultMailIdentity()
 		}
 	} else if sender != "human" && store != nil {
-		sender, err = resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, sender, idCache)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
-			return 1
+		// A --from carrying a peer city's segment is accepted verbatim: only
+		// its own city can check that identity. A local-city qualifier strips
+		// to the bare form, which stays identity-checked here — the local
+		// city is the one place identity can and must be checked.
+		if kind, addr := roster.ResolveCityAddress(sender); kind == mail.CityAddressForeign {
+			sender = addr
+		} else {
+			if kind == mail.CityAddressLocal {
+				sender = addr
+			}
+			if sender != "human" {
+				given := sender
+				sender, err = resolveMailIdentityWithConfigCached(cityPath, cfg, sessStore, sender, idCache)
+				if err != nil {
+					fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", given, err) //nolint:errcheck // best-effort stderr
+					return 1
+				}
+			}
 		}
 	}
 
@@ -1830,6 +1895,19 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 		args[0] = canonicalTo
 		if validRecipients != nil {
 			validRecipients[canonicalTo] = true
+		}
+		if kind, _ := roster.ResolveCityAddress(canonicalTo); kind == mail.CityAddressForeign {
+			if notify {
+				msg := crossCityNotifyRefusal("gc mail send", canonicalTo)
+				if jsonOut {
+					return writeJSONError(stdout, stderr, "cross_city_notify", msg, 1)
+				}
+				fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			// Qualify the stored sender so the recipient's plain reply
+			// resolves back to this city.
+			sender = roster.QualifySender(sender)
 		}
 	}
 
@@ -2258,6 +2336,28 @@ func cmdMailReplyJSON(args []string, subject, message string, notify bool, jsonO
 	body := message
 	if body == "" && len(args) > 1 {
 		body = strings.Join(args[1:], " ")
+	}
+
+	// A reply into a foreign-origin thread crosses cities: refuse --notify
+	// before any write, and store this city's sender city-qualified so
+	// the far side's plain reply resolves back here.
+	if cfg == nil {
+		cityPath, cfg = ambientMailTargetConfig()
+	}
+	if roster := mailCityRosterFor(cfg, cityPath); roster.Enabled() {
+		if orig, getErr := mp.Get(args[0]); getErr == nil {
+			if kind, _ := roster.ResolveCityAddress(orig.From); kind == mail.CityAddressForeign {
+				if notify {
+					msg := crossCityNotifyRefusal("gc mail reply", orig.From)
+					if jsonOut {
+						return writeJSONError(stdout, stderr, "cross_city_notify", msg, 1)
+					}
+					fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+					return 1
+				}
+				sender = roster.QualifySender(sender)
+			}
+		}
 	}
 
 	var nf nudgeFunc

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1078,7 +1078,7 @@ func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, sessS
 		// A slash-form recipient whose first segment names neither a rig nor
 		// a roster city refuses as unknown-city, so a stale roster is never
 		// spelled "session not found".
-		return "", mail.WrapUnresolvedRecipient(err, identifier, roster, mailCityLocalScopes(cfg))
+		return "", mail.RefuseUnknownCity(err, identifier, roster, cfg.RigNames())
 	}
 	return resolved, nil
 }
@@ -1258,7 +1258,7 @@ func resolveMailTargetsWithConfigCached(cityPath string, cfg *config.City, sessS
 	}
 	target, err := resolveLocalMailTargetsWithConfigCached(cityPath, cfg, sessStore, identifier, cache)
 	if err != nil {
-		return target, mail.WrapUnresolvedRecipient(err, identifier, roster, mailCityLocalScopes(cfg))
+		return target, mail.RefuseUnknownCity(err, identifier, roster, cfg.RigNames())
 	}
 	// Delivery addressed to <local city>/<addr> is a read on <addr>'s inbox.
 	target.recipients = roster.ExpandLocalRecipients(target.recipients)
@@ -1322,7 +1322,11 @@ func resolveMailTargetsCached(sessStore beads.Store, identifier string, cache *m
 
 func resolveMailTargetsForCommand(identifier string, stderr io.Writer, cmdName string) (resolvedMailTarget, bool) {
 	if normalized := normalizeNamedSessionTarget(identifier); normalized == "" || normalized == "human" {
-		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, true
+		// The operator's box serves city-qualified deliveries too: mail
+		// addressed to <local city>/human is a read on human's inbox.
+		cityPath, cfg := ambientMailTargetConfig()
+		roster := mailCityRosterFor(cfg, cityPath)
+		return resolvedMailTarget{display: "human", recipients: roster.ExpandLocalRecipients([]string{"human"})}, true
 	}
 	if isStorelessMailProvider() {
 		return resolveRawMailTargetForStorelessProvider(identifier, stderr, cmdName)
@@ -2345,18 +2349,27 @@ func cmdMailReplyJSON(args []string, subject, message string, notify bool, jsonO
 		cityPath, cfg = ambientMailTargetConfig()
 	}
 	if roster := mailCityRosterFor(cfg, cityPath); roster.Enabled() {
-		if orig, getErr := mp.Get(args[0]); getErr == nil {
-			if kind, _ := roster.ResolveCityAddress(orig.From); kind == mail.CityAddressForeign {
-				if notify {
-					msg := crossCityNotifyRefusal("gc mail reply", orig.From)
-					if jsonOut {
-						return writeJSONError(stdout, stderr, "cross_city_notify", msg, 1)
-					}
-					fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
-					return 1
-				}
-				sender = roster.QualifySender(sender)
+		orig, getErr := mp.Get(args[0])
+		if getErr != nil {
+			// Fail closed: without the thread origin the cross-city rules
+			// (notify refusal, sender qualification) cannot be applied.
+			msg := fmt.Sprintf("gc mail reply: cannot verify thread origin for cross-city rules: %v", getErr)
+			if jsonOut {
+				return writeJSONError(stdout, stderr, "cross_city_origin_unverified", msg, 1)
 			}
+			fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if kind, _ := roster.ResolveCityAddress(orig.From); kind == mail.CityAddressForeign {
+			if notify {
+				msg := crossCityNotifyRefusal("gc mail reply", orig.From)
+				if jsonOut {
+					return writeJSONError(stdout, stderr, "cross_city_notify", msg, 1)
+				}
+				fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			sender = roster.QualifySender(sender)
 		}
 	}
 

--- a/cmd/gc/mail_crosscity.go
+++ b/cmd/gc/mail_crosscity.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/mail"
+)
+
+// mailCityRosterFor builds the cross-city mail roster for the loaded city.
+// The zero roster (no [mail.crosscity] section, or no loadable config) is
+// disabled and leaves every recipient resolving exactly as today.
+func mailCityRosterFor(cfg *config.City, cityPath string) mail.CityRoster {
+	local, peers := cfg.MailCityRoster(loadedCityName(cfg, cityPath))
+	return mail.CityRoster{Local: local, Peers: peers}
+}
+
+// crossCityNotifyRefusal is the typed refusal for --notify on a recipient in
+// another city. A cross-machine wake primitive does not exist; the
+// recipient's wake is its own city's mail sweep, so the request is refused
+// loudly before any write rather than reporting a nudge into a leg that is
+// not there.
+func crossCityNotifyRefusal(cmdName, recipient string) string {
+	return fmt.Sprintf("%s: --notify does not cross cities: %q is in city %q; its wake is that city's own mail sweep. Retry without --notify.",
+		cmdName, recipient, strings.SplitN(recipient, "/", 2)[0])
+}
+
+// mailCityLocalScopes returns the first-segment names that stay local-scope
+// under cross-city addressing — the configured rig names — so a failed
+// rig-qualified resolution keeps today's error instead of an unknown-city
+// refusal.
+func mailCityLocalScopes(cfg *config.City) []string {
+	if cfg == nil || len(cfg.Rigs) == 0 {
+		return nil
+	}
+	scopes := make([]string, 0, len(cfg.Rigs))
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name != "" {
+			scopes = append(scopes, cfg.Rigs[i].Name)
+		}
+	}
+	return scopes
+}

--- a/cmd/gc/mail_crosscity.go
+++ b/cmd/gc/mail_crosscity.go
@@ -25,20 +25,3 @@ func crossCityNotifyRefusal(cmdName, recipient string) string {
 	return fmt.Sprintf("%s: --notify does not cross cities: %q is in city %q; its wake is that city's own mail sweep. Retry without --notify.",
 		cmdName, recipient, strings.SplitN(recipient, "/", 2)[0])
 }
-
-// mailCityLocalScopes returns the first-segment names that stay local-scope
-// under cross-city addressing — the configured rig names — so a failed
-// rig-qualified resolution keeps today's error instead of an unknown-city
-// refusal.
-func mailCityLocalScopes(cfg *config.City) []string {
-	if cfg == nil || len(cfg.Rigs) == 0 {
-		return nil
-	}
-	scopes := make([]string, 0, len(cfg.Rigs))
-	for i := range cfg.Rigs {
-		if cfg.Rigs[i].Name != "" {
-			scopes = append(scopes, cfg.Rigs[i].Name)
-		}
-	}
-	return scopes
-}

--- a/cmd/gc/mail_crosscity_test.go
+++ b/cmd/gc/mail_crosscity_test.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/mail/beadmail"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func crossCityTestConfig() *config.City {
+	return &config.City{
+		Workspace: config.Workspace{Name: "qlandia"},
+		Mail: config.MailConfig{CrossCity: &config.MailCrossCityConfig{
+			Cities: []string{"gastown", "westeros"},
+		}},
+		Rigs: []config.Rig{{Name: "qcore", Path: "rigs/qcore"}},
+	}
+}
+
+// A foreign-city recipient resolves from the roster alone. The nil session
+// store makes the guard structural: a regression that consults the
+// session store cannot pass.
+func TestResolveMailRecipientIdentityCrossCityForeignWithoutSessionStore(t *testing.T) {
+	got, err := resolveMailRecipientIdentity("", crossCityTestConfig(), nil, "gastown/mayor")
+	if err != nil {
+		t.Fatalf("resolveMailRecipientIdentity: %v", err)
+	}
+	if got != "gastown/mayor" {
+		t.Errorf("got %q, want canonical %q", got, "gastown/mayor")
+	}
+}
+
+func TestResolveMailRecipientIdentityCrossCityLocalStripHuman(t *testing.T) {
+	got, err := resolveMailRecipientIdentity("", crossCityTestConfig(), nil, "qlandia/human")
+	if err != nil {
+		t.Fatalf("resolveMailRecipientIdentity: %v", err)
+	}
+	if got != "human" {
+		t.Errorf("got %q, want %q", got, "human")
+	}
+}
+
+// <local city>/<addr> and <addr> are one mailbox: both spellings resolve to
+// the same canonical identity.
+func TestResolveMailRecipientIdentityCrossCityLocalQualifiedAliasIsOneMailbox(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "mayor",
+			"session_name": "mayor-session",
+		},
+	}); err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	cfg := crossCityTestConfig()
+	bare, err := resolveMailRecipientIdentity("", cfg, store, "mayor")
+	if err != nil {
+		t.Fatalf("resolve bare: %v", err)
+	}
+	qualified, err := resolveMailRecipientIdentity("", cfg, store, "qlandia/mayor")
+	if err != nil {
+		t.Fatalf("resolve qualified: %v", err)
+	}
+	if bare != qualified {
+		t.Errorf("qualified %q and bare %q must resolve to one mailbox", qualified, bare)
+	}
+}
+
+// An address whose first segment names no rig and no roster city refuses as a
+// typed unknown-city error — never as a session lookup failure; the two
+// failures must never be spelled the same.
+func TestResolveMailRecipientIdentityUnknownCityTypedError(t *testing.T) {
+	_, err := resolveMailRecipientIdentity("", crossCityTestConfig(), nil, "gastwn/mayor")
+	if err == nil {
+		t.Fatal("expected unknown-city error")
+	}
+	var unknownCity *mail.UnknownCityError
+	if !errors.As(err, &unknownCity) {
+		t.Fatalf("err = %v (%T), want *mail.UnknownCityError", err, err)
+	}
+	if unknownCity.City != "gastwn" {
+		t.Errorf("City = %q, want %q", unknownCity.City, "gastwn")
+	}
+	if errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("unknown-city refusal must not be a session-not-found error")
+	}
+}
+
+// A rig-qualified name keeps today's failure shape even when the roster is
+// active: the rig segment is a local scope, not a candidate city.
+func TestResolveMailRecipientIdentityRigSegmentKeepsTodayError(t *testing.T) {
+	_, err := resolveMailRecipientIdentity("", crossCityTestConfig(), nil, "qcore/nobody")
+	if err == nil {
+		t.Fatal("expected resolution failure")
+	}
+	var unknownCity *mail.UnknownCityError
+	if errors.As(err, &unknownCity) {
+		t.Errorf("rig-qualified failure must not be an unknown-city error: %v", err)
+	}
+}
+
+// Without [mail.crosscity], a city-shaped recipient keeps today's behavior.
+func TestResolveMailRecipientIdentityNoRosterUnchanged(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "qlandia"}}
+	_, err := resolveMailRecipientIdentity("", cfg, nil, "gastown/mayor")
+	if err == nil {
+		t.Fatal("expected resolution failure without a roster")
+	}
+	var unknownCity *mail.UnknownCityError
+	if errors.As(err, &unknownCity) {
+		t.Errorf("no roster: failure must not be an unknown-city error: %v", err)
+	}
+}
+
+// Read-side: resolving a local mail target expands its recipients with the
+// city-qualified alias, so delivery addressed either way is one read.
+func TestResolveMailTargetsCrossCityExpandsQualifiedAliases(t *testing.T) {
+	target, err := resolveMailTargetsWithConfig("", crossCityTestConfig(), nil, "human")
+	if err != nil {
+		t.Fatalf("resolveMailTargetsWithConfig: %v", err)
+	}
+	if target.display != "human" {
+		t.Errorf("display = %q, want %q", target.display, "human")
+	}
+	want := map[string]bool{"human": false, "qlandia/human": false}
+	for _, r := range target.recipients {
+		if _, ok := want[r]; ok {
+			want[r] = true
+		}
+	}
+	for addr, found := range want {
+		if !found {
+			t.Errorf("recipients %v must include %q", target.recipients, addr)
+		}
+	}
+}
+
+// Read-side: a foreign-city mailbox reads open-world, with no session lookup.
+func TestResolveMailTargetsCrossCityForeignReadsOpenWorld(t *testing.T) {
+	target, err := resolveMailTargetsWithConfig("", crossCityTestConfig(), nil, "gastown/mayor")
+	if err != nil {
+		t.Fatalf("resolveMailTargetsWithConfig: %v", err)
+	}
+	if target.display != "gastown/mayor" {
+		t.Errorf("display = %q, want %q", target.display, "gastown/mayor")
+	}
+	if len(target.recipients) != 1 || target.recipients[0] != "gastown/mayor" {
+		t.Errorf("recipients = %v, want [gastown/mayor]", target.recipients)
+	}
+}
+
+func writeCrossCityTestCity(t *testing.T) string {
+	t.Helper()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("GC_AGENT", "")
+	cityPath := t.TempDir()
+	cityTOML := `
+[workspace]
+name = "qlandia"
+
+[mail.crosscity]
+cities = ["gastown", "westeros"]
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+	return cityPath
+}
+
+func findMessageBead(t *testing.T, cityPath string) (beads.Bead, bool) {
+	t.Helper()
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.List(beads.ListQuery{Type: "message", Status: "open", TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("List messages: %v", err)
+	}
+	for _, b := range all {
+		if b.Type == "message" {
+			return b, true
+		}
+	}
+	return beads.Bead{}, false
+}
+
+// A fresh send to a peer city succeeds with no session for the recipient, and
+// the stored sender is city-qualified so a plain reply crosses back.
+func TestCmdMailSendCrossCityForeignRecipient(t *testing.T) {
+	cityPath := writeCrossCityTestCity(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend(nil, false, false, "human", "gastown/mayor", "cutover status", "leg is green", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailSend = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	msg, found := findMessageBead(t, cityPath)
+	if !found {
+		t.Fatal("message bead not found")
+	}
+	if msg.Assignee != "gastown/mayor" {
+		t.Errorf("Assignee = %q, want %q", msg.Assignee, "gastown/mayor")
+	}
+	if msg.From != "qlandia/human" {
+		t.Errorf("From = %q, want city-qualified %q", msg.From, "qlandia/human")
+	}
+}
+
+// --notify on a foreign recipient is a typed refusal at the sender, before
+// any write: the recipient's wake belongs to its own city's sweep.
+func TestCmdMailSendCrossCityNotifyRefused(t *testing.T) {
+	cityPath := writeCrossCityTestCity(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend(nil, true, false, "human", "gastown/mayor", "s", "b", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdMailSend = %d, want 1; stdout=%s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--notify") || !strings.Contains(stderr.String(), "gastown") {
+		t.Errorf("stderr = %q, want typed cross-city --notify refusal naming the city", stderr.String())
+	}
+	if _, found := findMessageBead(t, cityPath); found {
+		t.Error("refusal must happen before the message is written")
+	}
+}
+
+// --from carrying a foreign city segment is accepted verbatim: the sender's
+// identity can only be checked by its own city.
+func TestCmdMailSendCrossCityForeignFromAccepted(t *testing.T) {
+	cityPath := writeCrossCityTestCity(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend(nil, false, false, "westeros/mayor", "human", "relayed", "body", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailSend = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	msg, found := findMessageBead(t, cityPath)
+	if !found {
+		t.Fatal("message bead not found")
+	}
+	if msg.From != "westeros/mayor" {
+		t.Errorf("From = %q, want verbatim %q", msg.From, "westeros/mayor")
+	}
+}
+
+func seedForeignOriginMessage(t *testing.T, cityPath string) string {
+	t.Helper()
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	seeded, err := beadmail.New(store).Send("gastown/mayor", "human", "cutover", "leg is green")
+	if err != nil {
+		t.Fatalf("seed Send: %v", err)
+	}
+	return seeded.ID
+}
+
+// A reply that crosses cities stores this city's sender city-qualified, so
+// the far side's plain reply resolves back here.
+func TestCmdMailReplyCrossCityQualifiesSender(t *testing.T) {
+	cityPath := writeCrossCityTestCity(t)
+	id := seedForeignOriginMessage(t, cityPath)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{id, "received, thank you"}, "", "", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailReply = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.List(beads.ListQuery{Type: "message", Status: "open", TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("List messages: %v", err)
+	}
+	var reply beads.Bead
+	found := false
+	for _, b := range all {
+		if b.Type == "message" && b.ID != id {
+			reply = b
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("reply bead not found")
+	}
+	if reply.Assignee != "gastown/mayor" {
+		t.Errorf("reply Assignee = %q, want %q", reply.Assignee, "gastown/mayor")
+	}
+	if reply.From != "qlandia/human" {
+		t.Errorf("reply From = %q, want city-qualified %q", reply.From, "qlandia/human")
+	}
+}
+
+// --notify on a reply whose thread crosses cities is a typed refusal at the
+// sender, before any write.
+func TestCmdMailReplyCrossCityNotifyRefused(t *testing.T) {
+	cityPath := writeCrossCityTestCity(t)
+	id := seedForeignOriginMessage(t, cityPath)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{id, "body"}, "", "", true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdMailReply = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--notify") || !strings.Contains(stderr.String(), "gastown") {
+		t.Errorf("stderr = %q, want typed cross-city --notify refusal naming the city", stderr.String())
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.List(beads.ListQuery{Type: "message", TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("List messages: %v", err)
+	}
+	count := 0
+	for _, b := range all {
+		if b.Type == "message" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("message count = %d, want 1 (refusal must happen before the reply is written)", count)
+	}
+}
+
+// --from naming an unknown agent within the local city stays refused, with or
+// without the city qualifier: the local city is the one place identity can
+// and must be checked.
+func TestCmdMailSendCrossCityLocalFromStillChecked(t *testing.T) {
+	writeCrossCityTestCity(t)
+
+	for _, from := range []string{"qlandia/nobody", "nobody"} {
+		var stdout, stderr bytes.Buffer
+		code := cmdMailSend(nil, false, false, from, "human", "s", "b", &stdout, &stderr)
+		if code != 1 {
+			t.Errorf("cmdMailSend --from %q = %d, want 1", from, code)
+		}
+		if !strings.Contains(stderr.String(), "invalid sender") {
+			t.Errorf("--from %q stderr = %q, want invalid sender refusal", from, stderr.String())
+		}
+	}
+}

--- a/cmd/gc/mail_crosscity_test.go
+++ b/cmd/gc/mail_crosscity_test.go
@@ -258,6 +258,39 @@ func TestCmdMailSendCrossCityForeignFromAccepted(t *testing.T) {
 	}
 }
 
+// Delivery is a read on the operator's surface too: mail addressed to
+// <local city>/human is served by the plain `gc mail inbox` human default.
+// This drives the full command, not the resolver helper — the human
+// fast-path in resolveMailTargetsForCommand must route through the roster.
+func TestCmdMailInboxCrossCityServesCityQualifiedHumanDelivery(t *testing.T) {
+	cityPath := writeCrossCityTestCity(t)
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if _, err := beadmail.New(store).Send("gastown/mayor", "qlandia/human", "for the operator", "cutover done"); err != nil {
+		t.Fatalf("seed Send: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailInbox(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailInbox = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "for the operator") {
+		t.Errorf("inbox output %q must serve mail addressed to the city-qualified human form", stdout.String())
+	}
+
+	stdout.Reset()
+	code = cmdMailCountWithJSON([]string{"human"}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailCount = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1") {
+		t.Errorf("count output %q must include the city-qualified delivery", stdout.String())
+	}
+}
+
 func seedForeignOriginMessage(t *testing.T, cityPath string) string {
 	t.Helper()
 	store, err := openCityStoreAt(cityPath)
@@ -355,8 +388,63 @@ func TestCmdMailSendCrossCityLocalFromStillChecked(t *testing.T) {
 		if code != 1 {
 			t.Errorf("cmdMailSend --from %q = %d, want 1", from, code)
 		}
-		if !strings.Contains(stderr.String(), "invalid sender") {
-			t.Errorf("--from %q stderr = %q, want invalid sender refusal", from, stderr.String())
+		if !strings.Contains(stderr.String(), `invalid sender "nobody"`) {
+			t.Errorf("--from %q stderr = %q, want the refused sender named", from, stderr.String())
 		}
+	}
+}
+
+// The invalid-sender refusal names the sender the caller gave. (Previously
+// the message printed the zeroed resolution result: `invalid sender ""`.)
+func TestCmdMailSendInvalidFromNamesTheGivenSender(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("GC_AGENT", "")
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"plain-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend(nil, false, false, "nobody", "human", "s", "b", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdMailSend = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), `invalid sender "nobody"`) {
+		t.Errorf("stderr = %q, want the refused sender named", stderr.String())
+	}
+}
+
+// With the roster enabled, a reply whose thread origin cannot be read fails
+// closed: the cross-city rules (notify refusal, sender qualification) cannot
+// be applied to an unverifiable thread.
+func TestCmdMailReplyCrossCityFailsClosedWhenOriginUnreadable(t *testing.T) {
+	writeCrossCityTestCity(t)
+	t.Setenv("GC_MAIL", "fail")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{"gc-999", "body"}, "", "", false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdMailReply = %d, want 1; stdout=%s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "thread origin") {
+		t.Errorf("stderr = %q, want the fail-closed origin-verification refusal", stderr.String())
+	}
+}
+
+// The JSON surface refuses cross-city --notify with a typed error code.
+func TestCmdMailSendCrossCityNotifyRefusedJSON(t *testing.T) {
+	writeCrossCityTestCity(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSendJSON(nil, true, false, "human", "gastown/mayor", "s", "b", true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdMailSendJSON = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cross_city_notify") {
+		t.Errorf("json output %q must carry the cross_city_notify error code", stdout.String())
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2547,6 +2547,13 @@ Use --to as an alternative to the positional &lt;to&gt; argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
 Use --all to broadcast to all live sessions (excluding sender and "human").
 
+When [mail.crosscity] is configured, a recipient may be city-qualified:
+&lt;city&gt;/&lt;address&gt;, split on the first "/". This city's own name strips to the
+local form (&lt;city&gt;/mayor and mayor are one mailbox); a listed peer city's
+address is stored canonical as written, with no local session lookup, and the
+sender is stored city-qualified so a plain reply resolves back. --notify does
+not cross cities: the recipient's wake belongs to its own city's mail sweep.
+
 ```
 gc mail send [<to>] [<body>] [flags]
 ```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -515,6 +515,16 @@ MailConfig holds mail provider settings.
 |-------|------|----------|---------|-------------|
 | `provider` | string |  |  | Provider selects the mail backend: "fake", "fail", "exec:&lt;script&gt;", or "" (default: beadmail). |
 | `retention_ttl` | string |  |  | RetentionTTL is how long read messages are retained before purge. Empty or "0" disables read-message retention. |
+| `crosscity` | MailCrossCityConfig |  |  | CrossCity enables city-qualified mail addressing (&lt;city&gt;/&lt;address&gt;). Absent means disabled: every recipient resolves exactly as today. |
+
+## MailCrossCityConfig
+
+MailCrossCityConfig enables city-qualified mail addressing: recipients of the form <city>/<address>, where the first path segment names a city and the remainder is that city's own address form.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `city` | string |  |  | City is this city's own segment in city-qualified addresses. Empty defaults to the effective city name (workspace name, else the city directory's base name). &lt;City&gt;/&lt;address&gt; and &lt;address&gt; are one mailbox. |
+| `cities` | []string | **yes** |  | Cities lists the peer cities addressable as &lt;city&gt;/&lt;address&gt;. A recipient naming a listed city resolves against the roster and is never looked up in the local session store. |
 
 ## MaintenanceConfig
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1871,11 +1871,36 @@
         "retention_ttl": {
           "type": "string",
           "description": "RetentionTTL is how long read messages are retained before purge. Empty\nor \"0\" disables read-message retention."
+        },
+        "crosscity": {
+          "$ref": "#/$defs/MailCrossCityConfig",
+          "description": "CrossCity enables city-qualified mail addressing (\u003ccity\u003e/\u003caddress\u003e).\nAbsent means disabled: every recipient resolves exactly as today."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "MailConfig holds mail provider settings."
+    },
+    "MailCrossCityConfig": {
+      "properties": {
+        "city": {
+          "type": "string",
+          "description": "City is this city's own segment in city-qualified addresses. Empty\ndefaults to the effective city name (workspace name, else the city\ndirectory's base name). \u003cCity\u003e/\u003caddress\u003e and \u003caddress\u003e are one mailbox."
+        },
+        "cities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Cities lists the peer cities addressable as \u003ccity\u003e/\u003caddress\u003e. A\nrecipient naming a listed city resolves against the roster and is never\nlooked up in the local session store."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "cities"
+      ],
+      "description": "MailCrossCityConfig enables city-qualified mail addressing: recipients of the form \u003ccity\u003e/\u003caddress\u003e, where the first path segment names a city and the remainder is that city's own address form."
     },
     "MaintenanceConfig": {
       "properties": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1871,11 +1871,36 @@
         "retention_ttl": {
           "type": "string",
           "description": "RetentionTTL is how long read messages are retained before purge. Empty\nor \"0\" disables read-message retention."
+        },
+        "crosscity": {
+          "$ref": "#/$defs/MailCrossCityConfig",
+          "description": "CrossCity enables city-qualified mail addressing (\u003ccity\u003e/\u003caddress\u003e).\nAbsent means disabled: every recipient resolves exactly as today."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "MailConfig holds mail provider settings."
+    },
+    "MailCrossCityConfig": {
+      "properties": {
+        "city": {
+          "type": "string",
+          "description": "City is this city's own segment in city-qualified addresses. Empty\ndefaults to the effective city name (workspace name, else the city\ndirectory's base name). \u003cCity\u003e/\u003caddress\u003e and \u003caddress\u003e are one mailbox."
+        },
+        "cities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Cities lists the peer cities addressable as \u003ccity\u003e/\u003caddress\u003e. A\nrecipient naming a listed city resolves against the roster and is never\nlooked up in the local session store."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "cities"
+      ],
+      "description": "MailCrossCityConfig enables city-qualified mail addressing: recipients of the form \u003ccity\u003e/\u003caddress\u003e, where the first path segment names a city and the remainder is that city's own address form."
     },
     "MaintenanceConfig": {
       "properties": {

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -94,7 +94,7 @@ func (s *Server) resolveMailSendRecipientWithContext(ctx context.Context, recipi
 		// A slash-form recipient whose first segment names neither a rig nor
 		// a roster city refuses as unknown-city, so a stale roster is never
 		// spelled as a session lookup failure.
-		return "", mail.WrapUnresolvedRecipient(err, recipient, roster, mailCityLocalScopes(s.state.Config()))
+		return "", mail.RefuseUnknownCity(err, recipient, roster, s.state.Config().RigNames())
 	}
 	return resolved, nil
 }
@@ -145,23 +145,6 @@ func (s *Server) mailCityRoster() mail.CityRoster {
 	}
 	local, peers := cfg.MailCityRoster(fallback)
 	return mail.CityRoster{Local: local, Peers: peers}
-}
-
-// mailCityLocalScopes returns the first-segment names that stay local-scope
-// under cross-city addressing — the configured rig names — so a failed
-// rig-qualified resolution keeps today's error instead of an unknown-city
-// refusal.
-func mailCityLocalScopes(cfg *config.City) []string {
-	if cfg == nil || len(cfg.Rigs) == 0 {
-		return nil
-	}
-	scopes := make([]string, 0, len(cfg.Rigs))
-	for i := range cfg.Rigs {
-		if cfg.Rigs[i].Name != "" {
-			scopes = append(scopes, cfg.Rigs[i].Name)
-		}
-	}
-	return scopes
 }
 
 func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, recipient string) []string {

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -74,6 +75,31 @@ func (s *Server) resolveMailSendRecipientWithContext(ctx context.Context, recipi
 	if recipient == "human" {
 		return recipient, nil
 	}
+	roster := s.mailCityRoster()
+	switch kind, addr := roster.ResolveCityAddress(recipient); kind {
+	case mail.CityAddressForeign:
+		// A peer city's address is canonical as written; its identity can
+		// only be checked by that city, so the session store is never
+		// consulted.
+		return addr, nil
+	case mail.CityAddressLocal:
+		// <local city>/<addr> and <addr> are one mailbox.
+		recipient = addr
+		if recipient == "human" {
+			return recipient, nil
+		}
+	}
+	resolved, err := s.resolveLocalMailSendRecipientWithContext(ctx, recipient)
+	if err != nil {
+		// A slash-form recipient whose first segment names neither a rig nor
+		// a roster city refuses as unknown-city, so a stale roster is never
+		// spelled as a session lookup failure.
+		return "", mail.WrapUnresolvedRecipient(err, recipient, roster, mailCityLocalScopes(s.state.Config()))
+	}
+	return resolved, nil
+}
+
+func (s *Server) resolveLocalMailSendRecipientWithContext(ctx context.Context, recipient string) (string, error) {
 	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		resolved, err := mail.ResolveRecipient(recipient, agentEntries(s.state.Config()))
@@ -108,14 +134,61 @@ func (s *Server) resolveMailSendRecipientWithContext(ctx context.Context, recipi
 	return "", apiSessionTargetNotFound(recipient)
 }
 
+// mailCityRoster builds the cross-city mail roster for this city. The zero
+// roster (no [mail.crosscity] section) is disabled and leaves every recipient
+// resolving exactly as today.
+func (s *Server) mailCityRoster() mail.CityRoster {
+	cfg := s.state.Config()
+	fallback := ""
+	if p := strings.TrimSpace(s.state.CityPath()); p != "" {
+		fallback = filepath.Base(filepath.Clean(p))
+	}
+	local, peers := cfg.MailCityRoster(fallback)
+	return mail.CityRoster{Local: local, Peers: peers}
+}
+
+// mailCityLocalScopes returns the first-segment names that stay local-scope
+// under cross-city addressing — the configured rig names — so a failed
+// rig-qualified resolution keeps today's error instead of an unknown-city
+// refusal.
+func mailCityLocalScopes(cfg *config.City) []string {
+	if cfg == nil || len(cfg.Rigs) == 0 {
+		return nil
+	}
+	scopes := make([]string, 0, len(cfg.Rigs))
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name != "" {
+			scopes = append(scopes, cfg.Rigs[i].Name)
+		}
+	}
+	return scopes
+}
+
 func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, recipient string) []string {
 	recipient = strings.TrimSpace(recipient)
 	if recipient == "" {
 		return []string{""}
 	}
+	roster := s.mailCityRoster()
 	if recipient == "human" {
-		return []string{"human"}
+		return roster.ExpandLocalRecipients([]string{"human"})
 	}
+	switch kind, addr := roster.ResolveCityAddress(recipient); kind {
+	case mail.CityAddressForeign:
+		// Reads are open-world: a peer city's mailbox is readable with no
+		// session lookup.
+		return []string{addr}
+	case mail.CityAddressLocal:
+		recipient = addr
+		if recipient == "human" {
+			return roster.ExpandLocalRecipients([]string{"human"})
+		}
+	}
+	// Delivery addressed to <local city>/<addr> is a read on <addr>'s inbox.
+	return roster.ExpandLocalRecipients(s.resolveLocalMailQueryRecipientsWithContext(ctx, recipient))
+}
+
+func (s *Server) resolveLocalMailQueryRecipientsWithContext(ctx context.Context, recipient string) []string {
 	store := s.state.SessionsBeadStore().Store
 	if store == nil {
 		if resolved, err := mail.ResolveRecipient(recipient, agentEntries(s.state.Config())); err == nil {

--- a/internal/api/handler_mail_crosscity_test.go
+++ b/internal/api/handler_mail_crosscity_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/mail"
+)
+
+func enableCrossCity(state *fakeState) {
+	state.cfg.Mail.CrossCity = &config.MailCrossCityConfig{
+		Cities: []string{"gastown", "westeros"},
+	}
+}
+
+// A fresh send to a peer city resolves from the roster alone and stores the
+// address canonical as written — the fresh-send gate is the one place the
+// city-qualified namespace was refused.
+func TestMailSendCrossCityForeignRecipient(t *testing.T) {
+	state := newFakeState(t)
+	enableCrossCity(state)
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"mayor","to":"gastown/mayor","subject":"cutover","body":"leg is green"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/mail"), bytes.NewBufferString(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("send status = %d, want %d; body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var sent mail.Message
+	json.NewDecoder(rec.Body).Decode(&sent) //nolint:errcheck
+	if sent.To != "gastown/mayor" {
+		t.Errorf("To = %q, want canonical %q", sent.To, "gastown/mayor")
+	}
+	if sent.From != "test-city/mayor" {
+		t.Errorf("From = %q, want city-qualified %q (a plain reply must resolve back)", sent.From, "test-city/mayor")
+	}
+}
+
+// A reply that crosses cities stores this city's sender city-qualified, so
+// the far side's plain reply resolves back here — on the API surface
+// exactly as on the CLI.
+func TestMailReplyCrossCityQualifiesSender(t *testing.T) {
+	state := newFakeState(t)
+	enableCrossCity(state)
+	h := newTestCityHandler(t, state)
+
+	seeded, err := state.cityMailProv.Send("gastown/mayor", "myrig/worker", "cutover", "leg is green")
+	if err != nil {
+		t.Fatalf("seed Send: %v", err)
+	}
+
+	body := `{"from":"worker","subject":"re: cutover","body":"received"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/mail/")+seeded.ID+"/reply", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("reply status = %d, want success; body: %s", rec.Code, rec.Body.String())
+	}
+	var reply mail.Message
+	json.NewDecoder(rec.Body).Decode(&reply) //nolint:errcheck
+	if reply.To != "gastown/mayor" {
+		t.Errorf("To = %q, want %q", reply.To, "gastown/mayor")
+	}
+	if reply.From != "test-city/worker" {
+		t.Errorf("From = %q, want city-qualified %q", reply.From, "test-city/worker")
+	}
+}
+
+// <local city>/<addr> and <addr> are one mailbox: a local-qualified fresh
+// send canonicalizes exactly as the bare form does.
+func TestMailSendCrossCityLocalQualifiedRecipient(t *testing.T) {
+	state := newFakeState(t)
+	enableCrossCity(state)
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"mayor","to":"test-city/worker","subject":"s","body":"b"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/mail"), bytes.NewBufferString(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("send status = %d, want %d; body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var sent mail.Message
+	json.NewDecoder(rec.Body).Decode(&sent) //nolint:errcheck
+	if sent.To != "myrig/worker" {
+		t.Errorf("To = %q, want %q (local-qualified resolves like the bare form)", sent.To, "myrig/worker")
+	}
+}
+
+// An unknown city-shaped segment refuses with the typed unknown-city message
+// naming the roster, never a session lookup failure.
+func TestMailSendCrossCityUnknownCityRefused(t *testing.T) {
+	state := newFakeState(t)
+	enableCrossCity(state)
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"mayor","to":"gastwn/mayor","subject":"s","body":"b"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/mail"), bytes.NewBufferString(body)))
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("send status = %d, want refusal; body: %s", rec.Code, rec.Body.String())
+	}
+	respBody := rec.Body.String()
+	if !strings.Contains(respBody, "unknown city") || !strings.Contains(respBody, "gastwn") {
+		t.Errorf("body = %q, want typed unknown-city refusal naming %q", respBody, "gastwn")
+	}
+	if strings.Contains(respBody, "session") {
+		t.Errorf("body = %q: unknown-city refusal must not be spelled as a session lookup failure", respBody)
+	}
+}
+
+// Without [mail.crosscity], a city-shaped recipient keeps today's refusal.
+func TestMailSendCrossCityNoRosterUnchanged(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	body := `{"from":"mayor","to":"gastown/mayor","subject":"s","body":"b"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/mail"), bytes.NewBufferString(body)))
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("send status = %d, want refusal without a roster; body: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "unknown city") {
+		t.Errorf("body = %q: no roster means no unknown-city semantics", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "no bead store available") {
+		t.Errorf("body = %q: the no-roster refusal must keep today's exact shape", rec.Body.String())
+	}
+}
+
+// Delivery is a read: a message addressed to the reader's city-qualified
+// form is served by the reader's ordinary inbox query.
+func TestMailInboxCrossCityServesCityQualifiedDelivery(t *testing.T) {
+	state := newFakeState(t)
+	enableCrossCity(state)
+	h := newTestCityHandler(t, state)
+
+	if _, err := state.cityMailProv.Send("gastown/mayor", "test-city/myrig/worker", "hello", "over the shared store"); err != nil {
+		t.Fatalf("seed Send: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail?agent=myrig/worker"), nil))
+	var inbox struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	json.NewDecoder(rec.Body).Decode(&inbox) //nolint:errcheck
+	if inbox.Total != 1 {
+		t.Fatalf("inbox Total = %d, want 1 (city-qualified delivery must be a read); body: %+v", inbox.Total, inbox.Items)
+	}
+	if inbox.Items[0].To != "test-city/myrig/worker" {
+		t.Errorf("To = %q, want %q", inbox.Items[0].To, "test-city/myrig/worker")
+	}
+}

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -390,12 +390,21 @@ func (s *Server) humaHandleMailSend(ctx context.Context, input *MailSendInput) (
 		return nil, apierr.InvalidRequest.Msg("no mail provider available")
 	}
 
+	// A message that crosses cities stores this city's sender city-qualified
+	// so the recipient's plain reply resolves back here.
+	from := input.Body.From
+	if roster := s.mailCityRoster(); roster.Enabled() {
+		if kind, _ := roster.ResolveCityAddress(resolved); kind == mail.CityAddressForeign {
+			from = roster.QualifySender(from)
+		}
+	}
+
 	// Idempotency: send at most once per Idempotency-Key. On replay the closure
 	// is skipped entirely, so no duplicate Send, telemetry op, or MailSent event
 	// fires. The helper guarantees the reservation is released on a send error.
 	msg, err := withIdempotency(s.idem, "/v0/mail", input.IdempotencyKey, input.Body,
 		func() (mail.Message, error) {
-			sent, sendErr := mp.Send(input.Body.From, resolved, input.Body.Subject, input.Body.Body)
+			sent, sendErr := mp.Send(from, resolved, input.Body.Subject, input.Body.Body)
 			telemetry.RecordMailOp(ctx, "send", sendErr)
 			if sendErr != nil {
 				return mail.Message{}, apierr.Internal.Msg(sendErr.Error())
@@ -660,7 +669,18 @@ func (s *Server) humaHandleMailReply(ctx context.Context, input *MailReplyInput)
 				return mail.Message{}, apierr.MailNotFound.Msg("message " + id + " not found")
 			}
 
-			sent, replyErr := mp.Reply(id, input.Body.From, input.Body.Subject, input.Body.Body)
+			// A reply into a foreign-origin thread crosses cities: store
+			// this city's sender city-qualified so the far side's plain
+			// reply resolves back here.
+			from := input.Body.From
+			if roster := s.mailCityRoster(); roster.Enabled() {
+				if orig, getErr := mp.Get(id); getErr == nil {
+					if kind, _ := roster.ResolveCityAddress(orig.From); kind == mail.CityAddressForeign {
+						from = roster.QualifySender(from)
+					}
+				}
+			}
+			sent, replyErr := mp.Reply(id, from, input.Body.Subject, input.Body.Body)
 			telemetry.RecordMailOp(ctx, "reply", replyErr)
 			if replyErr != nil {
 				return mail.Message{}, apierr.Internal.Msg(replyErr.Error())

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -785,6 +785,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	if err := ValidateDoltConfig(root, path); err != nil {
 		return nil, nil, err
 	}
+	if err := ValidateMailCrossCity(root, cityRoot); err != nil {
+		return nil, nil, err
+	}
 
 	// Validate cross-entity semantic constraints.
 	if !opts.AllowMissingProviderReferences {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1797,6 +1797,9 @@ type MailConfig struct {
 	// RetentionTTL is how long read messages are retained before purge. Empty
 	// or "0" disables read-message retention.
 	RetentionTTL string `toml:"retention_ttl,omitempty"`
+	// CrossCity enables city-qualified mail addressing (<city>/<address>).
+	// Absent means disabled: every recipient resolves exactly as today.
+	CrossCity *MailCrossCityConfig `toml:"crosscity,omitempty"`
 }
 
 // RetentionTTLDuration parses RetentionTTL as a Go time.Duration. Empty or

--- a/internal/config/mail_crosscity.go
+++ b/internal/config/mail_crosscity.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// MailCrossCityConfig enables city-qualified mail addressing: recipients of
+// the form <city>/<address>, where the first path segment names a city and
+// the remainder is that city's own address form. Authoring the section is the
+// feature flag; omitting it keeps every recipient resolving exactly as today.
+type MailCrossCityConfig struct {
+	// City is this city's own segment in city-qualified addresses. Empty
+	// defaults to the effective city name (workspace name, else the city
+	// directory's base name). <City>/<address> and <address> are one mailbox.
+	City string `toml:"city,omitempty"`
+	// Cities lists the peer cities addressable as <city>/<address>. A
+	// recipient naming a listed city resolves against the roster and is never
+	// looked up in the local session store.
+	Cities []string `toml:"cities"`
+}
+
+// MailCityRoster returns the local city name and peer cities for
+// cross-city mail addressing, or ("", nil) when the section is absent.
+// fallbackCityName seeds the local name when neither [mail.crosscity] city
+// nor the workspace identity names it — callers pass the city directory's
+// base name, mirroring every other effective-city-name derivation.
+func (c *City) MailCityRoster(fallbackCityName string) (string, []string) {
+	if c == nil || c.Mail.CrossCity == nil {
+		return "", nil
+	}
+	cc := c.Mail.CrossCity
+	local := strings.TrimSpace(cc.City)
+	if local == "" {
+		local = EffectiveCityName(c, fallbackCityName)
+	}
+	return local, cc.Cities
+}
+
+// ValidateMailCrossCity validates the [mail.crosscity] section of a composed
+// config: a present section must list at least one syntactically valid,
+// duplicate-free peer city; the local city must not list itself; and no rig
+// may share a name with a listed city — the first mail-address segment must
+// bind unambiguously to either a rig or a city, never both (a collision here
+// would silently rebind existing rig-qualified mail). cityRoot supplies the
+// directory-derived fallback for the effective local city name.
+func ValidateMailCrossCity(cfg *City, cityRoot string) error {
+	if cfg == nil || cfg.Mail.CrossCity == nil {
+		return nil
+	}
+	cc := cfg.Mail.CrossCity
+	if len(cc.Cities) == 0 {
+		return fmt.Errorf("[mail.crosscity] cities must list at least one peer city")
+	}
+	fallback := ""
+	if cityRoot != "" {
+		fallback = filepath.Base(filepath.Clean(cityRoot))
+	}
+	local, _ := cfg.MailCityRoster(fallback)
+	if err := validateMailCityName(local); err != nil {
+		return fmt.Errorf("[mail.crosscity] city: %w", err)
+	}
+	seen := make(map[string]bool, len(cc.Cities))
+	for _, city := range cc.Cities {
+		if err := validateMailCityName(city); err != nil {
+			return fmt.Errorf("[mail.crosscity] cities: %w", err)
+		}
+		if seen[city] {
+			return fmt.Errorf("[mail.crosscity] cities lists duplicate city %q", city)
+		}
+		seen[city] = true
+		if city == local {
+			return fmt.Errorf("[mail.crosscity] cities must not list this city's own city %q", city)
+		}
+	}
+	for i := range cfg.Rigs {
+		if seen[cfg.Rigs[i].Name] || cfg.Rigs[i].Name == local {
+			return fmt.Errorf("rig %q collides with [mail.crosscity] city %q: the first mail-address segment must name either a rig or a city, never both", cfg.Rigs[i].Name, cfg.Rigs[i].Name)
+		}
+	}
+	return nil
+}
+
+// validateMailCityName enforces the city-segment syntax: non-empty, and
+// composed of letters, digits, "-", "_", or "." — above all no "/", which is
+// the address separator, and no whitespace.
+func validateMailCityName(name string) error {
+	if name == "" {
+		return fmt.Errorf("city name is empty")
+	}
+	if strings.IndexFunc(name, func(r rune) bool { return !isMailCityNameRune(r) }) >= 0 {
+		return fmt.Errorf("invalid city name %q: use letters, digits, '-', '_', or '.'", name)
+	}
+	return nil
+}
+
+func isMailCityNameRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.'
+}

--- a/internal/config/mail_crosscity.go
+++ b/internal/config/mail_crosscity.go
@@ -76,10 +76,26 @@ func ValidateMailCrossCity(cfg *City, cityRoot string) error {
 	}
 	for i := range cfg.Rigs {
 		if seen[cfg.Rigs[i].Name] || cfg.Rigs[i].Name == local {
-			return fmt.Errorf("rig %q collides with [mail.crosscity] city %q: the first mail-address segment must name either a rig or a city, never both", cfg.Rigs[i].Name, cfg.Rigs[i].Name)
+			return fmt.Errorf("rig %q collides with a [mail.crosscity] city of the same name: the first mail-address segment must name either a rig or a city, never both", cfg.Rigs[i].Name)
 		}
 	}
 	return nil
+}
+
+// RigNames returns the configured rig names. Cross-city mail resolution uses
+// them as the first-segment scopes that stay local, so a failed rig-qualified
+// lookup keeps its ordinary error instead of an unknown-city refusal.
+func (c *City) RigNames() []string {
+	if c == nil || len(c.Rigs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(c.Rigs))
+	for i := range c.Rigs {
+		if c.Rigs[i].Name != "" {
+			names = append(names, c.Rigs[i].Name)
+		}
+	}
+	return names
 }
 
 // validateMailCityName enforces the city-segment syntax: non-empty, and

--- a/internal/config/mail_crosscity_test.go
+++ b/internal/config/mail_crosscity_test.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestLoadParsesMailCrossCity(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "qlandia"
+
+[mail.crosscity]
+cities = ["gastown", "westeros"]
+`)
+	cfg, err := Load(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cc := cfg.Mail.CrossCity
+	if cc == nil {
+		t.Fatal("Mail.CrossCity = nil, want parsed section")
+	}
+	if cc.City != "" {
+		t.Errorf("City = %q, want empty (defaults to effective city name)", cc.City)
+	}
+	if len(cc.Cities) != 2 || cc.Cities[0] != "gastown" || cc.Cities[1] != "westeros" {
+		t.Errorf("Cities = %v, want [gastown westeros]", cc.Cities)
+	}
+}
+
+func TestMailCityRoster(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *City
+		fallback  string
+		wantLocal string
+		wantPeers []string
+	}{
+		{
+			name:      "nil config is disabled",
+			cfg:       nil,
+			fallback:  "qlandia",
+			wantLocal: "",
+			wantPeers: nil,
+		},
+		{
+			name:      "absent section is disabled",
+			cfg:       &City{},
+			fallback:  "qlandia",
+			wantLocal: "",
+			wantPeers: nil,
+		},
+		{
+			name: "explicit city wins over workspace name",
+			cfg: &City{
+				Workspace: Workspace{Name: "workspace-name"},
+				Mail: MailConfig{CrossCity: &MailCrossCityConfig{
+					City:   "qlandia",
+					Cities: []string{"gastown"},
+				}},
+			},
+			fallback:  "dir-name",
+			wantLocal: "qlandia",
+			wantPeers: []string{"gastown"},
+		},
+		{
+			name: "workspace name fills an empty city",
+			cfg: &City{
+				Workspace: Workspace{Name: "qlandia"},
+				Mail: MailConfig{CrossCity: &MailCrossCityConfig{
+					Cities: []string{"gastown"},
+				}},
+			},
+			fallback:  "dir-name",
+			wantLocal: "qlandia",
+			wantPeers: []string{"gastown"},
+		},
+		{
+			name: "fallback fills when nothing else names the city",
+			cfg: &City{
+				Mail: MailConfig{CrossCity: &MailCrossCityConfig{
+					Cities: []string{"gastown"},
+				}},
+			},
+			fallback:  "qlandia",
+			wantLocal: "qlandia",
+			wantPeers: []string{"gastown"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			local, peers := tt.cfg.MailCityRoster(tt.fallback)
+			if local != tt.wantLocal {
+				t.Errorf("local = %q, want %q", local, tt.wantLocal)
+			}
+			if len(peers) != len(tt.wantPeers) {
+				t.Fatalf("peers = %v, want %v", peers, tt.wantPeers)
+			}
+			for i := range peers {
+				if peers[i] != tt.wantPeers[i] {
+					t.Errorf("peers[%d] = %q, want %q", i, peers[i], tt.wantPeers[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMailCrossCity(t *testing.T) {
+	valid := func() *City {
+		return &City{
+			Workspace: Workspace{Name: "qlandia"},
+			Mail: MailConfig{CrossCity: &MailCrossCityConfig{
+				Cities: []string{"gastown", "westeros"},
+			}},
+		}
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*City)
+		wantErr string
+	}{
+		{
+			name:   "valid section passes",
+			mutate: func(*City) {},
+		},
+		{
+			name:   "absent section passes",
+			mutate: func(c *City) { c.Mail.CrossCity = nil },
+		},
+		{
+			name:    "empty cities list is refused",
+			mutate:  func(c *City) { c.Mail.CrossCity.Cities = nil },
+			wantErr: "cities",
+		},
+		{
+			name:    "duplicate city is refused",
+			mutate:  func(c *City) { c.Mail.CrossCity.Cities = []string{"gastown", "gastown"} },
+			wantErr: "duplicate",
+		},
+		{
+			name:    "invalid city name is refused",
+			mutate:  func(c *City) { c.Mail.CrossCity.Cities = []string{"gas town"} },
+			wantErr: "invalid",
+		},
+		{
+			name:    "city name with a slash is refused",
+			mutate:  func(c *City) { c.Mail.CrossCity.Cities = []string{"gas/town"} },
+			wantErr: "invalid",
+		},
+		{
+			name:    "explicit local city listed as a peer is refused",
+			mutate:  func(c *City) { c.Mail.CrossCity.City = "gastown" },
+			wantErr: "own city",
+		},
+		{
+			name:    "effective local city listed as a peer is refused",
+			mutate:  func(c *City) { c.Mail.CrossCity.Cities = []string{"qlandia"} },
+			wantErr: "own city",
+		},
+		{
+			name:    "directory-derived local city listed as a peer is refused",
+			mutate:  func(c *City) { c.Workspace.Name = ""; c.Mail.CrossCity.Cities = []string{"cityroot"} },
+			wantErr: "own city",
+		},
+		{
+			name:    "rig named like a peer city is refused",
+			mutate:  func(c *City) { c.Rigs = []Rig{{Name: "gastown", Path: "rigs/gastown"}} },
+			wantErr: "rig",
+		},
+		{
+			name:    "rig named like the local city is refused",
+			mutate:  func(c *City) { c.Rigs = []Rig{{Name: "qlandia", Path: "rigs/qlandia"}} },
+			wantErr: "rig",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := valid()
+			tt.mutate(cfg)
+			err := ValidateMailCrossCity(cfg, "/tmp/cityroot")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateMailCrossCity: %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateMailCrossCity: nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// The rig-collision rule must hold at the composed load path, not only when a
+// caller remembers to invoke the validator: a rig colliding with a roster
+// city is a load-time validation error, not a silent mis-bind.
+func TestLoadWithIncludesRejectsRigNamedLikeRosterCity(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "qlandia"
+
+[mail.crosscity]
+cities = ["gastown"]
+
+[[rigs]]
+name = "gastown"
+path = "rigs/gastown"
+`)
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes: nil error, want rig/city collision refusal")
+	}
+	if !strings.Contains(err.Error(), "gastown") {
+		t.Errorf("error %q should name the colliding city", err.Error())
+	}
+}

--- a/internal/mail/crosscity.go
+++ b/internal/mail/crosscity.go
@@ -1,0 +1,139 @@
+package mail
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// CityRoster names the local city and the peer cities addressable with
+// city-qualified mail addresses of the form <city>/<address>. The first path
+// segment is the city; everything after the first "/" is that city's own
+// address form and is opaque to every other city. City names match exactly,
+// never case-folded.
+type CityRoster struct {
+	Local string
+	Peers []string
+}
+
+// Enabled reports whether cross-city addressing is configured: a roster needs
+// both a local city name and at least one peer. The zero value is disabled and
+// leaves every recipient exactly as it resolves today.
+func (r CityRoster) Enabled() bool {
+	return strings.TrimSpace(r.Local) != "" && len(r.Peers) > 0
+}
+
+// CityAddressKind classifies a recipient under cross-city addressing rules.
+type CityAddressKind int
+
+const (
+	// CityAddressNone means the recipient carries no cross-city semantics and
+	// resolves exactly as it does without a roster.
+	CityAddressNone CityAddressKind = iota
+	// CityAddressLocal means the recipient named the local city; the returned
+	// address is the remainder, resolved locally. <local>/<addr> and <addr>
+	// are one mailbox.
+	CityAddressLocal
+	// CityAddressForeign means the recipient named a peer city; the returned
+	// address is canonical as written and must not be session-resolved.
+	CityAddressForeign
+)
+
+// ResolveCityAddress classifies recipient by its first path segment. A
+// recipient with no "/", an empty remainder, or a first segment naming no
+// roster city is CityAddressNone with the recipient returned unchanged, so
+// bare names and rig-qualified names keep today's behavior.
+func (r CityRoster) ResolveCityAddress(recipient string) (CityAddressKind, string) {
+	if !r.Enabled() {
+		return CityAddressNone, recipient
+	}
+	trimmed := strings.TrimSpace(recipient)
+	city, rest, found := strings.Cut(trimmed, "/")
+	if !found || rest == "" {
+		return CityAddressNone, recipient
+	}
+	if city == r.Local {
+		return CityAddressLocal, rest
+	}
+	if slices.Contains(r.Peers, city) {
+		return CityAddressForeign, trimmed
+	}
+	return CityAddressNone, recipient
+}
+
+// UnknownCityError refuses an address whose first segment names no known
+// city. It deliberately replaces the resolution failure it upgrades rather
+// than wrapping it: a stale roster must refuse with the cities it knows,
+// never fall through to a session lookup spelled "session not found".
+type UnknownCityError struct {
+	City  string
+	Known []string
+}
+
+func (e *UnknownCityError) Error() string {
+	return fmt.Sprintf("unknown city %q (known cities: %s)", e.City, strings.Join(e.Known, ", "))
+}
+
+// WrapUnresolvedRecipient upgrades a resolution failure into an
+// *UnknownCityError when the failed recipient's first segment names neither a
+// known city nor a local scope (a rig, or the local city itself). Every other
+// failure — no roster, no "/", a local scope the resolver already understood —
+// returns err unchanged.
+func WrapUnresolvedRecipient(err error, recipient string, roster CityRoster, localScopes []string) error {
+	if err == nil || !roster.Enabled() {
+		return err
+	}
+	segment, rest, found := strings.Cut(strings.TrimSpace(recipient), "/")
+	if !found || rest == "" || segment == roster.Local {
+		return err
+	}
+	if slices.Contains(roster.Peers, segment) || slices.Contains(localScopes, segment) {
+		return err
+	}
+	known := make([]string, 0, 1+len(roster.Peers))
+	known = append(known, roster.Local)
+	known = append(known, roster.Peers...)
+	return &UnknownCityError{City: segment, Known: known}
+}
+
+// ExpandLocalRecipients appends the city-qualified alias of each local
+// recipient address, so a read serves mail addressed either way: delivery to
+// <local>/<addr> is a read on <addr>'s inbox. Recipients already carrying a
+// roster city segment are left alone; duplicates collapse.
+func (r CityRoster) ExpandLocalRecipients(recipients []string) []string {
+	if !r.Enabled() {
+		return recipients
+	}
+	seen := make(map[string]bool, 2*len(recipients))
+	out := make([]string, 0, 2*len(recipients))
+	add := func(addr string) {
+		if addr == "" || seen[addr] {
+			return
+		}
+		seen[addr] = true
+		out = append(out, addr)
+	}
+	for _, addr := range recipients {
+		add(addr)
+	}
+	for _, addr := range recipients {
+		if kind, _ := r.ResolveCityAddress(addr); kind != CityAddressNone {
+			continue
+		}
+		add(r.Local + "/" + addr)
+	}
+	return out
+}
+
+// QualifySender returns the sender's city-qualified form for a message that
+// crosses cities, so the recipient's plain reply resolves back here. A sender
+// already carrying a roster city segment is returned unchanged.
+func (r CityRoster) QualifySender(sender string) string {
+	if !r.Enabled() || sender == "" {
+		return sender
+	}
+	if kind, _ := r.ResolveCityAddress(sender); kind != CityAddressNone {
+		return sender
+	}
+	return r.Local + "/" + sender
+}

--- a/internal/mail/crosscity.go
+++ b/internal/mail/crosscity.go
@@ -43,20 +43,28 @@ const (
 // recipient with no "/", an empty remainder, or a first segment naming no
 // roster city is CityAddressNone with the recipient returned unchanged, so
 // bare names and rig-qualified names keep today's behavior.
+//
+// The remainder gets the same minimal normalization local resolution applies
+// (surrounding whitespace and one trailing "/" trimmed), so a foreign send
+// cannot mint a mailbox the destination's own reads would never serve. The
+// split is single-level: <local>/<local>/<addr> is not recursively stripped.
 func (r CityRoster) ResolveCityAddress(recipient string) (CityAddressKind, string) {
 	if !r.Enabled() {
 		return CityAddressNone, recipient
 	}
-	trimmed := strings.TrimSpace(recipient)
-	city, rest, found := strings.Cut(trimmed, "/")
-	if !found || rest == "" {
+	city, rest, found := strings.Cut(strings.TrimSpace(recipient), "/")
+	if !found {
+		return CityAddressNone, recipient
+	}
+	rest = strings.TrimSuffix(strings.TrimSpace(rest), "/")
+	if rest == "" {
 		return CityAddressNone, recipient
 	}
 	if city == r.Local {
 		return CityAddressLocal, rest
 	}
 	if slices.Contains(r.Peers, city) {
-		return CityAddressForeign, trimmed
+		return CityAddressForeign, city + "/" + rest
 	}
 	return CityAddressNone, recipient
 }
@@ -74,12 +82,12 @@ func (e *UnknownCityError) Error() string {
 	return fmt.Sprintf("unknown city %q (known cities: %s)", e.City, strings.Join(e.Known, ", "))
 }
 
-// WrapUnresolvedRecipient upgrades a resolution failure into an
+// RefuseUnknownCity upgrades a resolution failure into an
 // *UnknownCityError when the failed recipient's first segment names neither a
 // known city nor a local scope (a rig, or the local city itself). Every other
 // failure — no roster, no "/", a local scope the resolver already understood —
 // returns err unchanged.
-func WrapUnresolvedRecipient(err error, recipient string, roster CityRoster, localScopes []string) error {
+func RefuseUnknownCity(err error, recipient string, roster CityRoster, localScopes []string) error {
 	if err == nil || !roster.Enabled() {
 		return err
 	}

--- a/internal/mail/crosscity_test.go
+++ b/internal/mail/crosscity_test.go
@@ -54,6 +54,10 @@ func TestResolveCityAddress(t *testing.T) {
 		{"city names match exactly, not case-folded", "Gastown/mayor", CityAddressNone, "Gastown/mayor"},
 		{"surrounding whitespace is trimmed", "  gastown/mayor  ", CityAddressForeign, "gastown/mayor"},
 		{"whitespace inside the first segment is not a city match", "gastown /mayor", CityAddressNone, "gastown /mayor"},
+		{"foreign remainder trims a trailing slash like local resolution does", "gastown/mayor/", CityAddressForeign, "gastown/mayor"},
+		{"foreign remainder trims surrounding whitespace", "gastown/ mayor", CityAddressForeign, "gastown/mayor"},
+		{"foreign remainder that is only separators falls through", "gastown//", CityAddressNone, "gastown//"},
+		{"local remainder trims a trailing slash", "qlandia/mayor/", CityAddressLocal, "mayor"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -88,7 +92,7 @@ func TestUnknownCityErrorMessage(t *testing.T) {
 	}
 }
 
-func TestWrapUnresolvedRecipient(t *testing.T) {
+func TestRefuseUnknownCity(t *testing.T) {
 	roster := enabledRoster()
 	base := fmt.Errorf("unknown recipient %q", "x")
 	rigs := []string{"qcore", "gascity"}
@@ -108,7 +112,7 @@ func TestWrapUnresolvedRecipient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := WrapUnresolvedRecipient(base, tt.recipient, tt.roster, rigs)
+			got := RefuseUnknownCity(base, tt.recipient, tt.roster, rigs)
 			var unknownCity *UnknownCityError
 			if tt.wantCity == "" {
 				if !errors.Is(got, base) {
@@ -128,9 +132,9 @@ func TestWrapUnresolvedRecipient(t *testing.T) {
 
 // The unknown-city refusal must replace the fall-through resolution error so a
 // stale roster can never be spelled "session not found".
-func TestWrapUnresolvedRecipientDoesNotUnwrapToOriginal(t *testing.T) {
+func TestRefuseUnknownCityDoesNotUnwrapToOriginal(t *testing.T) {
 	sentinel := errors.New("session not found")
-	got := WrapUnresolvedRecipient(sentinel, "gastwn/mayor", enabledRoster(), nil)
+	got := RefuseUnknownCity(sentinel, "gastwn/mayor", enabledRoster(), nil)
 	if errors.Is(got, sentinel) {
 		t.Errorf("unknown-city error must not unwrap to the resolution error it replaces")
 	}

--- a/internal/mail/crosscity_test.go
+++ b/internal/mail/crosscity_test.go
@@ -1,0 +1,223 @@
+package mail
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func enabledRoster() CityRoster {
+	return CityRoster{Local: "qlandia", Peers: []string{"gastown", "westeros"}}
+}
+
+func TestCityRosterEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		roster CityRoster
+		want   bool
+	}{
+		{"zero value", CityRoster{}, false},
+		{"local only", CityRoster{Local: "qlandia"}, false},
+		{"peers only", CityRoster{Peers: []string{"gastown"}}, false},
+		{"local and peers", enabledRoster(), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.roster.Enabled(); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCityAddress(t *testing.T) {
+	roster := enabledRoster()
+	tests := []struct {
+		name      string
+		recipient string
+		wantKind  CityAddressKind
+		wantAddr  string
+	}{
+		{"local prefix strips to rig-qualified rest", "qlandia/qcore/syl", CityAddressLocal, "qcore/syl"},
+		{"local prefix strips to bare rest", "qlandia/mayor", CityAddressLocal, "mayor"},
+		{"peer city is foreign, canonical as written", "gastown/mayor", CityAddressForeign, "gastown/mayor"},
+		{"foreign split is on the first slash only", "gastown/qcore/dalinar", CityAddressForeign, "gastown/qcore/dalinar"},
+		{"second peer", "westeros/human", CityAddressForeign, "westeros/human"},
+		{"unknown first segment falls through", "qcore/syl", CityAddressNone, "qcore/syl"},
+		{"bare name falls through", "mayor", CityAddressNone, "mayor"},
+		{"human falls through", "human", CityAddressNone, "human"},
+		{"bare local city name falls through", "qlandia", CityAddressNone, "qlandia"},
+		{"bare peer city name falls through", "gastown", CityAddressNone, "gastown"},
+		{"local city with empty rest falls through", "qlandia/", CityAddressNone, "qlandia/"},
+		{"peer city with empty rest falls through", "gastown/", CityAddressNone, "gastown/"},
+		{"city names match exactly, not case-folded", "Gastown/mayor", CityAddressNone, "Gastown/mayor"},
+		{"surrounding whitespace is trimmed", "  gastown/mayor  ", CityAddressForeign, "gastown/mayor"},
+		{"whitespace inside the first segment is not a city match", "gastown /mayor", CityAddressNone, "gastown /mayor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, addr := roster.ResolveCityAddress(tt.recipient)
+			if kind != tt.wantKind || addr != tt.wantAddr {
+				t.Errorf("ResolveCityAddress(%q) = (%v, %q), want (%v, %q)",
+					tt.recipient, kind, addr, tt.wantKind, tt.wantAddr)
+			}
+		})
+	}
+}
+
+func TestResolveCityAddressDisabledRoster(t *testing.T) {
+	var roster CityRoster
+	kind, addr := roster.ResolveCityAddress("gastown/mayor")
+	if kind != CityAddressNone || addr != "gastown/mayor" {
+		t.Errorf("disabled roster: got (%v, %q), want (%v, %q)",
+			kind, addr, CityAddressNone, "gastown/mayor")
+	}
+}
+
+func TestUnknownCityErrorMessage(t *testing.T) {
+	err := &UnknownCityError{City: "gastwn", Known: []string{"gastown", "qlandia", "westeros"}}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown city") || !strings.Contains(msg, `"gastwn"`) {
+		t.Errorf("message %q should name the unknown city", msg)
+	}
+	for _, known := range []string{"gastown", "qlandia", "westeros"} {
+		if !strings.Contains(msg, known) {
+			t.Errorf("message %q should list known city %q", msg, known)
+		}
+	}
+}
+
+func TestWrapUnresolvedRecipient(t *testing.T) {
+	roster := enabledRoster()
+	base := fmt.Errorf("unknown recipient %q", "x")
+	rigs := []string{"qcore", "gascity"}
+
+	tests := []struct {
+		name      string
+		roster    CityRoster
+		recipient string
+		wantCity  string // "" means the original error must come back unchanged
+	}{
+		{"unknown slash-form segment becomes unknown city", roster, "gastwn/mayor", "gastwn"},
+		{"known rig segment keeps the original error", roster, "qcore/nobody", ""},
+		{"local city segment keeps the original error", roster, "qlandia/nobody", ""},
+		{"peer city segment keeps the original error", roster, "gastown/mayor", ""},
+		{"no slash keeps the original error", roster, "nobody", ""},
+		{"disabled roster keeps the original error", CityRoster{}, "gastwn/mayor", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WrapUnresolvedRecipient(base, tt.recipient, tt.roster, rigs)
+			var unknownCity *UnknownCityError
+			if tt.wantCity == "" {
+				if !errors.Is(got, base) {
+					t.Errorf("got %v, want original error %v", got, base)
+				}
+				return
+			}
+			if !errors.As(got, &unknownCity) {
+				t.Fatalf("got %v (%T), want *UnknownCityError", got, got)
+			}
+			if unknownCity.City != tt.wantCity {
+				t.Errorf("City = %q, want %q", unknownCity.City, tt.wantCity)
+			}
+		})
+	}
+}
+
+// The unknown-city refusal must replace the fall-through resolution error so a
+// stale roster can never be spelled "session not found".
+func TestWrapUnresolvedRecipientDoesNotUnwrapToOriginal(t *testing.T) {
+	sentinel := errors.New("session not found")
+	got := WrapUnresolvedRecipient(sentinel, "gastwn/mayor", enabledRoster(), nil)
+	if errors.Is(got, sentinel) {
+		t.Errorf("unknown-city error must not unwrap to the resolution error it replaces")
+	}
+}
+
+func TestExpandLocalRecipients(t *testing.T) {
+	roster := enabledRoster()
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			"local addresses gain their city-qualified alias",
+			[]string{"qcore/syl", "mayor"},
+			[]string{"qcore/syl", "mayor", "qlandia/qcore/syl", "qlandia/mayor"},
+		},
+		{
+			"human gains the qualified alias",
+			[]string{"human"},
+			[]string{"human", "qlandia/human"},
+		},
+		{
+			"already-qualified local form is not double-qualified",
+			[]string{"qlandia/qcore/syl"},
+			[]string{"qlandia/qcore/syl"},
+		},
+		{
+			"foreign form is left alone",
+			[]string{"gastown/mayor"},
+			[]string{"gastown/mayor"},
+		},
+		{
+			"duplicates collapse",
+			[]string{"mayor", "qlandia/mayor"},
+			[]string{"mayor", "qlandia/mayor"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roster.ExpandLocalRecipients(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ExpandLocalRecipients(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("ExpandLocalRecipients(%v)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExpandLocalRecipientsDisabledRoster(t *testing.T) {
+	var roster CityRoster
+	in := []string{"qcore/syl", "human"}
+	got := roster.ExpandLocalRecipients(in)
+	if len(got) != len(in) || got[0] != in[0] || got[1] != in[1] {
+		t.Errorf("disabled roster must return recipients unchanged: got %v, want %v", got, in)
+	}
+}
+
+func TestQualifySender(t *testing.T) {
+	roster := enabledRoster()
+	tests := []struct {
+		name   string
+		sender string
+		want   string
+	}{
+		{"local identity gains the city prefix", "qcore/syl", "qlandia/qcore/syl"},
+		{"bare identity gains the city prefix", "mayor", "qlandia/mayor"},
+		{"human gains the city prefix", "human", "qlandia/human"},
+		{"already locally qualified stays put", "qlandia/qcore/syl", "qlandia/qcore/syl"},
+		{"foreign-qualified stays put", "gastown/mayor", "gastown/mayor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := roster.QualifySender(tt.sender); got != tt.want {
+				t.Errorf("QualifySender(%q) = %q, want %q", tt.sender, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQualifySenderDisabledRoster(t *testing.T) {
+	var roster CityRoster
+	if got := roster.QualifySender("mayor"); got != "mayor" {
+		t.Errorf("disabled roster must return sender unchanged: got %q", got)
+	}
+}


### PR DESCRIPTION
## RFC — asking for design buy-in before review

This PR is held as a **draft on purpose**. It is a complete, flag-gated, inert-when-off implementation, but it proposes a *topology* upstream has no reference deployment for, and that deserves a yes-or-no before anyone spends review cycles on ~1,600 lines.

**The topology.** Several independently operated cities share one physical store for the `messaging` bead class — a relocated `[storage.classes.messaging]` binding, which #4017 made a first-class front door. In that shape a cross-city mail is a plain read on the receiving side; the only missing piece is an address form that says *which* city a name belongs to. That is all this PR adds: `<city>/<address>`, split on the first `/`, roster-checked, opaque past the city segment.

**How it relates to `gc context`.** `gc context` switches a whole session onto a remote city's HTTP+SSE API — kubectx for cities. This is different and complementary: one address space over a shared store, so a plain `gc mail reply` on the receiving side routes back across cities with no context switch. If maintainers would rather cross-city mail always travel the control plane (the #5386 direction), this PR should not land — and we would like to know that now rather than after review.

**Sender trust, stated explicitly.** `--from` with a foreign city segment is accepted verbatim. That adds no authentication and removes none: a shared messaging store already means every writer is trusted, exactly as it does for any bead today — a caller who can write to the store can already forge any sender. The PR does not move that boundary and does not claim to. If upstream wants sender attestation, it belongs in the store/transport layer, not in address parsing.

**Reference deployment.** Our fleet (three cities over one hub store) is what this was built for; we can supply a `docs/guides` walkthrough with the real configuration if there is appetite.

**The ask:** appetite yes/no on the address form and the shared-store topology. On a no, we withdraw and carry nothing — the flag-gated shape means the fork does not depend on it.

---

## What

Opt-in **city-qualified mail addressing** behind a new `[mail.crosscity]` config section. When configured, a mail recipient may take the form `<city>/<address>`: the first path segment names a city, and everything after the first `/` is that city's own address form, opaque to every other city.

```toml
[mail.crosscity]
# city = "qlandia"          # optional; defaults to the effective city name
cities = ["gastown", "westeros"]
```

Behavior with the section present:

- **`<local city>/<addr>` and `<addr>` are one mailbox.** Sends canonicalize the local-qualified form to the bare form; reads serve mail addressed either way (inbox/check/count recipient sets gain the city-qualified alias, on both the CLI and API read paths).
- **A listed peer city's address is canonical as written and is never looked up in the local session store.** Fresh send was the one surface that refused any `/`-containing identifier it couldn't resolve locally; reply and inbox already accepted the namespace. This closes that asymmetry.
- **Senders on cross-city mail are stored city-qualified** (`<local city>/<sender>`), so a plain reply on the receiving side resolves back to the sending city. Applied consistently on CLI send, CLI reply into a foreign-origin thread, API send, and API reply.
- **`--from` carrying a peer city's segment is accepted verbatim** — only its own city can check that identity. A local-city-qualified `--from` strips to the bare form and stays identity-checked; an unknown local sender is still refused.
- **`--notify` on a cross-city recipient is a typed refusal before any write.** No cross-machine wake primitive exists; a nudge queued into a leg that is not there must not report success. The recipient's wake belongs to its own city's mail sweep.
- **An address whose first segment names neither a rig nor a known city refuses as `unknown city "<x>" (known cities: ...)`** — never as a session lookup failure — so a stale or missing roster entry is diagnosable on the first occurrence.
- **Config validation refuses a rig named like any roster city (the local city included):** the first mail-address segment must bind unambiguously to either a rig or a city, never both.

Absent `[mail.crosscity]`, every new branch is disabled by the roster's zero value and behavior is unchanged — pinned by no-roster guard tests on both the CLI and API surfaces.

## Why

Multi-city deployments — several Gas City instances coordinating over a shared store — have no way to address mail across city boundaries, so every crossing becomes an out-of-band relay with at least one hop that reports success into nothing. #4017 routed all non-work bead access through coordination-class front doors, making the messaging class's *storage* pluggable (`[storage.classes.messaging]` can relocate it). This PR completes the *addressing* side of that seam: with a resolvable cross-city namespace, a relocated shared messaging store serves cross-city delivery as a plain read, with no relay, no wake hop, and exactly-once by construction (one bead is the message).

This slice is deliberately inert: it makes city-qualified addressing work and be testable **within one store**, and moves nothing. Pointing the messaging class at a shared store is deployment configuration via the existing `[storage]` machinery, not part of this change.

## Design notes for reviewers

- The resolver core is a pure, dependency-free type (`mail.CityRoster`) with the CLI and API each wiring it at their existing resolution seams; the config package stays a leaf (no `internal/mail` import).
- `resolveLiveConfiguredNamedMailTarget`'s rejection of `/`-containing identifiers is intentionally untouched: the city split happens above it, and locally-stripped remainders flow through existing resolution unchanged.
- `[mail]` composes wholesale across config layers (existing section semantics); `crosscity` inherits that contract.
- API reads stay open-world for unresolved recipients exactly as today; the read-side alias expansion also covers unresolved names, which is deliberate — any local box `<addr>` must serve mail addressed to `<local city>/<addr>`, that is what makes delivery a read.
- A foreign remainder gets the same minimal normalization local resolution applies (surrounding whitespace, one trailing `/`), so a send to `gastown/mayor/` cannot mint a mailbox the destination's reads would never serve; the split stays single-level and the remainder otherwise opaque.
- With the roster enabled, a reply whose thread origin cannot be read fails closed — without the origin, the cross-city rules (notify refusal, sender qualification) cannot be applied.
- One deliberate message change on the disabled path: the invalid `--from` refusal now names the sender the caller gave; previously it printed the zeroed resolution result (`invalid sender ""`). Pinned by tests.
- Known follow-up: `--notify` on a reply into a thread this city *originated* cross-city (stored From `<local city>/<sender>`) still attempts a local nudge against the qualified form and reports "nudge failed"; teaching the nudge resolver the local-strip is the right home for that fix and is left out of this slice.
- Other follow-ups kept out: recording refused sends in mail telemetry (`undeliverable` with a reason, today refusals return before any telemetry), and sourcing the roster from data rather than config for deployments that want it centralized.

## Tests

- `internal/mail/crosscity_test.go` — table tests for the classifier (first-slash split, exact-match city names, empty remainders, whitespace, disabled roster), the typed unknown-city error (including that it does not unwrap to the resolution error it replaces), read-side expansion, and sender qualification.
- `internal/config/mail_crosscity_test.go` — parse, roster accessor (nil-safe, explicit-city precedence, workspace/directory fallbacks), validation table (empty/duplicate/invalid/self-listing cities, rig collisions against peer and local city names), and an end-to-end `LoadWithIncludes` refusal for the rig/city collision.
- `cmd/gc/mail_crosscity_test.go` — foreign resolution against a **nil session store** (a regression that consults the store cannot pass), one-mailbox equivalence, typed unknown-city vs rig-segment vs no-roster failure shapes, full-command send/reply flows (canonical To, qualified From, `--from` matrix, typed `--notify` refusals before any write), and read-target expansion.
- `internal/api/handler_mail_crosscity_test.go` — the same behaviors through the HTTP surface, including qualified From on send and reply, the exact no-roster refusal shape, and city-qualified delivery served by an ordinary inbox query.

`make test`, `go vet`, and the full `internal/api`, `internal/mail`, `internal/config` packages pass; `docs/reference/{config.md,cli.md,schema/city-schema.*}` are regenerated via `cmd/genschema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvU8iDeCxbuqVKqEp7W5RT

