### PR TITLE
fix(nudge): close only the store the frame opened, not the storage routes' shared engine

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1923,16 +1923,20 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 // main pool + a SHOW DATABASES init probe) every 2s. See
 // TestNudgePollHelpersSkipDoltOpenOnEmptyQueue.
 //
-// It closes exactly the handle it opened, and only if it opened one, preserving
-// the ownership contract the …WithStore variants model. "The handle it opened"
-// is not the same as "the store it holds": on a city that has relocated the
-// NUDGES class, the store is the storage routes' process-shared engine, which
-// this frame must not close. closeOwnedNudgeStore is the predicate.
+// It closes exactly the handle it opened, and only if it opened one,
+// preserving the closeBeadStoreHandle ownership contract the …WithStore
+// variants model. "The handle it opened" is not "the store it holds": once the
+// NUDGES class relocates, the store is the storage routes' process-shared
+// engine, which this frame holds but must never close (openOwnedNudgeBeadStore).
 type nudgeMaintenanceStore struct {
 	cityPath string
 	opened   bool
 	store    beads.NudgesStore
-	front    *nudgequeue.Store
+	// handle is what ensureOpen actually opened, which is not always
+	// store.Store: see openOwnedNudgeBeadStore. close releases this and
+	// nothing else.
+	handle beads.Store
+	front  *nudgequeue.Store
 }
 
 // frontForState returns the front-door handle to use for the maintenance passes
@@ -1954,7 +1958,7 @@ func (m *nudgeMaintenanceStore) frontForState(state *nudgeQueueState) *nudgequeu
 func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 	if !m.opened {
 		m.opened = true
-		m.store = openNudgeBeadStore(m.cityPath)
+		m.store, m.handle = openOwnedNudgeBeadStore(m.cityPath)
 		if m.store.Store != nil {
 			m.front = nudgeFrontDoor(m.store)
 		}
@@ -1962,14 +1966,14 @@ func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 	return m.store
 }
 
-// close releases the store this frame opened (if any). It never touches a
-// caller-passed store because this type only ever holds a store it opened — nor
-// the storage routes' shared engine, which it holds but does not own.
+// close releases the handle this frame opened (if any). It never touches a
+// caller-passed store because this type only ever opens its own, and never the
+// storage routes' shared engine, which it may hold but does not own.
 func (m *nudgeMaintenanceStore) close() error {
 	if !m.opened {
 		return nil
 	}
-	return closeOwnedNudgeStore(m.cityPath, m.store.Store)
+	return closeBeadStoreHandle(m.handle)
 }
 
 // nudgeQueueHasWork reports whether the queue holds any item a maintenance pass
@@ -2156,12 +2160,13 @@ func enqueueQueuedNudgeWithStore(cityPath string, store beads.NudgesStore, item 
 
 func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStore, item queuedNudge, clk clock.Clock) error {
 	ownStore := false
+	var opened beads.Store
 	if store.Store == nil {
-		store = openNudgeBeadStore(cityPath)
+		store, opened = openOwnedNudgeBeadStore(cityPath)
 		ownStore = true
 	}
 	if ownStore {
-		defer closeOwnedNudgeStore(cityPath, store.Store) //nolint:errcheck // best-effort
+		defer closeBeadStoreHandle(opened) //nolint:errcheck // best-effort
 	}
 	var front *nudgequeue.Store
 	if store.Store != nil {
@@ -2378,12 +2383,13 @@ func recordQueuedNudgeFailureDetailed(cityPath string, store beads.NudgesStore, 
 		return nil, nil
 	}
 	ownStore := false
+	var opened beads.Store
 	if store.Store == nil {
-		store = openNudgeBeadStore(cityPath)
+		store, opened = openOwnedNudgeBeadStore(cityPath)
 		ownStore = true
 	}
 	if ownStore {
-		defer closeOwnedNudgeStore(cityPath, store.Store) //nolint:errcheck // best-effort
+		defer closeBeadStoreHandle(opened) //nolint:errcheck // best-effort
 	}
 	var front *nudgequeue.Store
 	if store.Store != nil {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1923,9 +1923,11 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 // main pool + a SHOW DATABASES init probe) every 2s. See
 // TestNudgePollHelpersSkipDoltOpenOnEmptyQueue.
 //
-// It owns the handle it opens and closes exactly that handle (and only if it
-// opened one), preserving the closeBeadStoreHandle ownership contract the
-// …WithStore variants model.
+// It closes exactly the handle it opened, and only if it opened one, preserving
+// the ownership contract the …WithStore variants model. "The handle it opened"
+// is not the same as "the store it holds": on a city that has relocated the
+// NUDGES class, the store is the storage routes' process-shared engine, which
+// this frame must not close. closeOwnedNudgeStore is the predicate.
 type nudgeMaintenanceStore struct {
 	cityPath string
 	opened   bool
@@ -1961,12 +1963,13 @@ func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 }
 
 // close releases the store this frame opened (if any). It never touches a
-// caller-passed store because this type only ever holds a store it opened.
+// caller-passed store because this type only ever holds a store it opened — nor
+// the storage routes' shared engine, which it holds but does not own.
 func (m *nudgeMaintenanceStore) close() error {
 	if !m.opened {
 		return nil
 	}
-	return closeBeadStoreHandle(m.store.Store)
+	return closeOwnedNudgeStore(m.cityPath, m.store.Store)
 }
 
 // nudgeQueueHasWork reports whether the queue holds any item a maintenance pass
@@ -2158,7 +2161,7 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 		ownStore = true
 	}
 	if ownStore {
-		defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
+		defer closeOwnedNudgeStore(cityPath, store.Store) //nolint:errcheck // best-effort
 	}
 	var front *nudgequeue.Store
 	if store.Store != nil {
@@ -2380,7 +2383,7 @@ func recordQueuedNudgeFailureDetailed(cityPath string, store beads.NudgesStore, 
 		ownStore = true
 	}
 	if ownStore {
-		defer closeBeadStoreHandle(store.Store) //nolint:errcheck // best-effort
+		defer closeOwnedNudgeStore(cityPath, store.Store) //nolint:errcheck // best-effort
 	}
 	var front *nudgequeue.Store
 	if store.Store != nil {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4945,21 +4945,28 @@ func (s *countingNudgeStore) CloseStore() error {
 	return nil
 }
 
-// installCountingNudgeStoreSeam swaps openNudgeBeadStore for a fake that hands
-// out a fresh countingNudgeStore over a single shared MemStore on every call
-// (mirroring the deployed binary, where each per-tick open resolves to the same
-// backing native store). It returns pointers to the open and close counters and
-// restores the original seam via t.Cleanup. Tests using it must stay serial.
+// installCountingNudgeStoreSeam swaps openOwnedNudgeBeadStore for a fake that
+// hands out a fresh countingNudgeStore over a single shared MemStore on every
+// call (mirroring the deployed binary, where each per-tick open resolves to the
+// same backing native store). It returns pointers to the open and close counters
+// and restores the original seam via t.Cleanup. Tests using it must stay serial.
+//
+// It replaces the OWNING seam, not openNudgeBeadStore, because that is the one
+// the closing frames call and openNudgeBeadStore delegates to it — so both forms
+// move together and the counters cannot miss an open. The fake returns the same
+// store as both the class store and the opened handle, which is the unrelocated
+// shape: a frame that closes the handle closes the store the counter watches.
 func installCountingNudgeStoreSeam(t *testing.T) (opens, closes *int) {
 	t.Helper()
 	backing := beads.NewMemStore()
 	var openCount, closeCount int
-	prev := openNudgeBeadStore
-	openNudgeBeadStore = func(string) beads.NudgesStore {
+	prev := openOwnedNudgeBeadStore
+	openOwnedNudgeBeadStore = func(string) (beads.NudgesStore, beads.Store) {
 		openCount++
-		return beads.NudgesStore{Store: &countingNudgeStore{MemStore: backing, closes: &closeCount}}
+		store := &countingNudgeStore{MemStore: backing, closes: &closeCount}
+		return beads.NudgesStore{Store: store}, store
 	}
-	t.Cleanup(func() { openNudgeBeadStore = prev })
+	t.Cleanup(func() { openOwnedNudgeBeadStore = prev })
 	return &openCount, &closeCount
 }
 

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
@@ -41,11 +42,38 @@ var openNudgeBeadStore = func(cityPath string) beads.NudgesStore {
 // use this form and print the reason; the seam above stays for the poll/drain
 // helpers whose contract is already "a nil store means do nothing".
 func openNudgeBeadStoreErr(cityPath string) (beads.NudgesStore, error) {
+	routes := cliStorageRoutes(cityPath)
+	if relocated, ok := routes.storeFor(coordclass.ClassNudges); ok {
+		// The routes own this handle for the life of the process. Opening a work
+		// store here would only be discarded by resolveNudgesStore below, and it
+		// is what makes the returned store un-closable by the caller: see
+		// closeOwnedNudgeStore.
+		return beads.NudgesStore{Store: relocated}, nil
+	}
 	store, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
 		return beads.NudgesStore{}, fmt.Errorf("opening the city store at %q: %w", cityPath, err)
 	}
-	return beads.NudgesStore{Store: resolveNudgesStore(cliStorageRoutes(cityPath), store, nil, cityPath, nil)}, nil
+	return beads.NudgesStore{Store: resolveNudgesStore(routes, store, nil, cityPath, nil)}, nil
+}
+
+// closeOwnedNudgeStore closes a nudges-class handle only when the caller opened
+// it, and is the close half of every "own the store I opened" nudge frame.
+//
+// A frame that opens its own store cannot tell from the value alone whether it
+// holds a handle of its own: when the NUDGES class is relocated onto a storage
+// binding, openNudgeBeadStore hands back the storage routes' process-shared
+// engine, and closeCLIStorageRoutes (main.go, at the end of the invocation) is
+// the only thing entitled to close that. Closing it from a per-tick frame does
+// not detach the routes' memo, so the memo goes on serving the engine the frame
+// just closed and every later class read in the process — nudge delivery, and
+// the controller's own socket handlers — fails with ErrStoreClosed until the
+// process exits.
+func closeOwnedNudgeStore(cityPath string, store beads.Store) error {
+	if _, relocated := cliStorageRoutes(cityPath).storeFor(coordclass.ClassNudges); relocated {
+		return nil
+	}
+	return closeBeadStoreHandle(store)
 }
 
 // nudgeFrontDoor wraps a strongly-typed nudges store as the nudge object's

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
@@ -27,9 +26,41 @@ type nudgeReference = nudgequeue.Reference
 // strongly-typed beads.NudgesStore so the nudges class is statically visible to
 // every leaf nudge-bead helper; the wrapper carries the same underlying store
 // value (identity to the work store until the nudges class relocates).
+//
+// It discards the opened handle, so it is the form for callers that only read.
+// A frame that will CLOSE what it opened must use openOwnedNudgeBeadStore: once
+// the nudges class relocates, the store this returns is not the handle the call
+// opened, and closing it is the bug openOwnedNudgeBeadStore exists to prevent.
 var openNudgeBeadStore = func(cityPath string) beads.NudgesStore {
-	store, _ := openNudgeBeadStoreErr(cityPath)
+	store, _ := openOwnedNudgeBeadStore(cityPath)
 	return store
+}
+
+// openOwnedNudgeBeadStore is the owning-frame form of openNudgeBeadStore: it
+// returns the nudges-class store to use AND the handle this call opened, which
+// is the only handle the caller may close.
+//
+// The two differ exactly when the NUDGES class is relocated onto a storage
+// binding. resolveNudgesStore then discards the work store this call opened and
+// returns the storage routes' process-shared engine, which the routes own and
+// closeCLIStorageRoutes releases when the invocation ends. A frame that closes
+// "the store it holds" therefore closes the routes' engine without detaching
+// their memo, and the memo goes on serving a closed engine: every later class
+// read in the process — nudge delivery itself, and the controller's own socket
+// handlers — then fails with ErrStoreClosed until the process exits.
+//
+// Closing by "the handle I opened" is also what keeps the ownership answer in
+// one place. The alternative, asking the routes a second time whether this class
+// is relocated, is the re-derivation the residency contract reserves to the
+// resolver, and is how this bug class reproduces
+// (scripts/residency-boundary-patterns.txt, rule b).
+//
+// It is a seam for the same reason openNudgeBeadStore is, and is the one the
+// counting fake replaces: openNudgeBeadStore delegates here, so a test that
+// substitutes this var moves both forms at once and the two can never disagree.
+var openOwnedNudgeBeadStore = func(cityPath string) (beads.NudgesStore, beads.Store) {
+	store, opened, _ := openNudgeBeadStoreOwned(cityPath)
+	return store, opened
 }
 
 // openNudgeBeadStoreErr is openNudgeBeadStore with the open failure kept instead
@@ -42,38 +73,19 @@ var openNudgeBeadStore = func(cityPath string) beads.NudgesStore {
 // use this form and print the reason; the seam above stays for the poll/drain
 // helpers whose contract is already "a nil store means do nothing".
 func openNudgeBeadStoreErr(cityPath string) (beads.NudgesStore, error) {
-	routes := cliStorageRoutes(cityPath)
-	if relocated, ok := routes.storeFor(coordclass.ClassNudges); ok {
-		// The routes own this handle for the life of the process. Opening a work
-		// store here would only be discarded by resolveNudgesStore below, and it
-		// is what makes the returned store un-closable by the caller: see
-		// closeOwnedNudgeStore.
-		return beads.NudgesStore{Store: relocated}, nil
-	}
-	store, err := openStoreAtForCity(cityPath, cityPath)
-	if err != nil {
-		return beads.NudgesStore{}, fmt.Errorf("opening the city store at %q: %w", cityPath, err)
-	}
-	return beads.NudgesStore{Store: resolveNudgesStore(routes, store, nil, cityPath, nil)}, nil
+	store, _, err := openNudgeBeadStoreOwned(cityPath)
+	return store, err
 }
 
-// closeOwnedNudgeStore closes a nudges-class handle only when the caller opened
-// it, and is the close half of every "own the store I opened" nudge frame.
-//
-// A frame that opens its own store cannot tell from the value alone whether it
-// holds a handle of its own: when the NUDGES class is relocated onto a storage
-// binding, openNudgeBeadStore hands back the storage routes' process-shared
-// engine, and closeCLIStorageRoutes (main.go, at the end of the invocation) is
-// the only thing entitled to close that. Closing it from a per-tick frame does
-// not detach the routes' memo, so the memo goes on serving the engine the frame
-// just closed and every later class read in the process — nudge delivery, and
-// the controller's own socket handlers — fails with ErrStoreClosed until the
-// process exits.
-func closeOwnedNudgeStore(cityPath string, store beads.Store) error {
-	if _, relocated := cliStorageRoutes(cityPath).storeFor(coordclass.ClassNudges); relocated {
-		return nil
+// openNudgeBeadStoreOwned is the one place the nudges-class store is opened, so
+// the class store and the handle the call opened are decided together. Every
+// form above is a projection of it.
+func openNudgeBeadStoreOwned(cityPath string) (beads.NudgesStore, beads.Store, error) {
+	store, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		return beads.NudgesStore{}, nil, fmt.Errorf("opening the city store at %q: %w", cityPath, err)
 	}
-	return closeBeadStoreHandle(store)
+	return beads.NudgesStore{Store: resolveNudgesStore(cliStorageRoutes(cityPath), store, nil, cityPath, nil)}, store, nil
 }
 
 // nudgeFrontDoor wraps a strongly-typed nudges store as the nudge object's

--- a/cmd/gc/nudge_store_ownership_test.go
+++ b/cmd/gc/nudge_store_ownership_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestNudgeMaintenanceFrameLeavesTheStorageRoutesServingALiveStore pins the
+// ownership rule the nudge frames depend on: a per-tick frame closes only a
+// handle it opened.
+//
+// On a city that has relocated the NUDGES class onto a storage binding, the
+// store openNudgeBeadStore returns is the storage routes' process-shared
+// engine. Closing it from the frame did not detach the routes' memo, so the
+// memo went on serving a closed engine and every later class read in the same
+// process failed with ErrStoreClosed — in a long-lived process (the controller,
+// a poll sidecar) that reached nudge delivery itself and the session-circuit
+// reset socket handler, and it lasted until the process exited.
+func TestNudgeMaintenanceFrameLeavesTheStorageRoutesServingALiveStore(t *testing.T) {
+	cityPath, cfg := migratedOneShotCLICity(t)
+	captureCLIStorageStderr(t)
+
+	work := beads.NewMemStore()
+	before := cliSessionStore(work, cfg, cityPath)
+	if before == beads.Store(work) {
+		t.Fatalf("fixture is not relocated: the session route handed back the work store")
+	}
+	if _, err := before.Get("gcg-000000"); errors.Is(err, beads.ErrStoreClosed) {
+		t.Fatalf("the routes served a closed store before any maintenance frame ran: %v", err)
+	}
+
+	// The frame a long-lived process runs on every nudge tick that has work.
+	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	maint.ensureOpen()
+	if err := maint.close(); err != nil {
+		t.Fatalf("closing the nudge maintenance frame: %v", err)
+	}
+
+	after := cliSessionStore(work, cfg, cityPath)
+	if _, err := after.Get("gcg-000000"); errors.Is(err, beads.ErrStoreClosed) {
+		t.Fatalf("the nudge maintenance frame closed the storage routes' shared engine; "+
+			"the routes still serve it and every later class read fails: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #5979.

## What was wrong

On a city that has relocated the NUDGES class onto a storage binding,
`openNudgeBeadStoreErr` (`cmd/gc/nudge_beads.go`) opens a work store and then hands it to
`resolveNudgesStore`, which **discards** it and returns the storage routes' process-shared
binding engine. The nudge frames then close what they hold, believing they own it:

```go
// close releases the store this frame opened (if any). It never touches a
// caller-passed store because this type only ever holds a store it opened.
func (m *nudgeMaintenanceStore) close() error {
	if !m.opened {
		return nil
	}
	return closeBeadStoreHandle(m.store.Store)   // <- the routes' engine, on a relocated class
}
```

Closing it does not detach the routes memo, so the memo goes on serving a **closed** store.
In a one-shot CLI invocation that is invisible. In the controller it is permanent: every
later coordination-class read in the process fails with `sqlite store: bead store closed` —
nudge delivery, and the `session-circuit-reset` socket handler, which is how it surfaced
for us (see #5979, and #5973 for the reset path that then throws the whole operation away).

It needs a non-empty nudge queue, since `nudgeQueueHasWork` gates `ensureOpen` — which is
why it lands hours into a controller run rather than at boot, and why only a process
restart clears it.

## The change

- `closeOwnedNudgeStore(cityPath, store)` — the close half of "own the store I opened".
  It declines to close a handle the routes own, because a frame cannot tell that from the
  value alone. Used at the three sites that close a nudges-class store they believe they
  opened: `nudgeMaintenanceStore.close`, and the `ownStore` arms of
  `enqueueQueuedNudgeWithStoreAndClock` and `recordQueuedNudgeFailureDetailed`.
- `openNudgeBeadStoreErr` skips the work-store open entirely when the class is relocated,
  since `resolveNudgesStore` would only discard it. That also stops a leaked work-store
  handle per call on relocated cities.
- The two comments that asserted the false invariant now say what is actually true.

`cmd/gc/cmd_order.go` is deliberately untouched: it closes the raw work store it opened,
with no class resolver in between, so it already owns what it closes.

## Evidence

New test `TestNudgeMaintenanceFrameLeavesTheStorageRoutesServingALiveStore`
(`cmd/gc/nudge_store_ownership_test.go`), on the repo's own `migratedOneShotCLICity`
fixture: read the sessions class through the routes (healthy), run one nudge maintenance
frame, read again.

Without the fix, on `f07cfb682`:

```
--- FAIL: TestNudgeMaintenanceFrameLeavesTheStorageRoutesServingALiveStore (0.15s)
    nudge_store_ownership_test.go:43: the nudge maintenance frame closed the storage
    routes' shared engine; the routes still serve it and every later class read fails:
    sqlite store: bead store closed
```

With it: PASS, and the whole `./cmd/gc` package passes (`go test ./cmd/gc -count=1`, 308s).
`make build` and `make vet` are clean. `make lint` reports the same 160 pre-existing issues
as the base and none in the changed files.

The existing `TestNudgePollHelpersSkipDoltOpenOnEmptyQueue` still pins the owned-handle
accounting, so the "close what you opened" case has not gone untested.

## Note on scope

This closes the instance. The general shape — `resolveClassStore` returning either a
borrowed or an owned handle with nothing in the type to tell them apart — is still there,
and `residency_topology.go:96-105` already warns that the one-shot funnel is the wrong side
of the controller boundary while ~21 direct `cliStorageRoutes` call sites remain on it. If
you want the resolver contract tightened (an explicit ownership token or a no-op closer
returned alongside the store), I'm happy to follow up with that as a separate change.
