### PR TITLE
fix(session): render runtime-missing the moment a live session's runtime vanishes, not after the reconciler tick

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1406,6 +1406,12 @@ func sessionReason(s session.Info, infoIndex map[string]session.Info, cfg *confi
 	if reason := session.LifecycleDisplayReasonWithLivenessInfo(info, now, isRunning); reason != "" {
 		return reason
 	}
+	// s carries the live overlay (EnrichInfo's runtime downgrade); info is the
+	// persisted projection. Persisted active + live asleep = the runtime died
+	// and the reconciler has not caught up — say so instead of a wake reason.
+	if reason := session.LiveDowngradeReason(string(info.State), s.State); reason != "" {
+		return reason
+	}
 
 	// If config is available and no lifecycle reason blocks display, compute
 	// full wake reasons (including WakeConfig).

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1387,6 +1387,48 @@ func TestSessionReason_IndexMissReturnsDash(t *testing.T) {
 	}
 }
 
+// sys-erovf: a persisted-active session whose runtime vanished (OOM-kill,
+// evicted box) is downgraded to asleep in memory by EnrichInfo before the
+// reconciler persists sleep_reason=runtime-missing. The REASON column must say
+// runtime-missing in that window, not "-" and not a wake reason.
+func TestSessionReason_RuntimeMissingBeforeReconcilerTick(t *testing.T) {
+	provider := runtime.NewFake() // "dead-worker" never started: IsRunning=false
+	cfg := &config.City{}
+	bead := beads.Bead{
+		ID:     "gc-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "dead-worker",
+			"state":        "active",
+		},
+	}
+	live := session.Info{
+		ID:          "gc-1",
+		Template:    "worker",
+		State:       session.StateAsleep, // EnrichInfo's runtime downgrade
+		SessionName: "dead-worker",
+	}
+	wrapped := &attachmentCachingProvider{
+		Provider: provider,
+		cache:    buildAttachmentCache([]session.Info{live}, func(session.Info) (bool, error) { return false, nil }),
+	}
+
+	reason := sessionReason(live, map[string]session.Info{bead.ID: seedSessionInfo(bead)}, cfg, wrapped, nil, nil)
+	if reason != session.LifecycleReasonRuntimeMissing {
+		t.Fatalf("sessionReason = %q, want %q for persisted-active/live-asleep", reason, session.LifecycleReasonRuntimeMissing)
+	}
+
+	// Once the reconciler has persisted the downgrade, the persisted sleep_reason
+	// wins and the overlay contributes nothing new.
+	bead.Metadata["state"] = "asleep"
+	bead.Metadata["sleep_reason"] = "idle-timeout"
+	reason = sessionReason(live, map[string]session.Info{bead.ID: seedSessionInfo(bead)}, cfg, wrapped, nil, nil)
+	if reason != "idle-timeout" {
+		t.Fatalf("sessionReason = %q, want idle-timeout once persisted", reason)
+	}
+}
+
 func TestSessionReason_SleepReasonOverridesWakeReason(t *testing.T) {
 	provider := runtime.NewFake()
 	if err := provider.Start(context.Background(), "sleeping-worker", runtime.Config{Command: "echo"}); err != nil {

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -185,6 +185,11 @@ func sessionResponseWithReason(info session.Info, pr session.PersistedResponse, 
 		isRunning = sp.IsRunning
 	}
 	r.Reason = session.LifecycleDisplayReasonWithLiveness(pr.Status, pr.Metadata, time.Now().UTC(), info.SessionName, isRunning)
+	if r.Reason == "" {
+		// info carries the live overlay, pr.Metadata the persisted state: a
+		// persisted-active session the overlay put asleep lost its runtime.
+		r.Reason = session.LiveDowngradeReason(pr.Metadata["state"], info.State)
+	}
 	r.ConfiguredNamedSession = strings.TrimSpace(pr.Metadata[apiNamedSessionMetadataKey]) == "true"
 	r.SubmissionCapabilities = session.SubmissionCapabilitiesForMetadata(pr.Metadata, hasDeferredQueue)
 	// Expose only real_world_app_* prefixed metadata keys to API consumers.

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -2075,6 +2075,45 @@ func TestHandleSessionListIncludesReason(t *testing.T) {
 	}
 }
 
+// sys-erovf: the runtime died under a persisted-active session and the
+// reconciler has not yet written sleep_reason. The list must render
+// runtime-missing, not an empty reason that reads as idle.
+func TestHandleSessionListShowsRuntimeMissingBeforeReconcilerTick(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "Dead")
+	if err := fs.sp.Stop(info.SessionName); err != nil { // runtime gone, bead untouched
+		t.Fatalf("stop fake runtime: %v", err)
+	}
+	if fs.sp.IsRunning(info.SessionName) {
+		t.Fatalf("session %q should not be running after Stop", info.SessionName)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var body struct {
+		Items []sessionResponse `json:"items"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(body.Items))
+	}
+	if body.Items[0].State != string(session.StateAsleep) {
+		t.Fatalf("state = %q, want asleep (runtime overlay)", body.Items[0].State)
+	}
+	if body.Items[0].Reason != session.LifecycleReasonRuntimeMissing {
+		t.Fatalf("reason = %q, want %s", body.Items[0].Reason, session.LifecycleReasonRuntimeMissing)
+	}
+}
+
 func TestHandleSessionListShowsResetPendingForLiveRuntime(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -357,6 +357,24 @@ func LifecycleDisplayReasonWithLivenessInfo(info Info, now time.Time, isRunning 
 	return lifecycleDisplayReasonFromViewInfo(view, info)
 }
 
+// LiveDowngradeReason names the discriminator Manager.EnrichInfo drops: when
+// the persisted state still says active/awake but the live overlay reports the
+// session asleep, the only way that happens is the provider's is-running probe
+// answering false — the runtime died (OOM-kill, evicted box, tmux gone) and the
+// reconciler has not yet persisted sleep_reason=runtime-missing. Display callers
+// use this to render the same reason immediately, without a second probe, so a
+// dead session is never indistinguishable from an idle one (sys-erovf). Returns
+// "" whenever the two states agree or the persisted state is not active.
+func LiveDowngradeReason(persistedState string, live State) string {
+	switch State(strings.TrimSpace(persistedState)) {
+	case StateActive, StateAwake:
+		if live == StateAsleep {
+			return LifecycleReasonRuntimeMissing
+		}
+	}
+	return ""
+}
+
 // LifecycleResetPendingReasonVisible reports whether reset-pending should
 // replace other display reasons for an in-flight requested or continuation reset.
 func LifecycleResetPendingReasonVisible(status string, metadata map[string]string, now time.Time, sessionName string, isRunning func(string) bool) bool {

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -1092,3 +1092,24 @@ func lifecycleRepoRoot(t *testing.T) string {
 	}
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 }
+
+func TestLiveDowngradeReason(t *testing.T) {
+	cases := []struct {
+		persisted string
+		live      State
+		want      string
+	}{
+		{"active", StateAsleep, LifecycleReasonRuntimeMissing},
+		{"awake", StateAsleep, LifecycleReasonRuntimeMissing},
+		{" active ", StateAsleep, LifecycleReasonRuntimeMissing},
+		{"active", StateActive, ""},
+		{"asleep", StateAsleep, ""},
+		{"start-pending", StateAsleep, ""},
+		{"", StateAsleep, ""},
+	}
+	for _, tc := range cases {
+		if got := LiveDowngradeReason(tc.persisted, tc.live); got != tc.want {
+			t.Errorf("LiveDowngradeReason(%q, %q) = %q, want %q", tc.persisted, tc.live, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
When a session's runtime dies out from under a persisted-active bead (OOM-kill of the in-box process tree, an evicted Nomad box, a tmux server gone), `gc session list` and the sessions API show it as `asleep` with an empty REASON until the reconciler's next tick persists `sleep_reason=runtime-missing`. In that window a dead session is byte-identical to an idle one. Observed on a Nomad-runtime drill where the whole session tree was memcg-killed and an attached operator saw only a dropped connection with nothing anywhere saying the session had died.

## Root cause
`Manager.EnrichInfo` (`internal/session/manager.go`) already detects the condition: persisted `state=active` + provider `IsRunning()==false` → it downgrades `info.State` to `StateAsleep` in memory. But it sets no reason, and both REASON renderers — `sessionReason` in `cmd/gc/cmd_session.go` and `sessionResponseWithReason` in `internal/api/handler_sessions.go` — read only the persisted `sleep_reason` through `lifecycleDisplayReasonFromView`. The discriminator is computed and then dropped; only the reconciler (`cmd/gc/session_reconcile.go`, `healStatePatchWithRollbackInfo`) writes it durably, one tick later.

## Fix
Add `session.LiveDowngradeReason(persistedState, liveState)`: persisted `active`/`awake` + live `asleep` can only mean the runtime vanished, so it returns `LifecycleReasonRuntimeMissing`. Both renderers already hold the enriched Info *and* the persisted state, so the hook costs no additional `IsRunning` probe (the CLI list already pays one per active session in `EnrichInfo`; doubling it would fork a tmux probe per row). Precedence is unchanged: a persisted `sleep_reason` (once the reconciler has caught up) and reset-pending/circuit-open still win; the new reason only fills the pre-tick gap, and in the CLI it is checked before wake reasons so a dead session never renders `config`/`attached`. `EnrichInfo` itself is untouched (its byte-equivalence oracle `TestEnrichInfoMatchesBeadOverlay` still holds). No new State constant, no persistence change.

## Tests
- `TestSessionReason_RuntimeMissingBeforeReconcilerTick` (cmd/gc): persisted active, `sleep_reason` empty, live Info asleep → `runtime-missing`; once persisted `sleep_reason` exists it wins.
- `TestHandleSessionListShowsRuntimeMissingBeforeReconcilerTick` (internal/api): create a session, `Fake.Stop` its runtime without touching the bead, GET `/sessions` → `state=asleep`, `reason=runtime-missing`.
- `TestLiveDowngradeReason` (internal/session): table over active/awake/asleep/start-pending/empty.
`go test ./cmd/gc ./internal/api ./internal/session` passes on this branch; full `go test ./...` on the fork's live lineage showed an identical FAIL-name set to the pre-change baseline.

## Validation
Cut over on a live city (3 nodes, ~15 concurrent sessions) as 1.4.6-erovf-runtime-missing: `gc session list` and the API render every existing reason unchanged (`reset-pending`, persisted `runtime-missing`), API health 200 after restart, list latency unchanged (0.27 s / 0.04 s / 0.04 s). The pre-tick specimen is being reproduced by a kill-the-runtime drill on that city; the behavior is pinned by the tests above.