### PR TITLE
fix(hook): claim line always carries root_bead_id/continuation_group; gc.work_branch from the session work dir

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -2024,14 +2024,16 @@ func hookClaimSessionName(env []string) string {
 
 // hookClaimWorkBranchDir returns the directory whose checked-out branch is the
 // worker's work branch: the session work dir (GC_DIR, exported by the runtime
-// for every managed session) when it names an existing directory, else the
-// store dir the claim ran against. The store dir is the rig root for a
+// for every managed session) when it is an absolute path naming an existing
+// directory, else the store dir the claim ran against. A relative GC_DIR is
+// never honored: the runtime exports absolute paths, and a relative one would
+// resolve against the claim's arbitrary cwd. The store dir is the rig root for a
 // rig-scoped bead, so a worker that starts in its own worktree (agent
 // work_dir) would otherwise get the rig root's branch — usually main —
 // stamped as gc.work_branch over its real one, and every later gate reads the
 // wrong branch (citadel 2026-09-09: pc_e268966189e7, pc_bbf5bb62f1d0).
 func hookClaimWorkBranchDir(env []string, storeDir string) string {
-	if wd := hookClaimEnvValue(env, "GC_DIR"); wd != "" {
+	if wd := hookClaimEnvValue(env, "GC_DIR"); wd != "" && filepath.IsAbs(wd) {
 		if info, err := os.Stat(wd); err == nil && info.IsDir() {
 			return wd
 		}

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -273,8 +273,8 @@ type hookClaimJSONResult struct {
 	BeadID               string   `json:"bead_id,omitempty"`
 	Assignee             string   `json:"assignee,omitempty"`
 	Route                string   `json:"route,omitempty"`
-	RootBeadID           string   `json:"root_bead_id,omitempty"`
-	ContinuationGroup    string   `json:"continuation_group,omitempty"`
+	RootBeadID           string   `json:"root_bead_id"`
+	ContinuationGroup    string   `json:"continuation_group"`
 	ContinuationAssigned []string `json:"continuation_assigned,omitempty"`
 	DrainAcknowledged    bool     `json:"drain_acknowledged,omitempty"`
 }
@@ -1376,7 +1376,7 @@ func hookClaimLifecycleCandidate(bead beads.Bead, opts hookClaimOptions) bool {
 // write.
 func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string) map[string]string {
 	patch := map[string]string{}
-	if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
+	if branch := strings.TrimSpace(ops.ResolveWorkBranch(hookClaimWorkBranchDir(opts.Env, dir))); branch != "" &&
 		strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch &&
 		hookClaimWorktreeEvidenceIsWholeOrAbsent(bead) {
 		patch[beadmeta.WorkBranchMetadataKey] = branch
@@ -2020,6 +2020,23 @@ func hookClaimSessionName(env []string) string {
 		}
 	}
 	return strings.TrimSpace(sessionName)
+}
+
+// hookClaimWorkBranchDir returns the directory whose checked-out branch is the
+// worker's work branch: the session work dir (GC_DIR, exported by the runtime
+// for every managed session) when it names an existing directory, else the
+// store dir the claim ran against. The store dir is the rig root for a
+// rig-scoped bead, so a worker that starts in its own worktree (agent
+// work_dir) would otherwise get the rig root's branch — usually main —
+// stamped as gc.work_branch over its real one, and every later gate reads the
+// wrong branch (citadel 2026-09-09: pc_e268966189e7, pc_bbf5bb62f1d0).
+func hookClaimWorkBranchDir(env []string, storeDir string) string {
+	if wd := hookClaimEnvValue(env, "GC_DIR"); wd != "" {
+		if info, err := os.Stat(wd); err == nil && info.IsDir() {
+			return wd
+		}
+	}
+	return storeDir
 }
 
 // hookResolveWorkBranch returns the current git branch of dir, or "" when dir

--- a/cmd/gc/hook_claim_lifecycle_keys_test.go
+++ b/cmd/gc/hook_claim_lifecycle_keys_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// A directly routed bead (gc sling, no formula) has neither a workflow root nor
+// a continuation group. The worker role contract still records both from the
+// claim line — an empty continuation group is the "hard session boundary"
+// signal — so the line must carry the keys explicitly. With omitempty the keys
+// vanished and every worker was left to infer "absent means empty" (citadel
+// papercuts pc_b7a878218aac, pc_3be95454d9fe, pc_573e5bf01dfe, pc_33b927b6c054).
+func TestHookClaimWorkResultCarriesLifecycleKeysExplicitly(t *testing.T) {
+	result := hookClaimJSONResult{
+		SchemaVersion: "1",
+		OK:            true,
+		Command:       hookClaimCommandName,
+		Action:        "work",
+		Reason:        "claimed",
+		BeadID:        "gp-1",
+		Assignee:      "ci-abc123",
+		Route:         "rig/worker",
+	}
+	var out bytes.Buffer
+	if err := writeHookClaimResultLine(result, true, &out); err != nil {
+		t.Fatalf("writeHookClaimResultLine: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("result is not JSON: %v\n%s", err, out.String())
+	}
+	for _, key := range []string{"root_bead_id", "continuation_group"} {
+		value, ok := decoded[key]
+		if !ok {
+			t.Fatalf("work result omits %q; want an explicit empty string\n%s", key, out.String())
+		}
+		if value != "" {
+			t.Fatalf("%s = %#v, want \"\"", key, value)
+		}
+	}
+
+	raw, err := os.ReadFile(hookClaimResultSchemaPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", hookClaimResultSchemaPath, err)
+	}
+	schema := compileJSONSchema(t, "gc://schemas/hook/result.schema.json", raw)
+	if err := schema.Validate(decoded); err != nil {
+		t.Fatalf("work result does not match the published schema: %v\n%s", err, out.String())
+	}
+
+	// Removing either key from a work result must now be a schema violation, so
+	// a consumer validating the line can rely on both being present.
+	for _, key := range []string{"root_bead_id", "continuation_group"} {
+		stripped := make(map[string]any, len(decoded))
+		for k, v := range decoded {
+			if k != key {
+				stripped[k] = v
+			}
+		}
+		if err := schema.Validate(stripped); err == nil {
+			t.Fatalf("schema accepted a work result without %q", key)
+		}
+	}
+}
+
+// The drain line keeps validating with the keys present-but-empty: the schema
+// types them as plain strings and never requires them for action=drain.
+func TestHookClaimDrainResultStillMatchesSchemaWithLifecycleKeys(t *testing.T) {
+	var out bytes.Buffer
+	code := writeHookClaimDrain(hookClaimLabel, hookClaimReasonNoWork, true, false, nil, &out, &bytes.Buffer{})
+	if code != 1 {
+		t.Fatalf("drain without drain-ack exit = %d, want 1", code)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("drain result is not JSON: %v\n%s", err, out.String())
+	}
+	raw, err := os.ReadFile(hookClaimResultSchemaPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", hookClaimResultSchemaPath, err)
+	}
+	if err := compileJSONSchema(t, "gc://schemas/hook/result.schema.json", raw).Validate(decoded); err != nil {
+		t.Fatalf("drain result does not match the published schema: %v\n%s", err, out.String())
+	}
+}

--- a/cmd/gc/hook_claim_work_branch_dir_test.go
+++ b/cmd/gc/hook_claim_work_branch_dir_test.go
@@ -3,20 +3,27 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// workBranchDirSpy records the directory a claim asks ResolveWorkBranch about.
-type workBranchDirSpy struct{ dir string }
+// workBranchDirSpy answers ResolveWorkBranch per directory and records the
+// directory the claim asked about, so every row asserts both the directory
+// the claim chose and the branch that ends up stamped as gc.work_branch.
+type workBranchDirSpy struct {
+	branches map[string]string
+	dir      string
+}
 
 func (s *workBranchDirSpy) resolve(dir string) string {
 	s.dir = dir
-	return "gp-1"
+	return s.branches[dir]
 }
 
-func workBranchDirClaimOps(spy *workBranchDirSpy) hookClaimOps {
+func workBranchDirClaimOps(spy *workBranchDirSpy, stamped *map[string]string) hookClaimOps {
 	return hookClaimOps{
 		Runner: func(string, string) (string, error) {
 			return `[{"id":"gp-1","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
@@ -25,8 +32,11 @@ func workBranchDirClaimOps(spy *workBranchDirSpy) hookClaimOps {
 			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
 		ResolveWorkBranch: spy.resolve,
-		StampWorkMeta:     noopStampWorkMeta,
-		PublishRunMap:     noopPublishRunMap,
+		StampWorkMeta: func(_ context.Context, _ string, _ []string, _, _ string, patch map[string]string) error {
+			*stamped = patch
+			return nil
+		},
+		PublishRunMap: noopPublishRunMap,
 	}
 }
 
@@ -34,35 +44,66 @@ func workBranchDirClaimOps(spy *workBranchDirSpy) hookClaimOps {
 // the claim must read the work branch there, not from the store dir, which for
 // a rig-scoped bead is the rig root and usually sits on main. Before the fix a
 // worker whose lane was on gp-1 got gc.work_branch=main stamped.
+//
+// Contract pinned here: GC_DIR wins when it is an absolute path naming an
+// existing directory (the runtime always exports an absolute path; a symlink
+// is passed through as given and git resolves it); anything else — unset,
+// empty, relative, missing, or a regular file — falls back to the store dir.
+// Duplicate entries follow hookClaimEnvValue: the last one wins.
 func TestDoHookClaimResolvesWorkBranchFromSessionWorkDir(t *testing.T) {
-	storeDir := t.TempDir()
-	sessionDir := t.TempDir()
-	missingDir := storeDir + "/does-not-exist"
+	storeDir := t.TempDir()   // the rig root, checked out on main
+	sessionDir := t.TempDir() // the worker's lane, checked out on gp-1
+	missingDir := filepath.Join(storeDir, "does-not-exist")
+	regularFile := filepath.Join(storeDir, "not-a-directory")
+	if err := os.WriteFile(regularFile, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(t.TempDir(), "lane-link")
+	if err := os.Symlink(sessionDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
+	branches := map[string]string{storeDir: "main", sessionDir: "gp-1", linkDir: "gp-1"}
 
 	cases := map[string]struct {
-		env  []string
-		want string
+		env        []string
+		wantDir    string
+		wantBranch string
 	}{
 		"GC_DIR names the session worktree": {
-			env:  []string{"GC_SESSION_ID=s1", "GC_DIR=" + sessionDir},
-			want: sessionDir,
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + sessionDir}, wantDir: sessionDir, wantBranch: "gp-1",
+		},
+		"GC_DIR names the store dir itself (no work_dir: the scope root is the workdir)": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + storeDir}, wantDir: storeDir, wantBranch: "main",
 		},
 		"no GC_DIR falls back to the store dir": {
-			env:  []string{"GC_SESSION_ID=s1"},
-			want: storeDir,
-		},
-		"GC_DIR that does not exist falls back to the store dir": {
-			env:  []string{"GC_SESSION_ID=s1", "GC_DIR=" + missingDir},
-			want: storeDir,
+			env: []string{"GC_SESSION_ID=s1"}, wantDir: storeDir, wantBranch: "main",
 		},
 		"empty GC_DIR falls back to the store dir": {
-			env:  []string{"GC_SESSION_ID=s1", "GC_DIR="},
-			want: storeDir,
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR="}, wantDir: storeDir, wantBranch: "main",
+		},
+		"GC_DIR that does not exist falls back to the store dir": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + missingDir}, wantDir: storeDir, wantBranch: "main",
+		},
+		"GC_DIR naming a regular file falls back to the store dir": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + regularFile}, wantDir: storeDir, wantBranch: "main",
+		},
+		"relative GC_DIR falls back to the store dir": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=."}, wantDir: storeDir, wantBranch: "main",
+		},
+		"symlinked GC_DIR is used as given": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + linkDir}, wantDir: linkDir, wantBranch: "gp-1",
+		},
+		"duplicate GC_DIR entries: the last one wins": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + storeDir, "GC_DIR=" + sessionDir}, wantDir: sessionDir, wantBranch: "gp-1",
+		},
+		"trailing empty GC_DIR override falls back to the store dir": {
+			env: []string{"GC_SESSION_ID=s1", "GC_DIR=" + sessionDir, "GC_DIR="}, wantDir: storeDir, wantBranch: "main",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			spy := &workBranchDirSpy{}
+			spy := &workBranchDirSpy{branches: branches}
+			var stamped map[string]string
 			opts := hookClaimOptions{
 				Assignee:           "s1",
 				IdentityCandidates: []string{"s1"},
@@ -71,11 +112,14 @@ func TestDoHookClaimResolvesWorkBranchFromSessionWorkDir(t *testing.T) {
 				JSON:               true,
 			}
 			var stdout, stderr bytes.Buffer
-			if code := doHookClaim("bd ready --json", storeDir, opts, workBranchDirClaimOps(spy), &stdout, &stderr); code != 0 {
+			if code := doHookClaim("bd ready --json", storeDir, opts, workBranchDirClaimOps(spy, &stamped), &stdout, &stderr); code != 0 {
 				t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
 			}
-			if spy.dir != tc.want {
-				t.Fatalf("ResolveWorkBranch dir = %q, want %q", spy.dir, tc.want)
+			if spy.dir != tc.wantDir {
+				t.Fatalf("ResolveWorkBranch dir = %q, want %q", spy.dir, tc.wantDir)
+			}
+			if got := stamped["gc.work_branch"]; got != tc.wantBranch {
+				t.Fatalf("stamped gc.work_branch = %q, want %q (patch %v)", got, tc.wantBranch, stamped)
 			}
 		})
 	}

--- a/cmd/gc/hook_claim_work_branch_dir_test.go
+++ b/cmd/gc/hook_claim_work_branch_dir_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// workBranchDirSpy records the directory a claim asks ResolveWorkBranch about.
+type workBranchDirSpy struct{ dir string }
+
+func (s *workBranchDirSpy) resolve(dir string) string {
+	s.dir = dir
+	return "gp-1"
+}
+
+func workBranchDirClaimOps(spy *workBranchDirSpy) hookClaimOps {
+	return hookClaimOps{
+		Runner: func(string, string) (string, error) {
+			return `[{"id":"gp-1","status":"open","metadata":{"gc.routed_to":"worker"}}]`, nil
+		},
+		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
+			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
+		},
+		ResolveWorkBranch: spy.resolve,
+		StampWorkMeta:     noopStampWorkMeta,
+		PublishRunMap:     noopPublishRunMap,
+	}
+}
+
+// A session that starts in its own worktree (agent work_dir) exports GC_DIR;
+// the claim must read the work branch there, not from the store dir, which for
+// a rig-scoped bead is the rig root and usually sits on main. Before the fix a
+// worker whose lane was on gp-1 got gc.work_branch=main stamped.
+func TestDoHookClaimResolvesWorkBranchFromSessionWorkDir(t *testing.T) {
+	storeDir := t.TempDir()
+	sessionDir := t.TempDir()
+	missingDir := storeDir + "/does-not-exist"
+
+	cases := map[string]struct {
+		env  []string
+		want string
+	}{
+		"GC_DIR names the session worktree": {
+			env:  []string{"GC_SESSION_ID=s1", "GC_DIR=" + sessionDir},
+			want: sessionDir,
+		},
+		"no GC_DIR falls back to the store dir": {
+			env:  []string{"GC_SESSION_ID=s1"},
+			want: storeDir,
+		},
+		"GC_DIR that does not exist falls back to the store dir": {
+			env:  []string{"GC_SESSION_ID=s1", "GC_DIR=" + missingDir},
+			want: storeDir,
+		},
+		"empty GC_DIR falls back to the store dir": {
+			env:  []string{"GC_SESSION_ID=s1", "GC_DIR="},
+			want: storeDir,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			spy := &workBranchDirSpy{}
+			opts := hookClaimOptions{
+				Assignee:           "s1",
+				IdentityCandidates: []string{"s1"},
+				RouteTargets:       []string{"worker"},
+				Env:                tc.env,
+				JSON:               true,
+			}
+			var stdout, stderr bytes.Buffer
+			if code := doHookClaim("bd ready --json", storeDir, opts, workBranchDirClaimOps(spy), &stdout, &stderr); code != 0 {
+				t.Fatalf("doHookClaim = %d, want 0; stderr=%s", code, stderr.String())
+			}
+			if spy.dir != tc.want {
+				t.Fatalf("ResolveWorkBranch dir = %q, want %q", spy.dir, tc.want)
+			}
+		})
+	}
+}

--- a/schemas/hook/result.schema.json
+++ b/schemas/hook/result.schema.json
@@ -49,10 +49,12 @@
       "type": "string"
     },
     "root_bead_id": {
-      "type": "string"
+      "type": "string",
+      "description": "Workflow root of the claimed bead; empty for a directly routed bead. Always present on action=work."
     },
     "continuation_group": {
-      "type": "string"
+      "type": "string",
+      "description": "Continuation group of the claimed bead; empty means a hard session boundary after close. Always present on action=work."
     },
     "continuation_assigned": {
       "type": "array",
@@ -79,7 +81,9 @@
       "then": {
         "required": [
           "bead_id",
-          "assignee"
+          "assignee",
+          "root_bead_id",
+          "continuation_group"
         ]
       }
     },


### PR DESCRIPTION
## Why

Two claim-time defects every worker on a second-provider role agent hit on citadel (2026-09-09, papercuts pc_b7a878218aac, pc_3be95454d9fe, pc_573e5bf01dfe, pc_33b927b6c054, pc_e268966189e7, pc_bbf5bb62f1d0; bead gp-n8v2):

1. **`gc hook --claim --drain-ack --json` omitted `root_bead_id` and `continuation_group`** for a directly routed bead (no workflow root, no group) because both struct fields carried `omitempty`. The worker role contract records both from that line (an empty continuation group is the "hard session boundary, drain and exit" signal), so every worker was left inferring that absence means empty.
2. **`gc.work_branch` was stamped from the bead store dir**, which for a rig-scoped bead is the rig root (on `main`, or whatever a human left checked out). A worker that starts in its own worktree (agent `work_dir`) got the rig root's branch stamped over its real one on every claim. Observed live: a codex role worker on branch `gp-f1rs` in its lane got `gc.work_branch=main` (probe bead gp-f1rs, claim line and metadata quoted in the companion PR).

## What

- `cmd/gc/cmd_hook_claim.go`: drop `omitempty` on `RootBeadID` / `ContinuationGroup` (a drain line carries them as empty strings too; the schema types them as strings and never required them for `action=drain`). Add `hookClaimWorkBranchDir`: resolve the work branch from `GC_DIR` (exported by the runtime for every managed session via `SyncWorkDirEnv`) when it names an existing directory, else the store dir as before.
- `schemas/hook/result.schema.json`: `action=work` requires both lifecycle keys; descriptions say what empty means.
- Tests: `hook_claim_lifecycle_keys_test.go` (a work result with no root/group carries both keys as `""` and validates; stripping either is a schema violation; a drain result still validates) and `hook_claim_work_branch_dir_test.go` (table over `GC_DIR`: set, unset, empty, missing directory, regular file, symlinked directory, relative path, duplicate entries; plus an end-to-end row asserting the stamped `gc.work_branch` is the lane's branch, not the store dir's).

## Verification

- `go vet ./cmd/gc` clean; `go test ./cmd/gc -run 'TestDoHookClaim|TestHookClaim|Drain|Claim' -count=1` ok on this branch (`main` base aafac7d2e) and on the fork twin (`integration` base 10bd45ead).
- Codex gate (`codex exec --sandbox read-only`) on this diff: **VERDICT: CLEAN**, two MINOR findings on test coverage (the fake resolver returned a constant branch, so the table proved directory selection only; missing file/symlink/relative/duplicate rows). Both addressed in the last commit (test-only).
- No other producer or consumer of the two JSON keys in the tree (`git grep root_bead_id continuation_group` outside the hook claim files hits only the `gc.root_bead_id` bead metadata key, a different surface).

## Companion

gascity-packs: gastownhall/gascity-packs#413 (review copy aphexcx/gascity-packs-prs#31; the role prompt's Workspace section and claim-key tolerance, plus the `pre_start` worktree script that puts the worker in its own lane; that lane is what exposes defect 2). Fork twin of this PR: aphexcx/gascity branch `fix/gp-n8v2-hook-claim-fields` on `integration` (same patch; citadel installs from there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
