### PR TITLE
fix(rig): report effective suspension in rig add JSON

### DIFF
--- a/cmd/gc/management_json.go
+++ b/cmd/gc/management_json.go
@@ -90,7 +90,7 @@ func rigAddJSONSummary(rigPath string, rig config.Rig) managementActionResult {
 		Path:          rigPath,
 		Prefix:        rig.EffectivePrefix(),
 		DefaultBranch: rig.EffectiveDefaultBranch(),
-		Suspended:     managementBoolPtr(rig.Suspended),
+		Suspended:     managementBoolPtr(rig.EffectiveSuspendedOnStart()),
 	}
 	if result.Prefix == "" {
 		result.Prefix = config.DeriveBeadsPrefix(name)

--- a/cmd/gc/management_json.go
+++ b/cmd/gc/management_json.go
@@ -19,8 +19,16 @@ type managementActionResult struct {
 	Path          string `json:"path,omitempty"`
 	Prefix        string `json:"prefix,omitempty"`
 	DefaultBranch string `json:"default_branch,omitempty"`
-	Suspended     *bool  `json:"suspended,omitempty"`
-	State         string `json:"state,omitempty"`
+	// Suspended is the acting command's own view of suspension, never a live
+	// effective-state query. `rig add` and `agent add` report the authored
+	// startup default — for rigs, [config.Rig.EffectiveSuspendedOnStart] — so on
+	// a re-add of an existing rig it can disagree with `gc rig list --json`,
+	// which layers the runtime suspension-state override on top of that default
+	// (buildEffectiveSuspendedRigNames). `rig suspend|resume` and
+	// `agent suspend|resume` report the state the command just applied. Consumers
+	// needing a rig's live effective suspension must read `gc rig list --json`.
+	Suspended *bool  `json:"suspended,omitempty"`
+	State     string `json:"state,omitempty"`
 	// Status and RequestID are additive fields the remote `rig add` path emits so
 	// a script repointed at a remote city keeps the automation-critical keys plus
 	// the async outcome (provisioned/exists) and its idempotency id. Local

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -497,7 +498,7 @@ contract = "gc.healthz.v1"
 	return cityPath
 }
 
-func TestRigAddJSONEmitsOnlySummary(t *testing.T) {
+func TestRigAddJSONReportsEffectiveSuspendedOnStart(t *testing.T) {
 	clearGCEnv(t)
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "bd")
@@ -506,16 +507,24 @@ func TestRigAddJSONEmitsOnlySummary(t *testing.T) {
 	rigPath := filepath.Join(t.TempDir(), "frontend")
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"--city", cityPath, "rig", "add", rigPath, "--prefix", "fe", "--json"}, &stdout, &stderr)
+	code := run([]string{"--city", cityPath, "rig", "add", rigPath, "--prefix", "fe", "--start-suspended", "--json"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("run rig add --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
 	payload := decodeOneJSONLine(t, &stdout)
-	if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != "rig add" || payload["rig"] != "frontend" || payload["prefix"] != "fe" {
+	if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != "rig add" || payload["rig"] != "frontend" || payload["prefix"] != "fe" || payload["suspended"] != true {
 		t.Fatalf("payload = %+v", payload)
 	}
 	if strings.Contains(stdout.String(), "Adding rig") || strings.Contains(stdout.String(), "Rig added") {
 		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+
+	cfg, err := loadCityConfig(cityPath, io.Discard)
+	if err != nil {
+		t.Fatalf("load city config: %v", err)
+	}
+	if len(cfg.Rigs) != 1 || !cfg.Rigs[0].EffectiveSuspendedOnStart() {
+		t.Fatalf("stored rigs = %+v, want one effectively suspended rig", cfg.Rigs)
 	}
 }
 

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -141,6 +141,11 @@ func TestManagementJSONSuccessPayloadsValidateDeclaredSchemas(t *testing.T) {
 				writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
 				return cityPath, []string{"rig", "add", filepath.Join(t.TempDir(), "frontend"), "--prefix", "fe", "--json"}
 			},
+			check: func(t *testing.T, payload map[string]any) {
+				if got, ok := payload["suspended"].(bool); !ok || got {
+					t.Fatalf("suspended = %#v, want false without --start-suspended", payload["suspended"])
+				}
+			},
 		},
 		{
 			name: "rig suspend",

--- a/schemas/rig/add/result.schema.json
+++ b/schemas/rig/add/result.schema.json
@@ -12,7 +12,10 @@
     "path": { "type": "string" },
     "prefix": { "type": "string" },
     "default_branch": { "type": "string" },
-    "suspended": { "type": "boolean" }
+    "suspended": {
+      "type": "boolean",
+      "description": "The rig's authored startup suspension default (city.toml suspended_on_start, honoring the deprecated suspended alias) — not live effective state. On a re-add of an existing rig this can differ from `gc rig list --json`, which layers the runtime suspension-state override on top."
+    }
   },
   "additionalProperties": true
 }


### PR DESCRIPTION
## Summary

- Report the effective startup suspension state in the `gc rig add --json` result.
- Use the existing `EffectiveSuspendedOnStart()` helper so current and legacy config fields agree.
- Extend the command-level regression test to cover `--start-suspended`, the JSON envelope, and stored config.
- Thanks to @loucmane for reporting #5721.
- Fixes #5721.

## Testing

- [x] `go test ./cmd/gc -run '^TestRigAddJSONReportsEffectiveSuspendedOnStart$' -count=1`
- [x] `make vet`
- [ ] `make check` (local linter toolchain mismatch; details below)
- [ ] `make test` (unrelated environment/path failures; details below)
- [ ] `make check-docs` (not applicable; no documentation changed)
- [ ] `make test-integration` (not applicable; no runtime, controller, or workflow behavior changed)

## Checklist

- [x] Linked an issue: #5721
- [x] Added or updated tests for the behavior change
- [x] No documentation update is needed for this result-envelope correction
- [x] No breaking changes or migration steps

<details>
<summary>Verification details</summary>

- Regression proof: with the production line reverted, the focused test failed because the payload contained `suspended:false`; restoring the change made the same test pass.
- `make vet` passed.
- `make test` completed with 170 packages passing and 6 packages failing across 11 pre-existing environment/path-sensitive tests. Failures covered live Dolt runtime-port overrides, macOS `/private/var` path normalization, macOS application-support path selection, and worktree provenance; none touched the changed JSON summary or regression test.
- `make check` stopped at `fmt-check` because the installed `golangci-lint` was built with Go 1.25 and refuses the repository's Go 1.26.6 target. `gofmt` and `git diff --check` passed independently.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
