### PR TITLE
test(gc): characterise the desired-state freeze on a store-unavailable scope

### DIFF
--- a/cmd/gc/build_desired_state_unavailable_test.go
+++ b/cmd/gc/build_desired_state_unavailable_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// R-INV (plan item 1.3): a scope whose store is unavailable must FREEZE
+// its prior desired state — partial-marked templates retain their open
+// session counts — and must never silently flatten to zero demand. Other
+// scopes proceed unaffected (scope quarantine).
+
+// unavailableReadyStore wraps a Store and fails Ready with the typed
+// ErrStoreUnavailable, simulating a breaker-open scope.
+type unavailableReadyStore struct {
+	beads.Store
+}
+
+func (s *unavailableReadyStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
+	return nil, fmt.Errorf("listing ready beads: %w", beads.ErrStoreUnavailable)
+}
+
+func TestDefaultScaleCheckCountsStoreUnavailableQuarantinesOneScope(t *testing.T) {
+	healthy := beads.NewMemStore()
+	if _, err := healthy.Create(beads.Bead{
+		Title:    "routed work",
+		Metadata: map[string]string{"gc.routed_to": "hq/worker"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	targets := []defaultScaleCheckTarget{
+		{template: "vr/worker", storeKey: "vr", store: &unavailableReadyStore{Store: beads.NewMemStore()}},
+		{template: "hq/worker", storeKey: "hq", store: healthy},
+	}
+
+	counts, partials, errs := defaultScaleCheckCounts(targets)
+
+	if !partials["vr/worker"] {
+		t.Fatalf("partials = %v, want vr/worker marked partial when its store is unavailable", partials)
+	}
+	if partials["hq/worker"] {
+		t.Fatalf("partials = %v — a healthy scope must not be quarantined by another scope's outage", partials)
+	}
+	if got := counts["hq/worker"]; got != 1 {
+		t.Fatalf("counts[hq/worker] = %d, want 1 (healthy scopes proceed)", got)
+	}
+	if len(errs) == 0 {
+		t.Fatal("errs is empty; the unavailable scope must surface a diagnostic, not vanish")
+	}
+}
+
+func TestRetainScaleCheckPartialPoolDesiredFreezesUnavailableScope(t *testing.T) {
+	// The unavailable scope reported zero new demand (counts has no
+	// entry); retention must freeze the desired count at the number of
+	// currently-running sessions so the reconciler cannot drain the pool
+	// on a store outage.
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{
+		{
+			ID:     "gm-1",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"template":     "vr/worker",
+				"pool_managed": "true",
+				"pool_slot":    "1",
+				"state":        "awake",
+			},
+		},
+		{
+			ID:     "gm-2",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"template":     "vr/worker",
+				"pool_managed": "true",
+				"pool_slot":    "2",
+				"state":        "active",
+			},
+		},
+	})
+
+	got := retainScaleCheckPartialPoolDesired(nil, nil, sessionBeads, map[string]bool{"vr/worker": true})
+	if got["vr/worker"] != 2 {
+		t.Fatalf("retained pool desired = %v, want vr/worker frozen at 2 running sessions", got)
+	}
+
+	// Without partial marking the same zero-count input would drain — the
+	// typed unavailable signal is what arms the freeze.
+	if drained := retainScaleCheckPartialPoolDesired(nil, nil, sessionBeads, nil); len(drained) != 0 {
+		t.Fatalf("retention without partial templates = %v, want empty", drained)
+	}
+}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -37,6 +37,14 @@ var ErrReadyContextUnsupported = errors.New("context-aware ready unsupported")
 // handle has been closed.
 var ErrStoreClosed = errors.New("bead store closed")
 
+// ErrStoreUnavailable is returned when the backing bead store cannot be
+// reached: the transport circuit breaker is open, or a fresh attempt failed
+// with a transport-class error. Consumers must treat it as "unknown", never
+// as "empty": gc hook exits 2 (distinct from exit-1 no-work), the controller
+// freezes the affected scope's prior desired state, and CachingStore serves
+// last-good data tagged degraded. Check with errors.Is.
+var ErrStoreUnavailable = errors.New("bead store unavailable")
+
 // ErrParentProjectionSuperseded reports that a parent update was overtaken by a
 // concurrent reparent before the caller's projection wait could converge.
 var ErrParentProjectionSuperseded = errors.New("parent projection superseded by concurrent update")


### PR DESCRIPTION
Part of the split of the closed #3324 into independently reviewable pieces. Wave two. Based on `main`; stands alone.

## Why this exists

A scope whose bead store is unreachable reports zero ready work. Nothing in the reconciler distinguishes that from a genuinely empty queue, so the failure mode is a silent flatten to zero demand: the pool drains on a store outage, and the work is rediscovered a tick later, after the seats are gone.

The machinery that prevents this **already exists on `main`** — `defaultScaleCheckCounts` marks a template partial when its store read fails, and `retainScaleCheckPartialPoolDesired` freezes a partial template's desired count at the number of currently-running sessions. What did not exist was a test saying so, which makes it exactly the kind of behaviour a refactor removes without anything going red.

This is a characterisation PR: no production change beyond the typed sentinel the tests are expressed in.

## What it does

Two tests in a new `cmd/gc/build_desired_state_unavailable_test.go`:

**Scope quarantine.** A store that fails `Ready` with the typed unavailable error marks *its own* template partial and surfaces a diagnostic, while a healthy sibling scope still counts its work normally. The invariant is that one scope's outage does not stall the fleet — and equally, that the unavailable scope does not silently vanish from the error list.

**The freeze, with its negative.** Retention freezes the unavailable scope at its running-session count. The same zero-count input *without* the partial marking still drains to nothing. The negative half is the point: it shows the partial signal is what arms the freeze, so the test cannot pass by accident on an implementation that retains everything unconditionally.

## Verified to bite

Both were confirmed red against deliberate breakage before being proposed:

- making `markScaleCheckPartialTemplate` a no-op fails the quarantine test;
- short-circuiting the retention guard fails the freeze test.

Both restored green.

## Carried helper

`internal/beads.ErrStoreUnavailable` is the typed sentinel the tests express "unavailable" in, and it does not exist on `main` yet. The identical 8-line declaration is also carried by **#5949** (bd admission semaphore) and by the `gc hook` exit-2 PR — same file, same text, no semantic divergence. Whichever lands first, the others' copies drop out. Flagging it so it does not read as a real conflict. Nothing else here depends on those PRs.

## What it does NOT do

- No production behaviour change. `build_desired_state.go` is untouched.
- Does not make anything *return* `ErrStoreUnavailable` in production — the store layer that does is a separate piece. These tests inject a fake store that returns it, which is what lets them pin the reconciler's reaction independently of who produces the signal.
- Does not cover the API/dashboard projection of a degraded scope.

## Verification

- `go build ./...`, `go vet ./cmd/gc/ ./internal/beads/`, `gofmt -l` — clean
- `GC_FAST_UNIT=0 go test ./cmd/gc/ -run 'TestDefaultScaleCheckCountsStoreUnavailableQuarantinesOneScope|TestRetainScaleCheckPartialPoolDesiredFreezesUnavailableScope' -v` — 2 tests, both pass
- pre-push gauntlet (`test-local-parallel fast`, all 6 `cmd/gc` shards + core) — all jobs passed
