### PR TITLE
fix: warn when closed work is not published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gc bd` work closes now detect unpublished commits named in work metadata
+  or the close reason.** A commit passes when any remote-tracking ref contains
+  it or when all paths changed since its merge base have matching blobs on one,
+  so squash merges pass without unrelated target-branch changes causing false
+  warnings. The gate remains warn-only unless `GC_WORK_RECORD_ENFORCE` is set.
+
 - **Mail archive and delete now expand whitespace-joined message IDs.** Each
   positional argument is split into individual IDs before single-versus-batch
   dispatch, so shell variables containing multiple IDs no longer look like one

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -109,7 +109,11 @@ that assignee.
 
 gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
 from wedging the wrapper after printing command output. If you need
-auto-export behavior, invoke bd directly.`,
+auto-export behavior, invoke bd directly.
+
+When a work close names a commit, gc warns unless that commit is on a
+remote-tracking ref or all paths it changed have matching blobs on one. The
+blob check recognizes squash merges without comparing unrelated branch work.`,
 		Example: `  gc bd --rig my-project list
   gc bd --rig my-project create "New task"
   gc bd show my-project-abc          # auto-detects rig from bead prefix
@@ -476,10 +480,11 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 
 	// Work-record close gate (ADR-0009): a close routed through the SDK seam
 	// must satisfy the typed work-record contract (gc.work_outcome present;
-	// shipped ⇒ gc.work_commit reachable on gc.work_branch). Warn-only by default;
-	// blocks the close only when GC_WORK_RECORD_ENFORCE is set. Reuses the
-	// store/beads the write-ID guard above already opened and read, and the
-	// config the caller already loaded.
+	// shipped ⇒ gc.work_commit published directly or as squash-equivalent
+	// changed-path blobs on a remote-tracking ref). Warn-only by default; blocks
+	// the close only when GC_WORK_RECORD_ENFORCE is set. Reuses the store/beads
+	// the write-ID guard above already opened and read, and the config the caller
+	// already loaded.
 	if runWorkRecordCloseGate(bdArgs, target.ScopeRoot, cityPath, cfg, guardStore, guardBeads, stderr) {
 		return 1
 	}

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -6,8 +6,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/bdflags"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -16,9 +19,10 @@ import (
 // Work-record close gate (ADR-0009). Closing a work bead through the SDK close
 // seam (`gc bd close`) is validated against the typed work-record contract: the
 // bead must carry a typed gc.work_outcome, and a "shipped" outcome must point at
-// a commit that is reachable on the stamped gc.work_branch. This turns the
-// recurring "drain-without-commit" close (a close that leaves no artifact at
-// all) into a machine-checkable violation.
+// a commit published on a remote-tracking ref. Squash merges count as published
+// when every path changed by the work commit has the same blob on a remote ref.
+// This turns the recurring "drain-without-published-work" close into a
+// machine-checkable violation.
 //
 // The gate ships warn-only by default — violations are logged but the close
 // proceeds — so existing open beads migrate without breakage. Set
@@ -103,10 +107,10 @@ func isWorkRecordGatedBead(bead beads.Bead) bool {
 
 // validateWorkRecordOnClose checks bead against the typed work-record contract
 // and returns a human-readable message for each violation (empty slice ⇒ the
-// bead satisfies the contract). commitReachable reports whether a commit SHA is
-// an ancestor of a branch; it is injected so the rule is unit-testable without
-// a real repo. The caller is responsible for scoping (isWorkRecordGatedBead).
-func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, branch string) bool) []string {
+// bead satisfies the contract). commitPublished reports whether a commit is on
+// a remote-tracking ref or has squash-equivalent blobs there. The caller is
+// responsible for scoping (isWorkRecordGatedBead).
+func validateWorkRecordOnClose(bead beads.Bead, commitPublished func(commit string) bool) []string {
 	outcome := strings.TrimSpace(bead.Metadata[beadmeta.WorkOutcomeMetadataKey])
 	if outcome == "" {
 		return []string{fmt.Sprintf("missing %s (want one of shipped|no-op|blocked|abandoned)", beadmeta.WorkOutcomeMetadataKey)}
@@ -128,80 +132,169 @@ func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, bra
 	if branch == "" {
 		violations = append(violations, fmt.Sprintf("%s=shipped requires %s (the branch the commit lives on)", beadmeta.WorkOutcomeMetadataKey, beadmeta.WorkBranchMetadataKey))
 	}
-	if commit != "" && branch != "" && !commitReachable(commit, branch) {
-		violations = append(violations, fmt.Sprintf("%s %s is not reachable on %s %s", beadmeta.WorkCommitMetadataKey, commit, beadmeta.WorkBranchMetadataKey, branch))
+	if commit != "" && branch != "" && !commitPublished(commit) {
+		violations = append(violations, fmt.Sprintf("%s %s is not published on any remote-tracking ref", beadmeta.WorkCommitMetadataKey, commit))
 	}
 	return violations
 }
 
-// preferredReachabilityRef decides which ref gitCommitReachableOnBranch should
-// check commit-reachability against: refs/remotes/origin/<branch> when it
-// resolves, otherwise the bare branch name. gitrevisions precedence puts a
-// local refs/heads/<branch> ahead of any remote-tracking ref, but the
-// worktree named by gc.work_dir is rarely the one whose local branch tip
-// actually moves — a refinery or polecat that merges/pushes from a different
-// worktree advances the remote-tracking ref, never the local one checked out
-// elsewhere. Resolving against the local ref alone reports a landed commit as
-// unreachable until something happens to fast-forward it, which in that
-// topology may be never (gastownhall/gascity#5037).
-//
-// remoteRefResolves is injected so the decision is unit-testable without a
-// real git repository; the only production caller runs
-// `git rev-parse --verify --quiet <ref>`. Kept as a separate probe rather
-// than a fallback on the merge-base exit code so the caller can distinguish
-// "no such ref" from "not reachable"; see commitReachableOnEitherRef.
-func preferredReachabilityRef(branch string, remoteRefResolves func(ref string) bool) string {
-	if remote := "refs/remotes/origin/" + branch; remoteRefResolves(remote) {
-		return remote
+var commitTokenRE = regexp.MustCompile(`(?i)\b[0-9a-f]{7,40}\b`)
+
+const gitBlobPathBatchSize = 256
+
+func closeEvidenceFlag(verb, flag string) (reasonFile, ok bool) {
+	switch verb {
+	case "close":
+		switch flag {
+		case "-r", "--reason":
+			return false, true
+		case "--reason-file":
+			return true, true
+		}
+	case "update":
+		switch flag {
+		case "--notes", "--append-notes":
+			return false, true
+		}
 	}
-	return branch
+	return false, false
 }
 
-// commitReachableOnEitherRef reports whether a commit is reachable from the
-// branch's remote-tracking ref OR from the branch itself. The remote-tracking
-// ref is probed first (see preferredReachabilityRef) because it is the ref
-// that actually advances in a refinery/polecat topology; the bare branch name
-// is then still checked, because ADR-0009's contract is that the commit is
-// reachable on gc.work_branch — not that it has been pushed. Checking only the
-// remote ref would reject a commit that is genuinely on the local branch but
-// sits ahead of (or was never pushed to) origin, a false negative in the exact
-// mirror image of gastownhall/gascity#5037.
-//
-// Both probes are injected so the decision is unit-testable without a real git
-// repository. The local ref is never probed twice.
-func commitReachableOnEitherRef(branch string, remoteRefResolves, reachableOnRef func(ref string) bool) bool {
-	ref := preferredReachabilityRef(branch, remoteRefResolves)
-	if reachableOnRef(ref) {
-		return true
+func closeReasonCommitCandidates(bdArgs []string, scopeRoot string) []string {
+	if len(bdArgs) == 0 {
+		return nil
 	}
-	if ref == branch {
-		return false
+	valueFlags := bdflags.ValueFlags(bdArgs[0])
+	var candidates []string
+	for i := 1; i < len(bdArgs); i++ {
+		arg := bdArgs[i]
+		if arg == "--" {
+			break
+		}
+		flag, value, inline := strings.Cut(arg, "=")
+		reasonFile, ok := closeEvidenceFlag(bdArgs[0], flag)
+		if !ok {
+			if !inline && valueFlags[flag] && i+1 < len(bdArgs) {
+				i++
+			}
+			continue
+		}
+		if !inline {
+			if i+1 >= len(bdArgs) {
+				continue
+			}
+			i++
+			value = bdArgs[i]
+		}
+		if reasonFile {
+			if value == "-" {
+				continue
+			}
+			if !filepath.IsAbs(value) {
+				value = filepath.Join(scopeRoot, value)
+			}
+			data, err := os.ReadFile(value)
+			if err != nil {
+				continue
+			}
+			value = string(data)
+		}
+		candidates = append(candidates, commitTokenRE.FindAllString(value, -1)...)
 	}
-	return reachableOnRef(branch)
+	return candidates
 }
 
-// gitCommitReachableOnBranch reports whether commit is an ancestor of branch in
-// the git repository at repoDir (worktrees share one object store, so any
-// worktree dir resolves refs across the repo). A non-nil error from git — bad
-// repo, unknown ref, unknown commit — reads as "not reachable". A commit/branch
-// that looks like a flag (leading "-") is rejected outright so a malformed
-// metadata value can never be parsed as a git option. See
-// commitReachableOnEitherRef for how branch is resolved to the refs that can
-// prove reachability.
-func gitCommitReachableOnBranch(repoDir, commit, branch string) bool {
-	if strings.TrimSpace(repoDir) == "" || commit == "" || branch == "" {
+func validateCloseReasonCommitsOnPublishedRefs(
+	bead beads.Bead,
+	bdArgs []string,
+	scopeRoot, repoDir string,
+) []string {
+	if strings.TrimSpace(bead.Metadata[beadmeta.WorkCommitMetadataKey]) != "" {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var violations []string
+	for _, commit := range closeReasonCommitCandidates(bdArgs, scopeRoot) {
+		if _, ok := seen[commit]; ok {
+			continue
+		}
+		seen[commit] = struct{}{}
+		published, valid := gitCommitPublication(repoDir, commit)
+		if valid && !published {
+			violations = append(violations, fmt.Sprintf(
+				"commit %s named in close reason is not published on any remote-tracking ref",
+				commit,
+			))
+		}
+	}
+	return violations
+}
+
+// gitCommitPublication reports whether commit resolves locally and whether its
+// work is present on a remote-tracking ref. Direct ancestry covers ordinary
+// pushes. Changed-path blob equality covers squash merges without comparing
+// unrelated paths added to the destination branch after the work branched.
+func gitCommitPublication(repoDir, commit string) (published, valid bool) {
+	commit = strings.TrimSpace(commit)
+	if strings.TrimSpace(repoDir) == "" || commit == "" || strings.HasPrefix(commit, "-") {
+		return false, false
+	}
+	out, err := exec.Command(
+		"git", "-C", repoDir, "rev-parse", "--verify", "--quiet", commit+"^{commit}",
+	).Output()
+	if err != nil {
+		return false, false
+	}
+	commit = strings.TrimSpace(string(out))
+	out, err = exec.Command(
+		"git", "-C", repoDir, "for-each-ref", "--format=%(refname)", "refs/remotes/",
+	).Output()
+	if err != nil {
+		return false, true
+	}
+	for _, ref := range strings.Fields(string(out)) {
+		if exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", commit, ref).Run() == nil {
+			return true, true
+		}
+		if gitChangedPathBlobsMatchRef(repoDir, commit, ref) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// gitChangedPathBlobsMatchRef compares only paths changed from the work
+// commit's merge base through the commit. git diff --quiet compares their tree
+// entries and blob OIDs; unrelated destination-ref changes are out of scope.
+func gitChangedPathBlobsMatchRef(repoDir, commit, ref string) bool {
+	out, err := exec.Command("git", "-C", repoDir, "merge-base", commit, ref).Output()
+	if err != nil {
 		return false
 	}
-	if strings.HasPrefix(commit, "-") || strings.HasPrefix(branch, "-") {
+	base := strings.TrimSpace(string(out))
+	out, err = exec.Command(
+		"git", "-C", repoDir, "diff", "--name-only", "--no-renames", "-z", base, commit, "--",
+	).Output()
+	if err != nil {
 		return false
 	}
-	return commitReachableOnEitherRef(branch,
-		func(candidate string) bool {
-			return exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "--quiet", candidate).Run() == nil
-		},
-		func(ref string) bool {
-			return exec.Command("git", "-C", repoDir, "merge-base", "--is-ancestor", commit, ref).Run() == nil
-		})
+	encodedPaths := strings.TrimSuffix(string(out), "\x00")
+	if encodedPaths == "" {
+		return false
+	}
+	paths := strings.Split(encodedPaths, "\x00")
+	for len(paths) > 0 {
+		count := min(len(paths), gitBlobPathBatchSize)
+		args := []string{
+			"-C", repoDir, "diff", "--quiet", "--no-ext-diff", "--no-textconv", commit, ref, "--",
+		}
+		args = append(args, paths[:count]...)
+		if exec.Command("git", args...).Run() != nil {
+			return false
+		}
+		paths = paths[count:]
+	}
+	return true
 }
 
 // workRecordCloseTargets returns the bead IDs a bd invocation closes, and
@@ -329,10 +422,15 @@ func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched 
 		if projectionErr != nil {
 			violations = []string{projectionErr.Error()}
 		} else {
-			violations = validateWorkRecordOnClose(bead, func(commit, branch string) bool {
-				return gitCommitReachableOnBranch(repoDir, commit, branch)
+			violations = validateWorkRecordOnClose(bead, func(commit string) bool {
+				published, _ := gitCommitPublication(repoDir, commit)
+				return published
 			})
 		}
+		violations = append(
+			violations,
+			validateCloseReasonCommitsOnPublishedRefs(bead, bdArgs, scopeRoot, repoDir)...,
+		)
 		for _, v := range violations {
 			fmt.Fprintf(stderr, "gc bd: work-record gate (%s): close of %s: %s\n", mode, id, v) //nolint:errcheck // best-effort stderr
 		}

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -10,16 +10,16 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// alwaysReachable / neverReachable are injected commit-reachability oracles so
+// alwaysReachable / neverReachable are injected commit-publication oracles so
 // the work-record validation is testable without a real git repo.
-func alwaysReachable(string, string) bool { return true }
-func neverReachable(string, string) bool  { return false }
+func alwaysReachable(string) bool { return true }
+func neverReachable(string) bool  { return false }
 
 func TestValidateWorkRecordOnClose(t *testing.T) {
 	tests := []struct {
 		name      string
 		meta      map[string]string
-		reachable func(string, string) bool
+		reachable func(string) bool
 		wantViol  string // substring expected in the (single) violation; "" ⇒ no violations
 	}{
 		{
@@ -43,14 +43,14 @@ func TestValidateWorkRecordOnClose(t *testing.T) {
 			wantViol:  "",
 		},
 		{
-			name: "shipped with commit NOT reachable on branch is rejected",
+			name: "shipped with unpublished commit is rejected",
 			meta: map[string]string{
 				beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped,
 				beadmeta.WorkCommitMetadataKey:  "abc123",
 				beadmeta.WorkBranchMetadataKey:  "bd-x",
 			},
 			reachable: neverReachable,
-			wantViol:  "not reachable",
+			wantViol:  "not published",
 		},
 		{
 			name: "shipped without commit is rejected",
@@ -101,86 +101,6 @@ func TestValidateWorkRecordOnClose(t *testing.T) {
 			joined := strings.Join(got, " | ")
 			if !strings.Contains(joined, tc.wantViol) {
 				t.Fatalf("violation %q does not contain %q", joined, tc.wantViol)
-			}
-		})
-	}
-}
-
-// TestPreferredReachabilityRef exercises the ref-selection decision behind
-// gastownhall/gascity#5037 via an injected resolver rather than a real git
-// repository — this package's tracked test-resource census
-// (internal/testpolicy/resourcecensus, test/test-resources.toml) ratchets the
-// untagged subprocess call/file count down and forbids growing it without a
-// council-reviewed policy change, so a real end-to-end git fixture isn't the
-// right shape for this unit; see docs/reference/specs — the actual
-// git-merge-base call this feeds stays covered by the same trust level it
-// had before this fix (it was already untested and unchanged). Per the
-// issue's own guidance, this asserts the *resolved ref* rather than relying
-// on "no warning" as a proxy — the pre-fix code was fail-closed and silently
-// wrong for some bead types, so absence of a warning was never sufficient
-// evidence.
-func TestPreferredReachabilityRef(t *testing.T) {
-	tests := []struct {
-		name           string
-		branch         string
-		remoteResolves map[string]bool
-		want           string
-	}{
-		{
-			name:           "prefers the remote-tracking ref when it resolves",
-			branch:         "main",
-			remoteResolves: map[string]bool{"refs/remotes/origin/main": true},
-			want:           "refs/remotes/origin/main",
-		},
-		{
-			name:           "falls back to the bare branch name when no remote-tracking ref exists",
-			branch:         "main",
-			remoteResolves: map[string]bool{},
-			want:           "main",
-		},
-		{
-			name:           "does not confuse a different branch's remote-tracking ref for this one",
-			branch:         "main",
-			remoteResolves: map[string]bool{"refs/remotes/origin/release": true},
-			want:           "main",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := preferredReachabilityRef(tc.branch, func(ref string) bool { return tc.remoteResolves[ref] })
-			if got != tc.want {
-				t.Fatalf("preferredReachabilityRef(%q, ...) = %q, want %q", tc.branch, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestCommitReachableOnEitherRef pins the union: the remote-tracking ref is
-// preferred, but a commit reachable only from the local branch still passes.
-func TestCommitReachableOnEitherRef(t *testing.T) {
-	tests := []struct {
-		name           string
-		remoteResolves map[string]bool
-		reachable      map[string]bool
-		want           bool
-	}{
-		{"remote resolves and contains the commit", map[string]bool{"refs/remotes/origin/main": true}, map[string]bool{"refs/remotes/origin/main": true}, true},
-		{"remote is stale, local branch contains the commit", map[string]bool{"refs/remotes/origin/main": true}, map[string]bool{"main": true}, true},
-		{"neither ref contains the commit", map[string]bool{"refs/remotes/origin/main": true}, map[string]bool{}, false},
-		{"no remote-tracking ref, local branch contains the commit", map[string]bool{}, map[string]bool{"main": true}, true},
-		{"no remote-tracking ref, local branch does not", map[string]bool{}, map[string]bool{}, false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			probes := map[string]int{}
-			got := commitReachableOnEitherRef("main",
-				func(ref string) bool { return tc.remoteResolves[ref] },
-				func(ref string) bool { probes[ref]++; return tc.reachable[ref] })
-			if got != tc.want {
-				t.Fatalf("commitReachableOnEitherRef = %v, want %v", got, tc.want)
-			}
-			if probes["main"] > 1 {
-				t.Fatalf("local ref probed %d times, want at most 1", probes["main"])
 			}
 		})
 	}
@@ -260,6 +180,28 @@ func TestWorkRecordCloseTargets(t *testing.T) {
 			}
 			if strings.Join(ids, ",") != strings.Join(tc.wantIDs, ",") {
 				t.Fatalf("ids = %v, want %v", ids, tc.wantIDs)
+			}
+		})
+	}
+}
+
+func TestCloseReasonCommitCandidates(t *testing.T) {
+	const commit = "abc1234"
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"close reason", []string{"close", "wr-1", "--reason", "Done at " + commit}, []string{commit}},
+		{"update notes", []string{"update", "wr-1", "--notes=Commit " + commit}, []string{commit}},
+		{"other flag consumes reason-looking value", []string{"update", "wr-1", "--description", "--notes", commit}, nil},
+		{"terminator stops flag parsing", []string{"close", "wr-1", "--", "--reason", commit}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := closeReasonCommitCandidates(tc.args, "")
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("closeReasonCommitCandidates = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -424,35 +366,84 @@ func TestEvaluateWorkRecordCloseGateAtomicShippedUpdate(t *testing.T) {
 	runGit(t, repoDir, "init", "--initial-branch=main")
 	runGit(t, repoDir, "config", "user.name", "Gas City Test")
 	runGit(t, repoDir, "config", "user.email", "gc-test@test.local")
-	artifactPath := filepath.Join(repoDir, "artifact.txt")
-	if err := os.WriteFile(artifactPath, []byte("integrated\n"), 0o644); err != nil {
-		t.Fatalf("write artifact: %v", err)
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repoDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
 	}
+
+	writeFile("artifact.txt", "base\n")
+	runGit(t, repoDir, "add", "artifact.txt")
+	runGit(t, repoDir, "commit", "-m", "test: add base artifact")
+	base := strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+	runGit(t, repoDir, "update-ref", "refs/remotes/origin/main", base)
+
+	runGit(t, repoDir, "switch", "-c", "feature")
+	writeFile("artifact.txt", "integrated\n")
 	runGit(t, repoDir, "add", "artifact.txt")
 	runGit(t, repoDir, "commit", "-m", "test: integrate artifact")
 	commit := strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
 
-	store := beads.NewMemStoreFrom(1, []beads.Bead{{
-		ID:     "wr-atomic-shipped",
-		Type:   "task",
-		Status: "in_progress",
-		Metadata: map[string]string{
-			beadmeta.WorkDirMetadataKey: repoDir,
+	store := beads.NewMemStoreFrom(1, []beads.Bead{
+		{
+			ID:     "wr-atomic-shipped",
+			Type:   "task",
+			Status: "in_progress",
+			Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey: repoDir,
+			},
 		},
-	}}, nil)
+		{
+			ID:     "wr-reason-only",
+			Type:   "task",
+			Status: "in_progress",
+			Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:     repoDir,
+				beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeNoOp,
+			},
+		},
+	}, nil)
 	args := []string{
 		"update", "wr-atomic-shipped",
 		"--set-metadata", beadmeta.WorkOutcomeMetadataKey + "=" + beadmeta.WorkOutcomeShipped,
 		"--set-metadata", beadmeta.WorkCommitMetadataKey + "=" + commit,
-		"--set-metadata", beadmeta.WorkBranchMetadataKey + "=main",
+		"--set-metadata", beadmeta.WorkBranchMetadataKey + "=feature",
 		"--status=closed",
+		"--notes", "Done. Commit: " + commit + ".",
 	}
-	var stderr strings.Builder
-	if block := evaluateWorkRecordCloseGate(args, store, nil, repoDir, true, &stderr); block {
-		t.Fatalf("valid atomic shipped close blocked; stderr=%s", stderr.String())
+	reasonArgs := []string{"close", "wr-reason-only", "--reason", "Done. Commit: " + commit + "."}
+
+	for _, closeArgs := range [][]string{args, reasonArgs} {
+		var stderr strings.Builder
+		if block := evaluateWorkRecordCloseGate(closeArgs, store, nil, repoDir, false, &stderr); block {
+			t.Fatalf("warn-only unpublished close blocked; stderr=%s", stderr.String())
+		}
+		if got := stderr.String(); !strings.Contains(got, "not published") {
+			t.Fatalf("unpublished close stderr = %q, want publication warning", got)
+		}
 	}
-	if got := stderr.String(); got != "" {
-		t.Fatalf("valid atomic shipped close warned: %q", got)
+
+	runGit(t, repoDir, "switch", "main")
+	writeFile("unrelated.txt", "newer main work\n")
+	runGit(t, repoDir, "add", "unrelated.txt")
+	runGit(t, repoDir, "commit", "-m", "test: add unrelated main work")
+	runGit(t, repoDir, "cherry-pick", "--no-commit", commit)
+	runGit(t, repoDir, "commit", "-m", "test: squash feature")
+	squash := strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+	if squash == commit {
+		t.Fatal("squash commit unexpectedly retained the feature commit SHA")
+	}
+	runGit(t, repoDir, "update-ref", "refs/remotes/origin/main", squash)
+
+	for _, closeArgs := range [][]string{args, reasonArgs} {
+		var stderr strings.Builder
+		if block := evaluateWorkRecordCloseGate(closeArgs, store, nil, repoDir, true, &stderr); block {
+			t.Fatalf("published squash-equivalent close blocked; stderr=%s", stderr.String())
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("published squash-equivalent close warned: %q", got)
+		}
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -303,6 +303,10 @@ gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
 from wedging the wrapper after printing command output. If you need
 auto-export behavior, invoke bd directly.
 
+When a work close names a commit, gc warns unless that commit is on a
+remote-tracking ref or all paths it changed have matching blobs on one. The
+blob check recognizes squash merges without comparing unrelated branch work.
+
 ```
 gc bd [bd-args...]
 ```


### PR DESCRIPTION
## Summary
- check shipped work commits against every remote-tracking ref before closing
- recognize squash merges by comparing blobs only for paths changed by the work commit
- inspect commit SHAs named in close reasons and notes when typed work-commit metadata is absent

## Verification
- `go test ./cmd/gc -run '^(TestValidateWorkRecordOnClose|TestCloseReasonCommitCandidates|TestEvaluateWorkRecordCloseGateAtomicShippedUpdate)$' -count=1`
- affected `cmd/gc` fast shard 2 of 6
- `make lint-changed`
- `go vet ./...`
- `go test ./internal/testpolicy/resourcecensus -count=1`
- pre-push fast gate: all six `cmd/gc` shards passed; unit-core hit `TestRunSetupCommandCancellationRunsRollbackTrap`, whose isolated rerun passed