### PR TITLE
fix(runs): execute teardown steps after cancellation

### DIFF
--- a/internal/api/huma_handlers_run_cancel_test.go
+++ b/internal/api/huma_handlers_run_cancel_test.go
@@ -405,6 +405,99 @@ func TestRunCancelWireRoute(t *testing.T) {
 	}
 }
 
+// TestRunCancelLeavesTeardownStepOpenToExecute guards the finding that run
+// cancellation force-closed a workflow's always-run cleanup step as canceled
+// instead of letting it run: cancelRun's blanket subtree close swept the
+// teardown tail along with ordinary open work, so a step whose job is to
+// release the run's external resources (e.g. tearing down a sandbox) never
+// executed. The teardown step must stay open after cancel, and still be
+// closeable with a real outcome afterward, so the dispatcher can drive it to
+// completion — its pass condition may read ROOT_OUTCOME, which only exists
+// once the root itself is closed, which cancelRun already does.
+func TestRunCancelLeavesTeardownStepOpenToExecute(t *testing.T) {
+	fs := newFakeState(t)
+	store := fs.stores["myrig"]
+	root, err := store.Create(beads.Bead{
+		Title:    "run root",
+		Type:     "molecule",
+		Metadata: map[string]string{"gc.kind": "workflow", "gc.formula_contract": "graph.v2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	openStep, err := store.Create(beads.Bead{
+		Title:    "ordinary step",
+		Type:     "task",
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	teardown, err := store.Create(beads.Bead{
+		Title: "cleanup",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.scope_role":   "teardown",
+			"gc.step_id":      "cleanup",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{state: fs}
+
+	out, err := s.humaHandleRunCancel(context.Background(), &RunCancelInput{
+		CityScope: CityScope{CityName: "test-city"},
+		RunID:     root.ID,
+	})
+	if err != nil {
+		t.Fatalf("cancel error: %v", err)
+	}
+	if out.Body.Status != RunStatusCanceled {
+		t.Errorf("status = %q, want canceled", out.Body.Status)
+	}
+	// Root + the one ordinary step close; the teardown step is excluded from
+	// the sweep and stays open.
+	if out.Body.Closed != 2 {
+		t.Errorf("closed = %d, want 2 (root + ordinary step; the teardown step stays open)", out.Body.Closed)
+	}
+
+	afterCancel, err := store.Get(teardown.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterCancel.Status == "closed" {
+		t.Fatal("teardown step was force-closed by run cancel; it must stay open so it can still execute")
+	}
+	if got := afterCancel.Metadata["gc.outcome"]; got == "canceled" {
+		t.Fatal("teardown step was stamped canceled by run cancel; it never ran")
+	}
+
+	// The ordinary step DID close as canceled — cancel still winds down the
+	// rest of the run, it only exempts the teardown tail.
+	openAfter, err := store.Get(openStep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if openAfter.Status != "closed" || openAfter.Metadata["gc.outcome"] != "canceled" {
+		t.Errorf("ordinary step = %+v, want closed with gc.outcome=canceled", openAfter)
+	}
+
+	// The teardown step is still executable: it can now run to completion and
+	// record a real outcome, proving cancel did not strand it half-wound-down.
+	if _, err := store.CloseAll([]string{teardown.ID}, map[string]string{"gc.outcome": "pass"}); err != nil {
+		t.Fatalf("closing teardown step after cancel: %v", err)
+	}
+	executed, err := store.Get(teardown.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executed.Status != "closed" || executed.Metadata["gc.outcome"] != "pass" {
+		t.Errorf("executed teardown step = %+v, want closed with gc.outcome=pass", executed)
+	}
+}
+
 func TestRunCancelAlreadyTerminalConflict(t *testing.T) {
 	s, store, runID := newWorkflowRun(t)
 	// Close the root before canceling — the run is already terminal.

--- a/internal/api/huma_handlers_runs.go
+++ b/internal/api/huma_handlers_runs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/api/apierr"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/runproj"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
@@ -356,9 +357,13 @@ type cancelRunResult struct {
 // persists neither and never strands an open, half-marked root; on a non-atomic
 // store the marker is durably recorded so the returned 5xx's retry completes the
 // wind-down. Already-terminal runs (and already-closed members) are left
-// untouched — closing a completed member would rewrite its recorded outcome. Any
-// store read/write failure is returned so the caller reports a 5xx rather than a
-// phantom success.
+// untouched — closing a completed member would rewrite its recorded outcome. The
+// run's teardown tail (molecule.TeardownTailExclusion) is excluded from this
+// close: it runs AFTER the root reaches a terminal state by contract, and its
+// pass condition may read ROOT_OUTCOME, which this cancel's own close just
+// stamped — force-closing it unexecuted would strand the resources it releases.
+// Any store read/write failure is returned so the caller reports a 5xx rather
+// than a phantom success.
 func (s *Server) cancelRun(runID string) (cancelRunResult, error) {
 	var res cancelRunResult
 	for _, info := range s.workflowStores() {
@@ -374,12 +379,17 @@ func (s *Server) cancelRun(runID string) (cancelRunResult, error) {
 			if isClosedStatus(root.Status) {
 				continue // already terminal — nothing to wind down
 			}
-			n, err := sourceworkflow.CloseWorkflowSubtreeAs(
+			exclude, err := molecule.TeardownTailExclusion(info.store, root.ID)
+			if err != nil {
+				return res, err
+			}
+			n, err := sourceworkflow.CloseWorkflowSubtreeAsExcept(
 				info.store,
 				root.ID,
 				beadmeta.OutcomeCanceled,
 				runCanceledCloseReason,
 				map[string]string{beadmeta.CancelRequestedMetadataKey: "true"},
+				exclude,
 			)
 			if err != nil {
 				return res, err

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -212,8 +212,9 @@ const scopeAbortSkippedCloseReason = "scope member skipped: an earlier member of
 // workflow root is in a state that makes further work invalid. Three states
 // qualify — the root is gone (orphan), the root was canceled, or the root has
 // already settled. The finalizer is exempt because it is the bead that settles
-// the root, and the teardown tail is exempt because it runs after settlement by
-// contract.
+// the root, and the teardown tail is exempt from both the canceled- and
+// settled-root closes because it runs after the root reaches a terminal state
+// by contract — cancellation is one such terminal state, not an exception to it.
 func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, bool, error) {
 	if bead.Metadata[beadmeta.KindMetadataKey] == beadmeta.KindWorkflowFinalize {
 		return ControlResult{}, false, nil
@@ -233,7 +234,14 @@ func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOption
 		// the dispatcher, and is the consumer that gives gc.cancel_requested
 		// teeth.
 		if rootCanceled(root) {
-			return closeCanceledControl(store, bead, opts, rootID, rootStoreRef)
+			teardown, err := isTeardownTailControl(store, bead, rootID)
+			if err != nil {
+				return ControlResult{}, false, fmt.Errorf("%s: resolving teardown tail under canceled root %s: %w", bead.ID, rootID, err)
+			}
+			if !teardown {
+				return closeCanceledControl(store, bead, opts, rootID, rootStoreRef)
+			}
+			return ControlResult{}, false, nil
 		}
 		// A settled (closed) root is equally durable a stop signal. The
 		// finalizer closes the root BEFORE its bulk
@@ -299,11 +307,12 @@ func rootSettled(root beads.Bead) bool {
 }
 
 // isTeardownTailControl reports whether a control belongs to the teardown tail,
-// which runs AFTER the root settles by contract — its pass condition may branch
-// on ROOT_OUTCOME, which only finalize produces (#5271). teardownTailExclusion
-// keeps that tail out of the finalizer's own terminal sweep for the same
-// reason, and it is the authoritative definition, so the settled-root gate
-// defers to it rather than restating the rule.
+// which runs AFTER the root reaches a terminal state by contract — its pass
+// condition may branch on ROOT_OUTCOME, which only finalize produces (#5271).
+// molecule.TeardownTailExclusion keeps that tail out of the finalizer's own
+// terminal sweep for the same reason, and it is the authoritative definition,
+// so both the canceled-root and settled-root gates defer to it rather than
+// restating the rule.
 //
 // The cheap arm answers for retry and ralph controls, which expandRetry /
 // expandRalph mint with cloneStep and so inherit the host step's
@@ -319,7 +328,7 @@ func isTeardownTailControl(store beads.Store, bead beads.Bead, rootID string) (b
 	if strings.TrimSpace(bead.Metadata[beadmeta.StepIDMetadataKey]) == "" {
 		return false, nil
 	}
-	exclude, err := teardownTailExclusion(store, rootID)
+	exclude, err := molecule.TeardownTailExclusion(store, rootID)
 	if err != nil {
 		return false, err
 	}
@@ -995,7 +1004,7 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	// before completing the finalizer. This also repairs partially materialized
 	// workflows whose unused steps were never reached by ordinary dependency
 	// progression.
-	excludeTeardown, err := teardownTailExclusion(store, rootID)
+	excludeTeardown, err := molecule.TeardownTailExclusion(store, rootID)
 	if err != nil {
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: resolving teardown members: %w", rootID, err))
 	}
@@ -1027,41 +1036,6 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	}
 
 	return ControlResult{Processed: true, Action: "workflow-" + outcome}, nil
-}
-
-// teardownTailExclusion builds the predicate that keeps the teardown tail out
-// of the terminal sweep. Teardown work runs after the root settles by contract
-// (its pass condition may branch on the run outcome), so force-closing it at
-// settlement would skip the very step that releases the workflow's resources.
-//
-// The tail is the teardown-scoped members plus every attempt of the same step:
-// retry expansion strips gc.scope_role from the first attempt, leaving gc.step_id
-// as the only durable link back to the teardown step.
-func teardownTailExclusion(store beads.Store, rootID string) (func(beads.Bead) bool, error) {
-	members, err := molecule.ListSubtree(store, rootID)
-	if err != nil {
-		return nil, err
-	}
-	teardownStepIDs := make(map[string]struct{})
-	for _, member := range members {
-		if member.Metadata[beadmeta.ScopeRoleMetadataKey] != beadmeta.ScopeRoleTeardown {
-			continue
-		}
-		if stepID := strings.TrimSpace(member.Metadata[beadmeta.StepIDMetadataKey]); stepID != "" {
-			teardownStepIDs[stepID] = struct{}{}
-		}
-	}
-	return func(member beads.Bead) bool {
-		if member.Metadata[beadmeta.ScopeRoleMetadataKey] == beadmeta.ScopeRoleTeardown {
-			return true
-		}
-		stepID := strings.TrimSpace(member.Metadata[beadmeta.StepIDMetadataKey])
-		if stepID == "" {
-			return false
-		}
-		_, ok := teardownStepIDs[stepID]
-		return ok
-	}, nil
 }
 
 func preflightSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions) error {

--- a/internal/dispatch/terminal_root_gate_test.go
+++ b/internal/dispatch/terminal_root_gate_test.go
@@ -122,10 +122,38 @@ func TestProcessControlStopsControlWhenWorkflowRootTerminallyClosed(t *testing.T
 	}
 }
 
+// TestProcessControlKeepsTeardownTailRunningUnderCanceledRoot mirrors
+// TestProcessControlKeepsTeardownTailRunningUnderTerminalRoot for the
+// canceled-root arm: cancellation is a terminal state like any other, so the
+// teardown tail's contract (it runs AFTER the root reaches a terminal state,
+// its pass condition may branch on ROOT_OUTCOME) applies just the same. Before
+// this exemption, cancelRun's blanket subtree close force-closed the teardown
+// tail as canceled and it never executed.
+func TestProcessControlKeepsTeardownTailRunningUnderCanceledRoot(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	control := newTerminalRootRetryControl(t, store, "canceled", map[string]string{
+		"gc.scope_ref":  "teardown",
+		"gc.scope_role": "teardown",
+	})
+
+	result, err := ProcessControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if result.Action != "retry" || result.Created != 1 {
+		t.Fatalf("result = %+v, want the teardown tail to keep running under a canceled root (retry, created 1)", result)
+	}
+	if after := mustGet(t, store, control.ID); after.Status != "open" {
+		t.Fatalf("teardown control status = %q, want open", after.Status)
+	}
+}
+
 // TestProcessControlKeepsTeardownTailRunningUnderTerminalRoot guards the
 // contract #5271 established: a teardown step's control runs AFTER the root
 // settles by design — its pass condition may branch on ROOT_OUTCOME, which only
-// finalize produces. teardownTailExclusion keeps that tail out of the
+// finalize produces. molecule.TeardownTailExclusion keeps that tail out of the
 // finalizer's own sweep for the same reason, so the terminal-root gate must
 // exempt it too or the adopt-pr settlement deadlock comes straight back.
 //

--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -104,6 +104,42 @@ func CloseSubtreeWithMetadata(store beads.Store, rootID string, metadata map[str
 	return CloseSubtreeWithMetadataExcept(store, rootID, metadata, nil)
 }
 
+// TeardownTailExclusion builds the predicate that keeps a workflow's teardown
+// tail out of a terminal sweep over its subtree. Teardown work runs after the
+// root settles by contract (its pass condition may branch on the run
+// outcome), so force-closing it at settlement, or at cancellation, would skip
+// the very step that releases the workflow's resources.
+//
+// The tail is the teardown-scoped members plus every attempt of the same step:
+// retry expansion strips gc.scope_role from the first attempt, leaving
+// gc.step_id as the only durable link back to the teardown step.
+func TeardownTailExclusion(store beads.Store, rootID string) (func(beads.Bead) bool, error) {
+	members, err := ListSubtree(store, rootID)
+	if err != nil {
+		return nil, err
+	}
+	teardownStepIDs := make(map[string]struct{})
+	for _, member := range members {
+		if member.Metadata[beadmeta.ScopeRoleMetadataKey] != beadmeta.ScopeRoleTeardown {
+			continue
+		}
+		if stepID := strings.TrimSpace(member.Metadata[beadmeta.StepIDMetadataKey]); stepID != "" {
+			teardownStepIDs[stepID] = struct{}{}
+		}
+	}
+	return func(member beads.Bead) bool {
+		if member.Metadata[beadmeta.ScopeRoleMetadataKey] == beadmeta.ScopeRoleTeardown {
+			return true
+		}
+		stepID := strings.TrimSpace(member.Metadata[beadmeta.StepIDMetadataKey])
+		if stepID == "" {
+			return false
+		}
+		_, ok := teardownStepIDs[stepID]
+		return ok
+	}, nil
+}
+
 // CloseSubtreeWithMetadataExcept is CloseSubtreeWithMetadata with an exclusion
 // predicate: any member for which exclude reports true is left untouched. A nil
 // predicate closes the whole subtree.

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -433,7 +433,20 @@ func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 // signal that completes the wind-down rather than losing the intent. Returns
 // the count of newly closed beads.
 func CloseWorkflowSubtreeAs(store beads.Store, rootID, outcome, reason string, rootExtra map[string]string) (int, error) {
-	ordered, err := orderedOpenWorkflowSubtree(store, rootID)
+	return CloseWorkflowSubtreeAsExcept(store, rootID, outcome, reason, rootExtra, nil)
+}
+
+// CloseWorkflowSubtreeAsExcept is CloseWorkflowSubtreeAs with an exclusion
+// predicate: any member for which exclude reports true is left untouched, even
+// when it is otherwise open. A nil predicate closes the whole subtree, matching
+// CloseWorkflowSubtreeAs.
+//
+// The exclusion exists for members that stay executable after the workflow
+// reaches a terminal state — the teardown tail, which by contract runs after
+// the root settles or is canceled (see molecule.TeardownTailExclusion). Callers
+// own the policy; this function only skips.
+func CloseWorkflowSubtreeAsExcept(store beads.Store, rootID, outcome, reason string, rootExtra map[string]string, exclude func(beads.Bead) bool) (int, error) {
+	ordered, err := orderedOpenWorkflowSubtree(store, rootID, exclude)
 	if err != nil {
 		return 0, err
 	}
@@ -520,8 +533,9 @@ func closeRootWithMarker(store beads.Store, rootID string, rootMeta map[string]s
 // rootID (root included) ordered deepest-descendant-first and then blocker-first
 // via closeorder.Order, so a strict store accepts the close batch and the root
 // sorts last. Closed beads are excluded so an already-terminal member keeps its
-// recorded outcome.
-func orderedOpenWorkflowSubtree(store beads.Store, rootID string) ([]string, error) {
+// recorded outcome. A non-nil exclude also drops any member it reports true
+// for, even though it is open.
+func orderedOpenWorkflowSubtree(store beads.Store, rootID string, exclude func(beads.Bead) bool) ([]string, error) {
 	matched, err := ListWorkflowBeads(store, rootID)
 	if err != nil {
 		return nil, err
@@ -568,6 +582,9 @@ func orderedOpenWorkflowSubtree(store beads.Store, rootID string) ([]string, err
 	ids := make([]string, 0, len(matched))
 	for _, bead := range matched {
 		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		if exclude != nil && exclude(bead) {
 			continue
 		}
 		ids = append(ids, bead.ID)


### PR DESCRIPTION
## Summary

- keep always-run teardown steps open when a run is cancelled
- allow the dispatcher to execute the teardown tail under a cancelled root
- preserve retries and terminal-root control behavior for cleanup work
- add API and dispatcher regressions for cancellation cleanup

## Why

Run cancellation previously closed every open descendant without executing always-run cleanup. A cancelled run could therefore report a clean terminal state while leaving behind a sandbox, checkout, container, lease, or other external resource.

## Verification

- race-enabled cancellation and teardown-tail regressions
- affected API, dispatcher, molecule, and source-workflow package tests
- `go vet` on touched packages
- all ten `make test-fast-parallel` jobs
- independent exact-head review on `def9fb444a0512af05de1aae3f11b9484ae0b34f`
