### PR TITLE
test(cmd/gc): restore the guarded-alias stale-cache precondition after the partial-cache change

### DIFF
--- a/cmd/gc/pool_session_identifier_lock_test.go
+++ b/cmd/gc/pool_session_identifier_lock_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sort"
@@ -541,12 +542,21 @@ func TestCreatePoolSessionBeadWithGuardedAlias_LiveRecensusBypassesStaleForeignC
 	rigPath := t.TempDir()
 	primaryBacking := beads.NewMemStore()
 	primary := beads.NewCachingStoreForTest(primaryBacking, nil)
-	if err := primary.PrimeActive(); err != nil {
+	// Both caches are fully primed (cacheLive) rather than active-only. A
+	// partial prime answers no broad non-closed list query from cache at all,
+	// so the ordinary census below would fall back to the backing store and
+	// observe the external write immediately, collapsing the staleness window
+	// this test exists to reproduce. A fully primed cache serves that census
+	// from its own snapshot, which is the production shape: complete as of the
+	// prime and still blind to a later write committed by another process.
+	// Note the two unrelated senses of "live" here: this is the cache STATE,
+	// whereas the lock-time recensus bypass below is session.ListAllOptions.Live.
+	if err := primary.Prime(context.Background()); err != nil {
 		t.Fatalf("prime primary cache: %v", err)
 	}
 	foreignBacking := beads.NewMemStore()
 	foreign := beads.NewCachingStoreForTest(foreignBacking, nil)
-	if err := foreign.PrimeActive(); err != nil {
+	if err := foreign.Prime(context.Background()); err != nil {
 		t.Fatalf("prime foreign cache: %v", err)
 	}
 	maxSessions := 2


### PR DESCRIPTION
## Summary

`main` fails `make test` deterministically at 407114321, so anything gating on a
green `main` is blocked. This restores the failing test.

`TestCreatePoolSessionBeadWithGuardedAlias_LiveRecensusBypassesStaleForeignCache`
seeds a session holder straight into the foreign backing store, then asserts two
things in order. First, that an ordinary cache-served census misses that holder.
Second, that the lock-time recensus, which reads through with
`session.ListAllOptions{Live: true}`, still refuses the exact-name collision.

The first assertion is a precondition, not the behavior under test. It
establishes that the cache really is stale, so that the second assertion is
exercising the read-through rather than passing for free.

That precondition was built on partial-prime blindness. `PrimeActive` leaves the
cache in `cachePartial`, and a partial cache used to answer the census's broad
non-closed list query from its own incomplete snapshot, which had never loaded
the holder.

#5276 changed that deliberately. Partial caches now read through to the backing
store for broad non-closed queries, so an incomplete snapshot can no longer hide
blocked work. The ordinary census therefore sees the external write immediately,
and the precondition assertion fails before the behavior under test ever runs.

Neither change is wrong on its own. The test landed in #4789 on 2026-08-28 and
passed CI; #5276 passed CI; the two only conflict in the merged tree, which is
why no per-PR gate caught it.

## Fix

Prime both caches fully instead of active-only. A complete snapshot is still
served from cache for the broad query, and it is still blind to a write another
process commits directly to the backing store afterwards. That is the production
shape of the race the test models: complete as of the prime, stale from then on.

No production code changes. Both assertions are untouched.

## Why this is not a weakened test

With the fix applied, flipping the lock-time recensus from `Live: true` to
`Live: false` makes the test fail at the second assertion
(`guarded create error = <nil>`). Remove the behavior and the test still catches
it.

The alternative reading, that #5276 exposed a defect in the session census path,
does not hold. The fallback makes the census fresher, and a fresher census cannot
introduce this race. The lock-time read-through is still needed because a write
can land between the census and the lock.

## Test plan

- `make test` at this head: pass
- `go test ./cmd/gc -count=1`
- `go vet ./cmd/gc ./internal/beads`
- Bisected: green at 69f29eebf (parent of the #5276 squash), red at 0e7adb38d
- Mutation check described above, run against this head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
