### PR TITLE
feat: support env-backed Codex MCP bearer tokens

### DIFF
--- a/engdocs/proposals/mcp-materialization.md
+++ b/engdocs/proposals/mcp-materialization.md
@@ -134,6 +134,7 @@ The neutral MCP schema stays intentionally small:
   - `[env]`
 - remote transport:
   - `url`
+  - `bearer_token_env_var` (Codex projection only)
   - `[headers]`
 
 Rules:
@@ -141,6 +142,11 @@ Rules:
 - exactly one of `command` or `url` must be set
 - stdio definitions may not set `url` or `headers`
 - HTTP definitions may not set `command`, `args`, or `env`
+- `bearer_token_env_var` must be a valid environment-variable name, may be set
+  only on HTTP definitions, and may not be combined with an `Authorization`
+  entry in `[headers]`
+- projections other than Codex fail closed when `bearer_token_env_var` is set;
+  they do not silently drop the authentication reference
 - `description` is metadata only; it is excluded from runtime equality and
   restart fingerprints
 
@@ -356,6 +362,8 @@ Adoption and migration rules:
 ### Security and file permissions
 
 Projected runtime files may contain expanded secrets from `env` or `headers`.
+For Codex HTTP servers, `bearer_token_env_var` instead projects the environment
+variable name and leaves the token itself out of the managed file.
 
 Rules:
 

--- a/internal/materialize/mcp.go
+++ b/internal/materialize/mcp.go
@@ -14,6 +14,7 @@ import (
 )
 
 var validMCPServerName = regexp.MustCompile(`^[a-z0-9-]+$`)
+var validMCPEnvVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // MCPTransport identifies the neutral transport type supported by the MCP
 // catalog and provider projections.
@@ -32,19 +33,20 @@ const (
 // template expansion, transport validation, and relative path
 // resolution.
 type MCPServer struct {
-	Name        string
-	Description string
-	Transport   MCPTransport
-	Command     string
-	Args        []string
-	Env         map[string]string
-	URL         string
-	Headers     map[string]string
-	SourceFile  string
-	SourceDir   string
-	Template    bool
-	Layer       string
-	Origin      string
+	Name              string
+	Description       string
+	Transport         MCPTransport
+	Command           string
+	Args              []string
+	Env               map[string]string
+	URL               string
+	Headers           map[string]string
+	BearerTokenEnvVar string
+	SourceFile        string
+	SourceDir         string
+	Template          bool
+	Layer             string
+	Origin            string
 }
 
 // MCPShadow records a same-name replacement across precedence layers.
@@ -74,23 +76,25 @@ type MCPKV struct {
 // NormalizedMCPServer is the deterministic behavioral form used for equality
 // and drift hashing. Metadata and source provenance are intentionally excluded.
 type NormalizedMCPServer struct {
-	Name      string
-	Transport MCPTransport
-	Command   string
-	Args      []string
-	Env       []MCPKV
-	URL       string
-	Headers   []MCPKV
+	Name              string
+	Transport         MCPTransport
+	Command           string
+	Args              []string
+	Env               []MCPKV
+	URL               string
+	Headers           []MCPKV
+	BearerTokenEnvVar string
 }
 
 type rawMCPServer struct {
-	Name        string            `toml:"name"`
-	Description string            `toml:"description"`
-	Command     string            `toml:"command"`
-	Args        []string          `toml:"args"`
-	Env         map[string]string `toml:"env"`
-	URL         string            `toml:"url"`
-	Headers     map[string]string `toml:"headers"`
+	Name              string            `toml:"name"`
+	Description       string            `toml:"description"`
+	Command           string            `toml:"command"`
+	Args              []string          `toml:"args"`
+	Env               map[string]string `toml:"env"`
+	URL               string            `toml:"url"`
+	Headers           map[string]string `toml:"headers"`
+	BearerTokenEnvVar string            `toml:"bearer_token_env_var"`
 }
 
 // MCPDirSource identifies one directory contributing MCP definitions.
@@ -220,10 +224,11 @@ func MergeMCPDirs(sources []MCPDirSource, templateData map[string]string) (MCPCa
 // for equality and hashing.
 func NormalizeMCPServer(server MCPServer) NormalizedMCPServer {
 	n := NormalizedMCPServer{
-		Name:      server.Name,
-		Transport: server.Transport,
-		Command:   server.Command,
-		URL:       server.URL,
+		Name:              server.Name,
+		Transport:         server.Transport,
+		Command:           server.Command,
+		URL:               server.URL,
+		BearerTokenEnvVar: server.BearerTokenEnvVar,
 	}
 	if len(server.Args) > 0 {
 		n.Args = append([]string(nil), server.Args...)
@@ -284,18 +289,22 @@ func loadMCPFile(path, label string, templateData map[string]string) (MCPServer,
 	}
 
 	server := MCPServer{
-		Name:        identity,
-		Description: strings.TrimSpace(raw.Description),
-		Args:        append([]string(nil), raw.Args...),
-		Env:         cloneStringMap(raw.Env),
-		Headers:     cloneStringMap(raw.Headers),
-		SourceFile:  path,
-		SourceDir:   filepath.Dir(path),
-		Template:    isTemplate,
-		Layer:       label,
-		Origin:      label,
+		Name:              identity,
+		Description:       strings.TrimSpace(raw.Description),
+		Args:              append([]string(nil), raw.Args...),
+		Env:               cloneStringMap(raw.Env),
+		Headers:           cloneStringMap(raw.Headers),
+		BearerTokenEnvVar: strings.TrimSpace(raw.BearerTokenEnvVar),
+		SourceFile:        path,
+		SourceDir:         filepath.Dir(path),
+		Template:          isTemplate,
+		Layer:             label,
+		Origin:            label,
 	}
 	if command != "" {
+		if server.BearerTokenEnvVar != "" {
+			return MCPServer{}, fmt.Errorf("%s: stdio server may not set bearer_token_env_var", path)
+		}
 		if len(raw.Headers) > 0 {
 			return MCPServer{}, fmt.Errorf("%s: stdio server may not set headers", path)
 		}
@@ -307,6 +316,16 @@ func loadMCPFile(path, label string, templateData map[string]string) (MCPServer,
 		}
 		server.Transport = MCPTransportHTTP
 		server.URL = url
+		if server.BearerTokenEnvVar != "" && !validMCPEnvVarName.MatchString(server.BearerTokenEnvVar) {
+			return MCPServer{}, fmt.Errorf("%s: invalid bearer_token_env_var %q", path, server.BearerTokenEnvVar)
+		}
+		if server.BearerTokenEnvVar != "" {
+			for key := range server.Headers {
+				if strings.EqualFold(key, "Authorization") {
+					return MCPServer{}, fmt.Errorf("%s: bearer_token_env_var and Authorization header are mutually exclusive", path)
+				}
+			}
+		}
 	}
 	return server, nil
 }

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -341,6 +341,15 @@ func (p MCPProjection) applyCursor(fs fsys.FS) error {
 }
 
 func (p MCPProjection) validateProviderContract() error {
+	for _, server := range p.Servers {
+		if server.BearerTokenEnvVar != "" && p.Provider != MCPProviderCodex {
+			return fmt.Errorf(
+				"%s MCP projection does not support bearer_token_env_var for server %q",
+				p.Provider,
+				server.Name,
+			)
+		}
+	}
 	if p.Provider != MCPProviderCursor {
 		return nil
 	}
@@ -442,6 +451,9 @@ func (p MCPProjection) codexServersDoc() map[string]any {
 			entry["url"] = server.URL
 			if len(server.Headers) > 0 {
 				entry["http_headers"] = cloneStringMap(server.Headers)
+			}
+			if server.BearerTokenEnvVar != "" {
+				entry["bearer_token_env_var"] = server.BearerTokenEnvVar
 			}
 		}
 		out[server.Name] = entry

--- a/internal/materialize/mcp_project_test.go
+++ b/internal/materialize/mcp_project_test.go
@@ -456,10 +456,10 @@ command = "old"
 			Env:       map[string]string{"TOKEN": "secret"},
 		},
 		{
-			Name:      "remote",
-			Transport: MCPTransportHTTP,
-			URL:       "https://mcp.example.com",
-			Headers:   map[string]string{"Authorization": "Bearer token"},
+			Name:              "remote",
+			Transport:         MCPTransportHTTP,
+			URL:               "https://mcp.example.com",
+			BearerTokenEnvVar: "MCP_TOKEN",
 		},
 	})
 	if err != nil {
@@ -491,8 +491,8 @@ command = "old"
 	if got := remote["url"]; got != "https://mcp.example.com" {
 		t.Fatalf("remote url = %v, want https://mcp.example.com", got)
 	}
-	if _, ok := remote["http_headers"]; !ok {
-		t.Fatalf("remote http_headers missing: %#v", remote)
+	if got := remote["bearer_token_env_var"]; got != "MCP_TOKEN" {
+		t.Fatalf("remote bearer_token_env_var = %v, want MCP_TOKEN", got)
 	}
 
 	empty, err := BuildMCPProjection(MCPProviderCodex, dir, nil)
@@ -512,6 +512,34 @@ command = "old"
 	}
 	if _, ok := doc["mcp_servers"]; ok {
 		t.Fatalf("mcp_servers should be removed after cleanup: %#v", doc)
+	}
+}
+
+func TestApplyMCPProjectionRejectsBearerTokenEnvVarForNonCodexProviders(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{
+		MCPProviderClaude,
+		MCPProviderGemini,
+		MCPProviderOpenCode,
+		MCPProviderMimoCode,
+		MCPProviderCursor,
+	} {
+		t.Run(provider, func(t *testing.T) {
+			proj, err := BuildMCPProjection(provider, t.TempDir(), []MCPServer{{
+				Name:              "remote",
+				Transport:         MCPTransportHTTP,
+				URL:               "https://mcp.example.com",
+				BearerTokenEnvVar: "MCP_TOKEN",
+			}})
+			if err != nil {
+				t.Fatalf("BuildMCPProjection: %v", err)
+			}
+			err = proj.Apply(fsys.OSFS{})
+			if err == nil || !strings.Contains(err.Error(), "does not support bearer_token_env_var") {
+				t.Fatalf("Apply error=%v, want unsupported bearer_token_env_var", err)
+			}
+		})
 	}
 }
 

--- a/internal/materialize/mcp_test.go
+++ b/internal/materialize/mcp_test.go
@@ -72,6 +72,25 @@ TOKEN = "{{.Token}}"
 	}
 }
 
+func TestLoadMCPDirParsesBearerTokenEnvVar(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "remote.toml"), `
+name = "remote"
+url = "https://mcp.example.com"
+bearer_token_env_var = "MCP_TOKEN"
+`)
+
+	servers, err := LoadMCPDir(dir, "city", nil)
+	if err != nil {
+		t.Fatalf("LoadMCPDir: %v", err)
+	}
+	if got := servers[0].BearerTokenEnvVar; got != "MCP_TOKEN" {
+		t.Fatalf("BearerTokenEnvVar=%q, want MCP_TOKEN", got)
+	}
+}
+
 func TestLoadMCPDirRejectsDuplicateLogicalNames(t *testing.T) {
 	t.Parallel()
 
@@ -126,6 +145,21 @@ func TestLoadMCPDirValidatesNameAndTransport(t *testing.T) {
 			body:     "name = \"bad_name\"\ncommand = \"uvx\"\n",
 			wantErr:  `invalid server name`,
 		},
+		{
+			filename: "foo.toml",
+			body:     "name = \"foo\"\ncommand = \"uvx\"\nbearer_token_env_var = \"MCP_TOKEN\"\n",
+			wantErr:  `stdio server may not set bearer_token_env_var`,
+		},
+		{
+			filename: "foo.toml",
+			body:     "name = \"foo\"\nurl = \"https://example.com\"\nbearer_token_env_var = \"not-valid\"\n",
+			wantErr:  `invalid bearer_token_env_var`,
+		},
+		{
+			filename: "foo.toml",
+			body:     "name = \"foo\"\nurl = \"https://example.com\"\nbearer_token_env_var = \"MCP_TOKEN\"\n[headers]\nAuthorization = \"Bearer literal\"\n",
+			wantErr:  `bearer_token_env_var and Authorization header are mutually exclusive`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.wantErr, func(t *testing.T) {
@@ -170,10 +204,11 @@ func TestNormalizeMCPServerStableMapOrder(t *testing.T) {
 	t.Parallel()
 
 	server := MCPServer{
-		Name:      "foo",
-		Transport: MCPTransportStdio,
-		Command:   "uvx",
-		Args:      []string{"b", "a"},
+		Name:              "foo",
+		Transport:         MCPTransportStdio,
+		Command:           "uvx",
+		Args:              []string{"b", "a"},
+		BearerTokenEnvVar: "MCP_TOKEN",
 		Env: map[string]string{
 			"Z": "2",
 			"A": "1",
@@ -185,12 +220,13 @@ func TestNormalizeMCPServerStableMapOrder(t *testing.T) {
 	}
 	got := NormalizeMCPServer(server)
 	want := NormalizedMCPServer{
-		Name:      "foo",
-		Transport: MCPTransportStdio,
-		Command:   "uvx",
-		Args:      []string{"b", "a"},
-		Env:       []MCPKV{{Key: "A", Value: "1"}, {Key: "Z", Value: "2"}},
-		Headers:   []MCPKV{{Key: "X", Value: "1"}, {Key: "Y", Value: "2"}},
+		Name:              "foo",
+		Transport:         MCPTransportStdio,
+		Command:           "uvx",
+		Args:              []string{"b", "a"},
+		Env:               []MCPKV{{Key: "A", Value: "1"}, {Key: "Z", Value: "2"}},
+		Headers:           []MCPKV{{Key: "X", Value: "1"}, {Key: "Y", Value: "2"}},
+		BearerTokenEnvVar: "MCP_TOKEN",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("NormalizeMCPServer()=%#v, want %#v", got, want)


### PR DESCRIPTION
## Summary

- add `bearer_token_env_var` to HTTP MCP catalog definitions
- project it to Codex without materializing the token
- reject invalid env names, ambiguous literal Authorization headers, stdio use, and unsupported provider projections
- document the new neutral-catalog boundary

## Testing

- `go test ./internal/materialize` (Go 1.26.6 container with ICU development headers)

This enables agent-scoped Codex MCP integrations to keep bearer credentials in process environment instead of generated `.codex/config.toml` files.