### PR TITLE
fix(orders): dispatch due condition-triggered orders outside the per-tick rotation budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A condition-triggered order whose check passes now dispatches on the tick
+  that observes it, instead of queueing behind the per-tick dispatch budget.**
+  `orders.max_dispatches_per_tick` (default 4) capped every trigger type and
+  advanced a rotation cursor only when it spent a slot, so on a city with ~40
+  orders and a tick period longer than every sweep's interval the cooldown
+  sweeps were due at every tick and spent the whole budget before the rotation
+  reached anything else — each order got a turn roughly every ten ticks. A
+  condition order is a wake demand rather than a request for a turn: its check
+  reports that work is pending right now, and it is true only for as long as
+  that work waits. On maintainer-city the merge-queue order went 11 h without a
+  dispatch while merge beads sat ready, with no gate error, no suppression
+  event and nothing in the journal to show for it. Due condition orders now
+  fire outside the budget (still single-flighted by the open-tracking and
+  open-work gates, and still bounded by their own check), the budget and its
+  rotation are unchanged for cooldown, cron and event orders, and a tick that
+  spends its budget logs one line naming the orders it did not reach.
+
 - **A control bead served by a relocated class binding is routed to the
   dispatcher its own `gc.root_store_ref` names.** On a split city every rig's
   control beads live in one class binding. The reconciler dropped rig-rooted

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -745,179 +745,287 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 	m.prefetchConditionResults(candidates, now)
 
-	// Phase 2: the fire loop, in the same rotation order, over the same
-	// per-order state phase 1 resolved.
+	// Phase 2: the fire loop, in two passes over the same rotation order.
+	//
+	// A due condition order is not a sweep asking for its turn. Its check has
+	// just reported that work is pending right now, which is the order system's
+	// equivalent of a wake demand, and it already single-flights through the
+	// open-tracking and open-work gates below and self-limits by its own check.
+	// The budget exists to spread CLOCK-driven orders (cooldown/cron/event)
+	// across ticks and to avoid a cold-start burst; rationing a due condition
+	// order against sweeps defeats the trigger's whole purpose. On a city with
+	// ~40 orders and a tick period well past every sweep's interval, the sweeps
+	// are due at every tick and saturate the budget permanently, so a condition
+	// order whose condition is true for a window shorter than a full rotation of
+	// the cursor fires only by luck — maintainer-city's merge-queue order went
+	// 11h without a dispatch that way, with no gate error and no suppression
+	// event to show for it (ga-unaz7). Raising max_dispatches_per_tick only
+	// moves that cliff.
+	//
+	// Both passes run the identical per-candidate body; only the budget differs.
+	var unbudgeted, budgeted []*orderDispatchCandidate
 	for _, cand := range candidates {
-		idx := cand.idx
-		a := cand.order
-		target := cand.target
-		store := cand.store
-		storesForGate, storeKeysForGate := cand.gateStores, cand.gateStoreKeys
-		scoped := cand.scoped
-
-		baseLastRunFn := trackingIndex.lastRunFunc(storesForGate, storeKeysForGate, orders.LastRunAcross(orderFrontDoorsForStores(storesForGate)))
-		var lastRunErr error
-		var lastRunFromCache bool
-		lastRunFn := func(orderName string) (time.Time, error) {
-			last, fromCache, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
-			if err != nil {
-				lastRunErr = err
-			}
-			if fromCache {
-				lastRunFromCache = true
-			}
-			return last, err
-		}
-		cursorFn := orders.CursorAcross(orderFrontDoorsForStores(storesForGate))
-		if a.Trigger == "event" {
-			cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
-			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
-				continue
-			}
-			cursorFn = func(string) uint64 {
-				return cursor
-			}
-		}
-		triggerOpts := cand.triggerOpts
-		if err := cand.triggerErr; err != nil {
-			redacted := redactOrderEnvError(err, os.Environ())
-			msg := fmt.Sprintf("building trigger env: %s", redacted)
-			logDispatchError(m.stderr, "gc: order dispatch: building trigger env for %s: %s", a.ScopedName(), redacted)
-			// Leave this open so the existing open-work gate suppresses repeat
-			// ticks until the normal stale tracking sweep gives the order another try.
-			trackingBead, createErr := m.orderFrontDoorFor(store).CreateRun(scoped, orders.RunOpts{Outcome: orders.RunOutcomeTriggerEnvFailed})
-			if createErr != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: creating trigger env failure tracking bead for %s: %v", scoped, createErr)
-			} else {
-				m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
-			}
-			m.rec.Record(events.Event{
-				Type:    events.OrderFailed,
-				Actor:   "controller",
-				Subject: a.ScopedName(),
-				Message: msg,
-			})
-			if spendDispatchBudget(idx) {
-				return
-			}
-			continue
-		}
-		// A condition order's verdict was already computed by the parallel pass;
-		// re-running it here would fork the check a second time.
-		var result orders.TriggerResult
-		if cand.conditionResult != nil {
-			result = *cand.conditionResult
+		if dueConditionCandidate(cand) {
+			unbudgeted = append(unbudgeted, cand)
 		} else {
-			result = orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
+			budgeted = append(budgeted, cand)
 		}
-		if lastRunErr != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
+	}
+	for _, cand := range unbudgeted {
+		m.fireCandidate(ctx, cand, trackingIndex, &inFlight, cityPath, now)
+	}
+	for i, cand := range budgeted {
+		if !m.fireCandidate(ctx, cand, trackingIndex, &inFlight, cityPath, now) {
 			continue
 		}
-		if !result.Due {
-			// The streak counts consecutive refusals of a DUE order, so an
-			// undue tick ends the episode. Without this a condition order that
-			// wedges and then goes false freezes its streak forever: the next
-			// refusal — possibly an unrelated incident weeks later — alerts on
-			// its first tick, carrying a first_suppressed and a
-			// suppressed_for_ms that span both episodes.
-			//
-			// Error and suspension exits deliberately do NOT clear. Those ticks
-			// never consulted the gate, so they are not evidence it opened, and
-			// resetting on them would let a flapping store hide a permanently
-			// shut gate.
-			m.clearOpenWorkSuppression(scoped)
-			// A condition check killed by its deadline never proves its
-			// condition, so the order silently never fires. Surface that
-			// distinctly (normal "condition false" is not logged) so a check
-			// outgrowing its budget is diagnosable instead of invisible
-			// (ga-ocypq2). Raise the order's check_timeout to fix.
-			if a.Trigger == "condition" && strings.Contains(result.Reason, orders.ConditionCheckTimedOutMarker) {
-				logDispatchError(m.stderr, "gc: order dispatch: %s %s — raise check_timeout if the check needs a slow store read", a.ScopedName(), result.Reason)
-			}
-			continue
-		}
-		if lastRunFromCache && orderTriggerUsesLastRun(a) {
-			refreshedLastRun, err := baseLastRunFn(a.ScopedName())
-			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: refreshing last run for %s: %v", a.ScopedName(), err)
-				continue
-			}
-			if refreshedLastRun.After(result.LastRun) {
-				m.rememberLastRun(a.ScopedName(), storeKeysForGate, refreshedLastRun)
-				refreshedLastRunFn := func(string) (time.Time, error) {
-					return refreshedLastRun, nil
-				}
-				result = orders.CheckTriggerWithOptions(a, now, refreshedLastRunFn, m.ep, cursorFn, triggerOpts)
-				if !result.Due {
-					m.clearOpenWorkSuppression(scoped)
-					continue
-				}
-			}
-		}
-
-		// Skip dispatch if previous work hasn't been processed yet.
-		// Bound the wisp-aware open-work gate (#2921) with our per-order
-		// timeout so a slow store can't starve later orders. NoWorkGate orders
-		// skip this gate too (see the first-gate skip above).
-		if !a.NoWorkGate {
-			hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
-				return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.wispRootHasOpenWork, m.hasOpenWorkStrict)
-			})
-			if err != nil {
-				if m.gateFailClosed(ctx, a, scoped, err) {
-					if errors.Is(err, errGateTimeout) {
-						// Anchor to actual wall clock after the gate consumed orderGateTimeout;
-						// using the tick-start 'now' would set a deadline that has already passed.
-						m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
-					}
-					continue
-				}
-			}
-			if hasOpenWork {
-				// This skip is the one that can last forever: a wisp subtree
-				// stalled in a store the recovery sweep does not search holds the
-				// gate shut on every tick with nothing emitted (see
-				// sweepStaleOrderTrackingAcrossStoresLimitMode). Counting the
-				// streak and reporting it past a threshold makes that visible
-				// without changing what the gate decides (ga-a6zy9).
-				if payload, alert := m.noteOpenWorkSuppressed(scoped, now); alert {
-					m.rec.Record(events.Event{
-						Type:    events.OrderSuppressed,
-						Actor:   "controller",
-						Subject: scoped,
-						Message: fmt.Sprintf("open-work gate has suppressed this order for %d consecutive dispatch checks since %s",
-							payload.Consecutive, payload.FirstSuppressed),
-						Payload: events.OrderSuppressedPayloadJSON(payload),
-					})
-				}
-				continue
-			}
-			m.clearOpenWorkSuppression(scoped)
-		}
-
-		// Create the tracking bead (which suppresses re-fire on the next tick)
-		// and launch the shared dispatch core. The webhook receiver fires the
-		// same launchResolvedDispatch → dispatchOne path through the exported
-		// seam, so a tick dispatch and a webhook dispatch run the identical core,
-		// not two implementations. inFlight (this tick's WaitGroup) is reserved
-		// before the launch and released via onDone; on a create failure nothing
-		// launched, so it is released immediately to balance the reservation.
-		//
-		// Auto-triggered orders carry no args channel: vars/execEnv are nil.
-		inFlight.Add(1)
-		trackingBead, err := m.launchResolvedDispatch(ctx, store, target, a, cityPath, nil, nil, inFlight.Done)
-		if err != nil {
-			inFlight.Done()
-			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
-			continue
-		}
-		m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
-		if spendDispatchBudget(idx) {
+		if spendDispatchBudget(cand.idx) {
+			m.logDeferredCandidates(budgeted[i+1:])
 			return
 		}
 	}
+}
+
+// dueConditionCandidate reports whether a candidate is a condition-triggered
+// order whose check has already passed on this tick — the one class of order
+// the per-tick dispatch budget does not ration.
+//
+// Branching on Trigger alone covers both spellings of the trigger: the scanner
+// folds the deprecated `gate = "condition"` form into Order.Trigger
+// (orders.orderDecode.normalized), and so does the override layer
+// (config.OrderOverride.normalizeLegacyAliases), so no order reaches the
+// dispatcher still carrying a Gate.
+//
+// The verdict comes from prefetchConditionResults, which evaluates exactly the
+// condition candidates whose trigger env built cleanly. A nil result is a
+// candidate whose verdict the fire body has yet to reach on its own — an
+// unevaluated check, or a trigger-env failure whose tracking bead is an error
+// record rather than a dispatch — and it stays on the budgeted path, so a city
+// full of misconfigured condition orders cannot write a failure bead per order
+// per tick.
+func dueConditionCandidate(cand *orderDispatchCandidate) bool {
+	return cand.order.Trigger == "condition" && cand.conditionResult != nil && cand.conditionResult.Due
+}
+
+// maxDeferredOrderNames bounds the deferral line below. A city with forty
+// orders and a spent budget defers most of them, and the question the line
+// answers — "is the budget the reason nothing fired?" — is answered by the
+// count plus a sample, not by forty names.
+const maxDeferredOrderNames = 8
+
+// logDeferredCandidates emits the one line a tick that spent its budget owes an
+// operator. Budget starvation used to be invisible: no gate error, no
+// suppression event, nothing in the journal — the tick simply stopped part-way
+// through the rotation and the next one started over from the cursor.
+//
+// deferred is the candidates the rotation never reached, which is not the same
+// as a due-list: settling due-ness for the tail costs the per-order last-run and
+// event-cursor reads the budget exists to avoid (#3201, ga-l7jdg), so the line
+// reports what the tick already knows for free.
+func (m *memoryOrderDispatcher) logDeferredCandidates(deferred []*orderDispatchCandidate) {
+	if len(deferred) == 0 {
+		return
+	}
+	names := make([]string, 0, maxDeferredOrderNames+1)
+	for _, cand := range deferred {
+		if len(names) == maxDeferredOrderNames {
+			names = append(names, fmt.Sprintf("(+%d more)", len(deferred)-maxDeferredOrderNames))
+			break
+		}
+		names = append(names, cand.scoped)
+	}
+	logDispatchError(m.stderr, "gc: order dispatch: per-tick budget %d spent; %d order(s) deferred to a later tick: %s — raise orders.max_dispatches_per_tick if this repeats every tick",
+		m.maxDispatchesPerTick, len(deferred), strings.Join(names, ", "))
+}
+
+// openWorkGateShut reports whether the wisp-aware open-work gate (#2921) is
+// holding this order back because its previous dispatch's work is still moving.
+//
+// The gate read is bounded by our per-order timeout so a slow store cannot
+// starve the orders behind it, and a timeout that fails closed also arms the
+// per-order backoff. NoWorkGate orders skip the gate entirely (see the matching
+// open-tracking skip in dispatch's phase 1).
+func (m *memoryOrderDispatcher) openWorkGateShut(ctx context.Context, cand *orderDispatchCandidate, trackingIndex *orderDispatchTrackingIndex, now time.Time) bool {
+	a := cand.order
+	scoped := cand.scoped
+	if a.NoWorkGate {
+		return false
+	}
+	hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+		return trackingIndex.hasOpenWork(cand.gateStores, cand.gateStoreKeys, scoped, m.wispRootHasOpenWork, m.hasOpenWorkStrict)
+	})
+	if err != nil {
+		if m.gateFailClosed(ctx, a, scoped, err) {
+			if errors.Is(err, errGateTimeout) {
+				// Anchor to actual wall clock after the gate consumed orderGateTimeout;
+				// using the tick-start 'now' would set a deadline that has already passed.
+				m.setGateBackoff(scoped, time.Now().Add(orderGateBackoffDuration))
+			}
+			return true
+		}
+	}
+	if hasOpenWork {
+		// This skip is the one that can last forever: a wisp subtree
+		// stalled in a store the recovery sweep does not search holds the
+		// gate shut on every tick with nothing emitted (see
+		// sweepStaleOrderTrackingAcrossStoresLimitMode). Counting the
+		// streak and reporting it past a threshold makes that visible
+		// without changing what the gate decides (ga-a6zy9).
+		if payload, alert := m.noteOpenWorkSuppressed(scoped, now); alert {
+			m.rec.Record(events.Event{
+				Type:    events.OrderSuppressed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: fmt.Sprintf("open-work gate has suppressed this order for %d consecutive dispatch checks since %s",
+					payload.Consecutive, payload.FirstSuppressed),
+				Payload: events.OrderSuppressedPayloadJSON(payload),
+			})
+		}
+		return true
+	}
+	m.clearOpenWorkSuppression(scoped)
+	return false
+}
+
+// fireCandidate evaluates one candidate's trigger, runs the gates that bound it
+// and launches its dispatch.
+//
+// It reports whether the candidate consumed a dispatch: true when it wrote
+// order-run evidence, either by launching the dispatch or by recording the
+// trigger-env failure that stands in for one. Every other exit — undue, gated,
+// suppressed, store error — reports false and costs the caller nothing.
+//
+// The budget is deliberately not this function's business. Both fire passes call
+// it, so the gate logic exists once and the only difference between an
+// unbudgeted condition order and a budgeted sweep is what the caller does with
+// the answer.
+func (m *memoryOrderDispatcher) fireCandidate(ctx context.Context, cand *orderDispatchCandidate, trackingIndex *orderDispatchTrackingIndex, inFlight *sync.WaitGroup, cityPath string, now time.Time) bool {
+	a := cand.order
+	target := cand.target
+	store := cand.store
+	storesForGate, storeKeysForGate := cand.gateStores, cand.gateStoreKeys
+	scoped := cand.scoped
+
+	baseLastRunFn := trackingIndex.lastRunFunc(storesForGate, storeKeysForGate, orders.LastRunAcross(orderFrontDoorsForStores(storesForGate)))
+	var lastRunErr error
+	var lastRunFromCache bool
+	lastRunFn := func(orderName string) (time.Time, error) {
+		last, fromCache, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
+		if err != nil {
+			lastRunErr = err
+		}
+		if fromCache {
+			lastRunFromCache = true
+		}
+		return last, err
+	}
+	cursorFn := orders.CursorAcross(orderFrontDoorsForStores(storesForGate))
+	if a.Trigger == "event" {
+		cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
+		if err != nil {
+			logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
+			return false
+		}
+		cursorFn = func(string) uint64 {
+			return cursor
+		}
+	}
+	triggerOpts := cand.triggerOpts
+	if err := cand.triggerErr; err != nil {
+		redacted := redactOrderEnvError(err, os.Environ())
+		msg := fmt.Sprintf("building trigger env: %s", redacted)
+		logDispatchError(m.stderr, "gc: order dispatch: building trigger env for %s: %s", a.ScopedName(), redacted)
+		// Leave this open so the existing open-work gate suppresses repeat
+		// ticks until the normal stale tracking sweep gives the order another try.
+		trackingBead, createErr := m.orderFrontDoorFor(store).CreateRun(scoped, orders.RunOpts{Outcome: orders.RunOutcomeTriggerEnvFailed})
+		if createErr != nil {
+			logDispatchError(m.stderr, "gc: order dispatch: creating trigger env failure tracking bead for %s: %v", scoped, createErr)
+		} else {
+			m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
+		}
+		m.rec.Record(events.Event{
+			Type:    events.OrderFailed,
+			Actor:   "controller",
+			Subject: a.ScopedName(),
+			Message: msg,
+		})
+		return true
+	}
+	// A condition order's verdict was already computed by the parallel pass;
+	// re-running it here would fork the check a second time.
+	var result orders.TriggerResult
+	if cand.conditionResult != nil {
+		result = *cand.conditionResult
+	} else {
+		result = orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
+	}
+	if lastRunErr != nil {
+		logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
+		return false
+	}
+	if !result.Due {
+		// The streak counts consecutive refusals of a DUE order, so an
+		// undue tick ends the episode. Without this a condition order that
+		// wedges and then goes false freezes its streak forever: the next
+		// refusal — possibly an unrelated incident weeks later — alerts on
+		// its first tick, carrying a first_suppressed and a
+		// suppressed_for_ms that span both episodes.
+		//
+		// Error and suspension exits deliberately do NOT clear. Those ticks
+		// never consulted the gate, so they are not evidence it opened, and
+		// resetting on them would let a flapping store hide a permanently
+		// shut gate.
+		m.clearOpenWorkSuppression(scoped)
+		// A condition check killed by its deadline never proves its
+		// condition, so the order silently never fires. Surface that
+		// distinctly (normal "condition false" is not logged) so a check
+		// outgrowing its budget is diagnosable instead of invisible
+		// (ga-ocypq2). Raise the order's check_timeout to fix.
+		if a.Trigger == "condition" && strings.Contains(result.Reason, orders.ConditionCheckTimedOutMarker) {
+			logDispatchError(m.stderr, "gc: order dispatch: %s %s — raise check_timeout if the check needs a slow store read", a.ScopedName(), result.Reason)
+		}
+		return false
+	}
+	if lastRunFromCache && orderTriggerUsesLastRun(a) {
+		refreshedLastRun, err := baseLastRunFn(a.ScopedName())
+		if err != nil {
+			logDispatchError(m.stderr, "gc: order dispatch: refreshing last run for %s: %v", a.ScopedName(), err)
+			return false
+		}
+		if refreshedLastRun.After(result.LastRun) {
+			m.rememberLastRun(a.ScopedName(), storeKeysForGate, refreshedLastRun)
+			refreshedLastRunFn := func(string) (time.Time, error) {
+				return refreshedLastRun, nil
+			}
+			result = orders.CheckTriggerWithOptions(a, now, refreshedLastRunFn, m.ep, cursorFn, triggerOpts)
+			if !result.Due {
+				m.clearOpenWorkSuppression(scoped)
+				return false
+			}
+		}
+	}
+
+	if m.openWorkGateShut(ctx, cand, trackingIndex, now) {
+		return false
+	}
+
+	// Create the tracking bead (which suppresses re-fire on the next tick)
+	// and launch the shared dispatch core. The webhook receiver fires the
+	// same launchResolvedDispatch → dispatchOne path through the exported
+	// seam, so a tick dispatch and a webhook dispatch run the identical core,
+	// not two implementations. inFlight (this tick's WaitGroup) is reserved
+	// before the launch and released via onDone; on a create failure nothing
+	// launched, so it is released immediately to balance the reservation.
+	//
+	// Auto-triggered orders carry no args channel: vars/execEnv are nil.
+	inFlight.Add(1)
+	trackingBead, err := m.launchResolvedDispatch(ctx, store, target, a, cityPath, nil, nil, inFlight.Done)
+	if err != nil {
+		inFlight.Done()
+		logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
+		return false
+	}
+	m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
+	return true
 }
 
 // launchDispatchOne spawns dispatchOne with a context that cancels when

--- a/cmd/gc/order_dispatch_condition_budget_test.go
+++ b/cmd/gc/order_dispatch_condition_budget_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// A due condition order is a wake demand, not a request for a turn in the
+// rotation.
+//
+// The per-tick dispatch budget exists to spread clock-driven maintenance
+// (cooldown/cron/event) across ticks. On maintainer-city — ~40 enabled orders,
+// budget 4, a ~20 min tick — the sweeps were due at every tick and spent the
+// budget before the rotation ever reached pr-merge-queue, whose condition check
+// reports "a merge bead is ready right now". It went 11 h without a dispatch
+// with no gate error, no suppression event and nothing in the journal to show
+// for it (ga-unaz7). These tests pin the two halves of the fix: a due condition
+// order fires regardless of the budget, and it still answers to every gate that
+// bounds it.
+
+// conditionBudgetOrder is the condition-triggered exec order under test, whose
+// check verdict the caller chooses: "true" passes, "false" fails.
+func conditionBudgetOrder(check string) orders.Order {
+	return orders.Order{Name: "queue-c", Trigger: "condition", Check: check, Exec: "true"}
+}
+
+// cooldownBudgetOrder is a cooldown exec order that has never run, so it is due
+// on the first tick it is offered.
+func cooldownBudgetOrder(name string) orders.Order {
+	return orders.Order{Name: name, Trigger: "cooldown", Interval: "1h", Exec: "true"}
+}
+
+// newConditionBudgetDispatcher builds a single-store dispatcher over aa with a
+// faked exec runner and the given per-tick budget, and returns it with the
+// buffer its dispatch errors land in.
+func newConditionBudgetDispatcher(t *testing.T, aa []orders.Order, budget int) (*memoryOrderDispatcher, *bytes.Buffer, beads.Store) {
+	t.Helper()
+	store := beads.NewMemStore()
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	m := ad.(*memoryOrderDispatcher)
+	m.maxDispatchesPerTick = budget
+	var stderr bytes.Buffer
+	m.stderr = lockedStderr(&stderr)
+	t.Cleanup(func() { m.dispatchCancel() })
+	return m, &stderr, store
+}
+
+// runCountFor counts the beads carrying an order's run label.
+func runCountFor(t *testing.T, store beads.Store, scoped string) int {
+	t.Helper()
+	return len(trackingBeads(t, store, orders.RunLabel(scoped)))
+}
+
+// TestDispatchFiresDueConditionOrderOutsideTheRotationBudget is the defect:
+// with the budget spent by cooldown sweeps ahead of it in the rotation, a
+// condition order whose check has just passed must still fire this tick.
+func TestDispatchFiresDueConditionOrderOutsideTheRotationBudget(t *testing.T) {
+	aa := []orders.Order{
+		cooldownBudgetOrder("sweep-a"),
+		cooldownBudgetOrder("sweep-b"),
+		conditionBudgetOrder("true"),
+	}
+	m, _, store := newConditionBudgetDispatcher(t, aa, 1)
+	cityPath := t.TempDir()
+
+	m.dispatch(context.Background(), cityPath, time.Now())
+	drainOrderDispatch(t, m)
+
+	if got := runCountFor(t, store, "queue-c"); got != 1 {
+		t.Fatalf("condition order runs after a tick whose budget the sweeps spent = %d, want 1 — the budget starved a due condition order", got)
+	}
+	if got := runCountFor(t, store, "sweep-a"); got != 1 {
+		t.Fatalf("sweep-a runs = %d, want 1: the budgeted order at the head of the rotation must still fire", got)
+	}
+	// Control: the budget still binds the orders it is for. Without this the
+	// assertion above would also pass for a change that simply deleted it.
+	if got := runCountFor(t, store, "sweep-b"); got != 0 {
+		t.Fatalf("sweep-b runs = %d, want 0: a budget of 1 must defer the second due cooldown order", got)
+	}
+
+	// And the rotation still advances, so the deferred sweep fires next tick.
+	m.dispatch(context.Background(), cityPath, time.Now().Add(time.Second))
+	drainOrderDispatch(t, m)
+	if got := runCountFor(t, store, "sweep-b"); got != 1 {
+		t.Fatalf("sweep-b runs after the second tick = %d, want 1: the rotation cursor no longer advances", got)
+	}
+}
+
+// TestDispatchConditionOrderStillHonoursOpenTrackingGate: unbudgeted is not
+// ungated. A dispatch already recorded in flight suppresses the next one.
+func TestDispatchConditionOrderStillHonoursOpenTrackingGate(t *testing.T) {
+	a := conditionBudgetOrder("true")
+	m, _, store := newConditionBudgetDispatcher(t, []orders.Order{a}, 1)
+
+	front := orders.NewStore(beads.OrdersStore{Store: store})
+	if _, err := front.CreateRun(a.ScopedName(), orders.RunOpts{}); err != nil {
+		t.Fatalf("seed open tracking bead: %v", err)
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	drainOrderDispatch(t, m)
+
+	if got := runCountFor(t, store, a.ScopedName()); got != 1 {
+		t.Fatalf("runs = %d, want 1 (the seeded open tracking bead only): the open-tracking gate stopped holding a condition order", got)
+	}
+}
+
+// TestDispatchConditionOrderStillHonoursOpenWorkGate: an open wisp root
+// carrying the order's run label means the previous dispatch's work is still
+// moving, and that suppresses the fire whether or not a budget was consulted.
+func TestDispatchConditionOrderStillHonoursOpenWorkGate(t *testing.T) {
+	a := conditionBudgetOrder("true")
+	m, _, store := newConditionBudgetDispatcher(t, []orders.Order{a}, 1)
+
+	front := orders.NewStore(beads.OrdersStore{Store: store})
+	run, err := front.CreateRun(a.ScopedName(), orders.RunOpts{})
+	if err != nil {
+		t.Fatalf("seed tracking bead: %v", err)
+	}
+	closed := "closed"
+	if err := store.Update(run.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("close tracking bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "wisp",
+		Labels:   []string{orders.RunLabel(a.ScopedName())},
+		Metadata: map[string]string{beadmeta.KindMetadataKey: beadmeta.KindWisp},
+	}); err != nil {
+		t.Fatalf("seed open wisp root: %v", err)
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	drainOrderDispatch(t, m)
+
+	if got := runCountFor(t, store, a.ScopedName()); got != 2 {
+		t.Fatalf("beads carrying the run label = %d, want 2 (the closed tracking bead and the open wisp): the open-work gate stopped holding a condition order", got)
+	}
+}
+
+// TestDispatchConditionOrderWithFailingCheckDoesNotFire is the control on the
+// unbudgeted pass: it is selected by the check's verdict, not by the trigger
+// type.
+func TestDispatchConditionOrderWithFailingCheckDoesNotFire(t *testing.T) {
+	a := conditionBudgetOrder("false")
+	m, _, store := newConditionBudgetDispatcher(t, []orders.Order{a}, 1)
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	drainOrderDispatch(t, m)
+
+	if got := runCountFor(t, store, a.ScopedName()); got != 0 {
+		t.Fatalf("runs = %d, want 0: a condition order whose check fails must not fire", got)
+	}
+}
+
+// TestDispatchBudgetExhaustionLogsDeferredDueOrders: the starvation this whole
+// change is about was invisible. A tick that stops on its budget says so, and
+// names what it did not reach.
+func TestDispatchBudgetExhaustionLogsDeferredDueOrders(t *testing.T) {
+	aa := []orders.Order{cooldownBudgetOrder("sweep-a"), cooldownBudgetOrder("sweep-b")}
+	m, stderr, _ := newConditionBudgetDispatcher(t, aa, 1)
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	drainOrderDispatch(t, m)
+
+	logged := stderr.String()
+	if !strings.Contains(logged, "per-tick budget 1 spent") {
+		t.Fatalf("dispatch stderr = %q, want a line reporting the spent per-tick budget", logged)
+	}
+	if !strings.Contains(logged, "sweep-b") {
+		t.Fatalf("dispatch stderr = %q, want the deferred order named", logged)
+	}
+}
+
+// TestDispatchLogsNoDeferralWhenEveryDueOrderFires keeps the line above from
+// becoming per-tick noise on a city that is keeping up.
+func TestDispatchLogsNoDeferralWhenEveryDueOrderFires(t *testing.T) {
+	aa := []orders.Order{cooldownBudgetOrder("sweep-a"), cooldownBudgetOrder("sweep-b")}
+	m, stderr, _ := newConditionBudgetDispatcher(t, aa, 4)
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	drainOrderDispatch(t, m)
+
+	if logged := stderr.String(); strings.Contains(logged, "deferred to a later tick") {
+		t.Fatalf("dispatch stderr = %q, want no deferral line when the budget covered every due order", logged)
+	}
+}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1709,15 +1709,24 @@ func TestOrderDispatchRespectsMaxDispatchesPerTick(t *testing.T) {
 	}
 }
 
+// TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders pins the rotation: a
+// budget smaller than the due set must hand every order a turn across
+// consecutive ticks rather than replaying the head of the list.
+//
+// The orders are cooldown, not condition. Condition orders no longer consult
+// the budget at all (see TestDispatchFiresDueConditionOrderOutsideTheRotation-
+// Budget), so building the corpus out of them would make this pass on the
+// first tick and stop measuring the cursor. A 1ms interval against ticks a
+// second apart is the always-due shape on the budgeted path.
 func TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders(t *testing.T) {
 	store := beads.NewMemStore()
 	var aa []orders.Order
 	for i := 0; i < 5; i++ {
 		aa = append(aa, orders.Order{
-			Name:    fmt.Sprintf("condition-%d", i),
-			Trigger: "condition",
-			Check:   "true",
-			Exec:    "true",
+			Name:     fmt.Sprintf("cooldown-%d", i),
+			Trigger:  "cooldown",
+			Interval: "1ms",
+			Exec:     "true",
 		})
 	}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, func(context.Context, string, string, []string) ([]byte, error) {
@@ -1729,14 +1738,17 @@ func TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders(t *testing.T) {
 	m := ad.(*memoryOrderDispatcher)
 	m.maxDispatchesPerTick = 2
 
-	now := time.Date(2026, 5, 19, 2, 30, 0, 0, time.UTC)
+	// Anchored to wall clock: a tracking bead's CreatedAt is real time, so a
+	// fixed fake 'now' in the past would leave every fired order's cooldown
+	// clock reading negative and never due again.
+	now := time.Now()
 	for i := 0; i < 3; i++ {
 		ad.dispatch(context.Background(), t.TempDir(), now.Add(time.Duration(i)*time.Second))
 		ad.drain(context.Background())
 	}
 
 	for i := 0; i < 5; i++ {
-		label := fmt.Sprintf("order-run:condition-%d", i)
+		label := fmt.Sprintf("order-run:cooldown-%d", i)
 		if got := len(trackingBeads(t, store, label)); got == 0 {
 			t.Fatalf("%s did not dispatch under a rotating budget", label)
 		}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -598,7 +598,7 @@ OrdersConfig holds order settings for orders discovered from flat TOML files (on
 |-------|------|----------|---------|-------------|
 | `skip` | []string |  |  | Skip lists order names to exclude from scanning. |
 | `max_timeout` | string |  |  | MaxTimeout is an operator hard cap on the per-order dispatch timeout: no order's dispatched exec/formula runs longer than this. Go duration string (e.g., "60s"). Empty means uncapped (no override). This bounds the dispatch timeout only; a condition trigger's check_timeout is a separate probe deadline and is not capped here. |
-| `max_dispatches_per_tick` | integer |  |  | MaxDispatchesPerTick caps how many orders the supervisor dispatches per tick. Unset keeps the built-in default of 4; set to 1 to drain overdue cooldown orders one-per-tick at cold start instead of firing several concurrent goroutines at once. |
+| `max_dispatches_per_tick` | integer |  |  | MaxDispatchesPerTick caps how many clock-driven orders (cooldown, cron and event triggers) the supervisor dispatches per tick, in a rotation that resumes where the previous tick stopped. Unset keeps the built-in default of 4; set to 1 to drain overdue cooldown orders one-per-tick at cold start instead of firing several concurrent goroutines at once. Condition-triggered orders are outside this budget: a passing check means work is pending right now, so they dispatch on the tick that observes it and are bounded by their own check plus the open-work gate. |
 | `overrides` | []OrderOverride |  |  | Overrides apply per-order field overrides after scanning. Each override targets an order by name and optionally by rig. |
 
 ## PackDefaults

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -2104,7 +2104,7 @@
         },
         "max_dispatches_per_tick": {
           "type": "integer",
-          "description": "MaxDispatchesPerTick caps how many orders the supervisor dispatches\nper tick. Unset keeps the built-in default of 4; set to 1 to drain\noverdue cooldown orders one-per-tick at cold start instead of firing\nseveral concurrent goroutines at once."
+          "description": "MaxDispatchesPerTick caps how many clock-driven orders (cooldown, cron\nand event triggers) the supervisor dispatches per tick, in a rotation\nthat resumes where the previous tick stopped. Unset keeps the built-in\ndefault of 4; set to 1 to drain overdue cooldown orders one-per-tick at\ncold start instead of firing several concurrent goroutines at once.\nCondition-triggered orders are outside this budget: a passing check\nmeans work is pending right now, so they dispatch on the tick that\nobserves it and are bounded by their own check plus the open-work gate."
         },
         "overrides": {
           "items": {

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -2104,7 +2104,7 @@
         },
         "max_dispatches_per_tick": {
           "type": "integer",
-          "description": "MaxDispatchesPerTick caps how many orders the supervisor dispatches\nper tick. Unset keeps the built-in default of 4; set to 1 to drain\noverdue cooldown orders one-per-tick at cold start instead of firing\nseveral concurrent goroutines at once."
+          "description": "MaxDispatchesPerTick caps how many clock-driven orders (cooldown, cron\nand event triggers) the supervisor dispatches per tick, in a rotation\nthat resumes where the previous tick stopped. Unset keeps the built-in\ndefault of 4; set to 1 to drain overdue cooldown orders one-per-tick at\ncold start instead of firing several concurrent goroutines at once.\nCondition-triggered orders are outside this budget: a passing check\nmeans work is pending right now, so they dispatch on the tick that\nobserves it and are bounded by their own check plus the open-work gate."
         },
         "overrides": {
           "items": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2120,10 +2120,14 @@ type OrdersConfig struct {
 	// BurntSushi's omitempty does not drop a zero int, so a plain int would
 	// emit max_dispatches_per_tick = 0 into every marshaled city.toml.
 
-	// MaxDispatchesPerTick caps how many orders the supervisor dispatches
-	// per tick. Unset keeps the built-in default of 4; set to 1 to drain
-	// overdue cooldown orders one-per-tick at cold start instead of firing
-	// several concurrent goroutines at once.
+	// MaxDispatchesPerTick caps how many clock-driven orders (cooldown, cron
+	// and event triggers) the supervisor dispatches per tick, in a rotation
+	// that resumes where the previous tick stopped. Unset keeps the built-in
+	// default of 4; set to 1 to drain overdue cooldown orders one-per-tick at
+	// cold start instead of firing several concurrent goroutines at once.
+	// Condition-triggered orders are outside this budget: a passing check
+	// means work is pending right now, so they dispatch on the tick that
+	// observes it and are bounded by their own check plus the open-work gate.
 	MaxDispatchesPerTick *int `toml:"max_dispatches_per_tick,omitempty"`
 	// Overrides apply per-order field overrides after scanning.
 	// Each override targets an order by name and optionally by rig.


### PR DESCRIPTION
## The defect

`orders.max_dispatches_per_tick` (default 4) rationed **every** trigger type and
advanced its rotation cursor (`nextDispatchStart`) only when it spent a slot. So
each tick fired the first 4 due orders after the cursor and every order got a
dispatch opportunity roughly once per `ceil(orders / budget)` ticks.

That is the right shape for maintenance sweeps. It is the wrong shape for a
condition-triggered order, whose check does not say "I would like a turn" — it
says **work is pending right now**, and it says it only for as long as that work
waits. A cooldown order is due at every tick whose spacing exceeds its interval,
so on a slow-tick city the sweeps saturate the budget permanently and a condition
order whose window is shorter than a full rotation fires only by luck.

## Evidence (maintainer-city, read-only from the graph store and journal)

- `order:*` tracking beads are created in bursts of **exactly 4**, one burst
  every ~18–24 min: 20:04:41, 20:22:21, 20:24:25, 20:42:00, 21:00:11, 21:23:18,
  21:47:10, 22:06:07, 22:25:15, 22:33:59, 22:44:19 … — 12–16 dispatches/hour
  against ~40 enabled orders, i.e. a full rotation every ~3.5 h
  (pr-review-router fired 16:18, 20:24, 23:03). `city.toml` sets no override,
  so the budget is the built-in 4; the tick period on this city is ~20 min, not
  the ~110 s the `max_wakes_per_tick` comment nearby assumes.
- `pr-merge-queue` (trigger=condition, check `pr_merge.py queue-pending`, 2.8 s,
  exit 0 whenever a merge bead is `pr_merge.status=ready`) last fired **14:06Z —
  11 h earlier**. Merge beads for #5604/#5633 were ready 20:25–21:11Z. The ticks
  at **20:42Z and 21:00Z** fell inside that window and each fired four *cooldown*
  orders — beadless-session-reaper, pr-review-label-poll, quota-stall-reset,
  beads-health / cross-rig-deps, gate-sweep, nudge-mail-sweep,
  order-tracking-sweep — while the merge queue's condition was true. Same for the
  21:2x–21:3x window (#5918/#5928/#5929) and the 01:3x window (#5935).
- No gate error, no `order.suppressed` event, no timed-out-check line ever named
  `pr-merge-queue`. It was simply never reached before the budget was spent. The
  starvation was invisible.

Raising `max_dispatches_per_tick` on this city only moves the cliff, which is why
this is an SDK defect rather than a tuning problem.

## The change (`cmd/gc/order_dispatch.go`, `memoryOrderDispatcher.dispatch` phase 2)

Phase 2 is now two passes over the same rotation-ordered candidate list:

1. **Unbudgeted pass** over due condition candidates. Every gate still applies —
   the phase-1 open-tracking gate already ran, the open-work gate runs here, and
   the order self-limits by its own check — but no budget is consulted and no
   rotation cursor moves.
2. **Budgeted pass** over everything else, byte-for-byte the previous semantics:
   same `start`, same `spendDispatchBudget(idx)`, same `return` on exhaustion.
   `maxDispatchesPerTick == 0` still means unbounded.

Both passes call one shared `fireCandidate(...) bool`, so the trigger-env
failure record, the prefetched condition verdict, the lastRun refresh, the
open-work gate and the launch exist exactly once. The open-work gate block moved
into its own `openWorkGateShut` helper to keep both extracted functions under the
repo's complexity threshold.

**Which trigger spelling the branch keys on:** `Order.Trigger == "condition"`,
and that covers both spellings. `gate = "condition"` is folded into `Trigger` by
`orders.orderDecode.normalized()` (`internal/orders/order.go:151`) at scan time
and by `config.OrderOverride.normalizeLegacyAliases()`
(`internal/config/config.go:2173`) at override time, so no `Order` reaches the
dispatcher still carrying a `Gate`. The dispatcher's existing condition branches
(`prefetchConditionResults`, the check-timeout line) key on the same field.

**Observability.** A tick whose budget is spent now logs one grep-able line, in
the shape of the ga-ocypq2 timed-out-check line:

```
gc: order dispatch: per-tick budget 2 spent; the rotation did not reach 3 more order(s) this tick (due-ness not evaluated): cooldown-2, cooldown-3, cooldown-4
```

## Deliberate deviations from the design, and why

- **The line names *unreached* candidates, not a due-list.** The design's draft
  string said "due order(s)". Settling due-ness for the unreached tail would cost
  a per-order last-run fallback query (#3201) and a per-order event-cursor read
  (ga-l7jdg) — exactly the reads the budget exists to avoid — so the line reports
  what the tick already knows for free: the orders that cleared the cheap gates
  and were never reached, and it says so in those words rather than asserting
  deferral. Capped at 8 names plus a count.
- **A trigger-env failure on a condition order stays budgeted.** The design
  listed "trigger env failure" among the logic the unbudgeted pass should run.
  That path writes an *error* tracking bead rather than a dispatch, and
  `TestOrderDispatchTriggerEnvFailuresRespectMaxDispatchesPerTick` exists to keep
  it rationed — a city with 40 misconfigured condition orders would otherwise
  write 40 failure beads per tick. The unbudgeted pass therefore selects on the
  *prefetched passing check* (`conditionResult != nil && Due`), which is the
  literal statement of "work is pending right now".

## Tests — RED → GREEN

New file `cmd/gc/order_dispatch_condition_budget_test.go`, written first.

RED, on the unmodified dispatcher:

```
=== RUN   TestDispatchFiresDueConditionOrderOutsideTheRotationBudget
    order_dispatch_condition_budget_test.go:80: condition order runs after a tick whose budget the sweeps spent = 0, want 1 — the budget starved a due condition order
--- FAIL: TestDispatchFiresDueConditionOrderOutsideTheRotationBudget (0.01s)
=== RUN   TestDispatchConditionOrderStillHonoursOpenTrackingGate
--- PASS: TestDispatchConditionOrderStillHonoursOpenTrackingGate (0.00s)
=== RUN   TestDispatchConditionOrderStillHonoursOpenWorkGate
--- PASS: TestDispatchConditionOrderStillHonoursOpenWorkGate (0.01s)
=== RUN   TestDispatchConditionOrderWithFailingCheckDoesNotFire
--- PASS: TestDispatchConditionOrderWithFailingCheckDoesNotFire (0.01s)
=== RUN   TestDispatchBudgetExhaustionLogsDeferredDueOrders
    order_dispatch_condition_budget_test.go:177: dispatch stderr = "", want a line reporting the spent per-tick budget
--- FAIL: TestDispatchBudgetExhaustionLogsDeferredDueOrders (0.00s)
=== RUN   TestDispatchLogsNoDeferralWhenEveryDueOrderFires
--- PASS: TestDispatchLogsNoDeferralWhenEveryDueOrderFires (0.00s)
FAIL	github.com/gastownhall/gascity/cmd/gc	4.313s
```

GREEN, with the fix (`-race`, alongside the three pre-existing budget tests):

```
--- PASS: TestDispatchFiresDueConditionOrderOutsideTheRotationBudget (0.03s)
--- PASS: TestDispatchConditionOrderStillHonoursOpenTrackingGate (0.00s)
--- PASS: TestDispatchConditionOrderStillHonoursOpenWorkGate (0.01s)
--- PASS: TestDispatchConditionOrderWithFailingCheckDoesNotFire (0.01s)
--- PASS: TestDispatchBudgetExhaustionLogsDeferredDueOrders (0.01s)
--- PASS: TestDispatchLogsNoDeferralWhenEveryDueOrderFires (0.01s)
--- PASS: TestOrderDispatchRespectsMaxDispatchesPerTick (0.02s)
--- PASS: TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders (0.03s)
--- PASS: TestOrderDispatchTriggerEnvFailuresRespectMaxDispatchesPerTick (0.05s)
ok  	github.com/gastownhall/gascity/cmd/gc	15.126s
```

`TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders` was rebuilt out of cooldown
orders. It used five always-due *condition* orders, which under this change all
fire on the first tick — it would still have passed while measuring nothing.
Mutation-checked: pinning `nextDispatchStart = 0` fails it with
`order-run:cooldown-2 did not dispatch under a rotating budget`.

## Gates

| command | result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `gofmt -l cmd internal` | no output |
| `golangci-lint run ./cmd/gc/... ./internal/orders/... ./internal/config/...` | 0 issues |
| `make check-docs` | ok |
| `./scripts/check-residency-boundary.sh` | exit 0 |
| `go test ./cmd/gc -run 'Dispatch\|Order\|Budget\|Gate' -count=1` | ok (54.8s) |
| `make test-fast-parallel` | exit 0 — "All fast jobs passed" |
| `.githooks/pre-commit` | ran clean on the staged change |
| `./scripts/ci/complexity.sh check` | exit 1 — **byte-identical to an untouched `origin/main` export** (see below) |

`complexity-check` is red on `origin/main` today, independently of this PR. Run
against a clean `git archive origin/main` export, it reports the same nine
findings this branch reports, and none of them are in this diff:
`reconcileSessionBeadsTracedWithNamedDemand` 473 (baseline 461), `resolveTemplate`
87/86, `buildPreparedStartWithWorkDirResolver` 56/55, `doPrimeWithHookFormatOpts`
51/49, `doOrderCheckWithStoresResolverScopedJSON` 45/44, `acceptDialogFromStream`
31/29, `cmdNudgePoll` 25/22, plus new `filterAssignedWorkBeadsForSessionWakeWithStores`
26 and `releaseConfirmedOrphanSessionWork` 20. This PR adds **zero** entries:
`dispatch` drops well below its baseline 47 and both extracted helpers land under
the threshold of 20.

## Docs

- `internal/config/config.go` `MaxDispatchesPerTick` now says the budget covers
  cooldown/cron/event and that condition orders dispatch outside it.
- `docs/reference/config.md` and the city schema regenerated with `make generate`
  (never hand-edited); `make check-docs` passes.
- CHANGELOG `[Unreleased] → Fixed` bullet naming the mechanism and the 11 h
  maintainer-city outage.

## Maintainer fixups (adoption review)

One maintainer commit rides on top of the contributor commit above. It has two
unrelated parts, neither of which changes the dispatch behavior described here.

- **CI repair, `internal/doctor/checks_custom_types_test.go`.** The custom-types
  doctor test read `bd` through `CombinedOutput`, so `bd`'s success-path stderr
  diagnostics contaminated the JSON its assertions parse and the test failed in
  pre-review CI. It now uses `Output()` (stdout only) and re-appends
  `ExitError.Stderr` on the failure path so failure reports keep their
  diagnostics. Unrelated to order dispatch; it rides here because the branch
  needed it to go green.
- **Review fixes — documentation and operator-facing wording only.** The
  `MaxDispatchesPerTick` doc comment no longer reassures that condition orders
  are "bounded by their own check plus the open-work gate". The open-tracking and
  open-work gates are keyed per order and only hold back a redispatch of an order
  whose previous run is still moving, so they bound no tick total; the comment now
  states the real bound — this budget plus one dispatch per condition order whose
  check passed on that tick — and the cold-start case where no tracking bead
  exists yet, with `docs/reference/config.md` and the city schema regenerated from
  it. The budget-exhaustion line was reworded to claim only what the tick knows
  for free, and `logDeferredCandidates` / `maxDeferredOrderNames` / the two tests
  that pinned the old wording were renamed to `logUnreachedCandidates` /
  `maxUnreachedOrderNames` / `TestDispatchBudgetExhaustionLogsUnreachedOrders` /
  `TestDispatchLogsNothingUnreachedWhenEveryDueOrderFires`, so the RED/GREEN
  transcripts above predate that rename. One stray blank line was removed from the
  CHANGELOG entry.

## Out of scope

- **Why the maintainer-city tick takes ~20 min** (reconciler / beads-cache cost)
  is a separate incident. This change makes condition orders independent of it.
- **No change to `max_dispatches_per_tick` in maintainer-city's `city.toml`.**
- One consequence worth naming: a city where many condition checks pass on the
  same tick now launches all of them, where it previously launched at most
  `max_dispatches_per_tick`. That is the intent — each is single-flighted by its
  own tracking bead and open-work gate, and each says real work is waiting — but
  it is a load-shape change on condition-heavy cities.

Refs ga-j4p3y, ga-unaz7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
