### PR TITLE
fix(sling): validate cross-store routes in dry-run

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -1655,7 +1655,7 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 			return SlingResult{}, err
 		}
 	}
-	if shouldValidateBuiltInRouteStoreReachable(opts, deps) {
+	if opts.DryRun && shouldValidateBuiltInRouteStoreReachable(opts, deps) {
 		if err := validateBuiltInRouteStoreReachable(deps, b.ID, a); err != nil {
 			return SlingResult{}, err
 		}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -332,7 +332,7 @@ func onFormulaNeedsAttachment(opts SlingOpts, querier BeadQuerier, deps SlingDep
 }
 
 func shouldValidateBuiltInRouteStoreReachable(opts SlingOpts, deps SlingDeps) bool {
-	return deps.Router != nil && !opts.IsFormula && !opts.DryRun
+	return deps.Router != nil && !opts.IsFormula
 }
 
 // shouldReopenForReassign reports whether the pre-flight reassign reopen should

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -1655,6 +1655,11 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 			return SlingResult{}, err
 		}
 	}
+	if shouldValidateBuiltInRouteStoreReachable(opts, deps) {
+		if err := validateBuiltInRouteStoreReachable(deps, b.ID, a); err != nil {
+			return SlingResult{}, err
+		}
+	}
 
 	// Dry-run: return early with container preview info.
 	if opts.DryRun {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2364,6 +2364,43 @@ func TestDoSlingDryRunRefusesCrossStoreBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestDoSlingBatchDryRunRefusesCrossStoreBeforeMutation(t *testing.T) {
+	deps, router, target := crossStoreSlingDeps(t)
+	store := deps.Store
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	children := []beads.Bead{}
+	for _, title := range []string{"one", "two"} {
+		child, createErr := store.Create(beads.Bead{Title: title, Type: "task", ParentID: convoy.ID, Status: "open"})
+		if createErr != nil {
+			t.Fatalf("create child %s: %v", title, createErr)
+		}
+		children = append(children, child)
+	}
+	opts := SlingOpts{
+		Target:        target,
+		BeadOrFormula: convoy.ID,
+		Force:         true,
+		DryRun:        true,
+		NoFormula:     true,
+	}
+
+	result, err := DoSlingBatch(opts, deps, store)
+
+	requireCrossStoreRouteError(t, err)
+	if result.Routed != 0 {
+		t.Fatalf("Routed = %d, want 0", result.Routed)
+	}
+	for _, child := range children {
+		requireNoCrossStoreRouteMutation(t, store, child.ID, "")
+	}
+	if len(router.routed) != 0 {
+		t.Fatalf("router calls = %d, want 0", len(router.routed))
+	}
+}
+
 func TestDoSlingBatchRefusesCrossStoreBeforeFormulaMutation(t *testing.T) {
 	deps, router, target := crossStoreSlingDeps(t)
 	store := deps.Store

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2350,6 +2350,20 @@ func TestDoSlingRefusesCrossStoreReassignBeforeClearingAssignee(t *testing.T) {
 	}
 }
 
+func TestDoSlingDryRunRefusesCrossStoreBeforeMutation(t *testing.T) {
+	opts, deps, router, bead := crossStoreSlingFixture(t, "")
+	opts.NoFormula = true
+	opts.DryRun = true
+
+	_, err := DoSling(opts, deps, deps.Store)
+
+	requireCrossStoreRouteError(t, err)
+	requireNoCrossStoreRouteMutation(t, deps.Store, bead.ID, "")
+	if len(router.routed) != 0 {
+		t.Fatalf("router calls = %d, want 0", len(router.routed))
+	}
+}
+
 func TestDoSlingBatchRefusesCrossStoreBeforeFormulaMutation(t *testing.T) {
 	deps, router, target := crossStoreSlingDeps(t)
 	store := deps.Store


### PR DESCRIPTION
## Summary

Fixes #6075.

`gc sling --dry-run` now performs the existing built-in route-store reachability
check for plain and batch sling paths. A cross-store route therefore reports the
same `CrossStoreRouteError` that the real operation would report, before any
mutation or routing call.

Batch apply behavior is unchanged: non-dry-run batches retain their existing
per-child error reporting.

## Verification

- Added plain and convoy batch regression tests covering refusal and no mutation.
- `go test ./internal/sling -count=1` — PASS on Nomad.
- Focused existing cross-store tests — PASS on Nomad.
- `make build`, `make fmt-check`, `make lint`, `make vet`, and
  `make test-fsys-darwin-compile` — PASS on Nomad.
- Repository invariant checks — PASS on Nomad.

Release note: dry-run sling previews now surface cross-store routes that the
real sling would reject; same-store dry-run behavior is unchanged.
