### PR TITLE
perf(cli): reuse the loaded city config on gc ready's store opens (#6132)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -3978,7 +3978,7 @@ func openStandaloneRigStores(cfg *config.City, cityPath string) (map[string]bead
 		if strings.TrimSpace(rig.Path) == "" {
 			continue
 		}
-		store, err := openStoreAtForCity(rig.Path, cityPath)
+		store, err := openStoreAtForCityWithConfig(rig.Path, cityPath, cfg)
 		if err != nil {
 			failures = append(failures, rigStoreOpenFailure{rig: rig.Name, err: err})
 			continue

--- a/cmd/gc/cmd_ready.go
+++ b/cmd/gc/cmd_ready.go
@@ -264,7 +264,7 @@ func cmdReady(opts readyOpts, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc ready: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cityStore, err := openCityStoreAt(cityPath)
+	cityStore, err := openStoreAtForCityWithConfig(cityPath, cityPath, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc ready: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/native_dolt_env_cfg_reuse_test.go
+++ b/cmd/gc/native_dolt_env_cfg_reuse_test.go
@@ -265,3 +265,100 @@ func TestBdCloseGateReusesTheWriteGuardsStoreRead(t *testing.T) {
 		t.Fatalf("found %d %s call(s) in doBd, want exactly 1", calls, callee)
 	}
 }
+
+// cmdReady loads the city config once, then opens the city store. Opening it
+// through openCityStoreAt (which always passes a nil config down) re-ran the
+// whole city config load — builtin-cache readiness and pack expansion
+// included — for a store open cmdReady only needed to resolve which stores
+// federate ready work. On a controller-cadence caller of `gc ready`, that
+// reload was paid once per invocation on top of the load cmdReady had
+// already done.
+func TestReadyCityStoreReusesTheLoadedCityConfig(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "cmd_ready.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing cmd_ready.go: %v", err)
+	}
+
+	fn := findFuncDecl(file, "cmdReady")
+	if fn == nil {
+		t.Fatal("cmdReady not found in cmd_ready.go")
+	}
+
+	var opens int
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch ident.Name {
+		case "openCityStoreAt":
+			t.Fatal("cmdReady opens the city store without a config, which re-loads the city config it was handed")
+		case "openStoreAtForCityWithConfig":
+			opens++
+			if len(call.Args) != 3 {
+				t.Fatalf("openStoreAtForCityWithConfig: got %d args, want 3", len(call.Args))
+			}
+			arg, ok := call.Args[2].(*ast.Ident)
+			if !ok || arg.Name != "cfg" {
+				t.Fatalf("cmdReady passes %s as its config; want the already-loaded \"cfg\"", exprText(call.Args[2]))
+			}
+		}
+		return true
+	})
+	if opens != 1 {
+		t.Fatalf("found %d config-carrying store open(s) in cmdReady, want exactly 1", opens)
+	}
+}
+
+// openStandaloneRigStores opens one store per bound rig, and is shared by
+// both `gc ready` (readyRigLegStores) and the controller's supervisor loop
+// (buildStandaloneRigStores) — both callers already hand it a loaded city
+// config as a parameter. Opening each rig's store through openStoreAtForCity
+// discarded that config and re-loaded it once per rig, on top of the load
+// the caller had already done, on every store the loop opened.
+func TestStandaloneRigStoresReuseTheLoadedCityConfig(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "city_runtime.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing city_runtime.go: %v", err)
+	}
+
+	fn := findFuncDecl(file, "openStandaloneRigStores")
+	if fn == nil {
+		t.Fatal("openStandaloneRigStores not found in city_runtime.go")
+	}
+
+	var opens int
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch ident.Name {
+		case "openStoreAtForCity":
+			t.Fatal("openStandaloneRigStores opens a rig store without a config, which re-loads the city config its caller already handed it")
+		case "openStoreAtForCityWithConfig":
+			opens++
+			if len(call.Args) != 3 {
+				t.Fatalf("openStoreAtForCityWithConfig: got %d args, want 3", len(call.Args))
+			}
+			arg, ok := call.Args[2].(*ast.Ident)
+			if !ok || arg.Name != "cfg" {
+				t.Fatalf("openStandaloneRigStores passes %s as its config; want the already-loaded \"cfg\"", exprText(call.Args[2]))
+			}
+		}
+		return true
+	})
+	if opens != 1 {
+		t.Fatalf("found %d config-carrying store open(s) in openStandaloneRigStores, want exactly 1", opens)
+	}
+}


### PR DESCRIPTION
## What

`cmdReady` and the shared `openStandaloneRigStores` helper (used by both the `gc ready` CLI path and the controller/supervisor's `buildStandaloneRigStores`) opened their stores through non-config-threading helpers, which always pass `nil` for config and force a full city-config reload — builtin-cache readiness, pack expansion, everything — per store, even though the caller already holds the config in scope. On a 16-pool city this sits on a controller-cadence path; the only prior mitigation was a config band-aid (`probe_concurrency = 3`).

Fixes #6132.

## Fix

Two one-line call-site changes, matching an idiom already established elsewhere in the codebase:
- `cmd/gc/cmd_ready.go`: `cmdReady`'s city-store open now calls `openStoreAtForCityWithConfig(cityPath, cityPath, cfg)` instead of `openCityStoreAt(cityPath)`.
- `cmd/gc/city_runtime.go`: `openStandaloneRigStores`'s per-rig open now calls `openStoreAtForCityWithConfig(rig.Path, cityPath, cfg)` instead of `openStoreAtForCity(rig.Path, cityPath)`. Since this helper is shared by both `readyRigLegStores` (the `gc ready` CLI path) and `buildStandaloneRigStores` (the controller path), the fix covers both for free with no signature changes.

Adds two new AST-based conformance tests (`TestReadyCityStoreReusesTheLoadedCityConfig`, `TestStandaloneRigStoresReuseTheLoadedCityConfig`) mirroring the existing four guards in `native_dolt_env_cfg_reuse_test.go`, so a future regression at either call site fails the build rather than silently reintroducing the reload.

## Testing

`go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty on all three touched files. Full 6-test config-reuse conformance suite passes (4 pre-existing + 2 new).

Full local push-gate: all failures match this session's known-unrelated environmental clusters (dolt-fixture family, zcode interrupt tests) plus one shard failure already diagnosed in a sibling PR tonight as a leaked dolt test-server process contaminating an unrelated stderr-comparison test. None touch the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)