### PR TITLE
fix(cmd/gc): drop unused flag param from argvFlagValue (unparam)

### DIFF
--- a/cmd/gc/dolt_cleanup_reaper.go
+++ b/cmd/gc/dolt_cleanup_reaper.go
@@ -136,11 +136,11 @@ func extractConfigPath(argv []string) string {
 }
 
 // extractDataDirPath pulls the --data-dir <path> argument from a dolt
-// sql-server argv, reusing the generic flag-value parser already shared by
-// the standalone-conflict detector (dolt_standalone_conflict.go) rather than
-// hand-rolling a second parser.
+// sql-server argv, reusing the parser already shared by the
+// standalone-conflict detector (dolt_standalone_conflict.go) rather than
+// hand-rolling a second one.
 func extractDataDirPath(argv []string) string {
-	v, _ := argvFlagValue(argv, "--data-dir")
+	v, _ := argvFlagValue(argv)
 	return v
 }
 

--- a/cmd/gc/dolt_standalone_conflict.go
+++ b/cmd/gc/dolt_standalone_conflict.go
@@ -100,14 +100,20 @@ func doltSQLServerProcessOwnsDataDir(pid int, argv []string, args, dataDir strin
 }
 
 func argvDataDirMatches(argv []string, dataDir string) (bool, bool) {
-	value, ok := argvFlagValue(argv, "--data-dir")
+	value, ok := argvFlagValue(argv)
 	if !ok {
 		return false, false
 	}
 	return samePath(value, dataDir), true
 }
 
-func argvFlagValue(argv []string, flag string) (string, bool) {
+// argvFlagValue extracts the --data-dir value from a dolt sql-server argv,
+// handling both "--data-dir value" and "--data-dir=value" forms. The only
+// flag ever looked up here is --data-dir (dolt_cleanup_reaper.go's
+// extractDataDirPath is the other caller); it is not a parameter because no
+// second flag is in use.
+func argvFlagValue(argv []string) (string, bool) {
+	const flag = "--data-dir"
 	for i, arg := range argv {
 		if arg == flag {
 			if i+1 >= len(argv) {


### PR DESCRIPTION
## Summary
- `argvFlagValue` always received `"--data-dir"` from both call sites, so golangci-lint's `unparam` check flags the `flag` parameter as dead. This is a pre-existing finding on `main`, not introduced by any pending PR.
- Drop the `flag` parameter and inline the literal as a local `const` inside the function (both callers already agreed on the same value); update the doc comment on the other call site in `dolt_cleanup_reaper.go`.

## Why now
This finding is what's surfacing on external contributor PR #3389's Preflight/static checks — that PR adds two more callers of `argvFlagValue`, both also passing `"--data-dir"`, which makes lint-affected pick up the pre-existing issue. Fork is org-owned so we can't push a fix to their branch directly; clearing it on `main` means it disappears for them on their next rebase.

## Test plan
- [x] `go build ./cmd/gc/...`
- [x] `go vet ./cmd/gc/...`
- [x] `golangci-lint run --enable-only unparam ./cmd/gc/...` — 0 issues
- [x] `make lint-changed` — 0 issues
- [x] Targeted `go test ./cmd/gc/...` for all `argvFlagValue`/data-dir-adjacent tests — all PASS
- [x] Full `./scripts/test-local-parallel fast` (pre-push gate) — all 10 jobs passed

refs ga-343l2s