### PR TITLE
perf(nudge): reuse the loaded config and the target store across the per-prompt drain (#6157)

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -582,7 +582,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		return 1
 	}
 	if inject {
-		if err := ackQueuedNudgesWithOutcome(target.cityPath, queuedNudgeIDs(items), "accepted_for_injection", "", "hook-transport-accepted"); err != nil {
+		if err := ackQueuedNudgesWithOutcomeAndConfig(target.cityPath, target.cfg, queuedNudgeIDs(items), "accepted_for_injection", "", "hook-transport-accepted"); err != nil {
 			fmt.Fprintf(stderr, "gc nudge drain: recording injection ack: %v\n", err) //nolint:errcheck
 			return 0
 		}
@@ -2270,10 +2270,17 @@ func ackQueuedNudges(cityPath string, ids []string) error {
 }
 
 func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, commitBoundary string) error {
+	return ackQueuedNudgesWithOutcomeAndConfig(cityPath, nil, ids, outcome, reason, commitBoundary)
+}
+
+// ackQueuedNudgesWithOutcomeAndConfig is ackQueuedNudgesWithOutcome with the city
+// config supplied by a caller that already loaded it, so the ack's maintenance
+// store open does not reload city.toml and every pack.
+func ackQueuedNudgesWithOutcomeAndConfig(cityPath string, cfg *config.City, ids []string, outcome, reason, commitBoundary string) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	maint := nudgeMaintenanceStore{cityPath: cityPath, cfg: cfg}
 	defer maint.close() //nolint:errcheck // best-effort
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -115,6 +115,10 @@ type nudgeTarget struct {
 	cityPath          string
 	cityName          string
 	cfg               *config.City
+	// store is the nudge store resolveNudgeTarget opened to resolve the
+	// session; the drain reuses it for its maintenance, delivery and ack
+	// opens (each open runs the bd-context preflight) and closes it.
+	store             beads.NudgesStore
 	alias             string
 	aliasHistory      []string
 	identity          string
@@ -496,8 +500,9 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		fmt.Fprintf(stderr, "gc nudge drain: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	defer closeBeadStoreHandle(target.store.Store) //nolint:errcheck // best-effort
 	if inject {
-		wispExtra = wispStepInjectionContentWithConfig(target.cityPath, target.cfg)
+		wispExtra = wispStepInjectionContentWithStore(target.cityPath, target.cfg, target.store.Store)
 	}
 
 	now := time.Now()
@@ -515,7 +520,11 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		}
 		return 1
 	}
-	deliveryStore := openNudgeBeadStoreWithConfig(target.cityPath, target.cfg)
+	deliveryStore := target.store
+	if deliveryStore.Store == nil {
+		deliveryStore = openNudgeBeadStoreWithConfig(target.cityPath, target.cfg)
+		defer closeBeadStoreHandle(deliveryStore.Store) //nolint:errcheck // best-effort
+	}
 	// Two-store split: the nudge-queue delivery store stays on the nudges class
 	// (openNudgeBeadStore), while the session-class ops — wait-bead reads in
 	// splitQueuedNudgesForDelivery and the last-nudge-delivered stamp — route
@@ -582,7 +591,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		return 1
 	}
 	if inject {
-		if err := ackQueuedNudgesWithOutcomeAndConfig(target.cityPath, target.cfg, queuedNudgeIDs(items), "accepted_for_injection", "", "hook-transport-accepted"); err != nil {
+		if err := ackQueuedNudgesWithOutcomeUsingStore(target.cityPath, target.cfg, target.store, queuedNudgeIDs(items), "accepted_for_injection", "", "hook-transport-accepted"); err != nil {
 			fmt.Fprintf(stderr, "gc nudge drain: recording injection ack: %v\n", err) //nolint:errcheck
 			return 0
 		}
@@ -1329,7 +1338,9 @@ func resolveNudgeTarget(identifier string, warningWriter ...io.Writer) (nudgeTar
 			if getErr != nil {
 				return nudgeTarget{}, getErr
 			}
-			return resolveNudgeTargetFromSessionInfo(cityPath, cfg, info), nil
+			target := resolveNudgeTargetFromSessionInfo(cityPath, cfg, info)
+			target.store = store
+			return target, nil
 		}
 		if !errors.Is(err, session.ErrSessionNotFound) {
 			return nudgeTarget{}, err
@@ -1929,7 +1940,11 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 type nudgeMaintenanceStore struct {
 	cityPath string
 	cfg      *config.City // optional; reused by ensureOpen so the open skips a config load
+	// shared is an optional caller-owned handle (the drain's target store);
+	// when set, ensureOpen borrows it instead of opening, and close leaves it.
+	shared   beads.NudgesStore
 	opened   bool
+	borrowed bool
 	store    beads.NudgesStore
 	front    *nudgequeue.Store
 }
@@ -1953,7 +1968,12 @@ func (m *nudgeMaintenanceStore) frontForState(state *nudgeQueueState) *nudgequeu
 func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 	if !m.opened {
 		m.opened = true
-		m.store = openNudgeBeadStoreWithConfig(m.cityPath, m.cfg)
+		if m.shared.Store != nil {
+			m.borrowed = true
+			m.store = m.shared
+		} else {
+			m.store = openNudgeBeadStoreWithConfig(m.cityPath, m.cfg)
+		}
 		if m.store.Store != nil {
 			m.front = nudgeFrontDoor(m.store)
 		}
@@ -1964,7 +1984,7 @@ func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 // close releases the store this frame opened (if any). It never touches a
 // caller-passed store because this type only ever holds a store it opened.
 func (m *nudgeMaintenanceStore) close() error {
-	if !m.opened {
+	if !m.opened || m.borrowed {
 		return nil
 	}
 	return closeBeadStoreHandle(m.store.Store)
@@ -1978,20 +1998,21 @@ func nudgeQueueHasWork(state *nudgeQueueState) bool {
 }
 
 func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
-	return claimDueQueuedNudgesMatchingWithConfig(cityPath, target.cfg, now, func(item queuedNudge) bool {
+	return claimDueQueuedNudgesMatchingUsingStore(cityPath, target.cfg, target.store, now, func(item queuedNudge) bool {
 		return queuedNudgeClaimableForTarget(target, item)
 	})
 }
 
 func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
-	return claimDueQueuedNudgesMatchingWithConfig(cityPath, nil, now, match)
+	return claimDueQueuedNudgesMatchingUsingStore(cityPath, nil, beads.NudgesStore{}, now, match)
 }
 
-// claimDueQueuedNudgesMatchingWithConfig is claimDueQueuedNudgesMatching with the
-// city config supplied by a caller that already loaded it (the drain path), so
-// the maintenance store's open does not reload city.toml and every pack.
-func claimDueQueuedNudgesMatchingWithConfig(cityPath string, cfg *config.City, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
-	maint := nudgeMaintenanceStore{cityPath: cityPath, cfg: cfg}
+// claimDueQueuedNudgesMatchingUsingStore is claimDueQueuedNudgesMatching for a
+// caller that already loaded the city config and/or holds an open nudge store
+// (the drain path): a supplied store is borrowed, not reopened, so the
+// maintenance pass pays neither a config load nor a bd-context preflight.
+func claimDueQueuedNudgesMatchingUsingStore(cityPath string, cfg *config.City, shared beads.NudgesStore, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
+	maint := nudgeMaintenanceStore{cityPath: cityPath, cfg: cfg, shared: shared}
 	defer maint.close() //nolint:errcheck // best-effort
 	var claimed []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
@@ -2270,17 +2291,17 @@ func ackQueuedNudges(cityPath string, ids []string) error {
 }
 
 func ackQueuedNudgesWithOutcome(cityPath string, ids []string, outcome, reason, commitBoundary string) error {
-	return ackQueuedNudgesWithOutcomeAndConfig(cityPath, nil, ids, outcome, reason, commitBoundary)
+	return ackQueuedNudgesWithOutcomeUsingStore(cityPath, nil, beads.NudgesStore{}, ids, outcome, reason, commitBoundary)
 }
 
-// ackQueuedNudgesWithOutcomeAndConfig is ackQueuedNudgesWithOutcome with the city
-// config supplied by a caller that already loaded it, so the ack's maintenance
-// store open does not reload city.toml and every pack.
-func ackQueuedNudgesWithOutcomeAndConfig(cityPath string, cfg *config.City, ids []string, outcome, reason, commitBoundary string) error {
+// ackQueuedNudgesWithOutcomeUsingStore is ackQueuedNudgesWithOutcome for a caller
+// that already loaded the city config and/or holds an open nudge store (the
+// drain path); a supplied store is borrowed, not reopened.
+func ackQueuedNudgesWithOutcomeUsingStore(cityPath string, cfg *config.City, shared beads.NudgesStore, ids []string, outcome, reason, commitBoundary string) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	maint := nudgeMaintenanceStore{cityPath: cityPath, cfg: cfg}
+	maint := nudgeMaintenanceStore{cityPath: cityPath, cfg: cfg, shared: shared}
 	defer maint.close() //nolint:errcheck // best-effort
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -497,7 +497,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		return 1
 	}
 	if inject {
-		wispExtra = wispStepInjectionContent(target.cityPath)
+		wispExtra = wispStepInjectionContentWithConfig(target.cityPath, target.cfg)
 	}
 
 	now := time.Now()
@@ -515,7 +515,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		}
 		return 1
 	}
-	deliveryStore := openNudgeBeadStore(target.cityPath)
+	deliveryStore := openNudgeBeadStoreWithConfig(target.cityPath, target.cfg)
 	// Two-store split: the nudge-queue delivery store stays on the nudges class
 	// (openNudgeBeadStore), while the session-class ops — wait-bead reads in
 	// splitQueuedNudgesForDelivery and the last-nudge-delivered stamp — route
@@ -717,7 +717,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		fmt.Fprintf(stderr, "gc nudge poll: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	store, err := openNudgeBeadStoreErr(target.cityPath)
+	store, err := openNudgeBeadStoreErrWithConfig(target.cityPath, target.cfg)
 	if err != nil || store.Store == nil {
 		fmt.Fprintf(stderr, "gc nudge poll: opening the nudge store for %q: %v\n", target.agentKey(), err) //nolint:errcheck
 		return 1
@@ -842,7 +842,7 @@ func shouldKeepNudgePollerAlive(target nudgeTarget, missingSince, now time.Time)
 }
 
 func deliverSessionNudge(target nudgeTarget, message string, mode nudgeDeliveryMode, jsonOutput bool, stdout, stderr io.Writer) int {
-	store, err := openNudgeBeadStoreErr(target.cityPath)
+	store, err := openNudgeBeadStoreErrWithConfig(target.cityPath, target.cfg)
 	if err != nil || store.Store == nil {
 		fmt.Fprintf(stderr, "gc session nudge: opening the nudge store for %q: %v\n", target.agentKey(), err) //nolint:errcheck
 		return 1
@@ -1237,7 +1237,7 @@ func queuedNudgeDowngradeNote(target nudgeTarget, undelivered worker.NudgeUndeli
 }
 
 func sendMailNotify(target nudgeTarget, sender string) error {
-	store, err := openNudgeBeadStoreErr(target.cityPath)
+	store, err := openNudgeBeadStoreErrWithConfig(target.cityPath, target.cfg)
 	if err != nil {
 		return err
 	}
@@ -1317,7 +1317,7 @@ func resolveNudgeTarget(identifier string, warningWriter ...io.Writer) (nudgeTar
 	if err != nil {
 		return nudgeTarget{}, err
 	}
-	store := openNudgeBeadStore(cityPath)
+	store := openNudgeBeadStoreWithConfig(cityPath, cfg)
 	if store.Store != nil {
 		// Named-session materialization is a session WRITE, and the follow-up Get
 		// reads the session bead; both route through the session-class store
@@ -1475,7 +1475,7 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store, sessStore beads.S
 	}
 	deliveryStore := store
 	if deliveryStore == nil {
-		deliveryStore = openNudgeBeadStore(target.cityPath).Store
+		deliveryStore = openNudgeBeadStoreWithConfig(target.cityPath, target.cfg).Store
 	}
 	// sessStore is the SESSION-class store the caller resolved from the WORK store
 	// (the dispatcher threads cr.sessionsBeadStore().Store; the CLI poll derives it
@@ -1928,6 +1928,7 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 // …WithStore variants model.
 type nudgeMaintenanceStore struct {
 	cityPath string
+	cfg      *config.City // optional; reused by ensureOpen so the open skips a config load
 	opened   bool
 	store    beads.NudgesStore
 	front    *nudgequeue.Store
@@ -1952,7 +1953,7 @@ func (m *nudgeMaintenanceStore) frontForState(state *nudgeQueueState) *nudgequeu
 func (m *nudgeMaintenanceStore) ensureOpen() beads.NudgesStore {
 	if !m.opened {
 		m.opened = true
-		m.store = openNudgeBeadStore(m.cityPath)
+		m.store = openNudgeBeadStoreWithConfig(m.cityPath, m.cfg)
 		if m.store.Store != nil {
 			m.front = nudgeFrontDoor(m.store)
 		}
@@ -1977,13 +1978,20 @@ func nudgeQueueHasWork(state *nudgeQueueState) bool {
 }
 
 func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
-	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
+	return claimDueQueuedNudgesMatchingWithConfig(cityPath, target.cfg, now, func(item queuedNudge) bool {
 		return queuedNudgeClaimableForTarget(target, item)
 	})
 }
 
 func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
-	maint := nudgeMaintenanceStore{cityPath: cityPath}
+	return claimDueQueuedNudgesMatchingWithConfig(cityPath, nil, now, match)
+}
+
+// claimDueQueuedNudgesMatchingWithConfig is claimDueQueuedNudgesMatching with the
+// city config supplied by a caller that already loaded it (the drain path), so
+// the maintenance store's open does not reload city.toml and every pack.
+func claimDueQueuedNudgesMatchingWithConfig(cityPath string, cfg *config.City, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
+	maint := nudgeMaintenanceStore{cityPath: cityPath, cfg: cfg}
 	defer maint.close() //nolint:errcheck // best-effort
 	var claimed []queuedNudge
 	err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {

--- a/cmd/gc/cmd_nudge_config_reuse_test.go
+++ b/cmd/gc/cmd_nudge_config_reuse_test.go
@@ -104,7 +104,7 @@ func TestDrainHelpersBorrowTheTargetStore(t *testing.T) {
 	shared := openNudgeBeadStore(dir) // one open, via the counting seam
 	target := nudgeTarget{cityPath: dir, store: shared, alias: "worker", identity: "worker"}
 
-	before := *opens
+	before, closesBefore := *opens, *closes // enqueue above opened and closed its own store
 	claimed, err := claimDueQueuedNudgesForTarget(dir, target, now)
 	if err != nil {
 		t.Fatalf("claimDueQueuedNudgesForTarget: %v", err)
@@ -115,7 +115,7 @@ func TestDrainHelpersBorrowTheTargetStore(t *testing.T) {
 	if grew := *opens - before; grew != 0 {
 		t.Fatalf("drain helpers opened %d store(s) despite a shared target store", grew)
 	}
-	if *closes != 0 {
-		t.Fatalf("drain helpers closed the caller-owned shared store (%d close(s))", *closes)
+	if closed := *closes - closesBefore; closed != 0 {
+		t.Fatalf("drain helpers closed the caller-owned shared store (%d close(s))", closed)
 	}
 }

--- a/cmd/gc/cmd_nudge_config_reuse_test.go
+++ b/cmd/gc/cmd_nudge_config_reuse_test.go
@@ -88,3 +88,34 @@ func TestClaimDueQueuedNudgesForTargetReusesConfig(t *testing.T) {
 		t.Fatalf("claimDueQueuedNudgesForTarget re-parsed city config %d times despite target.cfg", grew)
 	}
 }
+
+// TestDrainHelpersBorrowTheTargetStore pins the second half of sys-2b9jfa: when
+// the drain hands its already-open target store to the claim and ack helpers,
+// they borrow it (zero further opens, so zero further bd-context preflights)
+// and leave closing it to the drain.
+func TestDrainHelpersBorrowTheTargetStore(t *testing.T) {
+	opens, closes := installCountingNudgeStoreSeam(t)
+	dir := t.TempDir()
+	now := time.Now()
+	item := newQueuedNudgeWithOptions("worker", "do work", "session", now, queuedNudgeOptions{ID: "n-borrow"})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	shared := openNudgeBeadStore(dir) // one open, via the counting seam
+	target := nudgeTarget{cityPath: dir, store: shared, alias: "worker", identity: "worker"}
+
+	before := *opens
+	claimed, err := claimDueQueuedNudgesForTarget(dir, target, now)
+	if err != nil {
+		t.Fatalf("claimDueQueuedNudgesForTarget: %v", err)
+	}
+	if err := ackQueuedNudgesWithOutcomeUsingStore(dir, nil, shared, queuedNudgeIDs(claimed), "injected", "", "test"); err != nil {
+		t.Fatalf("ackQueuedNudgesWithOutcomeUsingStore: %v", err)
+	}
+	if grew := *opens - before; grew != 0 {
+		t.Fatalf("drain helpers opened %d store(s) despite a shared target store", grew)
+	}
+	if *closes != 0 {
+		t.Fatalf("drain helpers closed the caller-owned shared store (%d close(s))", *closes)
+	}
+}

--- a/cmd/gc/cmd_nudge_config_reuse_test.go
+++ b/cmd/gc/cmd_nudge_config_reuse_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The per-prompt UserPromptSubmit drain (gc nudge drain --inject) loads the
+// city config once in resolveNudgeTarget and then opened the nudge store up to
+// three more times, each open reloading city.toml plus every pack (sys-2b9jfa,
+// upstream #6157). These tests pin that a caller holding the config reaches
+// the store without a second load, while the nil path keeps loading.
+func writeReuseTestCity(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	toml := "[workspace]\nname = \"t\"\n\n[beads]\nprovider = \"file\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestOpenNudgeBeadStoreWithConfigSkipsLoad(t *testing.T) {
+	dir := writeReuseTestCity(t)
+	cfg, err := loadCityConfig(dir, io.Discard)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	before := loadCityConfigCalls.Load()
+	if s := openNudgeBeadStoreWithConfig(dir, cfg); s.Store == nil {
+		t.Fatal("openNudgeBeadStoreWithConfig(cfg) returned no store")
+	}
+	if grew := loadCityConfigCalls.Load() - before; grew != 0 {
+		t.Fatalf("openNudgeBeadStoreWithConfig re-parsed city config %d times despite a non-nil cfg", grew)
+	}
+
+	before = loadCityConfigCalls.Load()
+	if s := openNudgeBeadStore(dir); s.Store == nil {
+		t.Fatal("openNudgeBeadStore returned no store")
+	}
+	if grew := loadCityConfigCalls.Load() - before; grew != 1 {
+		t.Fatalf("openNudgeBeadStore (nil cfg) parsed city config %d times, want exactly 1 (fallback load)", grew)
+	}
+}
+
+func TestOpenWispStepStoreWithConfigSkipsLoad(t *testing.T) {
+	dir := writeReuseTestCity(t)
+	t.Setenv("GC_RIG_ROOT", "")
+	cfg, err := loadCityConfig(dir, io.Discard)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	before := loadCityConfigCalls.Load()
+	if openWispStepStore(dir, cfg) == nil {
+		t.Fatal("openWispStepStore(cfg) returned nil")
+	}
+	if grew := loadCityConfigCalls.Load() - before; grew != 0 {
+		t.Fatalf("openWispStepStore re-parsed city config %d times despite a non-nil cfg", grew)
+	}
+}
+
+// TestClaimDueQueuedNudgesForTargetReusesConfig drives the drain's claim step
+// with a non-empty queue (so the maintenance store actually opens) and a target
+// that carries the config, as resolveNudgeTarget populates it.
+func TestClaimDueQueuedNudgesForTargetReusesConfig(t *testing.T) {
+	dir := writeReuseTestCity(t)
+	cfg, err := loadCityConfig(dir, io.Discard)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+	now := time.Now()
+	item := newQueuedNudgeWithOptions("worker", "do work", "session", now, queuedNudgeOptions{ID: "n-reuse"})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+	target := nudgeTarget{cityPath: dir, cfg: cfg, alias: "worker", identity: "worker"}
+
+	before := loadCityConfigCalls.Load()
+	if _, err := claimDueQueuedNudgesForTarget(dir, target, now); err != nil {
+		t.Fatalf("claimDueQueuedNudgesForTarget: %v", err)
+	}
+	if grew := loadCityConfigCalls.Load() - before; grew != 0 {
+		t.Fatalf("claimDueQueuedNudgesForTarget re-parsed city config %d times despite target.cfg", grew)
+	}
+}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4954,12 +4954,12 @@ func installCountingNudgeStoreSeam(t *testing.T) (opens, closes *int) {
 	t.Helper()
 	backing := beads.NewMemStore()
 	var openCount, closeCount int
-	prev := openNudgeBeadStore
-	openNudgeBeadStore = func(string) beads.NudgesStore {
+	prev := openNudgeBeadStoreWithConfig
+	openNudgeBeadStoreWithConfig = func(string, *config.City) beads.NudgesStore {
 		openCount++
 		return beads.NudgesStore{Store: &countingNudgeStore{MemStore: backing, closes: &closeCount}}
 	}
-	t.Cleanup(func() { openNudgeBeadStore = prev })
+	t.Cleanup(func() { openNudgeBeadStoreWithConfig = prev })
 	return &openCount, &closeCount
 }
 

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
@@ -26,9 +27,19 @@ type nudgeReference = nudgequeue.Reference
 // strongly-typed beads.NudgesStore so the nudges class is statically visible to
 // every leaf nudge-bead helper; the wrapper carries the same underlying store
 // value (identity to the work store until the nudges class relocates).
-var openNudgeBeadStore = func(cityPath string) beads.NudgesStore {
-	store, _ := openNudgeBeadStoreErr(cityPath)
+//
+// It takes the city config so a caller that already loaded it (the drain path
+// resolves its target from the same config) does not pay the full city+pack
+// TOML load again inside the store open; nil keeps the loading behavior.
+var openNudgeBeadStoreWithConfig = func(cityPath string, cfg *config.City) beads.NudgesStore {
+	store, _ := openNudgeBeadStoreErrWithConfig(cityPath, cfg)
 	return store
+}
+
+// openNudgeBeadStore is openNudgeBeadStoreWithConfig for callers with no
+// config in hand.
+func openNudgeBeadStore(cityPath string) beads.NudgesStore {
+	return openNudgeBeadStoreWithConfig(cityPath, nil)
 }
 
 // openNudgeBeadStoreErr is openNudgeBeadStore with the open failure kept instead
@@ -41,7 +52,13 @@ var openNudgeBeadStore = func(cityPath string) beads.NudgesStore {
 // use this form and print the reason; the seam above stays for the poll/drain
 // helpers whose contract is already "a nil store means do nothing".
 func openNudgeBeadStoreErr(cityPath string) (beads.NudgesStore, error) {
-	store, err := openStoreAtForCity(cityPath, cityPath)
+	return openNudgeBeadStoreErrWithConfig(cityPath, nil)
+}
+
+// openNudgeBeadStoreErrWithConfig is openNudgeBeadStoreErr reusing an
+// already-loaded city config (nil loads it).
+func openNudgeBeadStoreErrWithConfig(cityPath string, cfg *config.City) (beads.NudgesStore, error) {
+	store, err := openStoreAtForCityWithConfig(cityPath, cityPath, cfg)
 	if err != nil {
 		return beads.NudgesStore{}, fmt.Errorf("opening the city store at %q: %w", cityPath, err)
 	}

--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/extmsg"
 )
 
@@ -21,11 +22,18 @@ import (
 // rig-scoped polecat work beads live), otherwise the city store at cityPath.
 // When cityPath is empty the function falls back to GC_CITY from the env.
 func wispStepInjectionContent(cityPath string) string {
+	return wispStepInjectionContentWithConfig(cityPath, nil)
+}
+
+// wispStepInjectionContentWithConfig is wispStepInjectionContent for a caller
+// that already holds the city config (the per-prompt nudge drain), so the store
+// open underneath reuses it instead of reloading city.toml and every pack.
+func wispStepInjectionContentWithConfig(cityPath string, cfg *config.City) string {
 	effective := cityPath
 	if effective == "" {
 		effective = strings.TrimSpace(os.Getenv("GC_CITY"))
 	}
-	store := openWispStepStore(effective)
+	store := openWispStepStore(effective, cfg)
 	if store == nil {
 		return ""
 	}
@@ -46,9 +54,9 @@ func wispStepInjectionContent(cityPath string) string {
 // work lives); otherwise it opens the city store at cityPath.
 // Returns nil on any error — callers treat nil as "no store available".
 // This is the WORK store and stays unrouted; see resolveActiveWispStep.
-func openWispStepStore(cityPath string) beads.Store {
+func openWispStepStore(cityPath string, cfg *config.City) beads.Store {
 	if rigRoot := strings.TrimSpace(os.Getenv("GC_RIG_ROOT")); rigRoot != "" {
-		store, err := openStoreAtForCity(rigRoot, cityPath)
+		store, err := openStoreAtForCityWithConfig(rigRoot, cityPath, cfg)
 		if err == nil {
 			return store
 		}
@@ -56,7 +64,7 @@ func openWispStepStore(cityPath string) beads.Store {
 	if cityPath == "" {
 		return nil
 	}
-	store, err := openCityStoreAt(cityPath)
+	store, err := openStoreAtForCityWithConfig(cityPath, cityPath, cfg)
 	if err != nil {
 		return nil
 	}

--- a/cmd/gc/wisp_step_inject.go
+++ b/cmd/gc/wisp_step_inject.go
@@ -29,11 +29,25 @@ func wispStepInjectionContent(cityPath string) string {
 // that already holds the city config (the per-prompt nudge drain), so the store
 // open underneath reuses it instead of reloading city.toml and every pack.
 func wispStepInjectionContentWithConfig(cityPath string, cfg *config.City) string {
+	return wispStepInjectionContentWithStore(cityPath, cfg, nil)
+}
+
+// wispStepInjectionContentWithStore additionally accepts an open CITY store the
+// caller already holds. It is reused only when the step lookup would target the
+// city store anyway (GC_RIG_ROOT unset or equal to the city); a rig-scoped
+// lookup still opens the rig store, which is a different scope.
+func wispStepInjectionContentWithStore(cityPath string, cfg *config.City, cityStore beads.Store) string {
 	effective := cityPath
 	if effective == "" {
 		effective = strings.TrimSpace(os.Getenv("GC_CITY"))
 	}
-	store := openWispStepStore(effective, cfg)
+	var store beads.Store
+	rigRoot := strings.TrimSpace(os.Getenv("GC_RIG_ROOT"))
+	if cityStore != nil && effective != "" && (rigRoot == "" || rigRoot == effective) {
+		store = cityStore
+	} else {
+		store = openWispStepStore(effective, cfg)
+	}
 	if store == nil {
 		return ""
 	}


### PR DESCRIPTION
Fixes part of #6157 (levers 2 and the store-reuse follow-on; lever 1, one process per turn, is left for the discussion there).

## Problem

`gc nudge drain --inject` runs on every agent prompt (the `UserPromptSubmit` hook pair). Per process it loaded the city config in `resolveNudgeTarget`, then opened the nudge store up to five more times — target resolution, the maintenance store in `claimDueQueuedNudgesMatching`, the wisp-step store, the delivery store, and the ack's own maintenance store — and every open with a nil config re-ran `loadCityConfig` (city.toml + every pack, `ensureBuiltinPacksForConfigLoad`, provenance) and the bd-context preflight (`bd context --json` fork).

Measured on a 6-core Mac mini with ~12 live sessions, interleaved A/B, `/usr/bin/time -lp`, hook JSON on stdin:

| | `gc nudge drain --inject` CPU-s (median of 6) | `bd context --json` forks |
|---|---|---|
| before | 1.70 | 3 |
| after commit 1–2 (config threaded) | 1.45 | 3 |
| after commit 3 (store borrowed) | 1.25 | 2 |

`sample` confirms `loadCityConfig` frames go 4 → 0 in the drain. `gc mail check --inject` (one load, then the controller API) is unchanged at ~0.45 and is the per-process floor.

## Change

Same shape as #4682's `openStoreAtForCityWithConfig`: thread the config the drain already holds instead of memoizing.

1. `openNudgeBeadStoreWithConfig(cityPath, cfg)` becomes the seam (`openNudgeBeadStore` / `openNudgeBeadStoreErr` are nil-config wrappers, so the ~40 test call sites are untouched; the counting seam in `installCountingNudgeStoreSeam` moves to the new var). `nudgeMaintenanceStore` gains `cfg`; `claimDueQueuedNudgesMatching…`, the ack path, `wispStepInjectionContent…`/`openWispStepStore` get config-taking variants. All drain-path opens pass `target.cfg`.
2. `resolveNudgeTarget` already opened a store to resolve the session and leaked it. Keep it on `nudgeTarget.store`; the claim/ack maintenance passes and the delivery path borrow it (`nudgeMaintenanceStore.shared`, never closed by the borrower), the wisp-step lookup reuses it when it would target the city store anyway (`GC_RIG_ROOT` unset or equal to the city), and the drain closes it once on exit. Helpers with no shared store keep opening and closing their own, so `TestNudgePollHelpersCloseEveryStoreTheyOpen` still holds.

## Tests

`cmd/gc/cmd_nudge_config_reuse_test.go`: zero `loadCityConfigCalls` growth through `openNudgeBeadStoreWithConfig`, `openWispStepStore` and `claimDueQueuedNudgesForTarget` with a config in hand, exactly one on the nil path; `TestDrainHelpersBorrowTheTargetStore` pins zero opens and zero closes of the borrowed handle across claim + ack.

## Not in this PR

The two remaining preflight forks per drain (city-scope target store, rig-scope wisp store) and the per-process config load are structural; #6157 lever 1 (one process per turn) or an in-process preflight that does not fork `bd` would be the next steps and change contracts, so they are left for discussion.

Dogfooded on the reporter's rig (gascity v1.4.0 lineage + cherry-picks) since 2026-09-09T05:05Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PH9TvhnnmtmQ7RzYnqsx7j
