### PR TITLE
config: exclude agents per import edge

### DIFF
--- a/cmd/gc/builtin_include_doctor_check.go
+++ b/cmd/gc/builtin_include_doctor_check.go
@@ -549,7 +549,7 @@ func (c *builtinImportDoctorCheck) Fix(_ *doctor.CheckContext) error {
 				return fmt.Errorf("ensuring bundled import %q in pack.toml: %w", name, err)
 			}
 		}
-		if !maps.Equal(before, packManifest.Imports) {
+		if !importMapsEqual(before, packManifest.Imports) {
 			if err := writeCityPackManifest(fsys.OSFS{}, c.cityPath, packManifest); err != nil {
 				return fmt.Errorf("writing pack.toml: %w", err)
 			}
@@ -795,6 +795,19 @@ func ensureBundledImportBinding(imports map[string]config.Import, name string, i
 	}
 	imports[config.UniqueLegacyImportBinding(imports, name)] = imp
 	return imports, nil
+}
+
+func importMapsEqual(a, b map[string]config.Import) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for binding, left := range a {
+		right, ok := b[binding]
+		if !ok || !sameImport(left, right) {
+			return false
+		}
+	}
+	return true
 }
 
 // bundledImportForLegacySystemPacksRef maps a legacy reference under the

--- a/cmd/gc/builtin_include_doctor_check_test.go
+++ b/cmd/gc/builtin_include_doctor_check_test.go
@@ -198,7 +198,7 @@ provider = "file"
 		t.Fatalf("re-reading pack.toml manifest: %v", err)
 	}
 	wantGastown := config.Import{Source: gastownSource, Version: config.BundledSourcePinnedVersion(gastownSource)}
-	if got := packManifest.Imports["gastown"]; got != wantGastown {
+	if got := packManifest.Imports["gastown"]; !sameImport(got, wantGastown) {
 		t.Errorf("pack.toml import gastown after fix = %+v, want %+v (the stripped include's replacement must land)", got, wantGastown)
 	}
 
@@ -281,7 +281,7 @@ provider = "file"
 		t.Fatalf("re-reading pack.toml manifest: %v", err)
 	}
 	wantGastown := config.Import{Source: gastownSource, Version: config.BundledSourcePinnedVersion(gastownSource)}
-	if got := packManifest.Imports["gastown"]; got != wantGastown {
+	if got := packManifest.Imports["gastown"]; !sameImport(got, wantGastown) {
 		t.Errorf("pack.toml import gastown after the migrate→doctor two-step = %+v, want %+v", got, wantGastown)
 	}
 
@@ -459,16 +459,16 @@ source = ".gc/system/packs/core"
 	}
 	wantCore := config.Import{Source: coreSource, Version: config.BundledSourcePinnedVersion(coreSource)}
 	wantBd := config.Import{Source: bdSource, Version: config.BundledSourcePinnedVersion(bdSource)}
-	if got := after.Rigs[0].Imports["core"]; got != wantCore {
+	if got := after.Rigs[0].Imports["core"]; !sameImport(got, wantCore) {
 		t.Errorf("rig import core after fix = %+v, want %+v", got, wantCore)
 	}
-	if got := after.Rigs[0].Imports["bd"]; got != wantBd {
+	if got := after.Rigs[0].Imports["bd"]; !sameImport(got, wantBd) {
 		t.Errorf("rig include bd was not converted to a pinned bundled import: got %+v, want %+v", got, wantBd)
 	}
 	if len(after.Rigs[0].Includes) != 0 {
 		t.Errorf("rig includes after fix = %v, want none", after.Rigs[0].Includes)
 	}
-	if got := after.Defaults.Rig.Imports["core"]; got != wantCore {
+	if got := after.Defaults.Rig.Imports["core"]; !sameImport(got, wantCore) {
 		t.Errorf("default-rig import core after fix = %+v, want %+v", got, wantCore)
 	}
 	if got := after.Workspace.LegacyDefaultRigIncludes(); len(got) != 0 {
@@ -558,10 +558,10 @@ source = "./packs/altbd"
 	if got := after.Workspace.LegacyDefaultRigIncludes(); len(got) != 0 {
 		t.Errorf("workspace.default_rig_includes after fix = %v, want none", got)
 	}
-	if got, want := after.Defaults.Rig.Imports["core"], (config.Import{Source: "./packs/altcore"}); got != want {
+	if got, want := after.Defaults.Rig.Imports["core"], (config.Import{Source: "./packs/altcore"}); !sameImport(got, want) {
 		t.Errorf("occupied default-rig binding core after fix = %+v, want untouched %+v", got, want)
 	}
-	if got := after.Defaults.Rig.Imports["core-2"]; got != wantCore {
+	if got := after.Defaults.Rig.Imports["core-2"]; !sameImport(got, wantCore) {
 		t.Errorf("default-rig import core-2 after fix = %+v, want %+v (migrated include must land on a unique binding)", got, wantCore)
 	}
 	if len(after.Rigs) != 1 {
@@ -570,10 +570,10 @@ source = "./packs/altbd"
 	if got := after.Rigs[0].Includes; len(got) != 0 {
 		t.Errorf("rig includes after fix = %v, want none", got)
 	}
-	if got, want := after.Rigs[0].Imports["bd"], (config.Import{Source: "./packs/altbd"}); got != want {
+	if got, want := after.Rigs[0].Imports["bd"], (config.Import{Source: "./packs/altbd"}); !sameImport(got, want) {
 		t.Errorf("occupied rig binding bd after fix = %+v, want untouched %+v", got, want)
 	}
-	if got := after.Rigs[0].Imports["bd-2"]; got != wantBd {
+	if got := after.Rigs[0].Imports["bd-2"]; !sameImport(got, wantBd) {
 		t.Errorf("rig import bd-2 after fix = %+v, want %+v (migrated include must land on a unique binding)", got, wantBd)
 	}
 
@@ -649,11 +649,11 @@ source = "./packs/standards"
 	if err != nil {
 		t.Fatalf("re-reading pack.toml manifest: %v", err)
 	}
-	if got, want := packManifest.Imports["core"], (config.Import{Source: "./packs/standards"}); got != want {
+	if got, want := packManifest.Imports["core"], (config.Import{Source: "./packs/standards"}); !sameImport(got, want) {
 		t.Errorf("occupied pack.toml binding core after fix = %+v, want untouched %+v", got, want)
 	}
 	wantCore := config.Import{Source: coreSource, Version: config.BundledSourcePinnedVersion(coreSource)}
-	if got := packManifest.Imports["core-2"]; got != wantCore {
+	if got := packManifest.Imports["core-2"]; !sameImport(got, wantCore) {
 		t.Errorf("pack.toml import core-2 after fix = %+v, want %+v (required import must land on a unique binding, not be skipped)", got, wantCore)
 	}
 
@@ -797,6 +797,31 @@ transitive = false
 	}
 	if string(cityData) != cityToml {
 		t.Fatalf("Fix mutated city.toml despite the conflict:\n%s", cityData)
+	}
+}
+
+func TestImportMapsEqualIncludesAgentExclusions(t *testing.T) {
+	base := map[string]config.Import{
+		"shared": {
+			Source:        "../shared",
+			AgentsExclude: []string{"worker"},
+		},
+	}
+	if !importMapsEqual(base, map[string]config.Import{
+		"shared": {
+			Source:        "../shared",
+			AgentsExclude: []string{"worker"},
+		},
+	}) {
+		t.Fatal("importMapsEqual should accept equal agent selectors")
+	}
+	if importMapsEqual(base, map[string]config.Import{
+		"shared": {
+			Source:        "../shared",
+			AgentsExclude: []string{"keeper"},
+		},
+	}) {
+		t.Fatal("importMapsEqual must distinguish agent selectors")
 	}
 }
 

--- a/cmd/gc/import_state_doctor_check.go
+++ b/cmd/gc/import_state_doctor_check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -564,6 +565,12 @@ func rewriteLegacyPublicPackImportMap(cityPath string, imports map[string]config
 			if _, legacyTarget := legacyPublicPackForSource(cityPath, existing.Source); !legacyTarget {
 				return false, nil, fmt.Errorf("refusing to overwrite existing %q import with source %q", binding, existing.Source)
 			}
+			// The migration target supplies the durable source and pin, but
+			// the existing legacy declaration owns the composition options.
+			// Preserve those options (including agent narrowing) while
+			// relocating the source so --fix cannot silently widen the roster.
+			target.Import = preserveImportOptions(target.Import, existing)
+			targetBindings[binding] = target
 		}
 	}
 	for _, name := range legacyNames {
@@ -577,7 +584,19 @@ func rewriteLegacyPublicPackImportMap(cityPath string, imports map[string]config
 
 func sameImport(a, b config.Import) bool {
 	return strings.TrimSpace(a.Source) == strings.TrimSpace(b.Source) &&
-		strings.TrimSpace(a.Version) == strings.TrimSpace(b.Version)
+		strings.TrimSpace(a.Version) == strings.TrimSpace(b.Version) &&
+		a.Export == b.Export &&
+		a.ImportIsTransitive() == b.ImportIsTransitive() &&
+		strings.TrimSpace(a.Shadow) == strings.TrimSpace(b.Shadow) &&
+		slices.Equal(a.AgentsExclude, b.AgentsExclude)
+}
+
+func preserveImportOptions(target, existing config.Import) config.Import {
+	target.Export = existing.Export
+	target.Transitive = existing.Transitive
+	target.Shadow = existing.Shadow
+	target.AgentsExclude = append([]string(nil), existing.AgentsExclude...)
+	return target
 }
 
 func replaceImportOrderWithTargets(order []string, rewrites []legacyPublicPackRewrite) []string {

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -619,6 +619,74 @@ source = ".gc/system/packs/gastown"
 	}
 }
 
+func TestRewriteLegacyPublicPackImportsPreservesImportOptions(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+version = "old"
+export = true
+transitive = false
+shadow = "silent"
+agents_exclude = ["worker"]
+`)
+
+	changed, err := rewriteLegacyPublicPackImportsFS(fsys.OSFS{}, cityDir, map[string]wave1PublicPackImportTarget{
+		"gastown": {
+			Binding: "gastown",
+			Import:  config.Import{Source: "https://packages.example/gastown.git", Version: "^1.2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("rewriteLegacyPublicPackImportsFS: %v", err)
+	}
+	if !changed {
+		t.Fatal("rewriteLegacyPublicPackImportsFS reported no change, want pack.toml rewrite")
+	}
+	manifest, err := loadCityPackManifestFS(fsys.OSFS{}, cityDir)
+	if err != nil {
+		t.Fatalf("loadCityPackManifestFS: %v", err)
+	}
+	got := manifest.Imports["gastown"]
+	if got.Source != "https://packages.example/gastown.git" || got.Version != "^1.2" {
+		t.Fatalf("migrated import = %+v, want target source and version", got)
+	}
+	if !got.Export || got.Transitive == nil || *got.Transitive || got.Shadow != "silent" {
+		t.Fatalf("migrated import options = %+v, want export=true transitive=false shadow=silent", got)
+	}
+	if len(got.AgentsExclude) != 1 || got.AgentsExclude[0] != "worker" {
+		t.Fatalf("migrated AgentsExclude = %#v, want [worker]", got.AgentsExclude)
+	}
+}
+
+func TestSameImportComparesAllCompositionOptions(t *testing.T) {
+	base := config.Import{
+		Source:        "https://packages.example/gastown.git",
+		Version:       "^1.2",
+		Export:        true,
+		Transitive:    boolPtr(false),
+		Shadow:        "silent",
+		AgentsExclude: []string{"worker"},
+	}
+	if !sameImport(base, base) {
+		t.Fatal("sameImport should accept identical import options")
+	}
+	changed := base
+	changed.AgentsExclude = []string{"keeper"}
+	if sameImport(base, changed) {
+		t.Fatal("sameImport must distinguish AgentsExclude")
+	}
+	changed = base
+	changed.Export = false
+	if sameImport(base, changed) {
+		t.Fatal("sameImport must distinguish export")
+	}
+}
+
 // Regression for the ga-lurp5d follow-up review: the packv2 import-state
 // rewrite re-marshals pack.toml through the reduced cityPackManifest struct,
 // which would silently drop keys this gc binary does not recognize. A pack.toml

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -480,7 +480,7 @@ Import defines a named import of another pack.
 |-------|------|----------|---------|-------------|
 | `source` | string | **yes** |  | Source is the durable authored pack location: a local path, a remote git URL, or a dereferenceable GitHub tree URL for a pack below a repository root, such as "https://github.com/org/repo/tree/main/packs/foo". Registry handles are lookup-only in this release wave; authored [imports.*] entries store the resolved source plus optional version. |
 | `version` | string |  |  | Version is an optional semver constraint for git-backed imports (e.g., "^1.2"). Empty for local paths. "sha:&lt;hex&gt;" pins a specific commit. |
-| `agents_exclude` | []string |  |  | AgentsExclude removes imported agent templates by their local name on this import edge. Named sessions backed by an excluded agent are removed; other imported resources are retained. |
+| `agents_exclude` | []string |  |  | AgentsExclude removes named agent templates from this import edge. Selectors are matched against each agent's local name before the import binding is applied; other imported resources remain visible. |
 
 ## K8sConfig
 
@@ -1025,3 +1025,4 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 | `includes` | []string |  |  | Includes is the legacy city.toml pack-composition list.  Deprecated: use root pack.toml [imports.*] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
 | `default_rig_includes` | []string |  |  | DefaultRigIncludes is the legacy city.toml default-rig pack list.  Deprecated: use city.toml [defaults.rig.imports.&lt;binding&gt;] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. |
 | `env` | map[string]string |  |  | Env defines workspace-wide environment variables applied to every managed session. Lowest config-precedence — overridden by provider, agent, and patch env. Use for cross-cutting variables like GC_TARGET_BRANCH that every agent should inherit. |
+

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -480,6 +480,7 @@ Import defines a named import of another pack.
 |-------|------|----------|---------|-------------|
 | `source` | string | **yes** |  | Source is the durable authored pack location: a local path, a remote git URL, or a dereferenceable GitHub tree URL for a pack below a repository root, such as "https://github.com/org/repo/tree/main/packs/foo". Registry handles are lookup-only in this release wave; authored [imports.*] entries store the resolved source plus optional version. |
 | `version` | string |  |  | Version is an optional semver constraint for git-backed imports (e.g., "^1.2"). Empty for local paths. "sha:&lt;hex&gt;" pins a specific commit. |
+| `agents_exclude` | []string |  |  | AgentsExclude removes imported agent templates by their local name on this import edge. Named sessions backed by an excluded agent are removed; other imported resources are retained. |
 
 ## K8sConfig
 
@@ -1024,4 +1025,3 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 | `includes` | []string |  |  | Includes is the legacy city.toml pack-composition list.  Deprecated: use root pack.toml [imports.*] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
 | `default_rig_includes` | []string |  |  | DefaultRigIncludes is the legacy city.toml default-rig pack list.  Deprecated: use city.toml [defaults.rig.imports.&lt;binding&gt;] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. |
 | `env` | map[string]string |  |  | Env defines workspace-wide environment variables applied to every managed session. Lowest config-precedence — overridden by provider, agent, and patch env. Use for cross-cutting variables like GC_TARGET_BRANCH that every agent should inherit. |
-

--- a/docs/reference/schema/city-schema.json
+++ b/docs/reference/schema/city-schema.json
@@ -1782,6 +1782,13 @@
         "version": {
           "type": "string",
           "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
+        },
+        "agents_exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AgentsExclude removes named agent templates from this import edge.\nSelectors are matched against each agent's local name before the import\nbinding is applied; other imported resources remain visible."
         }
       },
       "additionalProperties": false,

--- a/docs/reference/schema/city-schema.txt
+++ b/docs/reference/schema/city-schema.txt
@@ -1782,6 +1782,13 @@
         "version": {
           "type": "string",
           "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
+        },
+        "agents_exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AgentsExclude removes named agent templates from this import edge.\nSelectors are matched against each agent's local name before the import\nbinding is applied; other imported resources remain visible."
         }
       },
       "additionalProperties": false,

--- a/docs/reference/schema/pack-schema.json
+++ b/docs/reference/schema/pack-schema.json
@@ -662,6 +662,13 @@
         "version": {
           "type": "string",
           "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
+        },
+        "agents_exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AgentsExclude removes named agent templates from this import edge.\nSelectors are matched against each agent's local name before the import\nbinding is applied; other imported resources remain visible."
         }
       },
       "additionalProperties": false,

--- a/docs/reference/schema/pack-schema.txt
+++ b/docs/reference/schema/pack-schema.txt
@@ -662,6 +662,13 @@
         "version": {
           "type": "string",
           "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
+        },
+        "agents_exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AgentsExclude removes named agent templates from this import edge.\nSelectors are matched against each agent's local name before the import\nbinding is applied; other imported resources remain visible."
         }
       },
       "additionalProperties": false,

--- a/docs/reference/specs/pack-spec.md
+++ b/docs/reference/specs/pack-spec.md
@@ -266,6 +266,7 @@ selector are part of the same source string.
 |---|---|---|---|
 | `source` | string | yes | Durable source for the pack root. Must not be empty. GitHub-hosted packs below a repository root should use dereferenceable `/tree/<ref>/<path>` URLs. |
 | `version` | string | no | Compatibility constraint for versioned sources. |
+| `agents_exclude` | array of strings | no | Local agent names to remove on this import edge. Invalid names fail loading; valid unmatched names warn and do nothing. Backing named sessions are removed with their excluded agents. |
 
 Public import TOML must not use fields named `path`, `ref`, `commit`, or
 `hash`. Registry handles such as `main:gascity` are command-time lookup handles
@@ -833,6 +834,11 @@ top-level `[imports.<binding>]` in `pack.toml`.
 If a pack import has an empty binding name or empty `source`, loading must
 fail.
 
+An import may set `agents_exclude` to a list of local agent names. Selectors
+are validated with the agent-name grammar; an invalid selector fails loading,
+while a valid selector that matches no agent is a warning and otherwise has no
+effect.
+
 ### 2.2. Versioning
 
 `PackImport.version` is a compatibility constraint for versioned sources.
@@ -904,6 +910,16 @@ When loading a pack for a rig-level surface:
 2. The loader drops agents and named sessions whose `scope` is `city`.
 3. For kept agents and named sessions whose `dir` is empty, the loader sets
    `dir` to the consuming rig's `name`.
+
+After cached results are retrieved and `transitive = false` filtering is
+applied, each import edge applies its `agents_exclude` selectors before
+binding stamping or dependency qualification. Matching uses the agent's local
+`name`, not its eventual qualified name. Named sessions whose backing
+`template` has a matching local name are removed with the agent. The filter is
+edge-local: importing the same source twice may exclude different agents on
+each edge. Providers, commands, doctors, runtimes, skills, formulas, orders,
+globals, requirements, and other non-agent content are unaffected. A cached
+pack result is never mutated by this filtering.
 
 Agents contributed by an `[imports.<binding>]` table are stamped with that
 binding at both the city level and the rig level. The consuming surface's own

--- a/engdocs/design/packv2/skew-analysis.md
+++ b/engdocs/design/packv2/skew-analysis.md
@@ -195,6 +195,7 @@ No expansion of `[agent_defaults]` surface in this wave.
 |--------|-------|----------|--------------------|
 | 🟢 | `source` | Present | **Keep.** |
 | 🟢 | `version` | Present | **Keep.** |
+| 🟢 | `agents_exclude` | Present | **Keep.** Per-edge local agent selectors; invalid names fail and valid unmatched names warn. |
 | 🟢 | `export` | Present | **Keep for the current rollout.** If `engdocs/design/pack-import-export-surface.md` is accepted, this becomes a legacy field during that deprecation window and is removed only after behavior-preserving explicit `[[exports]]` migration tooling ships. |
 | 🟢 | `transitive` | Present | **Keep for the current rollout.** If `engdocs/design/pack-import-export-surface.md` is accepted, this becomes a legacy field during that deprecation window and is removed only after generated explicit exports preserve currently leaked public surfaces or report intentional narrowing. |
 | 🟢 | `shadow` | Present | **Keep.** The explicit-export proposal does not replace `shadow`; preserve it unless a separate override/collision design deprecates it in its own documented wave. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -828,6 +828,10 @@ type Import struct {
 	// Version is an optional semver constraint for git-backed imports (e.g.,
 	// "^1.2"). Empty for local paths. "sha:<hex>" pins a specific commit.
 	Version string `toml:"version,omitempty"`
+	// AgentsExclude removes named agent templates from this import edge.
+	// Selectors are matched against each agent's local name before the import
+	// binding is applied; other imported resources remain visible.
+	AgentsExclude []string `toml:"agents_exclude,omitempty"`
 	// Export is a compatibility-only loader knob retained for older
 	// configs. It is intentionally omitted from generated public schemas.
 	Export bool `toml:"export,omitempty" jsonschema:"-"`
@@ -873,12 +877,15 @@ func (imp *Import) ImportIsTransitive() bool {
 
 // HasDefaultOptionSemantics reports whether the import carries the
 // default option semantics: not exported, transitive resolution enabled,
-// and shadow handling empty or "warn". This is the option half of the
+// shadow handling empty or "warn", and no agent narrowing. This is the option half of the
 // reuse policy composition applies when deciding whether an existing
 // same-source binding can stand in for a converted legacy include
 // (existingDefaultImportBindingForSource); the doctor migration's
 // same-source dedup shares it so the two policies cannot drift.
 func (imp *Import) HasDefaultOptionSemantics() bool {
+	if len(imp.AgentsExclude) > 0 {
+		return false
+	}
 	if imp.Export {
 		return false
 	}

--- a/internal/config/import_agents_exclude_test.go
+++ b/internal/config/import_agents_exclude_test.go
@@ -1,0 +1,301 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestImportAgentsExcludeParseAndRoundTrip(t *testing.T) {
+	cfg, err := Parse([]byte(`[workspace]
+name = "test"
+
+[imports.shared]
+source = "../shared"
+agents_exclude = ["worker", "unused"]
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := cfg.Imports["shared"].AgentsExclude; len(got) != 2 || got[0] != "worker" || got[1] != "unused" {
+		t.Fatalf("AgentsExclude = %#v, want [worker unused]", got)
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse(Marshal output): %v\n%s", err, data)
+	}
+	if got := got.Imports["shared"].AgentsExclude; len(got) != 2 || got[0] != "worker" || got[1] != "unused" {
+		t.Fatalf("round-tripped AgentsExclude = %#v, want [worker unused]", got)
+	}
+}
+
+func TestImportAgentsExcludeDisablesDefaultImportReuse(t *testing.T) {
+	if !(&Import{Source: "../shared"}).HasDefaultOptionSemantics() {
+		t.Fatal("unrestricted import should have default option semantics")
+	}
+	if (&Import{Source: "../shared", AgentsExclude: []string{"worker"}}).HasDefaultOptionSemantics() {
+		t.Fatal("agent-narrowed import must not have default option semantics")
+	}
+
+	target := map[string]Import{
+		"shared": {Source: "../shared", AgentsExclude: []string{"worker"}},
+	}
+	if !AddLegacyImports(target, []string{"../shared"}, nil) {
+		t.Fatal("AddLegacyImports should add a distinct unrestricted import")
+	}
+	if _, ok := target["shared-2"]; !ok {
+		t.Fatalf("imports = %#v, want narrowed shared plus unrestricted shared-2", target)
+	}
+}
+
+func TestImportAgentsExcludeCityPreservesSiblingContentAndRemovesNamedSession(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "shared")
+	writeTestFile(t, cityDir, "city.toml", `[workspace]
+name = "test"
+
+[imports.shared]
+source = "../shared"
+agents_exclude = ["worker"]
+`)
+	writeTestFile(t, packDir, "pack.toml", `[pack]
+name = "shared"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+start_command = "true"
+
+[[agent]]
+name = "keeper"
+scope = "city"
+start_command = "true"
+
+[[named_session]]
+name = "worker-alias"
+template = "worker"
+scope = "city"
+
+[[named_session]]
+name = "keeper-alias"
+template = "keeper"
+scope = "city"
+
+[providers.shared]
+command = "true"
+
+[global]
+session_live = ["echo retained"]
+`)
+	cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if prov == nil {
+		t.Fatal("LoadWithIncludes returned nil provenance")
+	}
+	for _, agent := range cfg.Agents {
+		if agent.Name == "worker" {
+			t.Fatalf("excluded worker survived: %#v", agent)
+		}
+		if agent.Name == "keeper" && agent.BindingName != "shared" {
+			t.Fatalf("keeper BindingName = %q, want shared", agent.BindingName)
+		}
+	}
+	if len(cfg.NamedSessions) != 1 || cfg.NamedSessions[0].Template != "keeper" {
+		t.Fatalf("NamedSessions = %#v, want only keeper session", cfg.NamedSessions)
+	}
+	if _, ok := cfg.Providers["shared"]; !ok {
+		t.Fatalf("provider from import was not retained: %#v", cfg.Providers)
+	}
+	if len(cfg.PackGlobals) == 0 || len(cfg.PackGlobals[0].SessionLive) != 1 {
+		t.Fatalf("pack globals were not retained: %#v", cfg.PackGlobals)
+	}
+}
+
+func TestImportAgentsExcludeRig(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "shared")
+	writeTestFile(t, cityDir, "city.toml", `[workspace]
+name = "test"
+
+[[rigs]]
+name = "app"
+path = "/tmp/app"
+
+[rigs.imports.shared]
+source = "../shared"
+agents_exclude = ["worker"]
+`)
+	writeTestFile(t, packDir, "pack.toml", `[pack]
+name = "shared"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "rig"
+start_command = "true"
+
+[[agent]]
+name = "keeper"
+scope = "rig"
+start_command = "true"
+
+[[named_session]]
+template = "worker"
+scope = "rig"
+
+[[named_session]]
+template = "keeper"
+scope = "rig"
+`)
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0].Name != "keeper" || cfg.Agents[0].QualifiedName() != "app/shared.keeper" {
+		t.Fatalf("rig agents = %#v, want app/shared.keeper only", cfg.Agents)
+	}
+	if len(cfg.NamedSessions) != 1 || cfg.NamedSessions[0].Template != "keeper" {
+		t.Fatalf("rig named sessions = %#v, want keeper only", cfg.NamedSessions)
+	}
+}
+
+func TestImportAgentsExcludeIsEdgeLocalWithCachedSource(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "shared")
+	writeTestFile(t, cityDir, "city.toml", `[workspace]
+name = "test"
+
+[imports.first]
+source = "../shared"
+agents_exclude = ["worker"]
+
+[imports.second]
+source = "../shared"
+agents_exclude = ["keeper"]
+`)
+	writeTestFile(t, packDir, "pack.toml", `[pack]
+name = "shared"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+start_command = "true"
+
+[[agent]]
+name = "keeper"
+scope = "city"
+start_command = "true"
+`)
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, agent := range cfg.Agents {
+		seen[agent.QualifiedName()] = true
+	}
+	if !seen["first.keeper"] || seen["first.worker"] || !seen["second.worker"] || seen["second.keeper"] {
+		t.Fatalf("edge-local exclusions produced agents %v", seen)
+	}
+}
+
+func TestImportAgentsExcludeNestedAndTransitiveFalse(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	outerDir := filepath.Join(dir, "outer")
+	innerDir := filepath.Join(dir, "inner")
+	writeTestFile(t, cityDir, "city.toml", `[workspace]
+name = "test"
+
+[imports.outer]
+source = "../outer"
+agents_exclude = ["deep"]
+`)
+	writeTestFile(t, outerDir, "pack.toml", `[pack]
+name = "outer"
+schema = 1
+
+[imports.inner]
+source = "../inner"
+export = true
+`)
+	writeTestFile(t, outerDir, "agents/keeper/agent.toml", "start_command = \"true\"\nscope = \"city\"\n")
+	writeTestFile(t, innerDir, "pack.toml", `[pack]
+name = "inner"
+schema = 1
+
+[[agent]]
+name = "deep"
+scope = "city"
+start_command = "true"
+
+[[named_session]]
+template = "deep"
+scope = "city"
+`)
+	cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	for _, agent := range cfg.Agents {
+		if agent.Name == "deep" {
+			t.Fatalf("nested excluded agent survived: %#v", agent)
+		}
+	}
+	for _, session := range cfg.NamedSessions {
+		if session.Template == "deep" {
+			t.Fatalf("nested excluded session survived: %#v", session)
+		}
+	}
+	if len(prov.Warnings) != 0 {
+		// The selector matches the nested agent before the edge-level filter;
+		// no unmatched-selector warning is expected in this case.
+		for _, warning := range prov.Warnings {
+			if strings.Contains(warning, "agents_exclude") && strings.Contains(warning, "deep") {
+				t.Fatalf("matched selector produced warning: %q", warning)
+			}
+		}
+	}
+}
+
+func TestImportAgentsExcludeInvalidAndUnmatched(t *testing.T) {
+	_, _, _, err := filterImportedAgentsByName(
+		[]Agent{{Name: "keeper"}}, nil, []string{"bad.name"}, `city import "shared"`)
+	if err == nil || !strings.Contains(err.Error(), "agents_exclude") {
+		t.Fatalf("invalid selector error = %v, want agents_exclude validation", err)
+	}
+	_, _, warnings, err := filterImportedAgentsByName(
+		[]Agent{{Name: "keeper"}}, nil, []string{"worker"}, `city import "shared"`)
+	if err != nil {
+		t.Fatalf("unmatched selector error = %v, want warning/no-op", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "matched no imported agent") {
+		t.Fatalf("unmatched warnings = %v, want one warning", warnings)
+	}
+}
+
+func TestImportAgentsExcludeKeepsDependsOnValidation(t *testing.T) {
+	kept, _, _, err := filterImportedAgentsByName([]Agent{
+		{Name: "keeper", DependsOn: []string{"worker"}},
+		{Name: "worker"},
+	}, nil, []string{"worker"}, `city import "shared"`)
+	if err != nil {
+		t.Fatalf("filterImportedAgentsByName: %v", err)
+	}
+	if err := ValidateAgents(kept); err == nil || !strings.Contains(err.Error(), "depends_on") {
+		t.Fatalf("ValidateAgents = %v, want missing dependency error", err)
+	}
+}

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -310,6 +310,14 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					globals = cachedPackLocalGlobals(cache, impDir)
 					skills = filterSkillsByPackDir(skills, impDir)
 				}
+				var excludeWarnings []string
+				agents, namedSessions, excludeWarnings, err = filterImportedAgentsByName(
+					agents, namedSessions, imp.AgentsExclude,
+					fmt.Sprintf("rig %q import %q", rig.Name, bindingName))
+				if err != nil {
+					return err
+				}
+				cfg.LoadWarnings = appendUnique(cfg.LoadWarnings, excludeWarnings...)
 				cfg.LoadWarnings = appendUnique(cfg.LoadWarnings, warnings...)
 				if len(services) > 0 {
 					return fmt.Errorf("rig %q import %q: [[service]] is only allowed in city-scoped packs", rig.Name, bindingName)
@@ -766,6 +774,14 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 				webhooks = filterWebhooksBySourceDir(webhooks, impDir)
 				mcpTopoDirs = filterPackDirsByRoot(topoDirs, impDir)
 			}
+			var excludeWarnings []string
+			agents, namedSessions, excludeWarnings, err = filterImportedAgentsByName(
+				agents, namedSessions, imp.AgentsExclude,
+				fmt.Sprintf("city import %q", bindingName))
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			packWarnings = appendUnique(packWarnings, excludeWarnings...)
 
 			// Stamp binding name on all agents and named sessions.
 			// At the city level, ALL agents from an import get the city's
@@ -1398,6 +1414,14 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 			impSkills = filterSkillsByPackDir(impSkills, impDir)
 			impWebhooks = filterWebhooksBySourceDir(impWebhooks, impDir)
 		}
+		var excludeWarnings []string
+		impAgents, impNamedSessions, excludeWarnings, err = filterImportedAgentsByName(
+			impAgents, impNamedSessions, imp.AgentsExclude,
+			fmt.Sprintf("import %q", bindingName))
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, nil, err
+		}
+		inheritedWarnings = appendUnique(inheritedWarnings, excludeWarnings...)
 
 		// Stamp binding name on all agents and named sessions from this import.
 		for i := range impAgents {
@@ -2551,6 +2575,54 @@ func filterNamedSessionsByScope(sessions []NamedSession, cityExpansion bool) []N
 		}
 	}
 	return result
+}
+
+// filterImportedAgentsByName applies an import edge's local-name selectors to
+// the already-loaded (and, when requested, transitive-filtered) result. The
+// returned slices are newly built so filtering cannot mutate a cached pack
+// result; callers can then stamp bindings and qualify dependencies normally.
+// Named sessions are coupled to their backing template, so a session whose
+// template's local component is excluded is removed as well.
+func filterImportedAgentsByName(agents []Agent, sessions []NamedSession, selectors []string, context string) ([]Agent, []NamedSession, []string, error) {
+	if len(selectors) == 0 {
+		return agents, sessions, nil, nil
+	}
+	excluded := make(map[string]struct{}, len(selectors))
+	for _, selector := range selectors {
+		if !validAgentName.MatchString(selector) {
+			return nil, nil, nil, fmt.Errorf("%s: agents_exclude entry %q must match [a-zA-Z0-9][a-zA-Z0-9_-]* (no spaces, slashes, or dots)", context, selector)
+		}
+		excluded[selector] = struct{}{}
+	}
+
+	found := make(map[string]struct{}, len(agents))
+	keptAgents := make([]Agent, 0, len(agents))
+	for _, agent := range agents {
+		if _, ok := excluded[agent.Name]; ok {
+			found[agent.Name] = struct{}{}
+			continue
+		}
+		keptAgents = append(keptAgents, agent)
+	}
+	var warnings []string
+	for _, selector := range selectors {
+		if _, ok := found[selector]; !ok {
+			warnings = append(warnings, fmt.Sprintf("%s: agents_exclude selector %q matched no imported agent", context, selector))
+		}
+	}
+
+	keptSessions := make([]NamedSession, 0, len(sessions))
+	for _, session := range sessions {
+		template := session.Template
+		if dot := strings.LastIndexByte(template, '.'); dot >= 0 {
+			template = template[dot+1:]
+		}
+		if _, ok := excluded[template]; ok {
+			continue
+		}
+		keptSessions = append(keptSessions, session)
+	}
+	return keptAgents, keptSessions, warnings, nil
 }
 
 func expandCityImportedAgentsForRigs(agents []Agent, rigs []Rig, bindingName string) []Agent {

--- a/internal/rig/imports.go
+++ b/internal/rig/imports.go
@@ -317,6 +317,33 @@ func sortedBoundImports(imports []config.BoundImport) []config.BoundImport {
 	return sorted
 }
 
+// boundImportsEqual compares the effective import declarations rather than
+// relying on Go's comparable constraint. Import contains slices and pointers,
+// so generic slices.Equal cannot compare BoundImport values. In particular,
+// AgentsExclude is part of an import edge's semantics and must participate in
+// equality checks used when deciding whether an existing rig matches a new
+// declaration.
+func boundImportsEqual(a, b []config.BoundImport) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Binding != b[i].Binding || !importsEqual(a[i].Import, b[i].Import) {
+			return false
+		}
+	}
+	return true
+}
+
+func importsEqual(a, b config.Import) bool {
+	return a.Source == b.Source &&
+		a.Version == b.Version &&
+		a.Export == b.Export &&
+		a.Shadow == b.Shadow &&
+		a.ImportIsTransitive() == b.ImportIsTransitive() &&
+		slices.Equal(a.AgentsExclude, b.AgentsExclude)
+}
+
 // MergeBoundImports is for already-bound import sets. Legacy default-rig
 // includes use composeDefaultRigImports so binding collisions can be
 // uniquified with the migration policy.
@@ -328,7 +355,7 @@ func MergeBoundImports(primary, secondary []config.BoundImport) ([]config.BoundI
 	seenByBinding := make(map[string]config.Import, len(primary)+len(secondary))
 	appendImport := func(bound config.BoundImport) error {
 		if prior, exists := seenByBinding[bound.Binding]; exists {
-			if prior.Source == bound.Import.Source {
+			if importsEqual(prior, bound.Import) || prior.Source == bound.Import.Source {
 				return nil
 			}
 			return fmt.Errorf("binding %q maps to both %q and %q", bound.Binding, prior.Source, bound.Import.Source)

--- a/internal/rig/imports_test.go
+++ b/internal/rig/imports_test.go
@@ -325,3 +325,40 @@ func TestResolveIncludeSourcesRejectsUnmatchedRegistryName(t *testing.T) {
 		t.Errorf("error does not name the token: %q", err.Error())
 	}
 }
+
+func TestBoundImportsEqualIncludesAgentExclusions(t *testing.T) {
+	base := []config.BoundImport{{
+		Binding: "shared",
+		Import:  config.Import{Source: "../shared", AgentsExclude: []string{"worker"}},
+	}}
+	if !boundImportsEqual(base, []config.BoundImport{{
+		Binding: "shared",
+		Import:  config.Import{Source: "../shared", AgentsExclude: []string{"worker"}},
+	}}) {
+		t.Fatal("identical bound imports should compare equal")
+	}
+	if boundImportsEqual(base, []config.BoundImport{{
+		Binding: "shared",
+		Import:  config.Import{Source: "../shared", AgentsExclude: []string{"keeper"}},
+	}}) {
+		t.Fatal("different agent exclusions should compare unequal")
+	}
+}
+
+func TestMergeBoundImportsPreservesPrimaryAgentExclusionsOnSameSource(t *testing.T) {
+	primary := []config.BoundImport{{
+		Binding: "shared",
+		Import:  config.Import{Source: "../shared", AgentsExclude: []string{"worker"}},
+	}}
+	secondary := []config.BoundImport{{
+		Binding: "shared",
+		Import:  config.Import{Source: "../shared"},
+	}}
+	merged, err := MergeBoundImports(primary, secondary)
+	if err != nil {
+		t.Fatalf("MergeBoundImports: %v", err)
+	}
+	if len(merged) != 1 || len(merged[0].Import.AgentsExclude) != 1 || merged[0].Import.AgentsExclude[0] != "worker" {
+		t.Fatalf("merged imports = %#v, want primary agents_exclude preserved", merged)
+	}
+}

--- a/internal/rig/provision.go
+++ b/internal/rig/provision.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -537,7 +536,7 @@ func emitRigBannerAndWarnings(deps Deps, req ProvisionRequest, plan rigMutationP
 			existingRigImports, err := effectiveRigBoundImports(plan.existingRig, deps.Cfg.Packs)
 			if err != nil {
 				emit(ProvisionStep{Name: "include-ignored", Warn: true, Detail: fmt.Sprintf("warning: --include flags %v ignored; existing rig imports could not be normalized (%v). Edit city.toml to change", includes, err)})
-			} else if !slices.Equal(existingRigImports, plan.explicitRigImports) {
+			} else if !boundImportsEqual(existingRigImports, plan.explicitRigImports) {
 				emit(ProvisionStep{Name: "include-ignored", Warn: true, Detail: fmt.Sprintf("warning: --include flags %v ignored (existing imports: %s); edit city.toml to change", includes, formatBoundImports(existingRigImports))})
 			}
 		}


### PR DESCRIPTION
## Summary

- Add `Import.AgentsExclude` / `agents_exclude` and apply it per city, rig, and nested import edge after cache/transitive filtering.
- Remove matching local agent templates and their named sessions while preserving non-agent resources and cached results.
- Keep selector semantics intact through import deduplication, rig planning, builtin-include repair, and legacy import-state migration.

Closes #5381

## Validation

- Focused and full cluster verification was run against live binary base commit `b1d6e881af6b8d9e79212643c2f8c346776d2440`.
- Local Go build/tests were not run; static diff checks passed.
- The generated `docs/reference/config.md` refresh is included.