### PR TITLE
feat(doctor,orders): say so when a provider binary is missing instead of starting empty

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -127,6 +127,15 @@ type agentBuildParams struct {
 	// etc.). Used by the skill materialization integration to decide
 	// stage-2 eligibility.
 	sessionProvider string
+
+	// providerUnresolved collects the provider-not-in-PATH failures that
+	// dropped templates from this build, so buildDesiredState can report
+	// the hole instead of just returning a smaller desired set. A pointer,
+	// not a slice: resolveTemplateForSessionBeadInfo (and any other seam
+	// that scopes params via `local := *bp`) must accumulate into the same
+	// place as the parent (ob-woag). Nil in focused unit fixtures that
+	// build params by hand; every recording site is nil-receiver-safe.
+	providerUnresolved *providerUnresolvedSet
 }
 
 // hasCompleteSessionSnapshot reports whether a store-backed build has a
@@ -145,6 +154,18 @@ func (p *agentBuildParams) hasCompleteSessionSnapshot() bool {
 		return p.sessionSnapshotComplete
 	}
 	return p.sessionBeads != nil && p.sessionBeads.LoadError() == nil
+}
+
+// recordProviderUnresolved forwards one template-resolution error to this
+// build's provider-not-in-PATH accumulator, and reports whether the error was
+// one. Nil-safe on both the params and the accumulator so the legacy fixtures
+// that hand-build params (and the storeless paths that pass a nil bp) stay
+// working.
+func (p *agentBuildParams) recordProviderUnresolved(template string, err error) bool {
+	if p == nil {
+		return false
+	}
+	return p.providerUnresolved.record(template, err)
 }
 
 // newAgentBuildParams constructs agentBuildParams from the common startup values.
@@ -171,6 +192,8 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 		beadNames:       make(map[string]string),
 		stderr:          stderr,
 		sessionProvider: cfg.Session.Provider,
+
+		providerUnresolved: newProviderUnresolvedSet(),
 	}
 	if store != nil {
 		params.poolSessionCreateBudget = poolplan.NewCreateBudget(cfg.Daemon.MaxWakesPerTickOrDefault())

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -156,6 +156,15 @@ type DesiredStateResult struct {
 	SessionSnapshotComplete bool
 	SessionOccupancyInfos   []session.Info
 	BeaconTime              time.Time
+	// ProviderUnresolved names every provider whose command did not resolve
+	// on PATH during this build, with the templates it cost. It is the
+	// answer to "why is desired_session_count zero" that ob-woag could not
+	// get from any surface: the drop sites log to a supervisor stderr and
+	// otherwise return a quietly smaller State. Non-empty here means the
+	// desired set is smaller than the config asked for, and by exactly the
+	// templates listed. The controller turns it into a trace record, an
+	// event, and a once-per-episode log line.
+	ProviderUnresolved []ProviderUnresolvedGroup
 }
 
 func (r DesiredStateResult) snapshotQueryPartial() bool {
@@ -1171,6 +1180,26 @@ func buildDesiredStateWithSessionBeadsAt(
 		)
 	}
 
+	// Publish the build's provider-PATH failures before the result is
+	// assembled, and put them in the trace next to the desired-state build
+	// site. ob-woag's trace showed desired_session_count=0 with the string
+	// "provider" absent from the whole cycle, which is what made the empty
+	// city look like an absence of demand rather than a broken host.
+	providerUnresolved := bp.providerUnresolved.snapshot()
+	for _, group := range providerUnresolved {
+		trace.RecordControllerDecision(
+			TraceSiteDesiredStateProviderUnresolved,
+			TraceReasonProviderNotInPath,
+			TraceOutcomeSkipped,
+			map[string]any{
+				"provider":          group.Provider,
+				"command":           group.Command,
+				"dropped_templates": group.DroppedTemplates,
+				"templates":         group.Templates,
+			},
+		)
+	}
+
 	sessionSnapshotComplete := bp.hasCompleteSessionSnapshot()
 	sessionOccupancyInfos := make([]session.Info, len(allOpenSessionInfos))
 	copy(sessionOccupancyInfos, allOpenSessionInfos)
@@ -1197,6 +1226,7 @@ func buildDesiredStateWithSessionBeadsAt(
 		SessionSnapshotComplete:            sessionSnapshotComplete,
 		SessionOccupancyInfos:              sessionOccupancyInfos,
 		BeaconTime:                         beaconTime,
+		ProviderUnresolved:                 providerUnresolved,
 	}
 }
 
@@ -6336,6 +6366,17 @@ func materializeProviderOverlaysBeforeFingerprint(
 
 func resolveTemplatePrepared(bp *agentBuildParams, cfgAgent *config.Agent, qualifiedName string, fpExtra map[string]string) (TemplateParams, error) {
 	if err := validateAgentSessionTransportForBuild(bp, cfgAgent, qualifiedName); err != nil {
+		// Every path that drops a template from the desired set — pool
+		// instances, named sessions, dependency floors, session-bead
+		// reuse — funnels its resolution through here and then does
+		// `continue`/`return` on the error, printing one line to a stderr
+		// that under the supervisor is a log file. ob-woag: that made a
+		// missing provider binary indistinguishable from "no demand" on
+		// every surface an operator actually looks at. Recording the
+		// failure here (rather than at each of the four call sites) keeps
+		// the diagnostic and the drop at the same seam, so a future drop
+		// site cannot forget to report.
+		bp.recordProviderUnresolved(qualifiedName, err)
 		return TemplateParams{}, err
 	}
 	prepareTemplateResolution(bp, cfgAgent, qualifiedName, bp.stderr)

--- a/cmd/gc/build_desired_state_provider_path_test.go
+++ b/cmd/gc/build_desired_state_provider_path_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// missingProviderCommand is a binary name no host will have on PATH. The
+// reproduction depends on a real exec.LookPath miss (newAgentBuildParams
+// installs exec.LookPath unconditionally), so the name has to be one nothing
+// could plausibly install.
+const missingProviderCommand = "gc-provider-that-is-not-installed-ob-woag"
+
+func missingProviderCity() *config.City {
+	return &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Provider: "ghost"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Name: "worker", Template: "worker", Mode: "always"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"ghost": {Command: missingProviderCommand},
+		},
+	}
+}
+
+// TestBuildDesiredState_MissingProviderBinary_ReportsDroppedTemplates is the
+// ob-woag reproduction. A city whose only always-on template names a provider
+// whose binary is absent reconciles to an EMPTY desired set — that part is
+// correct and unchanged, because there is no way to start the session. What
+// was wrong is that the emptiness was all the caller got back: the drop sites
+// print one line to a stderr that under the supervisor is a log file, and
+// return a quietly smaller State. `gc start` then reported success and the
+// city stayed empty with no surface naming the cause.
+//
+// The assertion that matters is the second one: the result must carry the
+// reason for its own emptiness.
+func TestBuildDesiredState_MissingProviderBinary_ReportsDroppedTemplates(t *testing.T) {
+	tmpDir := t.TempDir()
+	var stderr bytes.Buffer
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", tmpDir, time.Now(), missingProviderCity(), &localMockProvider{},
+		beads.NewMemStore(), nil, &sessionBeadSnapshot{}, nil, &stderr,
+	)
+
+	if len(result.State) != 0 {
+		t.Fatalf("desired sessions = %d, want 0 (the session cannot be built without its provider); keys=%v", len(result.State), mapKeys(result.State))
+	}
+	if len(result.ProviderUnresolved) != 1 {
+		t.Fatalf("ProviderUnresolved = %+v, want exactly one group; a build that dropped every session must say why. stderr=%q",
+			result.ProviderUnresolved, stderr.String())
+	}
+	group := result.ProviderUnresolved[0]
+	if group.Provider != "ghost" {
+		t.Errorf("group.Provider = %q, want %q", group.Provider, "ghost")
+	}
+	if group.Command != missingProviderCommand {
+		t.Errorf("group.Command = %q, want %q", group.Command, missingProviderCommand)
+	}
+	if group.DroppedTemplates < 1 {
+		t.Errorf("group.DroppedTemplates = %d, want at least 1", group.DroppedTemplates)
+	}
+	if len(group.Templates) == 0 || !strings.Contains(strings.Join(group.Templates, ","), "worker") {
+		t.Errorf("group.Templates = %v, want the dropped template named", group.Templates)
+	}
+}
+
+// TestBuildDesiredState_ResolvableProvider_ReportsNothing pins the negative:
+// the report is a fault signal, not a field that is always populated. "true"
+// is on PATH everywhere this test suite runs.
+func TestBuildDesiredState_ResolvableProvider_ReportsNothing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := missingProviderCity()
+	cfg.Providers["ghost"] = config.ProviderSpec{Command: "true"}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", tmpDir, time.Now(), cfg, &localMockProvider{},
+		beads.NewMemStore(), nil, &sessionBeadSnapshot{}, nil, io.Discard,
+	)
+
+	if len(result.ProviderUnresolved) != 0 {
+		t.Fatalf("ProviderUnresolved = %+v, want empty for a provider that resolves", result.ProviderUnresolved)
+	}
+}
+
+// TestBuildDesiredState_MissingProviderBinary_RecordsTrace covers the second
+// surface ob-woag named: the session-reconciler trace computed
+// desired_session_count=0 and the string "provider" appeared ZERO times in it,
+// so the trace read as "no demand" rather than "broken host".
+func TestBuildDesiredState_MissingProviderBinary_RecordsTrace(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityTOML(t, cityDir, "provider-path-town", "mayor")
+	cfg := missingProviderCity()
+
+	tracer := newSessionReconcilerTracer(cityDir, "provider-path-town", io.Discard)
+	if !tracer.Enabled() {
+		t.Fatal("tracer should be enabled")
+	}
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	cycle := mustBeginCycle(t, tracer, now, cfg)
+	traceID := cycle.traceID
+
+	buildDesiredStateWithSessionBeads(
+		"provider-path-town", cityDir, now, cfg, &localMockProvider{},
+		beads.NewMemStore(), nil, &sessionBeadSnapshot{}, cycle, io.Discard,
+	)
+
+	if err := cycle.End(TraceCompletionCompleted, traceRecordPayload{"phase": "tick"}); err != nil {
+		t.Fatalf("cycle.End: %v", err)
+	}
+	if err := tracer.Close(); err != nil {
+		t.Fatalf("tracer.Close: %v", err)
+	}
+
+	records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{TraceID: traceID})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	var found bool
+	for _, rec := range records {
+		if rec.SiteCode != TraceSiteDesiredStateProviderUnresolved {
+			continue
+		}
+		found = true
+		if rec.ReasonCode != TraceReasonProviderNotInPath {
+			t.Errorf("reason_code = %q, want %q", rec.ReasonCode, TraceReasonProviderNotInPath)
+		}
+		if got := rec.Fields["provider"]; got != "ghost" {
+			t.Errorf("trace provider field = %#v, want %q", got, "ghost")
+		}
+		if got := rec.Fields["command"]; got != missingProviderCommand {
+			t.Errorf("trace command field = %#v, want %q", got, missingProviderCommand)
+		}
+	}
+	if !found {
+		t.Fatalf("no %q record in %d trace records; the trace still cannot explain an empty desired set",
+			TraceSiteDesiredStateProviderUnresolved, len(records))
+	}
+}
+
+// TestReportUnresolvedProviders_AlertsOncePerEpisode covers the operator-facing
+// half: a controller log line and a .gc/events.jsonl record, each written once
+// per episode rather than once per tick. ob-woag found nothing in either place;
+// the failure mode of a naive fix is writing to both on every tick forever.
+func TestReportUnresolvedProviders_AlertsOncePerEpisode(t *testing.T) {
+	var stderr bytes.Buffer
+	rec := events.NewFake()
+	cr := &CityRuntime{logPrefix: "gc supervisor", stdout: io.Discard, stderr: &stderr, rec: rec}
+
+	failing := DesiredStateResult{
+		ProviderUnresolved: []ProviderUnresolvedGroup{{
+			Provider:         "ghost",
+			Command:          missingProviderCommand,
+			DroppedTemplates: 2,
+			Templates:        []string{"worker", "worker-2"},
+		}},
+	}
+
+	cr.reportUnresolvedProviders(failing)
+	first := stderr.String()
+	if !strings.Contains(first, "ghost") || !strings.Contains(first, missingProviderCommand) {
+		t.Fatalf("first alert = %q, want the provider and command named", first)
+	}
+	if !strings.Contains(first, "desired_session_count=0") {
+		t.Errorf("first alert = %q, want the desired_session_count that made the city look normal", first)
+	}
+	if len(rec.Events) != 1 {
+		t.Fatalf("recorded events = %d, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Type != events.ProviderUnresolved {
+		t.Errorf("event type = %q, want %q", rec.Events[0].Type, events.ProviderUnresolved)
+	}
+	if rec.Events[0].Subject != "ghost" {
+		t.Errorf("event subject = %q, want %q", rec.Events[0].Subject, "ghost")
+	}
+
+	// Same failure, next tick: latched.
+	cr.reportUnresolvedProviders(failing)
+	if got := stderr.String(); got != first {
+		t.Errorf("second tick wrote another line; a per-tick alert is its own outage:\n%s", got)
+	}
+	if len(rec.Events) != 1 {
+		t.Errorf("recorded events = %d after a second identical tick, want 1", len(rec.Events))
+	}
+
+	// Provider installed: the latch clears, so a later removal alerts again.
+	cr.reportUnresolvedProviders(DesiredStateResult{})
+	if len(rec.Events) != 1 {
+		t.Errorf("recovery recorded an event: %+v", rec.Events)
+	}
+	cr.reportUnresolvedProviders(failing)
+	if len(rec.Events) != 2 {
+		t.Fatalf("recorded events = %d after a recurrence, want 2", len(rec.Events))
+	}
+}
+
+// TestBeadReconcileTick_MissingProvider_CarriesCountInTrace pins the field that
+// answers the original question directly: desired_session_count and
+// provider_unresolved_count are in the SAME cycle-input record, so a zero
+// desired count can no longer be read as an idle city.
+func TestBeadReconcileTick_MissingProvider_CarriesCountInTrace(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityTOML(t, cityDir, "provider-path-town", "mayor")
+	cfg := missingProviderCity()
+
+	tracer := newSessionReconcilerTracer(cityDir, "provider-path-town", io.Discard)
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	cycle := mustBeginCycle(t, tracer, now, cfg)
+	traceID := cycle.traceID
+
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityDir,
+		cityName:            "provider-path-town",
+		cfg:                 cfg,
+		sp:                  runtime.NewFake(),
+		trace:               tracer,
+		standaloneCityStore: beads.NewMemStore(),
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.NewFake(),
+		logPrefix:           "gc supervisor",
+		stdout:              io.Discard,
+		stderr:              &stderr,
+	}
+
+	result := DesiredStateResult{
+		State: map[string]TemplateParams{},
+		ProviderUnresolved: []ProviderUnresolvedGroup{{
+			Provider:         "ghost",
+			Command:          missingProviderCommand,
+			DroppedTemplates: 1,
+			Templates:        []string{"worker"},
+		}},
+	}
+	cr.beadReconcileTick(context.Background(), result, newSessionBeadSnapshot(nil), cycle, false)
+	if err := cycle.End(TraceCompletionCompleted, traceRecordPayload{"phase": "tick"}); err != nil {
+		t.Fatalf("cycle.End: %v", err)
+	}
+	if err := tracer.Close(); err != nil {
+		t.Fatalf("tracer.Close: %v", err)
+	}
+
+	records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{TraceID: traceID})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	var sawSnapshot bool
+	for _, r := range records {
+		if r.RecordType != TraceRecordCycleInputSnapshot {
+			continue
+		}
+		sawSnapshot = true
+		if got := traceFieldInt(r.Fields["desired_session_count"]); got != 0 {
+			t.Errorf("desired_session_count = %d, want 0", got)
+		}
+		if got := traceFieldInt(r.Fields["provider_unresolved_count"]); got != 1 {
+			t.Errorf("provider_unresolved_count = %#v, want 1 beside desired_session_count=0", r.Fields["provider_unresolved_count"])
+		}
+	}
+	if !sawSnapshot {
+		t.Fatal("no cycle input snapshot record")
+	}
+	if !strings.Contains(stderr.String(), "not on PATH") {
+		t.Errorf("controller log = %q, want the provider alert", stderr.String())
+	}
+}
+
+// mustBeginCycle opens a trace cycle or fails the test. It exists so callers
+// get a value they can use directly: an inline `if cycle == nil { t.Fatal }`
+// followed by a later field read is what staticcheck's SA5011 reports, and the
+// warning is fair — the check reads as though nil were survivable here.
+func mustBeginCycle(t *testing.T, tracer *SessionReconcilerTracer, now time.Time, cfg *config.City) *SessionReconcilerTraceCycle {
+	t.Helper()
+	cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "controller_tick", now, cfg)
+	if cycle == nil {
+		t.Fatal("BeginCycle returned nil")
+	}
+	return cycle
+}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -231,6 +231,19 @@ type CityRuntime struct {
 	forceStopShutdown *atomic.Bool
 	logPrefix         string // "gc start" or "gc supervisor"
 	stdout, stderr    io.Writer
+
+	// providerUnresolvedAlerted latches the once-per-episode alert for a
+	// provider whose command is not on PATH, keyed by provider+command.
+	// The desired-state build repeats the same failure on every tick (and
+	// the cached demand snapshot replays it even between builds), so an
+	// unlatched report would put one line per provider per tick into the
+	// log and one event per tick into .gc/events.jsonl — a storm nobody
+	// reads, which is the failure mode ob-woag was reporting in the first
+	// place, only louder. The key is cleared once the provider resolves
+	// again, so a reinstall-then-remove fires a second alert. Mutated only
+	// from the reconcile tick, same single-goroutine convention as
+	// cr.demandSnapshot.
+	providerUnresolvedAlerted map[string]bool
 }
 
 // runtimeDemandSnapshotBackstopMaxAge bounds how long an EVENT-BACKED demand
@@ -2490,6 +2503,13 @@ func (cr *CityRuntime) newWarmClaimTriggerResolver(servingRigs map[string]beads.
 // first steady-state tick performs both.
 func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStateResult, sessionBeads *sessionBeadSnapshot, trace *sessionReconcilerTraceCycle, bootReconcile bool) {
 	desiredState := result.State
+	// Before anything else this tick: if the build dropped templates because
+	// a provider command is missing, say so. ob-woag: a city whose only
+	// always-on template used an uninstalled binary reconciled to an empty
+	// desired set and every surface reported that as normal. This runs ahead
+	// of the store guard on purpose — a storeless city that cannot resolve
+	// its provider is exactly as broken and exactly as silent.
+	cr.reportUnresolvedProviders(result)
 	store := cr.cityBeadStore()
 	if store == nil {
 		return
@@ -2916,6 +2936,12 @@ func (cr *CityRuntime) recordReconcileTraceInputs(
 		"named_scale_check_partial_templates": sortedBoolMapKeys(result.NamedScaleCheckPartialTemplates),
 		"session_query_partial":               result.SessionQueryPartial,
 		"snapshot_query_partial":              result.snapshotQueryPartial(),
+		// Carried in the same record as desired_session_count so the two
+		// are read together. A zero desired count with a non-zero
+		// unresolved count is a broken host, not an idle city — the
+		// distinction ob-woag's trace could not express.
+		"provider_unresolved_count":     len(result.ProviderUnresolved),
+		"provider_unresolved_providers": providerUnresolvedProviderNames(result.ProviderUnresolved),
 	})
 	for _, agent := range cr.cfg.Agents {
 		template := agent.QualifiedName()

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -254,6 +254,13 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		register(doctor.NewDurationRangeCheck(cfg))
 		register(doctor.NewProviderParityCheck(cfg))
+		// provider-path asks the host question its neighbors deliberately
+		// skip: provider-catalog checks the reference is declared and
+		// provider-parity inspects capability fields under a stub PATH
+		// lookup, so before ob-woag nothing verified that a referenced
+		// provider's binary actually exists. Real exec.LookPath here — a
+		// stub would reproduce the silence.
+		register(doctor.NewProviderPathCheck(cfg, exec.LookPath))
 		register(doctor.NewFormulaRequirementsCheck(cfg, cityPath))
 		register(doctor.NewNamedAlwaysMinConflictCheck(cfg))
 		register(doctor.NewInstructionsFileCheck(cfg, cityPath))

--- a/cmd/gc/provider_unresolved.go
+++ b/cmd/gc/provider_unresolved.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// providerUnresolvedTemplateSample bounds how many template identities one
+// group carries. A city with a hundred agents on one uninstalled provider
+// should produce a readable trace record and a readable log line, not a
+// hundred-entry list repeated on every reconcile tick; the count is reported
+// separately so nothing is lost by truncating the names.
+const providerUnresolvedTemplateSample = 8
+
+// ProviderUnresolvedGroup reports one provider whose command did not resolve
+// on PATH during a desired-state build, together with what that cost.
+//
+// This is the structured record ob-woag found missing. When a template's
+// provider binary is absent the controller drops every session using it from
+// the desired set; before this type the only trace of that was a line on the
+// supervisor's stderr, so `desired_session_count` went to 0 with the word
+// "provider" appearing nowhere in the reconciler trace and nothing at all in
+// .gc/events.jsonl.
+type ProviderUnresolvedGroup struct {
+	// Provider is the configured provider reference that failed.
+	Provider string
+	// Command is the binary lookPath could not find.
+	Command string
+	// DroppedTemplates counts every template resolution this provider
+	// failed during the build — the size of the hole in the desired set.
+	DroppedTemplates int
+	// Templates samples the affected identities, sorted and capped at
+	// providerUnresolvedTemplateSample.
+	Templates []string
+}
+
+// providerUnresolvedSet accumulates PATH-resolution failures across one
+// desired-state build, grouped by provider so a single uninstalled binary
+// shared by many agents reports once.
+//
+// The set is held by POINTER on agentBuildParams because several build paths
+// take a value copy of the params struct (resolveTemplateForSessionBeadInfo
+// does `local := *bp` to scope a beadNames override). A slice field on the
+// struct would collect failures into whichever copy happened to see them and
+// lose them at the seam; the shared pointer makes the accumulation
+// copy-transparent. The mutex is for the pool-evaluation fan-out, which
+// resolves templates from more than one goroutine.
+type providerUnresolvedSet struct {
+	mu     sync.Mutex
+	groups map[string]*ProviderUnresolvedGroup
+}
+
+func newProviderUnresolvedSet() *providerUnresolvedSet {
+	return &providerUnresolvedSet{groups: map[string]*ProviderUnresolvedGroup{}}
+}
+
+// record adds one failure if err is (or wraps) a provider-not-in-PATH error,
+// and reports whether it did. Any other resolution error is somebody else's
+// diagnostic: unknown-provider and bad-option faults are config errors the
+// config-valid / config-refs / provider-catalog checks already name, and
+// re-reporting them here would dilute the one signal this set exists to carry.
+// Nil-receiver-safe so build paths without an accumulator (focused unit
+// fixtures) cost one branch.
+func (s *providerUnresolvedSet) record(template string, err error) bool {
+	if s == nil || err == nil {
+		return false
+	}
+	var notInPath *config.ProviderNotInPATHError
+	if !errors.As(err, &notInPath) {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := notInPath.Provider + "\x00" + notInPath.Command
+	g, ok := s.groups[key]
+	if !ok {
+		g = &ProviderUnresolvedGroup{Provider: notInPath.Provider, Command: notInPath.Command}
+		s.groups[key] = g
+	}
+	g.DroppedTemplates++
+	if template != "" && len(g.Templates) < providerUnresolvedTemplateSample && !slices.Contains(g.Templates, template) {
+		g.Templates = append(g.Templates, template)
+	}
+	return true
+}
+
+// snapshot returns the accumulated groups in a stable order, safe to hand to
+// the caller (templates are copied, not aliased).
+func (s *providerUnresolvedSet) snapshot() []ProviderUnresolvedGroup {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.groups) == 0 {
+		return nil
+	}
+	out := make([]ProviderUnresolvedGroup, 0, len(s.groups))
+	for _, g := range s.groups {
+		templates := append([]string(nil), g.Templates...)
+		sort.Strings(templates)
+		out = append(out, ProviderUnresolvedGroup{
+			Provider:         g.Provider,
+			Command:          g.Command,
+			DroppedTemplates: g.DroppedTemplates,
+			Templates:        templates,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Command < out[j].Command
+	})
+	return out
+}
+
+// providerUnresolvedProviderNames lists the failing provider references in
+// stable order, for trace fields that want the names without the per-group
+// detail.
+func providerUnresolvedProviderNames(groups []ProviderUnresolvedGroup) []string {
+	names := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if !slices.Contains(names, g.Provider) {
+			names = append(names, g.Provider)
+		}
+	}
+	return names
+}
+
+// key is the group's stable identity, used by the controller's
+// once-per-episode alert latch.
+func (g ProviderUnresolvedGroup) key() string { return g.Provider + "\x00" + g.Command }
+
+// reportUnresolvedProviders turns a desired-state build's provider-PATH
+// failures into the two operator-visible records ob-woag found missing: a
+// controller log line and a .gc/events.jsonl entry. The reconciler trace is
+// written at the build site itself (buildDesiredStateWithSessionBeadsAt); this
+// is the half that reaches someone who is not already reading a trace.
+//
+// One alert per episode, not per tick. The desired-state build re-derives the
+// same failure every time it runs and the cached demand snapshot replays the
+// result in between, so the unlatched version of this would write a line and
+// an event on every controller tick for as long as the binary stays
+// uninstalled. Recovery clears the latch, so a provider that is installed and
+// then removed again alerts a second time.
+func (cr *CityRuntime) reportUnresolvedProviders(result DesiredStateResult) {
+	if cr == nil {
+		return
+	}
+	if len(result.ProviderUnresolved) == 0 && len(cr.providerUnresolvedAlerted) == 0 {
+		return
+	}
+	if cr.providerUnresolvedAlerted == nil {
+		cr.providerUnresolvedAlerted = map[string]bool{}
+	}
+	live := make(map[string]bool, len(result.ProviderUnresolved))
+	for _, group := range result.ProviderUnresolved {
+		key := group.key()
+		live[key] = true
+		if cr.providerUnresolvedAlerted[key] {
+			continue
+		}
+		cr.providerUnresolvedAlerted[key] = true
+		cr.emitProviderUnresolvedAlert(group, len(result.State))
+	}
+	for key := range cr.providerUnresolvedAlerted {
+		if !live[key] {
+			delete(cr.providerUnresolvedAlerted, key)
+		}
+	}
+}
+
+// emitProviderUnresolvedAlert writes one episode's alert to the controller log
+// and records it as a ProviderUnresolved event.
+//
+// The message carries desired_session_count deliberately: the reported symptom
+// was a city that started clean and stayed empty, and the number that made it
+// look normal is the number that has to appear beside its cause.
+func (cr *CityRuntime) emitProviderUnresolvedAlert(group ProviderUnresolvedGroup, desiredSessionCount int) {
+	templates := strings.Join(group.Templates, ", ")
+	if templates == "" {
+		templates = "(no template named)"
+	}
+	msg := fmt.Sprintf(
+		"provider %q command %q is not on PATH: %d template(s) dropped from the desired state (%s); "+
+			"desired_session_count=%d. Install the provider CLI or repoint [providers.%s].command, then `gc doctor` (check provider-path) to confirm.",
+		group.Provider, group.Command, group.DroppedTemplates, templates, desiredSessionCount, group.Provider,
+	)
+	if cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: %s\n", cr.logPrefix, msg) //nolint:errcheck // best-effort stderr
+	}
+	if cr.rec == nil {
+		return
+	}
+	payload, _ := json.Marshal(map[string]any{ //nolint:errcheck // map of scalars and strings cannot fail
+		"provider":              group.Provider,
+		"command":               group.Command,
+		"dropped_templates":     group.DroppedTemplates,
+		"templates":             group.Templates,
+		"desired_session_count": desiredSessionCount,
+	})
+	cr.rec.Record(events.Event{
+		Type:    events.ProviderUnresolved,
+		Ts:      time.Now().UTC(),
+		Actor:   "gc",
+		Subject: group.Provider,
+		Message: msg,
+		Payload: payload,
+	})
+}

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -59,13 +59,19 @@ const (
 type TraceSiteCode string
 
 const (
-	TraceSiteUnknown                        TraceSiteCode = "unknown"
-	TraceSiteScaleCheckExec                 TraceSiteCode = "trace.scale_check_exec"
-	TraceSiteCycleStart                     TraceSiteCode = "cycle.start"
-	TraceSiteCycleFinish                    TraceSiteCode = "cycle.finish"
-	TraceSiteConfigReload                   TraceSiteCode = "config.reload"
-	TraceSiteControllerTickPhase            TraceSiteCode = "controller.tick.phase"
-	TraceSiteDesiredStateBuild              TraceSiteCode = "desired_state.build"
+	TraceSiteUnknown             TraceSiteCode = "unknown"
+	TraceSiteScaleCheckExec      TraceSiteCode = "trace.scale_check_exec"
+	TraceSiteCycleStart          TraceSiteCode = "cycle.start"
+	TraceSiteCycleFinish         TraceSiteCode = "cycle.finish"
+	TraceSiteConfigReload        TraceSiteCode = "config.reload"
+	TraceSiteControllerTickPhase TraceSiteCode = "controller.tick.phase"
+	TraceSiteDesiredStateBuild   TraceSiteCode = "desired_state.build"
+	// TraceSiteDesiredStateProviderUnresolved records a template dropped
+	// from the desired set because its provider command is not on PATH.
+	// ob-woag: without it a missing binary reads exactly like no demand —
+	// desired_session_count falls to zero and the word "provider" never
+	// appears in the cycle.
+	TraceSiteDesiredStateProviderUnresolved TraceSiteCode = "desired_state.provider_unresolved"
 	TraceSiteDemandSnapshot                 TraceSiteCode = "demand_snapshot.load"
 	TraceSiteOrderDispatch                  TraceSiteCode = "orders.dispatch"
 	TraceSitePoolDemandCompute              TraceSiteCode = "pool_desired.compute"
@@ -168,19 +174,24 @@ const (
 	TraceReasonFSPressure             TraceReasonCode = "fs_pressure"
 	TraceReasonResetStalled           TraceReasonCode = "reset_stalled"
 
-	TraceReasonRateLimit                     TraceReasonCode = "rate_limit"
-	TraceReasonPendingCreate                 TraceReasonCode = "pending_create"
-	TraceReasonPreserve                      TraceReasonCode = "preserve"
-	TraceReasonConfigDriftAttachmentError    TraceReasonCode = "config_drift_attachment_error"
-	TraceReasonConfigDriftAttached           TraceReasonCode = "config_drift_attached"
-	TraceReasonConfigDriftRecentlyAttached   TraceReasonCode = "config_drift_recently_attached"
-	TraceReasonPending                       TraceReasonCode = "pending"
-	TraceReasonAcknowledged                  TraceReasonCode = "acknowledged"
-	TraceReasonMinFloorIdleWorker            TraceReasonCode = "min_floor_idle_worker"
-	TraceReasonLiveDrift                     TraceReasonCode = "live_drift"
-	TraceReasonCircuitOpen                   TraceReasonCode = "circuit_open"
-	TraceReasonCircuitTrip                   TraceReasonCode = "circuit_trip"
-	TraceReasonProviderRed                   TraceReasonCode = "provider_red"
+	TraceReasonRateLimit                   TraceReasonCode = "rate_limit"
+	TraceReasonPendingCreate               TraceReasonCode = "pending_create"
+	TraceReasonPreserve                    TraceReasonCode = "preserve"
+	TraceReasonConfigDriftAttachmentError  TraceReasonCode = "config_drift_attachment_error"
+	TraceReasonConfigDriftAttached         TraceReasonCode = "config_drift_attached"
+	TraceReasonConfigDriftRecentlyAttached TraceReasonCode = "config_drift_recently_attached"
+	TraceReasonPending                     TraceReasonCode = "pending"
+	TraceReasonAcknowledged                TraceReasonCode = "acknowledged"
+	TraceReasonMinFloorIdleWorker          TraceReasonCode = "min_floor_idle_worker"
+	TraceReasonLiveDrift                   TraceReasonCode = "live_drift"
+	TraceReasonCircuitOpen                 TraceReasonCode = "circuit_open"
+	TraceReasonCircuitTrip                 TraceReasonCode = "circuit_trip"
+	TraceReasonProviderRed                 TraceReasonCode = "provider_red"
+	// TraceReasonProviderNotInPath is distinct from TraceReasonProviderRed:
+	// red is a healthy-but-failing provider the gate parks and later
+	// resumes, whereas this one never resolved a binary at all and no
+	// amount of waiting fixes it.
+	TraceReasonProviderNotInPath             TraceReasonCode = "provider_not_in_path"
 	TraceReasonHealClearedStaleLease         TraceReasonCode = "heal_cleared_stale_lease"
 	TraceReasonPendingCreateRecoveryInFlight TraceReasonCode = "pending_create_recovery_in_flight"
 	TraceReasonPendingCreateRebuildFailed    TraceReasonCode = "pending_create_rebuild_failed"

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -29,6 +29,7 @@ builtin-pack-family
 config-semantics
 duration-range
 provider-parity
+provider-path
 formula-requirements
 named-always-min-conflict
 instructions-file

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -16,6 +16,42 @@ var (
 	ErrUnknownOption = errors.New("unknown option")
 )
 
+// ProviderNotInPATHError is the structured form of an ErrProviderNotInPATH
+// failure: it names the provider reference and the command that did not
+// resolve, so callers can act on the two identifiers instead of scraping them
+// back out of a formatted string.
+//
+// The motivating bug (ob-woag): a missing provider binary dropped every
+// session using that provider from the controller's desired state, and the
+// only place the cause survived was this error's *text*, printed to a
+// supervisor log nobody reads. `gc doctor` passed, `gc start` reported
+// success, the reconciler trace computed desired_session_count=0 without the
+// word "provider" appearing anywhere in it, and .gc/events.jsonl had no
+// record. Both new diagnostics — the doctor check and the reconciler's
+// dropped-session report — need the provider name and the command as data,
+// which is why this type exists rather than another fmt.Errorf.
+//
+// Error() reproduces the previous fmt.Errorf layout byte for byte and Unwrap
+// returns ErrProviderNotInPATH, so every existing errors.Is check and every
+// message assertion keeps working.
+type ProviderNotInPATHError struct {
+	// Provider is the provider reference as configured (the [providers.X]
+	// key or a built-in preset name), not the resolved binary.
+	Provider string
+	// Command is the binary that lookPath failed on — pathCheckBinary(),
+	// which is the first word of a multi-word command.
+	Command string
+}
+
+// Error renders the same text the sentinel-wrapping fmt.Errorf produced.
+func (e *ProviderNotInPATHError) Error() string {
+	return fmt.Sprintf("%s: provider %q command %q", ErrProviderNotInPATH.Error(), e.Provider, e.Command)
+}
+
+// Unwrap keeps errors.Is(err, ErrProviderNotInPATH) true for every caller
+// that predates the typed form.
+func (e *ProviderNotInPATHError) Unwrap() error { return ErrProviderNotInPATH }
+
 // LookPathFunc is the signature for exec.LookPath (or a test fake).
 type LookPathFunc func(string) (string, error)
 
@@ -167,7 +203,7 @@ func lookupProvider(name string, cityProviders map[string]ProviderSpec, lookPath
 		if spec, ok := cityProviders[name]; ok {
 			if spec.Command != "" {
 				if _, err := lookPath(spec.pathCheckBinary()); err != nil {
-					return nil, fmt.Errorf("%w: provider %q command %q", ErrProviderNotInPATH, name, spec.pathCheckBinary())
+					return nil, &ProviderNotInPATHError{Provider: name, Command: spec.pathCheckBinary()}
 				}
 			}
 			// Phase 2+: if the spec has explicit Base declared,
@@ -188,7 +224,7 @@ func lookupProvider(name string, cityProviders map[string]ProviderSpec, lookPath
 				merged := resolvedChainToSpec(resolved, spec)
 				if merged.Command != "" {
 					if _, err := lookPath(merged.pathCheckBinary()); err != nil {
-						return nil, fmt.Errorf("%w: provider %q command %q", ErrProviderNotInPATH, name, merged.pathCheckBinary())
+						return nil, &ProviderNotInPATHError{Provider: name, Command: merged.pathCheckBinary()}
 					}
 				}
 				return &merged, nil
@@ -217,7 +253,7 @@ func lookupProvider(name string, cityProviders map[string]ProviderSpec, lookPath
 	builtins := BuiltinProviders()
 	if spec, ok := builtins[name]; ok {
 		if _, err := lookPath(spec.pathCheckBinary()); err != nil {
-			return nil, fmt.Errorf("%w: provider %q command %q", ErrProviderNotInPATH, name, spec.pathCheckBinary())
+			return nil, &ProviderNotInPATHError{Provider: name, Command: spec.pathCheckBinary()}
 		}
 		return &spec, nil
 	}

--- a/internal/config/resolve_provider_not_in_path_test.go
+++ b/internal/config/resolve_provider_not_in_path_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func notFoundLookPath(string) (string, error) {
+	return "", errors.New("executable file not found in $PATH")
+}
+
+// TestResolveProvider_NotInPATH_IsStructured proves the failure carries the
+// provider reference and the command as data. Before ob-woag the only place
+// those two identifiers survived was the formatted message, which is why the
+// controller could drop every session for a missing binary and report nothing
+// but a smaller number.
+func TestResolveProvider_NotInPATH_IsStructured(t *testing.T) {
+	providers := map[string]ProviderSpec{"codex": {Command: "codex"}}
+	_, err := ResolveProvider(&Agent{Provider: "codex"}, &Workspace{}, providers, notFoundLookPath)
+	if err == nil {
+		t.Fatal("ResolveProvider() = nil error, want a PATH failure")
+	}
+	var notInPath *ProviderNotInPATHError
+	if !errors.As(err, &notInPath) {
+		t.Fatalf("errors.As(%v, *ProviderNotInPATHError) = false", err)
+	}
+	if notInPath.Provider != "codex" {
+		t.Errorf("Provider = %q, want %q", notInPath.Provider, "codex")
+	}
+	if notInPath.Command != "codex" {
+		t.Errorf("Command = %q, want %q", notInPath.Command, "codex")
+	}
+}
+
+// TestResolveProvider_NotInPATH_KeepsSentinelAndMessage pins the compatibility
+// contract: every caller that predates the typed form used errors.Is or
+// matched on the text, including `gc session new`, which was the one command
+// that named the cause correctly.
+func TestResolveProvider_NotInPATH_KeepsSentinelAndMessage(t *testing.T) {
+	providers := map[string]ProviderSpec{"codex": {Command: "codex"}}
+	_, err := ResolveProvider(&Agent{Provider: "codex"}, &Workspace{}, providers, notFoundLookPath)
+	if !errors.Is(err, ErrProviderNotInPATH) {
+		t.Fatalf("errors.Is(%v, ErrProviderNotInPATH) = false", err)
+	}
+	const want = `provider not found in PATH: provider "codex" command "codex"`
+	if err.Error() != want {
+		t.Errorf("Error() = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestResolveProvider_NotInPATH_ReportsCheckedBinary covers a multi-word
+// command: pathCheckBinary probes the first word, so that is the name the
+// operator has to install and therefore the one the error must report.
+func TestResolveProvider_NotInPATH_ReportsCheckedBinary(t *testing.T) {
+	providers := map[string]ProviderSpec{"wrapped": {Command: "aimux run codex"}}
+	_, err := ResolveProvider(&Agent{Provider: "wrapped"}, &Workspace{}, providers, notFoundLookPath)
+	var notInPath *ProviderNotInPATHError
+	if !errors.As(err, &notInPath) {
+		t.Fatalf("errors.As(%v, *ProviderNotInPATHError) = false", err)
+	}
+	if notInPath.Command != "aimux" {
+		t.Errorf("Command = %q, want the probed binary %q", notInPath.Command, "aimux")
+	}
+}

--- a/internal/doctor/checks_provider_path.go
+++ b/internal/doctor/checks_provider_path.go
@@ -1,0 +1,175 @@
+package doctor
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// ProviderPathCheck verifies that the provider command behind every template
+// a session can be built from actually resolves on PATH.
+//
+// It exists because of ob-woag: on a host where a referenced provider binary
+// was absent, the controller dropped every session using that provider from
+// its desired state and no surface said so. `gc start` reported "City started
+// under supervisor.", `gc status` showed the agents as "unknown (partial
+// status)", `gc agent list` showed them "active", and `gc doctor` passed 100
+// checks — not one of which asked whether a configured provider's command
+// exists. The city came up completely empty and the only command that named
+// the cause was `gc session new <template>`, which is the one command an
+// operator has no reason to run when start already claimed success.
+//
+// The neighboring provider checks all stop short of this question by design:
+// provider-catalog checks that every referenced provider is *declared*,
+// provider-catalog-local-readiness checks that locally-configured CLIs are
+// listed explicitly, and provider-parity inspects capability fields using a
+// stub PATH lookup (providerParityLookPath) because it is auditing config
+// semantics, not the host. This check is the one that touches the host.
+//
+// Reachability is "every configured agent template", not "every template with
+// demand right now". A pool template sitting at min_active_sessions = 0 is one
+// routed bead away from needing its provider, so a provider that cannot
+// resolve is a fault whether or not anything wants a session this second.
+// Agents that pin start_command are skipped: they bypass ProviderSpec
+// entirely and ResolveProvider never consults PATH for them.
+type ProviderPathCheck struct {
+	cfg      *config.City
+	lookPath config.LookPathFunc
+}
+
+// NewProviderPathCheck creates a check that resolves every configured agent's
+// provider against the supplied PATH lookup (production passes exec.LookPath).
+func NewProviderPathCheck(cfg *config.City, lookPath config.LookPathFunc) *ProviderPathCheck {
+	return &ProviderPathCheck{cfg: cfg, lookPath: lookPath}
+}
+
+// Name returns the check identifier.
+func (c *ProviderPathCheck) Name() string { return "provider-path" }
+
+// providerPathFailure is one provider whose command did not resolve, with the
+// templates that would be dropped because of it.
+type providerPathFailure struct {
+	provider  string
+	command   string
+	templates []string
+}
+
+// Run resolves each configured agent's provider and reports the ones whose
+// command is not on PATH.
+//
+// Only ErrProviderNotInPATH is reported. Every other resolution error
+// (unknown provider, an unresolvable base in a provider chain, a bad option
+// key) is a config fault that config-valid, config-refs and provider-catalog
+// already own; repeating them here would make one broken reference fail four
+// checks and bury the PATH signal this check exists to raise.
+func (c *ProviderPathCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil || c.lookPath == nil {
+		r.Status = StatusOK
+		r.Message = "no config; nothing to check"
+		return r
+	}
+
+	failures := c.collectFailures()
+	if len(failures) == 0 {
+		r.Status = StatusOK
+		r.Message = "every referenced provider command resolves on PATH"
+		return r
+	}
+
+	details := make([]string, 0, len(failures))
+	for _, f := range failures {
+		details = append(details, fmt.Sprintf(
+			"provider %q command %q is not on PATH: every session for %s is silently dropped from the controller's desired state",
+			f.provider, f.command, strings.Join(f.templates, ", "),
+		))
+	}
+
+	// Blocking, not advisory: an unresolvable provider is not a degraded
+	// mode. Every session that names it fails to build, so the templates
+	// listed above cannot start at all, and letting a consumer proceed past
+	// that is exactly the silence ob-woag reported.
+	r.Status = StatusError
+	r.Severity = SeverityBlocking
+	r.Message = fmt.Sprintf("%d provider command(s) not on PATH", len(failures))
+	r.Details = details
+	r.FixHint = "install the provider CLI (or point [providers.<name>].command at an installed binary) and re-run; `gc session new <template>` reports the same error for a single template"
+	return r
+}
+
+// collectFailures resolves every reachable agent and groups the PATH failures
+// by provider so a single missing binary shared by twenty agents reports as
+// one finding naming twenty templates, not twenty findings.
+func (c *ProviderPathCheck) collectFailures() []providerPathFailure {
+	byProvider := map[string]*providerPathFailure{}
+
+	record := func(template string, agent config.Agent) {
+		_, err := config.ResolveProvider(&agent, &c.cfg.Workspace, c.cfg.Providers, c.lookPath)
+		if err == nil {
+			return
+		}
+		var notInPath *config.ProviderNotInPATHError
+		if !errors.As(err, &notInPath) {
+			return
+		}
+		key := notInPath.Provider + "\x00" + notInPath.Command
+		f, ok := byProvider[key]
+		if !ok {
+			f = &providerPathFailure{provider: notInPath.Provider, command: notInPath.Command}
+			byProvider[key] = f
+		}
+		if template != "" {
+			f.templates = append(f.templates, template)
+		}
+	}
+
+	checkedAgent := false
+	for _, a := range c.cfg.Agents {
+		if a.StartCommand != "" {
+			continue
+		}
+		if strings.TrimSpace(a.Provider) == "" && strings.TrimSpace(c.cfg.Workspace.Provider) == "" {
+			continue
+		}
+		checkedAgent = true
+		record(a.QualifiedName(), a)
+	}
+	// A city can declare workspace.provider with no agents yet (a fresh
+	// `gc init`, or one whose agents all arrive from a pack that has not
+	// been installed). The default provider still has to resolve before the
+	// first template can start, so probe it under its own identity.
+	if !checkedAgent && strings.TrimSpace(c.cfg.Workspace.Provider) != "" {
+		record("workspace default provider", config.Agent{})
+	}
+
+	failures := make([]providerPathFailure, 0, len(byProvider))
+	for _, f := range byProvider {
+		sort.Strings(f.templates)
+		failures = append(failures, *f)
+	}
+	sort.Slice(failures, func(i, j int) bool {
+		if failures[i].provider != failures[j].provider {
+			return failures[i].provider < failures[j].provider
+		}
+		return failures[i].command < failures[j].command
+	})
+	return failures
+}
+
+// CanFix returns false — installing a provider CLI is not something the
+// doctor can do on the operator's behalf.
+func (c *ProviderPathCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *ProviderPathCheck) Fix(_ *CheckContext) error { return nil }
+
+// WarmupEligible returns true. `gc start` runs the warm-up-eligible checks and
+// prints a failure line before handing off to the supervisor, which is the
+// specific moment ob-woag reported as falsely clean: a city that cannot start
+// any of its always-on sessions announced "City started under supervisor." and
+// nothing else. The check is pure config reads plus one PATH lookup per
+// distinct provider, so it costs nothing against the warm-up deadline.
+func (c *ProviderPathCheck) WarmupEligible() bool { return true }

--- a/internal/doctor/checks_provider_path_test.go
+++ b/internal/doctor/checks_provider_path_test.go
@@ -1,0 +1,150 @@
+package doctor
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// failLookPath is a PATH lookup where nothing resolves — the host condition
+// ob-woag reported, without depending on what is installed on the machine
+// running the tests.
+func failLookPath(string) (string, error) { return "", errors.New("not found") }
+
+// okLookPath is a PATH lookup where everything resolves.
+func okLookPath(cmd string) (string, error) { return "/usr/bin/" + cmd, nil }
+
+func providerPathCity() *config.City {
+	return &config.City{
+		Agents: []config.Agent{{Name: "worker", Provider: "ghost"}},
+		Providers: map[string]config.ProviderSpec{
+			"ghost": {Command: "ghost-cli"},
+		},
+	}
+}
+
+func TestProviderPathCheck_NoConfig(t *testing.T) {
+	r := NewProviderPathCheck(nil, exec.LookPath).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want OK", r.Status)
+	}
+}
+
+func TestProviderPathCheck_ResolvesCleanly(t *testing.T) {
+	r := NewProviderPathCheck(providerPathCity(), okLookPath).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v (%s), want OK", r.Status, r.Message)
+	}
+}
+
+// TestProviderPathCheck_FlagsMissingCommand is the check ob-woag asked for:
+// `gc doctor` passed 100 checks on a city whose provider binary was absent.
+func TestProviderPathCheck_FlagsMissingCommand(t *testing.T) {
+	r := NewProviderPathCheck(providerPathCity(), failLookPath).Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %v (%s), want Error", r.Status, r.Message)
+	}
+	if r.Severity != SeverityBlocking {
+		t.Errorf("severity = %v, want blocking; the listed templates cannot start at all", r.Severity)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("details = %v, want one line", r.Details)
+	}
+	if !strings.Contains(r.Details[0], `"ghost"`) || !strings.Contains(r.Details[0], `"ghost-cli"`) {
+		t.Errorf("detail = %q, want the provider and its command named", r.Details[0])
+	}
+	if !strings.Contains(r.Details[0], "worker") {
+		t.Errorf("detail = %q, want the affected template named", r.Details[0])
+	}
+	if r.FixHint == "" {
+		t.Error("want a fix hint; the operator has to know what to install")
+	}
+}
+
+// TestProviderPathCheck_GroupsByProvider keeps the finding proportional to the
+// fault: one uninstalled binary is one problem, however many agents name it.
+func TestProviderPathCheck_GroupsByProvider(t *testing.T) {
+	cfg := providerPathCity()
+	cfg.Agents = append(cfg.Agents,
+		config.Agent{Name: "second", Provider: "ghost"},
+		config.Agent{Name: "third", Provider: "ghost"},
+	)
+	r := NewProviderPathCheck(cfg, failLookPath).Run(&CheckContext{})
+	if len(r.Details) != 1 {
+		t.Fatalf("details = %v, want one grouped finding for one missing binary", r.Details)
+	}
+	for _, name := range []string{"worker", "second", "third"} {
+		if !strings.Contains(r.Details[0], name) {
+			t.Errorf("detail = %q, want %q listed", r.Details[0], name)
+		}
+	}
+}
+
+// TestProviderPathCheck_SkipsStartCommandAgents mirrors provider-parity:
+// start_command bypasses ProviderSpec entirely, so ResolveProvider never
+// consults PATH for those agents and this check has nothing to say about them.
+func TestProviderPathCheck_SkipsStartCommandAgents(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker", StartCommand: "ghost-cli --serve"}},
+		Providers: map[string]config.ProviderSpec{
+			"ghost": {Command: "ghost-cli"},
+		},
+	}
+	r := NewProviderPathCheck(cfg, failLookPath).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v (%s), want OK", r.Status, r.Message)
+	}
+}
+
+// TestProviderPathCheck_ChecksWorkspaceDefaultWithoutAgents covers the fresh
+// city: workspace.provider is set, the agents have not arrived yet, and the
+// default still has to resolve before the first template can start.
+func TestProviderPathCheck_ChecksWorkspaceDefaultWithoutAgents(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "ghost"},
+		Providers: map[string]config.ProviderSpec{
+			"ghost": {Command: "ghost-cli"},
+		},
+	}
+	r := NewProviderPathCheck(cfg, failLookPath).Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %v (%s), want Error", r.Status, r.Message)
+	}
+}
+
+// TestProviderPathCheck_IgnoresNonPathResolutionErrors keeps this check
+// single-purpose. An undeclared provider reference is a config fault that
+// config-refs and provider-catalog already report; repeating it here would
+// make one bad reference fail several checks and bury the PATH signal.
+func TestProviderPathCheck_IgnoresNonPathResolutionErrors(t *testing.T) {
+	cfg := &config.City{
+		Agents:    []config.Agent{{Name: "worker", Provider: "undeclared"}},
+		Providers: map[string]config.ProviderSpec{},
+	}
+	r := NewProviderPathCheck(cfg, failLookPath).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v (%s), want OK — unknown-provider is not this check's finding", r.Status, r.Message)
+	}
+}
+
+// TestProviderPathCheck_WarmupEligible pins the opt-in. `gc start` runs the
+// warm-up-eligible checks, and the reported symptom was a start that announced
+// success on a city that could not bring up a single session.
+func TestProviderPathCheck_WarmupEligible(t *testing.T) {
+	if !NewProviderPathCheck(providerPathCity(), okLookPath).WarmupEligible() {
+		t.Error("provider-path must run in the gc start warm-up scan")
+	}
+}
+
+func TestProviderPathCheck_CannotFix(t *testing.T) {
+	c := NewProviderPathCheck(providerPathCity(), failLookPath)
+	if c.CanFix() {
+		t.Error("CanFix() = true; installing a provider CLI is not the doctor's job")
+	}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Errorf("Fix() = %v, want nil", err)
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -341,6 +341,20 @@ const (
 	// the next episode fires independently. (ADR-0013 A1 M3a)
 	ProviderHealthGateAlert = "provider.health_gate_alert"
 
+	// ProviderUnresolved fires once per episode when the desired-state build
+	// drops one or more templates because a referenced provider's command is
+	// not on PATH. Carries the provider reference, the command that failed,
+	// the dropped-template count and sample, and the desired_session_count
+	// the drop produced.
+	//
+	// It exists because ob-woag found a city that came up completely empty
+	// with no record anywhere: `gc start` reported success, `gc doctor`
+	// passed, the reconciler trace showed desired_session_count=0 without
+	// naming a provider, and this log had nothing in it at all. Latched by
+	// the emitter (CityRuntime.reportUnresolvedProviders) because the
+	// underlying failure re-derives on every controller tick.
+	ProviderUnresolved = "provider.unresolved"
+
 	// Emergency events are dolt-independent escalation records written to
 	// .gc/emergency and mirrored into the city event log.
 	EmergencySignaled = "emergency.signaled"
@@ -439,11 +453,11 @@ var KnownEventTypes = []string{
 	StorageBindingConverged, StorageBindingGenesis,
 	StorageBindingUnconverged, StorageBindingUncheckable,
 	StorageBindingNotConfigured,
-	// ProviderHealthGateAlert is intentionally omitted from KnownEventTypes.
-	// The event is emitted by the reconciler but its typed SSE payload is not
-	// yet registered in internal/api (the payload registration lives in a
-	// follow-up that adds the full SSE projection). Until then, subscribers
-	// receive it via the custom-event envelope.
+	// ProviderHealthGateAlert and ProviderUnresolved are intentionally omitted
+	// from KnownEventTypes. Both are emitted by the reconciler but neither has
+	// a typed SSE payload registered in internal/api (the payload registration
+	// lives in a follow-up that adds the full SSE projection). Until then,
+	// subscribers receive them via the custom-event envelope.
 }
 
 // Event is a single recorded occurrence in the system.


### PR DESCRIPTION
## What happens today

On a host where a referenced provider binary is absent from PATH, gc drops every session using that provider from the desired state and no surface says so:

- `gc start` reports `City started under supervisor.`
- `gc status` shows the affected agents as `unknown (partial status)`
- `gc agent list` shows them `active`
- `gc doctor` passes 100 checks — none of which asks whether a configured provider's command exists
- the session-reconciler trace computes `desired_session_count=0`, and the string `provider` appears **zero** times in it
- `.gc/events.jsonl` has no provider error

The only command that names the cause is `gc session new <template>`:

```
gc session new: provider not found in PATH: provider "codex" command "codex"
```

That is the one command an operator has no reason to run when `gc start` has already claimed success. The city comes up completely empty and reports a clean start.

## Changes

**1. `config.ProviderNotInPATHError`** — the structured form of the existing `ErrProviderNotInPATH` sentinel, carrying the provider reference and the command as fields rather than only inside formatted text. Both new diagnostics need those two identifiers as data, which is why this is a type and not another `fmt.Errorf`.

`Error()` reproduces the previous layout byte for byte and `Unwrap()` returns `ErrProviderNotInPATH`, so every existing `errors.Is` check and message assertion keeps working.

**2. A `provider-path` doctor check** — every template a session can be built from must have a provider command that resolves on the host.

The neighboring provider checks stop short of this by design, so this is not duplication: `provider-catalog` checks that every referenced provider is *declared*; `provider-catalog-local-readiness` checks that locally-configured CLIs are listed explicitly; `provider-parity` inspects capability fields using a *stub* PATH lookup because it is auditing config semantics rather than the host. This check is the one that touches the host.

Reachability is "every configured agent template", not "every template with demand right now" — a pool template at `min_active_sessions = 0` is one routed bead away from needing its provider. Agents pinning `start_command` are skipped: they bypass `ProviderSpec` and `ResolveProvider` never consults PATH for them.

**3. The reconciler reports what it dropped** — the desired-state build accumulates PATH failures and the controller emits them to both the log and `.gc/events.jsonl`, with `desired_session_count` printed beside the cause. The reported symptom was a city that started clean and stayed empty, so the number that made it look normal belongs next to the reason it wasn't.

## Design notes for review

- **Grouped by provider.** One uninstalled binary shared by fifty agents reports once, with a dropped-template count and a capped sample of names, not fifty times.
- **The accumulator is held by pointer** on `agentBuildParams`. Several build paths take a value copy of that struct (`resolveTemplateForSessionBeadInfo` does `local := *bp` to scope a `beadNames` override), so a slice field would collect failures into whichever copy happened to see them and lose them at the seam. A mutex covers the pool-evaluation fan-out, which resolves templates from more than one goroutine.
- **The alert latches per episode.** The build re-derives the same failure on every tick and the cached demand snapshot replays it in between, so an unlatched version would write a line and an event every tick for as long as the binary stays uninstalled. Recovery clears the latch, so install-then-remove alerts a second time.
- **Only `ProviderNotInPATH` is recorded.** Unknown-provider and bad-option faults are already named by the `config-valid` / `config-refs` / `provider-catalog` checks; folding them in here would dilute the one signal this carries.

## Verification

```
go build ./...                                                   OK
go vet ./cmd/gc/ ./internal/doctor/ ./internal/config/ ./internal/events/   OK
golangci-lint run --new-from-merge-base=origin/main --whole-files           0 issues
go test ./cmd/gc/                                                ok (306s)
go test ./internal/doctor/ ./internal/config/ ./internal/events/ ok
```

`cmd/gc/testdata/doctor_check_names.golden` gains `provider-path` in registration order. Rebased onto current `main` and the full gate re-run after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnYmK2nvdxwSKsG45LvinA
