### PR TITLE
fix(orders): read order-tracking sweeps from the Live tier (ga-v5vnyp)

### DIFF
--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -182,7 +182,11 @@ func (s *beadPolicyStore) ListByLabel(label string, limit int, opts ...beads.Que
 		Label:         label,
 		Limit:         limit,
 		IncludeClosed: beads.HasOpt(opts, beads.IncludeClosed),
-		TierMode:      policyTierFromOpts(opts),
+		// Both wrapped implementations (BdStore, CachingStore) set a Sort here;
+		// omitting it left SortDefault, which over a map is non-deterministic
+		// order — so any budgeted consumer got an arbitrary slice (ga-v5vnyp).
+		Sort:     beads.SortCreatedDesc,
+		TierMode: policyTierFromOpts(opts),
 	})
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1925,6 +1925,100 @@ func TestOrderTrackingSweepWatchdogClosesAllStaleTracking(t *testing.T) {
 	}
 }
 
+// TestOrderTrackingSweepWatchdogSeesBeadsWrittenBehindTheCache is the
+// regression test for ga-v5vnyp, and it is deliberately built on the PRODUCTION
+// store stack rather than a bare MemStore.
+//
+// That distinction is the whole point. Every other watchdog test here hands
+// CityRuntime a raw beads.NewMemStore(), so every read is authoritative and the
+// suite stayed green for the entire 43 hours the watchdog was blind in
+// production. The real controller store is a beadPolicyStore wrapping a
+// CachingStore, and order-tracking beads are created and closed through the
+// DISPATCHER's own uncached handle — so the cache never observes them. A
+// non-Live read therefore returns zero rows forever, the watchdog prints
+// nothing (it only speaks when it closes >0), and two orders sat gated for 51
+// minutes behind a 2-minute age-out that was running the whole time.
+//
+// The test reproduces exactly that: prime the cache while the store is EMPTY,
+// then write the stale tracking bead straight to the backing. Revert either
+// sweep reader to s.store.ListByLabel and this fails.
+func TestOrderTrackingSweepWatchdogSeesBeadsWrittenBehindTheCache(t *testing.T) {
+	backing := beads.NewMemStore()
+	cached := beads.NewCachingStoreForTest(backing, nil)
+	if err := cached.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive(): %v", err)
+	}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	store := wrapStoreWithBeadPolicies(cached, cfg)
+
+	// Written AFTER the prime and NOT through the cache — the dispatcher's
+	// uncached-handle shape.
+	stale, err := backing.Create(beads.Bead{
+		Title:  "order:nudge-on-route",
+		Labels: []string{"order-run:nudge-on-route", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(stale): %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 cfg,
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+	}
+	cr.runOrderTrackingSweepWatchdog(time.Now().Add(orderTrackingSweepWatchdogStaleAfter + time.Second))
+
+	got, err := backing.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get(stale): %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("stale tracking status = %s, want closed — the watchdog read a cached snapshot that never contained this bead (ga-v5vnyp)", got.Status)
+	}
+}
+
+// TestOrphanedOrderTrackingSweepSeesBeadsWrittenBehindTheCache is the same
+// proof for the STARTUP sweep, which is the other non-Live reader. It is the
+// net that is supposed to catch tracking beads orphaned by a controller that
+// died holding them — and it runs inside the very process whose cache cannot
+// be trusted to contain them.
+func TestOrphanedOrderTrackingSweepSeesBeadsWrittenBehindTheCache(t *testing.T) {
+	backing := beads.NewMemStore()
+	cached := beads.NewCachingStoreForTest(backing, nil)
+	if err := cached.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive(): %v", err)
+	}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	store := wrapStoreWithBeadPolicies(cached, cfg)
+
+	orphan, err := backing.Create(beads.Bead{
+		Title:  "order:order-tracking-sweep",
+		Labels: []string{"order-run:" + orderTrackingSweepOrder, labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(orphan): %v", err)
+	}
+
+	// The startup path (CityRuntime.sweepOrphanedOrderTracking) opens its own
+	// store from cityPath rather than using standaloneCityStore, so drive the
+	// sweep function directly with the production-shaped store. What this pins
+	// is the READER: OrphanedOpenRuns must see a bead the cache never absorbed.
+	if _, err := sweepOrphanedOrderTrackingLimit(store, orderTrackingSweepCloseBudget); err != nil {
+		t.Fatalf("sweepOrphanedOrderTrackingLimit(): %v", err)
+	}
+
+	got, err := backing.Get(orphan.ID)
+	if err != nil {
+		t.Fatalf("Get(orphan): %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("orphaned tracking status = %s, want closed — the startup sweep read a cached snapshot (ga-v5vnyp)", got.Status)
+	}
+}
+
 func TestOrderTrackingSweepWatchdogUsesCloseBudget(t *testing.T) {
 	store := beads.NewMemStore()
 	ids := make([]string, 0, orderTrackingSweepCloseBudget+1)

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3862,7 +3862,7 @@ func TestSweepOrphanedOrderTrackingRetryLimitSpendsRemainingBudget(t *testing.T)
 		t.Fatalf("n = %d, want 2", n)
 	}
 	if fs.listCalls != 1 {
-		t.Fatalf("ListByLabel calls = %d, want 1 (budget exhaustion should stop retries)", fs.listCalls)
+		t.Fatalf("order-tracking list calls = %d, want 1 (budget exhaustion should stop retries)", fs.listCalls)
 	}
 }
 
@@ -6363,7 +6363,7 @@ func TestSweepOrphanedOrderTracking_RetryOnTransientError(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	// Fail the first 2 ListByLabel calls, succeed on the 3rd.
+	// Fail the first 2 order-tracking list reads, succeed on the 3rd.
 	fs := &countFailStore{Store: inner, failCount: 2}
 	closed, err := sweepOrphanedOrderTrackingRetry(fs, 3, time.Millisecond)
 	if err != nil {
@@ -6373,7 +6373,7 @@ func TestSweepOrphanedOrderTracking_RetryOnTransientError(t *testing.T) {
 		t.Fatalf("closed = %d, want 1", closed)
 	}
 	if fs.calls != 3 {
-		t.Fatalf("ListByLabel calls = %d, want 3", fs.calls)
+		t.Fatalf("order-tracking list calls = %d, want 3", fs.calls)
 	}
 }
 
@@ -6394,7 +6394,7 @@ func TestSweepOrphanedOrderTracking_RetryExhausted(t *testing.T) {
 		t.Fatal("expected error when retries exhausted")
 	}
 	if fs.calls != 3 {
-		t.Fatalf("ListByLabel calls = %d, want 3", fs.calls)
+		t.Fatalf("order-tracking list calls = %d, want 3", fs.calls)
 	}
 }
 
@@ -6426,23 +6426,30 @@ func TestSweepOrphanedOrderTracking_RetryOnPartialClose(t *testing.T) {
 		t.Fatalf("n = %d, want 3 (accumulated across retries)", n)
 	}
 	if fs.listCalls != 3 {
-		t.Fatalf("ListByLabel calls = %d, want 3 (retry on partial close)", fs.listCalls)
+		t.Fatalf("order-tracking list calls = %d, want 3 (retry on partial close)", fs.listCalls)
 	}
 }
 
-// countFailStore wraps a Store and fails the first N ListByLabel calls.
+// countFailStore wraps a Store and fails the first N order-tracking list
+// reads. The injection sits on List, not ListByLabel, because the sweep reads
+// through beads.HandlesFor(store).Live.List (ga-v5vnyp) — an override left on
+// ListByLabel is never called, so the fault silently never fires and the retry
+// loop goes untested while the test still passes its earlier assertions.
 type countFailStore struct {
 	beads.Store
 	failCount int
 	calls     int
 }
 
-func (f *countFailStore) ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+func (f *countFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label != labelOrderTracking {
+		return f.Store.List(query)
+	}
 	f.calls++
 	if f.calls <= f.failCount {
 		return nil, fmt.Errorf("connection refused")
 	}
-	return f.Store.ListByLabel(label, limit, opts...)
+	return f.Store.List(query)
 }
 
 // closeFailStore wraps a Store and always fails CloseAll with a
@@ -6453,9 +6460,13 @@ type closeFailStore struct {
 	closeN    int // number of beads "closed" before error
 }
 
-func (f *closeFailStore) ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
-	f.listCalls++
-	return f.Store.ListByLabel(label, limit, opts...)
+// List counts the sweep's own order-tracking reads. Same reason as
+// countFailStore: the production read path is Live.List, not ListByLabel.
+func (f *closeFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == labelOrderTracking {
+		f.listCalls++
+	}
+	return f.Store.List(query)
 }
 
 func (f *closeFailStore) CloseAll(_ []string, _ map[string]string) (int, error) {

--- a/internal/orders/store_reads.go
+++ b/internal/orders/store_reads.go
@@ -136,7 +136,22 @@ func (s *Store) StaleOpenRuns(cutoff time.Time) ([]OrderRun, error) {
 	if s.store.Store == nil {
 		return nil, nil
 	}
-	all, err := s.store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
+	// LIVE, for the same cache-bypass reason as RecentRunsAll/OpenRuns, and this
+	// one is load-bearing: tracking beads are created and closed through the
+	// dispatcher's OWN uncached handle, so a cached read never observes them at
+	// all. Reading non-Live here made the stale-tracking watchdog return zero rows
+	// every 30s for 43h against a frozen city cache while the (Live) open-work
+	// gate saw the very same beads and held the orders shut — ga-v5vnyp.
+	// Sort oldest-first so the caller's close budget drains the oldest jam rather
+	// than an arbitrary slice of it (the wrapper drops Sort, leaving Go map order).
+	// IncludeClosed stays false and there is deliberately no Status filter, so
+	// in_progress tracking beads are still returned exactly as before.
+	all, err := beads.HandlesFor(s.store.Store).Live.List(beads.ListQuery{
+		Label:         labelOrderTracking,
+		IncludeClosed: false,
+		Sort:          beads.SortCreatedAsc,
+		TierMode:      beads.TierBoth,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +176,15 @@ func (s *Store) OrphanedOpenRuns() ([]OrderRun, error) {
 	if s.store.Store == nil {
 		return nil, nil
 	}
-	all, err := s.store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
+	// LIVE for the same reason as StaleOpenRuns: the startup sweep exists to clean
+	// up after a controller that died holding tracking beads, and a cache primed by
+	// the very process doing the sweeping cannot be trusted to contain them.
+	all, err := beads.HandlesFor(s.store.Store).Live.List(beads.ListQuery{
+		Label:         labelOrderTracking,
+		IncludeClosed: false,
+		Sort:          beads.SortCreatedAsc,
+		TierMode:      beads.TierBoth,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/orders/store_reads_test.go
+++ b/internal/orders/store_reads_test.go
@@ -150,6 +150,83 @@ func TestRecentRunsAllOpenRunsUseLiveTier(t *testing.T) {
 		t.Fatalf("OpenRuns(): %v", err)
 	}
 	assertAllLive(t, "OpenRuns", spy.queries)
+
+	// The two SWEEP readers are the ones that were NOT Live (ga-v5vnyp): they read
+	// through the controller's CachingStore, whose city-scope snapshot had been
+	// frozen for 43h and never contained the dispatcher-written tracking beads at
+	// all. They returned zero rows every 30s, silently, while the Live open-work
+	// gate saw the same beads and held the orders shut.
+	spy.queries = nil
+	if _, err := st.StaleOpenRuns(time.Now()); err != nil {
+		t.Fatalf("StaleOpenRuns(): %v", err)
+	}
+	assertAllLive(t, "StaleOpenRuns", spy.queries)
+	assertOldestFirst(t, "StaleOpenRuns", spy.queries)
+
+	spy.queries = nil
+	if _, err := st.OrphanedOpenRuns(); err != nil {
+		t.Fatalf("OrphanedOpenRuns(): %v", err)
+	}
+	assertAllLive(t, "OrphanedOpenRuns", spy.queries)
+	assertOldestFirst(t, "OrphanedOpenRuns", spy.queries)
+}
+
+// assertOldestFirst pins the close-budget ordering. Both sweep readers feed a
+// bounded close budget (orderTrackingSweepCloseBudget), so the order the rows
+// come back in decides WHICH stale beads get closed. Anything but oldest-first
+// lets a genuinely jammed old bead be starved indefinitely by newer ones.
+func assertOldestFirst(t *testing.T, name string, queries []beads.ListQuery) {
+	t.Helper()
+	if len(queries) == 0 {
+		t.Fatalf("%s issued no List query", name)
+	}
+	for i, q := range queries {
+		if q.Sort != beads.SortCreatedAsc {
+			t.Fatalf("%s query[%d].Sort = %v, want SortCreatedAsc (budgeted closes must drain oldest-first)", name, i, q.Sort)
+		}
+	}
+}
+
+// TestStaleOpenRunsKeepsInProgressAndExcludesClosed pins the two status
+// semantics the Live rewrite had to preserve. The pre-fix read passed no Status
+// filter, so an in_progress tracking bead was returned; adding Status:"open"
+// would have silently narrowed the sweep and left in_progress beads gating their
+// orders forever — a regression in the same direction as the bug being fixed.
+func TestStaleOpenRunsKeepsInProgressAndExcludesClosed(t *testing.T) {
+	store := beads.NewMemStore()
+	mk := func(title, status string) beads.Bead {
+		b, err := store.Create(beads.Bead{Title: title, Labels: []string{"order-run:digest", "order-tracking"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if status != "open" {
+			if err := store.Update(b.ID, beads.UpdateOpts{Status: &status}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return b
+	}
+	openBead := mk("order:digest open", "open")
+	inProgress := mk("order:digest running", "in_progress")
+	closedBead := mk("order:digest done", "closed")
+
+	runs, err := NewStore(beads.OrdersStore{Store: store}).StaleOpenRuns(time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("StaleOpenRuns(): %v", err)
+	}
+	got := make(map[string]bool, len(runs))
+	for _, r := range runs {
+		got[r.ID] = true
+	}
+	if !got[openBead.ID] {
+		t.Errorf("open tracking bead %s missing from StaleOpenRuns", openBead.ID)
+	}
+	if !got[inProgress.ID] {
+		t.Errorf("in_progress tracking bead %s missing from StaleOpenRuns — a Status:\"open\" filter would strand it", inProgress.ID)
+	}
+	if got[closedBead.ID] {
+		t.Errorf("closed tracking bead %s must not be swept", closedBead.ID)
+	}
 }
 
 func assertAllLive(t *testing.T, name string, queries []beads.ListQuery) {


### PR DESCRIPTION
## What

`StaleOpenRuns` and `OrphanedOpenRuns` are the only two readers in `internal/orders/store_reads.go` that do not declare a Live read: they call `s.store.ListByLabel`, which the controller's `beadPolicyStore` forwards into the CachingStore's in-memory snapshot instead of the backing store. Every peer reader (`RecentRunsAll`, `OpenRuns`, `ClosedRunsForRetention`, `HasOpenWork`) already reads `beads.HandlesFor(store).Live.List`.

Both sweep readers now read Live with `TierBoth` and `SortCreatedAsc`, so the bounded close budget drains the oldest jam first. `beadPolicyStore.ListByLabel` also gains the `Sort` its two wrapped implementations (BdStore, CachingStore) already set — the wrapper silently dropped it, leaving Go map iteration order under any budgeted consumer.

The second commit moves the sweep tests' fault injection (`countFailStore`, `closeFailStore`) from `ListByLabel` onto `List`, guarded on the order-tracking label: with the reader on the Live path, an override left on `ListByLabel` is never called, so the injected faults never fire and the retry loop goes untested.

## Why

Order-tracking beads are created and closed through the dispatcher's own uncached handle, so the controller's cache never observes them. Against a stale cache, the stale-tracking watchdog reads zero rows on every tick and prints nothing, while the Live open-work gate sees the very same beads and holds the orders shut — orders sit unfireable behind tracking beads the 2-minute age-out exists to close (ga-v5vnyp: in practice this left the watchdog blind for 43 hours). Status semantics are preserved: `IncludeClosed` stays false and there is no `Status:"open"` filter, so `in_progress` tracking beads are still swept.

## Tests

- `internal/orders`: `TestRecentRunsAllOpenRunsUseLiveTier` now covers both sweep readers and pins oldest-first ordering; new `TestStaleOpenRunsKeepsInProgressAndExcludesClosed` pins the status semantics. Both fail with the fix reverted ("StaleOpenRuns issued no List query").
- `cmd/gc`: new `TestOrderTrackingSweepWatchdogSeesBeadsWrittenBehindTheCache` and `TestOrphanedOrderTrackingSweepSeesBeadsWrittenBehindTheCache` build the production stack (`beadPolicyStore` over a primed `CachingStore`) and write the stale bead to the backing store behind the cache — the pre-existing watchdog tests all used a bare MemStore, which is why the suite stayed green while the production read path was blind.
- `cmd/gc`: the four `TestSweepOrphanedOrderTracking_Retry*` tests are re-pinned to the production read path; with `OrphanedOpenRuns` reverted to raw `ListByLabel` they fail again.
- `go build ./...`, `go vet`, `go test ./internal/orders -count=1`, and the full order-tracking sweep/watchdog family in `cmd/gc` pass.

Merge note: the first commit alone leaves the four retry tests red (the second repairs their fault injection); squash-merging keeps main green at every landed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvU8iDeCxbuqVKqEp7W5RT

Fixes #5832.
