### PR TITLE
fix(pool): treat a foreign <rig>/<name> claim as unobservable, not dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The pool orphan sweep treats a claim it cannot observe as unobservable,
+  not dead.** On a shared store, an assignee in `<rig>/<name>` form that this
+  city's config does not mint — another city's identity, or a binding since
+  REMOVED from local config — used to be judged by local session evidence
+  alone and silently stripped (`in_progress` → `open`, assignee cleared).
+  Both release sites now refuse such claims and log one
+  `protected N foreign/unknown identities` summary per sweep. Migration note
+  for the removed-binding case: decommissioning an agent from config no longer
+  lets the sweep reclaim its outstanding claims — release them explicitly
+  (`gc bd release`/reassign) when retiring a binding, and watch the summary
+  line for claims held back.
+
 - **The work-record close gate asks the repository the bead's OWNER points at,
   not the store it was read through.** A rig's work step that a relocated class
   binding holds has its commits on the rig's checkout, and both close doors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `protected N foreign/unknown identities` summary per sweep. Migration note
   for the removed-binding case: decommissioning an agent from config no longer
   lets the sweep reclaim its outstanding claims — release them explicitly
-  (`gc bd release`/reassign) when retiring a binding, and watch the summary
+  (`gc bd release-if-current <id> <assignee>`/reassign) when retiring a
+  binding, and watch the summary
   line for claims held back.
 
 - **The work-record close gate asks the repository the bead's OWNER points at,

--- a/cmd/gc/pool_orphan_foreign_identity.go
+++ b/cmd/gc/pool_orphan_foreign_identity.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// The pool orphan sweeper validates a claim it can SEE against liveness
+// evidence it may not be able to see. A work bead in a SHARED rig store is
+// visible to every city attached to that rig, but the session bead proving the
+// claim is alive lives in the claiming city's own hq — unfederated. So when a
+// foreign city's agent holds a claim, this city asks its own hq for that
+// session, does not find it, and concludes the claim is dead. Both cities do
+// it to each other: theirs cleared two of our P0s and a P1 in an 8-second
+// batch; ours cleared fifteen of theirs in 34 seconds on 2026-08-21.
+//
+// The gate below separates "no session bead exists" from "no session bead is
+// OBSERVABLE from here":
+//
+//	foreign / unknown  -> unobservable -> PROTECTED (skip, do not release)
+//	locally configured -> observable   -> today's behaviour, UNCHANGED
+//
+// The unchanged-for-local property is what makes this shippable onto a box
+// running live reviews, so every helper here is a pure read of local config.
+//
+// TWO THINGS THIS GATE DELIBERATELY DOES NOT DO.
+//
+// It does not test the RIG PREFIX. qcore is precisely the SHARED rig, so a
+// prefix test protects nothing — the discriminator has to be the agent
+// identity against the local roster.
+//
+// It does not test pool CAPACITY. "<local agent>-<slot>" is an instance
+// identity of a local agent family whatever the current max_active_sessions
+// says; measured against this city's own release history, live assignees run up
+// to qcore/gc.run-operator-36 against a pool configured for 4. Gating on the
+// slot ceiling would make every claim above the ceiling permanently unreapable
+// the moment a pool is shrunk.
+//
+// KNOWN RESIDUAL (tracked separately): two cities importing the same agent pack
+// share an identity space, so a foreign POOL instance ("qcore/gastown.furiosa")
+// is byte-identical to ours and this gate cannot protect it. It protects
+// foreign NAMED identities, which is the shape both observed incidents took.
+// Closing the residual needs a claiming-city discriminator on the claim itself.
+
+// poolAssigneeIsLocallyObservable reports whether assignee names an identity
+// whose liveness this city is in a position to answer.
+//
+// Anything that is not a well-formed <rig>/<name> identity returns true: bare
+// aliases, session bead IDs and runtime session names ("gastown__dog-ga-up143",
+// "claude-mc-xyz") are this city's own naming and were never the cross-city
+// hazard. Keeping them on the existing path is what preserves current
+// behaviour for every local assignee shape.
+func poolAssigneeIsLocallyObservable(cfg *config.City, cityName, assignee string) bool {
+	assignee = strings.TrimSpace(assignee)
+	if cfg == nil || assignee == "" {
+		return true
+	}
+	rig, local := config.ParseQualifiedName(assignee)
+	if strings.TrimSpace(rig) == "" || strings.TrimSpace(local) == "" {
+		return true
+	}
+	return poolIdentityInLocalRoster(cfg, cityName, assignee)
+}
+
+// poolIdentityInLocalRoster resolves a <rig>/<name> identity against local
+// config: configured named sessions, configured agent templates (including the
+// legacy bound form that persisted assignees still carry), namepool-themed pool
+// instances, and the instance identities gc mints for a local agent (numeric
+// slots and adhoc tokens).
+func poolIdentityInLocalRoster(cfg *config.City, cityName, identity string) bool {
+	for _, candidate := range poolIdentityLocalCandidates(identity) {
+		if _, ok := findNamedSessionSpec(cfg, cityName, candidate); ok {
+			return true
+		}
+		if findAgentByTemplate(cfg, candidate) != nil {
+			return true
+		}
+		if config.FindAgent(cfg, candidate) != nil {
+			return true
+		}
+		if poolIdentityIsThemedInstance(cfg, candidate) {
+			return true
+		}
+		if poolIdentityIsInstanceOfLocalAgent(cfg, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// poolIdentityLocalCandidates returns the identity itself plus, when its local
+// part carries a binding prefix, the binding-stripped form.
+//
+// Persisted assignees outlive the config that minted them: this city's own
+// release history is full of "qcore/gastown.polecat" and
+// "qcore/gc.run-operator-1" while the resolved config now holds those agents
+// UNBOUND as "qcore/polecat" and "qcore/run-operator". findAgentByTemplate
+// already carries that bound->unbound fallback for exact template lookups
+// (legacyBoundTemplateMatchesUnboundAgent); the instance forms below need the
+// same tolerance, so the stripping happens once, here, for every check.
+// Without it this gate reads 45 of this city's 46 historically-reaped pool
+// identities as foreign and protects them forever — a sweeper that has been
+// disabled rather than fixed.
+func poolIdentityLocalCandidates(identity string) []string {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return nil
+	}
+	candidates := []string{identity}
+	rig, local := config.ParseQualifiedName(identity)
+	if binding, unbound, ok := strings.Cut(local, "."); ok && binding != "" && unbound != "" {
+		stripped := unbound
+		if rig != "" {
+			stripped = rig + "/" + unbound
+		}
+		candidates = append(candidates, stripped)
+	}
+	return candidates
+}
+
+// poolIdentityIsThemedInstance matches a namepool display name, e.g.
+// "qcore/furiosa" against agent qcore/polecat whose namepool lists "furiosa".
+//
+// A generic rig-scoped template (Dir empty, Scope "rig") applies to every
+// configured rig, so its instances are addressed under a concrete rig this
+// template never names. config.FindAgent already synthesizes the rig-bound copy
+// for exact lookups; the themed comparison has to do the same or a legitimate
+// local "qcore/furiosa" reads as foreign.
+func poolIdentityIsThemedInstance(cfg *config.City, identity string) bool {
+	if cfg == nil {
+		return false
+	}
+	rig, _ := config.ParseQualifiedName(identity)
+	rigConfigured := rig != "" && cityHasRigNamed(cfg, rig)
+	for i := range cfg.Agents {
+		agentCfg := cfg.Agents[i]
+		variants := []config.Agent{agentCfg}
+		if rigConfigured && strings.TrimSpace(agentCfg.Dir) == "" && agentCfg.Scope == "rig" {
+			rigBound := agentCfg
+			rigBound.Dir = rig
+			variants = append(variants, rigBound)
+		}
+		for _, themed := range agentCfg.NamepoolNames {
+			if themed = strings.TrimSpace(themed); themed == "" {
+				continue
+			}
+			for v := range variants {
+				if variants[v].QualifiedInstanceName(themed) == identity {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func cityHasRigNamed(cfg *config.City, name string) bool {
+	if cfg == nil {
+		return false
+	}
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// poolIdentityIsInstanceOfLocalAgent matches an instance identity minted for a
+// locally-configured agent: "<local agent>-<slot>" or
+// "<local agent>-adhoc-<token>".
+//
+// Those are the two instance-name generators in the tree — poolInstanceName's
+// numeric slot form and session.GenerateAdhocIdentity, which cmd_hook.go writes
+// straight into the claim assignee for an aliasless pool worker
+// ("rig/polecat-adhoc-<hash>"). Both are recognised WITHOUT consulting the
+// pool's configured ceiling: see the capacity note at the top of this file.
+//
+// The grammar is closed on purpose rather than accepting any suffix, so this
+// stays a statement about identities gc actually mints. A THIRD generator added
+// later and not added here would have its claims protected — visibly, in the
+// per-sweep summary, rather than silently — which is the failure direction this
+// whole change is built around. Add new generators here.
+func poolIdentityIsInstanceOfLocalAgent(cfg *config.City, identity string) bool {
+	rig, local := config.ParseQualifiedName(identity)
+	for _, base := range poolInstanceBaseNames(local) {
+		baseIdentity := base
+		if rig != "" {
+			baseIdentity = rig + "/" + base
+		}
+		if findAgentByTemplate(cfg, baseIdentity) != nil {
+			return true
+		}
+		if config.FindAgent(cfg, baseIdentity) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// poolInstanceBaseNames strips a recognised instance suffix off an identity's
+// local part and returns the candidate agent names it could have been minted
+// from.
+func poolInstanceBaseNames(local string) []string {
+	var bases []string
+	if base, suffix, ok := cutLastDash(local); ok && isPoolSlotNumber(suffix) {
+		bases = append(bases, base)
+	}
+	if idx := strings.LastIndex(local, "-adhoc-"); idx > 0 {
+		if token := local[idx+len("-adhoc-"):]; token != "" {
+			bases = append(bases, local[:idx])
+		}
+	}
+	return bases
+}
+
+// isPoolSlotNumber accepts only the digits poolInstanceName emits. strconv.Atoi
+// would also accept "+1" and "0007", which no generator produces; letting them
+// through would make this predicate a claim about arbitrary strings rather than
+// about minted identities.
+func isPoolSlotNumber(s string) bool {
+	if s == "" || s == "0" || s[0] == '0' {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func cutLastDash(s string) (string, string, bool) {
+	idx := strings.LastIndex(s, "-")
+	if idx <= 0 || idx == len(s)-1 {
+		return "", "", false
+	}
+	return s[:idx], s[idx+1:], true
+}
+
+// protectedForeignAssignees accumulates one sweep's protected claims so the
+// skip is reported once per pass instead of once per candidate.
+//
+// The count is "candidates this gate skipped", not "beads proven still
+// claimed": the gate returns before the owner-store lookup and the
+// release-time revalidation, so a bead that a concurrent writer has since
+// completed is still counted here. That is deliberate — establishing the
+// stronger claim costs one store read per protected candidate every 30s, and
+// over-reporting is the safe direction for a leak detector.
+//
+// This exists because the gate above is otherwise INVISIBLE, and a silent skip
+// would be a fresh instance of the class it was written to fix. A local agent
+// removed from config is also "not in the local roster", so its claims become
+// protected too — correct as a default, but a permanent silent leak if nobody
+// can see it. Fifty protected claims for an identity nobody recognises has to
+// read as a decommissioned agent leaking, from the log alone, without knowing
+// to look for it.
+type protectedForeignAssignees struct {
+	order      []string
+	byIdentity map[string][]string
+}
+
+// protectedForeignAssigneeIDSampleLimit bounds the per-identity work-bead ID
+// sample so one leaking identity cannot turn the summary into an unreadable
+// line. The count is always exact; only the ID list is sampled.
+const protectedForeignAssigneeIDSampleLimit = 5
+
+func (p *protectedForeignAssignees) add(identity, workID string) {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return
+	}
+	if p.byIdentity == nil {
+		p.byIdentity = make(map[string][]string, 4)
+	}
+	if _, seen := p.byIdentity[identity]; !seen {
+		p.order = append(p.order, identity)
+	}
+	p.byIdentity[identity] = append(p.byIdentity[identity], strings.TrimSpace(workID))
+}
+
+func (p *protectedForeignAssignees) claims() int {
+	total := 0
+	for _, ids := range p.byIdentity {
+		total += len(ids)
+	}
+	return total
+}
+
+// summary renders the once-per-sweep line, or "" when nothing was protected.
+// Identities are sorted so consecutive sweeps produce comparable lines.
+func (p *protectedForeignAssignees) summary() string {
+	if len(p.byIdentity) == 0 {
+		return ""
+	}
+	identities := make([]string, len(p.order))
+	copy(identities, p.order)
+	sort.Strings(identities)
+	parts := make([]string, 0, len(identities))
+	for _, identity := range identities {
+		ids := p.byIdentity[identity]
+		sample := ids
+		suffix := ""
+		if len(sample) > protectedForeignAssigneeIDSampleLimit {
+			suffix = fmt.Sprintf(" +%d more", len(sample)-protectedForeignAssigneeIDSampleLimit)
+			sample = sample[:protectedForeignAssigneeIDSampleLimit]
+		}
+		// %q on the identity: it is untrusted text read off a bead written by
+		// another city, and an unquoted comma or newline would forge structure
+		// in a line an operator reads as a leak report.
+		parts = append(parts, fmt.Sprintf("%q (%d: %s%s)", identity, len(ids), strings.Join(sample, ", "), suffix))
+	}
+	return fmt.Sprintf("releaseOrphanedPoolAssignments: protected %d foreign/unknown identities this pass (%d claims): %s",
+		len(identities), p.claims(), strings.Join(parts, ", "))
+}
+
+func (p *protectedForeignAssignees) log() {
+	if summary := p.summary(); summary != "" {
+		log.Print(summary)
+	}
+}

--- a/cmd/gc/pool_orphan_foreign_identity.go
+++ b/cmd/gc/pool_orphan_foreign_identity.go
@@ -72,7 +72,26 @@ func poolAssigneeIsLocallyObservable(cfg *config.City, cityName, assignee string
 // instances, and the instance identities gc mints for a local agent (numeric
 // slots and adhoc tokens).
 func poolIdentityInLocalRoster(cfg *config.City, cityName, identity string) bool {
-	for _, candidate := range poolIdentityLocalCandidates(identity) {
+	for _, candidate := range poolIdentityLocalCandidates(cfg, identity) {
+		// A candidate still carrying a binding this city does not mint cannot
+		// name a local agent, whatever the resolvers say (ga-8yi7ne). This is
+		// the SECOND route into the collision and it does not go through the
+		// stripped candidate above: poolIdentityIsInstanceOfLocalAgent reduces
+		// "qcore/pool.omp-1" to base "qcore/pool.omp", which
+		// findAgentByTemplate then matches against our unbound "qcore/omp" via
+		// legacyBoundTemplateMatchesUnboundAgent — that helper accepts ANY
+		// binding, by design, because it also serves bound->unbound MIGRATION
+		// RECOVERY in cities where the binding was genuinely removed. So the
+		// discriminator cannot live there without breaking that recovery; it
+		// belongs here, where the question is "is this claim FOREIGN?" rather
+		// than "what agent did this identity used to name?".
+		//
+		// Gating candidates rather than individual checks is deliberate: all
+		// five resolvers below inherit it, so a sixth added later cannot
+		// silently reopen the hole.
+		if !poolCandidateBindingIsLocal(cfg, candidate) {
+			continue
+		}
 		if _, ok := findNamedSessionSpec(cfg, cityName, candidate); ok {
 			return true
 		}
@@ -93,7 +112,7 @@ func poolIdentityInLocalRoster(cfg *config.City, cityName, identity string) bool
 }
 
 // poolIdentityLocalCandidates returns the identity itself plus, when its local
-// part carries a binding prefix, the binding-stripped form.
+// part carries a binding prefix THIS CITY MINTS, the binding-stripped form.
 //
 // Persisted assignees outlive the config that minted them: this city's own
 // release history is full of "qcore/gastown.polecat" and
@@ -105,7 +124,23 @@ func poolIdentityInLocalRoster(cfg *config.City, cityName, identity string) bool
 // Without it this gate reads 45 of this city's 46 historically-reaped pool
 // identities as foreign and protects them forever — a sweeper that has been
 // disabled rather than fixed.
-func poolIdentityLocalCandidates(identity string) []string {
+//
+// THE BINDING GATE (ga-8yi7ne). Stripping ANY binding is what turned this gate
+// from a protection into a cross-city hazard: another city's canonical
+// "qcore/pool.omp-1" strips to "qcore/omp-1", which matches OUR configured
+// "qcore/omp", so their live claim reads as our dead instance and is released.
+// Measured in the field 2026-08-25 — the bead oscillated, released and
+// re-claimed twice, and only their post-hoc quarantine rule settled it.
+//
+// The fix is to strip only bindings this city could itself have minted. A
+// binding names an import, and the city's own agents record which import
+// carried them (config.Agent.BindingName), so the set is exact and needs no
+// heuristic. Measured on this city: {bd, cherub-law, core, gastown, gc,
+// oversight} — which covers every historically-reaped local identity — while
+// the neighbouring city's "pool" and "review" are absent. Their naming is
+// linter-certified canonical on their side and cannot be changed, so the
+// discriminator has to live here.
+func poolIdentityLocalCandidates(cfg *config.City, identity string) []string {
 	identity = strings.TrimSpace(identity)
 	if identity == "" {
 		return nil
@@ -113,13 +148,75 @@ func poolIdentityLocalCandidates(identity string) []string {
 	candidates := []string{identity}
 	rig, local := config.ParseQualifiedName(identity)
 	if binding, unbound, ok := strings.Cut(local, "."); ok && binding != "" && unbound != "" {
-		stripped := unbound
-		if rig != "" {
-			stripped = rig + "/" + unbound
+		if cityMintsBinding(cfg, binding) {
+			stripped := unbound
+			if rig != "" {
+				stripped = rig + "/" + unbound
+			}
+			candidates = append(candidates, stripped)
 		}
-		candidates = append(candidates, stripped)
 	}
 	return candidates
+}
+
+// cityMintsBinding reports whether binding names an import THIS city binds, and
+// so whether this city could itself have minted a "<binding>.<agent>" identity.
+//
+// The DECLARED import tables are the primary source, deliberately ahead of
+// anything inferred from the agents themselves. An import binding is a
+// declaration; whether some agent currently carries it is a side effect, and a
+// city whose only agent from an import has migrated bound->unbound would lose
+// the binding entirely if this read agents alone. That would strand exactly the
+// legacy identities the bound->unbound tolerance exists to keep resolvable.
+//
+//	cfg.Imports            city-level [imports.<binding>]
+//	cfg.DefaultRigImports  [defaults.rig.imports], for imports whose agents are
+//	                       not currently instantiated
+//	rig.Imports            rig-level [rigs.<rig>.imports]; a rig-scoped import
+//	                       mints "<rig>/<binding>.<agent>" just the same
+//	Agent.BindingName      backstop for agents composed through a path none of
+//	                       the tables above record
+//
+// An empty or unknown binding is NOT ours, and that refusal is the whole point.
+// It fails in the safe direction: declining to resolve only ever PROTECTS a
+// claim. Stranding this city's own stale work is repairable and, in the pool
+// sweeper, reported in the per-sweep protected-identity summary; releasing a
+// neighbouring city's live claim is neither.
+func cityMintsBinding(cfg *config.City, binding string) bool {
+	binding = strings.TrimSpace(binding)
+	if cfg == nil || binding == "" {
+		return false
+	}
+	if _, ok := cfg.Imports[binding]; ok {
+		return true
+	}
+	if _, ok := cfg.DefaultRigImports[binding]; ok {
+		return true
+	}
+	for i := range cfg.Rigs {
+		if _, ok := cfg.Rigs[i].Imports[binding]; ok {
+			return true
+		}
+	}
+	for i := range cfg.Agents {
+		if strings.TrimSpace(cfg.Agents[i].BindingName) == binding {
+			return true
+		}
+	}
+	return false
+}
+
+// poolCandidateBindingIsLocal reports whether a roster candidate is free of a
+// FOREIGN binding prefix. A candidate with no binding at all is local as far as
+// this predicate is concerned — bare names are this city's own naming and were
+// never the cross-city hazard.
+func poolCandidateBindingIsLocal(cfg *config.City, candidate string) bool {
+	_, local := config.ParseQualifiedName(strings.TrimSpace(candidate))
+	binding, unbound, ok := strings.Cut(local, ".")
+	if !ok || strings.TrimSpace(binding) == "" || strings.TrimSpace(unbound) == "" {
+		return true
+	}
+	return cityMintsBinding(cfg, binding)
 }
 
 // poolIdentityIsThemedInstance matches a namepool display name, e.g.

--- a/cmd/gc/pool_orphan_foreign_identity.go
+++ b/cmd/gc/pool_orphan_foreign_identity.go
@@ -319,6 +319,15 @@ func poolInstanceBaseNames(local string) []string {
 // would also accept "+1" and "0007", which no generator produces; letting them
 // through would make this predicate a claim about arbitrary strings rather than
 // about minted identities.
+//
+// Deliberately STRICTER than routeHasSlotSuffixShape
+// (demand_serve_predicate.go), which accepts any digit run ("007") because it
+// is a fail-open pre-filter on ROUTE shape. This one is a fail-closed claim
+// about minted IDENTITIES, and on "polecat-007" the two disagree by design:
+// here the unminted shape is PROTECTED AND NAMED in the sweep summary rather
+// than silently stripped to a base name — the safe direction for a suffix no
+// generator produces. Unifying them would force one predicate to answer the
+// other's question.
 func isPoolSlotNumber(s string) bool {
 	if s == "" || s == "0" || s[0] == '0' {
 		return false

--- a/cmd/gc/pool_orphan_foreign_identity.go
+++ b/cmd/gc/pool_orphan_foreign_identity.go
@@ -22,7 +22,7 @@ import (
 // OBSERVABLE from here":
 //
 //	foreign / unknown  -> unobservable -> PROTECTED (skip, do not release)
-//	locally configured -> observable   -> today's behaviour, UNCHANGED
+//	locally configured -> observable   -> today's behavior, UNCHANGED
 //
 // The unchanged-for-local property is what makes this shippable onto a box
 // running live reviews, so every helper here is a pure read of local config.
@@ -53,7 +53,7 @@ import (
 // aliases, session bead IDs and runtime session names ("gastown__dog-ga-up143",
 // "claude-mc-xyz") are this city's own naming and were never the cross-city
 // hazard. Keeping them on the existing path is what preserves current
-// behaviour for every local assignee shape.
+// behavior for every local assignee shape.
 func poolAssigneeIsLocallyObservable(cfg *config.City, cityName, assignee string) bool {
 	assignee = strings.TrimSpace(assignee)
 	if cfg == nil || assignee == "" {
@@ -137,7 +137,7 @@ func poolIdentityInLocalRoster(cfg *config.City, cityName, identity string) bool
 // carried them (config.Agent.BindingName), so the set is exact and needs no
 // heuristic. Measured on this city: {bd, cherub-law, core, gastown, gc,
 // oversight} — which covers every historically-reaped local identity — while
-// the neighbouring city's "pool" and "review" are absent. Their naming is
+// the neighboring city's "pool" and "review" are absent. Their naming is
 // linter-certified canonical on their side and cannot be changed, so the
 // discriminator has to live here.
 func poolIdentityLocalCandidates(cfg *config.City, identity string) []string {
@@ -181,7 +181,7 @@ func poolIdentityLocalCandidates(cfg *config.City, identity string) []string {
 // It fails in the safe direction: declining to resolve only ever PROTECTS a
 // claim. Stranding this city's own stale work is repairable and, in the pool
 // sweeper, reported in the per-sweep protected-identity summary; releasing a
-// neighbouring city's live claim is neither.
+// neighboring city's live claim is neither.
 func cityMintsBinding(cfg *config.City, binding string) bool {
 	binding = strings.TrimSpace(binding)
 	if cfg == nil || binding == "" {
@@ -274,7 +274,7 @@ func cityHasRigNamed(cfg *config.City, name string) bool {
 // Those are the two instance-name generators in the tree — poolInstanceName's
 // numeric slot form and session.GenerateAdhocIdentity, which cmd_hook.go writes
 // straight into the claim assignee for an aliasless pool worker
-// ("rig/polecat-adhoc-<hash>"). Both are recognised WITHOUT consulting the
+// ("rig/polecat-adhoc-<hash>"). Both are recognized WITHOUT consulting the
 // pool's configured ceiling: see the capacity note at the top of this file.
 //
 // The grammar is closed on purpose rather than accepting any suffix, so this
@@ -299,7 +299,7 @@ func poolIdentityIsInstanceOfLocalAgent(cfg *config.City, identity string) bool 
 	return false
 }
 
-// poolInstanceBaseNames strips a recognised instance suffix off an identity's
+// poolInstanceBaseNames strips a recognized instance suffix off an identity's
 // local part and returns the candidate agent names it could have been minted
 // from.
 func poolInstanceBaseNames(local string) []string {
@@ -362,7 +362,7 @@ func cutLastDash(s string) (string, string, bool) {
 // would be a fresh instance of the class it was written to fix. A local agent
 // removed from config is also "not in the local roster", so its claims become
 // protected too — correct as a default, but a permanent silent leak if nobody
-// can see it. Fifty protected claims for an identity nobody recognises has to
+// can see it. Fifty protected claims for an identity nobody recognizes has to
 // read as a decommissioned agent leaking, from the log alone, without knowing
 // to look for it.
 type protectedForeignAssignees struct {

--- a/cmd/gc/pool_orphan_foreign_identity_test.go
+++ b/cmd/gc/pool_orphan_foreign_identity_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// foreignIdentityTestCity mirrors the config shapes this city actually runs:
+// a rig-scoped pool agent with a namepool, addressed in persisted assignees
+// both bare ("repo/worker") and in the legacy bound form ("repo/pack.worker")
+// that outlived its binding.
+func foreignIdentityTestCity(t *testing.T) *config.City {
+	t.Helper()
+	return &config.City{
+		Rigs: []config.Rig{{Name: "repo", Path: t.TempDir()}},
+		Agents: []config.Agent{
+			{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)},
+			{
+				Name:              "worker",
+				Dir:               "repo",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(2),
+				NamepoolNames:     []string{"furiosa", "nux"},
+			},
+		},
+	}
+}
+
+func seedForeignIdentityWork(t *testing.T, store beads.Store, title, assignee string) beads.Bead {
+	t.Helper()
+	work, err := store.Create(beads.Bead{
+		Title:    title,
+		Assignee: assignee,
+		Metadata: map[string]string{"gc.routed_to": "repo/worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead %q: %v", title, err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status for %q: %v", title, err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead %q: %v", title, err)
+	}
+	return work
+}
+
+func captureSweepLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origWriter)
+		log.SetFlags(origFlags)
+	})
+	return &buf
+}
+
+// TestReleaseOrphanedPoolAssignments_ProtectsForeignIdentityAndStillReleasesLocal
+// is the non-vacuity test for the foreign-identity gate: ONE sweep carries a
+// foreign claim and a locally-configured claim whose session is genuinely gone,
+// and asserts the foreign one survives while the local one is still reclaimed.
+//
+// Split across two sweeps these assertions are individually satisfiable by a
+// sweeper that has been DISABLED (protect everything) or one that was never
+// changed (release everything). Together in one sweep they are not.
+func TestReleaseOrphanedPoolAssignments_ProtectsForeignIdentityAndStillReleasesLocal(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	foreign := seedForeignIdentityWork(t, rigStore, "P0 claimed by another city's crew", "repo/dalinar")
+	local := seedForeignIdentityWork(t, rigStore, "work held by a dead local pool worker", "repo/worker-1")
+
+	logBuf := captureSweepLog(t)
+	released := releaseOrphanedPoolAssignmentsFromBeads(
+		cityStore,
+		foreignIdentityTestCity(t),
+		cityPath,
+		nil,
+		[]beads.Bead{foreign, local},
+		[]beads.Store{rigStore, rigStore},
+		[]string{"repo", "repo"},
+		map[string]beads.Store{"repo": rigStore},
+	)
+
+	if len(released) != 1 || released[0].ID != local.ID {
+		t.Fatalf("released = %v, want exactly [%s] (the locally-configured dead holder)", released, local.ID)
+	}
+
+	gotForeign, err := rigStore.Get(foreign.ID)
+	if err != nil {
+		t.Fatalf("Get foreign work bead: %v", err)
+	}
+	if gotForeign.Status != "in_progress" || gotForeign.Assignee != "repo/dalinar" {
+		t.Fatalf("foreign claim = status %q assignee %q, want in_progress/repo/dalinar untouched", gotForeign.Status, gotForeign.Assignee)
+	}
+
+	gotLocal, err := rigStore.Get(local.ID)
+	if err != nil {
+		t.Fatalf("Get local work bead: %v", err)
+	}
+	if gotLocal.Status != "open" || gotLocal.Assignee != "" {
+		t.Fatalf("local claim = status %q assignee %q, want open/unassigned", gotLocal.Status, gotLocal.Assignee)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "protected 1 foreign/unknown identities this pass (1 claims)") {
+		t.Fatalf("missing protected-count summary in log:\n%s", logged)
+	}
+	if !strings.Contains(logged, `"repo/dalinar" (1: `+foreign.ID+")") {
+		t.Fatalf("summary does not name the protected identity and its claim:\n%s", logged)
+	}
+	if strings.Contains(logged, "repo/worker-1") {
+		t.Fatalf("released local holder must not appear as protected:\n%s", logged)
+	}
+}
+
+// TestReleaseOrphanedPoolAssignments_ForeignIdentityBatchLeavesNoRelease is the
+// 2026-08-21 regression: one sweep cleared fifteen foreign claims in 34s. The
+// batch must now produce zero releases and exactly one summary line naming
+// every identity with its claim count, so an accumulating leak is legible
+// without knowing to look for it.
+func TestReleaseOrphanedPoolAssignments_ForeignIdentityBatchLeavesNoRelease(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	var work []beads.Bead
+	var stores []beads.Store
+	var refs []string
+	for _, assignee := range []string{"repo/dalinar", "repo/pattern", "repo/szeth", "repo/dalinar", "repo/dalinar"} {
+		work = append(work, seedForeignIdentityWork(t, rigStore, "foreign claim "+assignee, assignee))
+		stores = append(stores, rigStore)
+		refs = append(refs, "repo")
+	}
+
+	logBuf := captureSweepLog(t)
+	released := releaseOrphanedPoolAssignmentsFromBeads(
+		cityStore, foreignIdentityTestCity(t), cityPath, nil, work, stores, refs,
+		map[string]beads.Store{"repo": rigStore},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none: every claim in this batch is foreign", released)
+	}
+	for _, wb := range work {
+		got, err := rigStore.Get(wb.ID)
+		if err != nil {
+			t.Fatalf("Get %s: %v", wb.ID, err)
+		}
+		if got.Status != "in_progress" || got.Assignee == "" {
+			t.Fatalf("%s = status %q assignee %q, want the claim intact", wb.ID, got.Status, got.Assignee)
+		}
+	}
+
+	logged := logBuf.String()
+	if got := strings.Count(logged, "protected "); got != 1 {
+		t.Fatalf("want exactly one per-sweep summary line, got %d:\n%s", got, logged)
+	}
+	if !strings.Contains(logged, "protected 3 foreign/unknown identities this pass (5 claims)") {
+		t.Fatalf("summary must count identities and claims separately:\n%s", logged)
+	}
+	for _, want := range []string{`"repo/dalinar" (3: `, `"repo/pattern" (1: `, `"repo/szeth" (1: `} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("summary missing %q:\n%s", want, logged)
+		}
+	}
+}
+
+// TestReleaseOrphanedPoolAssignments_NoForeignClaimsLogsNothing keeps the
+// summary a signal rather than per-tick noise: with a 30s patrol, an
+// unconditional line would be 2,880 log entries a day saying nothing.
+func TestReleaseOrphanedPoolAssignments_NoForeignClaimsLogsNothing(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	local := seedForeignIdentityWork(t, rigStore, "dead local holder", "repo/worker-1")
+
+	logBuf := captureSweepLog(t)
+	released := releaseOrphanedPoolAssignmentsFromBeads(
+		cityStore, foreignIdentityTestCity(t), cityPath, nil,
+		[]beads.Bead{local}, []beads.Store{rigStore}, []string{"repo"},
+		map[string]beads.Store{"repo": rigStore},
+	)
+	if len(released) != 1 {
+		t.Fatalf("released = %v, want the local dead holder reclaimed", released)
+	}
+	if strings.Contains(logBuf.String(), "foreign/unknown identities") {
+		t.Fatalf("no claim was protected, so no summary should be emitted:\n%s", logBuf.String())
+	}
+}
+
+// TestPoolAssigneeIsLocallyObservable is the roster matrix. Every "observable"
+// row is an assignee shape this city has ACTUALLY reaped (measured from 2,874
+// bead.dead_assignee_reopened events in its own event log), so a regression
+// here is a sweeper that stopped reclaiming real work.
+func TestPoolAssigneeIsLocallyObservable(t *testing.T) {
+	cfg := foreignIdentityTestCity(t)
+	cfg.NamedSessions = []config.NamedSession{
+		{Name: "lana", Template: "worker", Dir: "repo"},
+	}
+	for _, tc := range []struct {
+		name       string
+		assignee   string
+		observable bool
+	}{
+		{"configured agent", "repo/worker", true},
+		{"legacy bound form of an unbound agent", "repo/pack.worker", true},
+		{"numeric pool instance", "repo/worker-1", true},
+		{"numeric pool instance past the configured ceiling", "repo/worker-36", true},
+		{"legacy bound numeric pool instance", "repo/pack.worker-9", true},
+		{"namepool-themed instance", "repo/furiosa", true},
+		// cmd_hook.go writes session.GenerateAdhocIdentity straight into the
+		// claim assignee for an aliasless pool worker ("rig/polecat-adhoc-<hash>").
+		// Unrecognised, its work would be protected forever the moment that
+		// session died — a silent LOCAL leak, the worst failure this gate has.
+		{"adhoc pool instance", "repo/worker-adhoc-a1b2c3d4e5", true},
+		{"legacy bound adhoc pool instance", "repo/pack.worker-adhoc-a1b2c3d4e5", true},
+		// Only the digits poolInstanceName actually emits count as a slot;
+		// strconv.Atoi would also take these, which no generator produces.
+		{"non-minted slot suffix (signed)", "repo/worker-+1", false},
+		{"non-minted slot suffix (zero padded)", "repo/worker-007", false},
+		{"legacy bound themed instance", "repo/pack.nux", true},
+		{"configured named session", "repo/lana", true},
+		{"city-level agent", "worker", true},
+		{"bare session name", "worker-live", true},
+		{"runtime session name", "gastown__dog-ga-up143", true},
+		{"session bead id form", "claude-mc-xyz", true},
+		{"empty", "", true},
+		{"foreign named crew", "repo/dalinar", false},
+		{"foreign named crew in an unknown rig", "westeros/szeth", false},
+		{"decommissioned local agent", "repo/retired-hand", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poolAssigneeIsLocallyObservable(cfg, "testcity", tc.assignee); got != tc.observable {
+				t.Fatalf("poolAssigneeIsLocallyObservable(%q) = %v, want %v", tc.assignee, got, tc.observable)
+			}
+		})
+	}
+}
+
+// TestPoolAssigneeIsLocallyObservable_GenericRigScopedTemplate covers the
+// template shape that names no rig at all: a Scope="rig", Dir="" agent applies
+// to every configured rig, so its pool instances are addressed under a concrete
+// rig the template never mentions. Comparing against the unsynthesized agent
+// reads every one of those legitimate local holders as foreign.
+func TestPoolAssigneeIsLocallyObservable_GenericRigScopedTemplate(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "repo", Path: t.TempDir()}},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Scope:             "rig",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+			NamepoolNames:     []string{"furiosa"},
+		}},
+	}
+	for _, tc := range []struct {
+		assignee   string
+		observable bool
+	}{
+		{"repo/polecat", true},
+		{"repo/furiosa", true},
+		{"repo/polecat-3", true},
+		{"repo/polecat-adhoc-a1b2c3d4e5", true},
+		{"repo/dalinar", false},
+		{"otherrig/furiosa", false},
+	} {
+		t.Run(tc.assignee, func(t *testing.T) {
+			if got := poolAssigneeIsLocallyObservable(cfg, "testcity", tc.assignee); got != tc.observable {
+				t.Fatalf("poolAssigneeIsLocallyObservable(%q) = %v, want %v", tc.assignee, got, tc.observable)
+			}
+		})
+	}
+}
+
+// TestProtectedForeignAssigneesSummary pins the rendering: exact counts, sorted
+// identities, and a bounded ID sample so one leaking identity cannot make the
+// line unreadable.
+func TestProtectedForeignAssigneesSummary(t *testing.T) {
+	var empty protectedForeignAssignees
+	if got := empty.summary(); got != "" {
+		t.Fatalf("empty summary = %q, want empty", got)
+	}
+
+	var p protectedForeignAssignees
+	p.add("repo/zeta", "qc-2")
+	p.add("repo/alpha", "qc-1")
+	p.add("repo/zeta", "qc-3")
+	p.add("", "qc-ignored")
+	got := p.summary()
+	want := `releaseOrphanedPoolAssignments: protected 2 foreign/unknown identities this pass (3 claims): "repo/alpha" (1: qc-1), "repo/zeta" (2: qc-2, qc-3)`
+	if got != want {
+		t.Fatalf("summary =\n  %q\nwant\n  %q", got, want)
+	}
+
+	var forged protectedForeignAssignees
+	forged.add("repo/evil, \"repo/innocent\" (99: qc-x)", "qc-9")
+	if got := forged.summary(); strings.Count(got, "protected ") != 1 || !strings.Contains(got, `\"repo/innocent\`) {
+		t.Fatalf("an identity containing summary punctuation must be quoted, not spliced: %q", got)
+	}
+
+	var many protectedForeignAssignees
+	for _, id := range []string{"qc-1", "qc-2", "qc-3", "qc-4", "qc-5", "qc-6", "qc-7"} {
+		many.add("repo/leak", id)
+	}
+	gotMany := many.summary()
+	if !strings.Contains(gotMany, `"repo/leak" (7: qc-1, qc-2, qc-3, qc-4, qc-5 +2 more)`) {
+		t.Fatalf("bounded sample not rendered: %q", gotMany)
+	}
+}

--- a/cmd/gc/pool_orphan_foreign_identity_test.go
+++ b/cmd/gc/pool_orphan_foreign_identity_test.go
@@ -14,6 +14,13 @@ import (
 // a rig-scoped pool agent with a namepool, addressed in persisted assignees
 // both bare ("repo/worker") and in the legacy bound form ("repo/pack.worker")
 // that outlived its binding.
+//
+// The third agent is what makes "pack" a binding THIS city mints (ga-8yi7ne).
+// It is not decoration: the legacy bound forms above only resolve because some
+// agent from that import is still bound, which is exactly the field condition —
+// one agent moved bound→unbound while its siblings did not. Without it the
+// fixture would describe a city that had removed the import entirely, and the
+// bound forms SHOULD be unresolvable there.
 func foreignIdentityTestCity(t *testing.T) *config.City {
 	t.Helper()
 	return &config.City{
@@ -27,6 +34,7 @@ func foreignIdentityTestCity(t *testing.T) *config.City {
 				MaxActiveSessions: intPtr(2),
 				NamepoolNames:     []string{"furiosa", "nux"},
 			},
+			{Name: "sibling", Dir: "repo", BindingName: "pack"},
 		},
 	}
 }
@@ -236,6 +244,16 @@ func TestPoolAssigneeIsLocallyObservable(t *testing.T) {
 		{"runtime session name", "gastown__dog-ga-up143", true},
 		{"session bead id form", "claude-mc-xyz", true},
 		{"empty", "", true},
+		// ga-8yi7ne: a NEIGHBOURING city's canonical "<rig>/<binding>.<name>"
+		// whose binding this city does not mint. "pool" is not one of our
+		// imports; "worker" is our agent. Before the binding gate, every one of
+		// these resolved to our local worker and their live claims were
+		// released — measured in the shared store, where the bead oscillated
+		// between released and re-claimed twice.
+		{"foreign binding, plain", "repo/pool.worker", false},
+		{"foreign binding, numeric instance", "repo/pool.worker-1", false},
+		{"foreign binding, adhoc instance", "repo/pool.worker-adhoc-a1b2c3d4e5", false},
+		{"foreign binding, themed instance", "repo/pool.nux", false},
 		{"foreign named crew", "repo/dalinar", false},
 		{"foreign named crew in an unknown rig", "westeros/szeth", false},
 		{"decommissioned local agent", "repo/retired-hand", false},
@@ -316,5 +334,123 @@ func TestProtectedForeignAssigneesSummary(t *testing.T) {
 	gotMany := many.summary()
 	if !strings.Contains(gotMany, `"repo/leak" (7: qc-1, qc-2, qc-3, qc-4, qc-5 +2 more)`) {
 		t.Fatalf("bounded sample not rendered: %q", gotMany)
+	}
+}
+
+// TestCityMintsBinding pins the discriminator that decides whether a
+// "<binding>.<name>" identity could have been minted HERE (ga-8yi7ne).
+//
+// Both sources are asserted, and so is the refusal: an unknown binding must be
+// rejected, because that is the only thing standing between a neighbouring
+// city's canonical identity and our local agent of the same leaf name.
+func TestCityMintsBinding(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker"},                            // unbound: contributes nothing
+			{Name: "polecat", BindingName: "gastown"},   // bound: contributes "gastown"
+			{Name: "dog", BindingName: "bd"},            // bound: contributes "bd"
+			{Name: "spaced", BindingName: "  padded  "}, // trimmed on both sides
+		},
+		DefaultRigImports: map[string]config.Import{"core": {}},
+	}
+	for _, tc := range []struct {
+		name    string
+		binding string
+		want    bool
+	}{
+		{"binding carried by a configured agent", "gastown", true},
+		{"second binding on the same city", "bd", true},
+		{"binding is trimmed before comparison", "padded", true},
+		{"default rig import with no instantiated agent", "core", true},
+		{"neighbouring city's binding", "pool", false},
+		{"neighbouring city's other binding", "review", false},
+		{"empty binding is never ours", "", false},
+		{"whitespace binding is never ours", "   ", false},
+		{"agent NAME is not a binding", "worker", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cityMintsBinding(cfg, tc.binding); got != tc.want {
+				t.Fatalf("cityMintsBinding(%q) = %v, want %v", tc.binding, got, tc.want)
+			}
+		})
+	}
+	if cityMintsBinding(nil, "gastown") {
+		t.Fatal("cityMintsBinding(nil, ...) = true, want false — a nil config knows no bindings")
+	}
+}
+
+// TestForeignBindingIsRejectedAtThePolicyLayer covers the SECOND route into
+// the cross-city collision (ga-8yi7ne) — the one that does not go through the
+// stripped candidate.
+//
+// poolIdentityIsInstanceOfLocalAgent reduces "qcore/pool.omp-1" to base
+// "qcore/pool.omp", and findAgentByTemplate matches that against an unbound
+// "qcore/omp" through legacyBoundTemplateMatchesUnboundAgent. That helper
+// accepts ANY binding ON PURPOSE, because it also serves bound->unbound
+// migration recovery in cities that removed the binding entirely
+// (build_desired_state_legacy_bound_recovery_test.go depends on exactly that).
+// So the resolver is deliberately left alone and the discriminator sits in the
+// guard, which is asserted here.
+func TestForeignBindingIsRejectedAtThePolicyLayer(t *testing.T) {
+	cfg := &config.City{
+		Rigs:    []config.Rig{{Name: "qcore", Path: t.TempDir()}},
+		Imports: map[string]config.Import{"gastown": {}},
+		Agents: []config.Agent{
+			{Name: "omp", Dir: "qcore", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(4)},
+			{Name: "polecat", Dir: "qcore", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(4)},
+		},
+	}
+
+	// The resolver still mis-resolves, unchanged and intentionally so. If this
+	// assertion ever flips, the discriminator moved and the migration-recovery
+	// path needs re-checking.
+	if findAgentByTemplate(cfg, "qcore/pool.omp") == nil {
+		t.Fatal("precondition changed: findAgentByTemplate no longer resolves a foreign binding, so this test is no longer testing the second route")
+	}
+
+	for _, tc := range []struct {
+		name       string
+		assignee   string
+		observable bool
+	}{
+		{"foreign binding, instance form (the field case)", "qcore/pool.omp-1", false},
+		{"foreign binding, plain form", "qcore/pool.omp", false},
+		{"foreign binding, adhoc form", "qcore/pool.omp-adhoc-a1b2c3d4e5", false},
+		// The other direction. A minted binding must still resolve, or this
+		// "fix" strands 45 of this city's 46 historically reaped identities.
+		{"minted binding still resolves", "qcore/gastown.polecat-1", true},
+		{"our own bare instance is untouched", "qcore/omp-1", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poolAssigneeIsLocallyObservable(cfg, "testcity", tc.assignee); got != tc.observable {
+				t.Fatalf("poolAssigneeIsLocallyObservable(%q) = %v, want %v", tc.assignee, got, tc.observable)
+			}
+		})
+	}
+}
+
+// TestPoolCandidateBindingIsLocal pins the candidate filter directly, including
+// the shapes that must pass through untouched.
+func TestPoolCandidateBindingIsLocal(t *testing.T) {
+	cfg := &config.City{Imports: map[string]config.Import{"gastown": {}}}
+	for _, tc := range []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		{"minted binding", "qcore/gastown.polecat", true},
+		{"foreign binding", "qcore/pool.omp", false},
+		{"no binding at all", "qcore/omp", true},
+		{"bare name", "omp", true},
+		{"empty", "", true},
+		{"trailing dot is not a binding", "qcore/omp.", true},
+		{"leading dot is not a binding", "qcore/.omp", true},
+		{"session bead id form is untouched", "claude-mc-xyz", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poolCandidateBindingIsLocal(cfg, tc.candidate); got != tc.want {
+				t.Fatalf("poolCandidateBindingIsLocal(%q) = %v, want %v", tc.candidate, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/gc/pool_orphan_foreign_identity_test.go
+++ b/cmd/gc/pool_orphan_foreign_identity_test.go
@@ -230,7 +230,7 @@ func TestPoolAssigneeIsLocallyObservable(t *testing.T) {
 		{"namepool-themed instance", "repo/furiosa", true},
 		// cmd_hook.go writes session.GenerateAdhocIdentity straight into the
 		// claim assignee for an aliasless pool worker ("rig/polecat-adhoc-<hash>").
-		// Unrecognised, its work would be protected forever the moment that
+		// Unrecognized, its work would be protected forever the moment that
 		// session died — a silent LOCAL leak, the worst failure this gate has.
 		{"adhoc pool instance", "repo/worker-adhoc-a1b2c3d4e5", true},
 		{"legacy bound adhoc pool instance", "repo/pack.worker-adhoc-a1b2c3d4e5", true},
@@ -245,7 +245,7 @@ func TestPoolAssigneeIsLocallyObservable(t *testing.T) {
 		{"runtime session name", "gastown__dog-ga-up143", true},
 		{"session bead id form", "claude-mc-xyz", true},
 		{"empty", "", true},
-		// ga-8yi7ne: a NEIGHBOURING city's canonical "<rig>/<binding>.<name>"
+		// ga-8yi7ne: a NEIGHBORING city's canonical "<rig>/<binding>.<name>"
 		// whose binding this city does not mint. "pool" is not one of our
 		// imports; "worker" is our agent. Before the binding gate, every one of
 		// these resolved to our local worker and their live claims were
@@ -342,12 +342,12 @@ func TestProtectedForeignAssigneesSummary(t *testing.T) {
 // "<binding>.<name>" identity could have been minted HERE (ga-8yi7ne).
 //
 // Both sources are asserted, and so is the refusal: an unknown binding must be
-// rejected, because that is the only thing standing between a neighbouring
+// rejected, because that is the only thing standing between a neighboring
 // city's canonical identity and our local agent of the same leaf name.
 func TestCityMintsBinding(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{
-			{Name: "worker"},                            // unbound: contributes nothing
+			{Name: "worker"}, // unbound: contributes nothing
 			{Name: "polecat", BindingName: "gastown"},   // bound: contributes "gastown"
 			{Name: "dog", BindingName: "bd"},            // bound: contributes "bd"
 			{Name: "spaced", BindingName: "  padded  "}, // trimmed on both sides
@@ -363,8 +363,8 @@ func TestCityMintsBinding(t *testing.T) {
 		{"second binding on the same city", "bd", true},
 		{"binding is trimmed before comparison", "padded", true},
 		{"default rig import with no instantiated agent", "core", true},
-		{"neighbouring city's binding", "pool", false},
-		{"neighbouring city's other binding", "review", false},
+		{"neighboring city's binding", "pool", false},
+		{"neighboring city's other binding", "review", false},
 		{"empty binding is never ours", "", false},
 		{"whitespace binding is never ours", "   ", false},
 		{"agent NAME is not a binding", "worker", false},

--- a/cmd/gc/pool_orphan_foreign_identity_test.go
+++ b/cmd/gc/pool_orphan_foreign_identity_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // foreignIdentityTestCity mirrors the config shapes this city actually runs:
@@ -452,5 +453,108 @@ func TestPoolCandidateBindingIsLocal(t *testing.T) {
 				t.Fatalf("poolCandidateBindingIsLocal(%q) = %v, want %v", tc.candidate, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestReleaseOrphanedPoolAssignments_DecommissionedLocalIsProtectedAndReported
+// closes the review gap that the decommissioned-agent case existed only in the
+// predicate table. A locally-DECOMMISSIONED named identity is indistinguishable
+// from a foreign one — "not in the local roster" is all the gate can see — so
+// its claims are knowingly left unreapable. That is the accepted trade, and the
+// summary line IS its mitigation: this test proves through a real sweep over a
+// real store that the bead survives AND the summary names the identity, so the
+// leak is legible rather than silent.
+func TestReleaseOrphanedPoolAssignments_DecommissionedLocalIsProtectedAndReported(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// "repo/mad-max" reads exactly like yesterday's crew member whose agent
+	// stanza was removed: well-formed <rig>/<name>, rig resolves, name absent
+	// from the roster foreignIdentityTestCity declares.
+	decommissioned := seedForeignIdentityWork(t, rigStore, "claim held by a decommissioned local agent", "repo/mad-max")
+
+	logBuf := captureSweepLog(t)
+	released := releaseOrphanedPoolAssignmentsFromBeads(
+		cityStore,
+		foreignIdentityTestCity(t),
+		cityPath,
+		nil,
+		[]beads.Bead{decommissioned},
+		[]beads.Store{rigStore},
+		[]string{"repo"},
+		map[string]beads.Store{"repo": rigStore},
+	)
+
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none (a decommissioned identity is protected, not reaped)", released)
+	}
+	got, err := rigStore.Get(decommissioned.ID)
+	if err != nil {
+		t.Fatalf("Get decommissioned claim: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "repo/mad-max" {
+		t.Fatalf("claim = status %q assignee %q, want in_progress/repo/mad-max untouched", got.Status, got.Assignee)
+	}
+	logged := logBuf.String()
+	if !strings.Contains(logged, "protected 1 foreign/unknown identities this pass (1 claims)") {
+		t.Fatalf("the accepted leak's mitigation is the summary line, and it is missing:\n%s", logged)
+	}
+	if !strings.Contains(logged, `"repo/mad-max" (1: `+decommissioned.ID+")") {
+		t.Fatalf("summary must name the decommissioned identity and its claim:\n%s", logged)
+	}
+}
+
+// TestReleaseConfirmedOrphanSessionWork_GatesUnobservableIdentifier covers the
+// SECOND release site (the ga-jrnou orphan-close tie-break). Its identifier set
+// is built from raw session-bead metadata (sessionAssignmentIdentifierRawInfo),
+// not from the roster, so a stored session_name colliding with another city's
+// identity reaches this release with no other guard. One call carries both
+// claims: the unobservable identity is protected while the locally-minted pool
+// instance is still released — the same non-vacuity shape as the sweep test, so
+// a gate that simply disabled this site would fail the second half.
+func TestReleaseConfirmedOrphanSessionWork_GatesUnobservableIdentifier(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	cfg := foreignIdentityTestCity(t)
+	rigStores := map[string]beads.Store{"repo": rigStore}
+
+	foreign := seedForeignIdentityWork(t, rigStore, "claim under a foreign-shaped stored name", "repo/dalinar")
+	local := seedForeignIdentityWork(t, rigStore, "claim under a locally minted pool instance", "repo/worker-1")
+
+	logBuf := captureSweepLog(t)
+	released := releaseConfirmedOrphanSessionWork(cfg, cityStore, rigStores,
+		[]beads.Bead{foreign, local},
+		[]beads.Store{rigStore, rigStore},
+		session.Info{SessionNameMetadata: "repo/dalinar"},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none (the only matching identifier is unobservable)", released)
+	}
+	gotForeign, err := rigStore.Get(foreign.ID)
+	if err != nil {
+		t.Fatalf("Get foreign-shaped claim: %v", err)
+	}
+	if gotForeign.Status != "in_progress" || gotForeign.Assignee != "repo/dalinar" {
+		t.Fatalf("claim = status %q assignee %q, want in_progress/repo/dalinar untouched", gotForeign.Status, gotForeign.Assignee)
+	}
+	if logged := logBuf.String(); !strings.Contains(logged, `protected "repo/dalinar" (`+foreign.ID+`)`) {
+		t.Fatalf("gate must refuse loudly, naming the identity and claim:\n%s", logged)
+	}
+
+	released = releaseConfirmedOrphanSessionWork(cfg, cityStore, rigStores,
+		[]beads.Bead{foreign, local},
+		[]beads.Store{rigStore, rigStore},
+		session.Info{SessionNameMetadata: "repo/worker-1"},
+	)
+	if len(released) != 1 || released[0].ID != local.ID {
+		t.Fatalf("released = %v, want exactly [%s] (the locally minted instance still releases)", released, local.ID)
+	}
+	gotLocal, err := rigStore.Get(local.ID)
+	if err != nil {
+		t.Fatalf("Get local claim: %v", err)
+	}
+	if gotLocal.Status != "open" || gotLocal.Assignee != "" {
+		t.Fatalf("local claim = status %q assignee %q, want open/unassigned", gotLocal.Status, gotLocal.Assignee)
 	}
 }

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -263,6 +263,9 @@ func releaseOrphanedPoolAssignments(
 	}
 
 	var released []releasedPoolAssignment
+	var protectedForeign protectedForeignAssignees
+	defer protectedForeign.log()
+	cityName := cfg.EffectiveCityName()
 	for i, wb := range assignedWorkBeads {
 		if wb.Status != "open" && wb.Status != "in_progress" {
 			continue
@@ -305,6 +308,17 @@ func releaseOrphanedPoolAssignments(
 				continue
 			}
 			if assigneePreservesNamedSessionRoute(cfg, cityPath, template, assignee, workStoreRef, storeRefAware) {
+				continue
+			}
+			// Roster gate, deliberately AHEAD of the liveness question:
+			// liveOpenSessionAssignmentExists answers from THIS city's stores
+			// only, so for an identity this city does not configure a missing
+			// session bead is unobservable rather than absent. The two
+			// positive-evidence checks above can only ever SKIP a release, so
+			// running them first costs nothing and keeps the protected count
+			// reporting exactly the claims this gate saved.
+			if !poolAssigneeIsLocallyObservable(cfg, cityName, assignee) {
+				protectedForeign.add(assignee, wb.ID)
 				continue
 			}
 			if memoizedLiveOpenSessionAssignmentExists(sessionStoreLiveAssignee, assignee, sessionStore.Store, assignee) {

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -300,6 +300,13 @@ func releaseOrphanedPoolAssignments(
 		// it was, so a bead skipped by a liveness gate never reaches it.
 		ownerStore := assignedWorkOwnerStore(cfg, store, rigStores, assignedWorkStores, i, wb)
 		if assignee == "" {
+			// OUTSIDE the roster gate by construction: an empty assignee
+			// carries no identity to test, so this arm shares the stated
+			// residual with bare session names (see the package comment in
+			// pool_orphan_foreign_identity.go). The damage class the gate
+			// exists for — writing away another city's CLAIM — cannot occur
+			// here, since there is no claim identity to strip; what this arm
+			// touches is unassigned in_progress routing state only.
 			if wb.Status != "in_progress" {
 				continue
 			}
@@ -440,6 +447,21 @@ func releaseConfirmedOrphanSessionWork(
 			continue
 		}
 		if _, ok := identifiers[assignee]; !ok {
+			continue
+		}
+		// Roster gate on the SECOND release site. The identifiers set is
+		// built from this city's own session info, but it includes RAW
+		// metadata strings (bead ID, session_name, configured identity read
+		// off the store — see sessionAssignmentIdentifierRawInfo), not
+		// roster-derived names; a stored value that collides with another
+		// city's identity would otherwise carry that identity straight into
+		// a release here, ungated. Same predicate, same failure direction as
+		// the sweep path: unobservable means protect, loudly. The
+		// shared-pack residual applies here as everywhere — a pool instance
+		// byte-identical across cities passes any roster test (see the
+		// package comment in pool_orphan_foreign_identity.go).
+		if !poolAssigneeIsLocallyObservable(cfg, config.EffectiveCityName(cfg, ""), assignee) {
+			log.Printf("releaseConfirmedOrphanSessionWork: protected %q (%s): assignee is not locally observable — refusing orphan-close release", assignee, wb.ID)
 			continue
 		}
 		template := routedToOrLegacyWorkflowTarget(wb)


### PR DESCRIPTION
Fixes #5959

## Cross-city context (why this exists)

Two cities sharing one federated rig store (a Dolt hub) each run this pool orphan sweeper against it. The sweeper validates a claim's assignee liveness against **local** evidence only — `liveOpenSessionAssignmentExists` answers from the local city's session stores — so a claim held by an identity the *other* city configures reads as dead, and `releaseOrphanedPoolAssignment` strips its assignee. A federated claim validated against unfederated evidence.

This is not theoretical: both cities did it to each other. One direction took two P0s and a P1 in 8 seconds; the reverse took fifteen claims in 34 seconds. The strips leave no comment trail; the Go paths do emit `bead.dead_assignee_reopened` (`city_runtime.go`, `session_reconciler.go`), but the event lands in the stripping city's own log — the losing city sees nothing, so each incident was still reconstructed by archaeology. (Corrected per partner-city review: an earlier revision of this body claimed "no event".)

## The fix

A roster-membership gate **ahead of** the liveness question: an assignee that parses as a well-formed `<rig>/<name>` not present in the local city's resolved roster is *unobservable*, not dead — skip it. Two commits:

1. **`fix(pool): treat a foreign <rig>/<name> claim as unobservable, not dead`** — the gate (`poolAssigneeIsLocallyObservable`), its wiring at the release site, and a once-per-sweep summary line naming every protected identity and claim count.
2. **`fix(pool-sweeper): refuse a binding this city does not mint`** — closes the hole where a foreign identity matching a local *template shape* would still pass; without it the gate is a cross-city hazard rather than a protection.

## Properties reviewers should hold us to

- **Locally-configured identities keep today's behavior byte-for-byte.** A local agent with a genuinely dead session is STILL released. `TestReleaseOrphanedPoolAssignments_ProtectsForeignIdentityAndStillReleasesLocal` carries both claims in ONE sweep — it is the non-vacuity proof that this fixes the bug rather than disabling the sweeper. The two pre-existing load-bearing tests (`ReopensRigStoreMissingPoolAssignee`, `ReleasesRigWorkAssignedToUnreachableOpenSession`) pass unchanged; the deliberately label-only liveness query was not touched.
- **The skip is counted and logged, never silent.** A decommissioned local agent is also "not in the roster", so a silent skip would trade a loud cross-city bug for a quiet local leak. The summary line (`protected N foreign/unknown identities this pass (M claims): ...`) renders identities with %q so untrusted assignee text cannot forge structure in it.
- **Calibrated against history, not just fixtures**: replayed against 2,873 real releases from the originating city's event log (227 distinct assignees), the gate changes exactly ONE historical decision — the known cross-city strip — and preserves 2,685 of 2,686 legitimate gated reclamations. Mutation-tested: 10 mutants (including "gate never fires", "gate on rig prefix", "silent skip"), 10 killed.

## Porting notes

Rebased onto current `main` (319e93d3f). One hand-resolved hunk in `pool_session_name.go`: the gate keeps its place after the two positive-evidence checks (they can only ever SKIP a release, so ordering keeps the protected count meaning "claims this gate saved") and now sits ahead of #6068's memoized probe (`memoizedLiveOpenSessionAssignmentExists`); the tie-break test calls were updated to #5935's six-argument `releaseConfirmedOrphanSessionWork` (`assignedWorkStores` supplied index-aligned). Verified at this head: `go vet ./cmd/gc` clean; `-run` over all eleven foreign-identity/release tests green. A CHANGELOG entry names the removed-binding migration case (a decommissioned agent's claims are no longer reclaimed — release explicitly when retiring a binding; watch the `protected N foreign/unknown identities` line).

## Scope, stated precisely (updated after partner-city review)

This PR covers the Go RELEASE paths: the sweep (`releaseOrphanedPoolAssignments`) and, as of the review-response commit, the orphan-close tie-break (`releaseConfirmedOrphanSessionWork`) — the latter's identifier set includes raw session-bead metadata, so it needed the same gate. The empty-assignee reopen arm has no identity to test and is documented as outside the gate (no cross-city claim-strip is possible there).

Deliberately NOT in this PR, each named and tracked:
- **The shell sweeper** — the core pack's `orphan-sweep.sh` makes the same decision in shell and stays unguarded after this merge: #5955.
- **The shared-store WRITE sites** — `canonicalizeLegacyBoundAssignedWork` / `...UnassignedRoutedWork` rewriting the other city's assignee/routed_to is #5846 (same incident family, different verb). Its fix applies this PR's predicate at those write sites; the partner city has that slice queued on top of this PR (see review thread), so it is deferred here rather than half-done.

Release note: a claim held by an identity absent from the local roster — including a locally **decommissioned** agent's — is no longer reclaimed by the Go release paths; each skip is counted and named in a once-per-sweep summary line, which is the deliberate mitigation for the decommissioned-agent leak (end-to-end test proves the line fires).

## Known limit (stated, not hidden)

Two cities importing the same agent pack share an identity space, so the gate protects foreign NAMED identities, not foreign POOL instances (byte-identical names). Both observed incidents were named crew, so the observed damage is covered; closing the full class needs a claiming-city discriminator on the claim itself and is deliberately out of scope here.

Second stated limit (per partner-city review): the template-form foreign-binding row (`repo/pool.worker`) is protected at the predicate but NOT end to end — `canonicalizeLegacyBoundAssignedWork` (`build_desired_state.go`) rewrites that stored assignee to the local spelling before the next sweep sees it, and the local spelling then releases. That write site is #5846's territory (its fix is this PR's `cityMintsBinding` applied there; the partner city has that slice queued on top of this PR), so the end-to-end protection for template-form rows lands with #5846, not here.

Review requested from the partner city's gc build owner (navani) per the cross-city agreement — review, not a gate; she is being pointed at this PR through the cities' own channel rather than a GitHub mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB58oPyfY5JFzAmWJW5KcA



