### PR TITLE
fix(doltpool): bound idle connections below the server's wait_timeout

### DIFF
--- a/internal/doltpool/pool.go
+++ b/internal/doltpool/pool.go
@@ -31,6 +31,20 @@ const (
 	maxOpenConns    = 5
 	maxIdleConns    = 2
 	connMaxLifetime = time.Hour
+	// connMaxIdleTime must stay STRICTLY BELOW the server's wait_timeout,
+	// which gc's managed dolt config sets to 30s. Without it an idle pooled
+	// connection lives until connMaxLifetime (an hour), so the SERVER reaps
+	// it first and logs an error per reap:
+	//
+	//   Error reading packet from client N: read tcp ... i/o timeout
+	//   io.ReadFull(header size) failed
+	//
+	// 6565 such lines in one day were observed on a single managed city,
+	// arriving on a clean 30s cycle — the reaper working, logged at ERROR.
+	// Closing idle connections client-side first removes the events at the
+	// source rather than muting them. 20s leaves a 10s margin; equality
+	// with wait_timeout would be a race, not a bound.
+	connMaxIdleTime = 20 * time.Second
 	connTimeout     = 5 * time.Second
 	readTimeout     = 30 * time.Second
 	writeTimeout    = 30 * time.Second
@@ -92,6 +106,7 @@ func Open(host, port, user, password, database string) (*sql.DB, error) {
 	db.SetMaxOpenConns(maxOpenConns)
 	db.SetMaxIdleConns(maxIdleConns)
 	db.SetConnMaxLifetime(connMaxLifetime)
+	db.SetConnMaxIdleTime(connMaxIdleTime)
 	registry.dbs[k] = db
 	return db, nil
 }


### PR DESCRIPTION
## What

Adds `db.SetConnMaxIdleTime(20 * time.Second)` to the shared Dolt pool.

## Why

`internal/doltpool` sets `maxIdleConns = 2` and `connMaxLifetime = time.Hour`, but no idle timeout. An idle pooled connection therefore lives up to an hour, while gc's own managed Dolt config sets the server's `wait_timeout` to **30 seconds**. The server reaps the connection first and logs an error for each one:

```
Error reading packet from client N: read tcp ... i/o timeout
io.ReadFull(header size) failed
```

On one managed city this produced **6565 ERROR lines in a single day**, continuous from 00:00 to 17:22. The timestamps land on seconds `:02`, `:28`, `:32`, `:58` — two interleaved series on a 30s cycle, matching `wait_timeout` exactly. `ss` attribution showed every connection belonged to `gc`, with the churn concentrated on the supervisor's reconcile loop.

Nothing is failing here: this is the reaper working as designed, logged at ERROR. The costs are that a log crying wolf thousands of times a day trains operators to discount it, and the server burns CPU managing sockets the client should have closed itself.

## Why this value

`SetConnMaxIdleTime` must sit **strictly below** `wait_timeout` so the client closes idle connections first, removing the events at the source rather than muting them. 20s leaves a 10s margin; equality with `wait_timeout` would be a race, not a bound.

`connMaxLifetime` is deliberately left at an hour — it bounds connection *age*, not idleness, and age is not what the server is reaping.

This follows the lineage of the package itself, which was introduced to eliminate per-operation Open+Close churn (its own comment cites 2,618 TIME_WAIT sockets from one call site). This is the same class of problem one level down: connections that outlive what the other end expects.

## Not included

The log **severity** is not addressed here. `Error reading packet from client` is emitted by Dolt's go-mysql-server, so it is not this project's to change; it would be a separate issue upstream. Bundling the two would stall the half that can actually land.

## Test

`go build`, `go vet`, and `go test ./internal/doltpool/` all pass.
