### PR TITLE
fix(prompt): apply filesystem search guidance globally

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -614,6 +614,7 @@ func primeHookHasLiveManagedSession(cityPath string) bool {
 }
 
 func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt string, hookMode bool, hookFormat string, suppressPrompt bool, hookContextSuffix string, afterDelivery func()) {
+	prompt = appendFilesystemSearchGuidance(prompt)
 	if hookMode && suppressPrompt {
 		// Managed sessions receive the rendered startup prompt through the
 		// launch payload or nudge path. SessionStart hooks add context only.

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -175,8 +175,9 @@ schema = 2
 	if code != 0 {
 		t.Fatalf("doPrime() = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	if got := stdout.String(); got != "Agent: ada\n" {
-		t.Fatalf("stdout = %q, want %q", got, "Agent: ada\n")
+	want := appendFilesystemSearchGuidance("Agent: ada\n")
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 }
 
@@ -285,7 +286,7 @@ path = "./rigs/bravo"
 	if code != 0 {
 		t.Fatalf("doPrime() = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	if got := stdout.String(); got != "alpha-work-query" {
+	if got := stdout.String(); got != appendFilesystemSearchGuidance("alpha-work-query") {
 		t.Fatalf("stdout = %q, want alpha rig fragment; stderr=%q", got, stderr.String())
 	}
 	if strings.Contains(stdout.String(), "bravo-work-query") {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -6127,8 +6127,9 @@ prompt_template = "prompts/mayor.md"
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != promptContent {
-		t.Errorf("stdout = %q, want %q", stdout.String(), promptContent)
+	want := appendFilesystemSearchGuidance(promptContent)
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
 	}
 }
 
@@ -6170,8 +6171,9 @@ prompt_template = "prompts/mayor.md"
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != promptContent {
-		t.Errorf("stdout = %q, want %q", stdout.String(), promptContent)
+	want := appendFilesystemSearchGuidance(promptContent)
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
 	}
 }
 
@@ -6209,8 +6211,9 @@ name = "test-city"
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != promptContent {
-		t.Errorf("stdout = %q, want %q", stdout.String(), promptContent)
+	want := appendFilesystemSearchGuidance(promptContent)
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
 	}
 }
 
@@ -6244,7 +6247,7 @@ prompt_template = "prompts/mayor.md"
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0", code)
 	}
-	if stdout.String() != defaultPrimePrompt {
+	if stdout.String() != appendFilesystemSearchGuidance(defaultPrimePrompt) {
 		t.Errorf("stdout = %q, want default prompt", stdout.String())
 	}
 }
@@ -6437,7 +6440,7 @@ max_active_sessions = 1
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode(strict=true, agent without prompt_template) = %d, want 0 (supported config); stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != defaultPrimePrompt {
+	if stdout.String() != appendFilesystemSearchGuidance(defaultPrimePrompt) {
 		t.Errorf("stdout = %q, want defaultPrimePrompt (agent without prompt_template should fall through)", stdout.String())
 	}
 }
@@ -6524,7 +6527,7 @@ prompt_template = %q
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode(strict=true, absolute template path) = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != "absolute mayor prompt" {
+	if stdout.String() != appendFilesystemSearchGuidance("absolute mayor prompt") {
 		t.Errorf("stdout = %q, want absolute template content", stdout.String())
 	}
 }
@@ -6876,7 +6879,7 @@ func TestDoPrimeNoArgs(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0", code)
 	}
-	if stdout.String() != defaultPrimePrompt {
+	if stdout.String() != appendFilesystemSearchGuidance(defaultPrimePrompt) {
 		t.Errorf("stdout = %q, want default prompt", stdout.String())
 	}
 }
@@ -6927,8 +6930,9 @@ max = 3
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != promptContent {
-		t.Errorf("stdout = %q, want pool worker prompt %q", stdout.String(), promptContent)
+	want := appendFilesystemSearchGuidance(promptContent)
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want pool worker prompt %q", stdout.String(), want)
 	}
 }
 
@@ -7644,8 +7648,9 @@ prompt_template = "prompts/mayor.md"
 	if code != 0 {
 		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != promptContent {
-		t.Errorf("stdout = %q, want %q (got default prompt instead of mayor template)", stdout.String(), promptContent)
+	want := appendFilesystemSearchGuidance(promptContent)
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q (got default prompt instead of mayor template)", stdout.String(), want)
 	}
 }
 

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -18,8 +18,16 @@ import (
 )
 
 const (
-	canonicalPromptTemplateSuffix = ".template.md"
-	legacyPromptTemplateSuffix    = ".md.tmpl"
+	canonicalPromptTemplateSuffix   = ".template.md"
+	legacyPromptTemplateSuffix      = ".md.tmpl"
+	filesystemSearchGuidanceHeading = "**Never use wide filesystem searches when a CLI command exists.**"
+	filesystemSearchGuidance        = filesystemSearchGuidanceHeading + ` Wide
+traversals (` + "`find /`" + `, ` + "`find ~`" + `, ` + "`find /Users`" + `, ` + "`find $HOME`" + `) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+Music, removable volumes, and network mounts — and trigger permission
+prompts that block work. Use a Gas City or project CLI command instead.
+If a filesystem search is necessary, scope it to the current city, rig,
+or worktree root.`
 )
 
 // PromptContext holds template data for prompt rendering.
@@ -211,6 +219,19 @@ func renderPromptWithMeta(fs fsys.FS, cityPath, cityName, templatePath string, c
 		Version: fm.Version,
 		SHA:     promptmeta.SHA(rendered),
 	}
+}
+
+func appendFilesystemSearchGuidance(prompt string) string {
+	if prompt == "" || strings.Contains(prompt, filesystemSearchGuidanceHeading) {
+		return prompt
+	}
+	separator := "\n\n"
+	if strings.HasSuffix(prompt, "\n\n") {
+		separator = ""
+	} else if strings.HasSuffix(prompt, "\n") {
+		separator = "\n"
+	}
+	return prompt + separator + filesystemSearchGuidance
 }
 
 func promptTemplateSourcePath(cityPath, templatePath string) string {

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"io/fs"
 	"os"
@@ -15,7 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-const formulaFilesystemSearchGuidance = "**Never use wide filesystem searches when a CLI command exists.**"
+const formulaFilesystemSearchGuidance = filesystemSearchGuidanceHeading
 
 // materializeEmbeddedGastownPack writes the module-embedded gastown pack
 // (the exact bytes the gc binary bundles) to a t.TempDir()-rooted directory
@@ -60,6 +61,51 @@ func TestRenderPromptMissingFile(t *testing.T) {
 	got := renderPrompt(f, "/city", "", "prompts/missing.md", PromptContext{}, "", io.Discard, nil, nil, nil)
 	if got != "" {
 		t.Errorf("renderPrompt(missing) = %q, want empty", got)
+	}
+}
+
+func TestWritePrimePromptAddsFilesystemSearchGuidanceOnce(t *testing.T) {
+	for _, prompt := range []string{
+		"Custom agent prompt.\n",
+		"Custom agent prompt.\n\n" + filesystemSearchGuidance,
+	} {
+		var stdout strings.Builder
+		writePrimePromptWithFormat(&stdout, "test-city", "custom", prompt, false, "", false, "", nil)
+		if count := strings.Count(stdout.String(), formulaFilesystemSearchGuidance); count != 1 {
+			t.Fatalf("filesystem search guidance count = %d, want 1:\n%s", count, stdout.String())
+		}
+		for _, want := range []string{
+			"`find /`",
+			"`find ~`",
+			"`find /Users`",
+			"`find $HOME`",
+			"Desktop",
+			"Downloads",
+			"Music",
+			"network mounts",
+			"current city, rig,",
+		} {
+			if !strings.Contains(stdout.String(), want) {
+				t.Errorf("prime prompt missing %q:\n%s", want, stdout.String())
+			}
+		}
+	}
+}
+
+func TestWritePrimePromptFormatsFilesystemSearchGuidanceOnce(t *testing.T) {
+	var stdout strings.Builder
+	writePrimePromptWithFormat(&stdout, "test-city", "custom", "Custom agent prompt.\n", true, "codex", false, "", nil)
+
+	var output struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(stdout.String()), &output); err != nil {
+		t.Fatalf("unmarshal hook output: %v; stdout=%q", err, stdout.String())
+	}
+	if count := strings.Count(output.HookSpecificOutput.AdditionalContext, formulaFilesystemSearchGuidance); count != 1 {
+		t.Fatalf("filesystem search guidance count = %d, want 1:\n%s", count, output.HookSpecificOutput.AdditionalContext)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -404,6 +404,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	default:
 		prompt = beacon
 	}
+	if !suppressStartupPrompt {
+		prompt = appendFilesystemSearchGuidance(prompt)
+	}
 
 	// Step 9b: Append the assigned-skills appendix when the agent
 	// has a vendor sink, hasn't opted out, AND the runtime actually

--- a/cmd/gc/template_resolve_filesystem_guidance_test.go
+++ b/cmd/gc/template_resolve_filesystem_guidance_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveTemplateAddsFilesystemSearchGuidanceToStartupPrompt(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	params := &agentBuildParams{
+		cityName:        "city",
+		cityPath:        cityPath,
+		workspace:       &config.Workspace{Provider: "claude"},
+		providers:       map[string]config.ProviderSpec{"claude": {Command: "echo", PromptMode: "none"}},
+		lookPath:        func(string) (string, error) { return "/bin/echo", nil },
+		fs:              fsys.OSFS{},
+		rigs:            []config.Rig{},
+		beaconTime:      time.Unix(0, 0),
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+		sessionProvider: "tmux",
+	}
+	agent := &config.Agent{
+		Name:     "custom",
+		Scope:    "city",
+		Provider: "claude",
+		WorkDir:  ".gc/agents/custom",
+	}
+
+	resolved, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if count := strings.Count(resolved.Prompt, formulaFilesystemSearchGuidance); count != 1 {
+		t.Fatalf("filesystem search guidance count = %d, want 1:\n%s", count, resolved.Prompt)
+	}
+}


### PR DESCRIPTION
## Summary

- Apply the macOS filesystem-search safeguard at the shared startup-prompt delivery boundary instead of only in selected bundled role templates.
- Apply the same safeguard to every non-empty `gc prime` prompt, including provider-formatted hook context, while preserving managed-prompt suppression.
- Reuse the existing heading as an idempotence marker so bundled graph/pool/following-molecule prompts do not receive duplicate guidance.

Fixes #5873.

## Testing

- [ ] `make check`
  - Full `make check` is blocked by an unrelated formatting defect already present on `upstream/main` in `test/acceptance/worker_inference/worker_inference_test.go`.
- [ ] `make check-docs` if docs, navigation, or links changed
  - Not applicable; no documentation paths changed.
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
  - Not applicable; this changes prompt composition, not runtime/controller/workflow behavior.
- [x] Focused startup, prime, hook-format, suppression, and existing filesystem-guidance tests pass.
- [x] `make lint`
- [x] `go vet ./...`
- [x] `make build`
- [x] `make fmt-check-changed CI_STATIC_SELECT=./scripts/ci-static-select LINT_CHANGED_SCOPE=staged`

`make test-fast-parallel` reaches the repository's pre-existing path-with-spaces failure in `TestChangedStaticTargetsScopeLintAndFormattingToTheDiff`: its generated Makefile command does not quote the absolute `scripts/ci-static-select` path. The changed `cmd/gc` tests pass independently.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes — not required; the safeguard is emitted runtime guidance, with behavior covered by tests
- [x] Called out breaking changes or migration notes — none
