### PR TITLE
feat(storehealth): two-probe store-health patrol state machine

### DIFF
--- a/internal/storehealth/patrol.go
+++ b/internal/storehealth/patrol.go
@@ -1,0 +1,362 @@
+// Package storehealth implements the controller-internal store health
+// patrol (city-scale architecture plan item 1.5). Per scope, every
+// [storehealth] interval, it runs a two-probe matrix:
+//
+//   - Probe A: a routed-store read that forces a FRESH backend connection
+//     (the HQ poison hit new opens only — a pooled ride-along would miss
+//     it).
+//   - Probe B: a direct SELECT 1 against the managed dolt endpoint.
+//
+// The decision matrix (all thresholds from config, no judgment calls in
+// Go — the package holds only counters and comparisons):
+//
+//   - A-fail ∧ B-ok for ConsecutiveFails cycles ⇒ proxy poison. Capture
+//     forensics FIRST (goroutine dump + lsof + log tail into a quarantine
+//     dir), then reap the proxy via the injected lifecycle, trip the
+//     scope breaker until A passes, emit proxy.reaped + store.degraded
+//     (class transport). Rate-limited to one reap per scope per
+//     ReapCooldown; a second poison inside the window is alert-only with
+//     forensics kept.
+//   - A-ok ∧ B-fail ⇒ trip the breaker + doctor.alert, NEVER auto-kill the
+//     sql-server (emit store.degraded class backend).
+//   - A-ok ∧ B-ok ⇒ healthy; reset the consecutive counter and, if the
+//     scope was degraded, emit store.recovered.
+//
+// All side effects (probing, reaping, forensics, breaker, emission) are
+// injected through Hooks so the state machine is unit-testable with fakes
+// and holds no I/O of its own.
+package storehealth
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ProbeResult is the boolean outcome of one probe with an optional reason
+// string for forensic events. Ok=true means the probe succeeded.
+type ProbeResult struct {
+	Ok     bool
+	Reason string
+}
+
+// DegradeClass classifies a store degradation. The values mirror the
+// events package's store-degraded class constants; the patrol passes them
+// straight through to the emission hook.
+type DegradeClass string
+
+// Store degradation classes.
+const (
+	ClassTransport      DegradeClass = "transport"
+	ClassBackend        DegradeClass = "backend"
+	ClassWriteRejection DegradeClass = "write-rejection"
+)
+
+// Hooks are the injected side effects for one scope's patrol. Every field
+// is required for a live patrol; tests supply fakes. The patrol never
+// performs I/O directly — it only sequences these calls per the matrix.
+type Hooks struct {
+	// ProbeRoutedFresh runs probe A: a routed-store read forcing a fresh
+	// backend connection (e.g. a one-shot `bd list --limit 1` subprocess).
+	ProbeRoutedFresh func(ctx context.Context) ProbeResult
+	// ProbeBackendDirect runs probe B: a direct SELECT 1 against the
+	// managed dolt endpoint via the pooled connection.
+	ProbeBackendDirect func(ctx context.Context) ProbeResult
+	// CaptureForensics writes the pre-reap forensic bundle (SIGQUIT
+	// goroutine dump, lsof, log tail) into a quarantine directory and
+	// returns its path. Called before any reap.
+	CaptureForensics func(ctx context.Context) (dir string, err error)
+	// ReapProxy reaps the scope's db-proxy child(ren) via the existing
+	// lifecycle and returns the number of PIDs signaled.
+	ReapProxy func(ctx context.Context) (pidsSignaled int, err error)
+	// TripBreaker opens the scope's transport breaker so callers fail fast
+	// until probe A passes again. Idempotent.
+	TripBreaker func()
+	// EmitDegraded records a store.degraded event.
+	EmitDegraded func(class DegradeClass, reason string, consecutiveFails int)
+	// EmitRecovered records a store.recovered event.
+	EmitRecovered func(class DegradeClass)
+	// EmitProbeFailed records a per-cycle store.probe_failed breadcrumb.
+	EmitProbeFailed func(probe, reason string)
+	// EmitProxyReaped records a proxy.reaped event. rateLimited is true
+	// when a poison inside the cooldown window suppressed the reap.
+	EmitProxyReaped func(quarantineDir string, pidsSignaled int, rateLimited bool)
+	// EmitDoctorAlert records a doctor.alert (used for the A-ok∧B-fail
+	// backend-fault class, which never auto-kills the sql-server).
+	EmitDoctorAlert func(detail string)
+	// WriteProbe runs the write-path conformance probe: create+close one
+	// ephemeral bead of each RequiredCustomType through the normal store
+	// path. Ok=false with a reason means a persistent write rejection.
+	// Optional: nil disables the write-path probe for the scope.
+	WriteProbe func(ctx context.Context) ProbeResult
+}
+
+// Config holds the resolved thresholds for one scope's patrol. Durations
+// and counts only — the patrol makes no judgment calls.
+type Config struct {
+	// ConsecutiveFails is how many A-fail∧B-ok cycles confirm a poison.
+	ConsecutiveFails int
+	// ReapCooldown is the minimum spacing between reaps for the scope.
+	ReapCooldown time.Duration
+	// WriteProbeEvery is the cadence of the write-path conformance probe.
+	// Zero disables it even when Hooks.WriteProbe is set.
+	WriteProbeEvery time.Duration
+}
+
+// scopeState is the per-scope mutable patrol state. All fields are guarded
+// by mu so EvaluateCycle is safe to call from a single patrol goroutine
+// while State() is read concurrently for diagnostics.
+type scopeState struct {
+	mu sync.Mutex
+	// consecutiveTransportFails counts consecutive A-fail∧B-ok cycles.
+	consecutiveTransportFails int
+	// confirmed reports whether the current transport-poison episode has
+	// already crossed the confirm threshold. Once true, subsequent poison
+	// ticks skip the once-per-episode side effects (forensics capture,
+	// breaker trip, degraded emission) — the breaker is already open and the
+	// degraded event already emitted — and only keep the per-tick breadcrumb
+	// and the rate-limited reap. It resets on the healthy transition so a
+	// genuine recovery followed by a re-poison re-captures forensics.
+	confirmed bool
+	// degraded is the current degradation class, or "" when healthy.
+	degraded DegradeClass
+	// lastReapAt is when the most recent reap fired (zero = never), used
+	// for the cooldown rate-limit.
+	lastReapAt time.Time
+	// lastWriteProbeAt is when the write-path probe last ran.
+	lastWriteProbeAt time.Time
+}
+
+// ScopePatrol runs the health matrix for one scope. Construct with
+// NewScopePatrol; drive it with EvaluateCycle on the patrol ticker.
+type ScopePatrol struct {
+	cfg   Config
+	hooks Hooks
+	now   func() time.Time
+	st    scopeState
+}
+
+// NewScopePatrol builds a patrol for one scope. now is injectable for
+// deterministic tests; pass nil to use time.Now.
+func NewScopePatrol(cfg Config, hooks Hooks, now func() time.Time) *ScopePatrol {
+	if now == nil {
+		now = time.Now
+	}
+	if cfg.ConsecutiveFails <= 0 {
+		cfg.ConsecutiveFails = 3
+	}
+	return &ScopePatrol{cfg: cfg, hooks: hooks, now: now}
+}
+
+// EvaluateCycle runs one patrol cycle: probes A and B, applies the
+// decision matrix, and performs the resulting side effects through the
+// hooks. It is the single entry point so the matrix logic lives in one
+// place. Safe to call serially from the patrol ticker.
+func (p *ScopePatrol) EvaluateCycle(ctx context.Context) {
+	a := p.hooks.ProbeRoutedFresh(ctx)
+	b := p.hooks.ProbeBackendDirect(ctx)
+
+	switch {
+	case a.Ok && b.Ok:
+		p.onHealthy(ctx)
+	case !a.Ok && b.Ok:
+		p.onTransportPoison(ctx, a.Reason)
+	case a.Ok && !b.Ok:
+		p.onBackendFault(b.Reason)
+	default: // both fail
+		p.onBothFail(a.Reason, b.Reason)
+	}
+}
+
+// onHealthy resets the transport counter, emits store.recovered if the
+// scope was degraded, and runs the write-path conformance probe at its
+// configured cadence.
+func (p *ScopePatrol) onHealthy(ctx context.Context) {
+	p.st.mu.Lock()
+	wasDegraded := p.st.degraded
+	p.st.consecutiveTransportFails = 0
+	// End any active transport-poison episode so a genuine recovery followed
+	// by a re-poison re-captures forensics and re-emits degraded.
+	p.st.confirmed = false
+	// A transport recovery clears the transport class; a write-rejection
+	// degradation only clears when the write probe passes (below).
+	if p.st.degraded == ClassTransport || p.st.degraded == ClassBackend {
+		p.st.degraded = ""
+	}
+	p.st.mu.Unlock()
+
+	if wasDegraded == ClassTransport || wasDegraded == ClassBackend {
+		p.hooks.EmitRecovered(wasDegraded)
+	}
+
+	p.maybeWriteProbe(ctx)
+}
+
+// onTransportPoison handles A-fail∧B-ok: the proxy poison signature. It
+// counts toward the confirm threshold and, once reached, captures forensics,
+// reaps (rate-limited), trips the breaker, and emits — but only ONCE per
+// poison episode.
+//
+// The probe-failed breadcrumb is emitted every cycle so the per-tick signal
+// survives. The forensics capture, breaker trip, and degraded emission run
+// only on the cycle that first confirms the episode: once confirmed, the
+// breaker is already open and the degraded event already emitted, so
+// re-running them every 30s tick over a multi-hour outage would only produce
+// hundreds of duplicate quarantine captures and events. The rate-limited reap
+// keeps running so a still-poisoned proxy is retried after the cooldown. The
+// episode flag resets on the healthy transition (see onHealthy), so a genuine
+// recovery followed by a re-poison re-captures forensics.
+func (p *ScopePatrol) onTransportPoison(ctx context.Context, reason string) {
+	p.hooks.EmitProbeFailed("routed", reason)
+
+	p.st.mu.Lock()
+	p.st.consecutiveTransportFails++
+	count := p.st.consecutiveTransportFails
+	reached := count >= p.cfg.ConsecutiveFails
+	firstConfirm := reached && !p.st.confirmed
+	p.st.mu.Unlock()
+
+	if !reached {
+		return
+	}
+
+	if firstConfirm {
+		// First confirmation of this episode: capture forensics, mark the
+		// scope degraded, trip the breaker, and emit — once.
+		dir, _ := p.hooks.CaptureForensics(ctx)
+
+		p.st.mu.Lock()
+		p.st.confirmed = true
+		p.st.degraded = ClassTransport
+		withinCooldown := !p.st.lastReapAt.IsZero() && p.now().Sub(p.st.lastReapAt) < p.cfg.ReapCooldown
+		p.st.mu.Unlock()
+
+		p.hooks.TripBreaker()
+		p.hooks.EmitDegraded(ClassTransport, reason, count)
+
+		p.reap(ctx, dir, withinCooldown)
+		return
+	}
+
+	// Already confirmed for this episode: the breaker is open and degraded is
+	// emitted, and forensics were captured at first confirmation. Skip the
+	// once-per-episode work (forensics/trip/degraded) entirely; keep retrying
+	// the reap subject to the cooldown so a still-poisoned proxy is reaped once
+	// the window elapses. The episode's forensics dir is not re-captured, so
+	// the post-confirmation reap carries no quarantine dir.
+	p.st.mu.Lock()
+	withinCooldown := !p.st.lastReapAt.IsZero() && p.now().Sub(p.st.lastReapAt) < p.cfg.ReapCooldown
+	p.st.mu.Unlock()
+	if withinCooldown {
+		return
+	}
+	p.reap(ctx, "", false)
+}
+
+// reap performs the rate-limited proxy reap for a confirmed poison episode.
+// When withinCooldown is true the reap is suppressed (alert-only, forensics
+// kept); otherwise it reaps and records the reap time. dir is the forensics
+// quarantine directory carried on the proxy.reaped event.
+func (p *ScopePatrol) reap(ctx context.Context, dir string, withinCooldown bool) {
+	if withinCooldown {
+		// A poison inside the window: alert-only, keep forensics.
+		p.hooks.EmitProxyReaped(dir, 0, true)
+		return
+	}
+	pids, _ := p.hooks.ReapProxy(ctx)
+	p.st.mu.Lock()
+	p.st.lastReapAt = p.now()
+	p.st.mu.Unlock()
+	p.hooks.EmitProxyReaped(dir, pids, false)
+}
+
+// onBackendClassDegradation applies the shared backend-class degradation: it
+// resets the transport poison counter (the failure cannot be attributed to the
+// proxy), marks the scope backend-degraded, trips the breaker, and emits the
+// degraded event. Callers own their distinctive probe-failed and doctor-alert
+// emissions around it. reason is the human-readable cause carried on the
+// degraded event.
+func (p *ScopePatrol) onBackendClassDegradation(reason string) {
+	p.st.mu.Lock()
+	p.st.consecutiveTransportFails = 0
+	// A backend-class degradation supersedes any transport-poison episode:
+	// clear the episode flag so a later transport poison re-captures.
+	p.st.confirmed = false
+	p.st.degraded = ClassBackend
+	p.st.mu.Unlock()
+	p.hooks.TripBreaker()
+	p.hooks.EmitDegraded(ClassBackend, reason, 0)
+}
+
+// onBackendFault handles A-ok∧B-fail: the sql-server itself is unreachable
+// or read-only. Trip the breaker and alert, but NEVER auto-kill the
+// sql-server. Reset the transport counter (the proxy path is fine).
+func (p *ScopePatrol) onBackendFault(reason string) {
+	p.hooks.EmitProbeFailed("backend", reason)
+	p.onBackendClassDegradation(reason)
+	p.hooks.EmitDoctorAlert("managed dolt backend probe failed (A-ok, B-fail); sql-server not auto-killed: " + reason)
+}
+
+// onBothFail handles A-fail∧B-fail: the whole path is down. This is not the
+// isolated proxy-poison signature (B is also failing), so it is treated as
+// a backend-class degradation — trip + alert, never auto-kill — and the
+// transport poison counter is not advanced (we cannot attribute the
+// failure to the proxy when the direct backend is also unreachable).
+func (p *ScopePatrol) onBothFail(reasonA, reasonB string) {
+	p.hooks.EmitProbeFailed("routed", reasonA)
+	p.hooks.EmitProbeFailed("backend", reasonB)
+	p.onBackendClassDegradation(reasonB)
+	p.hooks.EmitDoctorAlert("both store probes failed (A-fail, B-fail); sql-server not auto-killed")
+}
+
+// maybeWriteProbe runs the write-path conformance probe when due. A
+// persistent write rejection (the post-cutover a74fefde8 class invisible
+// to a transport-only breaker) feeds the same degraded quarantine path
+// with class write-rejection. A passing probe clears a prior
+// write-rejection degradation.
+func (p *ScopePatrol) maybeWriteProbe(ctx context.Context) {
+	if p.hooks.WriteProbe == nil || p.cfg.WriteProbeEvery <= 0 {
+		return
+	}
+	p.st.mu.Lock()
+	due := p.st.lastWriteProbeAt.IsZero() || p.now().Sub(p.st.lastWriteProbeAt) >= p.cfg.WriteProbeEvery
+	if !due {
+		p.st.mu.Unlock()
+		return
+	}
+	p.st.lastWriteProbeAt = p.now()
+	wasWriteRejected := p.st.degraded == ClassWriteRejection
+	p.st.mu.Unlock()
+
+	res := p.hooks.WriteProbe(ctx)
+	if res.Ok {
+		if wasWriteRejected {
+			p.st.mu.Lock()
+			p.st.degraded = ""
+			p.st.mu.Unlock()
+			p.hooks.EmitRecovered(ClassWriteRejection)
+		}
+		return
+	}
+	p.st.mu.Lock()
+	p.st.degraded = ClassWriteRejection
+	p.st.mu.Unlock()
+	p.hooks.TripBreaker()
+	p.hooks.EmitDegraded(ClassWriteRejection, res.Reason, 0)
+}
+
+// Degraded reports the scope's current degradation class, or "" when
+// healthy. Safe for concurrent diagnostic reads.
+func (p *ScopePatrol) Degraded() DegradeClass {
+	p.st.mu.Lock()
+	defer p.st.mu.Unlock()
+	return p.st.degraded
+}
+
+// ConsecutiveTransportFails reports the current consecutive A-fail∧B-ok
+// count. Test/diagnostic visibility.
+func (p *ScopePatrol) ConsecutiveTransportFails() int {
+	p.st.mu.Lock()
+	defer p.st.mu.Unlock()
+	return p.st.consecutiveTransportFails
+}

--- a/internal/storehealth/patrol_test.go
+++ b/internal/storehealth/patrol_test.go
@@ -1,0 +1,321 @@
+package storehealth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// recordingHooks captures every hook invocation so tests can assert the
+// exact side-effect sequence the matrix produced.
+type recordingHooks struct {
+	aResult, bResult  ProbeResult
+	writeResult       ProbeResult
+	writeProbeSet     bool
+	forensicsDir      string
+	reapPIDs          int
+	tripped           int
+	degraded          []DegradeClass
+	recovered         []DegradeClass
+	probeFailed       []string
+	reaped            []reapCall
+	doctorAlerts      []string
+	forensicsCaptured int
+	reapCalled        int
+	writeProbeCalled  int
+}
+
+type reapCall struct {
+	dir         string
+	pids        int
+	rateLimited bool
+}
+
+func (h *recordingHooks) hooks() Hooks {
+	hk := Hooks{
+		ProbeRoutedFresh:   func(context.Context) ProbeResult { return h.aResult },
+		ProbeBackendDirect: func(context.Context) ProbeResult { return h.bResult },
+		CaptureForensics: func(context.Context) (string, error) {
+			h.forensicsCaptured++
+			return h.forensicsDir, nil
+		},
+		ReapProxy: func(context.Context) (int, error) {
+			h.reapCalled++
+			return h.reapPIDs, nil
+		},
+		TripBreaker:     func() { h.tripped++ },
+		EmitDegraded:    func(c DegradeClass, _ string, _ int) { h.degraded = append(h.degraded, c) },
+		EmitRecovered:   func(c DegradeClass) { h.recovered = append(h.recovered, c) },
+		EmitProbeFailed: func(probe, _ string) { h.probeFailed = append(h.probeFailed, probe) },
+		EmitProxyReaped: func(dir string, pids int, rl bool) {
+			h.reaped = append(h.reaped, reapCall{dir: dir, pids: pids, rateLimited: rl})
+		},
+		EmitDoctorAlert: func(detail string) { h.doctorAlerts = append(h.doctorAlerts, detail) },
+	}
+	if h.writeProbeSet {
+		hk.WriteProbe = func(context.Context) ProbeResult {
+			h.writeProbeCalled++
+			return h.writeResult
+		}
+	}
+	return hk
+}
+
+func ok() ProbeResult   { return ProbeResult{Ok: true} }
+func fail() ProbeResult { return ProbeResult{Ok: false, Reason: "boom"} }
+
+// TestEvaluateCycleMatrix is the A/B decision-matrix table test.
+func TestEvaluateCycleMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		a, b          ProbeResult
+		wantTripped   int
+		wantDegraded  []DegradeClass
+		wantAlerts    int
+		wantProbeFail int
+	}{
+		{"A-ok B-ok healthy", ok(), ok(), 0, nil, 0, 0},
+		{"A-fail B-ok poison (single cycle, not yet confirmed)", fail(), ok(), 0, nil, 0, 1},
+		{"A-ok B-fail backend fault", ok(), fail(), 1, []DegradeClass{ClassBackend}, 1, 1},
+		{"A-fail B-fail both down", fail(), fail(), 1, []DegradeClass{ClassBackend}, 1, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &recordingHooks{aResult: tc.a, bResult: tc.b}
+			p := NewScopePatrol(Config{ConsecutiveFails: 3, ReapCooldown: 10 * time.Minute}, h.hooks(), fixedClock(0))
+			p.EvaluateCycle(context.Background())
+			if h.tripped != tc.wantTripped {
+				t.Errorf("tripped = %d, want %d", h.tripped, tc.wantTripped)
+			}
+			if len(h.degraded) != len(tc.wantDegraded) {
+				t.Errorf("degraded = %v, want %v", h.degraded, tc.wantDegraded)
+			}
+			for i := range tc.wantDegraded {
+				if h.degraded[i] != tc.wantDegraded[i] {
+					t.Errorf("degraded[%d] = %v, want %v", i, h.degraded[i], tc.wantDegraded[i])
+				}
+			}
+			if len(h.doctorAlerts) != tc.wantAlerts {
+				t.Errorf("doctorAlerts = %d, want %d", len(h.doctorAlerts), tc.wantAlerts)
+			}
+			if len(h.probeFailed) != tc.wantProbeFail {
+				t.Errorf("probeFailed = %d, want %d", len(h.probeFailed), tc.wantProbeFail)
+			}
+		})
+	}
+}
+
+// TestTransportPoisonConfirmAfterThreshold asserts a reap fires only after
+// ConsecutiveFails consecutive A-fail∧B-ok cycles, forensics-first.
+func TestTransportPoisonConfirmAfterThreshold(t *testing.T) {
+	h := &recordingHooks{aResult: fail(), bResult: ok(), forensicsDir: "/q/scope-0", reapPIDs: 2}
+	p := NewScopePatrol(Config{ConsecutiveFails: 3, ReapCooldown: 10 * time.Minute}, h.hooks(), fixedClock(0))
+
+	// Cycles 1 and 2: counted, no reap yet.
+	p.EvaluateCycle(context.Background())
+	p.EvaluateCycle(context.Background())
+	if h.reapCalled != 0 || h.forensicsCaptured != 0 {
+		t.Fatalf("reap/forensics fired before threshold: reap=%d forensics=%d", h.reapCalled, h.forensicsCaptured)
+	}
+	if got := p.ConsecutiveTransportFails(); got != 2 {
+		t.Fatalf("consecutive fails = %d, want 2", got)
+	}
+
+	// Cycle 3: confirmed → forensics FIRST, then reap, trip, degraded(transport), proxy.reaped.
+	p.EvaluateCycle(context.Background())
+	if h.forensicsCaptured != 1 {
+		t.Fatalf("forensicsCaptured = %d, want 1", h.forensicsCaptured)
+	}
+	if h.reapCalled != 1 {
+		t.Fatalf("reapCalled = %d, want 1", h.reapCalled)
+	}
+	if h.tripped != 1 {
+		t.Fatalf("tripped = %d, want 1", h.tripped)
+	}
+	if len(h.degraded) != 1 || h.degraded[0] != ClassTransport {
+		t.Fatalf("degraded = %v, want [transport]", h.degraded)
+	}
+	if len(h.reaped) != 1 || h.reaped[0].rateLimited || h.reaped[0].pids != 2 || h.reaped[0].dir != "/q/scope-0" {
+		t.Fatalf("reaped = %+v, want one non-rate-limited reap of /q/scope-0 with 2 pids", h.reaped)
+	}
+	if p.Degraded() != ClassTransport {
+		t.Fatalf("Degraded() = %q, want transport", p.Degraded())
+	}
+}
+
+// TestReapRateLimitWithinCooldown asserts the reap is rate-limited across a
+// sustained poison episode: the proxy is reaped once at first confirmation,
+// not again inside the cooldown window, and once more after the window
+// expires. Forensics, the breaker trip, and the degraded emission are
+// once-per-episode (asserted in TestPoisonEpisodeEmitsOnceAcrossManyTicks);
+// here we focus on the reap cadence.
+func TestReapRateLimitWithinCooldown(t *testing.T) {
+	clk := &mutClock{}
+	h := &recordingHooks{aResult: fail(), bResult: ok(), forensicsDir: "/q/scope-1"}
+	p := NewScopePatrol(Config{ConsecutiveFails: 1, ReapCooldown: 10 * time.Minute}, h.hooks(), clk.now)
+
+	// First confirmed poison at t=0 → real reap, forensics captured once.
+	p.EvaluateCycle(context.Background())
+	if h.reapCalled != 1 || len(h.reaped) != 1 || h.reaped[0].rateLimited {
+		t.Fatalf("first poison should reap non-rate-limited: reap=%d reaped=%+v", h.reapCalled, h.reaped)
+	}
+	if h.forensicsCaptured != 1 {
+		t.Fatalf("forensicsCaptured = %d after first confirmation, want 1", h.forensicsCaptured)
+	}
+
+	// Second poison 5m later (inside 10m cooldown), episode already confirmed
+	// → no reap, no extra forensics, no extra reap event.
+	clk.advance(5 * time.Minute)
+	p.EvaluateCycle(context.Background())
+	if h.reapCalled != 1 {
+		t.Fatalf("reap called again inside cooldown: reapCalled = %d, want 1", h.reapCalled)
+	}
+	if h.forensicsCaptured != 1 {
+		t.Fatalf("forensics re-captured inside cooldown for a confirmed episode: forensicsCaptured = %d, want 1", h.forensicsCaptured)
+	}
+	if len(h.reaped) != 1 {
+		t.Fatalf("extra reap event emitted inside cooldown: reaped = %+v, want 1", h.reaped)
+	}
+
+	// A third poison after the cooldown expires → real reap again (the proxy
+	// is still poisoned and the window has elapsed).
+	clk.advance(6 * time.Minute) // now t=11m, > 10m after the t=0 reap
+	p.EvaluateCycle(context.Background())
+	if h.reapCalled != 2 {
+		t.Fatalf("reap should fire after cooldown expiry: reapCalled = %d, want 2", h.reapCalled)
+	}
+}
+
+// TestPoisonEpisodeEmitsOnceAcrossManyTicks asserts that a sustained poison
+// across many patrol ticks captures forensics, trips the breaker, and emits
+// degraded exactly ONCE per episode — only the per-tick probe-failed
+// breadcrumb repeats — and that a genuine recovery followed by a re-poison
+// re-captures.
+func TestPoisonEpisodeEmitsOnceAcrossManyTicks(t *testing.T) {
+	clk := &mutClock{}
+	h := &recordingHooks{aResult: fail(), bResult: ok(), forensicsDir: "/q/ep"}
+	// Large cooldown so the reap never re-fires; we are asserting the
+	// once-per-episode forensics/trip/degraded, isolated from the reap cadence.
+	p := NewScopePatrol(Config{ConsecutiveFails: 3, ReapCooldown: time.Hour}, h.hooks(), clk.now)
+
+	// 20 poison ticks at a 30s interval (a multi-minute outage).
+	for i := 0; i < 20; i++ {
+		p.EvaluateCycle(context.Background())
+		clk.advance(30 * time.Second)
+	}
+	if h.forensicsCaptured != 1 {
+		t.Fatalf("forensicsCaptured = %d across a sustained episode, want 1", h.forensicsCaptured)
+	}
+	if h.tripped != 1 {
+		t.Fatalf("tripped = %d across a sustained episode, want 1", h.tripped)
+	}
+	if len(h.degraded) != 1 || h.degraded[0] != ClassTransport {
+		t.Fatalf("degraded = %v across a sustained episode, want exactly [transport]", h.degraded)
+	}
+	// The per-tick breadcrumb survives: one routed probe-failed per cycle.
+	if len(h.probeFailed) != 20 {
+		t.Fatalf("probeFailed = %d, want 20 (one per tick — the per-cycle signal must survive)", len(h.probeFailed))
+	}
+
+	// Recovery clears the episode.
+	h.aResult = ok()
+	p.EvaluateCycle(context.Background())
+	clk.advance(30 * time.Second)
+	if p.Degraded() != "" || len(h.recovered) != 1 {
+		t.Fatalf("recovery not registered: degraded=%q recovered=%v", p.Degraded(), h.recovered)
+	}
+
+	// Re-poison after recovery → a NEW episode re-captures and re-emits.
+	h.aResult = fail()
+	for i := 0; i < 3; i++ {
+		p.EvaluateCycle(context.Background())
+		clk.advance(30 * time.Second)
+	}
+	if h.forensicsCaptured != 2 {
+		t.Fatalf("forensicsCaptured = %d after recovery→re-poison, want 2 (new episode re-captures)", h.forensicsCaptured)
+	}
+	if h.tripped != 2 {
+		t.Fatalf("tripped = %d after recovery→re-poison, want 2", h.tripped)
+	}
+	if len(h.degraded) != 2 {
+		t.Fatalf("degraded = %v after recovery→re-poison, want 2 emissions", h.degraded)
+	}
+}
+
+// TestHealthyAfterDegradedEmitsRecovered asserts recovery emission and
+// counter reset when a degraded scope's probes pass again.
+func TestHealthyAfterDegradedEmitsRecovered(t *testing.T) {
+	h := &recordingHooks{aResult: fail(), bResult: ok()}
+	p := NewScopePatrol(Config{ConsecutiveFails: 1, ReapCooldown: time.Minute}, h.hooks(), fixedClock(0))
+	p.EvaluateCycle(context.Background()) // degrade transport
+	if p.Degraded() != ClassTransport {
+		t.Fatalf("expected transport degradation, got %q", p.Degraded())
+	}
+
+	h.aResult = ok()
+	p.EvaluateCycle(context.Background()) // healthy
+	if p.Degraded() != "" {
+		t.Fatalf("Degraded() = %q after recovery, want empty", p.Degraded())
+	}
+	if len(h.recovered) != 1 || h.recovered[0] != ClassTransport {
+		t.Fatalf("recovered = %v, want [transport]", h.recovered)
+	}
+	if p.ConsecutiveTransportFails() != 0 {
+		t.Fatalf("consecutive fails not reset: %d", p.ConsecutiveTransportFails())
+	}
+}
+
+// TestWriteProbeRejectionDegrades asserts the write-path conformance probe
+// degrades with class write-rejection (the a74fefde8 runtime class), and
+// that a later passing probe clears it.
+func TestWriteProbeRejectionDegrades(t *testing.T) {
+	clk := &mutClock{}
+	h := &recordingHooks{aResult: ok(), bResult: ok(), writeProbeSet: true, writeResult: fail()}
+	p := NewScopePatrol(Config{ConsecutiveFails: 3, WriteProbeEvery: 10 * time.Minute}, h.hooks(), clk.now)
+
+	p.EvaluateCycle(context.Background()) // first cycle: write probe due, rejects
+	if h.writeProbeCalled != 1 {
+		t.Fatalf("writeProbeCalled = %d, want 1", h.writeProbeCalled)
+	}
+	if p.Degraded() != ClassWriteRejection {
+		t.Fatalf("Degraded() = %q, want write-rejection", p.Degraded())
+	}
+	if len(h.degraded) != 1 || h.degraded[0] != ClassWriteRejection {
+		t.Fatalf("degraded = %v, want [write-rejection]", h.degraded)
+	}
+
+	// Not yet due again (within 10m) → no extra probe.
+	clk.advance(5 * time.Minute)
+	p.EvaluateCycle(context.Background())
+	if h.writeProbeCalled != 1 {
+		t.Fatalf("write probe ran before its interval: writeProbeCalled = %d, want 1", h.writeProbeCalled)
+	}
+
+	// Due again, now passes → clears write-rejection, emits recovered.
+	clk.advance(6 * time.Minute)
+	h.writeResult = ok()
+	p.EvaluateCycle(context.Background())
+	if h.writeProbeCalled != 2 {
+		t.Fatalf("writeProbeCalled = %d, want 2", h.writeProbeCalled)
+	}
+	if p.Degraded() != "" {
+		t.Fatalf("Degraded() = %q after write recovery, want empty", p.Degraded())
+	}
+	if len(h.recovered) != 1 || h.recovered[0] != ClassWriteRejection {
+		t.Fatalf("recovered = %v, want [write-rejection]", h.recovered)
+	}
+}
+
+// --- deterministic clocks ---
+
+func fixedClock(t time.Duration) func() time.Time {
+	base := time.Unix(0, 0).Add(t)
+	return func() time.Time { return base }
+}
+
+type mutClock struct {
+	d time.Duration
+}
+
+func (c *mutClock) now() time.Time          { return time.Unix(0, 0).Add(c.d) }
+func (c *mutClock) advance(d time.Duration) { c.d += d }

--- a/internal/storehealth/quarantine.go
+++ b/internal/storehealth/quarantine.go
@@ -1,0 +1,104 @@
+package storehealth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// QuarantineDirName builds the forensic quarantine directory name for a
+// scope and sequence number: "<scope>-<seq>". The sequence is a monotonic
+// counter, NEVER a wall-clock or random value, so the names are
+// deterministic and tests can assert them exactly (plan item 1.5).
+//
+// scope is sanitized to a filesystem-safe token (path separators and other
+// awkward characters collapse to '_') because scope roots are absolute
+// paths.
+func QuarantineDirName(scope string, seq int) string {
+	return fmt.Sprintf("%s-%d", sanitizeScopeToken(scope), seq)
+}
+
+// NextQuarantineSeq returns the next monotonic sequence number for a scope
+// by scanning existing "<scope>-<n>" entries under quarantineRoot and
+// returning max(n)+1, or 0 when none exist. Derivation from directory
+// entries (rather than a wall-clock or random source) keeps reaps
+// deterministic and replayable. A read error on the root yields 0 so the
+// first reap after a missing root still produces a stable name.
+func NextQuarantineSeq(quarantineRoot, scope string) int {
+	token := sanitizeScopeToken(scope)
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil {
+		return 0
+	}
+	prefix := token + "-"
+	maxSeq := -1
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimPrefix(name, prefix))
+		if err != nil || n < 0 {
+			continue
+		}
+		if n > maxSeq {
+			maxSeq = n
+		}
+	}
+	return maxSeq + 1
+}
+
+// QuarantineDirPath joins the quarantine root with the next sequenced
+// directory name for a scope and returns the absolute path plus the seq.
+// It does not create the directory — the forensics hook does that.
+func QuarantineDirPath(quarantineRoot, scope string) (path string, seq int) {
+	seq = NextQuarantineSeq(quarantineRoot, scope)
+	return filepath.Join(quarantineRoot, QuarantineDirName(scope, seq)), seq
+}
+
+// sanitizeScopeToken collapses a scope root path into a filesystem-safe,
+// stable token: leading separators are dropped and every remaining
+// separator or awkward character becomes '_'. Two distinct scopes never
+// collide because the full path is preserved (only the separators change).
+func sanitizeScopeToken(scope string) string {
+	scope = strings.TrimSpace(scope)
+	scope = strings.Trim(scope, string(filepath.Separator))
+	if scope == "" {
+		return "scope"
+	}
+	var b strings.Builder
+	for _, r := range scope {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// sortedQuarantineSeqs returns the existing sequence numbers for a scope in
+// ascending order. Helper for tests asserting deterministic accumulation.
+func sortedQuarantineSeqs(quarantineRoot, scope string) []int {
+	token := sanitizeScopeToken(scope)
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil {
+		return nil
+	}
+	prefix := token + "-"
+	var seqs []int
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		if n, err := strconv.Atoi(strings.TrimPrefix(e.Name(), prefix)); err == nil && n >= 0 {
+			seqs = append(seqs, n)
+		}
+	}
+	sort.Ints(seqs)
+	return seqs
+}

--- a/internal/storehealth/quarantine_test.go
+++ b/internal/storehealth/quarantine_test.go
@@ -1,0 +1,88 @@
+package storehealth
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestQuarantineDirNameDeterministic asserts the name is a pure function of
+// (scope, seq) — never wall-clock or random.
+func TestQuarantineDirNameDeterministic(t *testing.T) {
+	const scope = "/Users/Shared/city/rigs/vr"
+	got1 := QuarantineDirName(scope, 0)
+	got2 := QuarantineDirName(scope, 0)
+	if got1 != got2 {
+		t.Fatalf("non-deterministic name: %q != %q", got1, got2)
+	}
+	if got := QuarantineDirName(scope, 7); filepath.Base(got) != got {
+		t.Fatalf("name %q contains a path separator; must be a single dir component", got)
+	}
+	// Distinct seqs yield distinct names.
+	if QuarantineDirName(scope, 0) == QuarantineDirName(scope, 1) {
+		t.Fatalf("seq 0 and 1 produced the same name")
+	}
+	// Distinct scopes yield distinct names.
+	if QuarantineDirName("/a/b", 0) == QuarantineDirName("/a/c", 0) {
+		t.Fatalf("distinct scopes collided")
+	}
+}
+
+// TestNextQuarantineSeqMonotonic asserts the seq is max(existing)+1, derived
+// from directory entries, and starts at 0 on an empty/missing root.
+func TestNextQuarantineSeqMonotonic(t *testing.T) {
+	root := t.TempDir()
+	const scope = "/city/rigs/hq"
+
+	if got := NextQuarantineSeq(root, scope); got != 0 {
+		t.Fatalf("first seq on empty root = %d, want 0", got)
+	}
+
+	// Create seq 0, 1, 2 directories; next must be 3.
+	for i := 0; i < 3; i++ {
+		if err := os.Mkdir(filepath.Join(root, QuarantineDirName(scope, i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := NextQuarantineSeq(root, scope); got != 3 {
+		t.Fatalf("seq after 0,1,2 = %d, want 3", got)
+	}
+
+	// A different scope under the same root is independent.
+	if got := NextQuarantineSeq(root, "/city/rigs/vr"); got != 0 {
+		t.Fatalf("independent scope seq = %d, want 0", got)
+	}
+
+	// A gap (delete seq 1) must still yield max+1 = 3 (monotonic, not
+	// gap-filling), so names never collide with a prior reap's artifacts.
+	if err := os.RemoveAll(filepath.Join(root, QuarantineDirName(scope, 1))); err != nil {
+		t.Fatal(err)
+	}
+	if got := NextQuarantineSeq(root, scope); got != 3 {
+		t.Fatalf("seq after deleting middle entry = %d, want 3 (monotonic)", got)
+	}
+}
+
+// TestQuarantineDirPathSequencing asserts repeated path allocation (with
+// the directory actually created between calls) accumulates deterministic,
+// non-colliding sequence numbers.
+func TestQuarantineDirPathSequencing(t *testing.T) {
+	root := t.TempDir()
+	const scope = "/city"
+
+	var seqs []int
+	for i := 0; i < 4; i++ {
+		path, seq := QuarantineDirPath(root, scope)
+		seqs = append(seqs, seq)
+		if err := os.Mkdir(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	if !reflect.DeepEqual(seqs, []int{0, 1, 2, 3}) {
+		t.Fatalf("allocated seqs = %v, want [0 1 2 3]", seqs)
+	}
+	if got := sortedQuarantineSeqs(root, scope); !reflect.DeepEqual(got, []int{0, 1, 2, 3}) {
+		t.Fatalf("on-disk seqs = %v, want [0 1 2 3]", got)
+	}
+}


### PR DESCRIPTION
Part of the split of #3324 (closed) into independently reviewable pieces.

**Stacks on #5945** (deterministic quarantine directory naming). Review that
one first; this PR's diff against `main` includes it until it merges.

## What

Adds `internal/storehealth/patrol.go` — `ScopePatrol`, the per-scope
decision matrix that distinguishes a wedged store *transport* from a fault
in the *backend itself*, so a poisoned connection path can be acted on
without ever auto-killing the sql-server.

Each cycle runs two probes:

- **Probe A** — a routed-store read that forces a *fresh* backend
  connection. Freshness is the point: the failure mode this exists for hits
  new opens only, so a pooled ride-along would miss it entirely.
- **Probe B** — a direct `SELECT 1` against the managed dolt endpoint.

and applies a fixed matrix:

| A | B | Action |
|---|---|---|
| fail | ok | Transport poisoned, backend fine. After `ConsecutiveFails` consecutive cycles: capture forensics **first**, then reap the transport child through the injected lifecycle, trip the scope breaker, emit degraded (class `transport`). Reap rate-limited to one per scope per `ReapCooldown`; a poison inside the window is alert-only with forensics kept. |
| ok | fail | Backend fault. Trip the breaker and alert — but **never** auto-kill the sql-server (class `backend`). |
| fail | fail | Whole path down. Because B is also failing the failure cannot be attributed to the transport, so the poison counter does not advance and this is handled as a backend-class degradation. |
| ok | ok | Healthy. Reset the counter, emit recovered if the scope was degraded, run the optional write-path conformance probe at its cadence. |

Sustained-outage behaviour is explicit and tested: forensics capture,
breaker trip and the degraded emission are **once per episode**, not once
per tick, so a multi-hour outage does not produce hundreds of duplicate
quarantine captures and events. Only the per-tick probe-failed breadcrumb
and the rate-limited reap repeat. The episode resets on a healthy
transition, so a genuine recovery followed by a re-poison re-captures.

## The package does zero I/O

This is the property that makes it upstreamable on its own. Probing,
forensics capture, reaping, breaker tripping and event emission are *all*
injected through a `Hooks` struct, and the clock is injectable too.
`patrol.go` imports exactly `context`, `sync` and `time` — nothing else,
stdlib or otherwise. The state machine holds only counters, timestamps and
comparisons; every threshold arrives from config. It is exercised entirely
with fakes and a deterministic clock, and it can be reviewed and merged
without reference to any particular caller.

## On the size

~683 lines (362 implementation, 321 tests) — deliberately above the usual
bar. It is one state machine plus the decision-matrix suite that pins it
down, and the two do not usefully separate. Splitting the write-rejection
arm into its own PR, the obvious cut, would leave a PR whose tests exercise
a branch nothing can reach. I would rather present the matrix whole.

The test file *is* the matrix: the A/B table, the confirm threshold, the
reap cooldown across an episode, once-per-episode emission across 20 ticks,
recovery, and the write-rejection arm.

## A note on the earlier review

An earlier attempt at this area was closed as "proxy-coupled, not cleanly
separable". That was accurate about the *feature*, but not about this
*package* — and the package is what is being proposed here. `patrol.go`
imports only `context`, `sync` and `time`; the sibling from #5945 imports
only stdlib. The proxy coupling lives entirely in a separate file, in a
different package, which is not part of this PR and is not proposed
upstream.

## Verification

```
gofmt -l internal/storehealth/       # clean
go build ./...                       # ok
go vet ./...                         # ok
go test ./internal/storehealth/      # ok
go test -race ./internal/storehealth/ # ok
```
