### PR TITLE
fix(pool): treat work-branch-only evidence as unmanaged

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -1377,7 +1377,8 @@ func hookClaimLifecycleCandidate(bead beads.Bead, opts hookClaimOptions) bool {
 func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string) map[string]string {
 	patch := map[string]string{}
 	if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
-		strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch {
+		strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch &&
+		hookClaimWorktreeEvidenceIsWholeOrAbsent(bead) {
 		patch[beadmeta.WorkBranchMetadataKey] = branch
 	}
 	if sessionID := hookClaimSessionID(opts.Env); sessionID != "" &&
@@ -1394,6 +1395,39 @@ func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClai
 		patch[beadmeta.ClaimedAtMetadataKey] = time.Now().UTC().Format(time.RFC3339)
 	}
 	return patch
+}
+
+// worktreeOwnershipEvidenceKeys are the eight worktree-ownership metadata
+// keys worktreeSpecForBead (pool_desired_state.go) requires alongside
+// gc.work_branch before it will treat a bead as a fully managed workspace.
+var worktreeOwnershipEvidenceKeys = []string{
+	beadmeta.WorktreeRepoMetadataKey,
+	beadmeta.WorktreeRootMetadataKey,
+	beadmeta.WorktreeBaseRefMetadataKey,
+	beadmeta.WorktreeBaseSHAMetadataKey,
+	beadmeta.WorktreeCreatorMetadataKey,
+	beadmeta.WorktreeOwnerMetadataKey,
+	beadmeta.WorktreeGenerationMetadataKey,
+	beadmeta.WorktreeLifecycleMetadataKey,
+}
+
+// hookClaimWorktreeEvidenceIsWholeOrAbsent reports whether a bead's other
+// eight worktree-ownership keys are either all present or all absent. A claim
+// must not be the thing that first introduces a partial (1-7 of 8) ownership
+// shape by ambiently stamping gc.work_branch onto a bead that already carries
+// some-but-not-all of the other eight keys -- that half-published shape is
+// exactly what worktreeSpecForBead hard-errors on (ga-ryeij1.1 Decision b).
+// Stamping stays safe at both boundaries: zero of the eight (a legacy or
+// not-yet-published bead) or all eight (evidence already complete; this is
+// just keeping the branch in sync).
+func hookClaimWorktreeEvidenceIsWholeOrAbsent(bead beads.Bead) bool {
+	present := 0
+	for _, key := range worktreeOwnershipEvidenceKeys {
+		if strings.TrimSpace(bead.Metadata[key]) != "" {
+			present++
+		}
+	}
+	return present == 0 || present == len(worktreeOwnershipEvidenceKeys)
 }
 
 func hookStampWorkMetaWithBdStore(_ context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error {

--- a/cmd/gc/cmd_hook_claim_stamp_test.go
+++ b/cmd/gc/cmd_hook_claim_stamp_test.go
@@ -388,6 +388,56 @@ func TestDoHookClaimIdentityStampFailureDoesNotFailClaim(t *testing.T) {
 	}
 }
 
+// TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard pins Decision (b)
+// of ga-ryeij1.1: a claim must not be the thing that FIRST introduces a
+// partial (1-7 of the other eight) worktreeSpecForBead ownership shape by
+// ambiently stamping gc.work_branch onto a bead that already carries
+// some-but-not-all of the other eight keys. Stamping stays allowed at the two
+// safe boundaries -- zero of the other eight (a legacy/unmanaged bead, or one
+// about to be fully published elsewhere) or all eight (full evidence already
+// established; this is just keeping the branch in sync) -- so this does not
+// change behavior for either fully-managed or fully-unmanaged beads, only the
+// half-published shapes worktreeSpecForBead must hard-error on.
+func TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard(t *testing.T) {
+	otherEightKeys := []string{
+		beadmeta.WorktreeRepoMetadataKey,
+		beadmeta.WorktreeRootMetadataKey,
+		beadmeta.WorktreeBaseRefMetadataKey,
+		beadmeta.WorktreeBaseSHAMetadataKey,
+		beadmeta.WorktreeCreatorMetadataKey,
+		beadmeta.WorktreeOwnerMetadataKey,
+		beadmeta.WorktreeGenerationMetadataKey,
+		beadmeta.WorktreeLifecycleMetadataKey,
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
+	ops := hookClaimOps{ResolveWorkBranch: func(string) string { return "bd-new-branch" }}
+
+	for _, tc := range []struct {
+		name         string
+		presentCount int
+		wantStamped  bool
+	}{
+		{name: "zero_of_eight_present", presentCount: 0, wantStamped: true},
+		{name: "one_of_eight_present", presentCount: 1, wantStamped: false},
+		{name: "seven_of_eight_present", presentCount: 7, wantStamped: false},
+		{name: "all_eight_present", presentCount: 8, wantStamped: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := map[string]string{beadmeta.KindMetadataKey: "worker"}
+			for i := 0; i < tc.presentCount; i++ {
+				meta[otherEightKeys[i]] = "present"
+			}
+			bead := beads.Bead{ID: "hw-partial", Status: "open", Metadata: meta}
+
+			patch := hookClaimIdentityPatch(bead, opts, ops, "/tmp/work")
+			_, stamped := patch[beadmeta.WorkBranchMetadataKey]
+			if stamped != tc.wantStamped {
+				t.Fatalf("presentCount=%d: gc.work_branch stamped=%v, want %v (patch=%v)", tc.presentCount, stamped, tc.wantStamped, patch)
+			}
+		})
+	}
+}
+
 func TestDoHookClaimEmitsStartedOnlyAfterDurableSessionReadback(t *testing.T) {
 	spy := &stampMetaSpy{}
 	meta := map[string]string{

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -99,9 +99,12 @@ func worktreeSpecForBead(bead beads.Bead, storeRef string) (*worktree.Spec, erro
 		{beadmeta.WorktreeLifecycleMetadataKey, bead.Metadata[beadmeta.WorktreeLifecycleMetadataKey]},
 	}
 	missing := make([]string, 0, len(values))
+	present := make([]string, 0, len(values))
 	for _, item := range values {
 		if strings.TrimSpace(item.value) == "" {
 			missing = append(missing, item.key)
+		} else {
+			present = append(present, item.key)
 		}
 	}
 	if len(missing) == len(values) {
@@ -115,6 +118,20 @@ func worktreeSpecForBead(bead beads.Bead, storeRef string) (*worktree.Spec, erro
 		if _, dup := legacyWorkDirNoticeSeen.LoadOrStore(bead.ID, struct{}{}); !dup {
 			log.Printf("worktreeSpecForBead: work bead %s has %s=%q with no worktree ownership metadata; treating as unmanaged",
 				bead.ID, pathKey, path)
+		}
+		return nil, nil
+	}
+	if len(present) == 1 && present[0] == beadmeta.WorkBranchMetadataKey {
+		// gc.work_branch alone is not incomplete evidence either -- it is the
+		// shape a hook claim's ambient branch stamp produces on an otherwise
+		// unmanaged bead (hookClaimIdentityPatch stamps gc.work_branch onto
+		// any bead with a resolvable branch, independent of whether the bead
+		// ever published worktree ownership evidence). Treat it the same as
+		// the zero-key case above instead of hard-erroring the seat into
+		// permanent starvation the first time a hook claim touches it.
+		if _, dup := legacyWorkDirNoticeSeen.LoadOrStore(bead.ID, struct{}{}); !dup {
+			log.Printf("worktreeSpecForBead: work bead %s has %s=%q with only %s published; treating as unmanaged",
+				bead.ID, pathKey, path, beadmeta.WorkBranchMetadataKey)
 		}
 		return nil, nil
 	}

--- a/cmd/gc/pool_trigger_worktree_owner_test.go
+++ b/cmd/gc/pool_trigger_worktree_owner_test.go
@@ -184,6 +184,30 @@ func TestWorktreeSpecForBeadTreatsWorkDirOnlyAsLegacy(t *testing.T) {
 	}
 }
 
+// TestWorktreeSpecForBeadTreatsWorkBranchOnlyAsUnmanaged covers the shape a
+// hook claim's ambient branch stamp actually produces on a legitimately
+// unmanaged bead (ga-ryeij1.1): work_dir + work_branch set, none of the other
+// eight ownership keys published. A hook claim stamps gc.work_branch alone
+// the moment it adopts any bead with a resolvable worktree branch, regardless
+// of whether the bead ever published ownership evidence -- so this shape is
+// not "incomplete evidence" any more than the zero-key case above is. Treat
+// it as unmanaged, not a hard error, or the pool seat starves permanently the
+// first time a hook claim touches it.
+func TestWorktreeSpecForBeadTreatsWorkBranchOnlyAsUnmanaged(t *testing.T) {
+	bead := beads.Bead{ID: "gc-test", Metadata: map[string]string{
+		beadmeta.WorkDirMetadataKey:    "/worktrees/gc-test",
+		beadmeta.WorkBranchMetadataKey: "work/gc-test",
+	}}
+
+	spec, err := worktreeSpecForBead(bead, "rig:gascity")
+	if err != nil {
+		t.Fatalf("worktreeSpecForBead: %v, want a work_dir+work_branch-only bead to be treated as unmanaged, not errored", err)
+	}
+	if spec != nil {
+		t.Fatalf("spec = %+v, want nil so the seat spawns unmanaged instead of starving", spec)
+	}
+}
+
 // TestWorktreeSpecForBeadRejectsSingleOwnershipKey pins the boundary the
 // unmanaged branch creates: nine missing ownership keys is "never published",
 // but eight missing is partial evidence and must still fail closed. An
@@ -206,6 +230,30 @@ func TestWorktreeSpecForBeadRejectsSingleOwnershipKey(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), beadmeta.WorktreeRepoMetadataKey) {
 		t.Fatalf("error = %v, want it to name the first missing key %q", err, beadmeta.WorktreeRepoMetadataKey)
+	}
+}
+
+// TestWorktreeSpecForBeadRejectsWorkBranchPlusOneOtherKey pins the boundary
+// the work_branch-only carve-out below must NOT swallow: work_dir +
+// work_branch plus exactly one of the other eight ownership keys is still a
+// partial, half-published shape and must fail closed exactly like
+// TestWorktreeSpecForBeadRejectsSingleOwnershipKey above. An overly broad
+// carve-out that matched on "work_branch present" rather than "work_branch is
+// the ONLY one of the nine present" would wrongly wave this shape through as
+// unmanaged too.
+func TestWorktreeSpecForBeadRejectsWorkBranchPlusOneOtherKey(t *testing.T) {
+	bead := beads.Bead{ID: "gc-test", Metadata: map[string]string{
+		beadmeta.WorkDirMetadataKey:       "/worktrees/gc-test",
+		beadmeta.WorkBranchMetadataKey:    "work/gc-test",
+		beadmeta.WorktreeOwnerMetadataKey: "gc-sling",
+	}}
+
+	spec, err := worktreeSpecForBead(bead, "rig:gascity")
+	if err == nil {
+		t.Fatalf("spec = %+v err = nil, want work_branch plus one other key to still fail closed", spec)
+	}
+	if spec != nil {
+		t.Fatalf("spec = %+v, want nil alongside the error", spec)
 	}
 }
 

--- a/release-gates/ga-n3zvcg-work-branch-unmanaged-gate.md
+++ b/release-gates/ga-n3zvcg-work-branch-unmanaged-gate.md
@@ -1,0 +1,61 @@
+# Release gate: work-branch-only ownership evidence is unmanaged
+
+- Bead: `ga-n3zvcg`
+- Review bead: `ga-976rti`
+- Build bead: `ga-ryeij1.1`
+- Reviewed commit: `d1a9edf1a1af84fc0c4286e2caf8eda1f0a00e2e`
+- Base: `origin/main@28fbaf81a8c8f9e6bb0cb67b6620aa80759d5dba`
+- Deploy mode: `remote`; push remote resolved to `origin`
+- Result: **PASS** — all candidate-owned tests and required lanes pass; unrelated full-suite and lint findings are attributed to pre-existing trackers under the non-diff-owned failure protocol.
+
+## Pre-flight
+
+- `git rev-parse --verify --quiet d1a9edf1a1af84fc0c4286e2caf8eda1f0a00e2e^{commit}` resolved the recorded value to the same full commit SHA.
+- GitHub reports no pull request carrying the reviewed commit, so neither already-merged nor closed-without-merging reconciliation applies.
+- The commits are internally authored. No contributor PR or contributor interaction is involved.
+- The commit range is one coupled feature in `cmd/gc`: the pool ownership reader accepts the ambient `gc.work_branch`-only shape, while hook claims avoid creating that shape on partially published worktree evidence.
+- `assert_deploy_ancestry_scope` passed for `ga-n3zvcg` and confirmed build bead `ga-ryeij1.1`; no unrelated or `.claude/**` content is present.
+
+## Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-976rti` records `verdict: pass` for the exact reviewed commit. No review carryover is involved. |
+| 2 | Acceptance criteria met | **PASS** | Source inspection and the focused acceptance run verify that `gc.work_dir` plus only ambient `gc.work_branch` is treated as unmanaged; every other partial ownership shape remains a hard error; existing contaminated beads self-resolve on their next read without a sweep; no metadata key or work-record value semantics changed; and hook claims retain their zero-of-eight/all-eight behavior while refusing to stamp into one-of-eight through seven-of-eight partial evidence. |
+| 3 | Tests pass | **PASS** | The documented full command `make test-local-full-parallel` ran on the exact reviewed commit with the rootless Podman socket configured through `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock` and `TESTCONTAINERS_RYUK_DISABLED=true`. Runner result: 37/40 jobs PASS, 3 raw FAIL, 0 jobs SKIP or omitted; logs: `/var/tmp/ga-n3zvcg-full.ETW7Jw`. All diff-owned tests were selected by passing full-suite shards. A supplemental exact-name run emitted 7 PASS records, 0 FAIL, 0 SKIP. The three raw failures are independently attributed below. `test_cmd_scope: full-suite`; `waiver_ref: none`; `ci_lane_run: n/a (no CI-config change)`. `policy_lane: PASS WITH ATTRIBUTED NON-DIFF DIAGNOSTICS` — `make test-ci-policy`, `make vet`, `go build ./...`, module/dependency/event-export/core-boundary guards, native DoltLite tests, and docs checks pass; full lint/format diagnostics occur only in byte-identical pre-existing files or ignored local `node_modules` and are attributed below. |
+| 4 | No high-severity review findings open | **PASS** | Review bead `ga-976rti` records no security findings and no unresolved HIGH finding. Its sole minor note is a non-blocking doc-comment completeness observation. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain` was empty before this gate artifact was written. `core.hooksPath` is `.githooks`. |
+| 6 | Branch diverges cleanly from main | **PASS** | `origin/main...d1a9edf1a1af84fc0c4286e2caf8eda1f0a00e2e` is 2 behind / 2 ahead, and `git merge-tree --write-tree origin/main d1a9edf1a1af84fc0c4286e2caf8eda1f0a00e2e` returned 0 with tree `7dfff1e55e8429ea7e26ca8b6dc4da48997cc7e5`. No self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | Both commits are confined to `cmd/gc` pool worktree-ownership evidence and its hook-claim producer, plus their tests. |
+
+## Diff-owned test evidence
+
+All cases below were selected by passing full-suite shards and passed again in the supplemental exact-name run:
+
+- `TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard/zero_of_eight_present`
+- `TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard/one_of_eight_present`
+- `TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard/seven_of_eight_present`
+- `TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard/all_eight_present`
+- `TestWorktreeSpecForBeadTreatsWorkBranchOnlyAsUnmanaged`
+- `TestWorktreeSpecForBeadRejectsWorkBranchPlusOneOtherKey`
+
+`diff_tests_executed: 7 PASS records (3 top-level tests plus 4 nested cases), 0 FAIL, 0 SKIP`
+
+## Full-suite failure attribution
+
+- `failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo | clause 1: not diff-owned; clause 2: tracker predates the run; clause 3(a): installed-binary/manifest mechanism is unreachable from cmd/gc and has exact origin/main reproductions; clause 4: no path overlap`
+- `failure_attribution: TestSweep_ReapsRealDoltDataDirAfterSIGKILL -> ga-vkhfnj | clause 1: not diff-owned; clause 2: tracker predates the run; clause 3(b): the same live-Dolt-directory signature is recorded on unrelated candidate ga-nht26j; clause 4: no examples/gastown or internal/doltorphan path overlap`
+- `failure_attribution: TestE2E_SuspendResume_City -> ga-dqd7gf | clause 1: not diff-owned; clause 2: tracker predates the run; clause 3(b/d): exact cross-PR and origin/main missing-citysus-report reproductions predate this gate; clause 4: no test/integration or suspend/resume-report path overlap`
+- `waiver_ref: none` — no diff-owned failure or skip occurred, so no independently granted waiver is required.
+
+## Policy/lint attribution
+
+- `policy_attribution: unchanged gofumpt findings -> ga-d3m213 | diagnostic-bearing blobs are identical at merge base, candidate, and origin/main; no candidate path overlap`
+- `policy_attribution: unchanged ResolvedProvider.Kind SA1019 uses -> ga-t88402 | diagnostic-bearing blobs are identical at merge base, candidate, and origin/main; no candidate path overlap`
+- `policy_attribution: unchanged internal/api SA4006 -> ga-egkp4x | diagnostic-bearing blob is identical at merge base, candidate, and origin/main; no candidate path overlap`
+- `policy_attribution: ignored dashboard node_modules govet/revive findings -> ga-039od0 | git confirms the scanned tree is ignored and untracked; the candidate changes no dashboard, dependency, or lint configuration path`
+- Policy logs: `/var/tmp/ga-n3zvcg-policy.2f9uFf`; focused acceptance log: `/var/tmp/ga-n3zvcg-targeted.log`; build log: `/var/tmp/ga-n3zvcg-build.log`.
+
+## Disposition
+
+All seven criteria pass. Create the isolated `deploy/ga-n3zvcg-gate` branch from the reviewed SHA, commit this checklist, push it to `origin`, open the pull request, publish deploy clearance on the exact PR head, and route the merge-request to mayor. The deployer does not merge.


### PR DESCRIPTION
## What this changes

Pool reconciliation now treats a work bead with `gc.work_dir` plus only the ambient `gc.work_branch` field as unmanaged work instead of rejecting it as malformed partial worktree ownership. This prevents an otherwise schedulable pool seat from being starved by bookkeeping that does not identify a managed worktree.

Hook claims also avoid adding `gc.work_branch` when a bead already has an incomplete managed-worktree evidence set. They continue to stamp it when the evidence set is wholly absent or wholly present, so the producer no longer creates the ambiguous shape the reader must reject.

## Review notes

- The reader-side exception is deliberately narrow: `gc.work_branch` must be the only ownership key present. Every other partial ownership shape remains a hard error.
- Existing affected beads recover on their next reconciliation read; there is no migration, sweep, schema change, or new metadata key.
- The hook guard checks key presence only. It does not read, rewrite, or clear work-record values.

## Test plan

- [x] Run the documented full local suite with rootless Podman enabled; confirm every changed test executes and inspect each attributed infrastructure failure against its tracker.
- [x] Exercise the zero, one, seven, and all-eight ownership-key boundaries plus the reader's accepted and rejected shapes.
- [x] Run build, vet, CI-policy, documentation, native DoltLite, and architectural boundary checks.
- [x] Review the [release gate](release-gates/ga-n3zvcg-work-branch-unmanaged-gate.md).

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5883 — Makes pool reconciliation treat a work bead carrying gc.work_dir plus only the ambient gc.work_branch as unmanaged rather than partial worktree evidence, and stops hook claims from stamping that branch onto beads that already hold incomplete ownership evidence, so a claimed bead's seat spawns unmanaged instead of starving on every tick. The separately suggested starvation-visibility signal (a doctor finding or an event for repeatedly skipped pool triggers) is not part of this change.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->