### PR TITLE
fix(beads): compare bd and the linked beads library by commit when both are pseudo-versions

### DIFF
--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -262,14 +262,50 @@ func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) 
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckWarn, "bd/beads version compatibility could not be confirmed", details)
 	}
 	if reason := library.unconfirmableReason(); reason != "" {
-		// The compare below only means something when both sides name the same
-		// released beads artifact. When the linked library does not — a source
-		// build, a replaced module, or a pseudo-version naming an untagged
-		// commit — the two strings can never be equal, and answering "mismatch"
-		// reports a verdict the check never had the evidence to reach. The
-		// schema version is validated above and is the real compatibility
-		// signal, so an unconfirmable library version must not take the native
-		// store offline; only a *confirmed* mismatch (below) should.
+		// A pseudo-version cannot be compared to a bd RELEASE version, but it CAN
+		// be compared to bd's own pseudo-version: both name a commit in the same
+		// repository, and equality of those commits is the strongest evidence of
+		// compatibility this check can obtain — stronger than the semver compare
+		// below, which only ever compares release tags.
+		//
+		// This is not an edge case. gc pins beads at a pseudo-version whenever it
+		// tracks beads ahead of beads' last tag, which is gc's normal state, and
+		// bd built from source reports one too. So the branch that declared the
+		// question unanswerable was covering the configuration in which the two
+		// binaries most often drift — and drift here is not cosmetic: opening the
+		// native store runs MigrateUp, so a gc built from a newer beads commit
+		// migrates every store it touches past what an older bd can read,
+		// irreversibly and on first contact. Observed 2026-09-08: a gc carrying
+		// beads bf97b73749ac (max migration 0059) took a fleet's bd — built from
+		// 98b4b79e6a4d (max migration 0054) — offline for every read, with this
+		// check passing throughout.
+		//
+		// Failing is therefore the safe verdict AND the preventive one: the
+		// factory routes a failed preflight to openBdFallback, so the migration
+		// that would break bd never runs at all.
+		if libRev, ok := library.pseudoRev(); ok {
+			if bdRev, bdOK := pseudoVersionRev(ctx.BDVersion); bdOK {
+				if bdRev == libRev {
+					return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckPass, "bd and the linked beads library are built from beads commit "+libRev, details)
+				}
+				return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd is built from beads commit "+bdRev+"; the linked beads library is "+libRev, details)
+			}
+		}
+		// Otherwise the compare below still means nothing: it only works when both
+		// sides name the same released beads artifact. When the linked library
+		// does not — a source build, a replaced module, or a pseudo-version faced
+		// with a bd that reports a release — the two strings can never be equal,
+		// and answering "mismatch" reports a verdict the check never had the
+		// evidence to reach. So an unconfirmable library version must not take
+		// the native store offline; only a *confirmed* mismatch should.
+		//
+		// Note what is NOT a safety net here: ctx.SchemaVersion. It is the bd
+		// CONTRACT shape (bd context reports 1), not the store's migration
+		// number, so the `SchemaVersion <= 0` guard above says nothing about
+		// migration skew and passing this check is not evidence that bd can read
+		// the store. The version comparison is the only migration-skew signal
+		// this check has, which is why the pseudo-version case above must
+		// answer rather than abstain.
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckPass, "bd/beads schema compatible; linked library version unconfirmed ("+reason+")", details)
 	}
 	if strings.TrimPrefix(ctx.BDVersion, "v") != libraryVersion {
@@ -380,6 +416,35 @@ func (b beadsLibrary) unconfirmableReason() string {
 func comparableReleaseVersion(version string) bool {
 	canonical := "v" + strings.TrimPrefix(strings.TrimSpace(version), "v")
 	return semver.IsValid(canonical) && !module.IsPseudoVersion(canonical)
+}
+
+// pseudoRev returns the beads commit this library was built from, when its
+// version is a pseudo-version naming one. A REPLACED module is excluded even
+// when its version looks like a pseudo-version: the replacement's revision
+// belongs to the replacement, so comparing it to a bd revision would assert
+// agreement between commits in two different repositories.
+func (b beadsLibrary) pseudoRev() (string, bool) {
+	if b.Replaced {
+		return "", false
+	}
+	return pseudoVersionRev(b.Version)
+}
+
+// pseudoVersionRev returns the 12-hex commit revision a pseudo-version names,
+// and reports whether version was a pseudo-version at all. A released version,
+// a "(devel)" source build, and anything that is not valid semver all return
+// false — the caller must treat "not comparable" and "different" as distinct
+// answers, because only the second is evidence of drift.
+func pseudoVersionRev(version string) (string, bool) {
+	canonical := "v" + strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if !semver.IsValid(canonical) || !module.IsPseudoVersion(canonical) {
+		return "", false
+	}
+	rev, err := module.PseudoVersionRev(canonical)
+	if err != nil || rev == "" {
+		return "", false
+	}
+	return rev, true
 }
 
 // linkedBeadsLibraryFrom extracts the linked beads library from build info.

--- a/internal/beads/contract/preflight_checker_test.go
+++ b/internal/beads/contract/preflight_checker_test.go
@@ -790,3 +790,146 @@ func TestComparableReleaseVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckVersionCompatPseudoVersionLockstep covers the case ga-40qh1's
+// widening left uncovered and the 2026-09-08 srvcity outage walked through: gc
+// and bd BOTH built from untagged commits, so both report pseudo-versions.
+//
+// ga-40qh1 was right that a pseudo-version cannot be compared to a bd RELEASE —
+// the two strings name different kinds of thing. It is comparable to another
+// pseudo-version, because both name a commit in the same repository, and that
+// comparison is the only evidence available in gc's normal configuration: gc
+// pins beads at an untagged commit whenever it tracks beads ahead of its last
+// tag.
+//
+// The stakes are why this must FAIL rather than warn. Opening the native store
+// runs MigrateUp, so a gc built from a newer beads commit migrates every store
+// it touches past what an older bd can read — irreversibly, on first contact.
+// A Fail routes the factory to openBdFallback, so the migration never runs.
+func TestCheckVersionCompatPseudoVersionLockstep(t *testing.T) {
+	validCtx := func(bdVersion string) PreflightBDContext {
+		return PreflightBDContext{Backend: "dolt", DoltMode: "server", BDVersion: bdVersion, SchemaVersion: 50}
+	}
+	const (
+		gcPin  = "1.1.1-0.20260805093327-bf97b73749ac" // gc's go.mod pin, 2026-09-08
+		bdOld  = "0.0.0-20260713082743-98b4b79e6a4d"   // the bd that went blind
+		bdSame = "0.0.0-20260805093327-bf97b73749ac"   // same commit, different stamp
+	)
+	tests := []struct {
+		name       string
+		libVersion string
+		replaced   bool
+		ctx        PreflightBDContext
+		want       PreflightCheckState
+		wantRev    string // substring the summary must name, when non-empty
+	}{
+		{
+			name:       "different commits — the live outage — fails",
+			libVersion: gcPin,
+			ctx:        validCtx(bdOld),
+			want:       PreflightCheckFail,
+			wantRev:    "98b4b79e6a4d",
+		},
+		{
+			// The version STAMPS differ (bd stamps its own 0.0.0-date-sha while
+			// gc records the module's v1.1.1-0.date-sha) but the commit is the
+			// same, which is the only thing that matters. A string compare would
+			// call this drift; it is lockstep.
+			name:       "same commit under different version stamps — passes",
+			libVersion: gcPin,
+			ctx:        validCtx(bdSame),
+			want:       PreflightCheckPass,
+			wantRev:    "bf97b73749ac",
+		},
+		{
+			// A replaced module's revision belongs to the replacement, not to
+			// beads. Comparing it to bd's revision would assert agreement between
+			// commits in two different repositories, so this stays unconfirmable
+			// — the ga-40qh1 enterprise-fork case, preserved.
+			name:       "replaced module with a pseudo-version stays unconfirmable",
+			libVersion: "0.0.0-20260810084121-1aa7bf160786",
+			replaced:   true,
+			ctx:        validCtx(bdOld),
+			want:       PreflightCheckPass,
+		},
+		{
+			// Only one side names a commit; equality of the underlying source is
+			// not establishable, so the pre-existing "unknown, pass" holds.
+			name:       "pseudo library vs bd release stays unconfirmable",
+			libVersion: gcPin,
+			ctx:        validCtx("1.1.0"),
+			want:       PreflightCheckPass,
+		},
+		{
+			// The mirror direction is NOT touched by this change and is already
+			// conservative: a released library pin is comparable, so the existing
+			// string compare runs, and a bd pseudo-version cannot be shown to be a
+			// newer release of it (major 0 vs 1) — so it fails to BdStore. Pinned
+			// here so the lockstep compare is never mistaken for having widened it.
+			name:       "release library vs bd pseudo-version keeps failing",
+			libVersion: "1.1.0",
+			ctx:        validCtx(bdOld),
+			want:       PreflightCheckFail,
+		},
+		{
+			// "(devel)" names no commit at all. gc and bd built from one tree both
+			// report it, and so would two unrelated trees; nothing to compare.
+			name:       "source build stays unconfirmable",
+			libVersion: "(devel)",
+			ctx:        validCtx(bdOld),
+			want:       PreflightCheckPass,
+		},
+		{
+			// A v prefix on either side is cosmetic and must not change the answer.
+			name:       "v-prefixed pseudo-versions on the same commit pass",
+			libVersion: "v" + gcPin,
+			ctx:        validCtx("v" + bdSame),
+			want:       PreflightCheckPass,
+			wantRev:    "bf97b73749ac",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := PreflightChecker{BeadsLibraryVersion: tt.libVersion, BeadsLibraryReplaced: tt.replaced}
+			got := c.checkVersionCompat(tt.ctx, nil)
+			if got.ID != PreflightCheckVersionCompat {
+				t.Fatalf("ID = %q, want %q", got.ID, PreflightCheckVersionCompat)
+			}
+			if got.State != tt.want {
+				t.Fatalf("state = %q, want %q (summary: %q)", got.State, tt.want, got.Summary)
+			}
+			if tt.wantRev != "" && !strings.Contains(got.Summary, tt.wantRev) {
+				t.Errorf("summary = %q, want it to name commit %q", got.Summary, tt.wantRev)
+			}
+		})
+	}
+}
+
+// TestPseudoVersionRev pins the parse the lockstep compare rests on. "Not
+// comparable" and "different" must stay distinct answers: only the second is
+// evidence of drift, and conflating them either blinds the check or takes
+// healthy scopes offline.
+func TestPseudoVersionRev(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantRev string
+		wantOK  bool
+	}{
+		{"1.1.1-0.20260805093327-bf97b73749ac", "bf97b73749ac", true},
+		{"v1.1.1-0.20260805093327-bf97b73749ac", "bf97b73749ac", true},
+		{"0.0.0-20260713082743-98b4b79e6a4d", "98b4b79e6a4d", true},
+		{"1.1.0", "", false},   // a release names no commit
+		{"v1.1.0", "", false},  // ditto
+		{"(devel)", "", false}, // a source build names no commit
+		{"", "", false},
+		{"not-a-version", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			rev, ok := pseudoVersionRev(tt.in)
+			if ok != tt.wantOK || rev != tt.wantRev {
+				t.Fatalf("pseudoVersionRev(%q) = (%q, %v), want (%q, %v)", tt.in, rev, ok, tt.wantRev, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`checkVersionCompat` abstains in exactly the configuration that is `gc`'s normal state, and that abstention is what lets a `gc`/`bd` beads skew silently destroy a city's stores.

The linked beads library is pinned as a pseudo-version. `comparableReleaseVersion` refuses it, `unconfirmableReason` fires, and the check returns **Pass** with `"bd/beads schema compatible; linked library version unconfirmed"` — the one verdict that guarantees the native store gets opened.

This is not hypothetical. On 2026-09-08 a host had:

| Binary | Linked beads | Max migration |
|---|---|---|
| `gc` (installed) | `bf97b73749ac` | 0059 |
| `bd` (on `PATH`) | `98b4b79e6a4d` | 0054 |

Opening a store runs `MigrateUp` unconditionally, with no prompt and no down-migration, so three stores went v54 → v59 on first contact. Migration `0055_move_leases_to_table` moves lease state out of the columns a v54 `bd` still selects, so from that moment **every agent `bd` call failed**:

```
schema version mismatch: database is at v59, binary knows up to v54 (5 migrations ahead)
```

The preflight check ran on each of those stores, and passed.

### The fix

Two pseudo-versions **can** be compared. A release version and a pseudo-version name points on different axes — that part of the existing reasoning is right — but two pseudo-versions both name a commit in the same repository, and for this pair "the same commit" is precisely the invariant that matters: `gc` links beads as a library, `bd` *is* beads, and both open the same stores.

So when the library pin is a pseudo-version and `ctx.BDVersion` is one too, compare the revisions (`module.PseudoVersionRev`) and `Fail` on mismatch.

**Failing here is preventive, not merely diagnostic.** `factory.go` routes a failed preflight to `openBdFallback` and never calls `openNativeStore`, so the migration that would break `bd` does not run at all. The check stops being a post-mortem and starts being the thing that prevents the incident.

### Scope

Deliberately narrow — every other configuration behaves exactly as before:

- A **replaced** module is excluded. Its version names a commit in a *different* repository, so the comparison would be meaningless. `pseudoRev()` returns `false` whenever `Replaced` is set, even if the version string looks like a pseudo-version.
- A release library against a pseudo-version `bd` already fails the pre-existing semver compare. Untouched.
- A genuinely unconfirmable pin (bd on a release version, library on a pseudo-version) still passes, with the same message as before.

One note for reviewers, because it looks like a safety net and is not: `ctx.SchemaVersion` is the **bd contract shape** — `bd context` reports `1` — not the store's migration number. The existing `SchemaVersion <= 0` guard says nothing about migration skew, so it could not have caught this.

## Testing

- [x] `make check` — `fmt-check`, `lint`, `vet`, and the topology/residency gates all pass.
  - `make test` reported one failure, `TestPackCommandExitReturnsThroughRun/eager`, which is environmental and unrelated: the assertion is `helper stderr … want empty` and the stderr it got was the dolt leak guard reaping a stale `sql-server` left behind by an earlier aborted run on the same machine. It passes on re-run: `go test -count=1 -run TestPackCommandExitReturnsThroughRun ./cmd/gc/` → `ok`. The change touches only `internal/beads/contract`.
- [ ] `make check-docs` — no docs, navigation or links changed.
- [ ] `make test-integration` — no runtime, controller or workflow behavior changed; the change is a pure verdict change inside one preflight check.

New tests in `preflight_checker_test.go`:

- `TestCheckVersionCompatPseudoVersionLockstep` — 7 cases covering matching commits (Pass), mismatched commits (Fail), a replaced module (stays unconfirmable), a bd release version against a pseudo-version library (stays unconfirmable), and the pre-existing release-vs-pseudo direction (still Fail, unchanged).
- `TestPseudoVersionRev` — 8 cases: canonical and `v`-less pseudo-versions, release versions, `dev`, empty, and malformed input.

## Checklist

- [x] Linked an issue, or explained why one is not needed — no upstream issue; this was found by an operator during a live incident on a self-hosted city and the repro is the version table above. Happy to file one if you'd prefer the paper trail.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — the user-visible surface is one check message, quoted in full in the test.
- [x] Called out breaking changes or migration notes — **behavior change worth naming**: a host running mismatched `gc`/`bd` pseudo-version builds that previously opened the native store will now fall back to `bd`. That is the intended outcome, and the failure message names both commits, but on a host that has *already* migrated its stores past its `bd` the fallback will itself fail — correctly, and visibly, instead of silently migrating more stores.
