### PR TITLE
Make gc dolt sync remote selection deterministic and safe

### DIFF
--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -24,25 +24,26 @@
 #      by name (same key derivation as GC_DOLT_REFSPEC_<DB_UPPER> above). This
 #      pins the remote regardless of scheme — an explicit override is by
 #      definition intentional, so it is honored even for a non-local remote.
-#   2. Exactly one configured remote: used regardless of scheme. There is no
-#      ambiguity to gate when the database was only ever told about one
-#      remote — being the sole choice is itself an instruction to use it.
-#   3. Multiple configured remotes, no override: the first file:// remote in
-#      name-sorted order wins, deterministically and independent of whatever
-#      order the database itself returns candidates in (gc-fqi7kq: an
-#      unordered SELECT made this pick 1-of-N at random, occasionally
-#      selecting a public network remote for private fleet data). Preferring
-#      file:// keeps local/backup remotes from losing to a network remote by
-#      accident.
-#   4. Multiple configured remotes, no override, none is file://: ambiguous
-#      by policy. Sync skips the database and reports why rather than
-#      guessing among non-local remotes; set the override (case 1) to choose.
+#   2. No override: the first file:// remote in name-sorted order wins,
+#      deterministically and independent of whatever order the database
+#      itself returns candidates in (gc-fqi7kq: an unordered SELECT made
+#      this pick 1-of-N at random, occasionally selecting a public network
+#      remote for private fleet data). Preferring file:// keeps local/backup
+#      remotes from losing to a network remote by accident.
+#   3. No override and no candidate is file://: ambiguous by policy,
+#      REGARDLESS of how many remotes are configured — including exactly
+#      one. Sync skips the database and reports why rather than pushing
+#      private data to a network remote by default; set the override
+#      (case 1) to choose one deliberately.
 #
 # Environment:
 #   GC_CITY_PATH                          (required) — city root
 #   GC_DOLT_PORT                          (required) — managed dolt port
 #   GC_DOLT_USER                          (default: root)
 #   GC_DOLT_PASSWORD                      (optional)
+#   GC_DOLT_REMOTE_<DB>                   (optional) — select which remote to
+#                     push to when a database has several, or to permit
+#                     pushing to a non-file:// remote (see Remote resolution).
 #   GC_DOLT_SYNC_PUSH_TIMEOUT_SECS
 #     (default: 1800) — wall-clock bound for SQL-mode remote push. Increase for
 #                     slow links or large first pushes (a multi-GB first push to
@@ -83,6 +84,8 @@ while [ $# -gt 0 ]; do
       echo "  exclude it from sync (reported as 'skipped (.no-sync)')."
       echo ""
       echo "Environment:"
+      echo "  GC_DOLT_REMOTE_<DB>              Select which remote to push to when a database has several"
+      echo "                                   (also the only way to push to a non-file:// remote)"
       echo "  GC_DOLT_SYNC_FETCH_TIMEOUT_SECS  pre-push fetch bound (default 60)"
       echo "  GC_DOLT_SYNC_PUSH_TIMEOUT_SECS   push bound (default 1800)"
       exit 0
@@ -300,8 +303,9 @@ classify_count() {
 # or the literal token "AMBIGUOUS" when no candidate is local and no override
 # was given — regardless of how many candidates there are, including exactly
 # one: a sole remote is not auto-selected unless it is local. Never depends
-# on the input's row order: candidates are sorted by name before any policy
-# rule is applied. Returns 1 (with its own stderr message) only when
+# on the input's row order: candidates are sorted by name (under LC_ALL=C, so
+# the winner is identical on every host, not merely stable per-locale) before
+# any policy rule is applied. Returns 1 (with its own stderr message) only when
 # GC_DOLT_REMOTE_<DB> is set but names a remote that is not among the
 # candidates.
 select_remote() {
@@ -309,7 +313,7 @@ select_remote() {
   sr_pairs="$2"
   [ -z "$sr_pairs" ] && return 0
 
-  sr_sorted=$(printf '%s\n' "$sr_pairs" | sort -t'|' -k1,1)
+  sr_sorted=$(printf '%s\n' "$sr_pairs" | LC_ALL=C sort -t'|' -k1,1)
 
   sr_override=$(remote_env_value "$sr_db") || return 1
   if [ -n "$sr_override" ]; then
@@ -335,7 +339,9 @@ select_remote() {
 # find_remote_sql <db> — query all configured remotes over SQL and resolve
 # the one to sync against via select_remote. ORDER BY name keeps the raw
 # query itself deterministic; select_remote re-sorts independently so
-# correctness never relies on the server actually honoring it.
+# correctness never relies on the server actually honoring it. Returns 1 when
+# the query itself fails (and reports that), and 2 when select_remote refuses
+# — it has already printed its own, more specific reason.
 find_remote_sql() {
   db="$1"
   remote_csv=$(dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes ORDER BY name") || {
@@ -343,7 +349,8 @@ find_remote_sql() {
     return 1
   }
   pairs=$(printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2}')
-  select_remote "$db" "$pairs"
+  # 2 = select_remote already printed a specific policy refusal; 1 = lookup failed.
+  select_remote "$db" "$pairs" || return 2
 }
 
 # resolve_refspec_sql <db> — emit two lines: local-branch and remote-branch.
@@ -440,12 +447,17 @@ sync_database_sql() {
   fi
 
   remote_pair=$(find_remote_sql "$name") || {
-    last_fail_reason="failed to query remotes"
+    find_rc=$?
+    if [ "$find_rc" -eq 2 ]; then
+      last_fail_reason="remote selection refused"
+    else
+      last_fail_reason="failed to query remotes"
+    fi
     return 1
   }
   if [ -z "$remote_pair" ] || [ "$remote_pair" = "AMBIGUOUS" ]; then
     if [ "$remote_pair" = "AMBIGUOUS" ]; then
-      echo "  $name: skipped (multiple remotes, none local; set GC_DOLT_REMOTE_$(db_env_key "$name" 2>/dev/null) to pin one)"
+      echo "  $name: skipped (no local remote; set GC_DOLT_REMOTE_$(db_env_key "$name" 2>/dev/null) to push to a non-local remote)"
     else
       echo "  $name: skipped (no remote)"
     fi
@@ -620,8 +632,9 @@ sync_database_sql() {
 
 # remotes_json_pairs <remotes.json path> — emit newline-separated "name|url"
 # pairs from a Dolt CLI remotes.json. Requires name and url to appear
-# adjacent as "name":"...","url":"..." (the shape Dolt actually writes); an
-# entry that doesn't match this shape is skipped rather than guessed at.
+# adjacent as "name":"...","url":"..." (the compact shape this parser
+# requires; the same pattern `pull/run.sh` uses); an entry that doesn't match
+# this shape is skipped rather than guessed at.
 remotes_json_pairs() {
   [ -f "$1" ] || return 0
   grep -o '"name":"[^"]*","url":"[^"]*"' "$1" 2>/dev/null |
@@ -638,10 +651,13 @@ sync_database_cli() {
 
   # Check for remote.
   pairs=$(remotes_json_pairs "$d/.dolt/remotes.json")
-  remote_pair=$(select_remote "$name" "$pairs") || return 1
+  remote_pair=$(select_remote "$name" "$pairs") || {
+    last_fail_reason="remote selection refused"
+    return 1
+  }
   if [ -z "$remote_pair" ] || [ "$remote_pair" = "AMBIGUOUS" ]; then
     if [ "$remote_pair" = "AMBIGUOUS" ]; then
-      echo "  $name: skipped (multiple remotes, none local; set GC_DOLT_REMOTE_$(db_env_key "$name" 2>/dev/null) to pin one)"
+      echo "  $name: skipped (no local remote; set GC_DOLT_REMOTE_$(db_env_key "$name" 2>/dev/null) to push to a non-local remote)"
     else
       echo "  $name: skipped (no remote)"
     fi

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -19,6 +19,25 @@
 #      on legacy setups.
 #   3. Fallback when active_branch() cannot be resolved (or in CLI mode): 'main'.
 #
+# Remote resolution (per database):
+#   1. GC_DOLT_REMOTE_<DB_UPPER> env var override, naming a configured remote
+#      by name (same key derivation as GC_DOLT_REFSPEC_<DB_UPPER> above). This
+#      pins the remote regardless of scheme — an explicit override is by
+#      definition intentional, so it is honored even for a non-local remote.
+#   2. Exactly one configured remote: used regardless of scheme. There is no
+#      ambiguity to gate when the database was only ever told about one
+#      remote — being the sole choice is itself an instruction to use it.
+#   3. Multiple configured remotes, no override: the first file:// remote in
+#      name-sorted order wins, deterministically and independent of whatever
+#      order the database itself returns candidates in (gc-fqi7kq: an
+#      unordered SELECT made this pick 1-of-N at random, occasionally
+#      selecting a public network remote for private fleet data). Preferring
+#      file:// keeps local/backup remotes from losing to a network remote by
+#      accident.
+#   4. Multiple configured remotes, no override, none is file://: ambiguous
+#      by policy. Sync skips the database and reports why rather than
+#      guessing among non-local remotes; set the override (case 1) to choose.
+#
 # Environment:
 #   GC_CITY_PATH                          (required) — city root
 #   GC_DOLT_PORT                          (required) — managed dolt port
@@ -189,16 +208,35 @@ valid_branch_name() {
   esac
 }
 
-# refspec_env_value <db> — emit the GC_DOLT_REFSPEC_<DB_UPPER> override, if any.
-# DB name is uppercased and '-' is replaced with '_' to form a valid env key.
-refspec_env_value() {
-  db="$1"
-  valid_database_name "$db" || return 1
-  key=$(printf '%s' "$db" | tr 'a-z-' 'A-Z_')
+# db_env_key <db> — uppercase a database name and replace '-' with '_' to form
+# an env-var key segment (shared by GC_DOLT_REFSPEC_<KEY> and
+# GC_DOLT_REMOTE_<KEY>). Returns 1 if the name itself is invalid. Empty stdout
+# with a 0 return means the name is valid but its uppercased form still
+# contains characters that cannot form a bare env var name (e.g. '.') — no
+# override is possible for it; callers treat that as "no override" rather
+# than an error.
+db_env_key() {
+  valid_database_name "$1" || return 1
+  key=$(printf '%s' "$1" | tr 'a-z-' 'A-Z_')
   case "$key" in
     *[!A-Z0-9_]*) return 0 ;;
   esac
+  printf '%s' "$key"
+}
+
+# refspec_env_value <db> — emit the GC_DOLT_REFSPEC_<DB_UPPER> override, if any.
+refspec_env_value() {
+  key=$(db_env_key "$1") || return 1
+  [ -z "$key" ] && return 0
   eval "printf '%s' \"\${GC_DOLT_REFSPEC_$key:-}\""
+}
+
+# remote_env_value <db> — emit the GC_DOLT_REMOTE_<DB_UPPER> override, if any.
+# See select_remote for how this pins remote selection.
+remote_env_value() {
+  key=$(db_env_key "$1") || return 1
+  [ -z "$key" ] && return 0
+  eval "printf '%s' \"\${GC_DOLT_REMOTE_$key:-}\""
 }
 
 warn_refspec_fallback() {
@@ -256,10 +294,60 @@ classify_count() {
   printf '%s\n' "$cc_out" | awk -F, 'NR == 2 { gsub(/^"|"$/, "", $1); print $1; exit }'
 }
 
+# select_remote <db> <pairs> — apply the remote-selection policy (see the
+# "Remote resolution" header doc) over newline-separated "name|url" candidate
+# pairs and emit the winner as "name|url". Emits nothing for zero candidates,
+# or the literal token "AMBIGUOUS" when multiple non-local candidates exist
+# with no override to break the tie. Never depends on the input's row order:
+# candidates are sorted by name before any policy rule is applied. Returns 1
+# (with its own stderr message) only when GC_DOLT_REMOTE_<DB> is set but
+# names a remote that is not among the candidates.
+select_remote() {
+  sr_db="$1"
+  sr_pairs="$2"
+  [ -z "$sr_pairs" ] && return 0
+
+  sr_sorted=$(printf '%s\n' "$sr_pairs" | sort -t'|' -k1,1)
+
+  sr_override=$(remote_env_value "$sr_db") || return 1
+  if [ -n "$sr_override" ]; then
+    sr_match=$(printf '%s\n' "$sr_sorted" | awk -F'|' -v want="$sr_override" '$1 == want {print; exit}')
+    if [ -z "$sr_match" ]; then
+      echo "  $sr_db: ERROR: GC_DOLT_REMOTE override '$sr_override' does not match any configured remote" >&2
+      return 1
+    fi
+    printf '%s\n' "$sr_match"
+    return 0
+  fi
+
+  sr_count=$(printf '%s\n' "$sr_sorted" | wc -l | tr -d '[:space:]')
+  if [ "$sr_count" -eq 1 ]; then
+    printf '%s\n' "$sr_sorted"
+    return 0
+  fi
+
+  sr_local=$(printf '%s\n' "$sr_sorted" | awk -F'|' '$2 ~ /^file:\/\// {print; exit}')
+  if [ -n "$sr_local" ]; then
+    printf '%s\n' "$sr_local"
+    return 0
+  fi
+
+  printf 'AMBIGUOUS\n'
+  return 0
+}
+
+# find_remote_sql <db> — query all configured remotes over SQL and resolve
+# the one to sync against via select_remote. ORDER BY name keeps the raw
+# query itself deterministic; select_remote re-sorts independently so
+# correctness never relies on the server actually honoring it.
 find_remote_sql() {
   db="$1"
-  remote_csv=$(dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1") || return 1
-  printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
+  remote_csv=$(dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes ORDER BY name") || {
+    echo "  $db: ERROR: failed to query remotes" >&2
+    return 1
+  }
+  pairs=$(printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2}')
+  select_remote "$db" "$pairs"
 }
 
 # resolve_refspec_sql <db> — emit two lines: local-branch and remote-branch.
@@ -356,12 +444,15 @@ sync_database_sql() {
   fi
 
   remote_pair=$(find_remote_sql "$name") || {
-    echo "  $name: ERROR: failed to query remotes" >&2
     last_fail_reason="failed to query remotes"
     return 1
   }
-  if [ -z "$remote_pair" ]; then
-    echo "  $name: skipped (no remote)"
+  if [ -z "$remote_pair" ] || [ "$remote_pair" = "AMBIGUOUS" ]; then
+    if [ "$remote_pair" = "AMBIGUOUS" ]; then
+      echo "  $name: skipped (multiple remotes, none local; set GC_DOLT_REMOTE_$(db_env_key "$name" 2>/dev/null) to pin one)"
+    else
+      echo "  $name: skipped (no remote)"
+    fi
     return 0
   fi
   remote_name=${remote_pair%%|*}
@@ -531,23 +622,38 @@ sync_database_sql() {
   return 1
 }
 
+# remotes_json_pairs <remotes.json path> — emit newline-separated "name|url"
+# pairs from a Dolt CLI remotes.json. Requires name and url to appear
+# adjacent as "name":"...","url":"..." (the shape Dolt actually writes); an
+# entry that doesn't match this shape is skipped rather than guessed at.
+remotes_json_pairs() {
+  [ -f "$1" ] || return 0
+  grep -o '"name":"[^"]*","url":"[^"]*"' "$1" 2>/dev/null |
+    sed 's/"name":"//;s/","url":"/|/;s/"$//'
+}
+
 sync_database_cli() {
   d="$1"
   name="$2"
+  if ! valid_database_name "$name"; then
+    echo "  $name: ERROR: invalid database name" >&2
+    return 1
+  fi
 
   # Check for remote.
-  remote_name=""
-  remote=""
-  if [ -f "$d/.dolt/remotes.json" ]; then
-    remote_name=$(grep -o '"name":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"name":"//;s/"//' || true)
-    remote=$(grep -o '"url":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"url":"//;s/"//' || true)
-  fi
-  [ -z "$remote_name" ] && remote_name="origin"
-
-  if [ -z "$remote" ]; then
-    echo "  $name: skipped (no remote)"
+  pairs=$(remotes_json_pairs "$d/.dolt/remotes.json")
+  remote_pair=$(select_remote "$name" "$pairs") || return 1
+  if [ -z "$remote_pair" ] || [ "$remote_pair" = "AMBIGUOUS" ]; then
+    if [ "$remote_pair" = "AMBIGUOUS" ]; then
+      echo "  $name: skipped (multiple remotes, none local; set GC_DOLT_REMOTE_$(db_env_key "$name" 2>/dev/null) to pin one)"
+    else
+      echo "  $name: skipped (no remote)"
+    fi
     return 0
   fi
+  remote_name=${remote_pair%%|*}
+  remote=${remote_pair#*|}
+
   if ! valid_remote_name "$remote_name"; then
     echo "  $name: ERROR: invalid remote name: $remote_name" >&2
     last_fail_reason="invalid remote name: $remote_name"

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -297,11 +297,13 @@ classify_count() {
 # select_remote <db> <pairs> — apply the remote-selection policy (see the
 # "Remote resolution" header doc) over newline-separated "name|url" candidate
 # pairs and emit the winner as "name|url". Emits nothing for zero candidates,
-# or the literal token "AMBIGUOUS" when multiple non-local candidates exist
-# with no override to break the tie. Never depends on the input's row order:
-# candidates are sorted by name before any policy rule is applied. Returns 1
-# (with its own stderr message) only when GC_DOLT_REMOTE_<DB> is set but
-# names a remote that is not among the candidates.
+# or the literal token "AMBIGUOUS" when no candidate is local and no override
+# was given — regardless of how many candidates there are, including exactly
+# one: a sole remote is not auto-selected unless it is local. Never depends
+# on the input's row order: candidates are sorted by name before any policy
+# rule is applied. Returns 1 (with its own stderr message) only when
+# GC_DOLT_REMOTE_<DB> is set but names a remote that is not among the
+# candidates.
 select_remote() {
   sr_db="$1"
   sr_pairs="$2"
@@ -317,12 +319,6 @@ select_remote() {
       return 1
     fi
     printf '%s\n' "$sr_match"
-    return 0
-  fi
-
-  sr_count=$(printf '%s\n' "$sr_sorted" | wc -l | tr -d '[:space:]')
-  if [ "$sr_count" -eq 1 ]; then
-    printf '%s\n' "$sr_sorted"
     return 0
   fi
 

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -58,7 +58,7 @@ func fakeDoltHeader(logPath, branch string) string {
 	return "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
 		"case \"$*\" in\n" +
-		"  *\"SELECT name, url FROM dolt_remotes LIMIT 1\"*)\n" +
+		"  *\"SELECT name, url FROM dolt_remotes ORDER BY name\"*)\n" +
 		"    printf 'name,url\\norigin,https://example.invalid/repo\\n' ; exit 0 ;;\n" +
 		"  *\"SELECT active_branch()\"*)\n" +
 		"    printf 'active_branch()\\n" + branch + "\\n' ; exit 0 ;;\n"
@@ -222,6 +222,147 @@ func TestSyncEmptyRemoteFirstPushPushes(t *testing.T) {
 	out := runFFSync(t, binDir, "--db", "app")
 	if !strings.Contains(readLog(t, logPath), "CALL DOLT_PUSH('origin', 'main')") {
 		t.Fatalf("first push to an empty remote must push.\nout:\n%s\nlog:\n%s", out, readLog(t, logPath))
+	}
+}
+
+// --- gc-fqi7kq: deterministic, opt-in-gated remote selection ---
+//
+// find_remote_sql (and the CLI-mode equivalent) must resolve the SAME remote
+// for a given database regardless of what order dolt_remotes rows arrive in;
+// must never auto-select a non-file:// remote when a file:// alternative
+// exists, or when no local alternative exists at all (skip with a stated
+// reason instead); and must honor an explicit GC_DOLT_REMOTE_<DB> override —
+// even over a non-local remote. These tests run --force --dry-run so the
+// fake dolt only needs to answer the remote-lookup + active_branch queries;
+// ff-classification is already covered by the tests above.
+
+// writeSyncFakeDoltMultiRemote installs a fake dolt that answers the
+// remote-lookup query with remoteRows ("name,url" pairs) in exactly the
+// order given, and active_branch() with "main". Callers only need the
+// installed binary (they assert on gc dolt sync's stdout), not the log
+// path, so unlike the other fixture builders in this file this one returns
+// nothing.
+func writeSyncFakeDoltMultiRemote(t *testing.T, dir string, remoteRows []string) {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	reply := "name,url\\n" + strings.Join(remoteRows, "\\n") + "\\n"
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
+    printf '` + reply + `'
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}
+
+// TestSyncRemoteSelectionIsOrderIndependent is the RED test from gc-fqi7kq: a
+// db whose dolt_remotes returns rows in varying order must resolve the same
+// remote every time. Mirrors the real incident's remote set (a git+https
+// upstream plus two file:// backups) across three distinct row orderings.
+func TestSyncRemoteSelectionIsOrderIndependent(t *testing.T) {
+	origin := "origin,git+https://github.com/gastownhall/beads"
+	usb := "usb,file:///mnt/usb/beads"
+	usbSnap := "usb_snap_20260820,file:///mnt/usb/beads_snap"
+	orders := [][]string{
+		{origin, usb, usbSnap},
+		{usbSnap, usb, origin},
+		{usb, origin, usbSnap},
+	}
+	const want = "-> usb:main (file:///mnt/usb/beads)"
+	for i, rows := range orders {
+		binDir := t.TempDir()
+		writeSyncFakeDoltMultiRemote(t, binDir, rows)
+		out := runFFSync(t, binDir, "--db", "app", "--force", "--dry-run")
+		if !strings.Contains(out, want) {
+			t.Fatalf("order %d: expected remote 'usb' selected regardless of row order.\nrows: %v\nout:\n%s", i, rows, out)
+		}
+	}
+}
+
+// TestSyncMultiRemoteAmbiguousNonLocalSkipsAndNeverPushes covers the case
+// where every configured remote is non-local: a default (non-opt-in) sync
+// must report the database as skipped, with a stated reason, and never
+// select or push to either remote.
+func TestSyncMultiRemoteAmbiguousNonLocalSkipsAndNeverPushes(t *testing.T) {
+	binDir := t.TempDir()
+	writeSyncFakeDoltMultiRemote(t, binDir, []string{
+		"mirror,git+https://example.invalid/mirror",
+		"origin,git+https://github.com/gastownhall/beads",
+	})
+	out := runFFSync(t, binDir, "--db", "app", "--force", "--dry-run")
+	if !strings.Contains(out, "skipped") || !strings.Contains(out, "none local") {
+		t.Fatalf("expected an ambiguous-remote skip with a stated reason.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "would") {
+		t.Fatalf("ambiguous remotes must never be auto-selected.\nout:\n%s", out)
+	}
+}
+
+// TestSyncMultiRemotePrefersLocalOverGitHttpsRemote covers the case where a
+// git+https remote is configured alongside a file:// alternative: the
+// git+https remote must never be the one selected/pushed.
+func TestSyncMultiRemotePrefersLocalOverGitHttpsRemote(t *testing.T) {
+	binDir := t.TempDir()
+	writeSyncFakeDoltMultiRemote(t, binDir, []string{
+		"origin,git+https://github.com/gastownhall/beads",
+		"usb,file:///mnt/usb/beads",
+	})
+	out := runFFSync(t, binDir, "--db", "app", "--force", "--dry-run")
+	if !strings.Contains(out, "-> usb:main (file:///mnt/usb/beads)") {
+		t.Fatalf("expected the local (file://) remote to be preferred over git+https.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "-> origin:") {
+		t.Fatalf("git+https remote must never be auto-selected when a local alternative exists.\nout:\n%s", out)
+	}
+}
+
+// TestSyncRemoteEnvOverridePinsNonLocalRemote verifies that GC_DOLT_REMOTE_<DB>
+// pins remote selection even to a non-local (git+https) remote that the
+// default policy would otherwise skip past in favor of a file:// alternative.
+func TestSyncRemoteEnvOverridePinsNonLocalRemote(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	writeSyncFakeBeadsBD(t, cityPath)
+
+	binDir := t.TempDir()
+	writeSyncFakeDoltMultiRemote(t, binDir, []string{
+		"origin,git+https://github.com/gastownhall/beads",
+		"usb,file:///mnt/usb/beads",
+	})
+
+	cmd := exec.Command("sh", script, "--db", "app", "--force", "--dry-run")
+	cmd.Env = append(syncFilteredEnv(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_REMOTE_APP=origin",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "-> origin:main (git+https://github.com/gastownhall/beads)") {
+		t.Fatalf("GC_DOLT_REMOTE_APP=origin should pin selection to origin even though usb (file://) is available.\nout:\n%s", out)
 	}
 }
 

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -314,7 +314,7 @@ func TestSyncMultiRemoteAmbiguousNonLocalSkipsAndNeverPushes(t *testing.T) {
 		"origin,git+https://github.com/gastownhall/beads",
 	})
 	out := runFFSync(t, binDir, "--db", "app", "--force", "--dry-run")
-	if !strings.Contains(out, "skipped") || !strings.Contains(out, "none local") {
+	if !strings.Contains(out, "skipped") || !strings.Contains(out, "no local remote") {
 		t.Fatalf("expected an ambiguous-remote skip with a stated reason.\nout:\n%s", out)
 	}
 	if strings.Contains(out, "would") {
@@ -376,11 +376,130 @@ func TestSyncSoleNonLocalRemoteSkipsAndNeverPushes(t *testing.T) {
 	})
 
 	out := runFFSync(t, binDir, "--db", "app", "--force", "--dry-run")
-	if !strings.Contains(out, "skipped") || !strings.Contains(out, "none local") {
+	if !strings.Contains(out, "skipped") || !strings.Contains(out, "no local remote") {
 		t.Fatalf("a sole non-local remote must be skipped with a stated reason, same as the multi-remote ambiguous case.\nout:\n%s", out)
 	}
 	if strings.Contains(out, "would") {
 		t.Fatalf("a sole non-local remote must never be auto-selected or pushed to.\nout:\n%s", out)
+	}
+}
+
+// TestSyncSQLUnknownRemoteOverrideFailsWithStatedReason covers the one path
+// where select_remote returns non-zero: GC_DOLT_REMOTE_<DB> names a remote
+// that is not configured. The database must fail (not silently fall back to
+// the default policy), the stderr must name the offending override, and the
+// trailing failure summary must attribute the failure to the refusal rather
+// than to a remote *query* failure that did not happen.
+func TestSyncSQLUnknownRemoteOverrideFailsWithStatedReason(t *testing.T) {
+	t.Parallel()
+	binDir := t.TempDir()
+	writeSyncFakeDoltMultiRemote(t, binDir, []string{
+		"origin,git+https://github.com/gastownhall/beads",
+		"usb,file:///mnt/usb/beads",
+	})
+
+	out, err := runFFSyncEnv(t, binDir, []string{"GC_DOLT_REMOTE_APP=nope"}, "--db", "app", "--force", "--dry-run")
+	if err == nil {
+		t.Fatalf("an override naming an unconfigured remote must fail the database.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "GC_DOLT_REMOTE override 'nope' does not match any configured remote") {
+		t.Fatalf("expected the specific unknown-override error.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "remote selection refused") {
+		t.Fatalf("summary must attribute the failure to the refusal, not to a remote-query failure.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "failed to query remotes") {
+		t.Fatalf("the remote query succeeded; it must not be blamed.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "would") {
+		t.Fatalf("a refused override must never fall back to selecting a remote.\nout:\n%s", out)
+	}
+}
+
+// --- CLI-mode (.dolt/remotes.json) equivalents of the SQL cases above ---
+//
+// sync_database_cli feeds select_remote from remotes_json_pairs instead of
+// dolt_remotes, so the same policy has a second, independently-parsed
+// candidate source. These mirror the SQL cases against it: prefer local,
+// skip a sole non-local remote, and honor the override. runSync forces CLI
+// mode by pointing the script at an unreachable SQL port.
+
+// writeSyncCLIRemotes creates the data/<db>/.dolt/remotes.json fixture that
+// sync_database_cli parses, and returns the city path it was created under.
+func writeSyncCLIRemotes(t *testing.T, remotesJSON string) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	dbDir := filepath.Join(cityPath, "data", "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotesJSON), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+	return cityPath
+}
+
+// TestSyncCLIMultiRemotePrefersLocal is the CLI-mode twin of
+// TestSyncMultiRemotePrefersLocalOverGitHttpsRemote: with a git+https remote
+// listed first and a file:// alternative available, the local one wins.
+func TestSyncCLIMultiRemotePrefersLocal(t *testing.T) {
+	t.Parallel()
+	cityPath := writeSyncCLIRemotes(t, `{"remotes":[{"name":"origin","url":"git+https://github.com/gastownhall/beads"},{"name":"usb","url":"file:///mnt/usb/beads"}]}`)
+	binDir := t.TempDir()
+	_ = writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	out, err := runSync(t, binDir, cityPath, []string{"GC_DOLT_REMOTE_APP="}, "--db", "app", "--dry-run")
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "-> usb:main (file:///mnt/usb/beads)") {
+		t.Fatalf("CLI mode should prefer the local (file://) remote over git+https.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "-> origin:") {
+		t.Fatalf("git+https remote must never be auto-selected when a local alternative exists.\nout:\n%s", out)
+	}
+}
+
+// TestSyncCLISoleNonLocalRemoteSkips is the CLI-mode twin of
+// TestSyncSoleNonLocalRemoteSkipsAndNeverPushes: a sole non-local remote is
+// not exempt from the locality rule just because there was nothing to
+// disambiguate.
+func TestSyncCLISoleNonLocalRemoteSkips(t *testing.T) {
+	t.Parallel()
+	cityPath := writeSyncCLIRemotes(t, `{"remotes":[{"name":"origin","url":"git+https://github.com/gastownhall/beads"}]}`)
+	binDir := t.TempDir()
+	_ = writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	out, err := runSync(t, binDir, cityPath, []string{"GC_DOLT_REMOTE_APP="}, "--db", "app", "--dry-run")
+	if err != nil {
+		t.Fatalf("a skip is not a failure; sync should exit 0: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "skipped") || !strings.Contains(out, "no local remote") {
+		t.Fatalf("a sole non-local remote must be skipped with a stated reason.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "would") {
+		t.Fatalf("a sole non-local remote must never be auto-selected or pushed to.\nout:\n%s", out)
+	}
+}
+
+// TestSyncCLIRemoteOverridePinsNonLocal is the CLI-mode twin of
+// TestSyncRemoteEnvOverridePinsNonLocalRemote: an explicit override pins a
+// non-local remote the default policy would otherwise pass over.
+func TestSyncCLIRemoteOverridePinsNonLocal(t *testing.T) {
+	t.Parallel()
+	cityPath := writeSyncCLIRemotes(t, `{"remotes":[{"name":"origin","url":"git+https://github.com/gastownhall/beads"},{"name":"usb","url":"file:///mnt/usb/beads"}]}`)
+	binDir := t.TempDir()
+	_ = writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	out, err := runSync(t, binDir, cityPath, []string{"GC_DOLT_REMOTE_APP=origin"}, "--db", "app", "--dry-run")
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "-> origin:main (git+https://github.com/gastownhall/beads)") {
+		t.Fatalf("GC_DOLT_REMOTE_APP=origin should pin selection to origin even though usb (file://) is available.\nout:\n%s", out)
 	}
 }
 

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -357,6 +357,28 @@ func TestSyncRemoteEnvOverridePinsNonLocalRemote(t *testing.T) {
 	}
 }
 
+// TestSyncSoleNonLocalRemoteSkipsAndNeverPushes covers the case the original
+// fix (ga-fqi7kq) missed: select_remote's sr_count -eq 1 branch returned the
+// sole candidate unconditionally, with no locality check at all, so a
+// database whose only configured remote is non-local (e.g. a public
+// git+https upstream) was auto-selected and pushed to. The locality rule
+// that already applies when there are multiple remotes must apply
+// identically when there is exactly one.
+func TestSyncSoleNonLocalRemoteSkipsAndNeverPushes(t *testing.T) {
+	binDir := t.TempDir()
+	writeSyncFakeDoltMultiRemote(t, binDir, []string{
+		"origin,git+https://github.com/gastownhall/beads",
+	})
+
+	out := runFFSync(t, binDir, "--db", "app", "--force", "--dry-run")
+	if !strings.Contains(out, "skipped") || !strings.Contains(out, "none local") {
+		t.Fatalf("a sole non-local remote must be skipped with a stated reason, same as the multi-remote ambiguous case.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "would") {
+		t.Fatalf("a sole non-local remote must never be auto-selected or pushed to.\nout:\n%s", out)
+	}
+}
+
 // TestSyncRejectsInvalidFetchTimeout covers the GC_DOLT_SYNC_FETCH_TIMEOUT_SECS
 // validator (the twin of the push-timeout validator): the bound is checked at
 // startup before any database is touched, and an empty / non-numeric / all-zero

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -22,9 +22,13 @@ import (
 	"testing"
 )
 
-// runFFSync sets up a one-DB ("app") SQL-mode city with the fake dolt already
-// installed in binDir, runs `gc dolt sync <args>`, and returns combined output.
-func runFFSync(t *testing.T, binDir string, args ...string) string {
+// runFFSyncEnv sets up a one-DB ("app") SQL-mode city with the fake dolt
+// already installed in binDir, runs `gc dolt sync <args>` with extraEnv
+// appended after the base sync env (so an override such as
+// GC_DOLT_REMOTE_<DB> takes effect), and returns combined output plus the
+// command's error so callers that must assert the sync itself did not fail
+// (as opposed to merely producing unexpected output) can do so.
+func runFFSyncEnv(t *testing.T, binDir string, extraEnv []string, args ...string) (string, error) {
 	t.Helper()
 	root := repoRoot(t)
 	script := filepath.Join(root, syncScript)
@@ -48,8 +52,18 @@ func runFFSync(t *testing.T, binDir string, args ...string) string {
 		"GC_DOLT_USER=root",
 		"GC_DOLT_PASSWORD=",
 	)
-	out, _ := cmd.CombinedOutput()
-	return string(out)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runFFSync is runFFSyncEnv with no extra environment variables, discarding
+// the command error: none of its callers assert on the sync's exit status,
+// only on its output.
+func runFFSync(t *testing.T, binDir string, args ...string) string {
+	t.Helper()
+	out, _ := runFFSyncEnv(t, binDir, nil, args...)
+	return out
 }
 
 // fakeDoltHeader is the shared preamble: log argv and answer the remote-lookup
@@ -328,40 +342,17 @@ func TestSyncMultiRemotePrefersLocalOverGitHttpsRemote(t *testing.T) {
 // pins remote selection even to a non-local (git+https) remote that the
 // default policy would otherwise skip past in favor of a file:// alternative.
 func TestSyncRemoteEnvOverridePinsNonLocalRemote(t *testing.T) {
-	root := repoRoot(t)
-	script := filepath.Join(root, syncScript)
-	port, cleanup := startReachableTCPListener(t)
-	defer cleanup()
-
-	cityPath := t.TempDir()
-	dataDir := filepath.Join(cityPath, "data")
-	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
-		t.Fatalf("mkdir db: %v", err)
-	}
-	writeSyncFakeBeadsBD(t, cityPath)
-
 	binDir := t.TempDir()
 	writeSyncFakeDoltMultiRemote(t, binDir, []string{
 		"origin,git+https://github.com/gastownhall/beads",
 		"usb,file:///mnt/usb/beads",
 	})
 
-	cmd := exec.Command("sh", script, "--db", "app", "--force", "--dry-run")
-	cmd.Env = append(syncFilteredEnv(),
-		"PATH="+binDir+":"+os.Getenv("PATH"),
-		"GC_CITY_PATH="+cityPath,
-		"GC_PACK_DIR="+root,
-		"GC_DOLT_DATA_DIR="+dataDir,
-		fmt.Sprintf("GC_DOLT_PORT=%d", port),
-		"GC_DOLT_USER=root",
-		"GC_DOLT_PASSWORD=",
-		"GC_DOLT_REMOTE_APP=origin",
-	)
-	out, err := cmd.CombinedOutput()
+	out, err := runFFSyncEnv(t, binDir, []string{"GC_DOLT_REMOTE_APP=origin"}, "--db", "app", "--force", "--dry-run")
 	if err != nil {
 		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "-> origin:main (git+https://github.com/gastownhall/beads)") {
+	if !strings.Contains(out, "-> origin:main (git+https://github.com/gastownhall/beads)") {
 		t.Fatalf("GC_DOLT_REMOTE_APP=origin should pin selection to origin even though usb (file://) is available.\nout:\n%s", out)
 	}
 }

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -282,6 +282,7 @@ exit 0
 // remote every time. Mirrors the real incident's remote set (a git+https
 // upstream plus two file:// backups) across three distinct row orderings.
 func TestSyncRemoteSelectionIsOrderIndependent(t *testing.T) {
+	t.Parallel()
 	origin := "origin,git+https://github.com/gastownhall/beads"
 	usb := "usb,file:///mnt/usb/beads"
 	usbSnap := "usb_snap_20260820,file:///mnt/usb/beads_snap"
@@ -306,6 +307,7 @@ func TestSyncRemoteSelectionIsOrderIndependent(t *testing.T) {
 // must report the database as skipped, with a stated reason, and never
 // select or push to either remote.
 func TestSyncMultiRemoteAmbiguousNonLocalSkipsAndNeverPushes(t *testing.T) {
+	t.Parallel()
 	binDir := t.TempDir()
 	writeSyncFakeDoltMultiRemote(t, binDir, []string{
 		"mirror,git+https://example.invalid/mirror",
@@ -324,6 +326,7 @@ func TestSyncMultiRemoteAmbiguousNonLocalSkipsAndNeverPushes(t *testing.T) {
 // git+https remote is configured alongside a file:// alternative: the
 // git+https remote must never be the one selected/pushed.
 func TestSyncMultiRemotePrefersLocalOverGitHttpsRemote(t *testing.T) {
+	t.Parallel()
 	binDir := t.TempDir()
 	writeSyncFakeDoltMultiRemote(t, binDir, []string{
 		"origin,git+https://github.com/gastownhall/beads",
@@ -342,6 +345,7 @@ func TestSyncMultiRemotePrefersLocalOverGitHttpsRemote(t *testing.T) {
 // pins remote selection even to a non-local (git+https) remote that the
 // default policy would otherwise skip past in favor of a file:// alternative.
 func TestSyncRemoteEnvOverridePinsNonLocalRemote(t *testing.T) {
+	t.Parallel()
 	binDir := t.TempDir()
 	writeSyncFakeDoltMultiRemote(t, binDir, []string{
 		"origin,git+https://github.com/gastownhall/beads",
@@ -365,6 +369,7 @@ func TestSyncRemoteEnvOverridePinsNonLocalRemote(t *testing.T) {
 // that already applies when there are multiple remotes must apply
 // identically when there is exactly one.
 func TestSyncSoleNonLocalRemoteSkipsAndNeverPushes(t *testing.T) {
+	t.Parallel()
 	binDir := t.TempDir()
 	writeSyncFakeDoltMultiRemote(t, binDir, []string{
 		"origin,git+https://github.com/gastownhall/beads",

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -73,7 +73,7 @@ func fakeDoltHeader(logPath, branch string) string {
 		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
 		"case \"$*\" in\n" +
 		"  *\"SELECT name, url FROM dolt_remotes ORDER BY name\"*)\n" +
-		"    printf 'name,url\\norigin,https://example.invalid/repo\\n' ; exit 0 ;;\n" +
+		"    printf 'name,url\\norigin,file:///example.invalid/repo\\n' ; exit 0 ;;\n" +
 		"  *\"SELECT active_branch()\"*)\n" +
 		"    printf 'active_branch()\\n" + branch + "\\n' ; exit 0 ;;\n"
 }

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -83,6 +83,11 @@ func startReachableTCPListener(t *testing.T) (int, func()) {
 	return listener.Addr().(*net.TCPAddr).Port, cleanup
 }
 
+// writeSyncFakeDolt is shared with pull_test.go (writeSyncFakeDolt is called
+// from TestPull* there too) — its remote-lookup arm intentionally matches on
+// the query prefix only ("...FROM dolt_remotes", no trailing clause) so it
+// answers both sync's "ORDER BY name" query and pull's unchanged "LIMIT 1"
+// query identically.
 func writeSyncFakeDolt(t *testing.T, dir string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
@@ -116,7 +121,7 @@ func writeSyncFakeDoltActiveBranch(t *testing.T, dir, activeBranch string) strin
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
-  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,https://example.invalid/repo\n'
     ;;
   *"CALL DOLT_FETCH("*)
@@ -146,7 +151,7 @@ func writeSyncFakeDoltInvalidActiveBranch(t *testing.T, dir string) string {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
-  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,https://example.invalid/repo\n'
     ;;
   *"CALL DOLT_FETCH("*)
@@ -170,6 +175,8 @@ exit 0
 	return logPath
 }
 
+// writeSyncFakeDoltRemoteLookupFailure is shared with pull_test.go — see the
+// writeSyncFakeDolt comment for why the match is prefix-only.
 func writeSyncFakeDoltRemoteLookupFailure(t *testing.T, dir string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
@@ -209,7 +216,7 @@ func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr s
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
-  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,https://example.invalid/repo\n'
     exit 0
     ;;
@@ -251,7 +258,7 @@ func writeSyncFakeDoltPushFailsNoTrailingNewline(t *testing.T, dir string, exitC
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
-  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,https://example.invalid/repo\n'
     exit 0
     ;;
@@ -342,7 +349,7 @@ func writeSyncFakeDoltPushEchoesArgs(t *testing.T, dir string) {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
-  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+  *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,https://example.invalid/repo\n'
     exit 0
     ;;
@@ -452,7 +459,7 @@ func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 	}
 	log := string(data)
 	for _, want := range []string{
-		"SELECT name, url FROM dolt_remotes LIMIT 1",
+		"SELECT name, url FROM dolt_remotes ORDER BY name",
 		"CALL DOLT_PUSH('origin', 'main')",
 	} {
 		if !strings.Contains(log, want) {
@@ -723,7 +730,7 @@ func TestSyncReportsLiveSQLRemoteLookupFailure(t *testing.T) {
 		t.Fatalf("read fake dolt log: %v", err)
 	}
 	log := string(data)
-	if !strings.Contains(log, "SELECT name, url FROM dolt_remotes LIMIT 1") {
+	if !strings.Contains(log, "SELECT name, url FROM dolt_remotes ORDER BY name") {
 		t.Fatalf("dolt log missing remote lookup:\n%s", log)
 	}
 	if strings.Contains(log, "DOLT_PUSH") {

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -95,7 +95,7 @@ func writeSyncFakeDolt(t *testing.T, dir string) string {
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
   *"SELECT name, url FROM dolt_remotes"*)
-    printf 'name,url\norigin,https://example.invalid/repo\n'
+    printf 'name,url\norigin,file:///example.invalid/repo\n'
     ;;
   *"CALL DOLT_FETCH("*)
     :
@@ -122,7 +122,7 @@ func writeSyncFakeDoltActiveBranch(t *testing.T, dir, activeBranch string) strin
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
-    printf 'name,url\norigin,https://example.invalid/repo\n'
+    printf 'name,url\norigin,file:///example.invalid/repo\n'
     ;;
   *"CALL DOLT_FETCH("*)
     :
@@ -152,7 +152,7 @@ func writeSyncFakeDoltInvalidActiveBranch(t *testing.T, dir string) string {
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
-    printf 'name,url\norigin,https://example.invalid/repo\n'
+    printf 'name,url\norigin,file:///example.invalid/repo\n'
     ;;
   *"CALL DOLT_FETCH("*)
     :
@@ -217,7 +217,7 @@ func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr s
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
-    printf 'name,url\norigin,https://example.invalid/repo\n'
+    printf 'name,url\norigin,file:///example.invalid/repo\n'
     exit 0
     ;;
   *"CALL DOLT_FETCH("*)
@@ -259,7 +259,7 @@ func writeSyncFakeDoltPushFailsNoTrailingNewline(t *testing.T, dir string, exitC
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
-    printf 'name,url\norigin,https://example.invalid/repo\n'
+    printf 'name,url\norigin,file:///example.invalid/repo\n'
     exit 0
     ;;
   *"CALL DOLT_FETCH("*)
@@ -350,7 +350,7 @@ func writeSyncFakeDoltPushEchoesArgs(t *testing.T, dir string) {
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
-    printf 'name,url\norigin,https://example.invalid/repo\n'
+    printf 'name,url\norigin,file:///example.invalid/repo\n'
     exit 0
     ;;
   *"CALL DOLT_FETCH("*)
@@ -445,7 +445,7 @@ func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 
 	// The success line is a parsed contract — assert it byte-for-byte so a
 	// format change is caught here rather than breaking downstream consumers.
-	if !strings.Contains(string(out), "  app: pushed main -> origin:main (https://example.invalid/repo)") {
+	if !strings.Contains(string(out), "  app: pushed main -> origin:main (file:///example.invalid/repo)") {
 		t.Fatalf("output missing byte-for-byte success line:\n%s", out)
 	}
 
@@ -637,7 +637,7 @@ func TestSyncDryRunShowsResolvedActiveBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gc dolt sync --dry-run failed: %v\n%s", err, out)
 	}
-	want := "app: would push gascity-3 -> origin:gascity-3 (https://example.invalid/repo)"
+	want := "app: would push gascity-3 -> origin:gascity-3 (file:///example.invalid/repo)"
 	if !strings.Contains(string(out), want) {
 		t.Fatalf("dry run output should show resolved refspec\nwant %q\ngot:\n%s", want, out)
 	}
@@ -748,7 +748,7 @@ func TestSyncCLIFallbackPushesOriginMain(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
 		t.Fatalf("mkdir db: %v", err)
 	}
-	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	remotes := `{"remotes":[{"name":"origin","url":"file:///example.invalid/repo"}]}`
 	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
 		t.Fatalf("write remotes: %v", err)
 	}
@@ -936,7 +936,7 @@ func TestSyncCLIFallbackReadsRepoStateForActiveBranch(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
 		t.Fatalf("mkdir db: %v", err)
 	}
-	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	remotes := `{"remotes":[{"name":"origin","url":"file:///example.invalid/repo"}]}`
 	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
 		t.Fatalf("write remotes: %v", err)
 	}
@@ -984,7 +984,7 @@ func TestSyncCLIFallbackIgnoresNestedRepoStateHead(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
 		t.Fatalf("mkdir db: %v", err)
 	}
-	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	remotes := `{"remotes":[{"name":"origin","url":"file:///example.invalid/repo"}]}`
 	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
 		t.Fatalf("write remotes: %v", err)
 	}
@@ -1648,7 +1648,7 @@ func TestSyncCLIPushReportsExitCode(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
 		t.Fatalf("mkdir db: %v", err)
 	}
-	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	remotes := `{"remotes":[{"name":"origin","url":"file:///example.invalid/repo"}]}`
 	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
 		t.Fatalf("write remotes: %v", err)
 	}
@@ -1679,7 +1679,7 @@ func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
 		t.Fatalf("mkdir db: %v", err)
 	}
-	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	remotes := `{"remotes":[{"name":"origin","url":"file:///example.invalid/repo"}]}`
 	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
 		t.Fatalf("write remotes: %v", err)
 	}

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -1717,7 +1717,7 @@ func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
 func TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "data")
-	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	remotes := `{"remotes":[{"name":"origin","url":"file:///example.invalid/repo"}]}`
 	for _, name := range []string{"good1", "bad", "good2"} {
 		dbDir := filepath.Join(dataDir, name)
 		if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -86,8 +86,8 @@ func startReachableTCPListener(t *testing.T) (int, func()) {
 // writeSyncFakeDolt is shared with pull_test.go (writeSyncFakeDolt is called
 // from TestPull* there too) — its remote-lookup arm intentionally matches on
 // the query prefix only ("...FROM dolt_remotes", no trailing clause) so it
-// answers both sync's "ORDER BY name" query and pull's unchanged "LIMIT 1"
-// query identically.
+// answers sync's and pull's remote-lookup queries identically without having
+// to track either one's trailing clause (both are "ORDER BY name" today).
 func writeSyncFakeDolt(t *testing.T, dir string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")

--- a/release-gates/ga-n9frq0-dolt-sync-remote-selection-gate.md
+++ b/release-gates/ga-n9frq0-dolt-sync-remote-selection-gate.md
@@ -1,0 +1,66 @@
+# Release gate: deterministic Dolt sync remote selection
+
+- Deploy bead: `ga-n9frq0`
+- Review bead: `ga-qapoc6` (`verdict: pass`)
+- Reviewed source: `abf9c263a78e00bf5a4dbe7e63dc82ac7eaf6d8d`
+- Base checked: `origin/main@5d486251b8a448d31e41c6e826af473a69f6d1ea`
+- Deploy mode: `remote` (`gastownhall/gascity`, push through the configured fork if origin is not writable)
+- Evaluated: 2026-09-04
+
+## Verdict
+
+**PASS.** The reviewed change is ready for an isolated deploy branch and pull request. The full-suite run retained six raw failures; all six are attributed below to four pre-existing, non-diff-owned conditions under the release-gate attribution protocol.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-qapoc6` is closed with `verdict: pass` and pins the exact reviewed commit above. The commit resolves locally to a commit object and equals the evaluated HEAD. |
+| 2 | Acceptance criteria met | PASS | `select_remote` sorts candidates, honors `GC_DOLT_REMOTE_<DB>`, prefers a local `file://` remote, and returns `AMBIGUOUS` rather than selecting a non-local remote without an override. Both SQL and CLI paths use the shared selection policy. The new order-independence, ambiguous-remote, local-preference, override, and sole-non-local tests pass. |
+| 3 | Tests pass | PASS with attributed failures | `make test-local-full-parallel` ran the documented full 40-job suite with the required rootless Podman environment: 34 jobs PASS, 6 jobs FAIL, 0 jobs SKIP. `examples/bd/dolt` passed in the full suite (`ok`, 80.820s). Every failure is non-diff-owned and attributed below. A verbose supplement, `go test -count=1 -v ./examples/bd/dolt/...`, recorded 305 PASS, 0 FAIL, 0 SKIP and maps all 47 top-level tests in the modified test files to PASS. |
+| 3a | Pre-existing failures attributed | PASS | Trackers predate this run, cover the observed root conditions, and were opened before use. The candidate touches only `examples/bd/dolt/**`; none of the failing test paths overlaps the diff. Per-condition evidence is below. |
+| 3b | Policy/lint lane | PASS | `make test-ci-policy`: PASS. `make lint-affected LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=734f18f45915399a900561c3f964e3af96cace0b`: PASS, 0 issues, including its standalone-vet closure. `make fmt-check-changed` with the same diff base: PASS. `make vet`: PASS. An earlier over-expanded invocation using the newer `origin/main` as a direct ref selected full scope because the candidate lacks a main-only gate file and found only tracked third-party `node_modules/flatted` diagnostics; that occurrence is attributed to `ga-bvixfw` and is not the candidate-diff lane. |
+| 3c | CI-config lane | PASS | `ci_lane_run: n/a (no CI configuration, job, matrix, timeout, or required-check change in this diff)`. |
+| 4 | No high-severity review findings open | PASS | `ga-qapoc6` records no blocking style or security findings and closes with PASS; unresolved HIGH count is 0. |
+| 5 | Final branch clean | PASS | `git status --porcelain=v1` produced no output after all test and policy runs. |
+| 6 | Branch diverges cleanly from main | PASS | After a final `git fetch origin main`, `git merge-tree --write-tree origin/main abf9c263a78e00bf5a4dbe7e63dc82ac7eaf6d8d` exited 0 and produced tree `cd08aec0dc1401a6ce68cdf31632ed206abd0c68`. No PR currently carries the reviewed SHA. |
+| 7 | Single feature theme | PASS | The six-commit range changes only three files under `examples/bd/dolt` and implements/tests one behavior: safe deterministic remote selection for `gc dolt sync`. `assert_deploy_ancestry_scope` passed for `ga-n9frq0`, `ga-h9n6hq`, `ga-2w96wd`, and `ga-fqi7kq`. |
+
+## Test evidence integrity
+
+- `test_cmd: make test-local-full-parallel`
+- `test_cmd_scope: full-suite`
+- `test_counts: 34 PASS jobs, 6 FAIL jobs, 0 SKIP jobs`
+- `diff_tests_executed: 47/47 top-level tests in examples/bd/dolt/sync_ffclassify_test.go and examples/bd/dolt/sync_test.go PASS`
+- `skip_justification: none (0 skips)`
+- `waiver_ref: none`
+- `ci_lane_run: n/a (no CI-config change)`
+- Full-suite log: `/var/tmp/ga-n9frq0-full-suite.log`
+- Per-job logs: `/var/tmp/gc-local-tests.bdQ2DM/`
+- Verbose Dolt log: `/var/tmp/ga-n9frq0-dolt-verbose.log`
+
+### Failure attribution
+
+- `TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a), mechanism`: the installed `bd` 1.1.0 build exposes newer flags than `internal/bdflags`; an `examples/bd/dolt` sync script/test diff cannot alter either the installed CLI or the flag manifest. Clause 1 passes (test not modified), clause 2 passes (tracker created 2026-08-15 and opened), and clause 4 passes (no path overlap).
+- `TestPersonalWorkFormulaCompileAndRun`, `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries`, and `TestHumaBinary_SessionMessageAsync -> ga-esyijp | clause 3(a), mechanism`: all fail during fixture `bd init`, before formula/API assertions, with the tracked beads#4566 dirty issues/comments schema-migration refusal. The candidate cannot alter schema migration or fixture bootstrap. Clauses 1, 2, and 4 pass.
+- `test/integration TestMain pinned-bd installation -> ga-qwkwiv | clause 3(a), mechanism`: DNS for `proxy.golang.org` failed through the host resolver before the REST shard could run. The candidate cannot alter host DNS or the pre-test pinned-binary installer. The open tracker predates this run and records the same full-gate DNS-loss condition on an unrelated candidate; there is no path overlap.
+- `TestE2E_SuspendResume_City -> ga-dqd7gf | clause 3(b), cross-candidate`: the exact missing `citysus.report` full-suite timeout was already recorded on an unrelated candidate. The test and session-report path do not overlap or import the changed example package. Clauses 1, 2, and 4 pass.
+- Initial over-expanded full-lint diagnostics in third-party `internal/api/dashboardspa/web/node_modules/flatted/** -> ga-bvixfw | clause 3(a), mechanism`: the candidate does not modify or generate that untracked dependency tree. The correctly scoped affected-diff lane passed with 0 issues.
+
+Each tracker received this run's bead, reviewed SHA, shard, log path, and symptom, and the appended comment was read back after writing.
+
+### Diff-owned test map
+
+The verbose supplement recorded PASS for every top-level test in the two modified test files:
+
+`TestSyncAheadOnlyFastForwardPushes`, `TestSyncBehindRefusesAndDoesNotPush`, `TestSyncCLIFallbackIgnoresNestedRepoStateHead`, `TestSyncCLIFallbackPushesOriginMain`, `TestSyncCLIFallbackReadsRepoStateForActiveBranch`, `TestSyncCLIForcePushReportsExitCode`, `TestSyncCLIPushReportsExitCode`, `TestSyncDivergedRefusesAndDoesNotPush`, `TestSyncDryRunShowsResolvedActiveBranch`, `TestSyncEmptyRemoteFirstPushPushes`, `TestSyncFetchTimeoutSkipsNeverPushes`, `TestSyncFirstPushWhenRemoteRefAbsentPushes`, `TestSyncForceStillPushesWhenDiverged`, `TestSyncForceUsesRefspecEnvOverrideWithLiveSQL`, `TestSyncForceUsesResolvedActiveBranchWithLiveSQL`, `TestSyncForceUsesSetUpstreamWithLiveSQL`, `TestSyncMultiRemoteAmbiguousNonLocalSkipsAndNeverPushes`, `TestSyncMultiRemotePrefersLocalOverGitHttpsRemote`, `TestSyncPushesActiveBranchWhenSet`, `TestSyncRefspecEnvOverride`, `TestSyncRefspecEnvOverrideHyphenInDBName`, `TestSyncRefspecInvalidOverrideFails`, `TestSyncRefspecOptionShapedOverrideFails`, `TestSyncRejectsEmptyPushTimeout`, `TestSyncRejectsInvalidFetchTimeout`, `TestSyncRejectsLeadingZeroPushTimeout`, `TestSyncRejectsNonNumericPushTimeout`, `TestSyncRejectsTripleZeroPushTimeout`, `TestSyncRejectsZeroPushTimeout`, `TestSyncRemoteEnvOverridePinsNonLocalRemote`, `TestSyncRemoteSelectionIsOrderIndependent`, `TestSyncReportsLiveSQLRemoteLookupFailure`, `TestSyncSQLPushEmptyStderrNoBlankLines`, `TestSyncSQLPushReplayDoesNotLeakPassword`, `TestSyncSQLPushReplaysStderr`, `TestSyncSQLPushReplaysStderrFinalLineWithoutTrailingNewline`, `TestSyncSQLPushReportsExitCode`, `TestSyncSQLPushTempFileFailureDegradesPerDb`, `TestSyncSQLPushTimeoutHonorsConfiguredCeiling`, `TestSyncSQLPushTimeoutReplaysNoMechanismMarker`, `TestSyncSQLPushTimeoutReportsTimeout`, `TestSyncSkipsDatabasesWithNoSyncMarker`, `TestSyncSoleNonLocalRemoteSkipsAndNeverPushes`, `TestSyncSummaryNamesFailedDatabaseAmongHealthyOnes`, `TestSyncUpToDateSkipsPush`, `TestSyncUsesLiveSQLWhenManagedServerReachable`, and `TestSyncWarnsWhenActiveBranchFallbacksToMain`.
+
+## Acceptance evidence
+
+- The final diff is 317 insertions and 49 deletions across `commands/sync/run.sh`, `sync_ffclassify_test.go`, and `sync_test.go`.
+- Candidate rows are sorted before selection, so database row order cannot change the winner.
+- An explicit configured remote name must match a real candidate and overrides scheme preference.
+- Without an override, local `file://` candidates are preferred; all-non-local sets, including a sole non-local remote, are skipped as ambiguous rather than pushed.
+- SQL and CLI modes both call the same `select_remote` policy.
+- The existing multi-database summary fixture now uses a local remote and still passes under the stricter selection policy.
+


### PR DESCRIPTION
## What this changes

`gc dolt sync` now selects push remotes deterministically. An explicit `GC_DOLT_REMOTE_<DB>` override wins; otherwise a local `file://` remote is preferred. If only non-local remotes are available without an override—including a sole non-local remote—the database is skipped instead of risking an unintended push. SQL and CLI fallback paths share the same policy.

## Review notes

- Review `examples/bd/dolt/commands/sync/run.sh` for override validation and the shared SQL/CLI selection path.
- This is a safety behavior change: unattended sync may now skip a sole non-local remote unless explicitly pinned.
- No config migration is required; operators that intend a network push can set `GC_DOLT_REMOTE_<DB>`.

## Test plan

- [x] Run `make test-local-full-parallel`; confirm the Dolt package passes and unrelated fleet failures match tracked conditions documented in the gate.
- [x] Run the verbose full `examples/bd/dolt` suite and confirm all modified tests execute with no skips.
- [x] Run policy, affected lint/format, and full vet lanes.
- [x] Release gate: [`release-gates/ga-n9frq0-dolt-sync-remote-selection-gate.md`](release-gates/ga-n9frq0-dolt-sync-remote-selection-gate.md)
