### PR TITLE
fix(reconciler): keep launch command on fresh start when provider has no SessionIDFlag

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -6373,14 +6373,16 @@ func rebaselineLaunchDriftHashesWithBatch(id string, sessFront *sessionpkg.Store
 
 // resolveSessionCommand returns the command to use when starting a session.
 // Precedence on a first start: fork (parentSID present + provider supports it)
-// > fresh (SessionIDFlag) > resume. The fork form resumes a parent brain
+// > fresh (SessionIDFlag, or the unchanged launch command when the provider
+// cannot bind a session key) > resume. The fork form resumes a parent brain
 // session, forks it into a new conversation, and binds gc's own session key so
 // all downstream tracking treats the child as a normal session. On any
 // subsequent wake (firstStart=false) the fork branch is skipped and the forked
 // child resumes via its own key. wake_mode=fresh still mints a new conversation
-// via SessionIDFlag. Fork preconditions (provider support, parent staleness,
-// wake_mode) are validated upstream in buildPreparedStartWithWorkDirResolver,
-// which fails loud rather than ever silently degrading a fork to a fresh start.
+// via SessionIDFlag when supported, otherwise it retains the launch command.
+// Fork preconditions (provider support, parent staleness, wake_mode) are
+// validated upstream in buildPreparedStartWithWorkDirResolver, which fails
+// loud rather than ever silently degrading a fork to a fresh start.
 func resolveSessionCommand(command, sessionKey, parentSID string, rp *config.ResolvedProvider, firstStart, forceFresh bool) string {
 	// forceFresh is part of the fork guard so this branch is self-contained: a
 	// fork resumes the parent brain, which contradicts the "discard context, start
@@ -6393,6 +6395,9 @@ func resolveSessionCommand(command, sessionKey, parentSID string, rp *config.Res
 	}
 	if (firstStart || forceFresh) && rp.SessionIDFlag != "" {
 		return command + " " + rp.SessionIDFlag + " " + sessionKey
+	}
+	if firstStart || forceFresh {
+		return command
 	}
 	return resolveResumeCommand(command, sessionKey, rp)
 }

--- a/cmd/gc/session_reconciler_fork_launch_test.go
+++ b/cmd/gc/session_reconciler_fork_launch_test.go
@@ -177,6 +177,15 @@ func TestResolveSessionCommand_ForkLaunch(t *testing.T) {
 			want:       "claude --session-id gc-key",
 		},
 		{
+			name:       "first start without session id flag keeps launch command",
+			rp: &config.ResolvedProvider{
+				Name:          "nomad-worker",
+				ResumeCommand: "gc-runtime-nomad provision",
+			},
+			firstStart: true,
+			want:       "gc-runtime-nomad start",
+		},
+		{
 			// Self-guard (HIGH): forceFresh contradicts forking (which resumes the
 			// parent brain), so even a firstStart with a parent must take the fresh
 			// form, not the fork form. validateForkLaunch fails loud on this upstream;

--- a/cmd/gc/session_reconciler_fork_launch_test.go
+++ b/cmd/gc/session_reconciler_fork_launch_test.go
@@ -141,6 +141,7 @@ func TestForkLaunch_RealBuiltinClaudeSpecPinsContract(t *testing.T) {
 func TestResolveSessionCommand_ForkLaunch(t *testing.T) {
 	tests := []struct {
 		name       string
+		command    string
 		parentSID  string
 		rp         *config.ResolvedProvider
 		firstStart bool
@@ -177,7 +178,8 @@ func TestResolveSessionCommand_ForkLaunch(t *testing.T) {
 			want:       "claude --session-id gc-key",
 		},
 		{
-			name: "first start without session id flag keeps launch command",
+			name:    "first start without session id flag keeps launch command",
+			command: "gc-runtime-nomad start",
 			rp: &config.ResolvedProvider{
 				Name:          "nomad-worker",
 				ResumeCommand: "gc-runtime-nomad provision",
@@ -186,7 +188,8 @@ func TestResolveSessionCommand_ForkLaunch(t *testing.T) {
 			want:       "gc-runtime-nomad start",
 		},
 		{
-			name: "fresh wake without session id flag keeps launch command",
+			name:    "fresh wake without session id flag keeps launch command",
+			command: "gc-runtime-nomad start",
 			rp: &config.ResolvedProvider{
 				Name:       "nomad-worker",
 				ResumeFlag: "--resume",
@@ -209,7 +212,11 @@ func TestResolveSessionCommand_ForkLaunch(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveSessionCommand("claude", "gc-key", tc.parentSID, tc.rp, tc.firstStart, tc.forceFresh)
+			command := tc.command
+			if command == "" {
+				command = "claude"
+			}
+			got := resolveSessionCommand(command, "gc-key", tc.parentSID, tc.rp, tc.firstStart, tc.forceFresh)
 			if got != tc.want {
 				t.Errorf("resolveSessionCommand = %q, want %q", got, tc.want)
 			}

--- a/cmd/gc/session_reconciler_fork_launch_test.go
+++ b/cmd/gc/session_reconciler_fork_launch_test.go
@@ -177,12 +177,21 @@ func TestResolveSessionCommand_ForkLaunch(t *testing.T) {
 			want:       "claude --session-id gc-key",
 		},
 		{
-			name:       "first start without session id flag keeps launch command",
+			name: "first start without session id flag keeps launch command",
 			rp: &config.ResolvedProvider{
 				Name:          "nomad-worker",
 				ResumeCommand: "gc-runtime-nomad provision",
 			},
 			firstStart: true,
+			want:       "gc-runtime-nomad start",
+		},
+		{
+			name: "fresh wake without session id flag keeps launch command",
+			rp: &config.ResolvedProvider{
+				Name:       "nomad-worker",
+				ResumeFlag: "--resume",
+			},
+			forceFresh: true,
 			want:       "gc-runtime-nomad start",
 		},
 		{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -12127,10 +12127,10 @@ func TestResolveSessionCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("first start without SessionIDFlag falls back to resume", func(t *testing.T) {
+	t.Run("first start without SessionIDFlag keeps launch command", func(t *testing.T) {
 		noSessionID := &config.ResolvedProvider{ResumeFlag: "--resume"}
 		got := resolveSessionCommand("agent run", "key-1", "", noSessionID, true, false)
-		want := "agent run --resume key-1"
+		want := "agent run"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}


### PR DESCRIPTION
resolveSessionCommand (cmd/gc/session_reconciler.go:6386) falls through to resolveResumeCommand whenever a first-start or forceFresh call hits a provider with SessionIDFlag == "" (e.g. nomad-worker providers, which only declare a ResumeCommand/ResumeFlag). That silently appends resume syntax onto a command that was never running a prior session, corrupting the launch command for any provider that can't bind a session key via a flag.

Fix: when SessionIDFlag is empty on a first-start/forceFresh call, return the launch command unchanged instead of falling into the resume branch.

Tests: added two subtests to TestResolveSessionCommand_ForkLaunch (first start / fresh wake, both without a SessionIDFlag) and corrected TestResolveSessionCommand's "first start without SessionIDFlag" case, which previously asserted the buggy resume-fallback as want.

Verification: go build ./... and go test -run TestResolveSessionCommand -v ./cmd/gc/... both green.

The defect is still live on main tip 1f19d26c8.