### PR TITLE
fix(core-pack): anchor worktree creation on $GC_DIR, not $(pwd) (#6014)

### DIFF
--- a/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
@@ -69,7 +69,12 @@ If the directory is missing, fall through to create a new one.
 
 **If no worktree** — create one:
 ```bash
-WORKTREE_PATH=$(pwd)/worktrees/"$WORK_BEAD_ID"
+AGENT_HOME="${GC_DIR:-}"
+if [ -z "$AGENT_HOME" ]; then
+    echo "GC_DIR is unset -- falling back to \\$(pwd)=$(pwd)" >&2
+    AGENT_HOME=$(pwd)
+fi
+WORKTREE_PATH="$AGENT_HOME/worktrees/$WORK_BEAD_ID"
 git worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
 cd "$WORKTREE_PATH"
 ```

--- a/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
@@ -98,7 +98,12 @@ if [ -z "$WORK_BEAD_ID" ]; then
 fi
 WORKTREE=$(gc bd show "$WORK_BEAD_ID" --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORKTREE" ]; then
-  WORKTREE_PATH=$(pwd)/worktrees/"$WORK_BEAD_ID"
+  AGENT_HOME="${GC_DIR:-}"
+  if [ -z "$AGENT_HOME" ]; then
+    echo "GC_DIR is unset -- falling back to \\$(pwd)=$(pwd)" >&2
+    AGENT_HOME=$(pwd)
+  fi
+  WORKTREE_PATH="$AGENT_HOME/worktrees/$WORK_BEAD_ID"
   git worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
   gc bd update "$WORK_BEAD_ID" --set-metadata work_dir="$WORKTREE_PATH"
   WORKTREE="$WORKTREE_PATH"


### PR DESCRIPTION
## What

Closes #6014. `mol-scoped-work.toml` and `mol-polecat-commit.toml` both computed a per-bead git worktree path as `\$(pwd)/worktrees/"\$WORK_BEAD_ID"` at the worktree-creation site. If a prior step in the same session had `cd`-ed elsewhere first — a routine occurrence, via a `cd <rig checkout> 2>/dev/null || cd <agent home>` fallback whose first arm can succeed — the worktree got planted inside that other directory (typically a tracked rig checkout) instead of under the agent's home. That leaves an untracked `worktrees/` directory inside the checkout, which then reads as permanently dirty and blocks drift detection from fast-forwarding it. The failure is quiet: once the worktree is later removed, the leftover empty parent directory is invisible to `git status`.

## Fix

This is the issue's own "fix candidate 1" — the smallest, no-step-contract-change option. Both worktree-creation sites now anchor on `\$GC_DIR` (already set in the agent's environment, confirmed by the issue's own reporter, no new plumbing needed), falling back to `\$(pwd)` only if `\$GC_DIR` is unset, with a stderr note when that fallback triggers.

**The trap the issue warned about, confirmed avoided:** `mol-polecat-commit.toml` has a *second*, unrelated `WORKTREE_PATH=\$(pwd)` in its cleanup step ("3. Clean up worktree") — that one is correct by design (the agent is already standing inside the worktree it's tearing down at that point) and was deliberately left untouched. Verified directly: `git diff origin/main` for that file shows zero changes anywhere near the cleanup section.

**One correction to the issue's own scope note:** it names `mol-polecat-work.toml` as a clean sibling formula that should not be touched. That formula doesn't actually exist anywhere in this repository — it ships from the separate gastown pack, referenced here only as a formula-name string in Go config/tests. Nothing to touch there either way; confirmed via a repo-wide grep that no other `\$(pwd)` worktree-creation site exists.

Fix candidate 2 from the issue (resolving the path in the runtime instead of in formula scripts, so no formula computes it from process state) was **not** attempted — the issue itself calls that "a maintainer call" and a step-contract change.

## Validation

- `bash -n` clean on the extracted script content, TOML parse-valid
- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- The repo's own authoritative formula-pack tests (`TestShippedFormulasHaveNoLegacyIssueRefs`, `TestShippedWorkflowFormulasComposeUnderGraphV2`) pass on both edited formulas
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction/health-script timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch either edited TOML file
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)