### PR TITLE
feat(storehealth): deterministic quarantine directory naming

### DIFF
--- a/internal/storehealth/quarantine.go
+++ b/internal/storehealth/quarantine.go
@@ -1,0 +1,104 @@
+package storehealth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// QuarantineDirName builds the forensic quarantine directory name for a
+// scope and sequence number: "<scope>-<seq>". The sequence is a monotonic
+// counter, NEVER a wall-clock or random value, so the names are
+// deterministic and tests can assert them exactly (plan item 1.5).
+//
+// scope is sanitized to a filesystem-safe token (path separators and other
+// awkward characters collapse to '_') because scope roots are absolute
+// paths.
+func QuarantineDirName(scope string, seq int) string {
+	return fmt.Sprintf("%s-%d", sanitizeScopeToken(scope), seq)
+}
+
+// NextQuarantineSeq returns the next monotonic sequence number for a scope
+// by scanning existing "<scope>-<n>" entries under quarantineRoot and
+// returning max(n)+1, or 0 when none exist. Derivation from directory
+// entries (rather than a wall-clock or random source) keeps reaps
+// deterministic and replayable. A read error on the root yields 0 so the
+// first reap after a missing root still produces a stable name.
+func NextQuarantineSeq(quarantineRoot, scope string) int {
+	token := sanitizeScopeToken(scope)
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil {
+		return 0
+	}
+	prefix := token + "-"
+	maxSeq := -1
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimPrefix(name, prefix))
+		if err != nil || n < 0 {
+			continue
+		}
+		if n > maxSeq {
+			maxSeq = n
+		}
+	}
+	return maxSeq + 1
+}
+
+// QuarantineDirPath joins the quarantine root with the next sequenced
+// directory name for a scope and returns the absolute path plus the seq.
+// It does not create the directory — the forensics hook does that.
+func QuarantineDirPath(quarantineRoot, scope string) (path string, seq int) {
+	seq = NextQuarantineSeq(quarantineRoot, scope)
+	return filepath.Join(quarantineRoot, QuarantineDirName(scope, seq)), seq
+}
+
+// sanitizeScopeToken collapses a scope root path into a filesystem-safe,
+// stable token: leading separators are dropped and every remaining
+// separator or awkward character becomes '_'. Two distinct scopes never
+// collide because the full path is preserved (only the separators change).
+func sanitizeScopeToken(scope string) string {
+	scope = strings.TrimSpace(scope)
+	scope = strings.Trim(scope, string(filepath.Separator))
+	if scope == "" {
+		return "scope"
+	}
+	var b strings.Builder
+	for _, r := range scope {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// sortedQuarantineSeqs returns the existing sequence numbers for a scope in
+// ascending order. Helper for tests asserting deterministic accumulation.
+func sortedQuarantineSeqs(quarantineRoot, scope string) []int {
+	token := sanitizeScopeToken(scope)
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil {
+		return nil
+	}
+	prefix := token + "-"
+	var seqs []int
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		if n, err := strconv.Atoi(strings.TrimPrefix(e.Name(), prefix)); err == nil && n >= 0 {
+			seqs = append(seqs, n)
+		}
+	}
+	sort.Ints(seqs)
+	return seqs
+}

--- a/internal/storehealth/quarantine_test.go
+++ b/internal/storehealth/quarantine_test.go
@@ -1,0 +1,88 @@
+package storehealth
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestQuarantineDirNameDeterministic asserts the name is a pure function of
+// (scope, seq) — never wall-clock or random.
+func TestQuarantineDirNameDeterministic(t *testing.T) {
+	const scope = "/Users/Shared/city/rigs/vr"
+	got1 := QuarantineDirName(scope, 0)
+	got2 := QuarantineDirName(scope, 0)
+	if got1 != got2 {
+		t.Fatalf("non-deterministic name: %q != %q", got1, got2)
+	}
+	if got := QuarantineDirName(scope, 7); filepath.Base(got) != got {
+		t.Fatalf("name %q contains a path separator; must be a single dir component", got)
+	}
+	// Distinct seqs yield distinct names.
+	if QuarantineDirName(scope, 0) == QuarantineDirName(scope, 1) {
+		t.Fatalf("seq 0 and 1 produced the same name")
+	}
+	// Distinct scopes yield distinct names.
+	if QuarantineDirName("/a/b", 0) == QuarantineDirName("/a/c", 0) {
+		t.Fatalf("distinct scopes collided")
+	}
+}
+
+// TestNextQuarantineSeqMonotonic asserts the seq is max(existing)+1, derived
+// from directory entries, and starts at 0 on an empty/missing root.
+func TestNextQuarantineSeqMonotonic(t *testing.T) {
+	root := t.TempDir()
+	const scope = "/city/rigs/hq"
+
+	if got := NextQuarantineSeq(root, scope); got != 0 {
+		t.Fatalf("first seq on empty root = %d, want 0", got)
+	}
+
+	// Create seq 0, 1, 2 directories; next must be 3.
+	for i := 0; i < 3; i++ {
+		if err := os.Mkdir(filepath.Join(root, QuarantineDirName(scope, i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := NextQuarantineSeq(root, scope); got != 3 {
+		t.Fatalf("seq after 0,1,2 = %d, want 3", got)
+	}
+
+	// A different scope under the same root is independent.
+	if got := NextQuarantineSeq(root, "/city/rigs/vr"); got != 0 {
+		t.Fatalf("independent scope seq = %d, want 0", got)
+	}
+
+	// A gap (delete seq 1) must still yield max+1 = 3 (monotonic, not
+	// gap-filling), so names never collide with a prior reap's artifacts.
+	if err := os.RemoveAll(filepath.Join(root, QuarantineDirName(scope, 1))); err != nil {
+		t.Fatal(err)
+	}
+	if got := NextQuarantineSeq(root, scope); got != 3 {
+		t.Fatalf("seq after deleting middle entry = %d, want 3 (monotonic)", got)
+	}
+}
+
+// TestQuarantineDirPathSequencing asserts repeated path allocation (with
+// the directory actually created between calls) accumulates deterministic,
+// non-colliding sequence numbers.
+func TestQuarantineDirPathSequencing(t *testing.T) {
+	root := t.TempDir()
+	const scope = "/city"
+
+	var seqs []int
+	for i := 0; i < 4; i++ {
+		path, seq := QuarantineDirPath(root, scope)
+		seqs = append(seqs, seq)
+		if err := os.Mkdir(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	if !reflect.DeepEqual(seqs, []int{0, 1, 2, 3}) {
+		t.Fatalf("allocated seqs = %v, want [0 1 2 3]", seqs)
+	}
+	if got := sortedQuarantineSeqs(root, scope); !reflect.DeepEqual(got, []int{0, 1, 2, 3}) {
+		t.Fatalf("on-disk seqs = %v, want [0 1 2 3]", got)
+	}
+}


### PR DESCRIPTION
Part of the split of #3324 (closed) into independently reviewable pieces.

## What

Adds `internal/storehealth/quarantine.go` — a small, pure helper for naming
the forensic quarantine directory that a store-health reap writes its
evidence into.

- `QuarantineDirName(scope, seq)` — the name is a pure function of its two
  arguments.
- `NextQuarantineSeq(root, scope)` — the sequence is a monotonic counter
  derived by scanning existing `<scope>-<n>` entries under the quarantine
  root and returning `max(n)+1`, **never** a wall-clock or random value.
- `QuarantineDirPath(root, scope)` — joins the two; it does not create the
  directory (the forensics hook does that).

## Why the sequence is derived, not generated

Making the name a function of on-disk state rather than of the clock is
what makes reap artifacts deterministic and replayable, and it lets tests
assert exact names instead of matching a timestamp pattern. It is also
monotonic rather than gap-filling: deleting an intermediate directory does
not cause the next reap to reuse that number, so a new reap's artifacts can
never land on top of a prior reap's.

Scope roots are absolute paths, so the scope is collapsed to a
filesystem-safe single path component: separators and other awkward
characters become `_`, while the full path is preserved so two distinct
scopes can never collide.

## Scope

104 lines of implementation, 88 of tests. It stands alone: nothing else in
the tree references it yet, and it imports only the standard library
(`fmt`, `os`, `path/filepath`, `sort`, `strconv`, `strings`). The only I/O
is a single `os.ReadDir` of the quarantine root, and a read error there
yields seq 0 so the first reap after a missing root still produces a stable
name.

## A note on the earlier review

An earlier attempt at this area was closed as "proxy-coupled, not cleanly
separable". That was accurate about the *feature*, but not about this
*package*. This file has no proxy coupling at all — see the import list
above. The proxy coupling lives entirely in a separate file that is not
part of this PR (or of its follow-up), and none of it is proposed here.

## Verification

```
gofmt -l internal/storehealth/   # clean
go build ./...                   # ok
go vet ./internal/storehealth/   # ok
go test ./internal/storehealth/  # ok (3 new tests, 24 total in package)
```
