### PR TITLE
fix(core/nudge-on-route): read bead.created and cut on a persisted event seq, not a 2m lookback (#4382)

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/nudge-on-route.sh
@@ -15,6 +15,17 @@
 # $GC_PACK_STATE_DIR/nudge-on-route-state.json, so it is both city- and
 # pack-scoped — multi-city installs never cross-pollinate.
 #
+# Two event sources, one window. Routing is often stamped in the CREATE
+# payload (`gc order run`, formula pours, poured step beads), so the only
+# lifecycle event such a bead ever emits before it is claimed is
+# bead.created (#4382); bead.updated alone misses every one of them. And
+# the controller fires this order on its own dispatch cadence — under
+# max_dispatches_per_tick that can be many minutes apart — while a fixed
+# wall-clock lookback only sees the last couple of minutes, so events
+# between two runs were dropped. Each run therefore processes every
+# bead.created/bead.updated event with seq > the high-water seq recorded by
+# the previous run (bounded by WINDOW), and records the new high-water mark.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
@@ -30,11 +41,12 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 CITY="${GC_CITY:-.}"
-# Event lookback window. Must exceed the controller's event-trigger eval
-# cadence so no routing event is missed between runs.
-LOOKBACK="${GC_NUDGE_ON_ROUTE_LOOKBACK:-2m}"
+# Upper bound on how far back one run reads. The real cut is the persisted
+# high-water seq; this only bounds the read (and is the lookback on the very
+# first run, when no seq has been recorded yet).
+WINDOW="${GC_NUDGE_ON_ROUTE_WINDOW:-${GC_NUDGE_ON_ROUTE_LOOKBACK:-1h}}"
 # Dedup entries older than this are pruned so the state file stays bounded.
-# Must comfortably exceed LOOKBACK so an active routing — which keeps
+# Must comfortably exceed WINDOW so an active routing — which keeps
 # re-emitting bead.updated as the reconciler refreshes it — is never
 # pruned and re-nudged. Accepts a simple Ns / Nm / Nh duration.
 RETENTION="${GC_NUDGE_ON_ROUTE_RETENTION:-1h}"
@@ -42,6 +54,8 @@ NUDGE_MESSAGE="${GC_NUDGE_ON_ROUTE_MESSAGE:-check for assigned work}"
 
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/core}"
 STATE_FILE="$PACK_STATE_DIR/nudge-on-route-state.json"
+# Highest event seq processed by the previous run (a bare integer).
+SEQ_FILE="$PACK_STATE_DIR/nudge-on-route-seq"
 mkdir -p "$PACK_STATE_DIR"
 
 # Convert a simple Go-style duration (Ns/Nm/Nh) to whole seconds.
@@ -80,24 +94,50 @@ MEMBERS
     gc session nudge "$_target" "$NUDGE_MESSAGE" >/dev/null 2>&1
 }
 
-# Pull recent bead.updated events. Best-effort: a read failure (API down)
-# must not crash the controller's order loop.
-EVENTS="$(gc events --type bead.updated --since "$LOOKBACK" 2>/dev/null)" || exit 0
+# Pull recent events. Best-effort: a read failure (API down) must not crash
+# the controller's order loop. One unfiltered read: `gc events --type` takes
+# a single exact type and both bead.created and bead.updated are needed.
+EVENTS="$(gc events --since "$WINDOW" 2>/dev/null)" || exit 0
 [ -n "$EVENTS" ] || exit 0
 
-# Reduce to unique "<bead_id>\t<routed_to>" pairs. Only events that actually
-# carry a non-empty gc.routed_to target are considered.
-#
-# The bead.updated payload is flat — .payload.id and .payload.metadata — not
-# the nested .payload.bead.{id,metadata} an earlier schema exposed. The nested
-# paths match nothing against the current event shape, so every routed bead was
-# silently dropped and no nudge was ever delivered.
+LAST_SEQ="$(cat "$SEQ_FILE" 2>/dev/null || true)"
+case "$LAST_SEQ" in ''|*[!0-9]*) LAST_SEQ=0 ;; esac
+
+# Reduce to unique "<bead_id>\t<routed_to>" pairs from events newer than the
+# previous run's high-water seq. Only events that actually carry a non-empty
+# gc.routed_to target are considered. The bead payload is read as
+# (.payload.bead // .payload): the API envelope wraps the bead under
+# .payload.bead while the `gc events` local fallback emits the bead fields
+# directly under .payload (#5968) — same normalization as the sibling
+# notify-on-human-gate-creation.sh.
 PAIRS="$(printf '%s\n' "$EVENTS" \
-    | jq -r 'select(.payload.metadata."gc.routed_to" != null
-                    and .payload.metadata."gc.routed_to" != "")
-             | [.payload.id, .payload.metadata."gc.routed_to"] | @tsv' 2>/dev/null \
+    | jq -r --argjson last "$LAST_SEQ" '
+        select((.seq // 0) > $last
+               and (.type == "bead.created" or .type == "bead.updated"))
+        | (.payload.bead // .payload) as $b
+        | select($b.metadata."gc.routed_to" != null
+                 and $b.metadata."gc.routed_to" != "")
+        | [$b.id, $b.metadata."gc.routed_to"] | @tsv' 2>/dev/null \
     | sort -u)" || PAIRS=""
-[ -n "$PAIRS" ] || exit 0
+
+# Advance the high-water mark to the newest event seen, regardless of type,
+# so the next run starts exactly where this one stopped. Unconditional: a
+# nudge that fails is usually a pool with no live member yet (its spawn
+# primes it), so holding the mark back for it would stall every later
+# routing behind it; a routing that still matters re-emits bead.updated as
+# the reconciler refreshes it and is picked up then.
+HEAD_SEQ="$(printf '%s\n' "$EVENTS" | jq -r '.seq // 0' 2>/dev/null | sort -n | tail -1)" || HEAD_SEQ=""
+case "$HEAD_SEQ" in ''|*[!0-9]*) HEAD_SEQ=0 ;; esac
+advance_seq() {
+    [ "$HEAD_SEQ" -gt "$LAST_SEQ" ] || return 0
+    _tmp="$(mktemp "$PACK_STATE_DIR/.nudge-on-route-seq.XXXXXX")"
+    printf '%s\n' "$HEAD_SEQ" > "$_tmp"
+    mv -f "$_tmp" "$SEQ_FILE"
+}
+if [ -z "$PAIRS" ]; then
+    advance_seq
+    exit 0
+fi
 
 # Load dedup state (object mapping "<bead>|<routed_to>" -> ISO timestamp).
 # A missing or corrupt file resets to an empty object rather than failing.
@@ -122,6 +162,7 @@ while IFS="$(printf '\t')" read -r bead_id routed_to; do
 done <<EOF
 $PAIRS
 EOF
+advance_seq
 
 # Prune entries older than RETENTION so the state file stays bounded.
 RETENTION_S="$(duration_to_seconds "$RETENTION")"

--- a/internal/bootstrap/packs/core/pack_orders_test.go
+++ b/internal/bootstrap/packs/core/pack_orders_test.go
@@ -385,3 +385,32 @@ func TestCoreEscalationScriptContract(t *testing.T) {
 		})
 	}
 }
+
+// TestNudgeOnRouteReadsCreatedEventsSinceLastSeq guards two silent-drop paths
+// (#4382, sys-8war2): routing stamped in the CREATE payload only ever emits
+// bead.created, so the script must read that type too; and the controller
+// fires this order on its own dispatch cadence, so a fixed wall-clock lookback
+// drops every routing event between two runs — the script must cut on the
+// high-water event seq it persisted last run, and tolerate both the nested
+// ({"bead": …}) and flat bead payload shapes `gc events` emits (#5968).
+func TestNudgeOnRouteReadsCreatedEventsSinceLastSeq(t *testing.T) {
+	data, err := fs.ReadFile(PackFS, "assets/scripts/nudge-on-route.sh")
+	if err != nil {
+		t.Fatalf("reading nudge-on-route.sh: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`.type == "bead.created"`,
+		`.type == "bead.updated"`,
+		`(.seq // 0) > $last`,
+		`(.payload.bead // .payload)`,
+		"nudge-on-route-seq",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("nudge-on-route.sh must read created+updated events past the persisted seq; missing %q", want)
+		}
+	}
+	if strings.Contains(body, "--type bead.updated") {
+		t.Errorf("nudge-on-route.sh must not filter to bead.updated only")
+	}
+}


### PR DESCRIPTION
## Summary

A correctly routed bead is never nudged in two common cases. On one city, a wisp poured by `gc order run` and routed to a live `max_active_sessions=1` agent sat unclaimed for 11 minutes next to an idle session until a human nudged it. Measured on the same city over 24h: `nudge-on-route` fired 98 times (every 10–25 min) while 50+ distinct routed pairs arrived in a 6h window; its dedup state held 4 keys.

## Root cause

1. **Routing stamped at creation is invisible.** `gc order run`, formula pours and poured step beads carry `gc.routed_to` in the create payload, so the only lifecycle event before the bead is claimed is `bead.created`. The script read `gc events --type bead.updated` only (`nudge-on-route.sh`, the `EVENTS=` line), so the pair never reached it. This is #4382. Event archive for the 11-minute case: `bead.created` at 13:53:25Z with `metadata.gc.routed_to` set; next event of any kind for that bead is the post-manual-nudge claim at 14:05:38Z. It is masked wherever a pool *spawns* a session for the work, and bites exactly the warm, already-live lanes the order exists for.
2. **The exec never learns which events it was fired for.** The controller persists an event cursor at `headSeq` when it fires the order (`order_dispatch.go`, `front.SetCursor`) but passes no window to the script, which read a fixed 2m wall-clock lookback. Any fire cadence above 2m — routine under `max_dispatches_per_tick` with a few dozen orders — silently drops every routing event between two runs.

## Fix

Pack script only, no Go behaviour change.

- One unfiltered `gc events --since $WINDOW` read (`--type` takes a single exact type), then select `bead.created` **or** `bead.updated` whose `seq` is greater than the high-water seq persisted by the previous run (`$GC_PACK_STATE_DIR/nudge-on-route-seq`), and record the new mark. `WINDOW` (default 1h, `GC_NUDGE_ON_ROUTE_LOOKBACK` still honoured) only bounds the read and is the lookback on the very first run.
- The mark advances unconditionally. A failed nudge is usually a pool with no live member yet (its spawn primes it); holding the mark for it would stall every later routing behind it. A routing that still matters re-emits `bead.updated` as the reconciler refreshes it and is picked up then. Dedup state and its retention are unchanged.
- The bead is read as `(.payload.bead // .payload)`, the same normalisation `notify-on-human-gate-creation.sh` already uses, so the selector is correct on both the API envelope and the local-fallback shape (#5968).
- The trigger stays `on = "bead.updated"` (`Order.On` is a single exact type; a second order sharing the state file would race and spend dispatch budget). Residual: a created-only routing is picked up on the next fire, which on a live city is continuous.

## Tests

- `TestNudgeOnRouteReadsCreatedEventsSinceLastSeq` pins the load-bearing strings (both event types, the seq cut, the payload normalisation, the seq file) and rejects a `--type bead.updated`-only read.
- Script exercised against a stub `gc` (bash + jq): nested created-routed payload nudged; flat updated payload nudged; identical events on a second run nudge nothing (seq gate); a failing target does not hold the mark and is not re-nudged once the pair is recorded.
- `go test ./internal/bootstrap/packs/core` passes on this branch.

## Validation

Deployed on the reporting city 2026-09-09 10:14Z. First two fires (10:21:59Z, 10:44:59Z): seq file written at 1089564 and advanced to 1089798, `order.failed` = 0. A bead born routed at 10:33:05Z with no `bead.updated` ever (`sys-hn1fat` → `core.control-dispatcher`) was nudged by the 10:44:59Z run — invisible to the previous script on both counts (created-only, and outside a 2m lookback).

Related: #4382 (this), #5968 (payload shape), #5314 (trigger cost), #4421 (nudge to an already-closed bead, not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wY5Up6buo9kEzyDTBMszk