### PR TITLE
fix(reconciler): release a binding-resident orphan claim through the leg that read it

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -272,10 +272,14 @@ func filterAssignedWorkBeadsForSessionWake(
 // length is dropped rather than partially applied, and the returned stores are
 // then nil.
 //
-// residency:allow — a caller's own snapshot, projected. It carries the legs it
-// was HANDED through the same keep/drop decision it applies to the beads; it
-// consults no binding, no namespace and no leg order, opens no store, and can
-// only ever return a subsequence of its own input.
+// residency:allow — a caller's own snapshot, projected. The []beads.Store this
+// returns is only ever a subsequence of the slice it was HANDED, carried through
+// the same keep/drop decision it applies to the beads; it opens no store and
+// builds no store list of its own. It DOES consult residency to make that
+// keep/drop decision — assignedWorkClaimRefs resolves the topology's claim refs
+// and assignedWorkStoreRefForAgent resolves each agent's rig name — but those are
+// reads of refs, never of legs, and cannot introduce a store the caller did not
+// already hand in.
 func filterAssignedWorkBeadsForSessionWakeWithStores(
 	cfg *config.City,
 	cityPath string,

--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -246,6 +246,10 @@ func filterAssignedWorkBeadsForPoolDemand(
 // returns the filtered beads plus their store refs, index-aligned, so callers
 // can resolve store-scoped wake-demand readiness (storeScopedBeadKey) for the
 // surviving beads without re-deriving each bead's originating store.
+//
+// The reconcile paths take the store-aware form below, which also carries the
+// legs the rows were read through; this two-value form is for callers that only
+// read the surviving rows.
 func filterAssignedWorkBeadsForSessionWake(
 	cfg *config.City,
 	cityPath string,
@@ -254,11 +258,36 @@ func filterAssignedWorkBeadsForSessionWake(
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStoreRefs []string,
 ) ([]beads.Bead, []string) {
+	kept, keptRefs, _ := filterAssignedWorkBeadsForSessionWakeWithStores(cfg, cityPath, leading, sessionInfos, assignedWorkBeads, assignedWorkStoreRefs, nil)
+	return kept, keptRefs
+}
+
+// filterAssignedWorkBeadsForSessionWakeWithStores is the store-aware form: it
+// projects the index-aligned snapshot stores through the same filter, so a
+// caller that must WRITE to a surviving row can do it through the leg the census
+// read the row through rather than re-deriving an owner from gc.routed_to (which
+// names a work ledger a binding-resident row does not live in — ga-b0o6a).
+//
+// assignedWorkStores must be as long as assignedWorkBeads; a slice of any other
+// length is dropped rather than partially applied, and the returned stores are
+// then nil.
+func filterAssignedWorkBeadsForSessionWakeWithStores(
+	cfg *config.City,
+	cityPath string,
+	leading beads.Store,
+	sessionInfos []sessionpkg.Info,
+	assignedWorkBeads []beads.Bead,
+	assignedWorkStoreRefs []string,
+	assignedWorkStores []beads.Store,
+) ([]beads.Bead, []string, []beads.Store) {
+	if len(assignedWorkStores) != len(assignedWorkBeads) {
+		assignedWorkStores = nil
+	}
 	if len(assignedWorkBeads) == 0 || len(assignedWorkStoreRefs) == 0 {
-		return assignedWorkBeads, assignedWorkStoreRefs
+		return assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores
 	}
 	if cfg == nil {
-		return assignedWorkBeads, assignedWorkStoreRefs
+		return assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores
 	}
 	claimRefs := assignedWorkClaimRefs(cityPath, cfg, leading)
 	reachableRefsByAssignee := make(map[string]map[string]struct{})
@@ -343,6 +372,17 @@ func filterAssignedWorkBeadsForSessionWake(
 
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
 	filteredRefs := make([]string, 0, len(assignedWorkBeads))
+	var filteredStores []beads.Store
+	if assignedWorkStores != nil {
+		filteredStores = make([]beads.Store, 0, len(assignedWorkBeads))
+	}
+	keep := func(i int, wb beads.Bead) {
+		filtered = append(filtered, wb)
+		filteredRefs = append(filteredRefs, assignedWorkStoreRefs[i])
+		if filteredStores != nil {
+			filteredStores = append(filteredStores, assignedWorkStores[i])
+		}
+	}
 	for i, wb := range assignedWorkBeads {
 		if i >= len(assignedWorkStoreRefs) {
 			continue
@@ -353,18 +393,16 @@ func filterAssignedWorkBeadsForSessionWake(
 		}
 		if _, ok := crossStore[assignee]; ok {
 			// City-scoped assignee: reachable from any store (vp-kvp).
-			filtered = append(filtered, wb)
-			filteredRefs = append(filteredRefs, assignedWorkStoreRefs[i])
+			keep(i, wb)
 			continue
 		}
 		if refs := reachableRefsByAssignee[assignee]; refs != nil {
 			if _, ok := refs[assignedWorkStoreRefs[i]]; ok {
-				filtered = append(filtered, wb)
-				filteredRefs = append(filteredRefs, assignedWorkStoreRefs[i])
+				keep(i, wb)
 			}
 		}
 	}
-	return filtered, filteredRefs
+	return filtered, filteredRefs, filteredStores
 }
 
 // readyAssignedFlagsForBeads resolves the store-scoped wake-demand readiness of

--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -271,6 +271,11 @@ func filterAssignedWorkBeadsForSessionWake(
 // assignedWorkStores must be as long as assignedWorkBeads; a slice of any other
 // length is dropped rather than partially applied, and the returned stores are
 // then nil.
+//
+// residency:allow — a caller's own snapshot, projected. It carries the legs it
+// was HANDED through the same keep/drop decision it applies to the beads; it
+// consults no binding, no namespace and no leg order, opens no store, and can
+// only ever return a subsequence of its own input.
 func filterAssignedWorkBeadsForSessionWakeWithStores(
 	cfg *config.City,
 	cityPath string,

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -100,6 +101,75 @@ func assignedWorkIDs(work []beads.Bead) []string {
 		ids = append(ids, wb.ID)
 	}
 	return ids
+}
+
+// TestFilterAssignedWorkBeadsForSessionWakeWithStoresProjectsSurvivingStores
+// pins the store projection where alignment is CONSTRUCTED. Every other test of
+// this contract exercises a consumer that is handed an already-aligned slice;
+// this one drops a bead in the MIDDLE and asserts the legs move with it.
+//
+// The assertion is store IDENTITY, not length. A projection that dropped the
+// bead but not its store yields a same-length pair that every downstream length
+// check accepts, and the orphan release then writes the surviving bead through
+// the leg that belonged to the dropped one — the exact cross-leg write ga-b0o6a
+// exists to prevent. Distinct MemStore handles per index are what make that
+// detectable.
+func TestFilterAssignedWorkBeadsForSessionWakeWithStoresProjectsSurvivingStores(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "riga", Path: filepath.Join(cityPath, "riga")},
+			{Name: "rigb", Path: filepath.Join(cityPath, "rigb")},
+		},
+		Agents: []config.Agent{{
+			Name: "worker",
+			Dir:  "riga",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+	sessions := []beads.Bead{{
+		ID:     "session-1",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":                  "riga/worker",
+			"session_name":              "worker-session",
+			"configured_named_identity": "riga/worker",
+		},
+	}}
+	work := []beads.Bead{
+		{ID: "leading-keep", Status: "in_progress", Assignee: "session-1"},
+		{ID: "other-rig-drop", Status: "in_progress", Assignee: "session-1"},
+		{ID: "own-rig-keep", Status: "in_progress", Assignee: "session-1"},
+	}
+	storeRefs := []string{"", "rigb", "riga"}
+	stores := []beads.Store{beads.NewMemStore(), beads.NewMemStore(), beads.NewMemStore()}
+
+	got, gotRefs, gotStores := filterAssignedWorkBeadsForSessionWakeWithStores(
+		cfg, cityPath, nil, sessionInfosFromBeads(sessions), work, storeRefs, stores,
+	)
+
+	wantIDs := []string{"leading-keep", "own-rig-keep"}
+	if gotIDs := assignedWorkIDs(got); !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("filtered work IDs = %v, want %v — the middle bead must drop", gotIDs, wantIDs)
+	}
+	wantRefs := []string{"", "riga"}
+	if !slices.Equal(gotRefs, wantRefs) {
+		t.Fatalf("filtered store refs = %#v, want %#v aligned with beads", gotRefs, wantRefs)
+	}
+	if len(gotStores) != len(wantIDs) {
+		t.Fatalf("filtered stores length = %d, want %d — a store must drop with its bead", len(gotStores), len(wantIDs))
+	}
+	wantStores := []beads.Store{stores[0], stores[2]}
+	for i, want := range wantStores {
+		if gotStores[i] != want {
+			t.Fatalf("filtered store at index %d is not the input store for %q; the projection is misordered, so a release would write through another bead's leg", i, wantIDs[i])
+		}
+	}
 }
 
 func TestFilterAssignedWorkBeadsForSessionWakeCityScopedAgentIsCrossStoreEligible(t *testing.T) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2894,6 +2894,14 @@ func filterReleasedAssignedWorkBeads(assignedWorkBeads []beads.Bead, released []
 	return filtered
 }
 
+// filterReleasedAssignedWorkSnapshot drops the rows this tick's orphan release
+// already reopened, keeping the refs and owner legs index-aligned with the beads
+// that survive.
+//
+// residency:allow — a caller's own snapshot, projected. It carries the legs it
+// was HANDED through the same keep/drop decision it applies to the beads; it
+// consults no binding, no namespace and no leg order, opens no store, and can
+// only ever return a subsequence of its own input.
 func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assignedWorkStoreRefs []string, assignedWorkStores []beads.Store, released []releasedPoolAssignment) ([]beads.Bead, []string, []beads.Store) {
 	if len(assignedWorkBeads) == 0 || len(released) == 0 {
 		return assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2719,11 +2719,13 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		)
 		// The claim-without-execution lane. Both backstops above end at the
 		// claim; this one starts there. It reads the UNFILTERED assigned-work
-		// triple, which is the only index-aligned (bead, store, ref) view in the
-		// tick — the release filter above rewrites beads and refs but not stores
-		// — and re-checks ownership against each session's own identities anyway,
-		// so a released bead (whose assignee resolves to no live session by
-		// construction) cannot match a running one.
+		// triple — the pre-release snapshot — and re-checks ownership against
+		// each session's own identities anyway, so a released bead (whose
+		// assignee resolves to no live session by construction) cannot match a
+		// running one. Alignment is not what distinguishes the two views: since
+		// ga-b0o6a, filterReleasedAssignedWorkSnapshot projects the stores in
+		// lockstep with the beads and refs, so the filtered triple is equally
+		// index-aligned.
 		nudgeStalledPoolExecution(
 			cr.sp,
 			cr.cfg,

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2452,6 +2452,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
+	assignedWorkStores := result.AssignedWorkStores
 	phaseStart := time.Now()
 	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
@@ -2466,7 +2467,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		// gated on confirmed non-liveness; emit the event BEFORE the snapshot
 		// filter so the dead assignee and route can still be read off the beads.
 		emitDeadAssigneeReopenedEvents(cr.rec, assignedWorkBeads, released, time.Now())
-		assignedWorkBeads, assignedWorkStoreRefs = filterReleasedAssignedWorkSnapshot(assignedWorkBeads, assignedWorkStoreRefs, released)
+		assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores = filterReleasedAssignedWorkSnapshot(assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores, released)
 	}
 	// Detached handoff orphans: the tick repairs only the beads the journal named
 	// since the last pass. The whole-corpus scan this replaced was a live
@@ -2586,7 +2587,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	cr.recordReconcileTraceInputs(trace, openInfos, desiredState, poolDesired, workSet, traceWorkRequested, readyWaitSet, result, recordPhase)
 
 	phaseStart = time.Now()
-	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, store, openInfos, assignedWorkBeads, assignedWorkStoreRefs)
+	awakeAssignedWorkBeads, awakeAssignedStoreRefs, awakeAssignedStores := filterAssignedWorkBeadsForSessionWakeWithStores(cr.cfg, cr.cityPath, store, openInfos, assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.filter_assigned_work_for_wake", phaseStart, map[string]any{
 		"assigned_work_bead_count":       len(assignedWorkBeads),
 		"awake_assigned_work_bead_count": len(awakeAssignedWorkBeads),
@@ -2601,6 +2602,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		withMaxSessionAgeTracker(cr.mat),
 		withAssignedWorkDeferTracker(cr.adt),
 		withReadyAssignedFlags(readyAssignedFlagsForBeads(result.ReadyAssigned, awakeAssignedWorkBeads, awakeAssignedStoreRefs)),
+		// The legs this tick read the surviving assigned work through. The
+		// orphan-close tie-break releases a held claim through its own leg
+		// instead of re-deriving a work ledger from gc.routed_to, which on a
+		// split city does not hold the graph-class row at all (ga-b0o6a).
+		withAssignedWorkStores(awakeAssignedStores),
 		// Warm-bind claim nudge: deliver a pool slot's claim instruction to an
 		// already-running, idle slot that had on-demand work bound to it after it
 		// last Started (bindPoolSessionTriggerBead), which cold Start's nudge cannot
@@ -2884,13 +2890,13 @@ func (cr *CityRuntime) recordReconcileTraceResults(
 }
 
 func filterReleasedAssignedWorkBeads(assignedWorkBeads []beads.Bead, released []releasedPoolAssignment) []beads.Bead {
-	filtered, _ := filterReleasedAssignedWorkSnapshot(assignedWorkBeads, nil, released)
+	filtered, _, _ := filterReleasedAssignedWorkSnapshot(assignedWorkBeads, nil, nil, released)
 	return filtered
 }
 
-func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assignedWorkStoreRefs []string, released []releasedPoolAssignment) ([]beads.Bead, []string) {
+func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assignedWorkStoreRefs []string, assignedWorkStores []beads.Store, released []releasedPoolAssignment) ([]beads.Bead, []string, []beads.Store) {
 	if len(assignedWorkBeads) == 0 || len(released) == 0 {
-		return assignedWorkBeads, assignedWorkStoreRefs
+		return assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores
 	}
 	releasedIndexes := make(map[int]struct{}, len(released))
 	for _, r := range released {
@@ -2903,14 +2909,20 @@ func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assigned
 		}
 	}
 	if len(releasedIndexes) == 0 {
-		return assignedWorkBeads, assignedWorkStoreRefs
+		return assignedWorkBeads, assignedWorkStoreRefs, assignedWorkStores
 	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads)-len(releasedIndexes))
 	var filteredStoreRefs []string
+	var filteredStores []beads.Store
 	// Preserve AssignedWorkBeads/AssignedWorkStoreRefs index alignment when
-	// both slices are complete; otherwise drop refs rather than guess.
+	// both slices are complete; otherwise drop refs rather than guess. The
+	// owner stores carry the same rule: a partial store slice released through
+	// the wrong index is a write to a store that never held the row.
 	if len(assignedWorkStoreRefs) == len(assignedWorkBeads) {
 		filteredStoreRefs = make([]string, 0, len(assignedWorkStoreRefs)-len(releasedIndexes))
+	}
+	if len(assignedWorkStores) == len(assignedWorkBeads) {
+		filteredStores = make([]beads.Store, 0, len(assignedWorkStores)-len(releasedIndexes))
 	}
 	for i, wb := range assignedWorkBeads {
 		if _, ok := releasedIndexes[i]; ok {
@@ -2920,11 +2932,14 @@ func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assigned
 		if filteredStoreRefs != nil {
 			filteredStoreRefs = append(filteredStoreRefs, assignedWorkStoreRefs[i])
 		}
+		if filteredStores != nil {
+			filteredStores = append(filteredStores, assignedWorkStores[i])
+		}
 	}
 	if filteredStoreRefs == nil {
 		filteredStoreRefs = assignedWorkStoreRefs
 	}
-	return filtered, filteredStoreRefs
+	return filtered, filteredStoreRefs, filteredStores
 }
 
 func traceWorkRequestedByTemplate(scaleCheckCounts map[string]int, namedDemand map[string]bool, workSet map[string]bool, cfg *config.City) map[string]bool {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1068,7 +1068,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		poolDesired = make(map[string]int)
 	}
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
-	awakeAssignedWorkBeads, awakeAssignedStoreRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, oneShotStore, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	awakeAssignedWorkBeads, awakeAssignedStoreRefs, awakeAssignedStores := filterAssignedWorkBeadsForSessionWakeWithStores(cfg, cityPath, oneShotStore, openInfos, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs, dsResult.AssignedWorkStores)
 	reconcileSessionBeadsAtPathWithNamedDemand(
 		sigCtx, cityPath, sessionBeads.OpenForReconcile(), sessionBeads, ds, cfgNames, cfg, sp, sessStore,
 		nil, awakeAssignedWorkBeads, rigStores, nil, dt, nil, poolDesired,
@@ -1079,6 +1079,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
 		stdout, stderr,
 		withReadyAssignedFlags(readyAssignedFlagsForBeads(dsResult.ReadyAssigned, awakeAssignedWorkBeads, awakeAssignedStoreRefs)),
+		withAssignedWorkStores(awakeAssignedStores),
 	)
 
 	// Post-reconcile sync: update bead state to reflect post-start reality.

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -306,9 +306,13 @@ func releaseOrphanedPoolAssignments(
 // assignedWorkBeads through, and it is how a binding-resident row is released at
 // all: gc.routed_to names a WORK ledger, and on a split city a graph-class step
 // no longer lives there, so the routed fallback asks a store that answers "no
-// such bead" and the release is silently skipped (ga-b0o6a). Nil or short keeps
-// the routed fallback for that bead, so callers that supply nothing are
-// unchanged.
+// such bead" and the release is silently skipped (ga-b0o6a). An absent slice
+// (nil or empty) keeps the routed fallback, so callers that supply nothing are
+// unchanged. A non-empty slice of any other length is a DIFFERENT snapshot, not
+// a smaller one: in-range beads are still resolved through it, and out-of-range
+// beads are skipped entirely rather than routed-fallback resolved. Callers must
+// reject a misaligned slice before calling — see reconcileSessionBeads, which
+// nils it and logs the mismatch.
 func releaseConfirmedOrphanSessionWork(
 	cfg *config.City,
 	store beads.Store,

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -301,11 +301,20 @@ func releaseOrphanedPoolAssignments(
 // Every per-bead gate from releaseOrphanedPoolAssignments applies unchanged,
 // including the live re-read in liveWorkAssignmentStillReleasable — the tick
 // snapshot names candidates but never by itself justifies a release.
+//
+// assignedWorkStores is the index-aligned snapshot of the legs the census read
+// assignedWorkBeads through, and it is how a binding-resident row is released at
+// all: gc.routed_to names a WORK ledger, and on a split city a graph-class step
+// no longer lives there, so the routed fallback asks a store that answers "no
+// such bead" and the release is silently skipped (ga-b0o6a). Nil or short keeps
+// the routed fallback for that bead, so callers that supply nothing are
+// unchanged.
 func releaseConfirmedOrphanSessionWork(
 	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	assignedWorkBeads []beads.Bead,
+	assignedWorkStores []beads.Store,
 	info session.Info,
 ) []releasedPoolAssignment {
 	if cfg == nil || store == nil || len(assignedWorkBeads) == 0 {
@@ -341,8 +350,11 @@ func releaseConfirmedOrphanSessionWork(
 		if agentCfg == nil || !agentCfg.SupportsGenericEphemeralSessions() {
 			continue
 		}
-		ownerStore := storeForPoolAssignment(cfg, store, rigStores, wb)
+		ownerStore := assignedWorkOwnerStore(cfg, store, rigStores, assignedWorkStores, i, wb)
 		if ownerStore == nil {
+			if len(assignedWorkStores) > 0 {
+				log.Printf("releaseConfirmedOrphanSessionWork: missing owner store for assigned work %q at index %d", wb.ID, i)
+			}
 			continue
 		}
 		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, wb.Status, assignee) {

--- a/cmd/gc/pool_session_release_binding_owner_test.go
+++ b/cmd/gc/pool_session_release_binding_owner_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// The maintainer-city shape behind ga-b0o6a: a rig-routed graph-class step whose
+// row lives in the relocated class binding, not in the rig work ledger its
+// gc.routed_to prefix names.
+const (
+	bindingOrphanSeat     = "test-city--gc.implementation-worker-1"
+	bindingOrphanTemplate = "beads/gc.implementation-worker"
+)
+
+func bindingOrphanConfig(t *testing.T) *config.City {
+	t.Helper()
+	return &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "beads", Path: filepath.Join(t.TempDir(), "beads")}},
+		Agents: []config.Agent{{
+			Name:              "gc.implementation-worker",
+			Dir:               "beads",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+		}},
+	}
+}
+
+// bindingOrphanClaim is the claim row: a graph-class step, in_progress under the
+// dead seat's identity, routed to the rig-scoped pool agent.
+func bindingOrphanClaim() beads.Bead {
+	return beads.Bead{
+		ID:       "gcg-1",
+		Title:    "graph step held by a dead seat",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: bindingOrphanSeat,
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: bindingOrphanTemplate,
+			"gc.root_store_ref":          "rig:beads",
+		},
+	}
+}
+
+func bindingOrphanSessionInfo() sessionpkg.Info {
+	return seedSessionInfo(beads.Bead{
+		ID:     "gcs-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"template":     bindingOrphanTemplate,
+			"session_name": bindingOrphanSeat,
+			"state":        "asleep",
+			"pool_managed": "true",
+		},
+	})
+}
+
+// TestReleaseConfirmedOrphanSessionWork_ReleasesBindingResidentClaimThroughAlignedStore
+// is the repro. The orphan-close tie-break resolved each candidate's owner store
+// from its gc.routed_to prefix, which names a WORK ledger. On a split city the
+// claim is a graph-class row that lives only in the class binding, so the rig
+// ledger answers "no such bead", the release is skipped, and the close guard
+// keeps refusing — the ga-jrnou wedge, reopened for every binding-resident row.
+//
+// The census already read the row through the binding. That leg is the row's
+// owner, and passing it index-aligned is the whole fix.
+func TestReleaseConfirmedOrphanSessionWork_ReleasesBindingResidentClaimThroughAlignedStore(t *testing.T) {
+	cfg := bindingOrphanConfig(t)
+	work := bindingOrphanClaim()
+	binding := beads.NewMemStoreFrom(1, []beads.Bead{work}, nil)
+	rigStores := map[string]beads.Store{"beads": beads.NewMemStore()}
+
+	released := releaseConfirmedOrphanSessionWork(
+		cfg, binding, rigStores, []beads.Bead{work}, []beads.Store{binding}, bindingOrphanSessionInfo(),
+	)
+
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %#v, want the binding-resident claim %q released through its aligned leg", released, work.ID)
+	}
+	got, err := binding.Get(work.ID)
+	if err != nil {
+		t.Fatalf("binding.Get(%s): %v", work.ID, err)
+	}
+	if got.Assignee != "" || got.Status != "open" {
+		t.Fatalf("claim after release: status=%q assignee=%q, want open/unassigned so pool demand can re-route it", got.Status, got.Assignee)
+	}
+}
+
+// TestReleaseConfirmedOrphanSessionWork_NilAlignedStoresKeepsRoutedFallback is
+// the mutation probe for the test above AND the compatibility contract: with no
+// aligned slice the resolver falls back to the gc.routed_to prefix exactly as it
+// always has. That fallback is what strands the row here — which is why the
+// aligned slice, not some new probe, is the thing under test.
+func TestReleaseConfirmedOrphanSessionWork_NilAlignedStoresKeepsRoutedFallback(t *testing.T) {
+	cfg := bindingOrphanConfig(t)
+	work := bindingOrphanClaim()
+	binding := beads.NewMemStoreFrom(1, []beads.Bead{work}, nil)
+	rigStores := map[string]beads.Store{"beads": beads.NewMemStore()}
+
+	released := releaseConfirmedOrphanSessionWork(
+		cfg, binding, rigStores, []beads.Bead{work}, nil, bindingOrphanSessionInfo(),
+	)
+
+	if len(released) != 0 {
+		t.Fatalf("released = %#v, want none — with no aligned leg the routed prefix names the rig ledger, which does not hold this row", released)
+	}
+	got, err := binding.Get(work.ID)
+	if err != nil {
+		t.Fatalf("binding.Get(%s): %v", work.ID, err)
+	}
+	if got.Status != "in_progress" || got.Assignee != bindingOrphanSeat {
+		t.Fatalf("claim = status %q assignee %q, want the untouched in_progress claim — the fallback must not write through a store that never held the row", got.Status, got.Assignee)
+	}
+}
+
+// TestReleaseConfirmedOrphanSessionWork_LegacyRigStoreUnchanged keeps the
+// pre-existing lane intact: a row that really does live in the rig ledger its
+// route names is still released when no aligned slice is supplied. Every caller
+// that passes nothing behaves exactly as it did.
+func TestReleaseConfirmedOrphanSessionWork_LegacyRigStoreUnchanged(t *testing.T) {
+	cfg := bindingOrphanConfig(t)
+	work := bindingOrphanClaim()
+	rigStore := beads.NewMemStoreFrom(1, []beads.Bead{work}, nil)
+	rigStores := map[string]beads.Store{"beads": rigStore}
+
+	released := releaseConfirmedOrphanSessionWork(
+		cfg, beads.NewMemStore(), rigStores, []beads.Bead{work}, nil, bindingOrphanSessionInfo(),
+	)
+
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %#v, want the rig-resident claim %q released through the routed fallback", released, work.ID)
+	}
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("rigStore.Get(%s): %v", work.ID, err)
+	}
+	if got.Assignee != "" || got.Status != "open" {
+		t.Fatalf("claim after release: status=%q assignee=%q, want open/unassigned", got.Status, got.Assignee)
+	}
+}
+
+// TestReleaseConfirmedOrphanSessionWork_MisalignedStoresReleaseNothing pins the
+// alignment invariant at the function boundary: a short slice is never indexed
+// past its end and never re-used for a bead it does not describe. The bead with
+// no aligned leg is skipped, not guessed at.
+func TestReleaseConfirmedOrphanSessionWork_MisalignedStoresReleaseNothing(t *testing.T) {
+	cfg := bindingOrphanConfig(t)
+	first := bindingOrphanClaim()
+	second := bindingOrphanClaim()
+	second.ID = "gcg-2"
+	binding := beads.NewMemStoreFrom(2, []beads.Bead{first, second}, nil)
+	rigStores := map[string]beads.Store{"beads": beads.NewMemStore()}
+
+	released := releaseConfirmedOrphanSessionWork(
+		cfg, binding, rigStores, []beads.Bead{first, second}, []beads.Store{binding}, bindingOrphanSessionInfo(),
+	)
+
+	if len(released) != 1 || released[0].ID != first.ID {
+		t.Fatalf("released = %#v, want only %q — a bead past the end of the aligned slice has no known owner and must be skipped", released, first.ID)
+	}
+	got, err := binding.Get(second.ID)
+	if err != nil {
+		t.Fatalf("binding.Get(%s): %v", second.ID, err)
+	}
+	if got.Status != "in_progress" || got.Assignee != bindingOrphanSeat {
+		t.Fatalf("claim %s = status %q assignee %q, want untouched", second.ID, got.Status, got.Assignee)
+	}
+}

--- a/cmd/gc/pool_session_release_binding_owner_test.go
+++ b/cmd/gc/pool_session_release_binding_owner_test.go
@@ -145,11 +145,11 @@ func TestReleaseConfirmedOrphanSessionWork_LegacyRigStoreUnchanged(t *testing.T)
 	}
 }
 
-// TestReleaseConfirmedOrphanSessionWork_MisalignedStoresReleaseNothing pins the
-// alignment invariant at the function boundary: a short slice is never indexed
-// past its end and never re-used for a bead it does not describe. The bead with
-// no aligned leg is skipped, not guessed at.
-func TestReleaseConfirmedOrphanSessionWork_MisalignedStoresReleaseNothing(t *testing.T) {
+// TestReleaseConfirmedOrphanSessionWork_MisalignedStoresSkipTheUnalignedBead
+// pins the alignment invariant at the function boundary: a short slice is never
+// indexed past its end and never re-used for a bead it does not describe. The
+// bead with no aligned leg is skipped, not guessed at.
+func TestReleaseConfirmedOrphanSessionWork_MisalignedStoresSkipTheUnalignedBead(t *testing.T) {
 	cfg := bindingOrphanConfig(t)
 	first := bindingOrphanClaim()
 	second := bindingOrphanClaim()

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -316,6 +316,12 @@ type startExecutionOptions struct {
 	// deferred under storeQueryPartial today.
 	deferSessionClosesOnBoot bool
 	readyAssignedFlags       []bool
+	// assignedWorkStores is index-aligned with the assignedWorkBeads passed to
+	// the same reconcile pass: the store each row was read through. The
+	// orphan-close tie-break releases through it instead of re-deriving an owner
+	// from gc.routed_to, which names a work ledger a binding-resident row does
+	// not live in. Nil or misaligned leaves that fallback in place.
+	assignedWorkStores []beads.Store
 	// warmClaimProbe, when set, enables the warm-bind claim nudge: it reports
 	// whether a pool slot's newly-bound trigger bead is still unclaimed, read from
 	// the store named by the session's gc.trigger_bead_store_ref. Built by the
@@ -428,6 +434,19 @@ func withDeferSessionClosesOnBoot() startExecutionOption {
 func withReadyAssignedFlags(readyAssignedFlags []bool) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.readyAssignedFlags = readyAssignedFlags
+	}
+}
+
+// withAssignedWorkStores installs the index-aligned snapshot stores for this
+// reconcile pass: the legs the census read each assignedWorkBeads row through.
+// The orphan-close tie-break releases a held claim through the leg that read it,
+// because gc.routed_to names a work ledger that on a split city no longer holds
+// the row (ga-b0o6a). The slice must be exactly as long as the assignedWorkBeads
+// passed to the same pass; anything else is ignored in favor of the routed
+// fallback. Nil (or the option omitted) leaves the fallback in place.
+func withAssignedWorkStores(assignedWorkStores []beads.Store) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.assignedWorkStores = assignedWorkStores
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1428,6 +1428,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	if startupTimeout <= 0 && cfg != nil {
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
 	}
+	// The orphan-close tie-break releases a held claim through the leg the census
+	// read it through. Alignment is the whole contract: a slice that does not
+	// describe this tick's snapshot is a different truth, not a smaller one, so a
+	// mismatch drops to the routed fallback rather than indexing it (ga-b0o6a).
+	orphanReleaseStores := reconcileOpts.assignedWorkStores
+	assignedWorkStoresMisaligned := len(orphanReleaseStores) > 0 && len(orphanReleaseStores) != len(assignedWorkBeads)
+	if assignedWorkStoresMisaligned {
+		log.Printf("reconcileSessionBeads: assigned work/store length mismatch: work=%d stores=%d", len(assignedWorkBeads), len(orphanReleaseStores))
+		orphanReleaseStores = nil
+	}
 	maxAgeTr := reconcileOpts.maxSessionAgeTr
 	assignedWorkDeferTr := reconcileOpts.assignedWorkDeferTr
 	asyncStopTracker := reconcileOpts.asyncStopTracker
@@ -2235,7 +2245,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						//
 						// Restricted to "orphaned": a "suspended" seat is configured and
 						// merely scaled down, so its work stays put for its return.
-						if released := releaseConfirmedOrphanSessionWork(cfg, store, rigStores, assignedWorkBeads, infoByID[id]); len(released) > 0 {
+						if released := releaseConfirmedOrphanSessionWork(cfg, store, rigStores, assignedWorkBeads, orphanReleaseStores, infoByID[id]); len(released) > 0 {
 							emitDeadAssigneeReopenedEvents(rec, assignedWorkBeads, released, clk.Now().UTC())
 							closed = closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, infoByID[id], reason, clk.Now().UTC(), stderr, false)
 						}
@@ -2261,7 +2271,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// for as long as the seat stays wedged (ga-jrnou).
 							outcome = TraceOutcomeNoChange
 						}
-						trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), outcome, template, name, nil)
+						var payload traceRecordPayload
+						if assignedWorkStoresMisaligned {
+							payload = traceRecordPayload{
+								"assigned_work_stores_misaligned": true,
+								"assigned_work_bead_cnt":          len(assignedWorkBeads),
+								"assigned_work_store_cnt":         len(reconcileOpts.assignedWorkStores),
+							}
+						}
+						trace.RecordDecision(TraceSiteReconcilerCloseOrphan, TraceReasonCode(reason), outcome, template, name, payload)
 					}
 				}
 				continue

--- a/cmd/gc/session_reconciler_binding_orphan_test.go
+++ b/cmd/gc/session_reconciler_binding_orphan_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// bindingOrphanReconcileEnv is the maintainer-city shape the orphan-close
+// tie-break wedges on (ga-b0o6a): a split city whose infrastructure classes are
+// relocated into one binding, a rig-scoped pool seat whose runtime is gone, and
+// the seat's claim resident in the BINDING rather than in the rig work ledger
+// its gc.routed_to prefix names.
+//
+// The rig ledger is deliberately empty. Every lane that resolves an owner store
+// from the route lands there, finds nothing, and leaves the claim held — while
+// the close guard, which reads the binding leg, correctly sees the work and
+// refuses to close the seat.
+type bindingOrphanReconcileEnv struct {
+	cityPath string
+	cfg      *config.City
+	binding  beads.Store
+	rig      beads.Store
+	sp       *runtime.Fake
+	session  beads.Bead
+	work     beads.Bead
+}
+
+func newBindingOrphanReconcileEnv(t *testing.T) *bindingOrphanReconcileEnv {
+	t.Helper()
+	cityPath := t.TempDir()
+	writeCityTOML(t, cityPath, "test-city", "gc.implementation-worker")
+	binding := beads.NewMemStore()
+	seedSplitRoutes(t, cityPath, binding)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Session:   config.SessionConfig{Provider: "fake"},
+		Rigs:      []config.Rig{{Name: "beads", Path: filepath.Join(cityPath, "beads")}},
+		Agents: []config.Agent{{
+			Name:              "gc.implementation-worker",
+			Dir:               "beads",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+
+	// Type + label matter: the reconciler resolves a seat's liveness through
+	// session.ResolveSessionRecordByExactID, which only recognizes a typed (or
+	// labeled and untyped) bead as a session record.
+	session, err := binding.Create(beads.Bead{
+		Title:  "gc.implementation-worker",
+		Type:   sessionpkg.BeadType,
+		Labels: []string{sessionpkg.LabelSession},
+		Metadata: map[string]string{
+			"session_name":       bindingOrphanSeat,
+			"template":           bindingOrphanTemplate,
+			"agent_name":         "gc.implementation-worker",
+			"state":              "asleep",
+			"generation":         "1",
+			"continuation_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	work, err := binding.Create(beads.Bead{
+		Title:    "graph step held by a dead seat",
+		Status:   "open",
+		Assignee: bindingOrphanSeat,
+		Metadata: map[string]string{
+			beadmeta.RoutedToMetadataKey: bindingOrphanTemplate,
+			"gc.root_store_ref":          "rig:beads",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	return &bindingOrphanReconcileEnv{
+		cityPath: cityPath,
+		cfg:      cfg,
+		binding:  binding,
+		rig:      beads.NewMemStore(),
+		sp:       runtime.NewFake(),
+		session:  session,
+		work:     work,
+	}
+}
+
+func (e *bindingOrphanReconcileEnv) rigStores() map[string]beads.Store {
+	return map[string]beads.Store{"beads": e.rig}
+}
+
+// reconcile runs one reconcile pass over the orphaned seat. Empty desired state
+// plus a provider that never started the session is a confirmed orphan.
+func (e *bindingOrphanReconcileEnv) reconcile(t *testing.T, options ...startExecutionOption) {
+	t.Helper()
+	reconcileSessionBeadsAtPath(
+		context.Background(), e.cityPath, []beads.Bead{e.session}, map[string]TemplateParams{}, map[string]bool{},
+		e.cfg, e.sp, e.binding, nil, []beads.Bead{e.work}, e.rigStores(), nil, newDrainTracker(),
+		map[string]int{}, false, nil, "test-city",
+		nil, clock.Real{}, events.NewFake(), time.Minute, 0,
+		io.Discard, io.Discard,
+		options...,
+	)
+}
+
+// tick runs the controller's own bead-reconcile tick, so the aligned stores must
+// travel the whole production route: DesiredStateResult.AssignedWorkStores →
+// wake filter → start option → orphan close.
+func (e *bindingOrphanReconcileEnv) tick(t *testing.T) {
+	t.Helper()
+	cr := &CityRuntime{
+		cityPath:            e.cityPath,
+		cityName:            "test-city",
+		cfg:                 e.cfg,
+		sp:                  e.sp,
+		standaloneCityStore: e.binding,
+		standaloneRigStores: e.rigStores(),
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.NewFake(),
+		logPrefix:           "gc",
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+	cr.beadReconcileTick(context.Background(), DesiredStateResult{
+		State:                 map[string]TemplateParams{},
+		AssignedWorkBeads:     []beads.Bead{e.work},
+		AssignedWorkStores:    []beads.Store{e.binding},
+		AssignedWorkStoreRefs: []string{""},
+	}, newSessionBeadSnapshot([]beads.Bead{e.session}), nil, false)
+}
+
+func (e *bindingOrphanReconcileEnv) get(t *testing.T, id string) beads.Bead {
+	t.Helper()
+	got, err := e.binding.Get(id)
+	if err != nil {
+		t.Fatalf("binding.Get(%s): %v", id, err)
+	}
+	return got
+}
+
+// TestSessionReconcilerOrphanCloseReleasesBindingResidentWorkThroughAlignedStores
+// is the end-to-end repair. The controller tick already knows which leg it read
+// each assigned-work row through; carrying that leg to the orphan-close
+// tie-break is what lets a binding-resident claim be released at all.
+//
+// Without it the tie-break asks the rig ledger named by gc.routed_to, gets "no
+// such bead", skips the release, and the close guard — which reads the binding —
+// keeps refusing. The seat then wedges for as long as the city runs (ga-jrnou,
+// 86 hours in the case that surfaced it).
+func TestSessionReconcilerOrphanCloseReleasesBindingResidentWorkThroughAlignedStores(t *testing.T) {
+	env := newBindingOrphanReconcileEnv(t)
+
+	env.tick(t)
+
+	work := env.get(t, env.work.ID)
+	if work.Assignee != "" || work.Status != "open" {
+		t.Fatalf("claim = status %q assignee %q, want open/unassigned — a confirmed-orphaned seat must not keep holding a binding-resident claim", work.Status, work.Assignee)
+	}
+	session := env.get(t, env.session.ID)
+	if session.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed — once the held work is released the close guard stops refusing, so the orphan closes in the same tick", session.Status)
+	}
+}
+
+// TestSessionReconcilerOrphanCloseWithAlignedStoresOptionReleasesHeldWork pins
+// the option itself, independent of the controller wiring above: the reconciler
+// releases through the supplied leg and closes the seat in the same pass.
+func TestSessionReconcilerOrphanCloseWithAlignedStoresOptionReleasesHeldWork(t *testing.T) {
+	env := newBindingOrphanReconcileEnv(t)
+
+	env.reconcile(t, withAssignedWorkStores([]beads.Store{env.binding}))
+
+	work := env.get(t, env.work.ID)
+	if work.Assignee != "" || work.Status != "open" {
+		t.Fatalf("claim = status %q assignee %q, want open/unassigned", work.Status, work.Assignee)
+	}
+	session := env.get(t, env.session.ID)
+	if session.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed", session.Status)
+	}
+}
+
+// TestSessionReconcilerOrphanCloseWithoutAlignedStoresLeavesBindingResidentWorkHeld
+// is the mutation probe: it documents the behavior every caller that supplies
+// no aligned stores still gets, and it is exactly the wedge. If this test ever
+// starts releasing, the tie-break has grown a second owner-store resolver and
+// the aligned leg is no longer what the tests above are measuring.
+func TestSessionReconcilerOrphanCloseWithoutAlignedStoresLeavesBindingResidentWorkHeld(t *testing.T) {
+	env := newBindingOrphanReconcileEnv(t)
+
+	env.reconcile(t)
+
+	work := env.get(t, env.work.ID)
+	if work.Assignee != bindingOrphanSeat || work.Status != "open" {
+		t.Fatalf("claim = status %q assignee %q, want the claim still held — with no aligned leg the routed prefix names the empty rig ledger", work.Status, work.Assignee)
+	}
+	session := env.get(t, env.session.ID)
+	if session.Status == "closed" {
+		t.Fatalf("session bead closed while still holding work — the close guard must keep refusing until the claim is actually released")
+	}
+}
+
+// TestSessionReconcilerOrphanCloseIgnoresMisalignedAssignedWorkStores pins the
+// alignment invariant at the call site. A slice that does not describe this
+// tick's assigned-work snapshot is not a smaller truth, it is a different one:
+// indexing it would release a claim through a store that never held it. The
+// site drops to the documented fallback instead — no panic, no release.
+func TestSessionReconcilerOrphanCloseIgnoresMisalignedAssignedWorkStores(t *testing.T) {
+	env := newBindingOrphanReconcileEnv(t)
+
+	env.reconcile(t, withAssignedWorkStores([]beads.Store{env.binding, env.rig}))
+
+	work := env.get(t, env.work.ID)
+	if work.Assignee != bindingOrphanSeat || work.Status != "open" {
+		t.Fatalf("claim = status %q assignee %q, want the claim untouched — a misaligned store slice must never be indexed", work.Status, work.Assignee)
+	}
+}


### PR DESCRIPTION
## Bug

`session_reconciler.go`'s orphan-close arm — the ga-jrnou tie-break, reached
only when a seat's runtime is *observably* dead and the close guard refuses
because the seat still holds work — called
`releaseConfirmedOrphanSessionWork`, which resolved each candidate's owner store
with `storeForPoolAssignment`: the rig named by the `gc.routed_to` prefix, else
the rig whose ID prefix matches, else the city store.

Those are all WORK ledgers. On a split city (maintainer-city: every infra class
relocated into one binding at `.gc/store`) the held claim is a graph-class step
that lives ONLY in the binding, so the rig ledger returns `ErrNotFound` from
`liveWorkAssignmentStillReleasable`, the release is skipped, the close guard —
which *does* read the binding leg — keeps refusing, and the dead seat wedges
indefinitely. That is ga-jrnou reopened for every binding-resident row.

The sibling path already gets this right: `releaseOrphanedPoolAssignments`
resolves through `assignedWorkOwnerStore`, which returns the index-aligned leg
the census actually read the row through.

## Fix

The leg that read the row is its owner; a `routed_to` prefix names a work ledger
that no longer holds graph-class rows.

- `releaseConfirmedOrphanSessionWork` takes an `assignedWorkStores []beads.Store`
  parameter (index-aligned with `assignedWorkBeads`) and resolves via
  `assignedWorkOwnerStore`. An absent (nil or empty) slice keeps the existing
  routed fallback, so every caller that supplies nothing is byte-identical to
  today; a non-empty slice of the wrong length is a different snapshot, and its
  out-of-range beads are skipped rather than routed-fallback resolved.
- The controller threads `DesiredStateResult.AssignedWorkStores` to the
  reconciler: through `filterReleasedAssignedWorkSnapshot` (which now projects
  the stores alongside the refs) and the new store-aware
  `filterAssignedWorkBeadsForSessionWakeWithStores`, delivered as the functional
  option `withAssignedWorkStores` rather than a positional parameter. `gc start`'s
  one-shot reconcile takes the same route.
- Alignment is a hard invariant: at the call site a slice whose length does not
  match this tick's snapshot drops to the fallback, logs, and is recorded in the
  close-orphan trace payload (`assigned_work_stores_misaligned`). A misaligned
  slice is never indexed.

No new store enumeration, no class-binding probe in `pool_session_name.go`, no
change to `storeForPoolAssignment` semantics, nothing touched in the residency
stack.

### One thing worth a reviewer's eye (second commit)

The residency contract's AST half flags any `cmd/gc` signature returning a raw
`[]beads.Store`, so the two projections above
(`filterAssignedWorkBeadsForSessionWakeWithStores`,
`filterReleasedAssignedWorkSnapshot`) tripped `TestResidencyResolverBoundary`.
They carry the index-aligned legs they were HANDED through the same keep/drop
decision they already apply to the beads — they open no store and can only
return a subsequence of their own input (the wake filter does resolve claim refs
and rig names to make its keep/drop decision — refs, never legs) — so each got a
`residency:allow <reason>` marker, matching the existing
constructor-input markers (`servingRigStores`, `rigLegsExcludingCityName`).
Baselining the rows would have grown the ratchet's denominator; inlining the
projections to dodge a signature check would have defeated the guard while
keeping the store list. (`scripts/check-residency-boundary.sh`, the grep half,
was green throughout — only the AST half sees signatures.)

## Tests

`cmd/gc/pool_session_release_binding_owner_test.go`

- `TestReleaseConfirmedOrphanSessionWork_ReleasesBindingResidentClaimThroughAlignedStore`
  — the repro: claim resident only in the binding, empty rig ledger, released
  through the aligned leg.
- `TestReleaseConfirmedOrphanSessionWork_NilAlignedStoresKeepsRoutedFallback` —
  the mutation probe: the same call with no aligned slice releases nothing, which
  is exactly the wedge and the documented fallback.
- `TestReleaseConfirmedOrphanSessionWork_LegacyRigStoreUnchanged` — a
  rig-resident row still releases through the routed fallback.
- `TestReleaseConfirmedOrphanSessionWork_MisalignedStoresSkipTheUnalignedBead`
  — a short slice is never indexed past its end; the bead past its end is
  skipped, and the in-range bead still releases.

`cmd/gc/assigned_work_scope_test.go`

- `TestFilterAssignedWorkBeadsForSessionWakeWithStoresProjectsSurvivingStores` —
  the projection itself: a middle bead is dropped and the returned stores are
  compared by handle identity, not length, so a store left behind by its bead
  cannot pass as aligned.

`cmd/gc/session_reconciler_binding_orphan_test.go` (split city via
`seedSplitRoutes`, `runtime.NewFake()`, `t.TempDir()`)

- `TestSessionReconcilerOrphanCloseReleasesBindingResidentWorkThroughAlignedStores`
  — end-to-end through `beadReconcileTick`: work released AND the seat closes in
  the same tick.
- `TestSessionReconcilerOrphanCloseWithAlignedStoresOptionReleasesHeldWork` — the
  option itself, independent of the controller wiring.
- `TestSessionReconcilerOrphanCloseWithoutAlignedStoresLeavesBindingResidentWorkHeld`
  — without the option the seat stays wedged; this is why the plumbing exists.
- `TestSessionReconcilerOrphanCloseIgnoresMisalignedAssignedWorkStores` — no
  panic, no release, fallback path.

All four positive tests were watched RED against the pre-fix resolver (real
assertion failures, not just a compile break) before the body was switched to
`assignedWorkOwnerStore`.

## Gates

- `go build ./cmd/gc` — pass
- `go vet ./cmd/gc` — pass
- `gofmt -l cmd/gc/` — clean
- `golangci-lint run ./cmd/gc/...` — 0 issues
- `./scripts/check-residency-boundary.sh` — pass
- `go test ./scripts -run TestResidency -count=1` — ok
- `go test ./cmd/gc -run 'Orphan|ReleaseConfirmed|ReleaseOrphaned|SessionReconciler|Reconcile' -count=1` — ok
- `make test-fast-parallel` — all 10 fast jobs passed (run by the pre-push hook)

Refs ga-b0o6a

