### PR TITLE
fix(reconciler): drain_acked_with_assigned_work fires only for genuinely-claimable strands (kill the demand-counter false positives without silencing a real strand)

### DIFF
--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -577,6 +577,92 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 	}
 }
 
+// TestFirstOpenClaimableAssignedWorkBeadFederatesAcrossReachableStores is the
+// cross-store regression for the drain-ack classifier's OPEN arm. Like its
+// in_progress peer it must federate across every reachable leg for a city-scoped
+// session (vp-kvp) — and because this arm SUPPRESSES provably-non-claimable rows,
+// a suppressed row on one leg must never mask a genuine strand on another.
+//
+// Each case parks a deferred row on one store and the claimable strand on the
+// other. The resolved plan visits the leading city store (Authority) before the
+// rig federation tail, so the first case is the suppressed-row-first direction
+// and the second is the control that the tail is not preferred; if that order
+// ever flips the two simply swap roles and both assertions still hold.
+//
+// The strand is identified by TITLE, not ID: each MemStore mints its own "gc-N"
+// sequence, so the two stores' first rows share an ID and an ID assertion here
+// would pass no matter which store answered.
+func TestFirstOpenClaimableAssignedWorkBeadFederatesAcrossReachableStores(t *testing.T) {
+	session := beads.Bead{
+		ID:     "session-1",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":     "auditor",
+			"session_name": "auditor-session",
+		},
+	}
+	for _, tc := range []struct {
+		name        string
+		strandInRig bool
+	}{
+		{name: "strand in rig store, deferred row in city store", strandInRig: true},
+		{name: "strand in city store, deferred row in rig store", strandInRig: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			rigPath := filepath.Join(cityPath, "riga")
+			cfg := &config.City{
+				Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+				Agents: []config.Agent{{
+					Name:  "auditor",
+					Scope: "city",
+				}},
+			}
+			cityStore := beads.NewMemStore()
+			rigStore := beads.NewMemStore()
+			rigStores := map[string]beads.Store{"riga": rigStore}
+
+			strandStore, deferredStore := rigStore, beads.Store(cityStore)
+			if !tc.strandInRig {
+				strandStore, deferredStore = cityStore, rigStore
+			}
+			// A FROZEN instant, threaded into the finder: the open arm's deferral
+			// evaluation takes its `now` from the caller, so the boundary this row
+			// sits on is fixed by the test rather than by whatever wall clock the
+			// suite happens to run at.
+			now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+			deferUntil := now.Add(time.Hour)
+			if _, err := deferredStore.Create(beads.Bead{
+				Title:      "deferred row",
+				Type:       "task",
+				Status:     "open",
+				Assignee:   session.ID,
+				DeferUntil: &deferUntil,
+			}); err != nil {
+				t.Fatalf("Create deferred work: %v", err)
+			}
+			strand, err := strandStore.Create(beads.Bead{
+				Title:    "claimable strand",
+				Type:     "task",
+				Status:   "open",
+				Assignee: session.ID,
+			})
+			if err != nil {
+				t.Fatalf("Create strand: %v", err)
+			}
+
+			bead, found, err := firstOpenClaimableAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session), now)
+			if err != nil {
+				t.Fatalf("firstOpenClaimableAssignedWorkBeadForReachableStore: %v", err)
+			}
+			if !found || bead.Title != strand.Title {
+				t.Fatalf("open-arm lookup must federate across stores and look past the deferred row; found=%v bead=%q want=%q", found, bead.Title, strand.Title)
+			}
+		})
+	}
+}
+
 func TestSessionHasOpenAssignedWorkMatchesConfiguredNamedSessionRuntimeFallback(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -558,9 +558,12 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 		t.Fatal("city-scoped session's in-progress rig-store work must keep it awake (recycle guard)")
 	}
 
-	bead, found, err := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session))
+	// The stranded in_progress walk resolves the same cross-store reachability; with
+	// no other live incarnation carrying the session's identity, the rig-store row is
+	// a genuine strand it must find.
+	bead, found, err := firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session), buildLiveSessionOwnerSet(nil, cfg, nil))
 	if err != nil {
-		t.Fatalf("firstOpenAssignedWorkBeadForReachableStore: %v", err)
+		t.Fatalf("firstStrandedInProgressAssignedWorkBeadForReachableStore: %v", err)
 	}
 	if !found || bead.ID != rigWork.ID {
 		t.Fatalf("stranded-bead lookup must find rig-store work for a city-scoped session; found=%v bead=%q want=%q", found, bead.ID, rigWork.ID)
@@ -575,13 +578,12 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 	}
 }
 
-// TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand pins finding #2: the
-// in_progress owner-liveness walk must run across EVERY reachable leg so a benign
-// in_progress row a live sibling owns in an earlier leg cannot mask a genuine
-// strand in a later leg. The single-result finder (firstOpenAssignedWorkBeadFor-
-// ReachableStore) stops at the first leg with any match, so the classifier that
-// inspected its one result would see the benign row and miss the strand. The
-// dedicated walk skips owner-live rows and keeps going.
+// TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand pins the cross-leg
+// masking guard: the in_progress owner-liveness walk must run across EVERY
+// reachable leg so a benign in_progress row a runtime-alive sibling owns in an
+// earlier leg cannot mask a genuine strand in a later leg. The per-leg probe
+// returns found=false for a leg holding only owned rows, so the walk skips the
+// benign city row and keeps going to find the strand in the rig leg.
 func TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "riga")
@@ -619,9 +621,12 @@ func TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand(t *testing.T) {
 	}
 	draining := sessiontest.SeedBead(t, drainingBead)
 	sibling := sessiontest.SeedBead(t, siblingBead)
-	// The draining seat AND a distinctly-named LIVE sibling both carry the pool
-	// alias; only the draining seat carries its own bead ID.
-	liveOwners := buildLiveSessionOwnerSet([]sessionpkg.Info{draining, sibling}, cfg)
+	// The draining seat AND a distinctly-named sibling both carry the pool alias;
+	// only the draining seat carries its own bead ID. The runtime probe reports the
+	// sibling positively alive, so the benign city row it owns is skipped.
+	liveOwners := buildLiveSessionOwnerSet([]sessionpkg.Info{draining, sibling}, cfg, func(info sessionpkg.Info) bool {
+		return info.ID == sibling.ID
+	})
 
 	// City leg: an in_progress row on the shared pool alias — a LIVE sibling owns
 	// it, so it is benign and must be walked past.
@@ -643,17 +648,8 @@ func TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand(t *testing.T) {
 		t.Fatalf("mark strand in_progress: %v", err)
 	}
 
-	// The single-result finder stops at the first leg with any match: it returns
-	// the benign city row and would let it mask the strand.
-	first, foundFirst, err := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, draining)
-	if err != nil {
-		t.Fatalf("firstOpenAssignedWorkBeadForReachableStore: %v", err)
-	}
-	if !foundFirst || first.ID != benign.ID {
-		t.Fatalf("single-result finder = (%v, %q), want the benign city row %q first (leg ordering assumption for this masking test)", foundFirst, first.ID, benign.ID)
-	}
-
-	// The dedicated owner-liveness walk skips the benign row and finds the strand.
+	// The owner-liveness walk skips the benign runtime-alive-sibling row in the
+	// city leg and finds the genuine strand in the rig leg.
 	got, found, err := firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, draining, liveOwners)
 	if err != nil {
 		t.Fatalf("firstStrandedInProgressAssignedWorkBeadForReachableStore: %v", err)
@@ -887,7 +883,7 @@ func TestSessionHasOpenAssignedWorkIncludesReachableAssignedWisp(t *testing.T) {
 	}
 }
 
-func TestFirstOpenAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
+func TestFirstStrandedInProgressAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
 	store := beads.NewMemStore()
 	wisp, err := store.Create(beads.Bead{
 		Title:     "active workflow step",
@@ -903,9 +899,11 @@ func TestFirstOpenAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
 		t.Fatalf("mark wisp in progress: %v", err)
 	}
 
-	got, found, err := firstOpenAssignedWorkBeadInStoreByIdentifiers(store, []string{"worker-session"})
+	// No live incarnation carries "worker-session", so the in_progress wisp is a
+	// genuine strand the finder must surface for session diagnostics.
+	got, found, err := firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(store, []string{"worker-session"}, "session-self", buildLiveSessionOwnerSet(nil, nil, nil))
 	if err != nil {
-		t.Fatalf("firstOpenAssignedWorkBeadInStoreByIdentifiers: %v", err)
+		t.Fatalf("firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers: %v", err)
 	}
 	if !found {
 		t.Fatal("assigned wisp work should be found for session diagnostics")

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -575,6 +575,94 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 	}
 }
 
+// TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand pins finding #2: the
+// in_progress owner-liveness walk must run across EVERY reachable leg so a benign
+// in_progress row a live sibling owns in an earlier leg cannot mask a genuine
+// strand in a later leg. The single-result finder (firstOpenAssignedWorkBeadFor-
+// ReachableStore) stops at the first leg with any match, so the classifier that
+// inspected its one result would see the benign row and miss the strand. The
+// dedicated walk skips owner-live rows and keeps going.
+func TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	const poolAlias = "riga/worker"
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:  "worker",
+			Scope: "city",
+		}},
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"riga": rigStore}
+
+	drainingBead := beads.Bead{
+		ID:     "session-draining",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":                   "worker",
+			"session_name":               "worker-1",
+			namedSessionIdentityMetadata: poolAlias,
+		},
+	}
+	siblingBead := beads.Bead{
+		ID:     "session-sibling",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":                   "worker",
+			"session_name":               "worker-2",
+			namedSessionIdentityMetadata: poolAlias,
+		},
+	}
+	draining := sessiontest.SeedBead(t, drainingBead)
+	sibling := sessiontest.SeedBead(t, siblingBead)
+	// The draining seat AND a distinctly-named LIVE sibling both carry the pool
+	// alias; only the draining seat carries its own bead ID.
+	liveOwners := buildLiveSessionOwnerSet([]sessionpkg.Info{draining, sibling}, cfg)
+
+	// City leg: an in_progress row on the shared pool alias — a LIVE sibling owns
+	// it, so it is benign and must be walked past.
+	benign, err := cityStore.Create(beads.Bead{Type: "task", Assignee: poolAlias})
+	if err != nil {
+		t.Fatalf("Create(benign): %v", err)
+	}
+	inProgress := "in_progress"
+	if err := cityStore.Update(benign.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark benign in_progress: %v", err)
+	}
+	// Rig leg: an in_progress row on the draining seat's OWN bead ID — no live
+	// incarnation but the draining seat itself owns it, so it is a genuine strand.
+	strand, err := rigStore.Create(beads.Bead{Type: "task", Assignee: drainingBead.ID})
+	if err != nil {
+		t.Fatalf("Create(strand): %v", err)
+	}
+	if err := rigStore.Update(strand.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark strand in_progress: %v", err)
+	}
+
+	// The single-result finder stops at the first leg with any match: it returns
+	// the benign city row and would let it mask the strand.
+	first, foundFirst, err := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, draining)
+	if err != nil {
+		t.Fatalf("firstOpenAssignedWorkBeadForReachableStore: %v", err)
+	}
+	if !foundFirst || first.ID != benign.ID {
+		t.Fatalf("single-result finder = (%v, %q), want the benign city row %q first (leg ordering assumption for this masking test)", foundFirst, first.ID, benign.ID)
+	}
+
+	// The dedicated owner-liveness walk skips the benign row and finds the strand.
+	got, found, err := firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, draining, liveOwners)
+	if err != nil {
+		t.Fatalf("firstStrandedInProgressAssignedWorkBeadForReachableStore: %v", err)
+	}
+	if !found || got.ID != strand.ID {
+		t.Fatalf("stranded walk = (%v, %q), want the genuine later-leg strand %q — a benign live-sibling row must not mask it", found, got.ID, strand.ID)
+	}
+}
+
 func TestSessionHasOpenAssignedWorkMatchesConfiguredNamedSessionRuntimeFallback(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -558,15 +558,14 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 		t.Fatal("city-scoped session's in-progress rig-store work must keep it awake (recycle guard)")
 	}
 
-	// The stranded in_progress walk resolves the same cross-store reachability; with
-	// no other live incarnation carrying the session's identity, the rig-store row is
-	// a genuine strand it must find.
-	bead, found, err := firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session), buildLiveSessionOwnerSet(nil, cfg, nil))
+	// The in_progress arm resolves the same cross-store reachability, so a
+	// city-scoped session's in_progress rig-store row is found across legs.
+	bead, found, err := firstInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session))
 	if err != nil {
-		t.Fatalf("firstStrandedInProgressAssignedWorkBeadForReachableStore: %v", err)
+		t.Fatalf("firstInProgressAssignedWorkBeadForReachableStore: %v", err)
 	}
 	if !found || bead.ID != rigWork.ID {
-		t.Fatalf("stranded-bead lookup must find rig-store work for a city-scoped session; found=%v bead=%q want=%q", found, bead.ID, rigWork.ID)
+		t.Fatalf("in_progress lookup must find rig-store work for a city-scoped session; found=%v bead=%q want=%q", found, bead.ID, rigWork.ID)
 	}
 
 	stranded, err := collectSessionAssignedWorkInfo(cityPath, cfg, cityStore, rigStores, sessiontest.SeedBead(t, session))
@@ -575,87 +574,6 @@ func TestSessionAssignedWorkGuardsFederateForCityScopedSession(t *testing.T) {
 	}
 	if len(stranded) != 1 || stranded[0].bead.ID != rigWork.ID {
 		t.Fatalf("stranded-work collector must include rig-store work for a city-scoped session; got %#v", stranded)
-	}
-}
-
-// TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand pins the cross-leg
-// masking guard: the in_progress owner-liveness walk must run across EVERY
-// reachable leg so a benign in_progress row a runtime-alive sibling owns in an
-// earlier leg cannot mask a genuine strand in a later leg. The per-leg probe
-// returns found=false for a leg holding only owned rows, so the walk skips the
-// benign city row and keeps going to find the strand in the rig leg.
-func TestFirstStrandedInProgressWalkDoesNotMaskLaterLegStrand(t *testing.T) {
-	cityPath := t.TempDir()
-	rigPath := filepath.Join(cityPath, "riga")
-	const poolAlias = "riga/worker"
-	cfg := &config.City{
-		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
-		Agents: []config.Agent{{
-			Name:  "worker",
-			Scope: "city",
-		}},
-	}
-	cityStore := beads.NewMemStore()
-	rigStore := beads.NewMemStore()
-	rigStores := map[string]beads.Store{"riga": rigStore}
-
-	drainingBead := beads.Bead{
-		ID:     "session-draining",
-		Type:   sessionBeadType,
-		Status: "open",
-		Metadata: map[string]string{
-			"template":                   "worker",
-			"session_name":               "worker-1",
-			namedSessionIdentityMetadata: poolAlias,
-		},
-	}
-	siblingBead := beads.Bead{
-		ID:     "session-sibling",
-		Type:   sessionBeadType,
-		Status: "open",
-		Metadata: map[string]string{
-			"template":                   "worker",
-			"session_name":               "worker-2",
-			namedSessionIdentityMetadata: poolAlias,
-		},
-	}
-	draining := sessiontest.SeedBead(t, drainingBead)
-	sibling := sessiontest.SeedBead(t, siblingBead)
-	// The draining seat AND a distinctly-named sibling both carry the pool alias;
-	// only the draining seat carries its own bead ID. The runtime probe reports the
-	// sibling positively alive, so the benign city row it owns is skipped.
-	liveOwners := buildLiveSessionOwnerSet([]sessionpkg.Info{draining, sibling}, cfg, func(info sessionpkg.Info) bool {
-		return info.ID == sibling.ID
-	})
-
-	// City leg: an in_progress row on the shared pool alias — a LIVE sibling owns
-	// it, so it is benign and must be walked past.
-	benign, err := cityStore.Create(beads.Bead{Type: "task", Assignee: poolAlias})
-	if err != nil {
-		t.Fatalf("Create(benign): %v", err)
-	}
-	inProgress := "in_progress"
-	if err := cityStore.Update(benign.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
-		t.Fatalf("mark benign in_progress: %v", err)
-	}
-	// Rig leg: an in_progress row on the draining seat's OWN bead ID — no live
-	// incarnation but the draining seat itself owns it, so it is a genuine strand.
-	strand, err := rigStore.Create(beads.Bead{Type: "task", Assignee: drainingBead.ID})
-	if err != nil {
-		t.Fatalf("Create(strand): %v", err)
-	}
-	if err := rigStore.Update(strand.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
-		t.Fatalf("mark strand in_progress: %v", err)
-	}
-
-	// The owner-liveness walk skips the benign runtime-alive-sibling row in the
-	// city leg and finds the genuine strand in the rig leg.
-	got, found, err := firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, cityStore, rigStores, draining, liveOwners)
-	if err != nil {
-		t.Fatalf("firstStrandedInProgressAssignedWorkBeadForReachableStore: %v", err)
-	}
-	if !found || got.ID != strand.ID {
-		t.Fatalf("stranded walk = (%v, %q), want the genuine later-leg strand %q — a benign live-sibling row must not mask it", found, got.ID, strand.ID)
 	}
 }
 
@@ -883,7 +801,7 @@ func TestSessionHasOpenAssignedWorkIncludesReachableAssignedWisp(t *testing.T) {
 	}
 }
 
-func TestFirstStrandedInProgressAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
+func TestFirstInProgressAssignedWorkBeadIncludesAssignedWisp(t *testing.T) {
 	store := beads.NewMemStore()
 	wisp, err := store.Create(beads.Bead{
 		Title:     "active workflow step",
@@ -899,11 +817,10 @@ func TestFirstStrandedInProgressAssignedWorkBeadIncludesAssignedWisp(t *testing.
 		t.Fatalf("mark wisp in progress: %v", err)
 	}
 
-	// No live incarnation carries "worker-session", so the in_progress wisp is a
-	// genuine strand the finder must surface for session diagnostics.
-	got, found, err := firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(store, []string{"worker-session"}, "session-self", buildLiveSessionOwnerSet(nil, nil, nil))
+	// An in_progress wisp assigned to the seat is surfaced for session diagnostics.
+	got, found, err := firstInProgressAssignedWorkBeadInStoreByIdentifiers(store, []string{"worker-session"})
 	if err != nil {
-		t.Fatalf("firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers: %v", err)
+		t.Fatalf("firstInProgressAssignedWorkBeadInStoreByIdentifiers: %v", err)
 	}
 	if !found {
 		t.Fatal("assigned wisp work should be found for session diagnostics")

--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -218,7 +218,13 @@ type hookClaimOps struct {
 	StampSessionClaim hookStampSessionClaimFunc
 	// ReadWorkMeta is the post-stamp authoritative readback used only to
 	// establish the durable lifecycle-start emission point.
-	ReadWorkMeta             func(context.Context, string, []string, string, string) (beads.Bead, error)
+	ReadWorkMeta func(context.Context, string, []string, string, string) (beads.Bead, error)
+	// ConfirmBlocked re-derives whether a bead is really blocked, from its live
+	// dependencies rather than bd's denormalized is_blocked projection (which
+	// production reads do not carry). Diagnostics-only: the demand/claim
+	// divergence classifier calls it to settle a row it cannot classify from the
+	// bead alone. Nothing on the claim path reads it.
+	ConfirmBlocked           func(context.Context, string, []string, string, string) (bool, error)
 	EmitExecutionStepStarted func(beads.Bead, string, []string, string)
 	// PublishRunMap writes best-effort session-to-run correlation without
 	// mutating the session bead after a successful work claim.
@@ -485,6 +491,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.ReadWorkMeta == nil {
 		ops.ReadWorkMeta = hookReadClaimedBeadWithBdStore
+	}
+	if ops.ConfirmBlocked == nil {
+		ops.ConfirmBlocked = hookConfirmBeadBlockedWithBdStore
 	}
 	if ops.EmitExecutionStepStarted == nil {
 		ops.EmitExecutionStepStarted = hookEmitExecutionStepStarted
@@ -1462,6 +1471,14 @@ func hookStampWorkMetaWithBdStore(_ context.Context, dir string, env []string, b
 
 func hookReadClaimedBeadWithBdStore(_ context.Context, dir string, env []string, beadID, assignee string) (beads.Bead, error) {
 	return hookClaimBdStore(dir, env, assignee).Get(beadID)
+}
+
+// hookConfirmBeadBlockedWithBdStore is the production ConfirmBlocked seam. It
+// binds its bd children to ctx — the divergence classifier runs after the drain
+// is already written, so its dependency walk must never outlive the deadline that
+// caller set.
+func hookConfirmBeadBlockedWithBdStore(ctx context.Context, dir string, env []string, beadID, assignee string) (bool, error) {
+	return beadHasUnmetPlainBlocksDep(hookClaimBdStoreContext(ctx, dir, env, assignee), beadID)
 }
 
 func hookEmitExecutionStepStarted(step beads.Bead, dir string, env []string, assignee string) {

--- a/cmd/gc/demand_divergence.go
+++ b/cmd/gc/demand_divergence.go
@@ -117,31 +117,77 @@ func classifyDemandTrigger(triggerID, dir string, opts hookClaimOptions, ops hoo
 	if status != "open" || !demandRowServable(bead) || !hookClaimMatchesRoute(bead, opts.RouteTargets) {
 		return status, events.DemandClaimBenign
 	}
-	now := ops.nowOrWallClock()
-	if demandRowReady(bead, now) {
+	switch classifyDemandRowClaimability(bead, ops.nowOrWallClock()) {
+	case demandRowClaimable:
 		// Open, servable, route-matching, and claimable right now — the agreement
 		// invariant breaking.
 		return status, events.DemandClaimDivergence
+	case demandRowBlockednessUnproven:
+		// bd's is_blocked signal is a DENORMALIZED projection that can lag a
+		// just-closed blocker, and production reads do not carry it at all — so
+		// neither reading may decide this on its own. Bucketing every
+		// no-projection row away from the counter would be worse than useless: it
+		// is the reading production always hands us, so the divergence metric
+		// would read zero forever and stop being the agreement signal it exists to
+		// be. Settle it instead, against the same live deps the drain-ack open arm
+		// settles on.
+		return status, classifyDemandTriggerBlockedness(triggerID, dir, opts, ops)
+	default:
+		// Deferred: gated by defer_until (or bd's indefinite deferral), a fresh
+		// bead-local field, so draining past it is correct pull.
+		return status, events.DemandClaimBenign
 	}
-	// Not ready. A deferred row is gated by defer_until, a fresh bead-local field,
-	// so deferring past it is correct pull → benign. But the is_blocked signal is
-	// bd's DENORMALIZED projection, which can lag a just-closed blocker; a
-	// stale-true reading would wrongly bury a genuinely-servable divergence in
-	// benign. This single-bead read cannot cheaply re-derive blockedness from live
-	// deps (the way a worker's ready query does), so a projection-blocked row is
-	// surfaced in its own bucket rather than silently suppressed.
-	if !beads.IsDeferred(bead, now) && bead.IsBlocked != nil && *bead.IsBlocked {
-		return status, events.DemandClaimProjectionBlocked
+}
+
+// classifyDemandTriggerBlockedness settles a trigger row whose blockedness the
+// bead alone could not answer, by re-deriving it from live dependencies.
+//
+// A genuinely blocked row was never claimable, so it is not the agreement
+// invariant breaking — but it is not folded into benign either: it gets its own
+// bucket, because a routed row the controller keeps counting while no worker can
+// take it is its own thing worth seeing. A row whose blocking deps turn out to be
+// MET is claimable, so it counts as divergence exactly as if the projection had
+// said so — a stale-true flag must not bury a real divergence.
+//
+// Every failure — no confirm seam wired, or a dep read that errors — reports
+// unknown, never divergence and never blocked. Same discipline as the read above:
+// a flaky store must not be able to manufacture the metric this counter exists to
+// keep trustworthy.
+func classifyDemandTriggerBlockedness(triggerID, dir string, opts hookClaimOptions, ops hookClaimOps) string {
+	if ops.ConfirmBlocked == nil {
+		return events.DemandClaimUnknown
 	}
-	return status, events.DemandClaimBenign
+	ctx, cancel := context.WithTimeout(context.Background(), hookClaimMutationTimeout)
+	defer cancel()
+	blocked, err := ops.ConfirmBlocked(ctx, dir, opts.Env, triggerID, opts.Assignee)
+	switch {
+	case err != nil:
+		return events.DemandClaimUnknown
+	case blocked:
+		return events.DemandClaimBlocked
+	default:
+		return events.DemandClaimDivergence
+	}
 }
 
 // demandDivergenceOpsForBead is a tiny adapter so the classification read can be
-// driven directly in tests without constructing a whole claim.
+// driven directly in tests without constructing a whole claim. The blockedness
+// settlement answers "not blocked", the shape a row with no unmet plain `blocks`
+// edge produces; demandDivergenceOpsForBlockedBead drives the other answers.
 func demandDivergenceOpsForBead(bead beads.Bead, err error) hookClaimOps {
+	return demandDivergenceOpsForBlockedBead(bead, err, false, nil)
+}
+
+// demandDivergenceOpsForBlockedBead is demandDivergenceOpsForBead with the
+// live-dep blockedness settlement stubbed too, so a test can drive a confirmed
+// blocker or a failed dependency read.
+func demandDivergenceOpsForBlockedBead(bead beads.Bead, readErr error, blocked bool, confirmErr error) hookClaimOps {
 	return hookClaimOps{
 		ReadWorkMeta: func(context.Context, string, []string, string, string) (beads.Bead, error) {
-			return bead, err
+			return bead, readErr
+		},
+		ConfirmBlocked: func(context.Context, string, []string, string, string) (bool, error) {
+			return blocked, confirmErr
 		},
 	}
 }

--- a/cmd/gc/demand_divergence.go
+++ b/cmd/gc/demand_divergence.go
@@ -111,10 +111,14 @@ func classifyDemandTrigger(triggerID, dir string, opts hookClaimOptions, ops hoo
 	}
 	status = strings.ToLower(strings.TrimSpace(bead.Status))
 	// The invariant is about a row that is STILL claimable by a worker for this
-	// template: open, unassigned, route-matching, and not excluded by the shared
-	// serving rules. Anything else means the row moved on — which is what a
-	// sibling claim looks like, and is correct pull.
-	if status == "open" && demandRowServable(bead) && hookClaimMatchesRoute(bead, opts.RouteTargets) {
+	// template: open, unassigned, route-matching, READY (no unmet blocking
+	// dependency and not deferred), and not excluded by the shared serving rules.
+	// Anything else means the row moved on or was never claimable — which is what
+	// a sibling claim OR a routed-but-blocked row looks like, and is correct pull.
+	// demandRowServable checks only the assignee/type/label exclusions, so the
+	// readiness gate (demandRowReady) is what keeps the routed-blocked family off
+	// the divergence counter.
+	if status == "open" && demandRowServable(bead) && demandRowReady(bead, ops.nowOrWallClock()) && hookClaimMatchesRoute(bead, opts.RouteTargets) {
 		return status, events.DemandClaimDivergence
 	}
 	return status, events.DemandClaimBenign

--- a/cmd/gc/demand_divergence.go
+++ b/cmd/gc/demand_divergence.go
@@ -111,15 +111,27 @@ func classifyDemandTrigger(triggerID, dir string, opts hookClaimOptions, ops hoo
 	}
 	status = strings.ToLower(strings.TrimSpace(bead.Status))
 	// The invariant is about a row that is STILL claimable by a worker for this
-	// template: open, unassigned, route-matching, READY (no unmet blocking
-	// dependency and not deferred), and not excluded by the shared serving rules.
-	// Anything else means the row moved on or was never claimable — which is what
-	// a sibling claim OR a routed-but-blocked row looks like, and is correct pull.
-	// demandRowServable checks only the assignee/type/label exclusions, so the
-	// readiness gate (demandRowReady) is what keeps the routed-blocked family off
-	// the divergence counter.
-	if status == "open" && demandRowServable(bead) && demandRowReady(bead, ops.nowOrWallClock()) && hookClaimMatchesRoute(bead, opts.RouteTargets) {
+	// template: open, unassigned, route-matching, and not excluded by the shared
+	// serving rules. Anything else — a row that moved on, a sibling claim — is
+	// correct pull.
+	if status != "open" || !demandRowServable(bead) || !hookClaimMatchesRoute(bead, opts.RouteTargets) {
+		return status, events.DemandClaimBenign
+	}
+	now := ops.nowOrWallClock()
+	if demandRowReady(bead, now) {
+		// Open, servable, route-matching, and claimable right now — the agreement
+		// invariant breaking.
 		return status, events.DemandClaimDivergence
+	}
+	// Not ready. A deferred row is gated by defer_until, a fresh bead-local field,
+	// so deferring past it is correct pull → benign. But the is_blocked signal is
+	// bd's DENORMALIZED projection, which can lag a just-closed blocker; a
+	// stale-true reading would wrongly bury a genuinely-servable divergence in
+	// benign. This single-bead read cannot cheaply re-derive blockedness from live
+	// deps (the way a worker's ready query does), so a projection-blocked row is
+	// surfaced in its own bucket rather than silently suppressed.
+	if !beads.IsDeferred(bead, now) && bead.IsBlocked != nil && *bead.IsBlocked {
+		return status, events.DemandClaimProjectionBlocked
 	}
 	return status, events.DemandClaimBenign
 }

--- a/cmd/gc/demand_divergence_test.go
+++ b/cmd/gc/demand_divergence_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -110,6 +111,8 @@ func TestDivergenceIsNotRecordedForAClaimsErroredDrain(t *testing.T) {
 // claimable counts as divergence; everything else is pull working.
 func TestDivergenceClassification(t *testing.T) {
 	routed := map[string]string{beadmeta.RoutedToMetadataKey: "rig/worker"}
+	blockedTrue := true
+	future := time.Now().Add(time.Hour)
 	for _, tt := range []struct {
 		name      string
 		bead      beads.Bead
@@ -122,6 +125,23 @@ func TestDivergenceClassification(t *testing.T) {
 			name: "still open and claimable", triggerID: "wb-1",
 			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed},
 			wantClass: events.DemandClaimDivergence, wantStat: "open",
+		},
+		{
+			// Open, unassigned, route-matching — but parked on an unmet blocking
+			// dependency (bd's is_blocked projection). A worker's ready query
+			// excludes it, so the seat drained past a row it could not claim:
+			// correct pull, NOT divergence. This is the routed-blocked family the
+			// readiness gate keeps off the counter.
+			name: "open but dependency-blocked", triggerID: "wb-1",
+			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed, IsBlocked: &blockedTrue},
+			wantClass: events.DemandClaimBenign, wantStat: "open",
+		},
+		{
+			// Open and route-matching but deferred into the future: also excluded
+			// by the ready query, so also not a divergence.
+			name: "open but deferred", triggerID: "wb-1",
+			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed, DeferUntil: &future},
+			wantClass: events.DemandClaimBenign, wantStat: "open",
 		},
 		{
 			name: "claimed by a sibling", triggerID: "wb-1",

--- a/cmd/gc/demand_divergence_test.go
+++ b/cmd/gc/demand_divergence_test.go
@@ -127,14 +127,15 @@ func TestDivergenceClassification(t *testing.T) {
 			wantClass: events.DemandClaimDivergence, wantStat: "open",
 		},
 		{
-			// Open, unassigned, route-matching — but parked on an unmet blocking
-			// dependency (bd's is_blocked projection). A worker's ready query
-			// excludes it, so the seat drained past a row it could not claim:
-			// correct pull, NOT divergence. This is the routed-blocked family the
-			// readiness gate keeps off the counter.
-			name: "open but dependency-blocked", triggerID: "wb-1",
+			// Open, unassigned, route-matching, and marked blocked ONLY by bd's
+			// denormalized is_blocked projection. That projection can lag a
+			// just-closed blocker, so rather than fold a potentially-stale-true
+			// reading into benign (which would hide a genuinely-servable
+			// divergence), it is surfaced in its own projection-blocked bucket —
+			// not the clean divergence counter, not silently suppressed.
+			name: "open but is_blocked projection true", triggerID: "wb-1",
 			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed, IsBlocked: &blockedTrue},
-			wantClass: events.DemandClaimBenign, wantStat: "open",
+			wantClass: events.DemandClaimProjectionBlocked, wantStat: "open",
 		},
 		{
 			// Open and route-matching but deferred into the future: also excluded

--- a/cmd/gc/demand_divergence_test.go
+++ b/cmd/gc/demand_divergence_test.go
@@ -114,28 +114,52 @@ func TestDivergenceClassification(t *testing.T) {
 	blockedTrue := true
 	future := time.Now().Add(time.Hour)
 	for _, tt := range []struct {
-		name      string
-		bead      beads.Bead
-		readErr   error
-		triggerID string
-		wantClass string
-		wantStat  string
+		name       string
+		bead       beads.Bead
+		readErr    error
+		blocked    bool
+		confirmErr error
+		triggerID  string
+		wantClass  string
+		wantStat   string
 	}{
 		{
+			// The PRODUCTION shape: bd's payloads never carry is_blocked, so the
+			// projection is absent and the live-dep settlement is what decides. No
+			// unmet plain `blocks` edge — the row really is claimable, and this is
+			// the agreement invariant breaking.
 			name: "still open and claimable", triggerID: "wb-1",
 			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed},
 			wantClass: events.DemandClaimDivergence, wantStat: "open",
 		},
 		{
-			// Open, unassigned, route-matching, and marked blocked ONLY by bd's
-			// denormalized is_blocked projection. That projection can lag a
-			// just-closed blocker, so rather than fold a potentially-stale-true
-			// reading into benign (which would hide a genuinely-servable
-			// divergence), it is surfaced in its own projection-blocked bucket —
-			// not the clean divergence counter, not silently suppressed.
-			name: "open but is_blocked projection true", triggerID: "wb-1",
+			// Same absent projection, but the live-dep settlement finds an unmet
+			// plain `blocks` edge. No worker could have claimed it, so it is not a
+			// divergence — and not folded into benign either. Absent is what
+			// production reads return, so a row can only reach this bucket at all
+			// because the settlement no longer depends on the projection.
+			name: "no projection but dep-confirmed blocked", triggerID: "wb-1",
+			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed},
+			blocked:   true,
+			wantClass: events.DemandClaimBlocked, wantStat: "open",
+		},
+		{
+			// bd's denormalized projection reads true, but the live deps are MET —
+			// the stale-true reading `bd recompute-blocked` exists to repair. The
+			// row is claimable, so burying it would hide a real divergence: the
+			// settlement, not the flag, has the last word.
+			name: "stale is_blocked projection with met deps", triggerID: "wb-1",
 			bead:      beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed, IsBlocked: &blockedTrue},
-			wantClass: events.DemandClaimProjectionBlocked, wantStat: "open",
+			wantClass: events.DemandClaimDivergence, wantStat: "open",
+		},
+		{
+			// The settlement's dependency read failed. An unreadable store is not
+			// evidence either way, and must never be able to manufacture the
+			// divergence metric.
+			name: "blockedness settlement read fails", triggerID: "wb-1",
+			bead:       beads.Bead{ID: "wb-1", Status: "open", Type: "task", Metadata: routed},
+			confirmErr: errors.New("dependency read failed"),
+			wantClass:  events.DemandClaimUnknown, wantStat: "open",
 		},
 		{
 			// Open and route-matching but deferred into the future: also excluded
@@ -173,7 +197,7 @@ func TestDivergenceClassification(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := divergenceOptions()
-			ops := demandDivergenceOpsForBead(tt.bead, tt.readErr)
+			ops := demandDivergenceOpsForBlockedBead(tt.bead, tt.readErr, tt.blocked, tt.confirmErr)
 			status, class := classifyDemandTrigger(tt.triggerID, "/rig", opts, ops)
 			if class != tt.wantClass {
 				t.Errorf("classification = %q, want %q", class, tt.wantClass)

--- a/cmd/gc/demand_serve_predicate.go
+++ b/cmd/gc/demand_serve_predicate.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
@@ -103,6 +104,31 @@ func demandRowServable(b beads.Bead) bool {
 		}
 	}
 	return true
+}
+
+// demandRowReady reports whether a trigger row a demand-spawned seat failed to
+// claim is still READY to be claimed — not parked on an unmet blocking
+// dependency and not deferred. A worker's Tier-3 ready query excludes both, so a
+// routed-but-blocked row that drained a seat is correct pull (nothing was
+// claimable), NOT a demand/claim divergence — the dominant false-positive class
+// the divergence classifier was over-counting.
+//
+// The blocked signal mirrors the wake side (bindNamedSessionTriggerBead): bd's
+// denormalized is_blocked projection is trusted when the store provides it, and
+// the raw "blocked" status is honored for stores that surface it; defer_until
+// (and bd's indefinite deferral) gate the time-bound half via beads.IsDeferred.
+// A nil is_blocked projection (native DoltLite snapshots, pre-1.0.5 bd) reads as
+// unblocked here, exactly as the ready query's dependency-derived fallback would
+// on the same row, so the classifier neither invents nor suppresses a divergence
+// beyond what a worker's own query could see.
+func demandRowReady(b beads.Bead, now time.Time) bool {
+	if strings.EqualFold(strings.TrimSpace(b.Status), "blocked") {
+		return false
+	}
+	if b.IsBlocked != nil && *b.IsBlocked {
+		return false
+	}
+	return !beads.IsDeferred(b, now)
 }
 
 // routeCollapseRewriteTarget returns the canonical base route a slot-suffixed

--- a/cmd/gc/demand_serve_predicate.go
+++ b/cmd/gc/demand_serve_predicate.go
@@ -106,31 +106,142 @@ func demandRowServable(b beads.Bead) bool {
 	return true
 }
 
-// demandRowReady reports whether a trigger row a demand-spawned seat failed to
-// claim is still READY to be claimed — not parked on an unmet blocking
-// dependency and not deferred. A worker's Tier-3 ready query excludes both, so a
+// demandRowClaimability names whether a trigger row a demand-spawned seat failed
+// to claim is still claimable by a worker right now — and, when it is not, WHY.
+// A worker's Tier-3 ready query excludes both a blocked and a deferred row, so a
 // routed-but-blocked row that drained a seat is correct pull (nothing was
 // claimable), NOT a demand/claim divergence — the dominant false-positive class
 // the divergence classifier was over-counting.
 //
-// The blocked signal reads bd's denormalized is_blocked projection when the store
-// provides it; defer_until (and bd's indefinite deferral) gate the time-bound
-// half via beads.IsDeferred. A nil is_blocked projection (native DoltLite
-// snapshots, pre-1.0.5 bd) reads as unblocked here, exactly as the ready query's
-// dependency-derived fallback would on the same row, so the classifier neither
-// invents nor suppresses a divergence beyond what a worker's own query could see.
-// Both callers — classifyDemandTrigger and the drain-ack open arm
-// (firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers) — pass a row already
-// constrained to status=="open", so a raw "blocked" status string never reaches
-// here. Both also treat the is_blocked half as advisory only: because it reads
-// the denormalized projection, each re-derives real blockedness from live deps
-// (its own bucket in classifyDemandTrigger, a dep confirmation in the drain-ack
-// arm) rather than suppressing on a possibly-stale-true flag.
-func demandRowReady(b beads.Bead, now time.Time) bool {
-	if b.IsBlocked != nil && *b.IsBlocked {
-		return false
+// The reason is the answer, not a bare "not ready", because the two consumers —
+// classifyDemandTrigger and the drain-ack open arm
+// (firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers) — act differently on
+// each cause: a deferral is PROOF of non-claimability, while an unproven
+// blockedness reading is only a question, to be settled against live deps. Naming
+// the cause here keeps that distinction in one place. Reconstructing it by
+// elimination at a call site ("the only remaining reason is …") would be valid
+// only while this function has exactly these clauses, and would break silently
+// the moment a third exclusion is added.
+type demandRowClaimability string
+
+const (
+	// demandRowClaimable: nothing bead-local keeps a worker from claiming the row.
+	// Reached only on POSITIVE evidence of unblockedness — an is_blocked
+	// projection that reads explicitly false, which is bd's own answer, computed
+	// through the ready-projection enrichment's `bd sql`/`bd blocked` door.
+	demandRowClaimable demandRowClaimability = "claimable"
+	// demandRowDeferred: defer_until, or bd's indefinite deferral, gates the row
+	// (beads.IsDeferred). Both are FRESH bead-local fields — never stale — so this
+	// is proof that no worker could have claimed the row.
+	demandRowDeferred demandRowClaimability = "deferred"
+	// demandRowBlockednessUnproven: the bead alone cannot settle whether the row is
+	// blocked, so each consumer re-derives it from live dependencies
+	// (beadHasUnmetPlainBlocksDep). Two readings land here, and neither is proof:
+	//
+	//   - is_blocked reads TRUE. bd's projection is DENORMALIZED and can read
+	//     stale-true after a blocker closes (issueops.countStaleIsBlockedSQL /
+	//     `bd recompute-blocked` exist precisely to repair it), so acting on it
+	//     alone would bury a row whose blocking deps are in fact met.
+	//   - is_blocked is ABSENT. That is the production reading (see
+	//     classifyDemandRowClaimability) and it is no evidence at all.
+	//
+	// Collapsing both into one cause is not elimination-by-default: every consumer
+	// switches on this case explicitly, and both readings get the same treatment
+	// because neither carries information the live-dep derivation does not.
+	demandRowBlockednessUnproven demandRowClaimability = "blockedness_unproven"
+)
+
+// classifyDemandRowClaimability answers the claimability question for one row.
+// Deferral is checked first: it is the cause that is proof, so a row that is both
+// deferred and flagged blocked classifies as deferred.
+//
+// An ABSENT is_blocked projection is not evidence of unblockedness, and this
+// predicate does not read it as any. bd's `list --json` / `show --json` payloads
+// do not carry the column, so BdStore.toBead leaves IsBlocked nil on every read;
+// beadFromNativeIssue cannot set it either. The projection is supplied only by
+// the CachingStore's ready-projection enrichment (enrichReadyProjectionForCache,
+// which asks bd through a separate `bd sql`/`bd blocked` door at cache-prime
+// time), so it is visible only on non-live cached reads — and both of this
+// predicate's callers read off that path: the drain-ack finders force live=true
+// and the divergence consumer uses a fresh BdStore.Get. Absence is therefore what
+// production actually hands this function, and classifying it as
+// demandRowBlockednessUnproven is what keeps the blocked half reachable on every
+// store class instead of inert.
+//
+// Reporting "unproven" is deliberately NOT the answer the ready query's
+// dependency-derived fallback gives — cachedBeadReady's nil branch re-derives
+// from the row's own direct blocking edges and CAN find the row blocked. This
+// single-bead predicate holds no deps, so it names what it does not know and
+// leaves the derivation to the consumer that can make it.
+//
+// Both callers pass a row already constrained to status=="open", so a raw
+// "blocked" status string never reaches here.
+func classifyDemandRowClaimability(b beads.Bead, now time.Time) demandRowClaimability {
+	if beads.IsDeferred(b, now) {
+		return demandRowDeferred
 	}
-	return !beads.IsDeferred(b, now)
+	if b.IsBlocked == nil || *b.IsBlocked {
+		return demandRowBlockednessUnproven
+	}
+	return demandRowClaimable
+}
+
+// beadHasUnmetPlainBlocksDep re-derives whether a row is really blocked, from its
+// live dependencies rather than bd's denormalized is_blocked projection. It is
+// the shared settlement both consumers of classifyDemandRowClaimability run on a
+// demandRowBlockednessUnproven row — the drain-ack open arm before suppressing a
+// possible strand, classifyDemandTrigger before bucketing a possible divergence —
+// so the verdict no longer depends on whether the store class happens to carry
+// the projection at all.
+//
+// It confirms on a plain `blocks` edge ONLY — narrower than the
+// DepList → IsReadyBlockingDependencyType → DependencySatisfied derivation used
+// for blocked_by enrichment, and deliberately so. Target-not-closed is not proof
+// of non-claimability for the other ready-blocking types: a `waits-for` gate
+// opens through bd-native state independently of its target's own status
+// (internal/formula/compile.go mints exactly that shape, a gate edge onto a step
+// that stays open; native_dolt_store.go's ready filter states it directly — "a
+// waits-for edge gates on the spawner's children rather than the spawner's own
+// status" — and declines the full predicate for the same reason), bdstore.go's
+// inline-dep derivation records that the flat DependencySatisfied rule "is
+// deliberately NOT reused" for a row bd has already offered, and the
+// `bd-gate-open` fixture pins the counterexample: a waits-for edge onto an OPEN
+// target reads is_blocked = 0, bd's ready OFFERS the row, and the direct-dep
+// predicate would hide it. Reusing that predicate here — in the one situation
+// where the row's blockedness is already unsettled — would second-guess a bd
+// verdict and silence a claimable row, the exact false negative this settlement
+// exists to prevent. An unmet `waits-for` / `conditional-blocks` target therefore
+// reads as NOT blocked.
+//
+// Residual this narrowing does NOT close: a plain `blocks` edge onto a PINNED
+// blocker is satisfied natively by bd (native_dolt_store.go, same comment), while
+// beads.Dep carries no pin visibility — so that row still confirms as blocked
+// even though bd would offer it. Closing it needs the blocker's pin state on the
+// dependency read, not a wider edge-type set.
+//
+// A dep or blocker read that FAILS is returned, not swallowed, and each consumer
+// fails closed on it: the drain-ack classifier surfaces the error to be logged
+// and never manufactures the alarm from an unreadable store, and the divergence
+// classifier reports unknown rather than inventing the metric it exists to keep
+// honest.
+func beadHasUnmetPlainBlocksDep(store beads.Store, id string) (bool, error) {
+	deps, err := store.DepList(id, "down")
+	if err != nil {
+		return false, err
+	}
+	for _, dep := range deps {
+		if dep.Type != "blocks" {
+			continue
+		}
+		blocker, err := store.Get(dep.DependsOnID)
+		if err != nil {
+			return false, err
+		}
+		if !beads.DependencySatisfied(blocker.Status, blocker.Metadata[beadmeta.WorkOutcomeMetadataKey]) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // routeCollapseRewriteTarget returns the canonical base route a slot-suffixed

--- a/cmd/gc/demand_serve_predicate.go
+++ b/cmd/gc/demand_serve_predicate.go
@@ -113,18 +113,15 @@ func demandRowServable(b beads.Bead) bool {
 // claimable), NOT a demand/claim divergence — the dominant false-positive class
 // the divergence classifier was over-counting.
 //
-// The blocked signal mirrors the wake side (bindNamedSessionTriggerBead): bd's
-// denormalized is_blocked projection is trusted when the store provides it, and
-// the raw "blocked" status is honored for stores that surface it; defer_until
-// (and bd's indefinite deferral) gate the time-bound half via beads.IsDeferred.
-// A nil is_blocked projection (native DoltLite snapshots, pre-1.0.5 bd) reads as
-// unblocked here, exactly as the ready query's dependency-derived fallback would
-// on the same row, so the classifier neither invents nor suppresses a divergence
-// beyond what a worker's own query could see.
+// The blocked signal reads bd's denormalized is_blocked projection when the store
+// provides it; defer_until (and bd's indefinite deferral) gate the time-bound
+// half via beads.IsDeferred. A nil is_blocked projection (native DoltLite
+// snapshots, pre-1.0.5 bd) reads as unblocked here, exactly as the ready query's
+// dependency-derived fallback would on the same row, so the classifier neither
+// invents nor suppresses a divergence beyond what a worker's own query could see.
+// The sole caller (classifyDemandTrigger) gates on status=="open" before calling
+// this, so a raw "blocked" status string never reaches here.
 func demandRowReady(b beads.Bead, now time.Time) bool {
-	if strings.EqualFold(strings.TrimSpace(b.Status), "blocked") {
-		return false
-	}
 	if b.IsBlocked != nil && *b.IsBlocked {
 		return false
 	}

--- a/cmd/gc/demand_serve_predicate.go
+++ b/cmd/gc/demand_serve_predicate.go
@@ -119,8 +119,13 @@ func demandRowServable(b beads.Bead) bool {
 // snapshots, pre-1.0.5 bd) reads as unblocked here, exactly as the ready query's
 // dependency-derived fallback would on the same row, so the classifier neither
 // invents nor suppresses a divergence beyond what a worker's own query could see.
-// The sole caller (classifyDemandTrigger) gates on status=="open" before calling
-// this, so a raw "blocked" status string never reaches here.
+// Both callers — classifyDemandTrigger and the drain-ack open arm
+// (firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers) — pass a row already
+// constrained to status=="open", so a raw "blocked" status string never reaches
+// here. Both also treat the is_blocked half as advisory only: because it reads
+// the denormalized projection, each re-derives real blockedness from live deps
+// (its own bucket in classifyDemandTrigger, a dep confirmation in the drain-ack
+// arm) rather than suppressing on a possibly-stale-true flag.
 func demandRowReady(b beads.Bead, now time.Time) bool {
 	if b.IsBlocked != nil && *b.IsBlocked {
 		return false

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -572,7 +572,6 @@ func recordDrainAckAssignedWorkEvent(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
-	liveOwners liveSessionOwnerSet,
 	subject string,
 	template string,
 	name string,
@@ -582,7 +581,7 @@ func recordDrainAckAssignedWorkEvent(
 	if rec == nil {
 		return
 	}
-	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info, liveOwners)
+	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info)
 	if beadLookupErr != nil {
 		fmt.Fprintf(stderr, "session reconciler: classifying drain-acked work for %s: %v\n", name, beadLookupErr) //nolint:errcheck
 	}
@@ -605,200 +604,42 @@ func recordDrainAckAssignedWorkEvent(
 	})
 }
 
-// liveSessionOwnerSet answers, for a drain-acked seat's in_progress row, the one
-// question that can positively excuse the strand alarm: is the row's assignee
-// still carried by some OTHER session whose RUNTIME is positively observed alive
-// this pass? Only a genuinely running sibling incarnation (the surplus-seat /
-// pool-recycle case) may suppress the alarm.
-//
-// The default is FIRE. Suppression demands a positively-confirmed benign cause,
-// so a candidate owner counts ONLY when its runtime is observed running/alive —
-// never merely because its session bead is not closed. Keying on bead-not-closed
-// was the silencing bug: it counted (a) a same-pass-draining sibling whose
-// runtime was just observed dead and (b) a drained-open ZOMBIE seat kept open by
-// the very row it stranded, letting two same-alias seats mutually suppress and a
-// zombie permanently silence a recurring cap-hit strand. Excluded from the owner
-// set up front: the draining seat itself (selfID), any closed seat, and any
-// drain-ack-stop-pending seat (on its way out, never a live replacement). Every
-// surviving candidate is then gated on a POSITIVE runtime observation.
-//
-// The decision is owner-LIVENESS, never assignee identity shape: a hook claim
-// stamps the alias/agent identity (hookClaimAssigneeIdentity), not the durable
-// bead ID, so keying on "assignee == this session's own bead ID" would silence
-// the exact gastownhall/gascity#2293 cap-hit strand the event exists to emit for.
-//
-// Runtime observation is lazy and memoized per session bead ID: the hot reconcile
-// path observes a candidate's runtime only when an in_progress strand is actually
-// being classified (rare), never once-per-session-per-tick. An observation error
-// or absent runtime resolves to "not alive" so an unconfirmable seat can never
-// suppress a strand — fail toward FIRE.
-type liveSessionOwnerSet struct {
-	// carriersByIdentifier maps each assignment identifier to the candidate
-	// session bead IDs that carry it (closed and drain-pending seats already
-	// excluded at build time).
-	carriersByIdentifier map[string]map[string]struct{}
-	// candidateByID recovers a candidate's Info (session name, template) so the
-	// lazy probe can observe its runtime.
-	candidateByID map[string]sessionpkg.Info
-	// runtimeAlive positively observes a candidate owner's runtime this pass. A
-	// nil probe means nothing can be confirmed alive, so no candidate suppresses
-	// (every strand fires).
-	runtimeAlive func(sessionpkg.Info) bool
-	// aliveByID memoizes runtimeAlive per candidate within the pass. The map is a
-	// reference type, so the value-receiver methods below share one memo table.
-	aliveByID map[string]bool
-}
-
-// buildLiveSessionOwnerSet indexes the assignment identifiers of every candidate
-// owner session by the session bead ID that carries them, pairing the index with
-// a lazy runtime-liveness probe. A candidate is any session Info that is neither
-// closed nor drain-ack-stop-pending: a closed or draining seat is never a live
-// replacement, so excluding both up front makes same-pass-drain mutual
-// suppression impossible by construction. It reads the same identifier set the
-// assigned-work finders query by (sessionAssignmentIdentifiersForConfigInfo), so
-// an assignee that matched a draining seat's identifiers is looked up under the
-// identity it was actually stamped with. runtimeAlive is the positive runtime
-// observation ownedByLiveSessionOtherThan gates every surviving candidate on.
-func buildLiveSessionOwnerSet(infos []sessionpkg.Info, cfg *config.City, runtimeAlive func(sessionpkg.Info) bool) liveSessionOwnerSet {
-	owners := liveSessionOwnerSet{
-		carriersByIdentifier: make(map[string]map[string]struct{}),
-		candidateByID:        make(map[string]sessionpkg.Info),
-		runtimeAlive:         runtimeAlive,
-		aliveByID:            make(map[string]bool),
-	}
-	for i := range infos {
-		info := infos[i]
-		id := strings.TrimSpace(info.ID)
-		if id == "" || info.Closed {
-			continue
-		}
-		// A drain-ack-stop-pending seat is already leaving; counting it as a live
-		// owner is how a same-pass-draining sibling would silence a peer's strand.
-		// Exclude it here, before the runtime probe would even be consulted.
-		if isDrainAckStopPendingInfo(info) {
-			continue
-		}
-		owners.candidateByID[id] = info
-		for _, identifier := range sessionAssignmentIdentifiersForConfigInfo(info, cfg) {
-			identifier = strings.TrimSpace(identifier)
-			if identifier == "" {
-				continue
-			}
-			carriers := owners.carriersByIdentifier[identifier]
-			if carriers == nil {
-				carriers = make(map[string]struct{})
-				owners.carriersByIdentifier[identifier] = carriers
-			}
-			carriers[id] = struct{}{}
-		}
-	}
-	return owners
-}
-
-// ownedByLiveSessionOtherThan reports whether some session OTHER than selfID
-// carries assignee AND has its runtime positively observed alive this pass — the
-// only positively-benign reason to suppress the strand alarm. selfID is the
-// draining seat's own bead ID, excluded so a seat is never counted as its own
-// live replacement. A candidate whose runtime cannot be confirmed alive (observed
-// dead, absent, or unobservable) does NOT suppress: the strand fires.
-func (o liveSessionOwnerSet) ownedByLiveSessionOtherThan(assignee, selfID string) bool {
-	assignee = strings.TrimSpace(assignee)
-	if assignee == "" {
-		return false
-	}
-	selfID = strings.TrimSpace(selfID)
-	for ownerID := range o.carriersByIdentifier[assignee] {
-		if ownerID == selfID {
-			continue
-		}
-		if o.runtimeAliveThisPass(ownerID) {
-			return true
-		}
-	}
-	return false
-}
-
-// runtimeAliveThisPass reports whether the candidate owner id is positively
-// observed runtime-alive this pass, memoizing the probe result per id. A nil
-// probe or an unknown id is "not alive" — the fail-toward-fire default.
-func (o liveSessionOwnerSet) runtimeAliveThisPass(id string) bool {
-	if o.runtimeAlive == nil {
-		return false
-	}
-	if alive, ok := o.aliveByID[id]; ok {
-		return alive
-	}
-	info, ok := o.candidateByID[id]
-	if !ok {
-		return false
-	}
-	alive := o.runtimeAlive(info)
-	o.aliveByID[id] = alive
-	return alive
-}
-
-// sessionRuntimeAliveProbe returns the positive runtime-liveness observation
-// buildLiveSessionOwnerSet gates candidate owners on. It observes the session's
-// provider runtime with the same liveness call the reconciler's forward pass and
-// drain-ack finalize use, and reports alive ONLY when the runtime is observed
-// running or its agent process is alive. A nil provider, an empty session name,
-// or an observation error reports NOT alive, so an unconfirmable seat can never
-// suppress a strand (default = fire).
-func sessionRuntimeAliveProbe(sp runtime.Provider, cfg *config.City) func(sessionpkg.Info) bool {
-	return func(info sessionpkg.Info) bool {
-		name := strings.TrimSpace(info.SessionNameMetadata)
-		if sp == nil || name == "" {
-			return false
-		}
-		running, alive, err := observeRuntimeProviderLiveness(sp, name, drainAckStopPendingProcessNames(cfg, info))
-		if err != nil {
-			return false
-		}
-		return running || alive
-	}
-}
-
 // drainAckClaimableAnomalyBead returns the work bead that makes a drain-acked
-// session a GENUINE drain-with-assigned-work anomaly worth alarming on, plus
-// whether one was found.
+// session a drain-with-assigned-work anomaly worth alarming on, plus whether one
+// was found.
 //
-// SessionDrainAckedWithAssignedWork must fire ONLY for a row the draining seat
-// could actually have claimed and did not — never for correct pull draining.
-// Two large classes of "assigned work" are correct pull, and both are
-// suppressed here:
+// SessionDrainAckedWithAssignedWork must never be silenced for a genuine strand:
+// a false negative (a stranded row nobody is working, kept quiet) is strictly
+// worse than the residual false-positive noise. So this classifier suppresses
+// ONLY provably-non-claimable work — cases where no worker for this seat could
+// have claimed the row, so draining past it was correct pull:
 //
-//   - An OPEN bead parked on an unmet dependency (routed to the seat's target
-//     but not yet ready). No worker can claim a blocked row, so a seat that
-//     drained past it drained correctly.
-//   - An IN_PROGRESS bead a sibling incarnation of the same pool whose RUNTIME is
-//     positively observed alive this pass is working, matched only because it
-//     carries a pool-shared assignee identity. A surplus seat draining while a
-//     genuinely-running sibling holds the row is normal.
+//   - An OPEN bead parked on an unmet dependency, deferred, or otherwise not
+//     ready. No worker can claim a blocked/deferred row, so a seat that drained
+//     past it drained correctly (firstReadyAssignedWorkBeadForReachableStore
+//     keys on readiness, and demandRowReady mirrors it on the divergence half).
+//   - A bead assigned to no identifier this seat carries (assignee-empty relative
+//     to the seat): the finders query by the seat's own identifiers, so an
+//     unassigned or foreign row is never returned.
+//   - The seat's own mol-do-work "drain" step (isSessionOwnDrainStepBead),
+//     excluded for parity with the close gate.
 //
-// A bead is a true anomaly when it is either open AND ready (claimable right
-// now) or in_progress with NO runtime-alive owner other than the draining seat
-// itself (dead sibling, same-pass-draining sibling, drained-open zombie, or a
-// named/pool seat with no live replacement — the gastownhall/gascity#2293 cap-hit
-// self-strand). The key is owner RUNTIME-LIVENESS (liveOwners positively observes
-// each candidate's runtime), NOT the assignee's identity shape and NOT mere
-// bead-not-closed: production hook claims stamp the alias/agent identity rather
-// than the durable bead ID, so a "assignee == own bead ID" test would silence the
-// strict superset of genuine alias-claimed strands, and counting a non-closed but
-// runtime-dead seat as a live owner would let a zombie or a same-pass-draining
-// sibling silence a genuine strand. The default is FIRE; suppression demands a
-// positively-confirmed runtime-alive owner. The open+ready candidate is resolved
-// first and independently, and the in_progress walk continues past benign
-// runtime-alive-sibling rows across every reachable leg
-// (firstStrandedInProgressAssignedWorkBeadForReachableStore) so neither can mask
-// the other. It fails CLOSED: a read error yields (found=false), so a flaky
-// store never manufactures the alarm this classifier exists to keep honest.
+// An IN_PROGRESS bead assigned to one of the seat's identifiers ALWAYS fires.
+// Distinguishing a genuine cap-hit strand (gastownhall/gascity#2293) from a
+// benign live-sibling claim cannot be done safely at finalize: every liveness
+// signal available here (tmux Running without Alive on a zombie pane, a stale
+// 30s liveness cache with no error channel, name-only keying that borrows a
+// duplicate-named seat's liveness, cross-tick memoization) has a hole that would
+// silence a real strand. Rather than risk that false negative, the in_progress
+// arm accepts the residual benign-live-sibling noise and fires unconditionally.
+// It fails CLOSED: a read error yields (found=false), so a flaky store never
+// manufactures the alarm this classifier exists to keep honest.
 func drainAckClaimableAnomalyBead(
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
-	liveOwners liveSessionOwnerSet,
 ) (beads.Bead, bool, error) {
 	readyBead, readyFound, err := firstReadyAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
 	if err != nil {
@@ -807,7 +648,7 @@ func drainAckClaimableAnomalyBead(
 	if readyFound {
 		return readyBead, true, nil
 	}
-	return firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info, liveOwners)
+	return firstInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
 }
 
 // drainAckFinalizeResult captures the Info-snapshot effect of a
@@ -871,7 +712,6 @@ func finalizeDrainAckStoppedSession(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
-	liveOwners liveSessionOwnerSet,
 	template string,
 	closeIfUnassigned bool,
 	dops drainOps,
@@ -1009,7 +849,7 @@ func finalizeDrainAckStoppedSession(
 	}
 	recordStopped(true)
 	if hasAssignedWork {
-		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, info, liveOwners, template, template, name, rec, stderr)
+		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, info, template, template, name, rec, stderr)
 	}
 	// Non-close drain-ack: the snapshot fold is the ApplyPatchInfo result above.
 	return drainAckFinalizeResult{folded: &foldedInfo}
@@ -1022,7 +862,6 @@ func reconcileDrainAckStopPending(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
-	liveOwners liveSessionOwnerSet,
 	tp TemplateParams,
 	desired bool,
 	dops drainOps,
@@ -1046,7 +885,7 @@ func reconcileDrainAckStopPending(
 		return true, drainAckFinalizeResult{}
 	}
 	return true, finalizeDrainAckStoppedSession(
-		cityPath, cfg, store, rigStores, info, liveOwners, tp.TemplateName,
+		cityPath, cfg, store, rigStores, info, tp.TemplateName,
 		!desired || isPoolManagedSessionInfo(info),
 		dops, dt, clk, rec, stderr,
 	)
@@ -1092,12 +931,6 @@ func finalizeDrainAckStopPendingSessions(
 	if store == nil || sp == nil || len(infos) == 0 {
 		return 0
 	}
-	// The caller-fed snapshot IS this pass's candidate-owner inventory (closed and
-	// drain-pending seats excluded at build), and the runtime probe positively
-	// confirms a candidate is still running before it may suppress a strand, so
-	// the classifier tells an in_progress bead a genuinely-live sibling owns from a
-	// genuine strand — never letting a same-pass-draining or zombie seat silence it.
-	liveOwners := buildLiveSessionOwnerSet(infos, cfg, sessionRuntimeAliveProbe(sp, cfg))
 	finalized := 0
 	for _, info := range infos {
 		if !isDrainAckStopPendingInfo(info) {
@@ -1135,7 +968,7 @@ func finalizeDrainAckStopPendingSessions(
 		// state=drained: open pool session beads occupy slots in the next demand
 		// calculation, while closed beads remain only as lifecycle history.
 		finalizeDrainAckStoppedSession(
-			cityPath, cfg, store, rigStores, info, liveOwners,
+			cityPath, cfg, store, rigStores, info,
 			normalizedSessionTemplateInfo(info, cfg),
 			isPoolManagedSessionInfo(info),
 			dops, dt, clk, rec, stderr,
@@ -1848,17 +1681,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	infoByID := tick.infoByID
 	orderedIDs := tick.orderedIDs
 
-	// The tick's candidate-owner inventory, indexed by assignment identifier, is
-	// built once from the tick-start snapshot (closed and drain-pending seats
-	// excluded) and paired with a lazy runtime probe, so the drain-ack anomaly
-	// classifier can tell an in_progress bead a genuinely RUNTIME-ALIVE sibling
-	// incarnation owns (correct surplus-seat / pool-recycle drain, suppress) from
-	// one with no live owner but the draining seat itself (a genuine strand, fire).
-	// The probe observes each candidate's runtime lazily at classification time, so
-	// a seat whose runtime died mid-tick or a drained-open zombie is excluded on a
-	// positive dead observation rather than trusted because its bead is still open.
-	liveOwners := buildLiveSessionOwnerSet(orderedInfos, cfg, sessionRuntimeAliveProbe(sp, cfg))
-
 	phaseStart = time.Now()
 	cbNow := clk.Now().UTC()
 	cbCfg, cbEnabled := sessionCircuitBreakerConfigFromCity(cfg)
@@ -2022,7 +1844,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			dt.clearSuspendDeferral(id)
 		}
 
-		if handled, result := reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, info, liveOwners, tp, desired, dops, dt, asyncStopTracker, clk, rec, stderr); handled {
+		if handled, result := reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, info, tp, desired, dops, dt, asyncStopTracker, clk, rec, stderr); handled {
 			// finalizeDrainAckStoppedSession (inside reconcileDrainAckStopPending)
 			// may close the bead in memory (Status=closed) on this true/continue
 			// path; fold that close onto the snapshot so the cross-session min-floor
@@ -2480,7 +2302,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							continue
 						}
 						result := finalizeDrainAckStoppedSession(
-							cityPath, cfg, store, rigStores, infoByID[id], liveOwners, template,
+							cityPath, cfg, store, rigStores, infoByID[id], template,
 							true, dops, dt, clk, rec, stderr,
 						)
 						// finalizeDrainAckStoppedSession may close the bead in memory; fold
@@ -2934,7 +2756,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						finalizeDT = nil
 					}
 					result := finalizeDrainAckStoppedSession(
-						cityPath, cfg, store, rigStores, infoByID[id], liveOwners, tp.TemplateName,
+						cityPath, cfg, store, rigStores, infoByID[id], tp.TemplateName,
 						isPoolManagedSessionInfo(infoByID[id]),
 						dops, finalizeDT,
 						clk, rec, stderr,
@@ -4924,38 +4746,34 @@ func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifie
 	return beads.Bead{}, false, nil
 }
 
-// firstStrandedInProgressAssignedWorkBeadForReachableStore walks EVERY reachable
-// leg for an in_progress work bead assigned to the draining session whose
-// assignee has no RUNTIME-ALIVE owner other than the session itself — a genuine
-// strand. A benign in_progress row a live sibling is working in an earlier leg
-// must not mask a genuine strand in a later leg, so the per-leg probe returns
-// found=false for a leg holding only owned rows and firstAssignedWorkBeadForSession
-// keeps walking. Returns (zero-bead, false, nil) when every in_progress match is
-// owned by a runtime-alive sibling incarnation.
-func firstStrandedInProgressAssignedWorkBeadForReachableStore(
+// firstInProgressAssignedWorkBeadForReachableStore walks EVERY reachable leg for
+// an in_progress work bead assigned to one of the draining session's identifiers
+// and returns the first one — the in_progress arm of the drain-ack anomaly
+// classifier. It does NOT attempt to distinguish a genuine strand from a benign
+// live-sibling claim: an in_progress row assigned to the seat always fires (see
+// drainAckClaimableAnomalyBead — a false negative is worse than the residual
+// false-positive). Returns (zero-bead, false, nil) when the seat holds no
+// in_progress row (only its own drain step and session beads are skipped).
+func firstInProgressAssignedWorkBeadForReachableStore(
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
-	liveOwners liveSessionOwnerSet,
 ) (beads.Bead, bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
 	return firstAssignedWorkBeadForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (beads.Bead, bool, error) {
-		return firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(s, identifiers, info.ID, liveOwners)
+		return firstInProgressAssignedWorkBeadInStoreByIdentifiers(s, identifiers)
 	})
 }
 
-// firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers returns the first
-// in_progress non-session, non-mail work bead in store assigned to one of the
-// given identifiers whose assignee is not owned by a runtime-alive session other
-// than selfID — i.e. a genuine strand. In_progress rows a runtime-alive sibling
-// incarnation is working (ownedByLiveSessionOtherThan true) are skipped so a
-// surplus-seat / pool-recycle drain does not alarm, and the seat's own mol-do-work
-// drain step is skipped for parity with the ready finder and the close gate.
-// identifiers are pre-compacted (deduped, no empties) by
+// firstInProgressAssignedWorkBeadInStoreByIdentifiers returns the first
+// in_progress non-session work bead in store assigned to one of the given
+// identifiers. The seat's own mol-do-work drain step (isSessionOwnDrainStepBead)
+// is skipped for parity with the ready finder and the close gate; everything else
+// fires. identifiers are pre-compacted (deduped, no empties) by
 // sessionAssignmentIdentifiersForConfigInfo.
-func firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string, selfID string, liveOwners liveSessionOwnerSet) (beads.Bead, bool, error) {
+func firstInProgressAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
@@ -4970,9 +4788,6 @@ func firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(store beads.Sto
 				continue
 			}
 			if isSessionOwnDrainStepBead(store, item) {
-				continue
-			}
-			if liveOwners.ownedByLiveSessionOtherThan(item.Assignee, selfID) {
 				continue
 			}
 			return item, true, nil

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -581,9 +581,9 @@ func recordDrainAckAssignedWorkEvent(
 	if rec == nil {
 		return
 	}
-	strandedBead, found, beadLookupErr := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info)
 	if beadLookupErr != nil {
-		fmt.Fprintf(stderr, "session reconciler: locating stranded bead for drain-acked %s: %v\n", name, beadLookupErr) //nolint:errcheck
+		fmt.Fprintf(stderr, "session reconciler: classifying drain-acked work for %s: %v\n", name, beadLookupErr) //nolint:errcheck
 	}
 	if !found {
 		return
@@ -602,6 +602,56 @@ func recordDrainAckAssignedWorkEvent(
 			"drain_acked_with_assigned_work",
 		),
 	})
+}
+
+// drainAckClaimableAnomalyBead returns the work bead that makes a drain-acked
+// session a GENUINE drain-with-assigned-work anomaly worth alarming on, plus
+// whether one was found.
+//
+// SessionDrainAckedWithAssignedWork must fire ONLY for a row the draining seat
+// could actually have claimed and did not — never for correct pull draining.
+// Two large classes of "assigned work" are correct pull, and both are
+// suppressed here:
+//
+//   - An OPEN bead parked on an unmet dependency (routed to the seat's target
+//     but not yet ready). No worker can claim a blocked row, so a seat that
+//     drained past it drained correctly.
+//   - An IN_PROGRESS bead a LIVE sibling incarnation of the same pool is
+//     working, matched only because it carries a pool-shared assignee identity.
+//     A surplus seat draining while a sibling holds the row is normal.
+//
+// A bead is a true anomaly when it is either open AND ready (claimable right
+// now) or in_progress AND assigned to THIS session's own durable bead ID — the
+// gastownhall/gascity#2293 "Shape A" self-strand where a worker exited mid-task
+// without nulling its assignee. The open+ready candidate is resolved first and
+// independently so a self-strand test on a single finder result cannot mask a
+// genuinely claimable row behind a benign in_progress match the finder returned
+// ahead of it. It fails CLOSED: a read error yields (found=false), so a flaky
+// store never manufactures the alarm this classifier exists to keep honest.
+func drainAckClaimableAnomalyBead(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	info sessionpkg.Info,
+) (beads.Bead, bool, error) {
+	readyBead, readyFound, err := firstReadyAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	if readyFound {
+		return readyBead, true, nil
+	}
+	strandedBead, found, err := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	if found &&
+		strings.EqualFold(strings.TrimSpace(strandedBead.Status), "in_progress") &&
+		strings.TrimSpace(strandedBead.Assignee) == strings.TrimSpace(info.ID) {
+		return strandedBead, true, nil
+	}
+	return beads.Bead{}, false, nil
 }
 
 // drainAckFinalizeResult captures the Info-snapshot effect of a
@@ -4675,6 +4725,83 @@ func firstOpenAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifier
 				}
 				return item, true, nil
 			}
+		}
+	}
+	return beads.Bead{}, false, nil
+}
+
+// firstReadyAssignedWorkBeadForReachableStore returns the first READY (open and
+// unblocked) work bead still assigned to the given session in the store the
+// session's configured agent can query, plus whether one was found. It mirrors
+// firstOpenAssignedWorkBeadForReachableStore's reachability/identifier
+// resolution but keys on readiness so the drain-ack anomaly classifier
+// (drainAckClaimableAnomalyBead) can tell a genuinely claimable strand from an
+// open bead parked on an unmet dependency, which no worker could have claimed.
+// Returns (zero-bead, false, nil) when nothing matches.
+func firstReadyAssignedWorkBeadForReachableStore(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	info sessionpkg.Info,
+) (beads.Bead, bool, error) {
+	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	var (
+		bead  beads.Bead
+		found bool
+	)
+	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		b, ok, err := firstReadyAssignedWorkBeadInStoreByIdentifiers(leg.Store, identifiers)
+		if err != nil {
+			return false, err
+		}
+		bead, found = b, ok
+		return ok, nil
+	})
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	if !found {
+		if err := assignedWorkScanComplete(res); err != nil {
+			return beads.Bead{}, false, err
+		}
+	}
+	return bead, found, nil
+}
+
+// firstReadyAssignedWorkBeadInStoreByIdentifiers returns the first ready (open,
+// unblocked) non-session, non-mail work bead in store assigned to any of the
+// given identifiers. It is the ready-keyed sibling of
+// firstOpenAssignedWorkBeadInStoreByIdentifiers: ReadyAssignedTo already
+// excludes in_progress and dependency-blocked rows, so this returns only rows a
+// worker for this session could claim right now.
+func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
+	if store == nil {
+		return beads.Bead{}, false, nil
+	}
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	seen := make(map[string]struct{}, len(identifiers))
+	for _, assignee := range identifiers {
+		if assignee == "" {
+			continue
+		}
+		if _, ok := seen[assignee]; ok {
+			continue
+		}
+		seen[assignee] = struct{}{}
+		items, err := wa.ReadyAssignedTo(assignee, beads.TierBoth)
+		if err != nil {
+			return beads.Bead{}, false, err
+		}
+		for _, item := range excludeMailMessageBeads(items) {
+			if sessionpkg.IsSessionBeadOrRepairable(item) {
+				continue
+			}
+			return item, true, nil
 		}
 	}
 	return beads.Bead{}, false, nil

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -575,13 +575,14 @@ func recordDrainAckAssignedWorkEvent(
 	subject string,
 	template string,
 	name string,
+	now time.Time,
 	rec events.Recorder,
 	stderr io.Writer,
 ) {
 	if rec == nil {
 		return
 	}
-	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info)
+	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info, now)
 	if beadLookupErr != nil {
 		fmt.Fprintf(stderr, "session reconciler: classifying drain-acked work for %s: %v\n", name, beadLookupErr) //nolint:errcheck
 	}
@@ -620,9 +621,10 @@ func recordDrainAckAssignedWorkEvent(
 //     (firstOpenClaimableAssignedWorkBeadForReachableStore) walks the seat's
 //     OpenAssignedTo rows (status=open) and suppresses a row ONLY when it is
 //     provably non-claimable: deferred (fresh bead-local defer_until), or blocked
-//     confirmed against LIVE deps — not on bd's denormalized is_blocked projection
-//     alone, which can read stale-true and would otherwise silence a strand whose
-//     deps are actually met. It does NOT borrow the beads.Ready projection, whose
+//     confirmed against LIVE deps — never on bd's denormalized is_blocked
+//     projection, which can read stale-true and would otherwise silence a strand
+//     whose deps are actually met, and which production reads do not carry at all.
+//     It does NOT borrow the beads.Ready projection, whose
 //     type/label exclusions (step, molecule, gate, gc:order-tracking, …) encode
 //     "not pull-claimable", not "not stranded" — so an OPEN step or other
 //     excluded-type row assigned straight to a seat at dispatch still FIRES,
@@ -633,33 +635,49 @@ func recordDrainAckAssignedWorkEvent(
 //   - The seat's own mol-do-work "drain" step (isSessionOwnDrainStepBead),
 //     excluded for parity with the close gate.
 //
-// An IN_PROGRESS bead assigned to one of the seat's identifiers ALWAYS fires, and
-// is probed FIRST so a graph/deps read error in the open arm can never silence it
-// (and so the payload prefers the most-urgent in_progress candidate, as
-// origin/main did). Distinguishing a genuine cap-hit strand
-// (gastownhall/gascity#2293) from a benign live-sibling claim cannot be done
-// safely at finalize: every liveness signal available here (tmux Running without
-// Alive on a zombie pane, a stale 30s liveness cache with no error channel,
-// name-only keying that borrows a duplicate-named seat's liveness, cross-tick
-// memoization) has a hole that would silence a real strand. Rather than risk that
-// false negative, the in_progress arm accepts the residual benign-live-sibling
-// noise and fires unconditionally. It fails CLOSED: when neither arm finds a bead
-// any arm's read error is surfaced (to be logged, never counted), so a flaky
-// store never manufactures the alarm this classifier exists to keep honest.
+// An IN_PROGRESS bead assigned to one of the seat's identifiers fires
+// unconditionally on sibling liveness — the arm applies the same two structural
+// exclusions listed above (session beads, the seat's own drain step) and then
+// probes NOTHING else, so no liveness or dependency signal can suppress it. It is
+// probed FIRST so a graph/deps read error in the open arm can never silence it,
+// and so the payload names the most-urgent candidate. That second preference is
+// deliberately STRONGER than origin/main's: base ran one combined probe per
+// reachable leg that tried in_progress before open WITHIN that leg, so leg order
+// won across legs and an open row in an earlier leg outranked an in_progress row
+// in a later one. These two walks each sweep EVERY leg, so in_progress now wins
+// ACROSS legs too. The alarm decision is identical either way; only which bead id
+// the payload names can differ, and only in multi-store cities.
+//
+// Distinguishing a genuine cap-hit strand (gastownhall/gascity#2293) from a benign
+// live-sibling claim cannot be done safely at finalize: every liveness signal
+// available here (tmux Running without Alive on a zombie pane, a stale 30s liveness
+// cache with no error channel, name-only keying that borrows a duplicate-named
+// seat's liveness, cross-tick memoization) has a hole that would silence a real
+// strand. Rather than risk that false negative, the in_progress arm accepts the
+// residual benign-live-sibling noise and fires unconditionally. It fails CLOSED:
+// when neither arm finds a bead any arm's read error is surfaced (to be logged,
+// never counted), so a flaky store never manufactures the alarm this classifier
+// exists to keep honest.
 func drainAckClaimableAnomalyBead(
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	now time.Time,
 ) (beads.Bead, bool, error) {
 	inProgressBead, inProgressFound, inProgressErr := firstInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
 	if inProgressFound {
-		return inProgressBead, true, nil
+		return inProgressBead, true, inProgressErr
 	}
-	openBead, openFound, openErr := firstOpenClaimableAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	openBead, openFound, openErr := firstOpenClaimableAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info, now)
 	if openFound {
-		return openBead, true, nil
+		// Carry the in_progress arm's error out with the found bead rather than
+		// dropping it: a partial scan of the MOST-URGENT arm must still reach the
+		// log. recordDrainAckAssignedWorkEvent logs any non-nil error and then
+		// independently checks found, so error-plus-found needs no special casing
+		// and the event still fires.
+		return openBead, true, errors.Join(inProgressErr, openErr)
 	}
 	// Neither arm found a bead. Surface any arm's read error (errors.Join elides
 	// nils, so a clean pass returns nil) so the caller logs it — swallowing a
@@ -868,7 +886,7 @@ func finalizeDrainAckStoppedSession(
 	}
 	recordStopped(true)
 	if hasAssignedWork {
-		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, info, template, template, name, rec, stderr)
+		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, info, template, template, name, clk.Now().UTC(), rec, stderr)
 	}
 	// Non-close drain-ack: the snapshot fold is the ApplyPatchInfo result above.
 	return drainAckFinalizeResult{folded: &foldedInfo}
@@ -4719,16 +4737,22 @@ func firstAssignedWorkBeadForSession(
 // drain-ack anomaly classifier (drainAckClaimableAnomalyBead), which suppresses
 // only provably-non-claimable rows. Returns (zero-bead, false, nil) when nothing
 // matches.
+//
+// now is the tick instant the deferral half of the claimability predicate is
+// evaluated at, threaded from the reconciler's clock so a frozen-clock harness
+// drives it the same way the divergence half's ops.Now seam does. One instant is
+// read for the whole walk, so every leg answers as of the same moment.
 func firstOpenClaimableAssignedWorkBeadForReachableStore(
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	now time.Time,
 ) (beads.Bead, bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
 	return firstAssignedWorkBeadForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (beads.Bead, bool, error) {
-		return firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(s, identifiers)
+		return firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(s, identifiers, now)
 	})
 }
 
@@ -4737,15 +4761,12 @@ func firstOpenClaimableAssignedWorkBeadForReachableStore(
 // identifiers that a worker could claim right now, plus whether one was found.
 //
 // It walks the raw OpenAssignedTo list (status=open) and suppresses a row ONLY
-// when it is provably non-claimable — deferred (defer_until / indefinite
-// deferral, fresh bead-local fields) or blocked on a genuinely unmet dependency.
-// demandRowReady is the cheap first gate (the same predicate the demand/claim-
-// divergence half uses), but its blocked half reads bd's DENORMALIZED is_blocked
-// projection, which can be stale-true; so a row this predicate rejects on the
-// is_blocked signal alone is re-confirmed against live deps
-// (openAssignedBeadHasUnmetBlockingDep) before it is suppressed, exactly as the
-// divergence half refuses to trust the projection blind. A row whose flag is
-// stale-true but whose deps are met is a genuine strand and FIRES.
+// when openAssignedRowProvablyNonClaimable says it is — deferred (defer_until /
+// indefinite deferral, fresh bead-local fields) or confirmed blocked on a
+// genuinely unmet plain `blocks` dependency. That helper owns the whole
+// suppression policy, including why bd's DENORMALIZED is_blocked projection is
+// never trusted on its own here; a row whose flag is stale-true but whose
+// blocking deps are met is a genuine strand and FIRES.
 // Every other open assigned row FIRES regardless of type. This deliberately does
 // NOT reuse the beads.Ready projection: Ready's type exclusions (step, molecule,
 // gate, merge-request, …) and label exclusions (gc:order-tracking, gc:session)
@@ -4758,11 +4779,18 @@ func firstOpenClaimableAssignedWorkBeadForReachableStore(
 // reported as a claimable strand. identifiers are pre-compacted (deduped, no
 // empties) by sessionAssignmentIdentifiersForConfigInfo, so no extra dedupe is
 // needed here.
-func firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
+func firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string, now time.Time) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
-	now := time.Now()
+	if now.IsZero() {
+		// A caller driving this finder directly never opened a tick clock; wall
+		// time is what the reconciler's own clock would have reported anyway. The
+		// fallback lives here rather than at each call site so a zero instant can
+		// never reach beads.IsDeferred, where it would read every future
+		// defer_until as deferred and suppress a genuine strand.
+		now = time.Now()
+	}
 	wa := workAssignmentForStore(beads.WorkStore{Store: store})
 	for _, assignee := range identifiers {
 		items, err := wa.OpenAssignedTo(assignee, "open", beads.TierBoth, true)
@@ -4776,33 +4804,12 @@ func firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(store beads.Store, i
 			if isSessionOwnDrainStepBead(store, item) {
 				continue
 			}
-			if !demandRowReady(item, now) {
-				// Not claimable per the cheap bead-local predicate. A deferred row
-				// is gated by defer_until / indefinite deferral — fresh bead-local
-				// fields, never stale — so no worker could have claimed it and
-				// draining past it was correct pull.
-				if beads.IsDeferred(item, now) {
-					continue
-				}
-				// The only remaining reason demandRowReady rejected an open,
-				// non-deferred row is bd's DENORMALIZED is_blocked projection, which
-				// can read STALE-TRUE: a just-closed blocker whose flag has not been
-				// recomputed (issueops.countStaleIsBlockedSQL / `bd recompute-blocked`
-				// exist precisely to repair it). Suppressing on that signal alone
-				// would silence a genuine strand whose deps are actually met — the
-				// last silencing hole. The divergence half (classifyDemandTrigger)
-				// already refuses to trust the projection blind; this arm must be
-				// equally rigorous, so confirm real blockedness against live deps
-				// before suppressing. Suppress only when a genuine unmet blocking
-				// dependency exists; if the deps are met the flag is stale and the
-				// row is a real strand that must FIRE.
-				blocked, err := openAssignedBeadHasUnmetBlockingDep(store, item.ID)
-				if err != nil {
-					return beads.Bead{}, false, err
-				}
-				if blocked {
-					continue
-				}
+			suppress, err := openAssignedRowProvablyNonClaimable(store, item, now)
+			if err != nil {
+				return beads.Bead{}, false, err
+			}
+			if suppress {
+				continue
 			}
 			return item, true, nil
 		}
@@ -4810,38 +4817,59 @@ func firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(store beads.Store, i
 	return beads.Bead{}, false, nil
 }
 
-// openAssignedBeadHasUnmetBlockingDep re-derives whether an open assigned row is
-// actually blocked, from its live dependencies rather than bd's denormalized
-// is_blocked projection. The drain-ack open arm calls it only when that
-// projection reads true (demandRowReady rejected an open, non-deferred row), to
-// confirm the flag is not stale before suppressing a possible strand.
+// openAssignedRowProvablyNonClaimable reports whether an OPEN assigned row is
+// provably non-claimable, and so may be suppressed instead of reported as a
+// strand. It carries the open arm's entire suppression policy, lifted out of the
+// walk above so that walk stays a scan and this stays a decision.
 //
-// It mirrors the canonical DepList → IsReadyBlockingDependencyType →
-// DependencySatisfied derivation used by cmd_ready.go's blocked_by enrichment and
-// the caching store's ready scan: a row is blocked when any ready-blocking edge
-// points at a target that has not closed satisfactorily. A dep or blocker read
-// that FAILS is returned, not swallowed — the open arm fails closed on it (the
-// classifier surfaces the error to be logged and never manufactures the alarm
-// from an unreadable store), matching how a gate-blocked step is treated as a
-// real fault rather than "no blocker" elsewhere.
-func openAssignedBeadHasUnmetBlockingDep(store beads.Store, id string) (bool, error) {
-	deps, err := store.DepList(id, "down")
-	if err != nil {
-		return false, err
+// classifyDemandRowClaimability (the predicate the demand/claim-divergence half
+// also answers with) names WHY a row is not claimable, and each cause gets the
+// treatment its evidence deserves:
+//
+//   - deferred — defer_until and bd's indefinite deferral are fresh bead-local
+//     fields, never stale, so this is PROOF: no worker could have claimed the row
+//     and draining past it was correct pull.
+//   - blockedness_unproven — bd's is_blocked projection reads STALE-CAPABLE true,
+//     or (the production reading) is absent entirely. Neither is proof, so the
+//     row's real blockedness is settled against live deps first
+//     (beadHasUnmetPlainBlocksDep), exactly as the divergence half settles it —
+//     one shared derivation, so suppression reaches every store class rather than
+//     only the cache-enriched reads that carry the column.
+//   - claimable — bd's projection says explicitly unblocked and nothing else
+//     bead-local excludes the row; it fires.
+//
+// Fails CLOSED on a dep-read error: the error is returned rather than read as "no
+// blocker", so the caller surfaces it instead of manufacturing the alarm from an
+// unreadable store. Know how far that reaches: it is wide precisely because the
+// production reading is ABSENT, so every non-deferred row settles against live
+// deps. The error returns straight out of
+// firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers, abandoning the rest of
+// that assignee's rows AND every remaining identifier, and it aborts
+// storeref.Walk inside firstAssignedWorkBeadForSession, abandoning every
+// remaining leg. So ONE unreadable row suppresses the seat's entire open-arm scan
+// for that finalize — which is one-shot (finalizeDrainAckStoppedSession), so the
+// alarm is dropped rather than retried, and a suppression that broad is not the
+// "provably non-claimable" proof this helper otherwise insists on. That polarity
+// and granularity are nonetheless the house treatment of this read shape, not a
+// local choice: cmd_ready.go's readyBlockedByForRows returns the error when a
+// blocking edge's target will not resolve rather than counting it as "no
+// blocker" — failing the whole ready query — because such an edge is a real
+// fault and not an absence. The most-urgent class never pays for it (the
+// in_progress arm is probed first and consults no dependencies), and the
+// polarity is pinned by
+// TestReconcileSessionBeads_DrainAckDepConfirmReadErrorNoFireAndLogsError.
+func openAssignedRowProvablyNonClaimable(store beads.Store, item beads.Bead, now time.Time) (bool, error) {
+	switch classifyDemandRowClaimability(item, now) {
+	case demandRowDeferred:
+		return true, nil
+	case demandRowBlockednessUnproven:
+		return beadHasUnmetPlainBlocksDep(store, item.ID)
+	default:
+		// Claimable, and any cause added to the predicate later. Suppressing
+		// nothing is the safe polarity for this arm: an unrecognized cause FIRES,
+		// so a strand is never silenced by a case this switch has not learned yet.
+		return false, nil
 	}
-	for _, dep := range deps {
-		if !beads.IsReadyBlockingDependencyType(dep.Type) {
-			continue
-		}
-		blocker, err := store.Get(dep.DependsOnID)
-		if err != nil {
-			return false, err
-		}
-		if !beads.DependencySatisfied(blocker.Status, blocker.Metadata[beadmeta.WorkOutcomeMetadataKey]) {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // firstInProgressAssignedWorkBeadForReachableStore walks EVERY reachable leg for

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -572,6 +572,7 @@ func recordDrainAckAssignedWorkEvent(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	liveOwners liveSessionOwnerSet,
 	subject string,
 	template string,
 	name string,
@@ -581,7 +582,7 @@ func recordDrainAckAssignedWorkEvent(
 	if rec == nil {
 		return
 	}
-	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info)
+	strandedBead, found, beadLookupErr := drainAckClaimableAnomalyBead(cityPath, cfg, store, rigStores, info, liveOwners)
 	if beadLookupErr != nil {
 		fmt.Fprintf(stderr, "session reconciler: classifying drain-acked work for %s: %v\n", name, beadLookupErr) //nolint:errcheck
 	}
@@ -604,6 +605,68 @@ func recordDrainAckAssignedWorkEvent(
 	})
 }
 
+// liveSessionOwnerSet maps every assignment identifier carried by a currently
+// live (non-closed) session to the set of session bead IDs that carry it. The
+// drain-ack anomaly classifier keys on it to decide whether an in_progress
+// bead's assignee is still owned by a LIVE sibling incarnation — the surplus-
+// seat / pool-recycle case that must NOT alarm — versus no live owner besides
+// the draining seat itself, which is a genuine strand that must alarm. The
+// decision is owner-LIVENESS, never assignee identity shape: a hook claim
+// stamps the alias/agent identity (hookClaimAssigneeIdentity), not the durable
+// bead ID, so keying on "assignee == this session's own bead ID" silences the
+// exact cap-hit strand the event exists to emit for.
+type liveSessionOwnerSet map[string]map[string]struct{}
+
+// buildLiveSessionOwnerSet indexes the assignment identifiers of every live
+// (non-closed) session Info by the session bead ID that carries them, so
+// ownedByLiveSessionOtherThan can answer sibling-liveness without re-walking
+// the tick's session snapshot per candidate. It reads the same identifier set
+// the assigned-work finders query by (sessionAssignmentIdentifiersForConfigInfo),
+// so an assignee that matched a draining seat's identifiers is looked up under
+// the identity it was actually stamped with.
+func buildLiveSessionOwnerSet(infos []sessionpkg.Info, cfg *config.City) liveSessionOwnerSet {
+	owners := make(liveSessionOwnerSet)
+	for i := range infos {
+		info := infos[i]
+		id := strings.TrimSpace(info.ID)
+		if id == "" || info.Closed {
+			continue
+		}
+		for _, identifier := range sessionAssignmentIdentifiersForConfigInfo(info, cfg) {
+			identifier = strings.TrimSpace(identifier)
+			if identifier == "" {
+				continue
+			}
+			carriers := owners[identifier]
+			if carriers == nil {
+				carriers = make(map[string]struct{})
+				owners[identifier] = carriers
+			}
+			carriers[id] = struct{}{}
+		}
+	}
+	return owners
+}
+
+// ownedByLiveSessionOtherThan reports whether some live session OTHER than
+// selfID carries assignee in its identifier set — i.e. another live incarnation
+// is genuinely handling a bead stamped with that assignee. selfID is the
+// draining seat's own bead ID, excluded so a seat is never counted as its own
+// live replacement.
+func (o liveSessionOwnerSet) ownedByLiveSessionOtherThan(assignee, selfID string) bool {
+	assignee = strings.TrimSpace(assignee)
+	if assignee == "" {
+		return false
+	}
+	selfID = strings.TrimSpace(selfID)
+	for ownerID := range o[assignee] {
+		if ownerID != selfID {
+			return true
+		}
+	}
+	return false
+}
+
 // drainAckClaimableAnomalyBead returns the work bead that makes a drain-acked
 // session a GENUINE drain-with-assigned-work anomaly worth alarming on, plus
 // whether one was found.
@@ -621,12 +684,17 @@ func recordDrainAckAssignedWorkEvent(
 //     A surplus seat draining while a sibling holds the row is normal.
 //
 // A bead is a true anomaly when it is either open AND ready (claimable right
-// now) or in_progress AND assigned to THIS session's own durable bead ID — the
-// gastownhall/gascity#2293 "Shape A" self-strand where a worker exited mid-task
-// without nulling its assignee. The open+ready candidate is resolved first and
-// independently so a self-strand test on a single finder result cannot mask a
-// genuinely claimable row behind a benign in_progress match the finder returned
-// ahead of it. It fails CLOSED: a read error yields (found=false), so a flaky
+// now) or in_progress with NO live owner other than the draining seat itself
+// (dead sibling, or a named/pool seat with no live replacement — the
+// gastownhall/gascity#2293 cap-hit self-strand). The key is owner-LIVENESS
+// against the reconciler's running-session inventory (liveOwners), NOT the
+// assignee's identity shape: production hook claims stamp the alias/agent
+// identity rather than the durable bead ID, so a "assignee == own bead ID" test
+// would silence the strict superset of genuine alias-claimed strands. The
+// open+ready candidate is resolved first and independently, and the in_progress
+// walk continues past benign live-sibling rows across every reachable leg
+// (firstStrandedInProgressAssignedWorkBeadForReachableStore) so neither can mask
+// the other. It fails CLOSED: a read error yields (found=false), so a flaky
 // store never manufactures the alarm this classifier exists to keep honest.
 func drainAckClaimableAnomalyBead(
 	cityPath string,
@@ -634,6 +702,7 @@ func drainAckClaimableAnomalyBead(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	liveOwners liveSessionOwnerSet,
 ) (beads.Bead, bool, error) {
 	readyBead, readyFound, err := firstReadyAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
 	if err != nil {
@@ -642,16 +711,7 @@ func drainAckClaimableAnomalyBead(
 	if readyFound {
 		return readyBead, true, nil
 	}
-	strandedBead, found, err := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
-	if err != nil {
-		return beads.Bead{}, false, err
-	}
-	if found &&
-		strings.EqualFold(strings.TrimSpace(strandedBead.Status), "in_progress") &&
-		strings.TrimSpace(strandedBead.Assignee) == strings.TrimSpace(info.ID) {
-		return strandedBead, true, nil
-	}
-	return beads.Bead{}, false, nil
+	return firstStrandedInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info, liveOwners)
 }
 
 // drainAckFinalizeResult captures the Info-snapshot effect of a
@@ -715,6 +775,7 @@ func finalizeDrainAckStoppedSession(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	liveOwners liveSessionOwnerSet,
 	template string,
 	closeIfUnassigned bool,
 	dops drainOps,
@@ -852,7 +913,7 @@ func finalizeDrainAckStoppedSession(
 	}
 	recordStopped(true)
 	if hasAssignedWork {
-		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, info, template, template, name, rec, stderr)
+		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, info, liveOwners, template, template, name, rec, stderr)
 	}
 	// Non-close drain-ack: the snapshot fold is the ApplyPatchInfo result above.
 	return drainAckFinalizeResult{folded: &foldedInfo}
@@ -865,6 +926,7 @@ func reconcileDrainAckStopPending(
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	liveOwners liveSessionOwnerSet,
 	tp TemplateParams,
 	desired bool,
 	dops drainOps,
@@ -888,7 +950,7 @@ func reconcileDrainAckStopPending(
 		return true, drainAckFinalizeResult{}
 	}
 	return true, finalizeDrainAckStoppedSession(
-		cityPath, cfg, store, rigStores, info, tp.TemplateName,
+		cityPath, cfg, store, rigStores, info, liveOwners, tp.TemplateName,
 		!desired || isPoolManagedSessionInfo(info),
 		dops, dt, clk, rec, stderr,
 	)
@@ -934,6 +996,10 @@ func finalizeDrainAckStopPendingSessions(
 	if store == nil || sp == nil || len(infos) == 0 {
 		return 0
 	}
+	// The caller-fed snapshot IS this pass's live-session inventory, so the
+	// drain-ack anomaly classifier can tell an in_progress bead a live sibling
+	// owns from a genuine strand without a re-query.
+	liveOwners := buildLiveSessionOwnerSet(infos, cfg)
 	finalized := 0
 	for _, info := range infos {
 		if !isDrainAckStopPendingInfo(info) {
@@ -971,7 +1037,7 @@ func finalizeDrainAckStopPendingSessions(
 		// state=drained: open pool session beads occupy slots in the next demand
 		// calculation, while closed beads remain only as lifecycle history.
 		finalizeDrainAckStoppedSession(
-			cityPath, cfg, store, rigStores, info,
+			cityPath, cfg, store, rigStores, info, liveOwners,
 			normalizedSessionTemplateInfo(info, cfg),
 			isPoolManagedSessionInfo(info),
 			dops, dt, clk, rec, stderr,
@@ -1684,6 +1750,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	infoByID := tick.infoByID
 	orderedIDs := tick.orderedIDs
 
+	// The tick's running-session inventory, indexed by assignment identifier, is
+	// built once from the tick-start snapshot so the drain-ack anomaly classifier
+	// can tell an in_progress bead a live sibling incarnation owns (correct
+	// surplus-seat / pool-recycle drain, suppress) from one with no live owner but
+	// the draining seat itself (a genuine strand, fire). Built before the forward
+	// pass so a session closed mid-tick is still counted as the live owner it was
+	// at tick start, matching the reconciler's coherent snapshot view.
+	liveOwners := buildLiveSessionOwnerSet(orderedInfos, cfg)
+
 	phaseStart = time.Now()
 	cbNow := clk.Now().UTC()
 	cbCfg, cbEnabled := sessionCircuitBreakerConfigFromCity(cfg)
@@ -1847,7 +1922,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			dt.clearSuspendDeferral(id)
 		}
 
-		if handled, result := reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, info, tp, desired, dops, dt, asyncStopTracker, clk, rec, stderr); handled {
+		if handled, result := reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, info, liveOwners, tp, desired, dops, dt, asyncStopTracker, clk, rec, stderr); handled {
 			// finalizeDrainAckStoppedSession (inside reconcileDrainAckStopPending)
 			// may close the bead in memory (Status=closed) on this true/continue
 			// path; fold that close onto the snapshot so the cross-session min-floor
@@ -2305,7 +2380,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							continue
 						}
 						result := finalizeDrainAckStoppedSession(
-							cityPath, cfg, store, rigStores, infoByID[id], template,
+							cityPath, cfg, store, rigStores, infoByID[id], liveOwners, template,
 							true, dops, dt, clk, rec, stderr,
 						)
 						// finalizeDrainAckStoppedSession may close the bead in memory; fold
@@ -2759,7 +2834,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						finalizeDT = nil
 					}
 					result := finalizeDrainAckStoppedSession(
-						cityPath, cfg, store, rigStores, infoByID[id], tp.TemplateName,
+						cityPath, cfg, store, rigStores, infoByID[id], liveOwners, tp.TemplateName,
 						isPoolManagedSessionInfo(infoByID[id]),
 						dops, finalizeDT,
 						clk, rec, stderr,
@@ -4778,7 +4853,10 @@ func firstReadyAssignedWorkBeadForReachableStore(
 // given identifiers. It is the ready-keyed sibling of
 // firstOpenAssignedWorkBeadInStoreByIdentifiers: ReadyAssignedTo already
 // excludes in_progress and dependency-blocked rows, so this returns only rows a
-// worker for this session could claim right now.
+// worker for this session could claim right now. It also skips the seat's own
+// mol-do-work drain step (isSessionOwnDrainStepBead), mirroring the close gate's
+// hasNonSessionNonOwnDrainStepWork so a session's own open drain step is never
+// reported as a claimable strand.
 func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
@@ -4799,6 +4877,95 @@ func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifie
 		}
 		for _, item := range excludeMailMessageBeads(items) {
 			if sessionpkg.IsSessionBeadOrRepairable(item) {
+				continue
+			}
+			if isSessionOwnDrainStepBead(store, item) {
+				continue
+			}
+			return item, true, nil
+		}
+	}
+	return beads.Bead{}, false, nil
+}
+
+// firstStrandedInProgressAssignedWorkBeadForReachableStore walks EVERY reachable
+// leg for an in_progress work bead assigned to the draining session whose
+// assignee has no live owner other than the session itself — a genuine strand.
+// Unlike firstOpenAssignedWorkBeadForReachableStore (which stops at the first
+// leg with any match), it must not let a benign in_progress row a live sibling
+// is working in an earlier leg mask a genuine strand in a later leg, so it keeps
+// walking until it finds an unowned in_progress row or exhausts the plan. This
+// mirrors the independence of the ready walk. Returns (zero-bead, false, nil)
+// when every in_progress match is owned by a live sibling incarnation.
+func firstStrandedInProgressAssignedWorkBeadForReachableStore(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	info sessionpkg.Info,
+	liveOwners liveSessionOwnerSet,
+) (beads.Bead, bool, error) {
+	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
+	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	var (
+		bead  beads.Bead
+		found bool
+	)
+	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
+		b, ok, err := firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(leg.Store, identifiers, info.ID, liveOwners)
+		if err != nil {
+			return false, err
+		}
+		bead, found = b, ok
+		return ok, nil
+	})
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	if !found {
+		if err := assignedWorkScanComplete(res); err != nil {
+			return beads.Bead{}, false, err
+		}
+	}
+	return bead, found, nil
+}
+
+// firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers returns the first
+// in_progress non-session, non-mail work bead in store assigned to one of the
+// given identifiers whose assignee is not owned by a live session other than
+// selfID — i.e. a genuine strand. In_progress rows a live sibling incarnation is
+// working (owner-liveness true) are skipped so a surplus-seat / pool-recycle
+// drain does not alarm, and the seat's own mol-do-work drain step is skipped for
+// parity with the ready finder and the close gate.
+func firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string, selfID string, liveOwners liveSessionOwnerSet) (beads.Bead, bool, error) {
+	if store == nil {
+		return beads.Bead{}, false, nil
+	}
+	wa := workAssignmentForStore(beads.WorkStore{Store: store})
+	seen := make(map[string]struct{}, len(identifiers))
+	for _, assignee := range identifiers {
+		if assignee == "" {
+			continue
+		}
+		if _, ok := seen[assignee]; ok {
+			continue
+		}
+		seen[assignee] = struct{}{}
+		items, err := wa.OpenAssignedTo(assignee, "in_progress", beads.TierBoth, true)
+		if err != nil {
+			return beads.Bead{}, false, err
+		}
+		for _, item := range items {
+			if sessionpkg.IsSessionBeadOrRepairable(item) {
+				continue
+			}
+			if isSessionOwnDrainStepBead(store, item) {
+				continue
+			}
+			if liveOwners.ownedByLiveSessionOtherThan(item.Assignee, selfID) {
 				continue
 			}
 			return item, true, nil

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -605,42 +605,89 @@ func recordDrainAckAssignedWorkEvent(
 	})
 }
 
-// liveSessionOwnerSet maps every assignment identifier carried by a currently
-// live (non-closed) session to the set of session bead IDs that carry it. The
-// drain-ack anomaly classifier keys on it to decide whether an in_progress
-// bead's assignee is still owned by a LIVE sibling incarnation — the surplus-
-// seat / pool-recycle case that must NOT alarm — versus no live owner besides
-// the draining seat itself, which is a genuine strand that must alarm. The
-// decision is owner-LIVENESS, never assignee identity shape: a hook claim
+// liveSessionOwnerSet answers, for a drain-acked seat's in_progress row, the one
+// question that can positively excuse the strand alarm: is the row's assignee
+// still carried by some OTHER session whose RUNTIME is positively observed alive
+// this pass? Only a genuinely running sibling incarnation (the surplus-seat /
+// pool-recycle case) may suppress the alarm.
+//
+// The default is FIRE. Suppression demands a positively-confirmed benign cause,
+// so a candidate owner counts ONLY when its runtime is observed running/alive —
+// never merely because its session bead is not closed. Keying on bead-not-closed
+// was the silencing bug: it counted (a) a same-pass-draining sibling whose
+// runtime was just observed dead and (b) a drained-open ZOMBIE seat kept open by
+// the very row it stranded, letting two same-alias seats mutually suppress and a
+// zombie permanently silence a recurring cap-hit strand. Excluded from the owner
+// set up front: the draining seat itself (selfID), any closed seat, and any
+// drain-ack-stop-pending seat (on its way out, never a live replacement). Every
+// surviving candidate is then gated on a POSITIVE runtime observation.
+//
+// The decision is owner-LIVENESS, never assignee identity shape: a hook claim
 // stamps the alias/agent identity (hookClaimAssigneeIdentity), not the durable
-// bead ID, so keying on "assignee == this session's own bead ID" silences the
-// exact cap-hit strand the event exists to emit for.
-type liveSessionOwnerSet map[string]map[string]struct{}
+// bead ID, so keying on "assignee == this session's own bead ID" would silence
+// the exact gastownhall/gascity#2293 cap-hit strand the event exists to emit for.
+//
+// Runtime observation is lazy and memoized per session bead ID: the hot reconcile
+// path observes a candidate's runtime only when an in_progress strand is actually
+// being classified (rare), never once-per-session-per-tick. An observation error
+// or absent runtime resolves to "not alive" so an unconfirmable seat can never
+// suppress a strand — fail toward FIRE.
+type liveSessionOwnerSet struct {
+	// carriersByIdentifier maps each assignment identifier to the candidate
+	// session bead IDs that carry it (closed and drain-pending seats already
+	// excluded at build time).
+	carriersByIdentifier map[string]map[string]struct{}
+	// candidateByID recovers a candidate's Info (session name, template) so the
+	// lazy probe can observe its runtime.
+	candidateByID map[string]sessionpkg.Info
+	// runtimeAlive positively observes a candidate owner's runtime this pass. A
+	// nil probe means nothing can be confirmed alive, so no candidate suppresses
+	// (every strand fires).
+	runtimeAlive func(sessionpkg.Info) bool
+	// aliveByID memoizes runtimeAlive per candidate within the pass. The map is a
+	// reference type, so the value-receiver methods below share one memo table.
+	aliveByID map[string]bool
+}
 
-// buildLiveSessionOwnerSet indexes the assignment identifiers of every live
-// (non-closed) session Info by the session bead ID that carries them, so
-// ownedByLiveSessionOtherThan can answer sibling-liveness without re-walking
-// the tick's session snapshot per candidate. It reads the same identifier set
-// the assigned-work finders query by (sessionAssignmentIdentifiersForConfigInfo),
-// so an assignee that matched a draining seat's identifiers is looked up under
-// the identity it was actually stamped with.
-func buildLiveSessionOwnerSet(infos []sessionpkg.Info, cfg *config.City) liveSessionOwnerSet {
-	owners := make(liveSessionOwnerSet)
+// buildLiveSessionOwnerSet indexes the assignment identifiers of every candidate
+// owner session by the session bead ID that carries them, pairing the index with
+// a lazy runtime-liveness probe. A candidate is any session Info that is neither
+// closed nor drain-ack-stop-pending: a closed or draining seat is never a live
+// replacement, so excluding both up front makes same-pass-drain mutual
+// suppression impossible by construction. It reads the same identifier set the
+// assigned-work finders query by (sessionAssignmentIdentifiersForConfigInfo), so
+// an assignee that matched a draining seat's identifiers is looked up under the
+// identity it was actually stamped with. runtimeAlive is the positive runtime
+// observation ownedByLiveSessionOtherThan gates every surviving candidate on.
+func buildLiveSessionOwnerSet(infos []sessionpkg.Info, cfg *config.City, runtimeAlive func(sessionpkg.Info) bool) liveSessionOwnerSet {
+	owners := liveSessionOwnerSet{
+		carriersByIdentifier: make(map[string]map[string]struct{}),
+		candidateByID:        make(map[string]sessionpkg.Info),
+		runtimeAlive:         runtimeAlive,
+		aliveByID:            make(map[string]bool),
+	}
 	for i := range infos {
 		info := infos[i]
 		id := strings.TrimSpace(info.ID)
 		if id == "" || info.Closed {
 			continue
 		}
+		// A drain-ack-stop-pending seat is already leaving; counting it as a live
+		// owner is how a same-pass-draining sibling would silence a peer's strand.
+		// Exclude it here, before the runtime probe would even be consulted.
+		if isDrainAckStopPendingInfo(info) {
+			continue
+		}
+		owners.candidateByID[id] = info
 		for _, identifier := range sessionAssignmentIdentifiersForConfigInfo(info, cfg) {
 			identifier = strings.TrimSpace(identifier)
 			if identifier == "" {
 				continue
 			}
-			carriers := owners[identifier]
+			carriers := owners.carriersByIdentifier[identifier]
 			if carriers == nil {
 				carriers = make(map[string]struct{})
-				owners[identifier] = carriers
+				owners.carriersByIdentifier[identifier] = carriers
 			}
 			carriers[id] = struct{}{}
 		}
@@ -648,23 +695,67 @@ func buildLiveSessionOwnerSet(infos []sessionpkg.Info, cfg *config.City) liveSes
 	return owners
 }
 
-// ownedByLiveSessionOtherThan reports whether some live session OTHER than
-// selfID carries assignee in its identifier set — i.e. another live incarnation
-// is genuinely handling a bead stamped with that assignee. selfID is the
+// ownedByLiveSessionOtherThan reports whether some session OTHER than selfID
+// carries assignee AND has its runtime positively observed alive this pass — the
+// only positively-benign reason to suppress the strand alarm. selfID is the
 // draining seat's own bead ID, excluded so a seat is never counted as its own
-// live replacement.
+// live replacement. A candidate whose runtime cannot be confirmed alive (observed
+// dead, absent, or unobservable) does NOT suppress: the strand fires.
 func (o liveSessionOwnerSet) ownedByLiveSessionOtherThan(assignee, selfID string) bool {
 	assignee = strings.TrimSpace(assignee)
 	if assignee == "" {
 		return false
 	}
 	selfID = strings.TrimSpace(selfID)
-	for ownerID := range o[assignee] {
-		if ownerID != selfID {
+	for ownerID := range o.carriersByIdentifier[assignee] {
+		if ownerID == selfID {
+			continue
+		}
+		if o.runtimeAliveThisPass(ownerID) {
 			return true
 		}
 	}
 	return false
+}
+
+// runtimeAliveThisPass reports whether the candidate owner id is positively
+// observed runtime-alive this pass, memoizing the probe result per id. A nil
+// probe or an unknown id is "not alive" — the fail-toward-fire default.
+func (o liveSessionOwnerSet) runtimeAliveThisPass(id string) bool {
+	if o.runtimeAlive == nil {
+		return false
+	}
+	if alive, ok := o.aliveByID[id]; ok {
+		return alive
+	}
+	info, ok := o.candidateByID[id]
+	if !ok {
+		return false
+	}
+	alive := o.runtimeAlive(info)
+	o.aliveByID[id] = alive
+	return alive
+}
+
+// sessionRuntimeAliveProbe returns the positive runtime-liveness observation
+// buildLiveSessionOwnerSet gates candidate owners on. It observes the session's
+// provider runtime with the same liveness call the reconciler's forward pass and
+// drain-ack finalize use, and reports alive ONLY when the runtime is observed
+// running or its agent process is alive. A nil provider, an empty session name,
+// or an observation error reports NOT alive, so an unconfirmable seat can never
+// suppress a strand (default = fire).
+func sessionRuntimeAliveProbe(sp runtime.Provider, cfg *config.City) func(sessionpkg.Info) bool {
+	return func(info sessionpkg.Info) bool {
+		name := strings.TrimSpace(info.SessionNameMetadata)
+		if sp == nil || name == "" {
+			return false
+		}
+		running, alive, err := observeRuntimeProviderLiveness(sp, name, drainAckStopPendingProcessNames(cfg, info))
+		if err != nil {
+			return false
+		}
+		return running || alive
+	}
 }
 
 // drainAckClaimableAnomalyBead returns the work bead that makes a drain-acked
@@ -679,20 +770,25 @@ func (o liveSessionOwnerSet) ownedByLiveSessionOtherThan(assignee, selfID string
 //   - An OPEN bead parked on an unmet dependency (routed to the seat's target
 //     but not yet ready). No worker can claim a blocked row, so a seat that
 //     drained past it drained correctly.
-//   - An IN_PROGRESS bead a LIVE sibling incarnation of the same pool is
-//     working, matched only because it carries a pool-shared assignee identity.
-//     A surplus seat draining while a sibling holds the row is normal.
+//   - An IN_PROGRESS bead a sibling incarnation of the same pool whose RUNTIME is
+//     positively observed alive this pass is working, matched only because it
+//     carries a pool-shared assignee identity. A surplus seat draining while a
+//     genuinely-running sibling holds the row is normal.
 //
 // A bead is a true anomaly when it is either open AND ready (claimable right
-// now) or in_progress with NO live owner other than the draining seat itself
-// (dead sibling, or a named/pool seat with no live replacement — the
-// gastownhall/gascity#2293 cap-hit self-strand). The key is owner-LIVENESS
-// against the reconciler's running-session inventory (liveOwners), NOT the
-// assignee's identity shape: production hook claims stamp the alias/agent
-// identity rather than the durable bead ID, so a "assignee == own bead ID" test
-// would silence the strict superset of genuine alias-claimed strands. The
-// open+ready candidate is resolved first and independently, and the in_progress
-// walk continues past benign live-sibling rows across every reachable leg
+// now) or in_progress with NO runtime-alive owner other than the draining seat
+// itself (dead sibling, same-pass-draining sibling, drained-open zombie, or a
+// named/pool seat with no live replacement — the gastownhall/gascity#2293 cap-hit
+// self-strand). The key is owner RUNTIME-LIVENESS (liveOwners positively observes
+// each candidate's runtime), NOT the assignee's identity shape and NOT mere
+// bead-not-closed: production hook claims stamp the alias/agent identity rather
+// than the durable bead ID, so a "assignee == own bead ID" test would silence the
+// strict superset of genuine alias-claimed strands, and counting a non-closed but
+// runtime-dead seat as a live owner would let a zombie or a same-pass-draining
+// sibling silence a genuine strand. The default is FIRE; suppression demands a
+// positively-confirmed runtime-alive owner. The open+ready candidate is resolved
+// first and independently, and the in_progress walk continues past benign
+// runtime-alive-sibling rows across every reachable leg
 // (firstStrandedInProgressAssignedWorkBeadForReachableStore) so neither can mask
 // the other. It fails CLOSED: a read error yields (found=false), so a flaky
 // store never manufactures the alarm this classifier exists to keep honest.
@@ -996,10 +1092,12 @@ func finalizeDrainAckStopPendingSessions(
 	if store == nil || sp == nil || len(infos) == 0 {
 		return 0
 	}
-	// The caller-fed snapshot IS this pass's live-session inventory, so the
-	// drain-ack anomaly classifier can tell an in_progress bead a live sibling
-	// owns from a genuine strand without a re-query.
-	liveOwners := buildLiveSessionOwnerSet(infos, cfg)
+	// The caller-fed snapshot IS this pass's candidate-owner inventory (closed and
+	// drain-pending seats excluded at build), and the runtime probe positively
+	// confirms a candidate is still running before it may suppress a strand, so
+	// the classifier tells an in_progress bead a genuinely-live sibling owns from a
+	// genuine strand — never letting a same-pass-draining or zombie seat silence it.
+	liveOwners := buildLiveSessionOwnerSet(infos, cfg, sessionRuntimeAliveProbe(sp, cfg))
 	finalized := 0
 	for _, info := range infos {
 		if !isDrainAckStopPendingInfo(info) {
@@ -1750,14 +1848,16 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	infoByID := tick.infoByID
 	orderedIDs := tick.orderedIDs
 
-	// The tick's running-session inventory, indexed by assignment identifier, is
-	// built once from the tick-start snapshot so the drain-ack anomaly classifier
-	// can tell an in_progress bead a live sibling incarnation owns (correct
-	// surplus-seat / pool-recycle drain, suppress) from one with no live owner but
-	// the draining seat itself (a genuine strand, fire). Built before the forward
-	// pass so a session closed mid-tick is still counted as the live owner it was
-	// at tick start, matching the reconciler's coherent snapshot view.
-	liveOwners := buildLiveSessionOwnerSet(orderedInfos, cfg)
+	// The tick's candidate-owner inventory, indexed by assignment identifier, is
+	// built once from the tick-start snapshot (closed and drain-pending seats
+	// excluded) and paired with a lazy runtime probe, so the drain-ack anomaly
+	// classifier can tell an in_progress bead a genuinely RUNTIME-ALIVE sibling
+	// incarnation owns (correct surplus-seat / pool-recycle drain, suppress) from
+	// one with no live owner but the draining seat itself (a genuine strand, fire).
+	// The probe observes each candidate's runtime lazily at classification time, so
+	// a seat whose runtime died mid-tick or a drained-open zombie is excluded on a
+	// positive dead observation rather than trusted because its bead is still open.
+	liveOwners := buildLiveSessionOwnerSet(orderedInfos, cfg, sessionRuntimeAliveProbe(sp, cfg))
 
 	phaseStart = time.Now()
 	cbNow := clk.Now().UTC()
@@ -4726,27 +4826,24 @@ func sessionHasAwakeAssignedWorkForReachableStore(
 	})
 }
 
-// firstOpenAssignedWorkBeadForReachableStore returns the first open or
-// in-progress work bead still assigned to the given session in the store the
-// session's configured agent can query, plus whether one was found. Uses the
-// same reachability resolution as sessionHasOpenAssignedWorkForReachableStore
-// (configured agent's store, with cross-store fallback when the agent
-// template isn't resolvable); emission sites that need the stranded bead's
-// ID (e.g., for the SessionDrainAckedWithAssignedWork event payload per
-// gastownhall/gascity#2293) call this instead of the bool-only helper.
-// Status iteration prefers "in_progress" over "open" so the bead returned is
-// the most-urgent stranded candidate — this is intentional and asymmetric
-// with the bool helpers, which short-circuit on any match and so iterate
-// in the historical "open" / "in_progress" order.
-// Returns (zero-bead, false, nil) when nothing matches.
-func firstOpenAssignedWorkBeadForReachableStore(
+// firstAssignedWorkBeadForSession walks the session's reachable work-store legs
+// in plan order and returns the first bead a per-leg probe reports, plus whether
+// one was found. It is the bead-returning peer of assignedWorkExistsForSession:
+// the probe answers a single leg, and the walk stops at the first leg whose probe
+// returns found=true. A probe that must skip benign rows (the stranded in_progress
+// finder) simply returns found=false for a leg holding only benign matches, so
+// the walk continues to later legs — a benign earlier-leg row can never mask a
+// genuine match in a later leg. Fails CLOSED: a leg read error aborts, and an
+// incomplete scan with no match is surfaced through assignedWorkScanComplete so a
+// dark rig is never reported as "no work".
+func firstAssignedWorkBeadForSession(
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
+	probe func(beads.Store) (beads.Bead, bool, error),
 ) (beads.Bead, bool, error) {
-	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
 	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
 	if err != nil {
 		return beads.Bead{}, false, err
@@ -4756,7 +4853,7 @@ func firstOpenAssignedWorkBeadForReachableStore(
 		found bool
 	)
 	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
-		b, ok, err := firstOpenAssignedWorkBeadInStoreByIdentifiers(leg.Store, identifiers)
+		b, ok, err := probe(leg.Store)
 		if err != nil {
 			return false, err
 		}
@@ -4774,45 +4871,13 @@ func firstOpenAssignedWorkBeadForReachableStore(
 	return bead, found, nil
 }
 
-func firstOpenAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
-	if store == nil {
-		return beads.Bead{}, false, nil
-	}
-	wa := workAssignmentForStore(beads.WorkStore{Store: store})
-	seen := make(map[string]struct{}, len(identifiers))
-	for _, status := range []string{"in_progress", "open"} {
-		for _, assignee := range identifiers {
-			if assignee == "" {
-				continue
-			}
-			key := status + "\x00" + assignee
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			items, err := wa.OpenAssignedTo(assignee, status, beads.TierBoth, true)
-			if err != nil {
-				return beads.Bead{}, false, err
-			}
-			for _, item := range items {
-				if sessionpkg.IsSessionBeadOrRepairable(item) {
-					continue
-				}
-				return item, true, nil
-			}
-		}
-	}
-	return beads.Bead{}, false, nil
-}
-
 // firstReadyAssignedWorkBeadForReachableStore returns the first READY (open and
 // unblocked) work bead still assigned to the given session in the store the
-// session's configured agent can query, plus whether one was found. It mirrors
-// firstOpenAssignedWorkBeadForReachableStore's reachability/identifier
-// resolution but keys on readiness so the drain-ack anomaly classifier
-// (drainAckClaimableAnomalyBead) can tell a genuinely claimable strand from an
-// open bead parked on an unmet dependency, which no worker could have claimed.
-// Returns (zero-bead, false, nil) when nothing matches.
+// session's configured agent can query, plus whether one was found. It keys on
+// readiness so the drain-ack anomaly classifier (drainAckClaimableAnomalyBead)
+// can tell a genuinely claimable strand from an open bead parked on an unmet
+// dependency, which no worker could have claimed. Returns (zero-bead, false, nil)
+// when nothing matches.
 func firstReadyAssignedWorkBeadForReachableStore(
 	cityPath string,
 	cfg *config.City,
@@ -4821,56 +4886,27 @@ func firstReadyAssignedWorkBeadForReachableStore(
 	info sessionpkg.Info,
 ) (beads.Bead, bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
-	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
-	if err != nil {
-		return beads.Bead{}, false, err
-	}
-	var (
-		bead  beads.Bead
-		found bool
-	)
-	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
-		b, ok, err := firstReadyAssignedWorkBeadInStoreByIdentifiers(leg.Store, identifiers)
-		if err != nil {
-			return false, err
-		}
-		bead, found = b, ok
-		return ok, nil
+	return firstAssignedWorkBeadForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (beads.Bead, bool, error) {
+		return firstReadyAssignedWorkBeadInStoreByIdentifiers(s, identifiers)
 	})
-	if err != nil {
-		return beads.Bead{}, false, err
-	}
-	if !found {
-		if err := assignedWorkScanComplete(res); err != nil {
-			return beads.Bead{}, false, err
-		}
-	}
-	return bead, found, nil
 }
 
 // firstReadyAssignedWorkBeadInStoreByIdentifiers returns the first ready (open,
 // unblocked) non-session, non-mail work bead in store assigned to any of the
-// given identifiers. It is the ready-keyed sibling of
-// firstOpenAssignedWorkBeadInStoreByIdentifiers: ReadyAssignedTo already
-// excludes in_progress and dependency-blocked rows, so this returns only rows a
-// worker for this session could claim right now. It also skips the seat's own
-// mol-do-work drain step (isSessionOwnDrainStepBead), mirroring the close gate's
+// given identifiers. ReadyAssignedTo already excludes in_progress and
+// dependency-blocked rows, so this returns only rows a worker for this session
+// could claim right now. It also skips the seat's own mol-do-work drain step
+// (isSessionOwnDrainStepBead), mirroring the close gate's
 // hasNonSessionNonOwnDrainStepWork so a session's own open drain step is never
-// reported as a claimable strand.
+// reported as a claimable strand. identifiers are pre-compacted (deduped, no
+// empties) by sessionAssignmentIdentifiersForConfigInfo, so no extra dedupe is
+// needed here.
 func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
 	wa := workAssignmentForStore(beads.WorkStore{Store: store})
-	seen := make(map[string]struct{}, len(identifiers))
 	for _, assignee := range identifiers {
-		if assignee == "" {
-			continue
-		}
-		if _, ok := seen[assignee]; ok {
-			continue
-		}
-		seen[assignee] = struct{}{}
 		items, err := wa.ReadyAssignedTo(assignee, beads.TierBoth)
 		if err != nil {
 			return beads.Bead{}, false, err
@@ -4890,13 +4926,12 @@ func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifie
 
 // firstStrandedInProgressAssignedWorkBeadForReachableStore walks EVERY reachable
 // leg for an in_progress work bead assigned to the draining session whose
-// assignee has no live owner other than the session itself — a genuine strand.
-// Unlike firstOpenAssignedWorkBeadForReachableStore (which stops at the first
-// leg with any match), it must not let a benign in_progress row a live sibling
-// is working in an earlier leg mask a genuine strand in a later leg, so it keeps
-// walking until it finds an unowned in_progress row or exhausts the plan. This
-// mirrors the independence of the ready walk. Returns (zero-bead, false, nil)
-// when every in_progress match is owned by a live sibling incarnation.
+// assignee has no RUNTIME-ALIVE owner other than the session itself — a genuine
+// strand. A benign in_progress row a live sibling is working in an earlier leg
+// must not mask a genuine strand in a later leg, so the per-leg probe returns
+// found=false for a leg holding only owned rows and firstAssignedWorkBeadForSession
+// keeps walking. Returns (zero-bead, false, nil) when every in_progress match is
+// owned by a runtime-alive sibling incarnation.
 func firstStrandedInProgressAssignedWorkBeadForReachableStore(
 	cityPath string,
 	cfg *config.City,
@@ -4906,54 +4941,26 @@ func firstStrandedInProgressAssignedWorkBeadForReachableStore(
 	liveOwners liveSessionOwnerSet,
 ) (beads.Bead, bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
-	plan, err := assignedWorkPlanForSessionInfo(cityPath, cfg, store, rigStores, info)
-	if err != nil {
-		return beads.Bead{}, false, err
-	}
-	var (
-		bead  beads.Bead
-		found bool
-	)
-	res, err := storeref.Walk(plan, func(leg storeref.Leg) (bool, error) {
-		b, ok, err := firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(leg.Store, identifiers, info.ID, liveOwners)
-		if err != nil {
-			return false, err
-		}
-		bead, found = b, ok
-		return ok, nil
+	return firstAssignedWorkBeadForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (beads.Bead, bool, error) {
+		return firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(s, identifiers, info.ID, liveOwners)
 	})
-	if err != nil {
-		return beads.Bead{}, false, err
-	}
-	if !found {
-		if err := assignedWorkScanComplete(res); err != nil {
-			return beads.Bead{}, false, err
-		}
-	}
-	return bead, found, nil
 }
 
 // firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers returns the first
 // in_progress non-session, non-mail work bead in store assigned to one of the
-// given identifiers whose assignee is not owned by a live session other than
-// selfID — i.e. a genuine strand. In_progress rows a live sibling incarnation is
-// working (owner-liveness true) are skipped so a surplus-seat / pool-recycle
-// drain does not alarm, and the seat's own mol-do-work drain step is skipped for
-// parity with the ready finder and the close gate.
+// given identifiers whose assignee is not owned by a runtime-alive session other
+// than selfID — i.e. a genuine strand. In_progress rows a runtime-alive sibling
+// incarnation is working (ownedByLiveSessionOtherThan true) are skipped so a
+// surplus-seat / pool-recycle drain does not alarm, and the seat's own mol-do-work
+// drain step is skipped for parity with the ready finder and the close gate.
+// identifiers are pre-compacted (deduped, no empties) by
+// sessionAssignmentIdentifiersForConfigInfo.
 func firstStrandedInProgressAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string, selfID string, liveOwners liveSessionOwnerSet) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
 	wa := workAssignmentForStore(beads.WorkStore{Store: store})
-	seen := make(map[string]struct{}, len(identifiers))
 	for _, assignee := range identifiers {
-		if assignee == "" {
-			continue
-		}
-		if _, ok := seen[assignee]; ok {
-			continue
-		}
-		seen[assignee] = struct{}{}
 		items, err := wa.OpenAssignedTo(assignee, "in_progress", beads.TierBoth, true)
 		if err != nil {
 			return beads.Bead{}, false, err

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -614,13 +614,15 @@ func recordDrainAckAssignedWorkEvent(
 // ONLY provably-non-claimable work — cases where no worker for this seat could
 // have claimed the row, so draining past it was correct pull:
 //
-//   - An OPEN bead that is blocked on an unmet dependency or deferred. No worker
-//     can claim a blocked/deferred row, so a seat that drained past it drained
-//     correctly. The open/claimable arm
+//   - An OPEN bead that is deferred or blocked on a genuinely unmet dependency.
+//     No worker can claim a deferred/blocked row, so a seat that drained past it
+//     drained correctly. The open/claimable arm
 //     (firstOpenClaimableAssignedWorkBeadForReachableStore) walks the seat's
 //     OpenAssignedTo rows (status=open) and suppresses a row ONLY when it is
-//     provably blocked or deferred (demandRowReady, the same predicate the
-//     divergence half uses). It does NOT borrow the beads.Ready projection, whose
+//     provably non-claimable: deferred (fresh bead-local defer_until), or blocked
+//     confirmed against LIVE deps — not on bd's denormalized is_blocked projection
+//     alone, which can read stale-true and would otherwise silence a strand whose
+//     deps are actually met. It does NOT borrow the beads.Ready projection, whose
 //     type/label exclusions (step, molecule, gate, gc:order-tracking, …) encode
 //     "not pull-claimable", not "not stranded" — so an OPEN step or other
 //     excluded-type row assigned straight to a seat at dispatch still FIRES,
@@ -641,9 +643,9 @@ func recordDrainAckAssignedWorkEvent(
 // name-only keying that borrows a duplicate-named seat's liveness, cross-tick
 // memoization) has a hole that would silence a real strand. Rather than risk that
 // false negative, the in_progress arm accepts the residual benign-live-sibling
-// noise and fires unconditionally. It fails CLOSED: an error is surfaced (to be
-// logged) only when BOTH arms fail without finding a bead, so a flaky store never
-// manufactures the alarm this classifier exists to keep honest.
+// noise and fires unconditionally. It fails CLOSED: when neither arm finds a bead
+// any arm's read error is surfaced (to be logged, never counted), so a flaky
+// store never manufactures the alarm this classifier exists to keep honest.
 func drainAckClaimableAnomalyBead(
 	cityPath string,
 	cfg *config.City,
@@ -659,13 +661,13 @@ func drainAckClaimableAnomalyBead(
 	if openFound {
 		return openBead, true, nil
 	}
-	// Neither arm found a bead. Surface an error only when BOTH probes failed: a
-	// single-arm read error with the other arm cleanly empty is not enough signal
-	// to manufacture the alarm (fail closed), but a total read failure is logged.
-	if inProgressErr != nil && openErr != nil {
-		return beads.Bead{}, false, errors.Join(inProgressErr, openErr)
-	}
-	return beads.Bead{}, false, nil
+	// Neither arm found a bead. Surface any arm's read error (errors.Join elides
+	// nils, so a clean pass returns nil) so the caller logs it — swallowing a
+	// single-arm error with the other arm cleanly empty is a diagnostics blind
+	// spot vs origin/main, which logged every finder error. This cannot manufacture
+	// the alarm: recordDrainAckAssignedWorkEvent only logs the error and fires
+	// solely on found=true, so a flaky store still fails closed.
+	return beads.Bead{}, false, errors.Join(inProgressErr, openErr)
 }
 
 // drainAckFinalizeResult captures the Info-snapshot effect of a
@@ -4735,8 +4737,15 @@ func firstOpenClaimableAssignedWorkBeadForReachableStore(
 // identifiers that a worker could claim right now, plus whether one was found.
 //
 // It walks the raw OpenAssignedTo list (status=open) and suppresses a row ONLY
-// when it is provably non-claimable — blocked on an unmet dependency or deferred
-// (demandRowReady, the same predicate the demand/claim-divergence half uses).
+// when it is provably non-claimable — deferred (defer_until / indefinite
+// deferral, fresh bead-local fields) or blocked on a genuinely unmet dependency.
+// demandRowReady is the cheap first gate (the same predicate the demand/claim-
+// divergence half uses), but its blocked half reads bd's DENORMALIZED is_blocked
+// projection, which can be stale-true; so a row this predicate rejects on the
+// is_blocked signal alone is re-confirmed against live deps
+// (openAssignedBeadHasUnmetBlockingDep) before it is suppressed, exactly as the
+// divergence half refuses to trust the projection blind. A row whose flag is
+// stale-true but whose deps are met is a genuine strand and FIRES.
 // Every other open assigned row FIRES regardless of type. This deliberately does
 // NOT reuse the beads.Ready projection: Ready's type exclusions (step, molecule,
 // gate, merge-request, …) and label exclusions (gc:order-tracking, gc:session)
@@ -4768,15 +4777,71 @@ func firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(store beads.Store, i
 				continue
 			}
 			if !demandRowReady(item, now) {
-				// Provably non-claimable: blocked on an unmet dependency or
-				// deferred. No worker could have claimed it, so draining past it
-				// was correct pull — the only open rows this arm suppresses.
-				continue
+				// Not claimable per the cheap bead-local predicate. A deferred row
+				// is gated by defer_until / indefinite deferral — fresh bead-local
+				// fields, never stale — so no worker could have claimed it and
+				// draining past it was correct pull.
+				if beads.IsDeferred(item, now) {
+					continue
+				}
+				// The only remaining reason demandRowReady rejected an open,
+				// non-deferred row is bd's DENORMALIZED is_blocked projection, which
+				// can read STALE-TRUE: a just-closed blocker whose flag has not been
+				// recomputed (issueops.countStaleIsBlockedSQL / `bd recompute-blocked`
+				// exist precisely to repair it). Suppressing on that signal alone
+				// would silence a genuine strand whose deps are actually met — the
+				// last silencing hole. The divergence half (classifyDemandTrigger)
+				// already refuses to trust the projection blind; this arm must be
+				// equally rigorous, so confirm real blockedness against live deps
+				// before suppressing. Suppress only when a genuine unmet blocking
+				// dependency exists; if the deps are met the flag is stale and the
+				// row is a real strand that must FIRE.
+				blocked, err := openAssignedBeadHasUnmetBlockingDep(store, item.ID)
+				if err != nil {
+					return beads.Bead{}, false, err
+				}
+				if blocked {
+					continue
+				}
 			}
 			return item, true, nil
 		}
 	}
 	return beads.Bead{}, false, nil
+}
+
+// openAssignedBeadHasUnmetBlockingDep re-derives whether an open assigned row is
+// actually blocked, from its live dependencies rather than bd's denormalized
+// is_blocked projection. The drain-ack open arm calls it only when that
+// projection reads true (demandRowReady rejected an open, non-deferred row), to
+// confirm the flag is not stale before suppressing a possible strand.
+//
+// It mirrors the canonical DepList → IsReadyBlockingDependencyType →
+// DependencySatisfied derivation used by cmd_ready.go's blocked_by enrichment and
+// the caching store's ready scan: a row is blocked when any ready-blocking edge
+// points at a target that has not closed satisfactorily. A dep or blocker read
+// that FAILS is returned, not swallowed — the open arm fails closed on it (the
+// classifier surfaces the error to be logged and never manufactures the alarm
+// from an unreadable store), matching how a gate-blocked step is treated as a
+// real fault rather than "no blocker" elsewhere.
+func openAssignedBeadHasUnmetBlockingDep(store beads.Store, id string) (bool, error) {
+	deps, err := store.DepList(id, "down")
+	if err != nil {
+		return false, err
+	}
+	for _, dep := range deps {
+		if !beads.IsReadyBlockingDependencyType(dep.Type) {
+			continue
+		}
+		blocker, err := store.Get(dep.DependsOnID)
+		if err != nil {
+			return false, err
+		}
+		if !beads.DependencySatisfied(blocker.Status, blocker.Metadata[beadmeta.WorkOutcomeMetadataKey]) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // firstInProgressAssignedWorkBeadForReachableStore walks EVERY reachable leg for

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -614,25 +614,35 @@ func recordDrainAckAssignedWorkEvent(
 // ONLY provably-non-claimable work — cases where no worker for this seat could
 // have claimed the row, so draining past it was correct pull:
 //
-//   - An OPEN bead parked on an unmet dependency, deferred, or otherwise not
-//     ready. No worker can claim a blocked/deferred row, so a seat that drained
-//     past it drained correctly (firstReadyAssignedWorkBeadForReachableStore
-//     keys on readiness, and demandRowReady mirrors it on the divergence half).
+//   - An OPEN bead that is blocked on an unmet dependency or deferred. No worker
+//     can claim a blocked/deferred row, so a seat that drained past it drained
+//     correctly. The open/claimable arm
+//     (firstOpenClaimableAssignedWorkBeadForReachableStore) walks the seat's
+//     OpenAssignedTo rows (status=open) and suppresses a row ONLY when it is
+//     provably blocked or deferred (demandRowReady, the same predicate the
+//     divergence half uses). It does NOT borrow the beads.Ready projection, whose
+//     type/label exclusions (step, molecule, gate, gc:order-tracking, …) encode
+//     "not pull-claimable", not "not stranded" — so an OPEN step or other
+//     excluded-type row assigned straight to a seat at dispatch still FIRES,
+//     which is the exact strand #2293 is about.
 //   - A bead assigned to no identifier this seat carries (assignee-empty relative
 //     to the seat): the finders query by the seat's own identifiers, so an
 //     unassigned or foreign row is never returned.
 //   - The seat's own mol-do-work "drain" step (isSessionOwnDrainStepBead),
 //     excluded for parity with the close gate.
 //
-// An IN_PROGRESS bead assigned to one of the seat's identifiers ALWAYS fires.
-// Distinguishing a genuine cap-hit strand (gastownhall/gascity#2293) from a
-// benign live-sibling claim cannot be done safely at finalize: every liveness
-// signal available here (tmux Running without Alive on a zombie pane, a stale
-// 30s liveness cache with no error channel, name-only keying that borrows a
-// duplicate-named seat's liveness, cross-tick memoization) has a hole that would
-// silence a real strand. Rather than risk that false negative, the in_progress
-// arm accepts the residual benign-live-sibling noise and fires unconditionally.
-// It fails CLOSED: a read error yields (found=false), so a flaky store never
+// An IN_PROGRESS bead assigned to one of the seat's identifiers ALWAYS fires, and
+// is probed FIRST so a graph/deps read error in the open arm can never silence it
+// (and so the payload prefers the most-urgent in_progress candidate, as
+// origin/main did). Distinguishing a genuine cap-hit strand
+// (gastownhall/gascity#2293) from a benign live-sibling claim cannot be done
+// safely at finalize: every liveness signal available here (tmux Running without
+// Alive on a zombie pane, a stale 30s liveness cache with no error channel,
+// name-only keying that borrows a duplicate-named seat's liveness, cross-tick
+// memoization) has a hole that would silence a real strand. Rather than risk that
+// false negative, the in_progress arm accepts the residual benign-live-sibling
+// noise and fires unconditionally. It fails CLOSED: an error is surfaced (to be
+// logged) only when BOTH arms fail without finding a bead, so a flaky store never
 // manufactures the alarm this classifier exists to keep honest.
 func drainAckClaimableAnomalyBead(
 	cityPath string,
@@ -641,14 +651,21 @@ func drainAckClaimableAnomalyBead(
 	rigStores map[string]beads.Store,
 	info sessionpkg.Info,
 ) (beads.Bead, bool, error) {
-	readyBead, readyFound, err := firstReadyAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
-	if err != nil {
-		return beads.Bead{}, false, err
+	inProgressBead, inProgressFound, inProgressErr := firstInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	if inProgressFound {
+		return inProgressBead, true, nil
 	}
-	if readyFound {
-		return readyBead, true, nil
+	openBead, openFound, openErr := firstOpenClaimableAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	if openFound {
+		return openBead, true, nil
 	}
-	return firstInProgressAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, info)
+	// Neither arm found a bead. Surface an error only when BOTH probes failed: a
+	// single-arm read error with the other arm cleanly empty is not enough signal
+	// to manufacture the alarm (fail closed), but a total read failure is logged.
+	if inProgressErr != nil && openErr != nil {
+		return beads.Bead{}, false, errors.Join(inProgressErr, openErr)
+	}
+	return beads.Bead{}, false, nil
 }
 
 // drainAckFinalizeResult captures the Info-snapshot effect of a
@@ -4693,14 +4710,14 @@ func firstAssignedWorkBeadForSession(
 	return bead, found, nil
 }
 
-// firstReadyAssignedWorkBeadForReachableStore returns the first READY (open and
-// unblocked) work bead still assigned to the given session in the store the
-// session's configured agent can query, plus whether one was found. It keys on
-// readiness so the drain-ack anomaly classifier (drainAckClaimableAnomalyBead)
-// can tell a genuinely claimable strand from an open bead parked on an unmet
-// dependency, which no worker could have claimed. Returns (zero-bead, false, nil)
-// when nothing matches.
-func firstReadyAssignedWorkBeadForReachableStore(
+// firstOpenClaimableAssignedWorkBeadForReachableStore returns the first OPEN,
+// claimable-now work bead still assigned to the given session in the store the
+// session's configured agent can query, plus whether one was found. "Claimable"
+// here means open and neither blocked nor deferred — the open arm of the
+// drain-ack anomaly classifier (drainAckClaimableAnomalyBead), which suppresses
+// only provably-non-claimable rows. Returns (zero-bead, false, nil) when nothing
+// matches.
+func firstOpenClaimableAssignedWorkBeadForReachableStore(
 	cityPath string,
 	cfg *config.City,
 	store beads.Store,
@@ -4709,35 +4726,51 @@ func firstReadyAssignedWorkBeadForReachableStore(
 ) (beads.Bead, bool, error) {
 	identifiers := sessionAssignmentIdentifiersForConfigInfo(info, cfg)
 	return firstAssignedWorkBeadForSession(cityPath, cfg, store, rigStores, info, func(s beads.Store) (beads.Bead, bool, error) {
-		return firstReadyAssignedWorkBeadInStoreByIdentifiers(s, identifiers)
+		return firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(s, identifiers)
 	})
 }
 
-// firstReadyAssignedWorkBeadInStoreByIdentifiers returns the first ready (open,
-// unblocked) non-session, non-mail work bead in store assigned to any of the
-// given identifiers. ReadyAssignedTo already excludes in_progress and
-// dependency-blocked rows, so this returns only rows a worker for this session
-// could claim right now. It also skips the seat's own mol-do-work drain step
+// firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers returns the first OPEN
+// non-session, non-mail work bead in store assigned to any of the given
+// identifiers that a worker could claim right now, plus whether one was found.
+//
+// It walks the raw OpenAssignedTo list (status=open) and suppresses a row ONLY
+// when it is provably non-claimable — blocked on an unmet dependency or deferred
+// (demandRowReady, the same predicate the demand/claim-divergence half uses).
+// Every other open assigned row FIRES regardless of type. This deliberately does
+// NOT reuse the beads.Ready projection: Ready's type exclusions (step, molecule,
+// gate, merge-request, …) and label exclusions (gc:order-tracking, gc:session)
+// encode "not pull-claimable", not "not stranded", so an OPEN step bead assigned
+// straight to a seat at dispatch — sitting open before the agent claims it —
+// would be silenced by Ready even though it is a genuine strand
+// (gastownhall/gascity#2293). It also skips the seat's own mol-do-work drain step
 // (isSessionOwnDrainStepBead), mirroring the close gate's
 // hasNonSessionNonOwnDrainStepWork so a session's own open drain step is never
 // reported as a claimable strand. identifiers are pre-compacted (deduped, no
 // empties) by sessionAssignmentIdentifiersForConfigInfo, so no extra dedupe is
 // needed here.
-func firstReadyAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
+func firstOpenClaimableAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
+	now := time.Now()
 	wa := workAssignmentForStore(beads.WorkStore{Store: store})
 	for _, assignee := range identifiers {
-		items, err := wa.ReadyAssignedTo(assignee, beads.TierBoth)
+		items, err := wa.OpenAssignedTo(assignee, "open", beads.TierBoth, true)
 		if err != nil {
 			return beads.Bead{}, false, err
 		}
-		for _, item := range excludeMailMessageBeads(items) {
+		for _, item := range items {
 			if sessionpkg.IsSessionBeadOrRepairable(item) {
 				continue
 			}
 			if isSessionOwnDrainStepBead(store, item) {
+				continue
+			}
+			if !demandRowReady(item, now) {
+				// Provably non-claimable: blocked on an unmet dependency or
+				// deferred. No worker could have claimed it, so draining past it
+				// was correct pull — the only open rows this arm suppresses.
 				continue
 			}
 			return item, true, nil

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2041,10 +2041,13 @@ func drainAckPoolAliasInProgressEventCount(t *testing.T, addLiveSibling bool) in
 // classifier the emitter fired on any open/in_progress assigned row, blocked or
 // not.
 //
-// The open/claimable arm keys on the denormalized is_blocked projection (the same
-// predicate demandRowReady uses), which MemStore.List does not derive from deps,
-// so the row is stamped is_blocked=true to model bd's production projection; the
-// live "blocks" dep is wired too so the row is genuinely blocked by every reader.
+// The row is stamped is_blocked=true AND wired with a live "blocks" dep so it is
+// blocked by every reader. The hand-stamped flag does NOT model bd's production
+// projection — bd's JSON payloads omit the column entirely, so production reads
+// leave it nil (that shape is pinned by
+// TestReconcileSessionBeads_DrainAckNoProjectionBlockedAssignedWorkSuppressesEvent).
+// It is here to pin that the flag does not change the verdict: blockedness is
+// settled from the live dep either way.
 func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *testing.T) {
 	blockedTrue := true
 	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
@@ -2066,12 +2069,60 @@ func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *tes
 	}
 }
 
+// TestReconcileSessionBeads_DrainAckNoProjectionBlockedAssignedWorkSuppressesEvent
+// pins the suppression arm on the shape production actually produces: an OPEN
+// assigned row blocked by an unmet plain `blocks` edge whose is_blocked
+// projection is ABSENT (nil).
+//
+// bd's `list --json` / `show --json` payloads do not carry the is_blocked column,
+// so BdStore.toBead leaves the field nil on every read and beadFromNativeIssue
+// cannot set it; only the CachingStore's ready-projection enrichment populates it,
+// on non-live cached reads the drain-ack finders never take (they force
+// live=true). An arm that suppressed only on a true-reading flag was therefore
+// dead in production — the dominant false-positive class kept firing. The
+// classifier now reads an absent projection as no evidence rather than as
+// "unblocked", settles it against the live dep, and suppresses.
+//
+// Contrast TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent:
+// identical wiring plus a hand-stamped is_blocked=true, which must reach the same
+// verdict — the flag is not what decides.
+func TestReconcileSessionBeads_DrainAckNoProjectionBlockedAssignedWorkSuppressesEvent(t *testing.T) {
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
+		blocker, err := store.Create(beads.Bead{Title: "upstream gate", Type: "task", Status: "open"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		work, err := store.Create(beads.Bead{Title: "downstream phase", Type: "task", Status: "open", Assignee: sessionID})
+		if err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+		if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd: %v", err)
+		}
+		// Guard the premise on a real read, after the dep exists: if the store
+		// ever started deriving is_blocked from deps, this test would quietly
+		// become a duplicate of the stamped-flag one and stop covering the shape
+		// production returns.
+		readBack, err := store.Get(work.ID)
+		if err != nil {
+			t.Fatalf("Get(work): %v", err)
+		}
+		if readBack.IsBlocked != nil {
+			t.Fatalf("work.IsBlocked = %v, want nil — this test is only meaningful on the absent-projection shape production reads return", *readBack.IsBlocked)
+		}
+	})
+	if count != 0 {
+		t.Fatalf("%s events = %d, want 0 — an open row blocked on an unmet plain `blocks` edge is not claimable whether or not bd's is_blocked projection is present, and absent is the only reading production produces",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckDeferredAssignedWorkSuppressesEvent pins the
 // deferred half of the provably-non-claimable suppression: an OPEN bead assigned
 // to the seat but deferred into the future is not claimable by any worker, so the
 // seat drained correctly and the event must NOT fire. defer_until is a fresh,
 // bead-local field, so both the pre-fix ready projection and the post-fix
-// demandRowReady predicate agree on it.
+// classifyDemandRowClaimability predicate agree on it.
 func TestReconcileSessionBeads_DrainAckDeferredAssignedWorkSuppressesEvent(t *testing.T) {
 	deferUntil := time.Now().Add(time.Hour)
 	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
@@ -2113,8 +2164,8 @@ func TestReconcileSessionBeads_DrainAckOpenStepAssignedWorkEmitsEvent(t *testing
 // MET — but whose is_blocked flag still reads true is a real strand: the seat
 // drained past claimable work. The open arm must confirm real blockedness against
 // live deps before suppressing, so a stale-true flag with met deps FIRES. Before
-// the fix the arm suppressed on the projection alone (demandRowReady) and silenced
-// it — no event, seat stopped, alarm never fires.
+// the fix the arm suppressed on the projection alone and silenced it — no event,
+// seat stopped, alarm never fires.
 //
 // Contrast TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent,
 // which keeps its blocker OPEN so the dep is genuinely unmet and suppression is
@@ -2144,6 +2195,96 @@ func TestReconcileSessionBeads_DrainAckStaleIsBlockedAssignedWorkEmitsEvent(t *t
 	if count != 1 {
 		t.Fatalf("%s events = %d, want 1 — an open row with a STALE is_blocked=true flag whose blocking dep has closed is a genuine strand; the open arm must confirm blockedness against live deps before suppressing",
 			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckWaitsForGateOpenAssignedWorkEmitsEvent is the
+// MAJOR regression guard for the dep-confirm's edge-type narrowing. bd gates a
+// `waits-for` edge through NATIVE state, independent of the target's own status:
+// internal/formula/compile.go mints exactly this shape (a gate edge onto a step
+// that stays open), native_dolt_store.go's ready filter declines the flat
+// satisfaction rule because "a waits-for edge gates on the spawner's children
+// rather than the spawner's own status", and the `bd-gate-open` fixture pins the
+// consequence — the row reads is_blocked = 0 and bd's ready OFFERS it, while a
+// direct-dep predicate would hide it.
+//
+// So an OPEN row whose only edge is a waits-for onto an OPEN target IS claimable,
+// and a stale-true is_blocked flag on it must not suppress the alarm: confirming
+// on any ready-blocking type would second-guess a bd verdict — in the one
+// situation where the projection is already suspect — and silence a genuine
+// strand. Only a plain `blocks` edge to an unsatisfied target is proof of
+// non-claimability.
+//
+// Contrast TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent:
+// identical wiring with a `blocks` edge, which correctly suppresses.
+func TestReconcileSessionBeads_DrainAckWaitsForGateOpenAssignedWorkEmitsEvent(t *testing.T) {
+	blockedTrue := true
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
+		gate, err := store.Create(beads.Bead{Title: "spawner step", Type: "task", Status: "open"})
+		if err != nil {
+			t.Fatalf("Create(gate): %v", err)
+		}
+		work, err := store.Create(beads.Bead{Title: "gated phase", Type: "task", Status: "open", Assignee: sessionID, IsBlocked: &blockedTrue})
+		if err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+		if err := store.DepAdd(work.ID, gate.ID, "waits-for"); err != nil {
+			t.Fatalf("DepAdd: %v", err)
+		}
+	})
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — a waits-for gate onto an OPEN target is not proof of non-claimability (bd opens it natively and offers the row), so the stale-true flag must not suppress a genuine strand",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// depListErrStore fails the dependency read the open arm's blockedness confirm
+// makes, serving every other read unchanged. It models a graph/deps read error
+// landing INSIDE beadHasUnmetPlainBlocksDep rather than on the open list that
+// feeds it (readyOpenErrStore covers that outer path).
+type depListErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s depListErrStore) DepList(_, _ string) ([]beads.Dep, error) {
+	return nil, s.err
+}
+
+// TestReconcileSessionBeads_DrainAckDepConfirmReadErrorNoFireAndLogsError pins the
+// confirm's INTERNAL error path, the one the outer-read guards above do not reach.
+// An open assigned row whose is_blocked projection reads true sends the open arm
+// into a live-dep confirmation; when THAT read fails, the classifier must fail
+// CLOSED — an unreadable store is not evidence of a strand, so no event — while
+// still surfacing the error for logging instead of swallowing it into a silent
+// "nothing found" (Don't-Swallow-Errors).
+func TestReconcileSessionBeads_DrainAckDepConfirmReadErrorNoFireAndLogsError(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	fake := events.NewFake()
+
+	info := env.createSessionInfo("worker", "worker")
+	blockedTrue := true
+	if _, err := env.store.Create(beads.Bead{Title: "flagged phase", Type: "task", Status: "open", Assignee: info.ID, IsBlocked: &blockedTrue}); err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	store := depListErrStore{Store: env.store, err: errors.New("dependency read failed")}
+	var stderr bytes.Buffer
+	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", time.Now(), fake, &stderr)
+
+	count := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			count++
+		}
+	}
+	if count != 0 {
+		t.Fatalf("%s events = %d, want 0 — the blockedness confirm could not read the deps, and an unreadable store must never manufacture the alarm",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+	if !strings.Contains(stderr.String(), "dependency read failed") {
+		t.Fatalf("stderr = %q, want it to surface the dep-confirm read error for logging; a failed confirmation must not vanish", stderr.String())
 	}
 }
 
@@ -2238,7 +2379,7 @@ func TestReconcileSessionBeads_DrainAckOpenArmReadErrorStillEmitsInProgressStran
 
 	store := readyOpenErrStore{Store: env.store, err: errors.New("graph readiness read failed")}
 	var stderr bytes.Buffer
-	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", fake, &stderr)
+	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", time.Now(), fake, &stderr)
 
 	count := 0
 	for i := range fake.Events {
@@ -2269,7 +2410,7 @@ func TestReconcileSessionBeads_DrainAckOpenArmReadErrorWithNoInProgressLogsError
 
 	store := readyOpenErrStore{Store: env.store, err: errors.New("graph readiness read failed")}
 	var stderr bytes.Buffer
-	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", fake, &stderr)
+	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", time.Now(), fake, &stderr)
 
 	count := 0
 	for i := range fake.Events {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1896,9 +1896,9 @@ func TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent(t *testing
 // drainAckAssignedWorkEventCount runs a worker session through the drain-ack
 // finalize lifecycle with work already seeded and returns how many
 // SessionDrainAckedWithAssignedWork events were emitted. seedWork receives the
-// session's durable bead ID and its session_name identity so a case can assign
-// work to the session itself, to a pool-shared identity, and wire dependencies.
-func drainAckAssignedWorkEventCount(t *testing.T, seedWork func(t *testing.T, store beads.Store, sessionID, sessionName string)) int {
+// session's durable bead ID so a case can assign work to the session and wire
+// dependencies.
+func drainAckAssignedWorkEventCount(t *testing.T, seedWork func(t *testing.T, store beads.Store, sessionID string)) int {
 	t.Helper()
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
@@ -1908,7 +1908,7 @@ func drainAckAssignedWorkEventCount(t *testing.T, seedWork func(t *testing.T, st
 
 	session := env.createSessionBead("worker", "worker")
 	env.markSessionActive(&session)
-	seedWork(t, env.store, session.ID, session.Metadata["session_name"])
+	seedWork(t, env.store, session.ID)
 
 	dops := newFakeDrainOps()
 	if err := dops.setDrainAck("worker"); err != nil {
@@ -2040,13 +2040,19 @@ func drainAckPoolAliasInProgressEventCount(t *testing.T, addLiveSibling bool) in
 // could have claimed it and the seat drained correctly. Before the anomaly
 // classifier the emitter fired on any open/in_progress assigned row, blocked or
 // not.
+//
+// The open/claimable arm keys on the denormalized is_blocked projection (the same
+// predicate demandRowReady uses), which MemStore.List does not derive from deps,
+// so the row is stamped is_blocked=true to model bd's production projection; the
+// live "blocks" dep is wired too so the row is genuinely blocked by every reader.
 func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *testing.T) {
-	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID, _ string) {
+	blockedTrue := true
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
 		blocker, err := store.Create(beads.Bead{Title: "upstream gate", Type: "task", Status: "open"})
 		if err != nil {
 			t.Fatalf("Create(blocker): %v", err)
 		}
-		work, err := store.Create(beads.Bead{Title: "downstream phase", Type: "task", Status: "open", Assignee: sessionID})
+		work, err := store.Create(beads.Bead{Title: "downstream phase", Type: "task", Status: "open", Assignee: sessionID, IsBlocked: &blockedTrue})
 		if err != nil {
 			t.Fatalf("Create(work): %v", err)
 		}
@@ -2056,6 +2062,45 @@ func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *tes
 	})
 	if count != 0 {
 		t.Fatalf("%s events = %d, want 0 — an open bead blocked on an unmet dependency is not claimable, so the seat drained correctly",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckDeferredAssignedWorkSuppressesEvent pins the
+// deferred half of the provably-non-claimable suppression: an OPEN bead assigned
+// to the seat but deferred into the future is not claimable by any worker, so the
+// seat drained correctly and the event must NOT fire. defer_until is a fresh,
+// bead-local field, so both the pre-fix ready projection and the post-fix
+// demandRowReady predicate agree on it.
+func TestReconcileSessionBeads_DrainAckDeferredAssignedWorkSuppressesEvent(t *testing.T) {
+	deferUntil := time.Now().Add(time.Hour)
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
+		if _, err := store.Create(beads.Bead{Title: "deferred phase", Type: "task", Status: "open", Assignee: sessionID, DeferUntil: &deferUntil}); err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+	})
+	if count != 0 {
+		t.Fatalf("%s events = %d, want 0 — an open bead deferred into the future is not claimable, so the seat drained correctly",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckOpenStepAssignedWorkEmitsEvent is the MAJOR
+// regression guard. An execution STEP bead can be assigned straight to a seat at
+// dispatch (control.go stamps step.Assignee) and sit OPEN before the agent claims
+// it — a genuine strand if the seat drains past it. beads.Ready TYPE-excludes
+// "step" (it is not pull-claimable Ready work), so an anomaly classifier that
+// keyed the open arm on the Ready projection SILENCED this strand. The open arm
+// now walks OpenAssignedTo and suppresses only provably blocked/deferred rows, so
+// an open step FIRES regardless of type.
+func TestReconcileSessionBeads_DrainAckOpenStepAssignedWorkEmitsEvent(t *testing.T) {
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
+		if _, err := store.Create(beads.Bead{Title: "dispatched step", Type: "step", Status: "open", Assignee: sessionID}); err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+	})
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — an OPEN step assigned straight to the seat is a genuine strand; the open arm must not borrow beads.Ready's type exclusions",
 			events.SessionDrainAckedWithAssignedWork, count)
 	}
 }
@@ -2097,13 +2142,70 @@ func TestReconcileSessionBeads_DrainAckAliasClaimedNoLiveOwnerEmitsEvent(t *test
 // genuinely claimable right now, so the anomaly classifier must still emit
 // SessionDrainAckedWithAssignedWork for it.
 func TestReconcileSessionBeads_DrainAckReadyAssignedWorkEmitsEvent(t *testing.T) {
-	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID, _ string) {
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
 		if _, err := store.Create(beads.Bead{Title: "ready phase", Type: "task", Status: "open", Assignee: sessionID}); err != nil {
 			t.Fatalf("Create(work): %v", err)
 		}
 	})
 	if count != 1 {
 		t.Fatalf("%s events = %d, want 1 — an open, unblocked bead assigned to the draining session is genuinely claimable and must still alarm",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// readyOpenErrStore fails the open/ready read path — both the pre-fix beads.Ready
+// projection (via Ready) and the post-fix OpenAssignedTo status=open List — while
+// serving the in_progress List unchanged. It models a graph/deps read error
+// landing on the open/claimable arm of the drain-ack classifier.
+type readyOpenErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s readyOpenErrStore) Ready(_ ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return nil, s.err
+}
+
+func (s readyOpenErrStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Status == "open" {
+		return nil, s.err
+	}
+	return s.Store.List(query)
+}
+
+// TestReconcileSessionBeads_DrainAckOpenArmReadErrorStillEmitsInProgressStrand is
+// the MINOR-1 regression guard. An in_progress cap-hit strand (#2293) must still
+// fire even when the open/claimable arm's store read errors: the classifier probes
+// the in_progress arm FIRST, so a graph/deps read failure in the open arm can no
+// longer return early and silence a genuine strand. Before the fix the open arm
+// ran first and its error short-circuited the whole classifier.
+func TestReconcileSessionBeads_DrainAckOpenArmReadErrorStillEmitsInProgressStrand(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	fake := events.NewFake()
+
+	info := env.createSessionInfo("worker", "worker")
+	work, err := env.store.Create(beads.Bead{Title: "cap-hit task", Type: "task", Assignee: info.ID})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	inProgress := "in_progress"
+	if err := env.store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark in progress: %v", err)
+	}
+
+	store := readyOpenErrStore{Store: env.store, err: errors.New("graph readiness read failed")}
+	var stderr bytes.Buffer
+	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", fake, &stderr)
+
+	count := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — an in_progress strand must still fire when the open/claimable arm's read errors (probe in_progress first)",
 			events.SessionDrainAckedWithAssignedWork, count)
 	}
 }
@@ -2201,7 +2303,7 @@ func drainAckAliasSiblingEventCount(t *testing.T, siblingName string, siblingDra
 // fires on the in_progress row unconditionally, so the strand is never silenced
 // by a same-pass-draining sibling.
 func TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent(t *testing.T) {
-	count := drainAckAliasSiblingEventCount(t, "worker-twin", true, func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
+	count := drainAckAliasSiblingEventCount(t, "worker-twin", true, func(_ *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
 		env.markSessionActive(sibling)
 		env.addDesired("worker-twin", "worker", true)
 	})
@@ -2220,7 +2322,7 @@ func TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent(t *testing
 // classifier fires on the in_progress row unconditionally, so a zombie sibling
 // never silences the strand.
 func TestReconcileSessionBeads_DrainAckZombieOpenSiblingEmitsEvent(t *testing.T) {
-	count := drainAckAliasSiblingEventCount(t, "worker-zombie", false, func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
+	count := drainAckAliasSiblingEventCount(t, "worker-zombie", false, func(_ *testing.T, _ *reconcilerTestEnv, sibling *beads.Bead) {
 		// Leave the zombie asleep (createSessionBead's default), never started in
 		// the provider (runtime dead), and NOT in the desired set — it stays an
 		// open, dead-runtime sibling that an owner-liveness classifier would have

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1952,6 +1952,86 @@ func drainAckAssignedWorkEventCount(t *testing.T, seedWork func(t *testing.T, st
 	return count
 }
 
+// drainAckPoolAliasInProgressEventCount runs a "worker" seat through the drain-ack
+// finalize lifecycle while it holds an IN_PROGRESS row stamped with a pool alias
+// (configured_named_identity) rather than its own durable bead ID — the way a
+// production hook claim stamps an aliased/pool seat (hookClaimAssigneeIdentity).
+// When addLiveSibling is true a SECOND seat with a distinct session name but the
+// SAME pool alias is present and alive in the reconciler's running-session
+// inventory for both ticks, so it is a genuine live owner of the row. Returns how
+// many SessionDrainAckedWithAssignedWork events fired: zero when a live sibling
+// owns the row (correct surplus-seat drain), one when no live incarnation but the
+// draining seat itself carries the alias (a genuine strand).
+func drainAckPoolAliasInProgressEventCount(t *testing.T, addLiveSibling bool) int {
+	t.Helper()
+	const poolAlias = "gc__worker-pool"
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	fake := events.NewFake()
+	env.rec = fake
+
+	draining := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&draining, map[string]string{namedSessionIdentityMetadata: poolAlias})
+	env.markSessionActive(&draining)
+
+	work, err := env.store.Create(beads.Bead{Title: "aliased task", Type: "task", Assignee: poolAlias})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	inProgress := "in_progress"
+	if err := env.store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark in progress: %v", err)
+	}
+
+	cfgNames := map[string]bool{"worker": true}
+	inventory := []beads.Bead{draining}
+	if addLiveSibling {
+		env.addDesired("worker-sib", "worker", true)
+		cfgNames["worker-sib"] = true
+		sibling := env.createSessionBead("worker-sib", "worker")
+		env.setSessionMetadata(&sibling, map[string]string{namedSessionIdentityMetadata: poolAlias})
+		env.markSessionActive(&sibling)
+		inventory = append(inventory, sibling)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+	reconcileSessionBeads(
+		context.Background(), inventory, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, dops, nil, nil, env.dt, nil, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Finalize tick: the draining seat's runtime is now stopped, so reload the whole
+	// inventory (draining seat is stop-pending; the sibling stays alive on its own
+	// distinct runtime) and reconcile again to drive the finalize + event decision.
+	waitForProviderStopped(t, env.sp, "worker")
+	reloaded := make([]beads.Bead, 0, len(inventory))
+	for _, b := range inventory {
+		got, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", b.ID, err)
+		}
+		reloaded = append(reloaded, got)
+	}
+	reconcileSessionBeads(
+		context.Background(), reloaded, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, dops, nil, nil, env.dt, nil, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	count := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			count++
+		}
+	}
+	return count
+}
+
 // TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent pins that
 // a session drain-acking while its only assigned bead is OPEN but parked on an
 // unmet dependency must NOT emit SessionDrainAckedWithAssignedWork. This is the
@@ -1980,28 +2060,35 @@ func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *tes
 	}
 }
 
-// TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent pins
-// that a session drain-acking while an IN_PROGRESS row carries a pool-shared
-// assignee identity (its session_name, not its own durable bead ID) must NOT
-// emit SessionDrainAckedWithAssignedWork. This is the second false-positive
-// class from live data (~17%): the row is being worked by a LIVE sibling
-// incarnation of the same pool, so a surplus seat draining past it is normal
-// pull, not a strand. Only a #2293 Shape A self-strand (assignee == this
-// session's own bead ID) keeps alarming — pinned by
-// TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent.
+// TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent pins the
+// owner-liveness suppression: a seat drain-acking while an IN_PROGRESS row is
+// owned by ANOTHER LIVE incarnation of the same pool (a distinctly-named sibling
+// that shares the row's pool alias and is up in the reconciler's running-session
+// inventory) must NOT emit SessionDrainAckedWithAssignedWork. This is the ~17%
+// false-positive class from live data: a surplus seat draining past a row a live
+// sibling is actively working is normal pull, not a strand. The sibling here
+// genuinely owns the row (shared configured_named_identity), which is the
+// distinction the fix keys on — not the assignee's identity shape.
 func TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent(t *testing.T) {
-	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, _, sessionName string) {
-		work, err := store.Create(beads.Bead{Title: "sibling task", Type: "task", Assignee: sessionName})
-		if err != nil {
-			t.Fatalf("Create(work): %v", err)
-		}
-		inProgress := "in_progress"
-		if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
-			t.Fatalf("mark in progress: %v", err)
-		}
-	})
+	count := drainAckPoolAliasInProgressEventCount(t, true)
 	if count != 0 {
-		t.Fatalf("%s events = %d, want 0 — in_progress work on a pool-shared identity is a live sibling's surplus-seat drain, not a strand",
+		t.Fatalf("%s events = %d, want 0 — an in_progress row a LIVE sibling incarnation owns is a surplus-seat drain, not a strand",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckAliasClaimedNoLiveOwnerEmitsEvent is the
+// genuine-strand RED test the owner-liveness fix exists for. A named/pool seat
+// claims a row under its ALIAS (configured_named_identity, as production hook
+// claims stamp — not the durable bead ID), hits its turn cap, and drain-acks
+// mid-task with NO live replacement: no other live incarnation carries the alias.
+// That is the #2293 cap-hit strand the event MUST emit for. The prior
+// "assignee == this session's own bead ID" gate silenced it (the alias is not the
+// bead ID), so this fails on that state; keying on owner-liveness fires it.
+func TestReconcileSessionBeads_DrainAckAliasClaimedNoLiveOwnerEmitsEvent(t *testing.T) {
+	count := drainAckPoolAliasInProgressEventCount(t, false)
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — an alias-claimed in_progress row with NO live owner but the draining seat is a genuine cap-hit strand",
 			events.SessionDrainAckedWithAssignedWork, count)
 	}
 }
@@ -3743,7 +3830,7 @@ func TestFinalizeDrainAckStoppedSessionDoesNotEmitEventsWhenFinalMetadataFails(t
 
 	failingStore := &failSetMetadataBatchStore{Store: env.store, err: errors.New("metadata write failed")}
 	finalizeDrainAckStoppedSession(
-		"", env.cfg, failingStore, nil, env.sessionInfo(session.ID), "worker", false,
+		"", env.cfg, failingStore, nil, env.sessionInfo(session.ID), nil, "worker", false,
 		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
 	)
 
@@ -3770,7 +3857,7 @@ func TestFinalizeDrainAckStoppedSessionFallsThroughWhenCloseGateRacesWithAssignm
 
 	racingStore := &assignOnListStore{Store: env.store, sessionID: session.ID}
 	finalizeDrainAckStoppedSession(
-		"", env.cfg, racingStore, nil, env.sessionInfo(session.ID), "worker", true,
+		"", env.cfg, racingStore, nil, env.sessionInfo(session.ID), nil, "worker", true,
 		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
 	)
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1893,6 +1893,135 @@ func TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent(t *testing
 	}
 }
 
+// drainAckAssignedWorkEventCount runs a worker session through the drain-ack
+// finalize lifecycle with work already seeded and returns how many
+// SessionDrainAckedWithAssignedWork events were emitted. seedWork receives the
+// session's durable bead ID and its session_name identity so a case can assign
+// work to the session itself, to a pool-shared identity, and wire dependencies.
+func drainAckAssignedWorkEventCount(t *testing.T, seedWork func(t *testing.T, store beads.Store, sessionID, sessionName string)) int {
+	t.Helper()
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	fake := events.NewFake()
+	env.rec = fake
+
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	seedWork(t, env.store, session.ID, session.Metadata["session_name"])
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
+
+	count := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			count++
+		}
+	}
+	return count
+}
+
+// TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent pins that
+// a session drain-acking while its only assigned bead is OPEN but parked on an
+// unmet dependency must NOT emit SessionDrainAckedWithAssignedWork. This is the
+// dominant false-positive class the operator classified from live data (~83% of
+// firings): the row is routed to the seat's target but blocked, so no worker
+// could have claimed it and the seat drained correctly. Before the anomaly
+// classifier the emitter fired on any open/in_progress assigned row, blocked or
+// not.
+func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *testing.T) {
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID, _ string) {
+		blocker, err := store.Create(beads.Bead{Title: "upstream gate", Type: "task", Status: "open"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		work, err := store.Create(beads.Bead{Title: "downstream phase", Type: "task", Status: "open", Assignee: sessionID})
+		if err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+		if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd: %v", err)
+		}
+	})
+	if count != 0 {
+		t.Fatalf("%s events = %d, want 0 — an open bead blocked on an unmet dependency is not claimable, so the seat drained correctly",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent pins
+// that a session drain-acking while an IN_PROGRESS row carries a pool-shared
+// assignee identity (its session_name, not its own durable bead ID) must NOT
+// emit SessionDrainAckedWithAssignedWork. This is the second false-positive
+// class from live data (~17%): the row is being worked by a LIVE sibling
+// incarnation of the same pool, so a surplus seat draining past it is normal
+// pull, not a strand. Only a #2293 Shape A self-strand (assignee == this
+// session's own bead ID) keeps alarming — pinned by
+// TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent.
+func TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent(t *testing.T) {
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, _, sessionName string) {
+		work, err := store.Create(beads.Bead{Title: "sibling task", Type: "task", Assignee: sessionName})
+		if err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+		inProgress := "in_progress"
+		if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+			t.Fatalf("mark in progress: %v", err)
+		}
+	})
+	if count != 0 {
+		t.Fatalf("%s events = %d, want 0 — in_progress work on a pool-shared identity is a live sibling's surplus-seat drain, not a strand",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckReadyAssignedWorkEmitsEvent guards against
+// over-suppression: an OPEN, unblocked bead assigned to the draining session is
+// genuinely claimable right now, so the anomaly classifier must still emit
+// SessionDrainAckedWithAssignedWork for it.
+func TestReconcileSessionBeads_DrainAckReadyAssignedWorkEmitsEvent(t *testing.T) {
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID, _ string) {
+		if _, err := store.Create(beads.Bead{Title: "ready phase", Type: "task", Status: "open", Assignee: sessionID}); err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+	})
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — an open, unblocked bead assigned to the draining session is genuinely claimable and must still alarm",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckOwnDrainStepClosesWithoutEvent pins that
 // a session whose ONLY assigned work is its own mol-do-work "drain" step
 // must actually close on drain-ack (no pool respawn) and must NOT emit

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2109,6 +2109,137 @@ func TestReconcileSessionBeads_DrainAckReadyAssignedWorkEmitsEvent(t *testing.T)
 	}
 }
 
+// drainAckAliasSiblingEventCount drives a "worker" seat holding an IN_PROGRESS row
+// stamped with a shared pool alias through the drain-ack finalize lifecycle, with
+// a second seat that also carries the SAME alias. seedSibling configures that
+// second seat's runtime and desired/config posture (via addDesired/provider Start
+// or leaving it dead) so a case can make it a genuinely-live owner or a dead
+// zombie; siblingDrainAck marks the sibling drain-acked in the same pass. It
+// returns how many SessionDrainAckedWithAssignedWork events fired. Everything runs
+// through the signature-stable reconcileSessionBeads entry point so the two new
+// fire-cases below compile and RED on the pre-fix bead-not-closed keying and GREEN
+// on the runtime-liveness keying.
+func drainAckAliasSiblingEventCount(t *testing.T, siblingName string, siblingDrainAck bool, seedSibling func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead)) int {
+	t.Helper()
+	const poolAlias = "gc__worker-pool"
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	fake := events.NewFake()
+	env.rec = fake
+
+	draining := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&draining, map[string]string{namedSessionIdentityMetadata: poolAlias})
+	env.markSessionActive(&draining)
+	env.addDesired("worker", "worker", true)
+
+	sibling := env.createSessionBead(siblingName, "worker")
+	env.setSessionMetadata(&sibling, map[string]string{namedSessionIdentityMetadata: poolAlias})
+	seedSibling(t, env, &sibling)
+
+	work, err := env.store.Create(beads.Bead{Title: "aliased task", Type: "task", Assignee: poolAlias})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	inProgress := "in_progress"
+	if err := env.store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark in progress: %v", err)
+	}
+
+	cfgNames := map[string]bool{"worker": true, siblingName: true}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck(worker): %v", err)
+	}
+	if siblingDrainAck {
+		if err := dops.setDrainAck(siblingName); err != nil {
+			t.Fatalf("setDrainAck(%s): %v", siblingName, err)
+		}
+	}
+
+	inventory := []beads.Bead{draining, sibling}
+	reconcileSessionBeads(
+		context.Background(), inventory, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, dops, nil, nil, env.dt, nil, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Finalize tick: the draining seat's runtime is now stopped, so reload the whole
+	// inventory and reconcile again to drive the finalize + event decision. The
+	// sibling's runtime state is whatever seedSibling / siblingDrainAck left it.
+	waitForProviderStopped(t, env.sp, "worker")
+	if siblingDrainAck {
+		waitForProviderStopped(t, env.sp, siblingName)
+	}
+	reloaded := make([]beads.Bead, 0, len(inventory))
+	for _, b := range inventory {
+		got, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", b.ID, err)
+		}
+		reloaded = append(reloaded, got)
+	}
+	reconcileSessionBeads(
+		context.Background(), reloaded, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, dops, nil, nil, env.dt, nil, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	count := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			count++
+		}
+	}
+	return count
+}
+
+// TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent pins the
+// same-pass-drain half of the owner-liveness fix. Two distinctly-named seats
+// share one pool alias and BOTH drain-ack in the same pass while an in_progress
+// row carries that alias. The pre-fix classifier keyed "live owner" on
+// bead-not-closed, so each draining seat counted the OTHER (still open, mid-drain)
+// as a live owner and they mutually SUPPRESSED — a false negative that silences a
+// genuine strand. Neither seat's runtime survives the drain, so keying on a
+// positive runtime observation (both dead, both drain-ack-stop-pending) leaves no
+// live owner and the strand MUST fire. RED on the pre-fix state (count 0), green
+// after (each unowned finalize fires, so >= 1).
+func TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent(t *testing.T) {
+	count := drainAckAliasSiblingEventCount(t, "worker-twin", true, func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
+		env.markSessionActive(sibling)
+		env.addDesired("worker-twin", "worker", true)
+	})
+	if count < 1 {
+		t.Fatalf("%s events = %d, want >= 1 — two same-alias seats draining together leave no live owner, so the shared in_progress row is a genuine strand and must not be mutually suppressed",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckZombieOpenSiblingEmitsEvent pins the
+// zombie-sibling half of the owner-liveness fix. A sibling seat shares the pool
+// alias and its session bead is still OPEN, but its RUNTIME is dead (never
+// started) and it is NOT drain-pending — a drained-open zombie kept open by the
+// very row it stranded. The pre-fix classifier counted it as a live owner because
+// its bead is not closed, permanently SILENCING the recurring cap-hit strand. It
+// is configured-but-not-desired, so the reconciler keeps it open ("suspended")
+// while it holds the shared alias work rather than closing it. Keying on a
+// positive runtime observation excludes the dead zombie, so the strand MUST fire.
+// RED on the pre-fix state (count 0), green after (count 1). The zombie is NOT
+// drain-pending, so this proves the RUNTIME observation — not the drain-pending
+// proxy — is what excludes it.
+func TestReconcileSessionBeads_DrainAckZombieOpenSiblingEmitsEvent(t *testing.T) {
+	count := drainAckAliasSiblingEventCount(t, "worker-zombie", false, func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
+		// Leave the zombie asleep (createSessionBead's default), never started in
+		// the provider (runtime dead), and NOT in the desired set so it is never
+		// woken or restarted — configured but scaled down, held open as "suspended"
+		// because it still carries the shared alias work.
+		_ = sibling
+	})
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — a drained-open zombie sibling whose runtime is dead is not a live owner, so the shared in_progress row is a genuine strand that must fire",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckOwnDrainStepClosesWithoutEvent pins that
 // a session whose ONLY assigned work is its own mol-do-work "drain" step
 // must actually close on drain-ack (no pool respawn) and must NOT emit
@@ -2203,7 +2334,7 @@ func TestReconcileSessionBeads_DrainAckOwnDrainStepClosesWithoutEvent(t *testing
 	}
 
 	// The drain step itself is untouched by the close gate — the event path
-	// (firstOpenAssignedWorkBeadForReachableStore) and IsSessionBeadOrRepairable
+	// (the drain-ack anomaly classifier) and IsSessionBeadOrRepairable
 	// classification are deliberately unchanged; this just confirms the fix
 	// didn't mutate the step bead as a side effect.
 	gotStep, err := env.store.Get(drainStep.ID)
@@ -3830,7 +3961,7 @@ func TestFinalizeDrainAckStoppedSessionDoesNotEmitEventsWhenFinalMetadataFails(t
 
 	failingStore := &failSetMetadataBatchStore{Store: env.store, err: errors.New("metadata write failed")}
 	finalizeDrainAckStoppedSession(
-		"", env.cfg, failingStore, nil, env.sessionInfo(session.ID), nil, "worker", false,
+		"", env.cfg, failingStore, nil, env.sessionInfo(session.ID), liveSessionOwnerSet{}, "worker", false,
 		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
 	)
 
@@ -3857,7 +3988,7 @@ func TestFinalizeDrainAckStoppedSessionFallsThroughWhenCloseGateRacesWithAssignm
 
 	racingStore := &assignOnListStore{Store: env.store, sessionID: session.ID}
 	finalizeDrainAckStoppedSession(
-		"", env.cfg, racingStore, nil, env.sessionInfo(session.ID), nil, "worker", true,
+		"", env.cfg, racingStore, nil, env.sessionInfo(session.ID), liveSessionOwnerSet{}, "worker", true,
 		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
 	)
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1957,11 +1957,11 @@ func drainAckAssignedWorkEventCount(t *testing.T, seedWork func(t *testing.T, st
 // (configured_named_identity) rather than its own durable bead ID — the way a
 // production hook claim stamps an aliased/pool seat (hookClaimAssigneeIdentity).
 // When addLiveSibling is true a SECOND seat with a distinct session name but the
-// SAME pool alias is present and alive in the reconciler's running-session
-// inventory for both ticks, so it is a genuine live owner of the row. Returns how
-// many SessionDrainAckedWithAssignedWork events fired: zero when a live sibling
-// owns the row (correct surplus-seat drain), one when no live incarnation but the
-// draining seat itself carries the alias (a genuine strand).
+// SAME pool alias is present and alive for both ticks. Returns how many
+// SessionDrainAckedWithAssignedWork events fired. The classifier does NOT try to
+// suppress an in_progress row on account of a live sibling (that cannot be done
+// safely at finalize — see drainAckClaimableAnomalyBead), so an in_progress row
+// ALWAYS fires whether or not a live sibling is present.
 func drainAckPoolAliasInProgressEventCount(t *testing.T, addLiveSibling bool) int {
 	t.Helper()
 	const poolAlias = "gc__worker-pool"
@@ -2060,35 +2060,34 @@ func TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent(t *tes
 	}
 }
 
-// TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent pins the
-// owner-liveness suppression: a seat drain-acking while an IN_PROGRESS row is
-// owned by ANOTHER LIVE incarnation of the same pool (a distinctly-named sibling
-// that shares the row's pool alias and is up in the reconciler's running-session
-// inventory) must NOT emit SessionDrainAckedWithAssignedWork. This is the ~17%
-// false-positive class from live data: a surplus seat draining past a row a live
-// sibling is actively working is normal pull, not a strand. The sibling here
-// genuinely owns the row (shared configured_named_identity), which is the
-// distinction the fix keys on — not the assignee's identity shape.
-func TestReconcileSessionBeads_DrainAckLiveSiblingInProgressSuppressesEvent(t *testing.T) {
+// TestReconcileSessionBeads_DrainAckLiveSiblingInProgressStillEmitsEvent pins the
+// deliberate safe-partial choice: an IN_PROGRESS row shared with ANOTHER LIVE
+// incarnation of the same pool STILL emits SessionDrainAckedWithAssignedWork. We
+// do NOT suppress on sibling liveness, because no liveness signal available at
+// finalize can distinguish a benign live-sibling claim from a genuine #2293
+// cap-hit strand without a hole that would silence a real strand (zombie tmux
+// pane reads Running, stale 30s liveness cache, duplicate-name keying). A false
+// negative (a stranded row kept quiet) is worse than this residual false
+// positive, so the in_progress arm fires unconditionally and accepts the noise.
+// (Inverted from the prior owner-liveness attempt, which this replaces.)
+func TestReconcileSessionBeads_DrainAckLiveSiblingInProgressStillEmitsEvent(t *testing.T) {
 	count := drainAckPoolAliasInProgressEventCount(t, true)
-	if count != 0 {
-		t.Fatalf("%s events = %d, want 0 — an in_progress row a LIVE sibling incarnation owns is a surplus-seat drain, not a strand",
+	if count < 1 {
+		t.Fatalf("%s events = %d, want >= 1 — an in_progress row fires regardless of sibling liveness (safe-partial: never risk silencing a genuine strand)",
 			events.SessionDrainAckedWithAssignedWork, count)
 	}
 }
 
 // TestReconcileSessionBeads_DrainAckAliasClaimedNoLiveOwnerEmitsEvent is the
-// genuine-strand RED test the owner-liveness fix exists for. A named/pool seat
-// claims a row under its ALIAS (configured_named_identity, as production hook
-// claims stamp — not the durable bead ID), hits its turn cap, and drain-acks
-// mid-task with NO live replacement: no other live incarnation carries the alias.
-// That is the #2293 cap-hit strand the event MUST emit for. The prior
-// "assignee == this session's own bead ID" gate silenced it (the alias is not the
-// bead ID), so this fails on that state; keying on owner-liveness fires it.
+// genuine-strand test the fix exists for. A named/pool seat claims a row under
+// its ALIAS (configured_named_identity, as production hook claims stamp — not the
+// durable bead ID), hits its turn cap, and drain-acks mid-task with NO live
+// replacement. That is the #2293 cap-hit strand the event MUST emit for; the
+// in_progress arm fires it.
 func TestReconcileSessionBeads_DrainAckAliasClaimedNoLiveOwnerEmitsEvent(t *testing.T) {
 	count := drainAckPoolAliasInProgressEventCount(t, false)
 	if count != 1 {
-		t.Fatalf("%s events = %d, want 1 — an alias-claimed in_progress row with NO live owner but the draining seat is a genuine cap-hit strand",
+		t.Fatalf("%s events = %d, want 1 — an alias-claimed in_progress row with no live replacement is a genuine cap-hit strand",
 			events.SessionDrainAckedWithAssignedWork, count)
 	}
 }
@@ -2112,13 +2111,13 @@ func TestReconcileSessionBeads_DrainAckReadyAssignedWorkEmitsEvent(t *testing.T)
 // drainAckAliasSiblingEventCount drives a "worker" seat holding an IN_PROGRESS row
 // stamped with a shared pool alias through the drain-ack finalize lifecycle, with
 // a second seat that also carries the SAME alias. seedSibling configures that
-// second seat's runtime and desired/config posture (via addDesired/provider Start
-// or leaving it dead) so a case can make it a genuinely-live owner or a dead
-// zombie; siblingDrainAck marks the sibling drain-acked in the same pass. It
-// returns how many SessionDrainAckedWithAssignedWork events fired. Everything runs
-// through the signature-stable reconcileSessionBeads entry point so the two new
-// fire-cases below compile and RED on the pre-fix bead-not-closed keying and GREEN
-// on the runtime-liveness keying.
+// second seat's posture (drained-and-dead twin, dead-runtime zombie, etc.);
+// siblingDrainAck marks the sibling drain-acked in the same pass. It returns how
+// many SessionDrainAckedWithAssignedWork events fired. Under the safe-partial
+// classifier the in_progress arm ALWAYS fires, so these cases are regression
+// guards that a same-alias sibling — whatever its liveness — never silences the
+// draining seat's strand (the exact false negative the prior owner-liveness
+// attempts kept re-introducing).
 func drainAckAliasSiblingEventCount(t *testing.T, siblingName string, siblingDrainAck bool, seedSibling func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead)) int {
 	t.Helper()
 	const poolAlias = "gc__worker-pool"
@@ -2193,16 +2192,14 @@ func drainAckAliasSiblingEventCount(t *testing.T, siblingName string, siblingDra
 	return count
 }
 
-// TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent pins the
-// same-pass-drain half of the owner-liveness fix. Two distinctly-named seats
-// share one pool alias and BOTH drain-ack in the same pass while an in_progress
-// row carries that alias. The pre-fix classifier keyed "live owner" on
-// bead-not-closed, so each draining seat counted the OTHER (still open, mid-drain)
-// as a live owner and they mutually SUPPRESSED — a false negative that silences a
-// genuine strand. Neither seat's runtime survives the drain, so keying on a
-// positive runtime observation (both dead, both drain-ack-stop-pending) leaves no
-// live owner and the strand MUST fire. RED on the pre-fix state (count 0), green
-// after (each unowned finalize fires, so >= 1).
+// TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent guards the
+// same-pass-drain case. Two distinctly-named seats share one pool alias and BOTH
+// drain-ack in the same pass while an in_progress row carries that alias. An
+// owner-liveness classifier keyed on bead-not-closed made each draining seat
+// count the OTHER (still open, mid-drain) as a live owner and mutually SUPPRESS —
+// a false negative that silences a genuine strand. The safe-partial classifier
+// fires on the in_progress row unconditionally, so the strand is never silenced
+// by a same-pass-draining sibling.
 func TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent(t *testing.T) {
 	count := drainAckAliasSiblingEventCount(t, "worker-twin", true, func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
 		env.markSessionActive(sibling)
@@ -2214,24 +2211,20 @@ func TestReconcileSessionBeads_DrainAckTwoSeatSamePassDrainEmitsEvent(t *testing
 	}
 }
 
-// TestReconcileSessionBeads_DrainAckZombieOpenSiblingEmitsEvent pins the
-// zombie-sibling half of the owner-liveness fix. A sibling seat shares the pool
-// alias and its session bead is still OPEN, but its RUNTIME is dead (never
-// started) and it is NOT drain-pending — a drained-open zombie kept open by the
-// very row it stranded. The pre-fix classifier counted it as a live owner because
-// its bead is not closed, permanently SILENCING the recurring cap-hit strand. It
-// is configured-but-not-desired, so the reconciler keeps it open ("suspended")
-// while it holds the shared alias work rather than closing it. Keying on a
-// positive runtime observation excludes the dead zombie, so the strand MUST fire.
-// RED on the pre-fix state (count 0), green after (count 1). The zombie is NOT
-// drain-pending, so this proves the RUNTIME observation — not the drain-pending
-// proxy — is what excludes it.
+// TestReconcileSessionBeads_DrainAckZombieOpenSiblingEmitsEvent guards the
+// zombie-sibling case. A sibling seat shares the pool alias and its session bead
+// is still OPEN, but its runtime is dead (never started) and it is NOT
+// drain-pending — a drained-open zombie kept open by the very row it stranded. An
+// owner-liveness classifier keyed on bead-not-closed counted it as a live owner
+// and permanently SILENCED the recurring cap-hit strand. The safe-partial
+// classifier fires on the in_progress row unconditionally, so a zombie sibling
+// never silences the strand.
 func TestReconcileSessionBeads_DrainAckZombieOpenSiblingEmitsEvent(t *testing.T) {
 	count := drainAckAliasSiblingEventCount(t, "worker-zombie", false, func(t *testing.T, env *reconcilerTestEnv, sibling *beads.Bead) {
 		// Leave the zombie asleep (createSessionBead's default), never started in
-		// the provider (runtime dead), and NOT in the desired set so it is never
-		// woken or restarted — configured but scaled down, held open as "suspended"
-		// because it still carries the shared alias work.
+		// the provider (runtime dead), and NOT in the desired set — it stays an
+		// open, dead-runtime sibling that an owner-liveness classifier would have
+		// mistaken for a live owner.
 		_ = sibling
 	})
 	if count != 1 {
@@ -3961,7 +3954,7 @@ func TestFinalizeDrainAckStoppedSessionDoesNotEmitEventsWhenFinalMetadataFails(t
 
 	failingStore := &failSetMetadataBatchStore{Store: env.store, err: errors.New("metadata write failed")}
 	finalizeDrainAckStoppedSession(
-		"", env.cfg, failingStore, nil, env.sessionInfo(session.ID), liveSessionOwnerSet{}, "worker", false,
+		"", env.cfg, failingStore, nil, env.sessionInfo(session.ID), "worker", false,
 		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
 	)
 
@@ -3988,7 +3981,7 @@ func TestFinalizeDrainAckStoppedSessionFallsThroughWhenCloseGateRacesWithAssignm
 
 	racingStore := &assignOnListStore{Store: env.store, sessionID: session.ID}
 	finalizeDrainAckStoppedSession(
-		"", env.cfg, racingStore, nil, env.sessionInfo(session.ID), liveSessionOwnerSet{}, "worker", true,
+		"", env.cfg, racingStore, nil, env.sessionInfo(session.ID), "worker", true,
 		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
 	)
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2105,6 +2105,48 @@ func TestReconcileSessionBeads_DrainAckOpenStepAssignedWorkEmitsEvent(t *testing
 	}
 }
 
+// TestReconcileSessionBeads_DrainAckStaleIsBlockedAssignedWorkEmitsEvent is the
+// MAJOR regression guard for the last silencing hole. bd's is_blocked field is a
+// DENORMALIZED projection that can lag a just-closed blocker (stale-true;
+// issueops.countStaleIsBlockedSQL / `bd recompute-blocked` exist to repair it).
+// An OPEN row assigned to the seat whose blocking dep has CLOSED — deps genuinely
+// MET — but whose is_blocked flag still reads true is a real strand: the seat
+// drained past claimable work. The open arm must confirm real blockedness against
+// live deps before suppressing, so a stale-true flag with met deps FIRES. Before
+// the fix the arm suppressed on the projection alone (demandRowReady) and silenced
+// it — no event, seat stopped, alarm never fires.
+//
+// Contrast TestReconcileSessionBeads_DrainAckBlockedAssignedWorkSuppressesEvent,
+// which keeps its blocker OPEN so the dep is genuinely unmet and suppression is
+// correct; here the same wiring closes the blocker to leave only the stale flag.
+func TestReconcileSessionBeads_DrainAckStaleIsBlockedAssignedWorkEmitsEvent(t *testing.T) {
+	blockedTrue := true
+	count := drainAckAssignedWorkEventCount(t, func(t *testing.T, store beads.Store, sessionID string) {
+		blocker, err := store.Create(beads.Bead{Title: "upstream gate", Type: "task", Status: "open"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		work, err := store.Create(beads.Bead{Title: "downstream phase", Type: "task", Status: "open", Assignee: sessionID, IsBlocked: &blockedTrue})
+		if err != nil {
+			t.Fatalf("Create(work): %v", err)
+		}
+		if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd: %v", err)
+		}
+		// Close the blocker but leave the work row's denormalized is_blocked flag
+		// stale-true — the exact state bd's projection lag produces. MemStore does
+		// not recompute is_blocked on a dependency's close, so the flag stays true
+		// while the live dep is now met.
+		if err := store.Close(blocker.ID); err != nil {
+			t.Fatalf("Close(blocker): %v", err)
+		}
+	})
+	if count != 1 {
+		t.Fatalf("%s events = %d, want 1 — an open row with a STALE is_blocked=true flag whose blocking dep has closed is a genuine strand; the open arm must confirm blockedness against live deps before suppressing",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckLiveSiblingInProgressStillEmitsEvent pins the
 // deliberate safe-partial choice: an IN_PROGRESS row shared with ANOTHER LIVE
 // incarnation of the same pool STILL emits SessionDrainAckedWithAssignedWork. We
@@ -2207,6 +2249,40 @@ func TestReconcileSessionBeads_DrainAckOpenArmReadErrorStillEmitsInProgressStran
 	if count != 1 {
 		t.Fatalf("%s events = %d, want 1 — an in_progress strand must still fire when the open/claimable arm's read errors (probe in_progress first)",
 			events.SessionDrainAckedWithAssignedWork, count)
+	}
+}
+
+// TestReconcileSessionBeads_DrainAckOpenArmReadErrorWithNoInProgressLogsError is
+// the MINOR-1 regression guard. When the open/claimable arm's store read errors
+// and the in_progress arm is cleanly empty, the classifier finds no bead — so it
+// must NOT fire, but it MUST surface the read error for logging rather than
+// swallow it. Before the fix a single-arm error with the other arm cleanly empty
+// returned (found=false, nil) and the diagnostic vanished, a regression vs
+// origin/main which logged every finder error. errors.Join now carries the lone
+// error up while still eliding the nil arm.
+func TestReconcileSessionBeads_DrainAckOpenArmReadErrorWithNoInProgressLogsError(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	fake := events.NewFake()
+
+	info := env.createSessionInfo("worker", "worker")
+
+	store := readyOpenErrStore{Store: env.store, err: errors.New("graph readiness read failed")}
+	var stderr bytes.Buffer
+	recordDrainAckAssignedWorkEvent("", env.cfg, store, nil, info, "worker", "worker", "worker", fake, &stderr)
+
+	count := 0
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			count++
+		}
+	}
+	if count != 0 {
+		t.Fatalf("%s events = %d, want 0 — no bead was found, so a read error alone must never manufacture the alarm",
+			events.SessionDrainAckedWithAssignedWork, count)
+	}
+	if !strings.Contains(stderr.String(), "graph readiness read failed") {
+		t.Fatalf("stderr = %q, want it to surface the open-arm read error for logging (Don't-Swallow-Errors); a single-arm error with the other arm cleanly empty must not vanish", stderr.String())
 	}
 }
 

--- a/cmd/gc/telemetry_lifecycle_metrics_test.go
+++ b/cmd/gc/telemetry_lifecycle_metrics_test.go
@@ -287,7 +287,7 @@ func TestFinalizeDrainAckStoppedSession_RecordsAgentStopMetric(t *testing.T) {
 		session.Metadata = patch.Apply(session.Metadata)
 
 		result := finalizeDrainAckStoppedSession(
-			"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), liveSessionOwnerSet{}, identity, true,
+			"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), identity, true,
 			newFakeDrainOps(), env.dt, env.clk, rec, &env.stderr,
 		)
 
@@ -878,7 +878,7 @@ func TestFinalizeDrainAckStoppedSession_WitnessBranchDoesNotRecordMetric(t *test
 	}
 
 	result := finalizeDrainAckStoppedSession(
-		"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), liveSessionOwnerSet{}, identity, true,
+		"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), identity, true,
 		newFakeDrainOps(), env.dt, env.clk, events.NewFake(), &env.stderr,
 	)
 

--- a/cmd/gc/telemetry_lifecycle_metrics_test.go
+++ b/cmd/gc/telemetry_lifecycle_metrics_test.go
@@ -287,7 +287,7 @@ func TestFinalizeDrainAckStoppedSession_RecordsAgentStopMetric(t *testing.T) {
 		session.Metadata = patch.Apply(session.Metadata)
 
 		result := finalizeDrainAckStoppedSession(
-			"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), nil, identity, true,
+			"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), liveSessionOwnerSet{}, identity, true,
 			newFakeDrainOps(), env.dt, env.clk, rec, &env.stderr,
 		)
 
@@ -878,7 +878,7 @@ func TestFinalizeDrainAckStoppedSession_WitnessBranchDoesNotRecordMetric(t *test
 	}
 
 	result := finalizeDrainAckStoppedSession(
-		"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), nil, identity, true,
+		"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), liveSessionOwnerSet{}, identity, true,
 		newFakeDrainOps(), env.dt, env.clk, events.NewFake(), &env.stderr,
 	)
 

--- a/cmd/gc/telemetry_lifecycle_metrics_test.go
+++ b/cmd/gc/telemetry_lifecycle_metrics_test.go
@@ -287,7 +287,7 @@ func TestFinalizeDrainAckStoppedSession_RecordsAgentStopMetric(t *testing.T) {
 		session.Metadata = patch.Apply(session.Metadata)
 
 		result := finalizeDrainAckStoppedSession(
-			"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), identity, true,
+			"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), nil, identity, true,
 			newFakeDrainOps(), env.dt, env.clk, rec, &env.stderr,
 		)
 
@@ -878,7 +878,7 @@ func TestFinalizeDrainAckStoppedSession_WitnessBranchDoesNotRecordMetric(t *test
 	}
 
 	result := finalizeDrainAckStoppedSession(
-		"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), identity, true,
+		"", env.cfg, env.store, nil, sessiontest.SeedBead(t, session), nil, identity, true,
 		newFakeDrainOps(), env.dt, env.clk, events.NewFake(), &env.stderr,
 	)
 

--- a/internal/events/payloads.go
+++ b/internal/events/payloads.go
@@ -199,9 +199,9 @@ type SessionDemandClaimDivergencePayload struct {
 	// ("open"/"in_progress"/"closed"), "unreadable" when the classification read
 	// failed, or empty when there was no row to read.
 	TriggerStatusAtDrain string `json:"trigger_status_at_drain,omitempty"`
-	// Classification is the verdict: benign, divergence, or unknown. It is
-	// carried rather than left to be re-derived, because the divergence count IS
-	// the rollout metric for the agreement fix.
+	// Classification is the verdict: benign, divergence, projection_blocked, or
+	// unknown. It is carried rather than left to be re-derived, because the
+	// divergence count IS the rollout metric for the agreement fix.
 	Classification string `json:"classification"`
 }
 

--- a/internal/events/payloads.go
+++ b/internal/events/payloads.go
@@ -163,6 +163,16 @@ const (
 	// route-matching. The controller counted work the worker's own read did not
 	// serve; this is the agreement invariant breaking.
 	DemandClaimDivergence = "divergence"
+	// DemandClaimProjectionBlocked: the trigger row is still open, unassigned and
+	// route-matching, and the only thing marking it non-claimable is bd's
+	// denormalized is_blocked projection — which can lag a just-closed blocker. A
+	// stale-true projection would hide a genuinely-servable divergence, and this
+	// single-bead read cannot cheaply re-derive blockedness from live deps the way
+	// a worker's ready query does, so a projection-blocked row is surfaced in its
+	// own bucket rather than silently folded into benign. It is NOT counted as a
+	// clean divergence (that metric must stay the agreement signal), but it is not
+	// hidden either.
+	DemandClaimProjectionBlocked = "projection_blocked"
 	// DemandClaimUnknown: the classification read could not be made (no trigger
 	// recorded, or the row could not be read). Never counted as either.
 	DemandClaimUnknown = "unknown"

--- a/internal/events/payloads.go
+++ b/internal/events/payloads.go
@@ -163,16 +163,16 @@ const (
 	// route-matching. The controller counted work the worker's own read did not
 	// serve; this is the agreement invariant breaking.
 	DemandClaimDivergence = "divergence"
-	// DemandClaimProjectionBlocked: the trigger row is still open, unassigned and
-	// route-matching, and the only thing marking it non-claimable is bd's
-	// denormalized is_blocked projection — which can lag a just-closed blocker. A
-	// stale-true projection would hide a genuinely-servable divergence, and this
-	// single-bead read cannot cheaply re-derive blockedness from live deps the way
-	// a worker's ready query does, so a projection-blocked row is surfaced in its
-	// own bucket rather than silently folded into benign. It is NOT counted as a
-	// clean divergence (that metric must stay the agreement signal), but it is not
-	// hidden either.
-	DemandClaimProjectionBlocked = "projection_blocked"
+	// DemandClaimBlocked: the trigger row is still open, unassigned and
+	// route-matching, and the only thing marking it non-claimable is a blocking
+	// dependency — re-derived from the row's LIVE deps, not read off bd's
+	// denormalized is_blocked projection, which can lag a just-closed blocker and
+	// is absent from the payloads these reads actually return. No worker could
+	// have claimed the row, so it is NOT counted as a clean divergence (that
+	// metric must stay the agreement signal) — but it is not folded into benign
+	// either: a routed row the controller keeps counting while nobody can take it
+	// is worth seeing on its own.
+	DemandClaimBlocked = "blocked"
 	// DemandClaimUnknown: the classification read could not be made (no trigger
 	// recorded, or the row could not be read). Never counted as either.
 	DemandClaimUnknown = "unknown"
@@ -199,9 +199,9 @@ type SessionDemandClaimDivergencePayload struct {
 	// ("open"/"in_progress"/"closed"), "unreadable" when the classification read
 	// failed, or empty when there was no row to read.
 	TriggerStatusAtDrain string `json:"trigger_status_at_drain,omitempty"`
-	// Classification is the verdict: benign, divergence, projection_blocked, or
-	// unknown. It is carried rather than left to be re-derived, because the
-	// divergence count IS the rollout metric for the agreement fix.
+	// Classification is the verdict: benign, divergence, blocked, or unknown. It
+	// is carried rather than left to be re-derived, because the divergence count
+	// IS the rollout metric for the agreement fix.
 	Classification string `json:"classification"`
 }
 


### PR DESCRIPTION
## Summary

The `session.drain_acked_with_assigned_work` / demand-claim-divergence signal was a **false-positive machine**: it fired every time a session correctly drained past work that wasn't its to claim. Live classification of a 142-event sample: ~83% the "assigned work" was routed to the session's *target* but assignee-empty and dep-blocked (not claimable); ~17% was `in_progress` on a *different live incarnation* of the same pool. Zero were genuine strandings. So the alarm buried real signal in noise.

## The invariant this fix holds

**Never silence a genuine strand** (a false negative is worse than the false-positive noise). So: suppress ONLY work that is *provably-non-claimable*; fire for everything else. This went through several rejected approaches that each traded noise for a silenced strand (identity-key, bead-not-closed-key, `running||alive` zombie-shell liveness, `beads.Ready` type-exclusions, trusting `is_blocked`) — each caught by adversarial review. The final design uses **no liveness/owner check at all**:

- `drainAckClaimableAnomalyBead` probes the seat's own `in_progress` work first. That arm fires unconditionally on sibling liveness — it applies the same two structural exclusions as the open arm (session beads, and the seat's own drain step) and then probes nothing else, because an `in_progress` row assigned to the seat is the seat's claimed work. It then walks the raw `OpenAssignedTo` list and suppresses a row **only** when a live-dep re-derivation confirms an unmet plain **`blocks`** dependency, when the row is deferred (fresh bead-local `defer_until`), or when it is the session's own drain step. Every other open assigned bead of any type fires.
- **bd's denormalized `is_blocked` column never decides that suppression** — neither its presence nor its absence. On the read paths both consumers use, bd's payloads do not carry the column at all, so the *production* reading is absent; and when a value is present it can lag stale-true past a closed blocker (the reading `bd recompute-blocked` exists to repair). Both readings are therefore treated identically, as *blockedness unproven*, and settled the same way: by walking the row's live dependencies. An unmet `waits-for` / `conditional-blocks` target is **not** proof of non-claimability — bd opens a `waits-for` gate through native state independently of its target's status — so only a plain `blocks` edge onto an unsatisfied blocker suppresses, and everything else fires.
- The demand-divergence half (`classifyDemandTrigger`) gets a matching readiness gate and a distinct `blocked` classification, re-derived through that same live-dep confirmation — annotated, not buried inside `benign`. A settlement read that fails classifies `unknown`, so an unreadable store can never manufacture the divergence count.
- Read errors are surfaced for logging (Don't-Swallow-Errors), never used to silence.

## Net effect, attributed to what actually changed

The sample's ~83% class is defined by two properties, and **only one of them is new in this diff**:

- **Assignee-empty is pre-existing base behavior**, not an effect of this change. The base emitter already resolved the seat's identifiers through `sessionAssignmentIdentifiersForConfigInfo` and already queried `OpenAssignedTo(assignee, ...)` per identifier, skipping `assignee == ""`, and already returned early when no bead was found. `cmd/gc/session_beads.go` and `cmd/gc/work_assignment.go` are byte-identical between the adopted base and this branch. A routed-but-assignee-empty row could not be returned at base either, so identifier keying delivers zero new suppression here.
- **Dep-blocked is the new mechanism** — the live-dep plain-`blocks` confirmation described above. Crucially it runs on the *absent*-projection reading, which is the reading production actually returns, so it engages in the fleet rather than only on a synthetic `is_blocked=true` row.

So the reduction this change can claim is attributable to the dep-confirm, plus two smaller net-new open-arm suppressions (deferred rows, and the own-drain-step skip). The ~17% live-sibling `in_progress` class deliberately **still** fires: no liveness signal available at finalize can tell it apart from a genuine cap-hit strand without opening a hole that silences a real one, so the in_progress arm accepts that residual noise. A genuine cap-hit strand (#2293) still fires. No claim-path drain-refuse guard was added (rejected — it defends a non-occurring stranding and risks spinning surplus seats).

Stated plainly: the 142-event sample was collected against a *deployed* binary that may predate the adopted base, so some of the observed reduction may be real relative to production-today while not being attributable to this diff. The mechanism claims above are derived from the base blobs, not from the sample.

## Tests

RED-then-GREEN for the strand-fires cases (open step-type bead, stale-`is_blocked` with met deps, ready-arm read error + in_progress strand) and the suppress cases (unmet plain `blocks` dep, deferred, assignee-empty), plus the narrowing's own guards: a `waits-for` gate onto an OPEN target fires, and a dep-confirm read error fires nothing while still surfacing the error.

The production shape — an unmet plain `blocks` edge with **no** `is_blocked` projection on the row — is pinned on both consumers, and a mutation probe reverting just that branch's polarity turns both red, so neither assertion is vacuous. The divergence verdict table pins all four blockedness outcomes: production-shape claimable → `divergence`, no-projection-but-dep-confirmed → `blocked`, stale projection with met deps → `divergence` (the flag does not get the last word), settlement read error → `unknown`. Adversarially reviewed by a Fable council across six rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5858 — touches the same classifier this issue quotes (classifyDemandTrigger in cmd/gc/demand_divergence.go): it adds a readiness gate and a new `blocked` classification, re-derived from the row's live dependencies, so a non-claimable row is annotated rather than folded into benign. It does not change the worker-store-only trigger read, so the cross-store blindness described in that issue — and the closed-in-worker-store/open-in-city-store benign path behind the 2,656 counts — is untouched.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->