### PR TITLE
perf(sessionlog): read pi's cwd-encoded session dir instead of walking every transcript root (stacked on #6089)

### DIFF
--- a/internal/sessionlog/pi_reader.go
+++ b/internal/sessionlog/pi_reader.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -167,12 +168,12 @@ func findPiSessionCandidatesIn(root, workDir string) []piSessionCandidate {
 		if !strings.HasSuffix(strings.ToLower(entry.Name()), ".jsonl") {
 			return nil
 		}
-		sessionID, cwd := piSessionHeader(path)
-		if cleanPiWorkDir(cwd) != workDir {
-			return nil
-		}
 		info, err := entry.Info()
 		if err != nil {
+			return nil
+		}
+		sessionID, cwd := cachedPiSessionHeader(path, info)
+		if cleanPiWorkDir(cwd) != workDir {
 			return nil
 		}
 		if sessionID == "" {
@@ -185,6 +186,48 @@ func findPiSessionCandidatesIn(root, workDir string) []piSessionCandidate {
 		return nil
 	}
 	return candidates
+}
+
+// piHeaderCacheEntry memoizes the parsed first-line header of a pi session
+// file. size+modTime form the stat signature: a rewritten transcript gets a new
+// signature and re-parses, while list/enrichment sweeps that revisit an
+// unchanged tree skip the per-file open+parse entirely.
+type piHeaderCacheEntry struct {
+	size      int64
+	modTimeNS int64
+	sessionID string
+	cwd       string
+}
+
+var (
+	piHeaderCacheMu sync.Mutex
+	piHeaderCache   = make(map[string]piHeaderCacheEntry)
+)
+
+// piHeaderCacheMaxEntries bounds the cache; deleted transcripts leave stale
+// keys behind, so past this size the map resets rather than growing forever.
+const piHeaderCacheMaxEntries = 16384
+
+func cachedPiSessionHeader(path string, info os.FileInfo) (string, string) {
+	size := info.Size()
+	modTimeNS := info.ModTime().UnixNano()
+
+	piHeaderCacheMu.Lock()
+	entry, ok := piHeaderCache[path]
+	piHeaderCacheMu.Unlock()
+	if ok && entry.size == size && entry.modTimeNS == modTimeNS {
+		return entry.sessionID, entry.cwd
+	}
+
+	sessionID, cwd := piSessionHeader(path)
+
+	piHeaderCacheMu.Lock()
+	if len(piHeaderCache) >= piHeaderCacheMaxEntries {
+		piHeaderCache = make(map[string]piHeaderCacheEntry)
+	}
+	piHeaderCache[path] = piHeaderCacheEntry{size: size, modTimeNS: modTimeNS, sessionID: sessionID, cwd: cwd}
+	piHeaderCacheMu.Unlock()
+	return sessionID, cwd
 }
 
 func parsePiFileDetailed(path string) ([]piEntry, string, SessionDiagnostics, error) {

--- a/internal/sessionlog/pi_reader.go
+++ b/internal/sessionlog/pi_reader.go
@@ -138,19 +138,90 @@ type piSessionCandidate struct {
 	modTime   time.Time
 }
 
+// piSessionDirName mirrors pi's own session-directory encoding
+// (getSessionDir in pi-coding-agent): "--" + cwd with one leading path
+// separator stripped and every "/", "\\" and ":" replaced by "-" + "--". Pi
+// writes every transcript for a cwd under exactly this directory of the
+// sessions root, so a lookup can read that one directory instead of walking
+// the whole root.
+func piSessionDirName(workDir string) string {
+	trimmed := workDir
+	if trimmed != "" && (trimmed[0] == '/' || trimmed[0] == '\\') {
+		trimmed = trimmed[1:]
+	}
+	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-")
+	return "--" + replacer.Replace(trimmed) + "--"
+}
+
+// piLegacyWalkExcludedRoots lists roots the legacy full-tree walk must never
+// descend into. The generic transcript search paths (the Claude projects tree
+// by default) are merged into the pi roots by mergePiSearchPaths, and that tree
+// can hold tens of thousands of .jsonl files that can never be pi transcripts:
+// walking it cost one readdir+lstat per file, per pi session row, per
+// /sessions request (gascity sys-by2243.75). Overridable for tests.
+var piLegacyWalkExcludedRoots = DefaultSearchPaths
+
 func findPiSessionCandidates(searchPaths []string, workDir string) []piSessionCandidate {
 	workDir = cleanPiWorkDir(workDir)
 	if workDir == "" {
 		return nil
 	}
 
+	roots := mergePiSearchPaths(searchPaths)
+	dirName := piSessionDirName(workDir)
 	var candidates []piSessionCandidate
-	for _, root := range mergePiSearchPaths(searchPaths) {
-		candidates = append(candidates, findPiSessionCandidatesIn(root, workDir)...)
+	encodedDirFound := false
+	for _, root := range roots {
+		dir := filepath.Join(root, dirName)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		encodedDirFound = true
+		candidates = append(candidates, piSessionCandidatesFromDir(dir, entries, workDir)...)
+	}
+	if !encodedDirFound {
+		// Legacy layout (transcripts not under the cwd-encoded directory):
+		// walk the pi roots, never the excluded generic roots.
+		excluded := make(map[string]bool)
+		for _, p := range piLegacyWalkExcludedRoots() {
+			excluded[filepath.Clean(p)] = true
+		}
+		for _, root := range roots {
+			if excluded[filepath.Clean(root)] {
+				continue
+			}
+			candidates = append(candidates, findPiSessionCandidatesIn(root, workDir)...)
+		}
 	}
 	sort.Slice(candidates, func(i, j int) bool {
 		return candidates[i].modTime.After(candidates[j].modTime)
 	})
+	return candidates
+}
+
+// piSessionCandidatesFromDir applies the same header check as the walk to the
+// .jsonl files of one directory, without descending.
+func piSessionCandidatesFromDir(dir string, entries []os.DirEntry, workDir string) []piSessionCandidate {
+	var candidates []piSessionCandidate
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".jsonl") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		sessionID, cwd := cachedPiSessionHeader(path, info)
+		if cleanPiWorkDir(cwd) != workDir {
+			continue
+		}
+		if sessionID == "" {
+			sessionID = piSessionID(path)
+		}
+		candidates = append(candidates, piSessionCandidate{path: path, sessionID: sessionID, modTime: info.ModTime()})
+	}
 	return candidates
 }
 

--- a/internal/sessionlog/pi_reader_test.go
+++ b/internal/sessionlog/pi_reader_test.go
@@ -438,3 +438,88 @@ func TestFindPiSessionFileFailsClosedOnAmbiguousCWD(t *testing.T) {
 		t.Fatalf("FindPiSessionFileByID(first) = %q, want %q", got, firstPath)
 	}
 }
+
+func writePiSessionHeaderFile(t *testing.T, path, workDir string) {
+	t.Helper()
+	body := `{"type":"session","version":3,"id":"sess-1","cwd":"` + filepath.ToSlash(workDir) + `"}`
+	if err := os.WriteFile(path, []byte(body+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestFindPiSessionFileByIDSkipsRereadWhenStatSignatureUnchanged(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project-aa")
+	otherDir := filepath.Join(filepath.Dir(workDir), "project-bb")
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() = %q, want %q", got, path)
+	}
+
+	// Rewrite the header to a different cwd of the same byte length and restore
+	// the original mtime, so the (size, mtime) stat signature is unchanged. The
+	// candidate scan must serve the cached header without re-reading the file.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	writePiSessionHeaderFile(t, path, otherDir)
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rewritten: %v", err)
+	}
+	if after.Size() != info.Size() {
+		t.Fatalf("rewrite changed size %d -> %d; test needs an identical signature", info.Size(), after.Size())
+	}
+	if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() after same-signature rewrite = %q, want cached %q", got, path)
+	}
+}
+
+func TestFindPiSessionFileByIDInvalidatesCacheOnChangedSignature(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	movedDir := workDir + "-moved"
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() = %q, want %q", got, path)
+	}
+
+	writePiSessionHeaderFile(t, path, movedDir)
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID(old cwd) = %q, want empty after header rewrite", got)
+	}
+	if got := FindPiSessionFileByID([]string{root}, movedDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID(new cwd) = %q, want %q", got, path)
+	}
+}
+
+func TestFindPiSessionFileByIDDropsDeletedFileDespiteCache(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	path := filepath.Join(root, "session.jsonl")
+	writePiSessionHeaderFile(t, path, workDir)
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != path {
+		t.Fatalf("FindPiSessionFileByID() = %q, want %q", got, path)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if got := FindPiSessionFileByID([]string{root}, workDir, "sess-1"); got != "" {
+		t.Fatalf("FindPiSessionFileByID() after delete = %q, want empty", got)
+	}
+}

--- a/internal/sessionlog/pi_reader_test.go
+++ b/internal/sessionlog/pi_reader_test.go
@@ -523,3 +523,70 @@ func TestFindPiSessionFileByIDDropsDeletedFileDespiteCache(t *testing.T) {
 		t.Fatalf("FindPiSessionFileByID() after delete = %q, want empty", got)
 	}
 }
+
+func TestPiSessionDirNameMatchesPiEncoding(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/Users/jonesy", "--Users-jonesy--"},
+		{"/Users/jonesy/Developer/gc/.gc/worktrees/sysadmin/polecats/hudson-3", "--Users-jonesy-Developer-gc-.gc-worktrees-sysadmin-polecats-hudson-3--"},
+		{"/private/tmp/claude-501/-Users-jonesy-scratchpad", "--private-tmp-claude-501--Users-jonesy-scratchpad--"},
+		{"/a/b:c", "--a-b-c--"},
+		{`C:\work\repo`, "--C--work-repo--"},
+	} {
+		if got := piSessionDirName(tc.in); got != tc.want {
+			t.Errorf("piSessionDirName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFindPiSessionFileByIDReadsEncodedCwdDirWithoutWalking(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	encoded := filepath.Join(root, piSessionDirName(filepath.Clean(workDir)))
+	if err := os.MkdirAll(encoded, 0o755); err != nil {
+		t.Fatalf("mkdir encoded pi dir: %v", err)
+	}
+	target := filepath.Join(encoded, "2026-01-01T00-00-00-000Z_in-dir.jsonl")
+	decoy := filepath.Join(root, "decoy.jsonl")
+	for _, item := range []struct{ path, id string }{{target, "in-dir"}, {decoy, "walk-only"}} {
+		body := `{"type":"session","version":3,"id":"` + item.id + `","cwd":"` + filepath.ToSlash(workDir) + `"}`
+		if err := os.WriteFile(item.path, []byte(body+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", item.path, err)
+		}
+	}
+
+	if got := FindPiSessionFileByID([]string{root}, workDir, "in-dir"); got != target {
+		t.Fatalf("FindPiSessionFileByID(in-dir) = %q, want %q", got, target)
+	}
+	// The encoded directory exists, so the lookup must not fall back to the
+	// tree walk: a matching transcript outside that directory stays invisible.
+	if got := FindPiSessionFileByID([]string{root}, workDir, "walk-only"); got != "" {
+		t.Fatalf("FindPiSessionFileByID(walk-only) = %q, want empty (no walk when encoded dir exists)", got)
+	}
+}
+
+func TestFindPiSessionCandidatesLegacyWalkSkipsExcludedRoots(t *testing.T) {
+	piRoot := t.TempDir()
+	excludedRoot := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	legacy := filepath.Join(piRoot, "legacy.jsonl")
+	inExcluded := filepath.Join(excludedRoot, "nested", "claude-looking.jsonl")
+	if err := os.MkdirAll(filepath.Dir(inExcluded), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, item := range []struct{ path, id string }{{legacy, "legacy"}, {inExcluded, "excluded"}} {
+		body := `{"type":"session","version":3,"id":"` + item.id + `","cwd":"` + filepath.ToSlash(workDir) + `"}`
+		if err := os.WriteFile(item.path, []byte(body+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", item.path, err)
+		}
+	}
+	prev := piLegacyWalkExcludedRoots
+	piLegacyWalkExcludedRoots = func() []string { return []string{excludedRoot} }
+	t.Cleanup(func() { piLegacyWalkExcludedRoots = prev })
+
+	if got := FindPiSessionFileByID([]string{piRoot, excludedRoot}, workDir, "legacy"); got != legacy {
+		t.Fatalf("FindPiSessionFileByID(legacy) = %q, want %q", got, legacy)
+	}
+	if got := FindPiSessionFileByID([]string{piRoot, excludedRoot}, workDir, "excluded"); got != "" {
+		t.Fatalf("FindPiSessionFileByID(excluded) = %q, want empty (excluded root must not be walked)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #6136. Stacked on #6089 (its commit is the first on this branch; review only `perf(sessionlog): read pi's cwd-encoded session dir…`).

`FindPiSessionFileByID` / `FindPiSessionFile` walked every root in `mergePiSearchPaths` — the pi sessions root **plus** the generic transcript search paths, i.e. `~/.claude/projects` by default — with a `readdir`+`lstat` per `.jsonl`, per pi session row, per `GET /v0/city/{city}/sessions`. On a host with 13k Claude transcripts one pi row cost 0.4–2 s and four rows 8–15 s while Claude rows cost 13 ms; `sample` showed the request goroutine blocked in `filepath.WalkDir → readdir/lstat`. #6089's header cache removes the open+parse but not the walk, and a lookup miss (the common case here) caches nothing.

Pi writes every transcript for a cwd under one deterministic directory — `"--" + cwd` with one leading separator stripped and `[/\\:]` replaced by `-`, `+ "--"` (`getSessionDir` in `@earendil-works/pi-coding-agent`) — so the lookup now `os.ReadDir`s that one directory under each root, applying the same header check as the walk. The legacy tree walk remains only when no root has the encoded directory, and it never descends into `DefaultSearchPaths()` (the Claude projects tree), which cannot hold pi transcripts. `piLegacyWalkExcludedRoots` is a package var so tests can substitute a temp root.

## Testing

- [x] Cluster (linux/amd64, `CGO_ENABLED=0`): `go test ./internal/sessionlog -run Pi` passes on this branch; full `go test ./...` has the same `--- FAIL` set as the base commit on the deployed lineage.
- [x] New tests in `pi_reader_test.go`: encoding table (POSIX, `:`, Windows-style), encoded dir found without walking (a matching decoy outside the dir stays invisible), legacy walk skips excluded roots. Existing flat-layout tests still pass via the legacy walk.
- [x] Dogfooded on a live city (v1.4.0 + backports), same minute, 13 active sessions, 3 runs each, all HTTP 200:
  - 3 claude rows: 0.259/0.021/0.010 s → 0.016/0.016/0.024 s
  - 1 pi row: 0.723/0.407/0.454 s → 0.162/0.007/0.012 s
  - 13-row active page: 0.741/0.326/0.381 s → 0.058/0.094/0.087 s
- [ ] `make check` — not run locally (no Go toolchain on the operator host).
- [ ] `make test-integration` — not run.

## Checklist

- [x] Linked an issue (#6136)
- [x] Added or updated tests for behavior changes
- [ ] Docs: no user-facing surface changes
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQru47R8EJ8UPk4rUvM8Ta
