### PR TITLE
fix(dispatch): close control-ready cache + dispatch-scope stores so the WAL can checkpoint (unbounded WAL growth → federated work-query starvation)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -145,6 +145,12 @@ func runControlDispatcher(beadID string, stdout, stderr io.Writer) error {
 	return runControlDispatcherWithStore(cityPath, storePath, store, beadID, stdout, stderr)
 }
 
+// openControlStoreForDispatch is the test seam for the scope-store open in
+// runControlDispatcherInStore, following the package's var-seam idiom (cf.
+// controlDispatcherServe, dispatch_runtime.go). Production always uses
+// openControlStoreAtForCity.
+var openControlStoreForDispatch = openControlStoreAtForCity
+
 func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, stderr io.Writer) error {
 	if cityPath == "" {
 		var err error
@@ -162,10 +168,23 @@ func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, std
 		return err
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
-	store, err := openControlStoreAtForCity(storePath, cityPath, cfg)
+	store, err := openControlStoreForDispatch(storePath, cityPath, cfg)
 	if err != nil {
 		return fmt.Errorf("opening scoped control store %q: %w", storePath, err)
 	}
+	// The whole dispatch below is synchronous — ProcessControl's closures
+	// (RecycleSession, MemberStores, EmitCurrent) all run before it returns and
+	// nothing retains store past this call — so releasing the scope handle we
+	// just opened at return is safe and stops leaking one bd/Dolt store (and its
+	// connections) per control bead processed by the serve loop. When the graph
+	// class relocated, the graph store is a different, process-shared value that
+	// controlBeadLedger resolves separately; we close only store, the work leg we
+	// opened here.
+	defer func() {
+		if cerr := closeBeadStoreHandle(store); cerr != nil {
+			fmt.Fprintf(stderr, "warning: control dispatch: closing scope store %q: %v\n", storePath, cerr) //nolint:errcheck // dispatch outcome is preserved
+		}
+	}()
 
 	return runControlDispatcherWithStoreAndConfig(cityPath, storePath, store, beadID, cfg, stdout, stderr)
 }

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -172,14 +172,19 @@ func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, std
 	if err != nil {
 		return fmt.Errorf("opening scoped control store %q: %w", storePath, err)
 	}
-	// The whole dispatch below is synchronous — ProcessControl's closures
-	// (RecycleSession, MemberStores, EmitCurrent) all run before it returns and
-	// nothing retains store past this call — so releasing the scope handle we
-	// just opened at return is safe and stops leaking one bd/Dolt store (and its
-	// connections) per control bead processed by the serve loop. When the graph
-	// class relocated, the graph store is a different, process-shared value that
+	// The whole dispatch below is synchronous — ProcessControl consumes its
+	// store-bearing options (RecycleSession, MemberStores) before it returns, the
+	// caller's own EmitCurrent step runs inline after it, and nothing retains
+	// store past this call — so releasing the scope handle we just opened at
+	// return is safe and stops leaking one bd/Dolt store (and its connections)
+	// per control bead processed by the serve loop. When the graph class
+	// relocated, the graph store is a different, process-shared value that
 	// controlBeadLedger resolves separately; we close only store, the work leg we
-	// opened here.
+	// opened here. Sibling handles this pipeline opens elsewhere —
+	// findBeadScopeAcrossStores' scan stores, makeSourceWorkflowStoresLister's
+	// per-scope opens, and the makeStoreRefResolver handles walkSourceBeadChain
+	// memoizes — stay unclosed: a deliberate scope boundary for this targeted WAL
+	// fix, tracked in ga-6fur2, not an oversight.
 	defer func() {
 		if cerr := closeBeadStoreHandle(store); cerr != nil {
 			fmt.Fprintf(stderr, "warning: control dispatch: closing scope store %q: %v\n", storePath, cerr) //nolint:errcheck // dispatch outcome is preserved

--- a/cmd/gc/control_rig_graph_federation_test.go
+++ b/cmd/gc/control_rig_graph_federation_test.go
@@ -609,7 +609,7 @@ func TestControlReadyCacheSourcesRouteTheSameLegsAsTheFallback(t *testing.T) {
 		cityPath, rigPath, binding := rigFederationFixture(t, `[]`)
 		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
 
-		sources, err := controlReadyCacheSources(rigPath, cityPath, nil)
+		sources, owned, err := controlReadyCacheSources(rigPath, cityPath, nil)
 		if err != nil {
 			t.Fatalf("controlReadyCacheSources for a split rig scope: %v", err)
 		}
@@ -623,13 +623,23 @@ func TestControlReadyCacheSourcesRouteTheSameLegsAsTheFallback(t *testing.T) {
 		if !sameStorePtr(sources[1], binding) {
 			t.Errorf("cache leg[1] = %T, want the city graph binding; the beads a city molecule routed to this rig stay unread on the cached arm", sources[1])
 		}
+		// Only the scoped leg is owned; the process-shared binding must never be
+		// closed by the per-prime cleanup.
+		if len(owned) != 1 || !sameStorePtr(owned[0], sources[0]) {
+			t.Errorf("owned = %d leg(s), want exactly the scope's own store; the shared binding must not be in owned", len(owned))
+		}
+		for _, o := range owned {
+			if sameStorePtr(o, binding) {
+				t.Errorf("owned includes the shared graph binding; closing it would poison every later graph-class op")
+			}
+		}
 	})
 
 	t.Run("split city scope snapshots only the binding", func(t *testing.T) {
 		cityPath, _, binding := rigFederationFixture(t, `[]`)
 		seedCLIStorageRoutes(t, cityPath, messagingSplitRoutes(binding))
 
-		sources, err := controlReadyCacheSources(cityPath, cityPath, nil)
+		sources, owned, err := controlReadyCacheSources(cityPath, cityPath, nil)
 		if err != nil {
 			t.Fatalf("controlReadyCacheSources for a split city scope: %v", err)
 		}
@@ -637,13 +647,18 @@ func TestControlReadyCacheSourcesRouteTheSameLegsAsTheFallback(t *testing.T) {
 			t.Fatalf("cache sources for a split city scope = %d leg(s), want exactly the binding; "+
 				"unioning the work store back in re-offers the frozen copies the migration retained", len(sources))
 		}
+		// A relocated city reads only the shared binding, which this call did not
+		// open, so nothing is owned.
+		if len(owned) != 0 {
+			t.Errorf("owned = %d leg(s), want 0; the relocated-city arm reads only the process-shared binding", len(owned))
+		}
 	})
 
 	t.Run("single-store rig scope snapshots one store", func(t *testing.T) {
 		cityPath, rigPath, binding := rigFederationFixture(t, `[]`)
 		seedCLIStorageRoutes(t, cityPath, nil)
 
-		sources, err := controlReadyCacheSources(rigPath, cityPath, nil)
+		sources, owned, err := controlReadyCacheSources(rigPath, cityPath, nil)
 		if err != nil {
 			t.Fatalf("controlReadyCacheSources for a single-store rig scope: %v", err)
 		}
@@ -653,6 +668,10 @@ func TestControlReadyCacheSourcesRouteTheSameLegsAsTheFallback(t *testing.T) {
 		}
 		if sameStorePtr(sources[0], binding) {
 			t.Errorf("the single leg is the unrouted binding, want the scope's own store")
+		}
+		// The lone scoped leg is call-owned and must be closed after priming.
+		if len(owned) != 1 || !sameStorePtr(owned[0], sources[0]) {
+			t.Errorf("owned = %d leg(s), want exactly the scope's own store", len(owned))
 		}
 	})
 }

--- a/cmd/gc/dispatch_control_ready.go
+++ b/cmd/gc/dispatch_control_ready.go
@@ -415,8 +415,8 @@ var controlReadyCacheRegistry = struct {
 }{byDir: make(map[string]*controlReadyCacheEntry)}
 
 // controlReadyCacheEntry holds a primed snapshot per leg for one scope dir.
-// Its backing stores are closed the instant PrimeActive returns (see
-// controlReadyCachesFor), so an entry is a set of CLOSED-backing snapshots: it
+// Its backing stores are closed when controlReadyCachesFor returns, once every
+// leg has primed, so an entry is a set of CLOSED-backing snapshots: it
 // may only be read through CachingStore.CachedReady, which answers entirely from
 // the in-memory snapshot. Any read that would need to touch the backing must
 // decline to controlReadyFallbackReady instead of consulting a closed handle.
@@ -526,6 +526,13 @@ func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.Cach
 // in the process with ErrStoreClosed. Only the scoped leg
 // (openControlStoreAtForCity) is freshly constructed per call, so only it is
 // returned as owned.
+//
+// An error return must not hand back opened stores. controlReadyCachesFor
+// registers its closing defer only after this call succeeds, so a store opened
+// before an error return would have nothing to close it. Today the sole error
+// return IS the failed open, so nothing is open on that path; an arm added
+// later that can fail after a successful open must close what it opened before
+// returning. The same obligation binds any controlReadyCacheSourcesFn seam.
 func controlReadyCacheSources(dir, cityPath string, cfg *config.City) (sources, owned []beads.Store, err error) {
 	// A relocated CITY scope does not open its scope store at all — that would
 	// be a bd process this scan never reads. The binding is process-shared, so

--- a/cmd/gc/dispatch_control_ready.go
+++ b/cmd/gc/dispatch_control_ready.go
@@ -414,6 +414,12 @@ var controlReadyCacheRegistry = struct {
 	byDir map[string]*controlReadyCacheEntry
 }{byDir: make(map[string]*controlReadyCacheEntry)}
 
+// controlReadyCacheEntry holds a primed snapshot per leg for one scope dir.
+// Its backing stores are closed the instant PrimeActive returns (see
+// controlReadyCachesFor), so an entry is a set of CLOSED-backing snapshots: it
+// may only be read through CachingStore.CachedReady, which answers entirely from
+// the in-memory snapshot. Any read that would need to touch the backing must
+// decline to controlReadyFallbackReady instead of consulting a closed handle.
 type controlReadyCacheEntry struct {
 	caches   []*beads.CachingStore
 	primedAt time.Time
@@ -453,7 +459,11 @@ type controlReadyCacheEntry struct {
 // common (e.g. a restart handoff window), but the control-dispatcher serve
 // loop's typical call pattern is sequential-per-tick per dir. Note the entries
 // are keyed by scope dir, so on a split city every rig dispatcher primes the
-// shared city binding independently (ga-n6gnr).
+// shared city binding independently (ga-n6gnr). That race stays safe under the
+// per-prime close below: each caller closes only the scoped backing IT opened,
+// and the registry loser's CachingStores are pure in-memory snapshots
+// (CachedReady never touches a backing), so an overwritten entry is never a
+// use-after-close.
 func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.CachingStore {
 	controlReadyCacheRegistry.mu.Lock()
 	entry, ok := controlReadyCacheRegistry.byDir[dir]
@@ -463,10 +473,29 @@ func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.Cach
 		return entry.caches
 	}
 
-	sources, err := controlReadyCacheSources(dir, cityPath, cfg)
+	sources, owned, err := controlReadyCacheSourcesFn(dir, cityPath, cfg)
 	if err != nil {
 		return nil
 	}
+	// Release the scoped backing handles the instant the snapshot is fully in
+	// memory. NewCachingStore is passive here (nil onChange, StartReconciler is
+	// never called) and CachedReady serves entirely from the primed in-memory
+	// snapshot without touching the backing, so the backing only has to be open
+	// for the PrimeActive scan itself. Closing it per prime keeps each prime's
+	// read mark on the shared graph binding's WAL short-lived instead of held by
+	// a leaked handle until *sql.DB GC-finalize -- the leak that let the WAL grow
+	// unbounded because a passive checkpoint can never truncate past a live read
+	// mark. This defer fires on BOTH the prime-failure early return and the
+	// success path, so a prime that fails partway still closes whatever it
+	// opened. Only owned legs are closed; the graph binding is process-shared
+	// (see controlReadyCacheSources).
+	defer func() {
+		for _, s := range owned {
+			if err := closeBeadStoreHandle(s); err != nil {
+				log.Printf("control-ready cache: closing primed scope store for %s: %v", dir, err)
+			}
+		}
+	}()
 	caches := make([]*beads.CachingStore, 0, len(sources))
 	for _, source := range sources {
 		cs := beads.NewCachingStore(source, nil)
@@ -486,21 +515,38 @@ func controlReadyCachesFor(dir, cityPath string, cfg *config.City) []*beads.Cach
 // controlReadyCacheSources returns the ordered ledgers to snapshot, applying the
 // same routing rule as controlReadyFallbackReady so the cached answer and the
 // fallback answer cannot disagree about which stores hold this scope's queue.
-func controlReadyCacheSources(dir, cityPath string, cfg *config.City) ([]beads.Store, error) {
+//
+// owned is the subset of sources this call constructed and is therefore
+// responsible for closing once the snapshot has been primed into memory. It is
+// deliberately NOT every source. The graph-class binding legs
+// (controlGraphBinding / controlGraphExtraLeg) resolve through the per-city
+// cliStorageRoutes memo, so the binding store is process-shared and closed only
+// by closeCLIStorageRoutes at process exit; CloseStore is a one-way latch, so
+// closing a binding leg here would poison every later graph-class read and write
+// in the process with ErrStoreClosed. Only the scoped leg
+// (openControlStoreAtForCity) is freshly constructed per call, so only it is
+// returned as owned.
+func controlReadyCacheSources(dir, cityPath string, cfg *config.City) (sources, owned []beads.Store, err error) {
 	// A relocated CITY scope does not open its scope store at all — that would
-	// be a bd process this scan never reads.
+	// be a bd process this scan never reads. The binding is process-shared, so
+	// nothing here owns it.
 	if binding, relocated := controlGraphBinding(cityPath, dir); relocated {
-		return []beads.Store{binding}, nil
+		return []beads.Store{binding}, nil, nil
 	}
 	scoped, err := openControlStoreAtForCity(dir, cityPath, cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if binding, federated := controlGraphExtraLeg(cityPath, dir); federated {
-		return []beads.Store{scoped, binding}, nil
+		return []beads.Store{scoped, binding}, []beads.Store{scoped}, nil
 	}
-	return []beads.Store{scoped}, nil
+	return []beads.Store{scoped}, []beads.Store{scoped}, nil
 }
+
+// controlReadyCacheSourcesFn is the test seam for controlReadyCacheSources,
+// following the package's own var-seam idiom (cf. controlDispatcherServe,
+// dispatch_runtime.go). Production always uses controlReadyCacheSources.
+var controlReadyCacheSourcesFn = controlReadyCacheSources
 
 // cachedControlReadyUnion merges the cached ready sets, requiring EVERY leg to
 // answer from cache. A leg that is dirty or still priming sends the whole scan

--- a/cmd/gc/dispatch_control_ready_leak_test.go
+++ b/cmd/gc/dispatch_control_ready_leak_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -239,5 +241,59 @@ func TestRunControlDispatcherInStoreClosesScopeStoreOnError(t *testing.T) {
 	}
 	if got := fake.closes(); got != 1 {
 		t.Fatalf("scope store closed %d times, want 1: the dispatch error path must not leak the opened store", got)
+	}
+}
+
+// TestRunControlDispatcherInStoreClosesScopeStoreOnSuccess pins the same leak
+// site on the path the serve loop actually takes. Both paths share one
+// unconditional defer today, so the error-path sibling above would stay green
+// under a restructure that closed only inside the error branch — while every
+// successful dispatch leaked a store again, which is the per-bead leak this
+// file exists to prevent.
+func TestRunControlDispatcherInStoreClosesScopeStoreOnSuccess(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	fake := newCloseCountingStore(t, false)
+	// An orphaned scope-check is the cheapest control bead that dispatches all
+	// the way to a processed result: gc.root_bead_id names a root the store
+	// does not hold, so ProcessControl closes the control bead and reports
+	// Processed without an error, and scope-check needs no city-config
+	// resolution. Status is forced to "open" by Create, which is what keeps
+	// this off ProcessControl's not-open skip.
+	control, err := fake.Create(beads.Bead{
+		Type: "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:         beadmeta.KindScopeCheck,
+			beadmeta.RootBeadIDMetadataKey:   "ga-missing-root",
+			beadmeta.RootStoreRefMetadataKey: "city:test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed control bead: %v", err)
+	}
+
+	prev := openControlStoreForDispatch
+	openControlStoreForDispatch = func(_, _ string, _ *config.City) (beads.Store, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { openControlStoreForDispatch = prev })
+
+	var stdout, stderr bytes.Buffer
+	if err := runControlDispatcherInStore(cityDir, cityDir, control.ID, &stdout, &stderr); err != nil {
+		t.Fatalf("runControlDispatcherInStore: %v (stderr=%q)", err, stderr.String())
+	}
+	// Assert the dispatch actually reached the processed branch. Without this
+	// the test would still pass if the bead stopped qualifying and ProcessControl
+	// returned a nil error from an early skip, which would silently stop
+	// covering the success path it is named for.
+	if !strings.Contains(stdout.String(), "action=orphaned-workflow") {
+		t.Fatalf("stdout = %q, want a processed control dispatch (stderr=%q)", stdout.String(), stderr.String())
+	}
+	if got := fake.closes(); got != 1 {
+		t.Fatalf("scope store closed %d times, want 1: the dispatch success path must not leak the opened store", got)
 	}
 }

--- a/cmd/gc/dispatch_control_ready_leak_test.go
+++ b/cmd/gc/dispatch_control_ready_leak_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// closeCountingStore is a beads.Store that counts CloseStore calls and poisons
+// its read methods after close, so a test can prove (a) how many times a handle
+// was closed and (b) that CachedReady never touches the backing once the
+// snapshot is in memory. It embeds *beads.MemStore so PrimeActive's list/dep
+// scan behaves like a real in-memory store during priming.
+type closeCountingStore struct {
+	*beads.MemStore
+	closeCount  atomic.Int64
+	closed      atomic.Bool
+	getNotFound bool // when true, Get always answers ErrNotFound (dispatch error path)
+}
+
+func newCloseCountingStore(t *testing.T, seedReady bool) *closeCountingStore {
+	t.Helper()
+	mem := beads.NewMemStore()
+	if seedReady {
+		if _, err := mem.Create(beads.Bead{Type: "task", Assignee: "control-dispatcher"}); err != nil {
+			t.Fatalf("seed ready bead: %v", err)
+		}
+	}
+	return &closeCountingStore{MemStore: mem}
+}
+
+func (s *closeCountingStore) CloseStore() error { //nolint:unparam // must satisfy the CloseStore() error store interface closeBeadStoreHandle asserts
+	s.closeCount.Add(1)
+	s.closed.Store(true)
+	return nil
+}
+
+func (s *closeCountingStore) closes() int64 { return s.closeCount.Load() }
+
+// List poisons after close so a stray read from a closed handle surfaces loudly.
+func (s *closeCountingStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if s.closed.Load() {
+		return nil, fmt.Errorf("closeCountingStore.List called after CloseStore (use-after-close)")
+	}
+	return s.MemStore.List(q)
+}
+
+// Get either forces the not-found dispatch path or poisons after close.
+func (s *closeCountingStore) Get(id string) (beads.Bead, error) {
+	if s.getNotFound {
+		return beads.Bead{}, beads.ErrNotFound
+	}
+	if s.closed.Load() {
+		return beads.Bead{}, fmt.Errorf("closeCountingStore.Get called after CloseStore (use-after-close)")
+	}
+	return s.MemStore.Get(id)
+}
+
+// forceControlReadyCacheStale rewinds a scope's primed timestamp past the TTL so
+// the next controlReadyCachesFor call re-primes instead of reusing the entry --
+// no clock seam needed.
+func forceControlReadyCacheStale(t *testing.T, dir string) {
+	t.Helper()
+	controlReadyCacheRegistry.mu.Lock()
+	defer controlReadyCacheRegistry.mu.Unlock()
+	entry, ok := controlReadyCacheRegistry.byDir[dir]
+	if !ok {
+		t.Fatalf("forceControlReadyCacheStale: no cache entry for %q", dir)
+	}
+	entry.primedAt = entry.primedAt.Add(-2 * controlReadyCacheTTL)
+}
+
+// installControlReadyCacheSourcesFn swaps the source seam for the duration of a
+// test and drops the scope's registry entry on cleanup so the global registry
+// never leaks fixtures across tests.
+func installControlReadyCacheSourcesFn(t *testing.T, dir string, fn func(dir, cityPath string, cfg *config.City) (sources, owned []beads.Store, err error)) {
+	t.Helper()
+	prev := controlReadyCacheSourcesFn
+	controlReadyCacheSourcesFn = fn
+	t.Cleanup(func() {
+		controlReadyCacheSourcesFn = prev
+		controlReadyCacheRegistry.mu.Lock()
+		delete(controlReadyCacheRegistry.byDir, dir)
+		controlReadyCacheRegistry.mu.Unlock()
+	})
+}
+
+// TestControlReadyCachesForClosesOwnedSourcesPerPrime is the regression pin for
+// the WAL-starvation leak: every TTL-stale re-prime must release the scoped
+// backing it opened, and the primed snapshot must keep answering afterward.
+func TestControlReadyCachesForClosesOwnedSourcesPerPrime(t *testing.T) {
+	dir := t.TempDir()
+
+	var mu sync.Mutex
+	var minted []*closeCountingStore
+	installControlReadyCacheSourcesFn(t, dir, func(_, _ string, _ *config.City) ([]beads.Store, []beads.Store, error) {
+		f := newCloseCountingStore(t, true)
+		mu.Lock()
+		minted = append(minted, f)
+		mu.Unlock()
+		return []beads.Store{f}, []beads.Store{f}, nil
+	})
+
+	const primes = 3
+	var caches []*beads.CachingStore
+	for i := 0; i < primes; i++ {
+		caches = controlReadyCachesFor(dir, dir, nil)
+		if len(caches) != 1 {
+			t.Fatalf("prime %d: controlReadyCachesFor returned %d caches, want 1", i, len(caches))
+		}
+		forceControlReadyCacheStale(t, dir)
+	}
+
+	mu.Lock()
+	opens := int64(len(minted))
+	var closes int64
+	for _, f := range minted {
+		closes += f.closes()
+	}
+	mu.Unlock()
+
+	if opens != primes {
+		t.Fatalf("opens = %d, want %d (each stale re-prime opens a fresh scoped store)", opens, primes)
+	}
+	// The leak fix must bound live handles: opens minus closes is the count of
+	// still-open backings, and the fix closes each per prime, so it is 0 here and
+	// must never exceed 1. On the pre-fix base closes == 0, so opens-closes == 3.
+	if opens-closes > 1 {
+		t.Fatalf("opens-closes = %d (opens=%d closes=%d), want <= 1: scoped backings are leaking", opens-closes, opens, closes)
+	}
+
+	// The last prime's snapshot must still answer from memory even though its
+	// backing was closed -- the poisoned fake proves CachedReady never touched it.
+	if _, ok := cachedControlReadyUnion(caches); !ok {
+		t.Fatal("cachedControlReadyUnion reported unavailable after the backing was closed; CachedReady must serve from the in-memory snapshot")
+	}
+}
+
+// TestControlReadyCachesForNeverClosesSharedBindingLeg pins the ownership
+// boundary: the process-shared graph binding must never be closed by the cache
+// prime, only the scoped leg this call opened.
+func TestControlReadyCachesForNeverClosesSharedBindingLeg(t *testing.T) {
+	dir := t.TempDir()
+
+	shared := newCloseCountingStore(t, false)
+	var mu sync.Mutex
+	var ownedMinted []*closeCountingStore
+	installControlReadyCacheSourcesFn(t, dir, func(_, _ string, _ *config.City) ([]beads.Store, []beads.Store, error) {
+		owned := newCloseCountingStore(t, true)
+		mu.Lock()
+		ownedMinted = append(ownedMinted, owned)
+		mu.Unlock()
+		// sources = {owned scoped leg, shared binding leg}; owned = {scoped leg}.
+		return []beads.Store{owned, shared}, []beads.Store{owned}, nil
+	})
+
+	const primes = 3
+	for i := 0; i < primes; i++ {
+		if got := controlReadyCachesFor(dir, dir, nil); len(got) != 2 {
+			t.Fatalf("prime %d: got %d caches, want 2 (scoped + binding legs)", i, len(got))
+		}
+		forceControlReadyCacheStale(t, dir)
+	}
+
+	if got := shared.closes(); got != 0 {
+		t.Fatalf("shared binding leg closed %d times, want 0: closing the process-shared binding poisons every later graph-class op", got)
+	}
+	mu.Lock()
+	var ownedCloses int64
+	for _, f := range ownedMinted {
+		ownedCloses += f.closes()
+	}
+	ownedOpens := int64(len(ownedMinted))
+	mu.Unlock()
+	if ownedCloses != ownedOpens {
+		t.Fatalf("owned scoped legs: closes = %d, want %d (one per prime)", ownedCloses, ownedOpens)
+	}
+}
+
+// TestControlReadyCachesForClosesOwnedSourcesOnPrimeFailure covers the
+// prime-failure early return: a source that cannot prime must still have its
+// opened backing closed rather than leaked.
+func TestControlReadyCachesForClosesOwnedSourcesOnPrimeFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	failing := &primeFailingStore{closeCountingStore: newCloseCountingStore(t, false)}
+	installControlReadyCacheSourcesFn(t, dir, func(_, _ string, _ *config.City) ([]beads.Store, []beads.Store, error) {
+		return []beads.Store{failing}, []beads.Store{failing}, nil
+	})
+
+	if got := controlReadyCachesFor(dir, dir, nil); got != nil {
+		t.Fatalf("controlReadyCachesFor = %v, want nil when a leg fails to prime", got)
+	}
+	if got := failing.closes(); got != 1 {
+		t.Fatalf("failing scoped leg closed %d times, want 1: the prime-failure early return must not leak the opened handle", got)
+	}
+}
+
+// primeFailingStore fails every List so CachingStore.PrimeActive returns an
+// error, exercising controlReadyCachesFor's early-return path.
+type primeFailingStore struct {
+	*closeCountingStore
+}
+
+func (s *primeFailingStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
+	return nil, fmt.Errorf("primeFailingStore: list unavailable")
+}
+
+// TestRunControlDispatcherInStoreClosesScopeStoreOnError pins the second leak
+// site: runControlDispatcherInStore must close the scope store it opened even
+// when the dispatch fails before completing.
+func TestRunControlDispatcherInStoreClosesScopeStoreOnError(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	fake := newCloseCountingStore(t, false)
+	fake.getNotFound = true // controlBeadLedger.Get -> ErrNotFound -> dispatch returns an error
+
+	prev := openControlStoreForDispatch
+	openControlStoreForDispatch = func(_, _ string, _ *config.City) (beads.Store, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { openControlStoreForDispatch = prev })
+
+	var stdout, stderr bytes.Buffer
+	err := runControlDispatcherInStore(cityDir, cityDir, "ga-missing-control", &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("runControlDispatcherInStore: err = nil, want an error for a missing control bead (stderr=%q)", stderr.String())
+	}
+	if got := fake.closes(); got != 1 {
+		t.Fatalf("scope store closed %d times, want 1: the dispatch error path must not leak the opened store", got)
+	}
+}


### PR DESCRIPTION
## Summary

The control-ready cache leaks bead-store handles, so the graph store's SQLite WAL never checkpoint-truncates and grows unbounded — observed live at **875 MB WAL vs 483 MB DB** on maintainer-city, which pushed each federated `gc ready` leg past `hookWorkQueryTimeout` (>120 s) and **starved every rig-scoped work-query** (seats' `gc hook --claim` timed out → `work_query_failed` → claims never landed → adopt-pr flow and PM/reviewer claims frozen for ~10 h).

## Root cause (proven)

`controlReadyCachesFor` (`cmd/gc/dispatch_control_ready.go`): whenever the cached ready snapshot is older than the 3 s TTL — i.e. essentially every idle poll across a `--serve` loop's life — it re-opens **fresh** backing `SQLiteStore`s, `PrimeActive()`s them (a read transaction held over a full ~500 MB active scan), and **overwrites the registry entry without ever `CloseStore()`-ing the previous one**. With multiple long-lived `convoy control --serve` loops re-priming every ~3 s, overlapping read-marks mean the WAL's checkpoint/reset window never opens, so it appends past the oldest mark unbounded. The leaked, un-closed stores make it worse: dropped connections only release on `*sql.DB` GC-finalize (write conn has `SetMaxOpenConns(1)` and no `ConnMaxIdleTime`). Second site: `runControlDispatcherInStore` (`cmd/gc/cmd_convoy_dispatch.go`) opens a store per control bead and never closes it.

## Fix

Release the read snapshot per iteration: `CloseStore()` each backing store immediately after `PrimeActive()` succeeds in `controlReadyCachesFor`, and `defer store.CloseStore()` in `runControlDispatcherInStore`. These `CachingStore`s are passive snapshots (`nil` onChange, `StartReconciler` never called, `CachedReady()` serves from the in-memory snapshot without touching the backing after prime), so closing the backing immediately is safe — no use-after-close, no change to the serve loop's wake/event semantics.

Note: `CloseStore` is a no-op for plain `*BdStore` legs (bd/doltlite provider path); it releases real handles for `SQLiteStore`/`DoltliteReadStore`/`NativeDoltStore` legs — which is the store type of the graph store that bloated here (verified: the 875 MB WAL truncated to 0 on that SQLite leg).

## Test

New `dispatch_control_ready_leak_test.go`: injects fake sources counting Open vs CloseStore, forces the entry stale N times, asserts `opens − closes ≤ 1`. Fails on base (closes==0), passes with the fix. Reviewed by a Fable council (correctness / use-after-close / minimality) — sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #6156 — touches the same per-TTL re-prime path in controlReadyCachesFor/controlReadyCacheSources, releasing the scoped store handle right after PrimeActive so it no longer leaks; it does not change the bd-vs-native store selection or the re-prime frequency, so the per-prime bd forking described in that issue is untouched and still open

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->