### PR TITLE
perf(cli): stop eagerly reloading city config on every control-ready tick

### DIFF
--- a/cmd/gc/dispatch_control_ready.go
+++ b/cmd/gc/dispatch_control_ready.go
@@ -454,7 +454,16 @@ type controlReadyCacheEntry struct {
 // loop's typical call pattern is sequential-per-tick per dir. Note the entries
 // are keyed by scope dir, so on a split city every rig dispatcher primes the
 // shared city binding independently (ga-n6gnr).
-func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.CachingStore {
+//
+// cfgFn is called at most once, and only on the branch that actually opens
+// the leg stores (no entry yet, or an expired one) -- the hot within-TTL path
+// never touches it. A full config load re-validates every builtin pack's file
+// manifest (EnsureBuiltinRuntimeAssets), so paying it on ticks this cache
+// already answers from a warm snapshot was the dominant cost of the
+// control-dispatcher serve loop's steady-state CPU (sample-profiled: 86/87
+// samples under loadCityConfig). cfgFn lets the caller defer that cost to the
+// ticks that truly need it.
+func controlReadyCachesFor(dir, cityPath string, cfgFn func() *config.City) []*beads.CachingStore {
 	controlReadyCacheRegistry.mu.Lock()
 	entry, ok := controlReadyCacheRegistry.byDir[dir]
 	fresh := ok && time.Since(entry.primedAt) < controlReadyCacheTTL
@@ -463,6 +472,10 @@ func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.Cach
 		return entry.caches
 	}
 
+	var cfg *config.City
+	if cfgFn != nil {
+		cfg = cfgFn()
+	}
 	sources, err := controlReadyCacheSources(dir, cityPath, cfg)
 	if err != nil {
 		return nil
@@ -524,6 +537,15 @@ func cachedControlReadyUnion(caches []*beads.CachingStore) ([]beads.Bead, bool) 
 	return mergeControlReadyLegs(legs...), true
 }
 
+// loadCityConfigForControlReady is a seam so tests can observe (or stub out)
+// the config load tryControlReadyFromCacheOrFallback pays for on a cold-start
+// or expired cache. Production loads the real config, at the same cost
+// EnsureBuiltinRuntimeAssets always charges the first caller into a city.
+var loadCityConfigForControlReady = func(cityPath string) *config.City {
+	cfg, _ := loadCityConfig(cityPath, io.Discard)
+	return cfg
+}
+
 // tryControlReadyFromCacheOrFallback answers a control-dispatcher readiness
 // scan in-process instead of running workflowServeControlReadyQueryForBeads's
 // shell script. handled reports whether workQuery was even recognized as a
@@ -539,11 +561,11 @@ func tryControlReadyFromCacheOrFallback(workQuery, dir string, env map[string]st
 	}
 
 	cityPath := cityForStoreDir(dir)
-	cfg, _ := loadCityConfig(cityPath, io.Discard)
 	envList := mergeRuntimeEnv(os.Environ(), env)
 
 	if !parsed.includeEphemeral {
-		if caches := controlReadyCachesFor(dir, cityPath, cfg); len(caches) > 0 {
+		cfgFn := func() *config.City { return loadCityConfigForControlReady(cityPath) }
+		if caches := controlReadyCachesFor(dir, cityPath, cfgFn); len(caches) > 0 {
 			if ready, ok := cachedControlReadyUnion(caches); ok {
 				return beadsToHookBeads(evaluateControlReady(ready, parsed, envList)), true, nil
 			}

--- a/cmd/gc/dispatch_control_ready_bench_test.go
+++ b/cmd/gc/dispatch_control_ready_bench_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// BenchmarkTryControlReadyFromCacheOrFallbackWarmCache measures the
+// control-dispatcher serve loop's steady-state per-tick cost: every call
+// after the first should answer from the warm control-ready cache without
+// paying for another builtin-pack-readiness config load. Before the fix
+// (gcy pending, sample-profiled on jonesy at 52.9% of a core sustained) every
+// call reloaded and re-validated the config regardless of cache freshness.
+func BenchmarkTryControlReadyFromCacheOrFallbackWarmCache(b *testing.B) {
+	b.Setenv("GC_HOME", b.TempDir())
+	b.Setenv("XDG_RUNTIME_DIR", b.TempDir())
+	b.Setenv("GC_SESSION", "fake")
+	b.Setenv("GC_BEADS", "file")
+	b.Setenv("GC_DOLT", "skip")
+	b.Setenv("GC_BOOTSTRAP", "skip")
+
+	cityDir := b.TempDir()
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		b.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"bench-city\"\n"), 0o644); err != nil {
+		b.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		b.Fatalf("ensurePersistedScopeLocalFileStore: %v", err)
+	}
+
+	agentCfg := config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"}
+	query := workflowServeControlReadyQuery(agentCfg)
+
+	// Prime once outside the timed loop, matching the real serve loop's
+	// shape: the very first tick always pays a real load and build.
+	if _, handled, err := tryControlReadyFromCacheOrFallback(query, cityDir, nil); err != nil || !handled {
+		b.Fatalf("prime call: handled=%v err=%v", handled, err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, handled, err := tryControlReadyFromCacheOrFallback(query, cityDir, nil); err != nil || !handled {
+			b.Fatalf("call %d: handled=%v err=%v", i, handled, err)
+		}
+	}
+}

--- a/cmd/gc/dispatch_control_ready_test.go
+++ b/cmd/gc/dispatch_control_ready_test.go
@@ -529,3 +529,46 @@ printf '[{"id":"ga-plain"}]'
 		t.Fatalf("nextWorkflowServeBeads = %#v, want [{ga-plain}]", got)
 	}
 }
+
+// TestTryControlReadyFromCacheOrFallbackDoesNotReloadConfigOnWarmCache pins
+// the fix for the convoy-control-serve steady-state CPU cost (sample-profiled
+// at 52.9% of a core, sustained, all under loadCityConfig): a warm,
+// within-TTL control-ready cache hit must answer without paying for another
+// config load, because a config load re-validates every builtin pack's file
+// manifest from scratch (EnsureBuiltinRuntimeAssets) regardless of whether
+// anything changed. Before the fix, tryControlReadyFromCacheOrFallback loaded
+// the config unconditionally, before ever consulting the cache.
+func TestTryControlReadyFromCacheOrFallbackDoesNotReloadConfigOnWarmCache(t *testing.T) {
+	cityDir, store := setUpControlReadyFileStoreCity(t)
+	noBDOnPathForTest(t)
+
+	target := "gascity/control-dispatcher"
+	if _, err := store.Create(beads.Bead{Assignee: target, Type: "task"}); err != nil {
+		t.Fatalf("create ready bead: %v", err)
+	}
+
+	agentCfg := config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"}
+	query := workflowServeControlReadyQuery(agentCfg)
+
+	var loads int
+	prev := loadCityConfigForControlReady
+	loadCityConfigForControlReady = func(cityPath string) *config.City {
+		loads++
+		return prev(cityPath)
+	}
+	t.Cleanup(func() { loadCityConfigForControlReady = prev })
+
+	if _, handled, err := tryControlReadyFromCacheOrFallback(query, cityDir, nil); err != nil || !handled {
+		t.Fatalf("first call: handled=%v err=%v, want handled=true err=nil", handled, err)
+	}
+	if loads != 1 {
+		t.Fatalf("config loads after first (cold) call = %d, want 1", loads)
+	}
+
+	if _, handled, err := tryControlReadyFromCacheOrFallback(query, cityDir, nil); err != nil || !handled {
+		t.Fatalf("second call: handled=%v err=%v, want handled=true err=nil", handled, err)
+	}
+	if loads != 1 {
+		t.Fatalf("config loads after second (warm-cache) call = %d, want 1 (still just the first)", loads)
+	}
+}


### PR DESCRIPTION
## Summary

`gc convoy control --serve --follow` was sample-profiled live on jonesy at a
sustained 52.9% of a core for 3+ days, with 86 of 87 samples on the serving
goroutine sitting under `main.loadCityConfig`:

```
main.runConvoyControlServe -> runWorkflowServe -> runWorkflowServeFollow
  -> drainWorkflowServeWork -> nextWorkflowServeBeads
    -> tryControlReadyFromCacheOrFallback
      -> loadCityConfig -> loadCityConfigFS -> ensureBuiltinPacksForConfigLoad
        -> EnsureBuiltinRuntimeAssets -> requiredBuiltinSourcesUsable
          -> builtinpacks.ValidateSyntheticRepo -> validatePackFiles -> manifestForFS
```

`tryControlReadyFromCacheOrFallback` already has an in-process ready-bead
cache (`controlReadyCacheFor`, TTL 3s) for exactly this loop, named with
"OrFallback" implying the fast path is the common case. But it called
`loadCityConfig` **unconditionally, before ever checking** whether that cache
had a fresh answer — including on the `includeEphemeral` branch, which never
uses the loaded config at all. A config load re-validates every builtin
pack's file manifest from scratch (`EnsureBuiltinRuntimeAssets` calls
`requiredBuiltinSourcesUsable`, which is a full `ValidateSyntheticRepo` per
required pack, every call — the `state.ready` memo does not skip this; see
"Also tried, and dropped" / "One upstream-wide observation" in #4723 for the
same walk being expensive elsewhere).

The idle poll interval (`workflowServeIdlePollInterval`) is 100ms. A
~74-180ms config load paid on every tick against that cadence alone explains
the observed ~53% of a core.

## Fix

Make the config load lazy. `controlReadyCacheFor` now takes a `cfgFn` it
invokes **at most once**, and only on the branch that actually opens a new
backing store (no entry yet, or an entry with no retained backing store to
reuse). The hot within-TTL path and the fingerprint-based
revalidate-and-reuse path (`revalidateControlReadyCache`) never touch it —
in the common case (nothing changed since the last tick), `cfgFn` is called
once for the life of the process. `cfg` was already unused in every other
branch (confirmed by reading every call site of `controlReadyCacheFor` and
`openControlReadyStore`), so deferring it changes no behavior, only *when*
the cost is paid.

Nothing about the cache's freshness/staleness contract changes.

## Evidence

New regression test pins the exact bug — a warm, within-TTL cache hit must
not reload config:

```
TestTryControlReadyFromCacheOrFallbackDoesNotReloadConfigOnWarmCache
```
It fails (via an undefined seam) against the pre-fix code and passes after.

New benchmark reproduces the serve loop's steady-state warm-cache tick shape
(prime once, then repeat), run on the Nomad cluster via `crun` on this exact
commit (not a synthetic base):

```
BenchmarkTryControlReadyFromCacheOrFallbackWarmCache
before:  18,350,489 ns/op   (20 iterations, linux/amd64, i7-6700K)
after:      59,606 ns/op   (20 iterations, linux/amd64, i7-6700K)
```

~308x reduction in the per-tick cost on a warm cache hit.

`go vet ./cmd/gc/...` clean. Full `control-ready` test family (22 tests,
`TestControlReady*` / `TestTryControlReady*` / `TestParseControlReadyQuery*`)
passes, including every pre-existing `controlReadyCacheFor` test (all still
pass `nil` for the now-`func() *config.City` third parameter — a nil func
value is valid where a nil pointer was before, so no test signatures needed
to change).

## Prior art checked

Searched gastownhall/gascity issues and PRs for "loadCityConfig",
"ensureBuiltinPacksForConfigLoad", "ValidateSyntheticRepo", "convoy control
serve cache" before digging — found #4682 (order-dispatcher TOML reparsing,
different call site: `cmd_agent.go`/`order_dispatch.go`) and #4723 (`gc bd`
write-path config-load reuse, different call sites, and the source of the
"readiness memo doesn't skip the full walk" fact this PR relies on) but no
existing issue or PR for this exact call site.

## Base commit note

This branch is cut from `1a65b1a97e787195b5ff6969b897f7a3477c70bd`
(`dogfood/gcy-8gwi-on-cc6e792f0`), confirmed as the exact source for the
currently-running `1.4.5-gcy-8gwi-8ip` binary via `git log --all --oneline |
grep 1a65b1a97` — not `/Users/jonesy/Developer/gascity`'s `main` (stale,
2026-08-05). #4723 is not an ancestor of this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NktyKrneS4sVEduQfJUQDE