### PR TITLE
fix(gc hook): render an unreachable store as exit 2, not the no-work exit 1

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1199,24 +1199,37 @@ const (
 
 var bdCommandRetrySleep = time.Sleep
 
+// bdTransportRetryableMarkers is the bd stderr/error string table gc uses
+// to classify transport-class failures. The managed retry below and gc
+// hook's store-unavailable signal both read it, so it is hoisted out of
+// bdTransportRetryableError rather than inlined: a marker added for one
+// consumer must classify for the other.
+//
+// It is an explicit compatibility surface with the bd CLI, and remains the
+// classification mechanism until bd ships a typed machine-readable error
+// envelope (a reserved exit-code contract distinguishing transport from
+// application failures; bd currently exits 1 for both, so exit codes carry
+// no transport signal today).
+var bdTransportRetryableMarkers = []string{
+	"server unreachable",
+	"dial tcp",
+	"connection refused",
+	"broken pipe",
+	"unexpected eof",
+	"bad connection",
+	"use of closed network connection",
+	// bd silently falls back to opening the on-disk store when it cannot
+	// reach the managed Dolt server. On an empty .beads/dolt/ that fallback
+	// triggers a JSONL auto-import, which presents as a 2m command timeout
+	// rather than a network error. Treat the auto-import marker as a
+	// transport failure so the managed-retry path republishes the correct
+	// port and retries against the live server. See gastownhall/gascity#1930.
+	bdSilentFallbackMarkerImport,
+	bdSilentFallbackMarkerEmptyDB,
+}
+
 func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
-	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, []string{
-		"server unreachable",
-		"dial tcp",
-		"connection refused",
-		"broken pipe",
-		"unexpected eof",
-		"bad connection",
-		"use of closed network connection",
-		// bd silently falls back to opening the on-disk store when it cannot
-		// reach the managed Dolt server. On an empty .beads/dolt/ that fallback
-		// triggers a JSONL auto-import, which presents as a 2m command timeout
-		// rather than a network error. Treat the auto-import marker as a
-		// transport failure so the managed-retry path republishes the correct
-		// port and retries against the live server. See gastownhall/gascity#1930.
-		bdSilentFallbackMarkerImport,
-		bdSilentFallbackMarkerEmptyDB,
-	})
+	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, bdTransportRetryableMarkers)
 }
 
 func bdTransportRecoverableError(cityPath, scopeRoot string, env map[string]string, err error) bool {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -47,10 +47,11 @@ With --claim: runs the standard startup claim protocol for one work item.
 				DrainAck:   drainAck,
 				JSON:       jsonOut,
 			}
-			if cmdHookWithOptions(args, opts, stdout, stderr) != 0 {
-				return errExit
-			}
-			return nil
+			// exitForCode, not `!= 0 → errExit`: the store-unavailable
+			// contract is exit 2 (reportWorkQueryFailure), and folding it
+			// into errExit renders it as the no-work exit 1 at the process
+			// boundary — the idle-agents-with-work-waiting dead-drop.
+			return exitForCode(cmdHookWithOptions(args, opts, stdout, stderr))
 		},
 	}
 	cmd.Flags().BoolVar(&inject, "inject", false, "silent legacy Stop-hook compatibility; skip work query and exit 0")
@@ -727,6 +728,27 @@ func claimHookWorkWithRunner(workQuery, workDir string, queryEnv []string, store
 	return writeHookClaimNoWork(claimOpts, ops, claimsErrored, workDir, stdout, stderr)
 }
 
+// workQueryStoreUnavailable reports whether err is a transport-class failure
+// (an unreachable store, not an empty queue) after classification.
+func workQueryStoreUnavailable(err error) bool {
+	return errors.Is(classifyWorkQueryStoreUnavailable(err), beads.ErrStoreUnavailable)
+}
+
+// reportWorkQueryFailure is the ONE place the token <=> exit-2 contract is
+// rendered: a transport-class failure prints "<prefix>: <token>: <err>" and
+// exits 2; anything else prints "<prefix>: <err>" and exits 1. Every path
+// that reports a failed work query shares it so the published contract
+// cannot drift between them.
+func reportWorkQueryFailure(prefix string, err error, stderr io.Writer) int {
+	classified := classifyWorkQueryStoreUnavailable(err)
+	if errors.Is(classified, beads.ErrStoreUnavailable) {
+		fmt.Fprintf(stderr, "%s: %s: %v\n", prefix, hookStoreUnavailableToken, classified) //nolint:errcheck // best-effort stderr
+		return 2
+	}
+	fmt.Fprintf(stderr, "%s: %v\n", prefix, err) //nolint:errcheck // best-effort stderr
+	return 1
+}
+
 // Claim-read retry pacing. A work-query ERROR is a failed read, and the failures
 // this bounds are transport-shaped: a contended SQLite leg, a store mid-write, a
 // binding whose engine is briefly refusing. Those clear in seconds, and the
@@ -965,6 +987,50 @@ type hookVisibility struct {
 	RouteTargets []string
 }
 
+// hookStoreUnavailableToken is the distinct stderr token gc hook emits
+// (with exit code 2) when the bead store is unreachable. Runtime hook
+// consumers match on it to distinguish "store down" from exit-1 no-work —
+// rendering an unreachable store as no-work is the chronic
+// idle-agents-with-work-waiting dead-drop.
+const hookStoreUnavailableToken = "GC_HOOK_STORE_UNAVAILABLE"
+
+// isTransportClassMessage reports whether a lowercased error message matches
+// the pinned transport-failure marker table (bdTransportRetryableMarkers).
+func isTransportClassMessage(lowerMsg string) bool {
+	for _, marker := range bdTransportRetryableMarkers {
+		if strings.Contains(lowerMsg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyWorkQueryStoreUnavailable wraps transport-class work-query failures
+// as beads.ErrStoreUnavailable so doHook can report them as exit 2 rather than
+// letting a dead store masquerade as a drained queue. Errors that already carry
+// the sentinel pass through unchanged; anything that is not transport-class is
+// returned as-is and stays an ordinary exit-1 error.
+func classifyWorkQueryStoreUnavailable(err error) error {
+	if err == nil || errors.Is(err, beads.ErrStoreUnavailable) {
+		return err
+	}
+	// Typed signals first. shellWorkQueryWithEnv wraps its deadline as
+	// context.DeadlineExceeded precisely so callers classify the timeout as a
+	// transient store error: a wedged-but-listening backend (hung connections,
+	// context-deadline floods — the dominant outage shape, not "connection
+	// refused") surfaces here, and reading it as no-work is the dead-drop the
+	// token exists to close.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", beads.ErrStoreUnavailable, err)
+	}
+	// isTransportClassMessage is the single pinned marker table shared with
+	// the bd managed-retry path; a marker added there must classify here too.
+	if isTransportClassMessage(strings.ToLower(err.Error())) {
+		return fmt.Errorf("%w: %w", beads.ErrStoreUnavailable, err)
+	}
+	return err
+}
+
 // doHook is the pure logic for gc hook. Runs the work query and outputs
 // results based on mode. Without inject: prints normalized ready-only output,
 // returns 0 if work exists, 1 if empty. With inject: skips the work query and
@@ -976,11 +1042,16 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	output, err := runner(workQuery, dir)
 	if err != nil {
-		if normalized := normalizeWorkQueryOutput(strings.TrimSpace(output)); normalized != "" {
-			fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
+		// A transport-class failure is an unreachable store, not an empty
+		// queue: no partial stdout, token + exit 2 (reportWorkQueryFailure).
+		// Any other failure first surfaces whatever partial output the query
+		// produced, then reports exit 1.
+		if !workQueryStoreUnavailable(err) {
+			if normalized := normalizeWorkQueryOutput(strings.TrimSpace(output)); normalized != "" {
+				fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
+			}
 		}
-		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return reportWorkQueryFailure("gc hook", err, stderr)
 	}
 
 	trimmed := strings.TrimSpace(output)

--- a/cmd/gc/cmd_hook_unavailable_test.go
+++ b/cmd/gc/cmd_hook_unavailable_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// gc hook must distinguish "store unreachable" (exit 2 + token) from
+// "no work" (exit 1): rendering an unreachable store as no-work is the
+// chronic idle-agents-with-work-waiting dead-drop (R-INV, plan item 1.3).
+
+func TestDoHookStoreUnavailableExitsTwoWithToken(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return "", fmt.Errorf("running work query %q: %w", "bd ready --json", beads.ErrStoreUnavailable)
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready --json", "/tmp/work", false, runner, &stdout, &stderr, hookVisibility{})
+	if code != 2 {
+		t.Fatalf("doHook = %d, want 2 for ErrStoreUnavailable; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), hookStoreUnavailableToken) {
+		t.Fatalf("stderr %q missing token %q", stderr.String(), hookStoreUnavailableToken)
+	}
+}
+
+func TestDoHookTransportClassErrorClassifiedUnavailable(t *testing.T) {
+	// Work queries shell out to bd; a wedged store presents as a raw exec
+	// error whose stderr carries the pinned transport markers.
+	runner := func(string, string) (string, error) {
+		return "", fmt.Errorf("running work query %q: exit status 1: Error: dial tcp 127.0.0.1:3307: connection refused", "bd ready --json")
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready --json", "/tmp/work", false, runner, &stdout, &stderr, hookVisibility{})
+	if code != 2 {
+		t.Fatalf("doHook = %d, want 2 for a transport-class work-query failure; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), hookStoreUnavailableToken) {
+		t.Fatalf("stderr %q missing token %q", stderr.String(), hookStoreUnavailableToken)
+	}
+}
+
+func TestDoHookOrdinaryErrorStaysExitOne(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return "", fmt.Errorf("running work query %q: exit status 1: unknown flag --bogus", "bd ready --bogus")
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready --bogus", "/tmp/work", false, runner, &stdout, &stderr, hookVisibility{})
+	if code != 1 {
+		t.Fatalf("doHook = %d, want 1 for an ordinary work-query failure", code)
+	}
+	if strings.Contains(stderr.String(), hookStoreUnavailableToken) {
+		t.Fatalf("stderr %q carries the store-unavailable token for an application error", stderr.String())
+	}
+}
+
+func TestDoHookNoWorkStaysExitOne(t *testing.T) {
+	runner := func(string, string) (string, error) { return "", nil }
+	var stdout, stderr bytes.Buffer
+	if code := doHook("bd ready --json", "/tmp/work", false, runner, &stdout, &stderr, hookVisibility{}); code != 1 {
+		t.Fatalf("doHook = %d, want 1 for empty output (no work)", code)
+	}
+}
+
+func TestClassifyWorkQueryStoreUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"already typed", fmt.Errorf("x: %w", beads.ErrStoreUnavailable), true},
+		{"dial tcp", errors.New("Error: dial tcp 127.0.0.1:3307: connect: connection refused"), true},
+		{"server unreachable", errors.New("bd: server unreachable"), true},
+		{"silent fallback pair", errors.New("auto-importing 312 issues into empty database"), true},
+		{"application error", errors.New("exit status 1: unknown flag"), false},
+		// A bare "timed out" STRING stays application-class until the marker
+		// tables converge (ga-y8qzd); the typed deadline the runner wraps is
+		// the transport signal, and it must classify.
+		{"timeout string without marker or typed deadline", errors.New("timed out after 30s"), false},
+		{"runner-wrapped context deadline", fmt.Errorf("running work query: %w", context.DeadlineExceeded), true},
+		{"context deadline behind a message", fmt.Errorf("gc hook: work query exceeded 30s: %w", context.DeadlineExceeded), true},
+	}
+	for _, tc := range cases {
+		got := classifyWorkQueryStoreUnavailable(tc.err)
+		if tc.want && !errors.Is(got, beads.ErrStoreUnavailable) {
+			t.Errorf("%s: classified err = %v, want ErrStoreUnavailable", tc.name, got)
+		}
+		if !tc.want && errors.Is(got, beads.ErrStoreUnavailable) {
+			t.Errorf("%s: classified err = %v, want NOT ErrStoreUnavailable", tc.name, got)
+		}
+		if tc.err == nil && got != nil {
+			t.Errorf("%s: classified nil to %v", tc.name, got)
+		}
+	}
+}
+
+// hookExitCodeCity writes a one-agent city whose work_query is the given shell
+// command and points GC_CITY at it, so `gc hook worker` runs that command as
+// its work query through the production shell runner.
+func hookExitCodeCity(t *testing.T, workQuery string) {
+	t.Helper()
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+work_query = %q
+`, workQuery)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+}
+
+// TestHookCommandRendersStoreUnavailableAsExitTwo pins the exit-2 contract at
+// the process boundary: doHook returning 2 is worthless if the cobra RunE
+// folds every non-zero code into errExit (exit 1), because that is exactly the
+// code a hook consumer reads to tell "store down" from "no work". The fork
+// parent mapped the code through exitForCode like `hook run` does; a resync
+// regressed it to `!= 0 → errExit`.
+func TestHookCommandRendersStoreUnavailableAsExitTwo(t *testing.T) {
+	hookExitCodeCity(t, "printf 'Error: dial tcp 127.0.0.1:3307: connection refused\\n' >&2; exit 1")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hook", "worker"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("gc hook rendered exit %d, want 2 for a transport-class work-query failure; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), hookStoreUnavailableToken) {
+		t.Fatalf("stderr %q missing token %q", stderr.String(), hookStoreUnavailableToken)
+	}
+}
+
+// TestHookCommandRendersNoWorkAsExitOne is the companion pin: the process
+// boundary still renders an empty poll as exit 1, so restoring exit 2 above
+// did not widen the no-work code.
+func TestHookCommandRendersNoWorkAsExitOne(t *testing.T) {
+	hookExitCodeCity(t, "printf '[]'")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hook", "worker"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("gc hook rendered exit %d, want 1 for no work; stdout=%q stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), hookStoreUnavailableToken) {
+		t.Fatalf("stderr %q carries the store-unavailable token on an empty poll", stderr.String())
+	}
+}
+
+// TestHookCommandRendersWorkQueryTimeoutAsExitTwo pins the wedged-store shape
+// end to end: a work query that hangs past hookWorkQueryTimeout is a
+// transport-class failure (the runner wraps context.DeadlineExceeded for
+// exactly this), so the process renders exit 2 with the token — not the
+// no-work exit 1 that drains the seat while the store is merely hung.
+func TestHookCommandRendersWorkQueryTimeoutAsExitTwo(t *testing.T) {
+	oldTimeout := hookWorkQueryTimeout
+	hookWorkQueryTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { hookWorkQueryTimeout = oldTimeout })
+	// The query blocks well past the (shortened) timeout; the runner's
+	// deadline, not the sleep, ends it.
+	hookExitCodeCity(t, "sleep 5; printf '[]'")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hook", "worker"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("gc hook rendered exit %d, want 2 for a timed-out work query; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), hookStoreUnavailableToken) {
+		t.Fatalf("stderr %q missing token %q", stderr.String(), hookStoreUnavailableToken)
+	}
+}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -37,6 +37,14 @@ var ErrReadyContextUnsupported = errors.New("context-aware ready unsupported")
 // handle has been closed.
 var ErrStoreClosed = errors.New("bead store closed")
 
+// ErrStoreUnavailable is returned when the backing bead store cannot be
+// reached: the transport circuit breaker is open, or a fresh attempt failed
+// with a transport-class error. Consumers must treat it as "unknown", never
+// as "empty": gc hook exits 2 (distinct from exit-1 no-work), the controller
+// freezes the affected scope's prior desired state, and CachingStore serves
+// last-good data tagged degraded. Check with errors.Is.
+var ErrStoreUnavailable = errors.New("bead store unavailable")
+
 // ErrParentProjectionSuperseded reports that a parent update was overtaken by a
 // concurrent reparent before the caller's projection wait could converge.
 var ErrParentProjectionSuperseded = errors.New("parent projection superseded by concurrent update")

--- a/internal/testenv/gc_env_baseline_test.go
+++ b/internal/testenv/gc_env_baseline_test.go
@@ -75,6 +75,16 @@ func TestGCEnvReadBaseline(t *testing.T) {
 				// const/var GC_NAME = "GC_..." — the const-idiom used by
 				// os.Getenv(gcName); freezing the definition catches a new var read
 				// through an intermediate constant.
+				//
+				// Not every GC_-prefixed string constant is an ENV VAR, and this
+				// freeze is specifically the env-read vocabulary. A constant named
+				// here is a GC_-shaped string with some other role (a stderr token
+				// consumers grep for, a metadata key), so recording it would pin a
+				// non-env name in an env drift lock and mask a later real addition
+				// of the same name.
+				if nonEnvGCConstant(x.Names) {
+					return true
+				}
 				for _, val := range x.Values {
 					if lit, ok := val.(*ast.BasicLit); ok {
 						record(lit)
@@ -172,4 +182,27 @@ func diffStringSets(want, got []string) (added, removed []string) {
 	sort.Strings(added)
 	sort.Strings(removed)
 	return added, removed
+}
+
+// nonEnvGCConstantNames are declarations whose VALUE is GC_-shaped but which
+// are not environment variables, so they are outside this freeze's subject.
+// Keep this list short and justified: anything here is a name the env-read
+// drift lock will not notice.
+var nonEnvGCConstantNames = map[string]string{
+	// A stderr token gc hook emits alongside exit code 2 so runtime hook
+	// consumers can distinguish "store unreachable" from exit-1 no-work. It is
+	// printed, never read from the environment.
+	"hookStoreUnavailableToken": "stderr token, not an env var",
+}
+
+func nonEnvGCConstant(names []*ast.Ident) bool {
+	for _, n := range names {
+		if n == nil {
+			continue
+		}
+		if _, ok := nonEnvGCConstantNames[n.Name]; ok {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Part of the split of the closed #3324 into independently reviewable pieces. Wave two. Based on `main`; independent of the other pieces.

## Why this exists

`gc hook` exits 1 both when the queue is drained and when the work query failed. A consumer cannot tell those apart, so a wedged bead store reads as "no work": the agent idles while work is waiting, and nothing in the loop ever says the store is down. This is the chronic idle-agents-with-work-waiting failure, and it is invisible by construction — every symptom looks like a quiet queue.

## What it does

A transport-class work-query failure now prints `GC_HOOK_STORE_UNAVAILABLE` on stderr and exits **2**. Everything else keeps the existing exit 1 (no work, or an ordinary application error).

Classification has two inputs, both mechanical:

- **A typed `context.DeadlineExceeded`** from the work-query runner, which already wraps its deadline for exactly this purpose. This is the important one: a wedged-but-listening backend — hung connections, context-deadline floods — is the dominant outage shape and never produces a "connection refused" string.
- **The pinned bd transport-marker table.** That table was inlined in the body of `bdTransportRetryableError`; it is hoisted to a package-level `bdTransportRetryableMarkers` so the managed-retry path and the hook classify off one list. A marker added for one consumer must classify for the other. Hoisting is the whole of the `bd_env.go` change — same markers, same order, no behaviour change.

The token and the exit code are produced by one function from one classification, so an edit cannot reach one and not the other.

## Two details worth review attention

**The cobra `RunE` now maps the code through `exitForCode` instead of folding every non-zero code into `errExit`.** Without that, `doHook` returning 2 is worthless: the process still exits 1 and the contract is dead at the boundary. `TestHookCommandRendersStoreUnavailableAsExitTwo` drives the real CLI entry point (`run([]string{"hook", "worker"}, …)` against a temp city whose `work_query` is a failing shell command), not `doHook`, precisely so this cannot regress with the unit tests still green. Reverting just this line fails that test and `TestHookCommandRendersWorkQueryTimeoutAsExitTwo`; the `doHook`-level tests stay green, which is the point.

**A transport-class failure no longer prints partial stdout.** Partial output from a failed read is not a work list, and a consumer that parses stdout must not be handed one. Non-transport failures still surface whatever the query produced, as before.

## Carried helper

`internal/beads.ErrStoreUnavailable` is the typed sentinel the contract is expressed in, and it does not exist on `main` yet. The identical 8-line declaration is also carried by **#5949** (bd admission semaphore) and by the desired-state-freeze characterisation PR — same file, same text, no semantic divergence. Whichever lands first, the others' copies drop out. Flagging it so it does not read as a real conflict.

## What it does NOT do

- **Does not cover `--claim`.** That is a separate follow-up which stacks on this one. `--claim` is the form agents run in the dispatch loop, so it is where the token matters most, but the two halves are independently reviewable and neither tests a branch the other reaches.
- **Does not change how any consumer reacts to exit 2.** `agentScriptHookExitIsNoWork` on `main` already treats a non-warning stderr line as a hook failure, so the new token line is handled correctly today without touching it.
- No new config, no new event type.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `GC_FAST_UNIT=0 go test ./cmd/gc/ -run 'TestDoHook|TestClassifyWorkQueryStoreUnavailable|TestHookCommandRenders' -v` — 63 tests pass, 8 of them new
- Proven to bite, twice: reverting the `exitForCode` line fails the two CLI-boundary tests; removing the marker-table branch from the classifier fails `TestDoHookTransportClassErrorClassifiedUnavailable` and `TestClassifyWorkQueryStoreUnavailable`. Both restored green.
- pre-push gauntlet (`test-local-parallel fast`, all 6 `cmd/gc` shards + core) — all jobs passed

## Carried helper (2): the `GC_*` env-vocabulary guard

`internal/testenv` freezes the set of `GC_*` names non-test code declares, so a new capability cannot quietly grow an ad-hoc env knob. `hookStoreUnavailableToken = "GC_HOOK_STORE_UNAVAILABLE"` trips it: the guard records any `const … = "GC_…"` declaration, and this one is a **stderr token that is printed, never read from the environment**.

The fix is a short, justified allowlist in the guard itself (`nonEnvGCConstantNames`) rather than an entry in `testdata/gc_env_read_baseline.golden`. Adding it to the golden would pin a non-env name inside an env drift lock and mask a later *real* addition of the same name — the guard would stop noticing it.

This was caught by the pre-push suite, not by the targeted tests, and the allowlist entry is load-bearing: removing it reproduces the failure naming `GC_HOOK_STORE_UNAVAILABLE`.
