### PR TITLE
feat(reconciler): trace session-sync and orphan-release liveness phases (ga-ihbl3e.1)

### DIFF
--- a/cmd/gc/assigned_work_residency_test.go
+++ b/cmd/gc/assigned_work_residency_test.go
@@ -294,7 +294,7 @@ func TestOrphanReleaseSparesALiveHoldersBindingResidentClaim(t *testing.T) {
 	infos := sessionInfosFromBeads([]beads.Bead{sess})
 	released := releaseOrphanedPoolAssignments(
 		work, beads.SessionStore{Store: work}, cfg, cityPath, infos,
-		[]beads.Bead{claim}, []beads.Store{work}, []string{""}, nil, nil,
+		[]beads.Bead{claim}, []beads.Store{work}, []string{""}, nil, nil, nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %v — a LIVE holder's claim was taken back on a leg the release path now reads; that is claim loss, not a strand", released)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5060,7 +5060,7 @@ func TestSyncDoesNotMintDuplicateForSameCycleSingletonCreate(t *testing.T) {
 	var syncStderr bytes.Buffer
 	syncSessionBeadsWithSnapshotAndRigStores(
 		cityPath, beads.SessionStore{Store: store}, nil, dsResult.State,
-		runtime.NewFake(), allConfiguredDS(dsResult.State), cfg, clk, &syncStderr, false, sessionBeads,
+		runtime.NewFake(), allConfiguredDS(dsResult.State), cfg, clk, &syncStderr, false, sessionBeads, nil,
 	)
 
 	// No duplicate was minted: exactly one open bead carries the created session_name.
@@ -5167,6 +5167,7 @@ func TestProductionOrderDeferredSingletonAliasReclaimsOnSecondTick(t *testing.T)
 		clk,
 		&firstSyncStderr,
 		true,
+		nil,
 		nil,
 	)
 	stillDeferred, err := store.Get(stale.ID)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -731,7 +731,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		result := cr.buildDesiredState(sessionBeads, startupTrace)
 		sessionBeads = cr.loadSessionBeadSnapshot()
 		result = cr.refreshDesiredState(result, sessionBeads)
-		sessionBeads = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
+		sessionBeads = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads, nil)
 		result = cr.refreshDesiredState(result, sessionBeads)
 		if ctx.Err() != nil {
 			return
@@ -1369,7 +1369,7 @@ func (cr *CityRuntime) tick(
 	result = cr.refreshDesiredState(result, sessionBeads)
 	recordPhase(TraceSiteDesiredStateBuild, "refresh_desired_state.before_sync", phaseStart, traceDesiredStateFields(result))
 	phaseStart = time.Now()
-	_ = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
+	_ = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads, recordPhase)
 	recordPhase(TraceSiteSessionSync, "sync_beads_and_update_index", phaseStart, traceDesiredStateFields(result))
 	// Reload snapshot after sync so the reconciler sees metadata written
 	// by syncBeadsAndUpdateIndex (e.g., configured_named_session/mode
@@ -2536,7 +2536,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// arm of this very tick is about to act on (the release-first ordering plus
 	// snapshot staleness otherwise produces the wake/release/retire treadmill).
 	preWakeCandidates, preWakeCandidateRefs := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, store, sessionBeads.OpenInfos(), assignedWorkBeads, assignedWorkStoreRefs)
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores, protectedWakeWorkKeys(preWakeCandidates, preWakeCandidateRefs))
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, sessStore, cr.cfg, cr.cityPath, sessionBeads.OpenInfos(), result, rigStores, protectedWakeWorkKeys(preWakeCandidates, preWakeCandidateRefs), recordPhase)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
 		"released_count": len(released),
 	})
@@ -3452,6 +3452,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		cr.stderr,
 		true,
 		sessionBeads,
+		nil,
 	)
 	// This targeted tick must include dynamically named pool sessions it just
 	// materialized. configuredSessionNamesWithSnapshot intentionally contains
@@ -3557,11 +3558,11 @@ func ensureManagedDoltPublishedForRuntime(
 }
 
 // syncBeadsAndUpdateIndex runs syncSessionBeads.
-func (cr *CityRuntime) syncBeadsAndUpdateIndex(desiredState map[string]TemplateParams, sessionBeads *sessionBeadSnapshot) *sessionBeadSnapshot {
+func (cr *CityRuntime) syncBeadsAndUpdateIndex(desiredState map[string]TemplateParams, sessionBeads *sessionBeadSnapshot, recordPhase func(TraceSiteCode, string, time.Time, map[string]any)) *sessionBeadSnapshot {
 	store := cr.sessionsBeadStore()
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cr.cityName, sessionBeads)
 	_, updated := syncSessionBeadsWithSnapshotAndRigStores(
-		cr.cityPath, store, cr.rigBeadStores(), desiredState, cr.sp, cfgNames, cr.cfg, clock.Real{}, cr.stderr, cr.sessionDrains != nil, sessionBeads,
+		cr.cityPath, store, cr.rigBeadStores(), desiredState, cr.sp, cfgNames, cr.cfg, clock.Real{}, cr.stderr, cr.sessionDrains != nil, sessionBeads, recordPhase,
 	)
 	return updated
 }

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1023,13 +1023,13 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	ds := dsResult.State
 	cfgNames := configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
 	_, sessionBeads = syncSessionBeadsWithSnapshotAndRigStores(
-		cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
+		cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads, nil,
 	)
 
 	// Same protection as the daemon tick: wake candidates computed before the
 	// release, so the one-shot path cannot reopen work this run is about to wake.
 	preWakeCandidates, preWakeCandidateRefs := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, oneShotStore, sessionBeads.OpenInfos(), dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores, protectedWakeWorkKeys(preWakeCandidates, preWakeCandidateRefs)); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, beads.SessionStore{Store: sessStore}, cfg, cityPath, sessionBeads.OpenInfos(), dsResult, rigStores, protectedWakeWorkKeys(preWakeCandidates, preWakeCandidateRefs), nil); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
@@ -1052,7 +1052,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		ds = dsResult.State
 		cfgNames = configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
 		_, sessionBeads = syncSessionBeadsWithSnapshotAndRigStores(
-			cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
+			cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads, nil,
 		)
 	}
 
@@ -1107,7 +1107,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	ds = dsResult.State
 	cfgNames = configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
 	syncSessionBeadsWithSnapshotAndRigStores(
-		cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, false, sessionBeads,
+		cityPath, beads.SessionStore{Store: sessStore}, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, false, sessionBeads, nil,
 	)
 
 	fmt.Fprintln(stdout, "City started.") //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -667,6 +667,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 		},
 		nil,
 		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %d work bead(s) from a partial snapshot, want none", len(released))
@@ -692,6 +693,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 		},
 		nil,
 		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %d work bead(s) from a partial session snapshot, want none", len(released))
@@ -714,6 +716,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 			AssignedWorkBeads:  []beads.Bead{work},
 			AssignedWorkStores: []beads.Store{store},
 		},
+		nil,
 		nil,
 		nil,
 	)

--- a/cmd/gc/dead_assignee_repair_test.go
+++ b/cmd/gc/dead_assignee_repair_test.go
@@ -187,7 +187,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveAssigneeStaysAssigned(t *testin
 		"",
 		sessionInfosFromBeads([]beads.Bead{live}),
 		[]beads.Bead{work},
-		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("live assignee must not be released, got %v", released)
@@ -242,7 +242,7 @@ func TestReleaseOrphanedPoolAssignments_NilSessionsStoreFallsBackToWorkStore(t *
 		"",
 		nil, // empty snapshot: the two snapshot gates miss, so the live re-read decides
 		[]beads.Bead{work},
-		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("a live assignee was released with a nil sessions store, got %v; "+

--- a/cmd/gc/execution_stalled_convergence_test.go
+++ b/cmd/gc/execution_stalled_convergence_test.go
@@ -178,7 +178,7 @@ func TestExecutionStalledDrainConvergesToAReclaimableRow(t *testing.T) {
 		t.Fatalf("re-reading the claim: %v", err)
 	}
 	released := releaseOrphanedPoolAssignments(h.env.store, beads.SessionStore{Store: h.env.store}, h.env.cfg, "", nil,
-		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil, nil)
+		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil, nil, nil)
 	if len(released) != 1 || released[0].ID != h.work.ID {
 		t.Fatalf("released = %+v, want the stalled claim reopened", released)
 	}
@@ -308,7 +308,7 @@ func TestExecutionStalledDrainDoesNotStrandAMidDrainWake(t *testing.T) {
 		t.Fatalf("re-reading the claim: %v", err)
 	}
 	released := releaseOrphanedPoolAssignments(h.env.store, beads.SessionStore{Store: h.env.store}, h.env.cfg, "", nil,
-		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil, nil)
+		[]beads.Bead{claimed}, []beads.Store{h.env.store}, []string{""}, nil, nil, nil)
 	if len(released) != 1 {
 		t.Fatalf("released = %+v, want the claim released once its holder is gone", released)
 	}

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -143,6 +143,7 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	result DesiredStateResult,
 	rigStores map[string]beads.Store,
 	protectedWakeWork map[storeScopedBeadKey]struct{},
+	recordPhase func(TraceSiteCode, string, time.Time, map[string]any),
 ) []releasedPoolAssignment {
 	// Partial input snapshots can make active work look orphaned for this
 	// tick only: missing work affects drain decisions, and missing sessions
@@ -150,7 +151,7 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	if result.snapshotQueryPartial() {
 		return nil
 	}
-	return releaseOrphanedPoolAssignments(store, sessionStore, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores, protectedWakeWork)
+	return releaseOrphanedPoolAssignments(store, sessionStore, cfg, cityPath, openSessionInfos, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores, protectedWakeWork, recordPhase)
 }
 
 // protectedWakeWorkKeys indexes the wake-candidate slice by store ref + bead ID
@@ -215,6 +216,7 @@ func releaseOrphanedPoolAssignments(
 	assignedWorkStoreRefs []string,
 	rigStores map[string]beads.Store,
 	protectedWakeWork map[storeScopedBeadKey]struct{},
+	recordPhase func(TraceSiteCode, string, time.Time, map[string]any),
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
@@ -250,6 +252,9 @@ func releaseOrphanedPoolAssignments(
 	// at ~14 minutes.
 	sessionStoreLiveAssignee := make(map[string]bool, len(assignedWorkBeads))
 	ownerStoreLiveAssignee := make(map[string]bool, len(assignedWorkBeads))
+	probeStart := time.Now()
+	memoizedProbeCount := 0
+	fallbackProbeCount := 0
 
 	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, store, openSessionInfos, storeRefAware)
 	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionInfos)*5)
@@ -331,8 +336,10 @@ func releaseOrphanedPoolAssignments(
 			if ownerStore != nil {
 				live := false
 				if storeAware && storeRefAware {
+					memoizedProbeCount++
 					live = memoizedLiveOpenSessionAssignmentExists(ownerStoreLiveAssignee, workStoreRef+"\x00"+assignee, ownerStore, assignee)
 				} else {
+					fallbackProbeCount++
 					live = liveOpenSessionAssignmentExists(ownerStore, assignee)
 				}
 				if live {
@@ -358,6 +365,12 @@ func releaseOrphanedPoolAssignments(
 			continue
 		}
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
+	}
+	if recordPhase != nil {
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments.liveness_probe", probeStart, map[string]any{
+			"memoized_count": memoizedProbeCount,
+			"fallback_count": fallbackProbeCount,
+		})
 	}
 	return released
 }

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -252,7 +252,8 @@ func releaseOrphanedPoolAssignments(
 	// at ~14 minutes.
 	sessionStoreLiveAssignee := make(map[string]bool, len(assignedWorkBeads))
 	ownerStoreLiveAssignee := make(map[string]bool, len(assignedWorkBeads))
-	probeStart := time.Now()
+	sweepStart := time.Now()
+	var probeElapsed time.Duration
 	memoizedProbeCount := 0
 	fallbackProbeCount := 0
 
@@ -335,6 +336,7 @@ func releaseOrphanedPoolAssignments(
 			// leave the fallback unmemoized rather than risk that.
 			if ownerStore != nil {
 				live := false
+				probeCallStart := time.Now()
 				if storeAware && storeRefAware {
 					memoizedProbeCount++
 					live = memoizedLiveOpenSessionAssignmentExists(ownerStoreLiveAssignee, workStoreRef+"\x00"+assignee, ownerStore, assignee)
@@ -342,6 +344,7 @@ func releaseOrphanedPoolAssignments(
 					fallbackProbeCount++
 					live = liveOpenSessionAssignmentExists(ownerStore, assignee)
 				}
+				probeElapsed += time.Since(probeCallStart)
 				if live {
 					continue
 				}
@@ -367,9 +370,10 @@ func releaseOrphanedPoolAssignments(
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	if recordPhase != nil {
-		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments.liveness_probe", probeStart, map[string]any{
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments.release_sweep", sweepStart, map[string]any{
 			"memoized_count": memoizedProbeCount,
 			"fallback_count": fallbackProbeCount,
+			"probe_ms":       probeElapsed.Milliseconds(),
 		})
 	}
 	return released

--- a/cmd/gc/pool_session_name_orphan_release_fanout_test.go
+++ b/cmd/gc/pool_session_name_orphan_release_fanout_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -72,6 +73,7 @@ func countOrphanReleaseLiveSessionLists(t *testing.T, workBeadCount int) int {
 		work,
 		stores,
 		storeRefs,
+		nil,
 		nil,
 		nil,
 	)
@@ -204,6 +206,7 @@ func TestReleaseOrphanedPoolAssignments_OwnerStoreMemoDoesNotCollapseDistinctSto
 				tc.refs,
 				nil,
 				nil,
+				nil,
 			)
 
 			var releasedIDs []string
@@ -227,4 +230,118 @@ func TestReleaseOrphanedPoolAssignments_OwnerStoreMemoDoesNotCollapseDistinctSto
 			}
 		})
 	}
+}
+
+// newDeadAssigneeWorkBeads creates n in_progress work beads in store, all
+// assigned to assignee and routed to the "worker" template, with no session
+// bead anywhere — the fixture shape that reaches the owner-store liveness
+// probe at the bottom of releaseOrphanedPoolAssignments's per-bead loop.
+func newDeadAssigneeWorkBeads(t *testing.T, store beads.Store, n int, assignee string) []beads.Bead {
+	t.Helper()
+
+	var work []beads.Bead
+	for i := 0; i < n; i++ {
+		b, err := store.Create(beads.Bead{
+			Title:    fmt.Sprintf("orphaned pool work %d", i),
+			Assignee: assignee,
+			Metadata: map[string]string{"gc.routed_to": "worker"},
+		})
+		if err != nil {
+			t.Fatalf("create work bead %d: %v", i, err)
+		}
+		if err := store.Update(b.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+			t.Fatalf("set work in_progress %d: %v", i, err)
+		}
+		if b, err = store.Get(b.ID); err != nil {
+			t.Fatalf("reload work bead %d: %v", i, err)
+		}
+		work = append(work, b)
+	}
+	return work
+}
+
+// findCapturedTracePhase returns the single captured phase with the given
+// name, failing the test if it is missing or duplicated.
+func findCapturedTracePhase(t *testing.T, captured []capturedTracePhase, name string) capturedTracePhase {
+	t.Helper()
+
+	var found []capturedTracePhase
+	for _, p := range captured {
+		if p.name == name {
+			found = append(found, p)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("phase %q recorded %d times, want 1; captured=%+v", name, len(found), captured)
+	}
+	return found[0]
+}
+
+// TestReleaseOrphanedPoolAssignments_RecordsMemoizedVsFallbackBranchCounts
+// covers ga-ihbl3e.1 work package 2: the owner-store liveness probe at the
+// bottom of the per-bead loop takes either the memoized branch (O(1) once the
+// store is warm) or the unmemoized liveOpenSessionAssignmentExists fallback
+// (a live store round-trip per bead) depending on whether the call is both
+// store-aware and store-ref-aware. That fallback is the exact residual cost
+// measured on gc-management 2026-09-05 (ga-451jnv): 319.5s of a 609,851ms
+// tick. The sweep must report how many assignees took each branch so a
+// regression that silently drops a store-aware caller back onto the fallback
+// shows up as a nonzero fallback_count instead of only as a duration blip.
+func TestReleaseOrphanedPoolAssignments_RecordsMemoizedVsFallbackBranchCounts(t *testing.T) {
+	t.Run("store-aware and store-ref-aware takes the memoized branch", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		work := newDeadAssigneeWorkBeads(t, mem, 3, "worker-dead")
+		stores := []beads.Store{mem, mem, mem}
+		storeRefs := []string{"", "", ""}
+
+		var captured []capturedTracePhase
+		recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
+			if start.IsZero() {
+				t.Fatalf("recordPhase %s: start time is zero", name)
+			}
+			captured = append(captured, capturedTracePhase{site: site, name: name, fields: fields})
+		}
+
+		releaseOrphanedPoolAssignments(
+			mem, beads.SessionStore{Store: mem}, testPoolReleaseConfig(), "", nil,
+			work, stores, storeRefs, nil, nil, recordPhase,
+		)
+
+		phase := findCapturedTracePhase(t, captured, "bead_reconcile.release_orphaned_pool_assignments.liveness_probe")
+		if phase.site != TraceSiteControllerTickPhase {
+			t.Fatalf("liveness_probe site = %q, want %q", phase.site, TraceSiteControllerTickPhase)
+		}
+		if got := phase.fields["memoized_count"]; got != 3 {
+			t.Fatalf("memoized_count = %v, want 3", got)
+		}
+		if got := phase.fields["fallback_count"]; got != 0 {
+			t.Fatalf("fallback_count = %v, want 0 — a store-aware, store-ref-aware call shape must stay on the memoized branch", got)
+		}
+	})
+
+	t.Run("neither store-aware nor store-ref-aware falls back to the unmemoized branch", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		work := newDeadAssigneeWorkBeads(t, mem, 3, "worker-dead")
+
+		var captured []capturedTracePhase
+		recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
+			if start.IsZero() {
+				t.Fatalf("recordPhase %s: start time is zero", name)
+			}
+			captured = append(captured, capturedTracePhase{site: site, name: name, fields: fields})
+		}
+
+		releaseOrphanedPoolAssignments(
+			mem, beads.SessionStore{Store: mem}, testPoolReleaseConfig(), "", nil,
+			work, nil, nil, nil, nil, recordPhase,
+		)
+
+		phase := findCapturedTracePhase(t, captured, "bead_reconcile.release_orphaned_pool_assignments.liveness_probe")
+		if got := phase.fields["fallback_count"]; got != 3 {
+			t.Fatalf("fallback_count = %v, want 3", got)
+		}
+		if got := phase.fields["memoized_count"]; got != 0 {
+			t.Fatalf("memoized_count = %v, want 0 — a call shape with no store awareness must not report memoized work", got)
+		}
+	})
 }

--- a/cmd/gc/pool_session_name_orphan_release_fanout_test.go
+++ b/cmd/gc/pool_session_name_orphan_release_fanout_test.go
@@ -307,15 +307,31 @@ func TestReleaseOrphanedPoolAssignments_RecordsMemoizedVsFallbackBranchCounts(t 
 			work, stores, storeRefs, nil, nil, recordPhase,
 		)
 
-		phase := findCapturedTracePhase(t, captured, "bead_reconcile.release_orphaned_pool_assignments.liveness_probe")
+		phase := findCapturedTracePhase(t, captured, "bead_reconcile.release_orphaned_pool_assignments.release_sweep")
 		if phase.site != TraceSiteControllerTickPhase {
-			t.Fatalf("liveness_probe site = %q, want %q", phase.site, TraceSiteControllerTickPhase)
+			t.Fatalf("release_sweep site = %q, want %q", phase.site, TraceSiteControllerTickPhase)
 		}
 		if got := phase.fields["memoized_count"]; got != 3 {
 			t.Fatalf("memoized_count = %v, want 3", got)
 		}
 		if got := phase.fields["fallback_count"]; got != 0 {
 			t.Fatalf("fallback_count = %v, want 0 — a store-aware, store-ref-aware call shape must stay on the memoized branch", got)
+		}
+		// probe_ms isolates the liveness-probe cost from the rest of the sweep
+		// body (ownership-index build, gates, release writes), which is the
+		// number ga-ihbl3e needs. Against a MemStore the probes finish in
+		// microseconds and floor to 0, so assert presence and a sane type
+		// rather than a nonzero duration.
+		probeMS, ok := phase.fields["probe_ms"]
+		if !ok {
+			t.Fatalf("release_sweep fields have no probe_ms; fields=%+v", phase.fields)
+		}
+		probeMSInt, ok := probeMS.(int64)
+		if !ok {
+			t.Fatalf("probe_ms = %v (%T), want int64", probeMS, probeMS)
+		}
+		if probeMSInt < 0 {
+			t.Fatalf("probe_ms = %d, want >= 0", probeMSInt)
 		}
 	})
 
@@ -336,7 +352,7 @@ func TestReleaseOrphanedPoolAssignments_RecordsMemoizedVsFallbackBranchCounts(t 
 			work, nil, nil, nil, nil, recordPhase,
 		)
 
-		phase := findCapturedTracePhase(t, captured, "bead_reconcile.release_orphaned_pool_assignments.liveness_probe")
+		phase := findCapturedTracePhase(t, captured, "bead_reconcile.release_orphaned_pool_assignments.release_sweep")
 		if got := phase.fields["fallback_count"]; got != 3 {
 			t.Fatalf("fallback_count = %v, want 3", got)
 		}

--- a/cmd/gc/pool_session_name_protected_wake_test.go
+++ b/cmd/gc/pool_session_name_protected_wake_test.go
@@ -44,6 +44,7 @@ func TestReleaseOrphanedPoolAssignments_RetainsProtectedWakeWork(t *testing.T) {
 		store, beads.SessionStore{Store: store}, testPoolReleaseConfig(), "", nil,
 		[]beads.Bead{work}, []beads.Store{store}, nil, nil,
 		map[storeScopedBeadKey]struct{}{{ID: work.ID}: {}},
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %v — protected wake work was reopened; the release arm ran ahead of the wake arm it must yield to", released)
@@ -66,6 +67,7 @@ func TestReleaseOrphanedPoolAssignments_EmptyProtectedSetStillReleases(t *testin
 	released := releaseOrphanedPoolAssignments(
 		store, beads.SessionStore{Store: store}, testPoolReleaseConfig(), "", nil,
 		[]beads.Bead{work}, []beads.Store{store}, nil, nil,
+		nil,
 		nil,
 	)
 	if len(released) != 1 || released[0].ID != work.ID {
@@ -106,6 +108,7 @@ func TestReleaseOrphanedPoolAssignments_ProtectsAliasAssignedRigWork(t *testing.
 		cityStore, beads.SessionStore{Store: cityStore}, testPoolReleaseConfig(), "", nil,
 		[]beads.Bead{work}, []beads.Store{ownerStore}, nil, nil,
 		map[storeScopedBeadKey]struct{}{{ID: work.ID}: {}},
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released %v — alias-assigned rig-store work was reopened despite wake protection", released)
@@ -163,6 +166,7 @@ func TestReleaseOrphanedPoolAssignments_ProtectionDoesNotCrossStoreIDCollision(t
 		storeA, beads.SessionStore{Store: storeA}, testPoolReleaseConfig(), "", nil,
 		[]beads.Bead{aWork, bWork}, []beads.Store{storeA, storeB}, []string{"", "rig:b"}, nil,
 		protectedWakeWorkKeys([]beads.Bead{aWork}, []string{""}),
+		nil,
 	)
 	if len(released) != 1 || released[0].ID != bWork.ID {
 		t.Fatalf("released = %v, want exactly storeB's %s — storeA's wake candidate shielded a same-ID bead in another store", released, bWork.ID)

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -2287,6 +2287,7 @@ func releaseProbeAssignments(store *conditionalReleaseProbeStore, work beads.Bea
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 
@@ -2489,7 +2490,7 @@ func releaseOrphanedPoolAssignmentsFromBeads(
 	}
 	// Single-store fixtures: the session class resolves to the work store, which
 	// is what a city without a [storage.classes] sessions binding does.
-	return releaseOrphanedPoolAssignments(store, beads.SessionStore{Store: store}, cfg, cityPath, infos, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores, nil)
+	return releaseOrphanedPoolAssignments(store, beads.SessionStore{Store: store}, cfg, cityPath, infos, assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, rigStores, nil, nil)
 }
 
 // gcSweepSessionBeadsFromBeads projects raw session beads to session.Info and
@@ -2591,6 +2592,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveModernPoolSessionWhenLiveListMi
 		nil, // open-session snapshot also misses the live session
 		[]beads.Bead{work},
 		[]beads.Store{store},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/cmd/gc/pool_session_release_owner_store_test.go
+++ b/cmd/gc/pool_session_release_owner_store_test.go
@@ -87,6 +87,7 @@ func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromWorkOwnerStore(t *testin
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -136,6 +137,7 @@ func TestReleaseOrphanedPoolAssignmentsReleasesWhenNoStoreHoldsTheSession(t *tes
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{ownerStore},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/cmd/gc/pool_session_release_session_store_test.go
+++ b/cmd/gc/pool_session_release_session_store_test.go
@@ -86,6 +86,7 @@ func TestReleaseOrphanedPoolAssignmentsReadsLivenessFromSessionStore(t *testing.
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -123,6 +124,7 @@ func TestReleaseOrphanedPoolAssignmentsStillReleasesWhenSessionStoreSaysDead(t *
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 1 || released[0].ID != work.ID {
@@ -157,6 +159,7 @@ func TestReleaseOrphanedPoolAssignmentsFallsBackToWorkStoreForLiveness(t *testin
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{single},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/cmd/gc/pool_slot_unaliased_test.go
+++ b/cmd/gc/pool_slot_unaliased_test.go
@@ -321,6 +321,7 @@ func TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s] — a stale slot-form assignee names no live session once pool beads are unaliased", released, work.ID)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1572,7 +1572,7 @@ func syncSessionBeads(
 	skipClose bool,
 ) map[string]string {
 	openIndex, _ := syncSessionBeadsWithSnapshotAndRigStores(
-		cityPath, beads.SessionStore{Store: store}, nil, desiredState, sp, configuredNames, cfg, clk, stderr, skipClose, nil,
+		cityPath, beads.SessionStore{Store: store}, nil, desiredState, sp, configuredNames, cfg, clk, stderr, skipClose, nil, nil,
 	)
 	return openIndex
 }
@@ -1588,7 +1588,7 @@ func syncSessionBeadsWithSnapshot(
 	sessionBeads *sessionBeadSnapshot,
 ) (map[string]string, *sessionBeadSnapshot) {
 	return syncSessionBeadsWithSnapshotAndRigStores(
-		"", beads.SessionStore{Store: store}, nil, desiredState, sp, configuredNames, cfg, clk, stderr, false, sessionBeads,
+		"", beads.SessionStore{Store: store}, nil, desiredState, sp, configuredNames, cfg, clk, stderr, false, sessionBeads, nil,
 	)
 }
 
@@ -1604,6 +1604,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	stderr io.Writer,
 	skipClose bool,
 	sessionBeads *sessionBeadSnapshot,
+	recordPhase func(TraceSiteCode, string, time.Time, map[string]any),
 ) (map[string]string, *sessionBeadSnapshot) {
 	// Session class typed at the boundary; the snapshot/repair/close helpers
 	// below take the unwrapped beads.Store. Same underlying store value, behavior
@@ -1628,10 +1629,16 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	// path; the reload-always delta is the same NDI-tolerated concurrent-writer
 	// visibility the W-pool skew reload already introduced (the retired
 	// snapshotOrLoadSessionBeads only re-listed on a same-cycle create skew).
+	loadExistingStart := time.Now()
 	existing, err := loadSessionBeads(store)
 	if err != nil {
 		fmt.Fprintf(stderr, "session beads: listing existing: %v\n", err) //nolint:errcheck
 		return nil, sessionBeads
+	}
+	if recordPhase != nil {
+		recordPhase(TraceSiteSessionSync, "sync_beads_and_update_index.load_existing", loadExistingStart, map[string]any{
+			"existing_count": len(existing),
+		})
 	}
 
 	// Repair session beads with empty types. The gc:session label (used by
@@ -1719,12 +1726,18 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		if visibleLoaded {
 			return visibleBySessionName, nil
 		}
+		loadVisibleStart := time.Now()
 		open, err := loadSessionBeads(store)
 		if err != nil {
 			return nil, err
 		}
 		visibleBySessionName = indexSessionBeadsByName(open)
 		visibleLoaded = true
+		if recordPhase != nil {
+			recordPhase(TraceSiteSessionSync, "sync_beads_and_update_index.load_visible_by_session_name", loadVisibleStart, map[string]any{
+				"visible_count": len(visibleBySessionName),
+			})
+		}
 		return visibleBySessionName, nil
 	}
 

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1631,14 +1631,18 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	// snapshotOrLoadSessionBeads only re-listed on a same-cycle create skew).
 	loadExistingStart := time.Now()
 	existing, err := loadSessionBeads(store)
-	if err != nil {
-		fmt.Fprintf(stderr, "session beads: listing existing: %v\n", err) //nolint:errcheck
-		return nil, sessionBeads
-	}
+	// Record before the error return: under store pressure the slow scan is
+	// also the one most likely to fail, so the failing case is the one the
+	// trace most needs. len(existing) is 0 on the error path, which is correct.
 	if recordPhase != nil {
 		recordPhase(TraceSiteSessionSync, "sync_beads_and_update_index.load_existing", loadExistingStart, map[string]any{
 			"existing_count": len(existing),
+			"ok":             err == nil,
 		})
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "session beads: listing existing: %v\n", err) //nolint:errcheck
+		return nil, sessionBeads
 	}
 
 	// Repair session beads with empty types. The gc:session label (used by
@@ -1728,15 +1732,20 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		loadVisibleStart := time.Now()
 		open, err := loadSessionBeads(store)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			visibleBySessionName = indexSessionBeadsByName(open)
+			visibleLoaded = true
 		}
-		visibleBySessionName = indexSessionBeadsByName(open)
-		visibleLoaded = true
+		// Record before the error return, for the same reason as the scan
+		// above: a failing recovery scan is exactly the one worth timing.
 		if recordPhase != nil {
 			recordPhase(TraceSiteSessionSync, "sync_beads_and_update_index.load_visible_by_session_name", loadVisibleStart, map[string]any{
 				"visible_count": len(visibleBySessionName),
+				"ok":            err == nil,
 			})
+		}
+		if err != nil {
+			return nil, err
 		}
 		return visibleBySessionName, nil
 	}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -8788,6 +8788,7 @@ func TestSyncSessionBeadsWithSnapshotAndRigStoresLeavesOrphanedSessionBeadOpenWh
 		&stderr,
 		false,
 		nil,
+		nil,
 	)
 
 	got, err := store.Get(sessionBead.ID)
@@ -8796,6 +8797,124 @@ func TestSyncSessionBeadsWithSnapshotAndRigStoresLeavesOrphanedSessionBeadOpenWh
 	}
 	if got.Status != "open" {
 		t.Fatalf("session bead status = %q, want open because rig-store work still owns it", got.Status)
+	}
+}
+
+// capturedTracePhase is a test spy record for a single recordPhase call.
+type capturedTracePhase struct {
+	site   TraceSiteCode
+	name   string
+	fields map[string]any
+}
+
+// TestSyncSessionBeadsWithSnapshotAndRigStoresRecordsLoadExistingPhase covers
+// ga-ihbl3e.1 work package 1: the unconditional existing-beads scan (Scan 1)
+// must report its own duration and row count as a distinct child phase of
+// TraceSiteSessionSync, not be folded silently into the caller's outer
+// "sync_beads_and_update_index" span. With an empty desired state the loop
+// never runs, so the second (memoized) scan must NOT fire.
+func TestSyncSessionBeadsWithSnapshotAndRigStoresRecordsLoadExistingPhase(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	sp := runtime.NewFake()
+	clk := &clock.Fake{Time: time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)}
+
+	var captured []capturedTracePhase
+	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
+		if start.IsZero() {
+			t.Fatalf("recordPhase %s: start time is zero", name)
+		}
+		captured = append(captured, capturedTracePhase{site: site, name: name, fields: fields})
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshotAndRigStores(
+		"", beads.SessionStore{Store: store}, nil, nil, sp, map[string]bool{}, nil, clk, &stderr, false, nil,
+		recordPhase,
+	)
+
+	var loadExisting *capturedTracePhase
+	for i := range captured {
+		switch captured[i].name {
+		case "sync_beads_and_update_index.load_existing":
+			loadExisting = &captured[i]
+		case "sync_beads_and_update_index.load_visible_by_session_name":
+			t.Fatalf("load_visible_by_session_name phase recorded with an empty desired state; nothing should trigger the second scan")
+		}
+	}
+	if loadExisting == nil {
+		t.Fatalf("no sync_beads_and_update_index.load_existing phase recorded; captured=%+v", captured)
+	}
+	if loadExisting.site != TraceSiteSessionSync {
+		t.Fatalf("load_existing site = %q, want %q", loadExisting.site, TraceSiteSessionSync)
+	}
+	if got := loadExisting.fields["existing_count"]; got != 1 {
+		t.Fatalf("load_existing existing_count = %v, want 1", got)
+	}
+}
+
+// TestSyncSessionBeadsWithSnapshotAndRigStoresRecordsLoadVisibleBySessionNamePhase
+// covers ga-ihbl3e.1 work package 1's second scan: loadVisibleBySessionName
+// only re-lists the store when a desired pool instance has no matching bead
+// yet (the stale-snapshot recovery lane). That lane is a second full store
+// scan folded into the same outer phase, so it must report its own duration
+// too — otherwise the two scans are indistinguishable in the trace.
+func TestSyncSessionBeadsWithSnapshotAndRigStoresRecordsLoadVisibleBySessionNamePhase(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	clk := &clock.Fake{Time: time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)}
+	desired := map[string]TemplateParams{
+		"pool-session": {
+			TemplateName: "pack/worker",
+			InstanceName: "pack/worker-1",
+			PoolSlot:     1,
+		},
+	}
+
+	var captured []capturedTracePhase
+	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
+		if start.IsZero() {
+			t.Fatalf("recordPhase %s: start time is zero", name)
+		}
+		captured = append(captured, capturedTracePhase{site: site, name: name, fields: fields})
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshotAndRigStores(
+		"", beads.SessionStore{Store: store}, nil, desired, sp, allConfiguredDS(desired), nil, clk, &stderr, false, nil,
+		recordPhase,
+	)
+
+	var loadExisting, loadVisible *capturedTracePhase
+	for i := range captured {
+		switch captured[i].name {
+		case "sync_beads_and_update_index.load_existing":
+			loadExisting = &captured[i]
+		case "sync_beads_and_update_index.load_visible_by_session_name":
+			loadVisible = &captured[i]
+		}
+	}
+	if loadExisting == nil {
+		t.Fatalf("no sync_beads_and_update_index.load_existing phase recorded; captured=%+v", captured)
+	}
+	if loadVisible == nil {
+		t.Fatalf("no sync_beads_and_update_index.load_visible_by_session_name phase recorded; a new pool instance with no existing bead must trigger the recovery scan; captured=%+v", captured)
+	}
+	if loadVisible.site != TraceSiteSessionSync {
+		t.Fatalf("load_visible_by_session_name site = %q, want %q", loadVisible.site, TraceSiteSessionSync)
+	}
+	if got := loadVisible.fields["visible_count"]; got != 0 {
+		t.Fatalf("load_visible_by_session_name visible_count = %v, want 0", got)
 	}
 }
 

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -337,6 +337,7 @@ func conformanceAssignedWorkCapture(t *testing.T, e splitEnv) {
 		got, stores, refs,
 		e.rigStores,
 		nil,
+		nil,
 	)
 	wantReleased := []string{dead.ID, hqDead.ID}
 	releasedIDs := make(map[string]bool, len(released))


### PR DESCRIPTION
## Summary
- Instrumentation-only change (no behavior change) to make two opaque hot phases of the reconciler tick visible in trace data, per `ga-ihbl3e`'s architecture investigation into tick-cadence overruns.
- Adds `recordPhase` spans in `syncSessionBeadsWithSnapshotAndRigStores` (`cmd/gc/session_beads.go`) around the unconditional session-bead scan and `loadVisibleBySessionName`'s body, to confirm whether the 176.2s (29% of tick) `session_sync.update_index` cost is scan-dominated and whether it's one scan or two.
- Adds a `recordPhase`-based counter in `releaseOrphanedPoolAssignments` (`cmd/gc/pool_session_name.go`) distinguishing the memoized-liveness-probe branch from the unmemoized ownerStore fallback branch per tick, to confirm or kill the "unmemoized ownerStore fallback" hypothesis for the residual 319.5s (52% of tick) cost.
- Fixes ~26 test call sites across 11 files where a prior rebase against #5568 (`protectedWakeWork`) silently coalesced two independently-appended trailing arguments to `releaseOrphanedPoolAssignments`/`releaseOrphanedPoolAssignmentsWhenSnapshotsComplete` into one slot (zero diff, zero conflict markers — only caught by `go test -gcflags="all=-e" -c -o /dev/null`).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -gcflags="all=-e" -c -o /dev/null ./cmd/gc/` — zero remaining compile errors after rebase-coalescing fixes
- [x] Full `cmd/gc` package test suite green pre- and post-rebase (both exit 0)
- [x] Local pre-push fast gate (`test-local-parallel fast`, 10 jobs incl. `unit-core`, sharded `unit-cmd-gc-*-of-6`) all passed
- [ ] Post-merge: capture one `gc trace show --type operation --since <window> --json` covering a full tick, confirm new spans appear with plausible durations, and post the result on `ga-ihbl3e` (parent bead)

Bead: ga-ihbl3e.1 (parent: ga-ihbl3e)