### PR TITLE
fix(worker): dispatch transcript reads on provider_kind, not the provider name

### DIFF
--- a/internal/worker/handle_history_provider_test.go
+++ b/internal/worker/handle_history_provider_test.go
@@ -1,0 +1,296 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/sessionlog"
+)
+
+// historyProvider picks the string sessionlog dispatches transcript reads and
+// tail-activity derivation on. A custom provider's NAME carries no family
+// signal and may carry a misleading one ("kimi-k3-manifold" is a claude seat),
+// so the raw provider_kind must win over the name. The worker_profile override
+// stays on top, and a session without a kind keeps resolving by name.
+func TestHistoryProviderPrefersProviderKindOverName(t *testing.T) {
+	cases := []struct {
+		name         string
+		profile      Profile
+		specProvider string
+		info         sessionpkg.Info
+		want         string
+		wantFamily   string
+	}{
+		{
+			name:         "custom zcode alias reads through the zcode family",
+			specProvider: "glm53",
+			info:         sessionpkg.Info{Provider: "glm53", ProviderKind: "zcode"},
+			want:         "zcode",
+			wantFamily:   "zcode",
+		},
+		{
+			name:         "claude alias with kimi in its name reads through claude",
+			specProvider: "kimi-k3-manifold",
+			info:         sessionpkg.Info{Provider: "kimi-k3-manifold", ProviderKind: "claude"},
+			want:         "claude",
+			wantFamily:   "claude",
+		},
+		{
+			name:         "bare provider without a kind keeps resolving by name",
+			specProvider: "codex-mini",
+			info:         sessionpkg.Info{Provider: "codex-mini"},
+			want:         "codex-mini",
+			wantFamily:   "codex",
+		},
+		{
+			name:         "blank kind falls through to the name",
+			specProvider: "codex-mini",
+			info:         sessionpkg.Info{Provider: "codex-mini", ProviderKind: "  "},
+			want:         "codex-mini",
+			wantFamily:   "codex",
+		},
+		{
+			name:         "empty info falls back to the spec provider",
+			specProvider: "codex-mini",
+			info:         sessionpkg.Info{},
+			want:         "codex-mini",
+			wantFamily:   "codex",
+		},
+		{
+			name:         "worker profile still wins over the kind",
+			profile:      ProfileClaudeTmuxCLI,
+			specProvider: "claude",
+			info:         sessionpkg.Info{Provider: "glm53", ProviderKind: "zcode"},
+			want:         string(ProfileClaudeTmuxCLI),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &SessionHandle{session: SessionSpec{Profile: tc.profile, Provider: tc.specProvider}}
+			got := h.historyProvider(tc.info)
+			if got != tc.want {
+				t.Fatalf("historyProvider(Provider=%q, ProviderKind=%q) = %q, want %q", tc.info.Provider, tc.info.ProviderKind, got, tc.want)
+			}
+			if tc.wantFamily != "" {
+				if family := sessionlog.ProviderFamily(got); family != tc.wantFamily {
+					t.Fatalf("ProviderFamily(%q) = %q, want %q", got, family, tc.wantFamily)
+				}
+			}
+		})
+	}
+}
+
+// Reproduces ga-0a1n5 at the worker boundary: a provider NAMED "glm53" whose
+// kind is zcode must read its whole-file mirror through the zcode reader.
+// Dispatching on the name fell through to the Claude JSONL reader and
+// produced an empty transcript.
+func TestSessionHandleReadsCustomZCodeProviderTranscriptByKind(t *testing.T) {
+	root := t.TempDir()
+	workDir := t.TempDir()
+	handle := newCustomKindHandle(t, root, workDir, "glm53", "zcode", sessionpkg.ProviderResume{})
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	mirror := filepath.Join(root, "sess_glm53.json")
+	writeZCodeMirror(t, mirror, "sess_glm53", workDir,
+		zcodeMirrorTurn{role: "user", text: "hello glm"},
+		zcodeMirrorTurn{role: "assistant", text: "hello from glm through zcode"},
+	)
+
+	history, err := handle.History(context.Background(), HistoryRequest{})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(history.Entries) != 2 {
+		t.Fatalf("History().Entries = %d, want 2 mirrored turns", len(history.Entries))
+	}
+	if history.Entries[0].Actor != ActorUser || history.Entries[0].Text != "hello glm" {
+		t.Fatalf("Entries[0] = %s %q, want user %q", history.Entries[0].Actor, history.Entries[0].Text, "hello glm")
+	}
+	if history.Entries[1].Actor != ActorAssistant || history.Entries[1].Text != "hello from glm through zcode" {
+		t.Fatalf("Entries[1] = %s %q, want assistant reply", history.Entries[1].Actor, history.Entries[1].Text)
+	}
+	if got := history.Entries[0].Provenance.Provider; got != "zcode" {
+		t.Fatalf("Provenance.Provider = %q, want the zcode family the mirror was read through", got)
+	}
+
+	transcript, err := handle.Transcript(context.Background(), TranscriptRequest{})
+	if err != nil {
+		t.Fatalf("Transcript: %v", err)
+	}
+	if transcript.Provider != "zcode" {
+		t.Fatalf("Transcript().Provider = %q, want zcode", transcript.Provider)
+	}
+	if got := len(transcript.Session.Messages); got != 2 {
+		t.Fatalf("Transcript().Session.Messages = %d, want 2", got)
+	}
+}
+
+// The inverse name collision: a claude seat NAMED "kimi-k3-manifold" must not
+// be routed to the Kimi reader because of the "kimi" substring in its name.
+func TestSessionHandleReadsClaudeKindTranscriptDespiteKimiName(t *testing.T) {
+	root := t.TempDir()
+	workDir := t.TempDir()
+	handle := newCustomKindHandle(t, root, workDir, "kimi-k3-manifold", "claude", sessionpkg.ProviderResume{
+		SessionIDFlag: "--session-id",
+		ResumeFlag:    "--resume",
+	})
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	info, err := handle.manager.Get(handle.sessionID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", handle.sessionID, err)
+	}
+	if info.SessionKey == "" {
+		t.Fatal("session key was not generated for the session-id provider")
+	}
+	if info.ProviderKind != "claude" {
+		t.Fatalf("Info.ProviderKind = %q, want claude", info.ProviderKind)
+	}
+
+	slugDir := filepath.Join(root, sessionlog.ProjectSlug(workDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", slugDir, err)
+	}
+	writeWorkerTestJSONL(t, filepath.Join(slugDir, info.SessionKey+".jsonl"), []map[string]any{
+		{"type": "user", "uuid": "u1", "message": map[string]any{"role": "user", "content": "hello claude"}},
+		{"type": "assistant", "uuid": "a1", "parentUuid": "u1", "message": map[string]any{
+			"role":        "assistant",
+			"model":       "claude-opus-4-5-20251101",
+			"stop_reason": "end_turn",
+			"content":     "hello from a kimi-named claude seat",
+		}},
+	})
+
+	history, err := handle.History(context.Background(), HistoryRequest{})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(history.Entries) != 2 {
+		t.Fatalf("History().Entries = %d, want 2 claude turns", len(history.Entries))
+	}
+	if history.Entries[1].Actor != ActorAssistant || history.Entries[1].Text != "hello from a kimi-named claude seat" {
+		t.Fatalf("Entries[1] = %s %q, want the assistant reply", history.Entries[1].Actor, history.Entries[1].Text)
+	}
+	if got := history.Entries[0].Provenance.Provider; got != "claude" {
+		t.Fatalf("Provenance.Provider = %q, want claude", got)
+	}
+}
+
+// Side effect of dispatching on the kind: a zcode-kind seat now takes the
+// derive-activity-from-history path (sessionlog.DerivesActivityFromHistory),
+// which is the intended path for that family because this repo owns the mirror
+// writer and it opens a turn with the user message and closes it with the
+// reply. With the name-based dispatch PhaseBusy was unreachable for a custom
+// zcode alias.
+func TestSessionHandleStateDerivesBusyFromZCodeMirrorByKind(t *testing.T) {
+	root := t.TempDir()
+	workDir := t.TempDir()
+	handle := newCustomKindHandle(t, root, workDir, "glm53", "zcode", sessionpkg.ProviderResume{})
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	mirror := filepath.Join(root, "sess_glm53.json")
+
+	writeZCodeMirror(t, mirror, "sess_glm53", workDir,
+		zcodeMirrorTurn{role: "user", text: "start the build"},
+	)
+	state, err := handle.State(context.Background())
+	if err != nil {
+		t.Fatalf("State (open turn): %v", err)
+	}
+	if state.Phase != PhaseBusy {
+		t.Fatalf("State().Phase with a trailing user message = %s, want %s", state.Phase, PhaseBusy)
+	}
+
+	writeZCodeMirror(t, mirror, "sess_glm53", workDir,
+		zcodeMirrorTurn{role: "user", text: "start the build"},
+		zcodeMirrorTurn{role: "assistant", text: "built"},
+	)
+	state, err = handle.State(context.Background())
+	if err != nil {
+		t.Fatalf("State (closed turn): %v", err)
+	}
+	if state.Phase != PhaseReady {
+		t.Fatalf("State().Phase with a closed turn = %s, want %s", state.Phase, PhaseReady)
+	}
+}
+
+// newCustomKindHandle builds a session-backed handle for a custom provider
+// alias (no canonical worker profile) whose family is carried only by the
+// provider_kind session metadata, mirroring how cmd/gc stamps resolved custom
+// providers.
+func newCustomKindHandle(t *testing.T, searchRoot, workDir, provider, kind string, resume sessionpkg.ProviderResume) *SessionHandle {
+	t.Helper()
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	// The stale-resume-key probe delay is production timing, not what these
+	// tests own; skip it so a keyed (session-id) start does not sleep.
+	manager := sessionpkg.NewManagerWithOptions(store, sp, sessionpkg.WithStaleKeyDetectionWaiter(
+		func(context.Context, string) error { return nil },
+	))
+	handle, err := NewSessionHandle(SessionHandleConfig{
+		Manager:     manager,
+		SearchPaths: []string{searchRoot},
+		Session: SessionSpec{
+			Template: "probe",
+			Title:    "Probe",
+			Command:  provider,
+			WorkDir:  workDir,
+			Provider: provider,
+			Resume:   resume,
+			Metadata: map[string]string{"provider_kind": kind},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSessionHandle: %v", err)
+	}
+	return handle
+}
+
+type zcodeMirrorTurn struct {
+	role string
+	text string
+}
+
+// writeZCodeMirror writes a zcode export mirror in the OpenCode {info, messages}
+// shape the zcode adapter produces, with info.directory bound to workDir so
+// discovery attributes it to the session.
+func writeZCodeMirror(t *testing.T, path, sessionID, workDir string, turns ...zcodeMirrorTurn) {
+	t.Helper()
+	messages := make([]map[string]any, 0, len(turns))
+	parent := ""
+	for i, turn := range turns {
+		id := fmt.Sprintf("msg_%d", i+1)
+		messages = append(messages, map[string]any{
+			"info": map[string]any{
+				"id":        id,
+				"sessionID": sessionID,
+				"role":      turn.role,
+				"parentID":  parent,
+				"time":      map[string]any{"created": 1770000000000 + int64(i)*1000},
+			},
+			"parts": []map[string]any{{"id": "part_" + id, "type": "text", "text": turn.text}},
+		})
+		parent = id
+	}
+	doc := map[string]any{
+		"info":     map[string]any{"id": sessionID, "directory": workDir},
+		"messages": messages,
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal zcode mirror: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}

--- a/internal/worker/handle_lifecycle.go
+++ b/internal/worker/handle_lifecycle.go
@@ -496,9 +496,14 @@ func (h *SessionHandle) providerLabel() string {
 // that the raw provider_kind takes precedence over the provider name because a
 // custom alias's name carries no family signal ("glm53" is a zcode seat) or a
 // misleading one ("kimi-k3-manifold" is a claude seat). Sessions without a
-// stamped kind keep resolving by name. Mirrors the precedence used by transcript
-// discovery (session.Manager.TranscriptPathClassified) so the file found and
-// the reader used agree.
+// stamped kind keep resolving by name. Mirrors the kind-over-name precedence
+// used by transcript discovery (session.Manager.TranscriptPathClassified),
+// which is the rung that keeps the file found and the reader used on the same
+// family; the Profile override above and the spec.Provider fallback below have
+// no discovery counterpart. Like discovery, this skips the builtin_ancestor
+// rung that session.ProviderFamilyFromInfo walks first — every current stamping
+// site writes provider_kind from that same ancestor, so skipping it cannot
+// change the answer.
 func (h *SessionHandle) historyProvider(info sessionpkg.Info) string {
 	if h.session.Profile != "" {
 		return string(h.session.Profile)

--- a/internal/worker/handle_lifecycle.go
+++ b/internal/worker/handle_lifecycle.go
@@ -491,9 +491,20 @@ func (h *SessionHandle) providerLabel() string {
 	return h.session.Provider
 }
 
+// historyProvider resolves the provider string sessionlog dispatches transcript
+// reads and tail-activity derivation on. The worker_profile override wins; after
+// that the raw provider_kind takes precedence over the provider name because a
+// custom alias's name carries no family signal ("glm53" is a zcode seat) or a
+// misleading one ("kimi-k3-manifold" is a claude seat). Sessions without a
+// stamped kind keep resolving by name. Mirrors the precedence used by transcript
+// discovery (session.Manager.TranscriptPathClassified) so the file found and
+// the reader used agree.
 func (h *SessionHandle) historyProvider(info sessionpkg.Info) string {
 	if h.session.Profile != "" {
 		return string(h.session.Profile)
+	}
+	if kind := strings.TrimSpace(info.ProviderKind); kind != "" {
+		return kind
 	}
 	if strings.TrimSpace(info.Provider) != "" {
 		return info.Provider


### PR DESCRIPTION
## What

`SessionHandle.historyProvider` resolved `Profile -> info.Provider -> spec.Provider`, so a custom provider alias was handed to `sessionlog` by **name**. `sessionlog.ReadProviderFile` picks its reader with `ProviderFamily(name)`, which meant:

- a provider named `glm53` (kind `zcode`) fell through to the default Claude JSONL reader and read **0 messages** from its whole-file mirror;
- a provider named `kimi-k3-manifold` (kind `claude`) matched the `kimi` substring and got the Kimi reader, also **0 messages**.

The CLI (`cmd/gc/session_logs_resolve.go`) and transcript discovery (`session.Manager.TranscriptPathClassified`) already prefer the raw `provider_kind`. The worker read path now uses the same precedence so the file found and the reader used agree:

```
Profile -> strings.TrimSpace(info.ProviderKind) -> info.Provider -> spec.Provider
```

`Profile` stays first: it is the `worker_profile` override.

## Side effect (intended)

`historyProvider` also feeds `snapshotTailActivity` / `TailActivityForProvider`, both gated on `sessionlog.DerivesActivityFromHistory`. A zcode-kind alias now derives tail activity from history, which is the documented contract for that family (this repo owns the zcode mirror writer; a trailing user message means a turn is in flight). Before this change `PhaseBusy` was unreachable for a custom zcode alias. Covered by `TestSessionHandleStateDerivesBusyFromZCodeMirrorByKind`.

Wire types are unchanged. API transcript/history responses populate their `provider` field from `info.Provider` (the name); the only place the resolved string surfaces is per-entry `Provenance.Provider`, which already carried the profile string (e.g. `claude/tmux-cli`) for profiled sessions.

**Provenance vs display (intended split).** For a kind-stamped alias the per-entry `Provenance.Provider` — surfaced as `SessionStructuredMessage.provider` and rendered as the dashboard transcript header chip — now reports the provider **family kind** (`zcode`, `claude`) rather than the alias name, because that is the family the reader actually dispatched on. Display surfaces keep the alias name: `State().Provider` (via `providerLabel`) and the session-level wire `provider` (from `info.Provider`) are unchanged. The split is observable even when the alias name already resolved to the right family — a `my-codex` alias with kind `codex` now reports `codex` per entry — so dashboard owners should expect that header chip to show the family rather than the alias.

## Tests (RED first, then GREEN)

`internal/worker/handle_history_provider_test.go`:

- `TestHistoryProviderPrefersProviderKindOverName` — precedence table: `glm53`/`zcode` -> zcode family, `kimi-k3-manifold`/`claude` -> claude, bare `codex-mini` keeps working, blank kind falls through, empty info falls back to the spec provider, `Profile` still wins.
- `TestSessionHandleReadsCustomZCodeProviderTranscriptByKind` — `History()` and `Transcript()` read a zcode mirror for a `glm53` seat through the zcode reader (2 turns, not 0).
- `TestSessionHandleReadsClaudeKindTranscriptDespiteKimiName` — a `kimi-k3-manifold` seat with kind `claude` reads its Claude JSONL through the Claude reader.
- `TestSessionHandleStateDerivesBusyFromZCodeMirrorByKind` — `State()` reports `busy` on a trailing user message and `ready` once the turn closes.

The keyed-start test injects a no-op `WithStaleKeyDetectionWaiter` instead of paying the 2s production delay.

All four failed on `origin/main` for the reported reason (0 entries / `ready` instead of `busy`) before the one-function change.

## Verification

- `go build ./...` — ok
- `go vet ./internal/worker/... ./internal/sessionlog/...` — clean
- `go test ./internal/worker/... ./internal/sessionlog/... -count=1` — all ok
- `go test ./cmd/gc/ -run TestGCNonTestFilesStayOnWorkerBoundary` — ok
- pre-commit hook: `make lint-changed` 0 issues, `make vet` clean, codegen unchanged
- pre-push hook: `make test-fast-parallel` passed

Refs: ga-0a1n5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

