### PR TITLE
fix(worktree): gc worktree ensure now materializes skills when --agent is given (#5951)

### DIFF
--- a/cmd/gc/cmd_worktree.go
+++ b/cmd/gc/cmd_worktree.go
@@ -25,6 +25,7 @@ type worktreeCmdOpts struct {
 	Generation string
 	Lifecycle  string
 	AttemptID  string
+	Agent      string
 	DryRun     bool
 	JSON       bool
 }
@@ -90,6 +91,8 @@ func newWorktreeEnsureCmd(stdout, stderr io.Writer) *cobra.Command {
 	}
 	worktreeFlagSet(cmd, &opts)
 	cmd.Flags().BoolVarP(&opts.DryRun, "dry-run", "n", false, "plan without mutating anything")
+	cmd.Flags().StringVar(&opts.Agent, "agent", "",
+		"qualified agent identity to best-effort materialize skills for after creation")
 	return cmd
 }
 
@@ -182,7 +185,38 @@ func runWorktreeEnsure(opts worktreeCmdOpts, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc worktree ensure: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	if !opts.DryRun && opts.Agent != "" {
+		materializeWorktreeAgentSkills(opts.Agent, rep.Path, stdout, stderr)
+	}
 	return writeWorktreeReport("ensure", rep, opts, stdout, stderr)
+}
+
+// materializeWorktreeAgentSkills best-effort materializes agent's skills
+// into path, reusing the same resolve-city/resolve-agent/materialize.Run
+// sequence the per-session PreStart hook drives via
+// `gc internal materialize-skills` (see materializeSkillsIntoWorkdir in
+// cmd_internal_materialize_skills.go). A failure at any step is logged to
+// stderr and never returned: worktree existence is ensure's postcondition,
+// not a materialized skill catalog.
+func materializeWorktreeAgentSkills(agentName, path string, stdout, stderr io.Writer) {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc worktree ensure: skill materialization skipped: city not found: %v\n", err) //nolint:errcheck
+		return
+	}
+	cfg, err := loadCityConfig(cityPath, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc worktree ensure: skill materialization skipped: city config unavailable: %v\n", err) //nolint:errcheck
+		return
+	}
+	agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
+	if !ok {
+		fmt.Fprintf(stderr, "gc worktree ensure: skill materialization skipped: unknown agent %q\n", agentName) //nolint:errcheck
+		return
+	}
+	if err := materializeSkillsIntoWorkdir(cfg, &agent, cityPath, path, nil, stdout, stderr); err != nil {
+		fmt.Fprintf(stderr, "gc worktree ensure: skill materialization failed: %v\n", err) //nolint:errcheck
+	}
 }
 
 func runWorktreeVerify(opts worktreeCmdOpts, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_worktree_test.go
+++ b/cmd/gc/cmd_worktree_test.go
@@ -74,6 +74,54 @@ func TestCmdWorktreeEnsureCreatesAndVerifies(t *testing.T) {
 	}
 }
 
+// clearCityEnv forces resolveCity to fail deterministically via the
+// ambient-upward-discovery refusal test binaries hit (main.go's
+// isTestBinary branch), regardless of what the host process inherited.
+func clearCityEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"GC_CITY", "GC_CITY_PATH", "GC_CITY_ROOT", "GC_DIR", "GC_RIG"} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestCmdWorktreeEnsureAgentFlagAttemptsMaterialization(t *testing.T) {
+	clearCityEnv(t)
+	repo, base := worktreeTestRepo(t)
+	root := t.TempDir()
+	wt := filepath.Join(root, "wt")
+	var stdout, stderr bytes.Buffer
+
+	opts := managedWorktreeCmdOpts(repo, root, wt, base)
+	opts.Agent = "gc-test-agent"
+	code := runWorktreeEnsure(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("ensure exit = %d, want 0 even when materialization can't resolve a city; stderr: %s", code, stderr.String())
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("worktree not created: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "skill materialization skipped") {
+		t.Errorf("stderr = %q, want evidence that --agent triggered a materialization attempt", stderr.String())
+	}
+}
+
+func TestCmdWorktreeEnsureNoAgentSkipsMaterialization(t *testing.T) {
+	clearCityEnv(t)
+	repo, base := worktreeTestRepo(t)
+	root := t.TempDir()
+	wt := filepath.Join(root, "wt")
+	var stdout, stderr bytes.Buffer
+
+	opts := managedWorktreeCmdOpts(repo, root, wt, base)
+	code := runWorktreeEnsure(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("ensure exit = %d, stderr: %s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "skill materialization") {
+		t.Errorf("stderr = %q, omitting --agent must not attempt materialization (regression guard for existing callers)", stderr.String())
+	}
+}
+
 func TestCmdWorktreeVerifyFailsOnMissing(t *testing.T) {
 	repo, _ := worktreeTestRepo(t)
 	root := t.TempDir()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5111,6 +5111,7 @@ gc worktree ensure [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--agent` | string |  | qualified agent identity to best-effort materialize skills for after creation |
 | `--base` | string |  | exact base ref used for this worktree (required) |
 | `--base-sha` | string |  | recorded base SHA to verify when reusing a worktree |
 | `--bead` | string |  | work bead bound to this worktree (required) |


### PR DESCRIPTION
## What

Closes #5951. Worktrees created directly via `gc worktree ensure` never got skill sinks materialized — the materializer (`internal/materialize.Run`) and its CLI wrapper (`gc internal materialize-skills`) already exist and are reused by two other call sites (the scope-root supervisor tick, and the per-session `PreStart` hook), but `gc worktree ensure` never invoked either one.

## Fix

New `--agent <name>` flag on `gc worktree ensure`; when given, triggers the same resolve-city/resolve-agent/`materialize.Run` sequence the `PreStart` hook already drives, scoped to the new worktree's path. Best-effort by design: a materialization failure is logged to stderr and never fails the `ensure` command itself, since worktree existence is its actual postcondition. Omitting `--agent` (every existing caller) leaves behavior completely unchanged — confirmed by a dedicated regression test.

## Scope note

The issue also names two formulas (`mol-verified-work`, `fable-nomad-code`) whose `prepare-worktree` steps should pass `--agent`. Neither formula's TOML exists in this repo — those pack definitions live in `gastownhall/gascity-packs`, a separate repo. This PR adds the capability those formulas would need to consume; wiring it into the actual formula steps is a separate, cross-repo follow-up.

## Validation

- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- `go test -tags gms_pure_go ./cmd/gc/... -run 'TestWorktreeEnsure|TestCmdWorktree'` — all 10 tests pass, including 2 new ones
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch `cmd/gc/cmd_worktree.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)