### PR TITLE
fix(dispatch): a rig control dispatcher on a split city probes the class binding it serves

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1769,6 +1769,10 @@ func convergedRoutedWorkBinding(
 	suspendedRigPaths map[string]bool,
 ) beads.Store {
 	legs, err := routedWorkStoreCandidates(cityPath, cfg, store, rigStores, suspendedRigPaths, censusRefScoped)
+	// An unresolvable topology takes the same conservative nil as a legacy city:
+	// fall back to the legacy target rather than guess a store. The error is not
+	// swallowed — collectOpenUnassignedRoutedWork resolves this same leg set later
+	// in this build and reports it there.
 	if err != nil || len(legs) == 0 {
 		return nil
 	}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -502,6 +502,10 @@ func buildDesiredStateWithSessionBeadsAt(
 			activeStores = append(activeStores, activeStore{store: s, ref: rig.Name})
 		}
 	}
+	// The store a control dispatcher's rows actually live in, asked once per
+	// build from the residency plan rather than guessed from config. Non-nil
+	// only on a city converged onto a class binding; see its doc comment.
+	controlBinding := convergedRoutedWorkBinding(cityPath, cfg, store, rigStores, suspendedRigPaths)
 
 	for i := range cfg.Agents {
 		if cfg.Agents[i].Suspended {
@@ -585,7 +589,7 @@ func buildDesiredStateWithSessionBeadsAt(
 			// retention for configured named-session beads.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 			if store != nil && !hasCustomScaleCheck {
-				ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
+				ownTarget := ownScaleCheckTarget(cityPath, cfg, &cfg.Agents[i], store, rigStores, controlBinding, storeScopedControlDispatcher)
 				// mode='always': named session is unconditionally desired by the named
 				// pass; pool demand is redundant and creates {name}-N phantoms when N
 				// routed beads arrive. mode='on_demand': pool demand wakes the sleeping
@@ -661,7 +665,7 @@ func buildDesiredStateWithSessionBeadsAt(
 		// new unassigned demand while assigned work drives resume requests.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 		if store != nil && !hasCustomScaleCheck {
-			ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
+			ownTarget := ownScaleCheckTarget(cityPath, cfg, &cfg.Agents[i], store, rigStores, controlBinding, storeScopedControlDispatcher)
 			defaultScaleTargets = append(defaultScaleTargets, ownTarget)
 			// Cross-store demand (FR-S0.1 / vp-s37): a rig pool's routed demand
 			// may live in the city store (vp-kvp cross-store delivery), which
@@ -1743,6 +1747,81 @@ func readyAssignedWorkAssignees(cfg *config.City, sessionBeads *sessionBeadSnaps
 	return result
 }
 
+// convergedRoutedWorkBinding reports the one class binding a city serves ALL
+// its routed work from, or nil when it serves any of it from a work ledger.
+//
+// The question is answered from the residency plan, not from config: the legs
+// come from routedWorkStoreCandidates, the same set collectOpenUnassignedRoutedWork
+// reads, so demand and collection cannot disagree about where routed work is.
+// A converged split narrows (storeref.Narrow, runtime plane) to nothing but its
+// binding legs, so "every leg is a class ref" IS "this city is converged"; a
+// city that relocates nothing keeps its work leg and answers nil.
+//
+// Two bindings would mean a per-class fan-out no constructor in this build
+// produces (TestTopologyConstructorsServeOnlyTheWholeSplit); until one can,
+// a plan that named more than one store gets the same conservative nil as a
+// legacy city rather than a guess about which one holds control work.
+func convergedRoutedWorkBinding(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	suspendedRigPaths map[string]bool,
+) beads.Store {
+	legs, err := routedWorkStoreCandidates(cityPath, cfg, store, rigStores, suspendedRigPaths, censusRefScoped)
+	if err != nil || len(legs) == 0 {
+		return nil
+	}
+	var binding beads.Store
+	for _, leg := range legs {
+		if leg.store == nil || !storeref.IsClassRef(leg.ref) {
+			return nil
+		}
+		if binding != nil && leg.store != binding {
+			return nil
+		}
+		binding = leg.store
+	}
+	return binding
+}
+
+// ownScaleCheckTarget picks the store a pool's default demand probe reads.
+//
+// It is its own scope's ledger — except for a store-scoped control dispatcher
+// on a city converged onto a class binding, where every scope's control rows
+// live in the binding and the rig work ledger the dispatcher is named after
+// holds none of them. There the target is the binding under the CITY store key,
+// byte-for-byte the target the city's own dispatcher already gets: the binding
+// is a city-scope store serving every scope, demand keys normalize class refs
+// onto "city" anyway (normalizeDemandStoreRef), and one store key means one
+// store group, listed once per tick for every dispatcher template — rows are
+// attributed to templates by route, not by store.
+//
+// This does not widen anyone's probe. A dispatcher still reads exactly one
+// store; it is just the one its rows live in.
+func ownScaleCheckTarget(
+	cityPath string,
+	cfg *config.City,
+	agentCfg *config.Agent,
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+	controlBinding beads.Store,
+	storeScopedControlDispatcher bool,
+) defaultScaleCheckTarget {
+	if storeScopedControlDispatcher && controlBinding != nil {
+		return defaultScaleCheckTarget{
+			template: agentCfg.QualifiedName(),
+			storeKey: "city",
+			store:    controlBinding,
+		}
+	}
+	return defaultScaleCheckTargetForAgent(cityPath, cfg, agentCfg, cityStore, rigStores)
+}
+
+// defaultScaleCheckTargetForAgent points a pool at its own scope's ledger: the
+// rig store for a Dir-scoped agent, the city store otherwise. A control
+// dispatcher on a split city is the documented exception — see
+// ownScaleCheckTarget, which is what the agent loop calls.
 func defaultScaleCheckTargetForAgent(
 	cityPath string,
 	cfg *config.City,

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -13546,7 +13546,8 @@ func rigDispatcherBindingCityConfig(rigPath string) *config.City {
 func registerSplitCityRoutes(t *testing.T, cityPath string, binding beads.Store) {
 	t.Helper()
 	routes := splitRoutes(binding)
-	registerResidencyRoutes(cityPath, routes, func() beads.Store { return beads.NewMemStore() })
+	work := beads.NewMemStore()
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return work })
 	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -13510,3 +13510,187 @@ func TestBuildDesiredStateRecordsDemandSubPhases(t *testing.T) {
 		}
 	}
 }
+
+// rigDispatcherBindingCityConfig is the two-dispatcher shape a split city
+// really runs: the city's own control dispatcher, and one bound to the
+// "fixture" rig. Both are deterministic, singleton, store-scoped pools.
+func rigDispatcherBindingCityConfig(rigPath string) *config.City {
+	return &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "fixture", Path: rigPath, Prefix: "fx"}},
+		Agents: []config.Agent{
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(1),
+			},
+			{
+				Name:              config.ControlDispatcherAgentName,
+				BindingName:       "core",
+				Dir:               "fixture",
+				StartCommand:      config.ControlDispatcherStartCommandFor("{{.Agent}}"),
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(1),
+			},
+		},
+	}
+}
+
+// registerSplitCityRoutes gives cityPath the shape a controller serving a
+// converged split really registers: one class binding for every infrastructure
+// class, and a city WORK store that is a DISTINCT ledger beside it. The store
+// buildDesiredState is then handed is the binding, because that is what the
+// sessions class resolves to.
+func registerSplitCityRoutes(t *testing.T, cityPath string, binding beads.Store) {
+	t.Helper()
+	routes := splitRoutes(binding)
+	registerResidencyRoutes(cityPath, routes, func() beads.Store { return beads.NewMemStore() })
+	t.Cleanup(func() { unregisterResidencyRoutes(cityPath, routes) })
+}
+
+// createRigRootedControlRow seeds one open, ready, unassigned control row owned
+// by the "fixture" rig and routed to that rig's dispatcher.
+func createRigRootedControlRow(t *testing.T, store beads.Store) beads.Bead {
+	t.Helper()
+	row, err := store.Create(beads.Bead{
+		Title:  "Finalize workflow",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindWorkflowFinalize,
+			beadmeta.RoutedToMetadataKey:     "fixture/core.control-dispatcher",
+			beadmeta.RootStoreRefMetadataKey: "rig:fixture",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create rig-rooted control row: %v", err)
+	}
+	return row
+}
+
+// poolSessionBeadForTemplate returns the single pool session bead a build
+// created for one template, so a test can read the provenance the launch path
+// actually persists.
+func poolSessionBeadForTemplate(t *testing.T, store beads.Store, template string) beads.Bead {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{Type: sessionBeadType, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var found []beads.Bead
+	for _, b := range all {
+		if b.Metadata["template"] == template {
+			found = append(found, b)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("pool session beads for %s = %d, want exactly 1 (beads: %v)", template, len(found), ids(all))
+	}
+	return found[0]
+}
+
+// A rig control dispatcher on a split city must probe the class binding it
+// serves, not the rig WORK ledger it is named after.
+//
+// On a converged split every scope's control rows live in ONE binding; the
+// rig's own work store holds none. The default probe pointed a Dir-scoped
+// dispatcher at rigStores[<rig>] anyway, so the row was counted by nobody and
+// the template's demand carried no per-bead provenance: the pool request went
+// out with an empty WorkBeadID, the spawned session bead carried no
+// gc.trigger_bead_id, and every backstop keyed on that stamp was inert for the
+// one dispatcher that had real work. A dispatcher probes the store its rows
+// live in; on a split city that is the binding for every scope.
+//
+// The demand probe is the half this asserts. The COLLECTION half —
+// collectOpenUnassignedRoutedWork admitting a rig-rooted row through the
+// binding leg, which is what feeds ReadyUnassignedRoutedWorkBeads and the
+// openControlDispatcherDemand floor — is #5918's, so the count here is 0
+// without the probe fix rather than a provenance-less 1.
+func TestBuildDesiredState_RigDispatcherOnSplitCityProbesTheBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	registerSplitCityRoutes(t, cityPath, binding)
+	cfg := rigDispatcherBindingCityConfig(t.TempDir())
+	row := createRigRootedControlRow(t, binding)
+
+	got := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), binding,
+		map[string]beads.Store{"fixture": beads.NewMemStore()}, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	const rigDispatcher = "fixture/core.control-dispatcher"
+	if got.ScaleCheckCounts[rigDispatcher] != 1 {
+		t.Fatalf("ScaleCheckCounts = %v, want 1 for %s: the binding holds its only control row", got.ScaleCheckCounts, rigDispatcher)
+	}
+	// The city dispatcher shares the store group and must not also claim the
+	// row: rows are attributed to templates by route, not by store.
+	if got.ScaleCheckCounts["core.control-dispatcher"] != 0 {
+		t.Fatalf("ScaleCheckCounts = %v, want 0 for the city dispatcher: %s owns the route", got.ScaleCheckCounts, rigDispatcher)
+	}
+
+	session := poolSessionBeadForTemplate(t, binding, rigDispatcher)
+	if trigger := session.Metadata[beadmeta.TriggerBeadIDMetadataKey]; trigger != row.ID {
+		t.Fatalf("gc.trigger_bead_id = %q, want %q: a bare count floor spawns a dispatcher with no idea which bead woke it", trigger, row.ID)
+	}
+	if ref := session.Metadata[beadmeta.TriggerBeadStoreRefMetadataKey]; ref != "city" {
+		t.Fatalf("gc.trigger_bead_store_ref = %q, want %q: the binding is a city-scope store", ref, "city")
+	}
+}
+
+// The rig dispatcher's create must not be gated on the health of a store that
+// holds none of its work. Pointing the probe at rigStores[<rig>] made an absent
+// rig WORK store mark the template partial, and errPoolSessionCreatePartial
+// then suppressed the create even though the binding had already proved demand.
+func TestBuildDesiredState_RigDispatcherOnSplitCityIgnoresRigWorkStoreHealth(t *testing.T) {
+	cityPath := t.TempDir()
+	binding := beads.NewMemStore()
+	registerSplitCityRoutes(t, cityPath, binding)
+	cfg := rigDispatcherBindingCityConfig(t.TempDir())
+	createRigRootedControlRow(t, binding)
+
+	got := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), binding,
+		nil, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	const rigDispatcher = "fixture/core.control-dispatcher"
+	if got.PoolScaleCheckPartialTemplates[rigDispatcher] {
+		t.Fatalf("PoolScaleCheckPartialTemplates = %v, want %s healthy: its work is in the binding, not the rig work store", got.PoolScaleCheckPartialTemplates, rigDispatcher)
+	}
+	for _, desired := range got.State {
+		if desired.TemplateName == rigDispatcher {
+			return
+		}
+	}
+	t.Fatalf("desired state = %v, want %s created on binding-proved demand", mapKeys(got.State), rigDispatcher)
+}
+
+// The legacy city is untouched: with nothing relocated, a rig dispatcher still
+// probes its own rig work store and stamps the rig ref on the session it spawns.
+func TestBuildDesiredState_RigDispatcherOnLegacyCityStillProbesRigStore(t *testing.T) {
+	cityPath := t.TempDir()
+	seedNoRoutes(t, cityPath)
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	cfg := rigDispatcherBindingCityConfig(t.TempDir())
+	row := createRigRootedControlRow(t, rigStore)
+
+	got := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), cityStore,
+		map[string]beads.Store{"fixture": rigStore}, newSessionBeadSnapshot(nil), nil, io.Discard,
+	)
+
+	const rigDispatcher = "fixture/core.control-dispatcher"
+	if got.ScaleCheckCounts[rigDispatcher] != 1 {
+		t.Fatalf("ScaleCheckCounts = %v, want 1 for %s from its own rig store", got.ScaleCheckCounts, rigDispatcher)
+	}
+	session := poolSessionBeadForTemplate(t, cityStore, rigDispatcher)
+	if trigger := session.Metadata[beadmeta.TriggerBeadIDMetadataKey]; trigger != row.ID {
+		t.Fatalf("gc.trigger_bead_id = %q, want %q", trigger, row.ID)
+	}
+	if ref := session.Metadata[beadmeta.TriggerBeadStoreRefMetadataKey]; ref != "rig:fixture" {
+		t.Fatalf("gc.trigger_bead_store_ref = %q, want %q: a city that relocates nothing keeps the rig probe", ref, "rig:fixture")
+	}
+}


### PR DESCRIPTION
## What this changes

A dispatcher probes the store its rows live in; on a split city that is the
binding for every scope.

`defaultScaleCheckTargetForAgent` points a Dir-scoped agent at
`rigStores[<rig>]` under `storeKey "rig:<name>"` — the rig WORK ledger. On a
city converged onto a class binding, every rig-rooted control row lives ONLY in
the binding, which the reconciler holds as its leading store. So the default
demand probe for a rig control dispatcher read an empty ledger:

- `scaleCheckDemandByTemplate[<rig>/core.control-dispatcher]` carried no
  `WorkBeadIDs` and no `StoreRefs`;
- the pool's `SessionRequest` was emitted with `WorkBeadID`/`WorkStoreRef`
  empty (`pool_desired_state.go`);
- the spawned dispatcher session bead therefore carried no
  `gc.trigger_bead_id`, and the idle-claim / warm-bind backstops keyed on that
  stamp were inert for it;
- and the create was gated on the health of a store that holds none of its
  work — an unavailable rig work store marked the template partial and
  `errPoolSessionCreatePartial` suppressed the create even though the binding
  had already proved demand.

The city dispatcher on the same topology got full provenance, because its own
target already IS the binding. The two scopes were asymmetric for no reason
other than which map the target came out of. Functionally masked today only
because the shipped dispatcher is `max_active_sessions=1` and self-polls.

`convergedRoutedWorkBinding` asks the question once per build from the
residency plan rather than guessing from config: the legs come from
`routedWorkStoreCandidates`, the same set `collectOpenUnassignedRoutedWork`
reads, so demand and collection cannot disagree about where routed work lives.
A converged split narrows (`storeref.Narrow`, runtime plane) to nothing but its
binding legs, so "every leg is a class ref" IS "this city is converged"; a city
that relocates nothing keeps its work leg and answers nil.

`ownScaleCheckTarget` then hands a store-scoped control dispatcher on such a
city the binding under the CITY store key — byte-for-byte the target the city's
own dispatcher already gets. Demand keys already normalize `class:*` onto
`"city"` (`normalizeDemandStoreRef`), and one store key means one store group,
listed once per tick for every dispatcher template; rows are attributed to
templates by route, not by store (`controllerDemandRouteCandidates`).

## Review notes

- The two `!storeScopedControlDispatcher` cross-store gates are untouched. This
  does not widen anyone's probe: a dispatcher still reads exactly one store, it
  is just the one its rows live in.
- Legacy (no binding) cities are byte-for-byte unchanged, and
  `defaultScaleCheckTargetForAgent` now carries a doc comment naming the
  split-city override.
- Partial gating now keys on the binding's health for rig dispatchers, correct
  by construction rather than by special-casing.
- Two bindings would mean a per-class fan-out no constructor in this build
  produces (`TestTopologyConstructorsServeOnlyTheWholeSplit`); until one can,
  such a plan gets the same conservative nil as a legacy city.
- Nothing in `openControlDispatcherDemand`, `normalizeDemandStoreRef`,
  `selectReadyUnassignedRoutedWork` or `repairBead` is touched — that is #5918's
  territory.
- Companion of #5918 (`ga-oytw9`), which is the COLLECTION half: admitting a
  rig-rooted row through the binding leg in `collectOpenUnassignedRoutedWork`,
  which is what feeds `ReadyUnassignedRoutedWorkBeads` and the
  `openControlDispatcherDemand` floor. Because that PR is still open, the RED
  here is a count of 0 rather than a provenance-less 1; the two PRs touch
  disjoint regions of `build_desired_state.go` and merge in either order.

## Test plan

New, in `cmd/gc/build_desired_state_test.go`:

- `TestBuildDesiredState_RigDispatcherOnSplitCityProbesTheBinding` — a
  rig-rooted, ready, routed control row lives only in the binding while
  `rigStores["fixture"]` is empty. Asserts `ScaleCheckCounts` is 1 for the rig
  dispatcher and 0 for the city dispatcher sharing the store group (attribution
  is by route), and that the session bead the build creates carries
  `gc.trigger_bead_id` = the row and `gc.trigger_bead_store_ref` = `city`.
- `TestBuildDesiredState_RigDispatcherOnSplitCityIgnoresRigWorkStoreHealth` —
  same city with no rig work store at all: the dispatcher is not in
  `PoolScaleCheckPartialTemplates` and its State entry exists.
- `TestBuildDesiredState_RigDispatcherOnLegacyCityStillProbesRigStore` — the
  control. Nothing relocated, row in the rig store, `gc.trigger_bead_store_ref`
  stays `rig:fixture`.

Mutation probe: disabling the override in `ownScaleCheckTarget` fails both
split-city tests (count 0; template partial) while the legacy control stays
green — so the two assertions are testing the override and not the fixture.

Gates run, all clean: `go build ./cmd/gc`, `go vet ./cmd/gc`, `gofmt -l cmd/gc`,
`golangci-lint run ./cmd/gc/...` (0 issues),
`./scripts/check-residency-boundary.sh`,
`go test ./cmd/gc -run 'ControlDispatcher|ScaleCheck|Demand|ClassBound|Residency' -count=1`,
and `make test-fast-parallel`.
