### PR TITLE
Add doctor cleanup for stale executor identity stamps

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -322,6 +322,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		if storeOK {
 			register(doctor.NewBeadsStoreCheck(cityPath, openStoreResultForCity(cityPath)))
 			register(newV2RoutedToNamespaceCheck(cfg, cityPath, storeFactory))
+			register(newExecutorIdentityResidueCheck(cfg, cityPath, storeFactory))
 			register(newCensusOwnerLivenessCheck(cfg, cityPath, storeFactory))
 			register(newRunTargetRoutedToBackfillCheck(cfg, cityPath, storeFactory))
 			register(newRouteRecoveryQuarantineCheck(cfg, cityPath, storeFactory))

--- a/cmd/gc/doctor_executor_identity_residue_check.go
+++ b/cmd/gc/doctor_executor_identity_residue_check.go
@@ -39,10 +39,15 @@ type executorIdentityResidueFinding struct {
 	label  string
 	store  beads.Store
 	beadID string
+	// keys is the set of metadata keys the triggering condition(s) actually
+	// named. Fix() clears exactly these keys -- never a fixed superset --
+	// so a trigger that did not fire can never lose state it never
+	// inspected.
+	keys []string
 }
 
 func (f executorIdentityResidueFinding) describe() string {
-	return fmt.Sprintf("%s bead %s carries stale executor-identity stamp residue (%s)", f.label, f.beadID, beadmeta.SessionNameMetadataKey)
+	return fmt.Sprintf("%s bead %s carries stale executor-identity stamp residue (%s)", f.label, f.beadID, strings.Join(f.keys, ", "))
 }
 
 func (c *executorIdentityResidueCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
@@ -78,10 +83,12 @@ func (c *executorIdentityResidueCheck) Fix(_ *doctor.CheckContext) error {
 	findings, skipped := c.collect()
 	var errs []error
 	for _, f := range findings {
-		clearKVs := map[string]string{
-			beadmeta.SessionNameMetadataKey:   "",
-			beadmeta.WorkDirMetadataKey:       "",
-			beadmeta.LegacyWorkDirMetadataKey: "",
+		if len(f.keys) == 0 {
+			continue
+		}
+		clearKVs := make(map[string]string, len(f.keys))
+		for _, key := range f.keys {
+			clearKVs[key] = ""
 		}
 		if err := f.store.SetMetadataBatch(f.beadID, clearKVs); err != nil {
 			errs = append(errs, fmt.Errorf("%s bead %s: clear executor-identity stamp: %w", f.label, f.beadID, err))
@@ -130,10 +137,11 @@ func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, l
 	routeIdentities := buildExecutorRouteIdentityIndex(items)
 	var findings []executorIdentityResidueFinding
 	for _, bd := range items {
-		if !isExecutorIdentityStampStale(c.cfg, bd, routeIdentities) {
+		keys := staleExecutorIdentityStampKeys(c.cfg, bd, routeIdentities)
+		if len(keys) == 0 {
 			continue
 		}
-		findings = append(findings, executorIdentityResidueFinding{label: label, store: store, beadID: bd.ID})
+		findings = append(findings, executorIdentityResidueFinding{label: label, store: store, beadID: bd.ID, keys: keys})
 	}
 	return findings, nil
 }
@@ -179,43 +187,100 @@ func (idx executorRouteIdentityIndex) legitimate(route, identity string) bool {
 	return ok
 }
 
-// isExecutorIdentityStampStale reports whether bd carries executor-identity
-// stamp residue. Closed and in_progress beads are always out of scope, as is
-// workflow topology (a run root, scope latch, or formula spec is never
-// itself claimed — only its descendant steps are — so a completed step's
-// visibility stamp copied onto the root must not read as residue even when
-// it no longer matches the root's own gc.routed_to).
+// staleExecutorIdentityStampKeys reports which metadata keys on bd carry
+// stale executor-identity stamp residue, or nil if none. Closed and
+// in_progress beads are always out of scope, as is workflow topology (a run
+// root, scope latch, or formula spec is never itself claimed — only its
+// descendant steps are — so a completed step's visibility stamp copied onto
+// the root must not read as residue even when it no longer matches the
+// root's own gc.routed_to).
 //
-// Two independent triggers follow, either of which flags the bead:
-//
-//   - A legacy work_dir that disagrees with the canonical gc.work_dir. This
-//     is checked regardless of gc.session_name, since the two keys can drift
-//     independently.
-//   - A non-empty gc.session_name on a bead with a non-empty gc.routed_to
-//     (an empty route is the ordinary post-claim/detached-orphan state, not
-//     residue) whose stamped session name is neither what the bead's CURRENT
-//     gc.routed_to would mint today — via agent.SessionNameFor, honoring any
-//     configured session_template, forward-encoded on every call, never
-//     against a fixed snapshot — nor a member of that route's legitimate
-//     executor-identity set (routeIdentities; a pool slot's own concrete
-//     session name is a legitimate stamp against its base route).
-func isExecutorIdentityStampStale(cfg *config.City, bd beads.Bead, routeIdentities executorRouteIdentityIndex) bool {
+// Two independent triggers follow, each contributing only the key(s) it
+// actually fired on to the result — see staleWorkDirStamp and
+// staleSessionNameStamp for the trigger conditions and stand-downs. Keeping
+// the two disjoint is load-bearing: Fix() clears exactly the returned keys,
+// so a trigger that did not fire can never lose state it never inspected.
+func staleExecutorIdentityStampKeys(cfg *config.City, bd beads.Bead, routeIdentities executorRouteIdentityIndex) []string {
 	if bd.Status == "closed" {
-		return false
+		return nil
 	}
 	if bd.Status == "in_progress" {
-		return false
+		return nil
 	}
 	if graphroute.IsWorkflowTopologyKind(bd.Metadata[beadmeta.KindMetadataKey]) {
-		return false
+		return nil
 	}
 
+	var keys []string
+	if staleWorkDirStamp(cfg, bd) {
+		keys = append(keys, beadmeta.WorkDirMetadataKey, beadmeta.LegacyWorkDirMetadataKey)
+	}
+	if staleSessionNameStamp(cfg, bd, routeIdentities) {
+		keys = append(keys, beadmeta.SessionNameMetadataKey)
+	}
+	return keys
+}
+
+// staleWorkDirStamp reports whether bd's legacy work_dir disagrees with its
+// canonical gc.work_dir in a way that is genuine residue, rather than a
+// repair candidate or an actively worktree-owning bead.
+//
+// Two stand-downs guard against clearing state a downstream fail-closed
+// check relies on:
+//
+//   - hasWorktreeOwnershipEvidence: worktreeSpecForBead treats a bead
+//     carrying worktree ownership metadata as actively managed and fails
+//     closed on a canonical/legacy disagreement for it. Clearing both keys
+//     here would erase the very evidence that check inspects, silently
+//     downgrading its fail-closed conflict error into a "no spec, unmanaged"
+//     no-op — the ga-6af29d/#6135 round-2 regression this stand-down closes.
+//   - poolSlotWorkDirRepairFor(cfg, bd) != nil: this shape (canonical
+//     clobbered with a pool-slot label, legacy still holding real per-bead
+//     evidence) is a repair candidate the reconciler's own one-shot sweep
+//     restores from legacy. Flagging it here races that repair for the same
+//     keys and, if this check's Fix() wins, blanks both instead of
+//     restoring the canonical.
+func staleWorkDirStamp(cfg *config.City, bd beads.Bead) bool {
 	workDir := strings.TrimSpace(bd.Metadata[beadmeta.WorkDirMetadataKey])
 	legacyWorkDir := strings.TrimSpace(bd.Metadata[beadmeta.LegacyWorkDirMetadataKey])
-	if workDir != "" && legacyWorkDir != "" && workDir != legacyWorkDir {
-		return true
+	if workDir == "" || legacyWorkDir == "" || workDir == legacyWorkDir {
+		return false
 	}
+	if hasWorktreeOwnershipEvidence(bd) {
+		return false
+	}
+	if poolSlotWorkDirRepairFor(cfg, bd) != nil {
+		return false
+	}
+	return true
+}
 
+// hasWorktreeOwnershipEvidence reports whether bd publishes any of the
+// worktree-ownership metadata keys worktreeSpecForBead inspects to tell a
+// managed per-bead worktree apart from an unmanaged spawn.
+func hasWorktreeOwnershipEvidence(bd beads.Bead) bool {
+	for _, key := range []string{
+		beadmeta.WorktreeRootMetadataKey,
+		beadmeta.WorktreeRepoMetadataKey,
+		beadmeta.WorktreeOwnerMetadataKey,
+	} {
+		if strings.TrimSpace(bd.Metadata[key]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// staleSessionNameStamp reports whether bd carries a stale gc.session_name:
+// a non-empty stamp on a bead with a non-empty gc.routed_to (an empty route
+// is the ordinary post-claim/detached-orphan state, not residue) whose
+// stamped session name is neither what the bead's CURRENT gc.routed_to would
+// mint today — via agent.SessionNameFor, honoring any configured
+// session_template, forward-encoded on every call, never against a fixed
+// snapshot — nor a member of that route's legitimate executor-identity set
+// (routeIdentities; a pool slot's own concrete session name is a legitimate
+// stamp against its base route).
+func staleSessionNameStamp(cfg *config.City, bd beads.Bead, routeIdentities executorRouteIdentityIndex) bool {
 	sessionName := strings.TrimSpace(bd.Metadata[beadmeta.SessionNameMetadataKey])
 	if sessionName == "" {
 		return false

--- a/cmd/gc/doctor_executor_identity_residue_check.go
+++ b/cmd/gc/doctor_executor_identity_residue_check.go
@@ -1,14 +1,26 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/agentutil"
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
-// executorIdentityResidueCheck is a gc doctor check for stale
-// executor-identity stamp residue: TODO(ga-cm2o5t.1.2) implement in the
-// GREEN step.
+// executorIdentityResidueCheck is a gc doctor check that finds and clears
+// stale executor-identity stamp residue left on beads: gc.session_name,
+// gc.work_dir, and the legacy work_dir metadata keys can survive after a
+// bead moves on from the executor that stamped them (design ref
+// ga-cm2o5t.1, PR #6099).
 type executorIdentityResidueCheck struct {
 	cfg      *config.City
 	cityPath string
@@ -23,10 +35,132 @@ func (c *executorIdentityResidueCheck) Name() string { return "executor-identity
 
 func (c *executorIdentityResidueCheck) CanFix() bool { return true }
 
+type executorIdentityResidueFinding struct {
+	label  string
+	store  beads.Store
+	beadID string
+}
+
+func (f executorIdentityResidueFinding) describe() string {
+	return fmt.Sprintf("%s bead %s carries stale executor-identity stamp residue", f.label, f.beadID)
+}
+
 func (c *executorIdentityResidueCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
-	return okCheck(c.Name(), "not yet implemented")
+	findings, skipped := c.collect()
+	if len(findings) == 0 && len(skipped) == 0 {
+		return okCheck(c.Name(), "no stale executor-identity stamp residue found")
+	}
+	details := make([]string, 0, len(findings)+len(skipped))
+	for _, f := range findings {
+		details = append(details, f.describe())
+	}
+	details = append(details, skipped...)
+	sort.Strings(details)
+	if len(findings) == 0 {
+		return warnCheck(c.Name(),
+			fmt.Sprintf("executor-identity-residue check skipped %d scope(s)", len(skipped)),
+			"fix bead store access, then rerun gc doctor",
+			details)
+	}
+	if len(skipped) > 0 {
+		return warnCheck(c.Name(),
+			fmt.Sprintf("%d bead(s) carry stale executor-identity stamp residue; %d scope(s) skipped", len(findings), len(skipped)),
+			"run gc doctor --fix to clear the stale stamps, fix skipped store access, then rerun gc doctor",
+			details)
+	}
+	return warnCheck(c.Name(),
+		fmt.Sprintf("%d bead(s) carry stale executor-identity stamp residue", len(findings)),
+		"run gc doctor --fix to clear the stale gc.session_name/gc.work_dir/work_dir stamps, then rerun gc doctor",
+		details)
 }
 
 func (c *executorIdentityResidueCheck) Fix(_ *doctor.CheckContext) error {
-	return nil
+	findings, skipped := c.collect()
+	var errs []error
+	for _, f := range findings {
+		clearKVs := map[string]string{
+			beadmeta.SessionNameMetadataKey:   "",
+			beadmeta.WorkDirMetadataKey:       "",
+			beadmeta.LegacyWorkDirMetadataKey: "",
+		}
+		if err := f.store.SetMetadataBatch(f.beadID, clearKVs); err != nil {
+			errs = append(errs, fmt.Errorf("%s bead %s: clear executor-identity stamp: %w", f.label, f.beadID, err))
+		}
+	}
+	if len(skipped) > 0 {
+		errs = append(errs, fmt.Errorf("executor-identity-residue skipped %d scope(s): %s", len(skipped), strings.Join(skipped, "; ")))
+	}
+	return errors.Join(errs...)
+}
+
+func (c *executorIdentityResidueCheck) collect() (findings []executorIdentityResidueFinding, skipped []string) {
+	scopes := []struct{ label, path string }{{"city", c.cityPath}}
+	if c.cfg != nil {
+		suspState, _ := loadSuspensionState(fsys.OSFS{}, c.cityPath)
+		for _, rig := range c.cfg.Rigs {
+			if suspensionstate.EffectiveRigSuspended(suspState, rig.Name, rig.EffectiveSuspendedOnStart()) || strings.TrimSpace(rig.Path) == "" {
+				continue
+			}
+			scopes = append(scopes, struct{ label, path string }{"rig " + rig.Name, rig.Path})
+		}
+	}
+	for _, sc := range scopes {
+		if c.newStore == nil || strings.TrimSpace(sc.path) == "" {
+			continue
+		}
+		store, err := c.newStore(sc.path)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: opening bead store: %v", sc.label, err))
+			continue
+		}
+		scopeFindings, err := c.collectStoreFindings(store, sc.label)
+		findings = append(findings, scopeFindings...)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: listing beads: %v", sc.label, err))
+		}
+	}
+	return findings, skipped
+}
+
+func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, label string) ([]executorIdentityResidueFinding, error) {
+	items, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		return nil, err
+	}
+	var findings []executorIdentityResidueFinding
+	for _, bd := range items {
+		if !isExecutorIdentityStampStale(c.cfg, bd) {
+			continue
+		}
+		findings = append(findings, executorIdentityResidueFinding{label: label, store: store, beadID: bd.ID})
+	}
+	return findings, nil
+}
+
+// isExecutorIdentityStampStale reports whether bd carries executor-identity
+// stamp residue: it is not in_progress, at least one of gc.session_name,
+// gc.work_dir, or the legacy work_dir key is non-empty, and — when
+// gc.session_name is set — the agent it names no longer matches the bead's
+// CURRENT gc.routed_to once both are canonicalized through
+// NormalizePoolRouteTarget. The comparison is re-derived from gc.routed_to on
+// every call, never against a fixed snapshot, so a bead whose stamp merely
+// canonicalizes to the same target it is already routed to is not flagged.
+func isExecutorIdentityStampStale(cfg *config.City, bd beads.Bead) bool {
+	if bd.Status == "in_progress" {
+		return false
+	}
+	sessionName := strings.TrimSpace(bd.Metadata[beadmeta.SessionNameMetadataKey])
+	workDir := strings.TrimSpace(bd.Metadata[beadmeta.WorkDirMetadataKey])
+	legacyWorkDir := strings.TrimSpace(bd.Metadata[beadmeta.LegacyWorkDirMetadataKey])
+	if sessionName == "" && workDir == "" && legacyWorkDir == "" {
+		return false
+	}
+	if sessionName != "" {
+		routedTo := strings.TrimSpace(bd.Metadata[beadmeta.RoutedToMetadataKey])
+		implied := agent.UnsanitizeQualifiedNameFromSession(sessionName)
+		if agentutil.NormalizePoolRouteTarget(cfg, implied) == agentutil.NormalizePoolRouteTarget(cfg, routedTo) {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/gc/doctor_executor_identity_residue_check.go
+++ b/cmd/gc/doctor_executor_identity_residue_check.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/graphroute"
+	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
@@ -44,6 +45,11 @@ type executorIdentityResidueFinding struct {
 	// so a trigger that did not fire can never lose state it never
 	// inspected.
 	keys []string
+	// identities is the executor-identity index this finding was judged
+	// against, carried so Fix() can re-run the same predicate on the live
+	// bead without rebuilding a different index and reaching a different
+	// verdict than the one that produced the finding.
+	identities executorRouteIdentityIndex
 }
 
 func (f executorIdentityResidueFinding) describe() string {
@@ -86,8 +92,26 @@ func (c *executorIdentityResidueCheck) Fix(_ *doctor.CheckContext) error {
 		if len(f.keys) == 0 {
 			continue
 		}
-		clearKVs := make(map[string]string, len(f.keys))
-		for _, key := range f.keys {
+		// Re-read the bead immediately before writing. collect()'s listing is
+		// a snapshot, and a worker -- usually in another process -- may have
+		// claimed, closed, or re-routed the bead in the window since. A claim
+		// atomically flips it open->in_progress and consumes gc.routed_to, so
+		// clearing the snapshot's keys would strip identity metadata off work
+		// in flight. Recompute the predicate on the live row and clear only
+		// the keys that still fire; a bead that no longer qualifies is skipped
+		// silently, the same guard sweepDetachedHandoffOrphans applies before
+		// its own write.
+		live, getErr := f.store.Get(f.beadID)
+		if getErr != nil {
+			errs = append(errs, fmt.Errorf("%s bead %s: re-read before clearing executor-identity stamp: %w", f.label, f.beadID, getErr))
+			continue
+		}
+		liveKeys := staleExecutorIdentityStampKeys(c.cfg, live, f.identities)
+		if len(liveKeys) == 0 {
+			continue
+		}
+		clearKVs := make(map[string]string, len(liveKeys))
+		for _, key := range liveKeys {
 			clearKVs[key] = ""
 		}
 		if err := f.store.SetMetadataBatch(f.beadID, clearKVs); err != nil {
@@ -101,47 +125,107 @@ func (c *executorIdentityResidueCheck) Fix(_ *doctor.CheckContext) error {
 }
 
 func (c *executorIdentityResidueCheck) collect() (findings []executorIdentityResidueFinding, skipped []string) {
-	scopes := []struct{ label, path string }{{"city", c.cityPath}}
+	if c.newStore == nil {
+		return nil, nil
+	}
+	type residueScope struct {
+		label string
+		store beads.Store
+	}
+	var scopes []residueScope
+	var cityStore beads.Store
+	if strings.TrimSpace(c.cityPath) != "" {
+		store, err := c.newStore(c.cityPath)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("city skipped: opening bead store: %v", err))
+		} else {
+			cityStore = store
+			scopes = append(scopes, residueScope{label: "city", store: store})
+		}
+	}
 	if c.cfg != nil {
 		suspState, _ := loadSuspensionState(fsys.OSFS{}, c.cityPath)
 		for _, rig := range c.cfg.Rigs {
 			if suspensionstate.EffectiveRigSuspended(suspState, rig.Name, rig.EffectiveSuspendedOnStart()) || strings.TrimSpace(rig.Path) == "" {
 				continue
 			}
-			scopes = append(scopes, struct{ label, path string }{"rig " + rig.Name, rig.Path})
+			label := "rig " + rig.Name
+			store, err := c.newStore(rig.Path)
+			if err != nil {
+				skipped = append(skipped, fmt.Sprintf("%s skipped: opening bead store: %v", label, err))
+				continue
+			}
+			scopes = append(scopes, residueScope{label: label, store: store})
 		}
 	}
+	if len(scopes) == 0 {
+		return nil, skipped
+	}
+
+	// Session beads belong to the session coordination class, which resolves to
+	// the city store by default and follows a [beads.classes.sessions]
+	// relocation otherwise -- never to a rig store. Build the executor-identity
+	// index from that one store and share it with every scope, because a rig
+	// store holds the claimed WORK beads this check inspects but none of the
+	// session beads that say which identities legitimately act for a route.
+	// Indexing each scope from its own listing leaves every rig with an empty
+	// index, so every pool-slot and alias stamp on rig work reads as a re-route
+	// hazard -- exactly the false positive the pool-instance and alias
+	// stand-downs exist to prevent.
+	//
+	// Without a usable index this check cannot tell residue from a legitimate
+	// identity, and its Fix() deletes state. So an index that cannot be built
+	// stands every scope down rather than scanning blind.
+	if cityStore == nil {
+		skipped = append(skipped, "all scopes skipped: session-identity index unavailable: city bead store did not open")
+		return nil, skipped
+	}
+	sessionStore := cliSessionStore(cityStore, c.cfg, c.cityPath)
+	sessionIdentities, err := buildExecutorRouteIdentityIndex(sessionStore)
+	if err != nil {
+		skipped = append(skipped, fmt.Sprintf("all scopes skipped: building session-identity index: %v", err))
+		return nil, skipped
+	}
+
 	for _, sc := range scopes {
-		if c.newStore == nil || strings.TrimSpace(sc.path) == "" {
-			continue
+		identities := sessionIdentities
+		// Union in a DISTINCT scope store's own session beads, so a rig that
+		// does hold session records still contributes them. Interface identity
+		// is the right test -- production stores are pointer-backed
+		// CachingStores -- and it keeps the default single-store city from
+		// scanning the same rows twice. The union is built into the scope's own
+		// index rather than into the shared one, so one scope's session beads
+		// can never leak into the next scope's verdict.
+		if sc.store != sessionStore {
+			scopeIdentities, idxErr := buildExecutorRouteIdentityIndex(sc.store)
+			if idxErr != nil {
+				skipped = append(skipped, fmt.Sprintf("%s skipped: listing session beads: %v", sc.label, idxErr))
+				continue
+			}
+			scopeIdentities.backfill(sessionIdentities)
+			identities = scopeIdentities
 		}
-		store, err := c.newStore(sc.path)
-		if err != nil {
-			skipped = append(skipped, fmt.Sprintf("%s skipped: opening bead store: %v", sc.label, err))
-			continue
-		}
-		scopeFindings, err := c.collectStoreFindings(store, sc.label)
+		scopeFindings, listErr := c.collectStoreFindings(sc.store, sc.label, identities)
 		findings = append(findings, scopeFindings...)
-		if err != nil {
-			skipped = append(skipped, fmt.Sprintf("%s skipped: listing beads: %v", sc.label, err))
+		if listErr != nil {
+			skipped = append(skipped, fmt.Sprintf("%s skipped: listing beads: %v", sc.label, listErr))
 		}
 	}
 	return findings, skipped
 }
 
-func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, label string) ([]executorIdentityResidueFinding, error) {
+func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, label string, routeIdentities executorRouteIdentityIndex) ([]executorIdentityResidueFinding, error) {
 	items, err := store.List(beads.ListQuery{Status: "open", AllowScan: true, Live: true})
 	if err != nil {
 		return nil, err
 	}
-	routeIdentities := buildExecutorRouteIdentityIndex(items)
 	var findings []executorIdentityResidueFinding
 	for _, bd := range items {
 		keys := staleExecutorIdentityStampKeys(c.cfg, bd, routeIdentities)
 		if len(keys) == 0 {
 			continue
 		}
-		findings = append(findings, executorIdentityResidueFinding{label: label, store: store, beadID: bd.ID, keys: keys})
+		findings = append(findings, executorIdentityResidueFinding{label: label, store: store, beadID: bd.ID, keys: keys, identities: routeIdentities})
 	}
 	return findings, nil
 }
@@ -152,31 +236,65 @@ func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, l
 // set when the route runs a pool — each pool slot mints its own concrete
 // session name (sessionBeadIdentifier semantics) while still belonging to
 // the same route (retiredSessionFallbackRoute semantics). Built fresh from
-// the same open, live-scanned beads on every check run, never persisted, so
-// it always reflects the pool's current membership.
+// the session-class store's session beads on every check run, never
+// persisted, so it always reflects the pool's current membership.
 type executorRouteIdentityIndex map[string]map[string]struct{}
 
-// buildExecutorRouteIdentityIndex indexes items's open session beads by
-// route (retiredSessionFallbackRoute) and identity (sessionBeadIdentifier),
-// the inverse direction of pool_detached_orphan_sweep.go's
-// detachedOrphanRouteIndex (session_name -> route, single-valued).
-func buildExecutorRouteIdentityIndex(items []beads.Bead) executorRouteIdentityIndex {
-	idx := make(executorRouteIdentityIndex)
-	for _, b := range items {
-		if b.Type != sessionBeadType {
-			continue
-		}
-		route := strings.TrimSpace(retiredSessionFallbackRoute(b))
-		identity := strings.TrimSpace(sessionBeadIdentifier(b))
-		if route == "" || identity == "" {
-			continue
-		}
-		if idx[route] == nil {
-			idx[route] = make(map[string]struct{})
-		}
-		idx[route][identity] = struct{}{}
+// add records identity as a legitimate executor for route, ignoring a pair
+// with an empty half.
+func (idx executorRouteIdentityIndex) add(route, identity string) {
+	if route == "" || identity == "" {
+		return
 	}
-	return idx
+	if idx[route] == nil {
+		idx[route] = make(map[string]struct{})
+	}
+	idx[route][identity] = struct{}{}
+}
+
+// backfill copies every route/identity pair from other that idx does not
+// already carry, mirroring pool_detached_orphan_sweep.go's
+// detachedOrphanRouteIndex.backfill. Membership here is a set per route
+// rather than a single value, so the union is taken pair by pair: a route
+// both indexes know keeps both their identities instead of one shadowing
+// the other.
+func (idx executorRouteIdentityIndex) backfill(other executorRouteIdentityIndex) {
+	for route, identities := range other {
+		for identity := range identities {
+			idx.add(route, identity)
+		}
+	}
+}
+
+// buildExecutorRouteIdentityIndex indexes store's session beads by route
+// (retiredSessionFallbackRoute) and identity (sessionBeadIdentifier), the
+// inverse direction of pool_detached_orphan_sweep.go's
+// detachedOrphanRouteIndex (session_name -> route, single-valued).
+//
+// Rows come from the session front door's ListAll, the canonical enumeration:
+// it unions the type leg with the label leg, so a crash- or migration-damaged
+// session bead that kept its gc:session label but lost its type still
+// contributes its identity. Closed session beads are included for the same
+// reason the sibling index includes them — the worker session is usually
+// already gone by the time a sweep runs, and dropping its bead would make
+// every stamp it left read as residue. Route and identity are read off the
+// typed Info projection via the retiredSessionFallbackRouteInfo /
+// sessionBeadIdentifierInfo mirrors, which are byte-identical to their raw-bead
+// forms, so no session bead is cracked open here.
+//
+// A partial listing yields usable rows and is used as-is; only a hard error
+// is returned, because an empty index cannot distinguish residue from a
+// legitimate identity and this check's Fix() deletes state.
+func buildExecutorRouteIdentityIndex(store beads.Store) (executorRouteIdentityIndex, error) {
+	idx := make(executorRouteIdentityIndex)
+	all, listErr := sessionFrontDoor(store).ListAll(session.ListAllOptions{IncludeClosed: true})
+	if listErr != nil && !beads.IsPartialResult(listErr) {
+		return nil, fmt.Errorf("listing session beads: %w", listErr)
+	}
+	for _, info := range all {
+		idx.add(strings.TrimSpace(retiredSessionFallbackRouteInfo(info)), strings.TrimSpace(sessionBeadIdentifierInfo(info)))
+	}
+	return idx, nil
 }
 
 func (idx executorRouteIdentityIndex) legitimate(route, identity string) bool {

--- a/cmd/gc/doctor_executor_identity_residue_check.go
+++ b/cmd/gc/doctor_executor_identity_residue_check.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// executorIdentityResidueCheck is a gc doctor check for stale
+// executor-identity stamp residue: TODO(ga-cm2o5t.1.2) implement in the
+// GREEN step.
+type executorIdentityResidueCheck struct {
+	cfg      *config.City
+	cityPath string
+	newStore func(string) (beads.Store, error)
+}
+
+func newExecutorIdentityResidueCheck(cfg *config.City, cityPath string, newStore func(string) (beads.Store, error)) *executorIdentityResidueCheck {
+	return &executorIdentityResidueCheck{cfg: cfg, cityPath: cityPath, newStore: newStore}
+}
+
+func (c *executorIdentityResidueCheck) Name() string { return "executor-identity-residue" }
+
+func (c *executorIdentityResidueCheck) CanFix() bool { return true }
+
+func (c *executorIdentityResidueCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	return okCheck(c.Name(), "not yet implemented")
+}
+
+func (c *executorIdentityResidueCheck) Fix(_ *doctor.CheckContext) error {
+	return nil
+}

--- a/cmd/gc/doctor_executor_identity_residue_check.go
+++ b/cmd/gc/doctor_executor_identity_residue_check.go
@@ -20,7 +20,7 @@ import (
 // stale executor-identity stamp residue left on beads: gc.session_name,
 // gc.work_dir, and the legacy work_dir metadata keys can survive after a
 // bead moves on from the executor that stamped them (design ref
-// ga-cm2o5t.1, PR #6099).
+// ga-cm2o5t.1, PR #6099; amended scope ga-6af29d decision 1).
 type executorIdentityResidueCheck struct {
 	cfg      *config.City
 	cityPath string
@@ -123,13 +123,14 @@ func (c *executorIdentityResidueCheck) collect() (findings []executorIdentityRes
 }
 
 func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, label string) ([]executorIdentityResidueFinding, error) {
-	items, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	items, err := store.List(beads.ListQuery{Status: "open", AllowScan: true, Live: true})
 	if err != nil {
 		return nil, err
 	}
+	routeIdentities := buildExecutorRouteIdentityIndex(items)
 	var findings []executorIdentityResidueFinding
 	for _, bd := range items {
-		if !isExecutorIdentityStampStale(c.cfg, bd) {
+		if !isExecutorIdentityStampStale(c.cfg, bd, routeIdentities) {
 			continue
 		}
 		findings = append(findings, executorIdentityResidueFinding{label: label, store: store, beadID: bd.ID})
@@ -137,34 +138,101 @@ func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, l
 	return findings, nil
 }
 
+// executorRouteIdentityIndex maps a route to the full set of executor
+// identities that legitimately act for it. The base session name a plain
+// SessionNameFor(route) encoding would produce is only one member of that
+// set when the route runs a pool — each pool slot mints its own concrete
+// session name (sessionBeadIdentifier semantics) while still belonging to
+// the same route (retiredSessionFallbackRoute semantics). Built fresh from
+// the same open, live-scanned beads on every check run, never persisted, so
+// it always reflects the pool's current membership.
+type executorRouteIdentityIndex map[string]map[string]struct{}
+
+// buildExecutorRouteIdentityIndex indexes items's open session beads by
+// route (retiredSessionFallbackRoute) and identity (sessionBeadIdentifier),
+// the inverse direction of pool_detached_orphan_sweep.go's
+// detachedOrphanRouteIndex (session_name -> route, single-valued).
+func buildExecutorRouteIdentityIndex(items []beads.Bead) executorRouteIdentityIndex {
+	idx := make(executorRouteIdentityIndex)
+	for _, b := range items {
+		if b.Type != sessionBeadType {
+			continue
+		}
+		route := strings.TrimSpace(retiredSessionFallbackRoute(b))
+		identity := strings.TrimSpace(sessionBeadIdentifier(b))
+		if route == "" || identity == "" {
+			continue
+		}
+		if idx[route] == nil {
+			idx[route] = make(map[string]struct{})
+		}
+		idx[route][identity] = struct{}{}
+	}
+	return idx
+}
+
+func (idx executorRouteIdentityIndex) legitimate(route, identity string) bool {
+	if route == "" || identity == "" {
+		return false
+	}
+	_, ok := idx[route][identity]
+	return ok
+}
+
 // isExecutorIdentityStampStale reports whether bd carries executor-identity
-// stamp residue. It is not in_progress, not workflow topology (a run root,
-// scope latch, or formula spec is never itself claimed — only its descendant
-// steps are — so a completed step's visibility stamp copied onto the root
-// must not read as residue even when it no longer matches the root's own
-// gc.routed_to), gc.session_name is non-empty, and the session name the
-// bead's CURRENT gc.routed_to would mint today — via agent.SessionNameFor,
-// honoring any configured session_template — no longer matches the stored
-// gc.session_name. The comparison forward-encodes from gc.routed_to on every
-// call, never against a fixed snapshot and never via a best-effort reverse
-// decode, so a bead whose stamp still matches what its current route would
-// mint — including through a custom session_template — is not flagged.
-func isExecutorIdentityStampStale(cfg *config.City, bd beads.Bead) bool {
+// stamp residue. Closed and in_progress beads are always out of scope, as is
+// workflow topology (a run root, scope latch, or formula spec is never
+// itself claimed — only its descendant steps are — so a completed step's
+// visibility stamp copied onto the root must not read as residue even when
+// it no longer matches the root's own gc.routed_to).
+//
+// Two independent triggers follow, either of which flags the bead:
+//
+//   - A legacy work_dir that disagrees with the canonical gc.work_dir. This
+//     is checked regardless of gc.session_name, since the two keys can drift
+//     independently.
+//   - A non-empty gc.session_name on a bead with a non-empty gc.routed_to
+//     (an empty route is the ordinary post-claim/detached-orphan state, not
+//     residue) whose stamped session name is neither what the bead's CURRENT
+//     gc.routed_to would mint today — via agent.SessionNameFor, honoring any
+//     configured session_template, forward-encoded on every call, never
+//     against a fixed snapshot — nor a member of that route's legitimate
+//     executor-identity set (routeIdentities; a pool slot's own concrete
+//     session name is a legitimate stamp against its base route).
+func isExecutorIdentityStampStale(cfg *config.City, bd beads.Bead, routeIdentities executorRouteIdentityIndex) bool {
+	if bd.Status == "closed" {
+		return false
+	}
 	if bd.Status == "in_progress" {
 		return false
 	}
 	if graphroute.IsWorkflowTopologyKind(bd.Metadata[beadmeta.KindMetadataKey]) {
 		return false
 	}
+
+	workDir := strings.TrimSpace(bd.Metadata[beadmeta.WorkDirMetadataKey])
+	legacyWorkDir := strings.TrimSpace(bd.Metadata[beadmeta.LegacyWorkDirMetadataKey])
+	if workDir != "" && legacyWorkDir != "" && workDir != legacyWorkDir {
+		return true
+	}
+
 	sessionName := strings.TrimSpace(bd.Metadata[beadmeta.SessionNameMetadataKey])
 	if sessionName == "" {
 		return false
 	}
 	routedTo := strings.TrimSpace(bd.Metadata[beadmeta.RoutedToMetadataKey])
+	if routedTo == "" {
+		return false
+	}
 	var sessionTemplate string
+	var cityName string
 	if cfg != nil {
 		sessionTemplate = cfg.Workspace.SessionTemplate
+		cityName = cfg.EffectiveCityName()
 	}
-	expected := agent.SessionNameFor(cfg.EffectiveCityName(), routedTo, sessionTemplate)
-	return expected != sessionName
+	expected := agent.SessionNameFor(cityName, routedTo, sessionTemplate)
+	if expected == sessionName {
+		return false
+	}
+	return !routeIdentities.legitimate(routedTo, sessionName)
 }

--- a/cmd/gc/doctor_executor_identity_residue_check.go
+++ b/cmd/gc/doctor_executor_identity_residue_check.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/agent"
-	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/graphroute"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
 
@@ -42,7 +42,7 @@ type executorIdentityResidueFinding struct {
 }
 
 func (f executorIdentityResidueFinding) describe() string {
-	return fmt.Sprintf("%s bead %s carries stale executor-identity stamp residue", f.label, f.beadID)
+	return fmt.Sprintf("%s bead %s carries stale executor-identity stamp residue (%s)", f.label, f.beadID, beadmeta.SessionNameMetadataKey)
 }
 
 func (c *executorIdentityResidueCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
@@ -138,29 +138,33 @@ func (c *executorIdentityResidueCheck) collectStoreFindings(store beads.Store, l
 }
 
 // isExecutorIdentityStampStale reports whether bd carries executor-identity
-// stamp residue: it is not in_progress, at least one of gc.session_name,
-// gc.work_dir, or the legacy work_dir key is non-empty, and — when
-// gc.session_name is set — the agent it names no longer matches the bead's
-// CURRENT gc.routed_to once both are canonicalized through
-// NormalizePoolRouteTarget. The comparison is re-derived from gc.routed_to on
-// every call, never against a fixed snapshot, so a bead whose stamp merely
-// canonicalizes to the same target it is already routed to is not flagged.
+// stamp residue. It is not in_progress, not workflow topology (a run root,
+// scope latch, or formula spec is never itself claimed — only its descendant
+// steps are — so a completed step's visibility stamp copied onto the root
+// must not read as residue even when it no longer matches the root's own
+// gc.routed_to), gc.session_name is non-empty, and the session name the
+// bead's CURRENT gc.routed_to would mint today — via agent.SessionNameFor,
+// honoring any configured session_template — no longer matches the stored
+// gc.session_name. The comparison forward-encodes from gc.routed_to on every
+// call, never against a fixed snapshot and never via a best-effort reverse
+// decode, so a bead whose stamp still matches what its current route would
+// mint — including through a custom session_template — is not flagged.
 func isExecutorIdentityStampStale(cfg *config.City, bd beads.Bead) bool {
 	if bd.Status == "in_progress" {
 		return false
 	}
-	sessionName := strings.TrimSpace(bd.Metadata[beadmeta.SessionNameMetadataKey])
-	workDir := strings.TrimSpace(bd.Metadata[beadmeta.WorkDirMetadataKey])
-	legacyWorkDir := strings.TrimSpace(bd.Metadata[beadmeta.LegacyWorkDirMetadataKey])
-	if sessionName == "" && workDir == "" && legacyWorkDir == "" {
+	if graphroute.IsWorkflowTopologyKind(bd.Metadata[beadmeta.KindMetadataKey]) {
 		return false
 	}
-	if sessionName != "" {
-		routedTo := strings.TrimSpace(bd.Metadata[beadmeta.RoutedToMetadataKey])
-		implied := agent.UnsanitizeQualifiedNameFromSession(sessionName)
-		if agentutil.NormalizePoolRouteTarget(cfg, implied) == agentutil.NormalizePoolRouteTarget(cfg, routedTo) {
-			return false
-		}
+	sessionName := strings.TrimSpace(bd.Metadata[beadmeta.SessionNameMetadataKey])
+	if sessionName == "" {
+		return false
 	}
-	return true
+	routedTo := strings.TrimSpace(bd.Metadata[beadmeta.RoutedToMetadataKey])
+	var sessionTemplate string
+	if cfg != nil {
+		sessionTemplate = cfg.Workspace.SessionTemplate
+	}
+	expected := agent.SessionNameFor(cfg.EffectiveCityName(), routedTo, sessionTemplate)
+	return expected != sessionName
 }

--- a/cmd/gc/doctor_executor_identity_residue_check_test.go
+++ b/cmd/gc/doctor_executor_identity_residue_check_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestExecutorIdentityResidueCheckFlagsAndFixesStaleStamp(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "stale stamp", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--builder",
+			"gc.work_dir":     "/worktrees/gascity/builder-1",
+			"work_dir":        "/legacy/worktrees/gascity/builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning: %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "CITY-1") {
+		t.Fatalf("details missing CITY-1:\n%s", details)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+
+	bd, err := cityStore.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for _, key := range []string{"gc.session_name", "gc.work_dir", "work_dir"} {
+		if v := bd.Metadata[key]; v != "" {
+			t.Fatalf("expected %s cleared, got %q", key, v)
+		}
+	}
+	if bd.Metadata["gc.routed_to"] != "gascity/reviewer" {
+		t.Fatalf("Fix must not touch gc.routed_to, got %q", bd.Metadata["gc.routed_to"])
+	}
+
+	result = check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status after fix = %v, want ok: %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckSkipsInProgressBead(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "in flight", Type: "task", Status: "in_progress", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--builder",
+			"gc.work_dir":     "/worktrees/gascity/builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (in_progress beads must never be flagged): %#v", result.Status, result)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+
+	bd, err := cityStore.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.session_name"] != "gascity--builder" || bd.Metadata["gc.work_dir"] != "/worktrees/gascity/builder-1" {
+		t.Fatalf("Fix must not touch an in_progress bead's stamps, got %+v", bd.Metadata)
+	}
+}
+
+func TestExecutorIdentityResidueCheckFixIsIdempotent(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := &residueSetMetadataBatchSpyStore{Store: beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "stale stamp", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--builder",
+		}},
+	}, nil)}
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("first Fix returned error: %v", err)
+	}
+	if cityStore.calls != 1 {
+		t.Fatalf("expected exactly 1 write after first Fix, got %d", cityStore.calls)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("second Fix returned error: %v", err)
+	}
+	if cityStore.calls != 1 {
+		t.Fatalf("expected zero additional writes on second Fix, got %d total", cityStore.calls)
+	}
+}
+
+func TestExecutorIdentityResidueCheckAllowsCanonicalSessionNameEncoding(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "still current", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "gascity--builder",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (session_name canonicalizes to current routed_to, not drift): %#v", result.Status, result)
+	}
+}
+
+type residueSetMetadataBatchSpyStore struct {
+	beads.Store
+	calls int
+}
+
+func (s *residueSetMetadataBatchSpyStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	s.calls++
+	return s.Store.SetMetadataBatch(id, kvs)
+}

--- a/cmd/gc/doctor_executor_identity_residue_check_test.go
+++ b/cmd/gc/doctor_executor_identity_residue_check_test.go
@@ -347,7 +347,7 @@ func TestExecutorIdentityResidueCheckDistinguishesLegitimatePoolInstanceFromStal
 	cityDir := t.TempDir()
 	cfg := &config.City{}
 	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
-		{ID: "SESSION-1", Type: sessionBeadType, Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+		{ID: "SESSION-1", Type: sessionBeadType, Status: "open", Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
 			"session_name": "gascity--builder-2",
 			"template":     "gascity/builder",
 		}},

--- a/cmd/gc/doctor_executor_identity_residue_check_test.go
+++ b/cmd/gc/doctor_executor_identity_residue_check_test.go
@@ -152,6 +152,162 @@ func TestExecutorIdentityResidueCheckAllowsCanonicalSessionNameEncoding(t *testi
 	}
 }
 
+func TestExecutorIdentityResidueCheckSkipsSessionBeadWithoutSessionName(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "session bead", Type: "session", Status: "open", Metadata: map[string]string{
+			"work_dir": "/worktrees/gascity/builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (a session bead's bare work_dir must not be flagged without gc.session_name): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckSkipsDrainStepWithoutSessionName(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "drain step", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.work_dir": "/worktrees/gascity/builder-1",
+			"work_dir":    "/worktrees/gascity/builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (a drain step/member carries both work_dir keys but never gc.session_name, so it must not be flagged): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckSkipsOpenPoolBeadWithoutSessionName(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "pool ready", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.work_dir": "/worktrees/gascity/builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (an open pool-ready bead has gc.work_dir but no gc.session_name, so it must not be flagged): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckSkipsWorkflowRunRootDespiteSessionNameStamp(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "workflow run root", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.kind":         "workflow",
+			"gc.session_name": "gascity--builder",
+			"gc.work_dir":     "/worktrees/gascity/builder-1",
+			"gc.routed_to":    "gascity/reviewer",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (a workflow run root is topology, never itself claimed; a completed step's visibility stamp on gc.session_name/gc.work_dir must not read as residue even though it mismatches gc.routed_to): %#v", result.Status, result)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	bd, err := cityStore.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.session_name"] != "gascity--builder" || bd.Metadata["gc.work_dir"] != "/worktrees/gascity/builder-1" {
+		t.Fatalf("Fix must not clear a workflow run root's visibility stamp, got %+v", bd.Metadata)
+	}
+}
+
+func TestExecutorIdentityResidueCheckAllowsCustomSessionTemplateEncoding(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{
+		Name:            "acmecity",
+		SessionTemplate: "{{.City}}-{{.Name}}",
+	}}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "custom template session", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "acmecity-builder",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (gc.session_name minted via a custom session_template forward-encodes from the current gc.routed_to, so it is current, not drift): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckDescribeNamesTriggeringKeys(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "stale stamp", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--builder",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning: %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "gc.session_name") {
+		t.Fatalf("describe() must name the triggering key(s), got:\n%s", details)
+	}
+}
+
 type residueSetMetadataBatchSpyStore struct {
 	beads.Store
 	calls int

--- a/cmd/gc/doctor_executor_identity_residue_check_test.go
+++ b/cmd/gc/doctor_executor_identity_residue_check_test.go
@@ -637,3 +637,169 @@ func TestExecutorIdentityResidueCheckAllowsAliasOnlySessionIdentity(t *testing.T
 		t.Fatalf("status = %v, want ok (SESSION-1 is a named session identified by alias, not session_name -- sessionBeadIdentifier falls back to alias, and CITY-1's gc.session_name matches that legitimate identity for gascity/mayor): %#v", result.Status, result)
 	}
 }
+
+// Round 4 (#6135 fix-merge) test cases below: session beads live in the
+// session coordination class (the city store by default), never in a rig
+// store, so a rig scope must resolve executor identities from there.
+
+func TestExecutorIdentityResidueCheckHonorsCitySessionIdentityForRigScopePoolSlot(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "gascity", Path: rigDir}}}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "SESSION-1", Type: sessionBeadType, Status: "open", Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+			"session_name": "gascity--builder-2",
+			"template":     "gascity/builder",
+		}},
+	}, nil)
+	rigStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "RIG-1", Title: "legitimate pool instance in a rig", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "gascity--builder-2",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, residueStoreFactory(t, cityDir, cityStore, rigDir, rigStore))
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (SESSION-1 lives in the city store because session beads are session-class; a rig scope must still see gascity--builder-2 as a legitimate identity for gascity/builder): %#v", result.Status, result)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	bd, err := rigStore.Get("RIG-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.session_name"] != "gascity--builder-2" {
+		t.Fatalf("Fix must not clear a legitimate pool-slot identity on a rig bead, got %q", bd.Metadata["gc.session_name"])
+	}
+}
+
+func TestExecutorIdentityResidueCheckHonorsCityAliasSessionIdentityForRigScope(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{Rigs: []config.Rig{{Name: "gascity", Path: rigDir}}}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "SESSION-1", Type: sessionBeadType, Status: "open", Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+			"alias":    "mayor",
+			"template": "gascity/mayor",
+		}},
+	}, nil)
+	rigStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "RIG-1", Title: "named session identity in a rig", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/mayor",
+			"gc.session_name": "mayor",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, residueStoreFactory(t, cityDir, cityStore, rigDir, rigStore))
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (an alias-only named session in the city store is a legitimate identity for a rig bead routed to gascity/mayor): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckHonorsLabelOnlySessionBeadIdentity(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "SESSION-1", Status: "open", Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+			"session_name": "gascity--builder-2",
+			"template":     "gascity/builder",
+		}},
+		{ID: "CITY-1", Title: "pool instance", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "gascity--builder-2",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (a crash/migration-damaged session bead keeps the gc:session label with an empty type; ListAllSessionBeads unions type and label, so its identity still counts): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckFixSkipsBeadClaimedSinceCollection(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := &residueClaimedOnGetSpyStore{Store: beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "claimed between collect and write", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--builder",
+		}},
+	}, nil)}
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning (the listed snapshot is still open): %#v", result.Status, result)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	if cityStore.writes != 0 {
+		t.Fatalf("expected zero writes when the live bead is in_progress at write time (a claim consumes gc.routed_to and puts the stamp back in service; clearing it would strip identity off work in flight), got %d", cityStore.writes)
+	}
+	bd, err := cityStore.Store.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.session_name"] != "gascity--builder" {
+		t.Fatalf("Fix must leave the stamp on a bead claimed since collection, got %q", bd.Metadata["gc.session_name"])
+	}
+}
+
+// residueStoreFactory returns a newStore func serving cityStore at cityDir and
+// rigStore at rigDir, failing the test on any other path.
+func residueStoreFactory(t *testing.T, cityDir string, cityStore beads.Store, rigDir string, rigStore beads.Store) func(string) (beads.Store, error) {
+	t.Helper()
+	return func(path string) (beads.Store, error) {
+		switch path {
+		case cityDir:
+			return cityStore, nil
+		case rigDir:
+			return rigStore, nil
+		}
+		return nil, fmt.Errorf("unexpected store path %q", path)
+	}
+}
+
+// residueClaimedOnGetSpyStore lists beads as open but returns them in_progress
+// from Get, standing in for a worker that claimed the bead in the window
+// between collection and the write.
+type residueClaimedOnGetSpyStore struct {
+	beads.Store
+	writes int
+}
+
+func (s *residueClaimedOnGetSpyStore) Get(id string) (beads.Bead, error) {
+	bd, err := s.Store.Get(id)
+	if err != nil {
+		return bd, err
+	}
+	bd.Status = "in_progress"
+	return bd, nil
+}
+
+func (s *residueClaimedOnGetSpyStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	s.writes++
+	return s.Store.SetMetadataBatch(id, kvs)
+}

--- a/cmd/gc/doctor_executor_identity_residue_check_test.go
+++ b/cmd/gc/doctor_executor_identity_residue_check_test.go
@@ -285,9 +285,13 @@ func TestExecutorIdentityResidueCheckDescribeNamesTriggeringKeys(t *testing.T) {
 	cityDir := t.TempDir()
 	cfg := &config.City{}
 	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
-		{ID: "CITY-1", Title: "stale stamp", Type: "task", Status: "open", Metadata: map[string]string{
+		{ID: "CITY-1", Title: "session-name residue", Type: "task", Status: "open", Metadata: map[string]string{
 			"gc.routed_to":    "gascity/reviewer",
 			"gc.session_name": "gascity--builder",
+		}},
+		{ID: "CITY-2", Title: "work_dir residue", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.work_dir": "/worktrees/gascity/builder-1",
+			"work_dir":    "/legacy/worktrees/gascity/builder-1",
 		}},
 	}, nil)
 
@@ -302,10 +306,40 @@ func TestExecutorIdentityResidueCheckDescribeNamesTriggeringKeys(t *testing.T) {
 	if result.Status != doctor.StatusWarning {
 		t.Fatalf("status = %v, want warning: %#v", result.Status, result)
 	}
-	details := strings.Join(result.Details, "\n")
-	if !strings.Contains(details, "gc.session_name") {
-		t.Fatalf("describe() must name the triggering key(s), got:\n%s", details)
+
+	sessionDetail := residueDetailFor(t, result.Details, "CITY-1")
+	if !strings.Contains(sessionDetail, "(gc.session_name)") {
+		t.Fatalf("describe() must name the triggering key for a session-name finding, got:\n%s", sessionDetail)
 	}
+	if strings.Contains(sessionDetail, "work_dir") {
+		t.Fatalf("describe() must not name work_dir keys for a session-name-only finding, got:\n%s", sessionDetail)
+	}
+
+	workDirDetail := residueDetailFor(t, result.Details, "CITY-2")
+	if !strings.Contains(workDirDetail, "(gc.work_dir, work_dir)") {
+		t.Fatalf("describe() must name both triggering keys for a work_dir finding, got:\n%s", workDirDetail)
+	}
+	if strings.Contains(workDirDetail, "session_name") {
+		t.Fatalf("describe() must not name gc.session_name for a work_dir-only finding, got:\n%s", workDirDetail)
+	}
+}
+
+// residueDetailFor returns the single detail line naming beadID, failing the
+// test if zero or more than one line matches.
+func residueDetailFor(t *testing.T, details []string, beadID string) string {
+	t.Helper()
+	var match string
+	count := 0
+	for _, d := range details {
+		if strings.Contains(d, beadID) {
+			match = d
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 detail line for bead %s, got %d:\n%s", beadID, count, strings.Join(details, "\n"))
+	}
+	return match
 }
 
 type residueSetMetadataBatchSpyStore struct {
@@ -481,6 +515,20 @@ func TestExecutorIdentityResidueCheckFlagsLegacyCanonicalWorkDirDisagreement(t *
 	if !strings.Contains(details, "CITY-1") {
 		t.Fatalf("details missing CITY-1:\n%s", details)
 	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	bd, err := cityStore.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.work_dir"] != "" || bd.Metadata["work_dir"] != "" {
+		t.Fatalf("Fix must clear the disagreeing work_dir keys, got %+v", bd.Metadata)
+	}
+	if bd.Metadata["gc.session_name"] != "gascity--builder" {
+		t.Fatalf("Fix must not clear gc.session_name when only the work_dir trigger fired (it is current, not a separate finding), got %q", bd.Metadata["gc.session_name"])
+	}
 }
 
 type residueListQuerySpyStore struct {
@@ -491,4 +539,101 @@ type residueListQuerySpyStore struct {
 func (s *residueListQuerySpyStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 	s.queries = append(s.queries, q)
 	return s.Store.List(q)
+}
+
+// Round 3 (ga-dkfmdu) test cases below.
+
+func TestExecutorIdentityResidueCheckPreservesWorkDirOnWorktreeOwningBead(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "worktree-owning bead, retired-slot session_name", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":      "gascity/reviewer",
+			"gc.session_name":   "gascity--builder-9",
+			"gc.work_dir":       "/worktrees/gascity/builder-1",
+			"work_dir":          "/legacy/worktrees/gascity/builder-1",
+			"gc.worktree_root":  "/worktrees/gascity/builder-1",
+			"gc.worktree_repo":  "gascity",
+			"gc.worktree_owner": "builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning (the retired-slot gc.session_name is a genuine independent finding): %#v", result.Status, result)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	bd, err := cityStore.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.work_dir"] != "/worktrees/gascity/builder-1" || bd.Metadata["work_dir"] != "/legacy/worktrees/gascity/builder-1" {
+		t.Fatalf("Fix must not clear work_dir keys on a bead carrying worktree-ownership evidence (clearing them defeats worktreeSpecForBead's fail-closed legacy/canonical conflict check by erasing the evidence it inspects), got %+v", bd.Metadata)
+	}
+	if bd.Metadata["gc.session_name"] != "" {
+		t.Fatalf("Fix must still clear the independently-stale gc.session_name, got %q", bd.Metadata["gc.session_name"])
+	}
+}
+
+func TestExecutorIdentityResidueCheckDefersToPoolSlotWorkDirRepair(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	bd := beads.Bead{ID: "CITY-1", Title: "canonical clobbered with pool-slot label", Type: "task", Status: "open", Metadata: map[string]string{
+		"gc.routed_to": "gascity/builder",
+		"gc.work_dir":  ".gc/worktrees/gascity/builder-1",
+		"work_dir":     "/legacy/worktrees/gascity/builder-1",
+	}}
+	if poolSlotWorkDirRepairFor(cfg, bd) == nil {
+		t.Fatalf("fixture premise broken: bead must match poolSlotWorkDirRepairFor's precondition (canonical pool-slot-shaped, legacy differs and is not)")
+	}
+
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{bd}, nil)
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (a bead matching poolSlotWorkDirRepairFor's precondition is a repair candidate, not residue -- flagging it races the repair sweep and risks destroying the same evidence the repair exists to restore): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckAllowsAliasOnlySessionIdentity(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "SESSION-1", Type: sessionBeadType, Status: "open", Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+			"alias":    "mayor",
+			"template": "gascity/mayor",
+		}},
+		{ID: "CITY-1", Title: "named session identity", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/mayor",
+			"gc.session_name": "mayor",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (SESSION-1 is a named session identified by alias, not session_name -- sessionBeadIdentifier falls back to alias, and CITY-1's gc.session_name matches that legitimate identity for gascity/mayor): %#v", result.Status, result)
+	}
 }

--- a/cmd/gc/doctor_executor_identity_residue_check_test.go
+++ b/cmd/gc/doctor_executor_identity_residue_check_test.go
@@ -317,3 +317,178 @@ func (s *residueSetMetadataBatchSpyStore) SetMetadataBatch(id string, kvs map[st
 	s.calls++
 	return s.Store.SetMetadataBatch(id, kvs)
 }
+
+// Round 2 (ga-p5eymu, amended ruling ga-6af29d decision 1) test cases below.
+
+func TestExecutorIdentityResidueCheckSkipsOpenBeadWithEmptyRoutedTo(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "detached handoff orphan", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.session_name": "gascity--builder",
+			"gc.work_branch":  "builder/ga-abc123",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (empty gc.routed_to is the ordinary post-claim/detached-orphan state, never residue): %#v", result.Status, result)
+	}
+}
+
+func TestExecutorIdentityResidueCheckDistinguishesLegitimatePoolInstanceFromStaleReroute(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "SESSION-1", Type: sessionBeadType, Labels: []string{sessionBeadLabel}, Metadata: map[string]string{
+			"session_name": "gascity--builder-2",
+			"template":     "gascity/builder",
+		}},
+		{ID: "CITY-1", Title: "legitimate pool instance", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "gascity--builder-2",
+		}},
+		{ID: "CITY-2", Title: "stale re-route", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--deployer",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning (CITY-2 is a genuine re-route hazard): %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	if strings.Contains(details, "CITY-1") {
+		t.Fatalf("CITY-1 carries a legitimate pool-instance identity (session bead SESSION-1 records gascity--builder-2 as a real member of gascity/builder's route) and must not be flagged:\n%s", details)
+	}
+	if !strings.Contains(details, "CITY-2") {
+		t.Fatalf("CITY-2's session name matches no session bead and no route encoding; it must still be flagged as a true positive:\n%s", details)
+	}
+}
+
+func TestExecutorIdentityResidueCheckScansWithLiveOpenQuery(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	store := &residueListQuerySpyStore{Store: beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "gascity--builder",
+		}},
+	}, nil)}
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok: %#v", result.Status, result)
+	}
+
+	found := false
+	for _, q := range store.queries {
+		if q.Status == "open" && q.Live {
+			found = true
+			if !q.AllowScan {
+				t.Fatalf("live open scan query %+v must set AllowScan", q)
+			}
+			if q.IncludeClosed {
+				t.Fatalf("live open scan query %+v should not also request IncludeClosed (Status=open already excludes closed; requesting both wastes the backing-store fetch)", q)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected a Status=%q Live=true scan query (gc-4zb pattern: mapBdStatus folds bd's raw review/testing/blocked into \"open\", so only a Live query reaches the backing store's own raw --status=open filter that actually excludes them), got queries: %+v", "open", store.queries)
+	}
+}
+
+func TestExecutorIdentityResidueCheckNeverFlagsClosedBead(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "closed with stale stamp", Type: "task", Status: "closed", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/reviewer",
+			"gc.session_name": "gascity--builder",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok (a stamp surviving close is documented behavior -- stampRunSessionIdentity keeps the completed-run->session link durable; closed beads are out of scope entirely): %#v", result.Status, result)
+	}
+
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	bd, err := cityStore.Get("CITY-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bd.Metadata["gc.session_name"] != "gascity--builder" {
+		t.Fatalf("Fix must not clear a closed bead's stamp, got %+v", bd.Metadata)
+	}
+}
+
+func TestExecutorIdentityResidueCheckFlagsLegacyCanonicalWorkDirDisagreement(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "work_dir disagreement, session_name current", Type: "task", Status: "open", Metadata: map[string]string{
+			"gc.routed_to":    "gascity/builder",
+			"gc.session_name": "gascity--builder",
+			"gc.work_dir":     "/worktrees/gascity/builder-1",
+			"work_dir":        "/legacy/worktrees/gascity/builder-1",
+		}},
+	}, nil)
+
+	check := newExecutorIdentityResidueCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	})
+
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning (legacy work_dir and canonical gc.work_dir disagree -- the ga-6af29d 20-bead class -- independent of gc.session_name, which is current): %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "CITY-1") {
+		t.Fatalf("details missing CITY-1:\n%s", details)
+	}
+}
+
+type residueListQuerySpyStore struct {
+	beads.Store
+	queries []beads.ListQuery
+}
+
+func (s *residueListQuerySpyStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.queries = append(s.queries, q)
+	return s.Store.List(q)
+}

--- a/cmd/gc/doctor_store_preflight.go
+++ b/cmd/gc/doctor_store_preflight.go
@@ -14,7 +14,7 @@ const doctorBeadStorePreflightTimeout = 5 * time.Second
 
 // City + per-rig store checks skipped on outage-shaped preflight; keep in sync with buildDoctorChecks.
 const (
-	doctorCityStoreCheckCount   = 14
+	doctorCityStoreCheckCount   = 15
 	doctorPerRigStoreCheckCount = 3
 )
 

--- a/cmd/gc/doctor_store_preflight_test.go
+++ b/cmd/gc/doctor_store_preflight_test.go
@@ -18,6 +18,7 @@ import (
 var doctorCityStoreDependentNames = []string{
 	"beads-store",
 	"v2-routed-to-namespace",
+	"executor-identity-residue",
 	"census-owner-liveness",
 	"run-target-routed-to-backfill",
 	"route-recovery-quarantine",
@@ -108,9 +109,9 @@ func TestBuildDoctorChecks_SkipsStoreChecksWhenStoreUnreachable(t *testing.T) {
 	if !strings.Contains(res.Message, "doltlite") {
 		t.Fatalf("preflight message = %q, want doltlite residual note", res.Message)
 	}
-	// Fourteen city checks plus three per active rig, two rigs active.
-	if !strings.Contains(res.Message, "skipped 20 store checks") {
-		t.Fatalf("preflight message = %q, want skip count 20", res.Message)
+	// Fifteen city checks plus three per active rig, two rigs active.
+	if !strings.Contains(res.Message, "skipped 21 store checks") {
+		t.Fatalf("preflight message = %q, want skip count 21", res.Message)
 	}
 	if !strings.Contains(res.Message, "2 rigs") {
 		t.Fatalf("preflight message = %q, want rig count 2", res.Message)

--- a/cmd/gc/doctor_warmup_eligible.go
+++ b/cmd/gc/doctor_warmup_eligible.go
@@ -87,3 +87,7 @@ func (c *poolIdleRoutedWorkCheck) WarmupEligible() bool { return false }
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
 func (c *startupHealthEpisodesCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *executorIdentityResidueCheck) WarmupEligible() bool { return false }

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -60,6 +60,7 @@ orphan-sessions
 bd-split-store
 beads-store
 v2-routed-to-namespace
+executor-identity-residue
 census-owner-liveness
 run-target-routed-to-backfill
 route-recovery-quarantine

--- a/release-gates/ga-3717xe-executor-identity-residue-gate.md
+++ b/release-gates/ga-3717xe-executor-identity-residue-gate.md
@@ -1,0 +1,126 @@
+# Release gate: executor-identity residue doctor sweep
+
+- Deploy bead: `ga-3717xe`
+- Build bead: `ga-cm2o5t.1.2`
+- Review bead: `ga-o0sl9f`
+- Reviewed source: `4698739c7e496319ca16d8b33936464214a11a4e`
+- Base checked: `origin/main@c6bb2aa30dd660c9dd9f955f9410e1e6fc202817`
+- Deploy branch: `deploy/ga-3717xe-gate`
+- Deploy mode: remote; push target: `fork`
+- Evaluated: 2026-09-07
+- Verdict: **PASS with three attributed, non-diff-owned test failures and one attributed lint-lane failure**
+
+## Gate checklist
+
+The target pre-flight ran before criterion 6. The reviewed SHA resolved to the
+full commit above and is not carried by an existing pull request. Criterion 6
+was checked first and passed against the freshly fetched base, so the remaining
+criteria were evaluated.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review-of-record `ga-o0sl9f` is closed with `verdict: pass` on the exact reviewed source. No review carryover is involved. |
+| 2 | Acceptance criteria met | **PASS** | The new `executor-identity-residue` doctor check enumerates the city plus active configured rigs, re-derives the current route for every bead, skips `in_progress` work, clears only `gc.session_name`, `gc.work_dir`, and legacy `work_dir` with partial-failure aggregation, retains `gc.routed_to`, reports through the established doctor result helpers, and is excluded from startup warmup. Tests cover stale cleanup, the in-progress guard, idempotence, canonical session-name equivalence, registration, preflight counts, and the ordered doctor-check catalog. No hardcoded role or point-in-time bead list was added. |
+| 3 | Tests pass | **PASS with attributed raw failures** | The documented full-scope 40-job command completed **37 PASS / 3 raw FAIL / 0 SKIP jobs**, with zero observed `--- SKIP` test events. Every diff-owned test listed below ran in a green process shard and a green integration-package shard. The three raw failures are attributed under criterion 3a. `test_cmd_scope: full-suite`; `waiver_ref: none`. |
+| 3a | Pre-existing failures attributed | **PASS** | `TestBdFlagManifestCurrent` is tracked by `ga-f0uceo`; `TestE2E_SuspendResume_City` by `ga-dqd7gf`; and the previously unseen missing-attempt-2 recovery condition is tracked by `ga-j88sfp`. The first two trackers predate the run. The third was created during this discovering run only after a decisive mechanism proof landed: the changed check can run only under `gc doctor`, is `WarmupEligible=false`, and its completed unit shards were no longer concurrent when the recovery lane started. No failing test path overlaps the diff. Sightings were written to the system of record and read back. |
+| 3b | Policy and static lanes | **PASS with one attributed raw lint failure** | `make test-ci-policy`, `make check-gomod-replace`, `make check-native-dependency-surface`, `make check-eventexport-isolation`, `make check-core-boundary`, `make test-native-doltlite-beads`, `make fmt-check-changed`, `make check-docs`, `go build ./...`, `go vet ./...`, and `git diff --check origin/main...HEAD` all PASS. `make lint-affected` conservatively widened to the full repository for the stale reviewed head, then replayed diagnostics from a deleted `/var/tmp/gc-maintainer-fix...` checkout and ignored dashboard `node_modules`; exact predating tracker `ga-u8z8j6` covers the condition, and no candidate-owned path appears in the output. |
+| 3c | CI-config lane | **PASS — n/a** | `ci_lane_run: n/a (no CI job, matrix, timeout, workflow, or required-check change)`. |
+| 4 | No high-severity review findings open | **PASS** | Unresolved HIGH findings: 0. The review records no blocking correctness, security, style, or coverage finding. |
+| 5 | Final branch is clean | **PASS** | `git status --porcelain=v1` was empty on the exact reviewed source after all test and policy checks and before this checklist was written. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree --write-tree --messages origin/main 4698739c7e496319ca16d8b33936464214a11a4e` returned tree `78361b2b809166a2463e23770a6121cd34a82269` with exit 0 and no conflict messages against `origin/main@c6bb2aa30dd660c9dd9f955f9410e1e6fc202817`. The candidate was 8 commits behind and 2 ahead when checked. No self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | Two TDD commits and seven files implement one `gc doctor` theme: detect and clear stale executor-identity stamps while preserving live work and current routing. |
+
+## Full-suite test evidence
+
+`test_cmd_scope: full-suite`
+
+```text
+export gc_test_gitconfig=caller-export-seed
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+TESTCONTAINERS_RYUK_DISABLED=true \
+LOCAL_TEST_LOG_DIR=/var/tmp/ga-3717xe-gate.tnlchT/jobs \
+LOCAL_TEST_JOBS=4 \
+CMD_GC_PROCESS_TOTAL=6 \
+GO_TEST_TIMEOUT=30m \
+make test-local-full-parallel
+```
+
+The rootless Podman socket was reachable before the run. The repository-pinned
+`docker.io/dolthub/dolt:2.1.7` image was pulled and resolved to digest
+`sha256:22319531c51c2fb2ca3639ad284d0ff9a98b55c25c6ba4ebeefbf7769e663916`.
+The caller export is an environment-only compatibility setup for this reviewed
+head, which predates the landed `ga-cesmzs` / PR #6116 runner fix; the script
+overwrites the seed with its real generated gitconfig path while retaining the
+export attribute. The first setup-only invocation omitted that export, aborted
+before any test ran, and is not counted as evidence.
+
+- `test_counts: 37 PASS jobs, 3 attributed raw FAIL jobs, 0 SKIP jobs`
+- `raw_test_failures: 3 attributed FAIL, none diff-owned`
+- `skip_justification: n/a; zero explicit test skips were observed`
+- `waiver_ref: none`
+- Full-run log: `/var/tmp/ga-3717xe-gate.tnlchT/full-suite.log`
+- Per-job logs: `/var/tmp/ga-3717xe-gate.tnlchT/jobs`
+
+`diff_tests_executed` — all PASS in green `cmd-gc-process` and
+`integration-packages-cmd-gc` shards:
+
+- `TestExecutorIdentityResidueCheckFlagsAndFixesStaleStamp`
+- `TestExecutorIdentityResidueCheckSkipsInProgressBead`
+- `TestExecutorIdentityResidueCheckFixIsIdempotent`
+- `TestExecutorIdentityResidueCheckAllowsCanonicalSessionNameEncoding`
+- `TestBuildDoctorChecks_SkipsStoreChecksWhenStoreUnreachable`
+- `TestBuildDoctorChecks_RegistersStoreChecksWhenStoreReachable`
+- `TestBuildDoctorChecks_RigStoreNameSetPreflight`
+- `TestBeadStorePreflightSkipCount`
+- `TestBuildDoctorChecks_NameSetUnchanged`
+
+## Raw failures and attribution
+
+| Raw result | Test | Tracker / proof |
+|---|---|---|
+| **FAIL — ATTRIBUTED** | `TestBdFlagManifestCurrent` | Open tracker `ga-f0uceo`, created 2026-08-15. Clause 3(a), mechanism: this test compares the host-installed `bd` surface with `internal/bdflags`; the candidate changes neither. `internal/bdflags` cannot import the changed `cmd/gc` main package, and there is no path overlap. |
+| **FAIL — ATTRIBUTED** | `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash` | Tracker `ga-j88sfp`, created during this discovering run under the landed-proof exception. Clause 3(a), mechanism: the failure occurred in a formula-recovery workflow that never invokes `gc doctor`; the new check is excluded from startup warmup and therefore cannot execute on this path. The candidate adds no suite target or resource-census load, and its unit-test shards completed before this lane started. There is no path overlap. |
+| **FAIL — ATTRIBUTED** | `TestE2E_SuspendResume_City` | Open tracker `ga-dqd7gf`, created 2026-09-02. Clause 3(a), mechanism: the exact tracked full-suite condition timed out waiting for `citysus.report`; the scenario invokes city suspend, session kill, and city resume, never `gc doctor`. The new check is excluded from startup warmup, and no test path overlaps. |
+
+`failure_attribution`:
+
+- `TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a) mechanism — installed-binary/source-manifest skew; candidate unreachable`
+- `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash -> ga-j88sfp | clause 3(a) mechanism — doctor-only, non-warmup change cannot execute in formula recovery`
+- `TestE2E_SuspendResume_City -> ga-dqd7gf | clause 3(a) mechanism — tracked report timeout in suspend/resume path; doctor-only change cannot execute`
+
+`inconclusive-guard: n/a — all three attributions have decisive mechanism
+proof.` The diff changes no resource-census baseline and adds no suite target.
+
+## Policy-lane attribution
+
+`policy_lane: required policy/static commands PASS; make lint-affected raw FAIL attributed to ga-u8z8j6`
+
+`LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=origin/main make lint-affected`
+selected full-repository scope because the older candidate lacks a path deleted
+on current main. Golangci then replayed 758 findings from a removed
+`/var/tmp/gc-maintainer-fix.4547.S6Jy0t` checkout plus three findings under
+ignored dashboard `node_modules`. This is the exact stale-head scope/cache leak
+tracked by open `ga-u8z8j6`, created 2026-08-25. The candidate changes none of
+those paths, no candidate-owned path appears in the output, and the independent
+policy, build, vet, format, docs, and boundary checks all pass. The sighting was
+appended and read back. Log:
+`/var/tmp/ga-3717xe-policy.5r4QH8/lint-affected.log`.
+
+## Pre-flight and ancestry evidence
+
+- The recorded commit passed a hex-only guard and resolved to the full reviewed
+  SHA above.
+- `gh api repos/gastownhall/gascity/commits/4698739c7e496319ca16d8b33936464214a11a4e/pulls`
+  returned no pull request, so no already-merged or closed-PR reconciliation
+  applies.
+- `assert_deploy_ancestry_scope origin/main 4698739c7e496319ca16d8b33936464214a11a4e ga-3717xe ga-cm2o5t.1.2`
+  passed. The accepted sibling is the confirmed build bead cited by both TDD
+  commits; no unrelated commit or `.claude/**` path rides in the range.
+- No `PR-DESCRIPTION` block or `gc.pr_ping` metadata is present.
+
+## Disposition
+
+All seven criteria pass. Cut the isolated `deploy/ga-3717xe-gate` branch at the
+reviewed SHA, commit this checklist, push it to the fork, open the PR, publish
+deploy clearance on the exact gated head, and route the merge-request to the
+mayor. The deployer does not merge.


### PR DESCRIPTION
## What this changes

`gc doctor` now reports stale executor identity metadata (`gc.session_name`, `gc.work_dir`, and legacy `work_dir`) on work that is no longer in progress and no longer routed to the stamped session. `gc doctor --fix` clears those stale stamps across the City and active rigs while preserving `gc.routed_to` and all in-progress work.

This makes stale ownership residue repairable in one explicit doctor sweep without putting cleanup judgment into startup or role-specific code.

## Review notes

- The check runs only in explicit doctor flows; it is excluded from startup warmup.
- Route identity is normalized and re-derived live for each bead; there is no stored ID snapshot or hardcoded role behavior.
- Fixes use batch metadata clearing per bead and aggregate partial failures.

## Test plan

- [x] Run the repository's full 40-job local suite with rootless Podman.
- [x] Exercise stale, in-progress, idempotent, canonical-route, registration, and preflight-count cases.
- [x] Run policy, boundary, build, vet, formatting, docs, and native DoltLite checks.
- [x] Release gate: [`release-gates/ga-3717xe-executor-identity-residue-gate.md`](release-gates/ga-3717xe-executor-identity-residue-gate.md)