### PR TITLE
fix(test): scrub the dolt leak-guard startup-sweep line from eager/lazy parity stderr

### DIFF
--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -312,18 +312,33 @@ func runPackCommandProcessWithEnv(t *testing.T, cityPath, scenario string, extra
 	if got, err := os.ReadFile(afterRun); err != nil || string(got) != "reached\n" {
 		t.Fatalf("post-run marker = %q, err=%v; run did not return through deferred lifecycle", got, err)
 	}
-	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stripTmuxLeakGuardNoise(stderr.String())}
+	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stripLeakGuardNoise(stderr.String())}
 }
 
-// stripTmuxLeakGuardNoise removes the tmux leak guard's own diagnostic lines
+// doltLeakGuardStartupSweepPrefix is the prefix of every line the dolt leak
+// guard emits from its pre-test sweeps, derived from the guard's own constants
+// so a relabel there cannot silently un-scrub these lines.
+const doltLeakGuardStartupSweepPrefix = doltLeakGuardStderrPrefix + doltLeakGuardStartupLabel + " "
+
+// stripLeakGuardNoise removes the test harness leak guards' own diagnostic
+// lines from captured subprocess stderr: the tmux guard's
 // (cmd/gc/tmux_leak_guard_test.go: sweepStaleTmuxTestServers,
 // writeTmuxLeakReport, and tmuxLeakGuardedTestingM.runWith's teardown report)
-// from captured subprocess stderr. TestMain re-runs in every re-exec'd
-// subprocess, so its startup sweep or teardown leak check can emit these
-// lines nondeterministically depending on unrelated concurrent sibling
-// suites' teardown timing — real CLI stderr assertions must not depend on
-// that timing.
-func stripTmuxLeakGuardNoise(s string) string {
+// and the dolt guard's startup sweeps (cmd/gc/path_helpers_test.go:
+// doltLeakGuardedTestingM.runWith's sweepStale and sweepOrphanDoltStoreDirs).
+// TestMain re-runs in every re-exec'd subprocess, and both guards sweep *host*
+// state — stale tmux sockets, stale cmd/gc test dolt sql-servers and their
+// orphaned store dirs — that the first child reaps and every later child then
+// cannot see. Whether a line appears is therefore a property of the machine,
+// not of the CLI under test, so real CLI stderr assertions must not depend on
+// it (ga-jghg8: a stale dolt sql-server on the CI host made the eager child
+// print a startup-sweep line the lazy child could not).
+//
+// Only the dolt guard's startup sweeps are stripped. Its teardown report
+// ("leaked N dolt sql-server process(es) under ...") names processes this very
+// child leaked, which is a real defect signal that must keep reaching the
+// captured stderr.
+func stripLeakGuardNoise(s string) string {
 	if s == "" {
 		return s
 	}
@@ -337,6 +352,7 @@ func stripTmuxLeakGuardNoise(s string) string {
 	for _, line := range lines {
 		switch {
 		case strings.HasPrefix(line, "cmd/gc tmux leak guard: "):
+		case strings.HasPrefix(line, doltLeakGuardStartupSweepPrefix):
 		case strings.HasPrefix(line, "  pid="):
 		case strings.HasPrefix(line, "  socket="):
 		default:
@@ -353,18 +369,23 @@ func stripTmuxLeakGuardNoise(s string) string {
 	return out
 }
 
-// TestStripTmuxLeakGuardNoise expresses the acceptance criteria for isolating
-// captured subprocess stderr from the tmux leak guard's own harness-level
-// diagnostics (cmd/gc/tmux_leak_guard_test.go): stripTmuxLeakGuardNoise must
-// remove exactly the guard's startup-sweep and teardown-leak lines, in any
+// TestStripLeakGuardNoise expresses the acceptance criteria for isolating
+// captured subprocess stderr from the harness leak guards' own diagnostics
+// (cmd/gc/tmux_leak_guard_test.go, cmd/gc/path_helpers_test.go):
+// stripLeakGuardNoise must remove exactly the tmux guard's startup-sweep and
+// teardown-leak lines and the dolt guard's startup-sweep lines, in any
 // position, while leaving real CLI stderr output (and its line order)
 // untouched. Without this, TestPackCommandCobraHelpAndUnknownParity's
 // eager/lazy stderr-equality assertion — and the several exact-empty-stderr
-// assertions elsewhere in this file — are vulnerable to a concurrent sibling
-// suite's teardown racing exactly one of the two subprocess launches' startup
-// sweep (ga-5pe5xv gate evidence: "a concurrent tmux leak-guard stderr line
-// captured by one parity side only").
-func TestStripTmuxLeakGuardNoise(t *testing.T) {
+// assertions elsewhere in this file — are vulnerable to whatever host residue
+// the first of the two subprocess launches happens to reap: a concurrent
+// sibling suite's teardown racing one startup sweep (ga-5pe5xv gate evidence:
+// "a concurrent tmux leak-guard stderr line captured by one parity side
+// only"), or a stale cmd/gc test dolt sql-server left on the machine
+// (ga-jghg8, PR #5634 CI: the eager child reaped it and printed the sweep
+// line, the lazy child found nothing). The dolt guard's teardown leak report
+// stays, so a child that really leaks a server still fails loudly.
+func TestStripLeakGuardNoise(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -396,6 +417,25 @@ func TestStripTmuxLeakGuardNoise(t *testing.T) {
 			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
 		},
 		{
+			name: "strips the dolt guard's startup sweep of stale cmd/gc test servers",
+			in: doltLeakGuardStartupSweepPrefix + "sweep reaping 1 stale cmd/gc test dolt sql-server process(es)\n" +
+				"  pid=4242 argv=\"dolt sql-server --config /tmp/gct-9/.gc/store/dolt/config.yaml\"\n" +
+				"Error: unknown command \"missing\" for \"gc backstage\"\n",
+			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
+		},
+		{
+			name: "strips the dolt guard's orphaned store-dir sweep between real stderr lines",
+			in: "Usage:\n" +
+				doltLeakGuardStartupSweepPrefix + "sweep removed orphaned dolt store dir /tmp/gct-dolt-9\n" +
+				"  gc backstage repo\n",
+			want: "Usage:\n  gc backstage repo\n",
+		},
+		{
+			name: "keeps the dolt guard's teardown leak report",
+			in:   doltLeakGuardStderrPrefix + "leaked 1 dolt sql-server process(es) under /tmp/gct-9\n",
+			want: doltLeakGuardStderrPrefix + "leaked 1 dolt sql-server process(es) under /tmp/gct-9\n",
+		},
+		{
 			name: "strips a guard block sandwiched between two real stderr lines",
 			in: "Usage:\n" +
 				"cmd/gc tmux leak guard: startup sweep reaping 1 stale test tmux server(s) whose socket root is gone\n" +
@@ -406,8 +446,8 @@ func TestStripTmuxLeakGuardNoise(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := stripTmuxLeakGuardNoise(test.in); got != test.want {
-				t.Fatalf("stripTmuxLeakGuardNoise(%q) = %q, want %q", test.in, got, test.want)
+			if got := stripLeakGuardNoise(test.in); got != test.want {
+				t.Fatalf("stripLeakGuardNoise(%q) = %q, want %q", test.in, got, test.want)
 			}
 		})
 	}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -131,6 +131,17 @@ func requireNoLeakedDoltAfterForPaths(t *testing.T, paths ...string) {
 	}, reapDoltLeakPIDs)
 }
 
+// doltLeakGuardStderrPrefix prefixes every diagnostic the cmd/gc test dolt
+// leak guard writes to stderr, and doltLeakGuardStartupLabel is the label it
+// stamps on the sweeps it runs *before* the tests start. Tests that capture a
+// re-exec'd child's stderr (cmd/gc/cmd_commands_test.go: stripLeakGuardNoise)
+// filter on these, so keep the printers below deriving their text from them
+// rather than repeating the literals.
+const (
+	doltLeakGuardStderrPrefix = "cmd/gc test dolt leak guard: "
+	doltLeakGuardStartupLabel = "startup"
+)
+
 type doltLeakGuardedTestingM struct {
 	m        *testing.M
 	tempRoot string
@@ -158,7 +169,7 @@ func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...s
 	// previous tempRoot-only behavior rather than breaking every test run.
 	sourceRoot, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: resolving source root: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"resolving source root: %v\n", err) //nolint:errcheck
 		sourceRoot = ""
 	}
 	return &doltLeakGuardedTestingM{
@@ -221,14 +232,14 @@ func (g *doltLeakGuardedTestingM) runWith(
 	reapLeaks func([]DoltProcInfo),
 	graceInitialInterval, graceMaxElapsedTime time.Duration,
 ) int {
-	_ = sweepStale("startup")
+	_ = sweepStale(doltLeakGuardStartupLabel)
 	sweepOrphanDirs()
 	stopSignalHandler := g.installSignalHandler()
 	defer stopSignalHandler()
 
 	initial, initialErr := snapshotDoltProcessesForConfigRoots(enumerate, g.leakRoots())
 	if initialErr != nil {
-		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: initial scan failed: %v\n", initialErr) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"initial scan failed: %v\n", initialErr) //nolint:errcheck
 	}
 
 	code := runTests()
@@ -237,10 +248,10 @@ func (g *doltLeakGuardedTestingM) runWith(
 	if initialErr == nil {
 		leaked, finalErr := g.waitForFinalScanToClear(enumerate, initial, graceInitialInterval, graceMaxElapsedTime)
 		if finalErr != nil {
-			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: final scan failed: %v\n", finalErr) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"final scan failed: %v\n", finalErr) //nolint:errcheck
 			guardFailed = true
 		} else if len(leaked) > 0 {
-			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s\n", len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"leaked %d dolt sql-server process(es) under %s\n", len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
 			writeDoltLeakReport(os.Stderr, leaked)
 			reapLeaks(leaked)
 			guardFailed = true
@@ -315,7 +326,7 @@ func (g *doltLeakGuardedTestingM) installSignalHandler() func() {
 	go func() {
 		select {
 		case sig := <-signals:
-			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: received %s; sweeping test dolt processes before exit\n", sig) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"received %s; sweeping test dolt processes before exit\n", sig) //nolint:errcheck
 			_ = g.reapDoltProcessesUnderRoot("signal")
 			g.cleanupTemporaryPaths()
 			signal.Stop(signals)
@@ -343,7 +354,7 @@ func (g *doltLeakGuardedTestingM) cleanupTemporaryPaths() {
 func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool {
 	procs, err := snapshotDoltProcessesForConfigRoots(discoverDoltProcesses, g.leakRoots())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s scan failed: %v\n", label, err) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"%s scan failed: %v\n", label, err) //nolint:errcheck
 		return true
 	}
 	if len(procs) == 0 {
@@ -356,7 +367,7 @@ func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool 
 	sort.Slice(leaked, func(i, j int) bool {
 		return leaked[i].PID < leaked[j].PID
 	})
-	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d dolt sql-server process(es) under %s\n", label, len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
+	fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"%s sweep reaping %d dolt sql-server process(es) under %s\n", label, len(leaked), strings.Join(g.nonEmptyLeakRoots(), ", ")) //nolint:errcheck
 	writeDoltLeakReport(os.Stderr, leaked)
 	reapDoltLeakProcesses(leaked)
 	return true
@@ -365,7 +376,7 @@ func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool 
 func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string) bool {
 	procs, err := discoverDoltProcesses()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s stale scan failed: %v\n", label, err) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"%s stale scan failed: %v\n", label, err) //nolint:errcheck
 		return true
 	}
 	activeRoots := cmdGCTestActiveRoots(g.tempRoot)
@@ -383,7 +394,7 @@ func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string)
 	sort.Slice(leaked, func(i, j int) bool {
 		return leaked[i].PID < leaked[j].PID
 	})
-	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d stale cmd/gc test dolt sql-server process(es)\n", label, len(leaked)) //nolint:errcheck
+	fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"%s sweep reaping %d stale cmd/gc test dolt sql-server process(es)\n", label, len(leaked)) //nolint:errcheck
 	writeDoltLeakReport(os.Stderr, leaked)
 	reapDoltLeakProcesses(leaked)
 	return true
@@ -400,10 +411,10 @@ func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string)
 func sweepOrphanDoltStoreDirs() {
 	result := doltorphan.Sweep(doltorphan.SweepConfig{Root: os.TempDir()})
 	for _, dir := range result.Removed {
-		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: startup sweep removed orphaned dolt store dir %s\n", dir) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"%s sweep removed orphaned dolt store dir %s\n", doltLeakGuardStartupLabel, dir) //nolint:errcheck
 	}
 	for _, err := range result.Errors {
-		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: startup sweep error: %v\n", err) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, doltLeakGuardStderrPrefix+"%s sweep error: %v\n", doltLeakGuardStartupLabel, err) //nolint:errcheck
 	}
 }
 


### PR DESCRIPTION
## Mechanism

`TestPackCommandCobraHelpAndUnknownParity` re-execs the test binary twice
(`runPackCommandProcess`, once eager and once lazy) and compares the two
children's stderr byte for byte. Every child runs `TestMain`, and `TestMain`
wraps two leak guards that sweep **host** state before the tests start:

- the tmux guard (`cmd/gc/tmux_leak_guard_test.go`) reaps stale test tmux
  sockets, and
- the dolt guard (`cmd/gc/path_helpers_test.go`,
  `doltLeakGuardedTestingM.runWith`) reaps stale `cmd/gc` test dolt
  sql-servers and their orphaned store dirs.

Whichever child runs first reaps the residue and prints a line about it; the
second child finds nothing and prints nothing. The capture path already
filtered the tmux guard's lines, but only by the literal prefix
`"cmd/gc tmux leak guard: "`. The dolt guard prints under
`"cmd/gc test dolt leak guard: "`, so its startup sweep sailed through the
scrub and landed on exactly one side of the parity comparison.

That is a property of the machine, not of the CLI under test, which is why it
belongs in the scrubber rather than in the assertion.

## Change

- `cmd/gc/path_helpers_test.go`: introduce `doltLeakGuardStderrPrefix` and
  `doltLeakGuardStartupLabel`, and route all of the guard's stderr printers
  plus the `sweepStale(...)` call site through them.
- `cmd/gc/cmd_commands_test.go`: rename `stripTmuxLeakGuardNoise` to
  `stripLeakGuardNoise` (it now covers both guards) and add a case for
  `doltLeakGuardStartupSweepPrefix`, which is *derived* from the two constants
  above so a relabel on the guard side cannot silently un-scrub the lines.

Scope is deliberately narrow. Only the dolt guard's **startup** sweeps are
stripped. Its teardown report — `leaked N dolt sql-server process(es) under
...` — names processes the child itself leaked, which is a real defect signal,
so it is kept and a table row pins that. **The parity assertion itself is
unchanged**; no `Contains`, no normalization, still byte-for-byte equality.

## CI evidence

PR #5634, job `102327958662` (Linux `cmd/gc` shard 8; Mac shard 8 identical):

```
TestPackCommandCobraHelpAndUnknownParity/binding_help_flag
stderr differs between eager and lazy dispatch
eager:
cmd/gc test dolt leak guard: startup sweep reaping 1 stale cmd/gc test dolt sql-server process(es)
lazy:
```

The maintainer-city review run classified it `base_preexisting` and reproduced
the same shape on untouched `main`
(`ci_red_base_preexisting_dolt_leak_guard_parity`).

## RED -> GREEN

RED first, using the exact production line from the CI failure:

```
--- FAIL: TestStripTmuxLeakGuardNoise/strips_the_dolt_guard's_startup_sweep_of_stale_cmd/gc_test_servers
    stripTmuxLeakGuardNoise(...) = "cmd/gc test dolt leak guard: startup sweep reaping 1 stale
    cmd/gc test dolt sql-server process(es)\nError: unknown command \"missing\" ...",
    want "Error: unknown command \"missing\" for \"gc backstage\"\n"
```

The control row added in the same commit — *keeps the dolt guard's teardown
leak report* — **passed** in that RED run, which is what shows the scrubber was
not already over-broad and that the new rows fail for the intended reason.

GREEN after the change, all 8 rows including both controls:

```
--- PASS: TestStripLeakGuardNoise (0.00s)
    ... strips_the_dolt_guard's_startup_sweep_of_stale_cmd/gc_test_servers
    ... strips_the_dolt_guard's_orphaned_store-dir_sweep_between_real_stderr_lines
    ... keeps_the_dolt_guard's_teardown_leak_report
```

The flake is simulated deterministically by injecting the sweep line into the
captured-stderr fixture, not by depending on a stale server: the guard's
process discovery reads `/proc` directly with no injection seam, and adding one
purely to force the line would change the guard's real behavior. On the host
that produced this branch, `ps -eo pid,comm | grep -c dolt` reported 114-115
dolt processes but **no** startup-sweep line was emitted on any run, i.e. none
of them classifies as a stale `cmd/gc` test server — the ambient flake did not
reproduce locally, hence the injected fixture. Nothing was killed.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./cmd/gc/...` | exit 0 |
| `gofmt -l cmd` | exit 0, no output |
| `golangci-lint run ./cmd/gc/...` | 0 issues |
| `go test ./cmd/gc -run 'TestPackCommandCobraHelpAndUnknownParity\|TestPackCommandExitReturnsThroughRun\|LeakGuard\|Scrub' -count=3` | ok, 68.9s |
| `go test ./cmd/gc -run 'Pack\|Parity\|Scrub\|LeakGuard' -count=1` | ok, 56.2s |
| `make test-fast-parallel` | All fast jobs passed, exit 0 |
| `.githooks/pre-commit` | ran, clean |
| `.githooks/pre-push` | ran (no `--no-verify`), all fast jobs passed |

No base-owned failures were encountered; nothing is worked around.

Note for archaeologists: `release-gates/ga-f9qq6o-tmux-leak-guard-noise-gate.md`
still names `TestStripTmuxLeakGuardNoise`. That file is a dated record of a past
gate run and is left as-is rather than rewritten to match the rename.

Refs: ga-jghg8, ga-rn76r, ga-j4p3y

🤖 Generated with [Claude Code](https://claude.com/claude-code)
