### PR TITLE
test(resilience): injectable jitter seam for deterministic breaker backoff

### DIFF
--- a/internal/resilience/registry.go
+++ b/internal/resilience/registry.go
@@ -1,6 +1,9 @@
 package resilience
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // OpClassBd is the operation class for bd CLI transport operations
 // (subprocess invocations against the managed Dolt backend). All bd
@@ -22,6 +25,7 @@ type Registry struct {
 	mu       sync.Mutex
 	settings Settings
 	onChange func(Transition)
+	jitter   func(capacity time.Duration) time.Duration
 	breakers map[Key]*Breaker
 }
 
@@ -60,8 +64,25 @@ func (r *Registry) Breaker(scope, opClass string) *Breaker {
 		return b
 	}
 	b := newBreaker(scope, opClass, r.settings, r.onChange)
+	if r.jitter != nil {
+		b.jitter = r.jitter
+	}
 	r.breakers[key] = b
 	return b
+}
+
+// SetJitterForTest pins the open-state jitter function on the registry
+// and every existing breaker so backoff deadlines are deterministic in
+// tests. Test-only.
+func (r *Registry) SetJitterForTest(fn func(capacity time.Duration) time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.jitter = fn
+	for _, b := range r.breakers {
+		b.mu.Lock()
+		b.jitter = fn
+		b.mu.Unlock()
+	}
 }
 
 // States returns a snapshot of every breaker's current state, for

--- a/internal/resilience/registry_jitter_test.go
+++ b/internal/resilience/registry_jitter_test.go
@@ -1,0 +1,132 @@
+package resilience
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// identityJitter is the canonical test pin: it returns the full backoff cap
+// instead of a uniform draw from (0, cap], so an open episode's deadline is
+// exactly OpenBase << (trips-1) and a test can assert on it.
+func identityJitter(capDur time.Duration) time.Duration { return capDur }
+
+func TestRegistrySetJitterForTestPinsNewBreakers(t *testing.T) {
+	reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1, OpenBase: time.Second, OpenMax: time.Minute})
+	reg.SetJitterForTest(identityJitter)
+
+	var mu sync.Mutex
+	var got []Transition
+	reg.SetOnStateChange(func(tr Transition) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, tr)
+	})
+
+	// Created AFTER the pin: the registry must seed it.
+	reg.Breaker("/city", OpClassBd).RecordFailure()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 {
+		t.Fatalf("got %d transitions, want 1", len(got))
+	}
+	if got[0].Backoff != time.Second {
+		t.Fatalf("open backoff = %v, want exactly %v — a pinned jitter must not draw randomly", got[0].Backoff, time.Second)
+	}
+}
+
+func TestRegistrySetJitterForTestPinsExistingBreakers(t *testing.T) {
+	reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1, OpenBase: 2 * time.Second, OpenMax: time.Minute})
+	// Created BEFORE the pin: SetJitterForTest must reach it too, the same way
+	// SetOnStateChange does.
+	b := reg.Breaker("/city", OpClassBd)
+	reg.SetJitterForTest(identityJitter)
+
+	var mu sync.Mutex
+	var got []Transition
+	reg.SetOnStateChange(func(tr Transition) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, tr)
+	})
+	b.RecordFailure()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 {
+		t.Fatalf("got %d transitions, want 1", len(got))
+	}
+	if got[0].Backoff != 2*time.Second {
+		t.Fatalf("open backoff = %v, want exactly %v", got[0].Backoff, 2*time.Second)
+	}
+}
+
+// TestRegistryPinnedJitterMakesBackoffRepeatable is the reason the seam
+// exists: without it, two registries with identical settings choose different
+// open deadlines, so any test that asserts on a backoff deadline is
+// time-dependent. It also pins the exponent, so a caller can assert on the
+// whole backoff ladder rather than only its cap.
+func TestRegistryPinnedJitterMakesBackoffRepeatable(t *testing.T) {
+	backoffs := func() []time.Duration {
+		reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1, OpenBase: time.Second, OpenMax: 8 * time.Second})
+		reg.SetJitterForTest(identityJitter)
+		var mu sync.Mutex
+		var out []time.Duration
+		reg.SetOnStateChange(func(tr Transition) {
+			mu.Lock()
+			defer mu.Unlock()
+			if tr.To == StateOpen {
+				out = append(out, tr.Backoff)
+			}
+		})
+		b := reg.Breaker("/city", OpClassBd)
+		for i := 0; i < 4; i++ {
+			b.RecordFailure()
+			// Force the next failure to re-open from half-open so trips climbs.
+			b.mu.Lock()
+			b.state = StateHalfOpen
+			b.mu.Unlock()
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]time.Duration(nil), out...)
+	}
+
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second}
+	for run := 0; run < 2; run++ {
+		got := backoffs()
+		if len(got) != len(want) {
+			t.Fatalf("run %d: got %d open transitions %v, want %d", run, len(got), got, len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d: backoff ladder = %v, want %v", run, got, want)
+			}
+		}
+	}
+}
+
+// TestRegistryUnpinnedJitterStillDrawsRandomly guards the seam from becoming
+// the default: a registry that was never pinned must keep full jitter, or the
+// thundering-herd protection the backoff exists for is silently gone.
+func TestRegistryUnpinnedJitterStillDrawsRandomly(t *testing.T) {
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 64; i++ {
+		reg := NewRegistry(Settings{Enabled: true, ConsecutiveFailures: 1, OpenBase: time.Second, OpenMax: time.Minute})
+		var mu sync.Mutex
+		var backoff time.Duration
+		reg.SetOnStateChange(func(tr Transition) {
+			mu.Lock()
+			defer mu.Unlock()
+			backoff = tr.Backoff
+		})
+		reg.Breaker("/city", OpClassBd).RecordFailure()
+		mu.Lock()
+		seen[backoff] = struct{}{}
+		mu.Unlock()
+	}
+	if len(seen) < 2 {
+		t.Fatalf("64 unpinned registries produced %d distinct backoffs %v, want a spread — full jitter is gone", len(seen), seen)
+	}
+}


### PR DESCRIPTION
Part of the twelve-way split of the closed #3324.

## Why this exists

`Breaker` already carries an injectable `jitter` field, but `Registry` — the
only public way to obtain a breaker — has no way to reach it. Every consumer
of a registry-owned breaker therefore gets a uniform draw from `(0, cap]` for
its open-state deadline, which makes any test that asserts on a backoff
deadline time-dependent. `Registry.SetJitterForTest` pins the jitter function
on the registry and on every breaker it has already handed out, exactly the
way `SetOnStateChange` already reaches both.

## What it does not do

Nothing about the default. An unpinned registry keeps full jitter; a test
guards that, because silently losing full jitter would remove the
thundering-herd protection the backoff exists for. No production caller is
added — the consumers that motivate this seam (the bd chokepoint breaker and
its timeout classification) are separate PRs in the same split.

## Stacking

None. This applies to current `origin/main` on its own.

## Extraction fidelity

`internal/resilience/registry.go` is taken verbatim from the fork:
`git diff fork/main -- internal/resilience/registry.go` is empty.

`internal/resilience/registry_jitter_test.go` is new and written for this PR —
the fork has no test for this seam because its only callers are `cmd/gc` tests
that live in later slices. Flagging that explicitly so it is not mistaken for
extracted code.

## Verification

```
gofmt -l internal/resilience/                      clean
go vet ./internal/resilience/                      clean
golangci-lint run ./internal/resilience/...        0 issues
go test ./internal/resilience/ -count=1 -v         31 PASS, 0 FAIL, 0 SKIP (0s)
go test ./internal/resilience/ -race -count=1      ok (1.0s)
```

Both new guards were checked by breaking what they guard:

- deleting `b.jitter = r.jitter` from `Registry.Breaker` →
  `TestRegistrySetJitterForTestPinsNewBreakers` fails
  (`open backoff = 254.137761ms, want exactly 1s`)
- deleting the existing-breaker loop from `SetJitterForTest` →
  `TestRegistrySetJitterForTestPinsExistingBreakers` fails
  (`open backoff = 1.794389616s, want exactly 2s`)
