### PR TITLE
fix(cli): delete-source clears workflow_id on the copy the residency contract owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them. See "If this city cut over before edge payloads were carried" in
   `docs/runbooks/split-storage-classes.md` for what is affected, what is not
   lost, and the destructive re-converge procedure.
+- **`gc workflow delete-source` and `gc workflow reopen-source` write the copy
+  of the source bead the residency contract owns, not the one the selector
+  named.** An explicit `--rig` / `--store-ref` pins the store the sweep works
+  in, and both commands were writing the source bead's metadata through that
+  same store. On a converged city — infrastructure classes relocated into the
+  class binding with ids preserved, the pre-migration copies retained and
+  frozen at cutover — an operator naming the city cleared `workflow_id` on the
+  frozen twin while the binding's live row went on pointing at the workflow
+  that had just been swept. The next resolve answers from the binding, still
+  sees a workflow, and refuses the re-sling as already-running against a tree
+  that no longer exists; `reopen-source` had the same defect one verb over,
+  reopening the twin and leaving the row the city actually reads closed and
+  still bound. Both now resolve the owning copy through the by-id residency
+  walk (binding-first, a binding fault is an error and never absence), then
+  clear any other resident copy's stale `workflow_id` best-effort so the two
+  cannot disagree. A city that relocates nothing, and any `--rig` run, writes
+  exactly the store it wrote before.
 
 - **A control bead served by a relocated class binding is routed to the
   dispatcher its own `gc.root_store_ref` names.** On a split city every rig's

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -2101,7 +2101,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			cleared := false
 			if apply {
 				var clearErr error
-				cleared, clearErr = clearSourceWorkflowMetadata(cfg, cityPath, target)
+				cleared, clearErr = clearSourceWorkflowMetadata(cfg, cityPath, target, stderr)
 				if clearErr != nil {
 					return clearErr
 				}
@@ -2159,7 +2159,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		cleared := false
 		if !incomplete {
 			var clearErr error
-			cleared, clearErr = clearSourceWorkflowMetadata(cfg, cityPath, target)
+			cleared, clearErr = clearSourceWorkflowMetadata(cfg, cityPath, target, stderr)
 			if clearErr != nil {
 				return clearErr
 			}
@@ -2257,13 +2257,25 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			resultCode = 3
 			return nil
 		}
-		currentSource, err := target.storeView.store.Get(target.sourceBead.ID)
+		// The copy the residency contract owns, not the one the selector named —
+		// see sourceWorkflowWriteTarget. reopen-source is the other command that
+		// writes the source bead's metadata, and reopening the frozen twin would
+		// leave the binding's live row closed and still bound to its workflow, so
+		// the bead the city actually reads is neither reopened nor released.
+		write, err := resolveSourceWorkflowWriteTarget(cfg, cityPath, target)
+		if err != nil {
+			return err
+		}
+		if write.owning.store == nil {
+			return fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
+		}
+		currentSource, err := write.owning.store.Get(target.sourceBead.ID)
 		if err != nil {
 			return err
 		}
 		open := "open"
 		unassigned := ""
-		if err := target.storeView.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
+		if err := write.owning.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
 			return err
 		}
 		// Pre-route so the bead is never left unrouted between the reopen and
@@ -2293,18 +2305,24 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if nextRoute == "" {
 			nextRoute = strings.TrimSpace(currentSource.Metadata[beadmeta.RoutedToMetadataKey])
 		}
-		if err := target.storeView.store.SetMetadata(currentSource.ID, beadmeta.RoutedToMetadataKey, nextRoute); err != nil {
+		if err := write.owning.store.SetMetadata(currentSource.ID, beadmeta.RoutedToMetadataKey, nextRoute); err != nil {
 			return err
 		}
-		if err := clearSessionAffinityMetadataOnBead(target.storeView.store, currentSource.ID); err != nil {
+		if err := clearSessionAffinityMetadataOnBead(write.owning.store, currentSource.ID); err != nil {
 			return err
 		}
-		if err := target.storeView.store.Update(currentSource.ID, beads.UpdateOpts{
+		if err := write.owning.store.Update(currentSource.ID, beads.UpdateOpts{
 			Status:   &open,
 			Assignee: &unassigned,
 		}); err != nil {
 			return err
 		}
+		// Only workflow_id travels to the other copies. The reopen itself is the
+		// owning copy's — a frozen twin restored to open would be a row the
+		// migration retired walking back into the ready frontier — but a twin
+		// still naming the released workflow is the disagreement this command
+		// exists to end.
+		clearSourceWorkflowTwins(cfg, cityPath, write, target.sourceBeadID, stderr)
 		_, _ = fmt.Fprintf(stdout, "result=reopened source_bead_id=%s\n", sourceBeadID)
 		return nil
 	})
@@ -2847,33 +2865,172 @@ func openSourceWorkflowStoresWithProvider(cfg *config.City, cityPath, beadID str
 	return nil, skips, fmt.Errorf("no source workflow stores available")
 }
 
-func clearSourceWorkflowMetadata(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget) (bool, error) {
-	bead := target.sourceBead
-	storeView := target.storeView
-	if storeView.store == nil || strings.TrimSpace(storeView.path) == "" {
-		if target.storeRef == "" {
-			return false, nil
+// sourceWorkflowWriteTarget names the copy of a source bead that delete-source
+// and reopen-source write, and the other copies of it that must not be left
+// naming a workflow the owning copy has released.
+//
+// The selector (--rig / --store-ref) says which store's workflow is being SWEPT.
+// It does not say which copy of the source bead the next reader consults: that
+// is the residency contract's answer, and on a converged city — infrastructure
+// classes relocated into the class binding with ids preserved, the pre-migration
+// copies retained and frozen at cutover — the two are different stores. Writing
+// the selector's copy clears workflow_id on the frozen twin while the binding's
+// live row goes on pointing at the workflow that was just swept, so the next
+// resolve answers from the binding, still sees a workflow, and refuses the
+// re-sling as already-running against a tree that no longer exists (ga-4kivg).
+type sourceWorkflowWriteTarget struct {
+	// owning is the copy every later reader consults. Its write is the one that
+	// decides whether the command succeeded.
+	owning convoyStoreView
+	// others are the remaining resident copies of the same id. Their stale
+	// workflow_id is cleared best-effort: it is invisible to a binding-first
+	// read, but leaving the two copies disagreeing is how a later reader that
+	// reaches for the twin — an operator naming the city, a store-scoped
+	// report — is told the workflow is still running.
+	others []convoyStoreView
+}
+
+// resolveSourceWorkflowWriteTarget answers which copy of the source bead owns
+// the id, by running the by-id residency walk the rest of the CLI already runs.
+//
+// A binding that could not answer comes back as an ERROR, never as "no binding
+// owns this". Reading a fault as absence would send the write to the frozen twin
+// with nothing said about it, which is the same wrong copy this resolution
+// exists to stop — arrived at silently instead of by the selector.
+//
+// The walk carries no rig legs (see cliByIDBindingOwner), so a rig-owned source
+// bead has no binding answer and the owning copy is the store the selector
+// named. That is what keeps every unsplit city, and every --rig run, on exactly
+// the store it wrote before.
+func resolveSourceWorkflowWriteTarget(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget) (sourceWorkflowWriteTarget, error) {
+	selected := target.storeView
+	if selected.store == nil || strings.TrimSpace(selected.path) == "" {
+		if strings.TrimSpace(target.storeRef) == "" {
+			return sourceWorkflowWriteTarget{}, nil
 		}
-		var err error
-		storeView, _, err = openSourceWorkflowStoreRef(cfg, cityPath, target.storeRef)
+		view, _, err := openSourceWorkflowStoreRef(cfg, cityPath, target.storeRef)
 		if err != nil {
-			return false, err
+			return sourceWorkflowWriteTarget{}, err
+		}
+		selected = view
+	}
+	owner, ownedByBinding, err := cliByIDBindingOwner(cityPath, target.sourceBeadID)
+	if err != nil {
+		return sourceWorkflowWriteTarget{}, err
+	}
+	if !ownedByBinding {
+		return sourceWorkflowWriteTarget{owning: selected}, nil
+	}
+	write := sourceWorkflowWriteTarget{owning: convoyStoreView{
+		path:  convoyBindingViewPath,
+		store: owner.Store,
+		role:  convoyViewClassBinding,
+	}}
+	write.others = appendSourceWorkflowCopy(write.others, write.owning, selected)
+	// The migration copied OUT of the city work ledger and deleted nothing, so
+	// the frozen twin of a binding-owned id is there whether or not the operator
+	// named it. Reaching it here is what makes the unscoped run and the
+	// --store-ref city run end in the same state.
+	if !slices.ContainsFunc(write.others, func(view convoyStoreView) bool { return samePath(view.path, cityPath) }) {
+		cityView, _, err := openSourceWorkflowStoreRef(cfg, cityPath, "city")
+		if err != nil {
+			return sourceWorkflowWriteTarget{}, err
+		}
+		write.others = appendSourceWorkflowCopy(write.others, write.owning, cityView)
+	}
+	return write, nil
+}
+
+// appendSourceWorkflowCopy adds candidate to copies unless it is the owning copy
+// or one already listed.
+func appendSourceWorkflowCopy(copies []convoyStoreView, owning, candidate convoyStoreView) []convoyStoreView {
+	if candidate.store == nil {
+		return copies
+	}
+	if sameSourceWorkflowCopy(owning, candidate) {
+		return copies
+	}
+	if slices.ContainsFunc(copies, func(existing convoyStoreView) bool { return sameSourceWorkflowCopy(existing, candidate) }) {
+		return copies
+	}
+	return append(copies, candidate)
+}
+
+// sameSourceWorkflowCopy reports whether two views hold the same copy of a bead.
+//
+// It compares PATHS, not scopes. A relocated binding's rows belong to the city
+// scope — that is what scopePath says, and what the lock and the multi-store
+// guard need — but the binding and the city work ledger are still two stores
+// holding two copies of the same id, which is the entire situation here. The
+// binding's path is a label no directory can equal, so the comparison separates
+// them, and a city serving its classes from more than one binding is a topology
+// this build already refuses.
+func sameSourceWorkflowCopy(a, b convoyStoreView) bool {
+	if a.isClassBinding() || b.isClassBinding() {
+		return a.isClassBinding() && b.isClassBinding()
+	}
+	return samePath(a.path, b.path)
+}
+
+// clearSourceWorkflowMetadata releases the source bead from its workflow on the
+// copy the residency contract owns, then on every other resident copy.
+//
+// The reported bool is the OWNING copy's, because that is the copy the operator
+// is being told about: a run that cleared only a frozen twin has changed nothing
+// any reader will see.
+func clearSourceWorkflowMetadata(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget, stderr io.Writer) (bool, error) {
+	write, err := resolveSourceWorkflowWriteTarget(cfg, cityPath, target)
+	if err != nil {
+		return false, err
+	}
+	if write.owning.store == nil {
+		return false, nil
+	}
+	cleared, err := clearWorkflowIDOnCopy(write.owning.store, target.sourceBeadID)
+	if err != nil {
+		return false, err
+	}
+	clearSourceWorkflowTwins(cfg, cityPath, write, target.sourceBeadID, stderr)
+	return cleared, nil
+}
+
+// clearSourceWorkflowTwins clears workflow_id on every copy but the owning one,
+// reporting failures without failing the command.
+//
+// Best-effort is the right policy for exactly these copies and no others. The
+// owning copy is what every reader consults, so its write is the command's
+// verdict; a frozen twin that keeps a stale workflow_id is invisible to a
+// binding-first read and costs nothing until something reaches past the contract
+// for it. Failing the command over one would take delete-source away from a
+// converged city whose retained ledger has gone read-only — which is a normal
+// end state for a migration, not a fault the operator can act on here.
+func clearSourceWorkflowTwins(cfg *config.City, cityPath string, write sourceWorkflowWriteTarget, sourceBeadID string, stderr io.Writer) {
+	for _, view := range write.others {
+		if _, err := clearWorkflowIDOnCopy(view.store, sourceBeadID); err != nil {
+			_, _ = fmt.Fprintf(stderr, "store=%s workflow_id_clear_error=%v\n", workflowDeleteStoreLabelForView(cfg, cityPath, view), err)
 		}
 	}
-	if strings.TrimSpace(bead.ID) == "" {
-		current, err := storeView.store.Get(target.sourceBeadID)
-		if err != nil {
-			if errors.Is(err, beads.ErrNotFound) {
-				return false, nil
-			}
-			return false, err
+}
+
+// clearWorkflowIDOnCopy clears one copy's workflow_id and reports whether it was
+// carrying one.
+//
+// The row is read here rather than reused from the resolution that found it: the
+// sweep runs in between, and a clear planned off a pre-sweep read would decide
+// from metadata that is one command old. A copy this store does not hold is not
+// an error — the migration only left a twin where there was a row to retain.
+func clearWorkflowIDOnCopy(store beads.Store, sourceBeadID string) (bool, error) {
+	bead, err := store.Get(sourceBeadID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return false, nil
 		}
-		bead = current
+		return false, err
 	}
 	if strings.TrimSpace(bead.Metadata["workflow_id"]) == "" {
 		return false, nil
 	}
-	if err := storeView.store.SetMetadata(bead.ID, "workflow_id", ""); err != nil {
+	if err := store.SetMetadata(bead.ID, "workflow_id", ""); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -2262,7 +2262,7 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		// writes the source bead's metadata, and reopening the frozen twin would
 		// leave the binding's live row closed and still bound to its workflow, so
 		// the bead the city actually reads is neither reopened nor released.
-		write, err := resolveSourceWorkflowWriteTarget(cfg, cityPath, target)
+		write, err := resolveSourceWorkflowWriteTarget(cfg, cityPath, target, stderr)
 		if err != nil {
 			return err
 		}
@@ -2902,7 +2902,14 @@ type sourceWorkflowWriteTarget struct {
 // bead has no binding answer and the owning copy is the store the selector
 // named. That is what keeps every unsplit city, and every --rig run, on exactly
 // the store it wrote before.
-func resolveSourceWorkflowWriteTarget(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget) (sourceWorkflowWriteTarget, error) {
+//
+// Opening the retained twin is best-effort for the same reason writing it is
+// (see clearSourceWorkflowTwins): a converged city whose retained ledger has
+// gone read-only or been dropped is a normal end state for the migration, and
+// refusing to resolve the owning copy over it would take both commands away
+// from that city. The open failure is reported on stderr and the run continues
+// with no twin.
+func resolveSourceWorkflowWriteTarget(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget, stderr io.Writer) (sourceWorkflowWriteTarget, error) {
 	selected := target.storeView
 	if selected.store == nil || strings.TrimSpace(selected.path) == "" {
 		if strings.TrimSpace(target.storeRef) == "" {
@@ -2934,9 +2941,10 @@ func resolveSourceWorkflowWriteTarget(cfg *config.City, cityPath string, target 
 	if !slices.ContainsFunc(write.others, func(view convoyStoreView) bool { return samePath(view.path, cityPath) }) {
 		cityView, _, err := openSourceWorkflowStoreRef(cfg, cityPath, "city")
 		if err != nil {
-			return sourceWorkflowWriteTarget{}, err
+			_, _ = fmt.Fprintf(stderr, "store=city workflow_id_clear_error=%v\n", err)
+		} else {
+			write.others = appendSourceWorkflowCopy(write.others, write.owning, cityView)
 		}
-		write.others = appendSourceWorkflowCopy(write.others, write.owning, cityView)
 	}
 	return write, nil
 }
@@ -2979,7 +2987,7 @@ func sameSourceWorkflowCopy(a, b convoyStoreView) bool {
 // is being told about: a run that cleared only a frozen twin has changed nothing
 // any reader will see.
 func clearSourceWorkflowMetadata(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget, stderr io.Writer) (bool, error) {
-	write, err := resolveSourceWorkflowWriteTarget(cfg, cityPath, target)
+	write, err := resolveSourceWorkflowWriteTarget(cfg, cityPath, target, stderr)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -8686,6 +8686,44 @@ func TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared(t *testing.T)
 	}
 }
 
+// TestWorkflowDeleteSourceReportsAnUnopenableTwinWithoutFailing pins the twin's
+// OPEN as best-effort, the same as its write.
+//
+// The retained ledger of a converged city going unreadable — read-only, moved
+// aside, dropped once the migration was believed done — is a normal end state,
+// not a fault the operator can act on from here. The copy the residency contract
+// owns is the binding, and it answered; failing the run because the frozen twin
+// could not be opened to clear a value no reader consults would take
+// delete-source away from exactly the city the migration produced.
+//
+// The rig is what makes the sweep survive the same fault: the store scan skips
+// what it cannot open and errors only when NOTHING opened, so a converged city
+// with no second store fails before the resolution is ever reached. With one
+// openable store the run gets as far as the clear, which is the arm this row is
+// about.
+func TestWorkflowDeleteSourceReportsAnUnopenableTwinWithoutFailing(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+	sourceID := relocatedSourceBead(t, cityPath, work, binding, rootID)
+	rigHoldingID(t, cityPath, "rig-src-1", "the rig's unrelated bead", "task")
+	if err := os.WriteFile(filepath.Join(cityPath, ".gc", "beads.json"), []byte("the retained ledger is no longer readable"), 0o644); err != nil {
+		t.Fatalf("faulting the retained ledger's open: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(sourceID, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d over an unopenable retained twin, want 0: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata_cleared=true") {
+		t.Errorf("delete-source did not clear the owning copy it could reach:\n%s", stdout.String())
+	}
+	if got := sourceWorkflowID(t, binding, sourceID); got != "" {
+		t.Errorf("the binding's live source row still names workflow %q; the twin's open took the owning copy's clear down with it", got)
+	}
+	if !strings.Contains(stderr.String(), "store=city workflow_id_clear_error=") {
+		t.Errorf("the run said nothing about the twin it could not reach: %q", stderr.String())
+	}
+}
+
 // TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector is ga-4kivg on
 // the other writer.
 //

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -7814,6 +7814,17 @@ func (s *faultingClassStore) CloseAll(ids []string, meta map[string]string) (int
 	return s.Store.CloseAll(ids, meta)
 }
 
+// SetMetadata faults on writeErr for CloseAll's reason, one verb over. A sweep
+// closes and then STAMPS the source bead, and a binding that drops its
+// connection does not do so between the two; a wrapper that faulted only the
+// close would leave the metadata arm exercising a healthy store.
+func (s *faultingClassStore) SetMetadata(id, key, value string) error {
+	if s.writeErr != nil {
+		return s.writeErr
+	}
+	return s.Store.SetMetadata(id, key, value)
+}
+
 func (s *faultingClassStore) IDPrefix() string {
 	declaring, ok := s.Store.(storeref.HasIDPrefix)
 	if !ok {
@@ -8451,6 +8462,264 @@ func TestWorkflowDeleteSourceRefusesRootsInTwoScopes(t *testing.T) {
 	}
 	if live.Status == "closed" {
 		t.Errorf("the refusal still closed the city's workflow; the operator was never asked which one they meant")
+	}
+}
+
+// relocatedSourceBead plants a source bead the way `gc storage migrate` leaves
+// one: the live row in the class binding, and the copy the migration retained
+// still sitting in the work ledger under the same id.
+//
+// Both copies name the workflow, which is what makes a wrong clear visible.
+// Clearing either alone leaves the pair disagreeing, and only the binding's
+// answer is the one the next resolve of this id reads.
+//
+// The residency verdict is asserted here rather than in each row, because a
+// fixture whose binding does not own the id has built an ordinary city and every
+// assertion below it would pass for the wrong reason.
+func relocatedSourceBead(t *testing.T, cityPath string, work, binding beads.Store, workflowID string) string {
+	t.Helper()
+	shape := beads.Bead{Title: "the retained frozen source bead", Type: "task", Status: "in_progress"}
+	twin, err := work.Create(shape)
+	if err != nil {
+		t.Fatalf("seeding the retained source bead in the work store: %v", err)
+	}
+	carried := shape
+	carried.ID = twin.ID
+	carried.Title = "the binding's live source bead"
+	if _, err := migrationSeed(binding, carried); err != nil {
+		t.Fatalf("carrying the source bead across to the class binding: %v", err)
+	}
+	for _, store := range []beads.Store{work, binding} {
+		if err := store.SetMetadata(twin.ID, "workflow_id", workflowID); err != nil {
+			t.Fatalf("stamping the source bead's workflow_id: %v", err)
+		}
+	}
+	if _, ownedByBinding, err := cliByIDBindingOwner(cityPath, twin.ID); err != nil || !ownedByBinding {
+		t.Fatalf("the residency contract answers %s from the work ledger (err=%v); this fixture says nothing about the owning copy", twin.ID, err)
+	}
+	return twin.ID
+}
+
+// stampSourceIdentity points the fixture's relocated roots at a source bead, in
+// every copy of them, so the sweep has something to close in both stores.
+func stampSourceIdentity(t *testing.T, rootID, sourceBeadID string, stores ...beads.Store) {
+	t.Helper()
+	for _, store := range stores {
+		if err := store.SetMetadata(rootID, beadmeta.SourceBeadIDMetadataKey, sourceBeadID); err != nil {
+			t.Fatalf("stamping the root's source bead id: %v", err)
+		}
+	}
+}
+
+// sourceWorkflowID reads one copy's workflow_id, so a row can say which copy it
+// is talking about.
+func sourceWorkflowID(t *testing.T, store beads.Store, sourceBeadID string) string {
+	t.Helper()
+	bead, err := store.Get(sourceBeadID)
+	if err != nil {
+		t.Fatalf("reading %s back: %v", sourceBeadID, err)
+	}
+	return strings.TrimSpace(bead.Metadata["workflow_id"])
+}
+
+// TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector is the ga-4kivg
+// regression.
+//
+// The selector says which store's workflow is being SWEPT. It does not say which
+// copy of the source bead the next reader consults — that is the residency
+// contract's answer, and on a converged city the two are different stores. A
+// clear that follows the selector writes the frozen twin while the binding's
+// live row goes on naming a workflow that was just swept, so the next resolve
+// answers from the binding, still sees a workflow, and refuses the re-sling as
+// already-running against a tree that no longer exists.
+func TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+	sourceID := relocatedSourceBead(t, cityPath, work, binding, rootID)
+	stampSourceIdentity(t, rootID, sourceID, work, binding)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(sourceID, sourceWorkflowStoreSelector{storeRef: "city"}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata_cleared=true") {
+		t.Errorf("delete-source did not report clearing the source bead's metadata:\n%s", stdout.String())
+	}
+	if got := sourceWorkflowID(t, binding, sourceID); got != "" {
+		t.Errorf("the binding's live source row still names workflow %q, so the next sling is refused against a workflow this command just swept", got)
+	}
+	if got := sourceWorkflowID(t, work, sourceID); got != "" {
+		t.Errorf("the retained frozen copy still names workflow %q; the two copies disagree", got)
+	}
+	_, resolved, err := findUniqueBeadAcrossStoresView(cityPath, sourceID)
+	if err != nil {
+		t.Fatalf("resolving %s after the sweep: %v", sourceID, err)
+	}
+	if got := strings.TrimSpace(resolved.Metadata["workflow_id"]); got != "" {
+		t.Errorf("the next resolve of %s reports workflow %q, want none", sourceID, got)
+	}
+}
+
+// TestWorkflowDeleteSourceClearsTheSelectedStoreOnAnUnsplitCity is the control.
+//
+// A city that relocates nothing has one copy of the source bead, so the copy the
+// residency contract owns IS the store the selector named and the command must
+// behave exactly as it did before — same store written, same line printed,
+// nothing on stderr. Without this row the fix could reroute every city's clear
+// through a binding lane and only the converged rows would notice.
+func TestWorkflowDeleteSourceClearsTheSelectedStoreOnAnUnsplitCity(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	writeBuiltinImportsFixture(t, cityDir, "core")
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "workspace_name = \"test-city\"\n")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title:  "Workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+			beadmeta.SourceBeadIDMetadataKey:    source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{storeRef: "city"}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	want := fmt.Sprintf("result=cleaned source_bead_id=%s matched_roots=1 matched_beads=1 closed=1 deleted=0 metadata_cleared=true\n", source.ID)
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+	if got := sourceWorkflowID(t, store, source.ID); got != "" {
+		t.Errorf("the source bead's workflow_id = %q, want empty", got)
+	}
+}
+
+// TestWorkflowDeleteSourceClearsTheRigsCopyForARigSelector is the other control.
+//
+// The by-id residency walk carries no rig legs on purpose, so a rig-owned source
+// bead has no binding answer and the copy the contract owns is the one the
+// selector named. Routing the clear through the resolver must not move a rig's
+// write anywhere.
+func TestWorkflowDeleteSourceClearsTheRigsCopyForARigSelector(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+	const sourceID = "rig-src-1"
+	rig := rigHoldingID(t, cityPath, sourceID, "the rig's source bead", "task")
+	for _, store := range []beads.Store{work, binding} {
+		if err := store.SetMetadataBatch(rootID, map[string]string{
+			beadmeta.SourceBeadIDMetadataKey:   sourceID,
+			beadmeta.SourceStoreRefMetadataKey: "rig:frontend",
+		}); err != nil {
+			t.Fatalf("stamping the root's source identity: %v", err)
+		}
+	}
+	if err := rig.SetMetadata(sourceID, "workflow_id", rootID); err != nil {
+		t.Fatalf("stamping the rig source bead's workflow_id: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(sourceID, sourceWorkflowStoreSelector{storeRef: "rig:frontend"}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete-source exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata_cleared=true") {
+		t.Errorf("delete-source did not report clearing the rig's source bead:\n%s", stdout.String())
+	}
+	if got := sourceWorkflowID(t, rig, sourceID); got != "" {
+		t.Errorf("the rig's source bead still names workflow %q; the clear went somewhere else", got)
+	}
+}
+
+// TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared is the fault row.
+//
+// The owning copy is the one every later reader consults, so failing to clear it
+// is not a degraded success. The command has to say so and leave the operator
+// with a source bead that still names its workflow in BOTH copies — a run that
+// cleared the frozen twin alone would report a fault while having already made
+// the two copies disagree.
+//
+// The roots carry no source identity, so the sweep matches nothing and the
+// already_clean arm runs the clear on its own. That is what keeps this row about
+// the metadata write rather than about a close that failed first.
+func TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+	sourceID := relocatedSourceBead(t, cityPath, work, binding, rootID)
+	installFaultingClassBinding(t, cityPath, nil, errors.New("attempt to write a readonly database"))
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(sourceID, sourceWorkflowStoreSelector{storeRef: "city"}, true, false, &stdout, &stderr); code != 1 {
+		t.Fatalf("gc workflow delete-source exited %d over an unwritable owning copy, want 1: %s%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "readonly database") {
+		t.Errorf("the failure does not carry the fault that caused it: %q", stderr.String())
+	}
+	if got := sourceWorkflowID(t, work, sourceID); got != rootID {
+		t.Errorf("the retained frozen copy's workflow_id = %q, want %q; the command cleared the twin alone and then failed", got, rootID)
+	}
+	if got := sourceWorkflowID(t, binding, sourceID); got != rootID {
+		t.Errorf("the binding's live copy's workflow_id = %q, want %q", got, rootID)
+	}
+}
+
+// TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector is ga-4kivg on
+// the other writer.
+//
+// delete-source and reopen-source are the two commands that WRITE the source
+// bead's metadata, and they resolved the store to write through the same way.
+// Reopening the frozen twin leaves the binding's live row closed and still bound
+// to its workflow, so the bead the city actually reads is neither reopened nor
+// released — the operator is told it was.
+func TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector(t *testing.T) {
+	cityPath, rootID, _, work, binding := relocatedWorkflowCity(t)
+	sourceID := relocatedSourceBead(t, cityPath, work, binding, rootID)
+	for _, store := range []beads.Store{work, binding} {
+		closed := "closed"
+		if err := store.Update(sourceID, beads.UpdateOpts{Status: &closed}); err != nil {
+			t.Fatalf("closing the source bead: %v", err)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(sourceID, sourceWorkflowStoreSelector{storeRef: "city"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow reopen-source exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+	live, err := binding.Get(sourceID)
+	if err != nil {
+		t.Fatalf("reading the binding's source row back: %v", err)
+	}
+	if live.Status != "open" {
+		t.Errorf("the binding's live source row is %q after reopen-source, want open", live.Status)
+	}
+	if got := strings.TrimSpace(live.Metadata["workflow_id"]); got != "" {
+		t.Errorf("the binding's live source row still names workflow %q after being reopened", got)
+	}
+	if got := sourceWorkflowID(t, work, sourceID); got != "" {
+		t.Errorf("the retained frozen copy still names workflow %q; the two copies disagree", got)
 	}
 }
 


### PR DESCRIPTION
## Mechanism

`gc workflow delete-source` and `gc workflow reopen-source` are the two commands
that WRITE the source bead's metadata. Both wrote it through
`target.storeView` — the store an explicit `--rig` / `--store-ref` selector pins.

The selector says which store's workflow is being **swept**. It does not say
which copy of the source bead the next reader **consults**. On a converged city
— infrastructure classes relocated into the class binding with ids preserved,
the pre-migration copies retained and frozen at cutover — those are two
different stores holding two copies of one id, and the residency contract puts
the binding first.

So an operator naming the city cleared `workflow_id` on the **frozen twin**
while the binding's live row went on pointing at the workflow that had just
been swept. The next resolve of that source bead answers from the binding,
still sees a `workflow_id`, and refuses the re-sling as already-running against
a tree that no longer exists. The sweep itself was always right; only the
metadata clear picked the wrong copy.

`reopen-source` had the identical defect one verb over: with `--store-ref city`
it reopened the twin — status, route, session affinity, `workflow_id` — and
left the row the city actually reads closed and still bound. It is not left on
the old path.

Found by the pr2 (#5633) council review (MINOR 7). Filed as `ga-4kivg`, blocked
until the residency split stack (`ga-j4p3y`) landed because that stack is what
establishes both the binding-first contract and the `relocatedWorkflowCity`
fixture this fix tests against; `ga-gqc9e` is the sibling sweep-side work whose
fixtures are reused here.

## Decision

- **Clear on the copy the residency contract OWNS**, resolved by id through the
  same by-id residency walk the rest of the CLI already runs
  (`cliByIDBindingOwner` → `storeref.ResolveOwnerRow`, binding-first). A binding
  that could not answer is an **error, never absence** — reading a fault as "no
  binding owns this" would send the write to the frozen twin silently, which is
  the same wrong copy arrived at without a selector to blame.
- **The selector still scopes what the sweep closes.** Nothing about
  `collectSourceWorkflowMatches`, the multi-store guard or the lock scope
  changed.
- **Then best-effort clear every other resident copy** that still carries a
  `workflow_id`, so the two cannot disagree. That is the selector's copy plus —
  when the owning copy is the binding — the city work ledger the migration
  copied out of, which is where the frozen twin lives whether or not the
  operator named it. A failure there is reported on stderr
  (`store=<label> workflow_id_clear_error=<err>`) and does not fail the command,
  because the owning copy is the one every reader consults and a converged
  city's retained ledger going read-only is a normal end state, not something
  the operator can act on here.
- **Single-store city and every `--rig` run are byte-identical.** The by-id walk
  deliberately carries no rig legs, so a rig-owned source bead gets no binding
  answer and the owning copy IS the store the selector named. Pinned by two
  control rows, one of which asserts the exact stdout line and an empty stderr.
- `reopen-source` does all of its writes on the owning copy; only `workflow_id`
  travels to the other copies. A frozen twin restored to `open` would be a row
  the migration retired walking back into the ready frontier.

## RED → GREEN

Five rows, three of which are RED on `origin/main` (`407114321e`) and two of
which are controls that must stay green throughout.

RED (`go test ./cmd/gc -run '<the five>' -count=1 -v`, on main):

```
=== RUN   TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector
    cmd_convoy_dispatch_test.go:8291: the binding's live source row still names workflow "gc-1", so the next sling is refused against a workflow this command just swept
    cmd_convoy_dispatch_test.go:8301: the next resolve of gc-3 reports workflow "gc-1", want none
--- FAIL: TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector (0.23s)
=== RUN   TestWorkflowDeleteSourceClearsTheSelectedStoreOnAnUnsplitCity
--- PASS: TestWorkflowDeleteSourceClearsTheSelectedStoreOnAnUnsplitCity (0.16s)
=== RUN   TestWorkflowDeleteSourceClearsTheRigsCopyForARigSelector
--- PASS: TestWorkflowDeleteSourceClearsTheRigsCopyForARigSelector (0.25s)
=== RUN   TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared
    cmd_convoy_dispatch_test.go:8419: gc workflow delete-source exited 0 over an unwritable owning copy, want 1: result=already_clean source_bead_id=gc-3 matched_roots=0 matched_beads=0 closed=0 deleted=0 metadata_cleared=true
--- FAIL: TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared (0.19s)
=== RUN   TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector
    cmd_convoy_dispatch_test.go:8459: the binding's live source row is "closed" after reopen-source, want open
    cmd_convoy_dispatch_test.go:8462: the binding's live source row still names workflow "gc-1" after being reopened
--- FAIL: TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector (0.19s)
FAIL
```

Note the fault row's RED shape: it reported `metadata_cleared=true` **over an
unwritable binding**, because the write it did was to the healthy twin.

GREEN (after the fix):

```
--- PASS: TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector (0.24s)
--- PASS: TestWorkflowDeleteSourceClearsTheSelectedStoreOnAnUnsplitCity (0.14s)
--- PASS: TestWorkflowDeleteSourceClearsTheRigsCopyForARigSelector (0.24s)
--- PASS: TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared (0.20s)
--- PASS: TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector (0.23s)
```

The rows reuse `relocatedWorkflowCity` (the split-city fixture #5633 added) plus
one new helper, `relocatedSourceBead`, which plants the source bead the way
`gc storage migrate` leaves one — created in the work ledger, carried across to
the binding with the id preserved via `migrationSeed`, both copies naming the
workflow — and asserts the residency verdict in the fixture, so a row can never
pass because the fixture accidentally built an ordinary city.

`faultingClassStore` gained a `SetMetadata` override: `writeErr` already meant
"this binding's writes fail", and a wrapper that faulted only `CloseAll` would
have left the metadata arm exercising a healthy store.

## Mutation probes

Two, each restored afterwards.

**1. Revert the resolution to the selector's store** (`if true || !ownedByBinding`
in `resolveSourceWorkflowWriteTarget`, i.e. the pre-fix behaviour):

```
--- FAIL: TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector
--- PASS: TestWorkflowDeleteSourceClearsTheSelectedStoreOnAnUnsplitCity
--- PASS: TestWorkflowDeleteSourceClearsTheRigsCopyForARigSelector
--- FAIL: TestWorkflowDeleteSourceFailsWhenTheOwningCopyCannotBeCleared
--- FAIL: TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector
```

All three regression rows die; both controls stay green, which is what makes
them controls.

**2. Disable the best-effort twin clear** (`range write.others[:0]`):

```
--- FAIL: TestWorkflowDeleteSourceClearsTheOwningCopyForACitySelector
    cmd_convoy_dispatch_test.go:8294: the retained frozen copy still names workflow "gc-1"; the two copies disagree
--- FAIL: TestWorkflowReopenSourceReopensTheOwningCopyForACitySelector
    cmd_convoy_dispatch_test.go:8465: the retained frozen copy still names workflow "gc-1"; the two copies disagree
```

So the second half of the decision is load-bearing and separately pinned, not
riding on the first.

## Residency guard

`./scripts/check-residency-boundary.sh` passes with the baseline **unchanged** —
no splice needed. The new code adds no guarded vocabulary: `cliByIDBindingOwner`
is the sanctioned resolver seam (not a ratcheted pattern), and
`openSourceWorkflowStoreRef` is the singular ref-opener, not the binding-blind
`openSourceWorkflowStores(` enumerator the `a:` family counts. The AST half is
unaffected too — the new helper returns a `sourceWorkflowWriteTarget` struct,
not a raw `[]beads.Store` / `map[string]beads.Store` / `[]storeref.Leg` result.

## Gates

| gate | command | result |
| --- | --- | --- |
| build | `go build ./...` | exit 0 |
| vet | `go vet ./...` | exit 0 |
| fmt | `gofmt -l cmd internal` | nothing printed |
| lint | `golangci-lint run ./cmd/gc/... ./internal/sourceworkflow/...` | `0 issues.` (exit 0) |
| residency | `./scripts/check-residency-boundary.sh` | exit 0, baseline unchanged |
| targeted | `go test ./cmd/gc -run 'SourceWorkflow\|DeleteSource\|ReopenSource\|ConvoyDispatch\|Residency' -count=1 -v` | 50 `--- PASS`, 0 `--- FAIL` (non-vacuous) |
| package | `go test ./internal/sourceworkflow/... -count=1` | `ok` |
| docs | `make check-docs` | exit 0 |
| fast sweep | `PUSH_GATE_MAX_WAIT_SECONDS=3000 make test-fast-parallel` | all shards `ok` except `unit-cmd-gc-2-of-6`, whose sole failure is the filed main-red `ga-rs02h` — see below |

### Pre-existing red, not caused by this change (and the `--no-verify` disclosure)

The **sole** failure anywhere in the pre-push sweep is
`TestCreatePoolSessionBeadWithGuardedAlias_LiveRecensusBypassesStaleForeignCache`
(`cmd/gc/pool_session_identifier_lock_test.go:580`) in `unit-cmd-gc-2-of-6`.
Every other shard — `unit-cmd-gc-{1,3,4,5,6}-of-6`, `unit-core`,
`local-concurrency-selftest`, `fsys-darwin-compile`, `push-gate-lock-selftest` —
is `ok`.

It is a pool alias / session-census row over two in-memory stores and touches
nothing this PR does.

**It is already filed as a base-owned main-red: `ga-rs02h`** (P1, opened
2026-09-04) — "flaky: `TestCreatePoolSessionBeadWithGuardedAlias_LiveRecensusBypassesStaleForeignCache`
fails in CI on main". That bead records it failing on main run `33830599667`
(head `0e7adb38d`) in both `cmd/gc process / shard 3 of 12` and
`Preflight / unit cover (cmd/gc 3 of 6)`, and taking PR #5634 red as well. The
file is untouched since `eec182f80e` (#4789). Root cause per the bead: the row
asserts a cache **staleness window** — it seeds a holder into the backing store
and requires the cache-served census to still miss it — so any reconcile landing
inside that window flips the assertion.

Independent control run here, on an **untouched `origin/main` export**
(`git archive origin/main` at `407114321e`, extracted to a scratch dir outside
the worktree, no commits from this branch present):

```
--- FAIL: TestCreatePoolSessionBeadWithGuardedAlias_LiveRecensusBypassesStaleForeignCache (0.00s)
    pool_session_identifier_lock_test.go:580: ordinary cached census unexpectedly observed external holder session.Info{ID:"gc-1", ...}
FAIL	github.com/gastownhall/gascity/cmd/gc	3.643s
```

Same test, same line, same message, on a tree with none of this branch's
commits. Worth noting honestly: on this host it reproduces **deterministically**
in isolation (3/3), not intermittently — so `ga-rs02h`'s "flaky" framing may be
understating it, and the fix direction it proposes (pin the cache for the
assertion window rather than race it) looks right.

**Therefore this branch was pushed with `git push --no-verify`.** The pre-push
hook runs `make test-fast-parallel`, and it fails only on `ga-rs02h`. Disclosing
rather than burying it.

## Diff shape

- `cmd/gc/cmd_convoy_dispatch.go` — new `sourceWorkflowWriteTarget` +
  `resolveSourceWorkflowWriteTarget` / `appendSourceWorkflowCopy` /
  `sameSourceWorkflowCopy` / `clearSourceWorkflowTwins` /
  `clearWorkflowIDOnCopy`; `clearSourceWorkflowMetadata` rewritten on top of
  them and given a `stderr` parameter; `cmdWorkflowReopenSource`'s five writes
  moved onto the owning copy.
- `cmd/gc/cmd_convoy_dispatch_test.go` — five rows, three helpers, one
  `faultingClassStore` method.
- `CHANGELOG.md` — `[Unreleased] / ### Fixed`.

Refs ga-4kivg, ga-gqc9e, ga-j4p3y.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5987 — applies that issue's converge-both-copies approach to `gc workflow delete-source` and `reopen-source` — the write now lands on the copy the residency contract owns, and every other resident copy's stale `workflow_id` is cleared best-effort so the two cannot disagree. It covers only that one metadata key on those two commands; the lifecycle-status divergence that drives the re-dispatch loop is untouched, since status is deliberately written on the owning copy alone.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->