### PR TITLE
fix(gc): pin invoking executable across Beads subprocesses

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -429,12 +429,15 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 	scopeRoot := resolveStoreScopeRoot(cs.cityPath, rigPath)
 	openExecStore := func() (beads.Store, error) {
 		s := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
-		env := gcExecStoreEnv(cs.cityPath, execStoreTarget{
+		env, err := gcExecStoreEnv(cs.cityPath, execStoreTarget{
 			ScopeRoot: scopeRoot,
 			ScopeKind: "rig",
 			Prefix:    prefix,
 			RigName:   rigName,
 		}, provider)
+		if err != nil {
+			return nil, err
+		}
 		if execProviderNeedsScopedDoltStoreEnv(provider) {
 			projected, err := bdRuntimeEnvForRigWithError(cs.cityPath, cfg, scopeRoot)
 			if err != nil {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1025,7 +1025,7 @@ var recoverManagedBDCommand = func(cityPath string) error {
 	overrides := cityRuntimeEnvMapForCity(cityPath)
 	gcBin, err := resolveProviderLifecycleGCBinary()
 	if err != nil {
-		return fmt.Errorf("resolve invoking gc executable: %w", err)
+		return err
 	}
 	if gcBin != "" {
 		overrides["GC_BIN"] = gcBin

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -48,6 +48,9 @@ func bdCommandRunnerForCity(cityPath string) beads.CommandRunner {
 func bdContextCommandRunnerForCity(cityPath string) beads.CommandRunner {
 	return func(dir, name string, args ...string) ([]byte, error) {
 		env := cityRuntimeEnvMapForCity(cityPath)
+		if err := pinBdGCEnvironment(env); err != nil {
+			return nil, err
+		}
 		bdBin, err := workspacePinnedBdBinary(cityPath)
 		if err != nil {
 			return nil, err
@@ -1020,6 +1023,13 @@ var (
 var recoverManagedBDCommand = func(cityPath string) error {
 	script := gcBeadsBdScriptPath(cityPath)
 	overrides := cityRuntimeEnvMapForCity(cityPath)
+	gcBin, err := resolveProviderLifecycleGCBinary()
+	if err != nil {
+		return fmt.Errorf("resolve invoking gc executable: %w", err)
+	}
+	if gcBin != "" {
+		overrides["GC_BIN"] = gcBin
+	}
 	if err := applyWorkspacePinnedBdBinary(overrides, cityPath); err != nil {
 		return err
 	}
@@ -1029,10 +1039,6 @@ var recoverManagedBDCommand = func(cityPath string) error {
 	applyBdContributorRoutingOptOut(overrides)
 	environ := mergeRuntimeEnv(processEnvSnapshotExcludingNativeDoltOpen(), overrides)
 	environ = append(environ, providerLifecycleDoltPathEnv(cityPath)...)
-	if gcBin := resolveProviderLifecycleGCBinary(); gcBin != "" {
-		environ = removeEnvKey(environ, "GC_BIN")
-		environ = append(environ, "GC_BIN="+gcBin)
-	}
 	return runProviderOpWithEnv(script, environ, "recover")
 }
 
@@ -1402,6 +1408,9 @@ func bdCommandRunnerWithManagedRetryErr(cityPath string, envFn func(dir string) 
 		if env == nil {
 			env = map[string]string{}
 		}
+		if err := pinBdGCEnvironment(env); err != nil {
+			return nil, err
+		}
 		ensureProjectedDoltEnvExplicit(env)
 		runner, runnerErr := beadsCommandRunnerForHostedCity(cityPath, env)
 		if runnerErr != nil {
@@ -1423,6 +1432,12 @@ func bdCommandRunnerWithManagedRetryErr(cityPath string, envFn func(dir string) 
 		retryEnv, retryEnvErr := envFn(dir)
 		if retryEnvErr != nil {
 			return nil, retryEnvErr
+		}
+		if retryEnv == nil {
+			retryEnv = map[string]string{}
+		}
+		if err := pinBdGCEnvironment(retryEnv); err != nil {
+			return nil, err
 		}
 		ensureProjectedDoltEnvExplicit(retryEnv)
 		retryRunner, runnerErr := beadsCommandRunnerForHostedCity(cityPath, retryEnv)

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -130,7 +130,11 @@ func TestBdCommandRunnerForCityCompleteStorageBindingSkipsManagedRetry(t *testin
 	}
 }
 
-func TestBdContextCommandRunnerForCityPinsCanonicalGCBinary(t *testing.T) {
+// TestBdCommandRunnerForCityCompleteBindingPinsCanonicalGCBinary drives
+// bdCommandRunnerForCity's complete-binding arm, which delegates to
+// bdContextCommandRunnerForCity. The managed-retry arm is covered by
+// TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms.
+func TestBdCommandRunnerForCityCompleteBindingPinsCanonicalGCBinary(t *testing.T) {
 	t.Setenv("GC_BIN", "/tmp/stale-gc")
 	cityPath := t.TempDir()
 	bdPath := filepath.Join(t.TempDir(), "bd")
@@ -190,6 +194,95 @@ func TestBeadsCommandRunnerWithContextPinsCanonicalGCBinary(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(out)); got != want {
 		t.Fatalf("child GC_BIN = %q, want canonical %q", got, want)
+	}
+}
+
+// TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms covers
+// the managed-retry arm — the default path for cities without a complete
+// storage binding — which pins GC_BIN twice: once on the initial env and again
+// on the retry env rebuilt after recovery. A real bd shim records the child's
+// GC_BIN on each attempt, so deleting either pin leaves the ambient
+// GC_BIN=/tmp/stale-gc in that attempt's child and reddens this test.
+func TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BIN", "/tmp/stale-gc")
+
+	captured := filepath.Join(t.TempDir(), "gc-bin-per-attempt")
+	bdPath := filepath.Join(t.TempDir(), "bd")
+	// Fail the first attempt the way an unreachable managed server fails,
+	// because that is the only failure shape bdTransportRetryableError matches;
+	// anything else leaves the retry env arm unreached and its assertion vacuous.
+	shim := fmt.Sprintf("#!/bin/sh\n"+
+		"printf '%%s\\n' \"$GC_BIN\" >> %[1]q\n"+
+		"if [ \"$(wc -l < %[1]q)\" -eq 1 ]; then\n"+
+		"echo 'server unreachable at 127.0.0.1:3307' >&2\n"+
+		"exit 17\n"+
+		"fi\n"+
+		"echo ok\n", captured)
+	if err := os.WriteFile(bdPath, []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	origResolve := resolveInvokingExecutable
+	origRecover := recoverManagedBDCommand
+	origSleep := bdCommandRetrySleep
+	t.Cleanup(func() {
+		resolveInvokingExecutable = origResolve
+		recoverManagedBDCommand = origRecover
+		bdCommandRetrySleep = origSleep
+	})
+	resolveInvokingExecutable = func() (string, error) { return gcBin, nil }
+	recoverCalls := 0
+	recoverManagedBDCommand = func(_ string) error {
+		recoverCalls++
+		return nil
+	}
+	bdCommandRetrySleep = func(time.Duration) {}
+
+	want, err := filepath.EvalSymlinks(gcBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No scope metadata is written, so scopeHasCompleteStorageBinding is false
+	// and bdCommandRunnerForCity would route here rather than to the
+	// complete-binding delegation.
+	cityPath := t.TempDir()
+	runner := bdCommandRunnerWithManagedRetryErr(cityPath, func(_ string) (map[string]string, error) {
+		return map[string]string{"BD_BIN": bdPath}, nil
+	})
+
+	out, err := runner(cityPath, "bd", "list", "--json")
+	if err != nil {
+		t.Fatalf("managed-retry runner error = %v, want nil after successful retry", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "ok" {
+		t.Fatalf("runner output = %q, want %q", got, "ok")
+	}
+	if recoverCalls != 1 {
+		t.Fatalf("recoverCalls = %d, want 1: the retry env arm must be reached", recoverCalls)
+	}
+
+	data, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatalf("read captured GC_BIN: %v", err)
+	}
+	attempts := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(attempts) != 2 {
+		t.Fatalf("bd attempts = %d (%q), want 2 (initial env then retry env)", len(attempts), attempts)
+	}
+	for i, got := range attempts {
+		arm := "initial env"
+		if i == 1 {
+			arm = "retry env"
+		}
+		if got != want {
+			t.Errorf("attempt %d (%s) child GC_BIN = %q, want canonical %q", i+1, arm, got, want)
+		}
 	}
 }
 

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -130,6 +130,69 @@ func TestBdCommandRunnerForCityCompleteStorageBindingSkipsManagedRetry(t *testin
 	}
 }
 
+func TestBdContextCommandRunnerForCityPinsCanonicalGCBinary(t *testing.T) {
+	t.Setenv("GC_BIN", "/tmp/stale-gc")
+	cityPath := t.TempDir()
+	bdPath := filepath.Join(t.TempDir(), "bd")
+	if err := os.WriteFile(bdPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$GC_BIN\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(fmt.Sprintf("[workspace]\nname = \"bound\"\n[workspace.env]\nBD_BIN = %q\n", bdPath)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeBoundCityFixture(t, cityPath)
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldResolve := resolveInvokingExecutable
+	resolveInvokingExecutable = func() (string, error) { return gcBin, nil }
+	t.Cleanup(func() { resolveInvokingExecutable = oldResolve })
+	want, err := filepath.EvalSymlinks(gcBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := bdCommandRunnerForCity(cityPath)(cityPath, "bd", "status")
+	if err != nil {
+		t.Fatalf("bd context runner: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Fatalf("child GC_BIN = %q, want canonical %q", got, want)
+	}
+}
+
+func TestBeadsCommandRunnerWithContextPinsCanonicalGCBinary(t *testing.T) {
+	t.Setenv("GC_BIN", "/tmp/stale-gc")
+	cityPath := t.TempDir()
+	bdPath := filepath.Join(t.TempDir(), "bd")
+	if err := os.WriteFile(bdPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$GC_BIN\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldResolve := resolveInvokingExecutable
+	resolveInvokingExecutable = func() (string, error) { return gcBin, nil }
+	t.Cleanup(func() { resolveInvokingExecutable = oldResolve })
+	env := map[string]string{"BD_BIN": bdPath}
+	runner, err := beadsCommandRunnerWithContextForHostedCity(context.Background(), cityPath, env)
+	if err != nil {
+		t.Fatalf("context runner: %v", err)
+	}
+	out, err := runner(cityPath, "bd", "status")
+	if err != nil {
+		t.Fatalf("context runner invocation: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(gcBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Fatalf("child GC_BIN = %q, want canonical %q", got, want)
+	}
+}
+
 func countBdShimInvocations(t *testing.T, path string) int {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -537,6 +600,30 @@ func TestRecoverManagedBDCommandCarriesWorkspaceBDBinaryPin(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(data)); got != pinned {
 		t.Fatalf("recover BD_BIN = %q, want workspace-pinned %q", got, pinned)
+	}
+}
+
+func TestRecoverManagedBDCommandStopsBeforeChildWhenGCBinaryResolutionFails(t *testing.T) {
+	cityPath := t.TempDir()
+	capture := filepath.Join(t.TempDir(), "recover-ran")
+	scriptPath := gcBeadsBdScriptPath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\ntouch "+capture+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	original := resolveProviderLifecycleGCBinary
+	resolveProviderLifecycleGCBinary = func() (string, error) { return "", errors.New("unavailable") }
+	t.Cleanup(func() { resolveProviderLifecycleGCBinary = original })
+
+	err := recoverManagedBDCommand(cityPath)
+	if err == nil || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("recoverManagedBDCommand() error = %v, want resolver failure", err)
+	}
+	if _, statErr := os.Stat(capture); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("recover child ran despite resolver failure; stat err = %v", statErr)
 	}
 }
 

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -2346,7 +2346,7 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 	env = append(env, providerLifecycleDoltPathEnv(cityPath)...)
 	gcBin, err := resolveProviderLifecycleGCBinary()
 	if err != nil {
-		return nil, fmt.Errorf("resolve invoking gc executable: %w", err)
+		return nil, err
 	}
 	if gcBin != "" {
 		env = pinInvokingGCBinary(env, gcBin)

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -127,17 +127,14 @@ func registerCityDoltConfigIfAbsent(cityPath string, cfg config.DoltConfig) (add
 	return !loaded
 }
 
-var resolveProviderLifecycleGCBinary = func() string {
+var resolveProviderLifecycleGCBinary = func() (string, error) {
 	if isTestBinary() {
-		return ""
+		// Lifecycle tests deliberately inject a fake GC_BIN into their child
+		// environment. Do not replace it with the Go test executable: that
+		// would recursively execute the test binary as gc.
+		return "", nil
 	}
-	if exe, err := os.Executable(); err == nil && exe != "" {
-		return exe
-	}
-	if path, err := exec.LookPath("gc"); err == nil && path != "" {
-		return path
-	}
-	return ""
+	return resolveBdInvokingGCBinary()
 }
 
 var (
@@ -1090,6 +1087,9 @@ func initDefaultRigBdStore(cityPath, dir, prefix, doltDatabase string) error {
 	}
 	env := map[string]string{
 		"BEADS_DIR": filepath.Join(dir, ".beads"),
+	}
+	if err := pinBdGCEnvironment(env); err != nil {
+		return err
 	}
 	applyExportSuppressionEnv(env)
 	args := []string{"init", "--server", "-p", prefix, "--skip-hooks"}
@@ -2262,7 +2262,7 @@ func providerLifecycleProcessEnvWithError(cityPath, provider string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	return providerLifecycleProcessEnvFromBase(cityPath, provider, env), nil
+	return providerLifecycleProcessEnvFromBase(cityPath, provider, env)
 }
 
 // providerLifecycleProcessEnvForScopeInitWithError builds the process env a
@@ -2314,9 +2314,9 @@ func applyLegacyRigScopeInitDoltEnv(env map[string]string, cityPath, scopeRoot s
 	mirrorBeadsDoltScopeEnv(env, target)
 }
 
-func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string) []string {
+func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string) ([]string, error) {
 	if !providerUsesBdStoreContract(provider) {
-		return env
+		return env, nil
 	}
 	if cityUsesDoltliteBeadsBackend(cityPath) {
 		env = removeEnvKey(env, "GC_BEADS_BACKEND")
@@ -2324,7 +2324,7 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		env = append(env, "GC_BEADS_BACKEND=doltlite", "BEADS_BACKEND=doltlite")
 		envMap := runtimeEnvEntriesToMap(env)
 		clearProjectedDoltEnv(envMap)
-		return mergeRuntimeEnv(nil, envMap)
+		return mergeRuntimeEnv(nil, envMap), nil
 	}
 	for _, key := range []string{
 		"GC_PACK_STATE_DIR",
@@ -2344,9 +2344,12 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		env = removeEnvKey(env, key)
 	}
 	env = append(env, providerLifecycleDoltPathEnv(cityPath)...)
-	if gcBin := resolveProviderLifecycleGCBinary(); gcBin != "" {
-		env = removeEnvKey(env, "GC_BIN")
-		env = append(env, "GC_BIN="+gcBin)
+	gcBin, err := resolveProviderLifecycleGCBinary()
+	if err != nil {
+		return nil, fmt.Errorf("resolve invoking gc executable: %w", err)
+	}
+	if gcBin != "" {
+		env = pinInvokingGCBinary(env, gcBin)
 	}
 	// Strip any inherited test-mode env unconditionally so a stray
 	// GC_MANAGED_DOLT_TEST_MODE=1 in a production parent shell can never
@@ -2417,7 +2420,7 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 			env = append(env, loglevelPrefix+val)
 		}
 	}
-	return env
+	return env, nil
 }
 
 func runtimeEnvEntriesToMap(environ []string) map[string]string {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -402,7 +402,7 @@ func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	cityPath := t.TempDir()
 	t.Setenv("GC_BIN", "/tmp/wrong-gc")
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return "/opt/gc/bin/gc" }
+	resolveProviderLifecycleGCBinary = func() (string, error) { return "/opt/gc/bin/gc", nil }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
 	envEntries := mustProviderLifecycleProcessEnv(t, cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
@@ -415,6 +415,28 @@ func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	}
 	if got := env["GC_BIN"]; got != "/opt/gc/bin/gc" {
 		t.Fatalf("providerLifecycleProcessEnv()[GC_BIN] = %q, want %q", got, "/opt/gc/bin/gc")
+	}
+}
+
+func TestProviderLifecycleProcessEnvRejectsGCBinaryResolutionFailure(t *testing.T) {
+	cityPath := t.TempDir()
+	original := resolveProviderLifecycleGCBinary
+	resolveProviderLifecycleGCBinary = func() (string, error) { return "", errors.New("unavailable") }
+	t.Cleanup(func() { resolveProviderLifecycleGCBinary = original })
+
+	_, err := providerLifecycleProcessEnvWithError(cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	if err == nil || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("providerLifecycleProcessEnvWithError() error = %v, want resolver failure", err)
+	}
+}
+
+func TestProviderLifecycleProcessEnvPreservesInjectedTestGCBinary(t *testing.T) {
+	env, err := providerLifecycleProcessEnvFromBase(t.TempDir(), "exec:/tmp/gc-beads-bd", []string{"GC_BIN=/tmp/test-wrapper"})
+	if err != nil {
+		t.Fatalf("providerLifecycleProcessEnvFromBase: %v", err)
+	}
+	if got := envSliceValue(env, "GC_BIN"); got != "/tmp/test-wrapper" {
+		t.Fatalf("GC_BIN = %q, want injected test wrapper", got)
 	}
 }
 
@@ -521,11 +543,14 @@ func TestProviderLifecycleProcessEnvPreservesAmbientWaitTimeout(t *testing.T) {
 	// No cityDoltConfigs entry: this is the silent-city.toml case.
 	cityDoltConfigs.Delete(cityPath)
 
-	envEntries := providerLifecycleProcessEnvFromBase(
+	envEntries, err := providerLifecycleProcessEnvFromBase(
 		cityPath,
 		"exec:"+gcBeadsBdScriptPath(cityPath),
 		[]string{"GC_DOLT_WAIT_TIMEOUT=45"},
 	)
+	if err != nil {
+		t.Fatalf("providerLifecycleProcessEnvFromBase: %v", err)
+	}
 
 	count := 0
 	for _, entry := range envEntries {
@@ -5762,7 +5787,7 @@ exit 99
 	}
 }
 
-func TestInitAndHookDirAdoptsAlreadyInitializedDefaultRigBdStore(t *testing.T) {
+func TestInitAndHookDirAdoptsAlreadyInitializedDefaultRigBdStorePinsCanonicalGCBinary(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "rigs", "tincan")
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
@@ -5786,12 +5811,14 @@ func TestInitAndHookDirAdoptsAlreadyInitializedDefaultRigBdStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	gcBinFile := filepath.Join(t.TempDir(), "bd-init-gc-bin")
 	fakeBd := filepath.Join(binDir, "bd")
 	fakeBdScript := fmt.Sprintf(`#!/bin/sh
 set -eu
 case "${1:-}" in
   init)
     printf '%%s\n' "$@" > %q
+    printf '%%s\n' "${GC_BIN-}" > %q
     echo "Found existing Dolt database 'tincan' for this workspace. This workspace is already initialized; just run bd commands normally. Aborting." >&2
     exit 1
     ;;
@@ -5803,10 +5830,18 @@ case "${1:-}" in
     exit 0
     ;;
 esac
-`, initArgsFile)
+`, initArgsFile, gcBinFile)
 	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldResolve := resolveInvokingExecutable
+	resolveInvokingExecutable = func() (string, error) { return gcBin, nil }
+	t.Cleanup(func() { resolveInvokingExecutable = oldResolve })
+	t.Setenv("GC_BIN", "/tmp/stale-gc")
 
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 
@@ -5815,6 +5850,17 @@ esac
 	}
 	if _, err := os.Stat(initArgsFile); err != nil {
 		t.Fatalf("expected bd init attempt, stat err = %v", err)
+	}
+	data, err := os.ReadFile(gcBinFile)
+	if err != nil {
+		t.Fatalf("read GC_BIN capture: %v", err)
+	}
+	wantGCBin, err := filepath.EvalSymlinks(gcBin)
+	if err != nil {
+		t.Fatalf("canonicalize expected gc binary: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != wantGCBin {
+		t.Fatalf("bd init GC_BIN = %q, want canonical %q", got, wantGCBin)
 	}
 	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); !os.IsNotExist(err) {
 		t.Fatalf("gc must not install bd event hooks for adopted rig (stat err=%v)", err)

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -197,6 +197,17 @@ func resolveBdInvokingGCBinary() (string, error) {
 	return canonical, nil
 }
 
+// pinBdGCEnvironment replaces ambient GC_BIN with the physical invoking
+// executable before the beads runner merges the child environment.
+func pinBdGCEnvironment(env map[string]string) error {
+	gcBin, err := resolveBdInvokingGCBinary()
+	if err != nil {
+		return err
+	}
+	env["GC_BIN"] = gcBin
+	return nil
+}
+
 func warnExternalBdOverrideDrift(stderr io.Writer, cityPath string, target execStoreTarget) {
 	resolved, ok, err := canonicalScopeDoltTarget(cityPath, target.ScopeRoot)
 	if err != nil || !ok || !resolved.External {

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -199,6 +199,11 @@ func resolveBdInvokingGCBinary() (string, error) {
 
 // pinBdGCEnvironment replaces ambient GC_BIN with the physical invoking
 // executable before the beads runner merges the child environment.
+//
+// Unlike resolveProviderLifecycleGCBinary this deliberately has no isTestBinary
+// carve-out: production callers of these paths must always pin, and tests
+// reaching them stub resolveInvokingExecutable rather than injecting a fake
+// GC_BIN into the child environment.
 func pinBdGCEnvironment(env map[string]string) error {
 	gcBin, err := resolveBdInvokingGCBinary()
 	if err != nil {

--- a/cmd/gc/cmd_bd_store_bridge.go
+++ b/cmd/gc/cmd_bd_store_bridge.go
@@ -139,7 +139,14 @@ func runBdStoreBridge(op string, args []string, dir, host, port, user string, st
 		return fmt.Errorf("missing --port")
 	}
 	password := bdStoreBridgePassword()
-	store := beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(bdStoreBridgeEnv(dir, host, port, user, password)))
+	env := bdStoreBridgeEnv(dir, host, port, user, password)
+	// Bridge operations can trigger bd hooks that recursively invoke gc. Pin
+	// those callbacks to this exact executable so an ambient GC_BIN cannot
+	// cross the city boundary or select a different gc installation.
+	if err := pinBdGCEnvironment(env); err != nil {
+		return fmt.Errorf("resolve invoking gc executable: %w", err)
+	}
+	store := beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(env))
 	switch op {
 	case "create":
 		var req bdStoreBridgeCreateRequest

--- a/cmd/gc/cmd_bd_store_bridge.go
+++ b/cmd/gc/cmd_bd_store_bridge.go
@@ -144,7 +144,7 @@ func runBdStoreBridge(op string, args []string, dir, host, port, user string, st
 	// those callbacks to this exact executable so an ambient GC_BIN cannot
 	// cross the city boundary or select a different gc installation.
 	if err := pinBdGCEnvironment(env); err != nil {
-		return fmt.Errorf("resolve invoking gc executable: %w", err)
+		return err
 	}
 	store := beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(env))
 	switch op {

--- a/cmd/gc/cmd_bd_store_bridge_test.go
+++ b/cmd/gc/cmd_bd_store_bridge_test.go
@@ -36,6 +36,7 @@ func writeFakeBdBridgeScript(t *testing.T, binDir, envFile, argsFile string) {
 	script := `#!/bin/sh
 set -eu
 printf 'BEADS_DIR=%s
+GC_BIN=%s
 GC_DOLT_HOST=%s
 GC_DOLT_PORT=%s
 GC_DOLT_USER=%s
@@ -52,7 +53,7 @@ BEADS_BACKEND=%s
 GC_BEADS_PREFIX=%s
 BD_EXPORT_AUTO=%s
 ' \
-  "${BEADS_DIR:-}" "${GC_DOLT_HOST:-}" "${GC_DOLT_PORT:-}" "${GC_DOLT_USER:-}" "${GC_DOLT_PASSWORD:-}" \
+  "${BEADS_DIR:-}" "${GC_BIN:-}" "${GC_DOLT_HOST:-}" "${GC_DOLT_PORT:-}" "${GC_DOLT_USER:-}" "${GC_DOLT_PASSWORD:-}" \
   "${BEADS_DOLT_SERVER_HOST:-}" "${BEADS_DOLT_SERVER_PORT:-}" "${BEADS_DOLT_SERVER_USER:-}" "${BEADS_DOLT_PASSWORD:-}" \
   "${BEADS_DOLT_SERVER_DATABASE:-}" "${BEADS_CREDENTIALS_FILE:-}" "${GC_BEADS:-}" "${GC_BEADS_BACKEND:-}" "${BEADS_BACKEND:-}" "${GC_BEADS_PREFIX:-}" \
   "${BD_EXPORT_AUTO:-}" > "` + envFile + `"
@@ -108,8 +109,20 @@ func TestBdStoreBridgeCreateCmdProjectsCanonicalEnvAndClearsAmbientAuthority(t *
 	envFile := filepath.Join(t.TempDir(), "bridge.env")
 	argsFile := filepath.Join(t.TempDir(), "bridge.args")
 	writeFakeBdBridgeScript(t, binDir, envFile, argsFile)
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldResolve := resolveInvokingExecutable
+	resolveInvokingExecutable = func() (string, error) { return gcBin, nil }
+	t.Cleanup(func() { resolveInvokingExecutable = oldResolve })
+	wantGCBin, err := filepath.EvalSymlinks(gcBin)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_BIN", "/tmp/stale-gc")
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong-db")
 	t.Setenv("BEADS_CREDENTIALS_FILE", "/tmp/stale-creds")
 	t.Setenv("GC_BEADS", "ambient-bd")
@@ -146,6 +159,9 @@ func TestBdStoreBridgeCreateCmdProjectsCanonicalEnvAndClearsAmbientAuthority(t *
 	envMap := readExecCaptureEnv(t, envFile)
 	if got := envMap["BEADS_DIR"]; got != filepath.Join(scopeDir, ".beads") {
 		t.Fatalf("BEADS_DIR = %q, want %q", got, filepath.Join(scopeDir, ".beads"))
+	}
+	if got := envMap["GC_BIN"]; got != wantGCBin {
+		t.Fatalf("GC_BIN = %q, want canonical %q (ambient value must not leak)", got, wantGCBin)
 	}
 	if got := envMap["GC_DOLT_HOST"]; got != "db.example.internal" {
 		t.Fatalf("GC_DOLT_HOST = %q, want db.example.internal", got)

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -3320,7 +3320,7 @@ func setupFreshManagedBdWaitTestCity(t *testing.T) string {
 
 	reexecGC := reexecGCTestBinaryForTests(t)
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return reexecGC }
+	resolveProviderLifecycleGCBinary = func() (string, error) { return reexecGC, nil }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
 	prevCityFlag, prevRigFlag := cityFlag, rigFlag
@@ -3377,7 +3377,7 @@ func setupManagedBdWaitTestCity(t *testing.T) (string, string) {
 	t.Setenv("PATH", strings.Join([]string{filepath.Dir(bdPath), filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
 
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
+	resolveProviderLifecycleGCBinary = func() (string, error) { return currentGCBinaryForTests(t), nil }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
 	prevCityFlag, prevRigFlag := cityFlag, rigFlag

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1720,7 +1720,10 @@ func openExecStoreAtForCityWithConfig(provider, scopeRoot, runtimeCityPath strin
 	if err != nil {
 		return nil, err
 	}
-	env := gcExecStoreEnv(runtimeCityPath, target, provider)
+	env, err := gcExecStoreEnv(runtimeCityPath, target, provider)
+	if err != nil {
+		return nil, err
+	}
 	if execProviderNeedsScopedDoltStoreEnv(provider) {
 		if target.ScopeKind == "rig" {
 			rigCfg := cfg

--- a/cmd/gc/scoped_store.go
+++ b/cmd/gc/scoped_store.go
@@ -51,6 +51,12 @@ func scopedBdStoreForRig(ctx context.Context, cityPath string, cfg *config.City,
 }
 
 func beadsCommandRunnerWithContextForHostedCity(ctx context.Context, cityPath string, env map[string]string) (beads.CommandRunner, error) {
+	if env == nil {
+		env = make(map[string]string)
+	}
+	if err := pinBdGCEnvironment(env); err != nil {
+		return nil, err
+	}
 	selected, err := citySelectsHostedBeadsCredentialProvider(cityPath)
 	if err != nil {
 		return nil, err

--- a/cmd/gc/store_target_exec.go
+++ b/cmd/gc/store_target_exec.go
@@ -83,7 +83,7 @@ func gcExecStoreEnv(cityPath string, target execStoreTarget, provider string) (m
 	if execProviderUsesCanonicalBdScopeFiles(provider) {
 		gcBin, err := resolveProviderLifecycleGCBinary()
 		if err != nil {
-			return nil, fmt.Errorf("resolve invoking gc executable: %w", err)
+			return nil, err
 		}
 		if gcBin != "" {
 			env["GC_BIN"] = gcBin

--- a/cmd/gc/store_target_exec.go
+++ b/cmd/gc/store_target_exec.go
@@ -68,7 +68,7 @@ func copyExecProjectedBackendEnv(dst, src map[string]string) {
 	}
 }
 
-func gcExecStoreEnv(cityPath string, target execStoreTarget, provider string) map[string]string {
+func gcExecStoreEnv(cityPath string, target execStoreTarget, provider string) (map[string]string, error) {
 	env := cityRuntimeEnvMapForCity(cityPath)
 	env["GC_PROVIDER"] = provider
 	env["GC_STORE_ROOT"] = target.ScopeRoot
@@ -81,7 +81,11 @@ func gcExecStoreEnv(cityPath string, target execStoreTarget, provider string) ma
 	env["BEADS_DOLT_AUTO_START"] = ""
 	env["GC_BIN"] = ""
 	if execProviderUsesCanonicalBdScopeFiles(provider) {
-		if gcBin := resolveProviderLifecycleGCBinary(); gcBin != "" {
+		gcBin, err := resolveProviderLifecycleGCBinary()
+		if err != nil {
+			return nil, fmt.Errorf("resolve invoking gc executable: %w", err)
+		}
+		if gcBin != "" {
 			env["GC_BIN"] = gcBin
 		}
 	}
@@ -89,11 +93,14 @@ func gcExecStoreEnv(cityPath string, target execStoreTarget, provider string) ma
 		env["GC_RIG"] = target.RigName
 		env["GC_RIG_ROOT"] = target.ScopeRoot
 	}
-	return env
+	return env, nil
 }
 
 func gcExecLifecycleInitProcessEnv(cityPath string, target execStoreTarget, provider string) ([]string, error) {
-	env := gcExecStoreEnv(cityPath, target, provider)
+	env, err := gcExecStoreEnv(cityPath, target, provider)
+	if err != nil {
+		return nil, err
+	}
 	if !execProviderNeedsScopedDoltInit(provider) {
 		return mergeRuntimeEnv(os.Environ(), env), nil
 	}

--- a/cmd/gc/store_target_exec_test.go
+++ b/cmd/gc/store_target_exec_test.go
@@ -225,14 +225,17 @@ func TestGcExecLifecycleInitProcessEnvDoesNotLeakAmbientBEADS_DIRForGcBeadsK8s(t
 func TestGcExecStoreEnvProjectsGCBinForGcBeadsBd(t *testing.T) {
 	cityDir := t.TempDir()
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return "/opt/gc/bin/gc" }
+	resolveProviderLifecycleGCBinary = func() (string, error) { return "/opt/gc/bin/gc", nil }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
-	env := gcExecStoreEnv(cityDir, execStoreTarget{
+	env, err := gcExecStoreEnv(cityDir, execStoreTarget{
 		ScopeRoot: cityDir,
 		ScopeKind: "city",
 		Prefix:    "gc",
 	}, "exec:/tmp/gc-beads-bd")
+	if err != nil {
+		t.Fatalf("gcExecStoreEnv(gc-beads-bd): %v", err)
+	}
 
 	if got := env["GC_BIN"]; got != "/opt/gc/bin/gc" {
 		t.Fatalf("GC_BIN = %q, want %q", got, "/opt/gc/bin/gc")
@@ -242,17 +245,48 @@ func TestGcExecStoreEnvProjectsGCBinForGcBeadsBd(t *testing.T) {
 func TestGcExecStoreEnvDoesNotProjectGCBinForUnrelatedExecProvider(t *testing.T) {
 	cityDir := t.TempDir()
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return "/opt/gc/bin/gc" }
+	resolveProviderLifecycleGCBinary = func() (string, error) { return "/opt/gc/bin/gc", nil }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
-	env := gcExecStoreEnv(cityDir, execStoreTarget{
+	env, err := gcExecStoreEnv(cityDir, execStoreTarget{
 		ScopeRoot: cityDir,
 		ScopeKind: "city",
 		Prefix:    "gc",
 	}, "exec:/tmp/custom-provider")
+	if err != nil {
+		t.Fatalf("gcExecStoreEnv(custom): %v", err)
+	}
 
 	if got := env["GC_BIN"]; got != "" {
 		t.Fatalf("GC_BIN = %q, want empty for unrelated exec provider", got)
+	}
+}
+
+func TestGcExecStoreEnvRejectsGCBinaryResolutionFailureForGcBeadsBd(t *testing.T) {
+	cityDir := t.TempDir()
+	original := resolveProviderLifecycleGCBinary
+	resolveProviderLifecycleGCBinary = func() (string, error) { return "", fmt.Errorf("unavailable") }
+	t.Cleanup(func() { resolveProviderLifecycleGCBinary = original })
+
+	_, err := gcExecStoreEnv(cityDir, execStoreTarget{
+		ScopeRoot: cityDir,
+		ScopeKind: "city",
+		Prefix:    "gc",
+	}, "exec:/tmp/gc-beads-bd")
+	if err == nil || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("gcExecStoreEnv() error = %v, want resolver failure", err)
+	}
+
+	env, err := gcExecStoreEnv(cityDir, execStoreTarget{
+		ScopeRoot: cityDir,
+		ScopeKind: "city",
+		Prefix:    "gc",
+	}, "exec:/tmp/custom-provider")
+	if err != nil {
+		t.Fatalf("gcExecStoreEnv(custom provider): %v", err)
+	}
+	if got := env["GC_BIN"]; got != "" {
+		t.Fatalf("GC_BIN = %q, want empty for unrelated provider", got)
 	}
 }
 
@@ -315,7 +349,10 @@ func TestGcExecStoreEnvProjectsCityAndRigTargets(t *testing.T) {
 		ScopeKind: "city",
 		Prefix:    "ct",
 	}
-	cityEnv := gcExecStoreEnv(cityDir, cityTarget, "exec:/tmp/spy")
+	cityEnv, err := gcExecStoreEnv(cityDir, cityTarget, "exec:/tmp/spy")
+	if err != nil {
+		t.Fatalf("gcExecStoreEnv(city): %v", err)
+	}
 	if got := cityEnv["GC_PROVIDER"]; got != "exec:/tmp/spy" {
 		t.Fatalf("GC_PROVIDER = %q, want exec:/tmp/spy", got)
 	}
@@ -348,7 +385,10 @@ func TestGcExecStoreEnvProjectsCityAndRigTargets(t *testing.T) {
 		Prefix:    "ra",
 		RigName:   "rig-a",
 	}
-	rigEnv := gcExecStoreEnv(cityDir, rigTarget, "exec:/tmp/spy")
+	rigEnv, err := gcExecStoreEnv(cityDir, rigTarget, "exec:/tmp/spy")
+	if err != nil {
+		t.Fatalf("gcExecStoreEnv(rig): %v", err)
+	}
 	if got := rigEnv["GC_STORE_ROOT"]; got != rigDir {
 		t.Fatalf("GC_STORE_ROOT = %q, want %q", got, rigDir)
 	}
@@ -588,12 +628,15 @@ dolt.auto-start: false
 	}})
 	t.Setenv("GC_DOLT_HOST", "ambient-dolt")
 
-	env := gcExecStoreEnv(cityDir, execStoreTarget{
+	env, err := gcExecStoreEnv(cityDir, execStoreTarget{
 		ScopeRoot: rigDir,
 		ScopeKind: "rig",
 		Prefix:    "fe",
 		RigName:   "frontend",
 	}, "exec:/tmp/gc-beads-bd")
+	if err != nil {
+		t.Fatalf("gcExecStoreEnv(gc-beads-bd): %v", err)
+	}
 	projected, err := bdRuntimeEnvForRigWithError(cityDir, &config.City{Rigs: []config.Rig{{
 		Name:   "frontend",
 		Path:   "rigs/frontend",


### PR DESCRIPTION
Beads subprocesses on the paths enumerated below now receive the physical path of the invoking GC executable in `GC_BIN`. Recovery, provider lifecycle, scoped stores, context runners, retries, default-rig initialization, and the store bridge reject executable-resolution failures before launching a child. Three managed-env paths are out of scope here and still inherit an ambient `GC_BIN` — the hook-claim mutation runner, the doctor store preflight, and the DoltLite early return; all three are pre-existing, untouched by this PR, and tracked in ga-wbycp.

The existing lifecycle test wrapper behavior is preserved. Unrelated exec providers keep an empty `GC_BIN`, and DoltLite retains its existing provider policy. This consolidates the context/bridge follow-up from #6046. The two independent GC_BIN commits have been extracted from the retired #6042 handoff stack and rebased onto main.

Sol and independent Astra reviewed the final implementation. Focused tests, targeted race tests, resource census, repository pre-commit lint/code generation/vet, and dashboard preview smoke passed. The complete fast baseline and all six CLI process shards plus product metrics passed. Dashboard build/type checks and a live preview HTTP smoke passed. The normal pre-push gate passed at d7637d1f3589034aceb060d70e1c853d24dd3c20.

Beads: ga-p9iuv.30.4 and ga-p9iuv.30.4.1.

Final-head GitHub Linux CI and Mac Regression passed. Mac make-test required one retry after an unrelated unchanged zcode terminal-input timing failure; all 12 Mac CLI process shards passed on the first attempt.


The validation above describes the original submission. The September 19 audit is revalidating the rebased head before adding it to the review queue.

_Codex-unknown-model-unknown-reasoning on behalf of julianknutsen_
