### PR TITLE
fix(hook): keep routed work scoped during store fallback

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
 )
@@ -2049,44 +2048,27 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 // hookRouteIdentitiesEqual reports whether two route/identity strings refer
 // to the same qualified agent, tolerating the tmux-safe session-name
 // encoding (/ -> --, . -> __) alongside the canonical slash-qualified form,
-// case (config-sourced and session-derived spellings of the same agent are
-// not guaranteed identical case - ga-lmy6yj), and the legacy bound-template
-// spelling ("dir/binding.name") a bound->unbound migration leaves behind
-// (legacyBoundTemplateMatchesUnboundAgent in session_reconcile.go). Every
-// normalization is applied identically to both sides, so it can only ever
-// make MORE things match - it can over-keep, never over-drop. This is the
-// single route-spelling matcher shared by the claim path
-// (hookClaimMatchesRoute) and the display path (hookCandidateVisible) per
-// ga-1xaqgo.2 - do not fork a second one.
+// and case (config-sourced and session-derived spellings of the same agent
+// are not guaranteed identical case - ga-lmy6yj). This is the single
+// route-spelling matcher shared by the claim path (hookClaimMatchesRoute)
+// and the display path (hookCandidateVisible) per ga-1xaqgo.2 - do not fork
+// a second one.
+//
+// This deliberately does NOT collapse the legacy bound-template spelling
+// ("dir/binding.name") onto its unbound form ("dir/name"): that migration is
+// owned by canonicalizeLegacyBoundUnassignedRoutedWork (build_desired_state.go),
+// which rewrites the bead's persisted route as an explicit, auditable step.
+// Treating the two spellings as always-already-equal here would let a claim
+// bypass that migration instead of triggering it (see
+// TestCanonicalizeLegacyBoundUnassignedRoutedWorkCanonicalWorkerClaims).
 func hookRouteIdentitiesEqual(a, b string) bool {
 	if a == b {
 		return true
 	}
-	unsanitizedA := agent.UnsanitizeQualifiedNameFromSession(a)
-	unsanitizedB := agent.UnsanitizeQualifiedNameFromSession(b)
-	if strings.EqualFold(unsanitizedA, unsanitizedB) {
-		return true
-	}
 	return strings.EqualFold(
-		normalizeHookBoundTemplateSpelling(unsanitizedA),
-		normalizeHookBoundTemplateSpelling(unsanitizedB),
+		agent.UnsanitizeQualifiedNameFromSession(a),
+		agent.UnsanitizeQualifiedNameFromSession(b),
 	)
-}
-
-// normalizeHookBoundTemplateSpelling collapses the legacy bound-template
-// qualified-name spelling ("dir/binding.name") onto its current unbound form
-// ("dir/name"), mirroring legacyBoundTemplateMatchesUnboundAgent's own
-// dir/Cut(local, ".") logic so a route or identity recorded under either
-// spelling still resolves to the same agent.
-func normalizeHookBoundTemplateSpelling(qualified string) string {
-	dir, local := config.ParseQualifiedName(qualified)
-	if binding, unbound, ok := strings.Cut(local, "."); ok && binding != "" && unbound != "" {
-		local = unbound
-	}
-	if dir == "" {
-		return local
-	}
-	return dir + "/" + local
 }
 
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -2047,18 +2047,22 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 
 // hookRouteIdentitiesEqual reports whether two route/identity strings refer
 // to the same qualified agent, tolerating the tmux-safe session-name
-// encoding (/ -> --, . -> __) alongside the canonical slash-qualified form.
-// gc.routed_to is always written in canonical form, but comparison
-// candidates built from a runtime session name (sessionForQuery) are
-// dash-encoded, so the two spellings must compare equal. This is the single
-// route-spelling matcher shared by the claim path (hookClaimMatchesRoute)
-// and the display path (hookCandidateVisible) per ga-1xaqgo.2 - do not fork
-// a second one.
+// encoding (/ -> --, . -> __) alongside the canonical slash-qualified form,
+// and case, since config-sourced and session-derived spellings of the same
+// agent are not guaranteed identical case (ga-lmy6yj). gc.routed_to is
+// always written in canonical form, but comparison candidates built from a
+// runtime session name (sessionForQuery) are dash-encoded, so the two
+// spellings must compare equal. This is the single route-spelling matcher
+// shared by the claim path (hookClaimMatchesRoute) and the display path
+// (hookCandidateVisible) per ga-1xaqgo.2 - do not fork a second one.
 func hookRouteIdentitiesEqual(a, b string) bool {
 	if a == b {
 		return true
 	}
-	return agent.UnsanitizeQualifiedNameFromSession(a) == agent.UnsanitizeQualifiedNameFromSession(b)
+	return strings.EqualFold(
+		agent.UnsanitizeQualifiedNameFromSession(a),
+		agent.UnsanitizeQualifiedNameFromSession(b),
+	)
 }
 
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
 )
@@ -2048,21 +2049,44 @@ func hookClaimHasIdentity(assignee string, identities []string) bool {
 // hookRouteIdentitiesEqual reports whether two route/identity strings refer
 // to the same qualified agent, tolerating the tmux-safe session-name
 // encoding (/ -> --, . -> __) alongside the canonical slash-qualified form,
-// and case, since config-sourced and session-derived spellings of the same
-// agent are not guaranteed identical case (ga-lmy6yj). gc.routed_to is
-// always written in canonical form, but comparison candidates built from a
-// runtime session name (sessionForQuery) are dash-encoded, so the two
-// spellings must compare equal. This is the single route-spelling matcher
-// shared by the claim path (hookClaimMatchesRoute) and the display path
-// (hookCandidateVisible) per ga-1xaqgo.2 - do not fork a second one.
+// case (config-sourced and session-derived spellings of the same agent are
+// not guaranteed identical case - ga-lmy6yj), and the legacy bound-template
+// spelling ("dir/binding.name") a bound->unbound migration leaves behind
+// (legacyBoundTemplateMatchesUnboundAgent in session_reconcile.go). Every
+// normalization is applied identically to both sides, so it can only ever
+// make MORE things match - it can over-keep, never over-drop. This is the
+// single route-spelling matcher shared by the claim path
+// (hookClaimMatchesRoute) and the display path (hookCandidateVisible) per
+// ga-1xaqgo.2 - do not fork a second one.
 func hookRouteIdentitiesEqual(a, b string) bool {
 	if a == b {
 		return true
 	}
+	unsanitizedA := agent.UnsanitizeQualifiedNameFromSession(a)
+	unsanitizedB := agent.UnsanitizeQualifiedNameFromSession(b)
+	if strings.EqualFold(unsanitizedA, unsanitizedB) {
+		return true
+	}
 	return strings.EqualFold(
-		agent.UnsanitizeQualifiedNameFromSession(a),
-		agent.UnsanitizeQualifiedNameFromSession(b),
+		normalizeHookBoundTemplateSpelling(unsanitizedA),
+		normalizeHookBoundTemplateSpelling(unsanitizedB),
 	)
+}
+
+// normalizeHookBoundTemplateSpelling collapses the legacy bound-template
+// qualified-name spelling ("dir/binding.name") onto its current unbound form
+// ("dir/name"), mirroring legacyBoundTemplateMatchesUnboundAgent's own
+// dir/Cut(local, ".") logic so a route or identity recorded under either
+// spelling still resolves to the same agent.
+func normalizeHookBoundTemplateSpelling(qualified string) string {
+	dir, local := config.ParseQualifiedName(qualified)
+	if binding, unbound, ok := strings.Cut(local, "."); ok && binding != "" && unbound != "" {
+		local = unbound
+	}
+	if dir == "" {
+		return local
+	}
+	return dir + "/" + local
 }
 
 func hookClaimMatchesRoute(candidate beads.Bead, routeTargets []string) bool {

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -26,10 +26,12 @@ func TestHookRouteIdentitiesEqual(t *testing.T) {
 		{"empty vs non-empty", "", "gascity/builder", false},
 		{"case insensitive", "Gascity/Builder", "gascity/builder", true},
 		{"case insensitive, dash-encoded", "Gascity--Builder", "gascity/builder", true},
-		{"legacy bound-template spelling, bound route", "gascity/gastown.builder", "gascity/builder", true},
-		{"legacy bound-template spelling, bound identity", "gascity/builder", "gascity/gastown.builder", true},
-		{"legacy bound-template spelling, both bound and dash-encoded", "gascity/gastown.builder", "gascity--gastown.builder", true},
-		{"legacy bound-template spelling must not collapse different agents", "gascity/gastown.deployer", "gascity/builder", false},
+		// A legacy bound-template spelling ("dir/binding.name") is deliberately
+		// NOT collapsed onto its unbound form here - that migration is owned by
+		// canonicalizeLegacyBoundUnassignedRoutedWork, which rewrites the
+		// persisted route explicitly rather than treating the two spellings as
+		// always-already-equal at compare time.
+		{"legacy bound-template spelling is not collapsed", "gascity/gastown.builder", "gascity/builder", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // --- hookRouteIdentitiesEqual ----------------------------------------------
@@ -25,6 +26,10 @@ func TestHookRouteIdentitiesEqual(t *testing.T) {
 		{"empty vs non-empty", "", "gascity/builder", false},
 		{"case insensitive", "Gascity/Builder", "gascity/builder", true},
 		{"case insensitive, dash-encoded", "Gascity--Builder", "gascity/builder", true},
+		{"legacy bound-template spelling, bound route", "gascity/gastown.builder", "gascity/builder", true},
+		{"legacy bound-template spelling, bound identity", "gascity/builder", "gascity/gastown.builder", true},
+		{"legacy bound-template spelling, both bound and dash-encoded", "gascity/gastown.builder", "gascity--gastown.builder", true},
+		{"legacy bound-template spelling must not collapse different agents", "gascity/gastown.deployer", "gascity/builder", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -78,6 +83,18 @@ func TestHookCandidateVisible(t *testing.T) {
 			assignee:   "reviewer-gm-wisp-b6tr3z",
 			identities: []string{"gascity/builder"},
 			want:       false,
+		},
+		{
+			// Tiers 1 and 2 of the default work query select on --assignee
+			// alone and never consult routed_to, so an owned crash-recovery
+			// bead may legitimately carry a stale or foreign route. The
+			// exemption is blanket: assignee match alone decides visibility,
+			// regardless of what routed_to says.
+			name:       "assigned to me, with a stale foreign route present",
+			assignee:   "gascity/builder",
+			routedTo:   "gascity/deployer",
+			identities: []string{"gascity/builder"},
+			want:       true,
 		},
 		{
 			name:     "assigned to someone else, no identity context at all",
@@ -322,5 +339,81 @@ func TestDoHookGa1xaqgoRegression(t *testing.T) {
 		if bytes.Contains([]byte(out), []byte(foreignID)) {
 			t.Errorf("stdout leaked foreign candidate %q: %s", foreignID, out)
 		}
+	}
+}
+
+// --- route-target call-site wiring ------------------------------------------
+
+// TestFilterForeignHookCandidatesPoolBaseRouteViaRoutedToIdentity pins that a
+// pool slot's own QualifiedName is slot-suffixed ("gascity/polecat-2"), but
+// the routed-pool tier matches on the BASE pool name (poolDemandTarget), so
+// demand work is written with the base route. hookClaimPrimaryRouteTarget
+// (agentutil.RoutedToIdentity) is what lets the slot recognize its own base
+// route; hookClaimRouteTargets is the same expansion the claim path uses.
+func TestFilterForeignHookCandidatesPoolBaseRouteViaRoutedToIdentity(t *testing.T) {
+	base := config.Agent{Dir: "gascity", Name: "polecat"}
+	slot := config.Agent{Dir: "gascity", Name: "polecat-2", PoolName: base.QualifiedName()}
+	candidates := []beads.Bead{
+		{ID: "ga-pool", Status: "open", Metadata: beads.StringMap{"gc.routed_to": base.QualifiedName()}},
+	}
+	raw, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	// The explicit-arg path blanks GC_TEMPLATE, so this is the full
+	// route-target set a slot agent gets.
+	routeTargets := hookClaimRouteTargets(hookClaimPrimaryRouteTarget(&slot), slot.QualifiedName(), "")
+	var kept []beads.Bead
+	if err := json.Unmarshal([]byte(filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: routeTargets})), &kept); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("dropped the pool slot's own base-route work: routeTargets=%v kept=%v", routeTargets, kept)
+	}
+
+	// Negative control: it is RoutedToIdentity doing the work, not the
+	// slot-suffixed qualified name, which must NOT match on its own. If this
+	// stops failing, the test above has gone vacuous.
+	var keptNarrow []beads.Bead
+	narrow := filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: []string{slot.QualifiedName()}})
+	if err := json.Unmarshal([]byte(narrow), &keptNarrow); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(keptNarrow) != 0 {
+		t.Errorf("slot-suffixed name matched the base route on its own: kept %v", keptNarrow)
+	}
+}
+
+// TestFilterForeignHookCandidatesLegacyWorkflowControlAliasMatched pins that
+// buildWorkQuery actively probes the legacy "<rig>/workflow-control" spelling
+// (legacyWorkflowControlQualifiedName), so a bead can carry that route.
+// hookClaimIdentityCandidates is what expands a raw identity into that alias.
+func TestFilterForeignHookCandidatesLegacyWorkflowControlAliasMatched(t *testing.T) {
+	candidates := []beads.Bead{
+		{ID: "ga-legacy", Status: "open", Metadata: beads.StringMap{"gc.routed_to": "gascity/workflow-control"}},
+	}
+	raw, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	identities := hookClaimIdentityCandidates("gascity/control-dispatcher")
+	var kept []beads.Bead
+	if err := json.Unmarshal([]byte(filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: identities})), &kept); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("dropped legacy workflow-control work: identities=%v kept=%v", identities, kept)
+	}
+
+	// Negative control: the unexpanded name alone does not carry the alias.
+	var keptNarrow []beads.Bead
+	narrow := filterForeignHookCandidates(string(raw), hookVisibility{RouteTargets: []string{"gascity/control-dispatcher"}})
+	if err := json.Unmarshal([]byte(narrow), &keptNarrow); err != nil {
+		t.Fatalf("unmarshal filtered output: %v", err)
+	}
+	if len(keptNarrow) != 0 {
+		t.Errorf("unexpanded identity matched the legacy alias: kept %v", keptNarrow)
 	}
 }

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -61,6 +61,35 @@ func TestHookClaimMatchesRouteToleratesSessionNameEncoding(t *testing.T) {
 	}
 }
 
+// TestHookRouteIdentitiesEqualDotAxisRegression guards against a matcher that
+// only reverses the slash-encoding axis ("--" -> "/") of a session-name
+// identity while leaving the dot-encoding axis ("__" -> ".") untouched. A
+// route spelled with a literal dot (e.g. a bound-template identity like
+// "triager.triager") must still match a session-encoded identity for the
+// same agent (e.g. "triager__triager"), or the filter wrongly treats an
+// agent's own routed work as belonging to someone else and drops it (ga-4wwxl7).
+func TestHookRouteIdentitiesEqualDotAxisRegression(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    string
+		identity string
+		want     bool
+	}{
+		{"dot template route vs dot-encoded session identity", "triager.triager", "triager__triager", true},
+		{"dir-qualified dot route vs session-encoded identity", "gastown.mayor", "gastown__mayor", true},
+		{"slash route vs session-encoded slash identity (pre-existing axis)", "gascity/builder", "gascity--builder", true},
+		{"combined slash+dot route vs fully session-encoded identity", "hello-world/gastown.polecat", "hello-world--gastown__polecat", true},
+		{"distinct identities must not match", "gascity/builder", "gascity--reviewer", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hookRouteIdentitiesEqual(tt.route, tt.identity); got != tt.want {
+				t.Errorf("hookRouteIdentitiesEqual(%q, %q) = %v, want %v", tt.route, tt.identity, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- hookCandidateVisible ---------------------------------------------------
 
 func TestHookCandidateVisible(t *testing.T) {

--- a/cmd/gc/cmd_hook_visibility_test.go
+++ b/cmd/gc/cmd_hook_visibility_test.go
@@ -23,6 +23,8 @@ func TestHookRouteIdentitiesEqual(t *testing.T) {
 		{"different rigs", "rig-a/planner", "rig-b/planner", false},
 		{"different agents, same rig", "gascity/builder", "gascity/reviewer", false},
 		{"empty vs non-empty", "", "gascity/builder", false},
+		{"case insensitive", "Gascity/Builder", "gascity/builder", true},
+		{"case insensitive, dash-encoded", "Gascity--Builder", "gascity/builder", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/release-gates/ga-lmy6yj-hook-route-filter-gate.md
+++ b/release-gates/ga-lmy6yj-hook-route-filter-gate.md
@@ -1,0 +1,128 @@
+# Release gate: backend-independent hook route filtering
+
+- Deploy bead: `ga-lmy6yj`
+- Related implementation bead: `ga-4wwxl7`
+- Review bead: `ga-rgf4nl`
+- Reviewed source: `515702a982ccb11e8a14fc946c53b45e6fbb7a80`
+- Source PR: [#5035](https://github.com/gastownhall/gascity/pull/5035)
+- Source branch: `fix/ga-lmy6yj-hook-routed-to-filter` (provenance only)
+- Planned deploy branch: `deploy/ga-lmy6yj-gate`
+- Base checked at gate time: `origin/main@a85f857b3987bd18593cea2e9594a17a82b10df1`
+- Gate result: **PASS with attributed pre-existing failures**
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Closed review bead `ga-rgf4nl` records `REVIEW VERDICT: PASS` for exact source `515702a982ccb11e8a14fc946c53b45e6fbb7a80`. It independently checked build, vet, the complete `cmd/gc` package, all five diff-owned tests, security, specification, and coverage, with no blocking finding. |
+| 2 | Acceptance criteria met | **PASS** | The hook display path applies route visibility after work-query output, independent of the native-store/fallback backend. Assigned recovery work remains visible despite stale routes; unassigned work is kept only when unrouted or routed to an accepted identity. The shared route matcher handles slash and dot session encodings plus case differences, while deliberately leaving legacy bound-template migration to its explicit persisted-route migration. Pool-base and legacy workflow-control aliases are covered. No `bd` version change or schema-skew workaround was introduced. |
+| 3 | Tests pass | **PASS with attributed failures** | The documented full-scope command, `make test-local-full-parallel`, completed 35/40 jobs PASS and 5/40 FAIL, with 0 observed test SKIP. The five failed jobs reduce to four open, pre-existing conditions attributed below; none is diff-owned. All six non-short `cmd/gc` process shards and all six integration `cmd/gc` shards passed. The exact-head GitHub `CI / required` aggregator passed, including 12/12 Linux `cmd/gc` process shards; 12/12 macOS `cmd/gc` process shards also passed. |
+| 3b | Policy, build, and static checks | **PASS with attributed cache failure** | `make test-ci-policy`, changed-file formatting, `go build ./...`, and `go vet ./...` passed. The exact-head GitHub `Preflight / static checks` and `Mac / quality (lint, fmt, vet, docs)` jobs passed. Local `lint-affected` failed only by replaying diagnostics from deleted sibling worktrees, attributed below to `ga-039od0`; no diagnostic resolves to either changed path. |
+| 3c | CI-config lane run | **PASS / n/a** | No workflow, matrix, timeout, required-check list, build-policy file, or CI configuration changed. |
+| 4 | No unresolved HIGH review findings | **PASS** | Review bead `ga-rgf4nl` records no high-severity style, security, specification, or coverage finding. |
+| 5 | Final branch clean | **PASS** | Before this record was added, detached source `HEAD` was clean and `git diff --check de50ed04441dd1549b0503e31d7e9fee7a45b48c..HEAD` passed. Cleanliness is rechecked after the gate commit. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree --messages origin/main HEAD` returned tree `9da8e675eb58e93bbdb148af97897deeca02ebc6` with no conflict messages. The reviewed source is 9 commits behind and 4 commits ahead of the checked base. Source PR #5035 remains `OPEN`, `MERGEABLE`, and exactly at the reviewed SHA. |
+| 7 | Single feature theme | **PASS** | Four reviewed commits touch only `cmd/gc/cmd_hook_claim.go` and `cmd/gc/cmd_hook_visibility_test.go`. Both bead IDs belong to one hook-routing identity/visibility theme; removing either normalization coverage or the route filter would leave the same user-visible work-selection contract incomplete. |
+
+## Source and ancestry evidence
+
+The recorded source resolves to a commit and matches both the reviewed PR head
+and the source checked by this gate:
+
+```text
+git rev-parse --verify --quiet '515702a982ccb11e8a14fc946c53b45e6fbb7a80^{commit}'
+515702a982ccb11e8a14fc946c53b45e6fbb7a80
+```
+
+The reviewed range over merge base
+`de50ed04441dd1549b0503e31d7e9fee7a45b48c` is:
+
+```text
+5d7266f3d2011b4842286ab14f0f7dc85c9b52d3 fix(hook): drop other agents' work from gc hook under the native-store fallback (ga-lmy6yj)
+e3459b6572009b04d82d53ec6ae1aa205808d21f fix(hook): widen the routed-work identity set and exempt assigned rows (ga-lmy6yj)
+ebe334c446d0efa354a5f842ec96175327899bdf fix(hook): normalize dot-encoded session identities in route filter (ga-4wwxl7)
+515702a982ccb11e8a14fc946c53b45e6fbb7a80 fix(hook): stop collapsing legacy bound-template spelling in route matcher (ga-lmy6yj)
+```
+
+Net reviewed diff: 2 files, 141 insertions, 5 deletions. No `.claude/**`,
+workflow, generated API, configuration, or unrelated package path is present.
+
+## Test evidence
+
+- `test_cmd`: `make test-local-full-parallel`
+- `test_cmd_scope`: `full-suite`
+- `test_counts`: 35 PASS jobs, 5 FAIL jobs, 0 observed test SKIP; 4 unique failing top-level tests/conditions
+- `full_log`: `/var/tmp/ga-lmy6yj-full-1788166500/full-suite.out`
+- `shard_logs`: `/var/tmp/ga-lmy6yj-full-1788166500`
+- `diff_tests_executed`:
+  - `TestHookRouteIdentitiesEqual`: PASS in `cmd-gc-process-2-of-6`
+  - `TestHookRouteIdentitiesEqualDotAxisRegression`: PASS in `cmd-gc-process-4-of-6`
+  - `TestHookCandidateVisible`: PASS in `cmd-gc-process-5-of-6`
+  - `TestFilterForeignHookCandidatesPoolBaseRouteViaRoutedToIdentity`: PASS in `cmd-gc-process-1-of-6`
+  - `TestFilterForeignHookCandidatesLegacyWorkflowControlAliasMatched`: PASS in `cmd-gc-process-2-of-6`
+- `waiver_ref`: none
+- `ci_lane_run`: n/a — no CI-config change
+- `skip_justification`: local full-scope output reported no test-level skip. GitHub's skipped jobs are path-gated/non-applicable lanes; the required aggregator passed and the path-relevant Linux and macOS `cmd/gc` process lanes completed successfully.
+
+### Full-suite failure attribution
+
+| Failure | Tracker | Attribution |
+|---|---|---|
+| `TestRepositoryLedgerMatchesCensusAndDocumentation` in `unit-core` and `integration-packages-core-4-of-4` | `ga-cp3hwi.1` | Clauses 1/4: `internal/testpolicy/resourcecensus` and its ledgers are untouched. Clause 3(a), mechanism: this diff adds no fixed sleep or subprocess call, changes no census/baseline, and adds no suite target, so it cannot produce the reported bootstrap-policy count drift. Tracker predates this run; sighting appended. |
+| `TestSessionEventsLive` in `integration-packages-core-3-of-4` | `ga-idsv6m` | Clauses 1/4: `internal/runtime/herdr` is untouched. Clause 3(a), mechanism: that package cannot import the `cmd/gc` main package, and the exact failure is the tracker's `getAgent evt-a: ok=false err=nil` race. Tracker predates this run; sighting appended. |
+| `TestBdFlagManifestCurrent` in `integration-packages-core-1-of-4` | `ga-f0uceo` | Clauses 1/4: `internal/bdflags` is untouched. Clause 3(a), mechanism: the test compares the installed `bd` command's flags with a manifest; hook route matching cannot alter either input. Tracker predates this run; sighting appended. |
+| `TestGCLiveContract_BeadsAndEvents` in `integration-rest-full-5-of-8` | `ga-esyijp` | Clauses 1/4: no integration, API, beads-init, or migration path changed. Clause 3(a), mechanism: the request failed while `bd init` rejected dirty-table schema migration, before hook routing was exercised. The condition tracker predates this run; sighting appended. |
+
+`failure_attribution`: all four conditions have a landed mechanism proof, an
+open tracker, and no changed-path overlap. The candidate adds neither declared
+nor undeclared test load.
+
+## Remote CI attribution
+
+PR #5035 reports 74 PASS, 2 FAIL, and 22 SKIP checks at the exact reviewed
+head. The required `CI / required` check is green. Both red checks are one
+macOS root condition:
+
+- `Mac / make test` and its `Mac regression summary` fail on
+  `TestSocketPathFallsBackToHomeConfigWhenXDGUnset` and
+  `TestSocketPathHonorsXDGConfigHomeOverHome`.
+- `failure_attribution`: those tests map to open tracker `ga-wu2jmy`.
+- Clauses 1/4: the failing file is `internal/runtime/herdr/client_test.go`,
+  outside the two changed `cmd/gc` paths.
+- Clause 3(d): the tracker records the identical failure on five independent
+  `origin/main` macOS runs from 2026-08-28 through 2026-08-31.
+- The gate appended this PR's exact job sighting to the tracker. All 12 macOS
+  `cmd/gc` process shards and the macOS quality lane passed.
+
+## Policy and static evidence
+
+```text
+make test-ci-policy                                                       PASS
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make fmt-check-changed PASS
+go build ./...                                                            PASS
+go vet ./...                                                              PASS
+GitHub: Preflight / static checks                                         PASS
+GitHub: Mac / quality (lint, fmt, vet, docs)                              PASS
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected FAIL-ATTRIBUTED
+```
+
+The local lint failure emitted diagnostics under deleted, non-repository paths
+such as `/var/tmp/gc-deploy-ga-d8g12r-eval` and warned that those files could
+not be opened. It also replayed paths from other scratch and maintainer-review
+worktrees. This is not current-tree static output.
+
+`policy_attribution`: golangci-lint deleted-worktree diagnostic replay maps to
+`ga-039od0`. Clauses 1/4 are clear because no emitted path is either changed
+file. Clause 3(a) is direct: the reported files are outside this repository and
+many no longer exist. The tracker was created during this discovering run under
+the same-run exception after that mechanism proof landed; it is a non-routed
+`gate-tracker`. The failed command was not rerun to manufacture a green result.
+
+Policy logs are under `/var/tmp/ga-lmy6yj-policy-1788167300`.
+
+## Release disposition
+
+**Gate PASS.** Create `deploy/ga-lmy6yj-gate` from the reviewed source, allow
+only the confirmed related ancestry ID `ga-4wwxl7`, commit this record, push the
+isolated branch, open the deploy PR, publish deploy clearance on its exact head,
+and route the merge request to mayor/mpr. The deployer does not merge.


### PR DESCRIPTION
## What this changes

`gc hook` now filters work-query results against the current agent's accepted routing identities even when the native beads store is unavailable and the command falls back to the external store path. Agents no longer see unassigned work routed to another agent or rig, while assigned crash-recovery work and valid pool-base routes remain visible.

Route matching also recognizes the session-safe slash and dot encodings plus case differences. Legacy bound-template routes are intentionally not collapsed by the matcher; their existing explicit migration remains responsible for rewriting persisted state.

## Review notes

- The change is confined to `cmd/gc` hook selection and its tests; it does not change the beads schema, migration policy, runtime providers, or configured role behavior.
- Display and claim use the same route matcher, avoiding backend-specific visibility drift.
- This isolated release-gated PR supersedes #5035 for merge; do not merge both.

## Test plan

- [x] Full local fast, process-backed `cmd/gc`, and integration shard union; all hook-owned shards pass and unrelated baseline failures are attributed in the gate record.
- [x] Policy suite, formatting check, build, and `go vet ./...`.
- [x] Exact reviewed head's required GitHub CI, including all Linux and macOS `cmd/gc` process shards.
- [x] Release gate: [`release-gates/ga-lmy6yj-hook-route-filter-gate.md`](release-gates/ga-lmy6yj-hook-route-filter-gate.md)