### PR TITLE
fix(doctor): surface effective city suspension as a doctor check (#6126)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -201,6 +201,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		}
 		register(doctor.NewConfigValidCheck(cfg))
 		register(doctor.NewLegacySuspendedFieldCheck(cfg))
+		register(doctor.NewCitySuspensionCheck(cfg))
 		// Rollout gates section: one advisory line per registered gate (value +
 		// origin + notices). Never blocks the exit code.
 		for _, c := range rolloutGateChecks(opts.RolloutFlags, opts.RolloutResolveErr) {

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -19,6 +19,7 @@ dolt-topology
 dolt-drift
 config-valid
 legacy-suspended-field
+city-suspension
 rollout:beads.conditional_writes
 rollout:beads.guarded_release
 rollout:daemon.formula_v2

--- a/internal/doctor/checks_city_suspension.go
+++ b/internal/doctor/checks_city_suspension.go
@@ -1,0 +1,104 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/suspensionstate"
+)
+
+// CitySuspensionCheck surfaces the city's *effective* suspension state —
+// the same city/agent-blocking condition `gc status --json` reports via
+// suspensionstate.EffectiveCitySuspended — as a doctor diagnostic.
+//
+// Without this check, an operator can run `gc doctor`, see every
+// controller/database check pass, and never learn that the reason the
+// city is doing no work is that it is suspended: doctor's other checks
+// verify infrastructure health, not whether agent work is intentionally
+// paused. Status already reports suspension; doctor had no equivalent.
+//
+// The check is deliberately informational: suspension is a normal,
+// intentional operator state, not a defect, so it is reported as
+// StatusWarning with SeverityAdvisory (never blocking) and it never
+// offers to auto-resume — CanFix is always false. It distinguishes an
+// explicit runtime override (`gc suspend`) from the configured
+// suspended_on_start default in city.toml so the message points the
+// operator at the right lever, and it reports an unreadable suspension
+// state as unknown rather than silently treating it as "not suspended".
+type CitySuspensionCheck struct {
+	cfg *config.City
+}
+
+// NewCitySuspensionCheck creates a check that reports the city's
+// effective suspension state, resolved with the workspace's configured
+// suspended_on_start default (mirrors NewLegacySuspendedFieldCheck's
+// closure-over-cfg shape).
+func NewCitySuspensionCheck(cfg *config.City) *CitySuspensionCheck {
+	return &CitySuspensionCheck{cfg: cfg}
+}
+
+// Name returns the check identifier.
+func (c *CitySuspensionCheck) Name() string { return "city-suspension" }
+
+// Run loads the runtime suspension state and reports the city's
+// effective suspension using the same resolution the runtime and
+// `gc status` use (suspensionstate.EffectiveCitySuspended merged with
+// cfg.Workspace.EffectiveSuspendedOnStart). A read error (a corrupt or
+// unreadable suspension-state.json — a missing file is not an error,
+// see suspensionstate.Load) is reported as unknown, never inferred to
+// mean the city is running.
+func (c *CitySuspensionCheck) Run(ctx *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		r.Status = StatusOK
+		r.Message = "no city config loaded"
+		return r
+	}
+	if ctx == nil || ctx.CityPath == "" {
+		r.Status = StatusOK
+		r.Message = "no city path available"
+		return r
+	}
+
+	st, err := suspensionstate.Load(fsys.OSFS{}, ctx.CityPath)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("city suspension state is unknown: failed to read suspension-state.json: %v", err)
+		return r
+	}
+
+	_, hasOverride := suspensionstate.ExplicitCity(st)
+	effective := suspensionstate.EffectiveCitySuspended(st, c.cfg.Workspace.EffectiveSuspendedOnStart())
+
+	if !effective {
+		r.Status = StatusOK
+		r.Message = "city is not suspended; agent work proceeds normally"
+		return r
+	}
+
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	if hasOverride {
+		r.Message = "city is suspended via an explicit runtime override (gc suspend); agent work is intentionally paused even though infrastructure is healthy. Run `gc resume` to resume it, or `gc status` to inspect."
+	} else {
+		r.Message = "city is suspended via the configured suspended_on_start default in city.toml; agent work is intentionally paused even though infrastructure is healthy. Run `gc resume` to resume for now, edit suspended_on_start to change the default, or `gc status` to inspect."
+	}
+	return r
+}
+
+// CanFix returns false: whether to resume a suspended city is an
+// operator decision, not a mechanical fix. The issue this check
+// addresses is explicit that suspension must never be auto-resumed.
+func (c *CitySuspensionCheck) CanFix() bool { return false }
+
+// Fix is a no-op; the check is report-only.
+func (c *CitySuspensionCheck) Fix(_ *CheckContext) error { return nil }
+
+// WarmupEligible returns true: like LegacySuspendedFieldCheck, this is
+// most useful right when the user is about to act on a stale-config
+// view — telling an operator at `gc start` time that the city is
+// suspended (and so will do no agent work regardless of how healthy
+// everything else looks) is exactly the top-level condition warm-up is
+// for.
+func (c *CitySuspensionCheck) WarmupEligible() bool { return true }

--- a/internal/doctor/checks_city_suspension_test.go
+++ b/internal/doctor/checks_city_suspension_test.go
@@ -1,0 +1,134 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func writeSuspensionStateFile(t *testing.T, cityPath, body string) {
+	t.Helper()
+	p := citylayout.SuspensionStateFile(cityPath)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCitySuspensionCheck_OK_NotSuspended(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{SuspendedOnStart: false}}
+	r := NewCitySuspensionCheck(cfg).Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK; message: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "not suspended") {
+		t.Errorf("message should confirm the city is not suspended, got: %q", r.Message)
+	}
+}
+
+func TestCitySuspensionCheck_Warns_ConfiguredDefault(t *testing.T) {
+	dir := t.TempDir()
+	// No runtime override written; suspension comes solely from the
+	// configured suspended_on_start default.
+	cfg := &config.City{Workspace: config.Workspace{SuspendedOnStart: true}}
+	r := NewCitySuspensionCheck(cfg).Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning; message: %s", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Errorf("severity = %v, want SeverityAdvisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "suspended_on_start") || !strings.Contains(r.Message, "configured") {
+		t.Errorf("message should distinguish the configured default, got: %q", r.Message)
+	}
+	if strings.Contains(r.Message, "explicit runtime override") {
+		t.Errorf("message should not claim an explicit override when none exists, got: %q", r.Message)
+	}
+}
+
+func TestCitySuspensionCheck_Warns_ExplicitOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeSuspensionStateFile(t, dir, `{"city":{"suspended":true}}`)
+	// Configured default is false; the explicit runtime override alone
+	// drives the effective state to suspended.
+	cfg := &config.City{Workspace: config.Workspace{SuspendedOnStart: false}}
+	r := NewCitySuspensionCheck(cfg).Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning; message: %s", r.Status, r.Message)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Errorf("severity = %v, want SeverityAdvisory", r.Severity)
+	}
+	if !strings.Contains(r.Message, "explicit runtime override") || !strings.Contains(r.Message, "gc suspend") {
+		t.Errorf("message should distinguish the explicit runtime override, got: %q", r.Message)
+	}
+}
+
+func TestCitySuspensionCheck_ExplicitResumeOverridesConfiguredDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeSuspensionStateFile(t, dir, `{"city":{"suspended":false}}`)
+	// Configured default says suspended, but an explicit resume override
+	// wins per suspensionstate.EffectiveCitySuspended.
+	cfg := &config.City{Workspace: config.Workspace{SuspendedOnStart: true}}
+	r := NewCitySuspensionCheck(cfg).Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK (explicit resume should win); message: %s", r.Status, r.Message)
+	}
+}
+
+func TestCitySuspensionCheck_UnreadableState_ReportsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	// Corrupt JSON: suspensionstate.Load returns an error (distinct from
+	// the missing-file case, which returns a zero-value State and no
+	// error).
+	writeSuspensionStateFile(t, dir, `{not valid json`)
+	cfg := &config.City{Workspace: config.Workspace{SuspendedOnStart: false}}
+	r := NewCitySuspensionCheck(cfg).Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %v, want StatusWarning for an unreadable state file", r.Status)
+	}
+	if !strings.Contains(strings.ToLower(r.Message), "unknown") {
+		t.Errorf("message should say the suspension state is unknown, got: %q", r.Message)
+	}
+	if strings.Contains(strings.ToLower(r.Message), "not suspended") {
+		t.Errorf("an unreadable state must never be inferred as not-suspended, got: %q", r.Message)
+	}
+}
+
+func TestCitySuspensionCheck_NoConfig(t *testing.T) {
+	r := NewCitySuspensionCheck(nil).Run(&CheckContext{CityPath: t.TempDir()})
+	if r.Status != StatusOK {
+		t.Errorf("nil config should not trigger a warning, got %v", r.Status)
+	}
+}
+
+func TestCitySuspensionCheck_NilContext(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{SuspendedOnStart: true}}
+	r := NewCitySuspensionCheck(cfg).Run(nil)
+	if r.Status != StatusOK {
+		t.Errorf("nil context should not trigger a warning, got %v", r.Status)
+	}
+}
+
+func TestCitySuspensionCheck_NotFixable(t *testing.T) {
+	c := NewCitySuspensionCheck(&config.City{})
+	if c.CanFix() {
+		t.Error("city suspension must never be auto-fixed (no auto-resume)")
+	}
+	if err := c.Fix(&CheckContext{CityPath: t.TempDir()}); err != nil {
+		t.Errorf("Fix should be a no-op, got error: %v", err)
+	}
+}
+
+func TestCitySuspensionCheck_WarmupEligible(t *testing.T) {
+	if !NewCitySuspensionCheck(nil).WarmupEligible() {
+		t.Error("the check should opt into warmup so suspension surfaces on `gc start`")
+	}
+}


### PR DESCRIPTION
## What

`gc doctor` gave no indication a city was suspended — an operator could run it, see every controller/database check pass, and never learn the reason the city is doing no work is that it's intentionally paused. `gc status --json` already reports this via `suspensionstate.EffectiveCitySuspended`; doctor had no equivalent.

Fixes #6126.

## Fix

New `CitySuspensionCheck` (`internal/doctor/checks_city_suspension.go`), registered in `cmd/gc/cmd_doctor.go` next to `NewLegacySuspendedFieldCheck`:

- Resolves suspension the same way the runtime does (`suspensionstate.EffectiveCitySuspended` merged with `cfg.Workspace.EffectiveSuspendedOnStart`) — no reimplemented logic.
- Distinguishes an explicit `gc suspend` runtime override from the configured `suspended_on_start` default in `city.toml`, with a message naming the right lever for each.
- Reports an unreadable/corrupt `suspension-state.json` as **unknown**, never silently inferred as "not suspended" (a missing file, per `suspensionstate.Load`'s own contract, is not an error and correctly resolves through the normal path).
- `StatusWarning` / `SeverityAdvisory` — informational only, never blocks/gates `gc doctor`'s exit code.
- `CanFix()` always `false` — never offers to auto-resume; suspension is an operator decision.
- Updates the `cmd/gc/testdata/doctor_check_names.golden` fixture to include the new check name.

## Testing

`go build -tags gms_pure_go ./...` clean, `gofmt -l .` empty on all touched files. New `TestCitySuspensionCheck_*` suite (9 tests, covering not-suspended / both suspension sources / unreadable state / no config / nil context / not-fixable / warmup-eligible) all pass, full `internal/doctor` package passes, `TestBuildDoctorChecks_NameSetUnchanged` (golden-fixture registration test) passes.

Full local push-gate: all failures match this session's known-unrelated environmental clusters (dolt-fixture family, zcode interrupt tests, and the leaked dolt test-server process contamination already diagnosed in two sibling PRs tonight). None touch the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)