### PR TITLE
fix(beads): consult native-open deferral before dialing the identity probe (#5965)

### DIFF
--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -31,15 +31,18 @@ type PreflightChecker struct {
 	BDContext func(scope string) (PreflightBDContext, error)
 	// DatabaseProjectID reads the authoritative database _project_id for the scope.
 	DatabaseProjectID func(scope string) (string, bool, error)
-	// DeferIdentityToNativeOpen reports whether, when the direct database probe
-	// cannot confirm project_id, the scope should stay native-eligible and defer
+	// DeferIdentityToNativeOpen reports whether the scope should skip the direct
+	// database probe altogether and stay native-eligible, deferring
 	// authoritative identity verification to beadslib's native-open path
 	// (verifyProjectIdentity over the authenticated connection) instead of
 	// degrading off the native store. It is true for external endpoints such as
 	// a hosted beads-gateway, whose EIA-as-username + TLS credential-command auth
-	// the control-plane root/plaintext probe cannot replicate, but whose database
-	// _project_id beadslib still verifies at open time — refusing to connect, and
-	// falling back to BdStore, on mismatch. Nil defaults to no deferral (Warn).
+	// the control-plane root/plaintext probe cannot replicate — the probe is
+	// known in advance to be unable to authenticate such an endpoint, so it is
+	// consulted before DatabaseProjectID is dialed, not after it fails — but
+	// whose database _project_id beadslib still verifies at open time,
+	// refusing to connect, and falling back to BdStore, on mismatch. Nil
+	// defaults to no deferral (Warn).
 	DeferIdentityToNativeOpen func(scope string) bool
 	// BeadsLibraryVersion is the linked github.com/steveyegge/beads module
 	// version. Empty means infer it from build info.
@@ -215,24 +218,26 @@ func (c PreflightChecker) checkIdentityMatch(scope string, metadata preflightMet
 	if c.DatabaseProjectID == nil {
 		return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckWarn, "database project_id reader is not configured", details)
 	}
+	// The direct SQL probe connects as root over plaintext and cannot
+	// authenticate an external hosted beads-gateway, whose identity is proven
+	// by an EIA-as-username + TLS credential command the control plane does
+	// not replicate here. For such endpoints the authoritative database
+	// _project_id is verified by beadslib at native-open time
+	// (verifyProjectIdentity over the authenticated connection), which
+	// refuses to connect on mismatch and drops the scope to BdStore — the
+	// same open-time gate BdStore itself relies on. Consult the deferral
+	// *before* dialing: a scope this is true for is known in advance to be
+	// unable to authenticate the direct probe, so dialing it anyway would
+	// only produce a rejected-authentication attempt on the remote server for
+	// a check whose answer is already decided (gastownhall/gascity#5965).
+	if c.DeferIdentityToNativeOpen != nil && c.DeferIdentityToNativeOpen(scope) {
+		return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckPass, "database identity deferred to native-open verification (external endpoint, probe skipped)", details)
+	}
 	dbProjectID, ok, err := c.DatabaseProjectID(scope)
 	details.DBProjectID = strings.TrimSpace(dbProjectID)
 	if err != nil || !ok || details.DBProjectID == "" {
-		// The direct SQL probe connects as root over plaintext and cannot
-		// authenticate an external hosted beads-gateway, whose identity is proven
-		// by an EIA-as-username + TLS credential command the control plane does
-		// not replicate here. For such endpoints the authoritative database
-		// _project_id is verified by beadslib at native-open time
-		// (verifyProjectIdentity over the authenticated connection), which
-		// refuses to connect on mismatch and drops the scope to BdStore — the
-		// same open-time gate BdStore itself relies on. Defer to that gate rather
-		// than claiming a confirmation the control plane cannot make, so the
-		// scope stays native-eligible without a false proof. A local endpoint,
-		// whose probe should have succeeded, still degrades so its genuine probe
-		// failure is not silently ignored.
-		if c.DeferIdentityToNativeOpen != nil && c.DeferIdentityToNativeOpen(scope) {
-			return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckPass, "database identity deferred to native-open verification (external endpoint)", details)
-		}
+		// A local endpoint, whose probe should have succeeded, still degrades
+		// so its genuine probe failure is not silently ignored.
 		return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckWarn, "database project_id could not be confirmed", details)
 	}
 	if metadata.ProjectID != details.DBProjectID {

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -342,12 +342,27 @@ func TestPreflightDefersIdentityToNativeOpenForExternalEndpoint(t *testing.T) {
 	assertCheckState(t, result, PreflightCheckIdentityMatch, PreflightCheckPass)
 }
 
-// TestPreflightExternalEndpointStillBlocksOnProbeMismatch guards the deferral:
-// deferring to native-open verification only applies when the direct probe is
-// UNAVAILABLE. If the probe does reach the database and reports a project_id that
-// disagrees with metadata, that is a genuine cross-project mismatch and must
-// still block native activation even for an external endpoint.
-func TestPreflightExternalEndpointStillBlocksOnProbeMismatch(t *testing.T) {
+// TestPreflightDeferredScopeNeverDialsTheDatabaseProbe pins the ordering fix for
+// gastownhall/gascity#5965: DeferIdentityToNativeOpen is consulted BEFORE
+// DatabaseProjectID is ever called, not only after a failed/unavailable probe.
+// A scope it returns true for is known in advance to be unable to authenticate
+// the direct root/plaintext probe (an external hosted beads-gateway), so
+// dialing it anyway only produces a rejected-authentication attempt on the
+// remote server for a check whose answer is already decided. Identity
+// verification for such a scope is entirely delegated to beadslib's
+// native-open path (verifyProjectIdentity over the authenticated connection),
+// which refuses to connect and falls back to BdStore on a genuine mismatch —
+// so the control-plane preflight no longer needs, or attempts, its own
+// pre-dial cross-check for these scopes.
+//
+// This supersedes the older
+// TestPreflightExternalEndpointStillBlocksOnProbeMismatch scenario: before the
+// fix, the dial always ran first, so a probe that happened to succeed with a
+// mismatched project_id was still caught here. After the fix the dial is
+// skipped outright for a deferred scope, so that in-depth guard is no longer
+// reachable in this check — the mismatch guarantee for such scopes lives
+// solely at native-open time.
+func TestPreflightDeferredScopeNeverDialsTheDatabaseProbe(t *testing.T) {
 	scope := "/city"
 	checker := testPreflightChecker(preflightMetadataJSON(`{
 		"backend": "dolt",
@@ -355,6 +370,11 @@ func TestPreflightExternalEndpointStillBlocksOnProbeMismatch(t *testing.T) {
 		"dolt_database": "gascity",
 		"project_id": "metadata-id"
 	}`), PreflightBDContext{Backend: "dolt", DoltMode: "server"}, "database-id")
+	called := false
+	checker.DatabaseProjectID = func(string) (string, bool, error) {
+		called = true
+		return "database-id", true, nil
+	}
 	checker.DeferIdentityToNativeOpen = func(string) bool { return true }
 
 	result, err := checker.Check(scope)
@@ -362,8 +382,11 @@ func TestPreflightExternalEndpointStillBlocksOnProbeMismatch(t *testing.T) {
 		t.Fatalf("Check() error = %v", err)
 	}
 
-	assertPreflightVerdict(t, result, PreflightVerdictBlocked, false)
-	assertCheckState(t, result, PreflightCheckIdentityMatch, PreflightCheckFail)
+	if called {
+		t.Fatalf("DatabaseProjectID was called for a scope where DeferIdentityToNativeOpen returned true; the dial must be skipped entirely")
+	}
+	assertPreflightVerdict(t, result, PreflightVerdictEligible, true)
+	assertCheckState(t, result, PreflightCheckIdentityMatch, PreflightCheckPass)
 }
 
 func TestPreflightUnreadableScopeReturnsError(t *testing.T) {


### PR DESCRIPTION
## What

Closes #5965. `checkIdentityMatch`'s direct database `_project_id` probe always dialed the target endpoint via `DatabaseProjectID(scope)` first, only consulting `DeferIdentityToNativeOpen(scope)` afterward, in the post-failure fallback branch. For any scope resolving to an external Dolt endpoint (a federated hub, a hosted beads-gateway), that dial is known in advance to be unable to authenticate — the direct root/plaintext probe can't replicate the endpoint's EIA-as-username + TLS credential-command auth — so every such preflight run produced one rejected-authentication attempt logged on the remote Dolt server, even though the triggering command succeeded once the check fell through to the deferral pass. On the reporter's hub host this was 80-84% of that box's syslog volume and multi-hundred-MB/week log growth.

## Fix

This is the issue's own "fix candidate 1" — the smallest, most targeted option. Moved the `DeferIdentityToNativeOpen(scope)` check ahead of the `DatabaseProjectID(scope)` dial in `checkIdentityMatch`: when it reports the scope defers to beadslib's native-open verification, return the deferred Pass result directly, without dialing at all. The post-dial fallback path (dial fails or is unconfigured, no deferral) is unchanged for local scopes whose probe should genuinely succeed.

**Test note:** one pre-existing test (`TestPreflightExternalEndpointStillBlocksOnProbeMismatch`) asserted that a deferred scope still blocks if the dial happens to succeed with a mismatched `project_id`. That scenario is now structurally unreachable — the dial is skipped outright for deferred scopes — and it was never the primary enforcement point anyway: the pre-existing code comment already stated that beadslib's native-open verification is what actually refuses to connect on a real mismatch for such endpoints. Replaced it with `TestPreflightDeferredScopeNeverDialsTheDatabaseProbe`, which asserts `DatabaseProjectID` is never invoked when `DeferIdentityToNativeOpen` returns true — the actual behavioral guarantee this fix makes.

Fix candidates 2 (change which credential the probe itself uses) and 3 (differentiate log messages) from the issue were intentionally not attempted — candidate 1 alone resolves the reported symptom with the smallest possible blast radius.

## Validation

- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- `go test -tags gms_pure_go ./internal/beads/contract/...` all pass, `go vet` clean
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction/preflight-retry timeouts in `examples/bd/dolt/dog_exec_scripts_test.go`, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch `internal/beads/contract/preflight_checker.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)