### PR TITLE
fix(processenv): keep valid secrets.env entries when one line is malformed (#5982)

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1253,10 +1253,11 @@ func supervisorSecretsEnvFilePath() string {
 
 // supervisorSecretsEnvFileEntries reads ${GC_HOME}/secrets.env and returns its
 // parsed key/value pairs. A missing file is the normal case and yields nil. A
-// present-but-unreadable or malformed file is logged to stderr and ignored so
-// a bad secrets file never blocks supervisor install/start; the caller still
-// gates whatever is returned on the persist allowlist or an explicit
-// GC_SUPERVISOR_ENV opt-in.
+// present-but-unreadable file is logged to stderr and ignored so a bad
+// secrets file never blocks supervisor install/start. A malformed line is
+// logged to stderr individually and skipped; every other, validly-parsed
+// entry in the file is still returned. The caller still gates whatever is
+// returned on the persist allowlist or an explicit GC_SUPERVISOR_ENV opt-in.
 func supervisorSecretsEnvFileEntries() map[string]string {
 	path := supervisorSecretsEnvFilePath()
 	data, err := os.ReadFile(path)
@@ -1266,10 +1267,9 @@ func supervisorSecretsEnvFileEntries() map[string]string {
 		}
 		return nil
 	}
-	entries, err := processenv.ParseEnvFile(string(data))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "gc: parsing supervisor secrets file %q: %v\n", path, err)
-		return nil
+	entries, errs := processenv.ParseEnvFile(string(data))
+	for _, parseErr := range errs {
+		fmt.Fprintf(os.Stderr, "gc: parsing supervisor secrets file %q: %v\n", path, parseErr)
 	}
 	return entries
 }

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -764,10 +764,10 @@ func TestBuildSupervisorServiceDataMissingSecretsFileIsNotAnError(t *testing.T) 
 }
 
 // TestBuildSupervisorServiceDataMalformedSecretsFileDegradesGracefully asserts
-// the documented fail-safe: a malformed secrets file does not block service
-// file generation (no error) and contributes no env — the malformed file is
-// ignored rather than partially applied, so the good first line must not leak
-// through.
+// the fix for #5982: a malformed line in the secrets file does not block
+// service file generation (no error) and does not wipe out the entries that
+// parsed cleanly — only the malformed line itself is skipped, the good entry
+// still reaches ExtraEnv.
 func TestBuildSupervisorServiceDataMalformedSecretsFileDegradesGracefully(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -781,8 +781,9 @@ func TestBuildSupervisorServiceDataMalformedSecretsFileDegradesGracefully(t *tes
 	if err != nil {
 		t.Fatalf("buildSupervisorServiceData with malformed secrets file: %v", err)
 	}
-	if _, ok := supervisorServiceEnvMap(data.ExtraEnv)["ANTHROPIC_AUTH_TOKEN"]; ok {
-		t.Fatalf("ExtraEnv should not include any key from a malformed secrets file")
+	if got := supervisorServiceEnvMap(data.ExtraEnv)["ANTHROPIC_AUTH_TOKEN"]; got != "sk-from-file" {
+		t.Fatalf("ExtraEnv[ANTHROPIC_AUTH_TOKEN] = %q, want %q (a malformed later line must not drop a good earlier entry)",
+			got, "sk-from-file")
 	}
 }
 

--- a/internal/processenv/envfile.go
+++ b/internal/processenv/envfile.go
@@ -17,11 +17,15 @@ import (
 //
 // Values are treated literally otherwise: there is no variable interpolation
 // and no inline-comment stripping on unquoted values (a '#' mid-value is kept).
-// A line missing '=' or with an empty key is a parse error so a malformed
-// secrets file fails loudly rather than silently dropping a credential. The
-// last assignment wins when a key repeats.
-func ParseEnvFile(content string) (map[string]string, error) {
+// A line missing '=' or with an empty key is malformed. Malformed lines are
+// skipped and reported individually rather than aborting the whole parse: the
+// returned map holds every successfully-parsed entry, and the returned error
+// slice holds one error per malformed line (nil/empty when the parse is
+// clean), so a single bad line in a secrets file no longer silently drops
+// every other credential in it. The last assignment wins when a key repeats.
+func ParseEnvFile(content string) (map[string]string, []error) {
 	out := make(map[string]string)
+	var errs []error
 	for i, raw := range strings.Split(content, "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -30,15 +34,17 @@ func ParseEnvFile(content string) (map[string]string, error) {
 		line = strings.TrimPrefix(line, "export ")
 		key, val, ok := strings.Cut(line, "=")
 		if !ok {
-			return nil, fmt.Errorf("line %d: missing '=' in %q", i+1, raw)
+			errs = append(errs, fmt.Errorf("line %d: missing '=' in %q", i+1, raw))
+			continue
 		}
 		key = strings.TrimSpace(key)
 		if key == "" {
-			return nil, fmt.Errorf("line %d: empty key in %q", i+1, raw)
+			errs = append(errs, fmt.Errorf("line %d: empty key in %q", i+1, raw))
+			continue
 		}
 		out[key] = unquoteEnvValue(strings.TrimSpace(val))
 	}
-	return out, nil
+	return out, errs
 }
 
 // unquoteEnvValue strips one layer of matching surrounding single or double

--- a/internal/processenv/envfile_test.go
+++ b/internal/processenv/envfile_test.go
@@ -1,6 +1,9 @@
 package processenv
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseEnvFileParsesCoreSyntax(t *testing.T) {
 	content := `# leading comment
@@ -14,9 +17,9 @@ QUOTED_SINGLE='single value'
 EMPTY_VALUE=
 TRAILING_INLINE=keep#notacomment
 `
-	got, err := ParseEnvFile(content)
-	if err != nil {
-		t.Fatalf("ParseEnvFile returned error: %v", err)
+	got, errs := ParseEnvFile(content)
+	if len(errs) != 0 {
+		t.Fatalf("ParseEnvFile returned errors: %v", errs)
 	}
 	want := map[string]string{
 		"ANTHROPIC_AUTH_TOKEN": "sk-live-123",
@@ -38,9 +41,9 @@ TRAILING_INLINE=keep#notacomment
 }
 
 func TestParseEnvFileEmptyContentReturnsEmptyMap(t *testing.T) {
-	got, err := ParseEnvFile("")
-	if err != nil {
-		t.Fatalf("ParseEnvFile returned error: %v", err)
+	got, errs := ParseEnvFile("")
+	if len(errs) != 0 {
+		t.Fatalf("ParseEnvFile returned errors: %v", errs)
 	}
 	if len(got) != 0 {
 		t.Fatalf("ParseEnvFile(\"\") = %v, want empty map", got)
@@ -53,18 +56,70 @@ func TestParseEnvFileRejectsMalformedLines(t *testing.T) {
 		"empty key":            "=value",
 		"empty key after trim": "   =value",
 	} {
-		if _, err := ParseEnvFile(content); err == nil {
-			t.Errorf("ParseEnvFile(%s) = nil error, want error", name)
+		if _, errs := ParseEnvFile(content); len(errs) == 0 {
+			t.Errorf("ParseEnvFile(%s) = no errors, want an error", name)
 		}
 	}
 }
 
 func TestParseEnvFileLastDuplicateWins(t *testing.T) {
-	got, err := ParseEnvFile("KEY=first\nKEY=second\n")
-	if err != nil {
-		t.Fatalf("ParseEnvFile returned error: %v", err)
+	got, errs := ParseEnvFile("KEY=first\nKEY=second\n")
+	if len(errs) != 0 {
+		t.Fatalf("ParseEnvFile returned errors: %v", errs)
 	}
 	if got["KEY"] != "second" {
 		t.Errorf("ParseEnvFile duplicate KEY = %q, want %q", got["KEY"], "second")
+	}
+}
+
+// TestParseEnvFileMalformedLineKeepsValidEntries asserts the fix for #5982: a
+// single malformed line no longer discards every already-parsed entry. All
+// valid lines survive, and the one bad line surfaces as a single error.
+func TestParseEnvFileMalformedLineKeepsValidEntries(t *testing.T) {
+	content := "GOOD_ONE=first\nMALFORMED LINE WITHOUT EQUALS\nGOOD_TWO=second\n"
+	got, errs := ParseEnvFile(content)
+	if len(errs) != 1 {
+		t.Fatalf("ParseEnvFile returned %d errors, want 1: %v", len(errs), errs)
+	}
+	want := map[string]string{
+		"GOOD_ONE": "first",
+		"GOOD_TWO": "second",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ParseEnvFile returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for key, wantVal := range want {
+		if got[key] != wantVal {
+			t.Errorf("ParseEnvFile()[%q] = %q, want %q", key, got[key], wantVal)
+		}
+	}
+}
+
+// TestParseEnvFileMultipleMalformedLinesEachReported asserts that every
+// malformed line is reported individually, with the correct 1-based line
+// number, while all valid entries in the same file still survive.
+func TestParseEnvFileMultipleMalformedLinesEachReported(t *testing.T) {
+	content := "GOOD_ONE=first\nMISSING EQUALS HERE\n=empty-key\nGOOD_TWO=second\n"
+	got, errs := ParseEnvFile(content)
+	if len(errs) != 2 {
+		t.Fatalf("ParseEnvFile returned %d errors, want 2: %v", len(errs), errs)
+	}
+	if !strings.HasPrefix(errs[0].Error(), "line 2:") {
+		t.Errorf("errs[0] = %v, want to reference line 2", errs[0])
+	}
+	if !strings.HasPrefix(errs[1].Error(), "line 3:") {
+		t.Errorf("errs[1] = %v, want to reference line 3", errs[1])
+	}
+	want := map[string]string{
+		"GOOD_ONE": "first",
+		"GOOD_TWO": "second",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ParseEnvFile returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for key, wantVal := range want {
+		if got[key] != wantVal {
+			t.Errorf("ParseEnvFile()[%q] = %q, want %q", key, got[key], wantVal)
+		}
 	}
 }


### PR DESCRIPTION
## What

Closes #5982. `${GC_HOME}/secrets.env` containing one malformed line (e.g. `CODEX_AUTH_JSON={`, a leftover from a multi-line paste the format never supported) caused `gc supervisor install`/`start` to lose **every** credential in the file, not just the bad line — `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, everything, with only one stderr line logged.

Root cause: `ParseEnvFile` (`internal/processenv/envfile.go`) returned `nil, error` on the very first malformed line (missing `=`, or an empty key), discarding every already-parsed valid entry. Its one and only production caller, `supervisorSecretsEnvFileEntries` (`cmd/gc/cmd_supervisor_lifecycle.go`), logged that single error and returned `nil` — full-file credential loss on a single typo.

## Fix

This is the issue's own recommended "fix candidate A" — the only viable one given `ParseEnvFile` has exactly one caller (confirmed via repo-wide grep, both before dispatch and again by the build). `ParseEnvFile`'s signature changed from `(map[string]string, error)` to `(map[string]string, []error)`: parsing now continues past a malformed line, collecting one error per bad line, and the returned map holds every entry that parsed cleanly — a clean parse still returns a nil/empty error slice, so the happy path is unchanged. `supervisorSecretsEnvFileEntries` now logs each malformed-line error individually to stderr (naming the line number and content) instead of one blanket "parsing failed" message, and returns the partial map instead of `nil`. The pre-existing "missing file is normal, yields nil silently" behavior is untouched.

New tests: a file with valid lines + 1 malformed line keeps all valid entries and reports exactly one error; a file with 2 malformed lines reports both with correct line numbers; the existing supervisor-secrets test flipped from asserting the old full-file-loss behavior to asserting a later malformed line no longer wipes an earlier good entry.

**Deliberately out of scope**, per the issue's own framing: fix candidate B (a separate lenient-variant function alongside the strict one) was not attempted — dead code with no caller was worse than the trivial-to-audit signature change. Multi-line quoted value support and the unrelated `gc supervisor uninstall` default-label warning were both explicitly excluded by the issue itself.

## Validation

- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- `go test -tags gms_pure_go ./internal/processenv/...` pass, plus the relevant `cmd/gc` secrets/supervisor tests
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch `internal/processenv/envfile.go` or `cmd/gc/cmd_supervisor_lifecycle.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)