### PR TITLE
fix(reconciler): back off and escalate repeated cold-start failures

### DIFF
--- a/cmd/gc/doctor_startup_health.go
+++ b/cmd/gc/doctor_startup_health.go
@@ -95,11 +95,18 @@ func formatStartupHealthEpisodeDetail(ep session.StartupHealthEpisode) string {
 	if alert == "" {
 		alert = "none"
 	}
-	return fmt.Sprintf("%s: %d consecutive %s failures (first=%s, last=%s, quarantined_until=%s, alert=%s)",
+	// held_until is the EFFECTIVE hold (StartHoldUntil: the later of the
+	// quarantine and the retry backoff), not QuarantinedUntil alone. Past the
+	// threshold the quarantine is re-stamped at its fixed duration on every
+	// failure while the backoff keeps growing to its cap, so reporting the
+	// quarantine by itself would understate how long starts are actually
+	// refused. Both are rendered so an operator can still tell the two apart.
+	return fmt.Sprintf("%s: %d consecutive %s failures (first=%s, last=%s, quarantined_until=%s, held_until=%s, alert=%s)",
 		ep.SessionName, ep.ConsecutiveCount, kind,
 		formatStartupHealthDetailTime(ep.FirstFailureAt),
 		formatStartupHealthDetailTime(ep.LastFailureAt),
 		formatStartupHealthDetailTime(ep.QuarantinedUntil),
+		formatStartupHealthDetailTime(ep.StartHoldUntil()),
 		alert)
 }
 

--- a/cmd/gc/doctor_startup_health_test.go
+++ b/cmd/gc/doctor_startup_health_test.go
@@ -358,3 +358,35 @@ func TestStartupHealthEpisodesCheckNeverLeaksLastDetail(t *testing.T) {
 		t.Errorf("FixHint leaks LastDetail: %q", result.FixHint)
 	}
 }
+
+// TestStartupHealthEpisodesCheckReportsTheEffectiveHoldNotJustTheQuarantine
+// pins that the rendered detail names the instant starts are ACTUALLY held
+// until. Past the threshold the quarantine is re-stamped at a fixed 5m on
+// every failure while the retry backoff keeps growing to its 30m cap, so
+// rendering QuarantinedUntil alone would tell an operator starts resume in
+// five minutes when the gate will in fact refuse for half an hour (sr-xf2xj).
+func TestStartupHealthEpisodesCheckReportsTheEffectiveHoldNotJustTheQuarantine(t *testing.T) {
+	cityDir := t.TempDir()
+	mem := beads.NewMemStore()
+	now := time.Now().UTC().Truncate(time.Second)
+	backoffUntil := now.Add(30 * time.Minute)
+	seedStartupHealthEpisode(t, mem, session.StartupHealthEpisode{
+		SessionName:      "chaos-worker-held",
+		ConsecutiveCount: 8,
+		Kind:             session.FailureKindTimeout,
+		FirstFailureAt:   now.Add(-2 * time.Hour),
+		LastFailureAt:    now,
+		QuarantinedUntil: now.Add(5 * time.Minute),
+		BackoffUntil:     backoffUntil,
+	})
+
+	result := newStartupHealthEpisodesCheck(&config.City{}, cityDir, func(_ string) (beads.Store, error) {
+		return mem, nil
+	}).Run(&doctor.CheckContext{})
+
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "held_until="+backoffUntil.Format(time.RFC3339)) {
+		t.Errorf("Details must report the effective hold (backoff, %s), not just the quarantine:\n%s",
+			backoffUntil.Format(time.RFC3339), details)
+	}
+}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -2384,6 +2384,20 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 				kind = sessionpkg.FailureKindTimeout
 			}
 			episode := sessionpkg.RecordStartupFailure(prior, kind, result.err.Error(), clk.Now(), defaultMaxWakeAttempts, defaultQuarantineDuration)
+			// Stamp the retry backoff (caller-owned policy, see
+			// RecordStartupFailure's contract). Below the quarantine threshold
+			// this is the ONLY thing bounding the retry cadence, and it is
+			// what turns an indefinite ~65s respawn loop into a capped one.
+			episode.BackoffUntil = startupBackoffUntil(episode.ConsecutiveCount, clk.Now())
+			// Escalate exactly once per episode. RecordStartupFailure raises
+			// the disposition to pending on crossing the threshold and never
+			// regresses it from sent, so this fires on the threshold failure
+			// only. The event is recorded BEFORE the disposition is persisted:
+			// if the save below fails, the next failure re-alerts rather than
+			// losing the escalation entirely. At-least-once is the right
+			// failure mode for an alert whose whole purpose is that 42 silent
+			// hours never happen again.
+			episode = emitStartupHealthAlert(rec, stderr, episode, tp.TemplateName)
 			if saveErr := sessFront.SaveStartupHealthEpisode(episode); saveErr != nil {
 				fmt.Fprintf(stderr, "session reconciler: saving startup-health episode for %s: %v\n", name, saveErr) //nolint:errcheck
 			}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3739,14 +3739,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if sessionIsQuarantinedInfo(info, clk) {
 				continue // crash-loop protection
 			}
-			if episode, err := sessFront.LoadStartupHealthEpisode(name); err != nil {
+			// LoadStartupHealthEpisode returns the zero episode alongside an
+			// error, so the hold check below is a no-op on the fail-open path.
+			startupEpisode, startupEpisodeErr := sessFront.LoadStartupHealthEpisode(name)
+			if startupEpisodeErr != nil {
 				// Fail open: proceed as if no quarantine episode exists rather
 				// than block every session start on a transient store-read
 				// error. Logged (matching the two LoadStartupHealthEpisode
 				// call sites in session_lifecycle_parallel.go) so the miss is
 				// observable instead of silent.
-				fmt.Fprintf(stderr, "session reconciler: loading startup-health episode for %s: %v\n", name, err) //nolint:errcheck
-			} else if !episode.QuarantinedUntil.IsZero() {
+				fmt.Fprintf(stderr, "session reconciler: loading startup-health episode for %s: %v\n", name, startupEpisodeErr) //nolint:errcheck
+			} else if !startupEpisode.QuarantinedUntil.IsZero() {
 				// Mirror the active episode onto the visible session row
 				// (ga-em8g4o) so a caller can see why a start is being held
 				// back through the typed front door alone, without a separate
@@ -3755,12 +3758,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				// whether "now" is still before QuarantinedUntil, so the
 				// mirrored state stays visible through the tick that lets the
 				// quarantine expire.
-				if mirrorErr := mirrorStartupHealthEpisodeMetadata(sessFront, target.info.ID, episode); mirrorErr != nil {
+				if mirrorErr := mirrorStartupHealthEpisodeMetadata(sessFront, target.info.ID, startupEpisode); mirrorErr != nil {
 					fmt.Fprintf(stderr, "session reconciler: mirroring startup-health episode for %s: %v\n", name, mirrorErr) //nolint:errcheck
 				}
-				if clk.Now().Before(episode.QuarantinedUntil) {
-					continue // startup-health crash-loop protection (pending-create failures)
-				}
+			}
+			// StartHoldUntil is the later of the threshold quarantine and the
+			// per-failure retry backoff. The mirror above stays gated on
+			// QuarantinedUntil alone: a sub-threshold backoff is the normal
+			// self-healing cadence and must not surface on the session row (or,
+			// through it, in gc doctor) as a crash-loop quarantine.
+			if hold := startupEpisode.StartHoldUntil(); !hold.IsZero() && clk.Now().Before(hold) {
+				continue // startup-health crash-loop protection (pending-create failures)
 			}
 			if pendingCreateStartInFlightInfo(info, clk, startupTimeout) {
 				if trace != nil {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2547,6 +2547,17 @@ func (c *capturingRecorder) Record(e events.Event) {
 	c.events = append(c.events, e)
 }
 
+// eventsOfType returns the captured events of one type, in emission order.
+func (c *capturingRecorder) eventsOfType(t string) []events.Event {
+	out := make([]events.Event, 0, len(c.events))
+	for _, e := range c.events {
+		if e.Type == t {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // strandedEvents returns the captured events.SessionStranded events,
 // in emission order. Specialized to the only event type any test in
 // this package currently filters for; add a sibling method (or migrate

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -323,6 +323,23 @@ const (
 	// quarantine.
 	defaultMaxWakeAttempts = 5
 
+	// defaultStartupBackoffBase and defaultStartupBackoffCap bound the retry
+	// cadence for a session whose cold start keeps failing. The FIRST failure
+	// gets no hold at all — a single transient spawn flake must still retry on
+	// the next tick — and from the second the hold doubles from the base up to
+	// the cap. Without this the reconciler retried a wedged start every ~65s
+	// forever: 2,306 identical cold_start_timeout failures over 42 hours, at
+	// 53-56/hour, with no backoff and no give-up (sr-xf2xj).
+	//
+	// The cap is deliberately a ceiling on the RATE, not a permanent stop.
+	// Both observed incidents ended with a start that simply succeeded on the
+	// unchanged path (attempt 2,307 after 42h; attempt 6 after 5min), so a
+	// hard "never retry again" would have blocked a recovery that did in fact
+	// happen. At the cap a wedged template costs two start attempts an hour
+	// instead of 55, and the escalation alert has already fired.
+	defaultStartupBackoffBase = 30 * time.Second
+	defaultStartupBackoffCap  = 30 * time.Minute
+
 	// rateLimitPeekLines is the amount of pane scrollback inspected before a
 	// rapid dead process is classified as a crash. Known provider rate-limit
 	// screens are short, so 120 lines favors robust detection over shaving a

--- a/cmd/gc/startup_health_backoff.go
+++ b/cmd/gc/startup_health_backoff.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/events"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// startupBackoffUntil returns the instant before which the next start attempt
+// for a session with consecutiveFailures consecutive cold-start failures must
+// be held back, or the zero time when it should retry immediately.
+//
+// The first failure gets no hold: a lone spawn flake must not delay recovery.
+// From the second the interval doubles from defaultStartupBackoffBase and is
+// clamped at defaultStartupBackoffCap. The shift is computed on a duration
+// bounded by the cap rather than by shifting the exponent, so a pathological
+// counter (the 2,306-failure episode in sr-xf2xj) cannot overflow it.
+func startupBackoffUntil(consecutiveFailures int, now time.Time) time.Time {
+	if consecutiveFailures < 2 {
+		return time.Time{}
+	}
+	hold := defaultStartupBackoffBase
+	for i := 2; i < consecutiveFailures; i++ {
+		hold *= 2
+		if hold >= defaultStartupBackoffCap {
+			hold = defaultStartupBackoffCap
+			break
+		}
+	}
+	return now.Add(hold)
+}
+
+// emitStartupHealthAlert records the once-per-episode escalation for a session
+// whose consecutive cold-start failures crossed the quarantine threshold, and
+// returns the episode with its disposition latched to sent so no further
+// failure in the same episode re-alerts.
+//
+// It is the consumer the raw per-attempt session.cold_start_timeout event
+// never had: that event fired 2,306 times over 42 hours and nothing read it,
+// so the storm was invisible until someone grepped the event stream by hand
+// (sr-xf2xj). The human-readable line goes to the reconciler's stderr, where
+// the rest of the session-lifecycle narration lands.
+func emitStartupHealthAlert(
+	rec events.Recorder,
+	stderr io.Writer,
+	episode sessionpkg.StartupHealthEpisode,
+	template string,
+) sessionpkg.StartupHealthEpisode {
+	if episode.AlertDisposition != sessionpkg.AlertDispositionPending {
+		return episode
+	}
+	episode.AlertDisposition = sessionpkg.AlertDispositionSent
+	hold := episode.StartHoldUntil()
+	msg := fmt.Sprintf(
+		"COLD-START STORM: session=%s template=%s %d consecutive %s start failures since %s. "+
+			"Starts held back until %s and retried on a capped backoff. "+
+			"Inspect with: gc doctor",
+		episode.SessionName, template, episode.ConsecutiveCount, startupHealthAlertKind(episode),
+		formatStartupHealthAlertTime(episode.FirstFailureAt),
+		formatStartupHealthAlertTime(hold),
+	)
+	fmt.Fprintln(stderr, "session reconciler: "+msg) //nolint:errcheck
+	if rec == nil {
+		return episode
+	}
+	// LastDetail is deliberately excluded: provider error text can carry
+	// credentials, exactly as doctor_startup_health.go keeps it out of its
+	// rendered check result.
+	payload, _ := json.Marshal(map[string]any{
+		"session_name":      episode.SessionName,
+		"template":          template,
+		"consecutive_count": episode.ConsecutiveCount,
+		"kind":              startupHealthAlertKind(episode),
+		"first_failure_at":  formatStartupHealthAlertTime(episode.FirstFailureAt),
+		"held_until":        formatStartupHealthAlertTime(hold),
+	})
+	rec.Record(events.Event{
+		Type:    events.SessionStartupHealthAlert,
+		Actor:   "controller",
+		Subject: episode.SessionName,
+		Message: msg,
+		Payload: payload,
+	})
+	return episode
+}
+
+func startupHealthAlertKind(episode sessionpkg.StartupHealthEpisode) string {
+	if kind := string(episode.Kind); kind != "" {
+		return kind
+	}
+	return "unspecified"
+}
+
+func formatStartupHealthAlertTime(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/cmd/gc/startup_health_backoff_test.go
+++ b/cmd/gc/startup_health_backoff_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+// TestStartupBackoffUntilSchedule pins the retry cadence a template gets while
+// its cold start keeps failing. The first failure retries immediately (a single
+// transient flake must not be penalised); from the second the hold doubles and
+// is capped, so a start path that stays wedged is retried on the order of twice
+// an hour instead of every 65 seconds (sr-xf2xj: 2,306 identical failures in
+// 42h).
+func TestStartupBackoffUntilSchedule(t *testing.T) {
+	now := time.Date(2026, 8, 25, 5, 3, 26, 0, time.UTC)
+	cases := []struct {
+		count int
+		want  time.Duration
+	}{
+		{0, 0},
+		{1, 0},
+		{2, 30 * time.Second},
+		{3, time.Minute},
+		{4, 2 * time.Minute},
+		{5, 4 * time.Minute},
+		{6, 8 * time.Minute},
+		{7, 16 * time.Minute},
+		{8, 30 * time.Minute},
+		{20, 30 * time.Minute},
+		{4000, 30 * time.Minute},
+	}
+	for _, tc := range cases {
+		got := startupBackoffUntil(tc.count, now)
+		if tc.want == 0 {
+			if !got.IsZero() {
+				t.Errorf("startupBackoffUntil(%d) = %v, want zero (no hold)", tc.count, got)
+			}
+			continue
+		}
+		if want := now.Add(tc.want); !got.Equal(want) {
+			t.Errorf("startupBackoffUntil(%d) = %v, want %v (+%v)", tc.count, got, want, tc.want)
+		}
+	}
+}
+
+// TestStartupBackoffNeverShortensTheThresholdQuarantine pins that the capped
+// backoff schedule is never weaker than the fixed quarantine it now sits
+// alongside: at the threshold failure the effective hold must still be at
+// least defaultQuarantineDuration.
+func TestStartupBackoffNeverShortensTheThresholdQuarantine(t *testing.T) {
+	now := time.Date(2026, 8, 25, 5, 3, 26, 0, time.UTC)
+	ep := sessionpkg.StartupHealthEpisode{
+		ConsecutiveCount: defaultMaxWakeAttempts,
+		QuarantinedUntil: now.Add(defaultQuarantineDuration),
+		BackoffUntil:     startupBackoffUntil(defaultMaxWakeAttempts, now),
+	}
+	if hold := ep.StartHoldUntil(); hold.Before(now.Add(defaultQuarantineDuration)) {
+		t.Errorf("StartHoldUntil() = %v, want >= %v (backoff must never shorten the quarantine)",
+			hold, now.Add(defaultQuarantineDuration))
+	}
+}
+
+// TestPendingCreateFailureAccruesBackoffHoldBelowThreshold pins that the
+// second consecutive cold-start failure records a backoff hold — the ONLY
+// thing standing between a wedged start path and an unbounded retry loop
+// below the quarantine threshold. The quarantine field must stay clear so
+// `gc doctor` keeps reporting only genuine crash loops.
+func TestPendingCreateFailureAccruesBackoffHoldBelowThreshold(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260906001)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+	sessionName := h.sessionName
+
+	h.env.sp.StartErrors[sessionName] = errors.New("provider start failure")
+	for i := 0; i < 2; i++ {
+		if i > 0 {
+			h.createReplacementPendingCreateBead()
+		}
+		if tick := runDesiredPendingCreateTicks(t, h); tick == -1 {
+			t.Fatalf("failure %d: pending-create claim never released within 30 ticks", i+1)
+		}
+	}
+
+	is := sessionpkg.NewStore(beads.SessionStore{Store: h.env.store})
+	episode, err := is.LoadStartupHealthEpisode(sessionName)
+	if err != nil {
+		t.Fatalf("LoadStartupHealthEpisode: %v", err)
+	}
+	if episode.ConsecutiveCount != 2 {
+		t.Fatalf("ConsecutiveCount = %d, want 2", episode.ConsecutiveCount)
+	}
+	if !episode.QuarantinedUntil.IsZero() {
+		t.Errorf("QuarantinedUntil = %v below threshold, want zero", episode.QuarantinedUntil)
+	}
+	want := episode.LastFailureAt.Add(defaultStartupBackoffBase)
+	if !episode.BackoffUntil.Equal(want) {
+		t.Errorf("BackoffUntil = %v, want %v (last failure + %v)", episode.BackoffUntil, want, defaultStartupBackoffBase)
+	}
+}
+
+// TestStartupHealthBackoffBlocksProviderStartUntilExpiry pins that the start
+// gate honours a sub-threshold backoff hold and releases on expiry.
+func TestStartupHealthBackoffBlocksProviderStartUntilExpiry(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260906002)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	is := sessionpkg.NewStore(beads.SessionStore{Store: h.env.store})
+	backoffUntil := h.env.clk.Now().Add(defaultStartupBackoffBase)
+	if err := is.SaveStartupHealthEpisode(sessionpkg.StartupHealthEpisode{
+		SessionName:      h.sessionName,
+		ConsecutiveCount: 2,
+		LastFailureAt:    h.env.clk.Now(),
+		BackoffUntil:     backoffUntil,
+	}); err != nil {
+		t.Fatalf("SaveStartupHealthEpisode: %v", err)
+	}
+
+	startsBefore := h.countRuntimeCalls("Start")
+	for i := 0; i < 5; i++ {
+		h.reconcileTick()
+	}
+	if got := h.countRuntimeCalls("Start"); got != startsBefore {
+		t.Fatalf("Start called %d more time(s) during backoff; want 0", got-startsBefore)
+	}
+
+	h.env.clk.Advance(backoffUntil.Add(time.Second).Sub(h.env.clk.Now()))
+	h.reconcileTick()
+	if got := h.countRuntimeCalls("Start"); got <= startsBefore {
+		t.Fatalf("Start not attempted after backoff expiry (calls before=%d after=%d)", startsBefore, got)
+	}
+}
+
+// TestStartupHealthAlertEmittedOncePerEpisode pins the escalation the bead
+// asks for: reaching the consecutive-failure threshold emits exactly one
+// session.startup_health_alert, and further failures in the same episode do
+// not re-emit it. Before this, session.cold_start_timeout was emitted per
+// attempt and nothing consumed it, so 42 hours of failure raised no signal.
+func TestStartupHealthAlertEmittedOncePerEpisode(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260906003)
+	rec := &capturingRecorder{}
+	h.env.rec = rec
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+	sessionName := h.sessionName
+
+	h.env.sp.StartErrors[sessionName] = errors.New("provider start failure")
+	for i := 0; i < defaultMaxWakeAttempts+1; i++ {
+		if i > 0 {
+			h.createReplacementPendingCreateBead()
+		}
+		if tick := runDesiredPendingCreateTicks(t, h); tick == -1 {
+			t.Fatalf("failure %d: pending-create claim never released within 30 ticks", i+1)
+		}
+	}
+
+	alerts := rec.eventsOfType(events.SessionStartupHealthAlert)
+	if len(alerts) != 1 {
+		t.Fatalf("recorded %d %s events, want exactly 1", len(alerts), events.SessionStartupHealthAlert)
+	}
+	if alerts[0].Subject != sessionName {
+		t.Errorf("alert Subject = %q, want %q", alerts[0].Subject, sessionName)
+	}
+
+	is := sessionpkg.NewStore(beads.SessionStore{Store: h.env.store})
+	episode, err := is.LoadStartupHealthEpisode(sessionName)
+	if err != nil {
+		t.Fatalf("LoadStartupHealthEpisode: %v", err)
+	}
+	if episode.AlertDisposition != sessionpkg.AlertDispositionSent {
+		t.Errorf("AlertDisposition = %q, want %q", episode.AlertDisposition, sessionpkg.AlertDispositionSent)
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -341,6 +341,15 @@ const (
 	// the next episode fires independently. (ADR-0013 A1 M3a)
 	ProviderHealthGateAlert = "provider.health_gate_alert"
 
+	// SessionStartupHealthAlert fires once per startup-health episode, when a
+	// session's consecutive cold-start failures cross the quarantine
+	// threshold. session.cold_start_timeout is emitted per attempt and is a
+	// raw datapoint; this is the escalation, carrying the consecutive count,
+	// the failure kind and how long starts are held back. AlertDisposition on
+	// the episode latches it to one alert per episode; a successful start
+	// clears the episode so the next one alerts independently (sr-xf2xj).
+	SessionStartupHealthAlert = "session.startup_health_alert"
+
 	// Emergency events are dolt-independent escalation records written to
 	// .gc/emergency and mirrored into the city event log.
 	EmergencySignaled = "emergency.signaled"
@@ -439,6 +448,11 @@ var KnownEventTypes = []string{
 	StorageBindingConverged, StorageBindingGenesis,
 	StorageBindingUnconverged, StorageBindingUncheckable,
 	StorageBindingNotConfigured,
+	// SessionStartupHealthAlert is intentionally omitted from KnownEventTypes
+	// for the same reason as ProviderHealthGateAlert below: the reconciler
+	// emits it, but its typed SSE payload registration lives in a follow-up.
+	// Subscribers receive it via the custom-event envelope; `gc events --type`
+	// filters on the raw string and is unaffected.
 	// ProviderHealthGateAlert is intentionally omitted from KnownEventTypes.
 	// The event is emitted by the reconciler but its typed SSE payload is not
 	// yet registered in internal/api (the payload registration lives in a

--- a/internal/session/startup_health.go
+++ b/internal/session/startup_health.go
@@ -22,6 +22,7 @@ const (
 	StartupHealthKindMetadataKey             = "startup_health_kind"
 	StartupHealthAlertMetadataKey            = "startup_health_alert_disposition"
 	StartupHealthQuarantinedUntilMetadataKey = "startup_health_quarantined_until"
+	StartupHealthBackoffUntilMetadataKey     = "startup_health_backoff_until"
 )
 
 // startupHealthLastDetailMaxRunes bounds StartupHealthEpisode.LastDetail.
@@ -62,6 +63,26 @@ type StartupHealthEpisode struct {
 	Kind             FailureKind
 	AlertDisposition AlertDisposition
 	QuarantinedUntil time.Time
+	// BackoffUntil holds the next start back for a growing, capped interval
+	// after each consecutive failure, independent of QuarantinedUntil. The two
+	// are separate because they mean different things to an operator: a
+	// backoff is the normal, self-healing retry cadence for a start path that
+	// may still clear on its own, whereas a quarantine means the
+	// consecutive-failure threshold was crossed and `gc doctor` reports it as
+	// an error. Folding the backoff into QuarantinedUntil would turn every
+	// transient double-flake into a doctor failure. The gate consults
+	// StartHoldUntil, which is the later of the two.
+	BackoffUntil time.Time
+}
+
+// StartHoldUntil is the single instant before which a start attempt for this
+// episode must not be made: the later of the threshold quarantine and the
+// per-failure backoff. Either may be zero; both zero means no hold.
+func (ep StartupHealthEpisode) StartHoldUntil() time.Time {
+	if ep.BackoffUntil.After(ep.QuarantinedUntil) {
+		return ep.BackoffUntil
+	}
+	return ep.QuarantinedUntil
 }
 
 // StartupHealthEpisodeFromMetadata projects a StartupHealthEpisode from a
@@ -88,6 +109,9 @@ func StartupHealthEpisodeFromMetadata(meta map[string]string) StartupHealthEpiso
 	if t, err := time.Parse(time.RFC3339, meta[StartupHealthQuarantinedUntilMetadataKey]); err == nil {
 		ep.QuarantinedUntil = t
 	}
+	if t, err := time.Parse(time.RFC3339, meta[StartupHealthBackoffUntilMetadataKey]); err == nil {
+		ep.BackoffUntil = t
+	}
 	return ep
 }
 
@@ -108,6 +132,7 @@ func startupHealthEpisodeToMetadata(ep StartupHealthEpisode) map[string]string {
 		StartupHealthKindMetadataKey:             string(ep.Kind),
 		StartupHealthAlertMetadataKey:            string(ep.AlertDisposition),
 		StartupHealthQuarantinedUntilMetadataKey: formatStartupHealthTime(ep.QuarantinedUntil),
+		StartupHealthBackoffUntilMetadataKey:     formatStartupHealthTime(ep.BackoffUntil),
 	}
 }
 
@@ -125,7 +150,10 @@ func formatStartupHealthTime(t time.Time) string {
 // QuarantinedUntil is set once ConsecutiveCount reaches threshold; and
 // AlertDisposition escalates to pending on entering quarantine but never
 // regresses away from AlertDispositionSent (an already-sent escalation stays
-// sent through further accrual).
+// sent through further accrual). BackoffUntil is deliberately NOT accrued
+// here: the retry cadence is a caller policy (its base and cap live beside
+// the caller's threshold and quarantine-duration constants), so the caller
+// stamps it on the returned episode before saving.
 func RecordStartupFailure(prior StartupHealthEpisode, kind FailureKind, detail string, now time.Time, threshold int, quarantineDuration time.Duration) StartupHealthEpisode {
 	firstFailureAt := prior.FirstFailureAt
 	if firstFailureAt.IsZero() {

--- a/internal/session/startup_health_backoff_test.go
+++ b/internal/session/startup_health_backoff_test.go
@@ -1,0 +1,87 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestStartHoldUntilReturnsLaterOfQuarantineAndBackoff pins that the single
+// value the start gate consults is the later of the two independent holds: the
+// short self-healing retry backoff and the threshold quarantine. Neither may
+// shorten the other.
+func TestStartHoldUntilReturnsLaterOfQuarantineAndBackoff(t *testing.T) {
+	base := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name       string
+		quarantine time.Time
+		backoff    time.Time
+		want       time.Time
+	}{
+		{"both zero", time.Time{}, time.Time{}, time.Time{}},
+		{"backoff only", time.Time{}, base.Add(30 * time.Second), base.Add(30 * time.Second)},
+		{"quarantine only", base.Add(5 * time.Minute), time.Time{}, base.Add(5 * time.Minute)},
+		{"quarantine later", base.Add(5 * time.Minute), base.Add(4 * time.Minute), base.Add(5 * time.Minute)},
+		{"backoff later", base.Add(5 * time.Minute), base.Add(30 * time.Minute), base.Add(30 * time.Minute)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := StartupHealthEpisode{QuarantinedUntil: tc.quarantine, BackoffUntil: tc.backoff}
+			if got := ep.StartHoldUntil(); !got.Equal(tc.want) {
+				t.Errorf("StartHoldUntil() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStartupHealthEpisodeBackoffUntilRoundTripsThroughMetadata pins that the
+// backoff hold survives a save/load cycle: it is the field that bounds the
+// retry cadence across controller restarts, so a projection that dropped it
+// would silently restore the unbounded 65s retry loop.
+func TestStartupHealthEpisodeBackoffUntilRoundTripsThroughMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	s := NewStore(beads.SessionStore{Store: store})
+	backoffUntil := time.Date(2026, 8, 20, 12, 8, 0, 0, time.UTC)
+	ep := StartupHealthEpisode{
+		SessionName:      "w",
+		ConsecutiveCount: 3,
+		BackoffUntil:     backoffUntil,
+	}
+	if err := s.SaveStartupHealthEpisode(ep); err != nil {
+		t.Fatalf("SaveStartupHealthEpisode: %v", err)
+	}
+	got, err := s.LoadStartupHealthEpisode("w")
+	if err != nil {
+		t.Fatalf("LoadStartupHealthEpisode: %v", err)
+	}
+	if !got.BackoffUntil.Equal(backoffUntil) {
+		t.Errorf("BackoffUntil = %v, want %v", got.BackoffUntil, backoffUntil)
+	}
+}
+
+// TestClearStartupHealthEpisodeClearsBackoffUntil pins that a successful start
+// releases the backoff hold, not just the quarantine — otherwise a recovered
+// session would keep being gated by a stale hold.
+func TestClearStartupHealthEpisodeClearsBackoffUntil(t *testing.T) {
+	store := beads.NewMemStore()
+	s := NewStore(beads.SessionStore{Store: store})
+	seeded := StartupHealthEpisode{
+		SessionName:      "w",
+		ConsecutiveCount: 4,
+		BackoffUntil:     time.Date(2026, 8, 20, 12, 8, 0, 0, time.UTC),
+	}
+	if err := s.SaveStartupHealthEpisode(seeded); err != nil {
+		t.Fatalf("SaveStartupHealthEpisode: %v", err)
+	}
+	if err := s.SaveStartupHealthEpisode(ClearStartupHealthEpisode("w")); err != nil {
+		t.Fatalf("SaveStartupHealthEpisode(cleared): %v", err)
+	}
+	got, err := s.LoadStartupHealthEpisode("w")
+	if err != nil {
+		t.Fatalf("LoadStartupHealthEpisode: %v", err)
+	}
+	if !got.BackoffUntil.IsZero() {
+		t.Errorf("BackoffUntil = %v after clear, want zero", got.BackoffUntil)
+	}
+}


### PR DESCRIPTION
## The problem

A session whose cold start keeps failing is retried on a fixed cadence, forever. In the incident that prompted this, one template produced **2,306 identical `session.cold_start_timeout` failures over 42 hours** — 53–56 an hour, roughly one every 65 seconds — with no backoff, no escalation and no ceiling.

`StartupHealthEpisode` already counts consecutive failures and quarantines at five for a flat five minutes, but a flat quarantine only divides the rate by a constant: across a 42-hour wedge that still permits on the order of 500 start attempts. And the episode's `AlertDisposition` is written but **read by nothing**, so no amount of consecutive failures ever reaches a human or an operator-facing consumer.

## What this changes

**1. A per-failure retry backoff on the episode.**

The first failure is not held back at all, so a single transient spawn flake still retries on the next tick. From the second, the hold doubles from 30s to a 30m cap.

`BackoffUntil` is a new field kept deliberately separate from `QuarantinedUntil` rather than folded into it: `doctor_startup_health.go` promotes any active quarantine to a hard `errorCheck`, so reusing that field would turn every transient double-flake into a `gc doctor` failure. The start gate consults `StartHoldUntil()` — the later of the two — while the session-row mirror stays gated on the quarantine alone, so a sub-threshold backoff never surfaces as a crash-loop quarantine.

**2. The cap is a rate ceiling, not a permanent stop — on purpose.**

Both observed incidents ended with a start that simply succeeded on the unchanged path (attempt 2,307 after 42 hours; attempt 6 after five minutes). A hard "after N failures, stop respawning" would have blocked a recovery that actually happened in both cases. At the cap a wedged template costs two start attempts an hour instead of 55, and the escalation below has already fired — which addresses the real cost (a silent, unbounded retry storm) without introducing a new failure mode (a permanently dead template that would have healed).

**3. `session.startup_health_alert`, emitted once per episode.**

Fires when the consecutive count crosses the quarantine threshold, carrying the count, the failure kind and how long starts are held back. `session.cold_start_timeout` remains the per-attempt datapoint; this is the escalation on top of it. `AlertDisposition` latches it to one alert per episode, and a successful start clears the episode so the next one alerts independently.

The event is recorded **before** the disposition is persisted: if the save fails, the next failure re-alerts rather than losing the escalation entirely. At-least-once is the right failure mode for an alert whose whole purpose is that 42 silent hours never happen again.

It is omitted from `KnownEventTypes` for the same reason as `ProviderHealthGateAlert` — that list drives only the typed SSE projection in `internal/api`, whose payload registration lands separately. Subscribers receive it through the custom-event envelope, and `gc events --type` filters on the raw string and is unaffected. `internal/api`'s event-payload/SSE coverage passes with the omission in place.

**4. `gc doctor` reports the effective hold.**

Past the threshold the quarantine is re-stamped at its fixed duration on every failure while the backoff keeps growing to its cap, so reporting `quarantined_until` alone would tell an operator starts resume in five minutes when the gate is actually refusing for thirty. The detail line now carries both, so the two remain distinguishable.

## Scope note for reviewers

The original analysis behind this change predates two commits already on `main`, and the diff is narrower as a result. `ga-o04bfr.1.1` added the persisted episode that counts failures across replacement pending-create beads, and `ga-vcjr9` made pool session runtime names a pure function of pool identity — which is what makes name-keyed counting work at all. Neither of those is re-litigated here. What was left genuinely missing upstream is only the two things above: **no backoff**, and **an escalation field nothing reads**.

## Testing

- `internal/session` and `internal/events` full suites pass.
- `internal/api` event-payload/SSE coverage passes, confirming the `KnownEventTypes` omission is safe.
- Full `cmd/gc` suite passes.
- Eight new tests: the backoff schedule (including that it never shortens the threshold quarantine), `StartHoldUntil` precedence, metadata round-trip and clearing, sub-threshold accrual on a pending-create failure, the start gate honouring the hold, one-alert-per-episode, and the doctor detail line reporting the effective hold.

`TestStartupHealthAlertEmittedOncePerEpisode` shows the retry interval visibly stretching across ticks 1, 1, 1, 1, 2, 5 — the backoff doing its job end to end rather than only in a unit assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RK9oCVD78MAXFv1GA956ay
