### PR TITLE
Select the safe option in workspace-trust dialogs

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -654,6 +654,13 @@ func containsWorkspaceTrustDialog(content string) bool {
 		strings.Contains(content, "Trust project folder?")
 }
 
+// workspaceTrustConfirmKeys is not yet implemented: it always reports no
+// confirmation available. TODO(GREEN): inspect the cursor row and compute
+// the keys needed to move onto the trust option before confirming.
+func workspaceTrustConfirmKeys(_ string) ([]string, bool) {
+	return nil, false
+}
+
 func containsPostTrustStartupDialog(content string) bool {
 	return containsExternalImportsDialog(content) ||
 		containsMCPTrustDialog(content) ||

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -584,8 +584,11 @@ func containsPostUpdateStartupDialog(content string) bool {
 // acceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
 // agents. Claude shows "Quick safety check"; Codex shows
 // "Do you trust the contents of this directory?"; pi (>= 0.79) shows
-// "Trust project folder?". In all cases the safe continue option is
-// pre-selected, so Enter accepts.
+// "Trust project folder?". The safe option isn't reliably pre-selected — a
+// stale Claude Code build can default the cursor to "No, exit" — so the
+// handler locates the cursor and the trust option in the rendered content
+// and moves the selection before confirming; it never blind-sends a fixed
+// key sequence, and sends nothing at all when it can't locate both rows.
 func acceptWorkspaceTrustDialog(
 	ctx context.Context,
 	budget *startupDialogBudget,
@@ -603,12 +606,14 @@ func acceptWorkspaceTrustDialog(
 		}
 
 		if containsWorkspaceTrustDialog(content) {
-			budget.observe()
-			if err := sendKeys("Enter"); err != nil {
-				return err
+			if keys, ok := workspaceTrustConfirmKeys(content); ok {
+				budget.observe()
+				if err := sendKeys(keys...); err != nil {
+					return err
+				}
+				sleep(ctx, startupDialogAcceptDelay)
+				return nil
 			}
-			sleep(ctx, startupDialogAcceptDelay)
-			return nil
 		}
 
 		if containsPromptIndicator(content) {
@@ -638,11 +643,11 @@ func acceptWorkspaceTrustDialogFromStream(
 	sendKeys func(keys ...string) error,
 ) (bool, error) {
 	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
-		match:       containsWorkspaceTrustDialog,
-		matchKeys:   []string{"Enter"},
-		matchDelay:  startupDialogAcceptDelay,
-		ready:       containsPromptIndicator,
-		readyOrNext: containsPostTrustStartupDialog,
+		match:        containsWorkspaceTrustDialog,
+		matchKeysFor: workspaceTrustConfirmKeys,
+		matchDelay:   startupDialogAcceptDelay,
+		ready:        containsPromptIndicator,
+		readyOrNext:  containsPostTrustStartupDialog,
 	})
 }
 
@@ -654,11 +659,115 @@ func containsWorkspaceTrustDialog(content string) bool {
 		strings.Contains(content, "Trust project folder?")
 }
 
-// workspaceTrustConfirmKeys is not yet implemented: it always reports no
-// confirmation available. TODO(GREEN): inspect the cursor row and compute
-// the keys needed to move onto the trust option before confirming.
-func workspaceTrustConfirmKeys(_ string) ([]string, bool) {
-	return nil, false
+// trustDialogLayout describes how one coding agent renders its
+// workspace-trust confirmation as a cursor-selectable option list: the
+// marker glyphs that can mark the selected row, and how to recognize the
+// row whose label is the safe "trust this workspace" option.
+type trustDialogLayout struct {
+	markers    []string
+	isTrustRow func(label string) bool
+}
+
+var claudeTrustDialogLayout = trustDialogLayout{
+	markers: []string{"❯", ">"},
+	isTrustRow: func(label string) bool {
+		return strings.Contains(strings.ToLower(label), "trust this folder") && !strings.HasPrefix(label, "No")
+	},
+}
+
+var geminiTrustDialogLayout = trustDialogLayout{
+	markers: []string{"●"},
+	isTrustRow: func(label string) bool {
+		return strings.Contains(strings.ToLower(label), "trust folder")
+	},
+}
+
+var piTrustDialogLayout = trustDialogLayout{
+	markers: []string{"→"},
+	isTrustRow: func(label string) bool {
+		return strings.EqualFold(strings.TrimSpace(label), "Trust")
+	},
+}
+
+// workspaceTrustConfirmKeys locates the cursor row and the safe trust
+// option in a rendered workspace-trust dialog and returns the keys that
+// move the selection onto that option and confirm it. Claude, Gemini, and
+// pi each render the confirmation as a cursor-navigable option list, but
+// with their own marker glyph and label wording (Claude: "❯"/"trust this
+// folder"; Gemini: "●"/"trust folder"; pi: "→"/"Trust"), so which layout to
+// scan with is chosen by which question text matched. Codex's trust prompt
+// has no rendered option list at all, so it's answered unconditionally —
+// there is no wrong selection to guard against.
+//
+// For the list-style layouts, it reports ok=false when the cursor or the
+// trust row can't be located — a layout still mid-render, or one none of
+// the known layouts match — so the caller sends nothing rather than
+// guessing: a fixed key sequence would confirm whichever option happens to
+// be pre-selected, including a "don't trust" option (the original bug, for
+// Claude).
+func workspaceTrustConfirmKeys(content string) ([]string, bool) {
+	switch {
+	case strings.Contains(content, "trust this folder") || strings.Contains(content, "Quick safety check"):
+		return deriveTrustDialogKeys(content, claudeTrustDialogLayout)
+	case strings.Contains(content, "Do you trust the files in this folder?"):
+		return deriveTrustDialogKeys(content, geminiTrustDialogLayout)
+	case strings.Contains(content, "Trust project folder?"):
+		return deriveTrustDialogKeys(content, piTrustDialogLayout)
+	case strings.Contains(content, "Do you trust the contents of this directory?"):
+		return []string{"Enter"}, true
+	default:
+		return nil, false
+	}
+}
+
+func deriveTrustDialogKeys(content string, layout trustDialogLayout) ([]string, bool) {
+	lines := strings.Split(content, "\n")
+	cutset := strings.Join(layout.markers, "") + " "
+
+	cursorIdx, trustIdx := -1, -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if cursorIdx == -1 {
+			for _, marker := range layout.markers {
+				if strings.HasPrefix(trimmed, marker) {
+					cursorIdx = i
+					break
+				}
+			}
+		}
+
+		if trustIdx == -1 {
+			label := strings.TrimSpace(strings.TrimLeft(trimmed, cutset))
+			if layout.isTrustRow(label) {
+				trustIdx = i
+			}
+		}
+	}
+
+	if cursorIdx == -1 || trustIdx == -1 {
+		return nil, false
+	}
+
+	switch delta := trustIdx - cursorIdx; {
+	case delta > 0:
+		keys := make([]string, 0, delta+1)
+		for i := 0; i < delta; i++ {
+			keys = append(keys, "Down")
+		}
+		return append(keys, "Enter"), true
+	case delta < 0:
+		keys := make([]string, 0, -delta+1)
+		for i := 0; i < -delta; i++ {
+			keys = append(keys, "Up")
+		}
+		return append(keys, "Enter"), true
+	default:
+		return []string{"Enter"}, true
+	}
 }
 
 func containsPostTrustStartupDialog(content string) bool {
@@ -1195,7 +1304,14 @@ type streamDialogSpec struct {
 	ready       func(string) bool
 	readyOrNext func(string) bool
 	matchKeys   []string
-	matchDelay  time.Duration
+	// matchKeysFor, when set, computes the keys to send from the matched
+	// content instead of using the static matchKeys — e.g. deriving the
+	// cursor movement needed for a dialog whose safe option isn't always
+	// pre-selected. A false second return means the content matched but
+	// the correct keys couldn't be determined yet; the match is treated
+	// as not found so the caller keeps waiting rather than guessing.
+	matchKeysFor func(string) ([]string, bool)
+	matchDelay   time.Duration
 }
 
 type replayableSnapshotStream struct {
@@ -1332,8 +1448,14 @@ func acceptDialogFromStream(
 		if len(history) > 0 {
 			for idx, content := range history {
 				if spec.match != nil && spec.match(content) {
-					snapshots.replay(history[idx+1:])
-					return true, sendDialogKeys(ctx, sendKeys, spec.matchKeys, spec.matchDelay)
+					keys, ok := spec.matchKeys, true
+					if spec.matchKeysFor != nil {
+						keys, ok = spec.matchKeysFor(content)
+					}
+					if ok {
+						snapshots.replay(history[idx+1:])
+						return true, sendDialogKeys(ctx, sendKeys, keys, spec.matchDelay)
+					}
 				}
 				if spec.readyOrNext != nil && spec.readyOrNext(content) {
 					snapshots.replay(history[idx:])

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -588,7 +588,9 @@ func containsPostUpdateStartupDialog(content string) bool {
 // stale Claude Code build can default the cursor to "No, exit" — so the
 // handler locates the cursor and the trust option in the rendered content
 // and moves the selection before confirming; it never blind-sends a fixed
-// key sequence, and sends nothing at all when it can't locate both rows.
+// key sequence. When it can't locate both rows it sends no keys, and the
+// snapshot falls through to the existing readiness check, which hands the
+// phase off. Holding the phase open instead is tracked separately.
 func acceptWorkspaceTrustDialog(
 	ctx context.Context,
 	budget *startupDialogBudget,
@@ -669,7 +671,10 @@ type trustDialogLayout struct {
 }
 
 var claudeTrustDialogLayout = trustDialogLayout{
-	markers: []string{"❯", ">"},
+	// Only "❯": a bare ">" is the most common false cursor in terminal
+	// scrollback (shell prompts, quoted text, diff context), and the real
+	// captured pane uses "❯".
+	markers: []string{"❯"},
 	isTrustRow: func(label string) bool {
 		return strings.Contains(strings.ToLower(label), "trust this folder") && !strings.HasPrefix(label, "No")
 	},
@@ -708,11 +713,18 @@ var piTrustDialogLayout = trustDialogLayout{
 func workspaceTrustConfirmKeys(content string) ([]string, bool) {
 	switch {
 	case strings.Contains(content, "trust this folder") || strings.Contains(content, "Quick safety check"):
-		return deriveTrustDialogKeys(content, claudeTrustDialogLayout)
+		// "Quick safety check" is the dialog's header line, so it anchors the
+		// scan above every option row. "trust this folder" is itself an option
+		// label, so it only anchors when the header isn't rendered.
+		question := "Quick safety check"
+		if !strings.Contains(content, question) {
+			question = "trust this folder"
+		}
+		return deriveTrustDialogKeys(content, question, claudeTrustDialogLayout)
 	case strings.Contains(content, "Do you trust the files in this folder?"):
-		return deriveTrustDialogKeys(content, geminiTrustDialogLayout)
+		return deriveTrustDialogKeys(content, "Do you trust the files in this folder?", geminiTrustDialogLayout)
 	case strings.Contains(content, "Trust project folder?"):
-		return deriveTrustDialogKeys(content, piTrustDialogLayout)
+		return deriveTrustDialogKeys(content, "Trust project folder?", piTrustDialogLayout)
 	case strings.Contains(content, "Do you trust the contents of this directory?"):
 		return []string{"Enter"}, true
 	default:
@@ -720,13 +732,23 @@ func workspaceTrustConfirmKeys(content string) ([]string, bool) {
 	}
 }
 
-func deriveTrustDialogKeys(content string, layout trustDialogLayout) ([]string, bool) {
+// deriveTrustDialogKeys locates the cursor row and the trust row in a
+// rendered option-list trust dialog and returns the keys that move the
+// selection onto the trust row and confirm it. question is the literal that
+// identified the dialog; the scan is scoped to the dialog itself so
+// scrollback can't supply a false cursor row.
+func deriveTrustDialogKeys(content, question string, layout trustDialogLayout) ([]string, bool) {
+	content = trustDialogWindow(content, question)
 	lines := strings.Split(content, "\n")
 	cutset := strings.Join(layout.markers, "") + " "
 
 	cursorIdx, trustIdx := -1, -1
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		// Strip a leading box-drawing border the same way
+		// containsPromptIndicator does, so a trust dialog a TUI renders inside
+		// a bordered box ("│ ❯ Yes, I trust this folder") still yields both a
+		// cursor row and a label instead of no keys at all.
+		trimmed := stripLeadingBoxBorder(strings.TrimSpace(line))
 		if trimmed == "" {
 			continue
 		}
@@ -768,6 +790,21 @@ func deriveTrustDialogKeys(content string, layout trustDialogLayout) ([]string, 
 	default:
 		return []string{"Enter"}, true
 	}
+}
+
+// trustDialogWindow narrows content to the rendered dialog by starting at the
+// line carrying the last occurrence of question. peek returns the whole pane
+// (capture-pane -S -120), so index 0 is up to 120 lines of scrollback above
+// the dialog, any of which could otherwise be mistaken for the cursor row.
+func trustDialogWindow(content, question string) string {
+	i := strings.LastIndex(content, question)
+	if i < 0 {
+		return content
+	}
+	if start := strings.LastIndexByte(content[:i], '\n'); start >= 0 {
+		return content[start+1:]
+	}
+	return content
 }
 
 func containsPostTrustStartupDialog(content string) bool {
@@ -1308,8 +1345,9 @@ type streamDialogSpec struct {
 	// content instead of using the static matchKeys — e.g. deriving the
 	// cursor movement needed for a dialog whose safe option isn't always
 	// pre-selected. A false second return means the content matched but
-	// the correct keys couldn't be determined yet; the match is treated
-	// as not found so the caller keeps waiting rather than guessing.
+	// the correct keys couldn't be determined; no keys are sent for that
+	// snapshot rather than guessing, and it falls through to the spec's
+	// readiness checks like any unmatched snapshot.
 	matchKeysFor func(string) ([]string, bool)
 	matchDelay   time.Duration
 }

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -1602,7 +1602,7 @@ func TestAcceptStartupDialogsWithTimeoutRefreshesBudgetOnProgress(t *testing.T) 
 				if time.Since(start) < renderDelay {
 					return "", nil // agent still booting: nothing on screen yet
 				}
-				return "Quick safety check", nil
+				return "Quick safety check: Is this a project you created or one you trust?\n\n❯ Yes, I trust this folder\n  No, exit\n\nEnter to confirm · Esc to cancel", nil
 			}
 			if time.Since(trustAccepted) < renderDelay {
 				return "", nil // next dialog has not rendered yet

--- a/internal/runtime/dialog_trust_selection_test.go
+++ b/internal/runtime/dialog_trust_selection_test.go
@@ -82,9 +82,12 @@ func TestWorkspaceTrustConfirmKeysNoExitSelected(t *testing.T) {
 }
 
 func TestWorkspaceTrustConfirmKeysUnrecognizedLayoutSendsNothing(t *testing.T) {
-	const content = ` Do you trust the contents of this directory?
+	const content = ` Quick safety check: Is this a project you created or one you trust?
 
- (layout not yet fully rendered)`
+ ❯ Some future option we don't recognize
+   Another unrecognized option
+
+ Enter to confirm · Esc to cancel`
 
 	keys, ok := workspaceTrustConfirmKeys(content)
 	if ok {

--- a/internal/runtime/dialog_trust_selection_test.go
+++ b/internal/runtime/dialog_trust_selection_test.go
@@ -112,3 +112,79 @@ func TestWorkspaceTrustConfirmKeysUnrecognizedLayoutSendsNothing(t *testing.T) {
 		t.Errorf("acceptWorkspaceTrustDialog() sent = %v, want no keys sent for an unrecognized trust layout", sent)
 	}
 }
+
+// trustDialogScrollback is plausible pane scrollback sitting above the live
+// dialog. peek uses capture-pane -S -120, so this is what index 0 of the
+// scanned content actually is. It deliberately carries both a "> " row and a
+// "❯ " row: neither may be mistaken for the dialog's cursor.
+const trustDialogScrollback = `$ gc rig add hold-court /home/u/src/hold-court
+> rig "hold-court" registered
+$ git log --oneline -3
+1639750d7 feat: green — Fix trust dialog selection
+17333ea11 Retry store-read timeouts instead of quarantining finalizers
+c96e54a3a feat(rppcheck): verify declared nudge fallback capability
+$ git show HEAD --stat
+> internal/runtime/dialog.go | 118 ++++++++++++-
+> 1 file changed, 114 insertions(+), 4 deletions(-)
+$ cat notes.md
+> Reviewer asked:
+> ❯ why does the seat die during startup?
+$ gc pool start builder
+  starting seat 1 of 4
+  starting seat 2 of 4
+$ claude
+ Welcome to Claude Code
+
+`
+
+func TestWorkspaceTrustConfirmKeysIgnoresScrollbackCursor(t *testing.T) {
+	content := trustDialogScrollback + realTrustDialogNoExitSelected
+
+	keys, ok := workspaceTrustConfirmKeys(content)
+	if !ok {
+		t.Fatalf("workspaceTrustConfirmKeys() ok = false, want true")
+	}
+	if want := []string{"Down", "Enter"}; !reflect.DeepEqual(keys, want) {
+		t.Errorf("workspaceTrustConfirmKeys() = %v, want %v\n"+
+			"scrollback above the dialog must not supply the cursor row", keys, want)
+	}
+}
+
+func TestWorkspaceTrustConfirmKeysBorderedLayout(t *testing.T) {
+	var bordered strings.Builder
+	for i, line := range strings.Split(realTrustDialogNoExitSelected, "\n") {
+		if i > 0 {
+			bordered.WriteString("\n")
+		}
+		bordered.WriteString("│ " + line)
+	}
+
+	keys, ok := workspaceTrustConfirmKeys(bordered.String())
+	if !ok {
+		t.Fatalf("workspaceTrustConfirmKeys() ok = false, want true for a bordered dialog")
+	}
+	if want := []string{"Down", "Enter"}; !reflect.DeepEqual(keys, want) {
+		t.Errorf("workspaceTrustConfirmKeys() = %v, want %v", keys, want)
+	}
+}
+
+func TestWorkspaceTrustConfirmKeysUpwardMovement(t *testing.T) {
+	// pi renders its trust prompt with the cursor able to start below the
+	// trust row, which is the only layout that needs Up rather than Down.
+	const content = ` Trust project folder?
+
+ /home/u/src/hold-court
+
+   Trust
+ → Don't trust
+
+ Enter to confirm · Esc to cancel`
+
+	keys, ok := workspaceTrustConfirmKeys(content)
+	if !ok {
+		t.Fatalf("workspaceTrustConfirmKeys() ok = false, want true")
+	}
+	if want := []string{"Up", "Enter"}; !reflect.DeepEqual(keys, want) {
+		t.Errorf("workspaceTrustConfirmKeys() = %v, want %v", keys, want)
+	}
+}

--- a/internal/runtime/dialog_trust_selection_test.go
+++ b/internal/runtime/dialog_trust_selection_test.go
@@ -1,0 +1,111 @@
+package runtime
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// realTrustDialogNoExitSelected is the verbatim pane content captured from a
+// dying pool seat (hold-court--builder-pool,
+// .gc/sessions/hold-court--builder-pool/start-stderr.log, 2026-09-01). The
+// cursor marker sits on "No, exit", not on the trust option.
+const realTrustDialogNoExitSelected = ` Accessing workspace:
+
+ /home/u/.gc/worktrees/hold-court/builder
+
+ Quick safety check: Is this a project you created or one you trust? (Like your
+ own code, a well-known open source project, or work from your team). If not,
+ take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ No, exit
+   Yes, I trust this folder
+
+ Enter to confirm · Esc to cancel`
+
+func TestWorkspaceTrustDialogDoesNotConfirmNoExit(t *testing.T) {
+	withZeroDialogTimings(t)
+
+	if !containsWorkspaceTrustDialog(realTrustDialogNoExitSelected) {
+		t.Fatalf("precondition: matcher should recognize the real trust dialog")
+	}
+
+	var sent []string
+	err := acceptWorkspaceTrustDialog(
+		context.Background(),
+		newStartupDialogBudget(time.Second),
+		func(int) (string, error) { return realTrustDialogNoExitSelected, nil },
+		func(keys ...string) error { sent = append(sent, keys...); return nil },
+	)
+	if err != nil {
+		t.Fatalf("acceptWorkspaceTrustDialog() error = %v", err)
+	}
+
+	if len(sent) > 0 && strings.EqualFold(sent[0], "Enter") {
+		t.Errorf("handler confirmed while %q was the selected row: sent=%v\n"+
+			"want the selection moved onto the trust option first (e.g. [Down Enter]), "+
+			"as acceptMCPTrustDialog already does", "No, exit", sent)
+	}
+}
+
+func TestWorkspaceTrustConfirmKeysTrustPreSelected(t *testing.T) {
+	const content = ` Quick safety check: Is this a project you created or one you trust?
+
+ ❯ Yes, I trust this folder
+   No, exit
+
+ Enter to confirm · Esc to cancel`
+
+	keys, ok := workspaceTrustConfirmKeys(content)
+	if !ok {
+		t.Fatalf("workspaceTrustConfirmKeys() ok = false, want true")
+	}
+	if want := []string{"Enter"}; !reflect.DeepEqual(keys, want) {
+		t.Errorf("workspaceTrustConfirmKeys() = %v, want %v", keys, want)
+	}
+}
+
+func TestWorkspaceTrustConfirmKeysNoExitSelected(t *testing.T) {
+	keys, ok := workspaceTrustConfirmKeys(realTrustDialogNoExitSelected)
+	if !ok {
+		t.Fatalf("workspaceTrustConfirmKeys() ok = false, want true")
+	}
+	if want := []string{"Down", "Enter"}; !reflect.DeepEqual(keys, want) {
+		t.Errorf("workspaceTrustConfirmKeys() = %v, want %v", keys, want)
+	}
+}
+
+func TestWorkspaceTrustConfirmKeysUnrecognizedLayoutSendsNothing(t *testing.T) {
+	const content = ` Do you trust the contents of this directory?
+
+ (layout not yet fully rendered)`
+
+	keys, ok := workspaceTrustConfirmKeys(content)
+	if ok {
+		t.Fatalf("workspaceTrustConfirmKeys() ok = true, want false; keys = %v", keys)
+	}
+	if len(keys) != 0 {
+		t.Errorf("workspaceTrustConfirmKeys() keys = %v, want empty when not ok", keys)
+	}
+
+	withZeroDialogTimings(t)
+	var sent []string
+	err := acceptWorkspaceTrustDialog(
+		context.Background(),
+		newStartupDialogBudget(100*time.Millisecond),
+		func(int) (string, error) { return content, nil },
+		func(keys ...string) error { sent = append(sent, keys...); return nil },
+	)
+	if err != nil {
+		t.Fatalf("acceptWorkspaceTrustDialog() error = %v", err)
+	}
+	if len(sent) != 0 {
+		t.Errorf("acceptWorkspaceTrustDialog() sent = %v, want no keys sent for an unrecognized trust layout", sent)
+	}
+}

--- a/release-gates/workspace-trust-dialog-selection-gate.md
+++ b/release-gates/workspace-trust-dialog-selection-gate.md
@@ -1,0 +1,71 @@
+# Release Gate: workspace-trust dialog selection
+
+Bead: `ga-g3ynzz`
+Source bead: `ga-rycvqb`
+Review bead: `ga-7hlgl0`
+Reviewed commit: `1639750d7fc3385be6ccac9a6cf082d477de8e1f`
+Base: `origin/main@17333ea115945bae32baac4e12cba832a5b30af0`
+Deploy mode: `remote` (push remote: `fork`)
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Review bead `ga-7hlgl0` is closed with verdict `pass` at the resolved reviewed commit. The review records no blocker or major findings. |
+| 2 | Acceptance criteria met | PASS | `workspaceTrustConfirmKeys` derives cursor movement for Claude, Gemini, and pi layouts, preserves unconditional confirmation for Codex's non-list prompt, and refuses to send keys for unrecognized layouts. Both polling and stream paths use the derived keys. The source bead's four selection cases exist and pass. |
+| 3 | Tests pass | PASS | The documented full local sweep executed 40 unit, process, formula, bead-store, runtime/tmux, and REST jobs. Raw result: 48,304 PASS / 4 FAIL / 208 SKIP. All four failures are pre-existing, tracked, non-diff-owned conditions with mechanism proof and no path overlap; attribution is detailed below. Every diff-owned test passed in both the unit and integration-tagged runtime sweeps. |
+| 4 | No high-severity review findings open | PASS | The reviewer recorded zero blocker/major findings and one informational Gemini hardening observation that is no worse than the pre-existing behavior. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | The reviewed tree was clean before gate generation; the isolated deploy branch was rechecked clean after committing this checklist. Ignored dashboard `node_modules/` and the advisory `.worktree-stale` marker are not candidate changes. |
+| 6 | Branch diverges cleanly from main | PASS | Pre-flight found no PR carrying the reviewed commit. `git merge-tree $(git merge-base origin/main 1639750d7f...) origin/main 1639750d7f...` produced no conflict markers. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The two TDD commits touch only `internal/runtime` workspace-trust dialog selection and its tests. `assert_deploy_ancestry_scope origin/main 1639750d7f... ga-g3ynzz ga-rycvqb` passed. |
+
+## Acceptance evidence
+
+- The real Claude pane capture with `No, exit` selected yields `Down`, then `Enter`; a pre-selected trust row yields only `Enter`.
+- Missing cursor or trust-row information returns `ok=false`, and the polling handler sends no keys.
+- The stream path calls `matchKeysFor` and leaves the snapshot unmatched when the safe key sequence cannot be derived.
+- The existing workspace-trust matcher and unrelated dialog handlers are unchanged.
+- Changed paths are limited to `internal/runtime/dialog.go`, `internal/runtime/dialog_test.go`, and `internal/runtime/dialog_trust_selection_test.go`.
+
+## Test evidence
+
+- `test_cmd: GOFLAGS=-v make test-local-full-parallel`
+- `test_cmd_scope: full-suite`
+- `test_counts: 48,304 PASS / 4 FAIL / 208 SKIP`
+- `skip_justification: expected pre-existing phase, platform, live-provider, persistence-opt-in, registry, and helper-process skips in the repository's full local runner; none is diff-owned.`
+- `diff_tests_executed:`
+  - `TestWorkspaceTrustDialogDoesNotConfirmNoExit`: PASS in `unit-core` and `integration-packages-core-3-of-4`
+  - `TestWorkspaceTrustConfirmKeysTrustPreSelected`: PASS in both sweeps
+  - `TestWorkspaceTrustConfirmKeysNoExitSelected`: PASS in both sweeps
+  - `TestWorkspaceTrustConfirmKeysUnrecognizedLayoutSendsNothing`: PASS in both sweeps
+  - `TestAcceptStartupDialogsWithTimeoutRefreshesBudgetOnProgress`: PASS in both sweeps
+- `waiver_ref: none`
+- `ci_lane_run: n/a (no CI configuration change in this diff)`
+- Raw logs: `/var/tmp/gascity-gate-ga-g3ynzz.Kqwxsj`
+
+### Failure attribution
+
+- `TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a): mechanism proven.` The candidate cannot alter `internal/bdflags` or the installed `bd` binary; `go list -deps -test ./internal/bdflags` does not include `internal/runtime`. No failing-test path overlaps the diff.
+- `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix -> ga-esyijp | clause 3(a): mechanism proven.` The fixture's installed `bd` process rejected a dirty-table schema migration under `gastownhall/beads#4566` before any agent or workspace-trust dialog started. No failing-test path overlaps the diff.
+- `TestGraphWorkflowFailureRunsCleanup -> ga-esyijp | clause 3(a): mechanism proven.` The fixture failed during the same tracked `bd` schema initialization, before workflow or dialog behavior. No failing-test path overlaps the diff.
+- `TestE2E_SuspendResume_City -> ga-dqd7gf | clause 3(a): mechanism proven.` The test uses `e2eReportScript`, not an interactive coding-agent trust prompt, and timed out on the already-tracked `citysus` report under whole-suite load. No failing-test path overlaps the diff.
+
+Each tracker predated this run, was opened before citation, and now contains this run's verified sighting. No inconclusive attribution path was used.
+
+## Policy and static lanes
+
+- `policy_lane: make test-ci-policy` — PASS (Python runner policy, CI suite coverage, `scripts/cipolicy`, `scripts/prwatchdog`, and static-scope contracts).
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected` — raw FAIL, attributed to `ga-u8z8j6`. Conservative stale-head fallback selected full lint, whose only findings were two `govet` and one `revive` diagnostic in ignored, untracked `internal/api/dashboardspa/web/node_modules/flatted/**`; the candidate has no path overlap. Tracker predates this run and contains the new sighting.
+- `make check-gomod-replace` — PASS.
+- `make check-native-dependency-surface` — PASS.
+- `make check-eventexport-isolation` — PASS.
+- `make check-core-boundary` — PASS.
+- `make test-native-doltlite-beads` — PASS.
+- `LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make fmt-check-changed` — PASS.
+- `make vet` — PASS.
+- `make check-docs` — PASS.
+
+## Environment integrity
+
+- Rootless Podman socket active at `/run/user/1000/podman/podman.sock` with `TESTCONTAINERS_RYUK_DISABLED=true` prepared before the full sweep.
+- No `dolt-tests-via-podman` cairn entry exists for this rig, and the documented full local command has no testcontainers-backed image requirement.

--- a/release-gates/workspace-trust-dialog-selection-gate.md
+++ b/release-gates/workspace-trust-dialog-selection-gate.md
@@ -12,7 +12,7 @@ Deploy mode: `remote` (push remote: `fork`)
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
 | 1 | Review PASS present | PASS | Review bead `ga-7hlgl0` is closed with verdict `pass` at the resolved reviewed commit. The review records no blocker or major findings. |
-| 2 | Acceptance criteria met | PASS | `workspaceTrustConfirmKeys` derives cursor movement for Claude, Gemini, and pi layouts, preserves unconditional confirmation for Codex's non-list prompt, and refuses to send keys for unrecognized layouts. Both polling and stream paths use the derived keys. The source bead's four selection cases exist and pass. |
+| 2 | Acceptance criteria met | PASS | `workspaceTrustConfirmKeys` derives cursor movement for Claude, Gemini, and pi layouts, preserves unconditional confirmation for Codex's non-list prompt, and refuses to send keys for unrecognized layouts. Both polling and stream paths use the derived keys. Committed selection cases cover the trust row pre-selected (Enter alone), the cursor on `No, exit` (Down then Enter), the cursor below the trust row (Up then Enter), an unrecognized layout (no keys), a dialog preceded by pane scrollback, and a box-bordered rendering. |
 | 3 | Tests pass | PASS | The documented full local sweep executed 40 unit, process, formula, bead-store, runtime/tmux, and REST jobs. Raw result: 48,304 PASS / 4 FAIL / 208 SKIP. All four failures are pre-existing, tracked, non-diff-owned conditions with mechanism proof and no path overlap; attribution is detailed below. Every diff-owned test passed in both the unit and integration-tagged runtime sweeps. |
 | 4 | No high-severity review findings open | PASS | The reviewer recorded zero blocker/major findings and one informational Gemini hardening observation that is no worse than the pre-existing behavior. Unresolved HIGH findings: 0. |
 | 5 | Final branch is clean | PASS | The reviewed tree was clean before gate generation; the isolated deploy branch was rechecked clean after committing this checklist. Ignored dashboard `node_modules/` and the advisory `.worktree-stale` marker are not candidate changes. |
@@ -39,6 +39,9 @@ Deploy mode: `remote` (push remote: `fork`)
   - `TestWorkspaceTrustConfirmKeysNoExitSelected`: PASS in both sweeps
   - `TestWorkspaceTrustConfirmKeysUnrecognizedLayoutSendsNothing`: PASS in both sweeps
   - `TestAcceptStartupDialogsWithTimeoutRefreshesBudgetOnProgress`: PASS in both sweeps
+  - `TestWorkspaceTrustConfirmKeysIgnoresScrollbackCursor`: PASS in `go test ./internal/runtime/ -run Trust -count=1`
+  - `TestWorkspaceTrustConfirmKeysBorderedLayout`: PASS in `go test ./internal/runtime/ -run Trust -count=1`
+  - `TestWorkspaceTrustConfirmKeysUpwardMovement`: PASS in `go test ./internal/runtime/ -run Trust -count=1`
 - `waiver_ref: none`
 - `ci_lane_run: n/a (no CI configuration change in this diff)`
 - Raw logs: `/var/tmp/gascity-gate-ga-g3ynzz.Kqwxsj`


### PR DESCRIPTION
## What this changes

New agent sessions no longer blindly confirm whichever option is selected when a workspace-trust dialog appears. Gas City now reads the rendered cursor position and affirmative trust row for Claude Code, Gemini CLI, and pi, moves to the safe option when needed, and then confirms it. Codex's non-list trust prompt keeps its direct confirmation behavior.

If a list-style dialog is incomplete or has an unfamiliar layout, Gas City sends no keys and keeps waiting. This prevents a default selection such as `No, exit` from terminating a newly provisioned session.

## Review notes

- Polling and stream-based dialog handling share the same selection derivation.
- The existing workspace-trust matcher and all unrelated startup-dialog handlers are unchanged.
- This does not pre-provision trust state; it fixes the runtime behavior when a trust prompt actually appears.

## Test plan

- [x] Exercise pre-selected trust, pre-selected exit, upward/downward movement, and unrecognized-layout cases.
- [x] Run the full local unit, process, formula, bead-store, runtime/tmux, and REST sweep; verify every changed test executes and passes.
- [x] Run CI policy, formatting, vet, documentation sync, native DoltLite, and repository boundary checks.
- [x] Release gate: [`release-gates/workspace-trust-dialog-selection-gate.md`](release-gates/workspace-trust-dialog-selection-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5796 — addresses the workspace-trust handler blindly confirming whichever row is selected — it now locates the cursor and the trust row in the rendered dialog, moves the selection onto the trust option before confirming, and sends no keys at all when the layout can't be read; regression coverage uses the verbatim captured pane with the cursor on the exit row, on both the polling and stream paths

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->