### PR TITLE
fix(sling): skip a child bead the fresh check finds already terminal (#5927)

### DIFF
--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -210,8 +210,9 @@ type SlingResult struct {
 	ContainerType string // "convoy", "epic", etc. (batch only)
 	Routed        int
 	Failed        int
-	Skipped       int // total skipped (idempotent + non-open)
+	Skipped       int // total skipped (idempotent + terminal + non-open)
 	IdempotentCt  int // how many were skipped due to idempotency
+	TerminalCt    int // how many were skipped because a fresh read found them already closed/tombstoned
 	Total         int
 	NudgeAgent    *config.Agent // non-nil if caller should nudge
 
@@ -1657,7 +1658,12 @@ func PromoteWorkflowLaunchBead(store beads.Store, beadID string) error {
 // BeadCheckResult holds the result of pre-flight bead state checks.
 type BeadCheckResult struct {
 	Idempotent bool
-	Warnings   []string
+	// AlreadyTerminal is true when the fresh read found the bead already
+	// closed/tombstoned. Distinct from Idempotent (already routed to this
+	// same target): a terminal bead may never have been routed at all, but
+	// dispatching it is still wrong, so callers must skip on this signal too.
+	AlreadyTerminal bool
+	Warnings        []string
 }
 
 // BeadCheckOptions configures pre-flight bead state checks for a route.

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -465,6 +465,16 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, dep
 		return BeadCheckResult{}
 	}
 
+	// A fresh read may find the bead already closed/tombstoned even though it
+	// was "open" at the batch's initial listing snapshot (#5927): another
+	// actor can close it during the window between that snapshot and this
+	// child's turn in the dispatch loop. None of the routing/idempotency
+	// checks below are meaningful for a bead that's already terminal, so
+	// short-circuit before them.
+	if convoycore.IsTerminalStatus(b.Status) {
+		return BeadCheckResult{AlreadyTerminal: true}
+	}
+
 	if IsCustomSlingQuery(a) {
 		return BeadCheckResult{Warnings: routedStateWarnings(b, beadID)}
 	}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -1679,6 +1679,7 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 	routed := 0
 	failed := 0
 	idempotent := 0
+	terminalSkipped := 0
 	// childErrors preserves typed child errors so errors.As at the top-level
 	// (cmdSling) can recover a *sourceworkflow.ConflictError emitted by any
 	// child and map it to exit code 3 + the cleanup hint. Stringifying into
@@ -1695,6 +1696,18 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 				childResult.Skipped = true
 				batchResult.Children = append(batchResult.Children, childResult)
 				idempotent++
+				continue
+			}
+			// TOCTOU guard (#5927): the batch's initial listing snapshot saw
+			// this child as "open", but the fresh read CheckBeadStateWithOptions
+			// just did may find it already closed/tombstoned -- another actor
+			// closed it during this loop's real work for prior siblings. Skip
+			// it like an idempotent hit, but count it separately so downstream
+			// reporting doesn't misattribute the reason.
+			if check.AlreadyTerminal {
+				childResult.Skipped = true
+				batchResult.Children = append(batchResult.Children, childResult)
+				terminalSkipped++
 				continue
 			}
 			batchResult.BeadWarnings = append(batchResult.BeadWarnings, check.Warnings...)
@@ -1800,8 +1813,9 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 
 	batchResult.Routed = routed
 	batchResult.Failed = failed
-	batchResult.Skipped = idempotent + len(skipped)
+	batchResult.Skipped = idempotent + terminalSkipped + len(skipped)
 	batchResult.IdempotentCt = idempotent
+	batchResult.TerminalCt = terminalSkipped
 
 	if opts.Nudge && routed > 0 {
 		batchResult.NudgeAgent = &a

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -721,6 +721,66 @@ func TestCheckBeadStatePoolLabelWithoutConvoyIsNotIdempotent(t *testing.T) {
 	}
 }
 
+// TestCheckBeadStateClosedIsTerminalNotIdempotent guards the TOCTOU fix for
+// #5927: a fresh read that finds the bead already closed must short-circuit
+// with AlreadyTerminal=true before any of the assignee/routing checks run,
+// even when the bead's metadata would otherwise look idempotent (routed to
+// this exact target). Terminal wins first.
+func TestCheckBeadStateClosedIsTerminalNotIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:    "already done",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+		Assignee: "mayor",
+	})
+	if err != nil {
+		t.Fatalf("store.Create(): %v", err)
+	}
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("store.Close(): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+	if !result.AlreadyTerminal {
+		t.Fatalf("expected AlreadyTerminal=true for closed bead, got %+v", result)
+	}
+	if result.Idempotent {
+		t.Fatalf("expected Idempotent=false when terminal short-circuits, got %+v", result)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected no warnings when terminal short-circuits, got %v", result.Warnings)
+	}
+}
+
+// TestCheckBeadStateTombstoneIsTerminal covers the other terminal status
+// recognized by convoycore.IsTerminalStatus.
+func TestCheckBeadStateTombstoneIsTerminal(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title: "tombstoned",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("store.Create(): %v", err)
+	}
+	tombstone := "tombstone"
+	if err := store.Update(bead.ID, beads.UpdateOpts{Status: &tombstone}); err != nil {
+		t.Fatalf("store.Update(): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+	if !result.AlreadyTerminal {
+		t.Fatalf("expected AlreadyTerminal=true for tombstoned bead, got %+v", result)
+	}
+	if result.Idempotent {
+		t.Fatalf("expected Idempotent=false when terminal short-circuits, got %+v", result)
+	}
+}
+
 func TestBeadPrefixSling(t *testing.T) {
 	tests := []struct {
 		id   string
@@ -3939,6 +3999,99 @@ func TestDoSlingBatchSkipsClosedChildren(t *testing.T) {
 	}
 	if result.Skipped != 1 {
 		t.Errorf("Skipped = %d, want 1 (closed child)", result.Skipped)
+	}
+}
+
+// raceCloseOnGetStore simulates the TOCTOU race from #5927 without real
+// concurrency: it embeds a real store, and the first time raceID is read via
+// Get it closes that bead first, then returns the now-closed bead. This
+// stands in for a concurrent actor closing the bead between the batch
+// dispatch loop's initial listing snapshot and this child's turn in the
+// loop -- the same "flip status on a later read" style used by
+// internal/dispatch/retry_test.go's stateful fake stores (e.g. failGetStore)
+// to simulate races without goroutines.
+type raceCloseOnGetStore struct {
+	beads.Store
+	raceID string
+	raced  bool
+}
+
+func (s *raceCloseOnGetStore) Get(id string) (beads.Bead, error) {
+	if id == s.raceID && !s.raced {
+		s.raced = true
+		if err := s.Close(id); err != nil {
+			return beads.Bead{}, err
+		}
+	}
+	return s.Store.Get(id)
+}
+
+// TestDoSlingBatchRacesCloseAgainstDispatch is the regression test for
+// #5927: the batch dispatch loop lists open children once, then does real
+// work (formula compilation, molecule checks, etc.) for each prior sibling
+// before a given child's turn. If that child transitions to closed during
+// the window, the pre-fix code never re-checked status before dispatching --
+// CheckBeadStateWithOptions's fresh q.Get(beadID) read the up-to-date status
+// but nothing looked at it. This races a close against the second child's
+// dispatch and asserts it is skipped (via the new AlreadyTerminal signal),
+// not dispatched or reported as a failure.
+func TestDoSlingBatchRacesCloseAgainstDispatch(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	base := deps.Store
+
+	convoy, err := base.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := base.Create(beads.Bead{Title: "first", Type: "task", ParentID: convoy.ID, Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raced, err := base.Create(beads.Bead{Title: "raced", Type: "task", ParentID: convoy.ID, Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	querier := &raceCloseOnGetStore{Store: base, raceID: raced.ID}
+
+	result, err := DoSlingBatch(SlingOpts{
+		Target: a, BeadOrFormula: convoy.ID,
+	}, deps, querier)
+	if err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+
+	if result.Routed != 1 {
+		t.Errorf("Routed = %d, want 1 (only %s, the non-raced child)", result.Routed, first.ID)
+	}
+	if result.Failed != 0 {
+		t.Errorf("Failed = %d, want 0 -- a raced close is a skip, not a failure", result.Failed)
+	}
+	if result.TerminalCt != 1 {
+		t.Errorf("TerminalCt = %d, want 1 (raced child skipped as already-terminal)", result.TerminalCt)
+	}
+
+	for _, cmd := range runner.calls {
+		if strings.Contains(cmd, raced.ID) {
+			t.Fatalf("dispatched raced child %s after it closed mid-loop: calls=%v", raced.ID, runner.calls)
+		}
+	}
+
+	var sawRacedChild bool
+	for _, c := range result.Children {
+		if c.BeadID != raced.ID {
+			continue
+		}
+		sawRacedChild = true
+		if !c.Skipped || c.Routed || c.Failed {
+			t.Errorf("raced child result = %+v, want Skipped=true and Routed=false, Failed=false", c)
+		}
+	}
+	if !sawRacedChild {
+		t.Fatalf("raced child %s missing from batch result children: %+v", raced.ID, result.Children)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #5927 (partial — fix candidate 2 only). `DoSlingBatch`'s dispatch loop lists a container's children and partitions them `open`/`skipped` once, at listing time. The loop then does real per-child work (formula compilation, molecule-attachment checks) for every prior sibling before a given child's turn — a real window during which the child bead can be closed elsewhere. Nothing re-checked status before actually dispatching, so an already-closed bead could still get a worker session spawned against it. Measured production impact on the reporter's city: one step re-dispatched 197 times after being closed; `bead.dead_assignee_reopened` fired 2783 times across 517 beads, accelerating (~500/day at time of filing).

## Fix — scoped to fix candidate 2 only

The issue offered two independent fix candidates. This addresses **candidate 2 only** — "the narrower, lower-risk fix" in the reporter's own words, scoped to the batch-sling dispatch loop's snapshot-vs-spawn ordering:

`CheckBeadStateWithOptions` already does a fresh `q.Get(beadID)` immediately before the dispatch loop acts on each child — so the fix closes the TOCTOU window at **zero extra store-read cost**. It now short-circuits with `BeadCheckResult{AlreadyTerminal: true}` when that fresh read finds the bead already closed/tombstoned (`convoycore.IsTerminalStatus`, an existing helper), before any of the routing/idempotency checks run. The dispatch loop treats `AlreadyTerminal` as a skip (not a failure), mirroring the existing `Idempotent` skip path exactly, but counted separately via a new `SlingResult.TerminalCt` so downstream reporting doesn't conflate "already routed" with "raced closed."

Verified the fix's necessity directly: reverting just the logic (keeping the struct fields so the new tests still compiled) and rerunning showed all 3 new tests fail, with the race test showing the raced-closed child actually got dispatched (`Routed = 2`, runner called with the closed sibling's bead ID). Restored the fix, all pass.

**Deliberately not touched:** fix candidate 1 (`internal/convoy/membership.go`'s `TrackItemIn` — a terminal-status guard at convoy-tracking time, closing a related but separate gap affecting every caller of convoy tracking, not just batch-sling dispatch). Left as a distinct, separate follow-up per the issue's own framing that the two candidates "guard different call paths."

## Validation

- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- `go test -tags gms_pure_go -count=1 ./internal/sling/...` all pass
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch `internal/sling/sling.go`, `sling_attachment.go`, or `sling_core.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)