### PR TITLE
perf(control): open the control-plane store through preflight so the dispatcher runs the native store

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -4708,25 +4708,30 @@ func TestOpenControlStoreAtForCityUsesControlRunnerForStaleBdScope(t *testing.T)
 		t.Fatalf("stale rig control update: %v", err)
 	}
 
-	if len(calls) != 1 {
-		t.Fatalf("bd calls = %#v, want one update call", calls)
+	// The factory's preflight (bd context --json) precedes the update: the
+	// control path now runs preflight like every other store open, and this
+	// stale scope (no project_id) falls back to bd. Pin the update call only.
+	updates := 0
+	update := -1
+	for i, call := range calls {
+		if len(call) > 0 && call[0] == "update" {
+			updates++
+			update = i
+		}
 	}
-	if len(envs) != 1 {
-		t.Fatalf("bd envs = %#v, want one command environment", envs)
+	if updates != 1 || len(envs) != len(calls) {
+		t.Fatalf("bd calls = %#v (envs %d), want exactly one update call", calls, len(envs))
 	}
-	if call := calls[0]; len(call) < 1 || call[0] != "update" {
-		t.Fatalf("bd call = %#v, want update ...", calls[0])
+	if slices.Contains(calls[update], "--sandbox") {
+		t.Fatalf("bd call = %#v, write-capable control stores must not use --sandbox", calls[update])
 	}
-	if slices.Contains(calls[0], "--sandbox") {
-		t.Fatalf("bd call = %#v, write-capable control stores must not use --sandbox", calls[0])
-	}
-	if got := envs[0]["BD_EXPORT_AUTO"]; got != "false" {
+	if got := envs[update]["BD_EXPORT_AUTO"]; got != "false" {
 		t.Fatalf("BD_EXPORT_AUTO = %q, want false", got)
 	}
-	if got := envs[0]["BEADS_DIR"]; got != filepath.Join(staleRigDir, ".beads") {
+	if got := envs[update]["BEADS_DIR"]; got != filepath.Join(staleRigDir, ".beads") {
 		t.Fatalf("BEADS_DIR = %q, want stale rig store", got)
 	}
-	if got := envs[0]["GC_RIG_ROOT"]; got != staleRigDir {
+	if got := envs[update]["GC_RIG_ROOT"]; got != staleRigDir {
 		t.Fatalf("GC_RIG_ROOT = %q, want stale rig root", got)
 	}
 }

--- a/cmd/gc/store_rollout.go
+++ b/cmd/gc/store_rollout.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -72,14 +73,19 @@ func conditionalWritesStoreID(scopeRoot, cityPath string) string {
 	return "rig/" + filepath.Base(scopeRoot)
 }
 
-// openControlBdStoreThroughFactory routes a control-plane bd store through
-// the beads factory so it carries the conditional-writes stamp. No
-// PreflightChecker is supplied, so the factory can never select the native
-// store for the control path (the zero checker fails preflight and the
-// factory takes the bd fallback — pinned by
-// TestOpenStoreAtForCityNilPreflightCheckerFallsBackToBd); the store comes
-// back raw, matching the control path's deliberately unwrapped handles.
+// openControlBdStoreThroughFactory routes a control-plane store through the
+// beads factory so it carries the conditional-writes stamp and, where the
+// scope passes preflight, comes back as the in-process native store rather
+// than a bd-forking BdStore. The control dispatcher is a long-lived serve
+// loop whose ready-cache probe and prime battery run on every wake, so a
+// BdStore here meant a `bd` subprocess per wake forever; the native store
+// answers the same reads over one Dolt connection.
+// The store comes back raw (no CachingStore/policy wrap), matching the
+// control path's deliberately unwrapped handles.
 func openControlBdStoreThroughFactory(scopeRoot, cityPath, provider string, cfg *config.City, openBd func() (beads.Store, error)) (beads.Store, error) {
+	if store := nativeControlStores.lookup(scopeRoot); store != nil {
+		return store, nil
+	}
 	flags, resolved := resolvedConditionalWritesFlags(cfg)
 	mode := gate.ModeUnset
 	if resolved {
@@ -92,12 +98,86 @@ func openControlBdStoreThroughFactory(scopeRoot, cityPath, provider string, cfg 
 		ConditionalWrites: mode,
 		OnConditionalWritesDegraded: lazyConditionalWritesDegradeEmitter(
 			cityPath, conditionalWritesStoreID(scopeRoot, cityPath), flags, resolved),
-		OpenBdStore: openBd,
+		OpenBdStore:      openBd,
+		PreflightChecker: newControlPreflightChecker(cityPath, provider),
+		OpenNativeStore: func() (beads.Store, error) {
+			return openNativeControlStore(scopeRoot, cityPath, cfg)
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
-	return result.Store, nil
+	return nativeControlStores.retain(scopeRoot, result.Store), nil
+}
+
+// openNativeControlStore opens the native store for a control-plane scope
+// the same way the controller's rig stores do (api_state.go openRigStore):
+// the scoped Dolt env for the initial open, plus a reopen hook that
+// re-resolves the CURRENT env on every reconnect. The reopen deliberately
+// reloads config (cfg is nil) because the dispatcher process can outlive a
+// managed-Dolt restart or rebind by days, and the env it opened with pins
+// the port as of open time.
+func openNativeControlStore(scopeRoot, cityPath string, cfg *config.City) (beads.Store, error) {
+	env, err := nativeDoltOpenEnvForScope(cityPath, cfg, scopeRoot)
+	if err != nil {
+		return nil, fmt.Errorf("project native control store env %s: %w", scopeRoot, err)
+	}
+	reopen := func(ctx context.Context) (beads.NativeStorage, error) {
+		freshEnv, rerr := nativeDoltOpenEnvForScopeContext(ctx, cityPath, nil, scopeRoot)
+		if rerr != nil {
+			return nil, fmt.Errorf("re-resolve native control store env %s: %w", scopeRoot, rerr)
+		}
+		return beads.OpenNativeStorage(ctx, scopeRoot, freshEnv)
+	}
+	return beads.OpenNativeDoltStoreAt(context.Background(), scopeRoot, env, beads.WithNativeReopen(reopen))
+}
+
+// newControlPreflightChecker is a seam so tests of the control path can
+// substitute a checker that never forks bd; production uses the same checker
+// as every other gc store open.
+var newControlPreflightChecker = newBeadsPreflightChecker
+
+// nativeControlStores retains one native store per scope for the life of the
+// process. The control-dispatcher serve loop opens the control store afresh
+// for every control bead it processes (runControlDispatcherInStore) and never
+// closes it; that was free with a BdStore, which holds nothing, but a native
+// store is a preflight (one bd fork, one identity probe) plus a Dolt
+// connection pool per open, and a pending bead is re-processed every tick.
+// Only native stores are retained: bd/file/mem fallbacks stay per-open, so
+// tests that reopen a temp scope under a different config are unaffected.
+// Scope resolution is thereby fixed at first open per process -- the same
+// restart-to-relocate rule the control-ready cache's retained backing already
+// documents.
+var nativeControlStores = &controlStoreRegistry{byRoot: map[string]beads.Store{}}
+
+type controlStoreRegistry struct {
+	mu     sync.Mutex
+	byRoot map[string]beads.Store
+}
+
+func (r *controlStoreRegistry) lookup(scopeRoot string) beads.Store {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.byRoot[scopeRoot]
+}
+
+// retain returns the store to hand out for scopeRoot: the store itself when
+// it is the first native store opened for that scope, the already-retained
+// one (closing the newcomer) when a concurrent first open lost the race, and
+// the store unchanged when it is not native.
+func (r *controlStoreRegistry) retain(scopeRoot string, store beads.Store) beads.Store {
+	native, ok := store.(*beads.NativeDoltStore)
+	if !ok {
+		return store
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, exists := r.byRoot[scopeRoot]; exists {
+		_ = native.CloseStore()
+		return existing
+	}
+	r.byRoot[scopeRoot] = store
+	return store
 }
 
 // conditionalWritesEventStoreKind maps internal store-kind names onto the

--- a/cmd/gc/store_rollout_test.go
+++ b/cmd/gc/store_rollout_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/rollout"
@@ -205,8 +206,9 @@ func TestOpenRigStoreThreadsConditionalWrites(t *testing.T) {
 
 // TestOpenControlBdStoreThroughFactoryStamps pins the control-dispatcher
 // routing: the raw control-plane bd store must come back factory-stamped
-// (and raw — control paths are deliberately unwrapped), with native
-// selection impossible (no preflight checker is supplied).
+// (and raw — control paths are deliberately unwrapped) when the scope fails
+// preflight (here: no .beads metadata under /city), i.e. the bd fallback is
+// still the factory's own, stamped, fallback.
 func TestOpenControlBdStoreThroughFactoryStamps(t *testing.T) {
 	cfg, err := config.Parse([]byte("[workspace]\nname = \"t\"\n\n[beads]\nconditional_writes = \"require\"\n"))
 	if err != nil {
@@ -216,6 +218,10 @@ func TestOpenControlBdStoreThroughFactoryStamps(t *testing.T) {
 	raw := beads.NewBdStore("/city", func(_, _ string, _ ...string) ([]byte, error) {
 		return capableHelp, nil
 	})
+	// A zero checker fails preflight on the metadata read without forking bd.
+	prev := newControlPreflightChecker
+	newControlPreflightChecker = func(_, _ string) contract.PreflightChecker { return contract.PreflightChecker{} }
+	t.Cleanup(func() { newControlPreflightChecker = prev })
 	store, err := openControlBdStoreThroughFactory("/city", "/city", "bd", cfg,
 		func() (beads.Store, error) { return raw, nil })
 	if err != nil {
@@ -230,6 +236,20 @@ func TestOpenControlBdStoreThroughFactoryStamps(t *testing.T) {
 	}
 	if writer == nil {
 		t.Fatal("require was not stamped onto the control-plane bd store")
+	}
+}
+
+// TestControlStoreRegistryRetainsOnlyNativeStores pins that per-open
+// fallbacks (bd, mem, file) are never memoized: only a native store, whose
+// open is a preflight plus a connection pool, is kept for the process.
+func TestControlStoreRegistryRetainsOnlyNativeStores(t *testing.T) {
+	reg := &controlStoreRegistry{byRoot: map[string]beads.Store{}}
+	mem := beads.NewMemStore()
+	if got := reg.retain("/scope", mem); got != beads.Store(mem) {
+		t.Fatalf("retain(mem) = %T, want the same store back", got)
+	}
+	if got := reg.lookup("/scope"); got != nil {
+		t.Fatalf("lookup after retaining a MemStore = %T, want nil (non-native stores are per-open)", got)
 	}
 }
 

--- a/internal/beads/factory_test.go
+++ b/internal/beads/factory_test.go
@@ -605,8 +605,9 @@ func TestOpenStoreAtForCityStampsConditionalWritesMode(t *testing.T) {
 // plane routing contract: a caller that supplies no PreflightChecker can
 // never be given the native store — the factory treats the missing checker
 // as preflight-unavailable and takes the bd fallback, stamping it like every
-// other path. (The control dispatcher routes its raw bd store through the
-// factory this way; native selection there would be a behavior change.)
+// other path. (The control dispatcher used to route its raw bd store
+// through the factory this way; it now supplies the checker like every
+// other store open, so this pins the no-checker caller contract only.)
 func TestOpenStoreAtForCityNilPreflightCheckerFallsBackToBd(t *testing.T) {
 	t.Setenv(nativeForceFallbackEnv, "")
 	bd := NewMemStore()


### PR DESCRIPTION
Fixes #6156. Same code path as #3892.

## Problem

`openControlBdStoreThroughFactory` (`cmd/gc/store_rollout.go`) passes no `PreflightChecker`, so the factory can never select the native store for the control dispatcher (the pinned `TestOpenStoreAtForCityNilPreflightCheckerFallsBackToBd` contract). `gc convoy control --serve --follow` is a long-lived loop that wakes every 1–5 s, and with a `BdStore` every control-ready prime and every control bead it processes is a `bd` subprocess. Measured on the reporter's rig (children of the dispatcher pid sampled at 0.5 s for 11 min): 76 `bd` forks = 6.8/min on a quiet host, 23% of all `bd` spawns there.

## Change

- `openControlBdStoreThroughFactory` passes `newBeadsPreflightChecker(cityPath, provider)` and an `OpenNativeStore` closure mirroring the controller's rig-store open (`api_state.go`): scoped Dolt env plus a reopen hook that re-resolves the current env on reconnect, because the dispatcher can outlive a managed-Dolt restart or rebind by days.
- One native store per scope is retained for the process (`nativeControlStores`). The serve loop opens the control store afresh for each control bead it processes (`runControlDispatcherInStore`) and never closes it; that was free with a `BdStore`, which holds nothing, but a native store is a preflight (one `bd context` fork, one identity probe) plus a Dolt connection pool per open, and a pending control bead is re-processed every tick. Non-native fallbacks (bd/file/mem) are never retained, so tests reopening a temp scope under a different config are unaffected. Scope resolution is fixed at first open per process, the same restart-to-relocate rule the control-ready cache's retained backing already documents.
- `newControlPreflightChecker` is a seam so the stamping test can use a zero checker without forking `bd`.

Readiness is unchanged: `NativeDoltStore` already implements `enrichReadyProjectionForCache` upstream (19e0862cf), so a cache primed over the native control store carries bd's `is_blocked` column exactly as the `BdStore` path did.

## Tests

- `TestOpenControlBdStoreThroughFactoryStamps` still pins the stamped bd fallback (now via a failing preflight rather than a missing checker).
- `TestControlStoreRegistryRetainsOnlyNativeStores` pins that a `MemStore` is never memoized.
- `TestOpenControlStoreAtForCityUsesControlRunnerForStaleBdScope` pins the update call instead of the call count, since the preflight's `bd context --json` now precedes it on a stale scope.
- `TestOpenStoreAtForCityNilPreflightCheckerFallsBackToBd` unchanged; its comment no longer claims the control dispatcher relies on it.

## Dogfood

Reporter's rig (gascity v1.4.0 lineage + cherry-picks), cut over 2026-09-09T07:50Z, dispatcher restarted 07:54Z: 351 wakes in the following 15 min with zero `bd` child processes (was ~6.8/min), dispatcher RSS flat at ~67 MB, `gc status` still reports `NativeDoltStore` for the city scope. On that lineage the fix also needed an in-process `ActiveFingerprint` for the native store (a local cache short-circuit upstream does not have), not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BP9ptqEPMokzorCQQD9aKC