### PR TITLE
test(dolt): fake both bounded-exec helper names in offsite tests

### DIFF
--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -4752,6 +4752,26 @@ exit %d
 	return logPath
 }
 
+// runtime.sh probes gtimeout before timeout, and binDir only prepends the
+// host PATH — a fake under one name loses to a real coreutils helper under
+// the other, so the invocation log the assertions need never appears.
+// Installing the same fake under both names makes selection deterministic
+// without pinning which name runtime.sh prefers.
+func writeBackupFakeTimeout(t *testing.T, binDir string) string {
+	t.Helper()
+	logPath := filepath.Join(binDir, "timeout.log")
+	script := fmt.Sprintf(`#!/bin/sh
+printf 'timeout %s\n' "$*" >> %s
+[ "$1" = "--kill-after=2" ] && shift
+shift
+exec "$@"
+`, "%s", shellQuote(logPath))
+	for _, name := range []string{"timeout", "gtimeout"} {
+		writeExecutable(t, filepath.Join(binDir, name), script)
+	}
+	return logPath
+}
+
 func writeBSDLikeGrep(t *testing.T, binDir string) {
 	t.Helper()
 	realGrep, err := exec.LookPath("grep")
@@ -4890,13 +4910,7 @@ func TestBackupScriptEscalatesOffsiteFailureWithConfiguredBound(t *testing.T) {
 	gcLogPath := writeDogFakeGC(t, binDir)
 	_ = writeBackupFakeDolt(t, binDir, "2.1.0", 0, "prod")
 	_ = writeBackupFakeRsync(t, binDir, 1)
-	timeoutLogPath := filepath.Join(binDir, "timeout.log")
-	writeExecutable(t, filepath.Join(binDir, "timeout"), fmt.Sprintf(`#!/bin/sh
-printf 'timeout %%s\n' "$*" >> %s
-[ "$1" = "--kill-after=2" ] && shift
-shift
-exec "$@"
-`, shellQuote(timeoutLogPath)))
+	timeoutLogPath := writeBackupFakeTimeout(t, binDir)
 
 	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir,
 		"GC_BACKUP_OFFSITE_PATH="+offsiteDir,
@@ -4953,13 +4967,7 @@ func TestBackupScriptRejectsUnusableOffsiteTimeout(t *testing.T) {
 			_ = writeDogFakeGC(t, binDir)
 			_ = writeBackupFakeDolt(t, binDir, "2.1.0", 0, "prod")
 			_ = writeBackupFakeRsync(t, binDir)
-			timeoutLogPath := filepath.Join(binDir, "timeout.log")
-			writeExecutable(t, filepath.Join(binDir, "timeout"), fmt.Sprintf(`#!/bin/sh
-printf 'timeout %%s\n' "$*" >> %s
-[ "$1" = "--kill-after=2" ] && shift
-shift
-exec "$@"
-`, shellQuote(timeoutLogPath)))
+			timeoutLogPath := writeBackupFakeTimeout(t, binDir)
 
 			out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir,
 				"GC_BACKUP_OFFSITE_PATH="+offsiteDir,


### PR DESCRIPTION
## Summary

`runtime.sh` probes `gtimeout` before `timeout`, and the offsite-test `binDir` only prepends the host PATH — so on a macOS host with coreutils installed the real `gtimeout` won helper selection and the fake's invocation log never appeared: `TestBackupScriptEscalatesOffsiteFailureWithConfiguredBound` and `TestBackupScriptRejectsUnusableOffsiteTimeout` failed with a missing `timeout.log`. One shared fixture now installs the identical fake under both names, making selection deterministic on macOS and Linux while the assertions keep covering the configured bound and the 300s fallback, without pinning which helper name `runtime.sh` prefers.

## Testing

Both named tests green at this head on a macOS host with coreutils present (the failing configuration); the fixture change is test-only.

## Notes

Split out of #6200 per review — it is unrelated to that PR's nudge-syntax fix and stands alone. Cherry-pick of the same commit (`-x` trailer preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWJiJMgU1MCXqQ3LZpXZJW