### PR TITLE
fix(workflow): refuse a workflow delete that would strand live steps

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1920,7 +1920,7 @@ func workflowDeleteStoreLabel(cfg *config.City, cityPath, scopePath string) stri
 	return scopePath
 }
 
-// ErrWorkflowDeleteLiveDescendants marks a REFUSED workflow delete: the bead
+// errWorkflowDeleteLiveDescendants marks a REFUSED workflow delete: the bead
 // still owns open descendants that are not themselves part of this delete, so
 // removing it would strand live, claimable work.
 //
@@ -1928,10 +1928,20 @@ func workflowDeleteStoreLabel(cfg *config.City, cityPath, scopePath string) stri
 // metadata fails with an out-of-vocabulary gc.failure_class, closes fail, and
 // mails an escalation, so the workflow becomes an escalation-mail generator
 // with zero forward progress (ga-033u0e). Scheduled pruners (order-tracking
-// retention, wisp GC) must treat this as a SKIP rather than a failure: the
-// candidate becomes eligible again on a later sweep once its descendants
-// reach a terminal state.
-var ErrWorkflowDeleteLiveDescendants = errors.New("workflow bead still owns live descendants")
+// retention, wisp GC) must treat this as a SKIP rather than a failure — not
+// joined into the sweep error, not charged to a batch cap: the candidate
+// becomes eligible again on a later sweep once its descendants reach a
+// terminal state, and a refusal charged to a cap on every sweep would starve
+// the collectible candidates listed behind it.
+var errWorkflowDeleteLiveDescendants = errors.New("workflow bead still owns live descendants")
+
+// workflowDeleteRefusal is the errWorkflowDeleteLiveDescendants error for id,
+// naming the open descendants that hold it. gc workflow delete-source prints
+// it verbatim on its delete_error= line, so it must let the operator find the
+// steps, not just the root.
+func workflowDeleteRefusal(id string, open []string) error {
+	return fmt.Errorf("%w: %s (open descendants: %s)", errWorkflowDeleteLiveDescendants, id, strings.Join(open, ","))
+}
 
 // workflowDeleteSkip builds the storeHasOpenDescendants skip predicate for a
 // delete of alsoDeleting. An open descendant does not block the delete when it
@@ -1952,7 +1962,7 @@ func workflowDeleteSkip(alsoDeleting map[string]struct{}) func(beads.Bead) bool 
 
 // assertWorkflowDeleteLeavesNothingStranded refuses a delete of id when it
 // still owns open descendants outside alsoDeleting. It uses the authoritative
-// storeHasOpenDescendants view (membership index, falling back to the tree
+// storeOpenDescendantIDs view (membership index, falling back to the tree
 // walk) so partial-stamp molecules — steps linked only by ParentID, with no
 // gc.root_bead_id — are seen too.
 //
@@ -1962,12 +1972,12 @@ func workflowDeleteSkip(alsoDeleting map[string]struct{}) func(beads.Bead) bool 
 // rather than guessing. A bead that lingers one more sweep is recoverable; a
 // stranded workflow is not.
 func assertWorkflowDeleteLeavesNothingStranded(store beads.Store, id string, alsoDeleting map[string]struct{}) error {
-	open, err := storeHasOpenDescendants(store, id, workflowDeleteSkip(alsoDeleting))
+	open, err := storeOpenDescendantIDs(store, id, workflowDeleteSkip(alsoDeleting))
 	if err != nil {
 		return fmt.Errorf("checking live descendants of %s: %w", id, err)
 	}
-	if open {
-		return fmt.Errorf("%w: %s", ErrWorkflowDeleteLiveDescendants, id)
+	if len(open) > 0 {
+		return workflowDeleteRefusal(id, open)
 	}
 	return nil
 }
@@ -2001,11 +2011,15 @@ func assertWorkflowDeleteSetLeavesNothingStranded(store beads.Store, ids []strin
 		if err != nil {
 			return fmt.Errorf("checking live descendants of %s: %w", id, err)
 		}
+		var open []string
 		for _, b := range members {
 			if b.ID == id || b.Status == "closed" || skip(b) {
 				continue
 			}
-			return fmt.Errorf("%w: %s (open descendant %s)", ErrWorkflowDeleteLiveDescendants, id, b.ID)
+			open = append(open, b.ID)
+		}
+		if len(open) > 0 {
+			return workflowDeleteRefusal(id, open)
 		}
 	}
 	return nil
@@ -2020,7 +2034,9 @@ func deleteWorkflowBeads(store beads.Store, ids []string) (int, []error) {
 	}
 	for _, id := range ids {
 		if err := assertWorkflowDeleteLeavesNothingStranded(store, id, deleting); err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", id, err))
+			// The guard's errors already name the bead; prefixing it again
+			// would print the id twice on delete-source's delete_error= line.
+			errs = append(errs, err)
 			continue
 		}
 		if err := deleteWorkflowBeadUnguarded(store, id); err != nil {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1920,11 +1920,110 @@ func workflowDeleteStoreLabel(cfg *config.City, cityPath, scopePath string) stri
 	return scopePath
 }
 
+// ErrWorkflowDeleteLiveDescendants marks a REFUSED workflow delete: the bead
+// still owns open descendants that are not themselves part of this delete, so
+// removing it would strand live, claimable work.
+//
+// A rootless step is unworkable by construction — every step that needs root
+// metadata fails with an out-of-vocabulary gc.failure_class, closes fail, and
+// mails an escalation, so the workflow becomes an escalation-mail generator
+// with zero forward progress (ga-033u0e). Scheduled pruners (order-tracking
+// retention, wisp GC) must treat this as a SKIP rather than a failure: the
+// candidate becomes eligible again on a later sweep once its descendants
+// reach a terminal state.
+var ErrWorkflowDeleteLiveDescendants = errors.New("workflow bead still owns live descendants")
+
+// workflowDeleteSkip builds the storeHasOpenDescendants skip predicate for a
+// delete of alsoDeleting. An open descendant does not block the delete when it
+// is being deleted in the same call (a whole-workflow teardown strands
+// nothing), or when it is a transient nudge/mail chore — the same carve-out
+// the single-flight dispatch gate makes, so a lingering notification bead
+// cannot permanently wedge retention and let closed tracking rows grow without
+// bound.
+func workflowDeleteSkip(alsoDeleting map[string]struct{}) func(beads.Bead) bool {
+	return func(b beads.Bead) bool {
+		if isTransientNotificationBead(b) {
+			return true
+		}
+		_, ok := alsoDeleting[b.ID]
+		return ok
+	}
+}
+
+// assertWorkflowDeleteLeavesNothingStranded refuses a delete of id when it
+// still owns open descendants outside alsoDeleting. It uses the authoritative
+// storeHasOpenDescendants view (membership index, falling back to the tree
+// walk) so partial-stamp molecules — steps linked only by ParentID, with no
+// gc.root_bead_id — are seen too.
+//
+// It fails CLOSED: an unreadable descendant view cannot prove the delete safe,
+// so the error propagates and the bead survives. That mirrors
+// reapOrphanedClosedWisps, which skips a candidate on any unreadable root Get
+// rather than guessing. A bead that lingers one more sweep is recoverable; a
+// stranded workflow is not.
+func assertWorkflowDeleteLeavesNothingStranded(store beads.Store, id string, alsoDeleting map[string]struct{}) error {
+	open, err := storeHasOpenDescendants(store, id, workflowDeleteSkip(alsoDeleting))
+	if err != nil {
+		return fmt.Errorf("checking live descendants of %s: %w", id, err)
+	}
+	if open {
+		return fmt.Errorf("%w: %s", ErrWorkflowDeleteLiveDescendants, id)
+	}
+	return nil
+}
+
+// assertWorkflowDeleteSetLeavesNothingStranded is the set-level guard for
+// callers that already collected an ownership closure and delete it as one
+// unit (the wisp GC's closed-root purge, gc workflow delete-source).
+//
+// It deliberately consults ONLY the gc.root_bead_id membership index and never
+// the tree walk. Running the full walk once per closure member is O(n·depth)
+// and would undo the batching those callers exist for, and it would be largely
+// redundant: they collect the closure with the same ownership rules the walk
+// applies. This is a backstop for the one case the closure collection cannot
+// see — an open descendant recorded outside the collected set — not a
+// replacement for the per-bead guard.
+func assertWorkflowDeleteSetLeavesNothingStranded(store beads.Store, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	deleting := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		deleting[id] = struct{}{}
+	}
+	skip := workflowDeleteSkip(deleting)
+	reader := beads.HandlesFor(store).Live
+	for _, id := range ids {
+		members, err := reader.List(beads.ListQuery{
+			Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: id},
+			TierMode: beads.TierBoth,
+		})
+		if err != nil {
+			return fmt.Errorf("checking live descendants of %s: %w", id, err)
+		}
+		for _, b := range members {
+			if b.ID == id || b.Status == "closed" || skip(b) {
+				continue
+			}
+			return fmt.Errorf("%w: %s (open descendant %s)", ErrWorkflowDeleteLiveDescendants, id, b.ID)
+		}
+	}
+	return nil
+}
+
 func deleteWorkflowBeads(store beads.Store, ids []string) (int, []error) {
 	deleted := 0
 	var errs []error
+	deleting := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
-		if err := deleteWorkflowBead(store, id); err != nil {
+		deleting[id] = struct{}{}
+	}
+	for _, id := range ids {
+		if err := assertWorkflowDeleteLeavesNothingStranded(store, id, deleting); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", id, err))
+			continue
+		}
+		if err := deleteWorkflowBeadUnguarded(store, id); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", id, err))
 			continue
 		}
@@ -1946,6 +2045,9 @@ func deleteWorkflowBeadsBatch(store beads.Store, ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
+	if err := assertWorkflowDeleteSetLeavesNothingStranded(store, ids); err != nil {
+		return err
+	}
 	if cd, ok := store.(beads.BatchDeleter); ok {
 		// A policy/capability wrapper advertises BatchDeleter to forward it, but
 		// reports ErrBatchDeleteUnsupported when its own backing lacks the
@@ -1956,14 +2058,32 @@ func deleteWorkflowBeadsBatch(store beads.Store, ids []string) error {
 		}
 	}
 	for _, id := range ids {
-		if err := deleteWorkflowBead(store, id); err != nil {
+		// Already guarded at the set level above; the per-bead guard would
+		// re-walk the same closure once per member.
+		if err := deleteWorkflowBeadUnguarded(store, id); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// deleteWorkflowBead removes a single workflow bead after proving the delete
+// strands nothing. Every unbatched caller (order-tracking retention, wisp
+// orphan reaping) goes through here, so the guard covers the class rather than
+// one pruner: deleteWorkflowBead has several callers and any of them can be
+// handed a root (ga-ejwo1q).
 func deleteWorkflowBead(store beads.Store, id string) error {
+	if err := assertWorkflowDeleteLeavesNothingStranded(store, id, nil); err != nil {
+		return err
+	}
+	return deleteWorkflowBeadUnguarded(store, id)
+}
+
+// deleteWorkflowBeadUnguarded is the raw graph delete — dep unwind, then
+// Delete, with dep restoration on failure. It performs NO stranding check;
+// call it only after assertWorkflowDeleteLeavesNothingStranded (or its
+// set-level twin) has cleared the bead.
+func deleteWorkflowBeadUnguarded(store beads.Store, id string) error {
 	downDeps, err := store.DepList(id, "down")
 	if err != nil {
 		return fmt.Errorf("list down deps: %w", err)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -6630,6 +6630,109 @@ func TestDeleteWorkflowBeadsRemovesDepsBeforeDelete(t *testing.T) {
 	}
 }
 
+// TestDeleteWorkflowBeadRefusesRootWithOpenDescendant covers the class fix for
+// ga-ejwo1q at the layer every unbatched caller shares: deleting a workflow
+// root that still owns open work is refused outright, so no pruner has to
+// remember to check.
+func TestDeleteWorkflowBeadRefusesRootWithOpenDescendant(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "workflow root", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	step, err := store.Create(beads.Bead{
+		Title:    "live step",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+	if err := store.Close(root.ID); err != nil {
+		t.Fatalf("Close(root): %v", err)
+	}
+
+	err = deleteWorkflowBead(store, root.ID)
+	if !errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
+		t.Fatalf("deleteWorkflowBead(root) err = %v, want ErrWorkflowDeleteLiveDescendants", err)
+	}
+	if _, err := store.Get(root.ID); err != nil {
+		t.Fatalf("root must survive a refused delete: %v", err)
+	}
+
+	// Once the step is terminal there is nothing left to strand, so the same
+	// call must succeed — the guard gates on descendant STATE, and a permanent
+	// refusal would leak closed tracking rows forever.
+	if err := store.Close(step.ID); err != nil {
+		t.Fatalf("Close(step): %v", err)
+	}
+	if err := deleteWorkflowBead(store, root.ID); err != nil {
+		t.Fatalf("deleteWorkflowBead(root) after step closed: %v", err)
+	}
+}
+
+// TestDeleteWorkflowBeadsDeletesWholeClosureIncludingOpenMembers guards the
+// other direction: a deliberate whole-workflow teardown (gc workflow
+// delete-source, the wisp GC closed-root closure purge) strands nothing by
+// definition, so open members inside the delete set must not block it.
+func TestDeleteWorkflowBeadsDeletesWholeClosureIncludingOpenMembers(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "workflow root", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	step, err := store.Create(beads.Bead{
+		Title:    "live step",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	})
+	if err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+
+	deleted, errs := deleteWorkflowBeads(store, []string{root.ID, step.ID})
+	if len(errs) != 0 {
+		t.Fatalf("deleteWorkflowBeads errs = %v, want none", errs)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+	for _, id := range []string{root.ID, step.ID} {
+		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		}
+	}
+}
+
+// TestDeleteWorkflowBeadsBatchRefusesOpenDescendantOutsideSet is the backstop
+// on the batched path: the closure collector is what decides the set, and if it
+// ever misses a live member the batch delete must fail rather than strand it.
+func TestDeleteWorkflowBeadsBatchRefusesOpenDescendantOutsideSet(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "workflow root", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "live step outside the collected closure",
+		Type:     "task",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	}); err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+	if err := store.Close(root.ID); err != nil {
+		t.Fatalf("Close(root): %v", err)
+	}
+
+	err = deleteWorkflowBeadsBatch(store, []string{root.ID})
+	if !errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
+		t.Fatalf("deleteWorkflowBeadsBatch err = %v, want ErrWorkflowDeleteLiveDescendants", err)
+	}
+	if _, err := store.Get(root.ID); err != nil {
+		t.Fatalf("root must survive a refused batch delete: %v", err)
+	}
+}
+
 func TestApplySourceWorkflowMatchCleanupDeletesOnlyCollectedWorkflowBeads(t *testing.T) {
 	store := beads.NewMemStore()
 	first, err := store.Create(beads.Bead{Title: "workflow first", Type: "task"})

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -6653,8 +6653,11 @@ func TestDeleteWorkflowBeadRefusesRootWithOpenDescendant(t *testing.T) {
 	}
 
 	err = deleteWorkflowBead(store, root.ID)
-	if !errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
-		t.Fatalf("deleteWorkflowBead(root) err = %v, want ErrWorkflowDeleteLiveDescendants", err)
+	if !errors.Is(err, errWorkflowDeleteLiveDescendants) {
+		t.Fatalf("deleteWorkflowBead(root) err = %v, want errWorkflowDeleteLiveDescendants", err)
+	}
+	if !strings.Contains(err.Error(), step.ID) {
+		t.Fatalf("deleteWorkflowBead(root) err = %q, want the open step %s named so the refusal is actionable", err, step.ID)
 	}
 	if _, err := store.Get(root.ID); err != nil {
 		t.Fatalf("root must survive a refused delete: %v", err)
@@ -6713,11 +6716,12 @@ func TestDeleteWorkflowBeadsBatchRefusesOpenDescendantOutsideSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create(root): %v", err)
 	}
-	if _, err := store.Create(beads.Bead{
+	step, err := store.Create(beads.Bead{
 		Title:    "live step outside the collected closure",
 		Type:     "task",
 		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create(step): %v", err)
 	}
 	if err := store.Close(root.ID); err != nil {
@@ -6725,11 +6729,143 @@ func TestDeleteWorkflowBeadsBatchRefusesOpenDescendantOutsideSet(t *testing.T) {
 	}
 
 	err = deleteWorkflowBeadsBatch(store, []string{root.ID})
-	if !errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
-		t.Fatalf("deleteWorkflowBeadsBatch err = %v, want ErrWorkflowDeleteLiveDescendants", err)
+	if !errors.Is(err, errWorkflowDeleteLiveDescendants) {
+		t.Fatalf("deleteWorkflowBeadsBatch err = %v, want errWorkflowDeleteLiveDescendants", err)
+	}
+	if !strings.Contains(err.Error(), step.ID) {
+		t.Fatalf("deleteWorkflowBeadsBatch err = %q, want the open step %s named", err, step.ID)
 	}
 	if _, err := store.Get(root.ID); err != nil {
 		t.Fatalf("root must survive a refused batch delete: %v", err)
+	}
+}
+
+// TestDeleteWorkflowBeadsRefusalNamesRootOnceAndOpenSteps pins the shape of
+// the refusal gc workflow delete-source prints verbatim on its delete_error=
+// line: the root named once (the guard's error already carries it, so the
+// per-id wrapper must not prefix it again) and every open step holding the
+// root named too, so the operator can find them without a second query.
+func TestDeleteWorkflowBeadsRefusalNamesRootOnceAndOpenSteps(t *testing.T) {
+	store := beads.NewMemStoreFrom(100, []beads.Bead{
+		{ID: "wf-root", Title: "workflow root", Status: "closed", Type: "task"},
+		{
+			ID: "wf-step-a", Title: "live step", Status: "open", Type: "task",
+			Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "wf-root"},
+		},
+		{
+			ID: "wf-step-b", Title: "live step", Status: "open", Type: "task",
+			Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "wf-root"},
+		},
+	}, nil)
+
+	deleted, errs := deleteWorkflowBeads(store, []string{"wf-root"})
+	if deleted != 0 || len(errs) != 1 {
+		t.Fatalf("deleteWorkflowBeads = (%d, %v), want (0, one refusal)", deleted, errs)
+	}
+	if !errors.Is(errs[0], errWorkflowDeleteLiveDescendants) {
+		t.Fatalf("errs[0] = %v, want errWorkflowDeleteLiveDescendants", errs[0])
+	}
+	msg := errs[0].Error()
+	if n := strings.Count(msg, "wf-root"); n != 1 {
+		t.Fatalf("errs[0] = %q, names the root %d times, want exactly once", msg, n)
+	}
+	for _, step := range []string{"wf-step-a", "wf-step-b"} {
+		if !strings.Contains(msg, step) {
+			t.Fatalf("errs[0] = %q, want open step %s named", msg, step)
+		}
+	}
+	if _, err := store.Get("wf-root"); err != nil {
+		t.Fatalf("root must survive a refused delete: %v", err)
+	}
+}
+
+// TestWorkflowDeleteFailsClosedWhenDescendantViewUnreadable covers the
+// fail-closed branch of every delete entry point: when the descendant view
+// cannot be read, the guard cannot prove the delete strands nothing, so the
+// read error propagates and the bead survives. The error is deliberately NOT
+// the refusal sentinel — an unreadable store is a sweep failure the pruners
+// must surface, not a skip they may quietly retry forever.
+func TestWorkflowDeleteFailsClosedWhenDescendantViewUnreadable(t *testing.T) {
+	cases := []struct {
+		name   string
+		delete func(beads.Store, string) error
+	}{
+		{name: "deleteWorkflowBead", delete: deleteWorkflowBead},
+		{name: "deleteWorkflowBeads", delete: func(store beads.Store, id string) error {
+			_, errs := deleteWorkflowBeads(store, []string{id})
+			return errors.Join(errs...)
+		}},
+		{name: "deleteWorkflowBeadsBatch", delete: func(store beads.Store, id string) error {
+			return deleteWorkflowBeadsBatch(store, []string{id})
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing := beads.NewMemStore()
+			root, err := backing.Create(beads.Bead{Title: "workflow root", Type: "task"})
+			if err != nil {
+				t.Fatalf("Create(root): %v", err)
+			}
+			if err := backing.Close(root.ID); err != nil {
+				t.Fatalf("Close(root): %v", err)
+			}
+
+			err = tc.delete(failingListStore{backing}, root.ID)
+			if err == nil {
+				t.Fatal("delete succeeded with an unreadable descendant view; the guard must fail closed")
+			}
+			if !errors.Is(err, errDarkLeg{}) {
+				t.Fatalf("err = %v, want the store's read error propagated", err)
+			}
+			if errors.Is(err, errWorkflowDeleteLiveDescendants) {
+				t.Fatalf("err = %v, must not read as a refusal: pruners skip refusals, an unreadable view must surface", err)
+			}
+			if _, err := backing.Get(root.ID); err != nil {
+				t.Fatalf("root must survive a delete the guard could not prove safe: %v", err)
+			}
+		})
+	}
+}
+
+// TestDeleteWorkflowBeadIgnoresTransientNotificationDescendants covers the
+// carve-out in workflowDeleteSkip: an open nudge chore or mail bead owned by
+// the root is delivery residue reaped on its own TTL, not live work, so it
+// neither blocks the delete nor appears among the named open descendants —
+// the same carve-out the single-flight dispatch gate makes, so a lingering
+// notification cannot wedge retention forever.
+func TestDeleteWorkflowBeadIgnoresTransientNotificationDescendants(t *testing.T) {
+	owned := func(id, title, beadType string, labels ...string) beads.Bead {
+		return beads.Bead{
+			ID: id, Title: title, Status: "open", Type: beadType, Labels: labels,
+			Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "wf-root"},
+		}
+	}
+	store := beads.NewMemStoreFrom(100, []beads.Bead{
+		{ID: "wf-root", Title: "workflow root", Status: "closed", Type: "task"},
+		owned("wf-mail", "escalation mail", "message"),
+		owned("wf-nudge", "wake nudge", nudgeBeadType, nudgeBeadLabel),
+		owned("wf-step", "live step", "task"),
+	}, nil)
+
+	// While a real step is open the delete is refused, and the refusal names
+	// that step alone: the chores are not what holds the root.
+	err := deleteWorkflowBead(store, "wf-root")
+	if !errors.Is(err, errWorkflowDeleteLiveDescendants) {
+		t.Fatalf("deleteWorkflowBead(wf-root) err = %v, want errWorkflowDeleteLiveDescendants", err)
+	}
+	if msg := err.Error(); !strings.Contains(msg, "wf-step") || strings.Contains(msg, "wf-mail") || strings.Contains(msg, "wf-nudge") {
+		t.Fatalf("refusal = %q, want wf-step named and the transient chores omitted", msg)
+	}
+
+	// With only the chores left open there is no live work to strand.
+	if err := store.Close("wf-step"); err != nil {
+		t.Fatalf("Close(wf-step): %v", err)
+	}
+	if err := deleteWorkflowBead(store, "wf-root"); err != nil {
+		t.Fatalf("deleteWorkflowBead(wf-root) with only transient chores open: %v", err)
+	}
+	if _, err := store.Get("wf-root"); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get(wf-root) err = %v, want ErrNotFound", err)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -3083,6 +3083,7 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 
 	cutoff := now.Add(-policy.deleteAfterClose)
 	deleted := 0
+	stranded := 0
 	var deleteErr error
 	for _, runs := range byOrder {
 		sort.Slice(runs, func(i, j int) bool {
@@ -3101,15 +3102,34 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 				continue
 			}
 			// deleteWorkflowBead is the graph-aware delete (dep unwind) the
-			// retention prune uses; it stays raw graph residual.
+			// retention prune uses; it stays raw graph residual. A closed
+			// tracking root can still own OPEN steps — the delete refuses
+			// those rather than stranding them (ga-ejwo1q).
 			if err := deleteWorkflowBead(store, run.ID); err != nil {
+				if errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
+					stranded++
+					continue
+				}
 				deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting closed order-tracking bead %q: %w", run.ID, err))
 				continue
 			}
 			deleted++
 		}
 	}
+	logRetainedForLiveDescendants(stranded)
 	return deleted, deleteErr
+}
+
+// logRetainedForLiveDescendants reports candidates the retention prune declined
+// to delete because they still own live work. Retention is a background sweep,
+// so a silent skip reads exactly like "nothing was eligible"; printing the
+// count is what makes a persistently-wedged root visible instead of a slow leak
+// nobody attributes.
+func logRetainedForLiveDescendants(n int) {
+	if n <= 0 {
+		return
+	}
+	log.Printf("order-tracking retention: retained %d expired closed root(s) that still own open steps (deleting them would strand the steps)", n)
 }
 
 // sweepClosedOrderTrackingRetentionBounded is the per-store bounded variant of
@@ -3135,6 +3155,7 @@ func sweepClosedOrderTrackingRetentionBounded(store beads.Store, now time.Time, 
 
 	cutoff := now.Add(-policy.deleteAfterClose)
 	deleted := 0
+	stranded := 0
 	var deleteErr error
 	for _, runs := range byOrder {
 		if deleted >= limit {
@@ -3159,12 +3180,17 @@ func sweepClosedOrderTrackingRetentionBounded(store beads.Store, now time.Time, 
 				continue
 			}
 			if err := deleteWorkflowBead(store, run.ID); err != nil {
+				if errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
+					stranded++
+					continue
+				}
 				deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting closed order-tracking bead %q: %w", run.ID, err))
 				continue
 			}
 			deleted++
 		}
 	}
+	logRetainedForLiveDescendants(stranded)
 	return deleted, deleteErr
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -2397,7 +2397,18 @@ func isTransientNotificationBead(b beads.Bead) bool {
 }
 
 // storeHasOpenDescendants reports whether the wisp rooted at rootID still has
-// any open descendant bead. It first consults the molecule membership index:
+// any open descendant bead. It is storeOpenDescendantIDs reduced to a bool: the
+// dispatch gate and the stale-wisp sweeper need only the answer, while the
+// workflow delete guard also needs the ids so its refusal can name the steps.
+func storeHasOpenDescendants(store beads.Store, rootID string, skip func(beads.Bead) bool) (bool, error) {
+	open, err := storeOpenDescendantIDs(store, rootID, skip)
+	return len(open) > 0, err
+}
+
+// storeOpenDescendantIDs returns the ids of the open descendant beads of the
+// wisp rooted at rootID: every open member the molecule membership index
+// reports, or, when the index reports none, the first open descendant the tree
+// walk reaches. It first consults the molecule membership index:
 // every descendant created by any growth path (initial pour, convoy Attach,
 // fanout fragments, retry attempts) carries gc.root_bead_id == rootID, an
 // invariant enforced in internal/molecule. A single metadata-filtered List
@@ -2420,7 +2431,7 @@ func isTransientNotificationBead(b beads.Bead) bool {
 // on some steps while sibling ParentID-only steps are un-stamped), it falls
 // back to the authoritative tree walk before reporting the root idle, so
 // single-flight is never weakened for un-stamped or partial-stamp data.
-func storeHasOpenDescendants(store beads.Store, rootID string, skip func(beads.Bead) bool) (bool, error) {
+func storeOpenDescendantIDs(store beads.Store, rootID string, skip func(beads.Bead) bool) ([]string, error) {
 	reader := beads.HandlesFor(store).Live
 	members, err := reader.List(beads.ListQuery{
 		Metadata:      map[string]string{beadmeta.RootBeadIDMetadataKey: rootID},
@@ -2428,8 +2439,9 @@ func storeHasOpenDescendants(store beads.Store, rootID string, skip func(beads.B
 		TierMode:      beads.TierBoth,
 	})
 	if err != nil {
-		return false, fmt.Errorf("listing wisp members of %s: %w", rootID, err)
+		return nil, fmt.Errorf("listing wisp members of %s: %w", rootID, err)
 	}
+	var open []string
 	for _, b := range members {
 		if b.ID == rootID || b.Status == "closed" {
 			continue
@@ -2437,29 +2449,38 @@ func storeHasOpenDescendants(store beads.Store, rootID string, skip func(beads.B
 		if skip != nil && skip(b) {
 			continue
 		}
-		return true, nil
+		open = append(open, b.ID)
+	}
+	if len(open) > 0 {
+		return open, nil
 	}
 	// No OPEN stamped member found. An empty or all-closed membership set does
 	// NOT prove the root is idle, because the index may be incomplete for a
 	// partial-stamp molecule (some steps carry gc.root_bead_id, sibling
 	// ParentID-only steps do not). Confirm with the authoritative walk before
 	// reporting no open work, keeping single-flight safe. The fast path still
-	// short-circuits the common in-flight case (any open stamped member) in one
+	// answers the common in-flight case (any open stamped member) in one
 	// query; the walk runs only when no open member is found — i.e. for
 	// orphan/just-completed roots.
-	return storeHasOpenDescendantsByWalk(store, rootID, skip)
+	id, err := storeFirstOpenDescendantByWalk(store, rootID, skip)
+	if err != nil || id == "" {
+		return nil, err
+	}
+	return []string{id}, nil
 }
 
-// storeHasOpenDescendantsByWalk is the authoritative O(tree) traversal used as
+// storeFirstOpenDescendantByWalk is the authoritative O(tree) traversal used as
 // the fallback for roots whose descendants lack the gc.root_bead_id membership
-// metadata. It is the historical storeHasOpenDescendants implementation. It
+// metadata. It returns the id of the first open descendant it reaches, or ""
+// when there is none — it stops at the first hit because every level costs a
+// store read. It is the historical storeHasOpenDescendants implementation. It
 // includes closed intermediate nodes so nested molecule work remains visible
 // after a direct child step has completed. Graph-v2 workflows can link children
 // with dependency edges instead of ParentID, so descendants include
 // parent-child/tracks/blocks dependents too. When skip is non-nil, an open
 // child for which skip returns true is not treated as blocking open work (its
 // subtree is still traversed).
-func storeHasOpenDescendantsByWalk(store beads.Store, rootID string, skip func(beads.Bead) bool) (bool, error) {
+func storeFirstOpenDescendantByWalk(store beads.Store, rootID string, skip func(beads.Bead) bool) (string, error) {
 	seen := map[string]struct{}{rootID: {}}
 	queue := []string{rootID}
 	// ParentID queries and closed intermediate traversal require live reads:
@@ -2471,7 +2492,7 @@ func storeHasOpenDescendantsByWalk(store beads.Store, rootID string, skip func(b
 
 		children, err := orderWispParentChildren(reader, parentID)
 		if err != nil {
-			return false, err
+			return "", err
 		}
 		for _, c := range children {
 			if c.ID == "" || c.ID == rootID {
@@ -2482,14 +2503,14 @@ func storeHasOpenDescendantsByWalk(store beads.Store, rootID string, skip func(b
 			}
 			seen[c.ID] = struct{}{}
 			if c.Status != "closed" && (skip == nil || !skip(c)) {
-				return true, nil
+				return c.ID, nil
 			}
 			queue = append(queue, c.ID)
 		}
 
 		children, err = orderWispGraphDependentChildren(reader, rootID, parentID)
 		if err != nil {
-			return false, err
+			return "", err
 		}
 		for _, c := range children {
 			if c.ID == "" || c.ID == rootID {
@@ -2500,12 +2521,12 @@ func storeHasOpenDescendantsByWalk(store beads.Store, rootID string, skip func(b
 			}
 			seen[c.ID] = struct{}{}
 			if c.Status != "closed" && (skip == nil || !skip(c)) {
-				return true, nil
+				return c.ID, nil
 			}
 			queue = append(queue, c.ID)
 		}
 	}
-	return false, nil
+	return "", nil
 }
 
 func orderWispMetadataDescendants(reader beads.LiveReader, rootID string, includeClosed bool) ([]beads.Bead, error) {
@@ -3083,7 +3104,7 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 
 	cutoff := now.Add(-policy.deleteAfterClose)
 	deleted := 0
-	stranded := 0
+	var retained []string
 	var deleteErr error
 	for _, runs := range byOrder {
 		sort.Slice(runs, func(i, j int) bool {
@@ -3106,8 +3127,8 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 			// tracking root can still own OPEN steps — the delete refuses
 			// those rather than stranding them (ga-ejwo1q).
 			if err := deleteWorkflowBead(store, run.ID); err != nil {
-				if errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
-					stranded++
+				if errors.Is(err, errWorkflowDeleteLiveDescendants) {
+					retained = append(retained, run.ID)
 					continue
 				}
 				deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting closed order-tracking bead %q: %w", run.ID, err))
@@ -3116,20 +3137,20 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 			deleted++
 		}
 	}
-	logRetainedForLiveDescendants(stranded)
+	logRetainedForLiveDescendants(retained)
 	return deleted, deleteErr
 }
 
-// logRetainedForLiveDescendants reports candidates the retention prune declined
-// to delete because they still own live work. Retention is a background sweep,
-// so a silent skip reads exactly like "nothing was eligible"; printing the
-// count is what makes a persistently-wedged root visible instead of a slow leak
-// nobody attributes.
-func logRetainedForLiveDescendants(n int) {
-	if n <= 0 {
+// logRetainedForLiveDescendants reports the candidates the retention prune
+// declined to delete because they still own live work. Retention is a
+// background sweep, so a silent skip reads exactly like "nothing was eligible";
+// naming the roots is what makes a persistently-wedged root visible, and
+// findable, instead of a slow leak nobody attributes.
+func logRetainedForLiveDescendants(ids []string) {
+	if len(ids) == 0 {
 		return
 	}
-	log.Printf("order-tracking retention: retained %d expired closed root(s) that still own open steps (deleting them would strand the steps)", n)
+	log.Printf("order-tracking retention: retained %d expired closed root(s) that still own open steps (deleting them would strand the steps): %s", len(ids), strings.Join(ids, ","))
 }
 
 // sweepClosedOrderTrackingRetentionBounded is the per-store bounded variant of
@@ -3155,7 +3176,7 @@ func sweepClosedOrderTrackingRetentionBounded(store beads.Store, now time.Time, 
 
 	cutoff := now.Add(-policy.deleteAfterClose)
 	deleted := 0
-	stranded := 0
+	var retained []string
 	var deleteErr error
 	for _, runs := range byOrder {
 		if deleted >= limit {
@@ -3180,8 +3201,8 @@ func sweepClosedOrderTrackingRetentionBounded(store beads.Store, now time.Time, 
 				continue
 			}
 			if err := deleteWorkflowBead(store, run.ID); err != nil {
-				if errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
-					stranded++
+				if errors.Is(err, errWorkflowDeleteLiveDescendants) {
+					retained = append(retained, run.ID)
 					continue
 				}
 				deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting closed order-tracking bead %q: %w", run.ID, err))
@@ -3190,7 +3211,7 @@ func sweepClosedOrderTrackingRetentionBounded(store beads.Store, now time.Time, 
 			deleted++
 		}
 	}
-	logRetainedForLiveDescendants(stranded)
+	logRetainedForLiveDescendants(retained)
 	return deleted, deleteErr
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4151,15 +4151,29 @@ func TestSweepClosedOrderTrackingRetentionRetainsRootsThatStillOwnOpenSteps(t *t
 	)
 	store := beads.NewMemStoreFrom(100, seed, nil)
 
-	deleted, err := sweepClosedOrderTrackingRetention(store, now, orderTrackingRetentionPolicy{
-		deleteAfterClose: 24 * time.Hour,
-		retainLast:       minClosedOrderTrackingRetained,
-	}, nil)
+	var (
+		deleted int
+		err     error
+	)
+	logOutput := captureWispGCLog(t, func() {
+		deleted, err = sweepClosedOrderTrackingRetention(store, now, orderTrackingRetentionPolicy{
+			deleteAfterClose: 24 * time.Hour,
+			retainLast:       minClosedOrderTrackingRetained,
+		}, nil)
+	})
 	if err != nil {
 		t.Fatalf("sweepClosedOrderTrackingRetention: %v", err)
 	}
 	if deleted != 1 {
 		t.Fatalf("deleted = %d, want 1 (alpha-01 only; alpha-00 still owns an open step)", deleted)
+	}
+	// A retained root is only actionable if the log says WHICH root: a count
+	// alone leaves the operator to re-derive it from the store.
+	if !strings.Contains(logOutput, "alpha-00") {
+		t.Fatalf("retention log = %q, want the retained root alpha-00 named", logOutput)
+	}
+	if strings.Contains(logOutput, "alpha-01") {
+		t.Fatalf("retention log = %q, names alpha-01, which was pruned, not retained", logOutput)
 	}
 
 	// Assert the ROOT/STEP PAIR, not just the root's survival: the defect is

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4113,6 +4113,110 @@ func TestSweepClosedOrderTrackingRetentionKeepsLatestTenPerOrderAcrossTiers(t *t
 	}
 }
 
+// TestSweepClosedOrderTrackingRetentionRetainsRootsThatStillOwnOpenSteps is the
+// ga-ejwo1q regression: the retention prune deleted an expired CLOSED tracking
+// root without looking at its descendants, leaving live steps rootless. A
+// rootless step is unworkable by construction — it can only fail
+// an out-of-vocabulary failure class and mail an escalation — so the prune manufactured noise
+// out of live work (ga-033u0e).
+//
+// The guard is descendant-state-sensitive, not a blanket "never delete a root":
+// alpha-00 owns an OPEN step and is retained, while alpha-01 owns only a CLOSED
+// step and still prunes on the same sweep.
+func TestSweepClosedOrderTrackingRetentionRetainsRootsThatStillOwnOpenSteps(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	beadTime := now.Add(-48 * time.Hour)
+	seed := make([]beads.Bead, 0, 14)
+	for i := 0; i < 12; i++ {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("alpha-%02d", i),
+			Title:     "order:alpha",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime.Add(time.Duration(i) * time.Minute),
+			Labels:    []string{"order-run:alpha", labelOrderTracking},
+		})
+	}
+	seed = append(seed,
+		beads.Bead{
+			ID: "alpha-00-step", Title: "live step", Status: "open", Type: "task",
+			CreatedAt: beadTime, Ephemeral: true,
+			Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "alpha-00"},
+		},
+		beads.Bead{
+			ID: "alpha-01-step", Title: "finished step", Status: "closed", Type: "task",
+			CreatedAt: beadTime, Ephemeral: true,
+			Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "alpha-01"},
+		},
+	)
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetention(store, now, orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}, nil)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetention: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (alpha-01 only; alpha-00 still owns an open step)", deleted)
+	}
+
+	// Assert the ROOT/STEP PAIR, not just the root's survival: the defect is
+	// the step outliving its root, so read the step's own pointer back and
+	// require it to still resolve.
+	step, err := store.Get("alpha-00-step")
+	if err != nil {
+		t.Fatalf("open step must not be deleted: %v", err)
+	}
+	if _, err := store.Get(step.Metadata[beadmeta.RootBeadIDMetadataKey]); err != nil {
+		t.Fatalf("open step left rootless — this is the ga-ejwo1q defect: %v", err)
+	}
+
+	if _, err := store.Get("alpha-01"); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("alpha-01 owns only closed steps and must still prune: err = %v", err)
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionBoundedRetainsRootsThatStillOwnOpenSteps(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	beadTime := now.Add(-48 * time.Hour)
+	seed := make([]beads.Bead, 0, 14)
+	for i := 0; i < 12; i++ {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("alpha-%02d", i),
+			Title:     "order:alpha",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime.Add(time.Duration(i) * time.Minute),
+			Labels:    []string{"order-run:alpha", labelOrderTracking},
+		})
+	}
+	seed = append(seed, beads.Bead{
+		ID: "alpha-00-step", Title: "live step", Status: "open", Type: "task",
+		CreatedAt: beadTime, Ephemeral: true,
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "alpha-00"},
+	})
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetentionBounded(store, now, orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}, nil, 10)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetentionBounded: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (alpha-01 only)", deleted)
+	}
+	if _, err := store.Get("alpha-00"); err != nil {
+		t.Fatalf("alpha-00 owns an open step and must be retained: %v", err)
+	}
+	if _, err := store.Get("alpha-00-step"); err != nil {
+		t.Fatalf("open step must not be stranded: %v", err)
+	}
+}
+
 func TestSweepClosedOrderTrackingRetentionPrunesLegacyUnscopedTracking(t *testing.T) {
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	beadTime := now.Add(-48 * time.Hour)

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -482,14 +482,19 @@ func reapOrphanedClosedWisps(store beads.Store, cutoff time.Time, batchCap int) 
 			continue
 		}
 
-		attempted++
-		if err := deleteWorkflowBead(store, c.ID); err != nil {
+		err := deleteWorkflowBead(store, c.ID)
+		if errors.Is(err, errWorkflowDeleteLiveDescendants) {
 			// A closed orphan can itself be an intermediate step that still
 			// owns open sub-steps; the delete refuses those. That is a skip,
-			// not a sweep failure — it becomes eligible once they finish.
-			if errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
-				continue
-			}
+			// not a sweep failure — it becomes eligible once they finish —
+			// and it is not charged to the batch cap: no delete was
+			// attempted, and an orphan refused on every sweep would otherwise
+			// hold a cap slot on every sweep, starving the reapable orphans
+			// listed behind it.
+			continue
+		}
+		attempted++
+		if err != nil {
 			deleteErr = errors.Join(deleteErr, fmt.Errorf("reaping orphaned closed wisp %q: %w", c.ID, err))
 			continue
 		}
@@ -707,7 +712,9 @@ var errBeadNoLongerEligible = errors.New("bead skipped: no longer eligible for d
 // of DELETE ATTEMPTS per call — counting failures, not just successes — so a
 // large backlog or a failing delete backend cannot make one sweep attempt an
 // unbounded amount of deletion work; the remainder drains on later ticks.
-// batchCap <= 0 disables the bound. Entries skipped for age never consume the cap.
+// batchCap <= 0 disables the bound. Entries skipped for age never consume the
+// cap, nor do entries whose delete the strand guard refused
+// (errWorkflowDeleteLiveDescendants): no delete was attempted for those.
 func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, batchCap int, deleteFn func(beads.Store, string) error) (int, error) {
 	purged := 0
 	attempted := 0
@@ -719,8 +726,19 @@ func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
+		err := deleteFn(store, entry.ID)
+		if errors.Is(err, errWorkflowDeleteLiveDescendants) {
+			// The strand guard refused the closure delete: an open descendant
+			// the closure collector did not see still holds the root. That is
+			// a skip, not a sweep failure — the root becomes eligible once the
+			// descendant finishes — and it is not charged to the cap: no
+			// delete was attempted, and a root refused on every sweep would
+			// otherwise hold a cap slot on every sweep, starving the
+			// collectible roots listed behind it.
+			continue
+		}
 		attempted++
-		if err := deleteFn(store, entry.ID); err != nil {
+		if err != nil {
 			if errors.Is(err, errBeadNoLongerEligible) {
 				continue
 			}

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -484,6 +484,12 @@ func reapOrphanedClosedWisps(store beads.Store, cutoff time.Time, batchCap int) 
 
 		attempted++
 		if err := deleteWorkflowBead(store, c.ID); err != nil {
+			// A closed orphan can itself be an intermediate step that still
+			// owns open sub-steps; the delete refuses those. That is a skip,
+			// not a sweep failure — it becomes eligible once they finish.
+			if errors.Is(err, ErrWorkflowDeleteLiveDescendants) {
+				continue
+			}
 			deleteErr = errors.Join(deleteErr, fmt.Errorf("reaping orphaned closed wisp %q: %w", c.ID, err))
 			continue
 		}

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -1523,6 +1523,116 @@ func TestWispGC_CollectsClosedGraphWorkflowRoot(t *testing.T) {
 	}
 }
 
+// laggingClosureStore models the race the closure purge's set-level strand
+// guard exists for: a step created between the closure collector's List and
+// the guard's live membership read. Its non-live List (what
+// collectExpiredBeadClosure reads) omits hiddenID; the live reader the guard
+// uses sees everything.
+type laggingClosureStore struct {
+	*gcTestStore
+	hiddenID string
+}
+
+func (s *laggingClosureStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	items, err := s.gcTestStore.List(query)
+	if err != nil || query.Live {
+		return items, err
+	}
+	kept := make([]beads.Bead, 0, len(items))
+	for _, b := range items {
+		if b.ID != s.hiddenID {
+			kept = append(kept, b)
+		}
+	}
+	return kept, nil
+}
+
+// TestWispGC_ClosurePurgeSkipsRefusedRootWithoutChargingCap applies the
+// pruner rule to the closed-root closure purge: a root whose closure delete
+// the strand guard refuses is a SKIP — no error joined into the sweep result
+// (so nothing printed to stderr every tick) and no charge against the closure
+// batch cap, because no delete was attempted. With the cap at 1 and the
+// refused root listed first, a sweep that charged the refusal would never
+// reach the collectible root behind it — on every tick, forever.
+func TestWispGC_ClosurePurgeSkipsRefusedRootWithoutChargingCap(t *testing.T) {
+	now := time.Now()
+	store := &laggingClosureStore{
+		gcTestStore: newGCStore([]beads.Bead{
+			makeGCBead("mol-refused", now.Add(-3*time.Hour), "closed", "molecule"),
+			{
+				ID:        "mol-refused.step",
+				Status:    "open",
+				Type:      "task",
+				CreatedAt: now.Add(-3 * time.Hour),
+				Metadata:  map[string]string{beadmeta.RootBeadIDMetadataKey: "mol-refused"},
+			},
+			makeGCBead("mol-ok", now.Add(-2*time.Hour), "closed", "molecule"),
+		}),
+		hiddenID: "mol-refused.step",
+	}
+
+	entries, err := closedWispGCEntries(store)
+	if err != nil {
+		t.Fatalf("closedWispGCEntries: %v", err)
+	}
+	purged, err := purgeExpiredBeadClosures(store, entries, now, 1)
+	if err != nil {
+		t.Fatalf("purgeExpiredBeadClosures: %v (a refused delete is a skip, not a sweep failure)", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (the refusal must not consume the cap slot mol-ok needs)", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-ok")
+	for _, id := range []string{"mol-refused", "mol-refused.step"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("Get(%s): %v, want the refused root and its open step to survive", id, err)
+		}
+	}
+}
+
+// TestWispGC_ReapSkipsOrphanOwningOpenSubStepWithoutChargingCap covers the
+// orphan reaper's refusal branch: a closed orphan that is itself an
+// intermediate step still owning an open sub-step is refused by the strand
+// guard. That is a skip — no error, and the candidate becomes eligible once
+// the sub-step finishes — and it must not charge the reap batch cap: no delete
+// was attempted, and with the cap at 1 and the refused orphan listed first, a
+// charged refusal would starve every reapable orphan behind it on every sweep.
+func TestWispGC_ReapSkipsOrphanOwningOpenSubStepWithoutChargingCap(t *testing.T) {
+	withReapOrphansEnforced(t, true)
+	withReapOrphanBatchCap(t, 1)
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCOrphanWisp("orphan-refused", now.Add(-3*time.Hour), "ghost-root"),
+		{
+			// Linked by ParentID only (no gc.root_bead_id), so the refusal
+			// comes from the guard's tree-walk fallback, not the membership
+			// index.
+			ID:        "orphan-refused.sub",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-3 * time.Hour),
+			ParentID:  "orphan-refused",
+			Ephemeral: true,
+		},
+		makeGCOrphanWisp("orphan-ok", now.Add(-2*time.Hour), "ghost-root"),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(beads.GraphStore{Store: store}, beads.MailStore{Store: store}, now)
+	if err != nil {
+		t.Fatalf("runGC: %v (a refused reap is a skip, not a sweep failure)", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (the refusal must not consume the cap slot orphan-ok needs)", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "orphan-ok")
+	for _, id := range []string{"orphan-refused", "orphan-refused.sub"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("Get(%s): %v, want the refused orphan and its open sub-step to survive", id, err)
+		}
+	}
+}
+
 // TestWispGC_ClosurePurgeHonorsBatchCap is the post-merge regression for the
 // finding that the closed-root closure purge had no per-tick bound. The selector
 // expansion (adding graph.v2/workflow roots) made a never-before-collected class


### PR DESCRIPTION
## What

`deleteWorkflowBead` unwound dependency edges and deleted the bead without looking at the workflow steps hanging off it via `gc.root_bead_id`. Order-tracking retention calls it on expired CLOSED tracking roots, and a closed root can still own OPEN steps — deleting one leaves those steps rootless, and a rootless step is unworkable by construction: root-metadata reads fail, closes fail, and each failure mails an escalation, so the workflow becomes an escalation generator with zero forward progress (ga-ejwo1q).

The delete layer now proves a delete strands nothing before it runs, and the guard is **set-aware** — a delete that removes a whole workflow strands nothing, so an open descendant inside the same delete set does not block it:

- `deleteWorkflowBead(id)` — guard against an empty set
- `deleteWorkflowBeads(ids)` — per-id guard, set = ids
- `deleteWorkflowBeadsBatch(ids)` — one set-level guard, then the batch delete

## Why guard the shared layer

`deleteWorkflowBead` has several callers (retention ×2, the wisp orphan reaper, the wisp closure purge, `gc workflow delete-source --apply --delete`) and any of them can be handed a root; fixing the one pruner observed to trip it would leave the class open.

The predicate is `storeHasOpenDescendants` — the authoritative view the single-flight dispatch gate already uses: membership index first, tree walk as fallback so partial-stamp molecules linked only by `ParentID` are seen. It fails **closed**: an unreadable descendant view propagates and the bead survives, mirroring `reapOrphanedClosedWisps` skipping on any unreadable root Get. A bead that lingers one more sweep is recoverable; a stranded workflow is not.

The batched path uses a membership-index-only backstop instead of the walk: walking once per closure member is O(n·depth) and would undo the batching that path exists for, and its callers already collect the closure with the same ownership rules the walk applies.

Scheduled pruners treat a refusal as a **skip**, not a sweep failure — the candidate becomes eligible again once its steps finish — and retention logs a count of what it retained, because a silent skip in a background sweep is indistinguishable from "nothing was eligible". Closed descendants deliberately do NOT block: they are terminal residue the wisp orphan reaper already collects, and blocking on them would leak closed tracking rows forever, which is what retention exists to prevent.


`gc workflow delete --force --delete` is not on that list on purpose: it does not go through `deleteWorkflowBead` — it shells out to `bd delete <ids> --cascade --force` (`deleteWorkflowMatches`) — so this guard does not cover it and it is left alone here.

## Test plan

- Five new memstore-level tests covering the per-bead refusal, whole-closure deletes staying allowed, the batch set-level refusal, and both retention sweeps retaining roots that still own open steps. Each was verified to FAIL with the guard stubbed to return nil.
- They assert the root/step PAIR rather than the root's survival alone (the defect is the step outliving its root), and a sibling root whose only step is CLOSED still prunes in the same sweep, so a guard that never deleted anything would fail them.
- `go build ./...`, `go vet ./cmd/gc/` clean; the surrounding workflow-delete/retention/wisp-reap family (52 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvU8iDeCxbuqVKqEp7W5RT

## Release note

`gc workflow delete-source --apply --delete` now refuses to delete a matched workflow root that still owns open steps outside the match set: it prints `store=<label> delete_error=workflow bead still owns live descendants: <root> (open descendants: <step-ids>)` per root and reports `result=incomplete … metadata_cleared=false` (exit 1) instead of `result=cleaned`. Order-tracking retention and wisp GC now retain such roots instead of stranding their steps — retention logs `order-tracking retention: retained N expired closed root(s) that still own open steps …: <root-ids>`; wisp GC skips them without charging its batch caps — and prune them once the steps reach a terminal state.

## Tests, second pass

The refusal is an uncharged skip in both wisp-GC paths (`TestWispGC_ClosurePurgeSkipsRefused…`, `TestWispGC_ReapSkipsOrphanOwning…`), the List-error fail-closed path and the transient-notification carve-out are driven with `failingListStore`, retention's retained roots are asserted by id, and the refusal names the open step ids. All were red before the source edits.

Fixes #5834.
