### PR TITLE
fix(nudge): coalesce reference-less queued session nudges with identical text per agent

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -2186,12 +2186,27 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 		if queuedNudgeExists(state, item.ID) {
 			return nil
 		}
-		// Supersede pending and in-flight nudges for the same (agent, source, reference).
-		if item.Reference != nil && item.Reference.ID != "" {
+		// Supersede pending and in-flight nudges for the same (agent, source,
+		// reference) — or, for reference-less nudges, the same (agent, source,
+		// message). A plain `gc session nudge` (e.g. the core pack's
+		// nudge-on-route firing once per routed bead) carries no reference, so
+		// N unanswered copies of one fixed wake text used to queue up and drain
+		// as N identical injections in a single turn (sys-8qaog). Mail
+		// reminders are deliberately excluded: each mail keeps its own
+		// reminder (TestSendMailNotifyQueuesIndependentRemindersForEachMail).
+		hasRef := item.Reference != nil && item.Reference.ID != ""
+		coalesceByText := !hasRef && item.Source == "session" && strings.TrimSpace(item.Message) != ""
+		if hasRef || coalesceByText {
 			matchesSupersession := func(existing queuedNudge) bool {
-				return existing.Agent == item.Agent && existing.Source == item.Source &&
-					existing.Reference != nil && existing.Reference.Kind == item.Reference.Kind &&
-					existing.Reference.ID == item.Reference.ID
+				if existing.Agent != item.Agent || existing.Source != item.Source {
+					return false
+				}
+				if hasRef {
+					return existing.Reference != nil && existing.Reference.Kind == item.Reference.Kind &&
+						existing.Reference.ID == item.Reference.ID
+				}
+				return (existing.Reference == nil || existing.Reference.ID == "") &&
+					existing.Message == item.Message
 			}
 			filtered := state.Pending[:0]
 			for i, existing := range state.Pending {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -2174,18 +2174,17 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 	err = withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
 		now := clk.Now()
 		deadline := now.Add(nudgeEnqueueMaintenanceBudget)
-		if err := recoverExpiredInFlightNudgesWithClock(state, front, now, deadline, clk); err != nil {
-			return err
-		}
-		if err := pruneExpiredQueuedNudgesWithClock(state, front, now, deadline, clk); err != nil {
-			return err
-		}
-		if err := pruneDeadQueuedNudgesWithClock(state, front, now, deadline, clk); err != nil {
-			return err
-		}
 		if queuedNudgeExists(state, item.ID) {
 			return nil
 		}
+		// Supersession runs BEFORE the maintenance passes: it is a correctness
+		// step (one store call per matched item, usually zero or one), while
+		// recover/prune are housekeeping that spend the shared budget on one
+		// store lookup per dead-letter item. With ~100 dead items under load
+		// the budget was gone before supersession started, both loops bailed
+		// on their first iteration, and identical session nudges kept
+		// accumulating (sys-8qaog). Housekeeping gets whatever is left; the
+		// foreground bound is unchanged.
 		// Supersede pending and in-flight nudges for the same (agent, source,
 		// reference) — or, for reference-less nudges, the same (agent, source,
 		// message). A plain `gc session nudge` (e.g. the core pack's
@@ -2197,6 +2196,13 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 		hasRef := item.Reference != nil && item.Reference.ID != ""
 		coalesceByText := !hasRef && item.Source == "session" && strings.TrimSpace(item.Message) != ""
 		if hasRef || coalesceByText {
+			// Say so when the budget runs out mid-scan rather than skipping
+			// silently: an unscanned tail means duplicates may remain.
+			budgetExhausted := func(queue string, remaining int) {
+				if nudgeWarningWriter != nil {
+					fmt.Fprintf(nudgeWarningWriter, "gc nudge enqueue: warning: supersession budget exhausted with %d %s item(s) unscanned; duplicates may remain\n", remaining, queue) //nolint:errcheck
+				}
+			}
 			matchesSupersession := func(existing queuedNudge) bool {
 				if existing.Agent != item.Agent || existing.Source != item.Source {
 					return false
@@ -2211,6 +2217,7 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 			filtered := state.Pending[:0]
 			for i, existing := range state.Pending {
 				if clk.Now().After(deadline) {
+					budgetExhausted("pending", len(state.Pending)-i)
 					filtered = append(filtered, state.Pending[i:]...)
 					break
 				}
@@ -2233,6 +2240,7 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 			inFlight := state.InFlight[:0]
 			for i, existing := range state.InFlight {
 				if clk.Now().After(deadline) {
+					budgetExhausted("in-flight", len(state.InFlight)-i)
 					inFlight = append(inFlight, state.InFlight[i:]...)
 					break
 				}
@@ -2248,6 +2256,15 @@ func enqueueQueuedNudgeWithStoreAndClock(cityPath string, store beads.NudgesStor
 				inFlight = append(inFlight, existing)
 			}
 			state.InFlight = inFlight
+		}
+		if err := recoverExpiredInFlightNudgesWithClock(state, front, now, deadline, clk); err != nil {
+			return err
+		}
+		if err := pruneExpiredQueuedNudgesWithClock(state, front, now, deadline, clk); err != nil {
+			return err
+		}
+		if err := pruneDeadQueuedNudgesWithClock(state, front, now, deadline, clk); err != nil {
+			return err
 		}
 		state.Pending = append(state.Pending, item)
 		sortQueuedNudges(state)

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -4610,6 +4610,56 @@ func TestEnqueueSupersedes_SameAgentSourceReference(t *testing.T) {
 	}
 }
 
+func TestEnqueueSupersedes_SameAgentSourceMessage_NoReference(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now()
+
+	// nudge-on-route shape: plain `gc session nudge`, fixed text, no reference.
+	first := newQueuedNudgeWithOptions("worker", "check for assigned work", "session", now, queuedNudgeOptions{ID: "n-first"})
+	if err := enqueueQueuedNudge(dir, first); err != nil {
+		t.Fatalf("enqueueQueuedNudge(first): %v", err)
+	}
+	second := newQueuedNudgeWithOptions("worker", "check for assigned work", "session", now.Add(time.Second), queuedNudgeOptions{ID: "n-second"})
+	if err := enqueueQueuedNudge(dir, second); err != nil {
+		t.Fatalf("enqueueQueuedNudge(second): %v", err)
+	}
+	// Different text, same agent/source: must NOT be coalesced.
+	other := newQueuedNudgeWithOptions("worker", "STOP work on bead-1", "session", now.Add(2*time.Second), queuedNudgeOptions{ID: "n-other"})
+	if err := enqueueQueuedNudge(dir, other); err != nil {
+		t.Fatalf("enqueueQueuedNudge(other): %v", err)
+	}
+	// Same text but carrying a reference: reference-less matching must leave it alone.
+	withRef := newQueuedNudgeWithOptions("worker", "check for assigned work", "session", now.Add(3*time.Second), queuedNudgeOptions{
+		ID:        "n-ref",
+		Reference: &nudgeReference{Kind: "bead", ID: "bead-789"},
+	})
+	if err := enqueueQueuedNudge(dir, withRef); err != nil {
+		t.Fatalf("enqueueQueuedNudge(withRef): %v", err)
+	}
+
+	// Same text from the mail source: mail reminders are never coalesced.
+	mail := newQueuedNudgeWithOptions("worker", "check for assigned work", "mail", now.Add(4*time.Second), queuedNudgeOptions{ID: "n-mail"})
+	if err := enqueueQueuedNudge(dir, mail); err != nil {
+		t.Fatalf("enqueueQueuedNudge(mail): %v", err)
+	}
+
+	pending, _, dead, err := listQueuedNudges(dir, "worker", now.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	got := map[string]bool{}
+	for _, p := range pending {
+		got[p.ID] = true
+	}
+	if len(pending) != 4 || !got["n-second"] || !got["n-other"] || !got["n-ref"] || !got["n-mail"] {
+		t.Fatalf("pending = %v, want exactly n-second, n-other, n-ref, n-mail", got)
+	}
+	if len(dead) != 1 || dead[0].ID != "n-first" || dead[0].LastError != "superseded" {
+		t.Fatalf("dead = %+v, want only n-first superseded", dead)
+	}
+}
+
 func TestEnqueueSupersedes_InFlightNudge(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/cmd/gc/sling_nudge_budget_test.go
+++ b/cmd/gc/sling_nudge_budget_test.go
@@ -219,14 +219,18 @@ func TestSlingNudgeEnqueueBudgetPreservesQueuedItems(t *testing.T) {
 			t.Fatalf("surviving dead nudge %q (i=%d) bucket = %q, want %q; buckets=%v", id, i, bucket, seededBuckets[id], buckets)
 		}
 	}
+	// Supersession runs before the budgeted housekeeping, so the matching
+	// pending and in-flight items are dead-lettered as superseded — preserved
+	// in the dead bucket, never dropped — even though the dead backlog alone
+	// would exhaust the budget.
 	for i := 0; i < 2; i++ {
 		id := fmt.Sprintf("nudge-pending-preserve-%d", i)
-		if bucket := buckets[id]; bucket != "pending" {
-			t.Fatalf("%s bucket = %q, want pending because supersede budget was already exhausted", id, bucket)
+		if bucket := buckets[id]; bucket != "dead" {
+			t.Fatalf("%s bucket = %q, want dead (superseded before housekeeping spent the budget)", id, bucket)
 		}
 		id = fmt.Sprintf("nudge-in-flight-preserve-%d", i)
-		if bucket := buckets[id]; bucket != "in-flight" {
-			t.Fatalf("%s bucket = %q, want in-flight because supersede budget was already exhausted", id, bucket)
+		if bucket := buckets[id]; bucket != "dead" {
+			t.Fatalf("%s bucket = %q, want dead (superseded before housekeeping spent the budget)", id, bucket)
 		}
 	}
 	if bucket := buckets[item.ID]; bucket != "pending" {


### PR DESCRIPTION
## Summary
A plain `gc session nudge <agent> "<text>"` carries no `Reference`, so the enqueue-time supersession in `enqueueQueuedNudgeWithStore` never applies to it. The core pack's `nudge-on-route` order fires the fixed text `check for assigned work` once per routed bead per pool member, and each unanswered copy queues as a new item. On a city with a 4-slot pool we observed 12 identical pending items per pool member accumulating at ~4 s cadence, 6 for a single polecat, and the whole batch draining as N identical `- [session] check for assigned work` lines in one injection when the session next idled. The agent reads that as N separate instructions; on our rig it produced spurious "injection" escalations because the repeated text matched a string agents are trained to refuse.

## Root cause
`cmd/gc/cmd_nudge.go` `enqueueQueuedNudgeWithStore`: the supersession block is gated on `item.Reference != nil && item.Reference.ID != ""`. Reference-less items (every `gc session nudge`, i.e. `source=session`) skip it entirely, so identical text is never coalesced.

## Fix
For `source=session` items with no reference, supersede pending and in-flight items that have the same `(agent, source, message)`, exactly as referenced items are already superseded by `(agent, source, reference)`. The newest item wins (it carries the live session fence). Different text is untouched. Referenced items keep the existing rule. Mail reminders (`source=mail`) are deliberately excluded: each mail keeps its own reminder, as pinned by `TestSendMailNotifyQueuesIndependentRemindersForEachMail`.

## Tests
- `TestEnqueueSupersedes_SameAgentSourceMessage_NoReference`: two identical reference-less session nudges → the first is dead-lettered `superseded`, the second stays pending; a different-text nudge, a same-text referenced nudge, and a same-text mail-source nudge all remain pending (four pending, one dead).
- Existing `TestEnqueueSupersedes_*` and `TestSendMailNotify*` families pass.

## Validation
Deployed on our city (gc 1.4.6 lineage). One nudge to a polecat holding a pending identical item superseded it in place (pending stayed at 1, dead entry `superseded`). Before the change the same agent had 6 identical pending copies; pool members had up to 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJEQ2QevrC8FhtSs4uGtmb

## Second commit: run supersession before the budgeted housekeeping

Dogfooding the first commit under pool load (4 pool members, one `check for assigned work` every ~4–20 s) showed identical items still accumulating: `enqueueQueuedNudgeWithStore` spends one 2 s foreground budget on recover/prune first, and `pruneDeadQueuedNudges` costs one store lookup per dead-letter item, so with ~100 dead items the deadline had already passed when the supersession loops started and they bailed on their first iteration (we saw 4 identical pending copies per pool member in a 40 s burst, then one enqueue during a quiet moment killing all of them at once). Supersession now runs first — it costs one store call per matched item, usually zero or one — and housekeeping takes whatever budget is left, so the foreground bound is unchanged. When the budget still cuts the scan short a warning is printed instead of skipping silently. `TestSlingNudgeEnqueueBudgetPreservesQueuedItems` pinned the old order (matching items stayed pending because the budget was gone); they are now dead-lettered as superseded, still preserved, within the same elapsed and store-op bounds.