### PR TITLE
fix(config): an unappliable patch is skipped and reported, not fatal

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -221,7 +221,7 @@ func isNonFatalLoadConfigWarning(warning string) bool {
 func shouldEmitLoadCityConfigWarning(warning string) bool {
 	// An unapplied patch is a CONDITION OF THIS INVOCATION, not a standing
 	// configuration choice, so it prints on every command — the opposite call
-	// from the always+fresh advisory below (ga-djvbvp). A patch that silently
+	// from the legacy workspace-field advisory below (ga-djvbvp). A patch that silently
 	// did nothing is how a typo survives forever, and the whole reason it is
 	// now safe to skip instead of aborting is that the skip is loud.
 	//

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -177,6 +177,11 @@ func emitLoadCityConfigWarnings(w io.Writer, prov *config.Provenance) {
 // [agent_defaults]/[agents] config remains strict-fatal because overlapping
 // default tables are ambiguous even after normalization.
 func isNonFatalLoadConfigWarning(warning string) bool {
+	// Non-fatal so ordinary commands keep working; `gc config --validate`
+	// still fails on it (ga-djvbvp).
+	if config.IsUnappliedPatchWarning(warning) {
+		return true
+	}
 	if config.IsRetiredKeyWarning(warning) {
 		return true
 	}
@@ -214,6 +219,22 @@ func isNonFatalLoadConfigWarning(warning string) bool {
 }
 
 func shouldEmitLoadCityConfigWarning(warning string) bool {
+	// An unapplied patch is a CONDITION OF THIS INVOCATION, not a standing
+	// configuration choice, so it prints on every command — the opposite call
+	// from the always+fresh advisory below (ga-djvbvp). A patch that silently
+	// did nothing is how a typo survives forever, and the whole reason it is
+	// now safe to skip instead of aborting is that the skip is loud.
+	//
+	// HONESTLY REDUNDANT TODAY, and kept anyway: mutation testing confirms
+	// deleting this branch changes nothing, because the fall-through to
+	// isNonFatalLoadConfigWarning already returns true for the same class. It
+	// stays because it DECOUPLES emit from fatality — if someone later makes
+	// unapplied patches strict-fatal by removing the case there, emission
+	// would otherwise stop at the same instant and the skip would go silent,
+	// which is the one outcome this design cannot tolerate.
+	if config.IsUnappliedPatchWarning(warning) {
+		return true
+	}
 	if config.IsLegacyWorkspaceFieldWarning(warning) {
 		return false
 	}

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -92,6 +92,30 @@ config element. Use -f to layer additional config files.`,
 }
 
 // doConfigShow loads city.toml (with includes) and dumps the resolved
+// unappliedPatchValidationErrors promotes unapplied-patch load warnings to
+// validation errors, so `gc config --validate` exits non-zero on them
+// (ga-djvbvp).
+//
+// This is the second half of a deliberate split. An unapplied patch is
+// NON-FATAL to ordinary commands, because every gc command loads config and
+// aborting the load meant one seat's typo stopped the entire city. It is FATAL
+// here, on the surface built to review configuration, because a fix that only
+// did the first half would trade a loud outage for a silent misconfiguration
+// that survives forever.
+//
+// Extracted from doConfigShow so the promotion is testable on its own:
+// doConfigShow resolves a city from the environment, and a mutation that
+// deleted this promotion inline survived the whole suite.
+func unappliedPatchValidationErrors(warnings []string) []string {
+	var errs []string
+	for _, w := range warnings {
+		if config.IsUnappliedPatchWarning(w) {
+			errs = append(errs, w)
+		}
+	}
+	return errs
+}
+
 // config, validates it, or shows provenance.
 func doConfigShow(validate, showProvenance, asJSON bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
@@ -135,6 +159,7 @@ func doConfigShow(validate, showProvenance, asJSON bool, stdout, stderr io.Write
 		validationErrors = append(validationErrors, err.Error())
 	}
 	validationErrors = append(validationErrors, validateLegacyFormulaConfigRoutes(cfg)...)
+	validationErrors = append(validationErrors, unappliedPatchValidationErrors(compositionWarnings)...)
 	validationWarnings := singletonSessionMigrationWarnings(cfg)
 
 	if validate {

--- a/cmd/gc/patch_unapplied_warning_test.go
+++ b/cmd/gc/patch_unapplied_warning_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// An unapplied patch has to reach the operator on EVERY command, because the
+// whole reason it is now safe to skip a dangling patch instead of aborting the
+// load is that the skip is loud (ga-djvbvp). The always+fresh advisory is the
+// deliberate contrast: a standing configuration choice stays off unrelated
+// commands, a condition of this invocation does not.
+func TestUnappliedPatchWarningIsAlwaysEmitted(t *testing.T) {
+	warning := `patches.agent[12] was NOT APPLIED: agent "cherub-law.conway" not found in merged config`
+
+	if !config.IsUnappliedPatchWarning(warning) {
+		t.Fatal("IsUnappliedPatchWarning did not recognise the emitted warning shape — the marker and the emitter have drifted apart")
+	}
+	if !shouldEmitLoadCityConfigWarning(warning) {
+		t.Fatal("an unapplied patch must print on every command; suppressing it turns a loud outage into a silent misconfiguration")
+	}
+	if !isNonFatalLoadConfigWarning(warning) {
+		t.Fatal("an unapplied patch must not be strict-fatal; that is the city-wide halt this change exists to remove")
+	}
+
+	// CONTRAST, so this test fails if the filter degenerates into "emit
+	// everything": the always+fresh advisory must still be suppressed.
+	fresh := `named_session "x": mode "always" with wake_mode "fresh" on template "x" starts a fresh provider session after every drain; use only for a deliberate restart-per-cycle actor`
+	if shouldEmitLoadCityConfigWarning(fresh) {
+		t.Fatal("the always+fresh advisory must stay off unrelated commands (ga-3upjic); the filter is now emitting everything")
+	}
+	if config.IsUnappliedPatchWarning(fresh) {
+		t.Fatal("the always+fresh advisory must not be classified as an unapplied patch")
+	}
+}
+
+// The emitter must actually put the warning on the writer, not merely classify
+// it. Without this, a correct classifier and a broken emit path look identical.
+func TestUnappliedPatchWarningReachesTheWriter(t *testing.T) {
+	warning := `patches.rigs[3] was NOT APPLIED: rig "ghost" not found in merged config`
+	var buf bytes.Buffer
+	emitLoadCityConfigWarnings(&buf, &config.Provenance{Warnings: []string{warning}})
+	if !strings.Contains(buf.String(), "ghost") {
+		t.Fatalf("unapplied-patch warning never reached the writer; got %q", buf.String())
+	}
+}
+
+// `gc config --validate` must FAIL on an unapplied patch (ga-djvbvp). This is
+// the half that keeps a typo from living forever now that it no longer aborts
+// every command — and a mutation deleting the promotion survived the suite
+// until this test existed.
+func TestUnappliedPatchFailsConfigValidate(t *testing.T) {
+	warnings := []string{
+		`patches.agent[12] was NOT APPLIED: agent "cherub-law.conway" not found in merged config`,
+		`named_session "x": mode "always" with wake_mode "fresh" starts a fresh provider session after every drain`,
+		`patches.rigs[0] was NOT APPLIED: rig "ghostrig" not found in merged config`,
+	}
+	errs := unappliedPatchValidationErrors(warnings)
+	if len(errs) != 2 {
+		t.Fatalf("want both unapplied patches promoted to validation errors, got %d: %q", len(errs), errs)
+	}
+	// BOTH, not just the first: the old ApplyPatches returned on the first bad
+	// patch and reported one defect per run.
+	if !strings.Contains(errs[0], "cherub-law.conway") || !strings.Contains(errs[1], "ghostrig") {
+		t.Fatalf("promoted the wrong warnings: %q", errs)
+	}
+	// NON-VACUITY: an unrelated advisory must NOT become a validation error,
+	// or --validate fails on every city that carries a standing advisory.
+	if len(unappliedPatchValidationErrors(warnings[1:2])) != 0 {
+		t.Fatal("the always+fresh advisory was promoted to a validation error")
+	}
+	if len(unappliedPatchValidationErrors(nil)) != 0 {
+		t.Fatal("a clean config produced validation errors")
+	}
+}

--- a/cmd/gc/patch_unapplied_warning_test.go
+++ b/cmd/gc/patch_unapplied_warning_test.go
@@ -14,7 +14,7 @@ import (
 // deprecation is the deliberate contrast: a standing configuration choice
 // stays off unrelated commands, a condition of this invocation does not.
 func TestUnappliedPatchWarningIsAlwaysEmitted(t *testing.T) {
-	warning := `patches.agent[12] was NOT APPLIED: agent "cherub-law.conway" not found in merged config`
+	warning := `patches.agent[12] was NOT APPLIED: agent "binding-x.ghost" not found in merged config`
 
 	if !config.IsUnappliedPatchWarning(warning) {
 		t.Fatal("IsUnappliedPatchWarning did not recognize the emitted warning shape — the marker and the emitter have drifted apart")
@@ -54,7 +54,7 @@ func TestUnappliedPatchWarningReachesTheWriter(t *testing.T) {
 // until this test existed.
 func TestUnappliedPatchFailsConfigValidate(t *testing.T) {
 	warnings := []string{
-		`patches.agent[12] was NOT APPLIED: agent "cherub-law.conway" not found in merged config`,
+		`patches.agent[12] was NOT APPLIED: agent "binding-x.ghost" not found in merged config`,
 		`named_session "x": mode "always" with wake_mode "fresh" starts a fresh provider session after every drain`,
 		`patches.rigs[0] was NOT APPLIED: rig "ghostrig" not found in merged config`,
 	}
@@ -64,7 +64,7 @@ func TestUnappliedPatchFailsConfigValidate(t *testing.T) {
 	}
 	// BOTH, not just the first: the old ApplyPatches returned on the first bad
 	// patch and reported one defect per run.
-	if !strings.Contains(errs[0], "cherub-law.conway") || !strings.Contains(errs[1], "ghostrig") {
+	if !strings.Contains(errs[0], "binding-x.ghost") || !strings.Contains(errs[1], "ghostrig") {
 		t.Fatalf("promoted the wrong warnings: %q", errs)
 	}
 	// NON-VACUITY: an unrelated advisory must NOT become a validation error,

--- a/cmd/gc/patch_unapplied_warning_test.go
+++ b/cmd/gc/patch_unapplied_warning_test.go
@@ -10,14 +10,14 @@ import (
 
 // An unapplied patch has to reach the operator on EVERY command, because the
 // whole reason it is now safe to skip a dangling patch instead of aborting the
-// load is that the skip is loud (ga-djvbvp). The always+fresh advisory is the
-// deliberate contrast: a standing configuration choice stays off unrelated
-// commands, a condition of this invocation does not.
+// load is that the skip is loud (ga-djvbvp). The legacy workspace-field
+// deprecation is the deliberate contrast: a standing configuration choice
+// stays off unrelated commands, a condition of this invocation does not.
 func TestUnappliedPatchWarningIsAlwaysEmitted(t *testing.T) {
 	warning := `patches.agent[12] was NOT APPLIED: agent "cherub-law.conway" not found in merged config`
 
 	if !config.IsUnappliedPatchWarning(warning) {
-		t.Fatal("IsUnappliedPatchWarning did not recognise the emitted warning shape — the marker and the emitter have drifted apart")
+		t.Fatal("IsUnappliedPatchWarning did not recognize the emitted warning shape — the marker and the emitter have drifted apart")
 	}
 	if !shouldEmitLoadCityConfigWarning(warning) {
 		t.Fatal("an unapplied patch must print on every command; suppressing it turns a loud outage into a silent misconfiguration")
@@ -27,13 +27,13 @@ func TestUnappliedPatchWarningIsAlwaysEmitted(t *testing.T) {
 	}
 
 	// CONTRAST, so this test fails if the filter degenerates into "emit
-	// everything": the always+fresh advisory must still be suppressed.
-	fresh := `named_session "x": mode "always" with wake_mode "fresh" on template "x" starts a fresh provider session after every drain; use only for a deliberate restart-per-cycle actor`
-	if shouldEmitLoadCityConfigWarning(fresh) {
-		t.Fatal("the always+fresh advisory must stay off unrelated commands (ga-3upjic); the filter is now emitting everything")
+	// everything": a suppressed standing advisory must stay suppressed.
+	suppressed := `city.toml: workspace.start_command is deprecated: Use per-agent start_command in agent.toml instead.`
+	if shouldEmitLoadCityConfigWarning(suppressed) {
+		t.Fatal("the legacy workspace-field deprecation must stay off unrelated commands; the filter is now emitting everything")
 	}
-	if config.IsUnappliedPatchWarning(fresh) {
-		t.Fatal("the always+fresh advisory must not be classified as an unapplied patch")
+	if config.IsUnappliedPatchWarning(suppressed) {
+		t.Fatal("the legacy workspace-field deprecation must not be classified as an unapplied patch")
 	}
 }
 

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -958,7 +958,12 @@ The patch/default order is:
 8. Implicit agents are injected.
 9. Root city `[agent_defaults]` applies.
 
-If a patch target does not exist when the patch runs, loading fails.
+If a pack-level patch target does not exist when the patch runs, loading
+fails. A city-level patch whose target does not exist is skipped and recorded
+as a load warning naming the patch and the reason (`patches.agent[3] was NOT
+APPLIED: ...`): the skipped patch modifies nothing, every `gc` command prints
+the warning, and `gc config --validate` reports it as a validation error and
+exits non-zero.
 
 ### 2.7. Defaults
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -721,6 +721,16 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 	}
 
+	// RE-DRAIN LoadWarnings AFTER PATCH APPLICATION (ga-djvbvp). The two copies
+	// near the start of composition run BEFORE the ApplyPatches calls above, so
+	// a warning recorded while applying a patch — which is where unapplied
+	// patches are now reported instead of aborting the load — would be written
+	// to root.LoadWarnings and never reach provenance. The CLI reads
+	// prov.Warnings, so without this the whole fix would be a silent no-op:
+	// recorded, unsurfaced, and indistinguishable from a clean config.
+	// appendUnique makes the earlier copies harmless to repeat.
+	prov.Warnings = appendUnique(prov.Warnings, root.LoadWarnings...)
+
 	// Apply [agent_defaults] values to all agents (explicit and implicit)
 	// that don't set their own override. Deprecated [agents] aliases are
 	// normalized during parse/load before composition reaches this point.

--- a/internal/config/implicit_agent_patch_repro_test.go
+++ b/internal/config/implicit_agent_patch_repro_test.go
@@ -173,12 +173,24 @@ suspended = true
 	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(cityTOML), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
-	if err == nil {
-		t.Fatal("expected error for typo patch target, got nil")
+	// The typo is STILL CAUGHT — the guarantee this test was written for — but
+	// no longer by aborting the load (ga-djvbvp). Every gc command loads
+	// config, so aborting meant one seat's typo stopped every agent in the
+	// city; on 2026-08-25 it killed a `gc bd update` on an unrelated bead.
+	// It is now reported in provenance, printed by the CLI on every command,
+	// and fails `gc config --validate`.
+	_, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("load must not fail on a typo patch target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not found in merged config") {
-		t.Fatalf("unexpected error shape: %v", err)
+	found := false
+	for _, w := range prov.Warnings {
+		if IsUnappliedPatchWarning(w) && strings.Contains(w, "not found in merged config") && strings.Contains(w, "not-a-real-agent") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("typo patch target was not reported; warnings = %q", prov.Warnings)
 	}
 }
 

--- a/internal/config/implicit_agent_patch_repro_test.go
+++ b/internal/config/implicit_agent_patch_repro_test.go
@@ -176,7 +176,7 @@ suspended = true
 	// The typo is STILL CAUGHT — the guarantee this test was written for — but
 	// no longer by aborting the load (ga-djvbvp). Every gc command loads
 	// config, so aborting meant one seat's typo stopped every agent in the
-	// city; on 2026-08-25 it killed a `gc bd update` on an unrelated bead.
+	// city; in one fleet it killed a `gc bd update` on an unrelated bead.
 	// It is now reported in provenance, printed by the CLI on every command,
 	// and fails `gc config --validate`.
 	_, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -637,15 +637,19 @@ name = "refinery"
 scope = "rig"
 `)
 
-	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
-	if err == nil {
-		t.Fatal("expected LoadWithIncludes to fail for nonexistent patch target")
+	// Reported, not fatal (ga-djvbvp) — see TestLoadWithIncludes_PatchTargetMissing.
+	_, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("load must not fail for a nonexistent patch target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "proj/gs.nonexistent") {
-		t.Errorf("error = %q, want mention of proj/gs.nonexistent", err)
+	found := false
+	for _, w := range prov.Warnings {
+		if IsUnappliedPatchWarning(w) && strings.Contains(w, "proj/gs.nonexistent") && strings.Contains(w, "not found") {
+			found = true
+		}
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error = %q, want mention of 'not found'", err)
+	if !found {
+		t.Errorf("nonexistent patch target was not reported; warnings = %q", prov.Warnings)
 	}
 }
 

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Patches holds all patch blocks from composition. Patches target existing
 // resources by identity key and modify specific fields. They are applied
@@ -331,34 +334,73 @@ func Fragments(items ...string) *[]string {
 	return &out
 }
 
+// unappliedPatchMarker is a stable substring on the warning emitted when a
+// patch cannot be applied. CLI warning classification keys off this marker, so
+// keep it in sync with IsUnappliedPatchWarning.
+const unappliedPatchMarker = "was NOT APPLIED"
+
+// IsUnappliedPatchWarning reports whether a load warning records a patch that
+// could not be applied. Keep in sync with unappliedPatchMarker.
+func IsUnappliedPatchWarning(warning string) bool {
+	return strings.Contains(warning, unappliedPatchMarker)
+}
+
 // ApplyPatches applies all patches to the config. Patches target existing
-// resources by identity key. If a patch targets a nonexistent resource,
-// an error is returned. Patches are intentional — they never generate
-// collision warnings.
+// resources by identity key.
+//
+// A PATCH THAT CANNOT BE APPLIED IS SKIPPED AND RECORDED, NOT FATAL
+// (ga-djvbvp). It used to abort the whole load, and because every gc command
+// loads config that meant one dangling reference stopped the entire city: on
+// 2026-08-25 a `gc bd update` on an unrelated bead died with
+// `patches.agent[12]: agent "cherub-law.conway" not found in merged config`
+// while a new seat was mid-stand-up. Standing up a seat touches the pack and
+// city.toml, and a local-path pack is live the instant it is written, so ANY
+// two-file edit opens a window where a reference exists and its target does
+// not. Halting every agent for the duration of someone else's edit is a worse
+// outcome than leaving one patch unapplied.
+//
+// Skipping is safe in a way that failing is not: a patch that matched nothing
+// changed nothing, so the config here is exactly the config without that
+// patch. The risk is the opposite one — that a real typo becomes invisible —
+// which is why every skip is recorded on LoadWarnings, why the CLI prints
+// those on EVERY command rather than only on configuration surfaces, and why
+// `gc config --validate` still exits non-zero on them.
+//
+// Every patch is attempted, so one bad patch no longer hides the next: the old
+// code returned on the first failure and reported one defect at a time.
+//
+// Patches are intentional — they never generate collision warnings.
+//
+// The error return is retained for systemic failures; unappliable targets do
+// not produce one.
 func ApplyPatches(cfg *City, patches Patches) error {
+	record := func(kind string, i int, err error) {
+		cfg.LoadWarnings = appendUnique(cfg.LoadWarnings,
+			fmt.Sprintf("patches.%s[%d] %s: %v", kind, i, unappliedPatchMarker, err))
+	}
 	for i, p := range patches.Agents {
 		if err := applyAgentPatch(cfg, &p); err != nil {
-			return fmt.Errorf("patches.agent[%d]: %w", i, err)
+			record("agent", i, err)
 		}
 	}
 	for i, p := range patches.NamedSessions {
 		if err := applyNamedSessionPatch(cfg, &p); err != nil {
-			return fmt.Errorf("patches.named_session[%d]: %w", i, err)
+			record("named_session", i, err)
 		}
 	}
 	for i, p := range patches.Rigs {
 		if err := applyRigPatch(cfg, &p); err != nil {
-			return fmt.Errorf("patches.rigs[%d]: %w", i, err)
+			record("rigs", i, err)
 		}
 	}
 	for i, p := range patches.Providers {
 		if err := applyProviderPatch(cfg, &p); err != nil {
-			return fmt.Errorf("patches.providers[%d]: %w", i, err)
+			record("providers", i, err)
 		}
 	}
 	for i, p := range patches.GitHubPRMonitors {
 		if err := applyGitHubPRMonitorPatch(cfg, &p); err != nil {
-			return fmt.Errorf("patches.github_pr_monitor[%d]: %w", i, err)
+			record("github_pr_monitor", i, err)
 		}
 	}
 	return nil

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -483,11 +483,12 @@ func (p *AgentPatch) TargetQualifiedName() string {
 // It enforces the AgentPatch identity contract every write boundary relies on:
 // Name is required, and the legacy Dir key and the newer Rig key (including the
 // "*" wildcard) are mutually exclusive. The HTTP patch API and the config editor
-// call this before persisting so a patch that would hard-fail the next config
-// load — an unresolvable dir+rig combination — can never be written to city.toml
-// and brick config loading. Apply-time resolution (agentPatchTargetDir and
-// applyAgentPatch) enforces the same rule for patches that arrive from other
-// sources, so this is a fail-fast guard at the edge, not the only guard.
+// call this before persisting so a patch that could never apply — an
+// unresolvable dir+rig combination — is rejected at write time instead of being
+// written to city.toml, where every subsequent load would skip it and warn.
+// Apply-time resolution (agentPatchTargetDir and applyAgentPatch) enforces the
+// same rule for patches that arrive from other sources, so this is a fail-fast
+// guard at the edge, not the only guard.
 func (p *AgentPatch) Validate() error {
 	if p.Name == "" {
 		return fmt.Errorf("agent patch: name is required")

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -351,8 +351,8 @@ func IsUnappliedPatchWarning(warning string) bool {
 // A PATCH THAT CANNOT BE APPLIED IS SKIPPED AND RECORDED, NOT FATAL
 // (ga-djvbvp). It used to abort the whole load, and because every gc command
 // loads config that meant one dangling reference stopped the entire city: on
-// 2026-08-25 a `gc bd update` on an unrelated bead died with
-// `patches.agent[12]: agent "cherub-law.conway" not found in merged config`
+// one fleet, a `gc bd update` on an unrelated bead died with
+// `patches.agent[12]: agent "binding-x.ghost" not found in merged config`
 // while a new seat was mid-stand-up. Standing up a seat touches the pack and
 // city.toml, and a local-path pack is live the instant it is written, so ANY
 // two-file edit opens a window where a reference exists and its target does

--- a/internal/config/patch_test.go
+++ b/internal/config/patch_test.go
@@ -216,11 +216,12 @@ func TestApplyPatches_AgentRigWildcard(t *testing.T) {
 func TestApplyPatches_AgentRigWildcardNoMatch(t *testing.T) {
 	cfg := &City{Agents: []Agent{{Name: "mayor"}}}
 	err := ApplyPatches(cfg, Patches{Agents: []AgentPatch{{Name: "polecat", Rig: "*", Suspended: ptrBool(true)}}})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("ApplyPatches must not fail on an unappliable wildcard: %v", err)
 	}
-	if !strings.Contains(err.Error(), "*/polecat") || !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("error = %q, want wildcard not found", err)
+	requireUnappliedPatchWarning(t, cfg.LoadWarnings, "patches.agent[0]", "*/polecat", "not found")
+	if cfg.Agents[0].Suspended {
+		t.Fatal("a skipped wildcard patch modified an agent it did not match")
 	}
 }
 
@@ -253,21 +254,23 @@ func TestApplyPatches_AgentRigLegacyDirStillWorks(t *testing.T) {
 }
 
 func TestApplyPatches_AgentRigAndDirConflict(t *testing.T) {
-	cfg := &City{Agents: []Agent{{Name: "polecat", Dir: "rigA"}}}
-	err := ApplyPatches(cfg, Patches{Agents: []AgentPatch{{Name: "polecat", Dir: "rigA", Rig: "rigB"}}})
-	if err == nil {
-		t.Fatal("expected error")
+	cfg := &City{Agents: []Agent{{Name: "polecat", Dir: "rigA", Provider: "stay"}}}
+	err := ApplyPatches(cfg, Patches{Agents: []AgentPatch{{Name: "polecat", Dir: "rigA", Rig: "rigB", Provider: ptrStr("llama")}}})
+	if err != nil {
+		t.Fatalf("ApplyPatches must not fail on a malformed patch: %v", err)
 	}
-	if !strings.Contains(err.Error(), "use only one of dir or rig") {
-		t.Fatalf("error = %q", err)
+	requireUnappliedPatchWarning(t, cfg.LoadWarnings, "patches.agent[0]", "use only one of dir or rig")
+	if cfg.Agents[0].Provider != "stay" {
+		t.Fatal("a skipped dir+rig patch modified its would-be target")
 	}
 }
 
 // TestAgentPatch_Validate covers the write-boundary identity guard that the
 // HTTP patch API and the config editor both call before persisting a patch:
 // Name is required, and the legacy Dir key and the newer Rig key (including the
-// "*" wildcard) are mutually exclusive. A dir+rig patch would hard-fail the
-// next config load, so it must be rejected fail-fast rather than written.
+// "*" wildcard) are mutually exclusive. A dir+rig patch would be skipped (and
+// flagged by `gc config --validate`) on every subsequent load, so it must be
+// rejected fail-fast rather than written.
 func TestAgentPatch_Validate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/patch_test.go
+++ b/internal/config/patch_test.go
@@ -469,33 +469,29 @@ func TestApplyPatches_AgentNotFound(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{{Name: "mayor"}},
 	}
-	err := ApplyPatches(cfg, Patches{
+	if err := ApplyPatches(cfg, Patches{
 		Agents: []AgentPatch{
 			{Dir: "hw", Name: "polecat", Suspended: ptrBool(true)},
 		},
-	})
-	if err == nil {
-		t.Fatal("expected error for nonexistent agent")
+	}); err != nil {
+		t.Fatalf("ApplyPatches must not fail on an unappliable target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "hw/polecat") {
-		t.Errorf("error = %q, want mention of hw/polecat", err)
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error = %q, want mention of 'not found'", err)
+	requireUnappliedPatchWarning(t, cfg.LoadWarnings, "patches.agent[0]", "hw/polecat", "not found")
+	// The config must be exactly the config without that patch — a patch that
+	// matched nothing must not have half-applied.
+	if cfg.Agents[0].Suspended {
+		t.Fatal("a skipped patch modified an agent it did not match")
 	}
 }
 
 func TestApplyPatches_AgentNameRequired(t *testing.T) {
 	cfg := &City{}
-	err := ApplyPatches(cfg, Patches{
+	if err := ApplyPatches(cfg, Patches{
 		Agents: []AgentPatch{{Suspended: ptrBool(true)}},
-	})
-	if err == nil {
-		t.Fatal("expected error for missing name")
+	}); err != nil {
+		t.Fatalf("ApplyPatches must not fail on a malformed patch: %v", err)
 	}
-	if !strings.Contains(err.Error(), "name is required") {
-		t.Errorf("error = %q, want 'name is required'", err)
-	}
+	requireUnappliedPatchWarning(t, cfg.LoadWarnings, "patches.agent[0]", "name is required")
 }
 
 func TestApplyPatches_RigPath(t *testing.T) {
@@ -613,16 +609,16 @@ func TestApplyPatches_RigNotFound(t *testing.T) {
 	cfg := &City{
 		Rigs: []Rig{{Name: "hw", Path: "/path"}},
 	}
-	err := ApplyPatches(cfg, Patches{
+	if err := ApplyPatches(cfg, Patches{
 		Rigs: []RigPatch{
 			{Name: "missing", Path: ptrStr("/new")},
 		},
-	})
-	if err == nil {
-		t.Fatal("expected error")
+	}); err != nil {
+		t.Fatalf("ApplyPatches must not fail on an unappliable rig target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "missing") {
-		t.Errorf("error = %q, want mention of 'missing'", err)
+	requireUnappliedPatchWarning(t, cfg.LoadWarnings, "patches.rigs[0]", "missing")
+	if cfg.Rigs[0].Path != "/path" {
+		t.Fatalf("a skipped rig patch modified the rig: path = %q", cfg.Rigs[0].Path)
 	}
 }
 
@@ -723,16 +719,16 @@ func TestApplyPatches_ProviderNotFound(t *testing.T) {
 	cfg := &City{
 		Providers: map[string]ProviderSpec{},
 	}
-	err := ApplyPatches(cfg, Patches{
+	if err := ApplyPatches(cfg, Patches{
 		Providers: []ProviderPatch{
 			{Name: "missing", Command: ptrStr("cmd")},
 		},
-	})
-	if err == nil {
-		t.Fatal("expected error")
+	}); err != nil {
+		t.Fatalf("ApplyPatches must not fail on an unappliable provider target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "missing") {
-		t.Errorf("error = %q, want mention of 'missing'", err)
+	requireUnappliedPatchWarning(t, cfg.LoadWarnings, "patches.providers[0]", "missing")
+	if len(cfg.Providers) != 0 {
+		t.Fatalf("a skipped provider patch created a provider: %v", cfg.Providers)
 	}
 }
 
@@ -826,13 +822,15 @@ dir = "hw"
 name = "ghost"
 suspended = true
 `)
-	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err == nil {
-		t.Fatal("expected error for patch targeting nonexistent agent")
+	// THE LOAD MUST SUCCEED (ga-djvbvp): every gc command loads config, so a
+	// dangling patch used to stop the entire city. The typo is still caught —
+	// it is reported in provenance, printed by the CLI on every command, and
+	// fails `gc config --validate`.
+	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("load must not fail on a dangling patch target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "hw/ghost") {
-		t.Errorf("error = %q, want mention of hw/ghost", err)
-	}
+	requireUnappliedPatchWarning(t, prov.Warnings, "hw/ghost", "not found")
 }
 
 func TestPatchesIsEmpty(t *testing.T) {
@@ -940,13 +938,14 @@ mode = "on_demand"
 template = "coder"
 mode = "always"
 `)
-	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err == nil {
-		t.Fatal("expected ambiguous named_session patch error")
+	// Ambiguity is skipped-and-reported for the same reason as a missing
+	// target: applying it would pick a target arbitrarily, and refusing to
+	// apply it must not cost the city every gc command.
+	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("load must not fail on an ambiguous patch target: %v", err)
 	}
-	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "coder") {
-		t.Fatalf("error = %q, want ambiguous coder target", err)
-	}
+	requireUnappliedPatchWarning(t, prov.Warnings, "ambiguous", "coder")
 }
 
 func TestApplyPatches_AgentSessionSetup(t *testing.T) {
@@ -1220,4 +1219,31 @@ func sliceEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// requireUnappliedPatchWarning asserts that an unappliable patch was reported
+// on cfg.LoadWarnings and that the report names every given substring
+// (ga-djvbvp). It replaces the old "ApplyPatches returns an error" assertions:
+// the GUARANTEE is unchanged — a patch that matched nothing must be reported,
+// naming the target and the reason — only the delivery moved from a fatal
+// error to a recorded warning that the CLI prints on every command and that
+// `gc config --validate` fails on.
+func requireUnappliedPatchWarning(t *testing.T, warnings []string, want ...string) {
+	t.Helper()
+	for _, w := range warnings {
+		if !IsUnappliedPatchWarning(w) {
+			continue
+		}
+		ok := true
+		for _, sub := range want {
+			if !strings.Contains(w, sub) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+	}
+	t.Fatalf("no unapplied-patch warning mentioning %v; warnings = %q", want, warnings)
 }


### PR DESCRIPTION
## Summary

**What.** A city-level `[[patches.*]]` entry whose target cannot be resolved no longer aborts config load. `ApplyPatches` now attempts every patch and records each failure on `LoadWarnings` as `patches.<kind>[<i>] was NOT APPLIED: <reason>`; composition re-drains those warnings into provenance after patch application. The CLI classifies them as non-fatal and prints them on every command, and `gc config --validate` promotes them to validation errors and still exits non-zero. Pack-level patches (applied inside recursive pack loading) are unchanged and still fail the load — a pack whose own patch dangles is one internally broken file, with no cross-file edit window.

**Why.** Every `gc` command loads config, so one dangling patch reference halted an entire city — including the commands you'd use to diagnose it. A dangling reference doesn't require a mistake: `city.toml` and a local-path pack are two files, and the pack is live the instant it's written, so any agent stand-up or rename opens a window where a `[[patches.agent]]` exists without its target. We hit this operating a multi-agent fleet: an unrelated command died with `patches.agent[12]: agent "..." not found in merged config` while a new seat was mid-stand-up. One seat's edit window stopping every other agent is a worse failure than one patch left unapplied.

**Why skipping does not weaken the contract.**

- A skipped patch changes nothing. Every error path in all five apply functions fires before any field is applied (the wildcard path errors only when zero agents matched), so the loaded config is exactly the config without that patch — never a half-applied one.
- The skip cannot go silent. The warning is emitted on every command (a condition of this invocation, unlike standing deprecation advisories, which stay filtered), and `gc config --validate` fails on it — any CI job or deploy gate that validates config still goes red on a typo.
- It matches how the loader already treats this defect class: a named session whose backing template doesn't resolve after pack expansion is disabled with a warning, not fatal.
- The residual risk is real and worth naming: a patch that used to match can drift out of effect (e.g. `suspended = true` or an env override after its target is renamed) and the city keeps running without it. But the fatal behavior never enforced that patch's intent either — the target still wasn't patched; failing the load just added a city-wide outage on top, and reported only the first defect per run. Now every unappliable patch is reported in one load, and enforcement lives on the surface built for it.

Follow-up commits: adapt the two `TestApplyPatches` cases from #4063 (wildcard no-match, dir+rig conflict) to assert the same guarantees against the recorded warning, and update the pack-spec sentence that stated the single fatal rule.

**Behavior note:** `LoadWithIncludes` no longer returns an error for an unappliable city-level patch; anything depending on that must check provenance warnings or `gc config --validate`. The eight tests that encoded the fatal contract were rewritten, not deleted — each still requires the typo to be reported naming target and reason, plus that the skipped patch modified nothing.

## Testing

- `go build ./...`; `go vet ./cmd/gc/... ./internal/config/...` — clean
- `go test ./internal/config` (full package) — ok
- `go test ./cmd/gc -run 'TestUnappliedPatch'` — always-emitted, reaches-the-writer, and fails-`--validate` all pass
- Negative check: restoring the old first-failure `return` in `ApplyPatches` makes `TestApplyPatches_AgentNotFound` and `TestApplyPatches_AgentRigWildcardNoMatch` fail with the new guard messages
- `make check-docs` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvU8iDeCxbuqVKqEp7W5RT
