### PR TITLE
fix(beads): preserve indefinite deferred cached readiness

### DIFF
--- a/cmd/gc/class_store_emit.go
+++ b/cmd/gc/class_store_emit.go
@@ -51,9 +51,9 @@ package main
 //
 // # What it emits, and what it deliberately does not
 //
-// The payload is the canonical bead snapshot CachingStore.notifyChange emits —
-// json.Marshal of the post-write bead, decodable by beads.DecodeBeadEventPayload
-// and foldable by the run projection — with the run/session/step correlation
+// The payload is the canonical bead snapshot from
+// beads.EncodeBeadEventPayload, decodable by beads.DecodeBeadEventPayload and
+// foldable by the run projection, with the run/session/step correlation
 // resolved onto the typed envelope from the same metadata keys and through the
 // same helpers. bead.closed rides only a genuine open→closed transition, because
 // the export boundary drops bead.updated and a metadata write to a closed bead
@@ -74,7 +74,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -165,7 +164,7 @@ func (s *emittingClassStore) emit(emissions ...classStoreEmission) {
 		if strings.TrimSpace(emission.bead.ID) == "" {
 			continue
 		}
-		payload, err := json.Marshal(emission.bead)
+		payload, err := beads.EncodeBeadEventPayload(emission.bead)
 		if err != nil {
 			warnClassStoreEmit(fmt.Errorf("marshaling the %s payload of %s: %w", emission.eventType, emission.bead.ID, err))
 			continue

--- a/cmd/gc/class_store_emit_test.go
+++ b/cmd/gc/class_store_emit_test.go
@@ -653,6 +653,48 @@ func TestClassStoreEmissionHydratesDependencyEdges(t *testing.T) {
 	}
 }
 
+func TestClassStoreEmissionPreservesStatusBasedDeferralUntilClose(t *testing.T) {
+	cityPath := t.TempDir()
+	leaf := beads.NewMemStore()
+	store := resolveGraphStore(splitClassRoutes(leaf).withCLIEmission(cityPath), beads.NewMemStore(), nil, cityPath, nil)
+
+	deferred, ok := beads.DecodeBeadEventPayload(
+		json.RawMessage(`{"id":"source-deferred","title":"deferred","status":"deferred","issue_type":"task"}`),
+	)
+	if !ok {
+		t.Fatal("deferred fixture did not decode")
+	}
+	created, err := leaf.Create(deferred)
+	if err != nil {
+		t.Fatalf("seeding deferred bead: %v", err)
+	}
+
+	if err := store.SetMetadata(created.ID, "gc.note", "still deferred"); err != nil {
+		t.Fatalf("metadata write: %v", err)
+	}
+	if err := store.Close(created.ID); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	got := beadEvents(readCityJournal(t, cityPath))
+	if len(got) != 2 {
+		t.Fatalf("got %s, want one update and one close", eventSummary(got))
+	}
+	var updateWire struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(got[0].Payload, &updateWire); err != nil {
+		t.Fatalf("decode update payload: %v", err)
+	}
+	if got[0].Type != events.BeadUpdated || updateWire.Status != "deferred" {
+		t.Errorf("first event = %s status=%q, want bead.updated status=deferred", got[0].Type, updateWire.Status)
+	}
+	closed, ok := beads.DecodeBeadEventPayload(got[1].Payload)
+	if !ok || got[1].Type != events.BeadClosed || closed.Status != "closed" {
+		t.Errorf("second event = %s payload=%s, want bead.closed with closed snapshot", got[1].Type, got[1].Payload)
+	}
+}
+
 // A post-write read miss must never produce a bare-id payload. An empty
 // snapshot does not say less than a full one — it CLOBBERS the fold, because a
 // projection applying it overwrites title, status and run membership with

--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -127,7 +127,7 @@ func loadEventBeadPayload(beadID string) (json.RawMessage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading bead: %w", err)
 	}
-	payload, err := json.Marshal(map[string]beads.Bead{"bead": bead})
+	payload, err := beads.EncodeBeadEventPayload(bead)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling bead payload: %w", err)
 	}

--- a/cmd/gc/cmd_event_emit_test.go
+++ b/cmd/gc/cmd_event_emit_test.go
@@ -194,17 +194,15 @@ func TestEventPayloadForEmitFallsBackToStoreBead(t *testing.T) {
 	if !json.Valid([]byte(payload)) {
 		t.Fatalf("payload is not valid JSON: %q", payload)
 	}
-	var decoded struct {
-		Bead beads.Bead `json:"bead"`
+	decoded, ok := beads.DecodeBeadEventPayload(json.RawMessage(payload))
+	if !ok {
+		t.Fatalf("payload is not a raw canonical bead snapshot: %s", payload)
 	}
-	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
-		t.Fatalf("Unmarshal(payload): %v", err)
+	if decoded.ID != created.ID {
+		t.Fatalf("payload bead ID = %q, want %q", decoded.ID, created.ID)
 	}
-	if decoded.Bead.ID != created.ID {
-		t.Fatalf("payload bead ID = %q, want %q", decoded.Bead.ID, created.ID)
-	}
-	if decoded.Bead.Title != "hook-created task" {
-		t.Fatalf("payload bead title = %q, want hook-created task", decoded.Bead.Title)
+	if decoded.Title != "hook-created task" {
+		t.Fatalf("payload bead title = %q, want hook-created task", decoded.Title)
 	}
 }
 
@@ -259,17 +257,15 @@ prefix = "fe"
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want none", stderr.String())
 	}
-	var decoded struct {
-		Bead beads.Bead `json:"bead"`
+	decoded, ok := beads.DecodeBeadEventPayload(json.RawMessage(payload))
+	if !ok {
+		t.Fatalf("payload is not a raw canonical bead snapshot: %s", payload)
 	}
-	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
-		t.Fatalf("Unmarshal(payload): %v", err)
+	if decoded.ID != created.ID {
+		t.Fatalf("payload bead ID = %q, want %q", decoded.ID, created.ID)
 	}
-	if decoded.Bead.ID != created.ID {
-		t.Fatalf("payload bead ID = %q, want %q", decoded.Bead.ID, created.ID)
-	}
-	if decoded.Bead.Title != "rig hook-created task" {
-		t.Fatalf("payload bead title = %q, want rig hook-created task", decoded.Bead.Title)
+	if decoded.Title != "rig hook-created task" {
+		t.Fatalf("payload bead title = %q, want rig hook-created task", decoded.Title)
 	}
 }
 

--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -1512,6 +1512,8 @@ func beadCopyDifference(want, got beads.Bead) string {
 		return fmt.Sprintf("title %q != %q", want.Title, got.Title)
 	case want.Status != got.Status:
 		return fmt.Sprintf("status %q != %q", want.Status, got.Status)
+	case want.IndefinitelyDeferred != got.IndefinitelyDeferred:
+		return fmt.Sprintf("indefinitely_deferred %v != %v", want.IndefinitelyDeferred, got.IndefinitelyDeferred)
 	case want.Type != got.Type:
 		return fmt.Sprintf("type %q != %q", want.Type, got.Type)
 	case want.Description != got.Description:

--- a/cmd/gc/infra_class_migrate.go
+++ b/cmd/gc/infra_class_migrate.go
@@ -1512,8 +1512,6 @@ func beadCopyDifference(want, got beads.Bead) string {
 		return fmt.Sprintf("title %q != %q", want.Title, got.Title)
 	case want.Status != got.Status:
 		return fmt.Sprintf("status %q != %q", want.Status, got.Status)
-	case want.IndefinitelyDeferred != got.IndefinitelyDeferred:
-		return fmt.Sprintf("indefinitely_deferred %v != %v", want.IndefinitelyDeferred, got.IndefinitelyDeferred)
 	case want.Type != got.Type:
 		return fmt.Sprintf("type %q != %q", want.Type, got.Type)
 	case want.Description != got.Description:

--- a/cmd/gc/infra_class_migrate_equality_test.go
+++ b/cmd/gc/infra_class_migrate_equality_test.go
@@ -110,6 +110,10 @@ func beadCopyFieldMutations() map[string]func(beads.Bead) beads.Bead {
 			b.IsBlocked = &blocked
 			return b
 		},
+		"IndefinitelyDeferred": func(b beads.Bead) beads.Bead {
+			b.IndefinitelyDeferred = true
+			return b
+		},
 	}
 }
 

--- a/cmd/gc/infra_class_migrate_equality_test.go
+++ b/cmd/gc/infra_class_migrate_equality_test.go
@@ -24,9 +24,14 @@ import (
 // a field added to beads.Bead is either compared by beadCopyDifference or listed
 // here — never silently unwitnessed.
 //
-// The reasons matter as much as the names. An exemption is a promise that a copy
-// which changed this field is still a faithful copy, and three of these five are
-// only true because something else witnesses the same state.
+// The reasons matter as much as the names. An exemption is normally a promise that
+// a copy which changed this field is still a faithful copy, and two of these five
+// are only true because something else witnesses the same state.
+// IndefinitelyDeferred is the one exemption that does not carry that promise: the
+// destination cannot hold it, so the deferral genuinely does not cross. It is
+// exempt because comparing it would refuse every copy of a deferred infra row
+// without preserving anything — not because the copy stays faithful. Do not cite
+// it as precedent for exempting a field the destination could hold.
 var beadCopyExemptFields = map[string]string{
 	"Revision": "store-internal optimistic-concurrency token. Each store mints and bumps its own; the destination's row is a fresh create, so its revision is unrelated to the source's by construction.",
 	"ClaimFence": "store-internal ownership fence, maintained per store like Revision. " +
@@ -35,6 +40,13 @@ var beadCopyExemptFields = map[string]string{
 		"cannot mint dangling cross-boundary edges. The edges it would have produced are witnessed by verifyInfraCopy's DepList comparison.",
 	"Dependencies": "create-time dependency shorthand, stripped by infraMigrationRow for the same reason as Needs, " +
 		"and witnessed the same way — through the source's own materialized dep rows rather than the create-time field.",
+	"IndefinitelyDeferred": "not a property of the copy but of READING the source. It is the read-time normalization of bd's " +
+		"richer status vocabulary (beads.normalizedBdReadState), re-derived on every work-store read; the destination stores " +
+		"Gas City's three-state status verbatim and has no richer status to normalize. Both sides therefore agree on the " +
+		"Status this stage does compare, and the field itself is json:\"-\" while SQLiteStore persists beads through " +
+		"bead_json — so it is structurally absent from the destination and comparing it would refuse EVERY copy of a " +
+		"deferred infra row, identically on each retry. What does not cross is the deferral itself: the binding reads such " +
+		"a row as plainly open.",
 }
 
 // infraEqualityFixture is a source row with every durable field populated to a
@@ -69,6 +81,10 @@ func infraEqualityFixture() beads.Bead {
 		IsBlocked:    &blocked,
 		Revision:     7,
 		ClaimFence:   3,
+		// Set so the exempt mutation below models the loss that actually
+		// happens — a source row carrying the marker against a destination that
+		// cannot hold it — rather than the destination inventing one.
+		IndefinitelyDeferred: true,
 	}
 }
 
@@ -110,10 +126,6 @@ func beadCopyFieldMutations() map[string]func(beads.Bead) beads.Bead {
 			b.IsBlocked = &blocked
 			return b
 		},
-		"IndefinitelyDeferred": func(b beads.Bead) beads.Bead {
-			b.IndefinitelyDeferred = true
-			return b
-		},
 	}
 }
 
@@ -126,6 +138,10 @@ func beadCopyExemptMutations() map[string]func(beads.Bead) beads.Bead {
 		"ClaimFence":   func(b beads.Bead) beads.Bead { b.ClaimFence = 0; return b },
 		"Needs":        func(b beads.Bead) beads.Bead { b.Needs = nil; return b },
 		"Dependencies": func(b beads.Bead) beads.Bead { b.Dependencies = nil; return b },
+		// The fixture carries the marker, so clearing it here is the real loss:
+		// a destination that cannot hold what the source read produced. This is
+		// the mutation that must NOT be refused, or the migration wedges.
+		"IndefinitelyDeferred": func(b beads.Bead) beads.Bead { b.IndefinitelyDeferred = false; return b },
 	}
 }
 
@@ -345,9 +361,28 @@ func TestVerifyInfraCopyRefusesADroppedDurableField(t *testing.T) {
 		NoHistory:   true,
 		DeferUntil:  &deferred,
 		Metadata:    beads.StringMap{"gc.session_name": "worker-1"},
+		// The source row carries the status-based deferral marker the work
+		// store produces for a bd-`deferred` row. The destination cannot hold
+		// it — it is json:"-" and SQLiteStore persists through bead_json — so
+		// the faithful subtest below is what proves the equality stage does not
+		// refuse a copy over a field no destination row can ever carry. The
+		// drop subtests inherit it and must still refuse for their own field.
+		IndefinitelyDeferred: true,
 	})
 	if err != nil {
 		t.Fatalf("seeding the source: %v", err)
+	}
+	// The marker reaches the source store only because MemStore.Create seeds
+	// Status directly rather than going through an explicit transition, which
+	// clears it. Assert it on the equality stage's OWN view of the source
+	// rather than assume it: if that ever changes, these subtests must fail
+	// loudly instead of comparing false against false and proving nothing.
+	seeded, err := readInfraSnapshot(source)
+	if err != nil {
+		t.Fatalf("reading the seeded source: %v", err)
+	}
+	if len(seeded) != 1 || !seeded[0].IndefinitelyDeferred {
+		t.Fatalf("the equality stage's view of the source does not carry the deferral marker: %+v", seeded)
 	}
 
 	for _, tc := range []struct {

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -151,8 +151,21 @@ the JSON shape:
 The same rule applies to both list mode and stream mode.
 
 `--payload-match` accepts top-level fields and dotted paths into nested
-payload objects. For example, use
-`--payload-match bead.issue_type=task` to match bead events by issue type.
+payload objects. Which form matches depends on the payload's shape on the
+path you are reading, and the two paths differ for `bead.*` events:
+
+- Against a running city, `gc events` reads through the API, which re-projects
+  a registered payload into its typed variant. `bead.*` decodes to
+  `BeadEventPayload`, whose single field is `bead`, so use
+  `--payload-match bead.issue_type=task` there.
+- Against a stopped city, `gc events` falls back to reading the local event
+  journal and passes each stored payload through verbatim. `bead.*` payloads
+  are stored as a raw bead snapshot, so their fields are top level: use
+  `--payload-match issue_type=task` there.
+
+A path that does not resolve is not an error — the record simply does not
+match — so the wrong form for the path returns nothing rather than reporting
+a problem.
 
 ## Machine-Readable Schema
 

--- a/internal/beads/atomic_close_memstore.go
+++ b/internal/beads/atomic_close_memstore.go
@@ -46,7 +46,7 @@ func (s *atomicCloseMemStore) CloseWithMetadataIfMatch(id string, expectedRevisi
 	for key, value := range metadata {
 		m.beads[i].Metadata[key] = value
 	}
-	m.beads[i].Status = "closed"
+	setBeadStatus(&m.beads[i], "closed")
 	m.beads[i].UpdatedAt = time.Now()
 	m.beads[i].Revision++
 	return cloneBead(m.beads[i]), nil

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1021,28 +1021,30 @@ func (b *bdIssue) toBead() Bead {
 			}
 		}
 	}
+	status, indefinitelyDeferred := normalizedBdReadState(b.Status, b.DeferUntil)
 	return Bead{
-		ID:           b.ID,
-		Title:        b.Title,
-		Status:       mapBdStatus(b.Status),
-		Type:         b.IssueType,
-		Priority:     cloneIntPtr(b.Priority),
-		CreatedAt:    b.CreatedAt.Truncate(time.Second),
-		UpdatedAt:    b.UpdatedAt.Truncate(time.Second),
-		Assignee:     b.Assignee,
-		From:         from,
-		ParentID:     parentID,
-		Ref:          b.Ref,
-		Needs:        b.Needs,
-		Description:  b.Description,
-		Labels:       b.Labels,
-		Metadata:     b.Metadata,
-		Dependencies: deps,
-		Ephemeral:    b.Ephemeral,
-		NoHistory:    b.NoHistory,
-		DeferUntil:   cloneTimePtr(b.DeferUntil),
-		IsBlocked:    b.IsBlocked.ptr(),
-		Revision:     int64(b.Revision),
+		ID:                   b.ID,
+		Title:                b.Title,
+		Status:               status,
+		Type:                 b.IssueType,
+		Priority:             cloneIntPtr(b.Priority),
+		CreatedAt:            b.CreatedAt.Truncate(time.Second),
+		UpdatedAt:            b.UpdatedAt.Truncate(time.Second),
+		Assignee:             b.Assignee,
+		From:                 from,
+		ParentID:             parentID,
+		Ref:                  b.Ref,
+		Needs:                b.Needs,
+		Description:          b.Description,
+		Labels:               b.Labels,
+		Metadata:             b.Metadata,
+		Dependencies:         deps,
+		Ephemeral:            b.Ephemeral,
+		NoHistory:            b.NoHistory,
+		DeferUntil:           cloneTimePtr(b.DeferUntil),
+		IsBlocked:            b.IsBlocked.ptr(),
+		IndefinitelyDeferred: indefinitelyDeferred,
+		Revision:             int64(b.Revision),
 	}
 }
 
@@ -1116,6 +1118,13 @@ func mapBdStatus(s string) string {
 	default:
 		return "open"
 	}
+}
+
+// normalizedBdReadState preserves bd's status-based indefinite deferral after
+// richer bd statuses collapse to Gas City's three-state model. A time-bound
+// deferral remains governed by DeferUntil so it can become ready after expiry.
+func normalizedBdReadState(status string, deferUntil *time.Time) (string, bool) {
+	return mapBdStatus(status), status == "deferred" && deferUntil == nil
 }
 
 type optionalBool struct {
@@ -2021,7 +2030,7 @@ func (tx *bdStoreTx) Close(id string) error {
 	if err != nil {
 		return err
 	}
-	item.current.Status = "closed"
+	setBeadStatus(&item.current, "closed")
 	item.closed = true
 	return nil
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2587,15 +2587,17 @@ func TestBdStoreReadyReturnsParseErrorOnMalformedJSON(t *testing.T) {
 
 func TestBdStoreStatusMapping(t *testing.T) {
 	tests := []struct {
-		bdStatus   string
-		wantStatus string
+		bdStatus           string
+		wantStatus         string
+		wantIndefiniteHold bool
 	}{
-		{"open", "open"},
-		{"in_progress", "in_progress"},
-		{"blocked", "open"},
-		{"review", "open"},
-		{"testing", "open"},
-		{"closed", "closed"},
+		{"open", "open", false},
+		{"in_progress", "in_progress", false},
+		{"blocked", "open", false},
+		{"deferred", "open", true},
+		{"review", "open", false},
+		{"testing", "open", false},
+		{"closed", "closed", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.bdStatus, func(t *testing.T) {
@@ -2614,6 +2616,9 @@ func TestBdStoreStatusMapping(t *testing.T) {
 			}
 			if b.Status != tt.wantStatus {
 				t.Errorf("status %q → %q, want %q", tt.bdStatus, b.Status, tt.wantStatus)
+			}
+			if b.IndefinitelyDeferred != tt.wantIndefiniteHold {
+				t.Errorf("IndefinitelyDeferred = %v, want %v", b.IndefinitelyDeferred, tt.wantIndefiniteHold)
 			}
 		})
 	}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -108,6 +108,16 @@ type Bead struct {
 	// after richer statuses normalize to Gas City's three-state model. Cache
 	// notifications restore status="deferred" on the event wire so another
 	// process can reconstruct it; other JSON surfaces remain unchanged.
+	//
+	// No read surface exposes it, so the two projections of the same bead
+	// disagree by design: a direct .gc/events.jsonl reader sees the
+	// status="deferred" EncodeBeadEventPayload wrote, while the HTTP, SSE and
+	// --json surfaces re-project through this struct and report status="open",
+	// defer_until=null, is_blocked=false — three signals that all read as
+	// "ready" for a bead ready deliberately excludes. An operator asking why a
+	// bead is not being picked up has nothing to read; giving the exclusion a
+	// derived read-only representation is a wire-design decision, not a
+	// consequence of this tag.
 	IndefinitelyDeferred bool `json:"-"`
 	// Revision is the store-internal optimistic-concurrency token for
 	// ConditionalWriter. It is deliberately json:"-" so it stays off every HTTP
@@ -582,6 +592,8 @@ func HasReadyExcludedLabel(b Bead) bool {
 
 // IsDeferred reports whether a bead is hidden indefinitely by bd's deferred
 // status or temporarily by a future defer_until.
+// cmd_hook.isFutureDeferredHookCandidate mirrors only the time-bound half; it
+// operates on raw bd JSON before this normalization.
 func IsDeferred(b Bead, now time.Time) bool {
 	return b.IndefinitelyDeferred ||
 		(b.DeferUntil != nil && b.DeferUntil.After(now))

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -100,10 +100,15 @@ type Bead struct {
 	// nil or past means ready). Create paths preserve it; UpdateOpts does not
 	// mutate it.
 	DeferUntil *time.Time `json:"defer_until,omitempty"`
-	// IsBlocked carries bd's denormalized ready-work projection. Nil means the
-	// store did not provide the projection and cached ready falls back to
+	// IsBlocked carries bd's denormalized dependency-ready projection. Nil
+	// means the store did not provide it and cached ready falls back to
 	// dependency-derived readiness for backward compatibility.
 	IsBlocked *bool `json:"is_blocked,omitempty"`
+	// IndefinitelyDeferred preserves bd's status-based indefinite deferral
+	// after richer statuses normalize to Gas City's three-state model. Cache
+	// notifications restore status="deferred" on the event wire so another
+	// process can reconstruct it; other JSON surfaces remain unchanged.
+	IndefinitelyDeferred bool `json:"-"`
 	// Revision is the store-internal optimistic-concurrency token for
 	// ConditionalWriter. It is deliberately json:"-" so it stays off every HTTP
 	// and SSE wire path (beads.Bead is both the Huma response type and the SSE
@@ -575,11 +580,18 @@ func HasReadyExcludedLabel(b Bead) bool {
 	return false
 }
 
-// IsDeferred reports whether a bead is hidden by a future defer_until,
-// mirroring bd ready's server-side filter (defer_until IS NULL OR <= now is
-// ready) and cmd_hook.isFutureDeferredHookCandidate.
+// IsDeferred reports whether a bead is hidden indefinitely by bd's deferred
+// status or temporarily by a future defer_until.
 func IsDeferred(b Bead, now time.Time) bool {
-	return b.DeferUntil != nil && b.DeferUntil.After(now)
+	return b.IndefinitelyDeferred ||
+		(b.DeferUntil != nil && b.DeferUntil.After(now))
+}
+
+// setBeadStatus applies an explicit Gas City status transition. Any such
+// transition supersedes richer source status that was normalized on read.
+func setBeadStatus(b *Bead, status string) {
+	b.Status = status
+	b.IndefinitelyDeferred = false
 }
 
 func isReadyBlockingDependencyType(t string) bool {

--- a/internal/beads/caching_store_conditional.go
+++ b/internal/beads/caching_store_conditional.go
@@ -196,7 +196,7 @@ func (c *CachingStore) CloseIfMatch(id string, expectedRevision int64) error {
 	}
 	// The close is proven committed; forcing the status onto the event
 	// payload states that fact without installing anything in the cache.
-	fresh.Status = "closed"
+	setBeadStatus(&fresh, "closed")
 	c.notifyChange("bead.closed", fresh)
 	return nil
 }

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -491,6 +491,7 @@ func mergeCacheEventPatch(base, patch Bead, fields map[string]json.RawMessage) B
 	}
 	if hasCacheEventField(fields, "status") {
 		merged.Status = patch.Status
+		merged.IndefinitelyDeferred = patch.IndefinitelyDeferred
 	}
 	if hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type") {
 		merged.Type = patch.Type
@@ -544,7 +545,9 @@ func cacheEventConflictsCurrent(current, patch Bead, fields map[string]json.RawM
 	if hasCacheEventField(fields, "title") && current.Title != patch.Title {
 		return true
 	}
-	if hasCacheEventField(fields, "status") && current.Status != patch.Status {
+	if hasCacheEventField(fields, "status") &&
+		(current.Status != patch.Status ||
+			current.IndefinitelyDeferred != patch.IndefinitelyDeferred) {
 		return true
 	}
 	if (hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type")) && current.Type != patch.Type {
@@ -723,7 +726,7 @@ func (c *CachingStore) notifyChange(eventType string, b Bead) {
 	if c.onChange == nil {
 		return
 	}
-	payload, err := json.Marshal(b)
+	payload, err := EncodeBeadEventPayload(b)
 	if err != nil {
 		c.recordProblem(fmt.Sprintf("marshal %s notification", eventType), err)
 		return
@@ -800,6 +803,7 @@ func beadChanged(old, fresh Bead, skipLabels bool) bool {
 		old.Ref != fresh.Ref ||
 		old.Description != fresh.Description ||
 		old.Ephemeral != fresh.Ephemeral ||
+		old.IndefinitelyDeferred != fresh.IndefinitelyDeferred ||
 		!timePtrEqual(old.DeferUntil, fresh.DeferUntil) ||
 		!boolPtrEqual(old.IsBlocked, fresh.IsBlocked) {
 		return true

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -3879,6 +3879,203 @@ func TestCachingStoreBdPrimeProjectsIsBlockedForAllBDRowsBD105(t *testing.T) {
 	}
 }
 
+func TestCachingStoreBdPrimeExcludesIndefinitelyDeferredRowsFromReady(t *testing.T) {
+	t.Parallel()
+
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) == 0 {
+			t.Fatal("empty bd command")
+		}
+		switch args[0] {
+		case "version":
+			return []byte("bd version 1.0.5 (test)\n"), nil
+		case "sql":
+			return []byte(`[{"id":"bd-deferred","is_blocked":0}]`), nil
+		case "list":
+			return []byte(`[
+				{"id":"bd-deferred","title":"parked","status":"deferred","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}}
+			]`), nil
+		case "query":
+			return []byte(`[]`), nil
+		case "dep":
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		return []byte(`[]`), nil
+	}
+
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	got, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Ready() = %+v, want indefinite deferred row excluded", got)
+	}
+	cached, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(cached) != 0 {
+		t.Fatalf("CachedReady() = %+v, want indefinite deferred row excluded", cached)
+	}
+
+	stored, err := cache.Get("bd-deferred")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.Status != "open" {
+		t.Fatalf("Status = %q, want normalized open", stored.Status)
+	}
+	if stored.IsBlocked == nil || *stored.IsBlocked {
+		t.Fatalf("IsBlocked = %v, want independent false dependency projection", stored.IsBlocked)
+	}
+	if !IsDeferred(stored, time.Now()) {
+		t.Fatal("status-based indefinite deferral was not preserved")
+	}
+}
+
+func TestCachingStoreStatusBasedDeferralCanReopen(t *testing.T) {
+	for _, reopen := range []string{"event", "local-update"} {
+		t.Run(reopen, func(t *testing.T) {
+			unblocked := false
+			backing := NewMemStore()
+			created, err := backing.Create(Bead{
+				Title:     "temporarily parked",
+				Type:      "task",
+				Status:    "open",
+				IsBlocked: &unblocked,
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+
+			cache.ApplyEvent("bead.updated", json.RawMessage(
+				fmt.Sprintf(`{"id":%q,"status":"deferred"}`, created.ID),
+			))
+			deferred, err := cache.Get(created.ID)
+			if err != nil {
+				t.Fatalf("Get after defer event: %v", err)
+			}
+			if !IsDeferred(deferred, time.Now()) {
+				t.Fatal("defer event did not preserve status-based indefinite deferral")
+			}
+
+			switch reopen {
+			case "event":
+				cache.ApplyEvent("bead.updated", json.RawMessage(
+					fmt.Sprintf(`{"id":%q,"status":"open"}`, created.ID),
+				))
+			case "local-update":
+				status := "open"
+				if err := cache.Update(created.ID, UpdateOpts{Status: &status}); err != nil {
+					t.Fatalf("Update(open): %v", err)
+				}
+			}
+
+			opened, err := cache.Get(created.ID)
+			if err != nil {
+				t.Fatalf("Get after reopen: %v", err)
+			}
+			if opened.IsBlocked == nil || *opened.IsBlocked {
+				t.Fatalf("reopened IsBlocked = %v, want authoritative false", opened.IsBlocked)
+			}
+			if IsDeferred(opened, time.Now()) {
+				t.Fatal("explicit reopen retained status-based indefinite deferral")
+			}
+			ready, ok := cache.CachedReady()
+			if !ok {
+				t.Fatal("CachedReady reported cache unavailable")
+			}
+			if len(ready) != 1 || ready[0].ID != created.ID {
+				t.Fatalf("CachedReady = %+v, want reopened bead %s", ready, created.ID)
+			}
+		})
+	}
+}
+
+func TestCachingStoreDependencyInvalidationPreservesStatusBasedDeferral(t *testing.T) {
+	blocked := true
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{Title: "blocker", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	deferred, err := backing.Create(Bead{
+		Title:                "indefinitely parked",
+		Type:                 "task",
+		Status:               "open",
+		IsBlocked:            &blocked,
+		IndefinitelyDeferred: true,
+	})
+	if err != nil {
+		t.Fatalf("Create deferred: %v", err)
+	}
+	if err := backing.DepAdd(deferred.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := cache.Close(blocker.ID); err != nil {
+		t.Fatalf("Close blocker: %v", err)
+	}
+
+	stored, err := cache.Get(deferred.ID)
+	if err != nil {
+		t.Fatalf("Get deferred: %v", err)
+	}
+	if !IsDeferred(stored, time.Now()) {
+		t.Fatal("dependency invalidation dropped status-based indefinite deferral")
+	}
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 0 {
+		t.Fatalf("CachedReady = %+v, want deferred bead excluded after blocker closes", ready)
+	}
+}
+
+func TestCachingStoreNotificationPreservesStatusBasedDeferral(t *testing.T) {
+	var payload json.RawMessage
+	cache := NewCachingStore(NewMemStore(), func(_, _, _, _, _ string, _ *[]string, got json.RawMessage) {
+		payload = append(payload[:0], got...)
+	})
+	cache.notifyChange("bead.updated", Bead{
+		ID:                   "gc-deferred",
+		Status:               "open",
+		Type:                 "task",
+		IndefinitelyDeferred: true,
+	})
+
+	var wire struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(payload, &wire); err != nil {
+		t.Fatalf("Unmarshal notification: %v", err)
+	}
+	if wire.Status != "deferred" {
+		t.Fatalf("wire status = %q, want deferred", wire.Status)
+	}
+	decoded, ok := DecodeBeadEventPayload(payload)
+	if !ok || !IsDeferred(decoded, time.Now()) {
+		t.Fatalf("notification round trip = %+v, ok=%v; want indefinite deferral", decoded, ok)
+	}
+}
+
 func TestCachingStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -589,7 +589,7 @@ func (c *CachingStore) mergeSnapshotLocked(
 		res.removes++
 		if d.notification == "bead.closed" {
 			closed := cloneBead(cached)
-			closed.Status = "closed"
+			setBeadStatus(&closed, "closed")
 			if freshClosed, ok := confirmedClosed[id]; ok {
 				closed = cloneBead(freshClosed)
 			}

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -77,7 +77,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 			notifyClosed := false
 			if current, ok := c.beads[id]; ok && current.Status != "closed" {
 				closed = cloneBead(current)
-				closed.Status = "closed"
+				setBeadStatus(&closed, "closed")
 				notifyClosed = true
 			}
 			c.tombstoneLocked(id, seq)
@@ -158,7 +158,7 @@ func (c *CachingStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, erro
 		updated = cloneBead(fresh)
 		notify = true
 	} else if b, ok := c.beads[id]; ok {
-		b.Status = "open"
+		setBeadStatus(&b, "open")
 		b.Assignee = ""
 		b.UpdatedAt = time.Now()
 		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
@@ -208,7 +208,7 @@ func (c *CachingStore) Close(id string) error {
 	var refreshed bool
 	if fresh, err := c.backing.Get(id); err == nil {
 		closed = fresh
-		closed.Status = "closed"
+		setBeadStatus(&closed, "closed")
 		found = true
 		refreshed = true
 	} else if !errors.Is(err, ErrNotFound) {
@@ -224,7 +224,7 @@ func (c *CachingStore) Close(id string) error {
 			clearDirty: true,
 		})
 	} else if b, ok := c.beads[id]; ok {
-		b.Status = "closed"
+		setBeadStatus(&b, "closed")
 		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
 			depsMode:   depsKeepCached,
 			seqMode:    seqKeep,
@@ -259,7 +259,7 @@ func (c *CachingStore) Reopen(id string) error {
 	var refreshed bool
 	if fresh, err := c.backing.Get(id); err == nil {
 		reopened = fresh
-		reopened.Status = "open"
+		setBeadStatus(&reopened, "open")
 		found = true
 		refreshed = true
 	} else if !errors.Is(err, ErrNotFound) {
@@ -275,7 +275,7 @@ func (c *CachingStore) Reopen(id string) error {
 			clearDirty: true,
 		})
 	} else if b, ok := c.beads[id]; ok {
-		b.Status = "open"
+		setBeadStatus(&b, "open")
 		c.absorbFreshLocked(id, b, time.Now(), absorbOpts{
 			depsMode:   depsKeepCached,
 			seqMode:    seqKeep,
@@ -662,7 +662,7 @@ func (c *CachingStore) refreshTxTouchedBeads(ids []string, closed map[string]str
 		}
 		if item.closed {
 			if b, ok := c.beads[item.id]; ok {
-				b.Status = "closed"
+				setBeadStatus(&b, "closed")
 				c.absorbFreshLocked(item.id, b, now, absorbOpts{
 					depsMode:   depsKeepCached,
 					seqMode:    seqKeep,
@@ -722,8 +722,16 @@ func (c *CachingStore) updateMatchesCached(id string, opts UpdateOpts) bool {
 	if opts.Title != nil && b.Title != *opts.Title {
 		return false
 	}
-	if opts.Status != nil && b.Status != *opts.Status {
-		return false
+	if opts.Status != nil {
+		if b.Status != *opts.Status {
+			return false
+		}
+		// bd's indefinite "deferred" status normalizes to open. An explicit
+		// open update is nevertheless the operation that removes the deferral,
+		// so it must reach the backing store.
+		if *opts.Status == "open" && b.IndefinitelyDeferred {
+			return false
+		}
 	}
 	if opts.Type != nil && b.Type != *opts.Type {
 		return false
@@ -1158,7 +1166,7 @@ func applyUpdateOptsToBead(bead Bead, opts UpdateOpts) Bead {
 		bead.Title = *opts.Title
 	}
 	if opts.Status != nil {
-		bead.Status = *opts.Status
+		setBeadStatus(&bead, *opts.Status)
 	}
 	if opts.Type != nil {
 		bead.Type = *opts.Type

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -1267,6 +1267,18 @@ func TestCachingStoreReopenClearsStatusBasedDeferralWhenRefreshFails(t *testing.
 	if err := cache.Prime(context.Background()); err != nil {
 		t.Fatalf("Prime: %v", err)
 	}
+	// The fixture reaches the cache deferred only because MemStore.Create
+	// seeds Status directly instead of taking an explicit transition, which
+	// clears the marker. Pin that here: without it, a Create that started
+	// clearing the marker would leave this test asserting !IsDeferred against
+	// a bead that was never deferred, and it would pass vacuously.
+	primed, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get before reopen: %v", err)
+	}
+	if !IsDeferred(primed, time.Now()) {
+		t.Fatalf("fixture is not deferred before the reopen, so the assertion below would be vacuous: %+v", primed)
+	}
 
 	backing.failNextGet = true
 	if err := cache.Reopen(created.ID); err != nil {

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 )
 
 // countingBackingStore wraps a Store and counts SetMetadata /
@@ -1247,6 +1248,36 @@ func TestCachingStoreReopenAdoptsFreshBackingRead(t *testing.T) {
 	if got.Revision != fresh.Revision {
 		t.Fatalf("cached revision after Reopen = %d, backing = %d; the successful refresh read must be adopted",
 			got.Revision, fresh.Revision)
+	}
+}
+
+func TestCachingStoreReopenClearsStatusBasedDeferralWhenRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	backing := &releaseRefreshFailOnceStore{Store: NewMemStore()}
+	created, err := backing.Create(Bead{
+		Title:                "deferred",
+		Status:               "open",
+		IndefinitelyDeferred: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.failNextGet = true
+	if err := cache.Reopen(created.ID); err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	reopened, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if IsDeferred(reopened, time.Now()) {
+		t.Fatalf("failed refresh fallback retained status-based deferral: %+v", reopened)
 	}
 }
 

--- a/internal/beads/event_payload.go
+++ b/internal/beads/event_payload.go
@@ -20,7 +20,11 @@ func EncodeBeadEventPayload(b Bead) (json.RawMessage, error) {
 //
 // Canonical shape = a raw bead snapshot. EncodeBeadEventPayload restores an
 // internal indefinite deferral as status="deferred" on this wire; every
-// consumer normalizes it again through this decoder. The wrapped
+// consumer that decodes through this package normalizes it again here. A
+// reader that consumes the stored bytes directly does not — see
+// Bead.IndefinitelyDeferred, which documents that a direct .gc/events.jsonl
+// reader sees the status="deferred" this wire carries. Do not widen the
+// encoder's rewrite without auditing those raw readers. The wrapped
 // {"bead":<snapshot>} shape (the registered BeadEventPayload contract) is
 // accepted as a tolerant fallback so a producer that ever emits it does not
 // silently starve consumers. A payload with an empty id, undecodable bytes, or
@@ -59,7 +63,11 @@ func decodeRawBead(data json.RawMessage) (Bead, bool) {
 	if err := json.Unmarshal(data, &b); err != nil || b.ID == "" {
 		return Bead{}, false
 	}
-	b.Status, b.IndefinitelyDeferred = normalizedBdReadState(b.Status, b.DeferUntil)
+	// Only bd's deferred status needs re-derivation here; leaving every other
+	// raw status untouched keeps the ga-3mv5d3 collapse off the event path.
+	if b.Status == "deferred" {
+		b.Status, b.IndefinitelyDeferred = normalizedBdReadState(b.Status, b.DeferUntil)
+	}
 	if b.Type == "" {
 		var compat struct {
 			Type string `json:"type"`

--- a/internal/beads/event_payload.go
+++ b/internal/beads/event_payload.go
@@ -2,17 +2,29 @@ package beads
 
 import "encoding/json"
 
+// EncodeBeadEventPayload marshals a canonical raw bead-event snapshot. A bd
+// status-based indefinite deferral is restored only for its normalized open
+// state; explicit Gas City transitions such as close or claim must win over a
+// stale internal marker.
+func EncodeBeadEventPayload(b Bead) (json.RawMessage, error) {
+	if b.Status == "open" && b.IndefinitelyDeferred {
+		b.Status = "deferred"
+	}
+	return json.Marshal(b)
+}
+
 // DecodeBeadEventPayload extracts a Bead from a bead.* event payload. It is the
 // single shared decoder for the bead-event wire shape; the API layer, the
 // caching store, and the run-view projection all route through it so their
 // tolerance can never drift apart on a future cleanup.
 //
-// Canonical shape = the RAW bead snapshot (json.Marshal(b)) — that is exactly
-// what CachingStore.notifyChange emits and what every .gc/events.jsonl row
-// holds. The wrapped {"bead":<snapshot>} shape (the registered BeadEventPayload
-// contract) is accepted as a tolerant fallback so a producer that ever emits it
-// does not silently starve consumers. A payload that decodes to a bead with an
-// empty id, an undecodable payload, or an empty payload is a decode miss:
+// Canonical shape = a raw bead snapshot. EncodeBeadEventPayload restores an
+// internal indefinite deferral as status="deferred" on this wire; every
+// consumer normalizes it again through this decoder. The wrapped
+// {"bead":<snapshot>} shape (the registered BeadEventPayload contract) is
+// accepted as a tolerant fallback so a producer that ever emits it does not
+// silently starve consumers. A payload with an empty id, undecodable bytes, or
+// no bytes is a decode miss:
 // (Bead{}, false).
 //
 // Bead's own json tags round-trip the raw wire faithfully (issue_type→Type,
@@ -39,13 +51,15 @@ func DecodeBeadEventPayload(payload json.RawMessage) (Bead, bool) {
 	return Bead{}, false
 }
 
-// decodeRawBead unmarshals a raw bead snapshot and applies the exec-style "type"
-// alias for issue_type. Returns false on decode error or empty id.
+// decodeRawBead unmarshals a raw bead snapshot, preserves bd's status-based
+// indefinite deferral, and applies the exec-style "type" alias for issue_type.
+// Returns false on decode error or empty id.
 func decodeRawBead(data json.RawMessage) (Bead, bool) {
 	var b Bead
 	if err := json.Unmarshal(data, &b); err != nil || b.ID == "" {
 		return Bead{}, false
 	}
+	b.Status, b.IndefinitelyDeferred = normalizedBdReadState(b.Status, b.DeferUntil)
 	if b.Type == "" {
 		var compat struct {
 			Type string `json:"type"`

--- a/internal/beads/event_payload_test.go
+++ b/internal/beads/event_payload_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-// TestDecodeBeadEventPayloadRawCanonical proves the canonical raw-bead shape —
-// what CachingStore.notifyChange actually marshals (json.Marshal(b)) and what
-// every .gc/events.jsonl row holds — decodes with full field fidelity.
+// TestDecodeBeadEventPayloadRawCanonical proves the canonical raw-bead shape
+// emitted by EncodeBeadEventPayload and stored in .gc/events.jsonl decodes with
+// full field fidelity.
 func TestDecodeBeadEventPayloadRawCanonical(t *testing.T) {
 	prio := 3
 	created := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
@@ -62,6 +62,95 @@ func TestDecodeBeadEventPayloadRawCanonical(t *testing.T) {
 	}
 	if len(got.Dependencies) != 1 || got.Dependencies[0].DependsOnID != "gcg-dep" {
 		t.Errorf("dependencies = %v, want one dep on gcg-dep", got.Dependencies)
+	}
+}
+
+func TestEncodeBeadEventPayloadPreservesOnlyActiveStatusBasedDeferral(t *testing.T) {
+	tests := []struct {
+		name string
+		bead Bead
+		want string
+	}{
+		{
+			name: "active status-based deferral",
+			bead: Bead{ID: "gcg-deferred", Status: "open", Type: "task", IndefinitelyDeferred: true},
+			want: "deferred",
+		},
+		{
+			name: "ordinary open bead",
+			bead: Bead{ID: "gcg-open", Status: "open", Type: "task"},
+			want: "open",
+		},
+		{
+			name: "explicit close wins over stale marker",
+			bead: Bead{ID: "gcg-closed", Status: "closed", Type: "task", IndefinitelyDeferred: true},
+			want: "closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := EncodeBeadEventPayload(tt.bead)
+			if err != nil {
+				t.Fatalf("EncodeBeadEventPayload: %v", err)
+			}
+			var wire struct {
+				Status string `json:"status"`
+			}
+			if err := json.Unmarshal(payload, &wire); err != nil {
+				t.Fatalf("decode encoded payload: %v", err)
+			}
+			if wire.Status != tt.want {
+				t.Fatalf("wire status = %q, want %q; payload=%s", wire.Status, tt.want, payload)
+			}
+		})
+	}
+}
+
+func TestMemStoreReopenClearsStatusBasedDeferral(t *testing.T) {
+	store := NewMemStore()
+	created, err := store.Create(Bead{
+		Title:                "deferred",
+		Status:               "open",
+		IndefinitelyDeferred: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Reopen(created.ID); err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	reopened, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if IsDeferred(reopened, time.Now()) {
+		t.Fatalf("Reopen left bead deferred: %+v", reopened)
+	}
+}
+
+func TestDecodeBeadEventPayloadPreservesStatusBasedDeferral(t *testing.T) {
+	got, ok := DecodeBeadEventPayload([]byte(`{"id":"gcg-deferred","status":"deferred","issue_type":"task"}`))
+	if !ok {
+		t.Fatal("deferred decode returned ok=false")
+	}
+	if got.Status != "open" {
+		t.Fatalf("Status = %q, want normalized open", got.Status)
+	}
+	if !IsDeferred(got, time.Now()) {
+		t.Fatal("status-based indefinite deferral was not preserved")
+	}
+
+	past := time.Now().Add(-time.Minute).Format(time.RFC3339Nano)
+	expired, ok := DecodeBeadEventPayload([]byte(`{"id":"gcg-expired","status":"deferred","issue_type":"task","defer_until":"` + past + `"}`))
+	if !ok {
+		t.Fatal("expired deferred decode returned ok=false")
+	}
+	if expired.Status != "open" {
+		t.Fatalf("expired Status = %q, want normalized open", expired.Status)
+	}
+	if IsDeferred(expired, time.Now()) {
+		t.Fatal("expired time-bound deferral remained deferred")
 	}
 }
 

--- a/internal/beads/event_payload_test.go
+++ b/internal/beads/event_payload_test.go
@@ -154,6 +154,41 @@ func TestDecodeBeadEventPayloadPreservesStatusBasedDeferral(t *testing.T) {
 	}
 }
 
+// TestDecodeBeadEventPayloadLeavesNonDeferredStatusVerbatim pins the decoder's
+// narrow scope: only bd's "deferred" status is re-derived here. Every other raw
+// status decodes verbatim, exactly as it did before the status-based deferral
+// marker existed. Re-widening this to normalize unconditionally would put the
+// ga-3mv5d3 status-erasure collapse (blocked/hooked/pinned → open) on the event
+// path, where no read edge's compensating controls apply.
+func TestDecodeBeadEventPayloadLeavesNonDeferredStatusVerbatim(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{name: "blocked", payload: `{"id":"gcg-blocked","status":"blocked","issue_type":"task"}`, want: "blocked"},
+		{name: "hooked", payload: `{"id":"gcg-hooked","status":"hooked","issue_type":"task"}`, want: "hooked"},
+		{name: "pinned", payload: `{"id":"gcg-pinned","status":"pinned","issue_type":"task"}`, want: "pinned"},
+		{name: "absent status", payload: `{"id":"gcg-absent","issue_type":"task"}`, want: ""},
+		{name: "ordinary open", payload: `{"id":"gcg-open","status":"open","issue_type":"task"}`, want: "open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := DecodeBeadEventPayload([]byte(tt.payload))
+			if !ok {
+				t.Fatal("decode returned ok=false")
+			}
+			if got.Status != tt.want {
+				t.Fatalf("Status = %q, want %q verbatim", got.Status, tt.want)
+			}
+			if got.IndefinitelyDeferred {
+				t.Fatalf("status %q gained the indefinite-deferral marker", tt.want)
+			}
+		})
+	}
+}
+
 // TestDecodeBeadEventPayloadWrappedFallback proves the tolerant {"bead":<snap>}
 // fallback still decodes (older/registered-contract shape), so a producer that
 // switched to the wrapped shape would not silently starve consumers.

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -230,7 +230,7 @@ func (m *MemStore) applyUpdateLocked(i int, opts UpdateOpts) {
 		m.beads[i].Title = *opts.Title
 	}
 	if opts.Status != nil {
-		m.beads[i].Status = *opts.Status
+		setBeadStatus(&m.beads[i], *opts.Status)
 	}
 	if opts.Description != nil {
 		m.beads[i].Description = *opts.Description
@@ -303,7 +303,7 @@ func (m *MemStore) ReleaseIfCurrent(id, expectedAssignee string) (bool, error) {
 		if m.beads[i].Status != "in_progress" || m.beads[i].Assignee != expectedAssignee {
 			return false, nil
 		}
-		m.beads[i].Status = "open"
+		setBeadStatus(&m.beads[i], "open")
 		m.beads[i].Assignee = ""
 		m.beads[i].UpdatedAt = time.Now()
 		m.beads[i].Revision++
@@ -323,7 +323,7 @@ func (m *MemStore) Close(id string) error {
 			if m.beads[i].Status == "closed" {
 				return nil
 			}
-			m.beads[i].Status = "closed"
+			setBeadStatus(&m.beads[i], "closed")
 			m.beads[i].UpdatedAt = time.Now()
 			m.beads[i].Revision++
 			return nil
@@ -339,11 +339,11 @@ func (m *MemStore) Reopen(id string) error {
 	defer m.mu.Unlock()
 	for i := range m.beads {
 		if m.beads[i].ID == id {
-			if m.beads[i].Status == "open" {
+			if m.beads[i].Status == "open" && !m.beads[i].IndefinitelyDeferred {
 				return nil
 			}
 			wasClosed := m.beads[i].Status == "closed"
-			m.beads[i].Status = "open"
+			setBeadStatus(&m.beads[i], "open")
 			m.beads[i].UpdatedAt = time.Now()
 			m.beads[i].Revision++
 			if wasClosed {
@@ -371,7 +371,7 @@ func (m *MemStore) CloseAll(ids []string, metadata map[string]string) (int, erro
 		if !idSet[m.beads[i].ID] || m.beads[i].Status == "closed" {
 			continue
 		}
-		m.beads[i].Status = "closed"
+		setBeadStatus(&m.beads[i], "closed")
 		m.beads[i].UpdatedAt = time.Now()
 		m.beads[i].Revision++
 		if m.beads[i].Metadata == nil {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -134,6 +134,9 @@ func (m *MemStore) Create(b Bead) (Bead, error) {
 	} else {
 		b.ID = m.mintIDLocked()
 	}
+	// Set directly rather than through setBeadStatus: create is not a status
+	// transition over an existing bead, so a caller-supplied
+	// IndefinitelyDeferred must survive into the store instead of being cleared.
 	b.Status = "open"
 	if b.Type == "" {
 		b.Type = "task"

--- a/internal/beads/memstore_conditional.go
+++ b/internal/beads/memstore_conditional.go
@@ -72,7 +72,7 @@ func (m *MemStore) CloseIfMatch(id string, expectedRevision int64) error {
 	if m.beads[i].Status == "closed" {
 		return nil
 	}
-	m.beads[i].Status = "closed"
+	setBeadStatus(&m.beads[i], "closed")
 	m.beads[i].UpdatedAt = time.Now()
 	m.beads[i].Revision++
 	return nil

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1412,13 +1412,13 @@ func (s *NativeDoltStore) Ready(queries ...ReadyQuery) ([]Bead, error) {
 			// deferral (defer_until in the past) can resurface. An issue
 			// with no defer_until at all was never time-bound — it's bd
 			// defer's status-based indefinite deferral — and must stay
-			// hidden. mapBdStatus collapses status to "open" and
-			// IsDeferred only inspects DeferUntil, so both would
-			// otherwise look identical to an ordinary open bead once
-			// beadFromNativeIssue erases the raw status. The per-status
-			// loop keyed this on the filter status it was querying for;
-			// with the whole set in one call the row's own raw status is
-			// the equivalent discriminator.
+			// hidden. beadFromNativeIssue now records that case as
+			// Bead.IndefinitelyDeferred and IsDeferred honors it, so the
+			// readiness filter already excludes such a row; this skip keeps
+			// it from being materialized at all. The per-status loop keyed
+			// this on the filter status it was querying for; with the whole
+			// set in one call the row's own raw status is the equivalent
+			// discriminator.
 			if issue.Status == beadslib.StatusDeferred && issue.DeferUntil == nil {
 				continue
 			}

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -2154,22 +2154,24 @@ func beadFromNativeIssue(issue *beadslib.Issue) (Bead, error) {
 	if err != nil {
 		return Bead{}, fmt.Errorf("parsing metadata for bead %q: %w: %w", issue.ID, errNativeIssueMetadataParse, err)
 	}
+	status, indefinitelyDeferred := normalizedBdReadState(string(issue.Status), issue.DeferUntil)
 	b := Bead{
-		ID:          issue.ID,
-		Title:       issue.Title,
-		Status:      mapBdStatus(string(issue.Status)),
-		Type:        string(issue.IssueType),
-		Priority:    nativePriorityFromIssue(issue),
-		CreatedAt:   issue.CreatedAt,
-		Assignee:    issue.Assignee,
-		From:        issue.Sender,
-		Description: issue.Description,
-		Labels:      append([]string(nil), issue.Labels...),
-		Metadata:    metadata,
-		Ephemeral:   issue.Ephemeral,
-		NoHistory:   issue.NoHistory,
-		DeferUntil:  cloneTimePtr(issue.DeferUntil),
-		Revision:    issue.RowVersion,
+		ID:                   issue.ID,
+		Title:                issue.Title,
+		Status:               status,
+		Type:                 string(issue.IssueType),
+		Priority:             nativePriorityFromIssue(issue),
+		CreatedAt:            issue.CreatedAt,
+		Assignee:             issue.Assignee,
+		From:                 issue.Sender,
+		Description:          issue.Description,
+		Labels:               append([]string(nil), issue.Labels...),
+		Metadata:             metadata,
+		Ephemeral:            issue.Ephemeral,
+		NoHistory:            issue.NoHistory,
+		DeferUntil:           cloneTimePtr(issue.DeferUntil),
+		IndefinitelyDeferred: indefinitelyDeferred,
+		Revision:             issue.RowVersion,
 	}
 	for _, dep := range issue.Dependencies {
 		if dep == nil {

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -233,16 +233,17 @@ func TestNativeDoltStoreConvertsDefaultPriorityAsUnset(t *testing.T) {
 
 func TestNativeDoltStoreMapsUpstreamStatusesToGasCityContract(t *testing.T) {
 	tests := []struct {
-		upstream beadslib.Status
-		want     string
+		upstream           beadslib.Status
+		want               string
+		wantIndefiniteHold bool
 	}{
-		{beadslib.StatusOpen, "open"},
-		{beadslib.StatusInProgress, "in_progress"},
-		{beadslib.StatusClosed, "closed"},
-		{beadslib.Status("blocked"), "open"},
-		{beadslib.Status("deferred"), "open"},
-		{beadslib.Status("pinned"), "open"},
-		{beadslib.Status("hooked"), "open"},
+		{beadslib.StatusOpen, "open", false},
+		{beadslib.StatusInProgress, "in_progress", false},
+		{beadslib.StatusClosed, "closed", false},
+		{beadslib.Status("blocked"), "open", false},
+		{beadslib.Status("deferred"), "open", true},
+		{beadslib.Status("pinned"), "open", false},
+		{beadslib.Status("hooked"), "open", false},
 	}
 
 	for _, tt := range tests {
@@ -258,6 +259,9 @@ func TestNativeDoltStoreMapsUpstreamStatusesToGasCityContract(t *testing.T) {
 			}
 			if bead.Status != tt.want {
 				t.Fatalf("Status = %q, want %q", bead.Status, tt.want)
+			}
+			if bead.IndefinitelyDeferred != tt.wantIndefiniteHold {
+				t.Fatalf("IndefinitelyDeferred = %v, want %v", bead.IndefinitelyDeferred, tt.wantIndefiniteHold)
 			}
 		})
 	}

--- a/internal/runproj/fold_test.go
+++ b/internal/runproj/fold_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 )
 
-// beadEvent builds a bead.* event with the REAL producer payload shape — the
-// raw bead snapshot json.Marshal(b) emits (never the wrapped {"bead":...} form,
-// which no producer writes). See CachingStore.notifyChange.
+// beadEvent builds a bead.* event with the real producer payload shape: a raw
+// bead snapshot (never the tolerated {"bead":...} envelope). See
+// beads.EncodeBeadEventPayload.
 func beadEvent(seq uint64, typ, id, status string) events.Event {
 	payload, _ := json.Marshal(beads.Bead{ID: id, Status: status, Type: "task"})
 	return events.Event{Seq: seq, Type: typ, Payload: payload}
@@ -77,8 +77,8 @@ func TestApplyCursorTracksMaxSeqEvenForIgnoredEvents(t *testing.T) {
 }
 
 func TestDecodeBeadAcceptsCanonicalRawShape(t *testing.T) {
-	// The canonical producer shape is the raw bead snapshot (json.Marshal(b),
-	// exactly what CachingStore.notifyChange emits) — NOT the wrapped
+	// The canonical producer shape is the raw bead snapshot emitted by
+	// beads.EncodeBeadEventPayload — NOT the wrapped
 	// {"bead": ...} form. The fold must decode it, and an envelope carrying no
 	// correlation ids leaves the bead's own metadata untouched.
 	raw, _ := json.Marshal(beads.Bead{ID: "canon", Status: "open", Type: "task"})


### PR DESCRIPTION
## Summary

**Change.** Keep indefinitely deferred work out of cached ready queues. Preserve that hold across native Dolt reads, cache priming and refresh, notifications, dependency invalidation, class-store events, and migration equality. Explicit reopen and close transitions still clear it.

**Why.** The work item CLI (`bd`) represents an indefinite deferral as `status=deferred` with no `defer_until`. Gas City normalizes that status to `open`, so the cached row previously became indistinguishable from runnable work and could reappear in `bd ready` after prime or refresh.

**State.** Implementation and regression coverage are complete. This bug was exposed while validating the worker-pool fix tracked in #4189; it is a separate cache-state defect.

**Next.** Upstream maintainers review and merge. No MoneyMachine owner action is required.

## Design

The new internal `IndefinitelyDeferred` projection preserves that source fact without changing Gas City's public three-state status model. Explicit `open` and `close` operations remove it; unrelated updates and cache/event round trips retain it.

## Testing

- [x] `make check`
- [x] targeted `go test -race` for deferred-readiness cache paths
- [x] `go test ./internal/beads -count=1`
- [x] `go test ./cmd/gc -count=1`
- [x] `go vet ./internal/beads ./cmd/gc`
- [ ] `make test-integration`: changed packages passed; the suite failed in unrelated runtime tests. Three hidden-tmux attach cases passed on immediate focused rerun. `TestE2E_SuspendResume_City` timed out identically on this branch and a clean `origin/main` worktree at `c96e54a3a`.
- [x] `make check-docs` not applicable: no documentation, navigation, or link changes

## Compatibility

The added marker is internal and excluded from JSON. Canonical bead-event payloads remain raw bead snapshots; consumers that do not know the field continue to decode the unchanged wire shape. No breaking change or migration is required.

## Checklist

- [x] Linked the related discovery context (#4189); no separate issue is needed because this pull request fully defines and fixes the defect
- [x] Added or updated tests for behavior changes
- [x] User-facing documentation is unchanged
- [x] Called out compatibility and migration impact above
