### PR TITLE
fix(test): guard the doctor tests' test-owned HOME with the retrying cleanup (ga-531fk)

### DIFF
--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -48,9 +47,9 @@ func TestCustomTypesCheck_MissingTypes(t *testing.T) {
 	// this check StatusOK, defeating the assertion below. Pin a test-owned
 	// HOME so that fallback file doesn't exist. See ga-zxpfic and
 	// TestCustomTypesCheck_TableDriftUsesTestOwnedDoltContext.
-	t.Setenv("HOME", t.TempDir())
+	testOwnedHome(t)
 
-	dir := t.TempDir()
+	dir := guardedTempDir(t)
 	beadsDir := filepath.Join(dir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 		t.Fatal(err)
@@ -65,22 +64,6 @@ func TestCustomTypesCheck_MissingTypes(t *testing.T) {
 	}
 	if !c.CanFix() {
 		t.Fatal("CanFix should return true")
-	}
-}
-
-// retryRemoveAllForTest retries os.RemoveAll briefly to absorb a lingering
-// embedded-dolt background writer that can hold files open a few dozen ms
-// past the owning bd subprocess's apparent exit — which otherwise races
-// t.TempDir()'s single-shot RemoveAll cleanup with an intermittent
-// "directory not empty" error. Falls through silently on final failure so
-// TempDir's own best-effort cleanup still gets the last word.
-func retryRemoveAllForTest(t *testing.T, dir string) {
-	t.Helper()
-	for i := 0; i < 10; i++ {
-		if err := os.RemoveAll(dir); err == nil {
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
 	}
 }
 
@@ -126,11 +109,9 @@ func TestCustomTypesCheck_TableDrift(t *testing.T) {
 	// to the shared server regardless of the vars above. Pin a test-owned
 	// HOME so that fallback file doesn't exist. See ga-zxpfic and
 	// TestCustomTypesCheck_TableDriftUsesTestOwnedDoltContext.
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testOwnedHome(t)
 
-	dir := t.TempDir()
-	t.Cleanup(func() { retryRemoveAllForTest(t, dir) })
+	dir := guardedTempDir(t)
 
 	runBD := func(args ...string) string {
 		t.Helper()
@@ -220,11 +201,9 @@ func TestCustomTypesCheck_TableDriftUsesTestOwnedDoltContext(t *testing.T) {
 		t.Setenv(key, "")
 	}
 
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testOwnedHome(t)
 
-	dir := t.TempDir()
-	t.Cleanup(func() { retryRemoveAllForTest(t, dir) })
+	dir := guardedTempDir(t)
 
 	runBD := func(args ...string) string {
 		t.Helper()

--- a/internal/doctor/tempdir_guard_test.go
+++ b/internal/doctor/tempdir_guard_test.go
@@ -1,0 +1,122 @@
+package doctor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	removeRetryAttempts = 10
+	removeRetryDelay    = 50 * time.Millisecond
+)
+
+// retryRemoveAllForTest retries os.RemoveAll briefly to absorb a lingering
+// embedded-dolt background writer that can hold files open a few dozen ms
+// past the owning bd subprocess's apparent exit — which otherwise races
+// t.TempDir()'s single-shot RemoveAll cleanup with an intermittent
+// "directory not empty" error. Falls through silently on final failure so
+// TempDir's own best-effort cleanup still gets the last word.
+func retryRemoveAllForTest(t *testing.T, dir string) {
+	t.Helper()
+	retryRemoveAll(dir, os.RemoveAll, removeRetryAttempts, removeRetryDelay)
+}
+
+// retryRemoveAll calls remove(dir) until it reports success or the attempt
+// budget runs out, pausing delay between tries.
+func retryRemoveAll(dir string, remove func(string) error, attempts int, delay time.Duration) {
+	for i := 0; i < attempts; i++ {
+		if err := remove(dir); err == nil {
+			return
+		}
+		time.Sleep(delay)
+	}
+}
+
+// guardedTempDir returns a t.TempDir() whose removal is retried by
+// retryRemoveAllForTest. Registering the cleanup after t.TempDir() has
+// registered its own means LIFO ordering runs the retrying removal first,
+// leaving TempDir's single-shot RemoveAll nothing to trip over. Every temp
+// dir a bd subprocess writes into needs this, so bead ga-531fk — where the
+// dir pinned as HOME was the one missing the guard and failed a Mac CI run
+// after its test body had already passed — cannot repeat: the guard now
+// comes with the directory instead of being a second line to remember.
+func guardedTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Cleanup(func() { retryRemoveAllForTest(t, dir) })
+	return dir
+}
+
+// testOwnedHome pins HOME to a fresh guarded temp dir for the duration of the
+// test and returns it. bd's config precedence falls through, as a last
+// resort, to $HOME/.beads/config.yaml, so only a test-owned HOME keeps a
+// machine-level dolt.shared-server setting out of the bd subprocesses these
+// tests spawn (ga-zxpfic). bd then writes $HOME/.beads/ itself, which is why
+// that dir needs the same retrying removal as the working dir.
+func testOwnedHome(t *testing.T) string {
+	t.Helper()
+	home := guardedTempDir(t)
+	t.Setenv("HOME", home)
+	return home
+}
+
+func TestRetryRemoveAllRetriesUntilRemovalSucceeds(t *testing.T) {
+	calls := 0
+	retryRemoveAll(t.TempDir(), func(string) error {
+		calls++
+		if calls < 3 {
+			return errors.New("directory not empty")
+		}
+		return nil
+	}, removeRetryAttempts, 0)
+	if calls != 3 {
+		t.Fatalf("remove called %d times, want 3 (two failures, then success)", calls)
+	}
+}
+
+func TestRetryRemoveAllStopsAtItsAttemptBudget(t *testing.T) {
+	calls := 0
+	retryRemoveAll(t.TempDir(), func(string) error {
+		calls++
+		return errors.New("directory not empty")
+	}, 4, 0)
+	if calls != 4 {
+		t.Fatalf("remove called %d times, want 4 (the attempt budget)", calls)
+	}
+}
+
+// TestGuardedTempDirRemovesItsDirWhenTheTestEnds pins the structural half of
+// the contract — the returned dir is test-scoped and gone once the owning
+// test finishes. The retry half is covered by the retryRemoveAll tests above,
+// since a single RemoveAll of an idle dir succeeds on the first attempt.
+func TestGuardedTempDirRemovesItsDirWhenTheTestEnds(t *testing.T) {
+	var dir string
+	t.Run("guarded", func(t *testing.T) {
+		dir = guardedTempDir(t)
+		if err := os.WriteFile(filepath.Join(dir, "leftover"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("Stat(%s) after the subtest returned err=%v, want the dir removed", dir, err)
+	}
+}
+
+func TestTestOwnedHomePinsHOMEToAGuardedTempDir(t *testing.T) {
+	var home string
+	t.Run("pinned", func(t *testing.T) {
+		home = testOwnedHome(t)
+		if got := os.Getenv("HOME"); got != home {
+			t.Fatalf("HOME = %q, want the test-owned dir %q", got, home)
+		}
+		if err := os.MkdirAll(filepath.Join(home, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if _, err := os.Stat(home); !os.IsNotExist(err) {
+		t.Fatalf("Stat(%s) after the subtest returned err=%v, want the test-owned HOME removed", home, err)
+	}
+}

--- a/internal/doctor/tempdir_guard_test.go
+++ b/internal/doctor/tempdir_guard_test.go
@@ -13,26 +13,38 @@ const (
 	removeRetryDelay    = 50 * time.Millisecond
 )
 
-// retryRemoveAllForTest retries os.RemoveAll briefly to absorb a lingering
+// retryRemoveAllForTest retries remove briefly to absorb a lingering
 // embedded-dolt background writer that can hold files open a few dozen ms
 // past the owning bd subprocess's apparent exit — which otherwise races
 // t.TempDir()'s single-shot RemoveAll cleanup with an intermittent
-// "directory not empty" error. Falls through silently on final failure so
-// TempDir's own best-effort cleanup still gets the last word.
-func retryRemoveAllForTest(t *testing.T, dir string) {
+// "directory not empty" error. It logs rather than fails on a final give-up,
+// so TempDir's own best-effort cleanup still gets the last word while a
+// future red run can still tell an insufficient guard from a missing one.
+// cmd/gc dodges the same lingering-writer hazard by placement instead — see
+// doltIdentityHomeDir (ga-7dgcg6).
+func retryRemoveAllForTest(t *testing.T, dir string, remove func(string) error) {
 	t.Helper()
-	retryRemoveAll(dir, os.RemoveAll, removeRetryAttempts, removeRetryDelay)
+	if err := retryRemoveAll(dir, remove, removeRetryAttempts, removeRetryDelay); err != nil {
+		t.Logf("guarded removal of %s exhausted %d attempts: %v", dir, removeRetryAttempts, err)
+	}
 }
 
 // retryRemoveAll calls remove(dir) until it reports success or the attempt
-// budget runs out, pausing delay between tries.
-func retryRemoveAll(dir string, remove func(string) error, attempts int, delay time.Duration) {
+// budget runs out, pausing delay between tries but not after the last one.
+// It returns nil once a removal succeeds, and otherwise the final failure so
+// the caller can report the give-up rather than discard it.
+func retryRemoveAll(dir string, remove func(string) error, attempts int, delay time.Duration) error {
+	var lastErr error
 	for i := 0; i < attempts; i++ {
-		if err := remove(dir); err == nil {
-			return
+		lastErr = remove(dir)
+		if lastErr == nil {
+			return nil
 		}
-		time.Sleep(delay)
+		if i < attempts-1 {
+			time.Sleep(delay)
+		}
 	}
+	return lastErr
 }
 
 // guardedTempDir returns a t.TempDir() whose removal is retried by
@@ -45,8 +57,18 @@ func retryRemoveAll(dir string, remove func(string) error, attempts int, delay t
 // comes with the directory instead of being a second line to remember.
 func guardedTempDir(t *testing.T) string {
 	t.Helper()
+	return guardedTempDirWith(t, os.RemoveAll)
+}
+
+// guardedTempDirWith is guardedTempDir with the removal call injected. The
+// registration is the whole point of the helper and yet is invisible to a
+// dir-is-gone assertion, because t.TempDir() removes an idle dir on its own;
+// injecting the removal is what lets a test observe that the cleanup was
+// registered at all. Ordinary callers want guardedTempDir.
+func guardedTempDirWith(t *testing.T, remove func(string) error) string {
+	t.Helper()
 	dir := t.TempDir()
-	t.Cleanup(func() { retryRemoveAllForTest(t, dir) })
+	t.Cleanup(func() { retryRemoveAllForTest(t, dir, remove) })
 	return dir
 }
 
@@ -65,7 +87,7 @@ func testOwnedHome(t *testing.T) string {
 
 func TestRetryRemoveAllRetriesUntilRemovalSucceeds(t *testing.T) {
 	calls := 0
-	retryRemoveAll(t.TempDir(), func(string) error {
+	err := retryRemoveAll(t.TempDir(), func(string) error {
 		calls++
 		if calls < 3 {
 			return errors.New("directory not empty")
@@ -75,23 +97,59 @@ func TestRetryRemoveAllRetriesUntilRemovalSucceeds(t *testing.T) {
 	if calls != 3 {
 		t.Fatalf("remove called %d times, want 3 (two failures, then success)", calls)
 	}
+	if err != nil {
+		t.Fatalf("retryRemoveAll returned %v, want nil once a removal succeeds", err)
+	}
 }
 
 func TestRetryRemoveAllStopsAtItsAttemptBudget(t *testing.T) {
 	calls := 0
-	retryRemoveAll(t.TempDir(), func(string) error {
+	wantErr := errors.New("directory not empty")
+	err := retryRemoveAll(t.TempDir(), func(string) error {
 		calls++
-		return errors.New("directory not empty")
+		return wantErr
 	}, 4, 0)
 	if calls != 4 {
 		t.Fatalf("remove called %d times, want 4 (the attempt budget)", calls)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("retryRemoveAll returned %v, want the final failure %v", err, wantErr)
+	}
+}
+
+// TestGuardedTempDirRegistersTheRetryingRemoval pins the wiring between the
+// two halves the tests below and above cover separately: that
+// guardedTempDirWith registers the retrying removal on the dir it hands
+// back. Deleting that registration — exactly the pre-ga-531fk shape — drives
+// calls to 0 and turns this red, which no dir-is-gone assertion can do,
+// since t.TempDir() removes an idle dir on its own. The injected remove
+// deliberately never removes anything: TempDir's own cleanup still clears
+// the dir. That the guardedTempDir wrapper every real caller uses reaches
+// this seam with a real removal is pinned separately by
+// TestGuardedTempDirRemovalRunsBeforeTempDirsOwnCleanup.
+func TestGuardedTempDirRegistersTheRetryingRemoval(t *testing.T) {
+	calls := 0
+	t.Run("guarded", func(t *testing.T) {
+		guardedTempDirWith(t, func(string) error {
+			calls++
+			if calls < 3 {
+				return errors.New("directory not empty")
+			}
+			return nil
+		})
+	})
+	if calls != 3 {
+		t.Fatalf("registered remove called %d times, want 3 (two failures, then success)", calls)
 	}
 }
 
 // TestGuardedTempDirRemovesItsDirWhenTheTestEnds pins the structural half of
 // the contract — the returned dir is test-scoped and gone once the owning
 // test finishes. The retry half is covered by the retryRemoveAll tests above,
-// since a single RemoveAll of an idle dir succeeds on the first attempt.
+// since a single RemoveAll of an idle dir succeeds on the first attempt; the
+// wiring between the two halves is covered by
+// TestGuardedTempDirRegistersTheRetryingRemoval for the seam and by
+// TestGuardedTempDirRemovalRunsBeforeTempDirsOwnCleanup for the wrapper.
 func TestGuardedTempDirRemovesItsDirWhenTheTestEnds(t *testing.T) {
 	var dir string
 	t.Run("guarded", func(t *testing.T) {
@@ -118,5 +176,29 @@ func TestTestOwnedHomePinsHOMEToAGuardedTempDir(t *testing.T) {
 	})
 	if _, err := os.Stat(home); !os.IsNotExist(err) {
 		t.Fatalf("Stat(%s) after the subtest returned err=%v, want the test-owned HOME removed", home, err)
+	}
+}
+
+// TestGuardedTempDirRemovalRunsBeforeTempDirsOwnCleanup pins the wrapper
+// half: that guardedTempDir itself reaches the seam with a real removal. It
+// sandwiches a probe cleanup between TempDir's base RemoveAll (registered by
+// the deliberate first t.TempDir() call) and guardedTempDir's retry cleanup,
+// so LIFO runs retry -> probe -> base and the probe observes whether the
+// guarded removal ran. Bypassing the seam (return t.TempDir()) or injecting
+// an inert remove both leave the dir standing and turn this red; no other
+// test here catches either shape.
+func TestGuardedTempDirRemovalRunsBeforeTempDirsOwnCleanup(t *testing.T) {
+	var removedBeforeBase bool
+	t.Run("guarded", func(t *testing.T) {
+		_ = t.TempDir() // first TempDir call: pins the base RemoveAll below ours
+		var dir string
+		t.Cleanup(func() {
+			_, err := os.Stat(dir)
+			removedBeforeBase = os.IsNotExist(err)
+		})
+		dir = guardedTempDir(t)
+	})
+	if !removedBeforeBase {
+		t.Fatal("guardedTempDir's cleanup did not remove the dir before TempDir's own cleanup ran")
 	}
 }


### PR DESCRIPTION
## Summary

The doctor tests that spawn `bd` pin `$HOME` at a `t.TempDir()`, because `bd`'s
config precedence falls through to `$HOME/.beads/config.yaml` and a machine HOME
with `dolt.shared-server: true` otherwise routes those subprocesses at the shared
server no matter which env vars the test scrubs (ga-zxpfic). That HOME is not
just a decoy directory — `bd` writes `$HOME/.beads/` into it, and the embedded
dolt background writer can hold files there open a few dozen ms past the owning
subprocess's apparent exit.

`retryRemoveAllForTest` exists precisely to absorb that lag, but it was only
registered for the *working* dir. The HOME dir was left to `t.TempDir()`'s
single-shot deferred `RemoveAll`, which lost the race on the Mac CI lane:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat
  /var/folders/.../TestCustomTypesCheck_TableDrift3082042356/001: directory not empty
--- FAIL: TestCustomTypesCheck_TableDrift (5.95s)
```

Mac Regression run 34174946211, job 101902481774. The test body had already
passed; only cleanup failed. `t.TempDir()` numbers sequentially from `001`, so
the failing `001` is the first call — the unguarded HOME.

## What changed

The guard now comes with the directory instead of being a second line each test
has to remember:

- `guardedTempDir(t)` returns a `t.TempDir()` with the retrying cleanup already
  registered. Registration order matters and is documented: because it registers
  *after* `t.TempDir()` registered its own, LIFO ordering runs the retrying
  removal first and leaves `TempDir`'s `RemoveAll` nothing to trip over.
- `testOwnedHome(t)` pins `$HOME` at one of those and returns it.

Every test in `internal/doctor` that pins a test-owned HOME for `bd`
subprocesses now uses them for **both** of its temp dirs:

| Test | HOME dir | working dir |
| --- | --- | --- |
| `TestCustomTypesCheck_TableDrift` | was unguarded → guarded | already guarded |
| `TestCustomTypesCheck_TableDriftUsesTestOwnedDoltContext` | was unguarded → guarded | already guarded |
| `TestCustomTypesCheck_MissingTypes` | was unguarded → guarded | was unguarded → guarded |

Those three are the complete set: a `t.Setenv("HOME"` sweep of the package
returns one other site, `setupFakeGitConfig` in `checks_beads_role_test.go`,
which spawns `git config` and never `bd`, so it has no dolt writer to outlive it.

The helpers and `retryRemoveAllForTest` move to a small
`internal/doctor/tempdir_guard_test.go` so the check's own test file is only
about the check.

## On proving it

The Mac race is not reproducible on this Linux host, so the retry behaviour is
pinned directly rather than by re-running the flake. `retryRemoveAllForTest`
keeps its exact semantics but its loop moves into
`retryRemoveAll(dir, remove, attempts, delay)` with the removal injected, which
makes both paths testable with no sleeps and no timing:

- `TestRetryRemoveAllRetriesUntilRemovalSucceeds` — a fake that fails twice then
  succeeds is called exactly three times.
- `TestRetryRemoveAllStopsAtItsAttemptBudget` — a fake that always fails is
  called exactly `attempts` times and the helper returns rather than hanging.
- `TestTestOwnedHomePinsHOMEToAGuardedTempDir` — `$HOME` is the returned dir, and
  the dir is gone once the owning subtest ends.
- `TestGuardedTempDirRemovesItsDirWhenTheTestEnds` — pins the structural half
  (the dir is test-scoped); its comment says outright that the retry half is
  covered by the two tests above, since a single `RemoveAll` of an idle dir
  succeeds on the first attempt.

Each new test was mutation-checked: breaking the loop bound to a single attempt
fails both retry tests (`remove called 1 times, want 3` / `want 4`), and dropping
the `t.Setenv` from `testOwnedHome` fails the HOME test with the real
`/home/ubuntu`. Beyond that, the change is mechanically sufficient by
construction: the guard being applied to the HOME dir is the same guard that has
protected the working dir of these tests since it was written.

## Gates

All run on this branch; every one exited 0.

| Gate | Exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./internal/doctor/...` | 0 |
| `gofmt -l internal/doctor` (no output) | 0 |
| `golangci-lint run ./internal/doctor/...` — 0 issues | 0 |
| `go test ./internal/doctor/ -count=1` | 0 |
| `make test-fast-parallel` — "All fast jobs passed" | 0 |
| `.githooks/pre-commit` (ran on the commit) | 0 |
| `.githooks/pre-push` (ran on the push, no `--no-verify`) | 0 |

`TestCustomTypesCheck_TableDrift` **ran** here rather than skipping — the PATH
`bd` is `1.1.0 (Enterprise dev, 8de373f05)`, so the CGO-less-binary skip of
ga-z3ehf did not apply — and passed in 6.72s, as did
`TestCustomTypesCheck_TableDriftUsesTestOwnedDoltContext` in 4.74s.

One base-owned wrinkle, disclosed rather than left to be found: the first
`make test-fast-parallel` run failed `TestRepositoryLedgerMatchesCensusAndDocumentation`
with a stale `fixed_sleep` baseline (320 vs 321 calls). That is the known
resource-census behaviour on **unstaged** files — the census saw the removed
literal `time.Sleep(50 * time.Millisecond)` but not the new file that carries it.
`git add` and re-run: green, with no baseline edit needed. The gate table above
is the staged re-run.

Refs ga-531fk. Unblocks ga-j4p3y: this flake is what broke #5644's pre-approval
CI on the Mac lane.
