### PR TITLE
fix(residency): retire the hand-rolled by-id probes onto the resolver (s6)

### DIFF
--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -139,6 +139,32 @@ func byIDPlanForTopology(topo storeref.Topology, id string) (storeref.ResolvedPl
 	return storeref.Plan(storeref.ByID{ID: id}, topo)
 }
 
+// byIDBeadForTopology reads the row id names over a topology the caller already
+// holds: plan ByID, resolve the owner, and read only if the winning probe did
+// not already.
+//
+// It is the ONE controller-side spelling of the by-id read. The warm-bind claim
+// probe (newWarmClaimTriggerResolver) and the wait-dependency reader
+// (waitDependencyPlanReader) both go through it, so a third controller surface
+// cannot grow a fourth answer to "which store holds this bead" — the drift this
+// lane exists to close.
+//
+// Unlike byIDOwnerForTopology there is no work-store fallback argument: a
+// controller-side caller holds no separate work axis to fall back TO. Its work
+// store is already a leg of the topology, so a clean miss on every leg is
+// beads.ErrNotFound and the caller decides what that means.
+func byIDBeadForTopology(topo storeref.Topology, id string) (beads.Bead, error) {
+	plan, err := byIDPlanForTopology(topo, id)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	owner, err := storeref.ResolveOwnerRow(plan, id)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	return beadForOwner(owner, id)
+}
+
 // cliByIDBindingOwner answers the binding half of the by-id question for a
 // surface whose work axis is not a beads.Store.
 //

--- a/cmd/gc/by_id_residency.go
+++ b/cmd/gc/by_id_residency.go
@@ -85,11 +85,7 @@ func cliByIDOwner(cityPath, id string, work beads.Store) (storeref.Owner, error)
 // for it would be this file picking a store out of a leg — the residency
 // boundary's one forbidden move, and pointless when the caller already has it.
 func byIDOwnerForTopology(topo storeref.Topology, id string, work beads.Store) (storeref.Owner, error) {
-	plan, err := byIDPlanForTopology(topo, id)
-	if err != nil {
-		return storeref.Owner{}, err
-	}
-	owner, err := withProvenRelicRemedy(storeref.ResolveOwnerRow(plan, id))
+	owner, err := byIDOwnerRowForTopology(topo, id)
 	switch {
 	case err == nil:
 		return owner, nil
@@ -139,6 +135,24 @@ func byIDPlanForTopology(topo storeref.Topology, id string) (storeref.ResolvedPl
 	return storeref.Plan(storeref.ByID{ID: id}, topo)
 }
 
+// byIDOwnerRowForTopology plans ByID, runs the owner-row executor and names the
+// remedy on the one denial that needs one.
+//
+// It is the step the two whole-plan readers below and above it share, and they
+// differ only in what a clean miss means to them: byIDOwnerForTopology hands
+// back the caller's own work store, byIDBeadForTopology has none to hand back.
+// Sharing it is what keeps withProvenRelicRemedy on both — an operator who hit
+// the proven-relic denial through the wait reader needs the same next move as
+// one who hit it through `gc bd`, and a remedy attached at two of three doors
+// is the drift this file exists to close.
+func byIDOwnerRowForTopology(topo storeref.Topology, id string) (storeref.Owner, error) {
+	plan, err := byIDPlanForTopology(topo, id)
+	if err != nil {
+		return storeref.Owner{}, err
+	}
+	return withProvenRelicRemedy(storeref.ResolveOwnerRow(plan, id))
+}
+
 // byIDBeadForTopology reads the row id names over a topology the caller already
 // holds: plan ByID, resolve the owner, and read only if the winning probe did
 // not already.
@@ -154,11 +168,7 @@ func byIDPlanForTopology(topo storeref.Topology, id string) (storeref.ResolvedPl
 // store is already a leg of the topology, so a clean miss on every leg is
 // beads.ErrNotFound and the caller decides what that means.
 func byIDBeadForTopology(topo storeref.Topology, id string) (beads.Bead, error) {
-	plan, err := byIDPlanForTopology(topo, id)
-	if err != nil {
-		return beads.Bead{}, err
-	}
-	owner, err := storeref.ResolveOwnerRow(plan, id)
+	owner, err := byIDOwnerRowForTopology(topo, id)
 	if err != nil {
 		return beads.Bead{}, err
 	}

--- a/cmd/gc/by_id_store_route.go
+++ b/cmd/gc/by_id_store_route.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // classRoutedStoreForID returns the store that actually holds id: the relocated
@@ -102,7 +103,7 @@ func classBindingForID(cityPath, id string) (beads.Store, bool, error) {
 // An error is a read that FAILED, never absence: reading "the binding could not
 // answer" as "the bead is not there" is the root-loss shape this lane exists to
 // prevent. The one error that is not a fault is the one-shot funnel's standing
-// refusal (isStandingStorageRefusal) — a verdict about the CITY's storage
+// refusal (storeref.IsStandingRefusal) — a verdict about the CITY's storage
 // configuration that says nothing about a bead, and a refused city still serves
 // WORK from its work ledger. So for a work-shaped id the refusal establishes
 // nothing and work answers; for an id inside a reserved namespace the refusal IS
@@ -115,7 +116,7 @@ func classRoutedStoreForIDIn(class beads.Store, id string, work beads.Store) (be
 		switch {
 		case errors.Is(err, beads.ErrNotFound):
 			return work, nil
-		case isStandingStorageRefusal(err) && !bdIDIsClassReserved(id):
+		case storeref.IsStandingRefusal(err) && !bdIDIsClassReserved(id):
 			return work, nil
 		default:
 			return nil, fmt.Errorf("reading %q from the relocated class binding: %w", id, err)

--- a/cmd/gc/by_id_store_route.go
+++ b/cmd/gc/by_id_store_route.go
@@ -68,29 +68,11 @@ func cityGraphClassBinding(cityPath string) beads.Store {
 	return store
 }
 
-// classBindingForID is the class leg of classRoutedStoreForID, for callers whose
-// work answer is a leg list rather than one store. A nil work leg makes the
-// residual answer nil, so ok=false means "no named leg answered".
-func classBindingForID(cityPath, id string) (beads.Store, bool, error) {
-	class := cityGraphClassBinding(cityPath)
-	if class == nil {
-		return nil, false, nil
-	}
-	store, err := classRoutedStoreForIDIn(class, id, nil)
-	if err != nil {
-		return nil, false, err
-	}
-	if store == nil {
-		return nil, false, nil
-	}
-	return class, true, nil
-}
-
 // classRoutedStoreForIDIn is classRoutedStoreForID with the binding already in
 // hand, for the callers that resolve it once per request and hold no cityPath to
 // hand cliByIDOwner: gc graph's per-id resolver (graphStores.storeFor), which
-// also needs the raw binding for convoycore.MemberClasses, and classBindingForID
-// itself. Nil class means no relocation.
+// also needs the raw binding for convoycore.MemberClasses. Nil class means no
+// relocation.
 //
 // It applies the resolver's rule directly against the opened binding. The class
 // store leads because it MINTS the reserved namespace, but minting is not

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2476,15 +2476,7 @@ func (cr *CityRuntime) stopConfigWatcher() {
 func (cr *CityRuntime) newWarmClaimTriggerResolver(servingRigs map[string]beads.Store) warmClaimTriggerResolver {
 	topo := cr.residencyTopology(servingRigs)
 	return func(triggerID string) (beads.Bead, error) {
-		plan, err := storeref.Plan(storeref.ByID{ID: triggerID}, topo)
-		if err != nil {
-			return beads.Bead{}, err
-		}
-		owner, err := storeref.ResolveOwnerRow(plan, triggerID)
-		if err != nil {
-			return beads.Bead{}, err
-		}
-		return beadForOwner(owner, triggerID)
+		return byIDBeadForTopology(topo, triggerID)
 	}
 }
 
@@ -2654,7 +2646,15 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	phaseStart = time.Now()
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cityName, sessionBeads)
 
-	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(sessionpkg.NewStore(sessStore), newWaitDependencyStoreSet(store, rigStores, cr.graphBeadStore()), cr.nudgesBeadStore(), time.Now(), sessionBeads)
+	// The dependency reader plans over the frame this tick is TOLD is serving,
+	// not over every rig store the runtime holds open: a suspended rig is dark,
+	// and reading it made every dependency lookup in the city fail.
+	suspendedRigPaths := buildSuspendedRigPathsForCity(cr.cfg, cr.cityPath)
+	waitDeps := newWaitDependencyPlanReader(
+		cr.residencyTopology(servingRigStores(cr.cfg, rigStores, suspendedRigPaths)),
+		len(suspendedRigPaths) > 0,
+	)
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(sessionpkg.NewStore(sessStore), waitDeps, cr.nudgesBeadStore(), time.Now(), sessionBeads)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: preparing waits: %v\n", cr.logPrefix, err) //nolint:errcheck
 		readyWaitSet = nil

--- a/cmd/gc/claim_class_route.go
+++ b/cmd/gc/claim_class_route.go
@@ -130,6 +130,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
 	"github.com/gastownhall/gascity/internal/storebinding"
+	"github.com/gastownhall/gascity/internal/storeref"
 )
 
 // errClaimRouteBindingCannotClaim reports that the relocated coordination-class
@@ -161,6 +162,13 @@ type hookClaimClassRoute struct {
 	// takes a beads.Store rather than the closed contract.
 	class beads.Store
 	graph storebinding.GraphStore
+
+	// topology is the residency frame holds() plans over, captured once at
+	// construction. Data, not a path and not a func: a route that re-entered the
+	// funnel per bead could resolve a DIFFERENT handle from the one class and
+	// graph were opened over, and would then prove a bead absent in one engine
+	// while the claim wrote through another.
+	topology storeref.Topology
 
 	resident map[string]bool
 
@@ -199,13 +207,48 @@ func newHookClaimClassRoute(class beads.Store) (*hookClaimClassRoute, error) {
 // newClaimClassRouteOver builds the route value over an already-projected front
 // door, with both per-invocation memos live. It is the one place they are
 // created, so a route can never reach the escalation with a nil map.
+//
+// The topology it derives is PESSIMISTIC: one binding over the given store,
+// serving every infrastructure class, censused by a nil relics func — which
+// storeref.BuildBindings reads as HasLegacyResidents=true for every store,
+// because a caller holding no censused routes is entitled to claim nothing more.
+// That makes probeRetired() false, so a route built here probes on exactly the
+// ids it probed on before this frame existed. Callers that DO hold a census —
+// hookClaimClassRouteForCity, the only production one — overwrite it with the
+// real thing.
+//
+// Deriving it through soleBindingResidency rather than assembling a ClassBinding
+// literal is the point of doing it at all: Prefixes, Classes, Ref and both
+// retirement bits then come from the one production derivation, so a route built
+// from a bare store cannot disagree with a route built from a city about what
+// the binding's namespaces are.
+//
+// class is what the topology's binding leg is, and graph must be the projection
+// OF that same store — newHookClaimClassRoute is what guarantees it. A caller
+// pairing a graph over one store with a topology over another would prove a bead
+// absent in one engine and write through the other, which is the split this
+// route exists to close, one level up.
 func newClaimClassRouteOver(class beads.Store, graph storebinding.GraphStore) *hookClaimClassRoute {
+	bindings, refused := soleBindingResidency(class)
 	return &hookClaimClassRoute{
 		class:    class,
 		graph:    graph,
+		topology: claimRouteTopology(bindings, refused),
 		resident: map[string]bool{},
 		workHeld: map[string]bool{},
 	}
+}
+
+// claimRouteTopology frames the bindings for holds().
+//
+// The work leg is the unprobed residual, which is what makes the plan's answer
+// readable as a yes/no about the BINDING alone: this route's work axis is the
+// federated bd fan-out the caller already ran and found not-found, not a store,
+// and a real work leg here would report those same beads owned by work again.
+// No rig legs, for the reason cliByIDOwner passes none — a claim escalation has
+// never read them, and starting to would change which beads it claims.
+func claimRouteTopology(bindings []storeref.ClassBinding, refused error) storeref.Topology {
+	return assembleResidencyTopology(nil, newUnprobedWorkResidual(), nil, bindings, refused)
 }
 
 // hookClaimRouteVerdict turns one class-route resolution into the claim ops the
@@ -270,7 +313,18 @@ func hookClaimClassRouteForCity(cityPath string) (*hookClaimClassRoute, error) {
 	if !relocated {
 		return nil, nil
 	}
-	return newHookClaimClassRoute(binding.Store)
+	route, err := newHookClaimClassRoute(binding.Store)
+	if err != nil {
+		return nil, err
+	}
+	// The census-bearing frame, read from the SAME memo cliSoleClassBinding just
+	// took the store out of. That is what makes the probe handle and the write
+	// handle one store by construction rather than by coincidence, and it is why
+	// the topology is not resolved from cityPath later: a second derivation could
+	// open a second engine on the same root.
+	bindings, refused := cliResidencyBindings(cityPath)
+	route.topology = claimRouteTopology(bindings, refused)
+	return route, nil
 }
 
 // knownResident reports whether an earlier probe in THIS invocation already
@@ -285,13 +339,23 @@ func (r *hookClaimClassRoute) knownResident(id string) bool {
 
 // holds probes the binding for id and memoizes the answer.
 //
-// An error is a read that FAILED, never absence. The single exception is the
-// one-shot funnel's standing refusal on a WORK-shaped id: it says this city's
-// storage configuration cannot be served, which is a fact about the city and
-// none about a particular bead, and a refused city still serves work from its
-// work ledger — so the caller's own work-store answer stands. An id only the
-// binding could own (a reserved class prefix) has nowhere else to live, so for
-// that one the refusal is the answer and surfaces.
+// The judgement is the residency resolver's, over the frame captured at
+// construction. It used to be spelled here — an unconditional Get, a not-found
+// arm, a hand-rolled standing-refusal arm — and every clause of it was a
+// restatement of one the by-id door already had. Two consequences follow from
+// the collapse, and both are the point:
+//
+// An error is a read that FAILED, never absence, and the one non-fault is the
+// one-shot funnel's standing refusal on a WORK-shaped id. That is now the
+// resolver's per-leg policy rather than a predicate here: a residence probe for
+// an id no relocated class could own tolerates the refusal, because a refused
+// city still serves work from its work ledger, while the authority leg for an id
+// inside a reserved namespace surfaces it, because there the refusal IS the
+// answer.
+//
+// And a binding the boot census certified relic-free is not probed at all for a
+// work-shaped id. The census is taken to retire exactly this read, and this seam
+// was paying it once per escalated bead while the by-id door had already stopped.
 func (r *hookClaimClassRoute) holds(id string) (bool, error) {
 	id = strings.TrimSpace(id)
 	if r == nil || id == "" {
@@ -300,19 +364,12 @@ func (r *hookClaimClassRoute) holds(id string) (bool, error) {
 	if known, ok := r.resident[id]; ok {
 		return known, nil
 	}
-	_, err := r.graph.Get(id)
-	switch {
-	case err == nil:
-		r.resident[id] = true
-		return true, nil
-	case errors.Is(err, beads.ErrNotFound):
-		r.resident[id] = false
-		return false, nil
-	case isStandingStorageRefusal(err) && !bdIDIsClassReserved(id):
-		return false, nil
-	default:
+	_, resident, err := byIDBindingOwnerForTopology(r.topology, id)
+	if err != nil {
 		return false, fmt.Errorf("reading %q from the relocated class binding: %w", id, err)
 	}
+	r.resident[id] = resident
+	return resident, nil
 }
 
 // routes reports whether a claim-time write for id must run against the binding

--- a/cmd/gc/claim_class_route_test.go
+++ b/cmd/gc/claim_class_route_test.go
@@ -520,3 +520,109 @@ func newClaimRouteFor(t *testing.T, class beads.Store) *hookClaimClassRoute {
 	}
 	return route
 }
+
+// claimCapableCountedStore is a counted binding that forwards the CAS.
+//
+// countingClassStore embeds the beads.Store INTERFACE, so it advertises no
+// two-argument Claim and newHookClaimClassRoute refuses it outright. That
+// refusal is correct and must stay — a route that cannot perform the one write
+// it exists for is worse than no route — so the capability is restored here, by
+// the fixture that wants it, rather than by widening the counter for every
+// caller.
+//
+// Get is NOT overridden: it promotes off the embedded counter, which is what
+// keeps the read count the only observable these rows assert on.
+type claimCapableCountedStore struct {
+	*countingClassStore
+	claims beads.Store
+}
+
+func (s claimCapableCountedStore) Claim(id, assignee string) (beads.Bead, bool, error) {
+	claimer, ok := s.claims.(interface {
+		Claim(id, assignee string) (beads.Bead, bool, error)
+	})
+	if !ok {
+		return beads.Bead{}, false, fmt.Errorf("the counted binding's leaf %T has no compare-and-swap claim", s.claims)
+	}
+	return claimer.Claim(id, assignee)
+}
+
+// installClaimCapableCountedBinding is installCountedClassBinding for the claim
+// route: the same counter and the same restated census verdict, wrapped so the
+// route's construction gate admits it.
+func installClaimCapableCountedBinding(t *testing.T, cityPath string, relicFree bool) *countingClassStore {
+	t.Helper()
+	return installCountedClassBindingWrapped(t, cityPath, relicFree, func(c *countingClassStore) beads.Store {
+		return claimCapableCountedStore{countingClassStore: c, claims: c.Store}
+	})
+}
+
+// claimRouteForCountedCity resolves the route the two retirement rows below
+// assert on, and fails the row rather than returning a nil one.
+func claimRouteForCountedCity(t *testing.T, cityPath string) *hookClaimClassRoute {
+	t.Helper()
+	route, err := hookClaimClassRouteForCity(cityPath)
+	if err != nil {
+		t.Fatalf("resolving the claim-time class route: %v", err)
+	}
+	if route == nil {
+		t.Fatal("a city serving its classes from a relocated binding resolved no claim route")
+	}
+	return route
+}
+
+// TestClaimRouteHoldsSkipsTheProbeOnACensusCleanBinding is the claim path's half
+// of the retirement the boot census is taken for.
+//
+// holds() is the residence probe, reached on every work-scope claim that comes
+// back not-found, and it read the binding unconditionally. The by-id door stopped
+// doing that when it moved onto storeref (ga-qdt5y.18) and this seam kept its own
+// hand-rolled version of the same judgement, so a converged relic-free city still
+// paid a binding read per escalated bead here while
+// TestBdByIDDoorSkipsTheProbeOnACensusCleanBinding reported the saving taken.
+//
+// Asserted on the read COUNT for the same reason as that row: the answer is
+// false either way, and the work that does not happen is the whole point.
+func TestClaimRouteHoldsSkipsTheProbeOnACensusCleanBinding(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	counter := installClaimCapableCountedBinding(t, cityPath, true)
+	route := claimRouteForCountedCity(t, cityPath)
+
+	held, err := route.holds("gc-abc123")
+	if err != nil {
+		t.Fatalf("holds on a work-shaped id: %v", err)
+	}
+	if held {
+		t.Error("the binding claims to hold a work-shaped id it never minted; the escalation would claim through the wrong ledger")
+	}
+	if counter.gets != 0 {
+		t.Errorf("the claim route read the class binding %d time(s) for a work-shaped id on a census-clean binding; the retirement the census was taken for is not being taken", counter.gets)
+	}
+}
+
+// TestClaimRouteHoldsKeepsTheAuthorityLegOnACensusCleanBinding is the
+// must-be-silent counterpart, and it is what stops the row above from being
+// satisfied by a holds() that stopped reading altogether.
+//
+// A clean census retires the RESIDENCE probe — the leg that exists only because
+// a migration preserved work-shaped ids. It never retires the authority leg: the
+// binding is the sole minter of its namespaces, so for an id inside one it is the
+// only store that can answer, and "no relics" says nothing about whether it holds
+// this particular bead.
+func TestClaimRouteHoldsKeepsTheAuthorityLegOnACensusCleanBinding(t *testing.T) {
+	cityPath, classStore := foreignProviderCity(t)
+	minted := mustCreateClassBead(t, classStore, beads.Bead{Title: "a step the clean binding holds"})
+	counter := installClaimCapableCountedBinding(t, cityPath, true)
+	route := claimRouteForCountedCity(t, cityPath)
+
+	resident, err := route.holds(minted.ID)
+	if err != nil {
+		t.Fatalf("holds on an id only the binding can mint: %v", err)
+	}
+	if !resident {
+		t.Fatal("the binding was reported not to hold a bead it minted; the claim would escalate past the only store that can answer")
+	}
+	if counter.gets != 1 {
+		t.Errorf("the claim route read the class binding %d time(s) for an id only that binding can mint, want exactly 1: zero means a clean census retired the authority leg, which nothing may do, and more than one means the probe is being repeated", counter.gets)
+	}
+}

--- a/cmd/gc/cli_storage_routes.go
+++ b/cmd/gc/cli_storage_routes.go
@@ -249,12 +249,12 @@ type standingStorageRefusal struct{ err error }
 func (e standingStorageRefusal) Error() string { return e.err.Error() }
 func (e standingStorageRefusal) Unwrap() error { return e.err }
 
-// isStandingStorageRefusal reports whether err is this build's standing verdict
-// about the city rather than a fault in the read that produced it.
-func isStandingStorageRefusal(err error) bool {
-	var refusal standingStorageRefusal
-	return errors.As(err, &refusal)
-}
+// The predicate over this type is storeref.IsStandingRefusal, which matches on
+// the StandingStorageRefusal() marker (declared in residency_topology.go)
+// instead of on this concrete type. cmd/gc had its own errors.As spelling until
+// the claim route stopped needing one: with the last production caller collapsed
+// onto the resolver, a second predicate could only drift from the one the
+// resolver's leg policy actually consults.
 
 // refusedClassStore is the store a relocated class resolves to on a city this
 // build must not serve: every operation fails with the refusal that says why and

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -774,10 +774,10 @@ func openBdByIDClassFrontDoor(cityPath string) (bdByIDClassDoor, bool, error) {
 // itself. There is exactly one implementation of "does this binding hold this
 // id" in the tree that knows about the boot census, and a second answer taken
 // locally would be blind to it — so the answer is asked for where it is known,
-// not recomputed where it isn't. (hookClaimClassRoute.holds, in
-// claim_class_route.go, is the last probe still asking the binding directly and
-// still census-blind; ga-qdt5y.16 tracks it, and it is why this comment does
-// not claim the divergence is closed.)
+// not recomputed where it isn't. hookClaimClassRoute.holds was the last probe
+// still asking the binding directly; ga-qdt5y.16 collapsed it onto the same
+// plan, over a frame it captures once at construction, so there is no longer a
+// second spelling of this judgement anywhere in cmd/gc.
 //
 // The probe is why an id with no reserved prefix is asked about at all: `gc
 // storage migrate` copies the work store's infrastructure slice with its ids

--- a/cmd/gc/cmd_bd_by_id_test.go
+++ b/cmd/gc/cmd_bd_by_id_test.go
@@ -2076,24 +2076,53 @@ func (s *countingClassStore) IDPrefix() string {
 // not named for the counting alone.
 func installCountedClassBinding(t *testing.T, cityPath string, relicFree bool) *countingClassStore {
 	t.Helper()
+	return installCountedClassBindingWrapped(t, cityPath, relicFree, func(c *countingClassStore) beads.Store { return c })
+}
+
+// installCountedClassBindingWrapped is the same installation with one more
+// wrapper around the counter before it goes into the routes.
+//
+// The counter embeds the beads.Store INTERFACE, so it declares no capability its
+// leaf has beyond Get and IDPrefix. That is right for the by-id door, which asks
+// for none — and wrong for the claim route, which is refused at construction by
+// a binding with no two-argument CAS (newHookClaimClassRoute). A route test
+// therefore needs a counter that forwards Claim, and forwarding it from the
+// counter itself would be worse than a second wrapper: every counted binding
+// would then ADVERTISE a capability its leaf may not have, which is the exact
+// thing the CAS gate exists to catch.
+//
+// wrap must return a store that still reaches the counter for Get — the count is
+// the only observable retirement has — and must forward IDPrefix for the same
+// reason the counter does, or the binding's mint bit reads false and the probe
+// stays for a reason that has nothing to do with the tier under test. It is
+// called exactly once; the store it returns is the binding's identity, so the
+// census verdict and the derivation check below are both keyed to that value and
+// not to the counter underneath it.
+func installCountedClassBindingWrapped(t *testing.T, cityPath string, relicFree bool, wrap func(*countingClassStore) beads.Store) *countingClassStore {
+	t.Helper()
 	routes := cliStorageRoutes(cityPath)
 	if routes == nil {
 		t.Fatal("the city resolved no routes to count")
 	}
 	var counter *countingClassStore
+	var installed beads.Store
 	restore := make(map[coordclass.Class]beads.Store, len(routes.stores))
 	for class, previous := range routes.stores {
 		restore[class] = previous
 		if counter == nil {
 			counter = &countingClassStore{Store: previous}
+			installed = wrap(counter)
 		}
-		routes.stores[class] = counter
+		routes.stores[class] = installed
 	}
 	if counter == nil {
 		t.Fatal("the city relocated no class store to count")
 	}
+	if installed == nil {
+		t.Fatal("wrap returned no store to install; the binding would read as absent rather than counted")
+	}
 	previousRelics := routes.relics
-	routes.relics = map[beads.Store]bool{counter: !relicFree}
+	routes.relics = map[beads.Store]bool{installed: !relicFree}
 	dropDerivedResidencyMemo(t, cityPath)
 	t.Cleanup(func() {
 		routes.relics = previousRelics
@@ -2117,7 +2146,7 @@ func installCountedClassBinding(t *testing.T, cityPath string, relicFree bool) *
 	if len(bindings) != 1 {
 		t.Fatalf("the counted city derives %d bindings, want the one this fixture serves; a count taken from one of several says nothing about the others", len(bindings))
 	}
-	if bindings[0].Leg.Store != beads.Store(counter) {
+	if bindings[0].Leg.Store != installed {
 		t.Fatalf("the door's binding resolves to %T, not the installed counter; the reads this row measures are happening somewhere it cannot see", bindings[0].Leg.Store)
 	}
 	if bindings[0].HasLegacyResidents == relicFree {

--- a/cmd/gc/cmd_start_warmup_routing_test.go
+++ b/cmd/gc/cmd_start_warmup_routing_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"github.com/gastownhall/gascity/internal/warmup"
 )
 
@@ -227,13 +228,15 @@ func TestWarmupMailRefusesOnAnUnconvergedCity(t *testing.T) {
 	// The refusal is asserted structurally rather than by its text: mail's
 	// sender-address read goes through session.ResolveAddress, whose error
 	// hygiene deliberately keeps the cause out of Error() while still
-	// unwrapping to it. isStandingStorageRefusal is the predicate that survives
+	// unwrapping to it. storeref.IsStandingRefusal is the predicate that survives
 	// that, and it says the precise thing — this is the build's verdict about
-	// the CITY, not a fault in one read. The remedy the operator acts on is on
-	// stderr, asserted next.
+	// the CITY, not a fault in one read. It is the resolver's own predicate, the
+	// one whose leg policy decides which refusals a residence probe may tolerate,
+	// so this row and that policy cannot disagree about what a refusal is. The
+	// remedy the operator acts on is on stderr, asserted next.
 	if _, err := provider.Send("gc-start-warmup", "mayor", "city warm-up: 2 doctor check(s) failed", "body"); err == nil {
 		t.Error("warm-up mail was accepted on a city that has not converged onto its binding")
-	} else if !isStandingStorageRefusal(err) {
+	} else if !storeref.IsStandingRefusal(err) {
 		t.Errorf("the refused warm-up send failed for some other reason than the storage refusal: %v", err)
 	}
 	if !strings.Contains(stderr.String(), storageMigrationCommand) {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -61,35 +61,71 @@ func (f waitDependencyReaderFunc) Get(id string) (beads.Bead, error) {
 	return f(id)
 }
 
-type waitDependencyStoreSet []beads.Store
+// errWaitDependencyUnproven marks a dependency lookup that found nothing over a
+// frame narrower than the city. It is deliberately NOT beads.ErrNotFound:
+// prepareWaitWakeStateWithSnapshot FAILS a wait on a proved absence, which is
+// terminal and destructive, so "no leg could answer" must never arrive wearing
+// the same error as "this bead does not exist".
+var errWaitDependencyUnproven = errors.New("wait dependency absence not proved: no leg could answer")
 
-func (s waitDependencyStoreSet) Get(id string) (beads.Bead, error) {
-	return storeref.Resolve(id, []beads.Store(s))
+// waitDependencyPlanReader resolves a wait's dependency beads through the
+// residency resolver's BY-ID door, over a topology the caller captured once,
+// instead of over a store list assembled here.
+//
+// # Why ByID and not the work federation
+//
+// A wait dependency is read BY ID, and the binding leads for an id inside a
+// relocated class's reserved namespace: that is what makes a graph-class step a
+// wait can watch visible at all (#5488), and it is what stops the read landing
+// on the frozen pre-migration twin `gc storage migrate` left in the work ledger
+// when the id was minted before the cutover and preserved across it (ga-cu12x).
+// The list this replaced went through storeref.Resolve, whose PrefixOwner fast
+// path routes on the id's own prefix and therefore answered every such id from
+// the retained copy no matter which store the caller put first.
+//
+// Outside every reserved namespace the plan is the house by-id order — the
+// unretired binding residence probes, then the city work ledger, then the rig
+// legs whose configured prefix covers the id — so a co-resident id still answers
+// from the copy `gc ready` serves and the claim lands on.
+//
+// # The topology is captured, not re-derived
+//
+// Re-planning per dependency from a city path could open a second engine on a
+// binding root and answer from a different handle than the one the tick's other
+// reads used. The plan itself is per-id (a ByID plan is id-specific), but every
+// plan is cut from the one captured frame.
+type waitDependencyPlanReader struct {
+	topo storeref.Topology
+	// narrowed records that the serving frame excluded a rig the config still
+	// declares. A bead in a suspended rig is out of FRAME, not out of the city,
+	// so absence over the narrowed frame is not proof and must not fail a wait
+	// that the rig would satisfy once it is unsuspended.
+	narrowed bool
 }
 
-// newWaitDependencyStoreSet assembles the legs a wait's dependency ids resolve
-// against. Without the graph leg a binding-resident dependency misses on every
-// leg, and prepareWaitWakeState reads that ErrNotFound as proof the dependency
-// is gone: a silent FailWait. It leads because the binding is authoritative.
-func newWaitDependencyStoreSet(cityStore beads.Store, rigStores map[string]beads.Store, graphStore beads.GraphStore) waitDependencyStoreSet {
-	stores := make(waitDependencyStoreSet, 0, 2+len(rigStores))
-	if graphStore.Store != nil && graphStore.Store != cityStore {
-		stores = append(stores, graphStore.Store)
+// newWaitDependencyPlanReader captures the frame the dependency reads plan over.
+func newWaitDependencyPlanReader(topo storeref.Topology, narrowedBySuspension bool) waitDependencyPlanReader {
+	return waitDependencyPlanReader{topo: topo, narrowed: narrowedBySuspension}
+}
+
+// Get answers three ways, and keeping them distinct is the point of the type: a
+// hit, a PROVED absence (beads.ErrNotFound, which fails the wait), and an
+// unproved one (errWaitDependencyUnproven, which retains it).
+//
+// A read that FAILED is neither: it surfaces as itself. The resolver's by-id
+// plan makes every leg fatal, and a fault is never flattened into absence here
+// — the pass reports it and retries on the next tick rather than reaping a
+// waiter over a store it could not read.
+func (r waitDependencyPlanReader) Get(id string) (beads.Bead, error) {
+	bead, err := byIDBeadForTopology(r.topo, id)
+	switch {
+	case err == nil:
+		return bead, nil
+	case errors.Is(err, beads.ErrNotFound) && r.narrowed:
+		return beads.Bead{}, fmt.Errorf("%w: a suspended rig is out of frame", errWaitDependencyUnproven)
+	default:
+		return beads.Bead{}, err
 	}
-	if cityStore != nil {
-		stores = append(stores, cityStore)
-	}
-	rigNames := make([]string, 0, len(rigStores))
-	for name := range rigStores {
-		rigNames = append(rigNames, name)
-	}
-	sort.Strings(rigNames)
-	for _, name := range rigNames {
-		if store := rigStores[name]; store != nil {
-			stores = append(stores, store)
-		}
-	}
-	return stores
 }
 
 func newWaitCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -919,9 +955,18 @@ func depsWaitReadyDetailedFrom(dependencies waitDependencyReader, wait sessionpk
 	closedCount := 0
 	foundAny := false
 	var missingErr error
+	// An unproved absence can neither ready a wait nor fail one, so it is carried
+	// to the end: a later dependency may still answer the question outright.
+	var unprovenErr error
 	for _, depID := range depIDs {
 		dep, err := dependencies.Get(depID)
 		if err != nil {
+			if errors.Is(err, errWaitDependencyUnproven) {
+				if unprovenErr == nil {
+					unprovenErr = fmt.Errorf("dependency %s: %w", depID, err)
+				}
+				continue
+			}
 			if errors.Is(err, beads.ErrNotFound) {
 				if mode != "any" {
 					return false, fmt.Errorf("dependency %s: %w", depID, err)
@@ -940,6 +985,12 @@ func depsWaitReadyDetailedFrom(dependencies waitDependencyReader, wait sessionpk
 				return true, nil
 			}
 		}
+	}
+	if unprovenErr != nil {
+		// Reported ahead of missingErr on purpose: if one dependency could not be
+		// read, "every dependency is missing" is not proved either, so the wait
+		// must pend rather than fail.
+		return false, unprovenErr
 	}
 	if mode == "any" {
 		if !foundAny && missingErr != nil {
@@ -1105,6 +1156,13 @@ func prepareWaitWakeStateWithSnapshot(sessFront *sessionpkg.Store, dependencies 
 		// scope, so resolution is the caller's, through the legs it assembled.
 		ready, depErr := depsWaitReadyDetailedFrom(dependencies, wait)
 		if depErr != nil {
+			if errors.Is(depErr, errWaitDependencyUnproven) {
+				// Retain THIS wait and keep going. The frame is narrower than the
+				// city — a suspended rig is out of it — so absence over that frame
+				// is not the proof this pass reaps a waiter on.
+				log.Printf("gc wait: wait %s: %v; retaining the wait for the next pass", wait.ID, depErr)
+				continue
+			}
 			if errors.Is(depErr, beads.ErrNotFound) {
 				if err := sessFront.FailWait(wait.ID, now, depErr.Error()); err != nil {
 					return nil, err

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -1001,6 +1001,26 @@ func depsWaitReadyDetailedFrom(dependencies waitDependencyReader, wait sessionpk
 	return closedCount == len(depIDs), nil
 }
 
+// loadWaitDependencyBead reads a wait's dependency on the ONE-SHOT plane.
+//
+// The binding is resolved FIRST, and the scan below is only what answers for an
+// id no binding holds. The scan's work axis is the city's store DIRECTORIES, and
+// a relocated class binding is not one of them — so before this leg went in
+// front, a dependency `gc storage migrate` had moved was not merely unrouted. The
+// scan answered, successfully, with the permanently-open copy the migration
+// retained in the city store, and a waiter on that dependency slept forever.
+//
+// Same defect the controller arm carried (waitDependencyPlanReader's
+// predecessor, ga-qdt5y.16), reached by a different code path; both arms now end
+// on the resolver.
+//
+// #5488 put a classBindingForID probe here first, which closed the blindness but
+// restated the judgement: its own class-leads rule, its own refusal arm, and a
+// second Get of a row the probe had already read. cliByIDBindingOwner is the
+// same question asked of storeref — the binding leads for an id inside its
+// reserved namespace, every unretired binding is a residence probe for an id
+// inside none, a refusal is classified by the leg's role, and beadForOwner
+// consumes the row the winning probe already paid for.
 func loadWaitDependencyBead(cityPath string, cityStore beads.Store, depID string) (beads.Bead, error) {
 	if strings.TrimSpace(cityPath) == "" {
 		if cityStore == nil {
@@ -1008,12 +1028,12 @@ func loadWaitDependencyBead(cityPath string, cityStore beads.Store, depID string
 		}
 		return cityStore.Get(depID)
 	}
-	// The binding is not a work scope, so no candidate below covers it. Probed
-	// first for the same retained-copy reason as newWaitDependencyStoreSet.
-	if binding, ok, err := classBindingForID(cityPath, depID); err != nil {
+	owner, ownedByBinding, err := cliByIDBindingOwner(cityPath, depID)
+	if err != nil {
 		return beads.Bead{}, err
-	} else if ok {
-		return binding.Get(depID)
+	}
+	if ownedByBinding {
+		return beadForOwner(owner, depID)
 	}
 	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -96,16 +96,43 @@ var errWaitDependencyUnproven = errors.New("wait dependency absence not proved: 
 // plan is cut from the one captured frame.
 type waitDependencyPlanReader struct {
 	topo storeref.Topology
-	// narrowed records that the serving frame excluded a rig the config still
-	// declares. A bead in a suspended rig is out of FRAME, not out of the city,
-	// so absence over the narrowed frame is not proof and must not fail a wait
-	// that the rig would satisfy once it is unsuspended.
-	narrowed bool
+	// outOfFrame says what this frame leaves out of the city, or is empty when
+	// it leaves out nothing. A bead the frame cannot reach is out of FRAME, not
+	// out of the city, so a miss over it is not proof and must not fail a wait
+	// the whole city would satisfy.
+	outOfFrame string
 }
 
-// newWaitDependencyPlanReader captures the frame the dependency reads plan over.
+// newWaitDependencyPlanReader captures the frame the dependency reads plan over,
+// and what that frame leaves out.
 func newWaitDependencyPlanReader(topo storeref.Topology, narrowedBySuspension bool) waitDependencyPlanReader {
-	return waitDependencyPlanReader{topo: topo, narrowed: narrowedBySuspension}
+	return waitDependencyPlanReader{topo: topo, outOfFrame: waitFrameGap(topo, narrowedBySuspension)}
+}
+
+// waitFrameGap names every part of the city this frame cannot answer for.
+//
+// Two things put a store out of frame, and they arrive from opposite
+// directions. Suspension is TOLD to the constructor: the caller already dropped
+// the rig from the serving set, so the leg is simply not there. A prefix fault
+// is READ off the frame itself: the leg is there, and the by-id plan declines
+// to reach it because the prefix the city configured for that rig is not the
+// prefix its store declares (storeref.Topology.PrefixFaults).
+//
+// A rig leg the plan gates out on an AGREEING prefix is neither, and must not
+// be listed here. Gating on the configured prefix is how absence stays provable
+// at all: on any multi-rig city most legs are gated out of most by-id plans, so
+// a rule that called every one of them a gap would make "this dependency is
+// gone" unprovable and a wait on a genuinely deleted dependency would pend
+// forever.
+func waitFrameGap(topo storeref.Topology, narrowedBySuspension bool) string {
+	var gaps []string
+	if narrowedBySuspension {
+		gaps = append(gaps, "a suspended rig is out of frame")
+	}
+	for _, fault := range topo.PrefixFaults() {
+		gaps = append(gaps, fault.String())
+	}
+	return strings.Join(gaps, "; ")
 }
 
 // Get answers three ways, and keeping them distinct is the point of the type: a
@@ -121,8 +148,8 @@ func (r waitDependencyPlanReader) Get(id string) (beads.Bead, error) {
 	switch {
 	case err == nil:
 		return bead, nil
-	case errors.Is(err, beads.ErrNotFound) && r.narrowed:
-		return beads.Bead{}, fmt.Errorf("%w: a suspended rig is out of frame", errWaitDependencyUnproven)
+	case errors.Is(err, beads.ErrNotFound) && r.outOfFrame != "":
+		return beads.Bead{}, fmt.Errorf("%w: %s", errWaitDependencyUnproven, r.outOfFrame)
 	default:
 		return beads.Bead{}, err
 	}
@@ -1178,7 +1205,8 @@ func prepareWaitWakeStateWithSnapshot(sessFront *sessionpkg.Store, dependencies 
 		if depErr != nil {
 			if errors.Is(depErr, errWaitDependencyUnproven) {
 				// Retain THIS wait and keep going. The frame is narrower than the
-				// city — a suspended rig is out of it — so absence over that frame
+				// city — a suspended rig is out of it, and so is a rig whose store
+				// declares a prefix its config does not — so a miss over that frame
 				// is not the proof this pass reaps a waiter on.
 				log.Printf("gc wait: wait %s: %v; retaining the wait for the next pass", wait.ID, depErr)
 				continue

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -22,9 +22,11 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/overlay"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/storeref"
 	"golang.org/x/mod/semver"
 )
 
@@ -47,6 +49,43 @@ type waitPrefixedStore struct {
 }
 
 func (s waitPrefixedStore) IDPrefix() string { return s.prefix }
+
+// waitDependencyReaderOver is the unsuspended, binding-free frame most wait
+// tests want: the city work store leading and the named rigs behind it, which is
+// the leg set these tests read before the reader planned through storeref.
+//
+// The config is synthesized from the prefixes the stores themselves declare
+// because the by-id plan's shadow rule is CONFIGURED-prefix gated: a rig leg
+// whose Prefix is empty covers no id and is out of every plan, so a topology
+// assembled with a nil config would drop the rig these rows are about. A real
+// city always supplies them (config.Rig.EffectivePrefix derives one from the rig
+// name when none is set), and cr.residencyTopology reads them off cr.cfg.
+func waitDependencyReaderOver(cityStore beads.Store, rigStores map[string]beads.Store) waitDependencyReader {
+	cfg := &config.City{}
+	cfg.Workspace.Prefix = declaredStoreIDPrefix(cityStore)
+	for _, name := range sortedStoreNames(rigStores) {
+		cfg.Rigs = append(cfg.Rigs, config.Rig{Name: name, Prefix: declaredStoreIDPrefix(rigStores[name])})
+	}
+	return newWaitDependencyPlanReader(assembleResidencyTopology(cfg, cityStore, rigStores, nil, nil), false)
+}
+
+// declaredStoreIDPrefix reads the prefix a test store declares, which is what
+// the city's config would have declared for it.
+func declaredStoreIDPrefix(store beads.Store) string {
+	if p, ok := store.(storeref.HasIDPrefix); ok {
+		return p.IDPrefix()
+	}
+	return ""
+}
+
+func sortedStoreNames(stores map[string]beads.Store) []string {
+	names := make([]string, 0, len(stores))
+	for name := range stores {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
 
 type waitDependencyGetErrorStore struct {
 	beads.Store
@@ -2528,7 +2567,7 @@ func TestDoSessionWait_RegistersReadyWaitForRigDependency(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := doSessionWait(sessionID, []string{depID}, false, "block", false, &stdout, &stderr, sessionWaitDeps{
 		sessions:         sessionFrontDoor(cityStore),
-		dependencies:     newWaitDependencyStoreSet(cityStore, map[string]beads.Store{"frontend": rigStore}, beads.GraphStore{}),
+		dependencies:     waitDependencyReaderOver(cityStore, map[string]beads.Store{"frontend": rigStore}),
 		now:              func() time.Time { return now },
 		createdBySession: originID,
 	})
@@ -2665,6 +2704,368 @@ prefix = "fe"
 	}
 }
 
+// The session and the wait are the same in every row below; only the dependency
+// and the store frame vary, which is what those rows are about.
+const (
+	waitWakeSessionID = "gcg-session-1"
+	waitWakeWaitID    = "gcg-wait-1"
+)
+
+// waitWakeCityStore builds the city work store every wake-state test starts
+// from: one open session and one pending deps-wait on depID.
+func waitWakeCityStore(now time.Time, depID string, extra ...beads.Bead) waitPrefixedStore {
+	seed := []beads.Bead{
+		{
+			ID:        waitWakeSessionID,
+			Title:     "worker session",
+			Type:      sessionBeadType,
+			Status:    "open",
+			Labels:    []string{sessionBeadLabel},
+			CreatedAt: now.Add(-time.Minute),
+			UpdatedAt: now.Add(-time.Minute),
+			Revision:  1,
+			Metadata: map[string]string{
+				"session_name":       "worker",
+				"agent_name":         "worker",
+				"continuation_epoch": "1",
+			},
+		},
+		{
+			ID:        waitWakeWaitID,
+			Title:     "wait:worker session",
+			Type:      waitBeadType,
+			Status:    "open",
+			Labels:    []string{waitBeadLabel, "session:" + waitWakeSessionID},
+			CreatedAt: now.Add(-time.Minute),
+			UpdatedAt: now.Add(-time.Minute),
+			Revision:  1,
+			Metadata: map[string]string{
+				"session_id":       waitWakeSessionID,
+				"session_name":     "worker",
+				"kind":             "deps",
+				"state":            waitStatePending,
+				"dep_ids":          depID,
+				"dep_mode":         "all",
+				"registered_epoch": "1",
+				"delivery_attempt": "1",
+			},
+		},
+	}
+	seed = append(seed, extra...)
+	return waitPrefixedStore{Store: beads.NewMemStoreFrom(len(seed), seed, nil), prefix: "gcg"}
+}
+
+func waitDepBead(now time.Time, depID, status string) beads.Bead {
+	return beads.Bead{
+		ID:        depID,
+		Title:     "dependency",
+		Type:      "task",
+		Status:    status,
+		CreatedAt: now.Add(-time.Minute),
+		UpdatedAt: now.Add(-time.Minute),
+		Revision:  1,
+	}
+}
+
+// assertWaitStillOpen reads the wait back and checks the pair that decides
+// whether a waiter survived the pass. The status is asserted open in every row
+// because that is the outcome under test: a wait the pass failed is closed, so
+// no row here may pass while the waiter was reaped.
+func assertWaitStillOpen(t *testing.T, store beads.Store, wantState string) {
+	t.Helper()
+	wait, err := store.Get(waitWakeWaitID)
+	if err != nil {
+		t.Fatalf("store.Get(wait): %v", err)
+	}
+	if got := wait.Metadata["state"]; got != wantState {
+		t.Fatalf("wait state = %q, want %q", got, wantState)
+	}
+	if wait.Status != "open" {
+		t.Fatalf("wait status = %q, want open", wait.Status)
+	}
+}
+
+// TestPrepareWaitWakeState_DarkCityWorkLegStillAbortsThePass is the CONTROL for
+// the dark-rig row above. A rig leg degrades and the pass goes on; the city work
+// leg is the authority and its going dark is a pass-level fault, so this row
+// asserts the error IS returned. Without it, a reader that simply stopped
+// reporting every leg failure would satisfy the dark-rig row.
+func TestPrepareWaitWakeState_DarkCityWorkLegStillAbortsThePass(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "ga-dep-1"
+	hardErr := errors.New("city work store unavailable")
+	cityStore := waitWakeCityStore(now, depID)
+	darkWork := waitDependencyGetErrorStore{Store: cityStore, prefix: "gcg", err: hardErr}
+
+	_, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		waitDependencyReaderOver(darkWork, nil),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	)
+	if !errors.Is(err, hardErr) {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot error = %v, want %v", err, hardErr)
+	}
+	assertWaitStillOpen(t, cityStore, waitStatePending)
+}
+
+// TestPrepareWaitWakeState_SuspendedFrameRetainsAnUnprovedWait pins the edge
+// that dropping suspended rigs opens: the frame is narrower than the city, so a
+// dependency found nowhere in it is out of FRAME, not proved absent, and the
+// waiter must survive to be re-read once the rig serves again.
+func TestPrepareWaitWakeState_SuspendedFrameRetainsAnUnprovedWait(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "ga-dep-1"
+	cityStore := waitWakeCityStore(now, depID)
+
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		newWaitDependencyPlanReader(assembleResidencyTopology(nil, cityStore, nil, nil, nil), true),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+	}
+	if readyWaitSet[waitWakeSessionID] {
+		t.Fatalf("readyWaitSet[%s] = true, want false", waitWakeSessionID)
+	}
+	assertWaitStillOpen(t, cityStore, waitStatePending)
+}
+
+// TestPrepareWaitWakeState_ResolvesBindingResidentDependency covers the leg the
+// hand-rolled list did not have at all. Before the plan, a dependency relocated
+// into a class binding resolved not-found on a split city and the wait was
+// actively FAILED — worse than blindness.
+func TestPrepareWaitWakeState_ResolvesBindingResidentDependency(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "gcb-dep-1"
+	cityStore := waitWakeCityStore(now, depID)
+	bindingStore := waitPrefixedStore{
+		Store:  beads.NewMemStoreFrom(1, []beads.Bead{waitDepBead(now, depID, "closed")}, nil),
+		prefix: "gcb",
+	}
+	bindings, refused := soleBindingResidency(bindingStore)
+	if refused != nil {
+		t.Fatalf("soleBindingResidency: %v", refused)
+	}
+
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		newWaitDependencyPlanReader(assembleResidencyTopology(nil, cityStore, nil, bindings, nil), false),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+	}
+	if !readyWaitSet[waitWakeSessionID] {
+		t.Fatalf("readyWaitSet[%s] = false, want true", waitWakeSessionID)
+	}
+	assertWaitStillOpen(t, cityStore, waitStateReady)
+}
+
+// waitWakeMigratedCityStore is waitWakeCityStore under the WORK-ERA id prefix a
+// city carried before its infrastructure classes were relocated. The prefix is
+// what the retained-copy rows below turn on: storeref.Resolve consults the store
+// whose self-declared IDPrefix owns the id first, so an id minted under this
+// prefix and preserved across the cutover resolved to this store and not to the
+// binding it was migrated into.
+func waitWakeMigratedCityStore(now time.Time, depID string, extra ...beads.Bead) waitPrefixedStore {
+	return waitPrefixedStore{Store: waitWakeCityStore(now, depID, extra...).Store, prefix: "hq"}
+}
+
+// TestPrepareWaitWakeState_MigrationPreservedDependencyAnswersFromTheBinding is
+// the row ga-cu12x names: `gc storage migrate` COPIES AND RETAINS and it
+// PRESERVES ids, so an infrastructure bead minted before the cutover keeps its
+// work-era prefix and exists twice — a frozen row in the work ledger and the
+// live row in the binding.
+//
+// The reader this replaced went through storeref.Resolve, whose PrefixOwner fast
+// path consults the store whose declared IDPrefix owns the id FIRST. For
+// "hq-dep-1" that is the city work store, so the wait read the frozen
+// pre-migration copy — successfully, with no error to notice — no matter which
+// leg the caller put first, which is why #5488's binding-first list did not
+// close this one. The by-id plan has no such fast path: an id inside NO
+// binding's reserved namespace is a migrate-preserved relic candidate, and every
+// binding that has not retired its residence probe is asked BEFORE the work
+// ledger.
+func TestPrepareWaitWakeState_MigrationPreservedDependencyAnswersFromTheBinding(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	// A work-era prefix, not a reserved one: no binding namespace claims it.
+	const depID = "hq-dep-1"
+	// The frozen twin the migration left behind, still OPEN as of the cutover.
+	cityStore := waitWakeMigratedCityStore(now, depID, waitDepBead(now, depID, "open"))
+	// The live row, closed after the cutover.
+	binding := waitPrefixedStore{
+		Store:  beads.NewMemStoreFrom(1, []beads.Bead{waitDepBead(now, depID, "closed")}, nil),
+		prefix: "gcb",
+	}
+	bindings, refused := soleBindingResidency(binding)
+	if refused != nil {
+		t.Fatalf("soleBindingResidency: %v", refused)
+	}
+
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		newWaitDependencyPlanReader(assembleResidencyTopology(nil, cityStore, nil, bindings, nil), false),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+	}
+	if !readyWaitSet[waitWakeSessionID] {
+		t.Fatalf("readyWaitSet[%s] = false, want true; the wait read the work ledger's frozen pre-migration copy instead of the binding's live row", waitWakeSessionID)
+	}
+	assertWaitStillOpen(t, cityStore, waitStateReady)
+}
+
+// TestWaitDependencyPlanReaderBindingFaultIsAnErrorNeverAbsence is the fault
+// control for the row above. A binding that cannot be read has said NOTHING
+// about the dependency, and the wake pass reaps a waiter on a proved absence —
+// so the one thing this reader may never do is spell a fault as beads.ErrNotFound.
+func TestWaitDependencyPlanReaderBindingFaultIsAnErrorNeverAbsence(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "hq-dep-1"
+	hardErr := errors.New("binding store unavailable")
+	cityStore := waitWakeMigratedCityStore(now, depID, waitDepBead(now, depID, "open"))
+	binding := waitDependencyGetErrorStore{
+		Store:  beads.NewMemStore(),
+		prefix: "gcb",
+		err:    hardErr,
+	}
+	bindings, refused := soleBindingResidency(binding)
+	if refused != nil {
+		t.Fatalf("soleBindingResidency: %v", refused)
+	}
+	reader := newWaitDependencyPlanReader(assembleResidencyTopology(nil, cityStore, nil, bindings, nil), false)
+
+	_, err := reader.Get(depID)
+	if !errors.Is(err, hardErr) {
+		t.Fatalf("Get(%s) error = %v, want %v; the work ledger's frozen copy must not answer for a binding that could not be read", depID, err, hardErr)
+	}
+	if errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get(%s) error = %v, must not wear beads.ErrNotFound: the wake pass fails a wait on a proved absence", depID, err)
+	}
+	if errors.Is(err, errWaitDependencyUnproven) {
+		t.Fatalf("Get(%s) error = %v, must not be downgraded to an unproven absence: a fault the operator has to see would then only be logged", depID, err)
+	}
+}
+
+// TestWaitDependencyPlanReaderSingleStoreCityIsByteIdentical is the control that
+// a city with nothing relocated pays nothing and answers exactly as its own
+// store does — the same value on a hit, and a proved absence on a miss.
+func TestWaitDependencyPlanReaderSingleStoreCityIsByteIdentical(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "hq-dep-1"
+	cityStore := waitWakeMigratedCityStore(now, depID, waitDepBead(now, depID, "closed"))
+	reader := newWaitDependencyPlanReader(assembleResidencyTopology(nil, cityStore, nil, nil, nil), false)
+
+	got, err := reader.Get(depID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", depID, err)
+	}
+	want, err := cityStore.Get(depID)
+	if err != nil {
+		t.Fatalf("cityStore.Get(%s): %v", depID, err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Get(%s) = %+v, want the store's own row %+v", depID, got, want)
+	}
+
+	_, missErr := reader.Get("hq-absent")
+	if !errors.Is(missErr, beads.ErrNotFound) {
+		t.Fatalf("Get(hq-absent) error = %v, want beads.ErrNotFound", missErr)
+	}
+	if errors.Is(missErr, errWaitDependencyUnproven) {
+		t.Fatalf("Get(hq-absent) error = %v; a complete frame proves absence, and a wait whose dependency is gone must still fail", missErr)
+	}
+}
+
+// TestPrepareWaitWakeState_CoResidentDependencyAnswersFromTheWorkStore pins the
+// deliberate flip in delta (d): storeref.Resolve consulted the store whose
+// self-declared IDPrefix owned the id FIRST, so a rig copy shadowed the work
+// ledger's. The plan reads work first (#5148), which is the copy `gc ready`
+// serves and the claim lands on, so the wait now agrees with them.
+func TestPrepareWaitWakeState_CoResidentDependencyAnswersFromTheWorkStore(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "ga-dep-1"
+	cityStore := waitWakeCityStore(now, depID, waitDepBead(now, depID, "closed"))
+	rigStore := waitPrefixedStore{
+		Store:  beads.NewMemStoreFrom(1, []beads.Bead{waitDepBead(now, depID, "open")}, nil),
+		prefix: "ga",
+	}
+
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		waitDependencyReaderOver(cityStore, map[string]beads.Store{"frontend": rigStore}),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+	}
+	if !readyWaitSet[waitWakeSessionID] {
+		t.Fatalf("readyWaitSet[%s] = false, want true; the rig's open copy shadowed the work store's closed one", waitWakeSessionID)
+	}
+	assertWaitStillOpen(t, cityStore, waitStateReady)
+}
+
+// TestDepsWaitReadyUnprovenDependencyNeitherFailsNorReadies pins the three-valued
+// contract at the layer that consumes it: an unproved absence is not a not-found
+// (which would fail the wait) and not a hit (which could ready it).
+func TestDepsWaitReadyUnprovenDependencyNeitherFailsNorReadies(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	unproven := fmt.Errorf("%w: rig frontend went dark", errWaitDependencyUnproven)
+
+	t.Run("all mode reports unproven without failing", func(t *testing.T) {
+		reader := waitDependencyReaderFunc(func(string) (beads.Bead, error) { return beads.Bead{}, unproven })
+		ready, err := depsWaitReadyDetailedFrom(reader, sessionpkg.WaitInfo{DepIDs: []string{"ga-1"}, DepMode: "all"})
+		if ready {
+			t.Fatal("ready = true, want false")
+		}
+		if !errors.Is(err, errWaitDependencyUnproven) {
+			t.Fatalf("err = %v, want an unproven error", err)
+		}
+		if errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("err = %v, must not wear beads.ErrNotFound: that would fail the wait", err)
+		}
+	})
+
+	t.Run("any mode still readies on a closed sibling", func(t *testing.T) {
+		reader := waitDependencyReaderFunc(func(id string) (beads.Bead, error) {
+			if id == "ga-2" {
+				return waitDepBead(now, id, "closed"), nil
+			}
+			return beads.Bead{}, unproven
+		})
+		ready, err := depsWaitReadyDetailedFrom(reader, sessionpkg.WaitInfo{DepIDs: []string{"ga-1", "ga-2"}, DepMode: "any"})
+		if err != nil {
+			t.Fatalf("depsWaitReadyDetailedFrom: %v", err)
+		}
+		if !ready {
+			t.Fatal("ready = false, want true")
+		}
+	})
+
+	t.Run("any mode does not fail when every dependency is unproven", func(t *testing.T) {
+		reader := waitDependencyReaderFunc(func(string) (beads.Bead, error) { return beads.Bead{}, unproven })
+		ready, err := depsWaitReadyDetailedFrom(reader, sessionpkg.WaitInfo{DepIDs: []string{"ga-1", "ga-2"}, DepMode: "any"})
+		if ready {
+			t.Fatal("ready = true, want false")
+		}
+		if !errors.Is(err, errWaitDependencyUnproven) {
+			t.Fatalf("err = %v, want an unproven error", err)
+		}
+	})
+}
+
 func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {
 	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
 	hardErr := errors.New("rig store unavailable")
@@ -2681,7 +3082,15 @@ func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {
 		{name: "closed rig dependency becomes ready", depStatus: "closed", wantReady: true, wantState: waitStateReady, wantStatus: "open"},
 		{name: "open rig dependency remains pending", depStatus: "open", wantState: waitStatePending, wantStatus: "open"},
 		{name: "missing rig dependency fails the wait", missing: true, wantState: waitStateFailed, wantStatus: "closed"},
-		{name: "hard rig read error is preserved", readErr: hardErr, wantState: waitStatePending, wantStatus: "open"},
+		// A dark SERVING rig leg is still a pass-level fault, and the wait is
+		// retained pending rather than failed: the by-id plan makes every leg
+		// fatal, so the fault surfaces as itself and is never flattened into the
+		// proved absence that would reap the waiter. The suspended-rig freeze
+		// this segment fixes is closed one level up, by narrowing the FRAME
+		// (servingRigStores) so a suspended rig is out of the plan rather than
+		// dark inside it — see
+		// TestPrepareWaitWakeState_SuspendedFrameRetainsAnUnprovedWait.
+		{name: "dark serving rig is a preserved fault, not a proved absence", readErr: hardErr, wantState: waitStatePending, wantStatus: "open"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			const (
@@ -2752,14 +3161,14 @@ func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {
 
 			readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
 				sessionFrontDoor(cityStore),
-				newWaitDependencyStoreSet(cityStore, map[string]beads.Store{"frontend": rigStore}, beads.GraphStore{}),
+				waitDependencyReaderOver(cityStore, map[string]beads.Store{"frontend": rigStore}),
 				beads.NudgesStore{Store: cityStore},
 				now,
 				nil,
 			)
 			if tc.readErr != nil {
 				if !errors.Is(err, tc.readErr) {
-					t.Fatalf("prepareWaitWakeStateWithSnapshot error = %v, want %v", err, tc.readErr)
+					t.Fatalf("prepareWaitWakeStateWithSnapshot error = %v, want %v; a leg that could not be read must never reach the pass as absence", err, tc.readErr)
 				}
 			} else if err != nil {
 				t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
@@ -3410,8 +3819,14 @@ func TestRouteWaitList_ThreeRungByteIdentical(t *testing.T) {
 
 // TestPrepareWaitWakeState_ResolvesGraphBindingDependencyBeads pins that a
 // dependency living in the relocated infrastructure binding resolves. Without
-// the graph leg it misses on every leg, and a clean miss is consumed as proof
+// the binding leg it misses on every leg, and a clean miss is consumed as proof
 // the dependency was deleted — a silent FailWait, with no event and no wake.
+//
+// Ported from #5488, which pinned the same property against the hand-rolled
+// store list this reader replaced. The list put the binding FIRST and that leg
+// order is preserved here by the resolver rather than by hand: `gcg-dep-1` is
+// inside the graph class's reserved namespace, so the by-id plan makes the
+// binding the AUTHORITY leg and nothing behind it is consulted.
 func TestPrepareWaitWakeState_ResolvesGraphBindingDependencyBeads(t *testing.T) {
 	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
 
@@ -3487,9 +3902,16 @@ func TestPrepareWaitWakeState_ResolvesGraphBindingDependencyBeads(t *testing.T) 
 			}
 			rigStore := waitPrefixedStore{Store: beads.NewMemStore(), prefix: "ga"}
 
+			bindings, refused := soleBindingResidency(binding)
+			if refused != nil {
+				t.Fatalf("soleBindingResidency: %v", refused)
+			}
 			readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
 				sessionFrontDoor(cityStore),
-				newWaitDependencyStoreSet(cityStore, map[string]beads.Store{"frontend": rigStore}, beads.GraphStore{Store: binding}),
+				newWaitDependencyPlanReader(
+					assembleResidencyTopology(nil, cityStore, map[string]beads.Store{"frontend": rigStore}, bindings, nil),
+					false,
+				),
 				beads.NudgesStore{Store: cityStore},
 				now,
 				nil,

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -3968,3 +3968,85 @@ func TestLoadWaitDependencyBeadReadsTheBindingOnAMigratedCity(t *testing.T) {
 		t.Errorf("resolved %q, want the binding-resident dependency %q", got.ID, dep.ID)
 	}
 }
+
+// seedRelocatedWaitDependency builds the shape a finished `gc storage migrate`
+// leaves behind: one dependency id resident in BOTH the class binding and the
+// city work store, where the binding copy is the live one and the work copy is
+// the frozen row the migration retained.
+//
+// The two copies are given OPPOSITE statuses on purpose. A test that only
+// checked which title came back would pass on a reader that resolved correctly
+// by accident; asserting on status makes the fixture answer the operational
+// question instead — does the wait fire — and the two answers cannot coincide.
+func seedRelocatedWaitDependency(t *testing.T) (cityPath string, work beads.Store, depID string) {
+	t.Helper()
+	cityPath, _ = foreignProviderCity(t)
+	work = workStoreFor(t, cityPath)
+
+	frozen, err := work.Create(beads.Bead{Title: "the retained work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding the retained work copy: %v", err)
+	}
+	resident, classStore := classResidentWorkShapedBead(t, cityPath, frozen.ID, "the class-binding copy")
+
+	// The binding's copy is the one that moved on. The work copy stays open
+	// forever — nothing writes to it again after the migration.
+	if err := classStore.Close(resident.ID); err != nil {
+		t.Fatalf("closing the class-binding copy of %s: %v", resident.ID, err)
+	}
+	if reread, err := work.Get(frozen.ID); err != nil {
+		t.Fatalf("re-reading the retained work copy: %v", err)
+	} else if reread.Status == "closed" {
+		t.Fatalf("fixture premise broken: closing the binding copy also closed the work copy, so no reader can tell the two apart")
+	}
+	return cityPath, work, resident.ID
+}
+
+// TestWaitDependencyReadServesTheBindingCopy is the one-shot twin of the
+// controller-arm fix in ga-qdt5y.16 slice B, reached by a different code path.
+//
+// loadWaitDependencyBead resolved a dependency by scanning the city's store
+// DIRECTORIES, and a relocated class binding is not one of them. So a dependency
+// the migration moved was not merely unrouted: the scan answered, successfully,
+// with the permanently-open copy retained in the work store. The wait's
+// dependency then never reads closed and the waiter sleeps forever.
+func TestWaitDependencyReadServesTheBindingCopy(t *testing.T) {
+	cityPath, work, depID := seedRelocatedWaitDependency(t)
+
+	dep, err := loadWaitDependencyBead(cityPath, work, depID)
+	if err != nil {
+		t.Fatalf("reading wait dependency %s: %v", depID, err)
+	}
+	if dep.Title != "the class-binding copy" {
+		t.Errorf("wait dependency read served %q, want the class-binding copy — the scan answered from the frozen work copy", dep.Title)
+	}
+	if dep.Status != "closed" {
+		t.Errorf("wait dependency %s read status %q, want closed; a waiter on this dependency never wakes", depID, dep.Status)
+	}
+}
+
+// TestWaitReadiesOnADependencyTheMigrationRelocated asserts the consequence
+// rather than the lookup: the wait itself must fire.
+//
+// The read above and this one fail together today, but they are not the same
+// assertion — a reader could serve the right row and still be consumed by a
+// readiness rule that ignores it. Pinning both means neither half can regress
+// while the other keeps the suite green.
+func TestWaitReadiesOnADependencyTheMigrationRelocated(t *testing.T) {
+	cityPath, work, depID := seedRelocatedWaitDependency(t)
+
+	dependencies := waitDependencyReaderFunc(func(id string) (beads.Bead, error) {
+		return loadWaitDependencyBead(cityPath, work, id)
+	})
+	ready, err := depsWaitReadyDetailedFrom(dependencies, sessionpkg.WaitInfo{
+		ID:      waitWakeWaitID,
+		DepIDs:  []string{depID},
+		DepMode: "all",
+	})
+	if err != nil {
+		t.Fatalf("evaluating readiness against relocated dependency %s: %v", depID, err)
+	}
+	if !ready {
+		t.Errorf("wait on relocated dependency %s is not ready; its only dependency is closed in the binding that owns it", depID)
+	}
+}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -3058,6 +3058,65 @@ func TestPrepareWaitWakeState_PrefixUncoveredRigDependencyDoesNotReapTheWaiter(t
 	assertWaitStillOpen(t, cityStore, waitStatePending)
 }
 
+// TestPrepareWaitWakeState_AgreeingPrefixRigStillProvesTheDependencyGone is the
+// CONTROL for the row above, and it is the half that bounds the fix.
+//
+// It builds the same shape — a rig leg the by-id plan gates out of the frame for
+// this dependency — and changes exactly the one thing the fix is allowed to
+// read: the rig's configured prefix IS the prefix its store declares. Nothing
+// disagrees, so nothing is faulted, the gate is exact, and a dependency in no
+// leg of the plan is GONE. The wait is reaped, as it was before the row above
+// existed.
+//
+// Without this row the cheapest way to pass that row is to call every gated-out
+// leg unproven, and that would be a worse defect than the one it fixes: on a
+// multi-rig city most legs are gated out of most by-id plans, so absence could
+// be proved nowhere and a wait on a genuinely deleted dependency would pend
+// forever instead of failing. Mutating waitFrameGap to report every gated-out
+// leg turns this row red and leaves the row above green.
+func TestPrepareWaitWakeState_AgreeingPrefixRigStillProvesTheDependencyGone(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "ga-dep-1"
+	cityStore := waitWakeCityStore(now, depID)
+	// Empty, and gated out anyway: "fe" does not cover "ga-dep-1". The rig has
+	// nothing to say about this id and has not contradicted itself about which
+	// ids it holds, which is the whole difference from the row above.
+	rigStore := waitPrefixedStore{Store: beads.NewMemStore(), prefix: "fe"}
+	cfg := &config.City{}
+	cfg.Workspace.Prefix = declaredStoreIDPrefix(cityStore)
+	cfg.Rigs = append(cfg.Rigs, config.Rig{Name: "frontend", Prefix: declaredStoreIDPrefix(rigStore)})
+
+	readyWaitSet, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		newWaitDependencyPlanReader(
+			assembleResidencyTopology(cfg, cityStore, map[string]beads.Store{"frontend": rigStore}, nil, nil),
+			false,
+		),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+	}
+	if readyWaitSet[waitWakeSessionID] {
+		t.Fatalf("readyWaitSet[%s] = true, want false", waitWakeSessionID)
+	}
+	wait, err := cityStore.Get(waitWakeWaitID)
+	if err != nil {
+		t.Fatalf("store.Get(wait): %v", err)
+	}
+	if got := wait.Metadata["state"]; got != waitStateFailed {
+		t.Fatalf("wait state = %q, want %q; a gated-out leg whose two prefixes agree must leave absence provable", got, waitStateFailed)
+	}
+	if wait.Status != "closed" {
+		t.Fatalf("wait status = %q, want closed", wait.Status)
+	}
+	if wait.Metadata["last_error"] == "" {
+		t.Fatal("last_error was not recorded")
+	}
+}
+
 // TestDepsWaitReadyUnprovenDependencyNeitherFailsNorReadies pins the three-valued
 // contract at the layer that consumes it: an unproved absence is not a not-found
 // (which would fail the wait) and not a hit (which could ready it).

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -3017,6 +3017,47 @@ func TestPrepareWaitWakeState_CoResidentDependencyAnswersFromTheWorkStore(t *tes
 	assertWaitStillOpen(t, cityStore, waitStateReady)
 }
 
+// TestPrepareWaitWakeState_PrefixUncoveredRigDependencyDoesNotReapTheWaiter is
+// the row the shared helper cannot reach. waitDependencyReaderOver synthesizes
+// each rig's CONFIGURED prefix from the prefix its store declares, so the two
+// are equal by construction there and a mismatch between them is unobservable.
+//
+// The mismatch matters because the by-id plan gates its rig legs on the
+// configured prefix (shadowLegsCovering): a rig whose config says "fe" is out
+// of frame for "ga-dep-1" even when its store holds that bead. The reader is
+// read by a pass that FAILS a wait on a proved absence, so the question is not
+// which copy answers — it is whether a leg the plan declined to read can be
+// spelled as proof the dependency is gone.
+//
+// The topology is therefore built directly, with the rig's configured prefix
+// deliberately disagreeing with what its store holds.
+func TestPrepareWaitWakeState_PrefixUncoveredRigDependencyDoesNotReapTheWaiter(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	const depID = "ga-dep-1"
+	cityStore := waitWakeCityStore(now, depID)
+	rigStore := waitPrefixedStore{
+		Store:  beads.NewMemStoreFrom(1, []beads.Bead{waitDepBead(now, depID, "closed")}, nil),
+		prefix: "ga",
+	}
+	cfg := &config.City{}
+	cfg.Workspace.Prefix = declaredStoreIDPrefix(cityStore)
+	cfg.Rigs = append(cfg.Rigs, config.Rig{Name: "frontend", Prefix: "fe"})
+
+	if _, err := prepareWaitWakeStateWithSnapshot(
+		sessionFrontDoor(cityStore),
+		newWaitDependencyPlanReader(
+			assembleResidencyTopology(cfg, cityStore, map[string]beads.Store{"frontend": rigStore}, nil, nil),
+			false,
+		),
+		beads.NudgesStore{Store: cityStore},
+		now,
+		nil,
+	); err != nil {
+		t.Fatalf("prepareWaitWakeStateWithSnapshot: %v", err)
+	}
+	assertWaitStillOpen(t, cityStore, waitStatePending)
+}
+
 // TestDepsWaitReadyUnprovenDependencyNeitherFailsNorReadies pins the three-valued
 // contract at the layer that consumes it: an unproved absence is not a not-found
 // (which would fail the wait) and not a hit (which could ready it).

--- a/cmd/gc/relic_census_boot_test.go
+++ b/cmd/gc/relic_census_boot_test.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -120,6 +121,77 @@ func TestBootCensusKeepsTheProbeForAMigratedBead(t *testing.T) {
 	}
 	if !bindingLegRead(t, routes, "ga-relic") {
 		t.Error("the plan for the relic's own id never reads the binding it lives in; the bead is unreachable")
+	}
+}
+
+// TestBootCensusIsLiveAndLeavesNothingOnDisk pins the shape of the census
+// itself: it is computed from the binding, per process, and remembered only in
+// the routes value the process already holds.
+//
+// The read is not free — it covers the binding's whole history, and a binding
+// that cannot answer the verdict itself is listed for it at 97ms per 10k rows
+// (internal/storeref/relic_census_bench_test.go) — and the obvious way to stop
+// paying it per process is a note on disk. That note would be a status
+// file: it goes stale the instant an operator rebuilds or re-points a binding,
+// nothing clears it, and a `gc` that trusts it retires or keeps a probe on a
+// verdict no store agrees with. AGENTS.md forbids exactly that, so the answer is
+// re-derived, and this row is what a future memo has to argue with.
+//
+// A second, independent open of the SAME city must reach the same verdict from
+// the store alone, and the city directory must gain no census artifact.
+func TestBootCensusIsLiveAndLeavesNothingOnDisk(t *testing.T) {
+	root := t.TempDir()
+	cfg := infraSplitConfig(filepath.Join(root, "store"))
+	plan, err := resolveCityStoragePlan(root, cfg)
+	if err != nil {
+		t.Fatalf("resolving the storage plan for a converged split city: %v", err)
+	}
+	target := mustResolveInfraTarget(t, root, cfg)
+
+	openAndCensus := func() bool {
+		routes, err := openStorageRoutes(plan, target)
+		if err != nil {
+			t.Fatalf("openStorageRoutes: %v", err)
+		}
+		defer func() { _ = routes.close() }()
+		censusBindingRelics(routes)
+		return soleBinding(t, routes).HasLegacyResidents
+	}
+
+	if first := openAndCensus(); first {
+		t.Fatalf("a binding with nothing carried across reported relics = %v", first)
+	}
+
+	store, err := openStorageRoutes(plan, target)
+	if err != nil {
+		t.Fatalf("openStorageRoutes: %v", err)
+	}
+	graph, ok := store.storeFor(coordclass.ClassGraph)
+	if !ok {
+		t.Fatal("the split city relocated no graph store")
+	}
+	creator, ok := graph.(beads.ForeignIDCreator)
+	if !ok {
+		t.Fatalf("%T cannot create with a foreign id, so it cannot hold a bead the migration carried across", graph)
+	}
+	if _, err := creator.CreateWithForeignID(beads.Bead{ID: "ga-relic", Title: "carried across", Type: "task"}); err != nil {
+		t.Fatalf("seeding the relic the way `gc storage migrate` does: %v", err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatalf("closing the seeding handle: %v", err)
+	}
+
+	if second := openAndCensus(); !second {
+		t.Fatal("a fresh open censused the binding clean after a relic was carried into it; the verdict is not being read from the store")
+	}
+
+	for _, name := range []string{
+		"storage-relic-census.json",
+		"relic-census.json",
+	} {
+		if _, err := os.Stat(filepath.Join(root, ".gc", name)); err == nil {
+			t.Errorf("the census wrote %s; a remembered verdict is a status file and goes stale the moment a binding is rebuilt", name)
+		}
 	}
 }
 

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -489,27 +489,27 @@ func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordcl
 // class store and no census — the shape a route constructed over a bare store is
 // in, with no routes behind it to ask.
 //
-// It lives here rather than at that call site because this file is where legs
-// are assembled, and it goes through residencyBindingsFor for the reason every
-// other constructor does: Prefixes, Classes, Ref and both retirement bits then
-// come from storeref.BuildBindings, so a topology built from a bare store cannot
-// disagree with one built from a city about what a binding's namespaces are.
+// It lives here rather than at that call site because this file is where the
+// city's class sets are named, and it goes through storeref.BuildBinding for
+// the reason every other constructor goes through BuildBindings: Prefixes,
+// Classes, Ref and both retirement bits then come from the one derivation, so
+// a topology built from a bare store cannot disagree with one built from a city
+// about what a binding's namespaces are.
 //
-// Both evidence funcs are nil, and their nils mean opposite things by design.
-// A nil relics func reads as HasLegacyResidents=true for every store: that is
-// not a stub, it is the honest verdict for a caller that took no census, and it
-// keeps the residence probe running. A nil proof func reads as
-// KnownLegacyResidents=false, which is equally honest for the same caller — a
-// bit that only ever DENIES a read must never be asserted without evidence.
+// The zero BindingOptions is the honest verdict for a caller that took no
+// census, and its two nil evidence funcs mean opposite things by design. A nil
+// relics func reads as HasLegacyResidents=true for every store, which keeps the
+// residence probe running. A nil proof func reads as KnownLegacyResidents=false
+// — a bit that only ever DENIES a read must never be asserted without evidence.
 //
-// store is used as a MAP KEY, so it inherits residencyBindingsFromRoutes's
-// confinement verbatim: a beads.Store whose dynamic type carries a slice, a map
-// or a func is not hashable and panics here. Every caller's store is one storage
-// boot opened or one a test wrapped around it, all pointer- or field-comparable,
-// which is the same argument that makes the grouping above safe.
+// store reaches BuildBinding as a MAP KEY, so it inherits
+// residencyBindingsFromRoutes's confinement verbatim: a beads.Store whose
+// dynamic type carries a slice, a map or a func is not hashable and panics
+// there. Every caller's store is one storage boot opened or one a test wrapped
+// around it, all pointer- or field-comparable, which is the same argument that
+// makes the grouping above safe.
 func soleBindingResidency(store beads.Store) ([]storeref.ClassBinding, error) {
-	order := []beads.Store{store} // residency:allow one opened binding, grouped for the shared BuildBindings derivation below
-	return residencyBindingsFor(order, map[beads.Store][]coordclass.Class{store: infrastructureClasses()}, nil, nil)
+	return storeref.BuildBinding(store, infrastructureClasses(), storeref.BindingOptions{})
 }
 
 // infrastructureClasses is the class set a whole split relocates: every

--- a/cmd/gc/residency_topology.go
+++ b/cmd/gc/residency_topology.go
@@ -353,10 +353,10 @@ type cliRelocatedBinding struct {
 // gate's sentence — and cliResidencyBindings reports that refusal alongside it.
 // Both callers want the STORE in that case, exactly as they got it before: the
 // refusal reaches them through the reads they were going to make anyway, and is
-// classified there. bdByIDClassDoor.resolve no longer classifies it itself —
-// since ga-qdt5y.18 it runs storeref's plan, which tolerates the refusal on a
-// residence probe and surfaces it on the authority leg. hookClaimClassRoute.holds
-// still carries its own hand-rolled version of that judgement (ga-qdt5y.16).
+// classified there. Neither classifies it itself any more: bdByIDClassDoor.resolve
+// runs storeref's plan (ga-qdt5y.18) and hookClaimClassRoute.holds runs the same
+// plan over its own captured frame (ga-qdt5y.16), and the plan tolerates the
+// refusal on a residence probe and surfaces it on the authority leg.
 // Returning it here instead would collapse "this city cannot be served" into
 // "this city relocates nothing", which sends those reads back to the work
 // ledger the beads were migrated off — the exact stale-answer path the door was
@@ -483,6 +483,33 @@ func residencyBindingsFromRoutesWithProof(routes *storageRoutes, known func(stor
 // OPPOSITE default: no proof is no evidence, and this bit only ever denies.
 func residencyBindingsFor(order []beads.Store, byStore map[beads.Store][]coordclass.Class, relics func(beads.Store) bool, known func(storeref.StoreRef) bool) ([]storeref.ClassBinding, error) {
 	return storeref.BuildBindings(order, byStore, storeref.BindingOptions{Relics: relics, KnownRelics: known})
+}
+
+// soleBindingResidency derives the bindings for a caller that holds ONE opened
+// class store and no census — the shape a route constructed over a bare store is
+// in, with no routes behind it to ask.
+//
+// It lives here rather than at that call site because this file is where legs
+// are assembled, and it goes through residencyBindingsFor for the reason every
+// other constructor does: Prefixes, Classes, Ref and both retirement bits then
+// come from storeref.BuildBindings, so a topology built from a bare store cannot
+// disagree with one built from a city about what a binding's namespaces are.
+//
+// Both evidence funcs are nil, and their nils mean opposite things by design.
+// A nil relics func reads as HasLegacyResidents=true for every store: that is
+// not a stub, it is the honest verdict for a caller that took no census, and it
+// keeps the residence probe running. A nil proof func reads as
+// KnownLegacyResidents=false, which is equally honest for the same caller — a
+// bit that only ever DENIES a read must never be asserted without evidence.
+//
+// store is used as a MAP KEY, so it inherits residencyBindingsFromRoutes's
+// confinement verbatim: a beads.Store whose dynamic type carries a slice, a map
+// or a func is not hashable and panics here. Every caller's store is one storage
+// boot opened or one a test wrapped around it, all pointer- or field-comparable,
+// which is the same argument that makes the grouping above safe.
+func soleBindingResidency(store beads.Store) ([]storeref.ClassBinding, error) {
+	order := []beads.Store{store} // residency:allow one opened binding, grouped for the shared BuildBindings derivation below
+	return residencyBindingsFor(order, map[beads.Store][]coordclass.Class{store: infrastructureClasses()}, nil, nil)
 }
 
 // infrastructureClasses is the class set a whole split relocates: every

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -1308,10 +1308,13 @@ func conformanceStrictCrossStoreDeps(t *testing.T, e splitEnv) {
 // answering from the work ledger for relocated graph ids and reported every live
 // molecule root as missing (#5125). Two things must hold on a split city:
 //
-//   - storeref.Resolve, the federating point read every future by-id router is
-//     built on, finds a class-resident bead across [work, class] legs — for the
-//     durable shape AND for the -wisp- suffix shape, whose prefix heuristic
-//     answer differs from an ordinary class id's.
+//   - the by-id plan every by-id router is now built on finds a class-resident
+//     bead over the city's own bindings — for the durable shape AND for the
+//     -wisp- suffix shape, whose prefix heuristic answer differs from an
+//     ordinary class id's. It reads through the same derivation the controller
+//     uses (residencyBindingsFromRoutes -> byIDBeadForTopology) rather than
+//     through storeref.Resolve, whose PrefixOwner fast path answers a
+//     migration-preserved id from the work ledger's frozen copy (ga-cu12x).
 //   - the shipped protection holds: a `bd sql` / `bd query` naming a relocated
 //     id is REFUSED rather than answered from the work ledger, and the refusal
 //     names the class-routed verb.
@@ -1321,15 +1324,16 @@ func conformanceStrictCrossStoreDeps(t *testing.T, e splitEnv) {
 func conformanceByIDReadFederation(t *testing.T, e splitEnv) {
 	durable := mintDurableGraphBead(t, e, "federated durable graph bead", "")
 	wisp := e.mintWisp(t, "federated read wisp")
-	legs := []beads.Store{e.work, e.class} // class is nil on single-store; Resolve skips nil legs
+	bindings, refused := residencyBindingsFromRoutes(e.routes)
+	topo := assembleResidencyTopology(e.cfg, e.work, nil, bindings, refused)
 
 	for _, tt := range []struct{ name, id string }{
 		{"durable", durable.ID},
 		{"wisp", wisp.ID},
 	} {
-		got, err := storeref.Resolve(tt.id, legs)
+		got, err := byIDBeadForTopology(topo, tt.id)
 		if err != nil || got.ID != tt.id {
-			t.Errorf("%s: storeref.Resolve(%q) = (%q, %v), want the bead — a federating by-id read that misses is the \"root does not exist\" report of #5125", tt.name, tt.id, got.ID, err)
+			t.Errorf("%s: byIDBeadForTopology(%q) = (%q, %v), want the bead — a federating by-id read that misses is the \"root does not exist\" report of #5125", tt.name, tt.id, got.ID, err)
 		}
 		msg, refused := bdSQLRelocatedClassRefusal(e.cfg, []string{"sql", "select id, status from issues where id = '" + tt.id + "'"})
 		if refused != e.split {

--- a/cmd/gc/storage_boot.go
+++ b/cmd/gc/storage_boot.go
@@ -137,6 +137,23 @@ func (r *storageRoutes) hasLegacyResidents(store beads.Store) bool {
 // is the busiest one-shot route in the CLI: the door no longer keeps a probe of
 // its own, so a binding certified clean here is a binding that path will not
 // read. A false clean is a lost bead, which is why every unknown answers true.
+//
+// # The cost, and why it is paid rather than written down
+//
+// The verdict covers the binding's WHOLE history and not its working set, so
+// it is never free: a store that answers it itself (beads.NamespaceCensus)
+// costs 0.4ms at 1k rows and 3.2ms at 10k, and one that has to be listed
+// instead costs 97ms at 10k (internal/storeref/relic_census_bench_test.go).
+// "Once per process" is what bounds it — the one-shot funnel takes it inside a
+// sync.Once per city (cliStorageRoutes) and the controller takes it once at boot
+// — and the verdict lives in the routes value those callers already hold.
+//
+// It is deliberately NOT remembered on disk. A note saying "this binding holds
+// relics" is a status file: it survives an operator rebuilding or re-pointing
+// the binding, nothing clears it, and a later `gc` then keeps or retires a probe
+// on a verdict no store agrees with. Querying live state is the house rule
+// (AGENTS.md), so the answer stays a read and the saving comes from making the
+// read cheaper. TestBootCensusIsLiveAndLeavesNothingOnDisk pins both halves.
 func censusBindingRelics(routes *storageRoutes) {
 	if routes == nil {
 		return

--- a/internal/beadmeta/leaf_test.go
+++ b/internal/beadmeta/leaf_test.go
@@ -1,0 +1,58 @@
+package beadmeta
+
+// beadmeta is a leaf, and that is what makes it a safe home for the tables
+// every other layer has to consult.
+//
+// The reserved-prefix table moved here from internal/config precisely because
+// config's cone reaches internal/git, internal/remotesource and
+// internal/worker/builtin -> internal/runtime: asking "which namespace does
+// this class mint under" was linking a process-spawning cone into every
+// package that asked. Nothing keeps it out except this test — one convenience
+// import of a gascity package would restore the cone silently, because the
+// relocation's only visible symptom is a build graph nobody reads.
+//
+// Test files are exempt on purpose: the generated testenv import is one, and a
+// test's dependencies are not the shipped package's.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPackageImportsNothingFromGasCity(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	parsed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		parsed++
+		for _, spec := range file.Imports {
+			path, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				t.Fatalf("%s: unquoting import %s: %v", name, spec.Path.Value, err)
+			}
+			if strings.HasPrefix(path, "github.com/gastownhall/gascity/") {
+				t.Errorf("%s imports %s; beadmeta must stay a leaf so a residency decision does not link a process-spawning cone", name, path)
+			}
+		}
+	}
+	// A walk that reached no file would pass vacuously, and the one thing this
+	// test asserts is the absence of something.
+	if parsed == 0 {
+		t.Fatal("parsed no non-test files; the leaf check inspected nothing")
+	}
+}

--- a/internal/beadmeta/reserved_prefixes.go
+++ b/internal/beadmeta/reserved_prefixes.go
@@ -1,0 +1,146 @@
+package beadmeta
+
+import (
+	"sort"
+	"strings"
+)
+
+// Coordination class names. They are part of the [beads.classes.<name>] config
+// contract and must not change without a migration.
+//
+// They live in this leaf rather than in internal/config because the question
+// "which namespace does this class mint under" has to be answerable without
+// config's dependency cone, which reaches internal/git, internal/remotesource
+// and internal/worker/builtin -> internal/runtime. A residency decision should
+// not drag a process-spawning cone behind it. internal/config and
+// internal/coordclass both name these classes; both now spell them from here,
+// so the three former copies cannot drift apart.
+const (
+	ClassNameWork      = "work"
+	ClassNameGraph     = "graph"
+	ClassNameMessaging = "messaging"
+	ClassNameSessions  = "sessions"
+	ClassNameOrders    = "orders"
+	ClassNameNudges    = "nudges"
+)
+
+// reservedClassPrefixes maps each SQLite-relocated coordination class to the
+// non-configurable bead-ID prefix its embedded store mints. This is the single
+// source of truth. Distinct prefixes keep cross-store ids unambiguous so a
+// stranded bd-era id never resolves into the wrong store.
+//
+// ClassNameWork is intentionally absent: work beads stay on bd/Dolt under the
+// rig/HQ EffectivePrefix, not a reserved class prefix.
+var reservedClassPrefixes = map[string]string{
+	ClassNameGraph:     "gcg",
+	ClassNameMessaging: "gcm",
+	ClassNameSessions:  "gcs",
+	ClassNameOrders:    "gco",
+	ClassNameNudges:    "gcn",
+}
+
+// reservedAuxiliaryPrefixes maps a class to the prefixes its store holds beads
+// under but does NOT mint from — a subsystem inside the class binding that
+// mints its own ids.
+//
+// The nudge queue is the one such subsystem: it derives a queue record's id
+// from the nudge it carries (a content hash rather than a sequence) so that
+// redelivering the same nudge is idempotent without a lookup. Those records
+// live in the nudges binding and are nudges-class beads in every sense that
+// matters to routing; they are simply not minted by the store's own sequence,
+// which is the only thing ReservedClassPrefix describes.
+//
+// A prefix here is reserved exactly as strongly as a mint prefix: a rig
+// configured with it collides with real ids, and an id carrying it belongs to
+// the class binding and nowhere else.
+var reservedAuxiliaryPrefixes = map[string][]string{
+	ClassNameNudges: {NudgeQueueIDPrefix},
+}
+
+// NudgeQueueIDPrefix is the prefix the nudge queue mints its records under.
+//
+// It is exported and lives HERE, in the package that owns what "reserved"
+// means, because two packages have to agree on it and only one of them can own
+// it. The queue in internal/storebinding mints ids with it; the reserved-prefix
+// table above routes ids carrying it to the nudges binding. A copy in each
+// package would let one change alone, and that split is silent in the worst
+// way: the minter writes ids under a prefix the router no longer reserves, so
+// queue records land in the work ledger, the queue reads its own binding, finds
+// nothing, and stops draining without an error anywhere.
+//
+// The trailing separator is NOT part of it. A reserved prefix is matched against
+// the segment before the first "-", so carrying the dash here would make the
+// table's entry match nothing at all.
+const NudgeQueueIDPrefix = "gcnq"
+
+// ReservedClassPrefix returns the id-prefix a SQLite-relocated coordination
+// class MINTS under (e.g. ClassNameOrders -> "gco"), and whether the class has
+// one. Classes without a reserved prefix (e.g. ClassNameWork) return ("", false).
+//
+// This is the store's IDPrefix, not the class's namespace union: a caller
+// deciding whether an id belongs to the class wants ReservedClassPrefixesFor,
+// which also covers the prefixes the class holds without minting.
+func ReservedClassPrefix(class string) (string, bool) {
+	p, ok := reservedClassPrefixes[class]
+	return p, ok
+}
+
+// ReservedClassPrefixesFor returns every reserved id-prefix belonging to a
+// class — the one it mints under first, then any auxiliary namespaces its
+// store holds. Classes with no reserved prefix return nil.
+//
+// Mint-first ordering is load-bearing for callers that take the head as "the"
+// prefix, and it is what lets a binding's namespace list be built by
+// concatenation without a second lookup.
+func ReservedClassPrefixesFor(class string) []string {
+	mint, ok := reservedClassPrefixes[class]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, 1+len(reservedAuxiliaryPrefixes[class]))
+	out = append(out, mint)
+	out = append(out, reservedAuxiliaryPrefixes[class]...)
+	return out
+}
+
+// AllReservedClassPrefixes returns every reserved id-prefix across all classes,
+// sorted. It is the namespace union an id is tested against when the class it
+// might belong to is not known in advance.
+func AllReservedClassPrefixes() []string {
+	out := make([]string, 0, len(reservedClassPrefixes)+len(reservedAuxiliaryPrefixes))
+	for class := range reservedClassPrefixes {
+		out = append(out, ReservedClassPrefixesFor(class)...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ReservedClassPrefixes returns a copy of the class -> reserved-prefix map.
+func ReservedClassPrefixes() map[string]string {
+	out := make(map[string]string, len(reservedClassPrefixes))
+	for class, prefix := range reservedClassPrefixes {
+		out[class] = prefix
+	}
+	return out
+}
+
+// IsReservedClassPrefix reports whether p (without a trailing "-") is a reserved
+// class id-prefix. Case-insensitive, matching rig prefix validation.
+func IsReservedClassPrefix(p string) bool {
+	p = strings.ToLower(strings.TrimSpace(p))
+	if p == "" {
+		return false
+	}
+	for _, reserved := range AllReservedClassPrefixes() {
+		if strings.ToLower(reserved) == p {
+			return true
+		}
+	}
+	return false
+}
+
+// ReservedClassPrefixListText returns the reserved class id-prefixes as a
+// sorted, comma-separated string for use in validation error messages.
+func ReservedClassPrefixListText() string {
+	return strings.Join(AllReservedClassPrefixes(), ", ")
+}

--- a/internal/beadmeta/reserved_prefixes_test.go
+++ b/internal/beadmeta/reserved_prefixes_test.go
@@ -1,0 +1,105 @@
+package beadmeta
+
+// The reserved id namespaces, and the auxiliary one the registry did not know
+// about.
+//
+// A class mints under one prefix, but a class STORE can hold beads under more
+// than one: the nudge queue mints its own records as "gcnq-…" inside the nudges
+// binding (internal/storebinding/beads_nudge_queue.go's nudgeQueueIDPrefix).
+// That prefix was never registered, so every consumer that asks "is this id
+// class-reserved" — the rig/HQ prefix validator, the `gc bd` by-id front door,
+// the residency topology's binding namespaces — answered no for a queue id.
+//
+// The consequences are asymmetric and both bad. A rig could be configured with
+// prefix "gcnq" and collide with the queue's own ids, and a by-id read of a
+// queue bead falls through to the work ledger, which answers it emptily and
+// confidently. Registration is what makes the union match the reality.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNudgeQueuePrefixIsReserved(t *testing.T) {
+	if !IsReservedClassPrefix("gcnq") {
+		t.Error("gcnq is not reserved; a rig could be configured with that prefix and collide with the nudge queue's own bead ids")
+	}
+	// Case-insensitive, matching ValidateRigs' prefix handling.
+	if !IsReservedClassPrefix("  GCNQ ") {
+		t.Error("gcnq is not reserved case-insensitively; the rig validator lowercases before comparing")
+	}
+}
+
+// The auxiliary prefix must not displace the one the class MINTS under. A
+// binding's store is opened with ReservedClassPrefix as its IDPrefix, so a
+// change there is a change to every id the class creates from then on.
+func TestReservedClassPrefixStillNamesTheMintPrefix(t *testing.T) {
+	got, ok := ReservedClassPrefix(ClassNameNudges)
+	if !ok {
+		t.Fatal("nudges has no reserved mint prefix")
+	}
+	if got != "gcn" {
+		t.Fatalf("nudges mints under %q, want gcn — this is the store's IDPrefix, not the namespace union", got)
+	}
+}
+
+func TestReservedClassPrefixesForCoversAuxiliaryNamespaces(t *testing.T) {
+	tests := []struct {
+		class string
+		want  []string
+	}{
+		{ClassNameNudges, []string{"gcn", "gcnq"}},
+		{ClassNameGraph, []string{"gcg"}},
+		{ClassNameWork, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.class, func(t *testing.T) {
+			got := ReservedClassPrefixesFor(tt.class)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ReservedClassPrefixesFor(%q) = %v, want %v", tt.class, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("ReservedClassPrefixesFor(%q) = %v, want %v (mint prefix first)", tt.class, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// Every prefix the registry knows must be reserved, and the union must be the
+// concatenation of the per-class unions. Stated as a property rather than a
+// literal list so registering a sixth class cannot leave one accessor behind.
+func TestReservedPrefixUnionAgreesWithPerClassUnions(t *testing.T) {
+	union := map[string]bool{}
+	for _, p := range AllReservedClassPrefixes() {
+		if !IsReservedClassPrefix(p) {
+			t.Errorf("AllReservedClassPrefixes returned %q, which IsReservedClassPrefix denies", p)
+		}
+		union[p] = true
+	}
+	for class := range reservedClassPrefixes {
+		for _, p := range ReservedClassPrefixesFor(class) {
+			if !union[p] {
+				t.Errorf("class %q reserves %q, which is missing from AllReservedClassPrefixes", class, p)
+			}
+		}
+	}
+}
+
+// The validator's message names what it refuses. An operator told "gcnq is
+// reserved" and then shown a list without gcnq in it has been told the rule and
+// shown a contradiction.
+func TestReservedPrefixListTextNamesEveryReservedPrefix(t *testing.T) {
+	text := ReservedClassPrefixListText()
+	fields := strings.FieldsFunc(text, func(r rune) bool { return r == ',' || r == ' ' })
+	seen := map[string]bool{}
+	for _, f := range fields {
+		seen[f] = true
+	}
+	for _, p := range AllReservedClassPrefixes() {
+		if !seen[p] {
+			t.Errorf("the validator's reserved-prefix list %q omits %q, which it refuses", text, p)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
@@ -1172,16 +1173,17 @@ func (r *Rig) EffectivePrefix() string {
 	return DeriveBeadsPrefix(r.Name)
 }
 
-// Coordination class names, mirroring coordclass.Class.String(). They are part of
-// the [beads.classes.<name>] config contract and must not change without a
-// migration.
+// Coordination class names. They are part of the [beads.classes.<name>] config
+// contract and must not change without a migration. They no longer MIRROR
+// coordclass.Class.String() — both spell the same beadmeta constants, so the
+// two vocabularies cannot drift apart.
 const (
-	BeadClassWork      = "work"
-	BeadClassGraph     = "graph"
-	BeadClassMessaging = "messaging"
-	BeadClassSessions  = "sessions"
-	BeadClassOrders    = "orders"
-	BeadClassNudges    = "nudges"
+	BeadClassWork      = beadmeta.ClassNameWork
+	BeadClassGraph     = beadmeta.ClassNameGraph
+	BeadClassMessaging = beadmeta.ClassNameMessaging
+	BeadClassSessions  = beadmeta.ClassNameSessions
+	BeadClassOrders    = beadmeta.ClassNameOrders
+	BeadClassNudges    = beadmeta.ClassNameNudges
 )
 
 // EffectiveDefaultBranch returns the rig's recorded default branch, or the

--- a/internal/config/reserved_prefixes.go
+++ b/internal/config/reserved_prefixes.go
@@ -1,129 +1,42 @@
 package config
 
-import (
-	"sort"
-	"strings"
-)
+import "github.com/gastownhall/gascity/internal/beadmeta"
 
-// reservedClassPrefixes maps each SQLite-relocated coordination class to the
-// non-configurable bead-ID prefix its embedded store mints. This is the single
-// source of truth, consolidating cmd/gc's classSQLitePrefix map and the
-// graphStoreIDPrefix constant. Distinct prefixes keep cross-store ids
-// unambiguous so a stranded bd-era id never resolves into the wrong store.
-//
-// BeadClassWork is intentionally absent: work beads stay on bd/Dolt under the
-// rig/HQ EffectivePrefix, not a reserved class prefix.
-var reservedClassPrefixes = map[string]string{
-	BeadClassGraph:     "gcg",
-	BeadClassMessaging: "gcm",
-	BeadClassSessions:  "gcs",
-	BeadClassOrders:    "gco",
-	BeadClassNudges:    "gcn",
-}
-
-// reservedAuxiliaryPrefixes maps a class to the prefixes its store holds beads
-// under but does NOT mint from — a subsystem inside the class binding that
-// mints its own ids.
-//
-// The nudge queue is the one such subsystem: it derives a queue record's id
-// from the nudge it carries (storebinding's nudgeQueueIDPrefix, a content hash
-// rather than a sequence) so that redelivering the same nudge is idempotent
-// without a lookup. Those records live in the nudges binding and are nudges-class
-// beads in every sense that matters to routing; they are simply not minted by
-// the store's own sequence, which is the only thing ReservedClassPrefix
-// describes.
-//
-// A prefix here is reserved exactly as strongly as a mint prefix: a rig
-// configured with it collides with real ids, and an id carrying it belongs to
-// the class binding and nowhere else.
-var reservedAuxiliaryPrefixes = map[string][]string{
-	BeadClassNudges: {NudgeQueueIDPrefix},
-}
+// The reserved-prefix table moved to internal/beadmeta, a stdlib-only leaf.
+// config's dependency cone reaches internal/git, internal/remotesource and
+// internal/worker/builtin -> internal/runtime, so every package that needed to
+// ask "which namespace does this class mint under" was dragging a
+// process-spawning cone behind it — internal/storeref imported config for this
+// table alone. These re-exports keep every existing call site spelling the
+// question through config.
 
 // NudgeQueueIDPrefix is the prefix the nudge queue mints its records under.
-//
-// It is exported and lives HERE, in the package that owns what "reserved" means,
-// because two packages have to agree on it and only one of them can own it. The
-// queue in internal/storebinding mints ids with it; the reserved-prefix table
-// above routes ids carrying it to the nudges binding. A copy in each package
-// would let one change alone, and that split is silent in the worst way: the
-// minter writes ids under a prefix the router no longer reserves, so queue
-// records land in the work ledger, the queue reads its own binding, finds
-// nothing, and stops draining without an error anywhere.
-//
-// The trailing separator is NOT part of it. A reserved prefix is matched against
-// the segment before the first "-" (see bdIDIsClassReserved), so carrying the
-// dash here would make the table's entry match nothing at all.
-const NudgeQueueIDPrefix = "gcnq"
+const NudgeQueueIDPrefix = beadmeta.NudgeQueueIDPrefix
 
 // ReservedClassPrefix returns the id-prefix a SQLite-relocated coordination
 // class MINTS under (e.g. BeadClassOrders -> "gco"), and whether the class has
 // one. Classes without a reserved prefix (e.g. BeadClassWork) return ("", false).
-//
-// This is the store's IDPrefix, not the class's namespace union: a caller
-// deciding whether an id belongs to the class wants ReservedClassPrefixesFor,
-// which also covers the prefixes the class holds without minting.
-func ReservedClassPrefix(class string) (string, bool) {
-	p, ok := reservedClassPrefixes[class]
-	return p, ok
-}
+func ReservedClassPrefix(class string) (string, bool) { return beadmeta.ReservedClassPrefix(class) }
 
 // ReservedClassPrefixesFor returns every reserved id-prefix belonging to a
 // class — the one it mints under first, then any auxiliary namespaces its
 // store holds. Classes with no reserved prefix return nil.
-//
-// Mint-first ordering is load-bearing for callers that take the head as "the"
-// prefix, and it is what lets a binding's namespace list be built by
-// concatenation without a second lookup.
 func ReservedClassPrefixesFor(class string) []string {
-	mint, ok := reservedClassPrefixes[class]
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, 1+len(reservedAuxiliaryPrefixes[class]))
-	out = append(out, mint)
-	out = append(out, reservedAuxiliaryPrefixes[class]...)
-	return out
+	return beadmeta.ReservedClassPrefixesFor(class)
 }
 
 // AllReservedClassPrefixes returns every reserved id-prefix across all classes,
 // sorted. It is the namespace union an id is tested against when the class it
 // might belong to is not known in advance.
-func AllReservedClassPrefixes() []string {
-	out := make([]string, 0, len(reservedClassPrefixes)+len(reservedAuxiliaryPrefixes))
-	for class := range reservedClassPrefixes {
-		out = append(out, ReservedClassPrefixesFor(class)...)
-	}
-	sort.Strings(out)
-	return out
-}
+func AllReservedClassPrefixes() []string { return beadmeta.AllReservedClassPrefixes() }
 
 // ReservedClassPrefixes returns a copy of the class -> reserved-prefix map.
-func ReservedClassPrefixes() map[string]string {
-	out := make(map[string]string, len(reservedClassPrefixes))
-	for class, prefix := range reservedClassPrefixes {
-		out[class] = prefix
-	}
-	return out
-}
+func ReservedClassPrefixes() map[string]string { return beadmeta.ReservedClassPrefixes() }
 
 // IsReservedClassPrefix reports whether p (without a trailing "-") is a reserved
 // class id-prefix. Case-insensitive, matching ValidateRigs' prefix handling.
-func IsReservedClassPrefix(p string) bool {
-	p = strings.ToLower(strings.TrimSpace(p))
-	if p == "" {
-		return false
-	}
-	for _, reserved := range AllReservedClassPrefixes() {
-		if strings.ToLower(reserved) == p {
-			return true
-		}
-	}
-	return false
-}
+func IsReservedClassPrefix(p string) bool { return beadmeta.IsReservedClassPrefix(p) }
 
 // reservedClassPrefixListText returns the reserved class id-prefixes as a
 // sorted, comma-separated string for use in validation error messages.
-func reservedClassPrefixListText() string {
-	return strings.Join(AllReservedClassPrefixes(), ", ")
-}
+func reservedClassPrefixListText() string { return beadmeta.ReservedClassPrefixListText() }

--- a/internal/config/reserved_prefixes_test.go
+++ b/internal/config/reserved_prefixes_test.go
@@ -1,88 +1,24 @@
 package config
 
-// The reserved id namespaces, and the auxiliary one the registry did not know
-// about.
+// The reserved-prefix table itself is tested in internal/beadmeta, where it
+// lives. What is left to test here is the join: config's BeadClass* names are
+// what every caller passes INTO that table, and they are declared in a different
+// file from the table's keys.
 //
-// A class mints under one prefix, but a class STORE can hold beads under more
-// than one: the nudge queue mints its own records as "gcnq-…" inside the nudges
-// binding (internal/storebinding/beads_nudge_queue.go's nudgeQueueIDPrefix).
-// That prefix was never registered, so every consumer that asks "is this id
-// class-reserved" — the rig/HQ prefix validator, the `gc bd` by-id front door,
-// the residency topology's binding namespaces — answered no for a queue id.
-//
-// The consequences are asymmetric and both bad. A rig could be configured with
-// prefix "gcnq" and collide with the queue's own ids, and a by-id read of a
-// queue bead falls through to the work ledger, which answers it emptily and
-// confidently. Registration is what makes the union match the reality.
+// A drift there answers "no reserved prefix" for a class that has one, and that
+// answer is silent in the worst direction — the id falls through to the work
+// ledger, which answers it emptily and confidently rather than erroring.
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestNudgeQueuePrefixIsReserved(t *testing.T) {
-	if !IsReservedClassPrefix("gcnq") {
-		t.Error("gcnq is not reserved; a rig could be configured with that prefix and collide with the nudge queue's own bead ids")
-	}
-	// Case-insensitive, matching ValidateRigs' prefix handling.
-	if !IsReservedClassPrefix("  GCNQ ") {
-		t.Error("gcnq is not reserved case-insensitively; the rig validator lowercases before comparing")
-	}
-}
-
-// The auxiliary prefix must not displace the one the class MINTS under. A
-// binding's store is opened with ReservedClassPrefix as its IDPrefix, so a
-// change there is a change to every id the class creates from then on.
-func TestReservedClassPrefixStillNamesTheMintPrefix(t *testing.T) {
-	got, ok := ReservedClassPrefix(BeadClassNudges)
-	if !ok {
-		t.Fatal("nudges has no reserved mint prefix")
-	}
-	if got != "gcn" {
-		t.Fatalf("nudges mints under %q, want gcn — this is the store's IDPrefix, not the namespace union", got)
-	}
-}
-
-func TestReservedClassPrefixesForCoversAuxiliaryNamespaces(t *testing.T) {
-	tests := []struct {
-		class string
-		want  []string
-	}{
-		{BeadClassNudges, []string{"gcn", "gcnq"}},
-		{BeadClassGraph, []string{"gcg"}},
-		{BeadClassWork, nil},
-	}
-	for _, tt := range tests {
-		t.Run(tt.class, func(t *testing.T) {
-			got := ReservedClassPrefixesFor(tt.class)
-			if len(got) != len(tt.want) {
-				t.Fatalf("ReservedClassPrefixesFor(%q) = %v, want %v", tt.class, got, tt.want)
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Fatalf("ReservedClassPrefixesFor(%q) = %v, want %v (mint prefix first)", tt.class, got, tt.want)
-				}
-			}
-		})
-	}
-}
-
-// Every prefix the registry knows must be reserved, and the union must be the
-// concatenation of the per-class unions. Stated as a property rather than a
-// literal list so registering a sixth class cannot leave one accessor behind.
-func TestReservedPrefixUnionAgreesWithPerClassUnions(t *testing.T) {
-	union := map[string]bool{}
-	for _, p := range AllReservedClassPrefixes() {
-		if !IsReservedClassPrefix(p) {
-			t.Errorf("AllReservedClassPrefixes returned %q, which IsReservedClassPrefix denies", p)
+func TestEveryRelocatedBeadClassNameKeysTheReservedTable(t *testing.T) {
+	for _, class := range []string{BeadClassGraph, BeadClassMessaging, BeadClassSessions, BeadClassOrders, BeadClassNudges} {
+		if _, ok := ReservedClassPrefix(class); !ok {
+			t.Errorf("config names the relocated class %q, but the reserved-prefix table has no key for it — ids it mints would fall through to the work ledger", class)
 		}
-		union[p] = true
 	}
-	for class := range reservedClassPrefixes {
-		for _, p := range ReservedClassPrefixesFor(class) {
-			if !union[p] {
-				t.Errorf("class %q reserves %q, which is missing from AllReservedClassPrefixes", class, p)
-			}
-		}
+	if _, ok := ReservedClassPrefix(BeadClassWork); ok {
+		t.Errorf("work has a reserved class prefix; work beads stay on bd under the rig/HQ EffectivePrefix")
 	}
 }
 

--- a/internal/coordclass/class.go
+++ b/internal/coordclass/class.go
@@ -47,6 +47,8 @@
 // against the exported constants where those are importable.
 package coordclass
 
+import "github.com/gastownhall/gascity/internal/beadmeta"
+
 // Class is the owning subsystem a bead belongs to — the unit of routing for the
 // coordination-store split. Each non-Work class is destined for its own typed
 // provider module, with bd as the first (identity) implementation. It is
@@ -95,17 +97,17 @@ const (
 func (c Class) String() string {
 	switch c {
 	case ClassWork:
-		return "work"
+		return beadmeta.ClassNameWork
 	case ClassGraph:
-		return "graph"
+		return beadmeta.ClassNameGraph
 	case ClassMessaging:
-		return "messaging"
+		return beadmeta.ClassNameMessaging
 	case ClassSessions:
-		return "sessions"
+		return beadmeta.ClassNameSessions
 	case ClassOrders:
-		return "orders"
+		return beadmeta.ClassNameOrders
 	case ClassNudges:
-		return "nudges"
+		return beadmeta.ClassNameNudges
 	default:
 		return "unknown"
 	}

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -287,44 +287,22 @@ func (e drainUnresolvedMemberError) Unwrap() error {
 	return errDrainUnresolvedMember
 }
 
-// drainMemberProbeSet returns the ordered store set used to resolve a drain
-// member bead: the primary graph store first, then the work-class member store
-// tail from opts.MemberStores. A drain control and its item-root molecules live
-// in the graph store, but the convoy members a drain reserves and reloads are
-// work beads that may live in a different per-class store. Resolving through this
-// set keeps member access consistent with the fresh convoycore.Members build
-// (which already threads opts.MemberStores). Empty MemberStores (single-store
-// callers) collapses the probe to the primary store, matching the pre-seam
-// store.Get behavior exactly.
-func drainMemberProbeSet(store beads.Store, opts ProcessOptions) []beads.Store {
-	probe := make([]beads.Store, 0, 1+len(opts.MemberStores))
-	probe = append(probe, store)
-	probe = append(probe, opts.MemberStores...)
-	return probe
-}
-
-// drainMemberOwningStore returns the store that owns memberID, probing the
-// primary graph store then the work-class member tail and returning the first
-// store whose Get succeeds. Because ids are prefix-disjoint across stores the
-// member lives in exactly one, so the first hit is authoritative. A store's
-// not-found probe is skipped; any other error is returned. When no probed store
-// has the member (every probe a clean not-found), it falls back to the primary
-// store so reservation reads/writes preserve their pre-seam not-found handling
-// (reserveDrainMember/releaseDrainReservations treat ErrNotFound as a no-op).
+// drainMemberOwningStore returns the store that owns memberID, resolved through
+// the drain's residency frame (drainResidency) rather than a hand-walked probe
+// list. When no store has the member it falls back to the primary store so
+// reservation reads/writes preserve their pre-seam not-found handling
+// (reserveDrainMember/releaseDrainReservations treat ErrNotFound as a no-op) —
+// and the fallback matters for correctness, not just parity: a reserved-namespace
+// miss resolves to a NIL store, which a caller must never write through.
 func drainMemberOwningStore(store beads.Store, memberID string, opts ProcessOptions) (beads.Store, error) {
-	for _, probe := range drainMemberProbeSet(store, opts) {
-		if probe == nil {
-			continue
-		}
-		if _, err := probe.Get(memberID); err != nil {
-			if errors.Is(err, beads.ErrNotFound) {
-				continue
-			}
-			return nil, err
-		}
-		return probe, nil
+	owner, found, err := resolveDrainMember(store, memberID, opts)
+	if err != nil {
+		return nil, err
 	}
-	return store, nil
+	if !found {
+		return store, nil
+	}
+	return owner.Store, nil
 }
 
 // drainMemberDepStore returns the store to read a drain member's dependency
@@ -388,26 +366,36 @@ func drainConvoyMembers(store beads.Store, convoyID string, opts ProcessOptions)
 	if len(opts.MemberStores) == 0 {
 		return convoycore.Members(store, convoyID, false)
 	}
+	topo, err := drainResidency(store, opts)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := storeref.Plan(storeref.RoutedWork{}, topo)
+	if err != nil {
+		return nil, err
+	}
+	// Deliberately un-deduped (nil id fn): Union's own first-leg-wins would drop
+	// the second copy of a member id outright, and this merge needs to SEE it —
+	// a placeholder recorded by the leg that answered first must still yield to
+	// the real bead another leg records.
+	union, err := storeref.Union[beads.Bead](plan, nil,
+		func(leg storeref.Leg) ([]beads.Bead, error) {
+			return convoycore.Members(leg.Store, convoyID, false, opts.MemberStores...)
+		})
+	if err != nil {
+		return nil, err
+	}
 	var merged []beads.Bead
 	at := make(map[string]int)
-	for _, probe := range drainMemberProbeSet(store, opts) {
-		if probe == nil {
+	for _, member := range union.Items {
+		i, seen := at[member.ID]
+		if !seen {
+			at[member.ID] = len(merged)
+			merged = append(merged, member)
 			continue
 		}
-		members, err := convoycore.Members(probe, convoyID, false, opts.MemberStores...)
-		if err != nil {
-			return nil, err
-		}
-		for _, member := range members {
-			i, seen := at[member.ID]
-			if !seen {
-				at[member.ID] = len(merged)
-				merged = append(merged, member)
-				continue
-			}
-			if convoycore.IsUnresolvedTrackedItem(merged[i]) && !convoycore.IsUnresolvedTrackedItem(member) {
-				merged[i] = member
-			}
+		if convoycore.IsUnresolvedTrackedItem(merged[i]) && !convoycore.IsUnresolvedTrackedItem(member) {
+			merged[i] = member
 		}
 	}
 	// Same order convoycore.MembersIn returns within one store, so the manifest
@@ -422,18 +410,19 @@ func drainConvoyMembers(store beads.Store, convoyID string, opts ProcessOptions)
 }
 
 func loadDrainManifestMembers(store beads.Store, controlID string, manifest drainManifest, opts ProcessOptions) ([]beads.Bead, error) {
-	probe := drainMemberProbeSet(store, opts)
 	members := make([]beads.Bead, 0, len(manifest.Rows))
 	for _, row := range manifest.Rows {
-		member, err := storeref.Resolve(row.MemberID, probe)
+		owner, found, err := resolveDrainMember(store, row.MemberID, opts)
 		if err != nil {
-			if errors.Is(err, beads.ErrNotFound) && strings.TrimSpace(row.MemberID) != "" {
-				members = append(members, beads.Bead{ID: row.MemberID, Title: row.MemberID, Type: "task", Status: "unknown"})
-				continue
-			}
 			return nil, fmt.Errorf("%s: loading persisted drain member %s: %w", controlID, row.MemberID, err)
 		}
-		members = append(members, member)
+		if !found {
+			// A blank id never reaches here: ByID refuses it above, which is the
+			// same outcome the pre-seam probe produced for one.
+			members = append(members, beads.Bead{ID: row.MemberID, Title: row.MemberID, Type: "task", Status: "unknown"})
+			continue
+		}
+		members = append(members, owner.Bead)
 	}
 	return members, nil
 }
@@ -792,6 +781,16 @@ const (
 //
 // Single-store callers skip the check entirely: there is one store, so every id
 // it resolves is co-resident and the probe would be pure overhead.
+//
+// The "is it resolvable at all" half goes through resolveDrainMember, the same
+// ByID plan the manifest and the reservation use. It used to be storeref.Resolve
+// over the member-store tail, whose PrefixOwner fast path routes on the id's own
+// prefix: a blocker whose class was relocated but whose id the migration
+// preserved matched the WORK store's prefix and was read from the frozen
+// retained copy, so a blocker CLOSED after the cutover still looked open and the
+// edge was dropped as unprojectable (ga-cu12x). The ambient store is asked
+// first, above, and that read is the co-residency question — a different one
+// from residency, and the only reason it stays hand-written here.
 func classifyDrainBlocker(store beads.Store, blockerID string, opts ProcessOptions) (drainBlockerResidence, error) {
 	if len(opts.MemberStores) == 0 {
 		return drainBlockerProjectable, nil
@@ -801,16 +800,16 @@ func classifyDrainBlocker(store beads.Store, blockerID string, opts ProcessOptio
 	} else if !errors.Is(err, beads.ErrNotFound) {
 		return drainBlockerUnclassified, err
 	}
-	blocker, err := storeref.Resolve(blockerID, opts.MemberStores)
+	owner, found, err := resolveDrainMember(store, blockerID, opts)
 	if err != nil {
-		if errors.Is(err, beads.ErrNotFound) {
-			// Resolvable nowhere: the source member's own edge already dangles.
-			// Report it rather than copying the dangle into another store.
-			return drainBlockerUnprojectable, nil
-		}
 		return drainBlockerUnclassified, err
 	}
-	if convoycore.IsTerminalStatus(blocker.Status) {
+	if !found {
+		// Resolvable nowhere: the source member's own edge already dangles.
+		// Report it rather than copying the dangle into another store.
+		return drainBlockerUnprojectable, nil
+	}
+	if convoycore.IsTerminalStatus(owner.Bead.Status) {
 		return drainBlockerSatisfied, nil
 	}
 	return drainBlockerUnprojectable, nil
@@ -1158,27 +1157,35 @@ func orderDrainMembersByDependencies(store beads.Store, members []beads.Bead, op
 	return ordered, nil
 }
 
-// drainUnitConvoyProbeSet returns the ordered store set a drain resolves its own
-// unit convoys through: the work-class member stores first, then the ambient
-// store.
+// walkDrainUnitConvoyLegs visits the stores a drain resolves its OWN unit
+// convoys through, stopping at the first leg that answers.
 //
-// It is the reverse of drainMemberProbeSet, and deliberately so. A unit convoy is
-// a SYNTHETIC convoy and a synthetic convoy is a WORK bead (coordclass.Classify),
-// so the work class is the authoritative answer and the ambient graph binding is
-// only a fallback for rows that predate that ruling. Asking the binding first
-// gets the wrong answer on a real converged city: cities migrated under the
-// previous classification carry an EDGELESS copy of every synthetic convoy in
-// their binding (`gc storage migrate` copied the row; importInfraSnapshot re-added
-// only the edges whose both endpoints were infra), so the binding can answer
-// gc.drain_unit_key with a convoy that has no tracks edge and cannot grow one.
+// The intent is RoutedWork, not ByID, and that is the whole reason this
+// resolution and drainMemberOwningStore's do not share an order. A unit convoy
+// is a SYNTHETIC convoy and a synthetic convoy is a WORK bead
+// (coordclass.Classify), so the work class is authoritative here and the ambient
+// graph binding is only a fallback for rows predating that ruling. Asking the
+// binding first gets the wrong answer on a real converged city: cities migrated
+// under the previous classification carry an EDGELESS copy of every synthetic
+// convoy in their binding (`gc storage migrate` copied the row;
+// importInfraSnapshot re-added only the edges whose both endpoints were infra),
+// so the binding can answer gc.drain_unit_key with a convoy that has no tracks
+// edge and cannot grow one. A drain MEMBER is the opposite case — foreign, class
+// unknown — which is why that one plans ByID and leads with the binding.
 //
-// With no member stores configured — every single-store caller — this is the one
-// ambient store, so every read through it is the single read it is today.
-func drainUnitConvoyProbeSet(store beads.Store, opts ProcessOptions) []beads.Store {
-	probe := make([]beads.Store, 0, 1+len(opts.MemberStores))
-	probe = append(probe, opts.MemberStores...)
-	probe = append(probe, store)
-	return probe
+// With no member stores configured — every single-store caller — the plan is the
+// one ambient store, so every read through it is the single read it is today.
+func walkDrainUnitConvoyLegs(store beads.Store, opts ProcessOptions, visit func(beads.Store) (bool, error)) error {
+	topo, err := drainResidency(store, opts)
+	if err != nil {
+		return err
+	}
+	plan, err := storeref.Plan(storeref.RoutedWork{}, topo)
+	if err != nil {
+		return err
+	}
+	_, err = storeref.Walk(plan, func(leg storeref.Leg) (bool, error) { return visit(leg.Store) })
+	return err
 }
 
 // drainWorkClassStore returns the handle for the work class: the first member
@@ -1230,17 +1237,22 @@ func drainUnitConvoyStore(store beads.Store, member beads.Bead, opts ProcessOpti
 	if memberID == "" || convoycore.IsUnresolvedTrackedItem(member) {
 		return drainWorkClassStore(store, opts), nil
 	}
-	for _, probe := range drainUnitConvoyProbeSet(store, opts) {
-		if probe == nil {
-			continue
-		}
+	var owner beads.Store
+	err := walkDrainUnitConvoyLegs(store, opts, func(probe beads.Store) (bool, error) {
 		if _, err := probe.Get(memberID); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
-				continue
+				return false, nil
 			}
-			return nil, err
+			return false, err
 		}
-		return probe, nil
+		owner = probe
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if owner != nil {
+		return owner, nil
 	}
 	return drainWorkClassStore(store, opts), nil
 }
@@ -1255,19 +1267,28 @@ func drainUnitConvoyStore(store beads.Store, member beads.Bead, opts ProcessOpti
 // lookup to a different store, it misses, and the drain mints a second unit
 // convoy for a row that already has one.
 func drainUnitConvoyByKey(store beads.Store, unitKey string, opts ProcessOptions) (beads.Bead, beads.Store, bool, error) {
-	for _, probe := range drainUnitConvoyProbeSet(store, opts) {
-		if probe == nil {
-			continue
-		}
+	var (
+		found beads.Bead
+		owner beads.Store
+	)
+	err := walkDrainUnitConvoyLegs(store, opts, func(probe beads.Store) (bool, error) {
 		existing, err := probe.ListByMetadata(map[string]string{beadmeta.DrainUnitKeyMetadataKey: unitKey}, 1, beads.WithBothTiers)
 		if err != nil {
-			return beads.Bead{}, nil, false, err
+			return false, err
 		}
-		if len(existing) > 0 {
-			return existing[0], probe, true, nil
+		if len(existing) == 0 {
+			return false, nil
 		}
+		found, owner = existing[0], probe
+		return true, nil
+	})
+	if err != nil {
+		return beads.Bead{}, nil, false, err
 	}
-	return beads.Bead{}, nil, false, nil
+	if owner == nil {
+		return beads.Bead{}, nil, false, nil
+	}
+	return found, owner, true, nil
 }
 
 func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID string, count int, row drainManifestRow, member beads.Bead, opts ProcessOptions) (beads.Bead, bool, error) {
@@ -1332,7 +1353,26 @@ func reloadDrainUnitConvoy(store beads.Store, unitConvoyID string, opts ProcessO
 	if len(opts.MemberStores) == 0 {
 		return store.Get(unitConvoyID)
 	}
-	return storeref.Resolve(unitConvoyID, drainUnitConvoyProbeSet(store, opts))
+	var reloaded beads.Bead
+	found := false
+	err := walkDrainUnitConvoyLegs(store, opts, func(probe beads.Store) (bool, error) {
+		bead, err := probe.Get(unitConvoyID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				return false, nil
+			}
+			return false, err
+		}
+		reloaded, found = bead, true
+		return true, nil
+	})
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	if !found {
+		return beads.Bead{}, fmt.Errorf("reloading drain unit convoy %s: %w", unitConvoyID, beads.ErrNotFound)
+	}
+	return reloaded, nil
 }
 
 func ensureDrainUnitTrack(store beads.Store, controlID, unitConvoyID string, member beads.Bead) error {

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -1222,7 +1222,7 @@ func drainWorkClassStore(store beads.Store, opts ProcessOptions) beads.Store {
 // migration's own equality invariant says never happens.
 //
 // Only the mint is derived from the member. Lookup by gc.drain_unit_key and
-// reload by id go through drainUnitConvoyProbeSet, because a member's
+// reload by id go through walkDrainUnitConvoyLegs, because a member's
 // resolvability can change between drain passes while the convoy it already
 // minted does not move.
 //

--- a/internal/dispatch/drain_residency.go
+++ b/internal/dispatch/drain_residency.go
@@ -1,0 +1,97 @@
+package dispatch
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/coordclass"
+	"github.com/gastownhall/gascity/internal/storeref"
+)
+
+// drainResidency is the frame a drain resolves ids over: the routed work class
+// store, plus the drain's own ambient store as the one class binding.
+//
+// It is built here rather than threaded down from the city on purpose — a city
+// topology federates every serving rig, and handing that to a drain would let a
+// drain resolve a member out of another scope. The two stores the caller
+// already routed are the whole frame.
+//
+// Relics is nil, which BuildBindings reads as "may hold legacy residents" and
+// so keeps the residence probe. That is the honest answer for a caller that
+// took no census.
+func drainResidency(store beads.Store, opts ProcessOptions) (storeref.Topology, error) {
+	if len(opts.MemberStores) == 0 {
+		return storeref.Topology{Work: storeref.Leg{Ref: storeref.WorkRef, Store: store}}, nil
+	}
+	if len(opts.MemberStores) > 1 {
+		return storeref.Topology{}, fmt.Errorf("drain residency: %d member stores, want at most 1", len(opts.MemberStores))
+	}
+	order := []beads.Store{store} // residency:allow one ambient binding, grouped for the shared BuildBindings derivation below
+	bindings, refused := storeref.BuildBindings(
+		order,
+		map[beads.Store][]coordclass.Class{store: drainInfrastructureClasses()},
+		storeref.BindingOptions{},
+	)
+	return storeref.Topology{
+		Work:     storeref.Leg{Ref: storeref.WorkRef, Store: drainWorkClassStore(store, opts)},
+		Bindings: bindings,
+		Refused:  refused,
+	}, nil
+}
+
+// drainInfrastructureClasses is every coordination class but work — the set a
+// class split relocates. Derived rather than listed so a new class joins the
+// binding the day it is declared.
+func drainInfrastructureClasses() []coordclass.Class {
+	classes := make([]coordclass.Class, 0, len(coordclass.Classes()))
+	for _, class := range coordclass.Classes() {
+		if class.IsInfrastructure() {
+			classes = append(classes, class)
+		}
+	}
+	return classes
+}
+
+// resolveDrainMember answers which store holds a member the drain reads but did
+// not mint, and what that store's row says.
+//
+// The intent is ByID, not RoutedWork: a member's class is not statically known,
+// so a binding copy is the live relocated bead and the work store's copy is the
+// frozen one a migration retained. (A drain unit convoy is the opposite — the
+// drain mints it and coordclass pins it to work — which is why that resolution
+// plans RoutedWork instead.)
+//
+// found=false covers both of ResolveOwnerRow's miss shapes: an id inside a
+// reserved namespace misses with a nil store, and an ordinary id ends in the
+// unprobed work residual whose own read decides the question. Callers must not
+// write through either.
+func resolveDrainMember(store beads.Store, memberID string, opts ProcessOptions) (storeref.Owner, bool, error) {
+	topo, err := drainResidency(store, opts)
+	if err != nil {
+		return storeref.Owner{}, false, err
+	}
+	plan, err := storeref.Plan(storeref.ByID{ID: memberID}, topo)
+	if err != nil {
+		return storeref.Owner{}, false, err
+	}
+	owner, err := storeref.ResolveOwnerRow(plan, memberID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return storeref.Owner{}, false, nil
+		}
+		return storeref.Owner{}, false, err
+	}
+	if owner.Read {
+		return owner, true, nil
+	}
+	bead, err := owner.Store.Get(memberID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return storeref.Owner{}, false, nil
+		}
+		return storeref.Owner{}, false, err
+	}
+	owner.Bead, owner.Read = bead, true
+	return owner, true, nil
+}

--- a/internal/dispatch/drain_residency.go
+++ b/internal/dispatch/drain_residency.go
@@ -17,9 +17,9 @@ import (
 // drain resolve a member out of another scope. The two stores the caller
 // already routed are the whole frame.
 //
-// Relics is nil, which BuildBindings reads as "may hold legacy residents" and
-// so keeps the residence probe. That is the honest answer for a caller that
-// took no census.
+// The zero BindingOptions leaves Relics nil, which BuildBinding reads as "may
+// hold legacy residents" and so keeps the residence probe. That is the honest
+// answer for a caller that took no census.
 func drainResidency(store beads.Store, opts ProcessOptions) (storeref.Topology, error) {
 	if len(opts.MemberStores) == 0 {
 		return storeref.Topology{Work: storeref.Leg{Ref: storeref.WorkRef, Store: store}}, nil
@@ -27,12 +27,7 @@ func drainResidency(store beads.Store, opts ProcessOptions) (storeref.Topology, 
 	if len(opts.MemberStores) > 1 {
 		return storeref.Topology{}, fmt.Errorf("drain residency: %d member stores, want at most 1", len(opts.MemberStores))
 	}
-	order := []beads.Store{store} // residency:allow one ambient binding, grouped for the shared BuildBindings derivation below
-	bindings, refused := storeref.BuildBindings(
-		order,
-		map[beads.Store][]coordclass.Class{store: drainInfrastructureClasses()},
-		storeref.BindingOptions{},
-	)
+	bindings, refused := storeref.BuildBinding(store, drainInfrastructureClasses(), storeref.BindingOptions{})
 	return storeref.Topology{
 		Work:     storeref.Leg{Ref: storeref.WorkRef, Store: drainWorkClassStore(store, opts)},
 		Bindings: bindings,

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -2710,3 +2710,171 @@ func TestEnsureDrainUnitConvoyFindsAConvoyMintedBeforeItsMemberVanished(t *testi
 		t.Fatalf("resuming pass created unit convoy %s (created=%v), want the already-minted %s; a lookup re-derived from the member moves stores the moment the member stops resolving", reused.ID, createdAgain, minted.ID)
 	}
 }
+
+// prefixDeclaringStore is a MemStore that DECLARES its mint prefix as a method,
+// which is what storeref.PrefixOwner routes on (storeref.HasIDPrefix).
+// beads.MemStore carries IDPrefix as a FIELD, so every existing drain fixture
+// stands its two stores up as prefix-LESS to storeref and the id-prefix fast
+// path never fires. Production stores all declare it (bdstore, native_dolt,
+// caching, exec), so a divergence that only appears when it fires is invisible
+// to a suite built on bare MemStores.
+type prefixDeclaringStore struct {
+	*beads.MemStore
+}
+
+func (s prefixDeclaringStore) IDPrefix() string { return s.MemStore.IDPrefix }
+
+// seedCoResidentDrainMember builds the shape neither existing fixture has: ONE
+// member id present in BOTH stores, over stores that declare their prefixes.
+//
+// seedSplitClassDrainWorkflow carries a copy of the CONVOY into the binding but
+// never of a member, and its stores are bare MemStores. Both gaps have to close
+// at once for a resolution disagreement about a member to be observable at all.
+func seedCoResidentDrainMember(t *testing.T) (work, graph prefixDeclaringStore, control, member beads.Bead) {
+	t.Helper()
+	workMem := beads.NewMemStore()
+	workMem.IDPrefix = "wrk"
+	work = prefixDeclaringStore{MemStore: workMem}
+
+	member, err := work.Create(beads.Bead{Title: "work copy", Type: "task"})
+	if err != nil {
+		t.Fatalf("create member in the work store: %v", err)
+	}
+
+	// The binding's co-resident copy: same id, its own row. This is what a
+	// migration leaves behind — the row is copied and the original retained.
+	graphMem := beads.NewMemStoreFrom(1000, []beads.Bead{{
+		ID:        member.ID,
+		Title:     "binding copy",
+		Type:      "task",
+		Status:    member.Status,
+		CreatedAt: member.CreatedAt,
+		UpdatedAt: member.UpdatedAt,
+	}}, nil)
+	graphMem.IDPrefix = "gcb"
+	graph = prefixDeclaringStore{MemStore: graphMem}
+
+	control, err = graph.Create(beads.Bead{
+		Title: "drain",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "drain",
+			"gc.drain_member_access": beadmeta.DrainMemberAccessExclusive,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create drain control: %v", err)
+	}
+	return work, graph, control, member
+}
+
+// TestClassifyDrainBlockerFaultIsAnErrorNeverAnOmittedEdge is the fault control
+// for the blocker classification's move onto the resolver. classifyDrainBlocker
+// answers a question whose "no" SILENTLY DROPS a dependency edge, so a store it
+// could not read must reach it as an error: an unread leg reported as
+// drainBlockerUnprojectable omits an edge that constrains the workflow, and an
+// unread leg reported as drainBlockerSatisfied omits one on the claim that a
+// blocker it never saw is terminal.
+func TestClassifyDrainBlockerFaultIsAnErrorNeverAnOmittedEdge(t *testing.T) {
+	work, graph, _, _ := seedCoResidentDrainMember(t)
+	hardErr := errors.New("work store unavailable")
+	opts := ProcessOptions{MemberStores: []beads.Store{drainGetErrorStore{Store: work, prefix: "wrk", err: hardErr}}}
+
+	residence, err := classifyDrainBlocker(graph, "wrk-blocker-1", opts)
+	if !errors.Is(err, hardErr) {
+		t.Fatalf("classifyDrainBlocker error = %v, want %v", err, hardErr)
+	}
+	if residence != drainBlockerUnclassified {
+		t.Fatalf("classifyDrainBlocker residence = %v, want drainBlockerUnclassified; a leg that could not be read must never decide an edge", residence)
+	}
+}
+
+// drainGetErrorStore is a leg whose every point read fails, with the id prefix
+// it declares kept intact so the plan still routes to it.
+type drainGetErrorStore struct {
+	beads.Store
+	prefix string
+	err    error
+}
+
+func (s drainGetErrorStore) IDPrefix() string { return s.prefix }
+
+func (s drainGetErrorStore) Get(string) (beads.Bead, error) { return beads.Bead{}, s.err }
+
+func coResidentDrainManifest(memberID string) drainManifest {
+	return drainManifest{
+		Version: 1,
+		Context: "separate",
+		Rows:    []drainManifestRow{{Index: 0, MemberID: memberID, UnitKey: "unit-0"}},
+	}
+}
+
+// TestManifestLoadAndReservationAgreeOnACoResidentMember pins the agreement the
+// two consumers of drainMemberProbeSet do not have: the manifest LOADS a member
+// through storeref.Resolve, which tries the id-prefix owner first, while the
+// reservation WRITES through drainMemberOwningStore, which hand-walks the same
+// list with no such fast path. Same list, different consultation order, so the
+// exclusive reservation can land on a row the manifest never serves — and an
+// exclusive reservation nothing reads is not a lock.
+func TestManifestLoadAndReservationAgreeOnACoResidentMember(t *testing.T) {
+	work, graph, control, member := seedCoResidentDrainMember(t)
+	opts := ProcessOptions{MemberStores: []beads.Store{work}}
+
+	if err := reserveDrainMember(graph, control, member, opts); err != nil {
+		t.Fatalf("reserveDrainMember: %v", err)
+	}
+	loaded, err := loadDrainManifestMembers(graph, control.ID, coResidentDrainManifest(member.ID), opts)
+	if err != nil {
+		t.Fatalf("loadDrainManifestMembers: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("loaded %d members, want 1", len(loaded))
+	}
+	if got := loaded[0].Metadata[beadmeta.ExclusiveDrainReservationMetadataKey]; got != control.ID {
+		t.Fatalf("manifest member reservation = %q, want %q; the reservation was written to a copy the manifest does not serve", got, control.ID)
+	}
+}
+
+// TestCoResidentDrainMemberAnswersFromTheBinding is the absolute row behind the
+// relative one above. A drain member is a FOREIGN bead of statically unknown
+// class — the drain reads it, it did not mint it — so a binding copy of a member
+// id is the live relocated bead and the work copy is the one the migration
+// retained frozen. Answering from work serves the frozen copy, which is the
+// stale-read half of the shape storereftest's binding-wins clauses forbid.
+//
+// It is deliberately not satisfied by making both surfaces agree: a fix that
+// converged them on work-first would pass the row above and fail this one.
+func TestCoResidentDrainMemberAnswersFromTheBinding(t *testing.T) {
+	work, graph, control, member := seedCoResidentDrainMember(t)
+	opts := ProcessOptions{MemberStores: []beads.Store{work}}
+
+	if err := reserveDrainMember(graph, control, member, opts); err != nil {
+		t.Fatalf("reserveDrainMember: %v", err)
+	}
+	loaded, err := loadDrainManifestMembers(graph, control.ID, coResidentDrainManifest(member.ID), opts)
+	if err != nil {
+		t.Fatalf("loadDrainManifestMembers: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].Title != "binding copy" {
+		t.Fatalf("manifest served %q, want the binding copy", loaded[0].Title)
+	}
+
+	bindingRow, err := graph.Get(member.ID)
+	if err != nil {
+		t.Fatalf("graph.Get(member): %v", err)
+	}
+	if got := bindingRow.Metadata[beadmeta.ExclusiveDrainReservationMetadataKey]; got != control.ID {
+		t.Fatalf("binding copy reservation = %q, want %q", got, control.ID)
+	}
+
+	workRow, err := work.Get(member.ID)
+	if err != nil {
+		t.Fatalf("work.Get(member): %v", err)
+	}
+	if workRow.Title != "work copy" {
+		t.Fatalf("retained work copy title = %q, want it untouched", workRow.Title)
+	}
+	if got := workRow.Metadata[beadmeta.ExclusiveDrainReservationMetadataKey]; got != "" {
+		t.Fatalf("retained work copy carries reservation %q, want none; the frozen copy must not be written", got)
+	}
+}

--- a/internal/storeref/bindings.go
+++ b/internal/storeref/bindings.go
@@ -20,8 +20,8 @@ package storeref
 import (
 	"sort"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/coordclass"
 )
 
@@ -126,7 +126,7 @@ func BuildBindings(order []beads.Store, byStore map[beads.Store][]coordclass.Cla
 func ReservedPrefixesFor(classes []coordclass.Class) []string {
 	prefixes := make([]string, 0, len(classes))
 	for _, class := range classes {
-		prefixes = append(prefixes, config.ReservedClassPrefixesFor(class.String())...)
+		prefixes = append(prefixes, beadmeta.ReservedClassPrefixesFor(class.String())...)
 	}
 	return prefixes
 }

--- a/internal/storeref/bindings.go
+++ b/internal/storeref/bindings.go
@@ -116,6 +116,24 @@ func BuildBindings(order []beads.Store, byStore map[beads.Store][]coordclass.Cla
 	return bindings, refused
 }
 
+// BuildBinding is BuildBindings for a plane that holds exactly ONE opened class
+// store and no grouping to derive: a drain framing its own ambient store, a
+// claim route constructed over a bare store.
+//
+// The grouping is trivial there, and both callers were writing it out — the
+// one-element order slice and the one-entry map — which is a store list
+// assembled outside the resolver for no reason other than to hand it straight
+// back. Assembling it here instead keeps every leg list in the package that
+// owns leg order, and the two callers cannot drift apart over what a one-store
+// grouping looks like.
+//
+// It is a shape, not a policy: opts still says what evidence the caller has,
+// and a caller with none passes the zero value and gets the pessimistic
+// bindings that entitles it to.
+func BuildBinding(store beads.Store, classes []coordclass.Class, opts BindingOptions) ([]ClassBinding, error) {
+	return BuildBindings([]beads.Store{store}, map[beads.Store][]coordclass.Class{store: classes}, opts)
+}
+
 // ReservedPrefixesFor returns the reserved id namespaces a class set HOLDS —
 // the prefix each class mints under plus any its store holds without minting,
 // such as the nudge queue's "gcnq" records inside the nudges store.

--- a/internal/storeref/storeref.go
+++ b/internal/storeref/storeref.go
@@ -133,7 +133,27 @@ func PrefixOwner(id string, stores []beads.Store) beads.Store {
 	return nil
 }
 
-// Resolve federates a point read: a bead lives in exactly one store, so it tries
+// Resolve federates a point read over a bare store LIST.
+//
+// # Superseded: do not add callers
+//
+// It has no callers outside this package's own tests. Every by-id read in the
+// tree now plans ByID over a Topology and executes it with ResolveOwnerRow,
+// which is not a stylistic preference: the PrefixOwner step below routes on the
+// id's OWN prefix, ahead of whatever order the caller assembled its list in, and
+// `gc storage migrate` copies-and-retains while PRESERVING ids. So for every
+// infrastructure bead minted before a cutover — which keeps its work-era prefix
+// — this function returns the work store and the caller reads the frozen
+// pre-migration row, successfully, with status and revision as of the cutover
+// and no error to notice (ga-cu12x). A plan has no such fast path: the binding
+// leads for an id inside its reserved namespace and every unretired binding is
+// probed ahead of work for an id inside none.
+//
+// It survives as the executor the plan's contract is compared against
+// (the leg-order and hard-failure rows in this package's tests) and because
+// deleting it would delete that comparison.
+//
+// The mechanics: a bead lives in exactly one store, so it tries
 // the prefix owner first (the cheap, fork-free path) and falls back to probing
 // every store in turn, returning the first hit. It preserves the first hard
 // (non-ErrNotFound) read failure seen across the owner probe and the fallback

--- a/internal/storeref/topology.go
+++ b/internal/storeref/topology.go
@@ -19,6 +19,7 @@ package storeref
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -202,6 +203,87 @@ func (t Topology) ClaimRefs() []StoreRef {
 		refs = append(refs, b.Leg.Ref)
 	}
 	return refs
+}
+
+// PrefixFault is one rig leg the by-id plan cannot gate honestly: its
+// CONFIGURED prefix — the only prefix shadowLegsCovering reads — is not the
+// prefix the leg's STORE declares it mints.
+//
+// Both are claims about the same namespace, one made by the city's config and
+// one by the store itself, and while they agree the gate is exact: a rig leg
+// that covers no part of an id's namespace holds nothing to say about that id,
+// so skipping it costs nothing and a miss over the remaining legs is PROVED
+// absence. That is what lets a wait on a genuinely deleted dependency fail on a
+// multi-rig city at all, and it is why a gated-out leg is not, by itself,
+// anything to report.
+//
+// When the two disagree the gate stops being exact in one direction: the plan
+// declines to read a store that may be holding the very id it was asked for.
+// The plan is not the thing that is wrong — it can only gate on what it was
+// told — the FRAME is, and a consumer that reads a miss over this frame as
+// proof of deletion is acting on a fault.
+//
+// Only a RIG leg can carry one. The work leg is in every by-id plan
+// unconditionally (RoleWorkFallback), so no prefix can gate it out, and a
+// binding is selected by the RESERVED namespaces its classes hold rather than
+// by a configured prefix.
+type PrefixFault struct {
+	// Ref names the leg, so a diagnostic can say which rig to reconcile.
+	Ref StoreRef
+
+	// Configured is the prefix the topology was built with — the one the plan
+	// gates on.
+	Configured string
+
+	// Declared is the prefix the leg's store says it mints.
+	Declared string
+}
+
+// String renders the fault as the sentence a consumer reports it with: which
+// leg, both prefixes, and what the disagreement costs.
+func (f PrefixFault) String() string {
+	return fmt.Sprintf(
+		"%s is configured with id prefix %q but its store declares %q, so the by-id plan gates it out of frame",
+		legName(f.Ref), f.Configured, f.Declared,
+	)
+}
+
+// PrefixFaults reports the rig legs whose configured and declared prefixes
+// disagree, in the plan's own rig order.
+//
+// Two shapes are deliberately NOT faults, and both exclusions are what keeps
+// this bounded to the disagreement rather than to gating itself.
+//
+// A store that declares NOTHING has made no claim to contradict. Reporting it
+// would fault the frame of every city whose rig work store is a bd/Dolt binding
+// with no configured mint prefix, and a consumer treating that as "absence
+// unprovable" could then prove absence nowhere — the failure the
+// configured-prefix gate exists to avoid, reintroduced from the other side.
+//
+// A rig leg resolving to the WORK store is not gated out at all: dedupeLegs
+// collapses it onto the work leg, which every by-id plan reads unconditionally.
+// The identity rule is the plan's own (storeSet), so the two cannot drift apart
+// about which legs a plan actually reaches.
+func (t Topology) PrefixFaults() []PrefixFault {
+	var reached storeSet
+	reached.addIfNew(t.Work.Store)
+	var faults []PrefixFault
+	for _, leg := range t.orderedRigs() {
+		declaring, ok := leg.Store.(HasIDPrefix)
+		if !ok {
+			continue
+		}
+		declared := strings.TrimSpace(declaring.IDPrefix())
+		configured := strings.TrimSpace(leg.Prefix)
+		if declared == "" || declared == configured {
+			continue
+		}
+		if !reached.addIfNew(leg.Store) {
+			continue
+		}
+		faults = append(faults, PrefixFault{Ref: leg.Ref, Configured: configured, Declared: declared})
+	}
+	return faults
 }
 
 // BindingFor returns the binding serving class c, if any.

--- a/internal/storeref/topology_prefix_fault_test.go
+++ b/internal/storeref/topology_prefix_fault_test.go
@@ -1,0 +1,97 @@
+package storeref
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// A rig leg whose two prefixes disagree is reported, and the report names both
+// so a consumer can say which rig to reconcile.
+func TestPrefixFaultsReportsARigWhoseDeclaredPrefixIsNotItsConfiguredOne(t *testing.T) {
+	rig := newPrefixed("ga")
+	topo := Topology{
+		Work: Leg{Ref: WorkRef, Store: newPrefixed("gcg"), Prefix: "gcg"},
+		Rigs: []Leg{{Ref: RigRef("frontend"), Store: rig, Prefix: "fe"}},
+	}
+
+	faults := topo.PrefixFaults()
+	if len(faults) != 1 {
+		t.Fatalf("PrefixFaults() = %v, want exactly the frontend rig", faults)
+	}
+	want := PrefixFault{Ref: RigRef("frontend"), Configured: "fe", Declared: "ga"}
+	if faults[0] != want {
+		t.Fatalf("PrefixFaults()[0] = %+v, want %+v", faults[0], want)
+	}
+	for _, part := range []string{"rig:frontend", `"fe"`, `"ga"`} {
+		if !strings.Contains(faults[0].String(), part) {
+			t.Errorf("PrefixFault.String() = %q, want it to name %s", faults[0].String(), part)
+		}
+	}
+}
+
+// The bounding rows. Each is a leg the by-id plan may well gate out, and none of
+// them is a FAULT: a consumer that treated them as one would be unable to prove
+// absence on any ordinary multi-rig city.
+func TestPrefixFaultsIsSilentOnEveryLegThatContradictsNothing(t *testing.T) {
+	work := newPrefixed("gcg")
+	for _, tc := range []struct {
+		name string
+		rig  Leg
+	}{
+		{
+			// The ordinary gated-out leg: the plan skips it for an id outside
+			// "fe", and it has said nothing to make that skip wrong.
+			name: "prefixes agree",
+			rig:  Leg{Ref: RigRef("frontend"), Store: newPrefixed("fe"), Prefix: "fe"},
+		},
+		{
+			// A bd/Dolt work store with no configured mint prefix. It has made
+			// no claim to contradict, and faulting it would fault most cities.
+			name: "store declares an empty prefix",
+			rig:  Leg{Ref: RigRef("frontend"), Store: newPrefixed(""), Prefix: "fe"},
+		},
+		{
+			name: "store declares no prefix at all",
+			rig:  Leg{Ref: RigRef("frontend"), Store: beads.NewMemStore(), Prefix: "fe"},
+		},
+		{
+			name: "no store",
+			rig:  Leg{Ref: RigRef("frontend"), Prefix: "fe"},
+		},
+		{
+			// dedupeLegs collapses this leg onto the work leg, which every by-id
+			// plan reads unconditionally, so no prefix gates it out of anything.
+			name: "the rig leg IS the work store",
+			rig:  Leg{Ref: RigRef("frontend"), Store: work, Prefix: "fe"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			topo := Topology{Work: Leg{Ref: WorkRef, Store: work, Prefix: "gcg"}, Rigs: []Leg{tc.rig}}
+			if faults := topo.PrefixFaults(); len(faults) != 0 {
+				t.Fatalf("PrefixFaults() = %v, want none", faults)
+			}
+		})
+	}
+}
+
+// Faults come back in the plan's own rig order, so two reports of one city read
+// the same way twice.
+func TestPrefixFaultsFollowsThePlansRigOrder(t *testing.T) {
+	topo := Topology{
+		Work: Leg{Ref: WorkRef, Store: newPrefixed("gcg"), Prefix: "gcg"},
+		Rigs: []Leg{
+			{Ref: RigRef("frontend"), Store: newPrefixed("ga"), Prefix: "fe"},
+			{Ref: RigRef("backend"), Store: newPrefixed("ga"), Prefix: "be"},
+		},
+	}
+
+	faults := topo.PrefixFaults()
+	if len(faults) != 2 {
+		t.Fatalf("PrefixFaults() = %v, want both rigs", faults)
+	}
+	if faults[0].Ref != RigRef("backend") || faults[1].Ref != RigRef("frontend") {
+		t.Fatalf("PrefixFaults() refs = %q, %q, want rig-ref ascending", faults[0].Ref, faults[1].Ref)
+	}
+}

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -90,6 +90,14 @@
 # which is the leg-order decision the resolver owns. Same shape as the drain.go
 # pair and pinned for the same reason; ga-qdt5y.16 covers it.
 #
+# cmd/gc/claim_class_route.go's holds was the fourth of that family and is the
+# first retired: ga-qdt5y.16 collapsed it onto storeref's ByID plan over a frame
+# the route captures at construction. Its row was `d:bdIDIsClassReserved` — the
+# vocabulary that gave it away, because deciding a refusal's meaning from an id's
+# prefix is the resolver's per-leg policy restated by hand. The route still
+# appears below on the cliSoleClassBinding row, which is a different claim (this
+# surface answers every reserved prefix from one store) and stays.
+#
 # The four ast:uncounted-call-spelling rows are storeFor calls reached through a
 # receiver no grep row names: cs.storageRoutes.storeFor in api_state.go,
 # cliStorageRoutes(cityPath).storeFor in cli_class_stores.go (the receiver is a
@@ -144,7 +152,6 @@ cmd/gc/city_runtime.go	run	a:rigBeadStores	1
 cmd/gc/city_runtime.go	sweepOrphanedOrderTrackingAtBoot	c:beads.Store-literal	1
 cmd/gc/city_runtime.go	syncBeadsAndUpdateIndex	a:rigBeadStores	1
 cmd/gc/city_runtime.go	tick	a:rigBeadStores	4
-cmd/gc/claim_class_route.go	holds	d:bdIDIsClassReserved	1
 cmd/gc/claim_class_route.go	hookClaimClassRouteForCity	b:cliSoleClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:graphClassBinding	1
 cmd/gc/class_store.go	graphClassBinding	b:routes.storeFor	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -66,20 +66,18 @@
 # single config.ReservedClassPrefix call is pinned, under the function that now
 # opens it. Still six rows, six hits.
 #
-# The two internal/dispatch/drain.go rows arrived when the signature rule
-# widened from cmd/gc+internal/api to every directory grep already scanned. The
-# comment that justified the narrower set claimed sling and dispatch held no
-# store-list constructor and that one added there would surface as a grep hit;
-# both halves of that were wrong — these two predate the claim, and a
-# constructor whose body names none of the vocabulary produces no grep hit at
-# all. Probe sets are the shape most worth watching here: a drain that assembles
-# its own candidate stores is deciding residency in its own order — and both of
-# these do. drainMemberProbeSet's list is walked with hand-rolled per-leg failure
-# policy; drainUnitConvoyProbeSet's is built in the REVERSE leg order of its own
-# sibling and handed straight to storeref.Resolve. Two probe sets in one file
-# disagreeing about leg order is the restatement this boundary exists to catch,
-# so these rows are a MIGRATION pinned open, not a sanctioned shape: ga-qdt5y.16
-# retires both.
+# Two internal/dispatch/drain.go rows arrived when the signature rule widened
+# from cmd/gc+internal/api to every directory grep already scanned, and both are
+# now retired by ga-qdt5y.16. Their opposite leg orders turned out NOT to be the
+# defect the row text originally claimed: a drain member is foreign and of
+# statically unknown class, so it resolves ByID and leads with the binding, while
+# a drain unit convoy is self-minted and statically ClassWork, so it resolves
+# RoutedWork and leads with work. Two orders, two intents — correct. The real
+# defect the pin caught was that drainMemberProbeSet's ONE list was consumed two
+# ways: hand-walked by drainMemberOwningStore and handed to storeref.Resolve by
+# loadDrainManifestMembers, whose id-prefix fast path made them disagree about
+# which co-resident copy of a member id was authoritative. The manifest served
+# one copy while the exclusive reservation was stamped on the other.
 #
 # cmd/gc/cmd_wait.go's newWaitDependencyStoreSet was the third of that family and
 # is the second retired. It had surfaced only when the signature rule learned to
@@ -249,5 +247,3 @@ internal/api/residency_by_id.go	resolveLegByConfiguredIDPrefix	d:IDInNamespace	1
 internal/api/residency_by_id.go	unroutedWorkLegs	a:BeadStores	1
 internal/api/residency_by_id.go	unroutedWorkLegs	ast:returns-store-list	1
 internal/api/state.go	(file-scope)	a:BeadStores	1
-internal/dispatch/drain.go	drainMemberProbeSet	ast:returns-store-list	1
-internal/dispatch/drain.go	drainUnitConvoyProbeSet	ast:returns-store-list	1

--- a/scripts/residency-boundary-baseline.txt
+++ b/scripts/residency-boundary-baseline.txt
@@ -81,14 +81,27 @@
 # so these rows are a MIGRATION pinned open, not a sanctioned shape: ga-qdt5y.16
 # retires both.
 #
-# cmd/gc/cmd_wait.go's newWaitDependencyStoreSet is the third of that family, and
-# it surfaced only when the signature rule learned to see through a local type
-# name: `type waitDependencyStoreSet []beads.Store` made the constructor's result
-# an *ast.Ident, and the rule had been reading spellings. The set's Get does hand
-# its list to storeref.Resolve — the executor applies the per-leg policy — but the
-# LIST is assembled here, city store first and rig stores in sorted-name order,
-# which is the leg-order decision the resolver owns. Same shape as the drain.go
-# pair and pinned for the same reason; ga-qdt5y.16 covers it.
+# cmd/gc/cmd_wait.go's newWaitDependencyStoreSet was the third of that family and
+# is the second retired. It had surfaced only when the signature rule learned to
+# see through a local type name: `type waitDependencyStoreSet []beads.Store` made
+# the constructor's result an *ast.Ident, and the rule had been reading spellings.
+# ga-qdt5y.16 collapsed it onto storeref's ByID plan over the topology the
+# controller already registered at boot, with the suspension frame threaded in
+# the way the census arms thread it. Three things were wrong with the list and
+# each was live. It read every rig the runtime held open, suspended ones
+# included, whose stores are dark — one suspended rig made every dependency read
+# in the city error, and the wake pass aborts on a dependency error, so no wait
+# anywhere could be readied. Its executor was storeref.Resolve, whose PrefixOwner
+# fast path consults the store whose declared prefix owns the id FIRST, so an
+# infrastructure id the migration preserved answered from the work ledger's
+# frozen twin no matter which leg the list put first (ga-cu12x) — the reason
+# #5488's binding-first ordering did not close it. And absence over the narrowed
+# serving frame was reported as a clean not-found, which FAILS a waiter; the
+# reader now answers "absence not proved" there instead.
+#
+# cmd_wait.go still appears below on the loadWaitDependencyBead row, which is the
+# one-shot registration/wake path (a:convoyStoreCandidates, reached only from
+# prepareWaitWakeStateForCity) and a different slice.
 #
 # cmd/gc/claim_class_route.go's holds was the fourth of that family and is the
 # first retired: ga-qdt5y.16 collapsed it onto storeref's ByID plan over a frame
@@ -191,7 +204,6 @@ cmd/gc/cmd_graph.go	doGraph	ast:uncounted-call-spelling	1
 cmd/gc/cmd_graph.go	resolveGraphInput	ast:uncounted-call-spelling	1
 cmd/gc/cmd_storage.go	reportBindingRelics	d:AllReservedClassPrefixes	1
 cmd/gc/cmd_wait.go	loadWaitDependencyBead	a:convoyStoreCandidates	1
-cmd/gc/cmd_wait.go	newWaitDependencyStoreSet	ast:returns-store-list	1
 cmd/gc/convergence_tick.go	buildConvergenceScopes	a:rigBeadStores	1
 cmd/gc/convergence_tick.go	buildConvergenceScopes	b:graphClassBinding	1
 cmd/gc/dispatch_control_ready.go	controlReadyCacheSources	ast:returns-store-list	1


### PR DESCRIPTION
**Segment 6 of 8 — re-split out of #5644, whose head had silently absorbed this
segment and s7 as squash merges.** Rebased onto `main`: #5644 (segment 5) landed
as squash `c6bb2aa30d`, #5626 (pr1) as `6f69447ce2`, #5600 as `abe0a0c6b9`. s7
(the residency-guard file split) is NOT here; it follows as its own PR.

See segment 1 for the bug class and the full segment table.

## The mechanism

`storeref.Resolve(id, stores)` tries `PrefixOwner` FIRST — the cheap fork-free
path — and `PrefixOwner` matches on the id's OWN prefix, ahead of whatever order
the caller assembled its list in. `gc storage migrate` COPIES AND RETAINS
(`infra_class_migrate.go:1006`) and it PRESERVES ids, so an infrastructure bead
minted before a cutover keeps its work-era prefix and exists twice: a frozen row
in the work ledger and the live row in the binding.

Net: every `storeref.Resolve` caller read the frozen pre-migration copy for every
migration-preserved infra id. Successfully, with no error to notice, with status
and revision as of the cutover. That is `ga-cu12x`, and its four live callers on
`main` — `cmd/gc/cmd_wait.go:67` and `internal/dispatch/drain.go:428/804/1335` —
are exactly the probes this segment retires. `ga-cu12x` closes here.

Each of the four had also grown its own answer to "which store owns this id", and
each was wrong in a different way besides.

## The retired sites

| site | was | now |
| --- | --- | --- |
| `cmd/gc/claim_class_route.go` `holds` | unconditional `graph.Get`, a hand-rolled not-found arm, a hand-rolled standing-refusal predicate keyed on the id's prefix | `storeref.ByID` over a frame captured at construction, executed by `storeref.ResolveBindingOwner` |
| `cmd/gc/cmd_wait.go` `newWaitDependencyStoreSet` | `storeref.Resolve` over `[binding, city, rigs sorted]` | `storeref.ByID` over the topology the controller registered, narrowed to the serving rigs |
| `cmd/gc/cmd_wait.go` `loadWaitDependencyBead` | #5488's `classBindingForID` probe, then a store-directory scan | `cliByIDBindingOwner` + `beadForOwner`, then the scan |
| `internal/dispatch/drain.go` `drainMemberProbeSet` | one list consumed two ways — hand-walked to RESERVE, `storeref.Resolve`d to SERVE | `resolveDrainMember` (`ByID`), one answer for both |
| `internal/dispatch/drain.go` `drainUnitConvoyProbeSet` | the sibling's list in reverse, handed to `storeref.Resolve` | `Plan(RoutedWork)` — work-led, which is correct for a self-minted `ClassWork` convoy |
| `internal/dispatch/drain.go` `classifyDrainBlocker` | `storeref.Resolve` over the member-store tail | `resolveDrainMember` |

The blocker site has no behaviour delta at the one member-store shape any
production caller constructs; its value is that "which store holds this id" now
has ONE spelling in `drain.go` instead of three, and that it was the last
`storeref.Resolve` caller in the tree. The ambient store is still asked first and
by hand there, because that read is the CO-RESIDENCY question — can this store's
dep table reference this id — which is a different question from residency.

`drainResidency` frames exactly ONE binding: the drain's own ambient store,
carrying every infrastructure class, censused by nobody and therefore
pessimistic. **More than one member store is REFUSED, loudly, rather than
walked.** That is a contract statement, not a TODO: a drain resolves inside the
two stores its caller already routed, and a frame that quietly grew a second
member leg would let a drain resolve a member out of another scope. Single-store
callers get a one-leg topology and the identity fast path, so they pay nothing.

With no production caller left, `storeref.Resolve` is documented as **superseded**
rather than deleted: `internal/storeref`'s own tests still compare the plan's
contract against it, and deleting it would delete that comparison. `cmd/gc`'s
by-id conformance row (I7) moves onto the derivation production actually runs
(`residencyBindingsFromRoutes` → `byIDBeadForTopology`), so the guard guards the
shipped path. `classBindingForID`, whose last caller was the one-shot wait
loader, is deleted.

`byIDBeadForTopology` is extracted from the closure #5928 put inside
`newWarmClaimTriggerResolver`: plan `ByID`, `ResolveOwnerRow`, `beadForOwner`.
Both controller-side by-id readers go through it, so there is one spelling and
not three.

Two supporting changes carry as-is:

- `internal/beadmeta/reserved_prefixes.go` moves the reserved-prefix table to a
  stdlib-only leaf. It lived in `internal/config`, which meant every consumer —
  `internal/coordclass` and `storeref` included — imported the config package to
  read a static table.
- `internal/storeref/relic_census_bench_test.go` measures what the boot census
  costs (7.2ms at 1k rows, 82ms at 10k, linear).

## Reconciliation with #5626 (pr1), which landed first

pr1 introduced `storeref.ResolveBindingOwner` — the `ModeFirstOwner` executor
that walks the binding legs and stops at the caller's own work axis BY ROLE —
and rewrote `cmd/gc/by_id_residency.go` around it. This branch was written
against a type-assertion form of the same question. **pr1's is the one that
survives; there is no residual type check on the work leg anywhere in the tree.**

| | before this rebase | after |
| --- | --- | --- |
| `byIDBindingOwnerForTopology` | `byIDOwnerForTopology` + `owner.Store.(unprobedWorkResidual)` | `byIDPlanForTopology` + `storeref.ResolveBindingOwner` + `withProvenRelicRemedy` (pr1's body, verbatim) |
| `cliByIDBindingOwner` / `cliByIDOwner` / `cliByIDPlan` topology | `residencyTopologyForCity` | `byIDResidencyTopology` (pr1's, which adds the refused-city relic proof) |
| `hookClaimClassRoute.holds` | the type-assertion form, via `byIDBindingOwnerForTopology` | unchanged call, now reaching `ResolveBindingOwner` |
| `soleBindingResidency` | `residencyBindingsFor(order, byStore, relics)` | `storeref.BuildBinding(store, classes, opts)` (see below) |

The assertion was not merely a duplicate spelling, it was the weaker one: it can
only see the store the walk RETURNED, so it cannot decline the shadow legs
ordered behind the residual, and `dedupeLegs` removes the residual outright on a
city whose binding resolved back to the work store. `ResolveBindingOwner` stops
on `Role.ownedByCallersWorkAxis()`, which covers both. Everything this branch
duplicated of pr1's — the `byIDOwnerForTopology` / `byIDPlanForTopology` /
`byIDBindingOwnerForTopology` split, which both PRs happened to introduce — is
deleted in favour of pr1's copy.

pr1's proven-relic refusal semantics are intact and untouched:
`ClassBinding.KnownLegacyResidents`, `ClassBinding.probeRefusalPolicy`,
`storeref.ProvenLegacyResidents`, `storeref.ErrProvenRelicRefusal`,
`residencyBindingsFromRoutesWithProof` and the whole of
`cmd/gc/by_id_relic_proof.go`. Two adjustments follow from them rather than
change them:

- `soleBindingResidency` and `drainResidency` both pass the zero
  `storeref.BindingOptions`, and their docs now say why its two nil evidence
  funcs mean OPPOSITE things: no census keeps the probe
  (`HasLegacyResidents=true`), no proof never denies a read
  (`KnownLegacyResidents=false`). A caller that took neither is entitled to
  exactly that pair.
- `byIDBeadForTopology` — this branch's new controller-side door — now shares
  `byIDOwnerRowForTopology` with `byIDOwnerForTopology`, so it inherits
  `withProvenRelicRemedy`. pr1 attached that remedy at the two doors it touched;
  a third door reaching the same denial without it would print the boot gate's
  own sentence and send the operator looking for a missing bead. The two
  whole-plan readers now differ only in what a clean miss means to them.

## Two changes from what #5645 proposed

**1. The wait reader is binding-FIRST, not binding-last.** #5645 replaced
#5488's binding-first store set with `Plan(RoutedWork)` + `Walk`, which puts the
binding LAST. That contradicts the residency doctrine this lane established since
(`ga-oytw9`/#5918, #5928): the binding LEADS for a class-resident id. The reader
here plans `ByID` instead, which is binding-first for an id inside a relocated
class's reserved namespace (#5488's property, now enforced by the resolver rather
than by a list order) AND puts every unretired binding's residence probe ahead of
the work ledger for an id inside none — which is the retained-copy case #5488's
ordering could not close, because `PrefixOwner` ran ahead of the list.

#5488's two rows are ported, not dropped:
`TestPrepareWaitWakeState_ResolvesGraphBindingDependencyBeads` now builds its
binding leg through `soleBindingResidency` and reads through the plan;
`TestLoadWaitDependencyBeadReadsTheBindingOnAMigratedCity` is unchanged, because
the loader it covers is the same loader.

`errWaitDependencyUnproven` is kept for "no leg could answer": absence over a
frame narrowed by a suspended rig is not proof, and failing a wait is terminal.
One consequence of `ByID` differs from #5645 and is called out rather than
hidden: the by-id plan makes every leg fatal, so a dark SERVING rig still aborts
the wake pass with its own error instead of degrading. The suspended-rig freeze
#5645's subject names is closed by narrowing the FRAME (`servingRigStores`) so a
suspended rig is out of the plan rather than dark inside it — which is the fix —
and no per-leg failure policy is restated in `cmd_wait.go`. The table row #5645
flipped is therefore renamed and kept asserting the fault, with a comment
pointing at the row that covers the freeze.

**2. No status file.** #5645 introduced `.gc/storage-relic-census.json` and a
reader/writer pair to memoize the census across processes. AGENTS.md: *"No status
files — query live state."* The monotonicity argument is sound in the abstract,
but the artefact goes stale the moment an operator rebuilds or re-points a
binding, nothing clears it, and a later `gc` then keeps or retires a probe on a
verdict no store agrees with. The memo file, its writer, its reader and its four
tests are dropped.

The bound the memo was reaching for already holds in-process and by construction:
`cliStorageRoutes` takes the census inside a `sync.Once` per city and the
controller takes it once at boot, so the verdict lives in the routes value both
callers already hold. That is now documented on `censusBindingRelics`, measured
by the bench (kept as the cost regression guard), and pinned by
`TestBootCensusIsLiveAndLeavesNothingOnDisk`. The real residual is a cheaper scan
rather than a cache — it needs a store-level id-namespace predicate
`beads.ListQuery` does not have — and `ga-dx4ho` carries it.

## RED → GREEN

Each retired probe has a split row that fails on the old reader, a fault control,
and a single-store control.

New in this re-split, and the row `ga-cu12x` asks for:

- `TestPrepareWaitWakeState_MigrationPreservedDependencyAnswersFromTheBinding` —
  the binding holds the live CLOSED dependency under a work-era id, the work
  ledger holds the frozen OPEN twin under its own declared prefix. The wait must
  ready. RED against the old reader: `readyWaitSet[...] = false`.
- `TestWaitDependencyPlanReaderBindingFaultIsAnErrorNeverAbsence` — a binding
  that cannot be read must arrive as that error, never as `beads.ErrNotFound`
  (which reaps the waiter) and never downgraded to unproven (which only logs).
  RED against the old reader: `error = <nil>`, the frozen copy answered.
- `TestWaitDependencyPlanReaderSingleStoreCityIsByteIdentical` — a city with
  nothing relocated gets the store's own row back and its own `ErrNotFound`.
- `TestClassifyDrainBlockerFaultIsAnErrorNeverAnOmittedEdge` — the blocker
  classification's "no" silently DROPS a dependency edge, so a leg that could not
  be read must never decide one.
- `TestBootCensusIsLiveAndLeavesNothingOnDisk` — a second independent open of the
  same city reaches the verdict from the store alone, and no census artefact is
  written.

Carried from #5645: `TestClaimRouteHoldsSkipsTheProbeOnACensusCleanBinding`,
`TestClaimRouteHoldsKeepsTheAuthorityLegOnACensusCleanBinding`,
`TestPrepareWaitWakeState_SuspendedFrameRetainsAnUnprovedWait`,
`TestPrepareWaitWakeState_ResolvesBindingResidentDependency`,
`TestPrepareWaitWakeState_CoResidentDependencyAnswersFromTheWorkStore`,
`TestPrepareWaitWakeState_DarkCityWorkLegStillAbortsThePass`,
`TestDepsWaitReadyUnprovenDependencyNeitherFailsNorReadies`,
`TestManifestLoadAndReservationAgreeOnACoResidentMember`,
`TestCoResidentDrainMemberAnswersFromTheBinding`,
`TestWaitDependencyReadServesTheBindingCopy`,
`TestWaitReadiesOnADependencyTheMigrationRelocated`.

pr1's own rows are unchanged and still green after the reconciliation, including
`TestResolveBindingOwnerNeverProbesTheWorkLeg` (the zero-probe pin the
type-assertion form could not make) and the `T3k` conformance rows that turn
`ByID(ga-xyz)` and `ByID(ra-7)` Fatal on a proven-relic binding.

## Mutation probes

Each applied and reverted.

Reverting the wait reader to `storeref.Resolve` over `[bindings, work, rigs]`:

```
--- FAIL: TestPrepareWaitWakeState_MigrationPreservedDependencyAnswersFromTheBinding
    readyWaitSet[gcg-session-1] = false, want true; the wait read the work
    ledger's frozen pre-migration copy instead of the binding's live row
--- FAIL: TestWaitDependencyPlanReaderBindingFaultIsAnErrorNeverAbsence
    Get(hq-dep-1) error = <nil>, want binding store unavailable
--- FAIL: TestPrepareWaitWakeState_CoResidentDependencyAnswersFromTheWorkStore
    readyWaitSet[gcg-session-1] = false, want true
```

The single-store control and the reserved-prefix row stay GREEN — the two that
were already right for a different reason.

Reverting `loadDrainManifestMembers` to the PrefixOwner-first probe set:

```
--- FAIL: TestManifestLoadAndReservationAgreeOnACoResidentMember
    manifest member reservation = "", want "gcb-1001"
--- FAIL: TestCoResidentDrainMemberAnswersFromTheBinding
    manifest served "work copy", want the binding copy
```

Removing the one-shot loader's binding leg entirely (the pre-#5488 scan) fails
all three of its rows, and fails them differently — the reserved-prefix row
reports "bead not found", the retained-copy rows report the frozen work copy
served open. Writing the census note by hand fails
`TestBootCensusIsLiveAndLeavesNothingOnDisk`.

## Baseline

Shrink-only: **four rows retired, none added.** The full baseline was
regenerated by the documented three-emitter splice
(`check-residency-boundary.sh --emit-baseline`, plus
`RESIDENCY_BASELINE_EMIT=1 go test ./scripts -run TestResidencyResolverBoundary`
and `-run TestResidencyASTExpressionRatchet`, concatenated and `LC_ALL=C sort`ed)
and compared byte-for-byte against the file below; the splice reproduces it
exactly, so nothing was re-keyed by the rebase.

```
-cmd/gc/claim_class_route.go	holds	d:bdIDIsClassReserved	1
-cmd/gc/cmd_wait.go	newWaitDependencyStoreSet	ast:returns-store-list	1
-internal/dispatch/drain.go	drainMemberProbeSet	ast:returns-store-list	1
-internal/dispatch/drain.go	drainUnitConvoyProbeSet	ast:returns-store-list	1
```

- `claim_class_route.go holds d:bdIDIsClassReserved` — the vocabulary that gave
  it away: deciding a refusal's meaning from an id's prefix is the resolver's
  per-leg policy restated by hand. The route still appears on its
  `b:cliSoleClassBinding` row, which is a different claim and stays.
- `cmd_wait.go newWaitDependencyStoreSet ast:returns-store-list` — the
  constructor is gone. `cmd_wait.go` still appears on the
  `loadWaitDependencyBead a:convoyStoreCandidates` row, which is the store-scan
  half of the one-shot loader and a different slice.
- the two `internal/dispatch/drain.go ast:returns-store-list` rows — both probe
  sets are gone. The prose above them is rewritten: their opposite leg orders
  turned out to be correct rather than the defect the row text claimed, and the
  real defect was one list consumed two ways.

`cmd/gc/residency_topology.go residencyBindingsFromRoutesWithProof
b:routes.storeFor` is pr1's re-key of `residencyBindingsFromRoutes`'s row and is
inherited from `main` unchanged.

**No `// residency:allow` marker is added by this PR.** The two new frames each
needed a one-store leg list — `soleBindingResidency` in `cmd/gc` and
`drainResidency` in `internal/dispatch` — and each was writing out the
one-element `order` slice and the one-entry `byStore` map by hand, in packages
that do not import each other, purely to hand them straight back to
`storeref.BuildBindings`. That is a store list assembled outside the resolver,
which is exactly what the guard is for. Both now call `storeref.BuildBinding`,
the one-store shape, so the literal lives in the package that owns leg order,
the two callers cannot drift over what a one-store grouping looks like, and the
guard has nothing to suppress. The header prose is updated for each retirement
so the file still explains every row it keeps. `scripts/` is otherwise untouched
— the guard's own file split is s7.

## Gates

Run on `32e1823ed8d389ee841eb239c5fd4a2aac936dc2`, rebased onto `main` at `c6bb2aa30d`.

| gate | exit | result |
| --- | --- | --- |
| `go build ./...` | 0 | clean |
| `go vet ./...` | 0 | clean |
| `gofmt -l cmd internal` | 0 | nothing printed |
| `gofmt -l cmd internal scripts` | 0 | nothing printed |
| `golangci-lint run ./cmd/gc/... ./internal/dispatch/... ./internal/storeref/... ./internal/beadmeta/...` | 0 | `0 issues.` |
| `./scripts/check-residency-boundary.sh` | 0 | clean |
| `./scripts/check-residency-boundary.sh --self-test` | 0 | clean |
| `go test ./internal/storeref/... ./internal/dispatch/... ./internal/beadmeta/... -count=1` | 0 | ok |
| `go test ./internal/config/... ./internal/coordclass/... -count=1` | 0 | ok |
| `go test ./cmd/gc -run 'Wait\|Drain\|Claim\|ByID\|Residency\|Relic\|Census\|Boot' -count=1` | 0 | ok |
| `go test ./scripts/... -count=1` | 0 | ok |
| `make test-fast-parallel` | 0 | `All fast jobs passed` (run by the pre-push hook on this exact head; see the note below) |

`make test-fast-parallel` is the suite `.githooks/pre-push` runs, and the row
above is that hook's run on this exact head — the push would not have completed
otherwise. It is recorded that way deliberately rather than run twice: this host
caps concurrent heavy suites at two slots
(`scripts/push-gate-lock-lib.sh`, `ga-owh20p`), and an earlier standalone
invocation exited **75 (EX_TEMPFAIL)** after waiting out the 600 s bound with
both slots held by unrelated runs. That exit code is the gate reporting host
contention, not a test result, and the documented response is to rerun rather
than to set `GC_PUSH_GATE_NO_CAP=1` — bypassing it is what produced the load
incidents the gate exists to prevent.

`.githooks/pre-commit` is active (`git config core.hooksPath` prints
`.githooks`) and ran on every commit here; the branch was pushed with the
pre-push hook enabled, no `--no-verify`. No base-owned failure was reproduced:
every gate above is green on this head.

Refs `ga-cu12x` (closes), `ga-j4p3y`, `ga-qdt5y.16`.

---

# Update — rebased onto `main`, and the prefix-fault row is fixed

Head is now `e8bf6de219ddc77a13d3d10f2e0231c61b2a4bd6`. The branch was **rebased**, not merged: the
`Merge remote-tracking branch 'origin/main'` commit (`49927f5e7e`) is gone, the
seven s6 commits and the maintainer's `chore(review)` commit (`e55acb3c8f`)
replay linearly onto `main`, and one new commit carries the fix below.

## The rebase

`git rebase --onto origin/main c6bb2aa30d` over the four merges that landed since
the branch was cut — #6139, #6138 (`workrecord.RepoDirFor` +
`workRecordRepoDirs`), #6142 (`ProvenLegacyResidents` on the closed-inclusive
census) and #5602 (`internal/beads/namespace_census.go` +
`storeref.legacyResidentVerdict`). `f3610ae8e6` was dropped as already upstream.

**One conflict**, `internal/storeref/relic_census_bench_test.go` (add/add).
`main`'s version wins whole: #5602 made the census answerable by a store-level
predicate (`beads.NamespaceCensus`), so `main`'s file benchmarks the predicate
and keeps the listing form as `BenchmarkRelicCensusScanFallback_10k`. This
branch's version measured only the listing form, which is a strict subset.

Two prose blocks this branch had written about that cost were left stale by that
resolution and are now corrected against a fresh measurement rather than
deleted — `censusBindingRelics` in `cmd/gc/storage_boot.go` and
`TestBootCensusIsLiveAndLeavesNothingOnDisk` in
`cmd/gc/relic_census_boot_test.go`. Both had cited the pre-#5602 numbers
(7.2 ms/1k, 82 ms/10k) and closed with "bounding it needs a store-level
id-namespace predicate `beads.ListQuery` does not have (`ga-dx4ho`)", which
#5602 landed. Measured on this head:

| form | 1k rows | 10k rows |
| --- | --- | --- |
| `beads.NamespaceCensus` predicate | 0.40 ms | 3.2 ms |
| listing fallback (native-Dolt binding) | — | 97 ms |

The argument the blocks exist to make is unchanged and now says the true thing:
the read is still paid per process rather than written to disk, and the saving
came from making the read cheaper, not from remembering it.

Everything else replayed clean, including
`scripts/residency-boundary-baseline.txt`, `internal/storeref/bindings.go`,
`cmd/gc/by_id_residency.go` and `internal/dispatch/drain.go`. The baseline is
unchanged from the version reviewed at `32e1823ed8`: shrink-only, **4 rows
retired, 0 added**, and `./scripts/check-residency-boundary.sh` exits 0 without
regeneration — no row re-keyed, so no 3-emitter splice was needed.

## The fix: a rig that contradicts its own config is a FAULT, not an absence

`e55acb3c8f` added
`TestPrepareWaitWakeState_PrefixUncoveredRigDependencyDoesNotReapTheWaiter`,
red. It builds a rig whose **configured** prefix (`"fe"`) disagrees with the
prefix its **store** declares (`"ga"`), and asserts that a wait on `ga-dep-1`
is retained rather than reaped.

The row is kept byte-for-byte. What it caught:

- the by-id plan gates rig legs on the CONFIGURED prefix (`shadowLegsCovering`),
  so the `"fe"` rig is out of the plan for `ga-dep-1` even though its store holds
  that bead;
- the plan therefore misses everywhere and returns `beads.ErrNotFound`;
- `waitDependencyPlanReader.Get` passed that through as a PROVED absence, and
  `prepareWaitWakeStateWithSnapshot` FAILS a wait on a proved absence — so a
  living dependency reaped its waiter.

A disagreement between what a rig's config says and what its store says is a
fault in the FRAME, and residency doctrine already holds that a fault is never
absence.

### Where the disagreement is detected

`storeref.Topology.PrefixFaults()` — read off the same captured frame the wait
reader already holds, in the package that owns both `Leg.Prefix` and the
`HasIDPrefix` declaration, so the fault and the gate that creates it are stated
once. It returns `[]PrefixFault{Ref, Configured, Declared}` in the plan's own
rig order, and `PrefixFault.String()` is the sentence a consumer logs.

`cmd/gc/cmd_wait.go` consumes it in `waitFrameGap`, which replaces the reader's
`narrowed bool` with an `outOfFrame string` naming what the frame leaves out.
The two causes now sit side by side and are handled identically: a suspended rig
is TOLD to the constructor (the caller already dropped it from the serving set),
a prefix fault is READ off the frame. Either one makes a miss
`errWaitDependencyUnproven`, so the wait pends and the next tick tries again.

### Why this stays bounded

**Gating rig legs on the configured prefix is not the bug and is not changed.**
On any multi-rig city most legs are gated out of most by-id plans; that is what
makes absence PROVABLE, and it is the only reason a wait on a genuinely deleted
dependency can ever fail. Three shapes are therefore explicitly *not* faults,
each pinned in `internal/storeref/topology_prefix_fault_test.go`:

| shape | why it is not a fault |
| --- | --- |
| the two prefixes AGREE | the gate is exact; a leg covering none of the id's namespace holds nothing to say about it |
| the store declares NOTHING (`""` or no `IDPrefix()`) | no claim to contradict — a bd/Dolt work store with no configured mint prefix, i.e. most cities |
| the rig leg IS the work store | `dedupeLegs` collapses it onto the work leg, which every by-id plan reads unconditionally |

Nothing outside the wait reader consumes `PrefixFaults()`, so no plan, drain,
claim route or census changes behaviour.

False positives are structurally unlikely for the same reason the fault is worth
reporting: on every production path a rig's store is OPENED with the configured
prefix — `controllerState.openRigStore(..., rig.EffectivePrefix(), ...)` feeds it
straight into the exec store's `GC_BEADS_PREFIX`, and
`work_query_probe.go` projects the same value — so the two agree by
construction. A city where they do not has an inconsistency an operator needs to
see, and the log line names the rig and both prefixes.

## The two rows, and the mutation that separates them

| row | before the fix | after the fix | under the mutation |
| --- | --- | --- | --- |
| `TestPrepareWaitWakeState_PrefixUncoveredRigDependencyDoesNotReapTheWaiter` (prefixes DISAGREE, dependency lives in the gated-out rig) | **RED** — `wait state = "failed", want "pending"` | **GREEN** | GREEN |
| `TestPrepareWaitWakeState_AgreeingPrefixRigStillProvesTheDependencyGone` (prefixes AGREE, leg still gated out, dependency absent everywhere) | **GREEN** | **GREEN** | **RED** — `wait state = "pending", want "failed"; a gated-out leg whose two prefixes agree must leave absence provable` |

The control is the same shape as the red row with exactly one thing changed —
the rig's configured prefix IS what its store declares — and it asserts the
opposite outcome: the wait is FAILED and CLOSED with `last_error` recorded,
because a dependency in no leg of an honest plan is gone.

**The mutation** is the cheap wrong fix the verdict forbids: replace the
`PrefixFaults()` loop in `waitFrameGap` with one that reports every rig leg,
i.e. treat every prefix-gated-out leg as out of frame.

```go
	for _, leg := range topo.Rigs {
		gaps = append(gaps, string(leg.Ref)+" is gated out of frame")
	}
```

That turns the control RED and leaves the new row GREEN, which is the whole
point of having both: it makes absence unprovable on any multi-rig city, so a
wait on a genuinely deleted dependency would pend forever — strictly worse than
the freeze being fixed. The mutation was applied, observed, and reverted; it is
not in the branch.

`internal/storeref/topology_prefix_fault_test.go` pins the predicate itself: the
positive row (both prefixes named in the report), five silent rows covering the
three shapes above (an agreeing prefix; a store declaring `""`, declaring no
`IDPrefix()` at all, or absent entirely; and a rig leg that IS the work store),
and rig-ref ordering.

## Gates — all on `e8bf6de219ddc77a13d3d10f2e0231c61b2a4bd6`

| gate | exit | result |
| --- | --- | --- |
| `go build ./...` | 0 | clean |
| `go vet ./...` | 0 | clean |
| `gofmt -l cmd internal` | 0 | nothing printed |
| `golangci-lint run ./cmd/gc/... ./internal/dispatch/... ./internal/storeref/... ./internal/beadmeta/...` | 0 | `0 issues.` |
| `./scripts/check-residency-boundary.sh` | 0 | clean, no regeneration |
| `./scripts/check-residency-boundary.sh --self-test` | 0 | clean |
| `go test ./internal/storeref/... ./internal/dispatch/... ./internal/beadmeta/... -count=1` | 0 | ok |
| `go test ./cmd/gc -run 'Wait\|Drain\|Claim\|ByID\|Residency\|Relic\|Census\|Boot' -count=1` | 0 | ok (44.6 s) |
| `go test ./scripts/... -count=1` | 0 | ok |
| `make test-fast-parallel` | 0 | `All fast jobs passed` — run by `.githooks/pre-push` on this exact head; the push would not have completed otherwise |

`make test-fast-parallel` is recorded as the pre-push hook's run rather than as a
second standalone invocation, for the reason the section above already gives:
this host caps concurrent heavy suites at two slots
(`scripts/push-gate-lock-lib.sh`, `ga-owh20p`), and the documented response to
contention is to wait rather than to set `GC_PUSH_GATE_NO_CAP=1`, which was left
untouched. `.githooks/pre-commit` is active and ran on the new commit; the push
used `--force-with-lease`, no `--no-verify`.

### One base-owned flake, disclosed and NOT worked around

A standalone `make test-fast-parallel` run on this head failed once in
`internal/storebinding/sqlite`:

```
--- FAIL: TestSQLiteWriterFenceSIGKILLAtReservationBoundaries/WAL_without_SHM/reservation-lock-pending
    sqlite_fence_process_linux_test.go:324: removing crash-retained SQLite SHM:
    remove .../graph/beads.sqlite-shm: no such file or directory
```

It is base-owned by construction: `git diff origin/main HEAD --
internal/storebinding internal/beads` is EMPTY, so that package is byte-identical
to `main` on this branch. The row kills a child process and requires SQLite to
have left a `-shm` behind; under a loaded 10-job harness the file is
occasionally already gone, which is a timing race in the fixture and not an
assertion about the code under test. It did not reproduce in 8 consecutive runs
on an untouched `origin/main` export (`git archive origin/main`), nor on re-run
here, nor in the pre-push hook's run on this head — the run recorded above
printed `All fast jobs passed` with that row green. **No workaround, skip, retry
or quarantine was added for it**: the recorded green is a clean run, not a run
with the row disabled.

Refs `ga-cu12x` (closes), `ga-j4p3y`, `ga-qdt5y.16`.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5987 — covers the same copy-and-retain co-residency on the read side — the wait-dependency, drain-member and claim-route probes now resolve a migration-preserved id to the binding's live row instead of the frozen pre-migration copy in the work ledger; it does not converge by-id writes onto the retained work row, tombstone it, or change the work-first precedence on the demand/claim surfaces, so the orphan-reopen and re-dispatch loop that issue measures is not addressed here

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
