### PR TITLE
Make canonical pause message allocation overflow-safe

### DIFF
--- a/internal/productmetrics/pause.go
+++ b/internal/productmetrics/pause.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/Masterminds/semver/v3"
 )
@@ -163,19 +164,28 @@ func canonicalPauseMessage(unsigned pauseUnsigned) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("productmetrics: canonicalize signed pause: %w", err)
 	}
-	message := make([]byte, 0, len(pauseDomainPrefix)+len(encoded))
+	capacity, err := canonicalPauseMessageCapacity(len(pauseDomainPrefix), len(encoded))
+	if err != nil {
+		return nil, err
+	}
+	message := make([]byte, 0, capacity)
 	message = append(message, pauseDomainPrefix...)
 	message = append(message, encoded...)
 	return message, nil
 }
 
-// canonicalPauseMessageCapacity is completed by the GREEN step (ga-n6gvg8.1):
-// it does not yet guard the sum itself against overflow.
+// canonicalPauseMessageCapacity proves prefixLen+encodedLen fits in an int
+// before it is used as a make() capacity, instead of letting the addition
+// wrap silently (CodeQL go/allocation-size-overflow, alert #262).
 func canonicalPauseMessageCapacity(prefixLen, encodedLen int) (int, error) {
 	if prefixLen < 0 || encodedLen < 0 {
 		return 0, fmt.Errorf("productmetrics: canonical pause message length is negative")
 	}
-	return prefixLen + encodedLen, nil
+	capacity, ok := checkedAddUint64(uint64(prefixLen), uint64(encodedLen))
+	if !ok || capacity > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("productmetrics: canonical pause message capacity overflow")
+	}
+	return int(capacity), nil
 }
 
 func validatePauseUnsigned(unsigned pauseUnsigned) error {

--- a/internal/productmetrics/pause.go
+++ b/internal/productmetrics/pause.go
@@ -169,6 +169,15 @@ func canonicalPauseMessage(unsigned pauseUnsigned) ([]byte, error) {
 	return message, nil
 }
 
+// canonicalPauseMessageCapacity is completed by the GREEN step (ga-n6gvg8.1):
+// it does not yet guard the sum itself against overflow.
+func canonicalPauseMessageCapacity(prefixLen, encodedLen int) (int, error) {
+	if prefixLen < 0 || encodedLen < 0 {
+		return 0, fmt.Errorf("productmetrics: canonical pause message length is negative")
+	}
+	return prefixLen + encodedLen, nil
+}
+
 func validatePauseUnsigned(unsigned pauseUnsigned) error {
 	if unsigned.SchemaVersion != SchemaVersionV1 {
 		return fmt.Errorf("productmetrics: signed pause schema version must be %d", SchemaVersionV1)

--- a/internal/productmetrics/pause_test.go
+++ b/internal/productmetrics/pause_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"os"
 	"reflect"
 	"strings"
@@ -60,6 +61,31 @@ func TestCanonicalPauseMessageMatchesRestrictedRFC8785Vector(t *testing.T) {
 	}
 	if want := pauseCanonicalOracle(testPauseRelease, testPauseEpoch, testPauseKeyID); !bytes.Equal(message, want) {
 		t.Fatalf("canonical message mismatch\n got: %q\nwant: %q", message, want)
+	}
+}
+
+// TestCanonicalPauseMessageCapacityMatchesPlainSumForNormalInputs pins the
+// non-overflow path to the same result a plain `prefixLen + encodedLen`
+// addition would produce, so the overflow guard below can't silently change
+// the allocated capacity for real-world inputs.
+func TestCanonicalPauseMessageCapacityMatchesPlainSumForNormalInputs(t *testing.T) {
+	prefixLen, encodedLen := len(pauseDomainPrefix), 128
+	got, err := canonicalPauseMessageCapacity(prefixLen, encodedLen)
+	if err != nil {
+		t.Fatalf("canonicalPauseMessageCapacity: %v", err)
+	}
+	if want := prefixLen + encodedLen; got != want {
+		t.Fatalf("canonicalPauseMessageCapacity = %d, want %d", got, want)
+	}
+}
+
+// TestCanonicalPauseMessageCapacityRejectsOverflow exercises the allocation
+// guard directly with a math.MaxInt-sized operand instead of an actual
+// oversized []byte, so the overflow path is provable without allocating
+// gigabytes of memory in a test.
+func TestCanonicalPauseMessageCapacityRejectsOverflow(t *testing.T) {
+	if _, err := canonicalPauseMessageCapacity(len(pauseDomainPrefix), math.MaxInt); err == nil {
+		t.Fatal("canonicalPauseMessageCapacity: want overflow error for math.MaxInt encoded length, got nil")
 	}
 }
 

--- a/release-gates/ga-gmv93g-canonical-pause-capacity-gate.md
+++ b/release-gates/ga-gmv93g-canonical-pause-capacity-gate.md
@@ -1,0 +1,84 @@
+# Release Gate: overflow-safe canonical pause capacity
+
+Bead: `ga-gmv93g`  
+Build bead: `ga-n6gvg8.1`  
+Review bead: `ga-xbdj59`  
+Reviewed commit: `05b56848b149e39b2ea4c98ee4d7cd2ff326579e`  
+Gated rebased commit: `d9bfecdf59cd90b77fbd2ec0e86b46d5c403d6a9`  
+Base: `origin/main@cfea9840eeedd643e8c12a37239a264eda1ce7d0`
+
+The reviewed two-commit diff was rebased onto current `origin/main`. Its stable
+patch-id remained `e100994f6b80d19e3f886c153a3184b8ae2cf53a`.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-xbdj59` is closed with `REVIEW ... verdict: PASS` for reviewed commit `05b56848b149e39b2ea4c98ee4d7cd2ff326579e`. The rebased candidate has the same stable patch-id as that reviewed diff. |
+| 2 | Acceptance criteria met | PASS | `canonicalPauseMessageCapacity` proves the sum with `checkedAddUint64`, rejects negative or greater-than-`math.MaxInt` lengths with contextual errors, and preserves the existing canonical byte path. The regression tests exercise normal and overflow paths without a large allocation. The diff is confined to `internal/productmetrics/pause.go` and `pause_test.go`. |
+| 3 | Tests pass | PASS | Full-scope command `make test-local-full-parallel` completed all 40 jobs: 36 job PASS, 4 job FAIL attributed below, 0 job SKIP. `test_cmd_scope: full-suite`. The `unit-core` package sweep and focused named confirmation both passed the candidate-owned tests. `go vet ./...` and `make test-ci-policy` passed. |
+| 4 | No high-severity review findings open | PASS | Review bead records no HIGH finding; unresolved HIGH count is 0. The only reviewer note was a non-blocking observation about a defensive negative-length branch. |
+| 5 | Final branch is clean | PASS | `git status --porcelain` was empty at gated commit `d9bfecdf59cd90b77fbd2ec0e86b46d5c403d6a9` before adding this gate artifact. The gate commit is verified clean separately before push. |
+| 6 | Branch diverges cleanly from main | PASS | After `git fetch origin main`, `git merge-base --is-ancestor origin/main HEAD` succeeded: current base `cfea9840eeedd643e8c12a37239a264eda1ce7d0` is an ancestor of gated head `d9bfecdf59cd90b77fbd2ec0e86b46d5c403d6a9`. |
+| 7 | Single feature theme | PASS | Both commits and both changed files implement one `internal/productmetrics` behavior: overflow-safe capacity calculation for canonical pause messages. |
+
+## Acceptance evidence
+
+- Overflow-safe arithmetic: `canonicalPauseMessageCapacity` converts only
+  non-negative lengths, uses the existing `checkedAddUint64`, and refuses a
+  result above `math.MaxInt` before the `make` capacity conversion.
+- No large allocation: `TestCanonicalPauseMessageCapacityRejectsOverflow`
+  passes `math.MaxInt` to the helper and verifies an error without allocating.
+- Normal behavior unchanged:
+  `TestCanonicalPauseMessageCapacityMatchesPlainSumForNormalInputs` and
+  `TestCanonicalPauseMessageMatchesRestrictedRFC8785Vector` pass.
+- Scope: `git diff --name-status origin/main...HEAD` reports only
+  `internal/productmetrics/pause.go` and
+  `internal/productmetrics/pause_test.go`.
+
+## Test evidence
+
+- `test_cmd: make test-local-full-parallel`
+- `test_cmd_scope: full-suite`
+- `test_counts: 36 job PASS, 4 job FAIL (all attributed), 0 job SKIP`
+- `diff_tests_executed:`
+  - `TestCanonicalPauseMessageCapacityMatchesPlainSumForNormalInputs` — PASS
+  - `TestCanonicalPauseMessageCapacityRejectsOverflow` — PASS
+  - `TestCanonicalPauseMessageMatchesRestrictedRFC8785Vector` — PASS
+- `skip_justification: none — no job or candidate-owned test skipped`
+- `waiver_ref: none required — all raw failures are non-diff-owned and satisfy criterion 3a attribution`
+- `policy_lane: make test-ci-policy — PASS`
+- `go vet ./...` — PASS
+- `ci_lane_run: n/a (no CI configuration change)`
+- Container preflight: rootless podman socket was ready; this repository has
+  no `dolt-tests-via-podman` cairn entry and the candidate does not add or
+  modify a testcontainers-backed test.
+
+Raw full-suite log: `/var/tmp/ga-gmv93g-full-suite.log`  
+Per-job logs: `/var/tmp/gc-local-tests.RF7POH/`
+
+## Failure attribution
+
+Each failure is outside the diff, has an open tracker predating this run, has
+independent evidence that the condition is not caused by this candidate, and
+has no path overlap with `internal/productmetrics`.
+
+- `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix` →
+  `ga-esyijp`. Clause 3(b), cross-diff: the tracker records the same
+  beads#4566 dirty-schema migration during fixture initialization across many
+  unrelated candidates. The failure occurred in `cmd/gc/cmd_bd_test.go`
+  before pause-message behavior.
+- `TestAdoptPRFormulaRetriesTransientReviewerStep` → `ga-esyijp`. Clause
+  3(b), cross-diff: identical dirty-schema migration at shared Dolt port 28231
+  during `gc init`, before formula behavior. The failing test is under
+  `test/integration`, outside the diff.
+- `TestBdFlagManifestCurrent` → `ga-f0uceo`. Clause 3(d), base-ref
+  reproduction: the tracker records the identical installed-`bd` flag drift
+  on clean `origin/main`, plus many unrelated candidate sightings. The failing
+  package is `internal/bdflags`, outside the diff.
+- `TestE2E_SuspendResume_City` → `ga-vkhfnj`. Clause 3(d), base-ref
+  reproduction: the tracker records the exact 93-second missing
+  `citysus.report` signature on candidate and base. The failing lifecycle test
+  is under `test/integration`, outside the diff.
+
+`inconclusive-guard: n/a — an independent clause-3 proof landed for every raw failure.`


### PR DESCRIPTION
## What this changes

Canonical signed-pause messages now validate the combined domain-prefix and canonical-JSON length before using it as a byte-slice capacity. If the sum cannot be represented safely as an `int`, message construction returns a contextual error instead of allowing integer wraparound to reach `make`.

Valid messages are byte-for-byte unchanged. This removes the allocation-overflow fragility without introducing a smaller arbitrary protocol cap.

## Review notes

- The change is confined to `internal/productmetrics/pause.go` and its tests.
- It reuses the existing checked unsigned-add helper and separately enforces `math.MaxInt` before conversion.
- The existing 4 KiB signed-pause caller bound and wire format are unchanged.
- The overflow regression test exercises `math.MaxInt` directly and does not allocate a large buffer.

## Test plan

- [x] Verify normal capacity and the existing canonical RFC 8785 vector remain unchanged.
- [x] Verify an overflow-sized operand returns an error without allocating.
- [x] Run the repository policy lane and `go vet ./...`.
- [x] Run the full local CI union; audit attributed host/main failures in the release gate.
- [x] Release gate: [`release-gates/ga-gmv93g-canonical-pause-capacity-gate.md`](release-gates/ga-gmv93g-canonical-pause-capacity-gate.md)