### PR TITLE
fix(reconciler): do not fresh-cycle a session for advancing to the next step of its own molecule

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -98,6 +98,7 @@ func buildAwakeInputFromReconciler(
 			blocked := wb.Status == "in_progress" && wb.IsBlocked != nil && *wb.IsBlocked
 			input.WorkBeads = append(input.WorkBeads, AwakeWorkBead{
 				ID: wb.ID, Assignee: a, Status: wb.Status, Ready: ready, Blocked: blocked,
+				WorkflowRoot: awakeWorkflowRoot(wb),
 			})
 		}
 	}
@@ -144,6 +145,7 @@ func buildAwakeInputFromReconciler(
 				strings.TrimSpace(info.ResetCommittedAt) != "",
 			CurrentlyProcessingBeadID: strings.TrimSpace(info.CurrentlyProcessingBeadID),
 			PostCreateProtected:       poolSessionWithinPostCreateProtection(info, clk),
+			CurrentlyProcessingWorkflowRoot: strings.TrimSpace(info.CurrentlyProcessingWorkflowRoot),
 		}
 		bead.HeldUntil = lifecycle.HeldUntil
 		bead.QuarantinedUntil = lifecycle.QuarantinedUntil
@@ -294,3 +296,4 @@ func parseSleepDuration(s string) time.Duration {
 	}
 	return d
 }
+

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -976,3 +976,18 @@ func TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes(t *testing.T) 
 		t.Errorf("wake reason = %q, want named-always", got.Reason)
 	}
 }
+
+func TestAwakeWorkflowRoot(t *testing.T) {
+	step := beads.Bead{ID: "s-1", Metadata: map[string]string{"gc.root_bead_id": "root-1", "gc.step_ref": "mol-x.a"}}
+	root := beads.Bead{ID: "root-1", Metadata: map[string]string{"gc.input_convoy_id": "cv-1"}}
+	solo := beads.Bead{ID: "wb-1"}
+	if got := awakeWorkflowRoot(step); got != "root-1" {
+		t.Fatalf("step root = %q, want root-1", got)
+	}
+	if got := awakeWorkflowRoot(root); got != "root-1" {
+		t.Fatalf("workflow root bead root = %q, want its own id", got)
+	}
+	if got := awakeWorkflowRoot(solo); got != "" {
+		t.Fatalf("standalone root = %q, want empty", got)
+	}
+}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -78,6 +78,9 @@ type AwakeSessionBead struct {
 	ContinuationResetPending  bool      // continuation_reset_pending metadata is set
 	CurrentlyProcessingBeadID string    // work bead the session is currently processing
 	PostCreateProtected       bool      // fresh successful pool create; preferred for scaled slots during grace
+	// CurrentlyProcessingWorkflowRoot is the workflow root recorded alongside
+	// CurrentlyProcessingBeadID (empty for legacy sessions and standalone beads).
+	CurrentlyProcessingWorkflowRoot string
 }
 
 // AwakeWorkBead represents a work bead with an assignee.
@@ -97,6 +100,9 @@ type AwakeWorkBead struct {
 	// releases the session's scale slot, which can wake a different session
 	// as scaled:demand.
 	Blocked bool
+	// WorkflowRoot identifies the molecule this bead is a step of (gc.root_bead_id,
+	// or the bead's own ID when it is a workflow root). Empty for standalone work.
+	WorkflowRoot string
 }
 
 // AwakeDecision is the output for a single session.
@@ -109,6 +115,9 @@ type AwakeDecision struct {
 	// use it to persist currently_processing_bead_id and to detect when an
 	// alive session has been reassigned to a different bead.
 	AssignedWorkBeadID string
+	// AssignedWorkflowRoot is the workflow root of AssignedWorkBeadID (empty for
+	// standalone work); persisted next to it so the next tick compares roots.
+	AssignedWorkflowRoot string
 	// RequiresFreshCycle is true when an alive session's recorded
 	// currently_processing_bead_id differs from AssignedWorkBeadID. The
 	// reconciler combines this with wake_mode=fresh to trigger a
@@ -303,7 +312,8 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// to the first matching work bead and flag the divergence — the
 	// reconciler reads this to decide whether to cycle the conversation for
 	// wake_mode=fresh.
-	assignedAnchor := make(map[string]string) // sessionName → matched work bead ID
+	assignedAnchor := make(map[string]string)     // sessionName → matched work bead ID
+	assignedAnchorRoot := make(map[string]string) // sessionName → workflow root of that anchor
 	for _, bead := range input.SessionBeads {
 		if bead.State == "closed" {
 			continue
@@ -312,11 +322,15 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			continue
 		}
 		var (
-			fallback   string
-			haveExact  bool
-			anchorBead string
-			recorded   = bead.CurrentlyProcessingBeadID
-			matchedAny = false
+			fallback     string
+			fallbackRoot string
+			siblingFound bool
+			haveExact    bool
+			anchorBead   string
+			anchorRoot   string
+			recorded     = bead.CurrentlyProcessingBeadID
+			recordedRoot = bead.CurrentlyProcessingWorkflowRoot
+			matchedAny   = false
 		)
 		for _, wb := range input.WorkBeads {
 			assignee := strings.TrimSpace(wb.Assignee)
@@ -329,11 +343,22 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			matchedAny = true
 			if recorded != "" && wb.ID == recorded {
 				anchorBead = wb.ID
+				anchorRoot = wb.WorkflowRoot
 				haveExact = true
 				break
 			}
+			// Prefer a sibling of the recorded bead (same workflow root) as the
+			// fallback anchor: a session that just closed one molecule step is
+			// still on that molecule, and its next step is the real anchor.
+			if recordedRoot != "" && wb.WorkflowRoot == recordedRoot && !siblingFound {
+				fallback = wb.ID
+				fallbackRoot = wb.WorkflowRoot
+				siblingFound = true
+				continue
+			}
 			if fallback == "" {
 				fallback = wb.ID
+				fallbackRoot = wb.WorkflowRoot
 			}
 		}
 		if !matchedAny {
@@ -341,9 +366,11 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		if !haveExact {
 			anchorBead = fallback
+			anchorRoot = fallbackRoot
 		}
 		desired[bead.SessionName] = "assigned-work"
 		assignedAnchor[bead.SessionName] = anchorBead
+		assignedAnchorRoot[bead.SessionName] = anchorRoot
 	}
 
 	// Min-active-sessions wake: keep min_active_sessions pool sessions warm
@@ -414,8 +441,19 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		if hasAssignedWork {
 			decision.AssignedWorkBeadID = anchor
+			decision.AssignedWorkflowRoot = assignedAnchorRoot[name]
+			// A fresh cycle means "this session was pointed at different work"
+			// (#1893). A different anchor bead inside the SAME workflow root is
+			// not that: it is the session advancing from one molecule step to the
+			// next, which must never restart the conversation. Roots are compared
+			// only when the recorded root is known; a legacy session without one
+			// keeps the id-only rule.
 			if bead.CurrentlyProcessingBeadID != "" && anchor != bead.CurrentlyProcessingBeadID {
-				decision.RequiresFreshCycle = true
+				sameWorkflow := bead.CurrentlyProcessingWorkflowRoot != "" &&
+					decision.AssignedWorkflowRoot == bead.CurrentlyProcessingWorkflowRoot
+				if !sameWorkflow {
+					decision.RequiresFreshCycle = true
+				}
 			}
 		}
 

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -2482,3 +2482,82 @@ func TestAssignedWork_NoRecordedCurrent_FirstMatchAnchors(t *testing.T) {
 		t.Fatal("RequiresFreshCycle = true, want false — no recorded current means no divergence")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Fresh-cycle divergence compares workflow roots, not anchor bead ids
+// (sys-by2243.118): advancing to the next step of the same molecule is not a
+// reassignment; being pointed at another workflow or a standalone bead is.
+// ---------------------------------------------------------------------------
+
+func freshCycleInput(recordedBead, recordedRoot string, work []AwakeWorkBead) AwakeInput {
+	return AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/hudson"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "gc-1", SessionName: "hudson-gc-1", Template: "rig/hudson",
+			State:                           "active",
+			CurrentlyProcessingBeadID:       recordedBead,
+			CurrentlyProcessingWorkflowRoot: recordedRoot,
+		}},
+		WorkBeads:       work,
+		RunningSessions: map[string]bool{"hudson-gc-1": true},
+		Now:             now,
+	}
+}
+
+func TestAssignedWork_NextStepOfSameWorkflow_NoFreshCycle(t *testing.T) {
+	// Step 1 (recorded) was closed, so it is no longer among the assigned work;
+	// steps 2 and 3 of the same molecule remain assigned to the session.
+	d := ComputeAwakeSet(freshCycleInput("step-1", "root-A", []AwakeWorkBead{
+		{ID: "step-2", Assignee: "hudson-gc-1", Status: "open", Ready: true, WorkflowRoot: "root-A"},
+		{ID: "step-3", Assignee: "hudson-gc-1", Status: "open", Ready: true, WorkflowRoot: "root-A"},
+	}))["hudson-gc-1"]
+	if d.AssignedWorkBeadID != "step-2" || d.AssignedWorkflowRoot != "root-A" {
+		t.Fatalf("anchor = %q root %q, want step-2 / root-A", d.AssignedWorkBeadID, d.AssignedWorkflowRoot)
+	}
+	if d.RequiresFreshCycle {
+		t.Fatal("RequiresFreshCycle = true, want false — next step of the same workflow is not a reassignment")
+	}
+}
+
+func TestAssignedWork_PrefersSiblingStepOverUnrelatedCandidate(t *testing.T) {
+	d := ComputeAwakeSet(freshCycleInput("step-1", "root-A", []AwakeWorkBead{
+		{ID: "other", Assignee: "hudson-gc-1", Status: "in_progress", WorkflowRoot: "root-B"},
+		{ID: "step-2", Assignee: "hudson-gc-1", Status: "open", Ready: true, WorkflowRoot: "root-A"},
+	}))["hudson-gc-1"]
+	if d.AssignedWorkBeadID != "step-2" {
+		t.Fatalf("anchor = %q, want the sibling step-2 over the first candidate", d.AssignedWorkBeadID)
+	}
+	if d.RequiresFreshCycle {
+		t.Fatal("RequiresFreshCycle = true, want false")
+	}
+}
+
+func TestAssignedWork_DifferentWorkflow_EmitsFreshCycle(t *testing.T) {
+	d := ComputeAwakeSet(freshCycleInput("step-1", "root-A", []AwakeWorkBead{
+		{ID: "step-9", Assignee: "hudson-gc-1", Status: "open", Ready: true, WorkflowRoot: "root-B"},
+	}))["hudson-gc-1"]
+	if !d.RequiresFreshCycle || d.AssignedWorkBeadID != "step-9" {
+		t.Fatalf("decision = %+v, want fresh cycle onto step-9 (different workflow)", d)
+	}
+}
+
+func TestAssignedWork_StandaloneReassign_EmitsFreshCycle(t *testing.T) {
+	// The #1893 case: an operator points the alive session at a standalone bead.
+	d := ComputeAwakeSet(freshCycleInput("step-1", "root-A", []AwakeWorkBead{
+		{ID: "wb-solo", Assignee: "hudson-gc-1", Status: "in_progress"},
+	}))["hudson-gc-1"]
+	if !d.RequiresFreshCycle || d.AssignedWorkBeadID != "wb-solo" || d.AssignedWorkflowRoot != "" {
+		t.Fatalf("decision = %+v, want fresh cycle onto standalone wb-solo", d)
+	}
+}
+
+func TestAssignedWork_LegacySessionWithoutRecordedRoot_KeepsIDRule(t *testing.T) {
+	// A session that recorded an anchor before roots existed keeps the id-only
+	// divergence until its next wake stamps a root.
+	d := ComputeAwakeSet(freshCycleInput("step-1", "", []AwakeWorkBead{
+		{ID: "step-2", Assignee: "hudson-gc-1", Status: "open", Ready: true, WorkflowRoot: "root-A"},
+	}))["hudson-gc-1"]
+	if !d.RequiresFreshCycle {
+		t.Fatal("RequiresFreshCycle = false, want true — no recorded root to compare")
+	}
+}

--- a/cmd/gc/compute_awake_workflow_root.go
+++ b/cmd/gc/compute_awake_workflow_root.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// awakeWorkflowRoot returns the molecule a work bead belongs to: a step carries
+// gc.root_bead_id; a workflow root (the bead that carries gc.input_convoy_id)
+// is its own root. Standalone beads have no root.
+func awakeWorkflowRoot(wb beads.Bead) string {
+	if root := strings.TrimSpace(wb.Metadata[beadmeta.RootBeadIDMetadataKey]); root != "" {
+		return root
+	}
+	if strings.TrimSpace(wb.Metadata[beadmeta.InputConvoyIDMetadataKey]) != "" {
+		return wb.ID
+	}
+	return ""
+}

--- a/cmd/gc/session_bead_cycle.go
+++ b/cmd/gc/session_bead_cycle.go
@@ -24,7 +24,7 @@ import (
 // the session id and the currently-processing bead off the caller's coherent
 // typed Info (Info.ID / Info.CurrentlyProcessingBeadID, both verbatim raw
 // mirrors); the fold the caller applies keeps the snapshot in step.
-func recordCurrentBeadIDOnWake(info sessionpkg.Info, sessFront *sessionpkg.Store, beadID string, stderr io.Writer) sessionpkg.MetadataPatch {
+func recordCurrentBeadIDOnWake(info sessionpkg.Info, sessFront *sessionpkg.Store, beadID, workflowRoot string, stderr io.Writer) sessionpkg.MetadataPatch {
 	if strings.TrimSpace(info.ID) == "" || sessFront == nil {
 		return nil
 	}
@@ -32,16 +32,17 @@ func recordCurrentBeadIDOnWake(info sessionpkg.Info, sessFront *sessionpkg.Store
 	if beadID == "" {
 		return nil
 	}
-	if info.CurrentlyProcessingBeadID == beadID {
+	workflowRoot = strings.TrimSpace(workflowRoot)
+	if info.CurrentlyProcessingBeadID == beadID && info.CurrentlyProcessingWorkflowRoot == workflowRoot {
 		return nil
 	}
-	if err := sessFront.RecordCurrentBead(info.ID, beadID); err != nil {
+	if err := sessFront.RecordCurrentBeadWithRoot(info.ID, beadID, workflowRoot); err != nil {
 		if stderr != nil {
 			fmt.Fprintf(stderr, "session reconciler: recording %s for %s: %v\n", sessionpkg.CurrentBeadIDKey, info.SessionNameMetadata, err) //nolint:errcheck
 		}
 		return nil
 	}
-	return sessionpkg.MetadataPatch{sessionpkg.CurrentBeadIDKey: beadID}
+	return sessionpkg.MetadataPatch{sessionpkg.CurrentBeadIDKey: beadID, sessionpkg.CurrentWorkflowRootKey: workflowRoot}
 }
 
 // cycleAliveSessionForFreshReassign tears down a live wake_mode=fresh
@@ -70,6 +71,7 @@ func cycleAliveSessionForFreshReassign(
 	cb *sessionCircuitBreaker,
 	name string,
 	newBeadID string,
+	newWorkflowRoot string,
 	now time.Time,
 	stdout, stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
@@ -102,6 +104,7 @@ func cycleAliveSessionForFreshReassign(
 		batch["session_key"] = ""
 	}
 	batch[sessionpkg.CurrentBeadIDKey] = newBeadID
+	batch[sessionpkg.CurrentWorkflowRootKey] = strings.TrimSpace(newWorkflowRoot)
 	if err := sessionFrontDoor(store).ApplyPatch(info.ID, batch); err != nil {
 		if stderr != nil {
 			fmt.Fprintf(stderr, "session reconciler: recording fresh-cycle handoff for %s: %v\n", name, err) //nolint:errcheck

--- a/cmd/gc/session_classifier_info_equiv_test.go
+++ b/cmd/gc/session_classifier_info_equiv_test.go
@@ -1069,6 +1069,10 @@ func TestSessionClassifierInfoEquivalence(t *testing.T) {
 			func(b beads.Bead) string { return b.Metadata[session.CurrentBeadIDKey] },
 			func(i session.Info) string { return i.CurrentlyProcessingBeadID },
 		},
+		"sessionCurrentlyProcessingWorkflowRoot": {
+			func(b beads.Bead) string { return b.Metadata[session.CurrentWorkflowRootKey] },
+			func(i session.Info) string { return i.CurrentlyProcessingWorkflowRoot },
+		},
 		"sessionCoreHashBreakdown": {
 			func(b beads.Bead) string { return b.Metadata["core_hash_breakdown"] },
 			func(i session.Info) string { return i.CoreHashBreakdown },

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -3820,7 +3820,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					"should_wake": shouldWake,
 				})
 			}
-			if fold := recordCurrentBeadIDOnWake(target.info, sessFront, decision.AssignedWorkBeadID, stderr); fold != nil {
+			if fold := recordCurrentBeadIDOnWake(target.info, sessFront, decision.AssignedWorkBeadID, decision.AssignedWorkflowRoot, stderr); fold != nil {
 				tick.apply(target.info.ID, fold)
 			}
 			// Capture-at-append: the recordCurrentBeadIDOnWake fold above lands on
@@ -3846,7 +3846,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// See #1893 (controller: alive on_demand session ignores
 			// bd update --assignee).
 			if decision.RequiresFreshCycle && info.WakeMode == "fresh" {
-				if ran, fold := cycleAliveSessionForFreshReassign(infoByID[target.info.ID], target.tp, sp, store, cfg, cb, name, decision.AssignedWorkBeadID, clk.Now(), stdout, stderr, trace); ran {
+				if ran, fold := cycleAliveSessionForFreshReassign(infoByID[target.info.ID], target.tp, sp, store, cfg, cb, name, decision.AssignedWorkBeadID, decision.AssignedWorkflowRoot, clk.Now(), stdout, stderr, trace); ran {
 					if fold != nil {
 						tick.apply(target.info.ID, fold)
 					}
@@ -3857,7 +3857,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// check has a baseline. Backfills legacy sessions that were
 			// already alive before this metadata existed and refreshes the
 			// record after the agent picks up its next bead in resume mode.
-			if fold := recordCurrentBeadIDOnWake(target.info, sessFront, decision.AssignedWorkBeadID, stderr); fold != nil {
+			if fold := recordCurrentBeadIDOnWake(target.info, sessFront, decision.AssignedWorkBeadID, decision.AssignedWorkflowRoot, stderr); fold != nil {
 				tick.apply(target.info.ID, fold)
 			}
 			// Session is correctly awake. Cancel any non-drift drain

--- a/cmd/gc/session_reconciler_bead_reassign_test.go
+++ b/cmd/gc/session_reconciler_bead_reassign_test.go
@@ -253,3 +253,66 @@ func reconcileSessionBeadsWithAssignedWork(env *restartRequestTestEnv, sessions 
 		&env.stderr,
 	)
 }
+
+// TestReconcileSessionBeads_AliveFreshModeNextStepDoesNotCycle pins
+// sys-by2243.118: a wake_mode=fresh session that closes one step of a
+// molecule and moves to the next step of the SAME molecule is advancing, not
+// being reassigned. The reconciler must keep the process alive and re-anchor
+// on the next step, recording the shared workflow root.
+func TestReconcileSessionBeads_AliveFreshModeNextStepDoesNotCycle(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "witness", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "witness", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "witness")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "witness",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:          "true",
+		namedSessionIdentityMetadata:     "witness",
+		namedSessionModeMetadata:         "on_demand",
+		"template":                       "witness",
+		"state":                          "active",
+		"wake_mode":                      "fresh",
+		"session_key":                    "conversation-A",
+		sessionpkg.CurrentBeadIDKey:      "step-1",
+		sessionpkg.CurrentWorkflowRootKey: "root-1",
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	// step-1 was closed by the session; steps 2 and 3 of the same molecule
+	// stay assigned to it.
+	step2 := beads.Bead{ID: "step-2", Title: "Verify pre-flights", Type: "task", Status: "in_progress", Assignee: "witness", Metadata: map[string]string{"gc.root_bead_id": "root-1", "gc.step_ref": "mol-x.preflight"}}
+	step3 := beads.Bead{ID: "step-3", Title: "Implement", Type: "task", Status: "open", Assignee: "witness", Metadata: map[string]string{"gc.root_bead_id": "root-1", "gc.step_ref": "mol-x.implement"}}
+
+	reconcileSessionBeadsWithAssignedWork(env, []beads.Bead{session}, []beads.Bead{step2, step3})
+
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatal("session was cycled on a step transition within the same workflow")
+	}
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata[sessionpkg.CurrentBeadIDKey] != "step-2" {
+		t.Fatalf("%s = %q, want step-2 (re-anchored on the next step)", sessionpkg.CurrentBeadIDKey, got.Metadata[sessionpkg.CurrentBeadIDKey])
+	}
+	if got.Metadata[sessionpkg.CurrentWorkflowRootKey] != "root-1" {
+		t.Fatalf("%s = %q, want root-1", sessionpkg.CurrentWorkflowRootKey, got.Metadata[sessionpkg.CurrentWorkflowRootKey])
+	}
+	if got.Metadata["session_key"] != "conversation-A" {
+		t.Fatalf("session_key = %q, want conversation-A preserved", got.Metadata["session_key"])
+	}
+}

--- a/internal/session/info_apply_patch_test.go
+++ b/internal/session/info_apply_patch_test.go
@@ -39,7 +39,7 @@ var allProjectedMetadataKeys = []string{
 	ResetCommittedAtKey,
 	"generation", "started_config_hash", "pin_awake", "held_until", "wait_hold",
 	"churn_count", "wake_mode", "sleep_intent", "instance_token", "detached_at",
-	CurrentBeadIDKey, "core_hash_breakdown", "started_provision_hash",
+	CurrentBeadIDKey, CurrentWorkflowRootKey, "core_hash_breakdown", "started_provision_hash",
 	"started_launch_hash", "started_live_hash", "live_hash", "startup_dialog_verified",
 	"config_drift_deferred_at",
 	"config_drift_deferred_key", "attached_config_drift_deferred_at",

--- a/internal/session/info_codec.go
+++ b/internal/session/info_codec.go
@@ -172,6 +172,7 @@ var infoKeyCodec = []infoKeySpec{
 	{"instance_token", func(i *Info, v string) { i.InstanceToken = v }},
 	{"detached_at", func(i *Info, v string) { i.DetachedAt = v }},
 	{CurrentBeadIDKey, func(i *Info, v string) { i.CurrentlyProcessingBeadID = v }},
+	{CurrentWorkflowRootKey, func(i *Info, v string) { i.CurrentlyProcessingWorkflowRoot = v }},
 	{"core_hash_breakdown", func(i *Info, v string) { i.CoreHashBreakdown = v }},
 	{"started_provision_hash", func(i *Info, v string) { i.StartedProvisionHash = v }},
 	{"started_launch_hash", func(i *Info, v string) { i.StartedLaunchHash = v }},

--- a/internal/session/info_codec_test.go
+++ b/internal/session/info_codec_test.go
@@ -126,6 +126,7 @@ func infoFromPersistedBeadFrozen(b beads.Bead) Info {
 		InstanceToken:                  b.Metadata["instance_token"],
 		DetachedAt:                     b.Metadata["detached_at"],
 		CurrentlyProcessingBeadID:      b.Metadata[CurrentBeadIDKey],
+		CurrentlyProcessingWorkflowRoot: b.Metadata[CurrentWorkflowRootKey],
 		CoreHashBreakdown:              b.Metadata["core_hash_breakdown"],
 		StartedProvisionHash:           b.Metadata["started_provision_hash"],
 		StartedLaunchHash:              b.Metadata["started_launch_hash"],

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -81,6 +81,13 @@ func PromptHash(prompt string) string {
 // cycle under wake_mode=fresh.
 const CurrentBeadIDKey = "currently_processing_bead_id"
 
+// CurrentWorkflowRootKey records the workflow root (gc.root_bead_id, or the
+// bead itself when it carries gc.input_convoy_id) of the bead named by
+// CurrentBeadIDKey. The reconciler compares roots, not bead ids, before
+// cycling a wake_mode=fresh session: advancing from one step of a molecule to
+// the next changes the anchor bead but not the work item.
+const CurrentWorkflowRootKey = "currently_processing_workflow_root"
+
 var freshWakeConversationResetKeys = []string{
 	"session_key",
 	"started_config_hash",

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -375,6 +375,9 @@ type Info struct {
 	// (CurrentBeadIDKey). compute_awake_bridge maps it (trimmed) onto
 	// LifecycleInput.CurrentlyProcessingBeadID.
 	CurrentlyProcessingBeadID string // currently_processing_bead_id (raw)
+	// CurrentlyProcessingWorkflowRoot is the RAW currently_processing_workflow_root
+	// metadata (CurrentWorkflowRootKey): the workflow root of the bead above.
+	CurrentlyProcessingWorkflowRoot string // currently_processing_workflow_root (raw)
 	// CoreHashBreakdown is the RAW core_hash_breakdown metadata (a JSON blob). The
 	// config-drift path feeds it verbatim to runtime.CoreFingerprintDriftFieldsFromJSON
 	// / LogCoreFingerprintDrift for the drift trace payload; the mirror keeps the

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -242,6 +242,12 @@ func (s *Store) CurrentClaimBeadID(id string) (string, error) {
 	return strings.TrimSpace(b.Metadata[beadmeta.CurrentClaimBeadIDMetadataKey]), nil
 }
 
+// RecordCurrentBeadWithRoot records the anchor bead and its workflow root in
+// one patch, so a reconciler tick never observes the id without its root.
+func (s *Store) RecordCurrentBeadWithRoot(id, beadID, workflowRoot string) error {
+	return s.ApplyPatch(id, MetadataPatch{CurrentBeadIDKey: beadID, CurrentWorkflowRootKey: workflowRoot})
+}
+
 // CloseWithoutReason closes the session bead identified by id without stamping
 // terminal close metadata. It is the front door for the raw store.Close(id)
 // call in closeBead, which stamps ClosePatch via setMetaBatch separately and


### PR DESCRIPTION
No upstream issue exists for this; the closest prior art is #1893 (the contract this change preserves) and #5474 (claim ordering, not the cycle predicate).

## Summary

On a `wake_mode = "fresh"` lane running a multi-step molecule whose step beads are all assigned to the session (`mol-polecat-work`, 7 steps), closing the current step kills the session that closed it. The supervisor logs it as a reassignment:

```
Cycled fresh-mode session 'hudson-gc-43y9g0' for bead reassign: sys-gbb3j9 -> sys-165oos
```

`sys-gbb3j9` and `sys-165oos` are consecutive steps of the same molecule ("Set up worktree and feature branch" → "Verify pre-flights pass on base branch"). The worker was five minutes into real work, had its branch up, and was recreated with an empty conversation. Over one supervisor log on the reporter's rig: 158 such cycles, 114 of them on the one pool lane whose steps take minutes each (a local 27B model), so a reconciler tick reliably lands inside the window. A 7-step molecule offers up to six kills per bead, each landing when the worker has the most context to lose. Workers that never close their steps survive, but then hold open step beads forever and the idle reaper cannot fire; there was no compliant path.

## Root cause

`cmd/gc/compute_awake_set.go` builds `assignedAnchor[session]` from `currently_processing_bead_id`. A closed bead has no awake demand, so once the session closes its current step the exact match cannot be found and the fallback takes the first other assigned open bead, which is the next sibling step. Then:

```go
if bead.CurrentlyProcessingBeadID != "" && anchor != bead.CurrentlyProcessingBeadID {
    decision.RequiresFreshCycle = true
}
```

and `session_reconciler.go` honours `RequiresFreshCycle` for any alive fresh-mode session via `cycleAliveSessionForFreshReassign`. The predicate is "my anchor id changed"; it cannot tell an operator pointing the session at different work (#1893, the case it was written for) from the session advancing through the work it already has.

## Fix

Compare the workflow root, not the bead id. No store lookup on the hot path.

- `internal/session`: new session-bead key `currently_processing_workflow_root` (`CurrentWorkflowRootKey`), decoded onto `Info`, written by `RecordCurrentBeadWithRoot` in the same single patch as the bead id.
- `cmd/gc/compute_awake_workflow_root.go`: `awakeWorkflowRoot(bead)` = `gc.root_bead_id`, or the bead itself when it carries `gc.input_convoy_id`, else `""`. The bridge fills `AwakeWorkBead.WorkflowRoot` from metadata.
- `ComputeAwakeSet`: when the recorded bead is gone, the fallback anchor prefers a sibling step of the recorded root; `RequiresFreshCycle` is set only when the new anchor's root differs from the recorded root. A standalone bead (root `""`) or a different molecule still cycles, so the #1893 behaviour is unchanged. A legacy session with no recorded root keeps the id-only rule until its next wake stamps one (self-healing after one tick).
- `cycleAliveSessionForFreshReassign` and both `recordCurrentBeadIDOnWake` sites stamp the root alongside the id.

## Tests

- `TestAssignedWork_NextStepOfSameWorkflow_NoFreshCycle`, `TestAssignedWork_PrefersSiblingStepOverUnrelatedCandidate`, `TestAssignedWork_DifferentWorkflow_EmitsFreshCycle`, `TestAssignedWork_StandaloneReassign_EmitsFreshCycle`, `TestAssignedWork_LegacySessionWithoutRecordedRoot_KeepsIDRule` (ComputeAwakeSet)
- `TestAwakeWorkflowRoot` (bridge), codec/patch/classifier registries extended for the new key
- `TestReconcileSessionBeads_AliveFreshModeNextStepDoesNotCycle`: end-to-end, fresh-mode session recorded on step-1/root-1, step-1 closed, step-2 in_progress + step-3 open with the same root → process still running, anchor moves to step-2, root unchanged, session key preserved.

Family run (`./cmd/gc ./internal/session ./internal/storebinding`) green on this branch rebased onto `main` at bf787a119.

## Validation

Dogfooded on the reporter's rig (v1.4.0 lineage + cherry-picks) since 2026-09-09T04:04Z, then proven by an induced drill on the affected lane because normal traffic there now bulk-closes steps at submit and never moves the anchor:

- Positive: with a live session anchored on step 1 (`currently_processing_bead_id=sys-bhm18x`, root `sys-e5fywz`), closing that step by hand moved the anchor to the sibling step (`sys-xa05uf`), same root, same session key, process untouched, 0 `Cycled fresh-mode` lines. Under the bug this exact transition is the kill above. The worker went on to deliver its branch.
- Negative control (same predicate, new branch): a live session with a recorded root, all of its steps closed, and a rootless bead assigned to it produced exactly one `Cycled fresh-mode session 'hudson-gc-0x89xe' for bead reassign: sys-3qhjaa -> sys-by2243.118.4` line. Cross-workflow reassignment still cycles.

One note for anyone measuring this: the cycle only applies to alive sessions (`shouldWake && target.alive`), so a lane whose process exits at submit will never show the bug at submit time; the kill happens on incremental step closes mid-molecule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfE7RRfhxJdMC5aghLe8bg
