### PR TITLE
Preserve city.toml formatting during agent suspend and resume

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -978,13 +978,7 @@ func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, s
 	// Try to find agent in raw config.
 	if resolved, ok := resolveAgentIdentity(cfg, name, currentRigContext(cfg)); ok {
 		resolvedQN := resolved.QualifiedName()
-		for i := range cfg.Agents {
-			if cfg.Agents[i].QualifiedName() == resolvedQN {
-				cfg.Agents[i].Suspended = suspended
-				break
-			}
-		}
-		if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
+		if err := config.WriteCityAgentSuspendedForEdit(fs, tomlPath, cfg, resolvedQN, suspended); err != nil {
 			fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/internal/config/site_binding_agent_suspend.go
+++ b/internal/config/site_binding_agent_suspend.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// ErrSurgicalAgentEditUnsupported indicates the on-disk [[agent]] block
+// identified by identity could not be unambiguously located in city.toml, so
+// a byte-preserving surgical edit cannot proceed. Callers must not treat
+// this as success: fall back to a full rewrite (accepting comment loss) or
+// surface the error, but never silently skip the mutation.
+var ErrSurgicalAgentEditUnsupported = errors.New("surgical agent suspend/resume edit not supported for this city.toml")
+
+// WriteCityAgentSuspendedForEdit toggles the suspended value for the inline
+// [[agent]] block matching identity (see ParseQualifiedName/AgentMatchesIdentity)
+// directly in the on-disk city.toml bytes, preserving every other byte --
+// comments, key order, and formatting all survive untouched. cfg is the
+// already-mutated config, used only to keep rig site bindings in sync with
+// the whole-file rewrite path; the agent mutation itself is applied to the
+// raw on-disk bytes, not re-serialized from cfg.
+//
+// It returns an error wrapping ErrSurgicalAgentEditUnsupported when the
+// target [[agent]] block cannot be unambiguously located in the raw text.
+//
+// TODO(ga-gc16k3): stub delegates to the lossy full-rewrite path pending the
+// surgical implementation; this reproduces today's comment-dropping bug so
+// the RED tests fail for the right reason.
+func WriteCityAgentSuspendedForEdit(fs fsys.FS, tomlPath string, cfg *City, _ string, _ bool) error {
+	return writeCityAndRigSiteBindingsForEdit(fs, tomlPath, cfg, nil)
+}

--- a/internal/config/site_binding_agent_suspend.go
+++ b/internal/config/site_binding_agent_suspend.go
@@ -1,17 +1,30 @@
 package config
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-// ErrSurgicalAgentEditUnsupported indicates the on-disk [[agent]] block
-// identified by identity could not be unambiguously located in city.toml, so
-// a byte-preserving surgical edit cannot proceed. Callers must not treat
-// this as success: fall back to a full rewrite (accepting comment loss) or
-// surface the error, but never silently skip the mutation.
+// ErrSurgicalAgentEditUnsupported indicates the on-disk [[agent]] (or
+// [[patches.agent]]) block identified by identity could not be
+// unambiguously located in city.toml, so a byte-preserving surgical edit
+// cannot proceed. Callers must not treat this as success: fall back to a
+// full rewrite (accepting comment loss) or surface the error, but never
+// silently skip the mutation.
 var ErrSurgicalAgentEditUnsupported = errors.New("surgical agent suspend/resume edit not supported for this city.toml")
+
+var (
+	tomlNameLineRe      = regexp.MustCompile(`^\s*name\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$`)
+	tomlDirLineRe       = regexp.MustCompile(`^\s*dir\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$`)
+	tomlSuspendedLineRe = regexp.MustCompile(`^(\s*suspended\s*=\s*)(?:true|false)\b(.*)$`)
+)
 
 // WriteCityAgentSuspendedForEdit toggles the suspended value for the inline
 // [[agent]] block matching identity (see ParseQualifiedName/AgentMatchesIdentity)
@@ -23,10 +36,227 @@ var ErrSurgicalAgentEditUnsupported = errors.New("surgical agent suspend/resume 
 //
 // It returns an error wrapping ErrSurgicalAgentEditUnsupported when the
 // target [[agent]] block cannot be unambiguously located in the raw text.
-//
-// TODO(ga-gc16k3): stub delegates to the lossy full-rewrite path pending the
-// surgical implementation; this reproduces today's comment-dropping bug so
-// the RED tests fail for the right reason.
-func WriteCityAgentSuspendedForEdit(fs fsys.FS, tomlPath string, cfg *City, _ string, _ bool) error {
-	return writeCityAndRigSiteBindingsForEdit(fs, tomlPath, cfg, nil)
+func WriteCityAgentSuspendedForEdit(fs fsys.FS, tomlPath string, cfg *City, identity string, suspended bool) error {
+	target, ok := findAgentByIdentity(cfg, identity)
+	if !ok {
+		return fmt.Errorf("%w: agent %q not found in %s", ErrSurgicalAgentEditUnsupported, identity, tomlPath)
+	}
+
+	return writeCityBytesForEdit(fs, tomlPath, cfg, func(existing []byte) ([]byte, error) {
+		content, ok := toggleAgentSuspendedBytes(existing, "[[agent]]", target.Name, target.Dir, suspended)
+		if !ok {
+			return nil, fmt.Errorf("%w: agent %q's [[agent]] block could not be unambiguously located in %s", ErrSurgicalAgentEditUnsupported, identity, tomlPath)
+		}
+		return content, nil
+	})
+}
+
+// AppendAgentPatchSuspendedForEdit appends a new [[patches.agent]] block
+// setting suspended for the agent identified by (dir, name), directly in the
+// on-disk city.toml bytes, preserving every other byte. It refuses (wrapping
+// ErrSurgicalAgentEditUnsupported) rather than guess when a [[patches.agent]]
+// block for (dir, name) already exists -- callers should fall back to a full
+// rewrite in that case.
+func AppendAgentPatchSuspendedForEdit(fs fsys.FS, tomlPath string, cfg *City, dir, name string, suspended bool) error {
+	return writeCityBytesForEdit(fs, tomlPath, cfg, func(existing []byte) ([]byte, error) {
+		if _, ok := toggleAgentSuspendedBytes(existing, "[[patches.agent]]", name, dir, suspended); ok {
+			return nil, fmt.Errorf("%w: a [[patches.agent]] block for %q already exists in %s; edit it directly", ErrSurgicalAgentEditUnsupported, name, tomlPath)
+		}
+
+		block, err := marshalAgentPatchBlock(dir, name, suspended)
+		if err != nil {
+			return nil, err
+		}
+		return appendBlock(existing, block), nil
+	})
+}
+
+// findAgentByIdentity returns the first agent in cfg.Agents matching
+// identity (see AgentMatchesIdentity), by value so callers get a stable
+// Name/Dir pair independent of any later mutation of cfg.Agents.
+func findAgentByIdentity(cfg *City, identity string) (Agent, bool) {
+	for i := range cfg.Agents {
+		if AgentMatchesIdentity(&cfg.Agents[i], identity) {
+			return cfg.Agents[i], true
+		}
+	}
+	return Agent{}, false
+}
+
+// writeCityBytesForEdit reads tomlPath's raw bytes, runs mutate over them,
+// and -- if mutate succeeds -- writes the result back atomically and
+// re-persists rig site bindings from cfg, restoring the prior city.toml and
+// site binding if that persist step fails. It mirrors
+// AppendRigAndWriteSiteBindingsForEdit's I/O shape so byte-preserving agent
+// edits get the same crash-safety guarantees as the rig-append path.
+func writeCityBytesForEdit(fs fsys.FS, tomlPath string, cfg *City, mutate func(existing []byte) ([]byte, error)) error {
+	cityRoot := filepath.Dir(tomlPath)
+	writePath, err := ResolveCityAppendPath(fs, tomlPath)
+	if err != nil {
+		return err
+	}
+
+	existing, err := fs.ReadFile(writePath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", writePath, err)
+	}
+
+	content, err := mutate(existing)
+	if err != nil {
+		return err
+	}
+
+	snapshot, err := snapshotCityAndSiteFiles(fs, writePath, SiteBindingPath(cityRoot))
+	if err != nil {
+		return err
+	}
+	if err := fsys.WriteFileIfChangedAtomic(fs, writePath, content, 0o644); err != nil {
+		return err
+	}
+	if err := persistRigSiteBindings(fs, cityRoot, cfg.Rigs, nil); err != nil {
+		if restoreErr := snapshot.restore(fs); restoreErr != nil {
+			return fmt.Errorf("writing .gc/site.toml failed and restoring city.toml/site binding failed: %w", errors.Join(err, restoreErr))
+		}
+		return fmt.Errorf("writing .gc/site.toml failed; restored city.toml and previous site binding, fix the site binding write error and retry: %w", err)
+	}
+	return nil
+}
+
+// toggleAgentSuspendedBytes locates the single array-of-tables block
+// starting with header (e.g. "[[agent]]" or "[[patches.agent]]") whose body
+// has name/dir matching targetName/targetDir, and returns existing with that
+// block's suspended key toggled to the desired state. ok is false when zero
+// or more than one block matches, since a byte-preserving edit cannot guess
+// which one the caller meant.
+func toggleAgentSuspendedBytes(existing []byte, header, targetName, targetDir string, suspended bool) ([]byte, bool) {
+	lines := strings.Split(string(existing), "\n")
+	start, end, ok := findTOMLArrayBlock(lines, header, targetName, targetDir)
+	if !ok {
+		return nil, false
+	}
+	return []byte(strings.Join(toggleSuspendedInRange(lines, start, end, suspended), "\n")), true
+}
+
+// findTOMLArrayBlock scans lines for array-of-tables blocks introduced by a
+// line exactly equal to header (after trimming whitespace), and returns the
+// [start, end) body range of the one whose name/dir key values match
+// targetName/targetDir. A block's body runs from its header to the next line
+// that opens a table/array-of-tables ("[...]"), or to EOF. ok is true only
+// when exactly one block matches -- ambiguity is refused, not guessed at.
+func findTOMLArrayBlock(lines []string, header, targetName, targetDir string) (start, end int, ok bool) {
+	matches := 0
+	for i, line := range lines {
+		if strings.TrimSpace(line) != header {
+			continue
+		}
+		bodyStart := i + 1
+		bodyEnd := len(lines)
+		for j := bodyStart; j < len(lines); j++ {
+			if strings.HasPrefix(strings.TrimSpace(lines[j]), "[") {
+				bodyEnd = j
+				break
+			}
+		}
+
+		name, dir, hasName := "", "", false
+		for j := bodyStart; j < bodyEnd; j++ {
+			if m := tomlNameLineRe.FindStringSubmatch(lines[j]); m != nil {
+				name, hasName = m[1], true
+				continue
+			}
+			if m := tomlDirLineRe.FindStringSubmatch(lines[j]); m != nil {
+				dir = m[1]
+			}
+		}
+		if hasName && name == targetName && dir == targetDir {
+			matches++
+			start, end = bodyStart, bodyEnd
+		}
+	}
+	return start, end, matches == 1
+}
+
+// toggleSuspendedInRange returns lines with the suspended key within
+// [start, end) toggled to reflect suspended: an existing suspended = <bool>
+// line is replaced in place (preserving its exact spacing and any trailing
+// comment); when suspended is false and no such line exists, lines is
+// returned unchanged; when suspended is true and no such line exists, a
+// fresh "suspended = true" line is inserted after the body's last non-blank
+// line. Suspended is never written out as an explicit false -- Agent.Suspended
+// is toml:"suspended,omitempty", so the canonical "not suspended" state is
+// the key's absence.
+func toggleSuspendedInRange(lines []string, start, end int, suspended bool) []string {
+	suspendedIdx := -1
+	for i := start; i < end; i++ {
+		if tomlSuspendedLineRe.MatchString(lines[i]) {
+			suspendedIdx = i
+			break
+		}
+	}
+
+	out := make([]string, 0, len(lines)+1)
+	switch {
+	case suspendedIdx >= 0 && suspended:
+		m := tomlSuspendedLineRe.FindStringSubmatch(lines[suspendedIdx])
+		out = append(out, lines[:suspendedIdx]...)
+		out = append(out, m[1]+"true"+m[2])
+		out = append(out, lines[suspendedIdx+1:]...)
+	case suspendedIdx >= 0:
+		out = append(out, lines[:suspendedIdx]...)
+		out = append(out, lines[suspendedIdx+1:]...)
+	case suspended:
+		insertAt := lastNonBlankLineIndex(lines, start, end)
+		out = append(out, lines[:insertAt+1]...)
+		out = append(out, "suspended = true")
+		out = append(out, lines[insertAt+1:]...)
+	default:
+		out = append(out, lines...)
+	}
+	return out
+}
+
+// lastNonBlankLineIndex returns the index of the last non-blank line in
+// [start, end), or start-1 if the range has no non-blank line.
+func lastNonBlankLineIndex(lines []string, start, end int) int {
+	last := start - 1
+	for i := start; i < end; i++ {
+		if strings.TrimSpace(lines[i]) != "" {
+			last = i
+		}
+	}
+	return last
+}
+
+// marshalAgentPatchBlock encodes a single [[patches.agent]] block. It
+// encodes under a top-level "agent"-tagged field (matching the rigBlock
+// trick in AppendRigAndWriteSiteBindingsForEdit) and rewrites the resulting
+// header, rather than encoding a nested "patches.agent" field directly, to
+// avoid depending on how the TOML encoder emits headers for a struct field
+// that is only reachable through an intermediate table.
+func marshalAgentPatchBlock(dir, name string, suspended bool) ([]byte, error) {
+	type patchBlock struct {
+		Agents []AgentPatch `toml:"agent"`
+	}
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc.Indent = ""
+	if err := enc.Encode(patchBlock{Agents: []AgentPatch{{Dir: dir, Name: name, Suspended: &suspended}}}); err != nil {
+		return nil, fmt.Errorf("serializing new agent patch block: %w", err)
+	}
+	return bytes.Replace(buf.Bytes(), []byte("[[agent]]"), []byte("[[patches.agent]]"), 1), nil
+}
+
+// appendBlock appends block to existing, ensuring existing ends with a
+// newline and separating the two with exactly one blank line -- the same
+// convention AppendRigAndWriteSiteBindingsForEdit uses for appended rig
+// blocks.
+func appendBlock(existing, block []byte) []byte {
+	content := make([]byte, len(existing))
+	copy(content, existing)
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		content = append(content, '\n')
+	}
+	content = append(content, '\n')
+	content = append(content, block...)
+	return content
 }

--- a/internal/config/site_binding_agent_suspend.go
+++ b/internal/config/site_binding_agent_suspend.go
@@ -71,6 +71,26 @@ func AppendAgentPatchSuspendedForEdit(fs fsys.FS, tomlPath string, cfg *City, di
 	})
 }
 
+// StripAgentPatchSuspendedForEdit removes the suspended override from the
+// [[patches.agent]] block matching (dir, name), directly in the on-disk
+// city.toml bytes, preserving every other byte. If removing suspended would
+// leave the block with nothing but its dir/name identity, the whole block
+// (including its "[[patches.agent]]" header and, if present, the single
+// blank line separating it from the previous section) is removed too --
+// the exact inverse of the blank-line convention appendBlock uses. It
+// refuses (wrapping ErrSurgicalAgentEditUnsupported) rather than guess when
+// the target [[patches.agent]] block cannot be unambiguously located, or has
+// no suspended key to strip.
+func StripAgentPatchSuspendedForEdit(fs fsys.FS, tomlPath string, cfg *City, dir, name string) error {
+	return writeCityBytesForEdit(fs, tomlPath, cfg, func(existing []byte) ([]byte, error) {
+		content, ok := stripAgentPatchSuspendedBytes(existing, name, dir)
+		if !ok {
+			return nil, fmt.Errorf("%w: [[patches.agent]] block for %q could not be unambiguously located in %s, or has no suspended key", ErrSurgicalAgentEditUnsupported, name, tomlPath)
+		}
+		return content, nil
+	})
+}
+
 // findAgentByIdentity returns the first agent in cfg.Agents matching
 // identity (see AgentMatchesIdentity), by value so callers get a stable
 // Name/Dir pair independent of any later mutation of cfg.Agents.
@@ -135,6 +155,52 @@ func toggleAgentSuspendedBytes(existing []byte, header, targetName, targetDir st
 		return nil, false
 	}
 	return []byte(strings.Join(toggleSuspendedInRange(lines, start, end, suspended), "\n")), true
+}
+
+// stripAgentPatchSuspendedBytes locates the single [[patches.agent]] block
+// whose body has name/dir matching targetName/targetDir, and returns
+// existing with that block's suspended key removed. When that leaves the
+// block with only its dir/name identity lines, the whole block (header
+// included) is dropped instead -- mirroring StripAgentPatchSuspended's
+// isAgentPatchOnlyIdentity check on the in-memory path. ok is false when
+// zero or more than one block matches, or the matching block has no
+// suspended key.
+func stripAgentPatchSuspendedBytes(existing []byte, targetName, targetDir string) ([]byte, bool) {
+	lines := strings.Split(string(existing), "\n")
+	start, end, ok := findTOMLArrayBlock(lines, "[[patches.agent]]", targetName, targetDir)
+	if !ok {
+		return nil, false
+	}
+
+	suspendedIdx := -1
+	onlyIdentity := true
+	for i := start; i < end; i++ {
+		switch {
+		case tomlSuspendedLineRe.MatchString(lines[i]):
+			suspendedIdx = i
+		case strings.TrimSpace(lines[i]) == "":
+		case tomlNameLineRe.MatchString(lines[i]), tomlDirLineRe.MatchString(lines[i]):
+		default:
+			onlyIdentity = false
+		}
+	}
+	if suspendedIdx < 0 {
+		return nil, false
+	}
+
+	var out []string
+	if onlyIdentity {
+		blockStart := start - 1 // the "[[patches.agent]]" header line
+		if blockStart > 0 && strings.TrimSpace(lines[blockStart-1]) == "" {
+			blockStart-- // swallow appendBlock's single separating blank line
+		}
+		out = append(out, lines[:blockStart]...)
+		out = append(out, lines[end:]...)
+	} else {
+		out = append(out, lines[:suspendedIdx]...)
+		out = append(out, lines[suspendedIdx+1:]...)
+	}
+	return []byte(strings.Join(out, "\n")), true
 }
 
 // findTOMLArrayBlock scans lines for array-of-tables blocks introduced by a

--- a/internal/config/site_binding_agent_suspend.go
+++ b/internal/config/site_binding_agent_suspend.go
@@ -21,8 +21,16 @@ import (
 var ErrSurgicalAgentEditUnsupported = errors.New("surgical agent suspend/resume edit not supported for this city.toml")
 
 var (
-	tomlNameLineRe      = regexp.MustCompile(`^\s*name\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$`)
-	tomlDirLineRe       = regexp.MustCompile(`^\s*dir\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$`)
+	tomlNameLineRe = regexp.MustCompile(`^\s*name\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$`)
+	tomlDirLineRe  = regexp.MustCompile(`^\s*dir\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$`)
+	// tomlRigLineRe deliberately matches the key alone, not a quoted value
+	// like its siblings: rig is a second targeting key that folds into the
+	// same identity as dir (see AgentPatch.TargetQualifiedName), including
+	// the "*" wildcard scope. This matcher does not model that fold, so any
+	// block carrying a rig key -- in any value syntax -- is refused rather
+	// than matched on dir alone, which would silently edit a rig-scoped
+	// block on behalf of a city-scoped target.
+	tomlRigLineRe       = regexp.MustCompile(`^\s*rig\s*=`)
 	tomlSuspendedLineRe = regexp.MustCompile(`^(\s*suspended\s*=\s*)(?:true|false)\b(.*)$`)
 )
 
@@ -224,7 +232,7 @@ func findTOMLArrayBlock(lines []string, header, targetName, targetDir string) (s
 			}
 		}
 
-		name, dir, hasName := "", "", false
+		name, dir, hasName, hasRig := "", "", false, false
 		for j := bodyStart; j < bodyEnd; j++ {
 			if m := tomlNameLineRe.FindStringSubmatch(lines[j]); m != nil {
 				name, hasName = m[1], true
@@ -232,7 +240,14 @@ func findTOMLArrayBlock(lines []string, header, targetName, targetDir string) (s
 			}
 			if m := tomlDirLineRe.FindStringSubmatch(lines[j]); m != nil {
 				dir = m[1]
+				continue
 			}
+			if tomlRigLineRe.MatchString(lines[j]) {
+				hasRig = true
+			}
+		}
+		if hasRig {
+			continue
 		}
 		if hasName && name == targetName && dir == targetDir {
 			matches++

--- a/internal/config/site_binding_agent_suspend_test.go
+++ b/internal/config/site_binding_agent_suspend_test.go
@@ -1,0 +1,310 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// Regression coverage for ga-gc16k3: gc agent suspend/resume on an inline
+// [[agent]] currently rewrites the whole of city.toml through a bare
+// struct-marshal round-trip (writeCityAndRigSiteBindingsForEdit), which has
+// no comment model at all -- every comment, and any TOML shape the struct
+// doesn't preserve byte-for-byte, is silently dropped. These tests exercise
+// WriteCityAgentSuspendedForEdit, which must instead toggle the `suspended`
+// key directly in the on-disk bytes.
+
+// TestWriteCityAgentSuspendedForEdit_PreservesCommentsAcrossSuspendResume
+// covers AC1: suspending then resuming an inline agent must retain 100% of
+// the original comment lines, verbatim, in order.
+func TestWriteCityAgentSuspendedForEdit_PreservesCommentsAcrossSuspendResume(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`# City configuration for Acme Corp.
+# Owned by the platform team; do not edit without review.
+
+[workspace]
+name = "acme-city"
+
+# Primary orchestrator agent -- keep this one pinned to opus.
+[[agent]]
+name = "mayor"
+provider = "claude"  # pinned for stability, see runbook
+
+[[agent]]
+name = "worker"
+provider = "codex"
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	setMayorSuspended(cfg, true)
+	if err := WriteCityAgentSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "mayor", true); err != nil {
+		t.Fatalf("WriteCityAgentSuspendedForEdit(suspend): %v", err)
+	}
+
+	cfg, err = Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("reload after suspend: %v", err)
+	}
+	setMayorSuspended(cfg, false)
+	if err := WriteCityAgentSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "mayor", false); err != nil {
+		t.Fatalf("WriteCityAgentSuspendedForEdit(resume): %v", err)
+	}
+
+	final, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	want := strings.Join(commentLines(original), "\n")
+	got := strings.Join(commentLines(final), "\n")
+	if want != got {
+		t.Fatalf("comment lines not preserved across suspend+resume:\nwant:\n%s\ngot:\n%s\nfull result:\n%s", want, got, final)
+	}
+}
+
+// TestWriteCityAgentSuspendedForEdit_DoesNotMaterializeAbsentTableOrReflowArray
+// covers AC2: the write must not materialize a previously-absent table as an
+// explicit zero value, and must not reflow a pre-existing single-line array.
+func TestWriteCityAgentSuspendedForEdit_DoesNotMaterializeAbsentTableOrReflowArray(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`[workspace]
+name = "acme-city"
+
+[[agent]]
+name = "mayor"
+args = ["--flag-one", "--flag-two"]
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	setMayorSuspended(cfg, true)
+	if err := WriteCityAgentSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "mayor", true); err != nil {
+		t.Fatalf("WriteCityAgentSuspendedForEdit: %v", err)
+	}
+
+	final, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(final), "[dolt]") {
+		t.Fatalf("absent [dolt] table was materialized:\n%s", final)
+	}
+	if !strings.Contains(string(final), `args = ["--flag-one", "--flag-two"]`) {
+		t.Fatalf("pre-existing single-line array was reflowed:\n%s", final)
+	}
+}
+
+// TestWriteCityAgentSuspendedForEdit_DiffLimitedToSuspendedKey covers AC3's
+// suspend direction: with comments stripped from both sides, the
+// post-mutation city.toml must equal the pre-mutation city.toml except for
+// the suspended key's line toggling in place (false -> true).
+func TestWriteCityAgentSuspendedForEdit_DiffLimitedToSuspendedKey(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`# header comment
+[workspace]
+name = "acme-city"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+suspended = false
+pre_start = ["echo starting", "echo ready"]
+
+[[agent]]
+name = "worker"
+provider = "codex"
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	setMayorSuspended(cfg, true)
+	if err := WriteCityAgentSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "mayor", true); err != nil {
+		t.Fatalf("WriteCityAgentSuspendedForEdit: %v", err)
+	}
+
+	final, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	before := strippedLines(original)
+	after := strippedLines(final)
+	if len(before) != len(after) {
+		t.Fatalf("line count changed: before=%d after=%d\nbefore:\n%s\nafter:\n%s", len(before), len(after), original, final)
+	}
+	changed := 0
+	for i := range before {
+		if before[i] == after[i] {
+			continue
+		}
+		changed++
+		if !strings.Contains(after[i], "suspended") {
+			t.Fatalf("unexpected line changed (not the suspended key): before %q, after %q", before[i], after[i])
+		}
+	}
+	if changed == 0 {
+		t.Fatalf("expected exactly one changed line (the suspended key), got none")
+	}
+}
+
+// TestWriteCityAgentSuspendedForEdit_ResumeDeletesSuspendedKeyEntirely covers
+// AC3's resume direction: Agent.Suspended is `toml:"suspended,omitempty"`, so
+// resuming an agent that has an explicit suspended = true line must delete
+// that line entirely -- not rewrite it to suspended = false -- leaving every
+// other line (comments included) untouched.
+func TestWriteCityAgentSuspendedForEdit_ResumeDeletesSuspendedKeyEntirely(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`# header comment
+[workspace]
+name = "acme-city"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+suspended = true
+pre_start = ["echo starting", "echo ready"]
+
+[[agent]]
+name = "worker"
+provider = "codex"
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	setMayorSuspended(cfg, false)
+	if err := WriteCityAgentSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "mayor", false); err != nil {
+		t.Fatalf("WriteCityAgentSuspendedForEdit(resume): %v", err)
+	}
+
+	final, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	for _, line := range strippedLines(final) {
+		if strings.Contains(line, "suspended") {
+			t.Fatalf("resume left an explicit suspended line instead of deleting it: %q\nfull result:\n%s", line, final)
+		}
+	}
+
+	var want []string
+	for _, line := range strippedLines(original) {
+		if strings.Contains(line, "suspended") {
+			continue
+		}
+		want = append(want, line)
+	}
+	got := strippedLines(final)
+	if len(want) != len(got) {
+		t.Fatalf("unexpected line count after resume: want %d got %d\nwant:\n%s\ngot:\n%s", len(want), len(got), strings.Join(want, "\n"), strings.Join(got, "\n"))
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			t.Fatalf("line %d changed unexpectedly: want %q got %q", i, want[i], got[i])
+		}
+	}
+}
+
+// TestWriteCityAgentSuspendedForEdit_RefusesWhenAgentBlockNotFound covers
+// AC4: when the target [[agent]] block cannot be unambiguously located, the
+// write must refuse (wrapping ErrSurgicalAgentEditUnsupported) rather than
+// silently doing nothing or falling back to a lossy rewrite, and city.toml
+// must be left byte-for-byte unchanged.
+func TestWriteCityAgentSuspendedForEdit_RefusesWhenAgentBlockNotFound(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`[workspace]
+name = "acme-city"
+
+[[agent]]
+name = "mayor"
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	err = WriteCityAgentSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "does-not-exist", true)
+	if !errors.Is(err, ErrSurgicalAgentEditUnsupported) {
+		t.Fatalf("WriteCityAgentSuspendedForEdit(unknown identity) error = %v, want wrapping ErrSurgicalAgentEditUnsupported", err)
+	}
+
+	final, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(final, original) {
+		t.Fatalf("city.toml was modified despite refusing the edit:\nbefore:\n%s\nafter:\n%s", original, final)
+	}
+}
+
+func setMayorSuspended(cfg *City, suspended bool) {
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "mayor" {
+			cfg.Agents[i].Suspended = suspended
+		}
+	}
+}
+
+// commentLines extracts every trimmed comment-only line ("# ..."), in order.
+func commentLines(data []byte) []string {
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// strippedLines returns every non-comment, non-blank line, in order, with
+// any trailing inline comment removed.
+func strippedLines(data []byte) []string {
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if i := strings.Index(trimmed, "#"); i >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:i])
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}

--- a/internal/config/site_binding_agent_suspend_test.go
+++ b/internal/config/site_binding_agent_suspend_test.go
@@ -308,3 +308,54 @@ func strippedLines(data []byte) []string {
 	}
 	return out
 }
+
+// TestStripAgentPatchSuspendedForEdit_RefusesRigScopedPatchBlock pins the
+// rig-targeting safety valve. AgentPatch grew a second targeting key, `rig`,
+// which folds into the same identity as the legacy `dir` key (see
+// AgentPatch.TargetQualifiedName). The byte matcher reads only `name` and
+// `dir`, so a block written with `rig = "myrig"` would otherwise parse as
+// dir == "" and match a *city*-scoped target -- a confident wrong match that
+// the "refuse rather than guess" guard cannot see, because nothing looks
+// ambiguous. A block carrying a rig key must therefore never match: the edit
+// refuses with ErrSurgicalAgentEditUnsupported and leaves city.toml
+// byte-for-byte unchanged.
+func TestStripAgentPatchSuspendedForEdit_RefusesRigScopedPatchBlock(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`# City configuration for Acme Corp.
+[workspace]
+name = "acme-city"
+
+[[agent]]
+name = "worker"
+
+# Rig-scoped override -- must not be touched by a city-scoped resume.
+[[patches.agent]]
+rig = "myrig"
+name = "worker"
+suspended = true
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Resume the city-scoped "worker" (dir == ""), whose identity is
+	// distinct from the rig-scoped patch block's.
+	err = StripAgentPatchSuspendedForEdit(fsys.OSFS{}, cityPath, cfg, "", "worker")
+	if !errors.Is(err, ErrSurgicalAgentEditUnsupported) {
+		t.Fatalf("StripAgentPatchSuspendedForEdit(city-scoped target, rig-scoped block) error = %v, want wrapping ErrSurgicalAgentEditUnsupported", err)
+	}
+
+	final, err := os.ReadFile(cityPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(final, original) {
+		t.Fatalf("rig-scoped [[patches.agent]] block was modified by a city-scoped resume:\nbefore:\n%s\nafter:\n%s", original, final)
+	}
+}

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -320,31 +320,40 @@ func boolPtr(b bool) *bool { return &b }
 // to durable config (not ephemeral session metadata).
 func (e *Editor) SuspendAgent(name string) error {
 	return e.EditExpanded(func(raw, expanded *config.City) error {
-		return mutateAgentSuspended(e.fs, filepath.Dir(e.tomlPath), raw, expanded, name, true)
+		return mutateAgentSuspended(e.fs, e.tomlPath, raw, expanded, name, true)
 	})
 }
 
 // ResumeAgent resumes a suspended agent, mirroring [Editor.SuspendAgent].
 func (e *Editor) ResumeAgent(name string) error {
 	return e.EditExpanded(func(raw, expanded *config.City) error {
-		return mutateAgentSuspended(e.fs, filepath.Dir(e.tomlPath), raw, expanded, name, false)
+		return mutateAgentSuspended(e.fs, e.tomlPath, raw, expanded, name, false)
 	})
 }
 
 // mutateAgentSuspended is the shared dispatch for SuspendAgent and
 // ResumeAgent. Branches on agent provenance:
-//   - OriginInline (city.toml [[agent]]): edit the raw struct.
+//   - OriginInline (city.toml [[agent]]): edit the raw struct in memory,
+//     then surgically toggle the on-disk suspended key so the generic
+//     EditExpanded writeback (a lossy full-struct marshal) never runs.
 //   - OriginDerived + convention-discovered (agents/<name>/): write
 //     agents/<name>/agent.toml; also strip any legacy [[patches.agent]]
 //     suspended override so it can't shadow the new value.
-//   - OriginDerived + pack-declared: add or update [[patches.agent]].
+//   - OriginDerived + pack-declared: surgically append a [[patches.agent]]
+//     block on disk, falling back to the in-memory patch (and the generic
+//     lossy writeback) only when the surgical append refuses.
 //
-// Returns [ErrUnmodified] when the change lives entirely in agent.toml
-// and raw was not touched, so EditExpanded skips the city.toml writeback.
-func mutateAgentSuspended(fs fsys.FS, cityRoot string, raw, expanded *config.City, name string, suspended bool) error {
+// Returns [ErrUnmodified] whenever the on-disk city.toml was already
+// written surgically (or the change lives entirely in agent.toml), so
+// EditExpanded skips its own city.toml writeback.
+func mutateAgentSuspended(fs fsys.FS, tomlPath string, raw, expanded *config.City, name string, suspended bool) error {
+	cityRoot := filepath.Dir(tomlPath)
 	switch AgentOrigin(raw, expanded, name) {
 	case OriginInline:
-		return SetAgentSuspended(raw, name, suspended)
+		if err := config.WriteCityAgentSuspendedForEdit(fs, tomlPath, raw, name, suspended); err != nil {
+			return err
+		}
+		return ErrUnmodified
 	case OriginDerived:
 		agent, ok, err := findLocalDiscoveredAgent(fs, expanded, cityRoot, name)
 		if err != nil {
@@ -365,9 +374,16 @@ func mutateAgentSuspended(fs fsys.FS, cityRoot string, raw, expanded *config.Cit
 			}
 			return ErrUnmodified
 		}
-		return AddOrUpdateAgentPatch(raw, name, func(p *config.AgentPatch) {
-			p.Suspended = boolPtr(suspended)
-		})
+		dir, base := config.ParseQualifiedName(name)
+		if err := config.AppendAgentPatchSuspendedForEdit(fs, tomlPath, raw, dir, base, suspended); err != nil {
+			if !errors.Is(err, config.ErrSurgicalAgentEditUnsupported) {
+				return err
+			}
+			return AddOrUpdateAgentPatch(raw, name, func(p *config.AgentPatch) {
+				p.Suspended = boolPtr(suspended)
+			})
+		}
+		return ErrUnmodified
 	case OriginNotFound:
 		return fmt.Errorf("%w: agent %q", ErrNotFound, name)
 	}

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -375,16 +375,16 @@ func mutateAgentSuspended(fs fsys.FS, tomlPath string, raw, expanded *config.Cit
 				// strip it surgically on disk so EditExpanded's lossy
 				// full-struct writeback (which drops every comment)
 				// doesn't run for what is otherwise a no-op city.toml
-				// change. Fall back to the lossy writeback -- raw
-				// already reflects the stripped patch, so it stays
-				// correct -- only when the on-disk block can't be
-				// unambiguously located.
+				// change. Refuse instead of falling back to the lossy
+				// writeback when the on-disk block can't be
+				// unambiguously located -- silently accepting comment
+				// loss here would defeat the point of the surgical edit.
 				dir, base := config.ParseQualifiedName(agent.QualifiedName())
 				if err := config.StripAgentPatchSuspendedForEdit(fs, tomlPath, raw, dir, base); err != nil {
 					if !errors.Is(err, config.ErrSurgicalAgentEditUnsupported) {
 						return err
 					}
-					return nil
+					return fmt.Errorf("agent %q: legacy [[patches.agent]] suspended override could not be surgically stripped: %w", name, err)
 				}
 			}
 			return ErrUnmodified

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -333,12 +333,13 @@ func (e *Editor) ResumeAgent(name string) error {
 
 // mutateAgentSuspended is the shared dispatch for SuspendAgent and
 // ResumeAgent. Branches on agent provenance:
-//   - OriginInline (city.toml [[agent]]): edit the raw struct in memory,
-//     then surgically toggle the on-disk suspended key so the generic
-//     EditExpanded writeback (a lossy full-struct marshal) never runs.
+//   - OriginInline (city.toml [[agent]]): surgically toggle the on-disk
+//     suspended key so the generic EditExpanded writeback (a lossy
+//     full-struct marshal) never runs.
 //   - OriginDerived + convention-discovered (agents/<name>/): write
 //     agents/<name>/agent.toml; also strip any legacy [[patches.agent]]
-//     suspended override so it can't shadow the new value.
+//     suspended override (in memory and, when unambiguous, surgically on
+//     disk too) so it can't shadow the new value.
 //   - OriginDerived + pack-declared: surgically append a [[patches.agent]]
 //     block on disk, falling back to the in-memory patch (and the generic
 //     lossy writeback) only when the surgical append refuses.
@@ -370,7 +371,21 @@ func mutateAgentSuspended(fs fsys.FS, tomlPath string, raw, expanded *config.Cit
 			// only strip the matching patch, not a same-named entry
 			// targeting a different rig.
 			if StripAgentPatchSuspended(raw, agent.QualifiedName()) {
-				return nil
+				// raw now reflects the stripped patch in memory. Also
+				// strip it surgically on disk so EditExpanded's lossy
+				// full-struct writeback (which drops every comment)
+				// doesn't run for what is otherwise a no-op city.toml
+				// change. Fall back to the lossy writeback -- raw
+				// already reflects the stripped patch, so it stays
+				// correct -- only when the on-disk block can't be
+				// unambiguously located.
+				dir, base := config.ParseQualifiedName(agent.QualifiedName())
+				if err := config.StripAgentPatchSuspendedForEdit(fs, tomlPath, raw, dir, base); err != nil {
+					if !errors.Is(err, config.ErrSurgicalAgentEditUnsupported) {
+						return err
+					}
+					return nil
+				}
 			}
 			return ErrUnmodified
 		}

--- a/internal/configedit/suspend_resume_comment_preservation_test.go
+++ b/internal/configedit/suspend_resume_comment_preservation_test.go
@@ -1,0 +1,241 @@
+package configedit_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/configedit"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// stripTOMLComments returns s as a slice of non-blank lines with any
+// trailing comment removed. Fixtures in this file never put '#' inside a
+// quoted value, so a plain substring split is enough to separate content
+// from commentary.
+func stripTOMLComments(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = line[:i]
+		}
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// diffContentLines compares before/after with comments and blank lines
+// stripped, as a multiset of lines, and reports which content lines were
+// lost (removed) or introduced (added). It is order-insensitive so it
+// isolates genuine content changes (a key gaining/losing a value, a table
+// appearing/disappearing) from harmless reordering, and it still catches
+// array reflow: a single-line array that becomes multi-line no longer
+// matches its old line verbatim, so it shows up as one removed + N added.
+func diffContentLines(before, after string) (removed, added []string) {
+	beforeCount := map[string]int{}
+	for _, l := range stripTOMLComments(before) {
+		beforeCount[l]++
+	}
+	afterCount := map[string]int{}
+	for _, l := range stripTOMLComments(after) {
+		afterCount[l]++
+	}
+	for l, bc := range beforeCount {
+		if ac := afterCount[l]; bc > ac {
+			for i := 0; i < bc-ac; i++ {
+				removed = append(removed, l)
+			}
+		}
+	}
+	for l, ac := range afterCount {
+		if bc := beforeCount[l]; ac > bc {
+			for i := 0; i < ac-bc; i++ {
+				added = append(added, l)
+			}
+		}
+	}
+	sort.Strings(removed)
+	sort.Strings(added)
+	return removed, added
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSuspendAgent_Inline_PreservesComments pins ga-gc16k3: suspending an
+// inline [[agent]] must not rewrite city.toml through the lossy
+// Editor.write -> ... -> City.Marshal struct round trip, which drops every
+// comment and can materialize absent tables as explicit zero values.
+func TestSuspendAgent_Inline_PreservesComments(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `# City-level rationale: primary orchestration city for gascity.
+[workspace]
+name = "test-city"
+
+# The mayor plans; coding agents work. Kept inline so patches never
+# shadow its suspended state.
+[[agent]]
+name = "mayor"
+provider = "claude"
+pre_start = ["echo starting", "echo ready"]
+`)
+	before := string(mustReadFile(t, path))
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.SuspendAgent("mayor"); err != nil {
+		t.Fatalf("SuspendAgent: %v", err)
+	}
+
+	after := string(mustReadFile(t, path))
+
+	for _, want := range []string{
+		"# City-level rationale: primary orchestration city for gascity.",
+		"# The mayor plans; coding agents work. Kept inline so patches never",
+		"# shadow its suspended state.",
+	} {
+		if !strings.Contains(after, want) {
+			t.Errorf("suspend dropped comment %q; city.toml now:\n%s", want, after)
+		}
+	}
+
+	if strings.Contains(after, "[dolt]") {
+		t.Errorf("suspend materialized an absent [dolt] table; city.toml now:\n%s", after)
+	}
+
+	if !strings.Contains(after, `pre_start = ["echo starting", "echo ready"]`) {
+		t.Errorf("suspend reflowed the single-line pre_start array; city.toml now:\n%s", after)
+	}
+
+	removed, added := diffContentLines(before, after)
+	if len(removed) != 0 {
+		t.Errorf("suspend removed unrelated content lines %v; city.toml now:\n%s", removed, after)
+	}
+	if want := []string{"suspended = true"}; !stringSlicesEqual(added, want) {
+		t.Errorf("suspend changed unrelated content; added lines = %v, want %v; city.toml now:\n%s", added, want, after)
+	}
+}
+
+// TestResumeAgent_Inline_PreservesComments mirrors
+// TestSuspendAgent_Inline_PreservesComments for the resume direction: the
+// suspended = true line must disappear (Suspended is bool,omitempty) and
+// nothing else should move.
+func TestResumeAgent_Inline_PreservesComments(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `# City-level rationale: primary orchestration city for gascity.
+[workspace]
+name = "test-city"
+
+# The mayor plans; coding agents work. Kept inline so patches never
+# shadow its suspended state.
+[[agent]]
+name = "mayor"
+provider = "claude"
+pre_start = ["echo starting", "echo ready"]
+suspended = true
+`)
+	before := string(mustReadFile(t, path))
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.ResumeAgent("mayor"); err != nil {
+		t.Fatalf("ResumeAgent: %v", err)
+	}
+
+	after := string(mustReadFile(t, path))
+
+	for _, want := range []string{
+		"# City-level rationale: primary orchestration city for gascity.",
+		"# The mayor plans; coding agents work. Kept inline so patches never",
+		"# shadow its suspended state.",
+	} {
+		if !strings.Contains(after, want) {
+			t.Errorf("resume dropped comment %q; city.toml now:\n%s", want, after)
+		}
+	}
+
+	if !strings.Contains(after, `pre_start = ["echo starting", "echo ready"]`) {
+		t.Errorf("resume reflowed the single-line pre_start array; city.toml now:\n%s", after)
+	}
+
+	removed, added := diffContentLines(before, after)
+	if want := []string{"suspended = true"}; !stringSlicesEqual(removed, want) {
+		t.Errorf("resume changed unrelated content; removed lines = %v, want %v; city.toml now:\n%s", removed, want, after)
+	}
+	if len(added) != 0 {
+		t.Errorf("resume added unrelated content lines %v; city.toml now:\n%s", added, after)
+	}
+}
+
+// TestSuspendAgent_PackDerived_PreservesComments covers the
+// [[patches.agent]] branch of mutateAgentSuspended (a pack-declared agent,
+// not a city-local convention agent). This branch still writes city.toml
+// through the same lossy Editor.write path, so existing comments must
+// survive and the only new content should be the appended patch block.
+func TestSuspendAgent_PackDerived_PreservesComments(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `# City-level rationale: primary orchestration city for gascity.
+[workspace]
+name = "test-city"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[[agent]]
+name = "worker"
+provider = "claude"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A conventional prompt template at the discovery location must not
+	// trigger the agent.toml write path when a pack [[agent]] entry exists.
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := string(mustReadFile(t, path))
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.SuspendAgent("worker"); err != nil {
+		t.Fatalf("SuspendAgent: %v", err)
+	}
+
+	after := string(mustReadFile(t, path))
+
+	if !strings.Contains(after, "# City-level rationale: primary orchestration city for gascity.") {
+		t.Errorf("suspend dropped comment; city.toml now:\n%s", after)
+	}
+
+	removed, added := diffContentLines(before, after)
+	if len(removed) != 0 {
+		t.Errorf("suspend removed unrelated content lines %v; city.toml now:\n%s", removed, after)
+	}
+	wantAdded := []string{
+		`[[patches.agent]]`,
+		`dir = ""`,
+		`name = "worker"`,
+		`suspended = true`,
+	}
+	sort.Strings(wantAdded)
+	if !stringSlicesEqual(added, wantAdded) {
+		t.Errorf("suspend changed unrelated content; added lines = %v, want %v; city.toml now:\n%s", added, wantAdded, after)
+	}
+}

--- a/internal/configedit/suspend_resume_comment_preservation_test.go
+++ b/internal/configedit/suspend_resume_comment_preservation_test.go
@@ -239,3 +239,76 @@ provider = "claude"
 		t.Errorf("suspend changed unrelated content; added lines = %v, want %v; city.toml now:\n%s", added, wantAdded, after)
 	}
 }
+
+// TestResumeAgent_LocalDiscovered_StripsLegacyPatchSuspended_PreservesComments
+// covers the fixture shape the round-1 review of ga-gc16k3 flagged as
+// uncovered: a locally-discovered agent (agents/<name>/agent.toml) that also
+// carries a legacy [[patches.agent]] suspended override. Resuming such an
+// agent must strip the now-redundant patch override without falling through
+// to the lossy Editor.write struct-marshal rewrite -- mutateAgentSuspended's
+// OriginDerived branch returned plain nil whenever StripAgentPatchSuspended
+// reported a change, and EditExpanded treats plain nil as "write the raw
+// config," dropping every comment. Functional (non-comment) behavior for
+// this exact fixture is already covered by
+// TestResumeAgent_StripsLegacyPatchSuspended in configedit_test.go; this
+// test adds the comment-preservation assertion that test predates.
+func TestResumeAgent_LocalDiscovered_StripsLegacyPatchSuspended_PreservesComments(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `# City-level rationale: primary orchestration city for gascity.
+[workspace]
+name = "test-city"
+
+[[patches.agent]]
+dir = ""
+name = "worker"
+suspended = true
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("suspended = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := string(mustReadFile(t, path))
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.ResumeAgent("worker"); err != nil {
+		t.Fatalf("ResumeAgent: %v", err)
+	}
+
+	after := string(mustReadFile(t, path))
+
+	if !strings.Contains(after, "# City-level rationale: primary orchestration city for gascity.") {
+		t.Errorf("resume dropped comment; city.toml now:\n%s", after)
+	}
+
+	if strings.Contains(after, "[[patches.agent]]") {
+		t.Errorf("resume should strip the legacy patch override; city.toml now:\n%s", after)
+	}
+
+	removed, added := diffContentLines(before, after)
+	wantRemoved := []string{
+		`[[patches.agent]]`,
+		`dir = ""`,
+		`name = "worker"`,
+		`suspended = true`,
+	}
+	sort.Strings(wantRemoved)
+	if !stringSlicesEqual(removed, wantRemoved) {
+		t.Errorf("resume changed unexpected content; removed lines = %v, want %v; city.toml now:\n%s", removed, wantRemoved, after)
+	}
+	if len(added) != 0 {
+		t.Errorf("resume added unrelated content lines %v; city.toml now:\n%s", added, after)
+	}
+}

--- a/internal/configedit/suspend_resume_comment_preservation_test.go
+++ b/internal/configedit/suspend_resume_comment_preservation_test.go
@@ -1,12 +1,14 @@
 package configedit_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/configedit"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -311,5 +313,68 @@ schema = 2
 	}
 	if len(added) != 0 {
 		t.Errorf("resume added unrelated content lines %v; city.toml now:\n%s", added, after)
+	}
+}
+
+// TestResumeAgent_LocalDiscovered_AmbiguousLegacyPatch_RefusesLossyRewrite
+// pins ga-47m118 round 3: the sibling failure mode to
+// TestResumeAgent_LocalDiscovered_StripsLegacyPatchSuspended_PreservesComments's
+// single-block success case above. Here two duplicate [[patches.agent]]
+// blocks share the same (dir, name) identity -- a leftover shape
+// findTOMLArrayBlock refuses to guess between -- so
+// StripAgentPatchSuspendedForEdit reports config.ErrSurgicalAgentEditUnsupported.
+// mutateAgentSuspended's OriginDerived branch used to swallow that error and
+// return plain nil, which EditExpanded treats as "write the raw config,"
+// silently deleting every comment in city.toml while leaving the ambiguous
+// patch blocks in place. Resuming must instead surface the refusal and
+// leave city.toml byte-for-byte untouched.
+func TestResumeAgent_LocalDiscovered_AmbiguousLegacyPatch_RefusesLossyRewrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `# City-level rationale: primary orchestration city for gascity.
+[workspace]
+name = "test-city"
+
+[[patches.agent]]
+dir = ""
+name = "worker"
+suspended = true
+
+[[patches.agent]]
+dir = ""
+name = "worker"
+suspended = true
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("suspended = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := string(mustReadFile(t, path))
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	err := ed.ResumeAgent("worker")
+
+	if err == nil {
+		t.Fatal("expected ResumeAgent to refuse the ambiguous legacy patch, got nil error")
+	}
+	if !errors.Is(err, config.ErrSurgicalAgentEditUnsupported) {
+		t.Errorf("expected error wrapping config.ErrSurgicalAgentEditUnsupported, got: %v", err)
+	}
+
+	after := string(mustReadFile(t, path))
+	if after != before {
+		t.Errorf("refused resume must leave city.toml byte-for-byte unchanged; diff:\nbefore:\n%s\nafter:\n%s", before, after)
 	}
 }

--- a/internal/configedit/suspend_resume_comment_preservation_test.go
+++ b/internal/configedit/suspend_resume_comment_preservation_test.go
@@ -182,9 +182,10 @@ suspended = true
 
 // TestSuspendAgent_PackDerived_PreservesComments covers the
 // [[patches.agent]] branch of mutateAgentSuspended (a pack-declared agent,
-// not a city-local convention agent). This branch still writes city.toml
-// through the same lossy Editor.write path, so existing comments must
-// survive and the only new content should be the appended patch block.
+// not a city-local convention agent). This fixture's fresh patch append now
+// takes the surgical AppendAgentPatchSuspendedForEdit path and returns
+// ErrUnmodified, so existing comments must survive and the only new content
+// should be the appended patch block.
 func TestSuspendAgent_PackDerived_PreservesComments(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, `# City-level rationale: primary orchestration city for gascity.

--- a/internal/configedit/suspend_resume_comment_preservation_test.go
+++ b/internal/configedit/suspend_resume_comment_preservation_test.go
@@ -233,7 +233,6 @@ provider = "claude"
 	}
 	wantAdded := []string{
 		`[[patches.agent]]`,
-		`dir = ""`,
 		`name = "worker"`,
 		`suspended = true`,
 	}

--- a/release-gates/ga-we6ffm-agent-suspend-resume-comment-preservation-gate.md
+++ b/release-gates/ga-we6ffm-agent-suspend-resume-comment-preservation-gate.md
@@ -1,0 +1,149 @@
+# Release gate: agent suspend/resume comment preservation
+
+- Deploy bead: `ga-we6ffm`
+- Build bead: `ga-gc16k3` (round-three fixup: `ga-47m118`)
+- Review bead: `ga-288fgv`
+- Reviewed source: `8ea15a2cc0d23ee3d1649613bb8030c984ab2766`
+- Base evaluated: `origin/main@202c53604dbd8961f81a2d0031ff904478c5a758`
+- Deploy mode: `remote`; push remote: `fork`
+- Gate result: **PASS with attributed raw test failures**
+
+`docs/PROJECT_MANIFEST.md` is absent from this repository and reviewed
+revision. This checklist applies the seven criteria in the deployer contract,
+the implementation bead's acceptance contract, and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review `ga-288fgv` is closed with `verdict: pass`, `tests_green: true`, no style/security finding, and `deploy_commit: 8ea15a2cc0d23ee3d1649613bb8030c984ab2766`. The SHA independently resolves to that exact commit. No review carryover is used. |
+| 2 | Acceptance criteria met | **PASS** | Agent suspend/resume now changes only the `suspended` key through surgical TOML edits, preserving comments, absent tables, array formatting, and surrounding bytes for inline and pack-derived declarations. Resume removes the key rather than materializing a false value. An ambiguous legacy patch block now returns a wrapped `ErrSurgicalAgentEditUnsupported` instead of falling through to a lossy full rewrite. All ten diff-owned tests passed twice in the full suite. |
+| 3 | Tests pass | **PASS with attributed raw failures** | The documented full local CI union completed all 40 jobs: **34 jobs PASS / 6 jobs with raw failures / 0 omitted**. Its top-level result lines contain **45,305 PASS / 7 raw FAIL / 191 SKIP**. Every one of the ten diff-owned tests passed in both unit and integration-package lanes, with 0 diff-owned FAIL and 0 diff-owned SKIP. All seven raw failures are non-diff-owned, tracked, mechanism-attributed, and path-disjoint under criterion 3a. Required policy and vet lanes passed. |
+| 3a | Non-diff-owned failures attributed | **PASS** | Five verified open trackers cover the complete failure set: installed-`bd` manifest drift (`ga-f0uceo`), expired provider-catalog waivers (`ga-cojd80`), host tmux default bindings (`ga-k3fxvj`), circuit-breaker diagnostics contaminating machine-readable `bd` stdout (`ga-io7xwr`), and an external Dolt SQL server failing readiness (`ga-woq0zj`). The first four trackers predate the run. The Dolt readiness tracker was filed and verified during this discovering run under the landed-mechanism exception: the connection refusal occurs entirely inside an unchanged external-server fixture, with clauses 1 and 4 clear. Sightings were appended and read back from every tracker. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy` passed. `go vet ./...` passed. `git diff --check origin/main...8ea15a2c...` passed. |
+| 3c | CI-config lane run | **PASS / n/a** | The candidate changes no workflow, CI job, matrix, timeout, required-check list, Makefile, or runner policy. `ci_lane_run: n/a (no CI-config change)`. |
+| 4 | No high-severity review findings open | **PASS** | Review `ga-288fgv` records no unresolved HIGH finding. Its security analysis confirms the change is error propagation and byte-preserving local configuration mutation only, with no new input, authority, dependency, endpoint, serialization format, or sensitive-data surface. |
+| 5 | Final branch clean | **PASS** | The exact-candidate detached worktree remained clean after the full suite, policy lane, vet, and diff check. All logs are outside the worktree. This checklist is the deployer's only new file and will be committed on the isolated branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | A fresh commit-to-PR lookup returned no PR. After the final fetch, `git merge-tree --write-tree --messages origin/main 8ea15a2c...` exited 0 and produced synthetic tree `bd40fc2896506d8db38788d3da08cbe867201510`, with clean auto-merges of `cmd/gc/cmd_agent.go` and `internal/configedit/configedit.go`. `assert_deploy_ancestry_scope` passed for the deploy/review/build lineage, with no `.claude/**` path or unrelated commit. No self-rebase was required. |
+| 7 | Single feature theme | **PASS** | Six TDD/fixup commits change five files for one theme: safe, byte-preserving agent suspend/resume and explicit refusal when a legacy patch cannot be edited unambiguously. |
+
+## Acceptance evidence
+
+- Inline-agent suspend and resume preserve header, section, and inline comments
+  byte-for-byte outside the target key.
+- Absent TOML tables remain absent and existing inline arrays are not reflowed.
+- Pack-derived and locally discovered agents use surgical patch edits.
+- Resume deletes `suspended` rather than writing `suspended = false`.
+- A missing or duplicate legacy patch block fails without changing the file.
+- Error propagation reaches the CLI/API caller instead of triggering the old
+  full-struct write fallback.
+- The feature diff is confined to `cmd/gc/cmd_agent.go`,
+  `internal/config/site_binding_agent_suspend.go` and its test, and
+  `internal/configedit/configedit.go` and its test.
+
+`diff_tests_executed` (each recorded PASS twice, with 0 FAIL/SKIP):
+
+- `TestWriteCityAgentSuspendedForEdit_PreservesCommentsAcrossSuspendResume`
+- `TestWriteCityAgentSuspendedForEdit_DoesNotMaterializeAbsentTableOrReflowArray`
+- `TestWriteCityAgentSuspendedForEdit_DiffLimitedToSuspendedKey`
+- `TestWriteCityAgentSuspendedForEdit_ResumeDeletesSuspendedKeyEntirely`
+- `TestWriteCityAgentSuspendedForEdit_RefusesWhenAgentBlockNotFound`
+- `TestSuspendAgent_Inline_PreservesComments`
+- `TestResumeAgent_Inline_PreservesComments`
+- `TestSuspendAgent_PackDerived_PreservesComments`
+- `TestResumeAgent_LocalDiscovered_StripsLegacyPatchSuspended_PreservesComments`
+- `TestResumeAgent_LocalDiscovered_AmbiguousLegacyPatch_RefusesLossyRewrite`
+
+## Test evidence
+
+The container-backed environment was established before the independent run:
+
+- rootless Podman 5.8.4 was reachable at
+  `unix:///run/user/1000/podman/podman.sock`;
+- `TESTCONTAINERS_RYUK_DISABLED=true` was set as required on this host;
+- cached Dolt SQL Server 1.32.4 was present;
+- the candidate does not introduce or change a container-image pin.
+
+```text
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true GOFLAGS=-v LOCAL_TEST_LOG_DIR=/var/tmp/ga-we6ffm-full.y7Vkai make test-local-full-parallel
+test_cmd_scope: full-suite
+test_job_counts: 34 PASS / 6 raw FAIL / 0 omitted
+test_counts: 45,305 PASS / 7 raw FAIL / 191 SKIP
+diff_tests_executed: 10 unique tests, each PASS in unit and integration-package lanes; 0 FAIL; 0 SKIP
+skip_justification: all 191 skips are unchanged platform, permission, optional-provider, live-infrastructure, helper-process, or opt-in integration guards; no diff-owned test skipped
+waiver_ref: none
+ci_lane_run: n/a (no CI configuration change)
+runner_log: /var/tmp/ga-we6ffm-artifacts.9aMjz7/full-suite.log
+shard_logs: /var/tmp/ga-we6ffm-full.y7Vkai
+policy_log: /var/tmp/ga-we6ffm-artifacts.9aMjz7/policy.log
+vet_log: /var/tmp/ga-we6ffm-artifacts.9aMjz7/vet.log
+```
+
+The command scheduled the complete 40-job local CI union, including every
+non-short `cmd-gc-process` shard, every integration `cmd/gc` package shard,
+unit/core, runtime/tmux, bdstore, review-formula, REST-smoke, and REST-full
+lanes. All six process-backed `cmd/gc` shards and all six integration `cmd/gc`
+package shards passed, satisfying the required-job mapping for the changed
+`cmd/gc/**` and `internal/**` paths.
+
+### Raw failures and attribution
+
+| Raw result | Tracker | Four-clause evidence |
+|---|---|---|
+| `TestBdFlagManifestCurrent` | `ga-f0uceo` | The unchanged test compares the externally installed `bd --help` surface with `internal/bdflags`. The candidate changes neither side, the open tracker predates this run, and there is no path overlap. |
+| `TestCatalogMatchesProductionWiringAndDocumentation` (2 occurrences) | `ga-cojd80` | Eight `runtime.Provider` waiver entries expired on 2026-08-26. This date-driven catalog-policy condition cannot be caused by the suspend/resume diff, its tracker predates the run, and there is no path overlap. |
+| `TestGetKeyBinding_CapturesDefaultBinding`, `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | `ga-k3fxvj` | Both unchanged tests read empty default bindings from this host's tmux server. The candidate changes no runtime/tmux path, and the exact open tracker predates this run. |
+| `TestCleanInstallTutorialPath` | `ga-io7xwr` | The external `bd config get issue_prefix` command emitted a circuit-breaker cleanup diagnostic onto stdout before the correct `tra` value. The candidate cannot change the external `bd` output channel; the exact tracker predates this run and the test file is outside the diff. |
+| `TestCompactScriptRealDoltRemotePush` | `ga-woq0zj` | The unchanged fixture's external Dolt SQL server never became query-ready within 20 seconds and the final client attempt received connection refused before the compaction script ran. The candidate changes no Dolt startup/compaction path. The landed mechanism plus clear clauses 1/4 permits the verified same-run tracker. |
+
+Every raw failure satisfies: (i) its test is not diff-owned; (ii) the named
+open tracker covers the root condition; (iii) the external/date-driven
+mechanism proves the candidate did not cause it; and (iv) the failing test path
+does not overlap the five-file diff. Because the mechanism proofs land, the
+inconclusive reachability guard is not invoked. The candidate adds ordinary
+tests inside already tracked packages but no suite target, matrix entry,
+parallelism, resource-census change, server, or listener.
+
+```text
+failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a) mechanism — installed-bd manifest drift; no path overlap
+failure_attribution: TestCatalogMatchesProductionWiringAndDocumentation -> ga-cojd80 | clause 3(a) mechanism — date-expired provider waivers; no path overlap
+failure_attribution: default tmux binding tests -> ga-k3fxvj | clause 3(a) mechanism — host tmux binding state; no path overlap
+failure_attribution: TestCleanInstallTutorialPath -> ga-io7xwr | clause 3(a) mechanism — external bd diagnostic contaminates stdout; no path overlap
+failure_attribution: TestCompactScriptRealDoltRemotePush -> ga-woq0zj | clause 3(a) mechanism — external server fails readiness before compact script; no path overlap
+inconclusive-guard: n/a — all mechanism proofs landed; added_test_load=no
+```
+
+## Policy and static evidence
+
+- `policy_lane: make test-ci-policy — PASS`
+- `static_lane: go vet ./... — PASS`
+- `format_lane: git diff --check origin/main...8ea15a2c... — PASS`
+- `ci_lane_run: n/a (no CI configuration change)`
+
+## Pre-push revalidation
+
+The normal push ran the repository's `test-fast-parallel` hook. Nine of ten
+jobs passed, including all six `cmd/gc` shards, the concurrency/lock
+self-tests, and the Darwin compile check. `unit-core` reproduced only the
+same `TestCatalogMatchesProductionWiringAndDocumentation` condition: eight
+`runtime.Provider` waivers owned by `ga-80po0c.3` expired on 2026-08-26.
+That deterministic, non-diff-owned failure remains covered by open tracker
+`ga-cojd80`; the exact pre-push sighting was appended and read back. Under
+the shared non-diff-owned gate-failure protocol this attributed hook failure
+does not invalidate the PASS gate and permits publishing with hook bypass.
+
+```text
+pre_push_gate: 9 PASS / 1 attributed FAIL
+pre_push_attribution: TestCatalogMatchesProductionWiringAndDocumentation -> ga-cojd80 | date-expired runtime.Provider waivers; no path overlap
+pre_push_logs: /var/tmp/gc-local-tests.lFvtSD
+```
+
+## Disposition
+
+All seven release criteria pass with complete non-diff attribution. Cut
+`deploy/ga-we6ffm-gate` from exact reviewed source
+`8ea15a2cc0d23ee3d1649613bb8030c984ab2766`, commit this checklist there,
+push the isolated branch, and open the pull request. The description's stale
+`deploy/ga-288fgv-gate` suggestion is provenance text only and is not used.
+Merge authority remains with mayor/mpr; the deployer does not merge.

--- a/release-gates/ga-we6ffm-agent-suspend-resume-comment-preservation-gate.md
+++ b/release-gates/ga-we6ffm-agent-suspend-resume-comment-preservation-gate.md
@@ -147,3 +147,12 @@ All seven release criteria pass with complete non-diff attribution. Cut
 push the isolated branch, and open the pull request. The description's stale
 `deploy/ga-288fgv-gate` suggestion is provenance text only and is not used.
 Merge authority remains with mayor/mpr; the deployer does not merge.
+
+## Amendment: criterion 3 scope
+
+Criterion 3's "0 diff-owned FAIL" held for the branch in isolation, not for
+the merge with `main`. `TestSuspendAgent_PackDerived_PreservesComments`
+failed against `main` after `AgentPatch.Dir` gained `omitempty`, which
+stopped the encoder emitting the `dir = ""` line the test asserted. Corrected
+in the maintainer fixup commit, along with the `rig`-key refusal in
+`findTOMLArrayBlock` that the same `main` change made necessary.


### PR DESCRIPTION
## What this changes

Agent suspend and resume now update `city.toml` surgically instead of serializing the whole configuration back to disk. Comments, section layout, inline arrays, and unrelated formatting remain byte-for-byte intact; resuming removes the `suspended` key instead of writing an explicit false value.

The same behavior covers agents declared directly in the city, inherited from a pack, and discovered from local configuration. If a legacy patch is ambiguous and cannot be edited safely, the command returns a clear error and leaves the file untouched.

## Review notes

- The write boundary lives in `internal/configedit`, with agent-binding decisions kept in `internal/config`.
- `cmd/gc` now propagates surgical-edit failures rather than falling back to a lossy full rewrite.
- The behavior is deliberately narrow: this does not change general TOML serialization or other configuration mutations.
- Please pay particular attention to missing/duplicate agent blocks and legacy pack-patch cleanup on resume.

## Test plan

- [x] Run the complete 40-job local CI union with rootless Podman; all ten changed-feature tests pass in both unit and integration-package lanes.
- [x] Run all six process-backed and all six integration `cmd/gc` shards.
- [x] Run `make test-ci-policy`, `go vet ./...`, and the repository pre-commit docs-sync hook.
- [x] Audit the release gate and tracker-backed attribution for unrelated host/date-driven failures: [`release-gates/ga-we6ffm-agent-suspend-resume-comment-preservation-gate.md`](release-gates/ga-we6ffm-agent-suspend-resume-comment-preservation-gate.md)