### PR TITLE
fix(controller): skip .git/node_modules/__pycache__ in the config-watch walk

### DIFF
--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -885,19 +885,37 @@ func watchConfigTargets(targets []config.WatchTarget, dirty *atomic.Bool, pokeCh
 	}
 }
 
+// ignoredConfigWatchDirs are directory names that never carry configuration
+// and are skipped at any depth, both when registering recursive watches
+// (configWatchRegistrar.addPath) and when classifying events.
+//
+// .gc and .beads are runtime state. .git, node_modules and __pycache__ are
+// the ecosystem trees every other pack-tree walk already skips
+// (config.isIgnoredPackRuntimePath, the cmd_lint walk): watching them
+// registers thousands of descriptors that carry no config, and — because a
+// watch event marks the config dirty — turns an ordinary commit, fetch or
+// dependency install inside a watched repo into a full config reload plus a
+// watcher restart. gastownhall/gascity#2954 removed node_modules from pack
+// content hashing (#3063); the watch walk kept descending into it.
+var ignoredConfigWatchDirs = map[string]struct{}{
+	".gc":          {},
+	".beads":       {},
+	".git":         {},
+	"node_modules": {},
+	"__pycache__":  {},
+}
+
 func shouldIgnoreConfigWatchEvent(path string) bool {
 	clean := filepath.Clean(path)
 	if clean == "" || clean == "." {
 		return false
 	}
-	sepGC := string(filepath.Separator) + ".gc"
-	sepBeads := string(filepath.Separator) + ".beads"
-	return clean == ".gc" ||
-		clean == ".beads" ||
-		strings.HasSuffix(clean, sepGC) ||
-		strings.HasSuffix(clean, sepBeads) ||
-		strings.Contains(clean, sepGC+string(filepath.Separator)) ||
-		strings.Contains(clean, sepBeads+string(filepath.Separator))
+	for _, part := range strings.Split(filepath.ToSlash(clean), "/") {
+		if _, ok := ignoredConfigWatchDirs[part]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // reloadResult holds the result of a config reload attempt.

--- a/cmd/gc/controller_watch_runtime_dirs_test.go
+++ b/cmd/gc/controller_watch_runtime_dirs_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestWatchConfigDirs_RecursiveRootIgnoresRuntimeDirs asserts that the
+// recursive config-watch walk skips the ecosystem/runtime directories every
+// other pack-tree walk in this repo already skips.
+//
+// addPath's recursive WalkDir filters directories through
+// shouldIgnoreConfigWatchEvent, which excludes only .gc and .beads. A
+// recursive WatchTarget — a local-git-repo import, or a rig whose import
+// source is the repo root — therefore registers a watch on every directory
+// under .git/, node_modules/ and __pycache__/, and every write inside them
+// (a commit, a fetch, an index.lock) reaches the event loop, marks the
+// config dirty, and drives a full config reload plus a watcher restart.
+//
+// isIgnoredPackRuntimePath (internal/config/pack.go) skips .beads, .cache,
+// .gc, .git, state, tmp, and node_modules/__pycache__ at any depth; the
+// lint walk in cmd/gc/cmd_lint.go skips .git, .gc, .beads, node_modules.
+// The watch walk is the one that does not, so the exclusion added for
+// gastownhall/gascity#2954 (pack content hashing, #3063) never reached it.
+func TestWatchConfigDirs_RecursiveRootIgnoresRuntimeDirs(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	root := t.TempDir()
+	packFile := filepath.Join(root, "pack.toml")
+	if err := os.WriteFile(packFile, []byte("[pack]\nname = \"p\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatalf("seed pack.toml: %v", err)
+	}
+
+	// Runtime/ecosystem subtrees that a real local-repo import carries.
+	runtimeDirs := map[string]string{
+		"git":         filepath.Join(root, ".git", "objects", "ab"),
+		"node":        filepath.Join(root, "node_modules", "left-pad", "lib"),
+		"pycache":     filepath.Join(root, "__pycache__"),
+		"nestedCache": filepath.Join(root, "skills", "s", "node_modules", "dep"),
+	}
+	for name, dir := range runtimeDirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "seed"), []byte("seed\n"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	// Unit-level: every runtime path must be classified as ignorable, the way
+	// .gc/.beads already are.
+	for name, dir := range runtimeDirs {
+		probe := filepath.Join(dir, "seed")
+		if !shouldIgnoreConfigWatchEvent(probe) {
+			t.Errorf("shouldIgnoreConfigWatchEvent(%q) = false, want true (%s)", probe, name)
+		}
+	}
+	if shouldIgnoreConfigWatchEvent(packFile) {
+		t.Fatalf("shouldIgnoreConfigWatchEvent(%q) = true, want false", packFile)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: root, Recursive: true}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	// Behavioral: writes inside the runtime subtrees must not poke the
+	// controller or mark the config dirty.
+	for name, dir := range runtimeDirs {
+		select {
+		case <-pokeCh:
+		default:
+		}
+		dirty.Store(false)
+
+		if err := os.WriteFile(filepath.Join(dir, "seed"), []byte("changed\n"), 0o644); err != nil {
+			t.Fatalf("rewrite %s: %v", name, err)
+		}
+		// Negative-assertion window: asserts no watcher poke arrives (ga-57b2dk exclusion).
+		select {
+		case <-pokeCh:
+			t.Errorf("unexpected watcher poke after write under %s; stderr=%q", name, stderr.String())
+		case <-time.After(250 * time.Millisecond):
+		}
+		if dirty.Load() {
+			t.Errorf("dirty flag set after write under %s; stderr=%q", name, stderr.String())
+		}
+	}
+
+	// Control: the watcher is live — a real pack edit still pokes. Without
+	// this the negative assertions above would pass on a dead watcher.
+	select {
+	case <-pokeCh:
+	default:
+	}
+	dirty.Store(false)
+	if err := os.WriteFile(packFile, []byte("[pack]\nname = \"p2\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatalf("rewrite pack.toml: %v", err)
+	}
+	awaitClose(t, pokeCh, "watcher poke after pack.toml edit")
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after pack.toml edit; stderr=%q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

- The recursive config-watch walk filters directories through exactly one predicate,
  `shouldIgnoreConfigWatchEvent` (`cmd/gc/controller.go:687`), which excluded only `.gc` and
  `.beads`. A recursive `WatchTarget` — a local-git-repo import, or a rig whose import source
  is the repo root — therefore registered a watch on every directory under `.git/`,
  `node_modules/` and `__pycache__/`.
- The same predicate gates the event loop (`cmd/gc/controller.go:846`), so writes in those
  trees were not filtered either: they reached the debounce timer, called `markDirty()`, and
  drove a full config re-evaluation plus `restartConfigWatcher`. An ordinary commit, fetch,
  checkout or `npm install` inside a watched repo was enough to trigger a reload with no
  configuration change to apply.
- Every other pack-tree walk in this repo already skips these directories —
  `isIgnoredPackRuntimePath` (`internal/config/pack.go:3013`) and the lint walk
  (`cmd/gc/cmd_lint.go:170`). The exclusion added for #2954 in #3063 covered pack *content
  hashing* but never reached the *watch registration* walk.
- This rewrites the predicate as a path-segment scan over a named set
  (`ignoredConfigWatchDirs`), adding `.git`, `node_modules` and `__pycache__`. As a
  side-effect it also tightens the existing `.gc`/`.beads` handling, which missed a leading
  relative segment (`".gc/x"` was not ignored by the old suffix/contains form).

Fixes #6033.

This is independent of #4504 / #5478 and both are wanted: bumping fsnotify to v1.10.1 bounds
the descriptors a watcher *release* leaks, while this stops the watch set from covering
`.git`/`node_modules` at all and stops a git write from triggering a reload. This PR does not
touch `go.mod`, so it does not conflict with #5478.

## Testing

Run on Linux (inotify). The defect is a walk-filter gap, so it is not backend-specific.

- [x] New regression `TestWatchConfigDirs_RecursiveRootIgnoresRuntimeDirs`
      (`cmd/gc/controller_watch_runtime_dirs_test.go`). Builds a recursive root containing
      `.git/objects/ab`, `node_modules/left-pad/lib`, `__pycache__` and
      `skills/s/node_modules/dep`; asserts each is classified ignorable and that a write in
      each produces no poke and no dirty flag. Includes a **control** — an ordinary
      `pack.toml` edit must still poke — so the negative assertions cannot pass on a dead
      watcher.
      - against `main@58a571faa`: **FAIL** (12 assertions: 4 classification, 8 behavioral)
      - with this change: **PASS**
- [x] `go test -count=1 -timeout 20m ./cmd/gc -run 'TestWatchConfigDirs|TestWatchConfigTargets|TestCityRuntimeReloadRestartsConfigWatcher'` — **9/9 PASS**
      (all pre-existing watcher tests, incl. `Regression780`, `CityRootIgnoresRuntimeTraceWrites`,
      `CityRootDoesNotWatchUnrelatedNestedSubdir`, `SymlinkSeedDirWatchesNestedPreExistingDir`)
- [x] `gofmt -l` — clean; `go vet ./cmd/gc/... ./internal/config/...` — exit 0
- [x] `go test -count=1 -timeout 25m ./cmd/gc` (full package) — 3 failures, all pre-existing
      on unmodified `main@58a571faa` and unrelated to the watcher:
      `TestRunProviderOpKillsProcessGroupOnTimeout`,
      `TestRunProviderOpWithEnvContextParentCancellationKillsProcessGroup`,
      `TestRunProviderProbeKillsProcessGroupOnTimeout`. Verified by running those three
      against unmodified `main` in the same environment — identical failures, and on a
      different builder host, so not node-specific.
- [ ] `make check` — not run in full; the scoped watcher suite plus the full `./cmd/gc`
      package run above are the relevant gate for a change confined to this predicate.
- [ ] `make check-docs` — N/A, no docs or navigation change.
- [ ] `make test-integration` — not run; no controller lifecycle redesign, the change is one
      path predicate.

## Checklist

- [x] Linked an issue — #6033
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — none; internal watch filtering only
- [x] Called out breaking changes or migration notes — none. The only behavior change is that
      writes under `.git`/`node_modules`/`__pycache__` no longer trigger a config reload. If a
      city intentionally kept configuration inside one of those directories it would stop being
      watched, but such a path is already invisible to pack content hashing
      (`isIgnoredPackRuntimePath`), so it could not participate in config evaluation anyway.

## Alternative considered

Exporting the `internal/config` runtime-path predicate so the hashing walk and the watch walk
share one list would prevent future drift, but their current semantics differ
(`isIgnoredPackRuntimePath` matches `.git`/`state`/`tmp` only at the tree root, and
`node_modules`/`__pycache__` at any depth), so unifying them is a deliberate decision rather
than a refactor. Happy to redo it that way if you prefer a single shared list — noted as
candidate 2 in #6033.
