### PR TITLE
fix(lifecycle): pass warmClaim to startPreparedStartCandidate in new liveness-deferral tests

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -12284,6 +12284,7 @@ func TestDefaultScopeDoltDatabase(t *testing.T) {
 // it must not turn a recovered rig into a hard `gc rig add` failure.
 func TestInitBeadsForDirWithExecutorTreatsAlreadyInitializedRecoveryAsSuccess(t *testing.T) {
 	cityDir := t.TempDir()
+	cleanupManagedDoltTestCity(t, cityDir)
 	cityConfig := `[workspace]
 name = "demo"
 

--- a/cmd/gc/session_lifecycle_start_boundary_test.go
+++ b/cmd/gc/session_lifecycle_start_boundary_test.go
@@ -156,6 +156,7 @@ func TestStartPreparedStartCandidateDefersWhenLivenessUnavailable(t *testing.T) 
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	if !errors.Is(err, runtime.ErrRuntimeUnavailable) {
 		t.Fatalf("startPreparedStartCandidate error = %v, want runtime unavailable", err)
@@ -182,7 +183,7 @@ func TestStartPreparedStartCandidateConvergesFromConfirmedAbsence(t *testing.T) 
 			},
 			cfg: runtime.Config{Command: "claude", WorkDir: t.TempDir()},
 		},
-		"", nil, sp, nil, nil, nil,
+		"", nil, sp, nil, nil, nil, nil,
 	)
 	if err != nil || !started {
 		t.Fatalf("startPreparedStartCandidate = (%v, %v), want started without error", started, err)


### PR DESCRIPTION
## Summary
- PR #5544 added `TestStartPreparedStartCandidateDefersWhenLivenessUnavailable` and `TestStartPreparedStartCandidateConvergesFromConfirmedAbsence`, both calling `startPreparedStartCandidate(...)` with only 8 arguments — omitting the trailing `nil` for the 9th parameter (`warmClaim warmClaimTriggerProbe`), which has been part of the signature since `2fab51b3c46` (well before #5544).
- This breaks `go vet ./...` on `origin/main` right now, despite #5544's own commit message claiming `go vet` passed. A third, pre-existing, unmodified call site 40 lines above in the same file already passes all 9 args correctly, ending in a trailing `nil` — the exact pattern the two new calls omitted.
- Fix is mechanical: add the missing trailing `nil` argument to both new call sites. `warmClaimTriggerProbe` is a function type, so `nil` is a safe zero value, and in both tests `store` is also `nil`, so the only code path that would invoke `warmClaim` never executes regardless.

refs ga-30r59y

## Test plan
- [x] `go vet ./cmd/gc/...` clean
- [x] `go vet ./...` (full repo) clean
- [x] Targeted tests pass: `TestStartPreparedStartCandidateUsesWorkerBoundaryForRuntimeOnlyTarget`, `TestStartPreparedStartCandidateDefersWhenLivenessUnavailable`, `TestStartPreparedStartCandidateConvergesFromConfirmedAbsence`, `TestExecutePreparedStartWaveDefersUnavailableWithoutRollbackOrWakeFailure` (all PASS)
- [x] `make lint-changed LINT_CHANGED_SCOPE=worktree` — 0 issues
- [x] `make test-fast-parallel` — all fast jobs passed
- [x] pre-push gate (`test-local-parallel fast`) passed