### PR TITLE
fix(residency): re-key infra_class_migrate.go's ReservedClassPrefix row to infraBindingIDPrefix after #5597 (unblocks the pre-push gate)

### DIFF
--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -60,6 +60,15 @@
 # declaring vocabulary counts as mentioning it, and the row still moves if the
 # declaration is renamed. "Hits" here means mentions, not call sites.
 #
+# infra_class_migrate.go's row is keyed to infraBindingIDPrefix, not to
+# openInfraDestination, since #5597 extracted the prefix derivation into that
+# helper (openInfraDestination and openInfraBindingReadOnly both consume it).
+# It is the same single ReservedClassPrefix site re-keyed to the function that
+# now opens it — a census move, not growth: the file still has one hit. Whether
+# the helper should consume internal/storeref instead of deriving the prefix is
+# #5597's author's call; this row only stops the ratchet reading a moved site
+# as a new one (ga-zohuic).
+#
 # The two internal/dispatch/drain.go rows arrived when the signature rule
 # widened from cmd/gc+internal/api to every directory grep already scanned. The
 # comment that justified the narrower set claimed sling and dispatch held no
@@ -185,7 +194,7 @@ cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	ast:returns-store-list
 cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	c:beads.Store-literal	3
 cmd/gc/doctor_order_tracking_retention.go	Run	c:beads.Store-literal	1
 cmd/gc/formula_cook_attach_class.go	attachGraftClassRefusal	b:graphClassBinding	1
-cmd/gc/infra_class_migrate.go	openInfraDestination	d:ReservedClassPrefix	1
+cmd/gc/infra_class_migrate.go	infraBindingIDPrefix	d:ReservedClassPrefix	1
 cmd/gc/order_dispatch.go	gateStoresFor	ast:returns-store-list	1
 cmd/gc/order_dispatch.go	gateStoresFor	c:beads.Store-literal	1
 cmd/gc/order_store.go	appendOrdersSweepStore	ast:returns-store-list	1


### PR DESCRIPTION
## What

Re-keys one row of `scripts/residency-boundary-baseline.txt`: `cmd/gc/infra_class_migrate.go`'s single `config.ReservedClassPrefix` site is now attributed to `infraBindingIDPrefix`, the helper #5597 extracted it into, instead of `openInfraDestination`, the function it used to live in. The header prose beside the row says why. No Go code changes.

## Why

Since #5597 merged (fc7a23a292, 2026-09-05 08:28 PDT) `TestResidencyBoundaryGrepRatchet` fails on `main` itself:

```
RESIDENCY-BOUNDARY: cmd/gc/infra_class_migrate.go infraBindingIDPrefix d:ReservedClassPrefix: 1 sites, baseline 0 — a NEW store-enumeration site.
RESIDENCY-BOUNDARY: cmd/gc/infra_class_migrate.go openInfraDestination d:ReservedClassPrefix: 0 sites, baseline 1 — shrink the baseline in the same commit that retires a site.
```

That test runs in the pre-push gate, so it has refused every push to this repo from every agent and human here since then. Reproduced in a clean worktree at fc7a23a292 with no other changes (ga-zohuic).

## Why a census move and not an allowance

The file still has exactly one `ReservedClassPrefix` hit; #5597 moved it into a helper (now consumed by `openInfraDestination` and `openInfraBindingReadOnly`). The ratchet keys rows by function, so a moved site reads as one growth row plus one shrink row. Re-keying the row describes the tree as it is and keeps the site pinned at 1, shrink-only from here, with no `// residency:allow` marker in the code.

Whether `infraBindingIDPrefix` should consume `internal/storeref` instead of deriving the prefix is #5597's author's call and is deliberately left open (comment on #5597, 2026-09-05 10:20 PDT). This is an unblock, not that decision.

## Evidence

- `bash scripts/check-residency-boundary.sh` exits 0 on the branch.
- `go test ./scripts -run 'TestResidency'` passes (ratchet, resolver boundary, AST ratchet, halves-agree).
- Rows re-sorted check: `grep -v '^#' scripts/residency-boundary-baseline.txt | LC_ALL=C sort -c` is silent.
- The baseline was edited by hand, not regenerated, so the three-emitter splice hazard the header warns about does not apply.
- The pre-push hook did **not** run on this push: the scratch clone it was pushed from had no `core.hooksPath` configured (since fixed on that clone). For a new branch the hook runs `make test-fast-parallel`; that job was run by hand on the branch afterwards and its result is posted in the first comment below.

Refs ga-zohuic (P1). Unblocks ga-451jnv's committed fix.
