### PR TITLE
fix(cmd/gc): skip dispatch-held siblings in continuation pre-assignment (#6026)

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -1216,7 +1216,13 @@ func preassignHookContinuationGroup(bead beads.Bead, opts hookClaimOptions, ops 
 			sibling.ID == bead.ID ||
 			strings.TrimSpace(sibling.Assignee) != "" ||
 			!strings.EqualFold(strings.TrimSpace(sibling.Status), "open") ||
-			!hookClaimMatchesRoute(sibling, opts.RouteTargets) {
+			!hookClaimMatchesRoute(sibling, opts.RouteTargets) ||
+			// Pre-assignment is a decision about what to DO with a bead, and a
+			// canonical dispatch hold (beadmeta.DispatchHoldLabels) means the
+			// sibling's required next actor is, by construction, not this
+			// claimant — mirrors isHeldHookCandidate in cmd_hook.go, the same
+			// check on the JSON-decoded work-query shape (gas-kg6, #6026).
+			beadCarriesDispatchHoldLabel(sibling.Labels) {
 			continue
 		}
 		if err := ops.AssignContinuation(ctx, dir, opts.Env, sibling.ID, pinAssignee); err != nil {
@@ -1225,6 +1231,23 @@ func preassignHookContinuationGroup(bead beads.Bead, opts hookClaimOptions, ops 
 		assigned = append(assigned, sibling.ID)
 	}
 	return assigned, nil
+}
+
+// beadCarriesDispatchHoldLabel reports whether labels contains a canonical
+// dispatch hold value (beadmeta.DispatchHoldLabels), compared case-insensitively.
+// Mirrors isHeldHookCandidate's comparison logic (cmd_hook.go) but operates
+// directly on beads.Bead's Labels []string instead of that function's
+// JSON-decoded map[string]any/[]any shape.
+func beadCarriesDispatchHoldLabel(labels []string) bool {
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		for _, hold := range beadmeta.DispatchHoldLabels {
+			if strings.EqualFold(label, hold) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func hookClaimWithBdStore(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {

--- a/cmd/gc/cmd_hook_claim_test.go
+++ b/cmd/gc/cmd_hook_claim_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
@@ -318,6 +319,55 @@ func TestPreassignHookContinuationGroupPinsSiblingsToSessionID(t *testing.T) {
 			}
 			want := []string{tc.wantAssignee, tc.wantAssignee}
 			if !reflect.DeepEqual(gotAssignees, want) {
+				t.Fatalf("pinned assignees = %#v, want %#v", gotAssignees, want)
+			}
+		})
+	}
+}
+
+// TestPreassignHookContinuationGroupSkipsHeldSiblings is the #6026 regression:
+// a continuation sibling carrying a canonical dispatch hold label
+// (beadmeta.DispatchHoldLabels) must never be pre-assigned to the claimant,
+// even when otherwise eligible (open, unassigned, route-matching). Pinning an
+// agent's name onto a bead deliberately parked hold:mayor/hold:external
+// contradicts the hold contract: the required next actor is, by construction,
+// not this session.
+func TestPreassignHookContinuationGroupSkipsHeldSiblings(t *testing.T) {
+	for _, label := range beadmeta.DispatchHoldLabels {
+		t.Run(label, func(t *testing.T) {
+			claimed := beads.Bead{
+				ID:       "work-1",
+				Status:   "in_progress",
+				Metadata: map[string]string{"gc.kind": "workflow", "gc.root_bead_id": "root-1", "gc.continuation_group": "group-a", "gc.run_target": "route-1"},
+			}
+			var gotAssignees []string
+			var assignedIDs []string
+			opts := hookClaimOptions{Assignee: "worker-1", RouteTargets: []string{"route-1"}}
+			ops := hookClaimOps{
+				ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+					return []beads.Bead{
+						{ID: "sib-held", Status: "open", Metadata: claimed.Metadata, Labels: []string{label}},
+						{ID: "sib-open", Status: "open", Metadata: claimed.Metadata},
+					}, nil
+				},
+				AssignContinuation: func(_ context.Context, _ string, _ []string, beadID, assignee string) error {
+					assignedIDs = append(assignedIDs, beadID)
+					gotAssignees = append(gotAssignees, assignee)
+					return nil
+				},
+			}
+
+			assigned, err := preassignHookContinuationGroup(claimed, opts, ops, ".")
+			if err != nil {
+				t.Fatalf("preassignHookContinuationGroup() error = %v", err)
+			}
+			if want := []string{"sib-open"}; !reflect.DeepEqual(assigned, want) {
+				t.Fatalf("REGRESSION #6026: assigned = %#v, want %#v (held sibling must be skipped, non-held sibling must still be assigned)", assigned, want)
+			}
+			if want := []string{"sib-open"}; !reflect.DeepEqual(assignedIDs, want) {
+				t.Fatalf("REGRESSION #6026: AssignContinuation called for %#v, want %#v; held sibling must never reach the assign mutation", assignedIDs, want)
+			}
+			if want := []string{"worker-1"}; !reflect.DeepEqual(gotAssignees, want) {
 				t.Fatalf("pinned assignees = %#v, want %#v", gotAssignees, want)
 			}
 		})


### PR DESCRIPTION
## What

Closes #6026. `preassignHookContinuationGroup` pins every open, unassigned, route-matching continuation sibling to the claimant when a pool worker claims any bead in a formula-declared continuation group. It never checked `beadmeta.DispatchHoldLabels`, so a sibling deliberately parked `hold:mayor`/`hold:external` — meaning its required next actor is, by construction, not this session — still got an agent's name written into its `assignee` field. This contradicts the repo's own documented hold-label contract, which every other serve/demand path already enforces: "filter on holds when deciding what to DO, never when deciding who EXISTS."

## Fix — scoped to fix candidate A only (the issue's own stated minimum)

Added `beadCarriesDispatchHoldLabel(labels []string) bool`, mirroring the comparison logic of the existing `isHeldHookCandidate` (`cmd_hook.go`) but operating directly on `beads.Bead.Labels []string` rather than that function's JSON-decoded `map[string]any`/`[]any` shape (a different data type than what `preassignHookContinuationGroup` has on hand, so the existing function couldn't be reused as-is). Wired into the pre-assignment loop's skip condition alongside the existing empty-id/self/already-assigned/not-open/route-mismatch checks.

New test proves both the fix and no over-filtering: for each hold-label value, a sibling carrying that label is excluded from the returned `assigned` slice and `AssignContinuation` is never called for it, while a second, otherwise-identical, non-held sibling in the same fixture is still assigned.

**Deliberately not implemented**, per the issue's own framing that candidate A alone fully fixes the reported bug:
- **Candidate B** (the same check, plus `beads.IsReadyExcludedType`, added to `claimFirstReadyHookAssignment` as defense-in-depth for the promote-and-serve tier) — a separate, additional seam, not the one that leaked in this report.
- **Candidate C** (skipping `step.Type == "gate"` in `graphroute.go`'s decoration loop) — the issue itself flags this as changing routing metadata on every existing graph.v2 workflow with a gate, a separate concern with its own migration note needed.

## Validation

- `go build -tags gms_pure_go ./...` clean
- `go test -tags gms_pure_go ./cmd/gc/... -run TestPreassignHookContinuationGroup` — all pass including the new `TestPreassignHookContinuationGroupSkipsHeldSiblings` (both `hold:mayor` and `hold:external` subtests)
- Full local push-gate run: all failures across every shard and `unit-core` confirmed to be pre-existing environmental/timing flakes (dolt-compaction timeouts, detached-probe/systemctl-delegate/lsof tests, interrupt-timing tests) unrelated to this change — none touch `cmd/gc/cmd_hook_claim.go`
- Pre-commit lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)