### PR TITLE
fix(order): thread resolved runtime vars into order-dispatch and persist for graph.v2

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -857,7 +857,11 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 		return 1
 	}
 
-	cookResult, err := molecule.Instantiate(context.Background(), moleculeStore, recipe, molecule.Options{})
+	// Thread the same caller vars used for validation above into instantiation.
+	// An empty Options here falls back to formula defaults only, so every
+	// {{var}} referencing a caller-supplied value renders empty (or its
+	// default) on the created bead text instead of the caller's value (#4668).
+	cookResult, err := molecule.Instantiate(context.Background(), moleculeStore, recipe, molecule.Options{Vars: vars})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -808,16 +808,17 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 	// GraphApplyStore and silently fall back to sequential creation. store stays
 	// the typed wrapper for the order-tracking bead operations below.
 	genericStore := store.Store
-	recipe, err := prepareOrderWispRecipe(context.Background(), genericStore, a, searchPaths, vars)
+	recipe, effectiveVars, err := prepareOrderWispRecipe(context.Background(), genericStore, a, searchPaths, vars)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	// Validate against the vars the caller supplied. Passing an empty Options here
+	// Validate against the resolved invocation vars (declared defaults
+	// applied), not the caller's raw --var map. Passing an empty Options here
 	// drops them, and ValidateRecipeRuntimeVars reads opts.Vars — so every
 	// `required = true` var reports as missing however many --var flags were given,
 	// making any formula with a required var unfireable as an order.
-	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: vars}); err != nil {
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: effectiveVars}); err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -857,11 +858,14 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 		return 1
 	}
 
-	// Thread the same caller vars used for validation above into instantiation.
-	// An empty Options here falls back to formula defaults only, so every
-	// {{var}} referencing a caller-supplied value renders empty (or its
-	// default) on the created bead text instead of the caller's value (#4668).
-	cookResult, err := molecule.Instantiate(context.Background(), moleculeStore, recipe, molecule.Options{Vars: vars})
+	// Thread the same resolved invocation vars used for validation above into
+	// instantiation. An empty Options here falls back to formula defaults
+	// only, so every {{var}} referencing a caller-supplied value renders
+	// empty (or its default) on the created bead text instead of the
+	// caller's value (#4668).
+	stampOrderWispRuntimeVars(recipe, effectiveVars)
+
+	cookResult, err := molecule.Instantiate(context.Background(), moleculeStore, recipe, molecule.Options{Vars: effectiveVars})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/graphv2"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/orders"
 )
@@ -2488,6 +2489,119 @@ title = "Do work"
 	}
 	if !foundControl {
 		t.Fatal("missing workflow-finalize control step")
+	}
+}
+
+// TestOrderRunGraphWorkflowPersistsRuntimeVars is the store-level regression
+// test for the graph.v2 stamping gap found on #4668: a caller var passed to a
+// graph.v2 order must be recoverable from the persisted root bead's
+// gc.graphv2_vars.v1 metadata (the key internal/dispatch/drain.go reads on
+// later fan-out), not just present on the in-memory recipe before
+// materialization.
+func TestOrderRunGraphWorkflowPersistsRuntimeVars(t *testing.T) {
+	cityDir := t.TempDir()
+	formulaDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, "fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cityToml := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[rigs]]
+name = "fixture"
+path = "fixture"
+
+[[agent]]
+name = "quinn"
+dir = "fixture"
+min_active_sessions = 0
+max_active_sessions = 2
+
+[[agent]]
+name = "control-dispatcher"
+max_active_sessions = 1
+
+[[agent]]
+name = "control-dispatcher"
+dir = "fixture"
+max_active_sessions = 1
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	graphFormula := `
+formula = "graph-var-work"
+version = 2
+contract = "graph.v2"
+
+[vars.subject]
+description = "Work subject"
+
+[[steps]]
+id = "step"
+title = "Do work"
+description = "Handle {{subject}} now."
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-var-work.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{
+		{Name: "var-patrol", Formula: "graph-var-work", Trigger: "cooldown", Interval: "15m", Pool: "fixture/quinn", FormulaLayer: formulaDir},
+	}
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunWithJSON(aa, "var-patrol", "", cityDir, beads.OrdersStore{Store: store}, eventLog, false, map[string]string{"subject": "widgets"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("store.ListOpen(): %v", err)
+	}
+
+	var root *beads.Bead
+	for i := range all {
+		if all[i].Title == "graph-var-work" {
+			root = &all[i]
+			break
+		}
+	}
+	if root == nil {
+		t.Fatalf("workflow root bead not found; beads=%#v", all)
+	}
+	raw := root.Metadata[graphv2.RuntimeVarsMetadataKey]
+	if raw == "" {
+		t.Fatalf("root bead %s metadata not stamped, want %s to persist caller vars", graphv2.RuntimeVarsMetadataKey, graphv2.RuntimeVarsMetadataKey)
+	}
+	got, err := graphv2.ParseRuntimeVarsMetadata(raw)
+	if err != nil {
+		t.Fatalf("ParseRuntimeVarsMetadata(%q): %v", raw, err)
+	}
+	if got["subject"] != "widgets" {
+		t.Fatalf("persisted runtime vars = %v, want subject=widgets", got)
+	}
+
+	var work *beads.Bead
+	for i := range all {
+		if all[i].Title == "Do work" {
+			work = &all[i]
+			break
+		}
+	}
+	if work == nil {
+		t.Fatalf("worker step bead not found; beads=%#v", all)
+	}
+	if want := "Handle widgets now."; work.Description != want {
+		t.Errorf("worker step description = %q, want %q (caller var must substitute into bead text)", work.Description, want)
 	}
 }
 

--- a/cmd/gc/order_args_channel_test.go
+++ b/cmd/gc/order_args_channel_test.go
@@ -8,8 +8,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/graphroute"
+	"github.com/gastownhall/gascity/internal/graphv2"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -80,16 +84,138 @@ title = "Work {i}"
 
 	// Without the var the required compile-time range var is unresolved and
 	// compilation fails — proving the var is what makes the recipe compile.
-	if _, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, nil); err == nil {
+	if _, _, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, nil); err == nil {
 		t.Fatal("prepareOrderWispRecipe with nil vars: expected failure for missing required range var n")
 	}
 
-	recipe, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, map[string]string{"n": "3"})
+	recipe, effectiveVars, err := prepareOrderWispRecipe(context.Background(), store, a, []string{dir}, map[string]string{"n": "3"})
 	if err != nil {
 		t.Fatalf("prepareOrderWispRecipe with vars: %v", err)
 	}
 	if len(recipe.Steps) != 4 {
 		t.Fatalf("len(recipe.Steps) = %d, want 4 (root + 3 loop iterations from n=3)", len(recipe.Steps))
+	}
+	// The resolved invocation vars must flow back to the caller so the wisp is
+	// instantiated with them (see #4668) — not discarded after compile.
+	if effectiveVars["n"] != "3" {
+		t.Fatalf("effectiveVars[n] = %q, want 3 (resolved vars returned for instantiation)", effectiveVars["n"])
+	}
+}
+
+// TestOrderRunSubstitutesCallerVarsInBeadText is the regression test for #4668:
+// a formula order dispatched with a caller var must substitute that value into
+// the instantiated bead text. The order-dispatch path previously discarded the
+// resolved invocation vars after compile and instantiated with
+// molecule.Options{}, so a {{var}} referencing a caller value rendered empty on
+// the created bead. The var lives only in the step description (the
+// title-only unresolved-var guard never catches it), reproducing the
+// reporter's silent empty-text symptom on the manual `gc order run` path.
+func TestOrderRunSubstitutesCallerVarsInBeadText(t *testing.T) {
+	dir := t.TempDir()
+	// subject is a declared-but-defaultless var: instantiation renders {{subject}}
+	// empty unless the caller value is threaded through to molecule.Instantiate.
+	formulaBody := `
+formula = "e1-var-text"
+version = 1
+
+[vars.subject]
+description = "Work subject"
+
+[[steps]]
+id = "work"
+title = "Work step"
+description = "Handle {{subject}} now."
+`
+	if err := os.WriteFile(filepath.Join(dir, "e1-var-text.toml"), []byte(strings.TrimSpace(formulaBody)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{Name: "textorder", Formula: "e1-var-text", Trigger: "manual", FormulaLayer: dir}}
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunWithJSON(aa, "textorder", "", t.TempDir(), beads.OrdersStore{Store: store}, nil, false, map[string]string{"subject": "widgets"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("store.ListOpen(): %v", err)
+	}
+	var work *beads.Bead
+	for i := range all {
+		if all[i].Title == "Work step" {
+			work = &all[i]
+			break
+		}
+	}
+	if work == nil {
+		t.Fatalf("work step bead not created; beads=%#v", all)
+	}
+	if want := "Handle widgets now."; work.Description != want {
+		t.Errorf("step description = %q, want %q (caller var must substitute into bead text)", work.Description, want)
+	}
+}
+
+// TestStampOrderWispRuntimeVarsPersistsForGraphV2 is the regression test for
+// the review gap found on #4668: a graph.v2 order wisp must persist its
+// resolved runtime vars onto the root (and any drain step) so a later
+// fan-out/drain can recover the caller's values, mirroring the sling and
+// formula-cook stamping paths (internal/sling/sling.go, cmd/gc/cmd_formula.go).
+// Without this stamp, internal/dispatch/drain.go's ParseRuntimeVarsMetadata
+// read finds nothing and the order-launched graph loses caller/default vars
+// after the initial instantiation.
+func TestStampOrderWispRuntimeVarsPersistsForGraphV2(t *testing.T) {
+	recipe := &formula.Recipe{
+		Steps: []formula.RecipeStep{
+			{
+				ID: "root",
+				Metadata: map[string]string{
+					beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+					beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+				},
+			},
+			{
+				ID:       "drain",
+				Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindDrain},
+			},
+			{
+				ID: "work",
+			},
+		},
+	}
+	if !graphroute.IsCompiledGraphWorkflow(recipe) {
+		t.Fatal("test fixture is not recognized as a compiled graph.v2 workflow; fix the fixture")
+	}
+
+	stampOrderWispRuntimeVars(recipe, map[string]string{"subject": "widgets"})
+
+	wantVars := map[string]string{"subject": "widgets"}
+	for _, id := range []string{"root", "drain"} {
+		var step *formula.RecipeStep
+		for i := range recipe.Steps {
+			if recipe.Steps[i].ID == id {
+				step = &recipe.Steps[i]
+				break
+			}
+		}
+		raw := step.Metadata[graphv2.RuntimeVarsMetadataKey]
+		if raw == "" {
+			t.Fatalf("step %q: %s metadata not stamped", id, graphv2.RuntimeVarsMetadataKey)
+		}
+		got, err := graphv2.ParseRuntimeVarsMetadata(raw)
+		if err != nil {
+			t.Fatalf("step %q: ParseRuntimeVarsMetadata(%q): %v", id, raw, err)
+		}
+		if got["subject"] != wantVars["subject"] {
+			t.Fatalf("step %q: parsed vars = %v, want %v", id, got, wantVars)
+		}
+	}
+
+	work := &recipe.Steps[2]
+	if _, ok := work.Metadata[graphv2.RuntimeVarsMetadataKey]; ok {
+		t.Fatalf("non-drain, non-root step %q must not be stamped", work.ID)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -2213,7 +2213,12 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 
-	cookResult, err := molecule.Instantiate(ctx, graphStore, recipe, molecule.Options{})
+	// Same fix as `gc order run` (cmd_order.go): thread the caller vars used
+	// for validation above into instantiation. An empty Options here falls
+	// back to formula defaults only, so every {{var}} referencing a
+	// caller-supplied value renders empty (or its default) on the created
+	// bead text instead of the caller's value (#4668).
+	cookResult, err := molecule.Instantiate(ctx, graphStore, recipe, molecule.Options{Vars: vars})
 	if err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1844,12 +1844,51 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, front *orders.
 	})
 }
 
-func prepareOrderWispRecipe(ctx context.Context, store beads.Store, a orders.Order, searchPaths []string, vars map[string]string) (*formula.Recipe, error) {
+// prepareOrderWispRecipe compiles an order's formula into a recipe and returns
+// the resolved invocation vars alongside it. The caller must thread those vars
+// into molecule.Instantiate; without them every {{var}} referencing a
+// caller-supplied value renders empty on the instantiated beads (#4668).
+func prepareOrderWispRecipe(ctx context.Context, store beads.Store, a orders.Order, searchPaths []string, vars map[string]string) (*formula.Recipe, map[string]string, error) {
 	inv, err := graphv2.PrepareInvocation(ctx, store, a.Formula, searchPaths, "", vars)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return formula.CompileWithoutRuntimeVarValidation(ctx, a.Formula, searchPaths, inv.Vars)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, a.Formula, searchPaths, inv.Vars)
+	if err != nil {
+		return nil, nil, err
+	}
+	return recipe, inv.Vars, nil
+}
+
+// stampOrderWispRuntimeVars records the resolved runtime vars on a graph.v2
+// order wisp root (and any drain steps) so downstream fan-out recovers the
+// caller-supplied values, mirroring the sling path's runtime-vars stamp. It
+// deliberately omits the input-convoy and root-key identity metadata that the
+// cook/sling stamps also write: order dispatch does not dedup wisps by root
+// key, and stamping one would suppress legitimate repeat runs of a scheduled
+// or event order. No-op for non-graph recipes or when no vars are supplied.
+func stampOrderWispRuntimeVars(recipe *formula.Recipe, vars map[string]string) {
+	if recipe == nil || len(recipe.Steps) == 0 || !graphroute.IsCompiledGraphWorkflow(recipe) {
+		return
+	}
+	runtimeVars := graphv2.RuntimeVarsMetadata(vars)
+	if runtimeVars == "" {
+		return
+	}
+	root := &recipe.Steps[0]
+	if root.Metadata == nil {
+		root.Metadata = make(map[string]string)
+	}
+	root.Metadata[graphv2.RuntimeVarsMetadataKey] = runtimeVars
+	for i := range recipe.Steps {
+		if recipe.Steps[i].Metadata[beadmeta.KindMetadataKey] != beadmeta.KindDrain {
+			continue
+		}
+		if recipe.Steps[i].Metadata == nil {
+			recipe.Steps[i].Metadata = make(map[string]string)
+		}
+		recipe.Steps[i].Metadata[graphv2.RuntimeVarsMetadataKey] = runtimeVars
+	}
 }
 
 func poolOrderRouteVisibilityWarning(a orders.Order, recipe *formula.Recipe) string {
@@ -2131,7 +2170,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if a.FormulaLayer != "" {
 		searchPaths = []string{a.FormulaLayer}
 	}
-	recipe, err := prepareOrderWispRecipe(ctx, store, a, searchPaths, vars)
+	recipe, effectiveVars, err := prepareOrderWispRecipe(ctx, store, a, searchPaths, vars)
 	if err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
@@ -2142,12 +2181,13 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
 		return
 	}
-	// Same fix as `gc order run` (cmd_order.go): validate against the supplied vars.
-	// An empty Options drops them and reports every required var as missing. On this
-	// path that is worse than on the manual one — the controller fires unattended, so
-	// a cooldown/cron order using a required var would fail on every tick with nobody
-	// reading the order.failed events.
-	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: vars}); err != nil {
+	// Same fix as `gc order run` (cmd_order.go): validate against the resolved
+	// invocation vars (declared defaults applied), not the caller's raw --var
+	// map. An empty Options drops them and reports every required var as
+	// missing. On this path that is worse than on the manual one — the
+	// controller fires unattended, so a cooldown/cron order using a required
+	// var would fail on every tick with nobody reading the order.failed events.
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: effectiveVars}); err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
 			Actor:   "controller",
@@ -2213,12 +2253,14 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 
-	// Same fix as `gc order run` (cmd_order.go): thread the caller vars used
-	// for validation above into instantiation. An empty Options here falls
-	// back to formula defaults only, so every {{var}} referencing a
-	// caller-supplied value renders empty (or its default) on the created
-	// bead text instead of the caller's value (#4668).
-	cookResult, err := molecule.Instantiate(ctx, graphStore, recipe, molecule.Options{Vars: vars})
+	// Same fix as `gc order run` (cmd_order.go): thread the resolved
+	// invocation vars used for validation above into instantiation. An empty
+	// Options here falls back to formula defaults only, so every {{var}}
+	// referencing a caller-supplied value renders empty (or its default) on
+	// the created bead text instead of the caller's value (#4668).
+	stampOrderWispRuntimeVars(recipe, effectiveVars)
+
+	cookResult, err := molecule.Instantiate(ctx, graphStore, recipe, molecule.Options{Vars: effectiveVars})
 	if err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -10549,3 +10549,72 @@ func TestOrderDispatchExecFailureEventBoundsTheOutputItCarries(t *testing.T) {
 		}
 	}
 }
+
+// TestDispatchWispSubstitutesCallerVarsIntoBeadText is the regression guard for
+// #4668: dispatchWisp must thread the caller's runtime vars into
+// molecule.Instantiate so a caller `--var` renders into the instantiated bead
+// TEXT (Title/Description), not just into compile-time control flow. The var
+// carries a non-empty default ("DEFAULT"), so the pre-fix path — which passed
+// an empty molecule.Options and fell back to defaults — rendered "DEFAULT"
+// instead of the caller value. This test fails on exactly that bug.
+func TestDispatchWispSubstitutesCallerVarsIntoBeadText(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "e-var-text.toml"), `
+formula = "e-var-text"
+version = 1
+
+[vars.subject]
+description = "subject to work on"
+default = "DEFAULT"
+
+[[steps]]
+id = "work"
+title = "Work on {{subject}}"
+description = "Handle {{subject}} now."
+`)
+
+	store := beads.NewMemStore()
+	a := orders.Order{Name: "text-order", Trigger: "manual", Formula: "e-var-text", FormulaLayer: dir}
+
+	m := &memoryOrderDispatcher{
+		rec:      events.Discard,
+		stderr:   lockedStderr(&bytes.Buffer{}),
+		cfg:      &config.City{},
+		cityName: "test-city",
+	}
+	m.dispatchWisp(context.Background(), store, execStoreTarget{}, a, t.TempDir(), "gc-tracking", map[string]string{"subject": "widgets"})
+
+	// The wisp root is a legacy molecule container; the substituted text lives
+	// on the "work" step bead. Find it by its rendered title prefix.
+	all, err := store.List(beads.ListQuery{IncludeClosed: true, AllowScan: true})
+	if err != nil {
+		t.Fatalf("store.List: %v", err)
+	}
+	var work *beads.Bead
+	for i := range all {
+		if strings.HasPrefix(all[i].Title, "Work on") {
+			work = &all[i]
+			break
+		}
+	}
+	if work == nil {
+		var titles []string
+		for _, b := range all {
+			titles = append(titles, b.Title)
+		}
+		t.Fatalf("no step bead with title prefix %q created; titles=%v", "Work on", titles)
+	}
+
+	if !strings.Contains(work.Description, "widgets") {
+		t.Fatalf("step description = %q, want it to contain caller var value \"widgets\"", work.Description)
+	}
+	if !strings.Contains(work.Title, "widgets") {
+		t.Fatalf("step title = %q, want it to contain caller var value \"widgets\"", work.Title)
+	}
+	if strings.Contains(work.Description, "DEFAULT") {
+		t.Fatalf("step description = %q still shows the var default; caller --var did not reach molecule.Instantiate (the #4668 bug)", work.Description)
+	}
+	if strings.Contains(work.Description, "{{subject}}") {
+		t.Fatalf("step description = %q left the placeholder unresolved", work.Description)
+	}
+}


### PR DESCRIPTION
## Summary

Order dispatch resolved a formula's invocation vars (defaults + caller-supplied
overrides) to validate the recipe, then instantiated the recipe with the raw
caller-supplied vars instead of the resolved set. Any `{{var}}` reference that
depended on a default (not explicitly passed by the caller) rendered empty on
the instantiated beads. This affected both order-dispatch paths: the manual
`gc order run` CLI and the controller's scheduled `dispatchWisp`.

For graph.v2 order wisps, the resolved vars were also never persisted onto the
root/drain step metadata, so fan-out and drain recovery during a scheduled
graph workflow run had no way to recover the caller's runtime vars.

## Changes

- `prepareOrderWispRecipe` now returns the resolved invocation vars
  (`inv.Vars`) alongside the compiled recipe.
- Both order-dispatch call sites (`gc order run`'s `doOrderRunWithJSON`, and
  the controller's `dispatchWisp`) validate and instantiate using the
  resolved vars, not the raw caller-supplied map.
- New `stampOrderWispRuntimeVars` helper stamps `gc.graphv2_vars.v1` metadata
  onto a graph.v2 order wisp's root step and any `gc.kind=drain` steps,
  mirroring the existing sling-path stamp, so scheduled graph-workflow orders
  recover their runtime vars the same way sling-dispatched ones do.

## Test plan

- [x] `TestPrepareOrderWispRecipeThreadsVarsToFormula` (updated for new return signature)
- [x] `TestOrderRunSubstitutesCallerVarsInBeadText` — manual `gc order run` e2e substitution
- [x] `TestStampOrderWispRuntimeVarsPersistsForGraphV2` — metadata stamping unit test
- [x] `TestOrderRunGraphWorkflowPersistsRuntimeVars` — full store-level graph.v2 persistence e2e
- [x] `go build ./...`, `go vet ./cmd/gc/...`, full `cmd/gc` package suite: green
- [x] Multi-model review (Claude x3 + Codex gpt-5.4 + Copilot gpt-5.3-codex): all PASS, no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)