### PR TITLE
feat: let pack runtimes opt into oversized prompt delivery

### DIFF
--- a/cmd/gc/prompt_delivery.go
+++ b/cmd/gc/prompt_delivery.go
@@ -74,9 +74,12 @@ const (
 // promptDeliverySupportFor confirms oversized-prompt support from the
 // runtime's own identity rather than assuming any given transport (including
 // ACP-style protocols) is argv-bound. Only runtimes this package has
-// positively classified return a non-default value; every other name —
-// including future/custom runtimes — hard-fails via the zero value.
-func promptDeliverySupportFor(runtimeName string) promptDeliverySupport {
+// positively classified, plus a pack-declared runtime whose
+// [runtimes.<name>] entry opts in via prompt_delivery (packRuntimes, keyed
+// by name — see config.DiscoveredRuntime.PromptDelivery), return a
+// non-default value; every other name — including future/custom runtimes —
+// hard-fails via the zero value.
+func promptDeliverySupportFor(runtimeName string, packRuntimes map[string]config.DiscoveredRuntime) promptDeliverySupport {
 	name := strings.TrimSpace(runtimeName)
 	// The legacy exec spelling constructs the same native t3bridge provider
 	// (runtime_registry.go RegisterPrefix("exec:")), so it is argv-safe too.
@@ -104,6 +107,9 @@ func promptDeliverySupportFor(runtimeName string) promptDeliverySupport {
 	case "t3bridge":
 		return promptDeliverySupportArgvSafe
 	default:
+		if packRuntimes[name].PromptDelivery == config.PromptDeliveryNudgeFallback {
+			return promptDeliverySupportNudgeFallback
+		}
 		return promptDeliverySupportUnsupported
 	}
 }
@@ -136,7 +142,13 @@ var errOversizedPromptUnsupportedRuntime = errors.New("startup prompt exceeds ar
 // An empty prompt delivers nothing. Judgment about prompt *content* stays in
 // templates; this function only routes an already-rendered prompt and reports
 // delivered/not-delivered.
-func promptDelivery(prompt string, isACP bool, rp *config.ResolvedProvider, nudge string, runtimeName string) (promptDeliveryResult, error) {
+//
+// packRuntimes is the city's pack-declared runtime registry
+// (config.City.Runtimes), consulted only for the oversized-prompt guard's
+// promptDeliverySupportFor classification; nil is fine when runtimeName is a
+// builtin runtime. promptDelivery remains pure/I-O-free: no provider
+// construction, handshake, or subprocess spawn happens here.
+func promptDelivery(prompt string, isACP bool, rp *config.ResolvedProvider, nudge string, runtimeName string, packRuntimes map[string]config.DiscoveredRuntime) (promptDeliveryResult, error) {
 	res := promptDeliveryResult{Nudge: nudge}
 	if prompt == "" {
 		return res, nil
@@ -154,7 +166,7 @@ func promptDelivery(prompt string, isACP bool, rp *config.ResolvedProvider, nudg
 
 	suffix := shellquote.Quote(prompt)
 	if len(prompt) >= maxPromptSuffixRawBytes || len(suffix) >= maxPromptSuffixQuotedBytes {
-		switch promptDeliverySupportFor(runtimeName) {
+		switch promptDeliverySupportFor(runtimeName, packRuntimes) {
 		case promptDeliverySupportArgvSafe:
 			// Falls through to normal argv delivery below: this runtime
 			// never carries the prompt through a size-limited argv, so the

--- a/cmd/gc/prompt_delivery_test.go
+++ b/cmd/gc/prompt_delivery_test.go
@@ -92,7 +92,7 @@ func TestPromptDelivery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := promptDelivery(tt.promp, tt.isACP, tt.rp, tt.nudge, tt.runtime)
+			got, err := promptDelivery(tt.promp, tt.isACP, tt.rp, tt.nudge, tt.runtime, nil)
 			if err != nil {
 				t.Fatalf("promptDelivery() unexpected error: %v", err)
 			}
@@ -143,7 +143,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 		if len(quoted) >= maxPromptSuffixQuotedBytes {
 			t.Fatalf("fixture invalid: quoted len %d already at/above quoted threshold %d", len(quoted), maxPromptSuffixQuotedBytes)
 		}
-		got, err := promptDelivery(prompt, false, arg, "wake", "tmux")
+		got, err := promptDelivery(prompt, false, arg, "wake", "tmux", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error: %v", err)
 		}
@@ -158,7 +158,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 		if len(prompt) < maxPromptSuffixRawBytes {
 			t.Fatalf("fixture invalid: raw len %d below raw threshold %d", len(prompt), maxPromptSuffixRawBytes)
 		}
-		got, err := promptDelivery(prompt, false, arg, "wake", "tmux")
+		got, err := promptDelivery(prompt, false, arg, "wake", "tmux", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error: %v", err)
 		}
@@ -187,7 +187,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 		if len(quoted) < maxPromptSuffixQuotedBytes {
 			t.Fatalf("fixture invalid: quoted len %d below quoted threshold %d", len(quoted), maxPromptSuffixQuotedBytes)
 		}
-		got, err := promptDelivery(prompt, false, arg, "wake", "tmux")
+		got, err := promptDelivery(prompt, false, arg, "wake", "tmux", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error: %v", err)
 		}
@@ -207,7 +207,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 		if len(prompt) < maxPromptSuffixRawBytes {
 			t.Fatalf("fixture invalid: expected >= %d raw bytes from UTF-8 repeats, got %d", maxPromptSuffixRawBytes, len(prompt))
 		}
-		got, err := promptDelivery(prompt, false, arg, "wake", "tmux")
+		got, err := promptDelivery(prompt, false, arg, "wake", "tmux", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error: %v", err)
 		}
@@ -222,7 +222,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 	t.Run("flag mode is also guarded", func(t *testing.T) {
 		flag := &config.ResolvedProvider{PromptMode: "flag", PromptFlag: "--prompt"}
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
-		got, err := promptDelivery(prompt, false, flag, "wake", "tmux")
+		got, err := promptDelivery(prompt, false, flag, "wake", "tmux", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error: %v", err)
 		}
@@ -236,7 +236,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 
 	t.Run("ACP is unaffected by size", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes*2)
-		got, err := promptDelivery(prompt, true, arg, "wake", "subprocess")
+		got, err := promptDelivery(prompt, true, arg, "wake", "subprocess", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error for ACP: %v", err)
 		}
@@ -252,7 +252,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 	t.Run("prompt_mode none is unaffected by size", func(t *testing.T) {
 		none := &config.ResolvedProvider{PromptMode: "none"}
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes*2)
-		got, err := promptDelivery(prompt, false, none, "wake", "subprocess")
+		got, err := promptDelivery(prompt, false, none, "wake", "subprocess", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error for prompt_mode=none: %v", err)
 		}
@@ -267,7 +267,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 	t.Run("argv-safe runtime (t3bridge) is unaffected by size", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes*2)
 		quoted := shellquote.Quote(prompt)
-		got, err := promptDelivery(prompt, false, arg, "wake", "t3bridge")
+		got, err := promptDelivery(prompt, false, arg, "wake", "t3bridge", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error for t3bridge: %v", err)
 		}
@@ -280,7 +280,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 
 	t.Run("nudge-fallback runtime (tmux) routes through nudge with no argv bytes", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
-		got, err := promptDelivery(prompt, false, arg, "wake", "tmux")
+		got, err := promptDelivery(prompt, false, arg, "wake", "tmux", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error for tmux: %v", err)
 		}
@@ -294,7 +294,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 
 	t.Run("empty runtime name (stock default) routes through nudge, not hard-fail", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
-		got, err := promptDelivery(prompt, false, arg, "wake", "")
+		got, err := promptDelivery(prompt, false, arg, "wake", "", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error for the stock default (empty) runtime name: %v", err)
 		}
@@ -309,7 +309,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 	t.Run("legacy t3bridge exec spelling stays argv-safe", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
 		quoted := shellquote.Quote(prompt)
-		got, err := promptDelivery(prompt, false, arg, "wake", "exec:/usr/lib/gc/gc-session-t3")
+		got, err := promptDelivery(prompt, false, arg, "wake", "exec:/usr/lib/gc/gc-session-t3", nil)
 		if err != nil {
 			t.Fatalf("promptDelivery() unexpected error for the legacy t3bridge exec spelling: %v", err)
 		}
@@ -321,9 +321,40 @@ func TestPromptDeliveryOversized(t *testing.T) {
 		}
 	})
 
+	t.Run("pack-declared nudge-fallback runtime routes through nudge with no argv bytes", func(t *testing.T) {
+		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
+		packRuntimes := map[string]config.DiscoveredRuntime{
+			"acme-runtime": {Name: "acme-runtime", PromptDelivery: "nudge-fallback"},
+		}
+		got, err := promptDelivery(prompt, false, arg, "wake", "acme-runtime", packRuntimes)
+		if err != nil {
+			t.Fatalf("promptDelivery() unexpected error for a pack-declared nudge-fallback runtime: %v", err)
+		}
+		if got.PromptSuffix != "" || got.PromptFlag != "" {
+			t.Errorf("promptDelivery() pack-declared nudge-fallback oversized must carry zero argv bytes, got PromptSuffix len=%d PromptFlag=%q", len(got.PromptSuffix), got.PromptFlag)
+		}
+		if !got.Delivered || !got.OversizedFallback {
+			t.Errorf("promptDelivery() pack-declared nudge-fallback oversized = %+v, want Delivered=true OversizedFallback=true", promptDeliveryResultLens(got))
+		}
+	})
+
+	t.Run("pack-declared runtime without prompt_delivery still hard-fails", func(t *testing.T) {
+		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
+		packRuntimes := map[string]config.DiscoveredRuntime{
+			"acme-runtime": {Name: "acme-runtime"},
+		}
+		_, err := promptDelivery(prompt, false, arg, "wake", "acme-runtime", packRuntimes)
+		if err == nil {
+			t.Fatalf("promptDelivery() error = nil, want a hard-fail error for a pack runtime with no prompt_delivery declared")
+		}
+		if !errors.Is(err, errOversizedPromptUnsupportedRuntime) {
+			t.Errorf("promptDelivery() error = %v, want errors.Is(err, errOversizedPromptUnsupportedRuntime)", err)
+		}
+	})
+
 	t.Run("unsupported runtime (subprocess) hard-fails before Start", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
-		got, err := promptDelivery(prompt, false, arg, "wake", "subprocess")
+		got, err := promptDelivery(prompt, false, arg, "wake", "subprocess", nil)
 		if err == nil {
 			t.Fatalf("promptDelivery() error = nil, want a hard-fail error for subprocess with an oversized prompt")
 		}
@@ -337,7 +368,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 
 	t.Run("unknown/unclassified runtime name defaults to hard-fail, not silent argv passthrough", func(t *testing.T) {
 		prompt := repeatToBytes("a", maxPromptSuffixRawBytes)
-		_, err := promptDelivery(prompt, false, arg, "wake", "some-future-custom-runtime")
+		_, err := promptDelivery(prompt, false, arg, "wake", "some-future-custom-runtime", nil)
 		if err == nil {
 			t.Fatalf("promptDelivery() error = nil, want a hard-fail error for an unclassified runtime with an oversized prompt")
 		}
@@ -350,7 +381,7 @@ func TestPromptDeliveryOversized(t *testing.T) {
 		const marker = "TESTMARKERMUSTNOTLEAK"
 		prompt := marker + repeatToBytes("a", maxPromptSuffixRawBytes)
 		quoted := shellquote.Quote(prompt)
-		_, err := promptDelivery(prompt, false, arg, "wake", "subprocess")
+		_, err := promptDelivery(prompt, false, arg, "wake", "subprocess", nil)
 		if err == nil {
 			t.Fatalf("promptDelivery() error = nil, want hard-fail error")
 		}
@@ -369,26 +400,47 @@ func TestPromptDeliveryOversized(t *testing.T) {
 
 func TestPromptDeliverySupportFor(t *testing.T) {
 	tests := []struct {
-		runtime string
-		want    promptDeliverySupport
+		runtime  string
+		runtimes map[string]config.DiscoveredRuntime
+		want     promptDeliverySupport
 	}{
-		{"tmux", promptDeliverySupportNudgeFallback},
-		{"t3bridge", promptDeliverySupportArgvSafe},
-		{"exec:/usr/lib/gc/gc-session-t3", promptDeliverySupportArgvSafe},
-		{"subprocess", promptDeliverySupportUnsupported},
-		{"", promptDeliverySupportNudgeFallback},
-		{" tmux", promptDeliverySupportNudgeFallback},
-		{"herdr", promptDeliverySupportNudgeFallback},
-		{"k8s", promptDeliverySupportNudgeFallback},
-		{"exec:./run.sh", promptDeliverySupportUnsupported},
-		{"ssh:host", promptDeliverySupportUnsupported},
-		{"hybrid", promptDeliverySupportNudgeFallback},
-		{"auto", promptDeliverySupportUnsupported},
-		{"totally-unknown-custom-runtime", promptDeliverySupportUnsupported},
+		{runtime: "tmux", want: promptDeliverySupportNudgeFallback},
+		{runtime: "t3bridge", want: promptDeliverySupportArgvSafe},
+		{runtime: "exec:/usr/lib/gc/gc-session-t3", want: promptDeliverySupportArgvSafe},
+		{runtime: "subprocess", want: promptDeliverySupportUnsupported},
+		{runtime: "", want: promptDeliverySupportNudgeFallback},
+		{runtime: " tmux", want: promptDeliverySupportNudgeFallback},
+		{runtime: "herdr", want: promptDeliverySupportNudgeFallback},
+		{runtime: "k8s", want: promptDeliverySupportNudgeFallback},
+		{runtime: "exec:./run.sh", want: promptDeliverySupportUnsupported},
+		{runtime: "ssh:host", want: promptDeliverySupportUnsupported},
+		{runtime: "hybrid", want: promptDeliverySupportNudgeFallback},
+		{runtime: "auto", want: promptDeliverySupportUnsupported},
+		{runtime: "totally-unknown-custom-runtime", want: promptDeliverySupportUnsupported},
+		{
+			runtime:  "acme-runtime",
+			runtimes: map[string]config.DiscoveredRuntime{"acme-runtime": {Name: "acme-runtime", PromptDelivery: "nudge-fallback"}},
+			want:     promptDeliverySupportNudgeFallback,
+		},
+		{
+			runtime:  " acme-runtime",
+			runtimes: map[string]config.DiscoveredRuntime{"acme-runtime": {Name: "acme-runtime", PromptDelivery: "nudge-fallback"}},
+			want:     promptDeliverySupportNudgeFallback,
+		},
+		{
+			runtime:  "acme-runtime-unset",
+			runtimes: map[string]config.DiscoveredRuntime{"acme-runtime-unset": {Name: "acme-runtime-unset"}},
+			want:     promptDeliverySupportUnsupported,
+		},
+		{
+			runtime:  "acme-runtime-missing",
+			runtimes: map[string]config.DiscoveredRuntime{"other-runtime": {Name: "other-runtime", PromptDelivery: "nudge-fallback"}},
+			want:     promptDeliverySupportUnsupported,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.runtime, func(t *testing.T) {
-			if got := promptDeliverySupportFor(tt.runtime); got != tt.want {
+			if got := promptDeliverySupportFor(tt.runtime, tt.runtimes); got != tt.want {
 				t.Errorf("promptDeliverySupportFor(%q) = %v, want %v", tt.runtime, got, tt.want)
 			}
 		})

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -106,6 +106,12 @@ type TemplateParams struct {
 	// EffectiveSessionProvider is the actual session provider after applying
 	// city-level defaults.
 	EffectiveSessionProvider string
+	// CityRuntimes is the city's pack-declared runtime registry
+	// (config.City.Runtimes), keyed by selection name. Consulted by
+	// promptDelivery's oversized-prompt guard so a pack-declared runtime
+	// (EffectiveSessionProvider naming one not in the builtin switch) can opt
+	// into nudge-fallback delivery. Nil when no city is bound (p.city == nil).
+	CityRuntimes map[string]config.DiscoveredRuntime
 	// DependencyOnly marks a realized cold slot kept only so dependency wake
 	// has something concrete to wake even when pool check wants zero.
 	DependencyOnly bool
@@ -720,6 +726,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	}
 	params.SessionOverride = cfgAgent.Session
 	params.EffectiveSessionProvider = effectiveSessionProvider(cfgAgent.Session, p.sessionProvider)
+	if p.city != nil {
+		params.CityRuntimes = p.city.Runtimes
+	}
 	return params, nil
 }
 
@@ -864,7 +873,7 @@ func templateParamsToConfigWithDelivery(tp TemplateParams) (runtime.Config, prom
 	// a first-turn delivery mechanism. Without argv/flag/nudge delivery, freshly
 	// spawned workers sit idle at the provider prompt. The routing policy lives
 	// in the pure promptDelivery derivation.
-	delivery, err := promptDelivery(tp.Prompt, tp.IsACP, tp.ResolvedProvider, tp.Hints.Nudge, tp.EffectiveSessionProvider)
+	delivery, err := promptDelivery(tp.Prompt, tp.IsACP, tp.ResolvedProvider, tp.Hints.Nudge, tp.EffectiveSessionProvider, tp.CityRuntimes)
 	configuredMode := "arg"
 	switch {
 	case tp.IsACP:

--- a/docs/reference/schema/pack-schema.json
+++ b/docs/reference/schema/pack-schema.json
@@ -1028,6 +1028,13 @@
         "protocol": {
           "type": "integer",
           "description": "Protocol is the RPP version the executable speaks. Version 0 is\nthe only version today; the declaration exists so future protocol\nbumps fail at composition instead of at session start."
+        },
+        "prompt_delivery": {
+          "type": "string",
+          "enum": [
+            "nudge-fallback"
+          ],
+          "description": "PromptDelivery opts this runtime into a non-default oversized-prompt\ndelivery strategy (cmd/gc promptDeliverySupportFor). Unset (the zero\nvalue) keeps today's behavior: an oversized prompt hard-fails for any\nruntime this package cannot positively classify. The only other\naccepted value is \"nudge-fallback\", asserting the runtime has a\nworking post-start Nudge path an oversized prompt can reroute\nthrough. This is a pack-composition-time assertion, not something gc\nverifies against the runtime executable — see\ndocs/reference/specs/pack-spec.md sec 1.2.8."
         }
       },
       "additionalProperties": false,

--- a/docs/reference/schema/pack-schema.txt
+++ b/docs/reference/schema/pack-schema.txt
@@ -1028,6 +1028,13 @@
         "protocol": {
           "type": "integer",
           "description": "Protocol is the RPP version the executable speaks. Version 0 is\nthe only version today; the declaration exists so future protocol\nbumps fail at composition instead of at session start."
+        },
+        "prompt_delivery": {
+          "type": "string",
+          "enum": [
+            "nudge-fallback"
+          ],
+          "description": "PromptDelivery opts this runtime into a non-default oversized-prompt\ndelivery strategy (cmd/gc promptDeliverySupportFor). Unset (the zero\nvalue) keeps today's behavior: an oversized prompt hard-fails for any\nruntime this package cannot positively classify. The only other\naccepted value is \"nudge-fallback\", asserting the runtime has a\nworking post-start Nudge path an oversized prompt can reroute\nthrough. This is a pack-composition-time assertion, not something gc\nverifies against the runtime executable — see\ndocs/reference/specs/pack-spec.md sec 1.2.8."
         }
       },
       "additionalProperties": false,

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -473,10 +473,25 @@ protocol = 0
 |---|---|---|
 | `command` | Required. The runtime executable. A bare name (no path separator) is resolved on PATH at session start. A relative path (any other value containing a separator) is anchored at the declaring pack directory during load. An absolute path is used as written. | required |
 | `protocol` | The RPP version the executable speaks. `0` is the only version today; any other value fails composition. | current |
+| `prompt_delivery` | Opts this runtime into a non-default oversized-prompt delivery strategy. Unset (default) or `"nudge-fallback"`; any other value fails composition. | current |
 
 `<name>` must not contain `:`, `/`, or whitespace, since `:` is reserved for
 prefix-form selection names (`exec:...`) and `/` and whitespace keep selection
 names shell- and TOML-friendly.
+
+`prompt_delivery` controls what happens when a rendered startup prompt is too
+large for an OS `exec()` argv (see the argv-safety guard in
+`cmd/gc/prompt_delivery.go`). A runtime `gc` does not already classify as
+argv-safe or nudge-capable hard-fails on an oversized prompt by default —
+unset is that default. Declaring `prompt_delivery = "nudge-fallback"`
+asserts the executable has a working post-start Nudge path (the same RPP
+Nudge operation builtin nudge-fallback runtimes like `tmux` use) that an
+oversized prompt can reroute through instead of argv. Like `command`, this
+is a pack-composition-time assertion: `gc` accepts the declaration as
+written and does not verify it against the runtime executable, at compose
+time or via the `pack-runtimes` doctor check below — a pack declaring
+`nudge-fallback` for an executable with no real Nudge support will not fail
+until an oversized prompt actually reaches that runtime at session start.
 
 City composition registers declared runtimes into a city-wide selection
 registry (`City.Runtimes`), including runtimes declared by rig-imported packs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1121,6 +1121,16 @@ type PackRuntimeEntry struct {
 	// the only version today; the declaration exists so future protocol
 	// bumps fail at composition instead of at session start.
 	Protocol int `toml:"protocol,omitempty"`
+	// PromptDelivery opts this runtime into a non-default oversized-prompt
+	// delivery strategy (cmd/gc promptDeliverySupportFor). Unset (the zero
+	// value) keeps today's behavior: an oversized prompt hard-fails for any
+	// runtime this package cannot positively classify. The only other
+	// accepted value is "nudge-fallback", asserting the runtime has a
+	// working post-start Nudge path an oversized prompt can reroute
+	// through. This is a pack-composition-time assertion, not something gc
+	// verifies against the runtime executable — see
+	// docs/reference/specs/pack-spec.md sec 1.2.8.
+	PromptDelivery string `toml:"prompt_delivery,omitempty" jsonschema:"enum=nudge-fallback"`
 }
 
 // PackCommandEntry declares a CLI subcommand provided by a pack.

--- a/internal/config/pack_runtimes.go
+++ b/internal/config/pack_runtimes.go
@@ -24,12 +24,23 @@ type DiscoveredRuntime struct {
 	// PackName and PackDir identify the declaring pack.
 	PackName string
 	PackDir  string
+	// PromptDelivery is the pack-declared oversized-prompt delivery
+	// strategy: "" (unset/default) or "nudge-fallback". See
+	// PackRuntimeEntry.PromptDelivery for the trust model.
+	PromptDelivery string
 }
 
 // supportedRuntimeProtocol is the highest RPP version this binary can
 // host. Mirrors runtime.ProtocolVersion0; kept as a local constant so the
 // config layer does not grow an import edge on internal/runtime.
 const supportedRuntimeProtocol = 0
+
+// PromptDeliveryNudgeFallback is the only non-default value
+// PackRuntimeEntry.PromptDelivery / DiscoveredRuntime.PromptDelivery
+// accepts. It asserts the declaring runtime has a working post-start Nudge
+// path that an oversized prompt can reroute through — consulted by cmd/gc's
+// promptDeliverySupportFor, not verified against the runtime executable.
+const PromptDeliveryNudgeFallback = "nudge-fallback"
 
 // packLocalRuntimes validates and resolves a pack's own [runtimes.<name>]
 // declarations. Pack-relative commands resolve against packDir; invalid
@@ -60,12 +71,18 @@ func packLocalRuntimes(tc *PackConfig, packDir string) ([]DiscoveredRuntime, err
 			return nil, fmt.Errorf("pack %q runtime %q: protocol %d not supported (this gc speaks RPP version %d)",
 				tc.Pack.Name, name, entry.Protocol, supportedRuntimeProtocol)
 		}
+		promptDelivery := strings.TrimSpace(entry.PromptDelivery)
+		if promptDelivery != "" && promptDelivery != PromptDeliveryNudgeFallback {
+			return nil, fmt.Errorf("pack %q runtime %q: prompt_delivery %q not supported (must be unset or %q)",
+				tc.Pack.Name, name, entry.PromptDelivery, PromptDeliveryNudgeFallback)
+		}
 		out = append(out, DiscoveredRuntime{
-			Name:     name,
-			Command:  resolveRuntimeCommand(command, packDir),
-			Protocol: entry.Protocol,
-			PackName: tc.Pack.Name,
-			PackDir:  packDir,
+			Name:           name,
+			Command:        resolveRuntimeCommand(command, packDir),
+			Protocol:       entry.Protocol,
+			PackName:       tc.Pack.Name,
+			PackDir:        packDir,
+			PromptDelivery: promptDelivery,
 		})
 	}
 	return out, nil
@@ -120,7 +137,8 @@ func mergeCityRuntimes(cfg *City, runtimes []DiscoveredRuntime) error {
 func sameRuntimeDeclaration(a, b DiscoveredRuntime) bool {
 	return samePackDir(a.PackDir, b.PackDir) &&
 		a.Command == b.Command &&
-		a.Protocol == b.Protocol
+		a.Protocol == b.Protocol &&
+		a.PromptDelivery == b.PromptDelivery
 }
 
 // samePackDir reports whether two pack directories resolve to the same absolute

--- a/internal/config/pack_runtimes_test.go
+++ b/internal/config/pack_runtimes_test.go
@@ -18,6 +18,7 @@ schema = 1
 [runtimes.cloudflare]
 command = "scripts/gc-runtime-cloudflare"
 protocol = 0
+prompt_delivery = "nudge-fallback"
 
 [runtimes.bridge]
 command = "gc-runtime-bridge"
@@ -48,6 +49,9 @@ command = "gc-runtime-bridge"
 	if cf.Name != "cloudflare" {
 		t.Errorf("Name = %q, want cloudflare", cf.Name)
 	}
+	if cf.PromptDelivery != "nudge-fallback" {
+		t.Errorf("PromptDelivery = %q, want nudge-fallback", cf.PromptDelivery)
+	}
 
 	// Bare names (no path separator) stay as-is for PATH lookup.
 	br, ok := cfg.Runtimes["bridge"]
@@ -56,6 +60,11 @@ command = "gc-runtime-bridge"
 	}
 	if br.Command != "gc-runtime-bridge" {
 		t.Errorf("bare command = %q, want gc-runtime-bridge (PATH name)", br.Command)
+	}
+	// prompt_delivery is opt-in: an undeclared runtime must not inherit any
+	// value merely by sharing a pack.toml with a declaring sibling.
+	if br.PromptDelivery != "" {
+		t.Errorf("PromptDelivery = %q, want empty (unset/default) for bridge", br.PromptDelivery)
 	}
 }
 
@@ -263,6 +272,28 @@ func TestMergeCityRuntimes_SameDirReDeclarationDedupes(t *testing.T) {
 	}
 }
 
+func TestMergeCityRuntimes_SameDirDifferentPromptDeliveryConflicts(t *testing.T) {
+	// Same resolved pack directory/command/protocol but a different declared
+	// PromptDelivery is not a diamond-import identical re-declaration: it is a
+	// genuine conflict a caller must not silently dedupe away, matching the
+	// existing treatment of a differing command or protocol.
+	cfg := &City{}
+	dir := t.TempDir()
+	a := DiscoveredRuntime{Name: "common", Command: "gc-runtime", Protocol: 0, PackName: "shared", PackDir: dir, PromptDelivery: "nudge-fallback"}
+	b := DiscoveredRuntime{Name: "common", Command: "gc-runtime", Protocol: 0, PackName: "shared", PackDir: dir, PromptDelivery: ""}
+
+	if err := mergeCityRuntimes(cfg, []DiscoveredRuntime{a}); err != nil {
+		t.Fatalf("first declaration must register: %v", err)
+	}
+	err := mergeCityRuntimes(cfg, []DiscoveredRuntime{b})
+	if err == nil {
+		t.Fatal("same dir/command/protocol with a different declared prompt_delivery must conflict, not dedupe")
+	}
+	if !strings.Contains(err.Error(), "common") {
+		t.Errorf("error %q should name the runtime", err)
+	}
+}
+
 func TestExpandCityPacks_PackRuntimeValidation(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -326,6 +357,15 @@ command = "run.sh"
 command = "run.sh"
 `,
 			wantErr: "must not contain",
+		},
+		{
+			name: "invalid prompt_delivery value",
+			toml: `
+[runtimes.foo]
+command = "run.sh"
+prompt_delivery = "bogus"
+`,
+			wantErr: "prompt_delivery",
 		},
 	}
 	for _, tc := range cases {

--- a/release-gates/ga-ggx43k-pack-runtime-prompt-delivery-gate.md
+++ b/release-gates/ga-ggx43k-pack-runtime-prompt-delivery-gate.md
@@ -1,0 +1,103 @@
+# Release gate: pack runtime prompt-delivery opt-in (`ga-ggx43k`)
+
+- Overall verdict: **PASS with attributed/waived raw test failures**
+- Evaluated: 2026-09-01 PDT / 2026-09-01 UTC
+- Deploy mode: `remote`; push remote: `origin`
+- Reviewed deploy source: `c0e16a482397e8f94408463809d931ea229103b4`
+- Source branch: `builder/ga-s5y62b.1` (provenance only)
+- Base evaluated: `origin/main@c374d52479c5ccb112d2a804b36526f777b203da`
+- Review bead: `ga-3juiyl`
+- Build bead: `ga-s5y62b.1`
+
+`docs/PROJECT_MANIFEST.md` is not present at the reviewed commit, so this gate
+uses the seven release criteria embedded in `mol-deployer-gate` and the
+deployer prompt. The pre-flight query found no pull request associated with
+the reviewed commit; the normal deploy path applies.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-3juiyl` is closed with reason `pass` on the exact reviewed commit. Its notes record no style, security, specification, or coverage finding. |
+| 2 | Acceptance criteria met | **PASS** | Independent diff inspection confirms `[runtimes.<name>].prompt_delivery = "nudge-fallback"` opts a pack-declared runtime into oversized-prompt nudge delivery; unset remains fail-closed; invalid values fail pack/city composition; differing diamond re-declarations conflict; and the sibling `internal/runtime/exec/json.go` / `internal/config/resolve.go` scope is untouched. All 63 diff-owned cases pass by name. |
+| 3 | Tests pass | **PASS with attributed/waived raw failures** | The documented complete matrix, `make test-local-full-parallel`, scheduled all 40 jobs and completed **37 PASS / 3 FAIL / 0 SKIP jobs**. Four non-diff-owned test failures are retained and adjudicated below; no candidate-owned failure remains. All six `cmd/gc` process shards required for this diff passed. |
+| 3a | Non-diff-owned failures attributed | **PASS** | `TestBdFlagManifestCurrent` is attributed to `ga-f0uceo`; `TestE2E_SuspendResume_City` is attributed to consolidated tracker `ga-vkhfnj`; and the exact beads#4566 dirty-schema failures in `TestCleanInstallTutorialPath` and `TestGCLiveContract_BeadsAndEvents` remain **FAIL-WAIVED** under the mayor standing authorization on `ga-6bnc42`, with current sightings recorded on `ga-vkhfnj` and `ga-lpfjhc`. Full evidence is below. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy`, fresh-cache affected-package lint, changed-file formatting, `go vet ./...`, and `git diff --check origin/main...HEAD` passed. The fresh-cache lint invocation reported `0 issues`. |
+| 3c | CI-config lane run | **PASS / n/a** | No workflow, job matrix, timeout, required-check list, runner policy, or CI configuration changed. |
+| 4 | No high-severity review findings open | **PASS** | The closed review bead records no findings and no blocker; no HIGH or request-changes finding is open for this reviewed source. |
+| 5 | Final branch clean | **PASS** | The detached reviewed-source worktree was clean after the full matrix and static gates. This checklist is the deployer's only change and will be committed separately on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree origin/main c0e16a482397e8f94408463809d931ea229103b4` exited 0 and produced tree `83dd01b21c46cd892380e3e8873c4367e88fb57a`. The candidate was one commit behind and one ahead of the evaluated base; no bounded self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | One reviewed commit adds the pack-runtime prompt-delivery declaration, composition validation, runtime lookup plumbing, tests, specification text, and generated pack-schema projections. All nine files serve that one configuration feature. |
+
+## Build and smoke evidence
+
+- `make build`: **PASS**; built `bin/gc` from the reviewed commit.
+- `./bin/gc version`: **PASS** (`dev`).
+- `./bin/gc --help`: **PASS**.
+- `make check-schema`: **PASS**; regenerated reference files remained clean.
+- `make check-docs`: **PASS**.
+- Build log: `/var/tmp/ga-ggx43k-build.out`.
+
+## Criterion 3 evidence
+
+Environment established before the full run:
+
+- `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`
+- `TESTCONTAINERS_RYUK_DISABLED=true`
+- `EXTRA_TEST_ENV` passed both values through the repository's scrubbed test wrapper
+- rootless Podman 5.8.4 was reachable; the rig has no cached `dolt-tests-via-podman` cairn entry and the source contains no pinned `dolthub/dolt*` container tag
+
+Test evidence:
+
+- `test_cmd`: `EXTRA_TEST_ENV="DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true" make test-local-full-parallel`
+- `test_cmd_scope`: `full-suite`
+- `test_counts`: **37 PASS / 3 FAIL / 0 SKIP jobs**; the three red jobs contain four failing top-level test names
+- `full_log`: `/var/tmp/ga-ggx43k-full-suite.out`
+- `shard_logs`: `/var/tmp/gc-local-tests.DE18B8`
+- `skip_justification`: none; no `--- SKIP:` result was observed in any shard log
+- `ci_lane_run`: n/a; no CI-config change
+- `waiver_ref`: mayor standing authorization on `ga-6bnc42`, limited to the two exact beads#4566 dirty-schema failures below
+
+Diff-owned tests were re-run verbosely after the full matrix:
+
+- `cmd/gc/prompt_delivery_test.go`: `TestPromptDelivery`, `TestPromptDeliveryOversized`, and `TestPromptDeliverySupportFor` — **43/43 top-level/subtest results PASS, 0 FAIL, 0 SKIP**.
+- `internal/config/pack_runtimes_test.go`: all 12 changed top-level functions, including validation and conflicting `prompt_delivery` re-declaration — **20/20 top-level/subtest results PASS, 0 FAIL, 0 SKIP**.
+- `diff_tests_executed`: **63/63 PASS, 0 FAIL, 0 SKIP**.
+- Verbose log: `/var/tmp/ga-ggx43k-diff-tests.out`.
+
+### Raw failure attribution
+
+- `failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a), mechanism — attributed`
+  - `integration-packages-core-4-of-4` reported the tracker's exact installed-`bd` flag-manifest drift: `--cpu-profile`, `--database`, `--mem-profile`, `--no-color`, and command-specific flags are absent from `internal/bdflags`.
+  - The candidate does not touch `internal/bdflags` or the installed CLI. `go list -deps ./internal/bdflags` includes neither changed Go package, and there is no path overlap.
+  - Current sighting appended to the predating open tracker; raw log: `/var/tmp/gc-local-tests.DE18B8/integration-packages-core-4-of-4.log`.
+
+- `failure_attribution: TestE2E_SuspendResume_City -> ga-vkhfnj | clause 3(a), mechanism — attributed`
+  - `integration-rest-full-2-of-8` timed out after 93.73 seconds waiting for `citysus.report`, matching the consolidated whole-suite contention signature.
+  - This fixture declares no pack runtime and its startup prompt is below the oversized guard. The candidate's new branch is limited to oversized prompts for pack-declared runtimes, so it is not exercised by this path; no `test/integration` file changed and no test-load/resource baseline changed.
+  - Current sighting appended to the predating open tracker; raw log: `/var/tmp/gc-local-tests.DE18B8/integration-rest-full-2-of-8.log`.
+
+- `failure_attribution: TestCleanInstallTutorialPath -> ga-vkhfnj / ga-lpfjhc | clause 3(a), mechanism — raw FAIL-WAIVED by ga-6bnc42`
+  - Fixture `gc init` failed with the exact gastownhall/beads#4566 signature: pending schema migrations altered pre-existing dirty `comments`/`events` tables, followed by the missing `leases` table.
+  - The failure occurs during Dolt store bootstrap before prompt delivery. The candidate does not change schema migration, store bootstrap, resource census, or test targets.
+  - Current sighting appended to the consolidated open tracker and the standing-authorization record; raw log: `/var/tmp/gc-local-tests.DE18B8/integration-rest-full-2-of-8.log`.
+
+- `failure_attribution: TestGCLiveContract_BeadsAndEvents -> ga-vkhfnj / ga-lpfjhc | clause 3(a), mechanism — raw FAIL-WAIVED by ga-6bnc42`
+  - The rig-create fixture returned HTTP 500 because `bd init` hit the same beads#4566 pending-dirty-table signature for `issues`.
+  - This is store initialization before the candidate's pack-runtime prompt-delivery behavior can run. No migration or store-bootstrap path changed.
+  - Current sighting appended to the consolidated open tracker and the standing-authorization record; raw log: `/var/tmp/gc-local-tests.DE18B8/integration-rest-full-5-of-8.log`.
+
+## Policy and static evidence
+
+- `make test-ci-policy`: **PASS** (5 runner-policy tests, 15 CI-suite-coverage tests, `scripts/cipolicy`, `scripts/prwatchdog`, and the focused static-scope contracts).
+- `GOLANGCI_LINT_CACHE=/var/tmp/ga-ggx43k-golangci-cache LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=3d317457dd7a7ff68f1c0333f7eb5fb399b2016c make lint-affected`: **PASS**, `0 issues`.
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=3d317457dd7a7ff68f1c0333f7eb5fb399b2016c make fmt-check-changed`: **PASS**.
+- `go vet ./...`: **PASS**.
+- `git diff --check origin/main...HEAD`: **PASS**.
+- Static logs: `/var/tmp/ga-ggx43k-static.out` and `/var/tmp/ga-ggx43k-lint-affected.out`.
+
+## Disposition
+
+Gate PASS. Cut `deploy/ga-ggx43k-gate` from the exact reviewed source, commit
+this checklist there, push the isolated branch, and open a pull request. Merge
+authority remains with mayor/mpr; the deployer does not merge.


### PR DESCRIPTION
## What this changes

Pack authors can set `prompt_delivery = "nudge-fallback"` under `[runtimes.<name>]` when a custom runtime supports post-start nudge delivery. Gas City then starts the runtime without an oversized prompt argument and delivers that prompt through the runtime's nudge path, avoiding operating-system argument-size limits.

Runtimes that omit the setting keep the existing fail-closed behavior. Invalid values fail configuration composition, and conflicting declarations of the same runtime are rejected.

## Review notes

- This is explicit and default-off; the declaration is a pack author's trust assertion about the runtime's nudge support.
- The change covers pack-declared runtimes only and leaves the built-in exec runtime behavior unchanged.
- The generated pack schema and pack specification include the new field.

## Test plan

- [x] Exercise normal, oversized, opt-in, unset, invalid-value, and conflicting-redeclaration cases in `cmd/gc` and `internal/config`.
- [x] Run the full local test matrix, including all six `cmd/gc` process shards, with non-candidate infrastructure failures documented in the release gate.
- [x] Run build, CLI smoke, schema/docs synchronization, policy, affected lint, formatting, and `go vet ./...` checks.
- [x] Release gate: [`release-gates/ga-ggx43k-pack-runtime-prompt-delivery-gate.md`](release-gates/ga-ggx43k-pack-runtime-prompt-delivery-gate.md)