### PR TITLE
fix(hostboot): drop redundant int64() conversion on darwin tv.Sec (ga-47doqg)

### DIFF
--- a/internal/hostboot/hostboot_darwin.go
+++ b/internal/hostboot/hostboot_darwin.go
@@ -18,5 +18,5 @@ func bootTime() (time.Time, error) {
 	if tv.Sec <= 0 {
 		return time.Time{}, fmt.Errorf("hostboot: implausible kern.boottime seconds %d", tv.Sec)
 	}
-	return time.Unix(int64(tv.Sec), int64(tv.Usec)*1000), nil
+	return time.Unix(tv.Sec, int64(tv.Usec)*1000), nil
 }


### PR DESCRIPTION
## Summary
- `unix.Timeval.Sec` is already `int64` on darwin, so `int64(tv.Sec)` at `internal/hostboot/hostboot_darwin.go:21` is a no-op that `golangci-lint`'s `unconvert` rejects under `make lint-full` (`Mac / quality`).
- Every needs-mac CI job declares `needs: [mac-quality, ...]`, so this single line currently blocks all Mac-tier CI signal fleet-wide (confirmed on #6192 and #6201 — both show the Mac tier fully SKIPPED behind this failure).
- `int64(tv.Usec)` is left untouched — `Usec` is `int32` there, so that conversion is real and required.
- Mathematically identical value, same width: no behavior change on any platform.

## Test plan
- [x] `GOOS=darwin GOARCH=arm64 go build ./internal/hostboot/` — clean
- [x] `GOOS=darwin GOARCH=arm64 go vet ./internal/hostboot/...` — clean
- [x] `GOOS=darwin GOARCH=arm64 golangci-lint run ./internal/hostboot/...` — 0 issues (previously 1: the exact reported `unconvert` failure)
- [x] Native Linux `go test ./internal/hostboot/...` — all PASS, no regression
- [x] Native Linux `go vet ./...` — clean
- [x] `make lint-changed` (scoped to this diff vs. `origin/main`) — 0 issues
- [x] `git push` survived the local 10-job pre-push gate (`fsys-darwin-compile`, `unit-core`, `unit-cmd-gc-{1..6}-of-6`, lock/concurrency selftests)

refs ga-47doqg