### PR TITLE
fix(reconciler): resolve the warm-bind trigger through the residency resolver

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2403,6 +2403,37 @@ func (cr *CityRuntime) stopConfigWatcher() {
 	}
 }
 
+// newWarmClaimTriggerResolver returns the reader the warm-bind claim probe asks
+// for one bound trigger bead, resolved over this controller's own topology: the
+// binding it opened at boot, its city work ledger, and the rig legs it is handed.
+//
+// It is the controller-side mirror of the CLI's by-id door (cliByIDOwner) — plan
+// ByID, execute it, and take the row the winning probe already read — for the same
+// reason that door exists. The binding LEADS for an id inside its reserved
+// namespace, so a graph-class step that lives only in the binding is found at all,
+// and a same-id relic that `gc storage migrate` left behind in the work ledger
+// (ids are preserved) is shadowed rather than answered: that relic is frozen open
+// forever, so answering from it would read as unclaimed on every tick.
+//
+// The topology is built once per reconcile tick, alongside the probe. Resolution
+// errors — a refused city, a dark leg, an id no leg could answer — reach the probe
+// as errors and it declines to nudge; nothing here converts a failed read into
+// absence.
+func (cr *CityRuntime) newWarmClaimTriggerResolver(servingRigs map[string]beads.Store) warmClaimTriggerResolver {
+	topo := cr.residencyTopology(servingRigs)
+	return func(triggerID string) (beads.Bead, error) {
+		plan, err := storeref.Plan(storeref.ByID{ID: triggerID}, topo)
+		if err != nil {
+			return beads.Bead{}, err
+		}
+		owner, err := storeref.ResolveOwnerRow(plan, triggerID)
+		if err != nil {
+			return beads.Bead{}, err
+		}
+		return beadForOwner(owner, triggerID)
+	}
+}
+
 // beadReconcileTick runs one bead-driven reconciliation pass. bootReconcile is
 // true only for the synchronous pass on the startup path: that pass must flip
 // readiness quickly, so it skips the undesired-pool-session sweep (a heavy
@@ -2604,14 +2635,15 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		// Warm-bind claim nudge: deliver a pool slot's claim instruction to an
 		// already-running, idle slot that had on-demand work bound to it after it
 		// last Started (bindPoolSessionTriggerBead), which cold Start's nudge cannot
-		// cover. The probe resolves the bound trigger from its owning store (via the
-		// cached rig stores) to confirm it is still unclaimed; the delivery + the
-		// once-per-binding marker live in startPreparedStartCandidate's warm-reuse
-		// branch. Provider-agnostic (not CanReportActivity-gated): on herdr this is
-		// the only closer of the warm-bind gap; on tmux it is the fast primary nudge
-		// ahead of the idle-timeout relaunch backstop, deduped by the marker + the
+		// cover. The probe resolves the bound trigger through the residency contract
+		// — the binding, then the work ledger, then the covering rig legs — to
+		// confirm it is still unclaimed; the delivery + the once-per-binding marker
+		// live in startPreparedStartCandidate's warm-reuse branch. Provider-agnostic
+		// (not CanReportActivity-gated): on herdr this is the only closer of the
+		// warm-bind gap; on tmux it is the fast primary nudge ahead of the
+		// idle-timeout relaunch backstop, deduped by the marker + the
 		// unclaimed-trigger gate.
-		withWarmClaimProbe(buildWarmClaimTriggerProbe(store, rigStores)),
+		withWarmClaimProbe(buildWarmClaimTriggerProbe(cr.newWarmClaimTriggerResolver(rigStores))),
 	}
 	if bootReconcile {
 		// #3288: skip the per-session orphan/failed-create session-bead closes on

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2419,6 +2419,60 @@ func (cr *CityRuntime) stopConfigWatcher() {
 // errors — a refused city, a dark leg, an id no leg could answer — reach the probe
 // as errors and it declines to nudge; nothing here converts a failed read into
 // absence.
+//
+// # The plan shape, and the two consequences of adopting it
+//
+// Plan(ByID) is: the binding that reserves the id's namespace under RoleAuthority,
+// else every unretired binding as a residence probe; then the city work ledger as
+// RoleWorkFallback; then each rig leg whose CONFIGURED prefix covers the id, as a
+// shadow. The work leg is the unprobed residual only when it is last, so as soon
+// as a rig shadow follows it, WORK IS PROBED FIRST and answers on a hit.
+//
+// That is the house by-id order — cliByIDOwner and the API's by-id resolver read
+// the same way — and taking it whole is deliberate, but it is the REVERSE of
+// controlBeadLedger's rig-scope-first order, which
+// TestControlDispatchRigScopePrefersItsOwnStore pins on purpose. The two lanes are
+// asking different questions: that one is HANDED a rig scope, so the rig's own
+// store leads by construction, while a pool slot's bound trigger arrives with no
+// scope at all and nothing licenses a rig leg to lead. So on a same-id collision
+// between the work ledger and a rig store, the CITY copy decides the nudge.
+// TestBuildWarmClaimTriggerProbe_SameIDCollisionResolvesToCityCopy pins it so a
+// future migration that mints a co-resident id changes a test rather than the
+// nudge. The stamp is not the tie-breaker for it: gc.trigger_bead_store_ref is the
+// demand LEG the row was counted under, chosen from the agent's configured rig
+// (build_desired_state.go:1755,1762), so it is not a residency statement and would
+// break ties toward a store the bead need not be in.
+//
+// Second consequence: shadowLegsCovering is IDInNamespace-gated, so a rig-resident
+// trigger whose id falls OUTSIDE its rig's EffectivePrefix — a rig whose prefix
+// changed in city.toml after those beads were minted — is out of the plan by
+// construction, where the deleted rig:<name> stamp parser reached it. It fails
+// closed to a lost warm-bind nudge
+// (TestBuildWarmClaimTriggerProbe_RigTriggerOutsideRigPrefixIsOutOfPlan).
+//
+// # Why servingRigs is the unfiltered rig map here
+//
+// residencyTopology's contract asks its caller to hand it the rigs it decided are
+// SERVING, because a suspended rig is routinely dark and a census over it comes
+// back Partial — and Partial means retain-don't-reap, so one suspended rig would
+// pin the whole fleet. A ByID plan has no Partial: a dark rig leg is PolicyFatal,
+// which surfaces as a resolution error, which the probe answers with the same
+// false it already gives a miss. The ANSWER is the same either way, and
+// beadReconcileTick holds no suspension frame — filtering here would buy it a
+// loadSuspensionState read per tick for a set that answer cannot use.
+//
+// The REPORTING is NOT the same either way, and that is an accepted cost here
+// rather than an equivalence. buildWarmClaimTriggerProbe reports every
+// non-ErrNotFound failure once per probe, and a dark leg is exactly that class,
+// where a filtered serving set would contribute no leg and leave a silent
+// ErrNotFound miss (TestBuildWarmClaimTriggerProbe_ReportsResolutionFaultOncePerTick
+// pins the dark-rig line). Nor does it converge on its own: the once-per-binding
+// marker is stamped only after a delivered nudge, so a probe that declines
+// re-faults on the next tick for as long as a slot keeps a binding into a
+// suspended rig — a configured steady state reported in the words of a transient
+// fault. That is accepted because the line is the only outside evidence the nudge
+// was declined at all. If the noise ever outweighs that evidence, hand this caller
+// servingRigStores as readyDemandSnapshotFingerprint does and delete this section.
 func (cr *CityRuntime) newWarmClaimTriggerResolver(servingRigs map[string]beads.Store) warmClaimTriggerResolver {
 	topo := cr.residencyTopology(servingRigs)
 	return func(triggerID string) (beads.Bead, error) {
@@ -2643,7 +2697,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		// warm-bind gap; on tmux it is the fast primary nudge ahead of the
 		// idle-timeout relaunch backstop, deduped by the marker + the
 		// unclaimed-trigger gate.
-		withWarmClaimProbe(buildWarmClaimTriggerProbe(cr.newWarmClaimTriggerResolver(rigStores))),
+		withWarmClaimProbe(buildWarmClaimTriggerProbe(cr.newWarmClaimTriggerResolver(rigStores), cr.stderr)),
 	}
 	if bootReconcile {
 		// #3288: skip the per-session orphan/failed-create session-bead closes on

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -317,9 +317,9 @@ type startExecutionOptions struct {
 	deferSessionClosesOnBoot bool
 	readyAssignedFlags       []bool
 	// warmClaimProbe, when set, enables the warm-bind claim nudge: it reports
-	// whether a pool slot's newly-bound trigger bead is still unclaimed, read from
-	// the store named by the session's gc.trigger_bead_store_ref. Built by the
-	// reconciler where the cached rig stores are in scope and consumed in
+	// whether a pool slot's newly-bound trigger bead is still unclaimed, resolved
+	// through the city's residency contract (newWarmClaimTriggerResolver). Built by
+	// the reconciler where the cached rig stores are in scope and consumed in
 	// startPreparedStartCandidate's warm-reuse branch. Nil disables the nudge.
 	warmClaimProbe warmClaimTriggerProbe
 }

--- a/cmd/gc/warm_bind_nudge.go
+++ b/cmd/gc/warm_bind_nudge.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -62,7 +66,16 @@ type warmClaimTriggerResolver func(triggerID string) (beads.Bead, error)
 //
 // A read error — a resolution the topology cannot answer, a refused city, a dark
 // leg — yields false: never nudge on uncertainty.
-func buildWarmClaimTriggerProbe(resolve warmClaimTriggerResolver) warmClaimTriggerProbe {
+//
+// That silence is safe but not free to operate: a declined nudge and a healthy
+// fleet where every trigger happens to be claimed look identical from outside. So
+// a fault — anything that is not the ordinary beads.ErrNotFound miss — is reported
+// to faults ONCE per probe. The reconciler builds one probe per tick, which makes
+// that once per tick rather than once per pool slot: a refused city or a dark
+// binding suppresses the nudge for every slot at once, so a per-session line would
+// be a fleet-sized burst of a single fact. A nil faults writer discards.
+func buildWarmClaimTriggerProbe(resolve warmClaimTriggerResolver, faults io.Writer) warmClaimTriggerProbe {
+	var reported sync.Once // the probe runs from async start goroutines too
 	return func(session beads.Bead) bool {
 		if resolve == nil {
 			return false
@@ -73,6 +86,11 @@ func buildWarmClaimTriggerProbe(resolve warmClaimTriggerResolver) warmClaimTrigg
 		}
 		wb, err := resolve(triggerID)
 		if err != nil {
+			if faults != nil && !errors.Is(err, beads.ErrNotFound) {
+				reported.Do(func() {
+					fmt.Fprintf(faults, "warm-bind claim nudge: resolving trigger %s failed, suppressing the nudge: %v\n", triggerID, err) //nolint:errcheck
+				})
+			}
 			return false
 		}
 		return isUnclaimedTrigger(wb, strings.TrimSpace(session.Metadata["session_name"]))

--- a/cmd/gc/warm_bind_nudge.go
+++ b/cmd/gc/warm_bind_nudge.go
@@ -30,57 +30,53 @@ const warmBindNudgeIdleTimeout = 30 * time.Second
 
 // warmClaimTriggerProbe reports whether a pool slot's bound trigger bead is still
 // unclaimed — open and not yet claimed by this slot — read live from the store
-// named by the session's gc.trigger_bead_store_ref. It is built by the reconciler
-// where the cached rig stores are in scope (buildWarmClaimTriggerProbe) and
-// threaded to the warm-reuse branch of startPreparedStartCandidate via the start
-// execution options. A nil probe (tests, and any start path that never builds one)
-// suppresses the nudge entirely; a probe that returns false suppresses it for that
-// session — the claim nudge fires only against a genuinely-unclaimed trigger, so it
-// is structurally invisible to a slot that has already begun its work (fail-closed
-// on any resolution uncertainty).
+// that holds it. It is built by the reconciler, where the city's opened routes and
+// rig stores are in scope (buildWarmClaimTriggerProbe over
+// CityRuntime.newWarmClaimTriggerResolver), and threaded to the warm-reuse branch
+// of startPreparedStartCandidate via the start execution options. A nil probe
+// (tests, and any start path that never builds one) suppresses the nudge entirely;
+// a probe that returns false suppresses it for that session — the claim nudge fires
+// only against a genuinely-unclaimed trigger, so it is structurally invisible to a
+// slot that has already begun its work (fail-closed on any resolution uncertainty).
 type warmClaimTriggerProbe func(session beads.Bead) bool
 
-// buildWarmClaimTriggerProbe returns a probe that resolves a session bead's bound
-// trigger from the store named by its gc.trigger_bead_store_ref (empty / city:*
-// → the city store; rig:<name> → the cached rig store) and reports whether that
-// trigger is still unclaimed. Reading the trigger directly from its owning store
-// — rather than the assignee-gated assigned-work snapshot the reverted poller
-// consulted — is what lets the warm-bind path see a freshly bound, not-yet-claimed
-// trigger at all: that snapshot omits an unassigned trigger, so the old poller was
-// blind to exactly this case. Any unresolved store or read error yields false:
-// never nudge on uncertainty.
-func buildWarmClaimTriggerProbe(cityStore beads.Store, rigStores map[string]beads.Store) warmClaimTriggerProbe {
+// warmClaimTriggerResolver reads one bound trigger bead by id, from wherever it
+// lives. It is the residency contract's answer, handed to the probe already
+// resolved: the probe's job is the claim question, not the store question.
+type warmClaimTriggerResolver func(triggerID string) (beads.Bead, error)
+
+// buildWarmClaimTriggerProbe returns a probe that reads a session bead's bound
+// trigger through resolve and reports whether that trigger is still unclaimed.
+//
+// Reading the trigger live — rather than consulting the assignee-gated
+// assigned-work snapshot the reverted poller used — is what lets the warm-bind
+// path see a freshly bound, not-yet-claimed trigger at all: that snapshot omits an
+// unassigned trigger, so the old poller was blind to exactly this case.
+//
+// The session's gc.trigger_bead_store_ref is NOT consulted. It records the demand
+// LEG the row was counted under, which on a split city is a work ledger even when
+// the bound step lives only in the class binding — so parsing it as a store
+// selector resolved every such trigger to a store that misses, and the probe failed
+// closed on work the slot was holding (ga-bmfmt). The stamp is still written, and
+// other readers still use it; residency is the resolver's question.
+//
+// A read error — a resolution the topology cannot answer, a refused city, a dark
+// leg — yields false: never nudge on uncertainty.
+func buildWarmClaimTriggerProbe(resolve warmClaimTriggerResolver) warmClaimTriggerProbe {
 	return func(session beads.Bead) bool {
+		if resolve == nil {
+			return false
+		}
 		triggerID := strings.TrimSpace(session.Metadata[beadmeta.TriggerBeadIDMetadataKey])
 		if triggerID == "" {
 			return false
 		}
-		store := warmClaimTriggerStore(session, cityStore, rigStores)
-		if store == nil {
-			return false
-		}
-		wb, err := store.Get(triggerID)
+		wb, err := resolve(triggerID)
 		if err != nil {
 			return false
 		}
 		return isUnclaimedTrigger(wb, strings.TrimSpace(session.Metadata["session_name"]))
 	}
-}
-
-// warmClaimTriggerStore resolves the store holding a session's trigger bead from
-// its gc.trigger_bead_store_ref marker: rig:<name> selects the cached rig store;
-// an empty or city:<name> ref falls back to the city store. Returns nil when a rig
-// ref names a store absent from the cache (fail-closed — the probe then declines
-// to nudge rather than guess).
-func warmClaimTriggerStore(session beads.Bead, cityStore beads.Store, rigStores map[string]beads.Store) beads.Store {
-	ref := strings.TrimSpace(session.Metadata[beadmeta.TriggerBeadStoreRefMetadataKey])
-	if strings.HasPrefix(ref, "rig:") {
-		if store := rigStores[strings.TrimPrefix(ref, "rig:")]; store != nil {
-			return store
-		}
-		return nil
-	}
-	return cityStore
 }
 
 // deliverWarmBindClaimNudge delivers a pool slot's claim nudge to an already

--- a/cmd/gc/warm_bind_nudge_test.go
+++ b/cmd/gc/warm_bind_nudge_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -209,54 +210,141 @@ func TestIsUnclaimedTrigger(t *testing.T) {
 	}
 }
 
-// The probe resolves the trigger from the store named by gc.trigger_bead_store_ref
-// (rig:<name> → the cached rig store; empty → the city store) and reports its
-// live claim state — the resolution the reverted poller's assignee-gated snapshot
-// could not do.
-func TestBuildWarmClaimTriggerProbe_ResolvesFromStoreRef(t *testing.T) {
-	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
-		{ID: "c-1", Status: "open"},
+// warmClaimProbeFor builds the probe the reconciler installs, through the same
+// controller topology constructor the tick uses. Building it from a real
+// CityRuntime rather than from a hand-assembled storeref.Topology is what makes
+// these tests assert the production wiring: a topology written out here would
+// keep passing after the controller stopped building one.
+func warmClaimProbeFor(cfg *config.City, work beads.Store, rigs map[string]beads.Store, routes *storageRoutes) warmClaimTriggerProbe {
+	cr := &CityRuntime{
+		cfg:                 cfg,
+		standaloneCityStore: work,
+		standaloneRigStores: rigs,
+		storageRoutes:       routes,
+	}
+	return buildWarmClaimTriggerProbe(cr.newWarmClaimTriggerResolver(cr.rigBeadStores()))
+}
+
+// warmBindStampedSession is a pool slot bound to trigger, carrying the
+// demand-leg stamp the binder wrote.
+func warmBindStampedSession(trigger, storeRef string) beads.Bead {
+	return beads.Bead{Metadata: map[string]string{
+		"session_name":                          "worker-1",
+		beadmeta.TriggerBeadIDMetadataKey:       trigger,
+		beadmeta.TriggerBeadStoreRefMetadataKey: storeRef,
+	}}
+}
+
+// warmBindDemandLegStamps are gc.trigger_bead_store_ref values a live city
+// writes for one and the same binding-resident trigger. Each names the demand
+// LEG the row was counted under — the group key build_desired_state carried into
+// the bind — and none of them is a statement about where the bead lives, so all
+// of them must resolve to the same row.
+var warmBindDemandLegStamps = []string{"", "city", "city:test-city", "class:gmnos", "rig:alpha"}
+
+// A split city keeps its graph-class step beads in the class binding, which is
+// in no work ledger at all. The probe resolves the trigger through the residency
+// contract, so every demand-leg stamp answers from the binding.
+func TestBuildWarmClaimTriggerProbe_ResolvesBindingResidentTrigger(t *testing.T) {
+	binding := beads.NewMemStoreFrom(0, []beads.Bead{{ID: "gcg-1", Status: "open"}}, nil)
+	work := beads.NewMemStore()
+	alpha := beads.NewMemStore()
+	probe := warmClaimProbeFor(residencyTestConfig(), work, map[string]beads.Store{"alpha": alpha}, splitRoutes(binding))
+
+	for _, stamp := range warmBindDemandLegStamps {
+		if !probe(warmBindStampedSession("gcg-1", stamp)) {
+			t.Errorf("stamp %q: want unclaimed=true — the binding holds the row, and no stamp value names a store that does", stamp)
+		}
+	}
+
+	// The churn invariant still holds on the binding row: the instant the slot
+	// claims, the probe goes quiet under every stamp.
+	claimed, assignee := "in_progress", "worker-1"
+	if err := binding.Update("gcg-1", beads.UpdateOpts{Status: &claimed, Assignee: &assignee}); err != nil {
+		t.Fatalf("claiming gcg-1 in the binding: %v", err)
+	}
+	for _, stamp := range warmBindDemandLegStamps {
+		if probe(warmBindStampedSession("gcg-1", stamp)) {
+			t.Errorf("stamp %q: a claimed trigger must read unclaimed=false", stamp)
+		}
+	}
+}
+
+// `gc storage migrate` PRESERVES ids, so a migrated city can hold a frozen
+// same-id copy of a relocated bead in its work ledger. That relic stays open
+// forever and reads as unclaimed; the binding is the authority, so the probe
+// answers from it and never from the relic.
+func TestBuildWarmClaimTriggerProbe_BindingShadowsRelicCopy(t *testing.T) {
+	relic := beads.Bead{ID: "gcg-2", Status: "open"}
+	binding := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "gcg-2", Status: "in_progress", Assignee: "worker-1"},
 	}, nil)
+	probe := warmClaimProbeFor(
+		residencyTestConfig(),
+		beads.NewMemStoreFrom(0, []beads.Bead{relic}, nil),
+		nil,
+		splitRoutes(binding),
+	)
+	if probe(warmBindStampedSession("gcg-2", "city:test-city")) {
+		t.Fatal("the work-ledger relic answered: a claimed binding row must shadow the frozen pre-migration copy")
+	}
+
+	// Control: the SAME relic on a city that relocates nothing is the only copy
+	// there is, and it answers — so the assertion above is the binding winning
+	// rather than the probe having gone blind to work.
+	legacy := warmClaimProbeFor(
+		residencyTestConfig(),
+		beads.NewMemStoreFrom(0, []beads.Bead{relic}, nil),
+		nil,
+		nil,
+	)
+	if !legacy(warmBindStampedSession("gcg-2", "city:test-city")) {
+		t.Fatal("a legacy city lost its own work-ledger trigger")
+	}
+}
+
+// The legacy answer, unchanged: on a city with no bindings a by-id plan is the
+// work ledger plus the rig legs whose configured prefix covers the id, which is
+// the store set the pre-resolver parser reached through the stamp.
+//
+// This is the adapted TestBuildWarmClaimTriggerProbe_ResolvesFromStoreRef. The
+// one case that could not survive is the unknown-rig fail-closed: there is no
+// hand parser left to feed a bad stamp to, so it is inverted below into the
+// assertion that a wrong stamp no longer decides anything.
+func TestBuildWarmClaimTriggerProbe_LegacyCityResolvesWorkAndRigLegs(t *testing.T) {
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{{ID: "c-1", Status: "open"}}, nil)
 	rigStore := beads.NewMemStoreFrom(0, []beads.Bead{
-		{ID: "w-1", Status: "open"},
+		{ID: "ra-1", Status: "open"},
+		{ID: "ra-2", Status: "open"},
 	}, nil)
-	rigStores := map[string]beads.Store{"webapp": rigStore}
-	probe := buildWarmClaimTriggerProbe(cityStore, rigStores)
+	probe := warmClaimProbeFor(residencyTestConfig(), cityStore, map[string]beads.Store{"alpha": rigStore}, nil)
 
-	rigSession := func(trigger, ref string) beads.Bead {
-		return beads.Bead{Metadata: map[string]string{
-			"session_name":                          "worker-1",
-			beadmeta.TriggerBeadIDMetadataKey:       trigger,
-			beadmeta.TriggerBeadStoreRefMetadataKey: ref,
-		}}
+	// The rig leg: ra-1 is inside rig alpha's configured prefix and open.
+	if !probe(warmBindStampedSession("ra-1", "rig:alpha")) {
+		t.Fatal("rig-resident open trigger: want unclaimed=true")
 	}
-
-	// rig:<name> → rig store; w-1 is open → unclaimed.
-	if !probe(rigSession("w-1", "rig:webapp")) {
-		t.Fatal("rig-ref open trigger: want unclaimed=true")
-	}
-	// Claim it in the rig store → probe flips to false.
+	// Claim it in the rig store → the probe flips.
 	claimed := "in_progress"
-	if err := rigStore.Update("w-1", beads.UpdateOpts{Status: &claimed}); err != nil {
-		t.Fatalf("update w-1: %v", err)
+	if err := rigStore.Update("ra-1", beads.UpdateOpts{Status: &claimed}); err != nil {
+		t.Fatalf("claiming ra-1: %v", err)
 	}
-	if probe(rigSession("w-1", "rig:webapp")) {
-		t.Fatal("rig-ref claimed trigger: want unclaimed=false")
+	if probe(warmBindStampedSession("ra-1", "rig:alpha")) {
+		t.Fatal("rig-resident claimed trigger: want unclaimed=false")
 	}
-	// Empty ref → city store; c-1 open → unclaimed.
-	if !probe(rigSession("c-1", "")) {
-		t.Fatal("empty-ref open trigger: want unclaimed=true (city store)")
+	// The work leg: c-1 is outside every rig prefix and lives in the city ledger.
+	if !probe(warmBindStampedSession("c-1", "")) {
+		t.Fatal("empty-stamp open trigger: want unclaimed=true (city work store)")
 	}
-	// rig ref naming an unknown store → fail-closed (nil store → false).
-	if probe(rigSession("w-1", "rig:ghost")) {
-		t.Fatal("unknown rig store: want fail-closed unclaimed=false")
+	// A stamp naming a store the bead is not in no longer decides anything.
+	if !probe(warmBindStampedSession("ra-2", "rig:ghost")) {
+		t.Fatal("a stamp naming an unknown store must not suppress a resolvable trigger")
 	}
-	// Missing trigger bead → read error → fail-closed.
-	if probe(rigSession("missing", "rig:webapp")) {
+	// A trigger no leg holds is a miss, and a miss never nudges.
+	if probe(warmBindStampedSession("missing", "")) {
 		t.Fatal("missing trigger bead: want fail-closed unclaimed=false")
 	}
 	// No bound trigger id → nothing to probe.
-	if probe(rigSession("", "rig:webapp")) {
+	if probe(warmBindStampedSession("", "rig:alpha")) {
 		t.Fatal("no trigger id: want unclaimed=false")
 	}
 }

--- a/cmd/gc/warm_bind_nudge_test.go
+++ b/cmd/gc/warm_bind_nudge_test.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 const warmClaimText = "Run gc hook --claim --json now; if it returns work, execute the claimed formula immediately."
@@ -210,19 +215,40 @@ func TestIsUnclaimedTrigger(t *testing.T) {
 	}
 }
 
-// warmClaimProbeFor builds the probe the reconciler installs, through the same
-// controller topology constructor the tick uses. Building it from a real
-// CityRuntime rather than from a hand-assembled storeref.Topology is what makes
-// these tests assert the production wiring: a topology written out here would
-// keep passing after the controller stopped building one.
-func warmClaimProbeFor(cfg *config.City, work beads.Store, rigs map[string]beads.Store, routes *storageRoutes) warmClaimTriggerProbe {
-	cr := &CityRuntime{
+// warmClaimRuntimeFor builds the controller the warm-bind lane reads through.
+// Going through a real CityRuntime rather than a hand-assembled storeref.Topology
+// is what makes these tests assert the production wiring: a topology written out
+// here would keep passing after the controller stopped building one.
+func warmClaimRuntimeFor(cfg *config.City, work beads.Store, rigs map[string]beads.Store, routes *storageRoutes) *CityRuntime {
+	return &CityRuntime{
 		cfg:                 cfg,
 		standaloneCityStore: work,
 		standaloneRigStores: rigs,
 		storageRoutes:       routes,
 	}
-	return buildWarmClaimTriggerProbe(cr.newWarmClaimTriggerResolver(cr.rigBeadStores()))
+}
+
+// warmClaimResolverFor builds the reader the reconciler hands the probe.
+func warmClaimResolverFor(cfg *config.City, work beads.Store, rigs map[string]beads.Store, routes *storageRoutes) warmClaimTriggerResolver {
+	cr := warmClaimRuntimeFor(cfg, work, rigs, routes)
+	return cr.newWarmClaimTriggerResolver(cr.rigBeadStores())
+}
+
+// warmClaimProbeFor builds the probe the reconciler installs over that resolver.
+func warmClaimProbeFor(cfg *config.City, work beads.Store, rigs map[string]beads.Store, routes *storageRoutes) warmClaimTriggerProbe {
+	return buildWarmClaimTriggerProbe(warmClaimResolverFor(cfg, work, rigs, routes), io.Discard)
+}
+
+// warmClaimByIDPlan is the by-id plan the warm-bind resolver executes for id.
+// Read alongside the probe assertions, it is what keeps a "the city copy won"
+// result from also passing on a plan that quietly lost the rig leg.
+func warmClaimByIDPlan(t *testing.T, cr *CityRuntime, id string) string {
+	t.Helper()
+	plan, err := storeref.Plan(storeref.ByID{ID: id}, cr.residencyTopology(cr.rigBeadStores()))
+	if err != nil {
+		t.Fatalf("Plan(ByID{%s}): %v", id, err)
+	}
+	return plan.String()
 }
 
 // warmBindStampedSession is a pool slot bound to trigger, carrying the
@@ -346,5 +372,182 @@ func TestBuildWarmClaimTriggerProbe_LegacyCityResolvesWorkAndRigLegs(t *testing.
 	// No bound trigger id → nothing to probe.
 	if probe(warmBindStampedSession("", "rig:alpha")) {
 		t.Fatal("no trigger id: want unclaimed=false")
+	}
+}
+
+// A same-id collision between the city work ledger and a rig store — on an id
+// INSIDE that rig's configured prefix, so the rig leg is genuinely in the plan —
+// resolves to the city copy, because Plan(ByID) probes the work fallback ahead of
+// the prefix-gated rig shadows.
+//
+// This pins the order, which is what makes it a decision rather than an accident.
+// It is deliberately the OPPOSITE of TestControlDispatchRigScopePrefersItsOwnStore:
+// that lane is HANDED a rig scope and pins the rig's own store first, while a pool
+// slot's trigger arrives with no scope at all, so nothing licenses a rig leg to
+// lead and the house by-id order (cliByIDOwner, internal/api's by-id resolver)
+// applies unchanged. newWarmClaimTriggerResolver's doc records the divergence.
+//
+// The two ledgers hold disjoint ids today, so the order cannot change a live
+// answer; pinning it means a future migration that does mint a co-resident id
+// changes THIS test rather than silently flipping every warm-bind nudge decision.
+func TestBuildWarmClaimTriggerProbe_SameIDCollisionResolvesToCityCopy(t *testing.T) {
+	// ra-1 is inside rig alpha's configured prefix, and both ledgers hold it.
+	collide := func(cityStatus, rigStatus string) *CityRuntime {
+		return warmClaimRuntimeFor(
+			residencyTestConfig(),
+			beads.NewMemStoreFrom(0, []beads.Bead{{ID: "ra-1", Status: cityStatus}}, nil),
+			map[string]beads.Store{"alpha": beads.NewMemStoreFrom(0, []beads.Bead{{ID: "ra-1", Status: rigStatus}}, nil)},
+			nil,
+		)
+	}
+	probeOf := func(cr *CityRuntime) warmClaimTriggerProbe {
+		return buildWarmClaimTriggerProbe(cr.newWarmClaimTriggerResolver(cr.rigBeadStores()), io.Discard)
+	}
+
+	// Precondition: BOTH ledgers are in the plan and the work leg leads. Without
+	// it, "the city copy decided" would also pass on a plan that lost the rig leg.
+	const wantPlan = `FirstOwner: ""[WorkFallback,Fatal] > rig:alpha[Shadow,Fatal]`
+	if got := warmClaimByIDPlan(t, collide("open", "open"), "ra-1"); got != wantPlan {
+		t.Fatalf("by-id plan = %q, want %q", got, wantPlan)
+	}
+
+	if probeOf(collide("in_progress", "open"))(warmBindStampedSession("ra-1", "rig:alpha")) {
+		t.Error("a claimed city copy must decide the nudge: the work leg is probed before the rig shadow")
+	}
+	if !probeOf(collide("open", "in_progress"))(warmBindStampedSession("ra-1", "rig:alpha")) {
+		t.Error("an open city copy must decide the nudge: the work leg is probed before the rig shadow")
+	}
+
+	// And the rig shadow is a live leg, not a decoration: with no city copy it
+	// answers, so the assertions above are leg ORDER and nothing else.
+	rigOnly := warmClaimProbeFor(
+		residencyTestConfig(),
+		beads.NewMemStore(),
+		map[string]beads.Store{"alpha": beads.NewMemStoreFrom(0, []beads.Bead{{ID: "ra-1", Status: "open"}}, nil)},
+		nil,
+	)
+	if !rigOnly(warmBindStampedSession("ra-1", "rig:alpha")) {
+		t.Error("rig shadow leg lost: a rig-resident open trigger must still read unclaimed")
+	}
+}
+
+// A rig-resident trigger whose id falls OUTSIDE that rig's effective prefix is out
+// of the by-id plan by construction — shadowLegsCovering is IDInNamespace-gated —
+// so it fails closed to no nudge. Pinned because it is the one population the
+// deleted rig:<name> stamp parser reached and the resolver does not.
+func TestBuildWarmClaimTriggerProbe_RigTriggerOutsideRigPrefixIsOutOfPlan(t *testing.T) {
+	outside := beads.Bead{ID: "zz-1", Status: "open"}
+	rigs := map[string]beads.Store{"alpha": beads.NewMemStoreFrom(0, []beads.Bead{outside}, nil)}
+
+	// "by construction" is the claim, so assert the construction: rig alpha holds
+	// zz-1 and is still absent from the plan, which is a work-only leg list.
+	cr := warmClaimRuntimeFor(residencyTestConfig(), beads.NewMemStore(), rigs, nil)
+	const wantPlan = `FirstOwner: ""[WorkFallback,Fatal]`
+	if got := warmClaimByIDPlan(t, cr, "zz-1"); got != wantPlan {
+		t.Fatalf("by-id plan = %q, want %q", got, wantPlan)
+	}
+
+	probe := warmClaimProbeFor(residencyTestConfig(), beads.NewMemStore(), rigs, nil)
+	if probe(warmBindStampedSession("zz-1", "rig:alpha")) {
+		t.Error("a rig bead outside its rig's prefix has no shadow leg; the probe must fail closed rather than answer from it")
+	}
+
+	// Control: the same id in the work ledger resolves, so the miss above is the
+	// prefix gate and not a probe that stopped reading anything.
+	inWork := warmClaimProbeFor(
+		residencyTestConfig(),
+		beads.NewMemStoreFrom(0, []beads.Bead{outside}, nil),
+		rigs,
+		nil,
+	)
+	if !inWork(warmBindStampedSession("zz-1", "rig:alpha")) {
+		t.Error("an open work-ledger trigger must read unclaimed")
+	}
+}
+
+// A resolution the topology cannot answer reaches the probe as an ERROR, not as a
+// miss, and the probe declines: never nudge on uncertainty. Asserting both halves
+// is the point — a future change to Plan's refusal gate or to PolicyFatal handling
+// that turned either case into beads.ErrNotFound would leave the probe's false
+// intact while quietly demoting a fault to an absence.
+func TestBuildWarmClaimTriggerProbe_ResolutionErrorsNeverNudge(t *testing.T) {
+	cases := map[string]struct {
+		trigger  string
+		resolver warmClaimTriggerResolver
+	}{
+		// A refused city routes its relocated classes at a store that answers
+		// every read with the standing refusal. gcg- is inside the binding's
+		// reserved namespace, so that binding LEADS the plan under PolicyFatal.
+		"refused binding": {
+			trigger: "gcg-1",
+			resolver: warmClaimResolverFor(
+				residencyTestConfig(),
+				beads.NewMemStore(),
+				nil,
+				splitRoutes(refusedClassStore{err: standingStorageRefusal{err: errStorageRefusedForTest{}}}),
+			),
+		},
+		// A suspended rig is routinely DARK: its store returns the open error on
+		// every read. ra-1 is inside alpha's prefix, so that dark leg is planned.
+		"dark rig leg": {
+			trigger: "ra-1",
+			resolver: warmClaimResolverFor(
+				residencyTestConfig(),
+				beads.NewMemStore(),
+				map[string]beads.Store{"alpha": unavailableStore{err: errors.New("open rig store alpha: no such file or directory")}},
+				nil,
+			),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := tc.resolver(tc.trigger)
+			if err == nil {
+				t.Fatalf("resolving %s: want an error, got a resolved bead", tc.trigger)
+			}
+			if errors.Is(err, beads.ErrNotFound) {
+				t.Fatalf("resolving %s: an unreadable leg reported absence (%v); a fault must never read as a miss", tc.trigger, err)
+			}
+			if buildWarmClaimTriggerProbe(tc.resolver, io.Discard)(warmBindStampedSession(tc.trigger, "")) {
+				t.Errorf("%s: the probe nudged on an unresolvable trigger", name)
+			}
+		})
+	}
+}
+
+// A resolution fault is reported ONCE per probe — the probe is built once per
+// beadReconcileTick, so that is once per tick — rather than once per pool slot: a
+// refused city or a dark binding suppresses the nudge for every slot at once, and
+// a per-session line would be a fleet-sized log burst of one fact. An expected
+// miss stays silent, because a trigger no leg holds is ordinary.
+func TestBuildWarmClaimTriggerProbe_ReportsResolutionFaultOncePerTick(t *testing.T) {
+	var log bytes.Buffer
+	dark := warmClaimResolverFor(
+		residencyTestConfig(),
+		beads.NewMemStore(),
+		map[string]beads.Store{"alpha": unavailableStore{err: errors.New("open rig store alpha: no such file or directory")}},
+		nil,
+	)
+	probe := buildWarmClaimTriggerProbe(dark, &log)
+	for range 3 {
+		if probe(warmBindStampedSession("ra-1", "rig:alpha")) {
+			t.Fatal("dark rig leg: the probe must decline")
+		}
+	}
+	if got := strings.Count(log.String(), "\n"); got != 1 {
+		t.Fatalf("reported %d lines for one standing fault across 3 slots, want 1:\n%s", got, log.String())
+	}
+	if !strings.Contains(log.String(), "ra-1") {
+		t.Errorf("the report names no trigger, so it cannot be acted on: %q", log.String())
+	}
+
+	// An ordinary miss is not a fault and stays silent.
+	var quiet bytes.Buffer
+	miss := buildWarmClaimTriggerProbe(warmClaimResolverFor(residencyTestConfig(), beads.NewMemStore(), nil, nil), &quiet)
+	if miss(warmBindStampedSession("nobody-holds-me", "")) {
+		t.Fatal("missing trigger: the probe must decline")
+	}
+	if quiet.Len() != 0 {
+		t.Errorf("a trigger no leg holds logged %q; only faults are worth a line", quiet.String())
 	}
 }


### PR DESCRIPTION
## The bug

`warmClaimTriggerStore` resolved a pool slot's bound trigger by hand-parsing the
session's `gc.trigger_bead_store_ref`: `rig:<name>` selected a cached rig ledger,
everything else fell back to the city work ledger. The probe was built with
`buildWarmClaimTriggerProbe(cr.cityBeadStore(), cr.rigBeadStores())` — two work
axes and no binding.

On a split city that stamp can never name the right store:

- the bound trigger is a **graph-class step bead**, which lives ONLY in the class
  binding — a store neither argument ever contains;
- the stamp is the **demand LEG key** the row was probed under
  (`build_desired_state.go` `entry.StoreRefs[b.ID] = group.storeKey`, carried as
  `request.WorkStoreRef` and stamped at bind time). On a live split city those
  rows read `city:<name>`.

So every stamp value resolved to a work ledger, `store.Get` returned
`ErrNotFound`, the probe failed closed, and the warm slot sat idle at its prompt
holding an unclaimed trigger. On tmux the idle-claim backstop eventually recovers
it; on herdr this probe is the ONLY closer of the warm-bind gap (see the doc
comment on `deliverWarmBindClaimNudge`).

## The fix

`buildWarmClaimTriggerProbe` now takes a trigger **resolver**
(`func(triggerID string) (beads.Bead, error)`) instead of two stores; the hand
parser is deleted. The reconciler builds that resolver from the residency
contract in `(*CityRuntime).newWarmClaimTriggerResolver`, the controller-side
mirror of the CLI's by-id door (`cliByIDOwner`):

```go
plan, err := storeref.Plan(storeref.ByID{ID: triggerID}, cr.residencyTopology(servingRigs))
owner, err := storeref.ResolveOwnerRow(plan, triggerID)
return beadForOwner(owner, triggerID)
```

The doctrine: **the residency resolver is the one lookup contract; the demand leg
key says where the row was COUNTED, not where it LIVES.** The stamp is still
written and other readers still use it — it is simply no longer a store selector.

Two consequences fall straight out of the resolver's rules:

- the binding **leads** for an id inside its reserved namespace, so a
  binding-resident `gcg-*` step is found at all;
- the same-id relic `gc storage migrate` leaves in the work ledger (ids are
  preserved, and that copy is frozen open forever, so it reads as unclaimed on
  every tick) is **shadowed**, not answered.

Fail-closed is preserved end to end: a plan the topology cannot answer, a refused
city, a dark leg or a clean miss all reach the probe as an error/miss and it
returns false. `deliverWarmBindClaimNudge`'s gates are untouched.

An unrelocated city is unchanged: a `ByID` plan with no bindings is the work
ledger plus the rig legs whose configured prefix covers the id, with the
single-leg work residual returned unprobed.

## Tests

`cmd/gc/warm_bind_nudge_test.go`, all built through the production wiring — a
real `CityRuntime` and `cr.residencyTopology`, via `splitRoutes(binding)` and
`residencyTestConfig()` — rather than a hand-assembled `storeref.Topology`:

- **`TestBuildWarmClaimTriggerProbe_ResolvesBindingResidentTrigger`** — a `gcg-1`
  step present ONLY in the binding, with the city work store and the rig store
  empty, resolves under every demand-leg stamp a live city writes (`""`, `city`,
  `city:test-city`, `class:gmnos`, `rig:alpha`). Claiming the binding row flips
  the probe to false under all five (the churn invariant still holds).
- **`TestBuildWarmClaimTriggerProbe_BindingShadowsRelicCopy`** — the same id open
  in the work ledger (relic) and `in_progress` in the binding reads false: the
  binding wins. Control: the same relic on a city that relocates nothing answers
  true, so the assertion is the binding winning rather than the probe going blind
  to work.
- **`TestBuildWarmClaimTriggerProbe_LegacyCityResolvesWorkAndRigLegs`** — the
  adapted `..._ResolvesFromStoreRef`: the legacy work leg and the covering rig
  leg answer exactly as before, a claimed rig row still flips the probe, a miss
  and an empty trigger id are still fail-closed. Its one case that could not
  survive is the unknown-rig fail-closed (there is no hand parser left to feed a
  bad stamp to), inverted into the assertion that a wrong stamp no longer decides
  anything.

## Mutation probe

Restoring the hand parser verbatim (as a scratch `buildWarmClaimTriggerProbeLegacy`
the test helper was pointed at) and re-running:

```
--- FAIL: TestBuildWarmClaimTriggerProbe_ResolvesBindingResidentTrigger
    stamp "":              want unclaimed=true
    stamp "city":          want unclaimed=true
    stamp "city:test-city": want unclaimed=true
    stamp "class:gmnos":   want unclaimed=true
    stamp "rig:alpha":     want unclaimed=true
--- FAIL: TestBuildWarmClaimTriggerProbe_BindingShadowsRelicCopy
    the work-ledger relic answered
--- FAIL: TestBuildWarmClaimTriggerProbe_LegacyCityResolvesWorkAndRigLegs
    a stamp naming an unknown store must not suppress a resolvable trigger
```

Every stamp fails, which is the bug reproduced. The legacy test fails on exactly
one line — the inverted case — and its work/rig-leg assertions still pass under
the parser, which is the pin that the legacy answer did not move.

## Gates

| gate | result |
| --- | --- |
| `go build ./cmd/gc` | 0 |
| `go vet ./cmd/gc` | 0 |
| `gofmt -l` (changed files) | clean |
| `golangci-lint run ./cmd/gc/...` | 0 issues |
| `./scripts/check-residency-boundary.sh` | 0 (no baseline change: the plan-based read names no forbidden vocabulary) |
| `go test ./scripts/ -run TestResidency` | ok |
| `go test ./cmd/gc -run 'WarmBind\|WarmClaim\|Residency\|ByID' -count=1` | ok |
| `go test ./internal/storeref/... -count=1` | ok |
| `make test-fast-parallel` | all fast jobs passed |

Refs ga-bmfmt
