### PR TITLE
fix(zcode): key the transcript mirror and sid store by seat, not session name

### DIFF
--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -1233,12 +1233,14 @@ func (m *Manager) TranscriptPathClassified(id string, searchPaths []string) (str
 	// zcode carries no session_key — no session-id flag, no hook plugin — so
 	// the keyed lookup above can never hit for it and the ambiguity guard below
 	// would leave every pooled worker transcript-dark. Its mirror is keyed by
-	// the identity the bead does hold.
+	// the identity the bead does hold: its name, its own id (the seat — two
+	// seats can share a name and epoch), and its continuation epoch.
 	if path := workertranscript.DiscoverScopedPath(
 		searchPaths,
 		provider,
 		workDir,
 		b.Metadata["session_name"],
+		b.ID,
 		b.Metadata["continuation_epoch"],
 	); path != "" {
 		return path, TranscriptFound, nil

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -5551,3 +5551,56 @@ func TestPersistInvocationUsageCursor(t *testing.T) {
 		t.Fatalf("cursor metadata after no-ops = %q, want u2", got)
 	}
 }
+
+// TestTranscriptPathZCodeResolvesEachSeatByBeadID pins the wiring that keys a
+// zcode transcript by the seat. Two seats can share session_name and
+// continuation_epoch (a pool slot re-seated within one run), and the adapter's
+// mirror scope tells them apart only by the session bead id gc exports to it
+// as GC_SESSION_ID — so that is what the lookup must carry, with the name-only
+// scope kept as the fallback for mirrors written before the seat was part of
+// the key.
+func TestTranscriptPathZCodeResolvesEachSeatByBeadID(t *testing.T) {
+	store := beads.NewMemStore()
+	mgr := NewManagerWithOptions(store, runtime.NewFake())
+	workDir := t.TempDir()
+	const sharedName = "beads--gc__implementation-reviewer-1-pool"
+
+	var infos []Info
+	for _, title := range []string{"seat-a", "seat-b", "seat-c"} {
+		info, err := mgr.CreateSession(context.Background(), CreateOptions{Template: "helper", Title: title, Command: "zcode-repl", WorkDir: workDir, Provider: "zcode", Resume: ProviderResume{}, Hints: runtime.Config{}, ExtraMeta: map[string]string{"session_origin": "manual"}})
+		if err != nil {
+			t.Fatalf("Create %s: %v", title, err)
+		}
+		if err := store.SetMetadataBatch(info.ID, map[string]string{"session_name": sharedName, "continuation_epoch": "1"}); err != nil {
+			t.Fatalf("SetMetadataBatch %s: %v", title, err)
+		}
+		infos = append(infos, info)
+	}
+
+	searchBase := t.TempDir()
+	write := func(scope, id string) string {
+		dir := filepath.Join(searchBase, scope)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		path := filepath.Join(dir, id+".json")
+		body := `{"info":{"id":"` + id + `","directory":"` + filepath.ToSlash(workDir) + `"},"messages":[]}`
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return path
+	}
+	seatA := write(sessionlog.ZCodeSeatMirrorScope(sharedName, infos[0].ID, "1"), "sess_a")
+	seatB := write(sessionlog.ZCodeSeatMirrorScope(sharedName, infos[1].ID, "1"), "sess_b")
+	legacy := write(sessionlog.ZCodeMirrorScope(sharedName, "1"), "sess_legacy")
+
+	for i, want := range []string{seatA, seatB, legacy} {
+		got, err := mgr.TranscriptPath(infos[i].ID, []string{searchBase})
+		if err != nil {
+			t.Fatalf("TranscriptPath(%s): %v", infos[i].ID, err)
+		}
+		if got != want {
+			t.Fatalf("TranscriptPath(%s) = %q, want %q", infos[i].ID, got, want)
+		}
+	}
+}

--- a/internal/sessionlog/zcode_reader.go
+++ b/internal/sessionlog/zcode_reader.go
@@ -107,25 +107,54 @@ func FindZCodeSessionFileByID(searchPaths []string, workDir, sessionID string) s
 	return bestPath
 }
 
-// ZCodeMirrorScope is the per-session, per-conversation subdirectory the zcode
-// adapter writes its mirrors into: "<session-name>#<continuation-epoch>",
-// sanitized the same way the adapter sanitizes it. Returns "" when either part
-// is missing.
+// ZCodeMirrorScope is the name-only, per-conversation subdirectory the zcode
+// adapter writes its mirrors into when it holds no session bead id:
+// "<session-name>#<continuation-epoch>", sanitized the same way the adapter
+// sanitizes it. Returns "" when either part is missing.
 func ZCodeMirrorScope(sessionName, continuationEpoch string) string {
 	sessionName = strings.TrimSpace(sessionName)
-	if sessionName == "" {
+	epoch := zcodeScopeEpoch(continuationEpoch)
+	if sessionName == "" || epoch == "" {
 		return ""
 	}
+	return sanitizeZCodeComponent(sessionName) + "#" + epoch
+}
+
+// ZCodeSeatMirrorScope is the per-seat mirror subdirectory:
+// "<session-name>@<session-bead-id>#<continuation-epoch>".
+//
+// Two seats can share a session name and continuation epoch — a pool slot
+// re-seated within one run does exactly that — so the name-only scope
+// collapsed both onto one mirror and one seat's transcript showed for both.
+// The adapter therefore keys its state by the session bead id gc exports to
+// the pane as GC_SESSION_ID whenever it has one; a resumed seat keeps its bead
+// id, which is what makes the key stable across restarts. "@" cannot survive
+// the adapter's component sanitization, so it is an unambiguous delimiter.
+// Returns "" when any part is missing, so a caller falls back to the name-only
+// scope.
+func ZCodeSeatMirrorScope(sessionName, sessionBeadID, continuationEpoch string) string {
+	sessionName = strings.TrimSpace(sessionName)
+	sessionBeadID = strings.TrimSpace(sessionBeadID)
+	epoch := zcodeScopeEpoch(continuationEpoch)
+	if sessionName == "" || sessionBeadID == "" || epoch == "" {
+		return ""
+	}
+	return sanitizeZCodeComponent(sessionName) + "@" + sanitizeZCodeComponent(sessionBeadID) + "#" + epoch
+}
+
+// zcodeScopeEpoch normalizes the continuation epoch the way the adapter does
+// (empty means the first epoch) and returns "" for anything non-numeric.
+func zcodeScopeEpoch(continuationEpoch string) string {
 	epoch := strings.TrimSpace(continuationEpoch)
 	if epoch == "" {
-		epoch = "1"
+		return "1"
 	}
 	for _, r := range epoch {
 		if r < '0' || r > '9' {
 			return ""
 		}
 	}
-	return sanitizeZCodeComponent(sessionName) + "#" + epoch
+	return epoch
 }
 
 // FindZCodeSessionFileByScope resolves the mirror for a session by the identity
@@ -133,24 +162,46 @@ func ZCodeMirrorScope(sessionName, continuationEpoch string) string {
 //
 // gc never learns zcode's provider session id — the family has no session-id
 // flag and no hook plugin, so session_key stays empty and every id-keyed lookup
-// misses. But the adapter names its mirror directory
-// "<session-name>#<continuation-epoch>", and both values live on the session
-// bead, so this resolves a specific session's transcript exactly: two workers
-// sharing a work dir each find their own, and a mirror left behind by a dead
-// session in a reused work dir is not surfaced for a fresh one.
-func FindZCodeSessionFileByScope(searchPaths []string, workDir, sessionName, continuationEpoch string) string {
-	scope := ZCodeMirrorScope(sessionName, continuationEpoch)
+// misses. But the adapter names its mirror directory from the session name,
+// the session bead id and the continuation epoch (ZCodeSeatMirrorScope), and
+// all three live on the session bead, so this resolves a specific seat's
+// transcript exactly: two seats sharing a work dir — or a session name — each
+// find their own, and a mirror left behind by a dead session in a reused work
+// dir is not surfaced for a fresh one.
+//
+// Mirrors written before the scope carried the seat, or by an adapter that was
+// not handed a session bead id, live under the name-only scope
+// (ZCodeMirrorScope). That scope is consulted only when the seat scope holds
+// nothing: once the seat has written anything, a name-only mirror is a sibling
+// seat's or stale.
+func FindZCodeSessionFileByScope(searchPaths []string, workDir, sessionName, sessionBeadID, continuationEpoch string) string {
 	workDir = cleanOpenCodeWorkDir(workDir)
-	if scope == "" || workDir == "" {
+	if workDir == "" {
 		return ""
 	}
+	roots := mergeZCodeSearchPaths(searchPaths)
+	if seat := ZCodeSeatMirrorScope(sessionName, sessionBeadID, continuationEpoch); seat != "" {
+		if path := findZCodeMirrorInScope(roots, seat, workDir); path != "" {
+			return path
+		}
+	}
+	scope := ZCodeMirrorScope(sessionName, continuationEpoch)
+	if scope == "" {
+		return ""
+	}
+	return findZCodeMirrorInScope(roots, scope, workDir)
+}
+
+// findZCodeMirrorInScope returns the newest mirror for workDir under scope
+// across roots, preferring a real mirror over a canceled-boot placeholder.
+func findZCodeMirrorInScope(roots []string, scope, workDir string) string {
 	var (
 		bestPath        string
 		bestTime        time.Time
 		bestPending     string
 		bestPendingTime time.Time
 	)
-	for _, root := range mergeZCodeSearchPaths(searchPaths) {
+	for _, root := range roots {
 		dir := filepath.Join(root, scope)
 		entries, err := os.ReadDir(dir)
 		if err != nil {

--- a/internal/sessionlog/zcode_reader.go
+++ b/internal/sessionlog/zcode_reader.go
@@ -172,7 +172,8 @@ func zcodeScopeEpoch(continuationEpoch string) string {
 // Mirrors written before the scope carried the seat, or by an adapter that was
 // not handed a session bead id, live under the name-only scope
 // (ZCodeMirrorScope). That scope is consulted only when the seat scope holds
-// nothing: once the seat has written anything, a name-only mirror is a sibling
+// nothing for this work dir — including when no seat id was supplied: once the
+// seat has written anything for this work dir, a name-only mirror is a sibling
 // seat's or stale.
 func FindZCodeSessionFileByScope(searchPaths []string, workDir, sessionName, sessionBeadID, continuationEpoch string) string {
 	workDir = cleanOpenCodeWorkDir(workDir)

--- a/internal/sessionlog/zcode_reader_test.go
+++ b/internal/sessionlog/zcode_reader_test.go
@@ -220,28 +220,28 @@ func TestFindZCodeSessionFileByScopeSeparatesSameWorkDirSessions(t *testing.T) {
 	first := write("s-gc-1#1", "sess_first")
 	second := write("s-gc-2#1", "sess_second")
 
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-1", "1"); got != first {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-1", "", "1"); got != first {
 		t.Fatalf("s-gc-1 resolved %q, want %q", got, first)
 	}
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-2", "1"); got != second {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-2", "", "1"); got != second {
 		t.Fatalf("s-gc-2 resolved %q, want %q", got, second)
 	}
 
 	// A dead session's mirror in a reused work dir must not surface for a fresh
 	// session — different epoch, different scope.
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-1", "2"); got != "" {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-1", "", "2"); got != "" {
 		t.Fatalf("fresh conversation resolved a superseded mirror: %q", got)
 	}
 	// A canceled-boot placeholder is the only mirror a first-turn failure
 	// leaves behind (no session id was ever assigned), so when no real mirror
 	// exists it must stay resolvable rather than the scope reading as empty.
 	pending := write("s-gc-3#1", "pending-s-gc-3_1")
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-3", "1"); got != pending {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-gc-3", "", "1"); got != pending {
 		t.Fatalf("first-turn placeholder not surfaced as fallback: got %q, want %q", got, pending)
 	}
 	// A name needing sanitization resolves the same way the adapter wrote it.
 	slashed := write("gascity_gc.worker-9#1", "sess_slashed")
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "gascity/gc.worker-9", "1"); got != slashed {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "gascity/gc.worker-9", "", "1"); got != slashed {
 		t.Fatalf("sanitized scope resolved %q, want %q", got, slashed)
 	}
 }
@@ -274,10 +274,10 @@ func TestFindZCodeSessionFileByScopeResolvesArchivedConversations(t *testing.T) 
 	archived := write(archive, "probe#1", "sess_before")
 	current := write(live, "probe#2", "sess_after")
 
-	if got := FindZCodeSessionFileByScope([]string{live}, workDir, "probe", "1"); got != archived {
+	if got := FindZCodeSessionFileByScope([]string{live}, workDir, "probe", "", "1"); got != archived {
 		t.Fatalf("pre-reset scope resolved %q, want the archived %q", got, archived)
 	}
-	if got := FindZCodeSessionFileByScope([]string{live}, workDir, "probe", "2"); got != current {
+	if got := FindZCodeSessionFileByScope([]string{live}, workDir, "probe", "", "2"); got != current {
 		t.Fatalf("post-reset scope resolved %q, want the live %q", got, current)
 	}
 	// The two scopes must not collapse onto one file — that is exactly what
@@ -315,20 +315,131 @@ func TestFindZCodeSessionFileByScopePrefersRealMirrorOverPending(t *testing.T) {
 
 	// First-turn failure: only the placeholder exists.
 	pending := write("s-boot#1", "pending-s-boot_1", workDir)
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-boot", "1"); got != pending {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-boot", "", "1"); got != pending {
 		t.Fatalf("placeholder-only scope resolved %q, want the placeholder %q", got, pending)
 	}
 
 	// Once a real mirror establishes in the same scope it wins outright.
 	realMirror := write("s-boot#1", "sess_real", workDir)
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-boot", "1"); got != realMirror {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-boot", "", "1"); got != realMirror {
 		t.Fatalf("real mirror not preferred over placeholder: got %q, want %q", got, realMirror)
 	}
 
 	// A placeholder whose embedded directory belongs to another work dir is
 	// filtered out exactly like a real mirror would be.
 	write("s-other#1", "pending-s-other_1", filepath.Join(t.TempDir(), "elsewhere"))
-	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-other", "1"); got != "" {
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "s-other", "", "1"); got != "" {
 		t.Fatalf("placeholder from another work dir surfaced: %q", got)
+	}
+}
+
+// Two seats can carry the same session name and continuation epoch — a pool
+// slot re-seated within one run does exactly that — so the name-only scope
+// collapsed both onto one mirror and one seat's transcript showed for both.
+// The seat scope carries the session bead id, which a resumed seat keeps.
+func TestZCodeSeatMirrorScope(t *testing.T) {
+	cases := []struct {
+		name, id, epoch, want string
+	}{
+		{"beads--gc__reviewer-1-pool", "gcg-session-575a839d", "1", "beads--gc__reviewer-1-pool@gcg-session-575a839d#1"},
+		{"beads--gc__reviewer-1-pool", "gcg-session-575a839d", "", "beads--gc__reviewer-1-pool@gcg-session-575a839d#1"},
+		{"gascity/gc.worker-9", "gc:session/1", "3", "gascity_gc.worker-9@gc_session_1#3"},
+		// Without a bead id there is no seat scope; the caller falls back to
+		// the name-only scope instead.
+		{"beads--gc__reviewer-1-pool", "", "1", ""},
+		{"", "gcg-session-575a839d", "1", ""},
+		{"beads--gc__reviewer-1-pool", "gcg-session-575a839d", "x", ""},
+	}
+	for _, tc := range cases {
+		if got := ZCodeSeatMirrorScope(tc.name, tc.id, tc.epoch); got != tc.want {
+			t.Errorf("ZCodeSeatMirrorScope(%q, %q, %q) = %q, want %q", tc.name, tc.id, tc.epoch, got, tc.want)
+		}
+	}
+}
+
+func TestFindZCodeSessionFileByScopeSeparatesSeatsSharingASessionName(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "shared-workdir")
+	write := func(scope, id string) string {
+		dir := filepath.Join(root, scope)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		path := filepath.Join(dir, id+".json")
+		body := `{"info":{"id":"` + id + `","directory":"` + filepath.ToSlash(workDir) + `"},"messages":[]}`
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		return path
+	}
+	const name = "beads--gc__implementation-reviewer-1-pool"
+	seatA := write(name+"@gcg-session-575a839d#1", "sess_a")
+	seatB := write(name+"@gcg-session-b2f5746a#1", "sess_b")
+
+	// The newer sibling must not win: each seat resolves its own mirror.
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(seatB, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, name, "gcg-session-575a839d", "1"); got != seatA {
+		t.Fatalf("seat a resolved %q, want %q", got, seatA)
+	}
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, name, "gcg-session-b2f5746a", "1"); got != seatB {
+		t.Fatalf("seat b resolved %q, want %q", got, seatB)
+	}
+	// A third seat of the same name has written nothing: it must not borrow a
+	// sibling's transcript.
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, name, "gcg-session-cafe0000#1", "1"); got != "" {
+		t.Fatalf("seat with no mirror resolved a sibling's: %q", got)
+	}
+}
+
+// Mirrors written before the scope carried the seat — or by an adapter that
+// was not handed a session bead id — live under the name-only scope and must
+// stay readable, but only when the seat scope itself has nothing.
+func TestFindZCodeSessionFileByScopeFallsBackToTheNameOnlyScope(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "project")
+	write := func(scope, id string) string {
+		dir := filepath.Join(root, scope)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		path := filepath.Join(dir, id+".json")
+		body := `{"info":{"id":"` + id + `","directory":"` + filepath.ToSlash(workDir) + `"},"messages":[]}`
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		return path
+	}
+	legacy := write("worker#1", "sess_legacy")
+
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "worker", "gcg-session-1", "1"); got != legacy {
+		t.Fatalf("seat with only a name-only mirror resolved %q, want %q", got, legacy)
+	}
+	// No bead id at all: the name-only scope is the only scope.
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "worker", "", "1"); got != legacy {
+		t.Fatalf("name-only lookup resolved %q, want %q", got, legacy)
+	}
+	// The fallback is by the same identity: another epoch still misses.
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "worker", "gcg-session-1", "2"); got != "" {
+		t.Fatalf("fallback crossed epochs: %q", got)
+	}
+
+	// Once the seat scope holds anything, the name-only mirror is stale for
+	// this seat even when it is newer — a sibling seat may still be writing it.
+	seat := write("worker@gcg-session-1#1", "sess_seat")
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(legacy, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "worker", "gcg-session-1", "1"); got != seat {
+		t.Fatalf("seat scope not preferred over the name-only scope: got %q, want %q", got, seat)
+	}
+	// A seat that only ever left a canceled-boot placeholder still owns its
+	// scope; the name-only mirror is not consulted behind it.
+	pending := write("worker@gcg-session-2#1", "pending-worker_gcg-session-2_1")
+	if got := FindZCodeSessionFileByScope([]string{root}, workDir, "worker", "gcg-session-2", "1"); got != pending {
+		t.Fatalf("placeholder-only seat resolved %q, want its placeholder %q", got, pending)
 	}
 }

--- a/internal/sessionlog/zcode_reader_test.go
+++ b/internal/sessionlog/zcode_reader_test.go
@@ -396,7 +396,8 @@ func TestFindZCodeSessionFileByScopeSeparatesSeatsSharingASessionName(t *testing
 
 // Mirrors written before the scope carried the seat — or by an adapter that
 // was not handed a session bead id — live under the name-only scope and must
-// stay readable, but only when the seat scope itself has nothing.
+// stay readable, but only when the seat scope itself has nothing for this
+// work dir.
 func TestFindZCodeSessionFileByScopeFallsBackToTheNameOnlyScope(t *testing.T) {
 	root := t.TempDir()
 	workDir := filepath.Join(t.TempDir(), "project")

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -451,10 +451,20 @@ func (h *harness) sidPath(key string) string {
 	return filepath.Join(h.home, ".local", "state", "gascity", "zcode", "sids", key+"#"+epoch)
 }
 
-// sid reads the persisted provider session id for the harness's session key.
+// seatKey mirrors the adapter's seat key: the session name, plus the session
+// bead id when gc exported one.
+func (h *harness) seatKey() string {
+	key := h.env["GC_SESSION"]
+	if id := h.env["GC_SESSION_ID"]; id != "" {
+		key += "@" + id
+	}
+	return key
+}
+
+// sid reads the persisted provider session id for the harness's seat.
 func (h *harness) sid() string {
 	h.t.Helper()
-	data, err := os.ReadFile(h.sidPath("test-session"))
+	data, err := os.ReadFile(h.sidPath(h.seatKey()))
 	if err != nil {
 		h.t.Fatalf("read sid: %v", err)
 	}
@@ -1420,14 +1430,15 @@ func (h *harness) pendingSessionID() string {
 	return "pending-" + regexp.MustCompile(`[^A-Za-z0-9._-]`).ReplaceAllString(h.epochScope(), "_")
 }
 
-// epochScope mirrors the adapter's per-epoch mirror directory, which is how a
-// conversation reset orphans the prior conversation's plaintext.
+// epochScope mirrors the adapter's per-seat, per-epoch mirror directory, which
+// is how a conversation reset orphans the prior conversation's plaintext and
+// how two seats of one session name stay apart.
 func (h *harness) epochScope() string {
 	epoch := h.env["GC_CONTINUATION_EPOCH"]
 	if epoch == "" {
 		epoch = "1"
 	}
-	return h.env["GC_SESSION"] + "#" + epoch
+	return h.seatKey() + "#" + epoch
 }
 
 func (h *harness) readExport(sessionID string) mirrorExport {
@@ -1577,5 +1588,118 @@ func TestUnparsableResponseClosesTheMirrorEntry(t *testing.T) {
 	}
 	if !strings.Contains(last.Parts[0].Text, "unparsable response") {
 		t.Fatalf("tail note = %q, want the unparsable-response outcome", last.Parts[0].Text)
+	}
+}
+
+// Two seats can share a session name and continuation epoch — a pool slot
+// re-seated within one run does exactly that — and keyed by name alone they
+// resumed each other's conversation and wrote one mirror between them, so one
+// seat's transcript showed for both. gc exports the session bead id to the
+// pane as GC_SESSION_ID; that is the seat, and every piece of per-conversation
+// state is keyed by it.
+func TestSeatsSharingASessionNameKeepSeparateConversations(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t, map[string]string{"STUB_SID": "sess_seat_a"})
+	h.env["GC_SESSION_ID"] = "gcg-session-575a839d"
+	h.run("seat a speaks\n")
+	if got := h.sid(); got != "sess_seat_a" {
+		t.Fatalf("seat a sid = %q, want sess_seat_a", got)
+	}
+	seatASid := h.sidPath(h.seatKey())
+	seatAMirror := filepath.Join(h.mirrorDir, h.epochScope(), "sess_seat_a.json")
+	if _, err := os.Stat(seatAMirror); err != nil {
+		t.Fatalf("seat a mirror missing: %v", err)
+	}
+	seatAHome := filepath.Join(h.home, ".local", "state", "gascity", "zcode", "homes", h.epochScope())
+	if _, err := os.Stat(seatAHome); err != nil {
+		t.Fatalf("seat a CLI home missing: %v", err)
+	}
+
+	// A second seat of the same name starts its own conversation: it must
+	// neither resume seat a's session nor sweep seat a's state as superseded.
+	h.resetLog()
+	h.env["GC_SESSION_ID"] = "gcg-session-b2f5746a"
+	h.env["STUB_SID"] = "sess_seat_b"
+	h.run("seat b speaks\n")
+	for _, arg := range h.calls()[0] {
+		if strings.HasPrefix(arg, "--resume=") {
+			t.Fatalf("seat b resumed a sibling seat's conversation: %q", arg)
+		}
+	}
+	if got := h.sid(); got != "sess_seat_b" {
+		t.Fatalf("seat b sid = %q, want sess_seat_b", got)
+	}
+	if _, err := os.Stat(filepath.Join(h.mirrorDir, h.epochScope(), "sess_seat_b.json")); err != nil {
+		t.Fatalf("seat b mirror missing: %v", err)
+	}
+	for _, kept := range []string{seatASid, seatAMirror, seatAHome} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Fatalf("seat b's start swept seat a's state %s: %v", kept, err)
+		}
+	}
+	// Nothing lands under the name-only scope once a seat is known.
+	if _, err := os.Stat(h.sidPath("test-session")); !os.IsNotExist(err) {
+		t.Fatalf("name-only sid still written alongside the seat's: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(h.mirrorDir, "test-session#1")); !os.IsNotExist(err) {
+		t.Fatalf("name-only mirror scope still written alongside the seat's: %v", err)
+	}
+}
+
+// State persisted before the scope carried the seat belongs to the one seat
+// that then had the name. The first start under the seat scope takes it over,
+// so the conversation resumes across the adapter upgrade and no stale mirror
+// stays adjacent to the live one for the model to read.
+func TestSeatAdoptsStateLeftUnderTheNameOnlyScope(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t, map[string]string{"STUB_SID": "sess_before_upgrade"})
+	h.run("before the upgrade\n")
+	stateRoot := filepath.Join(h.home, ".local", "state", "gascity", "zcode")
+	legacy := []string{
+		h.sidPath("test-session"),
+		filepath.Join(h.mirrorDir, "test-session#1"),
+		filepath.Join(stateRoot, "homes", "test-session#1"),
+	}
+	for _, path := range legacy {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("name-only state missing before the upgrade: %v", err)
+		}
+	}
+
+	h.resetLog()
+	h.env["GC_SESSION_ID"] = "gcg-session-575a839d"
+	h.run("after the upgrade\n")
+	if call := h.calls()[0]; !containsString(call, "--resume=sess_before_upgrade") {
+		t.Fatalf("seat did not resume the conversation it inherited: %q", call)
+	}
+	if got := h.sid(); got != "sess_before_upgrade" {
+		t.Fatalf("seat sid = %q, want the inherited sess_before_upgrade", got)
+	}
+	export := h.readExport("sess_before_upgrade")
+	var prompts []string
+	for _, message := range export.Messages {
+		if message.Info.Role == "user" {
+			prompts = append(prompts, message.Parts[0].Text)
+		}
+	}
+	if want := []string{"before the upgrade", "after the upgrade"}; !equalStrings(prompts, want) {
+		t.Fatalf("seat mirror prompts = %q, want the inherited history continued: %q", prompts, want)
+	}
+	// The CLI child's HOME followed too — its session database is what
+	// --resume actually reattaches to.
+	seatHome := filepath.Join(stateRoot, "homes", h.epochScope())
+	data, err := os.ReadFile(filepath.Join(seatHome, "child-home"))
+	if err != nil {
+		t.Fatalf("CLI child did not run with the seat's HOME: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != seatHome {
+		t.Fatalf("child HOME = %q, want %q", got, seatHome)
+	}
+	for _, path := range legacy {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("name-only state left behind after adoption: %s (%v)", path, err)
+		}
 	}
 }

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -1648,9 +1648,10 @@ func TestSeatsSharingASessionNameKeepSeparateConversations(t *testing.T) {
 }
 
 // State persisted before the scope carried the seat belongs to the one seat
-// that then had the name. The first start under the seat scope takes it over,
-// so the conversation resumes across the adapter upgrade and no stale mirror
-// stays adjacent to the live one for the model to read.
+// that then had the name — or, in the collision this fix removes, to both. The
+// first start under the seat scope takes it over, so the conversation resumes
+// across the adapter upgrade and the adopted copy stops sitting adjacent to
+// the live one for the model to read.
 func TestSeatAdoptsStateLeftUnderTheNameOnlyScope(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -124,9 +124,18 @@ if [[ -n "${GC_SESSION_ID:-}" ]]; then
 fi
 
 # adopt_name_only <legacy> <current>: an earlier adapter keyed this state by
-# session name alone. It belonged to the one seat that then had the name, so
-# the first seat-keyed start takes it over — the conversation resumes across
-# the upgrade, and no superseded copy stays adjacent for the model to read.
+# session name alone. It belonged to the one seat that then had the name — or,
+# in the collision this fix removes, to both — so the first seat-keyed start
+# takes it over: the conversation resumes across the upgrade, and the adopted
+# copy stops sitting adjacent to the fresh one for the model to read.
+#
+# Adoption is same-epoch only, and every sweep below globs the seat key, which
+# can never match a name-only path. Legacy state at a different epoch is
+# therefore left in place: sweeping the name-only scope from a seat-keyed start
+# could destroy state a concurrently live host-session seat of the same name
+# still owns, which is the cross-seat interference this fix exists to remove.
+# The residue is at most one generation per pre-upgrade name; reclaiming it
+# belongs in an offline sweep, not here.
 adopt_name_only() {
     if [[ "$seat_name" != "$sid_name" && -e "$1" && ! -e "$2" ]]; then
         mv "$1" "$2" 2>/dev/null || true

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -110,6 +110,29 @@ sid_dir="$state_home/gascity/zcode/sids"
 mkdir -p "$sid_dir"
 sid_name="$(sid_key | tr -c 'A-Za-z0-9._-' '_')"
 
+# The seat. gc exports the session bead id as GC_SESSION_ID, and two seats can
+# share a session name and continuation epoch — a pool slot re-seated within
+# one run does exactly that. Keyed by name alone they resumed each other's
+# conversation and wrote one mirror between them, so one seat's transcript
+# showed for both. A resumed seat keeps its bead id, which is what makes this
+# key stable across restarts. "@" cannot survive the sanitization, so a seat
+# key never collides with, or globs as, a name-only one. Without a bead id
+# (host-session setups) the key stays the name alone.
+seat_name="$sid_name"
+if [[ -n "${GC_SESSION_ID:-}" ]]; then
+    seat_name="$sid_name@$(printf '%s' "$GC_SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')"
+fi
+
+# adopt_name_only <legacy> <current>: an earlier adapter keyed this state by
+# session name alone. It belonged to the one seat that then had the name, so
+# the first seat-keyed start takes it over — the conversation resumes across
+# the upgrade, and no superseded copy stays adjacent for the model to read.
+adopt_name_only() {
+    if [[ "$seat_name" != "$sid_name" && -e "$1" && ! -e "$2" ]]; then
+        mv "$1" "$2" 2>/dev/null || true
+    fi
+}
+
 # The sid file is scoped to the session's continuation epoch, which is how gc
 # distinguishes "resume the same conversation" from "start a fresh one".
 # GC_RUNTIME_EPOCH bumps on every wake (a plain restart included), so it cannot
@@ -121,11 +144,12 @@ sid_name="$(sid_key | tr -c 'A-Za-z0-9._-' '_')"
 continuation_epoch="${GC_CONTINUATION_EPOCH:-1}"
 continuation_epoch="${continuation_epoch//[^0-9]/}"
 : "${continuation_epoch:=1}"
-sid_path="$sid_dir/$sid_name#$continuation_epoch"
+sid_path="$sid_dir/$seat_name#$continuation_epoch"
+adopt_name_only "$sid_dir/$sid_name#$continuation_epoch" "$sid_path"
 
-# Drop this session's superseded epochs so the sid dir does not grow one file
+# Drop this seat's superseded epochs so the sid dir does not grow one file
 # per reset for the life of the host.
-for stale in "$sid_dir/$sid_name"#*; do
+for stale in "$sid_dir/$seat_name"#*; do
     if [[ -f "$stale" && "$stale" != "$sid_path" ]]; then rm -f "$stale"; fi
 done
 
@@ -145,11 +169,12 @@ transcript_dir="${GC_ZCODE_TRANSCRIPT_DIR:-$HOME/.local/share/gascity/zcode-tran
 #   - the ZCode CLI's session sqlite, which lives under $HOME/.zcode and which
 #     ZCODE_STORAGE_DIR does not relocate.
 #
-# So the mirror is epoch-scoped exactly like the sid, superseded epochs are
-# swept, and the CLI child gets a per-epoch HOME so its own history cannot
-# outlive the conversation it belongs to.
+# So the mirror is seat- and epoch-scoped exactly like the sid, superseded
+# epochs are swept, and the CLI child gets a per-epoch HOME so its own history
+# cannot outlive the conversation it belongs to.
 mirror_root="$transcript_dir"
-transcript_dir="$transcript_dir/$sid_name#$continuation_epoch"
+transcript_dir="$transcript_dir/$seat_name#$continuation_epoch"
+adopt_name_only "$mirror_root/$sid_name#$continuation_epoch" "$transcript_dir"
 
 # A superseded conversation is ARCHIVED, not deleted. gc's reset contract is
 # record rotation, not record destruction: `gc session reset` is issued and the
@@ -166,7 +191,7 @@ transcript_dir="$transcript_dir/$sid_name#$continuation_epoch"
 # ZCode's own session database has no preservation contract and is the one copy
 # the CLI itself would reattach to.
 archive_root="$state_home/gascity/zcode/archived-transcripts"
-for stale in "$mirror_root/$sid_name"#*; do
+for stale in "$mirror_root/$seat_name"#*; do
     if [[ -d "$stale" && "$stale" != "$transcript_dir" ]]; then
         mkdir -p "$archive_root"
         rm -rf "$archive_root/$(basename "$stale")"
@@ -178,8 +203,9 @@ mkdir -p "$transcript_dir"
 # Per-epoch HOME for the CLI child only; this shell keeps the real HOME so the
 # sid and mirror paths above are unaffected.
 zcode_home_root="$state_home/gascity/zcode/homes"
-zcode_home="$zcode_home_root/$sid_name#$continuation_epoch"
-for stale in "$zcode_home_root/$sid_name"#*; do
+zcode_home="$zcode_home_root/$seat_name#$continuation_epoch"
+adopt_name_only "$zcode_home_root/$sid_name#$continuation_epoch" "$zcode_home"
+for stale in "$zcode_home_root/$seat_name"#*; do
     if [[ -d "$stale" && "$stale" != "$zcode_home" ]]; then rm -rf "$stale"; fi
 done
 mkdir -p "$zcode_home"
@@ -352,8 +378,8 @@ def last_user_text(export):
 def pending_session_id(mirror_dir):
     """Placeholder id for turns cancelled before a session id existed.
 
-    Derived from the mirror scope (<session-name>#<epoch>) so two workers
-    sharing a transcript root cannot collide on a literal "pending".
+    Derived from the mirror scope (<seat>#<epoch>) so two workers sharing a
+    transcript root cannot collide on a literal "pending".
     """
     scope = os.path.basename(os.path.normpath(mirror_dir)) or "default"
     return "pending-" + re.sub(r"[^A-Za-z0-9._-]", "_", scope)

--- a/internal/worker/transcript/discovery.go
+++ b/internal/worker/transcript/discovery.go
@@ -174,17 +174,19 @@ func providerHasKeyedTranscript(provider string) bool {
 }
 
 // DiscoverScopedPath resolves a transcript for families whose on-disk layout is
-// keyed by the session's own name and conversation epoch rather than by any
-// session id gc holds.
+// keyed by the session's own identity — name, bead id and conversation epoch —
+// rather than by any provider session id gc holds.
 //
 // Only zcode qualifies today: gc never learns its provider session id, so
 // DiscoverKeyedPath cannot hit, but the adapter names its mirror directory
-// from GC_SESSION_NAME and GC_CONTINUATION_EPOCH — both persisted on the
-// session bead. Returns "" for every other family, so callers can try it
-// unconditionally.
-func DiscoverScopedPath(searchPaths []string, provider, workDir, sessionName, continuationEpoch string) string {
+// from GC_SESSION_NAME, GC_SESSION_ID and GC_CONTINUATION_EPOCH — all
+// persisted on the session bead. The bead id is what tells two seats sharing
+// a session name apart; a mirror written by an adapter that had no bead id is
+// still found under the name-only scope. Returns "" for every other family,
+// so callers can try it unconditionally.
+func DiscoverScopedPath(searchPaths []string, provider, workDir, sessionName, sessionBeadID, continuationEpoch string) string {
 	if sessionlog.ProviderFamily(provider) != "zcode" {
 		return ""
 	}
-	return sessionlog.FindZCodeSessionFileByScope(searchPaths, workDir, sessionName, continuationEpoch)
+	return sessionlog.FindZCodeSessionFileByScope(searchPaths, workDir, sessionName, sessionBeadID, continuationEpoch)
 }

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -812,3 +812,37 @@ func quoteJSONString(value string) string {
 	}
 	return string(raw)
 }
+
+// DiscoverScopedPath is the seam the session manager reaches a zcode mirror
+// through, and the mirror scope is keyed by the seat — session name, session
+// bead id, continuation epoch — not by name and epoch alone: two seats can
+// share those. A seat with no seat-scoped mirror still reads the name-only
+// scope an earlier adapter wrote.
+func TestDiscoverScopedPathZCodeKeysBySeat(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "zcode-project")
+	write := func(scope, id string) string {
+		dir := filepath.Join(base, scope)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, id+".json")
+		body := `{"info":{"id":"` + id + `","directory":"` + filepath.ToSlash(workDir) + `"},"messages":[]}`
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	seat := write("pool-1@gcg-session-a#1", "sess_seat")
+	legacy := write("pool-1#1", "sess_legacy")
+
+	if got := DiscoverScopedPath([]string{base}, "zcode/tmux-cli", workDir, "pool-1", "gcg-session-a", "1"); got != seat {
+		t.Fatalf("DiscoverScopedPath(seat a) = %q, want %q", got, seat)
+	}
+	if got := DiscoverScopedPath([]string{base}, "zcode/tmux-cli", workDir, "pool-1", "gcg-session-b", "1"); got != legacy {
+		t.Fatalf("DiscoverScopedPath(seat without a seat-scoped mirror) = %q, want the name-only %q", got, legacy)
+	}
+	if got := DiscoverScopedPath([]string{base}, "claude/tmux-cli", workDir, "pool-1", "gcg-session-a", "1"); got != "" {
+		t.Fatalf("DiscoverScopedPath(claude) = %q, want empty for a non-zcode family", got)
+	}
+}


### PR DESCRIPTION
## What

The `zcode-repl` adapter keyed every piece of per-conversation state — the persisted provider sid, the export mirror gc reads transcripts from, the archive, and the CLI child's per-epoch `HOME` — by `<session_name>#<continuation_epoch>`. Two seats can share both (a pool slot re-seated within one run: `beads--gc__implementation-reviewer-1-pool#1` carried seats `gcg-session-575a839d...` and `gcg-session-b2f5746a...` of run `gcg-5436965277309570`), so the second seat resumed the first seat's zcode session and both wrote one mirror; `sessionlog.FindZCodeSessionFileByScope` then showed one seat's transcript for both.

The scope key now carries the session bead id the engine already exports to the pane as `GC_SESSION_ID` (`session.RuntimeEnv`): `<name>@<bead-id>#<epoch>`. A resumed seat keeps its bead id, so restart continuity is unchanged. `@` cannot survive the adapter's component sanitization (`tr -c 'A-Za-z0-9._-' '_'`), so seat and name-only scopes never collide, and neither's stale-epoch sweep globs the other.

## How

**Write side** — `internal/worker/adapters/zcode/zcode-repl`
- `seat_name` = sanitized `GC_SESSION_NAME` + `@` + sanitized `GC_SESSION_ID` when the engine exported one; otherwise the name alone (host-session setups, older engines) — fully backward compatible.
- sid file, mirror dir, archive sweep, and CLI `HOME` all key on `seat_name`; superseded-epoch sweeps are per seat, so a sibling seat's start no longer archives this seat's live mirror or deletes its sid.
- `adopt_name_only`: a seat-keyed start takes over same-epoch name-only state left by the previous adapter version (sid, mirror dir, CLI HOME — all three, because `--resume` reattaches through the CLI's sqlite in that HOME). The conversation resumes across the upgrade and no stale mirror stays adjacent in the live root for the model to read.

**Read side**
- `sessionlog.ZCodeSeatMirrorScope(name, beadID, epoch)` (new) and `FindZCodeSessionFileByScope` now takes the bead id: tries the seat scope first, falls back to the name-only scope only when the seat scope holds nothing — mirrors already on disk, and mirrors from an adapter not handed a bead id, stay readable. Per-scope resolution (newest real mirror, `pending-` placeholder as last resort, work-dir filter) is unchanged and factored into `findZCodeMirrorInScope`.
- `workertranscript.DiscoverScopedPath` carries the bead id; `session/chat.go` `TranscriptPathClassified` passes `b.ID`.

No wire types, API, or docs changed.

## Tests (TDD — each failed for the intended reason before the fix)

- `internal/sessionlog`: `TestZCodeSeatMirrorScope`, `TestFindZCodeSessionFileByScopeSeparatesSeatsSharingASessionName`, `TestFindZCodeSessionFileByScopeFallsBackToTheNameOnlyScope`
- `internal/worker/transcript`: `TestDiscoverScopedPathZCodeKeysBySeat`
- `internal/session`: `TestTranscriptPathZCodeResolvesEachSeatByBeadID` (bead → lookup wiring, incl. name-only fallback)
- `internal/worker/adapters/zcode` (real bash adapter + stub CLI): `TestSeatsSharingASessionNameKeepSeparateConversations`, `TestSeatAdoptsStateLeftUnderTheNameOnlyScope`; harness `seatKey()`/`epochScope()` mirror the adapter's key

## Verification

- `go build ./...` — ok
- `go vet ./internal/sessionlog/... ./internal/worker/transcript/... ./internal/session/... ./internal/worker/adapters/zcode/...` — ok
- `go test -count=1 ./internal/sessionlog/ ./internal/worker/transcript/ ./internal/session/ ./internal/worker/adapters/zcode/` — ok
- `go test -count=1 ./internal/worker/ ./internal/worker/workertest/ ./internal/worker/builtin/` (zcode phase-1/phase-2 fixtures and builtin profile) — ok
- `make lint-changed LINT_CHANGED_SCOPE=staged` — 0 issues
- `shellcheck -S warning zcode-repl` — only the pre-existing SC2115 at the archive `rm -rf` (identical on origin/main; untouched here)
- `.githooks/pre-commit` (origin/main copy) ran on the commit: format, lint, genspec/genclient/genschema (no drift), `go vet ./...`
- `.githooks/pre-push` ran `make test-fast-parallel` on push (see PR checks for CI)
- Not run: `make test-worker-inference PROFILE=zcode/tmux-cli` — the live leg needs `ZCODE_CJS` + `ZCODE_API_KEY` credentials, which this environment does not have. The live path is covered structurally: the engine exports `GC_SESSION_ID` to the pane (`session.RuntimeEnv`) and `handle.History` → `TranscriptPath` resolves through the seat-aware lookup.

Bead: ga-pm3tw

🤖 Generated with [Claude Code](https://claude.com/claude-code)
