### PR TITLE
fix: accept safe undeclared push-guard successors

### DIFF
--- a/release-gates/ga-2m6tqt-push-ownership-undeclared-successor-gate.md
+++ b/release-gates/ga-2m6tqt-push-ownership-undeclared-successor-gate.md
@@ -1,0 +1,46 @@
+# Release gate: push-ownership undeclared successor (`ga-2m6tqt`)
+
+- Gate result: **PASS**
+- Reviewed commit: `3c77b6789bd9621bd019cdd07cc72093cf72cb98`
+- Base ref: `origin/main@a85f857b3987bd18593cea2e9594a17a82b10df1`
+- Deploy mode: remote
+- Evaluation date: 2026-08-31
+- Full-suite logs: `/var/tmp/gc-local-tests.dLtqwB`
+
+`docs/PROJECT_MANIFEST.md` is not present at the evaluated ref. This gate uses
+the canonical criteria in `mol-deployer-gate.formula.toml`, the current
+deployer prompt, and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Reviewer PASS present for deployed commit | **PASS** | The independent reviewer closed `ga-0ywrmy.1` with verdict PASS and recorded deploy commit `3c77b6789bd9621bd019cdd07cc72093cf72cb98`. The reviewed commit is the exact commit evaluated here. |
+| 2 | Acceptance criteria met | **PASS** | The branch-reuse resolver now accepts an undeclared successor only after a fresh read confirms the branch-derived bead is inactive, the already-fetched in-progress set contains exactly one other bead, and that candidate passes the same live ownership predicate as the public guard. Ambiguity, unhealthy ownership, and read or parse failure remain fail-closed. The existing declared-successor, active-predecessor, deploy-gate, plain multi-match, retry, hook-wiring, and zsh behaviors remain covered. |
+| 3 | Tests pass | **PASS** | With rootless Podman enabled, the documented CI-equivalent command `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true make test-local-full-parallel` completed **36 PASS / 4 FAIL / 0 SKIP jobs**. All four raw failures are attributed under criterion 3a; none is diff-owned. The diff-owned shell suite completed **40 PASS / 0 FAIL / 0 SKIP**, including the rewritten unrelated-candidate case and both new undeclared-successor cases. Its Go wrapper passed in `integration-packages-core-4-of-4`. The source PR's exact reviewed head also has green `CI / required`, CodeQL, static, acceptance, generated-artifact, dashboard, vulnerability, and critical-path evidence checks in GitHub Actions run `33361916791` and its companion workflows. |
+| 3a | Pre-existing failures attributable | **PASS** | The diff changes only `scripts/push-ownership-guard.sh` and `scripts/test-push-ownership-guard.sh`. It cannot compile into or execute the failing `internal/runtime/herdr`, `internal/bdflags`, or `test/integration` code, and it changes no test census, Makefile, workflow, or runner policy. There is zero path overlap or test-load increase. Exact failures and open trackers: `TestSessionEventsLive` (`getAgent evt-a: ok=false`) -> `ga-vkhfnj`; `TestBdFlagManifestCurrent` (installed `bd` flags ahead of the checked manifest) -> `ga-f0uceo`; `TestE2E_SuspendResume_City` (timed out awaiting `citysus.report`) -> `ga-vkhfnj`; `TestHumaBinary_SessionMessageAsync` (beads#4566 dirty `events` table migration) -> `ga-esyijp`. Current-run occurrences were appended to those trackers. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy` passed: 5 runner-policy tests, 15 suite-coverage tests, `scripts/cipolicy`, `scripts/prwatchdog`, and the focused static-scope suite. `shellcheck` on both changed scripts, `bash -n`, `zsh -n`, `go build ./...`, `go vet ./...`, `git diff --check`, `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=2443a9d74166211ff8aef519810b039f23854edb make lint-affected`, and the matching `make fmt-check-changed` all passed. The affected selectors correctly reported no changed Go build inputs or Go files. |
+| 4 | No unresolved HIGH review findings | **PASS** | The independent reviewer reported no style or security findings and no unresolved defects; unresolved HIGH count is 0. |
+| 5 | Final branch clean | **PASS** | `git status --porcelain` was empty before this checklist was written. This checklist is the only gate artifact added afterward. |
+| 6 | Branch diverges cleanly from main | **PASS** | After refreshing `origin/main`, `git merge-tree --write-tree origin/main 3c77b6789bd9621bd019cdd07cc72093cf72cb98` exited 0 and produced tree `3f92ba80935769e8cfb29d44f5fe728c0c95778e`. Source PR #5795 remains OPEN, MERGEABLE, and pinned to the reviewed SHA. No self-rebase was necessary. |
+| 7 | Single feature theme | **PASS** | The one-commit, two-file change is confined to one subsystem: safe undeclared-successor resolution in the push-ownership guard and its regression tests. |
+
+## Test-integrity fields
+
+- `test_cmd`: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true make test-local-full-parallel`
+- `test_cmd_scope`: full-suite
+- `test_counts`: full union `36 PASS / 4 FAIL / 0 SKIP jobs`; all four failures attributed above; focused shell suite `40 PASS / 0 FAIL / 0 SKIP`
+- `diff_tests_executed`: all 40 cases in `scripts/test-push-ownership-guard.sh` PASS; specifically the rewritten unrelated-candidate rejection, new owned undeclared-single acceptance, and new ambiguous-multiple rejection cases PASS; Go wrapper `TestPushOwnershipGuard` PASS
+- `skip_justification`: none; the local runner reported no job-level or diff-owned skips. Package lines saying `[no tests to run]` are not skipped jobs.
+- `waiver_ref`: none; no diff-owned failure or waiver was used
+- `ci_lane_run`: n/a (no CI configuration change)
+- `policy_lane`: `make test-ci-policy` PASS
+- `failure_attribution`: `TestSessionEventsLive` and `TestE2E_SuspendResume_City` -> `ga-vkhfnj`; `TestBdFlagManifestCurrent` -> `ga-f0uceo`; `TestHumaBinary_SessionMessageAsync` / beads#4566 -> `ga-esyijp`; structural proof is the shell-only diff with zero path, build, execution, or test-load overlap
+
+## Disposition
+
+All criteria pass. Proceed from the reviewed SHA to the isolated
+`deploy/ga-2m6tqt-gate` branch, push that branch only, open the pull request,
+publish deploy clearance on the exact PR head, and route the merge request to
+the merge authority. The deployer does not merge.

--- a/scripts/push-ownership-guard.sh
+++ b/scripts/push-ownership-guard.sh
@@ -134,6 +134,68 @@ _pog_branch_id_bead_inactive() {
     [[ "$st" != "in_progress" && "$st" != "open" && -n "$st" ]]
 }
 
+# _pog_ownership_violation <json>: pure predicate over an already-fetched
+# `bd show <id> --json` payload (parsed here, not re-read). Prints nothing
+# and returns 0 when the bead reads as currently owned by this session;
+# otherwise prints a short, undecorated reason and returns 1. Checks, in
+# order: status open/in_progress, assignee among this session's live
+# identities, gc.routed_to unset-or-matching, no hold:mayor/hold:external
+# label. Shared by assert_bead_still_claimed (the public push gate, which
+# wraps the reason into its own BLOCKED/--no-verify message below) and
+# _pog_resolve_bead_id's undeclared-single-match tier (ga-0ywrmy.1, which
+# discards the reason and uses only the pass/fail to decide whether an
+# undeclared in-progress bead may stand in for a closed branch-derived one).
+#
+# NOTE: never name a local here 'status' — it is a zsh special parameter
+# (linked to $?, alongside $pipestatus) and this file is sourced into the
+# deployer's ambient zsh shell (ga-xi7wi6); binding a local named 'status'
+# there is a read-only-variable error, not a shadow.
+_pog_ownership_violation() {
+    local json="$1"
+    local bead_status assignee routed_to labels
+    bead_status="$(jq -r '.[0].status // empty' <<<"$json")"
+    assignee="$(jq -r '.[0].assignee // empty' <<<"$json")"
+    routed_to="$(jq -r '.[0].metadata."gc.routed_to" // empty' <<<"$json")"
+    labels="$(jq -r '.[0].labels[]? // empty' <<<"$json")"
+
+    if [[ "$bead_status" != "in_progress" && "$bead_status" != "open" ]]; then
+        printf "status is '%s', not in_progress/open; the claim behind this push is stale" "$bead_status"
+        return 1
+    fi
+
+    local -a _pog_identities=()
+    local _pog_ident
+    for _pog_ident in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}" "${GC_TEMPLATE:-}"; do
+        [[ -n "$_pog_ident" ]] && _pog_identities+=("$_pog_ident")
+    done
+    if [[ ${#_pog_identities[@]} -gt 0 ]]; then
+        local _pog_owned=0
+        for _pog_ident in "${_pog_identities[@]}"; do
+            if [[ -n "$assignee" && "$assignee" == "$_pog_ident" ]]; then _pog_owned=1; break; fi
+        done
+        if [[ $_pog_owned -eq 0 ]]; then
+            printf "assignee is '%s', not any current-session identity (%s); it was reassigned since this push began" "$assignee" "${_pog_identities[*]}"
+            return 1
+        fi
+    fi
+
+    if [[ -n "${GC_TEMPLATE:-}" && -n "$routed_to" && "$routed_to" != "$GC_TEMPLATE" ]]; then
+        printf "gc.routed_to is '%s', not this session's config identity (%s); it was rerouted since this push began" "$routed_to" "$GC_TEMPLATE"
+        return 1
+    fi
+
+    if grep -qx 'hold:mayor' <<<"$labels"; then
+        printf 'is held (hold:mayor); a mayor ruling is pending'
+        return 1
+    fi
+    if grep -qx 'hold:external' <<<"$labels"; then
+        printf 'is held (hold:external)'
+        return 1
+    fi
+
+    return 0
+}
+
 # _pog_resolve_bead_id: prints the bead id this push should be checked
 # against; prints nothing if none can be resolved. Resolution order:
 #   1. The current branch name, matched against ga-[0-9a-z]{6}(\.[0-9]+)* —
@@ -292,6 +354,49 @@ _pog_resolve_bead_id() {
         return
     fi
 
+    # UNDECLARED SINGLE MATCH (ga-0ywrmy.1): reached only once the declared-
+    # successor check above found nothing. Requires the SAME freshness gate
+    # (branch-derived bead confirmed inactive) plus one more condition: this
+    # session's in-progress list (already fetched above, not re-queried) has
+    # EXACTLY one entry -- no declared link required, cardinality alone is
+    # the safety bound, mirroring path 2's own single-match discipline. The
+    # sole candidate still has to pass a fresh live-ownership check below; an
+    # unrelated bead that happens to be this session's only other
+    # in-progress claim but reads back not-owned (closed, reassigned, held,
+    # ...) on its own fresh bd show must still not validate this push -- this
+    # tier only ever widens *resolution*, never *verification*.
+    #
+    # Cheap conditions (branch_id present, exactly one candidate already sitting
+    # in ${list_json} from the assignee-fallback fetch above, that candidate
+    # isn't literally branch_id) are checked FIRST, purely from data already in
+    # hand -- no I/O. _pog_branch_id_bead_inactive is deliberately the LAST
+    # link in this && chain, short-circuited so it only runs (and only pays for
+    # its own bd show + retries) once every cheap prerequisite already holds.
+    # The ordinary push -- branch_id resolves, no reuse in play at all -- must
+    # cost exactly the one bd show that assert_bead_still_claimed's own final
+    # check already makes; putting the I/O check first would double that cost
+    # on every push through this guard, not just the rare reuse case (caught
+    # by test_retry_exhausted_still_blocks's exact-call-count assertion).
+    if [[ -n "$branch_id" ]]; then
+        local undeclared_count
+        undeclared_count="$(jq -r 'length' <<<"${list_json:-[]}" 2>/dev/null || echo 0)"
+        if [[ "$undeclared_count" == "1" ]]; then
+            local undeclared_id
+            undeclared_id="$(jq -r '.[0].id // empty' <<<"${list_json:-[]}" 2>/dev/null || true)"
+            if [[ -n "$undeclared_id" && "$undeclared_id" != "$branch_id" ]] && _pog_branch_id_bead_inactive "$branch_id"; then
+                local undeclared_json
+                if undeclared_json="$(_pog_read_with_retry bd show "$undeclared_id" --json)" \
+                    && [[ -n "$undeclared_json" ]] \
+                    && jq -e '.' <<<"$undeclared_json" >/dev/null 2>&1 \
+                    && _pog_ownership_violation "$undeclared_json" >/dev/null 2>&1; then
+                    echo "push-ownership-guard: NOTE branch $branch was reused after $branch_id closed; this session has exactly one other in-progress bead ($undeclared_id) with no declared continuation link, using it as the undeclared single match" >&2
+                    printf '%s' "$undeclared_id"
+                    return
+                fi
+            fi
+        fi
+    fi
+
     if [[ -n "$branch_id" && -n "$assignee_id" && "$branch_id" != "$assignee_id" ]]; then
         echo "push-ownership-guard: WARNING branch name resolves to $branch_id but this session's in-progress assignment is $assignee_id; using $branch_id (branch name wins)" >&2
     fi
@@ -335,69 +440,10 @@ assert_bead_still_claimed() {
         return 1
     fi
 
-    # NOTE: never name this local 'status' — it is a zsh special parameter
-    # (linked to $?, alongside $pipestatus) and this function is sourced
-    # into the deployer's ambient zsh shell (ga-xi7wi6); binding a local
-    # named 'status' there is a read-only-variable error, not a shadow.
-    local bead_status assignee routed_to labels
-    bead_status="$(jq -r '.[0].status // empty' <<<"$json")"
-    assignee="$(jq -r '.[0].assignee // empty' <<<"$json")"
-    routed_to="$(jq -r '.[0].metadata."gc.routed_to" // empty' <<<"$json")"
-    labels="$(jq -r '.[0].labels[]? // empty' <<<"$json")"
-
-    if [[ "$bead_status" != "in_progress" && "$bead_status" != "open" ]]; then
-        echo "push-ownership-guard: BLOCKED — $id status is '$bead_status', not in_progress/open; the claim behind this push is stale. Bypass with: git push --no-verify" >&2
+    local reason
+    if ! reason="$(_pog_ownership_violation "$json")"; then
+        echo "push-ownership-guard: BLOCKED — $id $reason. Bypass with: git push --no-verify" >&2
         return 1
     fi
-
-    # A session-run claim sets bead.assignee from the first non-empty of
-    # GC_SESSION_NAME, GC_SESSION_ID, GC_ALIAS, GC_AGENT (see
-    # cmd/gc/cmd_hook.go's firstNonEmptyHookValue). Accept ANY of this
-    # session's live identities — GC_AGENT alone falsely blocks a push whose
-    # bead is legitimately assigned to the session name/id. Fail-closed
-    # semantics preserved: with identities present, an assignee matching none
-    # (including empty) still blocks.
-    #
-    # GC_TEMPLATE is also a valid match (ga-kzl21p): it's the bare pool
-    # identity (e.g. "gascity/builder"), stamped by the SDK at session start
-    # for every session shape regardless of which specific pool instance is
-    # running (e.g. "gascity/builder-1") — see internal/session/lifecycle.go.
-    # Work routed to the whole pool, rather than claimed by one instance, can
-    # carry that bare identity as assignee. Without this, a session whose
-    # GC_SESSION_NAME/GC_SESSION_ID/GC_ALIAS/GC_AGENT are all instance-shaped
-    # could never match a pool-level assignee, and completed, gate-verified
-    # work became unpushable with no reassignment and no bypass. This is the
-    # same trust boundary the routed_to check below already applies to
-    # GC_TEMPLATE — extended here to cover assignee too.
-    local -a _pog_identities=()
-    local _pog_ident
-    for _pog_ident in "${GC_SESSION_NAME:-}" "${GC_SESSION_ID:-}" "${GC_ALIAS:-}" "${GC_AGENT:-}" "${GC_TEMPLATE:-}"; do
-        [[ -n "$_pog_ident" ]] && _pog_identities+=("$_pog_ident")
-    done
-    if [[ ${#_pog_identities[@]} -gt 0 ]]; then
-        local _pog_owned=0
-        for _pog_ident in "${_pog_identities[@]}"; do
-            if [[ -n "$assignee" && "$assignee" == "$_pog_ident" ]]; then _pog_owned=1; break; fi
-        done
-        if [[ $_pog_owned -eq 0 ]]; then
-            echo "push-ownership-guard: BLOCKED — $id assignee is '$assignee', not any current-session identity (${_pog_identities[*]}); it was reassigned since this push began. Bypass with: git push --no-verify" >&2
-            return 1
-        fi
-    fi
-
-    if [[ -n "${GC_TEMPLATE:-}" && -n "$routed_to" && "$routed_to" != "$GC_TEMPLATE" ]]; then
-        echo "push-ownership-guard: BLOCKED — $id gc.routed_to is '$routed_to', not this session's config identity ($GC_TEMPLATE); it was rerouted since this push began. Bypass with: git push --no-verify" >&2
-        return 1
-    fi
-
-    if grep -qx 'hold:mayor' <<<"$labels"; then
-        echo "push-ownership-guard: BLOCKED — $id is held (hold:mayor); a mayor ruling is pending. Bypass with: git push --no-verify" >&2
-        return 1
-    fi
-    if grep -qx 'hold:external' <<<"$labels"; then
-        echo "push-ownership-guard: BLOCKED — $id is held (hold:external). Bypass with: git push --no-verify" >&2
-        return 1
-    fi
-
     return 0
 }

--- a/scripts/test-push-ownership-guard.sh
+++ b/scripts/test-push-ownership-guard.sh
@@ -721,18 +721,142 @@ FAKE
 # metadata.branch/build_bead tying it to THIS branch or to the closed
 # branch-derived bead must never be silently substituted -- the guard must
 # keep blocking on the real (closed) branch-derived bead instead.
+#
+# Needs an id-aware fake (unlike the pre-ga-0ywrmy.1 version of this test,
+# which used the single-canned-response write_show_json helper): that fake
+# answers ANY bd show call with the SAME "ga-oldbld closed" payload
+# regardless of id, which can no longer distinguish "the undeclared-match
+# tier fetched ga-unrel8d fresh and correctly rejected it" from "the tier
+# never looked at ga-unrel8d at all" -- both produce the exact same
+# observable rc/output. This fixture instead gives ga-unrel8d its own
+# genuinely distinguishable (and genuinely not-owned) response, and asserts
+# on show-ids.log that it was actually queried.
 test_bead_id_branch_reused_does_not_pick_unrelated_inprogress_bead_as_successor() {
-    local repo fbd out rc
+    local repo fbd out rc show_ids
     repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
     fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
-    write_fake_bd "$fbd"
-    printf '[{"id":"ga-unrel8d","metadata":{}}]' > "$fbd/fake-bd-state/list-json"
-    write_show_json "$fbd" "ga-oldbld" "closed" "agent-x" "tmpl-x" "[]"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-unrel8d) printf '[{"id":"ga-unrel8d","status":"in_progress","assignee":"someone-else","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-unrel8d","metadata":{}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
     out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
-    if [[ $rc -ne 0 ]] && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
-        record_pass "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor (rc=$rc, unrelated concurrent bead correctly ignored, blocks on the real closed bead)"
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -ne 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" && grep -qx "ga-unrel8d" <<<"$show_ids" \
+        && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor (rc=$rc, unrelated candidate ga-unrel8d checked fresh and rejected on its own assignee mismatch, still blocks on the real closed ga-oldbld)"
     else
-        record_fail "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor" "expected non-zero rc mentioning status+--no-verify (an unrelated in-progress bead under the same assignee must never be silently substituted), got rc=$rc, output: $out"
+        record_fail "resolve/branch-reused-does-not-pick-unrelated-inprogress-bead-as-successor" "expected non-zero rc mentioning status+--no-verify with BOTH ga-oldbld and ga-unrel8d fresh-checked (an unrelated in-progress bead must be verified, not blindly trusted or blindly ignored, and still not substituted once its own read shows a different assignee), got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# The undeclared-single-match tier (ga-0ywrmy.1): once the branch-derived
+# bead is confirmed inactive and NO in-progress bead declares itself its
+# successor via metadata, a session holding exactly one OTHER in-progress
+# bead -- with no declared link at all -- may still use it, but only if that
+# candidate independently passes the same live-ownership checks
+# assert_bead_still_claimed itself applies (status, assignee, routed_to,
+# hold). This is deliberately narrower than "any live claim wins": cardinality
+# (exactly one) is the resolution-time safety bound, and the fresh ownership
+# read is the verification-time safety bound -- see the sibling test above,
+# which pins the identical shape (single in-progress candidate, no declared
+# link) failing when that second bound doesn't hold.
+test_bead_id_branch_reused_accepts_undeclared_single_inprogress_match_when_branch_bead_closed() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      ga-undecl) printf '[{"id":"ga-undecl","status":"in_progress","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-undecl","metadata":{}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -eq 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" && grep -qx "ga-undecl" <<<"$show_ids" \
+        && grep -qi "undeclared single match" <<<"$out"; then
+        record_pass "resolve/branch-reused-accepts-undeclared-single-inprogress-match-when-branch-bead-closed (rc=0, checked ga-oldbld (found closed) then verified+used the undeclared live candidate ga-undecl with no declared link at all)"
+    else
+        record_fail "resolve/branch-reused-accepts-undeclared-single-inprogress-match-when-branch-bead-closed" "expected rc=0 with bd show called against both ga-oldbld and ga-undecl and a NOTE naming the undeclared-single-match path, got rc=$rc show_ids=[$show_ids], output: $out"
+    fi
+    rm -rf "$repo" "$fbd"
+}
+
+# Cardinality safety, mirrored for the undeclared-match tier: with TWO
+# in-progress beads and no declared link on either, "exactly one" fails and
+# the undeclared-match tier must not activate at all -- even though the
+# branch-derived bead is confirmed closed, there is no positive signal for
+# which (if either) in-progress bead continues it. Falls through to the
+# pre-existing block-on-branch_id behavior. Only ga-oldbld gets a configured
+# show-json response here -- if the tier ever mistakenly fired against
+# ambiguous cardinality, the resulting bd show on an unconfigured candidate
+# id would exit 1 and surface as a different failure shape than this test
+# asserts on, an incidental second guard on top of the explicit
+# show-ids.log negative assertion below.
+test_bead_id_branch_reused_undeclared_match_does_not_activate_with_multiple_inprogress() {
+    local repo fbd out rc show_ids
+    repo="$(new_repo_with_branch "builder/ga-oldbld-my-feature")"
+    fbd="$(mktemp -d "${TMPDIR:-/tmp}/gc-pog-fakebd.XXXXXX")"
+    cat > "$fbd/bd" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  show)
+    echo "$2" >> "$(dirname "$0")/show-ids.log"
+    case "$2" in
+      ga-oldbld) printf '[{"id":"ga-oldbld","status":"closed","assignee":"agent-x","metadata":{"gc.routed_to":"tmpl-x"},"labels":[]}]' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  list)
+    printf '[{"id":"ga-cand01","metadata":{}},{"id":"ga-cand02","metadata":{}}]'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+    chmod +x "$fbd/bd"
+    out="$(run_guard "$repo" "$fbd" "agent-x" "tmpl-x" 2>&1)"; rc=$?
+    show_ids="$(cat "$fbd/show-ids.log" 2>/dev/null || true)"
+    if [[ $rc -ne 0 ]] && grep -qx "ga-oldbld" <<<"$show_ids" \
+        && ! grep -qx "ga-cand01" <<<"$show_ids" && ! grep -qx "ga-cand02" <<<"$show_ids" \
+        && grep -qi "status" <<<"$out" && grep -q -- "--no-verify" <<<"$out"; then
+        record_pass "resolve/branch-reused-undeclared-match-does-not-activate-with-multiple-inprogress (rc=$rc, 2+ undeclared in-progress beads leaves the tier inactive, blocks on the real closed ga-oldbld, neither candidate ever queried)"
+    else
+        record_fail "resolve/branch-reused-undeclared-match-does-not-activate-with-multiple-inprogress" "expected non-zero rc mentioning status+--no-verify with neither candidate ever bd-show'd (2+ undeclared in-progress beads is not a positive single-match signal), got rc=$rc show_ids=[$show_ids], output: $out"
     fi
     rm -rf "$repo" "$fbd"
 }
@@ -1141,6 +1265,8 @@ run_all() {
     test_bead_id_branch_reused_successor_match_via_branch_metadata_alone
     test_bead_id_branch_reused_successor_match_via_build_bead_metadata_alone
     test_bead_id_branch_reused_does_not_pick_unrelated_inprogress_bead_as_successor
+    test_bead_id_branch_reused_accepts_undeclared_single_inprogress_match_when_branch_bead_closed
+    test_bead_id_branch_reused_undeclared_match_does_not_activate_with_multiple_inprogress
     test_bead_id_branch_reused_does_not_override_when_branch_bead_still_active
     test_bead_id_deploy_gate_branch_prefers_live_assignee
     test_bead_id_deploy_gate_branch_allows_when_no_live_assignee


### PR DESCRIPTION
## What this changes

The pre-push ownership guard now accepts a single, still-owned in-progress task as the successor to a closed task encoded in a reused branch name. This prevents legitimate rotated audit work from being blocked while preserving fail-closed checks.

The candidate must be the session’s only in-progress match and pass a fresh ownership, route, and hold check; ambiguous or unhealthy candidates still block.

## Review notes

- Shared ownership predicate reused by the normal guard and fallback.
- No changes to deploy-branch handling, ordinary multi-match behavior, or routing-mismatch handling.

## Test plan

- [x] Run the 40-case push-ownership regression suite.
- [x] Run the full local CI-equivalent suite with tracked non-diff failure attribution.
- [x] Run shell syntax, shellcheck, build, vet, and CI policy checks.
- [x] Release gate: [release-gates/ga-2m6tqt-push-ownership-undeclared-successor-gate.md](release-gates/ga-2m6tqt-push-ownership-undeclared-successor-gate.md)