### PR TITLE
fix(pool): keep idle pool sessions bound to work still in demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -3174,6 +3174,7 @@ func realizePoolDesiredSessionsAt(
 	// reserve an (alias, slot) for a fresh create. Mutates used/usedSlots
 	// under serial control so dedup and slot allocation remain deterministic.
 	items := make([]poolRealizeWorkItem, 0, len(poolState.Requests))
+	boundByWork, reserved := poolSessionsBoundToDemandedWork(bp, cfgAgent, qualifiedName, poolState.Requests)
 	for _, request := range poolState.Requests {
 		// planItem runs the per-request selection and returns the work item;
 		// any early-out (skip path) sets item.skip and returns. The single
@@ -3181,6 +3182,22 @@ func realizePoolDesiredSessionsAt(
 		planItem := func() poolRealizeWorkItem {
 			item := poolRealizeWorkItem{request: request}
 			var prefer *session.Info
+			selectUsed := used
+			if request.SessionBeadID == "" {
+				if bound, ok := boundByWork[strings.TrimSpace(request.WorkBeadID)]; ok && !used[bound.ID] {
+					prefer = &bound
+				} else if len(reserved) > 0 {
+					// Leave sessions bound to other still-demanded work for
+					// those requests; positional reuse would re-point them.
+					selectUsed = make(map[string]bool, len(used)+len(reserved))
+					for id := range used {
+						selectUsed[id] = true
+					}
+					for id := range reserved {
+						selectUsed[id] = true
+					}
+				}
+			}
 			if request.SessionBeadID != "" {
 				if candidate, ok := bp.sessionBeads.FindInfoByID(request.SessionBeadID); ok {
 					// Defense in depth: ComputePoolDesiredStates filters out
@@ -3195,7 +3212,7 @@ func realizePoolDesiredSessionsAt(
 					prefer = &candidate
 				}
 			}
-			sessionInfo, slot, plan, err := selectOrPlanPoolSessionBead(bp, cfgAgent, qualifiedName, prefer, request, poolDecisionTime, used, usedSlots)
+			sessionInfo, slot, plan, err := selectOrPlanPoolSessionBead(bp, cfgAgent, qualifiedName, prefer, request, poolDecisionTime, selectUsed, usedSlots)
 			if err != nil {
 				switch {
 				case errors.Is(err, errPoolSessionCreateBudgetExhausted):
@@ -3369,6 +3386,45 @@ func realizePoolDesiredSessionsAt(
 		installAgentSideEffects(bp, resolveAgent, tp, stderr)
 		desired[tp.SessionName] = tp
 	}
+}
+
+// poolSessionsBoundToDemandedWork maps each new-tier request's work bead to the
+// reusable session already carrying it as gc.trigger_bead_id, and returns the
+// IDs of those sessions so other requests skip them. Reuse in
+// selectOrPlanPoolSessionBead is otherwise positional (j-th request, j-th
+// reusable session), so any shift in request order or in the session set
+// between passes re-points every idle session's trigger — one store write and
+// one bead.updated event per session per reconcile tick (sys-rgwg4x).
+func poolSessionsBoundToDemandedWork(bp *agentBuildParams, cfgAgent *config.Agent, template string, requests []SessionRequest) (map[string]session.Info, map[string]bool) {
+	demanded := make(map[string]bool, len(requests))
+	for _, request := range requests {
+		if request.SessionBeadID != "" {
+			continue
+		}
+		if id := strings.TrimSpace(request.WorkBeadID); id != "" {
+			demanded[id] = true
+		}
+	}
+	if len(demanded) == 0 {
+		return nil, nil
+	}
+	boundByWork := make(map[string]session.Info)
+	reserved := make(map[string]bool)
+	for _, info := range reusablePoolSessionInfos(bp, cfgAgent, template, nil) {
+		if strings.TrimSpace(info.SessionNameMetadata) == "" {
+			continue
+		}
+		trigger := strings.TrimSpace(info.TriggerBeadID)
+		if !demanded[trigger] {
+			continue
+		}
+		if _, dup := boundByWork[trigger]; dup {
+			continue
+		}
+		boundByWork[trigger] = info
+		reserved[info.ID] = true
+	}
+	return boundByWork, reserved
 }
 
 // computePoolTriggerBindingPatch is the pure key-diff at the heart of

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4402,6 +4402,101 @@ func TestRealizePoolDesiredSessionsRebindUpdatesPackWorkspaceMetadata(t *testing
 	}
 }
 
+// seedReusablePoolSession creates an active, idle pool session bead for
+// template "worker" bound to triggerBead, and registers it in snapshot.
+func seedReusablePoolSession(t *testing.T, store beads.Store, snapshot *sessionBeadSnapshot, slot int, triggerBead string) beads.Bead {
+	t.Helper()
+	name := fmt.Sprintf("worker-%d", slot)
+	b, err := store.Create(beads.Bead{
+		Title:  name,
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":                        "worker",
+			"agent_name":                      name,
+			"alias":                           name,
+			"session_name":                    name,
+			"state":                           string(sessionpkg.BaseStateActive),
+			"pool_slot":                       strconv.Itoa(slot),
+			poolManagedMetadataKey:            boolMetadata(true),
+			beadmeta.TriggerBeadIDMetadataKey: triggerBead,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot.addInfo(sessiontest.SeedBead(t, b))
+	return b
+}
+
+// New-tier demand must reuse the idle session already carrying that work bead
+// as its trigger, and must not steal a session whose trigger is another bead
+// still in this pass's demand. Positional pairing re-pointed every idle
+// session's gc.trigger_bead_id whenever the request order or the session set
+// shifted between passes — a live store write plus a bead.updated event per
+// session per reconcile tick (sys-rgwg4x).
+func TestRealizePoolDesiredSessionsKeepsIdleSessionsBoundToTheirDemandedWork(t *testing.T) {
+	tests := []struct {
+		name     string
+		requests []string       // new-tier WorkBeadIDs, in request order
+		want     map[int]string // pool slot -> expected trigger after realize
+	}{
+		{
+			name:     "reversed request order keeps both bindings",
+			requests: []string{"gp-b", "gp-a"},
+			want:     map[int]string{1: "gp-a", 2: "gp-b"},
+		},
+		{
+			name:     "new work takes the session whose bead left demand, not the one still demanded",
+			requests: []string{"gp-c", "gp-a"},
+			want:     map[int]string{1: "gp-a", 2: "gp-c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			snapshot := &sessionBeadSnapshot{}
+			byID := map[int]string{}
+			for slot, trigger := range map[int]string{1: "gp-a", 2: "gp-b"} {
+				byID[slot] = seedReusablePoolSession(t, store, snapshot, slot, trigger).ID
+			}
+			cfg := &config.City{
+				Workspace: config.Workspace{Name: "test-city"},
+				Agents: []config.Agent{{
+					Name:              "worker",
+					StartCommand:      "true",
+					WorkDir:           ".gc/workspaces/{{.AgentBase}}",
+					MinActiveSessions: intPtr(0),
+					MaxActiveSessions: intPtr(2),
+				}},
+			}
+			var stderr bytes.Buffer
+			bp := newAgentBuildParams("test-city", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+			bp.sessionBeads = snapshot
+			requests := make([]SessionRequest, 0, len(tt.requests))
+			for _, id := range tt.requests {
+				requests = append(requests, SessionRequest{Template: "worker", Tier: "new", WorkBeadID: id})
+			}
+
+			realizePoolDesiredSessions(bp, &cfg.Agents[0], PoolDesiredState{Template: "worker", Requests: requests}, map[string]TemplateParams{}, &stderr)
+
+			if got := len(bp.sessionBeads.OpenInfos()); got != 2 {
+				t.Fatalf("open session beads = %d, want 2 (no fresh create); stderr=%q", got, stderr.String())
+			}
+			for slot, wantTrigger := range tt.want {
+				stored, err := store.Get(byID[slot])
+				if err != nil {
+					t.Fatalf("Get(slot %d): %v", slot, err)
+				}
+				if got := stored.Metadata[beadmeta.TriggerBeadIDMetadataKey]; got != wantTrigger {
+					t.Errorf("slot %d trigger = %q, want %q", slot, got, wantTrigger)
+				}
+			}
+		})
+	}
+}
+
 func TestRealizePoolDesiredSessionsLiveRetryPreservesLauncherWorkDir(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Problem

`realizePoolDesiredSessions` pairs new-tier requests with reusable sessions positionally (j-th request → j-th reusable session) and ignores the work bead a session already carries as `gc.trigger_bead_id`. Any shift in request order or in the session set between reconcile passes re-points every idle session's trigger, which is a store write plus a ~3 KB `bead.updated` event per session per tick.

Measured on a live city (6-core Mac mini, 4 hudson pool workers, 5 routed-unclaimed beads): one session bead received 134 `bead.updated` events in an hour, 133 of them a `gc.trigger_bead_id` flip cycling among the same 5 beads. Session-bead updates were 80% of `events.jsonl` bytes and the HQ Dolt log showed 700–1300 commits/hour around the clock, almost all `update bead <session>`. Every one of those events also fires the core pack's `nudge-on-route` event order.

## Fix

Before positional reuse, a new-tier request prefers the reusable session whose `TriggerBeadID` equals its `WorkBeadID`, and sessions bound to another bead still in this pass's demand are reserved for that bead's request. Behaviour for resume-tier requests and for sessions whose trigger left demand is unchanged.

## Test

`TestRealizePoolDesiredSessionsKeepsIdleSessionsBoundToTheirDemandedWork` covers both the reversed-request-order case and the "new work takes the session whose bead left demand" case. Without the fix it fails with `slot 1 trigger = "gp-b", want "gp-a"` (the positional swap); with it, `go vet` and the `Pool*`/`TriggerBinding*` tests in `cmd/gc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hwr5v9b9Fg7yYpdaN56DGJ