### PR TITLE
fix(workrecord): resolve the close gate's repository from the bead's owner, not the store it was read through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The work-record close gate asks the repository the bead's OWNER points at,
+  not the store it was read through.** A rig's work step that a relocated class
+  binding holds has its commits on the rig's checkout, and both close doors
+  asked the city's instead — the CLI class door hands its gate the city path,
+  and the HTTP door matched the store that answered against the configured rigs,
+  which a binding is not. With `GC_WORK_RECORD_ENFORCE` on, a compliant
+  `gc.work_outcome=shipped` close of such a bead was refused with "commit is not
+  reachable" against a repository that was never the bead's. Both doors now
+  resolve the repository through one rule (`workrecord.RepoDirFor`): the bead's
+  own `gc.work_dir`, else the scope `gc.root_store_ref` records — a rig owner to
+  that rig's checkout, a city or binding owner to the city's. An owner no
+  checkout is configured for is "unknown" rather than the city, and the
+  reachability clause degrades to a warning there on both doors instead of
+  refusing a close neither can judge; a bead with no outcome at all is still
+  refused. A bead that records no owner keeps the answer its door already gave,
+  so single-store cities are unchanged.
+
 - **The infra-class cutover now carries dependency-edge payloads.** Every
   within-infra edge the copy re-added went in through a writer that clears the
   pair's metadata sidecar, so the binding received those edges with their

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -917,7 +917,17 @@ func maybeRouteBdByID(cityPath, rigName string, bdArgs []string, stdout, stderr 
 	if !served {
 		return refuseUnservedClassMutation(door, bdArgs, named, namesClassBead, mutationIDs, stderr)
 	}
-	return serveBdByIDResolved(door, op, bdArgs, rigName, cityPath, stdout, stderr)
+	return serveBdByIDResolved(door, op, bdArgs, rigName, classDoorRepoDirs(cityPath), stdout, stderr)
+}
+
+// classDoorRepoDirs is the checkout table this door hands its close gate. A
+// binding is a store rather than a checkout, so the city is what a bead the
+// binding merely HOLDS answers to; a bead that names a rig as its owner answers
+// to that rig's checkout instead, which is why the rig table travels with the
+// city path. The table loads the config lazily (cityRigsLoader), so a read this
+// door serves pays for it only when a close actually asks.
+func classDoorRepoDirs(cityPath string) workRecordRepoDirs {
+	return workRecordRepoDirs{cityPath: cityPath, legacy: cityPath, rigs: cityRigsLoader(cityPath)}
 }
 
 // refuseUnservedClassMutation answers a by-ID invocation that addresses a bead
@@ -950,9 +960,9 @@ func refuseUnservedClassMutation(door bdByIDClassDoor, bdArgs []string, named st
 // resolves the id against the class binding, refuses the cases this surface
 // must not serve (a work-store id it does not own, a reserved-prefix id with no
 // row, an explicit --rig work scope), runs the ADR-0009 work-record close gate,
-// and dispatches the verb against the class graph. repoFallback is the git repo
-// the close gate falls back to when a closing bead carries no gc.work_dir.
-func serveBdByIDResolved(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, rigName, repoFallback string, stdout, stderr io.Writer) (int, bool) {
+// and dispatches the verb against the class graph. repoDirs is the checkout
+// table the close gate resolves a closing bead's repository from.
+func serveBdByIDResolved(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, rigName string, repoDirs workRecordRepoDirs, stdout, stderr io.Writer) (int, bool) {
 	resolution, err := door.resolve(op.ID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -983,7 +993,7 @@ func serveBdByIDResolved(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, rig
 		// So neither is taken. See refuseRigScopedClassOwnedTarget.
 		return refuseRigScopedClassOwnedTarget(door, op.ID, rig, stderr)
 	}
-	if gateBdByIDClassClose(door, op, bdArgs, resolution, repoFallback, stderr) {
+	if gateBdByIDClassClose(door, op, bdArgs, resolution, repoDirs, stderr) {
 		return 1, true
 	}
 	switch op.Verb {
@@ -1023,12 +1033,12 @@ func serveBdByIDResolved(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, rig
 // gate reuses it rather than re-reading the class store, and door.Store answers
 // any other id the argv might name. Returns true only when the close must be
 // blocked (enforcement on and the work record invalid).
-func gateBdByIDClassClose(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, resolution bdByIDResolution, repoFallback string, stderr io.Writer) bool {
+func gateBdByIDClassClose(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, resolution bdByIDResolution, repoDirs workRecordRepoDirs, stderr io.Writer) bool {
 	if op.Verb != bdByIDClose && op.Verb != bdByIDUpdate {
 		return false
 	}
 	preFetched := map[string]beads.Bead{op.ID: resolution.Bead}
-	return evaluateWorkRecordCloseGate(bdArgs, door.Store, preFetched, repoFallback, workRecordEnforceEnabled(), stderr)
+	return evaluateWorkRecordCloseGate(bdArgs, door.Store, preFetched, repoDirs, workRecordEnforceEnabled(), stderr)
 }
 
 // refuseRigScopedClassOwnedTarget refuses a by-ID invocation that pins a rig

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -113,6 +113,14 @@ func (d workRecordRepoDirs) CityDir() string { return strings.TrimSpace(d.cityPa
 // RigDir returns the named rig's checkout and whether this city configures that
 // rig at all. A configured rig that names no checkout answers ("", true), which
 // the rule reads as unknown rather than as the city.
+//
+// The name is matched case-insensitively, deliberately more forgiving than the
+// exact-match lookups this answer feeds (workdir.RigRootForName, sling's
+// rigSuspended). Refs are stamped by storeref.RigRef from the configured rig
+// name, so only a hand-stamped or historically-buggy ref differs by case;
+// matching it judges the close against that rig's checkout instead of degrading
+// to unverified. Both doors spell this matcher the same way, so whichever way it
+// resolves, one bead is still judged against one repository.
 func (d workRecordRepoDirs) RigDir(name string) (string, bool) {
 	if d.rigs == nil {
 		return "", false

--- a/cmd/gc/work_record_gate.go
+++ b/cmd/gc/work_record_gate.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
-	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/workrecord"
@@ -17,6 +17,14 @@ import (
 // beads it covers, what a valid record is, whether enforcement is on). The HTTP
 // plane runs the same package against the owner store its residency resolver
 // pins, so a close cannot dodge the contract by changing doors.
+//
+// That sentence covers the reachability clause too, which is the one part of the
+// contract a bead cannot answer alone: workrecord.RepoDirFor names the repository
+// from the bead's OWNER — its gc.work_dir, else the scope gc.root_store_ref
+// records — and both doors run it, so one bead is judged against one repository
+// however it is closed. Each door supplies only its own checkout table
+// (workRecordRepoDirs here, workRecordScopeDirs in internal/api) and its own
+// answer for a bead that names no owner.
 //
 // # Two entry points run this gate: the bd fall-through and the class door
 //
@@ -82,6 +90,82 @@ func validateWorkRecordOnClose(bead beads.Bead, commitReachable func(commit, bra
 // same question.
 func gitCommitReachableOnBranch(repoDir, commit, branch string) bool {
 	return workrecord.CommitReachableOnBranch(repoDir, commit, branch)
+}
+
+// workRecordRepoDirs is the CLI plane's checkout table, plus the answer this
+// door gave before a bead could name its owner.
+//
+// workrecord.RepoDirFor decides WHICH repository a bead answers to, from the
+// bead's own gc.work_dir or its gc.root_store_ref owner; this type only supplies
+// the directories. legacy is the scope the caller READ through — the resolved
+// work scope on the bd fall-through, the city on the class door — and it is
+// still the answer for a bead that records no owner, so a city that never
+// stamped one closes exactly as it did before.
+type workRecordRepoDirs struct {
+	cityPath string
+	legacy   string
+	rigs     func() []config.Rig
+}
+
+// CityDir returns the city checkout's directory.
+func (d workRecordRepoDirs) CityDir() string { return strings.TrimSpace(d.cityPath) }
+
+// RigDir returns the named rig's checkout and whether this city configures that
+// rig at all. A configured rig that names no checkout answers ("", true), which
+// the rule reads as unknown rather than as the city.
+func (d workRecordRepoDirs) RigDir(name string) (string, bool) {
+	if d.rigs == nil {
+		return "", false
+	}
+	for _, rig := range d.rigs() {
+		if !strings.EqualFold(strings.TrimSpace(rig.Name), name) {
+			continue
+		}
+		if strings.TrimSpace(rig.Path) == "" {
+			return "", true
+		}
+		return resolveStoreScopeRoot(d.cityPath, rig.Path), true
+	}
+	return "", false
+}
+
+// repoDirFor names the repository this close is judged against, or "" when the
+// bead's owner names no checkout this city knows.
+func (d workRecordRepoDirs) repoDirFor(bead beads.Bead) string {
+	dir, kind := workrecord.RepoDirFor(bead, d)
+	if kind == workrecord.ScopeUnrooted {
+		return strings.TrimSpace(d.legacy)
+	}
+	return dir
+}
+
+// cityRigsLoader returns a rig table that loads the city config at most once, on
+// first use.
+//
+// The class door is entered from doBd's cost gate, before anything in that
+// invocation has read city.toml, and every read routed through it must stay
+// cheap. The rig table answers one question — where a rig-OWNED bead's commit
+// lives — which only a close of a gated bead asks, so the load is deferred to
+// that point and never paid by a show, a claim, or a dep walk.
+//
+// A config this invocation cannot read yields no rigs, which the rule reads as
+// an unknown owner and degrades on. Failing the close on a read the door does
+// not otherwise need would be a refusal manufactured by the gate.
+func cityRigsLoader(cityPath string) func() []config.Rig {
+	var (
+		once sync.Once
+		rigs []config.Rig
+	)
+	return func() []config.Rig {
+		once.Do(func() {
+			cfg, err := loadCityConfigAdvisory(cityPath)
+			if err != nil || cfg == nil {
+				return
+			}
+			rigs = cfg.Rigs
+		})
+		return rigs
+	}
 }
 
 // workRecordCloseTargets returns the bead IDs a bd invocation closes, and
@@ -170,7 +254,17 @@ func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, cfg *co
 			return false
 		}
 	}
-	return evaluateWorkRecordCloseGate(bdArgs, store, preFetched, scopeRoot, workRecordEnforceEnabled(), stderr)
+	dirs := workRecordRepoDirs{
+		cityPath: cityPath,
+		legacy:   scopeRoot,
+		rigs: func() []config.Rig {
+			if cfg == nil {
+				return nil
+			}
+			return cfg.Rigs
+		},
+	}
+	return evaluateWorkRecordCloseGate(bdArgs, store, preFetched, dirs, workRecordEnforceEnabled(), stderr)
 }
 
 // evaluateWorkRecordCloseGate is the store-driven core of the close gate, split
@@ -178,7 +272,14 @@ func runWorkRecordCloseGate(bdArgs []string, scopeRoot, cityPath string, cfg *co
 // each violation and reports whether the close should be blocked. preFetched
 // (optional) supplies beads already read by an earlier guard in this same
 // invocation, avoiding a duplicate store.Get for the same ID.
-func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched map[string]beads.Bead, scopeRoot string, enforce bool, stderr io.Writer) (block bool) {
+//
+// dirs names the checkouts this city knows, and the reachability clause is asked
+// about the one the closing bead's owner points at. When that is nothing the
+// clause degrades to a warning rather than failing closed: the door cannot pose
+// the question, and refusing a close it could not judge on that basis would
+// block work on a config gap. The sibling clauses do not degrade — an outcome-
+// less bead is refused whether or not a repository was found.
+func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched map[string]beads.Bead, dirs workRecordRepoDirs, enforce bool, stderr io.Writer) (block bool) {
 	ids, ok := workRecordCloseTargets(bdArgs)
 	if !ok {
 		return false
@@ -201,17 +302,25 @@ func evaluateWorkRecordCloseGate(bdArgs []string, store beads.Store, preFetched 
 		}
 		var projectionErr error
 		bead, projectionErr = applyWorkRecordUpdateMetadata(bead, bdArgs)
-		repoDir := strings.TrimSpace(bead.Metadata[beadmeta.WorkDirMetadataKey])
-		if repoDir == "" {
-			repoDir = scopeRoot
-		}
 		var violations []string
 		if projectionErr != nil {
 			violations = []string{projectionErr.Error()}
 		} else {
+			// The repository is resolved from the PROJECTED bead: an atomic
+			// close may stamp the work directory or the owner in the same
+			// invocation that closes.
+			repoDir := dirs.repoDirFor(bead)
+			unverified := false
 			violations = validateWorkRecordOnClose(bead, func(commit, branch string) bool {
+				if repoDir == "" {
+					unverified = true
+					return true
+				}
 				return gitCommitReachableOnBranch(repoDir, commit, branch)
 			})
+			if unverified {
+				fmt.Fprintf(stderr, "gc bd: work-record gate (%s): close of %s: %s\n", mode, id, workrecord.ReachabilityUnverifiedNote) //nolint:errcheck // best-effort stderr
+			}
 		}
 		for _, v := range violations {
 			fmt.Fprintf(stderr, "gc bd: work-record gate (%s): close of %s: %s\n", mode, id, v) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/work_record_gate_owner_test.go
+++ b/cmd/gc/work_record_gate_owner_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// initWorkRecordGateRepo makes dir a git repository holding one commit on main.
+// A row that claims a commit is reachable on one checkout and not on another
+// has to own two real repositories; a stubbed oracle would only prove the stub.
+func initWorkRecordGateRepo(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating the checkout at %s: %v", dir, err)
+	}
+	runGit(t, dir, "init", "--initial-branch=main")
+	runGit(t, dir, "config", "user.name", "Gas City Test")
+	runGit(t, dir, "config", "user.email", "gc-test@test.local")
+	if err := os.WriteFile(filepath.Join(dir, "artifact.txt"), []byte(content+"\n"), 0o644); err != nil {
+		t.Fatalf("writing the artifact in %s: %v", dir, err)
+	}
+	runGit(t, dir, "add", "artifact.txt")
+	runGit(t, dir, "commit", "-m", "test: "+content)
+}
+
+// appendRigCheckout registers a rig with a checkout in an already-written
+// city.toml. The class binding the fixture resolved is city-scope and keyed off
+// [storage] alone, so a rig is orthogonal to it — but the close gate reads the
+// rig table to learn which checkout a rig-owned bead answers to.
+func appendRigCheckout(t *testing.T, cityPath, name, path string) {
+	t.Helper()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	body, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", tomlPath, err)
+	}
+	body = append(body, []byte(fmt.Sprintf("\n[[rigs]]\nname = %s\npath = %s\n",
+		strconv.Quote(name), strconv.Quote(path)))...)
+	if err := os.WriteFile(tomlPath, body, 0o644); err != nil {
+		t.Fatalf("writing %s: %v", tomlPath, err)
+	}
+}
+
+// seedClassResidentWorkRecord plants a work-shaped bead carrying a work record
+// into the class binding only, the way `gc storage migrate` leaves one behind.
+func seedClassResidentWorkRecord(t *testing.T, classStore beads.Store, id string, metadata map[string]string) beads.Bead {
+	t.Helper()
+	created, err := migrationSeed(classStore, beads.Bead{
+		ID:       id,
+		Title:    "a work step the binding holds",
+		Type:     "task",
+		Metadata: beads.StringMap(metadata),
+	})
+	if err != nil {
+		t.Fatalf("seeding %s in the class binding: %v", id, err)
+	}
+	if bdIDIsClassReserved(created.ID) {
+		t.Fatalf("the fixture id %q carries a reserved class prefix; it cannot exercise the residence probe", created.ID)
+	}
+	return created
+}
+
+// TestBdCloseClassResidentAsksTheOwningRigsCheckout is the CLI door's half of
+// the residency rule. The class door hands its gate the CITY checkout for every
+// bead it serves, because a binding is a store rather than a checkout — but a
+// bead whose gc.root_store_ref names a rig was worked in the RIG's checkout, and
+// its commit lives there. Asking the city repository reports a landed commit as
+// unreachable, which under enforcement refuses a close that satisfied the
+// contract.
+//
+// Both checkouts are real repositories and only the rig's holds the commit, so
+// "asked the wrong repository" is distinguishable from "asked no repository".
+func TestBdCloseClassResidentAsksTheOwningRigsCheckout(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	rigRepo := t.TempDir()
+	initWorkRecordGateRepo(t, rigRepo, "rig work")
+	commit := strings.TrimSpace(runGit(t, rigRepo, "rev-parse", "HEAD"))
+	initWorkRecordGateRepo(t, cityPath, "city work")
+	appendRigCheckout(t, cityPath, "r1", rigRepo)
+	// Set enforcement AFTER foreignProviderCity: clearGCEnv wipes live GC_* keys.
+	t.Setenv(workRecordEnforceEnvVar, "1")
+
+	owner := string(storeref.RigRef("r1"))
+	landed := seedClassResidentWorkRecord(t, classStore, "gc-rigowned1", map[string]string{
+		beadmeta.RootStoreRefMetadataKey: owner,
+		beadmeta.WorkOutcomeMetadataKey:  beadmeta.WorkOutcomeShipped,
+		beadmeta.WorkCommitMetadataKey:   commit,
+		beadmeta.WorkBranchMetadataKey:   "main",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", landed.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident close fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("close of a rig-owned bead whose commit is on the rig checkout exited %d: %s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "work-record gate") {
+		t.Errorf("a compliant close tripped the gate: %q", stderr.String())
+	}
+	after, err := classStore.Get(landed.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", landed.ID, err)
+	}
+	if after.Status != "closed" {
+		t.Errorf("the compliant close did not retire the class row; status=%q", after.Status)
+	}
+}
+
+// TestBdCloseClassResidentBlocksACommitNoCheckoutHolds is the control on the row
+// above: resolving the owning rig's checkout is not a license to stop asking.
+// A shipped close whose commit exists in neither repository is still refused.
+func TestBdCloseClassResidentBlocksACommitNoCheckoutHolds(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	rigRepo := t.TempDir()
+	initWorkRecordGateRepo(t, rigRepo, "rig work")
+	initWorkRecordGateRepo(t, cityPath, "city work")
+	appendRigCheckout(t, cityPath, "r1", rigRepo)
+	t.Setenv(workRecordEnforceEnvVar, "1")
+
+	nowhere := seedClassResidentWorkRecord(t, classStore, "gc-rignowhere1", map[string]string{
+		beadmeta.RootStoreRefMetadataKey: string(storeref.RigRef("r1")),
+		beadmeta.WorkOutcomeMetadataKey:  beadmeta.WorkOutcomeShipped,
+		beadmeta.WorkCommitMetadataKey:   "0000000000000000000000000000000000000000",
+		beadmeta.WorkBranchMetadataKey:   "main",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code, handled := maybeRouteBdByID(cityPath, "", []string{"close", nowhere.ID}, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("a class-resident close fell through to the bd subprocess: %q", stderr.String())
+	}
+	if code != 1 {
+		t.Fatalf("close of a commit no checkout holds exited %d, want 1 (blocked): %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not reachable") {
+		t.Errorf("the block does not name the unreachable commit: %q", stderr.String())
+	}
+	after, err := classStore.Get(nowhere.ID)
+	if err != nil {
+		t.Fatalf("re-reading %s: %v", nowhere.ID, err)
+	}
+	if after.Status == "closed" {
+		t.Errorf("the blocked close wrote to the class binding anyway; status=%q", after.Status)
+	}
+}
+
+// TestEvaluateWorkRecordCloseGateDegradesForAnUnknownOwner converges the CLI
+// door on the HTTP door's honest degrade. When the bead names an owner this
+// plane can point at no checkout for, there is no repository to ask: the
+// reachability clause degrades to a warning and says so, rather than failing
+// closed on a question the door cannot pose. The control is the clause that
+// never degrades — a bead with no outcome at all is still refused, because "the
+// commit could not be checked" is not a reason to accept a close that recorded
+// nothing.
+func TestEvaluateWorkRecordCloseGateDegradesForAnUnknownOwner(t *testing.T) {
+	dirs := workRecordRepoDirs{
+		cityPath: "/city",
+		legacy:   "/city",
+		rigs:     func() []config.Rig { return nil },
+	}
+	shipped := map[string]beads.Bead{
+		"wr-ghost-owned": {ID: "wr-ghost-owned", Type: "task", Status: "in_progress", Metadata: beads.StringMap{
+			beadmeta.RootStoreRefMetadataKey: string(storeref.RigRef("ghost")),
+			beadmeta.WorkOutcomeMetadataKey:  beadmeta.WorkOutcomeShipped,
+			beadmeta.WorkCommitMetadataKey:   "0000000000000000000000000000000000000000",
+			beadmeta.WorkBranchMetadataKey:   "main",
+		}},
+	}
+	var stderr strings.Builder
+	if block := evaluateWorkRecordCloseGate([]string{"close", "wr-ghost-owned"}, panicOnGetStore{}, shipped, dirs, true, &stderr); block {
+		t.Fatalf("an unanswerable reachability clause blocked the close: %s", stderr.String())
+	}
+	if out := stderr.String(); !strings.Contains(out, "reachability unverified") {
+		t.Fatalf("gate output %q does not report the degraded clause", out)
+	}
+
+	recordless := map[string]beads.Bead{
+		"wr-ghost-recordless": {ID: "wr-ghost-recordless", Type: "task", Status: "in_progress", Metadata: beads.StringMap{
+			beadmeta.RootStoreRefMetadataKey: string(storeref.RigRef("ghost")),
+		}},
+	}
+	var refusal strings.Builder
+	if block := evaluateWorkRecordCloseGate([]string{"close", "wr-ghost-recordless"}, panicOnGetStore{}, recordless, dirs, true, &refusal); !block {
+		t.Fatalf("an outcome-less close was accepted because the repository was unknown: %s", refusal.String())
+	}
+	if out := refusal.String(); !strings.Contains(out, "missing "+beadmeta.WorkOutcomeMetadataKey) {
+		t.Fatalf("gate output %q does not name the missing outcome", out)
+	}
+}

--- a/cmd/gc/work_record_gate_test.go
+++ b/cmd/gc/work_record_gate_test.go
@@ -321,7 +321,7 @@ func TestEvaluateWorkRecordCloseGate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr strings.Builder
-			block := evaluateWorkRecordCloseGate(tc.args, newStore(), nil, t.TempDir(), tc.enforce, &stderr)
+			block := evaluateWorkRecordCloseGate(tc.args, newStore(), nil, workRecordRepoDirs{legacy: t.TempDir()}, tc.enforce, &stderr)
 			if block != tc.wantBlock {
 				t.Fatalf("block = %v, want %v; stderr=%s", block, tc.wantBlock, stderr.String())
 			}
@@ -368,7 +368,7 @@ func TestEvaluateWorkRecordCloseGateAtomicShippedUpdate(t *testing.T) {
 		"--status=closed",
 	}
 	var stderr strings.Builder
-	if block := evaluateWorkRecordCloseGate(args, store, nil, repoDir, true, &stderr); block {
+	if block := evaluateWorkRecordCloseGate(args, store, nil, workRecordRepoDirs{legacy: repoDir}, true, &stderr); block {
 		t.Fatalf("valid atomic shipped close blocked; stderr=%s", stderr.String())
 	}
 	if got := stderr.String(); got != "" {
@@ -392,7 +392,7 @@ func TestEvaluateWorkRecordCloseGateUsesPreFetchedBead(t *testing.T) {
 		"wr-shipped-nocommit": {ID: "wr-shipped-nocommit", Type: "task", Status: "in_progress", Metadata: map[string]string{beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped}},
 	}
 	var stderr strings.Builder
-	block := evaluateWorkRecordCloseGate([]string{"close", "wr-shipped-nocommit"}, panicOnGetStore{}, preFetched, t.TempDir(), true, &stderr)
+	block := evaluateWorkRecordCloseGate([]string{"close", "wr-shipped-nocommit"}, panicOnGetStore{}, preFetched, workRecordRepoDirs{legacy: t.TempDir()}, true, &stderr)
 	if !block {
 		t.Fatalf("expected block=true for shipped-without-commit, got false; stderr=%s", stderr.String())
 	}

--- a/internal/api/work_record_close_gate.go
+++ b/internal/api/work_record_close_gate.go
@@ -11,12 +11,14 @@ package api
 // whatever still answers.
 //
 // Two things are this plane's own, and neither belongs in the shared package.
-// The first is the repository the reachability clause is asked about: the CLI
-// knows it from the caller's work scope, while here the owning store names it,
-// through the same residency resolution that decides which row the close writes.
-// The second is the refusal, which is the already-registered wrong-state 409 —
-// the state being wrong is precisely that the bead is not closable yet — so
-// gating these routes adds no status to the OpenAPI surface.
+// The first is the CHECKOUT TABLE the repository rule reads — the city
+// directory and the rig paths, which this plane holds in its live State and the
+// CLI holds in the config the invocation loaded. Which repository a given bead
+// answers to is not this plane's own: workrecord.RepoDirFor decides it from the
+// bead's owner, so both doors judge one bead against one repository. The second
+// is the refusal, which is the already-registered wrong-state 409 — the state
+// being wrong is precisely that the bead is not closable yet — so gating these
+// routes adds no status to the OpenAPI surface.
 
 import (
 	"context"
@@ -24,8 +26,8 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/api/apierr"
-	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/workrecord"
 )
 
@@ -95,11 +97,8 @@ func (s *Server) gateWorkRecordClose(ctx context.Context, id string, store beads
 			// The scope that owns this bead names no checkout (see
 			// workRecordRepoDir for which shapes produce that, and why the
 			// current State implementations do not), so there is no repository to
-			// ask. Refusing here would block closes on a question this plane
-			// cannot pose; the clause degrades to a warning and says so. Only this
-			// clause degrades — a bead with no outcome at all is still refused,
-			// because "the commit could not be checked" is not a reason to accept
-			// a close that recorded nothing.
+			// ask. The clause degrades to a warning and says so; see
+			// workrecord.ReachabilityUnverifiedNote for why only this one does.
 			unverified = true
 			return true
 		}
@@ -112,7 +111,7 @@ func (s *Server) gateWorkRecordClose(ctx context.Context, id string, store beads
 		mode = "enforced"
 	}
 	if unverified {
-		workRecordGateLogf("work-record gate (%s): close of %s: reachability unverified: the scope that holds this bead names no checkout", mode, id)
+		workRecordGateLogf("work-record gate (%s): close of %s: %s", mode, id, workrecord.ReachabilityUnverifiedNote)
 	}
 	for _, violation := range violations {
 		workRecordGateLogf("work-record gate (%s): close of %s: %s", mode, id, violation)
@@ -148,56 +147,99 @@ func projectSubmittedWorkRecord(stored beads.Bead, submitted map[string]string) 
 	return stored
 }
 
+// workRecordScopeDirs is this plane's checkout table: the city directory the
+// server was constructed with, and the rig paths the live config declares. A rig
+// path may be written relative to the city, so it is resolved the same way every
+// other scope root on this plane is.
+type workRecordScopeDirs struct {
+	cityPath string
+	rigs     []config.Rig
+}
+
+// CityDir returns the city checkout's directory.
+func (d workRecordScopeDirs) CityDir() string { return strings.TrimSpace(d.cityPath) }
+
+// RigDir returns the named rig's checkout and whether the config declares that
+// rig at all. A declared rig that names no checkout answers ("", true), which
+// the rule reads as unknown rather than as the city.
+func (d workRecordScopeDirs) RigDir(name string) (string, bool) {
+	for _, rig := range d.rigs {
+		if !strings.EqualFold(strings.TrimSpace(rig.Name), name) {
+			continue
+		}
+		if strings.TrimSpace(rig.Path) == "" {
+			return "", true
+		}
+		return resolveScopeRoot(d.cityPath, rig.Path), true
+	}
+	return "", false
+}
+
+// workRecordScopeDirs builds the checkout table from the server's live State.
+func (s *Server) workRecordScopeDirs() workRecordScopeDirs {
+	dirs := workRecordScopeDirs{cityPath: s.state.CityPath()}
+	if cfg := s.state.Config(); cfg != nil {
+		dirs.rigs = cfg.Rigs
+	}
+	return dirs
+}
+
 // workRecordRepoDir names the repository a shipped bead's commit must be
-// reachable in: the bead's own gc.work_dir if it recorded one, else the checkout
-// of whichever scope holds it — the rig's path for a rig-resident bead, the city
-// directory for a city-resident one and for one a relocated class binding owns.
-//
-// A binding is a store rather than a checkout, but that does not make its beads
-// unaskable: the city it lives under is a checkout, and it is the same directory
-// the CLI class door hands its own gate (serveBdByIDResolved passes cityPath as
-// the repoFallback that reaches evaluateWorkRecordCloseGate). Naming it here is
-// what keeps a binding-owned bead answering to one repository through both
-// doors, which is the whole point of gating this plane.
+// reachable in. The rule is workrecord.RepoDirFor's — gc.work_dir, else the
+// bead's OWNER — so this door and the CLI's judge one bead against one
+// repository; all this plane supplies is the checkout table and, for a bead that
+// names no owner, the answer it gave before owners were recorded.
 //
 // An empty result means "unknown" and must stay distinguishable from a path,
 // because falling back to a default would run git in whatever directory the
 // server happens to occupy and answer the reachability question about the wrong
-// repository. Two shapes produce it: a configured rig that names no checkout,
-// and a city that has no path at all. Both are defensive against a State
-// implementation the current ones do not produce. buildStores skips a rig with
-// an empty path outright, so BeadStore answers nil for one and the identity
-// match below — against a store a residency resolution handed back — never
-// selects it; and cityPath is set once at construction from an already-resolved
-// directory and never reassigned, so an empty one is not a state a city boots
-// into. State is an interface and the branches are cheap, so they stay — but
-// they are a contract for a future implementation, not a description of a
-// population this server observes. A refactor that changes either of those two
-// facts is what makes them live, and should update this note rather than find it
-// silently wrong. The path-less rig returns rather than continuing on purpose:
-// letting it fall through to the city checkout would ask about a repository that
-// is not the bead's, and under enforcement that is a false refusal rather than a
-// degraded clause.
+// repository.
+func (s *Server) workRecordRepoDir(store beads.Store, bead beads.Bead) string {
+	dirs := s.workRecordScopeDirs()
+	dir, kind := workrecord.RepoDirFor(bead, dirs)
+	if kind == workrecord.ScopeUnrooted {
+		return s.workRecordLegacyRepoDir(store, dirs)
+	}
+	return dir
+}
+
+// workRecordLegacyRepoDir is the answer this plane gave before a bead could name
+// its owner: the checkout of the scope the row was READ through — the rig's path
+// when a configured rig's store answered, the city directory otherwise. It stays
+// for the beads that record no gc.root_store_ref, which is every city that
+// predates the residency census, so their closes are unchanged.
 //
 // The store is matched by asking each CONFIGURED rig whether it is the one that
 // answered, rather than by enumerating the loaded stores: an enumeration is a
 // list of work stores, which is blind to a binding by construction, and the
-// question here is not "which stores exist" but "does the resolved owner have a
-// checkout to name".
-func (s *Server) workRecordRepoDir(store beads.Store, bead beads.Bead) string {
-	if dir := strings.TrimSpace(bead.Metadata[beadmeta.WorkDirMetadataKey]); dir != "" {
-		return dir
-	}
-	if cfg := s.state.Config(); cfg != nil {
-		for _, rig := range cfg.Rigs {
-			if s.state.BeadStore(rig.Name) != store {
-				continue
-			}
-			if strings.TrimSpace(rig.Path) == "" {
-				return ""
-			}
-			return resolveScopeRoot(s.state.CityPath(), rig.Path)
+// question is not "which stores exist" but "does the store that answered belong
+// to a rig with a checkout".
+//
+// A store no configured rig claims is the city store or a class binding, and
+// both answered to the city checkout before this rule existed. buildStores keys
+// only from cfg.Rigs and swaps the config and the store map under one lock, so
+// there is no third population to mistake for one.
+//
+// Two shapes still produce "unknown" here: a configured rig that names no
+// checkout, and a city with no path at all. Both are defensive against a State
+// implementation the current ones do not produce — buildStores skips a rig with
+// an empty path outright, so BeadStore answers nil for one and the identity
+// match never selects it, and cityPath is set once at construction from an
+// already-resolved directory and never reassigned. State is an interface and the
+// branches are cheap, so they stay; a refactor that changes either fact should
+// update this note rather than find it silently wrong.
+func (s *Server) workRecordLegacyRepoDir(store beads.Store, dirs workRecordScopeDirs) string {
+	for _, rig := range dirs.rigs {
+		if s.state.BeadStore(rig.Name) != store {
+			continue
 		}
+		// The path comes off the rig that MATCHED, not from a second lookup by
+		// name: the match here is store identity, and re-deriving it from a name
+		// would answer for whichever rig the name resolves to instead.
+		if strings.TrimSpace(rig.Path) == "" {
+			return ""
+		}
+		return resolveScopeRoot(dirs.cityPath, rig.Path)
 	}
-	return strings.TrimSpace(s.state.CityPath())
+	return dirs.CityDir()
 }

--- a/internal/api/work_record_close_gate.go
+++ b/internal/api/work_record_close_gate.go
@@ -162,6 +162,14 @@ func (d workRecordScopeDirs) CityDir() string { return strings.TrimSpace(d.cityP
 // RigDir returns the named rig's checkout and whether the config declares that
 // rig at all. A declared rig that names no checkout answers ("", true), which
 // the rule reads as unknown rather than as the city.
+//
+// The name is matched case-insensitively, deliberately more forgiving than the
+// exact-match lookups this answer feeds (workdir.RigRootForName, sling's
+// rigSuspended). Refs are stamped by storeref.RigRef from the configured rig
+// name, so only a hand-stamped or historically-buggy ref differs by case;
+// matching it judges the close against that rig's checkout instead of degrading
+// to unverified. Both doors spell this matcher the same way, so whichever way it
+// resolves, one bead is still judged against one repository.
 func (d workRecordScopeDirs) RigDir(name string) (string, bool) {
 	for _, rig := range d.rigs {
 		if !strings.EqualFold(strings.TrimSpace(rig.Name), name) {
@@ -219,6 +227,15 @@ func (s *Server) workRecordRepoDir(store beads.Store, bead beads.Bead) string {
 // both answered to the city checkout before this rule existed. buildStores keys
 // only from cfg.Rigs and swaps the config and the store map under one lock, so
 // there is no third population to mistake for one.
+//
+// The converse population is real and this answer is a guess for it: in legacy
+// shared-file mode buildStores aliases every rig backed by that store to one
+// handle, so MANY rigs claim it and the identity match selects whichever is
+// configured first — an ownerless bead whose work happened on a different rig
+// is judged against that first rig's checkout. The loop predates this rule and
+// RepoDirFor strictly narrows it, since a bead that names an owner no longer
+// reaches here; what is left is the pre-census population, where no answer is
+// better than a guess because the bead records nothing to resolve.
 //
 // Two shapes still produce "unknown" here: a configured rig that names no
 // checkout, and a city with no path at all. Both are defensive against a State

--- a/internal/api/work_record_close_gate_owner_test.go
+++ b/internal/api/work_record_close_gate_owner_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/storeref"
+	"github.com/gastownhall/gascity/internal/workrecord"
+)
+
+// initGateRepo makes dir a git repository holding exactly one commit on main.
+// The gate's reachability clause is a real git question, so a row claiming a
+// commit is reachable on one checkout and not on another has to own two real
+// repositories; a stubbed oracle would only prove the stub.
+func initGateRepo(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating the checkout at %s: %v", dir, err)
+	}
+	runResolverGit(t, dir, "init", "--initial-branch=main")
+	runResolverGit(t, dir, "config", "user.name", "Gas City Test")
+	runResolverGit(t, dir, "config", "user.email", "gc-test@test.local")
+	if err := os.WriteFile(filepath.Join(dir, "artifact.txt"), []byte(content+"\n"), 0o644); err != nil {
+		t.Fatalf("writing the artifact in %s: %v", dir, err)
+	}
+	runResolverGit(t, dir, "add", "artifact.txt")
+	runResolverGit(t, dir, "commit", "-m", "test: "+content)
+}
+
+// gateRepoHead reads the commit main points at out of the ref file rather than
+// through another git process. This package's test-resource census pins its
+// subprocess count, and a repository just initialized with one commit always
+// writes main as a loose ref, so the file is the cheaper truth.
+func gateRepoHead(t *testing.T, dir string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, ".git", "refs", "heads", "main"))
+	if err != nil {
+		t.Fatalf("reading main in %s: %v", dir, err)
+	}
+	commit := strings.TrimSpace(string(raw))
+	if len(commit) != 40 {
+		t.Fatalf("main in %s resolved to %q, which is not a commit SHA", dir, commit)
+	}
+	return commit
+}
+
+// TestAPIBeadCloseAsksTheOwningRigsCheckoutForABindingResidentBead is the
+// residency half of the gate. The store a row is served FROM says where it
+// lives; gc.root_store_ref says who OWNS it. A rig-owned work step that a
+// relocated class binding holds has its commits on the RIG's checkout, so
+// asking the city repository — which the store-identity resolution did, because
+// no configured rig claims the binding — reports a landed commit as unreachable
+// and refuses the close under enforcement.
+//
+// The city checkout here is a REAL repository that simply does not hold the
+// commit. That is the control separating "asked the wrong repository" from
+// "asked no repository at all": both answer not-reachable, and only the first
+// is this bug.
+func TestAPIBeadCloseAsksTheOwningRigsCheckoutForABindingResidentBead(t *testing.T) {
+	st, binding, _, _ := relocatedGraphRouteState(t)
+	rigRepo := st.cfg.Rigs[0].Path
+	initGateRepo(t, rigRepo, "rig work")
+	initGateRepo(t, st.cityPath, "city work")
+	commit := gateRepoHead(t, rigRepo)
+
+	prefix, ok := config.ReservedClassPrefix(config.BeadClassGraph)
+	if !ok {
+		t.Fatalf("ReservedClassPrefix(graph) returned ok=false; expected a reserved prefix")
+	}
+	owner := string(storeref.RigRef(st.cfg.Rigs[0].Name))
+	landed := seedGateBead(t, binding, prefix+"-owned", map[string]string{
+		beadmeta.RootStoreRefMetadataKey: owner,
+		beadmeta.WorkOutcomeMetadataKey:  beadmeta.WorkOutcomeShipped,
+		beadmeta.WorkCommitMetadataKey:   commit,
+		beadmeta.WorkBranchMetadataKey:   "main",
+	})
+	nowhere := seedGateBead(t, binding, prefix+"-nowhere", map[string]string{
+		beadmeta.RootStoreRefMetadataKey: owner,
+		beadmeta.WorkOutcomeMetadataKey:  beadmeta.WorkOutcomeShipped,
+		beadmeta.WorkCommitMetadataKey:   "0000000000000000000000000000000000000000",
+		beadmeta.WorkBranchMetadataKey:   "main",
+	})
+
+	t.Setenv(workrecord.EnforceEnvVar, "1")
+	logged := captureWorkRecordGateLog(t)
+	s := New(st)
+
+	if _, err := s.humaHandleBeadClose(context.Background(), &BeadCloseInput{ID: landed}); err != nil {
+		t.Fatalf("close of a rig-owned bead whose commit is on the rig checkout: %v (gate log: %s)", err, logged.String())
+	}
+	if out := logged.String(); strings.Contains(out, "reachability unverified") {
+		t.Fatalf("gate output %q degraded a clause the rig checkout can answer", out)
+	}
+	closed, err := binding.Get(landed)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", landed, err)
+	}
+	if closed.Status != "closed" {
+		t.Fatalf("status = %q, want closed", closed.Status)
+	}
+
+	// The control: the same owner, a commit no checkout holds. Resolving the
+	// repository correctly is not a license to stop asking.
+	_, err = s.humaHandleBeadClose(context.Background(), &BeadCloseInput{ID: nowhere})
+	assertConflict(t, err, "not reachable")
+}

--- a/internal/workrecord/repo_dir.go
+++ b/internal/workrecord/repo_dir.go
@@ -41,6 +41,15 @@ const ReachabilityUnverifiedNote = "reachability unverified: the scope that owns
 // rig's. It is an interface because the two doors reach the same city config by
 // different routes — the HTTP plane through the server's live State, the CLI
 // through the config the invocation loaded — and neither route belongs here.
+//
+// A returned directory is for handing to git, not for comparing as a string.
+// Each implementation resolves paths through its own plane's scope resolver, and
+// those disagree on spelling — one canonicalizes symlinks, the other is purely
+// lexical — so a city reached through a linked path names the same repository
+// two ways. git answers reachability identically through either, which is why
+// this rule can consume both; a consumer that instead compares, dedupes, or
+// diffs these strings across planes would first have to route both tables
+// through one canonicalizing resolver.
 type ScopeDirs interface {
 	// CityDir returns the city checkout's directory, or "" when the plane can
 	// name none.

--- a/internal/workrecord/repo_dir.go
+++ b/internal/workrecord/repo_dir.go
@@ -1,0 +1,119 @@
+package workrecord
+
+// Which repository a close is judged against.
+//
+// The contract's reachability clause — a shipped outcome must name a commit
+// reachable on the stamped branch — cannot be answered from the bead alone: it
+// needs a checkout to ask git about. Every close door has to pick the same one,
+// or the same bead passes through one door and is refused at another.
+//
+// The pick is a residency question, and the residency doctrine answers it: the
+// store a row is SERVED from says where it lives, and gc.root_store_ref says who
+// OWNS it. Those diverge for the population a relocated class binding holds —
+// a rig's work step whose commits are on the rig's checkout, living in a
+// city-scope binding — so resolving the repository from the store that answered
+// the read asks the city about a rig's commit and calls a landed commit
+// unreachable. Under enforcement that is a false refusal of a close that
+// satisfied the contract.
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// ReachabilityUnverifiedNote is what a door reports when it cannot pose the
+// reachability question at all: the bead names an owning scope, and the plane
+// can point at no checkout for it. Refusing there would block a close on a
+// question the door cannot ask, so the clause degrades to this warning — and
+// only this clause degrades. A bead with no outcome at all is still refused,
+// because "the commit could not be checked" is not a reason to accept a close
+// that recorded nothing.
+//
+// It is a constant so both doors report the same degradation in the same words;
+// a reader comparing two logs should not have to decide whether two sentences
+// describe one condition.
+const ReachabilityUnverifiedNote = "reachability unverified: the scope that owns this bead names no checkout"
+
+// ScopeDirs is the checkout table a plane knows: the city's directory, and each
+// rig's. It is an interface because the two doors reach the same city config by
+// different routes — the HTTP plane through the server's live State, the CLI
+// through the config the invocation loaded — and neither route belongs here.
+type ScopeDirs interface {
+	// CityDir returns the city checkout's directory, or "" when the plane can
+	// name none.
+	CityDir() string
+	// RigDir returns the checkout directory of the named rig, and whether the
+	// plane configures that rig at all. A configured rig that names no
+	// checkout answers ("", true); an unknown rig answers ("", false). Both
+	// resolve to "unknown" — the distinction is kept because the two are
+	// different operator-facing facts, not because the rule branches on it.
+	RigDir(name string) (string, bool)
+}
+
+// ScopeKind says which arm of the rule answered, which is what lets a caller
+// tell an empty result that means "unknown" from one that means "your turn".
+type ScopeKind string
+
+const (
+	// ScopeWorkDir means the bead recorded its own gc.work_dir.
+	ScopeWorkDir ScopeKind = "work_dir"
+	// ScopeRig means the bead's owner is a rig, and the plane named its
+	// checkout.
+	ScopeRig ScopeKind = "rig"
+	// ScopeCity means the bead's owner is city scope — the city store or a
+	// relocated class binding, which serves the whole city and belongs to no
+	// rig — and the plane named the city checkout.
+	ScopeCity ScopeKind = "city"
+	// ScopeUnknown means the bead names an owner the plane can point at no
+	// checkout for. There is no repository to ask, so the reachability clause
+	// degrades (see ReachabilityUnverifiedNote). It must never be answered
+	// with a default directory: git run in whatever directory the process
+	// occupies answers about the wrong repository.
+	ScopeUnknown ScopeKind = "unknown"
+	// ScopeUnrooted means the bead records no owner at all, so the caller's own
+	// legacy answer stands — the scope it read the row through. Every city that
+	// predates the residency census is in this population, and each door's
+	// answer for it is unchanged.
+	ScopeUnrooted ScopeKind = "unrooted"
+)
+
+// RepoDirFor names the repository a shipped bead's commit must be reachable in,
+// and reports which arm of the rule answered.
+//
+// In order: the bead's own gc.work_dir, because the commit was made where the
+// work happened; then its OWNER, read from gc.root_store_ref — a rig-owned bead
+// answers to that rig's checkout, a city-owned or binding-owned one to the city
+// checkout. An owner the plane can point at no checkout for is ScopeUnknown and
+// never the city: falling back there would ask about a repository that is not
+// the bead's, which under enforcement is a false refusal rather than a degraded
+// clause. A bead that records no owner is ScopeUnrooted, and the caller applies
+// the answer it gave before this rule existed.
+//
+// scopes may be nil; a caller that knows no checkouts learns nothing about the
+// bead's owner, which is ScopeUnknown rather than a panic on a close path.
+func RepoDirFor(bead beads.Bead, scopes ScopeDirs) (string, ScopeKind) {
+	if dir := strings.TrimSpace(bead.Metadata[beadmeta.WorkDirMetadataKey]); dir != "" {
+		return dir, ScopeWorkDir
+	}
+	rig, scoped := storeref.ScopeRigContext(bead.Metadata[beadmeta.RootStoreRefMetadataKey])
+	if !scoped {
+		return "", ScopeUnrooted
+	}
+	if scopes == nil {
+		return "", ScopeUnknown
+	}
+	if rig == "" {
+		if dir := strings.TrimSpace(scopes.CityDir()); dir != "" {
+			return dir, ScopeCity
+		}
+		return "", ScopeUnknown
+	}
+	dir, configured := scopes.RigDir(rig)
+	if dir = strings.TrimSpace(dir); !configured || dir == "" {
+		return "", ScopeUnknown
+	}
+	return dir, ScopeRig
+}

--- a/internal/workrecord/repo_dir_test.go
+++ b/internal/workrecord/repo_dir_test.go
@@ -1,0 +1,167 @@
+package workrecord
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// fixedScopeDirs is a plane's checkout table, spelled out. The real
+// implementations read a loaded city config; what the rule needs from them is
+// only "the city directory" and "this rig's directory, if the plane configures
+// that rig at all".
+type fixedScopeDirs struct {
+	city string
+	rigs map[string]string
+}
+
+func (d fixedScopeDirs) CityDir() string { return d.city }
+
+func (d fixedScopeDirs) RigDir(name string) (string, bool) {
+	dir, ok := d.rigs[name]
+	return dir, ok
+}
+
+// TestRepoDirFor is the shared rule both close doors run. It answers the one
+// question the work-record contract cannot answer from the bead's outcome
+// alone — "reachable on WHICH repository?" — from the bead's OWNER
+// (gc.root_store_ref), not from the store the row happened to be read through.
+//
+// The distinction is the residency doctrine: a relocated class binding is where
+// a row LIVES, and gc.root_store_ref is who OWNS it. A rig-owned bead resident
+// in the city's binding has its commits on the RIG's checkout, so asking the
+// city repo returns "not reachable" — a false refusal under enforcement.
+func TestRepoDirFor(t *testing.T) {
+	scopes := fixedScopeDirs{
+		city: "/city",
+		rigs: map[string]string{
+			"frontend": "/city/rigs/frontend",
+			"pathless": "",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		scopes   ScopeDirs
+		metadata map[string]string
+		wantDir  string
+		wantKind ScopeKind
+	}{
+		{
+			name: "a recorded work dir outranks the owning scope",
+			metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:      "/work/elsewhere",
+				beadmeta.RootStoreRefMetadataKey: "rig:frontend",
+				beadmeta.WorkOutcomeMetadataKey:  beadmeta.WorkOutcomeShipped,
+				beadmeta.WorkBranchMetadataKey:   "main",
+			},
+			wantDir:  "/work/elsewhere",
+			wantKind: ScopeWorkDir,
+		},
+		{
+			name:     "a rig-owned bead answers to the rig checkout",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "rig:frontend"},
+			wantDir:  "/city/rigs/frontend",
+			wantKind: ScopeRig,
+		},
+		{
+			name:     "a city-owned bead answers to the city checkout",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "city:test-city"},
+			wantDir:  "/city",
+			wantKind: ScopeCity,
+		},
+		{
+			// A binding is city scope: it serves the whole city's relocated
+			// classes and belongs to no rig, so a bead whose OWNER is the
+			// binding answers exactly as a city-owned one does.
+			name:     "a binding-owned bead is city scope",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "class:gmnos"},
+			wantDir:  "/city",
+			wantKind: ScopeCity,
+		},
+		{
+			// Never the city. Falling back would ask about a repository that is
+			// not the bead's, and under enforcement that is a false refusal
+			// rather than a degraded clause.
+			name:     "a rig this plane does not configure is unknown, not the city",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "rig:ghost"},
+			wantDir:  "",
+			wantKind: ScopeUnknown,
+		},
+		{
+			name:     "a configured rig that names no checkout is unknown, not the city",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "rig:pathless"},
+			wantDir:  "",
+			wantKind: ScopeUnknown,
+		},
+		{
+			name:     "a city-owned bead in a plane with no city checkout is unknown",
+			scopes:   fixedScopeDirs{},
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "city:test-city"},
+			wantDir:  "",
+			wantKind: ScopeUnknown,
+		},
+		{
+			// The compatibility arm. A city that never stamped a root ref —
+			// every single-store city before the residency census — keeps the
+			// answer its door already gave, byte for byte.
+			name:     "a bead with no owner leaves the answer to the caller",
+			metadata: map[string]string{beadmeta.WorkOutcomeMetadataKey: beadmeta.WorkOutcomeShipped},
+			wantDir:  "",
+			wantKind: ScopeUnrooted,
+		},
+		{
+			name:     "a legacy bare label is not an owner",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "frontend"},
+			wantDir:  "",
+			wantKind: ScopeUnrooted,
+		},
+		{
+			name:     "a rig ref with no rig name is not an owner",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "rig:"},
+			wantDir:  "",
+			wantKind: ScopeUnrooted,
+		},
+		{
+			name:     "surrounding whitespace does not hide the owner",
+			metadata: map[string]string{beadmeta.RootStoreRefMetadataKey: "  rig:frontend  "},
+			wantDir:  "/city/rigs/frontend",
+			wantKind: ScopeRig,
+		},
+		{
+			name:     "a bead with no metadata at all leaves the answer to the caller",
+			wantDir:  "",
+			wantKind: ScopeUnrooted,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dirs := tc.scopes
+			if dirs == nil {
+				dirs = scopes
+			}
+			bead := beads.Bead{Type: "task", Metadata: beads.StringMap(tc.metadata)}
+			gotDir, gotKind := RepoDirFor(bead, dirs)
+			if gotDir != tc.wantDir || gotKind != tc.wantKind {
+				t.Fatalf("RepoDirFor = (%q, %s), want (%q, %s)", gotDir, gotKind, tc.wantDir, tc.wantKind)
+			}
+		})
+	}
+}
+
+// TestRepoDirForWithoutScopeDirs pins the defensive arm: a caller that hands no
+// checkout table at all gets "unknown" rather than a panic. The rule runs on
+// both close doors, and a nil table is a caller bug that must not take the
+// close down with it.
+func TestRepoDirForWithoutScopeDirs(t *testing.T) {
+	rooted := beads.Bead{Type: "task", Metadata: beads.StringMap{beadmeta.RootStoreRefMetadataKey: "rig:frontend"}}
+	if dir, kind := RepoDirFor(rooted, nil); dir != "" || kind != ScopeUnknown {
+		t.Fatalf("RepoDirFor(rig-owned, nil) = (%q, %s), want (\"\", %s)", dir, kind, ScopeUnknown)
+	}
+	recorded := beads.Bead{Type: "task", Metadata: beads.StringMap{beadmeta.WorkDirMetadataKey: "/work/here"}}
+	if dir, kind := RepoDirFor(recorded, nil); dir != "/work/here" || kind != ScopeWorkDir {
+		t.Fatalf("RepoDirFor(work_dir, nil) = (%q, %s), want (\"/work/here\", %s)", dir, kind, ScopeWorkDir)
+	}
+}


### PR DESCRIPTION
## The bug

The ADR-0009 work-record close gate's reachability clause — a `shipped` outcome
must name a commit reachable on the stamped branch — is the one clause that
cannot be answered from the bead alone. It needs a checkout to ask git about,
and both close doors picked that checkout from where the row was **read**.

For one population those are different repositories: a rig's work step that a
relocated class binding holds. Its commits are on the **rig's** checkout, and
both doors asked the **city's**:

- CLI class door: `serveBdByIDResolved` hands `evaluateWorkRecordCloseGate` the
  `cityPath` as its `repoFallback`.
- HTTP door: `workRecordRepoDir` matched the store that answered against the
  configured rigs, and a binding is not one, so `a496031ba0`'s unconditional
  city fallback caught it.

With `GC_WORK_RECORD_ENFORCE` on, a compliant `gc.work_outcome=shipped` close of
such a bead was refused with `gc.work_commit … is not reachable on
gc.work_branch main` — against a repository that was never the bead's. That
population is not exotic: a task-typed molecule step carrying `gc.root_bead_id`
and no `gc.kind` is exactly `workrecord.Gated`'s population, and commonly
records no `gc.work_dir`.

## Mechanism

The residency doctrine already separates the two facts: the store a row is
served from says where it **lives**; `gc.root_store_ref` says who **owns** it.

`workrecord.RepoDirFor(bead, ScopeDirs) (string, ScopeKind)` is that rule, and
both doors run it:

| arm | answer | kind |
| --- | --- | --- |
| `gc.work_dir` set | that directory | `ScopeWorkDir` |
| owner is `rig:<name>` | that rig's checkout | `ScopeRig` |
| owner is `city:<name>` or `class:<token>` (a binding is city scope) | the city checkout | `ScopeCity` |
| owner named, no checkout configured for it | `""` | `ScopeUnknown` |
| no owner recorded | `""` | `ScopeUnrooted` — the caller's legacy answer stands |

An owner no checkout is configured for is **unknown, never the city**: falling
back there asks about a repository that is not the bead's, which under
enforcement is a false refusal rather than a degraded clause.

`ScopeUnrooted` is what keeps single-store cities byte-identical. Every city
that predates the residency census is in that population, so each door keeps the
answer it already gave — which is why `internal/api`'s store-identity match
**stays** (as `workRecordLegacyRepoDir`) rather than being deleted: it is that
plane's legacy answer, and deleting it would send a rig-resident bead with no
root ref to the city checkout. Each plane supplies only its own checkout table
(`workRecordScopeDirs` in `internal/api`, `workRecordRepoDirs` in `cmd/gc`).

### Degrade semantics, converged

`#5600` gave the HTTP door an honest degrade: an unknown repository warns
`reachability unverified` and the close proceeds, while a bead with no outcome
at all is still refused. The CLI door failed **closed** on the same condition —
`CommitReachableOnBranch` reads `""` as "not reachable" — so it now takes the
same degrade. Both doors print the same sentence, single-sourced as
`workrecord.ReachabilityUnverifiedNote`.

### Two implementation notes

- **`internal/workrecord` imports `internal/storeref`** for the
  `ScopeRigContext` parse. There is no cycle — nothing in `storeref`'s
  dependency closure imports `workrecord` (`go list -deps ./internal/storeref |
  grep workrecord` is empty) — so the ref vocabulary keeps one reader instead of
  a copy per plane. The func-parameter fallback was therefore not needed.
- **The class door loads the rig table lazily** (`cityRigsLoader`, a
  `sync.Once`). `maybeRouteBdByID` is entered from `doBd`'s cost gate before
  that invocation has read `city.toml`, and the rig table answers one question
  only a close of a gated bead asks — a show, a claim or a dep walk still pays
  nothing. A config this invocation cannot read yields no rigs, which degrades
  rather than manufacturing a refusal. Keeping `maybeRouteBdByID`'s signature
  also means the door rows below exercise the **real** config path a production
  close takes, rather than a `*config.City` a test handed in.

This **supersedes the store-identity fallback `a496031ba0` added**: that commit
made a binding-owned bead answer to the city, which is right for a
binding-**owned** bead and wrong for a rig-owned one the binding merely holds.

## RED → GREEN

Tests were written first. Every row below was observed failing against
`origin/main` + the tests, then passing with the fix.

| row | RED (before) | GREEN (after) |
| --- | --- | --- |
| `internal/workrecord` `TestRepoDirFor` (12 rows: work_dir wins; rig owner → rig dir; city owner → city dir; binding owner → city dir; unconfigured rig → unknown; path-less rig → unknown; city owner with no city dir → unknown; no owner → unrooted; bare legacy label → unrooted; `rig:` → unrooted; whitespace; no metadata) | build failure: `undefined: ScopeDirs / ScopeKind / RepoDirFor` | `ok` |
| `internal/workrecord` `TestRepoDirForWithoutScopeDirs` (nil table does not panic) | same build failure | `ok` |
| **API door** `TestAPIBeadCloseAsksTheOwningRigsCheckoutForABindingResidentBead` — binding-resident, `rig:myrig`-owned, `shipped`, commit on the rig checkout only, `GC_WORK_RECORD_ENFORCE=1` | `FAIL … conflict: bead gcg-owned does not satisfy the work-record close contract: gc.work_commit 1a7273a1… is not reachable on gc.work_branch main` | `PASS` (closes; no `reachability unverified` in the gate log) |
| **API door**, same bead with a commit no checkout holds | (already refused) | `PASS` — still a 409 `not reachable` |
| **CLI door** `TestBdCloseClassResidentAsksTheOwningRigsCheckout` — same shape through `maybeRouteBdByID` | `FAIL … exited 1: gc bd: work-record gate (enforced): close of gc-rigowned1: gc.work_commit 5c6d6f37… is not reachable on gc.work_branch main` | `PASS` (exit 0, class row closed, gate silent) |
| **CLI door** `TestBdCloseClassResidentBlocksACommitNoCheckoutHolds` | (already refused) | `PASS` — still exit 1 with `not reachable` |
| **CLI door** `TestEvaluateWorkRecordCloseGateDegradesForAnUnknownOwner` — unknown owner warns `reachability unverified` and proceeds; the outcome-less control is still refused | fails: the CLI door had no degrade and blocked on `""` | `PASS` |

Both door rows own **two real git repositories** — the rig's holds the commit,
the city's is a real repository that does not. That is the control separating
"asked the wrong repository" from "asked no repository at all": both answer
not-reachable, and only the first is this bug. Neither row adds an `os/exec`
construction (they reuse `runResolverGit` / `runGit`, and read the commit SHA
from the loose `main` ref), so the test-resource census is unmoved.

## The pins bite (mutation)

Dropping the root-ref arm from `RepoDirFor` on disk — `return "", ScopeUnrooted`
unconditionally after the `gc.work_dir` arm, so every bead falls back to the
caller's legacy answer — and re-running:

```
--- FAIL: TestRepoDirFor/a_rig-owned_bead_answers_to_the_rig_checkout
--- FAIL: TestRepoDirFor/a_city-owned_bead_answers_to_the_city_checkout
--- FAIL: TestRepoDirFor/a_binding-owned_bead_is_city_scope
--- FAIL: TestRepoDirFor/a_rig_this_plane_does_not_configure_is_unknown,_not_the_city
--- FAIL: TestRepoDirFor/a_configured_rig_that_names_no_checkout_is_unknown,_not_the_city
--- FAIL: TestRepoDirFor/a_city-owned_bead_in_a_plane_with_no_city_checkout_is_unknown
--- FAIL: TestRepoDirFor/surrounding_whitespace_does_not_hide_the_owner
--- FAIL: TestRepoDirForWithoutScopeDirs

--- FAIL: TestAPIBeadCloseAsksTheOwningRigsCheckoutForABindingResidentBead
    close of a rig-owned bead whose commit is on the rig checkout: conflict:
    … gc.work_commit 730ad14f… is not reachable on gc.work_branch main

--- FAIL: TestBdCloseClassResidentAsksTheOwningRigsCheckout
    close … exited 1: gc bd: work-record gate (enforced): … gc.work_commit
    d650ca37… is not reachable on gc.work_branch main
--- FAIL: TestEvaluateWorkRecordCloseGateDegradesForAnUnknownOwner
    an unanswerable reachability clause blocked the close
```

Both doors fail, on the rig-rooted rows, for the original reason. Mutation
reverted; the rows pass again.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `gofmt -l cmd internal` | 0 (no output) |
| `golangci-lint run ./internal/workrecord/... ./internal/api/... ./cmd/gc/...` | 0 (`0 issues.`) |
| `./scripts/check-residency-boundary.sh` | 0 — **baseline unchanged**, no row moved |
| `go test ./scripts/...` (the residency guard's AST half) | 0 |
| `go test ./internal/testpolicy/resourcecensus/...` (staged tree) | 0 — census unmoved |
| `bash scripts/check-core-boundary.sh` | 0 |
| `go test ./internal/workrecord/... ./internal/api/... -count=1` | 0 |
| `go test ./cmd/gc -run 'WorkRecord\|ByID\|Residency' -count=1` | 0 |
| `make test-fast-parallel` | 0 (`All fast jobs passed`) |
| `make dashboard-ci` | 0 — **no generated artifact moved** (`internal/api/openapi.json`, `docs/reference/schema/`, the generated TS client are all unchanged; this change touches no wire type) |

No base-owned failure was hit; nothing was worked around.

Refs: ga-hw5f7, ga-lkxrg, ga-j4p3y
