### PR TITLE
fix(gc): align bd mutations with pool session identities

### DIFF
--- a/cmd/gc/bd_actor_identity.go
+++ b/cmd/gc/bd_actor_identity.go
@@ -23,6 +23,14 @@ func projectBdActorForMutation(args []string, ambientActor, claimActor string, i
 	ambientActor = strings.TrimSpace(ambientActor)
 	claimActor = strings.TrimSpace(claimActor)
 	if bdMutationIsClaim(args) {
+		if ids, ok, ambiguous := bdMutationWriteIDs(args); ok && !ambiguous && len(ids) == 1 {
+			if bead, present := targets[ids[0]]; present {
+				assignee := strings.TrimSpace(bead.Assignee)
+				if hookClaimHasIdentity(assignee, identities) {
+					return assignee
+				}
+			}
+		}
 		if claimActor != "" {
 			return claimActor
 		}
@@ -69,18 +77,22 @@ func projectBdActorForMutation(args []string, ambientActor, claimActor string, i
 func projectBdActorInEnv(args []string, env []string, targets map[string]beads.Bead) []string {
 	ambientActor := bdEnvValue(env, "BEADS_ACTOR")
 	identities := bdSessionIdentityCandidates(env)
-	claimActor := firstNonEmptyHookValue(
+	claimActor := bdSessionClaimActor(env)
+	projected := projectBdActorForMutation(args, ambientActor, claimActor, identities, targets)
+	if projected == ambientActor || projected == "" {
+		return env
+	}
+	return bdEnvWithValue(env, "BEADS_ACTOR", projected)
+}
+
+func bdSessionClaimActor(env []string) string {
+	return firstNonEmptyHookValue(
 		bdEnvValue(env, "GC_ALIAS"),
 		bdEnvValue(env, "GC_SESSION_ID"),
 		bdEnvValue(env, "BEADS_ACTOR"),
 		bdEnvValue(env, "GC_AGENT"),
 		bdEnvValue(env, "GC_SESSION_NAME"),
 	)
-	projected := projectBdActorForMutation(args, ambientActor, claimActor, identities, targets)
-	if projected == ambientActor || projected == "" {
-		return env
-	}
-	return bdEnvWithValue(env, "BEADS_ACTOR", projected)
 }
 
 func bdSessionIdentityCandidates(env []string) []string {

--- a/cmd/gc/bd_actor_identity.go
+++ b/cmd/gc/bd_actor_identity.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// projectBdActorForMutation keeps the scalar BEADS_ACTOR interface compatible
+// with the session identity set that gc uses for ownership decisions. bd can
+// compare one actor string at a time; when a command targets work already
+// assigned to this session, pass bd the exact stored spelling instead of the
+// runtime spelling that led gc to the same session.
+//
+// Fresh --claim operations use the same actor selector as hook claims. For
+// close, heartbeat, and ordinary updates, projection is deliberately narrower:
+// every known non-empty target assignee must be one of this session's
+// identities, and all owned targets must have one exact spelling. Otherwise
+// the ambient actor is preserved so bd's own ownership guard rejects a foreign
+// or mixed-owner mutation.
+func projectBdActorForMutation(args []string, ambientActor, claimActor string, identities []string, targets map[string]beads.Bead) string {
+	ambientActor = strings.TrimSpace(ambientActor)
+	claimActor = strings.TrimSpace(claimActor)
+	if bdMutationIsClaim(args) {
+		if claimActor != "" {
+			return claimActor
+		}
+		return ambientActor
+	}
+
+	ids, ok, ambiguous := bdMutationWriteIDs(args)
+	if !ok || ambiguous || len(ids) == 0 || len(targets) == 0 {
+		return ambientActor
+	}
+
+	ownedSpelling := ""
+	for _, id := range ids {
+		bead, present := targets[id]
+		if !present {
+			return ambientActor
+		}
+		assignee := strings.TrimSpace(bead.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if !hookClaimHasIdentity(assignee, identities) {
+			return ambientActor
+		}
+		if ownedSpelling == "" {
+			ownedSpelling = assignee
+			continue
+		}
+		if ownedSpelling != assignee {
+			return ambientActor
+		}
+	}
+	if ownedSpelling != "" {
+		return ownedSpelling
+	}
+	return ambientActor
+}
+
+// projectBdActorInEnv applies projectBdActorForMutation to the complete
+// environment that gc is about to hand to the bd subprocess. The session
+// identity candidates intentionally mirror hookClaim's candidate set, while
+// the claim actor retains alias-first behavior for named holders and uses the
+// durable session bead ID for unaliased pool holders.
+func projectBdActorInEnv(args []string, env []string, targets map[string]beads.Bead) []string {
+	ambientActor := bdEnvValue(env, "BEADS_ACTOR")
+	identities := bdSessionIdentityCandidates(env)
+	claimActor := firstNonEmptyHookValue(
+		bdEnvValue(env, "GC_ALIAS"),
+		bdEnvValue(env, "GC_SESSION_ID"),
+		bdEnvValue(env, "BEADS_ACTOR"),
+		bdEnvValue(env, "GC_AGENT"),
+		bdEnvValue(env, "GC_SESSION_NAME"),
+	)
+	projected := projectBdActorForMutation(args, ambientActor, claimActor, identities, targets)
+	if projected == ambientActor || projected == "" {
+		return env
+	}
+	return bdEnvWithValue(env, "BEADS_ACTOR", projected)
+}
+
+func bdSessionIdentityCandidates(env []string) []string {
+	return hookClaimIdentityCandidates(
+		bdEnvValue(env, "GC_SESSION_ID"),
+		bdEnvValue(env, "GC_SESSION_NAME"),
+		bdEnvValue(env, "GC_ALIAS"),
+		bdEnvValue(env, "GC_AGENT"),
+		bdEnvValue(env, "BEADS_ACTOR"),
+	)
+}
+
+func bdMutationIsClaim(args []string) bool {
+	if len(args) < 2 || args[0] != "update" {
+		return false
+	}
+	for _, arg := range args[1:] {
+		if arg == "--claim" {
+			return true
+		}
+		if value, ok := strings.CutPrefix(arg, "--claim="); ok {
+			if parsed, err := strconv.ParseBool(value); err == nil {
+				return parsed
+			}
+		}
+	}
+	return false
+}
+
+func bdEnvValue(env []string, key string) string {
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && name == key {
+			return value
+		}
+	}
+	return ""
+}
+
+func bdEnvWithValue(env []string, key, value string) []string {
+	out := append([]string(nil), env...)
+	for i, entry := range out {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && name == key {
+			out[i] = key + "=" + value
+			return out
+		}
+	}
+	return append(out, key+"="+value)
+}

--- a/cmd/gc/bd_actor_identity.go
+++ b/cmd/gc/bd_actor_identity.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -103,23 +102,6 @@ func bdSessionIdentityCandidates(env []string) []string {
 		bdEnvValue(env, "GC_AGENT"),
 		bdEnvValue(env, "BEADS_ACTOR"),
 	)
-}
-
-func bdMutationIsClaim(args []string) bool {
-	if len(args) < 2 || args[0] != "update" {
-		return false
-	}
-	for _, arg := range args[1:] {
-		if arg == "--claim" {
-			return true
-		}
-		if value, ok := strings.CutPrefix(arg, "--claim="); ok {
-			if parsed, err := strconv.ParseBool(value); err == nil {
-				return parsed
-			}
-		}
-	}
-	return false
 }
 
 func bdEnvValue(env []string, key string) string {

--- a/cmd/gc/bd_actor_identity_test.go
+++ b/cmd/gc/bd_actor_identity_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestProjectBdActorForMutationUsesOwnedIdentitySet(t *testing.T) {
+	const (
+		sessionID = "gcg-session-abc123"
+		slot      = "city--mechanic-4-pool"
+	)
+	identities := []string{sessionID, slot}
+
+	tests := []struct {
+		name         string
+		args         []string
+		ambientActor string
+		claimActor   string
+		targets      map[string]beads.Bead
+		want         string
+	}{
+		{
+			name:         "fresh claim uses the canonical hook actor",
+			args:         []string{"update", "work-1", "--claim"},
+			ambientActor: slot,
+			claimActor:   sessionID,
+			targets:      map[string]beads.Bead{"work-1": {ID: "work-1"}},
+			want:         sessionID,
+		},
+		{
+			name:         "close projects the owned session identity",
+			args:         []string{"close", "work-1"},
+			ambientActor: slot,
+			targets:      map[string]beads.Bead{"work-1": {ID: "work-1", Assignee: sessionID}},
+			want:         sessionID,
+		},
+		{
+			name:         "heartbeat projects the owned session identity",
+			args:         []string{"heartbeat", "work-1"},
+			ambientActor: slot,
+			targets:      map[string]beads.Bead{"work-1": {ID: "work-1", Assignee: sessionID}},
+			want:         sessionID,
+		},
+		{
+			name:         "foreign owner stays foreign",
+			args:         []string{"close", "work-1"},
+			ambientActor: slot,
+			targets:      map[string]beads.Bead{"work-1": {ID: "work-1", Assignee: "other-session"}},
+			want:         slot,
+		},
+		{
+			name:         "mixed owned identities do not impersonate a batch",
+			args:         []string{"close", "work-1", "work-2"},
+			ambientActor: slot,
+			targets: map[string]beads.Bead{
+				"work-1": {ID: "work-1", Assignee: sessionID},
+				"work-2": {ID: "work-2", Assignee: slot},
+			},
+			want: slot,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectBdActorForMutation(tc.args, tc.ambientActor, tc.claimActor, identities, tc.targets); got != tc.want {
+				t.Fatalf("projectBdActorForMutation() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBdSessionIdentityCandidatesPreserveNamedAndPoolForms(t *testing.T) {
+	env := []string{
+		"GC_SESSION_ID=gcg-session-abc123",
+		"GC_SESSION_NAME=city--mechanic-4-pool",
+		"GC_ALIAS=",
+		"GC_AGENT=city--mechanic-4-pool",
+		"BEADS_ACTOR=city--mechanic-4-pool",
+	}
+	got := bdSessionIdentityCandidates(env)
+	for _, want := range []string{
+		"gcg-session-abc123",
+		"city--mechanic-4-pool",
+	} {
+		if !containsString(got, want) {
+			t.Fatalf("bdSessionIdentityCandidates() = %q, missing %q", got, want)
+		}
+	}
+
+	named := []string{
+		"GC_SESSION_ID=gcg-session-mayor",
+		"GC_SESSION_NAME=city--mayor",
+		"GC_ALIAS=city/mayor",
+		"GC_AGENT=city/mayor",
+		"BEADS_ACTOR=city/mayor",
+	}
+	if got := bdSessionIdentityCandidates(named); !containsString(got, "city/mayor") {
+		t.Fatalf("named bdSessionIdentityCandidates() = %q, missing configured alias", got)
+	}
+}

--- a/cmd/gc/bd_actor_identity_test.go
+++ b/cmd/gc/bd_actor_identity_test.go
@@ -37,6 +37,14 @@ func TestProjectBdActorForMutationUsesOwnedIdentitySet(t *testing.T) {
 			want:         sessionID,
 		},
 		{
+			name:         "claim keeps an owned slot spelling for adoption",
+			args:         []string{"update", "work-1", "--claim"},
+			ambientActor: slot,
+			claimActor:   sessionID,
+			targets:      map[string]beads.Bead{"work-1": {ID: "work-1", Assignee: slot}},
+			want:         slot,
+		},
+		{
 			name:         "heartbeat projects the owned session identity",
 			args:         []string{"heartbeat", "work-1"},
 			ambientActor: slot,

--- a/cmd/gc/bd_actor_identity_test.go
+++ b/cmd/gc/bd_actor_identity_test.go
@@ -1,10 +1,41 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+func TestGcBdPassesCanonicalSessionActorForFreshClaim(t *testing.T) {
+	actorCapture := filepath.Join(t.TempDir(), "actor")
+	managedDoltTestSetup(t, `#!/bin/sh
+set -eu
+printf '%s' "${BEADS_ACTOR:-}" > "${ACTOR_CAPTURE}"
+printf '{"id":"demo-abc","status":"in_progress"}\n'
+`)
+	t.Setenv("ACTOR_CAPTURE", actorCapture)
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_SESSION_ID", "gcg-session-abc123")
+	t.Setenv("GC_SESSION_NAME", "demo--mechanic-4-pool")
+	t.Setenv("GC_AGENT", "demo--mechanic-4-pool")
+	t.Setenv("BEADS_ACTOR", "demo--mechanic-4-pool")
+
+	var stdout, stderr bytes.Buffer
+	if code := doBd([]string{"update", "demo-abc", "--claim"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("doBd claim = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	got, err := os.ReadFile(actorCapture)
+	if err != nil {
+		t.Fatalf("read captured actor: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "gcg-session-abc123" {
+		t.Fatalf("bd received BEADS_ACTOR=%q, want durable session id", strings.TrimSpace(string(got)))
+	}
+}
 
 func TestProjectBdActorForMutationUsesOwnedIdentitySet(t *testing.T) {
 	const (

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -550,6 +550,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	env = projectBdActorInEnv(bdArgs, env, guardBeads)
 	cmd.Env = workQueryEnvForDir(env, cmd.Dir)
 
 	traceStart := time.Now()

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -1324,6 +1324,23 @@ func bdByIDClaimActor(target beads.Bead) string {
 	)
 }
 
+func bdMutationIsClaim(args []string) bool {
+	if len(args) < 2 || args[0] != "update" {
+		return false
+	}
+	for _, arg := range args[1:] {
+		if arg == "--claim" {
+			return true
+		}
+		if value, ok := strings.CutPrefix(arg, "--claim="); ok {
+			if parsed, err := strconv.ParseBool(value); err == nil {
+				return parsed
+			}
+		}
+	}
+	return false
+}
+
 // doBdByIDClaim acquires a class-store bead for assignee through the closed
 // graph contract.
 //

--- a/cmd/gc/cmd_bd_by_id.go
+++ b/cmd/gc/cmd_bd_by_id.go
@@ -990,7 +990,7 @@ func serveBdByIDResolved(door bdByIDClassDoor, op bdByIDOp, bdArgs []string, rig
 	case bdByIDShow:
 		return printBdByIDBead(resolution.Bead, op.JSON, door.bindingName(), stdout, stderr), true
 	case bdByIDClaim:
-		return doBdByIDClaim(resolution.Graph, op.ID, bdByIDClaimActor(), op.JSON, door.bindingName(), stdout, stderr), true
+		return doBdByIDClaim(resolution.Graph, op.ID, bdByIDClaimActor(resolution.Bead), op.JSON, door.bindingName(), stdout, stderr), true
 	case bdByIDRelease:
 		return doBdByIDReleaseIfCurrent(resolution.Graph, op.ID, op.Assignee, stdout, stderr), true
 	case bdByIDDepList:
@@ -1310,10 +1310,19 @@ func bdFirstReservedClassID(token string) (string, bool) {
 }
 
 // bdByIDClaimActor returns the identity a routed claim acquires the bead for.
-// It is BEADS_ACTOR — the same variable gc puts in the subprocess environment
-// and bd itself claims under — so a routed claim and a passthrough claim record
-// the same owner.
-func bdByIDClaimActor() string { return strings.TrimSpace(os.Getenv("BEADS_ACTOR")) }
+// It follows the same projection as the bd subprocess path: an already-owned
+// bead keeps its exact session identity, while a fresh claim uses the hook's
+// canonical actor (alias, then session id, then compatibility fallbacks).
+func bdByIDClaimActor(target beads.Bead) string {
+	env := os.Environ()
+	return projectBdActorForMutation(
+		[]string{"update", target.ID, "--claim"},
+		bdEnvValue(env, "BEADS_ACTOR"),
+		bdSessionClaimActor(env),
+		bdSessionIdentityCandidates(env),
+		map[string]beads.Bead{target.ID: target},
+	)
+}
 
 // doBdByIDClaim acquires a class-store bead for assignee through the closed
 // graph contract.


### PR DESCRIPTION
Fixes #5716

## Summary

Unaliased pool claims are recorded under the durable session bead ID, while the
runtime `BEADS_ACTOR` may still be the reusable pool slot name. This makes a
worker unable to close or heartbeat its own claim through `gc bd`.

This change projects the scalar actor passed to `bd` from the same identity set
used by `gc hook --claim`:

- fresh claims use alias-first identity selection, then the durable session ID;
- close, heartbeat, and ordinary mutations reuse an exact stored assignee only
  when it belongs to the current session's identity set;
- foreign and mixed-owner mutations retain the ambient actor and remain
  rejected by `bd`; no `--force` behavior is widened;
- the in-process class-store claim door uses the same projection.

## Validation

- Focused identity and end-to-end `gc bd` claim tests via `ops/bin/nomad-run`
- Full `go test ./cmd/gc` via `ops/bin/nomad-run`
- `make build` via `ops/bin/nomad-run`
- `make check` via `ops/bin/nomad-run` (fmt, lint, vet, invariant scripts, and
  hermetic all-package tests)

This is a point fix; no design artifact or documentation update is required.
