### PR TITLE
fix(beads): retry SQLite composite transactions on busy snapshots

### DIFF
--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -1624,6 +1624,8 @@ func (s *SQLiteStore) GetLocalString(id, key string) (string, error) {
 // Tx executes fn in one SQLite transaction. Every write is rolled back when
 // the callback returns an error, so callers can safely compose Create, Update,
 // metadata updates, and Close as one all-or-nothing operation.
+// A transient busy result retries the complete callback in a fresh transaction;
+// callers must keep side effects inside tx because fn may run more than once.
 func (s *SQLiteStore) Tx(_ string, fn func(tx Tx) error) error {
 	if err := s.ensureOpen(); err != nil {
 		return err
@@ -1631,19 +1633,21 @@ func (s *SQLiteStore) Tx(_ string, fn func(tx Tx) error) error {
 	if fn == nil {
 		return errors.New("beads tx: nil callback")
 	}
-	ctx := context.Background()
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("sqlite tx: begin: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-	if err := fn(&sqliteStoreTx{store: s, ctx: ctx, tx: tx}); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("sqlite tx: commit: %w", err)
-	}
-	return nil
+	return retryOnBusy(func() error {
+		ctx := context.Background()
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("sqlite tx: begin: %w", err)
+		}
+		defer tx.Rollback() //nolint:errcheck
+		if err := fn(&sqliteStoreTx{store: s, ctx: ctx, tx: tx}); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("sqlite tx: commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // AtomicTx reports that Tx uses a real SQLite transaction and rolls all

--- a/internal/beads/sqlite_store_test.go
+++ b/internal/beads/sqlite_store_test.go
@@ -114,6 +114,83 @@ func TestSQLiteStoreTxRollsBackEveryWriteOnCallbackError(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreTxRetriesBusySnapshot(t *testing.T) {
+	dir := t.TempDir()
+	opened, err := OpenSQLiteStore(dir)
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	store := opened.(*SQLiteStore)
+	t.Cleanup(func() { _ = store.CloseStore() })
+
+	seed, err := store.Create(Bead{Title: "seed"})
+	if err != nil {
+		t.Fatalf("seed Create: %v", err)
+	}
+
+	blocker, err := sql.Open("sqlite", sqliteStoreDSN(filepath.Join(dir, sqliteStoreFilename), false))
+	if err != nil {
+		t.Fatalf("open concurrent writer: %v", err)
+	}
+	blocker.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = blocker.Close() })
+
+	attempts := 0
+	const raceKey = "busy-snapshot-race"
+	err = store.Tx("retry busy snapshot", func(tx Tx) error {
+		attempts++
+		sqliteTx, ok := tx.(*sqliteStoreTx)
+		if !ok {
+			t.Fatalf("transaction type = %T, want *sqliteStoreTx", tx)
+		}
+
+		// Establish a deferred read snapshot. The concurrent commit below
+		// makes the first write return SQLITE_BUSY_SNAPSHOT.
+		var title string
+		if err := sqliteTx.tx.QueryRowContext(context.Background(),
+			`SELECT title FROM beads WHERE id=?`, seed.ID).Scan(&title); err != nil {
+			return fmt.Errorf("read seed snapshot: %w", err)
+		}
+		if attempts == 1 {
+			if _, err := blocker.Exec(`
+				INSERT INTO kv(key,value) VALUES(?,?)
+				ON CONFLICT(key) DO UPDATE SET value=excluded.value`, raceKey, "committed"); err != nil {
+				return fmt.Errorf("commit concurrent writer: %w", err)
+			}
+		}
+		_, err := tx.Create(Bead{Title: fmt.Sprintf("created on attempt %d", attempts)})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("Tx: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("Tx callback attempts = %d, want 2 after SQLITE_BUSY_SNAPSHOT", attempts)
+	}
+
+	var value string
+	if err := blocker.QueryRow(`SELECT value FROM kv WHERE key=?`, raceKey).Scan(&value); err != nil {
+		t.Fatalf("read concurrent writer commit: %v", err)
+	}
+	if value != "committed" {
+		t.Fatalf("concurrent writer value = %q, want committed", value)
+	}
+	rows, err := store.List(ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	created := false
+	for _, row := range rows {
+		if row.Title == "created on attempt 2" {
+			created = true
+			break
+		}
+	}
+	if len(rows) != 2 || !created {
+		t.Fatalf("rows after retry = %+v, want seed plus second-attempt create", rows)
+	}
+}
+
 func TestSQLiteStoreReadsAndWritesLegacyThreeColumnDepsSchema(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, sqliteStoreFilename)


### PR DESCRIPTION
Closes #6152

## Summary

`SQLiteStore.Tx` is the composite write path used by formula instantiation and
other multi-write operations. It opened one deferred SQLite transaction but did
not use the store's existing `retryOnBusy` helper. Under concurrent writes,
SQLite can return `SQLITE_BUSY_SNAPSHOT` (`database is locked (517)`) immediately;
the busy timeout cannot resolve that snapshot.

## Change

- Run the complete `SQLiteStore.Tx` callback through `retryOnBusy`.
- Each retry begins a fresh transaction, so the callback re-reads current state
  after the failed snapshot and preserves all-or-nothing semantics.
- Document that transaction callbacks must keep side effects inside `tx`, since
  a transient busy result may replay the callback.
- Add a deterministic two-connection regression test that creates a read
  snapshot, commits a competing write, and verifies the first attempt fails,
  the second succeeds, and only the successful write remains.

This is the existing native retry primitive; no sling wrapper, daemon knob, or
new local layer is introduced. The accepted beads/Dolt contract remains the
boundary: `engdocs/design/beads-dolt-contract-redesign.md`.

## Verification

- `go test -count=10 ./internal/beads -run '^TestSQLiteStoreTxRetriesBusySnapshot$'`
- `go test -count=1 ./internal/beads/...`
- `make build`
- `make check` (including lint, vet, boundary checks, and observable tests)

All Go commands ran through the Westlands Nomad builder wrapper.
