### PR TITLE
fix(init): fail closed on cross-city supervisor impact when stdin is not a terminal; add --standalone

### DIFF
--- a/cmd/gc/cityinit_impl.go
+++ b/cmd/gc/cityinit_impl.go
@@ -133,10 +133,16 @@ func cityInitDoInit(_ context.Context, req cityinit.InitRequest) error {
 
 func cityInitFinalize(_ context.Context, req cityinit.InitRequest) error {
 	var stdout, stderr bytes.Buffer
+	// The commandName deliberately differs from the CLI's "gc init": only the
+	// exact CLI command names gate interactively on cross-city supervisor
+	// impact (and, non-interactively, refuse without --yes). This path IS the
+	// supervisor acting on an operator's create-city API request — cycling
+	// itself is the requested operation, so it warns for the audit trail and
+	// proceeds.
 	if code := finalizeInit(req.Dir, &stdout, &stderr, initFinalizeOptions{
 		skipProviderReadiness: req.SkipProviderReadiness,
 		showProgress:          false,
-		commandName:           "gc init",
+		commandName:           "gc init (supervisor API)",
 	}); code != 0 {
 		detail := strings.TrimSpace(stderr.String())
 		if detail == "" {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -411,6 +411,7 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 	cmd.Flags().StringVar(&doltProjectIDFlag, "dolt-project-id", "", "authoritative beads project_id for the identity handshake (or "+envBeadsProjectID+"); derived from a bd_<id> --dolt-database when omitted")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
 	cmd.Flags().BoolVar(&noStart, "no-start", false, "initialize files and imports without registering or starting the city")
+	cmd.Flags().BoolVar(&noStart, "standalone", false, "alias for --no-start: never touch the shared supervisor (no service-file install, no registration, no start); run the city isolated afterwards with 'gc start --foreground'")
 	cmd.Flags().BoolVar(&preserveExisting, "preserve-existing", false, "keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	cmd.Flags().BoolVar(&assumeYesForSupervisorCycle, "yes", false, "bypass the cross-city supervisor cycle confirmation prompt (warning is still printed for the audit trail)")

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -324,8 +324,18 @@ func confirmCrossCitySupervisorImpact(cityPath string, promptOnImpact bool, stde
 		return true
 	}
 	if !confirmCrossCitySupervisorImpactStdinIsTerminal() {
-		fmt.Fprintln(stderr, "Continuing (stdin is not a terminal; pass --yes to silence this notice in scripted contexts).") //nolint:errcheck // best-effort stderr
-		return true
+		// Fail CLOSED here. This branch used to warn-and-proceed "in scripted
+		// contexts", but the commands that gate on impact (gc init,
+		// gc register) mutate shared infrastructure — they reinstall the
+		// supervisor service file and cycle the supervisor that manages every
+		// other registered city. A script or agent shell is exactly the
+		// context that cannot answer the prompt, and proceeding silently is
+		// how a throwaway test-city init restarted a production supervisor
+		// mid-deploy (2026-09-09). Scripted callers state their consent with
+		// --yes; the supervisor's own create-city API does not gate (its
+		// commandName never prompts on impact).
+		fmt.Fprintln(stderr, "Refusing: stdin is not a terminal and this operation would reconcile a supervisor managing other cities. Pass --yes to consent in scripted contexts, or use --no-start (init) to skip supervisor registration entirely.") //nolint:errcheck // best-effort stderr
+		return false
 	}
 	fmt.Fprint(stderr, "Continue? [y/N]: ") //nolint:errcheck // best-effort stderr
 	br := bufio.NewReader(confirmCrossCitySupervisorImpactStdin)

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -2919,12 +2919,17 @@ func TestConfirmCrossCitySupervisorImpactPromptEmptyDefaultsToNo(t *testing.T) {
 	}
 }
 
-func TestConfirmCrossCitySupervisorImpactNonTerminalStdinProceedsSilently(t *testing.T) {
-	// CI, scripts, pipes, `< /dev/null` all give a non-terminal stdin.
-	// In those contexts the guard cannot meaningfully prompt; it must
-	// warn (audit trail) and proceed, not abort. Aborting would break
-	// every scripted `gc init` / `gc register` invocation, including
-	// the acceptance test suite. See PR #2638 CI failure.
+func TestConfirmCrossCitySupervisorImpactNonTerminalStdinRefuses(t *testing.T) {
+	// CI, scripts, pipes, `< /dev/null`, and AGENT SHELLS all give a
+	// non-terminal stdin. This guard used to warn-and-proceed there, and
+	// that is exactly how a throwaway test-city `gc init` reinstalled the
+	// service file and cycled a production supervisor mid-deploy
+	// (2026-09-09): the context that cannot answer the prompt is the one
+	// that must not consent silently. It now fails CLOSED — scripted
+	// callers that mean it pass --yes (the acceptance suites run under a
+	// fresh GC_HOME with no other registered cities, so the guard never
+	// fires there), and the supervisor's own create-city API path uses a
+	// commandName that does not gate on impact.
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
 
@@ -2944,17 +2949,51 @@ func TestConfirmCrossCitySupervisorImpactNonTerminalStdinProceedsSilently(t *tes
 	t.Cleanup(func() { confirmCrossCitySupervisorImpactStdinIsTerminal = oldTerm })
 
 	var stderr bytes.Buffer
-	if !confirmCrossCitySupervisorImpact(cityPath, true, &stderr) {
-		t.Errorf("non-terminal stdin should proceed silently; stderr=%q", stderr.String())
+	if confirmCrossCitySupervisorImpact(cityPath, true, &stderr) {
+		t.Errorf("non-terminal stdin must REFUSE without --yes; stderr=%q", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "other-city") {
-		t.Errorf("warning should still be printed for audit; stderr=%q", stderr.String())
+		t.Errorf("warning should still name the impacted cities; stderr=%q", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "stdin is not a terminal") {
-		t.Errorf("non-tty notice should be printed; stderr=%q", stderr.String())
+	if !strings.Contains(stderr.String(), "Refusing") {
+		t.Errorf("refusal notice should be printed; stderr=%q", stderr.String())
 	}
 	if strings.Contains(stderr.String(), "Continue?") {
 		t.Errorf("prompt MUST NOT be emitted on non-tty path; stderr=%q", stderr.String())
+	}
+}
+
+// --yes still consents on a non-terminal stdin: the refusal above is about
+// SILENT consent, not about blocking scripted callers who state it.
+func TestConfirmCrossCitySupervisorImpactNonTerminalWithYesProceeds(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "new-city")
+	otherPath := filepath.Join(t.TempDir(), "other-city")
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(otherPath, "other-city"); err != nil {
+		t.Fatalf("seed register other: %v", err)
+	}
+
+	oldAlive := supervisorAliveHook
+	supervisorAliveHook = func() int { return 1234 }
+	t.Cleanup(func() { supervisorAliveHook = oldAlive })
+
+	oldTerm := confirmCrossCitySupervisorImpactStdinIsTerminal
+	confirmCrossCitySupervisorImpactStdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { confirmCrossCitySupervisorImpactStdinIsTerminal = oldTerm })
+
+	oldYes := assumeYesForSupervisorCycle
+	assumeYesForSupervisorCycle = true
+	t.Cleanup(func() { assumeYesForSupervisorCycle = oldYes })
+
+	var stderr bytes.Buffer
+	if !confirmCrossCitySupervisorImpact(cityPath, true, &stderr) {
+		t.Errorf("--yes must consent on a non-terminal stdin; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Continuing (--yes)") {
+		t.Errorf("--yes audit line should be printed; stderr=%q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
`gc init` on a box with a live multi-city supervisor reinstalls the supervisor service file, cycles the supervisor, and registers+starts the new city. The cross-city guard added in #2638 prompts interactively — but when stdin is not a terminal it warned and **proceeded**. A script or agent shell is precisely the context that cannot answer the prompt; measured consequence: a throwaway test-city `gc init` (env-scrubbed, ceiling-dirs set) restarted a production supervisor managing 20+ live sessions minutes after a deliberate deploy restart (2026-09-09).

Three changes:

1. **The non-terminal branch fails closed** for the commands that gate on impact (`gc init`, `gc register`): refuse with a message naming `--yes` and `--no-start`. `--yes` still consents in scripted contexts. The guard only fires when other cities are registered AND the supervisor is alive, so fresh-GC_HOME acceptance/CI runs never reach it (the #2638 CI concern does not re-arm).

2. **The supervisor's create-city API path is exempt** via its commandName (it never prompts on impact): the supervisor cycling itself is the requested operation. It keeps the audit warning.

3. **`gc init --standalone`** — alias for `--no-start` whose help text carries the isolation recipe: no service-file install, no registration, no start; run isolated with `gc start --foreground`.

Tests: the old proceed-silently pin is rewritten as a refusal pin (with the incident rationale), plus a new `--yes`-on-non-terminal consent test. `go test ./cmd/gc/ -run 'TestInit|TestRegister|TestSupervisorCity|TestCityInit|TestConfirmCrossCity|Census'` green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQnc3jpJEXCLiAUV2yWU1W