### PR TITLE
fix(order): gc order history must render outcome, not just cadence

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1533,18 +1533,18 @@ func renderOrderHistoryFromAPI(cr api.CachedRead[[]api.OrderHistoryView], name, 
 	}
 
 	if hasRig {
-		fmt.Fprintf(stdout, "%-20s %-15s %-15s %s\n", "ORDER", "RIG", "BEAD", "EXECUTED") //nolint:errcheck
+		fmt.Fprintf(stdout, "%-20s %-15s %-15s %-21s %s\n", "ORDER", "RIG", "BEAD", "EXECUTED", "OUTCOME") //nolint:errcheck
 		for _, e := range entries {
 			rig := e.Rig
 			if rig == "" {
 				rig = "-"
 			}
-			fmt.Fprintf(stdout, "%-20s %-15s %-15s %s\n", e.Name, rig, e.BeadID, e.CreatedAt) //nolint:errcheck
+			fmt.Fprintf(stdout, "%-20s %-15s %-15s %-21s %s\n", e.Name, rig, e.BeadID, e.CreatedAt, orderHistoryAPIOutcomeUnavailable) //nolint:errcheck
 		}
 	} else {
-		fmt.Fprintf(stdout, "%-20s %-15s %s\n", "ORDER", "BEAD", "EXECUTED") //nolint:errcheck
+		fmt.Fprintf(stdout, "%-20s %-15s %-21s %s\n", "ORDER", "BEAD", "EXECUTED", "OUTCOME") //nolint:errcheck
 		for _, e := range entries {
-			fmt.Fprintf(stdout, "%-20s %-15s %s\n", e.Name, e.BeadID, e.CreatedAt) //nolint:errcheck
+			fmt.Fprintf(stdout, "%-20s %-15s %-21s %s\n", e.Name, e.BeadID, e.CreatedAt, orderHistoryAPIOutcomeUnavailable) //nolint:errcheck
 		}
 	}
 
@@ -1606,6 +1606,7 @@ func doOrderHistoryBounded(name, rig string, aa []orders.Order, resolveStores or
 		rig       string
 		id        string
 		createdAt time.Time
+		outcome   string
 	}
 	var entries []historyEntry
 	seenEntries := make(map[string]bool)
@@ -1645,6 +1646,7 @@ func doOrderHistoryBounded(name, rig string, aa []orders.Order, resolveStores or
 					rig:       a.Rig,
 					id:        r.ID,
 					createdAt: r.CreatedAt,
+					outcome:   orderRunOutcomeDisplay(r),
 				})
 			}
 		}
@@ -1696,6 +1698,7 @@ func doOrderHistoryBounded(name, rig string, aa []orders.Order, resolveStores or
 				BeadID:    e.id,
 				Executed:  e.createdAt.Format(time.RFC3339),
 				CreatedAt: e.createdAt,
+				Outcome:   e.outcome,
 			})
 		}
 		return writeCLIJSONLineOrExit(stdout, stderr, "gc order history", payload)
@@ -1710,21 +1713,54 @@ func doOrderHistoryBounded(name, rig string, aa []orders.Order, resolveStores or
 	}
 
 	if hasRig {
-		fmt.Fprintf(stdout, "%-20s %-15s %-15s %s\n", "ORDER", "RIG", "BEAD", "EXECUTED") //nolint:errcheck
+		fmt.Fprintf(stdout, "%-20s %-15s %-15s %-21s %s\n", "ORDER", "RIG", "BEAD", "EXECUTED", "OUTCOME") //nolint:errcheck
 		for _, e := range entries {
 			rig := e.rig
 			if rig == "" {
 				rig = "-"
 			}
-			fmt.Fprintf(stdout, "%-20s %-15s %-15s %s\n", e.order, rig, e.id, e.createdAt.Format(time.RFC3339)) //nolint:errcheck
+			fmt.Fprintf(stdout, "%-20s %-15s %-15s %-21s %s\n", e.order, rig, e.id, e.createdAt.Format(time.RFC3339), e.outcome) //nolint:errcheck
 		}
 	} else {
-		fmt.Fprintf(stdout, "%-20s %-15s %s\n", "ORDER", "BEAD", "EXECUTED") //nolint:errcheck
+		fmt.Fprintf(stdout, "%-20s %-15s %-21s %s\n", "ORDER", "BEAD", "EXECUTED", "OUTCOME") //nolint:errcheck
 		for _, e := range entries {
-			fmt.Fprintf(stdout, "%-20s %-15s %s\n", e.order, e.id, e.createdAt.Format(time.RFC3339)) //nolint:errcheck
+			fmt.Fprintf(stdout, "%-20s %-15s %-21s %s\n", e.order, e.id, e.createdAt.Format(time.RFC3339), e.outcome) //nolint:errcheck
 		}
 	}
 	return 0
+}
+
+// orderHistoryAPIOutcomeUnavailable is what the API-sourced history route
+// prints in the OUTCOME column. api.OrderHistoryView (and the genclient entry
+// behind it) carry no outcome field, so that route genuinely cannot report one.
+// It prints "-" rather than blank or a guess: a surface that cannot tell success
+// from failure must SAY so, which is the whole lesson of ga-kahru9.
+const orderHistoryAPIOutcomeUnavailable = "-"
+
+// orderRunOutcomeDisplay renders one order run's terminal outcome for
+// `gc order history`, distinguishing the three states a tracking bead can end in.
+// Collapsing them is what let a 5-hour sync outage read as healthy (ga-7unsv0):
+// 18 of 21 consecutive runs carried the exec-failed label and the CLI showed only
+// that an exec had happened.
+//
+//	Outcome.Display() non-empty -> success | failed | canceled  (dispatcher stamped it)
+//	open                        -> running                      (still in flight)
+//	closed, nothing stamped     -> unknown                      (killed or swept
+//	                                                             before the
+//	                                                             dispatcher could
+//	                                                             stamp an outcome)
+//
+// The third state is the dangerous one and must never render as success: a run
+// killed mid-flight is closed by the order-tracking retention sweep with no
+// outcome label at all, which is byte-identical on the surface to a clean run.
+func orderRunOutcomeDisplay(r orders.OrderRun) string {
+	if d := r.Outcome.Display(); d != "" {
+		return d
+	}
+	if r.Open {
+		return "running"
+	}
+	return "unknown"
 }
 
 type orderHistoryJSONResult struct {
@@ -1742,6 +1778,10 @@ type orderHistoryJSONEntry struct {
 	BeadID    string    `json:"bead_id"`
 	Executed  string    `json:"executed"`
 	CreatedAt time.Time `json:"created_at"`
+	// Outcome is the run's terminal outcome: success, failed, canceled,
+	// running, or unknown. Omitted entirely by the API route, which cannot
+	// report one — see orderRunOutcomeDisplay.
+	Outcome string `json:"outcome,omitempty"`
 }
 
 type orderHistoryJSONSummary struct {

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -4292,3 +4292,105 @@ prefix = "ct"
 		t.Fatalf("%s status = %q, want closed — stale-close must run alongside retention", openID, got.Status)
 	}
 }
+
+// TestOrderHistoryRendersOutcomeForAllTrackingStates pins the ga-kahru9 fix.
+//
+// `gc order history` used to print ORDER/BEAD/EXECUTED only, so a run that
+// FAILED and a run that SUCCEEDED rendered byte-identically. During the
+// ga-7unsv0 sync outage 18 of 21 consecutive runs carried the exec-failed label
+// and the operator could not see one of them; the outage read as healthy for
+// roughly five hours.
+//
+// The third state is the one that matters most: a run killed before the
+// dispatcher stamped any outcome closes with NO outcome label at all, and must
+// render "unknown" — never blank, and never success.
+func TestOrderHistoryRendersOutcomeForAllTrackingStates(t *testing.T) {
+	store := beads.NewBdStore(t.TempDir(), func(_, _ string, args ...string) ([]byte, error) {
+		if !strings.Contains(strings.Join(args, " "), "--label=order-run:sync") {
+			return []byte(`[]`), nil
+		}
+		return []byte(`[
+			{"id":"RUN-OK","title":"sync","status":"closed","issue_type":"task","created_at":"2026-02-27T13:00:00Z","labels":["order-run:sync","exec"]},
+			{"id":"RUN-FAIL","title":"sync","status":"closed","issue_type":"task","created_at":"2026-02-27T12:00:00Z","labels":["order-run:sync","exec-failed"]},
+			{"id":"RUN-KILLED","title":"sync","status":"closed","issue_type":"task","created_at":"2026-02-27T11:00:00Z","labels":["order-run:sync"]},
+			{"id":"RUN-LIVE","title":"sync","status":"open","issue_type":"task","created_at":"2026-02-27T10:00:00Z","labels":["order-run:sync"]}
+		]`), nil
+	})
+	aa := []orders.Order{{Name: "sync", Formula: "mol-sync"}}
+	resolver := func(orders.Order) ([]beads.OrdersStore, error) {
+		return []beads.OrdersStore{{Store: store}}, nil
+	}
+
+	want := map[string]string{
+		"RUN-OK":     "success",
+		"RUN-FAIL":   "failed",
+		"RUN-KILLED": "unknown",
+		"RUN-LIVE":   "running",
+	}
+
+	// --- human table ---
+	var stdout, stderr bytes.Buffer
+	if code := doOrderHistoryWithStoresResolverJSON("sync", "", aa, resolver, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("doOrderHistory = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "OUTCOME") {
+		t.Fatalf("table has no OUTCOME column:\n%s", out)
+	}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		id := fields[1]
+		if _, tracked := want[id]; !tracked {
+			continue
+		}
+		seen[id] = true
+		if got := fields[len(fields)-1]; got != want[id] {
+			t.Errorf("%s outcome = %q, want %q\nline: %s", id, got, want[id], line)
+		}
+	}
+	// Non-vacuity: every state must actually have been exercised, or a
+	// silently-missing row would let this test pass while proving nothing.
+	for id := range want {
+		if !seen[id] {
+			t.Errorf("row %s never appeared in the table — assertion was vacuous:\n%s", id, out)
+		}
+	}
+
+	// --- json ---
+	stdout.Reset()
+	stderr.Reset()
+	if code := doOrderHistoryWithStoresResolverJSON("sync", "", aa, resolver, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("doOrderHistory --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	var payload orderHistoryJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Entries) != len(want) {
+		t.Fatalf("json entries = %d, want %d: %+v", len(payload.Entries), len(want), payload.Entries)
+	}
+	for _, e := range payload.Entries {
+		if e.Outcome != want[e.BeadID] {
+			t.Errorf("json %s outcome = %q, want %q", e.BeadID, e.Outcome, want[e.BeadID])
+		}
+	}
+}
+
+// TestOrderRunOutcomeDisplayNeverBlankForClosedRun guards the specific
+// regression: a closed run with no outcome label must not come back "" (which
+// rendered as an empty column and read as "nothing wrong").
+func TestOrderRunOutcomeDisplayNeverBlankForClosedRun(t *testing.T) {
+	if got := orderRunOutcomeDisplay(orders.OrderRun{Open: false}); got != "unknown" {
+		t.Errorf("closed run with no outcome = %q, want %q", got, "unknown")
+	}
+	if got := orderRunOutcomeDisplay(orders.OrderRun{Open: true}); got != "running" {
+		t.Errorf("open run with no outcome = %q, want %q", got, "running")
+	}
+	if got := orderRunOutcomeDisplay(orders.OrderRun{Outcome: orders.RunOutcomeExecFailed}); got != "failed" {
+		t.Errorf("exec-failed run = %q, want %q", got, "failed")
+	}
+}


### PR DESCRIPTION
## Problem

`gc order history` printed ORDER/BEAD/EXECUTED and dropped the run outcome, so a run that FAILED and a run that SUCCEEDED rendered byte-identically. During the ga-7unsv0 hub-sync outage, 18 of 21 consecutive runs carried the exec-failed label and the operator could not see one of them; the outage read as healthy for ~5 hours while the data plane had recorded every failure correctly.

The defect is one dropped field: the command builds its rows from `orders.OrderRun` values that already carry a typed `Outcome` (populated by `decodeRun`, with `Display()` alongside) and never reads it.

## Change

Adds an OUTCOME column to the table and an `outcome` field to `--json`, rendering three distinct states — collapsing them is the actual hazard:

- `success | failed | canceled` — dispatcher stamped an outcome
- `running` — still open
- `unknown` — closed with nothing stamped

The third is the dangerous one: a run killed before the dispatcher could stamp anything is closed by the order-tracking retention sweep with no outcome label, previously indistinguishable from a clean success. It must never render as success and must never render blank.

The API-sourced route cannot report an outcome at all (`api.OrderHistoryView` / `genclient.OrderHistoryEntry` have no such field); it prints `-` rather than guessing. Adding the field to the server schema plus client codegen is a follow-up (part B on ga-kahru9). Both routes currently fall back to the store path (verified `GC_DEBUG=1 route=fallback`), so the store path is the one that serves.

## Tests

- `TestOrderHistoryRendersOutcomeForAllTrackingStates` — all four render states, table and `--json`, with per-row non-vacuity assertions (a silently missing row fails the test).
- `TestOrderRunOutcomeDisplayNeverBlankForClosedRun` — closed-with-no-label renders `unknown`, never `""`.
- Full order-history family (21 tests incl. the #4790 `--limit`/`--since` bounds) green; `go build ./...` and `go vet` clean.
- Mutation-verified: making a killed run read as `success` fails the suite in both table and JSON paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvU8iDeCxbuqVKqEp7W5RT
