### PR TITLE
fix(residency): re-key the infra_class_migrate baseline row the s4/s8 squashes left disagreeing

### DIFF
--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -185,7 +185,7 @@ cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	ast:returns-store-list
 cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	c:beads.Store-literal	3
 cmd/gc/doctor_order_tracking_retention.go	Run	c:beads.Store-literal	1
 cmd/gc/formula_cook_attach_class.go	attachGraftClassRefusal	b:graphClassBinding	1
-cmd/gc/infra_class_migrate.go	openInfraDestination	d:ReservedClassPrefix	1
+cmd/gc/infra_class_migrate.go	infraBindingIDPrefix	d:ReservedClassPrefix	1
 cmd/gc/order_dispatch.go	gateStoresFor	ast:returns-store-list	1
 cmd/gc/order_dispatch.go	gateStoresFor	c:beads.Store-literal	1
 cmd/gc/order_store.go	appendOrdersSweepStore	ast:returns-store-list	1


### PR DESCRIPTION
## What

`main` is red on the residency boundary guard. This re-keys one baseline
row. No Go code changes.

## The failure

On `origin/main` at `fc7a23a292` (verified on an untouched export),
`./scripts/check-residency-boundary.sh` exits 1 with a matched grow/shrink
pair on a single file:

```
RESIDENCY-BOUNDARY: cmd/gc/infra_class_migrate.go infraBindingIDPrefix d:ReservedClassPrefix: 1 sites, baseline 0 — a NEW store-enumeration site. Consume internal/storeref (Plan/ResolveOwner/Union) or annotate the line with `// residency:allow <reason>`.
RESIDENCY-BOUNDARY: cmd/gc/infra_class_migrate.go openInfraDestination d:ReservedClassPrefix: 0 sites, baseline 1 — the baseline must SHRINK in the same commit that retires a site. Follow the regeneration procedure in the header of scripts/residency-boundary-baseline.txt; do NOT redirect --emit-baseline over that file, it emits this half' rows only.
```

After this PR:

```
$ ./scripts/check-residency-boundary.sh; echo $?
0
$ ./scripts/check-residency-boundary.sh --self-test; echo $?
0
```

## Why it broke: two squashes, one minute apart

Neither PR added a blind reader. The census key the guard pins is
`(path, function, pattern)`, so moving a call between functions **in the
same file** re-keys the row even when the call itself is untouched — and
the guard reports that as a simultaneous grow and shrink.

- **#5643 (s4, squash `7746bbe5ab`, merged 15:27Z)** stopped allowlisting
  `cmd/gc/infra_class_migrate.go` and pinned its single
  `config.ReservedClassPrefix` call in the baseline, attributed to
  `openInfraDestination` — the function that held it on that PR's base.
- **#5597 (s8, squash `fc7a23a292`, merged 15:28Z, one minute later)** had
  already extracted that call into a new helper, `infraBindingIDPrefix`,
  on **its** base.

Each PR was green against the base it was tested on. The merged result is
s4's baseline row describing a function layout s8 had replaced. Nothing in
either change is wrong; the two squashes simply disagree about where the
call lives.

## The fix

The file still makes exactly one hit, in exactly one function
(`infraBindingIDPrefix`, `cmd/gc/infra_class_migrate.go:594`), so the fix
is the baseline row, not the code:

```diff
-cmd/gc/infra_class_migrate.go	openInfraDestination	d:ReservedClassPrefix	1
+cmd/gc/infra_class_migrate.go	infraBindingIDPrefix	d:ReservedClassPrefix	1
```

That is the **entire** diff: 114 rows before, 114 after, no other row
moves and none drops, so the shrink-only ratchet is not loosened. The
header prose that pins these rows — "Six rows, six hits" across
`residency_topology.go`, `infra_class_migrate.go` and `cmd_storage.go` —
still counts correctly (4 + 1 + 1), and no header block names the
function by spelling, so no prose changes with the row.

Regenerated by the documented three-emitter splice in the baseline's own
header, not by redirecting `--emit-baseline` over the file (which would
have dropped the two AST halves and the hand-written header): the shell
half with its four `# PARTIAL:` warning lines dropped, plus both
`RESIDENCY_BASELINE_EMIT=1 go test ./scripts` emitters filtered with
`awk -F'\t' 'NF==4'` to strip the harness chatter, concatenated and put
through one `LC_ALL=C sort`.

## Gates

| command | exit |
| --- | --- |
| `./scripts/check-residency-boundary.sh` | 0 |
| `./scripts/check-residency-boundary.sh --self-test` | 0 |
| `go test ./scripts/... -count=1` (AST ratchet) | 0 — `ok` |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `make check-docs` | 0 |
| `make test-fast-parallel` | 0 — `All fast jobs passed` |

Refs ga-j4p3y
