### PR TITLE
fix(suspend): record the lifecycle event in the target city, not the ambient one (ga-41g9gr)

### DIFF
--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -139,7 +139,13 @@ func doSuspendCity(fs fsys.FS, cityPath string, suspend bool, jsonOut bool, stdo
 		return 1
 	}
 
-	rec := openCityRecorder(stderr)
+	// Record against the city whose state actually changed, not the
+	// ambient one. openCityRecorder re-resolves the city from cwd/env,
+	// which is not cityPath whenever the target was named explicitly
+	// (`gc suspend <dir>`) from inside a different, live city — that
+	// leaked city.suspended/city.resumed into an unrelated event log
+	// (ga-41g9gr).
+	rec := openCityRecorderAt(cityPath, stderr)
 	if suspend {
 		rec.Record(events.Event{
 			Type:  events.CitySuspended,

--- a/cmd/gc/cmd_suspend_test.go
+++ b/cmd/gc/cmd_suspend_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/suspensionstate"
 )
@@ -351,4 +353,64 @@ func TestSuspendInheritance(t *testing.T) {
 			t.Errorf("agent %q should be suspended when city has suspended_on_start=true", a.QualifiedName())
 		}
 	}
+}
+
+// TestSuspendRecordsEventInTargetCity is a regression guard for ga-41g9gr.
+//
+// doSuspendCity writes suspension state to its cityPath argument but used to
+// record the lifecycle event through openCityRecorder, which re-resolves the
+// *ambient* city from cwd/env independently of cityPath. Suspending an
+// explicitly named city from inside a different, live city therefore appended
+// city.suspended/city.resumed to the wrong city's event log — 23 spurious
+// pairs a day on the fleet's real city, which never itself suspended.
+//
+// The event must land in the city whose state actually changed.
+func TestSuspendRecordsEventInTargetCity(t *testing.T) {
+	ambient := newRealCityDir(t, "ambient")
+	target := newRealCityDir(t, "target")
+
+	// Ambient resolution (openCityRecorder -> resolveCity) points at a
+	// city that is NOT the suspend target.
+	t.Setenv("GC_CITY", ambient)
+
+	var stdout, stderr bytes.Buffer
+	if code := doSuspendCity(fsys.OSFS{}, target, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("suspend code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	ambientEvents := filepath.Join(ambient, ".gc", "events.jsonl")
+	if data, err := os.ReadFile(ambientEvents); err == nil && strings.Contains(string(data), events.CitySuspended) {
+		t.Errorf("city.suspended leaked into the ambient city's event log %s:\n%s",
+			ambientEvents, data)
+	}
+
+	targetEvents := filepath.Join(target, ".gc", "events.jsonl")
+	data, err := os.ReadFile(targetEvents)
+	if err != nil {
+		t.Fatalf("target city recorded no event at %s: %v", targetEvents, err)
+	}
+	if !strings.Contains(string(data), events.CitySuspended) {
+		t.Errorf("target event log %s = %q, want a %s record",
+			targetEvents, data, events.CitySuspended)
+	}
+}
+
+// newRealCityDir creates a minimal city on the real filesystem. The event
+// recorder always uses the OS filesystem regardless of the fsys.FS handed to
+// doSuspendCity, so this regression test cannot use fsys.NewFake.
+func newRealCityDir(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultCity(name)
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }


### PR DESCRIPTION
Investigated as ga-41g9gr (P1): the fleet's real city at `/home/jaword/projects/gc-management` was recording `city.suspended` + `city.resumed` pairs ~2s apart, actor `human`, 23 times in one day and daily since at least 09-04, with no operator involved. It was escalated as a live data-loss risk because `gc suspend`'s session-retire bug (ga-pmafyc) was in flight.

## Headline correction

**The real city was never actually suspended. Only the *event* leaked.**

`doSuspendCity` always writes `.gc/runtime/suspension-state.json` via `suspensionstate.SetCitySuspended` *before* recording the event, and a false→true transition cannot take `SetCitySuspended`'s unchanged-value early return. The real city's state file has mtime **Aug 25** and reads `{"city":{"suspended":false}}`. 116 lifecycle actions would have rewritten it 116 times; it has not been touched in 16 days, and `gc status` reports `Suspended: no`. So ga-pmafyc's retire path was never triggered by these events.

## Root cause

`cmd/gc/cmd_suspend.go:142`, inside `doSuspendCity`:

```go
rec := openCityRecorder(stderr)
```

`doSuspendCity` writes suspension state to its `cityPath` **argument**, but `openCityRecorder` (`cmd/gc/main.go:1397`) ignores `cityPath` and re-resolves the **ambient** city:

- `resolveSuspendDir(args)` → `resolveCommandCity(args)` — honors the positional dir, so `gc suspend <dir>` targets `<dir>`.
- `openCityRecorder` → `resolveCity()` → `resolveCommandCity(**nil**)` — ignores positional args and falls through to cwd walk-up.

Whenever the target is named explicitly and cwd is inside a *different* live city, the two disagree: **state goes to the target, the event goes to the ambient city.**

## Why the existing guard misses it

`resolveContextFromDir` already refuses ambient walk-up under `isTestBinary()` (ga-klo4gz). But `isTestBinary()` keys on `os.Args[0]` containing `.test`, and the leak happens in a **subprocess invocation of the real `gc` binary spawned by a test**, where that predicate is false. ga-klo4gz's guard is correct; this is a gap it structurally cannot cover.

## Evidence

1. **In-tree RED**, reproducing the production record verbatim:
   `{"seq":1,"type":"city.suspended","ts":...,"actor":"human"}` — leaked into the ambient log, target log absent entirely.
2. **Controlled repro** with the real `gc` binary, never touching the real city: separate ambient/target cities, `env -i`, `GC_HOME`/`XDG_RUNTIME_DIR` redirected. Target state correct; ambient got the event; target got none.
3. **Falsification control — cwd is the only variable.** Same binary, same `HOME`/`GC_HOME`/`XDG_RUNTIME_DIR`/`PATH`/target: cwd outside any city tree → no leak; cwd inside one → leak. This positively excludes the supervisor socket, a `HOME` registry, and the `gc` binary on `PATH`.
4. **The leak distribution is perfectly selective.** The real city's log holds 58 `city.suspended` + 58 `city.resumed` and **zero** other `city.*` events ever. The neighbouring integration call sites run `gc("", "start"/"stop"/"restart", cityDir)` the same cwd-less way — but `cmd_start.go:923` and `cmd_stop.go:392` build their recorder at `filepath.Join(cityPath, ".gc", "events.jsonl")`, i.e. target-scoped, so they cannot leak. Only `suspend` was ambient. No competing hypothesis explains 116 suspend/resume records with never a single start or stop.
5. **Timing:** the 1.80–2.22s suspend→resume gap matches `TestE2E_SuspendResume_City`'s body exactly (session kill + 500ms + removeFile + 1s + second subprocess spawn).

## The fix

One line: `openCityRecorder(stderr)` → `openCityRecorderAt(cityPath, stderr)`.

`openCityRecorderAt` already exists and is the established pattern at 17 call sites (`cmd_convoy.go:178`, `work_query_failure.go:109`, `molecule_autoclose.go:72`, `cmd_handoff.go:166`, `cmd_sling.go:498`, …). `cmd_suspend` was the sole outlier holding a resolved `cityPath` while using the ambient form. I confirmed the three commands that resolve their city from positional args are `suspend`, `reload`, and `citystatus`, and only `suspend` used the ambient recorder.

This also fixes a plain **production** bug independent of tests: an operator running `gc suspend /path/to/other-city` from inside city A suspended B but logged the event to A.

## Blast radius

Observability only — **not** the data-loss path. Every functional consumer of "is the city suspended" reads the state file via `effectiveCitySuspended` (`build_desired_state.go:393`, `cmd_start.go:74`, the API status handlers). Nothing acts on the `city.suspended` *event*; no order or gate is keyed on it. The real cost is exactly what happened here: false alarms for anything watching the event stream — this P1 among them.

## Test

`cmd/gc/cmd_suspend_test.go::TestSuspendRecordsEventInTargetCity` — asserts the event lands in the target city and not the ambient one. Verified RED before / GREEN after against this branch.

## Validation

- `go build ./cmd/gc/` — clean
- `go vet ./cmd/gc/` — clean
- `go test ./cmd/gc/ -run 'TestSuspend|TestResume|TestCitySuspend'` — 17/17 pass
- RED confirmed by reverting the single line: test fails, emitting the production record verbatim
- push-gate fast suite (unit-core + 6 cmd/gc shards) — all green

## Out of scope

The `gc()` integration helper (`test/integration/integration_test.go:851`) computes `envDir := commandCityDirForArgs(dir, args)` — which already resolves the city from `args[1]` for `start|stop|restart|suspend|resume` — but applies it only to the subprocess **environment**, passing the original (empty) `dir` as the **cwd**. So 15 call sites still run the real `gc` binary with the test process's cwd inherited. That is harmless now that no command uses the ambient recorder while holding an explicit target, but it is the latent enabler. Filed separately rather than fixed here: it cannot be validated from this seat, because this worktree lives *inside* the city tree and the integration package has a `TestMain`, so running it here would re-create the very hazard under investigation.
