### PR TITLE
feat(contrib): single-container city deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github/*
 !.github/scripts/
 !.github/scripts/install-claude-native.sh
+!.github/scripts/install-codex-archive.sh
 !.github/scripts/install-dolt-archive.sh
 !.github/requirements/
 !.github/requirements/mcp-agent-mail.txt

--- a/.github/scripts/install-codex-archive.sh
+++ b/.github/scripts/install-codex-archive.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Native Linux installer for container builds; Docker owns the install cache.
+set -euo pipefail
+
+if [[ $# != 1 || ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Usage: install-codex-archive.sh VERSION" >&2
+  exit 2
+fi
+version="$1"
+[[ "$(uname -s)" == Linux ]] || { echo "Linux is required" >&2; exit 1; }
+case "$(uname -m)" in
+  aarch64|arm64) arch=aarch64 ;;
+  x86_64|amd64) arch=x86_64 ;;
+  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+triple="${arch}-unknown-linux-musl"
+archive="codex-${triple}.tar.gz"
+expected_sha=""
+case "${version}:${arch}" in
+  0.152.1:x86_64) expected_sha="a0ed1b40b1d597b340f09ae00ecebc46670b06cb52aac315b9dc84fed0289fd0" ;;
+  0.152.1:aarch64) expected_sha="b65f964600972a948b898f4782e316a741a1b81c044622aa6bdf37ca4525debc" ;;
+esac
+
+# Renovate can advance VERSION before the checksum table is updated.
+# Require the release asset's SHA-256 from GitHub for those versions.
+if [[ -z "$expected_sha" ]]; then
+  auth=()
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+  digest="$(curl -fsSL --retry 3 "${auth[@]}" \
+    -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/openai/codex/releases/tags/rust-v${version}" \
+    | jq -er --arg asset "$archive" '.assets[] | select(.name == $asset) | .digest')"
+  [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || { echo "Missing SHA-256 for $archive" >&2; exit 1; }
+  expected_sha="${digest#sha256:}"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL --retry 3 -o "$tmp/$archive" \
+  "https://github.com/openai/codex/releases/download/rust-v${version}/${archive}"
+printf '%s  %s\n' "$expected_sha" "$tmp/$archive" | sha256sum --check --strict
+# Extract only the expected binary, not arbitrary archive paths.
+tar -xzOf "$tmp/$archive" "codex-${triple}" > "$tmp/codex"
+bin_dir="${CODEX_INSTALL_BIN_DIR:-/usr/local/bin}"
+install -d "$bin_dir"
+install -m 0755 "$tmp/codex" "$bin_dir/codex"
+"$bin_dir/codex" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       # break. Downstream consumers read these outputs unchanged.
       mail: ${{ steps.filter.outputs.mail == 'true' || steps.filter.outputs.shared == 'true' }}
       docker: ${{ steps.filter.outputs.docker == 'true' || steps.filter.outputs.shared == 'true' }}
+      docker_city: ${{ steps.filter.outputs.docker_city == 'true' || steps.filter.outputs.shared == 'true' }}
       k8s: ${{ steps.filter.outputs.k8s == 'true' || steps.filter.outputs.shared == 'true' }}
       beads: ${{ steps.filter.outputs.beads == 'true' || steps.filter.outputs.shared == 'true' }}
       packs: ${{ steps.filter.outputs.packs == 'true' || steps.filter.outputs.shared == 'true' }}
@@ -85,6 +86,20 @@ jobs:
               - 'scripts/gc-session-docker'
               - 'scripts/test-docker-session'
               - 'contrib/session-scripts/**'
+            docker_city:
+              - 'contrib/docker/**'
+              - 'contrib/k8s/Dockerfile.base'
+              - 'deps.env'
+              - '*.go'
+              - 'cmd/gc/**'
+              - 'internal/**'
+              - 'pkg/**'
+              - 'examples/**'
+              - 'schemas/**'
+              - 'scripts/test-docker-city'
+              - '.github/scripts/install-claude-native.sh'
+              - '.github/scripts/install-codex-archive.sh'
+              - '.dockerignore'
             k8s:
               - 'internal/session/**'
               - 'contrib/session-scripts/gc-session-k8s*'
@@ -505,6 +520,7 @@ jobs:
       - preflight-generated
       - contract-acceptance-previous
       - contract-acceptance-current
+      - docker-city
     if: ${{ always() }}
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     env:
@@ -517,10 +533,8 @@ jobs:
           import os
           import sys
 
-          # contract-acceptance-current is path-gated on the beads filter: it
-          # skips on PRs that touch no beads/contract path, which is the
-          # expected pass case. Every other dependency runs unconditionally.
-          allow_skipped = {"contract-acceptance-current"}
+          # These jobs are path-gated; other dependencies must run.
+          allow_skipped = {"contract-acceptance-current", "docker-city"}
           needs = json.loads(os.environ["NEEDS_JSON"])
           failures = {}
           for job, meta in sorted(needs.items()):
@@ -1506,6 +1520,24 @@ jobs:
       - name: Docker session tests
         run: make test-docker
 
+  docker-city:
+    name: Docker city
+    needs:
+      - runner-policy
+      - changes
+    if: needs.changes.outputs.docker_city == 'true'
+    runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Single-container city smoke test
+        run: make test-docker-city
+
   # Runs when session/K8s-related source paths change.
   # Requires K8s CI infrastructure — no-op until secrets are configured.
   k8s-session:
@@ -1622,6 +1654,7 @@ jobs:
       - worker-core-phase2-summary
       - pack-gate
       - docker-session
+      - docker-city
       - k8s-session
       - openclaw-bridge
     if: ${{ always() }}
@@ -1643,6 +1676,7 @@ jobs:
               "credential-provider-windows",
               "pack-gate",
               "docker-session",
+              "docker-city",
               "k8s-session",
               "openclaw-bridge",
           }

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -12,7 +12,15 @@ on:
       - ".github/requirements/mcp-agent-mail.txt"
       - ".github/scripts/install-*.sh"
       - ".github/workflows/container-scan.yml"
+      - "*.go"
+      - "cmd/**"
+      - "internal/**"
+      - "pkg/**"
+      - "examples/**"
+      - "schemas/**"
       - "contrib/beads-scripts/gc-beads-br"
+      - "contrib/beads-scripts/gc-beads-k8s"
+      - "contrib/docker/**"
       - "contrib/events-scripts/gc-events-k8s"
       - "contrib/k8s/**"
       - "contrib/mail-scripts/gc-mail-mcp-agent-mail"
@@ -36,7 +44,15 @@ on:
       - ".github/requirements/mcp-agent-mail.txt"
       - ".github/scripts/install-*.sh"
       - ".github/workflows/container-scan.yml"
+      - "*.go"
+      - "cmd/**"
+      - "internal/**"
+      - "pkg/**"
+      - "examples/**"
+      - "schemas/**"
       - "contrib/beads-scripts/gc-beads-br"
+      - "contrib/beads-scripts/gc-beads-k8s"
+      - "contrib/docker/**"
       - "contrib/events-scripts/gc-events-k8s"
       - "contrib/k8s/**"
       - "contrib/mail-scripts/gc-mail-mcp-agent-mail"
@@ -68,6 +84,8 @@ jobs:
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Select runner backend
         id: policy
         env:
@@ -92,7 +110,7 @@ jobs:
 
       - name: Install Trivy
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && github.token || '' }}
         run: |
           bin_dir="${RUNNER_TEMP}/gascity-trivy-bin"
           TRIVY_INSTALL_BIN_DIR="$bin_dir" .github/scripts/install-trivy-archive.sh "${TRIVY_VERSION}"
@@ -107,6 +125,12 @@ jobs:
             --format sarif \
             --output trivy-results/dockerfile-config.sarif \
             contrib/k8s
+          trivy config \
+            --severity HIGH,CRITICAL \
+            --ignorefile .trivyignore-config \
+            --format sarif \
+            --output trivy-results/dockerfile-config-docker.sarif \
+            contrib/docker
 
       - name: Upload Dockerfile SARIF
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -114,30 +138,41 @@ jobs:
         with:
           sarif_file: trivy-results/dockerfile-config.sarif
 
+      - name: Upload single-container Dockerfile SARIF
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: trivy-results/dockerfile-config-docker.sarif
+          category: trivy-config/contrib-docker
+
       - name: Upload Dockerfile scan artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: trivy-dockerfile-config
-          path: trivy-results/dockerfile-config.sarif
+          path: trivy-results/dockerfile-config*.sarif
           retention-days: 5
 
       - name: Summarize Dockerfile and manifest findings
         run: |
-          trivy config \
-            --severity HIGH,CRITICAL \
-            --ignorefile .trivyignore-config \
-            --format table \
-            contrib/k8s
+          for dir in contrib/k8s contrib/docker; do
+            trivy config \
+              --severity HIGH,CRITICAL \
+              --ignorefile .trivyignore-config \
+              --format table \
+              "$dir"
+          done
 
       - name: Enforce Dockerfile and manifest policy
         run: |
-          trivy config \
-            --severity HIGH,CRITICAL \
-            --ignorefile .trivyignore-config \
-            --exit-code 1 \
-            --format table \
-            contrib/k8s
+          for dir in contrib/k8s contrib/docker; do
+            trivy config \
+              --severity HIGH,CRITICAL \
+              --ignorefile .trivyignore-config \
+              --exit-code 1 \
+              --format table \
+              "$dir"
+          done
 
   image-vulnerabilities:
     name: Image vulnerabilities
@@ -165,7 +200,7 @@ jobs:
 
       - name: Install Trivy
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && github.token || '' }}
         run: |
           bin_dir="${RUNNER_TEMP}/gascity-trivy-bin"
           TRIVY_INSTALL_BIN_DIR="$bin_dir" .github/scripts/install-trivy-archive.sh "${TRIVY_VERSION}"
@@ -173,7 +208,7 @@ jobs:
 
       - name: Prepare image build inputs
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && github.token || '' }}
         run: |
           set -euo pipefail
           . ./deps.env
@@ -214,6 +249,11 @@ jobs:
             -t "gc-mcp-mail:${IMAGE_TAG}" \
             .
 
+          docker build \
+            -f contrib/docker/Dockerfile \
+            -t "gascity:${IMAGE_TAG}" \
+            .
+
       - name: Generate image SARIF and SBOMs
         run: |
           set -euo pipefail
@@ -223,6 +263,7 @@ jobs:
             "gc-agent:${IMAGE_TAG}"
             "gc-controller:${IMAGE_TAG}"
             "gc-mcp-mail:${IMAGE_TAG}"
+            "gascity:${IMAGE_TAG}"
           )
           for image in "${images[@]}"; do
             name="${image%%:*}"
@@ -252,6 +293,7 @@ jobs:
             "gc-agent:${IMAGE_TAG}"
             "gc-controller:${IMAGE_TAG}"
             "gc-mcp-mail:${IMAGE_TAG}"
+            "gascity:${IMAGE_TAG}"
           )
           overall_rc=0
           for image in "${images[@]}"; do
@@ -299,6 +341,13 @@ jobs:
         with:
           sarif_file: trivy-results/gc-mcp-mail.sarif
           category: trivy-image/gc-mcp-mail
+
+      - name: Upload single-container image SARIF
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: trivy-results/gascity.sarif
+          category: trivy-image/gascity
 
       - name: Upload image scan artifacts
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A single-container deployment under `contrib/docker`.** One image carries
+  `gc`, `bd`, Dolt, Claude Code, and Codex; `gc supervisor run` is the
+  foreground supervisor under `tini`, the workspace is bind-mounted at the
+  same absolute path inside and out, and client logins are mounted from the
+  host. Dolt is the same rebuilt binary the Kubernetes base image ships.
+  `make docker-city` builds the image for the current user,
+  `make test-docker-city` boots it without credentials, and the Container
+  Scan workflow covers it. See the new "Run a city in a container" guide.
+
 ### Changed
 
 - **`gc pack registry publish` now refuses an unscoped pack name unless you

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ endif
 endif
 endif
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-split-topology-rows check-version-tag lint lint-full lint-new lint-changed lint-affected fmt-check fmt-check-changed fmt vet test test-ci-policy test-mac test-fast-parallel test-fsys-darwin-compile test-herdr-live test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-productmetrics-testhook test-worker-core test-worker-core-phase2 test-worker-core-phase2-all test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-bd-conditional-release-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema complexity complexity-diff complexity-check complexity-update docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go dashboard-e2e-play dashboard-e2e
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-eventexport-isolation check-gomod-replace check-core-boundary check-native-dependency-surface check-routed-test-rows check-split-topology-rows check-version-tag lint lint-full lint-new lint-changed lint-affected fmt-check fmt-check-changed fmt vet test test-ci-policy test-mac test-fast-parallel test-fsys-darwin-compile test-herdr-live test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-productmetrics-testhook test-worker-core test-worker-core-phase2 test-worker-core-phase2-all test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-bd-cli-contract test-bd-conditional-release-contract test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mail-wisp-insert test-mcp-mail test-openclaw-bridge test-docker test-docker-city test-k8s test-cover test-cover-mac test-cover-noncmdgc test-cover-cmdgc-shard cover check-self-contained install install-tools install-buildx setup clean generate check-schema complexity complexity-diff complexity-check complexity-update docker-base docker-agent docker-controller docker-city docs-dev diagrams-excalidraw dashboard-smoke dashboard-e2e-go dashboard-e2e-play dashboard-e2e
 .PHONY: check-release-dist-ignore
 
 ## build: compile gc binary with version metadata
@@ -904,6 +904,10 @@ test-openclaw-bridge:
 test-docker: check-docker
 	./scripts/test-docker-session
 
+## test-docker-city: build the single-container city image and smoke it without credentials
+test-docker-city: docker-city
+	./scripts/test-docker-city
+
 ## test-k8s: run K8s session provider conformance tests
 test-k8s:
 	$(TEST_ENV) go test -tags integration ./test/integration/ -run TestK8sSessionConformance -v -count=1
@@ -1045,6 +1049,17 @@ docker-controller: check-docker
 		echo "Loading gc-controller:latest into kind cluster '$$cluster'..."; \
 		kind load docker-image gc-controller:latest --name "$$cluster"; \
 	fi
+
+## docker-city: build the single-container city image for the current user (gc, bd, Dolt from docker-base, Claude Code, Codex)
+docker-city: export GC_VERSION := $(VERSION)
+docker-city: docker-base
+	docker build -f contrib/docker/Dockerfile \
+		--build-arg GC_VERSION \
+		--build-arg GC_COMMIT=$(COMMIT)$(DIRTY) \
+		--build-arg GC_DATE=$(BUILD_TIME) \
+		--build-arg UID=$$(id -u) \
+		--build-arg GID=$$(id -g) \
+		-t gascity:latest .
 
 ## k8s-secret: create K8s secret with Claude credentials
 ## Usage: make k8s-secret CLAUDE_CONFIG_SRC=~/.claude [GC_K8S_NAMESPACE=gc]

--- a/contrib/docker/.env.example
+++ b/contrib/docker/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env next to compose.yaml. Paths must be absolute.
+
+# Directory that holds your cities. Mounted at the same path inside the container.
+GASCITY_WORKSPACE=/home/you/cities
+
+# Identity for git and Dolt commits. Run the guide's native setup after edits.
+GASCITY_AUTHOR_NAME=Your Name
+GASCITY_AUTHOR_EMAIL=you@example.com
+
+# Loopback port for the dashboard and API.
+GASCITY_PORT=8372
+
+# Client login state. Defaults to your host logins; point elsewhere to give
+# the container its own. Retained sources must exist; remove unused clients'
+# bind entries from compose.yaml (both entries for Claude).
+#GASCITY_CLAUDE_DIR=~/.claude
+#GASCITY_CLAUDE_JSON=~/.claude.json
+#GASCITY_CODEX_DIR=~/.codex

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,100 @@
+# syntax=docker/dockerfile:1
+# Gas City single-container city: one image, one process tree.
+#
+# `gc supervisor run` is the container's only long-lived process, started by
+# tini so children are reaped and SIGTERM drains cities before exit. Docker
+# owns the image, mounts, port, and restarts; Gas City owns everything else.
+#
+# Build:  make docker-city
+#         (builds contrib/k8s/Dockerfile.base first; Dolt is copied from it)
+# Run:    contrib/docker/compose.yaml; guide: docs/guides/running-in-a-container.md
+#
+# The supervisor binds all interfaces inside the container and accepts
+# unverified writes, so the loopback-only port publish in compose.yaml is the
+# trust boundary. Publish beyond loopback only with the hardened posture in
+# docs/runbooks/remote-hardened-city.md.
+
+ARG DOLT_IMAGE=gc-agent-base:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7 AS build
+WORKDIR /src
+COPY . .
+ARG TARGETOS TARGETARCH
+ARG GC_VERSION=dev
+ARG GC_COMMIT=unknown
+ARG GC_DATE=unknown
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -buildvcs=false \
+      -ldflags "-s -w -X main.version=$GC_VERSION -X main.commit=$GC_COMMIT -X main.date=$GC_DATE" \
+      -o /out/gc ./cmd/gc
+
+# bd is rebuilt from the beads revision deps.env pins, as contrib/k8s does:
+# the published tarball predates the patched grpc-go and trails the store
+# schema this gc writes.
+FROM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7 AS bd
+ARG GRPC_VERSION=1.82.1
+WORKDIR /bd
+RUN --mount=type=bind,source=deps.env,target=/deps.env \
+    --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    set -eu && . /deps.env && git init -q . \
+ && git fetch -q --depth 1 "https://github.com/${BD_REPO}.git" "$BD_CURRENT_REF" && git checkout -q FETCH_HEAD \
+ && go get "google.golang.org/grpc@v${GRPC_VERSION}" \
+ && CGO_ENABLED=1 go build -trimpath -tags gms_pure_go \
+      -ldflags "-s -w -X main.Version=${BD_CURRENT_VERSION#v} -X main.Commit=${BD_CURRENT_REF} -X main.Build=$(git rev-parse --short=10 HEAD)" \
+      -o /out/bd ./cmd/bd \
+ && /out/bd --version \
+ && go version -m /out/bd | tr '\t' ' ' | grep -Fq "dep google.golang.org/grpc v${GRPC_VERSION} "
+
+# Dolt is the binary the k8s images ship: rebuilt from source in
+# contrib/k8s/Dockerfile.base with the patched grpc-go and the current Go
+# toolchain, because the published Dolt release predates both.
+FROM ${DOLT_IMAGE} AS dolt
+
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    # lsof: TCP-LISTEN / port discovery for Dolt — runtime hard dep (gc doctor), not optional diagnostics.
+    lsof \
+    procps \
+    tini \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG CLAUDE_CODE_VERSION=2.1.258
+ARG CODEX_VERSION=0.152.1
+RUN --mount=type=bind,source=.github/scripts/install-claude-native.sh,target=/install-claude-native.sh \
+    bash /install-claude-native.sh "$CLAUDE_CODE_VERSION" && rm -rf /root/.claude /root/.claude.json /root/.cache
+RUN --mount=type=bind,source=.github/scripts/install-codex-archive.sh,target=/install-codex-archive.sh \
+    bash /install-codex-archive.sh "$CODEX_VERSION" && rm -rf /root/.codex
+
+COPY --from=dolt /usr/local/bin/dolt /usr/local/bin/dolt
+COPY --from=build /out/gc /usr/local/bin/gc
+COPY --from=bd /out/bd /usr/local/bin/bd
+
+# A real account, not a bare --user uid: Claude Code refuses root, and the
+# supervisor, Dolt, and both clients resolve HOME through passwd.
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --non-unique --gid "$GID" gascity \
+ && useradd --uid "$UID" --gid gascity --create-home --shell /bin/bash gascity \
+ && install -d -o gascity -g gascity -m 0700 \
+      /home/gascity/.gc /home/gascity/.dolt /home/gascity/.claude /home/gascity/.codex
+
+COPY --chown=gascity:gascity <<TOML /home/gascity/.gc/supervisor.toml
+[supervisor]
+bind = "0.0.0.0"
+allow_mutations = true
+write_auth_allow_unverified = true
+TOML
+
+ENV LANG=C.UTF-8 GC_SUPERVISOR_LOG_TEE=0
+USER gascity
+WORKDIR /home/gascity
+EXPOSE 8372
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
+  CMD curl -fsS -o /dev/null http://127.0.0.1:8372/health || exit 1
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["gc", "supervisor", "run"]

--- a/contrib/docker/compose.yaml
+++ b/contrib/docker/compose.yaml
@@ -1,0 +1,42 @@
+# Build with `make docker-city` at the repository root, then configure .env.
+name: gascity
+services:
+  gascity:
+    image: gascity:latest
+    pull_policy: never
+    restart: unless-stopped
+    stop_grace_period: 2m
+    ports:
+      - "127.0.0.1:${GASCITY_PORT:-8372}:8372"
+    working_dir: ${GASCITY_WORKSPACE:?absolute host path of the directory holding your cities}
+    environment:
+      GASCITY_AUTHOR_NAME: ${GASCITY_AUTHOR_NAME:?git author name for commits the city makes}
+      GASCITY_AUTHOR_EMAIL: ${GASCITY_AUTHOR_EMAIL:?git author email for commits the city makes}
+    volumes:
+      - home:/home/gascity
+      # Keep the host path so registrations and worktrees agree on both sides.
+      - type: bind
+        source: ${GASCITY_WORKSPACE}
+        target: ${GASCITY_WORKSPACE}
+        bind:
+          create_host_path: false
+      # Remove the binds for clients you do not use. Selected sources must exist.
+      # Claude Code needs both its directory and its file.
+      - type: bind
+        source: ${GASCITY_CLAUDE_DIR:-~/.claude}
+        target: /home/gascity/.claude
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${GASCITY_CLAUDE_JSON:-~/.claude.json}
+        target: /home/gascity/.claude.json
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${GASCITY_CODEX_DIR:-~/.codex}
+        target: /home/gascity/.codex
+        bind:
+          create_host_path: false
+
+volumes:
+  home:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -192,7 +192,8 @@
               "guides/gastown-config-recipes",
               "guides/using-json-from-gc",
               "guides/connected-clients",
-              "guides/multi-agent-engineering-environment"
+              "guides/multi-agent-engineering-environment",
+              "guides/running-in-a-container"
             ]
           }
         ]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,6 +10,7 @@ description: Install Gas City from Homebrew, a release tarball, or source.
 | [Homebrew](#homebrew-recommended) | macOS / Linux daily use | Yes (runtime deps) | `brew upgrade` |
 | [Direct download](#direct-download) | CI, containers, air-gapped hosts | No | Manual |
 | [Source build](#build-from-source) | Contributors, bleeding-edge | No | Manual |
+| [Container](/guides/running-in-a-container) | Agent tools run in a container; mounted workspace and client profiles remain writable | Yes (in the image) | Rebuild |
 
 **Most users should use Homebrew.** It installs all runtime dependencies
 automatically and keeps `gc` on your PATH. Choose direct download when you

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -22,6 +22,7 @@ the rest are task-oriented.
 - [Configure the Gastown Pack](/guides/gastown-config-recipes) — task-oriented config overrides for the Gastown pack: register rigs, scale pools, swap providers, patch agents, and tweak prompts.
 - [Use JSON from the gc CLI](/guides/using-json-from-gc) — drive `gc --json` and `gc --json-schema` from scripts, agents, tests, and other software.
 - [Set Up a Multi-Agent Engineering Environment](/guides/multi-agent-engineering-environment) — give a by-hand multi-human, multi-agent workflow a better home by writing the method down once.
+- [Run a City in a Container](/guides/running-in-a-container) — one Docker container with `gc`, `bd`, Dolt, Claude Code, and Codex around a bind-mounted workspace; nothing installed on the host.
 
 See also the [Troubleshooting runbooks](/troubleshooting/dolt-bloat-recovery)
 for operational recovery procedures, and the [Reference](/reference/index)

--- a/docs/guides/running-in-a-container.md
+++ b/docs/guides/running-in-a-container.md
@@ -1,0 +1,138 @@
+---
+title: Run a city in a container
+description: Run Gas City and its agent clients in one Docker container around a bind-mounted workspace.
+---
+
+`contrib/docker` packages `gc`, `bd`, Dolt, Claude Code, and Codex into one
+image. `tini` starts `gc supervisor run`; Gas City owns cities, Dolt servers,
+and agent sessions. Docker owns mounts, port publication, and restarts.
+There is no container-specific supervisor or startup script.
+
+## Build
+
+Use Docker Engine on Linux (including WSL2) with BuildKit and Compose 2.20.0
+or newer. From a checkout of this repository:
+
+```bash
+make docker-city
+```
+
+The image is built for your host uid and gid, with `make build`'s version
+metadata. It reuses Dolt from the Kubernetes base image, so the first build
+also builds that base and its tools. Only the Dolt binary is copied into the
+final city image; the Kubernetes runtime and sudo configuration are not.
+
+## Configure
+
+```bash
+cd contrib/docker
+cp .env.example .env
+```
+
+Edit `.env`:
+
+| Variable | Meaning |
+|----------|---------|
+| `GASCITY_WORKSPACE` | Existing absolute host directory that holds your cities. Mounted at the identical path inside. |
+| `GASCITY_AUTHOR_NAME`, `GASCITY_AUTHOR_EMAIL` | Git and Dolt identity for commits the city makes. |
+| `GASCITY_PORT` | Host loopback port. Default `8372`. |
+
+In `compose.yaml`, keep the client-state binds you want to share:
+
+- Claude Code uses both `~/.claude` and `~/.claude.json`.
+- Codex uses `~/.codex`.
+- **Remove the bind entries for clients you do not use** (both entries for
+  Claude). Unused client directories can remain in the container's home.
+
+Every retained source must exist with the correct file/directory type and
+be accessible to your uid/gid. `GASCITY_CLAUDE_DIR`, `GASCITY_CLAUDE_JSON`,
+and `GASCITY_CODEX_DIR` select alternative host sources; they do not create
+or authenticate them. See [Harness Recipes](/guides/harness-recipes) for
+client setup. No login state is baked into the image.
+
+Initialize the identity once, using Git and Dolt's native configuration
+commands rather than interpolating names into configuration syntax:
+
+```bash
+docker compose run --rm gascity sh -ec '
+    git config --global user.name "$GASCITY_AUTHOR_NAME"
+    git config --global user.email "$GASCITY_AUTHOR_EMAIL"
+    git config --global beads.role maintainer
+    dolt config --global --add user.name "$GASCITY_AUTHOR_NAME"
+    dolt config --global --add user.email "$GASCITY_AUTHOR_EMAIL"
+    dolt config --global --add metrics.disabled true
+    dolt config --global --add versioncheck.disabled true
+'
+```
+
+This runs as the normal container user and persists settings in the `home`
+volume. Repeat it after changing the author identity or creating a fresh
+home volume. Identity initialization does not run automatically at container startup.
+
+## Run
+
+```bash
+docker compose up -d --wait
+docker compose exec gascity gc init my-city --template minimal --default-provider claude
+```
+
+The service's working directory is your workspace. `.env` variables belong
+to Compose, so the command uses a relative city path rather than a host-shell
+variable. Open `http://127.0.0.1:<GASCITY_PORT>/`, using the port from `.env`
+(default `http://127.0.0.1:8372/`), for the dashboard and API.
+
+For city-local commands, select that city's working directory, for example:
+
+```bash
+docker compose exec -w /absolute/workspace/my-city gascity gc status
+```
+
+The workspace must include any Git common directory referenced by its linked
+worktrees; preserving a worktree path cannot expose metadata outside the mount.
+
+```bash
+docker compose stop
+docker compose start
+```
+
+The supervisor handles `SIGTERM` and reads its registered cities from the
+same `home` volume after restart. `docker compose down` preserves that volume;
+`down --volumes` deletes it. Rebuilding for a different uid/gid does not migrate
+existing volume ownership.
+
+## Upgrade
+
+From `contrib/docker`, update your checkout as appropriate, then:
+
+```bash
+make -C ../.. docker-city
+docker compose up -d --wait
+```
+
+The image seeds `/home/gascity/.gc/supervisor.toml` only when the `home`
+volume is first created. After that it is operator-owned configuration:
+rebuilding does not overwrite it or reset choices such as `allow_mutations`
+and `write_auth_allow_unverified`. Review release notes for configuration
+changes, explicitly edit the persisted file if needed, and restart the
+container. Do not delete the home volume merely to refresh defaults; that
+also discards the city registry and other state.
+
+Claude Code and Codex versions are build arguments tracked by Renovate.
+`bd` follows the source revision in `deps.env`; Dolt follows the Kubernetes
+base build. Inspect image scan results independently—sharing build inputs
+is not a guarantee of identical binaries or a passing vulnerability policy.
+
+## Trust boundary
+
+The supervisor listens on all container interfaces and accepts unverified
+writes. Compose publishes the port only on host loopback. Keep the container
+network trusted too; loopback publication is not authentication for peers
+that can reach the container directly. For remote access use the existing
+[Remote hardened city](/runbooks/remote-hardened-city) configuration.
+
+The workspace and client profiles are **writable host mounts**. Agents can
+modify or delete their contents, including settings used by later host-side
+client sessions. Supply dedicated client-state paths if you do not want to
+share your usual profiles. Other host paths are not mounted, there is no
+Docker socket, and the runtime is non-root. Containers share the host kernel;
+this is not VM-equivalent isolation. See [Trust boundaries](/reference/trust-boundaries).

--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,7 @@
       "customType": "regex",
       "fileMatch": [
         "/^\\.github/actions/setup-gascity-(ubuntu|macos)/action\\.yml$/",
+        "/^contrib/docker/Dockerfile$/",
         "/^contrib/k8s/Dockerfile\\.base$/",
         "/^scripts/worker_inference_setup\\.py$/"
       ],
@@ -73,6 +74,18 @@
       ],
       "datasourceTemplate": "npm",
       "depNameTemplate": "@anthropic-ai/claude-code"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "/^contrib/docker/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "CODEX_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "openai/codex",
+      "extractVersionTemplate": "^rust-v(?<version>.*)$"
     },
     {
       "customType": "regex",

--- a/scripts/build_provenance_test.go
+++ b/scripts/build_provenance_test.go
@@ -27,6 +27,53 @@ func readMakefile(t *testing.T) string {
 	return string(makefile)
 }
 
+// TestDockerCityVersionIsData rejects evaluating tag text as recipe shell code.
+func TestDockerCityVersionIsData(t *testing.T) {
+	for _, tag := range []string{"", "v1.2.3", "v1.2.3;#literal", "v1.2.3${GC_TEST_UNUSED}"} {
+		t.Run(tag, func(t *testing.T) {
+			tmp := t.TempDir()
+			writeExecutable(t, filepath.Join(tmp, "git"), `#!/bin/sh
+case "$1" in
+  describe) [ -n "$GC_TEST_TAG" ] || exit 1; printf '%s' "$GC_TEST_TAG" ;;
+  rev-parse) printf 'abcdef123' ;;
+  show) printf '2026-09-05T00:00:00Z' ;;
+  status) exit 0 ;;
+  *) exit 1 ;;
+esac
+`)
+			writeExecutable(t, filepath.Join(tmp, "docker"), `#!/bin/sh
+printf '%s\n' "$@" > "$GC_TEST_ARGS"
+printf '%s' "$GC_VERSION" > "$GC_TEST_VERSION"
+`)
+			argsPath := filepath.Join(tmp, "args")
+			versionPath := filepath.Join(tmp, "version")
+			cmd := makeCommand("--no-print-directory", "-f", filepath.Join(repoRoot(t), "Makefile"), "-o", "docker-base", "docker-city")
+			cmd.Dir = tmp
+			cmd.Env = []string{
+				"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
+				"HOME=" + tmp, "GC_TEST_TAG=" + tag,
+				"GC_TEST_ARGS=" + argsPath, "GC_TEST_VERSION=" + versionPath,
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("make docker-city: %v\n%s", err, out)
+			}
+			want := strings.TrimPrefix(tag, "v")
+			if tag == "" {
+				want = "dev"
+			}
+			version, err := os.ReadFile(versionPath)
+			if err != nil || string(version) != want {
+				t.Fatalf("exported version = %q, want %q; err=%v", version, want, err)
+			}
+			args, err := os.ReadFile(argsPath)
+			if err != nil || !strings.Contains(string(args), "--build-arg\nGC_VERSION\n") {
+				t.Fatalf("Docker must take GC_VERSION from the environment: %s; err=%v", args, err)
+			}
+		})
+	}
+}
+
 // TestBuildTargetDisablesToolchainVCSStamping asserts that `make build` keeps
 // the Go toolchain out of the provenance business.
 //

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "40c61d69abee24e0e025829045bbf699c7c9dcac44b1fb9911d94c9295ae4865"
+	expectedCIExecutionHash      = "848816197b789cd6b25beeb832a2917c63fdeaa3f641fce66d597eb8db781b30"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "a2c68532e85598b527a2cff2d2057c99ed5c65208fa34ea143869d8375f99a84"
 	expectedSetupActionHash      = "8f2d6b3a57f11d4f33a41211b1d3d5362d1437ba40c7b6db068abb98e731e5ac"
@@ -33,6 +33,21 @@ var requiredFilterPaths = map[string][]string{
 		"scripts/gc-session-docker",
 		"scripts/test-docker-session",
 		"contrib/session-scripts/**",
+	},
+	"docker_city": {
+		"contrib/docker/**",
+		"contrib/k8s/Dockerfile.base",
+		"deps.env",
+		"*.go",
+		"cmd/gc/**",
+		"internal/**",
+		"pkg/**",
+		"examples/**",
+		"schemas/**",
+		"scripts/test-docker-city",
+		".github/scripts/install-claude-native.sh",
+		".github/scripts/install-codex-archive.sh",
+		".dockerignore",
 	},
 	"k8s": {
 		"internal/session/**",

--- a/scripts/test-docker-city
+++ b/scripts/test-docker-city
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Credential-free Compose smoke. Run `make test-docker-city` to build first.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d)"
+export GASCITY_WORKSPACE="$TMP/workspace"
+export GASCITY_CLAUDE_DIR="$TMP/claude"
+export GASCITY_CLAUDE_JSON="$TMP/claude.json"
+export GASCITY_CODEX_DIR="$TMP/codex"
+export GASCITY_AUTHOR_NAME='Gas City "Smoke"'
+export GASCITY_AUTHOR_EMAIL=smoke@example.invalid
+export GASCITY_PORT=0
+compose=(docker compose --project-name "gc-city-test-$$" --env-file /dev/null -f contrib/docker/compose.yaml)
+cleanup() {
+    "${compose[@]}" down --volumes --remove-orphans
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+mkdir -p "$GASCITY_WORKSPACE" "$GASCITY_CLAUDE_DIR" "$GASCITY_CODEX_DIR"
+printf '{}\n' > "$GASCITY_CLAUDE_JSON"
+
+# Same native setup as the guide; exercise quoting in both configuration formats.
+"${compose[@]}" run --rm -T gascity sh -ec '
+    git config --global user.name "$GASCITY_AUTHOR_NAME"
+    git config --global user.email "$GASCITY_AUTHOR_EMAIL"
+    git config --global beads.role maintainer
+    dolt config --global --add user.name "$GASCITY_AUTHOR_NAME"
+    dolt config --global --add user.email "$GASCITY_AUTHOR_EMAIL"
+    dolt config --global --add metrics.disabled true
+    dolt config --global --add versioncheck.disabled true
+'
+"${compose[@]}" up -d --wait --wait-timeout 90
+container="$("${compose[@]}" ps -q gascity)"
+[[ "$("${compose[@]}" exec -T gascity id -u)" == "$(id -u)" ]]
+[[ "$("${compose[@]}" exec -T gascity cat /proc/1/comm)" == tini ]]
+[[ "$("${compose[@]}" exec -T gascity ps -o comm= --ppid 1 | tr -d ' ')" == gc ]]
+[[ "$("${compose[@]}" exec -T gascity git config --global user.name)" == "$GASCITY_AUTHOR_NAME" ]]
+[[ "$("${compose[@]}" exec -T gascity dolt config --global --get user.name)" == "$GASCITY_AUTHOR_NAME" ]]
+
+"${compose[@]}" exec -T gascity gc init smoke --template empty
+# pipefail must reject failed commands even if their diagnostic contains the path.
+"${compose[@]}" exec -T gascity gc cities | grep -F "$GASCITY_WORKSPACE/smoke"
+"${compose[@]}" exec -T -w "$GASCITY_WORKSPACE/smoke" gascity gc doctor
+[[ "$(stat -c %u "$GASCITY_WORKSPACE/smoke/city.toml")" == "$(id -u)" ]]
+"${compose[@]}" stop
+[[ "$(docker inspect --format '{{.State.ExitCode}}' "$container")" == 0 ]]
+
+# Keep the same volume: restarting must retain the registered city and identity.
+"${compose[@]}" up -d --wait --wait-timeout 90
+"${compose[@]}" exec -T gascity gc cities | grep -F "$GASCITY_WORKSPACE/smoke"
+"${compose[@]}" exec -T -w "$GASCITY_WORKSPACE/smoke" gascity gc doctor
+[[ "$("${compose[@]}" exec -T gascity git config --global user.name)" == "$GASCITY_AUTHOR_NAME" ]]
+"${compose[@]}" stop
+[[ "$(docker inspect --format '{{.State.ExitCode}}' "$container")" == 0 ]]
+printf 'PASS: Compose setup, identity, init, doctor, ownership, stop and restart\n'


### PR DESCRIPTION
## Summary

Add an opt-in Linux/WSL2 deployment under `contrib/docker`: one container around a bind-mounted workspace, using the existing foreground supervisor rather than a container-specific lifecycle layer.

- `tini` starts `gc supervisor run`; Gas City owns cities, Dolt servers and agent sessions. No entrypoint script, second supervisor, privileged mode, or Docker socket.
- Build a real non-root account with the invoking host uid/gid. Preserve workspace paths and let the deployer select client-state binds at the clients' normal paths. The workspace and selected profiles remain writable host mounts, not protected copies.
- Build `gc` from the checkout and `bd` from the pinned source revision; copy source-built Dolt from the existing Kubernetes base. Install native Claude Code/Codex binaries with checksum verification. Codex's installer is scoped to the Linux build caller.
- Configure Git and Dolt identity explicitly using their native commands in the persisted home. Supervisor configuration is seeded once, then operator-owned; upgrades do not silently overwrite it.
- Add Make targets, a credential-free Compose smoke including restart, existing CI/scan integration and policy updates, dependency-update rules, and a guide. Transport tag-derived version data through the environment rather than interpolating it into recipe shell syntax.

Related to #326. This supplies a documented manual Compose deployment; it does **not** implement transparent host-to-container CLI routing, a Dockerfile generator, or image publishing, and does not close that broader request.

## Testing

- Passed the Linux amd64 image build and actual Compose smoke using disposable state: quoted author identity, native process tree, city initialization, city listing, doctor, ownership, clean shutdown and persisted city health after restart.
- Passed the full `make test-ci-policy` target, `make check-docs`, affected-package lint, ShellCheck and whitespace checks during preparation. Added a build-provenance regression covering literal tag characters, leading-v stripping and the untagged `dev` value.
- Main fork CI, `Check`, `CI / required`, Docker city, Mac summary and the evidence check passed on the final fork revision. Preliminary CodeRabbit review completed; all review threads were addressed, including withdrawal of suggestions outside the documented Linux/operator-owned-config scope.
- Not certified here: arm64 execution, real-client authentication in the cleanup run, or a locally executed full Go/integration suite.

### Known failing image scan

The image vulnerability policy is **not green**. The recorded final-image scan reports 22 HIGH/CRITICAL occurrences in compiled Go dependencies: `bd` 3, Dolt 18 and `gc` 1; Debian packages report 0. The base branch's existing Kubernetes images also fail their scan. This is disclosed dependency debt, not a claim that our binaries or all scan results are identical.

- [Contribution scan](https://github.com/realies/gascity/actions/runs/33950702688/job/101264810051)
- [Base-image scan](https://github.com/realies/gascity/actions/runs/33931182055)

No vulnerability exceptions were added or extended, and no scan was disabled. Remediation/release/pin tracking is being investigated separately rather than silently expanding this deployment change into updates across multiple dependency trees. The PR is for review, not a request to merge despite failing policy.

## Checklist

- [x] Related issue and deliberately narrower scope explained above.
- [x] Credential-free deployment test and version-data regression added.
- [x] Setup, operation, upgrades, persistence, supported platform and trust boundaries documented.
- [x] New opt-in path; no changes required for existing deployments. Existing home volumes are not automatically migrated or re-owned.
