### PR TITLE
fix(supervisor): stay quiet when a live supervisor has no service manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   city dispatcher. The diagnostic names the binding and the owning scope.
   Supersedes #5548 and #5588; fixes #5547 and #5587.
 
+- **`gc init`, `gc register`, and `gc start` no longer print a systemd
+  install error when a supervisor is already serving the home.** The
+  platform-service install is still refreshed on hosts with a service
+  manager. Where none can host a unit (a foreground supervisor under a
+  container init, or a shell without a user-systemd session) the only
+  thing the install could do was fail and tell the user to enable
+  lingering or start a supervisor that was already running.
+
 - **Mail archive and delete now expand whitespace-joined message IDs.** Each
   positional argument is split into individual IDs before single-versus-batch
   dispatch, so shell variables containing multiple IDs no longer look like one

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -608,6 +608,15 @@ func ensureSupervisorRunning(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	// A supervisor that already serves this home keeps serving it with or
+	// without a service file. Where a service manager can host one, fall
+	// through so the install below refreshes the unit on upgrades. Where
+	// none can — a foreground supervisor under a container init, or a shell
+	// without a user-systemd session — the install could only fail, and its
+	// error would tell the user to fix something that is not broken.
+	if supervisorAliveHook() != 0 && !supervisorServiceManagerAvailable() {
+		return 0
+	}
 	// Always regenerate the service file so upgrades pick up template
 	// changes (e.g. PATH captured from the user's shell).
 	if doSupervisorInstall(stdout, stderr) != 0 {
@@ -621,6 +630,20 @@ func ensureSupervisorRunning(stdout, stderr io.Writer) int {
 		return 0
 	}
 	return waitForSupervisorReady(stderr)
+}
+
+// supervisorServiceManagerAvailable reports whether gc could install its
+// own supervisor service on this host right now: a reachable per-user
+// systemd manager on Linux, launchd on macOS, nothing elsewhere.
+func supervisorServiceManagerAvailable() bool {
+	switch supervisorRuntimeGOOS {
+	case "linux":
+		return supervisorSystemctlUserAvailable()
+	case "darwin":
+		return true
+	default:
+		return false
+	}
 }
 
 func platformSupervisorHomeOverrideError() (string, bool) {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -6771,3 +6771,67 @@ func TestRunSupervisorNoWarningForLowAPIPort(t *testing.T) {
 		t.Errorf("stdout = %q, want API listening message for low port", stdout.String())
 	}
 }
+
+func TestEnsureSupervisorRunningAliveWithoutServiceManagerStaysQuiet(t *testing.T) {
+	if goruntime.GOOS != "linux" && goruntime.GOOS != "darwin" {
+		t.Skip("platform supervisor only applies on linux/darwin")
+	}
+	if _, blocked := platformSupervisorHomeOverrideError(); blocked {
+		t.Skip("HOME differs from the account home; the override guard fires first")
+	}
+	t.Setenv(supervisorSystemdUnitEnv, "")
+	oldAlive := supervisorAliveHook
+	oldGOOS := supervisorRuntimeGOOS
+	oldAvailable := supervisorSystemctlUserAvailable
+	oldRun := supervisorSystemctlRun
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorRuntimeGOOS = oldGOOS
+		supervisorSystemctlUserAvailable = oldAvailable
+		supervisorSystemctlRun = oldRun
+	})
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorRuntimeGOOS = "linux"
+	supervisorSystemctlUserAvailable = func() bool { return false }
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return errors.New("no user manager")
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := ensureSupervisorRunning(&stdout, &stderr); code != 0 {
+		t.Fatalf("ensureSupervisorRunning code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected no output for a supervisor that is already serving; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("systemctl calls = %v, want none", calls)
+	}
+}
+
+func TestSupervisorServiceManagerAvailable(t *testing.T) {
+	oldGOOS := supervisorRuntimeGOOS
+	oldAvailable := supervisorSystemctlUserAvailable
+	t.Cleanup(func() {
+		supervisorRuntimeGOOS = oldGOOS
+		supervisorSystemctlUserAvailable = oldAvailable
+	})
+	for _, tc := range []struct {
+		goos        string
+		userManager bool
+		want        bool
+	}{
+		{goos: "linux", userManager: true, want: true},
+		{goos: "linux", userManager: false, want: false},
+		{goos: "darwin", userManager: false, want: true},
+		{goos: "windows", userManager: true, want: false},
+	} {
+		supervisorRuntimeGOOS = tc.goos
+		supervisorSystemctlUserAvailable = func() bool { return tc.userManager }
+		if got := supervisorServiceManagerAvailable(); got != tc.want {
+			t.Errorf("%s with user manager %v: got %v, want %v", tc.goos, tc.userManager, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Avoid a misleading service-install error when a supervisor is already serving the current home and no platform service manager is available.
- Preserve the existing unit-refresh behavior when a service manager is available. Delegation and HOME guards still run first; an explicit `gc supervisor install` is unchanged.
- Add focused regression coverage and a changelog entry. This was found running `gc supervisor run` in the foreground inside a container; the fix is independent of any container packaging.

## Testing

- Passed focused Linux tests for quiet success, service-manager detection, HOME rejection, and delegated start/already-running behavior.
- The quiet-success regression was checked failing without the fix and passing with it before the final rebase; rebasing left the Go source and tests byte-identical.
- Main fork CI completed successfully. Preliminary CodeRabbit review completed with no actionable comments.
- **Incomplete validation:** the separate Mac quality job timed out twice at its 35-minute limit while running repository-wide `golangci-lint run ./...`. It emitted no lint finding before cancellation; that is not a passing lint run. The dependent Mac summary/evidence checks remain unsuccessful. [Mac job evidence](https://github.com/realies/gascity/actions/runs/33931197001/job/101220906160).
- The full Go/integration suites were not run locally. No claim is made that all checks are green.

## Checklist

- [x] Issue rationale: small, self-contained diagnostic fix; no separate issue needed.
- [x] Tests cover the behavior change.
- [x] User-facing change recorded in CHANGELOG.
- [x] No breaking changes or migration steps.
