### PR TITLE
fix(reconciler): defer pending-create recovery while the start is in flight after the awake heal

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2893,7 +2893,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 		if alive && shouldRollbackPendingCreateInfo(infoByID[id]) {
 			switch stateBeforeHeal {
-			case sessionpkg.StateStartPending, sessionpkg.StateCreating:
+			// StateAwake belongs here with the two pre-start states: it is written
+			// only by the heal pass, which projects an alive tmux runtime to awake
+			// on the tick after PreWakePatch while the async provider.Start is
+			// still running under the startup timeout. Without it, that awake
+			// rewrite handed the still-starting session to
+			// recoverRunningPendingCreate, which committed the start (claim
+			// cleared, started_config_hash set) seconds before the goroutine's own
+			// deadline fired; the deadline then recorded a wake failure —
+			// continuation_reset_pending=true, session_key and started_config_hash
+			// cleared, wake_attempts accrued — against a runtime already committed
+			// as started, and nothing ever cleared the flag on the live runtime.
+			// StateActive is deliberately NOT here: only CommitStartedPatch writes
+			// it, so a claim on an active bead is a partial write to repair now
+			// (sys-ot93jj).
+			case sessionpkg.StateStartPending, sessionpkg.StateCreating, sessionpkg.StateAwake:
 				if pendingCreateStartInFlightInfo(infoByID[id], clk, startupTimeout) {
 					if trace != nil {
 						trace.RecordDecision(TraceSiteReconcilerPendingCreate, TraceReasonPendingCreateRecoveryInFlight, TraceOutcomeDeferred, tp.TemplateName, name, nil)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5908,6 +5908,60 @@ func TestReconcileSessionBeads_DefersPendingCreateRecoveryWhileStartInFlight(t *
 	}
 }
 
+// Regression for sys-ot93jj: the heal pass projects an alive tmux runtime to
+// state=awake on the tick after PreWakePatch, while the async provider.Start
+// is still in flight under the startup timeout. The pending-create recovery
+// gate used to key its in-flight guard on stateBeforeHeal being
+// creating/start-pending, so that awake rewrite let recoverRunningPendingCreate
+// commit the start (claim cleared, started_config_hash set) seconds before the
+// goroutine's own deadline fired — which then recorded a wake failure
+// (continuation_reset_pending=true, session_key/started_config_hash cleared,
+// wake_attempts accrued) against a runtime already committed as started, and
+// nothing ever cleared the flag on the live runtime.
+func TestReconcileSessionBeads_DefersPendingCreateRecoveryWhileStartInFlightAfterAwakeHeal(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "new-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"command":              "old-cmd",
+		"state":                "awake",
+		"pending_create_claim": "true",
+		"last_woke_at":         env.clk.Now().Add(-45 * time.Second).UTC().Format(time.RFC3339),
+	})
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "old-cmd"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.sp.SetMeta("worker", "GC_INSTANCE_TOKEN", session.Metadata["instance_token"]); err != nil {
+		t.Fatal(err)
+	}
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 while pending create start is still in flight", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want empty until async start commits", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want preserved while async start is in flight", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["state"] != "awake" {
+		t.Fatalf("state = %q, want awake while async start is in flight", got.Metadata["state"])
+	}
+}
+
 func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}


### PR DESCRIPTION
Fixes #6104.

## Problem

The heal pass projects an alive tmux runtime to `state=awake` on the tick after `PreWakePatch`, while the async `provider.Start` is still running under `startup_timeout`. The pending-create recovery gate keyed its in-flight guard on `stateBeforeHeal` being creating/start-pending, so that awake rewrite let `recoverRunningPendingCreate` commit the start (claim cleared, `started_config_hash` set) seconds before the goroutine's own deadline fired. The deadline then took the non-rollback failure arm (`rollbackPending` is false once the claim is gone, which also skips the runtime-converged shortcut) and `recordWakeFailure` wrote `ConversationResetPatch` — `continuation_reset_pending=true`, `session_key`/`started_config_hash` cleared, `wake_attempts` accrued — against a runtime already committed as started. Nothing clears that flag while the runtime lives, so the session shows `reset-pending` for its whole life and is exempt from idle sleep. Full timelines from two live instances are in the issue.

## Change

Add `StateAwake` to the guard's state set in `cmd/gc/session_reconciler.go`. `awake` is written only by the heal's alive projection (`projectRuntimeProjection`), so it is the post-heal face of an in-flight create. `active` is deliberately not added: only `CommitStartedPatch` writes it, so a claim on an active bead is a genuine partial write to repair now — that keeps `TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep` green (an active bead with a leftover claim must still be idle-stopped). Once the lease ages out, recovery proceeds exactly as before.

## Test

`TestReconcileSessionBeads_DefersPendingCreateRecoveryWhileStartInFlightAfterAwakeHeal` mirrors the existing `…WhileStartInFlight` test with `state=awake` and `last_woke_at` 45s old. On main it fails with `started_config_hash = "v5:…", want empty until async start commits`; with the fix it passes, alongside `TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep`, `TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight` and `TestPendingCreateStartInFlight_*`. Full `./cmd/gc` run on the fix vs its parent: failure set is a strict subset of the parent's (pre-existing container-fixture failures only, none new).

## Dogfood

Running live on the reporting city since 2026-09-07T01:17Z (12-slot pool with starts routinely at 55-65s under load). Validation criterion tracked there: the next start storm produces zero awake/active beads with `continuation_reset_pending=true` and `last_woke_at=""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6KSsFYCAkiv8XvV7K5tWu