### PR TITLE
fix(events): coordinate rotation across recorders

### DIFF
--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1557,7 +1557,7 @@ func TestFileRecorderFlockTimeoutFiresWithinBudget(t *testing.T) {
 	}
 	defer rec.Close() //nolint:errcheck // test cleanup
 
-	sib := mustOpenSiblingLock(t, path)
+	sib := mustOpenSiblingLock(t, recorderLockPath(path))
 	defer func() {
 		_ = syscall.Flock(int(sib.Fd()), syscall.LOCK_UN)
 		_ = sib.Close()
@@ -1595,7 +1595,7 @@ func TestFileRecorderFlockSucceedsAfterShortContention(t *testing.T) {
 	}
 	defer rec.Close() //nolint:errcheck // test cleanup
 
-	sib := mustOpenSiblingLock(t, path)
+	sib := mustOpenSiblingLock(t, recorderLockPath(path))
 	time.AfterFunc(50*time.Millisecond, func() {
 		_ = syscall.Flock(int(sib.Fd()), syscall.LOCK_UN)
 		_ = sib.Close()

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -40,17 +40,19 @@ const (
 
 // FileRecorder appends events to a JSONL file. It uses O_APPEND for
 // cross-process safety, a mutex for in-process serialization, and a
-// bounded-wait advisory file lock (flock) for cross-process serialization.
+// bounded-wait advisory lock on a stable events.jsonl.lock sidecar for
+// cross-process serialization across active-log renames.
 // Recording errors are written to stderr and never returned.
 //
 // FileRecorder implements [Provider] — it can both record and read events.
 type FileRecorder struct {
-	mu     sync.Mutex
-	path   string
-	file   *os.File
-	seq    uint64
-	stderr io.Writer
-	closed bool
+	mu       sync.Mutex
+	path     string
+	file     *os.File
+	lockFile *os.File // stable across rotations; never rename this inode
+	seq      uint64
+	stderr   io.Writer
+	closed   bool
 
 	// rotations tracks in-flight rotation goroutines so Close can
 	// drain them. Without this, callers that read events.jsonl
@@ -220,8 +222,14 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 	if err != nil {
 		return nil, fmt.Errorf("opening event log: %w", err)
 	}
+	lockFile, err := os.OpenFile(recorderLockPath(path), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("opening event log lock: %w", err)
+	}
 
 	r.file = file
+	r.lockFile = lockFile
 	r.seq = maxSeq
 	return r, nil
 }
@@ -241,22 +249,21 @@ func (r *FileRecorder) Record(e Event) {
 		return
 	}
 
-	r.maybeAutoRotateLocked()
-
-	// Cross-process flock contention only — r.mu already serializes
-	// in-process callers, so this loop never spins for an in-process peer.
-	// The bounded wait drops the recorder if a dead writer is holding the
-	// lock instead of blocking forever and piling up processes.
-	fd := int(r.file.Fd())
-	if err := lockRecorderFile(fd, r.path); err != nil {
+	if err := r.lockRecorder(); err != nil {
 		fmt.Fprintf(r.stderr, "events: lock: %v\n", err) //nolint:errcheck // best-effort stderr
 		return
 	}
 	defer func() {
-		if err := syscall.Flock(fd, syscall.LOCK_UN); err != nil {
+		if err := r.unlockRecorder(); err != nil {
 			fmt.Fprintf(r.stderr, "events: unlock: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 	}()
+	if err := r.reopenActiveIfRotatedLocked(); err != nil {
+		fmt.Fprintf(r.stderr, "events: %v\n", err) //nolint:errcheck // best-effort stderr
+		return
+	}
+
+	r.maybeAutoRotateLocked()
 
 	if err := r.writeRecordLocked(&e); err != nil {
 		fmt.Fprintf(r.stderr, "events: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -285,8 +292,7 @@ func (r *FileRecorder) AppendBatch(batch []Event) (resultErr error) {
 		return nil
 	}
 
-	fd := int(r.file.Fd())
-	if err := lockRecorderFile(fd, r.path); err != nil {
+	if err := r.lockRecorder(); err != nil {
 		return fmt.Errorf("lock: %w", err)
 	}
 	unlockPending := true
@@ -294,10 +300,13 @@ func (r *FileRecorder) AppendBatch(batch []Event) (resultErr error) {
 		if !unlockPending {
 			return
 		}
-		if err := syscall.Flock(fd, syscall.LOCK_UN); err != nil {
+		if err := r.unlockRecorder(); err != nil {
 			resultErr = errors.Join(resultErr, fmt.Errorf("unlock: %w", err))
 		}
 	}()
+	if err := r.reopenActiveIfRotatedLocked(); err != nil {
+		return err
+	}
 
 	latest, err := readLatestActiveSeq(r.path)
 	if err != nil {
@@ -321,8 +330,58 @@ func (r *FileRecorder) AppendBatch(batch []Event) (resultErr error) {
 	r.recordCount += uint64(len(batch))
 
 	unlockPending = false
-	if err := syscall.Flock(fd, syscall.LOCK_UN); err != nil {
+	if err := r.unlockRecorder(); err != nil {
 		return fmt.Errorf("unlock: %w", err)
+	}
+	return nil
+}
+
+func recorderLockPath(path string) string {
+	return path + ".lock"
+}
+
+func (r *FileRecorder) lockRecorder() error {
+	if r.lockFile == nil {
+		return fmt.Errorf("recorder lock file is unavailable")
+	}
+	return lockRecorderFile(int(r.lockFile.Fd()), r.path)
+}
+
+func (r *FileRecorder) unlockRecorder() error {
+	if r.lockFile == nil {
+		return fmt.Errorf("recorder lock file is unavailable")
+	}
+	return syscall.Flock(int(r.lockFile.Fd()), syscall.LOCK_UN)
+}
+
+// reopenActiveIfRotatedLocked makes a long-lived recorder follow path after a
+// peer has renamed the active log during rotation. The caller must hold both
+// r.mu and the stable recorder lock so the replacement cannot itself rotate
+// between the identity check and the next append.
+func (r *FileRecorder) reopenActiveIfRotatedLocked() error {
+	if r.file == nil {
+		return fmt.Errorf("recorder file is unavailable")
+	}
+	openedInfo, err := r.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat open event log: %w", err)
+	}
+	activeInfo, err := os.Stat(r.path)
+	if err != nil {
+		return fmt.Errorf("stat active event log: %w", err)
+	}
+	if os.SameFile(openedInfo, activeInfo) {
+		return nil
+	}
+
+	replacement, err := os.OpenFile(r.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("reopening rotated event log: %w", err)
+	}
+	stale := r.file
+	r.file = replacement
+	if err := stale.Close(); err != nil {
+		return fmt.Errorf("closing rotated event log: %w", err)
 	}
 	return nil
 }
@@ -379,8 +438,8 @@ func writeBatch(writer io.Writer, data []byte) error {
 
 // writeRecordLocked appends e to the active log under the recorder
 // mutex. Auto-fills Seq and Ts (if zero). The caller must already
-// hold both r.mu and (if cross-process safety matters) the file's
-// flock. Returns an error on marshal or write failure; the caller
+// hold both r.mu and (if cross-process safety matters) the stable
+// recorder lock. Returns an error on marshal or write failure; the caller
 // decides whether to log to stderr or surface it.
 func (r *FileRecorder) writeRecordLocked(e *Event) error {
 	if latest, err := readLatestActiveSeq(r.path); err == nil && latest > r.seq {
@@ -452,18 +511,29 @@ func (r *FileRecorder) maybeAutoRotateLocked() {
 // threshold. Safe to call concurrently with Record. Returns a
 // no-op result with Rotated=false if the active log is empty (an
 // empty file is never archived).
-func (r *FileRecorder) ForceRotate() (RotationResult, error) {
+func (r *FileRecorder) ForceRotate() (result RotationResult, resultErr error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {
 		return RotationResult{}, fmt.Errorf("recorder is closed")
 	}
+	if err := r.lockRecorder(); err != nil {
+		return RotationResult{}, fmt.Errorf("lock: %w", err)
+	}
+	defer func() {
+		if err := r.unlockRecorder(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("unlock: %w", err))
+		}
+	}()
+	if err := r.reopenActiveIfRotatedLocked(); err != nil {
+		return RotationResult{}, err
+	}
 	return r.rotateLocked()
 }
 
-// rotateLocked performs the close+rename+open+anchor sequence. It
-// must be called with r.mu held. The caller is responsible for
-// checking r.closed.
+// rotateLocked performs the close+rename+open+anchor sequence. It must be
+// called with r.mu and the stable recorder lock held. The caller is responsible
+// for checking r.closed and ensuring r.file still names the active path.
 //
 // On success, the prior active log is renamed to
 // events.jsonl.rotating-<ts> and a background goroutine compresses
@@ -692,21 +762,27 @@ func (w *fileWatcher) closeFd() {
 // process opens a recorder and runs the orphan reaper.
 func (r *FileRecorder) Close() error {
 	r.mu.Lock()
-	if r.closed {
+	if r.closed && r.file == nil && r.lockFile == nil {
 		r.mu.Unlock()
 		return nil
 	}
 	r.closed = true
 	file := r.file
 	r.file = nil
+	lockFile := r.lockFile
+	r.lockFile = nil
 	r.mu.Unlock()
 
 	r.rotations.Wait()
 
-	if file == nil {
-		return nil
+	var closeErr error
+	if file != nil {
+		closeErr = errors.Join(closeErr, file.Close())
 	}
-	return file.Close()
+	if lockFile != nil {
+		closeErr = errors.Join(closeErr, lockFile.Close())
+	}
+	return closeErr
 }
 
 // WaitForRotations blocks until every in-flight rotation goroutine

--- a/internal/events/recorder_batch_test.go
+++ b/internal/events/recorder_batch_test.go
@@ -90,7 +90,7 @@ func TestFileRecorderAppendBatchSurfacesClosedAndLockErrors(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() { _ = recorder.Close() })
-		sibling := mustOpenSiblingLock(t, path)
+		sibling := mustOpenSiblingLock(t, recorderLockPath(path))
 		t.Cleanup(func() { _ = sibling.Close() })
 
 		err = recorder.AppendBatch([]Event{{Type: ExecutionStepDefined}})

--- a/internal/events/rotation_force_test.go
+++ b/internal/events/rotation_force_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -134,6 +135,134 @@ func TestForceRotateMovesEventsToArchiveAndWritesAnchor(t *testing.T) {
 	}
 	if active[1].Seq != active[0].Seq+1 {
 		t.Errorf("post-rotate Seq = %d, want %d", active[1].Seq, active[0].Seq+1)
+	}
+}
+
+// A second long-lived recorder can hold the pre-rotation inode open. Its first
+// write after another recorder rotates must follow the path to the fresh active
+// file; otherwise it appends to an unlinked or in-flight rotating file whose
+// filename window was already fixed, making the event invisible to cursored
+// readers.
+func TestForceRotateMovesPeerRecorderToFreshActiveFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var rotatingStderr, peerStderr bytes.Buffer
+	rotating, err := NewFileRecorder(path, &rotatingStderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rotating.Close() //nolint:errcheck // test cleanup
+
+	peer, err := NewFileRecorder(path, &peerStderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer peer.Close() //nolint:errcheck // test cleanup
+
+	rotating.Record(Event{Type: BeadCreated, Actor: "rotator", Subject: "before"})
+	res, err := rotating.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate: %v", err)
+	}
+	if res.Done == nil {
+		t.Fatal("ForceRotate returned a nil completion channel")
+	}
+
+	// Append before compression completes to cover the production interleaving:
+	// rotation has fixed the old inode's filename window, while a peer that
+	// opened before the rename still holds that inode's descriptor.
+	peer.Record(Event{Type: BeadUpdated, Actor: "peer", Subject: "after"})
+	select {
+	case <-res.Done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("rotation compression did not complete")
+	}
+	archiveInfo, err := parseArchiveBasename(filepath.Base(res.ArchivePath))
+	if err != nil {
+		t.Fatalf("parse archive name: %v", err)
+	}
+	physicalFirst, physicalLast, err := readGzipSeqWindow(res.ArchivePath)
+	if err != nil {
+		t.Fatalf("read physical archive window: %v", err)
+	}
+	if physicalFirst != archiveInfo.FirstSeq || physicalLast != archiveInfo.LastSeq {
+		t.Fatalf("physical archive window = [%d,%d], filename window = [%d,%d]",
+			physicalFirst, physicalLast, archiveInfo.FirstSeq, archiveInfo.LastSeq)
+	}
+
+	active, err := readActiveOnly(path)
+	if err != nil {
+		t.Fatalf("read active: %v", err)
+	}
+	if len(active) != 2 {
+		t.Fatalf("active event count = %d, want anchor + peer event; events=%+v; peer stderr=%q",
+			len(active), active, peerStderr.String())
+	}
+	if active[0].Type != EventsRotated || active[0].Seq != 2 {
+		t.Fatalf("active anchor = %+v, want events.rotated seq 2", active[0])
+	}
+	if active[1].Subject != "after" || active[1].Seq != 3 {
+		t.Fatalf("peer event = %+v, want subject after seq 3", active[1])
+	}
+
+	all, err := ReadAll(path)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("ReadAll count = %d, want 3; events=%+v", len(all), all)
+	}
+	for i, event := range all {
+		wantSeq := uint64(i + 1)
+		if event.Seq != wantSeq {
+			t.Fatalf("event[%d].Seq = %d, want %d; events=%+v", i, event.Seq, wantSeq, all)
+		}
+	}
+	after, err := ReadFiltered(path, Filter{AfterSeq: 1})
+	if err != nil {
+		t.Fatalf("ReadFiltered(AfterSeq=1): %v", err)
+	}
+	if len(after) != 2 || after[0].Seq != 2 || after[1].Seq != 3 {
+		t.Fatalf("ReadFiltered(AfterSeq=1) seqs = %v, want [2 3]", seqsOf(after))
+	}
+	if rotatingStderr.Len() != 0 || peerStderr.Len() != 0 {
+		t.Fatalf("unexpected recorder stderr: rotating=%q peer=%q", rotatingStderr.String(), peerStderr.String())
+	}
+}
+
+func TestForceRotateWaitsForPeerRecorderLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	recorder, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recorder.Close() //nolint:errcheck // test cleanup
+	recorder.Record(Event{Type: BeadCreated, Subject: "before"})
+
+	peerLock := mustOpenSiblingLock(t, recorderLockPath(path))
+	time.AfterFunc(50*time.Millisecond, func() {
+		_ = syscall.Flock(int(peerLock.Fd()), syscall.LOCK_UN)
+		_ = peerLock.Close()
+	})
+
+	started := time.Now()
+	result, err := recorder.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed < 40*time.Millisecond {
+		t.Fatalf("ForceRotate acquired peer-held recorder lock after %v, want at least 40ms", elapsed)
+	}
+	if !result.Rotated {
+		t.Fatalf("ForceRotate result = %+v, want a rotation", result)
+	}
+	if result.Done != nil {
+		<-result.Done
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected recorder stderr: %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Outcome

Coordinates event recording and rotation through a stable sidecar flock so long-lived peer recorders reopen the active path after an inode-changing rename. This keeps archive filename windows aligned with physical contents and preserves ordered `AfterSeq` reads without loss or duplication.

Closes work item `gs-q5lwb.1`.

## Changes

- keep `events.jsonl.lock` open for the recorder lifetime and use it for `Record`, `AppendBatch`, and `ForceRotate`
- detect stale active-log descriptors with `os.SameFile` and reopen the current path before appending
- add concurrent recorder regression coverage for archive windows, active anchors, full reads, and cursored reads
- retain bounded flock contention behavior and cover rotation waiting on a peer-held lock

## Verification

- `go test -count=10 -run ^TestForceRotateMovesPeerRecorderToFreshActiveFile$ ./internal/events`
- `go test -count=1 -timeout=5m ./internal/events`
- `go test -race -count=1 ./internal/events`
- focused `internal/api` and `cmd/gc` event-rotation tests with CGO disabled
- resource census, `go vet ./...`, staged formatter/linter, code generation, and pre-commit hook

## Local gate exception

The host lacks ICU headers for native CGO builds, so affected API and CLI checks used CGO disabled. The full local push gate also hit the unrelated timing assertion `TestStopManagedCityForcesCleanupAfterTimeout` under host load above 75. An exact detached `origin/main` worktree at `615f5b794` reproduces the same failure (`564.9ms`, bounded-timeout assertion), while all affected patch suites pass. The ownership guard was run manually before the documented exceptional `--no-verify` fork push; required remote CI remains authoritative.