### PR TITLE
fix(doctor): gc doctor --json's ok field reflects real blocking-failure state (#5950)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -609,6 +609,11 @@ type doctorJSONResult struct {
 }
 
 type doctorJSONReport struct {
+	// OK mirrors the blocking-failure gate the plain-text/exit-code path
+	// already uses (report.BlockingFailed == 0), so it must be set
+	// explicitly here -- writeCLIJSONLine's generic envelope only injects a
+	// hardcoded ok:true when the payload doesn't already carry an "ok" key.
+	OK             bool               `json:"ok"`
 	Passed         int                `json:"passed"`
 	Warned         int                `json:"warned"`
 	Failed         int                `json:"failed"`
@@ -642,6 +647,7 @@ func doctorSeverityString(s doctor.CheckSeverity) string {
 
 func writeDoctorJSON(w io.Writer, report *doctor.Report) error {
 	out := doctorJSONReport{
+		OK:             report.BlockingFailed == 0,
 		Passed:         report.Passed,
 		Warned:         report.Warned,
 		Failed:         report.Failed,

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -1069,3 +1069,58 @@ func TestWriteDoctorJSONProjectsTimedOut(t *testing.T) {
 		t.Fatalf("timed_out appears %d times, want exactly 1 (only the abandoned check); out=%s", n, buf.String())
 	}
 }
+
+// TestWriteDoctorJSONOKReflectsBlockingFailed pins ok to the same gate the
+// plain-text/exit-code path already uses (BlockingFailed == 0) -- an
+// advisory-only failure must not flip ok to false, and a blocking failure
+// must not leave it stuck at the JSON envelope's hardcoded default of true.
+func TestWriteDoctorJSONOKReflectsBlockingFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		report *doctor.Report
+		wantOK bool
+	}{
+		{
+			name:   "clean report",
+			report: &doctor.Report{},
+			wantOK: true,
+		},
+		{
+			name: "advisory failure only",
+			report: &doctor.Report{
+				Failed: 1,
+				Results: []*doctor.CheckResult{
+					{Name: "advisory", Status: doctor.StatusError, Severity: doctor.SeverityAdvisory, Message: "advisory issue"},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "blocking failure",
+			report: &doctor.Report{
+				Failed:         1,
+				BlockingFailed: 1,
+				Results: []*doctor.CheckResult{
+					{Name: "blocking", Status: doctor.StatusError, Severity: doctor.SeverityBlocking, Message: "blocking issue"},
+				},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := writeDoctorJSON(&buf, tt.report); err != nil {
+				t.Fatalf("writeDoctorJSON: %v", err)
+			}
+			var decoded doctorJSONReport
+			if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+				t.Fatalf("decode doctor JSON: %v; out=%q", err, buf.String())
+			}
+			if decoded.OK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v; blocking_failed=%d out=%s", decoded.OK, tt.wantOK, tt.report.BlockingFailed, buf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Closes #5950. `gc doctor --json` always reported `ok:true` regardless of `blocking_failed`. Any automation checking `ok` alone (rather than parsing `blocking_failed`) would silently miss real blocking failures.

Root cause: `doctorJSONReport` had no `ok` field at all. The generic JSON success/failure envelope helper (`withDefaultSuccessOK`, used by many commands) injects a hardcoded `ok:true` whenever a payload doesn't already carry that key — completely independent of `report.BlockingFailed`, which the plain-text/exit-code path already gates on correctly. The two surfaces had simply never been wired together.

## Fix

Added `OK bool` to `doctorJSONReport`, set to `report.BlockingFailed == 0` in `writeDoctorJSON` — the same signal the exit-code path already uses. New table-driven test covers clean/advisory-only/blocking-failure cases, confirming `ok` stays `true` for an advisory-only failure (correct — advisory issues aren't blocking) and only flips `false` on an actual blocking failure.

## Validation

- `go build -tags gms_pure_go ./...` clean
- `go test -tags gms_pure_go ./cmd/gc/... -run 'TestWriteDoctorJSON|TestDoctorJSON'` all pass
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — including two coincidentally "Doctor"-named tests (`TestDoctorScriptSteadyHealthySkipsSweep`/`TestDoctorScriptSuppressedTickSkipsSweepAndSend`) that live in `examples/bd/dolt/dog_exec_scripts_test.go`, a dolt fixture script unrelated to `gc doctor` — none touch `cmd/gc/cmd_doctor.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)