### PR TITLE
feat(mail): add atomic idempotency keys to gc mail send

### DIFF
--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -38,6 +38,7 @@ type beadPolicyGraphStore struct {
 var (
 	_ beads.ConditionalAssignmentReleaser    = (*beadPolicyStore)(nil)
 	_ beads.ConditionalWritesResolveTargeter = (*beadPolicyStore)(nil)
+	_ beads.AtomicTxStore                    = (*beadPolicyStore)(nil)
 )
 
 // ConditionalWritesResolveTarget declares the wrapped store as the
@@ -49,6 +50,21 @@ var (
 // wrapper. beadPolicyGraphStore inherits this via its embedded
 // *beadPolicyStore.
 func (s *beadPolicyStore) ConditionalWritesResolveTarget() beads.Store { return s.Store }
+
+// AtomicTx preserves the wrapped store's transaction guarantee. The policy
+// layer does not replace Store.Tx; hiding this capability would make a native
+// or SQLite messaging store look non-atomic to domain services.
+func (s *beadPolicyStore) AtomicTx() bool { return beads.StoreSupportsAtomicTx(s.Store) }
+
+// IDPrefix preserves the wrapped store's declared ID namespace. Keyed mail
+// uses it to derive deterministic, in-namespace record and message IDs.
+func (s *beadPolicyStore) IDPrefix() string {
+	prefixer, ok := s.Store.(interface{ IDPrefix() string })
+	if !ok {
+		return ""
+	}
+	return prefixer.IDPrefix()
+}
 
 var (
 	_ beads.BatchDeleter = (*beadPolicyStore)(nil)

--- a/cmd/gc/bead_policy_store_conditional_test.go
+++ b/cmd/gc/bead_policy_store_conditional_test.go
@@ -37,3 +37,34 @@ func TestBeadPolicyStoreResolvesConditionalWritesThroughWrapper(t *testing.T) {
 		t.Fatal("resolve through policy wrapper returned no writer: the require stamp was hidden by interface embedding")
 	}
 }
+
+func TestBeadPolicyStorePreservesAtomicTransactionAndIDNamespace(t *testing.T) {
+	opened, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("mail"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	closer := opened.(interface{ CloseStore() error })
+	t.Cleanup(func() {
+		if err := closer.CloseStore(); err != nil {
+			t.Errorf("CloseStore: %v", err)
+		}
+	})
+
+	wrapped := wrapStoreWithBeadPolicies(opened, nil)
+	if !beads.StoreSupportsAtomicTx(wrapped) {
+		t.Fatalf("StoreSupportsAtomicTx(%T) = false, want the SQLite backing's true guarantee", wrapped)
+	}
+	prefixer, ok := wrapped.(interface{ IDPrefix() string })
+	if !ok || prefixer.IDPrefix() != "mail" {
+		t.Fatalf("policy-wrapped IDPrefix = (%T, %q), want mail", wrapped, func() string {
+			if !ok {
+				return ""
+			}
+			return prefixer.IDPrefix()
+		}())
+	}
+
+	if beads.StoreSupportsAtomicTx(wrapStoreWithBeadPolicies(beads.NewMemStore(), nil)) {
+		t.Fatal("policy wrapper invented atomic rollback over MemStore")
+	}
+}

--- a/cmd/gc/class_store_emit.go
+++ b/cmd/gc/class_store_emit.go
@@ -59,11 +59,12 @@ package main
 // the export boundary drops bead.updated and a metadata write to a closed bead
 // that rode bead.closed would re-close it in every replay.
 //
-// Tx is NOT shadowed. A transaction's effect is whatever its body did, and this
-// layer cannot know which beads changed without re-reading the store around
-// every call — so a Tx-shaped write on a relocated class stays event-dark, as it
-// was before this file. That is a known gap rather than an oversight; closing it
-// needs a touched-id set from the Tx itself.
+// Tx is shadowed narrowly enough to retain committed creates. The Tx interface
+// exposes Create directly, so this layer can capture each returned full bead
+// and emit it only after the backing transaction commits. Updates and closes
+// inside a Tx stay event-dark: Tx has no read method, so this layer cannot prove
+// a lifecycle edge or authoritative post-write snapshot without weakening the
+// event contract.
 //
 // Emission is best-effort, per the one-shot recorder precedent: the mutation has
 // already committed when the row is written, so a journal that cannot be opened
@@ -431,6 +432,40 @@ func (s *emittingClassStore) SetMetadataBatch(id string, values map[string]strin
 	}
 	s.emitUpdated(id)
 	return nil
+}
+
+// Tx preserves the backing transaction and emits successful creates only after
+// commit. A failed callback or commit emits nothing, so contenders that lose an
+// atomic unique-ID race cannot leave a false bead.created row.
+func (s *emittingClassStore) Tx(commitMsg string, fn func(beads.Tx) error) error {
+	if fn == nil {
+		return s.Store.Tx(commitMsg, nil)
+	}
+	var created []beads.Bead
+	err := s.Store.Tx(commitMsg, func(tx beads.Tx) error {
+		created = created[:0]
+		return fn(&emittingCreateTx{Tx: tx, created: &created})
+	})
+	if err != nil {
+		return err
+	}
+	for _, bead := range created {
+		s.emitCreated(bead, nil)
+	}
+	return nil
+}
+
+type emittingCreateTx struct {
+	beads.Tx
+	created *[]beads.Bead
+}
+
+func (tx *emittingCreateTx) Create(bead beads.Bead) (beads.Bead, error) {
+	created, err := tx.Tx.Create(bead)
+	if err == nil {
+		*tx.created = append(*tx.created, created)
+	}
+	return created, err
 }
 
 // DepAdd emits for the bead whose edges changed. The snapshot hydrates edges

--- a/cmd/gc/class_store_emit_test.go
+++ b/cmd/gc/class_store_emit_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -592,6 +593,45 @@ func TestEmittingClassStoreKeepsEveryEngineCapability(t *testing.T) {
 		if len(missing) > 0 {
 			t.Errorf("the emitting class store drops %v from %s; every one is a capability assertion that stops matching", missing, engine)
 		}
+	}
+}
+
+func TestEmittingClassStoreTransactionEmitsOnlyCommittedCreates(t *testing.T) {
+	cityPath := t.TempDir()
+	opened, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("gcm"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = opened.(interface{ CloseStore() error }).CloseStore() })
+	wrapped := splitClassRoutes(opened).withCLIEmission(cityPath).stores[coordclass.ClassMessaging]
+
+	if err := wrapped.Tx("committed pair", func(tx beads.Tx) error {
+		if _, err := tx.Create(beads.Bead{ID: "gcm-idem-one", Title: "record", Type: "message", Status: "closed"}); err != nil {
+			return err
+		}
+		_, err := tx.Create(beads.Bead{ID: "gcm-msg-one", Title: "message", Type: "message", Ephemeral: true})
+		return err
+	}); err != nil {
+		t.Fatalf("committed Tx: %v", err)
+	}
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 2 || got[0].Type != events.BeadCreated || got[1].Type != events.BeadCreated {
+		t.Fatalf("committed Tx events = %#v, want two bead.created rows", got)
+	}
+
+	wantRollback := errors.New("rollback")
+	if err := wrapped.Tx("rolled back pair", func(tx beads.Tx) error {
+		if _, err := tx.Create(beads.Bead{ID: "gcm-idem-two", Title: "record", Type: "message-idempotency"}); err != nil {
+			return err
+		}
+		return wantRollback
+	}); !errors.Is(err, wantRollback) {
+		t.Fatalf("rolled-back Tx = %v, want %v", err, wantRollback)
+	}
+	if got := beadEvents(readCityJournal(t, cityPath)); len(got) != 2 {
+		t.Fatalf("events after rollback = %#v, want no additional rows", got)
+	}
+	if _, err := wrapped.Get("gcm-idem-two"); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get rolled-back create = %v, want ErrNotFound", err)
 	}
 }
 

--- a/cmd/gc/cli_storage_routes_test.go
+++ b/cmd/gc/cli_storage_routes_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/mail"
 )
 
 // resetCLIStorageRoutes gives a test the process-scoped funnel in its start
@@ -195,6 +196,73 @@ func TestCLIMailWritesAndReadsTheBindingOnAMigratedCity(t *testing.T) {
 		t.Errorf("the one-shot mail write also landed in the work store as %s; a relocated class must be served from its binding only", sent.ID)
 	} else if !errors.Is(err, beads.ErrNotFound) {
 		t.Errorf("reading the work store for %s: %v", sent.ID, err)
+	}
+}
+
+func TestCLIKeyedMailTransactionLivesEntirelyInMessagingBinding(t *testing.T) {
+	cityPath, cfg := migratedOneShotCLICity(t)
+	captureCLIStorageStderr(t)
+
+	provider, code := openCityMailProvider(io.Discard, "gc mail send")
+	if provider == nil {
+		t.Fatalf("openCityMailProvider returned no provider (code=%d)", code)
+	}
+	keyed, ok := provider.(mail.IdempotentSender)
+	if !ok {
+		t.Fatalf("migrated provider %T has no IdempotentSender capability", provider)
+	}
+	request := mail.IdempotentSendRequest{From: "worker", To: "mayor", Subject: "PR ready", Body: "please review", IdempotencyKey: "migrated-pr-ready"}
+	first, err := keyed.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("first SendIdempotent: %v", err)
+	}
+	retry, err := keyed.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("retry SendIdempotent: %v", err)
+	}
+	if !first.Created || retry.Created || retry.Message.ID != first.Message.ID {
+		t.Fatalf("keyed results = first %+v retry %+v, want one creation and the same ID", first, retry)
+	}
+
+	if err := closeCLIStorageRoutes(); err != nil {
+		t.Fatalf("closing one-shot routes: %v", err)
+	}
+	binding := openMigratedDestination(t, mustResolveInfraTarget(t, cityPath, cfg))
+	if _, err := binding.Get(first.Message.ID); err != nil {
+		t.Fatalf("message %s not in messaging binding: %v", first.Message.ID, err)
+	}
+	rows, err := binding.List(beads.ListQuery{IncludeClosed: true, TierMode: beads.TierBoth, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list keyed mail rows in binding: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("binding keyed mail rows = %#v, want one message and one durable key record", rows)
+	}
+	recordID := ""
+	for _, row := range rows {
+		if row.ID == first.Message.ID {
+			continue
+		}
+		recordID = row.ID
+		if row.Status != "closed" || row.Ephemeral || !row.NoHistory {
+			t.Fatalf("binding durable key row = %#v, want closed non-ephemeral no-history", row)
+		}
+	}
+	if recordID == "" {
+		t.Fatalf("binding rows = %#v, want a durable row distinct from message %s", rows, first.Message.ID)
+	}
+
+	work, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("opening retained work store: %v", err)
+	}
+	t.Cleanup(func() { _ = closeBeadStoreHandle(work) })
+	for _, id := range []string{first.Message.ID, recordID} {
+		if _, err := work.Get(id); err == nil {
+			t.Errorf("keyed messaging row %s also landed in retained work", id)
+		} else if !errors.Is(err, beads.ErrNotFound) {
+			t.Errorf("reading retained work for %s: %v", id, err)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1463,6 +1463,7 @@ func newMailSendCmd(stdout, stderr io.Writer) *cobra.Command {
 	var to string
 	var subject string
 	var message string
+	var idempotencyKey string
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "send [<to>] [<body>]",
@@ -1476,20 +1477,33 @@ a non-running recipient. Unread mail alone does not request a wake.
 Use --from to override the sender identity.
 Use --to as an alternative to the positional <to> argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
+Use --idempotency-key for retry-safe single-recipient delivery. Exact retries
+return the original message ID; reusing a key with different sender, recipient,
+subject, or body fails. Keys are limited to 128 bytes and are not secrets.
 Use --all to broadcast to all live sessions (excluding sender and "human").`,
 		Example: `  gc mail send mayor "Build is green"
   gc mail send mayor -s "Build is green"
   gc mail send myrig/witness -s "Need investigation" -m "Attach logs from the last failed run"
   gc mail send --to mayor "Build is green"
   gc mail send human "Review needed for PR #42"
+  gc mail send mayor "Build is green" --idempotency-key build-42-green
   gc mail send polecat "Priority task" --notify
   gc mail send --all "Status update: tests passing"`,
 		Args: cobra.ArbitraryArgs,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(command *cobra.Command, args []string) error {
+			if command.Flags().Changed("idempotency-key") {
+				if err := mail.ValidateIdempotencyKey(idempotencyKey); err != nil {
+					fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+			}
 			code := 0
-			if jsonOut {
+			switch {
+			case idempotencyKey != "":
+				code = cmdMailSendWithIdempotencyJSON(args, notify, all, from, to, subject, message, idempotencyKey, jsonOut, stdout, stderr)
+			case jsonOut:
 				code = cmdMailSendJSON(args, notify, all, from, to, subject, message, true, stdout, stderr)
-			} else {
+			default:
 				code = cmdMailSend(args, notify, all, from, to, subject, message, stdout, stderr)
 			}
 			if code != 0 {
@@ -1506,8 +1520,10 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 	cmd.Flags().StringVar(&to, "to", "", "recipient address (alternative to positional argument)")
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "message subject line")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "message body text")
+	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "retry-safe key for a single-recipient send (1-128 bytes; do not use secrets)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	cmd.MarkFlagsMutuallyExclusive("to", "all")
+	cmd.MarkFlagsMutuallyExclusive("idempotency-key", "all")
 	return cmd
 }
 
@@ -1731,6 +1747,10 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 }
 
 func cmdMailSendJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, jsonOut bool, stdout, stderr io.Writer) int {
+	return cmdMailSendWithIdempotencyJSON(args, notify, all, from, to, subject, message, "", jsonOut, stdout, stderr)
+}
+
+func cmdMailSendWithIdempotencyJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, idempotencyKey string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail send")
 	if mp == nil {
 		return code
@@ -1839,7 +1859,7 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 	}
 
 	rec := openCityRecorder(stderr)
-	return doMailSendJSON(mp, rec, validRecipients, sender, args, nf, jsonOut, stdout, stderr)
+	return doMailSendWithIdempotencyJSON(mp, rec, validRecipients, sender, args, nf, idempotencyKey, jsonOut, stdout, stderr)
 }
 
 // doMailSend creates a message addressed to a recipient. args is [to, subject, body]
@@ -1850,6 +1870,10 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 }
 
 func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, jsonOut bool, stdout, stderr io.Writer) int {
+	return doMailSendWithIdempotencyJSON(mp, rec, validRecipients, sender, args, nudgeFn, "", jsonOut, stdout, stderr)
+}
+
+func doMailSendWithIdempotencyJSON(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, idempotencyKey string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
 		fmt.Fprintln(stderr, "gc mail send: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>]") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1871,19 +1895,41 @@ func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[s
 		return 1
 	}
 
-	m, err := mp.Send(sender, to, subject, body)
+	var (
+		m       mail.Message
+		created = true
+		err     error
+	)
+	if idempotencyKey == "" {
+		m, err = mp.Send(sender, to, subject, body)
+	} else if keyed, ok := mp.(mail.IdempotentSender); ok {
+		var result mail.IdempotentSendResult
+		result, err = keyed.SendIdempotent(mail.IdempotentSendRequest{
+			From:           sender,
+			To:             to,
+			Subject:        subject,
+			Body:           body,
+			IdempotencyKey: idempotencyKey,
+		})
+		m = result.Message
+		created = result.Created
+	} else {
+		err = fmt.Errorf("%w: provider %T has no atomic keyed-send capability", mail.ErrIdempotencyUnsupported, mp)
+	}
 	telemetry.RecordMailOp(context.Background(), "send", err)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	rec.Record(events.Event{
-		Type:    events.MailSent,
-		Actor:   m.From,
-		Subject: m.ID,
-		Message: to,
-		Payload: mailEventPayload(&m),
-	})
+	if created {
+		rec.Record(events.Event{
+			Type:    events.MailSent,
+			Actor:   m.From,
+			Subject: m.ID,
+			Message: to,
+			Payload: mailEventPayload(&m),
+		})
+	}
 	if !jsonOut {
 		fmt.Fprintf(stdout, "Sent message %s to %s\n", m.ID, to) //nolint:errcheck // best-effort stdout
 	}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -43,6 +43,14 @@ type threadOnlyMailProvider struct {
 	messages []mail.Message
 }
 
+type mailSendRecordingRecorder struct {
+	events []events.Event
+}
+
+func (r *mailSendRecordingRecorder) Record(event events.Event) {
+	r.events = append(r.events, event)
+}
+
 func (countOnlyMailProvider) Send(string, string, string, string) (mail.Message, error) {
 	panic("unexpected Send")
 }
@@ -128,6 +136,88 @@ func TestMailSendSuccess(t *testing.T) {
 	if b.Status != "open" {
 		t.Errorf("bead Status = %q, want %q", b.Status, "open")
 	}
+}
+
+func TestMailSendIdempotencyExecutionReturnsOriginalIDAndEmitsOnce(t *testing.T) {
+	opened, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("gc"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = opened.(interface{ CloseStore() error }).CloseStore() })
+	mp := beadmail.New(opened)
+	recipients := map[string]bool{"human": true, "mayor": true}
+	recorder := &mailSendRecordingRecorder{}
+
+	var firstOut, secondOut, stderr bytes.Buffer
+	args := []string{"mayor", "Review", "Please review PR 42"}
+	if code := doMailSendWithIdempotencyJSON(mp, recorder, recipients, "human", args, nil, "pr-42", true, &firstOut, &stderr); code != 0 {
+		t.Fatalf("first keyed send = %d; stderr=%s", code, stderr.String())
+	}
+	if code := doMailSendWithIdempotencyJSON(mp, recorder, recipients, "human", args, nil, "pr-42", true, &secondOut, &stderr); code != 0 {
+		t.Fatalf("retry keyed send = %d; stderr=%s", code, stderr.String())
+	}
+	var first, second mailActionResult
+	if err := json.Unmarshal(bytes.TrimSpace(firstOut.Bytes()), &first); err != nil {
+		t.Fatalf("decode first JSON: %v; output=%s", err, firstOut.String())
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(secondOut.Bytes()), &second); err != nil {
+		t.Fatalf("decode retry JSON: %v; output=%s", err, secondOut.String())
+	}
+	if first.ID == "" || second.ID != first.ID {
+		t.Fatalf("JSON message IDs = first %q, retry %q; want the same non-empty ID", first.ID, second.ID)
+	}
+	if len(recorder.events) != 1 || recorder.events[0].Type != events.MailSent || recorder.events[0].Subject != first.ID {
+		t.Fatalf("mail events = %#v, want one mail.sent for %s", recorder.events, first.ID)
+	}
+}
+
+func TestMailSendIdempotencyConflictFailsWithoutSecondEvent(t *testing.T) {
+	opened, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("gc"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = opened.(interface{ CloseStore() error }).CloseStore() })
+	mp := beadmail.New(opened)
+	recipients := map[string]bool{"human": true, "mayor": true}
+	recorder := &mailSendRecordingRecorder{}
+
+	if code := doMailSendWithIdempotencyJSON(mp, recorder, recipients, "human", []string{"mayor", "Review", "one"}, nil, "same-key", false, io.Discard, io.Discard); code != 0 {
+		t.Fatalf("first keyed send = %d", code)
+	}
+	var stderr bytes.Buffer
+	if code := doMailSendWithIdempotencyJSON(mp, recorder, recipients, "human", []string{"mayor", "Review", "two"}, nil, "same-key", false, io.Discard, &stderr); code != 1 {
+		t.Fatalf("conflicting keyed send = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), mail.ErrIdempotencyConflict.Error()) {
+		t.Fatalf("conflict stderr = %q, want %q", stderr.String(), mail.ErrIdempotencyConflict)
+	}
+	if len(recorder.events) != 1 {
+		t.Fatalf("mail events after conflict = %#v, want only the original", recorder.events)
+	}
+}
+
+func TestMailSendIdempotencyFlagValidationAndBroadcastExclusion(t *testing.T) {
+	t.Run("explicit empty key is rejected before opening a provider", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		cmd := newMailSendCmd(&stdout, &stderr)
+		cmd.SetArgs([]string{"mayor", "hello", "--idempotency-key="})
+		if err := cmd.Execute(); !errors.Is(err, errExit) {
+			t.Fatalf("Execute = %v, want errExit", err)
+		}
+		if !strings.Contains(stderr.String(), mail.ErrInvalidIdempotencyKey.Error()) {
+			t.Fatalf("stderr = %q, want invalid-key refusal", stderr.String())
+		}
+	})
+
+	t.Run("broadcast cannot share one key", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		cmd := newMailSendCmd(&stdout, &stderr)
+		cmd.SetArgs([]string{"--all", "status", "--idempotency-key", "broadcast-key"})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "idempotency-key all") {
+			t.Fatalf("Execute = %v, want mutually-exclusive flag error", err)
+		}
+	})
 }
 
 func TestMailSendJSON(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2545,6 +2545,9 @@ a non-running recipient. Unread mail alone does not request a wake.
 Use --from to override the sender identity.
 Use --to as an alternative to the positional &lt;to&gt; argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
+Use --idempotency-key for retry-safe single-recipient delivery. Exact retries
+return the original message ID; reusing a key with different sender, recipient,
+subject, or body fails. Keys are limited to 128 bytes and are not secrets.
 Use --all to broadcast to all live sessions (excluding sender and "human").
 
 ```
@@ -2559,6 +2562,7 @@ gc mail send mayor -s "Build is green"
 gc mail send myrig/witness -s "Need investigation" -m "Attach logs from the last failed run"
 gc mail send --to mayor "Build is green"
 gc mail send human "Review needed for PR #42"
+gc mail send mayor "Build is green" --idempotency-key build-42-green
 gc mail send polecat "Priority task" --notify
 gc mail send --all "Status update: tests passing"
 ```
@@ -2567,6 +2571,7 @@ gc mail send --all "Status update: tests passing"
 |------|------|---------|-------------|
 | `--all` | bool |  | broadcast to all live sessions (excludes sender and human) |
 | `--from` | string |  | sender identity (default: $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human") |
+| `--idempotency-key` | string |  | retry-safe key for a single-recipient send (1-128 bytes; do not use secrets) |
 | `--json` | bool |  | emit JSONL result |
 | `-m`, `--message` | string |  | message body text |
 | `--notify` | bool |  | request a recipient turn (including a managed wake if not running), even with earlier unread mail |

--- a/docs/tutorials/04-communication.md
+++ b/docs/tutorials/04-communication.md
@@ -50,6 +50,26 @@ Sent message mc-msg-8t8 to mayor
 `gc mail send` takes the recipient as a positional argument and the subject/body
 via `-s`/`-m` flags. (You can also pass just `<to> <body>` with no subject.)
 
+For a send that an automation may retry after a timeout or crash, provide one
+stable key:
+
+```shell
+gc mail send mayor -s "Review needed" -m "Please review PR 42" \
+  --idempotency-key pr-42-review
+```
+
+Repeating the exact command returns the original message ID and does not create
+a second message. Reusing the key with a different sender, recipient, subject,
+or body is rejected. Keys are 1-128 bytes, cannot contain whitespace or control
+characters, and are stored as operational metadata, so do not put secrets in
+them. `--idempotency-key` is single-recipient only and cannot be combined with
+`--all`. A selected mail backend that cannot provide atomic transactions is
+rejected before either the key record or message is written.
+
+The key deduplicates message persistence and its `mail.sent` event. A
+`--notify` nudge is a separate, per-invocation action and is not part of the
+messaging-store transaction.
+
 Mail does not create wake demand by itself. Add `--notify` to request a turn for
 the recipient even when earlier mail is still unread. In a managed city, that
 request can wake a non-running recipient; an unmanaged city queues the nudge for

--- a/engdocs/architecture/beads.md
+++ b/engdocs/architecture/beads.md
@@ -238,6 +238,32 @@ than spelled raw: the jq/bd shell builders in `internal/config/config.go`
 (via the local `jqMeta` helper and direct constant concatenation) and the
 SQL JSON paths in `internal/api/convoy_sql.go` (via `beadmeta.JSONPath`).
 
+### Keyed mail writes
+
+`internal/mail/beadmail.Provider.SendIdempotent` is the canonical storage edge
+for `gc mail send --idempotency-key`. It routes through the already-selected
+messaging-class store; neither the CLI nor a clone-local journal participates in
+deduplication.
+
+One atomic `Store.Tx` creates two rows in that same store: a closed durable
+no-history `message` record under a deterministic in-namespace ID, and the
+ephemeral open `message` row it owns. A metadata marker distinguishes the
+record; using the built-in type avoids a custom-type rollout. The record carries
+the exact key, a length-framed SHA-256 fingerprint of the immutable request
+fields, and the original message/thread IDs. A unique record-ID conflict is
+therefore the single-winner gate for concurrent callers. An exact retry returns
+the mapped message ID; a different fingerprint fails closed. The durable record
+remains after the ephemeral message is archived or purged, so an old key never
+silently creates a replacement.
+
+This path requires `StoreSupportsAtomicTx`: SQLite and native Dolt provide real
+rollback, while legacy sequential `BdStore.Tx`, FileStore, MemStore, and exec
+stores do not. Unsupported stores are rejected before any write. Store wrappers
+used by the CLI must forward both `AtomicTx` and `IDPrefix`. The relocated-class
+wrapper emits `bead.created` only after the transaction commits, and the
+separate `mail.sent` event is recorded only by the winning command invocation;
+an exact replay claims neither event again.
+
 ## Interactions
 
 | Depends on | How |

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -162,19 +162,24 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 	threadID := generateThreadID()
 	labels := []string{"thread:" + threadID}
 
-	title := subject
-	if title == "" && body != "" {
-		title = strings.SplitN(body, "\n", 2)[0]
-		if len(title) > 80 {
-			title = title[:77] + "..."
-		}
-	}
+	title := deriveSendTitle(subject, body)
 
 	b, err := p.createMessageBead(title, body, from, to, labels, metadata)
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)
 	}
 	return beadToMessage(b), nil
+}
+
+func deriveSendTitle(subject, body string) string {
+	if subject != "" || body == "" {
+		return subject
+	}
+	title := strings.SplitN(body, "\n", 2)[0]
+	if len(title) > 80 {
+		title = title[:77] + "..."
+	}
+	return title
 }
 
 // SendHandoff creates a handoff message from a [mail.HandoffIntent]. It speaks

--- a/internal/mail/beadmail/idempotency.go
+++ b/internal/mail/beadmail/idempotency.go
@@ -1,0 +1,199 @@
+package beadmail
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
+)
+
+const (
+	idempotencyKeyMetadataKey         = "mail.idempotency_key"
+	idempotencyRecordMetadataKey      = "mail.idempotency_record"
+	idempotencyFingerprintMetadataKey = "mail.idempotency_fingerprint"
+	idempotencyMessageIDMetadataKey   = "mail.idempotency_message_id"
+	idempotencyThreadIDMetadataKey    = "mail.idempotency_thread_id"
+	idempotencyRecordIDMetadataKey    = "mail.idempotency_record_id"
+	idempotencyRecordMarker           = "true"
+	idempotencyTxAttempts             = 4
+	idempotencyRetryDelay             = 10 * time.Millisecond
+)
+
+// SendIdempotent atomically creates one durable key record and one ephemeral
+// message in the provider's messaging-class store. Exact retries return the
+// original message; a key reused for different immutable fields fails closed.
+// Stores without real transaction rollback are refused before any write.
+func (p *Provider) SendIdempotent(request mail.IdempotentSendRequest) (mail.IdempotentSendResult, error) {
+	if err := mail.ValidateIdempotencyKey(request.IdempotencyKey); err != nil {
+		return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: %w", err)
+	}
+	if request.To == "" {
+		return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: recipient is required")
+	}
+	if p == nil || p.store == nil || !beads.StoreSupportsAtomicTx(p.store) {
+		return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: %w: messaging store %T does not provide atomic transaction rollback", mail.ErrIdempotencyUnsupported, idempotencyStore(p))
+	}
+	prefixer, ok := p.store.(interface{ IDPrefix() string })
+	if !ok {
+		return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: %w: messaging store %T does not declare its ID namespace", mail.ErrIdempotencyUnsupported, p.store)
+	}
+	prefix := strings.Trim(strings.ToLower(strings.TrimSpace(prefixer.IDPrefix())), "-")
+	if prefix == "" {
+		return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: %w: messaging store %T declares an empty ID namespace", mail.ErrIdempotencyUnsupported, p.store)
+	}
+	keyDigest := sha256.Sum256([]byte(request.IdempotencyKey))
+	digest := hex.EncodeToString(keyDigest[:])
+	recordID := prefix + "-mail-idem-" + digest
+	messageID := prefix + "-mail-msg-" + digest
+	fingerprint := idempotentRequestFingerprint(request)
+
+	if replay, found, err := p.idempotentReplay(recordID, messageID, fingerprint, request); found || err != nil {
+		return replay, err
+	}
+
+	resolvedFrom, routeMetadata, err := p.resolveSenderRoute(request.From)
+	if err != nil {
+		return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: %w", err)
+	}
+	threadID := generateThreadID()
+	createdAt := time.Now().Round(0).UTC()
+	record := beads.Bead{
+		ID:          recordID,
+		Title:       "mail idempotency " + digest[:16],
+		Status:      "closed",
+		Type:        messageBeadType,
+		Assignee:    request.To,
+		From:        resolvedFrom,
+		CreatedAt:   createdAt,
+		UpdatedAt:   createdAt,
+		NoHistory:   true,
+		Description: "Durable idempotency record for message " + messageID,
+		Metadata: map[string]string{
+			idempotencyKeyMetadataKey:         request.IdempotencyKey,
+			idempotencyRecordMetadataKey:      idempotencyRecordMarker,
+			idempotencyFingerprintMetadataKey: fingerprint,
+			idempotencyMessageIDMetadataKey:   messageID,
+			idempotencyThreadIDMetadataKey:    threadID,
+		},
+	}
+	messageMetadata := routeMetadata
+	if messageMetadata == nil {
+		messageMetadata = make(map[string]string, 2)
+	}
+	messageMetadata[idempotencyRecordIDMetadataKey] = recordID
+	messageMetadata[idempotencyFingerprintMetadataKey] = fingerprint
+	messageBead := beads.Bead{
+		ID:          messageID,
+		Title:       deriveSendTitle(request.Subject, request.Body),
+		Description: request.Body,
+		Type:        messageBeadType,
+		Assignee:    request.To,
+		From:        resolvedFrom,
+		Labels:      []string{"thread:" + threadID},
+		Metadata:    messageMetadata,
+		Ephemeral:   true,
+		CreatedAt:   createdAt,
+		UpdatedAt:   createdAt,
+	}
+
+	var created beads.Bead
+	var txErr error
+	for attempt := 1; attempt <= idempotencyTxAttempts; attempt++ {
+		txErr = p.store.Tx("gc: send mail idempotently", func(tx beads.Tx) error {
+			storedRecord, err := tx.Create(record)
+			if err != nil {
+				return fmt.Errorf("creating idempotency record: %w", err)
+			}
+			if storedRecord.ID != recordID {
+				return fmt.Errorf("creating idempotency record: store replaced pinned id %q with %q", recordID, storedRecord.ID)
+			}
+			created, err = tx.Create(messageBead)
+			if err != nil {
+				return fmt.Errorf("creating message: %w", err)
+			}
+			if created.ID != messageID {
+				return fmt.Errorf("creating message: store replaced pinned id %q with %q", messageID, created.ID)
+			}
+			return nil
+		})
+		if txErr == nil {
+			return mail.IdempotentSendResult{Message: beadToMessage(created), Created: true}, nil
+		}
+		if replay, found, replayErr := p.idempotentReplay(recordID, messageID, fingerprint, request); found || replayErr != nil {
+			return replay, replayErr
+		}
+		if attempt < idempotencyTxAttempts {
+			time.Sleep(idempotencyRetryDelay)
+		}
+	}
+	return mail.IdempotentSendResult{}, fmt.Errorf("beadmail idempotent send: atomic create failed after %d attempts: %w", idempotencyTxAttempts, txErr)
+}
+
+func idempotencyStore(p *Provider) beads.Store {
+	if p == nil {
+		return nil
+	}
+	return p.store
+}
+
+func idempotentRequestFingerprint(request mail.IdempotentSendRequest) string {
+	h := sha256.New()
+	var size [8]byte
+	for _, field := range []string{request.From, request.To, request.Subject, request.Body} {
+		binary.BigEndian.PutUint64(size[:], uint64(len(field)))
+		_, _ = h.Write(size[:])
+		_, _ = h.Write([]byte(field))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// idempotentReplay returns found=false only when the deterministic key record
+// is absent. Any present-but-conflicting or malformed record is a hard error.
+func (p *Provider) idempotentReplay(recordID, messageID, fingerprint string, request mail.IdempotentSendRequest) (mail.IdempotentSendResult, bool, error) {
+	record, err := p.store.Get(recordID)
+	if errors.Is(err, beads.ErrNotFound) {
+		return mail.IdempotentSendResult{}, false, nil
+	}
+	if err != nil {
+		return mail.IdempotentSendResult{}, false, fmt.Errorf("beadmail idempotent send: reading key record: %w", err)
+	}
+	if record.Type != messageBeadType || record.Metadata[idempotencyRecordMetadataKey] != idempotencyRecordMarker || record.Metadata[idempotencyKeyMetadataKey] != request.IdempotencyKey || record.Metadata[idempotencyFingerprintMetadataKey] != fingerprint {
+		return mail.IdempotentSendResult{}, true, fmt.Errorf("beadmail idempotent send: %w", mail.ErrIdempotencyConflict)
+	}
+	if storedMessageID := strings.TrimSpace(record.Metadata[idempotencyMessageIDMetadataKey]); storedMessageID == "" || storedMessageID != messageID {
+		return mail.IdempotentSendResult{}, true, fmt.Errorf("beadmail idempotent send: %w: key record has an invalid message id", mail.ErrIdempotencyRecordCorrupt)
+	}
+	threadID := strings.TrimSpace(record.Metadata[idempotencyThreadIDMetadataKey])
+	if threadID == "" {
+		return mail.IdempotentSendResult{}, true, fmt.Errorf("beadmail idempotent send: %w: key record has no thread id", mail.ErrIdempotencyRecordCorrupt)
+	}
+	messageBead, err := p.store.Get(messageID)
+	if err == nil {
+		if messageBead.Type != messageBeadType || messageBead.Metadata[idempotencyRecordIDMetadataKey] != recordID || messageBead.Metadata[idempotencyFingerprintMetadataKey] != fingerprint {
+			return mail.IdempotentSendResult{}, true, fmt.Errorf("beadmail idempotent send: %w: mapped message does not match its key record", mail.ErrIdempotencyRecordCorrupt)
+		}
+		return mail.IdempotentSendResult{Message: beadToMessage(messageBead), Created: false}, true, nil
+	}
+	if !errors.Is(err, beads.ErrNotFound) {
+		return mail.IdempotentSendResult{}, true, fmt.Errorf("beadmail idempotent send: reading original message: %w", err)
+	}
+	// Archive/purge may remove the ephemeral message, but the durable record
+	// still owns the key forever. Return the original ID without recreating it.
+	return mail.IdempotentSendResult{Message: mail.Message{
+		ID:        messageID,
+		From:      record.From,
+		To:        record.Assignee,
+		Subject:   deriveSendTitle(request.Subject, request.Body),
+		Body:      request.Body,
+		CreatedAt: record.CreatedAt,
+		ThreadID:  threadID,
+	}, Created: false}, true, nil
+}
+
+var _ mail.IdempotentSender = (*Provider)(nil)

--- a/internal/mail/beadmail/idempotency_test.go
+++ b/internal/mail/beadmail/idempotency_test.go
@@ -1,0 +1,286 @@
+package beadmail
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
+)
+
+type failSecondCreateAtomicStore struct {
+	*beads.SQLiteStore
+}
+
+type emptyPrefixAtomicStore struct {
+	*beads.SQLiteStore
+}
+
+func (*emptyPrefixAtomicStore) IDPrefix() string { return "" }
+
+func (s *failSecondCreateAtomicStore) Tx(commitMsg string, fn func(beads.Tx) error) error {
+	return s.SQLiteStore.Tx(commitMsg, func(tx beads.Tx) error {
+		return fn(&failSecondCreateTx{Tx: tx})
+	})
+}
+
+type failSecondCreateTx struct {
+	beads.Tx
+	creates int
+}
+
+func (tx *failSecondCreateTx) Create(bead beads.Bead) (beads.Bead, error) {
+	tx.creates++
+	if tx.creates == 2 {
+		return beads.Bead{}, errors.New("injected message create failure")
+	}
+	return tx.Tx.Create(bead)
+}
+
+func openIdempotencySQLiteStore(t *testing.T) *beads.SQLiteStore {
+	t.Helper()
+	opened, err := beads.OpenSQLiteStore(t.TempDir(), beads.WithSQLiteStoreIDPrefix("gc"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	store, ok := opened.(*beads.SQLiteStore)
+	if !ok {
+		t.Fatalf("OpenSQLiteStore returned %T, want *beads.SQLiteStore", opened)
+	}
+	t.Cleanup(func() {
+		if err := store.CloseStore(); err != nil {
+			t.Errorf("CloseStore: %v", err)
+		}
+	})
+	return store
+}
+
+func TestSendIdempotentRetryReturnsOriginalMessage(t *testing.T) {
+	store := openIdempotencySQLiteStore(t)
+	p := New(store)
+	request := mail.IdempotentSendRequest{
+		From:           "human",
+		To:             "mayor",
+		Subject:        "Review",
+		Body:           "Please review PR 42",
+		IdempotencyKey: "pr-42-review",
+	}
+
+	first, err := p.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("first SendIdempotent: %v", err)
+	}
+	second, err := p.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("retry SendIdempotent: %v", err)
+	}
+	if !first.Created || second.Created {
+		t.Fatalf("Created = first %v, retry %v; want true, false", first.Created, second.Created)
+	}
+	if first.Message.ID == "" || second.Message.ID != first.Message.ID {
+		t.Fatalf("message IDs = first %q, retry %q; want the same non-empty ID", first.Message.ID, second.Message.ID)
+	}
+
+	messages, err := store.List(beads.ListQuery{Type: messageBeadType, TierMode: beads.TierBoth, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].ID != first.Message.ID {
+		t.Fatalf("messages = %#v, want only %s", messages, first.Message.ID)
+	}
+	records, err := store.ListByMetadata(map[string]string{idempotencyRecordMetadataKey: idempotencyRecordMarker}, 0, beads.IncludeClosed, beads.WithBothTiers)
+	if err != nil {
+		t.Fatalf("list idempotency records: %v", err)
+	}
+	if len(records) != 1 || records[0].Status != "closed" || records[0].Ephemeral || !records[0].NoHistory {
+		t.Fatalf("idempotency records = %#v, want one closed durable no-history record", records)
+	}
+}
+
+func TestSendIdempotentConflictingRequestFailsClosed(t *testing.T) {
+	store := openIdempotencySQLiteStore(t)
+	p := New(store)
+	request := mail.IdempotentSendRequest{From: "human", To: "mayor", Subject: "Review", Body: "one", IdempotencyKey: "same-key"}
+	if _, err := p.SendIdempotent(request); err != nil {
+		t.Fatalf("first SendIdempotent: %v", err)
+	}
+	request.Body = "two"
+	if _, err := p.SendIdempotent(request); !errors.Is(err, mail.ErrIdempotencyConflict) {
+		t.Fatalf("conflicting SendIdempotent = %v, want ErrIdempotencyConflict", err)
+	}
+
+	messages, err := store.List(beads.ListQuery{Type: messageBeadType, TierMode: beads.TierBoth, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].Description != "one" {
+		t.Fatalf("messages after conflict = %#v, want only original body", messages)
+	}
+}
+
+func TestSendIdempotentCorruptMessageMappingFailsClosed(t *testing.T) {
+	store := openIdempotencySQLiteStore(t)
+	p := New(store)
+	request := mail.IdempotentSendRequest{From: "human", To: "mayor", Body: "one", IdempotencyKey: "corrupt-key"}
+	first, err := p.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("first SendIdempotent: %v", err)
+	}
+	if err := store.SetMetadata(first.Message.ID, idempotencyRecordIDMetadataKey, "wrong-record"); err != nil {
+		t.Fatalf("corrupt message mapping: %v", err)
+	}
+	if _, err := p.SendIdempotent(request); !errors.Is(err, mail.ErrIdempotencyRecordCorrupt) {
+		t.Fatalf("retry with corrupt message mapping = %v, want ErrIdempotencyRecordCorrupt", err)
+	}
+	messages, err := store.List(beads.ListQuery{Type: messageBeadType, Status: "open", TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].ID != first.Message.ID {
+		t.Fatalf("messages after corrupt retry = %#v, want only original %s", messages, first.Message.ID)
+	}
+}
+
+func TestSendIdempotentRetryAfterMessageArchiveKeepsOriginalID(t *testing.T) {
+	store := openIdempotencySQLiteStore(t)
+	p := New(store)
+	request := mail.IdempotentSendRequest{From: "human", To: "mayor", Body: "archive me", IdempotencyKey: "archive-retry"}
+	first, err := p.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("first SendIdempotent: %v", err)
+	}
+	if err := p.Archive(first.Message.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	retry, err := p.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("retry after archive: %v", err)
+	}
+	if retry.Created || retry.Message.ID != first.Message.ID {
+		t.Fatalf("retry after archive = %+v, want original ID %s without recreation", retry, first.Message.ID)
+	}
+	archived, err := store.Get(first.Message.ID)
+	if err != nil || archived.Status != "closed" {
+		t.Fatalf("archived original = (%+v, %v), want the original closed message", archived, err)
+	}
+	if err := store.Delete(first.Message.ID); err != nil {
+		t.Fatalf("purge archived message: %v", err)
+	}
+	retry, err = p.SendIdempotent(request)
+	if err != nil {
+		t.Fatalf("retry after purge: %v", err)
+	}
+	if retry.Created || retry.Message.ID != first.Message.ID {
+		t.Fatalf("retry after purge = %+v, want original ID %s without recreation", retry, first.Message.ID)
+	}
+	if _, err := store.Get(first.Message.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get message after purged retry = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSendIdempotentRollsBackRecordWhenMessageCreateFails(t *testing.T) {
+	base := openIdempotencySQLiteStore(t)
+	store := &failSecondCreateAtomicStore{SQLiteStore: base}
+	p := New(store)
+	request := mail.IdempotentSendRequest{From: "human", To: "mayor", Body: "must be atomic", IdempotencyKey: "rollback-key"}
+	if _, err := p.SendIdempotent(request); err == nil || !strings.Contains(err.Error(), "injected message create failure") {
+		t.Fatalf("SendIdempotent = %v, want injected failure", err)
+	}
+	items, err := base.List(beads.ListQuery{IncludeClosed: true, TierMode: beads.TierBoth, AllowScan: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("atomic rollback left rows: %#v", items)
+	}
+}
+
+func TestSendIdempotentConcurrentCallersCreateOneMessage(t *testing.T) {
+	store := openIdempotencySQLiteStore(t)
+	p := New(store)
+	request := mail.IdempotentSendRequest{From: "human", To: "mayor", Subject: "Review", Body: "concurrent", IdempotencyKey: "concurrent-key"}
+
+	const callers = 16
+	start := make(chan struct{})
+	results := make(chan mail.IdempotentSendResult, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := p.SendIdempotent(request)
+			results <- result
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent SendIdempotent: %v", err)
+		}
+	}
+	created := 0
+	messageID := ""
+	for result := range results {
+		if result.Created {
+			created++
+		}
+		if messageID == "" {
+			messageID = result.Message.ID
+		}
+		if result.Message.ID != messageID {
+			t.Fatalf("concurrent message ID = %q, want %q", result.Message.ID, messageID)
+		}
+	}
+	if created != 1 {
+		t.Fatalf("Created=true count = %d, want exactly 1", created)
+	}
+	messages, err := store.List(beads.ListQuery{Type: messageBeadType, TierMode: beads.TierBoth, AllowScan: true})
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].ID != messageID {
+		t.Fatalf("messages = %#v, want only %s", messages, messageID)
+	}
+}
+
+func TestSendIdempotentRejectsNonAtomicStoreBeforeWriting(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+	_, err := p.SendIdempotent(mail.IdempotentSendRequest{From: "human", To: "mayor", Body: "no partial write", IdempotencyKey: "unsupported"})
+	if !errors.Is(err, mail.ErrIdempotencyUnsupported) {
+		t.Fatalf("SendIdempotent = %v, want ErrIdempotencyUnsupported", err)
+	}
+	items, listErr := store.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierBoth})
+	if listErr != nil {
+		t.Fatalf("List: %v", listErr)
+	}
+	if len(items) != 0 {
+		t.Fatalf("non-atomic store contains %#v after refusal, want no writes", items)
+	}
+}
+
+func TestSendIdempotentRejectsEmptyStoreNamespaceBeforeWriting(t *testing.T) {
+	base := openIdempotencySQLiteStore(t)
+	store := &emptyPrefixAtomicStore{SQLiteStore: base}
+	p := New(store)
+	_, err := p.SendIdempotent(mail.IdempotentSendRequest{From: "human", To: "mayor", Body: "no namespace", IdempotencyKey: "unsupported-prefix"})
+	if !errors.Is(err, mail.ErrIdempotencyUnsupported) {
+		t.Fatalf("SendIdempotent = %v, want ErrIdempotencyUnsupported", err)
+	}
+	items, listErr := base.List(beads.ListQuery{IncludeClosed: true, AllowScan: true, TierMode: beads.TierBoth})
+	if listErr != nil {
+		t.Fatalf("List: %v", listErr)
+	}
+	if len(items) != 0 {
+		t.Fatalf("empty-namespace store contains %#v after refusal, want no writes", items)
+	}
+}

--- a/internal/mail/idempotency_test.go
+++ b/internal/mail/idempotency_test.go
@@ -1,0 +1,36 @@
+package mail
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{
+		"invoice-2026-09-01",
+		"worker/attempt:42",
+		"ключ-42",
+		strings.Repeat("x", MaxIdempotencyKeyBytes),
+	} {
+		if err := ValidateIdempotencyKey(key); err != nil {
+			t.Errorf("ValidateIdempotencyKey(%q): %v", key, err)
+		}
+	}
+
+	for _, key := range []string{
+		"",
+		" leading",
+		"trailing ",
+		"embedded\nnewline",
+		strings.Repeat("x", MaxIdempotencyKeyBytes+1),
+		string([]byte{0xff}),
+	} {
+		err := ValidateIdempotencyKey(key)
+		if !errors.Is(err, ErrInvalidIdempotencyKey) {
+			t.Errorf("ValidateIdempotencyKey(%q) = %v, want ErrInvalidIdempotencyKey", key, err)
+		}
+	}
+}

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -6,7 +6,11 @@ package mail //nolint:revive // internal package, always imported qualified
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // ErrAlreadyArchived is returned by [Provider.Archive] when the message has
@@ -16,6 +20,26 @@ var ErrAlreadyArchived = errors.New("already archived")
 
 // ErrNotFound is returned when a message ID does not exist.
 var ErrNotFound = errors.New("message not found")
+
+// ErrInvalidIdempotencyKey is returned when a keyed send uses an empty,
+// oversized, non-UTF-8, or whitespace/control-bearing key.
+var ErrInvalidIdempotencyKey = errors.New("invalid mail idempotency key")
+
+// ErrIdempotencyUnsupported is returned before writing when the selected mail
+// backend cannot atomically create the durable key record and message together.
+var ErrIdempotencyUnsupported = errors.New("mail idempotency unsupported")
+
+// ErrIdempotencyConflict is returned when a durable key record already exists
+// for different immutable request fields.
+var ErrIdempotencyConflict = errors.New("mail idempotency key conflicts with an existing request")
+
+// ErrIdempotencyRecordCorrupt is returned when a durable key record exists but
+// cannot prove which original message it owns. The send fails closed.
+var ErrIdempotencyRecordCorrupt = errors.New("mail idempotency record is corrupt")
+
+// MaxIdempotencyKeyBytes bounds the durable key copied into message-store
+// metadata. The limit is bytes, not runes, so it is stable across encodings.
+const MaxIdempotencyKeyBytes = 128
 
 const (
 	// AutoHandoffLabel marks mail created by gc handoff --auto for provider
@@ -42,6 +66,29 @@ const (
 	ReadMetadataKey = "mail.read"
 )
 
+// ValidateIdempotencyKey validates the opaque key accepted by keyed mail send.
+// Keys are compared byte-for-byte: callers must reuse the exact same value.
+func ValidateIdempotencyKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("%w: key is empty", ErrInvalidIdempotencyKey)
+	}
+	if len(key) > MaxIdempotencyKeyBytes {
+		return fmt.Errorf("%w: key is %d bytes (maximum %d)", ErrInvalidIdempotencyKey, len(key), MaxIdempotencyKeyBytes)
+	}
+	if !utf8.ValidString(key) {
+		return fmt.Errorf("%w: key is not valid UTF-8", ErrInvalidIdempotencyKey)
+	}
+	if strings.TrimSpace(key) != key {
+		return fmt.Errorf("%w: key has leading or trailing whitespace", ErrInvalidIdempotencyKey)
+	}
+	for _, r := range key {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("%w: key contains whitespace or control characters", ErrInvalidIdempotencyKey)
+		}
+	}
+	return nil
+}
+
 // Message represents a mail message between agents or humans.
 type Message struct {
 	ID        string    `json:"id"`
@@ -56,6 +103,31 @@ type Message struct {
 	Priority  int       `json:"priority,omitempty"`
 	CC        []string  `json:"cc,omitempty"`
 	Rig       string    `json:"rig,omitempty"`
+}
+
+// IdempotentSendRequest is the immutable request protected by an idempotency
+// key. A retry must repeat all five fields exactly; changing From, To, Subject,
+// or Body while reusing the key is a conflict.
+type IdempotentSendRequest struct {
+	From           string
+	To             string
+	Subject        string
+	Body           string
+	IdempotencyKey string
+}
+
+// IdempotentSendResult reports the original message and whether this call
+// created it. Created is false for an exact retry.
+type IdempotentSendResult struct {
+	Message Message
+	Created bool
+}
+
+// IdempotentSender is the optional mail capability used by gc mail send
+// --idempotency-key. Implementations must atomically bind one key to one
+// immutable request and message in their authoritative message store.
+type IdempotentSender interface {
+	SendIdempotent(IdempotentSendRequest) (IdempotentSendResult, error)
 }
 
 // HandoffIntent is the domain-shaped request for handoff mail. It lets the


### PR DESCRIPTION
## Summary

- add backward-compatible `gc mail send --idempotency-key` for retry-safe single-recipient sends
- atomically create a durable key record and its ephemeral message in the selected messaging-class store
- return the original message ID for an exact retry, and fail closed for conflicting or corrupt mappings
- reject keyed sends before writing when the backend cannot provide real transaction rollback
- preserve atomic transaction and ID-prefix capabilities through CLI store wrappers, including migrated storage bindings

The key record and message use deterministic IDs in the store's own namespace. A full SHA-256 key digest provides the unique-ID race gate, while the record retains the exact bounded key and a length-framed fingerprint of sender, recipient, subject, and body. The record is closed, durable, and no-history, so purging the ephemeral message does not free the key for reuse.

No issue is linked: this is a self-contained reliability improvement for automation retrying `gc mail send` after ambiguous outcomes.

## Compatibility and failure semantics

- sends without `--idempotency-key` keep the existing dispatch path unchanged
- `--all` and `--idempotency-key` are mutually exclusive
- keys are valid UTF-8, 1-128 bytes, and may not contain whitespace/control characters
- SQLite and native Dolt advertise atomic rollback; sequential legacy/file/memory/exec stores fail before either row is written
- `--notify` remains a separate per-invocation action because nudges may live in a different storage class and cannot join the messaging-store transaction
- no schema or custom bead-type migration is required; the closed key record uses the built-in `message` type plus a private metadata marker

## Testing

- [ ] `make check` (the monolithic `go test ./cmd/gc` portion hit its package-wide 10-minute timeout; changed-path and sharded evidence is below)
- [x] `make check-docs`
- [ ] `make test-integration` (no controller/workflow rollout performed)
- [x] `go test ./internal/mail/...`
- [x] `go test ./cmd/gc -run 'Test(Mail|EmittingClassStore|BeadPolicyStore|CLI.*Mail|ClassStore)' -count=1`
- [x] `go test ./cmd/gc -run '^(TestMailSendIdempotency|TestBeadPolicyStorePreservesAtomic|TestEmittingClassStoreTransaction|TestCLIKeyedMailTransaction)' -count=1`
- [x] `go test -race ./internal/mail/beadmail -run '^TestSendIdempotentConcurrentCallersCreateOneMessage$' -count=1`
- [x] `go vet ./internal/mail/... ./cmd/gc`
- [x] `make lint-changed` (0 issues)
- [x] regenerated `docs/reference/cli.md` with `gc gen-doc`; `git diff --check` passes

The tests cover exact replay/event-once behavior, conflicting payloads, corrupt mapping refusal, second-create rollback with no partial record, 16 concurrent callers with exactly one winner, non-atomic and empty-namespace pre-write refusal, migrated messaging-binding placement, and transaction-event emission only after commit.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes (none; keyed sends are opt-in)
