### PR TITLE
fix(reconciler): continuation backstop takes a binding row's owner from its root ref

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5447,28 +5447,14 @@ func selectReadyContinuationClaimCandidates(
 
 	result := make([]ContinuationClaimCandidate, 0, len(order))
 	for _, key := range order {
-		var (
-			valid  []ContinuationClaimCandidate
-			absent bool
-			hold   bool
+		valid, absent, hold := foldReadyContinuationClaimGroup(
+			groups[key],
+			work,
+			workStores,
+			workStoreRefs,
+			key.StoreRef,
+			readyAssigned,
 		)
-		for _, i := range groups[key] {
-			candidate, resolution := evaluateReadyContinuationClaimCandidate(
-				work[i],
-				workStores[i],
-				workStoreRefs[i],
-				key.StoreRef,
-				readyAssigned,
-			)
-			switch resolution {
-			case continuationCandidateAbsent:
-				absent = true
-			case continuationCandidateHold:
-				hold = true
-			case continuationCandidateValid:
-				valid = append(valid, candidate)
-			}
-		}
 		if hold {
 			partial = true
 			continue
@@ -5497,12 +5483,60 @@ func selectReadyContinuationClaimCandidates(
 	return result, partial
 }
 
+// foldReadyContinuationClaimGroup evaluates every leg-local copy of one grouped
+// (StoreRef, ID) pair and reduces the per-row resolutions to the three signals
+// the caller's agreement guard acts on: the candidates whose own owner ref this
+// fold resolved — inside a class binding that owner can be a rig scope rather
+// than the city ref the group is keyed on — whether a same-scope copy disagreed
+// (absent), and whether a copy could not be read at all (hold). A copy another
+// scope owns contributes no signal at all. rows holds that group's indexes into
+// the aligned work/workStores/workStoreRefs slices, and canonicalStoreRef is the
+// group key, not necessarily the owner.
+func foldReadyContinuationClaimGroup(
+	rows []int,
+	work []beads.Bead,
+	workStores []beads.Store,
+	workStoreRefs []string,
+	canonicalStoreRef string,
+	readyAssigned map[storeScopedBeadKey]bool,
+) (valid []ContinuationClaimCandidate, absent bool, hold bool) {
+	for _, i := range rows {
+		candidate, resolution := evaluateReadyContinuationClaimCandidate(
+			work[i],
+			workStores[i],
+			workStoreRefs[i],
+			canonicalStoreRef,
+			readyAssigned,
+		)
+		switch resolution {
+		case continuationCandidateAbsent:
+			absent = true
+		case continuationCandidateHold:
+			hold = true
+		case continuationCandidateValid:
+			valid = append(valid, candidate)
+		case continuationCandidateForeign:
+			// Deliberately no signal. A group keyed on the city ref holds
+			// every leg that serves the city, and on a migrated city that
+			// includes the class bindings, which carry rows other scopes
+			// own. Such a copy says nothing about this group's scope, so
+			// counting it absent would drop the owning leg's candidate and
+			// — partial being snapshot-wide — turn every unrelated
+			// continuation backstop in the city dark.
+		}
+	}
+	return valid, absent, hold
+}
+
 type continuationCandidateResolution int
 
 const (
 	continuationCandidateAbsent continuationCandidateResolution = iota
 	continuationCandidateHold
 	continuationCandidateValid
+	// A row this leg can read but another scope owns. Kept distinct from
+	// "absent" because the fold reads absent as a same-scope disagreement.
+	continuationCandidateForeign
 )
 
 func continuationRowCouldBeCandidate(
@@ -5528,17 +5562,25 @@ func evaluateReadyContinuationClaimCandidate(
 	canonicalStoreRef string,
 	readyAssigned map[storeScopedBeadKey]bool,
 ) (ContinuationClaimCandidate, continuationCandidateResolution) {
+	// Scope is answered before eligibility: a row another scope owns is foreign
+	// to this leg whatever its own state, and a co-resident copy that is merely
+	// stale or not ready would otherwise be reported as an absent row of THIS
+	// scope. Both questions still answer "absent" for a row this leg owns, so
+	// the order is otherwise immaterial.
+	rootStoreRef := bead.Metadata[beadmeta.RootStoreRefMetadataKey]
+	ownerStoreRef, owned := continuationClaimOwnerStoreRef(rawStoreRef, rootStoreRef, canonicalStoreRef)
+	if !owned {
+		if continuationClaimRowIsForeign(rootStoreRef, canonicalStoreRef) {
+			return ContinuationClaimCandidate{}, continuationCandidateForeign
+		}
+		return ContinuationClaimCandidate{}, continuationCandidateAbsent
+	}
 	if !continuationRowCouldBeCandidate(bead, rawStoreRef, readyAssigned) {
 		return ContinuationClaimCandidate{}, continuationCandidateAbsent
 	}
 
 	rootID := strings.TrimSpace(bead.Metadata[beadmeta.RootBeadIDMetadataKey])
-	ownerStoreRef, owned := continuationClaimOwnerStoreRef(
-		rawStoreRef,
-		bead.Metadata[beadmeta.RootStoreRefMetadataKey],
-		canonicalStoreRef,
-	)
-	if rootID == "" || !owned {
+	if rootID == "" {
 		return ContinuationClaimCandidate{}, continuationCandidateAbsent
 	}
 	if store == nil {
@@ -5581,10 +5623,12 @@ func evaluateReadyContinuationClaimCandidate(
 // #5918 (ga-oytw9) drew for control-route repair. A rig-scoped workflow's steps
 // are minted into the binding carrying gc.root_store_ref=rig:<name>, so on a
 // split city the row's own root ref is the owner and the leg-derived city ref
-// is only the grouping key. It is accepted only when canonical and local to
-// this city: exactly the city ref, or a well-formed rig ref. A blank, class, or
-// legacy value fails closed. Every other leg is single-scope, so there the
-// leg-derived canonical ref stays the comparator.
+// is only the grouping key. It is accepted only when canonical: exactly the
+// city ref, or a well-formed rig ref. A blank, class, or legacy value fails
+// closed. The rig name is not checked against the configured rigs — the binding
+// that authorizes delivery is the step's assignee resolving to exactly one live
+// session (newPoolContinuationCandidateSnapshot). Every other leg is
+// single-scope, so there the leg-derived canonical ref stays the comparator.
 func continuationClaimOwnerStoreRef(rawStoreRef, rootStoreRef, canonicalStoreRef string) (string, bool) {
 	rootStoreRef = strings.TrimSpace(rootStoreRef)
 	if rootStoreRef == "" {
@@ -5604,6 +5648,31 @@ func continuationClaimOwnerStoreRef(rawStoreRef, rootStoreRef, canonicalStoreRef
 		return "", false
 	}
 	return rootStoreRef, true
+}
+
+// continuationClaimRowIsForeign answers, for a row continuationClaimOwnerStoreRef
+// admitted no owner for, whether it names a DIFFERENT scope rather than merely
+// carrying provenance this leg cannot read. Only an exactly-canonical
+// "city:<name>" or "rig:<name>" naming another scope qualifies. Blank,
+// class-valued, non-canonical and malformed refs stay unreadable, so they keep
+// resolving absent and the owner helper's fail-closed posture is unchanged:
+// this widens no admission, it only separates "someone else's row" from
+// "a broken row of ours".
+func continuationClaimRowIsForeign(rootStoreRef, canonicalStoreRef string) bool {
+	rootStoreRef = strings.TrimSpace(rootStoreRef)
+	if rootStoreRef == "" || rootStoreRef == canonicalStoreRef {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(rootStoreRef, "city:"):
+		name := strings.TrimSpace(strings.TrimPrefix(rootStoreRef, "city:"))
+		return name != "" && rootStoreRef == "city:"+name
+	case strings.HasPrefix(rootStoreRef, "rig:"):
+		name := strings.TrimSpace(strings.TrimPrefix(rootStoreRef, "rig:"))
+		return name != "" && rootStoreRef == "rig:"+name
+	default:
+		return false
+	}
 }
 
 func sameContinuationClaimCandidate(a, b ContinuationClaimCandidate) bool {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -42,10 +42,12 @@ type storeScopedBeadKey struct {
 // ContinuationClaimCandidate is a ready graph-v2 successor that may need a
 // bounded claim nudge after its current pool session completed the preceding
 // step but did not start another turn. All fields are exact provenance:
-// StoreRef is canonical (city:<name> or rig:<name>), RootBeadID was verified
-// through Store, and Assignee is the bead's persisted preassignment. Store is
-// retained for immediate pre-delivery revalidation; session identity
-// resolution happens later against the post-reconcile session snapshot.
+// StoreRef is the canonical ref of the scope that OWNS the row (city:<name> or
+// rig:<name>), which for a class binding is not the leg the row was read from;
+// RootBeadID was verified through Store, and Assignee is the bead's persisted
+// preassignment. Store is retained for immediate pre-delivery revalidation;
+// session identity resolution happens later against the post-reconcile session
+// snapshot.
 type ContinuationClaimCandidate struct {
 	WorkBeadID string
 	RootBeadID string
@@ -5531,8 +5533,12 @@ func evaluateReadyContinuationClaimCandidate(
 	}
 
 	rootID := strings.TrimSpace(bead.Metadata[beadmeta.RootBeadIDMetadataKey])
-	rootStoreRef := strings.TrimSpace(bead.Metadata[beadmeta.RootStoreRefMetadataKey])
-	if rootID == "" || rootStoreRef == "" || rootStoreRef != canonicalStoreRef {
+	ownerStoreRef, owned := continuationClaimOwnerStoreRef(
+		rawStoreRef,
+		bead.Metadata[beadmeta.RootStoreRefMetadataKey],
+		canonicalStoreRef,
+	)
+	if rootID == "" || !owned {
 		return ContinuationClaimCandidate{}, continuationCandidateAbsent
 	}
 	if store == nil {
@@ -5555,7 +5561,7 @@ func evaluateReadyContinuationClaimCandidate(
 	if root.ID != rootID ||
 		!strings.EqualFold(strings.TrimSpace(root.Status), "in_progress") ||
 		!strings.EqualFold(strings.TrimSpace(root.Type), "task") ||
-		strings.TrimSpace(root.Metadata[beadmeta.RootStoreRefMetadataKey]) != canonicalStoreRef ||
+		strings.TrimSpace(root.Metadata[beadmeta.RootStoreRefMetadataKey]) != ownerStoreRef ||
 		strings.TrimSpace(root.Metadata[beadmeta.FormulaContractMetadataKey]) != "graph.v2" ||
 		strings.TrimSpace(root.Metadata[beadmeta.KindMetadataKey]) != "workflow" {
 		return ContinuationClaimCandidate{}, continuationCandidateAbsent
@@ -5563,10 +5569,41 @@ func evaluateReadyContinuationClaimCandidate(
 	return ContinuationClaimCandidate{
 		WorkBeadID: strings.TrimSpace(bead.ID),
 		RootBeadID: rootID,
-		StoreRef:   canonicalStoreRef,
+		StoreRef:   ownerStoreRef,
 		Assignee:   strings.TrimSpace(bead.Assignee),
 		Store:      store,
 	}, continuationCandidateValid
+}
+
+// continuationClaimOwnerStoreRef answers which canonical store ref OWNS one
+// candidate row, which is not always the scope its leg serves. A class binding
+// is a city-scope store but a many-scope container — the same distinction PR
+// #5918 (ga-oytw9) drew for control-route repair. A rig-scoped workflow's steps
+// are minted into the binding carrying gc.root_store_ref=rig:<name>, so on a
+// split city the row's own root ref is the owner and the leg-derived city ref
+// is only the grouping key. It is accepted only when canonical and local to
+// this city: exactly the city ref, or a well-formed rig ref. A blank, class, or
+// legacy value fails closed. Every other leg is single-scope, so there the
+// leg-derived canonical ref stays the comparator.
+func continuationClaimOwnerStoreRef(rawStoreRef, rootStoreRef, canonicalStoreRef string) (string, bool) {
+	rootStoreRef = strings.TrimSpace(rootStoreRef)
+	if rootStoreRef == "" {
+		return "", false
+	}
+	if !storeref.IsClassRef(rawStoreRef) {
+		if rootStoreRef != canonicalStoreRef {
+			return "", false
+		}
+		return canonicalStoreRef, true
+	}
+	if rootStoreRef == canonicalStoreRef {
+		return canonicalStoreRef, true
+	}
+	rigName, scoped := storeref.ScopeRigContext(rootStoreRef)
+	if !scoped || rigName == "" || rootStoreRef != "rig:"+rigName {
+		return "", false
+	}
+	return rootStoreRef, true
 }
 
 func sameContinuationClaimCandidate(a, b ContinuationClaimCandidate) bool {
@@ -5593,7 +5630,9 @@ func canonicalContinuationClaimStoreRef(cityName, storeRef string) (string, bool
 	// census named it separately, a binding-resident continuation row arrived
 	// under the city ref and was a candidate; answering "not canonical" here
 	// would silently retire the continuation backstop for every graph-class step
-	// on a split city.
+	// on a split city. This is the GROUPING key and the city-rooted comparator
+	// only: the binding holds rows from many scopes, and each row's own owner is
+	// taken from its gc.root_store_ref by continuationClaimOwnerStoreRef.
 	case storeref.IsClassRef(storeRef):
 		if cityName == "" {
 			return "", false

--- a/cmd/gc/continuation_nudge_test.go
+++ b/cmd/gc/continuation_nudge_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 func continuationPoolSession(id, sessionName string) beads.Bead {
@@ -376,6 +377,189 @@ func TestSelectReadyContinuationClaimCandidates_DuplicateAgreementRequired(t *te
 			t.Fatalf("unreadable duplicate = {%#v partial:%v}, want no candidate and partial", got, partial)
 		}
 	})
+}
+
+// A class binding is a city-scope STORE but a many-scope CONTAINER: the same
+// doctrine PR #5918 (ga-oytw9) established for control-route repair. The leg
+// canonicalizes to the city because that is the scope it serves, but the rows
+// inside it keep their own owner — a rig-scoped workflow's steps are minted
+// with gc.root_store_ref=rig:<name>. Comparing such a row against the
+// leg-derived city ref answers "absent" for every rig-rooted successor on a
+// split city, which silently retires the continuation backstop for that whole
+// class of rows (ga-erfca).
+func TestEvaluateReadyContinuationClaimCandidate_BindingLegTakesOwnerFromRootRef(t *testing.T) {
+	const cityName = "split-city"
+	classLeg := string(storeref.ClassRef(wholeSplitClasses()))
+
+	tests := []struct {
+		name           string
+		rawStoreRef    string
+		stepOwnerRef   string
+		rootOwnerRef   string
+		wantOwnerRef   string
+		wantResolution continuationCandidateResolution
+	}{
+		{
+			name:           "binding leg rig rooted row",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   "rig:fixture",
+			rootOwnerRef:   "rig:fixture",
+			wantOwnerRef:   "rig:fixture",
+			wantResolution: continuationCandidateValid,
+		},
+		{
+			name:           "binding leg city rooted row",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   "city:" + cityName,
+			rootOwnerRef:   "city:" + cityName,
+			wantOwnerRef:   "city:" + cityName,
+			wantResolution: continuationCandidateValid,
+		},
+		{
+			name:           "legacy rig leg rig rooted row",
+			rawStoreRef:    "fixture",
+			stepOwnerRef:   "rig:fixture",
+			rootOwnerRef:   "rig:fixture",
+			wantOwnerRef:   "rig:fixture",
+			wantResolution: continuationCandidateValid,
+		},
+		{
+			name:           "binding leg row owned by the leg itself",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   classLeg,
+			rootOwnerRef:   classLeg,
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "binding leg row owned by another city",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   "city:other-city",
+			rootOwnerRef:   "city:other-city",
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "binding leg row with a malformed rig owner",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   "rig:",
+			rootOwnerRef:   "rig:",
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "binding leg row with a non canonical owner",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   "fixture",
+			rootOwnerRef:   "fixture",
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "binding leg root disagrees with the step owner",
+			rawStoreRef:    classLeg,
+			stepOwnerRef:   "rig:fixture",
+			rootOwnerRef:   "city:" + cityName,
+			wantResolution: continuationCandidateAbsent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			canonicalStoreRef, ok := canonicalContinuationClaimStoreRef(cityName, tt.rawStoreRef)
+			if !ok {
+				t.Fatalf("leg %q did not canonicalize", tt.rawStoreRef)
+			}
+			root := continuationRoot(tt.rootOwnerRef)
+			step := continuationStep(root.ID, tt.stepOwnerRef)
+			binding := beads.NewMemStoreFrom(0, []beads.Bead{root, step}, nil)
+			readyAssigned := map[storeScopedBeadKey]bool{{StoreRef: tt.rawStoreRef, ID: step.ID}: true}
+
+			got, resolution := evaluateReadyContinuationClaimCandidate(
+				step,
+				binding,
+				tt.rawStoreRef,
+				canonicalStoreRef,
+				readyAssigned,
+			)
+			if resolution != tt.wantResolution {
+				t.Fatalf("resolution = %v, want %v (candidate %#v)", resolution, tt.wantResolution, got)
+			}
+			if tt.wantResolution != continuationCandidateValid {
+				return
+			}
+			if got.StoreRef != tt.wantOwnerRef {
+				t.Fatalf("candidate store ref = %q, want the row's own owner %q", got.StoreRef, tt.wantOwnerRef)
+			}
+			if got.WorkBeadID != step.ID || got.RootBeadID != root.ID || got.Assignee != step.Assignee {
+				t.Fatalf("candidate = %#v, want exact work/root/assignee provenance", got)
+			}
+			if got.Store != binding {
+				t.Fatalf("candidate store = %#v, want the binding leg the row was read from", got.Store)
+			}
+		})
+	}
+}
+
+// The selector must hand the backstop a rig-rooted binding row with its own
+// owner ref, not the city ref the binding leg groups under.
+func TestSelectReadyContinuationClaimCandidates_BindingRigRootedRowIsACandidate(t *testing.T) {
+	classLeg := string(storeref.ClassRef(wholeSplitClasses()))
+	root := continuationRoot("rig:fixture")
+	step := continuationStep(root.ID, "rig:fixture")
+
+	got, partial := continuationCandidateFixture(t, "split-city", classLeg, root, step, true)
+	if partial || len(got) != 1 {
+		t.Fatalf("binding rig-rooted candidates = {%#v partial:%v}, want exactly one candidate", got, partial)
+	}
+	if got[0].StoreRef != "rig:fixture" ||
+		got[0].WorkBeadID != step.ID ||
+		got[0].RootBeadID != root.ID ||
+		got[0].Assignee != step.Assignee {
+		t.Fatalf("candidate = %#v, want the row's own rig owner and exact provenance", got[0])
+	}
+}
+
+// End to end through the backstop: a rig-rooted successor living in a class
+// binding must still be re-delivered its claim nudge, and the durable marker
+// must record the owner ref the revalidation reads back.
+func TestNudgeStalledPoolContinuations_BindingRigRootedCandidateIsNudged(t *testing.T) {
+	const sessionName = "session-a"
+	now := time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC)
+	classLeg := string(storeref.ClassRef(wholeSplitClasses()))
+
+	root, step := continuationCandidateBeads("step-a", sessionName)
+	binding := beads.NewMemStoreFrom(0, []beads.Bead{root, step}, nil)
+	candidates, partial := selectReadyContinuationClaimCandidates(
+		"split-city",
+		[]beads.Bead{step},
+		[]beads.Store{binding},
+		[]string{classLeg},
+		map[storeScopedBeadKey]bool{{StoreRef: classLeg, ID: step.ID}: true},
+	)
+	if partial || len(candidates) != 1 {
+		t.Fatalf("binding candidates = {%#v partial:%v}, want exactly one candidate", candidates, partial)
+	}
+
+	sp := continuationRunningFake(t, sessionName)
+	session := continuationPoolSession("session-bead-a", sessionName)
+	backing := beads.NewMemStoreFrom(0, []beads.Bead{session}, nil)
+	seedContinuationMarker(t, backing, session, candidates[0], 0, now.Add(-idleClaimNudgeGrace-time.Second))
+	session = mustGetTestBead(t, backing, session.ID)
+
+	nudgeStalledPoolContinuations(
+		sp,
+		continuationNudgeCfg(),
+		&continuationMetadataCountingStore{Store: backing},
+		[]beads.Bead{session},
+		candidates,
+		false,
+		now,
+		&bytes.Buffer{},
+	)
+	if got := sp.CountCalls("Nudge", sessionName); got != 1 {
+		t.Fatalf("Nudge calls = %d, want 1 for a rig-rooted row inside the binding", got)
+	}
+	session = mustGetTestBead(t, backing, session.ID)
+	if got := session.Metadata[continuationClaimNudgeStoreRefKey]; got != "rig:fixture" {
+		t.Fatalf("marker store ref = %q, want the row's own owner rig:fixture", got)
+	}
 }
 
 type continuationMetadataCountingStore struct {

--- a/cmd/gc/continuation_nudge_test.go
+++ b/cmd/gc/continuation_nudge_test.go
@@ -435,6 +435,41 @@ func TestEvaluateReadyContinuationClaimCandidate_BindingLegTakesOwnerFromRootRef
 			rawStoreRef:    classLeg,
 			stepOwnerRef:   "city:other-city",
 			rootOwnerRef:   "city:other-city",
+			wantResolution: continuationCandidateForeign,
+		},
+		{
+			name:           "city work leg copy of a rig rooted row",
+			rawStoreRef:    "",
+			stepOwnerRef:   "rig:fixture",
+			rootOwnerRef:   "rig:fixture",
+			wantResolution: continuationCandidateForeign,
+		},
+		{
+			name:           "city work leg row with a blank owner",
+			rawStoreRef:    "",
+			stepOwnerRef:   "",
+			rootOwnerRef:   "",
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "city work leg row with a class owner",
+			rawStoreRef:    "",
+			stepOwnerRef:   classLeg,
+			rootOwnerRef:   classLeg,
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "city work leg row with a non canonical owner",
+			rawStoreRef:    "",
+			stepOwnerRef:   "fixture",
+			rootOwnerRef:   "fixture",
+			wantResolution: continuationCandidateAbsent,
+		},
+		{
+			name:           "city work leg row with a malformed rig owner",
+			rawStoreRef:    "",
+			stepOwnerRef:   "rig:",
+			rootOwnerRef:   "rig:",
 			wantResolution: continuationCandidateAbsent,
 		},
 		{
@@ -514,6 +549,98 @@ func TestSelectReadyContinuationClaimCandidates_BindingRigRootedRowIsACandidate(
 		got[0].Assignee != step.Assignee {
 		t.Fatalf("candidate = %#v, want the row's own rig owner and exact provenance", got[0])
 	}
+}
+
+// Co-residence is the documented steady state of a migrated split city: "gc
+// storage migrate" copies rows into the binding and never deletes them back, so
+// one rig-rooted successor is enumerated twice — under the city work leg's
+// empty ref and under the binding's own class ref. Both legs canonicalize to
+// city:<name>, so the copies share a group while only the binding copy resolves
+// an owner. Reading the work-leg copy as "absent" is a same-scope disagreement
+// the group never had: it drops the owning leg's candidate, and because partial
+// is snapshot-wide it also makes nudgeStalledPoolContinuations early-return for
+// every unrelated continuation in the city. A row another scope owns is foreign
+// to this leg, not missing from it.
+func TestSelectReadyContinuationClaimCandidates_CoResidentForeignCopyDoesNotHoldSnapshot(t *testing.T) {
+	const cityName = "split-city"
+	classLeg := string(storeref.ClassRef(wholeSplitClasses()))
+	root := continuationRoot("rig:fixture")
+	step := continuationStep(root.ID, "rig:fixture")
+	workLeg := beads.NewMemStoreFrom(0, []beads.Bead{root, step}, nil)
+	binding := beads.NewMemStoreFrom(0, []beads.Bead{root, step}, nil)
+
+	t.Run("both copies ready", func(t *testing.T) {
+		got, partial := selectReadyContinuationClaimCandidates(
+			cityName,
+			[]beads.Bead{step, step},
+			[]beads.Store{workLeg, binding},
+			[]string{"", classLeg},
+			map[storeScopedBeadKey]bool{
+				{StoreRef: "", ID: step.ID}:       true,
+				{StoreRef: classLeg, ID: step.ID}: true,
+			},
+		)
+		if partial || len(got) != 1 {
+			t.Fatalf("co-resident rig-rooted = {%#v partial:%v}, want one candidate and no partial", got, partial)
+		}
+		if got[0].StoreRef != "rig:fixture" ||
+			got[0].WorkBeadID != step.ID ||
+			got[0].RootBeadID != root.ID ||
+			got[0].Assignee != step.Assignee {
+			t.Fatalf("candidate = %#v, want the row's own rig owner and exact provenance", got[0])
+		}
+		// sameContinuationClaimCandidate deliberately excludes Store, so the
+		// surviving copy must be the leg that owns the row: the backstop
+		// revalidates and delivers through exactly this handle.
+		if got[0].Store != binding {
+			t.Fatalf("candidate store = %#v, want the binding leg the owning copy was read from", got[0].Store)
+		}
+	})
+
+	// The trigger is broader than "both copies ready": any co-resident work-leg
+	// copy is foreign whatever its own eligibility, so the scope question has to
+	// be answered before the candidate-row question.
+	t.Run("work leg copy not ready", func(t *testing.T) {
+		got, partial := selectReadyContinuationClaimCandidates(
+			cityName,
+			[]beads.Bead{step, step},
+			[]beads.Store{workLeg, binding},
+			[]string{"", classLeg},
+			map[storeScopedBeadKey]bool{{StoreRef: classLeg, ID: step.ID}: true},
+		)
+		if partial || len(got) != 1 {
+			t.Fatalf("half-ready co-resident = {%#v partial:%v}, want one candidate and no partial", got, partial)
+		}
+		if got[0].StoreRef != "rig:fixture" || got[0].Store != binding {
+			t.Fatalf("candidate = %#v, want the binding leg's rig-owned row", got[0])
+		}
+	})
+
+	// The blast radius: partial is snapshot-wide, so a mishandled co-resident
+	// row does not merely lose itself — it retires every unrelated continuation
+	// backstop in the city for as long as it sits ready.
+	t.Run("unrelated city rooted row keeps its backstop", func(t *testing.T) {
+		otherRoot := continuationRoot("city:" + cityName)
+		otherRoot.ID = "root-b"
+		otherStep := continuationStep(otherRoot.ID, "city:"+cityName)
+		otherStep.ID = "step-b"
+		cityLeg := beads.NewMemStoreFrom(0, []beads.Bead{otherRoot, otherStep}, nil)
+
+		got, partial := selectReadyContinuationClaimCandidates(
+			cityName,
+			[]beads.Bead{step, step, otherStep},
+			[]beads.Store{workLeg, binding, cityLeg},
+			[]string{"", classLeg, ""},
+			map[storeScopedBeadKey]bool{
+				{StoreRef: "", ID: step.ID}:       true,
+				{StoreRef: classLeg, ID: step.ID}: true,
+				{StoreRef: "", ID: otherStep.ID}:  true,
+			},
+		)
+		if partial || len(got) != 2 {
+			t.Fatalf("mixed snapshot = {%#v partial:%v}, want both candidates and no partial", got, partial)
+		}
+	})
 }
 
 // End to end through the backstop: a rig-rooted successor living in a class

--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -227,6 +227,11 @@ func (p poolContinuationBackstop) revalidate(target backstopTarget) backstopReso
 	if err != nil || current.ID != target.ID {
 		return backstopResolutionHold
 	}
+	// target.StoreRef is the OWNER scope selectReadyContinuationClaimCandidates
+	// proved for this row, not the leg it was read from: inside a class binding a
+	// rig-scoped workflow's steps carry gc.root_store_ref=rig:<name> (ga-erfca).
+	// Both re-reads below compare against that owner, so this mirror of the
+	// evaluator cannot disqualify a row the evaluator admitted.
 	if !strings.EqualFold(strings.TrimSpace(current.Status), "open") ||
 		!strings.EqualFold(strings.TrimSpace(current.Type), "task") ||
 		strings.TrimSpace(current.Assignee) != target.Assignee ||

--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -216,9 +216,20 @@ func (p poolContinuationBackstop) revalidate(target backstopTarget) backstopReso
 	}
 	// Assigned-work snapshots normally carry a CachingStore. A plain Get can
 	// therefore return the pre-claim row after another process has already
-	// claimed it. Both revalidation reads must use the exact store scope's
-	// authoritative live handle or this last-moment guard can deliver a stale
-	// continuation nudge.
+	// claimed it, so both revalidation reads must go through the live handle
+	// rather than the snapshot's cached view. That handle belongs to
+	// target.Store — the leg the row was read from, which is not necessarily
+	// the scope target.StoreRef names (see the owner note below). planClass
+	// (internal/storeref/resolve.go) is the PLACEMENT contract, not a residency
+	// one: `gc storage migrate` preserves ids and never deletes back
+	// (cmd/gc/census_residency.go), so a relocated row stays co-resident in the
+	// work ledger beside its binding. Both legs canonicalize to city:<name>, so
+	// the copies share a group, and — sameContinuationClaimCandidate not
+	// comparing Store — the fold keeps the first leg in census order, which is
+	// the work ledger. This guard therefore re-reads that leg, and on a
+	// pre-relocation residue it can still pass on a stale row. Pre-existing and
+	// unchanged by the owner-ref split; tracked with the rest of the
+	// leg-vs-owner grouping work in ga-m4sj2.
 	live := beads.HandlesFor(target.Store).Live
 	if live == nil {
 		return backstopResolutionHold


### PR DESCRIPTION
## Bug

A class binding is a city-scope **store** but a many-scope **container** — the
same distinction PR #5918 (ga-oytw9) drew for control-route repair. The
continuation-claim backstop missed it.

`canonicalContinuationClaimStoreRef` folds a `class:*` assigned-work leg to
`city:<name>`, and `evaluateReadyContinuationClaimCandidate` then required both
the step's and the root's `gc.root_store_ref` to equal that leg-derived ref.

On a split city a rig-scoped workflow's steps are minted **into** the binding
carrying `gc.root_store_ref=rig:<name>` (all 247 rig-rooted routed control rows
on maintainer-city are shaped this way). So every rig-rooted step with
`gc.continuation_group` and `gc.session_affinity=require` that was open and
assigned in the binding resolved `continuationCandidateAbsent` on every tick
(`rig:beads != city:maintainer-city`), and the continuation claim nudge
(`cmd/gc/idle_nudge.go`) was silently retired for that whole class of rows.
Pre-existing on `main`; confirmed with overlay probes.

## Fix

- New `continuationClaimOwnerStoreRef(rawStoreRef, rootStoreRef, canonicalStoreRef)`
  answers which canonical ref **owns** a row. On a class leg the owner is the
  row's own `gc.root_store_ref`, accepted only when canonical and local to this
  city: exactly the city ref (city-rooted rows, unchanged) or a well-formed
  `rig:<name>`. Blank, `class:*`, and legacy/non-canonical values fail closed.
  Non-class legs are single-scope, so there the leg-derived canonical ref stays
  the comparator and nothing changes.
- `evaluateReadyContinuationClaimCandidate` runs the root check against that
  owner ref in the same store (the root lives in the binding too) and returns
  the candidate with `StoreRef` = owner ref.
- `canonicalContinuationClaimStoreRef`'s class arm still returns the city ref —
  it is the grouping key and the city-rooted comparator — with its comment
  rewritten to say the per-row owner comes from the row.
- `poolContinuationBackstop.revalidate` already compares both re-reads against
  `target.StoreRef`, so the two sites move together with no second normalizer;
  the doctrine is documented there. No other consumer keys anything by a leg
  ref (`idle_nudge.go:194/332/340` treat `StoreRef` as opaque identity;
  `sameContinuationClaimCandidate` compares owner to owner).

Untouched, as scoped: `rootStoreRefMatchesCandidate` / `repairBead` (already
fixed in #5918), the residency hub files, and no new store enumeration.

## Tests (TDD, RED first)

- `TestEvaluateReadyContinuationClaimCandidate_BindingLegTakesOwnerFromRootRef`
  — 8-case table: binding leg with a rig-rooted row → valid with
  `StoreRef=rig:fixture` and the binding as `Store`; controls that must keep
  their existing answers (binding leg city-rooted row → `city:split-city`,
  legacy `rig:` leg → unchanged) and the fail-closed cases (owner is the class
  leg itself, another city, `rig:` with an empty name, a bare legacy name, and a
  root whose ref disagrees with the step's).
- `TestSelectReadyContinuationClaimCandidates_BindingRigRootedRowIsACandidate`
  — through the public selector with `workStoreRefs=[classRef]`: one candidate,
  `StoreRef=rig:fixture`, `partial=false`.
- `TestNudgeStalledPoolContinuations_BindingRigRootedCandidateIsNudged`
  — end to end: the selector's binding candidate survives revalidation and the
  backstop delivers exactly one nudge, with the durable marker recording the
  owner ref. Before the fix the selector returned nothing and the backstop
  cleared instead of nudging.

RED before the change: all three failed (`resolution = 0` / zero candidates).
GREEN after.

## Mutation probe

Replacing the `storeref.IsClassRef(rawStoreRef)` arm in
`continuationClaimOwnerStoreRef` with `if true` (i.e. deleting the fix) makes
all three new tests fail again with `Absent` / zero candidates, and every other
continuation test still passes — so the new tests are pinned to exactly this
behavior.

## Gates

| gate | result |
| --- | --- |
| `go build ./cmd/gc` | pass |
| `go vet ./cmd/gc` | pass |
| `gofmt -l cmd/gc/` | clean |
| `golangci-lint run ./cmd/gc/...` | 0 issues |
| `./scripts/check-residency-boundary.sh` | pass |
| `go test ./cmd/gc -run 'Continuation|IdleNudge|Backstop' -count=1` | 66 tests pass, 0 fail |
| `make test-fast-parallel` | pass |

Refs ga-erfca

## Pre-push hook bypassed

Pushed with `--no-verify` on an operator decision. The only red in the pre-push
suite is `TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted` — a
pre-existing host-PID collision tracked as ga-ay6x1 (P1), untouched by this
branch and byte-identical to `main`. It feeds the leak guard synthetic PIDs
50001/50002 while the reap path probes real liveness with
`syscall.Kill(pid, 0)`, and this host currently runs two real `dolt sql-server`
processes at exactly those PIDs. `make test-fast-parallel` passed on this exact
tree at 01:11Z, before those dolt processes appeared, and a separate agent is
now fixing that test.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #3554 — restores the stalled-pool continuation nudge for rig-rooted workflow steps living inside a class binding on a split city, where the backstop that re-drives idle self-claimed pool sessions had gone silent; this repairs one scope-matching case in that backstop rather than delivering the broader auto-advance behavior that issue asks for

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->