### PR TITLE
fix(sessionlog): thread the transcript entry's own timestamp through to Fact.At instead of stamping now (#5825)

### DIFF
--- a/internal/sessionlog/codex_usage.go
+++ b/internal/sessionlog/codex_usage.go
@@ -255,11 +255,12 @@ func boundedContextPercentage(inputTokens, contextWindow int) int {
 // CLI produces collapse to a single entry (the last observed wins, except a
 // first-observed non-empty Model is kept — a duplicate re-emitted after a
 // model-switching turn_context must not relabel the invocation), and
-// EntryUUID is the line timestamp. token_count lines with null info
-// (rate-limit-only refreshes) and all-zero per-call usage are skipped;
-// malformed lines are tolerated silently. The scan window is the last
-// tailChunkSize bytes, so usage that scrolled past the window is not
-// returned.
+// EntryUUID is the line timestamp, and Timestamp is the same value parsed
+// (RFC3339Nano, falling back to RFC3339) — zero when unparseable. token_count
+// lines with null info (rate-limit-only refreshes) and all-zero per-call
+// usage are skipped; malformed lines are tolerated silently. The scan window
+// is the last tailChunkSize bytes, so usage that scrolled past the window is
+// not returned.
 func ExtractCodexTailUsage(path string) ([]TailUsage, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -356,6 +357,7 @@ func codexTokenCountUsage(entry codexRawEntry, payload codexUsagePayload, model 
 		ReasoningTokens:     last.ReasoningOutputTokens,
 		CacheReadTokens:     last.CachedInputTokens,
 		ContextWindowTokens: contextWindowTokens,
+		Timestamp:           parseCodexSessionTime(entry.Timestamp),
 	}
 	if u.InputTokens <= 0 && u.OutputTokens <= 0 && u.ReasoningTokens <= 0 && u.CacheReadTokens <= 0 {
 		return TailUsage{}, false

--- a/internal/sessionlog/codex_usage_test.go
+++ b/internal/sessionlog/codex_usage_test.go
@@ -170,6 +170,32 @@ func TestExtractCodexTailUsage(t *testing.T) {
 	}
 }
 
+// TestExtractCodexTailUsageCapturesEntryTimestamp verifies Timestamp is
+// parsed from the same line the string-valued EntryUUID already carries.
+func TestExtractCodexTailUsageCapturesEntryTimestamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-2026-04-16T21-49-29-timestamp.jsonl")
+	writeCodexUsageLines(t, path, []string{
+		codexSessionMetaLine("2026-04-16T21:49:30.734Z", "/work/dir"),
+		codexTurnContextLine("2026-04-16T21:49:30.901Z", "gpt-5.4"),
+		codexTokenCountLine("2026-04-16T21:49:38.304Z", 15917, 15562, 10624, 355, 166),
+	})
+
+	usages, err := ExtractCodexTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractCodexTailUsage: %v", err)
+	}
+	if len(usages) != 1 {
+		t.Fatalf("got %d usages, want 1: %+v", len(usages), usages)
+	}
+	want, err := time.Parse(time.RFC3339Nano, "2026-04-16T21:49:38.304Z")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
+	}
+	if !usages[0].Timestamp.Equal(want) {
+		t.Errorf("usages[0].Timestamp = %v, want %v", usages[0].Timestamp, want)
+	}
+}
+
 // TestExtractCodexTailUsageDuplicateKeepsFirstModel pins the real codex
 // emission order around a model switch: the CLI re-emits the prior turn's
 // final cumulative snapshot AFTER the new turn's turn_context, so the

--- a/internal/sessionlog/tail.go
+++ b/internal/sessionlog/tail.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/pathutil"
 )
@@ -159,10 +160,11 @@ func splitLines(data []byte) [][]byte {
 
 // tailEntry is the minimal structure we decode from each JSONL line.
 type tailEntry struct {
-	Type    string          `json:"type"`
-	Subtype string          `json:"subtype,omitempty"`
-	UUID    string          `json:"uuid"`
-	Message json.RawMessage `json:"message"`
+	Type      string          `json:"type"`
+	Subtype   string          `json:"subtype,omitempty"`
+	UUID      string          `json:"uuid"`
+	Message   json.RawMessage `json:"message"`
+	Timestamp time.Time       `json:"timestamp"`
 }
 
 // messageStopReason extracts stop_reason from an assistant message.

--- a/internal/sessionlog/tail_usage.go
+++ b/internal/sessionlog/tail_usage.go
@@ -3,6 +3,7 @@ package sessionlog
 import (
 	"encoding/json"
 	"os"
+	"time"
 )
 
 // TailUsage is the per-invocation token usage parsed from one
@@ -37,6 +38,9 @@ type TailUsage struct {
 	// ContextWindowTokens is the model context window reported by the
 	// provider for this invocation, when available.
 	ContextWindowTokens int
+	// Timestamp is the transcript entry's own timestamp, when the provider
+	// format carries one. Zero when absent or unparseable.
+	Timestamp time.Time
 }
 
 // ExtractTailUsage reads the tail of a session transcript and returns one
@@ -88,6 +92,7 @@ func ExtractTailUsage(path string) ([]TailUsage, error) {
 			OutputTokens:        msg.Usage.OutputTokens,
 			CacheReadTokens:     msg.Usage.CacheReadInputTokens,
 			CacheCreationTokens: msg.Usage.CacheCreationInputTokens,
+			Timestamp:           entry.Timestamp,
 		}
 		if u.InputTokens <= 0 && u.OutputTokens <= 0 && u.CacheReadTokens <= 0 && u.CacheCreationTokens <= 0 {
 			continue

--- a/internal/sessionlog/tail_usage_test.go
+++ b/internal/sessionlog/tail_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestExtractTailUsageReturnsEntriesInFileOrder(t *testing.T) {
@@ -145,6 +146,49 @@ func TestExtractTailUsageCollapsesContentBlockEntriesByMessageID(t *testing.T) {
 		if usages[i] != w {
 			t.Errorf("usages[%d] = %+v, want %+v", i, usages[i], w)
 		}
+	}
+}
+
+func TestExtractTailUsageCapturesEntryTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	writeTailJSONL(t, path, []map[string]any{
+		{
+			"type":      "assistant",
+			"uuid":      "u1",
+			"timestamp": "2026-08-31T12:34:56.789Z",
+			"message": map[string]any{
+				"role":  "assistant",
+				"model": "claude-opus-4-7",
+				"usage": map[string]any{"input_tokens": 100, "output_tokens": 50},
+			},
+		},
+		// No timestamp field — Timestamp stays zero rather than defaulting to now.
+		{
+			"type": "assistant",
+			"uuid": "u2",
+			"message": map[string]any{
+				"role":  "assistant",
+				"model": "claude-opus-4-7",
+				"usage": map[string]any{"input_tokens": 7, "output_tokens": 3},
+			},
+		},
+	})
+
+	usages, err := ExtractTailUsage(path)
+	if err != nil {
+		t.Fatalf("ExtractTailUsage: %v", err)
+	}
+	if len(usages) != 2 {
+		t.Fatalf("ExtractTailUsage = %d entries, want 2: %+v", len(usages), usages)
+	}
+	want := time.Date(2026, 8, 31, 12, 34, 56, 789000000, time.UTC)
+	if !usages[0].Timestamp.Equal(want) {
+		t.Errorf("usages[0].Timestamp = %v, want %v", usages[0].Timestamp, want)
+	}
+	if !usages[1].Timestamp.IsZero() {
+		t.Errorf("usages[1].Timestamp = %v, want zero", usages[1].Timestamp)
 	}
 }
 

--- a/internal/worker/invocation_telemetry.go
+++ b/internal/worker/invocation_telemetry.go
@@ -220,7 +220,9 @@ func (h *SessionHandle) recordInvocationTelemetry(ctx context.Context) {
 // recordInvocationTelemetry collapse a re-recorded invocation to one fact at the
 // sink via IdempotencyKey. Unpriced is true exactly when the pricing registry
 // had no entry for the (family, model) pair; cost is then left zero and must be
-// read as "not measured", never as a free invocation.
+// read as "not measured", never as a free invocation. At prefers the
+// transcript entry's own Timestamp when the extractor populated one, falling
+// back to now for providers whose tail extraction leaves it zero.
 func modelUsageFact(u sessionlog.TailUsage, meta map[string]string, beadID, sessionID, worker, providerFamily string, cost float64, priced bool, now time.Time) usage.Fact {
 	// beadID and sessionID are the session bead id and the run-id fallback — the
 	// same fields the retired ResolveRunID(bead.Metadata, bead.ID, sessionID) read
@@ -237,6 +239,10 @@ func modelUsageFact(u sessionlog.TailUsage, meta map[string]string, beadID, sess
 	if !priced {
 		cost = 0
 	}
+	at := now
+	if !u.Timestamp.IsZero() {
+		at = u.Timestamp
+	}
 	return usage.Fact{
 		RunID:     runID,
 		SessionID: strings.TrimSpace(sessionID),
@@ -252,7 +258,7 @@ func modelUsageFact(u sessionlog.TailUsage, meta map[string]string, beadID, sess
 		CostUSDEstimate:     cost,
 		Unpriced:            !priced,
 		UpstreamReqID:       reqID,
-		At:                  now.UnixMilli(),
+		At:                  at.UnixMilli(),
 		IdempotencyKey:      usage.ModelIdempotencyKey(runID, reqID),
 	}
 }

--- a/internal/worker/invocation_telemetry_usagefact_test.go
+++ b/internal/worker/invocation_telemetry_usagefact_test.go
@@ -259,6 +259,37 @@ func TestModelUsageFact(t *testing.T) {
 	}
 }
 
+// TestModelUsageFactPrefersEntryTimestampOverNow pins the At fallback
+// contract: when the extractor populated the transcript entry's own
+// Timestamp, At must use it instead of the wall-clock now the caller passed
+// in — that now is when the FOLLOWING prompt operation happened to observe
+// the completed invocation, not when the invocation itself ran.
+func TestModelUsageFactPrefersEntryTimestampOverNow(t *testing.T) {
+	now := time.Unix(1000, 0).UTC()
+	entryTime := time.Unix(1, 0).UTC()
+	u := sessionlog.TailUsage{
+		EntryUUID:   "entry-1",
+		Model:       "claude-opus-4-7",
+		InputTokens: 100,
+		Timestamp:   entryTime,
+	}
+	bead := beads.Bead{ID: "b1", Metadata: map[string]string{"molecule_id": "mol-7"}}
+
+	f := modelUsageFact(u, bead.Metadata, bead.ID, "session-1", "w", "claude", 0.02, true, now)
+	if f.At != entryTime.UnixMilli() {
+		t.Fatalf("At = %d, want the entry's own timestamp %d, not now (%d)", f.At, entryTime.UnixMilli(), now.UnixMilli())
+	}
+
+	// A zero Timestamp (older transcript format, or a provider whose tail
+	// extraction doesn't populate it) must fall back to now unchanged.
+	uNoTimestamp := u
+	uNoTimestamp.Timestamp = time.Time{}
+	fallback := modelUsageFact(uNoTimestamp, bead.Metadata, bead.ID, "session-1", "w", "claude", 0.02, true, now)
+	if fallback.At != now.UnixMilli() {
+		t.Fatalf("At = %d, want now (%d) when Timestamp is zero", fallback.At, now.UnixMilli())
+	}
+}
+
 func TestModelAndComputeFactsShareSessionIDJoinKey(t *testing.T) {
 	sessionID := "session-1"
 	model := usage.Fact{SessionID: sessionID}


### PR DESCRIPTION
## What

Addresses #5825, Defect 2 ("lags flushes one wake"). Defect 1 (cwd+time session-attribution ambiguity) is a genuine design decision — cross-provider fallout, a new persisted-schema field, and a policy call on unmatched fallback rows — declined, not addressed here.

Root cause: Claude transcript entries carry a real per-entry `timestamp` field, and codex rollout entries carry an analogous one already parsed — but only reused as a dedup key, its temporal value discarded. `TailUsage` had nowhere to carry it, so `modelUsageFact` had no choice but to stamp `Fact.At` with `now` (the wall-clock time of the *next* prompt operation that happened to observe the completed turn, not when the turn actually happened). `Fact.At` feeds window-based ledger analysis, which is why the issue reports a "phantom seat breach" — a fact recorded one wake late can land on the wrong side of an analysis window boundary.

## Fix

`tailEntry`/`TailUsage` now carry the transcript entry's own `Timestamp` (plain RFC3339 for Claude, matching `Entry.Timestamp`'s existing decode shape; RFC3339Nano→RFC3339 fallback for codex via the already-existing `parseCodexSessionTime` helper). `modelUsageFact` prefers it for `Fact.At`, falling back to `now` when zero/absent — so this can't regress behavior for older transcript formats or a provider whose tail extraction doesn't populate it. New tests cover both the preferred-timestamp path and the zero-timestamp fallback, plus extraction-level tests for both provider formats.

## Files

`internal/sessionlog/tail.go`, `tail_usage.go`, `codex_usage.go` + 2 test files, `internal/worker/invocation_telemetry.go` + 1 test file. 7 files, 127/11.

## Validation

- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- `go test -tags gms_pure_go ./internal/sessionlog/... ./internal/worker/...` — both packages pass
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts under heavy system load, lsof/detached-probe/systemctl-delegate tests, interrupt-timing tests in `internal/worker/adapters/zcode` — the last of which also fails on stock `main`, confirmed via `git stash`) unrelated to this change — none touch `tail.go`, `tail_usage.go`, `codex_usage.go`, or `invocation_telemetry.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)