### PR TITLE
fix(test): leak-guard reap probes an injected liveness, not the real process table

### DIFF
--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -214,7 +214,7 @@ func TestRequireNoLeakedDoltAfter_OnlyNewPIDsInDiff(t *testing.T) {
 	if !strings.Contains(msg, strconv.Itoa(leakedPID)) {
 		t.Errorf("error missing leaked PID %d; got %q", leakedPID, msg)
 	}
-	if strings.Contains(msg, "pid=1000") {
+	if strings.Contains(msg, "pid=1000 ") {
 		t.Errorf("error must not include pre-existing PID 1000; got %q", msg)
 	}
 }

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -59,6 +60,36 @@ func (r *recordingTB) runCleanups() {
 	}
 }
 
+// linuxPIDMaxLimit is PID_MAX_LIMIT on 64-bit Linux (1<<22), the hard
+// ceiling /proc/sys/kernel/pid_max can be raised to. Used only as the
+// fallback when that file is unreadable.
+const linuxPIDMaxLimit = 4194304
+
+// unallocatablePIDs returns n ascending pids the kernel cannot have assigned
+// to any process on this host, because they sit above /proc/sys/kernel/pid_max.
+//
+// The leak guard's liveness probe is injected in these tests, so a colliding
+// pid no longer changes any outcome; picking unallocatable pids is defense in
+// depth against a future call site that pairs a fake killer with the real
+// prober again. That pairing is what made ga-ay6x1 deterministically red: the
+// fabricated pids 50001/50002 named two live dolt children on this host, so
+// the reap polled the real process table until its 5s deadline and appended a
+// cleanup-failure Errorf per pid.
+func unallocatablePIDs(t *testing.T, n int) []int {
+	t.Helper()
+	ceiling := linuxPIDMaxLimit
+	if raw, err := os.ReadFile("/proc/sys/kernel/pid_max"); err == nil {
+		if parsed, convErr := strconv.Atoi(strings.TrimSpace(string(raw))); convErr == nil && parsed > 0 {
+			ceiling = parsed
+		}
+	}
+	pids := make([]int, n)
+	for i := range pids {
+		pids[i] = ceiling + 1 + i
+	}
+	return pids
+}
+
 func doltTestProc(pid int, args ...string) DoltProcInfo {
 	configPath := filepath.Join(
 		"/tmp",
@@ -111,8 +142,9 @@ func TestRequireNoLeakedDoltAfter_NoChangeNoError(t *testing.T) {
 // log. This is the regression that originally motivated the helper
 // (3.3 GiB OOM from un-reaped dolt children — see ga-de27g).
 func TestRequireNoLeakedDoltAfter_NewPIDReportedWithArgv(t *testing.T) {
+	leakedPID := unallocatablePIDs(t, 1)[0]
 	leaked := DoltProcInfo{
-		PID:  99999,
+		PID:  leakedPID,
 		Argv: []string{"dolt", "sql-server", "--config=/tmp/Test123/.gc/runtime/dolt.yaml"},
 	}
 	enumerate := scriptedDoltEnumerator(t,
@@ -129,8 +161,8 @@ func TestRequireNoLeakedDoltAfter_NewPIDReportedWithArgv(t *testing.T) {
 		t.Fatalf("expected exactly 1 Errorf, got %d: %v", len(inner.errors), inner.errors)
 	}
 	msg := inner.errors[0]
-	if !strings.Contains(msg, "99999") {
-		t.Errorf("error message missing leaked PID 99999; got %q", msg)
+	if !strings.Contains(msg, strconv.Itoa(leakedPID)) {
+		t.Errorf("error message missing leaked PID %d; got %q", leakedPID, msg)
 	}
 	for _, arg := range leaked.Argv {
 		if !strings.Contains(msg, arg) {
@@ -165,8 +197,9 @@ func TestRequireNoLeakedDoltAfter_PreExistingPIDsNotReported(t *testing.T) {
 // only the new one appears in the error message. This proves the diff
 // is computed (cleanup minus initial), not re-reported in full.
 func TestRequireNoLeakedDoltAfter_OnlyNewPIDsInDiff(t *testing.T) {
+	leakedPID := unallocatablePIDs(t, 1)[0]
 	preexisting := doltTestProc(1000)
-	leaked := doltTestProc(9999, "--leaked")
+	leaked := doltTestProc(leakedPID, "--leaked")
 	enumerate := scriptedDoltEnumerator(t,
 		[]DoltProcInfo{preexisting},
 		[]DoltProcInfo{preexisting, leaked},
@@ -175,13 +208,13 @@ func TestRequireNoLeakedDoltAfter_OnlyNewPIDsInDiff(t *testing.T) {
 	requireNoLeakedDoltAfterWith(inner, enumerate)
 	inner.runCleanups()
 	if !inner.failed() {
-		t.Fatalf("expected leak Errorf for PID 9999; nothing recorded")
+		t.Fatalf("expected leak Errorf for PID %d; nothing recorded", leakedPID)
 	}
 	msg := strings.Join(inner.errors, "\n")
-	if !strings.Contains(msg, "9999") {
-		t.Errorf("error missing leaked PID 9999; got %q", msg)
+	if !strings.Contains(msg, strconv.Itoa(leakedPID)) {
+		t.Errorf("error missing leaked PID %d; got %q", leakedPID, msg)
 	}
-	if strings.Contains(msg, "1000") {
+	if strings.Contains(msg, "pid=1000") {
 		t.Errorf("error must not include pre-existing PID 1000; got %q", msg)
 	}
 }
@@ -194,8 +227,10 @@ func TestRequireNoLeakedDoltAfter_OnlyNewPIDsInDiff(t *testing.T) {
 //  2. PIDs are listed in ascending numerical order regardless of how
 //     the enumerator returns them.
 func TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted(t *testing.T) {
-	leakedHi := doltTestProc(50002, "--port=3308")
-	leakedLo := doltTestProc(50001, "--port=3307")
+	pids := unallocatablePIDs(t, 2)
+	lo, hi := pids[0], pids[1]
+	leakedHi := doltTestProc(hi, "--port=3308")
+	leakedLo := doltTestProc(lo, "--port=3307")
 	enumerate := scriptedDoltEnumerator(t,
 		nil,
 		// Order in slice deliberately unsorted to verify the helper sorts.
@@ -212,13 +247,13 @@ func TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted(t *testing.T) {
 			len(inner.errors), inner.errors)
 	}
 	msg := inner.errors[0]
-	iLo := strings.Index(msg, "50001")
-	iHi := strings.Index(msg, "50002")
+	iLo := strings.Index(msg, strconv.Itoa(lo))
+	iHi := strings.Index(msg, strconv.Itoa(hi))
 	if iLo == -1 {
-		t.Errorf("error missing PID 50001; got %q", msg)
+		t.Errorf("error missing PID %d; got %q", lo, msg)
 	}
 	if iHi == -1 {
-		t.Errorf("error missing PID 50002; got %q", msg)
+		t.Errorf("error missing PID %d; got %q", hi, msg)
 	}
 	if iLo != -1 && iHi != -1 && iLo > iHi {
 		t.Errorf("PIDs not in ascending order; got %q", msg)
@@ -254,10 +289,12 @@ func TestRequireNoLeakedDoltAfter_NewNonTestPIDIgnored(t *testing.T) {
 }
 
 func TestRequireNoLeakedDoltAfterWithFilterIgnoresUnownedTempPID(t *testing.T) {
+	pids := unallocatablePIDs(t, 2)
+	ownedPID, unownedPID := pids[0], pids[1]
 	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
 	unownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "other-city")
 	owned := DoltProcInfo{
-		PID: 1001,
+		PID: ownedPID,
 		Argv: []string{
 			"dolt",
 			"sql-server",
@@ -266,7 +303,7 @@ func TestRequireNoLeakedDoltAfterWithFilterIgnoresUnownedTempPID(t *testing.T) {
 		},
 	}
 	unowned := DoltProcInfo{
-		PID: 1002,
+		PID: unownedPID,
 		Argv: []string{
 			"dolt",
 			"sql-server",
@@ -288,18 +325,20 @@ func TestRequireNoLeakedDoltAfterWithFilterIgnoresUnownedTempPID(t *testing.T) {
 		t.Fatalf("expected scoped leak Errorf for owned PID; nothing recorded")
 	}
 	msg := strings.Join(inner.errors, "\n")
-	if !strings.Contains(msg, "1001") {
-		t.Fatalf("error missing owned leaked PID 1001; got %q", msg)
+	if !strings.Contains(msg, strconv.Itoa(ownedPID)) {
+		t.Fatalf("error missing owned leaked PID %d; got %q", ownedPID, msg)
 	}
-	if strings.Contains(msg, "1002") {
-		t.Fatalf("error included unowned leaked PID 1002; got %q", msg)
+	if strings.Contains(msg, strconv.Itoa(unownedPID)) {
+		t.Fatalf("error included unowned leaked PID %d; got %q", unownedPID, msg)
 	}
 }
 
 func TestRequireNoLeakedDoltAfterWithFilterReportsAndKillsOwnedPID(t *testing.T) {
+	pids := unallocatablePIDs(t, 2)
+	ownedPID, unownedPID := pids[0], pids[1]
 	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
 	owned := DoltProcInfo{
-		PID: 1001,
+		PID: ownedPID,
 		Argv: []string{
 			"dolt",
 			"sql-server",
@@ -308,7 +347,7 @@ func TestRequireNoLeakedDoltAfterWithFilterReportsAndKillsOwnedPID(t *testing.T)
 		},
 	}
 	unowned := DoltProcInfo{
-		PID: 1002,
+		PID: unownedPID,
 		Argv: []string{
 			"dolt",
 			"sql-server",
@@ -326,37 +365,38 @@ func TestRequireNoLeakedDoltAfterWithFilterReportsAndKillsOwnedPID(t *testing.T)
 	}
 	var killed []killCall
 	inner := &recordingTB{}
-	requireNoLeakedDoltAfterWithFilterAndKiller(inner, enumerate, func(configPath string) bool {
+	requireNoLeakedDoltAfterWithFilterAndReaper(inner, enumerate, func(configPath string) bool {
 		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
-	}, func(pid int, sig syscall.Signal) error {
+	}, scriptedDoltLeakReaper(func(pid int, sig syscall.Signal) error {
 		killed = append(killed, killCall{pid: pid, sig: sig})
 		return nil
-	})
+	}))
 	inner.runCleanups()
 
 	if !inner.failed() {
 		t.Fatalf("expected leak Errorf for owned PID; nothing recorded")
 	}
 	wantKilled := []killCall{
-		{pid: 1001, sig: syscall.SIGTERM},
-		{pid: 1001, sig: syscall.SIGKILL},
+		{pid: ownedPID, sig: syscall.SIGTERM},
+		{pid: ownedPID, sig: syscall.SIGKILL},
 	}
 	if fmt.Sprint(killed) != fmt.Sprint(wantKilled) {
 		t.Fatalf("killed = %v, want %v", killed, wantKilled)
 	}
 	msg := strings.Join(inner.errors, "\n")
-	if !strings.Contains(msg, "1001") {
-		t.Fatalf("error missing owned leaked PID 1001; got %q", msg)
+	if !strings.Contains(msg, strconv.Itoa(ownedPID)) {
+		t.Fatalf("error missing owned leaked PID %d; got %q", ownedPID, msg)
 	}
-	if strings.Contains(msg, "1002") {
-		t.Fatalf("error included unowned leaked PID 1002; got %q", msg)
+	if strings.Contains(msg, strconv.Itoa(unownedPID)) {
+		t.Fatalf("error included unowned leaked PID %d; got %q", unownedPID, msg)
 	}
 }
 
 func TestRequireNoLeakedDoltAfterWithFilterReportsKillErrors(t *testing.T) {
+	ownedPID := unallocatablePIDs(t, 1)[0]
 	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
 	owned := DoltProcInfo{
-		PID: 1001,
+		PID: ownedPID,
 		Argv: []string{
 			"dolt",
 			"sql-server",
@@ -366,22 +406,64 @@ func TestRequireNoLeakedDoltAfterWithFilterReportsKillErrors(t *testing.T) {
 	}
 	enumerate := scriptedDoltEnumerator(t, nil, []DoltProcInfo{owned})
 	inner := &recordingTB{}
-	requireNoLeakedDoltAfterWithFilterAndKiller(inner, enumerate, func(configPath string) bool {
+	requireNoLeakedDoltAfterWithFilterAndReaper(inner, enumerate, func(configPath string) bool {
 		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
-	}, func(_ int, sig syscall.Signal) error {
+	}, scriptedDoltLeakReaper(func(_ int, sig syscall.Signal) error {
 		if sig == syscall.SIGTERM {
 			return errors.New("synthetic kill failure")
 		}
 		return nil
-	})
+	}))
 	inner.runCleanups()
 
 	msg := strings.Join(inner.errors, "\n")
 	if !strings.Contains(msg, "test leaked 1 dolt sql-server") {
 		t.Fatalf("error missing leak report; got %q", msg)
 	}
-	if !strings.Contains(msg, "SIGTERM pid 1001") || !strings.Contains(msg, "synthetic kill failure") {
+	if !strings.Contains(msg, fmt.Sprintf("SIGTERM pid %d", ownedPID)) || !strings.Contains(msg, "synthetic kill failure") {
 		t.Fatalf("error missing kill failure; got %q", msg)
+	}
+}
+
+// TestRequireNoLeakedDoltAfterReportsStillAlivePIDAsCleanupFailure is the
+// control for the injected-liveness fix. Injecting processNeverAlive
+// everywhere would be worthless if it also silenced genuine reap failures,
+// so this case drives the guard with a probe that keeps reporting the pid
+// alive after SIGKILL and pins both halves of the expected report: the leak
+// itself still aggregates into exactly one Errorf, and the unreaped pid
+// still produces its own separate cleanup-failure Errorf naming it.
+func TestRequireNoLeakedDoltAfterReportsStillAlivePIDAsCleanupFailure(t *testing.T) {
+	ownedPID := unallocatablePIDs(t, 1)[0]
+	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
+	owned := DoltProcInfo{
+		PID: ownedPID,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(ownedRoot, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	enumerate := scriptedDoltEnumerator(t, nil, []DoltProcInfo{owned})
+	inner := &recordingTB{}
+	neverDies := func(int) bool { return true }
+	requireNoLeakedDoltAfterWithFilterAndReaper(inner, enumerate, func(configPath string) bool {
+		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
+	}, func(pids []int) []error {
+		return reapDoltLeakPIDsWithKillerAndWaiter(pids, ignoreProcessSignal, neverDies, time.Millisecond, 30*time.Millisecond)
+	})
+	inner.runCleanups()
+
+	if len(inner.errors) != 2 {
+		t.Fatalf("expected one aggregated leak Errorf plus one cleanup-failure Errorf, got %d: %v",
+			len(inner.errors), inner.errors)
+	}
+	if !strings.Contains(inner.errors[0], "test leaked 1 dolt sql-server") {
+		t.Fatalf("first Errorf must be the aggregated leak report; got %q", inner.errors[0])
+	}
+	if !strings.Contains(inner.errors[1], "test leaked dolt cleanup failed") ||
+		!strings.Contains(inner.errors[1], strconv.Itoa(ownedPID)) {
+		t.Fatalf("second Errorf must name the unreaped pid %d as a cleanup failure; got %q", ownedPID, inner.errors[1])
 	}
 }
 

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -75,6 +75,12 @@ const linuxPIDMaxLimit = 4194304
 // fabricated pids 50001/50002 named two live dolt children on this host, so
 // the reap polled the real process table until its 5s deadline and appended a
 // cleanup-failure Errorf per pid.
+//
+// Prefer this on guard and reap paths, which must not consult the real
+// process table at all, and when a test needs several distinct dead pids.
+// For a single pid that merely has to be dead right now, prefer nonLivePID
+// (test_orphan_sweep_branches_test.go), which probes pidAlive and skips the
+// test on a collision.
 func unallocatablePIDs(t *testing.T, n int) []int {
 	t.Helper()
 	ceiling := linuxPIDMaxLimit
@@ -178,6 +184,10 @@ func TestRequireNoLeakedDoltAfter_NewPIDReportedWithArgv(t *testing.T) {
 // this subtraction the helper would false-positive on every host
 // running an unrelated dolt server.
 func TestRequireNoLeakedDoltAfter_PreExistingPIDsNotReported(t *testing.T) {
+	// A small, realistic pid is deliberate here rather than an
+	// unallocatablePIDs value: the guard deletes every pre-existing pid from
+	// the leak set before it reports or reaps, so this pid never reaches a
+	// killer or a liveness prober and needs no unallocatable guarantee.
 	preexisting := doltTestProc(1000)
 	enumerate := scriptedDoltEnumerator(t,
 		[]DoltProcInfo{preexisting}, // initial
@@ -198,6 +208,9 @@ func TestRequireNoLeakedDoltAfter_PreExistingPIDsNotReported(t *testing.T) {
 // is computed (cleanup minus initial), not re-reported in full.
 func TestRequireNoLeakedDoltAfter_OnlyNewPIDsInDiff(t *testing.T) {
 	leakedPID := unallocatablePIDs(t, 1)[0]
+	// Pre-existing pids are diffed out before any reap (see
+	// PreExistingPIDsNotReported), so the literal needs no unallocatable
+	// guarantee; it is also the anchor of the negative assertion below.
 	preexisting := doltTestProc(1000)
 	leaked := doltTestProc(leakedPID, "--leaked")
 	enumerate := scriptedDoltEnumerator(t,

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -121,14 +121,14 @@ func clearInheritedBeadsEnv(t *testing.T) {
 // does not false-positive the cleanup check.
 func requireNoLeakedDoltAfterForPaths(t *testing.T, paths ...string) {
 	t.Helper()
-	requireNoLeakedDoltAfterWithFilterAndKiller(t, discoverDoltProcesses, func(configPath string) bool {
+	requireNoLeakedDoltAfterWithFilterAndReaper(t, discoverDoltProcesses, func(configPath string) bool {
 		for _, path := range paths {
 			if path != "" && pathutil.PathWithin(path, configPath) {
 				return true
 			}
 		}
 		return false
-	}, killProcess)
+	}, reapDoltLeakPIDs)
 }
 
 type doltLeakGuardedTestingM struct {
@@ -525,19 +525,15 @@ func writeDoltLeakReport(w io.Writer, leaked []DoltProcInfo) {
 }
 
 func reapDoltLeakProcesses(leaked []DoltProcInfo) {
-	_ = reapDoltLeakProcessesWithKiller(leaked, killProcess)
-}
-
-func reapDoltLeakProcessesWithKiller(leaked []DoltProcInfo, killFn func(int, syscall.Signal) error) []error {
 	pids := make([]int, 0, len(leaked))
 	for _, proc := range leaked {
 		pids = append(pids, proc.PID)
 	}
-	return reapDoltLeakPIDsWithKiller(pids, killFn)
+	_ = reapDoltLeakPIDs(pids)
 }
 
 // doltLeakReapPollInterval and doltLeakReapDeadline bound how long
-// reapDoltLeakPIDsWithKiller waits for a signaled pid to actually leave the
+// reapDoltLeakPIDs waits for a signaled pid to actually leave the
 // process table after SIGKILL, instead of returning as soon as the signal
 // call itself succeeds. A signal delivered successfully only means the
 // kernel accepted it, not that the process has exited -- callers racing a
@@ -548,8 +544,14 @@ const (
 	doltLeakReapDeadline     = 5 * time.Second
 )
 
-func reapDoltLeakPIDsWithKiller(pids []int, killFn func(int, syscall.Signal) error) []error {
-	return reapDoltLeakPIDsWithKillerAndWaiter(pids, killFn, processStillAlive, doltLeakReapPollInterval, doltLeakReapDeadline)
+// reapDoltLeakPIDs is the real-process reaper: it signals the real process
+// table and probes the real process table. Signaling and probing are two
+// halves of one reaper and must agree about which process table they act
+// on, so they are paired here rather than injected separately -- a no-op
+// killer wired to the real prober signals nothing yet still polls the real
+// table, which is exactly how ga-ay6x1 went red.
+func reapDoltLeakPIDs(pids []int) []error {
+	return reapDoltLeakPIDsWithKillerAndWaiter(pids, killProcess, processStillAlive, doltLeakReapPollInterval, doltLeakReapDeadline)
 }
 
 // processStillAlive reports whether pid is still present in the process
@@ -618,6 +620,35 @@ func reapDoltLeakPIDsWithKillerAndWaiter(pids []int, killFn func(int, syscall.Si
 
 func ignoreProcessSignal(int, syscall.Signal) error {
 	return nil
+}
+
+// processNeverAlive is the scripted-pid counterpart to processStillAlive: it
+// reports every pid as already exited without consulting the real process
+// table. Any guard driven by a fake killer must probe with this, because a
+// no-op killer never signals anything -- probing the real table for a
+// fabricated pid that happens to name a live process on the host makes the
+// reap spin its whole deadline and emit a spurious cleanup failure
+// (ga-ay6x1).
+func processNeverAlive(int) bool {
+	return false
+}
+
+// scriptedDoltLeakReapPollInterval and scriptedDoltLeakReapDeadline bound
+// reaps over fabricated pids. Nothing real is ever signaled on that path, so
+// the bounds only need to be long enough to prove the poll happened; the
+// production bounds above stay untouched.
+const (
+	scriptedDoltLeakReapPollInterval = 5 * time.Millisecond
+	scriptedDoltLeakReapDeadline     = 200 * time.Millisecond
+)
+
+// scriptedDoltLeakReaper builds a reaper over fabricated pids, pairing the
+// given fake killer with processNeverAlive so the reap never touches the
+// real process table.
+func scriptedDoltLeakReaper(killFn func(int, syscall.Signal) error) func([]int) []error {
+	return func(pids []int) []error {
+		return reapDoltLeakPIDsWithKillerAndWaiter(pids, killFn, processNeverAlive, scriptedDoltLeakReapPollInterval, scriptedDoltLeakReapDeadline)
+	}
 }
 
 // TestReapDoltLeakPIDsWithKillerAndWaiter_WaitsForConfirmedExit proves the
@@ -691,16 +722,23 @@ func requireNoLeakedDoltAfterWith(t testReporter, enumerate func() ([]DoltProcIn
 	t.Helper()
 	homeDir, _ := os.UserHomeDir()
 	tempDir := os.TempDir()
-	requireNoLeakedDoltAfterWithFilterAndKiller(t, enumerate, func(configPath string) bool {
+	requireNoLeakedDoltAfterWithFilterAndReaper(t, enumerate, func(configPath string) bool {
 		return isTestConfigPath(configPath, homeDir, tempDir)
-	}, ignoreProcessSignal)
+	}, scriptedDoltLeakReaper(ignoreProcessSignal))
 }
 
 func requireNoLeakedDoltAfterWithFilter(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool) {
-	requireNoLeakedDoltAfterWithFilterAndKiller(t, enumerate, includeConfigPath, ignoreProcessSignal)
+	requireNoLeakedDoltAfterWithFilterAndReaper(t, enumerate, includeConfigPath, scriptedDoltLeakReaper(ignoreProcessSignal))
 }
 
-func requireNoLeakedDoltAfterWithFilterAndKiller(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool, killFn func(int, syscall.Signal) error) {
+// requireNoLeakedDoltAfterWithFilterAndReaper is the injectable form of the
+// leak guard. It takes the whole reaper rather than just its killer: the
+// killer and the liveness prober must agree about which process table they
+// act on, and injecting only the killer let a scripted guard signal nothing
+// while still polling the real table for its fabricated pids (ga-ay6x1).
+// Production passes reapDoltLeakPIDs; scripted-pid tests pass
+// scriptedDoltLeakReaper.
+func requireNoLeakedDoltAfterWithFilterAndReaper(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool, reap func([]int) []error) {
 	t.Helper()
 	initial := snapshotDoltProcessPIDsWithFilter(t, enumerate, includeConfigPath)
 	t.Cleanup(func() {
@@ -722,7 +760,7 @@ func requireNoLeakedDoltAfterWithFilterAndKiller(t testReporter, enumerate func(
 		}
 		t.Errorf("test leaked %d dolt sql-server process(es); ensure cleanup paths reach shutdownBeadsProvider, or call clearInheritedBeadsEnv to prevent inherited GC_BEADS=bd from triggering gc-beads-bd.sh:\n%s",
 			len(leaked), strings.Join(rep, "\n"))
-		for _, err := range reapDoltLeakPIDsWithKiller(pids, killFn) {
+		for _, err := range reap(pids) {
 			t.Errorf("test leaked dolt cleanup failed: %v", err)
 		}
 	})

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -563,12 +563,14 @@ func processStillAlive(pid int) bool {
 	return err == nil || !errors.Is(err, syscall.ESRCH)
 }
 
-// reapDoltLeakPIDsWithKillerAndWaiter is the injectable-liveness form of
-// reapDoltLeakPIDsWithKiller, used directly by unit tests for the reaper
-// itself; production callers go through the two-arg wrapper above. After
-// signaling, it polls aliveFn for each pid until it reports exited or the
-// shared deadline elapses, so the caller gets a confirmed exit rather than
-// a fire-and-forget signal send.
+// reapDoltLeakPIDsWithKillerAndWaiter is the fully injectable form of the
+// reaper, used directly by unit tests for the reaper itself. Callers go
+// through one of the two pairings above: reapDoltLeakPIDs (real killer +
+// real prober) in production, scriptedDoltLeakReaper (fake killer +
+// processNeverAlive) for fabricated pids. After signaling, it polls aliveFn
+// for each pid until it reports exited or the shared deadline elapses, so
+// the caller gets a confirmed exit rather than a fire-and-forget signal
+// send.
 func reapDoltLeakPIDsWithKillerAndWaiter(pids []int, killFn func(int, syscall.Signal) error, aliveFn func(int) bool, pollInterval, deadline time.Duration) []error {
 	var errs []error
 	for _, pid := range pids {

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -565,12 +565,12 @@ func processStillAlive(pid int) bool {
 
 // reapDoltLeakPIDsWithKillerAndWaiter is the fully injectable form of the
 // reaper, used directly by unit tests for the reaper itself. Callers go
-// through one of the two pairings above: reapDoltLeakPIDs (real killer +
-// real prober) in production, scriptedDoltLeakReaper (fake killer +
-// processNeverAlive) for fabricated pids. After signaling, it polls aliveFn
-// for each pid until it reports exited or the shared deadline elapses, so
-// the caller gets a confirmed exit rather than a fire-and-forget signal
-// send.
+// through one of the two pairings defined in this file: reapDoltLeakPIDs
+// (real killer + real prober) in production, defined above, and
+// scriptedDoltLeakReaper (fake killer + processNeverAlive) for fabricated
+// pids, defined below. After signaling, it polls aliveFn for each pid until
+// it reports exited or the shared deadline elapses, so the caller gets a
+// confirmed exit rather than a fire-and-forget signal send.
 func reapDoltLeakPIDsWithKillerAndWaiter(pids []int, killFn func(int, syscall.Signal) error, aliveFn func(int) bool, pollInterval, deadline time.Duration) []error {
 	var errs []error
 	for _, pid := range pids {
@@ -636,8 +636,12 @@ func processNeverAlive(int) bool {
 }
 
 // scriptedDoltLeakReapPollInterval and scriptedDoltLeakReapDeadline bound
-// reaps over fabricated pids. Nothing real is ever signaled on that path, so
-// the bounds only need to be long enough to prove the poll happened; the
+// reaps over fabricated pids, and are inert on that path: scriptedDoltLeakReaper
+// hardwires processNeverAlive, so the waiter's very first probe reports exited
+// and neither bound is ever reached. They exist only to satisfy the shared
+// waiter's bounded signature -- tuning them changes nothing. What a scripted
+// leak-path test actually pays is the waiter's unconditional 250ms
+// SIGTERM-then-SIGKILL grace, which these constants do not govern. The
 // production bounds above stay untouched.
 const (
 	scriptedDoltLeakReapPollInterval = 5 * time.Millisecond
@@ -720,6 +724,13 @@ func TestReapDoltLeakPIDsWithKillerAndWaiter_TimesOutWithClearPIDError(t *testin
 // thin wrapper above; unit tests for the leak-detector itself pass a
 // recordingTB and a scripted enumerator so the report can be captured
 // without spawning real dolt children.
+//
+// Scripted enumerators over fabricated pids only. It hardwires
+// scriptedDoltLeakReaper, which reports leaks and never kills anything, so a
+// caller passing the real enumerator discoverDoltProcesses would get real
+// leaks reported and left running. Real-process guards go through
+// requireNoLeakedDoltAfterForPaths, or pass reapDoltLeakPIDs directly to
+// requireNoLeakedDoltAfterWithFilterAndReaper.
 func requireNoLeakedDoltAfterWith(t testReporter, enumerate func() ([]DoltProcInfo, error)) {
 	t.Helper()
 	homeDir, _ := os.UserHomeDir()
@@ -729,6 +740,11 @@ func requireNoLeakedDoltAfterWith(t testReporter, enumerate func() ([]DoltProcIn
 	}, scriptedDoltLeakReaper(ignoreProcessSignal))
 }
 
+// requireNoLeakedDoltAfterWithFilter is requireNoLeakedDoltAfterWith with an
+// injectable config-path filter, for unit tests that exercise which processes
+// the guard treats as test-owned. The same scripted-enumerator contract
+// applies: the reaper is scriptedDoltLeakReaper, which reports and never
+// kills, so the enumerator must be scripted over fabricated pids.
 func requireNoLeakedDoltAfterWithFilter(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool) {
 	requireNoLeakedDoltAfterWithFilterAndReaper(t, enumerate, includeConfigPath, scriptedDoltLeakReaper(ignoreProcessSignal))
 }

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -14,6 +14,12 @@ import (
 
 const testNonLivePID = 2147483647
 
+// nonLivePID returns a pid that is dead right now, probing pidAlive and
+// skipping the test when the fixed sentinel is unexpectedly alive. For guard
+// and reap paths that must never probe the real process table, or when a test
+// needs several distinct dead pids, prefer unallocatablePIDs
+// (dolt_leak_helper_test.go), which derives pids above
+// /proc/sys/kernel/pid_max and never probes.
 func nonLivePID(t *testing.T) int {
 	t.Helper()
 	if pidAlive(testNonLivePID) {

--- a/cmd/gc/tmux_leak_guard_test.go
+++ b/cmd/gc/tmux_leak_guard_test.go
@@ -155,7 +155,7 @@ func reapTmuxLeakProcesses(procs []tmuxProcInfo) {
 	for _, p := range procs {
 		pids = append(pids, p.PID)
 	}
-	_ = reapDoltLeakPIDsWithKiller(pids, killProcess)
+	_ = reapDoltLeakPIDs(pids)
 }
 
 // sweepStaleTmuxTestServers reaps tmux servers left behind by prior or


### PR DESCRIPTION
## Bug

`TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted` fabricated PIDs
50001/50002 and drove the leak guard with the no-op killer
`ignoreProcessSignal` — but the guard's reap hardcoded the **real** liveness
prober `processStillAlive` (`syscall.Kill(pid, 0)`). The killer and the prober
are two halves of one reaper; splitting them meant the guard signalled nothing
while still polling the real process table for pids it had invented.

When a fabricated pid names a live process on the host, the reap therefore
spins its full 5s deadline and appends a `cleanup failed` `Errorf` per pid,
breaking the "exactly one aggregated Errorf" assertion:

```
--- FAIL: TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted (5.09s)
    dolt_leak_helper_test.go:211: multiple leaks must be aggregated into one Errorf, got 3
      ... pid 50001 still alive after SIGKILL and 5s wait (leak-guard reap timed out)
      ... pid 50002 still alive after SIGKILL and 5s wait (leak-guard reap timed out)
```

This is not flaky — it stays red for as long as the pid range is occupied. On
the reporting host `/proc/50001` and `/proc/50002` were both live `dolt`
children of one sql-server, so `make test-fast-parallel` failed deterministically
and blocked every push. Previously seen on CI as run 32587221748 (cmd/gc shard
12 of 12).

## Fix

Inject the whole reaper instead of just its killer, so the two halves cannot
be mismatched by construction:

- `requireNoLeakedDoltAfterWithFilterAndKiller(..., killFn)` becomes
  `requireNoLeakedDoltAfterWithFilterAndReaper(..., reap func([]int) []error)`.
  The guard's only use of `killFn` was to hand it to the reaper, so there is
  no longer a seam that accepts one half alone.
- Production (`requireNoLeakedDoltAfterForPaths`) passes `reapDoltLeakPIDs`,
  which pairs `killProcess` with `processStillAlive` at the production
  poll/deadline bounds — identical behaviour to before.
- Scripted-pid guards pass `scriptedDoltLeakReaper(fakeKiller)`, which pairs
  the fake killer with the new `processNeverAlive`. No test path consults the
  real process table for a fabricated pid any more.
- `reapDoltLeakPIDsWithKiller` and `reapDoltLeakProcessesWithKiller` are gone:
  both were "injectable killer + hardcoded real prober", the exact shape of
  this bug, and every remaining caller passed the real `killProcess`.

Defense in depth: fabricated pids now come from `unallocatablePIDs(t, n)`,
which reads `/proc/sys/kernel/pid_max` and returns `pid_max+1 …`. The kernel
never allocates above that ceiling, so collision is impossible by
construction. With the probe injected a collision no longer changes any
outcome; this guards a future call site that re-pairs a fake killer with the
real prober.

Control kept: `TestRequireNoLeakedDoltAfterReportsStillAlivePIDAsCleanupFailure`
drives the guard with a probe that reports the pid alive after SIGKILL and
pins that the aggregation still emits one leak `Errorf` **plus** a separate
cleanup-failure `Errorf` naming the pid — so swapping in `processNeverAlive`
cannot silence a genuine reap failure.

## RED → GREEN

Before, on a host where 50001/50002 are live:

```
--- FAIL: TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted (5.09s)
    dolt_leak_helper_test.go:211: multiple leaks must be aggregated into one Errorf, got 3
```

After: `--- PASS ... (0.25s)` — a 5.09s stall becomes 0.25s.

`go test ./cmd/gc -run 'DoltLeak|LeakedDolt|RequireNoLeaked' -count=1 -v` →
**19 `--- PASS`, 0 FAIL, 0 SKIP.**

Both new probes are load-bearing, verified by mutation:

| Mutation | Result |
| --- | --- |
| `processNeverAlive` → `return true` | `MultipleLeaksReportedSorted` fails with the original text: `multiple leaks must be aggregated into one Errorf, got 3` + `still alive after SIGKILL` |
| control's `neverDies` → `return false` | control fails with `expected one aggregated leak Errorf plus one cleanup-failure Errorf, got 1` |

The two mutations fail differently, so neither test is vacuous.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./cmd/gc` | pass |
| `go vet ./cmd/gc` | pass |
| `gofmt -l cmd/gc/` | clean |
| `golangci-lint run ./cmd/gc/...` | 0 issues |
| `./scripts/check-residency-boundary.sh` | pass (exit 0) |
| `make test-fast-parallel` | pass (green via the pre-push hook: all 10 jobs, `unit-core` + all 6 `unit-cmd-gc` shards) |

One earlier `make test-fast-parallel` run failed on
`internal/productmetrics/TestRecordOnceKeepsStoredEventWhenSpawnWindowExpires`,
a package this branch does not touch (`git diff origin/main...HEAD` is three
`cmd/gc/*_test.go` files). It passes 5/5 in isolation and passed on the
pre-push rerun; it is a wall-clock `defaultRecordDecisionBudget` flake under
16-way parallelism. Filed separately as `ga-2rlkv`.

Refs ga-ay6x1
