### PR TITLE
fix(bd): route unserved by-ID READS on residence, not on servability

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -644,7 +644,18 @@ func bdMutationWriteIDs(args []string) (ids []string, ok bool, ambiguous bool) {
 	default:
 		return nil, false, false
 	}
+	ids, ambiguous = bdScanPositionalIDs(sub, args[1:])
+	return ids, true, ambiguous
+}
 
+// bdScanPositionalIDs is the argv scan bdMutationWriteIDs is built from, taken
+// on its own so a caller that has already resolved the subcommand can reuse it.
+//
+// sub names the bd subcommand whose flag manifests decide which tokens are
+// values ("close", "dep list"); rest is the argv AFTER it. ambiguous reports an
+// unrecognized flag that might consume the next token, which every caller must
+// fail closed on — the token would otherwise be read as a bead id.
+func bdScanPositionalIDs(sub string, rest []string) (ids []string, ambiguous bool) {
 	// valueFlags is the complete set of flags that consume the next argument as
 	// their value for this subcommand, in both long and short form.
 	// Sourced from `bd <sub> --help` (2026-06-10).
@@ -655,8 +666,8 @@ func bdMutationWriteIDs(args []string) (ids []string, ok bool, ambiguous bool) {
 	boolFlags := bdSubcmdBoolFlags(sub)
 
 	positional := false // true after "--"
-	for i := 1; i < len(args); i++ {
-		arg := args[i]
+	for i := 0; i < len(rest); i++ {
+		arg := rest[i]
 		if positional {
 			if arg != "" {
 				ids = append(ids, arg)
@@ -696,9 +707,9 @@ func bdMutationWriteIDs(args []string) (ids []string, ok bool, ambiguous bool) {
 		}
 		// Unknown flag. It might consume a value argument that looks like a
 		// bead ID. Fail-closed: report ambiguity so the caller can reject.
-		return nil, true, true
+		return nil, true
 	}
-	return ids, true, false
+	return ids, false
 }
 
 // bdSubcmdValueFlags returns the set of value-consuming flag names (in

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -145,19 +145,27 @@ package main
 // store census. That is once per process, memoized with every other one-shot
 // command's routing, but it is not free, so it is paid only by an invocation
 // that could concern a class-owned bead: a served by-ID form, an argv that
-// addresses a reserved-prefix id, or a MUTATION with unambiguous positional
-// ids. An ordinary work READ or SELECTOR never enters; a mutation addressing
-// ids enters exactly once per process.
+// addresses a reserved-prefix id, or an argv that ADDRESSES SUBJECTS BY ID with
+// an unambiguous positional scan — a mutation or a by-ID read alike. A SELECTOR
+// never enters; an argv addressing ids enters exactly once per process.
 //
-// The mutation arm is the widening, and the id shape is why it cannot be
-// narrower. A class store mints from its binding workspace's own prefix and
+// The addressed-subjects arm is the widening, and the id shape is why it cannot
+// be narrower. A class store mints from its binding workspace's own prefix and
 // `gc storage migrate` preserves ids, so "gc-123" says nothing about which
 // store holds the row — only a probe does, and skipping it is what sent every
 // unserved mutation of a class resident to the ledger that cannot hold it.
-// Reads and selectors stay outside because they address no subject whose
-// residence could decide anything: a selector QUOTES ids, and a read that this
-// surface serves is already inside. An ambiguous scan stays outside too, for
-// the plainest reason — it yields no ids to probe.
+//
+// READS are in the same arm, and gating them on servability instead was a real
+// defect rather than a hypothetical: `show <id>` is served and enters, while
+// `show <id> <id>` and `show --long <id>` address the same subject, are not
+// served, and used to fall through — so one flag or one extra id turned a
+// routed read into a work-store read, answered from the retained pre-migration
+// copy in bd's own shape with no diagnostic. Two spellings of one read
+// disagreeing about one bead's status is the wrong-answer lane this file
+// exists to close, and servability was never the question a READ has either.
+// Selectors still stay outside because they address no subject whose residence
+// could decide anything — a selector QUOTES ids. An ambiguous scan stays
+// outside too, for the plainest reason — it yields no ids to probe.
 
 import (
 	"encoding/json"
@@ -831,6 +839,66 @@ func bdByIDMutationSubjects(bdArgs []string) []string {
 	return ids
 }
 
+// bdByIDReadVerbs are the by-ID READ subcommands whose subjects this surface
+// must know the residence of.
+//
+// They are here because the funnel-entry gate used to ask "can I SERVE this
+// spelling", and that is a different question from "does this argv address a
+// subject by id". `show <id>` is served and enters; `show <id> <id>` and
+// `show --long <id>` are not served, addressed the same subject, and did not —
+// so a flag or a second id turned a routed read into a work-store read with no
+// diagnostic. On a city whose ids the migration PRESERVED that is not absence
+// but a different, frozen answer: the retained pre-migration copy, reported in
+// bd's own shape. Two spellings of one read then disagree about one bead's
+// status, which is the wrong-answer lane this file exists to close.
+//
+// Every READ verb parseBdByIDOp serves is listed, so each one's UNSERVED
+// spellings reach the residence probe rather than the work store. bdflags carries a
+// complete flag manifest for show and dep list; dep tree has none, so only its
+// flagless spelling yields subjects and every flagged one scans as ambiguous
+// and falls through exactly as it does today. That is the fail-closed
+// direction: an unrecognized flag never becomes a probed id.
+var bdByIDReadVerbs = map[string]bool{
+	"show":     true,
+	"dep list": true,
+	"dep tree": true,
+}
+
+// bdByIDReadSubjects returns the bead ids a by-ID READ argv ADDRESSES, or nil
+// when the argv is not such a read or cannot be scanned into ids.
+//
+// The subcommand is resolved the way every other door in this file resolves it
+// — through bdByIDSubcommand, which skips global flag values and knows bd's
+// two-word verbs — so `gc bd --actor bob show <id> <id>` is scanned as a show
+// rather than as an unknown verb.
+//
+// SELECTORS stay out by construction: `list`, `query` and `search` are not read
+// verbs here, because they QUOTE ids rather than address them, and their answer
+// is a projection this ledger cannot narrow. bd_relocated_classes.go refuses
+// those on its own terms.
+func bdByIDReadSubjects(bdArgs []string) []string {
+	sub, rest, resolved := bdByIDSubcommand(bdArgs)
+	if !resolved || !bdByIDReadVerbs[sub] {
+		return nil
+	}
+	ids, ambiguous := bdScanPositionalIDs(sub, rest)
+	if ambiguous {
+		return nil
+	}
+	return ids
+}
+
+// bdByIDAddressedSubjects returns every bead id an argv addresses by id,
+// whether it mutates them or reads them. It is the funnel-entry question:
+// nothing else in an argv can make a command concern a class-owned bead whose
+// id does not announce it.
+func bdByIDAddressedSubjects(bdArgs []string) []string {
+	if ids := bdByIDMutationSubjects(bdArgs); len(ids) > 0 {
+		return ids
+	}
+	return bdByIDReadSubjects(bdArgs)
+}
+
 // bdIDIsClassReserved reports whether id carries a reserved class id prefix.
 // Those namespaces belong to the relocated class stores — whether the store's
 // own sequence minted the id or a subsystem inside it did — so such an id
@@ -859,16 +927,21 @@ func bdIDIsClassReserved(id string) bool {
 func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr io.Writer) (int, bool) {
 	op, served := parseBdByIDOp(bdArgs)
 	named, namesClassBead := bdArgsNameClassOwnedBead(bdArgs)
-	mutationIDs := bdByIDMutationSubjects(bdArgs)
-	if !served && !namesClassBead && len(mutationIDs) == 0 {
+	subjectIDs := bdByIDAddressedSubjects(bdArgs)
+	if !served && !namesClassBead && len(subjectIDs) == 0 {
 		// Nothing here can concern a class-owned bead, so the binding is not
 		// opened and the funnel is not entered.
 		//
 		// This is also the cost gate. Entering the funnel resolves a plan and
 		// opens a database, and the born-split arm re-proves its invariant with
-		// a full work-store census; a read or selector that addresses no
-		// subject must not pay that, and neither must a mutation whose argv
-		// cannot be scanned into ids at all — there would be nothing to probe.
+		// a full work-store census; a SELECTOR, which addresses no subject,
+		// must not pay that, and neither must an argv that cannot be scanned
+		// into ids at all — there would be nothing to probe.
+		//
+		// An unserved by-ID READ is on the paying side, and its cost is bounded
+		// by the served form already being there: `show <id>` enters, so
+		// `show --long <id>` entering too adds no population beyond the
+		// spellings whose answers were wrong.
 		return 0, false
 	}
 	door, routed, err := openBdByIDClassFrontDoor(cityPath)
@@ -880,22 +953,28 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 		return 0, false
 	}
 	if !served {
-		return refuseUnservedClassMutation(door, bdArgs, named, namesClassBead, mutationIDs, stderr)
+		return refuseUnservedClassTarget(door, bdArgs, named, namesClassBead, subjectIDs, stderr)
 	}
 	return serveBdByIDResolved(door, op, bdArgs, rigName, cityPath, stdout, stderr)
 }
 
-// refuseUnservedClassMutation answers a by-ID invocation that addresses a bead
+// refuseUnservedClassTarget answers a by-ID invocation that addresses a bead
 // the class binding owns in a spelling this surface does not serve. Ownership
 // is proven from a reserved prefix (namesClassBead) or, failing that, from
-// RESIDENCE: an unserved mutation whose subjects the class binding actually
-// holds cannot be answered by the work store. Returning (0, false) means every
-// subject is an ordinary work bead — bd is still their truth and the caller's
-// passthrough answers byte-identically, including doBd's own exact-ID collision
-// guard, which this arm must not displace.
-func refuseUnservedClassMutation(door bdByIDClassDoor, bdArgs []string, named string, namesClassBead bool, mutationIDs []string, stderr io.Writer) (int, bool) {
+// RESIDENCE: an unserved mutation or read whose subjects the class binding
+// actually holds cannot be answered by the work store. Returning (0, false)
+// means every subject is an ordinary work bead — bd is still their truth and
+// the caller's passthrough answers byte-identically, including doBd's own
+// exact-ID collision guard, which this arm must not displace.
+//
+// A READ is refused rather than served on a best-effort basis because a partial
+// answer is the failure being fixed: `show <work-id> <class-id>` printing only
+// the work leg, or printing the class leg from the retained copy, are both
+// answers to a question the operator did not ask. The refusal names the bead
+// and the binding, and each id read on its own is served.
+func refuseUnservedClassTarget(door bdByIDClassDoor, bdArgs []string, named string, namesClassBead bool, subjectIDs []string, stderr io.Writer) (int, bool) {
 	if !namesClassBead {
-		resident, err := door.firstResident(mutationIDs)
+		resident, err := door.firstResident(subjectIDs)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1, true

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -488,6 +488,79 @@ func TestBdByIDRoutesAWorkShapedIDResidentInTheClassBinding(t *testing.T) {
 	}
 }
 
+// TestBdByIDUnservedReadOfAClassResidentIsRefusedNotAnsweredByTheWorkStore is
+// the split-view report: one bead, two spellings of one read, two different
+// statuses.
+//
+// `gc storage migrate` PRESERVES ids and RETAINS the work store's copy, so a
+// class-resident step keeps its work-shaped id and its pre-migration row stays
+// behind, frozen at migration time. The served read routes to the binding and
+// reports the live row; an unserved spelling of the same read used to fall
+// through to a bd subprocess pointed at the work store and report the frozen
+// one — CLOSED here, OPEN there, no diagnostic on either.
+//
+// Both spellings that produce it are here, because they miss the served parser
+// for unrelated reasons and only the second one looks like a flag problem:
+// a second positional id, and a flag the in-process arm does not implement.
+func TestBdByIDUnservedReadOfAClassResidentIsRefusedNotAnsweredByTheWorkStore(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	migrated := beads.Bead{ID: "demo-premigration", Title: "carried across by the migration", Type: "task"}
+	created, err := migrationSeed(classStore, migrated)
+	if err != nil {
+		t.Fatalf("seeding a work-shaped id in the class binding: %v", err)
+	}
+	if bdIDIsClassReserved(created.ID) {
+		t.Fatalf("the fixture id %q carries a reserved class prefix; it cannot exercise the residence probe", created.ID)
+	}
+
+	for name, args := range map[string][]string{
+		"a second positional id":  {"show", created.ID, "demo-otherwork"},
+		"the class id second":     {"show", "demo-otherwork", created.ID},
+		"an unimplemented flag":   {"show", "--long", created.ID},
+		"an unimplemented flag 2": {"show", created.ID, "--include-comments"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetCLIStorageRoutes(t)
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr)
+			if !handled {
+				t.Fatalf("%v fell through to the bd subprocess, which answers from the retained work-store copy", args)
+			}
+			if code == 0 {
+				t.Fatalf("%v exited 0; an unserved read of a class resident must refuse, not answer", args)
+			}
+			if got := stderr.String(); !strings.Contains(got, created.ID) || !strings.Contains(got, "class binding") {
+				t.Fatalf("the refusal for %v does not name the bead and the binding: %q", args, got)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("%v printed %q to stdout; a refusal answers nothing", args, stdout.String())
+			}
+		})
+	}
+}
+
+// TestBdByIDUnservedReadOfAWorkBeadKeepsThePassthrough is the other half of the
+// widening: entering the funnel is not the same as taking the command. An
+// unserved read whose subjects are all ordinary work beads must still reach bd,
+// byte-identically, or the widening breaks every `show --long` in the city.
+func TestBdByIDUnservedReadOfAWorkBeadKeepsThePassthrough(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+
+	for name, args := range map[string][]string{
+		"an unimplemented flag":  {"show", "--long", "demo-notresident"},
+		"a second positional id": {"show", "demo-notresident", "demo-alsonot"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetCLIStorageRoutes(t)
+			var stdout, stderr bytes.Buffer
+			code, handled := maybeRouteBdByID(cityPath, "", args, &stdout, &stderr)
+			if handled {
+				t.Fatalf("%v was taken by the by-ID surface (exit %d, %q); bd is still the truth for work beads", args, code, stderr.String())
+			}
+		})
+	}
+}
+
 // TestBdByIDServesTheStepCompletionWrite is the core-pack write:
 // graph-worker.md closes a worked bead with
 // `gc bd update <id> --set-metadata gc.outcome=pass --status closed`, and on a
@@ -887,6 +960,9 @@ func TestBdByIDEntersTheFunnelOnlyForInvocationsThatCouldConcernAClassBead(t *te
 		"class close":                {[]string{"close", reserved}, true},
 		"class id in an id flag":     {[]string{"list", "--parent", reserved}, true},
 		"unserved dep tree spelling": {[]string{"dep", "tree", "--show-all-paths", "gc-123"}, false},
+		"unserved multi-id show":     {[]string{"show", "gc-123", "gc-124"}, true},
+		"unserved show flag":         {[]string{"show", "--long", "gc-123"}, true},
+		"show with an unknown flag":  {[]string{"show", "--bogus", "v", "gc-123"}, false},
 		"served read on a work id":   {[]string{"show", "gc-123"}, true},
 		"served dep tree":            {[]string{"dep", "tree", "gc-123"}, true},
 		"served write on a work id":  {[]string{"update", "gc-123", "--status", "closed"}, true},


### PR DESCRIPTION
## Summary

On a city whose coordination classes are relocated, `gc storage migrate` preserves bead ids and retains the work store's pre-migration copy. The by-ID surface's funnel-entry gate asked whether a spelling could be **served**, which is a different question from whether the argv **addresses a subject by id**: `show <id>` entered and reported the binding's live row, while `show <id> <id>` and `show --long <id>` addressed the same subject, missed the served parser, and fell through to a `bd` subprocess pointed at the work store — which answered from the retained copy, in bd's own shape, with no diagnostic. Two spellings of one read then disagreed about one bead's status.

This widens the funnel-entry gate to every argv that addresses subjects by id, read or mutation alike, so an unserved read of a class resident reaches the existing refusal instead of the wrong ledger. Selectors and ambiguous scans still pay nothing.

Fixes #6015.

- `bdMutationWriteIDs`'s positional-argv scanner is factored out as `bdScanPositionalIDs` so it can be reused for reads.
- `bdByIDReadSubjects` / `bdByIDReadVerbs` extend the same scan to `show`, `dep list`, and `dep tree` — the full set of by-ID read verbs `parseBdByIDOp` serves.
- `bdByIDAddressedSubjects` merges mutation and read subjects into one funnel-entry question.
- `refuseUnservedClassMutation` is renamed `refuseUnservedClassTarget` to reflect that it now answers reads too.

## Test plan

- [x] `make build`, `make fmt-check vet`, `make lint-full` — all clean (0 issues repo-wide)
- [x] `go test ./cmd/gc/ -count=1` — full package passes except 5 pre-existing failures verified identical on unmodified `main` (process-group signal-handling tests that are sandbox/environment-dependent, unrelated to this change: `TestRunProviderOpKillsProcessGroupOnTimeout`, `TestRunProviderOpWithEnvContextParentCancellationKillsProcessGroup`, `TestRunProviderProbeKillsProcessGroupOnTimeout`, `TestPackV2ImportsScript/pack-v2-imports`, `TestHookTimeoutKillsTheWholeProcessGroup/group_cleanup_reaps_the_descendant`)
- [x] New regression tests `TestBdByIDUnservedReadOfAClassResidentIsRefusedNotAnsweredByTheWorkStore` and `TestBdByIDUnservedReadOfAWorkBeadKeepsThePassthrough` fail to exist / pass correctly on `main` vs the branch
- [x] Disposable fail-before repro (`gateFallsThrough`, argv-only, not included in this PR) confirms the routing gate falls through on unpatched `main` for `show <id> <id>`, and that the mutation arm was already protected