### PR TITLE
fix(processenv): error on unterminated quote in env file value (#6022)

### DIFF
--- a/internal/processenv/envfile.go
+++ b/internal/processenv/envfile.go
@@ -17,9 +17,12 @@ import (
 //
 // Values are treated literally otherwise: there is no variable interpolation
 // and no inline-comment stripping on unquoted values (a '#' mid-value is kept).
-// A line missing '=' or with an empty key is a parse error so a malformed
-// secrets file fails loudly rather than silently dropping a credential. The
-// last assignment wins when a key repeats.
+// A line missing '=', a line with an empty key, or a value that opens a quote
+// without closing it on the same line (multi-line quoted values are not
+// supported) is a parse error, so a malformed secrets file fails loudly
+// rather than silently dropping a credential or splitting a quoted value
+// across invented top-level keys. The last assignment wins when a key
+// repeats.
 func ParseEnvFile(content string) (map[string]string, error) {
 	out := make(map[string]string)
 	for i, raw := range strings.Split(content, "\n") {
@@ -36,9 +39,30 @@ func ParseEnvFile(content string) (map[string]string, error) {
 		if key == "" {
 			return nil, fmt.Errorf("line %d: empty key in %q", i+1, raw)
 		}
-		out[key] = unquoteEnvValue(strings.TrimSpace(val))
+		val = strings.TrimSpace(val)
+		if hasUnterminatedQuote(val) {
+			return nil, fmt.Errorf("line %d: unterminated quote in value for %q; multi-line values are not supported", i+1, key)
+		}
+		out[key] = unquoteEnvValue(val)
 	}
 	return out, nil
+}
+
+// hasUnterminatedQuote reports whether a trimmed value opens with a single or
+// double quote but does not close with that same quote character on this
+// line. That pattern is the signature of a value that was meant to span
+// multiple lines (e.g. a multi-line quoted shell script), which this
+// line-oriented parser cannot represent correctly: it would otherwise
+// silently truncate the value and may misparse the continuation lines as
+// unrelated top-level assignments. A single-character value that is just a
+// lone quote (e.g. val == `"`) is not treated as unterminated, since its
+// first and last byte are the same quote character.
+func hasUnterminatedQuote(val string) bool {
+	if len(val) < 2 {
+		return false
+	}
+	first, last := val[0], val[len(val)-1]
+	return (first == '"' || first == '\'') && last != first
 }
 
 // unquoteEnvValue strips one layer of matching surrounding single or double

--- a/internal/processenv/envfile_test.go
+++ b/internal/processenv/envfile_test.go
@@ -1,6 +1,9 @@
 package processenv
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseEnvFileParsesCoreSyntax(t *testing.T) {
 	content := `# leading comment
@@ -66,5 +69,58 @@ func TestParseEnvFileLastDuplicateWins(t *testing.T) {
 	}
 	if got["KEY"] != "second" {
 		t.Errorf("ParseEnvFile duplicate KEY = %q, want %q", got["KEY"], "second")
+	}
+}
+
+func TestParseEnvFileErrorsOnUnterminatedMultiLineQuote(t *testing.T) {
+	content := `GC_NOMAD_AGENT_LAUNCH_SCRIPT="export PATH=/mnt/nomad/gc/bin/current:$PATH
+export CODEX_HOME=$NOMAD_SECRETS_DIR/codex-home"
+`
+	_, err := ParseEnvFile(content)
+	if err == nil {
+		t.Fatal("expected a parse error for an unterminated quote spanning lines, got nil")
+	}
+	if !strings.Contains(err.Error(), "line 1") || !strings.Contains(err.Error(), "GC_NOMAD_AGENT_LAUNCH_SCRIPT") {
+		t.Errorf("ParseEnvFile error = %q, want it to name line 1 and key GC_NOMAD_AGENT_LAUNCH_SCRIPT", err)
+	}
+}
+
+func TestParseEnvFileRejectsUnterminatedQuoteVariants(t *testing.T) {
+	for name, content := range map[string]string{
+		"unterminated double quote": `FOO="bar`,
+		"unterminated single quote": `FOO='bar`,
+		"opens quote, closes other": `FOO="bar'`,
+	} {
+		if _, err := ParseEnvFile(content); err == nil {
+			t.Errorf("ParseEnvFile(%s) = nil error, want error", name)
+		}
+	}
+}
+
+func TestParseEnvFileAcceptsLegitimateQuotedAndEdgeCaseValues(t *testing.T) {
+	content := `FOO="bar"
+BAZ=
+LONE_DOUBLE_QUOTE="
+LONE_SINGLE_QUOTE='
+EMPTY_QUOTES=""
+`
+	got, err := ParseEnvFile(content)
+	if err != nil {
+		t.Fatalf("ParseEnvFile returned error: %v", err)
+	}
+	want := map[string]string{
+		"FOO":               "bar",
+		"BAZ":               "",
+		"LONE_DOUBLE_QUOTE": `"`,
+		"LONE_SINGLE_QUOTE": `'`,
+		"EMPTY_QUOTES":      "",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ParseEnvFile returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for key, wantVal := range want {
+		if got[key] != wantVal {
+			t.Errorf("ParseEnvFile()[%q] = %q, want %q", key, got[key], wantVal)
+		}
 	}
 }


### PR DESCRIPTION
## What

Closes #6022. A companion to #5982/#6043 (already shipped), but a genuinely different code path — this one produces **no error at all**. When a quoted value in `\${GC_HOME}/secrets.env` spans multiple lines (e.g. a multi-line shell script assigned to one variable) and every continuation line happens to contain `=`, `ParseEnvFile` silently truncates the value at the first newline (keeping a stray opening quote) and parses each continuation line as its **own** top-level key/value pair — inventing environment variables the operator never wrote. Found in production: a launch script assigned to `GC_NOMAD_AGENT_LAUNCH_SCRIPT` produced a stray `CODEX_HOME` variable from its own `export CODEX_HOME=...` continuation line.

Built against current `main` (pre-#5982/#6043 shape — that PR is not merged yet, so this one does not depend on it and keeps `ParseEnvFile`'s existing single-error-return signature).

## Fix

This is the issue's own recommended "fix candidate A" — convert the silent mis-parse into the loud failure the package already documents as its contract ("a malformed secrets file fails loudly rather than silently dropping a credential"). After key/value split and validation, a new `hasUnterminatedQuote` check: if the trimmed value opens with a quote character (`'`/`"`) but doesn't close with that same character on the same line, return a parse error naming the line and key instead of silently truncating. A lone single-character quote value (`val == "\""`) and a properly-closed empty quoted string (`""`) are both correctly exempted (checked via explicit test cases).

**Deliberately not implemented:** fix candidate B (actual multi-line value support — tracking an open quote across lines and joining them). The issue itself frames this as "a real grammar change... a maintainer product call rather than a bug fix," separate from this fix's scope.

**Coordination note with #5982/#6043:** the issue explicitly says the two "want landing together" in spirit — once #5982 merges (which changes `ParseEnvFile` to `(map, []error)`, collecting per-line errors instead of aborting), this fix's single `return nil, error` call site will need a small follow-up adaptation to fit the new partial-parse shape. Flagging here so whoever merges second doesn't hit a surprise conflict.

## Validation

- `go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty
- `go test -tags gms_pure_go ./internal/processenv/...` pass — build confirmed the new tests fail against pre-fix code (stashed the fix, reran, correctly got `nil` where an error was expected) before restoring it
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch `internal/processenv/envfile.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)