### PR TITLE
fix(rig): preserve an adopted store's issue_prefix case

### DIFF
--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2941,6 +2941,69 @@ func TestDoRigAdd_AdoptWithBdContractInvokesInitAndHook(t *testing.T) {
 	}
 }
 
+// TestDoRigAdd_AdoptPreservesPrefixCase: adopting a store whose issue_prefix
+// is mixed case must keep it byte-for-byte in city.toml and in the
+// canonicalized config.yaml — Beads prefix matching is case-sensitive, so a
+// lowercased prefix forks the id series of the adopted store.
+func TestDoRigAdd_AdoptPreservesPrefixCase(t *testing.T) {
+	cityPath := t.TempDir()
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	rigPath := filepath.Join(t.TempDir(), "contentbuild")
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"name":"contentbuild","issue_prefix":"KitFlowApp"}`
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configYaml := "issue_prefix: KitFlowApp\nissue-prefix: KitFlowApp\n"
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "config.yaml"), []byte(configYaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, requested := range []string{"KitFlowApp", "kitflowapp"} {
+		t.Run("prefix="+requested, func(t *testing.T) {
+			cityPath := t.TempDir()
+			writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+			var stdout, stderr bytes.Buffer
+			code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", requested, "", false, true, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("doRigAdd --adopt --prefix %s returned %d, stderr: %s", requested, code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Prefix: KitFlowApp") {
+				t.Errorf("stdout should report the store's prefix verbatim: %s", stdout.String())
+			}
+			cityToml, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(cityToml), `prefix = "KitFlowApp"`) {
+				t.Errorf("city.toml should store the adopted prefix verbatim:\n%s", cityToml)
+			}
+			cfgYaml, err := os.ReadFile(filepath.Join(rigPath, ".beads", "config.yaml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(cfgYaml), "kitflowapp") || !strings.Contains(string(cfgYaml), "issue_prefix: KitFlowApp") {
+				t.Errorf("config.yaml must keep issue_prefix: KitFlowApp:\n%s", cfgYaml)
+			}
+		})
+	}
+
+	t.Run("different --prefix is rejected", func(t *testing.T) {
+		cityPath := t.TempDir()
+		writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
+		var stdout, stderr bytes.Buffer
+		code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "other", "", false, true, &stdout, &stderr)
+		if code != 1 || !strings.Contains(stderr.String(), `already has bead prefix "KitFlowApp" (requested "other")`) {
+			t.Fatalf("expected prefix mismatch failure, got code %d, stderr: %s", code, stderr.String())
+		}
+	})
+}
+
 // TestDoRigAdd_AdoptWithBdContractProvider_NonAdoptControlInvokesInit is a
 // control: the same stubbed harness wired through a NON-adopt add also calls
 // initAndHookDir, proving that the empty-initCalls failure above (pre-fix) was

--- a/internal/rig/beadsstore.go
+++ b/internal/rig/beadsstore.go
@@ -14,13 +14,15 @@ import (
 // in the given rig directory. Returns the prefix and true if found, or empty
 // string and false if the file doesn't exist or has no prefix. Checks both
 // the underscore form (issue_prefix) and dash form (issue-prefix) since the
-// lifecycle code writes both.
+// lifecycle code writes both. The prefix is returned verbatim: Beads matches
+// prefixes case-sensitively, so callers that only need a lookup key lowercase
+// it themselves.
 func ReadBeadsPrefix(fs fsys.FS, rigPath string) (string, bool) {
 	prefix, ok, err := contract.ReadIssuePrefix(fs, filepath.Join(rigPath, ".beads", "config.yaml"))
 	if err != nil || !ok {
 		return "", false
 	}
-	return strings.ToLower(prefix), true
+	return strings.TrimSpace(prefix), true
 }
 
 // beadsDirContainsStore reports whether beadsPath contains evidence that it

--- a/internal/rig/provision.go
+++ b/internal/rig/provision.go
@@ -212,8 +212,13 @@ func planRigMutation(deps Deps, req ProvisionRequest, rigPath, resolvedDefaultBr
 		return rigMutationPlan{}, err
 	}
 
-	// Step 7: prefix resolution + collision checks.
-	prefix, err := resolveRigPrefix(cfg, req, name, reAdd, existingRig)
+	// Step 7: prefix resolution + collision checks. An adopted store's own
+	// prefix is read verbatim so the resolved prefix preserves its case.
+	adoptedPrefix := ""
+	if req.Adopt {
+		adoptedPrefix, _ = ReadBeadsPrefix(deps.FS, rigPath)
+	}
+	prefix, err := resolveRigPrefix(cfg, req, name, reAdd, existingRig, adoptedPrefix)
 	if err != nil {
 		return rigMutationPlan{}, err
 	}
@@ -225,7 +230,7 @@ func planRigMutation(deps Deps, req ProvisionRequest, rigPath, resolvedDefaultBr
 
 	// Step 8: build nextCfg.
 	needsValidation := !reAdd || reAddNeedsConfigWrite
-	nextCfg, defaultRigImports, commitRigImports, err := buildNextRigConfig(deps, req, rigPath, resolvedDefaultBranch, reAdd, reAddNeedsConfigWrite, existingRigIdx, explicitRigImports, commitRigImports)
+	nextCfg, defaultRigImports, commitRigImports, err := buildNextRigConfig(deps, req, rigPath, resolvedDefaultBranch, prefix, reAdd, reAddNeedsConfigWrite, existingRigIdx, explicitRigImports, commitRigImports)
 	if err != nil {
 		return rigMutationPlan{}, err
 	}
@@ -277,14 +282,21 @@ func detectRigReAdd(cfg *config.City, name, cityPath, rigPath string) (reAdd, ne
 }
 
 // resolveRigPrefix derives the rig's bead prefix — the existing rig's on a
-// re-add, the lowercased --prefix override, or one derived from the name — and,
-// for a fresh add, rejects a prefix that collides with HQ or another rig with
-// the byte-identical CLI text.
-func resolveRigPrefix(cfg *config.City, req ProvisionRequest, name string, reAdd bool, existingRig *config.Rig) (string, error) {
+// re-add, the adopted store's own prefix when --prefix names it (byte-for-byte:
+// Beads prefix matching is case-sensitive, so lowercasing a mixed-case store
+// would fork its id series), the lowercased --prefix override, or one derived
+// from the name — and, for a fresh add, rejects a prefix that collides with HQ
+// or another rig with the byte-identical CLI text. On --adopt, a --prefix that
+// differs from the store's prefix other than by case falls through to the
+// lowercased override so validateAdoptAndBeadsStore reports the mismatch as
+// before.
+func resolveRigPrefix(cfg *config.City, req ProvisionRequest, name string, reAdd bool, existingRig *config.Rig, adoptedPrefix string) (string, error) {
 	var prefix string
 	switch {
 	case reAdd:
 		prefix = existingRig.EffectivePrefix()
+	case req.Adopt && req.Prefix != "" && strings.EqualFold(req.Prefix, adoptedPrefix):
+		prefix = adoptedPrefix
 	case req.Prefix != "":
 		prefix = strings.ToLower(req.Prefix)
 	default:
@@ -311,7 +323,7 @@ func resolveRigPrefix(cfg *config.City, req ProvisionRequest, name string, reAdd
 // --include set them, which may reassign commitRigImports). A plain re-add
 // returns the caller's config unchanged. It returns the next config, any
 // default-rig imports it resolved, and the (possibly updated) packs.lock commit.
-func buildNextRigConfig(deps Deps, req ProvisionRequest, rigPath, resolvedDefaultBranch string, reAdd, reAddNeedsConfigWrite bool, existingRigIdx int, explicitRigImports []config.BoundImport, commitRigImports func() error) (*config.City, []config.BoundImport, func() error, error) {
+func buildNextRigConfig(deps Deps, req ProvisionRequest, rigPath, resolvedDefaultBranch, resolvedPrefix string, reAdd, reAddNeedsConfigWrite bool, existingRigIdx int, explicitRigImports []config.BoundImport, commitRigImports func() error) (*config.City, []config.BoundImport, func() error, error) {
 	fs := deps.FS
 	cfg := deps.Cfg
 	cityPath := deps.CityPath
@@ -330,9 +342,11 @@ func buildNextRigConfig(deps Deps, req ProvisionRequest, rigPath, resolvedDefaul
 		}
 		nextCfg = &next
 	} else if !reAdd {
+		// Store the resolved prefix when --prefix was given (on --adopt it
+		// carries the store's own case); a derived prefix stays implicit.
 		storedPrefix := ""
 		if req.Prefix != "" {
-			storedPrefix = strings.ToLower(req.Prefix)
+			storedPrefix = resolvedPrefix
 		}
 		addedRig := config.Rig{
 			Name:             name,
@@ -450,7 +464,9 @@ func validateAdoptAndBeadsStore(deps Deps, req ProvisionRequest, rigPath string,
 		}
 	}
 
-	if existingPrefix, ok := ReadBeadsPrefix(fs, rigPath); ok && existingPrefix != prefix {
+	// --adopt compares byte-for-byte (the store's prefix is the rig's prefix);
+	// re-add and fresh add keep their historical case-insensitive comparison.
+	if existingPrefix, ok := ReadBeadsPrefix(fs, rigPath); ok && (existingPrefix != prefix && (req.Adopt || !strings.EqualFold(existingPrefix, prefix))) {
 		switch {
 		case plan.reAdd:
 			// On re-add, --prefix is ignored (we use the existing rig's
@@ -541,7 +557,7 @@ func emitRigBannerAndWarnings(deps Deps, req ProvisionRequest, plan rigMutationP
 				emit(ProvisionStep{Name: "include-ignored", Warn: true, Detail: fmt.Sprintf("warning: --include flags %v ignored (existing imports: %s); edit city.toml to change", includes, formatBoundImports(existingRigImports))})
 			}
 		}
-		if req.Prefix != "" && strings.ToLower(req.Prefix) != plan.existingRig.EffectivePrefix() {
+		if req.Prefix != "" && !strings.EqualFold(req.Prefix, plan.existingRig.EffectivePrefix()) {
 			emit(ProvisionStep{Name: "prefix-ignored", Warn: true, Detail: fmt.Sprintf("warning: --prefix=%s ignored (existing: %s); edit city.toml to change", req.Prefix, plan.existingRig.EffectivePrefix())})
 		}
 		if defaultBranchOverride != "" &&

--- a/internal/rig/provision.go
+++ b/internal/rig/provision.go
@@ -465,8 +465,13 @@ func validateAdoptAndBeadsStore(deps Deps, req ProvisionRequest, rigPath string,
 	}
 
 	// --adopt compares byte-for-byte (the store's prefix is the rig's prefix);
-	// re-add and fresh add keep their historical case-insensitive comparison.
-	if existingPrefix, ok := ReadBeadsPrefix(fs, rigPath); ok && (existingPrefix != prefix && (req.Adopt || !strings.EqualFold(existingPrefix, prefix))) {
+	// re-add and fresh add keep their historical lowercased comparison and
+	// presentation.
+	existingPrefix, ok := ReadBeadsPrefix(fs, rigPath)
+	if ok && !req.Adopt {
+		existingPrefix = strings.ToLower(existingPrefix)
+	}
+	if ok && existingPrefix != prefix {
 		switch {
 		case plan.reAdd:
 			// On re-add, --prefix is ignored (we use the existing rig's
@@ -557,7 +562,7 @@ func emitRigBannerAndWarnings(deps Deps, req ProvisionRequest, plan rigMutationP
 				emit(ProvisionStep{Name: "include-ignored", Warn: true, Detail: fmt.Sprintf("warning: --include flags %v ignored (existing imports: %s); edit city.toml to change", includes, formatBoundImports(existingRigImports))})
 			}
 		}
-		if req.Prefix != "" && !strings.EqualFold(req.Prefix, plan.existingRig.EffectivePrefix()) {
+		if req.Prefix != "" && strings.ToLower(req.Prefix) != plan.existingRig.EffectivePrefix() {
 			emit(ProvisionStep{Name: "prefix-ignored", Warn: true, Detail: fmt.Sprintf("warning: --prefix=%s ignored (existing: %s); edit city.toml to change", req.Prefix, plan.existingRig.EffectivePrefix())})
 		}
 		if defaultBranchOverride != "" &&

--- a/internal/rig/provision_prefix_test.go
+++ b/internal/rig/provision_prefix_test.go
@@ -1,0 +1,122 @@
+package rig
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func writeBeadsConfig(t *testing.T, fs *fsys.Fake, rigPath, content string) {
+	t.Helper()
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := fs.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ReadBeadsPrefix must return the store's prefix verbatim: Beads matches
+// prefixes case-sensitively, so a lowercased read would fork the id series of
+// a mixed-case store on adopt.
+func TestReadBeadsPrefixPreservesCase(t *testing.T) {
+	fs := fsys.NewFake()
+	writeBeadsConfig(t, fs, "/rig", "backend: dolt\nissue_prefix: KitFlowApp\nissue-prefix: KitFlowApp\n")
+	got, ok := ReadBeadsPrefix(fs, "/rig")
+	if !ok || got != "KitFlowApp" {
+		t.Fatalf("ReadBeadsPrefix() = (%q, %v), want (%q, true)", got, ok, "KitFlowApp")
+	}
+}
+
+func TestResolveRigPrefix(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "hq", Prefix: "hq"}}
+	tests := []struct {
+		name          string
+		req           ProvisionRequest
+		adoptedPrefix string
+		want          string
+	}{
+		{"adopt with --prefix naming the store keeps its mixed case", ProvisionRequest{Name: "contentbuild", Adopt: true, Prefix: "KitFlowApp"}, "KitFlowApp", "KitFlowApp"},
+		{"adopt with --prefix differing only by case keeps the store's", ProvisionRequest{Name: "contentbuild", Adopt: true, Prefix: "kitflowapp"}, "KitFlowApp", "KitFlowApp"},
+		{"adopt without --prefix still derives from the name (validate reports the mismatch)", ProvisionRequest{Name: "content-build", Adopt: true}, "KitFlowApp", "cb"},
+		{"adopt with a different --prefix resolves the lowercased override", ProvisionRequest{Name: "contentbuild", Adopt: true, Prefix: "Other"}, "KitFlowApp", "other"},
+		{"adopt with no store prefix falls back to the lowercased override", ProvisionRequest{Name: "contentbuild", Adopt: true, Prefix: "Mixed"}, "", "mixed"},
+		{"fresh add lowercases --prefix as before", ProvisionRequest{Name: "contentbuild", Prefix: "Mixed"}, "", "mixed"},
+		{"fresh add derives from the name as before", ProvisionRequest{Name: "content-build"}, "", "cb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRigPrefix(cfg, tt.req, tt.req.Name, false, nil, tt.adoptedPrefix)
+			if err != nil {
+				t.Fatalf("resolveRigPrefix() error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveRigPrefix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("adopt still rejects a collision with HQ", func(t *testing.T) {
+		req := ProvisionRequest{Name: "contentbuild", Adopt: true, Prefix: "hq"}
+		_, err := resolveRigPrefix(cfg, req, req.Name, false, nil, "HQ")
+		if err == nil || !strings.Contains(err.Error(), "collides with HQ") {
+			t.Fatalf("resolveRigPrefix() error = %v, want HQ collision", err)
+		}
+	})
+}
+
+// validateAdoptAndBeadsStore compares byte-for-byte on --adopt (a --prefix
+// that differs from the store's is rejected with the existing text) and keeps
+// the historical case-insensitive comparison on a fresh add.
+func TestValidateAdoptAndBeadsStorePrefixCase(t *testing.T) {
+	fs := fsys.NewFake()
+	writeBeadsConfig(t, fs, "/rig", "issue_prefix: KitFlowApp\n")
+	if err := fs.WriteFile("/rig/.beads/metadata.json", []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps := Deps{FS: fs}
+
+	adopt := ProvisionRequest{Name: "contentbuild", Path: "/rig", Adopt: true}
+	if err := validateAdoptAndBeadsStore(deps, adopt, "/rig", rigMutationPlan{prefix: "KitFlowApp"}); err != nil {
+		t.Fatalf("adopt with the store's own prefix: %v", err)
+	}
+	err := validateAdoptAndBeadsStore(deps, adopt, "/rig", rigMutationPlan{prefix: "other"})
+	if err == nil || !strings.Contains(err.Error(), `already has bead prefix "KitFlowApp" (requested "other")`) {
+		t.Fatalf("adopt with a different prefix: error = %v", err)
+	}
+
+	// A re-add of a rig whose city.toml prefix was stored lowercased by an
+	// older gc keeps the historical case-insensitive comparison.
+	existing := &config.Rig{Name: "contentbuild", Path: "/rig", Prefix: "kitflowapp"}
+	reAdd := ProvisionRequest{Name: "contentbuild", Path: "/rig"}
+	if err := validateAdoptAndBeadsStore(deps, reAdd, "/rig", rigMutationPlan{prefix: "kitflowapp", reAdd: true, existingRig: existing}); err != nil {
+		t.Fatalf("re-add keeps case-insensitive prefix comparison: %v", err)
+	}
+}
+
+// buildNextRigConfig stores the adopted prefix verbatim so EffectivePrefix (and
+// EnsureCanonicalConfig on every later start) reproduce it instead of a
+// name-derived or lowercased one.
+func TestBuildNextRigConfigStoresAdoptedPrefix(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "hq", Prefix: "hq"}}
+	deps := Deps{
+		FS:       fsys.NewFake(),
+		Cfg:      cfg,
+		CityPath: "/city",
+		ComposePacks: func(_ string, imports []config.BoundImport) ([]config.BoundImport, func() error, error) {
+			return imports, func() error { return nil }, nil
+		},
+	}
+	req := ProvisionRequest{Name: "contentbuild", Path: "/rig", Adopt: true, Prefix: "KitFlowApp"}
+	next, _, _, err := buildNextRigConfig(deps, req, "/rig", "main", "KitFlowApp", false, false, -1, nil, func() error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(next.Rigs) != 1 || next.Rigs[0].Prefix != "KitFlowApp" || next.Rigs[0].EffectivePrefix() != "KitFlowApp" {
+		t.Fatalf("stored rig = %+v, want prefix KitFlowApp", next.Rigs)
+	}
+}

--- a/internal/rig/provision_prefix_test.go
+++ b/internal/rig/provision_prefix_test.go
@@ -71,7 +71,7 @@ func TestResolveRigPrefix(t *testing.T) {
 
 // validateAdoptAndBeadsStore compares byte-for-byte on --adopt (a --prefix
 // that differs from the store's is rejected with the existing text) and keeps
-// the historical case-insensitive comparison on a fresh add.
+// the historical lowercased comparison and message text on re-add.
 func TestValidateAdoptAndBeadsStorePrefixCase(t *testing.T) {
 	fs := fsys.NewFake()
 	writeBeadsConfig(t, fs, "/rig", "issue_prefix: KitFlowApp\n")
@@ -95,6 +95,10 @@ func TestValidateAdoptAndBeadsStorePrefixCase(t *testing.T) {
 	reAdd := ProvisionRequest{Name: "contentbuild", Path: "/rig"}
 	if err := validateAdoptAndBeadsStore(deps, reAdd, "/rig", rigMutationPlan{prefix: "kitflowapp", reAdd: true, existingRig: existing}); err != nil {
 		t.Fatalf("re-add keeps case-insensitive prefix comparison: %v", err)
+	}
+	err = validateAdoptAndBeadsStore(deps, reAdd, "/rig", rigMutationPlan{prefix: "other", reAdd: true, existingRig: existing})
+	if err == nil || !strings.Contains(err.Error(), `has bead prefix "kitflowapp" but city.toml has "other"`) {
+		t.Fatalf("re-add mismatch keeps the lowercased presentation: error = %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #5916.

## Problem

`gc rig add --adopt` lowercased `--prefix` in `resolveRigPrefix` and again when appending the rig to `city.toml`, and `ReadBeadsPrefix` lowercased the store's own prefix. A store with `issue_prefix: KitFlowApp` (1000+ ids `KitFlowApp-…`) was therefore adopted as `kitflowapp`; `EnsureCanonicalConfig` then wrote the lowercased prefix into `config.yaml` on every `gc start`, and new beads forked into a `kitflowapp-…` series. Beads prefix matching is case-sensitive (`internal/utils/issue_id.go`, `internal/validation/bead.go`), so there was no way to adopt such a store without changing its identity.

## Change

- On `--adopt`, when `--prefix` names the store's prefix (compared case-insensitively), resolve and store it **byte-for-byte** (rig entry, `city.toml`, canonical `config.yaml`).
- `validateAdoptAndBeadsStore` compares byte-for-byte on `--adopt` and keeps its case-insensitive comparison on re-add; a different `--prefix` is rejected.
- Fresh adds and derived prefixes are unchanged; the warning/error text for non-adopt paths stays byte-identical.
- `TestDoRigAdd_AdoptPreservesPrefixCase`: adopts a `MixedCase` store end to end and asserts `city.toml`, `config.yaml`, and rejection of a different `--prefix`.

## Verification

`go test ./internal/rig/ ./internal/beads/contract/` and `go vet` pass on top of `ed146d8d9`. Observed originally on a disposable city (Gas City 3e98278db + Beads bf97b73749); the same two commits run in production on a mixed-case adopted store since 2026-09-02.

Related: #5906 (adopt path when origin already has `refs/dolt/data`), #5907 (bd schema ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xto8aSo4FCT6iiqqAzzF2b
