### PR TITLE
Prevent reconciler pool-slot paths from clobbering worktree evidence

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -792,6 +792,17 @@ func buildDesiredStateWithSessionBeadsAt(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
+		// One-shot repair for beads a prior reconciler tick already clobbered
+		// (ga-3c5isi / #5193): restores gc.work_dir from the still-intact
+		// legacy work_dir when the canonical value was overwritten with a
+		// pool-slot label before workDirStampWouldClobberEvidence existed to
+		// prevent it. Idempotent — see repairPoolSlotWorkDirClobber. Runs
+		// BEFORE the stamp below: stampRunSessionIdentity writes through the
+		// store without refreshing assignedWorkBeads, so a sweep placed after
+		// it would read pre-stamp metadata and could undo a legitimate fresh
+		// stamp. Repair reads the snapshot it was collected with; the live
+		// stamp gets the last word.
+		repairPoolSlotWorkDirClobber(cfg, assignedWorkBeads, assignedWorkStores, stderr)
 		// Durably record which session is executing each in-progress work
 		// bead. The Assignee link is transient (cleared on close), so without
 		// this a completed run carries no session/worktree reference. See
@@ -799,13 +810,7 @@ func buildDesiredStateWithSessionBeadsAt(
 		// storePartial: stamping the beads that WERE collected is always
 		// correct, and any bead missed by a partial query simply gets stamped
 		// on a later tick.
-		stampRunSessionIdentity(assignedWorkBeads, assignedWorkStores, sessionBeads, stderr)
-		// One-shot repair for beads a prior reconciler tick already clobbered
-		// (ga-3c5isi / #5193): restores gc.work_dir from the still-intact
-		// legacy work_dir when the canonical value was overwritten with a
-		// pool-slot label before workDirStampWouldClobberEvidence existed to
-		// prevent it. Idempotent — see repairPoolSlotWorkDirClobber.
-		repairPoolSlotWorkDirClobber(assignedWorkBeads, assignedWorkStores, stderr)
+		stampRunSessionIdentity(cfg, assignedWorkBeads, assignedWorkStores, sessionBeads, stderr)
 		// Re-home work pre-assigned to a legacy template identity onto the
 		// configured canonical identity, so the canonical session the awake/scale
 		// accounting wakes for it can actually surface and claim it (the
@@ -821,12 +826,14 @@ func buildDesiredStateWithSessionBeadsAt(
 		subPhaseStart = time.Now()
 		var unassignedRoutedPartial bool
 		unassignedRoutedBeads, unassignedRoutedStores, unassignedRoutedStoreRefs, unassignedRoutedPartial = collectOpenUnassignedRoutedWork(cityPath, cfg, store, rigStores, suspendedRigPaths, stderr)
-		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
 		// Same repair as above, over the open/unassigned collection: a bead
 		// released back to open by a drain is clobbered the same way an
 		// in_progress one is, and never appears in assignedWorkBeads once
-		// reopened.
-		repairPoolSlotWorkDirClobber(unassignedRoutedBeads, unassignedRoutedStores, stderr)
+		// reopened. Ordered first here for the same reason as the assigned
+		// site: the sweep reads the snapshot it was collected with, before any
+		// later pass writes through the store behind it.
+		repairPoolSlotWorkDirClobber(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
+		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
 		// Same pass, same reason, different legacy form: a route stamped at a
 		// live slot ("<base>-N") is a load-balancing HINT that every raw reader
 		// — the generated query's --metadata-field, the claim's string compare —
@@ -5011,7 +5018,7 @@ func sessionBeadIdentifierInfo(info session.Info) string {
 // only a newly claimed (or reassigned) bead triggers a single write. A write
 // failure is logged and skipped — stamping is best-effort observability and
 // must never block reconciliation.
-func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, sessionBeads *sessionBeadSnapshot, stderr io.Writer) {
+func stampRunSessionIdentity(cfg *config.City, workBeads []beads.Bead, workStores []beads.Store, sessionBeads *sessionBeadSnapshot, stderr io.Writer) {
 	if sessionBeads == nil || len(workBeads) != len(workStores) {
 		return
 	}
@@ -5047,7 +5054,7 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		}
 		if workDir != "" && strings.TrimSpace(wb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
 			(!sbInfo.PoolManaged || workDirStampHasOwnershipEvidence(wb.Metadata, workDir)) &&
-			!workDirStampWouldClobberEvidence(wb.Metadata, workDir) {
+			!workDirStampWouldClobberEvidence(cfg, wb.Metadata, workDir) {
 			patch[beadmeta.WorkDirMetadataKey] = workDir
 		}
 		if len(patch) > 0 {
@@ -5060,7 +5067,7 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		// workBeads and route-time stamping skips it for pool agents. The
 		// dashboard's root-only snapshot reads the root's own metadata, so a
 		// worked step back-fills its root via gc.root_bead_id. (#2843)
-		stampRunRootFromStep(store, wb, sessionName, workDir, !sbInfo.PoolManaged, stampedRoots, stderr)
+		stampRunRootFromStep(cfg, store, wb, sessionName, workDir, !sbInfo.PoolManaged, stampedRoots, stderr)
 	}
 }
 
@@ -5082,7 +5089,7 @@ func workDirStampHasOwnershipEvidence(metadata map[string]string, workDir string
 // the root and writes only the keys that differ. Best-effort — a root that is
 // in another store, already gone, or already stamped is silently skipped (a
 // cross-store root gets stamped on its own store's reconcile pass).
-func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workDir string, allowUnownedWorkDir bool, stampedRoots map[string]struct{}, stderr io.Writer) {
+func stampRunRootFromStep(cfg *config.City, store beads.Store, step beads.Bead, sessionName, workDir string, allowUnownedWorkDir bool, stampedRoots map[string]struct{}, stderr io.Writer) {
 	rootID := strings.TrimSpace(step.Metadata[beadmeta.RootBeadIDMetadataKey])
 	if rootID == "" || rootID == step.ID {
 		return
@@ -5103,7 +5110,7 @@ func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workD
 	}
 	if workDir != "" && strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
 		(allowUnownedWorkDir || workDirStampHasOwnershipEvidence(root.Metadata, workDir)) &&
-		!workDirStampWouldClobberEvidence(root.Metadata, workDir) {
+		!workDirStampWouldClobberEvidence(cfg, root.Metadata, workDir) {
 		patch[beadmeta.WorkDirMetadataKey] = workDir
 	}
 	if len(patch) == 0 {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5033,7 +5033,8 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 			patch[beadmeta.SessionNameMetadataKey] = sessionName
 		}
 		if workDir != "" && strings.TrimSpace(wb.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
-			(!sbInfo.PoolManaged || workDirStampHasOwnershipEvidence(wb.Metadata, workDir)) {
+			(!sbInfo.PoolManaged || workDirStampHasOwnershipEvidence(wb.Metadata, workDir)) &&
+			!workDirStampWouldClobberEvidence(wb.Metadata, workDir) {
 			patch[beadmeta.WorkDirMetadataKey] = workDir
 		}
 		if len(patch) > 0 {
@@ -5088,7 +5089,8 @@ func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workD
 		patch[beadmeta.SessionNameMetadataKey] = sessionName
 	}
 	if workDir != "" && strings.TrimSpace(root.Metadata[beadmeta.WorkDirMetadataKey]) != workDir &&
-		(allowUnownedWorkDir || workDirStampHasOwnershipEvidence(root.Metadata, workDir)) {
+		(allowUnownedWorkDir || workDirStampHasOwnershipEvidence(root.Metadata, workDir)) &&
+		!workDirStampWouldClobberEvidence(root.Metadata, workDir) {
 		patch[beadmeta.WorkDirMetadataKey] = workDir
 	}
 	if len(patch) == 0 {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -798,6 +798,12 @@ func buildDesiredStateWithSessionBeadsAt(
 		// correct, and any bead missed by a partial query simply gets stamped
 		// on a later tick.
 		stampRunSessionIdentity(assignedWorkBeads, assignedWorkStores, sessionBeads, stderr)
+		// One-shot repair for beads a prior reconciler tick already clobbered
+		// (ga-3c5isi / #5193): restores gc.work_dir from the still-intact
+		// legacy work_dir when the canonical value was overwritten with a
+		// pool-slot label before workDirStampWouldClobberEvidence existed to
+		// prevent it. Idempotent — see repairPoolSlotWorkDirClobber.
+		repairPoolSlotWorkDirClobber(assignedWorkBeads, assignedWorkStores, stderr)
 		// Re-home work pre-assigned to a legacy template identity onto the
 		// configured canonical identity, so the canonical session the awake/scale
 		// accounting wakes for it can actually surface and claim it (the
@@ -814,6 +820,11 @@ func buildDesiredStateWithSessionBeadsAt(
 		var unassignedRoutedPartial bool
 		unassignedRoutedBeads, unassignedRoutedStores, unassignedRoutedStoreRefs, unassignedRoutedPartial = collectOpenUnassignedRoutedWork(cityPath, cfg, store, rigStores, suspendedRigPaths, stderr)
 		canonicalizeLegacyBoundUnassignedRoutedWork(cfg, unassignedRoutedBeads, unassignedRoutedStores, stderr)
+		// Same repair as above, over the open/unassigned collection: a bead
+		// released back to open by a drain is clobbered the same way an
+		// in_progress one is, and never appears in assignedWorkBeads once
+		// reopened.
+		repairPoolSlotWorkDirClobber(unassignedRoutedBeads, unassignedRoutedStores, stderr)
 		// Same pass, same reason, different legacy form: a route stamped at a
 		// live slot ("<base>-N") is a load-balancing HINT that every raw reader
 		// — the generated query's --metadata-field, the claim's string compare —

--- a/cmd/gc/build_desired_state_session_stamp_test.go
+++ b/cmd/gc/build_desired_state_session_stamp_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -41,7 +42,7 @@ func TestStampRunSessionIdentityStampsInProgressAssignedBead(t *testing.T) {
 	store := &countingStore{Store: mem}
 	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sessionName, workDir)})
 
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 	got, err := mem.Get("co-run1")
 	if err != nil {
@@ -57,7 +58,7 @@ func TestStampRunSessionIdentityStampsInProgressAssignedBead(t *testing.T) {
 	// Idempotent: a second pass over the now-stamped bead writes nothing.
 	stamped, _ := mem.Get("co-run1")
 	store.writes = 0
-	stampRunSessionIdentity([]beads.Bead{stamped}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{stamped}, []beads.Store{store}, sessions, io.Discard)
 	if store.writes != 0 {
 		t.Errorf("second pass wrote %d times, want 0 (stamp must be idempotent)", store.writes)
 	}
@@ -75,7 +76,7 @@ func TestStampRunSessionIdentityDoesNotManufactureWorktreeEvidence(t *testing.T)
 	poolSession.Metadata["pool_managed"] = "true"
 	sessions := newSessionBeadSnapshot([]beads.Bead{poolSession})
 
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 	got, err := mem.Get(run.ID)
 	if err != nil {
@@ -101,7 +102,7 @@ func TestStampRunSessionIdentityPropagatesToRunRoot(t *testing.T) {
 	store := &countingStore{Store: mem}
 	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sn, wd)})
 
-	stampRunSessionIdentity([]beads.Bead{step}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{step}, []beads.Store{store}, sessions, io.Discard)
 
 	gotStep, _ := mem.Get("gpk-step")
 	if gotStep.Metadata["gc.session_name"] != sn || gotStep.Metadata["gc.work_dir"] != wd {
@@ -118,7 +119,7 @@ func TestStampRunSessionIdentityPropagatesToRunRoot(t *testing.T) {
 	// Idempotent: a second pass writes nothing (step + root already stamped).
 	stamped, _ := mem.Get("gpk-step")
 	store.writes = 0
-	stampRunSessionIdentity([]beads.Bead{stamped}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{stamped}, []beads.Store{store}, sessions, io.Discard)
 	if store.writes != 0 {
 		t.Errorf("second pass wrote %d times, want 0 (step+root already stamped)", store.writes)
 	}
@@ -139,7 +140,7 @@ func TestStampRunSessionIdentityNamedSessionUsesAlias(t *testing.T) {
 	store := &countingStore{Store: mem}
 	sessions := newSessionBeadSnapshot([]beads.Bead{mayor})
 
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 	got, _ := mem.Get("dr-run")
 	if got.Metadata["gc.session_name"] != "mayor" {
@@ -185,7 +186,7 @@ func TestStampRunSessionIdentityResolvesByIDAndAliasHistory(t *testing.T) {
 			store := &countingStore{Store: mem}
 			sessions := newSessionBeadSnapshot([]beads.Bead{tc.sess})
 
-			stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+			stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 			got, _ := mem.Get("r")
 			if got.Metadata["gc.session_name"] != tc.wantName {
@@ -205,7 +206,7 @@ func TestStampRunSessionIdentitySkipsAmbiguousAssignee(t *testing.T) {
 	store := &countingStore{Store: mem}
 	sessions := newSessionBeadSnapshot([]beads.Bead{a, b})
 
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 	if store.writes != 0 {
 		t.Errorf("ambiguous assignee must not be stamped, got %d writes", store.writes)
@@ -221,7 +222,7 @@ func TestStampRunSessionIdentityReassignmentRestamps(t *testing.T) {
 	store := &countingStore{Store: mem}
 	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession("worker-b", "/new")})
 
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 	got, _ := mem.Get("co-run2")
 	if got.Metadata["gc.session_name"] != "worker-b" || got.Metadata["gc.work_dir"] != "/new" {
@@ -243,7 +244,7 @@ func TestStampRunSessionIdentitySkipsNonExecuting(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
 			store := &countingStore{Store: mem}
-			stampRunSessionIdentity([]beads.Bead{wb}, []beads.Store{store}, sessions, io.Discard)
+			stampRunSessionIdentity(gaConfig(), []beads.Bead{wb}, []beads.Store{store}, sessions, io.Discard)
 			if store.writes != 0 {
 				t.Errorf("expected no stamp, got %d writes", store.writes)
 			}
@@ -257,9 +258,9 @@ func TestStampRunSessionIdentityToleratesLengthMismatchAndNilSnapshot(t *testing
 	store := &countingStore{Store: mem}
 
 	// Mismatched slice lengths must be a no-op, not a panic.
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{}, newSessionBeadSnapshot(nil), io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{}, newSessionBeadSnapshot(nil), io.Discard)
 	// Nil snapshot must be a no-op, not a panic.
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, nil, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, nil, io.Discard)
 	if store.writes != 0 {
 		t.Errorf("expected no writes on degenerate input, got %d", store.writes)
 	}
@@ -287,7 +288,7 @@ func TestStampRunSessionIdentityPreservesRealEvidenceAgainstPoolSlotSelfCwd(t *t
 	// Not pool_managed: stampTestSession leaves pool_managed unset/false.
 	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sessionName, poolSlotSelf)})
 
-	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+	stampRunSessionIdentity(gaConfig(), []beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
 
 	got, err := mem.Get(run.ID)
 	if err != nil {
@@ -295,5 +296,91 @@ func TestStampRunSessionIdentityPreservesRealEvidenceAgainstPoolSlotSelfCwd(t *t
 	}
 	if got.Metadata["gc.work_dir"] != realEvidence {
 		t.Fatalf("gc.work_dir = %q, want %q (real worktree evidence must survive a pool-slot-shaped self cwd)", got.Metadata["gc.work_dir"], realEvidence)
+	}
+}
+
+func TestStampRunRootFromStepPreservesRootEvidenceAgainstPoolSlotCwd(t *testing.T) {
+	// The root back-fill carries the same guard as the step stamp, and needs
+	// its own behavior coverage: a non-pool session running from a pool slot
+	// satisfies allowUnownedWorkDir, so without workDirStampWouldClobberEvidence
+	// the root's real per-bead worktree evidence is overwritten with the slot
+	// label -- and the root is the bead the dashboard's root-only snapshot reads.
+	const (
+		sessionName  = "gascity--builder-1"
+		poolSlotSelf = "/home/jaword/projects/gc-management/.gc/worktrees/gascity/builder-1"
+		realEvidence = "/home/ds/gascity-worktrees/ga-3c5isi"
+	)
+	root := beads.Bead{
+		ID: "ga-root", Type: "molecule", Status: "in_progress",
+		Metadata: map[string]string{"gc.kind": "workflow", "gc.work_dir": realEvidence},
+	}
+	step := beads.Bead{
+		ID: "ga-step", Type: "step", Status: "in_progress", Assignee: sessionName,
+		Metadata: map[string]string{"gc.root_bead_id": "ga-root"},
+	}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{root, step}, nil)
+	store := &countingStore{Store: mem}
+
+	stampRunRootFromStep(gaConfig(), store, step, sessionName, poolSlotSelf, true, map[string]struct{}{}, io.Discard)
+
+	gotRoot, err := mem.Get("ga-root")
+	if err != nil {
+		t.Fatalf("Get(ga-root): %v", err)
+	}
+	if gotRoot.Metadata["gc.work_dir"] != realEvidence {
+		t.Errorf("root gc.work_dir = %q, want %q (real worktree evidence must survive a pool-slot cwd)",
+			gotRoot.Metadata["gc.work_dir"], realEvidence)
+	}
+	// The session_name half of the back-fill is unaffected by the work_dir guard.
+	if gotRoot.Metadata["gc.session_name"] != sessionName {
+		t.Errorf("root gc.session_name = %q, want %q", gotRoot.Metadata["gc.session_name"], sessionName)
+	}
+}
+
+func TestRepairPoolSlotWorkDirClobberThenStampPreservesLiveWorkDir(t *testing.T) {
+	// Ordering regression: the reconciler collects the work slice once and
+	// neither pass refreshes it, so a repair sweep placed AFTER
+	// stampRunSessionIdentity re-reads pre-stamp metadata and reverts the
+	// freshly stamped canonical back to the stale legacy value.
+	// Reconciliation runs repair first, then the live stamp, so the session's
+	// real path survives one full pass.
+	const (
+		sessionName = "gascity--worker-gc-7"
+		liveWorkDir = "/home/ds/gascity-worktrees/ga-live"
+		staleLegacy = "/home/ds/gascity-worktrees/ga-stale"
+		poolSlot    = ".gc/worktrees/gascity/builder-1"
+	)
+	newRun := func() beads.Bead {
+		return beads.Bead{
+			ID: "ga-run", Type: "task", Status: "in_progress", Assignee: sessionName,
+			Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       poolSlot,
+				beadmeta.LegacyWorkDirMetadataKey: staleLegacy,
+			},
+		}
+	}
+	// The store's bead and the collected snapshot must not share a metadata
+	// map: a store query returns clones, so writes through the store are
+	// invisible to the already-collected slice. MemStore seeded from the same
+	// value would alias the map and mask the ordering bug entirely.
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{newRun()}, nil)
+	store := &countingStore{Store: mem}
+	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sessionName, liveWorkDir)})
+	cfg := gaConfig()
+
+	// Same order, and the same collected-once slice, as
+	// buildDesiredStateWithSessionBeadsAt.
+	snapshot := []beads.Bead{newRun()}
+	stores := []beads.Store{store}
+	repairPoolSlotWorkDirClobber(cfg, snapshot, stores, io.Discard)
+	stampRunSessionIdentity(cfg, snapshot, stores, sessions, io.Discard)
+
+	got, err := mem.Get("ga-run")
+	if err != nil {
+		t.Fatalf("Get(ga-run): %v", err)
+	}
+	if got.Metadata[beadmeta.WorkDirMetadataKey] != liveWorkDir {
+		t.Errorf("gc.work_dir = %q, want %q (live stamp must get the last word over the repair sweep)",
+			got.Metadata[beadmeta.WorkDirMetadataKey], liveWorkDir)
 	}
 }

--- a/cmd/gc/build_desired_state_session_stamp_test.go
+++ b/cmd/gc/build_desired_state_session_stamp_test.go
@@ -264,3 +264,36 @@ func TestStampRunSessionIdentityToleratesLengthMismatchAndNilSnapshot(t *testing
 		t.Errorf("expected no writes on degenerate input, got %d", store.writes)
 	}
 }
+
+func TestStampRunSessionIdentityPreservesRealEvidenceAgainstPoolSlotSelfCwd(t *testing.T) {
+	// ga-3c5isi / #5193: a session whose OWN bead never carries
+	// pool_managed=true (a manual/named session, or a pool session mid
+	// classification) can still be physically running from a pool slot's own
+	// worktree root. Before this guard, !sbInfo.PoolManaged alone satisfied
+	// the stamp condition and gc.work_dir was overwritten unconditionally
+	// from that session's cwd -- clobbering real per-bead worktree evidence
+	// already on the work bead with a pool-slot label.
+	const (
+		sessionName  = "gascity--builder-1"
+		poolSlotSelf = "/home/jaword/projects/gc-management/.gc/worktrees/gascity/builder-1"
+		realEvidence = "/home/ds/gascity-worktrees/ga-3c5isi"
+	)
+	run := beads.Bead{
+		ID: "ga-3c5isi", Type: "task", Status: "in_progress", Assignee: sessionName,
+		Metadata: map[string]string{"gc.work_dir": realEvidence},
+	}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+	// Not pool_managed: stampTestSession leaves pool_managed unset/false.
+	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sessionName, poolSlotSelf)})
+
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+	got, err := mem.Get(run.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", run.ID, err)
+	}
+	if got.Metadata["gc.work_dir"] != realEvidence {
+		t.Fatalf("gc.work_dir = %q, want %q (real worktree evidence must survive a pool-slot-shaped self cwd)", got.Metadata["gc.work_dir"], realEvidence)
+	}
+}

--- a/cmd/gc/pool_slot_workdir.go
+++ b/cmd/gc/pool_slot_workdir.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// isPoolSlotWorkDirRoot reports whether path is shaped exactly like a pool
+// slot's own worktree root (.gc/worktrees/<rig>/<role>) -- a session-slot
+// label, not evidence that a bead owns a real per-bead worktree. It matches
+// both the city-relative form worktree-per-bead dispatch normally stores
+// (see resolveWorkDirAgainstCity) and the equivalent absolute form (legacy
+// convention): the match is on the LAST FOUR path segments only, so a
+// deeper per-bead path nested under a pool slot (.gc/worktrees/<rig>/<role>/<slug>)
+// or a differently-rooted worktree (worktrees/<bead-id>, .claude/worktrees/...)
+// correctly does not match.
+func isPoolSlotWorkDirRoot(_ string) bool {
+	return false
+}
+
+// workDirStampWouldClobberEvidence reports whether stamping workDir onto a
+// work (or molecule root) bead currently holding metadata would overwrite
+// genuine worktree evidence with a pool-slot label. It keys off the SHAPE of
+// the canonical value already on the bead and the shape of the incoming
+// value, rather than the executing session's self-reported pool_managed
+// status -- closing the gap where a session physically running from a pool
+// slot but whose own session bead never carries pool_managed=true could
+// otherwise bypass workDirStampHasOwnershipEvidence entirely.
+func workDirStampWouldClobberEvidence(_ map[string]string, _ string) bool {
+	return false
+}
+
+// poolSlotWorkDirRepair describes a one-shot repair for a bead whose
+// canonical gc.work_dir was clobbered with a pool-slot label while its
+// legacy work_dir still carries the real per-bead worktree evidence.
+type poolSlotWorkDirRepair struct {
+	// RestoreValue is the legacy work_dir value gc.work_dir should be reset to.
+	RestoreValue string
+}
+
+// poolSlotWorkDirRepairFor reports the repair needed for bead b, or nil if
+// none is needed: both gc.work_dir and work_dir must be set and unequal, and
+// gc.work_dir must match a pool-slot root exactly (isPoolSlotWorkDirRoot) --
+// other shapes (e.g. a legacy work_dir pointing into .claude/worktrees) are
+// left untouched rather than blanket-copied.
+func poolSlotWorkDirRepairFor(_ beads.Bead) *poolSlotWorkDirRepair {
+	return nil
+}

--- a/cmd/gc/pool_slot_workdir.go
+++ b/cmd/gc/pool_slot_workdir.go
@@ -7,18 +7,32 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // isPoolSlotWorkDirRoot reports whether path is shaped exactly like a pool
-// slot's own worktree root (.gc/worktrees/<rig>/<role>) -- a session-slot
+// slot's own worktree root (.gc/worktrees/<rig>/<slot>) -- a session-slot
 // label, not evidence that a bead owns a real per-bead worktree. It matches
 // both the city-relative form worktree-per-bead dispatch normally stores
 // (see resolveWorkDirAgainstCity) and the equivalent absolute form (legacy
-// convention): the match is on the LAST FOUR path segments only, so a
-// deeper per-bead path nested under a pool slot (.gc/worktrees/<rig>/<role>/<slug>)
-// or a differently-rooted worktree (worktrees/<bead-id>, .claude/worktrees/...)
-// correctly does not match.
-func isPoolSlotWorkDirRoot(path string) bool {
+// convention).
+//
+// Shape alone is not sufficient: per-bead worktrees are SIBLINGS of pool
+// slots under .gc/worktrees/<rig>/ (the same layout bead_worktree_reaper.go
+// guards with sessionHomes), so .gc/worktrees/gascity/ga-ui3mbs sits at the
+// exact depth a slot does. The final segment is therefore checked against the
+// city's configured bead prefixes: a name that resolves to a bead ID
+// ("ga-ui3mbs", "ga-klo4gz.11-measure") is a per-bead worktree, not a slot,
+// while "builder-1" / "builder-feature-branch" have no configured prefix and
+// stay slots.
+//
+// The match is on the LAST FOUR path segments only, so a deeper per-bead path
+// nested under a pool slot (.gc/worktrees/<rig>/<slot>/<slug>) or a
+// differently-rooted worktree (worktrees/<bead-id>, .claude/worktrees/...)
+// correctly does not match. Deeper slot layouts
+// (.gc/worktrees/<rig>/<pool>/<slot>) likewise do not match; both the guard
+// and the repair are simply inert there, which fails safe.
+func isPoolSlotWorkDirRoot(cfg *config.City, path string) bool {
 	var segments []string
 	for _, s := range strings.Split(path, "/") {
 		if s != "" {
@@ -29,7 +43,10 @@ func isPoolSlotWorkDirRoot(path string) bool {
 		return false
 	}
 	last4 := segments[len(segments)-4:]
-	return last4[0] == ".gc" && last4[1] == "worktrees"
+	if last4[0] != ".gc" || last4[1] != "worktrees" {
+		return false
+	}
+	return extractBeadIDFromWorktreeName(cfg, last4[3]) == ""
 }
 
 // workDirStampWouldClobberEvidence reports whether stamping workDir onto a
@@ -40,15 +57,28 @@ func isPoolSlotWorkDirRoot(path string) bool {
 // status -- closing the gap where a session physically running from a pool
 // slot but whose own session bead never carries pool_managed=true could
 // otherwise bypass workDirStampHasOwnershipEvidence entirely.
-func workDirStampWouldClobberEvidence(metadata map[string]string, workDir string) bool {
-	existing := metadata[beadmeta.WorkDirMetadataKey]
-	if existing == "" {
+//
+// When the canonical key is absent but the legacy key holds real, differing
+// evidence, a slot-shaped stamp is refused too: writing it manufactures
+// exactly the canonical/legacy disagreement worktreeSpecForBead fails closed
+// on, starving the bead instead of leaving it resolvable from legacy alone.
+//
+// Deliberately asymmetric with poolSlotWorkDirRepairFor on a nil cfg: without
+// config, isPoolSlotWorkDirRoot cannot recognize a per-bead name and errs
+// toward "is a slot". Here that only SUPPRESSES a write, which is harmless.
+// In the repair direction it would overwrite an accurate canonical, so
+// poolSlotWorkDirRepairFor bails out instead. Do not "simplify" the two into
+// a shared nil-cfg policy.
+func workDirStampWouldClobberEvidence(cfg *config.City, metadata map[string]string, workDir string) bool {
+	canonical := strings.TrimSpace(metadata[beadmeta.WorkDirMetadataKey])
+	legacy := strings.TrimSpace(metadata[beadmeta.LegacyWorkDirMetadataKey])
+	if canonical == "" {
+		return legacy != "" && legacy != workDir && isPoolSlotWorkDirRoot(cfg, workDir)
+	}
+	if isPoolSlotWorkDirRoot(cfg, canonical) {
 		return false
 	}
-	if isPoolSlotWorkDirRoot(existing) {
-		return false
-	}
-	return isPoolSlotWorkDirRoot(workDir)
+	return isPoolSlotWorkDirRoot(cfg, workDir)
 }
 
 // poolSlotWorkDirRepair describes a one-shot repair for a bead whose
@@ -60,20 +90,26 @@ type poolSlotWorkDirRepair struct {
 }
 
 // poolSlotWorkDirRepairFor reports the repair needed for bead b, or nil if
-// none is needed: both gc.work_dir and work_dir must be set and unequal, and
-// gc.work_dir must match a pool-slot root exactly (isPoolSlotWorkDirRoot) --
-// other shapes (e.g. a legacy work_dir pointing into .claude/worktrees) are
-// left untouched rather than blanket-copied.
-func poolSlotWorkDirRepairFor(b beads.Bead) *poolSlotWorkDirRepair {
-	if b.Metadata == nil {
+// none is needed: both gc.work_dir and work_dir must be non-blank and
+// unequal, and gc.work_dir must match a pool-slot root exactly
+// (isPoolSlotWorkDirRoot) -- other shapes (e.g. a legacy work_dir pointing
+// into .claude/worktrees) are left untouched rather than blanket-copied.
+//
+// A nil cfg skips the repair entirely. This direction WRITES, and without
+// config isPoolSlotWorkDirRoot cannot tell a per-bead worktree from a slot;
+// proceeding on shape alone would overwrite an accurate canonical with a
+// stale legacy path. See the note on workDirStampWouldClobberEvidence, which
+// keeps shape-only behavior because erring there only suppresses a write.
+func poolSlotWorkDirRepairFor(cfg *config.City, b beads.Bead) *poolSlotWorkDirRepair {
+	if cfg == nil || b.Metadata == nil {
 		return nil
 	}
-	canonical, hasCanonical := b.Metadata[beadmeta.WorkDirMetadataKey]
-	legacy, hasLegacy := b.Metadata[beadmeta.LegacyWorkDirMetadataKey]
-	if !hasCanonical || !hasLegacy || canonical == legacy {
+	canonical := strings.TrimSpace(b.Metadata[beadmeta.WorkDirMetadataKey])
+	legacy := strings.TrimSpace(b.Metadata[beadmeta.LegacyWorkDirMetadataKey])
+	if canonical == "" || legacy == "" || canonical == legacy {
 		return nil
 	}
-	if !isPoolSlotWorkDirRoot(canonical) {
+	if !isPoolSlotWorkDirRoot(cfg, canonical) {
 		return nil
 	}
 	return &poolSlotWorkDirRepair{RestoreValue: legacy}
@@ -89,12 +125,17 @@ func poolSlotWorkDirRepairFor(b beads.Bead) *poolSlotWorkDirRepair {
 // progress -- gating on status here would leave one of the two shapes found
 // in the wild across gascity/beads/BEADS permanently unrepaired.
 //
+// Run it BEFORE stampRunSessionIdentity on the same snapshot: the stamp
+// writes through the store without refreshing the in-memory slice, so a
+// sweep placed after it reads pre-stamp metadata and can undo a legitimate
+// fresh stamp. Repair first, live stamp last.
+//
 // Idempotent by design: once gc.work_dir is restored to the legacy value the
 // two keys are equal and poolSlotWorkDirRepairFor returns nil, so
 // steady-state reconciles after the first repair perform no writes. A write
 // failure is logged and skipped -- recovery is best-effort and must never
 // block reconciliation.
-func repairPoolSlotWorkDirClobber(workBeads []beads.Bead, workStores []beads.Store, stderr io.Writer) {
+func repairPoolSlotWorkDirClobber(cfg *config.City, workBeads []beads.Bead, workStores []beads.Store, stderr io.Writer) {
 	if len(workBeads) != len(workStores) {
 		return
 	}
@@ -103,7 +144,7 @@ func repairPoolSlotWorkDirClobber(workBeads []beads.Bead, workStores []beads.Sto
 		if store == nil {
 			continue
 		}
-		repair := poolSlotWorkDirRepairFor(wb)
+		repair := poolSlotWorkDirRepairFor(cfg, wb)
 		if repair == nil {
 			continue
 		}

--- a/cmd/gc/pool_slot_workdir.go
+++ b/cmd/gc/pool_slot_workdir.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -13,8 +18,18 @@ import (
 // deeper per-bead path nested under a pool slot (.gc/worktrees/<rig>/<role>/<slug>)
 // or a differently-rooted worktree (worktrees/<bead-id>, .claude/worktrees/...)
 // correctly does not match.
-func isPoolSlotWorkDirRoot(_ string) bool {
-	return false
+func isPoolSlotWorkDirRoot(path string) bool {
+	var segments []string
+	for _, s := range strings.Split(path, "/") {
+		if s != "" {
+			segments = append(segments, s)
+		}
+	}
+	if len(segments) < 4 {
+		return false
+	}
+	last4 := segments[len(segments)-4:]
+	return last4[0] == ".gc" && last4[1] == "worktrees"
 }
 
 // workDirStampWouldClobberEvidence reports whether stamping workDir onto a
@@ -25,8 +40,15 @@ func isPoolSlotWorkDirRoot(_ string) bool {
 // status -- closing the gap where a session physically running from a pool
 // slot but whose own session bead never carries pool_managed=true could
 // otherwise bypass workDirStampHasOwnershipEvidence entirely.
-func workDirStampWouldClobberEvidence(_ map[string]string, _ string) bool {
-	return false
+func workDirStampWouldClobberEvidence(metadata map[string]string, workDir string) bool {
+	existing := metadata[beadmeta.WorkDirMetadataKey]
+	if existing == "" {
+		return false
+	}
+	if isPoolSlotWorkDirRoot(existing) {
+		return false
+	}
+	return isPoolSlotWorkDirRoot(workDir)
 }
 
 // poolSlotWorkDirRepair describes a one-shot repair for a bead whose
@@ -42,6 +64,52 @@ type poolSlotWorkDirRepair struct {
 // gc.work_dir must match a pool-slot root exactly (isPoolSlotWorkDirRoot) --
 // other shapes (e.g. a legacy work_dir pointing into .claude/worktrees) are
 // left untouched rather than blanket-copied.
-func poolSlotWorkDirRepairFor(_ beads.Bead) *poolSlotWorkDirRepair {
-	return nil
+func poolSlotWorkDirRepairFor(b beads.Bead) *poolSlotWorkDirRepair {
+	if b.Metadata == nil {
+		return nil
+	}
+	canonical, hasCanonical := b.Metadata[beadmeta.WorkDirMetadataKey]
+	legacy, hasLegacy := b.Metadata[beadmeta.LegacyWorkDirMetadataKey]
+	if !hasCanonical || !hasLegacy || canonical == legacy {
+		return nil
+	}
+	if !isPoolSlotWorkDirRoot(canonical) {
+		return nil
+	}
+	return &poolSlotWorkDirRepair{RestoreValue: legacy}
+}
+
+// repairPoolSlotWorkDirClobber is the one-shot repair sweep for beads whose
+// canonical gc.work_dir was already clobbered with a pool-slot label by a
+// reconciler tick that predates workDirStampWouldClobberEvidence. Callers
+// pass it both the assigned (in_progress) and unassigned-routed (open) work
+// collections: poolSlotWorkDirRepairFor does not consult Status, and this
+// sweep deliberately does not add a status filter of its own, so a bead
+// released back to open by a drain is repaired exactly like one still in
+// progress -- gating on status here would leave one of the two shapes found
+// in the wild across gascity/beads/BEADS permanently unrepaired.
+//
+// Idempotent by design: once gc.work_dir is restored to the legacy value the
+// two keys are equal and poolSlotWorkDirRepairFor returns nil, so
+// steady-state reconciles after the first repair perform no writes. A write
+// failure is logged and skipped -- recovery is best-effort and must never
+// block reconciliation.
+func repairPoolSlotWorkDirClobber(workBeads []beads.Bead, workStores []beads.Store, stderr io.Writer) {
+	if len(workBeads) != len(workStores) {
+		return
+	}
+	for i, wb := range workBeads {
+		store := workStores[i]
+		if store == nil {
+			continue
+		}
+		repair := poolSlotWorkDirRepairFor(wb)
+		if repair == nil {
+			continue
+		}
+		patch := map[string]string{beadmeta.WorkDirMetadataKey: repair.RestoreValue}
+		if err := store.SetMetadataBatch(wb.ID, patch); err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "repairPoolSlotWorkDirClobber: %s: %v\n", wb.ID, err) //nolint:errcheck
+		}
+	}
 }

--- a/cmd/gc/pool_slot_workdir.go
+++ b/cmd/gc/pool_slot_workdir.go
@@ -65,10 +65,16 @@ func isPoolSlotWorkDirRoot(cfg *config.City, path string) bool {
 //
 // Deliberately asymmetric with poolSlotWorkDirRepairFor on a nil cfg: without
 // config, isPoolSlotWorkDirRoot cannot recognize a per-bead name and errs
-// toward "is a slot". Here that only SUPPRESSES a write, which is harmless.
-// In the repair direction it would overwrite an accurate canonical, so
-// poolSlotWorkDirRepairFor bails out instead. Do not "simplify" the two into
-// a shared nil-cfg policy.
+// toward "is a slot" for every four-segment .gc/worktrees path. That makes
+// this guard nil-inert in the INCOMING direction only: a slot-shaped incoming
+// value is still refused when the canonical is absent, but an EXISTING
+// canonical is misread as a slot too, hits the short-circuit below, and the
+// overwrite is PERMITTED -- so a nil cfg does not make this guard uniformly
+// conservative. The repair direction cannot tolerate even that, because it
+// writes, so poolSlotWorkDirRepairFor additionally refuses to act on a nil
+// cfg. Do not "simplify" the two into a shared nil-cfg policy. Neither branch
+// is reachable in production: every reconciler call site passes a loaded
+// config (city_runtime.go:3409 returns early on a nil filtered config).
 func workDirStampWouldClobberEvidence(cfg *config.City, metadata map[string]string, workDir string) bool {
 	canonical := strings.TrimSpace(metadata[beadmeta.WorkDirMetadataKey])
 	legacy := strings.TrimSpace(metadata[beadmeta.LegacyWorkDirMetadataKey])
@@ -93,13 +99,16 @@ type poolSlotWorkDirRepair struct {
 // none is needed: both gc.work_dir and work_dir must be non-blank and
 // unequal, and gc.work_dir must match a pool-slot root exactly
 // (isPoolSlotWorkDirRoot) -- other shapes (e.g. a legacy work_dir pointing
-// into .claude/worktrees) are left untouched rather than blanket-copied.
+// into .claude/worktrees) are left untouched rather than blanket-copied. The
+// legacy value must not itself be pool-slot shaped -- see the inline note on
+// that check below.
 //
 // A nil cfg skips the repair entirely. This direction WRITES, and without
 // config isPoolSlotWorkDirRoot cannot tell a per-bead worktree from a slot;
 // proceeding on shape alone would overwrite an accurate canonical with a
-// stale legacy path. See the note on workDirStampWouldClobberEvidence, which
-// keeps shape-only behavior because erring there only suppresses a write.
+// stale legacy path. See the note on workDirStampWouldClobberEvidence for the
+// other half of that asymmetry: it stays shape-only, which leaves it nil-inert
+// on an incoming value but NOT on an existing canonical.
 func poolSlotWorkDirRepairFor(cfg *config.City, b beads.Bead) *poolSlotWorkDirRepair {
 	if cfg == nil || b.Metadata == nil {
 		return nil
@@ -110,6 +119,14 @@ func poolSlotWorkDirRepairFor(cfg *config.City, b beads.Bead) *poolSlotWorkDirRe
 		return nil
 	}
 	if !isPoolSlotWorkDirRoot(cfg, canonical) {
+		return nil
+	}
+	// The repair's premise is that legacy still holds real per-bead evidence.
+	// A slot-shaped legacy is not that: promoting it would resolve the
+	// canonical/legacy conflict with another slot label and, on an
+	// open/unassigned bead (no later stamp to correct it), leave the bead
+	// pointed at a slot it does not own. Stay inert instead.
+	if isPoolSlotWorkDirRoot(cfg, legacy) {
 		return nil
 	}
 	return &poolSlotWorkDirRepair{RestoreValue: legacy}

--- a/cmd/gc/pool_slot_workdir_test.go
+++ b/cmd/gc/pool_slot_workdir_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestIsPoolSlotWorkDirRoot(t *testing.T) {
@@ -21,12 +22,42 @@ func TestIsPoolSlotWorkDirRoot(t *testing.T) {
 			path: "/home/jaword/projects/gc-management/.gc/worktrees/gascity/builder-1",
 			want: true,
 		},
+		"slot name with no configured bead prefix stays a slot": {
+			path: ".gc/worktrees/gascity/builder-feature-branch",
+			want: true,
+		},
 		"missing role segment": {
 			path: ".gc/worktrees/gascity",
 			want: false,
 		},
+		// Per-bead worktrees are SIBLINGS of pool slots at this exact depth in
+		// the default city layout, so shape alone cannot tell them apart. The
+		// configured-prefix check must reject these as slots, or the repair
+		// sweep overwrites their accurate canonical work_dir.
+		"bare per-bead worktree at slot depth": {
+			path: ".gc/worktrees/gascity/ga-ui3mbs",
+			want: false,
+		},
+		"absolute bare per-bead worktree at slot depth": {
+			path: "/home/jaword/projects/gc-management/.gc/worktrees/gascity/ga-ui3mbs",
+			want: false,
+		},
+		"compound per-bead worktree at slot depth": {
+			path: ".gc/worktrees/gascity/ga-klo4gz.11-measure",
+			want: false,
+		},
+		"hierarchical per-bead worktree at slot depth": {
+			path: ".gc/worktrees/gascity/ga-lvrcyp.3.1-post-init-retry",
+			want: false,
+		},
 		"per-bead worktree nested inside a pool slot": {
 			path: ".gc/worktrees/gascity/builder-1/ga-3c5isi",
+			want: false,
+		},
+		// Deeper slot layouts do not match the last-four check; guard and
+		// repair are both inert there, which fails safe.
+		"deeper pool slot layout is inert": {
+			path: ".gc/worktrees/frontend/polecats/polecat-1",
 			want: false,
 		},
 		"legacy per-bead worktree path": {
@@ -42,9 +73,10 @@ func TestIsPoolSlotWorkDirRoot(t *testing.T) {
 			want: false,
 		},
 	}
+	cfg := gaConfig()
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := isPoolSlotWorkDirRoot(tc.path); got != tc.want {
+			if got := isPoolSlotWorkDirRoot(cfg, tc.path); got != tc.want {
 				t.Errorf("isPoolSlotWorkDirRoot(%q) = %v, want %v", tc.path, got, tc.want)
 			}
 		})
@@ -55,6 +87,7 @@ func TestWorkDirStampWouldClobberEvidence(t *testing.T) {
 	const (
 		realEvidence      = "/home/ds/gascity-worktrees/ga-3c5isi"
 		otherRealEvidence = "/home/ds/gascity-worktrees/ga-other"
+		perBeadAtSlot     = ".gc/worktrees/gascity/ga-ui3mbs"
 		poolSlot          = ".gc/worktrees/gascity/builder-1"
 		otherPoolSlot     = ".gc/worktrees/gascity/builder-2"
 	)
@@ -68,9 +101,42 @@ func TestWorkDirStampWouldClobberEvidence(t *testing.T) {
 			workDir:  poolSlot,
 			want:     true,
 		},
+		// A per-bead worktree that happens to sit at slot depth is real
+		// evidence, not a slot label: it must be protected like any other.
+		"per-bead canonical at slot depth to pool slot label clobbers": {
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: perBeadAtSlot},
+			workDir:  poolSlot,
+			want:     true,
+		},
 		"absent to pool slot label is fine": {
 			metadata: map[string]string{},
 			workDir:  poolSlot,
+			want:     false,
+		},
+		// Canonical absent but legacy holding real, differing evidence:
+		// stamping a slot label here manufactures the canonical/legacy
+		// disagreement worktreeSpecForBead fails closed on.
+		"absent canonical with differing real legacy clobbers": {
+			metadata: map[string]string{beadmeta.LegacyWorkDirMetadataKey: realEvidence},
+			workDir:  poolSlot,
+			want:     true,
+		},
+		"whitespace-only canonical is treated as absent": {
+			metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       "   ",
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			},
+			workDir: poolSlot,
+			want:    true,
+		},
+		"absent canonical with legacy mirroring the incoming value is fine": {
+			metadata: map[string]string{beadmeta.LegacyWorkDirMetadataKey: poolSlot},
+			workDir:  poolSlot,
+			want:     false,
+		},
+		"absent canonical with real legacy but non-slot incoming is fine": {
+			metadata: map[string]string{beadmeta.LegacyWorkDirMetadataKey: realEvidence},
+			workDir:  otherRealEvidence,
 			want:     false,
 		},
 		"pool slot to different pool slot is fine": {
@@ -89,9 +155,10 @@ func TestWorkDirStampWouldClobberEvidence(t *testing.T) {
 			want:     false,
 		},
 	}
+	cfg := gaConfig()
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := workDirStampWouldClobberEvidence(tc.metadata, tc.workDir); got != tc.want {
+			if got := workDirStampWouldClobberEvidence(cfg, tc.metadata, tc.workDir); got != tc.want {
 				t.Errorf("workDirStampWouldClobberEvidence(%v, %q) = %v, want %v", tc.metadata, tc.workDir, got, tc.want)
 			}
 		})
@@ -101,40 +168,103 @@ func TestWorkDirStampWouldClobberEvidence(t *testing.T) {
 func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 	const (
 		poolSlot       = ".gc/worktrees/gascity/builder-1"
+		perBeadAtSlot  = ".gc/worktrees/gascity/ga-ui3mbs"
+		compoundAtSlot = ".gc/worktrees/gascity/ga-klo4gz.11-measure"
 		realEvidence   = "/home/ds/gascity-worktrees/ga-3c5isi"
+		staleLegacy    = "/home/ds/gascity-worktrees/ga-stale"
 		claudeWorktree = ".claude/worktrees/ga-45tz5p"
 	)
 	cases := map[string]struct {
+		cfg  *config.City
 		bead beads.Bead
 		want *poolSlotWorkDirRepair
 	}{
 		"pool-slot canonical with differing legacy needs repair": {
+			cfg: gaConfig(),
 			bead: beads.Bead{Metadata: map[string]string{
 				beadmeta.WorkDirMetadataKey:       poolSlot,
 				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 			}},
 			want: &poolSlotWorkDirRepair{RestoreValue: realEvidence},
 		},
+		// The accurate canonical of a per-bead worktree living at slot depth
+		// must survive: repairing it would relocate a live bead to a stale
+		// legacy path.
+		"bare per-bead canonical at slot depth is left untouched": {
+			cfg: gaConfig(),
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       perBeadAtSlot,
+				beadmeta.LegacyWorkDirMetadataKey: staleLegacy,
+			}},
+			want: nil,
+		},
+		"compound per-bead canonical at slot depth is left untouched": {
+			cfg: gaConfig(),
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       compoundAtSlot,
+				beadmeta.LegacyWorkDirMetadataKey: staleLegacy,
+			}},
+			want: nil,
+		},
+		// Without config the classifier cannot tell a per-bead worktree from a
+		// slot, and this direction WRITES -- so it must skip entirely rather
+		// than fall back to shape-only matching.
+		"nil cfg performs no repair": {
+			cfg: nil,
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       poolSlot,
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			}},
+			want: nil,
+		},
 		"already equal needs no repair": {
+			cfg: gaConfig(),
 			bead: beads.Bead{Metadata: map[string]string{
 				beadmeta.WorkDirMetadataKey:       realEvidence,
 				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 			}},
 			want: nil,
 		},
+		"equal after trimming needs no repair": {
+			cfg: gaConfig(),
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       realEvidence,
+				beadmeta.LegacyWorkDirMetadataKey: "  " + realEvidence + "  ",
+			}},
+			want: nil,
+		},
+		"whitespace-only legacy is treated as absent": {
+			cfg: gaConfig(),
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       poolSlot,
+				beadmeta.LegacyWorkDirMetadataKey: "   ",
+			}},
+			want: nil,
+		},
+		"whitespace-only canonical is treated as absent": {
+			cfg: gaConfig(),
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       " ",
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			}},
+			want: nil,
+		},
 		"canonical only needs no repair": {
+			cfg: gaConfig(),
 			bead: beads.Bead{Metadata: map[string]string{
 				beadmeta.WorkDirMetadataKey: poolSlot,
 			}},
 			want: nil,
 		},
 		"legacy only needs no repair": {
+			cfg: gaConfig(),
 			bead: beads.Bead{Metadata: map[string]string{
 				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 			}},
 			want: nil,
 		},
 		"canonical unequal but not pool-slot shaped (ga-45tz5p) is excluded": {
+			cfg: gaConfig(),
 			bead: beads.Bead{Metadata: map[string]string{
 				beadmeta.WorkDirMetadataKey:       claudeWorktree,
 				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
@@ -142,13 +272,14 @@ func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 			want: nil,
 		},
 		"nil metadata needs no repair": {
+			cfg:  gaConfig(),
 			bead: beads.Bead{},
 			want: nil,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := poolSlotWorkDirRepairFor(tc.bead)
+			got := poolSlotWorkDirRepairFor(tc.cfg, tc.bead)
 			if (got == nil) != (tc.want == nil) {
 				t.Fatalf("poolSlotWorkDirRepairFor() = %v, want %v", got, tc.want)
 			}
@@ -169,8 +300,11 @@ func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 // in_progress ones, so this sweep must not gate on bead status.
 func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 	const (
-		poolSlot     = ".gc/worktrees/gascity/builder-1"
-		realEvidence = "/home/ds/gascity-worktrees/ga-3c5isi"
+		poolSlot      = ".gc/worktrees/gascity/builder-1"
+		perBeadAtSlot = ".gc/worktrees/gascity/ga-ui3mbs"
+		compoundSlot  = ".gc/worktrees/gascity/ga-klo4gz.11-measure"
+		realEvidence  = "/home/ds/gascity-worktrees/ga-3c5isi"
+		staleLegacy   = "/home/ds/gascity-worktrees/ga-stale"
 	)
 	clobbered := beads.Bead{
 		ID: "ga-clobbered", Type: "task", Status: "open",
@@ -186,6 +320,22 @@ func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 			beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 		},
 	}
+	// A per-bead worktree sitting at the same depth as a pool slot: its
+	// canonical value is accurate and must not be reverted to a stale legacy.
+	perBead := beads.Bead{
+		ID: "ga-ui3mbs", Type: "task", Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       perBeadAtSlot,
+			beadmeta.LegacyWorkDirMetadataKey: staleLegacy,
+		},
+	}
+	compound := beads.Bead{
+		ID: "ga-klo4gz.11", Type: "task", Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       compoundSlot,
+			beadmeta.LegacyWorkDirMetadataKey: staleLegacy,
+		},
+	}
 	excluded := beads.Bead{
 		ID: "ga-45tz5p", Type: "task", Status: "open",
 		Metadata: map[string]string{
@@ -193,12 +343,13 @@ func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 			beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 		},
 	}
-	mem := beads.NewMemStoreFrom(0, []beads.Bead{clobbered, clean, excluded}, nil)
+	all := []beads.Bead{clobbered, clean, perBead, compound, excluded}
+	mem := beads.NewMemStoreFrom(0, all, nil)
 	store := &countingStore{Store: mem}
-	all := []beads.Bead{clobbered, clean, excluded}
-	stores := []beads.Store{store, store, store}
+	stores := []beads.Store{store, store, store, store, store}
+	cfg := gaConfig()
 
-	repairPoolSlotWorkDirClobber(all, stores, io.Discard)
+	repairPoolSlotWorkDirClobber(cfg, all, stores, io.Discard)
 
 	got, err := mem.Get("ga-clobbered")
 	if err != nil {
@@ -208,21 +359,71 @@ func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 		t.Errorf("gc.work_dir = %q, want %q (repaired from legacy work_dir)", got.Metadata[beadmeta.WorkDirMetadataKey], realEvidence)
 	}
 
-	gotExcluded, err := mem.Get("ga-45tz5p")
-	if err != nil {
-		t.Fatalf("Get(ga-45tz5p): %v", err)
-	}
-	if gotExcluded.Metadata[beadmeta.WorkDirMetadataKey] != ".claude/worktrees/ga-45tz5p" {
-		t.Errorf("gc.work_dir = %q, want unchanged (non-pool-slot shape must not be blanket-copied)", gotExcluded.Metadata[beadmeta.WorkDirMetadataKey])
+	for _, tc := range []struct {
+		id   string
+		want string
+	}{
+		{"ga-ui3mbs", perBeadAtSlot},
+		{"ga-klo4gz.11", compoundSlot},
+		{"ga-45tz5p", ".claude/worktrees/ga-45tz5p"},
+	} {
+		gotUntouched, err := mem.Get(tc.id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", tc.id, err)
+		}
+		if gotUntouched.Metadata[beadmeta.WorkDirMetadataKey] != tc.want {
+			t.Errorf("%s gc.work_dir = %q, want %q (accurate canonical must not be reverted to a stale legacy)",
+				tc.id, gotUntouched.Metadata[beadmeta.WorkDirMetadataKey], tc.want)
+		}
 	}
 
-	// Idempotent: a second pass over the now-repaired bead writes nothing --
+	// Idempotent: a second pass over the now-repaired beads writes nothing --
 	// the "one-shot" contract achieved via steady-state convergence rather
 	// than tracked migration-run state.
-	repaired, _ := mem.Get("ga-clobbered")
+	var second []beads.Bead
+	for _, b := range all {
+		refreshed, err := mem.Get(b.ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", b.ID, err)
+		}
+		second = append(second, refreshed)
+	}
 	store.writes = 0
-	repairPoolSlotWorkDirClobber([]beads.Bead{repaired, clean, gotExcluded}, stores, io.Discard)
+	repairPoolSlotWorkDirClobber(cfg, second, stores, io.Discard)
 	if store.writes != 0 {
 		t.Errorf("second pass wrote %d times, want 0 (repair must be one-shot/idempotent)", store.writes)
+	}
+}
+
+// TestRepairPoolSlotWorkDirClobberNilConfigIsInert pins the asymmetry
+// documented on poolSlotWorkDirRepairFor: the repair direction writes, so
+// without config it must skip rather than fall back to shape-only matching
+// and overwrite an accurate canonical.
+func TestRepairPoolSlotWorkDirClobberNilConfigIsInert(t *testing.T) {
+	const (
+		perBeadAtSlot = ".gc/worktrees/gascity/ga-ui3mbs"
+		staleLegacy   = "/home/ds/gascity-worktrees/ga-stale"
+	)
+	perBead := beads.Bead{
+		ID: "ga-ui3mbs", Type: "task", Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       perBeadAtSlot,
+			beadmeta.LegacyWorkDirMetadataKey: staleLegacy,
+		},
+	}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{perBead}, nil)
+	store := &countingStore{Store: mem}
+
+	repairPoolSlotWorkDirClobber(nil, []beads.Bead{perBead}, []beads.Store{store}, io.Discard)
+
+	if store.writes != 0 {
+		t.Errorf("nil cfg wrote %d times, want 0", store.writes)
+	}
+	got, err := mem.Get(perBead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", perBead.ID, err)
+	}
+	if got.Metadata[beadmeta.WorkDirMetadataKey] != perBeadAtSlot {
+		t.Errorf("gc.work_dir = %q, want %q (nil cfg must not repair)", got.Metadata[beadmeta.WorkDirMetadataKey], perBeadAtSlot)
 	}
 }

--- a/cmd/gc/pool_slot_workdir_test.go
+++ b/cmd/gc/pool_slot_workdir_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -155,5 +156,73 @@ func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 				t.Errorf("RestoreValue = %q, want %q", got.RestoreValue, tc.want.RestoreValue)
 			}
 		})
+	}
+}
+
+// TestRepairPoolSlotWorkDirClobber exercises the one-shot repair sweep (the
+// active driver for poolSlotWorkDirRepairFor) rather than the pure decision
+// function alone: ga-3c5isi's exit_contract requires beads already clobbered
+// -- by a prior reconciler tick, before workDirStampWouldClobberEvidence
+// existed -- to be actively restored, not merely protected from future
+// clobbers. Status-agnostic by design: mayor's manual sweep found latent
+// victims on OPEN beads (released back to open by a drain) as well as
+// in_progress ones, so this sweep must not gate on bead status.
+func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
+	const (
+		poolSlot     = ".gc/worktrees/gascity/builder-1"
+		realEvidence = "/home/ds/gascity-worktrees/ga-3c5isi"
+	)
+	clobbered := beads.Bead{
+		ID: "ga-clobbered", Type: "task", Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       poolSlot,
+			beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+		},
+	}
+	clean := beads.Bead{
+		ID: "ga-clean", Type: "task", Status: "in_progress",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       realEvidence,
+			beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+		},
+	}
+	excluded := beads.Bead{
+		ID: "ga-45tz5p", Type: "task", Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       ".claude/worktrees/ga-45tz5p",
+			beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+		},
+	}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{clobbered, clean, excluded}, nil)
+	store := &countingStore{Store: mem}
+	all := []beads.Bead{clobbered, clean, excluded}
+	stores := []beads.Store{store, store, store}
+
+	repairPoolSlotWorkDirClobber(all, stores, io.Discard)
+
+	got, err := mem.Get("ga-clobbered")
+	if err != nil {
+		t.Fatalf("Get(ga-clobbered): %v", err)
+	}
+	if got.Metadata[beadmeta.WorkDirMetadataKey] != realEvidence {
+		t.Errorf("gc.work_dir = %q, want %q (repaired from legacy work_dir)", got.Metadata[beadmeta.WorkDirMetadataKey], realEvidence)
+	}
+
+	gotExcluded, err := mem.Get("ga-45tz5p")
+	if err != nil {
+		t.Fatalf("Get(ga-45tz5p): %v", err)
+	}
+	if gotExcluded.Metadata[beadmeta.WorkDirMetadataKey] != ".claude/worktrees/ga-45tz5p" {
+		t.Errorf("gc.work_dir = %q, want unchanged (non-pool-slot shape must not be blanket-copied)", gotExcluded.Metadata[beadmeta.WorkDirMetadataKey])
+	}
+
+	// Idempotent: a second pass over the now-repaired bead writes nothing --
+	// the "one-shot" contract achieved via steady-state convergence rather
+	// than tracked migration-run state.
+	repaired, _ := mem.Get("ga-clobbered")
+	store.writes = 0
+	repairPoolSlotWorkDirClobber([]beads.Bead{repaired, clean, gotExcluded}, stores, io.Discard)
+	if store.writes != 0 {
+		t.Errorf("second pass wrote %d times, want 0 (repair must be one-shot/idempotent)", store.writes)
 	}
 }

--- a/cmd/gc/pool_slot_workdir_test.go
+++ b/cmd/gc/pool_slot_workdir_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestIsPoolSlotWorkDirRoot(t *testing.T) {
+	cases := map[string]struct {
+		path string
+		want bool
+	}{
+		"relative exact pool slot root": {
+			path: ".gc/worktrees/gascity/builder-1",
+			want: true,
+		},
+		"absolute exact pool slot root": {
+			path: "/home/jaword/projects/gc-management/.gc/worktrees/gascity/builder-1",
+			want: true,
+		},
+		"missing role segment": {
+			path: ".gc/worktrees/gascity",
+			want: false,
+		},
+		"per-bead worktree nested inside a pool slot": {
+			path: ".gc/worktrees/gascity/builder-1/ga-3c5isi",
+			want: false,
+		},
+		"legacy per-bead worktree path": {
+			path: "worktrees/ga-3c5isi",
+			want: false,
+		},
+		"claude worktrees shape (ga-45tz5p exclusion)": {
+			path: ".claude/worktrees/ga-45tz5p",
+			want: false,
+		},
+		"empty": {
+			path: "",
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isPoolSlotWorkDirRoot(tc.path); got != tc.want {
+				t.Errorf("isPoolSlotWorkDirRoot(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkDirStampWouldClobberEvidence(t *testing.T) {
+	const (
+		realEvidence      = "/home/ds/gascity-worktrees/ga-3c5isi"
+		otherRealEvidence = "/home/ds/gascity-worktrees/ga-other"
+		poolSlot          = ".gc/worktrees/gascity/builder-1"
+		otherPoolSlot     = ".gc/worktrees/gascity/builder-2"
+	)
+	cases := map[string]struct {
+		metadata map[string]string
+		workDir  string
+		want     bool
+	}{
+		"real evidence to pool slot label clobbers": {
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: realEvidence},
+			workDir:  poolSlot,
+			want:     true,
+		},
+		"absent to pool slot label is fine": {
+			metadata: map[string]string{},
+			workDir:  poolSlot,
+			want:     false,
+		},
+		"pool slot to different pool slot is fine": {
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: poolSlot},
+			workDir:  otherPoolSlot,
+			want:     false,
+		},
+		"pool slot to real evidence is fine": {
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: poolSlot},
+			workDir:  realEvidence,
+			want:     false,
+		},
+		"real evidence to different real evidence is fine": {
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: realEvidence},
+			workDir:  otherRealEvidence,
+			want:     false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := workDirStampWouldClobberEvidence(tc.metadata, tc.workDir); got != tc.want {
+				t.Errorf("workDirStampWouldClobberEvidence(%v, %q) = %v, want %v", tc.metadata, tc.workDir, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPoolSlotWorkDirRepairFor(t *testing.T) {
+	const (
+		poolSlot       = ".gc/worktrees/gascity/builder-1"
+		realEvidence   = "/home/ds/gascity-worktrees/ga-3c5isi"
+		claudeWorktree = ".claude/worktrees/ga-45tz5p"
+	)
+	cases := map[string]struct {
+		bead beads.Bead
+		want *poolSlotWorkDirRepair
+	}{
+		"pool-slot canonical with differing legacy needs repair": {
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       poolSlot,
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			}},
+			want: &poolSlotWorkDirRepair{RestoreValue: realEvidence},
+		},
+		"already equal needs no repair": {
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       realEvidence,
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			}},
+			want: nil,
+		},
+		"canonical only needs no repair": {
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey: poolSlot,
+			}},
+			want: nil,
+		},
+		"legacy only needs no repair": {
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			}},
+			want: nil,
+		},
+		"canonical unequal but not pool-slot shaped (ga-45tz5p) is excluded": {
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       claudeWorktree,
+				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
+			}},
+			want: nil,
+		},
+		"nil metadata needs no repair": {
+			bead: beads.Bead{},
+			want: nil,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := poolSlotWorkDirRepairFor(tc.bead)
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("poolSlotWorkDirRepairFor() = %v, want %v", got, tc.want)
+			}
+			if got != nil && got.RestoreValue != tc.want.RestoreValue {
+				t.Errorf("RestoreValue = %q, want %q", got.RestoreValue, tc.want.RestoreValue)
+			}
+		})
+	}
+}

--- a/cmd/gc/pool_slot_workdir_test.go
+++ b/cmd/gc/pool_slot_workdir_test.go
@@ -168,6 +168,7 @@ func TestWorkDirStampWouldClobberEvidence(t *testing.T) {
 func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 	const (
 		poolSlot       = ".gc/worktrees/gascity/builder-1"
+		otherPoolSlot  = ".gc/worktrees/gascity/builder-2"
 		perBeadAtSlot  = ".gc/worktrees/gascity/ga-ui3mbs"
 		compoundAtSlot = ".gc/worktrees/gascity/ga-klo4gz.11-measure"
 		realEvidence   = "/home/ds/gascity-worktrees/ga-3c5isi"
@@ -186,6 +187,18 @@ func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 				beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 			}},
 			want: &poolSlotWorkDirRepair{RestoreValue: realEvidence},
+		},
+		// The repair's premise is that legacy holds real per-bead evidence. A
+		// slot-shaped legacy is not that, so promoting it would only swap one
+		// slot label for another -- and on an open bead nothing follows the
+		// sweep to correct it.
+		"differing pool-slot legacy is left untouched": {
+			cfg: gaConfig(),
+			bead: beads.Bead{Metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       poolSlot,
+				beadmeta.LegacyWorkDirMetadataKey: otherPoolSlot,
+			}},
+			want: nil,
 		},
 		// The accurate canonical of a per-bead worktree living at slot depth
 		// must survive: repairing it would relocate a live bead to a stale
@@ -301,6 +314,7 @@ func TestPoolSlotWorkDirRepairFor(t *testing.T) {
 func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 	const (
 		poolSlot      = ".gc/worktrees/gascity/builder-1"
+		otherPoolSlot = ".gc/worktrees/gascity/builder-2"
 		perBeadAtSlot = ".gc/worktrees/gascity/ga-ui3mbs"
 		compoundSlot  = ".gc/worktrees/gascity/ga-klo4gz.11-measure"
 		realEvidence  = "/home/ds/gascity-worktrees/ga-3c5isi"
@@ -343,10 +357,19 @@ func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 			beadmeta.LegacyWorkDirMetadataKey: realEvidence,
 		},
 	}
-	all := []beads.Bead{clobbered, clean, perBead, compound, excluded}
+	// Both halves slot-shaped: the sweep has no real evidence to restore, so
+	// it must leave the bead alone rather than promote the other slot label.
+	slotToSlot := beads.Bead{
+		ID: "ga-slotslot", Type: "task", Status: "open",
+		Metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       poolSlot,
+			beadmeta.LegacyWorkDirMetadataKey: otherPoolSlot,
+		},
+	}
+	all := []beads.Bead{clobbered, clean, perBead, compound, excluded, slotToSlot}
 	mem := beads.NewMemStoreFrom(0, all, nil)
 	store := &countingStore{Store: mem}
-	stores := []beads.Store{store, store, store, store, store}
+	stores := []beads.Store{store, store, store, store, store, store}
 	cfg := gaConfig()
 
 	repairPoolSlotWorkDirClobber(cfg, all, stores, io.Discard)
@@ -366,6 +389,7 @@ func TestRepairPoolSlotWorkDirClobber(t *testing.T) {
 		{"ga-ui3mbs", perBeadAtSlot},
 		{"ga-klo4gz.11", compoundSlot},
 		{"ga-45tz5p", ".claude/worktrees/ga-45tz5p"},
+		{"ga-slotslot", poolSlot},
 	} {
 		gotUntouched, err := mem.Get(tc.id)
 		if err != nil {

--- a/release-gates/ga-f11syh-pool-slot-workdir-repair-gate.md
+++ b/release-gates/ga-f11syh-pool-slot-workdir-repair-gate.md
@@ -1,0 +1,81 @@
+# Release gate: reconciler pool-slot work-dir repair
+
+- Deploy bead: `ga-f11syh`
+- Build bead: `ga-3c5isi`
+- Review bead: `ga-a0471c`
+- Reviewed commit: `0aae22b74ebd928f732577c842c339db6d5a4f9f`
+- Provenance branch: `builder/ga-3c5isi`
+- Base: `origin/main@734f18f45915399a900561c3f964e3af96cace0b`
+- Deploy mode: remote
+- Intended deploy branch: `deploy/ga-f11syh-gate`
+- Evaluated: 2026-09-04
+- Verdict: **PASS**
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-a0471c` records an unqualified PASS for the exact reviewed commit. The SHA resolves to `0aae22b74ebd928f732577c842c339db6d5a4f9f`; no review carryover is involved. |
+| 2 | Acceptance criteria met | **PASS** | The two reconciler stamp sites now refuse to replace real `gc.work_dir` evidence with a pool-slot root. The repair sweep covers both assigned and reopened/unassigned-routed beads, restores only unequal canonical/legacy pairs whose canonical value is exactly pool-slot-shaped, leaves other shapes untouched, and converges without a second write. The five changed behavior tests passed. |
+| 3 | Tests pass | **PASS WITH ATTRIBUTED FAILURES** | The documented 40-job full local suite completed with 38 jobs PASS and 2 raw FAIL. Both failures are non-diff-owned, have predating condition trackers, satisfy the no-path-overlap rule, and have decisive mechanism or cross-run evidence below. All diff-owned tests ran in green shards. |
+| 3a | Pre-existing failures may be attributed | **PASS** | `TestBdFlagManifestCurrent` is tracked by `ga-f0uceo` and is structurally outside the changed code. `TestE2E_SuspendResume_City` is tracked by `ga-dqd7gf` and reproduced the tracker's exact 93-second missing-report signature already observed on an unrelated diff. Both tracker records were opened and this run's sightings were appended and verified. |
+| 3b | Policy/lint lane | **PASS** | Workflow policy, module policy, native-dependency surface, event-export isolation, open-core boundary, native DoltLite tests, affected-package lint/vet, changed-file formatting, full `go vet`, docs sync, and `go build ./...` passed. Affected lint reported 0 issues. |
+| 3c | CI-config lane | **PASS / n/a** | `ci_lane_run: n/a (no CI job, matrix, timeout, required-check list, workflow, or build target changed)`. |
+| 4 | No high-severity review findings open | **PASS** | Reviewer reported no blockers and no security concerns; unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | **PASS** | The exact reviewed SHA was evaluated from a clean detached checkout. `git diff --check` passed and `core.hooksPath` is `.githooks`. |
+| 6 | Branch diverges cleanly from main | **PASS** | Evaluated first, then refreshed after the full suite. No PR carries the reviewed SHA. `git merge-tree --write-tree origin/main 0aae22b74ebd928f732577c842c339db6d5a4f9f` exited 0 against refreshed base `734f18f45915399a900561c3f964e3af96cace0b`, producing tree `c53084a458c7af27e16a93723a3cc3af95c1049d`. No self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | Four files in `cmd/gc`: the reconciler stamp/repair implementation and its tests. The two commits implement one behavior theme: preserving and repairing canonical per-bead worktree evidence. |
+
+## Criterion 3 evidence
+
+```text
+test_cmd_scope: full-suite
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true LOCAL_TEST_JOBS=2 LOCAL_TEST_LOG_DIR=/var/tmp/gc-deploy-ga-f11syh.9BgXA4 make test-local-full-parallel
+test_counts: 38/40 jobs PASS, 2/40 jobs raw FAIL, 0/40 jobs SKIP
+top_level_skip_markers: 0
+package_no_tests_notices: 11 (expected build-tag/profile and shard partitioning; none is a diff-owned test package)
+job_logs: /var/tmp/gc-deploy-ga-f11syh.9BgXA4
+diff_tests_executed: TestStampRunSessionIdentityPreservesRealEvidenceAgainstPoolSlotSelfCwd PASS; TestIsPoolSlotWorkDirRoot PASS; TestWorkDirStampWouldClobberEvidence PASS; TestPoolSlotWorkDirRepairFor PASS; TestRepairPoolSlotWorkDirClobber PASS
+skip_justification: no top-level tests skipped; package-level no-test notices are intentional runner partitioning and do not include the diff-owned tests
+waiver_ref: none
+ci_lane_run: n/a (no CI configuration change)
+```
+
+The rootless Podman socket was active before the run. The cached container set
+included the repository's Dolt images and `testcontainers/ryuk:0.14.0`; Gas
+City has no `cairn` entry for `dolt-tests-via-podman`.
+
+The five diff-owned tests were explicitly assigned by the documented runner to
+completed green `cmd/gc` shards, and neither changed test file contains a skip
+call. The same tests were also assigned across the green integration `cmd/gc`
+shards where applicable.
+
+### Raw failure attribution
+
+| Raw failing test | Predating tracker | Attribution evidence |
+|---|---|---|
+| `TestBdFlagManifestCurrent` | `ga-f0uceo` | Clauses 1 and 4: `internal/bdflags/freshness_test.go` and `internal/bdflags/**` are untouched. Clause 3(a), mechanism: the test compares the repository manifest with the separately installed `bd` executable; the changed `cmd/gc` reconciler functions cannot alter either input. Exact installed-binary drift is the tracker's standing condition. Log: `integration-packages-core-1-of-4.log`. |
+| `TestE2E_SuspendResume_City` | `ga-dqd7gf` | Clauses 1 and 4: `test/integration/e2e_lifecycle_test.go` is untouched and has no path overlap with the diff. Clause 3(b), cross-run/cross-diff: the exact 93-second timeout waiting for `citysus.report` is recorded on the predating tracker from an unrelated container-security-only diff. Log: `integration-rest-full-2-of-8.log`. |
+
+No inconclusive attribution path was used.
+
+## Policy and static evidence
+
+Passed on reviewed commit `0aae22b74ebd928f732577c842c339db6d5a4f9f`:
+
+```text
+make test-ci-policy check-gomod-replace check-native-dependency-surface \
+  check-eventexport-isolation check-core-boundary test-native-doltlite-beads
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make fmt-check-changed
+make vet check-docs
+go build ./...
+git diff --check origin/main...0aae22b74ebd928f732577c842c339db6d5a4f9f
+```
+
+## Decision
+
+Gate **PASS**. Prepare the isolated `deploy/ga-f11syh-gate` branch from the
+reviewed SHA, commit this checklist, push it to the configured fork, and open a
+PR against `gastownhall/gascity:main`. Publish deploy clearance on the exact PR
+head before routing the merge request. The deployer does not merge.


### PR DESCRIPTION
## What this changes

The controller now preserves an existing canonical `gc.work_dir` when a reconciliation pass observes the agent's shared pool-slot directory. Previously that stamp could overwrite per-bead worktree evidence; once it diverged from the legacy `work_dir`, pool realization failed closed and the bead could be starved indefinitely.

The same pass also repairs previously clobbered beads when the canonical value is exactly a pool-slot root and the legacy value still holds the real worktree. The repair runs for both assigned work and work reopened as unassigned-but-routed.

## Review notes

- The prevention guard is shared by both work-bead and molecule-root stamp sites.
- Repair is deliberately narrow and idempotent: ambiguous paths, including `.claude/worktrees/**`, are left untouched.
- There are no config, API, wire-format, or migration changes.

## Test plan

- [x] Exercise exact pool-slot detection, clobber prevention, selective repair, and idempotence in `cmd/gc` tests.
- [x] Run the documented 40-job local suite with all diff-owned tests green; tracked unrelated failures are detailed in the gate record.
- [x] Run CI policy, affected lint/vet, formatting, docs sync, native DoltLite, full vet, and build checks.
- [x] Release gate: [`release-gates/ga-f11syh-pool-slot-workdir-repair-gate.md`](release-gates/ga-f11syh-pool-slot-workdir-repair-gate.md)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #4449 — addresses one slice of the conflation described in that issue: the reconciler's two stamp sites (stampRunSessionIdentity and stampRunRootFromStep) now refuse to overwrite an existing per-bead gc.work_dir with a pool-slot process directory, and a narrow sweep restores already-poisoned values from the legacy work_dir; it does not introduce the separate process-cwd key the issue asks for, and a process dir is still stamped into gc.work_dir when the bead has no prior value or when the incoming path is not exactly pool-slot-shaped

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->