### PR TITLE
fix(storeref): prove relics on the closed-inclusive census too (ga-q8ick)

### DIFF
--- a/cmd/gc/by_id_relic_proof.go
+++ b/cmd/gc/by_id_relic_proof.go
@@ -18,10 +18,10 @@ package main
 // The obvious place to keep this verdict is a note under the city's own .gc,
 // written by whichever process last managed to read the binding. It is the
 // wrong place twice over. It is a status file, which this codebase does not
-// keep (AGENTS.md: no status files — query live state), and it goes stale in
-// the DENYING direction: relics close over the weeks after a migration, so a
-// note written in March denies reads in June for a binding that has been clean
-// since April.
+// keep (AGENTS.md: no status files — query live state), and it could not
+// replace the census anyway: a note is only as good as the process that wrote
+// it, so it is absent on every city no such process has visited, and the read
+// below has to exist for those cities regardless.
 //
 // The premise the note was there to work around turns out to be false anyway.
 // "Refused" is a verdict about SERVING the binding — a convergence check, a
@@ -54,14 +54,14 @@ package main
 // The proof is keyed by BINDING ref, not by id, so what turns Fatal is the
 // whole binding's residence probe: every non-reserved by-id read on this city's
 // CLI fallback path denies, including a fresh post-migration work bead and a
-// rig-shadowed id that can have no frozen twin at all. That breadth is
-// deliberate rather than incidental. The census reads OPEN beads only, so it
-// cannot enumerate the closed relics a per-id rule would have to consult, and a
-// per-id rule would therefore deny LESS than the evidence supports. The corpus
-// pins it — residency_conformance_test.go's T3k rows make ByID(ga-xyz) and
-// ByID(ra-7) Fatal too, not just the reserved-prefix ones. The operator cost is
-// that one proven open relic takes the by-id door away for the city, not only
-// for the ids the migration preserved.
+// rig-shadowed id that can have no frozen twin at all. That breadth is a
+// deliberate choice rather than a forced one: the census enumerates closed
+// relics as well as open ones, so a per-id rule would have the population it
+// has to consult, and the corpus pins the binding-keyed breadth —
+// residency_conformance_test.go's T3k rows make ByID(ga-xyz) and ByID(ra-7)
+// Fatal too, not just the reserved-prefix ones. The operator cost is that one
+// proven relic takes the by-id door away for the city, not only for the ids
+// the migration preserved.
 //
 // # The absent case is the tolerant one
 //

--- a/cmd/gc/by_id_relic_proof_test.go
+++ b/cmd/gc/by_id_relic_proof_test.go
@@ -101,6 +101,39 @@ func TestRefusedCityDeniesTheRelicItsLiveCensusProves(t *testing.T) {
 	}
 }
 
+// TestRefusedCityDeniesADRAINEDRelicToo is the row above with the relic CLOSED,
+// and it is the case the symptom outlives.
+//
+// Draining a relic does not move it. The binding still holds the only live row
+// for that id, and `gc bd show`, `reopen` and `claim` all still ask for it by
+// id — while the work store still holds the copy `gc storage migrate` preserved
+// and never deleted, which reads OPEN with pre-migration fields. So a proof
+// that counted only OPEN residents handed the operator the worst arrangement of
+// the two: the probe survives the last close (HasLegacyResidents counts closed
+// relics since ga-qdt5y.19) but nothing is allowed to enforce it, and the read
+// falls through to the frozen copy exactly as it did before the fix — on the
+// city that has done the draining it was asked to do.
+//
+// The empty-binding control lives in the row above; what is added here is the
+// CLOSE, so a failure names the census rather than the plumbing.
+func TestRefusedCityDeniesADRAINEDRelicToo(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	relic, classStore := classResidentWorkShapedBead(t, cityPath, "gc-relic1", "carried across, then drained")
+	if err := classStore.Close(relic.ID); err != nil {
+		t.Fatalf("draining the relic: %v", err)
+	}
+
+	refuseTheseCities(t, theRefusalARefusedCityCarries(), cityPath)
+
+	_, ok, err := cliByIDBindingOwner(cityPath, relic.ID)
+	if err == nil {
+		t.Fatalf("a refused city whose binding holds %s CLOSED resolved to ok=%v with no error; the caller falls through to its scan and serves the copy the migration retained in the work store, which still reads open", relic.ID, ok)
+	}
+	if !errors.Is(err, storeref.ErrProvenRelicRefusal) {
+		t.Errorf("the denial reads %q and does not carry the proven-relic sentinel; closing a relic must change the drain count, not the proof", err)
+	}
+}
+
 // TestRefusedCityThatCannotOpenItsBindingFallsThrough is the proof's absent
 // case, and it is deliberately the tolerant one.
 //

--- a/internal/storeref/bindings.go
+++ b/internal/storeref/bindings.go
@@ -49,9 +49,9 @@ type BindingOptions struct {
 	// the binding at all — the refused city, where the live census has no store
 	// to ask and every answer falls back to the pessimistic default. The plane
 	// supplies a verdict it took itself, at the time it asks, against a handle
-	// it opened for the read; this is deliberately NOT a durable record, which
-	// would go stale in the DENYING direction as relics close over the weeks
-	// after a migration (cmd/gc/by_id_relic_proof.go argues that at length). A
+	// it opened for the read; this is deliberately NOT a durable record — a
+	// status file this codebase does not keep, and one that could not replace
+	// the census anyway (cmd/gc/by_id_relic_proof.go argues that at length). A
 	// ref the census does not name is "not known", so nil means "no census to
 	// ask" and the answer is false for every binding: this bit is evidence, and
 	// its absence must never be read as proof.

--- a/internal/storeref/relic_census.go
+++ b/internal/storeref/relic_census.go
@@ -116,14 +116,20 @@ func HasLegacyResidents(b ClassBinding) bool {
 // unreachable.
 //
 // So the only true answer here is a read that completed and found a resident.
-// It still reads the OPEN-only census, so the two differ in the census as well
-// as in the default: a binding whose relics have all CLOSED keeps its probe
-// (HasLegacyResidents counts them) but is not yet PROVEN to hold one. Closing
-// that gap is the one line it has always advertised — swap OpenLegacyResidents
-// for LegacyResidents and every caller inherits it, because nobody outside this
-// file names the census directly.
+// The DEFAULT is the whole of the difference: both forms read the same
+// closed-inclusive census, and they have to, because a closed relic is exactly
+// as reachable by id as an open one — it is still shown, reopened, claimed and
+// written by id, and `gc storage migrate` never deleted the work store's
+// pre-migration copy. A proof that stopped at the last CLOSE would leave the
+// binding with a probe HasLegacyResidents keeps and nothing may enforce, and
+// that id's next read would be answered by the frozen copy, OPEN forever with
+// pre-migration fields (ga-qdt5y.19).
+//
+// Sharing the census makes the two verdicts monotone together: proof implies
+// the pessimistic bit for every binding, in the field and in the decision
+// alike, rather than only for the ones a constructor happened to align.
 func ProvenLegacyResidents(b ClassBinding) bool {
-	relics, err := OpenLegacyResidents(b.Leg.Store, b.Prefixes)
+	relics, err := LegacyResidents(b.Leg.Store, b.Prefixes)
 	if err != nil {
 		return false
 	}

--- a/internal/storeref/relic_census_test.go
+++ b/internal/storeref/relic_census_test.go
@@ -95,10 +95,11 @@ func TestOpenLegacyResidentsIgnoresEveryNamespaceTheBindingHolds(t *testing.T) {
 // The DRAIN report stays open-only, and this is the row that keeps it that way.
 //
 // OpenLegacyResidents is now only `gc storage status`'s count — the number an
-// operator watches fall as the carried-across work closes. Retirement moved off
-// it (see TestAClosedRelicKeepsTheProbe). Widening this one to match the
-// verdict would be a natural-looking tidy-up that silently replaces a draining
-// count with one that can never fall, and nothing else in the tree would fail.
+// operator watches fall as the carried-across work closes. Both verdicts moved
+// off it: retirement in ga-qdt5y.19 (TestAClosedRelicKeepsTheProbe), the proof
+// in ga-q8ick (TestAClosedRelicIsProvenToo). Widening this one to match them
+// would be a natural-looking tidy-up that silently replaces a draining count
+// with one that can never fall, and nothing else in the tree would fail.
 func TestOpenLegacyResidentsIgnoresAClosedRelic(t *testing.T) {
 	store := newCensusStore()
 	store.seedBead(t, "ga-done")
@@ -230,6 +231,49 @@ func TestProvenLegacyResidentsFallsTheOTHERWay(t *testing.T) {
 	held.seedBead(t, "ga-relic")
 	if !ProvenLegacyResidents(censusBinding(held)) {
 		t.Error("a binding whose census read a work-shaped relic came back unproven; nothing would ever deny the frozen copy")
+	}
+}
+
+// TestAClosedRelicIsProvenToo is TestAClosedRelicKeepsTheProbe's missing half,
+// and the two are only sound together.
+//
+// The two verdicts differ in their DEFAULT, and that is the only difference
+// they are allowed. Reading different censuses on top of it produced a third
+// state nobody designed: closing the last relic kept the probe (ga-qdt5y.19)
+// but dropped the proof, so a refused city holding nothing but closed relics
+// carried a probe no caller was permitted to enforce. That is worse than either
+// answer alone, because the id still resolves — to the copy `gc storage
+// migrate` preserved in the work store and never deleted, which reads OPEN with
+// pre-migration fields — while the binding holding the live row is the one leg
+// the read is allowed to skip.
+//
+// A closed relic is proof for the same reason it keeps the probe: it is still
+// shown, reopened, claimed and written BY ID, and only this binding holds the
+// row those reads must land on.
+//
+// Mutation that must make this fire: ProvenLegacyResidents back on
+// OpenLegacyResidents.
+func TestAClosedRelicIsProvenToo(t *testing.T) {
+	store := newCensusStore()
+	store.seedBead(t, "ga-done")
+	if err := store.Close("ga-done"); err != nil {
+		t.Fatalf("closing the relic: %v", err)
+	}
+	if !ProvenLegacyResidents(censusBinding(store)) {
+		t.Error("a binding whose only relic has CLOSED came back unproven; it keeps a probe nothing may enforce, and that id falls to the frozen pre-migration copy in the work store")
+	}
+
+	// The control that has to answer the other way. Widening the proof to
+	// closed beads must widen only the CLOSED half: a binding that has closed
+	// its own infrastructure beads has proved nothing, and proving there would
+	// deny work-bead reads on every unconverged city that ever closed one.
+	own := newCensusStore()
+	own.seedBead(t, "gcg-1")
+	if err := own.Close("gcg-1"); err != nil {
+		t.Fatalf("closing the binding's own bead: %v", err)
+	}
+	if ProvenLegacyResidents(censusBinding(own)) {
+		t.Error("a binding holding only its own closed beads came back PROVEN; the row above would then pass against a predicate that proves everything")
 	}
 }
 


### PR DESCRIPTION
One line of behavior: `storeref.ProvenLegacyResidents` now reads the
closed-inclusive relic census, the same one the retirement verdict moved to in
#5644.

## Mechanism

`HasLegacyResidents` (keep the probe?) and `ProvenLegacyResidents` (deny this
read?) are two verdicts over one census, and the only difference they are
allowed is their DEFAULT: an unreadable binding must keep a probe and must not
deny a read. #5644 (ga-qdt5y.19) widened the retirement verdict to count closed
relics; the proof was left on `OpenLegacyResidents`, so the two also disagreed
about the census, and that produced a third state nobody designed.

A refused city whose relics had all CLOSED landed in it: `HasLegacyResidents`
counts the closed relic, so the residence probe survives — but
`KnownLegacyResidents` stays false, so `probeRefusalPolicy` returns
`PolicyRefusalTolerated` instead of `PolicyFatal`, the probe leg is skipped over
the standing storage refusal, `cliByIDBindingOwner` reports `ok=false`, and the
by-id surface falls through to its own directory scan. The scan finds the copy
`gc storage migrate` preserved in the work store and never deleted, which reads
OPEN with pre-migration fields, serves it, and the next write writes it. Exit 0,
no diagnostic — the ga-q8ick symptom, restored by the act of DRAINING the city,
which is the thing the operator was asked to do.

A closed relic is proof for exactly the reason it keeps the probe: it is still
shown, reopened, claimed and written BY ID, and only the binding holds the live
row those reads must land on. Sharing the census also makes the implication
"proven ⇒ pessimistic bit" hold for every binding rather than only the ones a
constructor happened to align.

The doc comment above `ProvenLegacyResidents` had advertised this as a pending
one-line swap; it now states the shared-census rule instead.

## RED → GREEN

Both rows were run against this branch with the one-line swap stashed out
(source at `c6bb2aa30d`, tests as committed), then with it restored.

`internal/storeref` — `TestAClosedRelicIsProvenToo` (new, next to
`TestProvenLegacyResidentsFallsTheOTHERWay`):

```
--- FAIL: TestAClosedRelicIsProvenToo (0.00s)
    relic_census_test.go:262: a binding whose only relic has CLOSED came back
    unproven; it keeps a probe nothing may enforce, and that id falls to the
    frozen pre-migration copy in the work store
```

`cmd/gc` — `TestRefusedCityDeniesADRAINEDRelicToo` (new, the consumer-side
denial, next to `TestRefusedCityDeniesTheRelicItsLiveCensusProves`):

```
--- FAIL: TestRefusedCityDeniesADRAINEDRelicToo (0.03s)
    by_id_relic_proof_test.go:130: a refused city whose binding holds gc-relic1
    CLOSED resolved to ok=false with no error; the caller falls through to its
    scan and serves the copy the migration retained in the work store, which
    still reads open
```

With the swap restored both PASS. Each carries a control so the swap cannot pass
by proving everything: the unit row also asserts that a binding holding only its
own CLOSED in-namespace bead stays UNPROVEN (the namespace filter still decides
what counts), and the consumer row's empty-binding control is the clean
fall-through already pinned in the sibling row above it.

No existing test asserted the open-only behaviour for the PROOF, so nothing was
adjusted — one row was added on each side. The refused-city rows in
`cmd/gc/by_id_relic_proof_test.go` and the boot-census rows in
`cmd/gc/relic_census_boot_test.go` are unchanged and still pass.

## `OpenLegacyResidents` stays

Grep for the symbol across the tree: after this change it has exactly one
non-test caller.

- `cmd/gc/cmd_storage.go:570` (`reportBindingRelics`) — the `gc storage status`
  DRAIN gauge. Open-only is the point there: it is the number an operator
  watches fall as the carried-across work closes, and the widened census can
  never reach zero. Its doc comment already stated the split and needed no edit.
- `internal/storeref/relic_census_test.go` —
  `TestOpenLegacyResidentsIgnoresAClosedRelic` is the row that keeps the drain
  count open-only against a natural-looking tidy-up. Its comment is updated to
  say that BOTH verdicts have now moved off it (retirement in ga-qdt5y.19, the
  proof here) rather than only retirement; three other rows there still call it
  for the census-shape assertions.

Nothing else in the tree names either census function, so no caller had to
change to inherit the fix.

## Gates

All run on the branch head, from the worktree, in this order.

| Gate | Exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./internal/storeref/... ./cmd/gc/...` | 0 |
| `gofmt -l internal cmd` | 0 (no output) |
| `golangci-lint run ./internal/storeref/... ./cmd/gc/...` | 0 (`0 issues.`) |
| `./scripts/check-residency-boundary.sh` | 0 |
| `go test ./internal/storeref/... -count=1` | 0 |
| `go test ./cmd/gc -run 'Relic\|Census\|Residency\|Refused' -count=1` | 0 |
| `make test-fast-parallel` | 0 (`All fast jobs passed`) |
| `.githooks/pre-commit` (hooksPath active) | 0 |
| `.githooks/pre-push` (pushed without `--no-verify`) | 0 |

`scripts/residency-boundary-baseline.txt` is untouched — no row added, none
removed — and the `// residency:allow` marker on the
`storeref.ProvenLegacyResidents` call in `cmd/gc/by_id_relic_proof.go` is
unchanged: the call site moved not at all, only the census it reads.

No base-owned failure was encountered; nothing is worked around.

Refs: ga-q8ick, ga-qdt5y.19, ga-j4p3y

🤖 Generated with [Claude Code](https://claude.com/claude-code)
