### PR TITLE
fix(test): export gitconfig to parallel runner children

### DIFF
--- a/scripts/test-local-concurrency.sh
+++ b/scripts/test-local-concurrency.sh
@@ -177,6 +177,28 @@ else
     record_fail "wiring.full_case_calls_selftest" "could not locate the full) case block in $LOCAL_PARALLEL"
 fi
 
+# Exercise the real initialization and fan-out without launching Go suites,
+# acquiring a gate slot, or recursively running this self-test.
+GITCONFIG_OUT="$(
+    unset gc_test_gitconfig
+    repo_root="$(dirname "$TEST_DIR")"
+    eval "$(sed -n '/^gc_test_gitconfig=/,/^# shellcheck source=lib\/test-slice.sh/{ /^# shellcheck/!p; }' "$LOCAL_PARALLEL")"
+    eval "$(sed -n '/^run_fan_out() {$/,/^}$/p' "$LOCAL_PARALLEL")"
+    log_dir="$(mktemp -d "${TMPDIR:-/var/tmp}/gc-gitconfig-test.XXXXXX")" || exit 1
+    trap 'rm -rf "$log_dir"' EXIT
+    export LOCAL_TEST_LOG_DIR="$log_dir"
+    export TEST_LOCAL_GOPATH="${GOPATH:-}" TEST_LOCAL_GOCACHE="${GOCACHE:-}"
+    export TEST_LOCAL_GOMODCACHE="${GOMODCACHE:-}" TEST_LOCAL_GOTMPDIR="${GOTMPDIR:-}"
+    export TEST_LOCAL_GOROOT="${GOROOT:-}" TEST_LOCAL_NICE=""
+    gate_fd=""
+    local_jobs=1
+    jobspecs=('gitconfig-probe::test -f "$GIT_CONFIG_GLOBAL" && test "$GIT_CONFIG_NOSYSTEM" = 1 && test "$(git config --global --get beads.role)" = maintainer')
+    run_fan_out
+)"
+GITCONFIG_RC=$?
+assert_eq "gitconfig.fan_out_child_receives_seeded_config" "$GITCONFIG_RC" "0"
+assert_contains "gitconfig.probe_completed" "$GITCONFIG_OUT" "[gitconfig-probe] ok"
+
 echo
 echo "local-concurrency tests: $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]

--- a/scripts/test-local-parallel
+++ b/scripts/test-local-parallel
@@ -27,6 +27,7 @@ cd "$repo_root"
 # One shared seeded gitconfig for every nested test env; resolved once so the
 # env -i block below cannot drift from the Makefile (scripts/test-gitconfig-path).
 gc_test_gitconfig="$("$repo_root/scripts/test-gitconfig-path")"
+export gc_test_gitconfig # The xargs bash children build their own env -i below.
 # shellcheck source=lib/test-slice.sh
 source "$repo_root/scripts/lib/test-slice.sh"
 gc_test_slice_reexec "$repo_root/scripts/test-local-parallel" "$@"


### PR DESCRIPTION
## Summary

Fixes #6112.

Export the seeded `gc_test_gitconfig` before the parallel runner launches `xargs ... bash -c` children. Without the export, every child aborts under `set -u` while preparing its `env -i`, before running its workload.

Extend the existing shell self-test with a probe through the actual initialization and `run_fan_out` function. It clears any inherited workaround, checks the child can read the seeded Git config, and avoids launching Go suites or recursively invoking the self-test. No new Go subprocess census entries or production test seams.

## Validation

- RED: `bash scripts/test-local-concurrency.sh` reported 24 passed, 2 failed, with `gc_test_gitconfig: unbound variable` from the real child.
- GREEN: the same self-test reported 26 passed, 0 failed. The existing strace-only check skipped on macOS.
- `bash -n scripts/test-local-parallel scripts/test-local-concurrency.sh` passed.
- Both focused Git-environment tests in `./scripts` passed with `-count=1`.
- `make vet` passed using resolved Go 1.26.6 with inherited GOROOT unset.
- Normal pre-commit hook passed.
- Normal push invoked `make test-fast-parallel` without the gitconfig workaround. All ten jobs reached workloads. Darwin compile, both shell self-tests, and cmd/gc shard 5 passed; the scripts Go package also passed within unit-core.

The full suite FAILED. It reproduced three mise-trust beads-init failures, three python3 mise-shim failures, and two backup-script tests missing `timeout.log`. Those were also observed on pristine upstream. This run also reported `TestStopManagedCityForcesCleanupAfterTimeout`, `TestStopManagedCityDoesNotUseStartupOrDriftTimeouts`, and `TestReleaseOrphanedPoolAssignments_DetachedProbeAliveSkipsRelease`. Cmd/gc shard 2 ended with FAIL without a named failing test in its log; its cause is unclassified. None is changed or suppressed here.

After the normal pre-push gate failed, the branch was pushed with `--no-verify`. This is not a green full-suite result.