### PR TITLE
fix(gc): bind delete-source scans to graph store

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -2623,7 +2623,21 @@ func unscannedSourceWorkflowStoreSkips(cfg *config.City, cityPath, selectedStore
 // expected to surface these (see formatSourceWorkflowStoreSkips) so operators
 // can see when singleton coverage degraded.
 func openSourceWorkflowStores(cfg *config.City, cityPath, beadID string) ([]convoyStoreView, []sourceWorkflowStoreSkip, error) {
-	return openSourceWorkflowStoresWith(cfg, cityPath, beadID, sourceWorkflowStoreOpener(cityPath))
+	// Keep the directory scan's ordinary views: source beads and legacy
+	// workflow roots still live in the work store after graph-class migration.
+	// Federation appends the relocated binding for the graph roots instead of
+	// replacing the work store with it.
+	stores, skips, err := openSourceWorkflowStoresWith(cfg, cityPath, beadID, func(dir string) (beads.Store, error) {
+		return openStoreAtForCity(dir, cityPath)
+	})
+	if err != nil {
+		return stores, skips, err
+	}
+	stores, err = convoyStoreViewsWithBinding(cityPath, stores)
+	if err != nil {
+		return nil, skips, err
+	}
+	return stores, skips, nil
 }
 
 // openSourceWorkflowStoresWith is the testable core of openSourceWorkflowStores.

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -574,12 +574,16 @@ func makeSourceWorkflowLocker(ctx context.Context, cityPath string, cfg *config.
 // stores; a relocated scope does not open the scope store at all, because that
 // would be a bd process this scan never reads.
 func makeSourceWorkflowStoresLister(cityPath string, cfg *config.City) func() ([]dispatch.SourceWorkflowStore, error) {
-	return makeSourceWorkflowStoresListerWithOpenStore(cityPath, cfg, func(dir string) (beads.Store, error) {
+	return makeSourceWorkflowStoresListerWithOpenStore(cityPath, cfg, sourceWorkflowStoreOpener(cityPath))
+}
+
+func sourceWorkflowStoreOpener(cityPath string) func(string) (beads.Store, error) {
+	return func(dir string) (beads.Store, error) {
 		if binding, relocated := controlGraphBinding(cityPath, dir); relocated {
 			return binding, nil
 		}
 		return openStoreAtForCity(dir, cityPath)
-	})
+	}
 }
 
 func makeSourceWorkflowStoresListerWithOpenStore(cityPath string, cfg *config.City, openStore func(string) (beads.Store, error)) func() ([]dispatch.SourceWorkflowStore, error) {
@@ -2619,9 +2623,7 @@ func unscannedSourceWorkflowStoreSkips(cfg *config.City, cityPath, selectedStore
 // expected to surface these (see formatSourceWorkflowStoreSkips) so operators
 // can see when singleton coverage degraded.
 func openSourceWorkflowStores(cfg *config.City, cityPath, beadID string) ([]convoyStoreView, []sourceWorkflowStoreSkip, error) {
-	return openSourceWorkflowStoresWith(cfg, cityPath, beadID, func(dir string) (beads.Store, error) {
-		return openStoreAtForCity(dir, cityPath)
-	})
+	return openSourceWorkflowStoresWith(cfg, cityPath, beadID, sourceWorkflowStoreOpener(cityPath))
 }
 
 // openSourceWorkflowStoresWith is the testable core of openSourceWorkflowStores.

--- a/cmd/gc/control_dispatch_graph_store_test.go
+++ b/cmd/gc/control_dispatch_graph_store_test.go
@@ -655,6 +655,57 @@ func TestSourceWorkflowStoresScanTheLedgerThatHoldsWorkflowRoots(t *testing.T) {
 	}
 }
 
+// TestOpenSourceWorkflowStoresScanTheBindingOnSplitCity pins the command-side
+// delete-source path to the same relocated graph ledger as workflow-finalize.
+// The lister above injects its opener, so it cannot catch openSourceWorkflowStores
+// accidentally using the raw scope opener again.
+func TestOpenSourceWorkflowStoresScanTheBindingOnSplitCity(t *testing.T) {
+	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir file store: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".gc", "beads.json"), []byte("{\"seq\":0,\"beads\":[]}\n"), 0o644); err != nil {
+		t.Fatalf("seed scope store: %v", err)
+	}
+
+	graphStore := beads.NewMemStoreFrom(1000, nil, nil)
+	seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(graphStore))
+	const sourceBeadID = "gc-1"
+	root, err := graphStore.Create(beads.Bead{
+		Title: "binding-resident workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:           beadmeta.KindWorkflow,
+			beadmeta.SourceBeadIDMetadataKey:   sourceBeadID,
+			beadmeta.SourceStoreRefMetadataKey: "city:test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live workflow root: %v", err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	stores, _, err := openSourceWorkflowStores(cfg, cityPath, "")
+	if err != nil {
+		t.Fatalf("open source workflow stores: %v", err)
+	}
+	var found []string
+	for _, info := range stores {
+		roots, err := sourceworkflow.ListLiveRoots(info.store, sourceBeadID, "city:test-city", "city:test-city")
+		if err != nil {
+			t.Fatalf("ListLiveRoots(%s): %v", info.path, err)
+		}
+		for _, live := range roots {
+			found = append(found, live.ID)
+		}
+	}
+	if !slices.Contains(found, root.ID) {
+		t.Fatalf("openSourceWorkflowStores scanned %v, want binding-resident root %s", found, root.ID)
+	}
+}
+
 // TestSourceWorkflowStoresStayOnTheScopeStoreWithNoRelocation is the
 // compatibility half: a city that relocates nothing resolves the same scope
 // store the scan always used, and no graph binding is consulted.


### PR DESCRIPTION
Closes #6242.

## Summary

`gc workflow delete-source` and the command-side source-workflow singleton
scan now federate the ordinary scope stores with the city's relocated graph
binding. This keeps source beads and legacy workflow roots visible while also
checking graph-resident workflow roots.

## Root cause

On a split city, `openSourceWorkflowStores` opened only the directory-scanned
stores. Graph-class workflow roots live in `controlGraphBinding`, so
`delete-source` could report `already_clean matched_roots=0` while `gc sling`
and workflow-finalize still saw a live root in the binding.

## Validation

- Added a regression test that seeds a live workflow root only in the relocated
  binding and verifies `openSourceWorkflowStores` finds it.
- Preserved existing relocated delete-source behavior by using the repository's
  `convoyStoreViewsWithBinding` federation instead of replacing the ordinary
  store view.
- Pinned-source focused regression suite: pass at `8c73625b9`.
- Current-main focused regression suite: pass.
- `make build`: pass.
- `make check`: pass (format, lint, vet, structural, and observable tests).

No user-facing output or release note is needed.

Related context: #5993 and #5992 address adjacent binding/scope cases but do
not cover this command-side source-store scan.
