### PR TITLE
test(pathutil): resolve want path in symlinked-ancestor test

### DIFF
--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -103,13 +103,23 @@ func TestResolveNearestExistingAncestorSymlinkedAncestor(t *testing.T) {
 	if err := os.Symlink(realParent, linkParent); err != nil {
 		t.Skip("symlinks not supported")
 	}
+	// Resolve realParent as well, the way the missing-leaf case above does.
+	// ResolveNearestExistingAncestor resolves the whole ancestor path, not
+	// just the link-parent component, and t.TempDir() can itself sit under a
+	// symlinked prefix — on macOS it returns /var/folders/... while /var is a
+	// symlink to /private/var. Building want from the unresolved realParent
+	// therefore compares a resolved path against an unresolved one.
+	resolvedRealParent, err := filepath.EvalSymlinks(realParent)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	target := filepath.Join(linkParent, "missing", "gc-home")
 	got, err := ResolveNearestExistingAncestor(target)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join(realParent, "missing", "gc-home")
+	want := filepath.Join(resolvedRealParent, "missing", "gc-home")
 	if got != want {
 		t.Fatalf("ResolveNearestExistingAncestor(%q) = %q, want %q", target, got, want)
 	}


### PR DESCRIPTION
## What this changes

`TestResolveNearestExistingAncestorSymlinkedAncestor` built its expected path
from the **unresolved** `t.TempDir()` root, then compared it against
`ResolveNearestExistingAncestor`, which resolves the **entire** ancestor path.

On macOS `t.TempDir()` returns `/var/folders/...` while `/var` is itself a
symlink to `/private/var`, so the two sides differed by that prefix:

```
got  /private/var/folders/.../real-parent/missing/gc-home
want /var/folders/.../real-parent/missing/gc-home
```

This is a test-only change. `want` is now built from the resolved parent,
matching the idiom the sibling `TestResolveNearestExistingAncestorMissingLeaf`
already uses two functions above.

## Why the helper is not the thing to change

`ResolveNearestExistingAncestor` returning the fully-resolved form is correct
and load-bearing. `symlinkAwareContainment` in `cmd/gc/api_state.go` compares
its output against `filepath.EvalSymlinks(cityPath)` — also fully resolved — to
decide whether a rig path escapes the city root. Collapsing the darwin alias
inside the helper would make those two sides disagree on macOS and weaken that
containment check.

The alias collapse belongs one layer up, in `NormalizePathForCompare`, where
`canonicalizePlatformPathAlias` already does it and
`TestNormalizePathForCompareCollapsesDarwinPrivateVarAlias` pins it.

## Impact

The test landed in #6247, whose own `Mac / make test` job was **skipped**, so it
never ran on macOS before merge. Since then every Mac Regression run that
actually executes that job has failed on this single test — five failing runs
across unrelated branches at the time of writing, against two different `main`
bases. Runs that appear green skipped the job. `Mac Regression` also runs
nightly and is called by `RC Gate`.

## Test plan

- [x] Reproduced the macOS failure **on Linux** by pointing `GOTMPDIR` at a
      symlinked directory, which reproduces the macOS shape (`t.TempDir()`
      returns a path whose prefix is a symlink). The test fails identically
      before this change and passes after.
- [x] `go test ./internal/pathutil/` passes with and without the symlinked
      `GOTMPDIR`.
- [x] Pre-commit: `lint-changed ./internal/pathutil` reports 0 issues;
      `go vet ./...` clean.
- [x] Pre-push `scripts/test-local-parallel fast` — all 10 jobs passed.

Found while investigating ga-nwa90w (a red `Mac / make test` on an unrelated
deploy PR, whose diff could not have touched `internal/pathutil`).
