### PR TITLE
fix(orders): one cron parser, so a range schedule fires instead of silently never firing

### DIFF
--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -173,7 +173,10 @@ Notes per trigger:
   waits `interval` since the last run. Drifts: a 3:02 run means the next is at
   3:07.
 - **`cron`** — a 5-field expression (minute, hour, day-of-month, month,
-  day-of-week) supporting `*`, integers, comma lists (`1,15`), and `*/N` steps.
+  day-of-week) supporting `*`, integers, comma lists (`1,15`), ranges (`16-23`),
+  and steps on either (`*/15`, `1-5/2`). A step counts from the start of its
+  range, so `*/2` on day-of-month is 1,3,5,…. Day-of-week takes 0 or 7 for
+  Sunday. A schedule that cannot be parsed is rejected when the order loads.
   Unlike cooldown it hits the same wall-clock times every day. Fires at most
   once per minute.
 - **`condition`** — the orchestrator runs `sh -c "<check>"` each tick, bounded by

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -1,10 +1,10 @@
 package doctor
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -156,7 +156,7 @@ func (c *OrderFiringCurrentCheck) run(ctx *CheckContext) *CheckResult {
 		return result
 	}
 
-	allOrders, err := scanOrderFiringCurrentOrders(cityPath, c.cfg)
+	allOrders, invalidOrders, err := scanOrderFiringCurrentOrdersWithInvalid(cityPath, c.cfg)
 	if err != nil {
 		result.Status = StatusError
 		result.Message = fmt.Sprintf("scan orders: %v", err)
@@ -189,6 +189,17 @@ func (c *OrderFiringCurrentCheck) run(ctx *CheckContext) *CheckResult {
 	// stay visible without converting an advisory error into a blocking gate.
 	var blockingErrors, advisoryErrors int
 	suspendedRigs := orderFiringCurrentSuspendedRigs(c.cfg, cityPath)
+
+	// An order that failed validation never reaches the loop below — it was
+	// dropped by the scan. Report it here or the check reads clean on a city
+	// whose order cannot load. Counted as monitored so the "no cron or
+	// cooldown orders" early return below cannot swallow it.
+	for _, detail := range invalidOrders {
+		worst = worseStatus(worst, StatusError)
+		result.Details = append(result.Details, detail)
+		blockingErrors++
+		monitored++
+	}
 
 	// Resolve every order-run lookup the loop below will need up front and in
 	// parallel. The pre-pass shares the cron-interval cache with the loop, so
@@ -254,7 +265,11 @@ func (c *OrderFiringCurrentCheck) run(ctx *CheckContext) *CheckResult {
 	case StatusWarning:
 		result.Message = "scheduled orders are overdue"
 	case StatusError:
-		result.Message = "scheduled orders are stale"
+		if len(invalidOrders) > 0 {
+			result.Message = fmt.Sprintf("%d order(s) failed to load", len(invalidOrders))
+		} else {
+			result.Message = "scheduled orders are stale"
+		}
 	}
 	if blockingErrors == 0 && advisoryErrors > 0 {
 		result.Severity = SeverityAdvisory
@@ -266,19 +281,45 @@ func (c *OrderFiringCurrentCheck) run(ctx *CheckContext) *CheckResult {
 }
 
 func scanOrderFiringCurrentOrders(cityPath string, cfg *config.City) ([]orders.Order, error) {
-	scanCfg := orderFiringCurrentScanConfig(cfg, cityPath)
-	scanCfg = orderFiringCurrentPruneSuspendedOnlyWildcardOverrides(cityPath, cfg, scanCfg)
-	allOrders, err := orderdiscovery.ScanAll(cityPath, scanCfg, orderFiringCurrentScanOptions(cityPath))
-	if err != nil {
-		return nil, err
-	}
-	return orders.FilterEnabled(allOrders), nil
+	all, _, err := scanOrderFiringCurrentOrdersWithInvalid(cityPath, cfg)
+	return all, err
 }
 
-func orderFiringCurrentScanOptions(cityPath string) orderdiscovery.ScanOptions {
+// scanOrderFiringCurrentOrdersWithInvalid also returns a detail line for every
+// order the scan REFUSED to load. Those orders are dropped from the returned
+// slice, so a caller that ignores them reports on a city as though the broken
+// order were not configured at all.
+func scanOrderFiringCurrentOrdersWithInvalid(cityPath string, cfg *config.City) ([]orders.Order, []string, error) {
+	scanCfg := orderFiringCurrentScanConfig(cfg, cityPath)
+	scanCfg = orderFiringCurrentPruneSuspendedOnlyWildcardOverrides(cityPath, cfg, scanCfg)
+	var invalid []string
+	allOrders, err := orderdiscovery.ScanAll(cityPath, scanCfg, orderFiringCurrentScanOptions(cityPath, &invalid))
+	if err != nil {
+		return nil, nil, err
+	}
+	return orders.FilterEnabled(allOrders), invalid, nil
+}
+
+// orderFiringCurrentScanOptions collects validation failures into collect when
+// it is non-nil, and only logs them when it is nil.
+//
+// Logging alone is how a broken order goes quiet. A failed order is dropped
+// from the scan, so the firing check counts zero monitored orders and reports
+// "no cron or cooldown orders" — a clean bill of health for a city whose order
+// cannot load. That is the same silent absence this check exists to catch, so
+// the caller that reports to the operator passes a collector.
+func orderFiringCurrentScanOptions(cityPath string, collect *[]string) orderdiscovery.ScanOptions {
 	return orderdiscovery.ScanOptions{
 		OnValidateError: func(orderName string, err error) error {
 			log.Printf("gc doctor: skipping invalid order %s for %s: %v", orderName, cityPath, err)
+			// Only schedule failures are reported. This check is about WHEN
+			// orders fire, so an order dropped because its schedule is
+			// unreadable is its subject; an order dropped over [order.env] is
+			// another check's, and surfacing it here would report the same
+			// misconfiguration twice under a heading about firing freshness.
+			if collect != nil && errors.Is(err, orders.ErrInvalidSchedule) {
+				*collect = append(*collect, fmt.Sprintf("%s: invalid order, not loaded: %v", orderName, err))
+			}
 			return nil
 		},
 		ValidateOrder: orders.ValidateExecEnvOverrides,
@@ -367,11 +408,11 @@ func orderFiringCurrentPruneSuspendedOnlyWildcardOverrides(cityPath string, orig
 
 func orderFiringCurrentScanWithoutOverrides(cityPath string, cfg *config.City) ([]orders.Order, error) {
 	if cfg == nil {
-		return orderdiscovery.ScanAll(cityPath, nil, orderFiringCurrentScanOptions(cityPath))
+		return orderdiscovery.ScanAll(cityPath, nil, orderFiringCurrentScanOptions(cityPath, nil))
 	}
 	clone := *cfg
 	clone.Orders.Overrides = nil
-	return orderdiscovery.ScanAll(cityPath, &clone, orderFiringCurrentScanOptions(cityPath))
+	return orderdiscovery.ScanAll(cityPath, &clone, orderFiringCurrentScanOptions(cityPath, nil))
 }
 
 // orderFiringCurrentSuspendedRigs resolves the effective suspension state
@@ -443,9 +484,12 @@ func expectedIntervalForOrder(order orders.Order, cronCache map[string]time.Dura
 }
 
 func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, error) {
-	fields := strings.Fields(schedule)
-	if len(fields) != 5 {
-		return 0, fmt.Errorf("invalid cron schedule: want 5 fields, got %d", len(fields))
+	// Parsed ONCE. The scan below evaluates up to 366*1440 = 527,040 minutes
+	// for a single schedule; re-parsing the expression inside that loop meant
+	// half a million parses per schedule, every time the check ran.
+	sched, err := orders.ParseCronSchedule(schedule)
+	if err != nil {
+		return 0, fmt.Errorf("invalid cron schedule: %w", err)
 	}
 
 	// Scan minute-by-minute from a fixed base so the result is deterministic
@@ -472,11 +516,7 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 		matches := make([]time.Time, 0, 16)
 		for i := 0; i < windowMinutes; i++ {
 			ts := base.Add(time.Duration(i) * time.Minute)
-			matched, err := cronScheduleMatchesAt(fields, ts)
-			if err != nil {
-				return 0, err
-			}
-			if matched {
+			if sched.MatchesAt(ts) {
 				matches = append(matches, ts)
 			}
 		}
@@ -514,105 +554,6 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 		return minGap, nil
 	}
 	return 0, fmt.Errorf("cron schedule %q has no firing minutes in a 366-day window", schedule)
-}
-
-func cronScheduleMatchesAt(fields []string, ts time.Time) (bool, error) {
-	specs := []struct {
-		name     string
-		field    string
-		value    int
-		min, max int
-	}{
-		{name: "minute", field: fields[0], value: ts.Minute(), min: 0, max: 59},
-		{name: "hour", field: fields[1], value: ts.Hour(), min: 0, max: 23},
-		{name: "day-of-month", field: fields[2], value: ts.Day(), min: 1, max: 31},
-		{name: "month", field: fields[3], value: int(ts.Month()), min: 1, max: 12},
-		{name: "day-of-week", field: fields[4], value: int(ts.Weekday()), min: 0, max: 6},
-	}
-	for _, spec := range specs {
-		matched, err := cronFieldMatchesForDoctor(spec.field, spec.value, spec.min, spec.max)
-		if err != nil {
-			return false, fmt.Errorf("invalid cron schedule: cannot parse %s field %q", spec.name, spec.field)
-		}
-		if !matched {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-func cronFieldMatchesForDoctor(field string, value, lowerBound, upperBound int) (bool, error) {
-	if strings.TrimSpace(field) == "" {
-		return false, fmt.Errorf("empty field")
-	}
-	for _, rawPart := range strings.Split(field, ",") {
-		part := strings.TrimSpace(rawPart)
-		matched, err := cronPartMatchesForDoctor(part, value, lowerBound, upperBound)
-		if err != nil {
-			return false, err
-		}
-		if matched {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func cronPartMatchesForDoctor(part string, value, lowerBound, upperBound int) (bool, error) {
-	if part == "" {
-		return false, fmt.Errorf("empty part")
-	}
-	rangePart, stepPart, hasStep := strings.Cut(part, "/")
-	step := 1
-	if hasStep {
-		parsed, err := strconv.Atoi(strings.TrimSpace(stepPart))
-		if err != nil || parsed <= 0 {
-			return false, fmt.Errorf("invalid step")
-		}
-		step = parsed
-	}
-
-	lo, hi, err := cronRangeForDoctor(strings.TrimSpace(rangePart), lowerBound, upperBound)
-	if err != nil {
-		return false, err
-	}
-	if value < lo || value > hi {
-		return false, nil
-	}
-	return (value-lo)%step == 0, nil
-}
-
-func cronRangeForDoctor(rangePart string, lowerBound, upperBound int) (int, int, error) {
-	switch {
-	case rangePart == "*":
-		return lowerBound, upperBound, nil
-	case strings.Contains(rangePart, "-"):
-		start, end, ok := strings.Cut(rangePart, "-")
-		if !ok {
-			return 0, 0, fmt.Errorf("invalid range")
-		}
-		lo, err := strconv.Atoi(strings.TrimSpace(start))
-		if err != nil {
-			return 0, 0, err
-		}
-		hi, err := strconv.Atoi(strings.TrimSpace(end))
-		if err != nil {
-			return 0, 0, err
-		}
-		if lo < lowerBound || hi > upperBound || lo > hi {
-			return 0, 0, fmt.Errorf("range out of bounds")
-		}
-		return lo, hi, nil
-	default:
-		value, err := strconv.Atoi(rangePart)
-		if err != nil {
-			return 0, 0, err
-		}
-		if value < lowerBound || value > upperBound {
-			return 0, 0, fmt.Errorf("value out of bounds")
-		}
-		return value, value, nil
-	}
 }
 
 // readEventTail reads the tail of the city event log through the check's

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -773,3 +773,35 @@ func TestOrderFiringCurrent_TimesOutStalledOrderHistory(t *testing.T) {
 		t.Fatalf("TimedOut = false, want true so callers (JSON output, doctor summary) can distinguish this from a confirmed failure")
 	}
 }
+
+// An order whose schedule cannot be parsed is dropped by the scan before this
+// check ever sees it. Reporting only to the log would let the check answer
+// "no cron or cooldown orders" — a clean bill of health — for a city whose
+// only order is broken. That is the silent absence this check exists to catch.
+func TestOrderFiringCurrent_InvalidScheduleIsReportedNotDropped(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "bad-hour", "cron", "0 24 * * *")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{
+		Type: events.ControllerStarted,
+		Ts:   now.Add(-8 * time.Hour),
+	})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %q; details = %v", result.Status, result.Message, result.Details)
+	}
+	if result.Severity != SeverityBlocking {
+		t.Fatalf("Severity = %v, want SeverityBlocking — an order that cannot load is not advisory", result.Severity)
+	}
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "bad-hour") || !strings.Contains(details, "invalid order, not loaded") {
+		t.Fatalf("details = %v, want them to name the order and say it did not load", result.Details)
+	}
+	if !strings.Contains(details, "hour") {
+		t.Fatalf("details = %v, want the offending field named", result.Details)
+	}
+	if result.Message == "no cron or cooldown orders" {
+		t.Fatalf("Message = %q — the broken order was swallowed", result.Message)
+	}
+}

--- a/internal/orders/cron.go
+++ b/internal/orders/cron.go
@@ -1,0 +1,229 @@
+package orders
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// This is the ONE cron parser in gc. It exists because there were two, and
+// they disagreed.
+//
+// The dispatcher used to carry a lenient matcher that understood "*", a bare
+// integer, a comma list and "*/N" — and silently skipped any part it could
+// not parse. `internal/doctor` grew a second, stricter parser that also
+// understood ranges ("16-23") and stepped ranges ("1-5/2"), bounds-checked
+// each field, and returned an error instead of swallowing one. Neither knew
+// about the other, so a schedule using a range was read two different ways in
+// one binary: the doctor computed a firing interval from it and reported the
+// order healthy, while the dispatcher's matcher never matched it and the order
+// never fired once. Nothing reported the disagreement, because "no match" and
+// "cannot parse" were the same value.
+//
+// Both callers now parse here. Divergence is not something to re-detect later;
+// it is something to make unrepresentable.
+
+// ErrInvalidSchedule marks a cron order rejected for its schedule rather than
+// for anything else about it. Order discovery DROPS an order that fails
+// validation, so a caller that reports on scheduling — gc doctor's firing
+// check — needs to tell "this order's trigger is broken", which is its
+// subject and must be surfaced, from an unrelated rejection that another
+// check already owns. Without the distinction, adding schedule validation
+// merely moves a visible failure into a log line.
+var ErrInvalidSchedule = errors.New("invalid schedule")
+
+// cronFieldBounds are the legal value ranges per field, in schedule order.
+// Day-of-week accepts 7 as a second spelling of Sunday, as cron does; matching
+// normalizes it (see cronField.matches).
+var cronFieldBounds = [5]struct {
+	name     string
+	min, max int
+}{
+	{"minute", 0, 59},
+	{"hour", 0, 23},
+	{"day-of-month", 1, 31},
+	{"month", 1, 12},
+	{"day-of-week", 0, 7},
+}
+
+// cronField is one parsed field: the union of its comma-separated parts.
+type cronField struct {
+	parts []cronPart
+	isDOW bool
+}
+
+// cronPart is one comma-separated term, normalized to a stepped range.
+// A bare "5" is the range 5-5 step 1; "*" is the field's full bounds.
+type cronPart struct {
+	lo, hi, step int
+}
+
+func (p cronPart) matches(v int) bool {
+	return v >= p.lo && v <= p.hi && (v-p.lo)%p.step == 0
+}
+
+func (f cronField) matches(v int) bool {
+	for _, p := range f.parts {
+		if p.matches(v) {
+			return true
+		}
+	}
+	// Sunday is both 0 and 7 in cron. time.Weekday only ever gives 0, so a
+	// field written "7" or "1-7" would otherwise never match a Sunday — the
+	// same silent never-fires this parser exists to eliminate.
+	if f.isDOW && v == 0 {
+		for _, p := range f.parts {
+			if p.matches(7) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CronSchedule is a parsed 5-field cron expression. The zero value is not
+// usable; obtain one from ParseCronSchedule.
+type CronSchedule struct {
+	fields [5]cronField
+}
+
+// MatchesAt reports whether the schedule fires at t's wall clock. t must
+// already be in the location the schedule is evaluated in; this reads only
+// t's calendar components.
+//
+// KNOWN DIVERGENCE FROM POSIX CRON, deliberately preserved here: all five
+// fields are ANDed. Vixie and POSIX cron special-case day-of-month against
+// day-of-week — when BOTH are restricted (neither is "*"), the schedule fires
+// when EITHER matches, not both. gc has always ANDed, in both of the parsers
+// this file replaces, so changing it here would be a second behavior change
+// riding along with a fix for something else. It is written down rather than
+// left to be rediscovered: an undocumented divergence is the same failure this
+// file exists to remove, one level up.
+func (s CronSchedule) MatchesAt(t time.Time) bool {
+	return s.fields[0].matches(t.Minute()) &&
+		s.fields[1].matches(t.Hour()) &&
+		s.fields[2].matches(t.Day()) &&
+		s.fields[3].matches(int(t.Month())) &&
+		s.fields[4].matches(int(t.Weekday()))
+}
+
+// ParseCronSchedule parses "minute hour day-of-month month day-of-week".
+//
+// Each field is a comma-separated list of: "*", an integer, a range "A-B", or
+// either of the last two with a step suffix ("*/N", "A-B/N"). Steps count from
+// the start of the range, so "*/15" on minutes is 0,15,30,45 and "*/2" on
+// day-of-month is 1,3,5,... — the field's minimum, not zero.
+//
+// An unparseable or out-of-bounds field is an error. That is the point: the
+// previous matcher returned "did not match" for input it could not read, which
+// is indistinguishable from a schedule that legitimately does not fire now, so
+// a typo cost a silent order rather than a loud failure.
+func ParseCronSchedule(schedule string) (CronSchedule, error) {
+	var s CronSchedule
+	raw := strings.Fields(schedule)
+	if len(raw) != 5 {
+		return s, fmt.Errorf("want 5 fields, got %d", len(raw))
+	}
+	for i, b := range cronFieldBounds {
+		f, err := parseCronField(raw[i], b.min, b.max)
+		if err != nil {
+			return s, fmt.Errorf("%s field %q: %w", b.name, raw[i], err)
+		}
+		f.isDOW = i == 4
+		s.fields[i] = f
+	}
+	return s, nil
+}
+
+func parseCronField(field string, fieldMin, fieldMax int) (cronField, error) {
+	var f cronField
+	if strings.TrimSpace(field) == "" {
+		return f, fmt.Errorf("empty field")
+	}
+	for _, raw := range strings.Split(field, ",") {
+		p, err := parseCronPart(strings.TrimSpace(raw), fieldMin, fieldMax)
+		if err != nil {
+			return f, err
+		}
+		f.parts = append(f.parts, p)
+	}
+	return f, nil
+}
+
+func parseCronPart(part string, fieldMin, fieldMax int) (cronPart, error) {
+	if part == "" {
+		return cronPart{}, fmt.Errorf("empty term")
+	}
+	rangeSpec, stepSpec, hasStep := strings.Cut(part, "/")
+	step := 1
+	if hasStep {
+		// A step needs something to step over. Cron rejects "1/2" — a step on
+		// a single value — and accepting it would silently turn a typo into a
+		// schedule that fires on exactly one value and looks intentional.
+		if rangeSpec != "*" && !strings.Contains(rangeSpec, "-") {
+			return cronPart{}, fmt.Errorf("step on the single value %q: use a range or \"*\"", rangeSpec)
+		}
+		n, err := parseCronInt(stepSpec)
+		if err != nil {
+			return cronPart{}, fmt.Errorf("step %q is not a number", stepSpec)
+		}
+		if n <= 0 {
+			return cronPart{}, fmt.Errorf("step %d must be positive", n)
+		}
+		step = n
+	}
+	lo, hi, err := parseCronRange(strings.TrimSpace(rangeSpec), fieldMin, fieldMax)
+	if err != nil {
+		return cronPart{}, err
+	}
+	return cronPart{lo: lo, hi: hi, step: step}, nil
+}
+
+// parseCronInt accepts only unsigned decimal digits. strconv.Atoi alone would
+// take "+5" and "-5"; cron does not, and a signed token in a schedule is a
+// typo that should be reported rather than quietly given a meaning.
+func parseCronInt(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty number")
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("%q is not a number", s)
+		}
+	}
+	return strconv.Atoi(s)
+}
+
+func parseCronRange(spec string, fieldMin, fieldMax int) (int, int, error) {
+	if spec == "*" {
+		return fieldMin, fieldMax, nil
+	}
+	if lo, hi, ok := strings.Cut(spec, "-"); ok {
+		start, err := parseCronInt(lo)
+		if err != nil {
+			return 0, 0, fmt.Errorf("range start %q is not a number", lo)
+		}
+		end, err := parseCronInt(hi)
+		if err != nil {
+			return 0, 0, fmt.Errorf("range end %q is not a number", hi)
+		}
+		if start > end {
+			return 0, 0, fmt.Errorf("range %d-%d is inverted", start, end)
+		}
+		if start < fieldMin || end > fieldMax {
+			return 0, 0, fmt.Errorf("range %d-%d is outside %d-%d", start, end, fieldMin, fieldMax)
+		}
+		return start, end, nil
+	}
+	v, err := parseCronInt(spec)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%q is not a number", spec)
+	}
+	if v < fieldMin || v > fieldMax {
+		return 0, 0, fmt.Errorf("%d is outside %d-%d", v, fieldMin, fieldMax)
+	}
+	return v, v, nil
+}

--- a/internal/orders/cron_test.go
+++ b/internal/orders/cron_test.go
@@ -1,0 +1,203 @@
+package orders
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// matchField evaluates one field in isolation by wildcarding the other four.
+func matchField(t *testing.T, index int, field string, ts time.Time) bool {
+	t.Helper()
+	parts := []string{"*", "*", "*", "*", "*"}
+	parts[index] = field
+	s, err := ParseCronSchedule(strings.Join(parts, " "))
+	if err != nil {
+		t.Fatalf("ParseCronSchedule(%q) error: %v", strings.Join(parts, " "), err)
+	}
+	return s.MatchesAt(ts)
+}
+
+const (
+	fieldMinute = iota
+	fieldHour
+	fieldDOM
+	fieldMonth
+	fieldDOW
+)
+
+// Wednesday, 2026-09-02.
+func at(t *testing.T, hour, minute int) time.Time {
+	t.Helper()
+	return time.Date(2026, 9, 2, hour, minute, 0, 0, time.UTC)
+}
+
+func TestParseCronScheduleFieldForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		index int
+		field string
+		hour  int
+		min   int
+		want  bool
+	}{
+		// Forms the pre-fix matcher already handled — kept so this change
+		// cannot quietly alter them.
+		{"star", fieldMinute, "*", 0, 5, true},
+		{"exact hit", fieldMinute, "5", 0, 5, true},
+		{"exact miss", fieldMinute, "5", 0, 3, false},
+		{"list hit", fieldMinute, "1,3,5", 0, 3, true},
+		{"list miss", fieldMinute, "1,3,5", 0, 2, false},
+		{"step hit", fieldMinute, "*/15", 0, 30, true},
+		{"step miss", fieldMinute, "*/15", 0, 31, false},
+
+		// Ranges: parsed clean and never matched before this change.
+		{"range low edge", fieldHour, "16-23", 16, 0, true},
+		{"range middle", fieldHour, "16-23", 18, 0, true},
+		{"range high edge", fieldHour, "16-23", 23, 0, true},
+		{"range below", fieldHour, "16-23", 15, 0, false},
+		{"range dow hit", fieldDOW, "1-5", 0, 0, true}, // Wednesday = 3
+		{"range dow miss", fieldDOW, "4-5", 0, 0, false},
+		{"stepped range hit", fieldHour, "16-23/2", 18, 0, true},
+		{"stepped range miss", fieldHour, "16-23/2", 19, 0, false},
+		{"range inside list", fieldHour, "1,16-23", 20, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchField(t, tt.index, tt.field, at(t, tt.hour, tt.min)); got != tt.want {
+				t.Errorf("field %q matched = %v, want %v", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+// A step counts from the start of its range, not from zero. The two agree on
+// minute and hour (minimum 0) and diverge on day-of-month and month (minimum
+// 1), where the pre-fix matcher's value%step gave even days for "*/2" while
+// cron gives odd ones. internal/doctor already used the start-of-range
+// reading, so unifying on it also settles a doctor/dispatcher disagreement.
+func TestParseCronScheduleStepAnchorsAtFieldMinimum(t *testing.T) {
+	for _, tc := range []struct {
+		day  int
+		want bool
+	}{{1, true}, {2, false}, {3, true}, {4, false}} {
+		ts := time.Date(2026, 9, tc.day, 0, 0, 0, 0, time.UTC)
+		if got := matchField(t, fieldDOM, "*/2", ts); got != tc.want {
+			t.Errorf("day-of-month */2 on day %d = %v, want %v", tc.day, got, tc.want)
+		}
+	}
+}
+
+// Cron spells Sunday both 0 and 7; time.Weekday only ever returns 0, so a
+// field written "7" has to be normalized or it never matches a Sunday.
+func TestParseCronScheduleSundayIsZeroOrSeven(t *testing.T) {
+	sunday := time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC)
+	if sunday.Weekday() != time.Sunday {
+		t.Fatalf("fixture is not a Sunday: %s", sunday.Weekday())
+	}
+	for _, field := range []string{"0", "7", "1-7", "6-7"} {
+		if !matchField(t, fieldDOW, field, sunday) {
+			t.Errorf("day-of-week %q did not match Sunday", field)
+		}
+	}
+	if matchField(t, fieldDOW, "1-5", sunday) {
+		t.Error("day-of-week 1-5 matched Sunday")
+	}
+}
+
+// Unreadable input must be an error, not a field that silently never matches.
+func TestParseCronScheduleRejectsMalformed(t *testing.T) {
+	tests := []struct {
+		schedule string
+		wantErr  string
+	}{
+		{"* * * *", "want 5 fields"},
+		{"* * * * * *", "want 5 fields"},
+		{"60 * * * *", "outside 0-59"},
+		{"* 24 * * *", "outside 0-23"},
+		{"* * 0 * *", "outside 1-31"},
+		{"* * * 13 *", "outside 1-12"},
+		{"* * * * 8", "outside 0-7"},
+		{"*/0 * * * *", "must be positive"},
+		{"*/x * * * *", "not a number"},
+		{"* 23-16 * * *", "inverted"},
+		{"* 16-2x * * *", "not a number"},
+		{"* MON * * *", "not a number"},
+		{"* * * * ", "want 5 fields"},
+		{"1,,3 * * * *", "empty term"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.schedule, func(t *testing.T) {
+			_, err := ParseCronSchedule(tt.schedule)
+			if err == nil {
+				t.Fatalf("ParseCronSchedule(%q) = nil error, want one", tt.schedule)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// The regression this change exists for, end to end: a real schedule from a
+// live city that Validate accepted and checkCron never fired.
+func TestCronRangeScheduleValidatesAndFires(t *testing.T) {
+	a := Order{Name: "weekday-sweep", Trigger: "cron", Schedule: "*/15 16-23 * * 1-5", Formula: "x"}
+	if err := Validate(a); err != nil {
+		t.Fatalf("Validate(%q) = %v, want nil", a.Schedule, err)
+	}
+	res := checkCron(a, at(t, 18, 30), neverRan)
+	if !res.Due {
+		t.Fatalf("Due = false (%s), want true — 18:30 Wednesday is inside 16-23 on 1-5", res.Reason)
+	}
+}
+
+func TestValidateRejectsUnreadableSchedule(t *testing.T) {
+	a := Order{Name: "typo", Trigger: "cron", Schedule: "*/15 16-2x * * 1-5", Formula: "x"}
+	err := Validate(a)
+	if err == nil {
+		t.Fatal("Validate = nil, want an error naming the bad field")
+	}
+	if !strings.Contains(err.Error(), "invalid schedule") || !strings.Contains(err.Error(), "hour") {
+		t.Errorf("error = %q, want it to name the invalid schedule and the hour field", err)
+	}
+}
+
+// An unreadable schedule that somehow reaches the dispatcher must say so,
+// rather than reporting the same "not matched" a healthy idle order reports.
+func TestCheckCronReportsUnreadableSchedule(t *testing.T) {
+	a := Order{Name: "typo", Trigger: "cron", Schedule: "*/15 16-2x * * 1-5", Formula: "x"}
+	res := checkCron(a, at(t, 18, 30), neverRan)
+	if res.Due {
+		t.Fatal("Due = true, want false")
+	}
+	if !strings.Contains(res.Reason, "bad cron schedule") {
+		t.Errorf("Reason = %q, want it to report a bad schedule", res.Reason)
+	}
+}
+
+// A step needs a range to step over, and cron numbers are unsigned. Both forms
+// parsed clean before and were given a meaning nobody wrote: "1/2" fired on
+// exactly one value, and strconv.Atoi quietly accepted "+5".
+func TestParseCronScheduleRejectsStepOnScalarAndSignedNumbers(t *testing.T) {
+	for _, tt := range []struct {
+		schedule string
+		wantErr  string
+	}{
+		{"1/2 * * * *", "step on the single value"},
+		{"+5 * * * *", "not a number"},
+		{"-5 * * * *", "not a number"},
+		{"*/+2 * * * *", "not a number"},
+		{"* +1-5 * * *", "not a number"},
+	} {
+		t.Run(tt.schedule, func(t *testing.T) {
+			_, err := ParseCronSchedule(tt.schedule)
+			if err == nil {
+				t.Fatalf("ParseCronSchedule(%q) = nil error, want one", tt.schedule)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -318,6 +318,15 @@ func Validate(a Order) error {
 		if a.Schedule == "" {
 			return fmt.Errorf("order %q: cron trigger requires schedule", a.Name)
 		}
+		// Validate the schedule's CONTENTS, not just its presence. Until this
+		// existed, a schedule the matcher could not read loaded clean and then
+		// never fired — the order was configured, listed, and reported active,
+		// and the only evidence it was dead was the absence of runs nobody was
+		// counting. Same reasoning as tz and check_timeout above: a typo must
+		// fail at load, where someone is looking.
+		if _, err := ParseCronSchedule(a.Schedule); err != nil {
+			return fmt.Errorf("order %q: %w %q: %w", a.Name, ErrInvalidSchedule, a.Schedule, err)
+		}
 	case "condition":
 		if a.Check == "" {
 			return fmt.Errorf("order %q: condition trigger requires check command", a.Name)

--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -183,12 +183,13 @@ const wallMinuteLayout = "2006-01-02 15:04"
 //     match a real instant; the catch-up scan detects the gap and fires the
 //     order once at the first real minute after the jump.
 func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
-	fields := strings.Fields(a.Schedule)
-	if len(fields) != 5 {
-		return TriggerResult{Due: false, Reason: fmt.Sprintf("bad cron schedule: want 5 fields, got %d", len(fields))}
+	// Parsed once, not per candidate minute: the catch-up scan below walks
+	// minute-by-minute over a bounded lookback, and the old matcher re-parsed
+	// all five fields on every step.
+	sched, err := ParseCronSchedule(a.Schedule)
+	if err != nil {
+		return TriggerResult{Due: false, Reason: fmt.Sprintf("bad cron schedule: %v", err)}
 	}
-
-	minute, hour, dom, month, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
 
 	loc, err := resolveOrderLocation(a, now)
 	if err != nil {
@@ -196,13 +197,7 @@ func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
 	}
 	now = now.In(loc)
 
-	matchesAt := func(t time.Time) bool {
-		return cronFieldMatches(minute, t.Minute()) &&
-			cronFieldMatches(hour, t.Hour()) &&
-			cronFieldMatches(dom, t.Day()) &&
-			cronFieldMatches(month, int(t.Month())) &&
-			cronFieldMatches(dow, int(t.Weekday()))
-	}
+	matchesAt := sched.MatchesAt
 	sameWallMinute := func(x, y time.Time) bool {
 		return x.Format(wallMinuteLayout) == y.Format(wallMinuteLayout)
 	}
@@ -281,29 +276,6 @@ func matchesInWallGap(matchesAt func(time.Time) bool, prev, t time.Time) bool {
 	}
 	for w, end := naive(prev).Add(time.Minute), naive(t); w.Before(end); w = w.Add(time.Minute) {
 		if matchesAt(w) {
-			return true
-		}
-	}
-	return false
-}
-
-// cronFieldMatches checks if a single cron field matches a value.
-// Supports: "*" (any), exact integer, or comma-separated values.
-func cronFieldMatches(field string, value int) bool {
-	if field == "*" {
-		return true
-	}
-	for _, part := range strings.Split(field, ",") {
-		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, "*/") {
-			step, err := strconv.Atoi(strings.TrimPrefix(part, "*/"))
-			if err == nil && step > 0 && value%step == 0 {
-				return true
-			}
-			continue
-		}
-		n, err := strconv.Atoi(part)
-		if err == nil && n == value {
 			return true
 		}
 	}

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -333,26 +333,6 @@ func TestCheckTriggerConditionKillsProcessGroupAfterWaitDelay(t *testing.T) {
 	processgrouptest.AssertFileSizeStable(t, heartbeatPath, size, 300*time.Millisecond)
 }
 
-func TestCronFieldMatches(t *testing.T) {
-	tests := []struct {
-		field string
-		value int
-		want  bool
-	}{
-		{"*", 5, true},
-		{"5", 5, true},
-		{"5", 3, false},
-		{"1,3,5", 3, true},
-		{"1,3,5", 2, false},
-	}
-	for _, tt := range tests {
-		got := cronFieldMatches(tt.field, tt.value)
-		if got != tt.want {
-			t.Errorf("cronFieldMatches(%q, %d) = %v, want %v", tt.field, tt.value, got, tt.want)
-		}
-	}
-}
-
 // newEventsProvider creates a FileRecorder-backed Provider with events for tests.
 func newEventsProvider(t *testing.T, evts []events.Event) events.Provider {
 	t.Helper()


### PR DESCRIPTION
Fixes #5709.

That issue's own "Suggested fix" is what this does, point for point.

## The two parsers

`internal/orders.cronFieldMatches` (the dispatcher) understood `*`, an integer, a comma list and `*/N`, and silently skipped any part it could not parse. `internal/doctor` grew a second parser that also understood ranges and stepped ranges, bounds-checked every field, and returned errors instead of swallowing them.

So one binary read one schedule two ways. For `*/15 16-23 * * 1-5`, at one commit:

```
internal/doctor  computeExpectedIntervalForCronSchedule -> 15m0s
                 cronScheduleMatchesAt(Wed 18:30)       -> true
internal/orders  checkCron(Wed 18:30)                   -> "cron: schedule not matched"
```

`Validate()` accepted it, because it only checked that `schedule` was non-empty and never read its contents. The order loaded, listed, and reported active, and never fired once. Nothing reported the disagreement: the dispatcher returned "did not match" for input it could not parse, which is the same value a healthy idle order returns.

## What changed

One parser (`internal/orders/cron.go`, exported as `ParseCronSchedule`/`MatchesAt`), both callers pointed at it, the duplicate deleted. Ranges and stepped ranges work. Day-of-week accepts `7` as Sunday — `time.Weekday` never returns 7, so a field written `7` or `1-7` also never matched. An unparseable schedule is now an error at load, beside the existing `tz` and `check_timeout` validation, instead of an order that quietly does nothing.

Parsing also moved out of the matching loops. `checkCron`'s catch-up scan walks minute-by-minute over a bounded lookback, and the doctor's interval scan evaluates up to `366*1440 = 527,040` minutes per schedule; both re-parsed all five fields on every step.

## Behavior changes worth calling out

- **A step now counts from the start of its range.** Identical on minute and hour (minimum 0). On day-of-month and month (minimum 1), `*/2` now means 1,3,5,… as cron does, where the dispatcher gave 2,4,6,…. `internal/doctor` already used the start-of-range reading, so this settles the disagreement rather than creating one. Flagged in #5709 as needing a release note.
- **A malformed schedule now fails at load** instead of loading clean and never firing.
- `1/2` (a step on a single value) and signed numbers like `+5` were accepted and are now rejected. Both parsed clean before and were given a meaning nobody wrote.

## Not changed, deliberately

gc ANDs day-of-month and day-of-week; POSIX and Vixie cron OR them when both are restricted. That is pre-existing in *both* parsers this replaces, so changing it here would be a second behavior change riding along with a fix for something else. It is now documented on `MatchesAt` rather than left to be rediscovered.

## One thing a reviewer should look at

Adding load-time validation means order discovery now *drops* an invalid order, and `gc doctor`'s firing check only `log.Printf`'d such drops. So a city whose only order had an unreadable schedule went from `StatusError: cannot compute expected interval` to `StatusOK: no cron or cooldown orders` — the validation had moved a visible failure into a log line.

The check now reports the orders it dropped, scoped with a new `orders.ErrInvalidSchedule` sentinel so it reports only *schedule* failures, which are its own subject. An order dropped over `[order.env]` stays quiet there, as two existing tests require, because another check owns that.

## Verification

```
go build ./...                                          OK
go vet   ./internal/orders/ ./internal/doctor/          OK
go test  ./internal/orders/ ./internal/doctor/          ok
go test  ./internal/api/ ./internal/config/ \
         ./internal/orderdiscovery/ ./internal/storebinding/... \
         ./internal/webhookmatch/ ./internal/webhooksink/       ok
go test  ./test/docsync                                 ok
```

New tests cover every field form, the step anchor on day-of-month, Sunday as both 0 and 7 including stepped ranges, fourteen malformed schedules, the end-to-end regression, and the doctor reporting a dropped order.

`docs/tutorials/07-orders.md` described the old dialect and is updated.
