### PR TITLE
feat(providers): add Claude Fable 5.1 to the builtin claude model choices

### DIFF
--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1268,6 +1268,7 @@ func TestResolveClaudeCanonicalModelIDsThroughResolvers(t *testing.T) {
 		"claude-opus-5[1m]",
 		"claude-sonnet-5",
 		"claude-fable-5",
+		"claude-fable-5-1",
 	} {
 		t.Run(model, func(t *testing.T) {
 			want := []string{"--model", model}

--- a/internal/worker/builtin/context_fable51_test.go
+++ b/internal/worker/builtin/context_fable51_test.go
@@ -1,0 +1,38 @@
+package builtin
+
+import "testing"
+
+// Claude Fable 5.1 (claude-fable-5-1) gets both enum forms the other Claude
+// generations have: the short alias operators pick from the select, and the
+// canonical id they pin verbatim in agent.toml. Without the canonical entry a
+// pinned "claude-fable-5-1" hits the ra-jbbv0 failure class (launch path
+// silently emits no --model, named-session path hard-errors); the resolver
+// side of that is asserted in internal/config/options_test.go.
+func TestClaudeModelChoicesIncludeFable51(t *testing.T) {
+	provider, ok := BuiltinProviders()["claude"]
+	if !ok {
+		t.Fatal("builtin claude provider missing")
+	}
+	byValue := make(map[string]BuiltinOptionChoice)
+	for _, option := range provider.OptionsSchema {
+		if option.Key != "model" {
+			continue
+		}
+		for _, choice := range option.Choices {
+			byValue[choice.Value] = choice
+		}
+	}
+	for _, value := range []string{"fable-5-1", "claude-fable-5-1"} {
+		choice, ok := byValue[value]
+		if !ok {
+			t.Fatalf("claude model choices missing %q", value)
+		}
+		if len(choice.FlagArgs) != 2 || choice.FlagArgs[0] != "--model" || choice.FlagArgs[1] != "claude-fable-5-1" {
+			t.Errorf("%s FlagArgs = %v, want [--model claude-fable-5-1]", value, choice.FlagArgs)
+		}
+		if len(choice.FlagAliases) != 1 || len(choice.FlagAliases[0]) != 2 ||
+			choice.FlagAliases[0][0] != "-m" || choice.FlagAliases[0][1] != "claude-fable-5-1" {
+			t.Errorf("%s FlagAliases = %v, want [[-m claude-fable-5-1]]", value, choice.FlagAliases)
+		}
+	}
+}

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -172,6 +172,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
 					{Value: "fable-5", Label: "Fable 5", FlagArgs: []string{"--model", "claude-fable-5"}, FlagAliases: [][]string{{"-m", "claude-fable-5"}}},
+					{Value: "fable-5-1", Label: "Fable 5.1", FlagArgs: []string{"--model", "claude-fable-5-1"}, FlagAliases: [][]string{{"-m", "claude-fable-5-1"}}},
 					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-8"}, FlagAliases: [][]string{{"-m", "claude-opus-4-8"}}},
 					{Value: "opus-5", Label: "Opus 5", FlagArgs: []string{"--model", "claude-opus-5"}, FlagAliases: [][]string{{"-m", "claude-opus-5"}}},
 					{Value: "opus-4-7", Label: "Opus 4.7", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
@@ -196,6 +197,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 					{Value: "claude-opus-5[1m]", Label: "Opus 5 1M (canonical id)", FlagArgs: []string{"--model", "claude-opus-5[1m]"}, FlagAliases: [][]string{{"-m", "claude-opus-5[1m]"}}},
 					{Value: "claude-sonnet-5", Label: "Sonnet 5 (canonical id)", FlagArgs: []string{"--model", "claude-sonnet-5"}, FlagAliases: [][]string{{"-m", "claude-sonnet-5"}}},
 					{Value: "claude-fable-5", Label: "Fable 5 (canonical id)", FlagArgs: []string{"--model", "claude-fable-5"}, FlagAliases: [][]string{{"-m", "claude-fable-5"}}},
+					{Value: "claude-fable-5-1", Label: "Fable 5.1 (canonical id)", FlagArgs: []string{"--model", "claude-fable-5-1"}, FlagAliases: [][]string{{"-m", "claude-fable-5-1"}}},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Claude Fable 5.1 ships as model id `claude-fable-5-1`. The builtin claude provider's model enum (`internal/worker/builtin/profiles.go`) is exact-match, so a pin of that id currently hits the ra-jbbv0 failure class that #4740 fixed for `claude-opus-5`: the launch path silently emits **no** `--model` (the agent runs on the provider default while `gc config show` still reports the pin) and the named-session resolution path hard-errors with `invalid value for model: claude-fable-5-1`.

This follows the `fable-5` (#3284) and canonical-id (#4740) precedent exactly:

- short alias `fable-5-1` ("Fable 5.1") for the select, and the canonical id `claude-fable-5-1` accepted verbatim — both emit `--model claude-fable-5-1` (with the `-m` alias)
- `claude-fable-5-1` added to `TestResolveClaudeCanonicalModelIDsThroughResolvers` so both resolvers keep accepting it
- `TestClaudeModelChoicesIncludeFable51` asserts both entries and their flag shape

## Not changed, on purpose

- Context window: `internal/modelwindow` already resolves any id containing `fable` to 1M, and the dashboard `TRUE_CONTEXT_WINDOWS` mirror is parity-tested against that list, so neither needs an edit.
- Provider inference (`t3bridge`) already routes any `claude*` id to the claude agent.
- No pricing rows, consistent with the other 5-generation ids (`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5` have none either).
- No Mythos entries; out of scope for this change.

## Test plan

- `go test -tags gms_pure_go -count=1 ./internal/config/ ./internal/worker/builtin/` — ok

Reported from operating a production Gas City node where agents are pinned to Claude model ids in `agent.toml`.
