### PR TITLE
fix: report session liveness while the controller runs

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -263,12 +263,16 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(&doctor.BeadsRoleCheck{})
 	}
 
-	// Controller check + supervisor HTTP check + session checks (gated by controller state).
+	// Controller check + supervisor HTTP check + session checks. Session
+	// checks are read-only reporting and register regardless of controller
+	// state (GH#5742); only their Fix() remediation defers to a running
+	// controller, guarded inside ZombieSessionsCheck.Fix and
+	// OrphanSessionsCheck.Fix via doctor.IsControllerRunning.
 	controllerRunning := opts.ControllerRunning
 	register(doctor.NewControllerCheck(cityPath, controllerRunning))
 	register(doctor.NewSupervisorHTTPCheck(opts.SupervisorRunning))
 
-	if cfgErr == nil && cfg != nil && !controllerRunning {
+	if cfgErr == nil && cfg != nil {
 		cityName := loadedCityName(cfg, cityPath)
 		st := cfg.Workspace.SessionTemplate
 		sp, err := newSessionProvider()

--- a/cmd/gc/cmd_doctor_extract_test.go
+++ b/cmd/gc/cmd_doctor_extract_test.go
@@ -95,6 +95,34 @@ func TestBuildDoctorChecksSkipsNamedAlwaysMinConflictCheckWithoutConfig(t *testi
 	}
 }
 
+// TestBuildDoctorChecksSessionLivenessChecksRegisteredRegardlessOfController_GH5742
+// is the inverted characterization test from ga-o04bfr.1.6: while the
+// controller runs, buildDoctorChecks must still register the read-only
+// session-liveness checks so a dead/zombie named session produces a doctor
+// finding instead of zero findings (gastownhall/gascity#5742).
+func TestBuildDoctorChecks_SessionLivenessChecksRegisteredRegardlessOfController_GH5742(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_DOLT", "skip")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Agents:    []config.Agent{{Name: "worker", ProcessNames: []string{"claude"}}},
+	}
+	sessionChecks := []string{"agent-sessions", "zombie-sessions", "orphan-sessions"}
+	for _, running := range []bool{true, false} {
+		names := doctorCheckNames(buildDoctorChecks(cityDir, cfg, nil, buildDoctorChecksOpts{
+			ControllerRunning: running, SkipCityDoltCheck: true, SkipManagedDoltCheck: true,
+		}))
+		for _, name := range sessionChecks {
+			if idx := doctorCheckIndex(names, name); idx < 0 {
+				t.Errorf("ControllerRunning=%v: %q expected but missing; names=%v", running, name, names)
+			}
+		}
+	}
+}
+
 func doctorCheckNames(checks []doctor.Check) []string {
 	names := make([]string, 0, len(checks))
 	for _, check := range checks {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -546,8 +546,13 @@ func (c *ZombieSessionsCheck) Run(_ *CheckContext) *CheckResult {
 // CanFix returns true — zombie sessions can be killed.
 func (c *ZombieSessionsCheck) CanFix() bool { return true }
 
-// Fix kills all zombie sessions.
-func (c *ZombieSessionsCheck) Fix(_ *CheckContext) error {
+// Fix kills all zombie sessions. It refuses while a controller is running
+// (GH#5742): the controller's own health patrol already reconciles zombie
+// sessions, and an uncoordinated Stop here would race it.
+func (c *ZombieSessionsCheck) Fix(ctx *CheckContext) error {
+	if IsControllerRunning(ctx.CityPath) {
+		return errControllerRunningFixSkipped
+	}
 	for _, a := range c.cfg.Agents {
 		if a.Suspended || len(a.ProcessNames) == 0 {
 			continue
@@ -627,8 +632,13 @@ func (c *OrphanSessionsCheck) Run(_ *CheckContext) *CheckResult {
 // CanFix returns true — orphan sessions can be killed.
 func (c *OrphanSessionsCheck) CanFix() bool { return true }
 
-// Fix kills all orphaned sessions.
-func (c *OrphanSessionsCheck) Fix(_ *CheckContext) error {
+// Fix kills all orphaned sessions. It refuses while a controller is running
+// (GH#5742): the controller's own health patrol already reconciles orphan
+// sessions, and an uncoordinated Stop here would race it.
+func (c *OrphanSessionsCheck) Fix(ctx *CheckContext) error {
+	if IsControllerRunning(ctx.CityPath) {
+		return errControllerRunningFixSkipped
+	}
 	prefix := "" // per-city socket isolation: all sessions belong to this city
 	running, err := c.sp.ListRunning(prefix)
 	if runtime.IsPartialListError(err) {
@@ -2887,6 +2897,13 @@ func (c *DoltVersionCheck) CanFix() bool { return false }
 
 // Fix is a no-op.
 func (c *DoltVersionCheck) Fix(_ *CheckContext) error { return nil }
+
+// errControllerRunningFixSkipped is returned by ZombieSessionsCheck.Fix and
+// OrphanSessionsCheck.Fix when a controller is running (GH#5742). The
+// controller's own health patrol already owns session remediation while it
+// runs; stopping sessions here too would race that reconciliation, so Fix
+// refuses instead of running — a documented no-op, not a silent skip.
+var errControllerRunningFixSkipped = errors.New("controller is running; skipping fix to avoid racing its own session reconciliation")
 
 // IsControllerRunning probes the controller lock file to determine if a
 // controller is currently running. It tries to acquire the flock — if it

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -11,6 +11,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -42,6 +45,37 @@ func setupCity(t *testing.T, tomlContent string) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+// holdControllerLock creates cityDir/.gc/controller.lock and takes an
+// exclusive flock on it, simulating a live controller for IsControllerRunning.
+// flock conflicts are per open-file-description, so IsControllerRunning's own
+// probe-open in this same process still observes the lock as held — exactly
+// how a separate controller process would. The lock is released via
+// t.Cleanup, so callers just call this and rely on it for the rest of the
+// test.
+func holdControllerLock(t *testing.T, cityDir string) {
+	t.Helper()
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatalf("mkdir .gc: %v", err)
+	}
+	path := filepath.Join(gcDir, "controller.lock")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		t.Fatalf("flock: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	})
 }
 
 // clearInheritedBeadsEnv scrubs GC_BEADS_SCOPE_ROOT (and related beads/dolt
@@ -879,6 +913,110 @@ func TestZombieSessionsCheck_Fix(t *testing.T) {
 	}
 }
 
+// TestZombieSessionsCheck_FixSkipsWhenControllerRunning is required by
+// ga-bq9vdi (GH#5742): ZombieSessionsCheck.Fix() kills sessions via the raw
+// runtime.Provider with neither fence engdocs/design/session-store-fences.md
+// requires for session-owned writers. The controller's own health patrol
+// already owns zombie remediation while it runs, so Fix() must re-check
+// doctor.IsControllerRunning and refuse — a documented error, not a crash or
+// a silent no-op that leaves --fix looking like it succeeded.
+func TestZombieSessionsCheck_FixSkipsWhenControllerRunning(t *testing.T) {
+	cityDir := t.TempDir()
+	holdControllerLock(t, cityDir)
+
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "mayor", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	sp.Zombies["mayor"] = true
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "mayor", ProcessNames: []string{"claude"}}},
+	}
+	c := NewZombieSessionsCheck(cfg, "test", "", sp)
+	err := c.Fix(&CheckContext{CityPath: cityDir})
+	if err == nil {
+		t.Fatal("Fix() error = nil, want refusal while controller is running")
+	}
+	if !strings.Contains(err.Error(), "controller is running") {
+		t.Errorf("Fix() error = %q, want it to explain the controller-running refusal", err.Error())
+	}
+	// The controller's own reconciler owns remediation while it runs — the
+	// zombie session must be left untouched, not raced.
+	if !sp.IsRunning("mayor") {
+		t.Error("zombie session was stopped despite controller running")
+	}
+	if n := sp.CountCalls("Stop", "mayor"); n != 0 {
+		t.Errorf("Stop called %d times, want 0 while controller is running", n)
+	}
+}
+
+// TestZombieSessionsCheck_FixDoesNotRaceControllerReconciliation is the
+// concurrency proof required by ga-bq9vdi (GH#5742) Scope item 3: a fake
+// controller reconciler tick (forensic capture, then stop-and-restart the
+// zombie) runs concurrently with doctor's own Fix() call against the same
+// session. With the controller-running guard in place, Fix() must defer
+// entirely — no double-stop, no interference with the reconciler's forensic
+// capture, and a final state that converges on whatever the reconciler did.
+func TestZombieSessionsCheck_FixDoesNotRaceControllerReconciliation(t *testing.T) {
+	cityDir := t.TempDir()
+	holdControllerLock(t, cityDir)
+
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "mayor", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	sp.Zombies["mayor"] = true
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "mayor", ProcessNames: []string{"claude"}}},
+	}
+	c := NewZombieSessionsCheck(cfg, "test", "", sp)
+
+	var forensicsCaptured int32
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Simulates the controller's own health-patrol reconciler tick, which
+	// owns zombie remediation while the controller is running: capture
+	// forensic state, stop the zombie, then restart it.
+	go func() {
+		defer wg.Done()
+		atomic.AddInt32(&forensicsCaptured, 1)
+		if err := sp.Stop("mayor"); err != nil {
+			t.Errorf("reconciler stop: %v", err)
+			return
+		}
+		if err := sp.Start(context.Background(), "mayor", runtime.Config{}); err != nil {
+			t.Errorf("reconciler restart: %v", err)
+		}
+	}()
+
+	// Concurrently, doctor's own --fix runs against the same session. With
+	// the controller live it must defer to the reconciler rather than issue
+	// a second, uncoordinated Stop.
+	var fixErr error
+	go func() {
+		defer wg.Done()
+		fixErr = c.Fix(&CheckContext{CityPath: cityDir})
+	}()
+
+	wg.Wait()
+
+	if fixErr == nil {
+		t.Fatal("Fix() error = nil, want refusal while controller is running")
+	}
+	if got := atomic.LoadInt32(&forensicsCaptured); got != 1 {
+		t.Fatalf("forensic capture ran %d times, want exactly 1 (owned solely by the reconciler)", got)
+	}
+	if n := sp.CountCalls("Stop", "mayor"); n != 1 {
+		t.Errorf("Stop(%q) called %d times, want exactly 1 (no double-stop)", "mayor", n)
+	}
+	if !sp.IsRunning("mayor") {
+		t.Error("session not running after reconciler restart — final state did not converge")
+	}
+}
+
 func TestZombieSessionsCheck_SkipsNoProcessNames(t *testing.T) {
 	sp := runtime.NewFake()
 	if err := sp.Start(context.Background(), "mayor", runtime.Config{}); err != nil {
@@ -954,6 +1092,43 @@ func TestOrphanSessionsCheck_Fix(t *testing.T) {
 	}
 	if !sp.IsRunning("mayor") {
 		t.Error("legitimate session was killed by fix")
+	}
+}
+
+// TestOrphanSessionsCheck_FixSkipsWhenControllerRunning is required by
+// ga-bq9vdi (GH#5742): OrphanSessionsCheck.Fix() kills sessions via the raw
+// runtime.Provider, racing the controller's own health patrol while it's
+// running. Fix() must re-check doctor.IsControllerRunning and refuse — a
+// documented error, not a crash or a silent no-op that leaves --fix looking
+// like it succeeded.
+func TestOrphanSessionsCheck_FixSkipsWhenControllerRunning(t *testing.T) {
+	cityDir := t.TempDir()
+	holdControllerLock(t, cityDir)
+
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "mayor", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.Start(context.Background(), "stale-worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "mayor"}},
+	}
+	c := NewOrphanSessionsCheck(cfg, "test", "", sp)
+	err := c.Fix(&CheckContext{CityPath: cityDir})
+	if err == nil {
+		t.Fatal("Fix() error = nil, want refusal while controller is running")
+	}
+	if !strings.Contains(err.Error(), "controller is running") {
+		t.Errorf("Fix() error = %q, want it to explain the controller-running refusal", err.Error())
+	}
+	if !sp.IsRunning("stale-worker") {
+		t.Error("orphan session was stopped despite controller running")
+	}
+	if n := sp.CountCalls("Stop", "stale-worker"); n != 0 {
+		t.Errorf("Stop called %d times, want 0 while controller is running", n)
 	}
 }
 

--- a/release-gates/ga-gmnj4h-doctor-session-liveness-gate.md
+++ b/release-gates/ga-gmnj4h-doctor-session-liveness-gate.md
@@ -1,0 +1,102 @@
+# Release gate: doctor session-liveness reporting while the controller runs
+
+- Deploy bead: `ga-gmnj4h`
+- Build bead: `ga-bq9vdi`
+- Review bead: `ga-muq5i1`
+- Reviewed source: `c9649b9acb5c8d06bd3c8e978f9ec30e17b39964`
+- Base checked: `origin/main@fcbd34178b1c86ec14f5b88ebc40dbe805f224ed`
+- Deploy branch: `deploy/ga-gmnj4h-gate`
+- Deploy mode: remote; push target: `fork`
+- Evaluated: 2026-09-02
+- Verdict: **PASS with three attributed, non-diff-owned test failures and one attributed local lint condition**
+
+## Gate checklist
+
+The target pre-flight ran before criterion 6. The reviewed source resolves to
+the full SHA above and is not carried by an existing pull request. Criterion 6
+was checked first and passed against the current fetched base, so the remaining
+criteria were evaluated.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review-of-record `ga-muq5i1` is closed with an explicit final PASS on the exact reviewed source. It independently records build, vet, test, security, coverage, and scope-compliance evidence. No review carryover is involved. |
+| 2 | Acceptance criteria met | **PASS** | `buildDoctorChecks` now registers the agent-session, zombie-session, and orphan-session checks whenever config loaded, regardless of controller state. Both destructive `Fix` paths re-check `IsControllerRunning` and return a documented refusal while the controller owns reconciliation. The registration, zombie refusal, orphan refusal, and concurrent reconciler tests cover all required branches. Startup-health episode code is untouched. The broader bounded tri-state observation work is explicitly split into follow-up `ga-xiukll`, consistent with this bead's recorded scope decision. |
+| 3 | Tests pass | **PASS with attributed failures** | The documented full-suite command completed all 40 jobs: **38 PASS / 2 raw FAIL / 0 SKIP jobs**. The two red jobs contain three top-level test failures, all non-diff-owned and attributed under criterion 3a. A fresh JSON-mode named probe reported **4 PASS / 0 FAIL / 0 SKIP** for every diff-owned test. `test_cmd_scope: full-suite`; `waiver_ref: none`. |
+| 3a | Pre-existing failures attributed | **PASS** | `TestBdFlagManifestCurrent` is tracked by `ga-f0uceo`; `TestE2E_SuspendResume_City` by `ga-dqd7gf`; and `TestCleanInstallTutorialPath`'s beads#4566 dirty-schema condition by `ga-esyijp`. Each tracker predates this run and was opened before attribution. Each failing command path is structurally unable to invoke the changed doctor code, and no failing test path overlaps the diff. Current sightings were appended and read back. |
+| 3b | Policy and static lanes | **PASS with one attributed local condition** | `make test-ci-policy` PASS; `make vet` PASS; `make fmt-check` PASS; `make build` PASS; `git diff --check origin/main...HEAD` PASS. `make lint` reported only three diagnostics in ignored, untracked dashboard `node_modules/flatted` Go code that is absent from `origin/main`; exact pre-existing tracker `ga-bvixfw` covers the condition. The candidate does not touch dashboard dependencies, and the sighting was appended and read back. |
+| 3c | CI-config lane | **PASS — n/a** | `ci_lane_run: n/a (no CI job, matrix, timeout, workflow, or required-check change)`. |
+| 4 | No high-severity review findings open | **PASS** | Unresolved HIGH findings: 0. The review records no blocking security, correctness, style, or coverage finding. |
+| 5 | Final branch is clean | **PASS** | The exact reviewed source was clean before branch creation. The gate checklist is the only deployer-authored file and will be committed separately on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | After a fresh fetch, `git merge-tree --write-tree origin/main c9649b9acb5c8d06bd3c8e978f9ec30e17b39964` returned tree `e78e3899d43b7969e06804a70ba62171b8a8c4c3` with exit 0 and no conflict messages against `origin/main@fcbd34178b1c86ec14f5b88ebc40dbe805f224ed`. No self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | Two TDD commits and four files implement one doctor/session-liveness theme: restore passive visibility while preserving the controller's exclusive remediation ownership. |
+
+## Full-suite test evidence
+
+`test_cmd_scope: full-suite`
+
+```text
+TMPDIR=/var/tmp \
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+TESTCONTAINERS_RYUK_DISABLED=true \
+LOCAL_TEST_LOG_DIR=/var/tmp/gc-gate-ga-gmnj4h-20260903/full \
+LOCAL_TEST_JOBS=4 \
+GO_TEST_TIMEOUT=30m \
+make test-local-full-parallel
+```
+
+The rootless Podman socket was present and `podman info` reported rootless
+operation before the run. Gas City's suite contains no testcontainers-backed
+test in this diff. All 40 documented full-runner jobs reached a terminal state;
+raw logs are retained at the path above.
+
+- `test_counts: 38 PASS jobs, 2 attributed raw FAIL jobs, 0 SKIP jobs`
+- `raw_test_failures: 3 attributed FAIL, none diff-owned`
+- `diff_tests_executed: 4 PASS, 0 FAIL, 0 SKIP`
+- `skip_justification: n/a for job results; no diff-owned test skipped`
+- `waiver_ref: none`
+
+Named diff-owned results from the fresh JSON-mode supplemental probe:
+
+- `TestBuildDoctorChecks_SessionLivenessChecksRegisteredRegardlessOfController_GH5742` — PASS
+- `TestZombieSessionsCheck_FixSkipsWhenControllerRunning` — PASS
+- `TestZombieSessionsCheck_FixDoesNotRaceControllerReconciliation` — PASS
+- `TestOrphanSessionsCheck_FixSkipsWhenControllerRunning` — PASS
+
+## Raw failures and attribution
+
+| Raw result | Test | Tracker / proof |
+|---|---|---|
+| **FAIL — ATTRIBUTED** | `TestBdFlagManifestCurrent` | Open tracker `ga-f0uceo`, created 2026-08-15. Clause 3(a): the test compares the host-installed `bd` help surface to `internal/bdflags`; neither the installed binary nor that package is changed. `internal/bdflags` cannot import `cmd/gc` or `internal/doctor`, and there is no path overlap. |
+| **FAIL — ATTRIBUTED** | `TestE2E_SuspendResume_City` | Open tracker `ga-dqd7gf`, created 2026-09-02 before this run. Clause 3(a): the exact tracked full-suite condition timed out waiting for `citysus.report`; the scenario invokes `suspend`, `session kill`, and `resume`, never `doctor`, and no test path overlaps. |
+| **FAIL — ATTRIBUTED** | `TestCleanInstallTutorialPath` | Open root-condition tracker `ga-esyijp`, created 2026-08-29. Clause 3(a): the log has the tracked beads#4566 dirty-schema migration signature during `gc rig add`, followed by a missing `leases` table. The changed doctor paths are not invoked by rig-add/schema bootstrap, and no test path overlaps. |
+
+`failure_attribution`:
+
+- `TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a) mechanism — installed-binary/source-manifest skew; candidate unreachable`
+- `TestE2E_SuspendResume_City -> ga-dqd7gf | clause 3(a) mechanism — tracked report timeout in suspend/resume path; doctor code unreachable`
+- `TestCleanInstallTutorialPath -> ga-esyijp | clause 3(a) mechanism — tracked dirty-schema bootstrap condition; doctor code unreachable`
+
+`inconclusive-guard: n/a — all three attributions have decisive mechanism
+proof.` The diff changes no resource-census baseline and adds no suite target.
+
+## Policy-lane attribution
+
+`policy_lane: make test-ci-policy — PASS; make lint — raw FAIL attributed to ga-bvixfw; make vet — PASS; make fmt-check — PASS`
+
+`make lint` found two `govet` constant-inline diagnostics and one `revive`
+package-comment diagnostic in
+`internal/api/dashboardspa/web/node_modules/flatted/golang/pkg/flatted/flatted.go`.
+That ignored, untracked file is absent from `origin/main`, and the candidate
+changes neither dashboard code nor dependencies. Open tracker `ga-bvixfw`
+predates this run and names this exact full-lint condition; the current sighting
+was appended and verified.
+
+## Pre-flight and ancestry evidence
+
+- The recorded reviewed SHA passed a hex-only guard and resolved to the full
+  commit above.
+- `gh api repos/gastownhall/gascity/commits/c9649b9acb5c8d06bd3c8e978f9ec30e17b39964/pulls` returned no
+  pull request, so no already-merged or closed-PR reconciliation applies.
+- `assert_deploy_ancestry_scope origin/main c9649b9acb5c8d06bd3c8e978f9ec30e17b39964 ga-gmnj4h ga-bq9vdi`
+  passed. The accepted sibling ID is the confirmed build bead cited by both
+  source commits; no unrelated commit or `.claude/**` path rides in the range.


### PR DESCRIPTION
## What this changes

`gc doctor` now reports configured agent-session, zombie-session, and orphan-session liveness findings even while the controller is running. Previously those checks were not registered in that state, so a dead or zombie always-mode session could produce a false all-clear.

Remediation remains conservative: zombie and orphan `--fix` operations re-check controller liveness at execution time and refuse while the controller owns reconciliation.

## Review notes

- The change separates read-only observation from destructive remediation; it does not alter controller reconciliation.
- Startup-health episode checks are unchanged.
- Bounded tri-state observation and broader suspension semantics are intentionally outside this patch and tracked separately.

## Test plan

- [x] Run the documented 40-job full local suite; audit the three unrelated host/tooling failures and their pre-existing trackers in the release gate.
- [x] Verify all four new or modified doctor tests report explicit PASS with no FAIL or SKIP.
- [x] Run build, standalone vet, formatting, workflow-policy, and pre-push fast-suite checks.
- [x] Review the release gate: [`release-gates/ga-gmnj4h-doctor-session-liveness-gate.md`](release-gates/ga-gmnj4h-doctor-session-liveness-gate.md)