### PR TITLE
perf(status): memoize runtime probes per pass, widen their budget

### DIFF
--- a/cmd/gc/status_provider.go
+++ b/cmd/gc/status_provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -11,8 +13,35 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+// gc status observes every configured agent through the runtime provider,
+// and each observation is several probes (IsRunning, ObserveLiveness,
+// GetMeta, GetLastActivity, ...). Subprocess-backed providers (tmux, herdr)
+// answer each probe with a fork+exec, and the status code asks the same
+// question many times over: pool discovery calls ListRunning("") once per
+// pool, a herdr ListRunning fans out to one `agent get` per bound session,
+// and every observation re-asks IsRunning for a name that was just listed.
+// On a nine-session city that measured 486 herdr spawns per `gc status`,
+// ~3 s of system time, with most probes hitting the old 50 ms bound: the
+// command reported partial status and showed live sessions as not running.
+//
+// statusProvider therefore treats one status pass as a point-in-time
+// snapshot of the runtime:
+//
+//   - identical read-only probes (same method, same arguments) run once per
+//     wrapper; concurrent and later callers share that one result;
+//   - a probe gets a realistic per-call budget (statusProviderCallTimeout),
+//     so a healthy runtime under host load is not reported as absent;
+//   - the pass as a whole has a wall-clock ceiling
+//     (statusProviderPassBudget), so a hung runtime costs one bounded wait
+//     rather than one per probe.
+//
+// A probe that outlives its caller's budget keeps running; its result is
+// kept and served to the next caller instead of being thrown away. Any
+// mutation through the wrapper (Start, Stop, SetMeta, ...) drops the
+// snapshot so a later probe re-reads the runtime.
 var (
-	statusProviderCallTimeout    = 50 * time.Millisecond
+	statusProviderCallTimeout    = 500 * time.Millisecond
+	statusProviderPassBudget     = 5 * time.Second
 	statusProviderTimeoutWarning = func() {
 		fmt.Fprintln(os.Stderr, "gc status: runtime status probe timed out; using partial status")
 	}
@@ -22,6 +51,17 @@ type statusProvider struct {
 	base     runtime.Provider
 	warnOnce sync.Once
 	partial  atomic.Bool
+
+	mu       sync.Mutex
+	deadline time.Time // pass deadline; zero until the first probe
+	probes   map[string]*statusProbe
+}
+
+// statusProbe is one in-flight or completed runtime probe. done is closed
+// once result holds the provider's answer.
+type statusProbe struct {
+	done   chan struct{}
+	result any
 }
 
 var _ runtime.RelaunchProvider = (*statusProvider)(nil)
@@ -45,166 +85,220 @@ func newBoundedStatusProvider(base runtime.Provider) runtime.Provider {
 	if sp, ok := base.(*statusProvider); ok {
 		return sp
 	}
-	return &statusProvider{base: base}
+	return &statusProvider{base: base, probes: make(map[string]*statusProbe)}
 }
 
-func boundedStatusCall[T any](p *statusProvider, fallback T, fn func() T) T {
-	if statusProviderCallTimeout <= 0 {
-		return fn()
+// statusProbeKey identifies a probe by method and arguments. NUL separates
+// the parts because provider arguments are free-form strings that may
+// contain any printable separator.
+func statusProbeKey(method string, args ...string) string {
+	return method + "\x00" + strings.Join(args, "\x00")
+}
+
+// probe returns the memoized probe for key, starting fn on a goroutine when
+// no probe with that key exists yet.
+func (p *statusProvider) probe(key string, fn func() any) *statusProbe {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if pr, ok := p.probes[key]; ok {
+		return pr
 	}
-	resultCh := make(chan T, 1)
+	pr := &statusProbe{done: make(chan struct{})}
+	p.probes[key] = pr
 	go func() {
-		resultCh <- fn()
+		pr.result = fn()
+		close(pr.done)
 	}()
-	select {
-	case result := <-resultCh:
-		return result
-	case <-time.After(statusProviderCallTimeout):
-		p.partial.Store(true)
-		p.warnOnce.Do(statusProviderTimeoutWarning)
-		return fallback
+	return pr
+}
+
+// invalidate drops the memoized probes. Called by every mutating method so
+// a probe issued after a mutation observes the runtime again.
+func (p *statusProvider) invalidate() {
+	p.mu.Lock()
+	p.probes = make(map[string]*statusProbe)
+	p.mu.Unlock()
+}
+
+// callBudget returns how long a probe issued at now may wait: the per-call
+// timeout, shortened to whatever is left of the pass budget. The pass
+// budget starts at the first probe, not at construction, because the
+// wrapper is built before the bead store is opened and that can take
+// seconds on its own. ok is false once the pass budget is spent.
+func (p *statusProvider) callBudget(now time.Time) (wait time.Duration, ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.deadline.IsZero() {
+		p.deadline = now.Add(statusProviderPassBudget)
 	}
+	remaining := p.deadline.Sub(now)
+	if remaining <= 0 {
+		return 0, false
+	}
+	return min(statusProviderCallTimeout, remaining), true
+}
+
+func (p *statusProvider) markPartial() {
+	p.partial.Store(true)
+	p.warnOnce.Do(statusProviderTimeoutWarning)
+}
+
+// boundedStatusCall answers a read-only probe from the pass snapshot,
+// running fn at most once per key. It returns fallback, and marks the status
+// partial, when the probe does not complete within the caller's budget; the
+// probe itself keeps running so its answer serves the next caller.
+func boundedStatusCall[T any](p *statusProvider, key string, fallback T, fn func() T) T {
+	pr := p.probe(key, func() any { return fn() })
+	if statusProviderCallTimeout <= 0 {
+		<-pr.done
+		return pr.result.(T)
+	}
+	if wait, ok := p.callBudget(time.Now()); ok {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-pr.done:
+			return pr.result.(T)
+		case <-timer.C:
+		}
+	}
+	p.markPartial()
+	return fallback
 }
 
 func (p *statusProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	p.invalidate()
 	return p.base.Start(ctx, name, cfg)
 }
 
 func (p *statusProvider) Stop(name string) error {
+	p.invalidate()
 	return p.base.Stop(name)
 }
 
 func (p *statusProvider) Interrupt(name string) error {
+	p.invalidate()
 	return p.base.Interrupt(name)
 }
 
 func (p *statusProvider) IsRunning(name string) bool {
-	return boundedStatusCall(p, false, func() bool {
+	return boundedStatusCall(p, statusProbeKey("IsRunning", name), false, func() bool {
 		return p.base.IsRunning(name)
 	})
 }
 
 func (p *statusProvider) IsAttached(name string) bool {
-	return boundedStatusCall(p, false, func() bool {
+	return boundedStatusCall(p, statusProbeKey("IsAttached", name), false, func() bool {
 		return p.base.IsAttached(name)
 	})
 }
 
 func (p *statusProvider) Attach(name string) error {
+	p.invalidate()
 	return p.base.Attach(name)
 }
 
 func (p *statusProvider) ProcessAlive(name string, processNames []string) bool {
-	return boundedStatusCall(p, false, func() bool {
+	key := statusProbeKey("ProcessAlive", name, strings.Join(processNames, ","))
+	return boundedStatusCall(p, key, false, func() bool {
 		return p.base.ProcessAlive(name, processNames)
 	})
 }
 
 func (p *statusProvider) ObserveLiveness(name string, processNames []string) runtime.Liveness {
-	return boundedStatusCall(p, runtime.Liveness{}, func() runtime.Liveness {
+	key := statusProbeKey("ObserveLiveness", name, strings.Join(processNames, ","))
+	return boundedStatusCall(p, key, runtime.Liveness{}, func() runtime.Liveness {
 		return runtime.ObserveLiveness(p.base, name, processNames)
 	})
 }
 
 func (p *statusProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	p.invalidate()
 	return p.base.Nudge(name, content)
 }
 
 func (p *statusProvider) SetMeta(name, key, value string) error {
+	p.invalidate()
 	return p.base.SetMeta(name, key, value)
 }
 
 func (p *statusProvider) GetMeta(name, key string) (string, error) {
-	result := boundedStatusCall(p, struct {
+	type result struct {
 		value string
 		err   error
-	}{}, func() struct {
-		value string
-		err   error
-	} {
+	}
+	r := boundedStatusCall(p, statusProbeKey("GetMeta", name, key), result{}, func() result {
 		value, err := p.base.GetMeta(name, key)
-		return struct {
-			value string
-			err   error
-		}{value: value, err: err}
+		return result{value: value, err: err}
 	})
-	return result.value, result.err
+	return r.value, r.err
 }
 
 func (p *statusProvider) RemoveMeta(name, key string) error {
+	p.invalidate()
 	return p.base.RemoveMeta(name, key)
 }
 
 func (p *statusProvider) Peek(name string, lines int) (string, error) {
-	result := boundedStatusCall(p, struct {
+	type result struct {
 		value string
 		err   error
-	}{}, func() struct {
-		value string
-		err   error
-	} {
+	}
+	r := boundedStatusCall(p, statusProbeKey("Peek", name, strconv.Itoa(lines)), result{}, func() result {
 		value, err := p.base.Peek(name, lines)
-		return struct {
-			value string
-			err   error
-		}{value: value, err: err}
+		return result{value: value, err: err}
 	})
-	return result.value, result.err
+	return r.value, r.err
 }
 
 func (p *statusProvider) ListRunning(prefix string) ([]string, error) {
-	result := boundedStatusCall(p, struct {
+	type result struct {
 		value []string
 		err   error
-	}{}, func() struct {
-		value []string
-		err   error
-	} {
+	}
+	r := boundedStatusCall(p, statusProbeKey("ListRunning", prefix), result{}, func() result {
 		value, err := p.base.ListRunning(prefix)
-		return struct {
-			value []string
-			err   error
-		}{value: value, err: err}
+		return result{value: value, err: err}
 	})
-	return result.value, result.err
+	return r.value, r.err
 }
 
 func (p *statusProvider) RouteACP(name string) {
 	if router, ok := p.base.(interface{ RouteACP(string) }); ok {
+		p.invalidate()
 		router.RouteACP(name)
 	}
 }
 
 func (p *statusProvider) GetLastActivity(name string) (time.Time, error) {
-	result := boundedStatusCall(p, struct {
+	type result struct {
 		value time.Time
 		err   error
-	}{}, func() struct {
-		value time.Time
-		err   error
-	} {
+	}
+	r := boundedStatusCall(p, statusProbeKey("GetLastActivity", name), result{}, func() result {
 		value, err := p.base.GetLastActivity(name)
-		return struct {
-			value time.Time
-			err   error
-		}{value: value, err: err}
+		return result{value: value, err: err}
 	})
-	return result.value, result.err
+	return r.value, r.err
 }
 
 func (p *statusProvider) ClearScrollback(name string) error {
+	p.invalidate()
 	return p.base.ClearScrollback(name)
 }
 
 func (p *statusProvider) CopyTo(name, src, relDst string) error {
+	p.invalidate()
 	return p.base.CopyTo(name, src, relDst)
 }
 
 func (p *statusProvider) SendKeys(name string, keys ...string) error {
+	p.invalidate()
 	return p.base.SendKeys(name, keys...)
 }
 
 func (p *statusProvider) RunLive(name string, cfg runtime.Config) error {
+	p.invalidate()
 	return p.base.RunLive(name, cfg)
 }
 
@@ -213,6 +307,7 @@ func (p *statusProvider) RunLive(name string, cfg runtime.Config) error {
 // by the status wrapper. Not bounded — it is a mutation, not a status probe.
 func (p *statusProvider) Relaunch(ctx context.Context, name string, cfg runtime.Config) error {
 	if rp, ok := p.base.(runtime.RelaunchProvider); ok {
+		p.invalidate()
 		return rp.Relaunch(ctx, name, cfg)
 	}
 	return runtime.ErrRelaunchUnsupported
@@ -227,20 +322,15 @@ func (p *statusProvider) Pending(name string) (*runtime.PendingInteraction, erro
 	if !ok {
 		return nil, nil
 	}
-	result := boundedStatusCall(p, struct {
+	type result struct {
 		value *runtime.PendingInteraction
 		err   error
-	}{}, func() struct {
-		value *runtime.PendingInteraction
-		err   error
-	} {
+	}
+	r := boundedStatusCall(p, statusProbeKey("Pending", name), result{}, func() result {
 		value, err := ip.Pending(name)
-		return struct {
-			value *runtime.PendingInteraction
-			err   error
-		}{value: value, err: err}
+		return result{value: value, err: err}
 	})
-	return result.value, result.err
+	return r.value, r.err
 }
 
 func (p *statusProvider) Respond(name string, response runtime.InteractionResponse) error {
@@ -248,5 +338,6 @@ func (p *statusProvider) Respond(name string, response runtime.InteractionRespon
 	if !ok {
 		return runtime.ErrInteractionUnsupported
 	}
+	p.invalidate()
 	return ip.Respond(name, response)
 }

--- a/cmd/gc/status_provider_test.go
+++ b/cmd/gc/status_provider_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -8,12 +9,17 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+// statusProbeProvider is a runtime.Provider whose IsRunning the test can
+// delay, gate, and count.
 type statusProbeProvider struct {
 	runtime.Provider
-	delay       atomic.Int64
-	running     atomic.Bool
-	liveness    atomic.Value
-	observeCall atomic.Int32
+	delay        atomic.Int64
+	running      atomic.Bool
+	liveness     atomic.Value
+	observeCall  atomic.Int32
+	runningCalls atomic.Int32
+	metaCalls    atomic.Int32
+	gate         chan struct{} // when set, IsRunning blocks until it is closed
 }
 
 func newStatusProbeProvider() *statusProbeProvider {
@@ -23,8 +29,17 @@ func newStatusProbeProvider() *statusProbeProvider {
 }
 
 func (p *statusProbeProvider) IsRunning(string) bool {
+	p.runningCalls.Add(1)
+	if p.gate != nil {
+		<-p.gate
+	}
 	time.Sleep(time.Duration(p.delay.Load()))
 	return p.running.Load()
+}
+
+func (p *statusProbeProvider) GetMeta(name, key string) (string, error) {
+	p.metaCalls.Add(1)
+	return p.Provider.GetMeta(name, key)
 }
 
 func (p *statusProbeProvider) ObserveLiveness(string, []string) runtime.Liveness {
@@ -32,33 +47,158 @@ func (p *statusProbeProvider) ObserveLiveness(string, []string) runtime.Liveness
 	return p.liveness.Load().(runtime.Liveness)
 }
 
-func TestStatusProviderTimeoutDoesNotStickAcrossCalls(t *testing.T) {
-	origTimeout := statusProviderCallTimeout
-	origWarn := statusProviderTimeoutWarning
+// setStatusProviderBudgets overrides the probe budgets for one test and
+// replaces the stderr warning with a counter.
+func setStatusProviderBudgets(t *testing.T, call, pass time.Duration) *atomic.Int32 {
+	t.Helper()
+	origCall, origPass, origWarn := statusProviderCallTimeout, statusProviderPassBudget, statusProviderTimeoutWarning
 	t.Cleanup(func() {
-		statusProviderCallTimeout = origTimeout
+		statusProviderCallTimeout = origCall
+		statusProviderPassBudget = origPass
 		statusProviderTimeoutWarning = origWarn
 	})
-	statusProviderCallTimeout = 10 * time.Millisecond
+	statusProviderCallTimeout = call
+	statusProviderPassBudget = pass
 	var warnings atomic.Int32
-	statusProviderTimeoutWarning = func() {
-		warnings.Add(1)
-	}
+	statusProviderTimeoutWarning = func() { warnings.Add(1) }
+	return &warnings
+}
 
+// A status pass is a point-in-time snapshot: the same probe asked twice
+// reaches the runtime once. Before this, a nine-session city spawned 486
+// herdr subprocesses per `gc status` because pool discovery and per-agent
+// observation kept re-asking ListRunning and IsRunning for the same names.
+func TestStatusProviderMemoizesIdenticalProbesWithinPass(t *testing.T) {
 	base := newStatusProbeProvider()
 	base.running.Store(true)
-	base.delay.Store(int64(100 * time.Millisecond))
+	wrapped := newBoundedStatusProvider(base)
+
+	for i := 0; i < 20; i++ {
+		if !wrapped.IsRunning("worker") {
+			t.Fatalf("IsRunning call %d = false, want true", i)
+		}
+	}
+	if got := base.runningCalls.Load(); got != 1 {
+		t.Fatalf("IsRunning reached the provider %d times for one name, want 1", got)
+	}
+	wrapped.IsRunning("other")
+	if got := base.runningCalls.Load(); got != 2 {
+		t.Fatalf("IsRunning reached the provider %d times for two names, want 2", got)
+	}
+
+	// Arguments are part of a probe's identity: two keys, two reads.
+	for _, key := range []string{"a", "a", "b"} {
+		_, _ = wrapped.GetMeta("worker", key)
+	}
+	if got := base.metaCalls.Load(); got != 2 {
+		t.Fatalf("GetMeta reached the provider %d times for two keys, want 2", got)
+	}
+}
+
+// Concurrent callers of one probe (the observation pool runs eight wide)
+// share a single in-flight runtime call instead of each spawning their own.
+func TestStatusProviderConcurrentIdenticalProbesShareOneCall(t *testing.T) {
+	base := newStatusProbeProvider()
+	base.running.Store(true)
+	base.gate = make(chan struct{})
+	wrapped := newBoundedStatusProvider(base)
+
+	results := make([]bool, 8)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = wrapped.IsRunning("worker")
+		}(i)
+	}
+	close(base.gate)
+	wg.Wait()
+
+	for i, running := range results {
+		if !running {
+			t.Fatalf("caller %d got false, want the shared probe's true", i)
+		}
+	}
+	if got := base.runningCalls.Load(); got != 1 {
+		t.Fatalf("IsRunning reached the provider %d times for eight concurrent callers, want 1", got)
+	}
+}
+
+// A probe that outlives its caller's budget is not thrown away: it keeps
+// running and its answer serves the next caller. The old wrapper discarded
+// the late result and re-spawned the probe on the next call, so a slow
+// runtime paid for every probe twice and still reported it as absent.
+func TestStatusProviderTimedOutProbeServesItsResultToTheNextCaller(t *testing.T) {
+	warnings := setStatusProviderBudgets(t, 10*time.Millisecond, 5*time.Second)
+	base := newStatusProbeProvider()
+	base.running.Store(true)
+	base.gate = make(chan struct{})
 	wrapped := newBoundedStatusProvider(base)
 
 	if wrapped.IsRunning("worker") {
-		t.Fatal("first IsRunning returned true, want timeout fallback false")
+		t.Fatal("first IsRunning returned true, want timeout fallback false while the probe is blocked")
 	}
-	base.delay.Store(0)
-	if !wrapped.IsRunning("worker") {
-		t.Fatal("second IsRunning returned false, want fresh provider result after timeout")
+	if !statusProviderPartial(wrapped) {
+		t.Fatal("statusProviderPartial = false, want true after a probe timeout")
+	}
+
+	close(base.gate)
+	deadline := time.Now().Add(5 * time.Second)
+	for !wrapped.IsRunning("worker") {
+		if time.Now().After(deadline) {
+			t.Fatal("IsRunning never delivered the late probe result after the provider answered")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := base.runningCalls.Load(); got != 1 {
+		t.Fatalf("IsRunning reached the provider %d times, want 1: the timed-out probe must be reused, not re-spawned", got)
 	}
 	if got := warnings.Load(); got != 1 {
 		t.Fatalf("timeout warnings = %d, want 1", got)
+	}
+}
+
+// The pass budget caps what a hung runtime can cost: once it is spent,
+// further probes return their fallback at once instead of each waiting out
+// the per-call timeout.
+func TestStatusProviderPassBudgetStopsWaitingOnAHungRuntime(t *testing.T) {
+	warnings := setStatusProviderBudgets(t, time.Second, 30*time.Millisecond)
+	base := newStatusProbeProvider()
+	base.running.Store(true)
+	base.gate = make(chan struct{})
+	t.Cleanup(func() { close(base.gate) }) // let the hung probes exit
+	wrapped := newBoundedStatusProvider(base)
+
+	start := time.Now()
+	for _, name := range []string{"a", "b", "c"} {
+		if wrapped.IsRunning(name) {
+			t.Fatalf("IsRunning(%q) = true, want fallback false from a hung probe", name)
+		}
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("three probes on a hung runtime took %s; the 30ms pass budget should have capped the wait well under the 1s per-call timeout", elapsed)
+	}
+	if !statusProviderPartial(wrapped) {
+		t.Fatal("statusProviderPartial = false, want true after the pass budget was spent")
+	}
+	if got := warnings.Load(); got != 1 {
+		t.Fatalf("timeout warnings = %d, want exactly 1 for the whole pass", got)
+	}
+}
+
+// A mutation through the wrapper invalidates the snapshot, so a probe
+// issued afterwards observes the runtime again.
+func TestStatusProviderMutationInvalidatesSnapshot(t *testing.T) {
+	base := newStatusProbeProvider()
+	base.running.Store(true)
+	wrapped := newBoundedStatusProvider(base)
+
+	wrapped.IsRunning("worker")
+	_ = wrapped.SetMeta("worker", "k", "v")
+	wrapped.IsRunning("worker")
+	if got := base.runningCalls.Load(); got != 2 {
+		t.Fatalf("IsRunning reached the provider %d times across a mutation, want 2", got)
 	}
 }
 
@@ -77,14 +217,7 @@ func TestStatusProviderPreservesNativeLivenessObservation(t *testing.T) {
 }
 
 func TestStatusProviderTimeoutMarksPartial(t *testing.T) {
-	origTimeout := statusProviderCallTimeout
-	origWarn := statusProviderTimeoutWarning
-	t.Cleanup(func() {
-		statusProviderCallTimeout = origTimeout
-		statusProviderTimeoutWarning = origWarn
-	})
-	statusProviderCallTimeout = 10 * time.Millisecond
-	statusProviderTimeoutWarning = func() {}
+	setStatusProviderBudgets(t, 10*time.Millisecond, 5*time.Second)
 
 	base := newStatusProbeProvider()
 	base.running.Store(true)

--- a/cmd/gc/status_provider_test.go
+++ b/cmd/gc/status_provider_test.go
@@ -125,6 +125,24 @@ func TestStatusProviderConcurrentIdenticalProbesShareOneCall(t *testing.T) {
 	}
 }
 
+// statusProbeDone returns the done channel of the probe memoized under key,
+// so a test can wait for a late probe's answer on the probe's own lifecycle
+// signal instead of polling the wrapper.
+func statusProbeDone(t *testing.T, sp runtime.Provider, key string) <-chan struct{} {
+	t.Helper()
+	p, ok := sp.(*statusProvider)
+	if !ok {
+		t.Fatalf("provider is %T, want *statusProvider", sp)
+	}
+	p.mu.Lock()
+	pr := p.probes[key]
+	p.mu.Unlock()
+	if pr == nil {
+		t.Fatalf("no probe memoized under %q", key)
+	}
+	return pr.done
+}
+
 // A probe that outlives its caller's budget is not thrown away: it keeps
 // running and its answer serves the next caller. The old wrapper discarded
 // the late result and re-spawned the probe on the next call, so a slow
@@ -144,12 +162,13 @@ func TestStatusProviderTimedOutProbeServesItsResultToTheNextCaller(t *testing.T)
 	}
 
 	close(base.gate)
-	deadline := time.Now().Add(5 * time.Second)
-	for !wrapped.IsRunning("worker") {
-		if time.Now().After(deadline) {
-			t.Fatal("IsRunning never delivered the late probe result after the provider answered")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-statusProbeDone(t, wrapped, statusProbeKey("IsRunning", "worker")):
+	case <-time.After(5 * time.Second):
+		t.Fatal("the timed-out probe never completed after the provider answered")
+	}
+	if !wrapped.IsRunning("worker") {
+		t.Fatal("IsRunning returned false after the late probe answered, want its memoized true")
 	}
 	if got := base.runningCalls.Load(); got != 1 {
 		t.Fatalf("IsRunning reached the provider %d times, want 1: the timed-out probe must be reused, not re-spawned", got)


### PR DESCRIPTION
## Summary

`gc status` observes every configured agent through the runtime provider, and each observation is several probes (`IsRunning`, `ObserveLiveness`, `GetMeta`, `GetLastActivity`, ...). Subprocess-backed providers (tmux, herdr) answer each probe with a fork+exec, and the status code asks the same question many times over: pool discovery calls `ListRunning("")` once per pool, a herdr `ListRunning` fans out to one `agent get` per bound session, and every observation re-asks `IsRunning` for a name that was just listed.

The status wrapper (`cmd/gc/status_provider.go`) bounded each probe at 50 ms and forgot the answer. On a nine-session city one `gc status --json` spawned 486 herdr subprocesses (53 `agent get` per live session, 52 `agent list`), burned about 3 s of system time in fork, took 5.7 s, and still printed `runtime status probe timed out; using partial status`, because a fork under host load exceeds 50 ms. The timed-out probes ran to completion anyway; only their answers were thrown away, and live sessions were shown as not running.

The wrapper now treats one status pass as a point-in-time snapshot of the runtime:

- identical read-only probes (same method, same arguments) run once per wrapper; concurrent and later callers share that one result, and a probe that outlives its caller's budget serves its late answer to the next caller instead of being re-spawned;
- the per-call budget is 500 ms, so a healthy runtime under host load is not reported as absent;
- the pass has a 5 s wall-clock ceiling, so a hung runtime costs one bounded wait rather than one per probe.

Mutations through the wrapper (`Start`, `Stop`, `SetMeta`, ...) drop the snapshot so a later probe re-reads the runtime.

Measured on the same city after the change: `gc status` 1.3 s, `gc status --json` 2.0 s, no partial-status warning, one `agent list` plus one `agent get` per live session.

## Testing

- [x] `gofmt`, `go vet ./cmd/gc/`, `go test ./cmd/gc/ -run Status` (new tests: memoization within a pass, concurrent callers sharing one in-flight probe, a timed-out probe serving its result to the next caller, the pass budget on a hung runtime, mutation invalidating the snapshot)
- [ ] `make check-docs` (no docs changed)
- [ ] `make test-integration` (the change is confined to the status wrapper; no runtime, controller or workflow behavior changes)

## Checklist

- [x] Linked an issue, or explained why one is not needed: found while profiling a slow `gc status` on a live city; tracked in that city's beads as gc-ici3j1, no upstream issue filed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes: none, the command's output is unchanged apart from the disappearing partial-status warning
- [x] Called out breaking changes or migration notes: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfHi4GDC8mtP1NoZAkR858
