### PR TITLE
feat(doctor): flag live seats whose cwd carries no materialized skill sink (#5951)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -219,6 +219,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewServiceSecretsPermsCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		register(doctor.NewSkillDanglingSinkCheck(doctorSkillStaticSinks(cityPath, cfg), materialize.LegacyOwnedRootsFor(cityPath), doctorLiveSessionSinks(cityPath, cfg)))
+		register(doctor.NewSkillMissingSinkCheck(doctorSkillMissingSinkCandidates(cityPath, cfg)))
 		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
 		register(doctor.NewOrderOutcomeHealthyCheck(cfg, cityPath))
 		register(newCodexHooksDriftCheck(cityPath, codexHookWorkDirs(cityPath, cfg)))

--- a/cmd/gc/cmd_doctor_skill_sinks.go
+++ b/cmd/gc/cmd_doctor_skill_sinks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/materialize"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -41,6 +42,31 @@ func doctorSkillStaticSinks(cityPath string, cfg *config.City) []string {
 // failing the whole check (the static sinks still scan).
 func doctorLiveSessionSinks(cityPath string, cfg *config.City) func() []string {
 	return func() []string {
+		var sinks []string
+		for _, c := range doctorLiveSessionSinkCandidates(cityPath, cfg)() {
+			sinks = append(sinks, c.SessionSink)
+		}
+		return sinks
+	}
+}
+
+// doctorLiveSessionSinkCandidate pairs one live session's own skill sink
+// with the scope-root sink of the agent it was started from, so the
+// missing-sink check can tell "this agent has no skills to deliver" apart
+// from "this session's cwd cannot see the skills its agent has".
+type doctorLiveSessionSinkCandidate struct {
+	SessionName string
+	SessionSink string // WorkDir × vendor sink for this session
+	ScopeSink   string // the originating agent's scope-root × vendor sink
+}
+
+// doctorLiveSessionSinkCandidates is the shared lazy session-store scan
+// behind doctorLiveSessionSinks (dangling links) and the missing-sink
+// check registered alongside it: both need the live WorkDir × vendor sink,
+// and the latter additionally needs the originating agent's scope-root
+// sink to know whether skills exist to have been materialized at all.
+func doctorLiveSessionSinkCandidates(cityPath string, cfg *config.City) func() []doctorLiveSessionSinkCandidate {
+	return func() []doctorLiveSessionSinkCandidate {
 		store, err := openSessionProviderStore(cityPath)
 		if err != nil {
 			return nil
@@ -49,7 +75,7 @@ func doctorLiveSessionSinks(cityPath string, cfg *config.City) func() []string {
 		if err != nil {
 			return nil
 		}
-		var sinks []string
+		var out []doctorLiveSessionSinkCandidate
 		for _, info := range infos {
 			if info.Closed || info.WorkDir == "" {
 				continue
@@ -58,8 +84,57 @@ func doctorLiveSessionSinks(cityPath string, cfg *config.City) func() []string {
 			if !ok {
 				continue
 			}
-			sinks = append(sinks, filepath.Join(info.WorkDir, vendor))
+			sessionSink := filepath.Join(info.WorkDir, vendor)
+			scopeSink := doctorAgentScopeSink(cityPath, cfg, info.AgentName, vendor)
+			// Every live session sink is kept here, including where
+			// scopeSink == sessionSink (the common case): the sibling
+			// dangling-sink check (doctorLiveSessionSinks) needs every
+			// live sink scanned regardless of scope-root equality. The
+			// missing-sink check filters that case out itself, since
+			// identical dirs can never be "missing" relative to each
+			// other.
+			out = append(out, doctorLiveSessionSinkCandidate{
+				SessionName: info.SessionName,
+				SessionSink: sessionSink,
+				ScopeSink:   scopeSink,
+			})
 		}
-		return sinks
+		return out
 	}
+}
+
+// doctorSkillMissingSinkCandidates adapts doctorLiveSessionSinkCandidates
+// to the doctor package's public candidate type for the missing-sink check.
+func doctorSkillMissingSinkCandidates(cityPath string, cfg *config.City) func() []doctor.SkillMissingSinkCandidate {
+	fn := doctorLiveSessionSinkCandidates(cityPath, cfg)
+	return func() []doctor.SkillMissingSinkCandidate {
+		src := fn()
+		out := make([]doctor.SkillMissingSinkCandidate, len(src))
+		for i, c := range src {
+			out[i] = doctor.SkillMissingSinkCandidate{
+				SessionName: c.SessionName,
+				SessionSink: c.SessionSink,
+				ScopeSink:   c.ScopeSink,
+			}
+		}
+		return out
+	}
+}
+
+// doctorAgentScopeSink resolves the given named agent's scope-root × vendor
+// sink path, or "" when the agent is unknown or its provider has no
+// registered vendor sink.
+func doctorAgentScopeSink(cityPath string, cfg *config.City, agentName, vendor string) string {
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if agent.Name != agentName {
+			continue
+		}
+		scopeRoot := resolveAgentScopeRoot(agent, cityPath, cfg.Rigs)
+		if !filepath.IsAbs(scopeRoot) {
+			scopeRoot = filepath.Join(cityPath, scopeRoot)
+		}
+		return filepath.Join(scopeRoot, vendor)
+	}
+	return ""
 }

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -35,6 +35,7 @@ instructions-file
 service-secrets-perms
 skill-collision
 skill-dangling-sink
+skill-missing-sink
 order-firing-current
 order-outcome-healthy
 codex-hooks-drift

--- a/internal/doctor/skill_missing_sink_check.go
+++ b/internal/doctor/skill_missing_sink_check.go
@@ -1,0 +1,95 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"sort"
+)
+
+// SkillMissingSinkCandidate is one live session whose own skill sink may
+// be invisible to its provider CLI: the session's WorkDir differs from the
+// originating agent's scope root (a per-bead worktree, typically), so the
+// scope-root materializer pass never reached it.
+type SkillMissingSinkCandidate struct {
+	SessionName string
+	SessionSink string // WorkDir × vendor sink the seat's CLI actually reads
+	ScopeSink   string // the originating agent's scope-root × vendor sink
+}
+
+// SkillMissingSinkCheck flags a live session's WorkDir that carries no
+// materialized skill sink at all, even though the agent it was started
+// from has skills materialized at its scope root. A provider whose CLI
+// reads a cwd-relative sink (.claude/skills, .agents/skills) sees none of
+// the pack/role skills once work moves into such a worktree — a real
+// capability gap between that seat and one still running at the scope
+// root (cr-mdi6h).
+type SkillMissingSinkCheck struct {
+	candidatesFn func() []SkillMissingSinkCandidate
+}
+
+// NewSkillMissingSinkCheck builds a check over the given lazy candidate
+// enumerator. candidatesFn is evaluated inside Run, matching the sibling
+// SkillDanglingSinkCheck's laziness: store-backed session enumeration
+// never slows doctor check construction or a run that never reaches it.
+func NewSkillMissingSinkCheck(candidatesFn func() []SkillMissingSinkCandidate) *SkillMissingSinkCheck {
+	return &SkillMissingSinkCheck{candidatesFn: candidatesFn}
+}
+
+// Name returns the check identifier.
+func (c *SkillMissingSinkCheck) Name() string { return "skill-missing-sink" }
+
+// sinkHasEntries reports whether dir exists and contains at least one
+// entry. A missing scope sink (no entries) means the agent has nothing to
+// deliver yet — not a defect the session-side sink can be blamed for.
+func sinkHasEntries(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
+}
+
+// Run reports a warning for every candidate whose scope-root sink has
+// materialized skills but whose own session sink is empty or absent.
+func (c *SkillMissingSinkCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.candidatesFn == nil {
+		r.Status = StatusOK
+		r.Message = "no live sessions to check"
+		return r
+	}
+	var missing []SkillMissingSinkCandidate
+	for _, cand := range c.candidatesFn() {
+		if cand.ScopeSink == "" || !sinkHasEntries(cand.ScopeSink) {
+			continue
+		}
+		if sinkHasEntries(cand.SessionSink) {
+			continue
+		}
+		missing = append(missing, cand)
+	}
+	if len(missing) == 0 {
+		r.Status = StatusOK
+		r.Message = "every live session's skill sink is materialized"
+		return r
+	}
+	sort.Slice(missing, func(i, j int) bool { return missing[i].SessionName < missing[j].SessionName })
+	details := make([]string, 0, len(missing))
+	for _, m := range missing {
+		details = append(details, fmt.Sprintf("%s: %s has no materialized skills (agent sink: %s)", m.SessionName, m.SessionSink, m.ScopeSink))
+	}
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	r.Message = fmt.Sprintf("%d live session(s) cannot see their agent's materialized skills", len(missing))
+	r.Details = details
+	r.FixHint = "run `gc internal materialize-skills --agent <agent> --workdir <dir>` for each session, or route worktree creation through a step that materializes into the worktree"
+	return r
+}
+
+// CanFix returns false — the fix requires per-session agent identity this
+// check does not itself resolve to a --fix-safe action.
+func (c *SkillMissingSinkCheck) CanFix() bool { return false }
+
+// Fix is never called: CanFix returns false.
+func (c *SkillMissingSinkCheck) Fix(_ *CheckContext) error { return nil }
+
+// WarmupEligible returns false — the candidate scan opens the session
+// store, which the `gc start` warm-up path should not pay for.
+func (c *SkillMissingSinkCheck) WarmupEligible() bool { return false }

--- a/internal/doctor/skill_missing_sink_check_test.go
+++ b/internal/doctor/skill_missing_sink_check_test.go
@@ -1,0 +1,113 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mkSinkEntry(t *testing.T, sink, name string) {
+	t.Helper()
+	if err := os.MkdirAll(sink, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "skill")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(sink, name)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSkillMissingSinkCheckNilCandidatesFn(t *testing.T) {
+	t.Parallel()
+	c := NewSkillMissingSinkCheck(nil)
+	if r := c.Run(&CheckContext{}); r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK (%s)", r.Status, r.Message)
+	}
+}
+
+func TestSkillMissingSinkCheckNoCandidates(t *testing.T) {
+	t.Parallel()
+	c := NewSkillMissingSinkCheck(func() []SkillMissingSinkCandidate { return nil })
+	if r := c.Run(&CheckContext{}); r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK (%s)", r.Status, r.Message)
+	}
+}
+
+func TestSkillMissingSinkCheckScopeSinkEmptyIsNotFlagged(t *testing.T) {
+	t.Parallel()
+	scope := filepath.Join(t.TempDir(), "no-such-scope-sink")
+	sess := filepath.Join(t.TempDir(), "no-such-session-sink")
+	c := NewSkillMissingSinkCheck(func() []SkillMissingSinkCandidate {
+		return []SkillMissingSinkCandidate{{SessionName: "s1", SessionSink: sess, ScopeSink: scope}}
+	})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK when the agent has nothing materialized to begin with (%s)", r.Status, r.Message)
+	}
+}
+
+func TestSkillMissingSinkCheckFlagsMissingSessionSink(t *testing.T) {
+	t.Parallel()
+	scope := t.TempDir()
+	mkSinkEntry(t, scope, "core.gc-work")
+	sess := filepath.Join(t.TempDir(), "worktree-with-no-sink")
+
+	c := NewSkillMissingSinkCheck(func() []SkillMissingSinkCandidate {
+		return []SkillMissingSinkCandidate{{SessionName: "worker-1", SessionSink: sess, ScopeSink: scope}}
+	})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning (%s)", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Errorf("severity = %v, want advisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "1 live session") {
+		t.Errorf("message = %q", r.Message)
+	}
+	if len(r.Details) != 1 || !strings.Contains(r.Details[0], "worker-1") {
+		t.Errorf("details = %v, want the flagged session named", r.Details)
+	}
+	if r.FixHint == "" {
+		t.Error("FixHint empty with a missing session sink present")
+	}
+	if c.CanFix() {
+		t.Error("CanFix = true, want false")
+	}
+}
+
+func TestSkillMissingSinkCheckMaterializedSessionSinkIsClean(t *testing.T) {
+	t.Parallel()
+	scope := t.TempDir()
+	mkSinkEntry(t, scope, "core.gc-work")
+	sess := t.TempDir()
+	mkSinkEntry(t, sess, "core.gc-work")
+
+	c := NewSkillMissingSinkCheck(func() []SkillMissingSinkCandidate {
+		return []SkillMissingSinkCandidate{{SessionName: "worker-1", SessionSink: sess, ScopeSink: scope}}
+	})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK (%s)", r.Status, r.Message)
+	}
+}
+
+func TestSkillMissingSinkCheckCandidatesFnLazy(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	c := NewSkillMissingSinkCheck(func() []SkillMissingSinkCandidate {
+		calls++
+		return nil
+	})
+	if calls != 0 {
+		t.Fatal("candidatesFn evaluated during construction")
+	}
+	c.Run(&CheckContext{})
+	if calls != 1 {
+		t.Fatalf("candidatesFn called %d times, want 1", calls)
+	}
+}


### PR DESCRIPTION
## What

A `gc doctor` check — `skill-missing-sink` — for the silent half of #5951.

When a session's work moves into a worktree the scope-root materializer never
reached, the seat loses every pack/role skill its provider CLI would have read
from a cwd-relative sink (`.claude/skills`, `.agents/skills`). Nothing says so:
the seat just has fewer capabilities than its agent was configured with, and a
sibling seat still running at the scope root has them all. That is how #5951 was
found in the first place — by noticing a seat's `<skills_instructions>` was
missing `core.*` entries, not by any health output.

This is detection only, and complementary to #5972: that PR lets a caller of
`gc worktree ensure` avoid *creating* the gap; this one reports the gap for
worktrees created by any means (a formula step that forgets the flag, an
operator's own `git worktree add`, an older worktree predating either).

## Fix

`doctor.NewSkillMissingSinkCheck` warns for every live (non-closed) session whose
own `WorkDir × vendor` sink is empty or absent while the agent it was started
from *does* have skills materialized at its scope root, and names the
`gc internal materialize-skills --agent <agent> --workdir <dir>` invocation that
repairs it.

- Advisory-only warning; never fails a doctor run.
- `WarmupEligible() == false` — the candidate scan opens the session store, which
  the `gc start` warm-up path should not pay for.
- `CanFix() == false` — the repair needs a per-session agent identity this check
  does not resolve to a `--fix`-safe action, so it reports and stops.
- An agent with an empty scope-root sink is never blamed on the session: there is
  nothing to deliver, so nothing is missing.

The session-store scan is shared with the sibling `skill-dangling-sink` check
(`doctorLiveSessionSinkCandidates`) and stays lazily evaluated inside `Run`, so a
store failure yields no candidates rather than failing the check, and check
construction never touches the store. Sharing the scan deliberately keeps
sessions whose cwd *is* the scope root: `skill-dangling-sink` dedupes sink paths
so they cost nothing there, and `skill-missing-sink` cannot flag a directory
against itself.

## Validation

- `make build`, `make fmt-check`, `make vet` clean
- `make lint` — zero issues in the touched packages
- `make check-docs` green
- `go test ./internal/doctor/... -count=1` green, including the new
  `skill_missing_sink_check_test.go` (nil candidate fn, no candidates, empty
  scope sink not flagged, missing session sink flagged, materialized session sink
  clean, candidate fn evaluated lazily inside `Run`)
- `go test ./cmd/gc/ -run "Doctor|SkillSink|Worktree" -count=1` green;
  `cmd/gc/testdata/doctor_check_names.golden` updated for the new check name
- `make check-release-dist-ignore`, `check-routed-test-rows`,
  `check-split-topology-rows`, `check-residency-boundary` green

Refs #5951
