### PR TITLE
fix(maintenance): cross-rig-deps external-dep filter can never match, so the order is a no-op

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -11116,13 +11116,7 @@ func TestWispCompactSkipsNonEphemeralBeads(t *testing.T) {
 	}
 }
 
-// crossRigDepsEnv installs a `bd` stub that handles three subcommand shapes:
-//   - `bd list --status=closed --closed-after=... --json` → returns closedJSON
-//   - `bd dep list <id> --direction=up --type=blocks --json` → returns depsJSON
-//   - `bd dep remove ...` and `bd dep add ...` → appended to BD_LOG
-//
-// BD_LOG is pre-created empty so skip-path tests can still read it.
-func crossRigDepsEnv(t *testing.T, closedJSON, depsJSON string) (bdLog string, env map[string]string) {
+func crossRigDepsStoreScanEnv(t *testing.T, eventsJSONL string) (bdLog string, env map[string]string) {
 	t.Helper()
 	binDir := t.TempDir()
 	bdLog = filepath.Join(t.TempDir(), "bd.log")
@@ -11130,60 +11124,97 @@ func crossRigDepsEnv(t *testing.T, closedJSON, depsJSON string) (bdLog string, e
 		t.Fatalf("WriteFile(bd log): %v", err)
 	}
 
-	stubPath := filepath.Join(binDir, "bd")
-	// Stub fails fast on unexpected subcommands or flag shapes so the test
-	// pins the script's bd contract; a regression dropping --json from
-	// `bd list` or --type=blocks from `bd dep list` would otherwise still
-	// pass.
-	writeExecutable(t, stubPath, fmt.Sprintf(`#!/bin/sh
-case "$1" in
-  list)
-    case "$*" in
-      *"--status=closed"*"--closed-after"*"--json"*)
-        cat <<'EOF'
+	writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
+case "${1:-}" in
+  events)
+    cat <<'JSON'
 %s
-EOF
-        exit 0
-        ;;
-      *)
-        echo "bd list called with unexpected args: $*" >&2
-        exit 2
-        ;;
-    esac
+JSON
+    exit 0
     ;;
-  dep)
-    case "$2" in
-      list)
-        case "$*" in
-          *"--direction=up"*"--type=blocks"*"--json"*)
-            cat <<'EOF'
-%s
-EOF
-            exit 0
-            ;;
-          *)
-            echo "bd dep list called with unexpected args: $*" >&2
-            exit 2
-            ;;
-        esac
+  rig)
+    cat <<'JSON'
+{"rigs":[{"name":"city","prefix":"hq","hq":true},{"name":"rig-a","prefix":"ra","hq":false},{"name":"rig-b","prefix":"rb","hq":false}]}
+JSON
+    exit 0
+    ;;
+  bd)
+    shift
+    scope="hq"
+    case "${1:-}" in
+      --city)
+        shift 2
         ;;
-      remove|add)
-        printf '%%s\n' "$*" >> "$BD_LOG"
-        exit 0
-        ;;
-      *)
-        echo "bd dep called with unexpected subcommand: $*" >&2
-        exit 2
+      --rig)
+        scope="$2"
+        shift 2
         ;;
     esac
+    export CROSS_RIG_TEST_SCOPE="$scope"
+    exec bd "$@"
     ;;
   *)
-    echo "bd called with unexpected subcommand: $*" >&2
+    echo "gc called with unexpected args: $*" >&2
     exit 2
     ;;
 esac
-`, closedJSON, depsJSON))
-	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
+`, eventsJSONL))
+
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+case "${1:-}" in
+  sql)
+    printf 'scope=%s sql\n' "$CROSS_RIG_TEST_SCOPE" >> "$BD_LOG"
+    case "$*" in
+      *"depends_on_external"*"type = 'blocks'"*) ;;
+      *)
+        echo "bd sql missing external blocks predicate: $*" >&2
+        exit 2
+        ;;
+    esac
+    case "$CROSS_RIG_TEST_SCOPE" in
+      rig-b)
+        cat <<'JSON'
+[{"issue_id":"rb-dependent","depends_on_external":"ra-blocker"},{"issue_id":"rb-still-blocked","depends_on_external":"ra-open"}]
+JSON
+        ;;
+      *)
+        printf '[]\n'
+        ;;
+    esac
+    exit 0
+    ;;
+  batch)
+    printf 'scope=%s batch\n' "$CROSS_RIG_TEST_SCOPE" >> "$BD_LOG"
+    if [ "${CROSS_RIG_TEST_BATCH_FAIL:-0}" = "1" ]; then
+      exit 1
+    fi
+    shift
+    batch_file=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -f)
+          batch_file="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    if [ -z "$batch_file" ]; then
+      echo "bd batch missing -f" >&2
+      exit 2
+    fi
+    cat "$batch_file" >> "$BD_LOG"
+    exit 0
+    ;;
+  *)
+    printf 'scope=%s unexpected=%s\n' "$CROSS_RIG_TEST_SCOPE" "$*" >> "$BD_LOG"
+    echo "bd called with unexpected args: $*" >&2
+    exit 2
+    ;;
+esac
+`)
 
 	env = map[string]string{
 		"BD_LOG":       bdLog,
@@ -11194,83 +11225,72 @@ esac
 	return bdLog, env
 }
 
-func TestCrossRigDepsConvertsExternalBlocksToRelated(t *testing.T) {
-	closed := `[{"id":"ga-blocker"}]`
-	deps := `[{"id":"external:other-rig:rig-dep-1"}]`
-
-	bdLog, env := crossRigDepsEnv(t, closed, deps)
-	runScript(t, coreScriptPath("cross-rig-deps.sh"), env)
+func TestCrossRigDepsScansExternalColumnOncePerStore(t *testing.T) {
+	events := `{"type":"bead.closed","payload":{"bead":{"id":"ra-blocker"}}}`
+	bdLog, env := crossRigDepsStoreScanEnv(t, events)
+	out, err := runScriptResult(t, coreScriptPath("cross-rig-deps.sh"), env)
+	if err != nil {
+		t.Fatalf("cross-rig-deps.sh failed: %v\n%s", err, out)
+	}
 
 	log, err := os.ReadFile(bdLog)
 	if err != nil {
 		t.Fatalf("ReadFile(bd log): %v", err)
 	}
 	s := string(log)
-	if !strings.Contains(s, "dep remove external:other-rig:rig-dep-1 external:ga-blocker") {
-		t.Fatalf("missing `bd dep remove` for external dep; bd log:\n%s", s)
+	for _, want := range []string{
+		"scope=hq sql",
+		"scope=rig-a sql",
+		"scope=rig-b sql",
+		"scope=rig-b batch",
+		"dep remove rb-dependent ra-blocker",
+		"dep add rb-dependent ra-blocker related",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("missing %q in bd log:\n%s", want, s)
+		}
 	}
-	if !strings.Contains(s, "dep add external:other-rig:rig-dep-1 external:ga-blocker --type=related") {
-		t.Fatalf("missing `bd dep add ... --type=related` for external dep; bd log:\n%s", s)
+	if got := strings.Count(s, " sql\n"); got != 3 {
+		t.Fatalf("sql scan count = %d, want one per store (3); bd log:\n%s", got, s)
 	}
-}
-
-func TestCrossRigDepsReportsResolvedSummary(t *testing.T) {
-	closed := `[{"id":"ga-blocker"}]`
-	deps := `[{"id":"external:other-rig:rig-dep-1"}]`
-
-	_, env := crossRigDepsEnv(t, closed, deps)
-	out, err := runScriptResult(t, coreScriptPath("cross-rig-deps.sh"), env)
-	if err != nil {
-		t.Fatalf("cross-rig-deps.sh failed: %v\n%s", err, out)
+	for _, banned := range []string{"dep list", "ra-open"} {
+		if strings.Contains(s, banned) {
+			t.Fatalf("unexpected %q in bd log:\n%s", banned, s)
+		}
 	}
 	if got, want := strings.TrimSpace(string(out)), "cross-rig-deps: resolved 1 cross-rig dependencies"; got != want {
 		t.Fatalf("summary = %q, want %q", got, want)
 	}
 }
 
-func TestCrossRigDepsSkipsInternalDeps(t *testing.T) {
-	closed := `[{"id":"ga-blocker"}]`
-	// Internal deps lack the "external:" prefix and must be left untouched
-	// — internal blocking semantics are bd's normal computeBlockedIDs path.
-	deps := `[{"id":"local-rig-dep"},{"id":"another-internal"}]`
-
-	bdLog, env := crossRigDepsEnv(t, closed, deps)
-	runScript(t, coreScriptPath("cross-rig-deps.sh"), env)
-
-	log, err := os.ReadFile(bdLog)
+func TestCrossRigDepsNoOpWithoutCloseEvents(t *testing.T) {
+	bdLog, env := crossRigDepsStoreScanEnv(t, "")
+	out, err := runScriptResult(t, coreScriptPath("cross-rig-deps.sh"), env)
 	if err != nil {
-		t.Fatalf("ReadFile(bd log): %v", err)
+		t.Fatalf("cross-rig-deps.sh failed: %v\n%s", err, out)
 	}
-	s := string(log)
-	if strings.Contains(s, "dep remove") || strings.Contains(s, "dep add") {
-		t.Fatalf("internal-only deps must not trigger bd dep remove/add; bd log:\n%s", s)
+	if len(out) != 0 {
+		t.Fatalf("quiet run output = %q, want empty", out)
 	}
-}
-
-func TestCrossRigDepsNoOpWhenNothingClosed(t *testing.T) {
-	bdLog, env := crossRigDepsEnv(t, `[]`, `[]`)
-	runScript(t, coreScriptPath("cross-rig-deps.sh"), env)
-
 	log, err := os.ReadFile(bdLog)
 	if err != nil {
 		t.Fatalf("ReadFile(bd log): %v", err)
 	}
 	if len(log) != 0 {
-		t.Fatalf("expected no bd dep calls when nothing recently closed; bd log:\n%s", log)
+		t.Fatalf("quiet run must not spawn bd; bd log:\n%s", log)
 	}
 }
 
-func TestCrossRigDepsHandlesEmptyDepsForClosedBead(t *testing.T) {
-	closed := `[{"id":"ga-blocker"}]`
-	bdLog, env := crossRigDepsEnv(t, closed, `[]`)
-	runScript(t, coreScriptPath("cross-rig-deps.sh"), env)
-
-	log, err := os.ReadFile(bdLog)
-	if err != nil {
-		t.Fatalf("ReadFile(bd log): %v", err)
+func TestCrossRigDepsFailsLoudWhenBatchFails(t *testing.T) {
+	events := `{"type":"bead.closed","payload":{"bead":{"id":"ra-blocker"}}}`
+	_, env := crossRigDepsStoreScanEnv(t, events)
+	env["CROSS_RIG_TEST_BATCH_FAIL"] = "1"
+	out, err := runScriptResult(t, coreScriptPath("cross-rig-deps.sh"), env)
+	if err == nil {
+		t.Fatalf("cross-rig-deps.sh succeeded despite bd batch failure:\n%s", out)
 	}
-	if len(log) != 0 {
-		t.Fatalf("closed bead with no upward deps should not call bd dep remove/add; bd log:\n%s", log)
+	if !strings.Contains(string(out), "bd batch failed in rig-b") {
+		t.Fatalf("missing batch failure diagnostic:\n%s", out)
 	}
 }
 
@@ -11410,92 +11430,5 @@ exit 1
 	}
 	if !strings.Contains(string(bdData), "update ga-heartbeat --persistent") {
 		t.Fatalf("expected expired heartbeat to be promoted, got bd calls:\n%s", bdData)
-	}
-}
-
-func TestCrossRigDepsReportsNonZeroCounter(t *testing.T) {
-	cityDir := t.TempDir()
-	binDir := t.TempDir()
-	bdLog := filepath.Join(t.TempDir(), "bd.log")
-
-	closedJSON := `[{"id":"ga-closed-1"},{"id":"ga-closed-2"},{"id":"ga-closed-internal"}]`
-	depsForClosed1 := `[{"id":"external:rig-a/ga-dep-1"},{"id":"external:rig-b/ga-dep-2"}]`
-	depsForClosed2 := `[{"id":"external:rig-a/ga-dep-3"},{"id":"external:rig-c/ga-dep-4"}]`
-	depsForClosedInternal := `[{"id":"ga-internal-1"},{"id":"ga-internal-2"}]`
-
-	writeExecutable(t, filepath.Join(binDir, "bd"), fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> "$BD_LOG"
-case "$1" in
-  list)
-    cat <<'JSON'
-%s
-JSON
-    exit 0
-    ;;
-  dep)
-    case "$2 $3" in
-      "list ga-closed-1")
-        cat <<'JSON'
-%s
-JSON
-        exit 0
-        ;;
-      "list ga-closed-2")
-        cat <<'JSON'
-%s
-JSON
-        exit 0
-        ;;
-      "list ga-closed-internal")
-        cat <<'JSON'
-%s
-JSON
-        exit 0
-        ;;
-      "remove "*|"add "*)
-        exit 0
-        ;;
-    esac
-    ;;
-esac
-exit 0
-`, closedJSON, depsForClosed1, depsForClosed2, depsForClosedInternal))
-	writeMaintenanceGCStub(t, filepath.Join(binDir, "gc"), "#!/bin/sh\nexit 0\n")
-
-	env := map[string]string{
-		"BD_LOG":       bdLog,
-		"GC_CITY":      cityDir,
-		"GC_CITY_PATH": cityDir,
-		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
-	}
-
-	script := coreScriptPath("cross-rig-deps.sh")
-	cmd := exec.Command(script)
-	cmd.Env = mergeTestEnv(env)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
-	}
-
-	logData, err := os.ReadFile(bdLog)
-	if err != nil {
-		t.Fatalf("ReadFile(bd log): %v", err)
-	}
-	for _, want := range []string{
-		"dep list ga-closed-1",
-		"dep list ga-closed-2",
-		"dep list ga-closed-internal",
-	} {
-		if !strings.Contains(string(logData), want) {
-			t.Fatalf("bd dep list call %q not observed:\n%s", want, logData)
-		}
-	}
-	if strings.Contains(string(logData), `dep remove "" `) || strings.Contains(string(logData), "dep remove  ") {
-		t.Fatalf("bogus empty-dep_id call observed (empty-filter guard regression?):\n%s", logData)
-	}
-
-	want := "cross-rig-deps: resolved 4 cross-rig dependencies"
-	if !strings.Contains(string(out), want) {
-		t.Fatalf("cross-rig-deps summary missing or wrong (subshell counter regression?)\nwant substring: %q\ngot output:\n%s\nbd log:\n%s", want, out, logData)
 	}
 }

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -11282,7 +11282,7 @@ func TestCrossRigDepsNoOpWithoutCloseEvents(t *testing.T) {
 }
 
 func TestCrossRigDepsFailsLoudWhenBatchFails(t *testing.T) {
-	events := `{"type":"bead.closed","payload":{"bead":{"id":"ra-blocker"}}}`
+	events := `{"type":"bead.closed","payload":{"id":"ra-blocker"}}`
 	_, env := crossRigDepsStoreScanEnv(t, events)
 	env["CROSS_RIG_TEST_BATCH_FAIL"] = "1"
 	out, err := runScriptResult(t, coreScriptPath("cross-rig-deps.sh"), env)

--- a/internal/bootstrap/packs/core/assets/scripts/cross-rig-deps.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/cross-rig-deps.sh
@@ -7,8 +7,10 @@
 # converts satisfied cross-rig blocks deps to related, preserving the
 # audit trail while removing blocking semantics.
 #
-# Uses a fixed lookback window (15 minutes) to find recently closed
-# issues. Idempotent — converting an already-related dep is a no-op.
+# Uses the bead.closed event stream with a fixed lookback window (15
+# minutes), then scans each store's indexed depends_on_external column
+# once. Cost is O(stores), not O(recently-closed beads). Idempotent —
+# converting an already-related dep is a no-op.
 #
 # Becomes unnecessary when beads supports cross-rig computeBlockedIDs.
 #
@@ -20,49 +22,93 @@ __SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$__SCRIPT_DIR/_bd_trace.sh" "cross-rig-deps"
 
+if ! command -v jq >/dev/null 2>&1; then
+    echo "cross-rig-deps: jq is required but not found in PATH" >&2
+    exit 1
+fi
+
 CITY="${GC_CITY:-.}"
 LOOKBACK="${CROSS_RIG_LOOKBACK:-15m}"
 
-# Step 1: Find recently closed issues.
-# Use a fixed lookback window rather than tracking patrol time.
-SINCE=$(date -u -d "-${LOOKBACK%m} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-        date -u -v-"${LOOKBACK%m}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || exit 0
+# Step 1: Read close transitions once. A quiet run exits before spawning bd.
+EVENTS=$(gc events --type bead.closed --since "$LOOKBACK" 2>/dev/null) || exit 0
+[ -n "$EVENTS" ] || exit 0
 
-CLOSED=$(gc bd list --status=closed --closed-after="$SINCE" --json 2>/dev/null) || exit 0
-if [ -z "$CLOSED" ] || [ "$CLOSED" = "[]" ]; then
-    exit 0
-fi
+CLOSED_IDS=$(printf '%s\n' "$EVENTS" \
+    | jq -r '.payload.bead.id // empty' 2>/dev/null \
+    | sort -u) || exit 0
+[ -n "$CLOSED_IDS" ] || exit 0
+CLOSED_JSON=$(printf '%s\n' "$CLOSED_IDS" | jq -Rsc 'split("\n") | map(select(length > 0))')
 
-# Step 2: For each closed issue, check for cross-rig dependents.
-# Capture jq output into variables (instead of piping into the loops) so
-# producer failures still trip pipefail+set -e fail-loud, and the loop
-# bodies run in the parent shell — RESOLVED is incremented in scope and
-# survives to the summary echo below. CLOSED is pre-validated as a
-# non-empty array on lines 26-29, so CLOSED_IDS is non-empty here.
+# Build the store list once. gc bd is routing sugar, not a federation
+# layer, so every store must be queried explicitly. The query volume is
+# therefore fixed at one read per store regardless of close throughput.
+RIGS_JSON=$(gc rig list --json 2>/dev/null) || exit 0
+SCOPES=$(printf '%s' "$RIGS_JSON" \
+    | jq -r '(.rigs // [])[]
+             | [(if .hq == true then "city" else "rig" end), .name]
+             | @tsv' 2>/dev/null) || exit 0
+[ -n "$SCOPES" ] || exit 0
+
+run_bd_for_scope() {
+    scope_kind="$1"
+    scope_name="$2"
+    shift 2
+    if [ "$scope_kind" = "city" ]; then
+        gc bd --city "$CITY" "$@"
+    else
+        gc bd --rig "$scope_name" "$@"
+    fi
+}
+
+# Cross-prefix targets are stored verbatim in depends_on_external. bd dep
+# list returns hydrated issue records and cannot surface a target that is
+# absent from the local store, so query the owning column directly.
+EXTERNAL_BLOCKS_SQL="SELECT issue_id, depends_on_external
+FROM dependencies
+WHERE type = 'blocks' AND depends_on_external IS NOT NULL
+UNION ALL
+SELECT issue_id, depends_on_external
+FROM wisp_dependencies
+WHERE type = 'blocks' AND depends_on_external IS NOT NULL"
+
+BATCH_FILE=$(mktemp "${TMPDIR:-/tmp}/cross-rig-deps.XXXXXX")
+trap 'rm -f "$BATCH_FILE"' EXIT
+
 RESOLVED=0
-CLOSED_IDS=$(echo "$CLOSED" | jq -r '.[].id' 2>/dev/null)
-while IFS= read -r closed_id; do
-    # Find beads that have a blocks dep on this closed issue.
-    DEPS=$(gc bd dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
-    if [ -z "$DEPS" ] || [ "$DEPS" = "[]" ]; then
+while IFS="$(printf '\t')" read -r scope_kind scope_name; do
+    [ -n "$scope_kind" ] || continue
+    ROWS=$(run_bd_for_scope "$scope_kind" "$scope_name" \
+        sql --json "$EXTERNAL_BLOCKS_SQL" 2>/dev/null) || continue
+    if [ -z "$ROWS" ] || [ "$ROWS" = "[]" ]; then
         continue
     fi
 
-    # Filter for external (cross-rig) deps. The select() filter may yield
-    # zero matches, in which case we skip rather than feed an empty
-    # here-string into `read` (which would produce one bogus iteration
-    # with dep_id="").
-    EXTERNAL_DEPS=$(echo "$DEPS" | jq -r '.[] | select(.id | startswith("external:")) | .id' 2>/dev/null)
-    if [ -z "$EXTERNAL_DEPS" ]; then
-        continue
+    MATCHES=$(printf '%s' "$ROWS" \
+        | jq -r --argjson closed "$CLOSED_JSON" '
+            .[]
+            | select(.issue_id != null and .depends_on_external != null)
+            | select(.depends_on_external as $target | $closed | index($target))
+            | [.issue_id, .depends_on_external]
+            | @tsv' 2>/dev/null) || MATCHES=""
+    [ -n "$MATCHES" ] || continue
+
+    : > "$BATCH_FILE"
+    while IFS="$(printf '\t')" read -r dep_id closed_id; do
+        [ -n "$dep_id" ] && [ -n "$closed_id" ] || continue
+        printf 'dep remove %s %s\n' "$dep_id" "$closed_id" >> "$BATCH_FILE"
+        printf 'dep add %s %s related\n' "$dep_id" "$closed_id" >> "$BATCH_FILE"
+    done <<< "$MATCHES"
+
+    STORE_RESOLVED=$(grep -c '^dep remove ' "$BATCH_FILE" 2>/dev/null) || STORE_RESOLVED=0
+    [ "$STORE_RESOLVED" -gt 0 ] || continue
+    if ! run_bd_for_scope "$scope_kind" "$scope_name" batch \
+            -f "$BATCH_FILE" -m "cross-rig-deps sweep"; then
+        echo "cross-rig-deps: bd batch failed in $scope_name — no dependencies were converted" >&2
+        exit 1
     fi
-    while IFS= read -r dep_id; do
-        # Convert blocks → related: remove blocking semantics, keep audit trail.
-        gc bd dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
-        gc bd dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
-        RESOLVED=$((RESOLVED + 1))
-    done <<< "$EXTERNAL_DEPS"
-done <<< "$CLOSED_IDS"
+    RESOLVED=$((RESOLVED + STORE_RESOLVED))
+done <<< "$SCOPES"
 
 if [ "$RESOLVED" -gt 0 ]; then
     echo "cross-rig-deps: resolved $RESOLVED cross-rig dependencies"

--- a/internal/bootstrap/packs/core/assets/scripts/cross-rig-deps.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/cross-rig-deps.sh
@@ -35,7 +35,7 @@ EVENTS=$(gc events --type bead.closed --since "$LOOKBACK" 2>/dev/null) || exit 0
 [ -n "$EVENTS" ] || exit 0
 
 CLOSED_IDS=$(printf '%s\n' "$EVENTS" \
-    | jq -r '.payload.bead.id // empty' 2>/dev/null \
+    | jq -r '.payload.bead.id // .payload.id // empty' 2>/dev/null \
     | sort -u) || exit 0
 [ -n "$CLOSED_IDS" ] || exit 0
 CLOSED_JSON=$(printf '%s\n' "$CLOSED_IDS" | jq -Rsc 'split("\n") | map(select(length > 0))')
@@ -73,13 +73,17 @@ FROM wisp_dependencies
 WHERE type = 'blocks' AND depends_on_external IS NOT NULL"
 
 BATCH_FILE=$(mktemp "${TMPDIR:-/tmp}/cross-rig-deps.XXXXXX")
-trap 'rm -f "$BATCH_FILE"' EXIT
+ERR_FILE=$(mktemp "${TMPDIR:-/tmp}/cross-rig-deps.err.XXXXXX")
+trap 'rm -f "$BATCH_FILE" "$ERR_FILE"' EXIT
 
 RESOLVED=0
 while IFS="$(printf '\t')" read -r scope_kind scope_name; do
     [ -n "$scope_kind" ] || continue
-    ROWS=$(run_bd_for_scope "$scope_kind" "$scope_name" \
-        sql --json "$EXTERNAL_BLOCKS_SQL" 2>/dev/null) || continue
+    if ! ROWS=$(run_bd_for_scope "$scope_kind" "$scope_name" \
+            sql --json "$EXTERNAL_BLOCKS_SQL" 2>"$ERR_FILE"); then
+        echo "cross-rig-deps: skipping $scope_name — bd sql failed: $(tail -n 1 "$ERR_FILE")" >&2
+        continue
+    fi
     if [ -z "$ROWS" ] || [ "$ROWS" = "[]" ]; then
         continue
     fi


### PR DESCRIPTION
## Problem

`cross-rig-deps.sh` filtered `bd dep list --json` output with
`select(.id | startswith("external:"))`. That can never match: `bd dep list`
returns hydrated issue records keyed by ordinary bead ids, and a cross-prefix
target is stored bare in the `depends_on_external` column
(`internal/storage/issueops/dependencies.go`, `INSERT ... dep.DependsOnID`
verbatim). So wherever the order is enabled it exits quietly having converted
nothing, and a satisfied cross-rig `blocks` dep keeps blocking forever.

The per-closed-bead loop also forked `gc bd dep list` once per recently closed
bead, so cost scaled with close throughput rather than store count.

## Fix

- Read close transitions once from `gc events --type bead.closed --since 15m`
  and exit before spawning `bd` on a quiet window.
- Scan each store once with one `bd sql --json` over `dependencies` and
  `wisp_dependencies` (`depends_on_external IS NOT NULL`), and convert the
  matches with a single transactional `bd batch` per store (`bd batch` already
  names this script as its designed consumer).
- Accept both `bead.closed` payload shapes — the raw snapshot
  `EncodeBeadEventPayload` emits and the wrapped `{"bead":…}` contract the
  cache-reconcile path emits — the same tolerance `DecodeBeadEventPayload`
  applies. Reading only one shape silently turns the sweep into a no-op on
  cities that emit the other.
- A per-store `bd sql` failure (e.g. a store without `wisp_dependencies`) now
  prints the last stderr line and moves on instead of skipping the store
  with no trace.

`jq` is now a hard requirement of the script (it was already used); it fails
loud if absent.

## Tests

`examples/gastown/maintenance_scripts_test.go`: `TestCrossRigDepsScansExternalColumnOncePerStore`,
`TestCrossRigDepsNoOpWithoutCloseEvents`, `TestCrossRigDepsFailsLoudWhenBatchFails`
replace the previous stubs (which asserted the impossible `external:` shape).
One stub uses the raw payload shape and one the wrapped shape.

`go test -run TestCrossRigDeps ./examples/gastown` — ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1s4f1Fau9XDqeRvSFRWHP