### PR TITLE
fix(sessionlog): compare Kimi Code test paths via samePath, not raw string equality (ga-f8j1ym)

### DIFF
--- a/internal/sessionlog/kimi_code_test.go
+++ b/internal/sessionlog/kimi_code_test.go
@@ -23,13 +23,13 @@ func TestKimiCodeDiscovery(t *testing.T) {
 	}
 	path := writeKimiContext(t, filepath.Join(root, "sessions", "wd_kimi-probe-ws_87061d3d7a56", "session_native", "agents", "main", "wire.jsonl"), []string{`{"type":"metadata","protocol_version":"1.5","created_at":1787252689149}`})
 	for _, search := range []string{root, filepath.Join(root, "sessions")} {
-		if got := FindKimiSessionFile([]string{search}, workDir); got != path {
+		if got := FindKimiSessionFile([]string{search}, workDir); !samePath(got, path) {
 			t.Errorf("newest = %q, want %q", got, path)
 		}
-		if got := FindKimiSessionFileIfUnambiguous([]string{search}, workDir); got != path {
+		if got := FindKimiSessionFileIfUnambiguous([]string{search}, workDir); !samePath(got, path) {
 			t.Errorf("unambiguous = %q, want %q", got, path)
 		}
-		if got := FindKimiSessionFileByID([]string{search}, workDir, "session_native"); got != path {
+		if got := FindKimiSessionFileByID([]string{search}, workDir, "session_native"); !samePath(got, path) {
 			t.Errorf("keyed = %q, want %q", got, path)
 		}
 	}
@@ -49,7 +49,7 @@ func TestKimiCodeDiscovery(t *testing.T) {
 	if got := FindKimiSessionFileIfUnambiguous([]string{root}, workDir); got != "" {
 		t.Fatalf("mixed layouts are ambiguous, got %q", got)
 	}
-	if got := FindKimiSessionFile([]string{root}, workDir); got != path {
+	if got := FindKimiSessionFile([]string{root}, workDir); !samePath(got, path) {
 		t.Fatalf("newest mixed layout = %q", got)
 	}
 }
@@ -164,7 +164,7 @@ func TestKimiCodeRootsAndWorkspaceIdentity(t *testing.T) {
 	}
 	path := writeKimiContext(t, filepath.Join(root, "sessions", kimiCodeWorkDirKey(workDir), "session_main", "agents", "main", "wire.jsonl"), []string{`{"type":"metadata","protocol_version":"1.5"}`})
 	writeKimiContext(t, filepath.Join(root, "sessions", kimiCodeWorkDirKey(workDir), "session_main", "agents", "agent-0", "wire.jsonl"), []string{`{"type":"metadata","protocol_version":"1.5"}`})
-	if got := FindKimiSessionFileByID(nil, alias, "session_main"); got != path {
+	if got := FindKimiSessionFileByID(nil, alias, "session_main"); !samePath(got, path) {
 		t.Fatalf("custom home / canonical workspace = %q", got)
 	}
 	rootAlias := filepath.Join(t.TempDir(), "account")
@@ -178,7 +178,7 @@ func TestKimiCodeRootsAndWorkspaceIdentity(t *testing.T) {
 	if got := FindKimiSessionFileIfUnambiguous(nil, workDir); got != "" {
 		t.Fatalf("ambiguous native sessions matched %q", got)
 	}
-	if got := FindKimiSessionFileByID(nil, workDir, "session_main"); got != path {
+	if got := FindKimiSessionFileByID(nil, workDir, "session_main"); !samePath(got, path) {
 		t.Fatalf("exact native key = %q", got)
 	}
 	for _, wd := range []string{"", " "} {
@@ -247,10 +247,10 @@ func TestKimiCodeSuccessfulLookupDoesNotWarnAboutLegacyLayout(t *testing.T) {
 	old := log.Writer()
 	log.SetOutput(&logs)
 	defer log.SetOutput(old)
-	if got := FindKimiSessionFile([]string{root}, workDir); got != path {
+	if got := FindKimiSessionFile([]string{root}, workDir); !samePath(got, path) {
 		t.Fatalf("lookup=%q", got)
 	}
-	if got := FindKimiSessionFileByID([]string{root}, workDir, "session_native"); got != path {
+	if got := FindKimiSessionFileByID([]string{root}, workDir, "session_native"); !samePath(got, path) {
 		t.Fatalf("keyed lookup=%q", got)
 	}
 	if logs.Len() != 0 {

--- a/internal/worker/sessionlog_adapter_test.go
+++ b/internal/worker/sessionlog_adapter_test.go
@@ -1699,7 +1699,7 @@ func TestSessionLogAdapterKimiCodeNativeSession(t *testing.T) {
 		`{"type":"turn.ended","reason":"completed","time":1787252689002}`,
 	)
 	adapter := SessionLogAdapter{SearchPaths: []string{t.TempDir()}}
-	if got := adapter.DiscoverTranscript("kimi/tmux-cli", "/tmp/kimi-probe-ws", "session_native"); got != path {
+	if got := adapter.DiscoverTranscript("kimi/tmux-cli", "/tmp/kimi-probe-ws", "session_native"); !samePath(got, path) {
 		t.Fatalf("discovery=%q", got)
 	}
 	snapshot, err := adapter.LoadHistory(LoadRequest{Provider: "kimi/tmux-cli", TranscriptPath: path})
@@ -1716,4 +1716,13 @@ func TestSessionLogAdapterKimiCodeNativeSession(t *testing.T) {
 	if activity != TailActivityIdle {
 		t.Fatalf("activity=%q", activity)
 	}
+}
+
+func samePath(a, b string) bool {
+	if a == b {
+		return true
+	}
+	resolvedA, errA := filepath.EvalSymlinks(a)
+	resolvedB, errB := filepath.EvalSymlinks(b)
+	return errA == nil && errB == nil && resolvedA == resolvedB
 }


### PR DESCRIPTION
## Summary
- Four Kimi Code discovery tests compared `FindKimiSessionFile*` return values against a raw `t.TempDir()`-derived path string. On macOS, `t.TempDir()` returns a `/var/folders/...` path that is itself a symlink to `/private/var/folders/...`; anything that resolves symlinks on the way back out names the same file but fails a raw `==` comparison.
- Invisible on Linux CI (no such indirection there), which is why this only ever surfaced on `Mac / quality (lint, fmt, vet, docs)`.
- Fixes every raw comparison in the four affected tests (`TestKimiCodeDiscovery`, `TestKimiCodeRootsAndWorkspaceIdentity`, `TestKimiCodeSuccessfulLookupDoesNotWarnAboutLegacyLayout`, `TestSessionLogAdapterKimiCodeNativeSession`), not just the first `t.Fatalf` site each hit — `t.Fatalf` aborts on first failure, so a single CI run's log only ever shows the first landmine per test; the later same-cause comparisons were still live and would have surfaced as a "new" Mac failure on a subsequent run.
- Uses the `samePath(a, b string) bool` helper already established in this repo for exactly this purpose (`filepath.EvalSymlinks` both sides, exact-match fast path) — reused as-is in `internal/sessionlog`, and reimplemented locally in `internal/worker`'s test file per this repo's existing per-package convention for this helper (it has no exported/shared home).
- Deliberately leaves comparisons against `""` (not-found/ambiguous checks) untouched — those aren't subject to symlink divergence and `samePath` would be semantically wrong there.
- Test-only change: normalizes both sides of each comparison, so it's neutral with respect to the still-open `ga-ytk4sf` design question about what the `Find*` functions themselves return.

## Test plan
- [x] `go test ./internal/sessionlog/... -run 'TestKimiCode' -v` — all pass
- [x] `go test ./internal/worker/... -run 'TestSessionLogAdapterKimiCodeNativeSession' -v` — pass
- [x] Full `go test ./internal/sessionlog/... ./internal/worker/...` — all pass, no regressions
- [x] `go vet ./internal/sessionlog/... ./internal/worker/...` — clean
- [x] `go build ./...` — clean
- [x] `git push` survived the local 10-job pre-push gate (`fsys-darwin-compile`, `unit-core`, `unit-cmd-gc-{1..6}-of-6`, lock/concurrency selftests)

refs ga-f8j1ym