### PR TITLE
fix(orders): expand a city import's rig-scoped orders once per rig

### DIFF
--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -278,6 +278,11 @@ rig-scoped orders appear once per importing rig (mirroring `scope` on
 was scanned from, so its formula must resolve from that pack rather than from any
 one rig's local `orders/` directory.
 
+The mirror holds for a pack imported at city scope too: an order there that
+declares `scope = "rig"` explicitly instantiates once per configured rig, as an
+agent or named session declaring the same does, while an order that declares
+nothing registers once, city-wide.
+
 ## Disabling and skipping orders
 
 Set `enabled = false` in an order's own definition to drop it from scanning

--- a/internal/orderdiscovery/discovery.go
+++ b/internal/orderdiscovery/discovery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
@@ -102,6 +103,24 @@ func ScanAll(cityPath string, cfg *config.City, opts ScanOptions) ([]orders.Orde
 			}
 			aa[i].Rig = rigName
 			rigOrders = append(rigOrders, aa[i])
+		}
+	}
+
+	// An order that declares scope = "rig" in a pack imported at city scope
+	// instantiates once per configured rig, the way an agent or named
+	// session declaring the same in that pack does (config's
+	// expandCityImportedAgentsForRigs): the declaration would otherwise be
+	// validated and then silently dropped, registering the order once,
+	// city-wide, against the city store. A rig that imports the pack itself
+	// already holds its instance from the loop above and is skipped. An
+	// order that declares nothing keeps its contract: once, city-wide.
+	cityOrders, cityRigScoped := splitCityImportedRigScopedOrders(cityOrders, cfg.PackDirs)
+	for _, rig := range cfg.Rigs {
+		for _, o := range cityRigScoped {
+			if orderUnderPackDirs(o.Source, cfg.RigPackDirs[rig.Name]) {
+				continue
+			}
+			rigOrders = append(rigOrders, cloneOrderForRig(o, rig.Name))
 		}
 	}
 
@@ -242,6 +261,63 @@ func formulaLayerRoot(layer string) orders.ScanRoot {
 		Dir:          filepath.Join(filepath.Dir(layer), "orders"),
 		FormulaLayer: layer,
 	}
+}
+
+// splitCityImportedRigScopedOrders partitions the city-level scan into the
+// orders that stay city-wide and those a city-imported pack declared with
+// scope = "rig", recognized by a Source under one of the pack dirs' orders/.
+func splitCityImportedRigScopedOrders(cityOrders []orders.Order, packDirs []string) (city, rigScoped []orders.Order) {
+	for _, o := range cityOrders {
+		if o.IsRigScoped() && orderUnderPackDirs(o.Source, packDirs) {
+			rigScoped = append(rigScoped, o)
+			continue
+		}
+		city = append(city, o)
+	}
+	return city, rigScoped
+}
+
+// orderUnderPackDirs reports whether an order file was scanned from the
+// orders/ directory of one of the given pack dirs.
+func orderUnderPackDirs(source string, packDirs []string) bool {
+	for _, dir := range packDirs {
+		if pathWithin(source, packRoot(dir).Dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithin(path, dir string) bool {
+	if path == "" || dir == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(dir), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+// cloneOrderForRig stamps a copy of a city-scanned order for one rig. The
+// maps are copied: overrides and env projection mutate them per instance.
+func cloneOrderForRig(o orders.Order, rig string) orders.Order {
+	o.Rig = rig
+	if o.Env != nil {
+		env := make(map[string]string, len(o.Env))
+		for k, v := range o.Env {
+			env[k] = v
+		}
+		o.Env = env
+	}
+	if o.Params != nil {
+		params := make(map[string]orders.OrderParam, len(o.Params))
+		for k, v := range o.Params {
+			params[k] = v
+		}
+		o.Params = params
+	}
+	return o
 }
 
 func packRoot(packDir string) orders.ScanRoot {

--- a/internal/orderdiscovery/discovery_city_import_scope_test.go
+++ b/internal/orderdiscovery/discovery_city_import_scope_test.go
@@ -1,0 +1,96 @@
+package orderdiscovery
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// An order that declares scope = "rig" in a pack imported at CITY scope
+// instantiates once per configured rig, the way an agent or named session
+// declaring the same in the same pack does (config's
+// expandCityImportedAgentsForRigs). Before the fix the declaration was
+// validated and then silently dropped: the order registered once,
+// city-wide, and resolveOrderStoreTarget routed it to the city store. An
+// order that declares nothing keeps its contract: once, city-wide.
+func TestScanAllCityImportedRigScopedOrderExpandsPerRig(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	packDir := filepath.Join(t.TempDir(), "review-pack")
+	writeOrderDiscoveryFile(t, filepath.Join(packDir, "orders"), "watch", `[order]
+scope = "rig"
+exec = "scripts/watch.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+	writeOrderDiscoveryFile(t, filepath.Join(packDir, "orders"), "sweep", `[order]
+exec = "scripts/sweep.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{City: []string{cityLayer}},
+		PackDirs:      []string{packDir},
+		Rigs:          []config.Rig{{Name: "alpha"}, {Name: "beta"}},
+	}
+
+	aa, err := ScanAll(cityPath, cfg, ScanOptions{})
+	if err != nil {
+		t.Fatalf("ScanAll returned error: %v", err)
+	}
+	watch := map[string]int{}
+	sweep := map[string]int{}
+	for _, a := range aa {
+		switch a.Name {
+		case "watch":
+			watch[a.Rig]++
+		case "sweep":
+			sweep[a.Rig]++
+		}
+	}
+	if len(watch) != 2 || watch["alpha"] != 1 || watch["beta"] != 1 {
+		t.Fatalf("rig-scoped order in a city import registered as %v, want one instance per rig (alpha, beta) and no city copy", watch)
+	}
+	if len(sweep) != 1 || sweep[""] != 1 {
+		t.Fatalf("unscoped order in a city import registered as %v, want once city-wide", sweep)
+	}
+}
+
+// Importing the same pack at both scopes must not double the rig-scoped
+// order: the rig that imports the pack itself keeps the instance from its
+// own scan, and only the rigs that do not import it get a fan-out copy.
+func TestScanAllCityImportedRigScopedOrderYieldsToRigImport(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	packDir := filepath.Join(t.TempDir(), "review-pack")
+	writeOrderDiscoveryFile(t, filepath.Join(packDir, "orders"), "watch", `[order]
+scope = "rig"
+exec = "scripts/watch.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{"alpha": {cityLayer}},
+		},
+		PackDirs:    []string{packDir},
+		RigPackDirs: map[string][]string{"alpha": {packDir}},
+		Rigs:        []config.Rig{{Name: "alpha"}, {Name: "beta"}},
+	}
+
+	aa, err := ScanAll(cityPath, cfg, ScanOptions{})
+	if err != nil {
+		t.Fatalf("ScanAll returned error: %v", err)
+	}
+	watch := map[string]int{}
+	for _, a := range aa {
+		if a.Name == "watch" {
+			watch[a.Rig]++
+		}
+	}
+	if len(watch) != 2 || watch["alpha"] != 1 || watch["beta"] != 1 {
+		t.Fatalf("rig-scoped order imported at both scopes registered as %v, want exactly one instance per rig", watch)
+	}
+}

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -218,6 +218,13 @@ func (a *Order) IsCityScoped() bool {
 	return a.Scope == "city"
 }
 
+// IsRigScoped reports whether the order declares scope = "rig" explicitly.
+// An order that declares nothing is rig-scoped only under a rig import;
+// orderdiscovery.ScanAll says what each declaration means at each scope.
+func (a *Order) IsRigScoped() bool {
+	return a.Scope == "rig"
+}
+
 // TimeoutOrDefault returns the order's configured timeout, or the
 // default: 300s for exec orders, 30s for formula orders.
 func (a *Order) TimeoutOrDefault() time.Duration {


### PR DESCRIPTION
## Summary

`orderdiscovery.ScanAll` now expands an order that declares `scope = "rig"` in a pack imported at city scope once per configured `[[rigs]]` entry, with `Rig` stamped, and drops the city-scoped copy. A rig that imports the same pack itself keeps the instance its own scan produced and gets no copy, so a pack imported at both scopes stays single per rig. Orders that declare nothing keep their contract: once, city-wide. Each copy owns its `Env` and `Params` maps, which overrides and the env projection mutate per instance.

Fixes #6218.

## Why

The order was validated and then silently dropped. `ScanAll` stamps `Rig` only in the rig loop, which runs for rigs with rig-level packs; a city-level scan stamps nothing, so the order registered once, city-wide, and `resolveOrderStoreTarget` routed it to the city store. For a formula order that minted its wisps and roots where the rig's pool never reads them. An agent or named session declaring the same scope in the same pack fans out once per rig (`expandCityImportedAgentsForRigs`), and the order field's own contract says it mirrors `[[named_session]].scope`.

## Testing

- `TestScanAllCityImportedRigScopedOrderExpandsPerRig` (`internal/orderdiscovery/discovery_city_import_scope_test.go`): red on `main` — one instance, `Rig == ""` — green here with one instance per rig, each stamped and owning its maps.
- `TestScanAllCityImportedRigScopedOrderYieldsToRigImport` (same file): red on `main` — a city copy beside the rig import's own instance — green here with the rig's instance alone.
- `go test ./internal/orderdiscovery/... ./internal/orders/...` green; `go vet` on both packages green; the pre-commit hook's `go vet ./...` green at the commit.
- [ ] `make test-integration` — not run: no runtime or controller behavior beyond discovery.
- Branch base `ae5163dd3`: `cmd/gc`'s tests on `main` compile only once #6216 merges; nothing here touches `cmd/gc`.

Release note: an order declaring `scope = "rig"` in a city-imported pack now fires once per configured rig, on that rig's store, instead of once city-wide.

## Scope

Deliberately not touched: pack commands from a rig-scoped import, which #949 removed and #6224 asks about; `resolveOrderStoreTarget`'s demotion of a rig order with a slash-less pool to city scope (separate); and the `[rigs.imports]` path, whose orders already carry `Rig`. Precedent: `expandCityImportedAgentsForRigs` gives agents and named sessions in a city import exactly this per-rig fan-out; this extends it to the order that declares the same scope.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes (`docs/tutorials/07-orders.md`: what a city import does with the declaration)
- [x] Called out breaking changes or migration notes (none; see the release note)

## Ownership

navani (a3ackerman) is the owner and author of this change; commit authorship is preserved on the branch. The PR is opened from the ckumar1 fork under the two towns' pooled contributor-slot arrangement (both accounts contribute to this repo and cap out on open-PR slots). navani answers maintainer comments directly. Base is ae5163dd3 rather than the branch-time tip 3f924d2a7, whose cmd/gc tests did not compile before #6216 (still open); the commit applies on either.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SaPPDicHTKZr1tTdobJK6

(PR opened by the fork-owner side; session: https://claude.ai/code/session_01SWJiJMgU1MCXqQ3LZpXZJW)
