### PR TITLE
perf(reconciler): memoize the orphan-release liveness probe per store

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -196,6 +196,22 @@ func releaseOrphanedPoolAssignments(
 		log.Printf("releaseOrphanedPoolAssignments: assigned work/store-ref length mismatch: work=%d storeRefs=%d", len(assignedWorkBeads), len(assignedWorkStoreRefs))
 	}
 
+	// The live gc:session listing inside liveOpenSessionAssignmentExists carries
+	// no assignee filter — it lists every session bead in the store and compares
+	// identities in Go — so its answer depends only on (store, assignee), and it
+	// cannot change while this sweep runs: the sweep writes WORK beads, never
+	// session beads. Memoize it per store so the cost is O(distinct assignees)
+	// live round-trips instead of O(assigned work beads).
+	//
+	// MEASURED on gc-management 2026-09-05 (ga-451jnv): 68-69 assigned work beads
+	// across 18 distinct assignees re-issued this listing once per bead per store,
+	// costing 645-725s per reconcile tick against a 30s patrol interval — and
+	// releasing 0 beads on every one of those ticks. buildDesiredState runs once
+	// per tick, so that phase alone bounded on-demand named-session wake latency
+	// at ~14 minutes.
+	sessionStoreLiveAssignee := make(map[string]bool, len(assignedWorkBeads))
+	ownerStoreLiveAssignee := make(map[string]bool, len(assignedWorkBeads))
+
 	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, store, openSessionInfos, storeRefAware)
 	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionInfos)*5)
 	for _, info := range openSessionInfos {
@@ -243,7 +259,7 @@ func releaseOrphanedPoolAssignments(
 			if assigneePreservesNamedSessionRoute(cfg, cityPath, template, assignee, workStoreRef, storeRefAware) {
 				continue
 			}
-			if liveOpenSessionAssignmentExists(sessionStore.Store, assignee) {
+			if memoizedLiveOpenSessionAssignmentExists(sessionStoreLiveAssignee, assignee, sessionStore.Store, assignee) {
 				continue
 			}
 			// The sessions binding is not the only ledger that can hold a session
@@ -254,8 +270,26 @@ func releaseOrphanedPoolAssignments(
 			// claims. A session bead of that shape lives in the work bead's own
 			// owner store, so probing that one store after the sessions store
 			// misses closes the gap without enumerating every attached store.
-			if ownerStore != nil && liveOpenSessionAssignmentExists(ownerStore, assignee) {
-				continue
+			// ownerStore varies per bead, so the memo key must name the store.
+			// assignedWorkStoreRefs is the index-aligned ref the caller already
+			// uses to scope readiness (storeScopedBeadKey), but it only IDENTIFIES
+			// the store when assignedWorkStores is what ownerStore came from: both
+			// slices are index-aligned to the same leg, so equal refs mean the same
+			// leg. Without that slice assignedWorkOwnerStore falls back to routing
+			// each bead through storeForPoolAssignment(wb), and two beads sharing a
+			// ref can then resolve to DIFFERENT stores — collapsing them onto one
+			// cached answer could release a live holder's claim. Require both, and
+			// leave the fallback unmemoized rather than risk that.
+			if ownerStore != nil {
+				live := false
+				if storeAware && storeRefAware {
+					live = memoizedLiveOpenSessionAssignmentExists(ownerStoreLiveAssignee, workStoreRef+"\x00"+assignee, ownerStore, assignee)
+				} else {
+					live = liveOpenSessionAssignmentExists(ownerStore, assignee)
+				}
+				if live {
+					continue
+				}
 			}
 		}
 
@@ -752,6 +786,26 @@ func liveOpenSessionAssignmentExists(store beads.Store, assignee string) bool {
 		}
 	}
 	return false
+}
+
+// memoizedLiveOpenSessionAssignmentExists caches liveOpenSessionAssignmentExists
+// under a caller-supplied key for the duration of one orphan-release sweep.
+//
+// The underlying probe's expensive arm is an assignee-independent live listing of
+// every session bead in the store, so repeating it for each work bead is pure
+// redundant I/O against the store the reconciler is already blocked on. The key
+// must identify the store as well as the assignee wherever more than one store is
+// probed; a caller with no stable store identifier must call the unmemoized form.
+func memoizedLiveOpenSessionAssignmentExists(memo map[string]bool, key string, store beads.Store, assignee string) bool {
+	if memo == nil {
+		return liveOpenSessionAssignmentExists(store, assignee)
+	}
+	if cached, ok := memo[key]; ok {
+		return cached
+	}
+	live := liveOpenSessionAssignmentExists(store, assignee)
+	memo[key] = live
+	return live
 }
 
 func liveSessionBeadExistsByIdentity(store beads.Store, assignee string) bool {

--- a/cmd/gc/pool_session_name_orphan_release_fanout_test.go
+++ b/cmd/gc/pool_session_name_orphan_release_fanout_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// countingLiveSessionListStore counts the live gc:session listings issued
+// against it. That query — beads.ListQuery{Label: sessionBeadLabel, Live: true}
+// in liveOpenSessionAssignmentExists (cmd/gc/pool_session_name.go) — carries no
+// assignee filter: it lists every session bead in the store and the caller then
+// compares assignees in Go. Its result is therefore invariant across the
+// per-work-bead loop in releaseOrphanedPoolAssignments, so counting it measures
+// redundant round-trips directly.
+type countingLiveSessionListStore struct {
+	beads.Store
+	liveSessionLists int
+}
+
+func (s *countingLiveSessionListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Live && query.Label == sessionBeadLabel {
+		s.liveSessionLists++
+	}
+	return s.Store.List(query)
+}
+
+// countOrphanReleaseLiveSessionLists runs one orphan-release sweep over
+// workBeadCount beads that all share a single assignee owning no live session
+// bead, and returns how many live gc:session listings the sweep issued.
+//
+// The fixture mirrors the production call shape: assignedWorkStoreRefs is
+// index-aligned with the work beads (storeRefAware), which is what
+// collectAssignedWorkBeadsWithStores always produces.
+func countOrphanReleaseLiveSessionLists(t *testing.T, workBeadCount int) int {
+	t.Helper()
+
+	mem := beads.NewMemStore()
+	store := &countingLiveSessionListStore{Store: mem}
+
+	var work []beads.Bead
+	var stores []beads.Store
+	var storeRefs []string
+	for i := 0; i < workBeadCount; i++ {
+		b, err := mem.Create(beads.Bead{
+			Title:    fmt.Sprintf("orphaned pool work %d", i),
+			Assignee: "worker-dead",
+			Metadata: map[string]string{"gc.routed_to": "worker"},
+		})
+		if err != nil {
+			t.Fatalf("Create work bead %d: %v", i, err)
+		}
+		if err := mem.Update(b.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+			t.Fatalf("Set work status %d: %v", i, err)
+		}
+		b, err = mem.Get(b.ID)
+		if err != nil {
+			t.Fatalf("Reload work bead %d: %v", i, err)
+		}
+		work = append(work, b)
+		stores = append(stores, store)
+		storeRefs = append(storeRefs, "")
+	}
+
+	releaseOrphanedPoolAssignments(
+		store,
+		beads.SessionStore{Store: store},
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		work,
+		stores,
+		storeRefs,
+		nil,
+	)
+	return store.liveSessionLists
+}
+
+// TestReleaseOrphanedPoolAssignments_LiveSessionListsDoNotScaleWithWorkBeads
+// pins the cost of the orphan-release sweep to the store topology, not to the
+// size of the assigned-work snapshot.
+//
+// MEASURED on the live gc-management controller 2026-09-05 (ga-451jnv): the
+// bead_reconcile.release_orphaned_pool_assignments phase took 645-725s on four
+// consecutive reconcile ticks and released 0 beads every time — 79-86% of a
+// tick whose configured patrol interval is 30s. The snapshot held 68-69
+// assigned work beads across only 18 distinct assignees, and the sweep probes
+// two stores per bead, so the assignee-independent listing above was issued
+// ~138 times per tick against a loaded Dolt store.
+//
+// The observable cost is wake latency. buildDesiredState — which computes the
+// named-session demand that wakes a sleeping on_demand singleton — runs once per
+// tick, so a ~14-minute tick bounds wake latency at ~14 minutes no matter how
+// promptly the sling poke arrives.
+//
+// Asserting independence rather than an exact count is deliberate: the honest
+// invariant is "this listing does not repeat per work bead", which a fixed
+// magic number would not distinguish from a smaller-but-still-linear sweep.
+func TestReleaseOrphanedPoolAssignments_LiveSessionListsDoNotScaleWithWorkBeads(t *testing.T) {
+	const (
+		smallSnapshot = 4
+		largeSnapshot = 40
+	)
+
+	small := countOrphanReleaseLiveSessionLists(t, smallSnapshot)
+	large := countOrphanReleaseLiveSessionLists(t, largeSnapshot)
+
+	if large != small {
+		t.Fatalf("live gc:session listings scale with the work snapshot: %d beads -> %d listings, %d beads -> %d listings; "+
+			"want the same count for both. liveOpenSessionAssignmentExists issues an assignee-independent "+
+			"List{Label: sessionBeadLabel, Live: true}, and releaseOrphanedPoolAssignments calls it inside its "+
+			"per-bead loop (once for the sessions store, once for the work bead's owner store), making the sweep "+
+			"O(work beads) live store round-trips instead of O(distinct assignees) — 645-725s per reconcile tick "+
+			"on gc-management, releasing 0 beads (ga-451jnv)",
+			smallSnapshot, small, largeSnapshot, large)
+	}
+}
+
+// seedOrphanedWorkInStore creates an in_progress work bead assigned to "nux"
+// with no session bead anywhere in store — a genuinely orphaned claim.
+func seedOrphanedWorkInStore(t *testing.T, store beads.Store, title string) beads.Bead {
+	t.Helper()
+
+	work, err := store.Create(beads.Bead{
+		Title:    title,
+		Type:     "task",
+		Status:   "open",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	if work, err = store.Get(work.ID); err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+	return work
+}
+
+// TestReleaseOrphanedPoolAssignments_OwnerStoreMemoDoesNotCollapseDistinctStores
+// pins the safety property the owner-store memo rests on: its cached answer is
+// keyed by the work bead's store ref as well as the assignee, so two beads that
+// share an assignee but live in DIFFERENT stores are still judged independently.
+//
+// The memo is sound only because liveOpenSessionAssignmentExists is
+// assignee-independent *per store* (see the fanout test above), which makes
+// (store, assignee) — not assignee alone — the correct key.
+// collectAssignedWorkBeadsWithStores appends assignedWorkStores[i] and
+// assignedWorkStoreRefs[i] from the same census leg ("the city work store under
+// the empty store-ref, the serving rigs under their names, then every relocated
+// class binding under its own class:* ref", build_desired_state.go), so equal
+// refs do mean the same store. This test keeps that invariant load-bearing
+// rather than incidental.
+//
+// Both collapse directions are claim-level bugs, which is why this asserts the
+// exact released set rather than a count: cache the live answer for the dead
+// store and a genuinely orphaned claim is stranded forever; cache the dead
+// answer for the live store and a live holder's claim is released underneath it
+// — the claim loss ga-g3pf0 and #5242 exist to prevent.
+func TestReleaseOrphanedPoolAssignments_OwnerStoreMemoDoesNotCollapseDistinctStores(t *testing.T) {
+	// Serves no session beads, so the sessions-store gate answers "dead" for
+	// both beads and the verdict falls to the owner-store probe under test.
+	sessionsStore := beads.NewMemStore()
+
+	liveStore := beads.NewMemStore() // a live session bead for "nux", plus its work
+	deadStore := beads.NewMemStore() // work only — "nux" holds no session here
+
+	liveWork := seedOwnerStoreReleaseFixture(t, liveStore, liveStore, "open")
+	deadWork := seedOrphanedWorkInStore(t, deadStore, "orphaned claim in a second store")
+
+	// Run both orderings: a memo populated by the live bead first must not leak
+	// into the dead bead's verdict, and vice versa.
+	for _, tc := range []struct {
+		name  string
+		work  []beads.Bead
+		store []beads.Store
+		refs  []string
+	}{
+		{"live first", []beads.Bead{liveWork, deadWork}, []beads.Store{liveStore, deadStore}, []string{"rig-live", "rig-dead"}},
+		{"dead first", []beads.Bead{deadWork, liveWork}, []beads.Store{deadStore, liveStore}, []string{"rig-dead", "rig-live"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Re-seed so each ordering starts from the same claim state.
+			if err := liveStore.Update(liveWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress"), Assignee: stringPtr("nux")}); err != nil {
+				t.Fatalf("restore live claim: %v", err)
+			}
+			if err := deadStore.Update(deadWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress"), Assignee: stringPtr("nux")}); err != nil {
+				t.Fatalf("restore dead claim: %v", err)
+			}
+
+			released := releaseOrphanedPoolAssignments(
+				sessionsStore,
+				beads.SessionStore{Store: sessionsStore},
+				testPoolReleaseConfig(),
+				"",
+				nil,
+				tc.work,
+				tc.store,
+				tc.refs,
+				nil,
+			)
+
+			var releasedIDs []string
+			for _, r := range released {
+				releasedIDs = append(releasedIDs, r.ID)
+			}
+			if len(releasedIDs) != 1 || releasedIDs[0] != deadWork.ID {
+				t.Fatalf("released %v, want exactly [%s] — the owner-store liveness memo collapsed two distinct "+
+					"stores onto one answer. liveOpenSessionAssignmentExists is assignee-independent per store, so "+
+					"its memo key must name the store (assignedWorkStoreRefs[i]) and not the assignee alone: %q holds "+
+					"a live session bead in one store and none in the other, and the two claims must be judged apart",
+					releasedIDs, deadWork.ID, "nux")
+			}
+			got, err := liveStore.Get(liveWork.ID)
+			if err != nil {
+				t.Fatalf("re-read the live holder's claim: %v", err)
+			}
+			if got.Status != "in_progress" || got.Assignee != "nux" {
+				t.Fatalf("the live holder's claim is status=%q assignee=%q, want in_progress/nux — a live claim was "+
+					"released from a cached verdict belonging to a different store", got.Status, got.Assignee)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this changes

`releaseOrphanedPoolAssignments` called `liveOpenSessionAssignmentExists` inside its per-work-bead loop — once for the sessions store, once for the work bead's owner store. That probe's expensive arm is a live `gc:session` listing carrying **no assignee filter**: it lists every session bead in the store and compares identities in Go. Its answer therefore depends only on `(store, assignee)` and cannot change while the sweep runs, because the sweep writes *work* beads, never *session* beads.

This memoizes the probe per store, so the cost is O(distinct assignees) live round-trips instead of O(assigned work beads).

## Why it matters

Measured on the live `gc-management` controller, one traced tick (`cycle-e253e5a702262a90`, 15:22:49Z–15:37:13Z):

```
cycle.finish                                     852987 ms
bead_reconcile_tick                              755922 ms
bead_reconcile.release_orphaned_pool_assignments 652753 ms  (76.5% of tick)
    released_count: 0
demand_snapshot.collect_assigned_work              2860 ms  beads: 69
```

69 assigned work beads x 2 probes = ~138 listings per tick, **releasing nothing**. Across 399 consecutive ticks the inter-tick gap ran min 43s / median 622s / mean 680s / max 2301s against a configured 30s patrol interval.

The observable cost is wake latency, because the phase sits in the critical path ahead of the wake: `load_demand_snapshot` at t=69s, orphan release completing at t=751s, `apply_wake_sleep_decisions` at t=822s, `execute_planned_starts` at t=852s. A sleeping on-demand named singleton waits most of a tick for a wake no matter how promptly the sling poke lands — which is the 8–13 minute band recorded in ga-w83ake.

## The subtle part — why the memo key names the store

Equal store refs mean the same census leg **only** because `collectAssignedWorkBeadsWithStores` appends `assignedWorkStores[i]` and `assignedWorkStoreRefs[i]` from one source. Where that slice is absent, `assignedWorkOwnerStore` falls back to routing each bead through `storeForPoolAssignment(wb)`, and two beads sharing a ref can resolve to **different** stores. Collapsing those onto one cached answer is a claim-level bug in both directions — a stranded orphan, or a live holder's claim released underneath it — so that path stays unmemoized. The second added test pins both directions.

This narrows the staleness window rather than widening it: the three liveness gates now agree on one snapshot, matching `openIdentifiers` and `legacyOpenIdentifiers` which are already built once before the loop, and `liveWorkAssignmentStillReleasable` still re-reads live before any release.

## Test plan

- [x] Two new tests in `cmd/gc/pool_session_name_orphan_release_fanout_test.go` (228 lines) covering the memoized path and the unmemoized fallback in both directions.
- [x] `go test ./cmd/gc -run OrphanRelease` — ok
- [x] `go vet ./cmd/gc/` — clean
- [x] Full pre-push gate (`make test-fast-parallel`, 10 jobs) — **All fast jobs passed**, no `--no-verify`.

Refs ga-451jnv.
