### PR TITLE
fix(nudge): let a seat's successor claim queued nudges fenced to its retired session

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1683,6 +1683,21 @@ func nudgeDispatcherIsSupervisor(cfg *config.City) bool {
 	return cfg.Daemon.NudgeDispatcherMode() == "supervisor"
 }
 
+// splitQueuedNudgesForTarget partitions claimed nudges into deliverable items
+// and rejects. Items whose fence (SessionID / ContinuationEpoch) does not match
+// the current target's fence are re-fenced in memory to the target's fence and
+// returned as deliverable when the target itself is resolved to a live session
+// bead — the caller already validated that this seat owns the item at claim
+// time (matchesQueueAgent), so a stale fence just marks the item as queued for
+// a prior incarnation of the same seat. Delivering it there is what the seat's
+// nudges were queued for; dead-lettering the whole queue every time a session
+// respawns (fresh wake after a failed spawn bumps ContinuationEpoch; a re-
+// materialization can mint a new SessionID) is the bug this coalesces around
+// (ga-bow, thunderfartcity:gp-u63s).
+//
+// A target with no resolved session identity (sessionID == "") cannot be
+// re-fenced against and still rejects, matching the pre-existing invariant
+// that fenced items are not delivered to an unresolved target.
 func splitQueuedNudgesForTarget(target nudgeTarget, items []queuedNudge) ([]queuedNudge, []queuedNudge) {
 	if len(items) == 0 {
 		return nil, nil
@@ -1690,10 +1705,16 @@ func splitQueuedNudgesForTarget(target nudgeTarget, items []queuedNudge) ([]queu
 	var deliverable []queuedNudge
 	var rejected []queuedNudge
 	for _, item := range items {
-		if !queuedNudgeMatchesTargetFence(target, item) {
+		if queuedNudgeMatchesTargetFence(target, item) {
+			deliverable = append(deliverable, item)
+			continue
+		}
+		if target.sessionID == "" {
 			rejected = append(rejected, item)
 			continue
 		}
+		item.SessionID = target.sessionID
+		item.ContinuationEpoch = target.continuationEpoch
 		deliverable = append(deliverable, item)
 	}
 	return deliverable, rejected

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1967,6 +1967,21 @@ func (m *nudgeMaintenanceStore) frontForState(state *nudgeQueueState) *nudgequeu
 	return m.front
 }
 
+// sessionRetired reports whether the session bead id is closed or gone. A
+// lookup failure other than not-found reads as live, so the item stays pending
+// instead of being claimed on a guess.
+func (m *nudgeMaintenanceStore) sessionRetired(id string) bool {
+	store := m.ensureOpen()
+	if store.Store == nil {
+		return false
+	}
+	b, err := store.Get(id)
+	if err != nil {
+		return errors.Is(err, beads.ErrNotFound)
+	}
+	return b.Status == "closed"
+}
+
 // ensureOpen opens the underlying store exactly once (idempotent) and returns
 // it. ack uses it directly to stamp terminal beads once it has confirmed
 // terminal items to terminalize.
@@ -1997,13 +2012,50 @@ func nudgeQueueHasWork(state *nudgeQueueState) bool {
 	return len(state.Pending) > 0 || len(state.InFlight) > 0 || len(state.Dead) > 0
 }
 
+// queuedNudgeClaimableAsSuccessor reports whether target may claim an item
+// queued for an earlier session of the same seat: the item's fenced session
+// bead is closed or gone, so the successor is the only runtime left that can
+// act on it. Without this an item fenced to a recycled session is never
+// claimed, never attempted, and dies at the TTL with last_attempt_at unset
+// (58 of 67 pending items on one city were in that state, sys-g999a).
+// splitQueuedNudgesForTarget then re-fences the claimed item onto target.
+// sessionRetired is consulted only for items the exact-fence check excluded.
+func queuedNudgeClaimableAsSuccessor(target nudgeTarget, item queuedNudge, sessionRetired func(string) bool) bool {
+	if item.SessionID == "" || target.sessionID == "" || item.SessionID == target.sessionID {
+		return false
+	}
+	if !target.matchesQueueAgent(item.Agent) {
+		return false
+	}
+	return sessionRetired(item.SessionID)
+}
+
 func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
-	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
-		return queuedNudgeClaimableForTarget(target, item)
+	retired := map[string]bool{}
+	return claimDueQueuedNudgesMatchingWithMaint(cityPath, now, func(item queuedNudge, maint *nudgeMaintenanceStore) bool {
+		if queuedNudgeClaimableForTarget(target, item) {
+			return true
+		}
+		return queuedNudgeClaimableAsSuccessor(target, item, func(id string) bool {
+			if v, ok := retired[id]; ok {
+				return v
+			}
+			retired[id] = maint.sessionRetired(id)
+			return retired[id]
+		})
 	})
 }
 
 func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(queuedNudge) bool) ([]queuedNudge, error) {
+	return claimDueQueuedNudgesMatchingWithMaint(cityPath, now, func(item queuedNudge, _ *nudgeMaintenanceStore) bool {
+		return match(item)
+	})
+}
+
+// claimDueQueuedNudgesMatchingWithMaint is claimDueQueuedNudgesMatching for a
+// matcher that needs the pass's maintenance store (the successor-claim
+// session lookup), so it borrows the handle instead of opening a second one.
+func claimDueQueuedNudgesMatchingWithMaint(cityPath string, now time.Time, match func(queuedNudge, *nudgeMaintenanceStore) bool) ([]queuedNudge, error) {
 	maint := nudgeMaintenanceStore{cityPath: cityPath}
 	defer maint.close() //nolint:errcheck // best-effort
 	var claimed []queuedNudge
@@ -2021,7 +2073,7 @@ func claimDueQueuedNudgesMatching(cityPath string, now time.Time, match func(que
 		}
 		pending := state.Pending[:0]
 		for _, item := range state.Pending {
-			if !match(item) {
+			if !match(item, &maint) {
 				pending = append(pending, item)
 				continue
 			}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -2874,12 +2874,20 @@ func TestTryDeliverQueuedNudgesByPollerReleasesClaimsWhenDeliveryDeclined(t *tes
 	}
 }
 
-func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(t *testing.T) {
+// TestTryDeliverQueuedNudgesByPollerCoalescesStaleFenceOntoLiveIncarnation
+// pins the ga-bow contract: a nudge queued for a prior ContinuationEpoch (or a
+// prior SessionID on the same seat) is coalesced onto the live incarnation
+// rather than dead-lettered when the seat's next incarnation drains. Before
+// this change, a fresh wake bumped the epoch and every queued reminder from
+// the previous conversation was dead-lettered as `queued nudge session fence
+// mismatch` — a whole-queue data loss on every failed-spawn respawn
+// (thunderfartcity:gp-u63s).
+func TestTryDeliverQueuedNudgesByPollerCoalescesStaleFenceOntoLiveIncarnation(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
 	now := time.Now().Add(-1 * time.Minute)
 
-	store := &failingTerminalNudgeStore{MemStore: beads.NewMemStore()}
+	store := beads.NewMemStore()
 	fake := runtime.NewFake()
 	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
 	info, err := mgr.CreateSession(context.Background(), session.CreateOptions{Template: "worker", Title: "Worker", Command: "codex", WorkDir: dir, Provider: "codex", Env: nil, Resume: session.ProviderResume{}, Hints: runtime.Config{WorkDir: dir}, ExtraMeta: map[string]string{"session_origin": "manual"}})
@@ -2892,7 +2900,7 @@ func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(
 	idleSince := time.Now().Add(-10 * time.Second)
 	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
 
-	stale := newQueuedNudgeWithOptions("worker", "stale fenced reminder", "session", now, queuedNudgeOptions{
+	stale := newQueuedNudgeWithOptions("worker", "stale-epoch reminder", "session", now, queuedNudgeOptions{
 		SessionID:         info.ID,
 		ContinuationEpoch: "1",
 	})
@@ -2906,19 +2914,6 @@ func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(
 	if err := enqueueQueuedNudgeWithStore(dir, beads.NudgesStore{Store: store}, fresh); err != nil {
 		t.Fatalf("enqueueQueuedNudgeWithStore(fresh): %v", err)
 	}
-	staleBead, ok, err := nudgeFrontDoor(beads.NudgesStore{Store: store}).Find(stale.ID)
-	if err != nil || !ok {
-		t.Fatalf("nudgeFrontDoor.Find(stale) = %v, ok=%v", err, ok)
-	}
-	// Terminal-marking the stale item's backing bead fails (store flake).
-	// Dead-lettering bookkeeping for stale items must not block delivery
-	// of the fence-matching item.
-	store.failID = staleBead.BeadID
-
-	var warnings bytes.Buffer
-	origWarn := nudgeWarningWriter
-	nudgeWarningWriter = &warnings
-	defer func() { nudgeWarningWriter = origWarn }()
 
 	target := nudgeTarget{
 		cityPath:          dir,
@@ -2935,7 +2930,7 @@ func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(
 		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
 	}
 	if !delivered {
-		t.Fatal("delivered = false, want the fence-matching nudge delivered despite stale-item bead-mark failure")
+		t.Fatal("delivered = false, want both nudges coalesced and delivered to the live incarnation")
 	}
 
 	var nudgeCalls []runtime.Call
@@ -2945,27 +2940,22 @@ func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(
 		}
 	}
 	if len(nudgeCalls) != 1 {
-		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
+		t.Fatalf("nudge calls = %d, want 1 (both items coalesced into one delivery)", len(nudgeCalls))
 	}
 	if !strings.Contains(nudgeCalls[0].Message, "wake up and resume your wisp") {
-		t.Fatalf("nudge message = %q, want fence-matching reminder", nudgeCalls[0].Message)
+		t.Fatalf("nudge message = %q, want the fresh reminder included", nudgeCalls[0].Message)
 	}
-	if strings.Contains(nudgeCalls[0].Message, "stale fenced reminder") {
-		t.Fatalf("nudge message = %q, must not deliver the fence-mismatched reminder", nudgeCalls[0].Message)
+	if !strings.Contains(nudgeCalls[0].Message, "stale-epoch reminder") {
+		t.Fatalf("nudge message = %q, want the stale-epoch reminder coalesced (not dead-lettered)", nudgeCalls[0].Message)
 	}
 
 	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
 	if err != nil {
 		t.Fatalf("listQueuedNudges: %v", err)
 	}
-	if len(pending) != 0 || len(inFlight) != 0 {
-		t.Fatalf("pending/inFlight = %d/%d, want 0/0", len(pending), len(inFlight))
-	}
-	if len(dead) != 1 || dead[0].ID != stale.ID {
-		t.Fatalf("dead = %+v, want exactly the stale fence-mismatched item", dead)
-	}
-	if !strings.Contains(warnings.String(), stale.ID) {
-		t.Fatalf("warnings = %q, want bead-mark failure surfaced for %s", warnings.String(), stale.ID)
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 0/0/0 (both delivered and acked; no fence-mismatch dead-letter)",
+			len(pending), len(inFlight), len(dead))
 	}
 }
 
@@ -3596,11 +3586,46 @@ func TestClaimDueQueuedNudgesForTargetClaimsSameSessionStaleEpoch(t *testing.T) 
 	}
 
 	deliverable, rejected := splitQueuedNudgesForTarget(target, claimed)
-	if len(deliverable) != 0 {
-		t.Fatalf("deliverable = %#v, want none", deliverable)
+	if len(rejected) != 0 {
+		t.Fatalf("rejected = %#v, want stale-epoch nudge re-fenced (not dead-lettered)", rejected)
 	}
-	if len(rejected) != 1 || rejected[0].ID != item.ID {
-		t.Fatalf("rejected = %#v, want stale same-session nudge rejected", rejected)
+	if len(deliverable) != 1 || deliverable[0].ID != item.ID {
+		t.Fatalf("deliverable = %#v, want stale-epoch nudge re-fenced to the live incarnation", deliverable)
+	}
+	if got := deliverable[0].ContinuationEpoch; got != "2" {
+		t.Fatalf("re-fenced ContinuationEpoch = %q, want %q (target's live epoch)", got, "2")
+	}
+	if got := deliverable[0].SessionID; got != "gc-1" {
+		t.Fatalf("re-fenced SessionID = %q, want %q (target's live sessionID)", got, "gc-1")
+	}
+}
+
+// TestSplitQueuedNudgesForTarget_ReFencesStaleSessionIDToLiveTarget pins the
+// same-seat-new-incarnation re-fence: an item pinned to the seat's prior
+// session bead (e.g. after a failed-spawn respawn re-materialized the named
+// session under a new ID) is not dead-lettered; the current target IS the
+// live incarnation for that seat (matchesQueueAgent proved it), so the item
+// is delivered there with its fence coalesced onto the live one. Regression
+// guard for ga-bow (thunderfartcity:gp-u63s).
+func TestSplitQueuedNudgesForTarget_ReFencesStaleSessionIDToLiveTarget(t *testing.T) {
+	items := []queuedNudge{
+		{ID: "n-stale-session", Agent: "worker", SessionID: "gc-old", ContinuationEpoch: "1"},
+	}
+	target := nudgeTarget{
+		agent:             config.Agent{Name: "worker"},
+		sessionID:         "gc-new",
+		continuationEpoch: "1",
+	}
+
+	deliverable, rejected := splitQueuedNudgesForTarget(target, items)
+	if len(rejected) != 0 {
+		t.Fatalf("rejected = %#v, want stale-sessionID nudge re-fenced (not dead-lettered)", rejected)
+	}
+	if len(deliverable) != 1 || deliverable[0].ID != "n-stale-session" {
+		t.Fatalf("deliverable = %#v, want the stale-sessionID nudge re-fenced onto the live target", deliverable)
+	}
+	if got := deliverable[0].SessionID; got != "gc-new" {
+		t.Fatalf("re-fenced SessionID = %q, want %q", got, "gc-new")
 	}
 }
 

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -3534,6 +3534,70 @@ func TestClaimDueQueuedNudgesForTargetLeavesSiblingFencePending(t *testing.T) {
 	}
 }
 
+func TestClaimDueQueuedNudgesForTargetClaimsRetiredSessionFence(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	retired, err := store.Create(beads.Bead{Title: "retired seat", Type: "session"})
+	if err != nil {
+		t.Fatalf("store.Create(retired): %v", err)
+	}
+	if err := store.Close(retired.ID); err != nil {
+		t.Fatalf("store.Close(retired): %v", err)
+	}
+	live, err := store.Create(beads.Bead{Title: "live sibling seat", Type: "session"})
+	if err != nil {
+		t.Fatalf("store.Create(live): %v", err)
+	}
+	now := time.Now().Add(-time.Minute)
+	for _, item := range []queuedNudge{
+		newQueuedNudgeWithOptions("worker", "queued before recycle", "session", now, queuedNudgeOptions{ID: "n-old", SessionID: retired.ID, ContinuationEpoch: "1"}),
+		newQueuedNudgeWithOptions("worker", "session bead gone", "session", now, queuedNudgeOptions{ID: "n-gone", SessionID: "gc-gone", ContinuationEpoch: "1"}),
+		newQueuedNudgeWithOptions("worker", "for a live sibling", "session", now, queuedNudgeOptions{ID: "n-live", SessionID: live.ID, ContinuationEpoch: "1"}),
+		newQueuedNudgeWithOptions("other", "other seat, retired fence", "session", now, queuedNudgeOptions{ID: "n-other", SessionID: retired.ID, ContinuationEpoch: "1"}),
+	} {
+		if err := enqueueQueuedNudge(dir, item); err != nil {
+			t.Fatalf("enqueueQueuedNudge(%s): %v", item.ID, err)
+		}
+	}
+
+	target := nudgeTarget{
+		cityPath:          dir,
+		agent:             config.Agent{Name: "worker"},
+		sessionID:         "gc-new",
+		continuationEpoch: "1",
+	}
+	claimed, err := claimDueQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("claimDueQueuedNudgesForTarget: %v", err)
+	}
+	if got := queuedNudgeIDs(claimed); len(got) != 2 || got[0] != "n-gone" || got[1] != "n-old" {
+		t.Fatalf("claimed IDs = %#v, want [n-gone n-old]", got)
+	}
+	deliverable, rejected := splitQueuedNudgesForTarget(target, claimed)
+	if len(rejected) != 0 || len(deliverable) != 2 {
+		t.Fatalf("deliverable = %d, rejected = %d, want 2/0", len(deliverable), len(rejected))
+	}
+	for _, item := range deliverable {
+		if item.SessionID != "gc-new" {
+			t.Fatalf("%s re-fenced to %q, want gc-new", item.ID, item.SessionID)
+		}
+	}
+
+	for agent, want := range map[string]string{"worker": "n-live", "other": "n-other"} {
+		pending, _, dead, err := listQueuedNudges(dir, agent, time.Now())
+		if err != nil {
+			t.Fatalf("listQueuedNudges(%s): %v", agent, err)
+		}
+		if got := queuedNudgeIDs(pending); len(got) != 1 || got[0] != want {
+			t.Fatalf("pending(%s) = %#v, want [%s]", agent, got, want)
+		}
+		if len(dead) != 0 {
+			t.Fatalf("dead(%s) = %d, want 0", agent, len(dead))
+		}
+	}
+}
+
 func TestClaimDueQueuedNudgesForTargetClaimsHistoricalAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

`queuedNudgeClaimableForTarget` requires `item.SessionID == target.sessionID`. A nudge queued against a session that has since closed is therefore never claimed by the same seat's next session: it is never attempted (`LastAttemptAt` is only stamped in `failedQueuedNudge`, which only runs on claimed items), never dead-lettered, and sits in `pending` until the 24h TTL prunes it as `expired`. Meanwhile `gc session nudge` already told the caller `Queued nudge for …` and exited 0.

Measured on one city (`.gc/nudges/state.json`, 2026-09-09): 67 pending, all with `last_attempt_at` unset, fenced to 39 distinct session ids of which 36 were closed. 58 of the 67 could never be delivered by anything.

This is the session-id half of what #5775 describes. #5775 re-fences a claimed item onto the current fence, but the claim filter still rejects a different session id, so its re-fence only ever sees the same-session/stale-epoch case. (#2165 had the claim-side shape, then dead-lettered instead of delivering.) Related: #3889.

## Fix

- `queuedNudgeClaimableAsSuccessor`: an item whose agent matches and whose fenced session bead is **closed or gone** is claimable by the seat's current session. A live sibling session keeps its items; a lookup failure other than not-found reads as live so nothing is claimed on a guess. Memoized per claim pass and consulted only for items the exact-fence check already excluded, so a queue with no stale fences pays nothing.
- `claimDueQueuedNudgesMatchingWithMaint` hands the matcher the pass's maintenance store so the session lookup borrows the already-open handle.
- The first commit is #5775 verbatim (`fa4d444ed`, cherry-picked with `-x`): once an item is claimed, its re-fence is what delivers it to the successor. It drops out on rebase when #5775 merges.

## Verification

- `TestClaimDueQueuedNudgesForTargetClaimsRetiredSessionFence`: retired-session item and gone-session item are claimed and re-fenced to the new session; the live-sibling item and another seat's item stay pending; nothing is dead-lettered.
- Existing claim/split/fence tests unchanged (beyond #5775's own test update).
- Deployed on the reporting city 2026-09-09 08:44Z; live evidence being collected there.