### PR TITLE
fix(push-gate): an occupied descriptor must not consume a free slot (ga-rjj9lm)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -993,8 +993,11 @@ that stays locked past its gate means a leaked descendant is still holding
 the descriptor (`lsof` on the slot file names it), not a stale file to
 delete. The gate needs `flock(1)`, which `docs/getting-started/installation.md`
 already lists as required; if it is absent the run proceeds uncapped with a
-warning rather than blocking. `GC_PUSH_GATE_NO_CAP=1` bypasses the cap
-entirely for one invocation.
+warning rather than blocking. The run likewise proceeds uncapped, with a
+diagnostic, if no descriptor in `[PUSH_GATE_FD_BASE, PUSH_GATE_FD_BASE +
+PUSH_GATE_FD_SPAN)` is free — an environment defect is never misreported as
+contention. `GC_PUSH_GATE_NO_CAP=1` bypasses the cap entirely for one
+invocation.
 
 The slot mechanics are covered by `scripts/test-push-gate-lock.sh`, run
 directly as the `push-gate-lock-selftest` job inside `test-local-parallel`

--- a/scripts/push-gate-lock-lib.sh
+++ b/scripts/push-gate-lock-lib.sh
@@ -136,10 +136,24 @@
 # Sourced by scripts/test-local-parallel and directly by
 # scripts/test-push-gate-lock.sh.
 
-# Base file-descriptor number for slot <i>; slot <i> always maps to
-# PUSH_GATE_FD_BASE + i. Fixed numbers rather than bash 4.1's `exec {var}<>`
-# keep the 3.2 floor above.
+# Lowest file-descriptor number the slot locks may use. Fixed numbers rather
+# than bash 4.1's `exec {var}<>` keep the 3.2 floor above.
+#
+# A slot is NOT bound to a fixed descriptor. It used to be — slot <i> always
+# took PUSH_GATE_FD_BASE + i — and that made slot availability depend on the
+# CALLER's descriptor table: a descriptor inherited from any ancestor at that
+# number made the acquire loop skip the slot without ever opening or flocking
+# its lock file, so a free slot was silently counted as busy and the caller
+# burned its whole wait bound (ga-rjj9lm; false FIX-IS-BAD push denial on
+# gastownhall/gascity#5783). Each acquire now takes the first FREE descriptor
+# at or above the base, so descriptor occupancy and slot occupancy are
+# independent facts.
 PUSH_GATE_FD_BASE=200
+# How far above the base to look for a free descriptor before giving up. Only
+# an acquire that is already holding slots consumes these, so the span only has
+# to exceed the largest sane PUSH_GATE_MAX_CONCURRENT plus whatever an ancestor
+# happens to have open in the range.
+PUSH_GATE_FD_SPAN=64
 
 # Resolve the city root, validating any env var before trusting it so a
 # stray GC_CITY_PATH can't redirect the lock directory arbitrarily.
@@ -295,14 +309,30 @@ push_gate_acquire_slot() {
         return 0
     fi
 
-    local _pgl_i _pgl_slot _pgl_fd _pgl_announced=0 _pgl_start=0
+    local _pgl_i _pgl_slot _pgl_fd _pgl_try _pgl_announced=0 _pgl_start=0
 
     while :; do
         for (( _pgl_i = 0; _pgl_i < _pgl_max; _pgl_i++ )); do
             _pgl_slot="$_pgl_slot_dir/slot-${_pgl_i}.lock"
-            _pgl_fd=$(( PUSH_GATE_FD_BASE + _pgl_i ))
-            if _push_gate_fd_in_use "$_pgl_fd"; then
-                continue
+            # Pick a descriptor for THIS attempt. Never let an in-use
+            # descriptor stand in for a busy slot: only flock below may
+            # decide a slot is taken (ga-rjj9lm).
+            _pgl_fd=""
+            for (( _pgl_try = PUSH_GATE_FD_BASE; _pgl_try < PUSH_GATE_FD_BASE + PUSH_GATE_FD_SPAN; _pgl_try++ )); do
+                if ! _push_gate_fd_in_use "$_pgl_try"; then
+                    _pgl_fd="$_pgl_try"
+                    break
+                fi
+            done
+            if [[ -z "$_pgl_fd" ]]; then
+                # Every descriptor in the span is taken, so no slot can be
+                # held no matter how long we wait. Degrade best-effort with a
+                # diagnostic, exactly as the missing-flock and unwritable-dir
+                # paths do — waiting out the bound here would report a
+                # contention timeout for what is not contention.
+                echo "push-gate: no free descriptor in [$PUSH_GATE_FD_BASE,$(( PUSH_GATE_FD_BASE + PUSH_GATE_FD_SPAN - 1 ))] — running without a cross-invocation cap" >&2
+                eval "$_pgl_fd_var="
+                return 0
             fi
             eval "exec ${_pgl_fd}<>\"\$_pgl_slot\"" || continue
             if flock -n "$_pgl_fd"; then

--- a/scripts/push-gate-lock-lib.sh
+++ b/scripts/push-gate-lock-lib.sh
@@ -70,12 +70,13 @@
 #     or `sleep` unvalidated.
 #   - A timed-out acquire returns 1 (shell-false), and ONLY a timed-out
 #     acquire returns 1 — every degrade case (missing flock(1), a slot dir
-#     that cannot be created) prints its own diagnostic and returns 0 with
-#     an empty fd instead, so callers can trust that a 1 always means a
-#     real wait-bound expiry, never an environment defect misreported as
-#     fleet contention. This library never calls `exit` itself — mapping a
-#     timeout to process exit code 75 is the caller's job
-#     (scripts/test-local-parallel), keeping this file a pure, testable
+#     that cannot be created, no free descriptor in [PUSH_GATE_FD_BASE,
+#     PUSH_GATE_FD_BASE+PUSH_GATE_FD_SPAN)) prints its own diagnostic and
+#     returns 0 with an empty fd instead, so callers can trust that a 1
+#     always means a real wait-bound expiry, never an environment defect
+#     misreported as fleet contention. This library never calls `exit`
+#     itself — mapping a timeout to process exit code 75 is the caller's
+#     job (scripts/test-local-parallel), keeping this file a pure, testable
 #     function library.
 #
 # FUNCTIONS
@@ -108,7 +109,9 @@
 #       ${GC_SESSION_NAME:-${GC_AGENT:-${GC_TEMPLATE:-unknown}}}. If the slot
 #       dir cannot be created (e.g. an unwritable parent), degrades the same
 #       way as a missing flock(1): diagnostic to stderr, empty fd, return 0
-#       — never conflated with a timeout. Otherwise sweeps slots 0..N-1
+#       — never conflated with a timeout. An acquire that finds no free
+#       descriptor in [PUSH_GATE_FD_BASE, PUSH_GATE_FD_BASE +
+#       PUSH_GATE_FD_SPAN) degrades identically. Otherwise sweeps slots 0..N-1
 #       non-blocking; acquires the first free one immediately (fd assigned
 #       to the caller's <fd_out_var>, return 0). If all slots are busy:
 #       prints an immediate unbuffered diagnostic naming current holders
@@ -245,10 +248,10 @@ push_gate_describe_slots() {
     done
 }
 
-# True when file descriptor $1 is already open in this shell. Slot FDs are
-# fixed numbers, so a second acquire in the same process must not re-open a
-# number it already holds: `exec N<>file` on a live N closes the old
-# descriptor and silently drops that slot's lock.
+# True when file descriptor $1 is already open in this shell. A slot FD is
+# chosen per attempt and must never be a number this shell already holds:
+# `exec N<>file` on a live N closes the old descriptor and silently drops
+# that slot's lock.
 _push_gate_fd_in_use() {
     ( true <&"$1" ) 2>/dev/null
 }

--- a/scripts/test-push-gate-lock.sh
+++ b/scripts/test-push-gate-lock.sh
@@ -142,7 +142,6 @@ else
     record_fail "inherit.detached_descendant_does_not_pin_slot" "could not acquire a slot to set up the case"
 fi
 
-
 # ---------------- an occupied descriptor must not consume a slot (ga-rjj9lm) ----------------
 # The slot index used to be hardwired to a descriptor number (slot i always
 # took FD PUSH_GATE_FD_BASE + i), and a descriptor already open in the CALLING
@@ -169,6 +168,35 @@ FDBASE_OUT="$(LIB="$LIB" DIR="$FDBASE_SLOTS" ANCHOR="$WORK/fdbase-anchor" \
         if [[ "$a" == "$b" ]]; then echo SAME_FD; else echo BOTH; fi
     ')"
 assert_eq "fd_base.occupied_descriptor_does_not_consume_a_slot" "$FDBASE_OUT" "BOTH"
+
+# ---------------- descriptor span exhausted: degrade best-effort, never misreport ----------------
+# Scanning for a free descriptor introduces a third way to fail before any
+# slot is even probed: every number in [PUSH_GATE_FD_BASE, +PUSH_GATE_FD_SPAN)
+# already open in the calling shell. No amount of waiting fixes that, so it
+# must degrade exactly as the missing-flock and unwritable-dir paths do —
+# diagnostic, empty fd, return 0 — and must never surface as a timeout, which
+# would send operators chasing contention that does not exist (ga-rjj9lm).
+FDSPAN_OUT="$(LIB="$LIB" DIR="$WORK/fdspan-slots" ANCHOR="$WORK/fdspan-anchor" \
+    PUSH_GATE_MAX_CONCURRENT=1 PUSH_GATE_MAX_WAIT_SECONDS=5 PUSH_GATE_POLL_SECONDS=1 \
+    bash -c '
+        . "$LIB"
+        : >"$ANCHOR"
+        for (( n = PUSH_GATE_FD_BASE; n < PUSH_GATE_FD_BASE + PUSH_GATE_FD_SPAN; n++ )); do
+            eval "exec $n<>\"\$ANCHOR\"" || { echo SETUP_FAILED; exit 0; }
+        done
+        z=preset
+        push_gate_acquire_slot "$DIR" z holder-H
+        echo "rc=$? fd=[$z]"
+    ' 2>&1)"
+assert_contains "fd_span.warns_no_free_descriptor" "$FDSPAN_OUT" "no free descriptor"
+assert_contains "fd_span.returns_zero_empty_fd"    "$FDSPAN_OUT" "rc=0 fd=[]"
+case "$FDSPAN_OUT" in
+    *"timed out"*)
+        record_fail "fd_span.never_reports_timeout" "found 'timed out' in output: $FDSPAN_OUT" ;;
+    *)
+        record_pass "fd_span.never_reports_timeout" ;;
+esac
+
 # ---------------- describe: a held slot whose recorded PID is gone is flagged ----------------
 # Hold a slot for real, then overwrite its holder line with a PID that cannot
 # exist — the exact shape a leaked descendant leaves behind: lock genuinely

--- a/scripts/test-push-gate-lock.sh
+++ b/scripts/test-push-gate-lock.sh
@@ -142,6 +142,33 @@ else
     record_fail "inherit.detached_descendant_does_not_pin_slot" "could not acquire a slot to set up the case"
 fi
 
+
+# ---------------- an occupied descriptor must not consume a slot (ga-rjj9lm) ----------------
+# The slot index used to be hardwired to a descriptor number (slot i always
+# took FD PUSH_GATE_FD_BASE + i), and a descriptor already open in the CALLING
+# process — inherited from any ancestor — made the acquire loop `continue` past
+# that slot without ever opening or flocking its lock file. A FREE slot was
+# counted as busy, silently: the caller burned its entire wait bound and then
+# reported "all N slot(s) busy" while describe_slots printed nothing for the
+# skipped slot, because that slot's lock file had never been created. That
+# self-contradicting output is the fingerprint. In production it became a false
+# FIX-IS-BAD push denial on gastownhall/gascity#5783 (47 passed / 4 failed
+# against slots that were in fact free, after a 600s stall).
+# Occupancy of a DESCRIPTOR must never be read as occupancy of a SLOT.
+FDBASE_SLOTS="$WORK/fdbase-slots"
+FDBASE_OUT="$(LIB="$LIB" DIR="$FDBASE_SLOTS" ANCHOR="$WORK/fdbase-anchor" \
+    PUSH_GATE_MAX_CONCURRENT=2 PUSH_GATE_MAX_WAIT_SECONDS=0 PUSH_GATE_POLL_SECONDS=1 \
+    bash -c '
+        . "$LIB"
+        : >"$ANCHOR"
+        # Occupy exactly the descriptor slot-0 would have claimed.
+        eval "exec ${PUSH_GATE_FD_BASE}<>\"\$ANCHOR\"" || { echo SETUP_FAILED; exit 0; }
+        a=""; b=""
+        push_gate_acquire_slot "$DIR" a holder-A || { echo FIRST_DENIED; exit 0; }
+        push_gate_acquire_slot "$DIR" b holder-B || { echo SECOND_DENIED; exit 0; }
+        if [[ "$a" == "$b" ]]; then echo SAME_FD; else echo BOTH; fi
+    ')"
+assert_eq "fd_base.occupied_descriptor_does_not_consume_a_slot" "$FDBASE_OUT" "BOTH"
 # ---------------- describe: a held slot whose recorded PID is gone is flagged ----------------
 # Hold a slot for real, then overwrite its holder line with a PID that cannot
 # exist — the exact shape a leaked descendant leaves behind: lock genuinely


### PR DESCRIPTION
## The bug

Slot `<i>` was hardwired to descriptor `PUSH_GATE_FD_BASE + i`, so **slot availability depended on the caller's descriptor table**. A descriptor inherited from any ancestor at that number made the acquire loop `continue` past the slot *without ever opening or flocking its lock file*. A free slot was counted as busy, silently — and the caller then burned its entire wait bound (600s by default) before reporting a contention timeout that was not contention.

## Evidence

**The production log contradicts itself, and only this path explains it.** `push_gate_describe_slots` prints a slot only if its lock file exists *and* the slot is currently locked. The pre-push gate log for #5783 printed:

```
push-gate: all 2 slot(s) busy, waiting up to 600s (checking every 15s):
  slot-1: 866807 2026-08-30T23:19:18Z holder-A roglet
push-gate: timed out after 600s waiting for a free slot
```

It declared *both* slots busy and then described only slot-1 — slot-0 was free at that moment. Genuine contention cannot produce that: under contention `slot-0.lock` exists, is held, and prints. The only code path that calls a slot busy without touching its lock file is the descriptor skip.

**Controlled reproduction, load held constant.** On one host at load average 35.3:

| condition | result |
|---|---|
| ordinary run | 51 passed, 0 failed |
| FD 200 held open | 47 passed, **4 failed** |

Same host, same load, same tree, same minute — the only variable is whether the base descriptor is open. The four failures are exactly those seen in production, with the same `slot-1: … holder-A` shape.

This also explains why re-running the suite by hand "proved" the fix good: a hand run has no ancestor holding the descriptor. That is a difference in **invocation context**, not host load.

## Why it mattered

`push-denial-lib.sh` classifies a failing local gate as `local_gate_failed`, which `mpr_push_failure_fix_is_unverified` treats as proof the fix itself is bad and `mpr_push_failure_is_permanent` marks permanently unretryable ("DO NOT retry the push and DO NOT use `--no-verify`"). So a descriptor collision was converted into a permanent, human-facing accusation against a correct fix — and cost 600s of gate time each time it fired.

## The change

Each acquire now scans upward from the base for the first **free** descriptor and binds it to the slot, so descriptor occupancy and slot occupancy are independent facts and only `flock` decides a slot is taken. `PUSH_GATE_FD_SPAN` (64) bounds the scan; when every descriptor in the span is occupied no slot can ever be held, so that degrades best-effort with a diagnostic rather than waiting out a bound it cannot satisfy — matching the existing missing-flock and unwritable-dir paths.

Stays inside the file's deliberate bash 3.2 floor (macOS stock `/bin/bash`): no dynamic FD allocation, no namerefs. `shellcheck` clean.

## Tests

New regression test `fd_base.occupied_descriptor_does_not_consume_a_slot` opens the base descriptor and requires two slots to still be acquirable. It fails with `SECOND_DENIED` before the lib change.

Verified 52/52 in five configurations: base descriptor free; FD 200 held (the production condition); 200+201 held; 200-219 held; and the degrade path with 200-263 held. The concurrency cap still denies a third acquire, and `describe_slots` now lists both slots instead of one.

The pre-push gate ran this change end to end: `[push-gate-lock-selftest] ok`, all fast jobs passed.

Bead: ga-rjj9lm
