### PR TITLE
fix: resolve configured namepool members for sling

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -400,6 +400,14 @@ func resolvePoolInstance(cfg *config.City, input string) (config.Agent, bool) {
 		if !a.SupportsInstanceExpansion() || a.UsesCanonicalSingletonPoolIdentity() {
 			continue
 		}
+		for slot, instanceName := range a.NamepoolNames {
+			if sp.Max >= 0 && slot+1 > sp.Max {
+				break
+			}
+			if input == a.QualifiedInstanceName(instanceName) {
+				return deepCopyAgent(&a, instanceName, a.Dir), true
+			}
+		}
 		prefix := a.QualifiedName() + "-"
 		if !strings.HasPrefix(input, prefix) {
 			continue
@@ -425,6 +433,18 @@ func matchPoolInstance(a config.Agent, input string) (config.Agent, bool) {
 	sp := scaleParamsFor(&a)
 	if !a.SupportsInstanceExpansion() || a.UsesCanonicalSingletonPoolIdentity() {
 		return config.Agent{}, false
+	}
+	for slot, instanceName := range a.NamepoolNames {
+		if sp.Max >= 0 && slot+1 > sp.Max {
+			break
+		}
+		candidate := instanceName
+		if a.BindingName != "" {
+			candidate = a.BindingName + "." + instanceName
+		}
+		if input == candidate {
+			return deepCopyAgent(&a, instanceName, a.Dir), true
+		}
 	}
 	prefix := a.Name + "-"
 	if !strings.HasPrefix(input, prefix) {

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -389,6 +389,41 @@ func TestResolveAgentIdentityResolvesBindingQualifiedPoolInstance(t *testing.T) 
 	}
 }
 
+// TestResolveAgentIdentityResolvesBindingQualifiedNamepoolMember reproduces
+// gc-lgoak: status exposes a bounded pool's configured themed member, but the
+// CLI dispatch resolver previously recognized only numeric "template-N"
+// members. A target such as "sites/gastown.furiosa" therefore failed before
+// sling could collapse it back to the pool route.
+func TestResolveAgentIdentityResolvesBindingQualifiedNamepoolMember(t *testing.T) {
+	max := 1
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			BindingName:       "gastown",
+			Dir:               "sites",
+			MaxActiveSessions: &max,
+			NamepoolNames:     []string{"furiosa", "nux"},
+		}},
+	}
+
+	a, ok := resolveAgentIdentity(cfg, "sites/gastown.furiosa", "")
+	if !ok {
+		t.Fatal("resolveAgentIdentity(sites/gastown.furiosa) = (_, false), want configured namepool member")
+	}
+	if got := a.QualifiedName(); got != "sites/gastown.furiosa" {
+		t.Fatalf("QualifiedName() = %q, want %q", got, "sites/gastown.furiosa")
+	}
+	if got := a.PoolName; got != "sites/gastown.polecat" {
+		t.Fatalf("PoolName = %q, want pool route %q", got, "sites/gastown.polecat")
+	}
+	if _, ok := resolveAgentIdentity(cfg, "sites/gastown.nux", ""); ok {
+		t.Fatal("namepool member above max_active_sessions resolved")
+	}
+	if _, ok := resolveAgentIdentity(cfg, "sites/gastown.ghost", ""); ok {
+		t.Fatal("unknown namepool member resolved")
+	}
+}
+
 func TestResolveAgentIdentityUsesRigContextForScopeUnqualifiedControlDispatcher(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{


### PR DESCRIPTION
## Summary

- resolve configured bounded namepool members in the CLI agent resolver
- preserve the base pool route when synthesizing a themed member
- reject members outside `max_active_sessions` and unknown names

## Root cause

`gc status` expands bounded pools through `namepool.txt`, so it can expose identities such as `sites/gastown.furiosa`. The CLI resolver used by `gc sling` only synthesized numeric pool identities (`polecat-N`). The displayed themed identity therefore failed before dispatch with `target_resolve_failed`.

This is separate from the `work_query` runtime-start behavior discussed in draft #5545: this failure occurs earlier, during target resolution.

## Validation

- regression test failed before the implementation and passes after it
- `go test -count=1 ./cmd/gc -run "^TestResolveAgentIdentity"`
- `go vet ./cmd/gc`
- `GC_FAST_UNIT=1 go test -count=1 -timeout=20m ./cmd/gc` (`ok`, 1045.526s)
- `gofmt` and `git diff --check`

The canonical parallel test runner could not complete on the local host because the macOS data volume had only about 1.5 GiB free and Go build work directories failed with `no space left on device`; GitHub CI is therefore the authoritative broad gate.