### PR TITLE
fix(workflow): read workflow descendants at TierBoth through the live handle (#6129)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -2945,10 +2945,12 @@ func findWorkflowBeads(store beads.Store, workflowID string) ([]beads.Bead, erro
 	for _, root := range roots {
 		addRoot(root)
 	}
+	reader := beads.HandlesFor(store).Live
 	for _, rootID := range rootIDs {
-		all, err := store.List(beads.ListQuery{
+		all, err := reader.List(beads.ListQuery{
 			Metadata:      map[string]string{beadmeta.RootBeadIDMetadataKey: rootID},
 			IncludeClosed: true,
+			TierMode:      beads.TierBoth,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("listing descendants of workflow %s: %w", rootID, err)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -7582,6 +7582,64 @@ func TestWorkflowDeleteSweepsTheRelocatedTreeAndTheRetainedCopy(t *testing.T) {
 	}
 }
 
+// TestWorkflowDeleteSweepsTheEphemeralTierOfTheRelocatedTree is the #6129
+// regression: findWorkflowBeads' descendants query left ListQuery.TierMode at
+// its zero value, TierIssues, which filters out Ephemeral rows. On a split
+// city the sweep still finds the root through the class binding, but every
+// wisp-tier step under it — the shape orchestration steps actually run in —
+// was silently dropped from the member set. `gc workflow delete` closed the
+// root and reported success while the ephemeral steps stayed open, rootless,
+// still carrying gc.root_bead_id pointing at a workflow that is gone.
+func TestWorkflowDeleteSweepsTheEphemeralTierOfTheRelocatedTree(t *testing.T) {
+	cityPath, _ := foreignProviderCity(t)
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	binding := soleClassBindingStore(t, cityPath)
+	root, err := binding.Create(beads.Bead{
+		Title:  "the workflow root",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey: beadmeta.KindWorkflow,
+		},
+	})
+	if err != nil {
+		t.Fatalf("seeding the workflow root in the class binding: %v", err)
+	}
+
+	creator, ok := binding.(beads.StorageCreateStore)
+	if !ok {
+		t.Fatalf("the class binding (%T) implements no StorageCreateStore, so this fixture cannot reach its ephemeral tier", binding)
+	}
+	wisp, err := creator.CreateWithStorage(beads.Bead{
+		Title:    "the ephemeral step",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: root.ID},
+	}, beads.StorageEphemeral)
+	if err != nil {
+		t.Fatalf("minting the ephemeral descendant in the class binding: %v", err)
+	}
+	if !wisp.Ephemeral {
+		t.Fatalf("minted descendant %s has Ephemeral=false; this fixture is not exercising the wisp tier the bug is about", wisp.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDelete(root.ID, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("gc workflow delete exited %d: %s%s", code, stdout.String(), stderr.String())
+	}
+
+	closedWisp, err := binding.Get(wisp.ID)
+	if err != nil {
+		t.Fatalf("reading the ephemeral descendant back from the binding: %v", err)
+	}
+	if closedWisp.Status != "closed" {
+		t.Errorf("the ephemeral descendant %s is %q after the sweep, want closed: the descendants query must read TierMode: TierBoth so a relocated binding's wisp-tier steps are not silently dropped from the workflow's member set", wisp.ID, closedWisp.Status)
+	}
+}
+
 // TestWorkflowDeleteRefusesToSweepPastABindingThatStandsRefused pins the arm
 // that separates a sweep from a read.
 //


### PR DESCRIPTION
## What

`findWorkflowBeads`'s descendants query left `ListQuery.TierMode` at its zero value (`TierIssues`), which filters out `Ephemeral` rows. On a split city whose coordination class is relocated to its own binding, this silently dropped every wisp-tier step from a workflow's member set: `gc workflow delete <root>` closed the root and reported success while its ephemeral steps stayed open, rootless, still carrying `gc.root_bead_id` pointing at a workflow that is gone.

Fixes #6129.

## Fix

Routes the descendants read through `beads.HandlesFor(store).Live`, which forces a live `TierBoth` read regardless of the query passed, and states `TierMode: beads.TierBoth` explicitly — the same idiom already used elsewhere in this file (`wispGCRootSelectors` in `wisp_gc.go`) and the exact pattern PR #5802 used to fix the identical shape in a sibling function. Two-line production change; the rest of the diff is the new regression test.

## Testing

`go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty. New regression test `TestWorkflowDeleteSweepsTheEphemeralTierOfTheRelocatedTree` mints an ephemeral descendant through a class-binding fixture's `StorageCreateStore`, runs the delete, and asserts the descendant is closed. Independently confirmed this is a real regression guard, not a tautology: reverted just the two production lines, reran the test — it fails with the exact expected message ("... after the sweep, want closed ... TierMode: TierBoth ..."), then restored the fix and reconfirmed it passes.

Full local push-gate: all failures match this session's known-unrelated environmental clusters (dolt-fixture family, zcode interrupt tests) plus one shard failure that self-diagnosed in its own output as a leaked dolt test-server process contaminating an unrelated stderr-comparison test. None touch the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)