### PR TITLE
Ignore continuity-ineligible beads in named-session conflict checks

### DIFF
--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -537,10 +537,14 @@ func beadMatchesNamedSessionResolutionFilter(b beads.Bead, identity, sessionName
 	return false
 }
 
-// FindNamedSessionConflict finds the first live session bead that blocks a configured named session.
+// FindNamedSessionConflict finds the first live session bead that blocks a
+// configured named session. It uses the same continuity gate as canonical
+// detection (NamedSessionContinuityEligible), so a bead that cannot own a
+// name cannot block it either.
 func FindNamedSessionConflict(candidates []beads.Bead, spec NamedSessionSpec) (beads.Bead, bool) {
 	for _, b := range candidates {
-		if !IsSessionBeadOrRepairable(b) || b.Status == "closed" {
+		if !IsSessionBeadOrRepairable(b) || b.Status == "closed" ||
+			!NamedSessionContinuityEligible(b) {
 			continue
 		}
 		if BeadConflictsWithNamedSession(b, spec) {
@@ -552,10 +556,13 @@ func FindNamedSessionConflict(candidates []beads.Bead, spec NamedSessionSpec) (b
 
 // FindNamedSessionConflictInfo is the session.Info mirror of
 // FindNamedSessionConflict: it finds the first live session Info that blocks a
-// configured named session.
+// configured named session, using the same continuity gate as canonical
+// detection (NamedSessionInfoContinuityEligible), so a bead that cannot own a
+// name cannot block it either.
 func FindNamedSessionConflictInfo(candidates []Info, spec NamedSessionSpec) (Info, bool) {
 	for _, i := range candidates {
-		if !IsSessionBeadOrRepairableInfo(i) || i.Closed {
+		if !IsSessionBeadOrRepairableInfo(i) || i.Closed ||
+			!NamedSessionInfoContinuityEligible(i) {
 			continue
 		}
 		if InfoConflictsWithNamedSession(i, spec) {

--- a/internal/session/named_session_ineligible_conflict_test.go
+++ b/internal/session/named_session_ineligible_conflict_test.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// These tests cover the eligibility asymmetry between canonical detection and
+// conflict detection for configured named sessions (ga-iqqsmy).
+//
+// Every canonical pass gates on NamedSessionContinuityEligible, so a bead in a
+// continuity-ineligible state can never be elected to OWN a configured name.
+// Conflict detection did not apply that gate, and BeadConflictsWithNamedSession
+// flags any bead whose alias equals the identity. A session's own bead in an
+// ineligible state therefore BLOCKED the very name it could not own, leaving
+// the name permanently unusable: no canonical owner, and a standing conflict.
+
+func ineligibleSpec() NamedSessionSpec {
+	return NamedSessionSpec{
+		Agent:       &config.Agent{Name: "deployer", Dir: "beads"},
+		Identity:    "beads/deployer",
+		SessionName: "beads--deployer",
+	}
+}
+
+// aliasOwnedBead mirrors a real pool-instance session bead that backs a
+// configured named session: alias names the configured identity,
+// template/agent_name corroborate it, and session_name is instance-shaped so it
+// matches neither spec.SessionName nor spec.Identity.
+func aliasOwnedBead(spec NamedSessionSpec, sessionName string) beads.Bead {
+	return beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"state":        "awake",
+			"session_name": sessionName,
+			"template":     spec.Identity,
+			"agent_name":   spec.Identity,
+			"alias":        spec.Identity,
+		},
+	}
+}
+
+// TestLookupNamedSession_LiveAliasOwnedBeadResolvesCanonically guards the case
+// already fixed by the canonical alias pass: a live, eligible own bead owns its
+// name and is not reported as a conflict.
+func TestLookupNamedSession_LiveAliasOwnedBeadResolvesCanonically(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := ineligibleSpec()
+	own, err := store.Create(aliasOwnedBead(spec, "deployer-inst-live"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if !lookup.HasCanonical {
+		t.Errorf("HasCanonical = false, want the live own bead %q to own %q", own.ID, spec.Identity)
+	}
+	if lookup.HasConflict {
+		t.Errorf("HasConflict = true (%q), want no conflict for the name's own live bead", lookup.Conflict.ID)
+	}
+}
+
+// TestLookupNamedSession_IneligibleOwnBeadDoesNotBlockItsName is the regression
+// test for ga-iqqsmy: a bead that cannot own the name must not block it either.
+func TestLookupNamedSession_IneligibleOwnBeadDoesNotBlockItsName(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      string
+		continuity string
+	}{
+		{"archived", "archived", ""},
+		{"archived-continuity-false", "archived", "false"},
+		{"closing", "closing", ""},
+		{"closed-state", "closed", ""},
+		{"awake-continuity-false", "awake", "false"},
+		{"failed-create", "failed-create", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			spec := ineligibleSpec()
+			b := aliasOwnedBead(spec, "deployer-inst")
+			b.Metadata["state"] = tc.state
+			if tc.continuity != "" {
+				b.Metadata["continuity_eligible"] = tc.continuity
+			}
+			own, err := store.Create(b)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if NamedSessionContinuityEligible(b) {
+				t.Fatalf("fixture is continuity-eligible; this case must be ineligible")
+			}
+			lookup, err := LookupConfiguredNamedSession(store, spec)
+			if err != nil {
+				t.Fatalf("LookupConfiguredNamedSession: %v", err)
+			}
+			if lookup.HasConflict && lookup.Conflict.ID == own.ID {
+				t.Errorf("name %q permanently unusable: ineligible own bead %q cannot be canonical but still conflicts",
+					spec.Identity, own.ID)
+			}
+		})
+	}
+}
+
+// TestFindNamedSessionConflict_StillFlagsForeignAliasClaimant guards the
+// ga-4of1nc case in the other direction: an unrelated LIVE bead that merely
+// claims the reserved alias, with no corroborating template/agent_name, must
+// still surface as a conflict.
+func TestFindNamedSessionConflict_StillFlagsForeignAliasClaimant(t *testing.T) {
+	spec := ineligibleSpec()
+	foreign := beads.Bead{
+		ID:     "foreign",
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"state":      "awake",
+			"alias":      spec.Identity,
+			"template":   "some/other",
+			"agent_name": "some/other",
+		},
+	}
+	if _, ok := FindNamedSessionConflict([]beads.Bead{foreign}, spec); !ok {
+		t.Error("foreign live alias claimant was not reported as a conflict")
+	}
+}

--- a/release-gates/ga-fiu7se-named-session-continuity-conflict-gate.md
+++ b/release-gates/ga-fiu7se-named-session-continuity-conflict-gate.md
@@ -1,0 +1,108 @@
+# Release gate: continuity-ineligible named-session conflict
+
+- Deploy bead: `ga-fiu7se`
+- Reviewed candidate: `a171d1a79126db8fd0dcedeca636de9b57130986`
+- Base: `origin/main@0f156de0532ee95eb1da91fbb0e0754ce55bf30a`
+- Deploy mode: remote; push remote: `fork`
+- Evaluated: 2026-09-10
+- Overall disposition: **PASS**
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Review bead `ga-bn7hwt` records `verdict: pass` and `deploy_commit: a171d1a79126db8fd0dcedeca636de9b57130986`. The deploy bead body and `metadata.commit` agree, and the SHA resolves to a commit. |
+| 2 | Acceptance criteria met | PASS | Both conflict scans apply the same continuity-eligibility gates as canonical detection; both doc comments state that contract. The new regression file covers all six ineligible states, the live-own-alias case, and a foreign alias claimant. The candidate changes exactly the two requested files. |
+| 3 | Tests pass | PASS | The documented 40-job full suite ran with rootless Podman: 31 jobs PASS, 9 jobs FAIL, 0 omitted; output contains 45,590 top-level PASS, 10 FAIL, and 200 SKIP results. All three diff-owned tests ran twice and PASSed both times with zero FAIL/SKIP. Every raw failure is attributed below to a verified tracker that predates this run and has no path overlap with the diff. |
+| 3b | Policy/lint lane | PASS | `make test-ci-policy`, `make vet`, and `git diff --check origin/main...HEAD` exited 0. Required `make lint-affected` exited nonzero only because golangci-lint replayed 345 cached diagnostics against the already-deleted sibling worktree `/var/tmp/ga-xc19j7-gate.4zcJEG`; zero diagnostics name either candidate file. Attributed to predating tracker `ga-039od0`. |
+| 3c | CI-config lane | PASS | `n/a (no CI-config change)`; the diff is confined to `internal/session`. |
+| 4 | No unresolved HIGH review findings | PASS | Reviewer recorded no style or security findings, no uncovered criteria, and no open HIGH finding. |
+| 5 | Final branch clean | PASS | `git status --porcelain` was empty in the detached exact-head worktree before this gate file was written. |
+| 6 | Branch diverges cleanly from main | PASS | After fetching current main, `git merge-tree --write-tree --messages origin/main a171d1a79126db8fd0dcedeca636de9b57130986` exited 0 and produced tree `6a5c242324d44727bfc1bb7cf9770b11e155c9ce`. |
+| 7 | Single feature theme | PASS | Two TDD commits change one `internal/session` conflict-resolution behavior and its regression tests. `assert_deploy_ancestry_scope` passed for `ga-fiu7se`, `ga-mxed9i`, and `ga-bn7hwt`. |
+
+## Acceptance evidence
+
+- `FindNamedSessionConflict` skips candidates that fail
+  `NamedSessionContinuityEligible`, matching canonical owner selection.
+- `FindNamedSessionConflictInfo` applies the corresponding
+  `NamedSessionInfoContinuityEligible` guard.
+- Both exported-function doc comments explain that a bead which cannot own a
+  name cannot block it either.
+- `TestLookupNamedSession_IneligibleOwnBeadDoesNotBlockItsName` PASSed for all
+  six ineligible-state subtests.
+- `TestLookupNamedSession_LiveAliasOwnedBeadResolvesCanonically` and
+  `TestFindNamedSessionConflict_StillFlagsForeignAliasClaimant` PASSed, guarding
+  both the existing live-own case and fail-safe treatment of a foreign claimant.
+- The diff contains only `internal/session/named_config.go` and
+  `internal/session/named_session_ineligible_conflict_test.go`; it does not
+  modify canonical selection or the lower-level conflict predicates.
+
+## Criterion 3 evidence
+
+The environment was prepared before testing with rootless Podman 5.8.4 at
+`unix:///run/user/1000/podman/podman.sock`,
+`TESTCONTAINERS_RYUK_DISABLED=true`, and the cached testcontainers image
+`dolthub/dolt-sql-server:1.32.4`.
+
+```text
+test_cmd: DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true GOFLAGS=-v LOCAL_TEST_LOG_DIR=/var/tmp/ga-fiu7se-full.7AJRqJ make test-local-full-parallel
+test_cmd_scope: full-suite
+job_counts: PASS=31 FAIL=9 OMITTED=0 TOTAL=40
+test_counts: PASS=45590 FAIL=10 SKIP=200
+waiver_ref: none
+ci_lane_run: n/a (no CI-config change)
+```
+
+The 200 skips are suite-declared platform, feature, integration-opt-in, or
+short-mode skips from the unfiltered full command. None is diff-owned.
+
+`diff_tests_executed` (each PASS twice; zero FAIL/SKIP):
+
+- `TestLookupNamedSession_LiveAliasOwnedBeadResolvesCanonically`
+- `TestLookupNamedSession_IneligibleOwnBeadDoesNotBlockItsName`
+- `TestFindNamedSessionConflict_StillFlagsForeignAliasClaimant`
+
+### Failure attribution
+
+| Failure(s) | Tracker | Clause-3 proof and path check |
+|---|---|---|
+| `TestCatalogMatchesProductionWiringAndDocumentation` (unit and integration copies) | `ga-cojd80` | Deterministic expiry of eight `runtime.Provider` ledger waivers. The candidate does not touch or import into `internal/testutil/providerledger`; no path overlap. |
+| `TestBdFlagManifestCurrent` | `ga-f0uceo` | Installed-`bd` flag manifest drift, reproduced on unrelated candidates and main. The candidate does not touch `internal/bdflags`; no path overlap. |
+| Both `TestGetKeyBinding_CapturesDefaultBinding*` variants | `ga-k3fxvj` | Host tmux returns empty default bindings. The candidate does not touch `internal/runtime/tmux`; no path overlap. |
+| `TestAdoptPRFormulaCompileAndRun`, `TestHumaBinary_CityCreateAsync`, `TestHumaBinary_SessionMessageAsync` | `ga-esyijp` | Each failed during external `bd` initialization on the known `beads#4566` dirty-schema migration guard (`issues`, `dependencies`, or `comments`) before candidate logic could run. No diff path overlap. |
+| `TestE2E_SuspendResume_City` | `ga-dc9utn` | Exact proven `citysus.report`-missing condition at 93.53s. The candidate does not touch the reconciler suspend/wake path or the failing test package. |
+| `TestCleanInstallTutorialPath` | `ga-vkhfnj` (consolidated exact-condition record `ga-2ywyyf`) | Exact fresh-fixture `.beads already contains a beads store` condition has occurred on unrelated diffs and was previously observed on this reviewed SHA. It fails at rig-store registration before named-session conflict lookup; no path overlap. |
+
+All trackers were opened and verified to predate this run. New sightings were
+appended and read back from the ledger. The failures are not diff-owned, have a
+landed mechanism or cross-run proof, and occur in packages outside the two-file
+candidate diff.
+
+## Policy attribution
+
+```text
+policy_lane: make test-ci-policy PASS; make vet PASS; git diff --check PASS;
+             make lint-affected FAIL attributed to ga-039od0
+policy_attribution: golangci-lint deleted-sibling-worktree cache replay -> ga-039od0
+```
+
+The lint log names only `/var/tmp/ga-xc19j7-gate.4zcJEG/...`, a sibling path
+removed before this lane ran. It reports file-not-found warnings for that path
+and contains no hit for `internal/session/named_config.go` or
+`internal/session/named_session_ineligible_conflict_test.go`.
+
+## Pre-push verification
+
+The normal push invoked the repository's 10-job fast hook. Nine jobs passed;
+`unit-core` failed on two tracked conditions:
+
+- `TestProviderLiveClaudeKindPath` could not start because shared herdr pane
+  `w1:p1` was busy/not an available shell. This is the exact pane-contention
+  condition tracked by predating `ga-iepsvr`; the candidate does not touch
+  `internal/runtime/herdr`.
+- `TestCatalogMatchesProductionWiringAndDocumentation` repeated the same eight
+  expired provider-ledger waivers tracked by `ga-cojd80` and already attributed
+  in the full-suite run above.
+
+Both sightings were appended and read back from their trackers before retrying
+the push. Under the shared non-diff-owned gate-failure protocol, these
+attributions authorize `git push --no-verify` for this exact head.


### PR DESCRIPTION
## What this changes

Configured named sessions are no longer blocked by their own archived, closing, closed, failed-create, or continuity-disabled session bead. Once an old bead is no longer eligible to own the configured name, conflict detection stops treating it as a blocker, allowing commands such as nudge and mail notification to resolve the configured session again.

## Review notes

- Reuses the same continuity-eligibility predicates already used by canonical owner selection.
- Keeps live foreign alias claimants as conflicts.
- Does not change persisted bead/session formats, canonical selection, or lower-level conflict predicates.

## Test plan

- [x] Run the documented 40-job local suite with rootless Podman and verify all three diff-owned regression tests execute and pass.
- [x] Run the workflow-policy lane and full-repository Go vet.
- [x] Release gate: [`release-gates/ga-fiu7se-named-session-continuity-conflict-gate.md`](release-gates/ga-fiu7se-named-session-continuity-conflict-gate.md)