### PR TITLE
fix(dolt): make leaked test store reapable via beads_test prefix (ga-szv0ge)

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -12315,7 +12315,15 @@ provider = "bd"
 		return alreadyErr
 	}
 
-	err := initBeadsForDirWithExecutor(cityDir, rigDir, "gsp", "gsp", execute)
+	// doltDatabase is deliberately overridden to a beads_test-prefixed name
+	// (rather than the "gsp" a real gascity-packs rig would use) because
+	// this test exercises the real finalizeCanonicalBdScopeInit success path
+	// (it opens a real store — see initBeadsForDirWithExecutor's
+	// isBdAlreadyInitializedError branch), which the fake execute above
+	// never touches. The prefix keeps that store identifiable and reapable
+	// by defaultStaleDatabasePrefixes (ga-szv0ge) instead of colliding with
+	// production "gsp" naming.
+	err := initBeadsForDirWithExecutor(cityDir, rigDir, "gsp", "beads_test_gsp", execute)
 	if errors.Is(err, alreadyErr) {
 		t.Fatalf("initBeadsForDirWithExecutor error = %v, want the recovery to be treated as success", err)
 	}

--- a/cmd/gc/dolt_cleanup_drop_planner.go
+++ b/cmd/gc/dolt_cleanup_drop_planner.go
@@ -17,8 +17,14 @@ import "strings"
 //   - beads_vr*: orchestrator mail/router_test.go random prefixes
 //   - beads_t[0-9a-f]*: protocol test random prefixes (t + 8 hex chars)
 //   - beads_test_bench_*: benchmark test fixture databases
+//   - beads_test*: gc-side test-owned scope override marker (ga-szv0ge) —
+//     tests that must exercise the real finalizeCanonicalBdScopeInit store
+//     open (so cannot be satisfied by a fake executor alone) pass this
+//     prefix as their doltDatabase override so any leaked database is
+//     reapable here even though the process/config-path reaper in
+//     dolt_cleanup_reaper.go never sees it
 var defaultStaleDatabasePrefixes = []string{
-	"testdb_", "test_guard_", "test_federation_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t", "beads_test_bench_",
+	"testdb_", "test_guard_", "test_federation_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t", "beads_test_bench_", "beads_test",
 }
 
 // systemDatabaseNames are the Dolt/MySQL system databases that SHOW

--- a/cmd/gc/dolt_cleanup_drop_planner_test.go
+++ b/cmd/gc/dolt_cleanup_drop_planner_test.go
@@ -185,12 +185,37 @@ func TestPlanDoltDrops_EmptyInputsProduceEmptyPlan(t *testing.T) {
 	}
 }
 
+func TestPlanDoltDrops_RecognizesGCSideTestScopeOverrideMarker(t *testing.T) {
+	// ga-szv0ge: TestInitBeadsForDirWithExecutorTreatsAlreadyInitializedRecoveryAsSuccess
+	// exercises the real finalizeCanonicalBdScopeInit store-open path and
+	// leaks a database named "beads_test_gsp" (its doltDatabase override).
+	// Confirm the planner actually treats that literal name as stale, and
+	// that it never collides with a name a real prefix-named rig (or the
+	// beads_t protocol-test negative fixtures) could plausibly use.
+	all := []string{"beads_test_gsp", "gsp", "beads_team", "beads_tenant", "beads_tmp_prod"}
+
+	plan := planDoltDrops(all, defaultStaleDatabasePrefixes, nil)
+
+	wantDrop := []string{"beads_test_gsp"}
+	if !equalStringSlice(plan.ToDrop, wantDrop) {
+		t.Errorf("ToDrop = %v, want %v", plan.ToDrop, wantDrop)
+	}
+	if len(plan.Skipped) != 0 {
+		t.Errorf("Skipped = %v, want empty", plan.Skipped)
+	}
+}
+
 func TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases(t *testing.T) {
 	// be-hjj-3 is the beads-side bead that converges these prefixes; until
 	// then we mirror beads/cmd/bd/dolt.go:staleDatabasePrefixes.
+	//
+	// "beads_test" is a gc-side-only addition (ga-szv0ge) with no beads-side
+	// counterpart: it marks a gc test's explicit doltDatabase scope override
+	// rather than a beads-generated name, so it is not part of the mirror
+	// and be-hjj-3 convergence does not need to add it upstream.
 	want := []string{
 		"testdb_", "test_guard_", "test_federation_",
-		"doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t", "beads_test_bench_",
+		"doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t", "beads_test_bench_", "beads_test",
 	}
 	if !equalStringSlice(defaultStaleDatabasePrefixes, want) {
 		t.Errorf("defaultStaleDatabasePrefixes = %v, want %v", defaultStaleDatabasePrefixes, want)


### PR DESCRIPTION
## Summary
- `TestInitBeadsForDirWithExecutorTreatsAlreadyInitializedRecoveryAsSuccess` exercises the real `finalizeCanonicalBdScopeInit` store-open path (independent of its fake `execute` callback), which leaks a real dolt store/process. Confirmed live: several already-orphaned `dolt sql-server` processes rooted at this test's temp dirs were found running with their `--config` path already deleted out from under them.
- `finalizeCanonicalBdScopeInit` never exposes the opened store handle back to the caller, so a `t.Cleanup`-based fix isn't available without changing that function's signature (out of scope per this bead's ruling — production-path behavior of `finalizeCanonicalBdScopeInit` is untouched).
- Fix is naming-based instead: override the test's `doltDatabase` to `beads_test_gsp` (was `gsp`, which collides with real gascity-packs rig naming — `defaultScopeDoltDatabase` names rig-scoped databases after their prefix), and add `"beads_test"` to `defaultStaleDatabasePrefixes` so any leaked database is identifiable and reapable by the drop planner even though the process/config-path reaper (`dolt_cleanup_reaper.go`) doesn't independently rely on the database name.
- Also fixes `TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases`, a golden-list test pinning the exact contents of `defaultStaleDatabasePrefixes` that wasn't covered by the `-run` filter used during initial verification and would otherwise have gone red on merge. Added a direct regression test (`TestPlanDoltDrops_RecognizesGCSideTestScopeOverrideMarker`) proving the exact override name `beads_test_gsp` is classified as a drop candidate and does not collide with the `beads_team`/`beads_tenant`/`beads_tmp_prod` negative fixtures.

## Test plan
- [x] `go build ./cmd/gc/...`
- [x] `go vet ./cmd/gc/...` and full-repo `go vet ./...` (via pre-commit hook)
- [x] `lint-changed` via `.githooks/pre-commit` — 0 issues
- [x] Targeted: `TestInitBeadsForDirWithExecutorTreatsAlreadyInitializedRecoveryAsSuccess` PASS
- [x] Targeted: all `TestPlanDoltDrops_*`, `TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases`, `TestValidDoltDatabaseIdentifierBoundaries` PASS (no regressions to existing false-positive-safety assertions)
- [x] Full fast suite via pre-push hook (`unit-core` + all 6 `unit-cmd-gc-*-of-6` shards) — all passed