### PR TITLE
test(cmd/gc): isolate stderr assertions from tmux leak-guard diagnostics

### DIFF
--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -315,6 +315,72 @@ func runPackCommandProcessWithEnv(t *testing.T, cityPath, scenario string, extra
 	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stderr.String()}
 }
 
+// stripTmuxLeakGuardNoise is a placeholder pending the green step; it does
+// not yet strip anything.
+func stripTmuxLeakGuardNoise(s string) string {
+	return s
+}
+
+// TestStripTmuxLeakGuardNoise expresses the acceptance criteria for isolating
+// captured subprocess stderr from the tmux leak guard's own harness-level
+// diagnostics (cmd/gc/tmux_leak_guard_test.go): stripTmuxLeakGuardNoise must
+// remove exactly the guard's startup-sweep and teardown-leak lines, in any
+// position, while leaving real CLI stderr output (and its line order)
+// untouched. Without this, TestPackCommandCobraHelpAndUnknownParity's
+// eager/lazy stderr-equality assertion — and the several exact-empty-stderr
+// assertions elsewhere in this file — are vulnerable to a concurrent sibling
+// suite's teardown racing exactly one of the two subprocess launches' startup
+// sweep (ga-5pe5xv gate evidence: "a concurrent tmux leak-guard stderr line
+// captured by one parity side only").
+func TestStripTmuxLeakGuardNoise(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no guard output left untouched",
+			in:   "Error: unknown command \"missing\" for \"gc backstage\"\n",
+			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "strips a leading startup-sweep block, keeps real stderr after it",
+			in: "cmd/gc tmux leak guard: startup sweep reaping 1 stale test tmux server(s) whose socket root is gone\n" +
+				"  pid=12345 argv=\"tmux -u -L test-city new-session -s mayor\"\n" +
+				"Error: unknown command \"missing\" for \"gc backstage\"\n",
+			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
+		},
+		{
+			name: "strips a trailing teardown-leak block, keeps real stderr before it",
+			in: "Error: unknown command \"missing\" for \"gc backstage\"\n" +
+				"cmd/gc tmux leak guard: 1 tmux server(s) leaked by this run under /tmp/gct-1-a\n" +
+				"  socket=/tmp/gct-1-a/tmux-1000/test-city (killed)\n" +
+				"cmd/gc tmux leak guard: a test created a real tmux session without tearing its server down; city-name sockets (e.g. -L test-city) have exit-empty off and live forever unless killed (dip-73cr05)\n",
+			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
+		},
+		{
+			name: "strips a guard block sandwiched between two real stderr lines",
+			in: "Usage:\n" +
+				"cmd/gc tmux leak guard: startup sweep reaping 1 stale test tmux server(s) whose socket root is gone\n" +
+				"  pid=999 argv=\"tmux -u -L test-city new-session -s mayor\"\n" +
+				"  gc backstage repo\n",
+			want: "Usage:\n  gc backstage repo\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := stripTmuxLeakGuardNoise(test.in); got != test.want {
+				t.Fatalf("stripTmuxLeakGuardNoise(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}
+
 const testTmuxSocketParentRootEnv = "GC_TEST_TMUX_SOCKET_PARENT_ROOT"
 
 func createAgedFreeTmuxSocketParent(t *testing.T) (string, string) {

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -312,13 +312,45 @@ func runPackCommandProcessWithEnv(t *testing.T, cityPath, scenario string, extra
 	if got, err := os.ReadFile(afterRun); err != nil || string(got) != "reached\n" {
 		t.Fatalf("post-run marker = %q, err=%v; run did not return through deferred lifecycle", got, err)
 	}
-	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stderr.String()}
+	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stripTmuxLeakGuardNoise(stderr.String())}
 }
 
-// stripTmuxLeakGuardNoise is a placeholder pending the green step; it does
-// not yet strip anything.
+// stripTmuxLeakGuardNoise removes the tmux leak guard's own diagnostic lines
+// (cmd/gc/tmux_leak_guard_test.go: sweepStaleTmuxTestServers,
+// writeTmuxLeakReport, and tmuxLeakGuardedTestingM.runWith's teardown report)
+// from captured subprocess stderr. TestMain re-runs in every re-exec'd
+// subprocess, so its startup sweep or teardown leak check can emit these
+// lines nondeterministically depending on unrelated concurrent sibling
+// suites' teardown timing — real CLI stderr assertions must not depend on
+// that timing.
 func stripTmuxLeakGuardNoise(s string) string {
-	return s
+	if s == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	trailingNewline := false
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		trailingNewline = true
+		lines = lines[:len(lines)-1]
+	}
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "cmd/gc tmux leak guard: "):
+		case strings.HasPrefix(line, "  pid="):
+		case strings.HasPrefix(line, "  socket="):
+		default:
+			kept = append(kept, line)
+		}
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	out := strings.Join(kept, "\n")
+	if trailingNewline {
+		out += "\n"
+	}
+	return out
 }
 
 // TestStripTmuxLeakGuardNoise expresses the acceptance criteria for isolating

--- a/release-gates/ga-f9qq6o-tmux-leak-guard-noise-gate.md
+++ b/release-gates/ga-f9qq6o-tmux-leak-guard-noise-gate.md
@@ -1,0 +1,72 @@
+# Release Gate: isolate command tests from tmux leak-guard diagnostics
+
+Date: 2026-09-02
+Deployer: gascity/deployer
+Status: PASS
+Deploy bead: ga-f9qq6o
+Build bead: ga-5pe5xv
+Review bead: ga-w22vvl
+Reviewed commit: 2a4de4b124c452cdfa8851a37b46817516da0e45
+Verified carryover commit: 76d63cb6adf9f708b3ae5da3ac2e446da10ace46
+Base checked: origin/main at faf4e3b89d115316e556edb0dcc2b4f2952c0e64
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the deployer release criteria and the repository testing policy in `TESTING.md`.
+
+## Gate summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-w22vvl` records `verdict: pass` for `2a4de4b124c452cdfa8851a37b46817516da0e45`. The builder recorded a rebase-only carryover to `76d63cb6adf9f708b3ae5da3ac2e446da10ace46`; independent recomputation produced the same stable full-diff patch ID, `6be3468fc4ae5e7078f46f27dfb04a02da427fe3`, for both commits. |
+| 2 | Acceptance criteria met | PASS | The test-only helper removes only the tmux leak guard's three harness-diagnostic prefixes from captured subprocess stderr, while preserving real command stderr, ordering, and trailing-newline behavior. The table test covers empty and no-op input plus leading, trailing, and sandwiched guard blocks. Every affected call path passed in the full suite. |
+| 3 | Tests pass | PASS | The documented full-scope command completed all 40 jobs: 39 job PASS, 1 attributed raw FAIL, 0 skipped jobs; 48,379 top-level test executions PASS, 1 raw FAIL, 208 SKIP. The sole failure was the pre-existing installed-`bd` manifest skew tracked by `ga-f0uceo`; it is outside the diff and attributed below. All diff-owned and affected tests passed. The independent policy lane and `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | The review records no style, security, or specification blocker and no HIGH finding. It reports clean formatting, vet, build, and lint results. |
+| 5 | Final branch is clean | PASS | The carryover checkout was clean before the gate artifact was written. The gate artifact is committed on the isolated deploy branch; no implementation edits or unrelated files are present. |
+| 6 | Branch diverges cleanly from main | PASS | The verified carryover commit contains `origin/main@faf4e3b89d115316e556edb0dcc2b4f2952c0e64` (`git merge-base --is-ancestor` exit 0), and `git merge-tree --write-tree` completed at tree `1be1696676e92c0661df542f6bc727c8fbb7827b`. No self-rebase was needed. |
+| 7 | Single feature theme | PASS | The two-commit series changes only `cmd/gc/cmd_commands_test.go` to make command-process stderr assertions independent of concurrent tmux leak-guard diagnostics. |
+
+## Criterion 3 evidence
+
+```text
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true GOFLAGS=-v GO_TEST_TIMEOUT=30m make test-local-full-parallel
+test_cmd_scope: full-suite
+test_job_counts: 39 PASS, 1 raw FAIL, 0 SKIP (40 total)
+test_counts: 48379 PASS, 1 raw FAIL, 208 SKIP (top-level Go test executions)
+policy_lane: make test-ci-policy — PASS
+vet_lane: go vet ./... — PASS
+ci_lane_run: n/a (no CI configuration change)
+waiver_ref: n/a
+full_log_dir: /var/tmp/ga-f9qq6o-full.9hpJrD
+```
+
+The rootless Podman 5.8.4 socket was live before the run. Cached images included
+the repository-pinned `docker.io/dolthub/dolt:2.1.7`, current
+`docker.io/dolthub/dolt-sql-server:2.2.0`, and
+`docker.io/testcontainers/ryuk:0.14.0` tags.
+
+`skip_justification`: the 208 top-level skips are suite-controlled helper,
+platform, unavailable-provider, or explicit opt-in cases exercised by the full
+matrix. None is in the modified test file, and the immediately preceding full
+gate on this feature reported the same 208-skip baseline.
+
+`diff_tests_executed`:
+
+- `TestStripTmuxLeakGuardNoise` — PASS in the process-backed and integration
+  `cmd/gc` shards.
+- `TestPackCommandCobraHelpAndUnknownParity` — PASS in both shard families.
+- `TestPackCommandExitReturnsThroughRun` — PASS in both shard families.
+- `TestPackCommandGroupMissRejectsUnknownSubcommands` — PASS in both shard
+  families.
+
+`failure_attribution`: `TestBdFlagManifestCurrent` -> `ga-f0uceo` | clause
+3(a), mechanism. The candidate modifies only package-local test code in
+`cmd/gc/cmd_commands_test.go`; it cannot affect `internal/bdflags` or change
+the installed `bd` binary. The failing test file is not diff-owned, the tracker
+predates this run and names the exact installed-binary/manifest skew, and there
+is no path overlap. This recurrence was appended to the tracker.
+
+## Decision
+
+PASS. The reviewed test-harness fix is current, content-identical to the
+reviewed diff, independently reverified across the complete local test matrix,
+and ready for an isolated deploy branch and pull request.


### PR DESCRIPTION
## What this changes

This stabilizes the `cmd/gc` command-process tests when multiple test suites run concurrently. The test harness now removes only its own tmux leak-guard diagnostic lines from captured subprocess stderr before comparing real command output.

Runtime `gc` behavior and user-visible CLI errors are unchanged.

## Review notes

- The filter is confined to `cmd/gc/cmd_commands_test.go`; no production path, configuration, or default changes.
- It matches the three leak-guard prefixes emitted by the harness and preserves all other stderr text, ordering, and trailing-newline behavior.
- Table coverage includes empty and unchanged input plus leading, trailing, and sandwiched diagnostic blocks.

## Test plan

- [x] `make test-local-full-parallel`; every affected command test passed. The unrelated installed-`bd` manifest skew is documented in the gate.
- [x] `make test-ci-policy`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-f9qq6o-tmux-leak-guard-noise-gate.md`](release-gates/ga-f9qq6o-tmux-leak-guard-noise-gate.md)