### PR TITLE
fix(beads): compare-and-swap the metadata merge on the native Dolt store

### DIFF
--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -335,6 +335,10 @@ type NativeDoltStore struct {
 	// single wall-clock bound on a read's whole reconnect-and-retry chain. Only
 	// tests set it (to exercise budget exhaustion without a real 90s wait).
 	readRetryBudgetOverride time.Duration
+	// afterMetadataMergeRead, when set, runs after each read that starts a
+	// metadata merge attempt, before its checked write. Only tests set it, to
+	// land a competing write in the window the compare-and-swap protects.
+	afterMetadataMergeRead func(id string)
 
 	// condWritesStamp carries the factory-stamped conditional-writes mode. The
 	// pinned upstream Storage contract requires row-version checked update and
@@ -1788,6 +1792,9 @@ func (s *NativeDoltStore) setMetadataBatchOnce(ctx context.Context, storage bead
 	}
 	if issue == nil {
 		return fmt.Errorf("bead %q: %w", id, ErrNotFound)
+	}
+	if s.afterMetadataMergeRead != nil {
+		s.afterMetadataMergeRead(id)
 	}
 	metadata, err := metadataMapFromNative(issue.Metadata)
 	if err != nil {

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1719,10 +1719,33 @@ const (
 // mid-retry, so a retry could run against a different storage than the one whose
 // transaction it is repeating.
 func retryOnNativeDoltSerializationConflict(attempt func() error) error {
+	return retryNativeDoltWrite(attempt, isNativeDoltSerializationConflict)
+}
+
+// retryOnNativeDoltMergeRace re-runs a checked read-merge-write attempt when a
+// concurrent writer preempted it: either the backend reported a serialization
+// conflict (the attempt's write never committed) or the compare-and-swap
+// refused with ErrVersionMismatch (the row changed after the attempt's read).
+// Both mean the attempt must read again and merge onto the committed row, so
+// both are retried with the budget retryOnNativeDoltSerializationConflict
+// applies; every other error is returned on the first try, as there. A version
+// mismatch is retried here and only here: for the conditional writers
+// (UpdateIfMatch and its siblings) it is the caller's fence and propagates.
+func retryOnNativeDoltMergeRace(attempt func() error) error {
+	return retryNativeDoltWrite(attempt, func(err error) bool {
+		return isNativeDoltSerializationConflict(err) || errors.Is(err, beadslib.ErrVersionMismatch)
+	})
+}
+
+// retryNativeDoltWrite runs attempt up to nativeWriteAttempts times, sleeping a
+// growing nativeWriteRetryBackoff after each error retryable accepts. The first
+// error retryable rejects, and the last attempt's error, are returned as they
+// are.
+func retryNativeDoltWrite(attempt func() error, retryable func(error) bool) error {
 	var err error
 	for n := 1; n <= nativeWriteAttempts; n++ {
 		err = attempt()
-		if err == nil || !isNativeDoltSerializationConflict(err) || n == nativeWriteAttempts {
+		if err == nil || !retryable(err) || n == nativeWriteAttempts {
 			return err
 		}
 		time.Sleep(time.Duration(n) * nativeWriteRetryBackoff)
@@ -1731,6 +1754,14 @@ func retryOnNativeDoltSerializationConflict(attempt func() error) error {
 }
 
 // SetMetadataBatch sets multiple metadata keys on a bead.
+//
+// The merge is a read-modify-write of the whole metadata map, so the write is a
+// compare-and-swap on the row version the read returned: an update that commits
+// between the read and the write makes the swap refuse, and the whole
+// read-merge-write runs again against the committed row instead of replacing it
+// with the stale map. An unchecked write-back cannot see that anything changed
+// and silently undoes the other writer's keys — a fence activation was lost
+// that way to a one-key stamp.
 func (s *NativeDoltStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	storage, release, err := s.acquireStorage()
 	if err != nil {
@@ -1738,16 +1769,18 @@ func (s *NativeDoltStore) SetMetadataBatch(id string, kvs map[string]string) err
 	}
 	defer release()
 
-	return retryOnNativeDoltSerializationConflict(func() error {
+	return retryOnNativeDoltMergeRace(func() error {
 		ctx, cancel := nativeDoltOperationContext(context.TODO())
 		defer cancel()
 		return s.setMetadataBatchOnce(ctx, storage, id, kvs)
 	})
 }
 
-// setMetadataBatchOnce performs one complete metadata read-merge-write attempt.
-// A retry must call this whole operation again so metadata committed by the
-// competing transaction is included rather than overwritten from a stale read.
+// setMetadataBatchOnce performs one complete metadata read-merge-write attempt:
+// it reads the bead, merges kvs into the map it read, and writes the merged map
+// back only while the bead still carries the row version that read returned. A
+// retry must call this whole operation again so metadata committed by the
+// competing writer is merged rather than overwritten from a stale read.
 func (s *NativeDoltStore) setMetadataBatchOnce(ctx context.Context, storage beadslib.Storage, id string, kvs map[string]string) error {
 	issue, err := storage.GetIssue(ctx, id)
 	if err != nil {
@@ -1770,7 +1803,10 @@ func (s *NativeDoltStore) setMetadataBatchOnce(ctx context.Context, storage bead
 	if err != nil {
 		return err
 	}
-	return nativeStoreError(id, storage.UpdateIssue(ctx, id, map[string]interface{}{"metadata": raw}, s.actor))
+	expected := issue.RowVersion
+	return nativeStoreError(id, storage.UpdateIssueChecked(ctx, id, map[string]interface{}{"metadata": raw}, s.actor, beadslib.UpdateIssueOptions{
+		ExpectedVersion: &expected,
+	}))
 }
 
 // isNativeDoltSerializationConflict reports only Dolt/MySQL transaction

--- a/internal/beads/native_dolt_store_close_retry_test.go
+++ b/internal/beads/native_dolt_store_close_retry_test.go
@@ -183,7 +183,7 @@ func TestNativeDoltStoreCloseAllRecoversWhenTheCloseConflictsAfterMetadataLanded
 			}
 			return out, nil
 		},
-		updateIssue: func(context.Context, string, map[string]interface{}, string) error {
+		updateIssueChecked: func(context.Context, string, map[string]interface{}, string, beadslib.UpdateIssueOptions) error {
 			atomic.AddInt32(&metadata, 1)
 			return nil
 		},

--- a/internal/beads/native_dolt_store_metadata_lost_update_internal_test.go
+++ b/internal/beads/native_dolt_store_metadata_lost_update_internal_test.go
@@ -1,0 +1,213 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	beadslib "github.com/steveyegge/beads"
+)
+
+// lostUpdateStorage models the two backend properties the metadata write path
+// depends on: an unchecked UpdateIssue replaces the row it names whatever
+// happened since the caller's read, and UpdateIssueChecked refuses with
+// ErrVersionMismatch when the row's version no longer equals the one the
+// caller expects. A concurrent update lands exactly once, right after the
+// first read the store performs, which is the interleaving observed in the
+// audit trail (the fence activation committing between a metadata read and
+// its write-back).
+type lostUpdateStorage struct {
+	beadslib.Storage
+	durable         *beadslib.Issue
+	concurrent      map[string]string
+	fired           bool
+	reads           int
+	uncheckedWrites int
+	// checkedWrites records the ExpectedVersion each checked write carried.
+	checkedWrites []int64
+}
+
+func (s *lostUpdateStorage) fireConcurrentUpdate() {
+	if s.fired {
+		return
+	}
+	s.fired = true
+	s.durable.Metadata = mergeNativeMetadataForTest(s.durable.Metadata, s.concurrent)
+	s.durable.RowVersion++
+}
+
+func (s *lostUpdateStorage) GetIssue(context.Context, string) (*beadslib.Issue, error) {
+	s.reads++
+	snapshot := cloneNativeIssueForTest(s.durable)
+	s.fireConcurrentUpdate()
+	return snapshot, nil
+}
+
+func (s *lostUpdateStorage) replaceMetadata(updates map[string]interface{}) error {
+	raw, ok := updates["metadata"].(json.RawMessage)
+	if !ok {
+		return errors.New("metadata update is not json.RawMessage")
+	}
+	s.durable.Metadata = append(json.RawMessage(nil), raw...)
+	s.durable.RowVersion++
+	return nil
+}
+
+func (s *lostUpdateStorage) UpdateIssue(_ context.Context, _ string, updates map[string]interface{}, _ string) error {
+	s.uncheckedWrites++
+	return s.replaceMetadata(updates)
+}
+
+func (s *lostUpdateStorage) UpdateIssueChecked(_ context.Context, _ string, updates map[string]interface{}, _ string, opts beadslib.UpdateIssueOptions) error {
+	if opts.ExpectedVersion == nil {
+		return errors.New("checked write carried no expected version")
+	}
+	s.checkedWrites = append(s.checkedWrites, *opts.ExpectedVersion)
+	if *opts.ExpectedVersion != s.durable.RowVersion {
+		return fmt.Errorf("%w: expected %d, got %d", beadslib.ErrVersionMismatch, *opts.ExpectedVersion, s.durable.RowVersion)
+	}
+	return s.replaceMetadata(updates)
+}
+
+func mergeNativeMetadataForTest(raw json.RawMessage, kvs map[string]string) json.RawMessage {
+	metadata := map[string]string{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &metadata); err != nil {
+			panic(err)
+		}
+	}
+	for k, v := range kvs {
+		metadata[k] = v
+	}
+	out, err := json.Marshal(metadata)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// TestNativeDoltStoreMetadataWriteKeepsAConcurrentUpdate pins that a metadata
+// write never undoes an update that committed between its read and its
+// write. The store merges the new keys into the map it read and writes the
+// whole map back, so an unchecked write-back replaces every key the
+// concurrent update touched with the values from before it. The interleaving
+// here is the audit trail of a lost review workflow: a graph step's fence
+// activation (routed_to restored, fence keys cleared) committed between a
+// heartbeat-shaped stamp's read and its write, and the stamp put the fence
+// back.
+func TestNativeDoltStoreMetadataWriteKeepsAConcurrentUpdate(t *testing.T) {
+	const (
+		id          = "gc-fenced-step"
+		readVersion = int64(7)
+	)
+	activation := map[string]string{
+		"gc.instantiating":      "",
+		"gc.deferred_routed_to": "",
+		"gc.routed_to":          "rig/pool",
+	}
+	newStorage := func() *lostUpdateStorage {
+		return &lostUpdateStorage{
+			durable: &beadslib.Issue{
+				ID:         id,
+				Title:      "Resolve PR identity",
+				Status:     beadslib.StatusOpen,
+				IssueType:  beadslib.TypeTask,
+				Priority:   2,
+				Metadata:   json.RawMessage(`{"gc.run_target":"pool","gc.instantiating":"true","gc.deferred_routed_to":"rig/pool"}`),
+				RowVersion: readVersion,
+			},
+			concurrent: activation,
+		}
+	}
+	assertKept := func(t *testing.T, storage *lostUpdateStorage, key, want string) {
+		t.Helper()
+		metadata, err := metadataMapFromNative(storage.durable.Metadata)
+		if err != nil {
+			t.Fatalf("parse durable metadata: %v", err)
+		}
+		if got := metadata[key]; got != want {
+			t.Fatalf("%s = %q after the metadata write, want %q (the concurrent update was overwritten by the stale map)", key, got, want)
+		}
+	}
+	assertRetriedFromAFreshRead := func(t *testing.T, storage *lostUpdateStorage) {
+		t.Helper()
+		if !storage.fired {
+			t.Fatal("the concurrent update never landed; the interleaving was not exercised")
+		}
+		if storage.uncheckedWrites != 0 {
+			t.Fatalf("unchecked writes = %d, want 0: an unchecked write-back cannot see the concurrent update", storage.uncheckedWrites)
+		}
+		if want := []int64{readVersion, readVersion + 1}; !slicesEqualInt64(storage.checkedWrites, want) {
+			t.Fatalf("checked writes carried versions %v, want %v: the refused swap must be retried from a fresh read", storage.checkedWrites, want)
+		}
+		if storage.reads != 2 {
+			t.Fatalf("reads = %d, want 2 (the first read, then the re-read after the refused swap)", storage.reads)
+		}
+	}
+
+	t.Run("SetMetadataBatch", func(t *testing.T) {
+		storage := newStorage()
+		store := newNativeDoltStoreForTest(storage)
+		if err := store.SetMetadataBatch(id, map[string]string{"gc.heartbeat": "now"}); err != nil {
+			t.Fatalf("SetMetadataBatch: %v", err)
+		}
+		assertKept(t, storage, "gc.instantiating", "")
+		assertKept(t, storage, "gc.deferred_routed_to", "")
+		assertKept(t, storage, "gc.routed_to", "rig/pool")
+		assertKept(t, storage, "gc.heartbeat", "now")
+		assertRetriedFromAFreshRead(t, storage)
+	})
+
+	t.Run("SetMetadata", func(t *testing.T) {
+		storage := newStorage()
+		store := newNativeDoltStoreForTest(storage)
+		if err := store.SetMetadata(id, "gc.heartbeat", "now"); err != nil {
+			t.Fatalf("SetMetadata: %v", err)
+		}
+		assertKept(t, storage, "gc.instantiating", "")
+		assertKept(t, storage, "gc.routed_to", "rig/pool")
+		assertKept(t, storage, "gc.heartbeat", "now")
+		assertRetriedFromAFreshRead(t, storage)
+	})
+}
+
+// TestNativeDoltStoreMetadataWriteGivesUpAfterRepeatedVersionMismatches pins
+// the retry budget: a swap refused on every attempt is returned to the caller
+// after nativeWriteAttempts fresh reads, not retried without bound.
+func TestNativeDoltStoreMetadataWriteGivesUpAfterRepeatedVersionMismatches(t *testing.T) {
+	getCalls := 0
+	checkedCalls := 0
+	storage := &nativeDoltStorageSpy{
+		getIssue: func(context.Context, string) (*beadslib.Issue, error) {
+			getCalls++
+			return &beadslib.Issue{ID: "gc-contended", RowVersion: int64(getCalls)}, nil
+		},
+		updateIssueChecked: func(_ context.Context, _ string, _ map[string]interface{}, _ string, opts beadslib.UpdateIssueOptions) error {
+			checkedCalls++
+			return fmt.Errorf("%w: expected %d, got %d", beadslib.ErrVersionMismatch, *opts.ExpectedVersion, *opts.ExpectedVersion+1)
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	err := store.SetMetadataBatch("gc-contended", map[string]string{"requested": "written"})
+	if !errors.Is(err, beadslib.ErrVersionMismatch) {
+		t.Fatalf("SetMetadataBatch error = %v, want ErrVersionMismatch after the retry budget", err)
+	}
+	if getCalls != nativeWriteAttempts || checkedCalls != nativeWriteAttempts {
+		t.Fatalf("calls = GetIssue:%d UpdateIssueChecked:%d, want %d each", getCalls, checkedCalls, nativeWriteAttempts)
+	}
+}
+
+func slicesEqualInt64(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/beads/native_dolt_store_metadata_merge_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_merge_integration_test.go
@@ -4,7 +4,12 @@ package beads
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	beadslib "github.com/steveyegge/beads"
 )
 
 // TestNativeDoltStoreSetMetadataBatchKeepsAConcurrentUpdateAgainstRealDolt is
@@ -15,9 +20,12 @@ import (
 // exactly one event is recorded for the stamp — the refused attempt leaves
 // none. The in-memory test owns the interleaving detail; this pins that the
 // backend's version check is the one the store compares against.
+//
+// The proof never skips: a host that cannot open the pinned backend fails
+// the test, so a lane cannot go green with the proof unexecuted.
 func TestNativeDoltStoreSetMetadataBatchKeepsAConcurrentUpdateAgainstRealDolt(t *testing.T) {
 	ctx := context.Background()
-	store := openRealNativeDoltStoreForCAS(t, "merge-race")
+	store := openRealNativeDoltStoreForMergeProof(t, "merge-race")
 
 	created, err := store.Create(Bead{
 		Title:    "fenced entry step",
@@ -90,4 +98,108 @@ func TestNativeDoltStoreSetMetadataBatchKeepsAConcurrentUpdateAgainstRealDolt(t 
 	if delta := countEvents() - afterCompetingWrite; delta != 1 {
 		t.Fatalf("events recorded by the merge = %d, want 1: the committed stamp records one event and the refused swap none", delta)
 	}
+}
+
+// TestNativeDoltStoreSetMetadataBatchRollsBackWhenTheEventInsertFails pins
+// the other half of the write's atomicity on the pinned server backend: the
+// audit event is inserted in the same transaction as the metadata update, so
+// a failing event insert leaves the row as it was — metadata, row version and
+// event count — and the caller sees the error. The failure is injected by
+// taking the events table away for the one write; the library writes event
+// ids explicitly, so the column's missing default is not a lever here.
+func TestNativeDoltStoreSetMetadataBatchRollsBackWhenTheEventInsertFails(t *testing.T) {
+	ctx := context.Background()
+	scopeRoot := t.TempDir()
+	port := startTestDoltServer(t)
+	beadsDir := filepath.Join(scopeRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("create .beads directory: %v", err)
+	}
+	metadata := fmt.Sprintf(`{"backend":"dolt","database":"beads","dolt_mode":"server","dolt_server_host":"127.0.0.1","dolt_server_port":%d}`, port)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	storage, err := beadslib.OpenBestAvailable(ctx, beadsDir)
+	if err != nil {
+		t.Fatalf("open the server-backed native storage the proof runs against: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Errorf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	accessor, ok := storage.(testRawDBGetter)
+	if !ok {
+		t.Fatal("server-backed storage does not expose a raw DB; the events table cannot be taken away")
+	}
+	db := accessor.DB()
+	store, err := newNativeDoltStoreAt(ctx, scopeRoot, nil)
+	if err != nil {
+		t.Fatalf("newNativeDoltStoreAt: %v", err)
+	}
+
+	created, err := store.Create(Bead{Title: "rollback probe", Metadata: map[string]string{"gc.a": "1"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	before, err := storage.GetIssue(ctx, created.ID)
+	if err != nil || before == nil {
+		t.Fatalf("GetIssue before: (%v, %v)", before, err)
+	}
+	eventsBefore, err := storage.GetEvents(ctx, created.ID, 100)
+	if err != nil {
+		t.Fatalf("GetEvents before: %v", err)
+	}
+
+	if _, err := db.Exec("RENAME TABLE `events` TO `events_offline`"); err != nil {
+		t.Fatalf("take the events table away: %v", err)
+	}
+	writeErr := store.SetMetadataBatch(created.ID, map[string]string{"gc.b": "2"})
+	if _, err := db.Exec("RENAME TABLE `events_offline` TO `events`"); err != nil {
+		t.Fatalf("restore the events table: %v", err)
+	}
+	if writeErr == nil {
+		t.Fatal("SetMetadataBatch succeeded with the events table gone; the event insert does not share the write's transaction")
+	}
+
+	after, err := storage.GetIssue(ctx, created.ID)
+	if err != nil || after == nil {
+		t.Fatalf("GetIssue after: (%v, %v)", after, err)
+	}
+	if after.RowVersion != before.RowVersion {
+		t.Fatalf("row version moved %d -> %d across a failed write: the metadata update was not rolled back with the event insert", before.RowVersion, after.RowVersion)
+	}
+	if string(after.Metadata) != string(before.Metadata) {
+		t.Fatalf("metadata changed across a failed write: before %s, after %s", before.Metadata, after.Metadata)
+	}
+	eventsAfter, err := storage.GetEvents(ctx, created.ID, 100)
+	if err != nil {
+		t.Fatalf("GetEvents after: %v", err)
+	}
+	if len(eventsAfter) != len(eventsBefore) {
+		t.Fatalf("events = %d after a failed write, want %d (none recorded for a write that did not commit)", len(eventsAfter), len(eventsBefore))
+	}
+}
+
+// openRealNativeDoltStoreForMergeProof opens the pinned native backend on a
+// fresh directory and fails — never skips — when it cannot.
+func openRealNativeDoltStoreForMergeProof(t *testing.T, actor string) *NativeDoltStore {
+	t.Helper()
+	ctx := context.Background()
+	storage, err := beadslib.OpenBestAvailable(ctx, filepath.Join(t.TempDir(), ".beads"))
+	if err != nil {
+		t.Fatalf("open the pinned native beads storage the proof runs against: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Errorf("close upstream storage: %v", err)
+		}
+	})
+	if err := storage.SetConfig(ctx, "issue_prefix", "gc"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+	return newNativeDoltStoreWithStorageAndPrefix(storage, actor, "gc")
 }

--- a/internal/beads/native_dolt_store_metadata_merge_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_merge_integration_test.go
@@ -164,10 +164,11 @@ func TestNativeDoltStoreSetMetadataBatchRollsBackWhenTheEventInsertFails(t *test
 		if restored {
 			return
 		}
-		restored = true
 		if _, err := db.Exec("RENAME TABLE `events_offline` TO `events`"); err != nil {
 			t.Errorf("restore the events table: %v", err)
+			return
 		}
+		restored = true
 	}
 	t.Cleanup(restoreEvents)
 	writeErr := store.SetMetadataBatch(created.ID, map[string]string{"gc.b": "2"})
@@ -175,8 +176,8 @@ func TestNativeDoltStoreSetMetadataBatchRollsBackWhenTheEventInsertFails(t *test
 	if writeErr == nil {
 		t.Fatal("SetMetadataBatch succeeded with the events table gone; the event insert does not share the write's transaction")
 	}
-	if !strings.Contains(strings.ToLower(writeErr.Error()), "events") {
-		t.Fatalf("SetMetadataBatch error = %v, want the missing events table named (a different failure would not prove the rollback)", writeErr)
+	if msg := strings.ToLower(writeErr.Error()); !strings.Contains(msg, "table not found") || !strings.Contains(msg, "events") {
+		t.Fatalf("SetMetadataBatch error = %v, want the missing events table diagnosed: the library names the events table on every event-insert failure, so only the table-not-found text proves the injected fault was the one that failed the write", writeErr)
 	}
 
 	after, err := storage.GetIssue(ctx, created.ID)

--- a/internal/beads/native_dolt_store_metadata_merge_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_merge_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	beadslib "github.com/steveyegge/beads"
@@ -140,6 +141,7 @@ func TestNativeDoltStoreSetMetadataBatchRollsBackWhenTheEventInsertFails(t *test
 	if err != nil {
 		t.Fatalf("newNativeDoltStoreAt: %v", err)
 	}
+	t.Cleanup(func() { _ = store.CloseStore() })
 
 	created, err := store.Create(Bead{Title: "rollback probe", Metadata: map[string]string{"gc.a": "1"}})
 	if err != nil {
@@ -157,12 +159,24 @@ func TestNativeDoltStoreSetMetadataBatchRollsBackWhenTheEventInsertFails(t *test
 	if _, err := db.Exec("RENAME TABLE `events` TO `events_offline`"); err != nil {
 		t.Fatalf("take the events table away: %v", err)
 	}
-	writeErr := store.SetMetadataBatch(created.ID, map[string]string{"gc.b": "2"})
-	if _, err := db.Exec("RENAME TABLE `events_offline` TO `events`"); err != nil {
-		t.Fatalf("restore the events table: %v", err)
+	restored := false
+	restoreEvents := func() {
+		if restored {
+			return
+		}
+		restored = true
+		if _, err := db.Exec("RENAME TABLE `events_offline` TO `events`"); err != nil {
+			t.Errorf("restore the events table: %v", err)
+		}
 	}
+	t.Cleanup(restoreEvents)
+	writeErr := store.SetMetadataBatch(created.ID, map[string]string{"gc.b": "2"})
+	restoreEvents()
 	if writeErr == nil {
 		t.Fatal("SetMetadataBatch succeeded with the events table gone; the event insert does not share the write's transaction")
+	}
+	if !strings.Contains(strings.ToLower(writeErr.Error()), "events") {
+		t.Fatalf("SetMetadataBatch error = %v, want the missing events table named (a different failure would not prove the rollback)", writeErr)
 	}
 
 	after, err := storage.GetIssue(ctx, created.ID)

--- a/internal/beads/native_dolt_store_metadata_merge_integration_test.go
+++ b/internal/beads/native_dolt_store_metadata_merge_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package beads
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNativeDoltStoreSetMetadataBatchKeepsAConcurrentUpdateAgainstRealDolt is
+// the real-store proof of the compare-and-swap: a second writer changes other
+// keys of the same bead between the merge's read and its checked write, on
+// the pinned backend with its own row version and audit events. The refused
+// swap is retried from a fresh read, every key of both writers survives, and
+// exactly one event is recorded for the stamp — the refused attempt leaves
+// none. The in-memory test owns the interleaving detail; this pins that the
+// backend's version check is the one the store compares against.
+func TestNativeDoltStoreSetMetadataBatchKeepsAConcurrentUpdateAgainstRealDolt(t *testing.T) {
+	ctx := context.Background()
+	store := openRealNativeDoltStoreForCAS(t, "merge-race")
+
+	created, err := store.Create(Bead{
+		Title:    "fenced entry step",
+		Metadata: map[string]string{"gc.run_target": "pool", "gc.instantiating": "true", "gc.deferred_routed_to": "rig/pool"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := created.ID
+
+	countEvents := func() int {
+		t.Helper()
+		storage, release, err := store.acquireStorage()
+		if err != nil {
+			t.Fatalf("acquire storage: %v", err)
+		}
+		defer release()
+		events, err := storage.GetEvents(ctx, id, 100)
+		if err != nil {
+			t.Fatalf("GetEvents: %v", err)
+		}
+		return len(events)
+	}
+
+	reads := 0
+	afterCompetingWrite := -1
+	store.afterMetadataMergeRead = func(readID string) {
+		reads++
+		if reads != 1 || readID != id {
+			return
+		}
+		// The competing writer: the fence activation, on other keys of the same
+		// row, committing after the merge's read and before its checked write.
+		if err := store.Update(id, UpdateOpts{Metadata: map[string]string{
+			"gc.instantiating":      "",
+			"gc.deferred_routed_to": "",
+			"gc.routed_to":          "rig/pool",
+		}}); err != nil {
+			t.Errorf("competing Update: %v", err)
+		}
+		afterCompetingWrite = countEvents()
+	}
+
+	if err := store.SetMetadataBatch(id, map[string]string{"gc.heartbeat": "now"}); err != nil {
+		t.Fatalf("SetMetadataBatch: %v", err)
+	}
+	if reads != 2 {
+		t.Fatalf("merge reads = %d, want 2 (the swap refused after the competing write, then a fresh read)", reads)
+	}
+
+	got, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for key, want := range map[string]string{
+		"gc.heartbeat":          "now",
+		"gc.instantiating":      "",
+		"gc.deferred_routed_to": "",
+		"gc.routed_to":          "rig/pool",
+		"gc.run_target":         "pool",
+	} {
+		if got.Metadata[key] != want {
+			t.Errorf("%s = %q, want %q (the competing write was lost or the merge was)", key, got.Metadata[key], want)
+		}
+	}
+
+	if afterCompetingWrite < 0 {
+		t.Fatal("the competing write never ran")
+	}
+	if delta := countEvents() - afterCompetingWrite; delta != 1 {
+		t.Fatalf("events recorded by the merge = %d, want 1: the committed stamp records one event and the refused swap none", delta)
+	}
+}

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -1026,7 +1026,7 @@ func TestNativeDoltStoreSetMetadataBatchRejectsInvalidExistingMetadata(t *testin
 				Metadata:  json.RawMessage(`{"existing":`),
 			}, nil
 		},
-		updateIssue: func(context.Context, string, map[string]interface{}, string) error {
+		updateIssueChecked: func(context.Context, string, map[string]interface{}, string, beadslib.UpdateIssueOptions) error {
 			updateCalled = true
 			return nil
 		},
@@ -1039,13 +1039,14 @@ func TestNativeDoltStoreSetMetadataBatchRejectsInvalidExistingMetadata(t *testin
 		t.Fatalf("SetMetadataBatch error = %v, want bead metadata context", err)
 	}
 	if updateCalled {
-		t.Fatal("UpdateIssue was called after invalid metadata")
+		t.Fatal("UpdateIssueChecked was called after invalid metadata")
 	}
 }
 
 func TestNativeDoltStoreSetMetadataBatchRetriesSerializationConflictFromFreshState(t *testing.T) {
 	getCalls := 0
 	updateCalls := 0
+	var expectedVersions []int64
 	var writtenMetadata json.RawMessage
 	storage := &nativeDoltStorageSpy{
 		getIssue: func(context.Context, string) (*beadslib.Issue, error) {
@@ -1055,16 +1056,21 @@ func TestNativeDoltStoreSetMetadataBatchRetriesSerializationConflictFromFreshSta
 				metadata = json.RawMessage(`{"concurrent":"preserved"}`)
 			}
 			return &beadslib.Issue{
-				ID:        "gc-conflict",
-				Title:     "metadata conflict",
-				Status:    beadslib.StatusOpen,
-				IssueType: beadslib.TypeTask,
-				Priority:  2,
-				Metadata:  metadata,
+				ID:         "gc-conflict",
+				Title:      "metadata conflict",
+				Status:     beadslib.StatusOpen,
+				IssueType:  beadslib.TypeTask,
+				Priority:   2,
+				Metadata:   metadata,
+				RowVersion: int64(getCalls),
 			}, nil
 		},
-		updateIssue: func(_ context.Context, _ string, updates map[string]interface{}, _ string) error {
+		updateIssueChecked: func(_ context.Context, _ string, updates map[string]interface{}, _ string, opts beadslib.UpdateIssueOptions) error {
 			updateCalls++
+			if opts.ExpectedVersion == nil {
+				t.Fatal("metadata write carried no expected version")
+			}
+			expectedVersions = append(expectedVersions, *opts.ExpectedVersion)
 			if updateCalls == 1 {
 				return errors.New("dolt commit: Error 1213 (40001): serialization failure: this transaction conflicts with a committed transaction, try restarting transaction")
 			}
@@ -1085,7 +1091,10 @@ func TestNativeDoltStoreSetMetadataBatchRetriesSerializationConflictFromFreshSta
 		t.Fatalf("GetIssue calls = %d, want 2 so retry re-reads current metadata", getCalls)
 	}
 	if updateCalls != 2 {
-		t.Fatalf("UpdateIssue calls = %d, want 2", updateCalls)
+		t.Fatalf("UpdateIssueChecked calls = %d, want 2", updateCalls)
+	}
+	if !slices.Equal(expectedVersions, []int64{1, 2}) {
+		t.Fatalf("expected versions = %v, want [1 2]: each attempt must swap against the version its own read returned", expectedVersions)
 	}
 	var got map[string]string
 	if err := json.Unmarshal(writtenMetadata, &got); err != nil {
@@ -1106,7 +1115,7 @@ func TestNativeDoltStoreSetMetadataBatchDoesNotRetryPermanentWriteError(t *testi
 			getCalls++
 			return &beadslib.Issue{ID: "gc-permanent", Metadata: json.RawMessage(`{"existing":"kept"}`)}, nil
 		},
-		updateIssue: func(context.Context, string, map[string]interface{}, string) error {
+		updateIssueChecked: func(context.Context, string, map[string]interface{}, string, beadslib.UpdateIssueOptions) error {
 			updateCalls++
 			return wantErr
 		},
@@ -1118,7 +1127,7 @@ func TestNativeDoltStoreSetMetadataBatchDoesNotRetryPermanentWriteError(t *testi
 		t.Fatalf("SetMetadataBatch error = %v, want %v", err, wantErr)
 	}
 	if getCalls != 1 || updateCalls != 1 {
-		t.Fatalf("calls = GetIssue:%d UpdateIssue:%d, want 1 each", getCalls, updateCalls)
+		t.Fatalf("calls = GetIssue:%d UpdateIssueChecked:%d, want 1 each", getCalls, updateCalls)
 	}
 }
 
@@ -1131,7 +1140,7 @@ func TestNativeDoltStoreSetMetadataBatchStopsAfterThreeSerializationConflicts(t 
 			getCalls++
 			return &beadslib.Issue{ID: "gc-persistent-conflict"}, nil
 		},
-		updateIssue: func(context.Context, string, map[string]interface{}, string) error {
+		updateIssueChecked: func(context.Context, string, map[string]interface{}, string, beadslib.UpdateIssueOptions) error {
 			updateCalls++
 			return wantErr
 		},
@@ -1143,7 +1152,7 @@ func TestNativeDoltStoreSetMetadataBatchStopsAfterThreeSerializationConflicts(t 
 		t.Fatalf("SetMetadataBatch error = %v, want %v", err, wantErr)
 	}
 	if getCalls != 3 || updateCalls != 3 {
-		t.Fatalf("calls = GetIssue:%d UpdateIssue:%d, want 3 each", getCalls, updateCalls)
+		t.Fatalf("calls = GetIssue:%d UpdateIssueChecked:%d, want 3 each", getCalls, updateCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

`NativeDoltStore.SetMetadataBatch` (and `SetMetadata`, its single-key form) now writes the merged metadata map back with `UpdateIssueChecked`, carrying the row version its read returned as `ExpectedVersion`, and re-runs the whole read-merge-write when the swap is refused with `ErrVersionMismatch` — under the same budget and backoff the serialization-conflict retry already applies to this path (`retryOnNativeDoltMergeRace` accepts both). The merged result, the actor, the audit event the standalone update records, the error mapping and the `Tx` route are unchanged.

Fixes #6222.

## Why

The merge read the bead's metadata, set the new keys in the map it had read and wrote the whole map back, unchecked. Nothing tied the write to the read, so a concurrent `Update` landing between them was undone key by key — and the existing retry could not see it, because two independent statements never conflict. The bd audit trail of one lost workflow shows it exactly: a graph step's fence activation committed (route restored, fence keys cleared), and within the same second a one-key stamp wrote back the pre-activation map with its key added, putting the fence back with a bare route (#6221 is that writer). Every metadata stamp that races an update on the same bead is exposed the same way: the reconciler's heartbeat and deferral marks, the drain-ack keys, the completion-facts stamp.

`UpdateIssueChecked` is the library's documented answer to this shape (beads #4911: an optional `ExpectedVersion` compare-and-swap on updates): the version check and the update share one transaction, and every update rewrites `row_lock` (`issueops/update.go`), so an update that lands between the read and the swap is always visible to the check. `UpdateIfMatch` already uses it this way; this brings the metadata merge onto the same primitive.

## Testing

- `TestNativeDoltStoreMetadataWriteKeepsAConcurrentUpdate` (`internal/beads/native_dolt_store_metadata_lost_update_internal_test.go`): a storage fake with the two backend properties the path depends on — an unchecked `UpdateIssue` replaces the row, `UpdateIssueChecked` refuses with `ErrVersionMismatch` once the row version moved — lands a concurrent update right after the store's first read. Red on `main` for both `SetMetadataBatch` and `SetMetadata` (`gc.instantiating = "true" after the metadata write, want ""`); green here, with the concurrent keys and the new key all present, no unchecked write, and the two checked writes each carrying the version of their own read.
- `TestNativeDoltStoreMetadataWriteGivesUpAfterRepeatedVersionMismatches` (same file): a swap refused on every attempt returns `ErrVersionMismatch` after `nativeWriteAttempts` fresh reads.
- The four existing `SetMetadataBatch` spy tests (`native_dolt_store_test.go`) and the `CloseAll` pairing test (`native_dolt_store_close_retry_test.go`) observe the checked write; the fresh-state retry test additionally pins that each attempt swaps against the version its own read returned.
- `go test ./internal/beads/` green; `go vet ./internal/beads/` green; `golangci-lint run --new-from-rev=<base>` clean; the pre-commit hook's `go vet ./...` green at the commit.
- [ ] `make test-native-doltlite-beads` — not run here (no native Dolt on this host); `UpdateIssueChecked` against a real store is covered by the existing `TestNativeDoltStoreMetadataCAS*AgainstRealDolt` tests, which drive `UpdateIfMatch` on the same primitive.
- Branch base `ae5163dd3`: `cmd/gc`'s tests on `main` compile only once #6216 merges; nothing here touches `cmd/gc`.

Release note: a native-Dolt metadata write that races another write to the same bead now re-reads and retries instead of overwriting the other write's keys.

## Scope

Deliberately not touched: the transactional read-merge-writes (`CompareAndSetMetadataKey`, `CloseWithMetadataIfMatch`, the `Tx` route through `applySetMetadataBatchInTx`), which are atomic already; the value-CAS API from #4501/#4863, which is single-key by design; and the retry budget itself. Precedent: `UpdateIfMatch` (#5099) wraps `UpdateIssueChecked` in the same serialization-conflict retry; this adds the version-mismatch re-read for the one caller whose expected version is its own read.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes (none: internal store path)
- [x] Called out breaking changes or migration notes (none; see the release note)

## Ownership

navani (a3ackerman) is the owner and author of this change; commit authorship is preserved on the branch. The PR is opened from the ckumar1 fork under the two towns' pooled contributor-slot arrangement (both accounts contribute to this repo and cap out on open-PR slots). navani answers maintainer comments directly. Base is ae5163dd3 rather than the branch-time tip 3f924d2a7, whose cmd/gc tests did not compile before #6216 (still open); the commit applies on either.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SaPPDicHTKZr1tTdobJK6

(PR opened by the fork-owner side; session: https://claude.ai/code/session_01SWJiJMgU1MCXqQ3LZpXZJW)
