### PR TITLE
fix(cmd/gc): reopen-source also reopens tracking convoys (#6045)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
@@ -2120,6 +2121,7 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			return err
 		}
 		_, _ = fmt.Fprintf(stdout, "result=reopened source_bead_id=%s\n", sourceBeadID)
+		reopenTrackingConvoysForReopenedSource(target.storeView.store, currentSource.ID, stdout, stderr)
 		return nil
 	})
 	if runErr != nil {
@@ -2127,6 +2129,43 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		return 1
 	}
 	return resultCode
+}
+
+// reopenTrackingConvoysForReopenedSource is the mirror image of
+// autocloseConvoyIfComplete on the reopen side of ga-6045: closing a convoy
+// via autoclose only fires once every tracked child has reached a terminal
+// status, but nothing previously reversed that when a caller later reopened
+// one of those children through `gc workflow reopen-source`. A closed convoy
+// could then sit invisible to `gc convoy check` (its listing query excludes
+// closed convoys) for an entire second work cycle on a child it no longer
+// accurately describes as done.
+//
+// This covers only the reopen-source path. It intentionally does not touch
+// `bd update --status open` or the REST `/bead/{id}/reopen` route, which can
+// reopen a tracked child the same way and remain exposed to the same staleness
+// (see gascity#6045 for the fuller discussion and the other two candidate
+// fixes this deliberately leaves out of scope).
+//
+// Best-effort by design: sourceID's own reopen has already succeeded and been
+// reported by the time this runs, so a lookup or convoy-update failure here is
+// surfaced as a warning rather than failing the overall command.
+func reopenTrackingConvoysForReopenedSource(store beads.Store, sourceID string, stdout, stderr io.Writer) {
+	convoys, err := convoycore.TrackingConvoysForItem(store, sourceID)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "warning: gc workflow reopen-source: listing tracking convoys for %s: %v\n", sourceID, err)
+		return
+	}
+	open := "open"
+	for _, convoy := range convoys {
+		if convoy.Type != "convoy" || !convoycore.IsTerminalStatus(convoy.Status) || hasLabel(convoy.Labels, "owned") {
+			continue
+		}
+		if err := store.Update(convoy.ID, beads.UpdateOpts{Status: &open}); err != nil {
+			_, _ = fmt.Fprintf(stderr, "warning: gc workflow reopen-source: reopening tracking convoy %s: %v\n", convoy.ID, err)
+			continue
+		}
+		_, _ = fmt.Fprintf(stdout, "result=reopened_tracking_convoy convoy_id=%s source_bead_id=%s\n", convoy.ID, sourceID)
+	}
 }
 
 // findWorkflowBeads returns all beads belonging to a workflow resolved by

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/coordclass"
 	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/events"
@@ -1386,6 +1387,132 @@ func TestCmdWorkflowReopenSourcePreservesRouteWithoutRunTarget(t *testing.T) {
 	}
 	if updated.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty", updated.Assignee)
+	}
+}
+
+// TestCmdWorkflowReopenSourceReopensTrackingConvoy is the regression test for
+// gascity#6045: autocloseConvoyIfComplete closes a convoy once every tracked
+// child reaches a terminal status, but nothing reversed that when a tracked
+// child was later reopened through `gc workflow reopen-source`. The convoy
+// then stayed closed — and invisible to `gc convoy check`, whose listing
+// query excludes closed convoys — across an entire second work cycle on a
+// child it no longer accurately described as done.
+func TestCmdWorkflowReopenSourceReopensTrackingConvoy(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	convoy, err := store.Create(beads.Bead{Title: "batch", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("Create(convoy): %v", err)
+	}
+	requireNoError(t, store.DepAdd(convoy.ID, source.ID, convoycore.TrackingDepType))
+	// Simulate autoclose having already fired: the convoy closed while its
+	// only tracked child (source) was terminal.
+	requireNoError(t, store.Close(convoy.ID))
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=reopened source_bead_id="+source.ID) {
+		t.Fatalf("stdout = %q, want reopened result for source", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "result=reopened_tracking_convoy convoy_id="+convoy.ID) {
+		t.Fatalf("stdout = %q, want reopened_tracking_convoy result for convoy %s", stdout.String(), convoy.ID)
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updatedSource, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if updatedSource.Status != "open" {
+		t.Fatalf("source status = %q, want open", updatedSource.Status)
+	}
+	updatedConvoy, err := reloaded.Get(convoy.ID)
+	if err != nil {
+		t.Fatalf("Get(convoy): %v", err)
+	}
+	if updatedConvoy.Status != "open" {
+		t.Fatalf("convoy status = %q, want open (tracking convoy should reopen alongside its child)", updatedConvoy.Status)
+	}
+}
+
+// TestCmdWorkflowReopenSourceLeavesOwnedTrackingConvoyClosed mirrors the
+// "owned" exemption autocloseConvoyIfComplete itself respects: an
+// owned-labeled convoy's lifecycle is managed manually, so reopening a
+// tracked child must not reopen it automatically.
+func TestCmdWorkflowReopenSourceLeavesOwnedTrackingConvoyClosed(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	convoy, err := store.Create(beads.Bead{Title: "owned batch", Type: "convoy", Labels: []string{"owned"}})
+	if err != nil {
+		t.Fatalf("Create(convoy): %v", err)
+	}
+	requireNoError(t, store.DepAdd(convoy.ID, source.ID, convoycore.TrackingDepType))
+	requireNoError(t, store.Close(convoy.ID))
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "result=reopened_tracking_convoy") {
+		t.Fatalf("stdout = %q, want no reopened_tracking_convoy line for an owned convoy", stdout.String())
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updatedSource, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if updatedSource.Status != "open" {
+		t.Fatalf("source status = %q, want open", updatedSource.Status)
+	}
+	updatedConvoy, err := reloaded.Get(convoy.ID)
+	if err != nil {
+		t.Fatalf("Get(convoy): %v", err)
+	}
+	if updatedConvoy.Status != "closed" {
+		t.Fatalf("convoy status = %q, want closed (owned convoy lifecycle is manual)", updatedConvoy.Status)
 	}
 }
 


### PR DESCRIPTION
## What

`autocloseConvoyIfComplete` closes a convoy once every tracked child reaches terminal status — correct at the instant it fires — but nothing ever reversed that when a tracked child was later reopened. The invariant "a closed convoy has no non-terminal tracked child" rotted the moment anyone reopened a child, and `gc convoy check` can't heal it: its listing query excludes closed convoys entirely.

Field evidence: 44 closed convoys on one production city currently have a non-terminal tracked child. Concrete instance: convoy `cr-b4i4a` closed via autoclose, its tracked child `cr-692as` was reopened via `gc convoy reopen-source`, worked, and re-closed — the convoy stayed closed and invisible to `convoy check` across the entire second work cycle.

Fixes #6045.

## Fix — deliberately partial, scope disclosed up front

`cmdWorkflowReopenSource` now calls a new `reopenTrackingConvoysForReopenedSource` right after it reopens the source bead: looks up tracking convoys via the existing `convoycore.TrackingConvoysForItem`, and reopens each one that is type `"convoy"`, currently terminal, and not labeled `"owned"` — the same exemption `autocloseConvoyIfComplete` itself respects. The convoy-side reopen only sets `Status`, leaving `Assignee` untouched, mirroring how the existing close path never touches `Assignee` either. Convoy lookup/reopen failures are best-effort: reported as stderr warnings, never fatal to the overall command, since the source bead's own reopen has already succeeded by that point.

This is the smallest, lowest-risk of three fix candidates considered, chosen deliberately over the other two — not because it's the complete answer:

- **Covered:** the `gc convoy reopen-source` CLI path only.
- **Not covered, and known-vulnerable to the identical bug after this fix:** plain `bd update --status open` and the REST `POST /bead/{id}/reopen` route — both can reopen a tracked child the same way and remain exposed.
- **Not attempted:** repairing the existing 44-row production backlog. This fix only prevents new instances via this one path; already-stale convoys stay stale.
- **Not attempted:** a symmetric `bead.updated`-driven reopen hook in the controller's event-handling path — a live, high-volume event-consumer change in production controller code, out of scope for a same-day fix.
- **Not attempted:** making `gc convoy check` self-healing via an `IncludeClosed` batch scan (which would also repair the backlog) — a separate, larger surface.

## Testing

`go build -tags gms_pure_go ./...` clean. `go test -tags gms_pure_go ./cmd/gc/... -run TestCmdWorkflowReopenSource` — all 7 pass, including two new tests:
- `TestCmdWorkflowReopenSourceReopensTrackingConvoy` — proves a closed convoy tracking the reopened source is reopened alongside it.
- `TestCmdWorkflowReopenSourceLeavesOwnedTrackingConvoyClosed` — proves an `owned`-labeled tracking convoy is correctly left closed.

Full local push-gate run: all failures match this session's known-unrelated environmental cluster, plus one governance-baseline test (`TestResidencyBoundaryGrepRatchet`) independently confirmed to fail identically on stock `main` — pre-existing drift unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)