### PR TITLE
perf(sessionlog): cache pi transcript headers by stat signature

### DIFF
--- a/internal/sessionlog/pi_reader.go
+++ b/internal/sessionlog/pi_reader.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -167,12 +168,12 @@ func findPiSessionCandidatesIn(root, workDir string) []piSessionCandidate {
 		if !strings.HasSuffix(strings.ToLower(entry.Name()), ".jsonl") {
 			return nil
 		}
-		sessionID, cwd := piSessionHeader(path)
-		if cleanPiWorkDir(cwd) != workDir {
-			return nil
-		}
 		info, err := entry.Info()
 		if err != nil {
+			return nil
+		}
+		sessionID, cwd := cachedPiSessionHeader(path, info)
+		if cleanPiWorkDir(cwd) != workDir {
 			return nil
 		}
 		if sessionID == "" {
@@ -185,6 +186,48 @@ func findPiSessionCandidatesIn(root, workDir string) []piSessionCandidate {
 		return nil
 	}
 	return candidates
+}
+
+// piHeaderCacheEntry memoizes the parsed first-line header of a pi session
+// file. size+modTime form the stat signature: a rewritten transcript gets a new
+// signature and re-parses, while list/enrichment sweeps that revisit an
+// unchanged tree skip the per-file open+parse entirely.
+type piHeaderCacheEntry struct {
+	size      int64
+	modTimeNS int64
+	sessionID string
+	cwd       string
+}
+
+var (
+	piHeaderCacheMu sync.Mutex
+	piHeaderCache   = make(map[string]piHeaderCacheEntry)
+)
+
+// piHeaderCacheMaxEntries bounds the cache; deleted transcripts leave stale
+// keys behind, so past this size the map resets rather than growing forever.
+const piHeaderCacheMaxEntries = 16384
+
+func cachedPiSessionHeader(path string, info os.FileInfo) (string, string) {
+	size := info.Size()
+	modTimeNS := info.ModTime().UnixNano()
+
+	piHeaderCacheMu.Lock()
+	entry, ok := piHeaderCache[path]
+	piHeaderCacheMu.Unlock()
+	if ok && entry.size == size && entry.modTimeNS == modTimeNS {
+		return entry.sessionID, entry.cwd
+	}
+
+	sessionID, cwd := piSessionHeader(path)
+
+	piHeaderCacheMu.Lock()
+	if len(piHeaderCache) >= piHeaderCacheMaxEntries {
+		piHeaderCache = make(map[string]piHeaderCacheEntry)
+	}
+	piHeaderCache[path] = piHeaderCacheEntry{size: size, modTimeNS: modTimeNS, sessionID: sessionID, cwd: cwd}
+	piHeaderCacheMu.Unlock()
+	return sessionID, cwd
 }
 
 func parsePiFileDetailed(path string) ([]piEntry, string, SessionDiagnostics, error) {

--- a/internal/sessionlog/pi_reader.go
+++ b/internal/sessionlog/pi_reader.go
@@ -206,6 +206,9 @@ var (
 
 // piHeaderCacheMaxEntries bounds the cache; deleted transcripts leave stale
 // keys behind, so past this size the map resets rather than growing forever.
+// The reset is an anti-leak cap, not a working-set-preserving eviction policy:
+// a tree with more live transcripts than this bound wipes mid-sweep and stops
+// caching. Real eviction is out of scope here and tracked in ga-gn1gf.
 const piHeaderCacheMaxEntries = 16384
 
 func cachedPiSessionHeader(path string, info os.FileInfo) (string, string) {
@@ -213,21 +216,41 @@ func cachedPiSessionHeader(path string, info os.FileInfo) (string, string) {
 	modTimeNS := info.ModTime().UnixNano()
 
 	piHeaderCacheMu.Lock()
-	entry, ok := piHeaderCache[path]
+	entry, hit := piHeaderCache[path]
 	piHeaderCacheMu.Unlock()
-	if ok && entry.size == size && entry.modTimeNS == modTimeNS {
+	if hit && entry.size == size && entry.modTimeNS == modTimeNS {
 		return entry.sessionID, entry.cwd
 	}
 
-	sessionID, cwd := piSessionHeader(path)
+	sessionID, cwd, read := piSessionHeader(path)
+	if !read {
+		// The read failed rather than finding no header. Storing that would
+		// freeze a transient fault into an authoritative "no transcript" answer
+		// until the file's size or mtime changes, which an idle transcript
+		// awaiting resume never does.
+		return sessionID, cwd
+	}
+	storePiHeaderCacheEntry(path, piHeaderCacheEntry{
+		size:      size,
+		modTimeNS: modTimeNS,
+		sessionID: sessionID,
+		cwd:       cwd,
+	}, piHeaderCacheMaxEntries)
+	return sessionID, cwd
+}
 
+// storePiHeaderCacheEntry records entry under path, resetting the cache first
+// when a new key would push it past maxEntries. A signature refresh of a key
+// already present cannot grow the map, so it never triggers the reset.
+// maxEntries is a parameter so tests can exercise the reset without creating
+// piHeaderCacheMaxEntries files.
+func storePiHeaderCacheEntry(path string, entry piHeaderCacheEntry, maxEntries int) {
 	piHeaderCacheMu.Lock()
-	if len(piHeaderCache) >= piHeaderCacheMaxEntries {
+	defer piHeaderCacheMu.Unlock()
+	if _, exists := piHeaderCache[path]; !exists && len(piHeaderCache) >= maxEntries {
 		piHeaderCache = make(map[string]piHeaderCacheEntry)
 	}
-	piHeaderCache[path] = piHeaderCacheEntry{size: size, modTimeNS: modTimeNS, sessionID: sessionID, cwd: cwd}
-	piHeaderCacheMu.Unlock()
-	return sessionID, cwd
+	piHeaderCache[path] = entry
 }
 
 func parsePiFileDetailed(path string) ([]piEntry, string, SessionDiagnostics, error) {
@@ -746,17 +769,30 @@ func parsePiTimestamp(raw string) time.Time {
 	return ts
 }
 
-func piSessionHeader(path string) (string, string) {
+// piSessionHeader parses the session ID and cwd from a pi transcript's first
+// line. read reports whether the file was actually read: false means the read
+// failed (the open errored, or the scan errored, which includes a first line
+// past the buffer limit), so the header is simply unknown. true means the file
+// was read, so empty return values are content-derived (an empty file, an
+// unparsable or non-session first record, or a session record carrying no id
+// or cwd) rather than a read failure. Callers that memoize the result must
+// store only read results, so a transient failure is retried instead of frozen
+// as an authoritative absence.
+func piSessionHeader(path string) (sessionID, cwd string, read bool) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", ""
+		return "", "", false
 	}
 	defer f.Close() //nolint:errcheck // read-only
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	if !scanner.Scan() {
-		return "", ""
+		// Scan reports an empty file and a failed read the same way, so
+		// scanner.Err() is the only thing that separates them. A first line
+		// longer than the buffer above lands here as bufio.ErrTooLong and is
+		// re-parsed every sweep, exactly as it was before the cache existed.
+		return "", "", scanner.Err() == nil
 	}
 	var header struct {
 		Type string `json:"type"`
@@ -764,12 +800,12 @@ func piSessionHeader(path string) (string, string) {
 		CWD  string `json:"cwd"`
 	}
 	if err := json.Unmarshal(scanner.Bytes(), &header); err != nil {
-		return "", ""
+		return "", "", true
 	}
 	if header.Type != "session" {
-		return "", ""
+		return "", "", true
 	}
-	return strings.TrimSpace(header.ID), header.CWD
+	return strings.TrimSpace(header.ID), header.CWD, true
 }
 
 func cleanPiWorkDir(path string) string {

--- a/internal/sessionlog/pi_reader_test.go
+++ b/internal/sessionlog/pi_reader_test.go
@@ -438,3 +438,88 @@ func TestFindPiSessionFileFailsClosedOnAmbiguousCWD(t *testing.T) {
 		t.Fatalf("FindPiSessionFileByID(first) = %q, want %q", got, firstPath)
 	}
 }
+
+func writePiSessionHeaderFile(t *testing.T, path, workDir string) {
+	t.Helper()
+	body := `{"type":"session","version":3,"id":"sess-1","cwd":"` + filepath.ToSlash(workDir) + `"}`
+	if err := os.WriteFile(path, []byte(body+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestFindPiSessionFileByIDSkipsRereadWhenStatSignatureUnchanged(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project-aa")
+	otherDir := filepath.Join(filepath.Dir(workDir), "project-bb")
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() = %q, want %q", got, path)
+	}
+
+	// Rewrite the header to a different cwd of the same byte length and restore
+	// the original mtime, so the (size, mtime) stat signature is unchanged. The
+	// candidate scan must serve the cached header without re-reading the file.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	writePiSessionHeaderFile(t, path, otherDir)
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rewritten: %v", err)
+	}
+	if after.Size() != info.Size() {
+		t.Fatalf("rewrite changed size %d -> %d; test needs an identical signature", info.Size(), after.Size())
+	}
+	if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() after same-signature rewrite = %q, want cached %q", got, path)
+	}
+}
+
+func TestFindPiSessionFileByIDInvalidatesCacheOnChangedSignature(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	movedDir := workDir + "-moved"
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() = %q, want %q", got, path)
+	}
+
+	writePiSessionHeaderFile(t, path, movedDir)
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID(old cwd) = %q, want empty after header rewrite", got)
+	}
+	if got := FindPiSessionFileByID([]string{root}, movedDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID(new cwd) = %q, want %q", got, path)
+	}
+}
+
+func TestFindPiSessionFileByIDDropsDeletedFileDespiteCache(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() = %q, want %q", got, path)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID() after delete = %q, want empty", got)
+	}
+}

--- a/internal/sessionlog/pi_reader_test.go
+++ b/internal/sessionlog/pi_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -441,9 +442,42 @@ func TestFindPiSessionFileFailsClosedOnAmbiguousCWD(t *testing.T) {
 
 func writePiSessionHeaderFile(t *testing.T, path, workDir string) {
 	t.Helper()
-	body := `{"type":"session","version":3,"id":"sess-1","cwd":"` + filepath.ToSlash(workDir) + `"}`
-	if err := os.WriteFile(path, []byte(body+"\n"), 0o644); err != nil {
+	writePiHeaderFile(t, path, "session", "sess-1", workDir)
+}
+
+// writePiHeaderFile writes a single pi header line of the given record type.
+// "session" and "message" have the same byte length, so a caller can rewrite one
+// as the other without changing the file's stat signature.
+func writePiHeaderFile(t *testing.T, path, recordType, id, workDir string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(piHeaderLine(recordType, id, workDir)+"\n"), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func piHeaderLine(recordType, id, workDir string) string {
+	return `{"type":"` + recordType + `","version":3,"id":"` + id + `","cwd":"` + filepath.ToSlash(workDir) + `"}`
+}
+
+// rewritePiFilePreservingSignature runs write against path and then asserts the
+// file's size is unchanged and restores its original mtime, so the (size, mtime)
+// stat signature the header cache keys on is identical to the pre-write one.
+func rewritePiFilePreservingSignature(t *testing.T, path string, write func()) {
+	t.Helper()
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	write()
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rewritten %s: %v", path, err)
+	}
+	if after.Size() != before.Size() {
+		t.Fatalf("rewrite changed size %d -> %d; test needs an identical signature", before.Size(), after.Size())
+	}
+	if err := os.Chtimes(path, before.ModTime(), before.ModTime()); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
 	}
 }
 
@@ -461,21 +495,9 @@ func TestFindPiSessionFileByIDSkipsRereadWhenStatSignatureUnchanged(t *testing.T
 	// Rewrite the header to a different cwd of the same byte length and restore
 	// the original mtime, so the (size, mtime) stat signature is unchanged. The
 	// candidate scan must serve the cached header without re-reading the file.
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	writePiSessionHeaderFile(t, path, otherDir)
-	after, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat rewritten: %v", err)
-	}
-	if after.Size() != info.Size() {
-		t.Fatalf("rewrite changed size %d -> %d; test needs an identical signature", info.Size(), after.Size())
-	}
-	if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
-		t.Fatalf("chtimes: %v", err)
-	}
+	rewritePiFilePreservingSignature(t, path, func() {
+		writePiSessionHeaderFile(t, path, otherDir)
+	})
 
 	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
 		t.Fatalf("FindPiSessionFileByID() after same-signature rewrite = %q, want cached %q", got, path)
@@ -504,6 +526,161 @@ func TestFindPiSessionFileByIDInvalidatesCacheOnChangedSignature(t *testing.T) {
 	}
 	if got := FindPiSessionFileByID([]string{root}, movedDir, "sess-1"); got != path {
 		t.Fatalf("FindPiSessionFileByID(new cwd) = %q, want %q", got, path)
+	}
+}
+
+func TestStorePiHeaderCacheEntryResetsOnlyForNewKeyAtCapacity(t *testing.T) {
+	cacheLen := func() int {
+		piHeaderCacheMu.Lock()
+		defer piHeaderCacheMu.Unlock()
+		return len(piHeaderCache)
+	}
+	piHeaderCacheMu.Lock()
+	saved := piHeaderCache
+	piHeaderCache = make(map[string]piHeaderCacheEntry)
+	piHeaderCacheMu.Unlock()
+	t.Cleanup(func() {
+		piHeaderCacheMu.Lock()
+		piHeaderCache = saved
+		piHeaderCacheMu.Unlock()
+	})
+
+	const maxEntries = 4
+	for i := 0; i < maxEntries; i++ {
+		storePiHeaderCacheEntry(fmt.Sprintf("/pi/s%d.jsonl", i), piHeaderCacheEntry{size: int64(i)}, maxEntries)
+	}
+	if got := cacheLen(); got != maxEntries {
+		t.Fatalf("cache length after filling to capacity = %d, want %d", got, maxEntries)
+	}
+
+	// A signature refresh of a key already present cannot grow the map, so it
+	// must not discard the working set.
+	storePiHeaderCacheEntry("/pi/s0.jsonl", piHeaderCacheEntry{size: 99}, maxEntries)
+	if got := cacheLen(); got != maxEntries {
+		t.Fatalf("cache length after refreshing a cached key = %d, want %d", got, maxEntries)
+	}
+
+	// A new key at capacity still resets: the bound is an anti-leak cap, not an
+	// eviction policy.
+	storePiHeaderCacheEntry("/pi/new.jsonl", piHeaderCacheEntry{size: 1}, maxEntries)
+	if got := cacheLen(); got != 1 {
+		t.Fatalf("cache length after inserting a new key at capacity = %d, want 1", got)
+	}
+}
+
+func TestFindPiSessionFileByIDRetriesAfterUnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-000 unreadable file is not enforced for root")
+	}
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	// Seal the transcript so os.Open fails with EACCES. That is an I/O failure,
+	// not a file that genuinely carries no session header.
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod 000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID() while unreadable = %q, want empty", got)
+	}
+
+	// Restoring the mode leaves size and mtime untouched, so the stat signature
+	// is unchanged: only a cache that refused to store the failed read can see
+	// the transcript again. Caching it would strand an idle transcript
+	// indefinitely, because nothing appends to it to change the signature.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod 644: %v", err)
+	}
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() after the read recovered = %q, want %q", got, path)
+	}
+}
+
+func TestFindPiSessionFileByIDRetriesAfterScanError(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	path := filepath.Join(root, "session.jsonl")
+
+	// A first line past the scanner's 1 MB limit surfaces as bufio.ErrTooLong:
+	// a read failure that Scan reports the same way as an empty file.
+	const total = 1024*1024 + 1024
+	if err := os.WriteFile(path, append(bytes.Repeat([]byte("x"), total-1), '\n'), 0o644); err != nil {
+		t.Fatalf("write oversized first line: %v", err)
+	}
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID() with an oversized first line = %q, want empty", got)
+	}
+
+	// Put a real header on line 1 and pad line 2 to the identical byte count, so
+	// the stat signature cannot change and only a re-read can find the header.
+	rewritePiFilePreservingSignature(t, path, func() {
+		header := piHeaderLine("session", "sess-1", workDir) + "\n"
+		body := append([]byte(header), bytes.Repeat([]byte("x"), total-len(header)-1)...)
+		if err := os.WriteFile(path, append(body, '\n'), 0o644); err != nil {
+			t.Fatalf("write header with padding: %v", err)
+		}
+	})
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() after the scan error cleared = %q, want %q", got, path)
+	}
+}
+
+func TestFindPiSessionFileByIDCachesNonSessionFirstLine(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	path := filepath.Join(root, "notes.jsonl")
+	writePiHeaderFile(t, path, "message", "sess-1", workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID() for a non-session first line = %q, want empty", got)
+	}
+
+	// "message" and "session" are the same byte length, so this rewrite keeps the
+	// stat signature. An absence derived from content — not from a failed read —
+	// is exactly what the signature tracks, so it must stay cached: that is the
+	// negative-caching win on non-pi .jsonl files.
+	rewritePiFilePreservingSignature(t, path, func() {
+		writePiHeaderFile(t, path, "session", "sess-1", workDir)
+	})
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID() after a same-signature rewrite = %q, want the cached empty result", got)
+	}
+}
+
+func TestFindPiSessionFileStrictStaysAmbiguousAfterTransientReadFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-000 unreadable file is not enforced for root")
+	}
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	firstPath := filepath.Join(root, "first.jsonl")
+	secondPath := filepath.Join(root, "second.jsonl")
+	writePiHeaderFile(t, firstPath, "session", "first", workDir)
+	writePiHeaderFile(t, secondPath, "session", "second", workDir)
+
+	if err := os.Chmod(secondPath, 0o000); err != nil {
+		t.Fatalf("chmod 000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secondPath, 0o644) })
+
+	// While the second transcript cannot be read it is not a candidate, so the
+	// guard sees one. That was true before the cache existed too.
+	got, err := FindPiSessionFileStrict([]string{root}, workDir)
+	if err != nil || got != firstPath {
+		t.Fatalf("FindPiSessionFileStrict() while unreadable = (%q, %v), want (%q, nil)", got, err, firstPath)
+	}
+
+	// chmod leaves size and mtime alone. Caching the failed read would keep the
+	// second transcript invisible, flipping the same-workdir guard from
+	// fail-closed to a confident wrong answer that callers then mutate.
+	if err := os.Chmod(secondPath, 0o644); err != nil {
+		t.Fatalf("chmod 644: %v", err)
+	}
+	if _, err := FindPiSessionFileStrict([]string{root}, workDir); !errors.Is(err, ErrAmbiguousPiSessionFile) {
+		t.Fatalf("FindPiSessionFileStrict() after the read recovered = %v, want ErrAmbiguousPiSessionFile", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`findPiSessionCandidatesIn` walks the whole pi sessions tree and opens + JSON-parses the first line of **every** `.jsonl` on **every** candidate scan. The scan runs per session row per `GET /sessions` request (via `ResolveKeyedTranscriptPaths` → `DiscoverKeyedPath` → `FindPiSessionFileByID`), so a page of N pi sessions over a tree of M transcripts costs N×M file opens per request — repeated for every request, even though transcript headers essentially never change after the first line is written.

Measured on a loaded 6-core host (16 active sessions, 152 transcript files): `GET /v0/city/{city}/sessions` took **29–43s per request**, with `sample` showing the time in `sessionlog.piSessionHeader` / `findPiSessionCandidatesIn` (walkDir + per-file open + `bufio.Scan` + `json.Unmarshal`, plus the 64KB scanner buffer allocation per file feeding GC pressure).

## Fix

Memoize the parsed header per path, keyed by the file's `(size, mtime)` stat signature:

- unchanged file → one `stat` (already needed for `modTime`), no open/parse
- rewritten file → new signature → re-parse
- deleted file → drops out naturally, because the walk still drives candidate membership; the cache only short-circuits the header read

The map is bounded (`piHeaderCacheMaxEntries`) and resets past the cap rather than growing forever on churned paths.

## Result

Same host, same workload, after deploying this change: `GET /sessions` **42s → 1.2–3.1s**; 1-minute load fell 33 → 12 within two minutes of cutover. Keyed pi transcript resolution verified end-to-end afterwards (`gc session logs <pi-session>` streams the correct transcript).

## Tests

- `TestFindPiSessionFileByIDSkipsRereadWhenStatSignatureUnchanged` — proves the cache actually short-circuits the read (in-place rewrite with identical size+mtime still serves the cached header)
- `TestFindPiSessionFileByIDInvalidatesCacheOnChangedSignature` — rewrite with a new signature re-parses
- `TestFindPiSessionFileByIDDropsDeletedFileDespiteCache` — deletion still removes the candidate

Related: #4390 tracks the same endpoint's O(N) growth from live runtime enrichment — different mechanism (client-go QPS on pod lookups); this PR removes the transcript-discovery term, and is kept deliberately small and standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)