### PR TITLE
Grow the usage scan window until the cursor is reachable

### DIFF
--- a/internal/sessionlog/codex_usage.go
+++ b/internal/sessionlog/codex_usage.go
@@ -55,7 +55,11 @@ func ExtractCodexTailMeta(path string) (*TailMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	return extractCodexTailMetaFromLines(splitLines(data), startsMidLine, truncated), nil
+	lines, err := splitLines(data)
+	if err != nil {
+		return nil, err
+	}
+	return extractCodexTailMetaFromLines(lines, startsMidLine, truncated), nil
 }
 
 // ExtractCodexTailMetaFromSearchPaths reads Codex tail metadata only after
@@ -289,12 +293,17 @@ func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 		return nil, err
 	}
 
+	lines, err := splitLines(data)
+	if err != nil {
+		return nil, err
+	}
+
 	var usages []TailUsage
 	// byMessageID maps a cumulative-total identity to its index in usages so
 	// duplicate token_count emissions collapse to a single entry.
 	byMessageID := make(map[string]int)
 	turnModel := seedModel
-	for _, line := range splitLines(data) {
+	for _, line := range lines {
 		var entry codexRawEntry
 		if err := json.Unmarshal(line, &entry); err != nil {
 			continue

--- a/internal/sessionlog/tail.go
+++ b/internal/sessionlog/tail.go
@@ -43,7 +43,7 @@ func ExtractTailMeta(path string) (*TailMeta, error) {
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
 
-	data, startsMidLine, err := readTail(f, tailChunkSize)
+	data, startsMidLine, err := readTail(f)
 	if err != nil {
 		return nil, err
 	}
@@ -87,9 +87,9 @@ func validateSearchPathFile(searchPaths []string, path string) (string, error) {
 	return "", fmt.Errorf("session log path is outside configured search paths")
 }
 
-// readTail reads the last n bytes of r (or the whole thing if smaller).
-func readTail(r io.ReadSeeker, n int64) ([]byte, bool, error) {
-	data, startsMidLine, _, err := readTailWindow(r, n)
+// readTail reads the last tailChunkSize bytes of r (or the whole thing if smaller).
+func readTail(r io.ReadSeeker) ([]byte, bool, error) {
+	data, startsMidLine, _, err := readTailWindow(r, tailChunkSize)
 	return data, startsMidLine, err
 }
 

--- a/internal/sessionlog/tail.go
+++ b/internal/sessionlog/tail.go
@@ -48,7 +48,10 @@ func ExtractTailMeta(path string) (*TailMeta, error) {
 		return nil, err
 	}
 
-	lines := splitLines(data)
+	lines, err := splitLines(data)
+	if err != nil {
+		return nil, err
+	}
 	return extractFromLines(lines, startsMidLine), nil
 }
 
@@ -139,11 +142,30 @@ func readTailWindowAt(r io.ReadSeeker, size, n int64) ([]byte, bool, bool, error
 	return data, startsMidLine, offset > 0, nil
 }
 
+// maxTailTokenBytes bounds a single JSONL line during a tail scan. Claude
+// entries can be large (tool results with full file contents, base64 images),
+// so the tail path uses the same 50MB ceiling the full-file reader adopted for
+// exactly that reason (parseFileDetailed).
+//
+// No current caller can reach this ceiling. The fixed-window paths scan
+// tailChunkSize (64KB), and ExtractTailUsageSince's growth loop stops at
+// maxUsageScanBytes (16MB), so the widest window any caller hands to splitLines
+// is three times below this bound and cannot hold a token that exceeds it. The
+// error return below is defense-in-depth against a future cap change, not a
+// live path — maxUsageScanBytes documents what raising the growth cap past this
+// constant would cost.
+const maxTailTokenBytes = 50 * 1024 * 1024
+
 // splitLines splits data into JSONL lines. Partial lines from a mid-file
 // read are tolerated — they fail json.Unmarshal silently in the caller.
-func splitLines(data []byte) [][]byte {
+//
+// A line longer than maxTailTokenBytes is reported rather than dropped:
+// bufio.Scanner stops permanently on bufio.ErrTooLong, so swallowing that
+// error would silently return a prefix of the window and hide every entry
+// after the oversized line — including the newest ones the caller came for.
+func splitLines(data []byte) ([][]byte, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	scanner.Buffer(make([]byte, 0, 256*1024), maxTailTokenBytes)
 	var lines [][]byte
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -154,7 +176,10 @@ func splitLines(data []byte) [][]byte {
 		copy(cp, line)
 		lines = append(lines, cp)
 	}
-	return lines
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("splitting session log tail: %w", err)
+	}
+	return lines, nil
 }
 
 // tailEntry is the minimal structure we decode from each JSONL line.

--- a/internal/sessionlog/tail_usage.go
+++ b/internal/sessionlog/tail_usage.go
@@ -56,11 +56,87 @@ func ExtractTailUsage(path string) ([]TailUsage, error) {
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
 
-	data, _, err := readTail(f, tailChunkSize)
+	data, _, err := readTail(f)
 	if err != nil {
 		return nil, err
 	}
+	return parseTailUsage(data), nil
+}
 
+// maxUsageScanBytes caps how far ExtractTailUsageSince will grow its scan
+// window when it cannot reach the cursor entry. It bounds the worst case (a
+// long-lived transcript whose cursor is stale or absent) while still covering
+// transcripts orders of magnitude larger than the fixed tail window.
+const maxUsageScanBytes = 16 * 1024 * 1024
+
+// ExtractTailUsageSince returns usage-bearing invocations from the tail of a
+// transcript, growing the scan window until the entry identified by cursorID
+// is inside it — so no invocation is skipped merely because more than
+// tailChunkSize bytes were appended since the last extraction.
+//
+// The fixed-window ExtractTailUsage silently drops any invocation that
+// scrolled past the last 64KB between two extractions. The persisted cursor
+// (session.MetadataKeyInvocationUsageCursor) is a message identity, not a byte
+// offset, so a later pass cannot reach back for what it missed and the usage
+// is lost permanently. Growing the window until the cursor is visible closes
+// that gap without introducing new persisted state: the caller's existing
+// cursor filter still decides what is new.
+//
+// The window doubles from tailChunkSize until the cursor entry is found, the
+// whole file is in the window, or maxUsageScanBytes is reached. An empty
+// cursorID (a session with no prior extraction) reads a single tailChunkSize
+// window, matching ExtractTailUsage: there is no anchor to reach back to, and
+// backfilling a full transcript on first sight is not this function's job.
+// Callers may receive entries at or before the cursor and must still filter.
+func ExtractTailUsageSince(path, cursorID string) ([]TailUsage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read-only file
+
+	if cursorID == "" {
+		data, _, err := readTail(f)
+		if err != nil {
+			return nil, err
+		}
+		return parseTailUsage(data), nil
+	}
+
+	for window := int64(tailChunkSize); ; window *= 2 {
+		data, _, truncated, err := readTailWindow(f, window)
+		if err != nil {
+			return nil, err
+		}
+		usages := parseTailUsage(data)
+		// Reached the cursor, or the whole file is in view: nothing older can
+		// still be owed. Either way this window is complete.
+		if !truncated || containsCursor(usages, cursorID) {
+			return usages, nil
+		}
+		if window >= maxUsageScanBytes {
+			// Cap hit with the cursor still out of view: return the widest
+			// window rather than nothing, so a stale cursor degrades to the
+			// old bounded behavior instead of losing everything.
+			return usages, nil
+		}
+	}
+}
+
+// containsCursor reports whether any extracted invocation carries the cursor
+// identity, under the same message-id-else-entry-uuid rule the telemetry
+// cursor is written with.
+func containsCursor(usages []TailUsage, cursorID string) bool {
+	for _, u := range usages {
+		if u.MessageID == cursorID || u.EntryUUID == cursorID {
+			return true
+		}
+	}
+	return false
+}
+
+// parseTailUsage extracts invocations from an already-read transcript window.
+func parseTailUsage(data []byte) []TailUsage {
 	var usages []TailUsage
 	// byMessageID maps a message identity to its index in usages so the
 	// content-block copies of one API response collapse to a single entry.
@@ -101,7 +177,18 @@ func ExtractTailUsage(path string) ([]TailUsage, error) {
 		}
 		usages = append(usages, u)
 	}
-	return usages, nil
+	return usages
+}
+
+// ExtractTailUsageSinceFromSearchPaths reads cursor-aware tail usage only
+// after verifying path resolves under one of the configured session-log
+// search roots. Mirrors ExtractTailUsageFromSearchPaths.
+func ExtractTailUsageSinceFromSearchPaths(searchPaths []string, path, cursorID string) ([]TailUsage, error) {
+	safePath, err := validateSearchPathFile(searchPaths, path)
+	if err != nil {
+		return nil, err
+	}
+	return ExtractTailUsageSince(safePath, cursorID)
 }
 
 // ExtractTailUsageFromSearchPaths reads tail usage only after verifying

--- a/internal/sessionlog/tail_usage.go
+++ b/internal/sessionlog/tail_usage.go
@@ -2,6 +2,7 @@ package sessionlog
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 )
 
@@ -60,13 +61,46 @@ func ExtractTailUsage(path string) ([]TailUsage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseTailUsage(data), nil
+	return parseTailUsage(data)
 }
 
 // maxUsageScanBytes caps how far ExtractTailUsageSince will grow its scan
 // window when it cannot reach the cursor entry. It bounds the worst case (a
 // long-lived transcript whose cursor is stale or absent) while still covering
 // transcripts orders of magnitude larger than the fixed tail window.
+//
+// The cap is a latency budget as much as a memory one. Both production callers
+// run synchronously: the prompt-op return path (worker.recordInvocationTelemetry,
+// deferred from Message and Nudge) and the deadline-bounded controller reconcile
+// tick (worker.Factory.SweepSessionModelUsage, which sweeps every terminal
+// session per tick). Each doubling re-reads AND re-parses the whole window, so
+// growing to a given size costs roughly twice that size in reads plus JSON
+// parsing. Measured against the ~1.5ms fixed 64KB window: ~85ms at 2MB, ~271ms
+// at 5.9MB, ~680ms at 19.7MB. Growth is paid only while the cursor sits outside
+// the fixed window — in steady state the first window contains it and the cost
+// is unchanged — so the bill lands on backlogged sessions and on the first pass
+// after a deploy. Raising this constant raises that worst case on both
+// synchronous lanes, but only one of them can recover anything for it: the
+// sweep folds the whole window through worker.usagesSinceCursor, while the
+// prompt-op seam folds through worker.usagesAfterCursor, which falls back to
+// the newest entry alone when the cursor is not in the window. A cap hit on
+// that lane therefore spends the full growth cost to return exactly what the
+// first tailChunkSize window already held.
+//
+// Reads and parses are not the whole bill. The window also fixes the size of
+// the pending batch each caller hands to usage.Sink, and every pending entry
+// costs one synchronous Record: usage.LocalSink opens, writes, fsyncs and
+// closes per fact (usage.ExecSink spawns a subprocess per fact). A cap-hit
+// window on a backlogged session therefore carries orders of magnitude more
+// facts than the fixed 64KB tail did, and that per-fact cost dominates the
+// read+parse figures above on both synchronous lanes.
+//
+// Raising it past maxTailTokenBytes (50MB) costs more than latency: it makes
+// bufio.ErrTooLong reachable in splitLines, which no caller can trigger
+// today, and worker's model-usage sweep classifies every extraction error as
+// transient. One permanently oversized transcript line would then leave that
+// session unsettled and retried on every controller tick, indefinitely. Keep
+// this cap below maxTailTokenBytes.
 const maxUsageScanBytes = 16 * 1024 * 1024
 
 // ExtractTailUsageSince returns usage-bearing invocations from the tail of a
@@ -83,12 +117,24 @@ const maxUsageScanBytes = 16 * 1024 * 1024
 // cursor filter still decides what is new.
 //
 // The window doubles from tailChunkSize until the cursor entry is found, the
-// whole file is in the window, or maxUsageScanBytes is reached. An empty
+// whole file is in the window, or maxUsageScanBytes is reached. Reaching the
+// cap bounds that gap rather than closing it: the widest window is returned
+// with a nil error, so invocations older than maxUsageScanBytes are lost
+// permanently just as the fixed window lost invocations older than
+// tailChunkSize. The returned value is indistinguishable from a complete scan,
+// so the cap-hit log line is the only signal. An empty
 // cursorID (a session with no prior extraction) reads a single tailChunkSize
 // window, matching ExtractTailUsage: there is no anchor to reach back to, and
 // backfilling a full transcript on first sight is not this function's job.
 // Callers may receive entries at or before the cursor and must still filter.
 func ExtractTailUsageSince(path, cursorID string) ([]TailUsage, error) {
+	return extractTailUsageSince(path, cursorID, maxUsageScanBytes)
+}
+
+// extractTailUsageSince is ExtractTailUsageSince with the growth cap supplied
+// by the caller, so tests can drive the cap branch without building a
+// multi-megabyte transcript.
+func extractTailUsageSince(path, cursorID string, maxScanBytes int64) ([]TailUsage, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -100,7 +146,7 @@ func ExtractTailUsageSince(path, cursorID string) ([]TailUsage, error) {
 		if err != nil {
 			return nil, err
 		}
-		return parseTailUsage(data), nil
+		return parseTailUsage(data)
 	}
 
 	for window := int64(tailChunkSize); ; window *= 2 {
@@ -108,16 +154,23 @@ func ExtractTailUsageSince(path, cursorID string) ([]TailUsage, error) {
 		if err != nil {
 			return nil, err
 		}
-		usages := parseTailUsage(data)
+		usages, err := parseTailUsage(data)
+		if err != nil {
+			return nil, err
+		}
 		// Reached the cursor, or the whole file is in view: nothing older can
 		// still be owed. Either way this window is complete.
 		if !truncated || containsCursor(usages, cursorID) {
 			return usages, nil
 		}
-		if window >= maxUsageScanBytes {
+		if window >= maxScanBytes {
 			// Cap hit with the cursor still out of view: return the widest
 			// window rather than nothing, so a stale cursor degrades to the
-			// old bounded behavior instead of losing everything.
+			// old bounded behavior instead of losing everything. Say so — the
+			// residual loss is exactly the silent gap this extractor exists to
+			// close, and it is invisible in the returned value.
+			log.Printf("sessionlog: usage scan cap reached path=%q window_bytes=%d cursor=%q; invocations older than the window are not returned",
+				path, window, cursorID)
 			return usages, nil
 		}
 	}
@@ -136,12 +189,19 @@ func containsCursor(usages []TailUsage, cursorID string) bool {
 }
 
 // parseTailUsage extracts invocations from an already-read transcript window.
-func parseTailUsage(data []byte) []TailUsage {
+// It fails rather than returning a prefix when the window carries a line the
+// splitter cannot hold: a truncated parse would drop the newest invocations
+// silently, which is the loss this package is trying to prevent.
+func parseTailUsage(data []byte) ([]TailUsage, error) {
+	lines, err := splitLines(data)
+	if err != nil {
+		return nil, err
+	}
 	var usages []TailUsage
 	// byMessageID maps a message identity to its index in usages so the
 	// content-block copies of one API response collapse to a single entry.
 	byMessageID := make(map[string]int)
-	for _, line := range splitLines(data) {
+	for _, line := range lines {
 		var entry tailEntry
 		if err := json.Unmarshal(line, &entry); err != nil {
 			continue
@@ -177,7 +237,7 @@ func parseTailUsage(data []byte) []TailUsage {
 		}
 		usages = append(usages, u)
 	}
-	return usages
+	return usages, nil
 }
 
 // ExtractTailUsageSinceFromSearchPaths reads cursor-aware tail usage only

--- a/internal/sessionlog/tail_usage_test.go
+++ b/internal/sessionlog/tail_usage_test.go
@@ -301,9 +301,14 @@ func TestExtractTailUsageFromSearchPathsRejectsEscapedPath(t *testing.T) {
 	}
 }
 
+// usageEntryPadBytes pads each entry built by buildUsageEntry so a handful of
+// them exceed the fixed 64KB tail window: ~3 entries fill one window, so a
+// 30-60 entry transcript spans many.
+const usageEntryPadBytes = 20 * 1024
+
 // buildUsageEntry returns one assistant entry whose padding makes the encoded
 // line large enough that a handful of entries exceed the fixed tail window.
-func buildUsageEntry(id string, padBytes int) map[string]any {
+func buildUsageEntry(id string) map[string]any {
 	return map[string]any{
 		"type": "assistant",
 		"uuid": "uuid-" + id,
@@ -317,7 +322,7 @@ func buildUsageEntry(id string, padBytes int) map[string]any {
 				"cache_read_input_tokens":     30,
 				"cache_creation_input_tokens": 40,
 			},
-			"content": strings.Repeat("x", padBytes),
+			"content": strings.Repeat("x", usageEntryPadBytes),
 		},
 	}
 }
@@ -331,11 +336,10 @@ func TestExtractTailUsageSinceReachesBackPastTheFixedWindow(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 
-	const entries = 60
-	const pad = 20 * 1024 // ~20KB per entry: 60 entries ≈ 1.2MB, ~19 windows
+	const entries = 60 // ~20KB per entry: 60 entries ≈ 1.2MB, ~19 windows
 	rows := make([]map[string]any, 0, entries)
 	for i := range entries {
-		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i), pad))
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i)))
 	}
 	writeTailJSONL(t, path, rows)
 
@@ -374,7 +378,7 @@ func TestExtractTailUsageSinceEmptyCursorMatchesFixedWindow(t *testing.T) {
 
 	rows := make([]map[string]any, 0, 40)
 	for i := range 40 {
-		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i), 20*1024))
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i)))
 	}
 	writeTailJSONL(t, path, rows)
 
@@ -391,15 +395,17 @@ func TestExtractTailUsageSinceEmptyCursorMatchesFixedWindow(t *testing.T) {
 	}
 }
 
-// TestExtractTailUsageSinceUnreachableCursorDegradesToBoundedWindow pins that a
-// stale or absent cursor returns the widest scanned window rather than nothing.
-func TestExtractTailUsageSinceUnreachableCursorDegradesToBoundedWindow(t *testing.T) {
+// TestExtractTailUsageSinceUnreachableCursorReturnsWholeFile pins that a stale
+// or absent cursor on a transcript smaller than the growth cap returns the
+// whole file rather than nothing. This exits through the !truncated branch, not
+// the cap branch — TestExtractTailUsageSinceStopsAtGrowthCap covers that one.
+func TestExtractTailUsageSinceUnreachableCursorReturnsWholeFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 
 	rows := make([]map[string]any, 0, 30)
 	for i := range 30 {
-		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i), 20*1024))
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i)))
 	}
 	writeTailJSONL(t, path, rows)
 
@@ -411,5 +417,99 @@ func TestExtractTailUsageSinceUnreachableCursorDegradesToBoundedWindow(t *testin
 	// cover it and returns everything instead of failing.
 	if len(got) != 30 {
 		t.Errorf("got %d entries, want all 30 once the window covers the file", len(got))
+	}
+}
+
+// TestExtractTailUsageSinceStopsAtGrowthCap pins the cap branch: once the
+// window reaches the growth cap with the cursor still out of view, the widest
+// scanned window is returned — not nothing, and not an unbounded scan. The cap
+// is injected so the branch is reachable without a multi-megabyte fixture.
+func TestExtractTailUsageSinceStopsAtGrowthCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	const entries = 30
+	rows := make([]map[string]any, 0, entries)
+	for i := range entries {
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i)))
+	}
+	writeTailJSONL(t, path, rows)
+
+	// ~600KB of transcript against a 128KB cap: the loop must exit through the
+	// cap with the cursor still unreached.
+	got, err := extractTailUsageSince(path, "msg_does_not_exist", 128*1024)
+	if err != nil {
+		t.Fatalf("extractTailUsageSince: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("cap branch returned nothing; want the widest scanned window")
+	}
+	if len(got) >= entries {
+		t.Errorf("got %d of %d entries; the cap must bound the scan short of the whole file",
+			len(got), entries)
+	}
+}
+
+// TestExtractTailUsageSinceSpansOversizedTranscriptLine pins that a transcript
+// line larger than the scanner's old 256KB token cap does not truncate the
+// grown window's parse. Growing the window is what first makes such a line
+// reachable, so swallowing bufio.ErrTooLong would drop every invocation after
+// it — including the newest ones, which the fixed 64KB window always saw. That
+// is the same silent, permanent loss ExtractTailUsageSince exists to close,
+// reintroduced in a new shape.
+func TestExtractTailUsageSinceSpansOversizedTranscriptLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	const half = 20
+	rows := make([]map[string]any, 0, 2*half+1)
+	for i := range half {
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_old_%02d", i)))
+	}
+	// One non-usage entry far above the old 256KB token cap, sitting between
+	// the cursor and the newest invocations.
+	rows = append(rows, map[string]any{
+		"type": "user",
+		"uuid": "uuid-oversized",
+		"message": map[string]any{
+			"role":    "user",
+			"content": strings.Repeat("y", 400*1024),
+		},
+	})
+	for i := range half {
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_new_%02d", i)))
+	}
+	writeTailJSONL(t, path, rows)
+
+	cursor := "msg_old_00"
+	newest := fmt.Sprintf("msg_new_%02d", half-1)
+
+	// Preconditions, so a failure below is a regression against the fixed
+	// window rather than a gap that predates the growth loop: the fixed window
+	// does see the newest invocation, and it does not reach the cursor.
+	fixed, err := ExtractTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractTailUsage: %v", err)
+	}
+	if !containsCursor(fixed, newest) {
+		t.Fatalf("precondition: fixed window did not see newest invocation %q (%d entries)", newest, len(fixed))
+	}
+	if containsCursor(fixed, cursor) {
+		t.Fatalf("precondition: fixed window already reaches the cursor, so the window never grows")
+	}
+
+	got, err := ExtractTailUsageSince(path, cursor)
+	if err != nil {
+		t.Fatalf("ExtractTailUsageSince: %v", err)
+	}
+	if !containsCursor(got, newest) {
+		t.Errorf("newest invocation %q missing from the grown window (%d entries): the oversized line truncated the parse",
+			newest, len(got))
+	}
+	if !containsCursor(got, cursor) {
+		t.Errorf("cursor %q not reached: got %d entries", cursor, len(got))
+	}
+	if len(got) != 2*half {
+		t.Errorf("got %d invocations, want all %d spanning the oversized line", len(got), 2*half)
 	}
 }

--- a/internal/sessionlog/tail_usage_test.go
+++ b/internal/sessionlog/tail_usage_test.go
@@ -1,8 +1,10 @@
 package sessionlog
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -296,5 +298,118 @@ func TestExtractTailUsageFromSearchPathsRejectsEscapedPath(t *testing.T) {
 	}
 	if len(usages) != 1 || usages[0].EntryUUID != "u1" {
 		t.Fatalf("ExtractTailUsageFromSearchPaths = %+v, want one u1 entry", usages)
+	}
+}
+
+// buildUsageEntry returns one assistant entry whose padding makes the encoded
+// line large enough that a handful of entries exceed the fixed tail window.
+func buildUsageEntry(id string, padBytes int) map[string]any {
+	return map[string]any{
+		"type": "assistant",
+		"uuid": "uuid-" + id,
+		"message": map[string]any{
+			"role":  "assistant",
+			"id":    id,
+			"model": "claude-opus-4-8",
+			"usage": map[string]any{
+				"input_tokens":                10,
+				"output_tokens":               20,
+				"cache_read_input_tokens":     30,
+				"cache_creation_input_tokens": 40,
+			},
+			"content": strings.Repeat("x", padBytes),
+		},
+	}
+}
+
+// TestExtractTailUsageSinceReachesBackPastTheFixedWindow pins the defect that
+// the fixed 64KB window drops every invocation that scrolled past it between
+// two extractions. The transcript below is many windows long, so the fixed
+// extractor cannot see the cursor entry or anything after it up to the last
+// window; the cursor-aware extractor must return them.
+func TestExtractTailUsageSinceReachesBackPastTheFixedWindow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	const entries = 60
+	const pad = 20 * 1024 // ~20KB per entry: 60 entries ≈ 1.2MB, ~19 windows
+	rows := make([]map[string]any, 0, entries)
+	for i := range entries {
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i), pad))
+	}
+	writeTailJSONL(t, path, rows)
+
+	// The cursor is the FIRST invocation: everything after it is owed.
+	cursor := "msg_00"
+
+	fixed, err := ExtractTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractTailUsage: %v", err)
+	}
+	if containsCursor(fixed, cursor) {
+		t.Fatalf("test is not exercising the defect: fixed window still reaches the cursor (%d entries)", len(fixed))
+	}
+
+	got, err := ExtractTailUsageSince(path, cursor)
+	if err != nil {
+		t.Fatalf("ExtractTailUsageSince: %v", err)
+	}
+	if !containsCursor(got, cursor) {
+		t.Fatalf("cursor %q not reached: got %d entries, want the window grown to include it", cursor, len(got))
+	}
+	if len(got) != entries {
+		t.Errorf("got %d invocations, want all %d from the cursor onward", len(got), entries)
+	}
+	if len(got) <= len(fixed) {
+		t.Errorf("cursor-aware scan returned %d entries, fixed window returned %d; want strictly more",
+			len(got), len(fixed))
+	}
+}
+
+// TestExtractTailUsageSinceEmptyCursorMatchesFixedWindow pins that a session
+// with no prior extraction keeps the old bounded behavior.
+func TestExtractTailUsageSinceEmptyCursorMatchesFixedWindow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	rows := make([]map[string]any, 0, 40)
+	for i := range 40 {
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i), 20*1024))
+	}
+	writeTailJSONL(t, path, rows)
+
+	fixed, err := ExtractTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractTailUsage: %v", err)
+	}
+	got, err := ExtractTailUsageSince(path, "")
+	if err != nil {
+		t.Fatalf("ExtractTailUsageSince: %v", err)
+	}
+	if len(got) != len(fixed) {
+		t.Errorf("empty cursor returned %d entries, want the fixed-window %d", len(got), len(fixed))
+	}
+}
+
+// TestExtractTailUsageSinceUnreachableCursorDegradesToBoundedWindow pins that a
+// stale or absent cursor returns the widest scanned window rather than nothing.
+func TestExtractTailUsageSinceUnreachableCursorDegradesToBoundedWindow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	rows := make([]map[string]any, 0, 30)
+	for i := range 30 {
+		rows = append(rows, buildUsageEntry(fmt.Sprintf("msg_%02d", i), 20*1024))
+	}
+	writeTailJSONL(t, path, rows)
+
+	got, err := ExtractTailUsageSince(path, "msg_does_not_exist")
+	if err != nil {
+		t.Fatalf("ExtractTailUsageSince: %v", err)
+	}
+	// The whole file (~600KB) is well under the cap, so the window grows to
+	// cover it and returns everything instead of failing.
+	if len(got) != 30 {
+		t.Errorf("got %d entries, want all 30 once the window covers the file", len(got))
 	}
 }

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -43,8 +43,11 @@ func defaultPricingRegistry() *pricing.Registry {
 // keystroke-delivery time, so the transcript tail at that point holds
 // previously COMPLETED invocations — the turn this operation triggers is
 // recorded by the next prompt operation on the session. Entries beyond the
-// extractor's scan window (a 64KB tail for claude and codex) or after the
-// final prompt op of a session go unrecorded.
+// extractor's scan window — which for claude grows from the 64KB tail up to
+// 16MB until the persisted cursor is in view, and for codex stays at that
+// fixed 64KB tail (the per-family coverage ceiling is stated in full on
+// SweepSessionModelUsage) — or after the final prompt op of a session go
+// unrecorded.
 //
 // Coverage is per transcript provider family, driven by the
 // invocationUsageSpecs registry, with per-family discovery bounds:
@@ -89,8 +92,13 @@ func defaultPricingRegistry() *pricing.Registry {
 // same session — whether in separate processes or on separate handles in one
 // process (the API server constructs a fresh handle per request) — can each
 // read the same stale cursor and double-record the pending batch.
-// invTelemetryMu only serializes ops that share a single handle instance.
-// Accepted as best-effort. RuntimeHandle prompt ops are permanently out of
+// invTelemetryMu only serializes ops that share a single handle instance. That
+// pending batch is now bounded by the grown scan window rather than the fixed
+// 64KB tail, so the duplicated OTel counter volume scales with backlog depth;
+// the facts still collapse on usage.ModelIdempotencyKey, the keyless counters
+// do not (see usagesSinceCursor). Accepted as best-effort.
+//
+// RuntimeHandle prompt ops are permanently out of
 // scope (decided in ga-tkvb31, not a pending gap): runtime-only sessions
 // have no transcript adapter, no session bead for the cursor, and no agent
 // identity, and will not gain bead-backed identity just for telemetry.
@@ -416,6 +424,14 @@ func usagesAfterCursor(usages []sessionlog.TailUsage, cursor string) []sessionlo
 // IdempotencyKey dedup (usage.ReadFacts) collapses any overlap with
 // already-recorded facts, so recovering the whole bounded tail cannot
 // double-count.
+//
+// That dedup covers the fact sink ONLY. sweepResolvedTranscript also emits OTel
+// counters (RecordInvocationTokens, RecordInvocationCostEstimate) for every
+// entry it folds, unconditionally and before the sink write; those counters are
+// monotonic and carry no idempotency key, so an out-of-window cursor
+// re-increments them for the whole window. The burst is bounded by the
+// extractor's window and self-corrects on the next pass — the cursor advances
+// to the newest entry — but the overlap it already counted is permanent.
 func usagesSinceCursor(usages []sessionlog.TailUsage, cursor string) []sessionlog.TailUsage {
 	if len(usages) == 0 {
 		return nil
@@ -461,12 +477,43 @@ func usagesSinceCursor(usages []sessionlog.TailUsage, cursor string) []sessionlo
 // skipping it. Every gate is slog.Debug'd so a fleet-wide zero is attributable in
 // the field instead of silently swallowed.
 //
-// Coverage ceiling (known, intentional — do NOT widen): discovery and extraction
-// read only the extractor's bounded transcript tail (a 64KB window per family),
-// so a very long autonomous interval recovers only its final few invocations —
-// earlier model/cost facts of that interval are lost. Widening the tail re-opens
-// the unbounded-scan and misattribution risks that bound exists to prevent;
-// fuller recovery is a separate, deliberate change.
+// Coverage ceiling, per transcript family — the two families differ, and the
+// difference is deliberate:
+//
+//   - claude: cursor-bounded growth, capped at 16MB — once a cursor exists.
+//     SessionLogAdapter.TailUsage routes to sessionlog.ExtractTailUsageSince,
+//     whose window doubles from the 64KB tail until the persisted cursor is
+//     in view, the whole file is in view, or the growth cap is reached — so a
+//     very long autonomous interval recovers its whole backlog rather than
+//     only its final few invocations. Only entries older than that capped
+//     window are lost, and the extractor logs the path, window, and cursor
+//     when it drops them.
+//     Before a cursor exists none of that applies. PersistInvocationUsageCursor
+//     no-ops on an empty value, so the cursor stays unset until some seam
+//     records an invocation; until then ExtractTailUsageSince short-circuits to
+//     one fixed tailChunkSize (64KB) read, never entering the growth loop and
+//     so never emitting the cap log. That first pass is the pre-change
+//     behavior — everything older than 64KB is dropped silently — and the
+//     cursor it then persists becomes the growth loop's stop condition, so no
+//     later pass reaches back across the gap. Both sweep lanes take this path:
+//     SweepSessionModelUsage and SweepSessionModelUsageAtPath share
+//     sweepResolvedTranscript, which reads the cursor from session-bead
+//     metadata.
+//   - codex: still the fixed 64KB tail, and still silently lossy.
+//     SessionLogAdapter.CodexTailUsage accepts the cursor and discards it, so a
+//     very long autonomous interval recovers only its final few invocations and
+//     the earlier model/cost facts of that interval are lost with no log line.
+//     Widening it needs its own correctness argument rather than this one: the
+//     codex extractor collapses on cumulative totals rather than per-message
+//     identity, so the cursor is not a usable stop condition there.
+//
+// Neither risk the old blanket "do not widen" ceiling cited survives
+// cursor-bounded growth, which is why claude was widened. The scan is not
+// unbounded: it terminates at the cursor, at EOF, or at the growth cap. And it
+// cannot misattribute: with the cursor at byte P and EOF at E, a cap-hit window
+// is exactly [E-16MB, E], every byte of which is after P — so every entry
+// returned is genuinely newer than the cursor, and the only loss is
+// [P, E-16MB), which is precisely what the extractor's cap log reports.
 //
 // Overlap with the prompt-op seam is safe: both stamp usage.ModelIdempotencyKey,
 // which usage.ReadFacts collapses, so an invocation recorded by both beats folds

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -144,7 +144,11 @@ func (h *SessionHandle) recordInvocationTelemetry(ctx context.Context) {
 			slog.String("session_id", id), slog.String("provider", providerFamily))
 		return
 	}
-	usages, err := spec.extract(h.adapter, path)
+	// Read the cursor BEFORE extracting: it bounds how far back the scan
+	// window must reach, so invocations appended since the last pass are not
+	// lost to the fixed tail window.
+	cursor := strings.TrimSpace(pr.Metadata[sessionpkg.MetadataKeyInvocationUsageCursor])
+	usages, err := spec.extract(h.adapter, path, cursor)
 	if err != nil {
 		slog.Debug("invocation telemetry: usage extraction failed; skipping",
 			slog.String("session_id", id), slog.String("provider", providerFamily), slog.Any("error", err))
@@ -155,7 +159,6 @@ func (h *SessionHandle) recordInvocationTelemetry(ctx context.Context) {
 			slog.String("session_id", id), slog.String("provider", providerFamily))
 		return
 	}
-	cursor := strings.TrimSpace(pr.Metadata[sessionpkg.MetadataKeyInvocationUsageCursor])
 	pending := usagesAfterCursor(usages, cursor)
 	if len(pending) == 0 {
 		slog.Debug("invocation telemetry: no new invocations since cursor; skipping",
@@ -267,7 +270,7 @@ func modelUsageFact(u sessionlog.TailUsage, meta map[string]string, beadID, sess
 // are swallowed so telemetry never affects operations.
 type invocationUsageSpec struct {
 	discover func(h *SessionHandle, id string, createdAt time.Time, meta map[string]string) string
-	extract  func(a SessionLogAdapter, path string) ([]sessionlog.TailUsage, error)
+	extract  func(a SessionLogAdapter, path, cursorID string) ([]sessionlog.TailUsage, error)
 }
 
 // codexInvocationDiscoveryWindow bounds how far after the wake anchor a
@@ -601,14 +604,17 @@ func (f *Factory) SweepSessionModelUsageAtPath(ctx context.Context, id string, m
 // the discovery-driven and already-resolved entry points.
 func (f *Factory) sweepResolvedTranscript(ctx context.Context, family, id string, meta map[string]string, path string, now time.Time) (emitted int, settled bool, err error) {
 	sink := f.usageSink
-	usages, extractErr := f.Adapter().InvocationUsage(family, path)
+	// Read the cursor BEFORE extracting: it bounds how far back the scan
+	// window must reach, so a sweep that falls more than one window behind
+	// still recovers the whole backlog instead of the tail's last few entries.
+	cursor := strings.TrimSpace(meta[sessionpkg.MetadataKeyInvocationUsageCursor])
+	usages, extractErr := f.Adapter().InvocationUsage(family, path, cursor)
 	if extractErr != nil {
 		// Transient: a torn mid-write tail can fail the parse; retry on a later tick.
 		slog.Debug("model-usage sweep: usage extraction failed; will retry",
 			slog.String("session_id", id), slog.String("provider", family), slog.Any("error", extractErr))
 		return 0, false, nil
 	}
-	cursor := strings.TrimSpace(meta[sessionpkg.MetadataKeyInvocationUsageCursor])
 	pending := usagesSinceCursor(usages, cursor)
 	if len(pending) == 0 {
 		// Swept: the transcript was read and the cursor is already current.

--- a/internal/worker/invocation_telemetry_usagefact_test.go
+++ b/internal/worker/invocation_telemetry_usagefact_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1431,5 +1432,118 @@ func TestFactorySweepSessionModelUsageKeylessCodexDirtySingletonRetries(t *testi
 	}
 	if facts[0].OutputTokens != 50 {
 		t.Fatalf("OutputTokens = %d, want 50 (proves the cwd==work_dir rollout recorded, not the sibling)", facts[0].OutputTokens)
+	}
+}
+
+// paddedUsageEntry returns a usage-bearing assistant entry inflated to roughly
+// padBytes so a modest number of entries exceeds the extractor's fixed tail
+// window, reproducing a real transcript's bytes-per-invocation.
+func paddedUsageEntry(uuid, messageID string, padBytes int) map[string]any {
+	entry := usageEntryWithMessageID(uuid, messageID, 100, 50, 0, 0)
+	entry["message"].(map[string]any)["content"] = strings.Repeat("x", padBytes)
+	return entry
+}
+
+// TestFactorySweepRecoversBacklogBeyondFixedTailWindow is the end-to-end guard
+// for the defect: when more than one tail window of transcript accumulates
+// between sweeps, every invocation past the window used to be dropped
+// permanently, because the persisted cursor is a message identity with no byte
+// offset to resume from. The sweep must now recover the whole backlog.
+func TestFactorySweepRecoversBacklogBeyondFixedTailWindow(t *testing.T) {
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+	sinkPath := filepath.Join(t.TempDir(), "usage.jsonl")
+
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	factory, err := NewFactory(FactoryConfig{
+		Store:       store,
+		Provider:    sp,
+		SearchPaths: []string{searchBase},
+		UsageSink:   usage.NewLocalSink(sinkPath),
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+
+	h, err := factory.Session(SessionSpec{
+		Profile:  ProfileClaudeTmuxCLI,
+		Template: "probe",
+		Title:    "Probe",
+		Command:  "claude",
+		WorkDir:  workDir,
+		Provider: "claude",
+		Metadata: map[string]string{"agent_name": "myrig/polecat-1"},
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	id := h.sessionID
+
+	info, err := h.manager.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", id, err)
+	}
+	slugDir := filepath.Join(searchBase, sessionlog.ProjectSlug(workDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", slugDir, err)
+	}
+	transcriptPath := filepath.Join(slugDir, info.SessionKey+".jsonl")
+
+	// 40 entries at ~20KB each ≈ 800KB: over a dozen fixed windows.
+	const backlog = 40
+	rows := make([]map[string]any, 0, backlog+1)
+	rows = append(rows, usageEntryWithMessageID("u0", "msg-cursor", 1, 1, 0, 0))
+	for i := range backlog {
+		rows = append(rows, paddedUsageEntry(fmt.Sprintf("u%d", i+1), fmt.Sprintf("msg-%02d", i), 20*1024))
+	}
+	writeWorkerTestJSONL(t, transcriptPath, rows)
+
+	// The session was last recorded at the very first entry, so all 40 that
+	// follow are owed. Under the fixed window only the last handful are visible.
+	if err := store.SetMetadata(id, sessionpkg.MetadataKeyInvocationUsageCursor, "msg-cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(id, "molecule_id", "run-Z"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Guard: the fixed window genuinely cannot reach the cursor, so this test
+	// keeps exercising the defect rather than quietly becoming a tautology.
+	fixed, err := sessionlog.ExtractTailUsage(transcriptPath)
+	if err != nil {
+		t.Fatalf("ExtractTailUsage: %v", err)
+	}
+	if len(fixed) >= backlog {
+		t.Fatalf("fixed tail window saw %d of %d entries; test no longer reproduces the backlog", len(fixed), backlog)
+	}
+
+	emitted, settled, err := factory.SweepSessionModelUsage(context.Background(), id, b.Metadata, time.Unix(1, 0).UTC())
+	if err != nil {
+		t.Fatalf("SweepSessionModelUsage: %v", err)
+	}
+	if !settled {
+		t.Fatal("a fully-recorded sweep must report settled")
+	}
+	if emitted != backlog {
+		t.Fatalf("emitted = %d, want %d (the whole backlog past the fixed window)", emitted, backlog)
+	}
+
+	facts, warnings, err := usage.ReadFacts(sinkPath)
+	if err != nil {
+		t.Fatalf("ReadFacts: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected sink warnings: %v", warnings)
+	}
+	if len(facts) != backlog {
+		t.Fatalf("sink holds %d facts, want %d", len(facts), backlog)
 	}
 }

--- a/internal/worker/invocation_telemetry_usagefact_test.go
+++ b/internal/worker/invocation_telemetry_usagefact_test.go
@@ -1547,3 +1547,121 @@ func TestFactorySweepRecoversBacklogBeyondFixedTailWindow(t *testing.T) {
 		t.Fatalf("sink holds %d facts, want %d", len(facts), backlog)
 	}
 }
+
+// TestFactorySweepWithoutCursorMatchesFixedTailWindow pins the other half of
+// the per-family coverage ceiling documented on SweepSessionModelUsage: growth
+// is cursor-bounded, so before a cursor exists there is no growth at all.
+// ExtractTailUsageSince short-circuits to one fixed 64KB read, and the sweep
+// therefore emits only what that window holds — the pre-change behavior, with
+// no cap log. The cursor the sweep then persists points at the newest entry,
+// which is the growth loop's stop condition, so no later sweep reaches back
+// across the gap. TestFactorySweepRecoversBacklogBeyondFixedTailWindow
+// pre-seeds a cursor and so cannot cover this branch.
+func TestFactorySweepWithoutCursorMatchesFixedTailWindow(t *testing.T) {
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+	sinkPath := filepath.Join(t.TempDir(), "usage.jsonl")
+
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	factory, err := NewFactory(FactoryConfig{
+		Store:       store,
+		Provider:    sp,
+		SearchPaths: []string{searchBase},
+		UsageSink:   usage.NewLocalSink(sinkPath),
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+
+	h, err := factory.Session(SessionSpec{
+		Profile:  ProfileClaudeTmuxCLI,
+		Template: "probe",
+		Title:    "Probe",
+		Command:  "claude",
+		WorkDir:  workDir,
+		Provider: "claude",
+		Metadata: map[string]string{"agent_name": "myrig/polecat-1"},
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	id := h.sessionID
+
+	info, err := h.manager.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", id, err)
+	}
+	slugDir := filepath.Join(searchBase, sessionlog.ProjectSlug(workDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", slugDir, err)
+	}
+	transcriptPath := filepath.Join(slugDir, info.SessionKey+".jsonl")
+
+	// Same ~800KB backlog as the cursor-seeded test, so the only difference
+	// between the two is whether a cursor exists.
+	const backlog = 40
+	rows := make([]map[string]any, 0, backlog)
+	for i := range backlog {
+		rows = append(rows, paddedUsageEntry(fmt.Sprintf("u%d", i+1), fmt.Sprintf("msg-%02d", i), 20*1024))
+	}
+	writeWorkerTestJSONL(t, transcriptPath, rows)
+
+	// No MetadataKeyInvocationUsageCursor: this is a session's first sweep.
+	if err := store.SetMetadata(id, "molecule_id", "run-Z"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(b.Metadata[sessionpkg.MetadataKeyInvocationUsageCursor]); got != "" {
+		t.Fatalf("precondition: cursor = %q, want empty", got)
+	}
+
+	// The fixed window is what the sweep is expected to be limited to, and it
+	// must be genuinely narrower than the backlog or this asserts nothing.
+	fixed, err := sessionlog.ExtractTailUsage(transcriptPath)
+	if err != nil {
+		t.Fatalf("ExtractTailUsage: %v", err)
+	}
+	if len(fixed) == 0 || len(fixed) >= backlog {
+		t.Fatalf("fixed tail window saw %d of %d entries; test no longer isolates the empty-cursor branch", len(fixed), backlog)
+	}
+
+	emitted, settled, err := factory.SweepSessionModelUsage(context.Background(), id, b.Metadata, time.Unix(1, 0).UTC())
+	if err != nil {
+		t.Fatalf("SweepSessionModelUsage: %v", err)
+	}
+	if !settled {
+		t.Fatal("a fully-recorded sweep must report settled")
+	}
+	if emitted != len(fixed) {
+		t.Fatalf("emitted = %d, want %d (the fixed window only, with no cursor to grow toward)", emitted, len(fixed))
+	}
+
+	facts, warnings, err := usage.ReadFacts(sinkPath)
+	if err != nil {
+		t.Fatalf("ReadFacts: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected sink warnings: %v", warnings)
+	}
+	if len(facts) != len(fixed) {
+		t.Fatalf("sink holds %d facts, want %d", len(facts), len(fixed))
+	}
+
+	// The persisted cursor is the newest entry, not the oldest one the sweep
+	// missed: the gap below it is unreachable from every later sweep.
+	after, err := store.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCursor := fmt.Sprintf("msg-%02d", backlog-1)
+	if got := after.Metadata[sessionpkg.MetadataKeyInvocationUsageCursor]; got != wantCursor {
+		t.Fatalf("persisted cursor = %q, want %q (the newest entry)", got, wantCursor)
+	}
+}

--- a/internal/worker/sessionlog_adapter.go
+++ b/internal/worker/sessionlog_adapter.go
@@ -110,8 +110,11 @@ func (a SessionLogAdapter) TailMetaForProvider(provider, path string) (*sessionl
 
 // TailUsage reads per-invocation token usage entries from the tail of a
 // discovered transcript path, validating it against the search-path roots.
-func (a SessionLogAdapter) TailUsage(path string) ([]sessionlog.TailUsage, error) {
-	return sessionlog.ExtractTailUsageFromSearchPaths(a.SearchPaths, path)
+// The scan window grows until cursorID is inside it, so invocations appended
+// since the last extraction are not lost to the fixed tail window. An empty
+// cursorID keeps the single fixed window.
+func (a SessionLogAdapter) TailUsage(path, cursorID string) ([]sessionlog.TailUsage, error) {
+	return sessionlog.ExtractTailUsageSinceFromSearchPaths(a.SearchPaths, path, cursorID)
 }
 
 // CodexTailUsage reads per-invocation token usage from the tail of a codex
@@ -119,7 +122,12 @@ func (a SessionLogAdapter) TailUsage(path string) ([]sessionlog.TailUsage, error
 // (~/.codex/sessions) on top of the configured search paths, because
 // a.SearchPaths alone holds claude-style roots that would reject real codex
 // rollout locations.
-func (a SessionLogAdapter) CodexTailUsage(path string) ([]sessionlog.TailUsage, error) {
+// cursorID is accepted for signature symmetry with TailUsage but not yet
+// honored: the codex extractor collapses on cumulative totals rather than
+// per-message identity, so window growth needs its own correctness argument.
+// The codex family therefore keeps the fixed tail window for now.
+func (a SessionLogAdapter) CodexTailUsage(path, cursorID string) ([]sessionlog.TailUsage, error) {
+	_ = cursorID
 	return sessionlog.ExtractCodexTailUsageFromSearchPaths(a.SearchPaths, path)
 }
 
@@ -128,12 +136,12 @@ func (a SessionLogAdapter) CodexTailUsage(path string) ([]sessionlog.TailUsage, 
 // the provider's invocation-usage family (invocationUsageSpecs). It returns
 // (nil, nil) for families without invocation-telemetry support, so callers can
 // treat "no extractor" and "no usage" uniformly.
-func (a SessionLogAdapter) InvocationUsage(provider, path string) ([]sessionlog.TailUsage, error) {
+func (a SessionLogAdapter) InvocationUsage(provider, path, cursorID string) ([]sessionlog.TailUsage, error) {
 	family, ok := InvocationUsageFamily(provider)
 	if !ok {
 		return nil, nil
 	}
-	return invocationUsageSpecs[family].extract(a, path)
+	return invocationUsageSpecs[family].extract(a, path, cursorID)
 }
 
 // TailActivityForProvider reads tail activity for a provider whose transcript

--- a/internal/worker/workertest/phase1.go
+++ b/internal/worker/workertest/phase1.go
@@ -105,7 +105,7 @@ func TranscriptUsageResult(profile Profile, snapshot *Snapshot) Result {
 	}
 
 	adapter := worker.SessionLogAdapter{SearchPaths: []string{snapshot.FixtureRoot}}
-	usages, err := adapter.InvocationUsage(profile.Provider, snapshot.TranscriptPath)
+	usages, err := adapter.InvocationUsage(profile.Provider, snapshot.TranscriptPath, "")
 	if err != nil {
 		return Fail(profile.ID, RequirementTranscriptUsage,
 			fmt.Sprintf("extract %s invocation usage: %v", family, err)).WithEvidence(evidence)
@@ -166,7 +166,7 @@ func TranscriptUsageCostResult(profile Profile, snapshot *Snapshot) Result {
 	}
 
 	adapter := worker.SessionLogAdapter{SearchPaths: []string{snapshot.FixtureRoot}}
-	usages, err := adapter.InvocationUsage(profile.Provider, snapshot.TranscriptPath)
+	usages, err := adapter.InvocationUsage(profile.Provider, snapshot.TranscriptPath, "")
 	if err != nil {
 		return Fail(profile.ID, RequirementInvocationUsageCost,
 			fmt.Sprintf("extract %s invocation usage: %v", family, err)).WithEvidence(evidence)


### PR DESCRIPTION
## Summary

Fixes #5922.

Model-usage extraction reads a fixed 64KB transcript tail, but the persisted dedup cursor (`MetadataKeyInvocationUsageCursor`) is a **message identity with no byte offset**. A pass that falls more than one window behind cannot reach back for what it missed, so those invocations are lost permanently instead of being recovered on a later tick.

At a measured **~15.6KB per invocation** on real transcripts, one window holds about **four** invocations. With `liveModelSweepMinInterval` at 30s, any session busier than that silently under-reports. On the 152-transcript sample in #5922, **78% of invocations sat outside a 64KB tail**, and `gc costs` reported ~0.2% of true spend.

Both consumers inherit the cap:

- `usagesAfterCursor` (prompt-op seam) falls back to `usages[len(usages)-1:]` — one invocation
- `usagesSinceCursor` (controller tick) returns the window, "bounded only by the extractor's tail window"

This also restores the behavior [`engdocs/design/usage-facts-v0.md`](https://github.com/gastownhall/gascity/blob/main/engdocs/design/usage-facts-v0.md) specified — *"On startup, reconcile from the durable cursor, not the 64KB tail."* The durable cursor shipped; the reconcile did not.

## Approach

`ExtractTailUsageSince` doubles the scan window from `tailChunkSize` until the cursor entry is inside it, the whole file is in view, or a 16MB cap is reached. **No new persisted state** — it uses the cursor already on the session bead, and callers still filter. Both extraction sites now read the cursor *before* extracting and thread it through.

Edges stay deliberately conservative:

| Case | Behavior |
|---|---|
| Empty cursor (no prior extraction) | single fixed window, exactly as today — first sight does not backfill history |
| Cursor unreachable / stale | widest scanned window, degrading to today rather than failing |
| Cap reached | returns what was scanned; bounded worst case |

Widening is safe for the sweep by its own stated invariant: `usagesSinceCursor` already notes that read-time `IdempotencyKey` dedup in `usage.ReadFacts` collapses overlap, "so recovering the whole bounded tail cannot double-count."

One incidental refactor: with the varying-window caller now using `readTailWindow` directly, `readTail`'s size parameter only ever receives `tailChunkSize`, which `unparam` flags. The constant is folded into `readTail` and its four callers simplified — required to keep `make lint` green, and it removes a knob nothing turned.

**Codex is intentionally left on the fixed window.** Its extractor collapses on cumulative totals rather than per-message identity, so window growth needs its own correctness argument. `CodexTailUsage` takes the cursor for signature symmetry and documents that it does not honor it.

## Testing

`make check` was run with the pinned golangci-lint 2.12.0. Results on macOS (arm64):

| Gate | Result |
|---|---|
| `fmt-check` | pass |
| `lint` | **0 issues** |
| `vet` | pass |
| `check-release-dist-ignore` | pass |
| `check-routed-test-rows` | pass |
| `check-split-topology-rows` | pass |
| `check-residency-boundary` | **blocked locally** — the script uses `declare -A`, which needs bash 4+; macOS ships 3.2. Fails identically on clean `main`. |
| `test` | green except two pre-existing environmental failures (below) |

Two `make test` failures reproduce **identically on clean upstream `main` (1154ad1)** with this branch absent, so they are not from this change:

- `examples/bd/dolt` `TestDoctorCheckVersionFloor*` — `unable to run dolt version`; the `env -i` PATH in the `test` target does not include `dolt`
- `scripts` `TestCmdGCProcessTimingEnvCrossesMakeIsolation`

The packages this PR touches are green: `internal/sessionlog`, `internal/worker`, `internal/worker/workertest`.

- [x] `make check` (with the two environmental exceptions above, both verified pre-existing)
- [ ] `make check-docs` — not applicable, no docs touched
- [ ] `make test-integration` — **not run**, no working integration environment here. The change is confined to transcript extraction and its two call sites, but the sweep is controller-adjacent, so please exercise it in CI.

### New tests

Four added. Each asserts the defect is present **before** asserting the fix, so they fail loudly if a future change makes the fixed window sufficient rather than quietly passing:

| Test | Pins |
|---|---|
| `TestExtractTailUsageSinceReachesBackPastTheFixedWindow` | window grows to reach a cursor many windows back |
| `TestExtractTailUsageSinceEmptyCursorMatchesFixedWindow` | no cursor ⇒ unchanged behavior |
| `TestExtractTailUsageSinceUnreachableCursorDegradesToBoundedWindow` | stale cursor ⇒ bounded, not empty |
| `TestFactorySweepRecoversBacklogBeyondFixedTailWindow` | end-to-end: sweep drains an 800KB backlog to the sink |

Verified they actually catch the defect by reverting the fix in place:

```
--- FAIL: TestFactorySweepRecoversBacklogBeyondFixedTailWindow
    emitted = 3, want 40 (the whole backlog past the fixed window)
```

3 of 40 — matching the ~4-per-window figure from the measurement.

One more flake worth flagging rather than burying, given #5804: under heavy parallel/cold-build load I twice saw `internal/worker/adapters/zcode` `TestInterrupt*` fail, with a different timing-shaped symptom each time (once "adapter exited on an idle SIGINT", once a truncated prompt `"still workin"` vs `"still working"`). Warm runs were 5/5 green both with and without this change, and that package imports none of the changed code.

## Checklist

- [x] Linked an issue (#5922)
- [x] Added tests for behavior changes
- [ ] Docs — no user-facing surface changed; `gc costs` output becomes correct, not different in shape
- [x] No breaking changes. `SessionLogAdapter.TailUsage`, `CodexTailUsage`, and `InvocationUsage` gain a `cursorID` parameter; all in-tree callers are updated, and passing `""` reproduces the previous behavior exactly.
