### PR TITLE
fix: skip local city anchors when session env already targets a remote city

### DIFF
--- a/internal/api/session_resolved_config_test.go
+++ b/internal/api/session_resolved_config_test.go
@@ -435,6 +435,64 @@ func TestCityAnchoredSessionEnvSkipsCityAnchorsWhenCityPathEmpty(t *testing.T) {
 	}
 }
 
+// TestCityAnchoredSessionEnvSkipsLocalAnchorsWhenRemoteTargeted is the
+// RED/GREEN regression for cr-vddb9.1: a nomad-routed remote session whose
+// provider env carries GC_CITY_URL or GC_CITY_CONTEXT must never also
+// receive the local city identity anchors (GC_CITY, GC_CITY_PATH,
+// GC_CITY_RUNTIME_DIR). Seeding both makes the nested gc binary in that
+// session fail closed at cmd/gc/remote_target.go's local-vs-remote conflict
+// guard with "conflicting targets" (matches the D2 failure in wisp
+// gcg--9223372036854774627 / session gcg--9223372036854774630 gating
+// cr-u4plc.1).
+func TestCityAnchoredSessionEnvSkipsLocalAnchorsWhenRemoteTargeted(t *testing.T) {
+	cityPath := t.TempDir()
+
+	t.Run("remote via GC_CITY_URL", func(t *testing.T) {
+		providerEnv := map[string]string{
+			"GC_CITY_URL":    "https://remote.example.test",
+			"PROVIDER_TOKEN": "ok",
+		}
+		got := cityAnchoredSessionEnv(cityPath, nil, providerEnv)
+		for _, key := range []string{"GC_CITY", "GC_CITY_PATH", "GC_CITY_RUNTIME_DIR"} {
+			if v, ok := got[key]; ok {
+				t.Errorf("%s = %q present, want absent when GC_CITY_URL targets a remote city", key, v)
+			}
+		}
+		if got["GC_CITY_URL"] != "https://remote.example.test" {
+			t.Errorf("GC_CITY_URL = %q, want preserved", got["GC_CITY_URL"])
+		}
+		if got["PROVIDER_TOKEN"] != "ok" {
+			t.Errorf("PROVIDER_TOKEN = %q, want ok", got["PROVIDER_TOKEN"])
+		}
+	})
+
+	t.Run("remote via GC_CITY_CONTEXT", func(t *testing.T) {
+		providerEnv := map[string]string{
+			"GC_CITY_CONTEXT": "remote-context",
+		}
+		got := cityAnchoredSessionEnv(cityPath, nil, providerEnv)
+		for _, key := range []string{"GC_CITY", "GC_CITY_PATH", "GC_CITY_RUNTIME_DIR"} {
+			if v, ok := got[key]; ok {
+				t.Errorf("%s = %q present, want absent when GC_CITY_CONTEXT targets a remote city", key, v)
+			}
+		}
+	})
+
+	t.Run("local — no remote keys present", func(t *testing.T) {
+		got := cityAnchoredSessionEnv(cityPath, nil, map[string]string{"PROVIDER_TOKEN": "ok"})
+		if got["GC_CITY"] != cityPath {
+			t.Errorf("GC_CITY = %q, want %q (anchors still seeded when no remote target present)", got["GC_CITY"], cityPath)
+		}
+		if got["GC_CITY_PATH"] != cityPath {
+			t.Errorf("GC_CITY_PATH = %q, want %q", got["GC_CITY_PATH"], cityPath)
+		}
+		wantRuntimeDir := filepath.Join(cityPath, ".gc", "runtime")
+		if got["GC_CITY_RUNTIME_DIR"] != wantRuntimeDir {
+			t.Errorf("GC_CITY_RUNTIME_DIR = %q, want %q", got["GC_CITY_RUNTIME_DIR"], wantRuntimeDir)
+		}
+	})
+}
+
 func TestResolvedSessionConfigForProviderSkipsStoredMCPMetadataForTmuxTransport(t *testing.T) {
 	cfg, err := resolvedSessionConfigForProvider(
 		"/tmp/test-city",

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -48,14 +48,18 @@ import (
 // regress per-dispatcher trace files for control-dispatcher sessions
 // restarted through the API. Dispatcher-trace handling stays the
 // responsibility of the caller that knows the qualified agent name.
+//
+// If the merged baseline+workspace+provider env already targets a remote
+// city (GC_CITY_URL or GC_CITY_CONTEXT set), the local city anchors are
+// omitted entirely: seeding them alongside a remote target makes the
+// nested gc binary in that session fail closed with "conflicting targets"
+// (cmd/gc/remote_target.go's local-vs-remote guard). A remote-targeted
+// session must resolve its city over the remote selector, not a local path.
 func cityAnchoredSessionEnv(cityPath string, workspaceEnv, providerEnv map[string]string) map[string]string {
 	baseline := processenv.ProviderProcessPassthroughEnv()
-	anchors := citylayout.CityIdentityEnvMap(cityPath)
 	gcBin, _ := os.Executable()
-	if len(baseline) == 0 && len(workspaceEnv) == 0 && len(providerEnv) == 0 && len(anchors) == 0 && gcBin == "" {
-		return nil
-	}
-	out := make(map[string]string, len(baseline)+len(workspaceEnv)+len(providerEnv)+len(anchors)+1)
+
+	out := make(map[string]string, len(baseline)+len(workspaceEnv)+len(providerEnv)+4)
 	for k, v := range baseline {
 		out[k] = v
 	}
@@ -64,6 +68,15 @@ func cityAnchoredSessionEnv(cityPath string, workspaceEnv, providerEnv map[strin
 	}
 	for k, v := range providerEnv {
 		out[k] = processenv.ExpandSessionEnvValue(v)
+	}
+
+	remoteTargeted := strings.TrimSpace(out["GC_CITY_URL"]) != "" || strings.TrimSpace(out["GC_CITY_CONTEXT"]) != ""
+	var anchors map[string]string
+	if !remoteTargeted {
+		anchors = citylayout.CityIdentityEnvMap(cityPath)
+	}
+	if len(baseline) == 0 && len(workspaceEnv) == 0 && len(providerEnv) == 0 && len(anchors) == 0 && gcBin == "" {
+		return nil
 	}
 	for k, v := range anchors {
 		out[k] = v


### PR DESCRIPTION
## Summary

Fixes #5860. A remote-targeted `gc` nomad session was failing closed with
`conflicting targets: a remote city (GC_CITY_URL/GC_CITY_CONTEXT) cannot be
combined with a local city env (...)` because `cityAnchoredSessionEnv`
(`internal/api/session_runtime.go`) unconditionally seeded local city-identity
anchors (`GC_CITY`, `GC_CITY_PATH`, `GC_CITY_RUNTIME_DIR`) into every session
env it composed, even when the merged env already carried `GC_CITY_URL` or
`GC_CITY_CONTEXT`.

## Root cause

`cityAnchoredSessionEnv` merged `citylayout.CityIdentityEnvMap(cityPath)` in
unconditionally, with no check for whether the baseline+workspace+provider env
already targets a remote city. The nested `gc` binary in that session then hit
`cmd/gc/remote_target.go`'s local-vs-remote conflict guard and failed closed —
correctly, given the contradictory env it was handed. This PR fixes the
seeding boundary, not the guard.

## Fix

`cityAnchoredSessionEnv` now checks the merged env for `GC_CITY_URL` /
`GC_CITY_CONTEXT` before seeding the local anchors, and omits
`GC_CITY`/`GC_CITY_PATH`/`GC_CITY_RUNTIME_DIR` when either is already set. The
existing three call sites (`session_resolution.go:330`,
`session_runtime.go:383`, `session_runtime.go:501` via
`session_resolved_config.go:41`) all route through this one helper, so the fix
covers all of them.

## Test evidence

RED/GREEN, `internal/api` package:

- RED (parent commit, before the fix): `TestCityAnchoredSessionEnvSkipsLocalAnchorsWhenRemoteTargeted` fails — anchors are seeded even with `GC_CITY_URL`/`GC_CITY_CONTEXT` present.
- GREEN (this PR): same test passes, three subtests — remote via `GC_CITY_URL`, remote via `GC_CITY_CONTEXT`, and local-only (no remote keys — anchors still seeded, no regression).
- Full `internal/api` package sweep is GREEN (verified via the project's Nomad builder pool).

## Scope

Does not touch `cmd/gc/remote_target.go`'s conflict-detection logic — that
guard is behaving correctly given the env it's handed; this PR fixes the
env-composition boundary that was handing it a self-contradictory env.

`cmd/gc/bd_env.go`'s separate `CityIdentityEnvMap` call (CLI `gc bd` env
projection, not session-spawn env) is a different code path and out of scope
for this fix.
