### PR TITLE
perf(beads): plan the ready projection through a derived table so Dolt uses the status index

### DIFF
--- a/internal/beads/bdstore_ready_projection.go
+++ b/internal/beads/bdstore_ready_projection.go
@@ -477,8 +477,14 @@ func (s *BdStore) fetchReadyProjection(door readyProjectionDoor, ids []string) (
 	return result, nil
 }
 
+// readyProjectionSQL wraps the UNION ALL in a derived table on purpose. Dolt
+// (go-mysql-server) plans a top-level UNION ALL as Table+Filter on both legs —
+// a full scan of every issue ever filed, growing with closed rows — while the
+// identical union inside `(...) t` plans IndexedTableAccess on the status
+// index for both legs, the same way fingerprintSQL already does. Measured on a
+// 15k-row issues table with ~1.2k open (gastownhall/gascity#6155).
 func readyProjectionSQL() string {
-	return "select id,is_blocked from issues where status <> 'closed' union all select id,is_blocked from wisps where status <> 'closed'"
+	return "select id,is_blocked from (select id,is_blocked from issues where status <> 'closed' union all select id,is_blocked from wisps where status <> 'closed') t"
 }
 
 // projectViaBlockedDoor runs the blocked door and classifies its failure the


### PR DESCRIPTION
Fixes #6155.

## Problem

`readyProjectionSQL()` in `internal/beads/bdstore_ready_projection.go` is a top-level `UNION ALL` over `issues` and `wisps` with `status <> 'closed'`. Under go-mysql-server/Dolt that shape plans as `Table` + `Filter` on both legs, so every control-ready prime scans every issue ever filed to return the open ones. The cost is a function of total row count and grows forever as closed beads accumulate.

The identical predicate on the same tables already plans `IndexedTableAccess` when it appears inside a derived table, which is exactly what `fingerprintSQL()` in `bdstore_fingerprint.go` does.

## Fix

Wrap the union in `(...) t`. One query-shape change, no schema change, same rows returned.

## Evidence (live Dolt 2.2.3, `issues` 15166 rows / 1185 open, `wisps` 157 / 42 open)

`EXPLAIN FORMAT=TREE`:
- shipped shape: `Union all` → `Filter(NOT(status='closed'))` → `Table(issues)` and the same for `wisps`
- derived shape: `Union all` → `IndexedTableAccess(issues) index: [issues.status,...]` and `IndexedTableAccess(wisps) index: [wisps.status]`

Server-side timing (25 iterations after warmup, 1226 rows returned, two rounds):

| shape | median | min |
|---|---|---|
| shipped | 49.5–59.5 ms | 46 ms |
| derived | 13.6–14.2 ms | 9.6 ms |

Both `BdStore` (via `bd sql`) and `NativeDoltStore` call the same `readyProjectionSQL()`, so both paths benefit. Existing tests only substring-match the query (`status <> 'closed'`, `from issues where`, `from wisps where`) and still pass.

Tested: `go test ./internal/beads -run 'ReadyProjection|Projection|Fingerprint'` green on this branch; full suite FAIL set identical to the base commit on our rig. Dogfooded on the rig's control dispatcher since 2026-09-09T09:16Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xv6nwtwhUNW3mr6VQDzMdf