### PR TITLE
fix(test-local-parallel): export gc_test_gitconfig so xargs fan-out workers can see it (ga-cesmzs)

### DIFF
--- a/scripts/git_test_env_test.go
+++ b/scripts/git_test_env_test.go
@@ -98,6 +98,13 @@ func TestShardTestEnvsIgnoreUserGitConfiguration(t *testing.T) {
 					t.Errorf("%s has %d occurrences of %q, want 1", path, got, pin)
 				}
 			}
+			// ga-cesmzs: only test-local-parallel crosses a subprocess boundary
+			// (the xargs fan-out worker), so only it must export the variable.
+			if path == "scripts/test-local-parallel" {
+				if got := strings.Count(content, "\nexport gc_test_gitconfig\n"); got != 1 {
+					t.Errorf("%s must export gc_test_gitconfig for the xargs fan-out workers (found %d)", path, got)
+				}
+			}
 		})
 	}
 }

--- a/scripts/test-local-parallel
+++ b/scripts/test-local-parallel
@@ -26,7 +26,7 @@ cd "$repo_root"
 
 # One shared seeded gitconfig for every nested test env; resolved once so the
 # env -i block below cannot drift from the Makefile (scripts/test-gitconfig-path).
-gc_test_gitconfig="$("$repo_root/scripts/test-gitconfig-path")"
+export gc_test_gitconfig="$("$repo_root/scripts/test-gitconfig-path")"
 # shellcheck source=lib/test-slice.sh
 source "$repo_root/scripts/lib/test-slice.sh"
 gc_test_slice_reexec "$repo_root/scripts/test-local-parallel" "$@"

--- a/scripts/test-local-parallel
+++ b/scripts/test-local-parallel
@@ -26,7 +26,10 @@ cd "$repo_root"
 
 # One shared seeded gitconfig for every nested test env; resolved once so the
 # env -i block below cannot drift from the Makefile (scripts/test-gitconfig-path).
-export gc_test_gitconfig="$("$repo_root/scripts/test-gitconfig-path")"
+# Exported because the xargs fan-out worker (run_fan_out) expands it in a child
+# process, which inherits only the environment (ga-cesmzs).
+gc_test_gitconfig="$("$repo_root/scripts/test-gitconfig-path")"
+export gc_test_gitconfig
 # shellcheck source=lib/test-slice.sh
 source "$repo_root/scripts/lib/test-slice.sh"
 gc_test_slice_reexec "$repo_root/scripts/test-local-parallel" "$@"


### PR DESCRIPTION
**Fleet push blocker, one-line fix.** Since #5157 (6204962ab2, merged 2026-09-06) landed, every `make test-fast-parallel` run that reaches `run_fan_out` aborts, and that is the pre-push hook path, so every `git push` from a gascity checkout fails until this is on main.

## Root cause

`scripts/test-local-parallel` line 29 resolves the shared test gitconfig once:

```bash
gc_test_gitconfig="$("$repo_root/scripts/test-gitconfig-path")"
```

but does not export it. `run_fan_out` (line 305) spawns each shard with `xargs -0 -n1 -P "$local_jobs" bash -c '…'`, and the worker body references `GIT_CONFIG_GLOBAL="$gc_test_gitconfig"` (line 321). A process started by xargs inherits only the environment, not the parent script's unexported shell variables, so under the worker's own `set -euo pipefail` every shard dies with:

```
gc_test_gitconfig: unbound variable
```

The same block already exports `TEST_LOCAL_GOPATH`, `TEST_LOCAL_GOCACHE`, `TEST_LOCAL_GOMODCACHE`, `TEST_LOCAL_GOTMPDIR`, `TEST_LOCAL_GOROOT` and `TEST_LOCAL_NICE` for exactly this reason; the new variable just missed the `export`.

## Fix

Add `export` on line 29. Nothing else changes; file mode stays `100755`.

## Evidence

- Reported and root-caused by the gascity builder while pushing an unrelated branch (ga-cm2o5t.1.2); it applied this same one-line change locally and confirmed the pre-push hook passes with it and fails without it (bead ga-cesmzs).
- The mechanism, isolated:
  ```
  $ v=x;        printf 'a\0' | xargs -0 -n1 bash -c 'set -u; echo "child sees: $v"'
  a: line 1: v: unbound variable
  $ export v=x; printf 'a\0' | xargs -0 -n1 bash -c 'set -u; echo "child sees: $v"'
  child sees: x
  ```
- `bash -n` clean on the changed file.

Refs: ga-cesmzs (gascity), #5157.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #6112 — adds the missing `export` to the `gc_test_gitconfig` assignment in scripts/test-local-parallel, so the xargs fan-out workers inherit it instead of aborting under `set -u` — the exact root cause described there; it does not add the focused regression test that issue suggests

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->