### PR TITLE
fix(hook): retire a workflow whose input convoy work was handed off to another lane (stacked on #6102)

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
 )
@@ -199,6 +200,13 @@ type hookClaimOps struct {
 	// provider meta: reconciler-tracked drains never set GC_DRAIN, so provider
 	// meta does not cover the population this fence exists for.
 	DrainPending hookDrainPendingFunc
+	// InputDone reports whether the workflow a candidate belongs to has an
+	// input convoy whose tracked work is already terminal (closed/tombstone),
+	// returning the workflow root id so SkipDoneWorkflow can retire it.
+	InputDone hookInputDoneFunc
+	// SkipDoneWorkflow closes a workflow root and its open steps with
+	// gc.outcome=skipped after InputDone reported the input terminal.
+	SkipDoneWorkflow hookSkipDoneWorkflowFunc
 	// EmitClaimRejected publishes a bead.claim_rejected event when a claim is
 	// lost to a different live claimant (ADR-0009). Best-effort.
 	EmitClaimRejected hookEmitClaimRejectedFunc
@@ -256,6 +264,8 @@ type (
 	hookAssignContinuationFunc func(context.Context, string, []string, string, string) error
 	hookDrainAckFunc           func(io.Writer) error
 	hookDrainPendingFunc       func(sessionID string) (bool, error)
+	hookInputDoneFunc          func(ctx context.Context, dir string, env []string, candidate beads.Bead) (string, bool, error)
+	hookSkipDoneWorkflowFunc   func(ctx context.Context, dir string, env []string, rootID string) error
 	hookEmitClaimRejectedFunc  func(beadID, existingClaimant, attemptedClaimant string)
 	hookResolveWorkBranchFunc  func(dir string) string
 	hookStampWorkMetaFunc      func(ctx context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error
@@ -420,6 +430,13 @@ func tryHookClaim(workQuery, dir string, opts *hookClaimOptions, ops *hookClaimO
 		return hookClaimResult{}
 	}
 
+	// Retire, before any tier looks at them, the candidates whose workflow has
+	// nothing left to do because its input convoy work is already terminal.
+	candidates = retireDoneWorkflowCandidates(candidates, *opts, *ops, dir, stderr)
+	if len(candidates) == 0 {
+		return hookClaimResult{}
+	}
+
 	if result, bead, ok := hookClaimExistingAssignment(candidates, *opts); ok {
 		// Adoption mints no CAS, so until now it minted its receipt on the word
 		// of the work query alone — and a stale caching-store row survives long
@@ -467,6 +484,12 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.DrainPending == nil {
 		ops.DrainPending = hookSessionDrainPending
+	}
+	if ops.InputDone == nil {
+		ops.InputDone = hookInputDoneWithBdStore
+	}
+	if ops.SkipDoneWorkflow == nil {
+		ops.SkipDoneWorkflow = hookSkipDoneWorkflowWithBdStore
 	}
 	if ops.EmitClaimRejected == nil {
 		ops.EmitClaimRejected = hookEmitClaimRejected
@@ -1225,6 +1248,136 @@ func preassignHookContinuationGroup(bead beads.Bead, opts hookClaimOptions, ops 
 		assigned = append(assigned, sibling.ID)
 	}
 	return assigned, nil
+}
+
+// retireDoneWorkflowCandidates drops every candidate this session would serve
+// (an adoptable/ready assignment of its own, or a claimable routed row) whose
+// workflow's input convoy work is already terminal, closing that workflow so
+// the pool stops re-dispatching it. A workflow poured for a bead that is
+// already closed — merged and closed by a refinery after the pour, or slung
+// twice — otherwise loops forever: the worker finds nothing to do, drain-acks
+// while still holding its step, the reconciler wakes the same seat (holding
+// in_progress work is a wake anchor) and the hook hands the same molecule out
+// again as existing_assignment; once the seat bead closes, dead-assignee
+// release reopens the step for the next seat. Neither the worker (roots are
+// never-closable by contract) nor the reconciler (drain-ack leaves work
+// untouched, #2293) has a path to end it, so the claim path is where the
+// done-check belongs.
+func retireDoneWorkflowCandidates(candidates []beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) []beads.Bead {
+	if ops.InputDone == nil || ops.SkipDoneWorkflow == nil {
+		return candidates
+	}
+	kept := candidates[:0:0]
+	for _, candidate := range candidates {
+		if hookClaimCandidateIsMessage(candidate) {
+			kept = append(kept, candidate)
+			continue
+		}
+		served := hookClaimHasIdentity(candidate.Assignee, opts.IdentityCandidates) ||
+			hookCandidateClaimable(candidate, opts.RouteTargets)
+		if served && hookSkipIfInputDone(candidate, opts, ops, dir, stderr) {
+			continue
+		}
+		kept = append(kept, candidate)
+	}
+	return kept
+}
+
+// hookSkipIfInputDone reports whether candidate belongs to a workflow whose
+// input convoy work is already terminal and, if so, retires that workflow
+// (root + open steps closed with gc.outcome=skipped). Lookup and close
+// failures are logged and treated as not-done so a store hiccup can never
+// suppress real work.
+func hookSkipIfInputDone(candidate beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
+	defer cancel()
+	rootID, done, err := ops.InputDone(ctx, dir, opts.Env, candidate)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: checking input convoy for %s: %v\n", candidate.ID, err) //nolint:errcheck
+		return false
+	}
+	if !done {
+		return false
+	}
+	if err := ops.SkipDoneWorkflow(ctx, dir, opts.Env, rootID); err != nil {
+		fmt.Fprintf(stderr, "gc hook --claim: retiring workflow %s whose input work is already terminal: %v\n", rootID, err) //nolint:errcheck
+		return false
+	}
+	fmt.Fprintf(stderr, "gc hook --claim: skipped %s: workflow %s input convoy work is already terminal; root and open steps closed as skipped\n", candidate.ID, rootID) //nolint:errcheck
+	return true
+}
+
+// workflowInputDone resolves candidate to its workflow root (itself when it
+// carries gc.input_convoy_id, else via gc.root_bead_id) and reports whether
+// every member the root's input convoy tracks is terminal. A root with no
+// input convoy, or a convoy with no resolvable members, is never "done".
+func workflowInputDone(store beads.Store, candidate beads.Bead) (string, bool, error) {
+	root := candidate
+	if strings.TrimSpace(root.Metadata[beadmeta.InputConvoyIDMetadataKey]) == "" {
+		rootID := strings.TrimSpace(candidate.Metadata[beadmeta.RootBeadIDMetadataKey])
+		if rootID == "" || rootID == candidate.ID {
+			return "", false, nil
+		}
+		var err error
+		root, err = store.Get(rootID)
+		if err != nil {
+			return "", false, fmt.Errorf("loading workflow root %s: %w", rootID, err)
+		}
+	}
+	convoyID := strings.TrimSpace(root.Metadata[beadmeta.InputConvoyIDMetadataKey])
+	if convoyID == "" {
+		return root.ID, false, nil
+	}
+	members, err := convoy.Members(store, convoyID, true)
+	if err != nil {
+		return root.ID, false, fmt.Errorf("listing input convoy %s members: %w", convoyID, err)
+	}
+	if len(members) == 0 {
+		return root.ID, false, nil
+	}
+	for _, m := range members {
+		if !convoy.IsTerminalStatus(m.Status) {
+			return root.ID, false, nil
+		}
+	}
+	return root.ID, true, nil
+}
+
+// skipDoneWorkflow closes rootID and every open/in_progress step under it
+// with gc.outcome=skipped so pool demand and continuation claims drop.
+func skipDoneWorkflow(store beads.Store, rootID string) error {
+	steps, err := store.List(beads.ListQuery{
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: rootID},
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return fmt.Errorf("listing steps of %s: %w", rootID, err)
+	}
+	ids := make([]string, 0, len(steps)+1)
+	seen := map[string]bool{}
+	for _, step := range steps {
+		if step.ID == "" || step.ID == rootID || seen[step.ID] || convoy.IsTerminalStatus(step.Status) {
+			continue
+		}
+		seen[step.ID] = true
+		ids = append(ids, step.ID)
+	}
+	ids = append(ids, rootID)
+	_, err = store.CloseAll(ids, map[string]string{
+		beadmeta.OutcomeMetadataKey: beadmeta.OutcomeSkipped,
+		"close_reason":              hookSkipDoneWorkflowCloseReason,
+	})
+	return err
+}
+
+const hookSkipDoneWorkflowCloseReason = "hook --claim: input convoy work already terminal; nothing to do"
+
+func hookInputDoneWithBdStore(_ context.Context, dir string, env []string, candidate beads.Bead) (string, bool, error) {
+	return workflowInputDone(hookClaimBdStore(dir, env, ""), candidate)
+}
+
+func hookSkipDoneWorkflowWithBdStore(_ context.Context, dir string, env []string, rootID string) error {
+	return skipDoneWorkflow(hookClaimBdStore(dir, env, ""), rootID)
 }
 
 func hookClaimWithBdStore(ctx context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, bool, error) {

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -264,7 +264,7 @@ type (
 	hookAssignContinuationFunc func(context.Context, string, []string, string, string) error
 	hookDrainAckFunc           func(io.Writer) error
 	hookDrainPendingFunc       func(sessionID string) (bool, error)
-	hookInputDoneFunc          func(ctx context.Context, dir string, env []string, candidate beads.Bead) (string, bool, error)
+	hookInputDoneFunc          func(ctx context.Context, dir string, env []string, candidate beads.Bead, identityCandidates []string) (string, bool, error)
 	hookSkipDoneWorkflowFunc   func(ctx context.Context, dir string, env []string, rootID string) error
 	hookEmitClaimRejectedFunc  func(beadID, existingClaimant, attemptedClaimant string)
 	hookResolveWorkBranchFunc  func(dir string) string
@@ -1291,7 +1291,7 @@ func retireDoneWorkflowCandidates(candidates []beads.Bead, opts hookClaimOptions
 func hookSkipIfInputDone(candidate beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string, stderr io.Writer) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
 	defer cancel()
-	rootID, done, err := ops.InputDone(ctx, dir, opts.Env, candidate)
+	rootID, done, err := ops.InputDone(ctx, dir, opts.Env, candidate, opts.IdentityCandidates)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc hook --claim: checking input convoy for %s: %v\n", candidate.ID, err) //nolint:errcheck
 		return false
@@ -1303,15 +1303,18 @@ func hookSkipIfInputDone(candidate beads.Bead, opts hookClaimOptions, ops hookCl
 		fmt.Fprintf(stderr, "gc hook --claim: retiring workflow %s whose input work is already terminal: %v\n", rootID, err) //nolint:errcheck
 		return false
 	}
-	fmt.Fprintf(stderr, "gc hook --claim: skipped %s: workflow %s input convoy work is already terminal; root and open steps closed as skipped\n", candidate.ID, rootID) //nolint:errcheck
+	fmt.Fprintf(stderr, "gc hook --claim: skipped %s: workflow %s input convoy work is already terminal or handed off to another lane; root and open steps closed as skipped\n", candidate.ID, rootID) //nolint:errcheck
 	return true
 }
 
 // workflowInputDone resolves candidate to its workflow root (itself when it
 // carries gc.input_convoy_id, else via gc.root_bead_id) and reports whether
-// every member the root's input convoy tracks is terminal. A root with no
-// input convoy, or a convoy with no resolvable members, is never "done".
-func workflowInputDone(store beads.Store, candidate beads.Bead) (string, bool, error) {
+// every member the root's input convoy tracks is terminal, or non-terminal
+// but handed off to an assignee outside identityCandidates (no longer ours to
+// wait on). A member that is still unassigned, or still assigned to one of
+// identityCandidates, blocks. A root with no input convoy, or a convoy with
+// no resolvable members, is never "done".
+func workflowInputDone(store beads.Store, candidate beads.Bead, identityCandidates []string) (string, bool, error) {
 	root := candidate
 	if strings.TrimSpace(root.Metadata[beadmeta.InputConvoyIDMetadataKey]) == "" {
 		rootID := strings.TrimSpace(candidate.Metadata[beadmeta.RootBeadIDMetadataKey])
@@ -1336,9 +1339,13 @@ func workflowInputDone(store beads.Store, candidate beads.Bead) (string, bool, e
 		return root.ID, false, nil
 	}
 	for _, m := range members {
-		if !convoy.IsTerminalStatus(m.Status) {
-			return root.ID, false, nil
+		if convoy.IsTerminalStatus(m.Status) {
+			continue
 		}
+		if strings.TrimSpace(m.Assignee) != "" && !hookClaimHasIdentity(m.Assignee, identityCandidates) {
+			continue
+		}
+		return root.ID, false, nil
 	}
 	return root.ID, true, nil
 }
@@ -1372,8 +1379,8 @@ func skipDoneWorkflow(store beads.Store, rootID string) error {
 
 const hookSkipDoneWorkflowCloseReason = "hook --claim: input convoy work already terminal; nothing to do"
 
-func hookInputDoneWithBdStore(_ context.Context, dir string, env []string, candidate beads.Bead) (string, bool, error) {
-	return workflowInputDone(hookClaimBdStore(dir, env, ""), candidate)
+func hookInputDoneWithBdStore(_ context.Context, dir string, env []string, candidate beads.Bead, identityCandidates []string) (string, bool, error) {
+	return workflowInputDone(hookClaimBdStore(dir, env, ""), candidate, identityCandidates)
 }
 
 func hookSkipDoneWorkflowWithBdStore(_ context.Context, dir string, env []string, rootID string) error {

--- a/cmd/gc/cmd_hook_claim_input_done_test.go
+++ b/cmd/gc/cmd_hook_claim_input_done_test.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/convoy"
+)
+
+// seedDoneWorkflow builds a store holding a workflow root whose input convoy
+// tracks a single member, plus one open step under the root. memberStatus
+// controls whether the tracked work is terminal.
+func seedDoneWorkflow(t *testing.T, memberStatus string) (*beads.MemStore, beads.Bead, beads.Bead) {
+	t.Helper()
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{Title: "the work"})
+	if err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+	if memberStatus == "closed" {
+		if err := store.Close(work.ID); err != nil {
+			t.Fatalf("close work: %v", err)
+		}
+	}
+	conv, err := store.Create(beads.Bead{Title: "input convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	if err := convoy.TrackItem(store, conv.ID, work.ID); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	root, err := store.Create(beads.Bead{Title: "mol", Metadata: map[string]string{
+		beadmeta.KindMetadataKey:          beadmeta.KindWorkflow,
+		beadmeta.InputConvoyIDMetadataKey: conv.ID,
+		beadmeta.RoutedToMetadataKey:      "rig/worker",
+	}})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	step, err := store.Create(beads.Bead{Title: "Load context", Metadata: map[string]string{
+		beadmeta.RootBeadIDMetadataKey:        root.ID,
+		beadmeta.ContinuationGroupMetadataKey: "pool-workflow",
+		beadmeta.RoutedToMetadataKey:          "rig/worker",
+	}})
+	if err != nil {
+		t.Fatalf("create step: %v", err)
+	}
+	return store, root, step
+}
+
+func TestWorkflowInputDoneDetectsTerminalConvoyMember(t *testing.T) {
+	store, root, step := seedDoneWorkflow(t, "closed")
+
+	rootID, done, err := workflowInputDone(store, root)
+	if err != nil {
+		t.Fatalf("workflowInputDone(root): %v", err)
+	}
+	if !done || rootID != root.ID {
+		t.Fatalf("root: done=%v rootID=%q, want done=true rootID=%q", done, rootID, root.ID)
+	}
+
+	rootID, done, err = workflowInputDone(store, step)
+	if err != nil {
+		t.Fatalf("workflowInputDone(step): %v", err)
+	}
+	if !done || rootID != root.ID {
+		t.Fatalf("step: done=%v rootID=%q, want done=true rootID=%q", done, rootID, root.ID)
+	}
+}
+
+func TestWorkflowInputDoneFalseWhileMemberOpen(t *testing.T) {
+	store, root, _ := seedDoneWorkflow(t, "open")
+	_, done, err := workflowInputDone(store, root)
+	if err != nil {
+		t.Fatalf("workflowInputDone: %v", err)
+	}
+	if done {
+		t.Fatal("done = true for an open convoy member, want false")
+	}
+}
+
+func TestWorkflowInputDoneFalseWithoutInputConvoy(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Metadata: map[string]string{
+		beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+	}})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_, done, err := workflowInputDone(store, root)
+	if err != nil {
+		t.Fatalf("workflowInputDone: %v", err)
+	}
+	if done {
+		t.Fatal("done = true with no input convoy, want false")
+	}
+}
+
+func TestSkipDoneWorkflowClosesRootAndSteps(t *testing.T) {
+	store, root, step := seedDoneWorkflow(t, "closed")
+	if err := store.Update(step.ID, beads.UpdateOpts{Status: strPtr("in_progress"), Assignee: strPtr("worker-1")}); err != nil {
+		t.Fatalf("update step: %v", err)
+	}
+
+	if err := skipDoneWorkflow(store, root.ID); err != nil {
+		t.Fatalf("skipDoneWorkflow: %v", err)
+	}
+	for _, id := range []string{root.ID, step.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+		if got.Metadata[beadmeta.OutcomeMetadataKey] != beadmeta.OutcomeSkipped {
+			t.Fatalf("%s gc.outcome = %q, want skipped", id, got.Metadata[beadmeta.OutcomeMetadataKey])
+		}
+	}
+}
+
+func TestDoHookClaimSkipsWorkflowWhoseInputIsDone(t *testing.T) {
+	candidates := []beads.Bead{{
+		ID:     "root-1",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:          beadmeta.KindWorkflow,
+			beadmeta.InputConvoyIDMetadataKey: "convoy-1",
+			beadmeta.RoutedToMetadataKey:      "worker",
+		},
+	}}
+	output, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	claimed := false
+	skipped := ""
+	drained := false
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimed = true
+			return beads.Bead{ID: beadID, Assignee: assignee}, true, nil
+		},
+		InputDone: func(_ context.Context, _ string, _ []string, candidate beads.Bead) (string, bool, error) {
+			return "root-1", true, nil
+		},
+		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
+			skipped = rootID
+			return nil
+		},
+		DrainAck: func(io.Writer) error {
+			drained = true
+			return nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "/rig", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker"},
+		DrainAck:     true,
+		JSON:         true,
+	}, ops, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if claimed {
+		t.Fatal("claimed a workflow whose input convoy work is already terminal")
+	}
+	if skipped != "root-1" {
+		t.Fatalf("skipped root = %q, want root-1", skipped)
+	}
+	if !drained {
+		t.Fatal("no-work drain not acknowledged after skipping the done workflow")
+	}
+	if !strings.Contains(stdout.String(), `"reason":"no_work"`) {
+		t.Fatalf("stdout = %q, want no_work drain", stdout.String())
+	}
+}
+
+func TestDoHookClaimSkipsExistingAssignmentWhoseInputIsDone(t *testing.T) {
+	// The per-seat treadmill: the seat already holds an in_progress step of a
+	// molecule whose work finished elsewhere. The hook must not hand that step
+	// back as existing_assignment; it must close the molecule and drain.
+	candidates := []beads.Bead{{
+		ID:       "step-1",
+		Status:   "in_progress",
+		Assignee: "worker-1",
+		Metadata: map[string]string{
+			beadmeta.RootBeadIDMetadataKey:        "root-1",
+			beadmeta.ContinuationGroupMetadataKey: "pool-workflow",
+			beadmeta.RoutedToMetadataKey:          "worker",
+		},
+	}}
+	output, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	skipped := ""
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			t.Fatalf("unexpected claim of %s", beadID)
+			return beads.Bead{}, false, nil
+		},
+		InputDone: func(_ context.Context, _ string, _ []string, candidate beads.Bead) (string, bool, error) {
+			return "root-1", true, nil
+		},
+		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
+			skipped = rootID
+			return nil
+		},
+		DrainAck: func(io.Writer) error { return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "/rig", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker"},
+		DrainAck:     true,
+		JSON:         true,
+	}, ops, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if skipped != "root-1" {
+		t.Fatalf("skipped root = %q, want root-1", skipped)
+	}
+	if strings.Contains(stdout.String(), "existing_assignment") {
+		t.Fatalf("stdout = %q, handed back a step of a done workflow", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"reason":"no_work"`) {
+		t.Fatalf("stdout = %q, want no_work drain", stdout.String())
+	}
+}
+
+func TestDoHookClaimStillClaimsWhenInputNotDone(t *testing.T) {
+	candidates := []beads.Bead{{
+		ID:     "root-1",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:          beadmeta.KindWorkflow,
+			beadmeta.InputConvoyIDMetadataKey: "convoy-1",
+			beadmeta.RoutedToMetadataKey:      "worker",
+		},
+	}}
+	output, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	claimedID := ""
+	ops := hookClaimOps{
+		Runner: func(string, string) (string, error) { return string(output), nil },
+		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+			claimedID = beadID
+			return beads.Bead{ID: beadID, Assignee: assignee, Status: "in_progress"}, true, nil
+		},
+		InputDone: func(_ context.Context, _ string, _ []string, candidate beads.Bead) (string, bool, error) {
+			return "root-1", false, nil
+		},
+		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
+			t.Fatalf("unexpected skip of %s", rootID)
+			return nil
+		},
+		ListContinuation: func(_ context.Context, _ string, _ []string, _, _ string) ([]beads.Bead, error) {
+			return nil, nil
+		},
+		AssignContinuation: func(_ context.Context, _ string, _ []string, _, _ string) error { return nil },
+		ResolveWorkBranch:  func(string) string { return "" },
+		StampWorkMeta: func(_ context.Context, _ string, _ []string, _, _ string, _ map[string]string) error {
+			return nil
+		},
+		PublishRunMap: func(_, _ string, _ ...string) error { return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHookClaim("query", "/rig", hookClaimOptions{
+		Assignee:     "worker-1",
+		RouteTargets: []string{"worker"},
+		JSON:         true,
+	}, ops, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doHookClaim = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if claimedID != "root-1" {
+		t.Fatalf("claimed = %q, want root-1", claimedID)
+	}
+}

--- a/cmd/gc/cmd_hook_claim_input_done_test.go
+++ b/cmd/gc/cmd_hook_claim_input_done_test.go
@@ -28,6 +28,11 @@ func seedDoneWorkflow(t *testing.T, memberStatus string) (*beads.MemStore, beads
 			t.Fatalf("close work: %v", err)
 		}
 	}
+	if memberStatus == "handed_off" {
+		if err := store.Update(work.ID, beads.UpdateOpts{Status: strPtr("open"), Assignee: strPtr("sysadmin/gastown.refinery")}); err != nil {
+			t.Fatalf("update work: %v", err)
+		}
+	}
 	conv, err := store.Create(beads.Bead{Title: "input convoy", Type: "convoy"})
 	if err != nil {
 		t.Fatalf("create convoy: %v", err)
@@ -57,7 +62,7 @@ func seedDoneWorkflow(t *testing.T, memberStatus string) (*beads.MemStore, beads
 func TestWorkflowInputDoneDetectsTerminalConvoyMember(t *testing.T) {
 	store, root, step := seedDoneWorkflow(t, "closed")
 
-	rootID, done, err := workflowInputDone(store, root)
+	rootID, done, err := workflowInputDone(store, root, nil)
 	if err != nil {
 		t.Fatalf("workflowInputDone(root): %v", err)
 	}
@@ -65,7 +70,7 @@ func TestWorkflowInputDoneDetectsTerminalConvoyMember(t *testing.T) {
 		t.Fatalf("root: done=%v rootID=%q, want done=true rootID=%q", done, rootID, root.ID)
 	}
 
-	rootID, done, err = workflowInputDone(store, step)
+	rootID, done, err = workflowInputDone(store, step, nil)
 	if err != nil {
 		t.Fatalf("workflowInputDone(step): %v", err)
 	}
@@ -76,7 +81,7 @@ func TestWorkflowInputDoneDetectsTerminalConvoyMember(t *testing.T) {
 
 func TestWorkflowInputDoneFalseWhileMemberOpen(t *testing.T) {
 	store, root, _ := seedDoneWorkflow(t, "open")
-	_, done, err := workflowInputDone(store, root)
+	_, done, err := workflowInputDone(store, root, nil)
 	if err != nil {
 		t.Fatalf("workflowInputDone: %v", err)
 	}
@@ -93,12 +98,56 @@ func TestWorkflowInputDoneFalseWithoutInputConvoy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	_, done, err := workflowInputDone(store, root)
+	_, done, err := workflowInputDone(store, root, nil)
 	if err != nil {
 		t.Fatalf("workflowInputDone: %v", err)
 	}
 	if done {
 		t.Fatal("done = true with no input convoy, want false")
+	}
+}
+
+func TestWorkflowInputDoneTrueWhenMemberHandedOffToOtherLane(t *testing.T) {
+	store, root, _ := seedDoneWorkflow(t, "handed_off")
+	_, done, err := workflowInputDone(store, root, []string{"gastown__polecat-gc-xxxx"})
+	if err != nil {
+		t.Fatalf("workflowInputDone: %v", err)
+	}
+	if !done {
+		t.Fatal("done = false for a member handed off to another lane, want true")
+	}
+}
+
+func TestWorkflowInputDoneFalseWhenMemberAssignedToIdentityCandidate(t *testing.T) {
+	store, root, _ := seedDoneWorkflow(t, "handed_off")
+	convoyID := root.Metadata[beadmeta.InputConvoyIDMetadataKey]
+	members, err := convoy.Members(store, convoyID, true)
+	if err != nil {
+		t.Fatalf("convoy.Members: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("members = %d, want 1", len(members))
+	}
+	if err := store.Update(members[0].ID, beads.UpdateOpts{Assignee: strPtr("gastown__polecat-gc-xxxx")}); err != nil {
+		t.Fatalf("update work: %v", err)
+	}
+	_, done, err := workflowInputDone(store, root, []string{"gastown__polecat-gc-xxxx"})
+	if err != nil {
+		t.Fatalf("workflowInputDone: %v", err)
+	}
+	if done {
+		t.Fatal("done = true for a member assigned to one of identityCandidates, want false")
+	}
+}
+
+func TestWorkflowInputDoneFalseWhenMemberUnassignedOpen(t *testing.T) {
+	store, root, _ := seedDoneWorkflow(t, "open")
+	_, done, err := workflowInputDone(store, root, []string{"gastown__polecat-gc-xxxx"})
+	if err != nil {
+		t.Fatalf("workflowInputDone: %v", err)
+	}
+	if done {
+		t.Fatal("done = true for an unassigned open member, want false")
 	}
 }
 
@@ -148,7 +197,7 @@ func TestDoHookClaimSkipsWorkflowWhoseInputIsDone(t *testing.T) {
 			claimed = true
 			return beads.Bead{ID: beadID, Assignee: assignee}, true, nil
 		},
-		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead) (string, bool, error) {
+		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead, _ []string) (string, bool, error) {
 			return "root-1", true, nil
 		},
 		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
@@ -211,7 +260,7 @@ func TestDoHookClaimSkipsExistingAssignmentWhoseInputIsDone(t *testing.T) {
 			t.Fatalf("unexpected claim of %s", beadID)
 			return beads.Bead{}, false, nil
 		},
-		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead) (string, bool, error) {
+		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead, _ []string) (string, bool, error) {
 			return "root-1", true, nil
 		},
 		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
@@ -264,7 +313,7 @@ func TestDoHookClaimStillClaimsWhenInputNotDone(t *testing.T) {
 			claimedID = beadID
 			return beads.Bead{ID: beadID, Assignee: assignee, Status: "in_progress"}, true, nil
 		},
-		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead) (string, bool, error) {
+		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead, _ []string) (string, bool, error) {
 			return "root-1", false, nil
 		},
 		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {

--- a/cmd/gc/cmd_hook_claim_input_done_test.go
+++ b/cmd/gc/cmd_hook_claim_input_done_test.go
@@ -148,7 +148,7 @@ func TestDoHookClaimSkipsWorkflowWhoseInputIsDone(t *testing.T) {
 			claimed = true
 			return beads.Bead{ID: beadID, Assignee: assignee}, true, nil
 		},
-		InputDone: func(_ context.Context, _ string, _ []string, candidate beads.Bead) (string, bool, error) {
+		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead) (string, bool, error) {
 			return "root-1", true, nil
 		},
 		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
@@ -207,11 +207,11 @@ func TestDoHookClaimSkipsExistingAssignmentWhoseInputIsDone(t *testing.T) {
 	skipped := ""
 	ops := hookClaimOps{
 		Runner: func(string, string) (string, error) { return string(output), nil },
-		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
+		Claim: func(_ context.Context, _ string, _ []string, beadID, _ string) (beads.Bead, bool, error) {
 			t.Fatalf("unexpected claim of %s", beadID)
 			return beads.Bead{}, false, nil
 		},
-		InputDone: func(_ context.Context, _ string, _ []string, candidate beads.Bead) (string, bool, error) {
+		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead) (string, bool, error) {
 			return "root-1", true, nil
 		},
 		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {
@@ -264,7 +264,7 @@ func TestDoHookClaimStillClaimsWhenInputNotDone(t *testing.T) {
 			claimedID = beadID
 			return beads.Bead{ID: beadID, Assignee: assignee, Status: "in_progress"}, true, nil
 		},
-		InputDone: func(_ context.Context, _ string, _ []string, candidate beads.Bead) (string, bool, error) {
+		InputDone: func(_ context.Context, _ string, _ []string, _ beads.Bead) (string, bool, error) {
 			return "root-1", false, nil
 		},
 		SkipDoneWorkflow: func(_ context.Context, _ string, _ []string, rootID string) error {


### PR DESCRIPTION
## Summary

Stacked on #6102 (first two commits are #6102's branch as-is; review only the last commit, `feat(hook-claim): treat handed-off input convoy members as done`). Extends #6101's fix to the handed-off case.

#6102 retires a workflow whose input convoy work is **terminal**. The same unbounded re-serve loop also happens when the input work bead is still open but has been **handed off to another lane** — the canonical case is a polecat's `mol-polecat-work` whose work bead was reassigned to the refinery at submit time. `submit-and-exit` drain-acks while the seat still holds its `in_progress` step; the reconciler re-wakes the seat (in_progress work is a wake anchor); the hook serves the same molecule again as `existing_assignment`; `#6102`'s terminal-only check does not fire because the work bead is `open`, so nothing ever ends it. Measured on a live city before this change: one session re-served one bead 199 times.

`workflowInputDone` now treats a convoy member as done when it is terminal **or** non-terminal but assigned to an identity outside the claiming session's `identityCandidates` (no longer ours to wait on). A member that is still unassigned, or still assigned to one of our own identities, keeps the workflow blocked, so a live worker's own claim is never retired. `hookInputDoneFunc` gains the `identityCandidates` parameter; the stderr diagnostic and close reason are unchanged apart from wording.

## Testing

- [x] Cluster (linux/amd64, `CGO_ENABLED=0`): `go test ./cmd/gc -run 'WorkflowInputDone|DoHookClaim|SkipDoneWorkflow'` passes on this branch (run id in the PR comment).
- [x] New tests in `cmd/gc/cmd_hook_claim_input_done_test.go`: handed-off member → done; member assigned to an identity candidate → not done; unassigned open member → not done.
- [x] Dogfooded on a live city on the deployed lineage (v1.4.0 + backports) through two polecat batches of 8 and 12 concurrent sessions: 15 handed-off molecules, 15 distinct (session, bead) `drain_acked_with_assigned_work` pairs with zero repeats, all 15 roots and steps closed `gc.outcome=skipped` by this path. Residual cost is one bounded re-wake per handed-off molecule (the worker's own terminal drain-ack precedes the next claim, where this check fires), versus the previous unbounded loop.
- [ ] `make check` — not run locally (no Go toolchain on the operator host); full `go test ./...` on the cluster has the same `--- FAIL` set as the base commit.
- [ ] `make test-integration` — not run.

## Checklist

- [x] Linked an issue (#6101, same loop, second trigger)
- [x] Added or updated tests for behavior changes
- [ ] Docs: no user-facing surface changes
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQru47R8EJ8UPk4rUvM8Ta
