### PR TITLE
fix(supervisor): stop watching .git subtrees under recursive config watch targets

### DIFF
--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -885,19 +885,31 @@ func watchConfigTargets(targets []config.WatchTarget, dirty *atomic.Bool, pokeCh
 	}
 }
 
+// configWatchIgnoredDirs names directories whose subtrees never carry config
+// content, so the config watcher neither registers a watch inside them nor
+// treats an event under one as config drift. It mirrors the runtime-path
+// exclusions the pack content hash already applies (isIgnoredPackRuntimePath,
+// internal/config/pack.go): a write under one of these cannot change a pack's
+// content hash, so a reload it triggers can only ever be a no-op. Watching
+// them is pure cost — a local-git-repo import's whole .git/objects tree is
+// registered on every watcher rebuild, and on macOS each rebuild leaks those
+// per-path kqueue descriptors (gastownhall/gascity#4504).
+var configWatchIgnoredDirs = []string{".gc", ".beads", ".git"}
+
 func shouldIgnoreConfigWatchEvent(path string) bool {
 	clean := filepath.Clean(path)
 	if clean == "" || clean == "." {
 		return false
 	}
-	sepGC := string(filepath.Separator) + ".gc"
-	sepBeads := string(filepath.Separator) + ".beads"
-	return clean == ".gc" ||
-		clean == ".beads" ||
-		strings.HasSuffix(clean, sepGC) ||
-		strings.HasSuffix(clean, sepBeads) ||
-		strings.Contains(clean, sepGC+string(filepath.Separator)) ||
-		strings.Contains(clean, sepBeads+string(filepath.Separator))
+	sep := string(filepath.Separator)
+	for _, name := range configWatchIgnoredDirs {
+		if clean == name ||
+			strings.HasSuffix(clean, sep+name) ||
+			strings.Contains(clean, sep+name+sep) {
+			return true
+		}
+	}
+	return false
 }
 
 // reloadResult holds the result of a config reload attempt.

--- a/cmd/gc/controller_hang_deadline_lint_test.go
+++ b/cmd/gc/controller_hang_deadline_lint_test.go
@@ -30,6 +30,7 @@ var controllerTestExcludedHangDeadlineLines = map[int]string{
 	877:  "negative-assertion window (asserts no watcher poke arrives)",
 	927:  "negative-assertion window (asserts no watcher poke arrives, loop body)",
 	1456: "bounded best-effort probe with no assertion on either branch",
+	2245: "negative-assertion window (asserts no watcher poke arrives for a .git write)",
 }
 
 func controllerTestPath(t *testing.T) string {

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -2178,3 +2178,82 @@ func TestTryReloadConfig_IncludesBuiltinPackOrders(t *testing.T) {
 }
 
 func (osFS) Chmod(name string, mode os.FileMode) error { return os.Chmod(name, mode) }
+
+// A recursive watch target that is a git worktree (the shape gc import add
+// writes for a local repo path) used to have its whole .git subtree walked and
+// watched: shouldIgnoreConfigWatchEvent pruned .gc and .beads but not .git.
+// Nothing under .git can change a pack's content hash — isIgnoredPackRuntimePath
+// (internal/config/pack.go) skips it on the content side — so every object, ref,
+// and reflog write fired a reload that was guaranteed to be a no-op, and each
+// reload rebuilds the watcher over the whole tree again.
+func TestWatchConfigDirs_RecursiveRootIgnoresGitSubtree(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	packFile := filepath.Join(dir, "pack.toml")
+	if err := os.WriteFile(packFile, []byte("name = \"sample\"\n"), 0o644); err != nil {
+		t.Fatalf("seed pack file: %v", err)
+	}
+	// Mirrors a real worktree closely enough for the walk: a loose-object
+	// directory nested two levels under .git, plus a packed-refs sibling.
+	objectDir := filepath.Join(dir, ".git", "objects", "ab")
+	if err := os.MkdirAll(objectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll git object dir: %v", err)
+	}
+	objectFile := filepath.Join(objectDir, "cdef0123456789")
+	if err := os.WriteFile(objectFile, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("seed git object: %v", err)
+	}
+
+	if !shouldIgnoreConfigWatchEvent(objectFile) {
+		t.Fatalf("shouldIgnoreConfigWatchEvent(%q) = false, want true", objectFile)
+	}
+	if !shouldIgnoreConfigWatchEvent(filepath.Join(dir, ".git")) {
+		t.Fatalf("shouldIgnoreConfigWatchEvent(<root>/.git) = false, want true")
+	}
+	// A path that merely mentions .git must not be pruned: only the directory
+	// itself and its subtree are excluded.
+	if shouldIgnoreConfigWatchEvent(filepath.Join(dir, "gitignore.toml")) {
+		t.Fatalf("shouldIgnoreConfigWatchEvent(<root>/gitignore.toml) = true, want false")
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: dir, Recursive: true}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	select {
+	case <-pokeCh:
+	default:
+	}
+	dirty.Store(false)
+
+	if err := os.WriteFile(objectFile, []byte("rewritten\n"), 0o644); err != nil {
+		t.Fatalf("rewrite git object: %v", err)
+	}
+	newObject := filepath.Join(objectDir, "fedcba9876543210")
+	if err := os.WriteFile(newObject, []byte("new object\n"), 0o644); err != nil {
+		t.Fatalf("write new git object: %v", err)
+	}
+	// Negative-assertion window: asserts no watcher poke arrives (ga-57b2dk exclusion).
+	select {
+	case <-pokeCh:
+		t.Fatalf("unexpected watcher poke after writes under .git; stderr=%q", stderr.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+	if dirty.Load() {
+		t.Fatalf("dirty flag set after writes under .git; stderr=%q", stderr.String())
+	}
+
+	// Positive control: the rest of the recursive tree is still watched.
+	if err := os.WriteFile(packFile, []byte("name = \"edited\"\n"), 0o644); err != nil {
+		t.Fatalf("edit pack file: %v", err)
+	}
+	awaitClose(t, pokeCh, "watcher poke after pack file edit")
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after pack file edit; stderr=%q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #6036.

`configWatchRegistrar`'s recursive walk prunes with `shouldIgnoreConfigWatchEvent` (`cmd/gc/controller.go:687`), which excluded `.gc` and `.beads` but not `.git`. A recursive watch target that is a git worktree — the shape `gc import add` writes for a local repo path, and any pack dir that lives inside one — had its whole `.git` subtree registered: `objects/**`, `refs/**`, `logs/**`.

Nothing under `.git` can change a pack's content hash — the content side already skips it (`isIgnoredPackRuntimePath`, `internal/config/pack.go:3019`, gating `collectFiles` → `packContentHashRecursive`). Since the same predicate also gates event delivery (`cmd/gc/controller.go:846`), every git object, ref, and reflog write enqueued a config reload that was guaranteed to be a no-op, and each reload rebuilds the watcher over the whole tree again. On macOS, where the kqueue backend holds one descriptor per watched path, those rebuilds are also where the descriptors accumulate (#4504) — `.git/objects` is typically the largest directory count under a watched repo root.

The change adds `.git` to the exclusion, keeping the any-depth matching `.gc` and `.beads` already use, and lifts the three names into a slice so a fourth is not three more string comparisons.

Deliberately not in scope: aligning the watch predicate with the *whole* pack-side ignore list (`node_modules`, `__pycache__`, `.cache`, `state`, `tmp` — the other half of #2954). That needs a maintainer's call on semantics, because the pack-side list matches `.cache`/`state`/`tmp` only as the first segment relative to the pack root while this predicate is depth-agnostic on absolute paths. Issue #6036 spells out the trade-off; happy to follow up if you want it.

## Testing

- [x] `make check` — `build`, `vet`, `fmt-check` clean. `make lint` exits 2 in my sandbox at unmodified `main@58a571faa` as well as on this branch (golangci-lint fails to run there), so it is unchanged by this PR, not verified by it.
- [ ] `make check-docs` — no docs touched.
- [x] `go test ./cmd/gc/... ./internal/config/...`: on this branch the failures are exactly the four also present at `main@58a571faa` in the same environment (`TestRunProviderOpKillsProcessGroupOnTimeout`, `TestRunProviderOpWithEnvContextParentCancellationKillsProcessGroup`, `TestRunProviderProbeKillsProcessGroupOnTimeout`, `TestPackV2ImportsScript` — all sandbox artifacts, all passing in isolation). No new failures.
- [x] `GOOS=darwin GOARCH=arm64 go vet ./cmd/gc/` — the platform this most affects still type-checks.

RED/GREEN for the new test, run on Linux (inotify):

```
# main@58a571faa
--- FAIL: TestWatchConfigDirs_RecursiveRootIgnoresGitSubtree
    shouldIgnoreConfigWatchEvent(".../001/.git/objects/ab/cdef0123456789") = false, want true
--- FAIL: TestRedProof_GitWriteWakesConfigWatcher
    RED CONFIRMED: watcher poke fired for a write under .git (dirty=true)

# this branch
--- PASS: TestWatchConfigDirs_RecursiveRootIgnoresGitSubtree (0.26s)
```

All seven pre-existing `TestWatchConfigDirs_*` tests still pass.

## Checklist

- [x] Linked an issue (#6036)
- [x] Added or updated tests for behavior changes — `TestWatchConfigDirs_RecursiveRootIgnoresGitSubtree` asserts the predicate, asserts no poke for two writes under `.git`, and keeps a positive control proving the rest of the recursive tree is still watched. Its negative-assertion window is registered in `controllerTestExcludedHangDeadlineLines`, per the ga-57b2dk rule in `TESTING.md` that a negative assertion's window is never migrated to the hang budget.
- [x] Updated docs for user-facing changes — none; the exclusion registry lives in the lint test, and `TESTING.md` states the rule generically.
- [x] Called out breaking changes or migration notes — none. The only behavior change is that a write confined to `.git` no longer triggers a reload, which could only ever have been a no-op reload.
