### PR TITLE
fix(proctable): never signal tmux infrastructure from KillByPID

### DIFF
--- a/internal/runtime/proctable/kill_target_darwin.go
+++ b/internal/runtime/proctable/kill_target_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package proctable
+
+import "github.com/gastownhall/gascity/internal/pidutil"
+
+// killTargetCmdline is indirected so the classifier's argv handling can be
+// covered without a live tmux process.
+var killTargetCmdline = pidutil.Cmdline
+
+// isInfrastructureKillTarget reports whether pid names tmux infrastructure (a
+// tmux server or client) by argv[0] — the token the Darwin scanner classifies,
+// since ps's first command token is argv[0], possibly a path, and tmux does not
+// retitle itself on Darwin. argv comes from kern.procargs2, so the
+// classification adds no subprocess to the kill path.
+//
+// The predicate fails OPEN: an unreadable argv (the process is gone, or
+// belongs to another user) reads as not infrastructure and the kill proceeds
+// exactly as before the guard. Failing closed would silently disable orphan
+// reaping on any procargs2 hiccup and let a genuine survivor race its
+// replacement, which is the outage the kill exists to prevent.
+func isInfrastructureKillTarget(pid int) bool {
+	argv, err := killTargetCmdline(pid)
+	if err != nil || len(argv) == 0 {
+		return false
+	}
+	return isInfrastructureCommand(argv[0])
+}

--- a/internal/runtime/proctable/kill_target_darwin_test.go
+++ b/internal/runtime/proctable/kill_target_darwin_test.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package proctable
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestIsInfrastructureKillTargetClassifiesArgv(t *testing.T) {
+	prev := killTargetCmdline
+	t.Cleanup(func() { killTargetCmdline = prev })
+
+	cases := []struct {
+		name string
+		argv []string
+		err  error
+		want bool
+	}{
+		{name: "bare tmux", argv: []string{"tmux"}, want: true},
+		{name: "tmux by path with the founding new-session argv", argv: []string{"/opt/homebrew/bin/tmux", "-u", "-L", "gc", "new-session", "-d"}, want: true},
+		{name: "retitled server", argv: []string{"tmux: server"}, want: true},
+		{name: "tmux-named wrapper stays reapable", argv: []string{"tmux-wrapper"}, want: false},
+		{name: "agent", argv: []string{"/usr/local/bin/claude", "--resume"}, want: false},
+		{name: "empty argv fails open", argv: nil, want: false},
+		{name: "unreadable fails open", err: errors.New("procargs2: operation not permitted"), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			killTargetCmdline = func(int) ([]string, error) { return tc.argv, tc.err }
+			if got := isInfrastructureKillTarget(4242); got != tc.want {
+				t.Fatalf("isInfrastructureKillTarget(%v, %v) = %v, want %v", tc.argv, tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsInfrastructureKillTargetHostSmoke reads the live host once: the test
+// binary itself must not classify as tmux infrastructure.
+func TestIsInfrastructureKillTargetHostSmoke(t *testing.T) {
+	if isInfrastructureKillTarget(os.Getpid()) {
+		t.Fatal("the test binary classified as tmux infrastructure")
+	}
+}

--- a/internal/runtime/proctable/kill_target_linux.go
+++ b/internal/runtime/proctable/kill_target_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package proctable
+
+// isInfrastructureKillTarget reports whether pid names tmux infrastructure (a
+// tmux server or client) by its /proc comm — the same reading the Linux
+// scanner uses to keep such processes out of the agent-root set, so the scan
+// and the kill path cannot drift on what counts as infrastructure.
+//
+// It reads through scanRoot and deliberately bypasses liveScanGuard: that
+// guard exists because a live /proc scan under go test can reap real agents
+// (gastownhall/gascity#2839), and a single comm read reaps nothing.
+//
+// The predicate fails OPEN: an unreadable comm (the process is gone, or
+// belongs to another user) reads as not infrastructure and the kill proceeds
+// exactly as before the guard. Failing closed would silently disable orphan
+// reaping on any procfs hiccup and let a genuine survivor race its
+// replacement, which is the outage the kill exists to prevent.
+func isInfrastructureKillTarget(pid int) bool {
+	return isInfrastructureProcess(scanRoot, pid)
+}

--- a/internal/runtime/proctable/kill_target_linux_test.go
+++ b/internal/runtime/proctable/kill_target_linux_test.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package proctable
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestIsInfrastructureKillTargetReadsComm(t *testing.T) {
+	root := t.TempDir()
+	write := func(pid int, comm string) {
+		t.Helper()
+		dir := filepath.Join(root, strconv.Itoa(pid))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(comm+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(100, "tmux: server")
+	write(101, "tmux")
+	write(102, "claude")
+	restore := SetScanRootForTesting(root)
+	defer restore()
+	for pid, want := range map[int]bool{100: true, 101: true, 102: false, 103: false} {
+		if got := isInfrastructureKillTarget(pid); got != want {
+			t.Errorf("isInfrastructureKillTarget(%d) = %v, want %v", pid, got, want)
+		}
+	}
+}

--- a/internal/runtime/proctable/kill_unix.go
+++ b/internal/runtime/proctable/kill_unix.go
@@ -5,11 +5,26 @@ package proctable
 import (
 	"errors"
 	"fmt"
+	"log"
 	"syscall"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// KillByPID's dependencies are indirected so a test can prove the
+// infrastructure refusal below is wired into KillByPID itself, not merely that
+// the classifier works in isolation. That distinction is the lesson of
+// gastownhall/gascity#5837: the first guard for that class was correct, tested,
+// and installed on a different kill family than the one that fired. The vars
+// are test-only injection points, unsynchronized; the package's tests do not
+// run in parallel, and stubKillByPIDDeps restores every one of them.
+var (
+	killByPIDInfrastructureTarget = isInfrastructureKillTarget
+	killByPIDSignal               = syscall.Kill
+	killByPIDAlive                = pidAlive
+	killByPIDStartTime            = pidutil.StartTime
 )
 
 // KillByPID terminates pid with SIGTERM, then SIGKILL after
@@ -18,8 +33,28 @@ import (
 // or a zombie — before returning. Already-gone processes are success. A process
 // that survives its own SIGKILL past the reap grace (e.g. wedged in D-state
 // under I/O) yields an error so callers can refuse to start a name-reused
-// replacement that would race it for the same work.
+// replacement that would race it for the same work. A target classified as
+// tmux infrastructure (a tmux server or client) is never signaled: the call
+// logs the refusal and returns nil, since such a process cannot race an agent
+// replacement and an error would block every gated start behind it.
 func KillByPID(pid int) error {
+	// Never signal tmux infrastructure. One socket is one server is every
+	// session in the city, and signalPIDWith signals the process group first,
+	// which for a tmux server is the server itself. The scanner has excluded
+	// tmux infrastructure from the agent-root set since
+	// gastownhall/gascity#5837, so no live caller hands a server in today;
+	// this is best-effort defense in depth for the kill family, which two
+	// providers reach with whatever PID they hold. It classifies the target
+	// at this instant, which narrows, not closes, the window for a PID
+	// recycled before the signal (gastownhall/gascity#6172). Refusing is
+	// success, not an error: a tmux server cannot race a replacement for an
+	// agent's work, so there is no orphan to refuse a Start over, and an error
+	// here would propagate through every gated start. The refusal logs
+	// because it should fire approximately never.
+	if pid > 1 && killByPIDInfrastructureTarget(pid) {
+		log.Printf("proctable: refusing to kill PID %d: tmux infrastructure, not an agent runtime; signaling its process group would take every session on its socket down (gastownhall/gascity#5837)", pid)
+		return nil
+	}
 	// Capture the target's start-time identity BEFORE signaling. During the
 	// post-SIGKILL reap wait the PID can be reaped and recycled to an unrelated
 	// process; without this, a recycled PID reads as "still alive" and we would
@@ -28,11 +63,11 @@ func KillByPID(pid int) error {
 	// exists and falls back to ps elsewhere, so it is empty only when neither
 	// mechanism can answer, in which case runLive falls back to plain liveness
 	// — current behavior preserved.
-	startTime, _ := pidutil.StartTime(pid)
+	startTime, _ := killByPIDStartTime(pid)
 	return killByPID(
 		pid,
-		syscall.Kill,
-		pidAlive,
+		killByPIDSignal,
+		killByPIDAlive,
 		func(p int) bool { return pidutil.AliveWithStartTime(p, startTime) },
 		runtime.ManagedProcessStopGrace,
 		runtime.ManagedProcessReapGrace,

--- a/internal/runtime/proctable/kill_unix_test.go
+++ b/internal/runtime/proctable/kill_unix_test.go
@@ -149,3 +149,63 @@ func TestWaitUntilRespectsZeroTimeout(t *testing.T) {
 		t.Fatal("waitUntil should report false when the condition never holds at zero timeout")
 	}
 }
+
+// stubKillByPIDDeps swaps KillByPID's injected dependencies for one test and
+// restores them on cleanup, so the infrastructure refusal is exercised through
+// KillByPID itself with no process spawned and nothing read from the host. A
+// guard that is correct but unreferenced is exactly the failure mode the first
+// fix for gastownhall/gascity#5837 had: installed on a different kill family
+// than the one that fired.
+func stubKillByPIDDeps(t *testing.T, infra func(int) bool, alive func(int) bool, kill func(int, syscall.Signal) error) {
+	t.Helper()
+	prevInfra, prevAlive, prevKill, prevStart := killByPIDInfrastructureTarget, killByPIDAlive, killByPIDSignal, killByPIDStartTime
+	killByPIDInfrastructureTarget, killByPIDAlive, killByPIDSignal = infra, alive, kill
+	killByPIDStartTime = func(int) (string, error) { return "", nil }
+	t.Cleanup(func() {
+		killByPIDInfrastructureTarget, killByPIDAlive, killByPIDSignal, killByPIDStartTime = prevInfra, prevAlive, prevKill, prevStart
+	})
+}
+
+// TestKillByPIDRefusesTmuxInfrastructureTarget fails immediately without the
+// guard: the liveness stub says alive, so KillByPID would signal the group,
+// and the signal stub fails the test on the first delivery.
+func TestKillByPIDRefusesTmuxInfrastructureTarget(t *testing.T) {
+	stubKillByPIDDeps(t,
+		func(pid int) bool { return pid == 4242 },
+		func(int) bool { return true },
+		func(pid int, sig syscall.Signal) error {
+			t.Fatalf("KillByPID signaled %d with %v: the tmux-infrastructure guard is not wired in", pid, sig)
+			return nil
+		},
+	)
+	if err := KillByPID(4242); err != nil {
+		t.Fatalf("KillByPID(tmux infrastructure) = %v, want nil: refusing is success", err)
+	}
+}
+
+// TestKillByPIDStillSignalsNonInfrastructureTarget pins that the guard does
+// not over-refuse: an agent PID still gets the group SIGTERM. The liveness
+// stub reports alive at entry and gone on the next poll, so neither grace
+// window is waited on; the SIGKILL escalation stays covered by the killByPID
+// core tests above.
+func TestKillByPIDStillSignalsNonInfrastructureTarget(t *testing.T) {
+	var signals []int
+	polls := 0
+	stubKillByPIDDeps(t,
+		func(int) bool { return false },
+		func(int) bool { polls++; return polls <= 1 },
+		func(pid int, sig syscall.Signal) error {
+			if sig != syscall.SIGTERM {
+				t.Fatalf("signal = %v, want SIGTERM", sig)
+			}
+			signals = append(signals, pid)
+			return nil
+		},
+	)
+	if err := KillByPID(4242); err != nil {
+		t.Fatalf("KillByPID(agent) = %v, want nil", err)
+	}
+	if !slices.Equal(signals, []int{-4242}) {
+		t.Fatalf("signals = %v, want the process group signaled once", signals)
+	}
+}


### PR DESCRIPTION
## Summary

`KillByPID` refuses to signal tmux infrastructure. It classifies its target with the scanner's own predicate from #5392 — `/proc/<pid>/comm` on Linux (the existing `isInfrastructureProcess`), `argv[0]` via `pidutil.Cmdline` on Darwin (`kern.procargs2`, no subprocess) — and returns success with a one-line stderr note instead of sending `SIGTERM` to the process group. Everything else about the kill is unchanged.

## Why

A tmux server is its own process-group leader, and `signalPIDWith` signals the group first, so `KillByPID` on a server's PID is the whole city: one socket, one server, every session. That is how one city was lost twice (2026-08-03 and 2026-08-13; the chain is on #6172). #5837 closed the feeder — the scanner no longer reports a server as an agent root — and both callers of this kill family are fed by that scan, so no live caller hands a server in on today's main. This is best-effort defence in depth for the last line: the classifier is exact-match by design (a `tmux-*` wrapper that is really an agent must stay reapable), so a command name it does not know reaches the same syscall with no check, and a PID recycled after the scan is caught only if it is recycled before this check — the guard narrows that window rather than closing it, and the SIGTERM-to-SIGKILL grace stays uncovered, as before. On our lineage the first guard for this class was correct, tested, and installed on the other kill family; the city was lost again through this one.

Refusing is success rather than an error: a tmux server cannot race a replacement for an agent's work, so there is no orphan to refuse a Start over, and an error here would propagate through `killExistingOrphans` to every gated start. The predicate fails open — an unreadable comm or argv reads as not infrastructure — because failing closed would silently disable orphan reaping on any procfs or `procargs2` hiccup and let a genuine survivor race its replacement. The note goes through `log.Printf`, as `workspacesvc`'s own refusal to signal an unsafe orphan-reap target does.

## Testing

- `TestKillByPIDRefusesTmuxInfrastructureTarget` and `TestKillByPIDStillSignalsNonInfrastructureTarget` drive `KillByPID` itself with the detector, the kill syscall, liveness, and the start-time reader injected — hermetic, nothing read from the host, no process spawned — so the refusal is proven wired in, not merely implemented. The first fails immediately without the guard (the liveness stub says alive, and the signal stub fails the test on the first delivery). The SIGKILL escalation stays covered by the existing `killByPID` core tests.
- `TestIsInfrastructureKillTargetReadsComm` (Linux, fake procfs via `SetScanRootForTesting`) and `TestIsInfrastructureKillTargetClassifiesArgv` (Darwin, injected argv reader: bare `tmux`, a path, the retitled server, a `tmux-*` wrapper that must stay reapable, empty and unreadable argv) cover the per-platform readers; one explicitly labelled Darwin smoke test reads the live host.
- `go test ./internal/runtime/proctable/ ./internal/runtime/tmux/ ./internal/runtime/subprocess/ ./internal/pidutil/`, `go vet` on darwin and `GOOS=linux`, and `make lint-changed` are clean. No new subprocess sites in source or tests.

## Scope

Only `KillByPID`. Sibling kill paths, checked and left alone with the reason: the tmux package's `terminateProcesses` / `KillPaneProcesses` / `KillPaneProcessesExcluding` family enumerates a pane's descendants and same-group reparented members, and the server is the pane's ancestor in its own group, unreachable by that enumeration (measured process groups on the 08-03 incident); `computeExcludingKillSet` is set math over those PIDs; `workspacesvc`'s orphan reap signals groups behind its own `unsafeSignalTarget` refusal over a service-identity-scoped scan a tmux server cannot enter; `processgroup.Terminate` only receives a group its caller spawned; the dolt and supervisor kill sites hold dolt and supervisor PIDs. `tmux.KillServer` is intentionally unguarded — killing the server is its job. One distinct mechanism is out of scope by nature: at city start, with no server running, the first session's own `tmux -L <socket> new-session` becomes the server (fork and setsid, PPID 1, same argv), so ending that one session ends the server through lineage rather than through any kill path; no kill-path guard covers session-equals-server. That server keeps a tmux `argv[0]`, so the classifier here does refuse it if it ever reaches `KillByPID`. The scan-side classification from #5392 is reused, not changed. No generated artifacts.

Fixes #6172. Refs #5837; precedent #5392. Reviewed before opening with the contributing pack's review rubric and an independent Codex read; both sets of findings are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBcMPssKbTUyfM7UtUYaoF
