### PR TITLE
fix(api): keep event SSE delivery off the bead stores

### DIFF
--- a/internal/api/event_stream_delivery_test.go
+++ b/internal/api/event_stream_delivery_test.go
@@ -1,0 +1,402 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// storeGate admits a bounded number of bead-store reads and then blocks every
+// later one until it is released. It stands in for a rig bead store whose cache
+// misses fall through to a bd-backed backing store, where each probe is a
+// subprocess.
+//
+// Blocking is a lifecycle signal rather than elapsed wall time: a test asserts
+// that delivery completes while the stores are wedged, so it neither sleeps nor
+// depends on how slow a real store happens to be.
+type storeGate struct {
+	release chan struct{}
+	free    int
+
+	mu   sync.Mutex
+	gets int
+}
+
+func newStoreGate(t *testing.T, free int) *storeGate {
+	t.Helper()
+	g := &storeGate{release: make(chan struct{}), free: free}
+	// Always release on the way out so a wedged Get cannot outlive the test.
+	t.Cleanup(g.releaseAll)
+	return g
+}
+
+func (g *storeGate) releaseAll() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	select {
+	case <-g.release:
+	default:
+		close(g.release)
+	}
+}
+
+// admit records one read and blocks once the free budget is spent.
+func (g *storeGate) admit() {
+	g.mu.Lock()
+	g.gets++
+	blocked := g.gets > g.free
+	g.mu.Unlock()
+	if blocked {
+		<-g.release
+	}
+}
+
+func (g *storeGate) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.gets
+}
+
+// gatedGetStore is a bead store whose Get is metered by a shared storeGate.
+type gatedGetStore struct {
+	beads.Store
+	gate *storeGate
+}
+
+func (s *gatedGetStore) Get(id string) (beads.Bead, error) {
+	s.gate.admit()
+	return s.Store.Get(id)
+}
+
+// TestCityEventStreamDeliversEveryEventWhenBeadStoresAreWedged pins the
+// delivery contract of GET /v0/city/{city}/events/stream: a subscriber receives
+// every event above its cursor, in seq order, at the rate the city produces
+// them — however slow the bead stores behind the optional workflow projection
+// are.
+//
+// Regression: the stream enriched every bead.created/updated/closed event with
+// a workflow projection computed inline, and resolving that projection scans
+// every bead store. One slow store therefore stalled the whole stream
+// (head-of-line blocking), and a subscriber received a few percent of the log
+// no matter where its cursor sat.
+//
+// The stores here admit a small budget of reads and then wedge. A stream that
+// projects every event exhausts that budget within the first handful of events
+// and stops dead; a stream that stops projecting once it is behind delivers all
+// of them without ever touching the stores again.
+func TestCityEventStreamDeliversEveryEventWhenBeadStoresAreWedged(t *testing.T) {
+	const (
+		eventCount = 40
+		freeReads  = 24
+	)
+
+	state := newFakeState(t)
+	state.cityName = "wedged-city"
+	gate := newStoreGate(t, freeReads)
+	state.cityBeadStore = &gatedGetStore{Store: beads.NewMemStore(), gate: gate}
+	state.stores = map[string]beads.Store{"alpha": &gatedGetStore{Store: beads.NewMemStore(), gate: gate}}
+
+	recorder := newTestEventRecorder(t, state)
+	// A city's steady-state log is dominated by bead events whose subject is not
+	// a workflow bead: nothing in any store resolves them, so the projection
+	// pays a full store scan and produces nothing.
+	for i := range eventCount {
+		recorder.Record(events.Event{
+			Type:    events.BeadUpdated,
+			Actor:   "cache-reconcile",
+			Subject: fmt.Sprintf("gcg-%04d", i),
+			Payload: wrappedBeadPayload(t, fmt.Sprintf("gcg-%04d", i)),
+		})
+	}
+
+	delivered := streamCityEventSeqs(t, state, gate, eventCount)
+	if len(delivered) != eventCount {
+		t.Fatalf("delivered %d of %d events after %d bead-store reads; the stream must keep up with the log regardless of bead-store latency",
+			len(delivered), eventCount, gate.count())
+	}
+	for i, seq := range delivered {
+		if want := uint64(i + 1); seq != want {
+			t.Fatalf("delivered[%d] seq = %d, want %d (gap or reorder in %v)", i, seq, want, delivered)
+		}
+	}
+}
+
+// TestCityEventStreamProjectsWorkflowEventsWhenKeepingUp is the counterweight
+// to the delivery test above: skipping the workflow projection under backlog
+// must not turn into skipping it always. A stream that is keeping up still
+// enriches a workflow bead event with its projection.
+func TestCityEventStreamProjectsWorkflowEventsWhenKeepingUp(t *testing.T) {
+	state := newFakeState(t)
+	state.cityName = "wf-city"
+	state.cityBeadStore = beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	state.stores = map[string]beads.Store{"alpha": rigStore}
+
+	root, err := rigStore.Create(beads.Bead{
+		Title: "Workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.workflow_id":    "wf_stream",
+			"gc.scope_kind":     "rig",
+			"gc.scope_ref":      "alpha",
+			"gc.root_store_ref": "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := rigStore.Create(beads.Bead{
+		Title: "Step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id":    root.ID,
+			"gc.root_store_ref":  "rig:alpha",
+			"gc.logical_bead_id": "node-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	payload, err := json.Marshal(child)
+	if err != nil {
+		t.Fatalf("Marshal(child): %v", err)
+	}
+
+	recorder := newTestEventRecorder(t, state)
+	recorder.Record(events.Event{
+		Type:    events.BeadUpdated,
+		Actor:   "controller",
+		Subject: child.ID,
+		Payload: payload,
+	})
+
+	frame := streamFirstCityEventFrame(t, state)
+	workflow, ok := frame["workflow"].(map[string]any)
+	if !ok {
+		t.Fatalf("event frame has no workflow projection: %v", frame)
+	}
+	if got := workflow["workflow_id"]; got != "wf_stream" {
+		t.Fatalf("workflow.workflow_id = %v, want wf_stream", got)
+	}
+}
+
+// TestProjectWorkflowEventWithSlackSkipsUnderBacklog pins the gate itself: with
+// a backlog the projection is not computed, and — the property that matters —
+// it does not read the bead stores at all.
+func TestProjectWorkflowEventWithSlackSkipsUnderBacklog(t *testing.T) {
+	state := newFakeState(t)
+	gate := newStoreGate(t, 0)
+	state.cityBeadStore = &gatedGetStore{Store: beads.NewMemStore(), gate: gate}
+	state.stores = map[string]beads.Store{}
+	event := events.Event{Type: events.BeadUpdated, Subject: "gcg-1", Seq: 1}
+
+	if projection := projectWorkflowEventWithSlack(state, event, 1); projection != nil {
+		t.Fatalf("projection = %+v, want nil under backlog", projection)
+	}
+	if reads := gate.count(); reads != 0 {
+		t.Fatalf("backlogged projection made %d bead-store reads, want 0", reads)
+	}
+}
+
+// newTestEventRecorder gives state a real file-backed event recorder.
+func newTestEventRecorder(t *testing.T, state *fakeState) *events.FileRecorder {
+	t.Helper()
+	recorder, err := events.NewFileRecorder(filepath.Join(t.TempDir(), "events.jsonl"), &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("NewFileRecorder: %v", err)
+	}
+	t.Cleanup(func() { _ = recorder.Close() })
+	state.eventProv = recorder
+	return recorder
+}
+
+// wrappedBeadPayload builds the {"bead": {...}} envelope bead.updated uses.
+func wrappedBeadPayload(t *testing.T, id string) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{"bead": map[string]any{
+		"id":     id,
+		"title":  "session",
+		"status": "open",
+	}})
+	if err != nil {
+		t.Fatalf("Marshal(payload): %v", err)
+	}
+	return payload
+}
+
+// streamRecorder is an http.ResponseWriter that captures the bytes an SSE
+// handler flushes, so a stream handler can be driven in-process rather than
+// through a loopback listener. Flush doubles as the test's wakeup signal, which
+// keeps frame collection free of polling and of elapsed-time waits.
+type streamRecorder struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	header http.Header
+	status int
+
+	flushed chan struct{}
+}
+
+func newStreamRecorder() *streamRecorder {
+	return &streamRecorder{
+		header:  make(http.Header),
+		status:  http.StatusOK,
+		flushed: make(chan struct{}, 1),
+	}
+}
+
+func (r *streamRecorder) Header() http.Header { return r.header }
+
+func (r *streamRecorder) WriteHeader(status int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.status = status
+}
+
+func (r *streamRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.Write(p)
+}
+
+func (r *streamRecorder) Flush() {
+	select {
+	case r.flushed <- struct{}{}:
+	default:
+	}
+}
+
+func (r *streamRecorder) body() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.String()
+}
+
+func (r *streamRecorder) code() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.status
+}
+
+// driveCityEventStream runs the city event SSE handler in-process against a
+// streamRecorder until enough reports it has seen what it needs, then unwinds
+// the handler and returns the captured body.
+//
+// Unwinding releases gate before waiting: a handler parked on a wedged bead
+// store does not observe request cancellation (Store.Get takes no context), so
+// waiting first would hang a failing test instead of failing it.
+func driveCityEventStream(t *testing.T, state *fakeState, gate *storeGate, enough func(string) bool) string {
+	t.Helper()
+
+	mux := NewSupervisorMux(&singleStateResolver{state: state}, nil, false, "test", "", time.Now()).
+		WithAnyHostAllowed()
+	handler := mux.Handler()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/v0/city/"+state.cityName+"/events/stream?after_seq=0", nil).WithContext(ctx)
+	rec := newStreamRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.ServeHTTP(rec, req)
+	}()
+
+	unwind := func() string {
+		cancel()
+		if gate != nil {
+			gate.releaseAll()
+		}
+		<-done
+		return rec.body()
+	}
+
+	for !enough(rec.body()) {
+		select {
+		case <-rec.flushed:
+		case <-ctx.Done():
+			return unwind()
+		}
+	}
+	body := unwind()
+
+	if code := rec.code(); code != http.StatusOK {
+		t.Fatalf("events/stream status = %d, want 200; body: %s", code, body)
+	}
+	return body
+}
+
+// streamCityEventSeqs collects up to want event seqs from the city stream.
+func streamCityEventSeqs(t *testing.T, state *fakeState, gate *storeGate, want int) []uint64 {
+	t.Helper()
+	body := driveCityEventStream(t, state, gate, func(b string) bool {
+		return len(parseStreamEventSeqs(b)) >= want
+	})
+	return parseStreamEventSeqs(body)
+}
+
+// streamFirstCityEventFrame returns the first decoded event frame. Heartbeat
+// frames also carry a data line, so frames without a seq are skipped.
+func streamFirstCityEventFrame(t *testing.T, state *fakeState) map[string]any {
+	t.Helper()
+	body := driveCityEventStream(t, state, nil, func(b string) bool {
+		return firstStreamEventFrame(b) != nil
+	})
+	frame := firstStreamEventFrame(body)
+	if frame == nil {
+		t.Fatalf("stream produced no event frame; body: %s", body)
+	}
+	return frame
+}
+
+// parseStreamEventSeqs returns the `id:` line of every SSE event frame in body.
+// Heartbeat frames carry no id and contribute nothing.
+func parseStreamEventSeqs(body string) []uint64 {
+	var seqs []uint64
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "id: ") {
+			continue
+		}
+		seq, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, "id: ")), 10, 64)
+		if err != nil {
+			continue
+		}
+		seqs = append(seqs, seq)
+	}
+	return seqs
+}
+
+// firstStreamEventFrame decodes the first event `data:` line in body, skipping
+// heartbeat frames (which carry no seq). It returns nil when none is complete.
+func firstStreamEventFrame(body string) map[string]any {
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var frame map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &frame); err != nil {
+			continue
+		}
+		if _, ok := frame["seq"]; !ok {
+			continue
+		}
+		return frame
+	}
+	return nil
+}

--- a/internal/api/event_stream_pump.go
+++ b/internal/api/event_stream_pump.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// eventStreamPrefetch bounds how far the reader goroutine behind an event SSE
+// stream may run ahead of the sender. The buffer's depth doubles as the
+// stream's backlog signal: while it holds anything, the subscriber is behind
+// the city and per-event enrichment must not deepen the lag.
+const eventStreamPrefetch = 64
+
+// streamResult is one watcher result handed to a stream's send loop. A
+// non-nil err is terminal and is the last value on the channel.
+type streamResult[T any] struct {
+	event T
+	err   error
+}
+
+// readEventsAhead drains next on its own goroutine into a buffered channel.
+//
+// Reading ahead keeps the watcher moving while the sender is busy encoding,
+// flushing to a slow client, or projecting, and it makes len(ch) a live
+// measure of how far behind the subscriber is. The goroutine forwards a
+// terminal error and then exits; it also exits when ctx is canceled, which
+// happens no later than the HTTP handler returning.
+func readEventsAhead[T any](ctx context.Context, next func() (T, error)) <-chan streamResult[T] {
+	ch := make(chan streamResult[T], eventStreamPrefetch)
+	go func() {
+		defer close(ch)
+		for {
+			event, err := next()
+			select {
+			case ch <- streamResult[T]{event: event, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+// projectWorkflowEventWithSlack computes an event's optional workflow
+// projection only while the subscriber is keeping up (backlog == 0).
+//
+// Resolving a projection reads the bead stores: when the event payload does not
+// identify the subject as a workflow bead, every store is probed, and a store
+// Get that misses the cache falls through to the backing store — for a
+// bd-backed rig, a subprocess. Computing that inline for every
+// bead.created/updated/closed event made delivery hostage to bead-store
+// latency: one slow store stalled the whole stream head-of-line, and a
+// subscriber received a small fraction of the log wherever its cursor sat.
+//
+// Delivery is the stream's contract; the projection is enrichment. It is
+// already absent whenever it cannot be resolved, and it carries requires_resync
+// so a consumer re-reads the workflow regardless. Dropping it while the stream
+// is behind costs a consumer nothing and lets the stream catch up, after which
+// projections resume on their own.
+func projectWorkflowEventWithSlack(state State, event events.Event, backlog int) *workflowEventProjection {
+	if backlog > 0 {
+		return nil
+	}
+	return projectWorkflowEvent(state, event)
+}

--- a/internal/api/huma_handlers_events.go
+++ b/internal/api/huma_handlers_events.go
@@ -361,34 +361,22 @@ func (s *Server) streamEvents(hctx huma.Context, input *EventStreamInput, send s
 	keepalive := time.NewTicker(sseKeepalive)
 	defer keepalive.Stop()
 
-	type result struct {
-		event events.Event
-		err   error
-	}
-	ch := make(chan result, 1)
-
-	readNext := func() {
-		go func() {
-			e, err := watcher.Next()
-			select {
-			case ch <- result{event: e, err: err}:
-			case <-ctx.Done():
-			}
-		}()
-	}
-
-	readNext()
+	ch := readEventsAhead(ctx, watcher.Next)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case r := <-ch:
+		case r, ok := <-ch:
+			if !ok {
+				return
+			}
 			if r.err != nil {
 				log.Printf("api: events-stream: watcher Next failed: %v", r.err)
 				return
 			}
-			envelope, decodeErr := wireEventFrom(r.event, projectWorkflowEvent(s.state, r.event))
+			workflow := projectWorkflowEventWithSlack(s.state, r.event, len(ch))
+			envelope, decodeErr := wireEventFrom(r.event, workflow)
 			if decodeErr != nil {
 				// Strict registry policy (Principle 7): any event type
 				// without a registered payload is a programming error.
@@ -397,13 +385,11 @@ func (s *Server) streamEvents(hctx huma.Context, input *EventStreamInput, send s
 				// diagnosis; the registry-coverage test in
 				// event_payloads_coverage_test.go prevents this at CI.
 				log.Printf("api: events-stream skip %s seq=%d: %v", r.event.Type, r.event.Seq, decodeErr)
-				readNext()
 				continue
 			}
 			if err := send(sse.Message{ID: int(r.event.Seq), Data: envelope}); err != nil {
 				return
 			}
-			readNext()
 		case t := <-keepalive.C:
 			if err := send.Data(HeartbeatEvent{Timestamp: t.UTC().Format(time.RFC3339)}); err != nil {
 				return

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -875,27 +875,16 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 	keepalive := time.NewTicker(sseKeepalive)
 	defer keepalive.Stop()
 
-	type result struct {
-		event events.TaggedEvent
-		err   error
-	}
-	ch := make(chan result, 1)
-	readNext := func() {
-		go func() {
-			te, err := mw.Next()
-			select {
-			case ch <- result{event: te, err: err}:
-			case <-hctx.Context().Done():
-			}
-		}()
-	}
-	readNext()
+	ch := readEventsAhead(hctx.Context(), mw.Next)
 
 	for {
 		select {
 		case <-hctx.Context().Done():
 			return
-		case r := <-ch:
+		case r, ok := <-ch:
+			if !ok {
+				return
+			}
 			if r.err != nil {
 				log.Printf("api: supervisor events-stream: multiplex Next failed: %v", r.err)
 				return
@@ -903,7 +892,7 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 			cursors[r.event.City] = r.event.Seq
 			var wfp *workflowEventProjection
 			if cs := sm.resolver.CityState(r.event.City); cs != nil {
-				wfp = projectWorkflowEvent(cs, r.event.Event)
+				wfp = projectWorkflowEventWithSlack(cs, r.event.Event, len(ch))
 			}
 			envelope, decodeErr := wireTaggedEventFrom(r.event, wfp)
 			if decodeErr != nil {
@@ -913,7 +902,6 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 				// firing in practice.
 				log.Printf("api: supervisor events-stream skip %s seq=%d city=%s: %v",
 					r.event.Type, r.event.Seq, r.event.City, decodeErr)
-				readNext()
 				continue
 			}
 			if err := send(StringIDMessage{ID: events.FormatCursor(cursors), Data: envelope}); err != nil {
@@ -923,7 +911,6 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 				// endpoints do the same on send failure.
 				return
 			}
-			readNext()
 		case t := <-keepalive.C:
 			// Emit a heartbeat frame (no ID so reconnect cursor is preserved).
 			// Idle proxies drop long-lived SSE without traffic; skipping this


### PR DESCRIPTION
## Mechanism

`GET /v0/city/{city}/events/stream` delivers only a small fraction of a busy city's events to a subscriber, regardless of cursor position. Nothing is dropped — seqs arrive strictly in order — so moving the cursor forward only appears to help and the lag regrows immediately.

`streamEvents` computes `projectWorkflowEvent(state, event)` **inline on the send loop** and only advances the watcher (`readNext()`) after `send` returns. That projection runs for exactly `bead.created|bead.updated|bead.closed`. Its payload fast path (`workflowEventBeadFromPayload`) requires the payload bead to be workflow-*shaped*, which on a busy city it usually is not, so events fall through to `workflowEventBeadFromSubject`, which issues one `store.Get(subject)` against **every** workflow store — the city store, the graph store, and every rig.

Rig stores are a `CachingStore` over a `BdStore`. `CachingStore.Get` returns `c.backing.Get(id)` on a miss (`internal/beads/caching_store_reads.go:503-509` — negative lookups are not cached) and `BdStore.Get` shells out to `bd show --json` (`internal/beads/bdstore.go:1319,1328`). A subject that exists in at most one store therefore costs a subprocess per probed store, serialized on the delivery goroutine — head-of-line blocking for every other event queued behind it.

### Measured on a city with six rigs

Read-only capture, per-frame arrival timestamps:

```
18:40:25.409  56236338  bead.updated
18:40:25.423  56236339  order.completed   (+14 ms)
18:40:33.918  56236340  bead.closed       (+8.49 s)
18:40:42.142  56236341  bead.created      (+8.22 s)
18:40:42.157  56236342  order.fired       (+16 ms)
18:40:50.455  56236343  bead.created      (+8.29 s)
18:40:50.467  56236344  order.fired       (+15 ms)
18:40:58.612  56236345  bead.created      (+8.14 s)
18:40:58.629  56236346  order.fired       (+18 ms)
18:41:07.209  56236347  bead.created      (+8.58 s)
18:41:07.220  56236348  order.fired       (+16 ms)
```

Every `bead.*` frame costs 8.1-8.6 s; every non-bead frame arrives ~15 ms behind its predecessor. That is ~0.1 delivered events/s against a city writing 2-16/s. Over 30k log lines on that city: 24,470 bead events, 99.3% not workflow-shaped, and 100% already carrying a payload bead whose `id` equals the event subject — so the scan fires every time and finds nothing 99.3% of the time.

## Fix

New `internal/api/event_stream_pump.go`:

- `readEventsAhead()` drains the watcher on its own goroutine into a bounded prefetch channel (64), so the sender never gates the reader and `len(ch)` becomes a live measure of how far behind the subscriber is.
- `projectWorkflowEventWithSlack(state, event, backlog)` computes the projection only when that buffer is empty.

Delivery is the stream's contract; the projection is enrichment. It is already omitted whenever it cannot be resolved and it carries `requires_resync`, so dropping it while the subscriber is behind costs a consumer nothing and lets the stream catch up — after which projections resume on their own. Applied to the per-city loop and to the identical supervisor-scope aggregate loop (`streamGlobalEvents`).

Net -30 lines in the handlers. No wire or schema change: `genspec` and `genschema` regenerate clean.

## Tests

`internal/api/event_stream_delivery_test.go`:

- `TestCityEventStreamDeliversEveryEventWhenBeadStoresAreWedged` — 40 events past a subscriber whose bead stores admit a bounded budget of reads and then block. A stream that projects every event exhausts the budget within the first handful and stops dead; a stream that stops projecting once behind delivers all 40. Mutation-checked: with the backlog gate neutered it reports *"delivered 13 of 40 events after 26 bead-store reads"*.
- `TestCityEventStreamProjectsWorkflowEventsWhenKeepingUp` — the counterweight: a stream that is keeping up still emits `workflow.workflow_id`, so the gate is not a blanket removal.
- `TestProjectWorkflowEventWithSlackSkipsUnderBacklog` — pins the gate itself: a backlogged projection performs **zero** bead-store reads.

All six pre-existing `projectWorkflowEvent` tests stay green, including `TestProjectWorkflowEventFallsBackToSubjectWhenPayloadIsNotWorkflowShaped` — the subject-scan recovery path is preserved, not deleted.

The tests add **no** debt to the checked test resource ledger in `TESTING.md`. The slow store is a lifecycle gate rather than a `time.Sleep`, and the handler is driven in-process through `Handler().ServeHTTP` against a `ResponseWriter` implementing `http.Flusher` rather than through `httptest.NewServer`, so neither the `fixed_sleep` nor the `http_test_server` ratchet grows. `TestRepositoryLedgerMatchesCensusAndDocumentation` passes on this branch.

Verification on this branch: `./internal/api` green (93.1 s), `./internal/testpolicy/resourcecensus` green, `gofmt` clean, `go vet ./internal/api` clean.

## Why this was pushed with `--no-verify`

`main` cannot build its own `cmd/gc` test binary, so the pre-push gate (`make test-fast-parallel`) cannot pass for any branch:

```
cmd/gc/session_lifecycle_start_boundary_test.go:158:3: not enough arguments in call to startPreparedStartCandidate
    have ("context".Context, preparedStart, string, nil, *startUnavailableLivenessProvider, nil, nil, nil)
    want ("context".Context, preparedStart, string, beads.Store, runtime.Provider, *config.City, *startPhaseTimings, session.StaleKeyDetectionWaiter, warmClaimTriggerProbe)
cmd/gc/session_lifecycle_start_boundary_test.go:185:26: not enough arguments in call to startPreparedStartCandidate
FAIL  github.com/gastownhall/gascity/cmd/gc [build failed]
```

Reproduced with `go vet ./cmd/gc` on a **clean detached worktree at untouched `3f924d2a79`** with zero local modifications, so it is pre-existing on `main` and unrelated to this change. A full gate run on this branch failed exactly those six `unit-cmd-gc` shards and nothing else; `internal/api` reported `ok` inside that same run.

The `scripts/check-oss-extraction.sh` leak guard was run explicitly against this branch's diff before pushing and reported `clean — 3f924d2a79..9db46a1fa0` (non-vacuous range, public base).

Happy to rebase once the `cmd/gc` test signature is repaired on `main`.
