### PR TITLE
fix(zcode): never run a prompt the drain timer cut in half (ga-fasb8)

### DIFF
--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -497,7 +497,7 @@ func TestIdleSeparatedPromptsStaySeparate(t *testing.T) {
 	s.send("first prompt")
 	time.Sleep(2500 * time.Millisecond)
 	s.send("second prompt")
-	time.Sleep(2500 * time.Millisecond)
+	s.waitForTurns(2)
 	if _, code := s.closeAndWait(); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
@@ -705,6 +705,31 @@ func TestALineSplitAcrossTheDrainWindowStaysOnePrompt(t *testing.T) {
 	want := "first line\nsecond line, part one - part two"
 	if got := h.prompts(); !equalStrings(got, []string{want}) {
 		t.Fatalf("prompts = %q, want %q", got, []string{want})
+	}
+}
+
+// An interrupt that lands with a half-delivered line in the adapter's hands
+// must DROP it, not run it. bash >= 4 assigns the partial input to the
+// variable and returns rc=1, which is indistinguishable from end-of-input on
+// an unterminated last line by status alone — so the loop has to consult the
+// INT trap, or a cancelled prompt is executed with its tail missing.
+func TestInterruptWithAPartialLineInHandRunsNoPrompt(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t, nil)
+	s := h.start()
+	s.waitForOutput("zcode-repl ready", adapterWaitBudget)
+	s.sendRaw("half a prompt, interrupted here")
+	// The adapter is silent while reading, so there is no lifecycle signal for
+	// "the bytes are in hand"; this gap is what puts them there.
+	time.Sleep(2500 * time.Millisecond)
+	s.signal(syscall.SIGINT)
+
+	if _, code := s.closeAndWait(); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if got := h.prompts(); len(got) != 0 {
+		t.Fatalf("an interrupt-truncated fragment was executed as a prompt: %q", got)
 	}
 }
 

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -712,7 +712,7 @@ func TestALineSplitAcrossTheDrainWindowStaysOnePrompt(t *testing.T) {
 // must DROP it, not run it. bash >= 4 assigns the partial input to the
 // variable and returns rc=1, which is indistinguishable from end-of-input on
 // an unterminated last line by status alone — so the loop has to consult the
-// INT trap, or a cancelled prompt is executed with its tail missing.
+// INT trap, or a canceled prompt is executed with its tail missing.
 func TestInterruptWithAPartialLineInHandRunsNoPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -665,8 +665,9 @@ func TestDrainKeepsPartialTrailingLine(t *testing.T) {
 	s.sendRaw("\n")
 	s.waitForTurns(1)
 	// Surviving the drain is the assertion that must hold on every platform: an
-	// unbound $more here killed the adapter under `set -u` on bash 3.2, which
-	// is exactly the regression this test's own shape provokes.
+	// unbound drain variable here killed the adapter under `set -u` on bash
+	// 3.2, which is exactly the regression this test's own shape provokes. The
+	// drain still clears its variables before every read for that reason.
 	if _, code := s.closeAndWait(); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
@@ -709,10 +710,15 @@ func TestALineSplitAcrossTheDrainWindowStaysOnePrompt(t *testing.T) {
 }
 
 // An interrupt that lands with a half-delivered line in the adapter's hands
-// must DROP it, not run it. bash >= 4 assigns the partial input to the
-// variable and returns rc=1, which is indistinguishable from end-of-input on
-// an unterminated last line by status alone — so the loop has to consult the
-// INT trap, or a canceled prompt is executed with its tail missing.
+// must DROP it, not run it. The signal here is followed by a stdin close, and
+// that end-of-input is what ends the read: it returns rc=1 with the partial
+// input assigned, which by status alone is indistinguishable from the
+// unterminated last line the adapter deliberately runs — so the loop has to
+// consult the INT trap, or a canceled prompt is executed with its tail
+// missing. A trapped INT on its own does not necessarily end the read: on bash
+// 5.2, if the rest of the line arrives the read resumes and completes with
+// rc=0, so this pins the end-of-input shape, which is the one that would
+// otherwise run the fragment.
 func TestInterruptWithAPartialLineInHandRunsNoPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/adapters/zcode/adapter_test.go
+++ b/internal/worker/adapters/zcode/adapter_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -649,7 +648,11 @@ func TestBracketedPasteWrappersAreStripped(t *testing.T) {
 }
 
 // A drain read that times out still holds whatever partial line arrived; losing
-// it silently truncates the prompt's last line.
+// it silently truncates the prompt's last line. This held only on bash >= 4
+// until the drain stopped timing a line read: bash 3.2 consumed the fragment
+// off the fd and discarded it before the script regained control. Now the
+// timer guards a one-byte read that has consumed nothing when it fires, so the
+// fragment survives on every shell and the assertion is unconditional.
 func TestDrainKeepsPartialTrailingLine(t *testing.T) {
 	t.Parallel()
 
@@ -660,7 +663,7 @@ func TestDrainKeepsPartialTrailingLine(t *testing.T) {
 	s.sendRaw("trailing line without a newline")
 	time.Sleep(2500 * time.Millisecond)
 	s.sendRaw("\n")
-	time.Sleep(2500 * time.Millisecond)
+	s.waitForTurns(1)
 	// Surviving the drain is the assertion that must hold on every platform: an
 	// unbound $more here killed the adapter under `set -u` on bash 3.2, which
 	// is exactly the regression this test's own shape provokes.
@@ -668,19 +671,40 @@ func TestDrainKeepsPartialTrailingLine(t *testing.T) {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
 
-	// *Keeping* the fragment, by contrast, is a bash 4.0 behavior: only there
-	// does a timed-out `read -t` save the partial line into the variable. bash
-	// 3.2 — what `#!/usr/bin/env bash` resolves to on stock macOS — consumes
-	// the fragment off the fd and discards it before the script regains
-	// control, so no adapter change can recover it. Gated by GOOS rather than
-	// by probing the shell because probing costs a subprocess, and the source
-	// resource ledger (test/test-resources.toml) ratchets those down, not up.
-	if runtime.GOOS == "darwin" {
-		return
-	}
 	joined := strings.Join(h.prompts(), "|")
 	if !strings.Contains(joined, "trailing line without a newline") {
 		t.Fatalf("partial trailing line was dropped; prompts = %q", h.prompts())
+	}
+}
+
+// A line whose bytes straddle the drain window must still reach the CLI whole.
+// The idle timer that closes a burst used to guard a whole-line read, and
+// `read -t` throws away everything it has already consumed when it fires: bash
+// >= 4 hands the fragment back and the loop appended it and ran the prompt
+// without its tail, bash 3.2 (stock macOS /bin/bash, and the Mac CI lane) had
+// already eaten those bytes off the fd and ran the prompt with them simply
+// gone. Both are the same defect — a prompt executed with bytes missing — and
+// this is a production defect, not a test artifact: the GLM 5.3 review arm runs
+// its prompts through this adapter (ga-fasb8).
+func TestALineSplitAcrossTheDrainWindowStaysOnePrompt(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t, nil)
+	s := h.start()
+	s.sendRaw("first line\n")
+	s.sendRaw("second line, part one - ")
+	// Longer than the adapter's drain window, so the idle timer expires with
+	// the second line half delivered.
+	time.Sleep(2500 * time.Millisecond)
+	s.sendRaw("part two\n")
+	s.waitForTurns(1)
+	if _, code := s.closeAndWait(); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	want := "first line\nsecond line, part one - part two"
+	if got := h.prompts(); !equalStrings(got, []string{want}) {
+		t.Fatalf("prompts = %q, want %q", got, []string{want})
 	}
 }
 

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -614,19 +614,23 @@ printf '%s\n' "$MARKER"
 
 while :; do
     interrupted=0
-    # Cleared before every read: a read that ends on a signal returns without
-    # touching the variable, so a stale value here would be re-run as a prompt.
+    # Cleared before every read: bash 3.2 returns from a signal-interrupted
+    # read without touching the variable, so a stale value would be re-run.
     line=
     IFS= read -r -n "$MAX_LINE_BYTES" line
     read_rc=$?
-    if (( read_rc != 0 )) && [[ -z "$line" ]]; then
-        # A trapped INT interrupts read; that is an interrupt, not end of input.
+    if (( read_rc != 0 )); then
+        # An INT is an interrupt, not end of input — and on bash >= 4 the read
+        # hands back whatever it had already taken (rc=1, variable assigned).
+        # DROP it: running a fragment the operator just cancelled is the same
+        # defect this loop exists to prevent, a prompt with bytes missing.
         if (( interrupted )) || (( read_rc > 128 )); then continue; fi
-        break
+        # Nothing in hand and no interrupt: end of input.
+        if [[ -z "$line" ]]; then break; fi
+        # A non-empty line with a failed status is end of input on an
+        # unterminated last line. Nothing more is coming, so run it rather than
+        # discard it; the next read sees the same end of input and stops.
     fi
-    # A non-empty line with a failed status is end of input on an unterminated
-    # last line. Nothing more is coming, so run it rather than discard it; the
-    # next read sees the same end of input with nothing in hand and stops.
 
     # Coalesce the rest of a pasted burst: gc sends the body, waits, then
     # Enter, so a 1s idle window closes the paste without splitting it.

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -14,7 +14,10 @@
 # lands as N lines with a trailing ESC byte on the last one. We read the first
 # line blocking, drain the rest of the burst on a 1s idle timeout — timed one
 # byte at a time, so the timer can never cut a line in half — strip control
-# bytes, and run ONE turn on the join.
+# bytes, and run ONE turn on the join. The cap is MAX_LINE_BYTES per LINE, not
+# per prompt: a prompt of any size is fine as long as its lines are, but one
+# unbroken line longer than the cap comes back rejoined with a newline the
+# sender never sent, changing that prompt's content and not just its framing.
 #
 # Prints "zcode-repl ready" at startup and after every turn — the provider's
 # ready_prompt_prefix. Turn failures print "zcode-repl error rc=N" and keep
@@ -56,8 +59,12 @@ readonly DRAIN_TIMEOUT=1
 # lseek, which fails on a tty and a pipe — so the leftover bytes live only in
 # that buffer, and the one-byte read the drain uses to time the idle window,
 # which is always unbuffered, would step straight past them. The value is a
-# ceiling on one line, not on a prompt: a longer line splits, which is what an
-# unbounded read would eventually do to memory anyway.
+# ceiling on one line, not on a prompt, and it bounds a read that was otherwise
+# unbounded in memory. Two things it is not: bash counts -n in characters, so in
+# a multibyte locale this is a character ceiling and the name is optimistic; and
+# a line over it does not merely split — the read returns rc=0 mid-line and the
+# drain rejoins the remainder as if it were the next line, inserting a newline
+# the sender never sent.
 readonly MAX_LINE_BYTES=1048576
 
 die_config() {
@@ -620,10 +627,20 @@ while :; do
     IFS= read -r -n "$MAX_LINE_BYTES" line
     read_rc=$?
     if (( read_rc != 0 )); then
-        # An INT is an interrupt, not end of input — and on bash >= 4 the read
-        # hands back whatever it had already taken (rc=1, variable assigned).
-        # DROP it: running a fragment the operator just cancelled is the same
-        # defect this loop exists to prevent, a prompt with bytes missing.
+        # An INT is an interrupt, not end of input. A trapped INT reaches a
+        # failed read in more than one shape: it can abort the read outright
+        # (rc > 128), or — measured on bash 5.2 — leave the read running and
+        # surface only at the end of input that follows, as rc=1 with the
+        # fragment assigned. The flag and the status together cover both, so
+        # DROP what is in hand: running a fragment the operator just canceled
+        # is the same defect this loop exists to prevent, a prompt with bytes
+        # missing.
+        #
+        # What no check here can do is recall bytes already taken. On bash 5.2
+        # a trapped INT does not end the read at all: if the rest of the line
+        # still arrives, the read resumes and completes with rc=0 and the whole
+        # line, never reaching this branch. So a live-pane C-c only cancels the
+        # partial line when an end of input follows it.
         if (( interrupted )) || (( read_rc > 128 )); then continue; fi
         # Nothing in hand and no interrupt: end of input.
         if [[ -z "$line" ]]; then break; fi

--- a/internal/worker/adapters/zcode/zcode-repl
+++ b/internal/worker/adapters/zcode/zcode-repl
@@ -12,7 +12,8 @@
 # NudgeSession): one literal send-keys of the whole message (embedded newlines
 # included), a short debounce, an Escape, then Enter. So a multi-line prompt
 # lands as N lines with a trailing ESC byte on the last one. We read the first
-# line blocking, drain the rest of the burst on a 1s idle timeout, strip control
+# line blocking, drain the rest of the burst on a 1s idle timeout — timed one
+# byte at a time, so the timer can never cut a line in half — strip control
 # bytes, and run ONE turn on the join.
 #
 # Prints "zcode-repl ready" at startup and after every turn — the provider's
@@ -49,6 +50,15 @@ readonly BUSY="zcode-repl turn in flight (C-c to interrupt)"
 readonly GUARD_TOKEN="zcode-repl "
 readonly MAX_CONSECUTIVE_FAILURES=5
 readonly DRAIN_TIMEOUT=1
+# Every read below passes -n, which is what keeps bash on its unbuffered,
+# byte-at-a-time reader for a tty and a pipe alike. Without it bash reads a line
+# through a 128-byte static buffer (zreadc) and pushes the remainder back with
+# lseek, which fails on a tty and a pipe — so the leftover bytes live only in
+# that buffer, and the one-byte read the drain uses to time the idle window,
+# which is always unbuffered, would step straight past them. The value is a
+# ceiling on one line, not on a prompt: a longer line splits, which is what an
+# unbounded read would eventually do to memory anyway.
+readonly MAX_LINE_BYTES=1048576
 
 die_config() {
     printf '%s: %s\n' "$PROG" "$1" >&2
@@ -604,43 +614,53 @@ printf '%s\n' "$MARKER"
 
 while :; do
     interrupted=0
-    IFS= read -r line
+    # Cleared before every read: a read that ends on a signal returns without
+    # touching the variable, so a stale value here would be re-run as a prompt.
+    line=
+    IFS= read -r -n "$MAX_LINE_BYTES" line
     read_rc=$?
-    if (( read_rc != 0 )); then
+    if (( read_rc != 0 )) && [[ -z "$line" ]]; then
         # A trapped INT interrupts read; that is an interrupt, not end of input.
         if (( interrupted )) || (( read_rc > 128 )); then continue; fi
         break
     fi
+    # A non-empty line with a failed status is end of input on an unterminated
+    # last line. Nothing more is coming, so run it rather than discard it; the
+    # next read sees the same end of input with nothing in hand and stops.
 
     # Coalesce the rest of a pasted burst: gc sends the body, waits, then
-    # Enter, so a 1s idle window closes the paste without splitting it. A
-    # timed-out read still assigns whatever partial line arrived, so take it
-    # before breaking — otherwise the tail of the last line is silently lost.
+    # Enter, so a 1s idle window closes the paste without splitting it.
     #
-    # Saving partial input on timeout is a bash 4.0 feature; bash 3.2 (still
-    # /bin/bash on stock macOS) returns from a timed-out read without touching
-    # the variable at all, having already consumed and discarded the fragment.
-    # Clearing it before every read is what makes the loop correct on both:
-    # bash >= 4 overwrites it with the fragment, bash 3.2 leaves the empty
-    # value and the branch below simply does not fire. Without this, $more is
-    # *unbound* on the first timed-out drain and `set -u` kills the whole
-    # adapter mid-prompt — on macOS that is every pane, on the first prompt.
-    # The 3.2 fragment itself is unrecoverable at this layer (the shell ate it
-    # before the script ran), so there it is dropped rather than misplaced;
-    # gc's own nudge always terminates its last line, so only a human pausing
-    # mid-line for longer than the drain window can hit it.
+    # The timer must never be allowed to expire in the middle of a line.
+    # `read -t` throws away everything it has already consumed when the timer
+    # fires — bash >= 4 hands that fragment back in the variable, bash 3.2
+    # (still /bin/bash on stock macOS) has eaten it off the fd and returns
+    # without touching the variable at all — and a loop that appends the
+    # fragment runs a prompt whose tail is missing, while one that drops it
+    # runs a prompt whose tail is gone entirely. Both are the same defect:
+    # a prompt executed with bytes missing.
+    #
+    # So the timer only ever guards a ONE-BYTE read. A one-byte read has
+    # consumed nothing when it times out, so there is nothing to lose; and
+    # once that byte is in hand the burst is known to be continuing, so the
+    # rest of its line comes from a blocking read that cannot end early. A
+    # prompt is therefore only ever run on whole lines.
     while :; do
-        more=
-        IFS= read -r -t "$DRAIN_TIMEOUT" more
-        drain_rc=$?
-        if (( drain_rc == 0 )); then
-            # A blank interior line reads as empty and must be kept: paragraph
-            # breaks are part of the prompt.
-            line+=$'\n'"$more"
+        peek=
+        IFS= read -r -n 1 -t "$DRAIN_TIMEOUT" peek
+        peek_rc=$?
+        # Non-zero is the idle window closing or end of input; either way the
+        # burst is over, and no byte was taken off the fd to lose.
+        if (( peek_rc != 0 )); then break; fi
+        if [[ -z "$peek" ]]; then
+            # The byte was the newline itself: a blank interior line, which is
+            # part of the prompt — paragraph breaks matter.
+            line+=$'\n'
             continue
         fi
-        if [[ -n "$more" ]]; then line+=$'\n'"$more"; fi
-        break
+        rest=
+        IFS= read -r -n "$MAX_LINE_BYTES" rest
+        line+=$'\n'"$peek$rest"
     done
 
     # Prompts over tmux's send-keys literal limit arrive as a bracketed paste


### PR DESCRIPTION
## Symptom

`Mac / make test` intermittently fails with

```
adapter_test.go:914: prompts = ["still workin"], want [still working]
```

— one prompt, executed missing its last byte, and **no second prompt carrying
the missing byte**. Seen on PR #5634 run 33930571152 and again on PR #6140 run
34185189112 (job 101932090162, `blacksmith-...-12vcpu` macOS 15), both on PRs
that touch nothing under `internal/worker/adapters/zcode`.

This is not a test-only problem. Since 2026-09-07 the GLM 5.3 review arm on
maintainer-city runs production prompts through this same adapter
(`provider glm53 = builtin:zcode`), so a prompt losing bytes is a production
defect.

## Mechanism

`internal/worker/adapters/zcode/zcode-repl` read the first line of a burst
blocking, then coalesced the rest of the paste with a **timed whole-line read**:

```bash
IFS= read -r line                       # blocking, first line
while :; do
    more=
    IFS= read -r -t "$DRAIN_TIMEOUT" more    # 1s timer around a LINE read
    drain_rc=$?
    if (( drain_rc == 0 )); then line+=$'\n'"$more"; continue; fi
    if [[ -n "$more" ]]; then line+=$'\n'"$more"; fi   # <-- runs a partial line
    break
done
```

`read -t` **throws away everything it has already consumed** when the timer
fires. Both shells lose data, differently:

- **bash >= 4** (`builtins/read.def`, the `setjmp(alrmbuf)` / `sigalrm` arm):
  on timeout it does `input_string[i] = '\0'; t = savestring(input_string);
  run_unwind_frame("read_builtin"); retval = 128+SIGALRM; goto assign_vars;`.
  The **unterminated fragment is handed back in `$more`**, the old
  `if [[ -n "$more" ]]` branch appended it and the loop ran the prompt anyway.
  The CLI got a prompt missing its tail, and the tail arrived later as a
  *separate* prompt.
- **bash 3.2** — still `/bin/bash` on stock macOS, and what
  `#!/usr/bin/env bash` resolves to on this lane (`blacksmith` macOS image, no
  brew `bash`; `setup-gascity-macos` installs only `tmux jq flock`). Its
  `read.def` arms `alarm(tmout)`; `sigalrm()` does `longjmp(alrmbuf, 1)`, and
  the landing pad is `run_unwind_frame("read_builtin"); return
  (EXECUTION_FAILURE);` — it **never reaches the assignment**. The bytes the
  read had already pulled off the fd (one at a time: `unbuffered_read =
  (nchars > 0) || (delim != '\n') || input_is_pipe`) are simply **gone**, and
  `$more` is left untouched. So the prompt runs with those bytes missing and
  **nothing ever carries them** — exactly the observed shape.

Both are the same defect: **a prompt executed with bytes missing**.

The observed CI failure matches the bash 3.2 arm byte for byte: one prompt
(`"still workin"`), the missing `g` never reappearing as another prompt, exit
code 0, and a 5.10 s test — 4 s of the test's own sleeps plus exactly one 1 s
drain window, i.e. one turn, not two.

### Fix

Stop timing a line read. The idle timer now guards a **one-byte** read:

```bash
peek=
IFS= read -r -n 1 -t "$DRAIN_TIMEOUT" peek
(( peek_rc != 0 )) && break        # window closed; nothing was consumed
[[ -z "$peek" ]] && { line+=$'\n'; continue; }   # that byte was the newline
rest=
IFS= read -r -n "$MAX_LINE_BYTES" rest           # blocking: finishes the line
line+=$'\n'"$peek$rest"
```

A one-byte read has consumed **nothing** when it times out, so there is nothing
to discard; and once that byte is in hand the burst is known to be continuing,
so the rest of its line comes from a blocking read that cannot end early. A
prompt is only ever assembled from whole lines, on both shells — under *any*
interleaving, including the one CI hit.

`-n` on every read is load-bearing, not cosmetic: without it bash reads a line
through `zreadc`'s 128-byte static buffer and pushes the remainder back with
`zsyncfd`'s `lseek`, which **fails on a tty and on a pipe** (`r < 0` leaves
`lused`/`lind` untouched), so the leftover bytes live only in that buffer — and
the one-byte timed read, which is always unbuffered, would step straight past
them. `MAX_LINE_BYTES` caps a single *line*, not a prompt.

Two smaller losses in the same loop go with it: `line` is cleared before the
read so a read that ends on a signal cannot leave a stale prompt to be re-run,
and a non-empty line returned with a failed status (end of input on an
unterminated last line) is now run rather than discarded.

## Repro evidence

The **defect** reproduces deterministically on both shells. The **specific CI
interleaving** does not reproduce on Linux, and is stated as unreproduced
rather than guessed at:

| probe | result |
| --- | --- |
| `go test -run TestInterruptWhileIdleDoesNotExit -count=100 -race` (bash 5.2) | green, no repro (516 s) |
| same test `-count=200` with bash 3.2.0 built from source, first on `PATH` (so `env bash` resolves to it) | green, no repro (1027 s) |
| 400 concurrent runs of the exact signal/write sequence under bash 3.2, jittered idle 1.0–2.5 s and gap 0.02–2.5 s | `bad=0 / 400` |
| bash 3.2 source read (`builtins/read.def`, `lib/sh/zread.c`) + the official 3.2 patch set (022/038/051 are the only read.def patches; 051 fixes the `interrupt_immediately` leak, so it is not in play on 3.2.57) | the blocking read at line 572 **cannot** return a short line with status 0 — the loop only exits at `c == delim`, EOF or error, and the latter two set a non-zero status. The drain read is the only read in the script that can hand the loop a line with bytes missing. |

## RED → GREEN

New test `TestALineSplitAcrossTheDrainWindowStaysOnePrompt` — one line whose
bytes straddle the drain window:

| shell | before | after |
| --- | --- | --- |
| bash 5.2 | `prompts = ["first line\nsecond line, part one - " "part two"]` — truncated prompt executed, tail ran as a second prompt | `["first line\nsecond line, part one - part two"]` |
| bash 3.2 | `prompts = ["first line" "part two"]` — `"second line, part one - "` **gone** | `["first line\nsecond line, part one - part two"]` |

`TestDrainKeepsPartialTrailingLine` also goes RED on bash 3.2 before
(`prompts = ["first line"]`) and green after; its `runtime.GOOS == "darwin"`
gate is deleted, because keeping the fragment was only unrecoverable on 3.2 while
the timer guarded a line read.

Production shape, driven over a **real pty** (not a pipe) with the gc wire
sequence `body / debounce / ESC / Enter`:

| script | bash 3.2 | bash 5.2 |
| --- | --- | --- |
| `origin/main` | `['alpha\nbeta\n\ngamma', 'delta']` — a whole line of the prompt lost | `['alpha\nbeta\n\ngamma', 'delta\nepsilon part one - ']` — truncated |
| this branch | `['alpha\nbeta\n\ngamma', 'delta\nepsilon part one - part two']` | same |

No pane echo regression: `-n` makes bash save/restore the tty around each read
(`ttsave`/`ttonechar`/`ttrestore`), and `tt_setonechar` does not touch `ECHO`,
so the pasted body still stays out of the pane.

## Gates

| gate | result |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./internal/worker/...` | 0 |
| `gofmt -l internal` | 0 (no output) |
| `golangci-lint run ./internal/worker/...` | 0 issues |
| `shellcheck internal/worker/adapters/zcode/zcode-repl` | 1 pre-existing SC2115 warning, **base-owned** — byte-identical on an untouched `origin/main` export of the file (line 172 there, line 182 here). No new finding. |
| `go test ./internal/worker/adapters/zcode/ -count=20` (bash 5.2) | ok, 515 s |
| `go test ./internal/worker/adapters/zcode/ -count=20` (bash 3.2) | ok, 515 s |
| `go test ./internal/testpolicy/resourcecensus/ -count=1` | ok — ledger flat (the new fixed sleep is offset by the `waitForTurns` swap) |
| `make test-fast-parallel` | run by the pre-push hook (no `--no-verify`) |

## Follow-up after merge

`~/.local/bin/zcode-repl` on maintainer-city is a **copy** refreshed from
`origin/main` (last refreshed to `26542454e5`; see memory
`codex-outage-cutover-20260907`), not a symlink into the repo. It must be
refreshed again after this merges, or the GLM 5.3 review arm keeps running the
lossy reader.

Refs ga-fasb8, ga-j4p3y.
