### PR TITLE
fix(beads): reject unknown persisted dolt targets

### DIFF
--- a/internal/beads/contract/init_intent.go
+++ b/internal/beads/contract/init_intent.go
@@ -61,7 +61,11 @@ func ResolveInitIntent(persisted InitScopeState, cliIntent, envIntent, configInt
 		if err != nil {
 			return InitIntentResolution{}, err
 		}
-		persistedIntent := InitIntent{Transport: transport, Target: normalizeTarget(persisted.Target)}
+		persistedTarget, err := normalizePersistedTarget(persisted.Target)
+		if err != nil {
+			return InitIntentResolution{}, err
+		}
+		persistedIntent := InitIntent{Transport: transport, Target: persistedTarget}
 		if persistedIntent.Transport != "" && persistedIntent.Target == "" {
 			persistedIntent.Target = "local"
 		}
@@ -128,12 +132,15 @@ func persistedTransport(mode string) (string, error) {
 	}
 }
 
-func normalizeTarget(target string) string {
+func normalizePersistedTarget(target string) (string, error) {
 	t := strings.ToLower(strings.TrimSpace(target))
-	if t == "local" || t == "external" {
-		return t
+	if t == "" {
+		return "", nil
 	}
-	return ""
+	if t == "local" || t == "external" {
+		return t, nil
+	}
+	return "", fmt.Errorf("persisted Dolt target %q is unsupported", target)
 }
 
 func formatIntent(intent InitIntent) string {

--- a/internal/beads/contract/init_intent_test.go
+++ b/internal/beads/contract/init_intent_test.go
@@ -83,6 +83,22 @@ func TestResolveInitIntentRejectsUnknownPersistedDoltMode(t *testing.T) {
 	}
 }
 
+func TestResolveInitIntentRejectsUnknownPersistedDoltTarget(t *testing.T) {
+	for _, target := range []string{"remote", "bogus", "localhost"} {
+		t.Run(target, func(t *testing.T) {
+			_, err := ResolveInitIntent(InitScopeState{
+				Initialized: true,
+				Backend:     "dolt",
+				DoltMode:    "server",
+				Target:      target,
+			}, InitIntent{}, InitIntent{}, InitIntent{}, InitIntent{Transport: "proxied", Target: "local"})
+			if err == nil {
+				t.Fatalf("ResolveInitIntent accepted unknown persisted dolt target %q", target)
+			}
+		})
+	}
+}
+
 func TestResolveInitIntentDoesNotReadAmbientEnvironment(t *testing.T) {
 	// The resolver accepts an explicit policy environment value only. An
 	// ambient BEADS_DOLT_* variable is intentionally invisible here, so it


### PR DESCRIPTION
Follow-up to #6011 for ga-p9iuv.30.3.1.

Reject malformed persisted Dolt target values instead of normalizing them to local/empty intent. Adds contract regression coverage.

Validation: full make test-fast-parallel gate passed; focused contract/selector tests and go vet passed.