### PR TITLE
test(cmd/gc): raise canned leak-guard PIDs above pid_max

### DIFF
--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -193,9 +193,17 @@ func TestRequireNoLeakedDoltAfter_OnlyNewPIDsInDiff(t *testing.T) {
 //     (operators get one report per test, not N).
 //  2. PIDs are listed in ascending numerical order regardless of how
 //     the enumerator returns them.
+//
+// The canned PIDs are chosen well above the host's realistic maximum PID
+// (Linux /proc/sys/kernel/pid_max defaults to 4194304; 5000001/5000002 sit
+// above it). The leak guard's reaper polls processStillAlive (kill -0) for
+// each leaked PID until it exits or the deadline lapses; on a shared host a
+// low canned PID (e.g. 50001) can collide with a real process owned by
+// another user/namespace and read as alive forever, surfacing spurious
+// "cleanup failed" errors that break this test's single-Errorf assertion.
 func TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted(t *testing.T) {
-	leakedHi := doltTestProc(50002, "--port=3308")
-	leakedLo := doltTestProc(50001, "--port=3307")
+	leakedHi := doltTestProc(5000002, "--port=3308")
+	leakedLo := doltTestProc(5000001, "--port=3307")
 	enumerate := scriptedDoltEnumerator(t,
 		nil,
 		// Order in slice deliberately unsorted to verify the helper sorts.
@@ -212,13 +220,13 @@ func TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted(t *testing.T) {
 			len(inner.errors), inner.errors)
 	}
 	msg := inner.errors[0]
-	iLo := strings.Index(msg, "50001")
-	iHi := strings.Index(msg, "50002")
+	iLo := strings.Index(msg, "5000001")
+	iHi := strings.Index(msg, "5000002")
 	if iLo == -1 {
-		t.Errorf("error missing PID 50001; got %q", msg)
+		t.Errorf("error missing PID 5000001; got %q", msg)
 	}
 	if iHi == -1 {
-		t.Errorf("error missing PID 50002; got %q", msg)
+		t.Errorf("error missing PID 5000002; got %q", msg)
 	}
 	if iLo != -1 && iHi != -1 && iLo > iHi {
 		t.Errorf("PIDs not in ascending order; got %q", msg)


### PR DESCRIPTION
## Summary

`TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted` feeds canned fake PIDs (`50001`/`50002`) through `requireNoLeakedDoltAfterWith`, which asserts exactly **one** aggregated `Errorf`. The cleanup then reaps the leaked PIDs via `reapDoltLeakPIDsWithKiller`, whose waiter polls `processStillAlive` (`kill -0`) until each PID exits or a 5 s deadline elapses (added in #5402).

On a shared host those low canned PIDs can collide with real processes owned by another user/namespace: `ps` cannot see them, but `kill -0` returns success, so `processStillAlive` reports them alive forever. The reaper times out twice and emits two extra `test leaked dolt cleanup failed: pid N still alive after SIGKILL …` errors, taking the test from the expected 1 `Errorf` to 3 and failing the single-aggregation assertion.

## Fix

Move the canned PIDs to `5000001`/`5000002`, above Linux's default `/proc/sys/kernel/pid_max` (`4194304`), so they can never collide with a live host process. The test's sorting/aggregation guarantees are unchanged; only the fixture PIDs and the matching `strings.Index` literals move.

## Why not the other low canned PIDs in the file?

Sibling tests using `1000`/`1001`/`9999`/etc. either route through `requireNoLeakedDoltAfterWithFilterAndKiller` with tolerant assertions (`strings.Contains`, not an exact error count) or exercise the enumerator/filter/snapshot logic without the production-waiter reap, so they do not flake on phantom aliveness. This change is surgical to the one test whose `len(inner.errors) != 1` assertion is broken by the collision.

## Testing

- Targeted test reproduced red before the change (3 errors instead of 1 on a host where PIDs 50001/50002 are live in another namespace).
- After: `go test -run TestRequireNoLeakedDoltAfter_MultipleLeaksReportedSorted ./cmd/gc/` passes **5 consecutive runs**.
- Full leak-helper + reaper suite green: `go test -run 'TestRequireNoLeakedDoltAfter|TestReapDoltLeakPIDs' ./cmd/gc/`.
- `go vet ./cmd/gc/` clean.