### PR TITLE
fix(reconciler): keep a live pool seat that holds assigned work out of the timer drains

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3899,6 +3899,36 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				cancelSessionDrainInfo(info, sp, dt)
 				continue
 			}
+			// Keep-alive by held work: a live pool seat that still holds assigned
+			// work — open or in_progress — is not drained by the reconciler's own
+			// timers (no-wake-reason, idle-sleep, config-suppressed). Its step may
+			// carry no wake demand right now: an open step whose dependency is
+			// running on another seat reads not-ready, so the awake set sees no
+			// reason to keep the holder. The holder is mid-molecule all the same.
+			// A drain sent here is acked at once by `gc hook --claim --drain-ack`
+			// and the seat abandons its run; the step strands and the work re-runs
+			// (#5731, #5473). Explicit intents (suspend, idle-stop-pending,
+			// max-age) still drain, exactly as they win over a heartbeat hold. A
+			// probe error fails closed — retain, do not drain — like every other
+			// assigned-work gate. Pool seats only: a named seat's held work is the
+			// retired-session lane's concern.
+			if intent == "" && isPoolManagedSessionInfo(info) {
+				holdsWork, holdsErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, info)
+				if holdsErr != nil {
+					fmt.Fprintf(stderr, "session reconciler: checking assigned work before draining %s: %v (retaining)\n", name, holdsErr) //nolint:errcheck
+					holdsWork = true
+				}
+				if holdsWork {
+					cancelSessionDrainInfo(info, sp, dt)
+					if trace != nil {
+						trace.RecordDecision(TraceSiteReconcilerDrainDecision, TraceReasonAssignedWork, TraceOutcomeNoChange, target.tp.TemplateName, name, traceRecordPayload{
+							"sleep_intent": intent,
+							"kept_by":      "assigned_work",
+						})
+					}
+					continue
+				}
+			}
 			var reason string
 			switch {
 			case intent == "idle-stop-pending":

--- a/cmd/gc/session_reconciler_holder_drain_test.go
+++ b/cmd/gc/session_reconciler_holder_drain_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// newDesiredPoolSeatWithNoWakeReason builds a live, desired pool-managed seat
+// that the awake set has no reason to keep awake: no pool demand, no hold.
+func newDesiredPoolSeatWithNoWakeReason(t *testing.T) (*reconcilerTestEnv, beads.Bead) {
+	t.Helper()
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{"pool_managed": "true"})
+	return env, session
+}
+
+func reconcileDesiredPoolSeat(env *reconcilerTestEnv, session beads.Bead, work []beads.Bead) {
+	reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		newDrainOps(env.sp),
+		work,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+}
+
+// Control: a desired pool seat holding nothing drains for no-wake-reason
+// today and must keep doing so.
+func TestReconcileSessionBeads_PoolSeatWithoutWorkDrainsForNoWakeReason(t *testing.T) {
+	env, session := newDesiredPoolSeatWithNoWakeReason(t)
+	reconcileDesiredPoolSeat(env, session, nil)
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatalf("expected a drain to begin; stdout=%q stderr=%q", env.stdout.String(), env.stderr.String())
+	}
+	if ds.reason != "no-wake-reason" {
+		t.Fatalf("drain reason = %q, want no-wake-reason", ds.reason)
+	}
+}
+
+// A live pool seat that still holds an assigned OPEN step carries no wake
+// demand while that step is dependency-blocked (bd's ready projection says
+// not ready), so the awake set has no reason to keep it — but the seat is
+// mid-molecule. Draining it is acked at once by `gc hook --claim --drain-ack`
+// and the seat abandons its run: the step strands and the work re-runs
+// (gastownhall/gascity#5731, #5473). Held work must keep the seat alive, the
+// way a heartbeat hold does.
+func TestReconcileSessionBeads_PoolSeatHoldingAssignedOpenWorkIsNotDrained(t *testing.T) {
+	env, session := newDesiredPoolSeatWithNoWakeReason(t)
+	blocked := true
+	work, err := env.store.Create(beads.Bead{
+		Title:     "emit-report (waits on run-review)",
+		Type:      "task",
+		Status:    "open",
+		Assignee:  session.ID,
+		IsBlocked: &blocked,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	reconcileDesiredPoolSeat(env, session, []beads.Bead{work})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("drain = %+v, want none: a live holder of assigned open work must not be drained", ds)
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("holder runtime was stopped")
+	}
+	if strings.Contains(env.stdout.String(), "Draining session 'worker'") {
+		t.Fatalf("unexpected drain line: %q", env.stdout.String())
+	}
+}
+
+// The same seat holding an in_progress claim is protected by the same gate:
+// the ack-time cancel already exists for that shape, this keeps the drain from
+// being sent at all.
+func TestReconcileSessionBeads_PoolSeatHoldingInProgressWorkIsNotDrained(t *testing.T) {
+	env, session := newDesiredPoolSeatWithNoWakeReason(t)
+	work, err := env.store.Create(beads.Bead{
+		Title:    "run-review",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	reconcileDesiredPoolSeat(env, session, []beads.Bead{work})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("drain = %+v, want none", ds)
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("holder runtime was stopped")
+	}
+}
+
+// An explicit intent still drains a holder: `gc session suspend` must win
+// over held work, exactly as it wins over a heartbeat hold.
+func TestReconcileSessionBeads_PoolSeatHoldingWorkStillDrainsOnExplicitIntent(t *testing.T) {
+	env, session := newDesiredPoolSeatWithNoWakeReason(t)
+	env.setSessionMetadata(&session, map[string]string{"sleep_intent": "user-hold", "state": "suspended"})
+	work, err := env.store.Create(beads.Bead{
+		Title:    "run-review",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	reconcileDesiredPoolSeat(env, session, []beads.Bead{work})
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatalf("expected the explicit-intent drain to begin; stdout=%q", env.stdout.String())
+	}
+	if ds.reason != "user-hold" {
+		t.Fatalf("drain reason = %q, want user-hold", ds.reason)
+	}
+}


### PR DESCRIPTION
## Summary

A live pool seat that still holds assigned work is no longer drained by the reconciler's own timers (no-wake-reason, idle-sleep, config-suppressed). Explicit intents (`gc session suspend`, idle-stop-pending, max-age) still drain it. One gate in the `!shouldWake && alive` arm of `reconcileSessionBeads`, mirroring the heartbeat-hold keep-alive from #3994.

## Why

An orchestrator seat holding an assigned `open` step whose dependency is running on another seat reads not-ready in bd's ready projection, so `workBeadHasAwakeDemand` gives the holder no wake demand and the reconciler begins a `no-wake-reason` drain. The seat's `gc hook --claim --drain-ack` acks it at once and the run is abandoned mid-molecule: the step strands, the dead-assignee lane releases it minutes later, and the work re-runs. Measured on one review plane on 2026-09-04: eight `session.drain_acked_with_assigned_work` on the same orchestrator in 85 minutes, a paid review re-run per drain. #5731 describes the stranding that follows; #5735 recovers from it. This PR stops the drain from being sent to a holder in the first place.

Gating the drain rather than the wake keeps demand accounting untouched: no extra seat is minted for a blocked step, and an asleep holder is still not woken for it. A probe error fails closed (retain, do not drain), like every other assigned-work gate in the reconciler.

## Testing

- `TestReconcileSessionBeads_PoolSeatWithoutWorkDrainsForNoWakeReason` pins the control: a desired pool seat with nothing assigned still drains for no-wake-reason.
- `TestReconcileSessionBeads_PoolSeatHoldingAssignedOpenWorkIsNotDrained` and `..._PoolSeatHoldingInProgressWorkIsNotDrained` are red without the gate, green with it.
- `TestReconcileSessionBeads_PoolSeatHoldingWorkStillDrainsOnExplicitIntent` pins that a suspend still wins over held work.
- `go test ./cmd/gc -run 'TestReconcile|TestCompute|TestSession|TestPool|TestDrain|TestNamed|TestOnDemand|TestAwake|TestWake' -count=1` passes; `go vet ./cmd/gc` is clean.

## Scope

Pool-managed seats only; a named seat's held work stays the retired-session lane's concern. The zero-grace drain-ack (#5473) and the recovery of already-stranded steps (#5735) are deliberately not touched. No generated artifacts.

Refs #5731, #5473. Complements #5735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5cd5opXyA2u7JM8gKQzb2
