### PR TITLE
feat(config): add the [storehealth] config block

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -40,6 +40,7 @@ City is the top-level configuration for a Gas City instance.
 | `session_sleep` | SessionSleepConfig |  |  | SessionSleep configures idle sleep policy defaults for managed sessions. |
 | `convergence` | ConvergenceConfig |  |  | Convergence configures convergence loop limits. |
 | `doctor` | DoctorConfig |  |  | Doctor configures gc doctor thresholds and policy toggles (worktree size warnings, nested-worktree auto-prune). |
+| `storehealth` | StoreHealthConfig |  |  | StoreHealth configures the controller-internal store health patrol (probe matrix, reap rate-limit, write-path conformance probe). |
 | `maintenance` | MaintenanceConfig |  |  | Maintenance configures periodic store-maintenance loops. |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
 | `webhook` | []Webhook |  |  | Webhooks declares inbound HTTP receivers mounted on the supervisor edge under /hook/&#123;name&#125;. Composed like Services (pack concatenation + SourceDir provenance + the default-closed public pack-guard). |
@@ -861,6 +862,18 @@ StorageConfig assigns each semantic storage class to a named binding and defines
 |-------|------|----------|---------|-------------|
 | `classes` | StorageClasses | **yes** |  | Classes contains the complete class-to-binding assignment. |
 | `bindings` | map[string]StorageBindingConfig |  |  | Bindings defines named provider-backed bindings. The reserved work binding is synthesized and must not appear here. |
+
+## StoreHealthConfig
+
+StoreHealthConfig configures the controller-internal store health patrol (city-scale architecture plan item 1.5).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | boolean |  | `true` | Enabled toggles the patrol. Defaults to true. Disabling restores the pre-patrol behavior (no two-probe matrix, no auto-reap). |
+| `interval` | string |  | `30s` | Interval is the per-scope probe cadence as a duration string. Defaults to "30s". |
+| `consecutive_fails` | integer |  | `3` | ConsecutiveFails is how many consecutive A-fail∧B-ok cycles confirm a proxy poison before forensics + reap. Defaults to 3. |
+| `reap_cooldown` | string |  | `10m` | ReapCooldown is the minimum spacing between reaps for one scope as a duration string. A second poison inside the window is alert-only with forensics kept. Defaults to "10m". |
+| `write_probe_interval` | string |  | `10m` | WriteProbeInterval is the cadence of the write-path conformance probe (create+close one ephemeral bead of each RequiredCustomType) as a duration string. Defaults to "10m". |
 
 ## Tier
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1211,6 +1211,10 @@
           "$ref": "#/$defs/DoctorConfig",
           "description": "Doctor configures gc doctor thresholds and policy toggles\n(worktree size warnings, nested-worktree auto-prune)."
         },
+        "storehealth": {
+          "$ref": "#/$defs/StoreHealthConfig",
+          "description": "StoreHealth configures the controller-internal store health patrol\n(probe matrix, reap rate-limit, write-path conformance probe)."
+        },
         "maintenance": {
           "$ref": "#/$defs/MaintenanceConfig",
           "description": "Maintenance configures periodic store-maintenance loops."
@@ -2945,6 +2949,38 @@
         "classes"
       ],
       "description": "StorageConfig assigns each semantic storage class to a named binding and defines every nonreserved binding used by those assignments; omitting `[storage]` keeps every class on the reserved `work` binding."
+    },
+    "StoreHealthConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled toggles the patrol. Defaults to true. Disabling restores the\npre-patrol behavior (no two-probe matrix, no auto-reap).",
+          "default": true
+        },
+        "interval": {
+          "type": "string",
+          "description": "Interval is the per-scope probe cadence as a duration string.\nDefaults to \"30s\".",
+          "default": "30s"
+        },
+        "consecutive_fails": {
+          "type": "integer",
+          "description": "ConsecutiveFails is how many consecutive A-fail∧B-ok cycles confirm a\nproxy poison before forensics + reap. Defaults to 3.",
+          "default": 3
+        },
+        "reap_cooldown": {
+          "type": "string",
+          "description": "ReapCooldown is the minimum spacing between reaps for one scope as a\nduration string. A second poison inside the window is alert-only with\nforensics kept. Defaults to \"10m\".",
+          "default": "10m"
+        },
+        "write_probe_interval": {
+          "type": "string",
+          "description": "WriteProbeInterval is the cadence of the write-path conformance probe\n(create+close one ephemeral bead of each RequiredCustomType) as a\nduration string. Defaults to \"10m\".",
+          "default": "10m"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "StoreHealthConfig configures the controller-internal store health patrol (city-scale architecture plan item 1.5)."
     },
     "Tier": {
       "properties": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1211,6 +1211,10 @@
           "$ref": "#/$defs/DoctorConfig",
           "description": "Doctor configures gc doctor thresholds and policy toggles\n(worktree size warnings, nested-worktree auto-prune)."
         },
+        "storehealth": {
+          "$ref": "#/$defs/StoreHealthConfig",
+          "description": "StoreHealth configures the controller-internal store health patrol\n(probe matrix, reap rate-limit, write-path conformance probe)."
+        },
         "maintenance": {
           "$ref": "#/$defs/MaintenanceConfig",
           "description": "Maintenance configures periodic store-maintenance loops."
@@ -2945,6 +2949,38 @@
         "classes"
       ],
       "description": "StorageConfig assigns each semantic storage class to a named binding and defines every nonreserved binding used by those assignments; omitting `[storage]` keeps every class on the reserved `work` binding."
+    },
+    "StoreHealthConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled toggles the patrol. Defaults to true. Disabling restores the\npre-patrol behavior (no two-probe matrix, no auto-reap).",
+          "default": true
+        },
+        "interval": {
+          "type": "string",
+          "description": "Interval is the per-scope probe cadence as a duration string.\nDefaults to \"30s\".",
+          "default": "30s"
+        },
+        "consecutive_fails": {
+          "type": "integer",
+          "description": "ConsecutiveFails is how many consecutive A-fail∧B-ok cycles confirm a\nproxy poison before forensics + reap. Defaults to 3.",
+          "default": 3
+        },
+        "reap_cooldown": {
+          "type": "string",
+          "description": "ReapCooldown is the minimum spacing between reaps for one scope as a\nduration string. A second poison inside the window is alert-only with\nforensics kept. Defaults to \"10m\".",
+          "default": "10m"
+        },
+        "write_probe_interval": {
+          "type": "string",
+          "description": "WriteProbeInterval is the cadence of the write-path conformance probe\n(create+close one ephemeral bead of each RequiredCustomType) as a\nduration string. Defaults to \"10m\".",
+          "default": "10m"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "StoreHealthConfig configures the controller-internal store health patrol (city-scale architecture plan item 1.5)."
     },
     "Tier": {
       "properties": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,6 +287,9 @@ type City struct {
 	// Doctor configures gc doctor thresholds and policy toggles
 	// (worktree size warnings, nested-worktree auto-prune).
 	Doctor DoctorConfig `toml:"doctor,omitempty"`
+	// StoreHealth configures the controller-internal store health patrol
+	// (probe matrix, reap rate-limit, write-path conformance probe).
+	StoreHealth StoreHealthConfig `toml:"storehealth,omitempty"`
 	// Maintenance configures periodic store-maintenance loops.
 	Maintenance MaintenanceConfig `toml:"maintenance,omitempty"`
 	// Services declares workspace-owned HTTP services mounted on the
@@ -2405,6 +2408,74 @@ func (c DoctorConfig) WorktreeRigErrorBytes() int64 {
 		return warn
 	}
 	return n
+}
+
+// StoreHealthConfig configures the controller-internal store health patrol
+// (city-scale architecture plan item 1.5). Every threshold is mechanical
+// (durations and counts) so the patrol holds no judgment calls in Go.
+type StoreHealthConfig struct {
+	// Enabled toggles the patrol. Defaults to true. Disabling restores the
+	// pre-patrol behavior (no two-probe matrix, no auto-reap).
+	Enabled *bool `toml:"enabled,omitempty" jsonschema:"default=true"`
+	// Interval is the per-scope probe cadence as a duration string.
+	// Defaults to "30s".
+	Interval string `toml:"interval,omitempty" jsonschema:"default=30s"`
+	// ConsecutiveFails is how many consecutive A-fail∧B-ok cycles confirm a
+	// proxy poison before forensics + reap. Defaults to 3.
+	ConsecutiveFails int `toml:"consecutive_fails,omitempty" jsonschema:"default=3"`
+	// ReapCooldown is the minimum spacing between reaps for one scope as a
+	// duration string. A second poison inside the window is alert-only with
+	// forensics kept. Defaults to "10m".
+	ReapCooldown string `toml:"reap_cooldown,omitempty" jsonschema:"default=10m"`
+	// WriteProbeInterval is the cadence of the write-path conformance probe
+	// (create+close one ephemeral bead of each RequiredCustomType) as a
+	// duration string. Defaults to "10m".
+	WriteProbeInterval string `toml:"write_probe_interval,omitempty" jsonschema:"default=10m"`
+}
+
+// StoreHealthEnabledOrDefault reports whether the patrol is enabled
+// (default true).
+func (c StoreHealthConfig) StoreHealthEnabledOrDefault() bool {
+	return c.Enabled == nil || *c.Enabled
+}
+
+// IntervalOrDefault returns the parsed probe interval, falling back to 30s.
+func (c StoreHealthConfig) IntervalOrDefault() time.Duration {
+	return positiveDurationOrDefault(c.Interval, 30*time.Second)
+}
+
+// ConsecutiveFailsOrDefault returns the confirm threshold, falling back to
+// 3 when unset or non-positive.
+func (c StoreHealthConfig) ConsecutiveFailsOrDefault() int {
+	if c.ConsecutiveFails > 0 {
+		return c.ConsecutiveFails
+	}
+	return 3
+}
+
+// ReapCooldownOrDefault returns the parsed reap cooldown, falling back to
+// 10m.
+func (c StoreHealthConfig) ReapCooldownOrDefault() time.Duration {
+	return positiveDurationOrDefault(c.ReapCooldown, 10*time.Minute)
+}
+
+// WriteProbeIntervalOrDefault returns the parsed write-probe interval,
+// falling back to 10m.
+func (c StoreHealthConfig) WriteProbeIntervalOrDefault() time.Duration {
+	return positiveDurationOrDefault(c.WriteProbeInterval, 10*time.Minute)
+}
+
+// positiveDurationOrDefault parses value as a Go duration, returning def
+// when value is empty, unparseable, or non-positive.
+func positiveDurationOrDefault(value string, def time.Duration) time.Duration {
+	if value == "" {
+		return def
+	}
+	v, err := time.ParseDuration(value)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
 }
 
 // parseHumanSize parses sizes like "10GB", "500 MB", "1024" (bytes

--- a/internal/config/storehealth_config_test.go
+++ b/internal/config/storehealth_config_test.go
@@ -1,0 +1,208 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseStoreHealthSection(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[storehealth]
+enabled = false
+interval = "45s"
+consecutive_fails = 5
+reap_cooldown = "20m"
+write_probe_interval = "1h"
+
+[[agent]]
+name = "mayor"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.StoreHealth.Enabled == nil || *cfg.StoreHealth.Enabled {
+		t.Errorf("Enabled = %v, want explicit false", cfg.StoreHealth.Enabled)
+	}
+	if cfg.StoreHealth.Interval != "45s" {
+		t.Errorf("Interval = %q, want %q", cfg.StoreHealth.Interval, "45s")
+	}
+	if cfg.StoreHealth.ConsecutiveFails != 5 {
+		t.Errorf("ConsecutiveFails = %d, want 5", cfg.StoreHealth.ConsecutiveFails)
+	}
+	if cfg.StoreHealth.ReapCooldown != "20m" {
+		t.Errorf("ReapCooldown = %q, want %q", cfg.StoreHealth.ReapCooldown, "20m")
+	}
+	if cfg.StoreHealth.WriteProbeInterval != "1h" {
+		t.Errorf("WriteProbeInterval = %q, want %q", cfg.StoreHealth.WriteProbeInterval, "1h")
+	}
+
+	// Configured values flow through the accessors unchanged.
+	if got := cfg.StoreHealth.IntervalOrDefault(); got != 45*time.Second {
+		t.Errorf("IntervalOrDefault() = %v, want 45s", got)
+	}
+	if got := cfg.StoreHealth.ConsecutiveFailsOrDefault(); got != 5 {
+		t.Errorf("ConsecutiveFailsOrDefault() = %d, want 5", got)
+	}
+	if got := cfg.StoreHealth.ReapCooldownOrDefault(); got != 20*time.Minute {
+		t.Errorf("ReapCooldownOrDefault() = %v, want 20m", got)
+	}
+	if got := cfg.StoreHealth.WriteProbeIntervalOrDefault(); got != time.Hour {
+		t.Errorf("WriteProbeIntervalOrDefault() = %v, want 1h", got)
+	}
+	if cfg.StoreHealth.StoreHealthEnabledOrDefault() {
+		t.Error("StoreHealthEnabledOrDefault() = true, want false when explicitly disabled")
+	}
+}
+
+func TestParseNoStoreHealthSection(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.StoreHealth != (StoreHealthConfig{}) {
+		t.Errorf("StoreHealth should be zero-valued when absent; got %+v", cfg.StoreHealth)
+	}
+	// An absent section must still yield the documented defaults, since the
+	// patrol reads thresholds exclusively through the accessors.
+	if !cfg.StoreHealth.StoreHealthEnabledOrDefault() {
+		t.Error("StoreHealthEnabledOrDefault() = false, want true by default")
+	}
+	if got := cfg.StoreHealth.IntervalOrDefault(); got != 30*time.Second {
+		t.Errorf("IntervalOrDefault() = %v, want 30s", got)
+	}
+	if got := cfg.StoreHealth.ConsecutiveFailsOrDefault(); got != 3 {
+		t.Errorf("ConsecutiveFailsOrDefault() = %d, want 3", got)
+	}
+	if got := cfg.StoreHealth.ReapCooldownOrDefault(); got != 10*time.Minute {
+		t.Errorf("ReapCooldownOrDefault() = %v, want 10m", got)
+	}
+	if got := cfg.StoreHealth.WriteProbeIntervalOrDefault(); got != 10*time.Minute {
+		t.Errorf("WriteProbeIntervalOrDefault() = %v, want 10m", got)
+	}
+}
+
+func TestMarshalOmitsEmptyStoreHealthSection(t *testing.T) {
+	c := DefaultCity("test")
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "[storehealth]") {
+		t.Errorf("Marshal output should not contain '[storehealth]' when empty:\n%s", data)
+	}
+}
+
+func TestStoreHealthAccessorsFallBackOnUnusableValues(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  StoreHealthConfig
+	}{
+		{"unparseable durations", StoreHealthConfig{
+			Interval:           "30 secs",
+			ReapCooldown:       "ten minutes",
+			WriteProbeInterval: "1hour",
+		}},
+		{"zero durations", StoreHealthConfig{
+			Interval:           "0s",
+			ReapCooldown:       "0",
+			WriteProbeInterval: "0m",
+		}},
+		{"negative durations", StoreHealthConfig{
+			Interval:           "-30s",
+			ReapCooldown:       "-10m",
+			WriteProbeInterval: "-10m",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.IntervalOrDefault(); got != 30*time.Second {
+				t.Errorf("IntervalOrDefault() = %v, want the 30s default", got)
+			}
+			if got := tt.cfg.ReapCooldownOrDefault(); got != 10*time.Minute {
+				t.Errorf("ReapCooldownOrDefault() = %v, want the 10m default", got)
+			}
+			if got := tt.cfg.WriteProbeIntervalOrDefault(); got != 10*time.Minute {
+				t.Errorf("WriteProbeIntervalOrDefault() = %v, want the 10m default", got)
+			}
+		})
+	}
+
+	// A non-positive count is unset, not a threshold of zero: a zero
+	// threshold would confirm a poison on the very first failed cycle.
+	for _, n := range []int{0, -1} {
+		cfg := StoreHealthConfig{ConsecutiveFails: n}
+		if got := cfg.ConsecutiveFailsOrDefault(); got != 3 {
+			t.Errorf("ConsecutiveFailsOrDefault() with %d = %d, want the 3 default", n, got)
+		}
+	}
+}
+
+func TestStoreHealthEnabledDefaultsToTrue(t *testing.T) {
+	enabled := true
+	tests := []struct {
+		name string
+		cfg  StoreHealthConfig
+		want bool
+	}{
+		{"unset defaults to enabled", StoreHealthConfig{}, true},
+		{"explicit true", StoreHealthConfig{Enabled: &enabled}, true},
+		{"explicit false", StoreHealthConfig{Enabled: new(bool)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.StoreHealthEnabledOrDefault(); got != tt.want {
+				t.Errorf("StoreHealthEnabledOrDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDurationsBadStoreHealthFields(t *testing.T) {
+	cfg := &City{
+		StoreHealth: StoreHealthConfig{
+			Interval:           "30 secs",
+			ReapCooldown:       "ten minutes",
+			WriteProbeInterval: "1hour",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 3 {
+		t.Fatalf("expected 3 warnings, got %d: %v", len(warnings), warnings)
+	}
+	joined := strings.Join(warnings, "|")
+	if !strings.Contains(joined, "[storehealth]") {
+		t.Errorf("warnings should mention section [storehealth]: %v", warnings)
+	}
+	for _, field := range []string{"interval", "reap_cooldown", "write_probe_interval"} {
+		if !strings.Contains(joined, field) {
+			t.Errorf("warnings should mention %s field: %v", field, warnings)
+		}
+	}
+}
+
+func TestValidateDurationsStoreHealthValidOK(t *testing.T) {
+	cfg := &City{
+		StoreHealth: StoreHealthConfig{
+			Interval:           "30s",
+			ConsecutiveFails:   3,
+			ReapCooldown:       "10m",
+			WriteProbeInterval: "10m",
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for valid [storehealth], got: %v", warnings)
+	}
+}

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -168,6 +168,11 @@ func ValidateDurations(cfg *City, source string) []string {
 		}
 	}
 
+	// Store health patrol durations.
+	check("[storehealth]", "interval", cfg.StoreHealth.Interval)
+	check("[storehealth]", "reap_cooldown", cfg.StoreHealth.ReapCooldown)
+	check("[storehealth]", "write_probe_interval", cfg.StoreHealth.WriteProbeInterval)
+
 	// Chat sessions config durations.
 	check("[chat_sessions]", "idle_timeout", cfg.ChatSessions.IdleTimeout)
 	check("[chat_sessions]", "grace_period", cfg.ChatSessions.GracePeriod)


### PR DESCRIPTION
Part of the split of #3324 (closed) into independently reviewable pieces.
Stands alone — no dependency on #5945 or #5946.

## What

Adds `StoreHealthConfig` and its `City` field, so the controller-internal
store health patrol reads its thresholds from `city.toml` instead of from
constants.

```toml
[storehealth]
enabled              = true   # toggle the patrol
interval             = "30s"  # per-scope probe cadence
consecutive_fails    = 3      # cycles that confirm a poison
reap_cooldown        = "10m"  # minimum spacing between reaps for one scope
write_probe_interval = "10m"  # cadence of the write-path conformance probe
```

Every knob is mechanical — durations and counts only, no judgment calls.
The values shown are the defaults; the block is entirely optional.

## Why each field goes through an `OrDefault` accessor

Nothing reads these fields directly. An absent section, an unparseable
value and a non-positive value all collapse to the documented default
rather than silently becoming zero at runtime — which matters here more
than usual, because a zero confirm threshold would trip on the very first
failed cycle and a zero interval would busy-loop. `positiveDurationOrDefault`
is the shared parse-or-default helper for the duration fields.

The three duration fields also join `ValidateDurations`, so a typo like
`"5mins"` surfaces as a load-time warning naming the section and the field
instead of defaulting silently.

## Generated docs

`docs/reference/config.md` and the city schema are **regenerated**
(`make generate`), not hand-edited. `make check-schema` is clean.

## Scope

- `internal/config/config.go`: +71 (the struct, its accessors, the `City`
  field, and the shared duration helper)
- `internal/config/validate_durations.go`: +5
- `internal/config/storehealth_config_test.go`: +208
- generated docs: +85

## Tests

Seven cases, covering the TOML wiring through the real `Parse` entry point
(not a hand-built struct), the defaults for an absent section, the fallback
behaviour for unparseable / zero / negative values, `enabled` defaulting to
true when unset, `Marshal` omitting the empty section, and both arms of the
duration validation.

## Verification

```
gofmt -l internal/ cmd/            # clean
go build ./...                     # ok
go vet ./...                       # ok
go test ./internal/config/...      # ok
go test ./test/docsync/            # ok
make check-schema                  # ok (generated docs in sync)
go test -run TestOpenAPISpecInSync ./internal/api/  # ok
```
