### PR TITLE
fix(supervisor): persist beads pool-deadline env overrides in the service file

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1106,6 +1106,15 @@ var supervisorServiceEnvNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // context need to survive launchd/systemd startup; arbitrary shell state can
 // be opted in with GC_SUPERVISOR_ENV.
 var supervisorServiceEnvKeys = map[string]bool{
+	// beads' pooled per-I/O deadline overrides (#1861 rationale, like the
+	// GC_DOLT_* keys). The supervisor's in-process store opens honor ONLY the
+	// env rung — the config.yaml rung reads a viper only cmd/bd initializes,
+	// .beads/.env is bd-main-only — so on a shared/hub-bound Dolt store where
+	// the 10s default is too tight these must survive plist regeneration.
+	// Scope: the storebinding workspace open withholds the BEADS_ namespace
+	// by design and keeps its defaults either way.
+	"BEADS_DOLT_POOL_READ_TIMEOUT":             true,
+	"BEADS_DOLT_POOL_WRITE_TIMEOUT":            true,
 	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": true,
 	"CLAUDE_CODE_EFFORT_LEVEL":                 true,
 	"CLAUDE_CODE_OAUTH_TOKEN":                  true,

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -6771,3 +6771,73 @@ func TestRunSupervisorNoWarningForLowAPIPort(t *testing.T) {
 		t.Errorf("stdout = %q, want API listening message for low port", stdout.String())
 	}
 }
+
+// TestBuildSupervisorServiceDataMergesPoolTimeoutKeysFromSecretsEnvFile pins
+// the survival path for beads' pooled per-I/O deadline overrides: the
+// supervisor's in-process store opens honor only the env rung, so the two
+// keys must persist into the service env from ${GC_HOME}/secrets.env without
+// a GC_SUPERVISOR_ENV opt-in — that is what the allowlist entry buys. Red on
+// base by construction (the keys were not allowlisted).
+func TestBuildSupervisorServiceDataMergesPoolTimeoutKeysFromSecretsEnvFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	// Ensure the keys are NOT present in the calling shell's environment.
+	t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "")
+	t.Setenv("BEADS_DOLT_POOL_WRITE_TIMEOUT", "")
+
+	writeSupervisorSecretsEnvFile(t, `# machine-local store deadlines
+BEADS_DOLT_POOL_READ_TIMEOUT=90s
+BEADS_DOLT_POOL_WRITE_TIMEOUT=90s
+`)
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for _, key := range []string{"BEADS_DOLT_POOL_READ_TIMEOUT", "BEADS_DOLT_POOL_WRITE_TIMEOUT"} {
+		if got[key] != "90s" {
+			t.Fatalf("ExtraEnv[%s] = %q, want 90s (all env: %#v)", key, got[key], got)
+		}
+	}
+}
+
+// TestBuildSupervisorServiceDataReadsPoolTimeoutKeysFromLaunchctl pins the
+// launchctl fallback tier for the same two keys, mirroring the GC_DOLT_*
+// credential test above.
+func TestBuildSupervisorServiceDataReadsPoolTimeoutKeysFromLaunchctl(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+	for _, key := range []string{
+		"BEADS_DOLT_POOL_READ_TIMEOUT",
+		"BEADS_DOLT_POOL_WRITE_TIMEOUT",
+	} {
+		t.Setenv(key, "")
+	}
+
+	stub := map[string]string{
+		"BEADS_DOLT_POOL_READ_TIMEOUT":  "120s",
+		"BEADS_DOLT_POOL_WRITE_TIMEOUT": "120s",
+	}
+	prev := supervisorLaunchctlGetenv
+	supervisorLaunchctlGetenv = func(key string) string { return stub[key] }
+	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for key, want := range stub {
+		if got[key] != want {
+			t.Fatalf("ExtraEnv[%s] = %q, want %q (all env: %#v)", key, got[key], want, got)
+		}
+	}
+}


### PR DESCRIPTION
The supervisor's in-process store opens honor only the env rung of beads' pool-deadline resolution (`caller > BEADS_DOLT_POOL_*_TIMEOUT env > config.yaml > 10s default`): the `config.yaml` rung reads a package-global viper that only `cmd/bd` initializes, and `.beads/.env` is loaded only by bd's `main()`. So for a gc supervisor pointed at a shared/hub-bound Dolt store, the env var is the **only** way to raise the deadline — and today it survives only as a `GC_SUPERVISOR_ENV` opt-in, which any plist regeneration from an environment lacking the opt-in silently drops, reverting the supervisor's shared-store deadlines to the 10s default.

That default is too tight on a loaded shared server: a multi-row `is_blocked` recompute measures in the tens of seconds on a busy hub, so root mints and closes die mid-operation with `invalid connection` while plain `SELECT 1` stays healthy — a silent, hard-to-attribute failure class hit in production this week on two machines.

This adds both keys to `supervisorServiceEnvKeys`, the same survival rationale as #1861's documented Dolt credential/logging settings: a deployment-level store setting must not depend on the installing shell's exports.

**Scope note**: the storage-binding workspace open (`internal/storebinding/beadsworkspace`) withholds the whole `BEADS_` namespace by design and keeps its defaults either way; this change covers the supervisor's shared-store opens, which are the ones that fail in production.

**Issue**: no upstream issue — the failure was diagnosed on a production deployment this week (fork-side tracking: ga-dwobeb class); #5524 is related, not fixed by this.

**Testing**: `go test ./cmd/gc/ -run TestBuildSupervisorServiceData -count=1` green (includes the two new tier tests, both red on base by construction); `gofmt` clean; full `go test ./cmd/gc/` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQnc3jpJEXCLiAUV2yWU1W