### PR TITLE
feat(config): add the [beads.resilience] config block

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -292,6 +292,22 @@ BeadsConfig holds bead store settings.
 | `conditional_writes` | string |  |  | ConditionalWrites selects the bead-write discipline: "off" (legacy, byte-identical), "auto" (compare-and-swap where the store is capable, loud degrade otherwise), or "require" (CAS or a typed refusal). Empty defaults to "off". Any other value fails config load. Enum: `off`, `auto`, `require` |
 | `guarded_release` | string |  |  | GuardedRelease selects the ownership-release discipline for work beads: "off" (legacy, owner-blind bd update/unclaim), "auto" (fence-guarded release verbs where the bd binary is capable, loud degrade otherwise), or "require" (guarded release or a typed refusal). Empty defaults to "off". Any other value fails config load. Enum: `off`, `auto`, `require` |
 | `policies` | map[string]BeadPolicyConfig |  |  | Policies defines per-bead-use storage and garbage-collection defaults. Policy names are interpreted by higher-level systems; unknown names are preserved so packs can stage future policy classes without breaking load. |
+| `resilience` | BeadsResilienceConfig |  |  | Resilience configures the transport circuit breaker that guards bd subprocess and store operations ([beads.resilience]). |
+
+## BeadsResilienceConfig
+
+BeadsResilienceConfig holds circuit breaker settings for transport-class bead store failures.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | boolean |  | `true` | Enabled toggles the breaker. Defaults to true. |
+| `consecutive_failures` | integer |  | `3` | ConsecutiveFailures is how many consecutive transport-class failures trip the breaker. Defaults to 3. |
+| `open_base` | string |  | `1s` | OpenBase is the initial open-state backoff cap as a duration string. Defaults to "1s". |
+| `open_max` | string |  | `60s` | OpenMax caps the open-state backoff as a duration string. Defaults to "60s". |
+| `half_open_interval` | string |  | `15s` | HalfOpenInterval is the minimum spacing between recovery probes while half-open, as a duration string. Defaults to "15s". |
+| `max_inflight_per_scope` | integer |  | `4` | MaxInflightPerScope bounds concurrent bd subprocesses per scope. The admission semaphore blocks the (n+1)th bd call for a scope until one in flight returns, capping the subprocess amplifier (plan item 1.9). Defaults to 4. Non-positive disables the per-scope cap. |
+| `max_inflight_global` | integer |  | `16` | MaxInflightGlobal bounds concurrent bd subprocesses across all scopes in the city. Defaults to 16. Non-positive disables the global cap. |
+| `max_admission_wait` | string |  | `30s` | MaxAdmissionWait bounds how long the admission semaphore waits for a free slot before failing fast, as a duration string. When the caps are saturated by bd subprocesses wedged on a backend transport timeout, a bounded wait prevents reconcile fan-out from blocking the controller tick indefinitely: an admission that cannot be granted within this window fails like an open breaker (typed ErrStoreUnavailable, zero subprocesses). Defaults to "30s". A non-positive value (e.g. "0s") restores the pre-bound behavior of blocking forever. |
 
 ## ChatSessionsConfig
 

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1067,11 +1067,62 @@
           },
           "type": "object",
           "description": "Policies defines per-bead-use storage and garbage-collection defaults.\nPolicy names are interpreted by higher-level systems; unknown names are\npreserved so packs can stage future policy classes without breaking load."
+        },
+        "resilience": {
+          "$ref": "#/$defs/BeadsResilienceConfig",
+          "description": "Resilience configures the transport circuit breaker that guards bd\nsubprocess and store operations ([beads.resilience])."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "BeadsConfig holds bead store settings."
+    },
+    "BeadsResilienceConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled toggles the breaker. Defaults to true.",
+          "default": true
+        },
+        "consecutive_failures": {
+          "type": "integer",
+          "description": "ConsecutiveFailures is how many consecutive transport-class failures\ntrip the breaker. Defaults to 3.",
+          "default": 3
+        },
+        "open_base": {
+          "type": "string",
+          "description": "OpenBase is the initial open-state backoff cap as a duration string.\nDefaults to \"1s\".",
+          "default": "1s"
+        },
+        "open_max": {
+          "type": "string",
+          "description": "OpenMax caps the open-state backoff as a duration string. Defaults\nto \"60s\".",
+          "default": "60s"
+        },
+        "half_open_interval": {
+          "type": "string",
+          "description": "HalfOpenInterval is the minimum spacing between recovery probes\nwhile half-open, as a duration string. Defaults to \"15s\".",
+          "default": "15s"
+        },
+        "max_inflight_per_scope": {
+          "type": "integer",
+          "description": "MaxInflightPerScope bounds concurrent bd subprocesses per scope. The\nadmission semaphore blocks the (n+1)th bd call for a scope until one\nin flight returns, capping the subprocess amplifier (plan item 1.9).\nDefaults to 4. Non-positive disables the per-scope cap.",
+          "default": 4
+        },
+        "max_inflight_global": {
+          "type": "integer",
+          "description": "MaxInflightGlobal bounds concurrent bd subprocesses across all scopes\nin the city. Defaults to 16. Non-positive disables the global cap.",
+          "default": 16
+        },
+        "max_admission_wait": {
+          "type": "string",
+          "description": "MaxAdmissionWait bounds how long the admission semaphore waits for a\nfree slot before failing fast, as a duration string. When the caps are\nsaturated by bd subprocesses wedged on a backend transport timeout, a\nbounded wait prevents reconcile fan-out from blocking the controller\ntick indefinitely: an admission that cannot be granted within this\nwindow fails like an open breaker (typed ErrStoreUnavailable, zero\nsubprocesses). Defaults to \"30s\". A non-positive value (e.g. \"0s\")\nrestores the pre-bound behavior of blocking forever.",
+          "default": "30s"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BeadsResilienceConfig holds circuit breaker settings for transport-class bead store failures."
     },
     "ChatSessionsConfig": {
       "properties": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1067,11 +1067,62 @@
           },
           "type": "object",
           "description": "Policies defines per-bead-use storage and garbage-collection defaults.\nPolicy names are interpreted by higher-level systems; unknown names are\npreserved so packs can stage future policy classes without breaking load."
+        },
+        "resilience": {
+          "$ref": "#/$defs/BeadsResilienceConfig",
+          "description": "Resilience configures the transport circuit breaker that guards bd\nsubprocess and store operations ([beads.resilience])."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "BeadsConfig holds bead store settings."
+    },
+    "BeadsResilienceConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled toggles the breaker. Defaults to true.",
+          "default": true
+        },
+        "consecutive_failures": {
+          "type": "integer",
+          "description": "ConsecutiveFailures is how many consecutive transport-class failures\ntrip the breaker. Defaults to 3.",
+          "default": 3
+        },
+        "open_base": {
+          "type": "string",
+          "description": "OpenBase is the initial open-state backoff cap as a duration string.\nDefaults to \"1s\".",
+          "default": "1s"
+        },
+        "open_max": {
+          "type": "string",
+          "description": "OpenMax caps the open-state backoff as a duration string. Defaults\nto \"60s\".",
+          "default": "60s"
+        },
+        "half_open_interval": {
+          "type": "string",
+          "description": "HalfOpenInterval is the minimum spacing between recovery probes\nwhile half-open, as a duration string. Defaults to \"15s\".",
+          "default": "15s"
+        },
+        "max_inflight_per_scope": {
+          "type": "integer",
+          "description": "MaxInflightPerScope bounds concurrent bd subprocesses per scope. The\nadmission semaphore blocks the (n+1)th bd call for a scope until one\nin flight returns, capping the subprocess amplifier (plan item 1.9).\nDefaults to 4. Non-positive disables the per-scope cap.",
+          "default": 4
+        },
+        "max_inflight_global": {
+          "type": "integer",
+          "description": "MaxInflightGlobal bounds concurrent bd subprocesses across all scopes\nin the city. Defaults to 16. Non-positive disables the global cap.",
+          "default": 16
+        },
+        "max_admission_wait": {
+          "type": "string",
+          "description": "MaxAdmissionWait bounds how long the admission semaphore waits for a\nfree slot before failing fast, as a duration string. When the caps are\nsaturated by bd subprocesses wedged on a backend transport timeout, a\nbounded wait prevents reconcile fan-out from blocking the controller\ntick indefinitely: an admission that cannot be granted within this\nwindow fails like an open breaker (typed ErrStoreUnavailable, zero\nsubprocesses). Defaults to \"30s\". A non-positive value (e.g. \"0s\")\nrestores the pre-bound behavior of blocking forever.",
+          "default": "30s"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BeadsResilienceConfig holds circuit breaker settings for transport-class bead store failures."
     },
     "ChatSessionsConfig": {
       "properties": {

--- a/internal/config/beads_resilience_test.go
+++ b/internal/config/beads_resilience_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// loadBeadsResilienceConfig writes content to a temp city.toml and loads it.
+func loadBeadsResilienceConfig(t *testing.T, content string) *City {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "city.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return cfg
+}
+
+func TestBeadsResilienceDefaults(t *testing.T) {
+	var r BeadsResilienceConfig
+	if !r.EnabledOrDefault() {
+		t.Error("EnabledOrDefault() = false for zero config, want true")
+	}
+	if got := r.ConsecutiveFailuresOrDefault(); got != 3 {
+		t.Errorf("ConsecutiveFailuresOrDefault() = %d, want 3", got)
+	}
+	if got := r.OpenBaseOrDefault(); got != time.Second {
+		t.Errorf("OpenBaseOrDefault() = %v, want 1s", got)
+	}
+	if got := r.OpenMaxOrDefault(); got != 60*time.Second {
+		t.Errorf("OpenMaxOrDefault() = %v, want 60s", got)
+	}
+	if got := r.HalfOpenIntervalOrDefault(); got != 15*time.Second {
+		t.Errorf("HalfOpenIntervalOrDefault() = %v, want 15s", got)
+	}
+	if got := r.MaxInflightPerScopeOrDefault(); got != 4 {
+		t.Errorf("MaxInflightPerScopeOrDefault() = %d, want 4", got)
+	}
+	if got := r.MaxInflightGlobalOrDefault(); got != 16 {
+		t.Errorf("MaxInflightGlobalOrDefault() = %d, want 16", got)
+	}
+	if got := r.MaxAdmissionWaitOrDefault(); got != 30*time.Second {
+		t.Errorf("MaxAdmissionWaitOrDefault() = %v, want 30s", got)
+	}
+}
+
+func TestBeadsResilienceMaxAdmissionWait(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"unset uses default", "", 30 * time.Second},
+		{"explicit positive", "45s", 45 * time.Second},
+		{"unparseable uses default", "not-a-duration", 30 * time.Second},
+		{"zero blocks forever", "0s", 0},
+		{"negative blocks forever", "-1s", -time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := BeadsResilienceConfig{MaxAdmissionWait: tc.value}
+			if got := r.MaxAdmissionWaitOrDefault(); got != tc.want {
+				t.Errorf("MaxAdmissionWaitOrDefault() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBeadsResilienceMaxAdmissionWaitValidated(t *testing.T) {
+	cfg := &City{}
+	cfg.Beads.Resilience.MaxAdmissionWait = "5mins"
+	warnings := ValidateDurations(cfg, "city.toml")
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "[beads.resilience]") && strings.Contains(w, "max_admission_wait") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ValidateDurations warnings = %v, want a [beads.resilience] max_admission_wait warning", warnings)
+	}
+}
+
+func TestBeadsResilienceInflightCaps(t *testing.T) {
+	tests := []struct {
+		name             string
+		perScope, global int
+		wantPer, wantGlb int
+	}{
+		{"zero uses defaults", 0, 0, 4, 16},
+		{"explicit positive", 8, 32, 8, 32},
+		{"negative disables", -1, -1, 0, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := BeadsResilienceConfig{MaxInflightPerScope: tc.perScope, MaxInflightGlobal: tc.global}
+			if got := r.MaxInflightPerScopeOrDefault(); got != tc.wantPer {
+				t.Errorf("MaxInflightPerScopeOrDefault() = %d, want %d", got, tc.wantPer)
+			}
+			if got := r.MaxInflightGlobalOrDefault(); got != tc.wantGlb {
+				t.Errorf("MaxInflightGlobalOrDefault() = %d, want %d", got, tc.wantGlb)
+			}
+		})
+	}
+}
+
+func TestBeadsResilienceParsesFromTOML(t *testing.T) {
+	cfg := loadBeadsResilienceConfig(t, `
+[workspace]
+name = "test"
+
+[beads.resilience]
+enabled = false
+consecutive_failures = 5
+open_base = "2s"
+open_max = "30s"
+half_open_interval = "10s"
+`)
+	r := cfg.Beads.Resilience
+	if r.EnabledOrDefault() {
+		t.Error("EnabledOrDefault() = true, want false (explicit enabled = false)")
+	}
+	if got := r.ConsecutiveFailuresOrDefault(); got != 5 {
+		t.Errorf("ConsecutiveFailuresOrDefault() = %d, want 5", got)
+	}
+	if got := r.OpenBaseOrDefault(); got != 2*time.Second {
+		t.Errorf("OpenBaseOrDefault() = %v, want 2s", got)
+	}
+	if got := r.OpenMaxOrDefault(); got != 30*time.Second {
+		t.Errorf("OpenMaxOrDefault() = %v, want 30s", got)
+	}
+	if got := r.HalfOpenIntervalOrDefault(); got != 10*time.Second {
+		t.Errorf("HalfOpenIntervalOrDefault() = %v, want 10s", got)
+	}
+}
+
+func TestBeadsResilienceInvalidValuesFallBackToDefaults(t *testing.T) {
+	r := BeadsResilienceConfig{
+		ConsecutiveFailures: -2,
+		OpenBase:            "not-a-duration",
+		OpenMax:             "-5s",
+		HalfOpenInterval:    "0s",
+	}
+	if got := r.ConsecutiveFailuresOrDefault(); got != 3 {
+		t.Errorf("ConsecutiveFailuresOrDefault() = %d, want 3", got)
+	}
+	if got := r.OpenBaseOrDefault(); got != time.Second {
+		t.Errorf("OpenBaseOrDefault() = %v, want 1s", got)
+	}
+	if got := r.OpenMaxOrDefault(); got != 60*time.Second {
+		t.Errorf("OpenMaxOrDefault() = %v, want 60s", got)
+	}
+	if got := r.HalfOpenIntervalOrDefault(); got != 15*time.Second {
+		t.Errorf("HalfOpenIntervalOrDefault() = %v, want 15s", got)
+	}
+}
+
+func TestBeadsResilienceDurationsValidated(t *testing.T) {
+	cfg := &City{}
+	cfg.Beads.Resilience.OpenBase = "5mins"
+	warnings := ValidateDurations(cfg, "city.toml")
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "[beads.resilience]") && strings.Contains(w, "open_base") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ValidateDurations warnings = %v, want a [beads.resilience] open_base warning", warnings)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1420,6 +1420,137 @@ type BeadsConfig struct {
 	// Policy names are interpreted by higher-level systems; unknown names are
 	// preserved so packs can stage future policy classes without breaking load.
 	Policies map[string]BeadPolicyConfig `toml:"policies,omitempty"`
+	// Resilience configures the transport circuit breaker that guards bd
+	// subprocess and store operations ([beads.resilience]).
+	Resilience BeadsResilienceConfig `toml:"resilience,omitempty"`
+}
+
+// BeadsResilienceConfig holds circuit breaker settings for transport-class
+// bead store failures. The breaker trips a (scope, opClass) circuit after
+// ConsecutiveFailures consecutive transport failures, backs off with full
+// jitter between OpenBase and OpenMax, and admits one recovery probe per
+// HalfOpenInterval. Disabling it restores pre-breaker behavior (every
+// operation dials the store).
+type BeadsResilienceConfig struct {
+	// Enabled toggles the breaker. Defaults to true.
+	Enabled *bool `toml:"enabled,omitempty" jsonschema:"default=true"`
+	// ConsecutiveFailures is how many consecutive transport-class failures
+	// trip the breaker. Defaults to 3.
+	ConsecutiveFailures int `toml:"consecutive_failures,omitempty" jsonschema:"default=3"`
+	// OpenBase is the initial open-state backoff cap as a duration string.
+	// Defaults to "1s".
+	OpenBase string `toml:"open_base,omitempty" jsonschema:"default=1s"`
+	// OpenMax caps the open-state backoff as a duration string. Defaults
+	// to "60s".
+	OpenMax string `toml:"open_max,omitempty" jsonschema:"default=60s"`
+	// HalfOpenInterval is the minimum spacing between recovery probes
+	// while half-open, as a duration string. Defaults to "15s".
+	HalfOpenInterval string `toml:"half_open_interval,omitempty" jsonschema:"default=15s"`
+	// MaxInflightPerScope bounds concurrent bd subprocesses per scope. The
+	// admission semaphore blocks the (n+1)th bd call for a scope until one
+	// in flight returns, capping the subprocess amplifier (plan item 1.9).
+	// Defaults to 4. Non-positive disables the per-scope cap.
+	MaxInflightPerScope int `toml:"max_inflight_per_scope,omitempty" jsonschema:"default=4"`
+	// MaxInflightGlobal bounds concurrent bd subprocesses across all scopes
+	// in the city. Defaults to 16. Non-positive disables the global cap.
+	MaxInflightGlobal int `toml:"max_inflight_global,omitempty" jsonschema:"default=16"`
+	// MaxAdmissionWait bounds how long the admission semaphore waits for a
+	// free slot before failing fast, as a duration string. When the caps are
+	// saturated by bd subprocesses wedged on a backend transport timeout, a
+	// bounded wait prevents reconcile fan-out from blocking the controller
+	// tick indefinitely: an admission that cannot be granted within this
+	// window fails like an open breaker (typed ErrStoreUnavailable, zero
+	// subprocesses). Defaults to "30s". A non-positive value (e.g. "0s")
+	// restores the pre-bound behavior of blocking forever.
+	MaxAdmissionWait string `toml:"max_admission_wait,omitempty" jsonschema:"default=30s"`
+}
+
+// EnabledOrDefault reports whether the breaker is enabled (default true).
+func (r BeadsResilienceConfig) EnabledOrDefault() bool {
+	return r.Enabled == nil || *r.Enabled
+}
+
+// ConsecutiveFailuresOrDefault returns the trip threshold, falling back to
+// 3 when unset or non-positive.
+func (r BeadsResilienceConfig) ConsecutiveFailuresOrDefault() int {
+	if r.ConsecutiveFailures > 0 {
+		return r.ConsecutiveFailures
+	}
+	return 3
+}
+
+// OpenBaseOrDefault returns the parsed OpenBase, falling back to 1s when
+// unset, unparseable, or non-positive. Invalid values surface as warnings
+// from ValidateDurations at load time.
+func (r BeadsResilienceConfig) OpenBaseOrDefault() time.Duration {
+	return positiveDurationOrDefault(r.OpenBase, time.Second)
+}
+
+// OpenMaxOrDefault returns the parsed OpenMax, falling back to 60s when
+// unset, unparseable, or non-positive.
+func (r BeadsResilienceConfig) OpenMaxOrDefault() time.Duration {
+	return positiveDurationOrDefault(r.OpenMax, 60*time.Second)
+}
+
+// HalfOpenIntervalOrDefault returns the parsed HalfOpenInterval, falling
+// back to 15s when unset, unparseable, or non-positive.
+func (r BeadsResilienceConfig) HalfOpenIntervalOrDefault() time.Duration {
+	return positiveDurationOrDefault(r.HalfOpenInterval, 15*time.Second)
+}
+
+// MaxInflightPerScopeOrDefault returns the per-scope bd admission limit,
+// falling back to 4 when unset. A negative value disables the cap (returns
+// 0); an explicit 0 also disables it.
+func (r BeadsResilienceConfig) MaxInflightPerScopeOrDefault() int {
+	if r.MaxInflightPerScope < 0 {
+		return 0
+	}
+	if r.MaxInflightPerScope == 0 {
+		return 4
+	}
+	return r.MaxInflightPerScope
+}
+
+// MaxInflightGlobalOrDefault returns the global bd admission limit, falling
+// back to 16 when unset. A negative value disables the cap (returns 0); an
+// explicit 0 also disables it.
+func (r BeadsResilienceConfig) MaxInflightGlobalOrDefault() int {
+	if r.MaxInflightGlobal < 0 {
+		return 0
+	}
+	if r.MaxInflightGlobal == 0 {
+		return 16
+	}
+	return r.MaxInflightGlobal
+}
+
+// MaxAdmissionWaitOrDefault returns the parsed MaxAdmissionWait, falling
+// back to 30s when unset or unparseable. A non-positive value (e.g. "0s" or
+// a negative duration) is preserved verbatim to mean "block forever",
+// disabling the bounded-wait fail-fast. Unparseable values surface as
+// warnings from ValidateDurations at load time.
+func (r BeadsResilienceConfig) MaxAdmissionWaitOrDefault() time.Duration {
+	if r.MaxAdmissionWait == "" {
+		return 30 * time.Second
+	}
+	v, err := time.ParseDuration(r.MaxAdmissionWait)
+	if err != nil {
+		return 30 * time.Second
+	}
+	return v
+}
+
+// positiveDurationOrDefault parses value as a Go duration, returning def
+// when value is empty, unparseable, or non-positive.
+func positiveDurationOrDefault(value string, def time.Duration) time.Duration {
+	if value == "" {
+		return def
+	}
+	v, err := time.ParseDuration(value)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
 }
 
 // EventHooksEnabled reports whether bead event hooks should be installed.

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -168,6 +168,12 @@ func ValidateDurations(cfg *City, source string) []string {
 		}
 	}
 
+	// Beads resilience (circuit breaker) durations.
+	check("[beads.resilience]", "open_base", cfg.Beads.Resilience.OpenBase)
+	check("[beads.resilience]", "open_max", cfg.Beads.Resilience.OpenMax)
+	check("[beads.resilience]", "half_open_interval", cfg.Beads.Resilience.HalfOpenInterval)
+	check("[beads.resilience]", "max_admission_wait", cfg.Beads.Resilience.MaxAdmissionWait)
+
 	// Chat sessions config durations.
 	check("[chat_sessions]", "idle_timeout", cfg.ChatSessions.IdleTimeout)
 	check("[chat_sessions]", "grace_period", cfg.ChatSessions.GracePeriod)


### PR DESCRIPTION
## Summary

Adds the `[beads.resilience]` config block — the tunables the bd transport circuit breaker and the bd subprocess admission semaphore will read — so those two features can land as small, reviewable follow-ups instead of arriving welded to their config.

Part of the split of #3324 (closed) into independently reviewable pieces. Stands alone — no dependency on #5945, #5946, or #5947. Nothing else from #3324 is here.

### What it adds

`BeadsResilienceConfig` and the `Beads.Resilience` field, with an `OrDefault` accessor per field and duration validation at load time:

| Key | Default | Meaning |
| --- | --- | --- |
| `enabled` | `true` | Toggles the breaker. |
| `consecutive_failures` | `3` | Transport-class failures that trip a circuit. |
| `open_base` | `1s` | Initial open-state backoff cap. |
| `open_max` | `60s` | Ceiling on the open-state backoff. |
| `half_open_interval` | `15s` | Minimum spacing between recovery probes. |
| `max_inflight_per_scope` | `4` | Concurrent bd subprocesses per scope. Non-positive disables. |
| `max_inflight_global` | `16` | Concurrent bd subprocesses city-wide. Non-positive disables. |
| `max_admission_wait` | `30s` | Bounded wait for an admission slot. Non-positive blocks forever. |

Unparseable durations fall back to the default and surface as a load-time warning from `ValidateDurations`, consistent with every other duration block.

### What it does NOT do

**Nothing reads these values.** No breaker, no semaphore, no behavior change of any kind — this PR is config plumbing and its tests, deliberately inert so the consumers can be reviewed on their own merits. It also does not touch `[storehealth]`, `[doctor]`, or the `[daemon]` duration checks, which belong to other PRs in the split.

### Heads-up: trivial overlap with #5947

Both this PR and #5947 (`[storehealth]` config) introduce the same shared
`positiveDurationOrDefault` helper in `internal/config/config.go` — it exists once
on the branch both were extracted from, and each PR needs it to build standalone.
**Whichever merges second should drop its copy of the helper**; the rest of both
diffs is disjoint. Flagging it here so it is not mistaken for a real conflict.

### Generated artifacts

`docs/reference/schema/city-schema.{json,txt}` and `docs/reference/config.md` are regenerated by `cmd/genschema`, not hand-edited (per `AGENTS.md`). `scripts/check-generated-docs-drift.sh` reports fresh.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `go test ./internal/config/` — 2074 tests pass, including 7 new `TestBeadsResilience*` cases (defaults, TOML parsing, invalid-value fallback, inflight caps, and the two `ValidateDurations` warning paths)
- `make test-fast-parallel` with `GC_FAST_UNIT=0` — all 10 jobs pass (`unit-core`, all six `cmd/gc` shards, and the three self-tests)
- `scripts/check-generated-docs-drift.sh` — fresh

## Checklist

- [x] Added tests
- [x] Inert by construction — no consumer, so no behavior change
- [x] Generated docs regenerated, not hand-edited
- [x] No breaking changes

Replaces the config portion of #3324.
