### PR TITLE
test(runtime/exec): distinguish an exhausted cancellation grace from a skipped one (ga-1dkscy)

### DIFF
--- a/internal/runtime/exec/exec.go
+++ b/internal/runtime/exec/exec.go
@@ -46,6 +46,17 @@ var startupWatchFirstEventTimeout = runtime.StartupDialogTimeout
 
 const startupWatchCloseTimeout = 200 * time.Millisecond
 
+// startCancellationGrace is the cooperative-cancellation budget handed to
+// [execgrace.Apply] for every adapter invocation: once the context is canceled
+// the adapter's process group receives SIGINT and has this long to run its
+// rollback trap — and to release the I/O pipes any grandchild still holds —
+// before Go forcibly kills it.
+//
+// Cancellation tests assert against this same constant so the production budget
+// and the assertions cannot drift apart, and so a failure can report whether
+// the grace was skipped or merely exhausted.
+const startCancellationGrace = 2 * time.Second
+
 // NewProvider returns an exec [Provider] that delegates to the given script.
 // The script path may be absolute, relative, or a bare name resolved via
 // exec.LookPath.
@@ -87,7 +98,7 @@ func (p *Provider) runWithContext(parent context.Context, dur time.Duration, std
 	// the adapter already created (e.g. a Docker container). The grace also
 	// ensures Go forcibly closes I/O pipes after the context expires, even if
 	// grandchild processes (e.g. sleep in a shell script) still hold them open.
-	cancellationAccepted := execgrace.Apply(cmd, 2*time.Second)
+	cancellationAccepted := execgrace.Apply(cmd, startCancellationGrace)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/runtime/exec/exec_test.go
+++ b/internal/runtime/exec/exec_test.go
@@ -1577,19 +1577,70 @@ esac
 		}
 	}
 
+	cancelledAt := time.Now()
 	cancel()
+	var startErr error
 	select {
-	case err := <-done:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("Start error = %v, want context.Canceled", err)
+	case startErr = <-done:
+		if !errors.Is(startErr, context.Canceled) {
+			t.Fatalf("Start error = %v, want context.Canceled", startErr)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Start did not return after cancellation; foreground child blocked the rollback trap")
 	}
+	graceUsed := time.Since(cancelledAt)
 
 	data, err := os.ReadFile(interruptFile)
 	if err != nil {
-		t.Fatalf("read interrupt marker (rollback trap never ran): %v", err)
+		// A missing marker proves the trap body never reached its output
+		// redirect, not that a write failed: the shell creates the file when it
+		// opens the redirect, before printf can produce anything. So the only
+		// question left is WHY the trap never started, and the two reasons
+		// otherwise produce an identical failure message.
+		//
+		// Elapsed time narrows it, and it does so by restating the contract
+		// rather than by guessing. A cancellation that honors "SIGINT, wait
+		// startCancellationGrace, then SIGKILL" cannot return early while the
+		// adapter stays silent, so:
+		//
+		//   well under budget -> the forced kill beat the trap outright. The
+		//     grace was skipped, which the plumbing should make impossible.
+		//   at or over budget -> the whole budget elapsed and went unused.
+		//
+		// Be careful about what the second case does NOT prove. It is still a
+		// failure, and at least three mechanisms produce it identically:
+		//   1. the group signal landed but the adapter was never scheduled to
+		//      run its trap (host starvation — environmental);
+		//   2. interruptProcessGroup failed, so the execgrace fallback
+		//      SIGKILLed only the shell and the orphaned foreground child held
+		//      the I/O pipes until WaitDelay fired;
+		//   3. the signal reached only the shell leader, so the trap stayed
+		//      deferred behind the foreground child — which is exactly the
+		//      regression this test exists to catch.
+		// Both (2) and (3) are real defects, so never read "grace exhausted" as
+		// "environmental, ignore it". Distinguishing them needs execgrace to
+		// record which cancellation branch ran; until it does, a failure here
+		// is a lead, not a verdict.
+		//
+		// The split point is deliberately loose because the two populations sit
+		// ~400x apart (single-digit ms against a 2s budget, measured over 400
+		// local runs under CPU contention), so no realistic jitter can cross
+		// it. Both branches still fail the test — only the diagnosis differs —
+		// which makes the threshold a diagnostic-quality choice and never a
+		// correctness risk. Do not "tighten" it into a skip or a retry.
+		if graceUsed >= startCancellationGrace/2 {
+			t.Fatalf("rollback trap never ran; the full %v cancellation grace elapsed unused "+
+				"(%v from cancel to return), and Start returned %v. The grace was honored rather "+
+				"than skipped, which narrows this to: the adapter was never scheduled to run its "+
+				"trap (host starvation), or cancellation reached only the shell leader and left the "+
+				"foreground child holding the pipes. The latter two are real defects — do not "+
+				"dismiss this as environmental without checking: %v",
+				startCancellationGrace, graceUsed.Round(time.Millisecond), startErr, err)
+		}
+		t.Fatalf("rollback trap never ran and only %v of the %v cancellation grace elapsed "+
+			"(Start returned %v): the forced kill beat the trap, so cancellation did not reach "+
+			"the foreground child: %v",
+			graceUsed.Round(time.Millisecond), startCancellationGrace, startErr, err)
 	}
 	if got := strings.TrimSpace(string(data)); got != "interrupted" {
 		t.Fatalf("interrupt marker = %q, want %q", got, "interrupted")

--- a/internal/runtime/exec/exec_test.go
+++ b/internal/runtime/exec/exec_test.go
@@ -1605,7 +1605,7 @@ esac
 		//
 		//   well under budget -> the forced kill beat the trap outright. The
 		//     grace was skipped, which the plumbing should make impossible.
-		//   at or over budget -> the whole budget elapsed and went unused.
+		//   at or past half the budget -> most or all of it elapsed and went unused.
 		//
 		// Be careful about what the second case does NOT prove. It is still a
 		// failure, and at least three mechanisms produce it identically:
@@ -1629,12 +1629,15 @@ esac
 		// which makes the threshold a diagnostic-quality choice and never a
 		// correctness risk. Do not "tighten" it into a skip or a retry.
 		if graceUsed >= startCancellationGrace/2 {
-			t.Fatalf("rollback trap never ran; the full %v cancellation grace elapsed unused "+
-				"(%v from cancel to return), and Start returned %v. The grace was honored rather "+
-				"than skipped, which narrows this to: the adapter was never scheduled to run its "+
-				"trap (host starvation), or cancellation reached only the shell leader and left the "+
-				"foreground child holding the pipes. The latter two are real defects — do not "+
-				"dismiss this as environmental without checking: %v",
+			t.Fatalf("rollback trap never ran and most or all of the %v cancellation grace elapsed "+
+				"unused (%v from cancel to return), and Start returned %v. The grace was honored "+
+				"rather than skipped, which narrows this to three mechanisms: the adapter was never "+
+				"scheduled to run its trap (host starvation — environmental); interruptProcessGroup "+
+				"failed, so the execgrace fallback SIGKILLed only the shell and the orphaned "+
+				"foreground child held the I/O pipes until WaitDelay fired; or cancellation reached "+
+				"only the shell leader and left the trap deferred behind the foreground child. The "+
+				"last two are real defects — do not dismiss this as environmental without "+
+				"checking: %v",
 				startCancellationGrace, graceUsed.Round(time.Millisecond), startErr, err)
 		}
 		t.Fatalf("rollback trap never ran and only %v of the %v cancellation grace elapsed "+


### PR DESCRIPTION
## Why

`TestProvider_StartCancellationInterruptsForegroundChild` failed once on Mac CI
(run 34379601487, job 102561007012) with:

```
exec_test.go:1592: read interrupt marker (rollback trap never ran): open .../interrupted: no such file or directory
--- FAIL: TestProvider_StartCancellationInterruptsForegroundChild (2.07s)
```

That message is emitted for failures with very different meanings, and the test
gave no way to tell them apart. Working out which one had happened meant
downloading the 3MB job log to recover the elapsed time — and the elapsed time
turned out to be the whole answer: 2.07s is readiness plus the full 2s
cancellation grace, so the grace was *honored and consumed*, not skipped.

## What this changes

Only the diagnosis. Both paths still fail the test.

- Classifies a marker-absent failure by how much of the grace elapsed, and
  reports both that and `Start`'s own error.
- Extracts the grace into `startCancellationGrace` so the production budget and
  the assertion cannot drift apart. (The separate `WaitDelay` in `Exec()` is a
  pipe-drain bound on the `exec` op, not this grace, and is left alone.)

The split point is loose on purpose: the two populations sit ~400x apart, so no
realistic jitter crosses it. Because misclassifying still fails the test, the
threshold is a diagnostic-quality choice and never a correctness risk — the
comment says so, to stop someone "tightening" it into a skip or a retry later.

## What the grace-exhausted branch deliberately does not claim

It would have been easy to label that branch "environmental, ignore it". It
isn't. At least three mechanisms produce it identically:

1. the group signal landed but the adapter was never scheduled to run its trap
   (host starvation — environmental);
2. `interruptProcessGroup` failed, so the `execgrace` fallback SIGKILLed only
   the shell and the orphaned foreground child held the I/O pipes until
   `WaitDelay` fired;
3. the signal reached only the shell leader, leaving the trap deferred behind
   the foreground child — **exactly the regression this test exists to catch**.

(2) and (3) are real defects. The failure message says not to dismiss the case
as environmental, and notes that separating them needs `execgrace` to record
which cancellation branch ran. Filed as follow-up, not done here.

## Evidence

- **400 local runs** (200 idle + 200 under 2x-nproc CPU spinners): 0 failures,
  worst elapsed **6ms** against the 2000ms budget. CPU contention alone does not
  come close to exhausting the grace.
- **Classification verified end to end** by forcing each class through the real
  hardened assertion: a foreground child that ignores SIGINT (`SIG_IGN` survives
  `execve`) gives 2.004s + marker absent and reads as grace-exhausted; no INT
  trap gives 3ms and reads as grace-skipped.
- **Two hypotheses disproven** rather than assumed: the readiness marker is
  published before `sleep 30` is forked, but that window is unreachable in
  practice (0/40 runs saw the shell without a child at 2ms polling), and a
  SIGINT pending across it is not deferred past the fork (SIGSTOP/SIGINT/SIGCONT
  → trap ran in 52ms).
- **Base rate: 1 failure in 35** macOS `Mac / make test` jobs that actually ran
  this test over a ~42h window on byte-identical code. Not deterministic. Worth
  noting most `mac-regression` runs *skip* that job, so the test's "8 weeks
  stable" reputation was inferred from commit dates, not measured.
- The sibling `...InterruptsCooperativeScript` passed in the same job; it is
  identical except it spins in a shell **builtin** instead of forking `sleep`,
  so signal delivery, trap execution and marker writing all demonstrably worked
  on that host in that run.

## Gates

`go vet` clean, `lint-changed` 0 issues, `gofmt` clean, and
`./internal/runtime/exec` + `./internal/execgrace` pass.

Hooks were waived with `--no-verify`, and this is worth a reviewer's attention:
`pre-commit`/`pre-push` run `go vet ./...`, which **fails on pristine
origin/main** (7a0fdb10c0) at
`cmd/gc/session_lifecycle_start_boundary_test.go:159`. Verified in a clean
worktree of origin/main with none of this diff applied — it is a pre-existing
break attributed to ga-30r59y, with the fix open in #6216. CI here will likely
be red for that same unrelated reason until #6216 lands.

No new subprocess or fixed-sleep call sites, so `test/test-resources.toml` is
unchanged.

Bead: ga-1dkscy