### PR TITLE
fix(status): defer local store reads behind API route

### DIFF
--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -186,11 +186,43 @@ func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int
 		return 1
 	}
 
+	// The local snapshot opens the bead/Dolt store. Keep it behind the API
+	// fallback: the supervisor serves a cached status view, so touching the
+	// contended local store first defeats the bounded control-plane route and
+	// can leave gc status with no output until an external timeout kills it.
+	localFallback := func() int {
+		return cmdCityStatusLocalFallback(cfg, cityPath, jsonOutput, stdout, stderr)
+	}
+	c, reason := cityStatusAPIClient(cityPath)
+	if c == nil {
+		logRoute(stderr, "status", "fallback", reason)
+		return localFallback()
+	}
+
+	// API rendering only needs the runtime provider for drain-state display;
+	// a nil session snapshot deliberately avoids a bead-store read here.
+	sp, err := newStatusSessionProviderForCityWithSnapshot(cfg, cityPath, nil)
+	if err != nil {
+		message := fmt.Sprintf("gc status: %v", err)
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "session_provider_failed", message, 1)
+		}
+		fmt.Fprintln(stderr, message) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	dops := newDrainOps(sp)
+	return routeCityStatus(cityPath, cfg, sp, dops, c, reason, jsonOutput, stdout, stderr, localFallback)
+}
+
+// cmdCityStatusLocalFallback builds the direct-store status view only when no
+// supervisor API response is available. Its provider receives the loaded
+// session snapshot because ACP transport routing depends on that local state.
+func cmdCityStatusLocalFallback(cfg *config.City, cityPath string, jsonOutput bool, stdout, stderr io.Writer) int {
 	storeStderr := stderr
 	if jsonOutput {
 		storeStderr = io.Discard
 	}
-	store, _, code := openCityStatusStore(cityPath, storeStderr)
+	store, diagnostic, code := openCityStatusStore(cityPath, storeStderr)
 	if code != 0 {
 		if jsonOutput {
 			return writeJSONError(stdout, stderr, "store_open_failed", "gc status: opening bead store failed", code)
@@ -208,8 +240,10 @@ func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int
 		return 1
 	}
 	dops := newDrainOps(sp)
-	c, reason := cityStatusAPIClient(cityPath)
-	return routeCityStatus(cityPath, cfg, sp, dops, c, reason, jsonOutput, stdout, stderr)
+	if jsonOutput {
+		return doCityStatusJSONWithDiagnosticAndSnapshot(sp, cfg, cityPath, store, diagnostic, statusSnapshot, stdout, stderr)
+	}
+	return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, statusSnapshot, stdout, stderr)
 }
 
 // cityStatusAPIClient returns (client, "") when the API path is available,
@@ -240,7 +274,22 @@ func routeCityStatus(
 	nilReason string,
 	jsonOutput bool,
 	stdout, stderr io.Writer,
+	fallbacks ...func() int,
 ) int {
+	fallback := func() int {
+		store, diagnostic, code := openCityStatusStore(cityPath, stderr)
+		if code != 0 {
+			return code
+		}
+		statusSnapshot := loadStatusSessionSnapshot(cityPath, cfg, cliSessionStore(store, cfg, cityPath), stderr)
+		if jsonOutput {
+			return doCityStatusJSONWithDiagnosticAndSnapshot(sp, cfg, cityPath, store, diagnostic, statusSnapshot, stdout, stderr)
+		}
+		return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, statusSnapshot, stdout, stderr)
+	}
+	if len(fallbacks) > 0 && fallbacks[0] != nil {
+		fallback = fallbacks[0]
+	}
 	var cr api.CachedRead[api.StatusView]
 	return routeRead(c, "status", nilReason, stderr,
 		func() error {
@@ -249,17 +298,7 @@ func routeCityStatus(
 			return err
 		},
 		func() int { return renderCityStatusFromAPI(cityPath, cr, dops, jsonOutput, stdout) },
-		func() int {
-			store, diagnostic, code := openCityStatusStore(cityPath, stderr)
-			if code != 0 {
-				return code
-			}
-			statusSnapshot := loadStatusSessionSnapshot(cityPath, cfg, cliSessionStore(store, cfg, cityPath), stderr)
-			if jsonOutput {
-				return doCityStatusJSONWithDiagnosticAndSnapshot(sp, cfg, cityPath, store, diagnostic, statusSnapshot, stdout, stderr)
-			}
-			return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, statusSnapshot, stdout, stderr)
-		},
+		fallback,
 	)
 }
 

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -1195,6 +1195,49 @@ func TestCmdCityStatus_SupervisorManagedNoAPIPortUsesSupervisorAPI(t *testing.T)
 	}
 }
 
+// TestCmdCityStatus_APIRouteDoesNotOpenLocalStore keeps the supervisor route
+// ahead of every bead/Dolt read. During a store-contention burst, opening the
+// local store can block even while the supervisor's cached status endpoint is
+// healthy; doing that work before choosing the API route made gc status emit
+// no output until the external command timeout killed it.
+func TestCmdCityStatus_APIRouteDoesNotOpenLocalStore(t *testing.T) {
+	t.Setenv("GC_DEBUG", "1")
+	cityPath := writeCityStatusTestCity(t)
+	if err := os.Mkdir(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("create store marker: %v", err)
+	}
+
+	srv := httptest.NewServer(okCityStatusHandler(t))
+	defer srv.Close()
+
+	origAlive, origSup := apiRouteControllerAliveHook, apiRouteSupervisorClientHook
+	origOpen := openCityStoreAtForStatus
+	t.Cleanup(func() {
+		apiRouteControllerAliveHook = origAlive
+		apiRouteSupervisorClientHook = origSup
+		openCityStoreAtForStatus = origOpen
+	})
+	apiRouteControllerAliveHook = func(string) int { return 4242 }
+	apiRouteSupervisorClientHook = func(cp string) *api.Client {
+		if cp != cityPath {
+			return nil
+		}
+		return api.NewCityScopedClient(srv.URL, "test-city")
+	}
+	openCityStoreAtForStatus = func(string) (beads.StoreOpenResult, error) {
+		t.Fatal("gc status opened the local bead store before using the healthy supervisor API")
+		return beads.StoreOpenResult{}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdCityStatus([]string{cityPath}, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdCityStatus exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "route=api") {
+		t.Fatalf("stderr missing route=api: %s", stderr.String())
+	}
+}
+
 // TestRouteCityStatus_APIJSONIncludesCacheAge verifies the API-path JSON
 // output carries the _cache_age_s envelope field while the fallback path
 // omits it. Enforces D5 from the gc-read-path design doc.


### PR DESCRIPTION
## Summary
- route supervisor-backed `gc status` before opening the local bead/Dolt store
- retain the original snapshot-aware local fallback when the control-plane route is unavailable
- add a regression test proving a healthy API route never opens the local store

## Root cause
`cmdCityStatus` opened the local city bead/Dolt store to construct its session snapshot before checking the supervisor's cached status API. Under unrelated local store contention this left `gc status` with no output despite a healthy control plane. The local open now occurs only in the API fallback.

`order-firing-current` already returns its existing bounded advisory result for a timed-out history lookup; its focused timeout and history-parallelism coverage was revalidated.

## Verification
- `CGO_ENABLED=0 go test -count=1 -v -run '^TestCmdCityStatus_(SupervisorManagedNoAPIPortUsesSupervisorAPI|APIRouteDoesNotOpenLocalStore)$' ./cmd/gc`
- `CGO_ENABLED=0 go test -count=1 -v -run '^(TestOrderFiringCurrent_TimesOutStalledOrderHistory|TestOrderFiringCurrent_TimeoutHintNamesQueryCost|TestOrderFiringCurrent_LastRunLookupsRunInParallel)$' ./internal/doctor`
- `CGO_ENABLED=0 go vet ./cmd/gc`

## Pre-push exception
The required fast gate failed in an unrelated baseline test. The exact serial command `CGO_ENABLED=0 go test -count=1 -run '^TestDefaultRunNetworkGitKillsDescendants$' ./internal/packman` failed identically on this branch (9f158b54e) and a detached clean `origin/main` worktree (615f5b794), both with the heartbeat-file timeout in `network_git_group_unix_test.go:44`. This comparison is recorded in gs-kxlj; the branch was pushed with an explicitly authorized `--no-verify` exception.