### PR TITLE
fix(mail): 24h handoff sweep TTL + mark-unread reopens closed messages

### DIFF
--- a/cmd/gc/nudge_mail_sweep.go
+++ b/cmd/gc/nudge_mail_sweep.go
@@ -11,8 +11,13 @@ import (
 )
 
 const (
-	nudgeMailSweepDefaultNudgeTTL     = 10 * time.Minute
-	nudgeMailSweepDefaultMailTTL      = 60 * time.Minute
+	nudgeMailSweepDefaultNudgeTTL = 10 * time.Minute
+	nudgeMailSweepDefaultMailTTL  = 60 * time.Minute
+	// nudgeMailSweepHandoffMailTTL is the retention window for read handoff
+	// mail (label mail.HandoffLabel). Handoff mail bridges restart/compaction
+	// gaps: a continuation that compacts hours after consuming its handoff
+	// may need to re-read it, so it far outlives ordinary read mail (ga-1kor).
+	nudgeMailSweepHandoffMailTTL      = 24 * time.Hour
 	nudgeMailSweepCloseBudget         = 50
 	nudgeMailSweepWatchdogInterval    = 5 * time.Minute
 	nudgeMailSweepWatchdogCloseBudget = 500
@@ -93,7 +98,7 @@ func sweepStaleNudgeMail(nudgeStore beads.NudgesStore, mailStore beads.MailStore
 		if limit == 0 {
 			mailBudget = 0
 		}
-		mailClosed, mailCloseErrs, mailListErr := beadmail.SweepReadMessagesBefore(mailStore, mailCutoff, mailBudget, nudgeMailSweepMailCloseReason)
+		mailClosed, mailCloseErrs, mailListErr := beadmail.SweepReadMessagesBefore(mailStore, mailCutoff, now.Add(-nudgeMailSweepHandoffMailTTL), mailBudget, nudgeMailSweepMailCloseReason)
 		if mailListErr != nil {
 			return result, fmt.Errorf("nudge-mail-sweep: listing read mail beads: %w", mailListErr)
 		}
@@ -138,7 +143,7 @@ func countStaleNudgeMail(nudgeStore beads.NudgesStore, mailStore beads.MailStore
 		if limit == 0 {
 			mailBudget = 0
 		}
-		mailCount, err := beadmail.CountReadMessagesBefore(mailStore, mailCutoff, mailBudget)
+		mailCount, err := beadmail.CountReadMessagesBefore(mailStore, mailCutoff, now.Add(-nudgeMailSweepHandoffMailTTL), mailBudget)
 		if err != nil {
 			return result, fmt.Errorf("nudge-mail-sweep (dry-run): listing read mail beads: %w", err)
 		}

--- a/cmd/gc/nudge_mail_sweep_test.go
+++ b/cmd/gc/nudge_mail_sweep_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
@@ -708,5 +709,59 @@ func TestCountStaleNudgeMail_MatchesSweepCounts(t *testing.T) {
 	}
 	if counts.MailClosed != 1 {
 		t.Errorf("count: MailClosed = %d, want 1", counts.MailClosed)
+	}
+}
+
+// handoffMailSeed builds a seed Bead representing a read handoff mail bead.
+func handoffMailSeed(id string, createdAt time.Time) beads.Bead {
+	b := mailSeed(id, createdAt)
+	b.Labels = append(b.Labels, mail.HandoffLabel)
+	return b
+}
+
+func TestSweepStaleNudgeMail_HandoffMailLongTTL(t *testing.T) {
+	// Read handoff mail (label mail.HandoffLabel) must survive the ordinary
+	// read-mail TTL and only sweep past nudgeMailSweepHandoffMailTTL (ga-1kor).
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	mailTTL := nudgeMailSweepDefaultMailTTL
+
+	seed := []beads.Bead{
+		handoffMailSeed("handoff-young", now.Add(-2*time.Hour)),                              // past mail TTL, within handoff TTL: keep
+		handoffMailSeed("handoff-ancient", now.Add(-nudgeMailSweepHandoffMailTTL-time.Hour)), // past handoff TTL: sweep
+		mailSeed("plain-old", now.Add(-2*time.Hour)),                                         // ordinary read mail past TTL: sweep
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	counts, err := countStaleNudgeMail(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, mailTTL, 0)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if counts.MailClosed != 2 {
+		t.Errorf("count: MailClosed = %d, want 2", counts.MailClosed)
+	}
+
+	result, err := sweepStaleNudgeMail(beads.NudgesStore{Store: store}, beads.MailStore{Store: store}, nil, now, nudgeMailSweepDefaultNudgeTTL, mailTTL, 0)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if result.MailClosed != 2 {
+		t.Errorf("sweep: MailClosed = %d, want 2", result.MailClosed)
+	}
+
+	young, err := store.Get("handoff-young")
+	if err != nil {
+		t.Fatalf("get handoff-young: %v", err)
+	}
+	if young.Status != "open" {
+		t.Errorf("handoff-young status = %q, want open (handoff TTL exemption)", young.Status)
+	}
+	for _, id := range []string{"handoff-ancient", "plain-old"} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Errorf("%s status = %q, want closed", id, b.Status)
+		}
 	}
 }

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -190,8 +190,8 @@ func (p *Provider) SendHandoff(intent mail.HandoffIntent) (mail.Message, error) 
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail handoff: %w", err)
 	}
-	labels := make([]string, 0, 1+len(intent.ExtraLabels))
-	labels = append(labels, "thread:"+intent.ThreadID)
+	labels := make([]string, 0, 2+len(intent.ExtraLabels))
+	labels = append(labels, mail.HandoffLabel, "thread:"+intent.ThreadID)
 	labels = append(labels, intent.ExtraLabels...)
 
 	b, err := p.createMessageBead(intent.Subject, intent.Body, from, intent.To, labels, metadata)
@@ -320,7 +320,11 @@ func (p *Provider) MarkRead(id string) error {
 	})
 }
 
-// MarkUnread marks a message as unread (removes "read" label).
+// MarkUnread marks a message as unread (removes "read" label). A closed
+// message bead (e.g. one closed by the mail retention sweep) is reopened
+// first: mark-unread exists to resurface a message, and a closed bead is
+// invisible to every inbox surface, so removing the label alone would
+// silently change nothing (ga-1kor).
 func (p *Provider) MarkUnread(id string) error {
 	b, err := p.store.Get(id)
 	if err != nil {
@@ -328,6 +332,11 @@ func (p *Provider) MarkUnread(id string) error {
 	}
 	if isRemovedMessageBead(b) {
 		return beadmailError("mark-unread", beads.ErrNotFound)
+	}
+	if b.Status == "closed" {
+		if err := p.store.Reopen(id); err != nil {
+			return fmt.Errorf("beadmail mark-unread: reopening closed message: %w", err)
+		}
 	}
 	return p.store.Update(id, beads.UpdateOpts{
 		RemoveLabels: []string{"read"},
@@ -898,7 +907,7 @@ const RetentionSweepCloseReason = "mail gc-swept: read mail bead past gc retenti
 // handling: listErr is the fatal candidate-listing failure (no beads were
 // swept), while closeErrs holds the per-bead metadata/close failures that do not
 // abort the sweep. Returns the number of beads closed.
-func SweepReadMessagesBefore(store beads.MailStore, cutoff time.Time, limit int, closeReason string) (closed int, closeErrs []error, listErr error) {
+func SweepReadMessagesBefore(store beads.MailStore, cutoff, handoffCutoff time.Time, limit int, closeReason string) (closed int, closeErrs []error, listErr error) {
 	candidates, err := readMessagesBefore(store.Store, cutoff, limit)
 	if err != nil {
 		return 0, nil, err
@@ -908,6 +917,9 @@ func SweepReadMessagesBefore(store beads.MailStore, cutoff time.Time, limit int,
 			break
 		}
 		if b.Status != "open" {
+			continue
+		}
+		if hasLabel(b.Labels, mail.HandoffLabel) && b.CreatedAt.After(handoffCutoff) {
 			continue
 		}
 		if err := store.SetMetadata(b.ID, "close_reason", closeReason); err != nil {
@@ -927,7 +939,7 @@ func SweepReadMessagesBefore(store beads.MailStore, cutoff time.Time, limit int,
 // would close for the same cutoff and limit, without mutating any bead. It is the
 // dry-run twin of the sweep and shares its candidate query and limit semantics so
 // the two stay in lockstep.
-func CountReadMessagesBefore(store beads.MailStore, cutoff time.Time, limit int) (int, error) {
+func CountReadMessagesBefore(store beads.MailStore, cutoff, handoffCutoff time.Time, limit int) (int, error) {
 	candidates, err := readMessagesBefore(store.Store, cutoff, limit)
 	if err != nil {
 		return 0, err
@@ -938,6 +950,9 @@ func CountReadMessagesBefore(store beads.MailStore, cutoff time.Time, limit int)
 			break
 		}
 		if b.Status != "open" {
+			continue
+		}
+		if hasLabel(b.Labels, mail.HandoffLabel) && b.CreatedAt.After(handoffCutoff) {
 			continue
 		}
 		count++

--- a/internal/mail/beadmail/beadmail_retention_test.go
+++ b/internal/mail/beadmail/beadmail_retention_test.go
@@ -103,7 +103,7 @@ func TestSweepReadMessagesBefore_ClosesAgedReadMailWithReason(t *testing.T) {
 	mailStore := beads.MailStore{Store: store}
 
 	const reason = "mail gc-swept: test retention reason padded to length"
-	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, cutoff, 0, reason)
+	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, cutoff, time.Time{}, 0, reason)
 	if listErr != nil {
 		t.Fatalf("unexpected list error: %v", listErr)
 	}
@@ -153,7 +153,7 @@ func TestSweepReadMessagesBefore_LimitCapsCloses(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 	mailStore := beads.MailStore{Store: store}
 
-	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, now, 2, "reason padded to twenty plus characters")
+	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, now, time.Time{}, 2, "reason padded to twenty plus characters")
 	if listErr != nil || len(closeErrs) != 0 {
 		t.Fatalf("unexpected errors: list=%v perBead=%v", listErr, closeErrs)
 	}
@@ -189,7 +189,7 @@ func TestSweepReadMessagesBefore_PerBeadCloseErrorIsCollected(t *testing.T) {
 	store := closeErrStore{MemStore: base, failClose: map[string]error{"bad": errors.New("close boom")}}
 	mailStore := beads.MailStore{Store: store}
 
-	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, now, 0, "reason padded to twenty plus characters")
+	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, now, time.Time{}, 0, "reason padded to twenty plus characters")
 	if listErr != nil {
 		t.Fatalf("unexpected list error: %v", listErr)
 	}
@@ -209,7 +209,7 @@ func TestSweepReadMessagesBefore_ListErrorIsFatal(t *testing.T) {
 	store := listErrStore{MemStore: beads.NewMemStore(), err: errors.New("store down")}
 	mailStore := beads.MailStore{Store: store}
 
-	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, now, 0, "reason padded to twenty plus characters")
+	closed, closeErrs, listErr := SweepReadMessagesBefore(mailStore, now, time.Time{}, 0, "reason padded to twenty plus characters")
 	if listErr == nil {
 		t.Fatal("expected fatal list error")
 	}
@@ -232,7 +232,7 @@ func TestCountReadMessagesBefore_CountsWithoutMutating(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 	mailStore := beads.MailStore{Store: store}
 
-	count, err := CountReadMessagesBefore(mailStore, now, 0)
+	count, err := CountReadMessagesBefore(mailStore, now, time.Time{}, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestCountReadMessagesBefore_LimitCapsCount(t *testing.T) {
 	store := beads.NewMemStoreFrom(100, seed, nil)
 	mailStore := beads.MailStore{Store: store}
 
-	count, err := CountReadMessagesBefore(mailStore, now, 2)
+	count, err := CountReadMessagesBefore(mailStore, now, time.Time{}, 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -518,8 +518,7 @@ func TestRetentionSweptReadMailStaysAddressableUntilPurge(t *testing.T) {
 
 	// The retention sweep closes the aged read mail with the canonical reason,
 	// exactly as the production nudge-mail watchdog does.
-	closed, closeErrs, listErr := SweepReadMessagesBefore(
-		beads.MailStore{Store: store}, time.Now().Add(time.Hour), 0, RetentionSweepCloseReason)
+	closed, closeErrs, listErr := SweepReadMessagesBefore(beads.MailStore{Store: store}, time.Now().Add(time.Hour), time.Time{}, 0, RetentionSweepCloseReason)
 	if listErr != nil {
 		t.Fatalf("sweep list error: %v", listErr)
 	}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -2925,3 +2925,45 @@ func mustCreateSessionBead(t *testing.T, store beads.Store, metadata map[string]
 	}
 	return b
 }
+
+func TestMarkUnreadReopensClosedMessage(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	b, err := store.Create(beads.Bead{
+		Title:    "HANDOFF: test",
+		Type:     "message",
+		Assignee: "cheryl",
+		Labels:   []string{mail.HandoffLabel},
+		Metadata: map[string]string{"close_reason": RetentionSweepCloseReason},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := p.MarkRead(b.ID); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := p.MarkUnread(b.ID); err != nil {
+		t.Fatalf("mark unread: %v", err)
+	}
+
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != "open" {
+		t.Errorf("status = %q, want open (mark-unread must reopen a swept/closed message)", got.Status)
+	}
+	for _, l := range got.Labels {
+		if l == "read" {
+			t.Error("read label still present after mark-unread")
+		}
+	}
+	if got.Metadata["mail.read"] != "false" {
+		t.Errorf("mail.read = %q, want false", got.Metadata["mail.read"])
+	}
+}

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -18,6 +18,10 @@ var ErrAlreadyArchived = errors.New("already archived")
 var ErrNotFound = errors.New("message not found")
 
 const (
+	// HandoffLabel marks all mail created by gc handoff. Handoff mail bridges
+	// a restart/compaction gap, so the retention sweep gives it a much longer
+	// TTL than ordinary read mail (see cmd/gc nudge_mail_sweep).
+	HandoffLabel = "gc:handoff"
 	// AutoHandoffLabel marks mail created by gc handoff --auto for provider
 	// context-cycle delivery.
 	AutoHandoffLabel = "gc:auto-handoff"


### PR DESCRIPTION
## Summary

**What.** Two retention fixes so handoffs survive a compaction gap:
- `SendHandoff` mail now carries a `gc:handoff` label (`mail.HandoffLabel`), and the nudge/mail retention sweep exempts labeled mail from the generic 60-minute read-mail TTL, closing it only past 24 hours (`nudgeMailSweepHandoffMailTTL`).
- `beadmail.MarkUnread` reopens a closed message bead before removing the `read` label.

**Why.** A handoff is marked read the moment the continuation ingests it, which starts the 60-minute sweep clock. A continuation that compacts or restarts hours later needs to re-read that handoff, but the sweep has closed it by then — and mark-unread, the tool meant to resurface a message, was a silent no-op on closed mail (every inbox surface lists only open beads) that also left a corrupted closed-but-unread record. The existing direct-ID gate keeps the reopen tightly scoped: only retention-swept mail (`close_reason == RetentionSweepCloseReason`) is addressable, so archived or user-removed mail cannot be resurrected.

Cherry-picked (`-x`, from `470b0f457`) out of our production fork, where it has run since mid-July. Adaptations to current main are noted in the commit message: the new tests use the post-#5209 `NudgesStore`/`MailStore` call shape, the mark-unread fixture seeds `RetentionSweepCloseReason` to pass the removed-message gate, and an unused import was dropped.

## Testing

- `go build ./...`; `go vet` on touched packages; pre-commit format/lint/codegen pipeline clean.
- New tests: `TestSweepStaleNudgeMail_HandoffMailLongTTL` (young handoff mail survives the 60m sweep, ancient handoff and plain read mail still close; count and sweep agree) and `TestMarkUnreadReopensClosedMessage` (swept message is open, label removed, `mail.read=false`).
- Full `./internal/mail`, `./internal/mail/beadmail`, `./internal/mail/exec` packages and the `cmd/gc` sweep/count family pass with `-count=1`.
- Negative-verified both mechanisms: disabling either one fails its test.

## Notes

- No migration: `gc:handoff` labels only newly created handoff mail; unlabeled existing mail keeps today's behavior.
- No user-facing docs affected (internal retention constants; the `SweepReadMessagesBefore`/`CountReadMessagesBefore` signature change is internal-package only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvU8iDeCxbuqVKqEp7W5RT
