### PR TITLE
fix(api): key the orders/check response cache on time, not the event sequence

### DIFF
--- a/internal/api/handler_order_check_cache_test.go
+++ b/internal/api/handler_order_check_cache_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// orderCheckTestOrders returns two cooldown orders — enough to make the
+// per-order fan-out visible in the store's call count, and deliberately free
+// of any condition trigger, which would disable the response cache outright.
+//
+// Each names a rig, because that is what gives it a store to read history
+// from: orderStoreInfosForState resolves a rig-scoped store first, and an
+// order naming neither a rig nor a city store yields no store info at all, so
+// the history read is skipped and the fan-out this file measures never
+// happens.
+func orderCheckTestOrders() []orders.Order {
+	enabled := true
+	return []orders.Order{
+		{Name: "dolt-health", Exec: "dolt status", Trigger: "cooldown", Interval: "5m", Rig: "myrig", Enabled: &enabled},
+		{Name: "mail-sweep", Exec: "gc mail sweep", Trigger: "cooldown", Interval: "5m", Rig: "myrig", Enabled: &enabled},
+	}
+}
+
+// TestHandleOrderCheckCachesAcrossIndexChanges pins the fix:
+// /orders/check keys its response cache on a wall-clock time bucket, not on
+// the event sequence.
+//
+// Keyed on the sequence, the cache was unreachable for the callers that need
+// it most. Building this body costs one labeled bead List per order per
+// store, and the endpoint's readers are pollers: the SBF observability
+// exporter reads it once a minute. On the two production cities the sequence
+// advanced about six times a minute, so an entry stored under one index was
+// never looked up under that index again, and every poll paid the full
+// rebuild — 5.8-11.1s on a 23-order city, 14.2-22.4s on a 26-order one,
+// against the exporter's 5s per-call timeout. Its collector marks a city down
+// when any single endpoint fails, so both cities reported unreachable while
+// every other endpoint answered normally.
+func TestHandleOrderCheckCachesAcrossIndexChanges(t *testing.T) {
+	// A wide bucket puts every request in this test in the same bucket, which
+	// isolates "sequence churn must not bust the cache" from bucket-boundary
+	// timing. The floor is pinned off so the bucket lookup alone carries the
+	// assertion.
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	oldFloor := orderCheckResponseTTLFloor
+	orderCheckResponseTTLFloor = 0
+	t.Cleanup(func() {
+		timeBucketResponseCacheTTL = oldTTL
+		orderCheckResponseTTLFloor = oldFloor
+	})
+
+	state := newFakeState(t)
+	store := &countingStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = store
+	state.autos = orderCheckTestOrders()
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/orders/check"), nil)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first orders/check = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	built := store.listByLabelCalls
+	if built == 0 {
+		t.Fatalf("labeled List calls after the first build = 0, want the per-order history reads; the test is not exercising the fan-out it means to")
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second orders/check = %d, want 200", rec.Code)
+	}
+	if store.listByLabelCalls != built {
+		t.Fatalf("labeled List calls after a cached repeat = %d, want %d", store.listByLabelCalls, built)
+	}
+
+	// The busy-city scenario: a moving event sequence must keep hitting the
+	// time-bucketed cache rather than forcing a rebuild.
+	for i := 0; i < 5; i++ {
+		state.eventProv.Record(events.Event{Type: events.BeadCreated, Actor: "human"})
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("orders/check after event %d = %d, want 200", i, rec.Code)
+		}
+	}
+	if store.listByLabelCalls != built {
+		t.Fatalf("labeled List calls after 5 sequence advances = %d, want %d (a time-bucketed cache must survive sequence churn)", store.listByLabelCalls, built)
+	}
+}
+
+// TestHandleOrderCheckServesStaleAndRefreshesInBackground pins the path that
+// actually keeps a fixed-interval poller off the cold build.
+//
+// A poller whose interval exceeds both the bucket TTL and the floor misses
+// both fast lookups every time, which is the exporter's exact shape: it reads
+// once a minute, and no wall-clock window short enough to be useful to
+// interactive callers is long enough to survive that gap. Serving the stale
+// entry and refreshing behind it is what makes that request cheap, and it is
+// the same treatment /status received (ra-4u2eqc).
+func TestHandleOrderCheckServesStaleAndRefreshesInBackground(t *testing.T) {
+	// Both fast lookups off: a zero bucket TTL gives every request its own
+	// bucket, and a zero floor admits nothing. Every request after the first
+	// therefore reaches the stale path.
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = 0
+	oldFloor := orderCheckResponseTTLFloor
+	orderCheckResponseTTLFloor = 0
+	t.Cleanup(func() {
+		timeBucketResponseCacheTTL = oldTTL
+		orderCheckResponseTTLFloor = oldFloor
+	})
+
+	state := newFakeState(t)
+	store := &countingStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = store
+	state.autos = orderCheckTestOrders()
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/orders/check"), nil)
+
+	// Prime the cache, so the request below has a stale entry to be served
+	// rather than falling through to the synchronous cold-start build.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("priming orders/check = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	primed := rec.Body.String()
+	builtOnce := store.listByLabelCalls
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("stale-served orders/check = %d, want 200", rec2.Code)
+	}
+	if rec2.Body.String() != primed {
+		t.Fatalf("stale-served body differs from the primed body\n got: %s\nwant: %s", rec2.Body.String(), primed)
+	}
+
+	srv.waitForBackground()
+
+	if store.listByLabelCalls <= builtOnce {
+		t.Fatalf("labeled List calls after the background refresh = %d, want more than %d (the refresh never rebuilt)", store.listByLabelCalls, builtOnce)
+	}
+	// Asserted over the whole map rather than against a reconstructed key.
+	// OrderCheckInput embeds CityScope, so the handler's key carries the city
+	// path parameter and a literal built here would not match it — the lookup
+	// would be false whether or not a guard leaked. "No guard is held for any
+	// key once the refresh has returned" is also the property that matters: a
+	// leaked one wedges every future refresh for that key.
+	if len(srv.responseRefreshing) != 0 {
+		t.Fatalf("responseRefreshing = %v after the background refresh returned, want empty (a leaked guard wedges every future refresh)", srv.responseRefreshing)
+	}
+}
+
+// TestHandleOrderCheckFreshBypassesCache holds the escape hatch open: a caller
+// that cannot tolerate a body built up to one poll interval ago asks for
+// ?fresh=true and is never served a cached one. Without this the staleness the
+// two tests above introduce would have no bound a caller can opt out of.
+func TestHandleOrderCheckFreshBypassesCache(t *testing.T) {
+	oldTTL := timeBucketResponseCacheTTL
+	timeBucketResponseCacheTTL = time.Hour
+	t.Cleanup(func() { timeBucketResponseCacheTTL = oldTTL })
+
+	state := newFakeState(t)
+	store := &countingStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = store
+	state.autos = orderCheckTestOrders()
+	h := newTestCityHandler(t, state)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, cityURL(state, "/orders/check"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("priming orders/check = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	built := store.listByLabelCalls
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, cityURL(state, "/orders/check?fresh=true"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fresh orders/check = %d, want 200", rec.Code)
+	}
+	if store.listByLabelCalls <= built {
+		t.Fatalf("labeled List calls after ?fresh=true = %d, want more than %d (fresh must rebuild)", store.listByLabelCalls, built)
+	}
+}

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,20 +67,91 @@ type OrderCheckListOutput struct {
 	Body OrderCheckListBody
 }
 
+// orderCheckResponseTTLFloor lets a non-fresh orders/check reuse a recently
+// built body after the time-bucket entry has rolled over, the same way
+// statusResponseTTLFloor does for /status. Var, not const, so tests can pin
+// the lookup order.
+var orderCheckResponseTTLFloor = 30 * time.Second
+
 // humaHandleOrderCheck is the Huma-typed handler for GET /v0/orders/check.
+//
+// The response cache is keyed on a TIME bucket rather than the event
+// sequence, and falls back to a TTL floor and then to stale-while-revalidate,
+// because this body is expensive to build and its readers poll on a fixed
+// interval. Building it costs one bead List per order per store — measured
+// 5.8-11.1s for a 23-order city and 14.2-22.4s for a 26-order one — while the
+// event sequence advanced about six times a minute on those same cities, so
+// an entry keyed on the index never survived to the next poll and every poll
+// paid the full rebuild. The SBF observability exporter reads this endpoint
+// once a minute with a 5s per-call timeout, and timed out on every scrape in
+// both cities; its collector marks a city down when any endpoint fails, so
+// the whole city read as unreachable while every other endpoint answered
+// normally.
+//
+// The three lookups are the /status recipe (ra-4u2eqc), for the same reason
+// it was adopted there: the bucket serves a burst of polls, the floor smooths
+// the bucket boundary, and the stale path keeps a fixed-interval poller off
+// the cold build entirely, refreshing behind it so the next poll is served a
+// body built without anyone waiting for it.
+//
+// Strict-freshness callers pass ?fresh=true and bypass all three, as before.
+// A city holding a condition-triggered order is never cached at all: its
+// due-ness comes from running a subprocess, and a cached answer would report
+// a check that did not happen.
 func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput) (*OrderCheckListOutput, error) {
 	aa := s.state.Orders()
 
-	ep := s.state.EventProvider()
-
-	index := s.latestIndex()
 	cacheKey := cacheKeyFor("orders-check", input)
 	useResponseCache := !input.Fresh && !hasConditionOrder(aa)
 	if useResponseCache {
-		if body, ok := cachedResponseAs[OrderCheckListBody](s, cacheKey, index); ok {
+		bucket := responseCacheTimeBucket(time.Now())
+		if body, ok := cachedResponseAs[OrderCheckListBody](s, cacheKey, bucket); ok {
+			return &OrderCheckListOutput{Body: body}, nil
+		}
+		if body, ok := cachedResponseWithinAgeAs[OrderCheckListBody](s, cacheKey, orderCheckResponseTTLFloor); ok {
+			return &OrderCheckListOutput{Body: body}, nil
+		}
+		if body, _, ok := staleResponseAs[OrderCheckListBody](s, cacheKey); ok {
+			s.refreshOrderCheckResponseInBackground(cacheKey)
 			return &OrderCheckListOutput{Body: body}, nil
 		}
 	}
+
+	body := s.buildOrderCheckBody(input.Fresh)
+	if useResponseCache {
+		s.storeResponse(cacheKey, responseCacheTimeBucket(time.Now()), body)
+	}
+	return &OrderCheckListOutput{Body: body}, nil
+}
+
+// refreshOrderCheckResponseInBackground kicks a detached rebuild of the
+// orders/check body for cacheKey and stores it under the time bucket current
+// at completion, so the next poll is served a fresh body without any caller
+// paying the rebuild cost inline. Coalesced via beginResponseRefresh, and
+// always non-fresh: only the cached path reaches it.
+func (s *Server) refreshOrderCheckResponseInBackground(cacheKey string) {
+	if !s.beginResponseRefresh(cacheKey) {
+		return
+	}
+	s.runBackground(func(_ context.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				// Best-effort, like the /status refresh: withRecovery does not
+				// cover detached goroutines, and the next poll rebuilds.
+				log.Printf("api: panic in background /orders/check refresh: %v\n%s", r, debug.Stack())
+			}
+		}()
+		defer s.endResponseRefresh(cacheKey)
+		s.storeResponse(cacheKey, responseCacheTimeBucket(time.Now()), s.buildOrderCheckBody(false))
+	})
+}
+
+// buildOrderCheckBody evaluates every order's trigger and builds the
+// orders/check response body. fresh bypasses the cached order-history reads
+// the evaluation is built on.
+func (s *Server) buildOrderCheckBody(fresh bool) OrderCheckListBody {
+	aa := s.state.Orders()
+	ep := s.state.EventProvider()
 
 	now := time.Now()
 	checks := make([]orderCheckResponse, 0, len(aa))
@@ -88,8 +160,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput)
 		if err != nil {
 			storeInfos = nil
 		}
-		history, _ := orderHistoryBeadsAcrossStoreInfosForCheck(storeInfos, a.ScopedName(), 1, time.Time{}, input.Fresh)
-		result := checkOrderTriggerForAPI(a, now, history, storeInfos, ep, input.Fresh)
+		history, _ := orderHistoryBeadsAcrossStoreInfosForCheck(storeInfos, a.ScopedName(), 1, time.Time{}, fresh)
+		result := checkOrderTriggerForAPI(a, now, history, storeInfos, ep, fresh)
 		cr := orderCheckResponse{
 			Name:       a.Name,
 			ScopedName: a.ScopedName(),
@@ -115,12 +187,7 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput)
 		checks = []orderCheckResponse{}
 	}
 
-	out := &OrderCheckListOutput{}
-	out.Body.Checks = checks
-	if useResponseCache {
-		s.storeResponse(cacheKey, index, out.Body)
-	}
-	return out, nil
+	return OrderCheckListBody{Checks: checks}
 }
 
 func hasConditionOrder(aa []orders.Order) bool {


### PR DESCRIPTION
## The problem

`/orders/check` has had a response cache since it was written, and its own pollers could never hit it. The entry was stored under the event sequence and looked up under exact equality:

```go
index := s.latestIndex()
if body, ok := cachedResponseAs[OrderCheckListBody](s, cacheKey, index); ok {
```

Any event anywhere in the city advances that index, including the events the polling itself emits. So the lookup missed on every request that was not a second request inside the same quiet moment — which, on a city doing work, does not happen.

That would be merely wasteful if the body were cheap. It is not: building it evaluates every order's due-ness on demand and costs **one labeled bead List per order per store**.

## Measured

Against the live supervisor at `127.0.0.1:8372`, two production cities:

| endpoint | time |
|---|---|
| `runs/census` | 0.001s |
| `orders` | 0.004s |
| `status` | 1.0s |
| **`orders/check`** | **5.8–11.1s** (23 orders) / **14.2–22.4s** (26 orders) |

The event sequence advanced roughly **six times a minute** on both cities. Every poll paid the full rebuild.

## Why it surfaced as something else entirely

The SBF observability exporter reads this endpoint once a minute with a 5s per-call timeout, so it timed out on **every** scrape in both cities. Its collector marks a city down when any single endpoint fails — so `city_up` sat at 0 while `status`, `orders` and `runs/census` all answered normally. The dashboard read *two cities unreachable* on a page where every other panel showed live data, and the whole order-health metric family was simply absent, because it is sourced from this endpoint alone.

The endpoint being slow is visible. The endpoint being slow *and* presenting as a reachability failure is not.

## The change

Adopt the `/status` recipe (`ra-4u2eqc`, #5028) wholesale — this is the same failure in the same shape, one handler over:

1. **Key on `responseCacheTimeBucket`** instead of the event index, so the entry survives sequence churn.
2. **TTL floor** (`orderCheckResponseTTLFloor`, 30s) for the request that lands just past a bucket boundary.
3. **Stale-while-revalidate** — serve the last-known-good body and refresh behind it.

The third is the load-bearing one, and it is worth being explicit about why the first two are not enough on their own. A fixed-interval poller reading once a minute misses **both** fast lookups every time: no wall-clock window short enough to be useful to an interactive caller is long enough to survive a 60s gap. Without the stale path, a 1/min reader pays the cold build on every single read no matter how the bucket is tuned. With it, no caller waits on the rebuild at all.

`refreshOrderCheckResponseInBackground` mirrors `refreshStatusResponseInBackground`: coalesced through `beginResponseRefresh` so concurrent misses share one rebuild, `defer s.endResponseRefresh` on every exit path, and a `recover()` because `withRecovery` does not cover detached goroutines.

## Unchanged

- `?fresh=true` bypasses all three lookups.
- The response shape. `/status` widens `X-GC-Cache-Age-S` to report response-entry age when it serves stale (`huma_types.go`); `OrderCheckListOutput` carries no such header — it is a bare `Body` struct, not a `ListOutput`/`IndexOutput` — so there is nothing here to widen, and adding one would be an OpenAPI change rather than a fix. That is the one part of the `/status` recipe deliberately not adopted.
- A city holding a **condition-triggered** order is not cached at all, exactly as before — its due-ness comes from running a subprocess, and a cached answer would report a check that did not happen.

## Tests

Three, in `handler_order_check_cache_test.go`. Each asserts on **work done** (`countingStore.listByLabelCalls`), not on the returned body, since a test that only compared responses would pass against the old index-keyed cache too.

- `TestHandleOrderCheckCachesAcrossIndexChanges` — five event-sequence advances between requests, and the fan-out must not repeat. This is the bug.
- `TestHandleOrderCheckServesStaleAndRefreshesInBackground` — both fast lookups pinned off, so every request after the first reaches the stale path; asserts the served body is byte-identical to the primed one, that the background refresh did rebuild, and that `responseRefreshing` is empty afterwards (a leaked guard wedges every future refresh for that key).
- `TestHandleOrderCheckFreshBypassesCache` — the escape hatch stays open.

`go test ./internal/api/` passes (135s, full package); `-race` on the new tests clean; pinned golangci-lint v2.12.0 reports 0 issues across `./internal/api/...`.

## Adjacent, not fixed here

The per-order evaluation is still serial and still O(orders × stores) in bead reads — this change makes at most one caller per bucket pay it instead of every caller, but does not make it cheaper. Evaluating orders concurrently, or splitting the expensive reason string behind a query parameter, are separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7UDQDVxrVJiFm4N6hrKUQ
