### PR TITLE
fix(test): strip dolt leak guard stderr in subprocess parity assertions (ga-vqhh23)

### DIFF
--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -312,18 +312,31 @@ func runPackCommandProcessWithEnv(t *testing.T, cityPath, scenario string, extra
 	if got, err := os.ReadFile(afterRun); err != nil || string(got) != "reached\n" {
 		t.Fatalf("post-run marker = %q, err=%v; run did not return through deferred lifecycle", got, err)
 	}
-	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stripTmuxLeakGuardNoise(stderr.String())}
+	return packCommandProcessResult{exitCode: exitCode, stdout: stdout.String(), stderr: stripLeakGuardNoise(stderr.String())}
 }
 
-// stripTmuxLeakGuardNoise removes the tmux leak guard's own diagnostic lines
-// (cmd/gc/tmux_leak_guard_test.go: sweepStaleTmuxTestServers,
-// writeTmuxLeakReport, and tmuxLeakGuardedTestingM.runWith's teardown report)
-// from captured subprocess stderr. TestMain re-runs in every re-exec'd
-// subprocess, so its startup sweep or teardown leak check can emit these
-// lines nondeterministically depending on unrelated concurrent sibling
-// suites' teardown timing — real CLI stderr assertions must not depend on
-// that timing.
-func stripTmuxLeakGuardNoise(s string) string {
+// stripLeakGuardNoise removes BOTH test leak guards' own diagnostic lines from
+// captured subprocess stderr:
+//
+//   - the tmux guard (cmd/gc/tmux_leak_guard_test.go: sweepStaleTmuxTestServers,
+//     writeTmuxLeakReport, and tmuxLeakGuardedTestingM.runWith's teardown report)
+//   - the dolt guard (cmd/gc/path_helpers_test.go: sweepStaleCmdGCTestDoltProcesses,
+//     reapDoltProcessesUnderRoot, sweepOrphanDoltStoreDirs, writeDoltLeakReport,
+//     and doltLeakGuardedTestingM's teardown scan)
+//
+// TestMain wraps m in both (newDoltLeakGuardedTestingM inside,
+// newTmuxLeakGuardedTestingM outside) and re-runs in every re-exec'd
+// subprocess, so either guard's startup sweep or teardown leak check can emit
+// lines nondeterministically depending on unrelated concurrent sibling suites'
+// teardown timing — real CLI stderr assertions must not depend on that timing.
+//
+// Both guards' per-process detail lines share the "  pid=" prefix, so a single
+// case covers them. Only the header prefixes differ, and omitting the dolt one
+// is what made main CI red for ~26h (ga-vqhh23): the eager side reaped a stale
+// dolt server and announced it while the lazy side had nothing left to reap, so
+// TestPackCommandCobraHelpAndUnknownParity's stderr-equality assertion failed on
+// a difference that had nothing to do with cobra dispatch.
+func stripLeakGuardNoise(s string) string {
 	if s == "" {
 		return s
 	}
@@ -337,6 +350,7 @@ func stripTmuxLeakGuardNoise(s string) string {
 	for _, line := range lines {
 		switch {
 		case strings.HasPrefix(line, "cmd/gc tmux leak guard: "):
+		case strings.HasPrefix(line, "cmd/gc test dolt leak guard: "):
 		case strings.HasPrefix(line, "  pid="):
 		case strings.HasPrefix(line, "  socket="):
 		default:
@@ -353,18 +367,25 @@ func stripTmuxLeakGuardNoise(s string) string {
 	return out
 }
 
-// TestStripTmuxLeakGuardNoise expresses the acceptance criteria for isolating
-// captured subprocess stderr from the tmux leak guard's own harness-level
-// diagnostics (cmd/gc/tmux_leak_guard_test.go): stripTmuxLeakGuardNoise must
-// remove exactly the guard's startup-sweep and teardown-leak lines, in any
-// position, while leaving real CLI stderr output (and its line order)
-// untouched. Without this, TestPackCommandCobraHelpAndUnknownParity's
-// eager/lazy stderr-equality assertion — and the several exact-empty-stderr
-// assertions elsewhere in this file — are vulnerable to a concurrent sibling
-// suite's teardown racing exactly one of the two subprocess launches' startup
-// sweep (ga-5pe5xv gate evidence: "a concurrent tmux leak-guard stderr line
-// captured by one parity side only").
-func TestStripTmuxLeakGuardNoise(t *testing.T) {
+// TestStripLeakGuardNoise expresses the acceptance criteria for isolating
+// captured subprocess stderr from BOTH test leak guards' harness-level
+// diagnostics (cmd/gc/tmux_leak_guard_test.go and cmd/gc/path_helpers_test.go):
+// stripLeakGuardNoise must remove exactly those guards' startup-sweep and
+// teardown-leak lines, in any position, while leaving real CLI stderr output
+// (and its line order) untouched. Without this,
+// TestPackCommandCobraHelpAndUnknownParity's eager/lazy stderr-equality
+// assertion — and the several exact-empty-stderr assertions elsewhere in this
+// file — are vulnerable to a concurrent sibling suite's teardown racing exactly
+// one of the two subprocess launches' startup sweep (ga-5pe5xv gate evidence:
+// "a concurrent tmux leak-guard stderr line captured by one parity side only";
+// ga-vqhh23: the same failure via the dolt guard, which kept main CI red ~26h).
+//
+// Coverage rule for whoever adds the NEXT guard to TestMain: a guard that
+// writes to os.Stderr from TestMain is captured by every re-exec'd subprocess
+// assertion in this file, so it must gain a case here in the same change. The
+// dolt guard did not, and the gap stayed invisible until a stale server
+// happened to exist during exactly one of two subprocess launches.
+func TestStripLeakGuardNoise(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -403,11 +424,46 @@ func TestStripTmuxLeakGuardNoise(t *testing.T) {
 				"  gc backstage repo\n",
 			want: "Usage:\n  gc backstage repo\n",
 		},
+		{
+			// The dolt leak guard is the tmux guard's sibling in TestMain
+			// (newDoltLeakGuardedTestingM wraps m; newTmuxLeakGuardedTestingM
+			// wraps that) and re-runs in every re-exec'd subprocess with the
+			// same nondeterminism, so its lines must be stripped for the same
+			// reason. Verbatim from the ga-vqhh23 CI failure (job 102498944987).
+			name: "strips the dolt guard's startup stale-sweep block",
+			in: "cmd/gc test dolt leak guard: startup sweep reaping 1 stale cmd/gc test dolt sql-server process(es)\n" +
+				"  pid=4242 argv=\"dolt sql-server --config /tmp/x/hq/.beads/config.yaml\"\n" +
+				"Error: unknown command \"missing\" for \"gc backstage\"\n",
+			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
+		},
+		{
+			name: "strips the dolt guard's teardown leak block",
+			in: "Error: unknown command \"missing\" for \"gc backstage\"\n" +
+				"cmd/gc test dolt leak guard: leaked 1 dolt sql-server process(es) under /tmp/gct-1-a\n" +
+				"  pid=4243 argv=\"dolt sql-server --config /tmp/gct-1-a/r001/.beads/config.yaml\"\n",
+			want: "Error: unknown command \"missing\" for \"gc backstage\"\n",
+		},
+		{
+			name: "strips the dolt guard's orphan-store-dir and scan-error lines",
+			in: "cmd/gc test dolt leak guard: startup sweep removed orphaned dolt store dir /tmp/tmp.abc\n" +
+				"cmd/gc test dolt leak guard: startup sweep error: permission denied\n" +
+				"Usage:\n",
+			want: "Usage:\n",
+		},
+		{
+			// The actual ga-vqhh23 regression: the eager side reaped a stale
+			// server and announced it, the lazy side had nothing left to reap.
+			// After stripping, both sides must compare equal.
+			name: "eager-with-dolt-noise and lazy-empty normalize to equal",
+			in: "cmd/gc test dolt leak guard: startup sweep reaping 1 stale cmd/gc test dolt sql-server process(es)\n" +
+				"  pid=4242 argv=\"dolt sql-server --config /tmp/x/hq/.beads/config.yaml\"\n",
+			want: "",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := stripTmuxLeakGuardNoise(test.in); got != test.want {
-				t.Fatalf("stripTmuxLeakGuardNoise(%q) = %q, want %q", test.in, got, test.want)
+			if got := stripLeakGuardNoise(test.in); got != test.want {
+				t.Fatalf("stripLeakGuardNoise(%q) = %q, want %q", test.in, got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes half of main's ~26-hour red window (ga-vqhh23).

## What was breaking

`TestPackCommandCobraHelpAndUnknownParity` asserts that a command produces
identical stderr under eager and lazy dispatch. On main it failed with:

```
stderr differs between eager and lazy dispatch
eager:
cmd/gc test dolt leak guard: startup sweep reaping 1 stale cmd/gc test dolt sql-server process(es)

lazy:
<empty>
```

The eager side's entire stderr is the dolt leak guard's startup sweep
announcing a reap. The lazy side, having no stale server left by then, printed
nothing. The parity assertion then failed on a difference that has nothing to
do with cobra dispatch.

## Root cause

`TestMain` wraps `m` in two leak guards — `newDoltLeakGuardedTestingM` inside,
`newTmuxLeakGuardedTestingM` outside. Both write diagnostics to `os.Stderr`,
and both re-run in every re-exec'd subprocess spawned by
`runPackCommandProcess`, which captures that stderr and compares the two sides
for equality.

The sanitizer already existed, but it only ever knew the tmux guard's header
prefix. The dolt guard's header (`cmd/gc test dolt leak guard: `) was never
added, so it survived into the compared value.

That also predicts the exact shape of the failure, which is what makes this the
mechanism rather than a plausible story: both guards emit their per-process
detail lines with the same `  pid=` prefix, and that case was already covered,
so the only survivor is the single header line. The failing job shows exactly a
one-line residue.

## The change

- Add the dolt guard's header prefix to the filter.
- Rename `stripTmuxLeakGuardNoise` to `stripLeakGuardNoise`, since it now
  covers both guards and leaving `Tmux` in the name is how the next person
  re-introduces the gap.
- Four new cases: the dolt guard's startup stale-sweep, teardown-leak,
  orphan-store-dir and scan-error lines, plus the eager-noise/lazy-empty pair
  that reproduces the regression directly. The five existing tmux cases are
  unchanged.
- A coverage rule in the doc comment for whoever adds the next guard to
  `TestMain`.

Test-only; no production code is touched.

## Relationship to ga-szv0ge

Complementary, not dependent. ga-szv0ge is the leak itself — test-created
stores look production-shaped to beads, so auto-started dolt servers are never
cleaned up. Fixing it removes today's trigger. But the parity assertion should
not depend on whether a housekeeping sweep happened to have something to say,
so this is worth fixing on its own. Both should land.

## Verification

```
go test ./cmd/gc/ -run TestStripLeakGuardNoise -count=1 -v     # 9/9 pass
go test ./cmd/gc/ -run TestPackCommandCobraHelpAndUnknownParity -count=1
go vet ./cmd/gc/
```

Full local fast gate (`test-local-parallel fast`, 10 jobs) passed on the pushed
head, including `unit-cmd-gc-2-of-6` — the shard that has failed on every one
of main's last five CI runs.

## Not fixed here

Main's red is at least three independent conditions. The other two:

- `TestE2E_SuspendResume_City` missing its citysus report — tracked on
  ga-dqd7gf, where I recorded the main-CI sighting. Also five-for-five on main.
- `internal/productmetrics` `RecordOnce = dropped, want stored replay` — filed
  as ga-p38ayk. Fresh intermittent, one of the last five runs.
