### PR TITLE
fix(hostboot): drop the redundant int64 conversion the Mac unconvert lint rejects

### DIFF
--- a/internal/hostboot/hostboot_darwin.go
+++ b/internal/hostboot/hostboot_darwin.go
@@ -18,5 +18,5 @@ func bootTime() (time.Time, error) {
 	if tv.Sec <= 0 {
 		return time.Time{}, fmt.Errorf("hostboot: implausible kern.boottime seconds %d", tv.Sec)
 	}
-	return time.Unix(int64(tv.Sec), int64(tv.Usec)*1000), nil
+	return time.Unix(tv.Sec, int64(tv.Usec)*1000), nil
 }


### PR DESCRIPTION
## The break

`Mac / quality (lint, fmt, vet, docs)` fails its `make lint` step on every PR
whose tested tree includes #5456:

```
internal/hostboot/hostboot_darwin.go:21:24: unnecessary conversion (unconvert)
	return time.Unix(int64(tv.Sec), int64(tv.Usec)*1000), nil
	                      ^
```

Evidence: job
[102325732447](https://github.com/gastownhall/gascity/actions/runs/34306984980/job/102325732447)
(run 34306984980, PR #5634 `residency/pr8-bd-byid-door`, completed
2026-09-09T03:31:15Z, conclusion `failure`).

`internal/hostboot/hostboot_darwin.go` was added by #5456
(`3a09f0d1d5`, merged 2026-09-08T22:02:40Z). On darwin
`golang.org/x/sys/unix.Timeval.Sec` is already `int64` — identically in
`ztypes_darwin_arm64.go` and `ztypes_darwin_amd64.go` — so `int64(tv.Sec)`
is a no-op conversion. `Usec` is `int32` on darwin, so `int64(tv.Usec)`
genuinely widens and is kept.

PR #5634's own head (`3fc0f3d436`) does not even contain
`internal/hostboot/`; it inherits the violation from the merge-with-`main`
tree CI actually checks out. That is the general shape — the fault is in
`main`, not in any one PR.

## Why only the Mac lane catches it

`make lint` is `golangci-lint run ./...`, and Go's build constraints mean a
`//go:build darwin` file is never type-checked by a Linux toolchain. The
Linux lint lane therefore does not compile `hostboot_darwin.go` at all and
has nothing to report; the macOS lane compiles it natively and `unconvert`
fires. Confirmed locally with a control on the **unfixed** line:

| Command (unfixed line restored) | Result |
| --- | --- |
| `golangci-lint run ./internal/hostboot/...` (host, linux) | `0 issues.` — exit 0, blind to it |
| `GOOS=darwin golangci-lint run ./internal/hostboot/...` | `hostboot_darwin.go:21:24: unnecessary conversion (unconvert)` — exit 1 |

So yes, `golangci-lint` honours `GOOS`, and it reproduces the CI message
byte-for-byte. That control is what proves the green Linux lane is a
false negative rather than a passing check.

## Cross-compile vet evidence (fixed tree)

Every build-tag arm of the package still compiles — the darwin arm, the
linux arm, and the `!darwin && !linux` unsupported arm:

| Target | `go vet ./internal/hostboot/` |
| --- | --- |
| `GOOS=darwin GOARCH=arm64` | exit 0 |
| `GOOS=darwin GOARCH=amd64` | exit 0 |
| `GOOS=linux GOARCH=amd64` | exit 0 |
| `GOOS=windows GOARCH=amd64` (unsupported arm) | exit 0 |

`GOOS=darwin golangci-lint run ./internal/hostboot/...` on the fixed tree:
`0 issues.`, exit 0.

I checked the rest of `3a09f0d1d5` for other `unconvert`-shaped lines. The
only other conversions it adds are `string(session.SleepReasonCityStop)`
(a named string type — required) and `[]byte(contents)` (required), both of
which the Linux lane already lints clean. This one line is the whole fix.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `gofmt -l internal` | exit 0, no output |
| `golangci-lint run ./internal/hostboot/...` | `0 issues.`, exit 0 |
| `GOOS=darwin golangci-lint run ./internal/hostboot/...` | `0 issues.`, exit 0 |
| `go test ./internal/hostboot/... -count=1` | `ok` 0.015s, exit 0 |
| `make test-fast-parallel` | `All fast jobs passed`, exit 0 |
| `.githooks/pre-commit` | ran at commit, clean (`lint-changed: ./internal/hostboot` → `0 issues.`) |
| `.githooks/pre-push` | ran at push (no `--no-verify`), push-gate cap respected |

No base-owned failures reproduced; every gate above is green on this branch.

## Overlap to be aware of

PR #6042 (`terra/ga-p9iuv-30-1-1-5`, a Dolt ownership-handoff feature PR)
carries the byte-identical one-liner as commit `b2074869ef`, which is why
that branch's Mac quality job is green while `main` stays red. That PR is a
feature change gated on its own review, so `main` would stay red until it
lands. Whichever of the two merges second will either apply cleanly or drop
to a no-op conflict on a single line — no coordination needed beyond this
note.

Refs ga-ily1a (the main-red bead), ga-j4p3y (residency storeref stack,
whose #5634 and #6147 Mac lanes this unblocks).
